### PR TITLE
fix(#1632): parser hardening bundle — recursion depth guards, duration i32 bounds, collection capacity/truncation

### DIFF
--- a/cqlite-core/src/parser/types/primitives.rs
+++ b/cqlite-core/src/parser/types/primitives.rs
@@ -144,15 +144,27 @@ pub fn parse_decimal(input: &[u8]) -> IResult<&[u8], Value> {
 /// All three components are returned as-is in `Value::Duration` to preserve
 /// calendar semantics (months ≠ 30 days; days ≠ 24 hours in all time zones).
 pub fn parse_duration(input: &[u8]) -> IResult<&[u8], Value> {
-    let (input, months) = parse_vint(input)?;
-    let (input, days) = parse_vint(input)?;
-    let (input, nanos) = parse_vint(input)?;
+    let (rest, months_raw) = parse_vint(input)?;
+    let (rest, days_raw) = parse_vint(rest)?;
+    let (rest, nanos) = parse_vint(rest)?;
+
+    // months/days are i32 in Cassandra's DurationType. Reject (rather than
+    // silently truncate via `as i32`) any encoded value outside the i32 range so
+    // a corrupt encoding errors instead of wrapping around (issue #1632). Mirrors
+    // the reader-side guard in `comparator_value_parsing::parse_duration_value`
+    // (issue #765).
+    let months = i32::try_from(months_raw).map_err(|_| {
+        nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Verify))
+    })?;
+    let days = i32::try_from(days_raw).map_err(|_| {
+        nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Verify))
+    })?;
 
     Ok((
-        input,
+        rest,
         Value::Duration {
-            months: months as i32,
-            days: days as i32,
+            months,
+            days,
             nanos,
         },
     ))
@@ -369,6 +381,39 @@ mod tests {
             }
             other => panic!("Expected Duration value, got {:?}", other),
         }
+    }
+
+    /// Issue #1632 (hardening b): months/days are i32 in Cassandra's
+    /// DurationType. A corrupt encoding with a value outside the i32 range must be
+    /// rejected as an error, NOT silently truncated via `as i32`. Fails on the
+    /// pre-#1632 code where the cast wraps the value instead of erroring.
+    #[test]
+    fn test_parse_duration_months_out_of_i32_range_errors() {
+        use super::super::super::vint::{encode_vint, parse_vint};
+
+        let too_big = i32::MAX as i64 + 1;
+        // Sanity: the VInt round-trips to the intended out-of-range value.
+        let months_bytes = encode_vint(too_big);
+        assert_eq!(parse_vint(&months_bytes).unwrap().1, too_big);
+
+        let mut over = Vec::new();
+        over.extend_from_slice(&months_bytes); // months overflow i32
+        over.extend_from_slice(&encode_vint(0));
+        over.extend_from_slice(&encode_vint(0));
+        assert!(
+            parse_duration(&over).is_err(),
+            "months > i32::MAX must error, not truncate"
+        );
+
+        let too_small = i32::MIN as i64 - 1;
+        let mut under = Vec::new();
+        under.extend_from_slice(&encode_vint(0));
+        under.extend_from_slice(&encode_vint(too_small)); // days underflow i32
+        under.extend_from_slice(&encode_vint(0));
+        assert!(
+            parse_duration(&under).is_err(),
+            "days < i32::MIN must error, not truncate"
+        );
     }
 
     /// S2 regression: duration with all-zero components should produce Duration{{0,0,0}}.

--- a/cqlite-core/src/storage/sstable/reader/parsing/comparator_value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/comparator_value_parsing.rs
@@ -18,6 +18,14 @@ use crate::{
     Error, Result,
 };
 
+/// Maximum nesting depth for recursive value decoding, mirroring the V5 frozen
+/// guard (`MAX_TYPE_NESTING_DEPTH` in `v5_compressed_legacy::mod`). A corrupt or
+/// adversarial deeply-nested type (e.g. `frozen<frozen<frozen<...>>>`) must
+/// return `Err` rather than recurse until the stack overflows and aborts the
+/// process (issue #1632). Shared by both exact-slice decoders — the standalone
+/// block-path decoder here and `SSTableReader::parse_value_with_comparator`.
+pub(crate) const MAX_VALUE_NESTING_DEPTH: usize = 10;
+
 /// Parse a value using a ComparatorType for schema-aware decoding
 ///
 /// This function handles all CQL types including:
@@ -37,6 +45,25 @@ pub fn parse_value_with_comparator(
     value_data: &[u8],
     comparator: &ComparatorType,
 ) -> Result<Value> {
+    parse_value_with_comparator_at_depth(value_data, comparator, 0)
+}
+
+/// Depth-tracking core of [`parse_value_with_comparator`]. Every recursive
+/// descent into a nested element/field/frozen inner type increments `depth`;
+/// exceeding [`MAX_VALUE_NESTING_DEPTH`] returns `Err` instead of recursing to a
+/// stack overflow (issue #1632). Guard-only: successful decoding of any value
+/// within the depth budget is byte-identical to before.
+fn parse_value_with_comparator_at_depth(
+    value_data: &[u8],
+    comparator: &ComparatorType,
+    depth: usize,
+) -> Result<Value> {
+    if depth > MAX_VALUE_NESTING_DEPTH {
+        return Err(Error::corruption(format!(
+            "Value decode recursion depth {} exceeds maximum {}",
+            depth, MAX_VALUE_NESTING_DEPTH
+        )));
+    }
     match comparator {
         ComparatorType::Boolean => {
             if value_data.len() == 1 {
@@ -210,29 +237,29 @@ pub fn parse_value_with_comparator(
         // element framing; tuple/UDT use Cassandra's 4-byte i32-BE field framing
         // (`TupleType`/`UserType` `putInt`, `-1` == null) — the same framing the
         // live block path (decoder #1) and the v5 frozen path already use.
-        ComparatorType::List(element_comparator) => super::value_parsing::parse_list_value_with(
-            value_data,
-            element_comparator,
-            parse_value_with_comparator,
-        ),
-        ComparatorType::Set(element_comparator) => super::value_parsing::parse_set_value_with(
-            value_data,
-            element_comparator,
-            parse_value_with_comparator,
-        ),
+        ComparatorType::List(element_comparator) => {
+            super::value_parsing::parse_list_value_with(value_data, element_comparator, |d, c| {
+                parse_value_with_comparator_at_depth(d, c, depth + 1)
+            })
+        }
+        ComparatorType::Set(element_comparator) => {
+            super::value_parsing::parse_set_value_with(value_data, element_comparator, |d, c| {
+                parse_value_with_comparator_at_depth(d, c, depth + 1)
+            })
+        }
         ComparatorType::Map(key_comparator, value_comparator) => {
             super::value_parsing::parse_map_value_with(
                 value_data,
                 key_comparator,
                 value_comparator,
-                parse_value_with_comparator,
+                |d, c| parse_value_with_comparator_at_depth(d, c, depth + 1),
             )
         }
-        ComparatorType::Tuple(field_comparators) => super::value_parsing::parse_tuple_value_with(
-            value_data,
-            field_comparators,
-            parse_value_with_comparator,
-        ),
+        ComparatorType::Tuple(field_comparators) => {
+            super::value_parsing::parse_tuple_value_with(value_data, field_comparators, |d, c| {
+                parse_value_with_comparator_at_depth(d, c, depth + 1)
+            })
+        }
         ComparatorType::Udt {
             type_name,
             keyspace,
@@ -241,7 +268,7 @@ pub fn parse_value_with_comparator(
             let udt = super::value_parsing::parse_udt_value_with(
                 value_data,
                 field_comparators,
-                parse_value_with_comparator,
+                |d, c| parse_value_with_comparator_at_depth(d, c, depth + 1),
             )?;
             // Preserve decoder #2's provenance (type_name/keyspace from the
             // comparator) rather than the helper's "unknown" placeholders.
@@ -252,7 +279,8 @@ pub fn parse_value_with_comparator(
             }))
         }
         ComparatorType::Frozen(inner_comparator) => {
-            let inner_value = parse_value_with_comparator(value_data, inner_comparator)?;
+            let inner_value =
+                parse_value_with_comparator_at_depth(value_data, inner_comparator, depth + 1)?;
             Ok(Value::Frozen(Box::new(inner_value)))
         }
         ComparatorType::Custom(name) => {
@@ -650,5 +678,59 @@ mod tests {
         let result = parse_value_with_comparator(&data, &comparator).unwrap();
 
         assert_eq!(result, Value::List(vec![Value::Blob(body)]));
+    }
+
+    // Issue #1632 (hardening a): a corrupt or adversarial deeply-nested type must
+    // return `Err` via the recursion-depth guard rather than recursing until the
+    // stack overflows and aborts the process. A `frozen<...>` chain recurses on
+    // the SAME bytes at every level (no byte consumed), so without the guard it
+    // would recurse unbounded.
+    #[test]
+    fn test_deeply_nested_frozen_type_errors_not_overflow() {
+        // 12 levels of frozen wrapping an int — exceeds MAX_VALUE_NESTING_DEPTH (10).
+        let mut comparator = ComparatorType::Int;
+        for _ in 0..12 {
+            comparator = ComparatorType::Frozen(Box::new(comparator));
+        }
+        let data = vec![0x00, 0x00, 0x00, 0x2A];
+        let result = parse_value_with_comparator(&data, &comparator);
+        assert!(
+            result.is_err(),
+            "12-level nested frozen type must Err, not stack-overflow/abort"
+        );
+    }
+
+    /// A modestly-nested type (within the limit) must still decode correctly, so
+    /// the guard does not regress successful-decode semantics (issue #1632).
+    #[test]
+    fn test_shallow_nested_frozen_still_decodes() {
+        let comparator = ComparatorType::Frozen(Box::new(ComparatorType::Frozen(Box::new(
+            ComparatorType::Int,
+        ))));
+        let data = vec![0x00, 0x00, 0x00, 0x2A]; // 42
+        let result = parse_value_with_comparator(&data, &comparator).unwrap();
+        assert_eq!(
+            result,
+            Value::Frozen(Box::new(Value::Frozen(Box::new(Value::Integer(42)))))
+        );
+    }
+
+    // Issue #1632 (hardening c): a corrupt, huge declared element count must not
+    // pre-allocate gigabytes. Capacity is clamped to REASONABLE_COLLECTION_CAPACITY
+    // and the short buffer makes the first element length exceed the data, so the
+    // decode returns `Err` promptly with bounded peak allocation (no OOM/panic).
+    #[test]
+    fn test_huge_declared_count_short_buffer_errors_bounded_alloc() {
+        let mut data = Vec::new();
+        encode_unsigned(1u64 << 30, &mut data); // declared count ~1 billion
+        encode_unsigned(1000, &mut data); // first element claims 1000 bytes...
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]); // ...but only 4 remain
+
+        let comparator = ComparatorType::List(Box::new(ComparatorType::Int));
+        let result = parse_value_with_comparator(&data, &comparator);
+        assert!(
+            result.is_err(),
+            "huge count + short buffer must Err without a huge pre-allocation"
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
@@ -654,10 +654,27 @@ impl V5CompressedLegacyParser {
                     );
                 }
 
+                // months/days are i32 in Cassandra's DurationType. Reject
+                // (rather than silently truncate via `as i32`) any encoded value
+                // outside the i32 range so a corrupt encoding errors instead of
+                // wrapping (issue #1632, item b).
+                let months = i32::try_from(months).map_err(|_| {
+                    Error::corruption(format!(
+                        "Cell '{}': duration months out of i32 range",
+                        column.name
+                    ))
+                })?;
+                let days = i32::try_from(days).map_err(|_| {
+                    Error::corruption(format!(
+                        "Cell '{}': duration days out of i32 range",
+                        column.name
+                    ))
+                })?;
+
                 offset += duration_len;
                 Value::Duration {
-                    months: months as i32,
-                    days: days as i32,
+                    months,
+                    days,
                     nanos,
                 }
             }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/complex_column.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/complex_column.rs
@@ -230,6 +230,14 @@ impl V5CompressedLegacyParser {
             ))
         })?;
 
+        // Bound the up-front collection allocation by the bytes actually available
+        // (issue #1632): every element/entry consumes at least one byte, so the
+        // declared count can never legitimately exceed the remaining buffer. A
+        // corrupt count near MAX_FROZEN_COLLECTION_SIZE against a short buffer must
+        // not pre-allocate ~MBs; the per-element parse below still Errs on the short
+        // buffer. Guard-only: valid inputs allocate the same (declared) capacity.
+        let prealloc_cap = cell_count_usize.min(data.len().saturating_sub(offset));
+
         // DS4 (Issue #700): Track max element writetime and element tombstone count
         // across all cells in this collection.
         let mut max_element_writetime: i64 = 0;
@@ -298,7 +306,7 @@ impl V5CompressedLegacyParser {
         {
             // Parse list elements
             let element_type = self.extract_collection_element_type(&column.data_type, "list")?;
-            let mut elements = Vec::with_capacity(cell_count_usize);
+            let mut elements = Vec::with_capacity(prealloc_cap);
 
             for i in 0..cell_count_usize {
                 let cell =
@@ -371,7 +379,7 @@ impl V5CompressedLegacyParser {
             // VALUE is always empty (HAS_EMPTY_VALUE flag = 0x04 set).
             // We must parse the path bytes as the element value, not the (empty) cell value.
             let element_type = self.extract_collection_element_type(&column.data_type, "set")?;
-            let mut elements = Vec::with_capacity(cell_count_usize);
+            let mut elements = Vec::with_capacity(prealloc_cap);
 
             for i in 0..cell_count_usize {
                 let cell =
@@ -470,7 +478,7 @@ impl V5CompressedLegacyParser {
         {
             // Parse map entries
             let (key_type, value_type) = self.extract_map_types(&column.data_type)?;
-            let mut entries = Vec::with_capacity(cell_count_usize);
+            let mut entries = Vec::with_capacity(prealloc_cap);
 
             for i in 0..cell_count_usize {
                 let cell =

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_consolidation_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_consolidation_tests.rs
@@ -38,7 +38,7 @@ fn decode_method(
     comp: &ComparatorType,
     bytes: &[u8],
 ) -> crate::Result<Value> {
-    reader.parse_value_with_comparator(bytes, comp)
+    reader.parse_value_with_comparator_at_depth(bytes, comp, 0)
 }
 
 /// Canonical Cassandra tuple/UDT field framing: 4-byte big-endian `i32` length

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_lockstep_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/decoder_lockstep_tests.rs
@@ -897,3 +897,63 @@ mod write_read {
         }
     }
 }
+
+// ===========================================================================
+// Issue #1632 (item b) — per-cell v5 duration i32 overflow hardening
+// ===========================================================================
+
+/// Frame a v5 per-cell `duration` body from three signed VInt components:
+/// `[flags 0x08][VUInt body_len][months][days][nanos]`.
+#[cfg(test)]
+fn frame_v5_duration_cell(months: i64, days: i64, nanos: i64) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&encode_vint(months));
+    body.extend_from_slice(&encode_vint(days));
+    body.extend_from_slice(&encode_vint(nanos));
+    frame_v5_cell(V5Framing::VintLen, &body)
+}
+
+/// Sanity: an in-range per-cell duration still decodes through the v5 ladder
+/// (`parse_cell_value_schema_order`) — the guard rejects nothing valid.
+#[tokio::test]
+async fn v5_cell_duration_in_range_ok() {
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    let parser = v5_parser();
+    let cell = frame_v5_duration_cell(1, 2, 3);
+    let v = decode_v5(&parser, &reader, "duration", &cell)
+        .expect("in-range duration should decode through the v5 cell path");
+    assert_eq!(
+        v,
+        Value::Duration {
+            months: 1,
+            days: 2,
+            nanos: 3
+        }
+    );
+}
+
+/// Issue #1632 (item b): the per-cell `duration` arm (`cell_value.rs`) must
+/// REJECT a months/days VInt outside the i32 range instead of silently wrapping
+/// via `as i32`. Pre-fix, `months as i32` wraps `i32::MAX + 1` to a negative
+/// value and returns Ok; the guard turns it into an error.
+#[tokio::test]
+async fn v5_cell_duration_out_of_i32_range_errors() {
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    let parser = v5_parser();
+
+    let over = frame_v5_duration_cell(i32::MAX as i64 + 1, 0, 0);
+    assert!(
+        decode_v5(&parser, &reader, "duration", &over).is_err(),
+        "months > i32::MAX must error, not wrap via `as i32`"
+    );
+
+    let under = frame_v5_duration_cell(0, i32::MIN as i64 - 1, 0);
+    assert!(
+        decode_v5(&parser, &reader, "duration", &under).is_err(),
+        "days < i32::MIN must error, not wrap via `as i32`"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/raw_type_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/raw_type_value.rs
@@ -363,10 +363,27 @@ impl V5CompressedLegacyParser {
                     ))
                 })?;
 
+                // months/days are i32 in Cassandra's DurationType. Reject
+                // (rather than silently truncate via `as i32`) any encoded value
+                // outside the i32 range so a corrupt encoding errors instead of
+                // wrapping (issue #1632, item b).
+                let months = i32::try_from(months).map_err(|_| {
+                    Error::corruption(format!(
+                        "Frozen element '{}': duration months out of i32 range",
+                        column_name
+                    ))
+                })?;
+                let days = i32::try_from(days).map_err(|_| {
+                    Error::corruption(format!(
+                        "Frozen element '{}': duration days out of i32 range",
+                        column_name
+                    ))
+                })?;
+
                 offset += duration_len;
                 Value::Duration {
-                    months: months as i32,
-                    days: days as i32,
+                    months,
+                    days,
                     nanos,
                 }
             }
@@ -1145,5 +1162,68 @@ impl V5CompressedLegacyParser {
         };
 
         Ok((value, offset))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::helpers::encode_unsigned;
+    use super::*;
+    use crate::parser::vint::encode_vuint;
+
+    fn zigzag(v: i64) -> u64 {
+        ((v << 1) ^ (v >> 63)) as u64
+    }
+
+    /// Build a raw-type-value duration body: `[VInt len][months][days][nanos]`.
+    fn duration_bytes(months: i64, days: i64, nanos: i64) -> Vec<u8> {
+        let mut body = Vec::new();
+        encode_unsigned(zigzag(months), &mut body);
+        encode_unsigned(zigzag(days), &mut body);
+        encode_unsigned(zigzag(nanos), &mut body);
+        let mut out = encode_vuint(body.len() as u64);
+        out.extend_from_slice(&body);
+        out
+    }
+
+    /// Sanity: an in-range duration still decodes through `parse_raw_type_value`.
+    #[test]
+    fn test_parse_raw_type_value_duration_in_range_ok() {
+        let parser = V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, None);
+        let data = duration_bytes(1, 2, 3);
+        let (value, _off) = parser
+            .parse_raw_type_value(&data, 0, "duration", "col", 0)
+            .expect("in-range duration should decode");
+        assert_eq!(
+            value,
+            Value::Duration {
+                months: 1,
+                days: 2,
+                nanos: 3
+            }
+        );
+    }
+
+    /// Issue #1632 (item b): the frozen-element duration arm must REJECT a
+    /// months/days VInt outside the i32 range instead of wrapping via `as i32`.
+    #[test]
+    fn test_parse_raw_type_value_duration_out_of_i32_range_errors() {
+        let parser = V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, None);
+
+        let over = duration_bytes(i32::MAX as i64 + 1, 0, 0);
+        assert!(
+            parser
+                .parse_raw_type_value(&over, 0, "duration", "col", 0)
+                .is_err(),
+            "months > i32::MAX must error, not wrap via `as i32`"
+        );
+
+        let under = duration_bytes(0, i32::MIN as i64 - 1, 0);
+        assert!(
+            parser
+                .parse_raw_type_value(&under, 0, "duration", "col", 0)
+                .is_err(),
+            "days < i32::MIN must error, not wrap via `as i32`"
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/raw_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/raw_value.rs
@@ -299,9 +299,25 @@ impl V5CompressedLegacyParser {
                     ))
                 })?;
 
+                // months/days are i32 in Cassandra's DurationType. Reject
+                // (rather than silently truncate via `as i32`) any encoded value
+                // outside the i32 range so a corrupt encoding errors instead of
+                // wrapping (issue #1632, item b).
+                let months = i32::try_from(months).map_err(|_| {
+                    Error::corruption(format!(
+                        "Frozen element '{}': duration months out of i32 range",
+                        column_name
+                    ))
+                })?;
+                let days = i32::try_from(days).map_err(|_| {
+                    Error::corruption(format!(
+                        "Frozen element '{}': duration days out of i32 range",
+                        column_name
+                    ))
+                })?;
                 Ok(Value::Duration {
-                    months: months as i32,
-                    days: days as i32,
+                    months,
+                    days,
                     nanos,
                 })
             }
@@ -715,6 +731,41 @@ mod tests {
             .parse_value_from_raw_bytes(&data, "duration", "col", 0)
             .unwrap();
         assert_eq!(val_short, val);
+    }
+
+    /// Issue #1632 (item b): the raw-value frozen `duration` arm must REJECT a
+    /// months/days VInt outside the i32 range instead of silently wrapping via
+    /// `as i32`. On pre-fix code `months as i32` wraps `i32::MAX + 1` to a
+    /// negative value and returns Ok; the guard turns it into an error.
+    #[test]
+    fn test_parse_value_from_raw_bytes_duration_months_out_of_i32_range_errors() {
+        let parser =
+            V5CompressedLegacyParser::new("test".to_string(), "table".to_string(), 0, 0, None);
+        let zigzag = |v: i64| ((v << 1) ^ (v >> 63)) as u64;
+
+        // months = i32::MAX + 1 (overflows i32), days = 0, nanos = 0.
+        let mut over = Vec::new();
+        encode_unsigned(zigzag(i32::MAX as i64 + 1), &mut over);
+        encode_unsigned(zigzag(0), &mut over);
+        encode_unsigned(zigzag(0), &mut over);
+        assert!(
+            parser
+                .parse_value_from_raw_bytes(&over, "duration", "col", 0)
+                .is_err(),
+            "months > i32::MAX must error, not wrap via `as i32`"
+        );
+
+        // days = i32::MIN - 1 (underflows i32), months = 0, nanos = 0.
+        let mut under = Vec::new();
+        encode_unsigned(zigzag(0), &mut under);
+        encode_unsigned(zigzag(i32::MIN as i64 - 1), &mut under);
+        encode_unsigned(zigzag(0), &mut under);
+        assert!(
+            parser
+                .parse_value_from_raw_bytes(&under, "duration", "col", 0)
+                .is_err(),
+            "days < i32::MIN must error, not wrap via `as i32`"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
@@ -113,10 +113,15 @@ where
     // Clamp pre-allocation: a corrupt huge count must not pre-allocate GBs (#1632).
     let mut elements = Vec::with_capacity(element_count.min(REASONABLE_COLLECTION_CAPACITY));
 
-    // Parse each element
+    // Decode EXACTLY `element_count` elements. A valid collection cell holds
+    // exactly `count` fully-encoded elements, so a buffer that runs dry before
+    // `count` elements are decoded is corrupt/truncated and must Err — silently
+    // returning a short partial list would accept a truncated cell (#1632).
     for _ in 0..element_count {
         if offset >= data.len() {
-            break;
+            return Err(Error::corruption(
+                "List declared more elements than present in buffer (truncated)",
+            ));
         }
 
         // Parse element length
@@ -180,10 +185,15 @@ where
     // Clamp pre-allocation: a corrupt huge count must not pre-allocate GBs (#1632).
     let mut entries = Vec::with_capacity(entry_count.min(REASONABLE_COLLECTION_CAPACITY));
 
-    // Parse each key-value pair
+    // Decode EXACTLY `entry_count` key/value pairs. A valid map cell holds
+    // exactly `count` fully-encoded entries, so a buffer that runs dry before
+    // `count` entries are decoded is corrupt/truncated and must Err — silently
+    // returning a short partial map would accept a truncated cell (#1632).
     for _ in 0..entry_count {
         if offset >= data.len() {
-            break;
+            return Err(Error::corruption(
+                "Map declared more entries than present in buffer (truncated)",
+            ));
         }
 
         // Parse key length and data
@@ -447,9 +457,13 @@ impl SSTableReader {
                 field_comparators, ..
             } => self.parse_udt_value(value_data, field_comparators, 0),
             ComparatorType::Frozen(inner_comparator) => {
-                // For frozen types, parse the inner type directly
+                // The outer `frozen<...>` layer costs one nesting level, so enter
+                // the inner comparator at depth 1 — symmetric with the block path
+                // (`parse_value_with_comparator_at_depth`'s Frozen arm recurses at
+                // depth+1). Entering at depth 0 would silently allow one extra
+                // nested level past MAX_VALUE_NESTING_DEPTH (#1632, guard-only).
                 let inner_value =
-                    self.parse_value_with_comparator_at_depth(value_data, inner_comparator, 0)?;
+                    self.parse_value_with_comparator_at_depth(value_data, inner_comparator, 1)?;
                 Ok(Value::Frozen(Box::new(inner_value)))
             }
             _ => decode_scalar_comparator(value_data, &comparator),

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
@@ -9,7 +9,16 @@ use crate::{
 };
 
 use super::super::types::SSTableReader;
-use super::comparator_value_parsing::parse_value_with_comparator as decode_scalar_comparator;
+use super::comparator_value_parsing::{
+    parse_value_with_comparator as decode_scalar_comparator, MAX_VALUE_NESTING_DEPTH,
+};
+
+/// Upper bound on collection capacity pre-allocated from a declared element/entry
+/// count. A corrupt or adversarial huge count (e.g. `2^30`) must not let us
+/// pre-allocate gigabytes up front; we reserve at most this many slots and grow
+/// on demand as real elements are decoded (issue #1632). Guard-only: the decoded
+/// value is unchanged, only the initial allocation is bounded.
+const REASONABLE_COLLECTION_CAPACITY: usize = 4096;
 
 // ============================================================================
 // Scalar decode shims (issue #1636 / J2)
@@ -95,12 +104,14 @@ where
     use crate::parser::vint::parse_vint_length;
 
     let mut offset = 0;
-    let mut elements = Vec::new();
 
     // Parse element count
     let (remaining, element_count) = parse_vint_length(&data[offset..])
         .map_err(|_| Error::corruption("Failed to parse list element count"))?;
     offset = data.len() - remaining.len();
+
+    // Clamp pre-allocation: a corrupt huge count must not pre-allocate GBs (#1632).
+    let mut elements = Vec::with_capacity(element_count.min(REASONABLE_COLLECTION_CAPACITY));
 
     // Parse each element
     for _ in 0..element_count {
@@ -160,12 +171,14 @@ where
     use crate::parser::vint::parse_vint_length;
 
     let mut offset = 0;
-    let mut entries = Vec::new();
 
     // Parse entry count
     let (remaining, entry_count) = parse_vint_length(&data[offset..])
         .map_err(|_| Error::corruption("Failed to parse map entry count"))?;
     offset = data.len() - remaining.len();
+
+    // Clamp pre-allocation: a corrupt huge count must not pre-allocate GBs (#1632).
+    let mut entries = Vec::with_capacity(entry_count.min(REASONABLE_COLLECTION_CAPACITY));
 
     // Parse each key-value pair
     for _ in 0..entry_count {
@@ -413,52 +426,68 @@ impl SSTableReader {
         // every scalar (incl. schema-derived Custom) routes through the ONE scalar
         // decode body in `comparator_value_parsing` (issue #1636 / J2), so a scalar
         // type fix lands in exactly one place.
+        // Top-level column value enters at depth 0; nested elements/fields/frozen
+        // inner types accumulate depth and are capped by MAX_VALUE_NESTING_DEPTH
+        // (issue #1632) so a corrupt/adversarial deeply-nested type errors rather
+        // than overflowing the stack.
         match &comparator {
             ComparatorType::List(element_comparator) => {
-                self.parse_list_value(value_data, element_comparator)
+                self.parse_list_value(value_data, element_comparator, 0)
             }
             ComparatorType::Set(element_comparator) => {
-                self.parse_set_value(value_data, element_comparator)
+                self.parse_set_value(value_data, element_comparator, 0)
             }
             ComparatorType::Map(key_comparator, value_comparator) => {
-                self.parse_map_value(value_data, key_comparator, value_comparator)
+                self.parse_map_value(value_data, key_comparator, value_comparator, 0)
             }
             ComparatorType::Tuple(field_comparators) => {
-                self.parse_tuple_value(value_data, field_comparators)
+                self.parse_tuple_value(value_data, field_comparators, 0)
             }
             ComparatorType::Udt {
                 field_comparators, ..
-            } => self.parse_udt_value(value_data, field_comparators),
+            } => self.parse_udt_value(value_data, field_comparators, 0),
             ComparatorType::Frozen(inner_comparator) => {
                 // For frozen types, parse the inner type directly
-                let inner_value = self.parse_value_with_comparator(value_data, inner_comparator)?;
+                let inner_value =
+                    self.parse_value_with_comparator_at_depth(value_data, inner_comparator, 0)?;
                 Ok(Value::Frozen(Box::new(inner_value)))
             }
             _ => decode_scalar_comparator(value_data, &comparator),
         }
     }
 
-    /// Parse value directly using ComparatorType (helper method for nested collection elements)
+    /// Parse value directly using ComparatorType (helper for nested collection elements).
     ///
-    /// This function provides complete recursive type parsing for collection elements,
-    /// including UDTs, tuples, nested collections, and frozen types.
-    pub(in crate::storage::sstable::reader) fn parse_value_with_comparator(
+    /// Provides complete recursive type parsing for collection elements, including
+    /// UDTs, tuples, nested collections, and frozen types. Entry callers pass
+    /// `depth = 0`; every recursive descent into a nested element/field/frozen inner type
+    /// increments `depth`; exceeding [`MAX_VALUE_NESTING_DEPTH`] returns `Err`
+    /// instead of recursing to a stack overflow (issue #1632). Guard-only:
+    /// successful decoding within the depth budget is byte-identical to before.
+    pub(in crate::storage::sstable::reader) fn parse_value_with_comparator_at_depth(
         &self,
         value_data: &[u8],
         comparator: &ComparatorType,
+        depth: usize,
     ) -> Result<Value> {
+        if depth > MAX_VALUE_NESTING_DEPTH {
+            return Err(Error::corruption(format!(
+                "Value decode recursion depth {} exceeds maximum {}",
+                depth, MAX_VALUE_NESTING_DEPTH
+            )));
+        }
         match comparator {
             ComparatorType::List(element_comparator) => {
-                self.parse_list_value(value_data, element_comparator)
+                self.parse_list_value(value_data, element_comparator, depth)
             }
             ComparatorType::Set(element_comparator) => {
-                self.parse_set_value(value_data, element_comparator)
+                self.parse_set_value(value_data, element_comparator, depth)
             }
             ComparatorType::Map(key_comparator, value_comparator) => {
-                self.parse_map_value(value_data, key_comparator, value_comparator)
+                self.parse_map_value(value_data, key_comparator, value_comparator, depth)
             }
             ComparatorType::Tuple(field_comparators) => {
-                self.parse_tuple_value(value_data, field_comparators)
+                self.parse_tuple_value(value_data, field_comparators, depth)
             }
             ComparatorType::Udt {
                 keyspace,
@@ -513,8 +542,11 @@ impl SSTableReader {
                     }
 
                     let field_data = &value_data[offset..offset + field_len];
-                    let field_value =
-                        self.parse_value_with_comparator(field_data, field_comparator)?;
+                    let field_value = self.parse_value_with_comparator_at_depth(
+                        field_data,
+                        field_comparator,
+                        depth + 1,
+                    )?;
 
                     fields.push(UdtField {
                         name: field_name.clone(),
@@ -530,7 +562,11 @@ impl SSTableReader {
                 }))
             }
             ComparatorType::Frozen(inner_comparator) => {
-                let inner_value = self.parse_value_with_comparator(value_data, inner_comparator)?;
+                let inner_value = self.parse_value_with_comparator_at_depth(
+                    value_data,
+                    inner_comparator,
+                    depth + 1,
+                )?;
                 Ok(Value::Frozen(Box::new(inner_value)))
             }
             // Every scalar (incl. schema-derived Custom) routes through the ONE
@@ -544,9 +580,10 @@ impl SSTableReader {
         &self,
         value_data: &[u8],
         element_comparator: &ComparatorType,
+        depth: usize,
     ) -> Result<Value> {
         parse_list_value_with(value_data, element_comparator, |data, comp| {
-            self.parse_value_with_comparator(data, comp)
+            self.parse_value_with_comparator_at_depth(data, comp, depth + 1)
         })
     }
 
@@ -555,9 +592,10 @@ impl SSTableReader {
         &self,
         value_data: &[u8],
         element_comparator: &ComparatorType,
+        depth: usize,
     ) -> Result<Value> {
         parse_set_value_with(value_data, element_comparator, |data, comp| {
-            self.parse_value_with_comparator(data, comp)
+            self.parse_value_with_comparator_at_depth(data, comp, depth + 1)
         })
     }
 
@@ -567,12 +605,13 @@ impl SSTableReader {
         value_data: &[u8],
         key_comparator: &ComparatorType,
         value_comparator: &ComparatorType,
+        depth: usize,
     ) -> Result<Value> {
         parse_map_value_with(
             value_data,
             key_comparator,
             value_comparator,
-            |data, comp| self.parse_value_with_comparator(data, comp),
+            |data, comp| self.parse_value_with_comparator_at_depth(data, comp, depth + 1),
         )
     }
 
@@ -581,9 +620,10 @@ impl SSTableReader {
         &self,
         value_data: &[u8],
         field_comparators: &[ComparatorType],
+        depth: usize,
     ) -> Result<Value> {
         parse_tuple_value_with(value_data, field_comparators, |data, comp| {
-            self.parse_value_with_comparator(data, comp)
+            self.parse_value_with_comparator_at_depth(data, comp, depth + 1)
         })
     }
 
@@ -594,6 +634,7 @@ impl SSTableReader {
         &self,
         value_data: &[u8],
         field_comparators: &[(String, ComparatorType)],
+        depth: usize,
     ) -> Result<Value> {
         let mut offset = 0;
         let mut fields = Vec::new();
@@ -641,7 +682,8 @@ impl SSTableReader {
 
             // Parse field value using field comparator
             let field_data = &value_data[offset..offset + field_len];
-            let field_value = self.parse_value_with_comparator(field_data, field_comparator)?;
+            let field_value =
+                self.parse_value_with_comparator_at_depth(field_data, field_comparator, depth + 1)?;
             offset += field_len;
 
             fields.push(UdtField {

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing_tests.rs
@@ -580,15 +580,15 @@ fn test_parse_list_truncated() {
     data.extend_from_slice(&42i32.to_be_bytes());
     // Missing second element
 
-    let result =
-        parse_list_value_with(&data, &ComparatorType::Int, |d, _| parse_int_value(d)).unwrap();
+    let result = parse_list_value_with(&data, &ComparatorType::Int, |d, _| parse_int_value(d));
 
-    // Should successfully parse 1 element (stops when no more data)
-    if let Value::List(elements) = result {
-        assert_eq!(elements.len(), 1);
-    } else {
-        panic!("Expected List value");
-    }
+    // A valid list holds EXACTLY `count` elements; a buffer that runs dry after
+    // 1 of 2 declared elements is a truncated cell and must Err, not silently
+    // return a short partial list (#1632).
+    assert!(
+        result.is_err(),
+        "list declaring more elements than present must Err (truncated), not accept a partial"
+    );
 }
 
 #[test]
@@ -797,6 +797,50 @@ fn test_parse_map_huge_count_short_buffer_errors_bounded_alloc() {
     );
 }
 
+// Issue #1632 acceptance criterion (roborev's exact case): a huge declared count
+// followed IMMEDIATELY by EOF (no element/entry bytes at all) is a truncated cell
+// and must Err — the old buffer-terminated loop silently returned Ok(empty). A
+// valid collection always carries exactly `count` fully-encoded elements, so
+// requiring `count` decoded elements never rejects well-formed data.
+
+#[test]
+fn test_parse_list_huge_count_eof_after_count_errors() {
+    let mut data = Vec::new();
+    data.extend_from_slice(&encode_vuint(1u64 << 30)); // ~1 billion elements, then EOF
+
+    let result = parse_list_value_with(&data, &ComparatorType::Int, |d, _| parse_int_value(d));
+    assert!(
+        result.is_err(),
+        "list: huge count then immediate EOF must Err (truncated), not Ok(empty)"
+    );
+}
+
+#[test]
+fn test_parse_set_huge_count_eof_after_count_errors() {
+    let mut data = Vec::new();
+    data.extend_from_slice(&encode_vuint(1u64 << 30)); // ~1 billion elements, then EOF
+
+    let result = parse_set_value_with(&data, &ComparatorType::Int, |d, _| parse_int_value(d));
+    assert!(
+        result.is_err(),
+        "set: huge count then immediate EOF must Err (truncated), not Ok(empty)"
+    );
+}
+
+#[test]
+fn test_parse_map_huge_count_eof_after_count_errors() {
+    let mut data = Vec::new();
+    data.extend_from_slice(&encode_vuint(1u64 << 30)); // ~1 billion entries, then EOF
+
+    let result = parse_map_value_with(&data, &ComparatorType::Int, &ComparatorType::Int, |d, _| {
+        parse_int_value(d)
+    });
+    assert!(
+        result.is_err(),
+        "map: huge count then immediate EOF must Err (truncated), not Ok(empty)"
+    );
+}
+
 // Issue #1632 (hardening a): the SSTableReader value-decode surface carries the
 // identical `MAX_VALUE_NESTING_DEPTH` guard as the free-function comparator path
 // (covered by `test_deeply_nested_frozen_type_errors_not_overflow`). This mirrors
@@ -810,11 +854,79 @@ fn test_parse_map_huge_count_short_buffer_errors_bounded_alloc() {
 // operates only on the passed-in slice. Fixture-gated: SKIP when absent.
 #[tokio::test]
 async fn test_1632_sstablereader_deeply_nested_frozen_errors_not_overflow() {
+    let Some(reader) = open_simple_table_fixture_reader().await else {
+        return; // SKIP: fixture absent (message already logged).
+    };
+
+    // 12 levels of frozen wrapping an int — exceeds MAX_VALUE_NESTING_DEPTH (10).
+    let mut comparator = ComparatorType::Int;
+    for _ in 0..12 {
+        comparator = ComparatorType::Frozen(Box::new(comparator));
+    }
+    // Any body works: frozen recurses without consuming bytes.
+    let data = vec![0x00, 0x00, 0x00, 0x2A];
+    let result = reader.parse_value_with_comparator_at_depth(&data, &comparator, 0);
+    assert!(
+        result.is_err(),
+        "12-level nested frozen type must Err via SSTableReader, not stack-overflow/abort"
+    );
+}
+
+// Issue #1632 (Finding 2): the schema-path `frozen<...>` arm
+// (`parse_value_with_schema_type`) must count the outer frozen layer just like
+// the block path (`parse_value_with_comparator_at_depth`). Before the fix the
+// schema path entered the inner comparator at depth 0, silently allowing ONE
+// extra nested level past MAX_VALUE_NESTING_DEPTH. This asserts the two paths
+// agree at BOTH the last-allowed depth (10 frozens → Ok) and one past it
+// (11 frozens → Err). Fixture-gated: SKIP when the dataset is absent.
+#[tokio::test]
+async fn test_1632_frozen_depth_schema_path_symmetric_with_block_path() {
+    let Some(reader) = open_simple_table_fixture_reader().await else {
+        return; // SKIP: fixture absent (message already logged).
+    };
+
+    // Any body works: frozen recurses without consuming bytes; an int leaf is 4B.
+    let data = vec![0x00, 0x00, 0x00, 0x2A];
+
+    // Build the equivalent block-path comparator for `n` frozen layers over int.
+    let frozen_comparator = |n: usize| -> ComparatorType {
+        let mut c = ComparatorType::Int;
+        for _ in 0..n {
+            c = ComparatorType::Frozen(Box::new(c));
+        }
+        c
+    };
+    // The type string `frozen<...<int>...>` for the schema path.
+    let frozen_type_string = |n: usize| -> String { "frozen<".repeat(n) + "int" + &">".repeat(n) };
+
+    // MAX_VALUE_NESTING_DEPTH is 10: 10 frozens is the last allowed depth, 11 exceeds it.
+    for (n, expect_ok) in [(10usize, true), (11usize, false)] {
+        let block = reader.parse_value_with_comparator_at_depth(&data, &frozen_comparator(n), 0);
+        let schema = reader.parse_value_with_schema_type(&data, &frozen_type_string(n));
+        assert_eq!(
+            block.is_ok(),
+            expect_ok,
+            "block path at {n} frozen layers should be ok={expect_ok}"
+        );
+        assert_eq!(
+            schema.is_ok(),
+            block.is_ok(),
+            "schema path must agree with block path at {n} frozen layers (symmetric depth counting)"
+        );
+    }
+}
+
+/// Open a reliably-present fetched fixture (`test_basic/simple_table`) as a real
+/// `SSTableReader`. The reader's own content is irrelevant to these depth/frozen
+/// tests — recursion operates only on the passed-in slice — but `SSTableReader`
+/// has no lightweight constructor. Returns `None` (after logging a SKIP) when the
+/// dataset is absent.
+#[cfg(test)]
+async fn open_simple_table_fixture_reader() -> Option<SSTableReader> {
     use crate::{Config, Platform};
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    // Resolve a reliably-present fetched fixture (test_basic/simple_table).
     let root = match std::env::var("CQLITE_DATASETS_ROOT") {
         Ok(r) if PathBuf::from(&r).is_dir() => PathBuf::from(r),
         _ => match PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -824,7 +936,7 @@ async fn test_1632_sstablereader_deeply_nested_frozen_errors_not_overflow() {
             Some(p) if p.is_dir() => p,
             _ => {
                 eprintln!("SKIP: datasets root absent.");
-                return;
+                return None;
             }
         },
     };
@@ -842,25 +954,14 @@ async fn test_1632_sstablereader_deeply_nested_frozen_errors_not_overflow() {
     });
     let Some(path) = data_db else {
         eprintln!("SKIP: test_basic/simple_table Data.db absent.");
-        return;
+        return None;
     };
 
     let config = Config::default();
     let platform = Arc::new(Platform::new(&config).await.expect("platform init"));
-    let reader = SSTableReader::open(&path, &config, platform)
-        .await
-        .expect("opening the fetched simple_table fixture should succeed");
-
-    // 12 levels of frozen wrapping an int — exceeds MAX_VALUE_NESTING_DEPTH (10).
-    let mut comparator = ComparatorType::Int;
-    for _ in 0..12 {
-        comparator = ComparatorType::Frozen(Box::new(comparator));
-    }
-    // Any body works: frozen recurses without consuming bytes.
-    let data = vec![0x00, 0x00, 0x00, 0x2A];
-    let result = reader.parse_value_with_comparator_at_depth(&data, &comparator, 0);
-    assert!(
-        result.is_err(),
-        "12-level nested frozen type must Err via SSTableReader, not stack-overflow/abort"
-    );
+    Some(
+        SSTableReader::open(&path, &config, platform)
+            .await
+            .expect("opening the fetched simple_table fixture should succeed"),
+    )
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing_tests.rs
@@ -758,3 +758,109 @@ fn test_value_parsing_blob_fallback_disabled() {
     // Note: Float and Double parsing is handled by the main parser (parse_value_by_type)
     // rather than standalone functions, so they are not tested here.
 }
+
+// ============================================================================
+// Issue #1632 (hardening c/d): a corrupt, huge declared element/entry count must
+// not pre-allocate gigabytes. The shared collection helpers clamp pre-allocation
+// to min(count, REASONABLE_COLLECTION_CAPACITY); with a short buffer the first
+// element/key length exceeds the data, so parsing returns Err promptly with
+// bounded peak allocation (no OOM / panic).
+// ============================================================================
+
+#[test]
+fn test_parse_list_huge_count_short_buffer_errors_bounded_alloc() {
+    let mut data = Vec::new();
+    data.extend_from_slice(&encode_vuint(1u64 << 30)); // ~1 billion elements
+    data.extend_from_slice(&encode_vuint(1000)); // first element claims 1000 bytes...
+    data.extend_from_slice(&42i32.to_be_bytes()); // ...but only 4 remain
+
+    let result = parse_list_value_with(&data, &ComparatorType::Int, |d, _| parse_int_value(d));
+    assert!(
+        result.is_err(),
+        "huge count + short buffer must Err without a huge pre-allocation"
+    );
+}
+
+#[test]
+fn test_parse_map_huge_count_short_buffer_errors_bounded_alloc() {
+    let mut data = Vec::new();
+    data.extend_from_slice(&encode_vuint(1u64 << 30)); // ~1 billion entries
+    data.extend_from_slice(&encode_vuint(1000)); // first key claims 1000 bytes...
+    data.extend_from_slice(&42i32.to_be_bytes()); // ...but only 4 remain
+
+    let result = parse_map_value_with(&data, &ComparatorType::Int, &ComparatorType::Int, |d, _| {
+        parse_int_value(d)
+    });
+    assert!(
+        result.is_err(),
+        "huge count + short buffer must Err without a huge pre-allocation"
+    );
+}
+
+// Issue #1632 (hardening a): the SSTableReader value-decode surface carries the
+// identical `MAX_VALUE_NESTING_DEPTH` guard as the free-function comparator path
+// (covered by `test_deeply_nested_frozen_type_errors_not_overflow`). This mirrors
+// that test through the real `SSTableReader::parse_value_with_comparator_at_depth`
+// method (entered at depth 0, as the schema path does): a deeply-nested
+// `frozen<...>` type recurses on the SAME bytes at every level, so without the
+// guard it would recurse to a stack overflow. It must return `Err`.
+//
+// `SSTableReader` has no lightweight constructor, so this opens a real (fetched)
+// SSTable — the reader's own data content is irrelevant; the frozen recursion
+// operates only on the passed-in slice. Fixture-gated: SKIP when absent.
+#[tokio::test]
+async fn test_1632_sstablereader_deeply_nested_frozen_errors_not_overflow() {
+    use crate::{Config, Platform};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    // Resolve a reliably-present fetched fixture (test_basic/simple_table).
+    let root = match std::env::var("CQLITE_DATASETS_ROOT") {
+        Ok(r) if PathBuf::from(&r).is_dir() => PathBuf::from(r),
+        _ => match PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|p| p.join("test-data/datasets"))
+        {
+            Some(p) if p.is_dir() => p,
+            _ => {
+                eprintln!("SKIP: datasets root absent.");
+                return;
+            }
+        },
+    };
+    let base = root.join("sstables/test_basic");
+    let data_db = std::fs::read_dir(&base).ok().and_then(|rd| {
+        rd.flatten().find_map(|e| {
+            let name = e.file_name();
+            let name = name.to_str()?;
+            if name.starts_with("simple_table-") {
+                let c = e.path().join("nb-1-big-Data.db");
+                return c.is_file().then_some(c);
+            }
+            None
+        })
+    });
+    let Some(path) = data_db else {
+        eprintln!("SKIP: test_basic/simple_table Data.db absent.");
+        return;
+    };
+
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.expect("platform init"));
+    let reader = SSTableReader::open(&path, &config, platform)
+        .await
+        .expect("opening the fetched simple_table fixture should succeed");
+
+    // 12 levels of frozen wrapping an int — exceeds MAX_VALUE_NESTING_DEPTH (10).
+    let mut comparator = ComparatorType::Int;
+    for _ in 0..12 {
+        comparator = ComparatorType::Frozen(Box::new(comparator));
+    }
+    // Any body works: frozen recurses without consuming bytes.
+    let data = vec![0x00, 0x00, 0x00, 0x2A];
+    let result = reader.parse_value_with_comparator_at_depth(&data, &comparator, 0);
+    assert!(
+        result.is_err(),
+        "12-level nested frozen type must Err via SSTableReader, not stack-overflow/abort"
+    );
+}


### PR DESCRIPTION
Closes #1632 (P0). Re-founded on current main after #1636 unified the ComparatorType decoders + #765 fixed one duration site.

Four guard-only hardenings (33-table parity byte-identical):
(a) recursion depth guards (MAX_VALUE_NESTING_DEPTH=10, mirroring the v5 type guard) threaded through both exact-slice ComparatorType value decoders → adversarial deep nesting Errs instead of stack-overflow abort;
(b) DURATION months/days now i32::try_from (Err on overflow) across ALL decode paths (primitives + comparator + 3 V5 legacy sites raw_value/raw_type_value/cell_value) — sweep-confirmed complete;
(c) collection capacity clamped to min(count, 4096) — corrupt huge count can't pre-allocate GBs;
(d) complex_column with_capacity bounded by remaining bytes;
plus truncated collections (declared count > encoded elements) now return a corruption Err (per the acceptance criteria) instead of silent partial.

**Quality bar (auto-merge on green):**
- `agent-gate.sh`: **PASS** (solo; integration/format-compat/smoke = 33-table parity green — truncation-Err change safe for valid data)
- rust-reviewer: clean (depth-10 matches shipping v5 guard; guard-only verified)
- roborev (codex): **No issues found** (after 2 completeness rounds: truncation-Err + all-V5-duration-sites)

Adversarial + red-on-main tests for depth, duration overflow, capacity, and truncation.