### PR TITLE
fix(#1981): gate minimal-features dead-code + enforce -D warnings in gate minimal-build

### DIFF
--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -66,7 +66,7 @@ pub mod fuzz_support;
 // allocation regression test in the SELECT executor's `lookup` module). It
 // delegates every operation to the system allocator and only bumps a per-thread
 // counter while a measurement is ACTIVE, so it is inert for every other test.
-#[cfg(test)]
+#[cfg(all(test, feature = "state_machine"))] // sole `measure` caller lives in the state_machine `query` module; else `-D dead-code` under minimal (#1981)
 pub(crate) mod test_alloc_probe {
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::cell::Cell;
@@ -120,7 +120,7 @@ pub(crate) mod test_alloc_probe {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "state_machine"))]
 #[global_allocator]
 static TEST_ALLOC: test_alloc_probe::CountingAllocator = test_alloc_probe::CountingAllocator;
 

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1803,7 +1803,7 @@ impl SSTableManager {
     /// The next `scan` on this manager pauses at its per-reader I/O, signalling
     /// [`Gate::reached`](scan_gate::Gate) and blocking on
     /// [`Gate::release`](scan_gate::Gate) until the test lets it continue.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "write-support", feature = "state_machine"))] // gated to sole caller issue_1591_scan_lock_test; not dead-code under minimal (#1981)
     fn arm_scan_gate(&self) -> Arc<scan_gate::Gate> {
         let gate = Arc::new(scan_gate::Gate::default());
         if let Ok(mut slot) = self.scan_gate.lock() {

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741k_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741k_tests.rs
@@ -262,6 +262,12 @@ async fn da_reader() -> (
 /// A full DELETED-partition buffer that parses cleanly: the deleted header
 /// followed by an END_OF_PARTITION marker (0x01) so the row loop terminates with
 /// zero rows.
+///
+/// Gated `write-support` (issue #1981) to match its only callers — the two
+/// `#[cfg(feature = "write-support")]` sliding-parser tests below (and the
+/// sibling `tiny_schema`/`da_reader` helpers) — so it is not dead-code under the
+/// minimal feature set's `-D warnings` build.
+#[cfg(feature = "write-support")]
 fn deleted_partition_full_buffer() -> Vec<u8> {
     let mut buf = deleted_oa_partition_header();
     buf.push(0x01); // END_OF_PARTITION

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2458,6 +2458,14 @@ dispatch_component() {
     binding-unwind-profile) run_component binding-unwind-profile bash "$REPO_ROOT/scripts/tests/test_binding_unwind_profile.sh" ;;
     tooling-tests) run_tooling_tests ;;
     minimal-build) run_component minimal-build bash -c '
+  # Match the CI "All Compression Build & Test" job byte-for-byte (issue #1981):
+  # that job sets RUSTFLAGS=-D warnings, so a warning-class error (e.g. an unused
+  # `#[cfg(test)]` helper whose only caller is feature-gated out under the minimal
+  # feature set — the dead-code lint) hard-fails CI but slipped past this gate,
+  # which ran WITHOUT -D warnings (#1972/#1978/#1981 all escaped locally this way).
+  # Export it for BOTH the build and the test-compile so this component enforces
+  # exactly what CI enforces.
+  export RUSTFLAGS="-D warnings" &&
   cargo build --package cqlite-core --no-default-features --features all-compression &&
   # Test-compile the minimal lane (issue #1978): the CI "All Compression Build &
   # Test" job runs `cargo test --no-default-features --features=all-compression


### PR DESCRIPTION
Fixes #1981 (3rd Minimal Features CI layer). With #1972/#1978 clearing the hard compile errors, CI's `All Compression Build & Test` (`RUSTFLAGS=-D warnings cargo test --no-default-features --features=all-compression --lib`) reached the **dead-code lint**, which failed on 3 unused-under-minimal items:
- `arm_scan_gate` (mod.rs:1807) — gated to match its sole caller `issue_1591_scan_lock_test` (`write-support`+`state_machine`).
- `deleted_partition_full_buffer` (regression_1741k_tests.rs) — gated `write-support` (its only callers; the module's 5 always-present tests stay, so gated the helper not the module).
- `measure`/`test_alloc_probe` (lib.rs) — gated `state_machine` to match the `query`-module caller.
No `#[allow(dead_code)]`; net-zero file growth (rationale folded into the `#[cfg]` line comments).

**Durable fix (stops the recurrence):** the gate's `minimal-build` component now exports `RUSTFLAGS=-D warnings` for its `cargo build` + `cargo test --lib --no-run` — matching CI exactly. #1972/#1978/#1981 all escaped locally *because* this ran without `-D warnings`. Verified: revert the fix → `scripts/agent-gate.sh --only minimal-build` FAILs; with fix → PASS.

Default/write-support builds unaffected (gated tests still compile+run under their features). Full `scripts/agent-gate.sh` **RESULT: PASS** at 81cf48f2.