### PR TITLE
fix(#2017): gate verify_full/manifest_carries on Data.db file not corruption dir (last main-CI nextest red)

### DIFF
--- a/cqlite-core/tests/issue_1396_uncompressed_crc_verify.rs
+++ b/cqlite-core/tests/issue_1396_uncompressed_crc_verify.rs
@@ -370,7 +370,8 @@ async fn verify_full_reports_uncompressed_chunk_crc_mismatch() {
     // EXISTS in CI even when the gitignored `nb-1-big-Data.db` is absent. Gating on
     // the dir let these tests slip past the skip and then hard-fail inside
     // `verify_sstable` on the missing Data.db. Gate on the Data.db and derive the dir.
-    let Some(data_db) = dataset_path_or_gate(CORRUPT_DATA_DB, "corrupt uncompressed fixture") else {
+    let Some(data_db) = dataset_path_or_gate(CORRUPT_DATA_DB, "corrupt uncompressed fixture")
+    else {
         return;
     };
     let dir = data_db
@@ -466,7 +467,8 @@ async fn manifest_carries_cassandra_oracle_and_cqlite_matches() {
     // EXISTS in CI even when the gitignored `nb-1-big-Data.db` is absent. Gating on
     // the dir let these tests slip past the skip and then hard-fail inside
     // `verify_sstable` on the missing Data.db. Gate on the Data.db and derive the dir.
-    let Some(data_db) = dataset_path_or_gate(CORRUPT_DATA_DB, "corrupt uncompressed fixture") else {
+    let Some(data_db) = dataset_path_or_gate(CORRUPT_DATA_DB, "corrupt uncompressed fixture")
+    else {
         return;
     };
     let dir = data_db

--- a/cqlite-core/tests/issue_1396_uncompressed_crc_verify.rs
+++ b/cqlite-core/tests/issue_1396_uncompressed_crc_verify.rs
@@ -36,8 +36,6 @@ use std::sync::Arc;
 /// Relative path of the corrupt uncompressed Data.db under the datasets root.
 const CORRUPT_DATA_DB: &str =
     "corruption/test_comp_corrupt/uncompressed_data_bit_flip/nb-1-big-Data.db";
-/// Directory of the corrupt fixture (for `verify_sstable`).
-const CORRUPT_DIR: &str = "corruption/test_comp_corrupt/uncompressed_data_bit_flip";
 /// Fully-qualified table the fixture was derived from.
 const TABLE: &str = "test_comp.uncompressed_table";
 
@@ -367,9 +365,18 @@ async fn clean_uncompressed_scan_verifies_and_returns_rows() {
 /// on the corrupt fixture, and reports NONE on the clean source.
 #[tokio::test]
 async fn verify_full_reports_uncompressed_chunk_crc_mismatch() {
-    let Some(dir) = dataset_path_or_gate(CORRUPT_DIR, "corrupt uncompressed fixture dir") else {
+    // #2017 follow-up: gate on the Data.db FILE, not the directory. The corruption
+    // fixture dir ships COMMITTED metadata (Digest.crc32 / TOC.txt), so CORRUPT_DIR
+    // EXISTS in CI even when the gitignored `nb-1-big-Data.db` is absent. Gating on
+    // the dir let these tests slip past the skip and then hard-fail inside
+    // `verify_sstable` on the missing Data.db. Gate on the Data.db and derive the dir.
+    let Some(data_db) = dataset_path_or_gate(CORRUPT_DATA_DB, "corrupt uncompressed fixture") else {
         return;
     };
+    let dir = data_db
+        .parent()
+        .expect("Data.db has a parent dir")
+        .to_path_buf();
     let config = Config::default();
     let platform = Arc::new(Platform::new(&config).await.expect("platform"));
     let report = verify_sstable(&dir, VerifyMode::Full, &config, platform)
@@ -454,9 +461,18 @@ async fn manifest_carries_cassandra_oracle_and_cqlite_matches() {
     );
 
     // CQLite's verdict must match the Cassandra oracle (corrupt == corrupt).
-    let Some(dir) = dataset_path_or_gate(CORRUPT_DIR, "corrupt uncompressed fixture dir") else {
+    // #2017 follow-up: gate on the Data.db FILE, not the directory. The corruption
+    // fixture dir ships COMMITTED metadata (Digest.crc32 / TOC.txt), so CORRUPT_DIR
+    // EXISTS in CI even when the gitignored `nb-1-big-Data.db` is absent. Gating on
+    // the dir let these tests slip past the skip and then hard-fail inside
+    // `verify_sstable` on the missing Data.db. Gate on the Data.db and derive the dir.
+    let Some(data_db) = dataset_path_or_gate(CORRUPT_DATA_DB, "corrupt uncompressed fixture") else {
         return;
     };
+    let dir = data_db
+        .parent()
+        .expect("Data.db has a parent dir")
+        .to_path_buf();
     let config = Config::default();
     let platform = Arc::new(Platform::new(&config).await.expect("platform"));
     let report = verify_sstable(&dir, VerifyMode::Full, &config, platform)


### PR DESCRIPTION
Follow-up to #2020. After #2020 fixed the flag conflation, 2 tests in `issue_1396_uncompressed_crc_verify` still failed nextest partition 2/3: `verify_full_reports_uncompressed_chunk_crc_mismatch` + `manifest_carries_cassandra_oracle_and_cqlite_matches`. They gated on the corruption **directory** (`CORRUPT_DIR`), which EXISTS in CI (committed `Digest.crc32`/`TOC.txt`) while the gitignored `nb-1-big-Data.db` is absent — so they slipped past the skip and hard-failed in `verify_sstable` (panic at :377 `.expect("verify_sstable should run")`).

Fix: gate on `CORRUPT_DATA_DB` (the Data.db FILE, like the 4 sibling tests) and derive the dir from its parent; removed the now-unused `CORRUPT_DIR` const.

Verified against the EXACT CI state (corruption dir present with metadata, Data.db removed) + `REQUIRE_DATASETS=1`: all 11 tests skip-clean (0 failed); normal run (fixture present) runs + passes. Full `scripts/agent-gate.sh` PASS (re-running post-fmt for a clean gate-of-record block).