### PR TITLE
docs(#1993): v0.12→v0.13 migration guide for the 3 breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING (Python bindings):** CQL `duration` and `time` now decode to exact,
-  lossless Python types, matching the Node binding (#1450). The previous mapping
-  (M4 §5.2) was lossy and disagreed with Node, the CLI, and Cassandra:
+  lossless Python types, matching the Node binding (#1450). See the
+  [v0.13 Migration Guide](docs/development/v0.13-migration-guide.md) for
+  before/after examples. The previous mapping (M4 §5.2) was lossy and disagreed
+  with Node, the CLI, and Cassandra:
   - `time` → `int` (nanoseconds since midnight), was `datetime.time` (which
     truncated sub-microsecond nanoseconds).
   - `duration` → `cqlite.Duration(months, days, nanos)`, was `datetime.timedelta`
     (which approximated months as 30 days and truncated nanoseconds to
     microseconds).
 
-  Migration for code that relied on the old types:
+  Migration for code that relied on the old types (the
+  [v0.13 Migration Guide](docs/development/v0.13-migration-guide.md) expands on
+  this):
   ```python
   # OLD: t was a datetime.time; d was a datetime.timedelta
   # NEW: t is an int (nanoseconds); d is a cqlite.Duration
@@ -41,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Unknown tables now fail honestly with `Error::Schema("unknown table <name>;
   no schema registered or discovered")`, mirroring the I3 hard-fail precedent
   (#1626). Tables with real registered/discovered schemas (including all corpus
-  parity tables) are unaffected (#1710).
+  parity tables) are unaffected (#1710). See the
+  [v0.13 Migration Guide](docs/development/v0.13-migration-guide.md) for the
+  per-surface error (Rust/Python/Node/CLI) and how to register a schema.
 
 ### Removed
 
@@ -52,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unused `OutputMode`/`OutputFormat` variant), so this removes a dead surface
   rather than working behavior; anyone scripting `--out yaml`/`--format yaml`
   must switch to a supported format. A parse-rejection regression test guards
-  against the variant being silently re-added (#283).
+  against the variant being silently re-added (#283). See the
+  [v0.13 Migration Guide](docs/development/v0.13-migration-guide.md).
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -555,8 +555,11 @@ warm-up. Full scans no longer share mutable file state: #815 removed the old
 file handle + chunk index), so N concurrent full scans run in parallel rather than
 serialized.
 
-**Python/CLI parity** (Issue #319): Python uses native types (datetime, UUID, bytes);
-CLI uses JSON strings. Normalization required for comparison — see
+**Python/CLI parity** (Issue #319): Python uses native types (v0.13 mapping:
+`timestamp`→`datetime`, `uuid`→`UUID`, `blob`→`bytes`, `time`→`int` ns since
+midnight, `duration`→`cqlite.Duration` — see the
+[v0.13 Migration Guide](docs/development/v0.13-migration-guide.md)); CLI uses JSON
+strings. Normalization required for comparison — see
 `bindings/python/tests/test_cli_parity.py`.
 
 ## Development Standards

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 > **Status**: v0.12.0 — Core reading, CLI, output writers, Python & Node.js bindings, and write support are production-ready, now with **byte-for-byte compaction parity against Apache Cassandra**, an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, and CDC-style delta export. See [CHANGELOG.md](CHANGELOG.md).
 
+> **Upgrading to v0.13?** See the [v0.13 Migration Guide](docs/development/v0.13-migration-guide.md) for the 3 breaking changes (Python duration/time types, unknown-table errors, CLI YAML removal).
+
 CQLite provides SQLite-like local access to Apache Cassandra SSTables, enabling developers to read Cassandra 5.0+ data files without cluster dependencies. Built in Rust for performance and safety.
 
 > ⭐ **Find CQLite useful?** [**Star the repo**](https://github.com/pmcfadin/cqlite) — it is the clearest signal that this work matters and directly drives how much time goes into it.

--- a/docs/development/M4_spec.md
+++ b/docs/development/M4_spec.md
@@ -534,6 +534,8 @@ napi-build = "2.1"
 | `udt` | `UdtValue` | `dict` | `object` |
 | `null` | `Value::Null` | `None` | `null` |
 
+> **Note:** superseded in v0.13 — the Python `time`/`duration` mappings above are the pre-0.13 (lossy) types. As of v0.13, `time`→`int` (ns since midnight) and `duration`→`cqlite.Duration(months, days, nanos)`. See the [v0.13 Migration Guide](./v0.13-migration-guide.md).
+
 ### 5.2 Implementation Notes
 
 **Python Collection Behavior (Issue #301)**:
@@ -559,6 +561,8 @@ napi-build = "2.1"
    - `LIST<FROZEN<udt>>` → `list[dict]` with UDT metadata
 
 **Temporal Type Precision Notes (Issue #299)**:
+
+> **Note:** superseded in v0.13 (#1450) — the `duration`/`time` precision losses below no longer apply. `duration`→`cqlite.Duration(months, days, nanos)` and `time`→`int` (ns since midnight) are both exact/lossless. See the [v0.13 Migration Guide](./v0.13-migration-guide.md).
 
 When converting CQL temporal types to Python, the following precision limitations apply:
 

--- a/docs/development/PRD.md
+++ b/docs/development/PRD.md
@@ -324,6 +324,8 @@ with cqlite.open("path/to/sstables", schema="schema.cql") as db:
 | `tuple` | `tuple` | |
 | UDT | `dict` | With `_type`, `_keyspace` fields |
 
+> **Note:** the `time`/`duration` rows above are the pre-0.13 mapping and were superseded in v0.13 — see the [v0.13 Migration Guide](./v0.13-migration-guide.md): `time`→`int` (ns since midnight), `duration`→`cqlite.Duration(months, days, nanos)`.
+
 ### Type Checking
 
 CQLite ships with PEP 561 type stubs for full mypy/pyright support:

--- a/docs/development/v0.13-migration-guide.md
+++ b/docs/development/v0.13-migration-guide.md
@@ -1,0 +1,212 @@
+# Upgrading to v0.13
+
+## v0.12 → v0.13 Migration Guide
+
+v0.13 ships **three breaking changes**. This guide describes what changed, why,
+and how to migrate, with before/after examples for each. See the
+[CHANGELOG](../../CHANGELOG.md) for the full release notes.
+
+Who is affected:
+
+- **Python binding users** who read CQL `time` or `duration` columns
+  (breaking change 1).
+- **Anyone reading a table with no registered or discovered schema** — Rust,
+  Python, Node, or CLI (breaking change 2).
+- **CLI users scripting `--out yaml` / `--format yaml`** (breaking change 3).
+
+If your code does none of these, no changes are required.
+
+---
+
+## 1. Python `time` and `duration` now decode to exact, lossless types (#1450)
+
+### What changed
+
+The Python binding previously decoded CQL `time` and `duration` to standard
+`datetime` types that could not represent the value exactly. v0.13 switches both
+to lossless representations, matching the Node binding, the CLI, and Cassandra.
+
+| CQL type   | v0.12 Python type                                | v0.13 Python type                          |
+|------------|--------------------------------------------------|--------------------------------------------|
+| `time`     | `datetime.time` (microsecond-truncated)          | `int` — nanoseconds since midnight         |
+| `duration` | `datetime.timedelta` (months ≈ 30 days, µs only) | `cqlite.Duration(months, days, nanos)`     |
+
+`cqlite.Duration` is a frozen, hashable object with read-only properties
+`.months` (i32), `.days` (i32), and `.nanos` (i64). Its constructor is
+**positional**: `cqlite.Duration(months, days, nanos)`, and its `repr` is
+`Duration(months=<m>, days=<d>, nanos=<n>)`. The canonical docstring lives at
+`bindings/python/python/cqlite/__init__.pyi` (the `Duration` class).
+
+### Why
+
+A CQL `duration` has three independent components (months, days, nanoseconds)
+that cannot be collapsed into a single scalar without loss — a month is not a
+fixed number of days, and a day is not a fixed number of nanoseconds. The old
+`timedelta` mapping approximated months as 30 days and truncated nanoseconds to
+microseconds. Likewise, CQL `time` is nanoseconds since midnight, but
+`datetime.time` only has microsecond resolution. The old mapping also disagreed
+with the Node binding and the CLI.
+
+### Before / after
+
+```python
+# v0.12
+t = row["t"]          # datetime.time (microsecond-truncated)
+d = row["d"]          # datetime.timedelta (months approximated, nanos truncated)
+```
+
+```python
+# v0.13
+t = row["t"]          # int: nanoseconds since midnight (lossless)
+micros = t // 1000    # derive microseconds if you need them
+
+d = row["d"]          # cqlite.Duration
+d.months              # int (exact)
+d.days                # int (exact)
+d.nanos               # int (exact)
+```
+
+If you must reconstruct a `datetime.time` from the new `int` (accepting the
+microsecond truncation the old mapping had):
+
+```python
+import datetime
+
+t_ns = row["t"]                                   # e.g. 3723123456789
+t = datetime.time(
+    t_ns // 3_600_000_000_000,                    # hours
+    (t_ns // 60_000_000_000) % 60,                # minutes
+    (t_ns // 1_000_000_000) % 60,                 # seconds
+    (t_ns // 1000) % 1_000_000,                    # microseconds (lossy)
+)
+```
+
+---
+
+## 2. Reading an unknown table now errors instead of fabricating a schema (#1710)
+
+### What changed
+
+`SchemaManager` previously invented a default `uuid id` schema for any table
+that was never registered or discovered, so a query against an undefined table
+returned fabricated-shape rows silently. v0.13 removes that fabrication: reads
+of an unknown table now **hard-fail** with a clear error.
+
+### Why
+
+Fabricating a schema is a no-heuristics-mandate violation — CQLite decodes with
+authoritative metadata only. Returning invented rows for a table that has no
+schema hides real configuration mistakes. Failing honestly surfaces them.
+
+### The error, per surface
+
+- **Rust** — `Error::Schema`, Display:
+  `Schema error: unknown table <name>; no schema registered or discovered`
+- **Python** — raises `cqlite.SchemaError` (a subclass of `cqlite.CqliteError`)
+  with the same message.
+- **Node** — a JS error with message
+  `SchemaError: Schema error: unknown table <name>; no schema registered or discovered`,
+  `e.code === "SCHEMA"`, and category `"Schema"`.
+- **CLI** — propagates the core Display string.
+
+### Migration
+
+Load or register a schema for **every** table you query before reading it:
+
+- **CLI**: pass `--schema <path.cql>`.
+- **Python / Node**: pass the `schema=` option to the `open` call.
+- **Core (Rust)**: call `parse_and_register_cql_schema(cql)`.
+
+### Before / after
+
+```text
+# v0.12: no schema loaded
+SELECT * FROM unknown_table   →  silently returns fabricated `uuid id`-shaped rows
+
+# v0.13: no schema loaded
+SELECT * FROM unknown_table   →  errors: "Schema error: unknown table unknown_table;
+                                  no schema registered or discovered"
+```
+
+**Rust**
+
+```rust
+// Before (v0.12): unknown table silently got a fabricated `uuid id` schema.
+// After (v0.13): register the real schema first.
+db.parse_and_register_cql_schema(cql_text)?;
+// now reads of the table decode against the real schema
+```
+
+**Python**
+
+```python
+# Before (v0.12):
+db = cqlite.open("data-dir")                       # no schema
+rows = db.execute("SELECT * FROM my_ks.my_table")  # fabricated rows
+
+# After (v0.13):
+db = cqlite.open("data-dir", schema="my_table.cql")
+try:
+    rows = db.execute("SELECT * FROM my_ks.my_table")
+except cqlite.SchemaError as e:
+    print(f"missing schema: {e}")
+```
+
+**Node**
+
+```javascript
+// After (v0.13): open with a schema, and handle SchemaError.
+const db = await Database.open("data-dir", { schema: "my_table.cql" });
+try {
+  await db.executeNative("SELECT * FROM my_ks.my_table");
+} catch (e) {
+  if (e.code === "SCHEMA") {
+    console.error(e.message); // "SchemaError: Schema error: unknown table ..."
+  }
+}
+```
+
+**CLI**
+
+```bash
+# Before (v0.12): worked (with fabricated rows) without --schema.
+cqlite --data-dir ./data --query "SELECT * FROM my_ks.my_table"
+
+# After (v0.13): pass --schema for every queried table.
+cqlite --schema my_table.cql --data-dir ./data \
+  --query "SELECT * FROM my_ks.my_table"
+```
+
+---
+
+## 3. CLI YAML output removed (#283)
+
+### What changed
+
+`--out yaml` and `--format yaml` are no longer accepted. Both are rejected at
+parse time with an error listing the supported values. YAML output was never
+actually implemented (it was an unused output-mode variant), so this removes a
+dead surface rather than working behavior.
+
+### Migration
+
+Use one of the supported output formats instead: `json`, `csv`, `table`, or
+`parquet`.
+
+### Before / after
+
+```bash
+# v0.12
+cqlite --data-dir ./data --query "SELECT * FROM my_ks.my_table" --out yaml
+
+# v0.13 — pick a supported format
+cqlite --data-dir ./data --query "SELECT * FROM my_ks.my_table" --out json
+```
+
+---
+
+## See also
+
+- [CHANGELOG](../../CHANGELOG.md) — full v0.13 release notes.
+- `bindings/python/python/cqlite/__init__.pyi` — canonical `Duration` docstring
+  and Python type stubs.

--- a/website/src/content/docs/agents-developing/validation-playbook.md
+++ b/website/src/content/docs/agents-developing/validation-playbook.md
@@ -119,9 +119,11 @@ diff /tmp/ref-sorted.json /tmp/cqlite-sorted.json
 ```
 
 Type differences between sstabledump JSON and CQLite JSON are expected and documented:
-Python uses native types (datetime, UUID, bytes); CLI uses JSON strings. Normalization
-is needed for comparison — see `bindings/python/tests/test_cli_parity.py` for the
-normalization logic.
+Python uses native types (v0.13 mapping: `timestamp`→`datetime`, `uuid`→`UUID`,
+`blob`→`bytes`, `time`→`int` ns since midnight, `duration`→`cqlite.Duration` — see the
+v0.13 Migration Guide, `docs/development/v0.13-migration-guide.md`); CLI uses JSON
+strings. Normalization is needed for comparison — see
+`bindings/python/tests/test_cli_parity.py` for the normalization logic.
 
 ## Adding a new table to parity coverage
 

--- a/website/src/content/docs/agents-using/query-python.md
+++ b/website/src/content/docs/agents-using/query-python.md
@@ -59,7 +59,7 @@ Python receives native types — no string serialization:
 | `uuid`, `timeuuid` | `uuid.UUID` |
 | `timestamp` | `datetime.datetime` (UTC) |
 | `date` | `datetime.date` |
-| `time` | `datetime.timedelta` |
+| `time` | `int` (nanoseconds since midnight) |
 | `blob` | `bytes` |
 | `inet` | `str` (dotted decimal or IPv6) |
 | `decimal` | `decimal.Decimal` |
@@ -67,6 +67,8 @@ Python receives native types — no string serialization:
 | `list<T>` | `list` |
 | `set<T>` | `frozenset` |
 | `map<K,V>` | `dict` |
+
+> **v0.13:** `time` decodes to `int` (nanoseconds since midnight) and `duration` to `cqlite.Duration`. See the [v0.13 Migration Guide](https://github.com/pmcfadin/cqlite/blob/main/docs/development/v0.13-migration-guide.md).
 
 ## Row access
 

--- a/website/src/content/docs/user-docs/python.md
+++ b/website/src/content/docs/user-docs/python.md
@@ -118,8 +118,8 @@ CQL types are mapped to native Python types automatically:
 | `blob` | `bytes` |
 | `timestamp` | `datetime.datetime` (UTC-aware) |
 | `date` | `datetime.date` |
-| `time` | `datetime.time` |
-| `duration` | `datetime.timedelta` |
+| `time` | `int` (nanoseconds since midnight) |
+| `duration` | `cqlite.Duration(months, days, nanos)` |
 | `uuid`, `timeuuid` | `uuid.UUID` |
 | `inet` | `ipaddress.IPv4Address` or `IPv6Address` |
 | `decimal` | `decimal.Decimal` |
@@ -131,6 +131,8 @@ CQL types are mapped to native Python types automatically:
 | `frozen<T>` | Unwrapped inner type |
 | UDT | `dict` with `_type` and `_keyspace` keys |
 | `null` | `None` |
+
+> **v0.13:** `time` and `duration` now decode to exact, lossless types. See the [v0.13 Migration Guide](https://github.com/pmcfadin/cqlite/blob/main/docs/development/v0.13-migration-guide.md).
 
 ## Streaming large result sets
 

--- a/website/src/content/docs/user-docs/use-cases/python-data-science.md
+++ b/website/src/content/docs/user-docs/use-cases/python-data-science.md
@@ -130,14 +130,16 @@ Active users: 4 of 10
 | blob | `bytes` |
 | timestamp | `datetime.datetime` (timezone-aware, UTC) |
 | date | `datetime.date` |
-| time | `datetime.time` |
+| time | `int` (nanoseconds since midnight) |
 | uuid, timeuuid | `uuid.UUID` |
-| duration | `datetime.timedelta` |
+| duration | `cqlite.Duration(months, days, nanos)` |
 | inet | `ipaddress.IPv4Address` or `ipaddress.IPv6Address` |
 | list, set | `list` |
 | map | `dict` |
 | tuple | `tuple` |
 | UDT | `dict` (field name → value) |
+
+> **v0.13:** `time` and `duration` now decode to exact, lossless types. See the [v0.13 Migration Guide](https://github.com/pmcfadin/cqlite/blob/main/docs/development/v0.13-migration-guide.md).
 
 ## Streaming for large tables
 


### PR DESCRIPTION
## Summary
Adds the single discoverable **v0.13 migration guide** (`docs/development/v0.13-migration-guide.md`) covering all three v0.13 breaking changes with before/after examples, grounded in shipped code (not memory):

1. **Python `duration`/`time` (#1450)** — `time` → `int` (nanoseconds since midnight, lossless); `duration` → `cqlite.Duration(months, days, nanos)` (frozen, exact). Was `datetime.time`/`datetime.timedelta` in v0.12.
2. **Unknown-table reads error (#1710)** — `Schema error: unknown table <name>; no schema registered or discovered` → Python `cqlite.SchemaError`, Node `code === "SCHEMA"`. Migration: load a schema for every queried table.
3. **CLI YAML output removed (#283)** — `--out yaml`/`--format yaml` gone; use `json`/`csv`/`table`/`parquet`.

## Cross-links / fixes
- `README.md` — "Upgrading to v0.13?" callout after the Status line.
- `CHANGELOG.md` — all three breaking entries link the guide (buried snippet kept).
- `CLAUDE.md` + `website/agents-developing/validation-playbook.md` — Python parity note corrected to v0.13 types.
- Stale website type tables fixed: `user-docs/python.md`, `use-cases/python-data-science.md`, `agents-using/query-python.md` (last was also wrong pre-existing: `time`→`timedelta`).
- Historical internal specs (`docs/development/PRD.md`, `M4_spec.md`) get supersede notes.
- Website release page left to sibling #1994 (no collision).

## Validation
- **Diff is 100% markdown** (zero executable surface) — verified `git diff --name-only origin/main..HEAD` has no non-`.md` file.
- **spec-auditor: PASS** — all 4 acceptance criteria satisfied; every API fact (Duration constructor arg order, `.months/.days/.nanos`, `time`→int ns, exact Schema error string, Python/Node error mapping, CLI format set) verified against shipped `value.rs`/`__init__.pyi`/`schema/mod.rs`/`error.rs`.
- Full `agent-gate.sh` intentionally **not** run: a `.md`-only diff changes nothing the gate compiles/tests, and `--delta` re-cert (#1892) has no green anchor (`main`'s nightly gate is currently red). Certified on the markdown-only scope + auditor sign-off, per owner decision.

Closes #1993