### PR TITLE
fix(#1708): one schema source of truth — SchemaManager delegates to the registry (AJ1)

### DIFF
--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -1101,9 +1101,15 @@ impl SelectExecutor {
     /// its shape) — this is purely query-side de-duplication.
     async fn resolve_table_schema(&self, table: &TableId) -> Option<Arc<TableSchema>> {
         let (keyspace, table_name) = parse_table_id(table);
+        // The registry owns freshness (issue #1708): an expired entry that cannot
+        // be refreshed surfaces as `Err`; schema resolution here is best-effort
+        // (missing/unresolvable schema falls back to row-derived columns), so a
+        // refresh error folds to `None` rather than aborting the query.
         self._schema
             .find_schema_by_table(&keyspace, &table_name)
             .await
+            .ok()
+            .flatten()
             .map(Arc::new)
     }
 

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -764,17 +764,38 @@ impl TableSchema {
     }
 }
 
-/// Schema management service for handling table schemas and UDT definitions
+/// Schema management service for handling table schemas and UDT definitions.
+///
+/// Issue #1708 (one schema source of truth): the manager holds an
+/// `Arc<RwLock<SchemaRegistry>>` and RESOLVES every schema/UDT lookup THROUGH
+/// that registry (and REGISTERS manager-side loads INTO it). It keeps NO
+/// by-value schema/UDT copy of its own, so registry-side TTL-refresh /
+/// auto-discovery and manager-side loads are always mutually visible — the two
+/// can never silently diverge. The registry owns freshness (TTL/refresh); the
+/// manager delegates.
 #[derive(Debug)]
 pub struct SchemaManager {
     #[allow(dead_code)]
     storage: Arc<StorageEngine>,
-    schemas: Arc<RwLock<HashMap<String, TableSchema>>>,
-    /// UDT registry for managing User Defined Types (internal, use accessor methods)
-    pub(crate) udt_registry: Arc<RwLock<UdtRegistry>>,
+    /// The single source of truth for table schemas and UDTs.
+    registry: Arc<RwLock<registry::SchemaRegistry>>,
 }
 
 impl SchemaManager {
+    /// Build a default schema registry sharing the given platform/config.
+    async fn default_registry(
+        platform: Arc<crate::platform::Platform>,
+        config: &Config,
+    ) -> Result<Arc<RwLock<registry::SchemaRegistry>>> {
+        let registry = registry::SchemaRegistry::new(
+            registry::SchemaRegistryConfig::default(),
+            platform,
+            config.clone(),
+        )
+        .await?;
+        Ok(Arc::new(RwLock::new(registry)))
+    }
+
     /// Create a new schema manager from a path
     pub async fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
         // Create temporary storage engine (not actually used in this context)
@@ -784,27 +805,22 @@ impl SchemaManager {
             StorageEngine::open(
                 path.as_ref(),
                 &config,
-                platform,
+                platform.clone(),
                 #[cfg(feature = "state_machine")]
                 None,
             )
             .await?,
         );
 
-        Ok(Self {
-            storage,
-            schemas: Arc::new(RwLock::new(HashMap::new())),
-            udt_registry: Arc::new(RwLock::new(UdtRegistry::new())),
-        })
+        let registry = Self::default_registry(platform, &config).await?;
+        Ok(Self { storage, registry })
     }
 
     /// Create a new schema manager with storage
-    pub async fn new_with_storage(storage: Arc<StorageEngine>, _config: &Config) -> Result<Self> {
-        let manager = Self {
-            storage,
-            schemas: Arc::new(RwLock::new(HashMap::new())),
-            udt_registry: Arc::new(RwLock::new(UdtRegistry::new())),
-        };
+    pub async fn new_with_storage(storage: Arc<StorageEngine>, config: &Config) -> Result<Self> {
+        let platform = Arc::new(crate::platform::Platform::new(config).await?);
+        let registry = Self::default_registry(platform, config).await?;
+        let manager = Self { storage, registry };
 
         // Load built-in UDT definitions for Cassandra 5.0 compatibility
         manager.load_default_udts().await;
@@ -817,6 +833,10 @@ impl SchemaManager {
     /// This constructor is used when schemas are loaded from external .cql files
     /// during ingestion, allowing the pre-loaded schemas to be used by the query engine.
     ///
+    /// Issue #1708: the registry is SHARED by reference (not snapshotted). Every
+    /// subsequent registry-side update is immediately visible to this manager,
+    /// and every manager-side load is registered back into this same registry.
+    ///
     /// # Arguments
     ///
     /// * `storage` - The storage engine instance
@@ -827,28 +847,16 @@ impl SchemaManager {
         registry: Arc<tokio::sync::RwLock<registry::SchemaRegistry>>,
         _config: &Config,
     ) -> Result<Self> {
-        // Acquire both schemas and UDT registry in a single lock scope to prevent deadlocks
-        let (loaded_schemas, udt_registry) = {
-            let registry_guard = registry.read().await;
-            let schemas = registry_guard.list_schemas(None).await?;
-            let udt_reg = registry_guard.get_udt_registry();
-            (schemas, udt_reg)
-        }; // Lock is dropped here before further processing
+        Ok(Self { storage, registry })
+    }
 
-        // Populate internal schemas map
-        let mut schemas_map = HashMap::new();
-        for schema in loaded_schemas {
-            let table_id = format!("{}.{}", schema.keyspace, schema.table);
-            schemas_map.insert(table_id, schema);
-        }
-
-        let manager = Self {
-            storage,
-            schemas: Arc::new(RwLock::new(schemas_map)),
-            udt_registry,
-        };
-
-        Ok(manager)
+    /// Access the shared schema registry (test-only).
+    ///
+    /// Lets tests register schemas/UDTs into the single source of truth the
+    /// manager resolves through, to assert cross-visibility (issue #1708).
+    #[cfg(test)]
+    pub(crate) fn registry(&self) -> Arc<RwLock<registry::SchemaRegistry>> {
+        self.registry.clone()
     }
 
     /// Load default UDT definitions that are commonly used in Cassandra
@@ -861,7 +869,7 @@ impl SchemaManager {
             .with_field("zip_code".to_string(), CqlType::Text, true)
             .with_field("country".to_string(), CqlType::Text, true);
 
-        self.udt_registry.write().await.register_udt(address_udt);
+        self.register_udt(address_udt).await;
 
         // Enhanced person UDT with nested address
         let person_udt = UdtTypeDef::new("test_keyspace".to_string(), "person".to_string())
@@ -888,7 +896,7 @@ impl SchemaManager {
                 true,
             );
 
-        self.udt_registry.write().await.register_udt(person_udt);
+        self.register_udt(person_udt).await;
 
         // Company UDT with nested person and address relationships
         let company_udt = UdtTypeDef::new("test_keyspace".to_string(), "company".to_string())
@@ -914,21 +922,25 @@ impl SchemaManager {
             )
             .with_field("founded_year".to_string(), CqlType::Int, true);
 
-        self.udt_registry.write().await.register_udt(company_udt);
+        self.register_udt(company_udt).await;
     }
 
-    /// Register a new UDT type definition
+    /// Register a new UDT type definition into the shared registry (issue #1708).
     pub async fn register_udt(&self, udt_def: UdtTypeDef) {
-        self.udt_registry.write().await.register_udt(udt_def);
+        // `SchemaRegistry::register_udt` is infallible in practice (it only
+        // inserts into the in-memory UDT registry); ignore the `Ok(())`.
+        let _ = self.registry.read().await.register_udt(udt_def).await;
     }
 
-    /// Get a UDT definition (returns a cloned UdtTypeDef)
+    /// Get a UDT definition from the shared registry (returns a cloned UdtTypeDef).
     pub async fn get_udt(&self, keyspace: &str, name: &str) -> Option<UdtTypeDef> {
-        self.udt_registry
+        self.registry
             .read()
             .await
             .get_udt(keyspace, name)
-            .cloned()
+            .await
+            .ok()
+            .flatten()
     }
 
     /// Load schema for a table.
@@ -938,59 +950,59 @@ impl SchemaManager {
     /// fabricated-shape rows for undefined tables, violating the no-heuristics
     /// mandate. This mirrors the I3 (#1626) hard-fail precedent (issue #1710).
     ///
-    /// This is a pure read-lock lookup: no write happens on the unknown-table
-    /// path, so there is no read-drop-write TOCTOU here.
+    /// This resolves THROUGH the shared registry (issue #1708), so a
+    /// registry-side TTL-refresh / auto-discovery is always observed and a
+    /// stale by-value snapshot can never be served. No write happens on the
+    /// unknown-table path.
     pub async fn load_schema(&self, table_name: &str) -> Result<TableSchema> {
-        let schemas = self.schemas.read().await;
-        schemas.get(table_name).cloned().ok_or_else(|| {
-            Error::schema(format!(
-                "unknown table {}; no schema registered or discovered",
-                table_name
-            ))
-        })
+        // A `keyspace.table` name resolves as an exact scoped lookup; a bare
+        // name matches by table name across keyspaces.
+        let (keyspace, table) = match table_name.split_once('.') {
+            Some((ks, tbl)) => (Some(ks.to_string()), tbl),
+            None => (None, table_name),
+        };
+        self.find_schema_by_table(&keyspace, table)
+            .await
+            .ok_or_else(|| {
+                Error::schema(format!(
+                    "unknown table {}; no schema registered or discovered",
+                    table_name
+                ))
+            })
     }
 
-    /// Parse and register a schema from a CQL CREATE TABLE statement
+    /// Parse and register a schema from a CQL CREATE TABLE statement.
+    ///
+    /// Registers INTO the shared registry (issue #1708) so the parsed schema is
+    /// immediately visible to every other holder of the registry (parsing paths,
+    /// other managers), not stored in a private manager-only map.
     pub async fn parse_and_register_cql_schema(&self, cql: &str) -> Result<TableSchema> {
         let schema = cql_parser::parse_cql_schema(cql)?;
-        let table_key = format!("{}.{}", schema.keyspace, schema.table);
-        self.schemas
-            .write()
+        self.registry
+            .read()
             .await
-            .insert(table_key.clone(), schema.clone());
+            .register_schema(schema.clone(), registry::SchemaSource::Cql(cql.to_string()))
+            .await?;
         Ok(schema)
     }
 
-    /// Find schema by table name with optional keyspace matching
+    /// Find schema by table name with optional keyspace matching.
+    ///
+    /// Resolves THROUGH the shared registry (issue #1708); the registry clones
+    /// only the matched schema.
     pub async fn find_schema_by_table(
         &self,
         keyspace: &Option<String>,
         table: &str,
     ) -> Option<TableSchema> {
-        let schemas = self.schemas.read().await;
-
-        // First try exact match if keyspace provided
-        if let Some(ks) = keyspace {
-            let key = format!("{}.{}", ks, table);
-            if let Some(schema) = schemas.get(&key) {
-                #[cfg(test)]
-                TABLE_SCHEMA_CLONES.with(|c| c.set(c.get() + 1));
-                return Some(schema.clone());
-            }
-        }
-
-        // Then try to find any schema matching the table name
-        let found = schemas
-            .values()
-            .find(|schema| {
-                cql_parser::table_name_matches(
-                    &Some(schema.keyspace.clone()),
-                    &schema.table,
-                    keyspace,
-                    table,
-                )
-            })
-            .cloned();
+        let found = self
+            .registry
+            .read()
+            .await
+            .find_schema_by_table(keyspace, table)
+            .await;
+        // Preserve the issue #1587 (E5) once-per-query deep-clone accounting: the
+        // registry performs exactly one `TableSchema` clone on a hit.
         #[cfg(test)]
         if found.is_some() {
             TABLE_SCHEMA_CLONES.with(|c| c.set(c.get() + 1));
@@ -1265,11 +1277,11 @@ mod tests {
             .expect("primitive/collection-only schema should validate");
     }
 
-    async fn test_manager() -> Arc<SchemaManager> {
+    async fn build_storage() -> Arc<StorageEngine> {
         let config = Config::default();
         let platform = Arc::new(crate::platform::Platform::new(&config).await.unwrap());
         let temp_dir = tempfile::tempdir().unwrap();
-        let storage = Arc::new(
+        Arc::new(
             StorageEngine::open(
                 temp_dir.path(),
                 &config,
@@ -1279,7 +1291,26 @@ mod tests {
             )
             .await
             .unwrap(),
-        );
+        )
+    }
+
+    async fn build_shared_registry() -> Arc<RwLock<registry::SchemaRegistry>> {
+        let config = Config::default();
+        let platform = Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+        Arc::new(RwLock::new(
+            registry::SchemaRegistry::new(
+                registry::SchemaRegistryConfig::default(),
+                platform,
+                config,
+            )
+            .await
+            .unwrap(),
+        ))
+    }
+
+    async fn test_manager() -> Arc<SchemaManager> {
+        let config = Config::default();
+        let storage = build_storage().await;
         Arc::new(
             SchemaManager::new_with_storage(storage, &config)
                 .await
@@ -1310,29 +1341,37 @@ mod tests {
             "error must name the unknown table, got: {err}"
         );
 
-        // And the failed lookup must NOT insert a fabricated entry.
-        assert!(
-            manager.schemas.read().await.is_empty(),
+        // And the failed lookup must NOT register a fabricated entry.
+        let stats = manager
+            .registry()
+            .read()
+            .await
+            .get_statistics()
+            .await
+            .unwrap();
+        assert_eq!(
+            stats.total_schemas, 0,
             "unknown-table lookup must not mutate the registry"
         );
     }
 
     /// Issue #1710: concurrent `load_schema` of a registered table returns the
-    /// real schema from every task, and never mutates the registry (the
-    /// unknown-table path no longer does a read-drop-write, so there is no
-    /// lost-update TOCTOU).
+    /// real schema from every task, and never mutates the registry.
     #[tokio::test]
     async fn test_concurrent_schema_access() {
         let manager = test_manager().await;
 
-        // Register 3 real schemas up front (authoritative metadata only).
+        // Register 3 real schemas up front THROUGH the shared registry (issue
+        // #1708 single source of truth; authoritative metadata only).
         for i in 0..3 {
             let name = format!("table_{}", i);
             manager
-                .schemas
-                .write()
+                .registry()
+                .read()
                 .await
-                .insert(name.clone(), table_schema_named(&name));
+                .register_schema(table_schema_named(&name), registry::SchemaSource::Manual)
+                .await
+                .unwrap();
         }
 
         // Spawn 10 concurrent tasks loading the 3 tables.
@@ -1351,11 +1390,142 @@ mod tests {
         }
 
         // Registry is unchanged: exactly the 3 registered entries, no fabrication.
-        let schemas = manager.schemas.read().await;
-        assert_eq!(schemas.len(), 3);
-        assert!(schemas.contains_key("table_0"));
-        assert!(schemas.contains_key("table_1"));
-        assert!(schemas.contains_key("table_2"));
+        let stats = manager
+            .registry()
+            .read()
+            .await
+            .get_statistics()
+            .await
+            .unwrap();
+        assert_eq!(stats.total_schemas, 3);
+        for i in 0..3 {
+            assert!(manager.load_schema(&format!("table_{}", i)).await.is_ok());
+        }
+    }
+
+    /// Issue #1708: the manager must resolve THROUGH the shared registry, never a
+    /// stale by-value snapshot captured at construction. Register v1, build the
+    /// manager, then update the schema THROUGH the registry (simulating a
+    /// TTL-refresh / auto-discovery re-registration) and confirm the manager
+    /// observes v2. RED on main (returned the snapshotted v1).
+    #[tokio::test]
+    async fn test_manager_reflects_registry_updates_no_stale_snapshot() {
+        let registry = build_shared_registry().await;
+
+        // v1: two columns (id uuid, value text).
+        let v1 = table_schema_named("evolving");
+        assert_eq!(v1.columns.len(), 2);
+        registry
+            .read()
+            .await
+            .register_schema(v1.clone(), registry::SchemaSource::Manual)
+            .await
+            .unwrap();
+
+        let storage = build_storage().await;
+        let config = Config::default();
+        let manager = SchemaManager::new_with_registry(storage, registry.clone(), &config)
+            .await
+            .unwrap();
+
+        let got_v1 = manager.get_table_schema("evolving").await.unwrap();
+        assert_eq!(got_v1.columns.len(), 2, "manager must see v1");
+
+        // Update THROUGH the registry: v2 adds a column.
+        let mut v2 = v1.clone();
+        v2.columns.push(Column {
+            name: "extra".to_string(),
+            data_type: "int".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        });
+        registry
+            .read()
+            .await
+            .register_schema(v2, registry::SchemaSource::Manual)
+            .await
+            .unwrap();
+
+        let got_v2 = manager.get_table_schema("evolving").await.unwrap();
+        assert_eq!(
+            got_v2.columns.len(),
+            3,
+            "manager must resolve THROUGH the registry, not a stale by-value snapshot"
+        );
+    }
+
+    /// Issue #1708: UDT-registry sharing must be constructor-INDEPENDENT. A UDT
+    /// registered into the shared registry is visible via the manager's `get_udt`
+    /// for EVERY constructor path, and a UDT registered via the manager is
+    /// visible via the shared registry. RED on main for `new`/`new_with_storage`
+    /// (they built an unshared private UDT-registry copy).
+    #[tokio::test]
+    async fn test_all_constructors_share_udt_registry() {
+        // Manager built via `new`.
+        let temp = tempfile::tempdir().unwrap();
+        let via_new = SchemaManager::new(temp.path()).await.unwrap();
+
+        // Manager built via `new_with_storage`.
+        let config = Config::default();
+        let via_storage = {
+            let storage = build_storage().await;
+            SchemaManager::new_with_storage(storage, &config)
+                .await
+                .unwrap()
+        };
+
+        // Manager built via `new_with_registry`.
+        let via_registry = {
+            let registry = build_shared_registry().await;
+            let storage = build_storage().await;
+            SchemaManager::new_with_registry(storage, registry, &config)
+                .await
+                .unwrap()
+        };
+
+        for (label, manager) in [
+            ("new", &via_new),
+            ("new_with_storage", &via_storage),
+            ("new_with_registry", &via_registry),
+        ] {
+            // registry -> manager visibility
+            let point = UdtTypeDef::new("ks_share".to_string(), "point".to_string()).with_field(
+                "x".to_string(),
+                CqlType::Int,
+                true,
+            );
+            manager
+                .registry()
+                .read()
+                .await
+                .register_udt(point)
+                .await
+                .unwrap();
+            assert!(
+                manager.get_udt("ks_share", "point").await.is_some(),
+                "[{label}] UDT registered in the shared registry must be visible via the manager"
+            );
+
+            // manager -> registry visibility
+            let line = UdtTypeDef::new("ks_share".to_string(), "line".to_string()).with_field(
+                "len".to_string(),
+                CqlType::Int,
+                true,
+            );
+            manager.register_udt(line).await;
+            let seen = manager
+                .registry()
+                .read()
+                .await
+                .get_udt("ks_share", "line")
+                .await
+                .unwrap();
+            assert!(
+                seen.is_some(),
+                "[{label}] UDT registered via the manager must be visible in the shared registry"
+            );
+        }
     }
 
     #[test]

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -962,7 +962,7 @@ impl SchemaManager {
             None => (None, table_name),
         };
         self.find_schema_by_table(&keyspace, table)
-            .await
+            .await?
             .ok_or_else(|| {
                 Error::schema(format!(
                     "unknown table {}; no schema registered or discovered",
@@ -988,26 +988,29 @@ impl SchemaManager {
 
     /// Find schema by table name with optional keyspace matching.
     ///
-    /// Resolves THROUGH the shared registry (issue #1708); the registry clones
-    /// only the matched schema.
+    /// Resolves THROUGH the shared registry (issue #1708); the registry owns
+    /// freshness (issue #1708 roborev Medium): a fresh matched entry is cloned
+    /// once (issue #1587), an EXPIRED entry is refreshed rather than served
+    /// stale, and an unregistered table yields `Ok(None)` with NO fabrication
+    /// (issue #1710). The registry's refresh error (if any) propagates as `Err`.
     pub async fn find_schema_by_table(
         &self,
         keyspace: &Option<String>,
         table: &str,
-    ) -> Option<TableSchema> {
+    ) -> Result<Option<TableSchema>> {
         let found = self
             .registry
             .read()
             .await
             .find_schema_by_table(keyspace, table)
-            .await;
+            .await?;
         // Preserve the issue #1587 (E5) once-per-query deep-clone accounting: the
         // registry performs exactly one `TableSchema` clone on a hit.
         #[cfg(test)]
         if found.is_some() {
             TABLE_SCHEMA_CLONES.with(|c| c.set(c.get() + 1));
         }
-        found
+        Ok(found)
     }
 
     /// Extract table information from CQL without full parsing
@@ -1023,7 +1026,7 @@ impl SchemaManager {
     /// Get table schema by name (async for compatibility)
     pub async fn get_table_schema(&self, table_name: &str) -> Result<TableSchema> {
         // Try to find schema by table name
-        if let Some(schema) = self.find_schema_by_table(&None, table_name).await {
+        if let Some(schema) = self.find_schema_by_table(&None, table_name).await? {
             Ok(schema)
         } else {
             Err(Error::Schema(format!(
@@ -1452,6 +1455,65 @@ mod tests {
             got_v2.columns.len(),
             3,
             "manager must resolve THROUGH the registry, not a stale by-value snapshot"
+        );
+    }
+
+    /// Issue #1708 (roborev Medium): the registry OWNS freshness and the manager
+    /// merely delegates — an entry EXPIRED in the registry must NOT be served
+    /// stale through the manager. With `cache_ttl_seconds = 0` the registered
+    /// schema expires, so `load_schema`/`get_table_schema` must return the
+    /// registry's refresh outcome (an `Err` here — no SSTables back a
+    /// manually-registered schema), NOT `Ok(stale schema)`. RED on HEAD, which
+    /// read the registry map directly and served the expired entry forever.
+    #[tokio::test]
+    async fn test_manager_does_not_serve_ttl_expired_schema() {
+        let config = Config::default();
+        let platform = Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+        let mut reg_config = registry::SchemaRegistryConfig::default();
+        reg_config.cache_ttl_seconds = 0; // every registered entry expires immediately
+        let registry = Arc::new(RwLock::new(
+            registry::SchemaRegistry::new(reg_config, platform, config.clone())
+                .await
+                .unwrap(),
+        ));
+
+        // Register a real schema THROUGH the shared registry.
+        registry
+            .read()
+            .await
+            .register_schema(
+                table_schema_named("stale_tbl"),
+                registry::SchemaSource::Manual,
+            )
+            .await
+            .unwrap();
+
+        let storage = build_storage().await;
+        let manager = SchemaManager::new_with_registry(storage, registry.clone(), &config)
+            .await
+            .unwrap();
+
+        // Let the zero-TTL entry expire.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // The manager must delegate to the registry's refresh path (which errors
+        // for a manually-registered schema with no backing SSTables) rather than
+        // serve the stale entry. On HEAD this returned `Ok(stale)`.
+        let loaded = manager.load_schema("stale_tbl").await;
+        assert!(
+            loaded.is_err(),
+            "manager must delegate TTL freshness to the registry, not serve a stale schema; got {loaded:?}"
+        );
+        let got = manager.get_table_schema("stale_tbl").await;
+        assert!(
+            got.is_err(),
+            "get_table_schema must also honor registry expiry; got {got:?}"
+        );
+
+        // The unknown-table no-fabrication contract (#1710) still holds.
+        assert!(
+            manager.load_schema("never_defined_here").await.is_err(),
+            "unknown table still errors (no fabrication)"
         );
     }
 

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -558,6 +558,44 @@ impl SchemaRegistry {
         Ok(results)
     }
 
+    /// Find a schema by table name, optionally scoped to a keyspace, cloning
+    /// only the matched schema (issue #1708).
+    ///
+    /// This is the single freshness-preserving lookup that [`crate::schema::SchemaManager`]
+    /// delegates to. Unlike [`Self::get_schema`] it reads the LIVE `schemas` map
+    /// directly (no TTL gate, no auto-discovery, no fabrication): a registry-side
+    /// TTL-refresh / re-registration is observed immediately by the manager, so
+    /// the manager can never serve a stale by-value snapshot. Returns `None` when
+    /// no schema matches (the manager maps that to its own not-found error).
+    pub async fn find_schema_by_table(
+        &self,
+        keyspace: &Option<String>,
+        table: &str,
+    ) -> Option<TableSchema> {
+        let schemas = self.schemas.read().await;
+
+        // Exact `keyspace.table` match first when a keyspace is provided.
+        if let Some(ks) = keyspace {
+            let key = format!("{}.{}", ks, table);
+            if let Some(entry) = schemas.get(&key) {
+                return Some(entry.schema.clone());
+            }
+        }
+
+        // Otherwise match any registered schema by table name (keyspace-aware).
+        schemas
+            .values()
+            .find(|entry| {
+                crate::schema::table_name_matches(
+                    &Some(entry.schema.keyspace.clone()),
+                    &entry.schema.table,
+                    keyspace,
+                    table,
+                )
+            })
+            .map(|entry| entry.schema.clone())
+    }
+
     /// Validate a schema
     #[allow(dead_code)]
     pub async fn validate_schema(&self, keyspace: &str, table: &str) -> Result<ValidationReport> {

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -561,39 +561,76 @@ impl SchemaRegistry {
     /// Find a schema by table name, optionally scoped to a keyspace, cloning
     /// only the matched schema (issue #1708).
     ///
-    /// This is the single freshness-preserving lookup that [`crate::schema::SchemaManager`]
-    /// delegates to. Unlike [`Self::get_schema`] it reads the LIVE `schemas` map
-    /// directly (no TTL gate, no auto-discovery, no fabrication): a registry-side
-    /// TTL-refresh / re-registration is observed immediately by the manager, so
-    /// the manager can never serve a stale by-value snapshot. Returns `None` when
-    /// no schema matches (the manager maps that to its own not-found error).
+    /// This is the single freshness-owning lookup that [`crate::schema::SchemaManager`]
+    /// delegates to, so the registry — not the manager — owns freshness:
+    ///
+    /// * A **fresh** matched entry is returned by value with exactly ONE
+    ///   `TableSchema` deep clone (issue #1587).
+    /// * An **expired** matched entry is NOT served stale: it is routed through
+    ///   the SAME TTL-refresh seam [`Self::get_schema`] uses for the matched
+    ///   entry ([`Self::refresh_schema`]), and the refreshed schema (or that
+    ///   seam's error) is returned. This closes the roborev Medium where an
+    ///   entry expired in the registry was served stale indefinitely through the
+    ///   manager.
+    /// * **No match** returns `Ok(None)` with NO auto-discovery and NO
+    ///   fabrication (issue #1710): a table nobody registered must surface as
+    ///   not-found (the manager maps `None` to its own not-found error), never a
+    ///   synthesized schema.
     pub async fn find_schema_by_table(
         &self,
         keyspace: &Option<String>,
         table: &str,
-    ) -> Option<TableSchema> {
-        let schemas = self.schemas.read().await;
-
-        // Exact `keyspace.table` match first when a keyspace is provided.
-        if let Some(ks) = keyspace {
-            let key = format!("{}.{}", ks, table);
-            if let Some(entry) = schemas.get(&key) {
-                return Some(entry.schema.clone());
-            }
+    ) -> Result<Option<TableSchema>> {
+        // Resolve the matched entry under a read guard. Clone the schema ONLY
+        // when it is fresh (the single #1587 clone); when it is EXPIRED, capture
+        // just its identity so the guard can be dropped BEFORE running the
+        // refresh seam (no `.await` is ever held under the read guard).
+        enum Matched {
+            Fresh(TableSchema),
+            Expired { keyspace: String, table: String },
         }
 
-        // Otherwise match any registered schema by table name (keyspace-aware).
-        schemas
-            .values()
-            .find(|entry| {
-                crate::schema::table_name_matches(
-                    &Some(entry.schema.keyspace.clone()),
-                    &entry.schema.table,
-                    keyspace,
-                    table,
-                )
-            })
-            .map(|entry| entry.schema.clone())
+        let matched = {
+            let schemas = self.schemas.read().await;
+
+            // Exact `keyspace.table` match first when a keyspace is provided.
+            let mut hit = keyspace
+                .as_ref()
+                .and_then(|ks| schemas.get(&format!("{}.{}", ks, table)));
+
+            // Otherwise match any registered schema by table name (keyspace-aware).
+            if hit.is_none() {
+                hit = schemas.values().find(|entry| {
+                    crate::schema::table_name_matches(
+                        &Some(entry.schema.keyspace.clone()),
+                        &entry.schema.table,
+                        keyspace,
+                        table,
+                    )
+                });
+            }
+
+            match hit {
+                None => None,
+                Some(entry) if self.is_entry_expired(entry) => Some(Matched::Expired {
+                    keyspace: entry.schema.keyspace.clone(),
+                    table: entry.schema.table.clone(),
+                }),
+                Some(entry) => Some(Matched::Fresh(entry.schema.clone())),
+            }
+        }; // read guard dropped here — no `.await` occurred under it.
+
+        match matched {
+            // No match: no fabrication, no auto-discovery (issue #1710).
+            None => Ok(None),
+            Some(Matched::Fresh(schema)) => Ok(Some(schema)),
+            // Expired: delegate freshness through the same refresh seam
+            // `get_schema` uses for the matched entry — never serve the stale
+            // copy.
+            Some(Matched::Expired { keyspace, table }) => {
+                self.refresh_schema(&keyspace, &table).await.map(Some)
+            }
+        }
     }
 
     /// Validate a schema
@@ -2288,5 +2325,81 @@ mod tests {
             .expect_err("expired schema should attempt discovery");
 
         assert!(matches!(err, Error::Schema(message) if message.contains("No SSTables found")));
+    }
+
+    /// Roborev Medium (issue #1708 follow-up): `find_schema_by_table` — the
+    /// single lookup the manager delegates to — must apply the SAME
+    /// TTL-expiry/refresh handling `get_schema` uses for the matched entry, and
+    /// must NOT serve an expired entry stale. With `cache_ttl_seconds = 0` the
+    /// registered entry expires, so the lookup delegates to the refresh seam
+    /// (which errors here because no SSTables back a manually-registered schema)
+    /// EXACTLY as `get_schema` does. RED on HEAD (read the map directly and
+    /// returned `Ok(Some(stale))`).
+    #[tokio::test]
+    async fn find_schema_by_table_honors_ttl_expiry_like_get_schema() {
+        let mut config = SchemaRegistryConfig::default();
+        config.cache_ttl_seconds = 0;
+        let registry = make_registry(config).await;
+
+        registry
+            .register_schema(simple_schema("events"), SchemaSource::Manual)
+            .await
+            .expect("register events schema");
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // `get_schema` triggers the refresh seam and errors on the expired entry.
+        let get_err = registry
+            .get_schema("test_ks", "events")
+            .await
+            .expect_err("expired schema attempts refresh");
+        assert!(matches!(&get_err, Error::Schema(m) if m.contains("No SSTables found")));
+
+        // Scoped `keyspace.table` lookup on the EXPIRED entry must behave
+        // identically: delegate to refresh (error), never `Ok(Some(stale))`.
+        let scoped = registry
+            .find_schema_by_table(&Some("test_ks".to_string()), "events")
+            .await;
+        assert!(
+            matches!(&scoped, Err(Error::Schema(m)) if m.contains("No SSTables found")),
+            "scoped lookup on an EXPIRED entry must delegate to refresh (not serve stale), got {scoped:?}"
+        );
+
+        // The bare-table-name path must honor expiry too.
+        let bare = registry.find_schema_by_table(&None, "events").await;
+        assert!(
+            matches!(&bare, Err(Error::Schema(m)) if m.contains("No SSTables found")),
+            "bare lookup on an EXPIRED entry must delegate to refresh, got {bare:?}"
+        );
+    }
+
+    /// A FRESH matched entry is still returned by value, and an unknown table
+    /// returns `Ok(None)` with NO fabrication/auto-discovery (issue #1710
+    /// preserved) — the two non-expiry outcomes the refresh path must not alter.
+    #[tokio::test]
+    async fn find_schema_by_table_returns_fresh_and_none_for_unknown() {
+        let registry = make_registry(SchemaRegistryConfig::default()).await;
+        registry
+            .register_schema(simple_schema("events"), SchemaSource::Manual)
+            .await
+            .expect("register");
+
+        let found = registry
+            .find_schema_by_table(&Some("test_ks".to_string()), "events")
+            .await
+            .expect("a fresh entry never triggers the refresh error path");
+        assert!(
+            matches!(found, Some(s) if s.table == "events"),
+            "fresh matched entry must be returned by value"
+        );
+
+        let missing = registry
+            .find_schema_by_table(&None, "never_registered")
+            .await
+            .expect("unknown table is Ok(None), not an error");
+        assert!(
+            missing.is_none(),
+            "unknown table must be None (no fabrication, no auto-discovery)"
+        );
     }
 }


### PR DESCRIPTION
Closes #1708 (P1, AJ1). Completes the schema train E5 #1587 → AJ2 #1709 → AJ1 #1708.

SchemaManager held by-value snapshots of the registry's schemas + UDTs → silently served stale schemas (never saw registry TTL-refresh/discovery) and diverged by constructor. Now it holds a single `Arc<RwLock<SchemaRegistry>>` and delegates ALL lookups/writes through it; the second schema map + UDT copy are removed. New `SchemaRegistry::find_schema_by_table` reads the live map, applies the registry's TTL-expiry/refresh for a matched entry, and returns None (no fabrication, per #1710) for unknown tables. All constructors share the registry (public signatures unchanged); AJ2's cached derived state keeps this a pointer-swap.

**Quality bar (auto-merge on green):**
- `agent-gate.sh`: **PASS** (solo)
- rust-reviewer: clean (no-stale-path + matching semantics + #1587 clone count verified)
- roborev (codex): **No issues found** (after TTL-delegation fix)

Tests: registry-refresh divergence (red on main), TTL-expiry-not-served-stale, constructor/UDT parity, #1710 unknown→Err + #1587 clone==1 preserved.