### PR TITLE
test(#1449): pin per-row conversion budgets (alloc / FFI-call ratchets)

### DIFF
--- a/bindings/node/__test__/conversion-budget.test.js
+++ b/bindings/node/__test__/conversion-budget.test.js
@@ -32,22 +32,45 @@ const SCHEMA = global.testPaths.SCHEMA_WIDE_ROWS;
 const QUERY = 'SELECT * FROM test_wide_rows.many_columns_table LIMIT 200';
 const MEASURE_PASSES = 7;
 
+// MEASUREMENT WINDOW (issue #1449 roborev fix): each pass now wraps
+// `executeNative(QUERY)` ITSELF inside the gc'd heap-delta window (gc x2, sample
+// heapUsed, executeNative + touch all rows, sample heapUsed again). The earlier
+// window sampled only `rows.map(r => ({...r}))` — a shallow spread of rows that
+// executeNative had ALREADY materialized — so the per-row conversion allocation
+// (the JS value graph built in `resolve()`/`row_to_object`) landed OUTSIDE the
+// ratchet. With executeNative inside, the delta captures the actual per-row
+// converted-value footprint.
+//
 // MEASURED BASELINE (2026-07-04, macOS arm64, release-unwind .node):
 //   executeNative(QUERY) -> 50 rows, ~8 non-null columns each.
-//   Per pass: double gc, read heapUsed, materialize `rows.map(r => ({...r}))`,
-//   read heapUsed again; per_row = delta / rowCount.
-//   Median-of-7 (as this test computes it) settled at 151.2 bytes/row once V8
-//   warmed; a cold first pass measured ~214.6. Single-sample spread over 12
-//   runs was min=151.2 / max=221.0.
-// Budget = 350 bytes/row: comfortably above the warm 151 and the cold ~215
-// medians (~1.6x-2.3x headroom, so it does not flake on V8 GC / hidden-class
-// churn — heapUsed deltas are noisier than Python's tracemalloc, which is why we
-// assert the MEDIAN pass, not a worst-case single sample), yet well below a
-// regression that inflates per-row storage: a synthetic ~2x-properties regression
-// measured 1222 bytes/row (see the "Prove the budget bites" note in the issue
-// #1449 delivery summary), an order of magnitude over the budget. Pinned to a
-// measured number per the issue mandate, never a guess.
-const BUDGET_BYTES_PER_ROW = 350;
+//   Median-of-7 (as this test computes it) stabilized at 1295.2 bytes/row once
+//   V8 warmed (a cold experiment measured 1357.6). Single-sample spread over 12
+//   warm samples was min=1295.2 / max=1534.9.
+// Budget = 1800 bytes/row: ~1.33x-1.39x over the warm/cold medians (headroom for
+// V8 GC / hidden-class churn — heapUsed deltas are noisier than Python's
+// tracemalloc, which is why we assert the MEDIAN pass, not a worst-case single
+// sample), yet below a regression that inflates the per-row value graph: a
+// synthetic value-graph-doubling regression (converting + retaining each cell's
+// value twice) measured a median of 2086.1 bytes/row (min 2047.5) — comfortably
+// over this budget. Pinned to a measured number per the issue mandate.
+//
+// WHAT THIS BUDGET DOES AND DOES NOT PIN (issue #1449, measured — honest scope):
+// The V8 `heapUsed` delta pins the GROSS per-row JS value-graph footprint, so it
+// catches an O(rows x columns) duplication/boxing of converted cell values
+// (proven above: the doubling regression trips it). It CANNOT observe two of the
+// W1-W4 wins from the binding layer, both confirmed by measurement here:
+//   * #1447 (clone -> move of row values in executeNative's `compute()`): the
+//     clone is a RUST-heap allocation, dropped before the post-execute V8 sample,
+//     and never touches the V8 heap — reverting it moved the median 1335.0 ->
+//     1333.8 (noise).
+//   * #1445/#1446 (column-key interning): V8 internally dedups property-name
+//     strings, so emitting a fresh key string per cell instead of the interned
+//     handle moved the median 1335.0 -> 1333.8 (noise) at this table's scale.
+// Those two wins are pinned elsewhere: #1448 by the Rust `#[cfg(test)]`
+// `set_map_ctor_lookups_bounded_per_result` counter (bindings/node/src/value.rs);
+// #1445/#1446/#1447 would need Rust-side allocation counters to ratchet directly
+// (none exists yet) — this heap test does not overclaim them.
+const BUDGET_BYTES_PER_ROW = 1800;
 
 function median(nums) {
   const sorted = [...nums].sort((a, b) => a - b);
@@ -85,17 +108,23 @@ describe('conversion per-row heap budget (issue #1449)', () => {
     let rowCount = 0;
 
     for (let pass = 0; pass < MEASURE_PASSES; pass += 1) {
+      // Measure the CONVERSION PATH: executeNative() is INSIDE the window
+      // (issue #1449 roborev fix) so the per-row value-graph allocation it
+      // builds is captured, not just a shallow spread of already-materialized
+      // rows.
+      global.gc();
+      global.gc();
+      const before = process.memoryUsage().heapUsed;
       const result = await db.executeNative(QUERY);
+      // Touch every row so V8 cannot elide the materialized graph before the
+      // post-execute sample.
+      const materialized = result.rows.map((r) => ({ ...r }));
+      const after = process.memoryUsage().heapUsed;
+
       rowCount = result.rowCount;
       // FAIL LOUDLY (never skip) on a present-but-empty/unreadable dataset — a
       // zero-row result would divide-by-zero and false-green the ratchet.
       expect(rowCount).toBeGreaterThan(0);
-
-      global.gc();
-      global.gc();
-      const before = process.memoryUsage().heapUsed;
-      const materialized = result.rows.map((r) => ({ ...r }));
-      const after = process.memoryUsage().heapUsed;
       // Keep the materialized data alive across the sample so nothing is freed
       // before `after` is read.
       expect(materialized.length).toBe(rowCount);

--- a/bindings/node/__test__/conversion-budget.test.js
+++ b/bindings/node/__test__/conversion-budget.test.js
@@ -46,13 +46,16 @@ const MEASURE_PASSES = 7;
 //   Median-of-7 (as this test computes it) stabilized at 1295.2 bytes/row once
 //   V8 warmed (a cold experiment measured 1357.6). Single-sample spread over 12
 //   warm samples was min=1295.2 / max=1534.9.
-// Budget = 1800 bytes/row: ~1.33x-1.39x over the warm/cold medians (headroom for
-// V8 GC / hidden-class churn — heapUsed deltas are noisier than Python's
-// tracemalloc, which is why we assert the MEDIAN pass, not a worst-case single
-// sample), yet below a regression that inflates the per-row value graph: a
-// synthetic value-graph-doubling regression (converting + retaining each cell's
-// value twice) measured a median of 2086.1 bytes/row (min 2047.5) — comfortably
-// over this budget. Pinned to a measured number per the issue mandate.
+// Budget = 2000 bytes/row: baseline measured on macOS arm64 release-unwind
+// (~1295 warm median, up to ~1535 single-sample). `process.memoryUsage().heapUsed`
+// deltas are platform/build-profile/GC-timing dependent, so 2000 leaves headroom
+// for Linux x64 / debug-build / GC-timing drift (heapUsed deltas are noisier than
+// Python's tracemalloc, which is why we assert the MEDIAN pass, not a worst-case
+// single sample) while staying under the ~2086 doubling-regression signal
+// (documented as the biting threshold): a synthetic value-graph-doubling
+// regression (converting + retaining each cell's value twice) measured a median
+// of 2086.1 bytes/row (min 2047.5), so the ratchet still bites a genuine
+// O(rows x columns) regression. Pinned to a measured number per the issue mandate.
 //
 // WHAT THIS BUDGET DOES AND DOES NOT PIN (issue #1449, measured — honest scope):
 // The V8 `heapUsed` delta pins the GROSS per-row JS value-graph footprint, so it
@@ -70,7 +73,7 @@ const MEASURE_PASSES = 7;
 // `set_map_ctor_lookups_bounded_per_result` counter (bindings/node/src/value.rs);
 // #1445/#1446/#1447 would need Rust-side allocation counters to ratchet directly
 // (none exists yet) — this heap test does not overclaim them.
-const BUDGET_BYTES_PER_ROW = 1800;
+const BUDGET_BYTES_PER_ROW = 2000;
 
 function median(nums) {
   const sorted = [...nums].sort((a, b) => a - b);

--- a/bindings/node/__test__/conversion-budget.test.js
+++ b/bindings/node/__test__/conversion-budget.test.js
@@ -1,0 +1,109 @@
+/**
+ * Per-row heap BUDGET ratchet for the Node binding conversion path (issue #1449,
+ * parent #1433).
+ *
+ * The per-row conversion wins landed in this epic — #1445 (interned/ordered
+ * keys), #1446 (ordered Node rows + one-time column-name interning), #1447
+ * (clone -> move of row values in executeNative), #1448 (Set/Map constructor
+ * caching). Nothing pinned them, so a refactor could silently re-introduce
+ * O(rows x columns) per-row allocation with no test noticing. This file makes
+ * the per-row JS-heap footprint a ratchet.
+ *
+ * SCOPE OF THIS TEST (the FFI-call budget lives elsewhere): the #1448
+ * constructor-lookup counter is Rust-`#[cfg(test)]` only and is NOT exposed to
+ * JS, so its "<= 1 lookup per Set/Map cache per result" budget is asserted in a
+ * Rust unit test (bindings/node/src/value.rs ::set_map_ctor_lookups_bounded_per_result).
+ * This JS test owns the complementary per-row heap-delta budget: it materializes
+ * a wide result and bounds the JS heap growth per row.
+ *
+ * MEASUREMENT: requires `--expose-gc` (package.json runs jest via
+ * `node --expose-gc ...`). We FAIL LOUDLY (never skip) if `global.gc` is absent
+ * or datasets are missing/empty — a silent skip would let a regression pass.
+ * `process.memoryUsage().heapUsed` is coarse and jittery, so we take the MEDIAN
+ * of several measured passes (each after a double gc) rather than a single noisy
+ * sample, and set the budget with generous headroom over the observed spread.
+ */
+const { Database } = require('../lib/index.js');
+
+const DIR = global.testPaths.SSTABLES_DIR;
+const SCHEMA = global.testPaths.SCHEMA_WIDE_ROWS;
+// Widest fixture schema (~101 declared columns), consistent with the Python
+// per-row alloc budget test. Non-null cells only are materialized per row.
+const QUERY = 'SELECT * FROM test_wide_rows.many_columns_table LIMIT 200';
+const MEASURE_PASSES = 7;
+
+// MEASURED BASELINE (2026-07-04, macOS arm64, release-unwind .node):
+//   executeNative(QUERY) -> 50 rows, ~8 non-null columns each.
+//   Per pass: double gc, read heapUsed, materialize `rows.map(r => ({...r}))`,
+//   read heapUsed again; per_row = delta / rowCount.
+//   Median-of-7 (as this test computes it) settled at 151.2 bytes/row once V8
+//   warmed; a cold first pass measured ~214.6. Single-sample spread over 12
+//   runs was min=151.2 / max=221.0.
+// Budget = 350 bytes/row: comfortably above the warm 151 and the cold ~215
+// medians (~1.6x-2.3x headroom, so it does not flake on V8 GC / hidden-class
+// churn — heapUsed deltas are noisier than Python's tracemalloc, which is why we
+// assert the MEDIAN pass, not a worst-case single sample), yet well below a
+// regression that inflates per-row storage: a synthetic ~2x-properties regression
+// measured 1222 bytes/row (see the "Prove the budget bites" note in the issue
+// #1449 delivery summary), an order of magnitude over the budget. Pinned to a
+// measured number per the issue mandate, never a guess.
+const BUDGET_BYTES_PER_ROW = 350;
+
+function median(nums) {
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+describe('conversion per-row heap budget (issue #1449)', () => {
+  let db;
+
+  beforeAll(async () => {
+    if (!global.DATASETS_AVAILABLE) {
+      throw new Error(
+        'Test data not available. Set CQLITE_DATASETS_ROOT or run fetch-datasets.sh'
+      );
+    }
+    // Budget measurement is meaningless without gc control; FAIL, do not skip.
+    if (typeof global.gc !== 'function') {
+      throw new Error(
+        'global.gc is unavailable — run jest via `node --expose-gc ' +
+          './node_modules/jest/bin/jest.js` (see package.json "test" script)'
+      );
+    }
+    db = await Database.open(DIR, { schema: SCHEMA });
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.close();
+    }
+  });
+
+  test('per-row JS heap stays under the measured budget', async () => {
+    const perRowSamples = [];
+    let rowCount = 0;
+
+    for (let pass = 0; pass < MEASURE_PASSES; pass += 1) {
+      const result = await db.executeNative(QUERY);
+      rowCount = result.rowCount;
+      // FAIL LOUDLY (never skip) on a present-but-empty/unreadable dataset — a
+      // zero-row result would divide-by-zero and false-green the ratchet.
+      expect(rowCount).toBeGreaterThan(0);
+
+      global.gc();
+      global.gc();
+      const before = process.memoryUsage().heapUsed;
+      const materialized = result.rows.map((r) => ({ ...r }));
+      const after = process.memoryUsage().heapUsed;
+      // Keep the materialized data alive across the sample so nothing is freed
+      // before `after` is read.
+      expect(materialized.length).toBe(rowCount);
+
+      perRowSamples.push((after - before) / rowCount);
+    }
+
+    const perRow = median(perRowSamples);
+    expect(perRow).toBeLessThan(BUDGET_BYTES_PER_ROW);
+  });
+});

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -632,6 +632,13 @@ pub fn row_to_object(
 mod tests {
     use super::*;
 
+    /// Serializes every test that resets/reads the process-global
+    /// `ctor_lookups` counter. The increment site lives in library code (a true
+    /// process-global, unlike the local-instance trick in `cqlite-core`'s
+    /// `work_counters`), so two `reset`-then-assert tests running under Rust's
+    /// default parallel runner would race. Both counter tests take this guard.
+    static CTOR_COUNTER_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_decimal_to_string_positive() {
         // 123 with scale 2 = 1.23
@@ -684,10 +691,11 @@ mod tests {
     // test on purpose: the counter is a process-global (the increment site is in
     // library code, unlike the local-instance trick in `cqlite-core`'s
     // `work_counters`), so splitting them into two `reset`-then-assert tests would
-    // race under Rust's default parallel test runner. No other test in this module
-    // touches the counter, so this single serial test is deterministic.
+    // race under Rust's default parallel test runner. Tests that touch the counter
+    // serialize on `CTOR_COUNTER_GUARD`.
     #[test]
     fn ctor_cache_fetches_at_most_once_per_cache() {
+        let _guard = CTOR_COUNTER_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         testing::reset_ctor_lookups();
 
         // Zero lookups when no set/map cell is ever converted (a `ConvCtx` never
@@ -709,5 +717,54 @@ mod tests {
         .expect("second hit");
         assert_eq!(*second, 7);
         assert_eq!(testing::ctor_lookups(), 1);
+    }
+
+    // Issue #1449: FFI-call BUDGET ratchet for the #1448 constructor-caching win.
+    //
+    // The `ctor_lookups` counter is Rust-`#[cfg(test)]` only and NOT exposed to
+    // JS, so per the issue this FFI-call budget is asserted here (Rust) while the
+    // JS test owns the per-row heap-delta budget.
+    //
+    // A `ConvCtx` lives for a WHOLE result conversion; its two `OnceCell`s back
+    // the `Set` and `Map` constructor caches. `row_to_object` -> `value_to_napi`
+    // routes every set/map cell through `set_constructor`/`map_constructor`, both
+    // of which delegate to the single `cache_get_or_try_init` fetch-vs-cached
+    // decision point. So converting a wide result of ROWS rows, each with several
+    // set AND map cells, must still fetch each global constructor at most once for
+    // the entire result — total lookups <= 2 (one Set cache + one Map cache),
+    // regardless of row/cell count. A regression to per-cell `get_global()` would
+    // make this O(rows x collection-cells).
+    //
+    // This exercises `cache_get_or_try_init` directly on two shared cells (exactly
+    // what `set_constructor`/`map_constructor` delegate to) because instantiating a
+    // real `ConvCtx` needs a live napi `Env`, which is unavailable in a unit test.
+    #[test]
+    fn set_map_ctor_lookups_bounded_per_result() {
+        let _guard = CTOR_COUNTER_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        testing::reset_ctor_lookups();
+
+        // One pair of caches shared across the whole simulated result, as a real
+        // per-result `ConvCtx` holds.
+        let set_cell: OnceCell<u32> = OnceCell::new();
+        let map_cell: OnceCell<u32> = OnceCell::new();
+
+        const ROWS: usize = 200;
+        const COLLECTION_CELLS_PER_ROW: usize = 5;
+        for _ in 0..ROWS {
+            for _ in 0..COLLECTION_CELLS_PER_ROW {
+                let _ = cache_get_or_try_init(&set_cell, || Ok(1u32)).expect("set ctor");
+                let _ = cache_get_or_try_init(&map_cell, || Ok(2u32)).expect("map ctor");
+            }
+        }
+
+        // 2 caches, each accessed ROWS * COLLECTION_CELLS_PER_ROW = 1000 times,
+        // but each fetched exactly once -> total 2. Budget is 2 (<=1 per cache).
+        let lookups = testing::ctor_lookups();
+        assert!(
+            lookups <= 2,
+            "constructor lookups {lookups} exceeded FFI-call budget of 2 \
+             (<=1 per Set/Map cache per result); a regression to per-cell \
+             get_global() would make this O(rows x collection-cells) — see #1449"
+        );
     }
 }

--- a/bindings/python/tests/test_conversion_budgets.py
+++ b/bindings/python/tests/test_conversion_budgets.py
@@ -39,17 +39,25 @@ WIDE_TABLE = "test_wide_rows.many_columns_table"
 ROW_LIMIT = 200
 
 # MEASURED BASELINE (2026-07-04, macOS arm64, maturin --profile dev):
-#   result = db.execute("SELECT * FROM test_wide_rows.many_columns_table LIMIT 200")
+#   MEASUREMENT WINDOW (issue #1449, roborev fix): the tracemalloc window now
+#   wraps BOTH `db.execute(...)` AND the `[dict(r) for r in result.rows]`
+#   materialization. Python's conversion of every row/cell to a PyObject is
+#   EAGER inside `execute()` (see result.rs `Row::from_core` / eager materialize),
+#   so the earlier window — which started tracemalloc AFTER execute() returned —
+#   measured only the dict re-packaging and left the W1-W4 conversion allocations
+#   (interned/ordered keys, one-time column-name interning) OUTSIDE the ratchet.
+#   With execute() now inside the window we capture the actual conversion cost:
 #   -> 50 rows x 101 columns present in the fixture
-#   materialize `[dict(r) for r in result.rows]` under tracemalloc
-#   -> traced peak = 412,150 bytes, i.e. per_row = 8,243.0 bytes (stable to the
-#      byte across 4 consecutive runs).
-# Budget = 13,000 bytes/row (~1.58x the observed 8,243) — modest headroom for
+#   -> traced peak observed across 10 consecutive runs = 8,967.0 .. 9,078.2
+#      bytes/row (vs the old post-execute-only ~8,243 — the ~800 bytes/row delta
+#      is the previously-unmeasured conversion allocation now inside the window).
+# Budget = 14,000 bytes/row (~1.54x the observed 9,078 max) — modest headroom for
 # interpreter/allocator variance across platforms and Python versions while
 # still tripping on a regression that roughly doubles per-row allocation (e.g.
-# re-interning every column key per row, or re-cloning row values). Documented
-# per the issue mandate: pinned to a measured number, never a guess.
-BUDGET_BYTES_PER_ROW = 13_000
+# re-interning every column key per row instead of the one-time #1445/#1446
+# interning). Documented per the issue mandate: pinned to a measured number,
+# never a guess.
+BUDGET_BYTES_PER_ROW = 14_000
 
 
 def test_per_row_alloc_budget():
@@ -62,7 +70,20 @@ def test_per_row_alloc_budget():
     skip_if_no_schema(SCHEMA_WIDE_ROWS)
 
     with cqlite.open(DATASETS, schema=SCHEMA_WIDE_ROWS) as db:
+        # Measure the CONVERSION PATH itself (issue #1449 roborev fix): the
+        # window MUST wrap execute() — Python converts every row/cell to a
+        # PyObject eagerly inside execute(), so measuring only the later
+        # `dict(r)` re-packaging left the W1-W4 conversion allocations
+        # unmeasured and a regression there would not trip this ratchet.
+        tracemalloc.start()
         result = db.execute(f"SELECT * FROM {WIDE_TABLE} LIMIT {ROW_LIMIT}")
+        materialized = [dict(r) for r in result.rows]
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        # Keep the materialized data alive across the measurement so nothing is
+        # freed before `peak` is read. The length checks below run AFTER
+        # tracemalloc.stop() so they add no allocation to the measured window.
         n = len(result)
         # FAIL LOUDLY (never skip) on a present-but-empty/unreadable dataset:
         # a zero-row result would make the per-row math divide-by-zero and
@@ -71,15 +92,6 @@ def test_per_row_alloc_budget():
             f"fixture {WIDE_TABLE} present but returned 0 rows — datasets "
             "unreadable or table dropped (see issue #1230)"
         )
-
-        # Measure ONLY the materialization allocation, mirroring test_performance.py.
-        tracemalloc.start()
-        materialized = [dict(r) for r in result.rows]
-        _, peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
-
-        # Keep the materialized data alive across the measurement so nothing is
-        # freed before `peak` is read.
         assert len(materialized) == n
 
         per_row = peak / n

--- a/bindings/python/tests/test_conversion_budgets.py
+++ b/bindings/python/tests/test_conversion_budgets.py
@@ -1,0 +1,95 @@
+"""Per-row allocation BUDGET tests for the Python binding conversion path.
+
+Issue #1449 (parent #1433). The per-row conversion wins landed in this epic —
+#1445 (interned/ordered keys), #1446 (ordered rows + one-time column-name
+interning), #1447 (clone -> move), #1448 (Set/Map constructor caching) — reduce
+allocations per converted row. Nothing pinned those wins, so a future refactor
+could silently re-introduce O(rows x columns) allocation without any test
+noticing. This module makes the allocation win a RATCHET: it materializes a wide
+result and asserts the per-row allocation peak stays under a MEASURED budget.
+
+This reuses the existing `tracemalloc` machinery already used by
+``test_performance.py`` — it does NOT stand up a second measurement harness.
+
+Dataset rule (issue #1230): the budget query is dataset-dependent. It asserts
+``len(result) > 0`` and FAILS LOUDLY on a present-but-empty/unreadable dataset
+rather than skipping, so a dropped fixture reds CI instead of false-greening.
+"""
+
+import tracemalloc
+
+import pytest
+
+from conftest import (
+    DATASETS,
+    SCHEMA_WIDE_ROWS,
+    require_test_data,
+    skip_if_no_schema,
+)
+
+import cqlite
+
+# ---------------------------------------------------------------------------
+# Wide table chosen deliberately: test_wide_rows.many_columns_table has ~101
+# columns, so it exercises the per-column conversion cost that the W1-W4 wins
+# target. A regression to O(rows x columns) allocation blows the per-row peak
+# on this table faster than any narrow table would.
+# ---------------------------------------------------------------------------
+WIDE_TABLE = "test_wide_rows.many_columns_table"
+ROW_LIMIT = 200
+
+# MEASURED BASELINE (2026-07-04, macOS arm64, maturin --profile dev):
+#   result = db.execute("SELECT * FROM test_wide_rows.many_columns_table LIMIT 200")
+#   -> 50 rows x 101 columns present in the fixture
+#   materialize `[dict(r) for r in result.rows]` under tracemalloc
+#   -> traced peak = 412,150 bytes, i.e. per_row = 8,243.0 bytes (stable to the
+#      byte across 4 consecutive runs).
+# Budget = 13,000 bytes/row (~1.58x the observed 8,243) — modest headroom for
+# interpreter/allocator variance across platforms and Python versions while
+# still tripping on a regression that roughly doubles per-row allocation (e.g.
+# re-interning every column key per row, or re-cloning row values). Documented
+# per the issue mandate: pinned to a measured number, never a guess.
+BUDGET_BYTES_PER_ROW = 13_000
+
+
+def test_per_row_alloc_budget():
+    """Per-row allocation peak on a wide result must stay under the budget.
+
+    Pins the W1-W4 conversion allocation wins so a future refactor cannot
+    silently re-introduce O(rows x columns) allocation.
+    """
+    require_test_data(SCHEMA_WIDE_ROWS)
+    skip_if_no_schema(SCHEMA_WIDE_ROWS)
+
+    with cqlite.open(DATASETS, schema=SCHEMA_WIDE_ROWS) as db:
+        result = db.execute(f"SELECT * FROM {WIDE_TABLE} LIMIT {ROW_LIMIT}")
+        n = len(result)
+        # FAIL LOUDLY (never skip) on a present-but-empty/unreadable dataset:
+        # a zero-row result would make the per-row math divide-by-zero and
+        # would false-green the ratchet.
+        assert n > 0, (
+            f"fixture {WIDE_TABLE} present but returned 0 rows — datasets "
+            "unreadable or table dropped (see issue #1230)"
+        )
+
+        # Measure ONLY the materialization allocation, mirroring test_performance.py.
+        tracemalloc.start()
+        materialized = [dict(r) for r in result.rows]
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        # Keep the materialized data alive across the measurement so nothing is
+        # freed before `peak` is read.
+        assert len(materialized) == n
+
+        per_row = peak / n
+        assert per_row < BUDGET_BYTES_PER_ROW, (
+            f"per-row allocation {per_row:.1f} bytes exceeded budget "
+            f"{BUDGET_BYTES_PER_ROW} bytes (rows={n}, peak={peak}). "
+            "A W1-W4 conversion win likely regressed (O(rows x columns) "
+            "allocation re-introduced) — see issue #1449."
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual measurement helper
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
Closes #1449. Follow-up gap filed as #1883.

## What (test-only — no production code changed)
Adds budget ratchets so a future refactor can't silently re-introduce per-row allocation/FFI-call blowups in the bindings:
- **Rust FFI-call budget** (`bindings/node/src/value.rs`, `#[cfg(test)]`): `set_map_ctor_lookups_bounded_per_result` asserts Set/Map constructor lookups ≤2 per result (pins #1448). **Synthetic-regression proven**: reverting #1448 to per-cell fetch turns it RED (2000 vs budget 2), restore → GREEN.
- **Node per-row heap budget** (`__test__/conversion-budget.test.js`, `--expose-gc`): `executeNative()` runs INSIDE the gc/heap-delta window; median-of-N per-row heap < **2000 B/row** (measured ~1295 warm on macOS arm64 release-unwind; budget leaves headroom for Linux/debug/GC drift while staying under the ~2086 value-graph-doubling regression signal). Pins the gross per-row value graph (a value-doubling regression goes RED at ~2086).
- **Python per-row alloc budget** (`tests/test_conversion_budgets.py`): `db.execute()` runs INSIDE the `tracemalloc` window; per-row peak < **14000 B/row** (measured ~9000). Fail-loud on present-but-empty (never skips).

## Honest coverage boundary (documented in-test; follow-up #1883)
An earlier roborev pass correctly flagged that the heap/alloc windows must include the conversion path — fixed (execute() moved inside both windows). Empirically, the binding-layer heap/alloc tests **cannot observe** #1447 (clone→move: the transient Rust-heap clone is freed before any V8/tracemalloc sample) or #1445/#1446 (V8 dedups property-name strings) — reverting either doesn't move the number. These budgets therefore pin the **gross per-row value graph** + the **ctor-lookup count** (#1448); the residual #1447/#1445/#1446 ratchet needs a **Rust-side alloc budget (dhat/allocator hook)**, filed as **#1883** (epic-H H2 territory). The tests state this boundary rather than overclaiming.

## Verification
- roborev (claude-code/opus): converged — the measurement-window Medium fixed; final pass had only a Low (Node budget headroom), addressed by widening 1800→2000. No correctness issues.
- Full agent-gate: **file-size / fmt / clippy / node-bindings PASS**; **python-bindings' `test_per_row_alloc_budget` PASS** (confirmed in-gate + direct). Two FAILs are pre-existing/environmental, NOT attributable: `core-tests` `issue_953_multichunk_cell_seek` (#1856) and the `python-bindings` `test_streaming_next_releases_gil` GIL flake. (The Node jest budget test isn't in the gate's scoped jest; validated directly, 3x green — the PR's Node CI lane runs the full suite.)

_Delivered by flow-lead worker; seams pre-approved (owner AFK)._