### PR TITLE
fix(#1972): gate get_udt_registry on state_machine (minimal-features dead-code CI red)

### DIFF
--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -939,6 +939,11 @@ impl SchemaRegistry {
     ///
     /// This method is used by SchemaManager when initialized with a pre-loaded registry
     /// to preserve the UDT definitions loaded during ingestion.
+    ///
+    /// Gated on `state_machine`: both callers (`storage::sstable::refresh` and the
+    /// `cli-helpers`-gated ingestion module) compile out without it, so it would be
+    /// dead code under `-D warnings` in the minimal-features build (issue #1972).
+    #[cfg(feature = "state_machine")]
     pub(crate) fn get_udt_registry(&self) -> Arc<RwLock<UdtRegistry>> {
         self.udt_registry.clone()
     }


### PR DESCRIPTION
Fixes #1972. `SchemaRegistry::get_udt_registry` (registry.rs:942) was `pub(crate)` with no cfg gate, but both its callers are effectively `state_machine`-only (refresh.rs:162 is `#[cfg(feature="state_machine")]`; ingestion.rs:122 is in the `cli-helpers` module, and `cli-helpers = ["state_machine"]`). Builds without `state_machine` (the `--no-default-features --features all-compression` and lz4+snappy minimal CI lanes) compiled the callers out → dead-code → `-D warnings` failed **Minimal Features CI** on main.

Fix: `#[cfg(feature = "state_machine")]` on the method (no `allow(dead_code)`). Verified pre-fix fails / post-fix compiles clean for both `--features all-compression` and `--features lz4,snappy`; default build unchanged.

Full `scripts/agent-gate.sh` **RESULT: PASS** at 21b0202b (file-size ratchet acknowledged via CQLITE_ALLOW_FILE_GROWTH=1 — registry.rs is a pre-existing 2412-line file, split tracked under #1116).

Follow-up (separate): the gate's `minimal-build` component runs without `RUSTFLAGS=-D warnings`, so it can't catch this dead-code-under-feature class locally — filing separately.