### PR TITLE
docs(#1994): v0.13 website release page + new-API docs (refresh/max_result_bytes/OTel) + CLI reference gaps

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -182,6 +182,78 @@ console.log(`Total rows: ${stats.totalRows}`);
 console.log(`Memory: ${stats.memoryUsedBytes} bytes`);
 ```
 
+### Refreshing SSTables (v0.13)
+
+If Cassandra (or another process) writes new SSTables while your `Database` handle
+is open, call `refresh()` to re-discover them. Refresh is **explicit-only** (CQLite
+never rescans behind your back) and **atomic / fail-closed**: if any newly found
+generation fails to open, the swap is rolled back and the handle keeps serving the
+prior, consistent set of readers.
+
+```typescript
+// ... time passes; Cassandra flushes/compacts new SSTables to disk ...
+
+const report = await db.refresh();
+console.log(`Tables scanned:  ${report.tablesScanned}`);
+console.log(`Readers added:   ${report.readersAdded}`);
+console.log(`Readers removed: ${report.readersRemoved}`);
+
+// Subsequent queries see the newly discovered data
+const result = await db.executeNative('SELECT * FROM keyspace.table');
+```
+
+`refresh(): Promise<RefreshReport>` resolves to a `RefreshReport` with the numeric
+fields `tablesScanned`, `readersAdded`, and `readersRemoved`.
+
+### Result Byte Budget (v0.13)
+
+Non-streaming queries are bounded by a result-size budget of **64 MiB** by default.
+When the materialized result's running byte estimate exceeds the budget, the query
+rejects with a `CqliteError` whose `code === 'QUERY'`, directing you to add a
+`LIMIT` clause or use `executeStreaming()`. Streaming queries are **not** subject
+to this budget.
+
+```typescript
+try {
+  const result = await db.executeNative('SELECT * FROM keyspace.big_table');
+  for (const row of result.rows) {
+    process(row);
+  }
+} catch (e) {
+  if (e.code === 'QUERY') {
+    // Result exceeded the 64 MiB byte budget — add a LIMIT or stream instead
+    for await (const row of db.executeStreaming('SELECT * FROM keyspace.big_table')) {
+      process(row);
+    }
+  } else {
+    throw e;
+  }
+}
+```
+
+### OpenTelemetry Tracing (v0.13)
+
+CQLite can emit OpenTelemetry traces when built with the `observability` Cargo
+feature; without that feature the configuration is accepted but is a no-op. Pass an
+`otel` option to `Database.open()`:
+
+```typescript
+const db = await Database.open('path/to/sstables', {
+  schema: 'schema.cql',
+  otel: {
+    enabled: true,                       // default false
+    endpoint: 'http://localhost:4317',   // default 'http://localhost:4317'
+    protocol: 'grpc',                    // 'grpc' (default) or 'http'
+    serviceName: 'cqlite',               // default 'cqlite'
+    serviceVersion: '0.13.0',            // default: package version
+    samplingRatio: 1.0,                  // default 1.0
+    timeoutMs: 10000,                    // default 10000
+  },
+});
+```
+
+Options are layered over the `CQLITE_OTEL_*` environment variables.
+
 ### Error Handling
 
 All errors include structured metadata for programmatic handling:

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -114,6 +114,93 @@ custom_config = {'memory': {'max_memory': 536870912}}  # 512 MB
 cqlite.validate_config(custom_config)
 ```
 
+### Refreshing SSTables (v0.13)
+
+If Cassandra (or another process) writes new SSTables while your database handle
+is open, call `refresh()` to re-discover them. Refresh is **explicit-only** (CQLite
+never rescans behind your back) and **atomic / fail-closed**: if any newly found
+generation fails to open, the swap is rolled back and the handle keeps serving the
+prior, consistent set of readers.
+
+```python
+import cqlite
+
+with cqlite.open('path/to/sstables', schema='schema.cql') as db:
+    # ... time passes; Cassandra flushes/compacts new SSTables to disk ...
+
+    report = db.refresh()
+    print(f'Tables scanned:  {report.tables_scanned}')
+    print(f'Readers added:   {report.readers_added}')
+    print(f'Readers removed: {report.readers_removed}')
+
+    # Subsequent queries see the newly discovered data
+    for row in db.execute('SELECT * FROM keyspace.table'):
+        print(row.to_dict())
+```
+
+`refresh()` returns a `RefreshReport` with the integer attributes
+`tables_scanned`, `readers_added`, and `readers_removed`, plus a `to_dict()`
+helper. It raises `RuntimeError` if the database is already closed, and
+`CqliteError` if a newly discovered generation fails to open (the prior reader
+set is preserved).
+
+### Result Byte Budget (v0.13)
+
+Non-streaming `execute()` queries are bounded by a result-size budget, defaulting
+to **64 MiB** (`64 * 1024 * 1024` bytes). When the materialized result's running
+byte estimate exceeds the budget, the query fails with a `cqlite.QueryError`
+directing you to add a `LIMIT` clause or switch to `execute_streaming()`. Streaming
+queries are **not** subject to this budget.
+
+Adjust the budget with the `max_result_bytes` key in the `config` passed to
+`cqlite.open()` (absent, it stays at 64 MiB):
+
+```python
+import cqlite
+
+# Raise the budget to 256 MiB for this handle
+config = {'max_result_bytes': 256 * 1024 * 1024}
+
+try:
+    with cqlite.open('path/to/data', schema='schema.cql', config=config) as db:
+        rows = db.execute('SELECT * FROM keyspace.big_table')
+        for row in rows:
+            process(row)
+except cqlite.QueryError as e:
+    # Result exceeded the byte budget — add a LIMIT or stream instead
+    print(f'Result too large: {e}')
+    for row in db.execute_streaming('SELECT * FROM keyspace.big_table'):
+        process(row)
+```
+
+### OpenTelemetry Tracing (v0.13)
+
+CQLite can emit OpenTelemetry traces when built with the `observability` Cargo
+feature; without that feature the configuration is accepted but is a no-op.
+Pass an `otel_config` dict to `cqlite.open()`. Values are layered over the
+`CQLITE_OTEL_*` environment variables, and OpenTelemetry is initialized once per
+process.
+
+```python
+import cqlite
+
+db = cqlite.open(
+    'path/to/sstables',
+    schema='schema.cql',
+    otel_config={
+        'enabled': True,                       # default False
+        'endpoint': 'http://localhost:4317',   # default 'http://localhost:4317'
+        'protocol': 'grpc',                    # 'grpc' (default) or 'http'
+        'service_name': 'cqlite',              # default 'cqlite'
+        'service_version': '0.13.0',           # default: package version
+        'sampling_ratio': 1.0,                 # default 1.0
+        'timeout_ms': 10000,                   # default 10000
+    },
+)
+```
+
+Unknown keys raise `ValueError`.
+
 ### Error Handling
 
 ```python

--- a/cqlite-cli/CLI_USAGE_EXAMPLES.md
+++ b/cqlite-cli/CLI_USAGE_EXAMPLES.md
@@ -9,7 +9,9 @@ This document provides comprehensive usage examples for the CQLite CLI in M2 mil
 - [One-Shot Mode Examples](#one-shot-mode-examples)
 - [REPL Mode Examples](#repl-mode-examples)
 - [Output Formats](#output-formats)
+- [Verifying SSTable Integrity](#verifying-sstable-integrity)
 - [Exporting Data (M3)](#exporting-data-m3)
+- [Delta Export (CDC)](#delta-export-cdc)
 - [Write Support (M5)](#write-support-m5)
 - [Command Reference](#command-reference)
 
@@ -546,6 +548,55 @@ id,name,email
 
 ---
 
+## Verifying SSTable Integrity
+
+`cqlite verify` checks the integrity of a single SSTable generation. It is
+**always available** (no feature flag) and short-circuits before any database
+initialization, so it works on a bare SSTable directory without a schema. The
+exit code is non-zero when verification fails, making it suitable for CI and
+health checks.
+
+### Syntax
+
+```bash
+cqlite verify <PATH> [--mode quick|full] [--out text|json]
+```
+
+- `<PATH>` — SSTable generation directory (the directory containing `*-Data.db`).
+- `--mode <MODE>` — `quick` or `full` (default `full`).
+  - **quick**: checks component presence, `TOC.txt` completeness, `Digest.crc32`,
+    `CompressionInfo.db` (including chunk-offset bounds), and BTI trie structure.
+  - **full**: everything in quick, plus inline `Data.db` chunk-CRC validation,
+    `Statistics.db`/`Summary.db` parse, and a complete row scan that fails loudly
+    on corrupt index/BTI components (no silent empty results).
+- `--out <OUT>` — report output format, `text` (default) or `json`.
+
+### Examples
+
+```bash
+# Full verification (default) with a human-readable report
+cqlite verify test-data/datasets/sstables/test_basic/simple_table-<uuid>
+
+# Fast structural check only (component presence, CRC, BTI structure)
+cqlite verify test-data/datasets/sstables/test_basic/simple_table-<uuid> --mode quick
+
+# Machine-readable JSON report (for CI / scripting)
+cqlite verify test-data/datasets/sstables/test_comp/lz4_table-<uuid> \
+       --mode full --out json
+```
+
+A failed verification returns a non-zero exit code, so you can gate automation on it:
+
+```bash
+if cqlite verify ./my-sstable-dir --mode quick --out json > report.json; then
+  echo "SSTable OK"
+else
+  echo "SSTable failed verification (see report.json)"
+fi
+```
+
+---
+
 ## Exporting Data (M3)
 
 CQLite M3 adds file-based export functionality for extracting data to various formats.
@@ -693,6 +744,72 @@ cqlite --schema schema.cql --data-dir ./large-dataset \
 ```
 
 No configuration needed - CQLite automatically streams the data efficiently.
+
+---
+
+## Delta Export (CDC)
+
+`cqlite delta-export` scans a single SSTable generation as a CDC delta and writes
+a Parquet file using the CQLite **delta envelope** — one record per change event.
+Each non-key column becomes a nullable struct carrying its value plus metadata,
+and dedicated envelope columns carry delete semantics.
+
+> **Note**: `delta-export` requires building with `--features delta-export`.
+>
+> ```bash
+> cargo build --package cqlite-cli --features delta-export
+> ```
+
+> **Schema requirement**: The `--schema` file must be a **bare `CREATE TABLE`
+> statement** (no `CREATE KEYSPACE` / `USE` preamble), consistent with the
+> CLAUDE.md guidance for delta-export.
+
+### Syntax
+
+```bash
+cqlite delta-export <SSTABLE_DIR> --schema <FILE> -o <FILE.parquet> [OPTIONS]
+```
+
+- `<SSTABLE_DIR>` — SSTable directory containing the `Data.db` file to scan.
+- `--schema <FILE>` (required) — CQL (`.cql`) or JSON (`.json`) schema for the table.
+- `--out <OUT>` — output format (default `parquet`; only `parquet` is supported).
+- `-o, --output <FILE>` (required) — output Parquet file path. Binary output cannot
+  be written to stdout, so this is mandatory.
+- `--envelope-prefix <PREFIX>` — envelope column prefix (default `__`). Change it to
+  avoid collisions with user columns named `__op`, `__ts`, `__range_start`, or
+  `__range_end`.
+- `--row-group-size <N>` — Parquet row-group size in records per row group
+  (default `10000`).
+- `--compression <C>` — Parquet compression codec: `snappy` (default), `zstd`, or
+  `uncompressed`.
+- `--source <ID>` — SSTable identity string written to the `cqlite.delta.source`
+  Parquet footer key. Defaults to the SSTable directory base name.
+- `--overwrite` — overwrite the output file if it exists (default: error if it exists).
+
+### Examples
+
+```bash
+# Export one SSTable generation as a delta-envelope Parquet file
+cqlite delta-export test-data/datasets/sstables/test_basic/simple_table-<uuid> \
+       --schema test-data/schemas/simple_table.cql \
+       --out parquet \
+       -o /tmp/delta.parquet
+
+# Use a custom envelope prefix to resolve __op / __ts column collisions
+cqlite delta-export test-data/datasets/sstables/test_basic/simple_table-<uuid> \
+       --schema test-data/schemas/simple_table.cql \
+       -o /tmp/delta.parquet \
+       --envelope-prefix _cqlite_
+
+# Tune Parquet output: zstd compression, larger row groups, overwrite existing file
+cqlite delta-export test-data/datasets/sstables/test_basic/simple_table-<uuid> \
+       --schema test-data/schemas/simple_table.cql \
+       -o /tmp/delta.parquet \
+       --compression zstd \
+       --row-group-size 50000 \
+       --source my-sstable-id \
+       --overwrite
+```
 
 ---
 
@@ -879,6 +996,66 @@ Packaging options:
 | `--compact` | Run compaction before export to merge multiple SSTables |
 | `--skip-validate` | Skip validation after export |
 
+#### One-Shot Compaction (`compact`)
+
+`cqlite compact` performs a **one-shot, policy-free compaction** over exactly the
+SSTables found in `<input_dir>` and writes the merged result to `--output`. It is
+distinct from the other compaction paths:
+
+- **`compact`** — explicit, deterministic merge of a fixed set of SSTables (no
+  managed write-dir, no LSM policy). Used by the compaction-parity harness.
+- **`maintenance`** — incremental *background* compaction inside a managed
+  `--write-dir`, bounded by a time budget (see below).
+- **`export-sstable`** — packages write-engine data for Cassandra import (with an
+  optional `--compact` step); it does not compact an arbitrary external directory.
+
+`compact` is separate from `admin compact` (a database-level command whose only
+flag is `--force`).
+
+The `<input_dir>` is scanned for `nb-*-big-Data.db` files.
+
+```bash
+cqlite compact <INPUT_DIR> -o <OUTPUT> --schema <PATH> [OPTIONS]
+```
+
+| Flag | Description |
+|------|-------------|
+| `input_dir` (positional) | Directory scanned for `nb-*-big-Data.db` inputs |
+| `-o, --output <OUTPUT>` (required) | Output directory (`keyspace/table/` is appended) |
+| `--schema <PATH>` (required) | CQL or JSON schema for the table |
+| `--gc-before <SECS>` | gc_grace cutoff, epoch seconds (`i64`); see caveat below |
+| `--now-sec <SECS>` | "now" epoch seconds (`i64`) for TTL expiry; see caveat below |
+| `--generation <N>` | Output SSTable generation number (`u64`, default `1`) |
+| `--major` (alias `--purge-tombstones`) | Treat as MAJOR compaction and purge gc-expired tombstones (default off) |
+
+> **Caveat — purging is not yet applied during the merge (issues #845/#848).**
+> `--gc-before` and `--now-sec` are accepted and threaded through, but they do not
+> currently drop purgeable data or expire TTLs during the merge. Do not rely on
+> them to remove data yet.
+
+> **Safety — `--major`/`--purge-tombstones`.** Purging tombstones is only correct
+> when `<input_dir>` contains **all** overlapping SSTables for the table; otherwise
+> a purged tombstone could resurrect data still shadowed elsewhere. This flag is
+> the operator's assertion that the input set is complete. Default (flag absent) is
+> conservative — tombstones are retained and nothing is purged.
+
+```bash
+# Merge every SSTable in ./inputs into one output SSTable
+cqlite compact ./inputs -o ./out \
+       --schema test-data/schemas/basic-types.cql
+
+# Deterministic parity-style run with an explicit generation number
+cqlite compact ./inputs -o ./out \
+       --schema test-data/schemas/basic-types.cql \
+       --generation 3 \
+       --gc-before 1700000000
+
+# MAJOR compaction that purges gc-expired tombstones (input set MUST be complete)
+cqlite compact ./inputs -o ./out \
+       --schema test-data/schemas/basic-types.cql \
+       --major
+```
+
 ### REPL Write Meta-Commands
 
 When running in REPL mode with write support enabled, additional meta-commands are available:
@@ -959,8 +1136,17 @@ cqlite --schema <PATH> --data-dir <DIR> -f <CQL_FILE> [--out <FORMAT>]
 # Low-level SSTable inspection
 cqlite read-sstable <sstable_or_dir> --schema <FILE> --format <FORMAT>
 
-# SSTable metadata
-cqlite info <sstable_or_dir> [--validate]
+# SSTable metadata (-f/--format text|json, -d/--detailed for extended stats)
+cqlite info <sstable_or_dir> [-f json] [-d]
+
+# Verify SSTable integrity (always available)
+cqlite verify <sstable_dir> [--mode quick|full] [--out text|json]
+
+# One-shot compaction (requires --features write-support)
+cqlite compact <input_dir> -o <output_dir> --schema <FILE> [--major]
+
+# CDC delta-envelope Parquet export (requires --features delta-export)
+cqlite delta-export <sstable_dir> --schema <FILE> -o <FILE.parquet>
 ```
 
 ### Global Flags
@@ -969,8 +1155,9 @@ cqlite info <sstable_or_dir> [--validate]
 |------|-------------|---------|
 | `--config <FILE>` | Load config (TOML/YAML/JSON) | `--config config.toml` |
 | `--schema <PATH>` | Schema file/directory (repeatable) | `--schema schemas/` |
-| `--data-dir <DIR>` | Cassandra data directory | `--data-dir /var/lib/cassandra/data` |
-| `-e, --execute <CQL>` | Execute single statement | `-e "SELECT * FROM users"` |
+| `--data-dir <DIR>` | Cassandra data directory (env `CQLITE_DATA_DIR`; mutually exclusive with `--dataset`) | `--data-dir /var/lib/cassandra/data` |
+| `--dataset <DATASET>` | Test dataset name; resolves under `CQLITE_DATASETS_ROOT/sstables/{dataset}/` (mutually exclusive with `--data-dir`) | `--dataset test_basic` |
+| `-e, --execute <CQL>` | Execute single statement (alias `--query`) | `-e "SELECT * FROM users"` |
 | `-f, --file <FILE>` | Execute statements from file | `-f script.cql` |
 | `--out <FORMAT>` | Output format (table/json/csv) | `--out json` |
 | `--limit <N>` | Cap rows returned | `--limit 100` |
@@ -980,6 +1167,55 @@ cqlite info <sstable_or_dir> [--validate]
 | `-v, --verbose` | Increase verbosity | `-vvv` |
 | `-q, --quiet` | Suppress output | `--quiet` |
 | `--no-color` | Disable colored output | `--no-color` |
+
+#### `--dataset` vs `--data-dir`
+
+`--dataset <NAME>` is a convenience for the bundled test data: it resolves the
+SSTables under `CQLITE_DATASETS_ROOT/sstables/{dataset}/` so you do not have to
+type the full path. It is **mutually exclusive** with `--data-dir` (clap rejects
+using both). Use `--data-dir` for a production Cassandra directory layout.
+
+```bash
+# Query a bundled test dataset by name
+export CQLITE_DATASETS_ROOT=/Users/patrick/local_projects/cqlite/test-data/datasets
+cqlite --dataset test_basic \
+       --schema /Users/patrick/local_projects/cqlite/test-data/schemas/basic-types.cql \
+       -e "SELECT * FROM test_basic.simple_table LIMIT 5"
+```
+
+#### OpenTelemetry Export Flags
+
+These flags configure OpenTelemetry (OTLP) export. The config plumbing is always
+compiled and parses regardless of build features, but **actual export requires a
+build with `--features observability`**; without it these flags are accepted and
+become a no-op. Each flag has a `CQLITE_OTEL_*` environment-variable fallback — an
+explicit flag wins over the env var.
+
+| Flag | Env fallback | Description |
+|------|-------------|-------------|
+| `--otel-enabled <BOOL>` | `CQLITE_OTEL_ENABLED` | Enable OTLP export (needs `--otel-endpoint` + `observability` feature) |
+| `--otel-endpoint <URL>` | `CQLITE_OTEL_ENDPOINT` | OTLP collector endpoint (gRPC endpoint or HTTP base URL) |
+| `--otel-protocol <PROTO>` | `CQLITE_OTEL_PROTOCOL` | Wire protocol: `grpc` or `http` |
+| `--otel-service-name <NAME>` | `CQLITE_OTEL_SERVICE_NAME` | `service.name` resource attribute |
+| `--otel-service-version <VER>` | `CQLITE_OTEL_SERVICE_VERSION` | `service.version` resource attribute |
+| `--otel-sampling-ratio <RATIO>` | `CQLITE_OTEL_SAMPLING_RATIO` | Trace sampling ratio in `[0.0, 1.0]` |
+| `--otel-timeout-ms <MS>` | `CQLITE_OTEL_TIMEOUT_MS` | OTLP exporter timeout in milliseconds |
+
+```bash
+# Export traces to a local OTLP collector (build with --features observability)
+cqlite --otel-enabled true \
+       --otel-endpoint http://localhost:4317 \
+       --otel-protocol grpc \
+       --otel-service-name cqlite-cli \
+       --otel-sampling-ratio 1.0 \
+       --schema schemas/ --data-dir /var/lib/cassandra/data \
+       -e "SELECT * FROM ks.users LIMIT 5"
+
+# Equivalent via environment variables
+export CQLITE_OTEL_ENABLED=true
+export CQLITE_OTEL_ENDPOINT=http://localhost:4317
+cqlite --schema schemas/ --data-dir /var/lib/cassandra/data -e "SELECT * FROM ks.users LIMIT 5"
+```
 
 ### Exit Codes
 
@@ -1120,7 +1356,7 @@ cqlite> :help
 ### M5 Features (Issue #392)
 - **Write support**: Mutation-based writes to local SSTables
 - **Write flags**: `--writable`, `--write-dir`, `--mutation`, `--mutations-file`, `--flush`
-- **Write subcommands**: `maintenance`, `write-stats`, `export-sstable`
+- **Write subcommands**: `maintenance`, `write-stats`, `export-sstable`, `compact`
 - **REPL meta-commands**: `.flush`, `.stats`, `.maintenance`
 - **SSTable export**: Cassandra-compatible SSTable generation for `sstableloader`
 - **Feature flag**: Requires `--features write-support` to build

--- a/docs/technical/api-specification.md
+++ b/docs/technical/api-specification.md
@@ -36,6 +36,21 @@ impl Database {
     
     /// Get database statistics
     pub fn stats(&self) -> DatabaseStats;
+
+    /// Re-discover SSTables written by Cassandra or another process while this
+    /// handle is open (issue #1749). Refresh is explicit-only (CQLite never
+    /// rescans behind your back) and atomic / fail-closed: if a newly found
+    /// generation fails to open, the swap is rolled back and the prior reader
+    /// set is preserved.
+    pub async fn refresh(&self) -> Result<RefreshReport>;
+}
+
+/// Result of a `Database::refresh` call.
+#[derive(Debug, Clone)]
+pub struct RefreshReport {
+    pub tables_scanned: usize,
+    pub readers_added: usize,
+    pub readers_removed: usize,
 }
 
 // Configuration options
@@ -60,6 +75,24 @@ impl Default for Config {
     }
 }
 ```
+
+> **Note:** The struct above is an illustrative summary. The authoritative
+> configuration lives in `cqlite-core/src/config.rs` as a nested `QueryConfig`,
+> which includes the result byte budget introduced in v0.13:
+>
+> ```rust
+> pub struct QueryConfig {
+>     // ... other query settings ...
+>
+>     /// Maximum materialized (non-streaming) result size in bytes.
+>     /// Default: DEFAULT_MAX_RESULT_BYTES = 64 * 1024 * 1024 (64 MiB).
+>     pub max_result_bytes: u64,
+> }
+> ```
+>
+> When a non-streaming query's running byte estimate exceeds `max_result_bytes`,
+> execution fails with `Error::ResultTooLarge` (see [Error Handling](#error-handling)).
+> Streaming queries are not subject to this budget.
 
 ### Schema Management
 
@@ -220,6 +253,36 @@ impl Database {
     
     /// Stream large result sets
     pub fn select_stream(&self, query: &str) -> impl Stream<Item = Result<Row>>;
+}
+```
+
+### Observability (OpenTelemetry)
+
+CQLite can export OpenTelemetry traces when built with the `observability` Cargo
+feature (Epic #1031). Without that feature the configuration is accepted but is a
+no-op. OpenTelemetry is initialized once per process.
+
+```rust
+use cqlite::observability::{ObservabilityConfig, OtlpProtocol};
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct ObservabilityConfig {
+    pub enabled: bool,             // default: false
+    pub endpoint: String,          // default: "http://localhost:4317"
+    pub protocol: OtlpProtocol,    // Grpc | Http, default: Grpc
+    pub service_name: String,      // default: "cqlite"
+    pub service_version: String,   // default: package version
+    pub sampling_ratio: f64,       // default: 1.0
+    pub timeout: Duration,         // default: 10_000 ms
+}
+
+impl ObservabilityConfig {
+    /// Build a config from the `CQLITE_OTEL_*` environment variables.
+    pub fn from_env() -> Self;
+
+    /// Fluent builder for programmatic configuration.
+    pub fn builder() -> ObservabilityConfigBuilder;
 }
 ```
 
@@ -726,6 +789,17 @@ pub enum Error {
     
     #[error("Query error: {0}")]
     Query(String),
+    
+    /// A non-streaming query's materialized result exceeded the configured
+    /// `QueryConfig::max_result_bytes` budget (default 64 MiB). Category: Query;
+    /// not recoverable. The message directs the caller to add a `LIMIT` clause
+    /// or use `execute_streaming`. Streaming queries are exempt from the budget.
+    #[error("result too large: estimated {estimated_bytes} bytes across {rows} rows exceeds budget of {budget_bytes} bytes; add a LIMIT clause or use execute_streaming")]
+    ResultTooLarge {
+        budget_bytes: u64,
+        estimated_bytes: u64,
+        rows: usize,
+    },
     
     #[error("Not found: {0}")]
     NotFound(String),

--- a/website/src/content/docs/agents-using/write-mutation.md
+++ b/website/src/content/docs/agents-using/write-mutation.md
@@ -44,7 +44,7 @@ cqlite \
 
 ```
 OK: 1 row(s) affected (4.5ms)
-CQLite CLI v0.11.0
+CQLite CLI v0.13.0
 Use --help for available commands
 ```
 
@@ -68,7 +68,7 @@ cqlite \
 ```
 Flushed: 1 partitions, 50 bytes
   Output: /tmp/cqlite-write/data/test_basic/simple_table/nb-1-big-Data.db
-CQLite CLI v0.11.0
+CQLite CLI v0.13.0
 Use --help for available commands
 ```
 
@@ -101,7 +101,7 @@ cqlite \
 OK: 1 row(s) affected (20.2ms)
 Flushed: 1 partitions, 50 bytes
   Output: /tmp/cqlite-write/data/test_basic/simple_table/nb-1-big-Data.db
-CQLite CLI v0.11.0
+CQLite CLI v0.13.0
 Use --help for available commands
 ```
 

--- a/website/src/content/docs/releases/index.md
+++ b/website/src/content/docs/releases/index.md
@@ -14,6 +14,7 @@ For the complete, granular change list, see the
 
 | Version | Date | Highlights |
 |---------|------|-----------|
+| [v0.13.0](/cqlite/releases/v0-13-0/) | 2026-07-05 | Performance release — read-path + point-read + compressed-chunk wins · byte-bounded results · `Database.refresh()` · 3 breaking changes |
 | [v0.12.0](/cqlite/releases/v0-12-0/) | 2026-06-22 | Arrow Flight + Trino connector · CDC delta-export to Parquet · byte-for-byte compaction parity |
 
 <!-- Convention: newest release first. Give each new release page a lower

--- a/website/src/content/docs/releases/v0-12-0.md
+++ b/website/src/content/docs/releases/v0-12-0.md
@@ -3,7 +3,7 @@ title: CQLite v0.12.0
 description: Arrow Flight + Trino connector, CDC delta-export to Parquet, and byte-for-byte compaction parity with Apache Cassandra.
 sidebar:
   label: v0.12.0
-  order: 1
+  order: 2
 ---
 
 # CQLite v0.12.0 — the compaction release

--- a/website/src/content/docs/releases/v0-13-0.md
+++ b/website/src/content/docs/releases/v0-13-0.md
@@ -1,0 +1,86 @@
+---
+title: CQLite v0.13.0
+description: The performance release — a read-path constant-factor bundle, positional point-reads, one payload+CRC read per compressed chunk, faster Node bindings, byte-bounded results, and Database.refresh().
+sidebar:
+  label: v0.13.0
+  order: 1
+---
+
+# CQLite v0.13.0 — the performance release
+
+Read and query Apache Cassandra 5.0 SSTables faster — no cluster required.
+This release is all about the read path: less work per query, fewer syscalls per
+lookup, and one I/O per compressed chunk.
+
+## 🚀 Performance
+
+- **Read-path constant-factor bundle (Epic E)** — a sweep of query-engine hot-path
+  cleanups: schema `Arc`, single projection, cached sort keys, a plan cache, and a
+  `GROUP BY` hash (#1587); a read-path idiom bundle (de-async, `FxHash`, OFFSET
+  skip/take, per-partition digest, IN-expansion allocation cuts; #1590); and dropping
+  the `table_readers` read guard before scanning (#1591).
+- **Point-read I/O (C2)** — a `ReadAt` positional-read trait removes the point-read
+  cursor convoy and the per-lookup `open(2)` (#1573).
+- **One payload + CRC read per compressed chunk** — the E3 A5 read-path bundle
+  collapses each compressed chunk down to a single payload+CRC read (#1585).
+- **Node bindings throughput** — batch-fetch streaming rows per async task (#1443),
+  move (not deep-clone) row values in `executeNative` (#1447), and cache `Set`/`Map`
+  constructors per result conversion (#1448).
+- **Cached comparators** — derived comparators are cached on `SchemaEntry` so
+  composite key ordering isn't rebuilt per comparison (#1709).
+
+## 🧰 New APIs
+
+- **Byte-bounded result budget** — queries now respect a `max_result_bytes` budget
+  (default **64 MiB**). A result that would exceed it fails fast with
+  `ResultTooLarge` instead of ballooning memory. Add a `LIMIT` clause or switch to
+  the streaming query API (streaming is not subject to the budget) to recover (#1582).
+- **`Database.refresh()`** — re-discover SSTables written by Cassandra or another
+  process after the database was opened. It is explicit-only and atomic, and reports
+  how many tables were scanned and how many readers were added/removed (#1749).
+
+## ✅ Correctness & no-heuristics
+
+- **No byte-pattern type guessing** — the raw-decode path no longer infers a value's
+  type from its byte pattern; blobs that happened to look like other types are
+  returned faithfully as blobs, per the no-heuristics mandate (#1630).
+- **Unknown-table reads fail honestly** rather than returning a fabricated `uuid id`
+  default schema (#1710, and see the breaking changes below).
+- **BTI `export-sstable` partition count** is read from the authoritative
+  `Statistics.db` reader instead of a derived estimate (#1622).
+- **Chunk-CRC corruption surfaces on point lookups** instead of silently proceeding
+  (#1411).
+- **Full-scan no longer issues duplicate scans** — bounded streaming replaces the old
+  4× duplicate table scan on the full-scan path (#1691).
+
+## ⚠️ Breaking changes
+
+v0.13.0 ships **three** breaking changes. See the
+[v0.13 Migration Guide](https://github.com/pmcfadin/cqlite/blob/main/docs/development/v0.13-migration-guide.md)
+for before/after examples and per-surface details.
+
+- **Python bindings** — CQL `duration` and `time` now decode to exact, lossless types
+  matching Node, the CLI, and Cassandra: `time` → `int` (nanoseconds since midnight),
+  `duration` → `cqlite.Duration(months, days, nanos)`. The old `datetime.time` /
+  `datetime.timedelta` mapping was lossy (#1450).
+- **Discovery-driven flows** — reading a table with no registered or discovered schema
+  now returns an error (`Table schema not found: {table}`) instead of a fabricated
+  `uuid id` default schema (#1710).
+- **CLI** — YAML query output was removed. `--out yaml` and `--format yaml` are
+  rejected at parse time; switch to `table`, `json`, `csv`, or `parquet` (#283).
+
+## Get it
+
+```bash
+brew install pmcfadin/cqlite/cqlite      # CLI (macOS + Linux)
+cargo add cqlite-core                     # Rust library
+pip install cqlite-py                     # Python
+npm install @cqlite/node                  # Node.js
+```
+
+Full detail in the
+[CHANGELOG](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md), and upgrade
+notes in the
+[v0.13 Migration Guide](https://github.com/pmcfadin/cqlite/blob/main/docs/development/v0.13-migration-guide.md).
+</content>
+</invoke>

--- a/website/src/content/docs/user-docs/cli-reference.md
+++ b/website/src/content/docs/user-docs/cli-reference.md
@@ -8,7 +8,7 @@ sidebar:
 
 # CLI Reference
 
-This page is built from the actual `cqlite --help` output (binary version 0.11.0, built with `--features write-support`). Every example on this page was run against the real test datasets (`cassandra5-small-full-v3.1`).
+This page is built from the actual `cqlite --help` output (binary version 0.13.0, built with `--features write-support`). Every example on this page was run against the real test datasets (`cassandra5-small-full-v3.1`).
 
 ## Synopsis
 

--- a/website/src/content/docs/user-docs/known-issues.md
+++ b/website/src/content/docs/user-docs/known-issues.md
@@ -8,7 +8,7 @@ sidebar:
 
 # Known Issues
 
-This page tracks **active bugs and sharp edges** in the current release (`v0.12.0`).
+This page tracks **active bugs and sharp edges** in the current release (`v0.13.0`).
 It is deliberately short and honest: if something here bites you, you are not doing
 it wrong.
 
@@ -19,7 +19,7 @@ it wrong.
   [**Open an issue**](https://github.com/pmcfadin/cqlite/issues/new/choose) — that is
   the single most useful thing you can do for the project.
 
-_Last reviewed: 2026-06-22 (v0.12.0)._
+_Last reviewed: 2026-07-05 (v0.13.0)._
 
 ## Python bindings
 

--- a/website/src/content/docs/user-docs/nodejs.md
+++ b/website/src/content/docs/user-docs/nodejs.md
@@ -86,6 +86,7 @@ await db.close(); // safe to call again
 | `cacheEnabled` | `boolean` (optional) | `true` | Enable block, row, and query caches |
 | `writable` | `boolean` (optional) | `false` | Enable INSERT/UPDATE/DELETE |
 | `writeDir` | `string` (optional) | — | Directory for WAL and flushed SSTables; required when `writable: true` |
+| `otel` | `OtelOptions` (optional) | — | OpenTelemetry tracing config (requires an `observability` build) |
 
 ## executeNative() — recommended
 
@@ -315,6 +316,54 @@ await db.close();
 - Counter columns cannot be written; `execute()` throws `CqliteError` for counter mutations.
 - The writer produces BIG-format index files, not BTI format.
 
+## Refreshing SSTables
+
+If Cassandra or another process writes new SSTables into the directory after you
+open the database, call `db.refresh()` to re-discover them. Discovery is
+**explicit-only** (CQLite never re-scans behind your back) and **atomic** — the new
+view is swapped in as a whole, so concurrent queries never see a partial set.
+
+```javascript
+const report = await db.refresh(); // Promise<RefreshReport>
+console.log(`Scanned ${report.tablesScanned} tables`);
+console.log(`Added ${report.readersAdded}, removed ${report.readersRemoved} readers`);
+```
+
+`RefreshReport` has the numeric fields `tablesScanned`, `readersAdded`, and
+`readersRemoved`.
+
+## Limiting result size
+
+Non-streaming queries respect a **byte-bounded result budget** with a core default of
+**64 MiB**. A query whose materialized result would exceed the budget fails fast — the
+thrown `CqliteError` has `code === "QUERY"` — instead of exhausting memory.
+
+To recover, add a `LIMIT` clause or switch to `executeStreaming()`, which is **not
+subject to the result budget**.
+
+## OpenTelemetry
+
+Builds compiled with the `observability` feature can emit OpenTelemetry traces. Pass
+an `otel` option to `Database.open()`:
+
+```javascript
+const db = await Database.open('/path/to/sstables', {
+  schema: '/path/to/schema.cql',
+  otel: {
+    enabled: true,
+    endpoint: 'http://localhost:4317',
+    protocol: 'grpc',            // 'grpc' or 'http'
+    serviceName: 'my-service',
+    serviceVersion: '1.2.3',
+    samplingRatio: 0.1,
+    timeoutMs: 5000,
+  },
+});
+```
+
+The `otel` config layers over the `CQLITE_OTEL_*` environment variables (explicit
+keys win). Omit it to leave tracing driven by the environment alone.
+
 ## TypeScript support
 
 Complete TypeScript definitions are included in `lib/index.d.ts`:
@@ -350,6 +399,7 @@ async function query(): Promise<void> {
 | `db.executeStreaming(query, config?)` | `StreamingResult` | Memory-bounded async iteration |
 | `db.exportParquet(query, path, options?)` | `Promise<number>` | Stream query results to a Parquet file |
 | `db.getStats()` | `Promise<DatabaseStats>` | Storage and memory metrics |
+| `db.refresh()` | `Promise<RefreshReport>` | Re-discover SSTables on disk |
 | `db.prepare(query)` | `Promise<PreparedStatement>` | Parse and plan a query |
 | `db.flushRun()` | `Promise<string>` | Flush memtable; returns Data.db path |
 | `db.maintenanceStep(options?)` | `Promise<MaintenanceReport>` | Incremental compaction |

--- a/website/src/content/docs/user-docs/python.md
+++ b/website/src/content/docs/user-docs/python.md
@@ -281,6 +281,67 @@ with cqlite.open(
 - Counter columns cannot be written; `execute()` raises `CqliteError` for counter mutations.
 - Concurrent queries on the same handle require a warm-up query first (see issue #311).
 
+## Refreshing SSTables
+
+If Cassandra or another process writes new SSTables into the directory after you
+open the database, call `db.refresh()` to re-discover them. Discovery is
+**explicit-only** (CQLite never re-scans behind your back) and **atomic** — the new
+view is swapped in as a whole, so concurrent queries never see a partial set.
+
+```python
+report = db.refresh()
+print(f"Scanned {report.tables_scanned} tables")
+print(f"Added {report.readers_added}, removed {report.readers_removed} readers")
+report.to_dict()   # {'tables_scanned': ..., 'readers_added': ..., 'readers_removed': ...}
+```
+
+`refresh()` returns a `RefreshReport` with integer attributes `tables_scanned`,
+`readers_added`, and `readers_removed`, plus a `to_dict()` helper.
+
+## Limiting result size
+
+Non-streaming queries respect a **byte-bounded result budget** (default **64 MiB**).
+A query whose materialized result would exceed the budget fails fast with a
+`cqlite.QueryError` instead of exhausting memory. Set the budget via the `config`
+dict passed to `open()`:
+
+```python
+# Raise (or lower) the per-query result budget, in bytes
+db = cqlite.open(
+    "data/sstables",
+    schema="schema.cql",
+    config={"max_result_bytes": 128 * 1024 * 1024},   # 128 MiB
+)
+```
+
+If a query exceeds the budget, add a `LIMIT` clause or switch to
+`db.execute_streaming()` — **streaming is not subject to the result budget**.
+
+## OpenTelemetry
+
+Builds compiled with the `observability` feature can emit OpenTelemetry traces.
+Pass an `otel_config` dict to `open()`:
+
+```python
+db = cqlite.open(
+    "data/sstables",
+    schema="schema.cql",
+    otel_config={
+        "enabled": True,
+        "endpoint": "http://localhost:4317",
+        "protocol": "grpc",              # "grpc" or "http"
+        "service_name": "my-service",
+        "service_version": "1.2.3",
+        "sampling_ratio": 0.1,
+        "timeout_ms": 5000,
+    },
+)
+```
+
+The dict is layered over the `CQLITE_OTEL_*` environment variables (explicit keys
+win). Unknown keys raise `ValueError`. Omit `otel_config` to leave tracing driven by
+the environment alone.
+
 ## Thread safety
 
 `Database` handles are thread-safe via `Arc<Database>`. All blocking operations
@@ -300,6 +361,7 @@ Do not share a single iterator across threads.
 | `db.export_parquet(query, path, *, row_group_size?, compression?)` | Stream query results to a Parquet file; returns row count |
 | `db.prepare(query)` | Parse and plan a query; returns `PreparedStatement` |
 | `db.stats()` | Storage and memory metrics; returns `DatabaseStats` |
+| `db.refresh()` | Re-discover SSTables on disk; returns `RefreshReport` |
 | `db.flush_run()` | Flush memtable to SSTable; returns Data.db path |
 | `db.maintenance_step(budget_ms)` | Incremental compaction; returns `MaintenanceReport` |
 | `db.write_stats` | Write engine snapshot; returns `WriteStats` |

--- a/website/src/content/docs/user-docs/roadmap.md
+++ b/website/src/content/docs/user-docs/roadmap.md
@@ -8,7 +8,7 @@ sidebar:
 
 # Roadmap
 
-CQLite is at **v0.12.0**. The read path, CLI, output writers (including Parquet),
+CQLite is at **v0.13.0**. The read path, CLI, output writers (including Parquet),
 Python and Node.js bindings, and write support with STCS compaction — now with
 **byte-for-byte compaction parity against Apache Cassandra**, an Arrow Flight + Trino
 connector, canonical BTI (`da`) write/read, and CDC-style delta export — are
@@ -19,7 +19,7 @@ The roadmap is community-driven. The fastest way to move something up the list i
 use case — and to [**star the repo**](https://github.com/pmcfadin/cqlite) so the
 project's reach is visible.
 
-_Last reviewed: 2026-06-22 (v0.12.0)._
+_Last reviewed: 2026-07-05 (v0.13.0)._
 
 ## Milestones
 
@@ -35,7 +35,7 @@ _Last reviewed: 2026-06-22 (v0.12.0)._
 
 ## In-flight epics
 
-These are the active workstreams between v0.12.0 and v1.0. Each links to its GitHub
+These are the active workstreams between v0.13.0 and v1.0. Each links to its GitHub
 epic with the child tasks.
 
 > Query-engine completeness (#756), `WRITETIME()`/`TTL()` in `SELECT` (#689), writer


### PR DESCRIPTION
Closes #1994.

Docs-only. Makes the 0.13 feature story discoverable on the website + user-facing API/CLI reference. Signatures verified against `cqlite-cli/src/cli_types.rs` and the shipped public API (research subagents per surface).

## A. Website (Astro)
- **New `/releases/v0-13-0/` page** — the *performance release*: Epic E read-path bundle (#1587/#1590/#1591), C2 point-read `ReadAt` (#1573), one payload+CRC read per compressed chunk (#1585), Node throughput (#1443/#1447/#1448), cached comparators (#1709); new APIs (`max_result_bytes`, `Database.refresh()`); the 3 breaking changes (#1450/#1710/#283) with migration-guide links. Wording drawn from the landed CHANGELOG `[Unreleased]` list.
- Releases-index row added; `v0-12-0` sidebar order bumped (newest-first).
- Stale version strings refreshed: `cli-reference.md` (0.11.0→0.13.0), `roadmap.md`, `known-issues.md`, `write-mutation.md` (3×). `python.md` type table was already v0.13 — left untouched.

## B. New public APIs documented
`Database.refresh()` (#1749), `max_result_bytes`/`ResultTooLarge` (64 MiB budget, #1582), OpenTelemetry config (#1031, needs `observability` feature) — added to `bindings/python/README.md`, `bindings/node/README.md`, website `python.md`/`nodejs.md`, and `docs/technical/api-specification.md` (Core interface + Error enum + Config note + Observability section).

## C. CLI reference (`CLI_USAGE_EXAMPLES.md`)
Added `verify`, `compact` (full flags + #845/#848 purge caveat + `--major` safety contract), `delta-export` (full flags), `--otel-*` (7 flags + env fallbacks), `--dataset`; fixed stale `info --validate` → real `-f/--format`/`-d/--detailed`. Did NOT advertise `admin`/`schema`/`bench`/`import` (flagged as thin/stubbed placeholders, per issue caveat).

## Validation
- **Astro doc build PASSES** (`npm run build`): 85 pages, all internal links valid (incl. new v0.13.0 page). Per owner directive, validated via the doc CI build — no full `agent-gate.sh` (docs-only, no code changed).

## HOLD
Manager order was `HOLD: merge after #1992 and #1993` — **both are now merged/closed**, so the hold is satisfied.

## Note for owner
Release page dated **2026-07-05** (today) as a sensible default since CHANGELOG/migration are landed and the cut is imminent — confirm/adjust the date at actual release cut.