### PR TITLE
fix(#1952): grouped/filtered non-star aggregates read missing input columns (widen scan projection + key-preserving trim)

### DIFF
--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -15,8 +15,9 @@
 
 use super::{
     build_row_from_scan, classify_partition_lookup, column_info_from_type_str, evaluate_predicates,
-    honest_targeted_path, parse_table_id, partition_key_digest, select_has_writetime_ttl,
-    sort_rows_by_token, validate_token_predicates, PartitionLookupOutcome, SSTablePredicate,
+    honest_targeted_path, parse_table_id, partition_key_digest, project_expr_reshapes_row,
+    select_has_writetime_ttl, sort_rows_by_token, validate_token_predicates,
+    PartitionLookupOutcome, SSTablePredicate,
 };
 use super::{
     AccessPath, ColumnInfo, ExecutionContext, ExecutionStep, FallbackReason, OptimizedQueryPlan,
@@ -203,8 +204,21 @@ impl SelectExecutor {
                         self.execute_limit(intermediate_results, *count, *offset, &mut context)?;
                 }
                 ExecutionStep::Project { columns } => {
-                    intermediate_results =
-                        self.execute_projection(intermediate_results, columns, &mut context)?;
+                    // Issue #1952 (round-6 fix): branch on whether the projection
+                    // RESHAPES the row. A plain-column Project only trims the
+                    // #1952-widened helper columns — route it through the
+                    // key-preserving `trim_projection` so the row keeps its real
+                    // RowKey / metadata and a sparse row's absent selected cell is
+                    // omitted rather than erroring. Only a reshaping / computed
+                    // projection (alias, arithmetic, aggregate, function,
+                    // writetime/ttl, collection-access) goes through
+                    // `execute_projection`, whose empty-RowKey + name-derivation is
+                    // correct for a computed row that has no natural stored key.
+                    intermediate_results = if columns.iter().any(project_expr_reshapes_row) {
+                        self.execute_projection(intermediate_results, columns, &mut context)?
+                    } else {
+                        self.trim_projection(intermediate_results, columns)
+                    };
                 }
             }
         }

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -1055,6 +1055,56 @@ impl SelectExecutor {
         Ok(projected_rows)
     }
 
+    /// Trim a plain-column `Project` down to its selected columns WITHOUT
+    /// reshaping the row (issue #1952 round-6 fix).
+    ///
+    /// The Project step's ONLY job for a plain-column SELECT (every expr is a
+    /// bare `Column`) is to drop the helper columns the #1952 scan-widening added
+    /// (WHERE / ORDER BY / GROUP BY / aggregate-argument columns that are not in
+    /// the SELECT clause). It is NOT a reshape: a plain column is identity-named,
+    /// so there are no new names to derive (#1763's alias/reshape naming does not
+    /// apply) and no computed values to build.
+    ///
+    /// Unlike [`Self::execute_projection`] — which is correct for reshaping /
+    /// computed rows but rebuilds each row with an EMPTY `RowKey` and errors on a
+    /// selected cell that is absent from a sparse row — this preserves each row's
+    /// real `key` (partition/clustering key), `metadata`, and `cell_metadata`
+    /// unchanged, and simply omits any selected cell that a sparse row lacks
+    /// (never an error). Preserving the key is the #1587-class contract downstream
+    /// consumers (per-partition-limit boundary detection, dedup, ordering, callers
+    /// inspecting `row.key`) rely on; before #1952 these bare-column selects
+    /// skipped the Project entirely and streamed the RAW keyed row.
+    ///
+    /// Rows are name-keyed maps and output column ORDER is carried by the query
+    /// metadata, so trimming = retaining the correct SET of named cells in place.
+    fn trim_projection(
+        &self,
+        mut rows: Vec<QueryRow>,
+        columns: &[SelectExpression],
+    ) -> Vec<QueryRow> {
+        // The selected plain-column source names. This method is only reached
+        // when every projection expr is a plain `Column` (the caller gates on
+        // `!columns.iter().any(project_expr_reshapes_row)`), so every expr
+        // contributes its source name and none reshapes.
+        let selected: std::collections::HashSet<&str> = columns
+            .iter()
+            .filter_map(|e| match e {
+                SelectExpression::Column(c) => Some(c.column.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        for row in &mut rows {
+            // Retain only the selected cells by source-name identity; key,
+            // metadata, and cell_metadata are left untouched. A selected cell
+            // absent from a sparse row is simply not present after the retain —
+            // never an error.
+            row.values
+                .retain(|name, _| selected.contains(name.as_ref()));
+        }
+        rows
+    }
+
     /// Execute a query without FROM clause (constant expressions like SELECT 1)
     fn execute_constant_query(
         &self,
@@ -1498,6 +1548,129 @@ mod tests {
         assert_eq!(projected[0].values.get("b"), Some(&Value::Integer(0)));
         assert_eq!(projected[0].values.get("c"), Some(&Value::Integer(0)));
         assert_eq!(projected[99].values.get("a"), Some(&Value::Integer(99)));
+    }
+
+    /// Issue #1952 (round-6 HIGH): a plain-column `Project` that only TRIMS the
+    /// #1952-widened helper columns must PRESERVE each row's real `RowKey`,
+    /// `metadata`, and `cell_metadata`, and drop only the unselected helper
+    /// columns. Pre-fix these bare-column selects routed through
+    /// `execute_projection`, which rebuilt every row with an EMPTY `RowKey`
+    /// (`vec![]`) — a #1587-class regression. This pins the key-preserving trim.
+    #[tokio::test]
+    async fn trim_projection_preserves_key_and_trims_helpers() {
+        let executor = create_test_executor().await;
+
+        // SELECT a, b  (helper column `helper` was added to the scan by #1952).
+        let columns = vec![
+            SelectExpression::Column(ColumnRef {
+                table: None,
+                column: "a".to_string(),
+            }),
+            SelectExpression::Column(ColumnRef {
+                table: None,
+                column: "b".to_string(),
+            }),
+        ];
+
+        let mut row = QueryRow::new(RowKey::new(vec![7, 8, 9]));
+        row.set("a", Value::Integer(1));
+        row.set("b", Value::Integer(2));
+        row.set("helper", Value::Integer(3));
+        row.set_metadata(crate::query::result::RowMetadata {
+            version: Some(42),
+            ttl: None,
+            tags: Default::default(),
+        });
+
+        let out = executor.trim_projection(vec![row], &columns);
+        assert_eq!(out.len(), 1);
+        let r = &out[0];
+
+        // Key PRESERVED (the core regression): not the empty `vec![]`.
+        assert_eq!(
+            r.key.0,
+            vec![7, 8, 9],
+            "trim must preserve the real RowKey, not destroy it to vec![]"
+        );
+        // Row metadata preserved.
+        assert_eq!(
+            r.metadata.version,
+            Some(42),
+            "row metadata must be preserved"
+        );
+        // Selected columns kept, helper trimmed.
+        assert_eq!(r.values.get("a"), Some(&Value::Integer(1)));
+        assert_eq!(r.values.get("b"), Some(&Value::Integer(2)));
+        assert!(
+            !r.values.contains_key("helper"),
+            "the unselected helper column must be trimmed"
+        );
+        let mut keys: Vec<&str> = r.values.keys().map(|k| k.as_ref()).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["a", "b"], "only the selected columns remain");
+    }
+
+    /// Issue #1952 (round-6 HIGH, second defect): a selected column ABSENT from a
+    /// sparse row must be OMITTED by the trim, never an error. Pre-fix
+    /// `execute_projection` called `evaluate_select_expression(Column)`, which
+    /// returns `Err("Column not found: <col>")` for an absent cell — so a sparse
+    /// row aborted the whole query. This pins the tolerant trim AND documents the
+    /// contrasting pre-fix defect (`execute_projection` still errors on the same
+    /// input), proving the regression is real.
+    #[tokio::test]
+    async fn trim_projection_tolerates_absent_selected_cell() {
+        let executor = create_test_executor().await;
+
+        // SELECT a, b — but this row is sparse: it has `a` (and a helper) but no `b`.
+        let columns = vec![
+            SelectExpression::Column(ColumnRef {
+                table: None,
+                column: "a".to_string(),
+            }),
+            SelectExpression::Column(ColumnRef {
+                table: None,
+                column: "b".to_string(),
+            }),
+        ];
+
+        let build_row = || {
+            let mut row = QueryRow::new(RowKey::new(vec![1]));
+            row.set("a", Value::Integer(10));
+            row.set("helper", Value::Integer(99));
+            row
+        };
+
+        // NEW trim path: no error; `b` simply omitted, `a` kept, helper trimmed,
+        // key preserved.
+        let out = executor.trim_projection(vec![build_row()], &columns);
+        assert_eq!(out.len(), 1);
+        let r = &out[0];
+        assert_eq!(r.key.0, vec![1], "sparse row keeps its real key");
+        assert_eq!(r.values.get("a"), Some(&Value::Integer(10)));
+        assert!(
+            !r.values.contains_key("b"),
+            "absent selected cell `b` is omitted, not defaulted"
+        );
+        assert!(!r.values.contains_key("helper"), "helper trimmed");
+
+        // CONTRAST: the pre-fix path (`execute_projection`) ERRORS on the same
+        // sparse input — this is exactly the defect the trim fixes.
+        let mut ctx = ExecutionContext {
+            table_id: TableId::new("ks.t"),
+            columns: Vec::new(),
+            rows_processed: 0,
+            scan_rows: 0,
+            projection_flags: ProjectionFlags::default(),
+            access_path: None,
+            reverse_served: false,
+        };
+        let err = executor
+            .execute_projection(vec![build_row()], &columns, &mut ctx)
+            .expect_err("pre-fix execute_projection must error on the absent cell");
+        assert!(
+            err.to_string().contains("Column not found"),
+            "the pre-fix defect is a 'Column not found' error on a sparse row; got: {err}"
+        );
     }
 
     /// Issue #1590 (E8): `execute_limit` now applies OFFSET via `skip`/`take`

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -207,6 +207,41 @@ fn project_expr_reshapes_row(expr: &SelectExpression) -> bool {
     !matches!(expr, SelectExpression::Column(_))
 }
 
+/// True when a plain-column `Project`'s OUTPUT column SET differs from the
+/// SSTable scan projection's column SET — i.e. the `Project` must TRIM helper
+/// columns the broadened scan added (issue #1952 streaming follow-up).
+///
+/// #1952 widened the scan projection to the UNION of the selected columns and
+/// the WHERE / ORDER BY / GROUP BY / aggregate-argument helper columns, relying
+/// on the `Project` step to trim the non-selected helpers back out. The
+/// materialized path runs `Project`; the streaming producer
+/// (`execute_streaming_background`) IGNORES a plain-column `Project`, so without
+/// this check it would emit rows still carrying the helper columns
+/// (e.g. `SELECT a WHERE b = 1` scans `["a","b"]` and would leak `b`).
+///
+/// Column ORDER is intentionally irrelevant: streamed rows are keyed by name in
+/// a `HashMap`, and output ordering is carried by the query metadata, so only
+/// the SET matters — a `Project` that merely reorders (same set) can still
+/// stream directly with no perf regression. When there is no scan step
+/// (e.g. a constant query) there is nothing to trim.
+fn project_trims_scan_columns(
+    columns: &[SelectExpression],
+    scan_projection: Option<&[String]>,
+) -> bool {
+    let Some(scan) = scan_projection else {
+        return false;
+    };
+    let output: std::collections::HashSet<&str> = columns
+        .iter()
+        .filter_map(|e| match e {
+            SelectExpression::Column(c) => Some(c.column.as_str()),
+            _ => None,
+        })
+        .collect();
+    let scan_set: std::collections::HashSet<&str> = scan.iter().map(|s| s.as_str()).collect();
+    output != scan_set
+}
+
 /// Default row-count safety valve for the bare `SelectExecutor` constructors
 /// (issue #1582). Matches [`crate::config::QueryConfig::max_result_rows`]'s
 /// default; the query engine overrides it via
@@ -517,23 +552,39 @@ impl SelectExecutor {
 
     /// Check if query plan requires full materialization before streaming
     fn requires_materialization(&self, plan: &OptimizedQueryPlan) -> bool {
+        // The SSTable scan projection = the source columns the scan keeps in each
+        // streamed row. A `Project` step whose output column SET differs from this
+        // scan set must TRIM helper columns (issue #1952), which the streaming
+        // producer cannot do — so such a plan must materialize.
+        let scan_projection: Option<&[String]> =
+            plan.execution_steps.iter().find_map(|step| match step {
+                ExecutionStep::SSTableScan { projection, .. } => Some(projection.as_slice()),
+                _ => None,
+            });
+
         for step in &plan.execution_steps {
             match step {
                 ExecutionStep::Sort { .. } => return true,
                 ExecutionStep::Aggregate { .. } => return true,
-                // Issue #1763: the streaming producer (`execute_streaming_background`)
-                // IGNORES `Project`, so it emits rows keyed by the SOURCE stored
-                // column names (e.g. `category`) even when the SELECT renames or
-                // evaluates them (e.g. `category AS cat`) — silently disagreeing
-                // with the query metadata, which uses the SELECT output names.
-                // A `Project` that RENAMES (alias) or EVALUATES (aggregate /
-                // arithmetic / literal / function) any item must fall back to the
-                // materialized execute()-then-stream path, which applies the
-                // `Project`. A `Project` of only plain `Column`s does not reshape
-                // the row (the scan already keyed those cells by the same names),
-                // so it can stream without materializing.
+                // The streaming producer (`execute_streaming_background`) IGNORES
+                // `Project`, so a `Project` step that changes the row's column SET
+                // or SHAPE must fall back to the materialized execute()-then-stream
+                // path (which applies the `Project`). Two disjoint cases:
+                //
+                //   * Issue #1763 — a RENAMING (`category AS cat`) or EVALUATING
+                //     (aggregate / arithmetic / literal / function) item reshapes
+                //     the row: streaming would key it by the SOURCE stored column
+                //     name, disagreeing with the SELECT-output query metadata.
+                //   * Issue #1952 (this follow-up) — a plain-column `Project` whose
+                //     OUTPUT set ≠ the scan projection set TRIMS the WHERE / ORDER
+                //     BY / GROUP BY / aggregate-arg helper columns the broadened
+                //     scan added; streaming would LEAK those helper columns.
+                //
+                // A `Project` of exactly the scan's plain columns (no reshape, no
+                // trim) keys each cell by the same name and can stream directly.
                 ExecutionStep::Project { columns }
-                    if columns.iter().any(project_expr_reshapes_row) =>
+                    if columns.iter().any(project_expr_reshapes_row)
+                        || project_trims_scan_columns(columns, scan_projection) =>
                 {
                     return true
                 }
@@ -2017,6 +2068,101 @@ mod tests {
         assert_eq!(
             cols[0].name, "wt",
             "Alias must override Cassandra convention"
+        );
+    }
+
+    /// Build an optimized plan for `sql` against a fixed 4-column table, so
+    /// `requires_materialization` can be asserted directly (issue #1952 streaming
+    /// follow-up). The scan projection is the #1952 broadened union (selected +
+    /// WHERE/ORDER BY/GROUP BY/agg-arg helper columns).
+    async fn plan_for(sql: &str) -> OptimizedQueryPlan {
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.unwrap());
+        let storage = Arc::new(
+            StorageEngine::open(
+                temp_dir.path(),
+                &config,
+                platform.clone(),
+                #[cfg(feature = "state_machine")]
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
+        schema
+            .parse_and_register_cql_schema(
+                "CREATE TABLE ks.t (id int PRIMARY KEY, a int, b int, c int)",
+            )
+            .await
+            .expect("schema registers");
+        let optimizer =
+            crate::query::select_optimizer::SelectOptimizer::new(schema.clone(), storage.clone());
+        let statement = crate::query::select_parser::parse_select(sql).unwrap();
+        optimizer.optimize(statement).await.unwrap()
+    }
+
+    /// #1952 streaming follow-up: a plain-column `SELECT` filtered by an
+    /// UNSELECTED WHERE column produces a scan projection (`a`,`b`) wider than the
+    /// SELECT output (`a`). The `Project` step must TRIM `b`; the streaming
+    /// producer ignores `Project`, so the plan MUST be routed through the
+    /// materialized path. Pre-fix this returned `false` (streaming leaked `b`).
+    #[tokio::test]
+    async fn requires_materialization_for_where_helper_trim() {
+        let plan = plan_for("SELECT a FROM ks.t WHERE b = 1").await;
+        let executor = create_test_executor().await;
+        assert!(
+            executor.requires_materialization(&plan),
+            "SELECT a WHERE b=1 scans [a,b] but outputs [a]; the Project TRIM of \
+             the helper column `b` must force materialization (streaming ignores \
+             Project and would leak `b`)"
+        );
+    }
+
+    /// #1952 streaming follow-up: an ORDER BY + WHERE query over UNSELECTED helper
+    /// columns must materialize (the trim path is additionally guaranteed by the
+    /// Sort step, but the projection-set check alone already forces it).
+    #[tokio::test]
+    async fn requires_materialization_for_order_by_helper_trim() {
+        let plan = plan_for("SELECT a FROM ks.t WHERE b = 1 ORDER BY c").await;
+        let executor = create_test_executor().await;
+        assert!(
+            executor.requires_materialization(&plan),
+            "SELECT a WHERE b=1 ORDER BY c scans [a,b,c] but outputs [a]; must \
+             materialize to trim helper columns b,c"
+        );
+    }
+
+    /// Regression: when the selected columns EXACTLY equal the scan projection
+    /// (no helper columns, no reshape) the optimizer emits NO redundant `Project`
+    /// and the plan streams directly — this must NOT be forced into
+    /// materialization (no perf regression for the common case).
+    #[tokio::test]
+    async fn no_materialization_when_output_equals_scan() {
+        // Both selected columns are exactly the scan set (WHERE column `a` is
+        // already selected), so there is no helper column to trim.
+        let plan = plan_for("SELECT a, b FROM ks.t WHERE a = 1").await;
+        let executor = create_test_executor().await;
+        assert!(
+            !executor.requires_materialization(&plan),
+            "SELECT a,b WHERE a=1 scans exactly [a,b] and outputs [a,b]; it must \
+             stream directly without materialization"
+        );
+    }
+
+    /// Regression: a reordered SELECT whose WHERE column is already selected
+    /// (`SELECT b, a WHERE a = 1`) has output set {a,b} == scan set {a,b}, so it
+    /// streams directly — `project_trims_scan_columns` compares SETS (not order),
+    /// so no false materialization is triggered.
+    #[tokio::test]
+    async fn no_materialization_for_reordered_select_no_helpers() {
+        let plan = plan_for("SELECT b, a FROM ks.t WHERE a = 1").await;
+        let executor = create_test_executor().await;
+        assert!(
+            !executor.requires_materialization(&plan),
+            "a reordered select with no helper columns (same column set) must \
+             stream directly"
         );
     }
 }

--- a/cqlite-core/src/query/select_naming.rs
+++ b/cqlite-core/src/query/select_naming.rs
@@ -60,6 +60,33 @@ pub(crate) fn unwrap_aggregate(expr: &SelectExpression) -> Option<&AggregateFunc
     }
 }
 
+/// Source (stored) column names referenced by an aggregate's ARGUMENT
+/// expressions, excluding the `*` wildcard.
+///
+/// Issue #1952: the SSTable scan projection MUST include these so grouped,
+/// non-star aggregates read their input cells. `build_row_from_scan` filters
+/// decoded cells by the scan projection; without the argument column a grouped
+/// query that also projects a group dimension (`SELECT category, SUM(value) ...
+/// GROUP BY category`) scans ONLY the dimension and silently aggregates from
+/// missing inputs (SUM/AVG → 0/null, COUNT(col) → 0, MIN/MAX → null). Returns an
+/// empty vec for non-aggregate expressions and for `COUNT(*)` (no argument
+/// column). The SOURCE column is read directly (never an alias), matching the
+/// column the aggregation plan accumulates via [`aggregate_column_and_alias`].
+pub(crate) fn aggregate_arg_source_columns(expr: &SelectExpression) -> Vec<String> {
+    let Some(agg) = unwrap_aggregate(expr) else {
+        return Vec::new();
+    };
+    agg.args
+        .iter()
+        .filter_map(|arg| match arg {
+            SelectExpression::Column(col_ref) if col_ref.column != "*" => {
+                Some(col_ref.column.clone())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
 /// The output column name for a (possibly aliased) aggregate SELECT expression,
 /// or `None` if `expr` is not an aggregate.
 ///
@@ -187,6 +214,24 @@ mod tests {
         assert_eq!(extract_column_name(&col("name")).as_deref(), Some("name"));
         let aliased_col = SelectExpression::Aliased(Box::new(col("name")), "n".to_string());
         assert_eq!(extract_column_name(&aliased_col).as_deref(), Some("n"));
+    }
+
+    /// Issue #1952: aggregate argument source columns are extracted for the scan
+    /// projection — the SOURCE column for a named aggregate, nothing for
+    /// `COUNT(*)` or a non-aggregate, so the scan never drops an aggregate input.
+    #[test]
+    fn aggregate_arg_source_columns_extracts_named_argument_only() {
+        assert_eq!(
+            aggregate_arg_source_columns(&sum_of("value")),
+            vec!["value"]
+        );
+        // COUNT(*) references no stored column.
+        assert!(aggregate_arg_source_columns(&count_star()).is_empty());
+        // Aliased aggregate still yields its inner argument's source column.
+        let aliased = SelectExpression::Aliased(Box::new(sum_of("value")), "s".to_string());
+        assert_eq!(aggregate_arg_source_columns(&aliased), vec!["value"]);
+        // Plain columns / non-aggregates contribute no aggregate-argument columns.
+        assert!(aggregate_arg_source_columns(&col("value")).is_empty());
     }
 
     /// A non-aggregate expression is not an aggregate name and falls back to the

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -2,8 +2,8 @@
 
 use super::select_ast::*;
 use super::select_naming::{
-    aggregate_column_and_alias, aggregate_output_name, projection_source_and_output,
-    unwrap_aggregate,
+    aggregate_arg_source_columns, aggregate_column_and_alias, aggregate_output_name,
+    projection_source_and_output, unwrap_aggregate,
 };
 use crate::{schema::SchemaManager, storage::StorageEngine, Error, Result, TableId, Value};
 use std::collections::HashMap;
@@ -592,14 +592,38 @@ fn literal_value(expr: &SelectExpression) -> Option<Value> {
 /// projecting `cat` would drop the cell (null value; the `Project` step / grouped
 /// dimension could not find it). Output naming is applied afterwards (`Project`
 /// step / metadata / `finalize_group`), all via `select_naming`. Aggregates name
-/// no stored cell and are excluded.
+/// no stored cell — but their ARGUMENT columns ARE stored cells and MUST be
+/// scanned (issue #1952): the projection is the UNION of the projected/grouped
+/// dimension source columns AND every non-star aggregate argument source column.
+/// Omitting the latter meant `SELECT category, SUM(value) ... GROUP BY category`
+/// scanned only `category`, so `build_row_from_scan` filtered `value` out and the
+/// aggregate silently computed from missing inputs (SUM/AVG → 0/null, COUNT(col)
+/// → 0, MIN/MAX → null). `COUNT(*)` contributes no argument column, and an empty
+/// projection (`SELECT *`) still means scan-all.
 fn extract_projection_columns(select_clause: &SelectClause) -> Vec<String> {
     match select_clause {
         SelectClause::All => Vec::new(),
-        SelectClause::Columns(exprs) | SelectClause::Distinct(exprs) => exprs
-            .iter()
-            .filter_map(|e| projection_source_and_output(e).map(|(source, _)| source))
-            .collect(),
+        SelectClause::Columns(exprs) | SelectClause::Distinct(exprs) => {
+            let mut columns: Vec<String> = Vec::new();
+            let mut push_unique = |col: String| {
+                if !columns.contains(&col) {
+                    columns.push(col);
+                }
+            };
+            for expr in exprs {
+                // Dimension / plain-column source (the SELECT output side is named
+                // later; the scan reads the SOURCE column).
+                if let Some((source, _)) = projection_source_and_output(expr) {
+                    push_unique(source);
+                }
+                // Aggregate argument source columns (the #1952 fix). Empty for
+                // `COUNT(*)` and non-aggregate expressions.
+                for source in aggregate_arg_source_columns(expr) {
+                    push_unique(source);
+                }
+            }
+            columns
+        }
     }
 }
 

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -246,7 +246,7 @@ impl SelectOptimizer {
         plan.execution_steps.push(ExecutionStep::SSTableScan {
             table: table_id,
             predicates: plan.sstable_predicates.clone(),
-            projection: extract_projection_columns(&statement.select_clause),
+            projection: extract_projection_columns(&statement),
         });
 
         // If we couldn't push any predicates down, keep the original WHERE as
@@ -600,12 +600,21 @@ fn literal_value(expr: &SelectExpression) -> Option<Value> {
 /// aggregate silently computed from missing inputs (SUM/AVG → 0/null, COUNT(col)
 /// → 0, MIN/MAX → null). `COUNT(*)` contributes no argument column, and an empty
 /// projection (`SELECT *`) still means scan-all.
-fn extract_projection_columns(select_clause: &SelectClause) -> Vec<String> {
-    match select_clause {
+///
+/// The union ALSO includes every `GROUP BY` source column, whether or not it is
+/// projected in the SELECT clause (the #1952 regression fix). `build_group_key`
+/// reads each grouped column's cell from the scanned row; if a grouped column is
+/// NOT in the SELECT clause -- `SELECT SUM(value) FROM t GROUP BY category` --
+/// deriving the projection from the SELECT clause alone omitted `category`, so
+/// every row's group key read `Null` and ALL groups collapsed into one, silently
+/// returning wrong grouped aggregates. Scanning the GROUP BY columns
+/// unconditionally keeps the group key correct.
+fn extract_projection_columns(statement: &SelectStatement) -> Vec<String> {
+    match &statement.select_clause {
         SelectClause::All => Vec::new(),
         SelectClause::Columns(exprs) | SelectClause::Distinct(exprs) => {
             let mut columns: Vec<String> = Vec::new();
-            let mut push_unique = |col: String| {
+            let push_unique = |columns: &mut Vec<String>, col: String| {
                 if !columns.contains(&col) {
                     columns.push(col);
                 }
@@ -614,12 +623,20 @@ fn extract_projection_columns(select_clause: &SelectClause) -> Vec<String> {
                 // Dimension / plain-column source (the SELECT output side is named
                 // later; the scan reads the SOURCE column).
                 if let Some((source, _)) = projection_source_and_output(expr) {
-                    push_unique(source);
+                    push_unique(&mut columns, source);
                 }
                 // Aggregate argument source columns (the #1952 fix). Empty for
                 // `COUNT(*)` and non-aggregate expressions.
                 for source in aggregate_arg_source_columns(expr) {
-                    push_unique(source);
+                    push_unique(&mut columns, source);
+                }
+            }
+            // GROUP BY source columns must ALWAYS be scanned so `build_group_key`
+            // can read them, even when a grouped column is not in the SELECT
+            // clause (the #1952 regression fix).
+            if let Some(group_by) = &statement.group_by {
+                for col in &group_by.columns {
+                    push_unique(&mut columns, col.column.clone());
                 }
             }
             columns

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -243,10 +243,16 @@ impl SelectOptimizer {
             plan.sstable_predicates = collect_sstable_predicates(where_clause)?;
         }
 
+        // The scan projection is the COMPLETE set of source columns any later
+        // step reads from the scanned row (see `extract_projection_columns`).
+        // Computed once and reused below to decide whether the redundant
+        // bare-column `Project` step can be skipped (issue #1587) — it can only be
+        // skipped when the scan projection is EXACTLY the selected columns.
+        let scan_projection = extract_projection_columns(&statement);
         plan.execution_steps.push(ExecutionStep::SSTableScan {
             table: table_id,
             predicates: plan.sstable_predicates.clone(),
-            projection: extract_projection_columns(&statement),
+            projection: scan_projection.clone(),
         });
 
         // If we couldn't push any predicates down, keep the original WHERE as
@@ -312,7 +318,30 @@ impl SelectOptimizer {
                         .iter()
                         .all(|e| matches!(e, SelectExpression::Column(_)));
 
-                if !is_bare_columns {
+                // The scan projection is now the COMPLETE referenced-column set, so
+                // it may carry WHERE / ORDER BY helper columns that are NOT in the
+                // SELECT list. When that happens the scan row has MORE columns than
+                // the SELECT clause, and the `Project` step is REQUIRED to trim the
+                // output back to the selected columns — otherwise those helper
+                // columns would leak into the result. Skip the redundant projection
+                // only when the scan projection is EXACTLY the bare selected columns
+                // (same names, same order).
+                let projection_is_exactly_selected = is_bare_columns && {
+                    let selected: Vec<&str> = exprs
+                        .iter()
+                        .filter_map(|e| match e {
+                            SelectExpression::Column(c) => Some(c.column.as_str()),
+                            _ => None,
+                        })
+                        .collect();
+                    scan_projection.len() == selected.len()
+                        && scan_projection
+                            .iter()
+                            .zip(&selected)
+                            .all(|(scanned, wanted)| scanned.as_str() == *wanted)
+                };
+
+                if !projection_is_exactly_selected {
                     plan.execution_steps.push(ExecutionStep::Project {
                         columns: exprs.clone(),
                     });
@@ -609,6 +638,33 @@ fn literal_value(expr: &SelectExpression) -> Option<Value> {
 /// every row's group key read `Null` and ALL groups collapsed into one, silently
 /// returning wrong grouped aggregates. Scanning the GROUP BY columns
 /// unconditionally keeps the group key correct.
+///
+/// Finally — when the projection is NON-EMPTY (and therefore FILTERS decoded
+/// cells) — the union includes every column referenced by the WHERE and ORDER BY
+/// clauses (the second #1952 regression fix):
+///   * WHERE predicate columns: a pushed predicate is re-checked per row by the
+///     backstop `evaluate_predicates`, and a non-pushed predicate by the residual
+///     `Filter` step; BOTH read the column from the scanned row. Omitting them
+///     meant `SELECT SUM(value) FROM t WHERE category = 'A'` scanned only
+///     `["value"]`, so `category` was filtered out, the backstop saw a missing
+///     column (SQL `UNKNOWN`), and EVERY row was rejected — an empty result / a
+///     zero-or-null aggregate instead of the real filtered value. (Before #1952
+///     this query had an EMPTY projection = scan-all, so `category` was present;
+///     #1952 made the projection non-empty and reintroduced the filtering.)
+///   * ORDER BY columns: for a non-aggregate query the `Sort` step evaluates each
+///     ORDER BY expression against the scanned row, so an ORDER BY on a
+///     non-selected column would otherwise sort by a filtered-away `Null`. (In the
+///     aggregate case `Sort` runs after `Aggregate` on the result rows; the extra
+///     scanned cells are simply ignored, so unioning them is safe either way.)
+///
+/// HAVING columns are intentionally NOT unioned: the executor implements no
+/// HAVING step (nothing in `select_executor` reads `having_clause`), so HAVING
+/// columns are never read from the scanned row and adding them would be dead
+/// columns.
+///
+/// An EMPTY base projection (`SELECT *`, or `SELECT COUNT(*)` with no dimension)
+/// still means scan-all, which already supplies every column any step needs, so
+/// nothing is unioned in that case and the "empty = scan all" contract holds.
 fn extract_projection_columns(statement: &SelectStatement) -> Vec<String> {
     match &statement.select_clause {
         SelectClause::All => Vec::new(),
@@ -637,6 +693,31 @@ fn extract_projection_columns(statement: &SelectStatement) -> Vec<String> {
             if let Some(group_by) = &statement.group_by {
                 for col in &group_by.columns {
                     push_unique(&mut columns, col.column.clone());
+                }
+            }
+
+            // An empty base projection means scan-all: it already supplies every
+            // referenced column, so leave it empty. Only a NON-EMPTY projection
+            // (which filters decoded cells) needs the WHERE / ORDER BY columns
+            // unioned in, or those steps read a filtered-away column.
+            if columns.is_empty() {
+                return columns;
+            }
+
+            // WHERE predicate columns (pushed backstop + residual Filter both read
+            // from the scanned row).
+            if let Some(where_clause) = &statement.where_clause {
+                for col_ref in where_clause.get_column_refs() {
+                    push_unique(&mut columns, col_ref.column);
+                }
+            }
+            // ORDER BY columns (the non-aggregate `Sort` reads from the scanned
+            // row; harmless in the aggregate case).
+            if let Some(order_by) = &statement.order_by {
+                for item in &order_by.items {
+                    for col_ref in item.expression.get_column_refs() {
+                        push_unique(&mut columns, col_ref.column);
+                    }
                 }
             }
             columns
@@ -797,6 +878,111 @@ mod tests {
             1 + project_step_count(&aplan),
             2,
             "an aliased projection must keep its Project pass"
+        );
+    }
+
+    /// Extract the SSTable-scan projection a parsed query plans to.
+    fn scan_projection_of(query: &str) -> Vec<String> {
+        let statement = crate::query::select_parser::parse_select(query)
+            .unwrap_or_else(|e| panic!("{query} must parse: {e}"));
+        extract_projection_columns(&statement)
+    }
+
+    /// #1952 REGRESSION (roborev HIGH, this round): a non-empty scan projection
+    /// must include WHERE predicate columns, or the per-row backstop
+    /// (`evaluate_predicates`) reads a filtered-away column and rejects every row.
+    /// `SELECT SUM(value) FROM t WHERE category = 'x'` must scan BOTH `value`
+    /// (the aggregate argument) AND `category` (the WHERE column).
+    #[test]
+    fn where_predicate_columns_are_scanned() {
+        let projection = scan_projection_of(
+            "SELECT SUM(value) FROM test_basic.multi_partition_table WHERE category = 'A'",
+        );
+        assert!(
+            projection.iter().any(|c| c == "value"),
+            "aggregate argument `value` must be scanned; got {projection:?}"
+        );
+        assert!(
+            projection.iter().any(|c| c == "category"),
+            "WHERE column `category` must be scanned so the predicate backstop can \
+             evaluate it; got {projection:?}"
+        );
+    }
+
+    /// The WHERE union covers columns referenced anywhere in the predicate tree
+    /// (AND/OR and both comparison operands), reusing `WhereExpression::get_column_refs`.
+    #[test]
+    fn where_columns_from_compound_predicate_are_scanned() {
+        let projection = scan_projection_of(
+            "SELECT SUM(value) FROM t WHERE category = 'A' AND (name = 'x' OR metadata = 'y')",
+        );
+        for col in ["value", "category", "name", "metadata"] {
+            assert!(
+                projection.iter().any(|c| c == col),
+                "referenced column `{col}` must be scanned; got {projection:?}"
+            );
+        }
+    }
+
+    /// ORDER BY columns are read from the scanned row by the non-aggregate `Sort`
+    /// step, so a non-selected ORDER BY column must be scanned too.
+    #[test]
+    fn order_by_columns_are_scanned() {
+        let projection = scan_projection_of("SELECT name FROM t ORDER BY value");
+        assert!(
+            projection.iter().any(|c| c == "name"),
+            "selected column `name` must be scanned; got {projection:?}"
+        );
+        assert!(
+            projection.iter().any(|c| c == "value"),
+            "ORDER BY column `value` must be scanned for the Sort step; got {projection:?}"
+        );
+    }
+
+    /// The "empty = scan all" contract holds: `SELECT *` and a bare `COUNT(*)`
+    /// with no dimension keep an EMPTY projection even with a WHERE clause (scan-all
+    /// already supplies every column), so nothing is spuriously unioned in.
+    #[test]
+    fn empty_projection_stays_empty_for_scan_all() {
+        assert!(
+            scan_projection_of("SELECT * FROM t WHERE category = 'A'").is_empty(),
+            "SELECT * must keep an empty (scan-all) projection"
+        );
+        assert!(
+            scan_projection_of("SELECT COUNT(*) FROM t WHERE category = 'A'").is_empty(),
+            "bare COUNT(*) with no dimension must keep an empty (scan-all) projection"
+        );
+    }
+
+    /// A bare-column SELECT whose WHERE references a NON-selected column must keep
+    /// its `Project` step (to trim the helper WHERE column out of the output),
+    /// while a bare-column SELECT with no extra columns still skips it (#1587).
+    #[tokio::test]
+    async fn bare_column_with_where_helper_keeps_project() {
+        let optimizer = make_optimizer().await;
+
+        // WHERE references `b`, which is NOT selected → scan projection is a
+        // superset of the selected columns → the Project step must be kept so `b`
+        // does not leak into the output.
+        let with_helper =
+            crate::query::select_parser::parse_select("SELECT a FROM t WHERE b = 1").unwrap();
+        let plan = optimizer.optimize(with_helper).await.unwrap();
+        assert_eq!(
+            project_step_count(&plan),
+            1,
+            "a bare-column SELECT with a non-selected WHERE column must keep its \
+             Project step to trim the helper column from the output"
+        );
+
+        // No extra columns → the #1587 skip still applies.
+        let no_helper =
+            crate::query::select_parser::parse_select("SELECT a, b FROM t WHERE a = 1").unwrap();
+        let plan = optimizer.optimize(no_helper).await.unwrap();
+        assert_eq!(
+            project_step_count(&plan),
+            0,
+            "a bare-column SELECT whose WHERE only references selected columns must \
+             still skip the redundant Project step (#1587)"
         );
     }
 

--- a/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
@@ -273,6 +273,127 @@ async fn grouped_count_column_with_unselected_dimension_is_per_group() {
     }
 }
 
+/// #1952 REGRESSION (roborev HIGH, second round): a non-empty scan projection
+/// must ALSO include WHERE predicate columns. `SELECT SUM(value) ... WHERE
+/// category = 'A'` has projection `["value"]` (the aggregate argument); before
+/// this fix `category` was filtered out of every scanned row, so the per-row
+/// backstop (`evaluate_predicates`) saw a missing column (SQL UNKNOWN) and
+/// REJECTED every row — an empty result / zero-or-null SUM. `category` is neither
+/// selected nor an aggregate argument, so only unioning WHERE columns fixes it.
+/// Asserts the exact single-group total from the committed JSONL golden.
+#[tokio::test]
+async fn single_sum_filtered_by_unselected_where_column_is_exact() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT SUM(value) \
+             FROM test_basic.multi_partition_table WHERE category = 'A'",
+        )
+        .await
+        .expect("filtered SUM query must execute");
+
+    // Ground truth: category A sum = 18_785_439 (from GROUPS / the golden).
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "an ungrouped SUM returns exactly one row; got {}",
+        result.rows.len()
+    );
+    let sum = result.rows[0].values.get("Sum_value");
+    assert_eq!(
+        sum,
+        Some(&Value::Float(18_785_439.0)),
+        "SUM(value) WHERE category = 'A' must equal the category-A total; the WHERE \
+         column `category` must be in the scan projection so the predicate backstop \
+         can evaluate it (pre-fix: `category` filtered out → every row rejected → \
+         empty / zero SUM)",
+    );
+}
+
+/// #1952 REGRESSION companion: a compound WHERE that filters on BOTH a
+/// non-projected dimension (`category`, dropped pre-fix) AND the aggregate
+/// argument column (`value`, "the predicate on the aggregate arg column too")
+/// must compute the exact filtered sum. Pre-fix `category` was filtered out so
+/// the backstop rejected every row (empty / zero SUM).
+#[tokio::test]
+async fn single_sum_filtered_by_unselected_and_agg_arg_columns_is_exact() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT SUM(value) \
+             FROM test_basic.multi_partition_table \
+             WHERE category = 'A' AND value > 500000",
+        )
+        .await
+        .expect("compound-filtered SUM query must execute");
+
+    // Ground truth: category A with value > 500000 → count 17, sum 12_520_796.
+    assert_eq!(result.rows.len(), 1, "an ungrouped SUM returns one row");
+    assert_eq!(
+        result.rows[0].values.get("Sum_value"),
+        Some(&Value::Float(12_520_796.0)),
+        "SUM(value) WHERE category = 'A' AND value > 500000 must equal the exact \
+         filtered subtotal; `category` (WHERE-only) must be scanned alongside \
+         `value` (the aggregate argument)",
+    );
+}
+
+/// #1952 correctness: `SELECT category, SUM(value) ... WHERE value > n GROUP BY
+/// category` — a predicate on the aggregate-argument column combined with GROUP
+/// BY must compute correct PER-GROUP sums over only the filtered rows. This
+/// exercises the combined WHERE + GROUP BY + aggregate-argument projection path.
+#[tokio::test]
+async fn grouped_sum_filtered_by_agg_arg_column_is_per_group() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, SUM(value) \
+             FROM test_basic.multi_partition_table \
+             WHERE value > 500000 GROUP BY category",
+        )
+        .await
+        .expect("grouped filtered SUM query must execute");
+
+    // Ground truth (value > 500000, from the golden):
+    //   A: sum 12_520_796   B: sum 11_760_014   C: sum 12_302_991
+    let filtered: &[(&str, i64)] = &[("A", 12_520_796), ("B", 11_760_014), ("C", 12_302_991)];
+    assert_eq!(
+        result.rows.len(),
+        filtered.len(),
+        "one row per group; got {}",
+        result.rows.len()
+    );
+    for &(cat, sum) in filtered {
+        assert_eq!(
+            agg_value(&result.rows, cat, "Sum_value"),
+            Some(&Value::Float(sum as f64)),
+            "SUM(value) WHERE value > 500000 for category {cat} must be the exact \
+             per-group filtered subtotal",
+        );
+    }
+}
+
 /// Regression guard: `COUNT(*)` grouped needs no argument column and must stay
 /// correct after the projection change (the group size per category).
 #[tokio::test]

--- a/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
@@ -1,0 +1,220 @@
+//! Issue #1952 (P1, value-correctness): the SSTable scan projection must
+//! include aggregate ARGUMENT source columns.
+//!
+//! Before the fix, `extract_projection_columns` emitted only the projected +
+//! grouped DIMENSION columns. For a grouped query that also projects a group
+//! dimension — `SELECT category, SUM(value) FROM t GROUP BY category` — the scan
+//! projection became `["category"]`, so `value` was filtered out of every scanned
+//! row before `update_aggregate` could read it. Non-star aggregates then silently
+//! computed from missing inputs (SUM/AVG → 0/null, COUNT(col) → 0, MIN/MAX →
+//! null). `COUNT(*)` (no argument column) was unaffected.
+//!
+//! These tests run through the public `Database::execute` path on a real
+//! Cassandra 5.0 fixture and assert EXACT per-group aggregate values derived
+//! from the committed JSONL golden.
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::types::Value;
+use cqlite_core::{Database, QueryRow};
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup(schema_file: &str, keyspace_filter: &str) -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join(schema_file);
+    if !schema_path.exists() {
+        return Err(format!("{schema_file} not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(keyspace_filter.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+/// Ground truth for `test_basic.multi_partition_table`, grouped by the `category`
+/// clustering column over the BIGINT `value` column. Derived directly from the
+/// committed JSONL golden (`nb-1-big-Data.db.jsonl`, 100 single-row partitions):
+///   A: count=36 sum=18785439 min=42438  max=990685
+///   B: count=36 sum=17144227 min=34344  max=941836
+///   C: count=28 sum=15711813 min=73596  max=979921
+const GROUPS: &[(&str, i64, i64, i64, i64)] = &[
+    ("A", 36, 18_785_439, 42_438, 990_685),
+    ("B", 36, 17_144_227, 34_344, 941_836),
+    ("C", 28, 15_711_813, 73_596, 979_921),
+];
+
+/// Find the row whose `category` equals `cat`, then return the value keyed by
+/// `agg_key` (the aggregate output name, e.g. `Sum_value`).
+fn agg_value<'a>(rows: &'a [QueryRow], cat: &str, agg_key: &str) -> Option<&'a Value> {
+    rows.iter().find_map(|row| {
+        match row.values.get("category") {
+            Some(Value::Text(t)) if t == cat => {}
+            _ => return None,
+        }
+        row.values.get(agg_key)
+    })
+}
+
+/// `SELECT category, SUM(value) ... GROUP BY category` must compute EXACT
+/// per-group sums. On origin/main `value` is filtered out of the scan projection
+/// so every SUM is `0.0` — this asserts the real totals.
+#[tokio::test]
+async fn grouped_sum_with_selected_dimension_is_exact() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, SUM(value) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("grouped SUM query must execute");
+
+    for &(cat, _count, sum, _min, _max) in GROUPS {
+        let got = agg_value(&result.rows, cat, "Sum_value");
+        assert_eq!(
+            got,
+            Some(&Value::Float(sum as f64)),
+            "SUM(value) for category {cat}; scan projection must include the \
+             aggregate argument column `value`",
+        );
+    }
+}
+
+/// `COUNT(value)` counts non-null `value` cells per group; every row has a
+/// `value`, so it equals the group size. On origin/main it is `0` (column
+/// filtered out).
+#[tokio::test]
+async fn grouped_count_column_with_selected_dimension_is_exact() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, COUNT(value) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("grouped COUNT(col) query must execute");
+
+    for &(cat, count, _sum, _min, _max) in GROUPS {
+        let got = agg_value(&result.rows, cat, "Count_value");
+        assert_eq!(
+            got,
+            Some(&Value::BigInt(count)),
+            "COUNT(value) for category {cat} must equal the non-null group size",
+        );
+    }
+}
+
+/// `MIN(value)` / `MAX(value)` per group. On origin/main both are `null` (column
+/// filtered out of the scan).
+#[tokio::test]
+async fn grouped_min_max_with_selected_dimension_is_exact() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, MIN(value), MAX(value) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("grouped MIN/MAX query must execute");
+
+    for &(cat, _count, _sum, min, max) in GROUPS {
+        assert_eq!(
+            agg_value(&result.rows, cat, "Min_value"),
+            Some(&Value::BigInt(min)),
+            "MIN(value) for category {cat}",
+        );
+        assert_eq!(
+            agg_value(&result.rows, cat, "Max_value"),
+            Some(&Value::BigInt(max)),
+            "MAX(value) for category {cat}",
+        );
+    }
+}
+
+/// Regression guard: `COUNT(*)` grouped needs no argument column and must stay
+/// correct after the projection change (the group size per category).
+#[tokio::test]
+async fn grouped_count_star_still_correct() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, COUNT(*) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("grouped COUNT(*) query must execute");
+
+    for &(cat, count, _sum, _min, _max) in GROUPS {
+        let got = agg_value(&result.rows, cat, "Count(*)");
+        assert_eq!(
+            got,
+            Some(&Value::BigInt(count)),
+            "COUNT(*) for category {cat} must equal the group size",
+        );
+    }
+}

--- a/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
@@ -531,6 +531,148 @@ async fn streaming_exact_match_projection_still_streams_correctly() {
     }
 }
 
+/// Parse a canonical UUID string (`xxxxxxxx-xxxx-...`) into its 16 raw bytes,
+/// matching `Value::Uuid([u8; 16])`.
+fn uuid_bytes(s: &str) -> [u8; 16] {
+    let hex: String = s.chars().filter(|c| *c != '-').collect();
+    let mut out = [0u8; 16];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16)
+            .unwrap_or_else(|_| panic!("bad uuid hex in {s}"));
+    }
+    out
+}
+
+/// #1952 (round-6 HIGH): a NON-aggregate, plain-column SELECT whose WHERE
+/// references an UNSELECTED column must PRESERVE each returned row's real
+/// partition/clustering `RowKey`. Pre-fix the kept `Project` step routed these
+/// bare-column selects through `SelectExecutor::execute_projection`, which
+/// rebuilt every row with an EMPTY `RowKey` (`vec![]`) — a #1587-class regression
+/// destroying the key downstream consumers (per-partition-limit boundary
+/// detection, dedup, ordering) rely on. This FAILS pre-fix (empty key).
+#[tokio::test]
+async fn nonaggregate_select_preserves_row_key() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT tenant_id, name \
+             FROM test_basic.multi_partition_table WHERE category = 'A'",
+        )
+        .await
+        .expect("non-aggregate filtered SELECT must execute");
+
+    assert_eq!(
+        result.rows.len(),
+        36,
+        "category A has 36 rows; got {}",
+        result.rows.len()
+    );
+    for row in &result.rows {
+        assert!(
+            !row.key.0.is_empty(),
+            "each returned row must carry its real (non-empty) partition key; \
+             pre-fix `execute_projection` destroyed it to vec![] (#1587-class \
+             regression)"
+        );
+    }
+}
+
+/// #1952 (round-6) audit guard: the UNSELECTED WHERE helper column (`category`)
+/// must NOT leak into a plain-column SELECT's output rows after the trim.
+#[tokio::test]
+async fn nonaggregate_select_does_not_leak_where_helper() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT tenant_id, name \
+             FROM test_basic.multi_partition_table WHERE category = 'A'",
+        )
+        .await
+        .expect("non-aggregate filtered SELECT must execute");
+
+    assert_eq!(result.rows.len(), 36, "category A has 36 rows");
+    for row in &result.rows {
+        assert!(
+            !row.values.contains_key("category"),
+            "the unselected WHERE helper column `category` must be trimmed, not \
+             leaked into the output row"
+        );
+        let mut keys: Vec<&str> = row.values.keys().map(|k| k.as_ref()).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["name", "tenant_id"],
+            "output row must contain exactly the selected columns"
+        );
+    }
+}
+
+/// #1952 (round-6) value parity: selected column values for the filtered rows
+/// match the committed JSONL golden. Three known category-A rows (keyed by
+/// partition `tenant_id`) must carry their exact golden `name`, and the row's
+/// preserved key must contain the partition-key tenant_id bytes.
+#[tokio::test]
+async fn nonaggregate_select_value_parity_with_golden() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT tenant_id, name \
+             FROM test_basic.multi_partition_table WHERE category = 'A'",
+        )
+        .await
+        .expect("non-aggregate filtered SELECT must execute");
+
+    // (tenant_id, expected name) triples taken directly from nb-1-big-Data.db.jsonl
+    // for category A.
+    let expected: &[(&str, &str)] = &[
+        ("98e05820-982d-411c-961f-26d1057474e4", "Mrs"),
+        ("a75b0a43-21c4-4561-8331-472a710f2e37", "position"),
+        ("17213719-bb70-453b-8398-7cd097ca9d11", "return"),
+    ];
+
+    for &(tid, expected_name) in expected {
+        let tid_bytes = uuid_bytes(tid);
+        let row = result
+            .rows
+            .iter()
+            .find(|r| matches!(r.values.get("tenant_id"), Some(Value::Uuid(b)) if *b == tid_bytes))
+            .unwrap_or_else(|| panic!("row for tenant_id {tid} not found in result"));
+
+        assert_eq!(
+            row.values.get("name"),
+            Some(&Value::Text(expected_name.to_string())),
+            "name for tenant_id {tid} must match the golden value"
+        );
+        // The preserved partition key must embed the tenant_id bytes (composite
+        // PK `(tenant_id, user_id)`), proving the key is real, not vec![].
+        assert!(
+            row.key.0.windows(16).any(|w| w == tid_bytes),
+            "preserved partition key must contain the tenant_id bytes for {tid}"
+        );
+    }
+}
+
 /// Regression guard: `COUNT(*)` grouped needs no argument column and must stay
 /// correct after the projection change (the group size per category).
 #[tokio::test]

--- a/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
@@ -673,6 +673,115 @@ async fn nonaggregate_select_value_parity_with_golden() {
     }
 }
 
+/// #1952 (roborev LOW): `SELECT DISTINCT` also produces a bare-column `Project`
+/// step. Distinct is deliberately scoped OUT of the #1587 "skip redundant
+/// Project" optimization (`is_bare_columns` requires `SelectClause::Columns`, so
+/// a `SelectClause::Distinct` ALWAYS pushes a `Project`) AND DISTINCT forces
+/// materialization (`requires_materialization`, mod.rs:596). So a DISTINCT query
+/// whose WHERE filters on an UNSELECTED column now flows through the new
+/// key-preserving `trim_projection` (the plain-column arm of the `Project` step
+/// in `execute.rs`): the scan projection is WIDENED with the WHERE helper
+/// (`category`), and the DISTINCT `Project` must TRIM that helper back out while
+/// preserving each row's real partition key.
+///
+/// `SELECT DISTINCT tenant_id, user_id ... WHERE category = 'A'` selects the two
+/// partition-key columns and filters on the clustering column `category` (NOT in
+/// the SELECT list). This asserts: (a) `category` is trimmed, never leaked; (b)
+/// the selected DISTINCT columns are present; (c) the result equals the exact
+/// distinct set from the golden — the 36 category-A partitions, all unique; (d)
+/// every returned row keeps a real (non-empty) composite partition key.
+#[tokio::test]
+async fn distinct_partition_key_trims_unselected_where_helper() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT DISTINCT tenant_id, user_id \
+             FROM test_basic.multi_partition_table WHERE category = 'A'",
+        )
+        .await
+        .expect("DISTINCT filtered query must execute");
+
+    // (c) Ground truth: category A has 36 rows, each a distinct single-row
+    // partition, so DISTINCT over the partition key returns 36 rows.
+    assert_eq!(
+        result.rows.len(),
+        36,
+        "DISTINCT tenant_id, user_id WHERE category='A' must return the 36 \
+         category-A partitions; got {}",
+        result.rows.len()
+    );
+
+    let mut seen_pairs: std::collections::HashSet<([u8; 16], [u8; 16])> =
+        std::collections::HashSet::new();
+    for row in &result.rows {
+        // (a) The unselected WHERE helper `category` must be TRIMMED, not leaked.
+        assert!(
+            !row.values.contains_key("category"),
+            "the unselected WHERE helper column `category` must be trimmed from a \
+             DISTINCT row, not leaked (DISTINCT routes through trim_projection)"
+        );
+        // (b) Exactly the two selected DISTINCT columns are present.
+        let mut keys: Vec<&str> = row.values.keys().map(|k| k.as_ref()).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["tenant_id", "user_id"],
+            "a DISTINCT row must contain exactly the selected partition-key columns"
+        );
+        // (d) The trim path must PRESERVE the real composite partition key (it is
+        // NOT rebuilt to an empty vec![] the way `execute_projection` would).
+        assert!(
+            !row.key.0.is_empty(),
+            "each DISTINCT row must carry its real (non-empty) composite partition \
+             key; the key-preserving trim must not destroy it to vec![]"
+        );
+
+        let tid = match row.values.get("tenant_id") {
+            Some(Value::Uuid(b)) => *b,
+            other => panic!("tenant_id must be a Uuid, got {other:?}"),
+        };
+        let uid = match row.values.get("user_id") {
+            Some(Value::Uuid(b)) => *b,
+            other => panic!("user_id must be a Uuid, got {other:?}"),
+        };
+        // (c) DISTINCT contract: no (tenant_id, user_id) pair repeats.
+        assert!(
+            seen_pairs.insert((tid, uid)),
+            "DISTINCT must not return a duplicate (tenant_id, user_id) pair"
+        );
+        // The preserved key must embed the partition-key bytes, proving it is the
+        // real on-disk key rather than a fabricated empty one.
+        assert!(
+            row.key.0.windows(16).any(|w| w == tid),
+            "the preserved partition key must contain the tenant_id bytes"
+        );
+    }
+
+    // (c) Three known category-A partitions (tenant_ids drawn from
+    // nb-1-big-Data.db.jsonl) must appear in the distinct set.
+    for tid in [
+        "98e05820-982d-411c-961f-26d1057474e4",
+        "a75b0a43-21c4-4561-8331-472a710f2e37",
+        "17213719-bb70-453b-8398-7cd097ca9d11",
+    ] {
+        let bytes = uuid_bytes(tid);
+        assert!(
+            result
+                .rows
+                .iter()
+                .any(|r| matches!(r.values.get("tenant_id"), Some(Value::Uuid(b)) if *b == bytes)),
+            "distinct set must contain the known category-A tenant_id {tid}"
+        );
+    }
+}
+
 /// Regression guard: `COUNT(*)` grouped needs no argument column and must stay
 /// correct after the projection change (the group size per category).
 #[tokio::test]

--- a/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
@@ -18,6 +18,7 @@
 use std::path::{Path, PathBuf};
 
 use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
 use cqlite_core::types::Value;
 use cqlite_core::{Database, QueryRow};
 
@@ -391,6 +392,142 @@ async fn grouped_sum_filtered_by_agg_arg_column_is_per_group() {
             "SUM(value) WHERE value > 500000 for category {cat} must be the exact \
              per-group filtered subtotal",
         );
+    }
+}
+
+/// Collect all rows from a streaming query into a Vec.
+async fn stream_all(db: &Database, sql: &str) -> Vec<QueryRow> {
+    let mut iter = db
+        .execute_streaming(sql, StreamingConfig::default())
+        .await
+        .expect("streaming query must start");
+    let mut rows = Vec::new();
+    while let Some(item) = iter.next_async().await {
+        rows.push(item.expect("streamed row must decode"));
+    }
+    rows
+}
+
+/// #1952 STREAMING follow-up (roborev HIGH): the broadened scan projection now
+/// includes UNSELECTED WHERE helper columns, relying on the `Project` step to
+/// trim them. The streaming producer ignores a plain-column `Project`, so before
+/// the `requires_materialization` fix, `SELECT value ... WHERE category = 'A'`
+/// scanned `[value, category]` and STREAMED both — leaking the WHERE helper
+/// column `category` into every streamed row. After the fix the plan routes
+/// through the materialized-then-stream path and each streamed row carries ONLY
+/// the selected column `value`.
+#[tokio::test]
+async fn streaming_trims_unselected_where_helper_column() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let rows = stream_all(
+        &db,
+        "SELECT value FROM test_basic.multi_partition_table WHERE category = 'A'",
+    )
+    .await;
+
+    // Ground truth: category A has 36 rows.
+    assert_eq!(
+        rows.len(),
+        36,
+        "streaming SELECT value WHERE category='A' must yield the 36 category-A rows"
+    );
+    for row in &rows {
+        let keys: Vec<&str> = row.values.keys().map(|k| k.as_ref()).collect();
+        assert_eq!(
+            keys,
+            vec!["value"],
+            "streamed row must contain ONLY the selected column `value`; the WHERE \
+             helper column `category` must be trimmed, not leaked (pre-fix the \
+             streaming path ignored the Project step and leaked `category`)"
+        );
+        assert!(
+            !row.values.contains_key("category"),
+            "the unselected WHERE helper column `category` must NOT appear in a \
+             streamed row"
+        );
+    }
+}
+
+/// #1952 STREAMING follow-up: a query with BOTH an ORDER BY helper and a WHERE
+/// helper (neither selected) must stream only the selected column. `SELECT value
+/// ... WHERE category = 'A' ORDER BY item_id` scans `[value, category, item_id]`
+/// and must trim `category` and `item_id` from every streamed row.
+#[tokio::test]
+async fn streaming_trims_unselected_where_and_order_by_helpers() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let rows = stream_all(
+        &db,
+        "SELECT value FROM test_basic.multi_partition_table \
+         WHERE category = 'A' ORDER BY item_id",
+    )
+    .await;
+
+    assert_eq!(rows.len(), 36, "category A has 36 rows");
+    for row in &rows {
+        let keys: Vec<&str> = row.values.keys().map(|k| k.as_ref()).collect();
+        assert_eq!(
+            keys,
+            vec!["value"],
+            "streamed row must contain ONLY `value`; WHERE helper `category` and \
+             ORDER BY helper `item_id` must be trimmed"
+        );
+    }
+}
+
+/// #1952 STREAMING regression guard: when the selected columns EXACTLY equal the
+/// scan projection (no helper columns to trim), the query must still stream
+/// directly and return correct rows — the fix must not force materialization for
+/// the common case. `SELECT value ... WHERE value > 500000` scans exactly
+/// `[value]` (the WHERE column is already selected), so no `Project`-trim is
+/// needed.
+#[tokio::test]
+async fn streaming_exact_match_projection_still_streams_correctly() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let rows = stream_all(
+        &db,
+        "SELECT value FROM test_basic.multi_partition_table WHERE value > 500000",
+    )
+    .await;
+
+    assert!(
+        !rows.is_empty(),
+        "there are rows with value > 500000; streaming must return them"
+    );
+    for row in &rows {
+        let keys: Vec<&str> = row.values.keys().map(|k| k.as_ref()).collect();
+        assert_eq!(
+            keys,
+            vec!["value"],
+            "each streamed row carries only `value`"
+        );
+        match row.values.get("value") {
+            Some(Value::BigInt(v)) => assert!(
+                *v > 500_000,
+                "streamed value {v} must satisfy the WHERE predicate value > 500000"
+            ),
+            other => panic!("expected BigInt value, got {other:?}"),
+        }
     }
 }
 

--- a/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
@@ -189,6 +189,90 @@ async fn grouped_min_max_with_selected_dimension_is_exact() {
     }
 }
 
+/// #1952 REGRESSION (roborev HIGH): `SELECT SUM(value) ... GROUP BY category`
+/// with `category` NOT in the SELECT clause. #1952 derived the scan projection
+/// from the SELECT clause, so the projection became `["value"]` and OMITTED the
+/// GROUP BY column `category`. `build_group_key` then read `category` as `Null`,
+/// collapsing ALL groups into one and returning a single wrong sum. The GROUP BY
+/// columns must ALWAYS be scanned. Asserts multiple distinct groups with EXACT
+/// per-group sums.
+#[tokio::test]
+async fn grouped_sum_with_unselected_dimension_is_per_group() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT SUM(value) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("grouped SUM (unselected dimension) query must execute");
+
+    // Multiple distinct groups must be returned, not one collapsed group.
+    assert_eq!(
+        result.rows.len(),
+        GROUPS.len(),
+        "GROUP BY category must return one row per group ({} groups), not a \
+         single collapsed group; scan projection must include the GROUP BY \
+         column `category`",
+        GROUPS.len(),
+    );
+
+    for &(cat, _count, sum, _min, _max) in GROUPS {
+        let got = agg_value(&result.rows, cat, "Sum_value");
+        assert_eq!(
+            got,
+            Some(&Value::Float(sum as f64)),
+            "SUM(value) for category {cat}; GROUP BY column `category` must be \
+             scanned even though it is not in the SELECT clause",
+        );
+    }
+}
+
+/// #1952 REGRESSION companion: `SELECT COUNT(value) ... GROUP BY category` with
+/// `category` unselected must produce correct PER-GROUP counts, not one collapsed
+/// group.
+#[tokio::test]
+async fn grouped_count_column_with_unselected_dimension_is_per_group() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT COUNT(value) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("grouped COUNT(col) (unselected dimension) query must execute");
+
+    assert_eq!(
+        result.rows.len(),
+        GROUPS.len(),
+        "GROUP BY category must return one row per group, not a collapsed group",
+    );
+
+    for &(cat, count, _sum, _min, _max) in GROUPS {
+        let got = agg_value(&result.rows, cat, "Count_value");
+        assert_eq!(
+            got,
+            Some(&Value::BigInt(count)),
+            "COUNT(value) for category {cat} must equal the non-null group size \
+             even though `category` is not in the SELECT clause",
+        );
+    }
+}
+
 /// Regression guard: `COUNT(*)` grouped needs no argument column and must stay
 /// correct after the projection change (the group size per category).
 #[tokio::test]


### PR DESCRIPTION
## Summary
Fixes #1952 (P1, value-correctness) — grouped/filtered non-star aggregates silently computed from missing inputs because the SSTable scan projection omitted the columns they read. `SELECT category, SUM(value) FROM t GROUP BY category` returned `SUM=0`; it now computes from real inputs.

## Root cause + fix
The scan projection was derived from the SELECT clause only, so aggregate ARGUMENT columns (and, once the projection became non-empty, GROUP BY / WHERE / ORDER BY helper columns) were filtered out of scanned rows before aggregation / the per-row predicate backstop could read them.

- **Widen the scan projection** to the union of: selected/grouped dimension source columns ∪ non-star aggregate-argument source columns ∪ GROUP BY columns ∪ (when non-empty) WHERE + ORDER BY columns. `COUNT(*)` and `SELECT *` keep the empty (scan-all) projection.
- **Key-preserving `trim_projection`** for plain-column `Project` steps: the widened scan carries helper columns that must be trimmed from non-aggregate output. The prior path (`execute_projection`) destroyed the RowKey (`RowKey::new(vec![])`) and errored on absent cells — a #1587-class regression. The new trim retains only the selected cells by name and **preserves `key`/`metadata`/`cell_metadata`**, tolerating absent cells. Reshaping projections (alias/arithmetic/aggregate/function/writetime) still use `execute_projection`.
- **Streaming**: `requires_materialization` now also forces materialization when a `Project` trims helper columns (the streaming producer ignores `Project`), so streamed rows never leak helpers.

## Tests
`cqlite-core/tests/issue_1952_aggregate_arg_projection.rs` — grouped SUM/AVG/COUNT(col)/MIN/MAX with selected + unselected dimensions; single aggregate filtered by unselected WHERE; streaming trim parity; RowKey preservation + absent-cell tolerance for non-aggregate plain-column trims; and DISTINCT routing through `trim_projection` (helper trimmed, composite key preserved). Plus optimizer/executor unit tests for the projection union and materialization routing.

## Notes
- This bug was masking a latent BTI bug (#1968, now merged): a probe in `issue_954_clustering_slice_seek` silently skipped because `SELECT ck WHERE pk=2` dropped `pk`. This branch is rebased on the #1968 fix; that test now runs and passes.
- **File-size**: this change grows already-over-threshold query-executor files (`select_executor/mod.rs`, `select_optimizer.rs`, `execute.rs`); gated with `CQLITE_ALLOW_FILE_GROWTH=1` (acknowledged per CLAUDE.md, epic #1116 — splitting these is out of scope for a P1 value-correctness fix; follow-up split under #1116).

## Gate
Full `scripts/agent-gate.sh` **RESULT: PASS** at `32570b92` (rebased on main incl. #1968). roborev findings addressed (widen-then-trim HIGH cascade resolved by the key-preserving trim; DISTINCT coverage added).
