### PR TITLE
fix(#1903): write throughput test asserts completion/consistency invariants, drops wall-clock floor

### DIFF
--- a/cqlite-core/tests/write_integration.rs
+++ b/cqlite-core/tests/write_integration.rs
@@ -1443,19 +1443,19 @@ async fn test_write_throughput() -> Result<()> {
     let elapsed = start.elapsed();
     let rows_per_sec = num_rows as f64 / elapsed.as_secs_f64();
 
+    // Info only: throughput is wall-clock/load-sensitive, so it's printed, not
+    // asserted (issue #1903). A regression net belongs in the criterion bench /
+    // perf-regression lane (docs/profiling.md), not the correctness suite.
     println!(
         "Write throughput: {:.0} rows/sec ({} rows in {:?})",
         rows_per_sec, num_rows, elapsed
     );
 
-    // Target: 50 rows/sec (conservative for CI with WAL sync per write)
-    // WAL fsync is intentionally per-write for durability, which limits throughput
-    // Production systems typically batch writes or use async WAL for higher throughput
-    assert!(
-        rows_per_sec >= 50.0,
-        "Write throughput {:.0} rows/sec below target of 50 rows/sec",
-        rows_per_sec
-    );
+    // Load-immune invariants by construction: every write returned Ok, every
+    // unique-pk row landed in the memtable, and flush persists all partitions.
+    assert_eq!(engine.memtable_row_count(), num_rows as usize);
+    let info = engine.flush().await?.expect("Should have data to flush");
+    assert_eq!(info.partition_count, num_rows as usize);
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #1903.

## What
`test_write_throughput` asserted a hard 50 rows/sec wall-clock floor — a performance assertion inside the correctness suite. Under machine load it flakes: it FAILed **two gates of record today** (#1846's at 27 rows/sec during a load-195 spike, #1856's at 42 rows/sec) as the sole red among 4,094 tests each time.

## Fix (same philosophy as #1774, merged earlier today)
Load-immune, by-construction invariants: every write returns Ok, `memtable_row_count() == 1000`, flush persists exactly 1000 partitions. Throughput still printed as info; a real throughput-regression net belongs in the criterion/perf-regression lane (docs/profiling.md). Net-zero diff (8+/8−).

## Evidence
10/10 consecutive passes under a parallel workspace build (load 61-115). roborev 1445: clean, zero findings.

```

==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.jKWNqr
commit: 076c35f1 branch: issue-1903-write-throughput-flake dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (6s)
core-tests:        PASS (189s)
tombstones-scan:   PASS (1s)
scan-offload-guard: PASS (1s)
memory-budget:     PASS (8s)
integration-tests: PASS (2s)
format-compat:     PASS (1s)
write-tests:       PASS (30s)
cli-tests:         PASS (7s)
compaction-byte-parity: PASS (2s)
python-bindings:   PASS (121s)
node-bindings:     PASS (161s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (1s)
binding-unwind-profile: PASS (1s)
tooling-tests:     PASS (25s)
minimal-build:     PASS (0s)
smoke:             PASS (6s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.jKWNqr
summary-file: /tmp/gate-1903-summary2.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```