### PR TITLE
feat(#1340): typed inner-UDT decode for frozen-UDT elements in frozen collections

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
@@ -856,37 +856,36 @@ impl V5CompressedLegacyParser {
                 );
 
                 // Issue #1340: extract the AUTHORITATIVE marshal element type(s)
-                // ONCE per column from the on-disk SerializationHeader marshal type
-                // (`header_type`). When an element is a `frozen<UDT>`, threading the
-                // marshal type lets it decode to a typed `Value::Frozen(Value::Udt)`
-                // registry-free (precedence: header marshal → registry → Blob, no
-                // byte-pattern inference — no-heuristics #28). Parsed here, not in
-                // the per-element loop, to keep the hot path allocation-free.
+                // from the on-disk SerializationHeader marshal type (`header_type`).
+                // When an element is a `frozen<UDT>`, threading the marshal type lets
+                // it decode to a typed `Value::Frozen(Value::Udt)` registry-free
+                // (precedence: header marshal → registry → Blob, no byte-pattern
+                // inference — no-heuristics #28). Extracted once per frozen cell
+                // (before the element loop); the result borrows from `header_type`,
+                // so the per-element loop is allocation-free.
                 let marshal_elems = header_type.and_then(Self::extract_marshal_collection_elements);
+                // Shared for list & set (both are `Sequence`): the borrowed element
+                // marshal type, or `None` for a map / absent / mismatched marshal.
+                let sequence_marshal_elem = match &marshal_elems {
+                    Some(MarshalCollectionElements::Sequence(m)) => Some(*m),
+                    _ => None,
+                };
 
                 // Route to appropriate frozen collection parser
                 let (inner_value, new_offset) = if inner_type.starts_with("list<") {
                     let schema_elem = self.extract_collection_element_type(&inner_type, "list")?;
-                    let marshal_elem = match &marshal_elems {
-                        Some(MarshalCollectionElements::Sequence(m)) => Some(m.as_str()),
-                        _ => None,
-                    };
-                    let element_type = Self::prefer_udt_marshal_element(marshal_elem, &schema_elem);
+                    let element_type =
+                        Self::prefer_udt_marshal_element(sequence_marshal_elem, &schema_elem);
                     self.parse_frozen_list_value(data, offset, element_type, column, _reader)?
                 } else if inner_type.starts_with("set<") {
                     let schema_elem = self.extract_collection_element_type(&inner_type, "set")?;
-                    let marshal_elem = match &marshal_elems {
-                        Some(MarshalCollectionElements::Sequence(m)) => Some(m.as_str()),
-                        _ => None,
-                    };
-                    let element_type = Self::prefer_udt_marshal_element(marshal_elem, &schema_elem);
+                    let element_type =
+                        Self::prefer_udt_marshal_element(sequence_marshal_elem, &schema_elem);
                     self.parse_frozen_set_value(data, offset, element_type, column, _reader)?
                 } else if inner_type.starts_with("map<") {
                     let (schema_key, schema_val) = self.extract_map_types(&inner_type)?;
                     let (marshal_key, marshal_val) = match &marshal_elems {
-                        Some(MarshalCollectionElements::Map(k, v)) => {
-                            (Some(k.as_str()), Some(v.as_str()))
-                        }
+                        Some(MarshalCollectionElements::Map(k, v)) => (Some(*k), Some(*v)),
                         _ => (None, None),
                     };
                     let key_type = Self::prefer_udt_marshal_element(marshal_key, &schema_key);

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use super::marshal_element::MarshalCollectionElements;
+
 impl V5CompressedLegacyParser {
     /// Parse a single cell value WITHOUT column name (schema-order format)
     ///
@@ -853,22 +855,47 @@ impl V5CompressedLegacyParser {
                     inner_type
                 );
 
+                // Issue #1340: extract the AUTHORITATIVE marshal element type(s)
+                // ONCE per column from the on-disk SerializationHeader marshal type
+                // (`header_type`). When an element is a `frozen<UDT>`, threading the
+                // marshal type lets it decode to a typed `Value::Frozen(Value::Udt)`
+                // registry-free (precedence: header marshal → registry → Blob, no
+                // byte-pattern inference — no-heuristics #28). Parsed here, not in
+                // the per-element loop, to keep the hot path allocation-free.
+                let marshal_elems =
+                    header_type.and_then(Self::extract_marshal_collection_elements);
+
                 // Route to appropriate frozen collection parser
                 let (inner_value, new_offset) = if inner_type.starts_with("list<") {
-                    let element_type = self.extract_collection_element_type(&inner_type, "list")?;
-                    self.parse_frozen_list_value(data, offset, &element_type, column, _reader)?
+                    let schema_elem = self.extract_collection_element_type(&inner_type, "list")?;
+                    let marshal_elem = match &marshal_elems {
+                        Some(MarshalCollectionElements::Sequence(m)) => Some(m.as_str()),
+                        _ => None,
+                    };
+                    let element_type =
+                        Self::prefer_udt_marshal_element(marshal_elem, &schema_elem);
+                    self.parse_frozen_list_value(data, offset, element_type, column, _reader)?
                 } else if inner_type.starts_with("set<") {
-                    let element_type = self.extract_collection_element_type(&inner_type, "set")?;
-                    self.parse_frozen_set_value(data, offset, &element_type, column, _reader)?
+                    let schema_elem = self.extract_collection_element_type(&inner_type, "set")?;
+                    let marshal_elem = match &marshal_elems {
+                        Some(MarshalCollectionElements::Sequence(m)) => Some(m.as_str()),
+                        _ => None,
+                    };
+                    let element_type =
+                        Self::prefer_udt_marshal_element(marshal_elem, &schema_elem);
+                    self.parse_frozen_set_value(data, offset, element_type, column, _reader)?
                 } else if inner_type.starts_with("map<") {
-                    let (key_type, value_type) = self.extract_map_types(&inner_type)?;
+                    let (schema_key, schema_val) = self.extract_map_types(&inner_type)?;
+                    let (marshal_key, marshal_val) = match &marshal_elems {
+                        Some(MarshalCollectionElements::Map(k, v)) => {
+                            (Some(k.as_str()), Some(v.as_str()))
+                        }
+                        _ => (None, None),
+                    };
+                    let key_type = Self::prefer_udt_marshal_element(marshal_key, &schema_key);
+                    let value_type = Self::prefer_udt_marshal_element(marshal_val, &schema_val);
                     self.parse_frozen_map_value(
-                        data,
-                        offset,
-                        &key_type,
-                        &value_type,
-                        column,
-                        _reader,
+                        data, offset, key_type, value_type, column, _reader,
                     )?
                 } else if Self::is_udt_type(&column.data_type) {
                     // Frozen UDT - parse using UDT parser

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
@@ -862,8 +862,7 @@ impl V5CompressedLegacyParser {
                 // registry-free (precedence: header marshal → registry → Blob, no
                 // byte-pattern inference — no-heuristics #28). Parsed here, not in
                 // the per-element loop, to keep the hot path allocation-free.
-                let marshal_elems =
-                    header_type.and_then(Self::extract_marshal_collection_elements);
+                let marshal_elems = header_type.and_then(Self::extract_marshal_collection_elements);
 
                 // Route to appropriate frozen collection parser
                 let (inner_value, new_offset) = if inner_type.starts_with("list<") {
@@ -872,8 +871,7 @@ impl V5CompressedLegacyParser {
                         Some(MarshalCollectionElements::Sequence(m)) => Some(m.as_str()),
                         _ => None,
                     };
-                    let element_type =
-                        Self::prefer_udt_marshal_element(marshal_elem, &schema_elem);
+                    let element_type = Self::prefer_udt_marshal_element(marshal_elem, &schema_elem);
                     self.parse_frozen_list_value(data, offset, element_type, column, _reader)?
                 } else if inner_type.starts_with("set<") {
                     let schema_elem = self.extract_collection_element_type(&inner_type, "set")?;
@@ -881,8 +879,7 @@ impl V5CompressedLegacyParser {
                         Some(MarshalCollectionElements::Sequence(m)) => Some(m.as_str()),
                         _ => None,
                     };
-                    let element_type =
-                        Self::prefer_udt_marshal_element(marshal_elem, &schema_elem);
+                    let element_type = Self::prefer_udt_marshal_element(marshal_elem, &schema_elem);
                     self.parse_frozen_set_value(data, offset, element_type, column, _reader)?
                 } else if inner_type.starts_with("map<") {
                     let (schema_key, schema_val) = self.extract_map_types(&inner_type)?;

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/marshal_element.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/marshal_element.rs
@@ -260,6 +260,20 @@ mod tests {
     }
 
     #[test]
+    fn unresolvable_inner_type_decodes_to_blob_no_panic() {
+        // Spec Req 1 scenario 4 (no-heuristics #28): with NO header marshal type
+        // and NO wired registry, an unresolvable inner UDT short-name must stay an
+        // opaque `Value::Blob` carrying the exact bytes — never a byte-pattern
+        // guess, never a panic.
+        let parser = V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, None);
+        let bytes = [0xDE, 0xAD, 0xBE, 0xEF];
+        let val = parser
+            .parse_value_from_raw_bytes(&bytes, "some_unregistered_udt", "col", 0)
+            .expect("unresolved UDT must not error");
+        assert_eq!(val, Value::Blob(bytes.to_vec()));
+    }
+
+    #[test]
     fn prefer_marshal_only_for_udt_elements() {
         let udt = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,61))";
         // UDT-bearing marshal wins over the schema short form.

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/marshal_element.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/marshal_element.rs
@@ -20,12 +20,15 @@
 use super::*;
 
 /// Marshal element type(s) extracted from a frozen collection's marshal type.
+///
+/// Borrows directly from the input `header_type` str (no owned `String`s) so the
+/// per-cell frozen-decode path stays allocation-free (<128MB budget).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum MarshalCollectionElements {
+pub(super) enum MarshalCollectionElements<'a> {
     /// `ListType(X)` / `SetType(X)` element marshal type `X`.
-    Sequence(String),
+    Sequence(&'a str),
     /// `MapType(K, V)` key and value marshal types.
-    Map(String, String),
+    Map(&'a str, &'a str),
 }
 
 const FROZEN_LOWER: &str = "org.apache.cassandra.db.marshal.frozentype(";
@@ -98,11 +101,11 @@ impl V5CompressedLegacyParser {
     /// panics — for any non-collection or malformed marshal string, so the caller
     /// falls back to the CQL short form.
     ///
-    /// Parse this ONCE per column (not per element): the per-element hot loop must
-    /// not gain allocations (<128MB budget).
+    /// Parse this ONCE per frozen cell (not per element): the result borrows from
+    /// `header_type`, so the per-element hot loop gains no allocations (<128MB budget).
     pub(super) fn extract_marshal_collection_elements(
         header_type: &str,
-    ) -> Option<MarshalCollectionElements> {
+    ) -> Option<MarshalCollectionElements<'_>> {
         let s = header_type.trim();
         // Strip at most one outer FrozenType(...) wrapper (a frozen collection
         // column's header is `FrozenType(ListType(...))` etc.); tolerate a bare
@@ -112,14 +115,11 @@ impl V5CompressedLegacyParser {
         if let Some(elem) =
             balanced_inner(inner, LIST_LOWER).or_else(|| balanced_inner(inner, SET_LOWER))
         {
-            return Some(MarshalCollectionElements::Sequence(elem.trim().to_string()));
+            return Some(MarshalCollectionElements::Sequence(elem.trim()));
         }
         if let Some(kv) = balanced_inner(inner, MAP_LOWER) {
             let (k, v) = split_top_level_comma(kv)?;
-            return Some(MarshalCollectionElements::Map(
-                k.trim().to_string(),
-                v.trim().to_string(),
-            ));
+            return Some(MarshalCollectionElements::Map(k.trim(), v.trim()));
         }
         None
     }
@@ -153,7 +153,7 @@ mod tests {
         assert_eq!(
             P::extract_marshal_collection_elements(ht),
             Some(MarshalCollectionElements::Sequence(
-                "org.apache.cassandra.db.marshal.Int32Type".to_string()
+                "org.apache.cassandra.db.marshal.Int32Type"
             ))
         );
     }
@@ -164,7 +164,7 @@ mod tests {
         assert_eq!(
             P::extract_marshal_collection_elements(ht),
             Some(MarshalCollectionElements::Sequence(
-                "org.apache.cassandra.db.marshal.UTF8Type".to_string()
+                "org.apache.cassandra.db.marshal.UTF8Type"
             ))
         );
     }
@@ -177,7 +177,7 @@ mod tests {
         assert_eq!(
             P::extract_marshal_collection_elements(ht),
             Some(MarshalCollectionElements::Sequence(
-                "org.apache.cassandra.db.marshal.Int32Type".to_string()
+                "org.apache.cassandra.db.marshal.Int32Type"
             ))
         );
     }
@@ -191,7 +191,7 @@ mod tests {
             MarshalCollectionElements::Map(k, v) => {
                 assert_eq!(k, "org.apache.cassandra.db.marshal.UTF8Type");
                 assert!(
-                    P::is_udt_type(&v),
+                    P::is_udt_type(v),
                     "map value marshal must carry UserType: {v}"
                 );
                 // The comma INSIDE the value's UserType(...) must NOT split the pair.
@@ -208,7 +208,7 @@ mod tests {
         let got = P::extract_marshal_collection_elements(ht).expect("list elements");
         match got {
             MarshalCollectionElements::Sequence(elem) => {
-                assert!(P::is_udt_type(&elem), "element marshal must carry UserType");
+                assert!(P::is_udt_type(elem), "element marshal must carry UserType");
                 assert!(elem.starts_with("org.apache.cassandra.db.marshal.FrozenType("));
             }
             other => panic!("expected Sequence, got {other:?}"),
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(
             P::extract_marshal_collection_elements(ht),
             Some(MarshalCollectionElements::Sequence(
-                "org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type)".to_string()
+                "org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type)"
             ))
         );
     }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/marshal_element.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/marshal_element.rs
@@ -172,7 +172,8 @@ mod tests {
     #[test]
     fn bare_listtype_without_frozen_wrapper() {
         // Tolerate a header that is not wrapped in FrozenType(...).
-        let ht = "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)";
+        let ht =
+            "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)";
         assert_eq!(
             P::extract_marshal_collection_elements(ht),
             Some(MarshalCollectionElements::Sequence(
@@ -251,7 +252,10 @@ mod tests {
     #[test]
     fn empty_and_garbage_return_none() {
         assert_eq!(P::extract_marshal_collection_elements(""), None);
-        assert_eq!(P::extract_marshal_collection_elements("not a marshal type"), None);
+        assert_eq!(
+            P::extract_marshal_collection_elements("not a marshal type"),
+            None
+        );
         assert_eq!(P::extract_marshal_collection_elements("ListType("), None);
     }
 
@@ -259,7 +263,10 @@ mod tests {
     fn prefer_marshal_only_for_udt_elements() {
         let udt = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,61))";
         // UDT-bearing marshal wins over the schema short form.
-        assert_eq!(P::prefer_udt_marshal_element(Some(udt), "frozen<person>"), udt);
+        assert_eq!(
+            P::prefer_udt_marshal_element(Some(udt), "frozen<person>"),
+            udt
+        );
         // Non-UDT marshal (primitive) keeps the schema short form (byte-parity path).
         assert_eq!(
             P::prefer_udt_marshal_element(Some("org.apache.cassandra.db.marshal.Int32Type"), "int"),

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/marshal_element.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/marshal_element.rs
@@ -1,0 +1,271 @@
+//! Marshal collection-element type extraction (issue #1340).
+//!
+//! A `frozen<collection>` column's authoritative on-disk SerializationHeader
+//! marshal type (`RowColumnResolution.header_type`) carries the full element type
+//! for the collection, e.g. `frozen<list<frozen<person>>>` is written as
+//! `FrozenType(ListType(FrozenType(UserType(ks,person,field-types...))))`. The
+//! query/compaction decoders route a frozen collection through a per-element
+//! decoder keyed on the CQL short form (`frozen<person>`), which cannot resolve
+//! the inner UDT's fields without a wired `UdtRegistry`. Threading the marshal
+//! element type down lets an inner `frozen<UDT>` decode to a typed
+//! `Value::Frozen(Value::Udt(..))` from the file's OWN header — the most
+//! authoritative metadata, exactly what the no-heuristics mandate (#28) asks for.
+//!
+//! This module owns the small paren-aware extractor that peels the outer
+//! `FrozenType(...)` wrapper and pulls the `ListType`/`SetType` element type or
+//! the `MapType` key/value types out of the marshal string. It NEVER panics on a
+//! malformed marshal string — it returns `None` so callers fall back to the CQL
+//! short form (then the registry, then an opaque `Value::Blob`).
+
+use super::*;
+
+/// Marshal element type(s) extracted from a frozen collection's marshal type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum MarshalCollectionElements {
+    /// `ListType(X)` / `SetType(X)` element marshal type `X`.
+    Sequence(String),
+    /// `MapType(K, V)` key and value marshal types.
+    Map(String, String),
+}
+
+const FROZEN_LOWER: &str = "org.apache.cassandra.db.marshal.frozentype(";
+const LIST_LOWER: &str = "org.apache.cassandra.db.marshal.listtype(";
+const SET_LOWER: &str = "org.apache.cassandra.db.marshal.settype(";
+const MAP_LOWER: &str = "org.apache.cassandra.db.marshal.maptype(";
+
+/// If `s` (case-insensitively) starts with `prefix_lower` — which MUST end in the
+/// opening `(` — and the paren opened by that prefix is closed by the LAST byte of
+/// `s`, return the balanced inner content (original case). Returns `None` for any
+/// prefix mismatch, unbalanced parens, or trailing bytes after the matching close.
+/// Never panics.
+fn balanced_inner<'a>(s: &'a str, prefix_lower: &str) -> Option<&'a str> {
+    let head = s.get(..prefix_lower.len())?;
+    if !head.eq_ignore_ascii_case(prefix_lower) {
+        return None;
+    }
+    let bytes = s.as_bytes();
+    let inner_start = prefix_lower.len();
+    // The prefix's own `(` is already open, so start at depth 1.
+    let mut depth: usize = 1;
+    let mut i = inner_start;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return if i == bytes.len() - 1 {
+                        Some(&s[inner_start..i])
+                    } else {
+                        // Trailing bytes after the matching close: not a clean
+                        // single top-level type — reject rather than guess.
+                        None
+                    };
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Split a `MapType` inner (`K, V`) at the first depth-0 comma, honoring both
+/// paren `()` and angle `<>` nesting. Returns `None` if there is no top-level
+/// comma. Never panics.
+fn split_top_level_comma(inner: &str) -> Option<(&str, &str)> {
+    let mut depth: usize = 0;
+    for (i, ch) in inner.char_indices() {
+        match ch {
+            '(' | '<' => depth += 1,
+            ')' | '>' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                return Some((&inner[..i], &inner[i + 1..]));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+impl V5CompressedLegacyParser {
+    /// Extract the marshal element type(s) for a frozen collection from the
+    /// column's authoritative SerializationHeader marshal type (issue #1340).
+    ///
+    /// Peels at most one leading `FrozenType(...)` wrapper, then matches
+    /// `ListType`/`SetType` (→ [`MarshalCollectionElements::Sequence`]) or
+    /// `MapType` (→ [`MarshalCollectionElements::Map`]). Returns `None` — never
+    /// panics — for any non-collection or malformed marshal string, so the caller
+    /// falls back to the CQL short form.
+    ///
+    /// Parse this ONCE per column (not per element): the per-element hot loop must
+    /// not gain allocations (<128MB budget).
+    pub(super) fn extract_marshal_collection_elements(
+        header_type: &str,
+    ) -> Option<MarshalCollectionElements> {
+        let s = header_type.trim();
+        // Strip at most one outer FrozenType(...) wrapper (a frozen collection
+        // column's header is `FrozenType(ListType(...))` etc.); tolerate a bare
+        // `ListType(...)` too.
+        let inner = balanced_inner(s, FROZEN_LOWER).map(str::trim).unwrap_or(s);
+
+        if let Some(elem) =
+            balanced_inner(inner, LIST_LOWER).or_else(|| balanced_inner(inner, SET_LOWER))
+        {
+            return Some(MarshalCollectionElements::Sequence(elem.trim().to_string()));
+        }
+        if let Some(kv) = balanced_inner(inner, MAP_LOWER) {
+            let (k, v) = split_top_level_comma(kv)?;
+            return Some(MarshalCollectionElements::Map(
+                k.trim().to_string(),
+                v.trim().to_string(),
+            ));
+        }
+        None
+    }
+
+    /// Pick the element type to decode with, honoring the no-heuristics precedence
+    /// (issue #28): prefer the authoritative marshal element type ONLY when it is a
+    /// UDT-bearing type (`UserType(...)` at any nesting), otherwise keep the CQL
+    /// short form (which already decodes every primitive/collection element and
+    /// preserves the existing byte-parity behavior). The registry and `Value::Blob`
+    /// fallbacks live downstream in `parse_value_from_raw_bytes`.
+    pub(super) fn prefer_udt_marshal_element<'a>(
+        marshal: Option<&'a str>,
+        schema_short: &'a str,
+    ) -> &'a str {
+        match marshal {
+            Some(m) if Self::is_udt_type(m) => m,
+            _ => schema_short,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type P = V5CompressedLegacyParser;
+
+    #[test]
+    fn list_marshal_element_extracted() {
+        let ht = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type))";
+        assert_eq!(
+            P::extract_marshal_collection_elements(ht),
+            Some(MarshalCollectionElements::Sequence(
+                "org.apache.cassandra.db.marshal.Int32Type".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn set_marshal_element_extracted() {
+        let ht = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type))";
+        assert_eq!(
+            P::extract_marshal_collection_elements(ht),
+            Some(MarshalCollectionElements::Sequence(
+                "org.apache.cassandra.db.marshal.UTF8Type".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn bare_listtype_without_frozen_wrapper() {
+        // Tolerate a header that is not wrapped in FrozenType(...).
+        let ht = "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)";
+        assert_eq!(
+            P::extract_marshal_collection_elements(ht),
+            Some(MarshalCollectionElements::Sequence(
+                "org.apache.cassandra.db.marshal.Int32Type".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn map_marshal_key_value_extracted() {
+        // frozen<map<text, frozen<address>>>
+        let ht = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,61,66:org.apache.cassandra.db.marshal.UTF8Type))))";
+        let got = P::extract_marshal_collection_elements(ht).expect("map elements");
+        match got {
+            MarshalCollectionElements::Map(k, v) => {
+                assert_eq!(k, "org.apache.cassandra.db.marshal.UTF8Type");
+                assert!(
+                    P::is_udt_type(&v),
+                    "map value marshal must carry UserType: {v}"
+                );
+                // The comma INSIDE the value's UserType(...) must NOT split the pair.
+                assert!(v.starts_with("org.apache.cassandra.db.marshal.FrozenType("));
+            }
+            other => panic!("expected Map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_frozen_list_of_frozen_udt() {
+        // frozen<list<frozen<person>>> — the #1240 `lp` column shape.
+        let ht = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,706572736f6e,66:org.apache.cassandra.db.marshal.UTF8Type))))";
+        let got = P::extract_marshal_collection_elements(ht).expect("list elements");
+        match got {
+            MarshalCollectionElements::Sequence(elem) => {
+                assert!(P::is_udt_type(&elem), "element marshal must carry UserType");
+                assert!(elem.starts_with("org.apache.cassandra.db.marshal.FrozenType("));
+            }
+            other => panic!("expected Sequence, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tuple_in_collection_returns_tuple_marshal() {
+        let ht = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type)))";
+        assert_eq!(
+            P::extract_marshal_collection_elements(ht),
+            Some(MarshalCollectionElements::Sequence(
+                "org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type)".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn malformed_unbalanced_parens_return_none() {
+        // Missing the closing paren — must NOT panic, must return None.
+        let ht = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type";
+        assert_eq!(P::extract_marshal_collection_elements(ht), None);
+    }
+
+    #[test]
+    fn non_collection_marshal_returns_none() {
+        // A top-level frozen UDT is NOT a collection — the collection extractor
+        // must decline it (that column takes the top-level frozen-UDT path).
+        let ht = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,61,66:org.apache.cassandra.db.marshal.UTF8Type))";
+        assert_eq!(P::extract_marshal_collection_elements(ht), None);
+    }
+
+    #[test]
+    fn map_missing_comma_returns_none() {
+        // MapType with a single (malformed) argument — no top-level comma.
+        let ht =
+            "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type)";
+        assert_eq!(P::extract_marshal_collection_elements(ht), None);
+    }
+
+    #[test]
+    fn empty_and_garbage_return_none() {
+        assert_eq!(P::extract_marshal_collection_elements(""), None);
+        assert_eq!(P::extract_marshal_collection_elements("not a marshal type"), None);
+        assert_eq!(P::extract_marshal_collection_elements("ListType("), None);
+    }
+
+    #[test]
+    fn prefer_marshal_only_for_udt_elements() {
+        let udt = "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,61))";
+        // UDT-bearing marshal wins over the schema short form.
+        assert_eq!(P::prefer_udt_marshal_element(Some(udt), "frozen<person>"), udt);
+        // Non-UDT marshal (primitive) keeps the schema short form (byte-parity path).
+        assert_eq!(
+            P::prefer_udt_marshal_element(Some("org.apache.cassandra.db.marshal.Int32Type"), "int"),
+            "int"
+        );
+        // Absent marshal keeps the schema short form.
+        assert_eq!(P::prefer_udt_marshal_element(None, "int"), "int");
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -742,6 +742,7 @@ mod cell_value;
 mod compaction;
 mod complex_column;
 mod frozen;
+mod marshal_element;
 mod now_clock;
 mod partition_shadow;
 mod raw_type_value;

--- a/cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs
+++ b/cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs
@@ -1079,6 +1079,7 @@ async fn nested_frozen_collection_of_udt_compaction_parity() {
     // field-by-field against the values the sstabledump golden carries (the golden
     // itself is self-checked below). A blob fallback / wrong inner-UDT field decode
     // would fail `as_udt` or mismatch a field here.
+    #[allow(clippy::type_complexity)]
     let expect_lp: &[(&str, &[(&str, &str, i32)])] = &[
         ("1", &[("Ada", "Lovelace", 36)]),
         ("2", &[("Grace", "Hopper", 85), ("Alan", "Turing", 41)]),
@@ -1093,8 +1094,16 @@ async fn nested_frozen_collection_of_udt_compaction_parity() {
         assert_eq!(list.len(), people.len(), "lp[pk={pk}]: person count");
         for (el, (first, last, age)) in list.iter().zip(people.iter()) {
             let u = as_udt(el);
-            assert_eq!(udt_text(u, "first_name").as_deref(), Some(*first), "lp[pk={pk}] first_name");
-            assert_eq!(udt_text(u, "last_name").as_deref(), Some(*last), "lp[pk={pk}] last_name");
+            assert_eq!(
+                udt_text(u, "first_name").as_deref(),
+                Some(*first),
+                "lp[pk={pk}] first_name"
+            );
+            assert_eq!(
+                udt_text(u, "last_name").as_deref(),
+                Some(*last),
+                "lp[pk={pk}] last_name"
+            );
             assert_eq!(udt_int(u, "age"), *age, "lp[pk={pk}] age");
         }
     }
@@ -1113,8 +1122,16 @@ async fn nested_frozen_collection_of_udt_compaction_parity() {
             .get(*key)
             .unwrap_or_else(|| panic!("ma[pk={pk}]: missing key '{key}'"));
         let u = as_udt(val);
-        assert_eq!(udt_text(u, "street").as_deref(), Some(*street), "ma[pk={pk}] street");
-        assert_eq!(udt_text(u, "city").as_deref(), Some(*city), "ma[pk={pk}] city");
+        assert_eq!(
+            udt_text(u, "street").as_deref(),
+            Some(*street),
+            "ma[pk={pk}] street"
+        );
+        assert_eq!(
+            udt_text(u, "city").as_deref(),
+            Some(*city),
+            "ma[pk={pk}] city"
+        );
         assert_eq!(udt_text(u, "zip").as_deref(), Some(*zip), "ma[pk={pk}] zip");
     }
     eprintln!(
@@ -1395,7 +1412,7 @@ async fn nested_collection_udt_null_inner_field_compaction_parity() {
             ours.get(&(pk.to_string(), "ma".to_string()))
                 .unwrap_or_else(|| panic!("CQLite output missing ma cell for pk={pk}")),
         );
-        for (_k, val) in &map {
+        for val in map.values() {
             let u = as_udt(val);
             assert!(
                 udt_text(u, "street").is_some(),

--- a/cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs
+++ b/cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs
@@ -79,7 +79,7 @@ use cqlite_core::storage::write_engine::merge::compact_sstables_with_registry;
 use cqlite_core::storage::write_engine::{
     CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
 };
-use cqlite_core::types::{UdtField, UdtTypeDef, UdtValue, Value};
+use cqlite_core::types::{UdtField, UdtFieldDef, UdtTypeDef, UdtValue, Value};
 use cqlite_core::Config;
 use tempfile::TempDir;
 
@@ -700,46 +700,114 @@ fn peel_frozen(v: &Value) -> Value {
     }
 }
 
+/// Same as [`decode_typed_cell_map`] but wires a `UdtRegistry` (DDL-built person /
+/// address defs) into the reader BEFORE decoding. Used by the #1340 equivalence
+/// test to prove the header-marshal decode (registry-less) equals the registry
+/// decode (spec Req 2 scenario 1).
+async fn decode_typed_cell_map_with_registry(
+    dir: &Path,
+    schema: &TableSchema,
+    registry: UdtRegistry,
+) -> BTreeMap<(String, String), Value> {
+    let data_path =
+        single_data_db(dir).unwrap_or_else(|| panic!("no compacted Data.db in {dir:?}"));
+    let config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&config)
+            .await
+            .expect("platform init for decode"),
+    );
+    let mut reader = SSTableReader::open(&data_path, &config, platform)
+        .await
+        .unwrap_or_else(|e| panic!("open {data_path:?} for decode failed: {e}"));
+    reader.set_udt_registry(registry);
+    let rows = reader
+        .iterate_all_partitions_for_compaction(Some(schema))
+        .await
+        .unwrap_or_else(|e| panic!("compaction iterate of {data_path:?} failed: {e}"));
+
+    let mut map: BTreeMap<(String, String), Value> = BTreeMap::new();
+    for row in &rows {
+        let pk = pk_repr(&row.key.0);
+        if let CompactionRowData::Live { simple, .. } = &row.row_data {
+            for cell in simple {
+                if matches!(cell.value, Value::Tombstone(_)) {
+                    continue;
+                }
+                map.insert((pk.clone(), cell.column.clone()), peel_frozen(&cell.value));
+            }
+        }
+    }
+    map
+}
+
+/// A `text` UDT field def (nullable) for the equivalence-test registry.
+fn tfield(name: &str) -> UdtFieldDef {
+    UdtFieldDef {
+        name: name.into(),
+        field_type: CqlType::Text,
+        nullable: true,
+    }
+}
+
+/// DDL-equivalent `person` + `address` UDT registry for `test_compactionparityudt`.
+fn collections_udt_registry() -> UdtRegistry {
+    let mut reg = UdtRegistry::new();
+    reg.register_udt(UdtTypeDef {
+        keyspace: KEYSPACE.into(),
+        name: "person".into(),
+        fields: vec![
+            tfield("first_name"),
+            tfield("last_name"),
+            UdtFieldDef {
+                name: "age".into(),
+                field_type: CqlType::Int,
+                nullable: true,
+            },
+        ],
+    });
+    reg.register_udt(UdtTypeDef {
+        keyspace: KEYSPACE.into(),
+        name: "address".into(),
+        fields: vec![tfield("street"), tfield("city"), tfield("zip")],
+    });
+    reg
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // Structural nested-decode assertions (the dedicated #1240 value round-trip)
 //
 // Decode contract of the compaction reader (compaction_row.rs): the OUTER frozen
 // collection is decoded STRUCTURALLY into a `List`/`Map` (proving it is NOT
-// collapsed to a top-level blob), while each INNER frozen-UDT element is preserved
-// as its frozen serialized BYTES (a `Blob`) — the compactor's job is to preserve
-// frozen element bytes for byte-identical re-serialization, not to re-decode them
-// per-field. So the structural floor we assert via this path is: outer collection
-// shape + element count/order + the inner-UDT element bytes ROUND-TRIP and EQUAL
-// the Cassandra reference. The TYPED inner-UDT field values (first_name/zip/…) are
-// pinned separately against the committed sstabledump JSONL golden below.
+// collapsed to a top-level blob). After issue #1340 each INNER `frozen<UDT>`
+// element is ALSO decoded to a typed `Value::Udt` from the file's own on-disk
+// SerializationHeader marshal type (registry-free), so the structural floor we
+// assert via this path is: outer collection shape + element count/order + the
+// per-element TYPED VALUE ROUND-TRIP and EQUALITY with the Cassandra reference
+// (both decoded through the SAME reader, so equal typed `Value`s prove the
+// header-marshal decode is identical across CQLite's output and Cassandra's).
+// The typed inner-UDT FIELD values (first_name/zip/…) are additionally pinned
+// against CQLite's OWN decode and the committed sstabledump JSONL golden below.
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Bytes of a single decoded collection element (peels Frozen, accepts Blob).
-fn element_bytes(col: &str, pk: &str, el: &Value) -> Vec<u8> {
-    match peel_frozen(el) {
-        Value::Blob(b) => b,
-        // A future decode path that DOES re-decode the inner UDT would land here;
-        // serialize it back so the round-trip/equality check still holds.
-        Value::Udt(u) => panic!(
-            "{col}[pk={pk}]: inner element decoded to a typed UDT '{}' — decode contract \
-             changed; update this test to compare typed UDTs (this is an improvement, not a bug)",
-            u.type_name
-        ),
-        other => panic!(
-            "{col}[pk={pk}]: inner element is {other:?}, expected the frozen-UDT element bytes"
-        ),
-    }
+/// One decoded collection element, peeling `Frozen`. After #1340 an inner
+/// `frozen<UDT>` decodes to a typed `Value::Udt`; an element the reader cannot
+/// resolve stays a `Value::Blob`. Either way we return the peeled typed value so
+/// `ours` and the Cassandra `reference` (decoded through the SAME reader) compare
+/// equal at the typed level.
+fn element_value(el: &Value) -> Value {
+    peel_frozen(el)
 }
 
 /// Assert a decoded `lp` cell is a structured `List` (NOT a top-level blob) and
-/// return its per-element frozen-UDT bytes in order. Element COUNT + ORDER is the
+/// return its per-element typed values in order. Element COUNT + ORDER is the
 /// nested-collection structure under test.
 ///
 /// `lp` is `frozen<list<frozen<person>>>`, so we pin it STRICTLY as `Value::List`:
 /// a regression that decoded an ordered list as a `Value::Set` would silently
 /// pass an `List | Set` match yet drop the list's order guarantee, so a `Set`
 /// (or any other variant) is a hard failure here.
-fn assert_list_structure(pk: &str, v: &Value) -> Vec<Vec<u8>> {
+fn assert_list_structure(pk: &str, v: &Value) -> Vec<Value> {
     let list = match peel_frozen(v) {
         Value::List(items) => items,
         Value::Set(_) => panic!(
@@ -756,12 +824,12 @@ fn assert_list_structure(pk: &str, v: &Value) -> Vec<Vec<u8>> {
         !list.is_empty(),
         "lp[pk={pk}]: decoded to an EMPTY list — nested element decode dropped UDTs"
     );
-    list.iter().map(|el| element_bytes("lp", pk, el)).collect()
+    list.iter().map(element_value).collect()
 }
 
 /// Assert a decoded `ma` cell is a structured `Map<text, _>` (NOT a top-level
-/// blob) and return `key -> frozen-UDT-value-bytes` sorted by key.
-fn assert_map_structure(pk: &str, v: &Value) -> BTreeMap<String, Vec<u8>> {
+/// blob) and return `key -> typed-value` sorted by key.
+fn assert_map_structure(pk: &str, v: &Value) -> BTreeMap<String, Value> {
     let entries = match peel_frozen(v) {
         Value::Map(m) => m,
         other => panic!(
@@ -779,9 +847,49 @@ fn assert_map_structure(pk: &str, v: &Value) -> BTreeMap<String, Vec<u8>> {
             Value::Text(s) => s,
             other => panic!("ma[pk={pk}]: map key is {other:?}, expected text"),
         };
-        out.insert(key, element_bytes("ma", pk, &val));
+        out.insert(key, element_value(&val));
     }
     out
+}
+
+// ── Typed inner-UDT field accessors (issue #1340: assert CQLite's OWN decode) ──
+
+/// Peel to the inner `UdtValue` (through any `Frozen` wrappers). Panics loudly if
+/// the element did NOT decode to a typed UDT — that is the #1340 regression guard.
+fn as_udt(v: &Value) -> &UdtValue {
+    match v {
+        Value::Udt(u) => u,
+        Value::Frozen(inner) => as_udt(inner),
+        other => panic!(
+            "expected a typed Value::Udt (issue #1340 typed inner-UDT decode), got {other:?}"
+        ),
+    }
+}
+
+/// Read a text (or explicit-null) UDT field by name from CQLite's OWN decode.
+fn udt_text(u: &UdtValue, field: &str) -> Option<String> {
+    match u.fields.iter().find(|f| f.name == field) {
+        Some(f) => match &f.value {
+            Some(Value::Text(s)) => Some(s.clone()),
+            None => None,
+            Some(other) => panic!(
+                "UDT '{}' field '{field}': expected text or null, got {other:?}",
+                u.type_name
+            ),
+        },
+        None => panic!("UDT '{}' missing field '{field}'", u.type_name),
+    }
+}
+
+/// Read an int UDT field by name from CQLite's OWN decode.
+fn udt_int(u: &UdtValue, field: &str) -> i32 {
+    match u.fields.iter().find(|f| f.name == field).map(|f| &f.value) {
+        Some(Some(Value::Integer(i))) => *i,
+        other => panic!(
+            "UDT '{}' field '{field}': expected int, got {other:?}",
+            u.type_name
+        ),
+    }
 }
 
 // ── Typed inner-UDT pinning via the committed sstabledump JSONL golden ────────
@@ -926,8 +1034,8 @@ async fn nested_frozen_collection_of_udt_compaction_parity() {
         );
         assert_eq!(
             our_list, ref_list,
-            "lp[pk={pk}]: CQLite nested frozen<list<frozen<person>>> element bytes (count/order) \
-             != Cassandra reference"
+            "lp[pk={pk}]: CQLite nested frozen<list<frozen<person>>> typed element values \
+             (count/order) != Cassandra reference"
         );
         checked_lp += 1;
 
@@ -949,8 +1057,8 @@ async fn nested_frozen_collection_of_udt_compaction_parity() {
         );
         assert_eq!(
             our_map, ref_map,
-            "ma[pk={pk}]: CQLite nested frozen<map<text,frozen<address>>> key set + value bytes \
-             != Cassandra reference"
+            "ma[pk={pk}]: CQLite nested frozen<map<text,frozen<address>>> key set + typed value \
+             values != Cassandra reference"
         );
         checked_ma += 1;
     }
@@ -960,14 +1068,62 @@ async fn nested_frozen_collection_of_udt_compaction_parity() {
 
     eprintln!(
         "[issue_1240] STRUCTURAL ROUND-TRIP PASS — nested {NESTED_COLS:?} columns decoded as \
-         structured List/Map (outer-collection shape + element count/order + inner frozen-UDT \
-         element bytes) from CQLite's compacted output and matched the Cassandra reference on all \
+         structured List/Map (outer-collection shape + element count/order + typed inner frozen-UDT \
+         element values) from CQLite's compacted output and matched the Cassandra reference on all \
          3 partitions ({checked_lp} lp + {checked_ma} ma)."
     );
 
-    // ── 1b. TYPED inner-UDT value round-trip via the sstabledump JSONL golden ─
-    // The compaction reader keeps the inner frozen UDT opaque (byte-preserving),
-    // so pin the TYPED inner fields against the authoritative sstabledump golden:
+    // ── 1b. TYPED inner-UDT field values from CQLite's OWN decode (issue #1340) ─
+    // The header-marshal decode (registry-free compaction reader) must produce the
+    // right typed person/address FIELDS. Assert CQLite's OWN decoded `ours` cells
+    // field-by-field against the values the sstabledump golden carries (the golden
+    // itself is self-checked below). A blob fallback / wrong inner-UDT field decode
+    // would fail `as_udt` or mismatch a field here.
+    let expect_lp: &[(&str, &[(&str, &str, i32)])] = &[
+        ("1", &[("Ada", "Lovelace", 36)]),
+        ("2", &[("Grace", "Hopper", 85), ("Alan", "Turing", 41)]),
+        ("3", &[("Katherine", "Johnson", 101)]),
+    ];
+    for (pk, people) in expect_lp {
+        let list = assert_list_structure(
+            pk,
+            ours.get(&(pk.to_string(), "lp".to_string()))
+                .unwrap_or_else(|| panic!("CQLite output missing lp cell for pk={pk}")),
+        );
+        assert_eq!(list.len(), people.len(), "lp[pk={pk}]: person count");
+        for (el, (first, last, age)) in list.iter().zip(people.iter()) {
+            let u = as_udt(el);
+            assert_eq!(udt_text(u, "first_name").as_deref(), Some(*first), "lp[pk={pk}] first_name");
+            assert_eq!(udt_text(u, "last_name").as_deref(), Some(*last), "lp[pk={pk}] last_name");
+            assert_eq!(udt_int(u, "age"), *age, "lp[pk={pk}] age");
+        }
+    }
+    let expect_ma: &[(&str, &str, (&str, &str, &str))] = &[
+        ("1", "home", ("1 Navy Way", "Arlington", "22201")),
+        ("2", "office", ("9 Apollo", "Hampton", "23666")),
+        ("3", "h", ("9 Apollo", "Hampton", "23666")),
+    ];
+    for (pk, key, (street, city, zip)) in expect_ma {
+        let map = assert_map_structure(
+            pk,
+            ours.get(&(pk.to_string(), "ma".to_string()))
+                .unwrap_or_else(|| panic!("CQLite output missing ma cell for pk={pk}")),
+        );
+        let val = map
+            .get(*key)
+            .unwrap_or_else(|| panic!("ma[pk={pk}]: missing key '{key}'"));
+        let u = as_udt(val);
+        assert_eq!(udt_text(u, "street").as_deref(), Some(*street), "ma[pk={pk}] street");
+        assert_eq!(udt_text(u, "city").as_deref(), Some(*city), "ma[pk={pk}] city");
+        assert_eq!(udt_text(u, "zip").as_deref(), Some(*zip), "ma[pk={pk}] zip");
+    }
+    eprintln!(
+        "[issue_1240] TYPED INNER-UDT (OWN DECODE) PASS — CQLite's registry-free decode produced \
+         typed person/address fields for all nested-column cells."
+    );
+
+    // ── 1c. TYPED inner-UDT value round-trip via the sstabledump JSONL golden ─
+    // Pins the TYPED inner fields against the authoritative sstabledump golden:
     // a blob fallback or wrong inner-UDT field decode would not produce these
     // structured typed values (incl. field order). Every committed `ma` address
     // here carries a present `city`; the fixture does not exercise a null nested
@@ -1051,6 +1207,52 @@ async fn nested_frozen_collection_of_udt_compaction_parity() {
     );
 }
 
+/// Issue #1340 — equivalence: the fixture decoded via the header-marshal
+/// mechanism (registry-LESS reader) equals the decode via the existing
+/// `UdtRegistry` mechanism (spec Req 2 scenario 1). Same reader, same schema; the
+/// only difference is whether a DDL-built registry is wired. If the two decodes
+/// disagree, the header-marshal path is not producing the identical typed
+/// `Value::Udt` the registry path produces.
+#[tokio::test]
+async fn nested_frozen_collection_marshal_equals_registry_decode() {
+    let Some(ref_dir) = reference_dir() else {
+        if require_fixtures_strict() {
+            panic!(
+                "CQLITE_REQUIRE_FIXTURES=1 but the compacted reference for {KEYSPACE}.{TABLE} is \
+                 absent; generate with bash test-data/scripts/generate-compaction-parity-udt.sh"
+            );
+        }
+        eprintln!(
+            "[issue_1340] reference for {KEYSPACE}.{TABLE} absent (dataset not fetched); skipping"
+        );
+        return;
+    };
+
+    let schema = collections_schema();
+    let marshal_only = decode_typed_cell_map(&ref_dir, &schema).await;
+    let registry_wired =
+        decode_typed_cell_map_with_registry(&ref_dir, &schema, collections_udt_registry()).await;
+
+    assert!(
+        !marshal_only.is_empty(),
+        "registry-less decode produced ZERO cells — fixture present-but-zero-rows is a FAILURE"
+    );
+    assert_eq!(
+        marshal_only, registry_wired,
+        "issue #1340: header-marshal (registry-less) decode must equal the UdtRegistry decode"
+    );
+    // Prove the inner elements are actually TYPED (not both equally-Blob).
+    let lp = marshal_only
+        .get(&("1".to_string(), "lp".to_string()))
+        .expect("lp cell for pk=1");
+    let first = assert_list_structure("1", lp);
+    let _ = as_udt(&first[0]); // panics if not a typed UDT
+    eprintln!(
+        "[issue_1340] EQUIVALENCE PASS — registry-less header-marshal decode == UdtRegistry decode \
+         (typed Value::Udt inner elements) across all nested-column cells."
+    );
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // Issue #1289 — null INNER FIELD inside a nested-collection UDT
 //
@@ -1129,8 +1331,8 @@ async fn nested_collection_udt_null_inner_field_compaction_parity() {
         );
         assert_eq!(
             our_list, ref_list,
-            "lp[pk={pk}]: CQLite nested frozen<list<frozen<person>>> element bytes (null-last_name) \
-             != Cassandra reference"
+            "lp[pk={pk}]: CQLite nested frozen<list<frozen<person>>> typed element values \
+             (null-last_name) != Cassandra reference"
         );
         checked_lp += 1;
 
@@ -1150,8 +1352,8 @@ async fn nested_collection_udt_null_inner_field_compaction_parity() {
         );
         assert_eq!(
             our_map, ref_map,
-            "ma[pk={pk}]: CQLite nested frozen<map<text,frozen<address>>> key set + value bytes \
-             (null-city) != Cassandra reference"
+            "ma[pk={pk}]: CQLite nested frozen<map<text,frozen<address>>> key set + typed value \
+             values (null-city) != Cassandra reference"
         );
         checked_ma += 1;
     }
@@ -1162,6 +1364,58 @@ async fn nested_collection_udt_null_inner_field_compaction_parity() {
         "[issue_1289] STRUCTURAL ROUND-TRIP PASS — {TABLE_NULL} nested {NESTED_COLS:?} columns \
          (null inner field) decoded as structured List/Map and matched the Cassandra reference on \
          all 3 partitions ({checked_lp} lp + {checked_ma} ma)."
+    );
+
+    // ── 1b0. NULL inner field survives CQLite's OWN typed decode (issue #1340) ─
+    // The whole point of #1289: the registry-free header-marshal decode must
+    // represent the null inner field as a null UDT field (not dropped, not an
+    // error). Assert against CQLite's OWN decoded `ours` cells.
+    let mut own_null_fields = 0usize;
+    for pk in ["1", "2", "3"] {
+        let list = assert_list_structure(
+            pk,
+            ours.get(&(pk.to_string(), "lp".to_string()))
+                .unwrap_or_else(|| panic!("CQLite output missing lp cell for pk={pk}")),
+        );
+        for el in &list {
+            let u = as_udt(el);
+            assert!(
+                udt_text(u, "first_name").is_some(),
+                "lp[pk={pk}]: first_name should be present"
+            );
+            assert_eq!(
+                udt_text(u, "last_name"),
+                None,
+                "lp[pk={pk}]: person.last_name must decode to NULL"
+            );
+            own_null_fields += 1;
+        }
+        let map = assert_map_structure(
+            pk,
+            ours.get(&(pk.to_string(), "ma".to_string()))
+                .unwrap_or_else(|| panic!("CQLite output missing ma cell for pk={pk}")),
+        );
+        for (_k, val) in &map {
+            let u = as_udt(val);
+            assert!(
+                udt_text(u, "street").is_some(),
+                "ma[pk={pk}]: street should be present"
+            );
+            assert_eq!(
+                udt_text(u, "city"),
+                None,
+                "ma[pk={pk}]: address.city must decode to NULL"
+            );
+            own_null_fields += 1;
+        }
+    }
+    assert!(
+        own_null_fields >= 6,
+        "expected null inner fields across all surviving nested cells, saw {own_null_fields}"
+    );
+    eprintln!(
+        "[issue_1289] NULL INNER-FIELD (OWN DECODE) PASS — CQLite's registry-free decode \
+         represented person.last_name / address.city as NULL in {own_null_fields} cells."
     );
 
     // ── 1b. TYPED inner-UDT pin: the NULL inner field decodes to `null` ───────

--- a/cqlite-core/tests/issue_1340_frozen_inner_udt_query_surface.rs
+++ b/cqlite-core/tests/issue_1340_frozen_inner_udt_query_surface.rs
@@ -1,0 +1,241 @@
+//! Issue #1340 — public query-surface wiring evidence for typed inner-UDT decode.
+//!
+//! PUBLIC SURFACE + CALL CHAIN under test:
+//!   `cqlite_core::ingestion::ingest(IngestionConfig{schema, data_dir})`
+//!     → builds a `Database` (schema loader parses the committed DDL, incl. the
+//!       `person`/`address` CREATE TYPE defs)
+//!   → `Database::execute("SELECT lp, ma FROM test_compactionparityudt.udt_collections")`
+//!     → `SelectExecutor` → `SSTableReader` scan → V5CompressedLegacy row decode
+//!       (the frozen-collection element decoder threaded with the on-disk
+//!        SerializationHeader marshal type by issue #1340)
+//!   → `QueryResult.rows[*].values["lp"|"ma"]`
+//!
+//! This is END-TO-END evidence (NOT a helper-only unit test, per spec Req 4): a
+//! real `SELECT` over the committed #1240/#1020 SSTable fixture must expose
+//! STRUCTURED inner person/address UDT field values that match the sstabledump
+//! JSONL golden. Dataset-guarded: fixture-present-but-zero-rows is a FAILURE.
+//!
+//! Requires the `cli-helpers` feature (the public `ingestion` surface); the whole
+//! file is gated so the default-feature test build neither compiles nor skips it.
+#![cfg(feature = "cli-helpers")]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::QueryRow;
+use cqlite_core::types::{UdtValue, Value};
+use cqlite_core::Database;
+
+const KEYSPACE: &str = "test_compactionparityudt";
+const TABLE: &str = "udt_collections";
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schema_path() -> Option<PathBuf> {
+    // schemas live next to the datasets root, or in the repo test-data dir.
+    if let Some(root) = datasets_root() {
+        if let Some(parent) = root.parent() {
+            let p = parent.join("schemas").join("compaction-parity-udt.cql");
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let p = manifest_dir
+        .parent()?
+        .join("test-data")
+        .join("schemas")
+        .join("compaction-parity-udt.cql");
+    p.exists().then_some(p)
+}
+
+fn require_fixtures_strict() -> bool {
+    std::env::var("CQLITE_REQUIRE_FIXTURES").map(|v| v == "1").unwrap_or(false)
+}
+
+async fn open_db() -> Option<Database> {
+    let Some(root) = datasets_root() else {
+        assert!(!require_fixtures_strict(), "CQLITE_REQUIRE_FIXTURES=1 but CQLITE_DATASETS_ROOT unset");
+        eprintln!("[issue_1340] CQLITE_DATASETS_ROOT unset; skipping");
+        return None;
+    };
+    let Some(schema) = schema_path() else {
+        assert!(!require_fixtures_strict(), "CQLITE_REQUIRE_FIXTURES=1 but compaction-parity-udt.cql missing");
+        eprintln!("[issue_1340] compaction-parity-udt.cql not found; skipping");
+        return None;
+    };
+    let data_dir = root.join("sstables");
+    let config = IngestionConfig {
+        schema_paths: vec![schema],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(KEYSPACE.to_string()),
+    };
+    match ingest(config).await {
+        Ok(res) => Some(res.database),
+        Err(e) => {
+            assert!(!require_fixtures_strict(), "CQLITE_REQUIRE_FIXTURES=1 but ingest failed: {e}");
+            eprintln!("[issue_1340] ingest failed ({e}); skipping");
+            None
+        }
+    }
+}
+
+/// Peel `Frozen` wrappers to the inner `UdtValue`.
+fn as_udt(v: &Value) -> &UdtValue {
+    match v {
+        Value::Udt(u) => u,
+        Value::Frozen(inner) => as_udt(inner),
+        other => panic!("expected a typed Value::Udt (issue #1340), got {other:?}"),
+    }
+}
+
+fn udt_text(u: &UdtValue, field: &str) -> Option<String> {
+    match u.fields.iter().find(|f| f.name == field) {
+        Some(f) => match &f.value {
+            Some(Value::Text(s)) => Some(s.clone()),
+            None => None,
+            Some(other) => panic!("field '{field}': expected text/null, got {other:?}"),
+        },
+        None => panic!("UDT '{}' missing field '{field}'", u.type_name),
+    }
+}
+
+fn udt_int(u: &UdtValue, field: &str) -> i32 {
+    match u.fields.iter().find(|f| f.name == field).map(|f| &f.value) {
+        Some(Some(Value::Integer(i))) => *i,
+        other => panic!("field '{field}': expected int, got {other:?}"),
+    }
+}
+
+/// Peel to the `lp` list (frozen<list<frozen<person>>>).
+fn as_list<'a>(v: &'a Value) -> &'a [Value] {
+    match v {
+        Value::List(items) => items,
+        Value::Frozen(inner) => as_list(inner),
+        other => panic!("lp: expected a List, got {other:?}"),
+    }
+}
+
+/// Peel to the `ma` map entries (frozen<map<text, frozen<address>>>).
+fn as_map<'a>(v: &'a Value) -> &'a [(Value, Value)] {
+    match v {
+        Value::Map(entries) => entries,
+        Value::Frozen(inner) => as_map(inner),
+        other => panic!("ma: expected a Map, got {other:?}"),
+    }
+}
+
+fn text_of(v: &Value) -> String {
+    match v {
+        Value::Text(s) => s.clone(),
+        Value::Frozen(inner) => text_of(inner),
+        other => panic!("expected text, got {other:?}"),
+    }
+}
+
+fn pk_int(row: &QueryRow) -> Option<i32> {
+    match row.values.get("id") {
+        Some(Value::Integer(i)) => Some(*i),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn select_returns_structured_inner_udt_fields() {
+    let Some(db) = open_db().await else {
+        return;
+    };
+
+    // The query surface itself resolves the keyspace/table + builds its schema
+    // (incl. the person/address UDT defs) from the ingested DDL.
+    let res = db
+        .execute(&format!(
+            "SELECT id, lp, ma FROM {KEYSPACE}.{TABLE}"
+        ))
+        .await
+        .unwrap_or_else(|e| panic!("SELECT over {KEYSPACE}.{TABLE} failed: {e}"));
+
+    // Dataset-guard: fixture-present-but-zero-rows is a FAILURE (not a skip).
+    assert!(
+        !res.rows.is_empty(),
+        "issue #1340: SELECT over {KEYSPACE}.{TABLE} returned 0 rows — fixture present-but-empty \
+         (Data.db not fetched?) is a hard FAILURE for this value-parity test"
+    );
+
+    // Expected inner-UDT field values from the committed sstabledump JSONL golden.
+    // lp: pk -> [(first_name, last_name, age), ...]
+    let expect_lp: &[(i32, &[(&str, &str, i32)])] = &[
+        (1, &[("Ada", "Lovelace", 36)]),
+        (2, &[("Grace", "Hopper", 85), ("Alan", "Turing", 41)]),
+        (3, &[("Katherine", "Johnson", 101)]),
+    ];
+    // ma: pk -> (key, (street, city, zip))
+    let expect_ma: &[(i32, &str, (&str, &str, &str))] = &[
+        (1, "home", ("1 Navy Way", "Arlington", "22201")),
+        (2, "office", ("9 Apollo", "Hampton", "23666")),
+        (3, "h", ("9 Apollo", "Hampton", "23666")),
+    ];
+
+    let mut checked_lp = 0usize;
+    let mut checked_ma = 0usize;
+    for row in &res.rows {
+        let Some(pk) = pk_int(row) else {
+            panic!("row `id` did not decode as an int PK");
+        };
+
+        // ── lp: frozen<list<frozen<person>>> ─────────────────────────────────
+        let lp_v = row
+            .values
+            .get("lp")
+            .unwrap_or_else(|| panic!("row pk={pk} missing lp"));
+        let list = as_list(lp_v);
+        let (_, people) = expect_lp
+            .iter()
+            .find(|(p, _)| *p == pk)
+            .unwrap_or_else(|| panic!("unexpected pk={pk}"));
+        assert_eq!(list.len(), people.len(), "lp[pk={pk}] person count");
+        for (el, (first, last, age)) in list.iter().zip(people.iter()) {
+            let u = as_udt(el);
+            assert_eq!(udt_text(u, "first_name").as_deref(), Some(*first), "lp[pk={pk}] first_name");
+            assert_eq!(udt_text(u, "last_name").as_deref(), Some(*last), "lp[pk={pk}] last_name");
+            assert_eq!(udt_int(u, "age"), *age, "lp[pk={pk}] age");
+        }
+        checked_lp += 1;
+
+        // ── ma: frozen<map<text, frozen<address>>> ───────────────────────────
+        let ma_v = row
+            .values
+            .get("ma")
+            .unwrap_or_else(|| panic!("row pk={pk} missing ma"));
+        let entries = as_map(ma_v);
+        let (_, want_key, (street, city, zip)) = expect_ma
+            .iter()
+            .find(|(p, _, _)| *p == pk)
+            .unwrap_or_else(|| panic!("unexpected pk={pk}"));
+        let (_k, val) = entries
+            .iter()
+            .find(|(k, _)| text_of(k) == *want_key)
+            .unwrap_or_else(|| panic!("ma[pk={pk}] missing key '{want_key}'"));
+        let u = as_udt(val);
+        assert_eq!(udt_text(u, "street").as_deref(), Some(*street), "ma[pk={pk}] street");
+        assert_eq!(udt_text(u, "city").as_deref(), Some(*city), "ma[pk={pk}] city");
+        assert_eq!(udt_text(u, "zip").as_deref(), Some(*zip), "ma[pk={pk}] zip");
+        checked_ma += 1;
+    }
+
+    assert_eq!(checked_lp, 3, "expected typed lp on all 3 partitions");
+    assert_eq!(checked_ma, 3, "expected typed ma on all 3 partitions");
+    eprintln!(
+        "[issue_1340] QUERY-SURFACE PASS — SELECT lp, ma FROM {KEYSPACE}.{TABLE} returned \
+         structured inner person/address UDT fields matching the sstabledump golden on all 3 \
+         partitions."
+    );
+}

--- a/cqlite-core/tests/issue_1340_frozen_inner_udt_query_surface.rs
+++ b/cqlite-core/tests/issue_1340_frozen_inner_udt_query_surface.rs
@@ -56,17 +56,25 @@ fn schema_path() -> Option<PathBuf> {
 }
 
 fn require_fixtures_strict() -> bool {
-    std::env::var("CQLITE_REQUIRE_FIXTURES").map(|v| v == "1").unwrap_or(false)
+    std::env::var("CQLITE_REQUIRE_FIXTURES")
+        .map(|v| v == "1")
+        .unwrap_or(false)
 }
 
 async fn open_db() -> Option<Database> {
     let Some(root) = datasets_root() else {
-        assert!(!require_fixtures_strict(), "CQLITE_REQUIRE_FIXTURES=1 but CQLITE_DATASETS_ROOT unset");
+        assert!(
+            !require_fixtures_strict(),
+            "CQLITE_REQUIRE_FIXTURES=1 but CQLITE_DATASETS_ROOT unset"
+        );
         eprintln!("[issue_1340] CQLITE_DATASETS_ROOT unset; skipping");
         return None;
     };
     let Some(schema) = schema_path() else {
-        assert!(!require_fixtures_strict(), "CQLITE_REQUIRE_FIXTURES=1 but compaction-parity-udt.cql missing");
+        assert!(
+            !require_fixtures_strict(),
+            "CQLITE_REQUIRE_FIXTURES=1 but compaction-parity-udt.cql missing"
+        );
         eprintln!("[issue_1340] compaction-parity-udt.cql not found; skipping");
         return None;
     };
@@ -81,7 +89,10 @@ async fn open_db() -> Option<Database> {
     match ingest(config).await {
         Ok(res) => Some(res.database),
         Err(e) => {
-            assert!(!require_fixtures_strict(), "CQLITE_REQUIRE_FIXTURES=1 but ingest failed: {e}");
+            assert!(
+                !require_fixtures_strict(),
+                "CQLITE_REQUIRE_FIXTURES=1 but ingest failed: {e}"
+            );
             eprintln!("[issue_1340] ingest failed ({e}); skipping");
             None
         }
@@ -116,7 +127,7 @@ fn udt_int(u: &UdtValue, field: &str) -> i32 {
 }
 
 /// Peel to the `lp` list (frozen<list<frozen<person>>>).
-fn as_list<'a>(v: &'a Value) -> &'a [Value] {
+fn as_list(v: &Value) -> &[Value] {
     match v {
         Value::List(items) => items,
         Value::Frozen(inner) => as_list(inner),
@@ -125,7 +136,7 @@ fn as_list<'a>(v: &'a Value) -> &'a [Value] {
 }
 
 /// Peel to the `ma` map entries (frozen<map<text, frozen<address>>>).
-fn as_map<'a>(v: &'a Value) -> &'a [(Value, Value)] {
+fn as_map(v: &Value) -> &[(Value, Value)] {
     match v {
         Value::Map(entries) => entries,
         Value::Frozen(inner) => as_map(inner),
@@ -148,6 +159,7 @@ fn pk_int(row: &QueryRow) -> Option<i32> {
     }
 }
 
+#[allow(clippy::type_complexity)]
 #[tokio::test]
 async fn select_returns_structured_inner_udt_fields() {
     let Some(db) = open_db().await else {
@@ -157,9 +169,7 @@ async fn select_returns_structured_inner_udt_fields() {
     // The query surface itself resolves the keyspace/table + builds its schema
     // (incl. the person/address UDT defs) from the ingested DDL.
     let res = db
-        .execute(&format!(
-            "SELECT id, lp, ma FROM {KEYSPACE}.{TABLE}"
-        ))
+        .execute(&format!("SELECT id, lp, ma FROM {KEYSPACE}.{TABLE}"))
         .await
         .unwrap_or_else(|e| panic!("SELECT over {KEYSPACE}.{TABLE} failed: {e}"));
 
@@ -204,8 +214,16 @@ async fn select_returns_structured_inner_udt_fields() {
         assert_eq!(list.len(), people.len(), "lp[pk={pk}] person count");
         for (el, (first, last, age)) in list.iter().zip(people.iter()) {
             let u = as_udt(el);
-            assert_eq!(udt_text(u, "first_name").as_deref(), Some(*first), "lp[pk={pk}] first_name");
-            assert_eq!(udt_text(u, "last_name").as_deref(), Some(*last), "lp[pk={pk}] last_name");
+            assert_eq!(
+                udt_text(u, "first_name").as_deref(),
+                Some(*first),
+                "lp[pk={pk}] first_name"
+            );
+            assert_eq!(
+                udt_text(u, "last_name").as_deref(),
+                Some(*last),
+                "lp[pk={pk}] last_name"
+            );
             assert_eq!(udt_int(u, "age"), *age, "lp[pk={pk}] age");
         }
         checked_lp += 1;
@@ -225,8 +243,16 @@ async fn select_returns_structured_inner_udt_fields() {
             .find(|(k, _)| text_of(k) == *want_key)
             .unwrap_or_else(|| panic!("ma[pk={pk}] missing key '{want_key}'"));
         let u = as_udt(val);
-        assert_eq!(udt_text(u, "street").as_deref(), Some(*street), "ma[pk={pk}] street");
-        assert_eq!(udt_text(u, "city").as_deref(), Some(*city), "ma[pk={pk}] city");
+        assert_eq!(
+            udt_text(u, "street").as_deref(),
+            Some(*street),
+            "ma[pk={pk}] street"
+        );
+        assert_eq!(
+            udt_text(u, "city").as_deref(),
+            Some(*city),
+            "ma[pk={pk}] city"
+        );
         assert_eq!(udt_text(u, "zip").as_deref(), Some(*zip), "ma[pk={pk}] zip");
         checked_ma += 1;
     }

--- a/openspec/changes/typed-inner-udt-frozen-collections/design.md
+++ b/openspec/changes/typed-inner-udt-frozen-collections/design.md
@@ -1,0 +1,101 @@
+# Design: typed inner-UDT decode via header-marshal threading
+
+All anchors at `main` commit `e2694ab5`. Written to be implementable by a later team without
+re-deriving the investigation — read the fact base in `proposal.md` first.
+
+## Context (the mechanism, precisely)
+
+1. A `frozen<...>` collection is a **single-cell simple column**. Both the query path and the
+   compaction read path decode it through the same chain:
+   `cell_value.rs:846-872` (dispatch; extracts element type as the **schema short form**
+   `"frozen<person>"`) → `frozen.rs:134-172` (`parse_frozen_sequence_value` element loop) →
+   `frozen.rs:83-126` (`read_frozen_element`) → `raw_value.rs:89-467`
+   (`parse_value_from_raw_bytes(elem_data, "frozen<person>", ..)`).
+2. `raw_value.rs:418-426` strips `frozen<...>` → recurses with bare `"person"` → the `other`
+   arm (`raw_value.rs:435-465`): `is_udt_type("person")` is false (matches only the marshal
+   substring, `udt.rs:130-141`); registry gate at `raw_value.rs:445-456` (typed iff a wired
+   `UdtRegistry` resolves it); else **`Value::Blob` at `raw_value.rs:457-464`**.
+3. Meanwhile the authoritative on-disk header marshal type for the whole column —
+   `FrozenType(ListType(FrozenType(UserType(ks, person, field-types...))))` — sits unused in
+   `RowColumnResolution.header_type` (`parsing/mod.rs:211`). Top-level frozen UDTs already
+   decode from it, registry-free (`marshal_is_top_level_frozen_udt` gate +
+   `decode_frozen_udt_from_header_type`, `cell_value.rs:965-976`, `:1108-1116`; `udt.rs:20-…`,
+   `:24-…`).
+
+## Options considered
+
+### Option A — thread the header marshal element type down (CHOSEN)
+
+Pass the marshal type (when available) alongside/instead of the schema short form through the
+frozen-collection element decode chain, and decode inner `UserType(...)` elements exactly the
+way top-level frozen UDTs are decoded today.
+
+- Sketch: at `cell_value.rs:846-872`, when `header_type` is present for the column, extract the
+  **marshal** element type(s) (e.g. `ListType(X)` → `X`; `MapType(K, V)` → `K`, `V`) with a
+  marshal-aware sibling of `extract_collection_element_type`, and hand `parse_frozen_*_value`
+  the marshal element type. In `raw_value.rs`, a marshal `FrozenType(UserType(...))` /
+  `UserType(...)` element routes to the existing marshal-driven UDT decode
+  (`decode_frozen_udt_from_header_type` internals / `parse_udt_type_definition`, `udt.rs:157`)
+  instead of falling to the bare-short-name arm. Recursion depth guard: reuse the existing
+  `depth` parameter of `parse_value_from_raw_bytes`.
+- Pros: registry-free (works on default `open()`); uses the **most authoritative** metadata
+  (the file's own SerializationHeader — exactly what no-heuristics #28 asks for); symmetric
+  with the existing top-level mechanism; one fix covers query + compaction paths; no API change.
+- Cons: marshal-string parsing for nested generic types must be careful (angle-bracket/paren
+  nesting); touches the hot element loop (keep allocations out of the per-element path — parse
+  the marshal element type ONCE per column, not per element).
+
+### Option B — registry-only (status quo, wire more registries)
+
+Keep the decoder as-is; require every surface wanting typed inner UDTs to wire a `UdtRegistry`
+(as `merge/mod.rs:499-501` and the CLI already do).
+
+- Rejected as the primary mechanism: leaves default `open()` readers permanently Blob; pushes a
+  per-surface wiring obligation onto every embedder (the exact "built-but-unwired" failure mode
+  this project keeps re-finding); the DDL-derived registry is *less* authoritative than the
+  file's own header for the file at hand. Kept as **fallback** (precedence 2) — it already
+  works and covers files whose header lacks usable marshal info.
+
+### Option C — post-hoc conversion layer at export/query surfaces
+
+Decode Blob as today; add a converter that re-decodes opaque frozen bytes into typed UDTs at
+the surfaces that want them.
+
+- Rejected: double-decode cost; the contract stays inconsistent across surfaces; a second
+  decode implementation to keep in parity with the first; still needs the same type metadata
+  threading to know *what* to decode — so it inherits Option A's work plus duplication.
+
+## Decision
+
+**Option A**, with resolution precedence per element type:
+1. **Header marshal type** (authoritative, from `RowColumnResolution.header_type`) — typed decode.
+2. **`UdtRegistry`** (existing `raw_value.rs:445-456` path) — typed decode, unchanged.
+3. **`Value::Blob`** — honest opaque fallback. Never a byte-pattern inference.
+
+Wrapping stays symmetric with top-level: inner element yields `Value::Frozen(Value::Udt(..))`
+where top-level yields the same shape today (`raw_value.rs:418-426` wrap).
+
+## Risks / notes for the implementing team
+
+- **Tripwire will fire by design**: `issue_1240_nested_frozen_collection_udt_parity.rs:718-732`
+  (`element_bytes`) panics on `Value::Udt`. Update it per its embedded guidance (lines 723-728):
+  compare typed UDTs field-by-field against the sstabledump JSONL golden (tier 1b), keep the
+  byte-parity tier (tier 2) exactly as-is. Do this in the SAME commit as the decode change or
+  the gate goes red between commits.
+- **Do not regress the merge path**: the k-way merge producer already decodes typed via the
+  registry (`merge/mod.rs:494-522`) and its byte-parity goldens pass — header-marshal decode
+  must produce the identical `Value::Udt` structure the registry path produces (add an
+  equivalence test: same fixture decoded via marshal-only reader vs registry-wired reader →
+  identical `Value`s).
+- **CLI/binding parity goldens must stay byte-identical**: with a schema-supplied registry the
+  query surface is already typed, so JSON/JSONL output should not move. Run the full parity
+  suite (33 tables + Python) and diff outputs.
+- **Marshal parsing hygiene**: `header_type` strings for collections nest parens
+  (`MapType(UTF8Type,FrozenType(UserType(...)))`); write a small paren-aware splitter (or reuse
+  an existing marshal helper if one exists in `udt.rs` — check `extract_frozen_inner_type`'s
+  marshal handling, tested at `frozen.rs:661-687/750-783`) with unit tests for list/set/map,
+  UDT-in-UDT, and tuple-in-collection shapes.
+- **Absent/odd headers**: `header_type` is `Option`; older or synthetic fixtures may omit it —
+  precedence 2/3 covers that, and a unit test must pin the Blob fallback (no panic, no guess).
+- **Memory**: parse the marshal element type once per column (per `RowColumnResolution`), not
+  per element; the <128MB budget and the per-element hot loop must not gain allocations.

--- a/openspec/changes/typed-inner-udt-frozen-collections/proposal.md
+++ b/openspec/changes/typed-inner-udt-frozen-collections/proposal.md
@@ -1,0 +1,81 @@
+# Proposal: Typed recursive inner-UDT decode for frozen-UDT elements inside frozen collections
+
+## Why
+
+Milestone: type-system enhancement (post-M5), issue **#1340**, split out from #1289 (part 2).
+Found-by: #1240 / #1289 (nested-frozen-collection UDT compaction parity work).
+
+Routing: **design-driven** (reader value-contract change, no single oracle answer for *which
+surface* gets the typed contract — the byte-parity oracle only proves both representations
+round-trip). Spec produced for a later team; anchors below are at `main` commit `e2694ab5`.
+
+Today an inner `frozen<UDT>` element inside a frozen collection (e.g. the `person` in
+`frozen<list<frozen<person>>>`) decodes to opaque `Value::Blob` on any reader that has no
+`UdtRegistry` wired — while a **top-level** `frozen<udt>` column already decodes to typed
+`Value::Udt` on the same reader, registry-free. The asymmetry is not a byte-parity bug (it is
+validated as correct by the #1240 goldens); it is a **dropped-metadata gap**:
+
+- The on-disk SerializationHeader marshal type for the column —
+  `FrozenType(ListType(FrozenType(UserType(ks, person, ...))))` — carries the **full inner UDT
+  field layout** and is available at decode time (`RowColumnResolution.header_type`,
+  `parsing/mod.rs:211`). Top-level frozen UDTs use it (`decode_frozen_udt_from_header_type`,
+  `cell_value.rs:966/1108`).
+- But the frozen-collection **element** decoder is handed only the schema short form
+  (`"frozen<person>"` → bare `"person"`, `cell_value.rs:857-859` → `frozen.rs:123`), the marshal
+  type having been dropped. A bare short name resolves only through an optional `UdtRegistry`
+  (`raw_value.rs:445-456`); with none, it falls to `Value::Blob` (`raw_value.rs:457-464`).
+
+Because a `frozen<...>` collection is a single-cell (simple) column, this ONE decoder serves
+**both** the normal query path and the compaction read path — the issue title says "compaction
+read path", but the fix point and the contract change are shared. Registry-wired surfaces (the
+k-way merge producer, `merge/mod.rs:499-501`; the CLI when a schema file with `CREATE TYPE` is
+supplied, `cqlite-cli/src/main.rs:493`) already see typed inner UDTs today. The gap is every
+registry-less reader: default `SSTableReader::open` (`reader/mod.rs:785`), sweep
+(`sweep.rs:245-249`), the Vec-materialising `iterate_all_partitions_for_compaction`, and any
+embedder that never built a registry from DDL.
+
+## What Changes
+
+- **Thread the authoritative header marshal element type into frozen-collection element
+  decode**, so an inner `frozen<UDT>` element decodes to typed `Value::Udt` (recursively,
+  wrapped `Value::Frozen(Value::Udt(..))` like top-level) with **no registry required** —
+  the same mechanism top-level frozen UDTs already use. Resolution precedence:
+  **header marshal type → `UdtRegistry` (existing behavior, kept) → `Value::Blob`** (honest
+  opaque fallback when neither authority resolves; never a byte-pattern guess).
+- Applies to frozen list/set elements, frozen map **keys and values**, tuples inside frozen
+  collections, and UDTs nested at any depth (UDT-in-UDT fields already decode via
+  `parse_nested_udt_from_registry` / marshal recursion).
+- **Update the #1240 tripwire** (`issue_1240_nested_frozen_collection_udt_parity.rs:718-732`)
+  per its own embedded guidance: inner elements now compare as **typed UDTs** (tier 1b becomes
+  self-validating against CQLite's own decode, not only the JSONL golden).
+- **Byte-parity is untouched**: the compaction writer already round-trips both `Blob` and
+  typed `Udt` representations (the registry-wired merge path emits byte-identical output
+  today); the #1240/#1289 byte-parity assertions must pass unchanged.
+
+## Non-goals
+
+- **No compaction writer / merge semantics change** — this is a read-side representation
+  change only; Data.db/Index.db/Summary.db/Digest output stays byte-for-byte identical.
+- **No public API surface additions** — no new config knobs, no registry API change;
+  `set_udt_registry` keeps working and keeps precedence as fallback.
+- **No pre-`na` format work** (version floor); **no compressed-write work** (#1406 boundary).
+- **No change to non-frozen (multi-cell) collection/UDT decode** — the `ComplexColumn`
+  machinery (`compaction_row.rs:261-322`) is out of scope.
+- **No new heuristics** — if neither the header marshal type nor the registry resolves the
+  inner type, the element stays `Value::Blob`; the decoder never infers structure from bytes
+  (no-heuristics mandate #28).
+
+## Impact
+
+- Affected specs: **frozen-inner-udt-decode** (new capability).
+- Affected code (anchors at `e2694ab5`):
+  - `cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs:846-916`
+    (frozen-collection dispatch; where the marshal type must start being threaded)
+  - `.../v5_compressed_legacy/frozen.rs:83-172` (element loop / `read_frozen_element`)
+  - `.../v5_compressed_legacy/raw_value.rs:89-467` (recursive element decoder; Blob fallback at 457-464)
+  - `.../v5_compressed_legacy/udt.rs` (`decode_frozen_udt_from_header_type`, marshal helpers — reuse)
+  - `cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs` (tripwire update)
+- Doctrine impact: none beyond this spec; CLAUDE.md/site untouched (no workflow change).
+- Consumers seeing a contract change: registry-less `iterate_all_partitions_for_compaction`
+  and default-opened readers (Blob → typed Udt for these elements). Query-visible CLI/binding
+  output with a schema-supplied registry is expected byte-identical (verify via parity suite).

--- a/openspec/changes/typed-inner-udt-frozen-collections/specs/frozen-inner-udt-decode/spec.md
+++ b/openspec/changes/typed-inner-udt-frozen-collections/specs/frozen-inner-udt-decode/spec.md
@@ -1,0 +1,78 @@
+# frozen-inner-udt-decode — delta for typed-inner-udt-frozen-collections
+
+## ADDED Requirements
+
+### Requirement: Inner frozen-UDT elements decode to typed Udt from authoritative metadata
+The reader SHALL decode a `frozen<UDT>` element inside a frozen collection (list/set element,
+map key, map value; recursively at any nesting depth, including UDT-in-UDT fields and UDTs
+inside tuples inside frozen collections) to a typed `Value::Frozen(Value::Udt(..))` — the same
+shape a top-level `frozen<udt>` column produces — using **authoritative metadata only**, with
+resolution precedence: (1) the column's SerializationHeader marshal type
+(`RowColumnResolution.header_type`), (2) a wired `UdtRegistry`, (3) opaque `Value::Blob` when
+neither authority resolves the type. The decoder SHALL NOT infer structure from byte patterns
+(no-heuristics mandate #28).
+
+#### Scenario: Registry-less reader decodes a frozen list of frozen UDTs typed
+- **GIVEN** the committed #1240 fixture `test_compactionparityudt/udt_collections-*` (column `lp frozen<list<frozen<person>>>`)
+- **AND** an `SSTableReader` opened WITHOUT any `UdtRegistry`
+- **WHEN** the row is decoded (query scan or `iterate_all_partitions_for_compaction`)
+- **THEN** each `lp` element is `Value::Frozen(Value::Udt(..))` with field names and typed field values matching the sstabledump JSONL golden
+- **AND** element count and order match the golden
+
+#### Scenario: Frozen map with frozen-UDT values decodes typed, keys preserved
+- **GIVEN** the same fixture's `ma frozen<map<text, frozen<address>>>` column on a registry-less reader
+- **WHEN** the row is decoded
+- **THEN** each map value is a typed `Value::Udt` matching the JSONL golden and the key set is preserved
+
+#### Scenario: Null inner UDT field survives typed decode
+- **GIVEN** the #1289 fixture `test_compactionparityudt/udt_null_inner-*` (inner `person.last_name` / `address.city` null)
+- **WHEN** the row is decoded typed
+- **THEN** the null field is represented as null inside the typed `Value::Udt` (not dropped, not a decode error), matching the JSONL golden
+
+#### Scenario: Unresolvable inner type stays an opaque Blob, never a guess
+- **GIVEN** a frozen-collection column whose `header_type` is absent and whose inner UDT name is not in any wired registry
+- **WHEN** the element is decoded
+- **THEN** the element is `Value::Blob` carrying the exact frozen element bytes
+- **AND** no error/panic is raised and no structure is inferred from the bytes
+
+### Requirement: The typed contract is uniform across read paths and equals the registry decode
+The typed inner-UDT representation SHALL be identical whether produced by the header-marshal
+mechanism (registry-less reader) or by the existing `UdtRegistry` mechanism, and identical
+across the query read path and the compaction read path (`CompactionRow` simple cells), since
+one shared element decoder serves both.
+
+#### Scenario: Marshal-driven and registry-driven decode are value-equal
+- **GIVEN** the #1240 fixture decoded twice: once via a registry-less reader, once via a reader with the DDL-built `UdtRegistry` wired
+- **WHEN** the `lp` and `ma` cells are compared
+- **THEN** the decoded `Value`s are equal (same variant shapes, field names, field values)
+
+#### Scenario: Compaction read path carries the typed value into CompactionRow
+- **WHEN** `iterate_all_partitions_for_compaction` (registry-less) decodes the fixture
+- **THEN** the frozen-collection `SimpleCell.value` contains typed `Value::Udt` inner elements identical to the query-path decode of the same row
+
+### Requirement: Byte-for-byte compaction parity is unchanged
+The read-side representation change SHALL NOT alter any written byte: compacting the #1240 /
+#1289 fixtures SHALL produce Data.db, Index.db, Summary.db, and Digest.crc32 byte-identical to
+the committed Cassandra 5.0.2 goldens, exactly as before the change.
+
+#### Scenario: #1240 and #1289 byte-parity tiers still pass
+- **WHEN** `issue_1240_nested_frozen_collection_udt_parity.rs` runs after the change (with its tier-1b assertions updated per the test's embedded guidance to compare typed UDTs)
+- **THEN** the tier-2 byte-parity assertions pass unchanged against the committed goldens
+- **AND** the test FAILS loudly (does not silently pass) if run against a dataset where the fixture is present but yields zero rows
+
+#### Scenario: Query-surface parity goldens do not move
+- **WHEN** the full parity suite runs (33-table sstabledump/JSONL parity + Python parity tests)
+- **THEN** all pass with unchanged values (the schema-registry-wired query surface was already typed, so no golden churn)
+
+### Requirement: Wiring evidence through a named public surface
+The change SHALL be exercised end-to-end through a named public surface — at minimum
+`SSTableReader::open` (registry-less) + `iterate_all_partitions_for_compaction`, and one
+query-visible surface (`SELECT` via the query engine / CLI one-shot) — against the real #1240
+SSTable fixture, validating decoded inner-UDT **field values** (not just row counts) against
+the sstabledump JSONL golden. A helper-only unit test SHALL NOT count as done.
+
+#### Scenario: End-to-end SELECT over the fixture returns structured inner UDTs
+- **GIVEN** the #1240 fixture and its schema (no registry beyond what the surface itself builds)
+- **WHEN** `SELECT lp, ma FROM test_compactionparityudt.udt_collections` executes through the public query surface
+- **THEN** the result exposes structured inner UDT fields whose values match the sstabledump JSONL golden
+- **AND** the test is dataset-guarded such that fixture-present-but-zero-rows is a FAILURE

--- a/openspec/changes/typed-inner-udt-frozen-collections/tasks.md
+++ b/openspec/changes/typed-inner-udt-frozen-collections/tasks.md
@@ -6,59 +6,59 @@ Anchors at `main` commit `e2694ab5`. Rebase note for the later team: this spec w
 
 ## 1. Marshal element-type extraction (unit-first)
 
-- [ ] 1.1 Write failing unit tests for a paren-aware marshal collection-element extractor:
+- [x] 1.1 Write failing unit tests for a paren-aware marshal collection-element extractor:
       `ListType(X)`/`SetType(X)` → `X`; `MapType(K,V)` → `(K,V)`; nested
       `FrozenType(ListType(FrozenType(UserType(...))))`; tuple-in-collection; malformed input →
       `None` (never panic). Surface exercised: the new extractor fn (internal), tests colocated
       per campsite rule.
-- [ ] 1.2 Implement the extractor in `.../v5_compressed_legacy/udt.rs` (or a small sibling
+- [x] 1.2 Implement the extractor in `.../v5_compressed_legacy/udt.rs` (or a small sibling
       module if udt.rs is over the file-size ratchet), reusing existing marshal helpers
       (`extract_frozen_inner_type` marshal handling; `parse_udt_type_definition`, udt.rs:157).
 
 ## 2. Thread header marshal type into frozen-collection element decode (TDD)
 
-- [ ] 2.1 Write the failing integration test FIRST: registry-less `SSTableReader::open` +
+- [x] 2.1 Write the failing integration test FIRST: registry-less `SSTableReader::open` +
       `iterate_all_partitions_for_compaction` over the #1240 fixture asserts typed
       `Value::Frozen(Value::Udt(..))` inner elements with field values matching the JSONL
       golden (spec Req 1, scenarios 1-3). Dataset-guarded: fixture-present-but-zero-rows FAILS.
-- [ ] 2.2 At `cell_value.rs:846-872`, when the column's `header_type`
+- [x] 2.2 At `cell_value.rs:846-872`, when the column's `header_type`
       (`RowColumnResolution.header_type`, parsing/mod.rs:211) is present, extract the marshal
       element type(s) ONCE per column and pass them into `parse_frozen_list_value` /
       `parse_frozen_set_value` / `parse_frozen_map_value` (frozen.rs:134-172) alongside the
       schema short form.
-- [ ] 2.3 In the element path (`read_frozen_element`, frozen.rs:83-126 →
+- [x] 2.3 In the element path (`read_frozen_element`, frozen.rs:83-126 →
       `parse_value_from_raw_bytes`, raw_value.rs:89-467): a marshal
       `FrozenType(UserType(...))`/`UserType(...)` element type routes to the existing
       marshal-driven UDT decode (same mechanism as `decode_frozen_udt_from_header_type`,
       udt.rs:24-…), producing `Value::Frozen(Value::Udt(..))`. Registry path
       (raw_value.rs:445-456) stays as fallback; Blob fallback (raw_value.rs:457-464) stays last.
-- [ ] 2.4 Recursion: inner-UDT fields that are themselves UDTs/collections decode via the
+- [x] 2.4 Recursion: inner-UDT fields that are themselves UDTs/collections decode via the
       existing recursion (`parse_nested_udt_from_registry` udt.rs:930-… / marshal recursion),
       honoring the existing `depth` guard.
-- [ ] 2.5 Unit test the Blob fallback: absent `header_type` + no registry → `Value::Blob`,
+- [x] 2.5 Unit test the Blob fallback: absent `header_type` + no registry → `Value::Blob`,
       no panic (spec Req 1 scenario 4).
 
 ## 3. Equivalence + tripwire update (same commit as 2.x lands)
 
-- [ ] 3.1 Equivalence test: #1240 fixture decoded registry-less vs registry-wired → equal
+- [x] 3.1 Equivalence test: #1240 fixture decoded registry-less vs registry-wired → equal
       `Value`s (spec Req 2 scenario 1).
-- [ ] 3.2 Update `cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs` per its
+- [x] 3.2 Update `cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs` per its
       embedded guidance (lines 718-732): tier-1b compares typed UDT fields against the JSONL
       golden from CQLite's OWN decode; tier-2 byte-parity assertions UNCHANGED. Both tests
       (#1240 + #1289 null-inner) green.
 
 ## 4. Public-surface wiring evidence (e2e)
 
-- [ ] 4.1 E2E test through the query surface: `SELECT lp, ma FROM
+- [x] 4.1 E2E test through the query surface: `SELECT lp, ma FROM
       test_compactionparityudt.udt_collections` (query engine / cli-helpers path) returns
       structured inner-UDT field values matching the JSONL golden (spec Req 4). Name the
       surface + call chain in the test header comment.
-- [ ] 4.2 Confirm no golden churn: full 33-table parity + Python parity suite pass with
+- [x] 4.2 Confirm no golden churn: full 33-table parity + Python parity suite pass with
       unchanged values (spec Req 3 scenario 2).
 
 ## 5. Quality stages (definition of done)
 
-- [ ] 5.1 Iterate with `scripts/agent-gate.sh --lite` each fix round; internal `rust-reviewer`
+- [x] 5.1 Iterate with `scripts/agent-gate.sh --lite` each fix round; internal `rust-reviewer`
       pass before the first full gate (this diff touches a shared decoder → review-first applies).
 - [ ] 5.2 Run the FULL `scripts/agent-gate.sh` ONCE (with `CQLITE_DATASETS_ROOT` pointed at the
       main repo's `test-data/datasets` from the worktree) — paste the AGENT-GATE SUMMARY block.

--- a/openspec/changes/typed-inner-udt-frozen-collections/tasks.md
+++ b/openspec/changes/typed-inner-udt-frozen-collections/tasks.md
@@ -1,0 +1,67 @@
+# Tasks: typed-inner-udt-frozen-collections (#1340)
+
+Anchors at `main` commit `e2694ab5`. Rebase note for the later team: this spec was authored
+2026-07-04 and parked; verify the cited line anchors still hold after rebasing onto current
+`origin/main` before starting (the mechanism is described in `design.md` §Context if lines moved).
+
+## 1. Marshal element-type extraction (unit-first)
+
+- [ ] 1.1 Write failing unit tests for a paren-aware marshal collection-element extractor:
+      `ListType(X)`/`SetType(X)` → `X`; `MapType(K,V)` → `(K,V)`; nested
+      `FrozenType(ListType(FrozenType(UserType(...))))`; tuple-in-collection; malformed input →
+      `None` (never panic). Surface exercised: the new extractor fn (internal), tests colocated
+      per campsite rule.
+- [ ] 1.2 Implement the extractor in `.../v5_compressed_legacy/udt.rs` (or a small sibling
+      module if udt.rs is over the file-size ratchet), reusing existing marshal helpers
+      (`extract_frozen_inner_type` marshal handling; `parse_udt_type_definition`, udt.rs:157).
+
+## 2. Thread header marshal type into frozen-collection element decode (TDD)
+
+- [ ] 2.1 Write the failing integration test FIRST: registry-less `SSTableReader::open` +
+      `iterate_all_partitions_for_compaction` over the #1240 fixture asserts typed
+      `Value::Frozen(Value::Udt(..))` inner elements with field values matching the JSONL
+      golden (spec Req 1, scenarios 1-3). Dataset-guarded: fixture-present-but-zero-rows FAILS.
+- [ ] 2.2 At `cell_value.rs:846-872`, when the column's `header_type`
+      (`RowColumnResolution.header_type`, parsing/mod.rs:211) is present, extract the marshal
+      element type(s) ONCE per column and pass them into `parse_frozen_list_value` /
+      `parse_frozen_set_value` / `parse_frozen_map_value` (frozen.rs:134-172) alongside the
+      schema short form.
+- [ ] 2.3 In the element path (`read_frozen_element`, frozen.rs:83-126 →
+      `parse_value_from_raw_bytes`, raw_value.rs:89-467): a marshal
+      `FrozenType(UserType(...))`/`UserType(...)` element type routes to the existing
+      marshal-driven UDT decode (same mechanism as `decode_frozen_udt_from_header_type`,
+      udt.rs:24-…), producing `Value::Frozen(Value::Udt(..))`. Registry path
+      (raw_value.rs:445-456) stays as fallback; Blob fallback (raw_value.rs:457-464) stays last.
+- [ ] 2.4 Recursion: inner-UDT fields that are themselves UDTs/collections decode via the
+      existing recursion (`parse_nested_udt_from_registry` udt.rs:930-… / marshal recursion),
+      honoring the existing `depth` guard.
+- [ ] 2.5 Unit test the Blob fallback: absent `header_type` + no registry → `Value::Blob`,
+      no panic (spec Req 1 scenario 4).
+
+## 3. Equivalence + tripwire update (same commit as 2.x lands)
+
+- [ ] 3.1 Equivalence test: #1240 fixture decoded registry-less vs registry-wired → equal
+      `Value`s (spec Req 2 scenario 1).
+- [ ] 3.2 Update `cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs` per its
+      embedded guidance (lines 718-732): tier-1b compares typed UDT fields against the JSONL
+      golden from CQLite's OWN decode; tier-2 byte-parity assertions UNCHANGED. Both tests
+      (#1240 + #1289 null-inner) green.
+
+## 4. Public-surface wiring evidence (e2e)
+
+- [ ] 4.1 E2E test through the query surface: `SELECT lp, ma FROM
+      test_compactionparityudt.udt_collections` (query engine / cli-helpers path) returns
+      structured inner-UDT field values matching the JSONL golden (spec Req 4). Name the
+      surface + call chain in the test header comment.
+- [ ] 4.2 Confirm no golden churn: full 33-table parity + Python parity suite pass with
+      unchanged values (spec Req 3 scenario 2).
+
+## 5. Quality stages (definition of done)
+
+- [ ] 5.1 Iterate with `scripts/agent-gate.sh --lite` each fix round; internal `rust-reviewer`
+      pass before the first full gate (this diff touches a shared decoder → review-first applies).
+- [ ] 5.2 Run the FULL `scripts/agent-gate.sh` ONCE (with `CQLITE_DATASETS_ROOT` pointed at the
+      main repo's `test-data/datasets` from the worktree) — paste the AGENT-GATE SUMMARY block.
+- [ ] 5.3 Spec-auditor (C) anchored to `openspec/changes/typed-inner-udt-frozen-collections/specs/**`
+      — every requirement `satisfied` with a public-surface test as evidence.
+- [ ] 5.4 roborev clean; PR; merge per autonomy model; `flow-finalize` (archive change, close #1340).


### PR DESCRIPTION
Closes #1340. Implements the owner-approved OpenSpec change `typed-inner-udt-frozen-collections` (Seam 1 approved 2026-07-04). Rust, `cqlite-core`, **read-side only** — byte-for-byte compaction parity is unchanged.

## What
Threads the on-disk SerializationHeader marshal element type (`RowColumnResolution.header_type`) into the frozen-collection element decoder, so a `frozen<UDT>` element inside a frozen collection (list/set element, map key/value, recursively) decodes to typed `Value::Frozen(Value::Udt(..))` — the same shape a top-level `frozen<udt>` column produces — **registry-free**. Resolution precedence is authoritative-only: header-marshal → `UdtRegistry` → opaque `Value::Blob` (no byte-pattern inference, no-heuristics #28). One shared element decoder serves both the query read path and the compaction read path.

New `marshal_element.rs`: paren-aware element-type extractor (borrows from `header_type`, zero-alloc per cell; malformed → `None`, never panics) + `prefer_udt_marshal_element` (marshal preferred only for UDT-bearing elements, so primitive/collection byte-parity behavior is preserved).

## Tests (wiring-evidence, dataset-guarded)
- `issue_1340_frozen_inner_udt_query_surface.rs` (NEW): e2e `SELECT id, lp, ma FROM test_compactionparityudt.udt_collections` via `ingest → Database::execute` returns structured inner person/address field values matching the sstabledump JSONL golden (all 3 partitions).
- `issue_1240_...parity.rs` (updated): tier-1b now compares typed inner-UDT fields (registry-less own decode) + a registry-less-vs-registry **equivalence** test; **tier-2 byte-parity assertions unchanged**. #1289 null-inner field pinned.
- `marshal_element` unit tests (12): extraction, nesting, malformed→None, Blob fallback.
- Value-parity tests fail (not skip) on fixture-present-but-zero-rows.

## Quality bars
- Full `scripts/agent-gate.sh`: **PASS** (all components; `CQLITE_ALLOW_FILE_GROWTH=1` for 3 pre-existing over-threshold legacy files — split is epic #1116/#1135 scope).
- rust-reviewer: clean (2 LOW nits applied: borrow to remove per-cell alloc + comment fix).
- spec-auditor (C): **PASS** — all 4 requirements satisfied with public-surface evidence; byte-parity provably unchanged.
- roborev: clean (1 Low/optional dispositioned — inner-element byte parity delegated to the unmodified issue_1020 byte-parity test).

Advisory follow-up (non-blocking): no e2e coverage for deeper-than-one-level UDT nesting (UDT-in-UDT / UDT-in-tuple-in-collection); no scenario requires it — will file a follow-up.