### PR TITLE
fix(#1997): deterministic ORDER BY id in CLI smoke test_select_json_simple

### DIFF
--- a/test-data/scripts/ci-one-shot-smoke.sh
+++ b/test-data/scripts/ci-one-shot-smoke.sh
@@ -322,9 +322,13 @@ run_test_suite() {
     echo ""
 
     # Test 1: Basic SELECT with JSON output (simple_table)
+    # ORDER BY id (#1997): simple_table is single-PK (id UUID, no clustering), so an
+    # unordered LIMIT returns storage/token order which drifts across engine changes
+    # and flaps the snapshot. ORDER BY id makes it deterministic; the output is
+    # byte-identical to the committed golden (id-sorted).
     run_test \
         "test_select_json_simple" \
-        "SELECT * FROM test_basic.simple_table LIMIT 3" \
+        "SELECT * FROM test_basic.simple_table ORDER BY id LIMIT 3" \
         "json" \
         0 \
         "${SNAPSHOTS_DIR}/select_simple_json.golden"


### PR DESCRIPTION
Fixes #1997. The `CLI tests and smoke` job failed `test_select_json_simple` because its query `SELECT * FROM test_basic.simple_table LIMIT 3` has no `ORDER BY` and `simple_table` is single-PK (`id UUID`, no clustering) — an unordered LIMIT returns storage/token order, which drifted vs the id-sorted golden (Dec-2025). Not a #1952 regression, not a value change (column set/order/formatting byte-identical; only which 3 rows).

Fix: add `ORDER BY id` → deterministic, and **verified byte-identical to the existing committed golden** (no golden regeneration). Future-proofs the smoke against scan-order drift. The PR's `CLI tests and smoke` job is the end-to-end verification.