### PR TITLE
fix(#1774): memory monitor test asserts by-construction invariants, no monotonic-RSS assumption

### DIFF
--- a/cqlite-core/src/benchmarks/cassandra5/mod.rs
+++ b/cqlite-core/src/benchmarks/cassandra5/mod.rs
@@ -483,6 +483,23 @@ pub mod utils {
             let sum: f64 = self.samples.iter().map(|&s| s - self.baseline_mb).sum();
             sum / self.samples.len() as f64
         }
+
+        /// Smallest observed delta (`sample - baseline`) across all samples.
+        ///
+        /// Unlike [`peak_usage_mb`](Self::peak_usage_mb) this is NOT clamped at
+        /// the baseline, so it may be negative when process RSS dips below the
+        /// baseline (routine page reclaim / allocator returning pages).
+        pub fn min_usage_mb(&self) -> f64 {
+            self.samples
+                .iter()
+                .map(|&s| s - self.baseline_mb)
+                .fold(f64::INFINITY, f64::min)
+        }
+
+        /// Number of recorded samples (the baseline counts as the first one).
+        pub fn sample_count(&self) -> usize {
+            self.samples.len()
+        }
     }
 
     /// Get current process memory usage in MB
@@ -638,8 +655,36 @@ mod tests {
         monitor.sample();
         monitor.sample();
 
-        assert!(monitor.peak_usage_mb() >= 0.0);
-        assert!(monitor.average_usage_mb() >= 0.0);
+        // The monitor records the baseline plus every explicit sample, so two
+        // sample() calls yield exactly three samples. This proves the monitor
+        // actually captured measurements (not a vacuous >= 0.0 tautology).
+        assert_eq!(
+            monitor.sample_count(),
+            3,
+            "expected baseline + 2 samples to be recorded"
+        );
+
+        // peak_usage_mb() is `peak.max(baseline) - baseline`, so it is >= 0 by
+        // construction regardless of RSS jitter.
+        let peak = monitor.peak_usage_mb();
+        assert!(peak >= 0.0, "peak usage must be non-negative, got {peak}");
+
+        // The average delta must lie within [min, max] of the observed deltas
+        // by construction (the mean of a set is bounded by its extremes). This
+        // makes NO monotonic-RSS or wall-clock assumption: RSS can dip below the
+        // baseline (page reclaim), so avg/min may be negative — only the
+        // ordering min <= avg <= peak is invariant. A regression that miscounts
+        // or misweights samples in average_usage_mb() would break this ordering.
+        let avg = monitor.average_usage_mb();
+        let min = monitor.min_usage_mb();
+        assert!(
+            avg >= min,
+            "average delta {avg} must be >= min observed delta {min}"
+        );
+        assert!(
+            avg <= peak,
+            "average delta {avg} must be <= peak delta {peak}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #1774.

## What
`benchmarks::cassandra5::test_memory_monitor` asserted `average_usage_mb() >= 0.0` — an invalid monotonic-RSS assumption (RSS dips below baseline under routine page reclaim). This standing flake red-gated unrelated PRs (#1770, #1772) and cost PR #1449 a full CI rerun cycle.

## Fix
Deterministic by-construction invariants that still catch real regressions: `sample_count() == 3` (samples actually recorded), `peak >= 0` (clamped by construction), and the ordering `min <= avg <= peak` (a mean bounded by its extremes — a miscount/misweight bug in average_usage_mb() breaks it). Added `min_usage_mb()`/`sample_count()` accessors.

## Evidence
10/10 consecutive passes under parallel cargo-build load. roborev 1443: clean, zero findings.

```

==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.xWhWJ3
commit: e34aea1a branch: issue-1774-memory-monitor-flake dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (73s)
core-tests:        PASS (616s)
tombstones-scan:   PASS (32s)
scan-offload-guard: PASS (38s)
memory-budget:     PASS (41s)
integration-tests: PASS (67s)
format-compat:     PASS (40s)
write-tests:       PASS (139s)
cli-tests:         PASS (172s)
compaction-byte-parity: PASS (13s)
python-bindings:   PASS (629s)
node-bindings:     PASS (539s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (8s)
binding-unwind-profile: PASS (0s)
tooling-tests:     PASS (25s)
minimal-build:     PASS (18s)
smoke:             PASS (55s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.xWhWJ3
summary-file: /tmp/gate-1774-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```