### PR TITLE
fix: wave-3 P0 batch — #1463 timestamp/parquet-config, #1489 delta-export guard, #1506 progress hygiene

### DIFF
--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -222,6 +222,7 @@ class Database:
         *,
         row_group_size: int = 10000,
         compression: str = "snappy",
+        config: "StreamingConfig | None" = None,
     ) -> int:
         """Export the results of a CQL query to a Parquet file.
 
@@ -233,6 +234,8 @@ class Database:
             path: Destination file path (created or truncated)
             row_group_size: Rows per Parquet row group (default: 10000)
             compression: "snappy" (default), "zstd", or "none"
+            config: Optional StreamingConfig tuning buffer/chunk sizes for the
+                underlying streaming scan (defaults to the engine default)
 
         Returns:
             Number of rows written

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -423,6 +423,8 @@ impl Database {
     /// * `path` - Destination file path (created or truncated)
     /// * `row_group_size` - Rows per Parquet row group (default: 10000)
     /// * `compression` - "snappy" (default), "zstd", or "none"
+    /// * `config` - Optional StreamingConfig for buffer/chunk sizes during the
+    ///   underlying streaming scan (defaults to the engine default when unset)
     ///
     /// # Returns
     ///
@@ -446,7 +448,7 @@ impl Database {
     /// )
     /// print(f"Exported {rows} row(s)")
     /// ```
-    #[pyo3(signature = (query, path, *, row_group_size=10000, compression="snappy"))]
+    #[pyo3(signature = (query, path, *, row_group_size=10000, compression="snappy", config=None))]
     pub fn export_parquet(
         &self,
         py: Python<'_>,
@@ -454,6 +456,7 @@ impl Database {
         path: &str,
         row_group_size: usize,
         compression: &str,
+        config: Option<&StreamingConfig>,
     ) -> PyResult<u64> {
         use cqlite_core::export::parquet::{
             ParquetCompression, ParquetExportOptions, StreamingParquetWriter,
@@ -486,6 +489,9 @@ impl Database {
         let db = self.inner();
         let query_owned = query.to_string();
         let path_owned = PathBuf::from(path);
+        // Resolve the streaming config while we still hold the GIL (the pyclass
+        // ref cannot cross `allow_threads`); default when unset (issue #1463).
+        let core_config = config.map(|c| c.to_core()).unwrap_or_default();
 
         // Release the GIL for the whole export (query + file writing).
         // Errors are split so each maps to the right Python exception:
@@ -493,10 +499,7 @@ impl Database {
         let result: Result<u64, PyErr> = py.allow_threads(|| {
             block_on(async {
                 let mut iter = db
-                    .execute_streaming(
-                        &query_owned,
-                        cqlite_core::query::result::StreamingConfig::default(),
-                    )
+                    .execute_streaming(&query_owned, core_config)
                     .await
                     .map_err(to_py_err)?;
 

--- a/bindings/python/src/value.rs
+++ b/bindings/python/src/value.rs
@@ -160,17 +160,24 @@ fn timestamp_to_datetime(py: Python<'_>, millis: i64) -> PyResult<PyObject> {
     let dt_class = datetime.getattr("datetime")?;
     let timezone = datetime.getattr("timezone")?;
     let utc = timezone.getattr("utc")?;
+    let timedelta = datetime.getattr("timedelta")?;
 
-    // Convert milliseconds to seconds and microseconds
-    // Use Euclidean division/remainder to correctly handle negative timestamps
-    let seconds = millis.div_euclid(1000);
-    let micros = millis.rem_euclid(1000) * 1000;
+    // Build the datetime integer-exactly: epoch(0, tz=utc) + timedelta(milliseconds=millis).
+    //
+    // Routing `millis` through an f64 (as the old `fromtimestamp` path did) loses
+    // microsecond exactness for far-future/far-past timestamps because such values
+    // exceed the 53-bit mantissa. Passing `millis` to `timedelta(milliseconds=...)`
+    // as a Python int keeps the conversion exact, and `timedelta` normalizes the
+    // value to days/seconds/microseconds with correct handling of negatives — which
+    // preserves the pre-epoch/negative correctness of Issue #341 without the
+    // Euclidean-division dance.
+    let epoch = dt_class.call_method1("fromtimestamp", (0i64, utc))?;
 
-    // Use fromtimestamp with UTC timezone
-    let dt = dt_class.call_method1(
-        "fromtimestamp",
-        (seconds as f64 + micros as f64 / 1_000_000.0, utc),
-    )?;
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("milliseconds", millis)?;
+    let td = timedelta.call((), Some(&kwargs))?;
+
+    let dt = epoch.call_method1("__add__", (td,))?;
     Ok(dt.into_pyobject(py)?.into_any().unbind())
 }
 

--- a/bindings/python/tests/test_export_parquet.py
+++ b/bindings/python/tests/test_export_parquet.py
@@ -139,6 +139,46 @@ class TestExportParquetScalars:
             assert table.num_rows == rows
 
 
+class TestExportParquetStreamingConfig:
+    """export_parquet must accept and thread a StreamingConfig (#1463)."""
+
+    QUERY = "SELECT * FROM test_basic.simple_table"
+
+    def test_export_parquet_respects_config(self, db, tmp_path):
+        """A non-default StreamingConfig is accepted and produces the same rows.
+
+        Before #1463 ``export_parquet`` hard-coded ``StreamingConfig::default()``
+        and rejected a ``config=`` keyword entirely (TypeError). This proves the
+        param is now accepted and threaded through the streaming scan without
+        changing the result: a small non-default buffer/chunk config exports the
+        identical row count to the default path.
+        """
+        expected = len(db.execute(self.QUERY).rows)
+        assert expected > 0, "fixture must have rows for a meaningful assertion"
+
+        cfg = cqlite.StreamingConfig(buffer_size=8, chunk_size=3)
+        out = tmp_path / "cfg.parquet"
+        rows = db.export_parquet(self.QUERY, str(out), config=cfg)
+
+        assert rows == expected, "config path must export the same rows as default"
+        _assert_parquet_magic(out)
+
+        # Row count is identical to the default (no-config) export.
+        out_default = tmp_path / "default.parquet"
+        default_rows = db.export_parquet(self.QUERY, str(out_default))
+        assert rows == default_rows
+
+        if HAVE_PYARROW:
+            assert pq.read_table(out).num_rows == expected
+
+    def test_export_parquet_config_none_matches_default(self, db, tmp_path):
+        """Passing config=None is identical to omitting it (default behavior)."""
+        out = tmp_path / "none.parquet"
+        rows = db.export_parquet(self.QUERY, str(out), config=None)
+        assert rows == len(db.execute(self.QUERY).rows)
+        _assert_parquet_magic(out)
+
+
 class TestExportParquetCollections:
     """Collections table export (test_collections.collection_table)."""
 

--- a/bindings/python/tests/test_types_temporal.py
+++ b/bindings/python/tests/test_types_temporal.py
@@ -446,6 +446,20 @@ CREATE TABLE IF NOT EXISTS t (
 """
 
 
+# Same single-table shape, a TIMESTAMP column, for the far-future exactness proof.
+_TIMESTAMP_SCHEMA = """\
+CREATE KEYSPACE IF NOT EXISTS temporal_exact
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE temporal_exact;
+
+CREATE TABLE IF NOT EXISTS t (
+    id  INT PRIMARY KEY,
+    wts TIMESTAMP
+);
+"""
+
+
 class TestTemporalExactness:
     """Prove values the OLD (M4 §5.2) lossy path corrupted are now preserved."""
 
@@ -492,6 +506,61 @@ class TestTemporalExactness:
         assert value == sub_us_nanos, f"expected exact {sub_us_nanos}, got {value}"
         assert value != old_lossy_nanos, (
             "sub-µs nanoseconds must NOT be truncated (regression to M4 §5.2)"
+        )
+
+    def test_far_future_timestamp_us_exact(self, tmp_path):
+        """A far-future TIMESTAMP converts to datetime microsecond-exactly (#1463).
+
+        The value 253_402_214_399_123 ms is in year 9999 with a 123 ms
+        (123_000 µs) fractional-second component. The old conversion routed
+        ``seconds + micros/1e6`` through an f64 whose ULP at that magnitude is
+        ~61 µs, so ``fromtimestamp`` read back 122_986 µs instead of 123_000 —
+        a silent microsecond error. Building the datetime as
+        ``epoch(0, utc) + timedelta(milliseconds=millis)`` (integer-exact) makes
+        the conversion lossless, so this asserts the exact expected datetime.
+        """
+        millis = 253_402_214_399_123  # year 9999, .123 s the f64 path corrupted
+        utc = datetime.timezone.utc
+        expected = datetime.datetime.fromtimestamp(0, tz=utc) + datetime.timedelta(
+            milliseconds=millis
+        )
+        assert expected.microsecond == 123_000  # sanity: what exactness must yield
+
+        schema = tmp_path / "schema.cql"
+        schema.write_text(_TIMESTAMP_SCHEMA)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        write_dir = tmp_path / "wd"
+
+        db = cqlite.open(
+            str(data_dir),
+            schema=str(schema),
+            writable=True,
+            write_dir=str(write_dir),
+        )
+        try:
+            db.execute(
+                f"INSERT INTO temporal_exact.t (id, wts) VALUES (1, {millis})"
+            )
+            path = db.flush_run()
+            assert path and Path(path).exists(), "flush must produce a real Data.db"
+        finally:
+            db.close()
+
+        with cqlite.open(str(write_dir / "data"), schema=str(schema)) as rd:
+            rows = [
+                row.to_dict()
+                for row in rd.execute("SELECT wts FROM temporal_exact.t")
+            ]
+
+        assert len(rows) == 1, f"exactly one row expected, got {rows}"
+        value = rows[0]["wts"]
+        assert isinstance(value, datetime.datetime), f"expected datetime, got {type(value)}"
+        assert value.tzinfo == utc, "timestamp must stay UTC-aware"
+        # The load-bearing assertion: exact to the microsecond (fails on f64 path).
+        assert value == expected, f"expected {expected!r}, got {value!r}"
+        assert value.microsecond == 123_000, (
+            f"microsecond must be exact 123000, got {value.microsecond}"
         )
 
     def test_duration_exact_months_days_nanos(self, db):

--- a/cqlite-cli/src/commands/delta_export.rs
+++ b/cqlite-cli/src/commands/delta_export.rs
@@ -58,6 +58,41 @@ impl DeltaExportResult {
     }
 }
 
+/// Enforce delta-export's single bare-`CREATE TABLE` schema contract (issue #1489).
+///
+/// delta-export requires a schema file containing exactly one bare `CREATE TABLE`
+/// statement — no `CREATE KEYSPACE` / `USE` preamble and no trailing statements.
+/// Without this guard a leading preamble fails with an opaque raw nom `{:?}` debug
+/// dump, and statements *after* the `CREATE TABLE` are silently discarded. Both are
+/// fail-open surprises. For CQL schema files we detect >1 top-level statement up
+/// front (via `split_cql_statements`) and emit a clear, targeted error. JSON schema
+/// documents are exempt: they are validated by the JSON loader, not this contract.
+#[cfg(feature = "delta-export")]
+fn ensure_bare_create_table_schema(
+    schema_path: &std::path::Path,
+    content: &str,
+) -> anyhow::Result<()> {
+    let is_cql = matches!(
+        schema_path
+            .extension()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_ascii_lowercase())
+            .as_deref(),
+        Some("cql") | Some("sql") | None
+    );
+    if !is_cql {
+        return Ok(());
+    }
+
+    let statements = cqlite_core::schema::cql_parser::split_cql_statements(content);
+    if statements.len() > 1 {
+        return Err(anyhow::anyhow!(
+            "delta-export requires a bare CREATE TABLE (no CREATE KEYSPACE / USE preamble)"
+        ));
+    }
+    Ok(())
+}
+
 /// Run the `delta-export` subcommand.
 ///
 /// This function is the `#[cfg(feature = "delta-export")]` path.  When the
@@ -106,6 +141,18 @@ pub async fn handle_delta_export(
     // -----------------------------------------------------------------------
     // Load schema (errors at schema-derivation time, before any I/O)
     // -----------------------------------------------------------------------
+    // Enforce the single bare-CREATE-TABLE contract before loading (issue #1489):
+    // a leading CREATE KEYSPACE / USE preamble would otherwise fail with an opaque
+    // nom debug dump, and trailing statements would be silently dropped.
+    let schema_src = std::fs::read_to_string(&args.schema).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to read schema file: {}: {}",
+            args.schema.display(),
+            e
+        )
+    })?;
+    ensure_bare_create_table_schema(&args.schema, &schema_src)?;
+
     let schema = crate::commands::load_schema_file(&args.schema, false, None)?;
 
     // -----------------------------------------------------------------------
@@ -301,4 +348,61 @@ pub async fn handle_delta_export(
         execution_time_ms: start.elapsed().as_secs_f64() * 1000.0,
         element_tombstone_warnings,
     })
+}
+
+#[cfg(all(test, feature = "delta-export"))]
+mod bare_create_table_schema_tests {
+    use super::ensure_bare_create_table_schema;
+    use std::path::Path;
+
+    const BARE: &str = "CREATE TABLE ks.t (id uuid PRIMARY KEY, name text);";
+    const LEADING_PREAMBLE: &str = "CREATE KEYSPACE ks WITH replication = \
+        {'class': 'SimpleStrategy', 'replication_factor': 1}; \
+        USE ks; \
+        CREATE TABLE ks.t (id uuid PRIMARY KEY, name text);";
+    const TRAILING_STATEMENT: &str = "CREATE TABLE ks.t (id uuid PRIMARY KEY, name text); \
+        CREATE INDEX ON ks.t (name);";
+
+    /// A single bare CREATE TABLE is accepted.
+    #[test]
+    fn bare_create_table_is_accepted() {
+        ensure_bare_create_table_schema(Path::new("schema.cql"), BARE)
+            .expect("a bare CREATE TABLE must be accepted");
+    }
+
+    /// A leading CREATE KEYSPACE / USE preamble must yield a clear, targeted
+    /// error naming the bare-CREATE-TABLE contract — not a raw nom debug dump.
+    /// On main this reached parse_cql_schema and produced a generic
+    /// "Failed to parse CQL schema: {:?}" nom error.
+    #[test]
+    fn leading_preamble_names_the_bare_create_table_contract() {
+        let err = ensure_bare_create_table_schema(Path::new("schema.cql"), LEADING_PREAMBLE)
+            .expect_err("a leading CREATE KEYSPACE / USE preamble must be rejected");
+        assert!(
+            err.to_string().contains("bare CREATE TABLE"),
+            "error must name the bare-CREATE-TABLE contract, got: {err}"
+        );
+    }
+
+    /// Statements *after* the CREATE TABLE must error rather than being silently
+    /// dropped. On main these were discarded (parse_cql_schema ignored the
+    /// remaining input) and the export silently succeeded.
+    #[test]
+    fn trailing_statement_names_the_bare_create_table_contract() {
+        let err = ensure_bare_create_table_schema(Path::new("schema.cql"), TRAILING_STATEMENT)
+            .expect_err("a trailing statement must be rejected");
+        assert!(
+            err.to_string().contains("bare CREATE TABLE"),
+            "error must name the bare-CREATE-TABLE contract, got: {err}"
+        );
+    }
+
+    /// JSON schema documents are exempt from the single-statement contract
+    /// (they are validated by the JSON loader, not this guard).
+    #[test]
+    fn json_schema_is_exempt() {
+        // Content that would trip the CQL guard, but with a .json extension.
+        ensure_bare_create_table_schema(Path::new("schema.json"), LEADING_PREAMBLE)
+            .expect("JSON schema files are exempt from the CQL single-statement contract");
+    }
 }

--- a/cqlite-cli/src/commands/delta_export.rs
+++ b/cqlite-cli/src/commands/delta_export.rs
@@ -64,14 +64,20 @@ impl DeltaExportResult {
 /// statement — no `CREATE KEYSPACE` / `USE` preamble and no trailing statements.
 /// Without this guard a leading preamble fails with an opaque raw nom `{:?}` debug
 /// dump, and statements *after* the `CREATE TABLE` are silently discarded. Both are
-/// fail-open surprises. For CQL schema files we detect >1 top-level statement up
-/// front (via `split_cql_statements`) and emit a clear, targeted error. JSON schema
-/// documents are exempt: they are validated by the JSON loader, not this contract.
+/// fail-open surprises. For CQL schema files we require **exactly one** top-level
+/// statement (via `split_cql_statements`) **and** that it classify as a
+/// `CREATE TABLE` (via `classify_statement`) — a zero-statement schema or a single
+/// non-`CREATE TABLE` statement (e.g. a lone `CREATE KEYSPACE`) would otherwise fall
+/// through to the legacy parser and reproduce the opaque error this guard replaces.
+/// JSON schema documents are exempt: they are validated by the JSON loader, not this
+/// contract.
 #[cfg(feature = "delta-export")]
 fn ensure_bare_create_table_schema(
     schema_path: &std::path::Path,
     content: &str,
 ) -> anyhow::Result<()> {
+    use cqlite_core::schema::cql_parser::{classify_statement, StatementType};
+
     let is_cql = matches!(
         schema_path
             .extension()
@@ -85,7 +91,12 @@ fn ensure_bare_create_table_schema(
     }
 
     let statements = cqlite_core::schema::cql_parser::split_cql_statements(content);
-    if statements.len() > 1 {
+    let is_single_create_table = statements.len() == 1
+        && matches!(
+            classify_statement(&statements[0]),
+            StatementType::CreateTable
+        );
+    if !is_single_create_table {
         return Err(anyhow::anyhow!(
             "delta-export requires a bare CREATE TABLE (no CREATE KEYSPACE / USE preamble)"
         ));
@@ -362,6 +373,9 @@ mod bare_create_table_schema_tests {
         CREATE TABLE ks.t (id uuid PRIMARY KEY, name text);";
     const TRAILING_STATEMENT: &str = "CREATE TABLE ks.t (id uuid PRIMARY KEY, name text); \
         CREATE INDEX ON ks.t (name);";
+    const LONE_KEYSPACE: &str = "CREATE KEYSPACE ks WITH replication = \
+        {'class': 'SimpleStrategy', 'replication_factor': 1};";
+    const EMPTY_SCHEMA: &str = "   \n  -- just a comment\n  ";
 
     /// A single bare CREATE TABLE is accepted.
     #[test]
@@ -391,6 +405,33 @@ mod bare_create_table_schema_tests {
     fn trailing_statement_names_the_bare_create_table_contract() {
         let err = ensure_bare_create_table_schema(Path::new("schema.cql"), TRAILING_STATEMENT)
             .expect_err("a trailing statement must be rejected");
+        assert!(
+            err.to_string().contains("bare CREATE TABLE"),
+            "error must name the bare-CREATE-TABLE contract, got: {err}"
+        );
+    }
+
+    /// A single statement that is NOT a CREATE TABLE (e.g. a lone CREATE
+    /// KEYSPACE) must yield the same targeted error. On pre-fix code this
+    /// single statement passed the `len() > 1` check and fell through to the
+    /// legacy parser, producing the opaque nom error the guard was meant to
+    /// replace.
+    #[test]
+    fn lone_non_create_table_names_the_bare_create_table_contract() {
+        let err = ensure_bare_create_table_schema(Path::new("schema.cql"), LONE_KEYSPACE)
+            .expect_err("a lone CREATE KEYSPACE must be rejected");
+        assert!(
+            err.to_string().contains("bare CREATE TABLE"),
+            "error must name the bare-CREATE-TABLE contract, got: {err}"
+        );
+    }
+
+    /// A zero-statement (empty / comment-only) schema must yield the same
+    /// targeted error rather than falling through to the legacy parser.
+    #[test]
+    fn empty_schema_names_the_bare_create_table_contract() {
+        let err = ensure_bare_create_table_schema(Path::new("schema.cql"), EMPTY_SCHEMA)
+            .expect_err("an empty/zero-statement schema must be rejected");
         assert!(
             err.to_string().contains("bare CREATE TABLE"),
             "error must name the bare-CREATE-TABLE contract, got: {err}"

--- a/cqlite-cli/src/commands/export_sstable.rs
+++ b/cqlite-cli/src/commands/export_sstable.rs
@@ -32,7 +32,14 @@ pub async fn export_sstable(
     schema_path: &Path,
     output_path: &Path,
     format: ExportFormat,
+    quiet: bool,
 ) -> Result<()> {
+    use std::io::IsTerminal;
+
+    // Issue #1506 / #284: progress + status chatter is suppressed under --quiet
+    // and when stdout is not a TTY.
+    let show_progress = !quiet && std::io::stdout().is_terminal();
+
     // Load schema with auto-detection
     let schema = load_schema_file(schema_path, false, None)?;
 
@@ -45,15 +52,24 @@ pub async fn export_sstable(
     let mut output_file = File::create(output_path)
         .with_context(|| format!("Failed to create output file: {}", output_path.display()))?;
 
-    println!("Exporting SSTable: {}", sstable_path.display());
-    println!("Output: {} ({})", output_path.display(), format);
+    if show_progress {
+        println!("Exporting SSTable: {}", sstable_path.display());
+        println!("Output: {} ({})", output_path.display(), format);
+    }
 
-    let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
+    // Hidden bar when suppressed; on a template error fall back to the default
+    // spinner style rather than panicking (the bar is cosmetic).
+    let pb = if show_progress {
+        let pb = ProgressBar::new_spinner();
+        if let Ok(style) = ProgressStyle::default_spinner()
             .template("{spinner:.green} [{elapsed_precise}] {pos} rows exported")
-            .unwrap(),
-    );
+        {
+            pb.set_style(style);
+        }
+        pb
+    } else {
+        ProgressBar::hidden()
+    };
 
     match format {
         ExportFormat::Json => export_as_json(&reader, &schema, &mut output_file, &pb).await,

--- a/cqlite-cli/src/commands/export_sstable.rs
+++ b/cqlite-cli/src/commands/export_sstable.rs
@@ -7,7 +7,7 @@
 #![allow(deprecated)]
 
 #[cfg(feature = "state_machine")]
-use super::schema_load::load_schema_file;
+use super::schema_load::load_schema_file_with_status;
 #[cfg(feature = "state_machine")]
 use super::support::RealDataParser;
 #[cfg(feature = "state_machine")]
@@ -40,8 +40,9 @@ pub async fn export_sstable(
     // and when stdout is not a TTY.
     let show_progress = !quiet && std::io::stdout().is_terminal();
 
-    // Load schema with auto-detection
-    let schema = load_schema_file(schema_path, false, None)?;
+    // Load schema with auto-detection. Issue #1506 / #284: schema-loading status
+    // is gated behind `show_progress` so `--quiet` (and non-TTY stdout) suppress it.
+    let schema = load_schema_file_with_status(schema_path, false, None, show_progress)?;
 
     let config = cqlite_core::Config::default();
     let platform = Arc::new(cqlite_core::platform::Platform::new(&config).await?);

--- a/cqlite-cli/src/commands/import.rs
+++ b/cqlite-cli/src/commands/import.rs
@@ -19,11 +19,19 @@ pub async fn import_data(
     file: &Path,
     format: crate::cli::ImportFormat,
     table: Option<&str>,
+    quiet: bool,
 ) -> Result<()> {
     use crate::cli::ImportFormat;
+    use std::io::IsTerminal;
 
-    println!("Importing data from: {}", file.display());
-    println!("Format: {format}, Target table: {table:?}");
+    // Issue #1506 / #284: progress + status chatter is suppressed under --quiet
+    // and when stdout is not a TTY. Genuine warnings/errors are still surfaced.
+    let show_progress = !quiet && std::io::stdout().is_terminal();
+
+    if show_progress {
+        println!("Importing data from: {}", file.display());
+        println!("Format: {format}, Target table: {table:?}");
+    }
 
     // Validate input file exists
     if !file.exists() {
@@ -51,25 +59,34 @@ pub async fn import_data(
         format!("SELECT table_name FROM system.tables WHERE table_name = '{target_table}'");
     match database.execute(&table_check_query).await {
         Ok(result) if result.rows.is_empty() => {
-            println!(
-                "⚠️  Warning: Table '{}' not found in system catalog. Assuming it exists or will be created during import.",
-                target_table
-            );
+            if show_progress {
+                println!(
+                    "⚠️  Warning: Table '{}' not found in system catalog. Assuming it exists or will be created during import.",
+                    target_table
+                );
+            }
         }
         Ok(_) => {
-            println!("✓ Target table '{target_table}' found");
+            if show_progress {
+                println!("✓ Target table '{target_table}' found");
+            }
         }
         Err(_) => {
-            println!(
-                "⚠️  Warning: Could not verify table existence (system tables may not be implemented). Proceeding with import..."
-            );
+            if show_progress {
+                println!(
+                    "⚠️  Warning: Could not verify table existence (system tables may not be implemented). Proceeding with import..."
+                );
+            }
         }
     }
 
     // Get table schema for validation
-    let table_columns = get_table_columns(database, &target_table).await
+    let table_columns = get_table_columns(database, &target_table)
+        .await
         .unwrap_or_else(|_| {
-            println!("⚠️  Warning: Could not retrieve table schema. Import may fail if column types don't match.");
+            if show_progress {
+                println!("⚠️  Warning: Could not retrieve table schema. Import may fail if column types don't match.");
+            }
             Vec::new()
         });
 
@@ -78,11 +95,14 @@ pub async fn import_data(
 
     match format {
         ImportFormat::Csv => {
-            _imported_rows = import_csv_data(database, file, &target_table, &table_columns).await?;
+            _imported_rows =
+                import_csv_data(database, file, &target_table, &table_columns, show_progress)
+                    .await?;
         }
         ImportFormat::Json => {
             _imported_rows =
-                import_json_data(database, file, &target_table, &table_columns).await?;
+                import_json_data(database, file, &target_table, &table_columns, show_progress)
+                    .await?;
         }
         ImportFormat::Parquet => {
             return Err(anyhow::anyhow!(
@@ -91,12 +111,14 @@ pub async fn import_data(
         }
     }
 
-    println!("\n📊 Import Summary:");
-    println!("  Rows imported: {_imported_rows}");
-    if error_count > 0 {
-        println!("  Errors: {error_count}");
+    if show_progress {
+        println!("\n📊 Import Summary:");
+        println!("  Rows imported: {_imported_rows}");
+        if error_count > 0 {
+            println!("  Errors: {error_count}");
+        }
+        println!("  ✅ Import completed successfully!");
     }
-    println!("  ✅ Import completed successfully!");
 
     Ok(())
 }
@@ -107,6 +129,7 @@ pub async fn import_data(
     _file: &Path,
     _format: crate::cli::ImportFormat,
     _table: Option<&str>,
+    _quiet: bool,
 ) -> Result<()> {
     Err(anyhow::anyhow!(
         "Data import is not available in M1.\n\
@@ -122,9 +145,9 @@ async fn import_csv_data(
     file: &Path,
     table: &str,
     table_columns: &[String],
+    show_progress: bool,
 ) -> Result<u64> {
     use csv::ReaderBuilder;
-    use indicatif::{ProgressBar, ProgressStyle};
 
     let file_handle =
         File::open(file).with_context(|| format!("Failed to open CSV file: {}", file.display()))?;
@@ -139,9 +162,11 @@ async fn import_csv_data(
         .with_context(|| "Failed to read CSV headers")?;
     let csv_columns: Vec<String> = headers.iter().map(|h| h.to_string()).collect();
 
-    println!("📋 CSV columns: {}", csv_columns.join(", "));
-    if !table_columns.is_empty() {
-        println!("📋 Table columns: {}", table_columns.join(", "));
+    if show_progress {
+        println!("📋 CSV columns: {}", csv_columns.join(", "));
+        if !table_columns.is_empty() {
+            println!("📋 Table columns: {}", table_columns.join(", "));
+        }
     }
 
     // Count total rows for progress
@@ -153,14 +178,10 @@ async fn import_csv_data(
         .has_headers(true)
         .from_reader(file_handle);
 
-    let pb = ProgressBar::new(total_rows);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template(
-                "Importing CSV [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} rows ({eta})",
-            )
-            .unwrap()
-            .progress_chars("=>-"),
+    let pb = make_bar(
+        total_rows,
+        "Importing CSV [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} rows ({eta})",
+        show_progress,
     );
 
     let mut imported_count = 0;
@@ -216,8 +237,8 @@ async fn import_json_data(
     file: &Path,
     table: &str,
     _table_columns: &[String],
+    show_progress: bool,
 ) -> Result<u64> {
-    use indicatif::{ProgressBar, ProgressStyle};
     use std::fs;
 
     let file_content = fs::read_to_string(file)
@@ -237,14 +258,14 @@ async fn import_json_data(
         }
     };
 
-    println!("📋 Found {} JSON objects to import", objects.len());
+    if show_progress {
+        println!("📋 Found {} JSON objects to import", objects.len());
+    }
 
-    let pb = ProgressBar::new(objects.len() as u64);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("Importing JSON [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} objects ({eta})")
-            .unwrap()
-            .progress_chars("=>-"),
+    let pb = make_bar(
+        objects.len() as u64,
+        "Importing JSON [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} objects ({eta})",
+        show_progress,
     );
 
     let mut imported_count = 0;
@@ -292,6 +313,26 @@ async fn import_json_data(
 
     pb.finish_with_message(format!("Imported {imported_count} objects from JSON"));
     Ok(imported_count)
+}
+
+/// Build an import progress bar honoring the #284 quiet/tty contract.
+///
+/// Returns a hidden bar when `show` is false (quiet mode or non-TTY). The
+/// `ProgressStyle::template(...)` result is handled without `unwrap()`/`expect()`:
+/// on a template error we fall back to indicatif's default bar style so the
+/// import still runs (the bar is cosmetic).
+#[cfg(feature = "state_machine")]
+fn make_bar(total: u64, template: &str, show: bool) -> indicatif::ProgressBar {
+    use indicatif::{ProgressBar, ProgressStyle};
+
+    if !show {
+        return ProgressBar::hidden();
+    }
+    let pb = ProgressBar::new(total);
+    if let Ok(style) = ProgressStyle::default_bar().template(template) {
+        pb.set_style(style.progress_chars("=>-"));
+    }
+    pb
 }
 
 /// Execute a batch of INSERT statements

--- a/cqlite-cli/src/commands/read_sstable.rs
+++ b/cqlite-cli/src/commands/read_sstable.rs
@@ -5,12 +5,14 @@ use anyhow::{Context, Result};
 use cqlite_core::types::{ScanRow, TableId};
 use cqlite_core::{storage::sstable::reader::SSTableReader, Config as CoreConfig, RowKey, Value};
 use indicatif::{ProgressBar, ProgressStyle};
+use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
 
 use crate::cli::OutputFormat;
 
 /// Execute the read-sstable command
+#[allow(clippy::too_many_arguments)]
 pub async fn execute_read_sstable_command(
     file_path: &Path,
     format: OutputFormat,
@@ -19,8 +21,16 @@ pub async fn execute_read_sstable_command(
     keys_only: bool,
     raw: bool,
     verbose: bool,
+    quiet: bool,
 ) -> Result<()> {
-    eprintln!("📖 Reading SSTable: {}", file_path.display());
+    // Issue #1506 / #284: progress + status chatter (stderr) is suppressed under
+    // --quiet and when stderr is not a TTY; the actual data output (stdout) is
+    // always emitted.
+    let show_status = !quiet && std::io::stderr().is_terminal();
+
+    if show_status {
+        eprintln!("📖 Reading SSTable: {}", file_path.display());
+    }
 
     // Validate file exists
     if !file_path.exists() {
@@ -30,8 +40,8 @@ pub async fn execute_read_sstable_command(
         ));
     }
 
-    // Create progress indicator
-    let pb = create_progress_bar("Opening SSTable");
+    // Create progress indicator (hidden when status output is suppressed)
+    let pb = create_progress_bar("Opening SSTable", show_status);
 
     // Initialize Platform and Config (following initialize_database pattern)
     let config = CoreConfig::default();
@@ -92,17 +102,21 @@ pub async fn execute_read_sstable_command(
     let displayed_count = display_entries.len();
 
     if displayed_count == 0 {
-        eprintln!(
-            "No entries to display (total: {}, skip: {})",
-            total_entries, skip
-        );
+        if show_status {
+            eprintln!(
+                "No entries to display (total: {}, skip: {})",
+                total_entries, skip
+            );
+        }
         return Ok(());
     }
 
-    eprintln!(
-        "Displaying {} of {} entries (skip: {})\n",
-        displayed_count, total_entries, skip
-    );
+    if show_status {
+        eprintln!(
+            "Displaying {} of {} entries (skip: {})\n",
+            displayed_count, total_entries, skip
+        );
+    }
 
     // Display based on format
     match format {
@@ -120,22 +134,32 @@ pub async fn execute_read_sstable_command(
         }
     }
 
-    eprintln!(
-        "\n✅ Displayed {} entries (total: {}, skipped: {})",
-        displayed_count, total_entries, skip
-    );
+    if show_status {
+        eprintln!(
+            "\n✅ Displayed {} entries (total: {}, skipped: {})",
+            displayed_count, total_entries, skip
+        );
+    }
 
     Ok(())
 }
 
-/// Create a progress bar for operations
-fn create_progress_bar(message: &str) -> ProgressBar {
+/// Create a progress bar for operations.
+///
+/// When `show` is false (quiet mode or non-TTY, per the #284 contract) a hidden
+/// bar is returned so no progress is drawn. The `ProgressStyle::template(...)`
+/// result is handled without `unwrap()`/`expect()`: on a template error we fall
+/// back to indicatif's default spinner style (the bar is cosmetic).
+fn create_progress_bar(message: &str, show: bool) -> ProgressBar {
+    if !show {
+        return ProgressBar::hidden();
+    }
     let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.green} [{elapsed_precise}] {msg}")
-            .expect("Failed to create progress bar template"),
-    );
+    if let Ok(style) =
+        ProgressStyle::default_spinner().template("{spinner:.green} [{elapsed_precise}] {msg}")
+    {
+        pb.set_style(style);
+    }
     pb.set_message(message.to_string());
     pb
 }

--- a/cqlite-cli/src/commands/read_sstable.rs
+++ b/cqlite-cli/src/commands/read_sstable.rs
@@ -75,8 +75,10 @@ pub async fn execute_read_sstable_command(
     let total_entries = entries.len();
     pb.finish_with_message(format!("✅ Read {} entries", total_entries));
 
-    // Show basic stats if verbose
-    if verbose {
+    // Show basic stats if verbose. Issue #1506 / #284: the verbose statistics
+    // block is status chatter on stderr, so `--quiet` wins over `--verbose` and
+    // suppresses it (gated behind `show_status`).
+    if verbose && show_status {
         let stats = reader.stats().await?;
         eprintln!("\n📊 SSTable Statistics:");
         eprintln!("  Total entries: {}", stats.entry_count);

--- a/cqlite-cli/src/commands/schema_load.rs
+++ b/cqlite-cli/src/commands/schema_load.rs
@@ -10,16 +10,39 @@ use cqlite_core::schema::{
 use std::collections::HashMap;
 use std::path::Path;
 
-/// Load schema from JSON or CQL file
+/// Load schema from JSON or CQL file.
+///
+/// Emits the "Loading schema…" status lines on stdout (legacy behavior). Handlers
+/// honoring the #284 quiet/tty contract should call
+/// [`load_schema_file_with_status`] instead so the status can be suppressed under
+/// `--quiet` / non-TTY.
 pub(crate) fn load_schema_file(
+    schema_path: &Path,
+    auto_detect: bool,
+    cassandra_version: Option<&str>,
+) -> Result<TableSchema> {
+    load_schema_file_with_status(schema_path, auto_detect, cassandra_version, true)
+}
+
+/// Like [`load_schema_file`], but suppresses the "Loading schema…" status lines
+/// when `show_status` is `false`.
+///
+/// Issue #1506 / #284: schema-loading status is non-essential chatter; a handler
+/// running under `--quiet` (or with a non-TTY stdout) passes `show_status = false`
+/// so no status is printed. The actual schema-loading behavior is unchanged — only
+/// the status-message emission is gated.
+pub(crate) fn load_schema_file_with_status(
     schema_path: &Path,
     _auto_detect: bool,
     _cassandra_version: Option<&str>,
+    show_status: bool,
 ) -> Result<TableSchema> {
     let schema_content = std::fs::read_to_string(schema_path)
         .with_context(|| format!("Failed to read schema file: {}", schema_path.display()))?;
 
-    println!("📋 Loading schema from: {}", schema_path.display());
+    if show_status {
+        println!("📋 Loading schema from: {}", schema_path.display());
+    }
 
     // Determine file type by extension
     let extension = schema_path
@@ -29,7 +52,9 @@ pub(crate) fn load_schema_file(
 
     match extension.to_lowercase().as_str() {
         "json" => {
-            println!("📝 Parsing JSON schema format");
+            if show_status {
+                println!("📝 Parsing JSON schema format");
+            }
             // Parse JSON schema
             let json_schema: serde_json::Value = serde_json::from_str(&schema_content)
                 .with_context(|| "Failed to parse JSON schema")?;
@@ -38,7 +63,9 @@ pub(crate) fn load_schema_file(
             parse_json_schema(&json_schema)
         }
         "cql" | "sql" | "" => {
-            println!("📝 Parsing CQL schema format");
+            if show_status {
+                println!("📝 Parsing CQL schema format");
+            }
             // Parse CQL schema
             parse_cql_schema(&schema_content).with_context(|| "Failed to parse CQL schema")
         }

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -690,6 +690,7 @@ async fn run_main() -> Result<()> {
                         false, // keys_only
                         false, // raw
                         cli.verbose > 0,
+                        cli.quiet,
                     )
                     .await;
                 }
@@ -890,7 +891,7 @@ async fn run_main() -> Result<()> {
             table,
             mapping: _,
             batch_size: _,
-        }) => commands::import_data(&database, &file, format, Some(&table)).await,
+        }) => commands::import_data(&database, &file, format, Some(&table), cli.quiet).await,
         Some(Commands::Export {
             file,
             format,
@@ -928,7 +929,7 @@ async fn run_main() -> Result<()> {
             verbose,
         }) => {
             commands::read_sstable::execute_read_sstable_command(
-                &file, format, limit, skip, keys_only, raw, verbose,
+                &file, format, limit, skip, keys_only, raw, verbose, cli.quiet,
             )
             .await
         }

--- a/cqlite-cli/tests/export_integration_tests.rs
+++ b/cqlite-cli/tests/export_integration_tests.rs
@@ -1098,6 +1098,7 @@ async fn test_export_sstable_to_parquet() {
         &schema_file,
         &output_file,
         ExportFormat::Parquet,
+        true, // quiet: suppress progress in tests
     )
     .await;
 

--- a/cqlite-cli/tests/issue_1506_progress_hygiene.rs
+++ b/cqlite-cli/tests/issue_1506_progress_hygiene.rs
@@ -136,6 +136,44 @@ fn test_read_sstable_quiet_suppresses_progress_preamble() {
     );
 }
 
+/// FINDING 2 (roborev, Low): `read-sstable --quiet --verbose` must NOT write the
+/// verbose SSTable statistics block to stderr — quiet wins over verbose for status
+/// output. Fails before the fix (the block is gated only on `verbose`) and passes
+/// after (`verbose && show_status`).
+#[test]
+fn test_read_sstable_quiet_verbose_suppresses_stats_block() {
+    let Some(data_db) = find_simple_table_data_db() else {
+        eprintln!("SKIP: no simple_table Data.db under datasets root");
+        return;
+    };
+
+    let output = run_cli_command(&[
+        "--quiet",
+        "read-sstable",
+        data_db.to_str().unwrap(),
+        "--verbose",
+        "--format",
+        "json",
+        "--limit",
+        "1",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "read-sstable --quiet --verbose should succeed. stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("SSTable Statistics")
+            && !stderr.contains("Total entries:")
+            && !stderr.contains("Compression ratio:"),
+        "read-sstable --quiet --verbose must suppress the verbose statistics block \
+         on stderr (quiet wins over verbose). Got:\n{stderr}"
+    );
+}
+
 #[test]
 fn test_import_quiet_suppresses_progress_preamble() {
     // Requires a valid data-dir + schema so the Database opens; the import
@@ -175,4 +213,72 @@ fn test_import_quiet_suppresses_progress_preamble() {
             && !stdout.contains("Import completed"),
         "import --quiet must emit no progress/status preamble on stdout. Got:\n{stdout}"
     );
+}
+
+// ============================================================================
+// (3) FINDING 1: export_sstable(quiet=true) suppresses schema-loading status
+// ============================================================================
+//
+// `export_sstable` is an internal library API with no CLI subcommand, so it
+// cannot be driven as a subprocess; and its schema-loading status is emitted via
+// `println!`, which Rust's test harness captures on a per-test thread-local
+// buffer (never on the process fd), so an in-process stdout-fd capture cannot
+// observe it. This regression is therefore locked down with a source-guard in
+// the same idiom as the `.template(` guard above: the handler must route schema
+// loading through the quiet-aware `load_schema_file_with_status(...)` gated on
+// its `show_progress` flag, and must NOT call the unconditional
+// `load_schema_file(...)` (which prints "Loading schema…" regardless of quiet).
+// Fails on `main` (unconditional call) and passes after the fix.
+
+#[test]
+fn test_export_sstable_schema_load_is_quiet_aware() {
+    let path = crate_root().join("src/commands/export_sstable.rs");
+    let src = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    let collapsed = src.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // Must use the quiet-aware loader gated on the handler's show_progress flag.
+    assert!(
+        collapsed.contains("load_schema_file_with_status(schema_path, false, None, show_progress)"),
+        "export_sstable must load its schema via \
+         load_schema_file_with_status(schema_path, false, None, show_progress) so schema \
+         status is suppressed under --quiet (#1506/#284)."
+    );
+
+    // Must NOT call the unconditional loader (which prints schema status regardless).
+    assert!(
+        !collapsed.contains("load_schema_file(schema_path"),
+        "export_sstable must not call the unconditional load_schema_file(...) \
+         (it prints schema-loading status even under --quiet); use \
+         load_schema_file_with_status(...) gated on show_progress instead."
+    );
+}
+
+/// The quiet-aware loader must actually gate every status `println!` behind its
+/// `show_status` flag (guards against a future edit that reintroduces an
+/// unconditional print inside the helper). Fails on `main` (no such helper /
+/// unconditional prints) and passes after the fix.
+#[test]
+fn test_schema_loader_gates_status_behind_show_status() {
+    let path = crate_root().join("src/commands/schema_load.rs");
+    let src = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    let collapsed = src.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        src.contains("fn load_schema_file_with_status(") && src.contains("show_status: bool"),
+        "schema_load must expose a load_schema_file_with_status(..., show_status: bool) helper (#1506)."
+    );
+
+    // Every schema-status println! must sit directly under an `if show_status {`
+    // guard so it is suppressed when the caller passes show_status=false.
+    for status in [
+        "if show_status { println!(\"📋 Loading schema",
+        "if show_status { println!(\"📝 Parsing JSON schema",
+        "if show_status { println!(\"📝 Parsing CQL schema",
+    ] {
+        assert!(
+            collapsed.contains(status),
+            "schema-loading status must be gated behind `if show_status` in \
+             schema_load.rs (#1506); missing guarded form for: {status}"
+        );
+    }
 }

--- a/cqlite-cli/tests/issue_1506_progress_hygiene.rs
+++ b/cqlite-cli/tests/issue_1506_progress_hygiene.rs
@@ -1,0 +1,178 @@
+//! Issue #1506 (epic #1471 hygiene, finding AF5): legacy subcommands must
+//! honor the #284 quiet/tty contract for progress output and must not call
+//! `.unwrap()`/`.expect()` on `ProgressStyle::template(...)`.
+//!
+//! Two guarantees are covered here:
+//!   1. A source grep-guard: none of the three legacy command modules build a
+//!      `ProgressStyle` template with `.unwrap()`/`.expect()` (they must use the
+//!      `if let Ok(style) = ...` fallback pattern from `commands/export.rs`).
+//!   2. Runtime: `--quiet` suppresses the progress/status preamble that the
+//!      `read-sstable` and `import` subcommands otherwise emit.
+//!
+//! Both fail on `main` (which panics-on-error and ignores `--quiet`) and pass
+//! after the fix.
+
+#![cfg(feature = "state_machine")]
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+/// Run the pre-built CLI binary, capturing stdout/stderr.
+fn run_cli_command(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_cqlite"))
+        .args(args)
+        .output()
+        .expect("Failed to execute CLI command")
+}
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn datasets_root() -> PathBuf {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| crate_root().parent().unwrap().join("test-data/datasets"))
+}
+
+fn schemas_dir() -> PathBuf {
+    crate_root().parent().unwrap().join("test-data/schemas")
+}
+
+/// Locate a concrete `*-Data.db` file under `test_basic/simple_table-*`, or
+/// return `None` when the binary dataset is not present (test then skips).
+fn find_simple_table_data_db() -> Option<PathBuf> {
+    let dir = datasets_root().join("sstables/test_basic");
+    let entries = fs::read_dir(&dir).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("simple_table-") {
+            continue;
+        }
+        let sub = fs::read_dir(entry.path()).ok()?;
+        for f in sub.flatten() {
+            let fname = f.file_name();
+            let fname = fname.to_string_lossy();
+            if fname.ends_with("Data.db") {
+                return Some(f.path());
+            }
+        }
+    }
+    None
+}
+
+// ============================================================================
+// (1) Source grep-guard: no unwrap()/expect() on ProgressStyle::template(...)
+// ============================================================================
+
+/// For each `.template(` occurrence in `path`, assert the enclosing statement
+/// (up to the next `;`) does not call `.unwrap()`/`.expect(` on the builder.
+fn assert_no_template_unwrap(rel: &str) {
+    let path = crate_root().join(rel);
+    let src = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    // Collapse whitespace so multi-line builder chains scan as one line.
+    let collapsed = src.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    let mut from = 0usize;
+    while let Some(rel_idx) = collapsed[from..].find(".template(") {
+        let start = from + rel_idx;
+        let end = collapsed[start..]
+            .find(';')
+            .map(|i| start + i)
+            .unwrap_or(collapsed.len());
+        let stmt = &collapsed[start..end];
+        assert!(
+            !stmt.contains(".unwrap()") && !stmt.contains(".expect("),
+            "{rel}: ProgressStyle template must not use unwrap()/expect(); \
+             use the `if let Ok(style) = ...` fallback from commands/export.rs. \
+             Offending statement: {stmt}"
+        );
+        from = end;
+    }
+}
+
+#[test]
+fn test_no_progressstyle_unwrap_in_legacy_commands() {
+    assert_no_template_unwrap("src/commands/read_sstable.rs");
+    assert_no_template_unwrap("src/commands/export_sstable.rs");
+    assert_no_template_unwrap("src/commands/import.rs");
+}
+
+// ============================================================================
+// (2) Runtime: --quiet suppresses the progress/status preamble
+// ============================================================================
+
+#[test]
+fn test_read_sstable_quiet_suppresses_progress_preamble() {
+    let Some(data_db) = find_simple_table_data_db() else {
+        eprintln!("SKIP: no simple_table Data.db under datasets root");
+        return;
+    };
+
+    let output = run_cli_command(&[
+        "--quiet",
+        "read-sstable",
+        data_db.to_str().unwrap(),
+        "--format",
+        "json",
+        "--limit",
+        "1",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "read-sstable --quiet should succeed. stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Reading SSTable")
+            && !stderr.contains("Displaying")
+            && !stderr.contains("Displayed"),
+        "read-sstable --quiet must emit no progress/status preamble on stderr. Got:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_import_quiet_suppresses_progress_preamble() {
+    // Requires a valid data-dir + schema so the Database opens; the import
+    // itself may warn on individual inserts (read-only db) — we only assert the
+    // progress/status preamble is gone under --quiet.
+    let data_dir = datasets_root().join("sstables");
+    let schema_file = schemas_dir().join("basic-types.cql");
+    if !data_dir.exists() || !schema_file.exists() {
+        eprintln!("SKIP: dataset/schema not present");
+        return;
+    }
+
+    let tmp = std::env::temp_dir().join("cqlite_issue_1506_import.csv");
+    fs::write(&tmp, "id,name\n1,alice\n").expect("write temp csv");
+
+    let output = run_cli_command(&[
+        "--quiet",
+        "--schema",
+        schema_file.to_str().unwrap(),
+        "--data-dir",
+        data_dir.to_str().unwrap(),
+        "import",
+        tmp.to_str().unwrap(),
+        "--format",
+        "csv",
+        "--table",
+        "test_basic.simple_table",
+    ]);
+
+    let _ = fs::remove_file(&tmp);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Importing data from:")
+            && !stdout.contains("Import Summary")
+            && !stdout.contains("CSV columns")
+            && !stdout.contains("Import completed"),
+        "import --quiet must emit no progress/status preamble on stdout. Got:\n{stdout}"
+    );
+}

--- a/cqlite-cli/tests/issue_1506_progress_hygiene.rs
+++ b/cqlite-cli/tests/issue_1506_progress_hygiene.rs
@@ -205,6 +205,17 @@ fn test_import_quiet_suppresses_progress_preamble() {
 
     let _ = fs::remove_file(&tmp);
 
+    // Assert the command actually reached (and completed) the import path before
+    // checking for absence of the preamble. `import_data` returns Ok even when
+    // individual inserts warn (read-only db), so a success exit means we ran the
+    // import — without this, an early command failure (which also emits no
+    // preamble) would pass the suppression checks vacuously (#1506 roborev Low).
+    assert!(
+        output.status.success(),
+        "import --quiet should reach the import path and exit successfully. stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stdout.contains("Importing data from:")

--- a/cqlite-core/src/export/arrow_convert.rs
+++ b/cqlite-core/src/export/arrow_convert.rs
@@ -19,7 +19,7 @@
 //! | date              | `Date32`                              | Signed days since 1970-01-01      |
 //! | time              | `Time64(Nanosecond)`                  | Nanos since midnight              |
 //! | decimal           | `Decimal128(38, DECIMAL_FIXED_SCALE)` | Rescaled; see strategy below      |
-//! | varint            | `Decimal128(38, 0)` or `Utf8`         | `Utf8` fallback on overflow       |
+//! | varint            | `Decimal128(38, 0)`                   | Err on >38-digit overflow (fail-closed, never Utf8) |
 //! | duration          | `Utf8` (CQL text form)                | Parquet crate v53 NYI MonthDayNano|
 //! | uuid/timeuuid     | `FixedSizeBinary(16)` + UUID ext      | Arrow UUID extension metadata     |
 //! | inet              | `Utf8`                                | Canonical textual form (deliberate)|


### PR DESCRIPTION
Integration branch for three independent oracle-driven P0 bug fixes (disjoint files, single serial full gate per #1116 fleet→integration pattern).

Closes #1463
Closes #1489
Closes #1506

## #1463 — Python bindings: integer-exact timestamp→datetime + export_parquet streaming config
- `timestamp_to_datetime` uses `epoch(0,utc)+timedelta(milliseconds=millis)` (integer-exact, no float drift).
- `export_parquet` gains optional `config=None` param.

## #1489 — delta-export: fail-closed bare-CREATE-TABLE schema guard + varint overflow doc
- `ensure_bare_create_table_schema` enforces **exactly one** statement classified as `CREATE TABLE` (rejects 0 statements, >1 statements, or a single non-CREATE-TABLE statement) with a single targeted error, instead of the opaque downstream parser error.
- varint overflow documentation on the arrow-convert path.

## #1506 — CLI progress/quiet hygiene
- No-`unwrap()` `ProgressStyle::template` (`if let Ok(style)` fallback).
- `show_progress = !quiet && stream.is_terminal()` across read-sstable/import/export-sstable.
- Quiet suppresses schema-loading status (`load_schema_file_with_status`) and the verbose stats block (`verbose && show_status`).

## Validation
- **Full agent-gate.sh: RESULT: PASS** at `a20af540` (22/22 components green; core-tests 568s serial-nextest).
- **Delta re-cert: RESULT: PASS** at `aca1d6a3` (test-only assertion add, `--delta a20af540`).
- roborev (codex): all findings resolved (Medium export-sstable schema quiet-leak, Low read-sstable verbose block, Low vacuous-pass test assertion).
