### PR TITLE
ci: make Node.js CI windows-latest non-required (continue-on-error) — Refs #1979

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -190,6 +190,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: build
     timeout-minutes: 20
+    # Issue #1979: windows-latest has 3 chronic, pre-existing, Windows-only test
+    # failures (refresh / write-smoke / execute-deprecation — filesystem/locking
+    # behaviors, e.g. refresh expects readersRemoved===1 but gets 0). They are NOT
+    # release-gating for v0.13 (owner decision 2026-07-05). Keep the leg RUNNING for
+    # visibility but non-blocking, so a windows failure does not red the workflow.
+    # ubuntu-latest + macos-14 remain required. Debt tracked in #1979.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Owner decision (2026-07-05): the 3 chronic, pre-existing, **Windows-only** Node test failures (`refresh.test.js`, `write-smoke.test.js`, `execute-deprecation.test.js` — Windows filesystem/locking behaviors) are **not release-gating for v0.13**.

Change: add `continue-on-error: ${{ matrix.os == 'windows-latest' }}` to the Node CI `test` matrix job. The windows leg keeps **running** (visibility retained — it still shows its result) but no longer reds the workflow; the downstream `quality-gate` job's `needs.test.result` becomes success when only the continue-on-error leg fails. **ubuntu-latest + macos-14 remain required.** (The `build` job's windows leg already passes.)

**Does NOT fix the Windows failures — Refs #1979** (kept open) to track the actual Windows debt. YAML validated.