### PR TITLE
fix(#2003): deterministic ORDER BY id on all remaining CLI smoke LIMIT queries (follow-up to #1998)

### DIFF
--- a/test-data/scripts/ci-one-shot-smoke.sh
+++ b/test-data/scripts/ci-one-shot-smoke.sh
@@ -336,7 +336,7 @@ run_test_suite() {
     # Test 2: Basic SELECT with CSV output (simple_table)
     run_test \
         "test_select_csv_simple" \
-        "SELECT * FROM test_basic.simple_table LIMIT 3" \
+        "SELECT * FROM test_basic.simple_table ORDER BY id LIMIT 3" \
         "csv" \
         0 \
         "${SNAPSHOTS_DIR}/select_simple_csv.golden"
@@ -344,7 +344,7 @@ run_test_suite() {
     # Test 3: Basic SELECT with table output (simple_table)
     run_test \
         "test_select_table_simple" \
-        "SELECT * FROM test_basic.simple_table LIMIT 2" \
+        "SELECT * FROM test_basic.simple_table ORDER BY id LIMIT 2" \
         "table" \
         0 \
         "${SNAPSHOTS_DIR}/select_simple_table.golden"
@@ -352,7 +352,7 @@ run_test_suite() {
     # Test 4: Column projection
     run_test \
         "test_select_columns" \
-        "SELECT id, name FROM test_basic.simple_table LIMIT 3" \
+        "SELECT id, name FROM test_basic.simple_table ORDER BY id LIMIT 3" \
         "json" \
         0 \
         "${SNAPSHOTS_DIR}/select_columns_json.golden"
@@ -372,7 +372,7 @@ run_test_suite() {
 
         run_test \
             "test_select_collections" \
-            "SELECT * FROM test_collections.collection_table LIMIT 2" \
+            "SELECT * FROM test_collections.collection_table ORDER BY id LIMIT 2" \
             "json" \
             0 \
             "${SNAPSHOTS_DIR}/select_collections_json.golden"


### PR DESCRIPTION
Follow-up to #1997/#1998. That PR fixed only `test_select_json_simple`; the smoke script stops at the first failure, masking 4 SIBLING tests with the identical order-unstable pattern (`SELECT ... LIMIT N` with no ORDER BY on single-PK tables): `test_select_csv_simple`, `test_select_table_simple`, `test_select_columns` (simple_table), and `test_select_collections` (collection_table, PK `id UUID`).

Fix: add `ORDER BY id` to all of them. Each verified **byte-identical to its committed golden** (no regen; set/map element order in collections also matches). **Full local smoke run (CI env): 11 PASS, 0 FAIL — ALL TESTS PASSED.** This is the comprehensive sweep #1998 should have been.