### PR TITLE
fix(#1625): pre-admission memtable size check + bounded iterative estimator (single-mutation hard-limit guard)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -46,6 +46,11 @@ crc32fast = { workspace = true }
 parking_lot = { workspace = true }
 dashmap = { workspace = true }
 lru = "0.16"
+# Stack-backed worklist for the write-path size estimator so shallow/normal
+# mutations incur ZERO heap allocation on the admission/accounting hot path
+# (issue #1625). Already compiled transitively (via dashmap/parking_lot), so
+# this direct dependency adds nothing to the build tree.
+smallvec = "1"
 
 # Memory management
 bytes = { workspace = true }

--- a/cqlite-core/src/storage/write_engine/admission_tests.rs
+++ b/cqlite-core/src/storage/write_engine/admission_tests.rs
@@ -1,0 +1,207 @@
+//! Honest memtable hard-limit admission tests (issue #1625).
+//!
+//! The pre-#1625 admission check compared only the *current* memtable size
+//! against the hard limit and never measured the incoming mutation, so a single
+//! jumbo mutation could be admitted into an empty memtable (blowing past the
+//! limit on the first insert) and a near-full memtable could be pushed over the
+//! limit before the *next* write was rejected. In addition, the size estimator
+//! returned a flat ~1KB for anything nested past the recursion depth cap, so a
+//! deeply/widely nested value was systematically under-counted.
+//!
+//! These tests exercise the real write surface (`WriteEngine::write`) so
+//! admission and accounting are validated together.
+
+use super::{Durability, Mutation, WriteEngine, WriteEngineConfig};
+use crate::error::Error;
+use crate::storage::write_engine::mutation::{CellOperation, PartitionKey, TableId};
+use crate::storage::write_engine::test_support::{create_test_mutation, create_test_schema};
+use crate::types::Value;
+use tempfile::TempDir;
+
+/// Build a mutation whose single text value is `bytes` long, used to force a
+/// jumbo/near-limit admission decision.
+fn create_sized_mutation(id: i32, bytes: usize, timestamp: i64) -> Mutation {
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value: Value::Text("x".repeat(bytes)),
+    }];
+    Mutation::new(table_id, pk, None, ops, timestamp, None)
+}
+
+/// A single jumbo mutation whose estimate alone exceeds the hard limit must be
+/// REJECTED even into an empty memtable (previously it was admitted because the
+/// check ignored the incoming mutation), with a distinct single-mutation error.
+#[test]
+fn test_single_jumbo_mutation_rejected_into_empty_memtable() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    )
+    .with_flush_threshold(1024 * 1024)
+    .with_hard_limit(64 * 1024) // 64KB
+    .with_durability(Durability::Disabled);
+
+    let mut engine = WriteEngine::new(config).unwrap();
+    assert_eq!(engine.memtable_size(), 0);
+
+    // 128KB value >> 64KB hard limit.
+    let jumbo = create_sized_mutation(1, 128 * 1024, 1_000_000);
+    let err = engine.write(jumbo).unwrap_err();
+    match err {
+        Error::Storage(msg) => {
+            assert!(
+                msg.contains("single mutation") && msg.contains("hard limit"),
+                "expected distinct single-mutation ceiling error, got: {msg}"
+            );
+        }
+        other => panic!("expected Storage error, got: {other:?}"),
+    }
+
+    // Nothing was admitted.
+    assert_eq!(engine.memtable_size(), 0);
+    assert_eq!(engine.memtable_row_count(), 0);
+}
+
+/// A write whose incoming size would push `current_size + incoming` over the
+/// hard limit is rejected PRE-admission — the mutation that crosses the line
+/// does not itself blow the budget.
+#[test]
+fn test_projected_sum_over_hard_limit_rejected() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    )
+    .with_flush_threshold(1024 * 1024)
+    .with_hard_limit(20 * 1024) // 20KB
+    .with_durability(Durability::Disabled);
+
+    let mut engine = WriteEngine::new(config).unwrap();
+
+    // First 12KB write fits.
+    engine
+        .write(create_sized_mutation(1, 12 * 1024, 1_000_000))
+        .unwrap();
+    let size_after_first = engine.memtable_size();
+    assert!(size_after_first >= 12 * 1024);
+
+    // Second 12KB write: 12KB + ~12KB > 20KB → rejected, memtable unchanged.
+    let err = engine
+        .write(create_sized_mutation(2, 12 * 1024, 1_000_001))
+        .unwrap_err();
+    match err {
+        Error::Storage(msg) => assert!(
+            msg.contains("would exceed hard limit"),
+            "expected projected-sum error, got: {msg}"
+        ),
+        other => panic!("expected Storage error, got: {other:?}"),
+    }
+    assert_eq!(
+        engine.memtable_size(),
+        size_after_first,
+        "rejected write must not change memtable size"
+    );
+    assert_eq!(engine.memtable_row_count(), 1);
+}
+
+/// A normal write still succeeds, and the memtable's post-insert size equals
+/// `size_before + estimate_mutation_size(&m)` — admission and accounting agree
+/// by construction.
+#[test]
+fn test_admission_and_accounting_agree() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    )
+    .with_durability(Durability::Disabled);
+
+    let mut engine = WriteEngine::new(config).unwrap();
+
+    let mutation = create_test_mutation(1, "a normal name", 1_000_000);
+    let predicted = engine.memtable.estimate_mutation_size(&mutation);
+    let before = engine.memtable_size();
+
+    engine.write(mutation).unwrap();
+
+    assert_eq!(
+        engine.memtable_size(),
+        before + predicted,
+        "post-insert size must equal size_before + estimate_mutation_size"
+    );
+    assert_eq!(engine.memtable_row_count(), 1);
+}
+
+/// A deeply nested (> MAX_NESTING_DEPTH) value must be estimated large enough to
+/// trip the hard-limit gate rather than counted as the old flat ~1KB. A
+/// 500-element list parked at the depth cap estimates in the hundreds of KB, so
+/// it exceeds a 64KB hard limit and is rejected.
+#[test]
+fn test_deeply_nested_mutation_trips_gate() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    )
+    .with_flush_threshold(1024 * 1024)
+    .with_hard_limit(64 * 1024) // 64KB
+    .with_durability(Durability::Disabled);
+
+    let mut engine = WriteEngine::new(config).unwrap();
+
+    // 32 single-element wrapper lists with a wide list at the depth cap.
+    let mut nested = Value::List((0..500).map(Value::Integer).collect());
+    for _ in 0..32 {
+        nested = Value::List(vec![nested]);
+    }
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value: nested,
+    }];
+    let mutation = Mutation::new(table_id, pk, None, ops, 1_000_000, None);
+
+    let err = engine.write(mutation).unwrap_err();
+    assert!(
+        matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
+        "deeply nested value must trip the hard-limit gate, got: {err:?}"
+    );
+    assert_eq!(engine.memtable_size(), 0);
+}
+
+/// The projected-sum uses `saturating_add`, so a memtable size near `usize::MAX`
+/// cannot overflow (a plain `+` would panic under debug overflow checks). The
+/// write is cleanly rejected instead of panicking.
+#[test]
+fn test_projected_sum_saturating_no_overflow() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    )
+    .with_durability(Durability::Disabled);
+
+    let mut engine = WriteEngine::new(config).unwrap();
+    // Force an unreachable near-max size to exercise the saturating add.
+    engine.memtable.set_size_bytes_for_test(usize::MAX - 8);
+
+    // A small mutation (< hard limit) passes the single-mutation ceiling but
+    // saturates the projected sum to usize::MAX > hard limit → rejected, with no
+    // arithmetic overflow/panic.
+    let err = engine
+        .write(create_test_mutation(1, "small", 1_000_000))
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::Storage(ref m) if m.contains("would exceed hard limit")),
+        "near-usize::MAX size must reject via saturating add, got: {err:?}"
+    );
+}

--- a/cqlite-core/src/storage/write_engine/admission_tests.rs
+++ b/cqlite-core/src/storage/write_engine/admission_tests.rs
@@ -138,10 +138,10 @@ fn test_admission_and_accounting_agree() {
     assert_eq!(engine.memtable_row_count(), 1);
 }
 
-/// A deeply nested (> MAX_NESTING_DEPTH) value must be estimated large enough to
-/// trip the hard-limit gate rather than counted as the old flat ~1KB. A
-/// 500-element list parked at the depth cap estimates in the hundreds of KB, so
-/// it exceeds a 64KB hard limit and is rejected.
+/// A deeply nested value carrying a genuinely large payload must trip the
+/// hard-limit gate. The iterative estimator (issue #1625) counts REAL bytes at
+/// every depth (no floor scaling), so a deep list of 500 × 200-byte strings
+/// (~100KB) is estimated accurately and exceeds a 64KB hard limit.
 #[test]
 fn test_deeply_nested_mutation_trips_gate() {
     let temp_dir = TempDir::new().unwrap();
@@ -156,8 +156,9 @@ fn test_deeply_nested_mutation_trips_gate() {
 
     let mut engine = WriteEngine::new(config).unwrap();
 
-    // 32 single-element wrapper lists with a wide list at the depth cap.
-    let mut nested = Value::List((0..500).map(Value::Integer).collect());
+    // 32 single-element wrapper lists around a wide list of 500 × 200-byte
+    // strings (~100KB of real payload).
+    let mut nested = Value::List((0..500).map(|_| Value::Text("y".repeat(200))).collect());
     for _ in 0..32 {
         nested = Value::List(vec![nested]);
     }
@@ -169,6 +170,13 @@ fn test_deeply_nested_mutation_trips_gate() {
     }];
     let mutation = Mutation::new(table_id, pk, None, ops, 1_000_000, None);
 
+    // ~100KB of real payload (500 * 200), accurately estimated (not a floor).
+    let estimate = engine.memtable.estimate_mutation_size(&mutation);
+    assert!(
+        estimate >= 500 * 200,
+        "estimate must reflect ~100KB of real payload, got {estimate}"
+    );
+
     let err = engine.write(mutation).unwrap_err();
     assert!(
         matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
@@ -178,11 +186,11 @@ fn test_deeply_nested_mutation_trips_gate() {
 }
 
 /// A deep NARROW collection wrapping a LARGE direct scalar must also trip the
-/// gate (issue #1625 roborev finding). Pre-fix, the depth-cap estimator scaled a
-/// collection by element COUNT × 1024, so `List([Text(128KB)])` parked at the cap
-/// was counted as ~1KB and passed a 64KB hard limit while retaining 128KB. The
-/// shallow per-child estimate now counts the large direct scalar at its real
-/// heap size, so the write is rejected.
+/// gate (issue #1625 roborev finding). Pre-fix, any node past the recursion
+/// depth cap collapsed to a ~1KB floor, so `List([Text(128KB)])` parked at the
+/// cap was counted as ~1KB and passed a 64KB hard limit while retaining 128KB.
+/// The iterative estimator counts the large scalar at its real heap size
+/// regardless of depth, so the write is rejected.
 #[test]
 fn test_deep_narrow_collection_with_large_scalar_trips_gate() {
     let temp_dir = TempDir::new().unwrap();
@@ -216,6 +224,150 @@ fn test_deep_narrow_collection_with_large_scalar_trips_gate() {
     assert!(
         matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
         "deep narrow collection with a large scalar must trip the gate, got: {err:?}"
+    );
+    assert_eq!(engine.memtable_size(), 0);
+}
+
+/// Build a `WriteEngine` with a 64KB hard limit for the deep-scalar tests.
+fn engine_with_64k_limit() -> (TempDir, WriteEngine) {
+    let temp_dir = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    )
+    .with_flush_threshold(1024 * 1024)
+    .with_hard_limit(64 * 1024) // 64KB
+    .with_durability(Durability::Disabled);
+    let engine = WriteEngine::new(config).unwrap();
+    (temp_dir, engine)
+}
+
+/// Wrap a value in `levels` single-element lists.
+fn wrap_in_lists(mut inner: Value, levels: usize) -> Value {
+    for _ in 0..levels {
+        inner = Value::List(vec![inner]);
+    }
+    inner
+}
+
+fn mutation_with_value(value: Value) -> Mutation {
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value,
+    }];
+    Mutation::new(table_id, pk, None, ops, 1_000_000, None)
+}
+
+/// A large scalar buried a FEW levels deep (`List([List([Text(128KB)])])`,
+/// 2 levels) must be estimated at its REAL heap size — not the old ~1KB
+/// depth-cap floor — and REJECTED against a 64KB hard limit. The iterative
+/// estimator has no depth cap, so no wrapping level can hide the scalar
+/// (issue #1625, 3rd iteration).
+#[test]
+fn test_large_scalar_two_levels_deep_rejected() {
+    let (_tmp, mut engine) = engine_with_64k_limit();
+
+    // List([List([Text(128KB)])]).
+    let value = wrap_in_lists(Value::List(vec![Value::Text("x".repeat(128 * 1024))]), 1);
+    let mutation = mutation_with_value(value);
+
+    // Estimate must be ~128KB (real size), NOT the ~1KB floor.
+    let estimate = engine.memtable.estimate_mutation_size(&mutation);
+    assert!(
+        estimate >= 128 * 1024,
+        "estimate must reflect the buried 128KB scalar, got {estimate}"
+    );
+
+    let err = engine.write(mutation).unwrap_err();
+    assert!(
+        matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
+        "2-level-buried large scalar must trip the gate, got: {err:?}"
+    );
+    assert_eq!(engine.memtable_size(), 0);
+}
+
+/// The same bypass at 3+ levels: `List([List([List([Text(128KB)])])])`.
+/// Pre-fix this reached the depth cap far enough down that the child collapsed
+/// to the ~1KB floor and admission ADMITTED it; the iterative estimator counts
+/// the real size and REJECTS it (issue #1625).
+#[test]
+fn test_large_scalar_three_levels_deep_rejected() {
+    let (_tmp, mut engine) = engine_with_64k_limit();
+
+    // List([List([List([Text(128KB)])])]).
+    let value = wrap_in_lists(Value::List(vec![Value::Text("x".repeat(128 * 1024))]), 2);
+    let mutation = mutation_with_value(value);
+
+    let estimate = engine.memtable.estimate_mutation_size(&mutation);
+    assert!(
+        estimate >= 128 * 1024,
+        "estimate must reflect the buried 128KB scalar, got {estimate}"
+    );
+
+    let err = engine.write(mutation).unwrap_err();
+    assert!(
+        matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
+        "3-level-buried large scalar must trip the gate, got: {err:?}"
+    );
+    assert_eq!(engine.memtable_size(), 0);
+}
+
+/// A large scalar buried BELOW where the old 32-level depth cap sat (33 wrapper
+/// lists, so the innermost `Text(128KB)` is at depth 34) must still be counted
+/// at its real size and rejected. Pre-fix, any node past depth 32 collapsed to
+/// the shallow floor and this slipped past admission (issue #1625).
+#[test]
+fn test_large_scalar_below_old_depth_cap_rejected() {
+    let (_tmp, mut engine) = engine_with_64k_limit();
+
+    // 33 wrapper lists around Text(128KB): innermost scalar is well past the
+    // old MAX_NESTING_DEPTH (32).
+    let value = wrap_in_lists(Value::Text("x".repeat(128 * 1024)), 33);
+    let mutation = mutation_with_value(value);
+
+    let estimate = engine.memtable.estimate_mutation_size(&mutation);
+    assert!(
+        estimate >= 128 * 1024,
+        "estimate must reflect the 128KB scalar below the old cap, got {estimate}"
+    );
+
+    let err = engine.write(mutation).unwrap_err();
+    assert!(
+        matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
+        "scalar below old depth cap must trip the gate, got: {err:?}"
+    );
+    assert_eq!(engine.memtable_size(), 0);
+}
+
+/// A pathological WIDE value that exceeds `MAX_ESTIMATE_NODES` (1_000_000) must
+/// fail CLOSED: the bounded iterative estimator stops at the node cap and
+/// returns `usize::MAX`, so the mutation is REJECTED — without stack overflow,
+/// arithmetic overflow, or hang. Construction is a single flat allocation so the
+/// test runs fast (issue #1625 DoS guard).
+#[test]
+fn test_pathological_node_cap_fails_closed() {
+    let (_tmp, mut engine) = engine_with_64k_limit();
+
+    // A flat list of 1_000_001 small integers: outer node + 1_000_001 children
+    // = 1_000_002 visited > MAX_ESTIMATE_NODES (1_000_000) → fail closed.
+    let value = Value::List((0..1_000_001i32).map(Value::Integer).collect());
+    let mutation = mutation_with_value(value);
+
+    // Estimator saturates to usize::MAX (fail-closed), never a small under-count.
+    let estimate = engine.memtable.estimate_mutation_size(&mutation);
+    assert_eq!(
+        estimate,
+        usize::MAX,
+        "hitting the node cap must fail closed with usize::MAX"
+    );
+
+    let err = engine.write(mutation).unwrap_err();
+    assert!(
+        matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
+        "node-cap fail-closed value must be rejected, got: {err:?}"
     );
     assert_eq!(engine.memtable_size(), 0);
 }

--- a/cqlite-core/src/storage/write_engine/admission_tests.rs
+++ b/cqlite-core/src/storage/write_engine/admission_tests.rs
@@ -177,6 +177,49 @@ fn test_deeply_nested_mutation_trips_gate() {
     assert_eq!(engine.memtable_size(), 0);
 }
 
+/// A deep NARROW collection wrapping a LARGE direct scalar must also trip the
+/// gate (issue #1625 roborev finding). Pre-fix, the depth-cap estimator scaled a
+/// collection by element COUNT × 1024, so `List([Text(128KB)])` parked at the cap
+/// was counted as ~1KB and passed a 64KB hard limit while retaining 128KB. The
+/// shallow per-child estimate now counts the large direct scalar at its real
+/// heap size, so the write is rejected.
+#[test]
+fn test_deep_narrow_collection_with_large_scalar_trips_gate() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    )
+    .with_flush_threshold(1024 * 1024)
+    .with_hard_limit(64 * 1024) // 64KB
+    .with_durability(Durability::Disabled);
+
+    let mut engine = WriteEngine::new(config).unwrap();
+
+    // Innermost: a single-element list holding one 128KB text scalar. Wrapped in
+    // 32 single-element lists so the `List([Text(128KB)])` lands exactly at the
+    // recursion depth cap (its Text child is a DIRECT child of the capped node).
+    let mut nested = Value::List(vec![Value::Text("x".repeat(128 * 1024))]);
+    for _ in 0..32 {
+        nested = Value::List(vec![nested]);
+    }
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value: nested,
+    }];
+    let mutation = Mutation::new(table_id, pk, None, ops, 1_000_000, None);
+
+    let err = engine.write(mutation).unwrap_err();
+    assert!(
+        matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
+        "deep narrow collection with a large scalar must trip the gate, got: {err:?}"
+    );
+    assert_eq!(engine.memtable_size(), 0);
+}
+
 /// The projected-sum uses `saturating_add`, so a memtable size near `usize::MAX`
 /// cannot overflow (a plain `+` would panic under debug overflow checks). The
 /// write is cleanly rejected instead of panicking.

--- a/cqlite-core/src/storage/write_engine/admission_tests.rs
+++ b/cqlite-core/src/storage/write_engine/admission_tests.rs
@@ -366,8 +366,45 @@ fn test_pathological_node_cap_fails_closed() {
 
     let err = engine.write(mutation).unwrap_err();
     assert!(
-        matches!(err, Error::Storage(ref m) if m.contains("hard limit")),
-        "node-cap fail-closed value must be rejected, got: {err:?}"
+        matches!(err, Error::Storage(ref m) if m.contains("fail-closed sentinel")),
+        "node-cap fail-closed value must be rejected via the sentinel guard, got: {err:?}"
+    );
+    assert_eq!(engine.memtable_size(), 0);
+}
+
+/// The estimator's `usize::MAX` fail-closed sentinel must be rejected EXPLICITLY,
+/// independent of `hard_limit`. With `hard_limit == usize::MAX` (a configurable
+/// value), the `incoming > hard_limit` ceiling check is `usize::MAX > usize::MAX`
+/// = false, so pre-fix the pathological mutation was ADMITTED, defeating the
+/// fail-closed guard. The dedicated sentinel check makes admission REJECT it
+/// regardless of how `hard_limit` is configured (issue #1625).
+#[test]
+fn test_sentinel_rejected_with_max_hard_limit() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    )
+    .with_flush_threshold(1024 * 1024)
+    .with_hard_limit(usize::MAX)
+    .with_durability(Durability::Disabled);
+    let mut engine = WriteEngine::new(config).unwrap();
+
+    // Pathological wide value that trips MAX_ESTIMATE_NODES → estimator returns
+    // usize::MAX.
+    let value = Value::List((0..1_000_001i32).map(Value::Integer).collect());
+    let mutation = mutation_with_value(value);
+    assert_eq!(
+        engine.memtable.estimate_mutation_size(&mutation),
+        usize::MAX,
+        "hitting the node cap must fail closed with usize::MAX"
+    );
+
+    let err = engine.write(mutation).unwrap_err();
+    assert!(
+        matches!(err, Error::Storage(ref m) if m.contains("fail-closed sentinel")),
+        "sentinel must be rejected even when hard_limit == usize::MAX, got: {err:?}"
     );
     assert_eq!(engine.memtable_size(), 0);
 }

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -194,12 +194,18 @@ impl Memtable {
     /// Estimate the size in bytes a CQL value would add to the memtable.
     ///
     /// Implemented as a BOUNDED ITERATIVE traversal (issue #1625): an explicit
-    /// heap-allocated worklist of `&Value` replaces the previous recursive
-    /// estimator. Because traversal state lives on the heap there is NO
-    /// stack-overflow risk, so there is NO depth cap and therefore NO collapsing
-    /// of deeply nested children to a conservative floor — a large scalar buried
-    /// arbitrarily deep (e.g. `List([List([List([Text(128KB)])])])`) is counted
-    /// at its real heap size, closing the hard-limit bypass.
+    /// worklist of `&Value` replaces the previous recursive estimator. Because
+    /// traversal state is not on the call stack there is NO stack-overflow risk,
+    /// so there is NO depth cap and therefore NO collapsing of deeply nested
+    /// children to a conservative floor — a large scalar buried arbitrarily deep
+    /// (e.g. `List([List([List([Text(128KB)])])])`) is counted at its real heap
+    /// size, closing the hard-limit bypass.
+    ///
+    /// The worklist is a stack-backed [`SmallVec`] with 32 inline slots, so the
+    /// common case (shallow/normal mutations — what the #1660 write-path
+    /// allocation budget test exercises) performs the whole traversal with ZERO
+    /// heap allocation on the admission/accounting hot path. Only pathologically
+    /// deep/wide values spill the worklist to the heap.
     ///
     /// Scalars contribute their real heap size (`Text`/`Blob`/`Varint`/`Inet`/
     /// `Json`/`Decimal` byte length; fixed widths otherwise). Collections, maps,
@@ -214,11 +220,16 @@ impl Memtable {
     /// estimate can never wrap around a small value.
     fn estimate_value_size(value: &crate::types::Value) -> usize {
         use crate::types::Value;
+        use smallvec::SmallVec;
 
         let mut total: usize = 0;
         let mut visited: usize = 0;
-        // Explicit heap worklist of borrowed values still to be measured.
-        let mut worklist: Vec<&Value> = vec![value];
+        // Stack-backed worklist of borrowed values still to be measured. The 32
+        // inline slots cover normal nesting/width, so shallow/normal mutations
+        // (the #1660 write-path allocation budget case) traverse with ZERO heap
+        // allocation; only pathological deep/wide values spill to the heap.
+        let mut worklist: SmallVec<[&Value; 32]> = SmallVec::new();
+        worklist.push(value);
 
         while let Some(v) = worklist.pop() {
             visited += 1;

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -78,8 +78,14 @@ impl Memtable {
 
         // Add mutation
         mutations.push(mutation);
-        self.row_count += 1;
-        self.size_bytes += mutation_size;
+        self.row_count = self.row_count.saturating_add(1);
+        // `saturating_add`: `mutation_size` can legitimately be `usize::MAX`
+        // (the estimator fails closed at the node cap, issue #1625). Admission
+        // rejects over-limit mutations, but a direct `Memtable` user (bypassing
+        // admission) or a `WriteEngine` with `memtable_hard_limit == usize::MAX`
+        // could otherwise panic in debug (overflow check) or wrap in release —
+        // the ledger update MUST be self-safe.
+        self.size_bytes = self.size_bytes.saturating_add(mutation_size);
 
         Ok(())
     }
@@ -231,6 +237,20 @@ impl Memtable {
         let mut worklist: SmallVec<[&Value; 32]> = SmallVec::new();
         worklist.push(value);
 
+        // Would scheduling `incoming` more children push the total node count
+        // past the cap? `visited` (popped so far) + `pending` (already queued) +
+        // `incoming` is the upper bound on nodes this traversal will touch. This
+        // is checked BEFORE enqueuing so a single flat collection with far more
+        // than `MAX_ESTIMATE_NODES` elements can never grow the worklist
+        // proportional to its element count — the DoS guard fails closed WITHOUT
+        // the huge allocation (issue #1625).
+        let would_exceed_cap = |visited: usize, pending: usize, incoming: usize| -> bool {
+            visited
+                .saturating_add(pending)
+                .saturating_add(incoming)
+                > Self::MAX_ESTIMATE_NODES
+        };
+
         while let Some(v) = worklist.pop() {
             visited += 1;
             if visited > Self::MAX_ESTIMATE_NODES {
@@ -262,10 +282,18 @@ impl Memtable {
                 Value::Tombstone(_) => total = total.saturating_add(24),
                 Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
                     total = total.saturating_add(16);
+                    if would_exceed_cap(visited, worklist.len(), items.len()) {
+                        return usize::MAX;
+                    }
                     worklist.extend(items.iter());
                 }
                 Value::Map(entries) => {
                     total = total.saturating_add(16);
+                    // Each entry enqueues both a key and a value.
+                    let incoming = entries.len().saturating_mul(2);
+                    if would_exceed_cap(visited, worklist.len(), incoming) {
+                        return usize::MAX;
+                    }
                     for (k, val) in entries {
                         worklist.push(k);
                         worklist.push(val);
@@ -273,6 +301,12 @@ impl Memtable {
                 }
                 Value::Udt(udt) => {
                     total = total.saturating_add(16);
+                    // Upper bound: at most one child per field (fields with a
+                    // value); check before touching any field so a wide UDT
+                    // cannot balloon the worklist.
+                    if would_exceed_cap(visited, worklist.len(), udt.fields.len()) {
+                        return usize::MAX;
+                    }
                     for field in &udt.fields {
                         total = total.saturating_add(field.name.len());
                         if let Some(fv) = field.value.as_ref() {
@@ -282,6 +316,9 @@ impl Memtable {
                 }
                 Value::Frozen(inner) => {
                     total = total.saturating_add(8);
+                    if would_exceed_cap(visited, worklist.len(), 1) {
+                        return usize::MAX;
+                    }
                     worklist.push(inner);
                 }
             }
@@ -908,6 +945,90 @@ mod tests {
             usize::MAX,
             "hitting the node cap must fail closed with usize::MAX (got {size})"
         );
+    }
+
+    #[test]
+    fn test_insert_with_pathological_value_saturates_ledger_no_panic() {
+        // Issue #1625 (roborev finding 1): a direct `Memtable` user bypasses the
+        // WriteEngine admission gate, so `insert_with_key` MUST be self-safe when
+        // the estimator returns `usize::MAX` (node cap fail-closed). The ledger
+        // update must saturate — never panic (debug overflow) or wrap (release).
+        let mut memtable = Memtable::new();
+
+        // A flat list past the node cap makes `mutation_size` == usize::MAX.
+        let pathological = Value::List(
+            (0..(Memtable::MAX_ESTIMATE_NODES as i32 + 5))
+                .map(Value::Integer)
+                .collect(),
+        );
+        let table_id = TableId::new("test_ks", "test_table");
+        let partition_key = PartitionKey::single("id", Value::Integer(1));
+        let key = DecoratedKey::from_key_bytes(1i32.to_be_bytes().to_vec()).unwrap();
+        let operations = vec![CellOperation::Write {
+            column: "big".to_string(),
+            value: pathological,
+        }];
+        let mutation = Mutation::new(table_id, partition_key, None, operations, 1, None);
+
+        // Sanity: the estimate really is usize::MAX for this mutation.
+        assert_eq!(memtable.estimate_mutation_size(&mutation), usize::MAX);
+
+        // Must not panic; ledger saturates at usize::MAX (no wrap to a small value).
+        memtable.insert_with_key(key, mutation).unwrap();
+        assert_eq!(memtable.size_bytes(), usize::MAX);
+    }
+
+    #[test]
+    fn test_insert_saturates_when_ledger_already_near_max() {
+        // Issue #1625 (roborev finding 1): incrementing an already-huge ledger by
+        // a normal mutation size must saturate, not wrap around to a small value.
+        let mut memtable = Memtable::new();
+        memtable.set_size_bytes_for_test(usize::MAX - 3);
+
+        let (key, mutation) = create_test_mutation(1, "Alice", None);
+        memtable.insert_with_key(key, mutation).unwrap();
+
+        assert_eq!(
+            memtable.size_bytes(),
+            usize::MAX,
+            "ledger must saturate at usize::MAX, never wrap"
+        );
+    }
+
+    #[test]
+    fn test_wide_collection_fails_closed_before_enqueuing_children() {
+        // Issue #1625 (roborev finding 2): a single flat collection whose element
+        // count exceeds MAX_ESTIMATE_NODES must fail closed (usize::MAX) at the
+        // ENQUEUE check — the worklist is never grown proportional to the element
+        // count. Verified for every enqueue site (list, map, UDT, frozen).
+        use crate::types::{UdtField, UdtValue};
+
+        let over = Memtable::MAX_ESTIMATE_NODES + 5;
+
+        // List / Set / Tuple enqueue site.
+        let list = Value::List((0..over as i32).map(Value::Integer).collect());
+        assert_eq!(Memtable::estimate_value_size(&list), usize::MAX);
+
+        // Map enqueue site (keys + values).
+        let map = Value::Map(
+            (0..over as i32)
+                .map(|i| (Value::Integer(i), Value::Integer(i)))
+                .collect(),
+        );
+        assert_eq!(Memtable::estimate_value_size(&map), usize::MAX);
+
+        // UDT enqueue site (field values).
+        let udt = Value::Udt(UdtValue {
+            type_name: "t".to_string(),
+            keyspace: "ks".to_string(),
+            fields: (0..over)
+                .map(|i| UdtField {
+                    name: String::new(),
+                    value: Some(Value::Integer(i as i32)),
+                })
+                .collect(),
+        });
+        assert_eq!(Memtable::estimate_value_size(&udt), usize::MAX);
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -131,20 +131,19 @@ impl Memtable {
         // Keep created_at unchanged - represents original creation time
     }
 
-    /// Maximum nesting depth for collection size estimation (prevents stack overflow)
-    const MAX_NESTING_DEPTH: usize = 32;
-
-    /// Conservative per-element byte FLOOR used when the recursion depth cap is
-    /// reached (issue #1625). The cap prevents stack overflow on pathological
-    /// nesting, but the original flat `1024`-per-value fallback systematically
-    /// UNDER-counted collections sitting at the depth boundary, letting an
-    /// over-budget mutation slip past admission. At the cap the estimator now
-    /// sums a SHALLOW per-direct-child estimate: a large direct scalar counts its
-    /// real heap size, while every element (and any nested-collection child we do
-    /// not recurse into) contributes at least this floor. That closes both the
-    /// wide-collection and the deep-narrow-wrapping-a-large-scalar undercounts
-    /// while staying non-recursive (stack-safe).
-    const DEEP_ELEMENT_ESTIMATE: usize = 1024;
+    /// Upper bound on the number of value nodes the ITERATIVE size estimator
+    /// visits before it fails closed (issue #1625).
+    ///
+    /// The estimator walks a value with an explicit heap worklist (no recursion,
+    /// so no stack-overflow risk and no depth cap collapsing deep children to a
+    /// floor). To bound worst-case work on a pathologically huge/deep value, the
+    /// traversal stops after visiting this many nodes and returns a
+    /// CONSERVATIVE-LARGE estimate (`usize::MAX`) that is GUARANTEED to exceed any
+    /// hard limit, so admission REJECTS the value rather than under-counting it.
+    /// Failing closed on the pathological case is the correct behavior for a DoS
+    /// guard. `1_000_000` is far beyond any legitimate mutation's node count yet
+    /// keeps the traversal cheap.
+    const MAX_ESTIMATE_NODES: usize = 1_000_000;
 
     /// Estimate the number of bytes a mutation would add to this memtable.
     ///
@@ -164,218 +163,120 @@ impl Memtable {
     /// - Clustering key size (if present)
     /// - Cell operation sizes (column names + values)
     fn mutation_size(mutation: &Mutation) -> usize {
-        let mut size = 48; // Base struct overhead
+        // Base struct overhead. All accumulation uses `saturating_add` because
+        // `estimate_value_size` may return `usize::MAX` (fail-closed) for a
+        // pathological value (issue #1625); a plain `+` would panic under debug
+        // overflow checks.
+        let mut size: usize = 48;
 
         // Partition key size
         for (col_name, value) in &mutation.partition_key.columns {
-            size += col_name.len();
-            size += Self::estimate_value_size_with_depth(value, 0);
+            size = size.saturating_add(col_name.len());
+            size = size.saturating_add(Self::estimate_value_size(value));
         }
 
         // Clustering key size
         if let Some(ref clustering_key) = mutation.clustering_key {
             for (col_name, value) in &clustering_key.columns {
-                size += col_name.len();
-                size += Self::estimate_value_size_with_depth(value, 0);
+                size = size.saturating_add(col_name.len());
+                size = size.saturating_add(Self::estimate_value_size(value));
             }
         }
 
         // Cell operations
         for op in &mutation.operations {
-            size += Self::estimate_operation_size(op);
+            size = size.saturating_add(Self::estimate_operation_size(op));
         }
 
         size
     }
 
-    /// Estimate the size of a CQL value in bytes
+    /// Estimate the size in bytes a CQL value would add to the memtable.
+    ///
+    /// Implemented as a BOUNDED ITERATIVE traversal (issue #1625): an explicit
+    /// heap-allocated worklist of `&Value` replaces the previous recursive
+    /// estimator. Because traversal state lives on the heap there is NO
+    /// stack-overflow risk, so there is NO depth cap and therefore NO collapsing
+    /// of deeply nested children to a conservative floor — a large scalar buried
+    /// arbitrarily deep (e.g. `List([List([List([Text(128KB)])])])`) is counted
+    /// at its real heap size, closing the hard-limit bypass.
+    ///
+    /// Scalars contribute their real heap size (`Text`/`Blob`/`Varint`/`Inet`/
+    /// `Json`/`Decimal` byte length; fixed widths otherwise). Collections, maps,
+    /// UDTs, tuples and frozen values contribute their per-container overhead and
+    /// push their children (maps push keys AND values; UDTs count field names and
+    /// push field values) onto the worklist.
+    ///
+    /// To bound worst-case work on a pathologically huge/deep value, traversal
+    /// stops after visiting [`MAX_ESTIMATE_NODES`](Self::MAX_ESTIMATE_NODES) and
+    /// FAILS CLOSED, returning `usize::MAX` so admission REJECTS the value rather
+    /// than under-counting it. All accumulation uses `saturating_add`, so the
+    /// estimate can never wrap around a small value.
     fn estimate_value_size(value: &crate::types::Value) -> usize {
-        Self::estimate_value_size_with_depth(value, 0)
-    }
-
-    /// Estimate the size of a CQL value in bytes with depth tracking
-    ///
-    /// Limits recursion depth to prevent stack overflow from deeply nested collections.
-    /// When max depth is reached, returns a conservative fixed estimate.
-    fn estimate_value_size_with_depth(value: &crate::types::Value, depth: usize) -> usize {
         use crate::types::Value;
 
-        // Prevent excessive recursion for deeply nested structures (stack-safety
-        // cap — MUST stay). Instead of a flat, systematically under-counting
-        // `1024` fallback (issue #1625), estimate the value's size WITHOUT
-        // recursing further: exact byte length for cheap-to-measure scalars, and
-        // an element-count-scaled conservative floor for collections so a wide
-        // collection parked at the depth boundary is not counted as ~1KB.
-        if depth >= Self::MAX_NESTING_DEPTH {
-            return Self::estimate_value_size_at_cap(value);
+        let mut total: usize = 0;
+        let mut visited: usize = 0;
+        // Explicit heap worklist of borrowed values still to be measured.
+        let mut worklist: Vec<&Value> = vec![value];
+
+        while let Some(v) = worklist.pop() {
+            visited += 1;
+            if visited > Self::MAX_ESTIMATE_NODES {
+                // Pathological value: fail closed so admission rejects it.
+                return usize::MAX;
+            }
+
+            match v {
+                Value::Null => {}
+                Value::Boolean(_) | Value::TinyInt(_) => total = total.saturating_add(1),
+                Value::SmallInt(_) => total = total.saturating_add(2),
+                Value::Integer(_) | Value::Float32(_) | Value::Date(_) => {
+                    total = total.saturating_add(4)
+                }
+                Value::BigInt(_)
+                | Value::Counter(_)
+                | Value::Timestamp(_)
+                | Value::Time(_)
+                | Value::Float(_) => total = total.saturating_add(8),
+                Value::Uuid(_) | Value::Duration { .. } => total = total.saturating_add(16),
+                Value::Text(s) => total = total.saturating_add(s.len()),
+                Value::Blob(bytes) | Value::Varint(bytes) | Value::Inet(bytes) => {
+                    total = total.saturating_add(bytes.len())
+                }
+                Value::Decimal { scale: _, unscaled } => {
+                    total = total.saturating_add(4).saturating_add(unscaled.len())
+                }
+                Value::Json(json) => total = total.saturating_add(json.to_string().len()),
+                Value::Tombstone(_) => total = total.saturating_add(24),
+                Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
+                    total = total.saturating_add(16);
+                    worklist.extend(items.iter());
+                }
+                Value::Map(entries) => {
+                    total = total.saturating_add(16);
+                    for (k, val) in entries {
+                        worklist.push(k);
+                        worklist.push(val);
+                    }
+                }
+                Value::Udt(udt) => {
+                    total = total.saturating_add(16);
+                    for field in &udt.fields {
+                        total = total.saturating_add(field.name.len());
+                        if let Some(fv) = field.value.as_ref() {
+                            worklist.push(fv);
+                        }
+                    }
+                }
+                Value::Frozen(inner) => {
+                    total = total.saturating_add(8);
+                    worklist.push(inner);
+                }
+            }
         }
 
-        match value {
-            Value::Null => 0,
-            Value::Boolean(_) => 1,
-            Value::TinyInt(_) => 1,
-            Value::SmallInt(_) => 2,
-            Value::Integer(_) => 4,
-            Value::BigInt(_) | Value::Counter(_) | Value::Timestamp(_) | Value::Time(_) => 8,
-            Value::Float32(_) => 4,
-            Value::Float(_) => 8,
-            Value::Text(s) => s.len(),
-            Value::Blob(bytes) | Value::Varint(bytes) | Value::Inet(bytes) => bytes.len(),
-            Value::Uuid(_) => 16,
-            Value::Date(_) => 4,
-            Value::Decimal { scale: _, unscaled } => 4 + unscaled.len(),
-            Value::Duration { .. } => 16,
-            Value::List(items) => {
-                items
-                    .iter()
-                    .map(|item| Self::estimate_value_size_with_depth(item, depth + 1))
-                    .sum::<usize>()
-                    + 16
-            }
-            Value::Set(items) => {
-                items
-                    .iter()
-                    .map(|item| Self::estimate_value_size_with_depth(item, depth + 1))
-                    .sum::<usize>()
-                    + 16
-            }
-            Value::Map(entries) => {
-                entries
-                    .iter()
-                    .map(|(k, v)| {
-                        Self::estimate_value_size_with_depth(k, depth + 1)
-                            + Self::estimate_value_size_with_depth(v, depth + 1)
-                    })
-                    .sum::<usize>()
-                    + 16
-            }
-            Value::Udt(udt) => {
-                udt.fields
-                    .iter()
-                    .map(|field| {
-                        field.name.len()
-                            + field
-                                .value
-                                .as_ref()
-                                .map_or(0, |v| Self::estimate_value_size_with_depth(v, depth + 1))
-                    })
-                    .sum::<usize>()
-                    + 16
-            }
-            Value::Tuple(items) => {
-                items
-                    .iter()
-                    .map(|item| Self::estimate_value_size_with_depth(item, depth + 1))
-                    .sum::<usize>()
-                    + 16
-            }
-            Value::Json(json) => json.to_string().len(),
-            Value::Frozen(inner) => Self::estimate_value_size_with_depth(inner, depth + 1) + 8,
-            Value::Tombstone(_) => 24, // timestamp + type + ttl overhead
-        }
-    }
-
-    /// Non-recursive size estimate used once the recursion depth cap is hit.
-    ///
-    /// Stack-safe (never recurses past DIRECT children): a scalar value at the
-    /// cap reports its exact byte length. A collection/map/UDT/tuple at the cap
-    /// sums a SHALLOW estimate of each direct child (see
-    /// [`shallow_child_estimate`](Self::shallow_child_estimate)) which counts a
-    /// large direct scalar child at its real heap size. This closes the
-    /// hard-limit bypass where a deep NARROW collection wrapping a large scalar
-    /// (e.g. 32 wrapper lists around `List([Text(128KB)])`) was estimated at the
-    /// old flat ~1KB and slipped past admission while retaining far more memory
-    /// (issue #1625). We still never recurse below direct children — a nested
-    /// collection child counts only the `DEEP_ELEMENT_ESTIMATE` floor — so the
-    /// depth cap stays a genuine stack-safety guard.
-    fn estimate_value_size_at_cap(value: &crate::types::Value) -> usize {
-        use crate::types::Value;
-
-        match value {
-            Value::Null => 0,
-            Value::Boolean(_) | Value::TinyInt(_) => 1,
-            Value::SmallInt(_) => 2,
-            Value::Integer(_) | Value::Float32(_) | Value::Date(_) => 4,
-            Value::BigInt(_)
-            | Value::Counter(_)
-            | Value::Timestamp(_)
-            | Value::Time(_)
-            | Value::Float(_) => 8,
-            Value::Uuid(_) | Value::Duration { .. } => 16,
-            Value::Text(s) => s.len(),
-            Value::Blob(bytes) | Value::Varint(bytes) | Value::Inet(bytes) => bytes.len(),
-            Value::Decimal { scale: _, unscaled } => 4 + unscaled.len(),
-            Value::Json(json) => json.to_string().len(),
-            Value::Tombstone(_) => 24,
-            // Collections: SHALLOW sum over DIRECT children, NON-recursive.
-            // Each direct scalar child contributes its real heap size (floored
-            // at DEEP_ELEMENT_ESTIMATE); each nested-collection child contributes
-            // only the floor (we intentionally do not recurse — stack safety).
-            Value::List(items) | Value::Set(items) | Value::Tuple(items) => items
-                .iter()
-                .map(Self::shallow_child_estimate)
-                .fold(0usize, usize::saturating_add)
-                .saturating_add(16),
-            Value::Map(entries) => entries
-                .iter()
-                .map(|(k, v)| {
-                    Self::shallow_child_estimate(k).saturating_add(Self::shallow_child_estimate(v))
-                })
-                .fold(0usize, usize::saturating_add)
-                .saturating_add(16),
-            Value::Udt(udt) => udt
-                .fields
-                .iter()
-                .map(|field| {
-                    field.name.len().saturating_add(
-                        field.value.as_ref().map_or(0, Self::shallow_child_estimate),
-                    )
-                })
-                .fold(0usize, usize::saturating_add)
-                .saturating_add(16),
-            Value::Frozen(inner) => Self::shallow_child_estimate(inner).saturating_add(8),
-        }
-    }
-
-    /// Shallow (NON-recursive) size estimate for a single DIRECT child of a
-    /// value parked at the recursion depth cap (issue #1625).
-    ///
-    /// A known scalar reports its real heap size (`Text`/`Blob`/`Json`/`Varint`/
-    /// `Inet`/`Decimal` byte length, fixed widths otherwise), floored at
-    /// `DEEP_ELEMENT_ESTIMATE` so every element still counts at least the
-    /// conservative floor. A nested collection/map/UDT/tuple/frozen child is NOT
-    /// recursed into — it contributes exactly the floor — which keeps the
-    /// estimator stack-safe while ensuring a large direct scalar is no longer
-    /// systematically under-counted.
-    fn shallow_child_estimate(value: &crate::types::Value) -> usize {
-        use crate::types::Value;
-
-        let floor = Self::DEEP_ELEMENT_ESTIMATE;
-        let scalar = match value {
-            Value::Null => 0,
-            Value::Boolean(_) | Value::TinyInt(_) => 1,
-            Value::SmallInt(_) => 2,
-            Value::Integer(_) | Value::Float32(_) | Value::Date(_) => 4,
-            Value::BigInt(_)
-            | Value::Counter(_)
-            | Value::Timestamp(_)
-            | Value::Time(_)
-            | Value::Float(_) => 8,
-            Value::Uuid(_) | Value::Duration { .. } => 16,
-            Value::Text(s) => s.len(),
-            Value::Blob(bytes) | Value::Varint(bytes) | Value::Inet(bytes) => bytes.len(),
-            Value::Decimal { scale: _, unscaled } => 4usize.saturating_add(unscaled.len()),
-            Value::Json(json) => json.to_string().len(),
-            Value::Tombstone(_) => 24,
-            // Nested collections: do NOT recurse (stack safety) — count the floor.
-            Value::List(_)
-            | Value::Set(_)
-            | Value::Tuple(_)
-            | Value::Map(_)
-            | Value::Udt(_)
-            | Value::Frozen(_) => 0,
-        };
-        scalar.max(floor)
+        total
     }
 
     /// Estimate the size of a cell operation
@@ -384,19 +285,25 @@ impl Memtable {
     ) -> usize {
         use crate::storage::write_engine::mutation::CellOperation;
 
+        // `saturating_add` throughout: `estimate_value_size` may return
+        // `usize::MAX` (fail-closed) for a pathological value (issue #1625).
         match op {
-            CellOperation::Write { column, value } => {
-                column.len() + Self::estimate_value_size(value) + 8 // +8 for overhead
-            }
+            CellOperation::Write { column, value } => column
+                .len()
+                .saturating_add(Self::estimate_value_size(value))
+                .saturating_add(8), // +8 for overhead
             CellOperation::WriteWithTtl {
                 column,
                 value,
                 ttl_seconds: _,
             } => {
                 // TTL cells: same as Write + 4 bytes for TTL + 4 bytes for local_deletion_time
-                column.len() + Self::estimate_value_size(value) + 16
+                column
+                    .len()
+                    .saturating_add(Self::estimate_value_size(value))
+                    .saturating_add(16)
             }
-            CellOperation::Delete { column, .. } => column.len() + 8,
+            CellOperation::Delete { column, .. } => column.len().saturating_add(8),
             CellOperation::DeleteRow => 8,
             // Epic #899: per-element complex ops. Each carries a column name,
             // the preserved cell path, an optional value, and temporal metadata.
@@ -405,13 +312,12 @@ impl Memtable {
                 cell_path,
                 value,
                 ..
-            } => {
-                column.len()
-                    + cell_path.len()
-                    + value.as_ref().map(Self::estimate_value_size).unwrap_or(0)
-                    + 16 // flags + ts/ldt/ttl deltas + length prefixes overhead
-            }
-            CellOperation::ComplexDeletion { column, .. } => column.len() + 16,
+            } => column
+                .len()
+                .saturating_add(cell_path.len())
+                .saturating_add(value.as_ref().map(Self::estimate_value_size).unwrap_or(0))
+                .saturating_add(16), // flags + ts/ldt/ttl deltas + length prefixes overhead
+            CellOperation::ComplexDeletion { column, .. } => column.len().saturating_add(16),
         }
     }
 
@@ -763,38 +669,36 @@ mod tests {
 
     #[test]
     fn test_memtable_nested_collection_depth_limit() {
-        // Create a deeply nested list structure (40 levels deep)
+        // Issue #1625: a deeply nested list wrapping a tiny scalar is handled by
+        // the ITERATIVE estimator without stack overflow and counted ACCURATELY
+        // (no depth cap, no floor). 40 lists (16 each) around Integer(42) (4).
         let mut nested_value = Value::Integer(42);
         for _ in 0..40 {
             nested_value = Value::List(vec![nested_value]);
         }
 
-        // Should not panic and should return conservative estimate
         let size = Memtable::estimate_value_size(&nested_value);
-
-        // At depth 32, should return 1024 for each remaining level
-        // First 32 levels recurse normally, remaining 8 levels return 1024 each
-        assert!(size > 0);
-        assert!(
-            size >= 1024,
-            "Should use conservative estimate at max depth"
+        assert_eq!(
+            size,
+            40 * 16 + 4,
+            "deep list of a tiny scalar must be counted accurately, not floored"
         );
     }
 
     #[test]
     fn test_memtable_nested_map_depth_limit() {
-        // Create deeply nested map structure
+        // Issue #1625: deep map nesting counted accurately. 35 maps, each +16
+        // overhead + Integer key (4), innermost Text("bottom") (6). No floor.
         let mut nested_value = Value::Text("bottom".to_string());
         for _ in 0..35 {
             nested_value = Value::Map(vec![(Value::Integer(1), nested_value)]);
         }
 
-        // Should not panic
         let size = Memtable::estimate_value_size(&nested_value);
-        assert!(size > 0);
-        assert!(
-            size >= 1024,
-            "Should use conservative estimate for deep nesting"
+        assert_eq!(
+            size,
+            35 * (16 + 4) + 6,
+            "deep map of a tiny scalar must be counted accurately, not floored"
         );
     }
 
@@ -802,7 +706,8 @@ mod tests {
     fn test_memtable_nested_udt_depth_limit() {
         use crate::types::{UdtField, UdtValue};
 
-        // Create deeply nested UDT structure
+        // Issue #1625: deep UDT nesting counted accurately. 35 UDTs, each +16
+        // overhead + field name "field" (5), innermost Integer(1) (4). No floor.
         let mut nested_value = Value::Integer(1);
         for i in 0..35 {
             let udt = UdtValue {
@@ -816,24 +721,29 @@ mod tests {
             nested_value = Value::Udt(udt);
         }
 
-        // Should not panic
         let size = Memtable::estimate_value_size(&nested_value);
-        assert!(size > 0);
-        assert!(size >= 1024);
+        assert_eq!(
+            size,
+            35 * (16 + 5) + 4,
+            "deep UDT of a tiny scalar must be counted accurately, not floored"
+        );
     }
 
     #[test]
     fn test_memtable_frozen_nested_depth_limit() {
-        // Create deeply nested frozen values
+        // Issue #1625: deep Frozen nesting must NOT stack-overflow (iterative)
+        // and is counted accurately. 40 frozen (8 each) around Integer(99) (4).
         let mut nested_value = Value::Integer(99);
         for _ in 0..40 {
             nested_value = Value::Frozen(Box::new(nested_value));
         }
 
-        // Should not panic or cause stack overflow
         let size = Memtable::estimate_value_size(&nested_value);
-        assert!(size > 0);
-        assert!(size >= 1024);
+        assert_eq!(
+            size,
+            40 * 8 + 4,
+            "deep frozen of a tiny scalar must be counted accurately, not floored"
+        );
     }
 
     #[test]
@@ -869,22 +779,21 @@ mod tests {
 
     #[test]
     fn test_memtable_depth_limit_exact_boundary() {
-        // Test at exactly the max depth (32 levels)
+        // Issue #1625: with the iterative estimator there is no depth cap, so
+        // adding a wrapper level increases the estimate by exactly one List's
+        // overhead (16) — no discontinuity/jump to a floor at any depth.
         let mut nested_value = Value::Integer(1);
         for _ in 0..32 {
             nested_value = Value::List(vec![nested_value]);
         }
 
-        // Should handle max depth normally
         let size = Memtable::estimate_value_size(&nested_value);
-        assert!(size > 0);
+        assert_eq!(size, 32 * 16 + 4);
 
-        // Add one more level - should hit depth limit on deepest value
+        // One more wrapper: exactly +16, not a jump to any conservative floor.
         nested_value = Value::List(vec![nested_value]);
         let size_over = Memtable::estimate_value_size(&nested_value);
-
-        // Size with depth limit should be >= 1024 due to conservative estimate
-        assert!(size_over >= 1024);
+        assert_eq!(size_over, size + 16);
     }
 
     #[test]
@@ -908,22 +817,28 @@ mod tests {
     }
 
     #[test]
-    fn test_deep_wide_collection_not_undercounted() {
-        // Issue #1625: a WIDE collection parked exactly at the recursion depth
-        // cap must NOT be counted as the old flat ~1KB. Build 32 single-element
-        // wrapper lists (depths 0..31) with a 500-element list at the cap
-        // (depth 32); the cap estimate should dwarf 1KB.
-        let wide = Value::List((0..500).map(Value::Integer).collect());
+    fn test_deep_wide_collection_counted_accurately() {
+        // Issue #1625: a WIDE collection buried under many wrapper lists must be
+        // counted at its REAL byte size regardless of depth. The iterative
+        // estimator has no depth cap, so the 500 × 200-byte strings (~100KB) at
+        // the bottom are summed exactly — not collapsed to any floor.
+        let wide = Value::List((0..500).map(|_| Value::Text("y".repeat(200))).collect());
         let mut nested = wide;
         for _ in 0..32 {
             nested = Value::List(vec![nested]);
         }
 
         let size = Memtable::estimate_value_size(&nested);
-        // 500 elements * DEEP_ELEMENT_ESTIMATE floor => far larger than 1KB.
+        let real_payload = 500 * 200; // 100_000 bytes of text
         assert!(
-            size > 100 * 1024,
-            "wide collection at depth cap must not be under-counted (got {size})"
+            size >= real_payload,
+            "wide collection must count real bytes at any depth (got {size})"
+        );
+        // Accurate, not wildly inflated: real payload + bounded per-container
+        // overhead only.
+        assert!(
+            size < real_payload + 10 * 1024,
+            "estimate must be accurate, not floor-inflated (got {size})"
         );
     }
 
@@ -931,13 +846,11 @@ mod tests {
     fn test_deep_narrow_collection_large_scalar_not_undercounted() {
         // Issue #1625 (roborev finding): a deep NARROW collection wrapping a
         // large DIRECT scalar must not be systematically under-counted. Wrap a
-        // `List([Text(128KB)])` in 32 single-element lists so the inner list
-        // lands exactly at the depth cap; its Text child is a DIRECT child.
+        // `List([Text(128KB)])` in 32 single-element lists.
         //
-        // Pre-fix: the cap estimator scaled by element count × 1024, so this was
-        // counted as ~1KB (16 + 1*1024 = 1040) — small enough to slip a 64KB gate.
-        // Post-fix: the shallow per-child estimate counts the 128KB scalar at its
-        // real heap size, so the estimate is on the order of the large scalar.
+        // Pre-fix: any node past the depth cap collapsed to a ~1KB floor — small
+        // enough to slip a 64KB gate. Post-fix: the iterative estimator counts
+        // the 128KB scalar at its real heap size regardless of depth.
         let big = 128 * 1024;
         let mut nested = Value::List(vec![Value::Text("x".repeat(big))]);
         for _ in 0..32 {
@@ -949,6 +862,40 @@ mod tests {
             size >= big,
             "deep narrow collection with a large scalar must count the scalar's \
              real heap size, not the old ~1KB floor (got {size}, expected >= {big})"
+        );
+    }
+
+    #[test]
+    fn test_large_scalar_buried_below_old_cap_counted() {
+        // Issue #1625 (3rd iteration): a large scalar buried MANY levels below
+        // where the old depth cap (32) sat must be counted at real size. Wrap a
+        // 128KB text in 40 single-element lists — well past the old cap — and
+        // confirm the iterative estimator still sees the full 128KB.
+        let big = 128 * 1024;
+        let mut nested = Value::Text("z".repeat(big));
+        for _ in 0..40 {
+            nested = Value::List(vec![nested]);
+        }
+
+        let size = Memtable::estimate_value_size(&nested);
+        assert!(
+            size >= big,
+            "scalar buried below the old depth cap must be counted at real size \
+             (got {size}, expected >= {big})"
+        );
+    }
+
+    #[test]
+    fn test_pathological_node_cap_returns_usize_max() {
+        // Issue #1625: exceeding MAX_ESTIMATE_NODES must FAIL CLOSED (usize::MAX),
+        // never under-count — and never overflow or hang. A flat list of
+        // 1_000_001 integers is a single fast allocation that trips the cap.
+        let value = Value::List((0..1_000_001i32).map(Value::Integer).collect());
+        let size = Memtable::estimate_value_size(&value);
+        assert_eq!(
+            size,
+            usize::MAX,
+            "hitting the node cap must fail closed with usize::MAX (got {size})"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -68,8 +68,10 @@ impl Memtable {
     /// the decorated key from the partition key using the table schema.
     #[tracing::instrument(name = "memtable.insert", skip(self, key, mutation))]
     pub fn insert_with_key(&mut self, key: DecoratedKey, mutation: Mutation) -> Result<()> {
-        // Calculate mutation size (conservative estimate)
-        let mutation_size = Self::estimate_mutation_size(&mutation);
+        // Calculate mutation size (conservative estimate). This is the SAME
+        // computation the admission gate consults via `estimate_mutation_size`,
+        // so accounting and admission can never drift (issue #1625).
+        let mutation_size = Self::mutation_size(&mutation);
 
         // Get or create mutation list for this partition
         let mutations = self.data.entry(key).or_default();
@@ -132,6 +134,25 @@ impl Memtable {
     /// Maximum nesting depth for collection size estimation (prevents stack overflow)
     const MAX_NESTING_DEPTH: usize = 32;
 
+    /// Conservative per-element byte estimate used when the recursion depth cap
+    /// is reached (issue #1625). The cap prevents stack overflow on pathological
+    /// nesting, but the previous flat `1024`-per-value fallback systematically
+    /// UNDER-counted a wide collection sitting at the depth boundary (a
+    /// thousand-element list counted as ~1KB), letting an over-budget mutation
+    /// slip past admission. Scaling by the collection's element count keeps the
+    /// estimate non-recursive (still stack-safe) while refusing to under-count.
+    const DEEP_ELEMENT_ESTIMATE: usize = 1024;
+
+    /// Estimate the number of bytes a mutation would add to this memtable.
+    ///
+    /// Returns the SAME value that [`Memtable::insert_with_key`] adds to
+    /// `size_bytes`, so the write-engine admission gate (issue #1625) and the
+    /// running size accounting agree by construction — both funnel through the
+    /// private [`Memtable::mutation_size`] computation, so there is no drift.
+    pub(crate) fn estimate_mutation_size(&self, m: &Mutation) -> usize {
+        Self::mutation_size(m)
+    }
+
     /// Estimate the size of a mutation in bytes
     ///
     /// Conservative estimate includes:
@@ -139,7 +160,7 @@ impl Memtable {
     /// - Partition key size (key bytes)
     /// - Clustering key size (if present)
     /// - Cell operation sizes (column names + values)
-    fn estimate_mutation_size(mutation: &Mutation) -> usize {
+    fn mutation_size(mutation: &Mutation) -> usize {
         let mut size = 48; // Base struct overhead
 
         // Partition key size
@@ -176,10 +197,14 @@ impl Memtable {
     fn estimate_value_size_with_depth(value: &crate::types::Value, depth: usize) -> usize {
         use crate::types::Value;
 
-        // Prevent excessive recursion for deeply nested structures
+        // Prevent excessive recursion for deeply nested structures (stack-safety
+        // cap — MUST stay). Instead of a flat, systematically under-counting
+        // `1024` fallback (issue #1625), estimate the value's size WITHOUT
+        // recursing further: exact byte length for cheap-to-measure scalars, and
+        // an element-count-scaled conservative floor for collections so a wide
+        // collection parked at the depth boundary is not counted as ~1KB.
         if depth >= Self::MAX_NESTING_DEPTH {
-            // Return conservative estimate: assume 1KB for deeply nested value
-            return 1024;
+            return Self::estimate_value_size_at_cap(value);
         }
 
         match value {
@@ -247,6 +272,44 @@ impl Memtable {
         }
     }
 
+    /// Non-recursive size estimate used once the recursion depth cap is hit.
+    ///
+    /// Stack-safe (never recurses): scalars report their exact byte length, and
+    /// collections report a conservative floor scaled by their DIRECT element
+    /// count (`DEEP_ELEMENT_ESTIMATE` per element). This replaces the old flat
+    /// `1024` fallback so a wide collection sitting exactly at the depth cap is
+    /// no longer under-counted as ~1KB (issue #1625) — the value it returns is
+    /// large enough to trip the memtable hard-limit admission gate.
+    fn estimate_value_size_at_cap(value: &crate::types::Value) -> usize {
+        use crate::types::Value;
+
+        let per = Self::DEEP_ELEMENT_ESTIMATE;
+        match value {
+            Value::Null => 0,
+            Value::Boolean(_) | Value::TinyInt(_) => 1,
+            Value::SmallInt(_) => 2,
+            Value::Integer(_) | Value::Float32(_) | Value::Date(_) => 4,
+            Value::BigInt(_)
+            | Value::Counter(_)
+            | Value::Timestamp(_)
+            | Value::Time(_)
+            | Value::Float(_) => 8,
+            Value::Uuid(_) | Value::Duration { .. } => 16,
+            Value::Text(s) => s.len(),
+            Value::Blob(bytes) | Value::Varint(bytes) | Value::Inet(bytes) => bytes.len(),
+            Value::Decimal { scale: _, unscaled } => 4 + unscaled.len(),
+            Value::Json(json) => json.to_string().len(),
+            Value::Tombstone(_) => 24,
+            // Collections: conservative, element-count-scaled, NON-recursive.
+            Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
+                16 + items.len().saturating_mul(per)
+            }
+            Value::Map(entries) => 16 + entries.len().saturating_mul(2 * per),
+            Value::Udt(udt) => 16 + udt.fields.len().saturating_mul(per),
+            Value::Frozen(_) => 8 + per,
+        }
+    }
+
     /// Estimate the size of a cell operation
     fn estimate_operation_size(
         op: &crate::storage::write_engine::mutation::CellOperation,
@@ -282,6 +345,14 @@ impl Memtable {
             }
             CellOperation::ComplexDeletion { column, .. } => column.len() + 16,
         }
+    }
+
+    /// Test-only: force the tracked approximate size, used to exercise the
+    /// admission gate's `saturating_add` overflow guard near `usize::MAX`
+    /// (issue #1625) — a size unreachable through real inserts.
+    #[cfg(test)]
+    pub(crate) fn set_size_bytes_for_test(&mut self, size: usize) {
+        self.size_bytes = size;
     }
 
     /// Get current timestamp in microseconds since Unix epoch
@@ -746,6 +817,46 @@ mod tests {
 
         // Size with depth limit should be >= 1024 due to conservative estimate
         assert!(size_over >= 1024);
+    }
+
+    #[test]
+    fn test_estimate_mutation_size_matches_insert_accounting() {
+        // Issue #1625: the admission gate and the running size accounting must
+        // agree by construction — `estimate_mutation_size(&m)` must equal the
+        // delta `size_bytes()` gains from inserting the same mutation.
+        let mut memtable = Memtable::new();
+        let (key, mutation) = create_test_mutation(7, "some data here", Some(42));
+
+        let before = memtable.size_bytes();
+        let predicted = memtable.estimate_mutation_size(&mutation);
+        memtable.insert_with_key(key, mutation).unwrap();
+        let actual_delta = memtable.size_bytes() - before;
+
+        assert_eq!(
+            predicted, actual_delta,
+            "estimate_mutation_size must equal the size delta insert applies"
+        );
+        assert!(predicted > 0);
+    }
+
+    #[test]
+    fn test_deep_wide_collection_not_undercounted() {
+        // Issue #1625: a WIDE collection parked exactly at the recursion depth
+        // cap must NOT be counted as the old flat ~1KB. Build 32 single-element
+        // wrapper lists (depths 0..31) with a 500-element list at the cap
+        // (depth 32); the cap estimate should dwarf 1KB.
+        let wide = Value::List((0..500).map(Value::Integer).collect());
+        let mut nested = wide;
+        for _ in 0..32 {
+            nested = Value::List(vec![nested]);
+        }
+
+        let size = Memtable::estimate_value_size(&nested);
+        // 500 elements * DEEP_ELEMENT_ESTIMATE floor => far larger than 1KB.
+        assert!(
+            size > 100 * 1024,
+            "wide collection at depth cap must not be under-counted (got {size})"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -245,10 +245,7 @@ impl Memtable {
         // proportional to its element count — the DoS guard fails closed WITHOUT
         // the huge allocation (issue #1625).
         let would_exceed_cap = |visited: usize, pending: usize, incoming: usize| -> bool {
-            visited
-                .saturating_add(pending)
-                .saturating_add(incoming)
-                > Self::MAX_ESTIMATE_NODES
+            visited.saturating_add(pending).saturating_add(incoming) > Self::MAX_ESTIMATE_NODES
         };
 
         while let Some(v) = worklist.pop() {

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -134,13 +134,16 @@ impl Memtable {
     /// Maximum nesting depth for collection size estimation (prevents stack overflow)
     const MAX_NESTING_DEPTH: usize = 32;
 
-    /// Conservative per-element byte estimate used when the recursion depth cap
-    /// is reached (issue #1625). The cap prevents stack overflow on pathological
-    /// nesting, but the previous flat `1024`-per-value fallback systematically
-    /// UNDER-counted a wide collection sitting at the depth boundary (a
-    /// thousand-element list counted as ~1KB), letting an over-budget mutation
-    /// slip past admission. Scaling by the collection's element count keeps the
-    /// estimate non-recursive (still stack-safe) while refusing to under-count.
+    /// Conservative per-element byte FLOOR used when the recursion depth cap is
+    /// reached (issue #1625). The cap prevents stack overflow on pathological
+    /// nesting, but the original flat `1024`-per-value fallback systematically
+    /// UNDER-counted collections sitting at the depth boundary, letting an
+    /// over-budget mutation slip past admission. At the cap the estimator now
+    /// sums a SHALLOW per-direct-child estimate: a large direct scalar counts its
+    /// real heap size, while every element (and any nested-collection child we do
+    /// not recurse into) contributes at least this floor. That closes both the
+    /// wide-collection and the deep-narrow-wrapping-a-large-scalar undercounts
+    /// while staying non-recursive (stack-safe).
     const DEEP_ELEMENT_ESTIMATE: usize = 1024;
 
     /// Estimate the number of bytes a mutation would add to this memtable.
@@ -274,16 +277,20 @@ impl Memtable {
 
     /// Non-recursive size estimate used once the recursion depth cap is hit.
     ///
-    /// Stack-safe (never recurses): scalars report their exact byte length, and
-    /// collections report a conservative floor scaled by their DIRECT element
-    /// count (`DEEP_ELEMENT_ESTIMATE` per element). This replaces the old flat
-    /// `1024` fallback so a wide collection sitting exactly at the depth cap is
-    /// no longer under-counted as ~1KB (issue #1625) — the value it returns is
-    /// large enough to trip the memtable hard-limit admission gate.
+    /// Stack-safe (never recurses past DIRECT children): a scalar value at the
+    /// cap reports its exact byte length. A collection/map/UDT/tuple at the cap
+    /// sums a SHALLOW estimate of each direct child (see
+    /// [`shallow_child_estimate`](Self::shallow_child_estimate)) which counts a
+    /// large direct scalar child at its real heap size. This closes the
+    /// hard-limit bypass where a deep NARROW collection wrapping a large scalar
+    /// (e.g. 32 wrapper lists around `List([Text(128KB)])`) was estimated at the
+    /// old flat ~1KB and slipped past admission while retaining far more memory
+    /// (issue #1625). We still never recurse below direct children — a nested
+    /// collection child counts only the `DEEP_ELEMENT_ESTIMATE` floor — so the
+    /// depth cap stays a genuine stack-safety guard.
     fn estimate_value_size_at_cap(value: &crate::types::Value) -> usize {
         use crate::types::Value;
 
-        let per = Self::DEEP_ELEMENT_ESTIMATE;
         match value {
             Value::Null => 0,
             Value::Boolean(_) | Value::TinyInt(_) => 1,
@@ -300,14 +307,75 @@ impl Memtable {
             Value::Decimal { scale: _, unscaled } => 4 + unscaled.len(),
             Value::Json(json) => json.to_string().len(),
             Value::Tombstone(_) => 24,
-            // Collections: conservative, element-count-scaled, NON-recursive.
-            Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
-                16 + items.len().saturating_mul(per)
-            }
-            Value::Map(entries) => 16 + entries.len().saturating_mul(2 * per),
-            Value::Udt(udt) => 16 + udt.fields.len().saturating_mul(per),
-            Value::Frozen(_) => 8 + per,
+            // Collections: SHALLOW sum over DIRECT children, NON-recursive.
+            // Each direct scalar child contributes its real heap size (floored
+            // at DEEP_ELEMENT_ESTIMATE); each nested-collection child contributes
+            // only the floor (we intentionally do not recurse — stack safety).
+            Value::List(items) | Value::Set(items) | Value::Tuple(items) => items
+                .iter()
+                .map(Self::shallow_child_estimate)
+                .fold(0usize, usize::saturating_add)
+                .saturating_add(16),
+            Value::Map(entries) => entries
+                .iter()
+                .map(|(k, v)| {
+                    Self::shallow_child_estimate(k).saturating_add(Self::shallow_child_estimate(v))
+                })
+                .fold(0usize, usize::saturating_add)
+                .saturating_add(16),
+            Value::Udt(udt) => udt
+                .fields
+                .iter()
+                .map(|field| {
+                    field.name.len().saturating_add(
+                        field.value.as_ref().map_or(0, Self::shallow_child_estimate),
+                    )
+                })
+                .fold(0usize, usize::saturating_add)
+                .saturating_add(16),
+            Value::Frozen(inner) => Self::shallow_child_estimate(inner).saturating_add(8),
         }
+    }
+
+    /// Shallow (NON-recursive) size estimate for a single DIRECT child of a
+    /// value parked at the recursion depth cap (issue #1625).
+    ///
+    /// A known scalar reports its real heap size (`Text`/`Blob`/`Json`/`Varint`/
+    /// `Inet`/`Decimal` byte length, fixed widths otherwise), floored at
+    /// `DEEP_ELEMENT_ESTIMATE` so every element still counts at least the
+    /// conservative floor. A nested collection/map/UDT/tuple/frozen child is NOT
+    /// recursed into — it contributes exactly the floor — which keeps the
+    /// estimator stack-safe while ensuring a large direct scalar is no longer
+    /// systematically under-counted.
+    fn shallow_child_estimate(value: &crate::types::Value) -> usize {
+        use crate::types::Value;
+
+        let floor = Self::DEEP_ELEMENT_ESTIMATE;
+        let scalar = match value {
+            Value::Null => 0,
+            Value::Boolean(_) | Value::TinyInt(_) => 1,
+            Value::SmallInt(_) => 2,
+            Value::Integer(_) | Value::Float32(_) | Value::Date(_) => 4,
+            Value::BigInt(_)
+            | Value::Counter(_)
+            | Value::Timestamp(_)
+            | Value::Time(_)
+            | Value::Float(_) => 8,
+            Value::Uuid(_) | Value::Duration { .. } => 16,
+            Value::Text(s) => s.len(),
+            Value::Blob(bytes) | Value::Varint(bytes) | Value::Inet(bytes) => bytes.len(),
+            Value::Decimal { scale: _, unscaled } => 4usize.saturating_add(unscaled.len()),
+            Value::Json(json) => json.to_string().len(),
+            Value::Tombstone(_) => 24,
+            // Nested collections: do NOT recurse (stack safety) — count the floor.
+            Value::List(_)
+            | Value::Set(_)
+            | Value::Tuple(_)
+            | Value::Map(_)
+            | Value::Udt(_)
+            | Value::Frozen(_) => 0,
+        };
+        scalar.max(floor)
     }
 
     /// Estimate the size of a cell operation
@@ -856,6 +924,31 @@ mod tests {
         assert!(
             size > 100 * 1024,
             "wide collection at depth cap must not be under-counted (got {size})"
+        );
+    }
+
+    #[test]
+    fn test_deep_narrow_collection_large_scalar_not_undercounted() {
+        // Issue #1625 (roborev finding): a deep NARROW collection wrapping a
+        // large DIRECT scalar must not be systematically under-counted. Wrap a
+        // `List([Text(128KB)])` in 32 single-element lists so the inner list
+        // lands exactly at the depth cap; its Text child is a DIRECT child.
+        //
+        // Pre-fix: the cap estimator scaled by element count × 1024, so this was
+        // counted as ~1KB (16 + 1*1024 = 1040) — small enough to slip a 64KB gate.
+        // Post-fix: the shallow per-child estimate counts the 128KB scalar at its
+        // real heap size, so the estimate is on the order of the large scalar.
+        let big = 128 * 1024;
+        let mut nested = Value::List(vec![Value::Text("x".repeat(big))]);
+        for _ in 0..32 {
+            nested = Value::List(vec![nested]);
+        }
+
+        let size = Memtable::estimate_value_size(&nested);
+        assert!(
+            size >= big,
+            "deep narrow collection with a large scalar must count the scalar's \
+             real heap size, not the old ~1KB floor (got {size}, expected >= {big})"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -67,6 +67,10 @@ mod stats;
 mod sweep;
 #[cfg(all(test, feature = "write-support"))]
 mod test_support;
+// Issue #1625: honest memtable hard-limit admission tests live in a sibling
+// module to avoid growing the already-oversized `mod.rs` (epic #1116/#1135).
+#[cfg(all(test, feature = "write-support"))]
+mod admission_tests;
 
 #[cfg(feature = "write-support")]
 pub use maintenance::MaintenanceReport;
@@ -840,14 +844,9 @@ impl WriteEngine {
 
         reject_counter_cells(&mutation)?;
 
-        // Check hard limit before accepting write
-        if self.memtable.size_bytes() >= self.config.memtable_hard_limit {
-            return Err(Error::Storage(format!(
-                "Memtable at hard limit ({} bytes >= {} bytes). Flush required before accepting more writes.",
-                self.memtable.size_bytes(),
-                self.config.memtable_hard_limit
-            )));
-        }
+        // Honest hard-limit admission: gate on current size + the INCOMING
+        // mutation's estimated size, and reject a lone jumbo write (issue #1625).
+        self.check_admission(&mutation)?;
 
         // 1. Append to WAL (durability) — skipped when Durability::Disabled
         if self.config.durability == Durability::SyncEachWrite {
@@ -866,6 +865,48 @@ impl WriteEngine {
         self.rows_written += 1;
         crate::observability::add_counter(crate::observability::catalog::WRITE_MUTATIONS, 1, &[]);
         self.record_memtable_gauges();
+
+        Ok(())
+    }
+
+    /// Honest memtable hard-limit admission (issue #1625).
+    ///
+    /// The pre-#1625 check compared only the *current* memtable size against the
+    /// hard limit — it never measured the incoming mutation, so (a) a single
+    /// jumbo mutation could be admitted into an empty memtable and blow straight
+    /// past the limit, and (b) a mutation could push a nearly-full memtable over
+    /// the limit before the next write was rejected. This gate measures the
+    /// incoming mutation with the SAME estimator the memtable uses for
+    /// accounting, then:
+    ///
+    /// 1. Rejects any single mutation whose estimate alone exceeds the hard
+    ///    limit (the ceiling for one mutation is the hard limit itself) with a
+    ///    distinct error, so a lone jumbo write can never be admitted.
+    /// 2. Rejects the write when `current_size + incoming` would exceed the hard
+    ///    limit (`saturating_add`, so the sum can never overflow `usize`).
+    fn check_admission(&self, mutation: &Mutation) -> Result<()> {
+        let hard_limit = self.config.memtable_hard_limit;
+        let incoming = self.memtable.estimate_mutation_size(mutation);
+
+        // (1) Single-mutation ceiling: one mutation may not exceed the hard
+        // limit on its own, regardless of how empty the memtable is.
+        if incoming > hard_limit {
+            return Err(Error::Storage(format!(
+                "Write rejected: single mutation estimated at {incoming} bytes exceeds \
+                 memtable hard limit {hard_limit} bytes (a single mutation may not exceed \
+                 the hard limit)"
+            )));
+        }
+
+        // (2) Projected sum: never admit a write that would push the memtable
+        // over the hard limit.
+        let projected = self.memtable.size_bytes().saturating_add(incoming);
+        if projected > hard_limit {
+            return Err(Error::Storage(format!(
+                "Write rejected: memtable {} + mutation {incoming} would exceed hard limit {hard_limit}",
+                self.memtable.size_bytes()
+            )));
+        }
 
         Ok(())
     }
@@ -904,14 +945,9 @@ impl WriteEngine {
 
         reject_counter_cells(&mutation)?;
 
-        // Check hard limit before accepting write
-        if self.memtable.size_bytes() >= self.config.memtable_hard_limit {
-            return Err(Error::Storage(format!(
-                "Memtable at hard limit ({} bytes >= {} bytes). Flush required before accepting more writes.",
-                self.memtable.size_bytes(),
-                self.config.memtable_hard_limit
-            )));
-        }
+        // Honest hard-limit admission: gate on current size + the INCOMING
+        // mutation's estimated size, and reject a lone jumbo write (issue #1625).
+        self.check_admission(&mutation)?;
 
         // 1. Append to WAL (durability) — skipped when Durability::Disabled
         if self.config.durability == Durability::SyncEachWrite {

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -888,6 +888,19 @@ impl WriteEngine {
         let hard_limit = self.config.memtable_hard_limit;
         let incoming = self.memtable.estimate_mutation_size(mutation);
 
+        // (0) Fail-closed sentinel: the estimator returns `usize::MAX` when a
+        // mutation is pathological/unmeasurable (node-cap hit). Reject it
+        // EXPLICITLY and unconditionally — a `>` comparison against a
+        // configurable `hard_limit == usize::MAX` would otherwise be false and
+        // admit the very mutation the sentinel is meant to fence off.
+        if incoming == usize::MAX {
+            return Err(Error::Storage(
+                "Write rejected: mutation size could not be bounded (estimator \
+                 fail-closed sentinel); refusing admission"
+                    .to_string(),
+            ));
+        }
+
         // (1) Single-mutation ceiling: one mutation may not exceed the hard
         // limit on its own, regardless of how empty the memtable is.
         if incoming > hard_limit {

--- a/cqlite-core/tests/test_issue_1625_estimator_worklist_bound.rs
+++ b/cqlite-core/tests/test_issue_1625_estimator_worklist_bound.rs
@@ -1,0 +1,134 @@
+//! Bounded-worklist regression guard for Issue #1625 (roborev finding 2).
+//!
+//! The iterative size estimator (`Memtable::estimate_value_size`) fails closed
+//! at `MAX_ESTIMATE_NODES` nodes. The finding: the node cap was checked only when
+//! POPPING a node, but every container arm enqueued ALL of its children up front
+//! (`worklist.extend(...)` / per-entry `push`). A single flat collection with far
+//! more than `MAX_ESTIMATE_NODES` elements therefore allocated a reference
+//! worklist proportional to its element count BEFORE the estimator failed closed
+//! — weakening the DoS guard.
+//!
+//! The fix checks `visited + pending + incoming` against the cap BEFORE enqueuing
+//! any children and returns `usize::MAX` (fail closed) without growing the
+//! worklist. This test proves the worklist stays bounded by comparing two inserts
+//! that differ ONLY in how many children the estimator would enqueue:
+//!
+//!   * UNDER-cap flat list (fully enqueued): the estimator grows its worklist to
+//!     ~N references (log2(N) reallocations).
+//!   * OVER-cap flat list (fails closed at the enqueue check): the estimator
+//!     never grows its worklist.
+//!
+//! `Memtable::insert_with_key` performs NO serialization, so the estimator's
+//! worklist is the only per-insert allocation that scales with the collection.
+//! The per-insert BTreeMap/Vec/tracing overhead is constant and cancels in the
+//! comparison, so the over-cap insert must allocate STRICTLY FEWER times than the
+//! under-cap insert. Pre-fix, both grow the worklist and the counts match.
+//!
+//! This file is its own test binary with exactly one `#[test]`, so the global
+//! counter observes allocations only from this test's thread.
+
+#![cfg(feature = "write-support")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use cqlite_core::storage::write_engine::{
+    CellOperation, DecoratedKey, Memtable, Mutation, PartitionKey, TableId,
+};
+use cqlite_core::types::Value;
+
+struct CountingAlloc;
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static COUNTING: AtomicBool = AtomicBool::new(false);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+/// Mirror of the private `Memtable::MAX_ESTIMATE_NODES` (1_000_000).
+const MAX_ESTIMATE_NODES: usize = 1_000_000;
+
+fn make_mutation(list_len: usize) -> Mutation {
+    let value = Value::List((0..list_len as i32).map(Value::Integer).collect());
+    let ops = vec![CellOperation::Write {
+        column: "big".to_string(),
+        value,
+    }];
+    Mutation::new(
+        TableId::new("ks", "t"),
+        PartitionKey::single("id", Value::Integer(1)),
+        None,
+        ops,
+        1,
+        None,
+    )
+}
+
+/// Insert one mutation into a fresh single-partition memtable and return the
+/// number of heap allocations performed inside `insert_with_key`.
+fn allocs_for_insert(m: Mutation) -> (usize, usize) {
+    // Build everything (key, memtable) BEFORE the counting window so only the
+    // work inside `insert_with_key` — including the estimator — is measured.
+    let mut memtable = Memtable::new();
+    let key = DecoratedKey::from_key_bytes(vec![0, 0, 0, 1]).expect("key");
+
+    COUNTING.store(true, Ordering::Relaxed);
+    let baseline = ALLOCS.load(Ordering::Relaxed);
+    memtable.insert_with_key(key, m).expect("insert");
+    let allocs = ALLOCS.load(Ordering::Relaxed) - baseline;
+    COUNTING.store(false, Ordering::Relaxed);
+
+    (allocs, memtable.size_bytes())
+}
+
+#[test]
+fn estimator_worklist_bounded_at_node_cap() {
+    // UNDER cap: the estimator enqueues all ~1M children (worklist grows).
+    let (under_allocs, under_size) = allocs_for_insert(make_mutation(MAX_ESTIMATE_NODES - 1));
+    // A finite (non-saturated) estimate: the value fit under the cap.
+    assert_ne!(
+        under_size,
+        usize::MAX,
+        "under-cap insert should produce a finite ledger size"
+    );
+
+    // OVER cap: the estimator fails closed at the enqueue check WITHOUT growing
+    // the worklist, so the ledger saturates to usize::MAX.
+    let (over_allocs, over_size) = allocs_for_insert(make_mutation(MAX_ESTIMATE_NODES + 5));
+    assert_eq!(
+        over_size,
+        usize::MAX,
+        "over-cap insert must fail closed (usize::MAX)"
+    );
+
+    // The ONLY allocation difference between the two inserts is the estimator's
+    // worklist growth. Failing closed BEFORE enqueuing must allocate strictly
+    // fewer times than fully enqueuing ~1M children. Pre-fix these are equal
+    // (both grow the worklist); post-fix the over-cap path grows it not at all.
+    assert!(
+        over_allocs < under_allocs,
+        "issue #1625: over-cap insert allocated {over_allocs} times, not fewer \
+         than the under-cap insert's {under_allocs} — the estimator is still \
+         growing its worklist past the node cap before failing closed"
+    );
+}


### PR DESCRIPTION
Closes #1625 (P1).

Memtable admission now gates on projected size (`current + estimate(mutation)`) and rejects any single mutation whose estimate alone exceeds the hard limit — closing the single-jumbo-mutation overshoot. The recursive depth-capped size estimator is replaced by a **bounded iterative traversal** (heap worklist, no stack-overflow, no depth cap) that counts all descendants' real sizes and **fails closed** (`usize::MAX`, rejected unconditionally) at a 1M-node cap. Worklist is a stack-backed SmallVec (zero heap alloc for normal writes — #1660 budget holds); ledger accounting is overflow-safe (saturating).

**Quality bar (auto-merge on green):**
- `agent-gate.sh`: **PASS** (full gate, solo run)
- rust-reviewer: clean
- roborev (codex): correctness converged over 5 rounds (depth-cap undercount → iterative estimator → alloc budget → overflow/eager-cap → fail-closed sentinel, all fixed). Remaining Medium is a PERF-only double-estimation deferred to **#1956**.

Tests: single-jumbo reject, projected-sum reject, deep-narrow + buried-scalar (2/3+ levels) reject, node-cap fail-closed (no hang/overflow), sentinel reject under hard_limit==usize::MAX, saturating accounting, #1660 alloc budget.