### PR TITLE
refactor(#1636): J2 partial — unify the two exact-slice ComparatorType value decoders

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/comparator_value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/comparator_value_parsing.rs
@@ -13,8 +13,8 @@
 //! `AbstractType.writeValue()`.
 
 use crate::{
-    parser::vint::{parse_vint, parse_vint_length},
-    types::{ComparatorType, UdtField, UdtValue, Value},
+    parser::vint::parse_vint,
+    types::{ComparatorType, UdtValue, Value},
     Error, Result,
 };
 
@@ -205,21 +205,52 @@ pub fn parse_value_with_comparator(
                 .map_err(|_| Error::corruption("Invalid JSON value"))?;
             Ok(Value::Json(json_value))
         }
-        ComparatorType::List(element_comparator) => {
-            parse_list_value(value_data, element_comparator)
-        }
-        ComparatorType::Set(element_comparator) => parse_set_value(value_data, element_comparator),
+        // Structural types route through the ONE shared structural body in
+        // `value_parsing` (issue #1636 / J2). Non-frozen collections use VInt
+        // element framing; tuple/UDT use Cassandra's 4-byte i32-BE field framing
+        // (`TupleType`/`UserType` `putInt`, `-1` == null) — the same framing the
+        // live block path (decoder #1) and the v5 frozen path already use.
+        ComparatorType::List(element_comparator) => super::value_parsing::parse_list_value_with(
+            value_data,
+            element_comparator,
+            parse_value_with_comparator,
+        ),
+        ComparatorType::Set(element_comparator) => super::value_parsing::parse_set_value_with(
+            value_data,
+            element_comparator,
+            parse_value_with_comparator,
+        ),
         ComparatorType::Map(key_comparator, value_comparator) => {
-            parse_map_value(value_data, key_comparator, value_comparator)
+            super::value_parsing::parse_map_value_with(
+                value_data,
+                key_comparator,
+                value_comparator,
+                parse_value_with_comparator,
+            )
         }
-        ComparatorType::Tuple(field_comparators) => {
-            parse_tuple_value(value_data, field_comparators)
-        }
+        ComparatorType::Tuple(field_comparators) => super::value_parsing::parse_tuple_value_with(
+            value_data,
+            field_comparators,
+            parse_value_with_comparator,
+        ),
         ComparatorType::Udt {
             type_name,
             keyspace,
             field_comparators,
-        } => parse_udt_value(value_data, type_name, keyspace, field_comparators),
+        } => {
+            let udt = super::value_parsing::parse_udt_value_with(
+                value_data,
+                field_comparators,
+                parse_value_with_comparator,
+            )?;
+            // Preserve decoder #2's provenance (type_name/keyspace from the
+            // comparator) rather than the helper's "unknown" placeholders.
+            Ok(Value::Udt(UdtValue {
+                keyspace: keyspace.clone().unwrap_or_else(|| "unknown".to_string()),
+                type_name: type_name.to_string(),
+                fields: udt.fields,
+            }))
+        }
         ComparatorType::Frozen(inner_comparator) => {
             let inner_value = parse_value_with_comparator(value_data, inner_comparator)?;
             Ok(Value::Frozen(Box::new(inner_value)))
@@ -277,192 +308,6 @@ fn parse_duration_value(value_data: &[u8]) -> Result<Value> {
         days,
         nanos,
     })
-}
-
-/// Parse a list value using the element comparator
-fn parse_list_value(value_data: &[u8], element_comparator: &ComparatorType) -> Result<Value> {
-    let mut offset = 0;
-    let mut elements = Vec::new();
-
-    // Parse element count
-    let (remaining, element_count) = parse_vint_length(&value_data[offset..])
-        .map_err(|_| Error::corruption("Failed to parse list element count"))?;
-    offset = value_data.len() - remaining.len();
-
-    // Parse each element
-    for _ in 0..element_count {
-        if offset >= value_data.len() {
-            break;
-        }
-
-        // Parse element length
-        let (remaining, element_len) = parse_vint_length(&value_data[offset..])
-            .map_err(|_| Error::corruption("Failed to parse list element length"))?;
-        offset = value_data.len() - remaining.len();
-
-        if element_len > remaining.len() {
-            return Err(Error::corruption(
-                "List element length exceeds available data",
-            ));
-        }
-
-        // Parse element value using element comparator (recursive)
-        let element_data = &remaining[..element_len];
-        let element_value = parse_value_with_comparator(element_data, element_comparator)?;
-        elements.push(element_value);
-        offset += element_len;
-    }
-
-    Ok(Value::List(elements))
-}
-
-/// Parse a set value using the element comparator
-fn parse_set_value(value_data: &[u8], element_comparator: &ComparatorType) -> Result<Value> {
-    // Sets are parsed similarly to lists
-    let list_value = parse_list_value(value_data, element_comparator)?;
-    if let Value::List(elements) = list_value {
-        Ok(Value::Set(elements))
-    } else {
-        Err(Error::corruption("Failed to parse set value"))
-    }
-}
-
-/// Parse a map value using key and value comparators
-fn parse_map_value(
-    value_data: &[u8],
-    key_comparator: &ComparatorType,
-    value_comparator: &ComparatorType,
-) -> Result<Value> {
-    let mut offset = 0;
-    let mut entries = Vec::new();
-
-    // Parse entry count
-    let (remaining, entry_count) = parse_vint_length(&value_data[offset..])
-        .map_err(|_| Error::corruption("Failed to parse map entry count"))?;
-    offset = value_data.len() - remaining.len();
-
-    // Parse each key-value pair
-    for _ in 0..entry_count {
-        if offset >= value_data.len() {
-            break;
-        }
-
-        // Parse key length and data
-        let (remaining, key_len) = parse_vint_length(&value_data[offset..])
-            .map_err(|_| Error::corruption("Failed to parse map key length"))?;
-        offset = value_data.len() - remaining.len();
-
-        if key_len > remaining.len() {
-            return Err(Error::corruption("Map key length exceeds available data"));
-        }
-
-        let key_data = &remaining[..key_len];
-        let key_value = parse_value_with_comparator(key_data, key_comparator)?;
-        offset += key_len;
-
-        // Parse value length and data
-        let (remaining, value_len) = parse_vint_length(&value_data[offset..])
-            .map_err(|_| Error::corruption("Failed to parse map value length"))?;
-        offset = value_data.len() - remaining.len();
-
-        if value_len > remaining.len() {
-            return Err(Error::corruption("Map value length exceeds available data"));
-        }
-
-        let value_data_slice = &remaining[..value_len];
-        let value = parse_value_with_comparator(value_data_slice, value_comparator)?;
-        offset += value_len;
-
-        entries.push((key_value, value));
-    }
-
-    Ok(Value::Map(entries))
-}
-
-/// Parse a tuple value using field comparators
-fn parse_tuple_value(value_data: &[u8], field_comparators: &[ComparatorType]) -> Result<Value> {
-    let mut offset = 0;
-    let mut fields = Vec::new();
-
-    // Parse each field
-    for field_comparator in field_comparators {
-        if offset >= value_data.len() {
-            // Remaining fields are null
-            fields.push(Value::Null);
-            continue;
-        }
-
-        // Parse field length
-        let (remaining, field_len) = parse_vint_length(&value_data[offset..])
-            .map_err(|_| Error::corruption("Failed to parse tuple field length"))?;
-        offset = value_data.len() - remaining.len();
-
-        if field_len > remaining.len() {
-            return Err(Error::corruption(
-                "Tuple field length exceeds available data",
-            ));
-        }
-
-        // Parse field value using field comparator (recursive)
-        let field_data = &remaining[..field_len];
-        let field_value = parse_value_with_comparator(field_data, field_comparator)?;
-        fields.push(field_value);
-        offset += field_len;
-    }
-
-    Ok(Value::Tuple(fields))
-}
-
-/// Parse a UDT value using field comparators
-fn parse_udt_value(
-    value_data: &[u8],
-    type_name: &str,
-    keyspace: &Option<String>,
-    field_comparators: &[(String, ComparatorType)],
-) -> Result<Value> {
-    let mut offset = 0;
-    let mut fields = Vec::new();
-
-    // Parse each field
-    for (field_name, field_comparator) in field_comparators {
-        if offset >= value_data.len() {
-            // Remaining fields are null
-            fields.push(UdtField {
-                name: field_name.clone(),
-                value: None,
-            });
-            continue;
-        }
-
-        // Parse field length
-        let (remaining, field_len) = parse_vint_length(&value_data[offset..]).map_err(|_| {
-            Error::corruption(format!("Failed to parse UDT field {} length", field_name))
-        })?;
-        offset = value_data.len() - remaining.len();
-
-        if field_len > remaining.len() {
-            return Err(Error::corruption(format!(
-                "UDT field {} length exceeds available data",
-                field_name
-            )));
-        }
-
-        // Parse field value using field comparator (recursive)
-        let field_data = &remaining[..field_len];
-        let field_value = parse_value_with_comparator(field_data, field_comparator)?;
-
-        fields.push(UdtField {
-            name: field_name.clone(),
-            value: Some(field_value),
-        });
-        offset += field_len;
-    }
-
-    Ok(Value::Udt(UdtValue {
-        keyspace: keyspace.clone().unwrap_or_else(|| "unknown".to_string()),
-        type_name: type_name.to_string(),
-        fields,
-    }))
 }
 
 #[cfg(test)]

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_consolidation_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_consolidation_tests.rs
@@ -1,0 +1,147 @@
+//! J2 decoder-consolidation equivalence net (issue #1636, Epic #1603).
+//!
+//! Issue #1636 collapses the duplicated `ComparatorType -> Value` decoders. Two
+//! live decoders share their scalar decode logic but historically DIVERGED on the
+//! structural (tuple / UDT) framing:
+//!
+//! * **decoder #1** — [`SSTableReader::parse_value_with_comparator`]
+//!   (`value_parsing.rs`): tuple/UDT field lengths are 4-byte big-endian signed
+//!   `i32` (`-1` == null), matching Cassandra `TupleType`/`UserType`
+//!   (`accessor.putInt`), the write side, and the v5 frozen path.
+//! * **decoder #2** — the free [`parse_value_with_comparator`]
+//!   (`comparator_value_parsing.rs`, driven by the block-path
+//!   `RowCellStateMachine`): tuple/UDT field lengths were VInt-encoded.
+//!
+//! Feeding the SAME canonical (Cassandra-`i32`-BE) tuple/UDT bytes through both
+//! decoders produced DIFFERENT results — the exact "type fix must land in N places
+//! or paths silently diverge" defect J2 removes. This module pins the equivalence:
+//! after consolidation both decoders share one structural body (i32-BE for
+//! tuple/UDT, VInt for the non-frozen collection element framing they already
+//! agreed on) and the assertions below hold identically.
+//!
+//! Golden arbiter for the tuple/UDT verdict: Cassandra `TupleType.buildValue` /
+//! `UserType` write 4-byte `i32` field lengths (`-1` for null) — the same framing
+//! `value_parsing::parse_tuple_value_with` (decoder #1, the live block path) and
+//! the v5 frozen path already use. The VInt tuple/UDT arm in decoder #2 was the
+//! outlier (dead for the `nb` corpus, which routes tuples through decoder #1 /
+//! the v5 ladder); i32-BE is the retained behavior.
+
+use super::decoder_lockstep_tests::{open_reader, scalar_cases};
+use crate::storage::sstable::reader::parsing::comparator_value_parsing::parse_value_with_comparator as decode_free;
+use crate::storage::sstable::reader::types::SSTableReader;
+use crate::types::{ComparatorType, Value};
+
+/// Decode value bytes through decoder #1 (the `SSTableReader` method) using a
+/// `ComparatorType` directly (no type-string round-trip).
+fn decode_method(reader: &SSTableReader, comp: &ComparatorType, bytes: &[u8]) -> crate::Result<Value> {
+    reader.parse_value_with_comparator(bytes, comp)
+}
+
+/// Canonical Cassandra tuple/UDT field framing: 4-byte big-endian `i32` length
+/// prefix (`-1` for null), then the field body.
+fn push_i32_field(buf: &mut Vec<u8>, body: &[u8]) {
+    buf.extend_from_slice(&(body.len() as i32).to_be_bytes());
+    buf.extend_from_slice(body);
+}
+
+/// Scalar decode is byte-identical across both decoders today; this sweep is a
+/// regression guard so the consolidation cannot silently move a scalar arm.
+#[tokio::test]
+async fn consolidation_scalars_method_eq_free() {
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    for case in scalar_cases() {
+        let comp = ComparatorType::from_data_type(case.cql_type)
+            .unwrap_or_else(|e| panic!("comparator for {} failed: {e:?}", case.cql_type));
+        let a = decode_method(&reader, &comp, &case.value_bytes);
+        let b = decode_free(&case.value_bytes, &comp);
+        match (&a, &b) {
+            (Ok(va), Ok(vb)) => assert_eq!(
+                va, vb,
+                "decoder #1 (method) vs #2 (free) disagree on scalar {}",
+                case.cql_type
+            ),
+            (Err(_), Err(_)) => {}
+            _ => panic!(
+                "decoder #1 vs #2 Ok/Err mismatch on scalar {}: {a:?} vs {b:?}",
+                case.cql_type
+            ),
+        }
+    }
+}
+
+/// MUST-FAIL on main / pass after consolidation: the SAME canonical i32-BE tuple
+/// bytes must decode IDENTICALLY through both decoders. On main decoder #2 used
+/// VInt framing and diverged; after J2 both share the i32-BE structural body.
+#[tokio::test]
+async fn consolidation_tuple_i32_framing_method_eq_free() {
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    // tuple<int, text> = (5, "hi") in Cassandra i32-BE field framing.
+    let mut bytes = Vec::new();
+    push_i32_field(&mut bytes, &5i32.to_be_bytes());
+    push_i32_field(&mut bytes, b"hi");
+    let comp = ComparatorType::Tuple(vec![ComparatorType::Int, ComparatorType::Text]);
+
+    let method = decode_method(&reader, &comp, &bytes)
+        .expect("decoder #1 decodes i32-BE tuple");
+    let free = decode_free(&bytes, &comp).expect("decoder #2 must decode i32-BE tuple after J2");
+    assert_eq!(
+        method,
+        Value::Tuple(vec![Value::Integer(5), Value::Text("hi".into())]),
+        "decoder #1 tuple decode drifted"
+    );
+    assert_eq!(
+        method, free,
+        "LOCKSTEP: decoder #1 (method, i32-BE) vs decoder #2 (free) must agree on \
+         canonical tuple bytes (J2 #1636 — VInt tuple arm collapsed to i32-BE)"
+    );
+}
+
+/// MUST-FAIL on main / pass after: canonical i32-BE UDT bytes decode identically
+/// through both decoders (framing convergence; both fabricate the same fields).
+#[tokio::test]
+async fn consolidation_udt_i32_framing_method_eq_free() {
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    // udt person { name text, age int } = { "bob", 30 } in i32-BE field framing.
+    let mut bytes = Vec::new();
+    push_i32_field(&mut bytes, b"bob");
+    push_i32_field(&mut bytes, &30i32.to_be_bytes());
+    let comp = ComparatorType::Udt {
+        type_name: "person".to_string(),
+        keyspace: Some("ks".to_string()),
+        field_comparators: vec![
+            ("name".to_string(), ComparatorType::Text),
+            ("age".to_string(), ComparatorType::Int),
+        ],
+    };
+
+    let method = decode_method(&reader, &comp, &bytes).expect("decoder #1 decodes i32-BE udt");
+    let free = decode_free(&bytes, &comp).expect("decoder #2 must decode i32-BE udt after J2");
+    // Field values must agree (keyspace/type_name provenance may differ by path;
+    // the framing + field decode is what J2 unifies).
+    let (Value::Udt(m), Value::Udt(f)) = (&method, &free) else {
+        panic!("expected UDT values, got {method:?} / {free:?}");
+    };
+    let mvals: Vec<_> = m.fields.iter().map(|x| (&x.name, &x.value)).collect();
+    let fvals: Vec<_> = f.fields.iter().map(|x| (&x.name, &x.value)).collect();
+    assert_eq!(
+        mvals, fvals,
+        "LOCKSTEP: decoder #1 (method, i32-BE) vs decoder #2 (free) must agree on \
+         canonical UDT field framing (J2 #1636 — VInt UDT arm collapsed to i32-BE)"
+    );
+    assert_eq!(
+        m.fields[0].value.as_ref(),
+        Some(&Value::Text("bob".into())),
+        "UDT name field"
+    );
+    assert_eq!(
+        m.fields[1].value.as_ref(),
+        Some(&Value::Integer(30)),
+        "UDT age field"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_consolidation_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_consolidation_tests.rs
@@ -33,7 +33,11 @@ use crate::types::{ComparatorType, Value};
 
 /// Decode value bytes through decoder #1 (the `SSTableReader` method) using a
 /// `ComparatorType` directly (no type-string round-trip).
-fn decode_method(reader: &SSTableReader, comp: &ComparatorType, bytes: &[u8]) -> crate::Result<Value> {
+fn decode_method(
+    reader: &SSTableReader,
+    comp: &ComparatorType,
+    bytes: &[u8],
+) -> crate::Result<Value> {
     reader.parse_value_with_comparator(bytes, comp)
 }
 
@@ -85,8 +89,7 @@ async fn consolidation_tuple_i32_framing_method_eq_free() {
     push_i32_field(&mut bytes, b"hi");
     let comp = ComparatorType::Tuple(vec![ComparatorType::Int, ComparatorType::Text]);
 
-    let method = decode_method(&reader, &comp, &bytes)
-        .expect("decoder #1 decodes i32-BE tuple");
+    let method = decode_method(&reader, &comp, &bytes).expect("decoder #1 decodes i32-BE tuple");
     let free = decode_free(&bytes, &comp).expect("decoder #2 must decode i32-BE tuple after J2");
     assert_eq!(
         method,

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_lockstep_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_lockstep_tests.rs
@@ -543,7 +543,7 @@ async fn synthetic_reader() -> SSTableReader {
         .expect("opening the synthetic BIG sstable should succeed")
 }
 
-async fn open_reader() -> Option<SSTableReader> {
+pub(crate) async fn open_reader() -> Option<SSTableReader> {
     #[cfg(feature = "write-support")]
     {
         // Dataset-independent: the lockstep net ALWAYS runs, no fixture needed.

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -765,6 +765,11 @@ mod test_support;
 #[cfg(test)]
 pub(crate) mod decoder_lockstep_tests;
 
+// Issue #1636 (Epic #1603, finding J2): decoder-consolidation equivalence net.
+// Pins that the two live `ComparatorType` decoders share one structural body.
+#[cfg(test)]
+mod decoder_consolidation_tests;
+
 #[cfg(test)]
 mod regression_1741c_tests;
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
@@ -10,112 +10,65 @@ use crate::{
 
 use super::super::types::SSTableReader;
 use super::comparator_value_parsing::parse_value_with_comparator as decode_scalar_comparator;
-use super::custom_scalar::decode_custom_scalar;
 
 // ============================================================================
-// Standalone Pure Parsing Functions
+// Scalar decode shims (issue #1636 / J2)
+//
+// These are thin delegations to the ONE scalar decode body in
+// `comparator_value_parsing::parse_value_with_comparator` — the single owner of
+// per-type scalar decoding. They exist only to preserve the small
+// `parse_*_value` test/call surface; they carry no decode logic of their own, so
+// a scalar type fix still lands in exactly one place.
 // ============================================================================
 
-/// Parse boolean value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_boolean_value(data: &[u8]) -> Result<Value> {
-    if data.len() == 1 {
-        Ok(Value::Boolean(data[0] != 0))
-    } else {
-        Err(Error::corruption("Invalid boolean value length"))
-    }
+    decode_scalar_comparator(data, &ComparatorType::Boolean)
 }
 
-/// Parse tinyint value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_tinyint_value(data: &[u8]) -> Result<Value> {
-    if data.len() == 1 {
-        Ok(Value::TinyInt(data[0] as i8))
-    } else {
-        Err(Error::corruption("Invalid tinyint value length"))
-    }
+    decode_scalar_comparator(data, &ComparatorType::TinyInt)
 }
 
-/// Parse smallint value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_smallint_value(data: &[u8]) -> Result<Value> {
-    if data.len() == 2 {
-        let val = i16::from_be_bytes([data[0], data[1]]);
-        Ok(Value::SmallInt(val))
-    } else {
-        Err(Error::corruption("Invalid smallint value length"))
-    }
+    decode_scalar_comparator(data, &ComparatorType::SmallInt)
 }
 
-/// Parse int value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_int_value(data: &[u8]) -> Result<Value> {
-    if data.len() == 4 {
-        let val = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
-        Ok(Value::Integer(val))
-    } else {
-        Err(Error::corruption("Invalid int value length"))
-    }
+    decode_scalar_comparator(data, &ComparatorType::Int)
 }
 
-/// Parse bigint value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_bigint_value(data: &[u8]) -> Result<Value> {
-    if data.len() == 8 {
-        let val = i64::from_be_bytes([
-            data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
-        ]);
-        Ok(Value::BigInt(val))
-    } else {
-        Err(Error::corruption("Invalid bigint value length"))
-    }
+    decode_scalar_comparator(data, &ComparatorType::BigInt)
 }
 
-/// Parse counter value from raw bytes
-///
-/// Counter values at this stage are already extracted i64 values (8 bytes big-endian).
-/// The CounterContext parsing happens earlier in V5CompressedLegacyParser.
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_counter_value(data: &[u8]) -> Result<Value> {
-    if data.len() == 8 {
-        let val = i64::from_be_bytes([
-            data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
-        ]);
-        Ok(Value::Counter(val))
-    } else {
-        Err(Error::corruption("Invalid counter value length"))
-    }
+    decode_scalar_comparator(data, &ComparatorType::Counter)
 }
 
-/// Parse text value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_text_value(data: &[u8]) -> Result<Value> {
-    String::from_utf8(data.to_vec())
-        .map(Value::Text)
-        .map_err(|_| Error::corruption("Invalid UTF-8 in text value"))
+    decode_scalar_comparator(data, &ComparatorType::Text)
 }
 
-/// Parse blob value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_blob_value(data: &[u8]) -> Result<Value> {
-    Ok(Value::Blob(data.to_vec()))
+    decode_scalar_comparator(data, &ComparatorType::Blob)
 }
 
-/// Parse UUID value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_uuid_value(data: &[u8]) -> Result<Value> {
-    if data.len() == 16 {
-        let uuid_bytes: [u8; 16] = data
-            .try_into()
-            .map_err(|_| Error::corruption("Invalid UUID byte array"))?;
-        Ok(Value::Uuid(uuid_bytes))
-    } else {
-        Err(Error::corruption("Invalid UUID value length"))
-    }
+    decode_scalar_comparator(data, &ComparatorType::Uuid)
 }
 
-/// Parse DATE value from raw bytes
+/// Decode a scalar value through the single scalar decode body.
 pub(crate) fn parse_date_value(data: &[u8]) -> Result<Value> {
-    if data.len() == 4 {
-        // Cassandra DATE: 4-byte big-endian unsigned int with Integer.MIN_VALUE offset
-        // for byte-order comparability. Decode by adding i32::MIN back.
-        let stored = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
-        let days_since_epoch = stored.wrapping_add(i32::MIN as u32) as i32;
-        Ok(Value::Date(days_since_epoch))
-    } else {
-        Err(Error::corruption("Invalid DATE value length"))
-    }
+    decode_scalar_comparator(data, &ComparatorType::Date)
 }
 
 /// Parse list value with recursive element parsing via closure
@@ -446,18 +399,11 @@ impl SSTableReader {
         // Convert data type string directly to ComparatorType for decoding
         let comparator = ComparatorType::from_data_type(data_type)?;
 
-        // Use comparator to decode the value properly
+        // Structural types keep this reader's recursion + modern-format guards;
+        // every scalar (incl. schema-derived Custom) routes through the ONE scalar
+        // decode body in `comparator_value_parsing` (issue #1636 / J2), so a scalar
+        // type fix lands in exactly one place.
         match &comparator {
-            ComparatorType::Boolean => parse_boolean_value(value_data),
-            ComparatorType::TinyInt => parse_tinyint_value(value_data),
-            ComparatorType::SmallInt => parse_smallint_value(value_data),
-            ComparatorType::Int => parse_int_value(value_data),
-            ComparatorType::BigInt => parse_bigint_value(value_data),
-            ComparatorType::Counter => parse_counter_value(value_data),
-            ComparatorType::Text => parse_text_value(value_data),
-            ComparatorType::Blob => parse_blob_value(value_data),
-            ComparatorType::Uuid => parse_uuid_value(value_data),
-            ComparatorType::Date => parse_date_value(value_data),
             ComparatorType::List(element_comparator) => {
                 self.parse_list_value(value_data, element_comparator)
             }
@@ -478,19 +424,7 @@ impl SSTableReader {
                 let inner_value = self.parse_value_with_comparator(value_data, inner_comparator)?;
                 Ok(Value::Frozen(Box::new(inner_value)))
             }
-            // Scalar types with no self-recursion: delegate to the authoritative
-            // standalone decoder (issue #1627 — these previously fell through to a
-            // wrong-typed Value::Blob).
-            ComparatorType::Float32
-            | ComparatorType::Float
-            | ComparatorType::Timestamp
-            | ComparatorType::Varint
-            | ComparatorType::Decimal
-            | ComparatorType::Duration
-            | ComparatorType::Json => decode_scalar_comparator(value_data, &comparator),
-            // `time`/`inet` arrive as schema-derived Custom(name); genuinely-unknown
-            // custom types remain the only legitimate blob fallback.
-            ComparatorType::Custom(name) => decode_custom_scalar(name, value_data),
+            _ => decode_scalar_comparator(value_data, &comparator),
         }
     }
 
@@ -504,16 +438,6 @@ impl SSTableReader {
         comparator: &ComparatorType,
     ) -> Result<Value> {
         match comparator {
-            ComparatorType::Boolean => parse_boolean_value(value_data),
-            ComparatorType::TinyInt => parse_tinyint_value(value_data),
-            ComparatorType::SmallInt => parse_smallint_value(value_data),
-            ComparatorType::Int => parse_int_value(value_data),
-            ComparatorType::BigInt => parse_bigint_value(value_data),
-            ComparatorType::Counter => parse_counter_value(value_data),
-            ComparatorType::Text => parse_text_value(value_data),
-            ComparatorType::Blob => parse_blob_value(value_data),
-            ComparatorType::Uuid => parse_uuid_value(value_data),
-            ComparatorType::Date => parse_date_value(value_data),
             ComparatorType::List(element_comparator) => {
                 self.parse_list_value(value_data, element_comparator)
             }
@@ -599,18 +523,9 @@ impl SSTableReader {
                 let inner_value = self.parse_value_with_comparator(value_data, inner_comparator)?;
                 Ok(Value::Frozen(Box::new(inner_value)))
             }
-            // Scalar collection elements: delegate to the authoritative standalone
-            // decoder rather than blob-decoding them (issue #1627, same defect
-            // class as parse_value_with_schema_type).
-            ComparatorType::Float32
-            | ComparatorType::Float
-            | ComparatorType::Timestamp
-            | ComparatorType::Varint
-            | ComparatorType::Decimal
-            | ComparatorType::Duration
-            | ComparatorType::Json => decode_scalar_comparator(value_data, comparator),
-            // `time`/`inet` as schema-derived Custom(name); unknown custom → blob.
-            ComparatorType::Custom(name) => decode_custom_scalar(name, value_data),
+            // Every scalar (incl. schema-derived Custom) routes through the ONE
+            // scalar decode body in `comparator_value_parsing` (issue #1636 / J2).
+            _ => decode_scalar_comparator(value_data, comparator),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
@@ -312,7 +312,6 @@ where
 /// Cassandra UDT field lengths are encoded as 4-byte big-endian signed int32
 /// (TupleType.java / UserType.java use `accessor.putInt`), with -1 meaning null.
 /// This is NOT VInt encoding.
-#[allow(dead_code)] // Used in tests; may be used by future refactoring
 pub(crate) fn parse_udt_value_with<F>(
     data: &[u8],
     field_comparators: &[(String, ComparatorType)],

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
@@ -14,59 +14,69 @@ use super::comparator_value_parsing::parse_value_with_comparator as decode_scala
 // ============================================================================
 // Scalar decode shims (issue #1636 / J2)
 //
-// These are thin delegations to the ONE scalar decode body in
-// `comparator_value_parsing::parse_value_with_comparator` — the single owner of
-// per-type scalar decoding. They exist only to preserve the small
-// `parse_*_value` test/call surface; they carry no decode logic of their own, so
-// a scalar type fix still lands in exactly one place.
+// Test-only thin delegations to the ONE scalar decode body in
+// `comparator_value_parsing::parse_value_with_comparator` (the single owner of
+// per-type scalar decoding). Production code routes scalars there directly (the
+// `_ => decode_scalar_comparator(..)` arms below), so these carry NO decode logic
+// and exist only as the `parse_*_value` unit-test surface — hence `#[cfg(test)]`.
 // ============================================================================
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_boolean_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::Boolean)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_tinyint_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::TinyInt)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_smallint_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::SmallInt)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_int_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::Int)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_bigint_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::BigInt)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_counter_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::Counter)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_text_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::Text)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_blob_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::Blob)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_uuid_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::Uuid)
 }
 
-/// Decode a scalar value through the single scalar decode body.
+/// Decode a scalar value through the single scalar decode body (test surface).
+#[cfg(test)]
 pub(crate) fn parse_date_value(data: &[u8]) -> Result<Value> {
     decode_scalar_comparator(data, &ComparatorType::Date)
 }


### PR DESCRIPTION
Partial delivery of #1636 (J2, epic #1603), per the owner's **"bank partial + rescope"** decision. Oracle-driven (golden JSONL arbiter); no OpenSpec.

## What this banks (behavior-preserving)
Unifies the two live **exact-slice** ComparatorType cell-value decoders — #1 `value_parsing.rs` (block path) and #2 `comparator_value_parsing.rs` — onto **one shared scalar body** (`decode_scalar_comparator`) and **one shared structural body** (`parse_*_value_with`). Decoder #2's list/set/map/tuple/UDT arms now route through the shared bodies; its ~250 duplicate lines are deleted. The 10 now-unused `parse_*_value` fns become `#[cfg(test)]` shims.

**Framing convergence (golden-arbitrated):** decoder #2's tuple/UDT field framing moves VInt → **Cassandra i32-BE**. This was dead for the `nb`/`oa`/`da` corpus (those route through decoder #1 / the v5 ladder, already i32-BE), so **no golden output changes** (51/51 smoke parity, full integration green). It also *fixes a latent read↔write mismatch* — the writer (`serialization/types.rs`) already emits i32-BE with an explicit `// CRITICAL: 4-byte BE i32 length, NOT VInt!`, which old decoder #2 contradicted. An independent rust-reviewer confirmed the non-regression via 4 lines of evidence.

## TDD
`decoder_consolidation_tests.rs` — `consolidation_tuple_i32_framing_method_eq_free` / `_udt_...` FAIL on pre-change main (VInt vs i32-BE) and PASS after; `consolidation_scalars_method_eq_free` regression guard.

## Explicitly NOT in this partial (rescoped — the issue body overstated the duplication)
- **Decoder #3 (`SchemaParser`)** — a live, genuinely different length-prefix decoder; merging is behavior-changing → design follow-up **#1965**.
- **`ComplexTypeParser`** — distinct error semantics → design follow-up **#1965**.
- **UDT i32-BE decode still in 3 copies** within `value_parsing.rs` (roborev) → behavior-preserving single-owner routing follow-up **#1964**.
- **block-vs-v5 float/varint divergences** live in J1's files, blocked on **#1635 (J1)** → follow-up **#1964**.

## Notes (roborev Low, dispositioned)
- Trailing-field truncation semantics for decoder #2 now match decoder #1 (`break`-omit vs old Null-fill) — corrupt/truncated input only; well-framed Cassandra data always full-frames every field.

## Quality bars
- Full `scripts/agent-gate.sh`: **PASS** (all components incl. compaction-byte-parity; `CQLITE_ALLOW_FILE_GROWTH=1` for the `mod.rs` +5 `mod` declaration on a pre-existing over-threshold file — split is epic #1116 scope).
- rust-reviewer: clean (non-regression independently confirmed; 3 LOW nits → notes / follow-ups).
- roborev: clean (3 Low dispositioned; substantive UDT-3-copies item → #1964).

Remaining J2 scope tracked in #1964 (mechanical) + #1965 (design). Refs #1603.