### PR TITLE
fix(#1763): aggregate/grouped result metadata names match row value keys (single source)

### DIFF
--- a/cqlite-core/src/query/mod.rs
+++ b/cqlite-core/src/query/mod.rs
@@ -34,6 +34,8 @@ pub mod select_executor;
 #[cfg(feature = "state_machine")]
 pub mod select_integration_tests;
 #[cfg(feature = "state_machine")]
+pub mod select_naming;
+#[cfg(feature = "state_machine")]
 pub mod select_optimizer;
 #[cfg(feature = "state_machine")]
 pub mod select_parser;

--- a/cqlite-core/src/query/select_ast.rs
+++ b/cqlite-core/src/query/select_ast.rs
@@ -423,9 +423,17 @@ impl SelectStatement {
 }
 
 impl SelectExpression {
-    /// Check if this expression is an aggregate function
+    /// Check if this expression is an aggregate function.
+    ///
+    /// An aliased aggregate (`COUNT(*) AS total`) is still an aggregate: unwrap
+    /// `Aliased` so `SELECT COUNT(*) AS total` is planned through the aggregation
+    /// step rather than falling into row-level projection (issue #1763).
     pub fn is_aggregate(&self) -> bool {
-        matches!(self, SelectExpression::Aggregate(_))
+        match self {
+            SelectExpression::Aggregate(_) => true,
+            SelectExpression::Aliased(inner, _) => inner.is_aggregate(),
+            _ => false,
+        }
     }
 
     /// Update `max_plus_one` to `max(current, marker_index + 1)` over every

--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -249,9 +249,14 @@ pub(super) fn finalize_group(
     let mut row_values: HashMap<std::sync::Arc<str>, Value> =
         HashMap::with_capacity(agg_plan.group_by_columns.len() + agg_plan.aggregates.len());
 
-    for (i, col) in agg_plan.group_by_columns.iter().enumerate() {
+    // Issue #1763: emit each grouped dimension under its SELECT OUTPUT name
+    // (alias when present, else the column name) — the SAME `select_naming` source
+    // that names the result metadata column — so the grouped dimension's row value
+    // key can never diverge from its metadata name. The group KEY was read by the
+    // raw stored column (`build_group_key`); only the emitted key differs.
+    for (i, out_name) in agg_plan.group_by_output_names.iter().enumerate() {
         if let Some(v) = group_key.get(i) {
-            row_values.insert(col.as_str().into(), v.clone());
+            row_values.insert(out_name.as_str().into(), v.clone());
         }
     }
 
@@ -287,6 +292,7 @@ mod tests {
     fn count_star_plan() -> AggregationPlan {
         AggregationPlan {
             group_by_columns: vec!["g".to_string()],
+            group_by_output_names: vec!["g".to_string()],
             aggregates: vec![AggregateComputation {
                 function: AggregateType::Count,
                 column: "*".to_string(),

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -1104,11 +1104,11 @@ impl SelectExecutor {
                         continue;
                     }
 
-                    let column_name = match expr {
-                        SelectExpression::Column(col_ref) => col_ref.column.clone(),
-                        SelectExpression::Aliased(_, alias) => alias.clone(),
-                        _ => format!("col_{i}"),
-                    };
+                    // Issue #1763: name aggregate result columns via the SAME
+                    // single source (`result_column_name` → `aggregate_output_name`)
+                    // that keys the emitted row values in `finalize_group`, so
+                    // metadata and row keys can never diverge (never `col_N`).
+                    let column_name = crate::query::select_naming::result_column_name(expr, i);
 
                     // Look up CQL type for this column in the schema (Issue #674).
                     let cql_type_opt = schema_opt.and_then(|schema| {

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -194,6 +194,19 @@ fn projected_column_name(expr: &SelectExpression, index: usize) -> std::sync::Ar
     }
 }
 
+/// True when a `Project` expression RENAMES or EVALUATES its input rather than
+/// passing a stored column through unchanged (issue #1763).
+///
+/// A plain `Column` is emitted by the SSTable scan under the same name a
+/// `Project` would re-key it to, so streaming it directly matches the query
+/// metadata. Anything else — an alias (`category AS cat`), an aggregate, an
+/// arithmetic/function expression, or a literal — reshapes or renames the row,
+/// so the streaming path must materialize (fall back to execute-then-stream) to
+/// apply the `Project` and keep row value keys equal to the metadata names.
+fn project_expr_reshapes_row(expr: &SelectExpression) -> bool {
+    !matches!(expr, SelectExpression::Column(_))
+}
+
 /// SELECT query executor for SSTable-based storage
 pub struct SelectExecutor {
     /// Schema manager for metadata
@@ -453,6 +466,22 @@ impl SelectExecutor {
             match step {
                 ExecutionStep::Sort { .. } => return true,
                 ExecutionStep::Aggregate { .. } => return true,
+                // Issue #1763: the streaming producer (`execute_streaming_background`)
+                // IGNORES `Project`, so it emits rows keyed by the SOURCE stored
+                // column names (e.g. `category`) even when the SELECT renames or
+                // evaluates them (e.g. `category AS cat`) — silently disagreeing
+                // with the query metadata, which uses the SELECT output names.
+                // A `Project` that RENAMES (alias) or EVALUATES (aggregate /
+                // arithmetic / literal / function) any item must fall back to the
+                // materialized execute()-then-stream path, which applies the
+                // `Project`. A `Project` of only plain `Column`s does not reshape
+                // the row (the scan already keyed those cells by the same names),
+                // so it can stream without materializing.
+                ExecutionStep::Project { columns }
+                    if columns.iter().any(project_expr_reshapes_row) =>
+                {
+                    return true
+                }
                 _ => {}
             }
         }

--- a/cqlite-core/src/query/select_naming.rs
+++ b/cqlite-core/src/query/select_naming.rs
@@ -1,0 +1,184 @@
+//! Output/column name derivation for SELECT expressions.
+//!
+//! Extracted from the optimizer so result-metadata naming, the aggregation
+//! plan's row-value keys, and scan-projection column extraction all share ONE
+//! set of pure functions and cannot disagree (issue #1763). The invariant this
+//! module upholds: an aggregate's `metadata.columns[i].name` (via
+//! [`result_column_name`]) equals the row value key that `finalize_group` emits
+//! (via the aggregation plan's alias, derived from [`aggregate_output_name`]) —
+//! an explicit alias when present, else the derived expression text, never a
+//! synthetic `col_N`.
+
+use super::select_ast::*;
+
+/// The scan-projection column name for a SELECT expression, or `None` when the
+/// expression does not name a stored column (aggregates, literals, arithmetic).
+///
+/// Issue #1763: an aliased aggregate (`COUNT(*) AS total`) is NOT a stored
+/// column — it is excluded exactly as a bare aggregate is, so the alias never
+/// enters the scan as a phantom column; its output name comes from the
+/// aggregation plan, not a projected cell.
+pub(crate) fn extract_column_name(expr: &SelectExpression) -> Option<String> {
+    match expr {
+        SelectExpression::Column(col_ref) => Some(col_ref.column.clone()),
+        SelectExpression::Aliased(inner, _) if inner.is_aggregate() => None,
+        SelectExpression::Aliased(_, alias) => Some(alias.clone()),
+        _ => None,
+    }
+}
+
+/// Borrow the `AggregateFunction` from an aggregate expression, unwrapping a
+/// surrounding `Aliased` (`COUNT(*) AS total`). Returns `None` for non-aggregate
+/// expressions.
+pub(crate) fn unwrap_aggregate(expr: &SelectExpression) -> Option<&AggregateFunction> {
+    match expr {
+        SelectExpression::Aggregate(agg) => Some(agg),
+        SelectExpression::Aliased(inner, _) => unwrap_aggregate(inner),
+        _ => None,
+    }
+}
+
+/// The output column name for a (possibly aliased) aggregate SELECT expression,
+/// or `None` if `expr` is not an aggregate.
+///
+/// Issue #1763: the SINGLE source of truth for aggregate output names, shared by
+/// the aggregation plan (which keys row values via `finalize_group`) and result-
+/// metadata construction ([`result_column_name`]). Deriving both from this one
+/// function guarantees `metadata.columns[i].name` equals the emitted row value
+/// key for aggregates — an explicit alias when present, else the derived
+/// expression text (never a synthetic `col_N`).
+pub(crate) fn aggregate_output_name(expr: &SelectExpression) -> Option<String> {
+    match expr {
+        SelectExpression::Aggregate(agg) => Some(aggregate_column_and_alias(agg).1),
+        SelectExpression::Aliased(inner, alias) if inner.is_aggregate() => Some(alias.clone()),
+        _ => None,
+    }
+}
+
+/// The result (output) column name for a projected SELECT expression at position
+/// `index`, as it appears in `metadata.columns`.
+///
+/// Issue #1763: an aggregate is named by [`aggregate_output_name`] — the SAME
+/// source that keys the emitted row values (`finalize_group` via the aggregation
+/// plan alias) — so result metadata can never disagree with aggregate row value
+/// keys. Non-aggregate expressions use the column name, an explicit alias, or the
+/// synthetic `col_{index}` fallback. `WriteTimeTtl` is intentionally NOT handled
+/// here — the caller names those before reaching this function.
+pub(crate) fn result_column_name(expr: &SelectExpression, index: usize) -> String {
+    if let Some(name) = aggregate_output_name(expr) {
+        return name;
+    }
+    match expr {
+        SelectExpression::Column(col_ref) => col_ref.column.clone(),
+        SelectExpression::Aliased(_, alias) => alias.clone(),
+        _ => format!("col_{index}"),
+    }
+}
+
+/// Resolve `(column, alias)` for an aggregate. `COUNT(*)` and any aggregate
+/// referencing `*` yields `("*", "Func(*)")`; a single named column yields
+/// `(name, "Func_name")`; anything else falls back to `("*", "Func")`.
+pub(crate) fn aggregate_column_and_alias(agg: &AggregateFunction) -> (String, String) {
+    let references_star = agg.args.is_empty()
+        || agg
+            .args
+            .iter()
+            .any(|arg| matches!(arg, SelectExpression::Column(c) if c.column == "*"));
+
+    if references_star {
+        return ("*".to_string(), format!("{:?}(*)", agg.function));
+    }
+
+    match agg.args.first().and_then(extract_column_name) {
+        Some(col_name) => {
+            let alias = format!("{:?}_{}", agg.function, col_name);
+            (col_name, alias)
+        }
+        None => ("*".to_string(), format!("{:?}", agg.function)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn col(name: &str) -> SelectExpression {
+        SelectExpression::Column(ColumnRef {
+            table: None,
+            column: name.to_string(),
+        })
+    }
+
+    fn count_star() -> SelectExpression {
+        SelectExpression::Aggregate(AggregateFunction {
+            function: AggregateType::Count,
+            args: vec![],
+            distinct: false,
+        })
+    }
+
+    fn sum_of(c: &str) -> SelectExpression {
+        SelectExpression::Aggregate(AggregateFunction {
+            function: AggregateType::Sum,
+            args: vec![col(c)],
+            distinct: false,
+        })
+    }
+
+    /// The output name a bare aggregate exposes in metadata MUST equal the alias
+    /// the aggregation plan keys its row value by — the derived expression text,
+    /// never `col_N` (issue #1763).
+    #[test]
+    fn unaliased_aggregate_name_is_expression_text() {
+        assert_eq!(result_column_name(&count_star(), 0), "Count(*)");
+        assert_eq!(
+            aggregate_output_name(&count_star()).as_deref(),
+            Some("Count(*)")
+        );
+        // Metadata name == aggregation-plan alias (the single-source invariant).
+        assert_eq!(
+            result_column_name(&count_star(), 0),
+            aggregate_column_and_alias(unwrap_aggregate(&count_star()).unwrap()).1
+        );
+        assert_eq!(result_column_name(&sum_of("value"), 3), "Sum_value");
+    }
+
+    /// An explicit alias wins for BOTH metadata naming and the plan's row-value
+    /// key, so the two remain identical.
+    #[test]
+    fn aliased_aggregate_name_is_the_alias() {
+        let aliased = SelectExpression::Aliased(Box::new(count_star()), "total".to_string());
+        assert_eq!(result_column_name(&aliased, 0), "total");
+        assert_eq!(aggregate_output_name(&aliased).as_deref(), Some("total"));
+        // Unwraps to the inner aggregate for accumulation.
+        assert!(unwrap_aggregate(&aliased).is_some());
+    }
+
+    /// An aliased aggregate is never emitted as a scan-projection column (it is
+    /// not a stored cell), matching the bare-aggregate exclusion.
+    #[test]
+    fn aliased_aggregate_is_not_a_projection_column() {
+        let aliased = SelectExpression::Aliased(Box::new(count_star()), "total".to_string());
+        assert_eq!(extract_column_name(&aliased), None);
+        assert_eq!(extract_column_name(&count_star()), None);
+        // A plain column and a plain-aliased column still project normally.
+        assert_eq!(extract_column_name(&col("name")).as_deref(), Some("name"));
+        let aliased_col = SelectExpression::Aliased(Box::new(col("name")), "n".to_string());
+        assert_eq!(extract_column_name(&aliased_col).as_deref(), Some("n"));
+    }
+
+    /// A non-aggregate expression is not an aggregate name and falls back to the
+    /// synthetic positional name only when it is neither a column nor aliased.
+    #[test]
+    fn non_aggregate_naming_and_fallback() {
+        assert_eq!(aggregate_output_name(&col("x")), None);
+        assert_eq!(result_column_name(&col("x"), 2), "x");
+        assert_eq!(
+            result_column_name(
+                &SelectExpression::Literal(crate::types::Value::Integer(1)),
+                5
+            ),
+            "col_5"
+        );
+    }
+}

--- a/cqlite-core/src/query/select_naming.rs
+++ b/cqlite-core/src/query/select_naming.rs
@@ -27,6 +27,28 @@ pub(crate) fn extract_column_name(expr: &SelectExpression) -> Option<String> {
     }
 }
 
+/// For a plain-column SELECT projection (possibly aliased), return
+/// `(source_column, output_name)` where `source_column` is the stored column the
+/// scan reads and `output_name` is what appears in `metadata.columns`.
+///
+/// Issue #1763 (grouped dimensions): `finalize_group` keys a grouped dimension's
+/// row VALUE by its SELECT OUTPUT name so it matches the metadata name, while the
+/// group KEY is still read from the row by the raw stored column. This pairs the
+/// two: `Column(x)` → `(x, x)`, `Aliased(Column(x), "a")` → `(x, "a")`. The
+/// output side is exactly what [`extract_column_name`] returns, so a grouped
+/// dimension's row key can never diverge from its metadata name. Returns `None`
+/// for aggregates, literals, arithmetic, etc.
+pub(crate) fn projection_source_and_output(expr: &SelectExpression) -> Option<(String, String)> {
+    match expr {
+        SelectExpression::Column(col_ref) => Some((col_ref.column.clone(), col_ref.column.clone())),
+        SelectExpression::Aliased(inner, alias) => match inner.as_ref() {
+            SelectExpression::Column(col_ref) => Some((col_ref.column.clone(), alias.clone())),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Borrow the `AggregateFunction` from an aggregate expression, unwrapping a
 /// surrounding `Aliased` (`COUNT(*) AS total`). Returns `None` for non-aggregate
 /// expressions.

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -193,6 +193,27 @@ impl SelectOptimizer {
             FromClause::Table(t) | FromClause::TableAlias(t, _) => t.clone(),
         };
 
+        // Issue #1763: reject `SELECT DISTINCT <aggregate>` (e.g.
+        // `SELECT DISTINCT COUNT(*)`). `is_aggregate()` now unwraps aliased
+        // aggregates inside a `DISTINCT` clause, so `requires_aggregation()`
+        // returns true and an aggregation is planned — but `plan_aggregation`
+        // collects its computations ONLY from `SelectClause::Columns`, so a
+        // DISTINCT aggregate would plan an aggregation with NO computations and
+        // silently drop the result column. DISTINCT over an aggregate is also not
+        // a meaningful shape (the aggregate already collapses all rows to a
+        // single value, making DISTINCT redundant) and Cassandra rejects it.
+        // Fail cleanly here rather than return a wrong result.
+        if let SelectClause::Distinct(exprs) = &statement.select_clause {
+            if exprs.iter().any(|e| e.is_aggregate()) {
+                return Err(Error::query_execution(
+                    "SELECT DISTINCT with an aggregate function is not supported; \
+                     DISTINCT over an aggregate is redundant because the aggregate \
+                     already collapses rows to a single value"
+                        .to_string(),
+                ));
+            }
+        }
+
         if let Some(where_clause) = &statement.where_clause {
             // Validate EVERY token() restriction in the WHERE tree before pushdown
             // (roborev FINDING: token() under OR/NOT was never traversed, so an

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -1,6 +1,9 @@
 //! Query optimizer for SELECT statements - basic planning and predicate pushdown.
 
 use super::select_ast::*;
+use super::select_naming::{
+    aggregate_column_and_alias, aggregate_output_name, extract_column_name, unwrap_aggregate,
+};
 use crate::{schema::SchemaManager, storage::StorageEngine, Error, Result, TableId, Value};
 use std::sync::Arc;
 
@@ -543,14 +546,6 @@ fn extract_projection_columns(select_clause: &SelectClause) -> Vec<String> {
     }
 }
 
-fn extract_column_name(expr: &SelectExpression) -> Option<String> {
-    match expr {
-        SelectExpression::Column(col_ref) => Some(col_ref.column.clone()),
-        SelectExpression::Aliased(_, alias) => Some(alias.clone()),
-        _ => None,
-    }
-}
-
 fn plan_aggregation(statement: &SelectStatement) -> AggregationPlan {
     let group_by_columns = statement
         .group_by
@@ -561,44 +556,27 @@ fn plan_aggregation(statement: &SelectStatement) -> AggregationPlan {
     let mut aggregates = Vec::new();
     if let SelectClause::Columns(exprs) = &statement.select_clause {
         for expr in exprs {
-            if let SelectExpression::Aggregate(agg) = expr {
-                let (column, alias) = aggregate_column_and_alias(agg);
-                aggregates.push(AggregateComputation {
-                    function: agg.function.clone(),
-                    column,
-                    alias,
-                    distinct: agg.distinct,
-                });
-            }
+            // Issue #1763: handle both bare `COUNT(*)` and aliased
+            // `COUNT(*) AS total`. The output name (`alias`) is derived by the
+            // SINGLE shared source `aggregate_output_name`, so the row value key
+            // emitted by `finalize_group` can never diverge from the result
+            // metadata column name built by `get_result_columns`.
+            let Some((agg, alias)) = unwrap_aggregate(expr).zip(aggregate_output_name(expr)) else {
+                continue;
+            };
+            let (column, _) = aggregate_column_and_alias(agg);
+            aggregates.push(AggregateComputation {
+                function: agg.function.clone(),
+                column,
+                alias,
+                distinct: agg.distinct,
+            });
         }
     }
 
     AggregationPlan {
         group_by_columns,
         aggregates,
-    }
-}
-
-/// Resolve `(column, alias)` for an aggregate. `COUNT(*)` and any aggregate
-/// referencing `*` yields `("*", "Func(*)")`; a single named column yields
-/// `(name, "Func_name")`; anything else falls back to `("*", "Func")`.
-fn aggregate_column_and_alias(agg: &AggregateFunction) -> (String, String) {
-    let references_star = agg.args.is_empty()
-        || agg
-            .args
-            .iter()
-            .any(|arg| matches!(arg, SelectExpression::Column(c) if c.column == "*"));
-
-    if references_star {
-        return ("*".to_string(), format!("{:?}(*)", agg.function));
-    }
-
-    match agg.args.first().and_then(extract_column_name) {
-        Some(col_name) => {
-            let alias = format!("{:?}_{}", agg.function, col_name);
-            (col_name, alias)
-        }
-        None => ("*".to_string(), format!("{:?}", agg.function)),
     }
 }
 

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -2,9 +2,11 @@
 
 use super::select_ast::*;
 use super::select_naming::{
-    aggregate_column_and_alias, aggregate_output_name, extract_column_name, unwrap_aggregate,
+    aggregate_column_and_alias, aggregate_output_name, projection_source_and_output,
+    unwrap_aggregate,
 };
 use crate::{schema::SchemaManager, storage::StorageEngine, Error, Result, TableId, Value};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 // Test-only counter for the number of times `SelectOptimizer::optimize` runs
@@ -146,7 +148,13 @@ pub enum SSTableFilterOp {
 /// Aggregation execution plan
 #[derive(Debug, Clone)]
 pub struct AggregationPlan {
+    /// Raw stored column names `build_group_key` reads from each scanned row.
     pub group_by_columns: Vec<String>,
+    /// Issue #1763: SELECT OUTPUT name per grouped dimension (parallel to
+    /// `group_by_columns`); `finalize_group` emits the value under this name so it
+    /// equals the metadata column name (both from `select_naming`). Alias when
+    /// projected with one, else the column name.
+    pub group_by_output_names: Vec<String>,
     pub aggregates: Vec<AggregateComputation>,
 }
 
@@ -537,21 +545,54 @@ fn literal_value(expr: &SelectExpression) -> Option<Value> {
     }
 }
 
+/// Columns the SSTable scan must READ: the SOURCE stored column names, NOT the
+/// SELECT output aliases.
+///
+/// Issue #1763: `build_row_from_scan` filters decoded cells by physical column
+/// name, so an aliased projection (`category AS cat`) MUST scan `category` —
+/// projecting `cat` would drop the cell (null value; the `Project` step / grouped
+/// dimension could not find it). Output naming is applied afterwards (`Project`
+/// step / metadata / `finalize_group`), all via `select_naming`. Aggregates name
+/// no stored cell and are excluded.
 fn extract_projection_columns(select_clause: &SelectClause) -> Vec<String> {
     match select_clause {
         SelectClause::All => Vec::new(),
-        SelectClause::Columns(exprs) | SelectClause::Distinct(exprs) => {
-            exprs.iter().filter_map(extract_column_name).collect()
-        }
+        SelectClause::Columns(exprs) | SelectClause::Distinct(exprs) => exprs
+            .iter()
+            .filter_map(|e| projection_source_and_output(e).map(|(source, _)| source))
+            .collect(),
     }
 }
 
 fn plan_aggregation(statement: &SelectStatement) -> AggregationPlan {
-    let group_by_columns = statement
+    let group_by_columns: Vec<String> = statement
         .group_by
         .as_ref()
         .map(|g| g.columns.iter().map(|col| col.column.clone()).collect())
         .unwrap_or_default();
+
+    // Issue #1763 (grouped dimensions): map each grouped column to its SELECT
+    // OUTPUT name via the SAME `select_naming` source `get_result_columns` uses,
+    // so `finalize_group` emits the grouped value under the metadata column name.
+    // `col AS alias` yields `alias`; bare or not-projected yields the column name.
+    let mut output_for_source: HashMap<String, String> = HashMap::new();
+    if let SelectClause::Columns(exprs) | SelectClause::Distinct(exprs) = &statement.select_clause {
+        for expr in exprs {
+            if let Some((source, output)) = projection_source_and_output(expr) {
+                // First projection of a source column wins (matches metadata order).
+                output_for_source.entry(source).or_insert(output);
+            }
+        }
+    }
+    let group_by_output_names: Vec<String> = group_by_columns
+        .iter()
+        .map(|col| {
+            output_for_source
+                .get(col.as_str())
+                .cloned()
+                .unwrap_or_else(|| col.clone())
+        })
+        .collect();
 
     let mut aggregates = Vec::new();
     if let SelectClause::Columns(exprs) = &statement.select_clause {
@@ -576,6 +617,7 @@ fn plan_aggregation(statement: &SelectStatement) -> AggregationPlan {
 
     AggregationPlan {
         group_by_columns,
+        group_by_output_names,
         aggregates,
     }
 }

--- a/cqlite-core/tests/issue_1763_aggregate_metadata_alias.rs
+++ b/cqlite-core/tests/issue_1763_aggregate_metadata_alias.rs
@@ -200,6 +200,120 @@ async fn multi_aggregate_metadata_names_and_order_match_row_keys() {
     }
 }
 
+/// GROUP BY grouped-dimension name parity (roborev follow-up on #1763): for
+/// `SELECT category AS cat, COUNT(*) AS total ... GROUP BY category`, the grouped
+/// dimension's result METADATA name is the SELECT alias (`cat`), but before this
+/// fix `finalize_group` keyed the group VALUE under the raw GROUP BY column name
+/// (`category`) — so JSON/bindings read `cat` as null. Both the grouped dimension
+/// AND the aggregate must have metadata names that equal their row value keys,
+/// and the raw `category` name must NOT leak as a row key.
+#[tokio::test]
+async fn grouped_dimension_aliased_metadata_equals_row_key() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category AS cat, COUNT(*) AS total \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("aliased grouped dimension query must execute");
+
+    let meta_names: Vec<String> = result
+        .metadata
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    assert_eq!(
+        meta_names,
+        vec!["cat".to_string(), "total".to_string()],
+        "grouped-dimension + aggregate metadata names in SELECT order"
+    );
+
+    let row = result
+        .rows
+        .first()
+        .expect("GROUP BY query must return at least one row");
+
+    // Every metadata column name (grouped dimension AND aggregate) is a row key.
+    for name in &meta_names {
+        assert!(
+            row.values.contains_key(name.as_str()),
+            "issue #1763: metadata column {name:?} MUST be a row value key; row keys \
+             were {:?}",
+            row.values.keys().collect::<Vec<_>>()
+        );
+    }
+    // The raw GROUP BY column name must NOT leak as a row key, and no key is null
+    // for a value that exists (the alias must carry the grouped value).
+    assert!(
+        !row.values.contains_key("category"),
+        "issue #1763: raw GROUP BY column name `category` must not leak as a row \
+         value key when the SELECT aliases it to `cat`; row keys were {:?}",
+        row.values.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !row.values
+            .get("cat")
+            .is_none_or(cqlite_core::types::Value::is_null),
+        "issue #1763: grouped dimension `cat` must carry the group value, not null"
+    );
+}
+
+/// Unaliased grouped dimension: metadata name == row key == the column name
+/// (`category`) — the single `select_naming` source yields the same name on both
+/// sides even without an alias.
+#[tokio::test]
+async fn grouped_dimension_unaliased_metadata_equals_row_key() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, COUNT(*) AS total \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("unaliased grouped dimension query must execute");
+
+    let meta_names: Vec<String> = result
+        .metadata
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    assert_eq!(
+        meta_names,
+        vec!["category".to_string(), "total".to_string()],
+        "unaliased grouped dimension keeps its column name in metadata"
+    );
+
+    let row = result
+        .rows
+        .first()
+        .expect("GROUP BY query must return at least one row");
+    for name in &meta_names {
+        assert!(
+            row.values.contains_key(name.as_str()),
+            "issue #1763: metadata column {name:?} MUST be a row value key; row keys \
+             were {:?}",
+            row.values.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
 /// CLI-surface parity: `QueryResult::to_json` (the exact renderer behind the CLI
 /// `--out json` path) keys each row field by `metadata.columns[i].name` and looks
 /// the value up in `row.values`. Before the fix, an aggregate's metadata name

--- a/cqlite-core/tests/issue_1763_aggregate_metadata_alias.rs
+++ b/cqlite-core/tests/issue_1763_aggregate_metadata_alias.rs
@@ -18,6 +18,7 @@
 use std::path::{Path, PathBuf};
 
 use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
 use cqlite_core::Database;
 
 fn datasets_root() -> Option<PathBuf> {
@@ -312,6 +313,122 @@ async fn grouped_dimension_unaliased_metadata_equals_row_key() {
             row.values.keys().collect::<Vec<_>>()
         );
     }
+}
+
+/// Streaming path parity (roborev Medium #1: metadata != row-key on
+/// `execute_streaming`). The streaming producer IGNORED the `Project` step, so an
+/// aliased projection (`category AS cat`) streamed rows keyed by the SOURCE
+/// column (`category`) while the query metadata used the SELECT output name
+/// (`cat`) — a silent disagreement between metadata and row value keys. The fix
+/// makes `requires_materialization` fall back to the materialized
+/// execute()-then-stream path whenever a `Project` renames/evaluates an
+/// expression. Assert the streamed rows are keyed by the SELECT output name
+/// (`cat`, NOT `category`), carry a non-null value, and match the metadata name.
+#[tokio::test]
+async fn streaming_aliased_projection_row_key_equals_metadata() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let mut iter = db
+        .execute_streaming(
+            "SELECT category AS cat FROM test_basic.multi_partition_table",
+            StreamingConfig::default(),
+        )
+        .await
+        .expect("streaming aliased projection must start");
+
+    // Metadata uses the SELECT output name.
+    let meta_names: Vec<String> = iter
+        .metadata
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    assert_eq!(
+        meta_names,
+        vec!["cat".to_string()],
+        "streaming metadata column is the SELECT alias `cat`"
+    );
+
+    let mut saw_row = false;
+    while let Some(row_result) = iter.next_async().await {
+        let row = row_result.expect("streamed row must not error");
+        saw_row = true;
+        // The row VALUE must be keyed by the SELECT output name, matching metadata.
+        assert!(
+            row.values.contains_key("cat"),
+            "roborev #1 (streaming): metadata name `cat` MUST be a row value key; \
+             row keys were {:?}",
+            row.values.keys().collect::<Vec<_>>()
+        );
+        // The raw source column name must NOT leak as a row value key.
+        assert!(
+            !row.values.contains_key("category"),
+            "roborev #1 (streaming): raw source column `category` must not leak as a \
+             row value key when the SELECT aliases it to `cat`; row keys were {:?}",
+            row.values.keys().collect::<Vec<_>>()
+        );
+        // The aliased clustering value must be present (non-null).
+        assert!(
+            !row.values
+                .get("cat")
+                .is_none_or(cqlite_core::types::Value::is_null),
+            "roborev #1 (streaming): aliased projection `cat` must carry a non-null value"
+        );
+    }
+    assert!(
+        saw_row,
+        "streaming aliased projection must yield at least one row"
+    );
+}
+
+/// DISTINCT + aliased aggregate regression (roborev Medium #2). `is_aggregate()`
+/// now unwraps aliased aggregates inside `SELECT DISTINCT`, so
+/// `SELECT DISTINCT COUNT(*) AS total` planned an aggregation whose
+/// `plan_aggregation` collected NO computations (it reads only
+/// `SelectClause::Columns`) — returning a row MISSING `total` (silent wrong
+/// result). DISTINCT over an aggregate is not a meaningful shape (Cassandra
+/// rejects it), so CQLite rejects it with a clear error rather than dropping the
+/// column.
+#[tokio::test]
+async fn distinct_over_aggregate_is_rejected() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT DISTINCT COUNT(*) AS total FROM test_basic.multi_partition_table")
+        .await;
+
+    let err = result.expect_err(
+        "roborev #2: SELECT DISTINCT over an aggregate must return a clear Err, not a \
+         row silently missing the aggregate column",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("DISTINCT") && msg.contains("aggregate"),
+        "roborev #2: rejection message should explain DISTINCT-over-aggregate; got {msg:?}"
+    );
+
+    // The same shape without an alias is rejected identically (the regression was
+    // introduced by unwrapping aliased aggregates, but the shape itself is the
+    // unsupported one).
+    let unaliased = db
+        .execute("SELECT DISTINCT COUNT(*) FROM test_basic.multi_partition_table")
+        .await;
+    assert!(
+        unaliased.is_err(),
+        "roborev #2: unaliased SELECT DISTINCT COUNT(*) must also be rejected"
+    );
 }
 
 /// CLI-surface parity: `QueryResult::to_json` (the exact renderer behind the CLI

--- a/cqlite-core/tests/issue_1763_aggregate_metadata_alias.rs
+++ b/cqlite-core/tests/issue_1763_aggregate_metadata_alias.rs
@@ -1,0 +1,256 @@
+//! Issue #1763: aggregate result METADATA column names must equal the emitted
+//! ROW value key.
+//!
+//! Before the fix, an aggregate query's `metadata.columns[i].name` used a
+//! synthetic `col_0` fallback while the row value map keyed the same column by
+//! the derived aggregate alias (e.g. `Count(*)`) — so `metadata.columns`
+//! disagreed with the row value keys for aggregates. This regressed BOTH the
+//! `execute()` and `executeNative()` binding paths because the divergence lives
+//! in cqlite-core result-metadata construction (surfaced during #1446).
+//!
+//! These tests assert the invariant at the public `Database::execute` surface:
+//! for an aggregate column, `metadata.columns[i].name == row.values` key.
+//! - WITHOUT an explicit alias → both equal the expression text (never `col_0`).
+//! - WITH an explicit alias (`... AS total`) → both equal `total`.
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::Database;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup(schema_file: &str, keyspace_filter: &str) -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join(schema_file);
+    if !schema_path.exists() {
+        return Err(format!("{schema_file} not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(keyspace_filter.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+/// Assert that every metadata column name is present as a row value key, and
+/// return the single aggregate column name (the non-empty metadata name).
+fn assert_metadata_matches_row_keys(db_result: &cqlite_core::query::result::QueryResult) -> String {
+    let row = db_result
+        .rows
+        .first()
+        .expect("aggregate query must return exactly one result row");
+    assert_eq!(
+        db_result.metadata.columns.len(),
+        1,
+        "single-aggregate query has exactly one result column; got {:?}",
+        db_result
+            .metadata
+            .columns
+            .iter()
+            .map(|c| c.name.clone())
+            .collect::<Vec<_>>()
+    );
+    let meta_name = db_result.metadata.columns[0].name.clone();
+    assert!(
+        !meta_name.starts_with("col_"),
+        "issue #1763: aggregate metadata column must NOT be a synthetic `col_N` \
+         fallback; got {meta_name:?}"
+    );
+    assert!(
+        row.values.contains_key(meta_name.as_str()),
+        "issue #1763: metadata column name {meta_name:?} MUST be a row value key; \
+         row keys were {:?}",
+        row.values.keys().collect::<Vec<_>>()
+    );
+    meta_name
+}
+
+/// WITHOUT an explicit alias: metadata name == row value key == expression text
+/// (the derived aggregate name), never `col_0`.
+#[tokio::test]
+async fn aggregate_without_alias_metadata_equals_row_key() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT COUNT(*) FROM test_basic.multi_partition_table")
+        .await
+        .expect("unaliased COUNT(*) must execute");
+
+    let name = assert_metadata_matches_row_keys(&result);
+    // The derived expression text for COUNT(*) — must be identical for metadata
+    // AND the row value key (single source), and must NOT be `col_0`.
+    assert_eq!(
+        name, "Count(*)",
+        "unaliased aggregate name is the expression text, shared by metadata and row key"
+    );
+}
+
+/// WITH an explicit alias: metadata name == row value key == the alias.
+#[tokio::test]
+async fn aggregate_with_alias_metadata_equals_row_key() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT COUNT(*) AS total FROM test_basic.multi_partition_table")
+        .await
+        .expect("aliased COUNT(*) AS total must execute");
+
+    let name = assert_metadata_matches_row_keys(&result);
+    assert_eq!(
+        name, "total",
+        "aliased aggregate name is the explicit alias, shared by metadata and row key"
+    );
+}
+
+/// Multi-aggregate: `metadata.columns` names AND order must match the emitted row
+/// value keys, in SELECT-clause order (NOT the alphabetical order an unordered
+/// row-value map would otherwise expose). `SUM(value), COUNT(*)` picks names
+/// whose SELECT order (`Sum_value`, `Count(*)`) differs from their alphabetical
+/// order (`Count(*)`, `Sum_value`), so the assertion pins the contract.
+#[tokio::test]
+async fn multi_aggregate_metadata_names_and_order_match_row_keys() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT SUM(value), COUNT(*) FROM test_basic.multi_partition_table")
+        .await
+        .expect("multi-aggregate SELECT must execute");
+
+    let row = result
+        .rows
+        .first()
+        .expect("aggregate query must return exactly one result row");
+
+    let meta_names: Vec<String> = result
+        .metadata
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+
+    // Contract: SELECT-clause order, derived expression text, never `col_N`.
+    assert_eq!(
+        meta_names,
+        vec!["Sum_value".to_string(), "Count(*)".to_string()],
+        "issue #1763: multi-aggregate metadata columns must be the derived names in \
+         SELECT order (not alphabetical, not synthetic col_N)"
+    );
+
+    // Every metadata column name must be an actual row value key (name parity).
+    for name in &meta_names {
+        assert!(
+            row.values.contains_key(name.as_str()),
+            "issue #1763: metadata column {name:?} must be a row value key; row keys \
+             were {:?}",
+            row.values.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+/// CLI-surface parity: `QueryResult::to_json` (the exact renderer behind the CLI
+/// `--out json` path) keys each row field by `metadata.columns[i].name` and looks
+/// the value up in `row.values`. Before the fix, an aggregate's metadata name
+/// (`col_0`) did not match its row value key (`Count(*)`), so the CLI JSON emitted
+/// `"col_0": null` — silently dropping the aggregate result. This asserts the JSON
+/// carries the aggregate value under its real name (aliased and unaliased),
+/// covering the CLI leg of the 3-way parity. (Python/Node bindings consume the
+/// same cqlite-core metadata + row values and were already correct after #1446;
+/// the core name-parity guard above is what protects those surfaces.)
+#[tokio::test]
+async fn aggregate_to_json_uses_aggregate_name_not_null() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for (query, name) in [
+        (
+            "SELECT COUNT(*) FROM test_basic.multi_partition_table",
+            "Count(*)",
+        ),
+        (
+            "SELECT COUNT(*) AS total FROM test_basic.multi_partition_table",
+            "total",
+        ),
+    ] {
+        let result = db
+            .execute(query)
+            .await
+            .expect("aggregate query must execute");
+        let json = result.to_json();
+        let first_row = json
+            .get("rows")
+            .and_then(|r| r.as_array())
+            .and_then(|a| a.first())
+            .expect("to_json must emit at least one row");
+        let value = first_row.get(name).unwrap_or_else(|| {
+            panic!("issue #1763: CLI JSON must key the aggregate by {name:?}; row was {first_row}")
+        });
+        assert!(
+            value.is_number() && value.as_i64() == Some(100),
+            "issue #1763: CLI JSON field {name:?} must carry the COUNT value (100 rows), \
+             not null/synthetic; got {value}"
+        );
+        // The synthetic fallback must never appear as a JSON field.
+        assert!(
+            first_row.get("col_0").is_none(),
+            "issue #1763: CLI JSON must not contain a synthetic `col_0` field; row was {first_row}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1763.

Aggregate + grouped-dimension result METADATA column names now derive from the same `select_naming` source as the emitted row value keys, so `metadata.columns[i].name == row key` (alias > expr text, never `col_0`). Also caught + fixed: `COUNT(*) AS total` previously errored entirely; a pre-existing `SELECT col AS alias` projection bug; streaming aliased projections (materialization fallback); and DISTINCT-over-aggregate now cleanly rejected (matches Cassandra).

**Quality bar (auto-merge on green):**
- `agent-gate.sh`: **PASS** (full gate, solo run)
- rust-reviewer: clean
- roborev (codex): NAME-parity findings all fixed across 3 rounds; the remaining HIGH is a pre-existing VALUE bug (aggregate-arg projection) out of this issue's scope → filed **#1952** + **#1941** (metadata types).

Tests: aggregate name parity (aliased/unaliased), grouped-dimension parity, streaming alias, DISTINCT rejection — on the real `Database::execute`/streaming/CLI surfaces.