### PR TITLE
fix(#1978): gate write-support-only test module out of minimal-features test build (+ gate-gap check)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -776,7 +776,7 @@ mod regression_1741c_tests;
 #[cfg(test)]
 mod regression_1741d_tests;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "write-support"))]
 mod regression_1741h_tests;
 
 #[cfg(test)]

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -111,7 +111,8 @@
 #                      the machine-wide full-gate concurrency cap queues at N,
 #                      exempts --lite, and releases a slot on SIGKILL (uses the
 #                      gate's hermetic stub mode, never real gate work).
-#   minimal-build      cargo build -p cqlite-core --no-default-features --features all-compression
+#   minimal-build      cargo build + `cargo test --lib --no-run` (compile-only)
+#                      -p cqlite-core --no-default-features --features all-compression
 #   smoke              bash test-data/scripts/smoke-test-all-tables.sh
 #   file-size          campsite-rule ratchet (epic #1116 / #1135): lists changed
 #                      .rs files over threshold (800 src / 1500 test, total lines)
@@ -2317,7 +2318,8 @@ run_file_size
 #     delivery-telemetry + tooling-tests (pure shell/stdlib tool tests; the lone
 #     CQLITE_DATASETS_ROOT in test_agent_gate_summary.sh *sets an empty* root to
 #     exercise the preflight, it consumes no real data), minimal-build (a cargo
-#     build, no tests run), and format-compat. format-compat is excluded (#1175
+#     build plus a compile-only `cargo test --lib --no-run`; no tests run, no
+#     data — issue #1978), and format-compat. format-compat is excluded (#1175
 #     finding 1): its sole target (cargo test -p format-compatibility-tests,
 #     tests/format-compatibility) is pure in-memory byte-level format-compliance
 #     assertions with hardcoded vectors — it reads no CQLITE_DATASETS_ROOT and no
@@ -2455,7 +2457,15 @@ dispatch_component() {
     parity-report) run_parity_report ;;
     binding-unwind-profile) run_component binding-unwind-profile bash "$REPO_ROOT/scripts/tests/test_binding_unwind_profile.sh" ;;
     tooling-tests) run_tooling_tests ;;
-    minimal-build) run_component minimal-build cargo build --package cqlite-core --no-default-features --features all-compression ;;
+    minimal-build) run_component minimal-build bash -c '
+  cargo build --package cqlite-core --no-default-features --features all-compression &&
+  # Test-compile the minimal lane (issue #1978): the CI "All Compression Build &
+  # Test" job runs `cargo test --no-default-features --features=all-compression
+  # --lib`, which compiles the test targets. A plain `cargo build` never does, so
+  # a `#[cfg(test)]` module referencing a write-support-gated item (e.g.
+  # storage::serialization) silently escaped this gate. Compile-only (--no-run)
+  # keeps it fast; no data fixtures needed for a compile check.
+  cargo test --package cqlite-core --no-default-features --features all-compression --lib --no-run' ;;
     smoke) run_component smoke bash -c '
   cargo build --package cqlite-cli --bin cqlite &&
   CQLITE_CLI="${CARGO_TARGET_DIR:-$PWD/target}/debug/cqlite" bash test-data/scripts/smoke-test-all-tables.sh' ;;


### PR DESCRIPTION
Fixes #1978. After #1972 fixed the `get_udt_registry` dead-code error, **Minimal Features CI** still failed: the `All Compression Build & Test` job's `cargo test --no-default-features --features=all-compression --lib` couldn't compile because `regression_1741h_tests` (declared `#[cfg(test)]` only) references `storage::serialization::vint` (which is `#[cfg(feature = "write-support")]`). The lib build failed first on `get_udt_registry` before #1972, masking this.

Fix: gate the module on write-support — `#[cfg(all(test, feature = "write-support"))] mod regression_1741h_tests;` (matching the sibling `write_read` gate). Single offender; the exact CI command now compiles + runs clean (1458 passed). Default/write-support build still compiles and runs those 3 tests — coverage unchanged.

**Gate-gap closed (same PR):** the gate's `minimal-build` component only ran `cargo build` (no test compile), so it never caught this or #1972's class locally. Added `cargo test --no-default-features --features all-compression --lib --no-run` (compile-only, fast) to that component.

Full `scripts/agent-gate.sh` **RESULT: PASS** at 99512364 (all 21 components green, minimal-build now includes the test-compile check).