### PR TITLE
release(#2023): version bump 0.12.0→0.13.0 + CHANGELOG v0.13.0 + README/CLAUDE (tag-ready)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.13.0] - 2026-07-05
+
+_The performance release._ Read-path constant-factor wins (Epic E, C2), Node
+bindings throughput, and byte-bounded result budgets, on top of v0.12.0's
+byte-for-byte compaction parity — plus no-heuristics correctness fixes.
+
+### Known Issues
+
+- **Node.js `Test (windows-latest)` CI leg** is failing and is **waived** for the
+  v0.13.0 release (best-effort, not release-gated) — tracked in [#2007](https://github.com/pmcfadin/cqlite/issues/2007).
+- **Coverage Gate `(enforced)` (90%) leg** is not green and is **waived** for the
+  v0.13.0 release; restoration is post-0.13 — tracked in [#2022](https://github.com/pmcfadin/cqlite/issues/2022).
+
 ### Added
 
 - Typed inner-UDT decode for frozen-UDT elements inside frozen collections (#1340, PR #1960)
@@ -75,10 +88,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-<!-- DRAFT (release-prep): curated from the merge log since v0.12.0; owner to
-     verify/trim wording before the release commit. See
-     docs/development/release-0.13-checklist.md. -->
-
 - **No-heuristics: removed blob-decode byte-pattern guessing.** The raw-decode
   path no longer infers a value's type from its byte pattern; blobs that happened
   to look like other types are returned faithfully as blobs, per the no-heuristics
@@ -101,9 +110,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Surface chunk-CRC corruption on point lookups instead of silently proceeding (#1411, PR #1777)
 
 ### Performance
-
-<!-- DRAFT (release-prep): this release's headline theme is read-path + bindings
-     performance. Owner to confirm framing before the release commit. -->
 
 - **Read-path constant-factor bundle (Epic E):** query-engine hot-path cleanups
   (schema `Arc`, single projection, cached sort keys, plan cache, GROUP BY hash;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code when working with CQLite.
 
 CQLite is a Rust library for local Apache Cassandra SSTable access. It reads Cassandra 5.0 data files without cluster dependencies.
 
-**Status**: v0.12.0 (Jun 2026) - Core reading (M1), CLI (M2), Output Writers (M3), Python & Node.js Bindings (M4), and Write Support + STCS compaction (M5) are complete. v0.12.0 adds byte-for-byte compaction parity vs Apache Cassandra, an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, CDC-style delta-export, and `WRITETIME()`/`TTL()` in `SELECT`. Next: M6 (WASM bindings), M7 (perf validation + v1.0).
+**Status**: v0.13.0 (Jul 2026) - the performance release. Core reading (M1), CLI (M2), Output Writers (M3), Python & Node.js Bindings (M4), and Write Support + STCS compaction (M5) are complete. v0.13.0 adds read-path constant-factor speedups (Epic E, C2), Node bindings throughput, byte-bounded result budgets (`Error::ResultTooLarge`), explicit `Database::refresh()`, and no-heuristics correctness fixes, on top of v0.12.0's byte-for-byte compaction parity vs Apache Cassandra, Arrow Flight + Trino connector, canonical BTI (`da`) write/read, CDC-style delta-export, and `WRITETIME()`/`TTL()` in `SELECT`. Next: M6 (WASM bindings), M7 (perf validation + v1.0).
 
 ## Documentation
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ resolver = "2"
 # belongs to an unrelated project; the CLI publishes as `cqlite-cli` (binary
 # `cqlite`). See issue #782.
 name = "cqlite"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 publish = false
 
@@ -47,7 +47,7 @@ crc32fast = { workspace = true }
 cqlite-integration-tests = { path = "tests" }
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://cassandra.apache.org"><img src="https://img.shields.io/badge/cassandra-5.0+-green.svg" alt="Cassandra"></a>
 </p>
 
-> **Status**: v0.12.0 — Core reading, CLI, output writers, Python & Node.js bindings, and write support are production-ready, now with **byte-for-byte compaction parity against Apache Cassandra**, an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, and CDC-style delta export. See [CHANGELOG.md](CHANGELOG.md).
+> **Status**: v0.13.0 — the performance release. Core reading, CLI, output writers, Python & Node.js bindings, and write support are production-ready, now with **read-path constant-factor speedups**, **byte-bounded result budgets**, explicit `Database.refresh()`, no-heuristics correctness fixes, and **byte-for-byte compaction parity against Apache Cassandra**, an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, and CDC-style delta export. See [CHANGELOG.md](CHANGELOG.md).
 
 > **Upgrading to v0.13?** See the [v0.13 Migration Guide](docs/development/v0.13-migration-guide.md) for the 3 breaking changes (Python duration/time types, unknown-table errors, CLI YAML removal).
 
@@ -316,6 +316,14 @@ cargo build -p cqlite-core --no-default-features
 - [x] Real BTI trie node-type dispatch and schema-typed query result columns
 - [x] Published documentation site at [pmcfadin.github.io/cqlite](https://pmcfadin.github.io/cqlite/)
 
+### ✅ v0.13.0 (Jul 2026) — the performance release
+- [x] **Read-path constant-factor speedups** — query-engine hot-path cleanups (schema `Arc`, single projection, cached sort keys, plan cache), read-path idiom bundle, and point-read I/O via a positional-read (`ReadAt`) trait
+- [x] **Node.js bindings throughput** — batch-fetch streaming rows, move (not clone) row values in `executeNative`, cached `Set`/`Map` constructors
+- [x] **Byte-bounded result budget** — `Error::ResultTooLarge` + `QueryConfig.max_result_bytes` (default 64 MiB)
+- [x] **Per-surface SSTable freshness contract** + explicit `Database.refresh()`
+- [x] **No-heuristics correctness** — removed blob-decode byte-pattern guessing; unknown-table reads fail honestly instead of fabricating a default schema
+- See [CHANGELOG.md](CHANGELOG.md) for the full per-release detail
+
 ### ✅ v0.12.0 (Jun 2026) — the compaction release
 - [x] **Byte-for-byte compaction parity vs Apache Cassandra** — `cqlite compact` + a differential harness in CI, full reconciliation rule set (complex deletions, tombstone tie-breaks, `gc_grace` purging, range tombstones, per-cell/dropped-column purging, non-frozen UDT multi-cell)
 - [x] **Arrow Flight server + Trino connector** — query SSTables as a federated source with predicate, token-range, and aggregation pushdown
@@ -331,7 +339,7 @@ See the [**Roadmap**](#roadmap) section below for in-flight epics and milestones
 
 ## Roadmap
 
-CQLite is at **v0.12.0** and production-ready for the use cases above. The path to
+CQLite is at **v0.13.0** and production-ready for the use cases above. The path to
 **v1.0** is tracked in the open. Full detail, with milestones, lives at
 [pmcfadin.github.io/cqlite → Roadmap](https://pmcfadin.github.io/cqlite/user-docs/roadmap/).
 
@@ -349,7 +357,7 @@ The roadmap follows real-world use. Want something prioritized?
 
 ## Known Issues
 
-CQLite is honest about its sharp edges. The current release (`v0.12.0`) has a few
+CQLite is honest about its sharp edges. The current release (`v0.13.0`) has a few
 known gaps — none of which block the core read/export workflows. Full, dated list:
 [pmcfadin.github.io/cqlite → Known Issues](https://pmcfadin.github.io/cqlite/user-docs/known-issues/).
 
@@ -504,4 +512,4 @@ Special thanks to the Apache Cassandra community and the many contributors who m
 
 ---
 
-**Note**: M1 through M5 milestones are complete and the project is at **v0.12.0**. Core SSTable reading, CLI, output writers (including Parquet), Python and Node.js bindings, and write support with STCS compaction and **byte-for-byte compaction parity vs Apache Cassandra** are production-ready, alongside an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, and CDC-style delta export. Next: M6 (WASM bindings) and M7 (performance validation + v1.0).
+**Note**: M1 through M5 milestones are complete and the project is at **v0.13.0**. Core SSTable reading, CLI, output writers (including Parquet), Python and Node.js bindings, and write support with STCS compaction and **byte-for-byte compaction parity vs Apache Cassandra** are production-ready, alongside read-path performance wins, byte-bounded result budgets, an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, and CDC-style delta export. Next: M6 (WASM bindings) and M7 (performance validation + v1.0).

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.12.0"
+version = "0.13.0"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # version is required (alongside path) so the dep resolves when published to
 # crates.io. Keep this literal in sync with [workspace.package].version on every
 # release (see release checklist).
-cqlite-core = { path = "../cqlite-core", version = "0.12.0" }
+cqlite-core = { path = "../cqlite-core", version = "0.13.0" }
 
 # CLI framework
 clap = { workspace = true }

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,9 +83,10 @@ Welcome to the CQLite documentation hub. This directory holds technical document
 
 ## 📈 Project Status
 
-- **Current Version**: 0.12.0
+- **Current Version**: 0.13.0
 - **Cassandra Compatibility**: 5.0+ with BTI (`da`) format read **and** write support
 - **Milestones Complete**: M1 (Core Reading), M2 (CLI), M3 (Output Writers), M4 (Python & Node.js Bindings), M5 (Write Support + Compaction)
+- **v0.13.0**: Read-path constant-factor speedups (Epic E, C2) · Node bindings throughput · byte-bounded result budgets · explicit `Database.refresh()` · no-heuristics correctness fixes
 - **v0.12.0**: Byte-for-byte compaction parity vs Apache Cassandra · Arrow Flight + Trino connector · canonical BTI write/read · CDC delta-export · `WRITETIME()`/`TTL()` in `SELECT`
 - **Next**: M6 (WebAssembly Bindings), M7 (Performance validation + v1.0)
 - **Test Pass Rate**: 100% (33/33 tables vs sstabledump, see `test-data/validation-matrix.md`)


### PR DESCRIPTION
Closes #2023 — the release-mechanics lane for **v0.13.0**. Tag-ready commit; the owner creates/pushes the `v0.13.0` tag (this PR does **not** tag).

## What changed
All version sites moved `0.12.0 → 0.13.0` **together**:
- `Cargo.toml` — `[workspace.package] version` + the crate at ~line 50
- **`cqlite-cli/Cargo.toml`** — `cqlite-core = { …, version = "0.13.0" }` internal dep pin. **This site is not in the issue checklist but is publish-critical:** a `0.12.0` requirement would fail `cargo publish` (release.yml) against a `0.13.0` core (`^0.12.0` excludes `0.13.0`).
- `bindings/python/pyproject.toml` — `version`
- `bindings/node/package.json` — `"version"`

CHANGELOG:
- Renamed `## [Unreleased]` → `## [v0.13.0] - 2026-07-05`, opened a fresh empty `## [Unreleased]` above it.
- Added the "performance release" theme line and a **Known Issues** section pointing at the two documented waivers: **#2007** (Node.js `Test (windows-latest)`) and **#2022** (Coverage Gate `(enforced)`).
- Removed the release-prep DRAFT curation HTML comments (curation landed via #1992).

README / docs / CLAUDE:
- `README.md` — status line, roadmap current-version refs, feature summary; added a `✅ v0.13.0 (Jul 2026)` release entry.
- `docs/README.md` — `Current Version: 0.13.0` + a v0.13.0 bullet.
- `CLAUDE.md` — `Status: v0.13.0 (Jul 2026) — the performance release`.

Grep-sweep: no stray **live** `0.12.0` in `*.toml`/`*.json`; remaining `.md` hits are historical release entries only.

## Gate of record (FULL `scripts/agent-gate.sh`, no --delta/--lite)
```
==== AGENT-GATE SUMMARY ====
commit: 856443f8 branch: issue-2023-version-bump-013 dirty: no
accelerators: sccache=on nextest=on lanes=on
file-size: PASS  fmt: PASS  clippy: PASS  core-tests: PASS
tombstones-scan: PASS  scan-offload-guard: PASS  byte-budget-guard: PASS
memory-budget: PASS  integration-tests: PASS  format-compat: PASS
write-tests: PASS  cli-tests: PASS  compaction-byte-parity: PASS
python-bindings: PASS  node-bindings: PASS  delivery-telemetry: PASS
parity-report: PASS  binding-unwind-profile: PASS  tooling-tests: PASS
minimal-build: PASS  smoke: PASS
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```
`parity-report` PASS covers the derived-artifact `cargo run -p cassandra-parity -- report --check`; both bindings + `minimal-build` validate the bumped versions build publish-ready.

roborev: running against `origin/main`; will confirm clean before merge.
