### PR TITLE
fix(#1968): BTI open-lower-bound clustering slice keeps the implicit first row-index block

### DIFF
--- a/cqlite-core/src/storage/sstable/bti/parser/rows.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/rows.rs
@@ -491,6 +491,18 @@ pub fn resolve_rows_db_entry(rows_db: &[u8], rows_offset: usize) -> BtiResult<Bt
 /// partition (as produced by [`iterate_rows_in_bti_trie`]).  `start`/`end` are
 /// byte-comparable clustering bounds in the **same encoding as the trie keys**.
 /// Reversed bounds (`start > end`) yield an empty result.
+///
+/// ## Implicit first block (issue #1968)
+///
+/// The trie stores a separator per block EXCEPT the first: the block covering
+/// keys BELOW `entries[0]`'s separator lives at the partition body start and has
+/// NO entry here (mirroring `RowIndexReader.separatorFloor`, which returns the
+/// partition start for a key below the first separator).  This function therefore
+/// only ever returns STORED blocks — it CANNOT return that implicit first block.
+/// A caller whose `start` sorts below `entries[0]`'s separator (e.g. an OPEN lower
+/// bound, `start == b""`) MUST additionally decode from the partition body start
+/// so the earliest clustering rows are not dropped; see
+/// `resolve_bti_clustering_seek_window` in `reader/data_access/bti.rs`.
 pub fn select_row_index_blocks_for_range(
     entries: &[(Vec<u8>, BtiRowIndexEntry)],
     start: &[u8],

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -384,10 +384,49 @@ impl SSTableReader {
         }
 
         let blocks = select_row_index_blocks_for_range(&entries, &start_bytes, &end_bytes);
+
+        // IMPLICIT FIRST BLOCK (issue #1968). A `Rows.db` row-index trie stores a
+        // separator per block EXCEPT the first: the block covering keys BELOW the
+        // first separator lives at the partition body start and has NO trie entry
+        // (mirroring Cassandra `RowIndexReader.separatorFloor`, which returns the
+        // partition start for a key below the first separator). Consequently
+        // `select_row_index_blocks_for_range` — which operates purely over the
+        // stored (separator, block) entries — can NEVER return that implicit block.
+        //
+        // The requested range overlaps the implicit first block iff its
+        // physical-lower bound sorts strictly BELOW the first separator
+        // (`start_bytes < entries[0].sep`). The canonical trigger is an OPEN lower
+        // bound (`ck < N` / `ck <= N`), whose physical-lower sentinel is `-∞` = the
+        // empty slice `b""`, but a closed lower bound below the first separator
+        // (`ck >= 2 AND ck < 20`, `ck = 0`) hits it too. When the range includes
+        // that block the earliest clustering rows precede every stored block, so the
+        // decode MUST begin at the partition body start (rel 0) or those rows are
+        // silently dropped (the pre-fix bug returned `ck=8..19` for `ck < 20`).
+        let includes_implicit_first_block = entries
+            .first()
+            .map(|(sep, _)| start_bytes.as_slice() < sep.as_slice())
+            .unwrap_or(false);
+
         if blocks.is_empty() {
-            // No block overlaps the range. The slice may still select rows that
-            // share the floor block's separator boundary; to stay correct we fall
-            // back to a full-partition decode rather than risk dropping a row.
+            if includes_implicit_first_block {
+                // The range lies ENTIRELY within the implicit first block (its
+                // physical-upper is also below the first separator, e.g. `ck <= 3`
+                // or `ck = 0`): no stored block overlaps, but the implicit block
+                // does. Narrow to [partition body start, first stored block start);
+                // the post-scan backstop trims to the exact predicate.
+                let body_end_rel = entries
+                    .first()
+                    .map(|(_sep, b)| b.data_offset as usize)
+                    .unwrap_or(usize::MAX);
+                return Ok(Some(ClusteringRowWindow {
+                    body_start_rel: 0,
+                    body_end_rel,
+                }));
+            }
+            // No block (implicit or stored) overlaps the range. The slice may still
+            // select rows that share the floor block's separator boundary; to stay
+            // correct we fall back to a full-partition decode rather than risk
+            // dropping a row.
             return Ok(None);
         }
 
@@ -405,7 +444,12 @@ impl SSTableReader {
         let has_static = schema
             .map(|s| s.columns.iter().any(|c| c.is_static))
             .unwrap_or(false);
-        let body_start_rel = if has_static {
+        // Start at the earliest selected STORED block — UNLESS the table has a
+        // static row, or the range also covers the implicit first block (issue
+        // #1968); either case must decode from the partition body start (rel 0) so
+        // the static prefix / the implicit block's rows are seen. The END bound
+        // still narrows the decode in both cases.
+        let body_start_rel = if has_static || includes_implicit_first_block {
             0
         } else {
             blocks

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -402,25 +402,28 @@ impl SSTableReader {
         // that block the earliest clustering rows precede every stored block, so the
         // decode MUST begin at the partition body start (rel 0) or those rows are
         // silently dropped (the pre-fix bug returned `ck=8..19` for `ck < 20`).
-        let includes_implicit_first_block = entries
-            .first()
+        // Bind the first stored entry ONCE and reuse it for both the predicate and
+        // the entirely-within-implicit-block window below, so the window end can
+        // never diverge from the predicate (no `usize::MAX` over-read fallback).
+        let first_entry = entries.first();
+        let includes_implicit_first_block = first_entry
             .map(|(sep, _)| start_bytes.as_slice() < sep.as_slice())
             .unwrap_or(false);
 
         if blocks.is_empty() {
-            if includes_implicit_first_block {
+            // `includes_implicit_first_block` is true only when `first_entry` is
+            // `Some`; the `if let` makes that invariant explicit and reuses the exact
+            // entry that satisfied the predicate (its start is the window end).
+            if let (true, Some((_sep, first_block))) = (includes_implicit_first_block, first_entry)
+            {
                 // The range lies ENTIRELY within the implicit first block (its
                 // physical-upper is also below the first separator, e.g. `ck <= 3`
                 // or `ck = 0`): no stored block overlaps, but the implicit block
                 // does. Narrow to [partition body start, first stored block start);
                 // the post-scan backstop trims to the exact predicate.
-                let body_end_rel = entries
-                    .first()
-                    .map(|(_sep, b)| b.data_offset as usize)
-                    .unwrap_or(usize::MAX);
                 return Ok(Some(ClusteringRowWindow {
                     body_start_rel: 0,
-                    body_end_rel,
+                    body_end_rel: first_block.data_offset as usize,
                 }));
             }
             // No block (implicit or stored) overlaps the range. The slice may still

--- a/cqlite-core/tests/issue_1968_bti_open_lower_bound.rs
+++ b/cqlite-core/tests/issue_1968_bti_open_lower_bound.rs
@@ -193,7 +193,15 @@ async fn open_lower_bound_lt_keeps_first_block() {
         Some(AccessPath::ClusteringSlice),
         "Issue #1968: `ck < ?` must engage the clustering slice, not fall back to a full scan",
     );
-    let bound = expected.len() as u64 + 64;
+    // A BTI clustering slice decodes whole row-index blocks, so `rows_decoded`
+    // overshoots the exact 20-row predicate match by up to (roughly) one row-index
+    // block. Rather than bake in a magic per-block row count tied to this fixture's
+    // exact block sizing (a benign regeneration could change it and flip the test to
+    // a false failure), derive the slack from the fixture's known partition size:
+    // half the partition stays well clear of a full-partition regression
+    // (~PARTITION_ROW_COUNT) yet is robust to block-layout changes. The strict
+    // `< PARTITION_ROW_COUNT` assertion below is the primary bounded-decode guard.
+    let bound = expected.len() as u64 + (PARTITION_ROW_COUNT as u64 / 2);
     assert!(
         rows_decoded > 0 && rows_decoded <= bound,
         "Issue #1968: rows_decoded ({rows_decoded}) must be in (0, {bound}] for a 20-row `ck < 20` \

--- a/cqlite-core/tests/issue_1968_bti_open_lower_bound.rs
+++ b/cqlite-core/tests/issue_1968_bti_open_lower_bound.rs
@@ -1,0 +1,323 @@
+//! Issue #1968 (P1, oracle/value-correctness): a BTI clustering slice with an
+//! OPEN lower bound (`ck < N` / `ck <= N`, no `>=`) must NOT drop the partition's
+//! FIRST row-index block.
+//!
+//! ## The bug
+//!
+//! A `Rows.db` row-index trie stores a separator per block EXCEPT the first: the
+//! block covering keys BELOW the first separator lives at the partition body start
+//! and has no trie entry. For an OPEN lower bound the physical-lower sentinel is
+//! `-∞` (`b""`), so `select_row_index_blocks_for_range` returns the STORED blocks
+//! overlapping the range but never that implicit first block. The pre-fix decode
+//! started at the earliest STORED block, silently skipping the earliest clustering
+//! rows: `SELECT pk, ck, payload ... WHERE pk = 2 AND ck < 20` returned `ck=8..19`
+//! instead of `ck=0..19`.
+//!
+//! The fix (in `resolve_bti_clustering_seek_window`) begins the decode at the
+//! partition body start whenever the range's physical-lower bound sorts below the
+//! first separator (open lower, or a closed lower below the first separator such as
+//! `ck >= 2 AND ck < 20` or `ck = 0`), so the implicit first block's rows are kept.
+//!
+//! These tests use a projection that INCLUDES `pk` — the shape that reproduces the
+//! bug on plain origin/main WITHOUT depending on issue #1952 (a bare `SELECT ck`
+//! seek probe is unrelated). The two-bound / open-upper / equality shapes that
+//! already worked are re-asserted here as regression guards.
+//!
+//! Requires `CQLITE_DATASETS_ROOT` and the fetched binary SSTables; skipped (not
+//! failed) when the data isn't present. Excluded under `tombstones` (that build
+//! compiles out the seek and the work counters).
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    not(feature = "tombstones")
+))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::access_path::{self, AccessPath};
+use cqlite_core::storage::sstable::work_counters;
+use cqlite_core::Database;
+use cqlite_core::Value;
+
+const QUALIFIED_TABLE: &str = "test_da.wide_table";
+const KEYSPACE_FILTER: &str = "/test_da/";
+/// Clustering rows per partition in the fixture (ck = 0..299).
+const PARTITION_ROW_COUNT: usize = 300;
+
+/// Serialize the tests: the work counters and access-path probe are process-global,
+/// so two of these running concurrently would clobber each other's `reset()` / read.
+static PROBE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup() -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join("wide-table-bti.cql");
+    if !schema_path.exists() {
+        return Err(format!("schema not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(KEYSPACE_FILTER.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+async fn skip_or_db() -> Option<Database> {
+    match setup().await {
+        Ok(db) => Some(db),
+        Err(e) => {
+            eprintln!("Skipping (BTI wide_table): {e}");
+            None
+        }
+    }
+}
+
+/// The sorted `ck` integers a query returned, to compare against an expected slice
+/// independent of row ordering.
+fn cks(rows: &[cqlite_core::query::result::QueryRow]) -> Vec<i32> {
+    let mut out: Vec<i32> = rows
+        .iter()
+        .filter_map(|r| match r.values.get("ck") {
+            Some(Value::Integer(i)) => Some(*i),
+            _ => None,
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+/// Run one slice query (projection INCLUDES `pk` — the #1968 reproduction shape)
+/// under the probe lock, returning `(returned_cks, rows_decoded, access_path)`.
+async fn run_slice(db: &Database, where_clause: &str) -> (Vec<i32>, u64, Option<AccessPath>) {
+    work_counters::reset();
+    access_path::reset();
+    let result = db
+        .execute(&format!(
+            "SELECT pk, ck, payload FROM {QUALIFIED_TABLE} WHERE {where_clause}"
+        ))
+        .await
+        .unwrap_or_else(|e| panic!("slice query `{where_clause}` failed: {e}"));
+    let rows_decoded = work_counters::rows_decoded();
+    let path = result.metadata.access_path.clone();
+    (cks(&result.rows), rows_decoded, path)
+}
+
+/// Skip helper: confirm pk=2 is populated (Data.db fetched) via a pk-INCLUDING
+/// projection (a bare `SELECT ck` probe would need issue #1952). Returns the db and
+/// full pk=2 partition when present.
+async fn db_and_pk2(db: &Database) -> Option<Vec<i32>> {
+    let full = db
+        .execute(&format!(
+            "SELECT pk, ck, payload FROM {QUALIFIED_TABLE} WHERE pk = 2"
+        ))
+        .await
+        .expect("pk=2 partition read must succeed");
+    if full.rows.is_empty() {
+        eprintln!("Skipping: wide_table returned 0 rows (Data.db not fetched?)");
+        return None;
+    }
+    assert_eq!(
+        full.rows.len(),
+        PARTITION_ROW_COUNT,
+        "fixture invariant: pk=2 must hold {PARTITION_ROW_COUNT} clustering rows",
+    );
+    Some(cks(&full.rows))
+}
+
+// ---------------------------------------------------------------------------
+// 1. THE BUG: open lower bound `ck < 20` must return ck=0..=19, NOT 8..=19.
+//    Also asserts the slice ENGAGES (ClusteringSlice) with a BOUNDED decode — so
+//    the fix is not a silent regression to a full-partition scan.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn open_lower_bound_lt_keeps_first_block() {
+    let _g = PROBE_LOCK.lock().await;
+    let Some(db) = skip_or_db().await else {
+        return;
+    };
+    if db_and_pk2(&db).await.is_none() {
+        return;
+    }
+
+    // `ck < 20` selects ck = 0..=19 (20 rows). The pre-fix bug dropped the implicit
+    // first block and returned ck = 8..=19.
+    let expected: Vec<i32> = (0..20).collect();
+    let (returned, rows_decoded, path) = run_slice(&db, "pk = 2 AND ck < 20").await;
+
+    assert_eq!(
+        returned, expected,
+        "Issue #1968: pk=2 AND ck < 20 must return ck=0..=19 (pre-fix bug returned ck=8..=19, \
+         dropping the partition's first row-index block)",
+    );
+
+    // Honest, bounded access path: the seek engaged (not a full-partition fallback).
+    assert_eq!(
+        path,
+        Some(AccessPath::ClusteringSlice),
+        "Issue #1968: `ck < ?` must engage the clustering slice, not fall back to a full scan",
+    );
+    let bound = expected.len() as u64 + 64;
+    assert!(
+        rows_decoded > 0 && rows_decoded <= bound,
+        "Issue #1968: rows_decoded ({rows_decoded}) must be in (0, {bound}] for a 20-row `ck < 20` \
+         slice; a regression to full-partition decode reads ~{PARTITION_ROW_COUNT}",
+    );
+    assert!(
+        rows_decoded < PARTITION_ROW_COUNT as u64,
+        "Issue #1968: rows_decoded ({rows_decoded}) must stay strictly below the partition's \
+         {PARTITION_ROW_COUNT} rows (the fix must keep the first block WITHOUT a full scan)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Inclusive open lower bound `ck <= N` also keeps the first block, across an
+//    N below the first separator (`ck <= 3`, entirely inside the implicit block)
+//    and an N above it (`ck <= 12`, implicit block + first stored block).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn open_lower_bound_lte_keeps_first_block() {
+    let _g = PROBE_LOCK.lock().await;
+    let Some(db) = skip_or_db().await else {
+        return;
+    };
+    let Some(all_cks) = db_and_pk2(&db).await else {
+        return;
+    };
+
+    for n in [3i32, 12] {
+        let expected: Vec<i32> = all_cks.iter().copied().filter(|c| *c <= n).collect();
+        let (returned, _decoded, path) = run_slice(&db, &format!("pk = 2 AND ck <= {n}")).await;
+        assert_eq!(
+            returned, expected,
+            "Issue #1968: pk=2 AND ck <= {n} must return ck=0..={n} (implicit first block kept)",
+        );
+        // `ck <= 3` lies ENTIRELY within the implicit first block; the narrowed
+        // seek engages there too (no full-scan fallback).
+        assert_eq!(
+            path,
+            Some(AccessPath::ClusteringSlice),
+            "Issue #1968: `ck <= {n}` must engage the clustering slice",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Closed lower bound BELOW the first separator (`ck >= 2 AND ck < 20`,
+//    `ck = 0`) — same implicit-first-block hazard, must be correct.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn closed_lower_bound_below_first_separator_keeps_first_block() {
+    let _g = PROBE_LOCK.lock().await;
+    let Some(db) = skip_or_db().await else {
+        return;
+    };
+    let Some(all_cks) = db_and_pk2(&db).await else {
+        return;
+    };
+
+    // Two-bound whose lower bound (2) is below the first stored separator (ck=8):
+    // ck 2..7 live in the implicit first block and must NOT be dropped.
+    let expected: Vec<i32> = all_cks
+        .iter()
+        .copied()
+        .filter(|c| (2..20).contains(c))
+        .collect();
+    let (returned, _d, path) = run_slice(&db, "pk = 2 AND ck >= 2 AND ck < 20").await;
+    assert_eq!(
+        returned, expected,
+        "Issue #1968: pk=2 AND ck in [2,20) must return ck=2..=19 (ck 2..7 are in the implicit \
+         first block)",
+    );
+    assert_eq!(path, Some(AccessPath::ClusteringSlice));
+
+    // Equality on the very first clustering value.
+    let (returned0, _d0, path0) = run_slice(&db, "pk = 2 AND ck = 0").await;
+    assert_eq!(
+        returned0,
+        vec![0],
+        "Issue #1968: pk=2 AND ck = 0 must return exactly ck=0 (implicit first block)",
+    );
+    assert_eq!(path0, Some(AccessPath::ClusteringSlice));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Regression guards: the shapes that already worked must STAY correct — a
+//    two-bound range above the first block, an open UPPER bound, and equality in
+//    the interior. Byte-parity vs the full-scan-filtered in-memory baseline.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn previously_working_shapes_still_correct() {
+    let _g = PROBE_LOCK.lock().await;
+    let Some(db) = skip_or_db().await else {
+        return;
+    };
+    let Some(all_cks) = db_and_pk2(&db).await else {
+        return;
+    };
+
+    type SliceCase = (&'static str, fn(i32) -> bool);
+    let cases: &[SliceCase] = &[
+        // Two-bound range entirely ABOVE the first block (start > first separator).
+        ("pk = 2 AND ck >= 100 AND ck < 110", |c| {
+            (100..110).contains(&c)
+        }),
+        // Open UPPER bound (`ck >= a`, tail of the partition).
+        ("pk = 2 AND ck >= 290", |c| c >= 290),
+        // Equality in the interior.
+        ("pk = 2 AND ck = 150", |c| c == 150),
+    ];
+
+    for (where_clause, pred) in cases {
+        let expected: Vec<i32> = all_cks.iter().copied().filter(|c| pred(*c)).collect();
+        let (returned, _decoded, path) = run_slice(&db, where_clause).await;
+        assert_eq!(
+            returned, expected,
+            "Issue #1968: `{where_clause}` must equal the full-scan-filtered baseline",
+        );
+        assert_eq!(
+            path,
+            Some(AccessPath::ClusteringSlice),
+            "Issue #1968: `{where_clause}` must still engage the clustering slice",
+        );
+    }
+}

--- a/cqlite-core/tests/issue_1968_bti_open_lower_bound.rs
+++ b/cqlite-core/tests/issue_1968_bti_open_lower_bound.rs
@@ -45,6 +45,12 @@ const QUALIFIED_TABLE: &str = "test_da.wide_table";
 const KEYSPACE_FILTER: &str = "/test_da/";
 /// Clustering rows per partition in the fixture (ck = 0..299).
 const PARTITION_ROW_COUNT: usize = 300;
+/// The `ck` of the FIRST STORED row-index separator for pk=2. The block covering
+/// ck 0..(this-1) is the implicit first block with no trie entry; the first trie
+/// separator sits at this value. Matches the other tests' documented layout (the
+/// implicit first block is ck 0..7). Used to pin the equality-boundary case where a
+/// closed lower bound lands EXACTLY on this separator.
+const FIRST_SEPARATOR_CK: i32 = 8;
 
 /// Serialize the tests: the work counters and access-path probe are process-global,
 /// so two of these running concurrently would clobber each other's `reset()` / read.
@@ -285,6 +291,86 @@ async fn closed_lower_bound_below_first_separator_keeps_first_block() {
         "Issue #1968: pk=2 AND ck = 0 must return exactly ck=0 (implicit first block)",
     );
     assert_eq!(path0, Some(AccessPath::ClusteringSlice));
+}
+
+// ---------------------------------------------------------------------------
+// 3b. EQUALITY BOUNDARY: a closed lower bound EQUAL to the first stored separator
+//     (`ck >= FIRST_SEPARATOR_CK`) must select the first STORED block, NOT the
+//     implicit first block. This pins Cassandra `RowIndexReader.separatorFloor`
+//     semantics and guards against a naive `<=` regression.
+//
+//     WHY `<` (STRICT), not `<=`, is the correct comparison against `entries[0].sep`:
+//     a key EQUAL to the first separator belongs to the first STORED block (the
+//     separator is the block's INCLUSIVE start — Cassandra floors a lookup key to
+//     the greatest separator <= key). The implicit first block holds only keys
+//     STRICTLY BELOW the first separator, so it must be included ONLY when the
+//     range's physical-lower bound sorts STRICTLY below `entries[0].sep`. For a
+//     lower bound exactly equal to the separator (`ck >= 8`, sep = 8), `8 < 8` is
+//     false, so the implicit block is correctly EXCLUDED from the decode.
+//
+//     A naive `<=` (`8 <= 8` true) would wrongly re-include the implicit block for
+//     `ck >= 8`. The returned rows stay ck=8..=19 either way (the `ck >= 8` row
+//     predicate filters out ck 0..7 post-decode), so this test asserts the DECODE
+//     WORK: `ck >= 8` (equal to the separator, implicit block excluded) must decode
+//     strictly FEWER rows than `ck >= 2` (below the separator, implicit block
+//     included) over the same upper bound. Under a `<=` regression both would start
+//     at the partition body and decode the implicit block, making the counts equal —
+//     which this strict-`<` assertion catches.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn closed_lower_bound_equal_to_first_separator_excludes_implicit_block() {
+    let _g = PROBE_LOCK.lock().await;
+    let Some(db) = skip_or_db().await else {
+        return;
+    };
+    let Some(all_cks) = db_and_pk2(&db).await else {
+        return;
+    };
+
+    let sep = FIRST_SEPARATOR_CK;
+    let upper = 20;
+
+    // Primary correctness: `ck >= sep AND ck < 20` returns exactly ck=sep..=19.
+    let expected: Vec<i32> = all_cks
+        .iter()
+        .copied()
+        .filter(|c| (sep..upper).contains(c))
+        .collect();
+    let (returned, decoded_at_sep, path) =
+        run_slice(&db, &format!("pk = 2 AND ck >= {sep} AND ck < {upper}")).await;
+    assert_eq!(
+        returned, expected,
+        "Issue #1968: pk=2 AND ck in [{sep},{upper}) must return ck={sep}..=19 (a lower bound EQUAL \
+         to the first separator lands on the first STORED block; the implicit block ck 0..{} is \
+         correctly EXCLUDED)",
+        sep - 1,
+    );
+    assert_eq!(
+        path,
+        Some(AccessPath::ClusteringSlice),
+        "Issue #1968: `ck >= {sep} AND ck < {upper}` must engage the clustering slice",
+    );
+
+    // Regression guard on DECODE WORK: a lower bound BELOW the first separator
+    // (`ck >= 2`) includes the implicit first block, so it must decode STRICTLY MORE
+    // rows than the equality-boundary slice (`ck >= sep`), which excludes it. A naive
+    // `<=` against `entries[0].sep` would re-include the implicit block for `ck >= sep`
+    // and flatten this inequality.
+    let (_below, decoded_below_sep, _p) =
+        run_slice(&db, &format!("pk = 2 AND ck >= 2 AND ck < {upper}")).await;
+    assert!(
+        decoded_at_sep > 0 && decoded_below_sep > 0,
+        "Issue #1968: both equality-boundary and below-separator slices must decode some rows \
+         (at_sep={decoded_at_sep}, below_sep={decoded_below_sep})",
+    );
+    assert!(
+        decoded_at_sep < decoded_below_sep,
+        "Issue #1968: `ck >= {sep}` (equal to the first separator, implicit block EXCLUDED) must \
+         decode strictly fewer rows ({decoded_at_sep}) than `ck >= 2` (below the separator, \
+         implicit block INCLUDED, {decoded_below_sep}); equal counts would mean a naive `<=` \
+         wrongly re-included the implicit block at the equality boundary",
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/cqlite-core/tests/issue_954_clustering_slice_seek.rs
+++ b/cqlite-core/tests/issue_954_clustering_slice_seek.rs
@@ -224,7 +224,7 @@ async fn single_bound_lt_slice_parity_and_bounded_decode() {
     // Skip if no data.
     let probe = db
         .execute(&format!(
-            "SELECT ck FROM {QUALIFIED_TABLE} WHERE pk = 2 LIMIT 1"
+            "SELECT pk, ck FROM {QUALIFIED_TABLE} WHERE pk = 2 LIMIT 1"
         ))
         .await
         .expect("probe must succeed");


### PR DESCRIPTION
## Summary
Fixes #1968 — a BTI clustering slice whose physical lower bound sorts **below the partition's first row-index separator** (open lower bound `ck < N`, and also `ck >= a AND ck < b` / `ck = 0` where `a`/the key is below the first separator) silently dropped the partition's **implicit first row-index block**, omitting the earliest clustering rows.

`SELECT pk, ck, payload FROM test_da.wide_table WHERE pk = 2 AND ck < 20` returned `ck=[8..19]`; it now correctly returns `ck=[0..19]`.

## Root cause
`resolve_bti_clustering_seek_window` (`cqlite-core/src/storage/sstable/reader/data_access/bti.rs`). A `Rows.db` row-index trie stores a separator per block **except the first**: the block covering keys below the first separator lives at the partition body start (offset 0) with **no trie entry** (mirrors Cassandra `RowIndexReader.separatorFloor`). Block selection + bound derivation were already correct; the caller set `body_start_rel = min(selected offsets)`, skipping the implicit first block when the range extended below the first separator.

## Fix
- Compute `includes_implicit_first_block = start_bytes < entries[0].sep`; when true, force `body_start_rel = 0` so the implicit block is decoded (end bound still narrows). Also narrows the entirely-within-implicit-block case that previously fell back to a full scan.
- Doc note on `select_row_index_blocks_for_range` (`rows.rs`) that it never returns the implicit first block and the caller must handle it.

## Tests
- New `cqlite-core/tests/issue_1968_bti_open_lower_bound.rs` — covers `ck < N`, `ck <= N`, `ck >= a AND ck < b` (a below first sep), and guards that `ck >= a` / two-bound / equality above the first separator stay correct. Fail-first verified (`[8..19]` vs `[0..19]`).
- Hardened `issue_954_clustering_slice_seek::single_bound_lt_…` probe to `SELECT pk, ck` so it stops silently skipping and actually exercises the slice.

## Context
This bug was latent on `main` — its regression test silently skipped because its probe hit the separate projection bug #1952. Fixing #1952 un-masks it; filed + fixed here as its own oracle issue so #1952 can land green.

## Gate
Full `scripts/agent-gate.sh` **RESULT: PASS** (`core-tests: PASS`) at `f8129ce8`.
