### PR TITLE
fix(#1995): scope CQLITE_REQUIRE_FIXTURES off general ci.yml lanes (unblock main CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,15 @@ jobs:
       - name: Run core lib/doc tests with timings
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
-          # Issue #1230: fail-closed. The ~70 legacy dataset-dependent tests skip
-          # on missing data; with these flags an absent/empty fixture FAILS the
-          # lane (via require_fixtures_strict) instead of false-greening.
-          CQLITE_REQUIRE_FIXTURES: "1"
+          # Issue #1230: fail-closed on the MAIN dataset corpus — the ~70 legacy
+          # dataset-dependent tests skip on missing data; this flag makes an
+          # absent/empty fetched corpus FAIL the lane instead of false-greening.
+          # NOTE (#1995): CQLITE_REQUIRE_FIXTURES is deliberately NOT set on this
+          # general fast lane — it additionally demands Docker/corruption-corpus/
+          # byte-oracle fixtures this lane does not provision (hard-panicking the
+          # skip-clean tests). That strict enforcement lives in the provisioned
+          # nightly tiers (nightly-docker-parity, compression-corruption-parity,
+          # sstabledump-parity-gate, exhaustive-regeneration).
           CQLITE_PARITY_REQUIRE_DATASETS: "1"
           RUST_LOG: debug
           RUST_BACKTRACE: full
@@ -257,7 +262,6 @@ jobs:
       - name: Archive core integration tests
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
-          CQLITE_REQUIRE_FIXTURES: "1"
           CQLITE_PARITY_REQUIRE_DATASETS: "1"
           RUST_LOG: debug
           RUST_BACKTRACE: full
@@ -384,7 +388,6 @@ jobs:
       - name: Run core integration nextest partition
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
-          CQLITE_REQUIRE_FIXTURES: "1"
           CQLITE_PARITY_REQUIRE_DATASETS: "1"
           RUST_LOG: debug
           RUST_BACKTRACE: full
@@ -548,7 +551,6 @@ jobs:
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
           # Issue #1230: fail-closed for the dataset-dependent golden-path lane.
-          CQLITE_REQUIRE_FIXTURES: "1"
           CQLITE_PARITY_REQUIRE_DATASETS: "1"
         run: |
           bash scripts/ci/ci-timing-summary.sh measure "integration tests" -- bash <<'BASH'


### PR DESCRIPTION
Fixes #1995. The general `CI` workflow has been red for 24h+ because the tier overhaul (#23aba02a) set `CQLITE_REQUIRE_FIXTURES=1` on the fast general lanes (Core lib/doc, nextest archive, nextest partition ×3, Integration tests), but those lanes don't provision Docker / the corruption corpus / byte-oracle / zstd-dict fixtures — so ~13 fail-closed SKIP tests hard-panic (issue_911 sstabledump, issue_1396 CRC corpus, issue_1382 deferred byte-oracle, etc.).

**Fix:** remove only `CQLITE_REQUIRE_FIXTURES` from the 4 general lanes; **keep** `CQLITE_PARITY_REQUIRE_DATASETS` (the actual #1230 anti-silent-skip guard on the fetched main corpus, which IS provisioned). Strict fixture enforcement remains in the provisioned nightly tiers (nightly-docker-parity, compression-corruption-parity, sstabledump-parity-gate, exhaustive-regeneration).

**Verified locally:** with `CQLITE_PARITY_REQUIRE_DATASETS=1` and no `CQLITE_REQUIRE_FIXTURES`, `issue_911`/`issue_1382` (fixtures absent) skip-clean and PASS. YAML validated. The PR's own CI run is the end-to-end verification (general lanes should go green).

Owner decision (2026-07-05): scope strict to provisioned lanes.