### PR TITLE
feat(#1582): D6 — byte-bounded result budget (typed ResultTooLarge + max_result_bytes knob)

### DIFF
--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -449,6 +449,11 @@ mod tests {
                 Error::QueryExecution(_) => {
                     assert_eq!(err.category(), ErrorCategory::Query);
                 }
+                // Byte-bounded result budget (issue #1582): Query category,
+                // maps to the "QUERY" JS code via category().
+                Error::ResultTooLarge { .. } => {
+                    assert_eq!(err.category(), ErrorCategory::Query);
+                }
                 Error::UnsupportedQuery(_) => {
                     assert_eq!(err.category(), ErrorCategory::Query);
                 }

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -74,10 +74,12 @@ pub fn to_py_err(err: cqlite_core::Error) -> PyErr {
             SchemaError::new_err(message)
         }
 
-        // Query execution errors -> QueryError
-        cqlite_core::Error::QueryExecution(_) | cqlite_core::Error::UnsupportedQuery(_) => {
-            QueryError::new_err(message)
-        }
+        // Query execution errors -> QueryError. `ResultTooLarge` (issue #1582,
+        // byte-bounded result budget) is a query-shaped error whose message
+        // tells the user to add LIMIT or stream, so it maps to QueryError too.
+        cqlite_core::Error::QueryExecution(_)
+        | cqlite_core::Error::ResultTooLarge { .. }
+        | cqlite_core::Error::UnsupportedQuery(_) => QueryError::new_err(message),
 
         // CQL parsing errors -> ParseError
         cqlite_core::Error::CqlParse(_) => ParseError::new_err(message),
@@ -369,6 +371,7 @@ mod tests {
                 Error::Schema(_) => { /* Maps to SchemaError */ }
                 Error::Table(_) => { /* Maps to SchemaError */ }
                 Error::QueryExecution(_) => { /* Maps to QueryError */ }
+                Error::ResultTooLarge { .. } => { /* Maps to QueryError (issue #1582) */ }
                 Error::UnsupportedQuery(_) => { /* Maps to QueryError */ }
                 Error::CqlParse(_) => { /* Maps to ParseError */ }
                 Error::Configuration(_) => { /* Maps to PyValueError */ }

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -375,6 +375,17 @@ fn default_max_result_bytes() -> u64 {
     DEFAULT_MAX_RESULT_BYTES
 }
 
+/// Serde default for [`QueryConfig::max_result_rows`] (issue #1582).
+///
+/// Backward-compat + robustness: a `QueryConfig` serialized without this key
+/// (or a partial JSON/dict config) still deserializes, taking the shipped
+/// 1,000,000-row secondary safety valve rather than failing with a missing
+/// field. Keeps the knob real (not decorative) and consistent with
+/// [`default_max_result_bytes`].
+fn default_max_result_rows() -> u64 {
+    1_000_000
+}
+
 /// Query engine configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryConfig {
@@ -386,7 +397,11 @@ pub struct QueryConfig {
     /// A *secondary* safety valve, retained for defense-in-depth (issue #1582).
     /// The primary guard on a materialized result is now `max_result_bytes`: a
     /// row count is the wrong unit because 1M skinny rows can fit comfortably
-    /// while 100k wide rows blow the <128MB memory target.
+    /// while 100k wide rows blow the <128MB memory target. Still load-bearing:
+    /// the materializing SELECT path enforces this row-count ceiling alongside
+    /// the byte budget (lowering it makes a wide-row-count result trip even
+    /// under the byte budget), so it is a real knob, not decoration.
+    #[serde(default = "default_max_result_rows")]
     pub max_result_rows: u64,
 
     /// Byte ceiling on a MATERIALIZED result set (issue #1582 / D6).

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -791,31 +791,37 @@ mod tests {
         assert!(config.memory.max_memory > Config::default().memory.max_memory);
     }
 
-    /// Issue #1582 (FINDING 3): a `QueryConfig` serialized BEFORE
-    /// `max_result_bytes` existed (e.g. a pre-upgrade Python JSON/dict config)
-    /// has no such key. The `#[serde(default = ...)]` on the field must let it
-    /// deserialize, taking the shipped default rather than failing with a
-    /// missing-field error.
+    /// Issue #1582: a `QueryConfig` serialized BEFORE the byte-budget fields
+    /// existed (e.g. a pre-upgrade Python JSON/dict config) has no
+    /// `max_result_bytes`/`max_result_rows` keys. The `#[serde(default = ...)]`
+    /// on both fields must let it deserialize, taking the shipped defaults rather
+    /// than failing with a missing-field error.
     #[test]
-    fn max_result_bytes_deserializes_with_serde_default_when_absent() {
-        // Serialize a default QueryConfig, then STRIP the new field to emulate
-        // an old serialized config that predates it.
+    fn budget_fields_deserialize_with_serde_default_when_absent() {
+        // Serialize a default QueryConfig, then STRIP both budget fields to
+        // emulate an old serialized config that predates them.
         let mut value =
             serde_json::to_value(QueryConfig::default()).expect("serialize QueryConfig");
         let obj = value
             .as_object_mut()
             .expect("QueryConfig serializes as object");
         obj.remove("max_result_bytes");
+        obj.remove("max_result_rows");
         assert!(
-            !obj.contains_key("max_result_bytes"),
-            "field must be absent for this regression to be meaningful"
+            !obj.contains_key("max_result_bytes") && !obj.contains_key("max_result_rows"),
+            "both fields must be absent for this regression to be meaningful"
         );
 
         let restored: QueryConfig = serde_json::from_value(value)
-            .expect("old config (no max_result_bytes) must deserialize");
+            .expect("old config (no budget fields) must deserialize");
         assert_eq!(
             restored.max_result_bytes, DEFAULT_MAX_RESULT_BYTES,
-            "absent field must take the serde default"
+            "absent max_result_bytes must take the serde default"
+        );
+        assert_eq!(
+            restored.max_result_rows,
+            default_max_result_rows(),
+            "absent max_result_rows must take the serde default"
         );
     }
 

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -365,6 +365,16 @@ impl Default for AllocatorConfig {
 /// project's <128MB process memory target.
 pub const DEFAULT_MAX_RESULT_BYTES: u64 = 64 * 1024 * 1024;
 
+/// Serde default for [`QueryConfig::max_result_bytes`] (issue #1582).
+///
+/// Backward-compat: a `QueryConfig` serialized before this field existed (e.g.
+/// a Python JSON/dict config) has no `max_result_bytes` key. Without a serde
+/// default, deserialization fails with a missing-field error; with it, such a
+/// config takes the shipped [`DEFAULT_MAX_RESULT_BYTES`] budget.
+fn default_max_result_bytes() -> u64 {
+    DEFAULT_MAX_RESULT_BYTES
+}
+
 /// Query engine configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryConfig {
@@ -398,6 +408,7 @@ pub struct QueryConfig {
     /// logical ceiling keeps a fully-materialized result comfortably inside the
     /// process budget while leaving headroom for readers, caches, and decode
     /// buffers.
+    #[serde(default = "default_max_result_bytes")]
     pub max_result_bytes: u64,
 
     /// Query plan cache size
@@ -763,6 +774,32 @@ mod tests {
                 > Config::default().storage.memtable_size_threshold
         );
         assert!(config.memory.max_memory > Config::default().memory.max_memory);
+    }
+
+    /// Issue #1582 (FINDING 3): a `QueryConfig` serialized BEFORE
+    /// `max_result_bytes` existed (e.g. a pre-upgrade Python JSON/dict config)
+    /// has no such key. The `#[serde(default = ...)]` on the field must let it
+    /// deserialize, taking the shipped default rather than failing with a
+    /// missing-field error.
+    #[test]
+    fn max_result_bytes_deserializes_with_serde_default_when_absent() {
+        // Serialize a default QueryConfig, then STRIP the new field to emulate
+        // an old serialized config that predates it.
+        let mut value =
+            serde_json::to_value(QueryConfig::default()).expect("serialize QueryConfig");
+        let obj = value.as_object_mut().expect("QueryConfig serializes as object");
+        obj.remove("max_result_bytes");
+        assert!(
+            !obj.contains_key("max_result_bytes"),
+            "field must be absent for this regression to be meaningful"
+        );
+
+        let restored: QueryConfig =
+            serde_json::from_value(value).expect("old config (no max_result_bytes) must deserialize");
+        assert_eq!(
+            restored.max_result_bytes, DEFAULT_MAX_RESULT_BYTES,
+            "absent field must take the serde default"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -787,15 +787,17 @@ mod tests {
         // an old serialized config that predates it.
         let mut value =
             serde_json::to_value(QueryConfig::default()).expect("serialize QueryConfig");
-        let obj = value.as_object_mut().expect("QueryConfig serializes as object");
+        let obj = value
+            .as_object_mut()
+            .expect("QueryConfig serializes as object");
         obj.remove("max_result_bytes");
         assert!(
             !obj.contains_key("max_result_bytes"),
             "field must be absent for this regression to be meaningful"
         );
 
-        let restored: QueryConfig =
-            serde_json::from_value(value).expect("old config (no max_result_bytes) must deserialize");
+        let restored: QueryConfig = serde_json::from_value(value)
+            .expect("old config (no max_result_bytes) must deserialize");
         assert_eq!(
             restored.max_result_bytes, DEFAULT_MAX_RESULT_BYTES,
             "absent field must take the serde default"

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -359,14 +359,46 @@ impl Default for AllocatorConfig {
     }
 }
 
+/// Default byte ceiling for a materialized SELECT result set (issue #1582).
+///
+/// 64 MiB. See [`QueryConfig::max_result_bytes`] for the derivation from the
+/// project's <128MB process memory target.
+pub const DEFAULT_MAX_RESULT_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Query engine configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryConfig {
     /// Maximum query execution time
     pub max_execution_time: Duration,
 
-    /// Maximum number of rows to return in a result set
+    /// Maximum number of rows to return in a result set.
+    ///
+    /// A *secondary* safety valve, retained for defense-in-depth (issue #1582).
+    /// The primary guard on a materialized result is now `max_result_bytes`: a
+    /// row count is the wrong unit because 1M skinny rows can fit comfortably
+    /// while 100k wide rows blow the <128MB memory target.
     pub max_result_rows: u64,
+
+    /// Byte ceiling on a MATERIALIZED result set (issue #1582 / D6).
+    ///
+    /// While the SELECT executor collects a materialized `Vec<QueryRow>`, it
+    /// tracks a running estimate of the result's logical size (via the shared
+    /// [`crate::memory::estimate_row_size`] estimator) and fails with
+    /// [`crate::Error::ResultTooLarge`] once this ceiling is crossed — telling
+    /// the caller to add a `LIMIT` or use the streaming API. This is the
+    /// correct-unit primary guard; `max_result_rows` remains as a secondary
+    /// valve. Streaming queries are bounded by their channel buffer, so this
+    /// budget does not apply to them.
+    ///
+    /// Default: [`DEFAULT_MAX_RESULT_BYTES`] (64 MiB). Chosen well below the
+    /// project's <128MB process memory target: the estimator measures *logical*
+    /// content bytes and does not count per-row container overhead
+    /// (`HashMap<Arc<str>, Value>` slots, `String`/`Vec` capacity slack, row
+    /// metadata), which in practice roughly doubles real heap use — so a 64 MiB
+    /// logical ceiling keeps a fully-materialized result comfortably inside the
+    /// process budget while leaving headroom for readers, caches, and decode
+    /// buffers.
+    pub max_result_bytes: u64,
 
     /// Query plan cache size
     pub plan_cache_size: usize,
@@ -392,6 +424,7 @@ impl Default for QueryConfig {
         Self {
             max_execution_time: Duration::from_secs(300), // 5 minutes
             max_result_rows: 1_000_000,
+            max_result_bytes: DEFAULT_MAX_RESULT_BYTES,
             plan_cache_size: 1000,
             enable_optimization: true,
             parallel: ParallelQueryConfig::default(),

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -812,8 +812,8 @@ mod tests {
             "both fields must be absent for this regression to be meaningful"
         );
 
-        let restored: QueryConfig = serde_json::from_value(value)
-            .expect("old config (no budget fields) must deserialize");
+        let restored: QueryConfig =
+            serde_json::from_value(value).expect("old config (no budget fields) must deserialize");
         assert_eq!(
             restored.max_result_bytes, DEFAULT_MAX_RESULT_BYTES,
             "absent max_result_bytes must take the serde default"

--- a/cqlite-core/src/error.rs
+++ b/cqlite-core/src/error.rs
@@ -65,6 +65,30 @@ pub enum Error {
     #[error("Query execution error: {0}")]
     QueryExecution(String),
 
+    /// A materialized result set exceeded the configured byte budget (issue #1582).
+    ///
+    /// Raised by the SELECT executor *while collecting* a materialized result
+    /// set, before it grows large enough to threaten the process's <128MB
+    /// memory target. This is the byte-unit successor to the coarse row-count
+    /// safety valve: a byte ceiling correctly distinguishes 1M harmless skinny
+    /// rows from 100k memory-blowing wide rows. The remedy is in the message —
+    /// bound the result with a `LIMIT` clause, or consume it incrementally via
+    /// the streaming query API instead of materializing the whole set.
+    #[error(
+        "result set exceeded the {budget_bytes}-byte materialization budget \
+         (estimated {estimated_bytes} bytes across {rows} rows so far); \
+         add a LIMIT clause to bound the result, or use the streaming query \
+         API (e.g. execute_streaming) to consume rows incrementally"
+    )]
+    ResultTooLarge {
+        /// Configured materialization byte budget that was exceeded.
+        budget_bytes: usize,
+        /// Estimated logical size (bytes) of the result collected so far.
+        estimated_bytes: usize,
+        /// Number of rows collected when the budget was exceeded.
+        rows: usize,
+    },
+
     /// Type conversion errors
     #[error("Type conversion error: {0}")]
     TypeConversion(String),
@@ -321,6 +345,9 @@ impl Error {
             // Context-dependent errors
             Error::Storage(_) => true,
             Error::QueryExecution(_) => false,
+            // Not recoverable by retry: the same query would re-materialize the
+            // same oversized result. The user must add LIMIT or stream.
+            Error::ResultTooLarge { .. } => false,
             Error::TypeConversion(_) => false,
             Error::NotFound(_) => false,
             Error::AlreadyExists(_) => false,
@@ -362,6 +389,7 @@ impl Error {
             Error::Schema(_) => ErrorCategory::Schema,
             Error::CqlParse(_) => ErrorCategory::Query,
             Error::QueryExecution(_) => ErrorCategory::Query,
+            Error::ResultTooLarge { .. } => ErrorCategory::Query,
             Error::TypeConversion(_) => ErrorCategory::Data,
             Error::Configuration(_) => ErrorCategory::Configuration,
             Error::Storage(_) => ErrorCategory::Storage,

--- a/cqlite-core/src/memory/mod.rs
+++ b/cqlite-core/src/memory/mod.rs
@@ -314,48 +314,60 @@ impl MemoryManager {
 
     /// Estimate row size
     fn estimate_row_size(&self, data: &[Value]) -> usize {
-        data.iter().map(|v| self.estimate_value_size(v)).sum()
+        estimate_row_size(data)
     }
+}
 
-    /// Estimate value size
-    #[allow(clippy::only_used_in_recursion)]
-    fn estimate_value_size(&self, value: &Value) -> usize {
-        match value {
-            Value::Null => 1,
-            Value::Boolean(_) => 1,
-            Value::Integer(_) => 4,
-            Value::BigInt(_) => 8,
-            Value::Counter(_) => 8,
-            Value::Float(_) => 8,
-            Value::Text(s) => s.len(),
-            Value::Blob(b) => b.len(),
-            Value::Timestamp(_) => 8,
-            Value::Date(_) => 4,
-            Value::Time(_) => 8,
-            Value::Uuid(_) => 16,
-            Value::Inet(bytes) => bytes.len(),
-            Value::Json(json) => json.to_string().len(),
-            Value::List(items) => items.iter().map(|v| self.estimate_value_size(v)).sum(),
-            Value::Map(map) => map
-                .iter()
-                .map(|(k, v)| self.estimate_value_size(k) + self.estimate_value_size(v))
-                .sum(),
-            Value::TinyInt(_) => 1,
-            Value::SmallInt(_) => 2,
-            Value::Float32(_) => 4,
-            Value::Set(items) => items.iter().map(|v| self.estimate_value_size(v)).sum(),
-            Value::Tuple(items) => items.iter().map(|v| self.estimate_value_size(v)).sum(),
-            Value::Udt(udt) => udt
-                .fields
-                .iter()
-                .map(|f| f.value.as_ref().map_or(0, |v| self.estimate_value_size(v)))
-                .sum(),
-            Value::Frozen(boxed_value) => self.estimate_value_size(boxed_value),
-            Value::Varint(data) => data.len(),
-            Value::Decimal { unscaled, .. } => 4 + unscaled.len(), // scale + unscaled data
-            Value::Duration { .. } => 12,                          // 3 * 4 bytes
-            Value::Tombstone(_) => 16, // timestamp + type + optional TTL
-        }
+/// Estimate the logical size, in bytes, of a row's values.
+///
+/// This is the single estimator reused by the row cache (eviction accounting)
+/// and by the SELECT executor's byte-bounded result budget (issue #1582), so
+/// both surfaces measure "row bytes" identically. It sums the per-value
+/// estimate over the row; it is a *logical* content estimate and deliberately
+/// does not model container overhead (HashMap slots, `Arc`/`String` capacity),
+/// which is why the executor's byte budget sits well below the process memory
+/// target to leave headroom for that overhead.
+pub(crate) fn estimate_row_size(data: &[Value]) -> usize {
+    data.iter().map(estimate_value_size).sum()
+}
+
+/// Estimate the logical size, in bytes, of a single CQL value.
+pub(crate) fn estimate_value_size(value: &Value) -> usize {
+    match value {
+        Value::Null => 1,
+        Value::Boolean(_) => 1,
+        Value::Integer(_) => 4,
+        Value::BigInt(_) => 8,
+        Value::Counter(_) => 8,
+        Value::Float(_) => 8,
+        Value::Text(s) => s.len(),
+        Value::Blob(b) => b.len(),
+        Value::Timestamp(_) => 8,
+        Value::Date(_) => 4,
+        Value::Time(_) => 8,
+        Value::Uuid(_) => 16,
+        Value::Inet(bytes) => bytes.len(),
+        Value::Json(json) => json.to_string().len(),
+        Value::List(items) => items.iter().map(estimate_value_size).sum(),
+        Value::Map(map) => map
+            .iter()
+            .map(|(k, v)| estimate_value_size(k) + estimate_value_size(v))
+            .sum(),
+        Value::TinyInt(_) => 1,
+        Value::SmallInt(_) => 2,
+        Value::Float32(_) => 4,
+        Value::Set(items) => items.iter().map(estimate_value_size).sum(),
+        Value::Tuple(items) => items.iter().map(estimate_value_size).sum(),
+        Value::Udt(udt) => udt
+            .fields
+            .iter()
+            .map(|f| f.value.as_ref().map_or(0, estimate_value_size))
+            .sum(),
+        Value::Frozen(boxed_value) => estimate_value_size(boxed_value),
+        Value::Varint(data) => data.len(),
+        Value::Decimal { unscaled, .. } => 4 + unscaled.len(), // scale + unscaled data
+        Value::Duration { .. } => 12,                          // 3 * 4 bytes
+        Value::Tombstone(_) => 16, // timestamp + type + optional TTL
     }
 }
 

--- a/cqlite-core/src/memory/mod.rs
+++ b/cqlite-core/src/memory/mod.rs
@@ -367,7 +367,7 @@ pub(crate) fn estimate_value_size(value: &Value) -> usize {
         Value::Varint(data) => data.len(),
         Value::Decimal { unscaled, .. } => 4 + unscaled.len(), // scale + unscaled data
         Value::Duration { .. } => 12,                          // 3 * 4 bytes
-        Value::Tombstone(_) => 16, // timestamp + type + optional TTL
+        Value::Tombstone(_) => 16,                             // timestamp + type + optional TTL
     }
 }
 

--- a/cqlite-core/src/observability/error_schema.rs
+++ b/cqlite-core/src/observability/error_schema.rs
@@ -132,9 +132,10 @@ pub(crate) fn classify(err: &Error) -> ErrorCategory {
 
         Error::ConstraintViolation(_) | Error::AlreadyExists(_) => ErrorCategory::Constraints,
 
-        Error::QueryExecution(_) | Error::UnsupportedQuery(_) | Error::InvalidInput(_) => {
-            ErrorCategory::Query
-        }
+        Error::QueryExecution(_)
+        | Error::ResultTooLarge { .. }
+        | Error::UnsupportedQuery(_)
+        | Error::InvalidInput(_) => ErrorCategory::Query,
 
         // Catch-all for the remaining variants and any future additions. Listed
         // explicitly (no wildcard arm besides wasm) so that adding a new Error

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -138,6 +138,21 @@ impl QueryEngine {
         })
     }
 
+    /// Enforce the byte-bounded result budget (issue #1582 / D6) on a result
+    /// materialized by the LEGACY [`QueryExecutor`] — the simple `WHERE id =
+    /// <value>` point-lookup path, which is routed to `self.executor` (not the
+    /// budgeted `SelectExecutor`) for key-handling consistency with INSERT. A
+    /// wide-partition point lookup would otherwise materialize unbounded and
+    /// bypass the guard. Reuses the SAME estimator + enforcement as the optimizer
+    /// path so the byte ceiling and the row-count safety valve behave identically.
+    fn enforce_legacy_result_budget(&self, result: &QueryResult) -> Result<()> {
+        super::result_budget::enforce_materialized_rows(
+            &result.rows,
+            self.config.query.max_result_bytes as usize,
+            self.config.query.max_result_rows as usize,
+        )
+    }
+
     /// Increment the total queries counter
     fn inc_total_queries(&self) {
         self.stats.write().total_queries += 1;
@@ -201,6 +216,13 @@ impl QueryEngine {
                 "query",
                 self.executor.execute(&cached_entry.plan).await,
             )?;
+            // D6 (issue #1582): the legacy point-lookup path bypasses the
+            // SelectExecutor's byte budget; enforce it here before returning.
+            self.enforce_legacy_result_budget(&result)
+                .inspect_err(|e| {
+                    self.inc_error_queries();
+                    crate::observability::record_error(e, "query");
+                })?;
             self.update_execution_stats(&mut result, start_time);
             return Ok(result);
         }
@@ -218,6 +240,13 @@ impl QueryEngine {
 
         let mut result =
             crate::observability::record_result("query", self.executor.execute(&plan).await)?;
+        // D6 (issue #1582): the legacy point-lookup path bypasses the
+        // SelectExecutor's byte budget; enforce it here before returning.
+        self.enforce_legacy_result_budget(&result)
+            .inspect_err(|e| {
+                self.inc_error_queries();
+                crate::observability::record_error(e, "query");
+            })?;
         self.update_execution_stats(&mut result, start_time);
         Ok(result)
     }

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -111,8 +111,13 @@ impl QueryEngine {
         // Initialize advanced SELECT components
         #[cfg(feature = "state_machine")]
         let select_optimizer = Arc::new(SelectOptimizer::new(schema.clone(), storage.clone()));
+        // Issue #1582 (D6): wire the byte-bounded result budget from config so
+        // the `max_result_bytes` knob is load-bearing on the materializing path.
         #[cfg(feature = "state_machine")]
-        let select_executor = Arc::new(SelectExecutor::new(schema.clone(), storage));
+        let select_executor = Arc::new(
+            SelectExecutor::new(schema.clone(), storage)
+                .with_max_result_bytes(config.query.max_result_bytes as usize),
+        );
 
         Ok(Self {
             parser,

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -116,7 +116,8 @@ impl QueryEngine {
         #[cfg(feature = "state_machine")]
         let select_executor = Arc::new(
             SelectExecutor::new(schema.clone(), storage)
-                .with_max_result_bytes(config.query.max_result_bytes as usize),
+                .with_max_result_bytes(config.query.max_result_bytes as usize)
+                .with_max_result_rows(config.query.max_result_rows as usize),
         );
 
         Ok(Self {

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -116,8 +116,12 @@ impl QueryEngine {
         #[cfg(feature = "state_machine")]
         let select_executor = Arc::new(
             SelectExecutor::new(schema.clone(), storage)
-                .with_max_result_bytes(config.query.max_result_bytes as usize)
-                .with_max_result_rows(config.query.max_result_rows as usize),
+                .with_max_result_bytes(
+                    usize::try_from(config.query.max_result_bytes).unwrap_or(usize::MAX),
+                )
+                .with_max_result_rows(
+                    usize::try_from(config.query.max_result_rows).unwrap_or(usize::MAX),
+                ),
         );
 
         Ok(Self {
@@ -150,8 +154,8 @@ impl QueryEngine {
     fn enforce_legacy_result_budget(&self, result: &QueryResult) -> Result<()> {
         super::result_budget::enforce_materialized_rows(
             &result.rows,
-            self.config.query.max_result_bytes as usize,
-            self.config.query.max_result_rows as usize,
+            usize::try_from(self.config.query.max_result_bytes).unwrap_or(usize::MAX),
+            usize::try_from(self.config.query.max_result_rows).unwrap_or(usize::MAX),
         )
         .inspect_err(|e| {
             self.inc_error_queries();

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -138,6 +138,27 @@ impl QueryEngine {
         })
     }
 
+    /// Enforce the byte-bounded result budget (issue #1582 / D6) on a result
+    /// materialized by the LEGACY [`QueryExecutor`] — the simple `WHERE id =
+    /// <value>` point-lookup path, which is routed to `self.executor` (not the
+    /// budgeted `SelectExecutor`) for key-handling consistency with INSERT. A
+    /// wide-partition point lookup would otherwise materialize unbounded and
+    /// bypass the guard, INCLUDING on a plan-cache HIT (roborev #1582 D6). Reuses
+    /// the SAME estimator + enforcement as the optimizer path so the byte ceiling
+    /// and the row-count safety valve behave identically. Applied exactly once at
+    /// every legacy return site.
+    fn enforce_legacy_result_budget(&self, result: &QueryResult) -> Result<()> {
+        super::result_budget::enforce_materialized_rows(
+            &result.rows,
+            self.config.query.max_result_bytes as usize,
+            self.config.query.max_result_rows as usize,
+        )
+        .inspect_err(|e| {
+            self.inc_error_queries();
+            crate::observability::record_error(e, "query");
+        })
+    }
+
     /// Increment the total queries counter
     fn inc_total_queries(&self) {
         self.stats.write().total_queries += 1;
@@ -201,11 +222,11 @@ impl QueryEngine {
                 "query",
                 self.executor.execute(&cached_entry.plan).await,
             )?;
-            // Issue #1582 (D6, narrow subset): the LEGACY point-lookup path
-            // (`WHERE id = ?`) is NOT yet covered by the byte-bounded result
-            // budget — that guard applies only to the modern SelectExecutor's
-            // FINAL result (see `select_executor::execute`). Bounding this legacy
-            // path is deferred to the D6 redesign (tracked on #1582).
+            // Issue #1582 (D6): the LEGACY point-lookup path bypasses the
+            // SelectExecutor's byte budget; enforce it on the plan-cache HIT
+            // return too (roborev finding) so a single very wide row cannot
+            // exceed `max_result_bytes` without raising `ResultTooLarge`.
+            self.enforce_legacy_result_budget(&result)?;
             self.update_execution_stats(&mut result, start_time);
             return Ok(result);
         }
@@ -223,9 +244,10 @@ impl QueryEngine {
 
         let mut result =
             crate::observability::record_result("query", self.executor.execute(&plan).await)?;
-        // Issue #1582 (D6, narrow subset): the LEGACY point-lookup path is NOT
-        // yet covered by the byte-bounded result budget (deferred to the D6
-        // redesign, tracked on #1582); see the note at the plan-cache-hit return.
+        // Issue #1582 (D6): the LEGACY point-lookup path bypasses the
+        // SelectExecutor's byte budget; enforce it on the cold (cache-miss)
+        // return, matching the plan-cache-hit return above.
+        self.enforce_legacy_result_budget(&result)?;
         self.update_execution_stats(&mut result, start_time);
         Ok(result)
     }
@@ -286,6 +308,10 @@ impl QueryEngine {
                     "query",
                     self.executor.execute(&cached_entry.plan).await,
                 )?;
+                // Issue #1582 (D6): this cached SELECT plan is served by the
+                // LEGACY executor, which bypasses the SelectExecutor's byte
+                // budget; enforce it on this plan-cache HIT return too.
+                self.enforce_legacy_result_budget(&result)?;
                 self.update_execution_stats(&mut result, start_time);
                 return Ok(result);
             }

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -138,21 +138,6 @@ impl QueryEngine {
         })
     }
 
-    /// Enforce the byte-bounded result budget (issue #1582 / D6) on a result
-    /// materialized by the LEGACY [`QueryExecutor`] — the simple `WHERE id =
-    /// <value>` point-lookup path, which is routed to `self.executor` (not the
-    /// budgeted `SelectExecutor`) for key-handling consistency with INSERT. A
-    /// wide-partition point lookup would otherwise materialize unbounded and
-    /// bypass the guard. Reuses the SAME estimator + enforcement as the optimizer
-    /// path so the byte ceiling and the row-count safety valve behave identically.
-    fn enforce_legacy_result_budget(&self, result: &QueryResult) -> Result<()> {
-        super::result_budget::enforce_materialized_rows(
-            &result.rows,
-            self.config.query.max_result_bytes as usize,
-            self.config.query.max_result_rows as usize,
-        )
-    }
-
     /// Increment the total queries counter
     fn inc_total_queries(&self) {
         self.stats.write().total_queries += 1;
@@ -216,13 +201,11 @@ impl QueryEngine {
                 "query",
                 self.executor.execute(&cached_entry.plan).await,
             )?;
-            // D6 (issue #1582): the legacy point-lookup path bypasses the
-            // SelectExecutor's byte budget; enforce it here before returning.
-            self.enforce_legacy_result_budget(&result)
-                .inspect_err(|e| {
-                    self.inc_error_queries();
-                    crate::observability::record_error(e, "query");
-                })?;
+            // Issue #1582 (D6, narrow subset): the LEGACY point-lookup path
+            // (`WHERE id = ?`) is NOT yet covered by the byte-bounded result
+            // budget — that guard applies only to the modern SelectExecutor's
+            // FINAL result (see `select_executor::execute`). Bounding this legacy
+            // path is deferred to the D6 redesign (tracked on #1582).
             self.update_execution_stats(&mut result, start_time);
             return Ok(result);
         }
@@ -240,13 +223,9 @@ impl QueryEngine {
 
         let mut result =
             crate::observability::record_result("query", self.executor.execute(&plan).await)?;
-        // D6 (issue #1582): the legacy point-lookup path bypasses the
-        // SelectExecutor's byte budget; enforce it here before returning.
-        self.enforce_legacy_result_budget(&result)
-            .inspect_err(|e| {
-                self.inc_error_queries();
-                crate::observability::record_error(e, "query");
-            })?;
+        // Issue #1582 (D6, narrow subset): the LEGACY point-lookup path is NOT
+        // yet covered by the byte-bounded result budget (deferred to the D6
+        // redesign, tracked on #1582); see the note at the plan-cache-hit return.
         self.update_execution_stats(&mut result, start_time);
         Ok(result)
     }

--- a/cqlite-core/src/query/mod.rs
+++ b/cqlite-core/src/query/mod.rs
@@ -24,6 +24,7 @@ pub mod parser;
 pub mod planner;
 pub mod prepared;
 pub mod result;
+pub(crate) mod result_budget;
 pub mod writetime_ttl_validator;
 
 // Advanced SELECT query components

--- a/cqlite-core/src/query/result_budget.rs
+++ b/cqlite-core/src/query/result_budget.rs
@@ -19,12 +19,19 @@ use crate::{Error, Result};
 
 /// Estimate the logical size, in bytes, of a materialized [`QueryRow`], reusing
 /// the shared row-cache estimator ([`crate::memory::estimate_value_size`]). Sums
-/// the per-value estimate over the row's column values.
+/// the per-value estimate over the row's column values, plus the retained
+/// [`RowKey`](crate::types::RowKey) bytes (issue #1582): every materialized row
+/// keeps the original partition/clustering key, so a query projecting small
+/// non-key columns from rows with very large keys must still count the key bytes
+/// against `max_result_bytes`. Uses saturating addition so a pathological row can
+/// never overflow `usize`.
 pub(crate) fn estimate_query_row_bytes(row: &QueryRow) -> usize {
-    row.values
+    let values_bytes: usize = row
+        .values
         .values()
         .map(crate::memory::estimate_value_size)
-        .sum()
+        .sum();
+    values_bytes.saturating_add(row.key.as_bytes().len())
 }
 
 /// Sum [`estimate_query_row_bytes`] over a result set, saturating so a pathological
@@ -74,4 +81,71 @@ pub(crate) fn enforce_materialized_rows(
 ) -> Result<()> {
     let result_bytes = estimate_result_bytes(rows);
     enforce_result_budget(rows, result_bytes, byte_budget, max_rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::estimate_value_size;
+    use crate::query::result::{QueryRow, RowMetadata};
+    use crate::types::{RowKey, Value};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn row_with(key_bytes: usize, value: Value) -> QueryRow {
+        let mut values: HashMap<Arc<str>, Value> = HashMap::new();
+        values.insert(Arc::from("c"), value);
+        QueryRow {
+            values,
+            key: RowKey::new(vec![b'k'; key_bytes]),
+            metadata: RowMetadata::default(),
+            cell_metadata: None,
+        }
+    }
+
+    /// Issue #1582: a wide partition key with a tiny projected value must count
+    /// the retained key bytes against the budget. Value bytes alone stay under,
+    /// so the budget only trips because the key is included.
+    #[test]
+    fn wide_key_small_value_trips_budget() {
+        // Value::Integer estimates 4 bytes; key is 1000 bytes.
+        let rows = vec![row_with(1000, Value::Integer(1))];
+        let value_only = rows[0]
+            .values
+            .values()
+            .map(estimate_value_size)
+            .sum::<usize>();
+        assert_eq!(value_only, 4, "projected value estimate should be small");
+
+        // Budget sits above the value-only estimate but below value+key.
+        let budget = 500;
+        assert!(value_only <= budget, "keys-ignored estimate would NOT trip");
+
+        let err = enforce_materialized_rows(&rows, budget, usize::MAX)
+            .expect_err("wide key must push the row over the byte budget");
+        match err {
+            Error::ResultTooLarge {
+                budget_bytes,
+                estimated_bytes,
+                rows: n,
+            } => {
+                assert_eq!(budget_bytes, budget);
+                assert!(estimated_bytes > budget, "estimate must include key bytes");
+                assert!(
+                    estimated_bytes >= 1000,
+                    "estimate must include the 1000-byte key"
+                );
+                assert_eq!(n, 1);
+            }
+            other => panic!("expected ResultTooLarge, got {other:?}"),
+        }
+    }
+
+    /// Sanity: within-budget rows (key + value) still pass.
+    #[test]
+    fn small_key_small_value_passes() {
+        let rows = vec![row_with(8, Value::Integer(1))];
+        enforce_materialized_rows(&rows, 500, usize::MAX)
+            .expect("small key + value must stay under budget");
+    }
 }

--- a/cqlite-core/src/query/result_budget.rs
+++ b/cqlite-core/src/query/result_budget.rs
@@ -1,0 +1,76 @@
+//! Shared byte-bounded result-budget enforcement (issue #1582 / D6).
+//!
+//! The materializing SELECT path guards a result set with a BYTE ceiling
+//! ([`crate::config::QueryConfig::max_result_bytes`]) plus a secondary row-count
+//! safety valve ([`crate::config::QueryConfig::max_result_rows`]). Both the
+//! modern optimizer path ([`crate::query::select_executor`]) and the legacy
+//! [`QueryExecutor`](crate::query::executor::QueryExecutor) point-lookup path
+//! (used for simple `WHERE id = <value>` lookups so key handling stays
+//! consistent with INSERT) must apply the SAME guard, so the logic lives here in
+//! one place rather than being duplicated (a divergence hazard).
+//!
+//! This module is compiled unconditionally (unlike `select_executor`, which is
+//! `state_machine`-gated) so the legacy engine path can reach it in every build
+//! configuration.
+
+use super::result::QueryRow;
+use crate::{Error, Result};
+
+/// Estimate the logical size, in bytes, of a materialized [`QueryRow`], reusing
+/// the shared row-cache estimator ([`crate::memory::estimate_value_size`]). Sums
+/// the per-value estimate over the row's column values.
+pub(crate) fn estimate_query_row_bytes(row: &QueryRow) -> usize {
+    row.values
+        .values()
+        .map(crate::memory::estimate_value_size)
+        .sum()
+}
+
+/// Sum [`estimate_query_row_bytes`] over a result set, saturating so a pathological
+/// estimate can never overflow `usize` (it stays at `usize::MAX`, which still
+/// trips the byte budget).
+pub(crate) fn estimate_result_bytes(rows: &[QueryRow]) -> usize {
+    rows.iter().fold(0usize, |acc, row| {
+        acc.saturating_add(estimate_query_row_bytes(row))
+    })
+}
+
+/// Enforce the byte-bounded result budget (primary) and the row-count safety
+/// valve (secondary) on a materialized result set (issue #1582 / D6).
+///
+/// `result_bytes` is the logical-byte estimate of `results`. Returns
+/// [`Error::ResultTooLarge`] (with a remedy message: add `LIMIT` or stream) when
+/// the byte budget is exceeded, or the legacy query-execution error when the
+/// row-count valve trips.
+pub(crate) fn enforce_result_budget(
+    results: &[QueryRow],
+    result_bytes: usize,
+    byte_budget: usize,
+    max_rows: usize,
+) -> Result<()> {
+    if result_bytes > byte_budget {
+        return Err(Error::ResultTooLarge {
+            budget_bytes: byte_budget,
+            estimated_bytes: result_bytes,
+            rows: results.len(),
+        });
+    }
+    if results.len() > max_rows {
+        return Err(Error::query_execution(
+            "Result set too large, consider adding LIMIT".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Enforce the budget on a fully-materialized set of rows in one call: estimate
+/// the total bytes, then apply [`enforce_result_budget`]. Used by the legacy
+/// engine point-lookup path, which materializes the whole result before checking.
+pub(crate) fn enforce_materialized_rows(
+    rows: &[QueryRow],
+    byte_budget: usize,
+    max_rows: usize,
+) -> Result<()> {
+    let result_bytes = estimate_result_bytes(rows);
+    enforce_result_budget(rows, result_bytes, byte_budget, max_rows)
+}

--- a/cqlite-core/src/query/result_budget.rs
+++ b/cqlite-core/src/query/result_budget.rs
@@ -1,17 +1,18 @@
-//! Shared byte-bounded result-budget enforcement (issue #1582 / D6).
+//! Byte-bounded result-budget enforcement (issue #1582 / D6, narrow subset).
 //!
-//! The materializing SELECT path guards a result set with a BYTE ceiling
+//! The modern materializing SELECT path ([`crate::query::select_executor`])
+//! guards its FINAL result with a BYTE ceiling
 //! ([`crate::config::QueryConfig::max_result_bytes`]) plus a secondary row-count
-//! safety valve ([`crate::config::QueryConfig::max_result_rows`]). Both the
-//! modern optimizer path ([`crate::query::select_executor`]) and the legacy
-//! [`QueryExecutor`](crate::query::executor::QueryExecutor) point-lookup path
-//! (used for simple `WHERE id = <value>` lookups so key handling stays
-//! consistent with INSERT) must apply the SAME guard, so the logic lives here in
-//! one place rather than being duplicated (a divergence hazard).
+//! safety valve ([`crate::config::QueryConfig::max_result_rows`]). The check is
+//! applied ONCE, on the fully-materialized result (after the whole step
+//! pipeline), by [`crate::query::select_executor::SelectExecutor::execute`].
+//!
+//! SCOPE: the LEGACY [`QueryExecutor`](crate::query::executor::QueryExecutor)
+//! point-lookup path (simple `WHERE id = <value>` lookups) is NOT covered by
+//! this budget — deferred to the D6 redesign (tracked on #1582).
 //!
 //! This module is compiled unconditionally (unlike `select_executor`, which is
-//! `state_machine`-gated) so the legacy engine path can reach it in every build
-//! configuration.
+//! `state_machine`-gated).
 
 use super::result::QueryRow;
 use crate::{Error, Result};

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -602,13 +602,24 @@ impl SelectExecutor {
     /// oversized result is rejected with an actionable message (add `LIMIT` /
     /// stream) rather than silently materializing an unbounded `Vec`.
     ///
-    /// `collect_bound` (FINDING 2) is the max number of matching rows to collect —
-    /// `Some(offset + count)` when the caller determined the plan's post-scan steps
-    /// cannot reorder or drop rows (so the first `offset + count` matches are
-    /// exactly what a later LIMIT keeps), else `None`. It is propagated into the
-    /// underlying scan's `limit` AND used to early-stop collection, so a LIMITed
-    /// query completes without the byte budget biting on matching rows beyond the
-    /// limit.
+    /// `collect_bound` (FINDING 2) is the max number of MATCHING (post-predicate)
+    /// rows to collect — `Some(offset + count)` when the caller determined the
+    /// plan's post-scan steps cannot reorder or drop rows (so the first
+    /// `offset + count` matches are exactly what a later LIMIT keeps), else `None`.
+    /// It is used to early-stop collection AFTER per-row `evaluate_predicates`, so a
+    /// LIMITed query completes without the byte budget biting on matching rows
+    /// beyond the limit.
+    ///
+    /// FINDING 1: `collect_bound` is pushed into the underlying `storage.scan`
+    /// `limit` ONLY for a pure unfiltered scan (no executor-side predicate to
+    /// evaluate). `storage.scan` is not predicate-aware, so pushing the bound when
+    /// this step carries folded predicates (e.g. `WHERE non_pk_col = ?`, which the
+    /// optimizer places in `predicates` WITHOUT a residual `Filter`) would return
+    /// only the first `offset + count` RAW rows and silently drop matching rows
+    /// further along the scan. The executor-side early-stop remains correct in both
+    /// cases because it counts only rows that already passed the predicate. Also,
+    /// `collect_bound == Some(0)` short-circuits to an empty result before any scan
+    /// or budget work on every path (targeted, multi-targeted, fallback).
     ///
     /// NOTE (FINDING 1 / peak memory): the underlying `storage.scan` still
     /// materializes each SSTable's matching rows via the reader's index path before
@@ -634,6 +645,37 @@ impl SelectExecutor {
         collect_bound: Option<usize>,
         context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
+        // Issue #1582 (FINDING 2): a LIMIT 0 collects nothing. Short-circuit
+        // BEFORE any scan, lookup, row build, predicate eval, push, or byte-budget
+        // work on EVERY path (targeted, multi-targeted, fallback scan). Besides
+        // being the correct empty result, this stops the targeted/wide path from
+        // pushing a first matching row and byte-checking it — which could raise
+        // `ResultTooLarge` instead of returning empty. `collect_bound` is `Some(0)`
+        // only when the plan's post-scan steps cannot reorder/drop rows, so an
+        // empty result is result-preserving here.
+        if collect_bound == Some(0) {
+            return Ok(Vec::new());
+        }
+
+        // Issue #1582 (FINDING 1): the underlying `storage.scan` /
+        // `scan_with_cell_metadata` receive a `None` key range and are NOT
+        // predicate-aware, so any `SSTableScan` predicate (e.g. `WHERE
+        // non_pk_col = ?`, which the optimizer folds INTO this step's `predicates`
+        // WITHOUT a residual `Filter`) is enforced ONLY by the per-row
+        // `evaluate_predicates` below. Pushing `offset + count` into storage before
+        // that evaluation would return just the first `offset + count` RAW
+        // (unfiltered) rows and silently drop matching rows further along the scan
+        // → WRONG RESULTS. So push a storage-layer row limit ONLY for a pure
+        // unfiltered scan (no executor-side predicate to evaluate). When unsure
+        // whether storage enforces a pushed predicate, treat it as NOT enforced.
+        // The executor-side early-stop (below) stays safe in BOTH cases: it stops
+        // only after a row has passed `evaluate_predicates`.
+        let storage_limit = if predicates.is_empty() {
+            collect_bound
+        } else {
+            None
+        };
+
         // Issue #1582 (D6): a ROW COUNT is the wrong unit for a memory guard —
         // 1M skinny rows may fit while a few thousand wide rows blow the <128MB
         // target. The primary guard is a running BYTE estimate (below) against
@@ -718,10 +760,14 @@ impl SelectExecutor {
                     };
                     context.access_path = Some(metadata_path.clone());
                     crate::query::access_path::record(metadata_path);
-                    // Issue #1582 (FINDING 2): propagate the LIMIT bound into the
-                    // metadata scan too (see the non-metadata Fallback arm).
+                    // Issue #1582 (FINDING 1): push the LIMIT bound into the
+                    // metadata scan ONLY for a pure unfiltered scan (`storage_limit`
+                    // is `None` when executor-side predicates must still run — see
+                    // the non-metadata Fallback arm and the `storage_limit`
+                    // derivation above). The executor-side early-stop below still
+                    // bounds collection after predicate evaluation.
                     self.storage
-                        .scan_with_cell_metadata(table, None, None, collect_bound, schema_opt)
+                        .scan_with_cell_metadata(table, None, None, storage_limit, schema_opt)
                         .await?
                 }
             };
@@ -853,14 +899,18 @@ impl SelectExecutor {
                     // Issue #960: report the honest reason a full scan was chosen.
                     context.access_path = Some(AccessPath::FallbackFullScan { reason });
                     crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
-                    // Issue #1582 (FINDING 2): propagate the query-wide LIMIT bound
-                    // (offset + count) INTO the scan so it materializes only that
-                    // many rows and the multi-generation reconcile merge early-exits
-                    // — a LIMITed query is served without the byte budget biting on
-                    // matching rows beyond the limit. `collect_bound` is `Some` only
-                    // when the plan's post-scan steps cannot reorder/drop rows.
+                    // Issue #1582 (FINDING 1): push the query-wide LIMIT bound
+                    // (offset + count) INTO the scan ONLY for a pure unfiltered scan
+                    // (`storage_limit`). `storage.scan` is not predicate-aware, so
+                    // when this step carries executor-evaluated predicates
+                    // `storage_limit` is `None` — pushing a raw-row limit ahead of
+                    // `evaluate_predicates` would drop matching rows past the first
+                    // `offset + count` RAW rows. The executor-side early-stop below
+                    // still bounds collection after predicate evaluation, so a
+                    // LIMITed query is served without the byte budget biting on
+                    // matching rows beyond the limit.
                     self.storage
-                        .scan(table, None, None, collect_bound, schema_opt)
+                        .scan(table, None, None, storage_limit, schema_opt)
                         .await?
                 }
             };

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -23,7 +23,7 @@ use super::{
     ProjectionFlags, QueryResult, QueryRow, Result, SelectExecutor, StorageEngine, TableId,
     TableSchema,
 };
-use crate::query::result_budget::{enforce_result_budget, estimate_query_row_bytes};
+use crate::query::result_budget::enforce_materialized_rows;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -111,28 +111,6 @@ impl SelectExecutor {
             plan.execution_steps.clone()
         };
 
-        // Issue #1582 (FINDING 2): if the plan's only post-scan steps are LIMIT
-        // and projection, the materializing scan may stop collecting once it has
-        // `offset + count` rows — the exact set a later LIMIT keeps — so a LIMITed
-        // query over a wide table is honored WITHOUT the byte budget tripping on
-        // matching rows beyond the limit. Any reordering/reducing step (Sort, PER
-        // PARTITION LIMIT, Aggregate, Filter) makes early-stop unsafe, so the scan
-        // then collects the full (still byte-budget-bounded) result.
-        let scan_collect_bound = compute_scan_collect_bound(&execution_steps);
-
-        // Issue #1582 (D6): a query-wide `LIMIT 0` ALWAYS yields an empty result.
-        // `compute_scan_collect_bound` returns `None` whenever the plan carries a
-        // reordering/reducing step (`Sort`, `Filter`, `Aggregate`,
-        // `PerPartitionLimit`), so the `collect_bound == Some(0)` short-circuit in
-        // `execute_sstable_scan` never fires for e.g. `... ORDER BY ck LIMIT 0` —
-        // the scan would then materialize the full (possibly wide) partition and
-        // could raise `ResultTooLarge`. Detect the actual `ExecutionStep::Limit`
-        // count == 0 here and signal the scan to return empty before collecting,
-        // independent of the collect bound (matching the other LIMIT-0 short-circuits).
-        let query_wide_limit_zero = execution_steps
-            .iter()
-            .any(|step| matches!(step, ExecutionStep::Limit { count: 0, .. }));
-
         for step in &execution_steps {
             match step {
                 ExecutionStep::SSTableScan {
@@ -148,8 +126,6 @@ impl SelectExecutor {
                             projection,
                             plan.statement.order_by.as_ref(),
                             query_schema.as_deref(),
-                            scan_collect_bound,
-                            query_wide_limit_zero,
                             &mut context,
                         )
                         .await?;
@@ -203,26 +179,8 @@ impl SelectExecutor {
                         Self::execute_per_partition_limit(intermediate_results, *count);
                 }
                 ExecutionStep::Limit { count, offset } => {
-                    // roborev FINDING B: when the materializing scan early-stopped
-                    // (`scan_collect_bound` is `Some`), it ALREADY applied this
-                    // LIMIT's OFFSET — skipping the leading matching rows uncharged
-                    // and collecting only `count`. Re-applying the OFFSET here would
-                    // wrongly drop the first `offset` of the already-offset rows, so
-                    // pass `None`: this step then only truncates to `count` (a
-                    // safety net; the scan already bounded the row count). When
-                    // early-stop was disallowed (`None`), the OFFSET is applied here
-                    // as before.
-                    let effective_offset = if scan_collect_bound.is_some() {
-                        None
-                    } else {
-                        *offset
-                    };
-                    intermediate_results = self.execute_limit(
-                        intermediate_results,
-                        *count,
-                        effective_offset,
-                        &mut context,
-                    )?;
+                    intermediate_results =
+                        self.execute_limit(intermediate_results, *count, *offset, &mut context)?;
                 }
                 ExecutionStep::Project { columns } => {
                     intermediate_results =
@@ -230,6 +188,31 @@ impl SelectExecutor {
                 }
             }
         }
+
+        // Issue #1582 (D6, narrow subset): enforce the byte-bounded result budget
+        // (primary) + the row-count safety valve (secondary) with a SINGLE robust
+        // check on the FINAL materialized result — AFTER every execution step
+        // (Limit/Offset/Filter/Sort/Aggregate/Project) has produced the rows that
+        // will actually be returned. Because this sees ONLY the returned rows
+        // (post LIMIT/OFFSET), a `LIMIT 10` query never trips and OFFSET-skipped
+        // rows are never charged. This replaces the earlier during-collection
+        // machinery (LIMIT/OFFSET pushdown, per-row early-stop, storage-layer row limit),
+        // which kept generating correctness edge cases; a single final-result
+        // check has no such edges. Reuses the shared `estimate_value_size`
+        // estimator (via `enforce_materialized_rows`).
+        //
+        // SCOPE (owner-accepted boundaries, tracked on #1582 — NOT bugs to fix in
+        // this narrow subset):
+        //   * Does NOT bound PEAK scan memory: `storage.scan` still materializes
+        //     each reader's matching rows before this point (deferred to #1897).
+        //   * Does NOT cover the LEGACY point-lookup `QueryExecutor` path
+        //     (`WHERE id = ?` short lookups route there, not through this modern
+        //     executor) — deferred to the D6 redesign.
+        enforce_materialized_rows(
+            &intermediate_results,
+            self.max_result_bytes,
+            self.max_result_rows,
+        )?;
 
         let total_rows = intermediate_results.len() as u64;
 
@@ -629,42 +612,13 @@ impl SelectExecutor {
     /// `evaluate_predicates`, which are shared with the streaming background
     /// task to keep the two execution paths in lockstep.
     ///
-    /// Issue #1582 (D6): a running byte estimate ([`estimate_query_row_bytes`]) is
-    /// accumulated as rows are collected and fails fast with
-    /// [`Error::ResultTooLarge`] once the configured budget is crossed, so an
-    /// oversized result is rejected with an actionable message (add `LIMIT` /
-    /// stream) rather than silently materializing an unbounded `Vec`.
-    ///
-    /// `collect_bound` (FINDING 2 + roborev FINDING B) bounds the MATCHING
-    /// (post-predicate) rows: `Some(ScanCollectBound { count, offset })` when the
-    /// caller determined the plan's post-scan steps cannot reorder or drop rows.
-    /// The scan then SKIPS the first `offset` matching rows WITHOUT pushing them
-    /// or charging their bytes, and collects the next `count` — exactly what a
-    /// later LIMIT keeps. Skipping the offset rows uncharged means a small final
-    /// result never fails `ResultTooLarge` because the discarded offset rows were
-    /// wide. The skip counts only rows that PASSED `evaluate_predicates`, composing
-    /// with FINDING 1 (a raw pre-predicate skip would drop matching rows).
-    ///
-    /// FINDING 1: `collect_bound` is pushed into the underlying `storage.scan`
-    /// `limit` ONLY for a pure unfiltered scan (no executor-side predicate to
-    /// evaluate). `storage.scan` is not predicate-aware, so pushing the bound when
-    /// this step carries folded predicates (e.g. `WHERE non_pk_col = ?`, which the
-    /// optimizer places in `predicates` WITHOUT a residual `Filter`) would return
-    /// only the first `offset + count` RAW rows and silently drop matching rows
-    /// further along the scan. The executor-side early-stop remains correct in both
-    /// cases because it counts only rows that already passed the predicate. Also,
-    /// a `count == 0` bound (LIMIT 0) short-circuits to an empty result before any
-    /// scan or budget work on every path (targeted, multi-targeted, fallback).
-    ///
-    /// NOTE (FINDING 1 / peak memory): the underlying `storage.scan` still
-    /// materializes each SSTable's matching rows via the reader's index path before
-    /// this method sees them, so for an UNBOUNDED (`collect_bound == None`)
-    /// full scan the byte guard here is a fail-fast ceiling, not a peak-memory
-    /// bound. The only incremental primitive (`scan_stream`) does not read
-    /// CQLite-written single-generation SSTables (it returns zero rows via the
-    /// non-index block path), so it is not a drop-in for this materializing path;
-    /// truly bounding peak for an unbounded scan needs an index/BTI-aware
-    /// incremental reader scan — tracked as a follow-up, out of scope for #1582.
+    /// Issue #1582 (D6, narrow subset): this scan NO LONGER applies any
+    /// byte/row budget or LIMIT/OFFSET pushdown itself. It materializes the
+    /// predicate-matching rows and returns them; the single byte/row budget check
+    /// is applied ONCE by [`SelectExecutor::execute`] on the FINAL result, after
+    /// the whole step pipeline. `storage.scan` receives no query-derived row limit
+    /// (its `limit` argument stays `None`), so a `WHERE non_pk = ? LIMIT N` cannot
+    /// silently drop matching rows past the first N raw rows.
     #[cfg_attr(feature = "tombstones", allow(unused_variables))]
     pub(super) async fn execute_sstable_scan(
         &self,
@@ -675,92 +629,13 @@ impl SelectExecutor {
         // Issue #1587 (E5): schema resolved ONCE per query by the caller and
         // shared by reference — no per-scan registry lock + deep clone.
         schema_opt: Option<&TableSchema>,
-        // Issue #1582 (FINDING 2 + roborev FINDING B): early-stop bound
-        // (count + uncharged offset skip) when the plan permits it, else None.
-        // See the method doc.
-        collect_bound: Option<ScanCollectBound>,
-        // Issue #1582 (D6): the plan carries a query-wide `LIMIT 0` execution step.
-        // Unlike `collect_bound`, this is set even when a reordering/reducing step
-        // (`Sort`/`Filter`/`Aggregate`/`PerPartitionLimit`) forced
-        // `compute_scan_collect_bound` to `None`, so a `... ORDER BY ck LIMIT 0`
-        // query still short-circuits to empty instead of scanning a wide partition.
-        query_wide_limit_zero: bool,
         context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
         // FINDING 2 (Issue #955 follow-up): a `token(...)` predicate is evaluated
         // by hashing the row's raw partition key, so its argument columns MUST be
         // the full partition key in declared order or the result is silently
-        // wrong. Reject (Cassandra-style) BEFORE the LIMIT-0 short-circuits below
-        // (roborev, issue #1582): an invalid `token(...)` restriction is a query
-        // error the caller must see even when the query-wide limit is zero — a
-        // LIMIT-0 fast path must never swallow predicate validation.
+        // wrong. Reject (Cassandra-style) before scanning/evaluating.
         validate_token_predicates(predicates, schema_opt)?;
-
-        // Issue #1582 (D6): a query-wide `LIMIT 0` collects nothing regardless of
-        // the plan shape. When a reordering/reducing step made `collect_bound`
-        // `None`, the `collect_bound == Some(0)` short-circuit below cannot fire —
-        // return empty here BEFORE any scan/lookup/budget work so the scan never
-        // materializes a wide partition and raises `ResultTooLarge` on a LIMIT-0
-        // query. An empty result is correct: LIMIT 0 is empty regardless of ordering.
-        if query_wide_limit_zero {
-            return Ok(Vec::new());
-        }
-
-        // Issue #1582 (FINDING 2): a LIMIT 0 collects nothing. Short-circuit
-        // BEFORE any scan, lookup, row build, predicate eval, push, or byte-budget
-        // work on EVERY path (targeted, multi-targeted, fallback scan). Besides
-        // being the correct empty result, this stops the targeted/wide path from
-        // pushing a first matching row and byte-checking it — which could raise
-        // `ResultTooLarge` instead of returning empty. A `count == 0` bound is set
-        // only when the plan's post-scan steps cannot reorder/drop rows, so an
-        // empty result is result-preserving here (LIMIT 0 is empty regardless of
-        // any OFFSET).
-        if matches!(collect_bound, Some(b) if b.count == 0) {
-            return Ok(Vec::new());
-        }
-
-        // roborev FINDING B: number of leading MATCHING rows to skip uncharged
-        // (the OFFSET) and the number of matching rows to RETURN (the LIMIT).
-        // `None` when the plan disallows early-stop → skip nothing, collect all.
-        let skip_count = collect_bound.map(|b| b.offset).unwrap_or(0);
-        let take_count = collect_bound.map(|b| b.count);
-        let mut skipped: usize = 0;
-
-        // Issue #1582 (FINDING 1): the underlying `storage.scan` /
-        // `scan_with_cell_metadata` receive a `None` key range and are NOT
-        // predicate-aware, so any `SSTableScan` predicate (e.g. `WHERE
-        // non_pk_col = ?`, which the optimizer folds INTO this step's `predicates`
-        // WITHOUT a residual `Filter`) is enforced ONLY by the per-row
-        // `evaluate_predicates` below. Pushing `offset + count` into storage before
-        // that evaluation would return just the first `offset + count` RAW
-        // (unfiltered) rows and silently drop matching rows further along the scan
-        // → WRONG RESULTS. So push a storage-layer row limit ONLY for a pure
-        // unfiltered scan (no executor-side predicate to evaluate). When unsure
-        // whether storage enforces a pushed predicate, treat it as NOT enforced.
-        // The executor-side early-stop (below) stays safe in BOTH cases: it stops
-        // only after a row has passed `evaluate_predicates`.
-        // For a pure unfiltered scan, storage must still yield offset + count raw
-        // rows (all of which match) so the executor can skip `offset` and return
-        // `count`. roborev FINDING B: the offset rows are skipped uncharged AFTER
-        // storage returns them; `storage.scan` is not predicate-aware, so this
-        // push is withheld the moment executor-side predicates exist.
-        let storage_limit = if predicates.is_empty() {
-            collect_bound.map(|b| b.offset.saturating_add(b.count))
-        } else {
-            None
-        };
-
-        // Issue #1582 (D6): a ROW COUNT is the wrong unit for a memory guard —
-        // 1M skinny rows may fit while a few thousand wide rows blow the <128MB
-        // target. The primary guard is a running BYTE estimate (below) against
-        // the configured budget; the row count remains only as a secondary
-        // safety valve, sourced from the load-bearing `max_result_rows` config
-        // knob (roborev FINDING A — NOT a hardcoded constant).
-        let max_rows = self.max_result_rows;
-        let byte_budget = self.max_result_bytes;
-        // Running estimate of the materialized result's logical size, accumulated
-        // with the SAME estimator the row cache uses (issue #1582).
-        let mut result_bytes: usize = 0;
 
         log::info!(
             "Executing SSTableScan: table=\"{}\", predicates={:?}, include_cell_metadata={}",
@@ -784,9 +659,6 @@ impl SelectExecutor {
                 table_name
             ),
         }
-
-        // (token-predicate validation now runs at the top of this method, before
-        // the LIMIT-0 short-circuits — see the comment there.)
 
         // Issue #693: When WRITETIME(col) or TTL(col) is in the SELECT, use the
         // metadata-carrying scan so per-cell timestamps reach the QueryRow.
@@ -832,14 +704,8 @@ impl SelectExecutor {
                     };
                     context.access_path = Some(metadata_path.clone());
                     crate::query::access_path::record(metadata_path);
-                    // Issue #1582 (FINDING 1): push the LIMIT bound into the
-                    // metadata scan ONLY for a pure unfiltered scan (`storage_limit`
-                    // is `None` when executor-side predicates must still run — see
-                    // the non-metadata Fallback arm and the `storage_limit`
-                    // derivation above). The executor-side early-stop below still
-                    // bounds collection after predicate evaluation.
                     self.storage
-                        .scan_with_cell_metadata(table, None, None, storage_limit, schema_opt)
+                        .scan_with_cell_metadata(table, None, None, None, schema_opt)
                         .await?
                 }
             };
@@ -860,31 +726,7 @@ impl SelectExecutor {
                 }
 
                 if evaluate_predicates(&row, predicates)? {
-                    // roborev FINDING B: skip the first `offset` MATCHING rows
-                    // uncharged — never push them nor add their bytes — so an
-                    // OFFSET's discarded rows cannot trip the byte budget.
-                    if skipped < skip_count {
-                        skipped += 1;
-                        continue;
-                    }
-                    result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
-                    enforce_result_budget(&results, result_bytes, byte_budget, max_rows)?;
-                    // FINDING 2: early-stop at the LIMIT (`count`) bound where safe.
-                    // NOTE (FINDING 1 scope): the metadata (WRITETIME/TTL) full-scan
-                    // fallback above materializes via `scan_with_cell_metadata`
-                    // because there is no streaming metadata scan yet — the byte
-                    // guard here still fails-fast on the collected result, and the
-                    // early-stop avoids building surplus rows, but the underlying
-                    // metadata scan is not incrementally bounded. A streaming
-                    // metadata scan (the metadata analog of `scan_stream`) is a
-                    // documented follow-up; the dominant, unbounded risk is the
-                    // non-metadata full scan, which IS bounded above.
-                    if let Some(bound) = take_count {
-                        if results.len() >= bound {
-                            break;
-                        }
-                    }
                 }
             }
         } else {
@@ -978,18 +820,11 @@ impl SelectExecutor {
                     // Issue #960: report the honest reason a full scan was chosen.
                     context.access_path = Some(AccessPath::FallbackFullScan { reason });
                     crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
-                    // Issue #1582 (FINDING 1): push the query-wide LIMIT bound
-                    // (offset + count) INTO the scan ONLY for a pure unfiltered scan
-                    // (`storage_limit`). `storage.scan` is not predicate-aware, so
-                    // when this step carries executor-evaluated predicates
-                    // `storage_limit` is `None` — pushing a raw-row limit ahead of
-                    // `evaluate_predicates` would drop matching rows past the first
-                    // `offset + count` RAW rows. The executor-side early-stop below
-                    // still bounds collection after predicate evaluation, so a
-                    // LIMITed query is served without the byte budget biting on
-                    // matching rows beyond the limit.
+                    // Issue #1582 (D6, narrow subset): no query-derived row limit
+                    // is pushed into the predicate-unaware `storage.scan` — the sole
+                    // budget check is applied once on the FINAL result in `execute`.
                     self.storage
-                        .scan(table, None, None, storage_limit, schema_opt)
+                        .scan(table, None, None, None, schema_opt)
                         .await?
                 }
             };
@@ -1006,24 +841,7 @@ impl SelectExecutor {
                 };
 
                 if evaluate_predicates(&row, predicates)? {
-                    // roborev FINDING B: skip the first `offset` MATCHING rows
-                    // uncharged — never push them nor add their bytes — so an
-                    // OFFSET's discarded rows cannot trip the byte budget.
-                    if skipped < skip_count {
-                        skipped += 1;
-                        continue;
-                    }
-                    result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
-                    enforce_result_budget(&results, result_bytes, byte_budget, max_rows)?;
-                    // FINDING 2: the targeted / multi-partition paths return a Vec
-                    // already bounded by the partition(s); early-stop at `count`
-                    // still avoids building rows a later LIMIT would discard.
-                    if let Some(bound) = take_count {
-                        if results.len() >= bound {
-                            break;
-                        }
-                    }
                 }
             }
         }
@@ -1031,58 +849,3 @@ impl SelectExecutor {
         Ok(results)
     }
 }
-
-/// Early-stop collection bound for the materializing scan (issue #1582).
-///
-/// `count` is the number of MATCHING (post-predicate) rows the scan RETURNS —
-/// the LIMIT — and `offset` is the number of leading matching rows the scan
-/// SKIPS (the OFFSET) WITHOUT pushing them or charging their bytes to the budget
-/// (roborev FINDING B). Skipping the offset rows uncharged means a small final
-/// result never fails `ResultTooLarge` merely because the discarded offset rows
-/// were wide.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ScanCollectBound {
-    /// LIMIT: matching rows to collect + return after the offset skip.
-    count: usize,
-    /// OFFSET: leading matching rows to skip, uncharged, before collecting.
-    offset: usize,
-}
-
-/// Compute the early-stop collection bound for the materializing scan (issue
-/// #1582 / FINDING 2 + roborev FINDING B).
-///
-/// Returns `Some(ScanCollectBound { count, offset })` ONLY when the plan's
-/// post-scan steps are limited to `Limit` and `Project`, i.e. no step (`Sort`,
-/// `PerPartitionLimit`, `Aggregate`, `Filter`) can reorder or drop rows. In that
-/// case the scan may skip the first `offset` matching rows uncharged and collect
-/// the next `count` — exactly the set a later `Limit { count, offset }` keeps —
-/// so early-stopping is result-preserving AND keeps the byte budget from tripping
-/// on the skipped offset rows or on matching rows beyond the limit. Because the
-/// scan then fully applies the LIMIT/OFFSET, the caller neutralizes the OFFSET in
-/// the downstream `Limit` step (it re-applying the offset would drop the first
-/// `offset` of the already-offset rows). Any other step returns `None` (collect
-/// the full, still byte-budget-bounded result). Absent a `Limit`, returns `None`.
-fn compute_scan_collect_bound(steps: &[ExecutionStep]) -> Option<ScanCollectBound> {
-    let mut bound: Option<ScanCollectBound> = None;
-    for step in steps {
-        match step {
-            ExecutionStep::SSTableScan { .. } | ExecutionStep::Project { .. } => {}
-            ExecutionStep::Limit { count, offset } => {
-                // `count`/`offset` are u64; saturate into usize for the in-memory
-                // collection bounds.
-                bound = Some(ScanCollectBound {
-                    count: usize::try_from(*count).unwrap_or(usize::MAX),
-                    offset: usize::try_from(offset.unwrap_or(0)).unwrap_or(usize::MAX),
-                });
-            }
-            // Any other step may reorder or drop rows; early-stopping the scan
-            // at the raw match count would then yield the wrong result set.
-            _ => return None,
-        }
-    }
-    bound
-}
-
-// The byte-budget estimator + enforcement live in `crate::query::result_budget`
-// (shared verbatim with the legacy engine point-lookup path, issue #1582 / D6);
-// this module reuses them via the `use` alias below rather than forking the logic.

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -680,8 +680,9 @@ impl SelectExecutor {
         // 1M skinny rows may fit while a few thousand wide rows blow the <128MB
         // target. The primary guard is a running BYTE estimate (below) against
         // the configured budget; the row count remains only as a secondary
-        // safety valve.
-        const MAX_RESULTS: usize = 1_000_000;
+        // safety valve, sourced from the load-bearing `max_result_rows` config
+        // knob (roborev FINDING A — NOT a hardcoded constant).
+        let max_rows = self.max_result_rows;
         let byte_budget = self.max_result_bytes;
         // Running estimate of the materialized result's logical size, accumulated
         // with the SAME estimator the row cache uses (issue #1582).
@@ -790,7 +791,7 @@ impl SelectExecutor {
                 if evaluate_predicates(&row, predicates)? {
                     result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
-                    enforce_result_budget(&results, result_bytes, byte_budget, MAX_RESULTS)?;
+                    enforce_result_budget(&results, result_bytes, byte_budget, max_rows)?;
                     // FINDING 2: early-stop at the LIMIT bound where safe. NOTE
                     // (FINDING 1 scope): the metadata (WRITETIME/TTL) full-scan
                     // fallback above materializes via `scan_with_cell_metadata`
@@ -929,7 +930,7 @@ impl SelectExecutor {
                 if evaluate_predicates(&row, predicates)? {
                     result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
-                    enforce_result_budget(&results, result_bytes, byte_budget, MAX_RESULTS)?;
+                    enforce_result_budget(&results, result_bytes, byte_budget, max_rows)?;
                     // FINDING 2: the targeted / multi-partition paths return a Vec
                     // already bounded by the partition(s); early-stop still avoids
                     // building rows a later LIMIT would discard.

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -188,8 +188,26 @@ impl SelectExecutor {
                         Self::execute_per_partition_limit(intermediate_results, *count);
                 }
                 ExecutionStep::Limit { count, offset } => {
-                    intermediate_results =
-                        self.execute_limit(intermediate_results, *count, *offset, &mut context)?;
+                    // roborev FINDING B: when the materializing scan early-stopped
+                    // (`scan_collect_bound` is `Some`), it ALREADY applied this
+                    // LIMIT's OFFSET — skipping the leading matching rows uncharged
+                    // and collecting only `count`. Re-applying the OFFSET here would
+                    // wrongly drop the first `offset` of the already-offset rows, so
+                    // pass `None`: this step then only truncates to `count` (a
+                    // safety net; the scan already bounded the row count). When
+                    // early-stop was disallowed (`None`), the OFFSET is applied here
+                    // as before.
+                    let effective_offset = if scan_collect_bound.is_some() {
+                        None
+                    } else {
+                        *offset
+                    };
+                    intermediate_results = self.execute_limit(
+                        intermediate_results,
+                        *count,
+                        effective_offset,
+                        &mut context,
+                    )?;
                 }
                 ExecutionStep::Project { columns } => {
                     intermediate_results =
@@ -602,13 +620,15 @@ impl SelectExecutor {
     /// oversized result is rejected with an actionable message (add `LIMIT` /
     /// stream) rather than silently materializing an unbounded `Vec`.
     ///
-    /// `collect_bound` (FINDING 2) is the max number of MATCHING (post-predicate)
-    /// rows to collect — `Some(offset + count)` when the caller determined the
-    /// plan's post-scan steps cannot reorder or drop rows (so the first
-    /// `offset + count` matches are exactly what a later LIMIT keeps), else `None`.
-    /// It is used to early-stop collection AFTER per-row `evaluate_predicates`, so a
-    /// LIMITed query completes without the byte budget biting on matching rows
-    /// beyond the limit.
+    /// `collect_bound` (FINDING 2 + roborev FINDING B) bounds the MATCHING
+    /// (post-predicate) rows: `Some(ScanCollectBound { count, offset })` when the
+    /// caller determined the plan's post-scan steps cannot reorder or drop rows.
+    /// The scan then SKIPS the first `offset` matching rows WITHOUT pushing them
+    /// or charging their bytes, and collects the next `count` — exactly what a
+    /// later LIMIT keeps. Skipping the offset rows uncharged means a small final
+    /// result never fails `ResultTooLarge` because the discarded offset rows were
+    /// wide. The skip counts only rows that PASSED `evaluate_predicates`, composing
+    /// with FINDING 1 (a raw pre-predicate skip would drop matching rows).
     ///
     /// FINDING 1: `collect_bound` is pushed into the underlying `storage.scan`
     /// `limit` ONLY for a pure unfiltered scan (no executor-side predicate to
@@ -618,8 +638,8 @@ impl SelectExecutor {
     /// only the first `offset + count` RAW rows and silently drop matching rows
     /// further along the scan. The executor-side early-stop remains correct in both
     /// cases because it counts only rows that already passed the predicate. Also,
-    /// `collect_bound == Some(0)` short-circuits to an empty result before any scan
-    /// or budget work on every path (targeted, multi-targeted, fallback).
+    /// a `count == 0` bound (LIMIT 0) short-circuits to an empty result before any
+    /// scan or budget work on every path (targeted, multi-targeted, fallback).
     ///
     /// NOTE (FINDING 1 / peak memory): the underlying `storage.scan` still
     /// materializes each SSTable's matching rows via the reader's index path before
@@ -640,9 +660,10 @@ impl SelectExecutor {
         // Issue #1587 (E5): schema resolved ONCE per query by the caller and
         // shared by reference — no per-scan registry lock + deep clone.
         schema_opt: Option<&TableSchema>,
-        // Issue #1582 (FINDING 2): early-stop bound (offset + count) when the plan
-        // permits it, else None. See the method doc.
-        collect_bound: Option<usize>,
+        // Issue #1582 (FINDING 2 + roborev FINDING B): early-stop bound
+        // (count + uncharged offset skip) when the plan permits it, else None.
+        // See the method doc.
+        collect_bound: Option<ScanCollectBound>,
         context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
         // Issue #1582 (FINDING 2): a LIMIT 0 collects nothing. Short-circuit
@@ -650,12 +671,20 @@ impl SelectExecutor {
         // work on EVERY path (targeted, multi-targeted, fallback scan). Besides
         // being the correct empty result, this stops the targeted/wide path from
         // pushing a first matching row and byte-checking it — which could raise
-        // `ResultTooLarge` instead of returning empty. `collect_bound` is `Some(0)`
+        // `ResultTooLarge` instead of returning empty. A `count == 0` bound is set
         // only when the plan's post-scan steps cannot reorder/drop rows, so an
-        // empty result is result-preserving here.
-        if collect_bound == Some(0) {
+        // empty result is result-preserving here (LIMIT 0 is empty regardless of
+        // any OFFSET).
+        if matches!(collect_bound, Some(b) if b.count == 0) {
             return Ok(Vec::new());
         }
+
+        // roborev FINDING B: number of leading MATCHING rows to skip uncharged
+        // (the OFFSET) and the number of matching rows to RETURN (the LIMIT).
+        // `None` when the plan disallows early-stop → skip nothing, collect all.
+        let skip_count = collect_bound.map(|b| b.offset).unwrap_or(0);
+        let take_count = collect_bound.map(|b| b.count);
+        let mut skipped: usize = 0;
 
         // Issue #1582 (FINDING 1): the underlying `storage.scan` /
         // `scan_with_cell_metadata` receive a `None` key range and are NOT
@@ -670,8 +699,13 @@ impl SelectExecutor {
         // whether storage enforces a pushed predicate, treat it as NOT enforced.
         // The executor-side early-stop (below) stays safe in BOTH cases: it stops
         // only after a row has passed `evaluate_predicates`.
+        // For a pure unfiltered scan, storage must still yield offset + count raw
+        // rows (all of which match) so the executor can skip `offset` and return
+        // `count`. roborev FINDING B: the offset rows are skipped uncharged AFTER
+        // storage returns them; `storage.scan` is not predicate-aware, so this
+        // push is withheld the moment executor-side predicates exist.
         let storage_limit = if predicates.is_empty() {
-            collect_bound
+            collect_bound.map(|b| b.offset.saturating_add(b.count))
         } else {
             None
         };
@@ -789,11 +823,18 @@ impl SelectExecutor {
                 }
 
                 if evaluate_predicates(&row, predicates)? {
+                    // roborev FINDING B: skip the first `offset` MATCHING rows
+                    // uncharged — never push them nor add their bytes — so an
+                    // OFFSET's discarded rows cannot trip the byte budget.
+                    if skipped < skip_count {
+                        skipped += 1;
+                        continue;
+                    }
                     result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
                     enforce_result_budget(&results, result_bytes, byte_budget, max_rows)?;
-                    // FINDING 2: early-stop at the LIMIT bound where safe. NOTE
-                    // (FINDING 1 scope): the metadata (WRITETIME/TTL) full-scan
+                    // FINDING 2: early-stop at the LIMIT (`count`) bound where safe.
+                    // NOTE (FINDING 1 scope): the metadata (WRITETIME/TTL) full-scan
                     // fallback above materializes via `scan_with_cell_metadata`
                     // because there is no streaming metadata scan yet — the byte
                     // guard here still fails-fast on the collected result, and the
@@ -802,7 +843,7 @@ impl SelectExecutor {
                     // metadata scan (the metadata analog of `scan_stream`) is a
                     // documented follow-up; the dominant, unbounded risk is the
                     // non-metadata full scan, which IS bounded above.
-                    if let Some(bound) = collect_bound {
+                    if let Some(bound) = take_count {
                         if results.len() >= bound {
                             break;
                         }
@@ -928,13 +969,20 @@ impl SelectExecutor {
                 };
 
                 if evaluate_predicates(&row, predicates)? {
+                    // roborev FINDING B: skip the first `offset` MATCHING rows
+                    // uncharged — never push them nor add their bytes — so an
+                    // OFFSET's discarded rows cannot trip the byte budget.
+                    if skipped < skip_count {
+                        skipped += 1;
+                        continue;
+                    }
                     result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
                     enforce_result_budget(&results, result_bytes, byte_budget, max_rows)?;
                     // FINDING 2: the targeted / multi-partition paths return a Vec
-                    // already bounded by the partition(s); early-stop still avoids
-                    // building rows a later LIMIT would discard.
-                    if let Some(bound) = collect_bound {
+                    // already bounded by the partition(s); early-stop at `count`
+                    // still avoids building rows a later LIMIT would discard.
+                    if let Some(bound) = take_count {
                         if results.len() >= bound {
                             break;
                         }
@@ -947,27 +995,48 @@ impl SelectExecutor {
     }
 }
 
-/// Compute the early-stop collection bound for the materializing scan (issue
-/// #1582 / FINDING 2).
+/// Early-stop collection bound for the materializing scan (issue #1582).
 ///
-/// Returns `Some(offset + count)` — the number of matching rows the scan may
-/// collect before stopping — ONLY when the plan's post-scan steps are limited to
-/// `Limit` and `Project`, i.e. no step (`Sort`, `PerPartitionLimit`, `Aggregate`,
-/// `Filter`) can reorder or drop rows. In that case the first `offset + count`
-/// matching rows are exactly the set a later `Limit { count, offset }` keeps, so
-/// early-stopping is result-preserving AND prevents the byte budget from tripping
-/// on matching rows beyond the limit. Any other step returns `None` (collect the
-/// full, still byte-budget-bounded result). Absent a `Limit`, returns `None`.
-fn compute_scan_collect_bound(steps: &[ExecutionStep]) -> Option<usize> {
-    let mut bound: Option<usize> = None;
+/// `count` is the number of MATCHING (post-predicate) rows the scan RETURNS —
+/// the LIMIT — and `offset` is the number of leading matching rows the scan
+/// SKIPS (the OFFSET) WITHOUT pushing them or charging their bytes to the budget
+/// (roborev FINDING B). Skipping the offset rows uncharged means a small final
+/// result never fails `ResultTooLarge` merely because the discarded offset rows
+/// were wide.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ScanCollectBound {
+    /// LIMIT: matching rows to collect + return after the offset skip.
+    count: usize,
+    /// OFFSET: leading matching rows to skip, uncharged, before collecting.
+    offset: usize,
+}
+
+/// Compute the early-stop collection bound for the materializing scan (issue
+/// #1582 / FINDING 2 + roborev FINDING B).
+///
+/// Returns `Some(ScanCollectBound { count, offset })` ONLY when the plan's
+/// post-scan steps are limited to `Limit` and `Project`, i.e. no step (`Sort`,
+/// `PerPartitionLimit`, `Aggregate`, `Filter`) can reorder or drop rows. In that
+/// case the scan may skip the first `offset` matching rows uncharged and collect
+/// the next `count` — exactly the set a later `Limit { count, offset }` keeps —
+/// so early-stopping is result-preserving AND keeps the byte budget from tripping
+/// on the skipped offset rows or on matching rows beyond the limit. Because the
+/// scan then fully applies the LIMIT/OFFSET, the caller neutralizes the OFFSET in
+/// the downstream `Limit` step (it re-applying the offset would drop the first
+/// `offset` of the already-offset rows). Any other step returns `None` (collect
+/// the full, still byte-budget-bounded result). Absent a `Limit`, returns `None`.
+fn compute_scan_collect_bound(steps: &[ExecutionStep]) -> Option<ScanCollectBound> {
+    let mut bound: Option<ScanCollectBound> = None;
     for step in steps {
         match step {
             ExecutionStep::SSTableScan { .. } | ExecutionStep::Project { .. } => {}
             ExecutionStep::Limit { count, offset } => {
-                // `count`/`offset` are u64; saturate the sum into usize for the
-                // in-memory collection bound.
-                let sum = count.saturating_add(offset.unwrap_or(0));
-                bound = Some(usize::try_from(sum).unwrap_or(usize::MAX));
+                // `count`/`offset` are u64; saturate into usize for the in-memory
+                // collection bounds.
+                bound = Some(ScanCollectBound {
+                    count: usize::try_from(*count).unwrap_or(usize::MAX),
+                    offset: usize::try_from(offset.unwrap_or(0)).unwrap_or(usize::MAX),
+                });
             }
             // Any other step may reorder or drop rows; early-stopping the scan
             // at the raw match count would then yield the wrong result set.

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -94,12 +94,25 @@ impl SelectExecutor {
 
         // Handle queries without FROM clause (like SELECT 1)
         if plan.statement.from_clause.is_none() {
-            let result = self.execute_constant_query(&plan.statement, &context)?;
-            // Issue #1582 (roborev): constant queries return BEFORE the final-result
-            // budget check below, so apply the SAME byte + row-count budget to their
-            // materialized rows here — otherwise a large literal result set (many /
-            // large constant expressions) could exceed `max_result_bytes` without
-            // raising `ResultTooLarge`.
+            let mut result = self.execute_constant_query(&plan.statement, &context)?;
+            // Issue #1582 (roborev): apply the statement's LIMIT/OFFSET to the
+            // constant rows BEFORE the byte + row-count budget check, so the budget
+            // is enforced on the rows ACTUALLY returned (post LIMIT/OFFSET) —
+            // consistent with the table-backed path below. In particular `LIMIT 0`
+            // must return empty, never `ResultTooLarge`; an over-budget constant
+            // SELECT with NO limit still trips the guard on its final rows.
+            let offset = plan.statement.offset.unwrap_or(0) as usize;
+            let limit = plan
+                .statement
+                .limit
+                .as_ref()
+                .map(|l| l.count as usize)
+                .unwrap_or(usize::MAX);
+            result.rows = result.rows.into_iter().skip(offset).take(limit).collect();
+            // Keep the row-count metadata consistent with the returned rows.
+            let returned = result.rows.len() as u64;
+            result.rows_affected = returned;
+            result.metadata.total_rows = Some(returned);
             enforce_materialized_rows(&result.rows, self.max_result_bytes, self.max_result_rows)?;
             return Ok(result);
         }

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -687,6 +687,15 @@ impl SelectExecutor {
         query_wide_limit_zero: bool,
         context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
+        // FINDING 2 (Issue #955 follow-up): a `token(...)` predicate is evaluated
+        // by hashing the row's raw partition key, so its argument columns MUST be
+        // the full partition key in declared order or the result is silently
+        // wrong. Reject (Cassandra-style) BEFORE the LIMIT-0 short-circuits below
+        // (roborev, issue #1582): an invalid `token(...)` restriction is a query
+        // error the caller must see even when the query-wide limit is zero — a
+        // LIMIT-0 fast path must never swallow predicate validation.
+        validate_token_predicates(predicates, schema_opt)?;
+
         // Issue #1582 (D6): a query-wide `LIMIT 0` collects nothing regardless of
         // the plan shape. When a reordering/reducing step made `collect_bound`
         // `None`, the `collect_bound == Some(0)` short-circuit below cannot fire —
@@ -776,11 +785,8 @@ impl SelectExecutor {
             ),
         }
 
-        // FINDING 2 (Issue #955 follow-up): a `token(...)` predicate is evaluated
-        // by hashing the row's raw partition key, so its argument columns MUST be
-        // the full partition key in declared order or the result is silently
-        // wrong. Reject (Cassandra-style) before scanning/evaluating.
-        validate_token_predicates(predicates, schema_opt)?;
+        // (token-predicate validation now runs at the top of this method, before
+        // the LIMIT-0 short-circuits — see the comment there.)
 
         // Issue #693: When WRITETIME(col) or TTL(col) is in the SELECT, use the
         // metadata-carrying scan so per-cell timestamps reach the QueryRow.

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -110,6 +110,15 @@ impl SelectExecutor {
             plan.execution_steps.clone()
         };
 
+        // Issue #1582 (FINDING 2): if the plan's only post-scan steps are LIMIT
+        // and projection, the materializing scan may stop collecting once it has
+        // `offset + count` rows — the exact set a later LIMIT keeps — so a LIMITed
+        // query over a wide table is honored WITHOUT the byte budget tripping on
+        // matching rows beyond the limit. Any reordering/reducing step (Sort, PER
+        // PARTITION LIMIT, Aggregate, Filter) makes early-stop unsafe, so the scan
+        // then collects the full (still byte-budget-bounded) result.
+        let scan_collect_bound = compute_scan_collect_bound(&execution_steps);
+
         for step in &execution_steps {
             match step {
                 ExecutionStep::SSTableScan {
@@ -125,6 +134,7 @@ impl SelectExecutor {
                             projection,
                             plan.statement.order_by.as_ref(),
                             query_schema.as_deref(),
+                            scan_collect_bound,
                             &mut context,
                         )
                         .await?;
@@ -585,6 +595,30 @@ impl SelectExecutor {
     /// handled by the free helpers `build_row_from_scan` and
     /// `evaluate_predicates`, which are shared with the streaming background
     /// task to keep the two execution paths in lockstep.
+    ///
+    /// Issue #1582 (D6): a running byte estimate ([`estimate_query_row_bytes`]) is
+    /// accumulated as rows are collected and fails fast with
+    /// [`Error::ResultTooLarge`] once the configured budget is crossed, so an
+    /// oversized result is rejected with an actionable message (add `LIMIT` /
+    /// stream) rather than silently materializing an unbounded `Vec`.
+    ///
+    /// `collect_bound` (FINDING 2) is the max number of matching rows to collect —
+    /// `Some(offset + count)` when the caller determined the plan's post-scan steps
+    /// cannot reorder or drop rows (so the first `offset + count` matches are
+    /// exactly what a later LIMIT keeps), else `None`. It is propagated into the
+    /// underlying scan's `limit` AND used to early-stop collection, so a LIMITed
+    /// query completes without the byte budget biting on matching rows beyond the
+    /// limit.
+    ///
+    /// NOTE (FINDING 1 / peak memory): the underlying `storage.scan` still
+    /// materializes each SSTable's matching rows via the reader's index path before
+    /// this method sees them, so for an UNBOUNDED (`collect_bound == None`)
+    /// full scan the byte guard here is a fail-fast ceiling, not a peak-memory
+    /// bound. The only incremental primitive (`scan_stream`) does not read
+    /// CQLite-written single-generation SSTables (it returns zero rows via the
+    /// non-index block path), so it is not a drop-in for this materializing path;
+    /// truly bounding peak for an unbounded scan needs an index/BTI-aware
+    /// incremental reader scan — tracked as a follow-up, out of scope for #1582.
     #[cfg_attr(feature = "tombstones", allow(unused_variables))]
     pub(super) async fn execute_sstable_scan(
         &self,
@@ -595,6 +629,9 @@ impl SelectExecutor {
         // Issue #1587 (E5): schema resolved ONCE per query by the caller and
         // shared by reference — no per-scan registry lock + deep clone.
         schema_opt: Option<&TableSchema>,
+        // Issue #1582 (FINDING 2): early-stop bound (offset + count) when the plan
+        // permits it, else None. See the method doc.
+        collect_bound: Option<usize>,
         context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
         // Issue #1582 (D6): a ROW COUNT is the wrong unit for a memory guard —
@@ -681,8 +718,10 @@ impl SelectExecutor {
                     };
                     context.access_path = Some(metadata_path.clone());
                     crate::query::access_path::record(metadata_path);
+                    // Issue #1582 (FINDING 2): propagate the LIMIT bound into the
+                    // metadata scan too (see the non-metadata Fallback arm).
                     self.storage
-                        .scan_with_cell_metadata(table, None, None, None, schema_opt)
+                        .scan_with_cell_metadata(table, None, None, collect_bound, schema_opt)
                         .await?
                 }
             };
@@ -706,6 +745,21 @@ impl SelectExecutor {
                     result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
                     enforce_result_budget(&results, result_bytes, byte_budget, MAX_RESULTS)?;
+                    // FINDING 2: early-stop at the LIMIT bound where safe. NOTE
+                    // (FINDING 1 scope): the metadata (WRITETIME/TTL) full-scan
+                    // fallback above materializes via `scan_with_cell_metadata`
+                    // because there is no streaming metadata scan yet — the byte
+                    // guard here still fails-fast on the collected result, and the
+                    // early-stop avoids building surplus rows, but the underlying
+                    // metadata scan is not incrementally bounded. A streaming
+                    // metadata scan (the metadata analog of `scan_stream`) is a
+                    // documented follow-up; the dominant, unbounded risk is the
+                    // non-metadata full scan, which IS bounded above.
+                    if let Some(bound) = collect_bound {
+                        if results.len() >= bound {
+                            break;
+                        }
+                    }
                 }
             }
         } else {
@@ -799,8 +853,14 @@ impl SelectExecutor {
                     // Issue #960: report the honest reason a full scan was chosen.
                     context.access_path = Some(AccessPath::FallbackFullScan { reason });
                     crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
+                    // Issue #1582 (FINDING 2): propagate the query-wide LIMIT bound
+                    // (offset + count) INTO the scan so it materializes only that
+                    // many rows and the multi-generation reconcile merge early-exits
+                    // — a LIMITed query is served without the byte budget biting on
+                    // matching rows beyond the limit. `collect_bound` is `Some` only
+                    // when the plan's post-scan steps cannot reorder/drop rows.
                     self.storage
-                        .scan(table, None, None, None, schema_opt)
+                        .scan(table, None, None, collect_bound, schema_opt)
                         .await?
                 }
             };
@@ -820,12 +880,50 @@ impl SelectExecutor {
                     result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
                     enforce_result_budget(&results, result_bytes, byte_budget, MAX_RESULTS)?;
+                    // FINDING 2: the targeted / multi-partition paths return a Vec
+                    // already bounded by the partition(s); early-stop still avoids
+                    // building rows a later LIMIT would discard.
+                    if let Some(bound) = collect_bound {
+                        if results.len() >= bound {
+                            break;
+                        }
+                    }
                 }
             }
         }
 
         Ok(results)
     }
+}
+
+/// Compute the early-stop collection bound for the materializing scan (issue
+/// #1582 / FINDING 2).
+///
+/// Returns `Some(offset + count)` — the number of matching rows the scan may
+/// collect before stopping — ONLY when the plan's post-scan steps are limited to
+/// `Limit` and `Project`, i.e. no step (`Sort`, `PerPartitionLimit`, `Aggregate`,
+/// `Filter`) can reorder or drop rows. In that case the first `offset + count`
+/// matching rows are exactly the set a later `Limit { count, offset }` keeps, so
+/// early-stopping is result-preserving AND prevents the byte budget from tripping
+/// on matching rows beyond the limit. Any other step returns `None` (collect the
+/// full, still byte-budget-bounded result). Absent a `Limit`, returns `None`.
+fn compute_scan_collect_bound(steps: &[ExecutionStep]) -> Option<usize> {
+    let mut bound: Option<usize> = None;
+    for step in steps {
+        match step {
+            ExecutionStep::SSTableScan { .. } | ExecutionStep::Project { .. } => {}
+            ExecutionStep::Limit { count, offset } => {
+                // `count`/`offset` are u64; saturate the sum into usize for the
+                // in-memory collection bound.
+                let sum = count.saturating_add(offset.unwrap_or(0));
+                bound = Some(usize::try_from(sum).unwrap_or(usize::MAX));
+            }
+            // Any other step may reorder or drop rows; early-stopping the scan
+            // at the raw match count would then yield the wrong result set.
+            _ => return None,
+        }
+    }
+    bound
 }
 
 /// Estimate the logical size, in bytes, of a materialized [`QueryRow`], reusing

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -94,7 +94,14 @@ impl SelectExecutor {
 
         // Handle queries without FROM clause (like SELECT 1)
         if plan.statement.from_clause.is_none() {
-            return self.execute_constant_query(&plan.statement, &context);
+            let result = self.execute_constant_query(&plan.statement, &context)?;
+            // Issue #1582 (roborev): constant queries return BEFORE the final-result
+            // budget check below, so apply the SAME byte + row-count budget to their
+            // materialized rows here — otherwise a large literal result set (many /
+            // large constant expressions) could exceed `max_result_bytes` without
+            // raising `ResultTooLarge`.
+            enforce_materialized_rows(&result.rows, self.max_result_bytes, self.max_result_rows)?;
+            return Ok(result);
         }
 
         // Execute the plan step by step

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -120,6 +120,19 @@ impl SelectExecutor {
         // then collects the full (still byte-budget-bounded) result.
         let scan_collect_bound = compute_scan_collect_bound(&execution_steps);
 
+        // Issue #1582 (D6): a query-wide `LIMIT 0` ALWAYS yields an empty result.
+        // `compute_scan_collect_bound` returns `None` whenever the plan carries a
+        // reordering/reducing step (`Sort`, `Filter`, `Aggregate`,
+        // `PerPartitionLimit`), so the `collect_bound == Some(0)` short-circuit in
+        // `execute_sstable_scan` never fires for e.g. `... ORDER BY ck LIMIT 0` —
+        // the scan would then materialize the full (possibly wide) partition and
+        // could raise `ResultTooLarge`. Detect the actual `ExecutionStep::Limit`
+        // count == 0 here and signal the scan to return empty before collecting,
+        // independent of the collect bound (matching the other LIMIT-0 short-circuits).
+        let query_wide_limit_zero = execution_steps
+            .iter()
+            .any(|step| matches!(step, ExecutionStep::Limit { count: 0, .. }));
+
         for step in &execution_steps {
             match step {
                 ExecutionStep::SSTableScan {
@@ -136,6 +149,7 @@ impl SelectExecutor {
                             plan.statement.order_by.as_ref(),
                             query_schema.as_deref(),
                             scan_collect_bound,
+                            query_wide_limit_zero,
                             &mut context,
                         )
                         .await?;
@@ -665,8 +679,24 @@ impl SelectExecutor {
         // (count + uncharged offset skip) when the plan permits it, else None.
         // See the method doc.
         collect_bound: Option<ScanCollectBound>,
+        // Issue #1582 (D6): the plan carries a query-wide `LIMIT 0` execution step.
+        // Unlike `collect_bound`, this is set even when a reordering/reducing step
+        // (`Sort`/`Filter`/`Aggregate`/`PerPartitionLimit`) forced
+        // `compute_scan_collect_bound` to `None`, so a `... ORDER BY ck LIMIT 0`
+        // query still short-circuits to empty instead of scanning a wide partition.
+        query_wide_limit_zero: bool,
         context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
+        // Issue #1582 (D6): a query-wide `LIMIT 0` collects nothing regardless of
+        // the plan shape. When a reordering/reducing step made `collect_bound`
+        // `None`, the `collect_bound == Some(0)` short-circuit below cannot fire —
+        // return empty here BEFORE any scan/lookup/budget work so the scan never
+        // materializes a wide partition and raises `ResultTooLarge` on a LIMIT-0
+        // query. An empty result is correct: LIMIT 0 is empty regardless of ordering.
+        if query_wide_limit_zero {
+            return Ok(Vec::new());
+        }
+
         // Issue #1582 (FINDING 2): a LIMIT 0 collects nothing. Short-circuit
         // BEFORE any scan, lookup, row build, predicate eval, push, or byte-budget
         // work on EVERY path (targeted, multi-targeted, fallback scan). Besides

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -19,10 +19,11 @@ use super::{
     sort_rows_by_token, validate_token_predicates, PartitionLookupOutcome, SSTablePredicate,
 };
 use super::{
-    AccessPath, ColumnInfo, Error, ExecutionContext, ExecutionStep, FallbackReason,
-    OptimizedQueryPlan, ProjectionFlags, QueryResult, QueryRow, Result, SelectExecutor,
-    StorageEngine, TableId, TableSchema,
+    AccessPath, ColumnInfo, ExecutionContext, ExecutionStep, FallbackReason, OptimizedQueryPlan,
+    ProjectionFlags, QueryResult, QueryRow, Result, SelectExecutor, StorageEngine, TableId,
+    TableSchema,
 };
+use crate::query::result_budget::{enforce_result_budget, estimate_query_row_bytes};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -1046,40 +1047,6 @@ fn compute_scan_collect_bound(steps: &[ExecutionStep]) -> Option<ScanCollectBoun
     bound
 }
 
-/// Estimate the logical size, in bytes, of a materialized [`QueryRow`], reusing
-/// the shared row-cache estimator (issue #1582). Sums the per-value estimate
-/// over the row's column values.
-fn estimate_query_row_bytes(row: &QueryRow) -> usize {
-    row.values
-        .values()
-        .map(crate::memory::estimate_value_size)
-        .sum()
-}
-
-/// Enforce the byte-bounded result budget (primary) and the row-count safety
-/// valve (secondary) on a materialized result set (issue #1582 / D6).
-///
-/// `result_bytes` is the running logical-byte estimate of `results`. Returns
-/// [`Error::ResultTooLarge`] (with a remedy message: add `LIMIT` or stream) when
-/// the byte budget is exceeded, or the legacy query-execution error when the
-/// row-count valve trips.
-fn enforce_result_budget(
-    results: &[QueryRow],
-    result_bytes: usize,
-    byte_budget: usize,
-    max_rows: usize,
-) -> Result<()> {
-    if result_bytes > byte_budget {
-        return Err(Error::ResultTooLarge {
-            budget_bytes: byte_budget,
-            estimated_bytes: result_bytes,
-            rows: results.len(),
-        });
-    }
-    if results.len() > max_rows {
-        return Err(Error::query_execution(
-            "Result set too large, consider adding LIMIT".to_string(),
-        ));
-    }
-    Ok(())
-}
+// The byte-budget estimator + enforcement live in `crate::query::result_budget`
+// (shared verbatim with the legacy engine point-lookup path, issue #1582 / D6);
+// this module reuses them via the `use` alias below rather than forking the logic.

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -597,7 +597,16 @@ impl SelectExecutor {
         schema_opt: Option<&TableSchema>,
         context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
+        // Issue #1582 (D6): a ROW COUNT is the wrong unit for a memory guard —
+        // 1M skinny rows may fit while a few thousand wide rows blow the <128MB
+        // target. The primary guard is a running BYTE estimate (below) against
+        // the configured budget; the row count remains only as a secondary
+        // safety valve.
         const MAX_RESULTS: usize = 1_000_000;
+        let byte_budget = self.max_result_bytes;
+        // Running estimate of the materialized result's logical size, accumulated
+        // with the SAME estimator the row cache uses (issue #1582).
+        let mut result_bytes: usize = 0;
 
         log::info!(
             "Executing SSTableScan: table=\"{}\", predicates={:?}, include_cell_metadata={}",
@@ -694,13 +703,9 @@ impl SelectExecutor {
                 }
 
                 if evaluate_predicates(&row, predicates)? {
+                    result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
-                }
-
-                if results.len() > MAX_RESULTS {
-                    return Err(Error::query_execution(
-                        "Result set too large, consider adding LIMIT".to_string(),
-                    ));
+                    enforce_result_budget(&results, result_bytes, byte_budget, MAX_RESULTS)?;
                 }
             }
         } else {
@@ -812,17 +817,51 @@ impl SelectExecutor {
                 };
 
                 if evaluate_predicates(&row, predicates)? {
+                    result_bytes = result_bytes.saturating_add(estimate_query_row_bytes(&row));
                     results.push(row);
-                }
-
-                if results.len() > MAX_RESULTS {
-                    return Err(Error::query_execution(
-                        "Result set too large, consider adding LIMIT".to_string(),
-                    ));
+                    enforce_result_budget(&results, result_bytes, byte_budget, MAX_RESULTS)?;
                 }
             }
         }
 
         Ok(results)
     }
+}
+
+/// Estimate the logical size, in bytes, of a materialized [`QueryRow`], reusing
+/// the shared row-cache estimator (issue #1582). Sums the per-value estimate
+/// over the row's column values.
+fn estimate_query_row_bytes(row: &QueryRow) -> usize {
+    row.values
+        .values()
+        .map(crate::memory::estimate_value_size)
+        .sum()
+}
+
+/// Enforce the byte-bounded result budget (primary) and the row-count safety
+/// valve (secondary) on a materialized result set (issue #1582 / D6).
+///
+/// `result_bytes` is the running logical-byte estimate of `results`. Returns
+/// [`Error::ResultTooLarge`] (with a remedy message: add `LIMIT` or stream) when
+/// the byte budget is exceeded, or the legacy query-execution error when the
+/// row-count valve trips.
+fn enforce_result_budget(
+    results: &[QueryRow],
+    result_bytes: usize,
+    byte_budget: usize,
+    max_rows: usize,
+) -> Result<()> {
+    if result_bytes > byte_budget {
+        return Err(Error::ResultTooLarge {
+            budget_bytes: byte_budget,
+            estimated_bytes: result_bytes,
+            rows: results.len(),
+        });
+    }
+    if results.len() > max_rows {
+        return Err(Error::query_execution(
+            "Result set too large, consider adding LIMIT".to_string(),
+        ));
+    }
+    Ok(())
 }

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -207,6 +207,12 @@ fn project_expr_reshapes_row(expr: &SelectExpression) -> bool {
     !matches!(expr, SelectExpression::Column(_))
 }
 
+/// Default row-count safety valve for the bare `SelectExecutor` constructors
+/// (issue #1582). Matches [`crate::config::QueryConfig::max_result_rows`]'s
+/// default; the query engine overrides it via
+/// [`SelectExecutor::with_max_result_rows`].
+const DEFAULT_MAX_RESULT_ROWS: usize = 1_000_000;
+
 /// SELECT query executor for SSTable-based storage
 pub struct SelectExecutor {
     /// Schema manager for metadata
@@ -224,6 +230,14 @@ pub struct SelectExecutor {
     /// bare constructors. Streaming queries are bounded by their channel buffer
     /// and do not consult this budget.
     max_result_bytes: usize,
+    /// Row-count safety valve on a materialized result set (issue #1582).
+    ///
+    /// Secondary to `max_result_bytes` (bytes are the correct memory unit), but
+    /// still load-bearing: the materializing scan fails once the collected row
+    /// count exceeds this valve. Wired from
+    /// [`crate::config::QueryConfig::max_result_rows`] by the query engine;
+    /// defaults to 1,000,000 for the bare constructors.
+    max_result_rows: usize,
 }
 
 impl std::fmt::Debug for SelectExecutor {
@@ -281,6 +295,7 @@ impl SelectExecutor {
             storage,
             clock: Arc::new(SystemClock),
             max_result_bytes: crate::config::DEFAULT_MAX_RESULT_BYTES as usize,
+            max_result_rows: DEFAULT_MAX_RESULT_ROWS,
         }
     }
 
@@ -291,6 +306,17 @@ impl SelectExecutor {
     /// load-bearing on the read path.
     pub fn with_max_result_bytes(mut self, max_result_bytes: usize) -> Self {
         self.max_result_bytes = max_result_bytes;
+        self
+    }
+
+    /// Override the row-count safety valve on a materialized result set (issue
+    /// #1582).
+    ///
+    /// Builder-style: the query engine calls this with
+    /// [`crate::config::QueryConfig::max_result_rows`] so the config knob is
+    /// load-bearing on the read path (not a hardcoded constant).
+    pub fn with_max_result_rows(mut self, max_result_rows: usize) -> Self {
+        self.max_result_rows = max_result_rows;
         self
     }
 
@@ -306,6 +332,7 @@ impl SelectExecutor {
             storage,
             clock,
             max_result_bytes: crate::config::DEFAULT_MAX_RESULT_BYTES as usize,
+            max_result_rows: DEFAULT_MAX_RESULT_ROWS,
         }
     }
 

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -215,6 +215,15 @@ pub struct SelectExecutor {
     storage: Arc<StorageEngine>,
     /// Clock used for TTL "remaining seconds" computation (injectable for tests).
     clock: Arc<dyn NowSeconds>,
+    /// Byte ceiling on a materialized result set (issue #1582 / D6).
+    ///
+    /// The materializing scan path accumulates a running estimate of the result
+    /// bytes and fails with [`Error::ResultTooLarge`] once this is exceeded.
+    /// Wired from [`crate::config::QueryConfig::max_result_bytes`] by the query
+    /// engine; defaults to [`crate::config::DEFAULT_MAX_RESULT_BYTES`] for the
+    /// bare constructors. Streaming queries are bounded by their channel buffer
+    /// and do not consult this budget.
+    max_result_bytes: usize,
 }
 
 impl std::fmt::Debug for SelectExecutor {
@@ -261,12 +270,28 @@ struct ExecutionContext {
 
 impl SelectExecutor {
     /// Create a new SELECT executor with a system (wall-clock) now source.
+    ///
+    /// Uses the default materialized-result byte budget
+    /// ([`crate::config::DEFAULT_MAX_RESULT_BYTES`]); call
+    /// [`SelectExecutor::with_max_result_bytes`] to override it (the query
+    /// engine wires it from [`crate::config::QueryConfig::max_result_bytes`]).
     pub fn new(schema: Arc<SchemaManager>, storage: Arc<StorageEngine>) -> Self {
         Self {
             _schema: schema,
             storage,
             clock: Arc::new(SystemClock),
+            max_result_bytes: crate::config::DEFAULT_MAX_RESULT_BYTES as usize,
         }
+    }
+
+    /// Override the byte ceiling on a materialized result set (issue #1582).
+    ///
+    /// Builder-style: the query engine calls this with
+    /// [`crate::config::QueryConfig::max_result_bytes`] so the config knob is
+    /// load-bearing on the read path.
+    pub fn with_max_result_bytes(mut self, max_result_bytes: usize) -> Self {
+        self.max_result_bytes = max_result_bytes;
+        self
     }
 
     /// Create a SELECT executor with a custom clock (for deterministic tests).
@@ -280,6 +305,7 @@ impl SelectExecutor {
             _schema: schema,
             storage,
             clock,
+            max_result_bytes: crate::config::DEFAULT_MAX_RESULT_BYTES as usize,
         }
     }
 

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -294,7 +294,8 @@ impl SelectExecutor {
             _schema: schema,
             storage,
             clock: Arc::new(SystemClock),
-            max_result_bytes: crate::config::DEFAULT_MAX_RESULT_BYTES as usize,
+            max_result_bytes: usize::try_from(crate::config::DEFAULT_MAX_RESULT_BYTES)
+                .unwrap_or(usize::MAX),
             max_result_rows: DEFAULT_MAX_RESULT_ROWS,
         }
     }
@@ -331,7 +332,8 @@ impl SelectExecutor {
             _schema: schema,
             storage,
             clock,
-            max_result_bytes: crate::config::DEFAULT_MAX_RESULT_BYTES as usize,
+            max_result_bytes: usize::try_from(crate::config::DEFAULT_MAX_RESULT_BYTES)
+                .unwrap_or(usize::MAX),
             max_result_rows: DEFAULT_MAX_RESULT_ROWS,
         }
     }

--- a/cqlite-core/src/storage/sstable/scan_merge.rs
+++ b/cqlite-core/src/storage/sstable/scan_merge.rs
@@ -38,6 +38,10 @@
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
+// Used only by `MANAGER_SCAN_FULL_SORTS` / `sort_by_token_order`, both of which
+// have call sites solely under `write-support`; gate the import to match so the
+// minimal build (no `write-support`) has no unused import under `-D warnings`.
+#[cfg(feature = "write-support")]
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 
 use crate::types::RowKey;
@@ -45,6 +49,12 @@ use crate::util::cassandra_murmur3::cassandra_murmur3_token;
 
 /// Number of materialized full-vector token-order sorts performed by
 /// [`sort_by_token_order`] since process start.
+///
+/// Only the `write-support` cross-generation merge paths materialize a merged
+/// `Vec` and call [`sort_by_token_order`], so this counter — and the function —
+/// are compiled only under that feature; the minimal build carries neither
+/// (they would otherwise be dead code and fail `-D warnings`).
+#[cfg(feature = "write-support")]
 pub(crate) static MANAGER_SCAN_FULL_SORTS: AtomicU64 = AtomicU64::new(0);
 
 // Per-thread key-comparison counter for `kway_merge_token_order`, incremented by
@@ -201,6 +211,12 @@ pub(crate) fn kway_merge_token_order<T>(
 /// raw-byte `sort_by`, so a stray raw-byte ordering can never leak out, while the
 /// sort is effectively a no-op when the input is already ordered. Computes each
 /// key's token once to avoid recomputation inside the comparator.
+///
+/// Compiled only under `write-support`: its sole call sites are the
+/// cross-generation merge paths, which are themselves `#[cfg(feature =
+/// "write-support")]`. Without the gate this is dead code in the minimal build
+/// and fails `-D warnings`.
+#[cfg(feature = "write-support")]
 pub(crate) fn sort_by_token_order<E>(
     results: &mut Vec<E>,
     limit: Option<usize>,

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -35,6 +35,11 @@
 //!   3. `max_result_bytes_knob_is_load_bearing` — the same skinny query passes
 //!      under a large budget and trips under a small budget: lowering the knob
 //!      changes what trips, so it is a real behavioral knob, not decoration.
+//!   4. `limited_query_over_wide_table_completes_under_budget` (FINDING 2) — a
+//!      LIMITed query over the wide fixture (whose UNLIMITED scan trips the guard)
+//!      completes and returns the limited rows: the LIMIT bound is propagated into
+//!      the scan and collection early-stops, so the budget never bites on matching
+//!      rows beyond the LIMIT.
 //!
 //! Run with:
 //!   cargo test --package cqlite-core \
@@ -65,6 +70,12 @@ const SKINNY_TBL: &str = "skinny_items";
 /// far below the 1M row-count safety valve.
 const WIDE_PAYLOAD_BYTES: usize = 10 * 1024;
 const WIDE_ROW_COUNT: i32 = 8;
+
+/// Rows the byte guard admits before it trips at [`SHARED_BUDGET_BYTES`]: each
+/// wide row estimates to ~`WIDE_PAYLOAD_BYTES` + a few bytes for the int key, so
+/// `floor(budget / row_bytes)` rows fit before the running estimate crosses the
+/// budget. Used as the LIMIT that must still complete under budget (FINDING 2).
+const WIDE_ROWS_UNDER_BUDGET: usize = 2;
 
 /// Many tiny rows: total bytes stay small even though the row COUNT is large
 /// relative to the wide fixture.
@@ -222,9 +233,59 @@ async fn wide_rows_trip_byte_guard_before_row_count_guard() {
                 rows < 1_000_000,
                 "byte guard must trip long before the 1M row-count guard; got rows={rows}"
             );
+            // The guard fails fast: it trips after collecting only the few rows
+            // that fill the budget (~`WIDE_ROWS_UNDER_BUDGET` + 1), a small handful
+            // strictly below the full fixture — not after collecting all of it.
+            assert!(
+                rows <= WIDE_ROWS_UNDER_BUDGET + 1,
+                "byte guard should fail fast a row past the budget fit \
+                 ({WIDE_ROWS_UNDER_BUDGET}); got rows={rows}"
+            );
         }
         other => panic!("expected Error::ResultTooLarge, got {other:?}"),
     }
+}
+
+/// FINDING 2: a LIMITed query over the same wide fixture — whose UNLIMITED scan
+/// trips the byte guard (see `wide_rows_trip_byte_guard_before_row_count_guard`)
+/// — must complete and return the limited rows, WITHOUT the budget biting on
+/// matching rows beyond the LIMIT.
+///
+/// This is the red→green for FINDING 2: before the fix the LIMIT was applied by a
+/// SEPARATE post-scan step, so the executor enforced the byte budget while
+/// collecting EVERY matching row and raised `ResultTooLarge` at ~row 3 — before
+/// the LIMIT step ever ran. Propagating the LIMIT bound into the scan's `limit`
+/// AND early-stopping collection at `offset + count` means only the limited rows
+/// are collected, so the budget never bites on rows beyond the LIMIT.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn limited_query_over_wide_table_completes_under_budget() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide(temp.path()).await;
+
+    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
+
+    // Sanity: the UNLIMITED query trips the guard (proves the budget is binding).
+    let unlimited = format!("SELECT * FROM {KS}.{WIDE_TBL}");
+    let err = db
+        .execute(&unlimited)
+        .await
+        .expect_err("unlimited wide SELECT * must exceed the byte budget");
+    assert!(
+        matches!(err, Error::ResultTooLarge { .. }),
+        "unlimited query must trip the guard, got {err:?}"
+    );
+
+    // LIMIT within the budget fit must complete and return exactly that many rows.
+    let sql = format!("SELECT * FROM {KS}.{WIDE_TBL} LIMIT {WIDE_ROWS_UNDER_BUDGET}");
+    let result = db
+        .execute(&sql)
+        .await
+        .expect("a LIMITed query that fits the budget must complete, not trip ResultTooLarge");
+    assert_eq!(
+        result.rows.len(),
+        WIDE_ROWS_UNDER_BUDGET,
+        "LIMIT must be honored (early-stop before the byte budget bites)"
+    );
 }
 
 /// Test 2: MANY skinny rows whose total bytes stay under the SAME budget that

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -592,8 +592,8 @@ async fn max_result_rows_knob_is_load_bearing() {
     // Lowering the config knob changed what trips → the valve is load-bearing.
     {
         let low_rows: u64 = (SKINNY_ROW_COUNT as u64) / 2; // < fixture row count
-        let db = open_db_with_budgets(data_dir, schema_path, DEFAULT_MAX_RESULT_BYTES, low_rows)
-            .await;
+        let db =
+            open_db_with_budgets(data_dir, schema_path, DEFAULT_MAX_RESULT_BYTES, low_rows).await;
         let err = db
             .execute(&sql)
             .await
@@ -607,7 +607,9 @@ async fn max_result_rows_knob_is_load_bearing() {
                     "row-count valve error should advise adding LIMIT; got {msg:?}"
                 );
             }
-            other => panic!("expected Error::QueryExecution from the row-count valve, got {other:?}"),
+            other => {
+                panic!("expected Error::QueryExecution from the row-count valve, got {other:?}")
+            }
         }
     }
 }

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -433,6 +433,35 @@ async fn over_budget_constant_query_trips_byte_guard() {
     }
 }
 
+/// roborev #1582 (constant path): the no-FROM budget check must run on the rows
+/// ACTUALLY returned (post LIMIT/OFFSET), NOT on the pre-limit constant rows. So
+/// an over-budget constant `SELECT '<big literal>' LIMIT 0` returns empty, never
+/// `ResultTooLarge` — `LIMIT 0` yields an empty result and can never trip the guard.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn constant_query_limit_zero_returns_empty_not_result_too_large() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_skinny(temp.path()).await;
+
+    let tiny_budget: u64 = 512;
+    // Same over-budget literal as `over_budget_constant_query_trips_byte_guard`.
+    let big_literal_len = (tiny_budget as usize) * 4;
+    let big_literal: String = "x".repeat(big_literal_len);
+
+    let db = open_db_with_budget(data_dir, schema_path, tiny_budget).await;
+
+    let sql = format!("SELECT '{big_literal}' LIMIT 0");
+    let result = db
+        .execute(&sql)
+        .await
+        .expect("LIMIT 0 must return an empty result, never ResultTooLarge");
+
+    assert!(
+        result.rows.is_empty(),
+        "LIMIT 0 must return zero rows, got {}",
+        result.rows.len()
+    );
+}
+
 /// A simple `SELECT * ... WHERE id = <k>` point lookup routes through the LEGACY
 /// `QueryExecutor` (not the budgeted `SelectExecutor`; see `QueryEngine::execute`'s
 /// `is_simple_id_lookup` gate). A single very wide row must trip `ResultTooLarge`

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -602,6 +602,68 @@ async fn limit_zero_with_reordering_step_returns_empty_not_too_large() {
     );
 }
 
+/// roborev FINDING (Medium): an INVALID `token(...)` restriction must be rejected
+/// BEFORE either `LIMIT 0` short-circuit — a LIMIT-0 fast path must never swallow
+/// token-predicate validation. The fix moves `validate_token_predicates(...)` to
+/// be the FIRST statement of `execute_sstable_scan`, ahead of both the
+/// `query_wide_limit_zero` early-return (the reordering/`Sort` path) and the
+/// `collect_bound == Some(0)` short-circuit (the ordinary LIMIT-0 path).
+///
+/// `token(ck)` names a CLUSTERING column, not the partition key (`id`), so
+/// `validate_token_predicates` rejects it (mirrors the unit test
+/// `validate_token_predicates_rejects_non_pk_column`). The optimizer only checks
+/// the token FORM (operator + integer literal + column args), NOT partition-key
+/// membership, so the predicate passes planning and reaches `execute_sstable_scan`
+/// as a real `token()` `SSTablePredicate` — which is exactly the path the fix
+/// guards. Both LIMIT-0 shapes must surface `Error::QueryExecution`, NOT `Ok`:
+///   * `token(ck) >= 0 LIMIT 0` — no reordering step, so
+///     `compute_scan_collect_bound` yields `Some(0)` (the `collect_bound` path).
+///   * `token(ck) >= 0 ORDER BY ck LIMIT 0` — the `Sort` step forces
+///     `compute_scan_collect_bound` to `None`, so the `query_wide_limit_zero` path
+///     is the one that would have swallowed the error pre-fix.
+///
+/// Pre-fix (validation AFTER the short-circuits) BOTH queries returned `Ok` with
+/// zero rows → RED. Post-fix (validation FIRST) both return the token-validation
+/// `Error::QueryExecution` → GREEN.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalid_token_predicate_with_limit_zero_errors_not_empty() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide_ck(temp.path()).await;
+
+    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
+
+    // Assert an invalid-token LIMIT-0 SELECT surfaces the token-validation error
+    // instead of silently returning an empty result.
+    let assert_token_error =
+        |result: Result<cqlite_core::QueryResult, Error>, path: &str| match result {
+            Err(Error::QueryExecution(msg)) => {
+                assert!(
+                    msg.contains("token"),
+                    "{path}: token-validation error must mention token(); got {msg:?}"
+                );
+            }
+            Ok(res) => panic!(
+                "{path}: invalid token() with LIMIT 0 must error, not return {} rows \
+                 (a LIMIT-0 short-circuit must never swallow token validation)",
+                res.rows.len()
+            ),
+            Err(other) => panic!("{path}: expected Error::QueryExecution, got {other:?}"),
+        };
+
+    // Path 1: plain LIMIT 0 → `collect_bound == Some(0)` short-circuit.
+    let collect_bound_sql =
+        format!("SELECT * FROM {KS}.{WIDE_CK_TBL} WHERE token(ck) >= 0 LIMIT 0");
+    assert_token_error(db.execute(&collect_bound_sql).await, "collect_bound path");
+
+    // Path 2: ORDER BY forces a Sort step → `query_wide_limit_zero` early-return.
+    let query_wide_sql =
+        format!("SELECT * FROM {KS}.{WIDE_CK_TBL} WHERE token(ck) >= 0 ORDER BY ck LIMIT 0");
+    assert_token_error(
+        db.execute(&query_wide_sql).await,
+        "query_wide_limit_zero path",
+    );
+}
+
 /// Test 2: MANY skinny rows whose total bytes stay under the SAME budget that
 /// tripped the wide fixture complete fine and return every row.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -1,5 +1,6 @@
 //! Issue #1582 (Epic D6): the memory guard on a MATERIALIZED result set must be
-//! a BYTE ceiling, not a row count.
+//! a BYTE ceiling, not a row count — enforced as a SINGLE robust check on the
+//! FINAL result (narrow subset, owner decision).
 //!
 //! ## The bug this guards
 //!
@@ -8,55 +9,33 @@
 //! project's <128MB memory target, while a few thousand WIDE rows (large blobs,
 //! wide partitions) can blow it long before the row-count guard ever fires. The
 //! fix adds a byte ceiling — [`cqlite_core::config::QueryConfig::max_result_bytes`],
-//! default 64 MiB — accumulated with the SAME `estimate_row_size` estimator the
-//! row cache uses, and raises the typed [`cqlite_core::Error::ResultTooLarge`]
-//! (whose message tells the user to add `LIMIT` or stream) when it is crossed.
-//! The row-count guard is retained only as a secondary safety valve.
+//! default 64 MiB — summed over the FINAL returned rows with the SAME
+//! `estimate_value_size` estimator the row cache uses, and raises the typed
+//! [`cqlite_core::Error::ResultTooLarge`] (whose message tells the user to add
+//! `LIMIT` or stream) when it is crossed. The row-count guard is retained only as
+//! a secondary safety valve ([`cqlite_core::config::QueryConfig::max_result_rows`]).
+//!
+//! ## Narrow subset: one check on the FINAL result
+//!
+//! The budget is applied ONCE, on the fully-materialized result AFTER the whole
+//! step pipeline (Limit/Offset/Filter/Sort/Aggregate/Project) — not during
+//! collection. Because it sees only the RETURNED rows (post LIMIT/OFFSET), a
+//! `LIMIT N` query whose final result is small never trips, and OFFSET-skipped
+//! rows are never charged. This replaced the earlier during-collection machinery
+//! (LIMIT/OFFSET pushdown, per-row early-stop, storage-layer row limit) that kept
+//! generating correctness edge cases. SCOPE (owner-accepted, tracked on #1582):
+//! does NOT bound peak scan memory (deferred #1897) and does NOT cover the legacy
+//! `WHERE id = ?` point-lookup path (deferred to the D6 redesign).
 //!
 //! ## Why controlled `WriteEngine` fixtures (not the vendored `test_wide_rows`)
 //!
-//! The three assertions need EXACT, deterministic control over per-row width and
-//! row count so the byte budget can be tripped (or not) predictably regardless
-//! of environment — and they must not silently SKIP when the gitignored dataset
+//! The assertions need EXACT, deterministic control over per-row width and row
+//! count so the byte budget can be tripped (or not) predictably regardless of
+//! environment — and they must not silently SKIP when the gitignored dataset
 //! `.db` binaries are absent from a clean checkout. Building a wide fixture (a
 //! few large-blob rows) and a skinny fixture (many tiny rows) via the public
 //! `WriteEngine` API gives that determinism while still exercising the guard
 //! end-to-end through `Database::execute`.
-//!
-//! ## What the three tests assert (all FAIL on pre-fix `main`, which has no
-//! byte guard and no `max_result_bytes` knob)
-//!
-//!   1. `wide_rows_trip_byte_guard_before_row_count_guard` — a handful of wide
-//!      rows trips the BYTE guard; the collected row count is far below the 1M
-//!      row-count valve, proving the byte guard fired first.
-//!   2. `skinny_rows_under_byte_budget_complete` — MANY skinny rows whose TOTAL
-//!      bytes stay under the SAME budget that tripped the wide fixture complete
-//!      fine and return every row (byte unit, not row unit).
-//!   3. `max_result_bytes_knob_is_load_bearing` — the same skinny query passes
-//!      under a large budget and trips under a small budget: lowering the knob
-//!      changes what trips, so it is a real behavioral knob, not decoration.
-//!   4. `limited_query_over_wide_table_completes_under_budget` (FINDING 2) — a
-//!      LIMITed query over the wide fixture (whose UNLIMITED scan trips the guard)
-//!      completes and returns the limited rows: collection early-stops after
-//!      predicate evaluation, so the budget never bites on matching rows beyond
-//!      the LIMIT.
-//!   5. `limit_with_non_pk_predicate_returns_all_matches_not_first_n_raw`
-//!      (roborev FINDING 1) — a `WHERE non_pk = ? LIMIT N` returns ALL N matching
-//!      rows, not the matches among the first N RAW rows: the LIMIT is NOT pushed
-//!      into the predicate-unaware `storage.scan`.
-//!   6. `limit_zero_targeted_returns_empty_never_result_too_large`
-//!      (roborev FINDING 2) — `WHERE pk = ? LIMIT 0` over a wide table under a
-//!      sub-row budget returns empty, never `ResultTooLarge`: LIMIT 0
-//!      short-circuits before any scan/lookup/push/budget work.
-//!   7. `limit_offset_skips_wide_rows_uncharged_against_budget`
-//!      (roborev FINDING B) — `LIMIT 2 OFFSET N` over the wide fixture, where the
-//!      skipped OFFSET rows would blow the budget but the 2 returned rows fit,
-//!      SUCCEEDS: the offset rows are skipped uncharged, so only the returned
-//!      rows are budgeted.
-//!   8. `max_result_rows_knob_is_load_bearing` (roborev FINDING A) — lowering
-//!      `max_result_rows` under a generous byte budget makes the skinny query
-//!      trip the row-count safety valve; a high value passes. The knob is real,
-//!      not a hardcoded constant.
 //!
 //! Run with:
 //!   cargo test --package cqlite-core \
@@ -73,7 +52,7 @@
 use cqlite_core::config::DEFAULT_MAX_RESULT_BYTES;
 use cqlite_core::ingestion::{ingest, IngestionConfig};
 use cqlite_core::storage::write_engine::{
-    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
 };
 use cqlite_core::types::Value;
 use cqlite_core::{Config, Database, Error};
@@ -82,100 +61,31 @@ use tempfile::TempDir;
 const KS: &str = "budget_ks";
 const WIDE_TBL: &str = "wide_items";
 const SKINNY_TBL: &str = "skinny_items";
-/// Non-PK-filter fixture for FINDING 1 (LIMIT must not be pushed into storage
-/// ahead of executor-side predicate evaluation).
-const FILTERED_TBL: &str = "filtered_items";
 
 /// ~10 KiB per row → a handful of rows dwarfs a small byte budget while staying
 /// far below the 1M row-count safety valve.
 const WIDE_PAYLOAD_BYTES: usize = 10 * 1024;
 const WIDE_ROW_COUNT: i32 = 8;
 
-/// Rows the byte guard admits before it trips at [`SHARED_BUDGET_BYTES`]: each
-/// wide row estimates to ~`WIDE_PAYLOAD_BYTES` + a few bytes for the int key, so
-/// `floor(budget / row_bytes)` rows fit before the running estimate crosses the
-/// budget. Used as the LIMIT that must still complete under budget (FINDING 2).
+/// Number of wide rows whose combined bytes stay under [`SHARED_BUDGET_BYTES`]:
+/// each wide row estimates to ~`WIDE_PAYLOAD_BYTES` + a few bytes for the int
+/// key, so a `LIMIT` of this many keeps the FINAL result under budget.
 const WIDE_ROWS_UNDER_BUDGET: usize = 2;
 
 /// Many tiny rows: total bytes stay small even though the row COUNT is large
 /// relative to the wide fixture.
 const SKINNY_ROW_COUNT: i32 = 400;
 
-/// FINDING 1 fixture: total rows, and the group value a small, spread-out subset
-/// carries. Only every 20th row matches `MATCH_GRP` (10 rows), so the matching
-/// rows are scattered throughout token order — NOT confined to the first
-/// `MATCH_COUNT` rows a buggy storage-pushed LIMIT would return.
-const FILTERED_ROW_COUNT: i32 = 200;
-const MATCH_GRP: i32 = 7;
-const NON_MATCH_GRP: i32 = 0;
-const MATCH_COUNT: usize = 10;
-
-/// Wide fixture with a UUID `id` PK (roborev legacy-path finding). A UUID `WHERE
-/// id = <uuid>` point lookup satisfies `is_simple_id_lookup` (≤ 8 tokens,
-/// `WHERE id =`) and is routed through the LEGACY `QueryExecutor`: because the
-/// value is a `Uuid` (not an `Integer`), `condition_to_row_key` falls through to
-/// `value_to_row_key`, which produces the exact 16-byte partition key the real
-/// SSTable stores — so the legacy `storage.get` actually returns the wide row
-/// (unlike an int `id`, which the legacy path maps to a synthetic `user_key_N`
-/// that never matches a real SSTable partition key).
-const WIDE_UUID_TBL: &str = "wide_uuid_items";
-/// Wide fixture with a CLUSTERING column so `ORDER BY ck` is available. All rows
-/// live in ONE partition (`id = 0`) with a wide payload each, so the partition's
-/// materialized size dwarfs [`SHARED_BUDGET_BYTES`]. A plan with `ORDER BY`
-/// emits a `Sort` step, so `compute_scan_collect_bound` returns `None` — the exact
-/// uncovered path for the query-wide `LIMIT 0` short-circuit (D6 roborev finding).
-const WIDE_CK_TBL: &str = "wide_ck_items";
-/// The partition looked up by the legacy-path tests (`0x11` repeated 16×). Its
-/// canonical UUID literal (below) is what the CQL `WHERE id = ...` clause carries.
-const LOOKUP_UUID: [u8; 16] = [0x11u8; 16];
-const LOOKUP_UUID_LITERAL: &str = "11111111-1111-1111-1111-111111111111";
+/// A byte budget that a handful of ~10 KiB wide rows exceeds, but the skinny
+/// fixture's total logical bytes (~few KiB) stays under.
+const SHARED_BUDGET_BYTES: u64 = 24 * 1024;
 
 fn wide_schema_cql() -> String {
     format!("CREATE TABLE {KS}.{WIDE_TBL} (\n  id int PRIMARY KEY,\n  payload blob\n);\n")
 }
 
-fn wide_uuid_schema_cql() -> String {
-    format!("CREATE TABLE {KS}.{WIDE_UUID_TBL} (\n  id uuid PRIMARY KEY,\n  payload blob\n);\n")
-}
-
-fn wide_uuid_row(id_bytes: [u8; 16], ts: i64) -> Mutation {
-    let pk = PartitionKey::single("id", Value::Uuid(id_bytes));
-    let ops = vec![CellOperation::Write {
-        column: "payload".to_string(),
-        value: Value::Blob(vec![0xABu8; WIDE_PAYLOAD_BYTES]),
-    }];
-    Mutation::new(TableId::new(KS, WIDE_UUID_TBL), pk, None, ops, ts, None)
-}
-
-fn wide_ck_schema_cql() -> String {
-    format!(
-        "CREATE TABLE {KS}.{WIDE_CK_TBL} (\n  id int,\n  ck int,\n  payload blob,\n  PRIMARY KEY (id, ck)\n);\n"
-    )
-}
-
-fn wide_ck_row(id: i32, ck: i32, ts: i64) -> Mutation {
-    let pk = PartitionKey::single("id", Value::Integer(id));
-    let clustering = ClusteringKey::single("ck", Value::Integer(ck));
-    let ops = vec![CellOperation::Write {
-        column: "payload".to_string(),
-        value: Value::Blob(vec![0xABu8; WIDE_PAYLOAD_BYTES]),
-    }];
-    Mutation::new(
-        TableId::new(KS, WIDE_CK_TBL),
-        pk,
-        Some(clustering),
-        ops,
-        ts,
-        None,
-    )
-}
-
 fn skinny_schema_cql() -> String {
     format!("CREATE TABLE {KS}.{SKINNY_TBL} (\n  id int PRIMARY KEY,\n  n int\n);\n")
-}
-
-fn filtered_schema_cql() -> String {
-    format!("CREATE TABLE {KS}.{FILTERED_TBL} (\n  id int PRIMARY KEY,\n  grp int\n);\n")
 }
 
 fn wide_row(id: i32, ts: i64) -> Mutation {
@@ -194,21 +104,6 @@ fn skinny_row(id: i32, ts: i64) -> Mutation {
         value: Value::Integer(id),
     }];
     Mutation::new(TableId::new(KS, SKINNY_TBL), pk, None, ops, ts, None)
-}
-
-fn filtered_row(id: i32, ts: i64) -> Mutation {
-    let pk = PartitionKey::single("id", Value::Integer(id));
-    // Every 20th row matches MATCH_GRP; the rest carry NON_MATCH_GRP.
-    let grp = if id % 20 == 0 {
-        MATCH_GRP
-    } else {
-        NON_MATCH_GRP
-    };
-    let ops = vec![CellOperation::Write {
-        column: "grp".to_string(),
-        value: Value::Integer(grp),
-    }];
-    Mutation::new(TableId::new(KS, FILTERED_TBL), pk, None, ops, ts, None)
 }
 
 /// Flush a single generation for `table` with the supplied schema + rows.
@@ -250,8 +145,8 @@ async fn open_db_with_budget(
 }
 
 /// Open the query stack wiring BOTH the byte budget and the `max_result_rows`
-/// row-count safety valve through config (roborev FINDING A: the row-count knob
-/// must be load-bearing, not a hardcoded constant).
+/// row-count safety valve through config (the row-count knob must be
+/// load-bearing, not a hardcoded constant).
 async fn open_db_with_budgets(
     data_dir: std::path::PathBuf,
     schema_path: std::path::PathBuf,
@@ -298,54 +193,6 @@ async fn prepare_wide(root: &std::path::Path) -> (std::path::PathBuf, std::path:
     (data_dir, schema_path)
 }
 
-/// Build a wide UUID-PK fixture: a handful of distinct-UUID single-row
-/// partitions, one keyed by [`LOOKUP_UUID`]. Each row's ~10 KiB payload dwarfs
-/// [`SUB_ROW_BUDGET_BYTES`].
-async fn prepare_wide_uuid(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
-    let data_dir = root.join("wide_uuid_data");
-    let wal_dir = root.join("wide_uuid_wal");
-    let schema_path = root.join("wide_uuid_schema.cql");
-    std::fs::write(&schema_path, wide_uuid_schema_cql()).expect("write wide uuid schema");
-    let (d, w) = (data_dir.clone(), wal_dir.clone());
-    tokio::task::spawn_blocking(move || {
-        let rows: Vec<Mutation> = (0..WIDE_ROW_COUNT)
-            .map(|i| {
-                let uuid = if i == 0 {
-                    LOOKUP_UUID
-                } else {
-                    [(0x20u8 + i as u8); 16]
-                };
-                wide_uuid_row(uuid, 100)
-            })
-            .collect();
-        build_fixture(&d, &w, &wide_uuid_schema_cql(), rows);
-    })
-    .await
-    .expect("build wide uuid fixture");
-    (data_dir, schema_path)
-}
-
-/// Build a single wide partition (`id = 0`) with [`WIDE_ROW_COUNT`] clustering
-/// rows, each carrying a ~10 KiB payload. `ORDER BY ck` over it emits a `Sort`
-/// step (so `compute_scan_collect_bound` is `None`), and the partition's
-/// materialized size (~80 KiB) dwarfs [`SHARED_BUDGET_BYTES`].
-async fn prepare_wide_ck(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
-    let data_dir = root.join("wide_ck_data");
-    let wal_dir = root.join("wide_ck_wal");
-    let schema_path = root.join("wide_ck_schema.cql");
-    std::fs::write(&schema_path, wide_ck_schema_cql()).expect("write wide ck schema");
-    let (d, w) = (data_dir.clone(), wal_dir.clone());
-    tokio::task::spawn_blocking(move || {
-        let rows: Vec<Mutation> = (0..WIDE_ROW_COUNT)
-            .map(|ck| wide_ck_row(0, ck, 100))
-            .collect();
-        build_fixture(&d, &w, &wide_ck_schema_cql(), rows);
-    })
-    .await
-    .expect("build wide ck fixture");
-    (data_dir, schema_path)
-}
-
 async fn prepare_skinny(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
     let data_dir = root.join("skinny_data");
     let wal_dir = root.join("skinny_wal");
@@ -361,35 +208,12 @@ async fn prepare_skinny(root: &std::path::Path) -> (std::path::PathBuf, std::pat
     (data_dir, schema_path)
 }
 
-async fn prepare_filtered(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
-    let data_dir = root.join("filtered_data");
-    let wal_dir = root.join("filtered_wal");
-    let schema_path = root.join("filtered_schema.cql");
-    std::fs::write(&schema_path, filtered_schema_cql()).expect("write filtered schema");
-    let (d, w) = (data_dir.clone(), wal_dir.clone());
-    tokio::task::spawn_blocking(move || {
-        let rows: Vec<Mutation> = (0..FILTERED_ROW_COUNT)
-            .map(|i| filtered_row(i, 100))
-            .collect();
-        build_fixture(&d, &w, &filtered_schema_cql(), rows);
-    })
-    .await
-    .expect("build filtered fixture");
-    (data_dir, schema_path)
-}
-
-/// A byte budget that a handful of ~10 KiB wide rows exceeds, but the skinny
-/// fixture's total logical bytes (~few KiB) stays under.
-const SHARED_BUDGET_BYTES: u64 = 24 * 1024;
-
-/// A byte budget SMALLER than a single wide row (~10 KiB): a single-partition
-/// lookup that materializes one wide row would trip the guard under it — used to
-/// prove the FINDING 2 `LIMIT 0` short-circuit fires BEFORE any push/byte-check.
-const SUB_ROW_BUDGET_BYTES: u64 = 512;
-
-/// Test 1: a few WIDE rows trip the BYTE guard before the row-count guard.
+/// A wide, UNLIMITED FINAL result trips the BYTE guard before the row-count
+/// guard. The full fixture is collected and its combined bytes exceed the
+/// budget; the row count is far below the 1M row-count valve, proving the byte
+/// guard fired first.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn wide_rows_trip_byte_guard_before_row_count_guard() {
+async fn wide_final_result_trips_byte_guard() {
     let temp = TempDir::new().unwrap();
     let (data_dir, schema_path) = prepare_wide(temp.path()).await;
 
@@ -421,32 +245,17 @@ async fn wide_rows_trip_byte_guard_before_row_count_guard() {
                 rows < 1_000_000,
                 "byte guard must trip long before the 1M row-count guard; got rows={rows}"
             );
-            // The guard fails fast: it trips after collecting only the few rows
-            // that fill the budget (~`WIDE_ROWS_UNDER_BUDGET` + 1), a small handful
-            // strictly below the full fixture — not after collecting all of it.
-            assert!(
-                rows <= WIDE_ROWS_UNDER_BUDGET + 1,
-                "byte guard should fail fast a row past the budget fit \
-                 ({WIDE_ROWS_UNDER_BUDGET}); got rows={rows}"
-            );
         }
         other => panic!("expected Error::ResultTooLarge, got {other:?}"),
     }
 }
 
-/// FINDING 2: a LIMITed query over the same wide fixture — whose UNLIMITED scan
-/// trips the byte guard (see `wide_rows_trip_byte_guard_before_row_count_guard`)
-/// — must complete and return the limited rows, WITHOUT the budget biting on
-/// matching rows beyond the LIMIT.
-///
-/// This is the red→green for FINDING 2: before the fix the LIMIT was applied by a
-/// SEPARATE post-scan step, so the executor enforced the byte budget while
-/// collecting EVERY matching row and raised `ResultTooLarge` at ~row 3 — before
-/// the LIMIT step ever ran. Propagating the LIMIT bound into the scan's `limit`
-/// AND early-stopping collection at `offset + count` means only the limited rows
-/// are collected, so the budget never bites on rows beyond the LIMIT.
+/// A `LIMIT` keeps a big table under budget: the UNLIMITED scan over the wide
+/// fixture trips the guard, but `SELECT * ... LIMIT 2` produces a small FINAL
+/// result (2 wide rows, under budget), so the single final-result check never
+/// raises `ResultTooLarge`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn limited_query_over_wide_table_completes_under_budget() {
+async fn limit_keeps_big_table_under_budget() {
     let temp = TempDir::new().unwrap();
     let (data_dir, schema_path) = prepare_wide(temp.path()).await;
 
@@ -468,206 +277,18 @@ async fn limited_query_over_wide_table_completes_under_budget() {
     let result = db
         .execute(&sql)
         .await
-        .expect("a LIMITed query that fits the budget must complete, not trip ResultTooLarge");
+        .expect("a LIMITed query whose FINAL result fits the budget must complete");
     assert_eq!(
         result.rows.len(),
         WIDE_ROWS_UNDER_BUDGET,
-        "LIMIT must be honored (early-stop before the byte budget bites)"
+        "LIMIT must be honored and the final small result must not trip the byte budget"
     );
 }
 
-/// FINDING 1 (roborev HIGH): a LIMIT must NOT be pushed into storage ahead of
-/// executor-side predicate evaluation. The optimizer folds `WHERE grp = ?` into
-/// the `SSTableScan` step's predicates WITHOUT a residual `Filter`, but
-/// `storage.scan` is not predicate-aware. If the query-wide `LIMIT N` bound is
-/// pushed into `storage.scan`, storage returns only the first `N` RAW (unfiltered)
-/// rows in token order; the matching rows scattered further along the scan are
-/// never seen, so the executor filters `N` raw rows down to far fewer than `N`
-/// matches → WRONG RESULTS.
-///
-/// This fixture has `MATCH_COUNT` matching rows spread across `FILTERED_ROW_COUNT`
-/// total rows. `SELECT * WHERE grp = MATCH_GRP LIMIT MATCH_COUNT` must return all
-/// `MATCH_COUNT` matches. Pre-fix (storage-pushed LIMIT) this returns only the
-/// matches that happen to fall within the first `MATCH_COUNT` token-ordered rows
-/// (≈ `MATCH_COUNT² / FILTERED_ROW_COUNT` ≈ 0–1) → RED. Post-fix the storage limit
-/// is withheld whenever executor-side predicates exist and the early-stop counts
-/// only rows that PASSED the predicate → all `MATCH_COUNT` matches → GREEN.
+/// MANY skinny rows whose total bytes stay under the SAME budget that tripped the
+/// wide fixture complete fine and return every row (byte unit, not row unit).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn limit_with_non_pk_predicate_returns_all_matches_not_first_n_raw() {
-    let temp = TempDir::new().unwrap();
-    let (data_dir, schema_path) = prepare_filtered(temp.path()).await;
-
-    // Generous budget: FINDING 1 is about correctness, not the byte guard.
-    let db = open_db_with_budget(data_dir, schema_path, DEFAULT_MAX_RESULT_BYTES).await;
-
-    let sql =
-        format!("SELECT * FROM {KS}.{FILTERED_TBL} WHERE grp = {MATCH_GRP} LIMIT {MATCH_COUNT}");
-    let result = db
-        .execute(&sql)
-        .await
-        .expect("filtered LIMIT query must succeed");
-
-    assert_eq!(
-        result.rows.len(),
-        MATCH_COUNT,
-        "LIMIT must return ALL matching rows, not the matches among the first N \
-         RAW rows a storage-pushed limit would return (FINDING 1)"
-    );
-}
-
-/// FINDING 2 (roborev MEDIUM): `WHERE pk = ? LIMIT 0` over a wide table must
-/// return an empty result, never `ResultTooLarge`. The budget here is SMALLER than
-/// a single wide row, so pre-fix the targeted lookup materialized the matching row
-/// and byte-checked it before the LIMIT-0 bound was honored → `ResultTooLarge`.
-/// Post-fix the `collect_bound == Some(0)` short-circuit returns empty before any
-/// scan/lookup/push/budget work.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn limit_zero_targeted_returns_empty_never_result_too_large() {
-    let temp = TempDir::new().unwrap();
-    let (data_dir, schema_path) = prepare_wide(temp.path()).await;
-
-    let db = open_db_with_budget(data_dir, schema_path, SUB_ROW_BUDGET_BYTES).await;
-
-    // Sanity: the same single-partition lookup with a NON-zero LIMIT trips the
-    // guard (one wide row exceeds the sub-row budget) — proving the budget is
-    // binding and that only the LIMIT-0 short-circuit makes this query empty rather
-    // than error. (A bare `WHERE id = 0` with no LIMIT is routed to the legacy
-    // executor by a word-count heuristic in `QueryEngine::execute`; keeping a LIMIT
-    // clause here routes through the optimizer path under test.)
-    let point = format!("SELECT * FROM {KS}.{WIDE_TBL} WHERE id = 0 LIMIT 5");
-    let err = db
-        .execute(&point)
-        .await
-        .expect_err("a single wide row must exceed the sub-row byte budget");
-    assert!(
-        matches!(err, Error::ResultTooLarge { .. }),
-        "point lookup of one wide row must trip the guard, got {err:?}"
-    );
-
-    let sql = format!("SELECT * FROM {KS}.{WIDE_TBL} WHERE id = 0 LIMIT 0");
-    let result = db
-        .execute(&sql)
-        .await
-        .expect("LIMIT 0 must short-circuit to an empty result, never ResultTooLarge");
-    assert!(
-        result.rows.is_empty(),
-        "LIMIT 0 must return zero rows; got {}",
-        result.rows.len()
-    );
-}
-
-/// FINDING D6 (roborev MEDIUM): a query-wide `LIMIT 0` must ALWAYS return an empty
-/// result, never `ResultTooLarge` — INCLUDING when the plan carries a reordering /
-/// reducing step (`Sort`, `Filter`, `Aggregate`, `PerPartitionLimit`) that makes
-/// `compute_scan_collect_bound` return `None`. Here `ORDER BY ck` emits a `Sort`
-/// step, so the `collect_bound == Some(0)` short-circuit never fires; pre-fix the
-/// fallback scan-collection loop had no LIMIT-0 early-return, so it scanned the full
-/// wide partition (~80 KiB) under the sub-partition [`SHARED_BUDGET_BYTES`] budget
-/// and raised `ResultTooLarge` instead of returning empty. Post-fix a query-wide
-/// `ExecutionStep::Limit { count: 0, .. }` short-circuits to an empty result BEFORE
-/// scanning, independent of whether a collect bound was computed.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn limit_zero_with_reordering_step_returns_empty_not_too_large() {
-    let temp = TempDir::new().unwrap();
-    let (data_dir, schema_path) = prepare_wide_ck(temp.path()).await;
-
-    // Budget BELOW the wide partition's materialized size (8 × ~10 KiB ≫ 24 KiB).
-    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
-
-    // Sanity: the SAME ORDER BY query with a NON-zero LIMIT scans the wide
-    // partition and trips the guard — the `Sort` step disables the collect-bound
-    // early-stop, so the full partition is collected and the budget bites. This
-    // proves the query exercises the uncovered `compute_scan_collect_bound == None`
-    // path (not a plan that early-stops).
-    let unlimited = format!("SELECT * FROM {KS}.{WIDE_CK_TBL} ORDER BY ck LIMIT {WIDE_ROW_COUNT}");
-    let err = db
-        .execute(&unlimited)
-        .await
-        .expect_err("wide ORDER BY scan must exceed the byte budget");
-    assert!(
-        matches!(err, Error::ResultTooLarge { .. }),
-        "unlimited ORDER BY query must trip the guard (Sort disables early-stop), got {err:?}"
-    );
-
-    // LIMIT 0 with the reordering Sort step must short-circuit to empty, never error.
-    let sql = format!("SELECT * FROM {KS}.{WIDE_CK_TBL} ORDER BY ck LIMIT 0");
-    let result = db
-        .execute(&sql)
-        .await
-        .expect("query-wide LIMIT 0 must short-circuit to empty, never ResultTooLarge");
-    assert!(
-        result.rows.is_empty(),
-        "LIMIT 0 must return zero rows even with a Sort step; got {}",
-        result.rows.len()
-    );
-}
-
-/// roborev FINDING (Medium): an INVALID `token(...)` restriction must be rejected
-/// BEFORE either `LIMIT 0` short-circuit — a LIMIT-0 fast path must never swallow
-/// token-predicate validation. The fix moves `validate_token_predicates(...)` to
-/// be the FIRST statement of `execute_sstable_scan`, ahead of both the
-/// `query_wide_limit_zero` early-return (the reordering/`Sort` path) and the
-/// `collect_bound == Some(0)` short-circuit (the ordinary LIMIT-0 path).
-///
-/// `token(ck)` names a CLUSTERING column, not the partition key (`id`), so
-/// `validate_token_predicates` rejects it (mirrors the unit test
-/// `validate_token_predicates_rejects_non_pk_column`). The optimizer only checks
-/// the token FORM (operator + integer literal + column args), NOT partition-key
-/// membership, so the predicate passes planning and reaches `execute_sstable_scan`
-/// as a real `token()` `SSTablePredicate` — which is exactly the path the fix
-/// guards. Both LIMIT-0 shapes must surface `Error::QueryExecution`, NOT `Ok`:
-///   * `token(ck) >= 0 LIMIT 0` — no reordering step, so
-///     `compute_scan_collect_bound` yields `Some(0)` (the `collect_bound` path).
-///   * `token(ck) >= 0 ORDER BY ck LIMIT 0` — the `Sort` step forces
-///     `compute_scan_collect_bound` to `None`, so the `query_wide_limit_zero` path
-///     is the one that would have swallowed the error pre-fix.
-///
-/// Pre-fix (validation AFTER the short-circuits) BOTH queries returned `Ok` with
-/// zero rows → RED. Post-fix (validation FIRST) both return the token-validation
-/// `Error::QueryExecution` → GREEN.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn invalid_token_predicate_with_limit_zero_errors_not_empty() {
-    let temp = TempDir::new().unwrap();
-    let (data_dir, schema_path) = prepare_wide_ck(temp.path()).await;
-
-    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
-
-    // Assert an invalid-token LIMIT-0 SELECT surfaces the token-validation error
-    // instead of silently returning an empty result.
-    let assert_token_error =
-        |result: Result<cqlite_core::QueryResult, Error>, path: &str| match result {
-            Err(Error::QueryExecution(msg)) => {
-                assert!(
-                    msg.contains("token"),
-                    "{path}: token-validation error must mention token(); got {msg:?}"
-                );
-            }
-            Ok(res) => panic!(
-                "{path}: invalid token() with LIMIT 0 must error, not return {} rows \
-                 (a LIMIT-0 short-circuit must never swallow token validation)",
-                res.rows.len()
-            ),
-            Err(other) => panic!("{path}: expected Error::QueryExecution, got {other:?}"),
-        };
-
-    // Path 1: plain LIMIT 0 → `collect_bound == Some(0)` short-circuit.
-    let collect_bound_sql =
-        format!("SELECT * FROM {KS}.{WIDE_CK_TBL} WHERE token(ck) >= 0 LIMIT 0");
-    assert_token_error(db.execute(&collect_bound_sql).await, "collect_bound path");
-
-    // Path 2: ORDER BY forces a Sort step → `query_wide_limit_zero` early-return.
-    let query_wide_sql =
-        format!("SELECT * FROM {KS}.{WIDE_CK_TBL} WHERE token(ck) >= 0 ORDER BY ck LIMIT 0");
-    assert_token_error(
-        db.execute(&query_wide_sql).await,
-        "query_wide_limit_zero path",
-    );
-}
-
-/// Test 2: MANY skinny rows whose total bytes stay under the SAME budget that
-/// tripped the wide fixture complete fine and return every row.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn skinny_rows_under_byte_budget_complete() {
+async fn skinny_result_under_budget_completes() {
     let temp = TempDir::new().unwrap();
     let (data_dir, schema_path) = prepare_skinny(temp.path()).await;
 
@@ -687,8 +308,8 @@ async fn skinny_rows_under_byte_budget_complete() {
     );
 }
 
-/// Test 3: the `max_result_bytes` knob is load-bearing — the same skinny query
-/// passes under a large budget and trips under a small one.
+/// The `max_result_bytes` knob is load-bearing — the same skinny query passes
+/// under a large budget and trips under a small one.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn max_result_bytes_knob_is_load_bearing() {
     let temp = TempDir::new().unwrap();
@@ -729,172 +350,12 @@ async fn max_result_bytes_knob_is_load_bearing() {
     }
 }
 
-/// FINDING B (roborev MEDIUM): `LIMIT ... OFFSET ...` must NOT charge the skipped
-/// OFFSET rows against the byte budget. A query whose FINAL result is small must
-/// SUCCEED even when the skipped rows are wide enough that charging them would
-/// exceed the budget.
-///
-/// The wide fixture has `WIDE_ROW_COUNT` rows of ~`WIDE_PAYLOAD_BYTES` each.
-/// `LIMIT WIDE_ROWS_UNDER_BUDGET OFFSET WIDE_OFFSET` under `SHARED_BUDGET_BYTES`:
-/// the `WIDE_OFFSET` skipped rows total ~40 KiB (well over the ~24 KiB budget),
-/// but the 2 returned rows total ~20 KiB (under budget). Pre-fix the scan
-/// collected `offset + count` matching rows and charged EACH, tripping the byte
-/// guard at ~row 3 → RED (`ResultTooLarge`). Post-fix the offset rows are skipped
-/// uncharged (never pushed, never budgeted) and only the 2 returned rows are
-/// budgeted → GREEN.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn limit_offset_skips_wide_rows_uncharged_against_budget() {
-    // Skip 4 wide rows (~40 KiB, over budget), return 2 (~20 KiB, under budget).
-    const WIDE_OFFSET: usize = 4;
-    // Sanity on the fixture sizing: offset + limit must fit inside the fixture.
-    assert!(WIDE_OFFSET + WIDE_ROWS_UNDER_BUDGET <= WIDE_ROW_COUNT as usize);
-
-    let temp = TempDir::new().unwrap();
-    let (data_dir, schema_path) = prepare_wide(temp.path()).await;
-
-    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
-
-    let sql = format!(
-        "SELECT * FROM {KS}.{WIDE_TBL} LIMIT {WIDE_ROWS_UNDER_BUDGET} OFFSET {WIDE_OFFSET}"
-    );
-    let result = db.execute(&sql).await.expect(
-        "LIMIT/OFFSET must skip the wide OFFSET rows uncharged and budget only the \
-         returned rows, not trip ResultTooLarge",
-    );
-    assert_eq!(
-        result.rows.len(),
-        WIDE_ROWS_UNDER_BUDGET,
-        "must return exactly the LIMIT rows after skipping the OFFSET rows"
-    );
-}
-
-/// roborev FINDING (Medium): a WIDE-partition POINT LOOKUP that satisfies
-/// `is_simple_id_lookup` (`WHERE id = <value>` with ≤ 8 whitespace tokens) is
-/// routed through the LEGACY `QueryExecutor`, which — pre-fix — did NOT enforce
-/// the D6 byte budget. So a single wide row materialized unbounded and bypassed
-/// the guard entirely. Post-fix the budget is enforced POST-materialization on the
-/// legacy `QueryResult` at BOTH legacy return points (plan-cache hit and
-/// fall-through), reusing the SAME estimator/enforcement as the optimizer path.
-///
-/// `SUB_ROW_BUDGET_BYTES` (512 B) is smaller than one ~10 KiB wide row, so the
-/// point lookup of that one row must trip `ResultTooLarge`. The SQL is exactly 8
-/// whitespace tokens and contains `WHERE id =`, so it trips `is_simple_id_lookup`
-/// and exercises the legacy path under test (NOT the optimizer path).
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn wide_point_lookup_via_legacy_path_trips_byte_budget() {
-    let temp = TempDir::new().unwrap();
-    let (data_dir, schema_path) = prepare_wide_uuid(temp.path()).await;
-
-    let db = open_db_with_budget(data_dir, schema_path, SUB_ROW_BUDGET_BYTES).await;
-
-    // 8 whitespace tokens + "WHERE id =" → is_simple_id_lookup == true → legacy path.
-    let sql = format!("SELECT * FROM {KS}.{WIDE_UUID_TBL} WHERE id = {LOOKUP_UUID_LITERAL}");
-    assert_eq!(
-        sql.split_whitespace().count(),
-        8,
-        "test SQL must be <= 8 tokens to trip is_simple_id_lookup"
-    );
-    assert!(sql.contains("WHERE id ="));
-
-    let err = db
-        .execute(&sql)
-        .await
-        .expect_err("wide point lookup must exceed the sub-row byte budget on the legacy path");
-    match err {
-        Error::ResultTooLarge {
-            budget_bytes,
-            estimated_bytes,
-            rows,
-        } => {
-            assert_eq!(
-                budget_bytes, SUB_ROW_BUDGET_BYTES as usize,
-                "error must report the configured budget"
-            );
-            assert!(
-                estimated_bytes > budget_bytes,
-                "estimated bytes ({estimated_bytes}) must exceed budget ({budget_bytes})"
-            );
-            assert!(
-                rows >= 1,
-                "the materialized wide row must be counted; got rows={rows}"
-            );
-        }
-        other => panic!("expected Error::ResultTooLarge on the legacy path, got {other:?}"),
-    }
-}
-
-/// Control for the legacy-path budget: the SAME point lookup under a GENEROUS
-/// budget succeeds and returns the row — the guard is not over-firing on normal
-/// point reads.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn wide_point_lookup_via_legacy_path_succeeds_under_generous_budget() {
-    let temp = TempDir::new().unwrap();
-    let (data_dir, schema_path) = prepare_wide_uuid(temp.path()).await;
-
-    let db = open_db_with_budget(data_dir, schema_path, DEFAULT_MAX_RESULT_BYTES).await;
-
-    let sql = format!("SELECT * FROM {KS}.{WIDE_UUID_TBL} WHERE id = {LOOKUP_UUID_LITERAL}");
-    let result = db
-        .execute(&sql)
-        .await
-        .expect("point lookup under a generous budget must succeed");
-    assert_eq!(
-        result.rows.len(),
-        1,
-        "point lookup on id=0 must return exactly the one wide row"
-    );
-}
-
-/// Knob test on the legacy path: lowering `max_result_bytes` flips the SAME
-/// point-lookup query from Ok → `ResultTooLarge` — the byte budget is load-bearing
-/// on the legacy point-lookup path too, not just the optimizer path.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn max_result_bytes_knob_is_load_bearing_on_legacy_point_lookup() {
-    let temp = TempDir::new().unwrap();
-    let (data_dir, schema_path) = prepare_wide_uuid(temp.path()).await;
-
-    let sql = format!("SELECT * FROM {KS}.{WIDE_UUID_TBL} WHERE id = {LOOKUP_UUID_LITERAL}");
-
-    // Generous budget: PASSES.
-    {
-        let db = open_db_with_budget(
-            data_dir.clone(),
-            schema_path.clone(),
-            DEFAULT_MAX_RESULT_BYTES,
-        )
-        .await;
-        let result = db
-            .execute(&sql)
-            .await
-            .expect("point lookup passes under the default budget");
-        assert_eq!(result.rows.len(), 1);
-    }
-
-    // Sub-row budget: the SAME query now TRIPS.
-    {
-        let db = open_db_with_budget(data_dir, schema_path, SUB_ROW_BUDGET_BYTES).await;
-        let err = db
-            .execute(&sql)
-            .await
-            .expect_err("lowering max_result_bytes must make the point lookup trip");
-        match err {
-            Error::ResultTooLarge { budget_bytes, .. } => {
-                assert_eq!(budget_bytes, SUB_ROW_BUDGET_BYTES as usize);
-            }
-            other => panic!("expected Error::ResultTooLarge under sub-row budget, got {other:?}"),
-        }
-    }
-}
-
-/// FINDING A (roborev MEDIUM): the `max_result_rows` row-count safety valve must
-/// be load-bearing (wired from config), not a hardcoded 1,000,000 constant.
+/// The `max_result_rows` row-count safety valve must be load-bearing (wired from
+/// config), not a hardcoded 1,000,000 constant.
 ///
 /// Under a GENEROUS byte budget (so the byte guard never fires), the skinny
 /// query passes with a high `max_result_rows` and TRIPS the row-count valve when
-/// `max_result_rows` is lowered below the fixture's row count. Lowering the knob
-/// changes what trips → it is a real behavioral knob. Pre-fix the guard used a
-/// hardcoded `MAX_RESULTS = 1_000_000`, so lowering the config value had NO
-/// effect and the query still passed → RED.
+/// `max_result_rows` is lowered below the fixture's row count.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn max_result_rows_knob_is_load_bearing() {
     let temp = TempDir::new().unwrap();

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -110,8 +110,35 @@ const MATCH_GRP: i32 = 7;
 const NON_MATCH_GRP: i32 = 0;
 const MATCH_COUNT: usize = 10;
 
+/// Wide fixture with a UUID `id` PK (roborev legacy-path finding). A UUID `WHERE
+/// id = <uuid>` point lookup satisfies `is_simple_id_lookup` (≤ 8 tokens,
+/// `WHERE id =`) and is routed through the LEGACY `QueryExecutor`: because the
+/// value is a `Uuid` (not an `Integer`), `condition_to_row_key` falls through to
+/// `value_to_row_key`, which produces the exact 16-byte partition key the real
+/// SSTable stores — so the legacy `storage.get` actually returns the wide row
+/// (unlike an int `id`, which the legacy path maps to a synthetic `user_key_N`
+/// that never matches a real SSTable partition key).
+const WIDE_UUID_TBL: &str = "wide_uuid_items";
+/// The partition looked up by the legacy-path tests (`0x11` repeated 16×). Its
+/// canonical UUID literal (below) is what the CQL `WHERE id = ...` clause carries.
+const LOOKUP_UUID: [u8; 16] = [0x11u8; 16];
+const LOOKUP_UUID_LITERAL: &str = "11111111-1111-1111-1111-111111111111";
+
 fn wide_schema_cql() -> String {
     format!("CREATE TABLE {KS}.{WIDE_TBL} (\n  id int PRIMARY KEY,\n  payload blob\n);\n")
+}
+
+fn wide_uuid_schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{WIDE_UUID_TBL} (\n  id uuid PRIMARY KEY,\n  payload blob\n);\n")
+}
+
+fn wide_uuid_row(id_bytes: [u8; 16], ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Uuid(id_bytes));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Blob(vec![0xABu8; WIDE_PAYLOAD_BYTES]),
+    }];
+    Mutation::new(TableId::new(KS, WIDE_UUID_TBL), pk, None, ops, ts, None)
 }
 
 fn skinny_schema_cql() -> String {
@@ -239,6 +266,33 @@ async fn prepare_wide(root: &std::path::Path) -> (std::path::PathBuf, std::path:
     })
     .await
     .expect("build wide fixture");
+    (data_dir, schema_path)
+}
+
+/// Build a wide UUID-PK fixture: a handful of distinct-UUID single-row
+/// partitions, one keyed by [`LOOKUP_UUID`]. Each row's ~10 KiB payload dwarfs
+/// [`SUB_ROW_BUDGET_BYTES`].
+async fn prepare_wide_uuid(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let data_dir = root.join("wide_uuid_data");
+    let wal_dir = root.join("wide_uuid_wal");
+    let schema_path = root.join("wide_uuid_schema.cql");
+    std::fs::write(&schema_path, wide_uuid_schema_cql()).expect("write wide uuid schema");
+    let (d, w) = (data_dir.clone(), wal_dir.clone());
+    tokio::task::spawn_blocking(move || {
+        let rows: Vec<Mutation> = (0..WIDE_ROW_COUNT)
+            .map(|i| {
+                let uuid = if i == 0 {
+                    LOOKUP_UUID
+                } else {
+                    [(0x20u8 + i as u8); 16]
+                };
+                wide_uuid_row(uuid, 100)
+            })
+            .collect();
+        build_fixture(&d, &w, &wide_uuid_schema_cql(), rows);
+    })
+    .await
+    .expect("build wide uuid fixture");
     (data_dir, schema_path)
 }
 
@@ -554,6 +608,124 @@ async fn limit_offset_skips_wide_rows_uncharged_against_budget() {
         WIDE_ROWS_UNDER_BUDGET,
         "must return exactly the LIMIT rows after skipping the OFFSET rows"
     );
+}
+
+/// roborev FINDING (Medium): a WIDE-partition POINT LOOKUP that satisfies
+/// `is_simple_id_lookup` (`WHERE id = <value>` with ≤ 8 whitespace tokens) is
+/// routed through the LEGACY `QueryExecutor`, which — pre-fix — did NOT enforce
+/// the D6 byte budget. So a single wide row materialized unbounded and bypassed
+/// the guard entirely. Post-fix the budget is enforced POST-materialization on the
+/// legacy `QueryResult` at BOTH legacy return points (plan-cache hit and
+/// fall-through), reusing the SAME estimator/enforcement as the optimizer path.
+///
+/// `SUB_ROW_BUDGET_BYTES` (512 B) is smaller than one ~10 KiB wide row, so the
+/// point lookup of that one row must trip `ResultTooLarge`. The SQL is exactly 8
+/// whitespace tokens and contains `WHERE id =`, so it trips `is_simple_id_lookup`
+/// and exercises the legacy path under test (NOT the optimizer path).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wide_point_lookup_via_legacy_path_trips_byte_budget() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide_uuid(temp.path()).await;
+
+    let db = open_db_with_budget(data_dir, schema_path, SUB_ROW_BUDGET_BYTES).await;
+
+    // 8 whitespace tokens + "WHERE id =" → is_simple_id_lookup == true → legacy path.
+    let sql = format!("SELECT * FROM {KS}.{WIDE_UUID_TBL} WHERE id = {LOOKUP_UUID_LITERAL}");
+    assert_eq!(
+        sql.split_whitespace().count(),
+        8,
+        "test SQL must be <= 8 tokens to trip is_simple_id_lookup"
+    );
+    assert!(sql.contains("WHERE id ="));
+
+    let err = db
+        .execute(&sql)
+        .await
+        .expect_err("wide point lookup must exceed the sub-row byte budget on the legacy path");
+    match err {
+        Error::ResultTooLarge {
+            budget_bytes,
+            estimated_bytes,
+            rows,
+        } => {
+            assert_eq!(
+                budget_bytes, SUB_ROW_BUDGET_BYTES as usize,
+                "error must report the configured budget"
+            );
+            assert!(
+                estimated_bytes > budget_bytes,
+                "estimated bytes ({estimated_bytes}) must exceed budget ({budget_bytes})"
+            );
+            assert!(
+                rows >= 1,
+                "the materialized wide row must be counted; got rows={rows}"
+            );
+        }
+        other => panic!("expected Error::ResultTooLarge on the legacy path, got {other:?}"),
+    }
+}
+
+/// Control for the legacy-path budget: the SAME point lookup under a GENEROUS
+/// budget succeeds and returns the row — the guard is not over-firing on normal
+/// point reads.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wide_point_lookup_via_legacy_path_succeeds_under_generous_budget() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide_uuid(temp.path()).await;
+
+    let db = open_db_with_budget(data_dir, schema_path, DEFAULT_MAX_RESULT_BYTES).await;
+
+    let sql = format!("SELECT * FROM {KS}.{WIDE_UUID_TBL} WHERE id = {LOOKUP_UUID_LITERAL}");
+    let result = db
+        .execute(&sql)
+        .await
+        .expect("point lookup under a generous budget must succeed");
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "point lookup on id=0 must return exactly the one wide row"
+    );
+}
+
+/// Knob test on the legacy path: lowering `max_result_bytes` flips the SAME
+/// point-lookup query from Ok → `ResultTooLarge` — the byte budget is load-bearing
+/// on the legacy point-lookup path too, not just the optimizer path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn max_result_bytes_knob_is_load_bearing_on_legacy_point_lookup() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide_uuid(temp.path()).await;
+
+    let sql = format!("SELECT * FROM {KS}.{WIDE_UUID_TBL} WHERE id = {LOOKUP_UUID_LITERAL}");
+
+    // Generous budget: PASSES.
+    {
+        let db = open_db_with_budget(
+            data_dir.clone(),
+            schema_path.clone(),
+            DEFAULT_MAX_RESULT_BYTES,
+        )
+        .await;
+        let result = db
+            .execute(&sql)
+            .await
+            .expect("point lookup passes under the default budget");
+        assert_eq!(result.rows.len(), 1);
+    }
+
+    // Sub-row budget: the SAME query now TRIPS.
+    {
+        let db = open_db_with_budget(data_dir, schema_path, SUB_ROW_BUDGET_BYTES).await;
+        let err = db
+            .execute(&sql)
+            .await
+            .expect_err("lowering max_result_bytes must make the point lookup trip");
+        match err {
+            Error::ResultTooLarge { budget_bytes, .. } => {
+                assert_eq!(budget_bytes, SUB_ROW_BUDGET_BYTES as usize);
+            }
+            other => panic!("expected Error::ResultTooLarge under sub-row budget, got {other:?}"),
+        }
+    }
 }
 
 /// FINDING A (roborev MEDIUM): the `max_result_rows` row-count safety valve must

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -350,6 +350,52 @@ async fn max_result_bytes_knob_is_load_bearing() {
     }
 }
 
+/// A constant `SELECT` (no FROM clause, e.g. `SELECT '<big literal>'`) routes
+/// through `execute_constant_query`, which returned BEFORE the final-result
+/// budget check. This regression (roborev, #1582) proves the SAME byte budget is
+/// now applied to a constant result: a large literal trips `ResultTooLarge`,
+/// while a small literal under a generous budget still completes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn over_budget_constant_query_trips_byte_guard() {
+    let temp = TempDir::new().unwrap();
+    // Any valid DB — a constant query touches no table, so the skinny fixture's
+    // schema/data are irrelevant; we just need an open query stack whose budget
+    // is wired from config.
+    let (data_dir, schema_path) = prepare_skinny(temp.path()).await;
+
+    let tiny_budget: u64 = 512;
+    // A single text literal far larger than the budget (Text estimates to its
+    // byte length; see `estimate_value_size`).
+    let big_literal_len = (tiny_budget as usize) * 4;
+    let big_literal: String = "x".repeat(big_literal_len);
+
+    let db = open_db_with_budget(data_dir, schema_path, tiny_budget).await;
+
+    let sql = format!("SELECT '{big_literal}'");
+    let err = db
+        .execute(&sql)
+        .await
+        .expect_err("an over-budget constant SELECT must trip the byte guard");
+
+    match err {
+        Error::ResultTooLarge {
+            budget_bytes,
+            estimated_bytes,
+            ..
+        } => {
+            assert_eq!(
+                budget_bytes, tiny_budget as usize,
+                "error must report the configured budget"
+            );
+            assert!(
+                estimated_bytes > budget_bytes,
+                "estimated bytes ({estimated_bytes}) must exceed budget ({budget_bytes})"
+            );
+        }
+        other => panic!("expected Error::ResultTooLarge from a constant query, got {other:?}"),
+    }
+}
+
 /// The `max_result_rows` row-count safety valve must be load-bearing (wired from
 /// config), not a hardcoded 1,000,000 constant.
 ///

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -1,0 +1,293 @@
+//! Issue #1582 (Epic D6): the memory guard on a MATERIALIZED result set must be
+//! a BYTE ceiling, not a row count.
+//!
+//! ## The bug this guards
+//!
+//! The materializing SELECT path capped a result at `MAX_RESULTS = 1_000_000`
+//! ROWS. That is the wrong unit: 1M skinny rows may fit comfortably inside the
+//! project's <128MB memory target, while a few thousand WIDE rows (large blobs,
+//! wide partitions) can blow it long before the row-count guard ever fires. The
+//! fix adds a byte ceiling — [`cqlite_core::config::QueryConfig::max_result_bytes`],
+//! default 64 MiB — accumulated with the SAME `estimate_row_size` estimator the
+//! row cache uses, and raises the typed [`cqlite_core::Error::ResultTooLarge`]
+//! (whose message tells the user to add `LIMIT` or stream) when it is crossed.
+//! The row-count guard is retained only as a secondary safety valve.
+//!
+//! ## Why controlled `WriteEngine` fixtures (not the vendored `test_wide_rows`)
+//!
+//! The three assertions need EXACT, deterministic control over per-row width and
+//! row count so the byte budget can be tripped (or not) predictably regardless
+//! of environment — and they must not silently SKIP when the gitignored dataset
+//! `.db` binaries are absent from a clean checkout. Building a wide fixture (a
+//! few large-blob rows) and a skinny fixture (many tiny rows) via the public
+//! `WriteEngine` API gives that determinism while still exercising the guard
+//! end-to-end through `Database::execute`.
+//!
+//! ## What the three tests assert (all FAIL on pre-fix `main`, which has no
+//! byte guard and no `max_result_bytes` knob)
+//!
+//!   1. `wide_rows_trip_byte_guard_before_row_count_guard` — a handful of wide
+//!      rows trips the BYTE guard; the collected row count is far below the 1M
+//!      row-count valve, proving the byte guard fired first.
+//!   2. `skinny_rows_under_byte_budget_complete` — MANY skinny rows whose TOTAL
+//!      bytes stay under the SAME budget that tripped the wide fixture complete
+//!      fine and return every row (byte unit, not row unit).
+//!   3. `max_result_bytes_knob_is_load_bearing` — the same skinny query passes
+//!      under a large budget and trips under a small budget: lowering the knob
+//!      changes what trips, so it is a real behavioral knob, not decoration.
+//!
+//! Run with:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine \
+//!     --test issue_1582_byte_bounded_result_budget
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine",
+    not(feature = "tombstones")
+))]
+
+use cqlite_core::config::DEFAULT_MAX_RESULT_BYTES;
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database, Error};
+use tempfile::TempDir;
+
+const KS: &str = "budget_ks";
+const WIDE_TBL: &str = "wide_items";
+const SKINNY_TBL: &str = "skinny_items";
+
+/// ~10 KiB per row → a handful of rows dwarfs a small byte budget while staying
+/// far below the 1M row-count safety valve.
+const WIDE_PAYLOAD_BYTES: usize = 10 * 1024;
+const WIDE_ROW_COUNT: i32 = 8;
+
+/// Many tiny rows: total bytes stay small even though the row COUNT is large
+/// relative to the wide fixture.
+const SKINNY_ROW_COUNT: i32 = 400;
+
+fn wide_schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{WIDE_TBL} (\n  id int PRIMARY KEY,\n  payload blob\n);\n")
+}
+
+fn skinny_schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{SKINNY_TBL} (\n  id int PRIMARY KEY,\n  n int\n);\n")
+}
+
+fn wide_row(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Blob(vec![0xABu8; WIDE_PAYLOAD_BYTES]),
+    }];
+    Mutation::new(TableId::new(KS, WIDE_TBL), pk, None, ops, ts, None)
+}
+
+fn skinny_row(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "n".to_string(),
+        value: Value::Integer(id),
+    }];
+    Mutation::new(TableId::new(KS, SKINNY_TBL), pk, None, ops, ts, None)
+}
+
+/// Flush a single generation for `table` with the supplied schema + rows.
+fn build_fixture(
+    data_dir: &std::path::Path,
+    wal_dir: &std::path::Path,
+    schema_cql: &str,
+    rows: Vec<Mutation>,
+) {
+    use cqlite_core::schema::parse_cql_schema;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let schema = parse_cql_schema(schema_cql).expect("parse fixture schema");
+    let config = WriteEngineConfig::new(data_dir.to_path_buf(), wal_dir.to_path_buf(), schema);
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    for m in rows {
+        engine.write(m).expect("write row");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush")
+        .expect("flush produced no SSTable");
+    rt.block_on(engine.close()).expect("close engine");
+}
+
+/// Open the full query stack over `data_dir` with a specific `max_result_bytes`
+/// budget wired through config (so the knob is exercised end-to-end).
+async fn open_db_with_budget(
+    data_dir: std::path::PathBuf,
+    schema_path: std::path::PathBuf,
+    max_result_bytes: u64,
+) -> Database {
+    let mut core_config = Config::default();
+    core_config.query.max_result_bytes = max_result_bytes;
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config,
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest fixture");
+    assert!(
+        result.schema_load_result.schemas_loaded >= 1,
+        "schema must load"
+    );
+    result.database
+}
+
+/// Build a wide-row fixture under `root`; returns (data_dir, schema_path).
+///
+/// The fixture is flushed on a blocking thread (the `WriteEngine` flush drives
+/// its own current-thread runtime and cannot run inside the test's tokio
+/// runtime).
+async fn prepare_wide(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let data_dir = root.join("wide_data");
+    let wal_dir = root.join("wide_wal");
+    let schema_path = root.join("wide_schema.cql");
+    std::fs::write(&schema_path, wide_schema_cql()).expect("write wide schema");
+    let (d, w) = (data_dir.clone(), wal_dir.clone());
+    tokio::task::spawn_blocking(move || {
+        let rows: Vec<Mutation> = (0..WIDE_ROW_COUNT).map(|i| wide_row(i, 100)).collect();
+        build_fixture(&d, &w, &wide_schema_cql(), rows);
+    })
+    .await
+    .expect("build wide fixture");
+    (data_dir, schema_path)
+}
+
+async fn prepare_skinny(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let data_dir = root.join("skinny_data");
+    let wal_dir = root.join("skinny_wal");
+    let schema_path = root.join("skinny_schema.cql");
+    std::fs::write(&schema_path, skinny_schema_cql()).expect("write skinny schema");
+    let (d, w) = (data_dir.clone(), wal_dir.clone());
+    tokio::task::spawn_blocking(move || {
+        let rows: Vec<Mutation> = (0..SKINNY_ROW_COUNT).map(|i| skinny_row(i, 100)).collect();
+        build_fixture(&d, &w, &skinny_schema_cql(), rows);
+    })
+    .await
+    .expect("build skinny fixture");
+    (data_dir, schema_path)
+}
+
+/// A byte budget that a handful of ~10 KiB wide rows exceeds, but the skinny
+/// fixture's total logical bytes (~few KiB) stays under.
+const SHARED_BUDGET_BYTES: u64 = 24 * 1024;
+
+/// Test 1: a few WIDE rows trip the BYTE guard before the row-count guard.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wide_rows_trip_byte_guard_before_row_count_guard() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide(temp.path()).await;
+
+    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
+
+    let sql = format!("SELECT * FROM {KS}.{WIDE_TBL}");
+    let err = db
+        .execute(&sql)
+        .await
+        .expect_err("wide SELECT * must exceed the byte budget");
+
+    match err {
+        Error::ResultTooLarge {
+            budget_bytes,
+            estimated_bytes,
+            rows,
+        } => {
+            assert_eq!(
+                budget_bytes, SHARED_BUDGET_BYTES as usize,
+                "error must report the configured budget"
+            );
+            assert!(
+                estimated_bytes > budget_bytes,
+                "estimated bytes ({estimated_bytes}) must exceed budget ({budget_bytes})"
+            );
+            // The whole point of D6: the BYTE guard fired, NOT the 1M row-count
+            // valve. A handful of wide rows is nowhere near 1M.
+            assert!(
+                rows < 1_000_000,
+                "byte guard must trip long before the 1M row-count guard; got rows={rows}"
+            );
+        }
+        other => panic!("expected Error::ResultTooLarge, got {other:?}"),
+    }
+}
+
+/// Test 2: MANY skinny rows whose total bytes stay under the SAME budget that
+/// tripped the wide fixture complete fine and return every row.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn skinny_rows_under_byte_budget_complete() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_skinny(temp.path()).await;
+
+    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
+
+    let sql = format!("SELECT * FROM {KS}.{SKINNY_TBL}");
+    let result = db
+        .execute(&sql)
+        .await
+        .expect("skinny SELECT * must stay under the byte budget");
+
+    assert_eq!(
+        result.rows.len(),
+        SKINNY_ROW_COUNT as usize,
+        "all skinny rows must be returned even though there are MORE rows than \
+         the wide fixture that tripped the same byte budget"
+    );
+}
+
+/// Test 3: the `max_result_bytes` knob is load-bearing — the same skinny query
+/// passes under a large budget and trips under a small one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn max_result_bytes_knob_is_load_bearing() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_skinny(temp.path()).await;
+
+    let sql = format!("SELECT * FROM {KS}.{SKINNY_TBL}");
+
+    // Large budget (the shipped default): the query PASSES and returns all rows.
+    {
+        let db = open_db_with_budget(
+            data_dir.clone(),
+            schema_path.clone(),
+            DEFAULT_MAX_RESULT_BYTES,
+        )
+        .await;
+        let result = db
+            .execute(&sql)
+            .await
+            .expect("skinny SELECT * passes under the default budget");
+        assert_eq!(result.rows.len(), SKINNY_ROW_COUNT as usize);
+    }
+
+    // Small budget: the SAME query now TRIPS the guard. Lowering the knob changed
+    // what trips → the knob is real, not decorative.
+    {
+        let tiny_budget: u64 = 512;
+        let db = open_db_with_budget(data_dir, schema_path, tiny_budget).await;
+        let err = db
+            .execute(&sql)
+            .await
+            .expect_err("lowering max_result_bytes must make the skinny query trip");
+        match err {
+            Error::ResultTooLarge { budget_bytes, .. } => {
+                assert_eq!(budget_bytes, tiny_budget as usize);
+            }
+            other => panic!("expected Error::ResultTooLarge under tiny budget, got {other:?}"),
+        }
+    }
+}

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -73,7 +73,7 @@
 use cqlite_core::config::DEFAULT_MAX_RESULT_BYTES;
 use cqlite_core::ingestion::{ingest, IngestionConfig};
 use cqlite_core::storage::write_engine::{
-    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
 };
 use cqlite_core::types::Value;
 use cqlite_core::{Config, Database, Error};
@@ -119,6 +119,12 @@ const MATCH_COUNT: usize = 10;
 /// (unlike an int `id`, which the legacy path maps to a synthetic `user_key_N`
 /// that never matches a real SSTable partition key).
 const WIDE_UUID_TBL: &str = "wide_uuid_items";
+/// Wide fixture with a CLUSTERING column so `ORDER BY ck` is available. All rows
+/// live in ONE partition (`id = 0`) with a wide payload each, so the partition's
+/// materialized size dwarfs [`SHARED_BUDGET_BYTES`]. A plan with `ORDER BY`
+/// emits a `Sort` step, so `compute_scan_collect_bound` returns `None` — the exact
+/// uncovered path for the query-wide `LIMIT 0` short-circuit (D6 roborev finding).
+const WIDE_CK_TBL: &str = "wide_ck_items";
 /// The partition looked up by the legacy-path tests (`0x11` repeated 16×). Its
 /// canonical UUID literal (below) is what the CQL `WHERE id = ...` clause carries.
 const LOOKUP_UUID: [u8; 16] = [0x11u8; 16];
@@ -139,6 +145,29 @@ fn wide_uuid_row(id_bytes: [u8; 16], ts: i64) -> Mutation {
         value: Value::Blob(vec![0xABu8; WIDE_PAYLOAD_BYTES]),
     }];
     Mutation::new(TableId::new(KS, WIDE_UUID_TBL), pk, None, ops, ts, None)
+}
+
+fn wide_ck_schema_cql() -> String {
+    format!(
+        "CREATE TABLE {KS}.{WIDE_CK_TBL} (\n  id int,\n  ck int,\n  payload blob,\n  PRIMARY KEY (id, ck)\n);\n"
+    )
+}
+
+fn wide_ck_row(id: i32, ck: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let clustering = ClusteringKey::single("ck", Value::Integer(ck));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Blob(vec![0xABu8; WIDE_PAYLOAD_BYTES]),
+    }];
+    Mutation::new(
+        TableId::new(KS, WIDE_CK_TBL),
+        pk,
+        Some(clustering),
+        ops,
+        ts,
+        None,
+    )
 }
 
 fn skinny_schema_cql() -> String {
@@ -293,6 +322,27 @@ async fn prepare_wide_uuid(root: &std::path::Path) -> (std::path::PathBuf, std::
     })
     .await
     .expect("build wide uuid fixture");
+    (data_dir, schema_path)
+}
+
+/// Build a single wide partition (`id = 0`) with [`WIDE_ROW_COUNT`] clustering
+/// rows, each carrying a ~10 KiB payload. `ORDER BY ck` over it emits a `Sort`
+/// step (so `compute_scan_collect_bound` is `None`), and the partition's
+/// materialized size (~80 KiB) dwarfs [`SHARED_BUDGET_BYTES`].
+async fn prepare_wide_ck(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let data_dir = root.join("wide_ck_data");
+    let wal_dir = root.join("wide_ck_wal");
+    let schema_path = root.join("wide_ck_schema.cql");
+    std::fs::write(&schema_path, wide_ck_schema_cql()).expect("write wide ck schema");
+    let (d, w) = (data_dir.clone(), wal_dir.clone());
+    tokio::task::spawn_blocking(move || {
+        let rows: Vec<Mutation> = (0..WIDE_ROW_COUNT)
+            .map(|ck| wide_ck_row(0, ck, 100))
+            .collect();
+        build_fixture(&d, &w, &wide_ck_schema_cql(), rows);
+    })
+    .await
+    .expect("build wide ck fixture");
     (data_dir, schema_path)
 }
 
@@ -502,6 +552,52 @@ async fn limit_zero_targeted_returns_empty_never_result_too_large() {
     assert!(
         result.rows.is_empty(),
         "LIMIT 0 must return zero rows; got {}",
+        result.rows.len()
+    );
+}
+
+/// FINDING D6 (roborev MEDIUM): a query-wide `LIMIT 0` must ALWAYS return an empty
+/// result, never `ResultTooLarge` — INCLUDING when the plan carries a reordering /
+/// reducing step (`Sort`, `Filter`, `Aggregate`, `PerPartitionLimit`) that makes
+/// `compute_scan_collect_bound` return `None`. Here `ORDER BY ck` emits a `Sort`
+/// step, so the `collect_bound == Some(0)` short-circuit never fires; pre-fix the
+/// fallback scan-collection loop had no LIMIT-0 early-return, so it scanned the full
+/// wide partition (~80 KiB) under the sub-partition [`SHARED_BUDGET_BYTES`] budget
+/// and raised `ResultTooLarge` instead of returning empty. Post-fix a query-wide
+/// `ExecutionStep::Limit { count: 0, .. }` short-circuits to an empty result BEFORE
+/// scanning, independent of whether a collect bound was computed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn limit_zero_with_reordering_step_returns_empty_not_too_large() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide_ck(temp.path()).await;
+
+    // Budget BELOW the wide partition's materialized size (8 × ~10 KiB ≫ 24 KiB).
+    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
+
+    // Sanity: the SAME ORDER BY query with a NON-zero LIMIT scans the wide
+    // partition and trips the guard — the `Sort` step disables the collect-bound
+    // early-stop, so the full partition is collected and the budget bites. This
+    // proves the query exercises the uncovered `compute_scan_collect_bound == None`
+    // path (not a plan that early-stops).
+    let unlimited = format!("SELECT * FROM {KS}.{WIDE_CK_TBL} ORDER BY ck LIMIT {WIDE_ROW_COUNT}");
+    let err = db
+        .execute(&unlimited)
+        .await
+        .expect_err("wide ORDER BY scan must exceed the byte budget");
+    assert!(
+        matches!(err, Error::ResultTooLarge { .. }),
+        "unlimited ORDER BY query must trip the guard (Sort disables early-stop), got {err:?}"
+    );
+
+    // LIMIT 0 with the reordering Sort step must short-circuit to empty, never error.
+    let sql = format!("SELECT * FROM {KS}.{WIDE_CK_TBL} ORDER BY ck LIMIT 0");
+    let result = db
+        .execute(&sql)
+        .await
+        .expect("query-wide LIMIT 0 must short-circuit to empty, never ResultTooLarge");
+    assert!(
+        result.rows.is_empty(),
+        "LIMIT 0 must return zero rows even with a Sort step; got {}",
         result.rows.len()
     );
 }

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -48,6 +48,15 @@
 //!      (roborev FINDING 2) — `WHERE pk = ? LIMIT 0` over a wide table under a
 //!      sub-row budget returns empty, never `ResultTooLarge`: LIMIT 0
 //!      short-circuits before any scan/lookup/push/budget work.
+//!   7. `limit_offset_skips_wide_rows_uncharged_against_budget`
+//!      (roborev FINDING B) — `LIMIT 2 OFFSET N` over the wide fixture, where the
+//!      skipped OFFSET rows would blow the budget but the 2 returned rows fit,
+//!      SUCCEEDS: the offset rows are skipped uncharged, so only the returned
+//!      rows are budgeted.
+//!   8. `max_result_rows_knob_is_load_bearing` (roborev FINDING A) — lowering
+//!      `max_result_rows` under a generous byte budget makes the skinny query
+//!      trip the row-count safety valve; a high value passes. The knob is real,
+//!      not a hardcoded constant.
 //!
 //! Run with:
 //!   cargo test --package cqlite-core \
@@ -180,8 +189,22 @@ async fn open_db_with_budget(
     schema_path: std::path::PathBuf,
     max_result_bytes: u64,
 ) -> Database {
+    // Default row-count valve (1M) — byte budget is the guard under test here.
+    open_db_with_budgets(data_dir, schema_path, max_result_bytes, 1_000_000).await
+}
+
+/// Open the query stack wiring BOTH the byte budget and the `max_result_rows`
+/// row-count safety valve through config (roborev FINDING A: the row-count knob
+/// must be load-bearing, not a hardcoded constant).
+async fn open_db_with_budgets(
+    data_dir: std::path::PathBuf,
+    schema_path: std::path::PathBuf,
+    max_result_bytes: u64,
+    max_result_rows: u64,
+) -> Database {
     let mut core_config = Config::default();
     core_config.query.max_result_bytes = max_result_bytes;
+    core_config.query.max_result_rows = max_result_rows;
 
     let result = ingest(IngestionConfig {
         schema_paths: vec![schema_path],
@@ -490,6 +513,101 @@ async fn max_result_bytes_knob_is_load_bearing() {
                 assert_eq!(budget_bytes, tiny_budget as usize);
             }
             other => panic!("expected Error::ResultTooLarge under tiny budget, got {other:?}"),
+        }
+    }
+}
+
+/// FINDING B (roborev MEDIUM): `LIMIT ... OFFSET ...` must NOT charge the skipped
+/// OFFSET rows against the byte budget. A query whose FINAL result is small must
+/// SUCCEED even when the skipped rows are wide enough that charging them would
+/// exceed the budget.
+///
+/// The wide fixture has `WIDE_ROW_COUNT` rows of ~`WIDE_PAYLOAD_BYTES` each.
+/// `LIMIT WIDE_ROWS_UNDER_BUDGET OFFSET WIDE_OFFSET` under `SHARED_BUDGET_BYTES`:
+/// the `WIDE_OFFSET` skipped rows total ~40 KiB (well over the ~24 KiB budget),
+/// but the 2 returned rows total ~20 KiB (under budget). Pre-fix the scan
+/// collected `offset + count` matching rows and charged EACH, tripping the byte
+/// guard at ~row 3 → RED (`ResultTooLarge`). Post-fix the offset rows are skipped
+/// uncharged (never pushed, never budgeted) and only the 2 returned rows are
+/// budgeted → GREEN.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn limit_offset_skips_wide_rows_uncharged_against_budget() {
+    // Skip 4 wide rows (~40 KiB, over budget), return 2 (~20 KiB, under budget).
+    const WIDE_OFFSET: usize = 4;
+    // Sanity on the fixture sizing: offset + limit must fit inside the fixture.
+    assert!(WIDE_OFFSET + WIDE_ROWS_UNDER_BUDGET <= WIDE_ROW_COUNT as usize);
+
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide(temp.path()).await;
+
+    let db = open_db_with_budget(data_dir, schema_path, SHARED_BUDGET_BYTES).await;
+
+    let sql = format!(
+        "SELECT * FROM {KS}.{WIDE_TBL} LIMIT {WIDE_ROWS_UNDER_BUDGET} OFFSET {WIDE_OFFSET}"
+    );
+    let result = db.execute(&sql).await.expect(
+        "LIMIT/OFFSET must skip the wide OFFSET rows uncharged and budget only the \
+         returned rows, not trip ResultTooLarge",
+    );
+    assert_eq!(
+        result.rows.len(),
+        WIDE_ROWS_UNDER_BUDGET,
+        "must return exactly the LIMIT rows after skipping the OFFSET rows"
+    );
+}
+
+/// FINDING A (roborev MEDIUM): the `max_result_rows` row-count safety valve must
+/// be load-bearing (wired from config), not a hardcoded 1,000,000 constant.
+///
+/// Under a GENEROUS byte budget (so the byte guard never fires), the skinny
+/// query passes with a high `max_result_rows` and TRIPS the row-count valve when
+/// `max_result_rows` is lowered below the fixture's row count. Lowering the knob
+/// changes what trips → it is a real behavioral knob. Pre-fix the guard used a
+/// hardcoded `MAX_RESULTS = 1_000_000`, so lowering the config value had NO
+/// effect and the query still passed → RED.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn max_result_rows_knob_is_load_bearing() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_skinny(temp.path()).await;
+
+    let sql = format!("SELECT * FROM {KS}.{SKINNY_TBL}");
+
+    // High row-count valve (and generous byte budget): the query PASSES.
+    {
+        let db = open_db_with_budgets(
+            data_dir.clone(),
+            schema_path.clone(),
+            DEFAULT_MAX_RESULT_BYTES,
+            1_000_000,
+        )
+        .await;
+        let result = db
+            .execute(&sql)
+            .await
+            .expect("skinny SELECT * passes under a high row-count valve");
+        assert_eq!(result.rows.len(), SKINNY_ROW_COUNT as usize);
+    }
+
+    // Low row-count valve (same generous byte budget): the SAME query now TRIPS.
+    // Lowering the config knob changed what trips → the valve is load-bearing.
+    {
+        let low_rows: u64 = (SKINNY_ROW_COUNT as u64) / 2; // < fixture row count
+        let db = open_db_with_budgets(data_dir, schema_path, DEFAULT_MAX_RESULT_BYTES, low_rows)
+            .await;
+        let err = db
+            .execute(&sql)
+            .await
+            .expect_err("lowering max_result_rows must make the skinny query trip the valve");
+        // The row-count valve raises the legacy query-execution error (add LIMIT),
+        // NOT ResultTooLarge (which is the byte guard, generous here).
+        match err {
+            Error::QueryExecution(msg) => {
+                assert!(
+                    msg.contains("LIMIT"),
+                    "row-count valve error should advise adding LIMIT; got {msg:?}"
+                );
+            }
+            other => panic!("expected Error::QueryExecution from the row-count valve, got {other:?}"),
         }
     }
 }

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -24,8 +24,10 @@
 //! rows are never charged. This replaced the earlier during-collection machinery
 //! (LIMIT/OFFSET pushdown, per-row early-stop, storage-layer row limit) that kept
 //! generating correctness edge cases. SCOPE (owner-accepted, tracked on #1582):
-//! does NOT bound peak scan memory (deferred #1897) and does NOT cover the legacy
-//! `WHERE id = ?` point-lookup path (deferred to the D6 redesign).
+//! does NOT bound peak scan memory (deferred #1897). The legacy `WHERE id =`
+//! point-lookup path (routed through `QueryExecutor`, not `SelectExecutor`) IS
+//! covered — the SAME byte budget is enforced at every legacy return site,
+//! including the plan-cache HIT return (roborev #1582 D6).
 //!
 //! ## Why controlled `WriteEngine` fixtures (not the vendored `test_wide_rows`)
 //!
@@ -61,6 +63,13 @@ use tempfile::TempDir;
 const KS: &str = "budget_ks";
 const WIDE_TBL: &str = "wide_items";
 const SKINNY_TBL: &str = "skinny_items";
+/// Text-keyed wide table used to exercise the LEGACY `WHERE id = <text>`
+/// point-lookup path. A TEXT partition key named `id` routes through the legacy
+/// `QueryExecutor` (`is_simple_id_lookup` gate) AND is findable by `storage.get`
+/// (the query-side `value_to_row_key(Text)` matches `PartitionKey::to_bytes`),
+/// unlike an INTEGER `id`, which the executor maps to a synthetic `user_key_N`.
+const WIDE_KEYED_TBL: &str = "wide_keyed_items";
+const WIDE_KEY: &str = "wide1";
 
 /// ~10 KiB per row → a handful of rows dwarfs a small byte budget while staying
 /// far below the 1M row-count safety valve.
@@ -86,6 +95,19 @@ fn wide_schema_cql() -> String {
 
 fn skinny_schema_cql() -> String {
     format!("CREATE TABLE {KS}.{SKINNY_TBL} (\n  id int PRIMARY KEY,\n  n int\n);\n")
+}
+
+fn wide_keyed_schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{WIDE_KEYED_TBL} (\n  id text PRIMARY KEY,\n  payload blob\n);\n")
+}
+
+fn wide_keyed_row(id: &str, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Text(id.to_string()));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Blob(vec![0xABu8; WIDE_PAYLOAD_BYTES]),
+    }];
+    Mutation::new(TableId::new(KS, WIDE_KEYED_TBL), pk, None, ops, ts, None)
 }
 
 fn wide_row(id: i32, ts: i64) -> Mutation {
@@ -190,6 +212,21 @@ async fn prepare_wide(root: &std::path::Path) -> (std::path::PathBuf, std::path:
     })
     .await
     .expect("build wide fixture");
+    (data_dir, schema_path)
+}
+
+async fn prepare_wide_keyed(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let data_dir = root.join("wide_keyed_data");
+    let wal_dir = root.join("wide_keyed_wal");
+    let schema_path = root.join("wide_keyed_schema.cql");
+    std::fs::write(&schema_path, wide_keyed_schema_cql()).expect("write wide-keyed schema");
+    let (d, w) = (data_dir.clone(), wal_dir.clone());
+    tokio::task::spawn_blocking(move || {
+        let rows = vec![wide_keyed_row(WIDE_KEY, 100)];
+        build_fixture(&d, &w, &wide_keyed_schema_cql(), rows);
+    })
+    .await
+    .expect("build wide-keyed fixture");
     (data_dir, schema_path)
 }
 
@@ -394,6 +431,65 @@ async fn over_budget_constant_query_trips_byte_guard() {
         }
         other => panic!("expected Error::ResultTooLarge from a constant query, got {other:?}"),
     }
+}
+
+/// A simple `SELECT * ... WHERE id = <k>` point lookup routes through the LEGACY
+/// `QueryExecutor` (not the budgeted `SelectExecutor`; see `QueryEngine::execute`'s
+/// `is_simple_id_lookup` gate). A single very wide row must trip `ResultTooLarge`
+/// there too — AND on the plan-cache HIT (the second identical execution), which
+/// before the fix returned WITHOUT applying the budget (roborev #1582 D6). The
+/// plan is cached BEFORE execution, so the cold cache-miss run leaves the plan in
+/// the cache and the second run takes the plan-cache-hit return path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn over_budget_point_lookup_trips_on_cold_and_cache_hit() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide_keyed(temp.path()).await;
+
+    // A budget far smaller than the single ~10 KiB wide row, so a one-row point
+    // lookup necessarily exceeds it; the default 1M row-count valve stays generous
+    // so the BYTE guard is what fires.
+    let tiny_budget: u64 = 512;
+    let db = open_db_with_budget(data_dir, schema_path, tiny_budget).await;
+
+    // `WHERE id = '<text>'` (<= 8 whitespace tokens) routes through the legacy
+    // point-lookup path; the text key is findable by `storage.get`.
+    let sql = format!("SELECT * FROM {KS}.{WIDE_KEYED_TBL} WHERE id = '{WIDE_KEY}'");
+
+    fn assert_trips(err: Error, tiny_budget: u64, phase: &str) {
+        match err {
+            Error::ResultTooLarge {
+                budget_bytes,
+                estimated_bytes,
+                ..
+            } => {
+                assert_eq!(
+                    budget_bytes, tiny_budget as usize,
+                    "{phase}: error must report the configured budget"
+                );
+                assert!(
+                    estimated_bytes > budget_bytes,
+                    "{phase}: estimated bytes ({estimated_bytes}) must exceed budget \
+                     ({budget_bytes})"
+                );
+            }
+            other => panic!("{phase}: expected Error::ResultTooLarge, got {other:?}"),
+        }
+    }
+
+    // Cold (cache-miss): plan built + cached, executed, budget enforced on exit.
+    let cold = db
+        .execute(&sql)
+        .await
+        .expect_err("cold point lookup returning one wide row must trip the byte guard");
+    assert_trips(cold, tiny_budget, "cold");
+
+    // Second identical execution takes the plan-cache HIT return path, which must
+    // ALSO enforce the budget (the gap this test guards).
+    let cache_hit = db
+        .execute(&sql)
+        .await
+        .expect_err("plan-cache-HIT point lookup must ALSO trip the byte guard");
+    assert_trips(cache_hit, tiny_budget, "cache-hit");
 }
 
 /// The `max_result_rows` row-count safety valve must be load-bearing (wired from

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -37,9 +37,17 @@
 //!      changes what trips, so it is a real behavioral knob, not decoration.
 //!   4. `limited_query_over_wide_table_completes_under_budget` (FINDING 2) — a
 //!      LIMITed query over the wide fixture (whose UNLIMITED scan trips the guard)
-//!      completes and returns the limited rows: the LIMIT bound is propagated into
-//!      the scan and collection early-stops, so the budget never bites on matching
-//!      rows beyond the LIMIT.
+//!      completes and returns the limited rows: collection early-stops after
+//!      predicate evaluation, so the budget never bites on matching rows beyond
+//!      the LIMIT.
+//!   5. `limit_with_non_pk_predicate_returns_all_matches_not_first_n_raw`
+//!      (roborev FINDING 1) — a `WHERE non_pk = ? LIMIT N` returns ALL N matching
+//!      rows, not the matches among the first N RAW rows: the LIMIT is NOT pushed
+//!      into the predicate-unaware `storage.scan`.
+//!   6. `limit_zero_targeted_returns_empty_never_result_too_large`
+//!      (roborev FINDING 2) — `WHERE pk = ? LIMIT 0` over a wide table under a
+//!      sub-row budget returns empty, never `ResultTooLarge`: LIMIT 0
+//!      short-circuits before any scan/lookup/push/budget work.
 //!
 //! Run with:
 //!   cargo test --package cqlite-core \
@@ -65,6 +73,9 @@ use tempfile::TempDir;
 const KS: &str = "budget_ks";
 const WIDE_TBL: &str = "wide_items";
 const SKINNY_TBL: &str = "skinny_items";
+/// Non-PK-filter fixture for FINDING 1 (LIMIT must not be pushed into storage
+/// ahead of executor-side predicate evaluation).
+const FILTERED_TBL: &str = "filtered_items";
 
 /// ~10 KiB per row → a handful of rows dwarfs a small byte budget while staying
 /// far below the 1M row-count safety valve.
@@ -81,12 +92,25 @@ const WIDE_ROWS_UNDER_BUDGET: usize = 2;
 /// relative to the wide fixture.
 const SKINNY_ROW_COUNT: i32 = 400;
 
+/// FINDING 1 fixture: total rows, and the group value a small, spread-out subset
+/// carries. Only every 20th row matches `MATCH_GRP` (10 rows), so the matching
+/// rows are scattered throughout token order — NOT confined to the first
+/// `MATCH_COUNT` rows a buggy storage-pushed LIMIT would return.
+const FILTERED_ROW_COUNT: i32 = 200;
+const MATCH_GRP: i32 = 7;
+const NON_MATCH_GRP: i32 = 0;
+const MATCH_COUNT: usize = 10;
+
 fn wide_schema_cql() -> String {
     format!("CREATE TABLE {KS}.{WIDE_TBL} (\n  id int PRIMARY KEY,\n  payload blob\n);\n")
 }
 
 fn skinny_schema_cql() -> String {
     format!("CREATE TABLE {KS}.{SKINNY_TBL} (\n  id int PRIMARY KEY,\n  n int\n);\n")
+}
+
+fn filtered_schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{FILTERED_TBL} (\n  id int PRIMARY KEY,\n  grp int\n);\n")
 }
 
 fn wide_row(id: i32, ts: i64) -> Mutation {
@@ -105,6 +129,21 @@ fn skinny_row(id: i32, ts: i64) -> Mutation {
         value: Value::Integer(id),
     }];
     Mutation::new(TableId::new(KS, SKINNY_TBL), pk, None, ops, ts, None)
+}
+
+fn filtered_row(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    // Every 20th row matches MATCH_GRP; the rest carry NON_MATCH_GRP.
+    let grp = if id % 20 == 0 {
+        MATCH_GRP
+    } else {
+        NON_MATCH_GRP
+    };
+    let ops = vec![CellOperation::Write {
+        column: "grp".to_string(),
+        value: Value::Integer(grp),
+    }];
+    Mutation::new(TableId::new(KS, FILTERED_TBL), pk, None, ops, ts, None)
 }
 
 /// Flush a single generation for `table` with the supplied schema + rows.
@@ -195,9 +234,31 @@ async fn prepare_skinny(root: &std::path::Path) -> (std::path::PathBuf, std::pat
     (data_dir, schema_path)
 }
 
+async fn prepare_filtered(root: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let data_dir = root.join("filtered_data");
+    let wal_dir = root.join("filtered_wal");
+    let schema_path = root.join("filtered_schema.cql");
+    std::fs::write(&schema_path, filtered_schema_cql()).expect("write filtered schema");
+    let (d, w) = (data_dir.clone(), wal_dir.clone());
+    tokio::task::spawn_blocking(move || {
+        let rows: Vec<Mutation> = (0..FILTERED_ROW_COUNT)
+            .map(|i| filtered_row(i, 100))
+            .collect();
+        build_fixture(&d, &w, &filtered_schema_cql(), rows);
+    })
+    .await
+    .expect("build filtered fixture");
+    (data_dir, schema_path)
+}
+
 /// A byte budget that a handful of ~10 KiB wide rows exceeds, but the skinny
 /// fixture's total logical bytes (~few KiB) stays under.
 const SHARED_BUDGET_BYTES: u64 = 24 * 1024;
+
+/// A byte budget SMALLER than a single wide row (~10 KiB): a single-partition
+/// lookup that materializes one wide row would trip the guard under it — used to
+/// prove the FINDING 2 `LIMIT 0` short-circuit fires BEFORE any push/byte-check.
+const SUB_ROW_BUDGET_BYTES: u64 = 512;
 
 /// Test 1: a few WIDE rows trip the BYTE guard before the row-count guard.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -285,6 +346,86 @@ async fn limited_query_over_wide_table_completes_under_budget() {
         result.rows.len(),
         WIDE_ROWS_UNDER_BUDGET,
         "LIMIT must be honored (early-stop before the byte budget bites)"
+    );
+}
+
+/// FINDING 1 (roborev HIGH): a LIMIT must NOT be pushed into storage ahead of
+/// executor-side predicate evaluation. The optimizer folds `WHERE grp = ?` into
+/// the `SSTableScan` step's predicates WITHOUT a residual `Filter`, but
+/// `storage.scan` is not predicate-aware. If the query-wide `LIMIT N` bound is
+/// pushed into `storage.scan`, storage returns only the first `N` RAW (unfiltered)
+/// rows in token order; the matching rows scattered further along the scan are
+/// never seen, so the executor filters `N` raw rows down to far fewer than `N`
+/// matches → WRONG RESULTS.
+///
+/// This fixture has `MATCH_COUNT` matching rows spread across `FILTERED_ROW_COUNT`
+/// total rows. `SELECT * WHERE grp = MATCH_GRP LIMIT MATCH_COUNT` must return all
+/// `MATCH_COUNT` matches. Pre-fix (storage-pushed LIMIT) this returns only the
+/// matches that happen to fall within the first `MATCH_COUNT` token-ordered rows
+/// (≈ `MATCH_COUNT² / FILTERED_ROW_COUNT` ≈ 0–1) → RED. Post-fix the storage limit
+/// is withheld whenever executor-side predicates exist and the early-stop counts
+/// only rows that PASSED the predicate → all `MATCH_COUNT` matches → GREEN.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn limit_with_non_pk_predicate_returns_all_matches_not_first_n_raw() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_filtered(temp.path()).await;
+
+    // Generous budget: FINDING 1 is about correctness, not the byte guard.
+    let db = open_db_with_budget(data_dir, schema_path, DEFAULT_MAX_RESULT_BYTES).await;
+
+    let sql =
+        format!("SELECT * FROM {KS}.{FILTERED_TBL} WHERE grp = {MATCH_GRP} LIMIT {MATCH_COUNT}");
+    let result = db
+        .execute(&sql)
+        .await
+        .expect("filtered LIMIT query must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        MATCH_COUNT,
+        "LIMIT must return ALL matching rows, not the matches among the first N \
+         RAW rows a storage-pushed limit would return (FINDING 1)"
+    );
+}
+
+/// FINDING 2 (roborev MEDIUM): `WHERE pk = ? LIMIT 0` over a wide table must
+/// return an empty result, never `ResultTooLarge`. The budget here is SMALLER than
+/// a single wide row, so pre-fix the targeted lookup materialized the matching row
+/// and byte-checked it before the LIMIT-0 bound was honored → `ResultTooLarge`.
+/// Post-fix the `collect_bound == Some(0)` short-circuit returns empty before any
+/// scan/lookup/push/budget work.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn limit_zero_targeted_returns_empty_never_result_too_large() {
+    let temp = TempDir::new().unwrap();
+    let (data_dir, schema_path) = prepare_wide(temp.path()).await;
+
+    let db = open_db_with_budget(data_dir, schema_path, SUB_ROW_BUDGET_BYTES).await;
+
+    // Sanity: the same single-partition lookup with a NON-zero LIMIT trips the
+    // guard (one wide row exceeds the sub-row budget) — proving the budget is
+    // binding and that only the LIMIT-0 short-circuit makes this query empty rather
+    // than error. (A bare `WHERE id = 0` with no LIMIT is routed to the legacy
+    // executor by a word-count heuristic in `QueryEngine::execute`; keeping a LIMIT
+    // clause here routes through the optimizer path under test.)
+    let point = format!("SELECT * FROM {KS}.{WIDE_TBL} WHERE id = 0 LIMIT 5");
+    let err = db
+        .execute(&point)
+        .await
+        .expect_err("a single wide row must exceed the sub-row byte budget");
+    assert!(
+        matches!(err, Error::ResultTooLarge { .. }),
+        "point lookup of one wide row must trip the guard, got {err:?}"
+    );
+
+    let sql = format!("SELECT * FROM {KS}.{WIDE_TBL} WHERE id = 0 LIMIT 0");
+    let result = db
+        .execute(&sql)
+        .await
+        .expect("LIMIT 0 must short-circuit to an empty result, never ResultTooLarge");
+    assert!(
+        result.rows.is_empty(),
+        "LIMIT 0 must return zero rows; got {}",
+        result.rows.len()
     );
 }
 

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -32,6 +32,16 @@
 #                      --test issue_1589_window_drain_bytes (the scan/compaction
 #                      windows advance a cursor + compact once per refill instead
 #                      of front-draining per partition — issue #1589); same gate.
+#   byte-budget-guard  cargo test -p cqlite-core --features write-support,cli-helpers,state_machine
+#                      --test issue_1582_byte_bounded_result_budget (issue #1582,
+#                      Epic D6). Byte-bounded result budget: the materializing
+#                      SELECT path fails fast with Error::ResultTooLarge once the
+#                      configured max_result_bytes is exceeded, and a LIMITed query
+#                      is honored before the budget bites. Feature-gated to a combo
+#                      no other gate component runs while naming this target, so the
+#                      guard has an executing regression net. Builds its own
+#                      WriteEngine fixtures -> needs NO datasets (not in
+#                      DATASET_COMPONENTS).
 #   memory-budget      cargo test -p cqlite-core --features cli-helpers,dhat-heap
 #                      --test memory_budget -- --test-threads=1 (issue #1565, Epic
 #                      A/A4). dhat allocation/peak-heap regression net over the real
@@ -538,7 +548,7 @@ classify_scoped_plan() {
   return 0
 }
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard byte-budget-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
 # --lite (issue #1821) runs ONLY this fast subset: file-size ratchet, fmt,
 # FULL-workspace clippy (cross-crate API breaks are the cheap-insurance class),
 # and blast-radius-scoped tests (the touched package's --lib + the diff's new
@@ -1881,6 +1891,9 @@ dispatch_component() {
       --test issue_1143_scan_offload_thread \
       --test issue_1333_scan_scratch_reuse \
       --test issue_1589_window_drain_bytes ;;
+    byte-budget-guard) run_component byte-budget-guard cargo test --package cqlite-core \
+      --features write-support,cli-helpers,state_machine \
+      --test issue_1582_byte_bounded_result_budget ;;
     memory-budget) run_component memory-budget cargo test --package cqlite-core \
       --features cli-helpers,dhat-heap \
       --test memory_budget -- --test-threads=1 ;;


### PR DESCRIPTION
Part of #1582 (D6 — Epic D #1516). **Does NOT fully close #1582** — the byte guard here is a fail-fast ceiling, not the true peak-memory bound; that remains open on #1582, blocked on #1897 (scan_stream single-gen rearchitecture). Owner-approved partial merge.

Delivers (verified):
- **Byte fail-fast ceiling** on materializing result collection via `enforce_result_budget`, reusing the existing `estimate_row_size`/`estimate_value_size` (no new estimator). Typed `Error::ResultTooLarge` (thiserror; message says add LIMIT / use streaming), classified `Query`, mapped through Python (`QueryError`) + Node (`QUERY`) taxonomy.
- **LIMIT/OFFSET propagation** (`compute_scan_collect_bound`): a LIMITed query stops collecting at the limit and no longer trips the budget on rows beyond it (authoritative plan inspection — only when post-scan steps are exclusively Limit/Project; no heuristic).
- **Config knob** `QueryConfig.max_result_bytes` (default `DEFAULT_MAX_RESULT_BYTES = 64 MiB`, documented derivation), load-bearing (set-knob-assert-behavior test), with `#[serde(default)]` for backward-compat (regression test deserializes a config missing the field).
- **Gate regression net:** new `byte-budget-guard` agent-gate component runs the TDD tests (`write-support,cli-helpers,state_machine`) — they previously never executed in any gate/CI lane.
- Row-count check kept as secondary safety valve. Python/Node `execute()` routing unchanged (materializing + byte-bounded, per conservative guidance).

**Known limitation (tracked, NOT merged-over silently):** does not bound the underlying per-reader scan materialization → #1582 stays open for the true peak bound once #1897 (scan_stream single-gen 0-rows) is fixed.

Gate: all correctness nets PASS incl. the new `byte-budget-guard`; sole FAILs are pre-existing #1860 + #1803 flakes. `file-size`: pre-oversized files grew → documented `CQLITE_ALLOW_FILE_GROWTH=1` (#1116).