### PR TITLE
perf(#1848): loud accelerator degradation WARNs + machine-checkable accelerators: SUMMARY line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,55 @@ sccache --stop-server
 sccache --start-server
 ```
 
+### Accelerator degradation is LOUD, not silent (issue #1848)
+
+Every optional accelerator the gate depends on — **sccache** (cross-worktree
+compile cache), **cargo-nextest** (parallel core-tests), and **parallel component
+lanes** (needs bash ≥4.3 for `wait -n`) — is auto-detected. When one is **missing**
+the gate now emits a **loud `WARN:` line on STDERR** with the one-line install
+command, so a machine can never silently run ~3x slower again (the 2026-07-03/04
+field failures: sccache and nextest both un-installed for weeks, and stock macOS
+bash 3.2 serializing the lanes — all inert wins with no signal):
+
+```
+agent-gate: WARN: sccache not installed — cross-worktree compile caching DISABLED (~25.6% slower fresh builds); install: brew install sccache (#1848)
+agent-gate: WARN: cargo-nextest not installed — core-tests fall back to serial 'cargo test' (much slower long pole); install: brew install cargo-nextest (#1848)
+agent-gate: WARN: bash <4.3 lacks 'wait -n' — gate components run SERIALLY (no parallel lanes; AGENT_GATE_JOBS=1); install: brew install bash (#1848)
+```
+
+Every SUMMARY block (full **and** `--lite`) carries a **machine-checkable
+`accelerators:` line**, so degradation is visible in the pasted block, not just
+scrollback:
+
+```
+accelerators: sccache=on nextest=absent lanes=serial
+```
+
+State values: `on` (detected & used) · `absent` (missing → WARN) · `off`
+(intentionally disabled via `CQLITE_DISABLE_SCCACHE=1` / `CQLITE_DISABLE_NEXTEST=1`
+/ `AGENT_GATE_JOBS=1`; **no WARN**) · `lanes=serial` (degraded by bash <4.3). An
+intentional opt-out is `off`, never `absent`, and never warns. Self-test coverage:
+`scripts/tests/test_agent_gate_summary.sh` (cases 9a/9b assert the `off`/`absent`
+markers and the WARN).
+
+### Disk hygiene for multi-worktree gates (issue #1848)
+
+Each active worktree owns its own ~25–30GB `target/` dir. Several concurrent
+worktrees can exhaust the disk mid-gate (a confusing hard failure). `flow-finalize`
+removes a finished issue's worktree; additionally prune stale worktrees' `target/`
+dirs and size the shared cache with `SCCACHE_CACHE_SIZE` (recommend `30G` on the
+10-core machine).
+
+**macOS Time Machine local-snapshot gotcha:** deleting `target/` dirs alone often
+reclaims **nothing** while a Time Machine *local snapshot* is pinning the freed
+blocks. If free space does not recover after deleting build artifacts, check and
+thin snapshots:
+
+```bash
+tmutil listlocalsnapshots /                 # any snapshot pins freed blocks
+tmutil thinlocalsnapshots / 40000000000 4   # thin to reclaim (field: 9.1Gi -> 72Gi)
+```
+
 ### Gate Parallelism and nextest (issue #1737)
 
 The gate runs **~75% faster** than v0.12.0 on warm machines via two levers:

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -209,12 +209,25 @@ fi
 # ~/Library/Caches/Mozilla.sccache on macOS). Cache size limit:
 # $SCCACHE_CACHE_SIZE (default 10 GiB; raise for multi-user builds).
 # Measurement (issue #1822): 25.6% speedup on fresh worktrees with warm cache.
-if [ "${CQLITE_DISABLE_SCCACHE:-0}" != 1 ] && command -v sccache >/dev/null 2>&1; then
+#
+# Accelerator state (issue #1848): every optional accelerator the gate depends on
+# records a state in ACCEL_* — `on` (detected & used), `absent` (NOT installed →
+# a LOUD WARN with the one-line install command, so a machine is never silently
+# 3x slower again), or `off` (intentionally disabled via CQLITE_DISABLE_*; no
+# WARN). The states are stamped into a machine-checkable `accelerators:` line in
+# the SUMMARY block so degradation is visible in the pasted block, not just
+# scrollback. All WARN/banner text goes to STDERR: hidden hook modes (--classify-*)
+# must keep STDOUT empty, and this detection runs before the hook dispatch.
+ACCEL_SCCACHE=absent
+if [ "${CQLITE_DISABLE_SCCACHE:-0}" = 1 ]; then
+  ACCEL_SCCACHE=off
+elif command -v sccache >/dev/null 2>&1; then
   export RUSTC_WRAPPER=sccache
   export CARGO_INCREMENTAL=0
-  # Diagnostic banner on STDERR: hidden hook modes (--classify-*) must keep their
-  # STDOUT empty, and this dispatch runs before the hook branch (issue #1821).
+  ACCEL_SCCACHE=on
   echo "agent-gate: sccache detected; using as RUSTC_WRAPPER with CARGO_INCREMENTAL=0 (#1822)" >&2
+else
+  echo "agent-gate: WARN: sccache not installed — cross-worktree compile caching DISABLED (~25.6% slower fresh builds); install: brew install sccache (#1848)" >&2
 fi
 export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datasets}"
 
@@ -227,12 +240,19 @@ export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datase
 # additionally runs `cargo test --doc` so doctest coverage is never silently
 # dropped (same package/feature selection + same skip).
 NEXTEST=0
-if [ "${CQLITE_DISABLE_NEXTEST:-0}" != 1 ] && command -v cargo-nextest >/dev/null 2>&1; then
+ACCEL_NEXTEST=absent
+if [ "${CQLITE_DISABLE_NEXTEST:-0}" = 1 ]; then
+  ACCEL_NEXTEST=off
+elif command -v cargo-nextest >/dev/null 2>&1; then
   NEXTEST=1
+  ACCEL_NEXTEST=on
   # Banner on STDERR: hidden hook modes (--classify-*, --scoped-test-cmd-noparser)
   # must keep STDOUT empty, and this detection runs before the hook dispatch (same
   # rule the sccache banner above already follows; #1821/#1825).
   echo "agent-gate: cargo-nextest detected ($(cargo nextest --version 2>/dev/null | head -1)); core-tests uses nextest + a cargo test --doc pass (#1737)" >&2
+else
+  # #1848: absent accelerator → LOUD WARN + one-line install command (STDERR).
+  echo "agent-gate: WARN: cargo-nextest not installed — core-tests fall back to serial 'cargo test' (much slower long pole); install: brew install cargo-nextest (#1848)" >&2
 fi
 
 # Bounded component parallelism (issue #1737): independent gate components run
@@ -257,15 +277,33 @@ case "$AGENT_GATE_JOBS" in *[!0-9]*|'') AGENT_GATE_JOBS=1 ;; esac
 # The bounded pool relies on `wait -n` (bash 4.3+). On older bash (e.g. macOS's
 # stock /bin/bash 3.2) fall back to sequential execution rather than risk a
 # busy-poll race; correctness is identical, only wall-clock differs.
-if [ "$AGENT_GATE_JOBS" -gt 1 ] && \
-   ! { [ "${BASH_VERSINFO[0]:-0}" -gt 4 ] || \
-       { [ "${BASH_VERSINFO[0]:-0}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 3 ]; }; }; then
-  # Banner on STDERR (see nextest note above): hidden hook modes must keep STDOUT
-  # empty, and this runs before the hook dispatch — under stock bash 3.2 this
-  # branch is always taken, so an stdout banner here corrupted --classify-* output.
-  echo "agent-gate: bash < 4.3 lacks 'wait -n'; components run sequentially (AGENT_GATE_JOBS=1)" >&2
-  AGENT_GATE_JOBS=1
+#
+# #1848: lanes are a gate accelerator too. lanes=on (parallel), lanes=serial
+# (degraded by bash <4.3 → LOUD WARN + install command), or lanes=off (component
+# parallelism intentionally not in play, e.g. AGENT_GATE_JOBS=1 or a low core
+# count; no WARN).
+ACCEL_LANES=off
+if [ "$AGENT_GATE_JOBS" -gt 1 ]; then
+  if [ "${BASH_VERSINFO[0]:-0}" -gt 4 ] || \
+     { [ "${BASH_VERSINFO[0]:-0}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 3 ]; }; then
+    ACCEL_LANES=on
+  else
+    # Banner on STDERR (see nextest note above): hidden hook modes must keep STDOUT
+    # empty, and this runs before the hook dispatch — under stock bash 3.2 this
+    # branch is always taken, so an stdout banner here corrupted --classify-* output.
+    echo "agent-gate: WARN: bash <4.3 lacks 'wait -n' — gate components run SERIALLY (no parallel lanes; AGENT_GATE_JOBS=1); install: brew install bash (#1848)" >&2
+    AGENT_GATE_JOBS=1
+    ACCEL_LANES=serial
+  fi
 fi
+
+# accelerators_line: the machine-checkable one-liner stamped into every SUMMARY
+# block (full, lite, and the emission selftest). Values: on|absent|off|serial.
+# See the ACCEL_* detection above (#1848).
+accelerators_line() {
+  printf 'accelerators: sccache=%s nextest=%s lanes=%s' \
+    "${ACCEL_SCCACHE:-unknown}" "${ACCEL_NEXTEST:-unknown}" "${ACCEL_LANES:-unknown}"
+}
 
 # Static-golden mandate (coordinator directive for #1737): the local gate runs
 # against STATIC GOLDENS only. The live Docker/Cassandra sstabledump parity tests
@@ -677,6 +715,7 @@ if [ "$SELFTEST" -eq 1 ]; then
     "commit: selftest branch: selftest dirty: no"
     "datasets: 0 Data.db files under (selftest)"
     "ci-pins: (selftest)"
+    "$(accelerators_line)"
   )
   for i in "${!NAMES[@]}"; do
     meta+=("$(printf '%-18s %s (%s)' "${NAMES[$i]}:" "${STATUSES[$i]}" "${TIMES[$i]}")")
@@ -1394,6 +1433,7 @@ run_lite() {
   declare -a SUMMARY_META=()
   SUMMARY_META+=("commit: $(git rev-parse --short HEAD) branch: $(git rev-parse --abbrev-ref HEAD) dirty: $(test -n "$(git status --porcelain)" && echo yes || echo no)")
   SUMMARY_META+=("lite-scope: file-size fmt clippy scoped-tests (full gate NOT run — run it once before merge)")
+  SUMMARY_META+=("$(accelerators_line)")
   local i
   for i in "${!NAMES[@]}"; do
     SUMMARY_META+=("$(printf '%-18s %s (%s)' "${NAMES[$i]}:" "${STATUSES[$i]}" "${TIMES[$i]}")")
@@ -1839,6 +1879,7 @@ else
   SUMMARY_META+=("datasets: $DATA_COUNT")
 fi
 SUMMARY_META+=("ci-pins: $PINS")
+SUMMARY_META+=("$(accelerators_line)")
 if [ -n "$ONLY" ]; then
   SUMMARY_META+=("mode: PARTIAL (--only $ONLY) - does NOT count as the gate")
   [ "$OVERALL" = "PASS" ] && OVERALL=PARTIAL

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -481,19 +481,77 @@ else
 fi
 
 # 9b. Absent → WARN + `absent` marker. Build a minimal PATH bindir that symlinks
-#     the tools the selftest needs but deliberately OMITS sccache + cargo-nextest,
-#     so `command -v` finds neither regardless of whether they are installed on the
-#     host. Non-fatal: if the minimal-PATH run cannot start, skip with an info note.
+#     the tools the selftest path needs but deliberately OMITS sccache +
+#     cargo-nextest, so `command -v` inside the gate finds neither regardless of
+#     what is installed on the host.
+#
+#     FAIL-CLOSED (roborev, job 1438): a selftest guarding against silent
+#     degradation must never itself degrade silently. If the minimal-PATH run
+#     cannot start or trips a missing tool, that is a TEST FAILURE (`bad`) naming
+#     the tool to add to the allowlist below — never a quiet info-skip that turns
+#     this commit's most important assertion into a no-op on some hosts.
+#
+#     Allowlist provenance: traced empirically by running the selftest under a
+#     bash-only PATH and iterating until exit 0. The REQUIRED set (the selftest
+#     path hard-fails without them) is: bash dirname mktemp grep cp cat. The
+#     other coreutils below are headroom so a future gate change that touches a
+#     common tool (mkdir, tail, cut, wc, stat, ...) keeps working instead of
+#     failing this case. Tools the gate itself guards with fallbacks (nproc,
+#     sysctl, cargo, git, python3) are OPTIONAL here: absent-on-host is a
+#     specifically-known, documented platform difference (no nproc on macOS, no
+#     sysctl on Linux), so they are linked when present and skipped when not.
+#
+#     Tool paths resolve via `type -P` (forces a PATH *file* lookup; bash 3.2+)
+#     — NOT `command -v`, which can return a shell function/alias NAME from the
+#     host environment and produce a self-referential dangling symlink.
 accel_bin="$tmp/accel-bin"
 mkdir -p "$accel_bin"
-for tool in bash env git python3 grep sed awk cat head tr sort dirname basename \
-            mktemp rm ln cargo nproc sysctl uname date printf test; do
-  p=$(command -v "$tool" 2>/dev/null) || continue
-  ln -sf "$p" "$accel_bin/$tool" 2>/dev/null || true
+accel_link_fail=0
+# REQUIRED: the selftest path hard-fails without these — missing on the host is
+# itself a failure (fail-closed), not a skip.
+for tool in bash dirname mktemp grep cp cat; do
+  p=$(type -P "$tool" 2>/dev/null)
+  if [ -z "$p" ]; then
+    bad "accel-absent: required tool '$tool' not resolvable on this host (cannot build minimal PATH)"
+    accel_link_fail=1
+    continue
+  fi
+  if ! ln -sf "$p" "$accel_bin/$tool" 2>/dev/null; then
+    bad "accel-absent: could not link required tool '$tool' into minimal PATH"
+    accel_link_fail=1
+  fi
+done
+# OPTIONAL: gate-guarded/platform tools + coreutils headroom (see provenance note).
+for tool in env git python3 sed awk head tail tr sort cut wc stat mkdir rm ln mv \
+            touch chmod basename uname date sleep expr find xargs hostname \
+            cargo nproc sysctl; do
+  p=$(type -P "$tool" 2>/dev/null) || continue
+  [ -n "$p" ] && { ln -sf "$p" "$accel_bin/$tool" 2>/dev/null || true; }
 done
 absent_err="$tmp/absent.stderr"
-if PATH="$accel_bin" AGENT_GATE_SUMMARY_FILE="$tmp/absent.txt" \
-     "$accel_bin/bash" "$GATE" --emit-summary-selftest >/dev/null 2>"$absent_err"; then
+absent_rc=0
+if [ "$accel_link_fail" -eq 0 ]; then
+  PATH="$accel_bin" AGENT_GATE_SUMMARY_FILE="$tmp/absent.txt" \
+    "$accel_bin/bash" "$GATE" --emit-summary-selftest >/dev/null 2>"$absent_err" || absent_rc=$?
+  # Any 'command not found' means the gate now invokes a tool the allowlist
+  # lacks — fail loudly and NAME it so the fix is mechanical (add it above).
+  if grep -q 'command not found' "$absent_err"; then
+    bad "accel-absent: gate hit 'command not found' under minimal PATH — add the named tool(s) to the allowlist above"
+    grep 'command not found' "$absent_err" | sort -u
+    accel_link_fail=1
+  fi
+  # A non-zero rc WITHOUT a visible 'command not found' can still be a missing
+  # tool: emit_summary suppresses its verifier's stderr (grep ... 2>/dev/null),
+  # so e.g. a missing grep surfaces as a bogus 'could not write complete summary
+  # file' instead. Either way a non-zero rc here is a test FAILURE, never a skip.
+  if [ "$absent_rc" -ne 0 ] && [ "$accel_link_fail" -eq 0 ]; then
+    bad "accel-absent: selftest under minimal PATH exited $absent_rc (want 0; possibly a missing tool whose error was suppressed — see stderr)"
+    echo "------- stderr -------"; cat "$absent_err"; echo "----------------------"
+    accel_link_fail=1
+  fi
+fi
+if [ "$accel_link_fail" -eq 0 ]; then
+  ok "accel-absent: selftest EXECUTED under minimal PATH (exit 0, no missing tools)"
   if grep -qE '^accelerators: sccache=absent nextest=absent ' "$tmp/absent.txt"; then
     ok "accel-absent: missing accelerators marked absent in SUMMARY"
   else
@@ -507,8 +565,6 @@ if PATH="$accel_bin" AGENT_GATE_SUMMARY_FILE="$tmp/absent.txt" \
     bad "accel-absent: missing loud WARN for an absent accelerator"
     echo "------- stderr -------"; cat "$absent_err"; echo "----------------------"
   fi
-else
-  echo "info - accel-absent: selftest under minimal PATH did not start; skipping absent-WARN assertions"
 fi
 
 echo "----"

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -48,6 +48,29 @@ trap 'rm -rf "$tmp"' EXIT
 # scratch dir, so (a) we never write the repo-root default during the test, and
 # (b) we can assert the EXACT caller-provided path is complete — the contract.
 
+# assert_accelerators <label> <file>: issue #1848 — the SUMMARY block must carry a
+# machine-checkable `accelerators:` line naming every optional accelerator's state
+# (sccache / nextest / lanes = on|absent|off|serial), so a silent degradation is
+# visible in the pasted block. Assert the line exists with all three keys and a
+# recognized state value (backward-compatible extension; the older markers still
+# assert via assert_complete).
+assert_accelerators() {
+  local label="$1" file="$2"
+  local line
+  line=$(grep -E '^accelerators: ' "$file" 2>/dev/null | head -1)
+  if [ -z "$line" ]; then
+    bad "$label: no 'accelerators:' line in SUMMARY block (file: $file)"
+    echo "------- captured -------"; cat "$file"; echo "------------------------"
+    return
+  fi
+  if printf '%s\n' "$line" \
+       | grep -Eq '^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial)$'; then
+    ok "$label: accelerators line well-formed ($line)"
+  else
+    bad "$label: malformed accelerators line: '$line'"
+  fi
+}
+
 # assert_exit <label> <actual-rc> <expected-rc>: assert a captured exit status.
 # Positive selftest cases must exit 0; a regression that emits a complete summary
 # but exits non-zero would otherwise sail through assert_complete unnoticed.
@@ -67,6 +90,8 @@ AGENT_GATE_SUMMARY_FILE="$tmp/case1.txt" \
 assert_exit "tee-pipe" "${PIPESTATUS[0]}" 0
 assert_complete "tee-pipe" "$tmp/tee.log"
 assert_complete "tee-pipe-caller-file" "$tmp/case1.txt"
+# #1848: the full SUMMARY block carries a well-formed accelerators line.
+assert_accelerators "tee-pipe-caller-file" "$tmp/case1.txt"
 
 # 2. Backgrounded capture + wait (streamed copy must be complete).
 AGENT_GATE_SUMMARY_FILE="$tmp/case2.txt" \
@@ -253,6 +278,8 @@ else
   bad "lite-selftest: missing LITE markers or MODE line (file: $lite_file)"
   echo "------- captured -------"; cat "$lite_file"; echo "------------------------"
 fi
+# #1848: the LITE SUMMARY block also carries the accelerators line.
+assert_accelerators "lite-selftest" "$lite_file"
 # The lite block MUST NOT carry the full-gate markers (would be pasteable as the
 # full SUMMARY). The full START marker is a prefix of the LITE one, so match the
 # full marker only when it is NOT the LITE marker (i.e. its own line boundaries).
@@ -427,6 +454,61 @@ if [ -x /bin/bash ]; then
   else
     bad "bash-compat: --lite classification path failed under /bin/bash (major ${bin_bash_major:-?})"
   fi
+fi
+
+# 9. Accelerator absence WARN + state markers (issue #1848). The gate must:
+#    (a) mark an intentionally-disabled accelerator (CQLITE_DISABLE_*) `off` and
+#        emit NO WARN; (b) mark a truly MISSING accelerator `absent` and emit a
+#        LOUD WARN with the one-line install command. A silent 3x-slower machine is
+#        the failure this guards against.
+#
+# 9a. Intentional disable → off + no WARN (deterministic; no PATH surgery).
+disable_err="$tmp/disable.stderr"
+AGENT_GATE_SUMMARY_FILE="$tmp/disable.txt" \
+  CQLITE_DISABLE_SCCACHE=1 CQLITE_DISABLE_NEXTEST=1 \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>"$disable_err"
+if grep -qE '^accelerators: sccache=off nextest=off ' "$tmp/disable.txt"; then
+  ok "accel-disable: CQLITE_DISABLE_* -> sccache=off nextest=off in SUMMARY"
+else
+  bad "accel-disable: disabled accelerators not marked off"
+  grep '^accelerators:' "$tmp/disable.txt" 2>/dev/null || cat "$tmp/disable.txt"
+fi
+if grep -q 'WARN: sccache not installed' "$disable_err" \
+   || grep -q 'WARN: cargo-nextest not installed' "$disable_err"; then
+  bad "accel-disable: emitted an absent-WARN for an INTENTIONALLY disabled accelerator"
+else
+  ok "accel-disable: no absent-WARN when accelerator intentionally disabled"
+fi
+
+# 9b. Absent → WARN + `absent` marker. Build a minimal PATH bindir that symlinks
+#     the tools the selftest needs but deliberately OMITS sccache + cargo-nextest,
+#     so `command -v` finds neither regardless of whether they are installed on the
+#     host. Non-fatal: if the minimal-PATH run cannot start, skip with an info note.
+accel_bin="$tmp/accel-bin"
+mkdir -p "$accel_bin"
+for tool in bash env git python3 grep sed awk cat head tr sort dirname basename \
+            mktemp rm ln cargo nproc sysctl uname date printf test; do
+  p=$(command -v "$tool" 2>/dev/null) || continue
+  ln -sf "$p" "$accel_bin/$tool" 2>/dev/null || true
+done
+absent_err="$tmp/absent.stderr"
+if PATH="$accel_bin" AGENT_GATE_SUMMARY_FILE="$tmp/absent.txt" \
+     "$accel_bin/bash" "$GATE" --emit-summary-selftest >/dev/null 2>"$absent_err"; then
+  if grep -qE '^accelerators: sccache=absent nextest=absent ' "$tmp/absent.txt"; then
+    ok "accel-absent: missing accelerators marked absent in SUMMARY"
+  else
+    bad "accel-absent: missing accelerators not marked absent"
+    grep '^accelerators:' "$tmp/absent.txt" 2>/dev/null || cat "$tmp/absent.txt"
+  fi
+  if grep -q 'WARN: sccache not installed' "$absent_err" \
+     && grep -q 'WARN: cargo-nextest not installed' "$absent_err"; then
+    ok "accel-absent: loud WARN + install command emitted for each missing accelerator"
+  else
+    bad "accel-absent: missing loud WARN for an absent accelerator"
+    echo "------- stderr -------"; cat "$absent_err"; echo "----------------------"
+  fi
+else
+  echo "info - accel-absent: selftest under minimal PATH did not start; skipping absent-WARN assertions"
 fi
 
 echo "----"


### PR DESCRIPTION
Fixes #1848.

## What
The gate's accelerators (sccache, cargo-nextest, bash≥4.3 lane parallelism) previously degraded **silently** — this machine ran ~3x slower for weeks with no signal (sccache/nextest absent, stock bash 3.2). Now:
- Loud `WARN:` per missing accelerator with the exact install command.
- `accelerators: sccache=<s> nextest=<s> lanes=<s>` line (`on|absent|off|serial`) in every SUMMARY block (full, --lite, selftest) — degradation is machine-checkable in the pasted artifact, not scrollback.
- Fail-closed selftests (40/40 under both bash 3.2 and 5.3), incl. making the minimal-PATH test itself unable to skip silently — plus two latent hazards found in the audit (suppressed-grep error masquerade, `command -v` alias trap → `type -P`).
- CLAUDE.md: accelerator doctrine + multi-worktree disk hygiene (Time Machine `tmutil thinlocalsnapshots` gotcha).

## Quality trail
roborev 1438 (1 Low → fixed fail-closed) + 1439 (3 Lows, all explicitly no-action/inert). The SUMMARY below self-demonstrates the new line:

```

==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.x5b9zz
commit: 4710fe14 branch: issue-1848-accelerator-warns dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (100s)
core-tests:        PASS (539s)
tombstones-scan:   PASS (31s)
scan-offload-guard: PASS (36s)
memory-budget:     PASS (40s)
integration-tests: PASS (54s)
format-compat:     PASS (31s)
write-tests:       PASS (128s)
cli-tests:         PASS (142s)
compaction-byte-parity: PASS (8s)
python-bindings:   PASS (515s)
node-bindings:     PASS (435s)
delivery-telemetry: PASS (1s)
parity-report:     PASS (5s)
binding-unwind-profile: PASS (1s)
tooling-tests:     PASS (24s)
minimal-build:     PASS (15s)
smoke:             PASS (46s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.x5b9zz
summary-file: /tmp/gate-1848-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```