### PR TITLE
feat(#1336): RF-correct logical optimizer row count for Flight/Trino

### DIFF
--- a/docs/flight-trino/PLAN.md
+++ b/docs/flight-trino/PLAN.md
@@ -46,6 +46,36 @@ filtering pinned to a single replica, Trino would see each row RF times. cqlite'
 compaction reconciles only *within* a node; cross-replica dedup is the connector's
 job (one range → one replica) backed by the server's range filter.
 
+### Statistics semantics: two different de-replication mechanisms (issue #1336)
+The **scan path** and the **optimizer-stats path** both have to undo RF over-counting,
+but by different means, and they must not be confused:
+
+- **Scan path — dedupe by token range.** One split per read-replica token range, pinned
+  to exactly one replica; the server filters output to that `(start, end]` range, so each
+  logical row is emitted once cluster-wide (above).
+- **Stats path — de-replicate by uniform replica-count division.** `table_stats` has no
+  token fields, so `CqliteFlightMetadata.getTableStatistics` sums the whole-table
+  `live_rows` across the keyspace's DISTINCT scoped replica hosts (≈ RF × logical
+  cardinality) and reports `ROW_COUNT = live_rows / R`. `R` is the **uniform per-token-range
+  distinct scoped read-replica count** derived ONLY from the authoritative Sidecar
+  `tokenRangeReplicas` response (never by parsing `replication = {...}` strategy strings —
+  no-heuristics mandate #28), under the same `localDatacenter` scoping the stats sum was
+  collected under.
+
+**Fail-closed conditions** (report `TableStatistics.empty()`, today's behavior — statistics
+failures never fail query planning): non-uniform per-range replica counts (topology
+mid-transition), a zero-replica range, `table_stats` `complete=false` (undecodable
+`Statistics.db` / unreachable replica / #1327 count contradiction), or ANY Sidecar/Flight
+error or timeout. The result is memoized per `(keyspace, table)` so one planning pass
+fetches `tokenRangeReplicas` and `table_stats` at most once each per table.
+
+**Caveats (documented, accepted):** under replica divergence (repair lag, differing
+compaction of expired data) the quotient is the mean across replicas — a well-behaved
+`Estimate`, not an exact count. **Transient replication** (Cassandra experimental) is
+invisible in Sidecar's replica lists, so such keyspaces may over-divide; documented out of
+scope. The AUTOMATIC GROUP-BY pushdown gate (`estimateGroupRatio`) is UNCHANGED — it uses
+the RF-invariant `partition_count / live_rows` ratio where replica over-count cancels.
+
 ---
 
 ## 3. Grounded API facts (from spike — quote these when implementing)

--- a/openspec/changes/rf-correct-row-stats/design.md
+++ b/openspec/changes/rf-correct-row-stats/design.md
@@ -1,0 +1,118 @@
+# Design: RF-correct logical row count via authoritative replica-count division
+
+## Context (facts, verified against the worktree)
+
+- **Scan path is already RF-deduplicated**: `CqliteFlightSplitManager.buildSplits`
+  (`CqliteFlightSplitManager.java:68-95`) emits one split per read-replica token range, pinned to
+  exactly ONE replica (`pickReplica`, `:102-114`, local-DC preferred, deterministic), and the Rust
+  server filters each scan to the split's `(start, end]` token range
+  (`ticket.rs:240-246`, `filter.rs:62-86,209-217`, `producer.rs:384-409,437-438`). Each row is read
+  once cluster-wide.
+- **Stats path is not**: `fetchTableStats` (`CqliteFlightMetadata.java:639-650`) sends a
+  whole-table `table_stats` request (no token fields exist on `TableStatsRequest`,
+  `cqlite-flight/src/stats.rs:92-119` / `service.rs:419-467`) to the DISTINCT union of replica
+  hosts (`replicaHosts`, `:667-692`, scoped to `localDatacenter` when set, else all DCs) and sums
+  (`aggregateNodeStats`, `:724-750`). On RF=N the sum counts every logical row ~N times.
+- **`Statistics.db` is not range-decomposable**: `read_table_counts`
+  (`cqlite-core/src/parser/repair_metadata.rs:805-810`) yields whole-SSTable
+  `partition_count` (Σ `estimatedPartitionSize` histogram buckets) and `total_rows`
+  (STATS `totalRows`, `None` when not traversable). There is no per-token-range breakdown.
+- **Sidecar provides authoritative per-range replica lists**: `tokenRangeReplicas(keyspace)`
+  (`SidecarClient.java:44-47`) → `ReplicaInfo{start, end, replicasByDatacenter}`
+  (`SidecarModels.java:39-51`). Host lists only — no per-range counts of rows/partitions.
+- **Completeness is already fail-closed** end to end: server taints `complete=false` on any
+  missing/undecodable `Statistics.db`, missing `totalRows`, or the #1327 empty-histogram
+  contradiction (`stats.rs:310-319`); connector taints on unreachable hosts
+  (`TableStats.UNAVAILABLE` fold).
+
+## Decision
+
+**Approach A — connector-side logical de-replication (chosen).**
+
+For a non-aggregated table handle, `getTableStatistics`:
+
+1. `ranges = sidecar.tokenRangeReplicas(keyspace).readReplicas()`; scope each range's replica set
+   with the SAME DC rule `replicaHosts` uses (`localDatacenter` when configured, else all DCs).
+2. Derive `R_i = |distinct scoped replicas of range i|`. **Require `R_i` identical (= R ≥ 1) for
+   all ranges**; any non-uniformity (mid-bootstrap/decommission topology, partially-replicated DC,
+   empty range replica set) → return `TableStatistics.empty()`.
+3. `stats = fetchTableStats(handle)` (existing whole-table, all-scoped-hosts sum). Require
+   `stats.complete()`; else `empty()`.
+4. Report `TableStatistics.builder().setRowCount(Estimate.of((double) stats.liveRows() / R))`.
+5. Any `RuntimeException` / timeout anywhere → `empty()` (same degrade posture as
+   `groupRatioForGate`, `:446-464`; planning must never fail because stats were unavailable).
+6. Memoize `stats` (and the derived `R`) per `(keyspace, table)` in the `CqliteFlightMetadata`
+   instance so one planning pass fetches at most once per table.
+
+Correctness argument (no distribution assumption): under NTS/SimpleStrategy the per-keyspace
+replica count is uniform across the token space **within the scoping** (per-DC RF is a keyspace-
+level constant; total RF likewise). Summing whole-table `live_rows` over the distinct scoped
+host set counts each logical row exactly once per replica that stores it — i.e. exactly `R`
+times when replicas are consistent. Division is exact under consistency; under replica
+divergence (repair lag, differing compaction of expired data) it returns the mean across
+replicas — a well-behaved estimate, which is precisely `Estimate`'s contract. The uniformity
+check makes the one situation where "count replicas per range" and "keyspace RF" can disagree
+(topology in transition) fail closed to today's behavior.
+
+No-heuristics compliance: the divisor is obtained by **counting actual replicas in
+authoritative token-range metadata**, never by parsing `replication = {...}` strategy-class
+option strings (fragile across NTS per-DC maps and transient-replication `"3/1"` syntax — that
+was the issue's own objection to the naive "derive RF" variant, and it is why Alternative C is
+rejected). No byte-pattern or distribution guessing anywhere.
+
+## Alternatives considered
+
+**B — token-range-scoped `table_stats` (the issue's initial lean): rejected.** It sounds like
+"match the split assignment," but it cannot produce an honest per-range **row** count:
+`Statistics.db` has no per-range breakdown, so the server would have to either (i) scan
+`Data.db`/walk `Index.db` per planning call — `Index.db`/BTI range walks give per-range
+*partition* counts, but per-range *rows* would still be `partitions_in_range × avg_rows_per_
+partition`, a rows-uniform-across-partitions attribution — or (ii) do a real data scan at
+planning time (unaffordable vs the 3 s stats budget). Either way it embeds MORE inference than
+Approach A while also demanding a new wire field, per-format (BIG + BTI) server-side range
+counting, and a bigger test surface. Kept as a documented future refinement iff per-split cost
+estimates are ever needed; nothing in A blocks it.
+
+**C — divide by RF parsed from keyspace schema replication options: rejected.** String-
+interpreting strategy-class options (NTS per-DC maps, transient `"3/1"`) is exactly the fragility
+the issue flags, gives no fail-closed signal during topology transitions, and duplicates
+information the token-range endpoint states authoritatively.
+
+**D — sum stats from only the split-assigned (one-per-range) host subset: rejected as
+insufficient alone.** Each node's `Statistics.db` covers **everything that node replicates**, not
+just its split-assigned ranges (see "hosts" below), so summing whole-table stats over the deduped
+host subset still multi-counts. Range scoping would be required to fix that — which is
+Alternative B.
+
+## Known limitations (documented, accepted)
+
+- **Replica divergence** makes the result an average-across-replicas estimate rather than an
+  exact count. Acceptable: Trino stats are `Estimate`s; today's alternative is no signal at all.
+- **Transient replication** (Cassandra experimental) is invisible in Sidecar's replica lists;
+  keyspaces using it may over-divide. Documented out of scope.
+- `live_rows` is the STATS `totalRows` upper bound (pre-tombstone-merge), consistent with how the
+  gate already interprets it (#944).
+
+## Deployment/topology notes
+
+"Hosts" here are one cqlite-flight server per Cassandra node, each reading that node's local
+data dir (`cqlite-flight/src/main.rs:19-31`); a node's dir contains every range the node
+replicates. That is why D fails and why A's whole-table-sum ÷ R is the clean identity.
+
+## Test design (fail-first, fixture-driven)
+
+- Extend the `AggregateNodeStatsTest`-style harness (it already models RF>1 via injected fetch
+  functions + multi-replica `ReplicaInfo`): RF=3 fixture where three hosts each report 200 rows →
+  `getTableStatistics` must report **200**, not 600 (this is the issue's acceptance criterion:
+  physical sum ≠ logical cardinality).
+- Multi-DC fixture (dc1 RF=3, dc2 RF=2) with `localDatacenter=dc1` → divisor 3; unset → divisor 5.
+- Fail-closed fixtures: non-uniform per-range counts → `empty()`; `complete=false` → `empty()`;
+  Sidecar throws / stats timeout → `empty()` and planning proceeds.
+- Pin unchanged behavior: global agg still `ROW_COUNT=1`, grouped agg still `empty()`
+  (`CqliteFlightTableStatisticsTest` updated: the non-aggregated case flips from
+  pinned-`empty()` to pinned-logical-count under healthy fixtures, with new pinned-`empty()`
+  fail-closed cases).
+- `EstimateGroupRatioTest` and the gate tests must pass **unmodified** (gate untouched).
+- Wiring evidence: the public surface is Trino's `ConnectorMetadata.getTableStatistics`; the
+  end-to-end test drives it through `CqliteFlightMetadata` with real `TableStats` JSON decode +
+  real `SidecarModels` parsing (no mocking of the derivation itself).

--- a/openspec/changes/rf-correct-row-stats/proposal.md
+++ b/openspec/changes/rf-correct-row-stats/proposal.md
@@ -4,6 +4,10 @@ Issue: #1336 (deferred from #944 / PR #1329). Design-driven (connector architect
 distributed-stats semantics) → OpenSpec, Seam-1 owner approval required. Milestone: connector
 enhancement (post-v0.12, Flight/Trino track).
 
+**Owner approved (Seam 1): 2026-07-04.** Parked for a later implementation team — pick up by
+fetching branch `issue-1336-rf-correct-row-stats` (existing worktree/claim) and running
+`flow-implement 1336` against this change's `tasks.md`. Do not re-run `flow-activate`.
+
 ## Why
 
 `CqliteFlightMetadata.getTableStatistics` returns `TableStatistics.empty()` for every

--- a/openspec/changes/rf-correct-row-stats/proposal.md
+++ b/openspec/changes/rf-correct-row-stats/proposal.md
@@ -1,0 +1,84 @@
+# Proposal: RF-correct optimizer row-count stats for the Flight/Trino connector
+
+Issue: #1336 (deferred from #944 / PR #1329). Design-driven (connector architecture +
+distributed-stats semantics) → OpenSpec, Seam-1 owner approval required. Milestone: connector
+enhancement (post-v0.12, Flight/Trino track).
+
+## Why
+
+`CqliteFlightMetadata.getTableStatistics` returns `TableStatistics.empty()` for every
+non-aggregated scan (`CqliteFlightMetadata.java:891-910`), so Trino's cost-based optimizer plans
+CQLite scans with **no cardinality signal at all** — join ordering, join distribution
+(broadcast vs partitioned), and filter selectivity all fall back to Trino's blind defaults.
+
+#944 had to defer this: the only absolute counts the connector can fetch
+(`fetchTableStats`, `CqliteFlightMetadata.java:639-650`) are whole-table `Statistics.db` sums
+collected from **every** replica host of the keyspace, so on a replicated keyspace (RF=3) the
+sum is ~3× the logical table cardinality. Reporting that number would actively mislead the
+optimizer, so #944 conservatively reported nothing. The AUTOMATIC aggregation-pushdown gate was
+unaffected because it uses only the RF-invariant ratio `partition_count / live_rows`.
+
+This change closes the deferral: derive the **logical (de-replicated)** row count from
+authoritative replica-topology metadata and report it, failing closed to today's `empty()`
+whenever the derivation cannot be grounded.
+
+## What Changes
+
+Connector-side only (Java, `trino-connector/`). **No Rust/Flight server changes; no wire
+changes; no new config knobs.**
+
+1. `getTableStatistics` (non-aggregated branch): fetch table stats over the existing
+   `table_stats` DoAction (unchanged wire), fetch `tokenRangeReplicas` from Sidecar (existing
+   endpoint), derive the per-token-range distinct read-replica count `R` under the same
+   `localDatacenter` scoping that `replicaHosts`/split selection already use, and — **only when
+   `R` is identical across every range and `stats.complete()`** — report
+   `ROW_COUNT = live_rows / R`. Any other condition (non-uniform `R`, incomplete stats, Sidecar
+   or Flight error, timeout) returns `TableStatistics.empty()` exactly as today.
+2. Memoize the fetched stats per `(keyspace, table)` within the metadata instance so repeated
+   optimizer calls during one planning pass pay for at most one fetch (planning-time cost stays
+   bounded by the existing `tableStatsTimeoutMillis` degrade path from #944).
+3. The aggregated branches of `getTableStatistics` (global agg → `ROW_COUNT = 1`, grouped agg →
+   `empty()`) and the entire AUTOMATIC pushdown gate (`estimateGroupRatio`,
+   `declineGroupByPushdown`) are **untouched**.
+
+Why this beats the issue's sketched token-range-scoped alternative: `Statistics.db` exposes only
+whole-SSTable counts (histogram `partition_count`, STATS `totalRows`) — it is **not
+range-decomposable** — so a token-range-scoped `table_stats` could produce a per-range *row*
+count only via a planning-time data scan (unaffordable) or a rows-uniform-across-ranges
+attribution assumption (**more** inference, not less). The replica-count divide needs no
+distribution assumption: in a consistent keyspace every logical row is stored on exactly `R`
+scoped read replicas, so the cross-host sum counts each row exactly `R` times. Full comparison in
+`design.md`.
+
+## Non-goals
+
+- **Per-column statistics** (NDV, min/max, null fraction). Cassandra 5.0 `Statistics.db` carries
+  no reliable per-regular-column cardinality; there is no authoritative source. Same fail-closed
+  posture as #944 (issue #1336 says "ideally" — explicitly out).
+- **Token-range-scoped `table_stats` / per-split stats.** No server or wire changes here; kept as
+  a documented future refinement if per-split cost estimates are ever needed (see design.md
+  Alternative B).
+- **Grouped-aggregate output cardinality.** Grouped-agg handles keep `TableStatistics.empty()`.
+- **Live multi-node (RF>1) e2e harness.** The repo's docker e2e stack is single-node; RF>1
+  validation is by deterministic multi-replica fixtures (the established
+  `AggregateNodeStatsTest` pattern), not a live 3-node cluster.
+- **Transient replication** (Cassandra experimental): Sidecar's replica lists do not distinguish
+  transient replicas; keyspaces using it are outside this estimate's correctness envelope
+  (documented limitation, design.md).
+
+## Doctrine impact
+
+None to CLAUDE.md or the agents-developing site. The change strengthens no-heuristics compliance
+in an existing surface (divisor comes from counting actual per-range replicas in authoritative
+Sidecar metadata — never from parsing replication-strategy option strings) and keeps #944's
+fail-closed posture. `docs/flight-trino/PLAN.md` gets a short stats-semantics note as part of the
+change.
+
+## Impact
+
+- Code: `trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java` (+ a
+  small pure helper for the uniform-replica-count derivation), tests alongside existing
+  `CqliteFlightTableStatisticsTest` / `AggregateNodeStatsTest`.
+- Specs: new capability `flight-optimizer-stats` (ADDED requirements).
+- Risk: low — additive estimate with fail-closed degrade to current behavior; gate and
+  aggregated paths untouched.

--- a/openspec/changes/rf-correct-row-stats/specs/flight-optimizer-stats/spec.md
+++ b/openspec/changes/rf-correct-row-stats/specs/flight-optimizer-stats/spec.md
@@ -1,0 +1,85 @@
+# flight-optimizer-stats
+
+RF-correct logical optimizer row-count statistics for the Flight/Trino connector (issue #1336,
+deferred from #944).
+
+## ADDED Requirements
+
+### Requirement: Non-aggregated scans report a logical (de-replicated) row count
+For a non-aggregated table handle, `CqliteFlightMetadata.getTableStatistics` SHALL report
+`TableStatistics` with `ROW_COUNT = live_rows / R`, where `live_rows` is the existing
+cross-replica-host `table_stats` sum and `R` is the uniform per-token-range distinct
+read-replica count derived from Sidecar `tokenRangeReplicas` under the same `localDatacenter`
+scoping used by `replicaHosts` and split selection. The physical replica-summed total SHALL
+never be reported as the row count.
+
+#### Scenario: RF=3 keyspace reports logical, not physical, cardinality
+- **WHEN** `getTableStatistics` runs for a non-aggregated handle over a keyspace whose every token range has 3 scoped read replicas and whose three replica hosts each report 200 live rows (physical sum 600)
+- **THEN** the reported `ROW_COUNT` estimate is 200
+- **AND** not 600
+
+#### Scenario: Multi-DC replica sets divide by the scoped replica count
+- **WHEN** a keyspace is replicated dc1=3, dc2=2 and `localDatacenter` is configured as `dc1`
+- **THEN** the divisor is 3 (the dc1-scoped per-range replica count)
+- **AND** when `localDatacenter` is not configured, the divisor is 5 (all-DC scoping), matching the host set the stats sum was collected from
+
+#### Scenario: One planning pass fetches stats at most once per table
+- **WHEN** the optimizer calls `getTableStatistics` repeatedly for the same `(keyspace, table)` within one metadata instance
+- **THEN** the connector issues at most one `table_stats` fetch and one `tokenRangeReplicas` fetch for that table, reusing the memoized result
+
+### Requirement: The divisor derives only from authoritative token-range replica metadata
+The replica-count divisor SHALL be obtained by counting distinct scoped replicas per token range
+in the Sidecar `tokenRangeReplicas` response. It SHALL NOT be obtained by parsing keyspace
+replication-strategy option strings, and no distributional assumption (e.g. rows uniform across
+token ranges or partitions) SHALL enter the derivation (no-heuristics mandate, issue #28).
+
+#### Scenario: Divisor counts actual per-range replicas
+- **WHEN** the divisor for a keyspace is derived
+- **THEN** it equals the distinct scoped read-replica count shared by every token range in the authoritative `tokenRangeReplicas` response
+- **AND** no code path parses `replication = {...}` strategy options to obtain it
+
+### Requirement: The logical row count fails closed to empty statistics
+Whenever the derivation cannot be grounded, `getTableStatistics` SHALL return
+`TableStatistics.empty()` (today's behavior) rather than a possibly-wrong number. Grounding
+failures include: per-range scoped replica counts that are not identical across all ranges, a
+range with zero scoped replicas, `table_stats` reporting `complete=false`, and any Sidecar or
+Flight error or timeout. Statistics failures SHALL never fail query planning.
+
+#### Scenario: Non-uniform per-range replica counts fail closed
+- **WHEN** the scoped `tokenRangeReplicas` response contains ranges with differing distinct replica counts (e.g. topology mid-transition)
+- **THEN** `getTableStatistics` returns `TableStatistics.empty()`
+
+#### Scenario: Incomplete stats fail closed
+- **WHEN** the aggregated `TableStats` has `complete=false` (unreachable host, undecodable `Statistics.db`, missing `totalRows`, or the #1327 count contradiction)
+- **THEN** `getTableStatistics` returns `TableStatistics.empty()`
+
+#### Scenario: Infrastructure failure degrades to no estimate, never a planning failure
+- **WHEN** the Sidecar call or a `table_stats` fetch throws or exceeds `tableStatsTimeoutMillis`
+- **THEN** `getTableStatistics` returns `TableStatistics.empty()`
+- **AND** the query continues planning normally
+
+### Requirement: Aggregation paths and the AUTOMATIC pushdown gate are unchanged
+This feature SHALL NOT change the behavior of the aggregated branches of `getTableStatistics`
+(global aggregate → `ROW_COUNT = 1`; grouped aggregate → `TableStatistics.empty()`) nor of the
+AUTOMATIC GROUP-BY pushdown gate (`estimateGroupRatio` / `declineGroupByPushdown`, which use
+only the RF-invariant `partition_count / live_rows` ratio).
+
+#### Scenario: Aggregated handles keep their existing statistics
+- **WHEN** `getTableStatistics` runs for a global-aggregate handle
+- **THEN** it reports `ROW_COUNT = 1`
+- **AND** for a grouped-aggregate handle it returns `TableStatistics.empty()`
+
+#### Scenario: Gate decisions are identical before and after
+- **WHEN** the existing gate test suite (`EstimateGroupRatioTest` and related pushdown tests) runs against this change
+- **THEN** it passes without modification
+
+### Requirement: The logical count is exercised through the public connector surface
+The feature SHALL be validated through Trino's `ConnectorMetadata.getTableStatistics` on
+`CqliteFlightMetadata` (the public surface), with real `TableStats` JSON decoding and real
+`SidecarModels` token-range parsing in the fixtures — not by unit-testing a private helper alone
+(wiring-evidence doctrine).
+
+#### Scenario: End-to-end derivation over decoded fixtures
+- **WHEN** the RF>1 validation test runs
+- **THEN** it drives `CqliteFlightMetadata.getTableStatistics` end to end over multi-replica `tokenRangeReplicas` JSON fixtures and per-host `table_stats` responses
+- **AND** asserts the reported estimate equals the logical cardinality

--- a/openspec/changes/rf-correct-row-stats/tasks.md
+++ b/openspec/changes/rf-correct-row-stats/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: rf-correct-row-stats (#1336)
+
+All work is Java, `trino-connector/` only. No Rust, no wire, no config changes. Fail-first TDD:
+write each failing test before the code that satisfies it. Surfaces are named per task
+(wiring-evidence).
+
+## 1. Uniform replica-count derivation (pure helper)
+- [ ] 1.1 Add a pure static helper (suggested: `uniformReplicaCount(TokenRangeReplicasResponse, String localDatacenter)` beside `replicaHosts` in `CqliteFlightMetadata.java`) returning `OptionalInt`: the distinct scoped read-replica count iff identical (≥1) across all ranges, else empty. Reuse the exact DC-scoping rule of `replicaHosts` (`localDatacenter` when set, else all DCs).
+- [ ] 1.2 Tests (new `UniformReplicaCountTest` or extend `AggregateNodeStatsTest`): uniform RF=3 → 3; multi-DC dc1=3/dc2=2 with `localDatacenter=dc1` → 3, unset → 5; non-uniform ranges → empty; zero-replica range → empty; duplicate replica entries within a range are deduped. Fixtures use real `SidecarModels` parsing.
+
+## 2. Logical row count in `getTableStatistics` (surface: `ConnectorMetadata.getTableStatistics`)
+- [ ] 2.1 Failing test first: RF=3, three hosts × 200 rows → expect `ROW_COUNT = 200` (not 600) through `CqliteFlightMetadata.getTableStatistics` end to end (injected fetch functions, real `TableStats` JSON decode) — the issue's acceptance criterion.
+- [ ] 2.2 Implement the non-aggregated branch: fetch `tokenRangeReplicas` + `fetchTableStats`, require uniform `R` and `stats.complete()`, report `Estimate.of((double) liveRows / R)`; wrap the whole derivation so any `RuntimeException`/timeout → `TableStatistics.empty()` (mirror `groupRatioForGate`'s degrade posture).
+- [ ] 2.3 Memoize per `(keyspace, table)` in the metadata instance; test: repeated calls → one fetch (counting stub).
+- [ ] 2.4 Fail-closed tests: non-uniform ranges → `empty()`; `complete=false` → `empty()`; Sidecar throws → `empty()` and no exception escapes.
+- [ ] 2.5 Update `CqliteFlightTableStatisticsTest`: non-aggregated pinned case moves from always-`empty()` to logical-count-when-grounded + `empty()`-when-not; aggregated pins (global → 1, grouped → `empty()`) unchanged.
+
+## 3. Unchanged-gate proof
+- [ ] 3.1 Run the full existing connector suite; `EstimateGroupRatioTest`, `PrimaryKeyExtractorTest`, `TableStatsTest`, split-manager tests must pass **unmodified**.
+
+## 4. Docs
+- [ ] 4.1 Add a stats-semantics note to `docs/flight-trino/PLAN.md` (scan path dedupes by token range; stats path de-replicates by uniform replica-count division; fail-closed conditions; transient-replication + replica-divergence caveats).
+
+## 5. Quality stages (gate → C → roborev)
+- [ ] 5.1 `./gradlew test` in `trino-connector/` green (the Java suite is the blast-radius test set).
+- [ ] 5.2 `scripts/agent-gate.sh --lite` per fix round; FULL `scripts/agent-gate.sh` ONCE before merge (`CQLITE_DATASETS_ROOT` → main repo's `test-data/datasets`); paste the `==== AGENT-GATE SUMMARY ====` block verbatim.
+- [ ] 5.3 `spec-auditor` (C) anchored to `openspec/changes/rf-correct-row-stats/specs/**` — every requirement `satisfied` with a public-surface test as evidence.
+- [ ] 5.4 roborev clean (`/roborev-review-branch --base origin/main`); pre-empt the recurring-findings checklist (esp. float division edge cases and no-heuristics).
+- [ ] 5.5 PR referencing #1336; merge-on-green per autonomy model; then `flow-finalize` (archive change, remove worktree, close issue).

--- a/openspec/changes/rf-correct-row-stats/tasks.md
+++ b/openspec/changes/rf-correct-row-stats/tasks.md
@@ -5,21 +5,21 @@ write each failing test before the code that satisfies it. Surfaces are named pe
 (wiring-evidence).
 
 ## 1. Uniform replica-count derivation (pure helper)
-- [ ] 1.1 Add a pure static helper (suggested: `uniformReplicaCount(TokenRangeReplicasResponse, String localDatacenter)` beside `replicaHosts` in `CqliteFlightMetadata.java`) returning `OptionalInt`: the distinct scoped read-replica count iff identical (≥1) across all ranges, else empty. Reuse the exact DC-scoping rule of `replicaHosts` (`localDatacenter` when set, else all DCs).
-- [ ] 1.2 Tests (new `UniformReplicaCountTest` or extend `AggregateNodeStatsTest`): uniform RF=3 → 3; multi-DC dc1=3/dc2=2 with `localDatacenter=dc1` → 3, unset → 5; non-uniform ranges → empty; zero-replica range → empty; duplicate replica entries within a range are deduped. Fixtures use real `SidecarModels` parsing.
+- [x] 1.1 Add a pure static helper (suggested: `uniformReplicaCount(TokenRangeReplicasResponse, String localDatacenter)` beside `replicaHosts` in `CqliteFlightMetadata.java`) returning `OptionalInt`: the distinct scoped read-replica count iff identical (≥1) across all ranges, else empty. Reuse the exact DC-scoping rule of `replicaHosts` (`localDatacenter` when set, else all DCs).
+- [x] 1.2 Tests (new `UniformReplicaCountTest` or extend `AggregateNodeStatsTest`): uniform RF=3 → 3; multi-DC dc1=3/dc2=2 with `localDatacenter=dc1` → 3, unset → 5; non-uniform ranges → empty; zero-replica range → empty; duplicate replica entries within a range are deduped. Fixtures use real `SidecarModels` parsing.
 
 ## 2. Logical row count in `getTableStatistics` (surface: `ConnectorMetadata.getTableStatistics`)
-- [ ] 2.1 Failing test first: RF=3, three hosts × 200 rows → expect `ROW_COUNT = 200` (not 600) through `CqliteFlightMetadata.getTableStatistics` end to end (injected fetch functions, real `TableStats` JSON decode) — the issue's acceptance criterion.
-- [ ] 2.2 Implement the non-aggregated branch: fetch `tokenRangeReplicas` + `fetchTableStats`, require uniform `R` and `stats.complete()`, report `Estimate.of((double) liveRows / R)`; wrap the whole derivation so any `RuntimeException`/timeout → `TableStatistics.empty()` (mirror `groupRatioForGate`'s degrade posture).
-- [ ] 2.3 Memoize per `(keyspace, table)` in the metadata instance; test: repeated calls → one fetch (counting stub).
-- [ ] 2.4 Fail-closed tests: non-uniform ranges → `empty()`; `complete=false` → `empty()`; Sidecar throws → `empty()` and no exception escapes.
-- [ ] 2.5 Update `CqliteFlightTableStatisticsTest`: non-aggregated pinned case moves from always-`empty()` to logical-count-when-grounded + `empty()`-when-not; aggregated pins (global → 1, grouped → `empty()`) unchanged.
+- [x] 2.1 Failing test first: RF=3, three hosts × 200 rows → expect `ROW_COUNT = 200` (not 600) through `CqliteFlightMetadata.getTableStatistics` end to end (injected fetch functions, real `TableStats` JSON decode) — the issue's acceptance criterion.
+- [x] 2.2 Implement the non-aggregated branch: fetch `tokenRangeReplicas` + `fetchTableStats`, require uniform `R` and `stats.complete()`, report `Estimate.of((double) liveRows / R)`; wrap the whole derivation so any `RuntimeException`/timeout → `TableStatistics.empty()` (mirror `groupRatioForGate`'s degrade posture).
+- [x] 2.3 Memoize per `(keyspace, table)` in the metadata instance; test: repeated calls → one fetch (counting stub).
+- [x] 2.4 Fail-closed tests: non-uniform ranges → `empty()`; `complete=false` → `empty()`; Sidecar throws → `empty()` and no exception escapes.
+- [x] 2.5 Update `CqliteFlightTableStatisticsTest`: non-aggregated pinned case moves from always-`empty()` to logical-count-when-grounded + `empty()`-when-not; aggregated pins (global → 1, grouped → `empty()`) unchanged.
 
 ## 3. Unchanged-gate proof
-- [ ] 3.1 Run the full existing connector suite; `EstimateGroupRatioTest`, `PrimaryKeyExtractorTest`, `TableStatsTest`, split-manager tests must pass **unmodified**.
+- [x] 3.1 Run the full existing connector suite; `EstimateGroupRatioTest`, `PrimaryKeyExtractorTest`, `TableStatsTest`, split-manager tests must pass **unmodified**.
 
 ## 4. Docs
-- [ ] 4.1 Add a stats-semantics note to `docs/flight-trino/PLAN.md` (scan path dedupes by token range; stats path de-replicates by uniform replica-count division; fail-closed conditions; transient-replication + replica-divergence caveats).
+- [x] 4.1 Add a stats-semantics note to `docs/flight-trino/PLAN.md` (scan path dedupes by token range; stats path de-replicates by uniform replica-count division; fail-closed conditions; transient-replication + replica-divergence caveats).
 
 ## 5. Quality stages (gate → C → roborev)
 - [ ] 5.1 `./gradlew test` in `trino-connector/` green (the Java suite is the blast-radius test set).

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -63,6 +63,14 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * fetch per table. Concurrent-safe via {@link ConcurrentHashMap#computeIfAbsent}
      * (Trino may plan on multiple threads); the derivation is idempotent and never
      * returns null (it returns {@link TableStatistics#empty()} on any failure).
+     *
+     * <p>Negative ({@code empty()}) results are memoized on purpose. This cache is scoped
+     * to a single short-lived, per-planning-pass {@code ConnectorMetadata} instance, and
+     * memoizing {@code empty()} deliberately avoids re-hammering a failing/timing-out
+     * Sidecar (with slow timeouts) within that pass. The accepted tradeoff: a transient
+     * blip is not retried until the next planning pass (a new metadata instance). This is
+     * consistent with the spec's fail-closed requirement, where {@code empty()} is the
+     * correct grounded-or-not answer (issue #1336).
      */
     private final Map<SchemaTableName, TableStatistics> nonAggregatedStatsCache =
             new ConcurrentHashMap<>();
@@ -997,6 +1005,10 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
         }
         // Non-aggregated scan: report the logical (de-replicated) row count, memoized
         // per (keyspace, table) so one planning pass fetches at most once per table.
+        // Negative empty() results are cached on purpose (issue #1336): this cache lives
+        // only for this short-lived per-planning-pass metadata instance, so memoizing
+        // empty() avoids re-hammering a down/slow Sidecar within the pass. The tradeoff is
+        // that a transient blip is not retried until the next pass (a new metadata instance).
         SchemaTableName key = new SchemaTableName(handle.keyspace(), handle.table());
         return nonAggregatedStatsCache.computeIfAbsent(
                 key, k -> logicalRowCountStatistics(handle));

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -36,10 +36,14 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import in.mcfad.cqlite.flight.sidecar.SidecarClient;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.RingEntry;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
 
 /**
  * Connector metadata backed by Sidecar (DDL discovery) and the cqlite-flight
@@ -50,6 +54,18 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
     private final CqliteFlightConfig config;
     private final SidecarClient sidecar;
     private final CqliteFlightClient flight;
+
+    /**
+     * Per-{@code (keyspace, table)} memo of the non-aggregated logical row-count
+     * statistics (issue #1336). One optimizer planning pass calls
+     * {@link #getTableStatistics} repeatedly for the same table; memoizing here bounds
+     * it to at most one {@code tokenRangeReplicas} fetch and one {@code table_stats}
+     * fetch per table. Concurrent-safe via {@link ConcurrentHashMap#computeIfAbsent}
+     * (Trino may plan on multiple threads); the derivation is idempotent and never
+     * returns null (it returns {@link TableStatistics#empty()} on any failure).
+     */
+    private final Map<SchemaTableName, TableStatistics> nonAggregatedStatsCache =
+            new ConcurrentHashMap<>();
 
     public CqliteFlightMetadata(CqliteFlightConfig config, SidecarClient sidecar, CqliteFlightClient flight) {
         this.config = config;
@@ -637,6 +653,17 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * only on the otherwise-pushable path), and MUST be for a supported AUTOMATIC GROUP BY.
      */
     TableStats fetchTableStats(CqliteFlightTableHandle handle) {
+        return fetchTableStats(handle, tokenRangeReplicas(handle.keyspace()));
+    }
+
+    /**
+     * Same as {@link #fetchTableStats(CqliteFlightTableHandle)} but over an
+     * ALREADY-FETCHED token-range replica set (issue #1336). The logical-row-count path
+     * derives the divisor and the target host set from ONE {@code tokenRangeReplicas}
+     * response, so it must not fetch it a second time here. Package-private and
+     * overridable as a test seam.
+     */
+    TableStats fetchTableStats(CqliteFlightTableHandle handle, TokenRangeReplicasResponse replicas) {
         byte[] body = tableStatsRequest(handle.keyspace(), handle.table());
         int port = config.flightPort();
         // Bound each per-replica DoAction with a deadline (issue #944): this runs during
@@ -644,9 +671,18 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
         // (a TIMED_OUT FlightRuntimeException → the fetch-failure → UNAVAILABLE path in
         // aggregateNodeStats), never stall the planner.
         long timeoutMillis = config.tableStatsTimeoutMillis();
-        Set<String> hosts =
-                replicaHosts(sidecar.tokenRangeReplicas(handle.keyspace()), config.localDatacenter());
+        Set<String> hosts = replicaHosts(replicas, config.localDatacenter());
         return aggregateNodeStats(hosts, address -> flight.tableStats(address, port, body, timeoutMillis));
+    }
+
+    /**
+     * The keyspace's authoritative token-range read replicas from Sidecar. Package-
+     * private and overridable as a test seam (issue #1336) so the logical-row-count
+     * derivation can be driven end to end over decoded JSON fixtures without a live
+     * Sidecar.
+     */
+    TokenRangeReplicasResponse tokenRangeReplicas(String keyspace) {
+        return sidecar.tokenRangeReplicas(keyspace);
     }
 
     /**
@@ -665,30 +701,88 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * DC scoping. Static and package-private for unit testing without a live Sidecar.
      */
     static Set<String> replicaHosts(
-            in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse replicas,
+            TokenRangeReplicasResponse replicas,
             String localDatacenter) {
         Set<String> hosts = new LinkedHashSet<>();
         if (replicas == null || replicas.readReplicas() == null) {
             return hosts;
         }
         for (var range : replicas.readReplicas()) {
-            Map<String, List<String>> byDc = range.replicasByDatacenter();
-            if (byDc == null) {
-                continue;
-            }
-            // Mirror buildSplits/pickReplica DC scoping: use the local DC's replicas for
-            // this range when present, else fall back to every DC's replicas.
-            List<String> local =
-                    localDatacenter != null ? byDc.get(localDatacenter) : null;
-            if (local != null && !local.isEmpty()) {
-                addHosts(hosts, local);
-            } else {
-                for (List<String> dcReplicas : byDc.values()) {
-                    addHosts(hosts, dcReplicas);
-                }
+            hosts.addAll(scopedRangeReplicas(range, localDatacenter));
+        }
+        return hosts;
+    }
+
+    /**
+     * The distinct scoped read-replica HOSTS (ports stripped) of ONE token range,
+     * under the SAME DC-scoping rule {@link #replicaHosts} and split selection use:
+     * the local DC's replicas when it has any for the range, else every DC's replicas.
+     * Deduplicates replica entries within the range (a host repeated in the range's
+     * lists is one host). Returns an empty set for a null/absent replica map.
+     */
+    private static Set<String> scopedRangeReplicas(ReplicaInfo range, String localDatacenter) {
+        Set<String> hosts = new LinkedHashSet<>();
+        if (range == null) {
+            return hosts;
+        }
+        Map<String, List<String>> byDc = range.replicasByDatacenter();
+        if (byDc == null) {
+            return hosts;
+        }
+        // Mirror buildSplits/pickReplica DC scoping: use the local DC's replicas for
+        // this range when present, else fall back to every DC's replicas.
+        List<String> local = localDatacenter != null ? byDc.get(localDatacenter) : null;
+        if (local != null && !local.isEmpty()) {
+            addHosts(hosts, local);
+        } else {
+            for (List<String> dcReplicas : byDc.values()) {
+                addHosts(hosts, dcReplicas);
             }
         }
         return hosts;
+    }
+
+    /**
+     * The uniform per-token-range distinct scoped read-replica count, or empty when it
+     * is not well-defined (issue #1336). This is the divisor that turns the physical,
+     * replica-summed {@code table_stats} row total into a logical (de-replicated)
+     * cardinality: summing whole-table {@code live_rows} across the distinct scoped
+     * replica hosts counts each logical row once per replica that stores it, i.e.
+     * exactly {@code R} times when {@code R} is the shared per-range replica count.
+     *
+     * <p>The count is derived ONLY by counting distinct scoped replicas per range in the
+     * authoritative {@code tokenRangeReplicas} response, under the identical
+     * {@code localDatacenter} scoping as {@link #replicaHosts} (so the divisor matches
+     * the host set the stats sum was collected from). It NEVER parses keyspace
+     * {@code replication = {...}} strategy strings and makes no distributional
+     * assumption (no-heuristics mandate, issue #28).
+     *
+     * <p>Returns {@link OptionalInt#empty()} (fail closed → the caller reports no row
+     * count) when: there are no ranges, any range has zero scoped replicas, or the
+     * per-range counts are not identical across all ranges (e.g. a topology mid-
+     * transition). A present value is guaranteed {@code >= 1}.
+     */
+    static OptionalInt uniformReplicaCount(
+            TokenRangeReplicasResponse replicas, String localDatacenter) {
+        if (replicas == null || replicas.readReplicas() == null
+                || replicas.readReplicas().isEmpty()) {
+            return OptionalInt.empty();
+        }
+        int shared = -1;
+        for (var range : replicas.readReplicas()) {
+            int count = scopedRangeReplicas(range, localDatacenter).size();
+            if (count < 1) {
+                // A range with no scoped replica → cannot ground the divisor.
+                return OptionalInt.empty();
+            }
+            if (shared == -1) {
+                shared = count;
+            } else if (shared != count) {
+                // Non-uniform per-range replica counts (topology in transition).
+                return OptionalInt.empty();
+            }
+        }
+        return OptionalInt.of(shared);
     }
 
     private static void addHosts(Set<String> hosts, List<String> replicas) {
@@ -872,21 +966,22 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * known, so we return {@link TableStatistics#empty()} and let Trino estimate
      * rather than fabricate (#28).
      *
-     * <p>For a <em>non-aggregated</em> handle we intentionally report {@link
-     * TableStatistics#empty()} (unknown) rather than {@code stats.liveRows()}. The
-     * cqlite-flight {@code table_stats} action sums whole-table {@code Statistics.db}
-     * counts across ALL replica hosts of the keyspace, so on a replicated keyspace
-     * (e.g. RF=3) {@code liveRows()} is the PHYSICAL replica row total (≈ RF × the
-     * logical table cardinality), NOT the logical number of rows a scan emits. It is
-     * not authoritatively de-duplicated to a single copy of the token space, so
-     * exposing it would mislead Trino's cost optimizer. RF-correct / token-range-scoped
-     * optimizer row counts are deferred to a follow-up issue; until then we report no
-     * row-count estimate and let Trino fall back to its own. Note this does NOT affect
-     * the GROUP BY pushdown gate ({@link #estimateGroupRatio}), which uses an
-     * RF-invariant ratio ({@code partition_count / live_rows}) where replica
-     * over-counting cancels in numerator and denominator. Column-level stats are left
-     * unknown — Cassandra 5.0 stores no reliable per-regular-column NDV, so reporting
-     * any would be a heuristic (#28).
+     * <p>For a <em>non-aggregated</em> handle we report a LOGICAL (de-replicated) row
+     * count {@code ROW_COUNT = live_rows / R} (issue #1336). {@code live_rows} is the
+     * existing whole-table {@code table_stats} sum across the keyspace's distinct scoped
+     * replica hosts (≈ RF × the logical cardinality on a replicated keyspace); {@code R}
+     * is the {@link #uniformReplicaCount uniform per-token-range distinct scoped replica
+     * count}. Dividing by {@code R} un-does the replica over-count so the optimizer sees
+     * one copy of the token space. The derivation FAILS CLOSED to {@link
+     * TableStatistics#empty()} (today's behavior) when it cannot be grounded — non-
+     * uniform per-range replica counts, a zero-replica range, incomplete {@code
+     * table_stats} ({@code complete=false}), or ANY Sidecar/Flight error or timeout — so
+     * planning never sees a possibly-wrong number and never fails on a stats error. Note
+     * this does NOT affect the GROUP BY pushdown gate ({@link #estimateGroupRatio}),
+     * which uses an RF-invariant ratio ({@code partition_count / live_rows}) where
+     * replica over-counting cancels in numerator and denominator. Column-level stats are
+     * left unknown — Cassandra 5.0 stores no reliable per-regular-column NDV, so
+     * reporting any would be a heuristic (#28).
      */
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle table) {
@@ -900,13 +995,48 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             // regardless of replication factor.
             return TableStatistics.builder().setRowCount(Estimate.of(1)).build();
         }
-        // Non-aggregated scan: stats.liveRows() is the replica-summed PHYSICAL row
-        // total (≈ RF × logical cardinality), not the logical rows a scan emits, and
-        // is not authoritatively de-duplicated to one copy of the token space. Do not
-        // expose a knowably-wrong number to the optimizer — report unknown and let
-        // Trino estimate. (RF-correct row counts are deferred to a follow-up issue;
-        // the GROUP BY gate is unaffected — see estimateGroupRatio.)
-        return TableStatistics.empty();
+        // Non-aggregated scan: report the logical (de-replicated) row count, memoized
+        // per (keyspace, table) so one planning pass fetches at most once per table.
+        SchemaTableName key = new SchemaTableName(handle.keyspace(), handle.table());
+        return nonAggregatedStatsCache.computeIfAbsent(
+                key, k -> logicalRowCountStatistics(handle));
+    }
+
+    /**
+     * Derive the non-aggregated logical row-count statistics
+     * {@code ROW_COUNT = live_rows / R} (issue #1336), or {@link TableStatistics#empty()}
+     * when the derivation cannot be grounded. Fetches the token-range replicas ONCE and
+     * reuses that response for BOTH the divisor {@code R} and the {@code table_stats}
+     * host set. Any {@link RuntimeException}/timeout anywhere degrades to {@code empty()}
+     * (same posture as {@code groupRatioForGate}): statistics failures must never fail
+     * query planning.
+     */
+    private TableStatistics logicalRowCountStatistics(CqliteFlightTableHandle handle) {
+        try {
+            TokenRangeReplicasResponse replicas = tokenRangeReplicas(handle.keyspace());
+            String localDatacenter = config != null ? config.localDatacenter() : null;
+            OptionalInt replicaCount = uniformReplicaCount(replicas, localDatacenter);
+            if (replicaCount.isEmpty()) {
+                // Non-uniform / zero-replica ranges → cannot de-replicate → fail closed.
+                return TableStatistics.empty();
+            }
+            int r = replicaCount.getAsInt();
+            if (r < 1) {
+                // Defensive: uniformReplicaCount already guarantees R >= 1, but never
+                // divide by a non-positive divisor.
+                return TableStatistics.empty();
+            }
+            TableStats stats = fetchTableStats(handle, replicas);
+            if (!stats.complete()) {
+                // Partial/undecodable per-node stats are not authoritative → fail closed.
+                return TableStatistics.empty();
+            }
+            double logicalRows = (double) stats.liveRows() / r;
+            return TableStatistics.builder().setRowCount(Estimate.of(logicalRows)).build();
+        } catch (RuntimeException e) {
+            // Any Sidecar/Flight error or timeout → no estimate; planning proceeds.
+            return TableStatistics.empty();
+        }
     }
 
     /** Resolve the table's Arrow schema by asking any flight node's GetSchema. */

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightLogicalRowCountTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightLogicalRowCountTest.java
@@ -1,0 +1,222 @@
+package in.mcfad.cqlite.flight;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.mcfad.cqlite.flight.sidecar.SidecarClient;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
+import io.trino.spi.statistics.TableStatistics;
+import org.apache.arrow.flight.CallStatus;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end tests for the RF-correct LOGICAL row count reported by
+ * {@link CqliteFlightMetadata#getTableStatistics} on a non-aggregated handle
+ * (issue #1336), driven THROUGH the public {@code ConnectorMetadata} surface with
+ * real {@code SidecarModels} token-range parsing and real {@link TableStats} JSON
+ * decode (wiring-evidence doctrine) — not by unit-testing a private helper alone.
+ *
+ * <p>The stub overrides only the two package-private I/O seams
+ * ({@code tokenRangeReplicas} and {@code fetchTableStats}); the derivation under test
+ * (uniform-replica-count division, completeness gate, fail-closed posture, memoization)
+ * runs unchanged.
+ */
+class CqliteFlightLogicalRowCountTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** A complete per-host {@code table_stats} JSON with the given live-row count. */
+    private static String statsJson(long liveRows, long partitions, boolean complete) {
+        return "{\"live_rows\":" + liveRows + ",\"partition_count\":" + partitions
+                + ",\"sstable_count\":1,\"complete\":" + complete + ",\"skipped_sstables\":0}";
+    }
+
+    /** RF=3 over one keyspace: every range has the same three scoped replicas. */
+    private static final String RF3_REPLICAS = """
+            {"writeReplicas":[],"readReplicas":[
+              {"start":"-100","end":"100","replicasByDatacenter":{
+                "dc1":["10.0.0.1:7000","10.0.0.2:7000","10.0.0.3:7000"]}}
+            ]}""";
+
+    private static CqliteFlightConfig config(String localDatacenter) {
+        return new CqliteFlightConfig(
+                URI.create("http://sidecar:9043"), 8815, localDatacenter,
+                GroupByPushdownPolicy.AUTOMATIC, 0.5, 3000);
+    }
+
+    private static CqliteFlightTableHandle plainHandle() {
+        return new CqliteFlightTableHandle("ks", "t", "ddl");
+    }
+
+    /**
+     * Metadata stub whose only overrides are the two I/O seams. It records how many
+     * times each seam is hit (memoization evidence) and decodes REAL per-host
+     * {@code table_stats} JSON via {@link TableStats} + real {@code replicaHosts} +
+     * real {@code aggregateNodeStats}.
+     */
+    private static final class StubMetadata extends CqliteFlightMetadata {
+        private final String localDatacenter;
+        private final String replicasJson;
+        private final Map<String, String> perHostStatsJson;
+        private final RuntimeException replicasError;
+        int replicaFetches = 0;
+        int statsFetches = 0;
+
+        StubMetadata(String localDatacenter, String replicasJson,
+                Map<String, String> perHostStatsJson, RuntimeException replicasError) {
+            super(config(localDatacenter), null, null);
+            this.localDatacenter = localDatacenter;
+            this.replicasJson = replicasJson;
+            this.perHostStatsJson = perHostStatsJson;
+            this.replicasError = replicasError;
+        }
+
+        @Override
+        TokenRangeReplicasResponse tokenRangeReplicas(String keyspace) {
+            replicaFetches++;
+            if (replicasError != null) {
+                throw replicasError;
+            }
+            return SidecarClient.parseTokenRangeReplicas(replicasJson);
+        }
+
+        @Override
+        TableStats fetchTableStats(CqliteFlightTableHandle handle, TokenRangeReplicasResponse replicas) {
+            statsFetches++;
+            Set<String> hosts = CqliteFlightMetadata.replicaHosts(replicas, localDatacenter);
+            return CqliteFlightMetadata.aggregateNodeStats(hosts, address -> {
+                String json = perHostStatsJson.get(address);
+                if (json == null) {
+                    // Host not modeled → treat as not-hosting (Flight NOT_FOUND).
+                    throw CallStatus.NOT_FOUND.withDescription("no stats for " + address)
+                            .toRuntimeException();
+                }
+                if (UNREACHABLE.equals(json)) {
+                    // Transport failure (unreachable) → aggregate folds UNAVAILABLE.
+                    throw new RuntimeException(address + " unreachable");
+                }
+                try {
+                    return MAPPER.readValue(json, TableStats.class);
+                } catch (Exception e) {
+                    throw new IllegalStateException("bad stats json", e);
+                }
+            });
+        }
+    }
+
+    /** Sentinel marking a host as unreachable (a transport failure, not not-hosting). */
+    private static final String UNREACHABLE = "__unreachable__";
+
+    @Test
+    void rf3ThreeHostsEachTwoHundredRowsReportsLogicalTwoHundred() {
+        // The issue's acceptance criterion: physical sum is 600 (3 × 200) but the
+        // reported optimizer ROW_COUNT is the LOGICAL cardinality 200 = 600 / R(=3).
+        Map<String, String> perHost = Map.of(
+                "10.0.0.1", statsJson(200, 10, true),
+                "10.0.0.2", statsJson(200, 10, true),
+                "10.0.0.3", statsJson(200, 10, true));
+        StubMetadata metadata = new StubMetadata("dc1", RF3_REPLICAS, perHost, null);
+
+        TableStatistics stats = metadata.getTableStatistics(null, plainHandle());
+
+        assertEquals(200.0, stats.getRowCount().getValue(), 0.0,
+                "RF=3, three hosts × 200 rows → logical ROW_COUNT 200 (not the physical sum 600)");
+    }
+
+    @Test
+    void onePlanningPassFetchesEachSeamAtMostOnce() {
+        // Repeated getTableStatistics calls for the same (keyspace, table) reuse the
+        // memoized result: exactly one tokenRangeReplicas fetch and one table_stats
+        // fetch across the whole planning pass (issue #1336, scenario 3).
+        Map<String, String> perHost = Map.of(
+                "10.0.0.1", statsJson(200, 10, true),
+                "10.0.0.2", statsJson(200, 10, true),
+                "10.0.0.3", statsJson(200, 10, true));
+        StubMetadata metadata = new StubMetadata("dc1", RF3_REPLICAS, perHost, null);
+
+        CqliteFlightTableHandle handle = plainHandle();
+        TableStatistics first = metadata.getTableStatistics(null, handle);
+        TableStatistics second = metadata.getTableStatistics(null, handle);
+        TableStatistics third = metadata.getTableStatistics(null, handle);
+
+        assertEquals(200.0, first.getRowCount().getValue(), 0.0);
+        assertEquals(first.getRowCount().getValue(), second.getRowCount().getValue(), 0.0);
+        assertEquals(first.getRowCount().getValue(), third.getRowCount().getValue(), 0.0);
+        assertEquals(1, metadata.replicaFetches, "tokenRangeReplicas fetched at most once per table");
+        assertEquals(1, metadata.statsFetches, "table_stats fetched at most once per table");
+    }
+
+    @Test
+    void nonUniformPerRangeReplicaCountsFailClosed() {
+        // Range 1 has 3 replicas, range 2 has 2 → non-uniform → empty(); the divisor
+        // is ungrounded, so table_stats is not even fetched.
+        String replicas = """
+                {"writeReplicas":[],"readReplicas":[
+                  {"start":"-100","end":"0","replicasByDatacenter":{
+                    "dc1":["10.0.0.1:7000","10.0.0.2:7000","10.0.0.3:7000"]}},
+                  {"start":"0","end":"100","replicasByDatacenter":{
+                    "dc1":["10.0.0.2:7000","10.0.0.3:7000"]}}
+                ]}""";
+        StubMetadata metadata = new StubMetadata("dc1", replicas, Map.of(), null);
+
+        TableStatistics stats = metadata.getTableStatistics(null, plainHandle());
+
+        assertEquals(TableStatistics.empty(), stats,
+                "non-uniform per-range replica counts fail closed to empty");
+        assertTrue(stats.getRowCount().isUnknown());
+        assertEquals(0, metadata.statsFetches,
+                "an ungrounded divisor short-circuits before the table_stats fetch");
+    }
+
+    @Test
+    void incompleteStatsFailClosed() {
+        // One replica reports complete=false → the aggregate is incomplete → empty().
+        Map<String, String> perHost = Map.of(
+                "10.0.0.1", statsJson(200, 10, true),
+                "10.0.0.2", statsJson(200, 10, false),
+                "10.0.0.3", statsJson(200, 10, true));
+        StubMetadata metadata = new StubMetadata("dc1", RF3_REPLICAS, perHost, null);
+
+        TableStatistics stats = metadata.getTableStatistics(null, plainHandle());
+
+        assertEquals(TableStatistics.empty(), stats,
+                "incomplete table_stats (complete=false) fail closed to empty");
+        assertTrue(stats.getRowCount().isUnknown());
+    }
+
+    @Test
+    void unreachableReplicaFailsClosed() {
+        // One of the three replicas is unreachable (transport failure, NOT a not-hosting
+        // NOT_FOUND): aggregateNodeStats folds UNAVAILABLE, tainting the aggregate to
+        // complete=false, so the derivation fails closed to empty().
+        Map<String, String> perHost = Map.of(
+                "10.0.0.1", statsJson(200, 10, true),
+                "10.0.0.2", statsJson(200, 10, true),
+                "10.0.0.3", UNREACHABLE);
+        StubMetadata metadata = new StubMetadata("dc1", RF3_REPLICAS, perHost, null);
+
+        TableStatistics stats = metadata.getTableStatistics(null, plainHandle());
+
+        assertEquals(TableStatistics.empty(), stats,
+                "an unreachable replica taints completeness → fail closed to empty");
+    }
+
+    @Test
+    void sidecarErrorFailsClosedWithoutEscaping() {
+        // Any Sidecar/Flight error during the derivation degrades to empty() and never
+        // escapes into query planning (issue #1336).
+        StubMetadata metadata = new StubMetadata("dc1", RF3_REPLICAS, Map.of(),
+                new RuntimeException("sidecar down"));
+
+        TableStatistics stats = metadata.getTableStatistics(null, plainHandle());
+
+        assertEquals(TableStatistics.empty(), stats,
+                "a Sidecar failure degrades to empty(), not a planning exception");
+        assertTrue(stats.getRowCount().isUnknown());
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightTableStatisticsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightTableStatisticsTest.java
@@ -19,12 +19,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * row; a grouped aggregate's group count is unknown. These tests pin that the
  * optimizer-facing stats reflect the output, not the underlying SSTable rows.
  *
- * <p>A NON-aggregated handle now reports {@link TableStatistics#empty()} (unknown):
- * the {@code table_stats} row total is summed across ALL keyspace replicas (≈ RF ×
- * logical cardinality) and is not de-duplicated to one copy of the token space, so
- * we deliberately do not expose it as an optimizer row count (issue #944). Both
- * branches of {@code getTableStatistics} now return before touching Sidecar/Flight,
- * so a {@code new CqliteFlightMetadata(null, null, null)} suffices to exercise them.
+ * <p>A NON-aggregated handle now reports a LOGICAL (de-replicated) row count
+ * {@code live_rows / R} WHEN it can be grounded, and FAILS CLOSED to
+ * {@link TableStatistics#empty()} when it cannot (issue #1336). The end-to-end
+ * grounded derivation (RF=3 → 200, memoization, per-condition fail-closed) is pinned
+ * in {@link CqliteFlightLogicalRowCountTest}; here we pin (a) the aggregated branches
+ * (which still return before touching Sidecar/Flight) and (b) that the non-aggregated
+ * branch fails closed to {@code empty()} when the derivation cannot be grounded
+ * (here: no Sidecar available), never throwing into query planning.
  */
 class CqliteFlightTableStatisticsTest {
 
@@ -93,19 +95,21 @@ class CqliteFlightTableStatisticsTest {
     }
 
     @Test
-    void nonAggregatedHandleReportsUnknownRowCount() {
-        // The table_stats row total is replica-summed (≈ RF × logical cardinality)
-        // and not de-duplicated to one copy of the token space, so we do NOT expose
-        // it as an optimizer row count (issue #944) — report unknown so Trino
-        // estimates instead of trusting a knowably-wrong physical-replica total.
+    void nonAggregatedHandleFailsClosedWhenDerivationUngrounded() {
+        // Non-aggregated: the connector now reports a LOGICAL row count live_rows / R
+        // when it can ground R from tokenRangeReplicas AND get complete table_stats
+        // (pinned end to end in CqliteFlightLogicalRowCountTest). When it CANNOT be
+        // grounded — here there is no Sidecar/Flight at all — it fails closed to
+        // empty() (today's safe behavior) and never throws into query planning
+        // (issue #1336).
         CqliteFlightTableHandle plain = new CqliteFlightTableHandle("ks", "t", "ddl");
         assertFalse(plain.isAggregated());
 
         TableStatistics stats = metadata.getTableStatistics(null, plain);
         assertEquals(TableStatistics.empty(), stats,
-                "non-aggregated row count is replica-summed → empty (not exposed)");
+                "an ungrounded logical-row-count derivation fails closed to empty");
         assertTrue(stats.getRowCount().isUnknown(),
-                "non-aggregated row count must be unknown (replica-summed, not logical)");
+                "row count must be unknown when the derivation cannot be grounded");
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/UniformReplicaCountTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/UniformReplicaCountTest.java
@@ -1,0 +1,130 @@
+package in.mcfad.cqlite.flight;
+
+import in.mcfad.cqlite.flight.sidecar.SidecarClient;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CqliteFlightMetadata#uniformReplicaCount} — the divisor that
+ * turns the physical, replica-summed {@code table_stats} row total into a logical
+ * (de-replicated) cardinality (issue #1336).
+ *
+ * <p>Fixtures are REAL {@code tokenRangeReplicas} JSON decoded through
+ * {@link SidecarClient#parseTokenRangeReplicas} (real {@code SidecarModels} parsing),
+ * not hand-built records — the divisor must be honest end to end from the wire shape.
+ *
+ * <p>The count derives ONLY from the authoritative per-range replica lists under the
+ * same {@code localDatacenter} scoping as {@code replicaHosts}; it never parses
+ * keyspace {@code replication = {...}} strategy strings (no-heuristics mandate #28).
+ */
+class UniformReplicaCountTest {
+
+    private static TokenRangeReplicasResponse parse(String json) {
+        return SidecarClient.parseTokenRangeReplicas(json);
+    }
+
+    @Test
+    void uniformRf3AcrossRangesCountsThree() {
+        // Every range has 3 distinct scoped replicas → divisor 3.
+        String json = """
+                {"writeReplicas":[],"readReplicas":[
+                  {"start":"-100","end":"0","replicasByDatacenter":{
+                    "dc1":["10.0.0.1:7000","10.0.0.2:7000","10.0.0.3:7000"]}},
+                  {"start":"0","end":"100","replicasByDatacenter":{
+                    "dc1":["10.0.0.2:7000","10.0.0.3:7000","10.0.0.4:7000"]}}
+                ]}""";
+
+        assertEquals(OptionalInt.of(3),
+                CqliteFlightMetadata.uniformReplicaCount(parse(json), "dc1"),
+                "every range has 3 distinct scoped replicas → divisor 3");
+    }
+
+    @Test
+    void multiDcScopesToLocalDatacenterReplicaCount() {
+        // dc1 RF=3, dc2 RF=2. With localDatacenter=dc1 the divisor is the dc1-scoped
+        // per-range count (3) — matching the host set the stats sum is collected from.
+        String json = """
+                {"writeReplicas":[],"readReplicas":[
+                  {"start":"-100","end":"100","replicasByDatacenter":{
+                    "dc1":["10.0.0.1:7000","10.0.0.2:7000","10.0.0.3:7000"],
+                    "dc2":["10.1.0.1:7000","10.1.0.2:7000"]}}
+                ]}""";
+
+        assertEquals(OptionalInt.of(3),
+                CqliteFlightMetadata.uniformReplicaCount(parse(json), "dc1"),
+                "localDatacenter=dc1 → dc1-scoped per-range replica count 3");
+    }
+
+    @Test
+    void multiDcUnsetLocalDatacenterCountsAllDcs() {
+        // Same fixture, localDatacenter unset → all-DC scoping → 3 + 2 = 5 distinct hosts.
+        String json = """
+                {"writeReplicas":[],"readReplicas":[
+                  {"start":"-100","end":"100","replicasByDatacenter":{
+                    "dc1":["10.0.0.1:7000","10.0.0.2:7000","10.0.0.3:7000"],
+                    "dc2":["10.1.0.1:7000","10.1.0.2:7000"]}}
+                ]}""";
+
+        assertEquals(OptionalInt.of(5),
+                CqliteFlightMetadata.uniformReplicaCount(parse(json), null),
+                "no local DC → all-DC distinct replica count 3+2=5");
+    }
+
+    @Test
+    void nonUniformPerRangeCountsFailClosed() {
+        // Range 1 has 3 replicas, range 2 has 2 (topology mid-transition) → empty.
+        String json = """
+                {"writeReplicas":[],"readReplicas":[
+                  {"start":"-100","end":"0","replicasByDatacenter":{
+                    "dc1":["10.0.0.1:7000","10.0.0.2:7000","10.0.0.3:7000"]}},
+                  {"start":"0","end":"100","replicasByDatacenter":{
+                    "dc1":["10.0.0.2:7000","10.0.0.3:7000"]}}
+                ]}""";
+
+        assertTrue(CqliteFlightMetadata.uniformReplicaCount(parse(json), "dc1").isEmpty(),
+                "differing per-range replica counts must fail closed to empty");
+    }
+
+    @Test
+    void zeroReplicaRangeFailsClosed() {
+        // A range whose local-DC replica list is empty and has no other DC → zero
+        // scoped replicas → empty (never divide by zero).
+        String json = """
+                {"writeReplicas":[],"readReplicas":[
+                  {"start":"-100","end":"0","replicasByDatacenter":{
+                    "dc1":["10.0.0.1:7000","10.0.0.2:7000"]}},
+                  {"start":"0","end":"100","replicasByDatacenter":{}}
+                ]}""";
+
+        assertTrue(CqliteFlightMetadata.uniformReplicaCount(parse(json), "dc1").isEmpty(),
+                "a range with zero scoped replicas must fail closed to empty");
+    }
+
+    @Test
+    void duplicateReplicaEntriesWithinARangeAreDeduped() {
+        // The same host (port-stripped) appears twice in a range's list → counted once.
+        // Two distinct hosts → divisor 2, not 3.
+        String json = """
+                {"writeReplicas":[],"readReplicas":[
+                  {"start":"-100","end":"100","replicasByDatacenter":{
+                    "dc1":["10.0.0.1:7000","10.0.0.1:7000","10.0.0.2:7000"]}}
+                ]}""";
+
+        assertEquals(OptionalInt.of(2),
+                CqliteFlightMetadata.uniformReplicaCount(parse(json), "dc1"),
+                "duplicate replica entries within a range are deduped");
+    }
+
+    @Test
+    void emptyOrNullResponsesFailClosed() {
+        assertTrue(CqliteFlightMetadata.uniformReplicaCount(null, "dc1").isEmpty());
+        assertTrue(CqliteFlightMetadata.uniformReplicaCount(
+                        parse("{\"writeReplicas\":[],\"readReplicas\":[]}"), "dc1").isEmpty(),
+                "no ranges → cannot ground a divisor → empty");
+    }
+}


### PR DESCRIPTION
Closes #1336. Implements the owner-approved OpenSpec change `rf-correct-row-stats` (Seam 1 approved 2026-07-04). **Java-only**, `trino-connector/` — no Rust/wire/config changes.

## What
Non-aggregated `CqliteFlightMetadata.getTableStatistics` now reports a logical (de-replicated) `ROW_COUNT = live_rows / R`, where `R` is the uniform per-token-range distinct scoped read-replica count from authoritative Sidecar `tokenRangeReplicas` (same `localDatacenter` scoping as `replicaHosts`). One `tokenRangeReplicas` fetch feeds both the divisor and the stats host set; result memoized per `(keyspace, table)` per metadata instance.

**Fails closed to `TableStatistics.empty()`** on non-uniform per-range replica counts, zero-replica range, `stats.complete()==false`, or any Sidecar/Flight error/timeout — statistics never fail query planning. Divisor derives ONLY from `tokenRangeReplicas` (never replication-strategy strings; no distributional assumption — no-heuristics #28). Aggregated branches (global→1, grouped→empty) and the AUTOMATIC group-by gate are unchanged.

## Tests (wiring-evidence)
- `CqliteFlightLogicalRowCountTest` (new): RF=3, 3 hosts × 200 rows → **200 not 600** through the public `getTableStatistics` with real `SidecarModels` token-range parse + real `TableStats` JSON decode; memoization (one fetch/seam over 3 calls); fail-closed cases (non-uniform, complete=false, unreachable, Sidecar error).
- `UniformReplicaCountTest` (new, 7): helper incl. multi-DC scoping + dedup.
- `CqliteFlightTableStatisticsTest` (updated): aggregated pins unchanged; non-aggregated now logical-when-grounded / empty-when-not.

## Quality bars
- `./gradlew test` (trino-connector): **157 tests green**.
- Full `scripts/agent-gate.sh`: **PASS** (all components).
- spec-auditor (C): **PASS** — every requirement satisfied with public-surface evidence.
- roborev: clean (1 Low/optional finding on memoizing `empty()` dispositioned as the intended fail-closed/anti-hammer tradeoff; documented in-code).