### PR TITLE
perf(#1709): cache derived comparators on SchemaEntry (AJ2 — zero deep-clone/parse per parsing-context request)

### DIFF
--- a/cqlite-core/src/schema/cql_type_parser.rs
+++ b/cqlite-core/src/schema/cql_type_parser.rs
@@ -58,6 +58,8 @@ impl CqlType {
 
     /// Parse CQL type string into structured type
     pub fn parse(type_str: &str) -> Result<Self> {
+        #[cfg(test)]
+        crate::schema::work_counters::record_parse_call();
         Self::parse_with_depth(type_str, 0)
     }
 

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -22,6 +22,53 @@ mod udt_registry;
 
 pub use udt_registry::UdtRegistry;
 
+/// Test-only work counters for the derived-comparator caching path (issue #1709).
+///
+/// Compiled out entirely in non-test builds (`#[cfg(test)]`), so they impose
+/// zero cost on production code. They let the registry unit tests assert that,
+/// after a schema is registered, [`registry::SchemaRegistry::get_parsing_context`]
+/// performs ZERO `CqlType::parse` calls and ZERO `TableSchema` deep clones on the
+/// request path (both were `O(columns)` / `4` per call before caching).
+///
+/// The counters are **thread-local**, not global atomics: with the default
+/// `#[tokio::test]` current-thread runtime, a test's awaited async work runs on
+/// the test's own OS thread, so each test observes only its own parse/clone work
+/// and is immune to pollution from tests running concurrently on other threads.
+#[cfg(test)]
+pub(crate) mod work_counters {
+    use std::cell::Cell;
+
+    thread_local! {
+        /// Incremented once per [`super::CqlType::parse`] invocation.
+        static PARSE_CALLS: Cell<usize> = const { Cell::new(0) };
+        /// Incremented once per `TableSchema` deep clone performed by
+        /// [`super::registry::SchemaRegistry::get_schema`].
+        static SCHEMA_CLONES: Cell<usize> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn record_parse_call() {
+        PARSE_CALLS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub(crate) fn record_schema_clone() {
+        SCHEMA_CLONES.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Reset both counters to zero (call before the measured request path).
+    pub(crate) fn reset() {
+        PARSE_CALLS.with(|c| c.set(0));
+        SCHEMA_CLONES.with(|c| c.set(0));
+    }
+
+    pub(crate) fn parse_calls() -> usize {
+        PARSE_CALLS.with(|c| c.get())
+    }
+
+    pub(crate) fn schema_clones() -> usize {
+        SCHEMA_CLONES.with(|c| c.get())
+    }
+}
+
 // Re-export aggregator components
 pub use aggregator::{
     AggregatorConfig, LoadErrorType, LoadResult, SchemaAggregator, SchemaLoadError,

--- a/cqlite-core/src/schema/parser_tests.rs
+++ b/cqlite-core/src/schema/parser_tests.rs
@@ -82,12 +82,12 @@ mod parser_tests {
             ComparatorType::List(Box::new(ComparatorType::Text)),
         );
 
-        ParsingContext {
+        ParsingContext::from_owned(
             schema,
-            partition_comparators: vec![ComparatorType::Int],
-            clustering_comparators: vec![ComparatorType::BigInt],
+            vec![ComparatorType::Int],
+            vec![ComparatorType::BigInt],
             column_comparators,
-        }
+        )
     }
 
     #[test]
@@ -198,12 +198,12 @@ mod parser_tests {
         column_comparators.insert("id".to_string(), ComparatorType::Int);
         column_comparators.insert("region".to_string(), ComparatorType::Text);
 
-        let context = ParsingContext {
+        let context = ParsingContext::from_owned(
             schema,
-            partition_comparators: vec![ComparatorType::Int, ComparatorType::Text],
-            clustering_comparators: vec![],
+            vec![ComparatorType::Int, ComparatorType::Text],
+            vec![],
             column_comparators,
-        };
+        );
 
         let parser = SchemaParser::new(context).unwrap();
 
@@ -235,12 +235,7 @@ mod parser_tests {
         let mut column_comparators = HashMap::new();
         column_comparators.insert("user_id".to_string(), ComparatorType::Uuid);
 
-        let context = ParsingContext {
-            schema,
-            partition_comparators: vec![],
-            clustering_comparators: vec![],
-            column_comparators,
-        };
+        let context = ParsingContext::from_owned(schema, vec![], vec![], column_comparators);
 
         let parser = SchemaParser::new(context).unwrap();
 
@@ -275,12 +270,7 @@ mod parser_tests {
         let mut column_comparators = HashMap::new();
         column_comparators.insert("nested".to_string(), map_comparator);
 
-        let context = ParsingContext {
-            schema,
-            partition_comparators: vec![],
-            clustering_comparators: vec![],
-            column_comparators,
-        };
+        let context = ParsingContext::from_owned(schema, vec![], vec![], column_comparators);
 
         let parser = SchemaParser::new(context).unwrap();
 
@@ -318,12 +308,7 @@ mod parser_tests {
         let mut column_comparators = HashMap::new();
         column_comparators.insert("frozen_set".to_string(), frozen_comparator);
 
-        let context = ParsingContext {
-            schema,
-            partition_comparators: vec![],
-            clustering_comparators: vec![],
-            column_comparators,
-        };
+        let context = ParsingContext::from_owned(schema, vec![], vec![], column_comparators);
 
         let parser = SchemaParser::new(context).unwrap();
 
@@ -369,8 +354,8 @@ mod parser_tests {
 
     #[test]
     fn test_incomplete_context_rejected() {
-        let context = ParsingContext {
-            schema: TableSchema {
+        let context = ParsingContext::from_owned(
+            TableSchema {
                 keyspace: "test".to_string(),
                 table: "test".to_string(),
                 partition_keys: vec![],
@@ -379,10 +364,10 @@ mod parser_tests {
                 comments: HashMap::new(),
                 dropped_columns: HashMap::new(),
             },
-            partition_comparators: vec![],
-            clustering_comparators: vec![],
-            column_comparators: HashMap::new(),
-        };
+            vec![],
+            vec![],
+            HashMap::new(),
+        );
 
         let result = SchemaParser::new(context);
         assert!(result.is_err());
@@ -472,12 +457,12 @@ mod parser_tests {
         column_comparators.insert("sequence".to_string(), ComparatorType::BigInt);
         column_comparators.insert("value".to_string(), ComparatorType::Float);
 
-        let context = ParsingContext {
+        let context = ParsingContext::from_owned(
             schema,
-            partition_comparators: vec![ComparatorType::Text, ComparatorType::Int],
-            clustering_comparators: vec![ComparatorType::Timestamp, ComparatorType::BigInt],
+            vec![ComparatorType::Text, ComparatorType::Int],
+            vec![ComparatorType::Timestamp, ComparatorType::BigInt],
             column_comparators,
-        };
+        );
 
         let parser = SchemaParser::new(context).unwrap();
 
@@ -543,12 +528,12 @@ mod parser_tests {
         );
         column_comparators.insert("user_profiles".to_string(), frozen_list_comparator);
 
-        let context = ParsingContext {
+        let context = ParsingContext::from_owned(
             schema,
-            partition_comparators: vec![ComparatorType::Int],
-            clustering_comparators: vec![ComparatorType::BigInt],
+            vec![ComparatorType::Int],
+            vec![ComparatorType::BigInt],
             column_comparators,
-        };
+        );
 
         let parser = SchemaParser::new(context).unwrap();
 

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -95,11 +95,82 @@ pub struct SchemaRegistry {
     update_locks: std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
+/// Derived parsing state precomputed once at schema registration (issue #1709).
+///
+/// [`SchemaRegistry::get_parsing_context`] is on the read path (called per
+/// Index.db lookup via `key_digest`). Re-deriving the comparators — which are
+/// CONSTANT for a registered schema — on every call cost four `TableSchema`
+/// deep clones and one `CqlType::parse` per column per call. We instead compute
+/// these once when the [`SchemaEntry`] is created and hand them out as `Arc`
+/// clones (a pointer bump). The state lives ON the entry so it is invalidated
+/// atomically whenever the entry is replaced.
+#[derive(Debug, Clone)]
+struct DerivedParsingState {
+    /// The complete table schema, shared.
+    schema: Arc<TableSchema>,
+    /// Comparators for partition key components, in key order.
+    partition_comparators: Arc<Vec<ComparatorType>>,
+    /// Comparators for clustering key components, in key order.
+    clustering_comparators: Arc<Vec<ComparatorType>>,
+    /// Comparators for all columns, keyed by column name.
+    column_comparators: Arc<HashMap<String, ComparatorType>>,
+}
+
+impl DerivedParsingState {
+    /// Compute the derived comparators for a schema. Runs `CqlType::parse` per
+    /// key/column exactly once, at registration time.
+    fn compute(schema: &TableSchema) -> Result<Self> {
+        let mut partition_comparators = Vec::new();
+        for key_column in schema.ordered_partition_keys() {
+            let cql_type = CqlType::parse(&key_column.data_type)?;
+            partition_comparators.push(ComparatorType::from_cql_type(&cql_type)?);
+        }
+
+        let mut clustering_comparators = Vec::new();
+        for key_column in schema.ordered_clustering_keys() {
+            let cql_type = CqlType::parse(&key_column.data_type)?;
+            clustering_comparators.push(ComparatorType::from_cql_type(&cql_type)?);
+        }
+
+        let mut column_comparators = HashMap::new();
+        for column in &schema.columns {
+            let cql_type = CqlType::parse(&column.data_type)?;
+            column_comparators.insert(
+                column.name.clone(),
+                ComparatorType::from_cql_type(&cql_type)?,
+            );
+        }
+
+        Ok(Self {
+            schema: Arc::new(schema.clone()),
+            partition_comparators: Arc::new(partition_comparators),
+            clustering_comparators: Arc::new(clustering_comparators),
+            column_comparators: Arc::new(column_comparators),
+        })
+    }
+
+    /// Build a [`ParsingContext`] by cloning the shared `Arc`s (pointer bumps,
+    /// no deep clone, no parse).
+    fn to_parsing_context(&self) -> ParsingContext {
+        ParsingContext {
+            schema: self.schema.clone(),
+            partition_comparators: self.partition_comparators.clone(),
+            clustering_comparators: self.clustering_comparators.clone(),
+            column_comparators: self.column_comparators.clone(),
+        }
+    }
+}
+
 /// Schema entry in the registry
 #[derive(Debug, Clone)]
 struct SchemaEntry {
     /// The table schema
     schema: TableSchema,
+    /// Precomputed derived parsing state (comparators), or `None` if it could
+    /// not be derived at registration (e.g. a malformed type string). When
+    /// `None`, `get_parsing_context` recomputes on demand, preserving the exact
+    /// original error behavior without deep-cloning the schema.
+    derived: Option<DerivedParsingState>,
     /// Extended schema information if available
     extended_info: Option<SchemaInfo>,
     /// When the schema was registered/updated
@@ -375,9 +446,14 @@ impl SchemaRegistry {
             SchemaValidationStatus::NotValidated
         };
 
-        // Create schema entry
+        // Create schema entry, precomputing the derived comparators once so the
+        // read-path `get_parsing_context` is a pointer bump (issue #1709). A
+        // malformed type leaves `derived = None`; the error then surfaces on the
+        // context path exactly as before (never fails registration).
+        let derived = DerivedParsingState::compute(&schema).ok();
         let entry = SchemaEntry {
             schema: schema.clone(),
+            derived,
             extended_info: None,
             registered_at: SystemTime::now(),
             source,
@@ -426,6 +502,8 @@ impl SchemaRegistry {
                     drop(schemas); // Release read lock
                     return self.refresh_schema(keyspace, table).await;
                 }
+                #[cfg(test)]
+                crate::schema::work_counters::record_schema_clone();
                 Ok(entry.schema.clone())
             }
             None => {
@@ -854,19 +932,50 @@ impl SchemaRegistry {
         Ok(comparators)
     }
 
-    /// Get the complete schema context for parsing operations
+    /// Get the complete schema context for parsing operations.
+    ///
+    /// This is on the read path (per Index.db lookup). For a registered, fresh
+    /// entry it does ZERO `TableSchema` deep clones and ZERO `CqlType::parse`
+    /// calls: it takes ONE read guard and hands out `Arc` clones of the derived
+    /// state precomputed at registration (issue #1709).
     pub async fn get_parsing_context(&self, keyspace: &str, table: &str) -> Result<ParsingContext> {
-        let schema = self.get_schema(keyspace, table).await?;
-        let partition_comparators = self.get_partition_key_comparator(keyspace, table).await?;
-        let clustering_comparators = self.get_clustering_key_comparator(keyspace, table).await?;
-        let column_comparators = self.get_table_comparators(keyspace, table).await?;
+        let table_id = format!("{}.{}", keyspace, table);
 
-        Ok(ParsingContext {
-            schema,
-            partition_comparators,
-            clustering_comparators,
-            column_comparators,
-        })
+        // Fast path: present, fresh, precomputed. One guard, no await under it,
+        // no deep clone, no parse.
+        {
+            let schemas = self.schemas.read().await;
+            if let Some(entry) = schemas.get(&table_id) {
+                if !self.is_entry_expired(entry) {
+                    match &entry.derived {
+                        Some(derived) => return Ok(derived.to_parsing_context()),
+                        // Precompute failed (malformed type): reproduce the
+                        // original error via on-demand recompute. No await held.
+                        None => {
+                            return DerivedParsingState::compute(&entry.schema)
+                                .map(|d| d.to_parsing_context())
+                        }
+                    }
+                }
+            }
+        }
+
+        // Cold path: missing or TTL-expired. Trigger the refresh/auto-discovery
+        // seam (which reinserts the entry with derived state), then read it
+        // back. This is not the post-registration request path.
+        self.get_schema(keyspace, table).await?;
+
+        let schemas = self.schemas.read().await;
+        match schemas.get(&table_id) {
+            Some(entry) => match &entry.derived {
+                Some(derived) => Ok(derived.to_parsing_context()),
+                None => DerivedParsingState::compute(&entry.schema).map(|d| d.to_parsing_context()),
+            },
+            None => Err(Error::Schema(format!(
+                "Schema not found: {}.{}",
+                keyspace, table
+            ))),
+        }
     }
 
     /// Get ComparatorType for clustering key columns (for clustering comparison)
@@ -1025,8 +1134,12 @@ impl SchemaRegistry {
         let table_id = format!("{}.{}", schema.keyspace, schema.table);
         let source = SchemaSource::Discovered(sstable_files.clone());
 
+        // Precompute derived comparators once (issue #1709); this is the
+        // TTL-refresh / auto-discovery seam, so recompute here too.
+        let derived = DerivedParsingState::compute(&schema).ok();
         let entry = SchemaEntry {
             schema,
+            derived,
             extended_info: schema_info,
             registered_at: SystemTime::now(),
             source,
@@ -1463,20 +1576,44 @@ pub struct RegistryStatistics {
     pub cache_hit_rate: f64,
 }
 
-/// Schema-driven parsing context containing all necessary type information
+/// Schema-driven parsing context containing all necessary type information.
+///
+/// Fields are `Arc`-shared with the registry's cached [`SchemaEntry`] derived
+/// state (issue #1709), so constructing a context is a set of pointer bumps
+/// rather than deep clones + per-column type parsing.
 #[derive(Debug, Clone)]
 pub struct ParsingContext {
     /// The complete table schema
-    pub schema: TableSchema,
+    pub schema: Arc<TableSchema>,
     /// Comparators for partition key components
-    pub partition_comparators: Vec<ComparatorType>,
+    pub partition_comparators: Arc<Vec<ComparatorType>>,
     /// Comparators for clustering key components
-    pub clustering_comparators: Vec<ComparatorType>,
+    pub clustering_comparators: Arc<Vec<ComparatorType>>,
     /// Comparators for all columns by name
-    pub column_comparators: HashMap<String, ComparatorType>,
+    pub column_comparators: Arc<HashMap<String, ComparatorType>>,
 }
 
 impl ParsingContext {
+    /// Construct a context from owned parts, sharing each behind an `Arc`.
+    ///
+    /// The registry hands out contexts from precomputed `Arc`s (issue #1709);
+    /// this constructor covers callers that derive the parts ad hoc (e.g.
+    /// `schema_aware_reader`) and keeps the `Arc` wrapping an implementation
+    /// detail of `ParsingContext`.
+    pub fn from_owned(
+        schema: TableSchema,
+        partition_comparators: Vec<ComparatorType>,
+        clustering_comparators: Vec<ComparatorType>,
+        column_comparators: HashMap<String, ComparatorType>,
+    ) -> Self {
+        Self {
+            schema: Arc::new(schema),
+            partition_comparators: Arc::new(partition_comparators),
+            clustering_comparators: Arc::new(clustering_comparators),
+            column_comparators: Arc::new(column_comparators),
+        }
+    }
+
     /// Get comparator for a specific column
     pub fn get_column_comparator(&self, column_name: &str) -> Option<&ComparatorType> {
         self.column_comparators.get(column_name)
@@ -1877,6 +2014,220 @@ mod tests {
             .changes
             .iter()
             .any(|change| matches!(change.change_type, SchemaChangeType::ColumnAdded)));
+    }
+
+    /// A schema exercising every derived vector: a 2-component partition key, a
+    /// 2-component clustering key, and several regular/collection columns.
+    fn multi_column_schema(name: &str) -> TableSchema {
+        use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
+        TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: name.to_string(),
+            partition_keys: vec![
+                KeyColumn {
+                    name: "region".to_string(),
+                    data_type: "text".to_string(),
+                    position: 0,
+                },
+                KeyColumn {
+                    name: "shard".to_string(),
+                    data_type: "int".to_string(),
+                    position: 1,
+                },
+            ],
+            clustering_keys: vec![
+                ClusteringColumn {
+                    name: "ts".to_string(),
+                    data_type: "timestamp".to_string(),
+                    position: 0,
+                    order: ClusteringOrder::Asc,
+                },
+                ClusteringColumn {
+                    name: "seq".to_string(),
+                    data_type: "bigint".to_string(),
+                    position: 1,
+                    order: ClusteringOrder::Desc,
+                },
+            ],
+            columns: vec![
+                Column {
+                    name: "region".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "shard".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "ts".to_string(),
+                    data_type: "timestamp".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "seq".to_string(),
+                    data_type: "bigint".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "payload".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "tags".to_string(),
+                    data_type: "list<text>".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// Issue #1709 (red on main): after registration, `get_parsing_context` must
+    /// perform ZERO `CqlType::parse` calls and ZERO `TableSchema` deep clones on
+    /// the request path. Before caching this was `O(columns)` parses and 4 deep
+    /// clones per call.
+    #[tokio::test]
+    async fn get_parsing_context_does_zero_work_after_registration() {
+        let registry = make_registry(SchemaRegistryConfig::default()).await;
+        registry
+            .register_schema(multi_column_schema("metrics"), SchemaSource::Manual)
+            .await
+            .expect("register");
+
+        // Measure only the request path.
+        crate::schema::work_counters::reset();
+        let _ctx = registry
+            .get_parsing_context("test_ks", "metrics")
+            .await
+            .expect("context");
+
+        assert_eq!(
+            crate::schema::work_counters::parse_calls(),
+            0,
+            "get_parsing_context must not parse any CQL types after registration"
+        );
+        assert_eq!(
+            crate::schema::work_counters::schema_clones(),
+            0,
+            "get_parsing_context must not deep-clone the schema after registration"
+        );
+
+        // A second call is likewise free.
+        crate::schema::work_counters::reset();
+        let _ctx2 = registry
+            .get_parsing_context("test_ks", "metrics")
+            .await
+            .expect("context2");
+        assert_eq!(crate::schema::work_counters::parse_calls(), 0);
+        assert_eq!(crate::schema::work_counters::schema_clones(), 0);
+    }
+
+    /// The cached context must be field-by-field IDENTICAL to the pre-cache path
+    /// (schema + the three comparator collections derived on demand).
+    #[tokio::test]
+    async fn cached_parsing_context_matches_on_demand_derivation() {
+        for schema in [simple_schema("simple"), multi_column_schema("wide")] {
+            let table = schema.table.clone();
+            let registry = make_registry(SchemaRegistryConfig::default()).await;
+            registry
+                .register_schema(schema, SchemaSource::Manual)
+                .await
+                .expect("register");
+
+            let ctx = registry
+                .get_parsing_context("test_ks", &table)
+                .await
+                .expect("context");
+
+            // Reference: the original per-call derivation helpers.
+            let ref_schema = registry
+                .get_schema("test_ks", &table)
+                .await
+                .expect("schema");
+            let ref_partition = registry
+                .get_partition_key_comparator("test_ks", &table)
+                .await
+                .expect("partition");
+            let ref_clustering = registry
+                .get_clustering_key_comparator("test_ks", &table)
+                .await
+                .expect("clustering");
+            let ref_columns = registry
+                .get_table_comparators("test_ks", &table)
+                .await
+                .expect("columns");
+
+            // TableSchema has no PartialEq; compare structurally via serde_json
+            // (order-independent for maps), which is a true field-by-field check.
+            assert_eq!(
+                serde_json::to_value(&*ctx.schema).expect("ctx schema json"),
+                serde_json::to_value(&ref_schema).expect("ref schema json"),
+                "schema mismatch for {}",
+                table
+            );
+            assert_eq!(
+                *ctx.partition_comparators, ref_partition,
+                "partition comparators mismatch for {}",
+                table
+            );
+            assert_eq!(
+                *ctx.clustering_comparators, ref_clustering,
+                "clustering comparators mismatch for {}",
+                table
+            );
+            assert_eq!(
+                *ctx.column_comparators, ref_columns,
+                "column comparators mismatch for {}",
+                table
+            );
+        }
+    }
+
+    /// Two contexts handed out for the same registered schema share the same
+    /// underlying `Arc` allocations (pointer bump, not deep copy).
+    #[tokio::test]
+    async fn parsing_contexts_share_arc_backing() {
+        let registry = make_registry(SchemaRegistryConfig::default()).await;
+        registry
+            .register_schema(multi_column_schema("shared"), SchemaSource::Manual)
+            .await
+            .expect("register");
+
+        let a = registry
+            .get_parsing_context("test_ks", "shared")
+            .await
+            .expect("a");
+        let b = registry
+            .get_parsing_context("test_ks", "shared")
+            .await
+            .expect("b");
+
+        assert!(Arc::ptr_eq(&a.schema, &b.schema));
+        assert!(Arc::ptr_eq(
+            &a.partition_comparators,
+            &b.partition_comparators
+        ));
+        assert!(Arc::ptr_eq(
+            &a.clustering_comparators,
+            &b.clustering_comparators
+        ));
+        assert!(Arc::ptr_eq(&a.column_comparators, &b.column_comparators));
     }
 
     #[tokio::test]

--- a/cqlite-core/src/storage/sstable/key_digest.rs
+++ b/cqlite-core/src/storage/sstable/key_digest.rs
@@ -46,7 +46,7 @@ impl KeyDigestComputer {
         // Step 1: Parse partition key bytes into typed values
         let partition_values = self.parse_partition_key_bytes(
             partition_key_bytes,
-            &parsing_context.partition_comparators,
+            parsing_context.partition_comparators.as_slice(),
         )?;
 
         // Step 2: Create byte-comparable encoding for the composite key
@@ -303,10 +303,10 @@ mod tests {
         };
 
         ParsingContext {
-            schema,
-            partition_comparators,
-            clustering_comparators: vec![],
-            column_comparators: HashMap::new(),
+            schema: std::sync::Arc::new(schema),
+            partition_comparators: std::sync::Arc::new(partition_comparators),
+            clustering_comparators: std::sync::Arc::new(vec![]),
+            column_comparators: std::sync::Arc::new(HashMap::new()),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/key_digest_test.rs
+++ b/cqlite-core/src/storage/sstable/key_digest_test.rs
@@ -33,10 +33,10 @@ mod tests {
         };
 
         ParsingContext {
-            schema,
-            partition_comparators,
-            clustering_comparators: vec![],
-            column_comparators: HashMap::new(),
+            schema: std::sync::Arc::new(schema),
+            partition_comparators: std::sync::Arc::new(partition_comparators),
+            clustering_comparators: std::sync::Arc::new(vec![]),
+            column_comparators: std::sync::Arc::new(HashMap::new()),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/schema_aware_reader.rs
+++ b/cqlite-core/src/storage/sstable/schema_aware_reader.rs
@@ -257,10 +257,10 @@ impl SchemaAwareReader {
         let column_comparators = schema.get_all_comparators()?;
 
         Ok(ParsingContext {
-            schema: schema.clone(),
-            partition_comparators,
-            clustering_comparators,
-            column_comparators,
+            schema: std::sync::Arc::new(schema.clone()),
+            partition_comparators: std::sync::Arc::new(partition_comparators),
+            clustering_comparators: std::sync::Arc::new(clustering_comparators),
+            column_comparators: std::sync::Arc::new(column_comparators),
         })
     }
 
@@ -552,7 +552,7 @@ impl SchemaAwareReader {
         let mut key_bytes = Vec::new();
         for (value, comparator) in partition_key
             .iter()
-            .zip(&self.context.partition_comparators)
+            .zip(self.context.partition_comparators.iter())
         {
             let serialized = self.serialize_value_with_comparator(value, comparator)?;
             key_bytes.extend_from_slice(&serialized);
@@ -560,7 +560,7 @@ impl SchemaAwareReader {
 
         // Serialize clustering key if provided
         if let Some(ck) = clustering_key {
-            for (value, comparator) in ck.iter().zip(&self.context.clustering_comparators) {
+            for (value, comparator) in ck.iter().zip(self.context.clustering_comparators.iter()) {
                 let serialized = self.serialize_value_with_comparator(value, comparator)?;
                 key_bytes.extend_from_slice(&serialized);
             }
@@ -584,7 +584,7 @@ impl SchemaAwareReader {
         let mut total_length = 0;
         for (value, comparator) in partition_values
             .iter()
-            .zip(&self.context.partition_comparators)
+            .zip(self.context.partition_comparators.iter())
         {
             let serialized = self.serialize_value_with_comparator(value, comparator)?;
             total_length += serialized.len();
@@ -705,14 +705,20 @@ mod tests {
         // Build the context directly from the schema (create_parsing_context
         // ignores the registry) so the test needs no async registry/platform.
         let context = ParsingContext {
-            partition_comparators: schema
-                .get_partition_key_comparators()
-                .expect("partition comparators"),
-            clustering_comparators: schema
-                .get_clustering_key_comparators()
-                .expect("clustering comparators"),
-            column_comparators: schema.get_all_comparators().expect("column comparators"),
-            schema,
+            partition_comparators: std::sync::Arc::new(
+                schema
+                    .get_partition_key_comparators()
+                    .expect("partition comparators"),
+            ),
+            clustering_comparators: std::sync::Arc::new(
+                schema
+                    .get_clustering_key_comparators()
+                    .expect("clustering comparators"),
+            ),
+            column_comparators: std::sync::Arc::new(
+                schema.get_all_comparators().expect("column comparators"),
+            ),
+            schema: std::sync::Arc::new(schema),
         };
         let parser = SchemaParser::new(context.clone()).expect("schema parser");
         (context, parser)

--- a/cqlite-core/tests/enhanced_index_operation_tests.rs
+++ b/cqlite-core/tests/enhanced_index_operation_tests.rs
@@ -127,12 +127,12 @@ async fn test_sstable_reader_index_operations(reader: &SSTableReader) {
         dropped_columns: HashMap::new(),
     };
 
-    let parsing_context = ParsingContext {
-        schema: simple_schema,
-        partition_comparators: vec![ComparatorType::Text],
-        clustering_comparators: vec![],
-        column_comparators: HashMap::new(),
-    };
+    let parsing_context = ParsingContext::from_owned(
+        simple_schema,
+        vec![ComparatorType::Text],
+        vec![],
+        HashMap::new(),
+    );
     let _schema_lookup = reader
         .lookup_partition_with_schema_context(schema_test_key, &parsing_context)
         .await;

--- a/cqlite-core/tests/schema_parser_property_tests.rs
+++ b/cqlite-core/tests/schema_parser_property_tests.rs
@@ -26,12 +26,7 @@ fn create_test_context(columns: Vec<Column>) -> ParsingContext {
         dropped_columns: HashMap::new(),
     };
 
-    ParsingContext {
-        partition_comparators: vec![ComparatorType::Int],
-        clustering_comparators: vec![],
-        column_comparators: HashMap::new(),
-        schema,
-    }
+    ParsingContext::from_owned(schema, vec![ComparatorType::Int], vec![], HashMap::new())
 }
 
 /// Property: Parsing a value and re-encoding it should consume exactly the right number of bytes
@@ -59,7 +54,7 @@ fn test_primitive_types_consumed_bytes() {
         }];
 
         let mut context = create_test_context(columns);
-        context.column_comparators.insert(
+        std::sync::Arc::make_mut(&mut context.column_comparators).insert(
             "test_col".to_string(),
             ComparatorType::from_cql_type(&CqlType::parse(type_name).unwrap()).unwrap(),
         );
@@ -106,8 +101,7 @@ fn test_variable_length_types_consumed_bytes() {
     }];
 
     let mut context = create_test_context(columns);
-    context
-        .column_comparators
+    std::sync::Arc::make_mut(&mut context.column_comparators)
         .insert("text_col".to_string(), ComparatorType::Text);
 
     let parser = SchemaParser::new(context).unwrap();
@@ -150,7 +144,7 @@ fn test_list_consumed_bytes() {
     }];
 
     let mut context = create_test_context(columns);
-    context.column_comparators.insert(
+    std::sync::Arc::make_mut(&mut context.column_comparators).insert(
         "list_col".to_string(),
         ComparatorType::from_cql_type(&CqlType::parse("list<int>").unwrap()).unwrap(),
     );
@@ -198,7 +192,7 @@ fn test_map_consumed_bytes() {
     }];
 
     let mut context = create_test_context(columns);
-    context.column_comparators.insert(
+    std::sync::Arc::make_mut(&mut context.column_comparators).insert(
         "map_col".to_string(),
         ComparatorType::from_cql_type(&CqlType::parse("map<int, int>").unwrap()).unwrap(),
     );
@@ -250,7 +244,7 @@ fn test_nested_list_consumed_bytes() {
     }];
 
     let mut context = create_test_context(columns);
-    context.column_comparators.insert(
+    std::sync::Arc::make_mut(&mut context.column_comparators).insert(
         "nested_col".to_string(),
         ComparatorType::from_cql_type(&CqlType::parse("list<list<int>>").unwrap()).unwrap(),
     );
@@ -303,8 +297,8 @@ fn test_null_handling_in_row() {
         },
     ];
 
-    let context = ParsingContext {
-        schema: TableSchema {
+    let context = ParsingContext::from_owned(
+        TableSchema {
             keyspace: "test_ks".to_string(),
             table: "test_table".to_string(),
             partition_keys: vec![KeyColumn {
@@ -317,15 +311,15 @@ fn test_null_handling_in_row() {
             comments: HashMap::new(),
             dropped_columns: HashMap::new(),
         },
-        partition_comparators: vec![ComparatorType::Int],
-        clustering_comparators: vec![],
-        column_comparators: {
+        vec![ComparatorType::Int],
+        vec![],
+        {
             let mut map = HashMap::new();
             map.insert("id".to_string(), ComparatorType::Int);
             map.insert("nullable_col".to_string(), ComparatorType::Text);
             map
         },
-    };
+    );
 
     let parser = SchemaParser::new(context).unwrap();
 
@@ -365,7 +359,7 @@ fn test_tuple_consumed_bytes() {
     }];
 
     let mut context = create_test_context(columns);
-    context.column_comparators.insert(
+    std::sync::Arc::make_mut(&mut context.column_comparators).insert(
         "tuple_col".to_string(),
         ComparatorType::from_cql_type(&CqlType::parse("tuple<int, text>").unwrap()).unwrap(),
     );


### PR DESCRIPTION
Closes #1709 (P1, AJ2). Part of the schema train E5 #1587 → AJ2 → AJ1 #1708.

`SchemaRegistry::get_parsing_context` deep-cloned the whole `TableSchema` 4× and re-ran `CqlType::parse` per column on EVERY read-path request. Now derived state (`Arc`-wrapped schema + partition/clustering/column comparators) is computed ONCE at registration on a new `DerivedParsingState` stored on `SchemaEntry`; the request path is one read-guard → Arc pointer-bumps. Zero deep clones, zero parse per request; invalidated atomically with the entry (register + discovery seams).

**Quality bar (auto-merge on green):**
- `agent-gate.sh`: **PASS** (solo)
- rust-reviewer: clean (equivalence + no-stale-cache + concurrency verified; 2 optional NITs → follow-up)
- roborev (codex): **No issues found**

Tests: work-counter oracle (CqlType::parse == 0 & schema deep-clone == 0 per request, red-verified), old-vs-new equivalence over multi-column/collection schemas, Arc-sharing.

Unblocks #1708 (AJ1). NITs for follow-up: store schema once as Arc (dedup entry.schema vs derived.schema); comment the intentional malformed-schema re-parse.