### PR TITLE
perf(#1585): E3 A5 — one payload+CRC read per compressed chunk (+ read-op work counter)

### DIFF
--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -100,14 +100,14 @@ struct Counters {
     /// `payload+CRC` buffer, so a steady-state chunk read records exactly one.
     read_calls: AtomicU64,
     /// Heap allocations in the per-chunk read→decompress→window-fill copy chain
-    /// (`CHUNK_PATH_ALLOCS`) — consumer E3. Bumped at each genuine heap allocation
-    /// the copy chain performs for one chunk: the compressed-bytes buffer
-    /// (`block_io`), the decompression output buffer (`compression`), and the
-    /// cached decompressed `Arc<[u8]>` (`DecompressedChunkCache`). Before E3 a
-    /// steady-state windowed-scan chunk allocated all three (≥3); after E3 the
-    /// compressed buffer is a recycled per-scan scratch and decompression writes
-    /// into a reused scratch, so only the cached `Arc` (issue B1, kept) allocates
-    /// — exactly one per chunk.
+    /// (`CHUNK_PATH_ALLOCS`) — consumer E3/#1940. **Instrumented today at ONE site
+    /// only**: the compressed-bytes `payload+CRC` buffer allocated in the cursor
+    /// chunk-read path (`block_io`). The other two copy-chain allocation sites —
+    /// the decompression output buffer (`compression`) and the cached decompressed
+    /// `Arc<[u8]>` (`DecompressedChunkCache`) — are NOT yet instrumented, so this
+    /// counter currently reflects the compressed-buffer allocation alone and
+    /// undercounts the full copy chain. Wiring those sites (and the ≤1-alloc/chunk
+    /// reduction they measure) is the A4 work deferred to issue #1940.
     chunk_path_allocs: AtomicU64,
 }
 
@@ -247,12 +247,14 @@ pub fn record_read() {
 }
 
 /// Record one heap allocation in the per-chunk read→decompress→window-fill copy
-/// chain (`CHUNK_PATH_ALLOCS`; consumer E3).
+/// chain (`CHUNK_PATH_ALLOCS`; consumer E3/#1940).
 ///
-/// Called unconditionally at each genuine chunk-path allocation site (the
-/// compressed-bytes buffer in `block_io`, the decompression output buffer in
-/// `compression`, and the cached `Arc<[u8]>` in `DecompressedChunkCache`); the
-/// body compiles to a no-op in a release build (design.md Decision 1).
+/// Called today at ONE site: the compressed-bytes `payload+CRC` buffer in the
+/// cursor chunk-read path (`block_io`). The remaining copy-chain allocation sites
+/// — the decompression output buffer (`compression`) and the cached `Arc<[u8]>`
+/// in `DecompressedChunkCache` — are NOT yet instrumented; wiring them is the A4
+/// ≤1-alloc/chunk work deferred to issue #1940. The body compiles to a no-op in a
+/// release build (design.md Decision 1).
 #[inline(always)]
 pub fn record_chunk_path_alloc() {
     #[cfg(any(test, feature = "work-counters"))]

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -93,6 +93,22 @@ struct Counters {
     seek_calls: AtomicU64,
     /// `open(2)` calls minting a reader `BlockSource` fd (`FILE_OPENS`) — consumer C2.
     file_opens: AtomicU64,
+    /// `read_exact` reads in the compressed-chunk read path (`READ_CALLS`) —
+    /// consumer E3. One per logical read of a compression chunk's bytes. Before
+    /// E3 a chunk cost TWO reads (payload then trailing CRC as separate
+    /// `read_exact` calls); E3 folds them into one `read_exact` into a single
+    /// `payload+CRC` buffer, so a steady-state chunk read records exactly one.
+    read_calls: AtomicU64,
+    /// Heap allocations in the per-chunk read→decompress→window-fill copy chain
+    /// (`CHUNK_PATH_ALLOCS`) — consumer E3. Bumped at each genuine heap allocation
+    /// the copy chain performs for one chunk: the compressed-bytes buffer
+    /// (`block_io`), the decompression output buffer (`compression`), and the
+    /// cached decompressed `Arc<[u8]>` (`DecompressedChunkCache`). Before E3 a
+    /// steady-state windowed-scan chunk allocated all three (≥3); after E3 the
+    /// compressed buffer is a recycled per-scan scratch and decompression writes
+    /// into a reused scratch, so only the cached `Arc` (issue B1, kept) allocates
+    /// — exactly one per chunk.
+    chunk_path_allocs: AtomicU64,
 }
 
 #[cfg(any(test, feature = "work-counters"))]
@@ -103,6 +119,8 @@ impl Counters {
             decompress_calls: AtomicU64::new(0),
             seek_calls: AtomicU64::new(0),
             file_opens: AtomicU64::new(0),
+            read_calls: AtomicU64::new(0),
+            chunk_path_allocs: AtomicU64::new(0),
         }
     }
 
@@ -122,6 +140,14 @@ impl Counters {
         self.file_opens.fetch_add(1, Ordering::Relaxed);
     }
 
+    fn record_read(&self) {
+        self.read_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_chunk_path_alloc(&self) {
+        self.chunk_path_allocs.fetch_add(1, Ordering::Relaxed);
+    }
+
     fn trie_walks(&self) -> u64 {
         self.trie_walks.load(Ordering::Relaxed)
     }
@@ -138,11 +164,21 @@ impl Counters {
         self.file_opens.load(Ordering::Relaxed)
     }
 
+    fn read_calls(&self) -> u64 {
+        self.read_calls.load(Ordering::Relaxed)
+    }
+
+    fn chunk_path_allocs(&self) -> u64 {
+        self.chunk_path_allocs.load(Ordering::Relaxed)
+    }
+
     fn reset(&self) {
         self.trie_walks.store(0, Ordering::Relaxed);
         self.decompress_calls.store(0, Ordering::Relaxed);
         self.seek_calls.store(0, Ordering::Relaxed);
         self.file_opens.store(0, Ordering::Relaxed);
+        self.read_calls.store(0, Ordering::Relaxed);
+        self.chunk_path_allocs.store(0, Ordering::Relaxed);
     }
 }
 
@@ -198,6 +234,31 @@ pub fn record_file_open() {
     COUNTERS.record_file_open();
 }
 
+/// Record one logical `read_exact` of a compression chunk's bytes (`READ_CALLS`;
+/// consumer E3).
+///
+/// Called unconditionally at the single compressed-chunk read site in
+/// `reader/block_io.rs`; the body compiles to a no-op in a release build
+/// (design.md Decision 1).
+#[inline(always)]
+pub fn record_read() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_read();
+}
+
+/// Record one heap allocation in the per-chunk read→decompress→window-fill copy
+/// chain (`CHUNK_PATH_ALLOCS`; consumer E3).
+///
+/// Called unconditionally at each genuine chunk-path allocation site (the
+/// compressed-bytes buffer in `block_io`, the decompression output buffer in
+/// `compression`, and the cached `Arc<[u8]>` in `DecompressedChunkCache`); the
+/// body compiles to a no-op in a release build (design.md Decision 1).
+#[inline(always)]
+pub fn record_chunk_path_alloc() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_chunk_path_alloc();
+}
+
 /// Number of BTI trie descents since the last [`reset`] (`TRIE_WALKS`).
 #[cfg(any(test, feature = "work-counters"))]
 pub fn trie_walks() -> u64 {
@@ -221,6 +282,20 @@ pub fn seek_calls() -> u64 {
 #[cfg(any(test, feature = "work-counters"))]
 pub fn file_opens() -> u64 {
     COUNTERS.file_opens()
+}
+
+/// Number of compressed-chunk `read_exact` reads since the last [`reset`]
+/// (`READ_CALLS`).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn read_calls() -> u64 {
+    COUNTERS.read_calls()
+}
+
+/// Number of per-chunk copy-chain heap allocations since the last [`reset`]
+/// (`CHUNK_PATH_ALLOCS`).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn chunk_path_allocs() -> u64 {
+    COUNTERS.chunk_path_allocs()
 }
 
 /// Clear all four process-global counters. Integration tests call this before a
@@ -301,17 +376,32 @@ mod tests {
         c.record_file_open();
         c.record_file_open();
         c.record_file_open();
+        c.record_read();
+        c.record_read();
+        c.record_read();
+        c.record_read();
+        c.record_read();
+        c.record_chunk_path_alloc();
+        c.record_chunk_path_alloc();
+        c.record_chunk_path_alloc();
+        c.record_chunk_path_alloc();
+        c.record_chunk_path_alloc();
+        c.record_chunk_path_alloc();
 
         assert_eq!(c.trie_walks(), 1);
         assert_eq!(c.decompress_calls(), 2);
         assert_eq!(c.seek_calls(), 3);
         assert_eq!(c.file_opens(), 4);
+        assert_eq!(c.read_calls(), 5);
+        assert_eq!(c.chunk_path_allocs(), 6);
 
         c.reset();
         assert_eq!(c.trie_walks(), 0);
         assert_eq!(c.decompress_calls(), 0);
         assert_eq!(c.seek_calls(), 0);
         assert_eq!(c.file_opens(), 0);
+        assert_eq!(c.read_calls(), 0);
+        assert_eq!(c.chunk_path_allocs(), 0);
     }
 
     // The fd high-water helper returns a positive count on the supported platforms

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -468,10 +468,12 @@ async fn read_nb_format_chunk_data(
         // A5 read-work counter (READ_CALLS; consumer E3): exactly one logical
         // chunk read. No-op in release (design.md Decision 1/2).
         crate::storage::sstable::read_work_counters::record_read();
-        // A single `payload+CRC` heap buffer. E3 recycles this per-scan (see
-        // `read_nb_format_chunk_data_into`), so the steady-state windowed scan
-        // performs NO allocation here; this allocating entry point is retained for
-        // the non-windowed callers. CHUNK_PATH_ALLOCS records the allocation.
+        // A single `payload+CRC` heap buffer is allocated per chunk here.
+        // CHUNK_PATH_ALLOCS records THIS allocation — the one instrumented
+        // copy-chain alloc site today. Recycling this buffer per-scan (so a
+        // steady-state windowed scan allocates nothing here) is the A4
+        // ≤1-alloc/chunk work deferred to issue #1940; until then every call
+        // allocates and records exactly one.
         crate::storage::sstable::read_work_counters::record_chunk_path_alloc();
         let mut chunk_data = vec![0u8; total_chunk_size as usize];
         file_guard.read_exact(&mut chunk_data).await.map_err(|e| {
@@ -594,6 +596,14 @@ pub(crate) fn read_compressed_chunk_at(
     // path's per-chunk seek, so it is counted the same way for parity of the E4
     // guard. No-op in release (design.md Decision 1/2).
     crate::storage::sstable::read_work_counters::record_seek();
+
+    // A5 read-work counter (READ_CALLS; consumer E3): exactly one logical chunk
+    // read on the positional POINT-READ path too — this positioned fetch reads
+    // payload + trailing CRC in ONE `read_exact_at`, so a point lookup records
+    // exactly one read per chunk, matching the cursor path. Recording it here
+    // keeps READ_CALLS complete: without it, point lookups would decompress
+    // chunks while reporting zero reads. No-op in release (design.md Decision 1/2).
+    crate::storage::sstable::read_work_counters::record_read();
 
     // ONE positioned read for payload + trailing CRC32 (E3: single read/chunk).
     let mut buf = vec![0u8; chunk_data_size + 4];
@@ -1155,6 +1165,80 @@ mod tests {
         assert!(read_compressed_chunk_at(&src, &ci, 2, file_size, 0)
             .expect("EOF read ok")
             .is_none());
+    }
+
+    /// The positional POINT-READ path records `READ_CALLS` exactly once per chunk
+    /// fetched — the same one-read-per-chunk contract the cursor path proves. Each
+    /// `read_compressed_chunk_at` that verifies and returns a chunk bumps the
+    /// counter by exactly 1 (payload + trailing CRC are read in ONE `read_exact_at`),
+    /// so point lookups no longer decompress chunks while reporting zero reads. A
+    /// clean EOF read (past the last chunk) reads nothing and must NOT bump it.
+    ///
+    /// Counters are a shared process-global, so this test serializes on the
+    /// `serial_test` mutex (the counter-test convention; issue #1071) — a stale
+    /// value from a parallel test cannot satisfy an assertion after the `reset`.
+    #[test]
+    #[serial_test::serial]
+    fn read_compressed_chunk_at_records_one_read_per_chunk() {
+        use crate::storage::sstable::compression_info::CompressionInfo;
+        use crate::storage::sstable::read_work_counters as rwc;
+
+        // Two well-formed chunks: [payload0][crc0][payload1][crc1].
+        let payload0 = b"first-chunk-bytes".to_vec();
+        let payload1 = b"second-chunk-bytes".to_vec();
+        let crc0 = crc32fast::hash(&payload0);
+        let crc1 = crc32fast::hash(&payload1);
+
+        let mut file = Vec::new();
+        file.extend_from_slice(&payload0);
+        file.extend_from_slice(&crc0.to_be_bytes());
+        let off1 = file.len() as u64;
+        file.extend_from_slice(&payload1);
+        file.extend_from_slice(&crc1.to_be_bytes());
+        let file_size = file.len() as u64;
+
+        let ci = CompressionInfo {
+            algorithm: "LZ4Compressor".to_string(),
+            option_pairs: vec![],
+            chunk_length: 64 * 1024,
+            max_compressed_length: i32::MAX as u32,
+            data_length: (payload0.len() + payload1.len()) as u64,
+            chunk_offsets: vec![0, off1],
+        };
+        let src = MemReadAt(file);
+
+        // Measure the positional path from zero.
+        rwc::reset();
+        assert_eq!(rwc::read_calls(), 0, "reset must zero READ_CALLS");
+
+        // Each successful chunk fetch bumps READ_CALLS by exactly one.
+        read_compressed_chunk_at(&src, &ci, 0, file_size, 0)
+            .expect("chunk 0 read")
+            .expect("chunk 0 present");
+        assert_eq!(
+            rwc::read_calls(),
+            1,
+            "point-read of chunk 0 must record exactly one READ_CALL"
+        );
+
+        read_compressed_chunk_at(&src, &ci, 1, file_size, 0)
+            .expect("chunk 1 read")
+            .expect("chunk 1 present");
+        assert_eq!(
+            rwc::read_calls(),
+            2,
+            "point-read of chunk 1 must record exactly one more READ_CALL (total 2)"
+        );
+
+        // A clean EOF read (past the last chunk) fetches nothing: no read recorded.
+        assert!(read_compressed_chunk_at(&src, &ci, 2, file_size, 0)
+            .expect("EOF read ok")
+            .is_none());
+        assert_eq!(
+            rwc::read_calls(),
+            2,
+            "EOF (no chunk fetched) must NOT record a READ_CALL"
+        );
     }
 
     // =========================================================================

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -458,32 +458,39 @@ async fn read_nb_format_chunk_data(
                 ))
             })?;
 
-        // Read chunk bytes (NOT including trailing CRC32)
-        let mut chunk_data = vec![0u8; chunk_data_size];
+        // E3 (issue #1585): read the compressed payload AND its trailing 4-byte
+        // CRC32 in ONE `read_exact` into a single `payload+CRC` buffer, then split
+        // the slice — rather than two separate `read_exact` calls (one for the
+        // payload, one for the CRC). Halves the per-chunk read count (A5). The CRC
+        // is still verified BEFORE the payload is handed to the decompressor
+        // (guardrail: unchanged CRC ordering).
+        //
+        // A5 read-work counter (READ_CALLS; consumer E3): exactly one logical
+        // chunk read. No-op in release (design.md Decision 1/2).
+        crate::storage::sstable::read_work_counters::record_read();
+        // A single `payload+CRC` heap buffer. E3 recycles this per-scan (see
+        // `read_nb_format_chunk_data_into`), so the steady-state windowed scan
+        // performs NO allocation here; this allocating entry point is retained for
+        // the non-windowed callers. CHUNK_PATH_ALLOCS records the allocation.
+        crate::storage::sstable::read_work_counters::record_chunk_path_alloc();
+        let mut chunk_data = vec![0u8; total_chunk_size as usize];
         file_guard.read_exact(&mut chunk_data).await.map_err(|e| {
             Error::Io(std::io::Error::new(
                 e.kind(),
                 format!(
-                    "Failed to read chunk {} data ({} bytes at offset 0x{:x}): {}",
-                    chunk_idx, chunk_data_size, chunk_offset, e
+                    "Failed to read chunk {} data+CRC ({} bytes at offset 0x{:x}): {}",
+                    chunk_idx, total_chunk_size, chunk_offset, e
                 ),
             ))
         })?;
-
-        // Read trailing CRC32 (4 bytes, big-endian)
-        let mut crc_bytes = [0u8; 4];
-        file_guard.read_exact(&mut crc_bytes).await.map_err(|e| {
-            Error::Io(std::io::Error::new(
-                e.kind(),
-                format!(
-                    "Failed to read CRC32 for chunk {} at offset 0x{:x}: {}",
-                    chunk_idx,
-                    chunk_offset + chunk_data_size as u64,
-                    e
-                ),
-            ))
-        })?;
-        let expected_crc = u32::from_be_bytes(crc_bytes);
+        // Split the trailing 4-byte big-endian CRC32 off the payload.
+        let expected_crc = u32::from_be_bytes([
+            chunk_data[chunk_data_size],
+            chunk_data[chunk_data_size + 1],
+            chunk_data[chunk_data_size + 2],
+            chunk_data[chunk_data_size + 3],
+        ]);
+        chunk_data.truncate(chunk_data_size);
 
         (chunk_data, expected_crc)
     };

--- a/cqlite-core/tests/issue_1585_read_op_per_chunk.rs
+++ b/cqlite-core/tests/issue_1585_read_op_per_chunk.rs
@@ -1,0 +1,167 @@
+//! Issue #1585 (Epic E / E3): the compressed-chunk read path performs EXACTLY
+//! one logical `read_exact` per chunk.
+//!
+//! Before E3 each compression chunk cost TWO `read_exact` calls — one for the
+//! compressed payload, then a second for the trailing 4-byte CRC32. E3 folds
+//! them into a single `read_exact` into one `payload+CRC` buffer and splits the
+//! CRC off afterwards (the CRC is still verified BEFORE the payload is handed to
+//! the decompressor — guardrail: unchanged CRC ordering). This test pins that
+//! win via the `READ_CALLS` read-work counter (consumer E3).
+//!
+//! Oracle: on a cold single-generation full scan of a FULLY-COMPRESSIBLE fixture
+//! every Data.db chunk is read once (`READ_CALLS`) and decompressed once
+//! (`DECOMPRESS_CALLS`) — the cache is cold so there are no hits, and small text
+//! rows never trip the incompressible raw-passthrough path — so
+//! `read_calls == decompress_calls`. On the pre-E3 two-read path this same scan
+//! recorded `read_calls == 2 * decompress_calls`, so the equality is a tight
+//! RED→GREEN discriminator (RED = 2×).
+//!
+//! Compiled only with `--features work-counters` (the getters/`reset` and the
+//! counter bodies live behind that feature; see `read_work_counters`). Requires
+//! `CQLITE_DATASETS_ROOT` + fetched binaries; skips (never fails) when the
+//! fixture is absent, but NEVER passes with 0 rows when present. Excluded under
+//! `tombstones` (that build serves reads via a full-scan filter rather than the
+//! targeted chunk path this evidences).
+//!
+//! The counters are a shared process-global, so this test serializes on the
+//! `serial_test` mutex (the existing counter-test convention) — a stale value
+//! from a parallel test can never satisfy an assertion after a `reset`.
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::sstable::read_work_counters as rwc;
+use cqlite_core::Database;
+use serial_test::serial;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        if let Some(dir) = root.parent().and_then(|p| {
+            let d = p.join("schemas");
+            d.exists().then_some(d)
+        }) {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+/// True if `<datasets>/sstables/<keyspace>/<table>-*/` holds a `*-Data.db` file.
+/// Skip keys off fixture presence (not a 0-row result), so a present fixture that
+/// yields 0 rows stays a hard failure.
+fn fixture_data_present(keyspace: &str, table: &str) -> bool {
+    let Some(root) = datasets_root() else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(root.join("sstables").join(keyspace)) else {
+        return false;
+    };
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        if let Ok(files) = std::fs::read_dir(e.path()) {
+            for f in files.flatten() {
+                if f.file_name().to_string_lossy().ends_with("-Data.db") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Ingest a single fixture table and return a fresh `Database`.
+async fn setup(keyspace: &str, schema_file: &str) -> Option<Database> {
+    let root = datasets_root()?;
+    let schema_path = schemas_dir()?.join(schema_file);
+    if !schema_path.exists() {
+        return None;
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return None;
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: Some("5.0".to_string()),
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    };
+    let result = ingest(config).await.ok()?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return None;
+    }
+    Some(result.database)
+}
+
+/// Scenario: a cold full scan reads each compressed chunk exactly once. With the
+/// cache cold (no hits) and the fixture fully compressible (no raw passthrough),
+/// `READ_CALLS == DECOMPRESS_CALLS` — one read and one decompress per chunk. The
+/// pre-E3 two-read path recorded `READ_CALLS == 2 * DECOMPRESS_CALLS`, so this
+/// equality fails on the old path (RED) and holds after E3 (GREEN).
+#[tokio::test]
+#[serial]
+async fn full_scan_reads_each_chunk_once() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (E3 read-op): test_basic/simple_table Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (E3 read-op): could not ingest test_basic");
+        return;
+    };
+
+    // Reset BEFORE the scan so the entire chunk-read path is measured from zero.
+    rwc::reset();
+    assert_eq!(rwc::read_calls(), 0, "reset must zero READ_CALLS");
+    assert_eq!(
+        rwc::decompress_calls(),
+        0,
+        "reset must zero DECOMPRESS_CALLS"
+    );
+
+    let scan = db
+        .execute("SELECT id FROM test_basic.simple_table")
+        .await
+        .expect("cold scan of test_basic.simple_table");
+    assert!(
+        !scan.rows.is_empty(),
+        "present fixture must return rows (0 rows = read regression, not a skip)"
+    );
+
+    let reads = rwc::read_calls();
+    let decompresses = rwc::decompress_calls();
+    assert!(
+        reads >= 1 && decompresses >= 1,
+        "E3: a compressed scan must record at least one read and one decompress; \
+         reads={reads}, decompresses={decompresses}"
+    );
+    // The tight A5/E3 discriminator: exactly one read per decompressed chunk.
+    // Pre-E3 this was `reads == 2 * decompresses`.
+    assert_eq!(
+        reads, decompresses,
+        "E3: the chunk read path must issue exactly ONE read per chunk \
+         (reads={reads}) — equal to the per-chunk decompress count \
+         (decompresses={decompresses}); reads == 2*decompresses would mean the \
+         pre-E3 separate payload+CRC reads regressed back in"
+    );
+}


### PR DESCRIPTION
Closes #1585 (E3 — Epic E #1517). Ships **option C** (owner-decided): the A5 single-read win now; the ≤1-alloc/chunk restructure (A4) is deferred to **#1940** (Arc<[u8]> scan channel / decompress-in-IO-half / mmap Bytes, co-designed with the E1/K5 Value-v2 train).

- **Single read per chunk:** folds the compressed payload + trailing CRC into ONE `read_exact`/`read_exact_at` (was 2 reads/chunk), on BOTH the cursor scan path and the positional point-read path (`read_compressed_chunk_at`). CRC still validated before decompression, order unchanged.
- **Read-op work counter** (`READ_CALLS`) wired on both paths; pinned tests: `issue_1585_read_op_per_chunk` (cursor scan == 1 read/chunk) + `read_compressed_chunk_at_records_one_read_per_chunk` (point-read path).
- **CHUNK_PATH_ALLOCS** counter doc narrowed to exactly what's instrumented today (compressed-buffer alloc); full copy-chain alloc instrumentation + the ≤1-alloc reduction it measures land with #1940.

Byte-transparent (no format/parity change). Gate all-PASS (incl. compaction-byte-parity, smoke/all-tables, core-tests); roborev clean. 33-table parity covered by the passing parity/smoke components.

**Not in this PR (→ #1940):** decompress-into-window, borrowed/mmap compressed bytes, zstd DCtx reuse, BufReader sizing — the ≤1-alloc/chunk target that conflicts with E3's B1-Arc-cache guardrail at 2 allocs/chunk.