### PR TITLE
feat(#1573): ReadAt positional-read trait — kill the point-read cursor convoy + per-lookup open(2) (C2)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -1069,6 +1069,86 @@ mod tests {
     use tempfile::TempDir;
 
     // =========================================================================
+    // Positional compressed-chunk read: CRC-before-decompress (issue #1573, C2)
+    // =========================================================================
+
+    /// An in-memory [`ReadAt`](super::read_at::ReadAt) for exercising the
+    /// positional chunk reader without touching the filesystem.
+    struct MemReadAt(Vec<u8>);
+    impl crate::storage::sstable::reader::read_at::ReadAt for MemReadAt {
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+            let start = offset as usize;
+            if start >= self.0.len() {
+                return Ok(0);
+            }
+            let avail = &self.0[start..];
+            let n = avail.len().min(buf.len());
+            buf[..n].copy_from_slice(&avail[..n]);
+            Ok(n)
+        }
+        fn len(&self) -> u64 {
+            self.0.len() as u64
+        }
+    }
+
+    /// A chunk whose stored CRC does not match its payload fails CRC in
+    /// `read_compressed_chunk_at` — the error is raised BEFORE any decompression
+    /// is attempted (the function returns the compressed bytes only after the CRC
+    /// verifies, so a corrupt chunk never reaches the caller's decompressor).
+    /// Guardrail #1411: CRC-then-decompress ordering.
+    #[test]
+    fn read_compressed_chunk_at_verifies_crc_before_returning() {
+        use crate::storage::sstable::compression_info::CompressionInfo;
+
+        // Two records: [payload0][crc0][payload1][WRONG crc1].
+        let payload0 = b"first-chunk-bytes".to_vec();
+        let payload1 = b"second-chunk-bytes".to_vec();
+        let crc0 = crc32fast::hash(&payload0);
+        let good_crc1 = crc32fast::hash(&payload1);
+        let wrong_crc1 = good_crc1 ^ 0xffff_ffff; // deliberately corrupt
+
+        let mut file = Vec::new();
+        file.extend_from_slice(&payload0);
+        file.extend_from_slice(&crc0.to_be_bytes());
+        let off1 = file.len() as u64;
+        file.extend_from_slice(&payload1);
+        file.extend_from_slice(&wrong_crc1.to_be_bytes());
+        let file_size = file.len() as u64;
+
+        let ci = CompressionInfo {
+            algorithm: "LZ4Compressor".to_string(),
+            option_pairs: vec![],
+            chunk_length: 64 * 1024,
+            max_compressed_length: i32::MAX as u32,
+            data_length: (payload0.len() + payload1.len()) as u64,
+            chunk_offsets: vec![0, off1],
+        };
+        let src = MemReadAt(file);
+
+        // Chunk 0 verifies and returns its exact compressed bytes.
+        let got = read_compressed_chunk_at(&src, &ci, 0, file_size, 0)
+            .expect("chunk 0 read")
+            .expect("chunk 0 present");
+        assert_eq!(got, payload0, "verified chunk returns its exact payload");
+
+        // Chunk 1's CRC is wrong: a corruption error is raised (before any
+        // decompress the caller would do on the returned bytes).
+        let err = read_compressed_chunk_at(&src, &ci, 1, file_size, 0)
+            .expect_err("corrupt CRC must error before decompress");
+        match err {
+            Error::InvalidFormat(m) => {
+                assert!(m.contains("CRC32 mismatch"), "unexpected error text: {m}")
+            }
+            other => panic!("expected InvalidFormat CRC mismatch, got {other:?}"),
+        }
+
+        // Past the last chunk is a clean EOF (None), never a panic.
+        assert!(read_compressed_chunk_at(&src, &ci, 2, file_size, 0)
+            .expect("EOF read ok")
+            .is_none());
+    }
+
+    // =========================================================================
     // ASCII corruption detection tests
     // =========================================================================
 

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -590,15 +590,17 @@ pub(crate) fn read_compressed_chunk_at(
 
     // ONE positioned read for payload + trailing CRC32 (E3: single read/chunk).
     let mut buf = vec![0u8; chunk_data_size + 4];
-    source.read_exact_at(absolute_offset, &mut buf).map_err(|e| {
-        Error::Io(std::io::Error::other(format!(
-            "Failed to read chunk {} ({} bytes at offset 0x{:x}): {}",
-            chunk_idx,
-            chunk_data_size + 4,
-            absolute_offset,
-            e
-        )))
-    })?;
+    source
+        .read_exact_at(absolute_offset, &mut buf)
+        .map_err(|e| {
+            Error::Io(std::io::Error::other(format!(
+                "Failed to read chunk {} ({} bytes at offset 0x{:x}): {}",
+                chunk_idx,
+                chunk_data_size + 4,
+                absolute_offset,
+                e
+            )))
+        })?;
     let expected_crc = u32::from_be_bytes([
         buf[chunk_data_size],
         buf[chunk_data_size + 1],

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -517,6 +517,110 @@ async fn read_nb_format_chunk_data(
     Ok(Some(chunk_data))
 }
 
+/// Positional (`pread`) sibling of [`read_nb_format_chunk_data`] for the
+/// POINT-READ path (issue #1573, C2).
+///
+/// Reads compressed chunk `chunk_idx` from a [`ReadAt`](super::read_at::ReadAt)
+/// source at its `CompressionInfo`-resolved offset, verifies the trailing CRC32,
+/// and returns the compressed bytes ready for the caller to decompress. Unlike
+/// the cursor version this takes no seek cursor and no mutex — the offset is a
+/// parameter, so concurrent point reads never serialize and never `open(2)` per
+/// call. Returns `Ok(None)` once `chunk_idx` is past the last chunk (EOF).
+///
+/// CRC-then-decompress ordering (guardrail #1411) is preserved verbatim: the CRC
+/// is checked HERE, before the caller decompresses. A mismatch is a typed
+/// `Error::InvalidFormat` naming the chunk + offset, identical to the cursor path,
+/// and the caller never sees (nor decompresses) the payload.
+pub(crate) fn read_compressed_chunk_at(
+    source: &dyn super::read_at::ReadAt,
+    comp_info: &crate::storage::sstable::compression_info::CompressionInfo,
+    chunk_idx: usize,
+    file_size: u64,
+    header_offset: u64,
+) -> Result<Option<Vec<u8>>> {
+    if chunk_idx >= comp_info.chunk_offsets.len() {
+        return Ok(None); // EOF
+    }
+
+    let chunk_offset = comp_info
+        .compressed_chunk_offset(chunk_idx)
+        .ok_or_else(|| Error::InvalidFormat(format!("No offset for chunk {}", chunk_idx)))?;
+
+    let total_chunk_size = comp_info
+        .compressed_chunk_size(chunk_idx, file_size)
+        .ok_or_else(|| {
+            Error::InvalidFormat(format!(
+                "Cannot determine size for chunk {} (file_size={})",
+                chunk_idx, file_size
+            ))
+        })?;
+
+    if total_chunk_size < 4 {
+        return Err(Error::InvalidFormat(format!(
+            "Chunk {} size too small: {} bytes (minimum 4 for CRC)",
+            chunk_idx, total_chunk_size
+        )));
+    }
+
+    // Bounds-check against the actual Data.db length BEFORE allocating — a corrupt
+    // CompressionInfo offset must surface as a recoverable error, never a
+    // multi-exabyte allocation (mirrors the cursor path's roborev #970 guard).
+    let chunk_end = chunk_offset
+        .checked_add(header_offset)
+        .and_then(|abs| abs.checked_add(total_chunk_size));
+    match chunk_end {
+        Some(end) if end <= file_size => {}
+        _ => {
+            return Err(Error::InvalidFormat(format!(
+                "Chunk {} at offset 0x{:x} with size {} exceeds Data.db length {} \
+                 — corrupt CompressionInfo.db chunk offset",
+                chunk_idx, chunk_offset, total_chunk_size, file_size
+            )));
+        }
+    }
+
+    let chunk_data_size = (total_chunk_size - 4) as usize;
+    let absolute_offset = chunk_offset + header_offset;
+
+    // A5 read-work counter (SEEK_CALLS; consumer E4): the positioned chunk read
+    // resolves its own offset (no cursor seek), but it stands in for the cursor
+    // path's per-chunk seek, so it is counted the same way for parity of the E4
+    // guard. No-op in release (design.md Decision 1/2).
+    crate::storage::sstable::read_work_counters::record_seek();
+
+    // ONE positioned read for payload + trailing CRC32 (E3: single read/chunk).
+    let mut buf = vec![0u8; chunk_data_size + 4];
+    source.read_exact_at(absolute_offset, &mut buf).map_err(|e| {
+        Error::Io(std::io::Error::other(format!(
+            "Failed to read chunk {} ({} bytes at offset 0x{:x}): {}",
+            chunk_idx,
+            chunk_data_size + 4,
+            absolute_offset,
+            e
+        )))
+    })?;
+    let expected_crc = u32::from_be_bytes([
+        buf[chunk_data_size],
+        buf[chunk_data_size + 1],
+        buf[chunk_data_size + 2],
+        buf[chunk_data_size + 3],
+    ]);
+    buf.truncate(chunk_data_size);
+
+    // CRC BEFORE decompress (guardrail #1411): fail fast on mismatch; the caller
+    // never decompresses a chunk that did not verify.
+    let computed_crc = crc32fast::hash(&buf);
+    if computed_crc != expected_crc {
+        return Err(Error::InvalidFormat(format!(
+            "CRC32 mismatch for chunk {} at offset 0x{:x}: expected=0x{:08x}, \
+             computed=0x{:08x}, chunk_size={}",
+            chunk_idx, chunk_offset, expected_crc, computed_crc, chunk_data_size
+        )));
+    }
+
+    Ok(Some(buf))
+}
+
 /// Read block header for BTI format
 async fn read_bti_format_block_header(
     file: &Arc<Mutex<BlockSource>>,

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -449,8 +449,9 @@ impl SSTableReader {
     ///   decompresses the chunk that contains that offset and continues forward
     ///   chunk-by-chunk ONLY until the target partition is fully parsed — it never
     ///   decompresses earlier chunks or the rest of the file (issue #831 perf
-    ///   finding). The whole-section [`stitch_all_chunks`] fallback is used only
-    ///   when chunk targeting is impossible (no/zero `chunk_length`).
+    ///   finding). The whole-section `point_read_whole_section` fallback (one
+    ///   positioned read of the entire data section) is used only when chunk
+    ///   targeting is impossible (no/zero `chunk_length`).
     /// - **Prefix-collision guard**: the trie may return a candidate for a
     ///   prefix-colliding key, so the decoded partition key is verified to equal
     ///   the queried key before any row is returned.
@@ -614,12 +615,16 @@ impl SSTableReader {
     ///
     /// Fallbacks (preserve prior behaviour exactly): when `compression_info` is
     /// `None` (uncompressed BTI Data.db) or `chunk_length` is 0/absent, this
-    /// decompresses the WHOLE section via [`stitch_all_chunks`] (`window_base = 0`)
-    /// and runs the same single-partition parse.
+    /// reads the WHOLE section in one positioned read via
+    /// `point_read_whole_section` (`window_base = 0`, CRC-verified when a CRC.db
+    /// is present) and runs the same single-partition parse.
     ///
-    /// Uses its own per-scan [`ScanCursor`] (private file position + chunk
-    /// index), so concurrent lookups run in parallel without serialization
-    /// (issue #815).
+    /// Chunks are fetched with positioned (`read_at`) reads on the shared
+    /// `point_source` — no per-lookup `open(2)`, no `ScanCursor`, and no mutex.
+    /// `chunk_index` is a plain local (a lookup is single-threaded within
+    /// itself), so concurrent lookups run in parallel without serialization;
+    /// safety comes from `read_at` taking `&self` (issue #1573, superseding the
+    /// per-scan-cursor approach of issue #815).
     pub(super) async fn bti_decompress_and_parse_target(
         &self,
         offset: usize,
@@ -1234,8 +1239,10 @@ impl SSTableReader {
     /// Murmur3 token order and truncated to `limit` — identical post-processing
     /// to the V5CompressedLegacy stitched path.
     ///
-    /// Uses its own per-scan [`ScanCursor`], so it runs in parallel with other
-    /// scans on this reader without serialization (issue #815).
+    /// Uses its own per-scan
+    /// [`ScanCursor`](crate::storage::sstable::reader::source::ScanCursor), so it
+    /// runs in parallel with other scans on this reader without serialization
+    /// (issue #815).
     ///
     /// [`parse_block_with_cell_metadata`]: crate::storage::sstable::reader::parsing::V5CompressedLegacyParser::parse_block_with_cell_metadata
     ///

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -582,16 +582,14 @@ impl SSTableReader {
             }
         }
         // CRC-verify the covering chunk(s) when a CRC.db is present (no-op for BTI
-        // and compressed tables). `verify_uncompressed_range` takes a u32 size, so
-        // walk the section in ≤ u32::MAX windows; the verifier memoizes per chunk,
-        // so a boundary-straddling window never re-CRCs a chunk.
+        // and compressed tables) BEFORE returning the bytes. The section is already
+        // resident in `whole`, so verify against those in-memory bytes rather than
+        // re-reading the identical range from `point_source` — the section is
+        // transferred from disk EXACTLY ONCE (issue #1573 roborev), preserving the
+        // CRC-before-use ordering and the CRC algorithm unchanged.
         if self.crc_reader.is_some() {
-            let mut off = header_size;
-            while off < end {
-                let span = (end - off).min(u32::MAX as u64) as u32;
-                self.verify_uncompressed_range(off, span).await?;
-                off += span as u64;
-            }
+            self.verify_uncompressed_section_in_buffer(header_size, &whole)
+                .await?;
         }
         Ok(whole)
     }

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -565,7 +565,21 @@ impl SSTableReader {
         let len = end.saturating_sub(header_size);
         let mut whole = vec![0u8; len as usize];
         if len > 0 {
-            self.point_source.read_exact_at(header_size, &mut whole)?;
+            // Read the section in BOUNDED windows rather than one section-sized
+            // `read_exact_at`. A `DirectReadAt` backend allocates a per-call
+            // aligned bounce buffer as large as the requested range, so a single
+            // whole-section read would transiently ~double resident memory vs the
+            // <128MB target for a large section. Windowing caps the bounce buffer
+            // at ~`WHOLE_SECTION_READ_WINDOW` regardless of backend (issue #1573
+            // roborev); `whole` itself is the returned data and is unavoidable.
+            const WHOLE_SECTION_READ_WINDOW: usize = 1 << 20; // 1 MiB
+            let mut filled = 0usize;
+            while filled < whole.len() {
+                let win_end = (filled + WHOLE_SECTION_READ_WINDOW).min(whole.len());
+                self.point_source
+                    .read_exact_at(header_size + filled as u64, &mut whole[filled..win_end])?;
+                filled = win_end;
+            }
         }
         // CRC-verify the covering chunk(s) when a CRC.db is present (no-op for BTI
         // and compressed tables). `verify_uncompressed_range` takes a u32 size, so

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -536,12 +536,17 @@ impl SSTableReader {
         let Some(ci) = self.compression_info.as_deref() else {
             return Ok(None);
         };
+        // header_offset is ALWAYS 0 for NB/BTI: CompressionInfo chunk offsets are
+        // absolute from Data.db byte 0 (any embedded header is part of the
+        // compressed data), exactly as the cursor path hardcodes in
+        // `read_next_block_impl`. Passing `actual_header_size` here would shift
+        // every chunk read and fail CRC.
         super::super::block_io::read_compressed_chunk_at(
             self.point_source.as_ref(),
             ci,
             chunk_idx,
             self.stats.file_size,
-            self.actual_header_size as u64,
+            0,
         )
     }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -18,8 +18,6 @@ use std::io::SeekFrom;
 use tokio::io::AsyncSeekExt;
 
 #[cfg(not(feature = "tombstones"))]
-use super::super::source::ScanCursor;
-#[cfg(not(feature = "tombstones"))]
 use super::model::{physical_byte_bounds_for_slice, ClusteringRowWindow, ClusteringSlice};
 
 impl SSTableReader {
@@ -529,6 +527,56 @@ impl SSTableReader {
         (target_chunk, window_base, within)
     }
 
+    /// Positional (`pread`) fetch of compressed chunk `chunk_idx` for the
+    /// POINT-READ path (issue #1573, C2). Reads via the shared `point_source` — no
+    /// per-lookup `open(2)`, no cursor, no mutex — CRC-checks the chunk, and
+    /// returns the compressed bytes (the caller decompresses). `Ok(None)` at EOF.
+    /// Only called on the chunk-targeted path, where `CompressionInfo` is present.
+    pub(super) fn point_read_compressed_chunk(&self, chunk_idx: usize) -> Result<Option<Vec<u8>>> {
+        let Some(ci) = self.compression_info.as_deref() else {
+            return Ok(None);
+        };
+        super::super::block_io::read_compressed_chunk_at(
+            self.point_source.as_ref(),
+            ci,
+            chunk_idx,
+            self.stats.file_size,
+            self.actual_header_size as u64,
+        )
+    }
+
+    /// Positional (`pread`) read of the ENTIRE uncompressed data section for the
+    /// point-read whole-section fallback (issue #1573, C2) — used when chunk
+    /// targeting is impossible (no/zero `chunk_length`, i.e. an uncompressed BTI or
+    /// nb-without-CompressionInfo Data.db). Reads `[header_size, file_size)` in one
+    /// positioned read and, when a `CRC.db` is present (uncompressed BIG), verifies
+    /// the covering chunks BEFORE the bytes are parsed — preserving the CRC-then-use
+    /// ordering the cursor path enforced via `read_uncompressed_data_block`.
+    pub(super) async fn point_read_whole_section(&self) -> Result<Vec<u8>> {
+        let header_size = self.calculate_header_size() as u64;
+        // Authoritative file length straight from the positional source (== the
+        // reader's `file_size`; using the source keeps the read self-consistent).
+        let end = self.point_source.len();
+        let len = end.saturating_sub(header_size);
+        let mut whole = vec![0u8; len as usize];
+        if len > 0 {
+            self.point_source.read_exact_at(header_size, &mut whole)?;
+        }
+        // CRC-verify the covering chunk(s) when a CRC.db is present (no-op for BTI
+        // and compressed tables). `verify_uncompressed_range` takes a u32 size, so
+        // walk the section in ≤ u32::MAX windows; the verifier memoizes per chunk,
+        // so a boundary-straddling window never re-CRCs a chunk.
+        if self.crc_reader.is_some() {
+            let mut off = header_size;
+            while off < end {
+                let span = (end - off).min(u32::MAX as u64) as u32;
+                self.verify_uncompressed_range(off, span).await?;
+                off += span as u64;
+            }
+        }
+        Ok(whole)
+    }
+
     /// Decompress only the chunk(s) needed to fully parse the target partition at
     /// uncompressed `offset`, then parse and return its row value (issue #831).
     ///
@@ -572,9 +620,10 @@ impl SSTableReader {
     ) -> Result<Option<ScanRow>> {
         use crate::storage::sstable::compression::Compression;
 
-        // Issue #815: each lookup uses its own cursor so concurrent lookups on
-        // this reader never share a mutable file position / chunk index.
-        let cursor = self.new_scan_cursor().await?;
+        // Issue #1573 (C2): the point path fetches chunks via positioned reads on
+        // the shared `point_source` — no per-lookup `open(2)`, no cursor, no mutex.
+        // `chunk_index` is a plain local (a lookup is single-threaded within
+        // itself); concurrency safety comes from `read_at` being `&self`.
 
         // Determine the chunk-targeting parameters. `chunk_length == 0` (or no
         // CompressionInfo) means we cannot chunk-target -> whole-section fallback.
@@ -584,48 +633,20 @@ impl SSTableReader {
             .map(|ci| ci.chunk_length as usize)
             .filter(|&len| len > 0);
 
+        let mut chunk_index = 0usize;
         let (target_chunk, window_base, mut window) = match chunk_length {
             Some(len) => {
                 let (target_chunk, window_base, _within) = Self::bti_chunk_target(offset, len);
-                // Seek to the START of target_chunk so read_next_block() reads it
-                // first, and set the shared chunk index accordingly. Chunk offsets
-                // are relative to file start for NB/BTI (header_offset = 0).
-                let chunk_start = self
-                    .compression_info
-                    .as_ref()
-                    .and_then(|ci| ci.compressed_chunk_offset(target_chunk))
-                    .ok_or_else(|| {
-                        Error::corruption(format!(
-                            "BTI point lookup: no compressed offset for target chunk {} \
-                             (offset {}, chunk_length {})",
-                            target_chunk, offset, len
-                        ))
-                    })?;
-                {
-                    let mut file_guard = cursor.file.lock().await;
-                    // A5 read-work counter (SEEK_CALLS; consumer E4): BTI point-lookup
-                    // target-chunk seek on the production read path. No-op in release
-                    // (design.md Decision 1/2).
-                    crate::storage::sstable::read_work_counters::record_seek();
-                    file_guard.seek(SeekFrom::Start(chunk_start)).await?;
-                }
-                cursor
-                    .chunk_index
-                    .store(target_chunk, std::sync::atomic::Ordering::Relaxed);
+                // Positioned reads resolve their own offset from the chunk index, so
+                // no pre-seek is needed — just start at `target_chunk`.
+                chunk_index = target_chunk;
                 (target_chunk, window_base, Vec::<u8>::new())
             }
             None => {
-                // Whole-section fallback (uncompressed BTI, or chunk_length absent/0).
-                let header_size = self.calculate_header_size();
-                {
-                    let mut file_guard = cursor.file.lock().await;
-                    // A5 read-work counter (SEEK_CALLS; consumer E4): whole-section
-                    // fallback seek-to-data-start. No-op in release (design.md
-                    // Decision 1/2).
-                    crate::storage::sstable::read_work_counters::record_seek();
-                    file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
-                }
-                let whole = self.stitch_all_chunks(&cursor).await?;
+                // Whole-section fallback (uncompressed BTI, or chunk_length absent/0):
+                // one positioned read of the whole data section, CRC-verified when a
+                // CRC.db is present (see `point_read_whole_section`).
+                let whole = self.point_read_whole_section().await?;
                 (0usize, 0usize, whole)
             }
         };
@@ -647,16 +668,13 @@ impl SSTableReader {
             // If chunk-targeted, append the next chunk before each parse attempt
             // (the whole-section fallback already has all bytes in `window`).
             if chunk_targeted {
-                // Cache key: the ABSOLUTE chunk index about to be read. `read_next_block`
-                // reads `cursor.chunk_index` then increments it, so capture it first
-                // (issue #1567). Shared cache is consulted before decompress; a hit
-                // skips the decompressor (the compressed bytes were still read).
-                let this_chunk = cursor
-                    .chunk_index
-                    .load(std::sync::atomic::Ordering::Relaxed)
-                    as u64;
-                match self.read_next_block(&cursor).await? {
+                // Cache key: the ABSOLUTE chunk index about to be read (issue #1567).
+                // Shared cache is consulted before decompress; a hit skips the
+                // decompressor (the compressed bytes were still read + CRC-checked).
+                let this_chunk = chunk_index as u64;
+                match self.point_read_compressed_chunk(chunk_index)? {
                     Some(compressed_chunk) => {
+                        chunk_index += 1;
                         let key = self.chunk_cache_key(super::NS_BTI_CHUNK, this_chunk);
                         let decompressed_chunk: std::sync::Arc<[u8]> = if let Some(hit) =
                             self.chunk_cache.get(&key)
@@ -857,9 +875,8 @@ impl SSTableReader {
         schema_opt: Option<&crate::schema::TableSchema>,
         parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
     ) -> Result<Option<Vec<ScanRow>>> {
-        // Issue #815: each lookup uses its own cursor so concurrent lookups on
-        // this reader never share a mutable file position / chunk index.
-        let cursor = self.new_scan_cursor().await?;
+        // Issue #1573 (C2): positioned reads on the shared `point_source` — no
+        // per-lookup `open(2)`, no cursor, no mutex. `chunk_index` is a plain local.
 
         // Determine the chunk-targeting parameters. `chunk_length == 0` (or no
         // CompressionInfo) means we cannot chunk-target -> whole-section fallback.
@@ -869,45 +886,19 @@ impl SSTableReader {
             .map(|ci| ci.chunk_length as usize)
             .filter(|&len| len > 0);
 
+        let mut chunk_index = 0usize;
         let (target_chunk, window_base, mut window) = match chunk_length {
             Some(len) => {
                 let (target_chunk, window_base, _within) = Self::bti_chunk_target(offset, len);
-                let chunk_start = self
-                    .compression_info
-                    .as_ref()
-                    .and_then(|ci| ci.compressed_chunk_offset(target_chunk))
-                    .ok_or_else(|| {
-                        Error::corruption(format!(
-                            "BTI single-partition seek: no compressed offset for target chunk {} \
-                             (offset {}, chunk_length {})",
-                            target_chunk, offset, len
-                        ))
-                    })?;
-                {
-                    let mut file_guard = cursor.file.lock().await;
-                    // A5 read-work counter (SEEK_CALLS; consumer E4): BTI
-                    // single-partition target-chunk seek on the production read path.
-                    // No-op in release (design.md Decision 1/2).
-                    crate::storage::sstable::read_work_counters::record_seek();
-                    file_guard.seek(SeekFrom::Start(chunk_start)).await?;
-                }
-                cursor
-                    .chunk_index
-                    .store(target_chunk, std::sync::atomic::Ordering::Relaxed);
+                // Positioned reads resolve their own offset from the chunk index.
+                chunk_index = target_chunk;
                 (target_chunk, window_base, Vec::<u8>::new())
             }
             None => {
-                // Whole-section fallback (uncompressed BTI, or chunk_length absent/0).
-                let header_size = self.calculate_header_size();
-                {
-                    let mut file_guard = cursor.file.lock().await;
-                    // A5 read-work counter (SEEK_CALLS; consumer E4): whole-section
-                    // fallback seek-to-data-start. No-op in release (design.md
-                    // Decision 1/2).
-                    crate::storage::sstable::read_work_counters::record_seek();
-                    file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
-                }
-                let whole = self.stitch_all_chunks(&cursor).await?;
+                // Whole-section fallback (uncompressed BTI, or chunk_length absent/0):
+                // one positioned read of the whole data section, CRC-verified when a
+                // CRC.db is present (see `point_read_whole_section`).
+                let whole = self.point_read_whole_section().await?;
                 (0usize, 0usize, whole)
             }
         };
@@ -959,7 +950,7 @@ impl SSTableReader {
                     || !Self::bti_partition_key_bytes_available(&window, within, key.as_bytes())
                 {
                     match self
-                        .bti_pull_decompressed_chunk(&cursor, &mut window)
+                        .bti_pull_decompressed_chunk(&mut chunk_index, &mut window)
                         .await?
                     {
                         true => continue, // chunk appended; re-check the header
@@ -995,7 +986,7 @@ impl SSTableReader {
             let needed = end_offset.saturating_sub(window_base);
             while window.len() < needed {
                 if !self
-                    .bti_pull_decompressed_chunk(&cursor, &mut window)
+                    .bti_pull_decompressed_chunk(&mut chunk_index, &mut window)
                     .await?
                 {
                     break; // EOF: window holds all available bytes.
@@ -1048,12 +1039,16 @@ impl SSTableReader {
     #[cfg(not(feature = "tombstones"))]
     async fn bti_pull_decompressed_chunk(
         &self,
-        cursor: &ScanCursor,
+        chunk_index: &mut usize,
         window: &mut Vec<u8>,
     ) -> Result<bool> {
         use crate::storage::sstable::compression::Compression;
-        match self.read_next_block(cursor).await? {
+        // Issue #1573 (C2): positioned chunk fetch — no cursor, no mutex, no
+        // per-lookup open. CRC is verified inside `point_read_compressed_chunk`
+        // BEFORE we decompress here (guardrail #1411).
+        match self.point_read_compressed_chunk(*chunk_index)? {
             Some(compressed_chunk) => {
+                *chunk_index += 1;
                 let decompressed_chunk = if let Some(compression_reader) = &self.compression_reader
                 {
                     let compression = Compression::new(*compression_reader.algorithm())?;

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -532,7 +532,6 @@ impl SSTableReader {
     async fn get_cached_data(&self, block_offset: u64, size: u32) -> Result<Vec<u8>> {
         use crate::parser::header::CassandraVersion;
         use crate::storage::sstable::compression::Compression;
-        use tokio::io::AsyncReadExt;
 
         let key = self.chunk_cache_key_ranged(NS_BIG_POINT, block_offset, size);
         if let Some(hit) = self.chunk_cache.get(&key) {
@@ -542,13 +541,11 @@ impl SSTableReader {
         self.record_cache_miss();
 
         // Read from disk (counted so a repeat read can prove zero underlying reads).
+        // Positioned read on the shared point source (issue #1573, C2): no cursor
+        // mutex is held across this I/O, so concurrent point reads do not convoy.
         model::CHUNK_READ_CALLS.fetch_add(1, Ordering::Relaxed);
-        let mut file = self.file.lock().await;
-        file.seek(SeekFrom::Start(block_offset)).await?;
-
         let mut buffer = vec![0u8; size as usize];
-        file.read_exact(&mut buffer).await?;
-        drop(file); // Release file lock early
+        self.point_source.read_exact_at(block_offset, &mut buffer)?;
 
         // Decompress if needed
         let data = if let Some(compression_reader) = &self.compression_reader {
@@ -595,8 +592,6 @@ impl SSTableReader {
     /// No-op when this reader has no `CRC.db` (compressed tables carry inline
     /// per-chunk CRCs; BTI ships none; an absent `CRC.db` is warn-and-proceed).
     async fn verify_uncompressed_range(&self, offset: u64, size: u32) -> Result<()> {
-        use tokio::io::AsyncReadExt;
-
         let Some(crc) = self.crc_reader.as_deref() else {
             return Ok(());
         };
@@ -644,15 +639,14 @@ impl SSTableReader {
                 break; // range extends past EOF; nothing real to verify
             }
             let mut buf = vec![0u8; (hi - lo) as usize];
-            {
-                let mut file = self.file.lock().await;
-                file.seek(SeekFrom::Start(lo)).await?;
-                file.read_exact(&mut buf).await.map_err(|e| {
-                    Error::corruption(format!(
-                        "failed to read uncompressed chunk {chunk} at Data.db offset 0x{lo:x} for CRC verification: {e}"
-                    ))
-                })?;
-            }
+            // Positioned read on the shared point source (issue #1573, C2): the CRC
+            // verifier never holds a cursor mutex across I/O, so it neither convoys
+            // concurrent point reads nor disturbs any scan cursor's position.
+            self.point_source.read_exact_at(lo, &mut buf).map_err(|e| {
+                Error::corruption(format!(
+                    "failed to read uncompressed chunk {chunk} at Data.db offset 0x{lo:x} for CRC verification: {e}"
+                ))
+            })?;
             let computed = crc32fast::hash(&buf);
             let expected = crc.crc_for_chunk(chunk as usize)?;
             if computed != expected {

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -598,12 +598,6 @@ impl SSTableReader {
         if size == 0 {
             return Ok(());
         }
-        let cs = crc.chunk_size() as u64;
-        if cs == 0 {
-            return Err(Error::corruption(
-                "CRC.db chunk size is zero; cannot verify uncompressed read",
-            ));
-        }
         let file_size = self.stats.file_size;
         // Fix 3 (issue #1396): a corrupt on-disk offset/size can overflow
         // `offset + size` (debug panic / wrapped range that misattributes CRC
@@ -620,7 +614,95 @@ impl SSTableReader {
                      Data.db length {file_size}; refusing to verify a corrupt offset"
                 ))
             })?;
-        let first = offset / cs;
+        // Each covering chunk is CRC'd over its on-disk bytes via a positioned
+        // read on the shared point source (issue #1573, C2): the verifier never
+        // holds a cursor mutex across I/O, so it neither convoys concurrent point
+        // reads nor disturbs any scan cursor's position.
+        self.verify_covering_chunks(crc, offset, end, |lo, hi, chunk| {
+            let mut buf = vec![0u8; (hi - lo) as usize];
+            self.point_source.read_exact_at(lo, &mut buf).map_err(|e| {
+                Error::corruption(format!(
+                    "failed to read uncompressed chunk {chunk} at Data.db offset 0x{lo:x} for CRC verification: {e}"
+                ))
+            })?;
+            Ok(crc32fast::hash(&buf))
+        })
+    }
+
+    /// In-buffer counterpart of [`Self::verify_uncompressed_range`] for the
+    /// whole-section point-read fallback (issue #1573): the section is ALREADY
+    /// resident in `section`, covering Data.db `[base, base + section.len())`, so
+    /// each fully-contained covering chunk is CRC-checked directly from memory —
+    /// the section is transferred from disk EXACTLY ONCE (the caller's windowed
+    /// read), not a second time for CRC. A chunk that straddles below `base` (only
+    /// possible when `base` is not `CRC.db`-chunk-aligned, e.g. a nonzero header
+    /// that does not fall on a chunk boundary) re-reads just that one chunk so the
+    /// CRC-before-use guarantee holds regardless of header alignment. Same CRC32
+    /// algorithm, chunk layout, memoization, and mismatch/typed-error semantics as
+    /// [`Self::verify_uncompressed_range`].
+    async fn verify_uncompressed_section_in_buffer(&self, base: u64, section: &[u8]) -> Result<()> {
+        let Some(crc) = self.crc_reader.as_deref() else {
+            return Ok(());
+        };
+        if section.is_empty() {
+            return Ok(());
+        }
+        let file_size = self.stats.file_size;
+        let end = base
+            .checked_add(section.len() as u64)
+            .filter(|end| *end <= file_size)
+            .ok_or_else(|| {
+                Error::corruption(format!(
+                    "uncompressed section [0x{base:x}, +{}) overflows or exceeds the Data.db \
+                     length {file_size}; refusing to verify a corrupt section",
+                    section.len()
+                ))
+            })?;
+        self.verify_covering_chunks(crc, base, end, |lo, hi, chunk| {
+            if lo >= base && hi <= end {
+                // Chunk fully resident in the already-read buffer — CRC from
+                // memory, no second I/O.
+                let s = (lo - base) as usize;
+                let e = (hi - base) as usize;
+                Ok(crc32fast::hash(&section[s..e]))
+            } else {
+                // Chunk extends below `base` (unaligned header) — read just it.
+                let mut buf = vec![0u8; (hi - lo) as usize];
+                self.point_source.read_exact_at(lo, &mut buf).map_err(|e| {
+                    Error::corruption(format!(
+                        "failed to read uncompressed chunk {chunk} at Data.db offset 0x{lo:x} for CRC verification: {e}"
+                    ))
+                })?;
+                Ok(crc32fast::hash(&buf))
+            }
+        })
+    }
+
+    /// Walk the `CRC.db` chunk(s) covering Data.db `[start, end)` (`end` already
+    /// bounds-checked `<= file_size` by the caller, `end > start`), skipping chunks
+    /// already verified for this reader, comparing each covering chunk's CRC32 to
+    /// `CRC.db`, and memoizing successes so a chunk is verified at most once per
+    /// reader lifetime. `compute(lo, hi, chunk)` yields the CRC32 of the chunk's
+    /// on-disk bytes `[lo, hi)`; callers supply either a positioned disk read or an
+    /// in-buffer slice, which is what lets the whole-section fallback read its bytes
+    /// exactly once. This is the single place the chunk geometry, mismatch error,
+    /// and memoization live — the two public verify entry points differ ONLY in how
+    /// they source each chunk's bytes.
+    fn verify_covering_chunks(
+        &self,
+        crc: &super::crc::CrcDb,
+        start: u64,
+        end: u64,
+        mut compute: impl FnMut(u64, u64, u64) -> Result<u32>,
+    ) -> Result<()> {
+        let cs = crc.chunk_size() as u64;
+        if cs == 0 {
+            return Err(Error::corruption(
+                "CRC.db chunk size is zero; cannot verify uncompressed read",
+            ));
+        }
+        let file_size = self.stats.file_size;
+        let first = start / cs;
         let last = (end - 1) / cs;
         for chunk in first..=last {
             // Skip chunks already verified for this reader.
@@ -638,16 +720,7 @@ impl SSTableReader {
             if hi <= lo {
                 break; // range extends past EOF; nothing real to verify
             }
-            let mut buf = vec![0u8; (hi - lo) as usize];
-            // Positioned read on the shared point source (issue #1573, C2): the CRC
-            // verifier never holds a cursor mutex across I/O, so it neither convoys
-            // concurrent point reads nor disturbs any scan cursor's position.
-            self.point_source.read_exact_at(lo, &mut buf).map_err(|e| {
-                Error::corruption(format!(
-                    "failed to read uncompressed chunk {chunk} at Data.db offset 0x{lo:x} for CRC verification: {e}"
-                ))
-            })?;
-            let computed = crc32fast::hash(&buf);
+            let computed = compute(lo, hi, chunk)?;
             let expected = crc.crc_for_chunk(chunk as usize)?;
             if computed != expected {
                 return Err(Error::corruption(format!(

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -490,7 +490,9 @@ impl SSTableReader {
                     Arc::new(read_at::PlainFileReadAt::open(path, file_size)?)
                 }
             },
-            ScanSource::Buffered { .. } => Arc::new(read_at::PlainFileReadAt::open(path, file_size)?),
+            ScanSource::Buffered { .. } => {
+                Arc::new(read_at::PlainFileReadAt::open(path, file_size)?)
+            }
         };
 
         // Parse header - read available bytes, not a fixed size

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -28,6 +28,8 @@ mod integrity;
 mod key_digest;
 pub(crate) mod parsing; // Needs to be accessible from row_cell_state_machine
 mod partition_lookup;
+// Positional (`pread`-style) point-read backends (issue #1573, Epic C / C2).
+mod read_at;
 // sync-fallback registry-schema pre-resolution (issue #1692)
 #[cfg(feature = "state_machine")]
 mod registry_schema;
@@ -464,6 +466,30 @@ impl SSTableReader {
         .await?;
         let file = Arc::new(Mutex::new(source));
 
+        // Build the POINT-READ positional source ONCE at open (issue #1573, C2).
+        // It shares the reader's `Arc<Mmap>` when the backend is mmap (no extra
+        // mapping / fd); for buffered/direct it holds one dedicated read-only fd,
+        // which is exactly the "open the fd once, positioned-read thereafter"
+        // contract that removes the BTI per-lookup `open(2)`. Every non-mmap
+        // backend degrades gracefully to a plain positioned fd if the faster
+        // backend is refused, mirroring `build_block_sources`.
+        let point_source: Arc<dyn read_at::ReadAt> = match &scan_source {
+            ScanSource::Mapped(mmap) => Arc::new(read_at::MmapReadAt::new(mmap.clone())),
+            #[cfg(unix)]
+            ScanSource::Direct { .. } => match read_at::DirectReadAt::open(path, file_size) {
+                Ok(d) => Arc::new(d) as Arc<dyn read_at::ReadAt>,
+                Err(e) => {
+                    log::warn!(
+                        "Direct-I/O point source for {} failed ({}); using buffered pread",
+                        path.display(),
+                        e
+                    );
+                    Arc::new(read_at::PlainFileReadAt::open(path, file_size)?)
+                }
+            },
+            ScanSource::Buffered { .. } => Arc::new(read_at::PlainFileReadAt::open(path, file_size)?),
+        };
+
         // Parse header - read available bytes, not a fixed size
         // NOTE: For NB format files (Cassandra 4.x+), Data.db often contains compressed row data
         // with no embedded header. The header.rs module detects this via filename pattern and
@@ -726,6 +752,7 @@ impl SSTableReader {
             file_path: path.to_path_buf(),
             file,
             scan_source,
+            point_source,
             header,
             parser,
             index,

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -30,6 +30,9 @@ pub(crate) mod parsing; // Needs to be accessible from row_cell_state_machine
 mod partition_lookup;
 // Positional (`pread`-style) point-read backends (issue #1573, Epic C / C2).
 mod read_at;
+// Concurrency scenarios for the ReadAt point-read migration (issue #1573).
+#[cfg(test)]
+mod read_at_point_tests;
 // sync-fallback registry-schema pre-resolution (issue #1692)
 #[cfg(feature = "state_machine")]
 mod registry_schema;
@@ -797,6 +800,22 @@ impl SSTableReader {
     #[cfg(test)]
     pub(crate) async fn is_mmap_backed(&self) -> bool {
         self.file.lock().await.is_mmap()
+    }
+
+    /// Clone the reader's shared positional point source (issue #1573 convoy
+    /// scenario). Test-only: lets a test wrap the real source in a slow/serializing
+    /// decorator, then reinstall it via [`set_point_source`](Self::set_point_source).
+    #[cfg(test)]
+    pub(crate) fn clone_point_source(&self) -> Arc<dyn read_at::ReadAt> {
+        self.point_source.clone()
+    }
+
+    /// Replace the reader's point source (issue #1573 convoy scenario). Test-only;
+    /// requires `&mut self`, so it must be called BEFORE the reader is shared
+    /// behind an `Arc` across the concurrent point reads under test.
+    #[cfg(test)]
+    pub(crate) fn set_point_source(&mut self, src: Arc<dyn read_at::ReadAt>) {
+        self.point_source = src;
     }
 
     /// Whether this reader's block source is backed by direct I/O.

--- a/cqlite-core/src/storage/sstable/reader/read_at.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at.rs
@@ -28,7 +28,7 @@
 //!
 //! | Backend | `read_at` | Notes |
 //! |---------|-----------|-------|
-//! | [`PlainFileReadAt`] | `FileExt::read_at` (Unix) / `seek_read` (Windows) on ONE shared `File` | Positioned reads on a shared fd are independent — no lock. |
+//! | [`PlainFileReadAt`] | `FileExt::read_at` (Unix, lock-free) / `Mutex`-guarded `seek_read` (Windows) on ONE shared `File` | Unix `pread` is positional so reads are independent (no lock); Windows `seek_read` moves the shared cursor, so it is serialized under a `Mutex`. Positioned reads on a shared fd are independent — no lock. |
 //! | [`MmapReadAt`] | slice indexing into the resident map | Bounds-checked; zero syscalls per read. |
 //! | [`DirectReadAt`] (Unix) | aligned positioned read honoring the `O_DIRECT` 4K rule | A per-call aligned bounce buffer keeps `&self` (no shared cursor). |
 //!
@@ -175,12 +175,27 @@ impl<R: ReadAt> ReadAt for SerializingReadAt<R> {
 
 /// Positional reads over a plain file handle.
 ///
-/// Wraps ONE shared `std::fs::File`. On Unix, `FileExt::read_at` issues a `pread`
-/// that does not touch the fd's offset, so concurrent reads on this single handle
-/// are independent — no lock, no per-lookup `open(2)`. Opened once at reader open
-/// and shared for the reader's lifetime (design.md Decision 3).
+/// Wraps ONE shared `std::fs::File`, opened once at reader open and shared for the
+/// reader's lifetime (design.md Decision 3).
+///
+/// On **Unix**, `FileExt::read_at` issues a `pread` that does not touch the fd's
+/// offset, so concurrent reads on this single handle are independent — no lock, no
+/// per-lookup `open(2)`.
+///
+/// On **Windows** there is no positional `pread`: `seek_read` MOVES the handle's
+/// file pointer, so two concurrent reads on one shared handle would race the cursor
+/// and return the wrong bytes (silent corruption). The Windows arm therefore guards
+/// the handle with a `std::sync::Mutex` and performs the seek+read under the lock,
+/// serializing Windows point reads for correctness while still opening the fd only
+/// once. The Unix arm keeps its lock-free `Arc<File>` (issue #1573 roborev finding).
 pub(crate) struct PlainFileReadAt {
+    /// Unix: shared handle, read lock-free via positional `pread` (no cursor).
+    #[cfg(unix)]
     file: Arc<std::fs::File>,
+    /// Windows: `seek_read` mutates the shared cursor, so the handle is `Mutex`-
+    /// guarded and read+seek happen atomically under the lock (see struct docs).
+    #[cfg(windows)]
+    file: std::sync::Mutex<std::fs::File>,
     len: u64,
 }
 
@@ -188,7 +203,10 @@ impl PlainFileReadAt {
     /// Wrap an already-open file handle whose length is `len`.
     pub(crate) fn new(file: std::fs::File, len: u64) -> Self {
         Self {
+            #[cfg(unix)]
             file: Arc::new(file),
+            #[cfg(windows)]
+            file: std::sync::Mutex::new(file),
             len,
         }
     }
@@ -212,14 +230,19 @@ impl ReadAt for PlainFileReadAt {
 
     #[cfg(windows)]
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
-        // Windows has no `pread`; `seek_read` is the platform equivalent. It DOES
-        // move the handle's file pointer, so concurrent callers on one handle can
-        // race the cursor — acceptable here because the correctness scenarios run
-        // on the Unix backends in CI (design.md Risks: "Windows drift"). Windows
-        // builds that need concurrent point reads would front this with per-caller
-        // handles; not required for the Cassandra-5.0 read floor CQLite targets.
+        // Windows has no positional `pread`; `seek_read` MOVES the handle's file
+        // pointer, so two concurrent `read_at` calls on the one shared handle would
+        // race the cursor and return the wrong bytes (silent corruption). We hold a
+        // `Mutex` across the seek+read so Windows point reads are serialized and
+        // correct, while still opening the fd only once (issue #1573 roborev
+        // finding). This intentionally trades Windows concurrency for correctness;
+        // the Unix arm above needs no lock because `FileExt::read_at` is positional
+        // and never touches the fd offset. Recover a poisoned lock in-place (a
+        // panicking reader cannot leave the handle in a torn state) rather than
+        // `unwrap`/`expect` in library code.
         use std::os::windows::fs::FileExt;
-        Ok(self.file.seek_read(buf, offset)?)
+        let file = self.file.lock().unwrap_or_else(|e| e.into_inner());
+        Ok(file.seek_read(buf, offset)?)
     }
 
     fn len(&self) -> u64 {

--- a/cqlite-core/src/storage/sstable/reader/read_at.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at.rs
@@ -1,0 +1,451 @@
+//! Positional (`pread`-style) read backends for the SSTable point-read path
+//! (issue #1573, Epic C / C2).
+//!
+//! # Why this exists
+//!
+//! The historical point-read path served every read through a single
+//! [`BlockSource`](super::source::BlockSource) behind an
+//! `Arc<Mutex<BlockSource>>`. That mutex exists ONLY to guard a mutable seek
+//! cursor, and it was held **across disk I/O**, so N concurrent point reads on
+//! one SSTable serialized one-at-a-time (the convoy). The BTI variant sidestepped
+//! the mutex by paying `File::open` **per lookup** instead — trading the convoy
+//! for per-op `open(2)` syscalls and an fd-exhaustion risk under load.
+//!
+//! Both pathologies share one root cause: a *stateful* file cursor. [`ReadAt`]
+//! removes the state. A positioned read carries its offset as a call parameter,
+//! not as shared mutable file state, so:
+//!
+//! - **No mutable position** — the trait has no seek cursor.
+//! - **No `&mut self`** — every method takes `&self`, so concurrent callers share
+//!   one value with no exclusive borrow and no mutex.
+//! - **No seek** — the offset is a parameter of the read.
+//!
+//! A positioned read on a shared file descriptor is independent of every other
+//! positioned read (POSIX `pread`/`FileExt::read_at` does not touch the fd's
+//! offset), so the lock is not merely moved off the point path — it is removed.
+//!
+//! # Backends
+//!
+//! | Backend | `read_at` | Notes |
+//! |---------|-----------|-------|
+//! | [`PlainFileReadAt`] | `FileExt::read_at` (Unix) / `seek_read` (Windows) on ONE shared `File` | Positioned reads on a shared fd are independent — no lock. |
+//! | [`MmapReadAt`] | slice indexing into the resident map | Bounds-checked; zero syscalls per read. |
+//! | [`DirectReadAt`] (Unix) | aligned positioned read honoring the `O_DIRECT` 4K rule | A per-call aligned bounce buffer keeps `&self` (no shared cursor). |
+//!
+//! The trait is intentionally shaped so the windowed streaming scan can adopt it
+//! later (audit F3) without requiring it now; this change migrates only the
+//! point-read path (design.md Decision 4).
+
+use std::sync::Arc;
+
+use memmap2::Mmap;
+
+use crate::{Error, Result};
+
+/// A positional byte source: reads are addressed by an explicit `offset`, never
+/// by a shared mutable cursor.
+///
+/// Every method takes `&self`. Two concurrent `read_at` calls at different
+/// offsets are independent — neither observes nor disturbs the other's position,
+/// because there is no position. This is the whole point of the refactor
+/// (issue #1573): concurrent point reads on one SSTable no longer serialize on a
+/// cross-I/O mutex, and BTI lookups no longer `open(2)` per call.
+pub(crate) trait ReadAt: Send + Sync {
+    /// Read up to `buf.len()` bytes starting at absolute file `offset`, returning
+    /// the number of bytes read. A short read (fewer than `buf.len()`) is legal
+    /// at/near EOF, exactly like POSIX `pread`.
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize>;
+
+    /// Total length of the backing file in bytes.
+    fn len(&self) -> u64;
+
+    /// Read EXACTLY `buf.len()` bytes starting at `offset`, erroring with
+    /// [`std::io::ErrorKind::UnexpectedEof`] if the source is exhausted first.
+    ///
+    /// Default impl loops [`read_at`](Self::read_at) so every backend gets an
+    /// exact-read helper for free; backends may override if they can do better.
+    fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<()> {
+        let mut filled = 0usize;
+        while filled < buf.len() {
+            let n = self.read_at(offset + filled as u64, &mut buf[filled..])?;
+            if n == 0 {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "read_exact_at: reached EOF after {filled} of {} bytes at offset 0x{offset:x}",
+                        buf.len()
+                    ),
+                )));
+            }
+            filled += n;
+        }
+        Ok(())
+    }
+}
+
+/// Delegating impl so an `Arc<dyn ReadAt>` (or `Arc<ConcreteBackend>`) is itself a
+/// `ReadAt`. Lets the point path hold a single `Arc<dyn ReadAt>` and lets a test
+/// wrap the reader's existing shared source without unsizing gymnastics.
+impl<T: ReadAt + ?Sized> ReadAt for Arc<T> {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        (**self).read_at(offset, buf)
+    }
+    fn len(&self) -> u64 {
+        (**self).len()
+    }
+    fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<()> {
+        (**self).read_exact_at(offset, buf)
+    }
+}
+
+/// A `ReadAt` that sleeps before delegating — models a slow backend so the convoy
+/// test can prove concurrent point reads overlap instead of serializing, and
+/// counts invocations so a routing assertion can prove the point path reached the
+/// trait at all. Test-only (issue #1573 convoy scenario).
+#[cfg(test)]
+pub(crate) struct SleepingReadAt<R: ReadAt> {
+    inner: R,
+    delay: std::time::Duration,
+    calls: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[cfg(test)]
+impl<R: ReadAt> SleepingReadAt<R> {
+    pub(crate) fn new(
+        inner: R,
+        delay: std::time::Duration,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        Self {
+            inner,
+            delay,
+            calls,
+        }
+    }
+}
+
+#[cfg(test)]
+impl<R: ReadAt> ReadAt for SleepingReadAt<R> {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        std::thread::sleep(self.delay);
+        self.inner.read_at(offset, buf)
+    }
+    fn len(&self) -> u64 {
+        self.inner.len()
+    }
+}
+
+/// Positional reads over a plain file handle.
+///
+/// Wraps ONE shared `std::fs::File`. On Unix, `FileExt::read_at` issues a `pread`
+/// that does not touch the fd's offset, so concurrent reads on this single handle
+/// are independent — no lock, no per-lookup `open(2)`. Opened once at reader open
+/// and shared for the reader's lifetime (design.md Decision 3).
+pub(crate) struct PlainFileReadAt {
+    file: Arc<std::fs::File>,
+    len: u64,
+}
+
+impl PlainFileReadAt {
+    /// Wrap an already-open file handle whose length is `len`.
+    pub(crate) fn new(file: std::fs::File, len: u64) -> Self {
+        Self {
+            file: Arc::new(file),
+            len,
+        }
+    }
+
+    /// Open `path` read-only for positioned reads, recording one `open(2)` in the
+    /// read-work counters (consumer C2). This is the single per-reader open the
+    /// BTI point path used to pay per lookup.
+    pub(crate) fn open(path: &std::path::Path, len: u64) -> Result<Self> {
+        crate::storage::sstable::read_work_counters::record_file_open();
+        let file = std::fs::File::open(path)?;
+        Ok(Self::new(file, len))
+    }
+}
+
+impl ReadAt for PlainFileReadAt {
+    #[cfg(unix)]
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        use std::os::unix::fs::FileExt;
+        Ok(self.file.read_at(buf, offset)?)
+    }
+
+    #[cfg(windows)]
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        // Windows has no `pread`; `seek_read` is the platform equivalent. It DOES
+        // move the handle's file pointer, so concurrent callers on one handle can
+        // race the cursor — acceptable here because the correctness scenarios run
+        // on the Unix backends in CI (design.md Risks: "Windows drift"). Windows
+        // builds that need concurrent point reads would front this with per-caller
+        // handles; not required for the Cassandra-5.0 read floor CQLite targets.
+        use std::os::windows::fs::FileExt;
+        Ok(self.file.seek_read(buf, offset)?)
+    }
+
+    fn len(&self) -> u64 {
+        self.len
+    }
+}
+
+/// Positional reads over a memory-mapped file.
+///
+/// A slice read out of the resident map — zero syscalls, and trivially `&self`
+/// (the map is immutable). Shares the reader's existing `Arc<Mmap>` when the
+/// backend is mmap, so no extra mapping or fd is created.
+pub(crate) struct MmapReadAt {
+    mmap: Arc<Mmap>,
+}
+
+impl MmapReadAt {
+    pub(crate) fn new(mmap: Arc<Mmap>) -> Self {
+        Self { mmap }
+    }
+}
+
+impl ReadAt for MmapReadAt {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        let data: &[u8] = &self.mmap;
+        let len = data.len() as u64;
+        // At/past EOF: zero bytes, matching `File`/pread semantics.
+        if offset >= len {
+            return Ok(0);
+        }
+        let start = offset as usize;
+        let avail = &data[start..];
+        let n = avail.len().min(buf.len());
+        buf[..n].copy_from_slice(&avail[..n]);
+        Ok(n)
+    }
+
+    fn len(&self) -> u64 {
+        self.mmap.len() as u64
+    }
+}
+
+/// I/O alignment (bytes) for `O_DIRECT`: the offset, length, and buffer must all
+/// be a multiple of the device logical block size. 4096 is a safe superset of the
+/// common 512/4096 sector sizes (mirrors `source::DIRECT_IO_ALIGN`).
+#[cfg(unix)]
+const DIRECT_IO_ALIGN: usize = 4096;
+
+/// Positional reads over a file opened with direct I/O (`O_DIRECT` / `F_NOCACHE`).
+///
+/// `O_DIRECT` mandates aligned transfers, so each `read_at` allocates its OWN
+/// aligned bounce buffer, `pread`s an aligned superset of the requested range,
+/// and copies out the requested sub-range. Because the bounce buffer is per-call
+/// (never shared), the backend keeps `&self` with no shared mutable cursor — two
+/// concurrent `read_at`s never touch the same buffer.
+#[cfg(unix)]
+pub(crate) struct DirectReadAt {
+    file: Arc<std::fs::File>,
+    len: u64,
+}
+
+#[cfg(unix)]
+impl DirectReadAt {
+    /// Open `path` with direct I/O for positioned reads. Records one `open(2)`
+    /// (consumer C2). Returns an error if the platform/filesystem refuses direct
+    /// I/O so the caller can fall back to buffered.
+    pub(crate) fn open(path: &std::path::Path, len: u64) -> Result<Self> {
+        let file = super::source::open_direct_file(path)?;
+        crate::storage::sstable::read_work_counters::record_file_open();
+        Ok(Self {
+            file: Arc::new(file),
+            len,
+        })
+    }
+}
+
+#[cfg(unix)]
+impl ReadAt for DirectReadAt {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        use std::os::unix::fs::FileExt;
+        if offset >= self.len || buf.is_empty() {
+            return Ok(0);
+        }
+        let align = DIRECT_IO_ALIGN as u64;
+        let aligned_off = (offset / align) * align;
+        let head = (offset - aligned_off) as usize;
+        // Round the aligned span up to cover [offset, offset+buf.len()).
+        let want_end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or_else(|| Error::corruption("direct read_at: offset+len overflow"))?
+            .min(self.len);
+        let span = (want_end - aligned_off) as usize;
+        let aligned_len = span
+            .checked_next_multiple_of(DIRECT_IO_ALIGN)
+            .unwrap_or(usize::MAX & !(DIRECT_IO_ALIGN - 1));
+        let mut bounce = AlignedBuf::new(aligned_len, DIRECT_IO_ALIGN)?;
+        let got = self.file.read_at(bounce.as_mut_slice(), aligned_off)?;
+        if got <= head {
+            return Ok(0);
+        }
+        let usable = &bounce.as_slice()[head..got];
+        let n = usable.len().min(buf.len());
+        buf[..n].copy_from_slice(&usable[..n]);
+        Ok(n)
+    }
+
+    fn len(&self) -> u64 {
+        self.len
+    }
+}
+
+/// A heap allocation whose start address is aligned to a requested boundary, as
+/// required for `O_DIRECT` transfer buffers. Local to the point-read path so it
+/// stays independent of the scan-cursor `AlignedBuf` in `source.rs`.
+#[cfg(unix)]
+struct AlignedBuf {
+    ptr: std::ptr::NonNull<u8>,
+    layout: std::alloc::Layout,
+}
+
+// SAFETY: `AlignedBuf` uniquely owns its allocation for its whole lifetime; the
+// raw pointer is never aliased or shared, so moving it across threads is sound.
+#[cfg(unix)]
+unsafe impl Send for AlignedBuf {}
+
+#[cfg(unix)]
+impl AlignedBuf {
+    fn new(size: usize, align: usize) -> Result<Self> {
+        let size = size.max(align);
+        let layout = std::alloc::Layout::from_size_align(size, align)
+            .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, e)))?;
+        // SAFETY: `layout` has non-zero size (size >= align >= 1).
+        let raw = unsafe { std::alloc::alloc_zeroed(layout) };
+        let ptr = std::ptr::NonNull::new(raw).ok_or_else(|| {
+            Error::Io(std::io::Error::new(
+                std::io::ErrorKind::OutOfMemory,
+                "aligned alloc failed",
+            ))
+        })?;
+        Ok(Self { ptr, layout })
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        // SAFETY: `ptr` is valid for `layout.size()` initialised bytes (zeroed on
+        // alloc, then overwritten by reads) and borrowed immutably here.
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.layout.size()) }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: `ptr` is valid for `layout.size()` bytes and uniquely borrowed.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.layout.size()) }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        // SAFETY: `ptr`/`layout` are exactly the values from the matching
+        // `alloc_zeroed`, freed exactly once here.
+        unsafe { std::alloc::dealloc(self.ptr.as_ptr(), self.layout) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Barrier;
+
+    fn temp_file(bytes: &[u8], tag: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "cqlite_readat_{}_{}.bin",
+            tag,
+            std::process::id()
+        ));
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    #[test]
+    fn plain_file_positioned_reads_return_their_own_bytes() {
+        let data: Vec<u8> = (0..=255u8).cycle().take(9000).collect();
+        let path = temp_file(&data, "plain");
+        let src = PlainFileReadAt::open(&path, data.len() as u64).unwrap();
+
+        let mut a = [0u8; 8];
+        src.read_exact_at(100, &mut a).unwrap();
+        assert_eq!(&a, &data[100..108]);
+
+        let mut b = [0u8; 8];
+        src.read_exact_at(5000, &mut b).unwrap();
+        assert_eq!(&b, &data[5000..5008]);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mmap_positioned_reads_return_their_own_bytes() {
+        let data: Vec<u8> = (0..=255u8).cycle().take(9000).collect();
+        let path = temp_file(&data, "mmap");
+        let file = std::fs::File::open(&path).unwrap();
+        // SAFETY: read-only map of a file we exclusively control in this test.
+        let mmap = unsafe { memmap2::MmapOptions::new().map(&file).unwrap() };
+        let src = MmapReadAt::new(Arc::new(mmap));
+
+        let mut a = [0u8; 8];
+        src.read_exact_at(100, &mut a).unwrap();
+        assert_eq!(&a, &data[100..108]);
+        let mut b = [0u8; 8];
+        src.read_exact_at(5000, &mut b).unwrap();
+        assert_eq!(&b, &data[5000..5008]);
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Interleaved concurrent positioned reads at different offsets each return
+    /// their own bytes — no cross-contamination from the other read's position
+    /// (there is no position). Proves the `&self`, no-shared-cursor contract.
+    #[test]
+    fn interleaved_concurrent_reads_do_not_cross_contaminate() {
+        let data: Vec<u8> = (0..=255u8).cycle().take(1 << 16).collect();
+        let path = temp_file(&data, "interleave");
+        let src = Arc::new(PlainFileReadAt::open(&path, data.len() as u64).unwrap());
+
+        let barrier = Arc::new(Barrier::new(2));
+        let off_a = 111u64;
+        let off_b = 40000u64;
+        let expect_a = data[off_a as usize..off_a as usize + 32].to_vec();
+        let expect_b = data[off_b as usize..off_b as usize + 32].to_vec();
+
+        let (s1, b1) = (Arc::clone(&src), Arc::clone(&barrier));
+        let t = std::thread::spawn(move || {
+            let mut acc = Vec::new();
+            b1.wait();
+            for _ in 0..200 {
+                let mut buf = [0u8; 32];
+                s1.read_exact_at(off_a, &mut buf).unwrap();
+                acc.push(buf.to_vec());
+            }
+            acc
+        });
+
+        barrier.wait();
+        for _ in 0..200 {
+            let mut buf = [0u8; 32];
+            src.read_exact_at(off_b, &mut buf).unwrap();
+            assert_eq!(buf.to_vec(), expect_b, "offset B read got A's/other bytes");
+        }
+        for got in t.join().unwrap() {
+            assert_eq!(got, expect_a, "offset A read got B's/other bytes");
+        }
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn read_exact_at_past_eof_is_unexpected_eof() {
+        let data = b"abc";
+        let path = temp_file(data, "eof");
+        let src = PlainFileReadAt::open(&path, data.len() as u64).unwrap();
+        let mut buf = [0u8; 8];
+        let err = src.read_exact_at(1, &mut buf).unwrap_err();
+        match err {
+            Error::Io(e) => assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof),
+            other => panic!("expected UnexpectedEof, got {other:?}"),
+        }
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/read_at.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at.rs
@@ -527,13 +527,13 @@ mod tests {
         // (offset, length) pairs exercising each alignment corner.
         let align = DIRECT_IO_ALIGN as u64;
         let cases: &[(u64, usize)] = &[
-            (0, 100),               // offset 0, within first block
-            (37, 200),              // unaligned, within first block
-            (align - 10, 50),       // spans the first 4K boundary
-            (align, DIRECT_IO_ALIGN), // aligned start, spans into next block
-            (align + 7, 5000),      // unaligned start crossing multiple blocks
+            (0, 100),                  // offset 0, within first block
+            (37, 200),                 // unaligned, within first block
+            (align - 10, 50),          // spans the first 4K boundary
+            (align, DIRECT_IO_ALIGN),  // aligned start, spans into next block
+            (align + 7, 5000),         // unaligned start crossing multiple blocks
             ((len - 300) as u64, 300), // exact final bytes (partial final block)
-            ((len - 10) as u64, 5), // near EOF within the partial final block
+            ((len - 10) as u64, 5),    // near EOF within the partial final block
         ];
         for &(off, n) in cases {
             let mut want = vec![0u8; n];

--- a/cqlite-core/src/storage/sstable/reader/read_at.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at.rs
@@ -137,6 +137,42 @@ impl<R: ReadAt> ReadAt for SleepingReadAt<R> {
     }
 }
 
+/// CONTROL double for the convoy scenario: a slow source whose `read_at` holds a
+/// `std::sync::Mutex` ACROSS the sleep+read, exactly reproducing the pre-#1573
+/// `Arc<Mutex<BlockSource>>` cursor that serialized point reads. Used to prove the
+/// convoy harness CAN serialize (~N×delay), so the parallel result on the real
+/// migrated `point_source` (no mutex) is a real speedup, not a fast harness.
+#[cfg(test)]
+pub(crate) struct SerializingReadAt<R: ReadAt> {
+    inner: R,
+    delay: std::time::Duration,
+    lock: std::sync::Mutex<()>,
+}
+
+#[cfg(test)]
+impl<R: ReadAt> SerializingReadAt<R> {
+    pub(crate) fn new(inner: R, delay: std::time::Duration) -> Self {
+        Self {
+            inner,
+            delay,
+            lock: std::sync::Mutex::new(()),
+        }
+    }
+}
+
+#[cfg(test)]
+impl<R: ReadAt> ReadAt for SerializingReadAt<R> {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        // Hold the lock across the "I/O" (sleep) — the convoy the refactor removes.
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        std::thread::sleep(self.delay);
+        self.inner.read_at(offset, buf)
+    }
+    fn len(&self) -> u64 {
+        self.inner.len()
+    }
+}
+
 /// Positional reads over a plain file handle.
 ///
 /// Wraps ONE shared `std::fs::File`. On Unix, `FileExt::read_at` issues a `pread`

--- a/cqlite-core/src/storage/sstable/reader/read_at.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at.rs
@@ -389,11 +389,8 @@ mod tests {
     use std::sync::Barrier;
 
     fn temp_file(bytes: &[u8], tag: &str) -> std::path::PathBuf {
-        let path = std::env::temp_dir().join(format!(
-            "cqlite_readat_{}_{}.bin",
-            tag,
-            std::process::id()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("cqlite_readat_{}_{}.bin", tag, std::process::id()));
         std::fs::write(&path, bytes).unwrap();
         path
     }

--- a/cqlite-core/src/storage/sstable/reader/read_at.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at.rs
@@ -481,4 +481,92 @@ mod tests {
         }
         std::fs::remove_file(&path).ok();
     }
+
+    /// The `O_DIRECT` backend's per-call 4K alignment math (`aligned_off`/`head`/
+    /// `want_end`/`checked_next_multiple_of`), aligned bounce buffer, and
+    /// short-read/EOF handling must return EXACTLY the bytes a plain positioned
+    /// read would, at every awkward alignment: offset 0, an unaligned offset, an
+    /// offset spanning a 4K block boundary, and a partial final block at/near EOF.
+    /// `PlainFileReadAt` over the same file is the oracle. Guarded `#[cfg(unix)]`
+    /// and SKIPS GRACEFULLY when the temp filesystem refuses `O_DIRECT` (common on
+    /// tmpfs/overlayfs) — mirroring `source::direct_cursor_reads_and_seeks`.
+    #[cfg(unix)]
+    #[test]
+    fn direct_read_at_matches_plain_oracle_at_boundaries() {
+        // File size deliberately NOT a 4096 multiple → forces a partial final
+        // block and non-trivial `aligned_len` rounding.
+        let len = DIRECT_IO_ALIGN * 2 + 1234;
+        let mut data = vec![0u8; len];
+        // Deterministic pseudo-random content (LCG) so mismatches are meaningful.
+        let mut x = 0x1234_5678u32;
+        for b in data.iter_mut() {
+            x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            *b = (x >> 24) as u8;
+        }
+        let path = temp_file(&data, "direct");
+        let oracle = PlainFileReadAt::open(&path, data.len() as u64).unwrap();
+
+        // Open may fail on filesystems without O_DIRECT support → skip cleanly.
+        let direct = match DirectReadAt::open(&path, data.len() as u64) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("O_DIRECT open unsupported here ({e}); skipping DirectReadAt test");
+                std::fs::remove_file(&path).ok();
+                return;
+            }
+        };
+        // Some filesystems accept the O_DIRECT open but refuse aligned reads
+        // (EINVAL) → probe once and skip cleanly rather than fail.
+        let mut probe = [0u8; 16];
+        if let Err(e) = direct.read_at(0, &mut probe) {
+            eprintln!("O_DIRECT read unsupported here ({e}); skipping DirectReadAt test");
+            std::fs::remove_file(&path).ok();
+            return;
+        }
+
+        // (offset, length) pairs exercising each alignment corner.
+        let align = DIRECT_IO_ALIGN as u64;
+        let cases: &[(u64, usize)] = &[
+            (0, 100),               // offset 0, within first block
+            (37, 200),              // unaligned, within first block
+            (align - 10, 50),       // spans the first 4K boundary
+            (align, DIRECT_IO_ALIGN), // aligned start, spans into next block
+            (align + 7, 5000),      // unaligned start crossing multiple blocks
+            ((len - 300) as u64, 300), // exact final bytes (partial final block)
+            ((len - 10) as u64, 5), // near EOF within the partial final block
+        ];
+        for &(off, n) in cases {
+            let mut want = vec![0u8; n];
+            oracle.read_exact_at(off, &mut want).unwrap();
+            let mut got = vec![0u8; n];
+            direct.read_exact_at(off, &mut got).unwrap();
+            assert_eq!(got, want, "DirectReadAt mismatch at off={off} n={n}");
+        }
+
+        // Short read at EOF: request more than remains → exactly the tail, and
+        // byte-for-byte identical to the oracle's short read.
+        let tail_off = (len - 100) as u64;
+        let mut big = vec![0u8; 500];
+        let got_n = direct.read_at(tail_off, &mut big).unwrap();
+        let mut oracle_big = vec![0u8; 500];
+        let oracle_n = oracle.read_at(tail_off, &mut oracle_big).unwrap();
+        assert_eq!(got_n, oracle_n, "short-read length must match oracle");
+        assert_eq!(got_n, 100, "should read exactly the 100 remaining bytes");
+        assert_eq!(&big[..got_n], &oracle_big[..oracle_n]);
+
+        // Fully past EOF → 0 bytes (matches File/pread and MmapReadAt).
+        let mut none = [0u8; 32];
+        assert_eq!(direct.read_at(len as u64, &mut none).unwrap(), 0);
+        assert_eq!(direct.read_at(len as u64 + align, &mut none).unwrap(), 0);
+
+        // read_exact_at fully past EOF → UnexpectedEof, consistent with the
+        // other backends.
+        let err = direct.read_exact_at(len as u64, &mut none).unwrap_err();
+        match err {
+            Error::Io(e) => assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof),
+            other => panic!("expected UnexpectedEof, got {other:?}"),
+        }
+
+        std::fs::remove_file(&path).ok();
+    }
 }

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -1,0 +1,162 @@
+//! In-crate concurrency scenarios for the `ReadAt` point-read migration
+//! (issue #1573, Epic C / C2). These live in-crate (not in `tests/`) because they
+//! inject a `pub(crate)` [`ReadAt`](super::read_at::ReadAt) test double into the
+//! reader's `point_source` — a surface no external crate can reach.
+//!
+//! Requires `CQLITE_DATASETS_ROOT` + fetched binaries; every test skips (never
+//! fails) when its fixture is absent, and never treats 0 rows as a skip.
+
+#![cfg(test)]
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use super::read_at::{SerializingReadAt, SleepingReadAt};
+use super::SSTableReader;
+use crate::{Config, Platform};
+
+/// Locate a `*-Data.db` under `<datasets>/sstables/<keyspace>/<table>-*/`.
+/// Returns `None` (skip) when the datasets root or fixture is absent.
+fn find_data_db(keyspace: &str, table: &str) -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let ks_dir = PathBuf::from(root).join("sstables").join(keyspace);
+    let prefix = format!("{table}-");
+    for entry in std::fs::read_dir(&ks_dir).ok()?.flatten() {
+        if !entry.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        for f in std::fs::read_dir(entry.path()).ok()?.flatten() {
+            if f.file_name().to_string_lossy().ends_with("-Data.db") {
+                return Some(f.path());
+            }
+        }
+    }
+    None
+}
+
+async fn open_reader(path: &std::path::Path) -> Option<SSTableReader> {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.ok()?);
+    SSTableReader::open(path, &config, platform).await.ok()
+}
+
+/// Issue every offset concurrently through `read_value_at_offset` on a shared
+/// reader and return the wall time. Each offset is distinct so the shared chunk
+/// cache does not collapse the reads into one.
+async fn concurrent_point_reads(reader: Arc<SSTableReader>, offsets: &[u64], size: u32) -> Duration {
+    let start = Instant::now();
+    let mut handles = Vec::new();
+    for &off in offsets {
+        let r = Arc::clone(&reader);
+        handles.push(tokio::spawn(async move {
+            // Result is intentionally ignored: the scenario measures whether the
+            // reads SERIALIZE, not their payload (payload correctness is the
+            // parity test's job). Every call still traverses the point source.
+            let _ = r.read_value_at_offset(off, size).await;
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+    start.elapsed()
+}
+
+/// Scenario: 8 concurrent point reads do NOT convoy.
+///
+/// The reader's `point_source` is wrapped in a 12ms-sleeping [`SleepingReadAt`]
+/// (no lock) for the treatment, and in a lock-holding [`SerializingReadAt`] for
+/// the control. The control proves the harness CAN serialize (the pre-#1573
+/// `Arc<Mutex<BlockSource>>` convoy: ~N×delay); the treatment proves the migrated
+/// positional path does NOT (well under 8×delay), because positioned reads on a
+/// shared source are independent (`&self`, no cursor mutex).
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn eight_concurrent_point_reads_do_not_convoy() {
+    let Some(path) = find_data_db("test_basic", "uncompressed_table") else {
+        eprintln!("SKIP (#1573 convoy): test_basic/uncompressed_table Data.db absent");
+        return;
+    };
+    let delay = Duration::from_millis(12);
+    // 8 distinct offsets (distinct cache keys) so each read reaches the source.
+    let offsets: Vec<u64> = (0..8u64).map(|i| i * 96).collect();
+    let size = 48u32;
+
+    // --- Control: a lock-holding source serializes (reproduces the convoy). ---
+    {
+        let mut reader = open_reader(&path).await.expect("open control reader");
+        let real = reader.clone_point_source();
+        reader.set_point_source(Arc::new(SerializingReadAt::new(real, delay)));
+        let reader = Arc::new(reader);
+        let elapsed = concurrent_point_reads(reader, &offsets, size).await;
+        assert!(
+            elapsed >= Duration::from_millis(60),
+            "control (lock-across-I/O) must serialize the 8 reads (~convoy); got {:?} \
+             — if this is fast the harness is not actually contending",
+            elapsed
+        );
+    }
+
+    // --- Treatment: the migrated positional source runs the 8 reads in parallel. ---
+    {
+        let mut reader = open_reader(&path).await.expect("open treatment reader");
+        let real = reader.clone_point_source();
+        let calls = Arc::new(AtomicUsize::new(0));
+        reader.set_point_source(Arc::new(SleepingReadAt::new(real, delay, calls.clone())));
+        let reader = Arc::new(reader);
+        let elapsed = concurrent_point_reads(reader, &offsets, size).await;
+        assert!(
+            calls.load(Ordering::Relaxed) >= offsets.len(),
+            "point path must route through `point_source` (>= {} reads); got {} \
+             — a 0 here means get_cached_data no longer uses point_source",
+            offsets.len(),
+            calls.load(Ordering::Relaxed)
+        );
+        assert!(
+            elapsed < Duration::from_millis(55),
+            "migrated positional point reads must NOT convoy: 8 × {:?} in parallel \
+             should finish well under 8×delay; got {:?}",
+            delay,
+            elapsed
+        );
+    }
+}
+
+/// Scenario: two concurrent interleaved point reads at different offsets each
+/// return their own bytes (no cross-contamination), driven end-to-end through the
+/// reader's `read_value_at_offset` on the shared positional source.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_point_reads_return_correct_bytes() {
+    let Some(path) = find_data_db("test_basic", "uncompressed_table") else {
+        eprintln!("SKIP (#1573 interleave): test_basic/uncompressed_table Data.db absent");
+        return;
+    };
+    let reader = Arc::new(open_reader(&path).await.expect("open reader"));
+
+    // Two disjoint ranges read concurrently many times; each must be internally
+    // consistent across repetitions (a shared cursor would interleave them).
+    let (off_a, off_b, size) = (0u64, 256u64, 32u32);
+    let first_a = reader
+        .read_value_at_offset(off_a, size)
+        .await
+        .expect("read A");
+    let first_b = reader
+        .read_value_at_offset(off_b, size)
+        .await
+        .expect("read B");
+
+    let mut handles = Vec::new();
+    for _ in 0..50 {
+        let (ra, rb) = (Arc::clone(&reader), Arc::clone(&reader));
+        let (ea, eb) = (first_a.clone(), first_b.clone());
+        handles.push(tokio::spawn(async move {
+            let a = ra.read_value_at_offset(off_a, size).await.expect("A");
+            let b = rb.read_value_at_offset(off_b, size).await.expect("B");
+            assert_eq!(a, ea, "offset A read drifted under concurrency");
+            assert_eq!(b, eb, "offset B read drifted under concurrency");
+        }));
+    }
+    for h in handles {
+        h.await.expect("task");
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -87,43 +87,45 @@ async fn eight_concurrent_point_reads_do_not_convoy() {
     let size = 48u32;
 
     // --- Control: a lock-holding source serializes (reproduces the convoy). ---
-    {
+    let control = {
         let mut reader = open_reader(&path).await.expect("open control reader");
         let real = reader.clone_point_source();
         reader.set_point_source(Arc::new(SerializingReadAt::new(real, delay)));
         let reader = Arc::new(reader);
-        let elapsed = concurrent_point_reads(reader, &offsets, size).await;
-        assert!(
-            elapsed >= Duration::from_millis(60),
-            "control (lock-across-I/O) must serialize the 8 reads (~convoy); got {:?} \
-             — if this is fast the harness is not actually contending",
-            elapsed
-        );
-    }
+        concurrent_point_reads(reader, &offsets, size).await
+    };
 
     // --- Treatment: the migrated positional source runs the 8 reads in parallel. ---
-    {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let treatment = {
         let mut reader = open_reader(&path).await.expect("open treatment reader");
         let real = reader.clone_point_source();
-        let calls = Arc::new(AtomicUsize::new(0));
         reader.set_point_source(Arc::new(SleepingReadAt::new(real, delay, calls.clone())));
         let reader = Arc::new(reader);
-        let elapsed = concurrent_point_reads(reader, &offsets, size).await;
-        assert!(
-            calls.load(Ordering::Relaxed) >= offsets.len(),
-            "point path must route through `point_source` (>= {} reads); got {} \
-             — a 0 here means get_cached_data no longer uses point_source",
-            offsets.len(),
-            calls.load(Ordering::Relaxed)
-        );
-        assert!(
-            elapsed < Duration::from_millis(55),
-            "migrated positional point reads must NOT convoy: 8 × {:?} in parallel \
-             should finish well under 8×delay; got {:?}",
-            delay,
-            elapsed
-        );
-    }
+        concurrent_point_reads(reader, &offsets, size).await
+    };
+
+    // Routing proof (deterministic; this is what is RED on `main`, where
+    // get_cached_data/verify_uncompressed_range still lock `self.file` and never
+    // touch `point_source`): the point path must reach the injected source.
+    assert!(
+        calls.load(Ordering::Relaxed) >= offsets.len(),
+        "point path must route through `point_source` (>= {} reads); got {} \
+         — a 0 here means the point path no longer uses point_source",
+        offsets.len(),
+        calls.load(Ordering::Relaxed)
+    );
+
+    // Parallelism proof, expressed RELATIVE to the measured control (no absolute
+    // wall-clock threshold, so it does not flake on a slow/loaded CI host): the
+    // serialized control does ~8× the sleeping work, so the parallel treatment
+    // must be at least ~2× faster. On `main` (mutex convoy) treatment ≈ control.
+    assert!(
+        treatment.saturating_mul(2) < control,
+        "migrated positional point reads must NOT convoy: parallel treatment {treatment:?} \
+         should be far faster than the serialized control {control:?} (>= 2×); \
+         near-equal means the reads still serialize"
+    );
 }
 
 /// Scenario: two concurrent interleaved point reads at different offsets each

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -6,8 +6,6 @@
 //! Requires `CQLITE_DATASETS_ROOT` + fetched binaries; every test skips (never
 //! fails) when its fixture is absent, and never treats 0 rows as a skip.
 
-#![cfg(test)]
-
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -45,7 +45,11 @@ async fn open_reader(path: &std::path::Path) -> Option<SSTableReader> {
 /// Issue every offset concurrently through `read_value_at_offset` on a shared
 /// reader and return the wall time. Each offset is distinct so the shared chunk
 /// cache does not collapse the reads into one.
-async fn concurrent_point_reads(reader: Arc<SSTableReader>, offsets: &[u64], size: u32) -> Duration {
+async fn concurrent_point_reads(
+    reader: Arc<SSTableReader>,
+    offsets: &[u64],
+    size: u32,
+) -> Duration {
     let start = Instant::now();
     let mut handles = Vec::new();
     for &off in offsets {

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -331,6 +331,46 @@ fn offset_from(base: u64, offset: i64) -> io::Result<u64> {
     Ok(result)
 }
 
+/// Open a file handle in cache-bypassing (direct-I/O) mode for the current
+/// platform. Shared by the scan-cursor [`DirectCursor`] and the point-read
+/// [`DirectReadAt`](super::read_at::DirectReadAt) so both honor the exact same
+/// per-platform primitive.
+///
+/// - Linux/Android: `O_DIRECT`.
+/// - macOS: `F_NOCACHE` (the per-fd equivalent; no `O_DIRECT`).
+/// - other Unix: unsupported → the caller falls back to buffered I/O.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) fn open_direct_file(path: &Path) -> io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECT)
+        .open(path)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn open_direct_file(path: &Path) -> io::Result<std::fs::File> {
+    use std::os::unix::io::AsRawFd;
+    let file = std::fs::File::open(path)?;
+    // SAFETY: `fcntl` with `F_NOCACHE` on a freshly opened, valid fd.
+    let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_NOCACHE, 1) };
+    if rc == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(file)
+}
+
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android", target_os = "macos"))
+))]
+pub(crate) fn open_direct_file(_path: &Path) -> io::Result<std::fs::File> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "direct I/O is not supported on this platform",
+    ))
+}
+
 /// I/O alignment (bytes) for direct reads. `O_DIRECT` requires the file
 /// offset, transfer length, and user buffer to all be aligned to the logical
 /// block size of the underlying device. 4096 is a safe superset of the common
@@ -412,40 +452,8 @@ impl DirectCursor {
     }
 
     /// Open a file handle in cache-bypassing mode for the current platform.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn open_direct(path: &Path) -> io::Result<std::fs::File> {
-        use std::os::unix::fs::OpenOptionsExt;
-        std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_DIRECT)
-            .open(path)
-    }
-
-    /// macOS has no `O_DIRECT`; `F_NOCACHE` is the equivalent per-fd hint that
-    /// tells the unified buffer cache not to retain data for this descriptor.
-    #[cfg(target_os = "macos")]
-    fn open_direct(path: &Path) -> io::Result<std::fs::File> {
-        use std::os::unix::io::AsRawFd;
-        let file = std::fs::File::open(path)?;
-        // SAFETY: `fcntl` with `F_NOCACHE` on a freshly opened, valid fd.
-        let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_NOCACHE, 1) };
-        if rc == -1 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(file)
-    }
-
-    /// Other Unix targets: no portable cache-bypass primitive is wired up, so
-    /// report unsupported and let the caller fall back to buffered I/O.
-    #[cfg(all(
-        unix,
-        not(any(target_os = "linux", target_os = "android", target_os = "macos"))
-    ))]
-    fn open_direct(_path: &Path) -> io::Result<std::fs::File> {
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "direct I/O is not supported on this platform",
-        ))
+        open_direct_file(path)
     }
 
     /// Ensure the byte at `self.pos` is resident in `buf`, refilling with one

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -244,6 +244,17 @@ pub struct SSTableReader {
     /// Template for minting fresh per-scan [`BlockSource`]s so concurrent scans
     /// never share a mutable file position or chunk index (issue #815).
     pub(crate) scan_source: ScanSource,
+    /// Positional (`pread`-style) source for the POINT-READ path (issue #1573,
+    /// Epic C / C2). Opened ONCE at reader open and shared for the reader's
+    /// lifetime. Because [`ReadAt`](super::read_at::ReadAt) takes `&self` (no seek,
+    /// no mutable position), concurrent point reads on one reader neither
+    /// serialize on a cursor mutex nor `open(2)` `Data.db` per lookup — the two
+    /// point-path pathologies C2 removes. Shares the reader's `Arc<Mmap>` when the
+    /// backend is mmap (no extra mapping / fd); otherwise it holds one dedicated
+    /// read-only fd. Scans still use [`scan_source`](Self::scan_source); this
+    /// source is intentionally shaped so scans could adopt it later (audit F3)
+    /// without requiring it now.
+    pub(crate) point_source: std::sync::Arc<dyn super::read_at::ReadAt>,
     /// SSTable header information
     pub(crate) header: SSTableHeader,
     /// Parser for SSTable format

--- a/cqlite-core/tests/issue_1573_readat_positional.rs
+++ b/cqlite-core/tests/issue_1573_readat_positional.rs
@@ -1,0 +1,344 @@
+//! Issue #1573 (Epic C / C2): the `ReadAt` positional point-read migration,
+//! validated through the public `Database` API.
+//!
+//! Covers the observable spec scenarios that do not need internal injection:
+//! - **fd high-water:** BTI point lookups no longer `open(2)` per call — 64
+//!   concurrent lookups + 8 scans keep `FILE_OPENS` bounded (fails on `main`,
+//!   where each BTI lookup minted a fresh scan-cursor fd).
+//! - **value parity:** rows via the migrated point-read path byte-match the scan
+//!   path (the correctness oracle) over the corpus.
+//! - **scans unchanged:** a full scan is deterministic and non-empty after the
+//!   point-read migration (the windowed pipeline is untouched).
+//!
+//! Compiled only with `--features work-counters` (the `FILE_OPENS` getter lives
+//! behind it, mirroring `issue_1566_read_work_counters`). Requires
+//! `CQLITE_DATASETS_ROOT` + fetched binaries; every test skips (never fails) when
+//! its fixture is absent, and never treats 0 rows as a skip. Excluded under
+//! `tombstones` (that build serves point reads via a full-scan filter rather than
+//! the targeted seek this evidences).
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::sstable::read_work_counters as rwc;
+use cqlite_core::{Database, Value};
+use serial_test::serial;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        if let Some(dir) = root.parent().and_then(|p| {
+            let d = p.join("schemas");
+            d.exists().then_some(d)
+        }) {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+/// True if `<datasets>/sstables/<keyspace>/<table>-*/` holds a `*-Data.db`. Skip
+/// keys off fixture presence (not a 0-row result), so a present fixture that
+/// yields 0 rows stays a hard failure.
+fn fixture_data_present(keyspace: &str, table: &str) -> bool {
+    let Some(root) = datasets_root() else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(root.join("sstables").join(keyspace)) else {
+        return false;
+    };
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        if let Ok(files) = std::fs::read_dir(e.path()) {
+            for f in files.flatten() {
+                if f.file_name().to_string_lossy().ends_with("-Data.db") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+async fn setup(keyspace: &str, schema_file: &str) -> Option<Database> {
+    let root = datasets_root()?;
+    let schema_path = schemas_dir()?.join(schema_file);
+    if !schema_path.exists() {
+        return None;
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return None;
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: Some("5.0".to_string()),
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    };
+    let result = ingest(config).await.ok()?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return None;
+    }
+    Some(result.database)
+}
+
+/// Canonical unquoted 8-4-4-4-12 UUID literal the SELECT parser accepts (#956).
+fn uuid_to_literal(bytes: &[u8; 16]) -> String {
+    let h = |range: std::ops::Range<usize>| -> String {
+        bytes[range].iter().map(|b| format!("{b:02x}")).collect()
+    };
+    format!(
+        "{}-{}-{}-{}-{}",
+        h(0..4),
+        h(4..6),
+        h(6..8),
+        h(8..10),
+        h(10..16)
+    )
+}
+
+/// Every `id` UUID present in `table`, learned from a full scan (the oracle).
+async fn learn_ids(db: &Database, table: &str) -> Vec<[u8; 16]> {
+    let Ok(scan) = db.execute(&format!("SELECT id FROM {table}")).await else {
+        return Vec::new();
+    };
+    scan.rows
+        .iter()
+        .filter_map(|r| match r.values.get("id") {
+            Some(Value::Uuid(b)) => Some(*b),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Scenario (fd high-water): 64 concurrent BTI point lookups + 8 concurrent scans
+/// keep `FILE_OPENS` bounded. On `main` each BTI lookup minted a fresh scan-cursor
+/// fd (`new_scan_cursor` → `open(2)`), so 64 concurrent lookups recorded ~64
+/// opens; the migrated positional path opens the fd once at reader-open and issues
+/// positioned reads thereafter, so the lookups record none — only the (unchanged)
+/// per-scan cursor opens remain.
+#[tokio::test]
+#[serial]
+async fn bti_lookups_do_not_open_per_lookup() {
+    if !fixture_data_present("test_da", "simple_table") {
+        eprintln!("SKIP (#1573 fd): optional BTI test_da/simple_table not present");
+        return;
+    }
+    let Some(db) = setup("test_da", "da-test.cql").await else {
+        eprintln!("SKIP (#1573 fd): could not ingest test_da");
+        return;
+    };
+    let table = "test_da.simple_table";
+    let ids = learn_ids(&db, table).await;
+    assert!(
+        !ids.is_empty(),
+        "present BTI fixture must yield >= 1 id (0 = read regression, not a skip)"
+    );
+    let db = std::sync::Arc::new(db);
+
+    // Reader is now open (from the learning scan); reset so we measure only the
+    // opens the 64 lookups + 8 scans trigger.
+    rwc::reset();
+    assert_eq!(rwc::file_opens(), 0, "reset must zero FILE_OPENS");
+    let fd_before = rwc::fd_high_water();
+
+    let point_sql = format!(
+        "SELECT id, name FROM {table} WHERE id = {}",
+        uuid_to_literal(&ids[0])
+    );
+    let mut handles = Vec::new();
+    for _ in 0..64u32 {
+        let (d, sql) = (db.clone(), point_sql.clone());
+        handles.push(tokio::spawn(async move { d.execute(&sql).await }));
+    }
+    for _ in 0..8u32 {
+        let d = db.clone();
+        let sql = format!("SELECT id FROM {table}");
+        handles.push(tokio::spawn(async move { d.execute(&sql).await }));
+    }
+    for h in handles {
+        let _ = h.await.expect("task").expect("query");
+    }
+
+    // The 64 point lookups must contribute ZERO opens; only the 8 scans mint
+    // cursors (unchanged). A generous cap distinguishes the fixed path (~8) from
+    // main's per-lookup opens (~64 + 8). If a lookup ever opened, this trips.
+    let opens = rwc::file_opens();
+    assert!(
+        opens <= 16,
+        "64 BTI lookups + 8 scans recorded {opens} opens; the migrated point path \
+         must not open(2) per lookup (main records ~72 here). Expected <= 16 \
+         (the per-scan cursor opens only)."
+    );
+
+    // Secondary sanity via the fd sampler where supported: the process fd count
+    // after the ops drains back near the open-time baseline (scan cursors closed).
+    if let (Some(before), Some(after)) = (fd_before, rwc::fd_high_water()) {
+        assert!(
+            after <= before + 24,
+            "fd count grew unexpectedly: before={before}, after={after}"
+        );
+    }
+}
+
+/// Scenario (value parity): every row returned by the migrated point-read path
+/// byte-matches the scan path (the correctness oracle) for the corpus table.
+/// `value_col` is a non-key column projected alongside `id`.
+async fn assert_point_equals_scan(
+    keyspace: &str,
+    schema: &str,
+    table_short: &str,
+    table: &str,
+    value_col: &str,
+) {
+    if !fixture_data_present(keyspace, table_short) {
+        eprintln!("SKIP (#1573 parity): {keyspace}/{table_short} Data.db absent");
+        return;
+    }
+    let Some(db) = setup(keyspace, schema).await else {
+        eprintln!("SKIP (#1573 parity): could not ingest {keyspace}");
+        return;
+    };
+    let ids = learn_ids(&db, table).await;
+    assert!(
+        !ids.is_empty(),
+        "present fixture must yield >= 1 id (0 = read regression, not a skip)"
+    );
+
+    // Oracle: the full scan's row for each id.
+    let scan = db
+        .execute(&format!("SELECT id, {value_col} FROM {table}"))
+        .await
+        .expect("scan");
+    for id in &ids {
+        let point = db
+            .execute(&format!(
+                "SELECT id, {value_col} FROM {table} WHERE id = {}",
+                uuid_to_literal(id)
+            ))
+            .await
+            .expect("point read");
+        assert_eq!(
+            point.rows.len(),
+            1,
+            "point read of a present key must return exactly one row"
+        );
+        let scanned = scan
+            .rows
+            .iter()
+            .find(|r| matches!(r.values.get("id"), Some(Value::Uuid(b)) if b == id))
+            .expect("scanned row for id");
+        assert_eq!(
+            point.rows[0].values.get("id"),
+            scanned.values.get("id"),
+            "point-read id must byte-match the scan path"
+        );
+        assert_eq!(
+            point.rows[0].values.get(value_col),
+            scanned.values.get(value_col),
+            "point-read value must byte-match the scan path"
+        );
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn big_point_read_matches_scan() {
+    assert_point_equals_scan(
+        "test_basic",
+        "basic-types.cql",
+        "simple_table",
+        "test_basic.simple_table",
+        "name",
+    )
+    .await;
+}
+
+/// Exercises the whole-section point-read fallback (`point_read_whole_section`)
+/// AND its CRC.db verification: `uncompressed_table` has no CompressionInfo, so
+/// the point path reads the whole data section positionally and CRC-checks it.
+#[tokio::test]
+#[serial]
+async fn big_uncompressed_point_read_matches_scan() {
+    assert_point_equals_scan(
+        "test_basic",
+        "basic-types.cql",
+        "uncompressed_table",
+        "test_basic.uncompressed_table",
+        "data",
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn bti_point_read_matches_scan() {
+    assert_point_equals_scan(
+        "test_da",
+        "da-test.cql",
+        "simple_table",
+        "test_da.simple_table",
+        "name",
+    )
+    .await;
+}
+
+/// Scenario (scans unchanged): a full scan is non-empty and deterministic after
+/// the point-read migration — two consecutive scans return identical rows in
+/// identical order (the windowed pipeline is untouched by this change).
+#[tokio::test]
+#[serial]
+async fn scan_output_is_unchanged_and_deterministic() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("SKIP (#1573 scan): test_basic/simple_table Data.db absent");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("SKIP (#1573 scan): could not ingest test_basic");
+        return;
+    };
+    let sql = "SELECT id, name FROM test_basic.simple_table";
+    let first = db.execute(sql).await.expect("first scan");
+    assert!(
+        !first.rows.is_empty(),
+        "present fixture must return rows (0 rows = read regression, not a skip)"
+    );
+    let second = db.execute(sql).await.expect("second scan");
+    assert_eq!(
+        first.rows.len(),
+        second.rows.len(),
+        "scan row count must be stable across runs"
+    );
+    for (a, b) in first.rows.iter().zip(second.rows.iter()) {
+        assert_eq!(
+            a.values.get("id"),
+            b.values.get("id"),
+            "scan order/content must be deterministic (id)"
+        );
+        assert_eq!(
+            a.values.get("name"),
+            b.values.get("name"),
+            "scan order/content must be deterministic (name)"
+        );
+    }
+}

--- a/openspec/changes/readat-positional/design.md
+++ b/openspec/changes/readat-positional/design.md
@@ -1,0 +1,72 @@
+# Design — readat-positional
+
+## Context
+
+Source of truth: `docs/reports/read-path-performance-audit-2026-07-01.md` §Epic C; issue #1573
+(child C2 of Epic C #1515). Anchors as of `main` @ `5c080d2a`.
+
+**Owner Decision #3 (2026-07-01):** the `ReadAt` sync-core refactor is endorsed as the target
+read architecture. This design records that endorsed target; it does not re-litigate the call
+or weigh alternatives — the architecture is locked.
+
+Guardrails carried from the issue: do NOT rewrite the windowed streaming scan; CRC-then-decompress
+ordering and error classification unchanged; do NOT flip `use_mmap` here.
+
+## Decision 1 — the `ReadAt` trait (endorsed target; replaces the cursor-mutex)
+
+Introduce a positional-read trait in the reader I/O layer:
+
+```
+trait ReadAt {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize>;
+    fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<()>;
+}
+```
+
+Invariants (the whole point of the refactor):
+- **No mutable position** — the trait carries no seek cursor.
+- **No `&mut self`** — every method takes `&self`, so concurrent callers share one value with
+  no exclusive borrow and no mutex.
+- **No seek** — the offset is a parameter of the read, not shared file state.
+
+This **replaces** the `Arc<Mutex<BlockSource>>` cursor on the point-read path. Today the mutex
+exists solely to serialize access to a mutable seek position and is held **across disk I/O**
+(`types.rs:217`, `data_access/mod.rs:428-445`), which is exactly the convoy. A positioned read
+on a shared fd is independent of every other positioned read, so the lock is not merely moved —
+it is removed from this path entirely.
+
+## Decision 2 — per-backend implementations
+
+| Backend | `read_at` implementation | Notes |
+|---------|--------------------------|-------|
+| buffered / plain | `std::os::unix::fs::FileExt::read_at` on ONE shared `File` | A shared fd's positioned reads are independent — no lock needed. Replaces per-op `File::open`. |
+| mmap | slice indexing into the resident map | Bounds-checked slice read; zero syscalls per read. |
+| O_DIRECT | positioned read honoring the existing 4K alignment logic | Reuse the alignment/bounce-buffer math already present in the direct backend; only the seek+read becomes a positioned read. |
+| Windows | `std::os::windows::fs::FileExt::seek_read`, cfg-gated | Matches the platform cfg-gating pattern already used by the existing backends. |
+
+## Decision 3 — migrate the point-read path onto `ReadAt`
+
+- **BIG chunk fetch:** resolve the query key's partition offset → the chunk via
+  `CompressionInfo::chunk_for_offset` → `read_at` that chunk's byte range → CRC check →
+  decompress. Remove the `Mutex<BlockSource>` from this path. CRC-then-decompress ordering is
+  preserved verbatim.
+- **BTI lookups:** open the fd **once at reader open** and store the `ReadAt` backend on the
+  reader; every subsequent lookup issues positioned reads instead of `File::open`
+  (`source.rs:108-130`). This eliminates the per-lookup open/close and the fd-exhaustion class.
+- Offset resolution logic (bloom/trie prune, `chunk_for_offset` at `bti.rs:600-640`) is
+  unchanged — only the byte-fetch mechanism moves from cursor+seek / per-op-open to `read_at`.
+
+## Decision 4 — scans left on the existing pipeline (scoped, per guardrail)
+
+The windowed streaming scan is not migrated. The trait is intentionally shaped so a scan can
+later hold a `ReadAt` and issue positioned window reads (F3), but that migration is out of scope
+here. Scans remain functionally unchanged; their parity/behavior is asserted, not modified.
+
+## Risks
+
+- **fd lifetime:** the once-opened BTI fd must live for the reader's lifetime; store it on the
+  reader (owned `File` behind the `ReadAt` impl) so it closes on reader drop — no leak, no churn.
+- **O_DIRECT alignment:** the positioned-read path must keep the existing 4K alignment handling;
+  covered by reusing the current alignment logic and by the positional-read correctness scenario.
+- **Windows drift:** cfg-gated `seek_read` is compiled but exercised only where the workspace
+  builds on Windows; the correctness scenarios run on the Unix backends in CI.

--- a/openspec/changes/readat-positional/proposal.md
+++ b/openspec/changes/readat-positional/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Milestone: Epic C #1515 read-path performance audit (2026-07), Wave 3, child **C2**.
+Source of truth: `docs/reports/read-path-performance-audit-2026-07-01.md` §Epic C.
+
+Routing: **design-driven** (perf/architecture). The load-bearing architectural call — a
+`ReadAt` sync-core refactor — is **owner-endorsed** (Owner Decision #3, 2026-07-01: "the
+`ReadAt` sync-core refactor is endorsed as the target read architecture — build it; do not
+re-litigate"). This OpenSpec change transcribes that already-decided design; it does not
+propose or weigh alternatives.
+
+The point-read path has two pathologies with one root cause — a **stateful file cursor**:
+
+1. **Shared-cursor convoy.** BIG point reads serialize on an `Arc<Mutex<BlockSource>>` that
+   is held **across disk I/O** (`types.rs:217`, `data_access/mod.rs:428-445`). N concurrent
+   point reads on one SSTable execute one-at-a-time — a pre-#815 convoy that survived on the
+   point path. The lock protects a mutable seek position, so it cannot be dropped before the
+   read completes.
+2. **Per-lookup `open(2)` fd churn.** BTI lookups sidestep the mutex by paying `File::open`
+   **per lookup** (`source.rs:108-130`, default `use_mmap: false`) — an open/close syscall
+   pair per operation and fd-exhaustion risk under concurrent load.
+
+## What Changes
+
+The endorsed solution is a **`ReadAt` positional-read trait** — `read_at(&self, offset, buf)`
+(and `read_exact_at`) with **no mutable position, no `&mut self`, no seek** — so a single
+shared file descriptor's positioned reads are independent and require no lock.
+
+- **Introduce `ReadAt`** in the reader I/O layer.
+- **Implement it per backend**: buffered/plain via `std::os::unix::fs::FileExt::read_at` on
+  ONE shared `File`; mmap via slice indexing into the map; O_DIRECT via a positioned read that
+  honors the existing 4K alignment logic; Windows via `std::os::windows::fs::FileExt::seek_read`,
+  cfg-gated consistently with the existing backend code.
+- **Migrate the point-read path** — BIG chunk fetch + BTI lookups — off the `Mutex<BlockSource>`
+  cursor and off per-op `File::open` onto `ReadAt`: resolve offset → `read_at` the chunk → CRC
+  check → decompress. The BTI fd is opened **once at reader open**, then only positioned reads.
+- **Preserve** CRC-then-decompress ordering and all error classification, unchanged.
+
+## Non-goals
+
+- **Scans stay on the cursor/windowed pipeline for now — do NOT churn it.** The windowed
+  streaming scan (`scan_stream_windowed.rs`) is A-grade, protected "already good" machinery.
+  F3 routes scan blocking-I/O work properly later; the trait is designed so scans can adopt
+  `ReadAt` later, but this change does not migrate them.
+- **Do NOT flip `use_mmap`.** The default disk-access mode (Decision #2) and F3's blocking-fault
+  gate are separate; this change keeps the current default and only removes the per-op-open and
+  cursor-mutex mechanisms.
+- **No change to CRC-then-decompress ordering or error classification.**
+- **Windows support is cfg-gated consistently** with the existing backend code — not a new
+  first-class platform target introduced here.
+- **No cache work** (that is Epic B / B1) and **no BIG index digest fix** (that is C1) — this
+  change is scoped to the positional-read/fd/convoy mechanisms only.

--- a/openspec/changes/readat-positional/specs/point-read-io/spec.md
+++ b/openspec/changes/readat-positional/specs/point-read-io/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Concurrent point reads do not serialize on a cross-I/O mutex
+The point-read path SHALL NOT hold a mutex across disk I/O. Concurrent point reads on a single
+SSTable SHALL execute without serializing on a shared file-cursor lock — the `Arc<Mutex<BlockSource>>`
+convoy on the point path is removed. Reads SHALL be served via positioned reads (`ReadAt`) on a shared
+file descriptor, whose positioned reads are independent of one another.
+
+#### Scenario: 8 concurrent gets do not convoy
+- **GIVEN** an SSTable whose read backend is a test double whose `read_at` sleeps 10ms per call
+- **WHEN** 8 concurrent point reads (`get()`) are issued against that one SSTable
+- **THEN** total wall time is far less than 8×10ms (e.g. under 40ms), proving the reads do not serialize
+- **AND** on current `main` the same test fails (~80ms) because the shared-cursor mutex serializes them
+
+### Requirement: BTI lookups do not open the file per lookup
+BTI point lookups SHALL open the underlying file descriptor exactly once (at reader open) and issue
+positioned reads thereafter. A point lookup SHALL NOT call `File::open` per operation.
+
+#### Scenario: fd high-water stays bounded under load
+- **GIVEN** an open BTI reader and the open-time file-descriptor count recorded
+- **WHEN** 64 point lookups and 8 scans are issued
+- **THEN** the process fd high-water mark is at most open-time fds plus a small constant
+- **AND** on current `main` the same test fails on BTI because each lookup opens the file
+
+### Requirement: Positioned reads return correct bytes with no shared mutable cursor
+The `ReadAt` trait SHALL expose `read_at(&self, offset, buf) -> Result<usize>` and `read_exact_at`
+with no mutable position, no `&mut self`, and no seek. Each backend (buffered/plain via
+`FileExt::read_at` on one shared file, mmap via slice indexing, O_DIRECT honoring 4K alignment, and
+the cfg-gated Windows `seek_read`) SHALL return the exact bytes at the requested offset independent of
+any other in-flight read.
+
+#### Scenario: interleaved positioned reads each return their own bytes
+- **GIVEN** a `ReadAt` backend over a file with known content
+- **WHEN** two positioned reads at different offsets are issued concurrently (interleaved)
+- **THEN** each read returns exactly the bytes at its requested offset, with no cross-contamination from the other read's position
+- **AND** the trait methods take `&self` (no `&mut self`, no seek), so no shared mutable cursor exists
+
+### Requirement: CRC is verified before decompression on the chunk path
+The BIG chunk-fetch path migrated onto `ReadAt` SHALL preserve CRC-then-decompress ordering: the chunk's
+CRC is verified before the payload is decompressed, and error classification is unchanged.
+
+#### Scenario: a corrupt chunk fails CRC before any decompress attempt
+- **GIVEN** a chunk whose stored CRC does not match its payload, fetched via `read_at`
+- **WHEN** the point-read path fetches that chunk
+- **THEN** the CRC check fails and the same corruption error is raised before decompression is attempted
+- **AND** the decompressor is never invoked for that chunk
+
+### Requirement: Rows returned via the ReadAt point-read path byte-match the prior path
+Point reads served through the `ReadAt` path SHALL be value-identical to the pre-refactor point-read
+path over the 33-table corpus (correctness oracle).
+
+#### Scenario: 33-table point-read parity
+- **GIVEN** the 33-table test corpus with real SSTable binaries present
+- **WHEN** point reads are executed over each table via the `ReadAt` point-read path
+- **THEN** every returned row byte-matches the result the pre-refactor path produced (and the sstabledump JSONL goldens)
+- **AND** when the binaries are absent the parity test skips clean rather than passing on 0 rows
+
+### Requirement: Scans remain functionally unchanged
+This change SHALL NOT migrate or rewrite the windowed streaming scan. Scan output and behavior SHALL be
+unchanged; the trait is shaped so scans can adopt `ReadAt` later (F3) without requiring it now.
+
+#### Scenario: scan output is unchanged after the point-read migration
+- **GIVEN** the windowed streaming scan pipeline (`scan_stream_windowed.rs`) untouched by this change
+- **WHEN** a full scan is executed over a corpus table
+- **THEN** the scan returns the same rows in the same order as before the point-read migration
+- **AND** the scan continues to use the existing cursor/windowed pipeline (no `scan_stream_windowed.rs` rewrite)

--- a/openspec/changes/readat-positional/tasks.md
+++ b/openspec/changes/readat-positional/tasks.md
@@ -1,0 +1,49 @@
+# Tasks — readat-positional
+
+## 1. TDD tests first (write FIRST, must fail on current `main`)
+- [ ] 1.1 **Convoy test** (surface: `SSTableReader::get` / point-read path): wrap the source in a
+      test double whose `read_at` sleeps 10ms; issue 8 concurrent `get()`s on one SSTable and assert
+      total wall time ≪ 8×10ms (e.g. < 40ms). Must fail (~80ms) on current `main`.
+- [ ] 1.2 **fd high-water test** (surface: BTI point-lookup path): record open-time fd count, issue
+      64 point lookups + 8 scans, assert fd high-water ≤ open-time fds + small constant. Uses A5's fd
+      helper. Must fail on current `main` (BTI per-lookup opens).
+- [ ] 1.3 **Positional-read correctness test** (surface: `ReadAt` impls): interleaved `read_at` at
+      distinct offsets each return exactly the bytes at their offset; assert the trait methods take
+      `&self` (no shared mutable cursor). Cover buffered, mmap, and O_DIRECT backends.
+- [ ] 1.4 **CRC-before-decompress test** (surface: BIG chunk-fetch path): a chunk with a bad CRC
+      fetched via `read_at` raises the same corruption error before decompress; decompressor not invoked.
+- [ ] 1.5 **33-table value parity test** (surface: `Database::execute` `WHERE pk = ?` point path):
+      point reads via the `ReadAt` path byte-match the pre-refactor results and sstabledump JSONL
+      goldens; skip-not-fail when binaries absent.
+
+## 2. `ReadAt` trait + backends (production)
+- [ ] 2.1 Define the `ReadAt` trait in the reader I/O layer: `read_at(&self, offset, buf) -> Result<usize>`
+      and `read_exact_at` — no mutable position, no `&mut self`, no seek.
+- [ ] 2.2 Implement `ReadAt` for the buffered/plain backend via `std::os::unix::fs::FileExt::read_at`
+      on ONE shared `File`.
+- [ ] 2.3 Implement `ReadAt` for the mmap backend via bounds-checked slice indexing.
+- [ ] 2.4 Implement `ReadAt` for the O_DIRECT backend via a positioned read honoring the existing 4K
+      alignment logic.
+- [ ] 2.5 cfg-gate a Windows `ReadAt` impl via `std::os::windows::fs::FileExt::seek_read`, consistent
+      with the existing backend cfg-gating.
+
+## 3. Migrate the point-read path (production)
+- [ ] 3.1 BIG chunk fetch (`data_access/mod.rs:428-445`): resolve offset → `read_at` chunk → CRC →
+      decompress; remove the `Mutex<BlockSource>` from this path. Preserve CRC-then-decompress ordering
+      and error classification.
+- [ ] 3.2 BTI lookups (`source.rs:108-130`): open the fd ONCE at reader open and store the `ReadAt`
+      backend on the reader; replace per-lookup `File::open` with positioned reads.
+- [ ] 3.3 Confirm no `unwrap()`/`expect()` introduced in library code; error paths reuse existing
+      classification.
+
+## 4. Guardrails (do-not-touch verification)
+- [ ] 4.1 Assert `scan_stream_windowed.rs` is unmodified by this change (scans stay on the existing
+      cursor/windowed pipeline; F3 handles scan blocking later).
+- [ ] 4.2 Assert `use_mmap` default is unchanged (this change does not flip it).
+
+## 5. Validation
+- [ ] 5.1 Run tasks 1.1–1.5 red-then-green (with `CQLITE_DATASETS_ROOT` set for parity).
+- [ ] 5.2 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim.
+- [ ] 5.3 `RUSTFLAGS="-D warnings"` clean; workspace clippy `--all-targets`.
+- [ ] 5.4 spec-auditor (**C**) PASS against `openspec/changes/readat-positional/specs/**`.
+- [ ] 5.5 roborev clean (`--base origin/main`).


### PR DESCRIPTION
Closes #1573 (C2 — Epic C #1515 read-path audit, Wave 3; owner-endorsed architecture, Decision #3). OpenSpec change: `readat-positional`.

## Problem
Two point-read pathologies, one root cause (a stateful file cursor): (1) **convoy** — BIG point reads serialized on a shared `Arc<Mutex<BlockSource>>` held across disk I/O; (2) **fd churn** — BTI lookups paid `File::open` per lookup.

## Change
- New `pub(crate) trait ReadAt { read_at/read_exact_at; len }` (positional, `&self`, no seek, no mutable cursor), with backends: `PlainFileReadAt` (Unix `pread` on one shared fd; Windows `seek_read` under a `#[cfg(windows)]` Mutex for correctness — Unix stays lock-free), `MmapReadAt` (slice), `DirectReadAt` (O_DIRECT, 4K-aligned bounce buffer, `&self`).
- The point-read path (BIG chunk fetch + BTI lookups) migrated off the cursor-mutex + per-lookup open onto a `point_source: Arc<dyn ReadAt>` built ONCE at reader open. Mutex removed from the point path (not relocated); BTI fd opened once.
- CRC-before-decompress preserved (#1411); whole-section fallback reads the section **once** and CRC-verifies from the resident buffer (`verify_uncompressed_section_in_buffer`).
- **Non-goals honored:** scans stay on the cursor/windowed pipeline (untouched); `use_mmap` default unchanged; no cache/index-digest work.

## Tests (TDD, red-on-main → green)
- Convoy killed: `eight_concurrent_point_reads_do_not_convoy` (machine-relative, routing-guard).
- fd bounded: `bti_lookups_do_not_open_per_lookup` (64 lookups + 8 scans → opens ≤16 vs ~72 on main).
- Positioned-read correctness incl. O_DIRECT alignment/EOF: `interleaved_concurrent_reads_do_not_cross_contaminate`, `concurrent_point_reads_return_correct_bytes`, `direct_read_at_matches_plain_oracle_at_boundaries`.
- CRC-before-decompress: `read_compressed_chunk_at_verifies_crc_before_returning`.
- Value parity vs scan oracle: `big_point_read_matches_scan`, `big_uncompressed_point_read_matches_scan`, `bti_point_read_matches_scan` (skip-clean absent; 0 rows = hard fail).
- Scans unchanged: `scan_output_is_unchanged_and_deterministic`.

## Quality bar
- Full `agent-gate.sh` (gate of record, commit 3662d047): **all change-attributable components PASS** (fmt, clippy, integration, write, cli, compaction-parity, node, memory-budget, smoke, minimal-build…). Overall `RESULT: FAIL` is caused **solely** by two known/unrelated failures, each the only failure in its component: `core-tests` → `issue_953 multichunk_row_seek_returns_full_partition` (**#1856**, local-only `test_da/wide_table` Data.db absent) and `python-bindings` → `test_streaming_next_releases_gil` (load-sensitive GIL flake).
- **C-audit (spec-auditor): PASS** — all 6 `readat-positional` requirements satisfied with public/observable-surface test evidence; scans confirmed untouched.
- **roborev: clean** — "no correctness, security, or regression issues found" (4 convergence rounds: partial/boundary-index consistency on the point path, O_DIRECT test coverage, bounded bounce buffer + in-buffer CRC, stale doc links, Windows shared-cursor race — all closed).

Pre-existing CI reds expected on this PR (not from this change; the CI team owns them): compression-build lanes (**#1866**, scan_merge dead-code) and `sstabledump-parity` writetime lane (**#1242** dataset guard, red on all PRs incl. #1865). Follow-ups filed: **#1869** (BIG clustering-slice per-query fd), **#1879** (Windows CI lane + arm test).