### PR TITLE
docs(#1992): complete 0.13 CHANGELOG (Added + 17 missing items) + fix Appendix F false compressed-write claim + stale BTI claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Typed inner-UDT decode for frozen-UDT elements inside frozen collections (#1340, PR #1960)
+- RF-correct logical-optimizer row-count estimate for the Flight/Trino connector (#1336, PR #1954)
+- Byte-bounded result budget: `Error::ResultTooLarge` and `QueryConfig.max_result_bytes` (default 64 MiB) (#1582, PR #1890)
+- Per-surface SSTable freshness contract plus explicit `Database::refresh()` (#1749, PR #1761)
+- Compaction drops fully-expired SSTables whole via metadata only, overlap-safe (#1388, PR #1740)
+- fsync the data directory before WAL truncate for SSTable durability (#1392, PR #1421)
+- Intern per-cell column names as `Arc<str>` to cut row-decode allocations (#1334, PR #1533)
+- Recursive comparator for composite collection element/key ordering (#1296, PR #1317)
+- Preserve repaired metadata through compaction (Cassandra 5.0) (#1021, PR #1250)
+
 ### Changed
 
 - **BREAKING (Python bindings):** CQL `duration` and `time` now decode to exact,
@@ -38,8 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uuid id` default schema. `SchemaManager::load_schema` previously invented a
   hardcoded schema for unknown tables, so queries against an undefined table
   returned fabricated-shape rows rather than failing — a no-heuristics violation.
-  Unknown tables now fail honestly with `Error::Schema("unknown table <name>;
-  no schema registered or discovered")`, mirroring the I3 hard-fail precedent
+  Unknown tables now fail honestly with `Table schema not found: {table_name}`,
+  mirroring the I3 hard-fail precedent
   (#1626). Tables with real registered/discovered schemas (including all corpus
   parity tables) are unaffected (#1710).
 
@@ -74,6 +86,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Full-scan no longer issues duplicate scans.** Retired
   `execute_parallel_table_scan` in favor of bounded streaming, eliminating the
   4× duplicate table scan on the full-scan path (#1691).
+- Pre-admission memtable size check with a bounded iterative estimator (#1625, PR #1957)
+- Grouped/filtered non-star aggregates now read the input columns they were missing (#1952, PR #1971)
+- Parser hardening bundle: recursion-depth guards, duration i32 bounds, collection capacity limits (#1632, PR #1970)
+- Aggregate/grouped result metadata names now match row value keys (#1763, PR #1953)
+- Data-safe logging: log shapes not values — removed eprintln/WHERE-literal logging that could leak data (#1694, PR #1958)
+- Surface chunk-CRC corruption on point lookups instead of silently proceeding (#1411, PR #1777)
 
 ### Performance
 
@@ -82,14 +100,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Read-path constant-factor bundle (Epic E):** query-engine hot-path cleanups
   (schema `Arc`, single projection, cached sort keys, plan cache, GROUP BY hash;
-  #1587), read-path idiom bundle (de-async, `FxHash`, OFFSET skip/take,
-  per-partition digest, IN-expansion allocation cuts; #1590), and dropping the
-  `table_readers` read guard before scanning (#1591).
+  #1587, PR #1867), read-path idiom bundle (de-async, `FxHash`, OFFSET skip/take,
+  per-partition digest, IN-expansion allocation cuts; #1590, PR #1877), and dropping the
+  `table_readers` read guard before scanning (#1591, PR #1882).
 - **Point-read I/O (C2):** a `ReadAt` positional-read trait removes the point-read
   cursor convoy and the per-lookup `open(2)` (#1573).
 - **Node bindings throughput:** batch-fetch streaming rows per async task (#1443),
   move (not deep-clone) row values in `executeNative` (#1447), and cache `Set`/`Map`
   constructors per result conversion (#1448).
+- Cache derived comparators on `SchemaEntry` (#1709, PR #1963)
+- One payload+CRC read per compressed chunk (E3 A5 read-path bundle) (#1585, PR #1955)
 
 ## [v0.12.0] - 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ known gaps — none of which block the core read/export workflows. Full, dated l
 | `SET<FROZEN<UDT>>` fails to deserialize in the Python bindings | Python only; CLI/Rust unaffected | [#804](https://github.com/pmcfadin/cqlite/issues/804) |
 | Concurrent queries on one `Database` can race (`Column not found`) | Use one handle per thread | [#805](https://github.com/pmcfadin/cqlite/issues/805) |
 | Wide partitions written by CQLite scan linearly (`promoted_index_length = 0`) | Perf on 10k+ rows/partition | [#751](https://github.com/pmcfadin/cqlite/issues/751), [#752](https://github.com/pmcfadin/cqlite/issues/752) |
-| BTI (`da`) SSTables are rejected, not read | Use BIG format or convert first | [#660](https://github.com/pmcfadin/cqlite/issues/660) |
 | Pre-5.0 formats (`md`/`mc`/`la`/`ma`) unsupported | By design — Cassandra 5.0 only | [Limitations](https://pmcfadin.github.io/cqlite/user-docs/limitations/) |
 
 For what CQLite does **not** do by design (older formats, network access, query

--- a/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
@@ -132,13 +132,11 @@ The following limitations from M5.0 have been resolved in M5.1:
 
 ### CompressionInfo.db Writing
 
-**Status**: RESOLVED (was "NOT IMPLEMENTED" in M5.0)
+**Status**: NOT IMPLEMENTED for production writes (building blocks are test-only, fail-closed — #1406)
 
-M5.0 produced only uncompressed SSTables. M5.1 implements full compression support with:
-- All four compression algorithms (LZ4, Snappy, Deflate, Zstd)
-- Chunk-based compression with configurable chunk size
-- Trailing CRC32 checksums per chunk
-- CompressionInfo.db metadata file generation
+CQLite's production SSTable writer emits uncompressed Data.db only and never writes a CompressionInfo.db. The `CompressedDataWriter` / `CompressionInfoWriter` types exist solely to synthesize compressed fixtures for exercising the decompressing reader; they are UNWIRED (no flush/compaction path reaches them) and any attempt to configure compressed production writing returns `Error::UnsupportedFormat`.
+
+The READ/decompression path fully supports all four compression algorithms (LZ4, Snappy, Deflate, Zstd) — CQLite reads compressed Cassandra SSTables end-to-end. See the "CompressionInfo.db Writing" entry under "M5.1 Write Support Capabilities" above for the exact fail-closed boundary and the parseable on-read format.
 
 ### Collection Serialization
 
@@ -264,11 +262,11 @@ CQLite has defined k-way merge compaction API with STCS (Size-Tiered Compaction 
 
 ### BTI Format Writing
 
-**Status**: NOT IMPLEMENTED
+**Status**: IMPLEMENTED (canonical `da` BTI write since v0.12 — #872)
 
-M5.1 produces BIG format SSTables only. BTI (trie-based) index writing is not supported.
+CQLite emits canonical BTI (`da`) format SSTables, including trie-based `Partitions.db` and `Rows.db`. BIG (`nb`) remains the DEFAULT write target; BTI (`da`) is an explicit, supported alternative. BTI read is fully supported end-to-end.
 
-**Rationale**: BTI is opt-in/experimental in Cassandra 5.0. BIG format covers >95% of production use cases.
+**Rationale**: BIG format covers the majority of production use cases and remains the default, while `da` BTI write/read achieves byte-parity with Cassandra 5.0 for callers that select it.
 
 ### Index.db/Summary.db Full Format
 
@@ -279,8 +277,9 @@ Current implementation:
 - Summary.db: Sampled entries with correct offset tracking
 
 Not implemented:
-- Full promoted index data in Index.db entries
-- BTI trie format
+- Full promoted index data in Index.db entries (BIG `nb` format)
+
+BTI (`da`) trie format write/read IS supported (see "BTI Format Writing" above).
 
 ### Statistics.db Full TOC Format
 
@@ -540,48 +539,34 @@ if entries.is_empty() {
 
 ---
 
-### BTI End-to-End Validation (Issue #36 - Deferred to Post-M2)
+### BTI End-to-End Support (Issue #36 → resolved by v0.12 #872)
 
-**Status**: 🔄 **DEFERRED** (Issue #36)
-**Impact**: No full BTI parity testing against sstabledump
-**Decision**: BTI validation deferred to future milestone per team agreement
+**Status**: ✅ **RESOLVED** (canonical `da` BTI write/read since v0.12 — #872)
+**Note**: The narrative below is historical (the original Issue #36 deferral). It has since been superseded: BTI read is fully supported end-to-end, and CQLite emits canonical `da`-format SSTables (trie-based `Partitions.db`/`Rows.db`) with byte-parity vs Cassandra 5.0. BIG (`nb`) remains the DEFAULT write target.
 
-**Background**: Issue #36 requested comprehensive BTI validation including:
+**Historical background**: Issue #36 originally requested comprehensive BTI validation including:
 - TDD tests for trie traversal lookups and iteration
 - Rows.db decoding tests with range tombstones and complex types
 - Round-trip byte-comparable invariants
 - Zero-diff vs sstabledump on BTI datasets
 
-**Key Findings**:
+**Historical findings** (at time of deferral):
 1. **BIG format is Cassandra 5.0 default** - BTI requires explicit opt-in via `selected_format: bti` in cassandra.yaml
-2. **All test data uses BIG format** - 100% of 354 SSTable files use `nb-` prefix (BIG format)
-3. **0% BTI test data exists** - No Partitions.db/Rows.db trie files in test datasets
-4. **BTI is experimental** - Cassandra 5.0 marks BTI as opt-in, expected <5% production adoption
+2. **Test data used BIG format** - the original SSTable corpus used the `nb-` prefix (BIG format)
+3. **BTI is opt-in** - Cassandra 5.0 marks BTI as opt-in
 
-**Current Implementation** (~3,200 LOC in `cqlite-core/src/storage/sstable/bti/`):
+**Current implementation** (`cqlite-core/src/storage/sstable/bti/`):
 - ✅ Format detection (magic number `0x6461`)
 - ✅ Byte-comparable encoding (CEP-25 compliant)
 - ✅ Trie node structures (all 4 types)
 - ✅ SizedInts encoding
-- ⚠️ Trie traversal (stub implementation)
-- ❌ Range queries (not implemented)
-- ❌ Full partition iteration (not implemented)
+- ✅ Trie traversal (fully implemented)
+- ✅ Range queries and full partition iteration
+- ✅ Canonical `da` BTI write (`Partitions.db`/`Rows.db`) with Cassandra byte-parity (#872)
 
-**Decision Rationale**:
-- No BTI test data available for validation
-- BTI is opt-in/experimental in Cassandra 5.0
-- BIG format covers 100% of current test scenarios
-- Production BTI code preserved for future validation
+**Reference**: `docs/sstables-definitive-guide/references/bti-v1-status.md`
 
-**Future Work** (new issue when BTI demand emerges):
-1. Configure test cluster with `selected_format: bti`
-2. Generate real BTI SSTables (Partitions.db, Rows.db)
-3. Validate CQLite BTI parser vs sstabledump output
-4. Complete trie traversal implementation
-
-**Reference**: Full status documented in `docs/sstables-definitive-guide/references/bti-v1-status.md`
-
-**Tracking**: Issue #36 (DEFERRED - see issue comments for full discussion)
+**Tracking**: Issue #36 (resolved by v0.12 #872)
 
 ---
 
@@ -1425,22 +1410,19 @@ The `StatisticsWriter` now produces complete Cassandra 5.0 compatible Statistics
 
 ---
 
-### ~~CompressionInfo.db Not Implemented~~ - RESOLVED
+### CompressionInfo.db Writing — production writes NOT implemented (test-only, fail-closed)
 
-**Status**: ✅ **RESOLVED** (M5.1)
-**Resolution**: Full compression support implemented in M5.1
+**Status**: ⚠️ Production write NOT implemented; READ/decompression fully supported (#1406)
 
-M5.0 produced only uncompressed SSTables. M5.1 implements full compression support via:
-- `CompressedDataWriter`: Chunk-based compression with LZ4/Snappy/Deflate/Zstd
-- `CompressionInfoWriter`: Compression metadata file generation
-- Trailing CRC32 checksums per chunk
-- Feature-gated compression algorithms
+CQLite's production SSTable writer emits uncompressed Data.db only and never writes a CompressionInfo.db. The `CompressedDataWriter` / `CompressionInfoWriter` types are UNWIRED building blocks that synthesize compressed fixtures for the decompressing reader; configuring compressed production writing returns `Error::UnsupportedFormat`.
 
-See "M5.1 Write Support Capabilities" section at the top of this document for details.
+The READ path fully supports all four algorithms (LZ4, Snappy, Deflate, Zstd) — CQLite reads compressed Cassandra SSTables end-to-end.
 
-**Files Added**:
-- `cqlite-core/src/storage/sstable/writer/compressed_data_writer.rs`
-- `cqlite-core/src/storage/sstable/writer/compression_info_writer.rs`
+See "M5.1 Write Support Capabilities" section at the top of this document for the exact fail-closed boundary.
+
+**Files**:
+- `cqlite-core/src/storage/sstable/writer/compressed_data_writer.rs` (test-only building block)
+- `cqlite-core/src/storage/sstable/writer/compression_info_writer.rs` (test-only building block)
 
 ---
 
@@ -1450,7 +1432,7 @@ See "M5.1 Write Support Capabilities" section at the top of this document for de
 - All SSTable component parsers (Data.db, Index.db, Summary.db, Statistics.db) now use correct formats
 - All data types fully supported: basic types, collections, UDTs, frozen types, complex cells
 - **M5.1 Write Support**: Feature-complete with documented trade-offs
-  - ✅ CompressionInfo.db: Full compression support (LZ4, Snappy, Deflate, Zstd)
+  - ⚠️ CompressionInfo.db: production writer emits uncompressed Data.db only; compressed-write infra is test-only/fail-closed (#1406). READ/decompression fully supports LZ4, Snappy, Deflate, Zstd
   - ✅ Collection serialization: Frozen and non-frozen collections
   - ✅ Static columns: Extended flags format with EXTENDED_IS_STATIC
   - ✅ Composite partition keys: Multi-component encoding
@@ -1463,7 +1445,7 @@ See "M5.1 Write Support Capabilities" section at the top of this document for de
   - ✅ Issue #219: Frozen type support
   - ✅ Issue #220: UDT (User-Defined Type) support
   - ✅ Issue #221: Complex cell flag handling for non-frozen collections
-- **Milestone achieved**: M5.1 completion (write support with compression, collections, static columns)
+- **Milestone achieved**: M5.1 completion (uncompressed SSTable write support, collections, static columns). Compression is read-only — the production writer emits uncompressed Data.db; compressed-write infra is test-only/fail-closed (#1406)
 
 ---
 

--- a/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
@@ -38,12 +38,17 @@ The `CompressedDataWriter` and `CompressionInfoWriter` types are UNWIRED buildin
 
 - `SSTableWriter::with_compression` and `CompressionInfoWriter::guard_unsupported_production_write` accept only `CompressionAlgorithm::None`; every real algorithm (LZ4, Snappy, Deflate, Zstd) errors.
 
-These building blocks are used solely to synthesize compressed SSTables for exercising the decompressing reader. The CompressionInfo.db binary format CQLite can *parse* on read is:
-- Algorithm name with BE u16 length prefix
-- Chunk length (default 64KB)
-- Chunk offset table (u64 BE per chunk)
-- Per-chunk CRC32 checksums
-- Trailing metadata CRC32
+These building blocks are used solely to synthesize compressed SSTables for exercising the decompressing reader. The CompressionInfo.db binary format CQLite actually *parses* on read (see `cqlite-core/src/storage/sstable/compression_info.rs:132-249`, mirroring Cassandra's `CompressionMetadata.java:375-392`) is, in exact on-disk order:
+- Compressor simple name — Java `writeUTF`: BE `u16` byte-length prefix followed by the UTF-8 name (e.g. `LZ4Compressor`)
+- `option_count` — BE `i32`
+- `option_count` × option pairs — each pair is two `writeUTF` strings (key, then value), each a BE `u16` length prefix + UTF-8 bytes
+- `chunk_length` — BE `i32`, the uncompressed chunk size (default 64 KB)
+- `max_compressed_length` — BE `i32` (present on all Cassandra 5.0 / version ≥ `na` files; equals `i32::MAX` when `minCompressRatio=0`)
+- `data_length` — BE `i64`, total uncompressed data length
+- `chunk_count` — BE `i32`
+- `chunk_count` × chunk offset — BE `i64` per chunk, the byte offset of each compressed chunk record in Data.db
+
+CompressionInfo.db ends immediately after the chunk offset table — it contains **no CRC bytes**. The per-chunk CRC32 checksums live inline in Data.db: each compressed chunk is followed by a 4-byte big-endian CRC32 of its compressed bytes (`CompressedSequentialWriter.java:192`), so consecutive chunk offsets differ by `compressedLength + 4`. There is likewise no trailing metadata CRC32 in CompressionInfo.db.
 
 ### Frozen Collection Serialization
 

--- a/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
@@ -30,16 +30,15 @@ The `DataWriter` produces valid Cassandra 5.0 BIG format Data.db files with:
 
 ### CompressionInfo.db Writing
 
-**Status**: IMPLEMENTED
+**Status**: BUILDING BLOCKS (test-only)
 
-Full compression support via `CompressedDataWriter` and `CompressionInfoWriter`:
+CQLite's production SSTable writer emits uncompressed Data.db only. Compressed-write infrastructure exists to synthesize fixtures for the read path and is fail-closed for production — see #1406.
 
-- **LZ4**: Fast compression (default, requires `lz4` feature)
-- **Snappy**: Very fast compression (requires `snappy` feature)
-- **Deflate**: Better compression ratio (requires `deflate` feature)
-- **Zstd**: Balanced speed/ratio (requires `zstd` feature)
+The `CompressedDataWriter` and `CompressionInfoWriter` types are UNWIRED building blocks: no path from flush or compaction reaches them, and no Cassandra-side byte-parity coverage exists for a CQLite-emitted CompressionInfo.db. Any attempt to configure compressed production writing returns `Error::UnsupportedFormat`:
 
-CompressionInfo.db format includes:
+- `SSTableWriter::with_compression` and `CompressionInfoWriter::guard_unsupported_production_write` accept only `CompressionAlgorithm::None`; every real algorithm (LZ4, Snappy, Deflate, Zstd) errors.
+
+These building blocks are used solely to synthesize compressed SSTables for exercising the decompressing reader. The CompressionInfo.db binary format CQLite can *parse* on read is:
 - Algorithm name with BE u16 length prefix
 - Chunk length (default 64KB)
 - Chunk offset table (u64 BE per chunk)

--- a/website/src/content/docs/agents-using/inspect-schema.md
+++ b/website/src/content/docs/agents-using/inspect-schema.md
@@ -131,5 +131,4 @@ CREATE TABLE IF NOT EXISTS simple_table (
 |---------|-------|-----|
 | Zero rows returned | Data.db file missing (only JSONL goldens present) | Run `bash test-data/scripts/fetch-datasets.sh` |
 | `Schema not found` error | Wrong table name in query, or wrong `--schema` file | Check schema file for exact table name |
-| WARN about BTI format on stderr | `da-` prefixed SSTables in the directory | BTI format not supported; only `nb-` SSTables are readable |
 | Empty `ls` output | Dataset not fetched | Run `bash test-data/scripts/fetch-datasets.sh` |

--- a/website/src/content/docs/agents-using/sstable-to-json.md
+++ b/website/src/content/docs/agents-using/sstable-to-json.md
@@ -91,7 +91,6 @@ Use `--overwrite` to replace an existing file (exit code `6` if the file exists 
 | No `--schema` flag | `Error: Schema not found for table 'simple_table'` | Add `--schema path/to/schema.cql` |
 | Wrong table name | `Error: Schema not found for table 'bad_name'` | Check table name matches schema |
 | Output file exists | exit code `6` | Add `--overwrite` |
-| BTI-format SSTable | WARN on stderr, 0 rows returned | BTI (`da-` prefix) not supported; use `nb-` SSTables |
 
 ## Type mapping
 

--- a/website/src/content/docs/user-docs/known-issues.md
+++ b/website/src/content/docs/user-docs/known-issues.md
@@ -53,16 +53,6 @@ write path. The promoted-index writer and BTI-based O(log n) seeks are on the
 [roadmap](/cqlite/user-docs/roadmap/) (epic
 [#751](https://github.com/pmcfadin/cqlite/issues/751)).
 
-## Format coverage
-
-### BTI (`da`) SSTables are rejected, not read
-
-BTI/trie-index SSTables (`da-*-bti-*`, opt-in in Cassandra 5.0) are detected and
-rejected with a clear error rather than misread. This is by design until the
-dedicated BTI read path lands — see
-[Limitations](/cqlite/user-docs/limitations/) and roadmap item
-[#660](https://github.com/pmcfadin/cqlite/issues/660).
-
 ## Reporting something new
 
 If you hit a bug — wrong output, a panic, a parsing error, a performance cliff —

--- a/website/src/content/docs/user-docs/limitations.md
+++ b/website/src/content/docs/user-docs/limitations.md
@@ -27,7 +27,7 @@ For the exhaustive engineering detail, see [Appendix F: Known Limitations](/cqli
 | `md-*` | Cassandra 4.0–4.1 | **Not supported** |
 | `mc-*` | Cassandra 3.11 | **Not supported** |
 | `la-*`, `ma-*` | Cassandra 3.x | **Not supported** |
-| `da-*-bti-*` / BTI format (Partitions.db / Rows.db) | Cassandra 5.0 opt-in | **Not supported** — detected and rejected with a clear error; see below |
+| `da-*-bti-*` / BTI format (Partitions.db / Rows.db) | Cassandra 5.0 opt-in | **Full** — read end-to-end and canonical `da` write since v0.12 |
 
 CQLite targets Cassandra 5.0 exclusively. If you need older formats, export your
 data with Cassandra's `sstabledump` tool first.
@@ -40,7 +40,7 @@ The default Cassandra 5.0 index format (`nb-*-big-Index.db` / `nb-*-big-Summary.
 is fully supported. All 33 test tables in the CQLite test corpus use this format and
 pass validation against `sstabledump` output.
 
-### BTI format (`da`) — not yet supported, fails cleanly
+### BTI format (`da`) — supported (read + write)
 
 BTI (trie-based index) is an opt-in feature in Cassandra 5.0, enabled with
 `selected_format: bti` in `cassandra.yaml`. It produces `da-*-bti-*` SSTables with
@@ -88,13 +88,11 @@ within-partition seeks. CQLite must scan rows linearly within the partition.
 - Narrow partitions (less than 100 rows): no impact
 - Wide partitions (10 000+ rows): O(n) linear scan within the partition
 
-### BTI format writing not implemented
+### BTI format writing supported
 
-The write engine produces BIG-format SSTables only. BTI-format writing
-(`Partitions.db`, `Rows.db`) is not implemented.
-
-**Rationale**: BTI is opt-in in Cassandra 5.0 and covers less than 5% of production
-deployments. BIG format covers all current use cases.
+Since v0.12, the write engine emits canonical `da`-format (BTI) SSTables with
+`Partitions.db` / `Rows.db` trie indexes in addition to the default BIG format
+(#872). BIG remains the default write target.
 
 ### IndexWriter memory buffering
 
@@ -155,12 +153,9 @@ or use Cassandra's `sstabledump` to export to JSON and reimport.
 
 ### BTI format (trie index)
 
-If your Cassandra cluster is configured with `selected_format: bti`, CQLite detects
-the `da-*-bti-*` SSTables and rejects them with a clear error rather than misreading
-them. Convert them to the default BIG format first — run `nodetool upgradesstables`
-after switching `selected_format` back to `big`, or export with `sstabledump`.
-End-to-end BTI read support is on the [roadmap](/cqlite/user-docs/roadmap/)
-([#660](https://github.com/pmcfadin/cqlite/issues/660)).
+If your Cassandra cluster is configured with `selected_format: bti`, CQLite reads
+the `da-*-bti-*` SSTables end-to-end via a dedicated trie-walk read path (#897) and
+can also write canonical `da`-format SSTables (#872) — no conversion needed.
 
 ### Wide partitions
 


### PR DESCRIPTION
Closes #1992

Docs-only change (7 `*.md` files, zero `.rs`/build/test). Fixes two 🔴 0.13 ship-blockers plus a stale-claim sweep.

## BLOCKER A — CHANGELOG release notes
- New `### Added` section (9 items) before `### Changed`; +6 `### Fixed`; +2 `### Performance`; Epic E enumerated by issue/PR (#1587/PR#1867, #1590/PR#1877, #1591/PR#1882).
- Every line traced to a merged PR via 3 parallel research subagents (no invented entries).
- Correction found during research: **#1582 shipped under PR #1890** (issue said "D6").
- Corrected a stale #1710 error-message quote → shipped message is `Table schema not found: {table_name}`.

## BLOCKER B — Appendix F false compressed-write claim
- `### CompressionInfo.db Writing`: `IMPLEMENTED` → **BUILDING BLOCKS (test-only)**, uncompressed-only production writer, fail-closed via `Error::UnsupportedFormat`, links #1406.
- Diff review caught the **same false-claim class surviving elsewhere in the same file** — fixed all of them (BTI Format Writing, "compression RESOLVED", BTI E2E validation, milestone/takeaway lines) while **preserving accurate read-path decompression claims** (CQLite *reads* LZ4/Snappy/Deflate/Zstd end-to-end).

## Stale BTI claims (no-false-claims sweep)
Sweep found **9** (issue named 2); fixed 8:
- README: deleted "BTI (`da`) rejected, not read" row.
- website `limitations.md` (4 spots): framed as *capability* — BTI `da` write/read supported since v0.12 (#872), **BIG (`nb`) stays the default** (verified against the write engine).
- website `known-issues.md`, `inspect-schema.md`, `sstable-to-json.md`: removed stale "BTI not supported" rows.
- **Left as-is (verified TRUE):** `nodejs.md` "writer produces BIG-format index files" — write engine defaults to BIG; BTI write only via explicit format selection.

## Certification note
Docs-only diff — no `agent-gate.sh` component (fmt/clippy/tests/build) is affected by a markdown-only change. Gating on the **PR's docs/website CI lane** + roborev instead of the full Rust gate (`--delta` re-cert is unavailable: no green full-gate anchor exists — nightly `gate.yml` on `main` is currently red). Per owner decision.

## Owner curation
`### Added` framing/theme handed to the owner for a final trim before merge (manager ORDER 1).