### PR TITLE
fix(#1991): collections_with_udts row-builder KeyError:0 + actionable per-table insert guard

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -106,7 +106,11 @@
 #                      (#1232) — fails if a generate-*.sh enumerates the whole
 #                      SSTable corpus and grep -z filters by keyspace; needs no
 #                      python3 so it runs even on the SKIP path, and any failure
-#                      hard-FAILs this component. On the python3 path also runs
+#                      hard-FAILs this component. Also runs (no python3 needed)
+#                      scripts/tests/test_udt_rowbuilder_tuple_shape.sh (#1991) —
+#                      pins the nb row-builder's UDT value to a positional tuple
+#                      (a dict → KeyError: 0 under prepared inserts) + an
+#                      actionable 0-row abort. On the python3 path also runs
 #                      scripts/tests/test_gate_concurrency_cap.sh (#1825) — proves
 #                      the machine-wide full-gate concurrency cap queues at N,
 #                      exempts --lite, and releases a slot on SIGKILL (uses the
@@ -1441,6 +1445,22 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_generator_keyspace_scoping.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (keyspace-scoping guard); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # UDT row-builder tuple-shape guard (#1991): no python3/Docker needed, always
+  # runs. Pins build_udt_value() to a positional tuple (a dict → KeyError: 0
+  # under prepared inserts, aborting the exhaustive regen) + an actionable 0-row
+  # abort. A failure FAILs the component, mirroring the keyspace-scoping guard.
+  echo ">>> [$name] bash scripts/tests/test_udt_rowbuilder_tuple_shape.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_udt_rowbuilder_tuple_shape.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (udt-rowbuilder tuple-shape guard); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/tests/test_udt_rowbuilder_tuple_shape.sh
+++ b/scripts/tests/test_udt_rowbuilder_tuple_shape.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# test_udt_rowbuilder_tuple_shape.sh — regression lint guard for issue #1991.
+#
+# The nb row-builder in test-data/scripts/regenerate-datasets.sh inserts UDT
+# values through PREPARED statements. cassandra-driver serializes a UDT bound to
+# a prepared statement POSITIONALLY (UserType.serialize_safe reads `val[i]`), so
+# a UDT value MUST be a tuple/sequence in declared field order. A dict raises
+# `KeyError: 0` on the first field, every row is skipped, 0 rows are inserted and
+# the whole exhaustive regeneration aborts (the exact 2026-07 field failure on
+# `collections_with_udts`). This is driver-version-independent.
+#
+# This guard runs WITHOUT Docker or a live Cassandra so a regression (someone
+# refactors build_udt_value back to a dict, or a driver bump reintroduces the
+# shape mismatch by copy-paste) is caught in the fast tooling-tests lane, not
+# weeks later in the weekly cron.
+#
+# It asserts, by static inspection of build_udt_value():
+#   1. it returns a positional `tuple(...)`, and
+#   2. it does NOT build a per-field dict for the UDT value.
+# It also asserts the per-table zero-row abort is ACTIONABLE: it captures the
+# first failing row's traceback (traceback.format_exc()) and prints it on abort.
+#
+# Backs: issue #1991.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GEN="$REPO_ROOT/test-data/scripts/regenerate-datasets.sh"
+
+fail=0
+
+if [[ ! -f "$GEN" ]]; then
+  echo "[lint][FAIL] generator not found: $GEN" >&2
+  exit 1
+fi
+
+# --- Extract the body of the build_udt_value() Python function ---------------
+# From the `def build_udt_value` line to the next top-level `def ` at the same
+# (4-space) indentation. Keeps the assertions robust to line-number drift.
+udt_fn="$(
+  awk '
+    /^    def build_udt_value\(/ { grab=1; print; next }
+    grab && /^    def [A-Za-z_]+\(/ { exit }
+    grab { print }
+  ' "$GEN"
+)"
+
+if [[ -z "$udt_fn" ]]; then
+  echo "[lint][FAIL] could not locate build_udt_value() in $GEN" >&2
+  exit 1
+fi
+
+# 1. Must return a positional tuple.
+if ! grep -Eq 'return[[:space:]]+tuple\(' <<<"$udt_fn"; then
+  echo "[lint][FAIL] build_udt_value() must return a positional 'tuple(...)' of" >&2
+  echo "  UDT field values in declared order (issue #1991). Prepared-statement" >&2
+  echo "  UDT serialization reads fields positionally (val[i]); a dict raises" >&2
+  echo "  KeyError: 0 and skips every row." >&2
+  fail=1
+fi
+
+# 2. Must NOT build a per-field dict for the UDT value (the reintroduced bug):
+#    a `result[<name>] = ...` assignment or a `{<key>: sample_val(...)}` /
+#    `{... : ...}` dict-comprehension over the fields.
+if grep -Eq 'result\[[^]]+\][[:space:]]*=' <<<"$udt_fn" \
+   || grep -Eq '\{[^}]*:[^}]*sample_val' <<<"$udt_fn"; then
+  echo "[lint][FAIL] build_udt_value() builds a DICT for the UDT value — this is" >&2
+  echo "  the issue #1991 regression (KeyError: 0 under prepared inserts). Return" >&2
+  echo "  a positional tuple in declared field order instead." >&2
+  fail=1
+fi
+
+# --- Assert the per-table zero-row abort is ACTIONABLE (issue #1991) ----------
+# It must capture the first failure traceback and reference it on the 0-row
+# abort, so CI logs alone are enough to diagnose a future breakage.
+if ! grep -q 'traceback.format_exc()' "$GEN"; then
+  echo "[lint][FAIL] the row-builder must capture the first failing row's" >&2
+  echo "  traceback.format_exc() so the 0-row abort is actionable (issue #1991)." >&2
+  fail=1
+fi
+if ! grep -Eq '0 rows inserted.*aborting' "$GEN"; then
+  echo "[lint][FAIL] the fail-closed 0-row abort message (naming the table) is" >&2
+  echo "  missing from the row-builder (issue #1991)." >&2
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "[lint] UDT row-builder tuple-shape guard FAILED (issue #1991)." >&2
+  exit 1
+fi
+
+echo "[lint] UDT row-builder tuple-shape guard PASSED: build_udt_value() returns a positional tuple; 0-row abort is actionable."

--- a/test-data/scripts/regenerate-datasets.sh
+++ b/test-data/scripts/regenerate-datasets.sh
@@ -243,14 +243,26 @@ try:
         print(f"  [udt] Could not discover/register UDTs: {udt_exc}", flush=True)
 
     def build_udt_value(type_name, depth=0):
-        """Construct a plain dict for a UDT, recursing for nested UDTs."""
-        if depth > 5:
-            return {}
+        """Construct a POSITIONAL TUPLE for a UDT (declared field order),
+        recursing for nested UDTs.
+
+        The value MUST be a tuple/sequence in field-declaration order, NOT a
+        dict: prepared-statement binary UDT serialization in cassandra-driver
+        (UserType.serialize_safe) reads fields positionally via `val[i]`, so a
+        dict raises `KeyError: 0` on the very first field and every row is
+        skipped (issue #1991 — a driver-version-independent contract; observed
+        with cassandra-driver 3.30.0 against cassandra:5.0.2). The unprepared
+        `%s` path used by test_oa/test_da accepts a dict via CQL-literal
+        encoding, but this generic path prepares its INSERTs, so it needs a
+        tuple. udt_fields_cache preserves schema field order (dict(zip(...))),
+        so iterating fields.values() yields fields in declared order.
+        """
         fields = udt_fields_cache.get(type_name.lower(), {})
-        result = {}
-        for fname, ftype in fields.items():
-            result[fname] = sample_val(ftype, depth=depth + 1)
-        return result
+        if depth > 5:
+            # Recursion guard: emit an all-null tuple of the correct arity
+            # (never reached by the current corpus, whose UDTs nest 1 level).
+            return tuple(None for _ in fields)
+        return tuple(sample_val(ftype, depth=depth + 1) for ftype in fields.values())
 
     def sample_val(ctype, depth=0):
         """Generate a value for any CQL type, including nested collections and UDTs."""
@@ -337,12 +349,12 @@ try:
             print(f"  [skip] {tbl}: no partition key found", flush=True)
             continue
 
-        # Detect tables that have UDT columns; they are now handled by the
-        # generic path via build_udt_value() + registered dict UDTs above.
+        # Detect tables that have UDT columns; they are handled by the generic
+        # path via build_udt_value(), which emits positional tuples (issue #1991).
         all_types_list = [t for _, (_, t) in cols.items()]
         has_udt = any(has_udt_type(t) for t in all_types_list)
         if has_udt:
-            print(f"  [udt-table] {tbl}: UDT columns detected — using registered dict path", flush=True)
+            print(f"  [udt-table] {tbl}: UDT columns detected — using positional-tuple UDT path", flush=True)
 
         # Counter tables require UPDATE, not INSERT. Detect by checking if all
         # regular columns are of type 'counter'.
@@ -353,6 +365,7 @@ try:
 
         n_inserted = 0
         n_skipped = 0
+        first_tb = None  # full traceback of the first failed row (for an actionable abort)
 
         if is_counter_table:
             # Counter tables use UPDATE ... SET col = col + N WHERE pk_col = ?
@@ -370,6 +383,8 @@ try:
                     n_inserted += 1
                 except Exception as e:
                     n_skipped += 1
+                    if first_tb is None:
+                        first_tb = traceback.format_exc()
                     if n_skipped <= 3:
                         print(f"  [row-skip] {tbl}: {type(e).__name__}: {e}", flush=True)
         else:
@@ -388,11 +403,25 @@ try:
                     # Only skip type-incompatible individual rows (e.g. duration literals).
                     # Print every skip so failures are visible.
                     n_skipped += 1
+                    if first_tb is None:
+                        first_tb = traceback.format_exc()
                     if n_skipped <= 3:
                         print(f"  [row-skip] {tbl}: {type(e).__name__}: {e}", flush=True)
 
         if n_inserted == 0:
-            print(f"[ERROR] 0 rows inserted into {tbl} ({n_skipped} skipped) — aborting!", flush=True)
+            # Fail-closed, ACTIONABLE abort (issue #1991): a present table whose
+            # every insert failed is a hard error, never a silent skip. Name the
+            # offending table and print the FIRST row's full traceback so a
+            # future breakage (e.g. a cassandra-driver upgrade changing UDT/tuple
+            # representation) is diagnosable straight from the CI log, without a
+            # local Docker repro. sys.exit() here also stops before the next
+            # table, so one table's failure can't leave a misleading mid-matrix
+            # partially-regenerated state.
+            print(f"[ERROR] Table '$keyspace.{tbl}': 0 rows inserted ({n_skipped} attempts, all failed) — aborting keyspace regeneration.", flush=True)
+            print(f"[ERROR] Table '$keyspace.{tbl}': first-row failure traceback (fix this table's row-builder shape; see issue #1991):", flush=True)
+            if first_tb:
+                sys.stdout.write(first_tb)
+                sys.stdout.flush()
             sys.exit(1)
         print(f"  {tbl}: {n_inserted} rows inserted ({n_skipped} skipped)", flush=True)
         total_inserted += n_inserted

--- a/test-data/scripts/regenerate-datasets.sh
+++ b/test-data/scripts/regenerate-datasets.sh
@@ -224,8 +224,11 @@ try:
             return {}
         return dict(zip(row.field_names, row.field_types))
 
-    # Discover and register all UDTs in this keyspace so the driver can
-    # serialize UDT values as dicts (the same approach used for test_oa.udt_table).
+    # Discover all UDTs in this keyspace and cache their authoritative field
+    # order from system_schema.types; build_udt_value() emits POSITIONAL TUPLES
+    # in that declared order, which is what prepared-statement UDT serialization
+    # requires (issue #1991). register_user_type(..., dict) only affects how the
+    # driver DESERIALIZES UDTs read back — inserts never bind dicts here.
     udt_fields_cache = {}
     try:
         udts_rs = session.execute(
@@ -325,7 +328,8 @@ try:
         if bare == 'duration':
             return Duration(months=random.randint(0, 12), days=random.randint(0, 30),
                             nanoseconds=random.randint(0, 10**9))
-        # UDT: if the bare type name is a known UDT in this keyspace, build a dict
+        # UDT: if the bare type name is a known UDT in this keyspace, build a
+        # positional tuple in declared field order (issue #1991)
         if bare in udt_fields_cache:
             return build_udt_value(bare, depth=depth)
         # text, varchar, ascii, and anything unrecognized


### PR DESCRIPTION
## Summary

Fixes #1991 — the weekly **Exhaustive Regeneration** workflow aborted in *"Regenerate storage-format matrix (nb/oa/da)"* because every one of the 50 row inserts into `test_collections.collections_with_udts` threw `KeyError: 0` (0 rows inserted → fail-closed abort).

## Confirmed root cause (reproduced locally, not guessed)

The nb row-builder in `test-data/scripts/regenerate-datasets.sh` binds **dict** UDT values to **prepared** statements. cassandra-driver serializes a UDT bound to a prepared statement **positionally** — `UserType.serialize_safe` reads `val[i]` by integer index — so a dict raises `KeyError: 0` on the very first field. Every row is skipped, and the per-table fail-closed guard aborts the regeneration.

The `test_oa.udt_table` path the code claimed to mirror works only because it uses **unprepared** `%s` statements (CQL-literal encoding accepts a dict). The generic nb path prepares its INSERTs, so the dict shape was never valid there. This is a driver-version-independent contract, confirmed against the workflow's exact stack (cassandra:5.0.2 container, cassandra-driver 3.30.0).

Local repro traceback (identical failure signature to CI run 28703186938):

```
  [row-skip] collections_with_udts: KeyError: 0
Traceback (most recent call last):
  File "cassandra/query.py", line 506, in cassandra.query.PreparedStatement.bind
  File "cassandra/query.py", line 636, in cassandra.query.BoundStatement.bind
  File "cassandra/cqltypes.py", line 809, in cassandra.cqltypes._ParameterizedType.serialize
  File "cassandra/cqltypes.py", line 848, in cassandra.cqltypes._SimpleParameterizedType.serialize_safe
  File "cassandra/cqltypes.py", line 314, in cassandra.cqltypes._CassandraType.to_binary
  File "cassandra/cqltypes.py", line 809, in cassandra.cqltypes._ParameterizedType.serialize
  File "cassandra/cqltypes.py", line 1035, in cassandra.cqltypes.UserType.serialize_safe
KeyError: 0
```

## Fix

1. **`build_udt_value()` now returns a positional tuple** in declared field order (authoritative order from `system_schema.types` `field_names`/`field_types`, preserved by `udt_fields_cache`). No heuristics — the schema is the only source of field order.
2. **Actionable per-table zero-row abort**: the guard still fail-closes (0 rows on a present table = hard abort, never a silent skip, and `sys.exit(1)` before the next table prevents a misleading mid-matrix state), but it now names `keyspace.table`, reports `N attempts, all failed`, and prints the **first failing row's full traceback** — so the next breakage (e.g. a driver bump) is diagnosable straight from the CI log without a local Docker repro.
3. **No-Docker regression guard**: `scripts/tests/test_udt_rowbuilder_tuple_shape.sh`, wired into the agent-gate `tooling-tests` component, statically pins `build_udt_value()` to the tuple shape (FAILs on a dict) and pins the actionable-abort behavior. Verified both ways: PASS on the fix, FAIL on the reverted dict shape.

## Local repro evidence (Docker, cassandra:5.0.2 + cassandra-driver 3.30.0)

- **Before (dict shape)**: `MODE=dict: inserted=0 skipped=50` — traceback above, exactly matching the CI failure.
- **After (this PR's edited `insert_nb_rows` body, extracted verbatim from the script and run against a fresh `test_collections` keyspace built from `test-data/schemas/collections.cql`)**:

```
  [udt] Registered UDT: test_collections.address_type
  [udt] Registered UDT: test_collections.contact_info
  collection_clustering_table: 50 rows inserted (0 skipped)
  collection_table: 50 rows inserted (0 skipped)
  [udt-table] collections_with_udts: UDT columns detected — using positional-tuple UDT path
  collections_with_udts: 50 rows inserted (0 skipped)
  empty_collections_table: 50 rows inserted (0 skipped)
  frozen_collections_table: 50 rows inserted (0 skipped)
  large_collections_table: 50 rows inserted (0 skipped)
  nested_collections_table: 50 rows inserted (0 skipped)
  typed_collections_table: 50 rows inserted (0 skipped)
[OK] Keyspace 'test_collections': 400 total rows inserted across 8 tables
```

- **Simulated regression (dict forced back in a temp copy)** — the new abort is actionable:

```
[ERROR] Table 'test_collections.collections_with_udts': 0 rows inserted (50 attempts, all failed) — aborting keyspace regeneration.
[ERROR] Table 'test_collections.collections_with_udts': first-row failure traceback (fix this table's row-builder shape; see issue #1991):
Traceback (most recent call last):
  ...
  File "cassandra/cqltypes.py", line 1035, in cassandra.cqltypes.UserType.serialize_safe
KeyError: 0
```

## Corpus / goldens

**No committed corpus, golden, or manifest files change in this PR** — the fix is generator + tooling only. The committed corpus was never affected (the workflow deliberately does not commit regenerated binaries, design D6). The full end-to-end regen + `corpus-audit` proof-out is the weekly workflow's job; the next scheduled/dispatched `exhaustive-regeneration.yml` run validates the matrix end-to-end.

## Gate

Full `scripts/agent-gate.sh` SUMMARY (gate of record):

```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.11wkmn
commit: 4463446b branch: issue-1991-udt-rowbuilder-keyerror dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (3s)
core-tests:        PASS (146s)
tombstones-scan:   PASS (1s)
scan-offload-guard: PASS (40s)
byte-budget-guard: PASS (8s)
memory-budget:     PASS (41s)
integration-tests: PASS (61s)
format-compat:     PASS (32s)
write-tests:       PASS (131s)
cli-tests:         PASS (142s)
compaction-byte-parity: PASS (9s)
python-bindings:   PASS (109s)
node-bindings:     PASS (126s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (7s)
binding-unwind-profile: PASS (0s)
tooling-tests:     PASS (32s)
minimal-build:     PASS (66s)
smoke:             PASS (55s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.11wkmn
summary-file: /tmp/gate-summary-1991.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```
