### PR TITLE
perf(#1846): CLI integration tests use CARGO_BIN_EXE — ~12x on export suite

### DIFF
--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -160,6 +160,14 @@ name = "issue_1388_compact_major_drop"
 path = "tests/issue_1388_compact_major_drop.rs"
 required-features = ["write-support"]
 
+# Issue #1846: this target spawns the pre-built `cqlite` binary via
+# CARGO_BIN_EXE_cqlite and exercises write-path DML, so it must be compiled with
+# `write-support` for that binary to be write-capable.
+[[test]]
+name = "cli_dml_integration_tests"
+path = "tests/cli_dml_integration_tests.rs"
+required-features = ["write-support"]
+
 [features]
 # M2+ production defaults: Interactive REPL with query engine
 default = ["interactive", "tui", "cli-helpers"]

--- a/cqlite-cli/tests/cli_dml_integration_tests.rs
+++ b/cqlite-cli/tests/cli_dml_integration_tests.rs
@@ -26,18 +26,15 @@ fn schemas_dir() -> PathBuf {
     project_root().join("test-data/schemas")
 }
 
-/// Run CLI command with write support and capture output
+/// Run CLI command with write support and capture output.
+///
+/// Uses the pre-built binary (`CARGO_BIN_EXE_cqlite`), avoiding a nested
+/// `cargo run` rebuild per test. This test target declares
+/// `required-features = ["write-support"]` in `cqlite-cli/Cargo.toml`, so the
+/// harness compiles the `cqlite` binary with `write-support` enabled and
+/// `CARGO_BIN_EXE_cqlite` points at that write-capable binary.
 fn run_write_cli(args: &[&str]) -> Output {
-    Command::new("cargo")
-        .args([
-            "run",
-            "--quiet",
-            "--package",
-            "cqlite-cli",
-            "--features",
-            "write-support",
-            "--",
-        ])
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .current_dir(project_root())
         .output()

--- a/cqlite-cli/tests/comprehensive_select_test.rs
+++ b/cqlite-cli/tests/comprehensive_select_test.rs
@@ -30,8 +30,6 @@ use std::process::Command;
 // Test Configuration
 // =============================================================================
 
-const CLI_BINARY: &str = "cqlite";
-
 /// Get datasets root from environment or default path
 fn get_datasets_root() -> PathBuf {
     std::env::var("CQLITE_DATASETS_ROOT")
@@ -110,13 +108,8 @@ fn run_select_query(keyspace: &str, table: &str, schema_file: &str) -> QueryTest
     let schema_path = get_schemas_dir().join(schema_file);
     let query = format!("SELECT * FROM {}.{} LIMIT 10", keyspace, table);
 
-    let output = Command::new("cargo")
+    let output = Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args([
-            "run",
-            "--quiet",
-            "--bin",
-            CLI_BINARY,
-            "--",
             "--schema",
             schema_path.to_str().unwrap(),
             "--data-dir",

--- a/cqlite-cli/tests/delta_export_tests.rs
+++ b/cqlite-cli/tests/delta_export_tests.rs
@@ -39,21 +39,12 @@ use tempfile::TempDir;
 
 /// Run the pre-built `cqlite` binary compiled with `--features delta-export`.
 ///
-/// Uses `cargo run --quiet --features delta-export` to ensure the correct
-/// feature set is active.  `assert_cmd::cargo_bin` cannot select cargo features
-/// for the binary it resolves, so it cannot be used here without losing the
-/// delta-export feature.
+/// This test target declares `required-features = ["delta-export", ...]` in
+/// `cqlite-cli/Cargo.toml`, so the harness compiles the `cqlite` binary with
+/// `delta-export` enabled and `CARGO_BIN_EXE_cqlite` points at that binary.
+/// Using it avoids a nested `cargo run` rebuild per test.
 fn run_cli(args: &[&str]) -> std::process::Output {
-    Command::new("cargo")
-        .args([
-            "run",
-            "--quiet",
-            "--package",
-            "cqlite-cli",
-            "--features",
-            "delta-export",
-            "--",
-        ])
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .output()
         .expect("failed to spawn cqlite")

--- a/cqlite-cli/tests/duckdb_parquet_validation.rs
+++ b/cqlite-cli/tests/duckdb_parquet_validation.rs
@@ -39,12 +39,10 @@ use tempfile::TempDir;
 // Helper Functions
 // ============================================================================
 
-const CLI_BINARY: &str = "cqlite";
-
-/// Run CLI command and capture output
+/// Run CLI command and capture output using the pre-built binary
+/// (`CARGO_BIN_EXE_cqlite`), avoiding a nested `cargo run` rebuild per test.
 fn run_cli_command(args: &[&str]) -> Output {
-    Command::new("cargo")
-        .args(["run", "--quiet", "--bin", CLI_BINARY, "--"])
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .output()
         .expect("Failed to execute CLI command")

--- a/cqlite-cli/tests/end_to_end_tests.rs
+++ b/cqlite-cli/tests/end_to_end_tests.rs
@@ -26,11 +26,11 @@ mod e2e_tests {
 
     /// Helper to run CLI with timeout
     fn run_cli_with_timeout(args: &[&str], timeout: Duration) -> Result<std::process::Output> {
-        let mut cmd = Command::new("cargo");
-        cmd.args(["run", "--bin", CLI_BINARY, "--"]).args(args);
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_cqlite"));
+        cmd.args(args);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-        println!("Running command: cargo run --bin {CLI_BINARY} -- {args:?}");
+        println!("Running command: {CLI_BINARY} {args:?}");
 
         let start = Instant::now();
         let mut child = cmd.spawn()?;
@@ -43,8 +43,7 @@ mod e2e_tests {
                 // Simpler approach: re-exec using output() when quick; here, we can just return a minimal Output.
                 // To preserve logs, we re-run with output() if it was fast; else, provide empty.
                 // For test stability, re-run to capture output:
-                let output = Command::new("cargo")
-                    .args(["run", "--bin", CLI_BINARY, "--"])
+                let output = Command::new(env!("CARGO_BIN_EXE_cqlite"))
                     .args(args)
                     .output()?;
                 println!(

--- a/cqlite-cli/tests/error_handling_tests.rs
+++ b/cqlite-cli/tests/error_handling_tests.rs
@@ -18,11 +18,10 @@ use tempfile::TempDir;
 /// - Data corruption scenarios
 /// - Security and permission issues
 
-const _CLI_BINARY: &str = "cqlite"; // TODO: Use in actual CLI tests
-
+/// Run CLI commands using the pre-built binary (`CARGO_BIN_EXE_cqlite`),
+/// avoiding a nested `cargo run` rebuild per test.
 fn run_cli_command(args: &[&str]) -> Result<std::process::Output> {
-    Command::new("cargo")
-        .args(&["run", "--bin", _CLI_BINARY, "--"])
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .output()
         .map_err(|e| anyhow::anyhow!("Failed to run CLI command: {}", e))

--- a/cqlite-cli/tests/export_integration_tests.rs
+++ b/cqlite-cli/tests/export_integration_tests.rs
@@ -31,12 +31,10 @@ mod common;
 // Helper Functions
 // ============================================================================
 
-const CLI_BINARY: &str = "cqlite";
-
-/// Run CLI command and capture output
+/// Run CLI command and capture output using the pre-built binary
+/// (`CARGO_BIN_EXE_cqlite`), avoiding a nested `cargo run` rebuild per test.
 fn run_cli_command(args: &[&str]) -> Output {
-    Command::new("cargo")
-        .args(["run", "--quiet", "--bin", CLI_BINARY, "--"])
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .output()
         .expect("Failed to execute CLI command")

--- a/cqlite-cli/tests/integration_tests.rs
+++ b/cqlite-cli/tests/integration_tests.rs
@@ -16,8 +16,6 @@ use tempfile::TempDir;
 /// - Interactive REPL mode
 /// - SSTable reading capabilities
 
-const CLI_BINARY: &str = "cqlite";
-
 /// Test helper to create a temporary database
 pub fn create_temp_database() -> Result<(TempDir, PathBuf)> {
     let temp_dir = TempDir::new()?;
@@ -25,10 +23,10 @@ pub fn create_temp_database() -> Result<(TempDir, PathBuf)> {
     Ok((temp_dir, db_path))
 }
 
-/// Test helper to run CLI commands
+/// Test helper to run CLI commands using the pre-built binary
+/// (`CARGO_BIN_EXE_cqlite`), avoiding a nested `cargo run` rebuild per test.
 pub fn run_cli_command(args: &[&str]) -> Result<std::process::Output> {
-    Command::new("cargo")
-        .args(&["run", "--bin", CLI_BINARY, "--"])
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .output()
         .map_err(|e| anyhow::anyhow!("Failed to run CLI command: {}", e))

--- a/cqlite-cli/tests/one_shot_integration_test.rs
+++ b/cqlite-cli/tests/one_shot_integration_test.rs
@@ -13,12 +13,10 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-const CLI_BINARY: &str = "cqlite";
-
-/// Test helper to run CLI commands and capture output
+/// Test helper to run CLI commands and capture output using the pre-built binary
+/// (`CARGO_BIN_EXE_cqlite`), avoiding a nested `cargo run` rebuild per test.
 fn run_cli_command(args: &[&str]) -> std::process::Output {
-    Command::new("cargo")
-        .args(&["run", "--quiet", "--bin", CLI_BINARY, "--"])
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .output()
         .expect("Failed to execute CLI command")

--- a/cqlite-cli/tests/parquet_dataset_roundtrip_tests.rs
+++ b/cqlite-cli/tests/parquet_dataset_roundtrip_tests.rs
@@ -74,12 +74,14 @@ fn schemas_dir() -> PathBuf {
 }
 
 /// Run the cqlite CLI with the given arguments, returning (stdout, stderr, success).
+///
+/// Uses the pre-built binary (`CARGO_BIN_EXE_cqlite`), avoiding a nested
+/// `cargo run` rebuild per test.
 fn run_cli(args: &[&str]) -> (String, String, bool) {
-    let output = Command::new("cargo")
-        .args(["run", "--quiet", "--package", "cqlite-cli", "--"])
+    let output = Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .output()
-        .expect("failed to spawn cargo run");
+        .expect("failed to spawn cqlite");
     (
         String::from_utf8_lossy(&output.stdout).into_owned(),
         String::from_utf8_lossy(&output.stderr).into_owned(),

--- a/cqlite-cli/tests/table_snapshot_tests.rs
+++ b/cqlite-cli/tests/table_snapshot_tests.rs
@@ -24,12 +24,10 @@ use std::process::Command;
 #[path = "common/golden_snapshots.rs"]
 mod golden_snapshots;
 
-const CLI_BINARY: &str = "cqlite";
-
-/// Test helper to run CLI commands and capture output
+/// Test helper to run CLI commands and capture output using the pre-built
+/// binary (`CARGO_BIN_EXE_cqlite`), avoiding a nested `cargo run` rebuild per test.
 fn run_cli_command(args: &[&str]) -> std::process::Output {
-    Command::new("cargo")
-        .args(["run", "--quiet", "--bin", CLI_BINARY, "--"])
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
         .args(args)
         .output()
         .expect("Failed to execute CLI command")

--- a/cqlite-cli/tests/test_helpers.rs
+++ b/cqlite-cli/tests/test_helpers.rs
@@ -16,14 +16,23 @@ use tempfile::TempDir;
 /// - File and directory management
 /// - Performance measurement tools
 
-pub const CLI_BINARY: &str = "cqlite";
 #[allow(dead_code)]
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Path to the pre-built `cqlite` binary for this test crate.
+///
+/// `CARGO_BIN_EXE_cqlite` is injected by Cargo at compile time and points at the
+/// exact binary the harness built for these integration tests (with whatever
+/// features the test invocation selected). Using it avoids spawning a nested
+/// `cargo run` per test, which re-locks the build graph and can rebuild
+/// mid-test-run.
+pub fn cqlite_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cqlite")
+}
+
 /// Execute CLI command with arguments
 pub fn run_cli(args: &[&str]) -> Result<Output> {
-    Command::new("cargo")
-        .args(["run", "--bin", CLI_BINARY, "--"])
+    Command::new(cqlite_bin())
         .args(args)
         .output()
         .map_err(|e| anyhow::anyhow!("Failed to execute CLI command: {}", e))
@@ -340,13 +349,12 @@ pub fn extract_timing_ms(output: &Output) -> Option<f64> {
     None
 }
 
-/// Check if CLI binary is available
+/// Check if CLI binary is available.
+///
+/// With `CARGO_BIN_EXE_cqlite` the harness has already built the binary as a test
+/// dependency, so it exists on disk by construction; confirm the path is present.
 pub fn cli_available() -> bool {
-    Command::new("cargo")
-        .args(["check", "--bin", CLI_BINARY])
-        .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
+    Path::new(cqlite_bin()).exists()
 }
 
 /// Performance measurement utilities

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1341,12 +1341,19 @@ run_scoped_tests() {
   echo ">>> [$name] blast-radius packages: $scoped_note"
 
   # Union a comma-list of features into a newline-set (Bash 3.2-safe dedup).
+  # The separator is placed BETWEEN elements (not trailing): `add_features` is
+  # called via `featset=$(add_features ...)`, and command substitution strips
+  # trailing newlines, so a trailing-newline scheme would glue the first element
+  # of the next call onto the last existing element (e.g. "write-support" +
+  # "delta-export" -> "write-supportdelta-export"). Prepending "$set"+newline
+  # only when non-empty keeps every element on its own line regardless.
   add_features() {
-    local set=$1 list=$2 x oldifs=$IFS
+    local set=$1 list=$2 x oldifs=$IFS nl
+    nl=$'\n'
     IFS=,
     for x in $list; do
       [ -n "$x" ] || continue
-      printf '%s\n' "$set" | grep -qxF "$x" || set="${set}${x}"$'\n'
+      printf '%s\n' "$set" | grep -qxF "$x" || set="${set:+${set}${nl}}${x}"
     done
     IFS=$oldifs
     printf '%s' "$set"


### PR DESCRIPTION
Fixes #1846.

## What
~93 CLI integration tests spawned the binary via `cargo run` per test (build-graph re-lock + potential mid-run rebuilds). Now they use `env!("CARGO_BIN_EXE_cqlite")` — Cargo builds the bin once as a test dependency. Feature fidelity preserved via `[[test]] required-features` (write-support for cli_dml; delta-export/duckdb-tests already declared). Zero assertion changes.

## Measured (warm cache, same worktree)
| Suite | Before | After |
|---|---|---|
| export_integration_tests (22) | 31.95s wall | **2.70s (~12x)** |
| comprehensive_select_test | 9.97s | 2.00s |
| table_snapshot_tests | 4.58s | 1.03s |
| duckdb_parquet_validation | 7.63s | 2.35s |

## Also in this PR
- Fixes a latent `agent-gate.sh --lite` scoper bug: `add_features` glued feature names across calls (e.g. `write-supportdelta-export`) whenever a diff touched 2+ feature-gated test targets — separator now placed between elements (bash 3.2-safe).
- Surfaced 10 pre-existing failures on main in a gate-uncovered test zone → triaged as #1896 (4 look like #1853-class TTL fixture time bombs).

## Quality trail
roborev 1441: clean, zero findings. First gate run FAILed solely on #1903 (documented wall-clock flake, untouched path, measured load-195 spike; evidence stamped on #1903) — re-run at idle:

```

==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.TRTgWe
commit: 1bf38bf1 branch: issue-1846-cargo-bin-exe dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (2s)
core-tests:        PASS (161s)
tombstones-scan:   PASS (0s)
scan-offload-guard: PASS (1s)
memory-budget:     PASS (8s)
integration-tests: PASS (2s)
format-compat:     PASS (0s)
write-tests:       PASS (34s)
cli-tests:         PASS (4s)
compaction-byte-parity: PASS (2s)
python-bindings:   PASS (104s)
node-bindings:     PASS (139s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (1s)
binding-unwind-profile: PASS (1s)
tooling-tests:     PASS (25s)
minimal-build:     PASS (0s)
smoke:             PASS (5s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.TRTgWe
summary-file: /tmp/gate-1846-summary2.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```