### PR TITLE
perf(H): #1616 struct-size pins + #1618 parser work-counters (Epic H measurement infra)

### DIFF
--- a/cqlite-core/src/storage/sstable/bti/node.rs
+++ b/cqlite-core/src/storage/sstable/bti/node.rs
@@ -108,6 +108,15 @@ pub struct SizedPointer {
     pub size: u8,
 }
 
+// Struct-size regression guard (issue #1616, Epic H/H3; see
+// docs/reports/parser-performance-audit-2026-07-01.md §Epic H (finding H3)). BTI trie
+// pointer decoded once per transition during partition lookup on the read hot
+// path. Measured 16 bytes today (u64 + u8, padded) on 64-bit targets. Update
+// this pin DELIBERATELY, never silently: any change — growth or shrink — must
+// be a reviewed edit here.
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<SizedPointer>() == 16);
+
 impl SizedPointer {
     /// Create a new sized pointer
     pub fn new(distance: u64) -> Self {
@@ -166,6 +175,15 @@ pub struct Transition {
     pub child: SizedPointer,
 }
 
+// Struct-size regression guard (issue #1616, Epic H/H3; see
+// docs/reports/parser-performance-audit-2026-07-01.md §Epic H (finding H3)). One BTI
+// `Transition` is decoded per trie edge walked during partition lookup on the
+// read hot path. Measured 24 bytes today (u8 + `SizedPointer`, padded) on
+// 64-bit targets. Update this pin DELIBERATELY, never silently: any change —
+// growth or shrink — must be a reviewed edit here.
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<Transition>() == 24);
+
 impl Transition {
     pub fn new(byte: u8, child: SizedPointer) -> Self {
         Self { byte, child }
@@ -182,6 +200,15 @@ pub struct PayloadRef {
     /// Optional checksum for validation
     pub checksum: Option<u32>,
 }
+
+// Struct-size regression guard (issue #1616, Epic H/H3; see
+// docs/reports/parser-performance-audit-2026-07-01.md §Epic H (finding H3)). One BTI
+// `PayloadRef` is produced per matched leaf during partition lookup on the read
+// hot path. Measured 24 bytes today (u64 + u32 + Option<u32>, padded) on 64-bit
+// targets. Update this pin DELIBERATELY, never silently: any change — growth or
+// shrink — must be a reviewed edit here.
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<PayloadRef>() == 24);
 
 impl PayloadRef {
     pub fn new(offset: u64, length: u32) -> Self {

--- a/cqlite-core/src/storage/sstable/bti/parser/node_decode.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/node_decode.rs
@@ -303,6 +303,9 @@ fn dense_child(offset: u64, delta: u64) -> Option<SizedPointer> {
 /// node-type nibble is out of range, or any other structural invariant is
 /// violated.
 pub(crate) fn parse_bti_node(data: &[u8], offset: u64) -> BtiResult<BtiNode> {
+    // Issue #1618 (H5): count every node/pointer decode (L1/L3: pairs with
+    // BTI_NODES_VISITED to prove the descent does not re-decode nodes).
+    crate::storage::sstable::read_work_counters::record_bti_pointer_decode();
     if data.is_empty() {
         return Err(Error::Parse("Empty BTI node data".to_string()));
     }

--- a/cqlite-core/src/storage/sstable/bti/parser/traversal.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/traversal.rs
@@ -226,6 +226,8 @@ where
         }
 
         nodes_visited = nodes_visited.saturating_add(1);
+        // Issue #1618 (H5): count every node the DFS enters (L1/L3: <40 nodes visited).
+        crate::storage::sstable::read_work_counters::record_bti_node_visited();
         if nodes_visited > trie_data.len() {
             return Err(Error::Parse(format!(
                 "BTI DFS exceeded total work bound ({nodes_visited} nodes visited > \

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -67,6 +67,37 @@
 //!   to bound fd growth. It is a *sample*, not an atomic — wrapping every
 //!   `open`/`close` to keep a live count is invasive and racy; sampling at a test
 //!   checkpoint is what the guard actually needs.
+//!
+//! # Parser work counters (Issue #1618, Epic H / H5)
+//!
+//! H5 lands the *parser* gauges the audit (`§Epic H`, block 2) needs so epics
+//! J1/K2/K3/L1/L3 can assert their claims ("zero `to_lowercase` per cell", "one
+//! header try-parse per partition", "<40 BTI nodes visited"). Same cfg-gated,
+//! zero-in-release pattern as the A5 counters above:
+//!
+//! - [`record_type_normalize`] / [`type_normalize_calls`] — **`TYPE_NORMALIZE_CALLS`**:
+//!   one per `data_type.to_lowercase()` in the per-cell decode path — the value-parse
+//!   normalization (`v5_compressed_legacy/cell_value.rs`) and the per-column
+//!   complex-check (`v5_compressed_legacy/udt.rs::is_complex_column`). Consumer **J1**
+//!   (zero `to_lowercase` per cell): flips its assertion to `== 0` once the type name
+//!   is normalized once at schema-load, not per cell.
+//! - [`record_partition_header_try_parse`] / [`partition_header_try_parses`] —
+//!   **`PARTITION_HEADER_TRY_PARSES`**: one per speculative partition-header parse
+//!   (`v5_compressed_legacy/row_framing.rs::parse_partition_header_full`, the single
+//!   boundary-peek/try-parse primitive every emit path routes through). Consumer
+//!   **K2/K3** (one try-parse per partition): flips to an exact per-partition bound.
+//! - [`record_bti_node_visited`] / [`bti_nodes_visited`] — **`BTI_NODES_VISITED`**:
+//!   one per node the BTI DFS enters (`bti/parser/traversal.rs`). Consumer **L1/L3**
+//!   (<40 BTI nodes visited): flips to the bounded-descent count.
+//! - [`record_bti_pointer_decode`] / [`bti_pointer_decodes`] — **`BTI_POINTER_DECODES`**:
+//!   one per BTI node/pointer decode (`bti/parser/node_decode.rs::parse_bti_node`).
+//!   Consumer **L1/L3**: pairs with `BTI_NODES_VISITED` to prove the descent does not
+//!   re-decode nodes.
+//! - [`record_row_sort`] / [`row_sort_invocations`] — **`ROW_SORT_INVOCATIONS`**:
+//!   one per per-row cell `sort_by` at the shared display-row builder
+//!   (`v5_compressed_legacy/mod.rs::build_display_row`, which #1334 consolidated the
+//!   former `block_emit`/`block_emit_windowed` sort sites into). Consumer **K2/L**:
+//!   flips to prove cells arrive pre-sorted (no per-row sort).
 
 // The atomics, the process-global, the struct methods, the getters, and `reset`
 // exist ONLY in test/feature builds — a release build links none of them, which is
@@ -109,6 +140,19 @@ struct Counters {
     /// undercounts the full copy chain. Wiring those sites (and the ≤1-alloc/chunk
     /// reduction they measure) is the A4 work deferred to issue #1940.
     chunk_path_allocs: AtomicU64,
+    /// `data_type.to_lowercase()` calls in the per-cell decode path
+    /// (`TYPE_NORMALIZE_CALLS`, Issue #1618) — consumer J1.
+    type_normalize_calls: AtomicU64,
+    /// Speculative partition-header parses (`PARTITION_HEADER_TRY_PARSES`,
+    /// Issue #1618) — consumers K2/K3.
+    partition_header_try_parses: AtomicU64,
+    /// BTI DFS node entries (`BTI_NODES_VISITED`, Issue #1618) — consumers L1/L3.
+    bti_nodes_visited: AtomicU64,
+    /// BTI node/pointer decodes (`BTI_POINTER_DECODES`, Issue #1618) — consumers L1/L3.
+    bti_pointer_decodes: AtomicU64,
+    /// Per-row cell `sort_by` invocations (`ROW_SORT_INVOCATIONS`, Issue #1618) —
+    /// consumers K2/L.
+    row_sort_invocations: AtomicU64,
 }
 
 #[cfg(any(test, feature = "work-counters"))]
@@ -121,6 +165,11 @@ impl Counters {
             file_opens: AtomicU64::new(0),
             read_calls: AtomicU64::new(0),
             chunk_path_allocs: AtomicU64::new(0),
+            type_normalize_calls: AtomicU64::new(0),
+            partition_header_try_parses: AtomicU64::new(0),
+            bti_nodes_visited: AtomicU64::new(0),
+            bti_pointer_decodes: AtomicU64::new(0),
+            row_sort_invocations: AtomicU64::new(0),
         }
     }
 
@@ -148,6 +197,27 @@ impl Counters {
         self.chunk_path_allocs.fetch_add(1, Ordering::Relaxed);
     }
 
+    fn record_type_normalize(&self) {
+        self.type_normalize_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_partition_header_try_parse(&self) {
+        self.partition_header_try_parses
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_bti_node_visited(&self) {
+        self.bti_nodes_visited.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_bti_pointer_decode(&self) {
+        self.bti_pointer_decodes.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_row_sort(&self) {
+        self.row_sort_invocations.fetch_add(1, Ordering::Relaxed);
+    }
+
     fn trie_walks(&self) -> u64 {
         self.trie_walks.load(Ordering::Relaxed)
     }
@@ -172,6 +242,26 @@ impl Counters {
         self.chunk_path_allocs.load(Ordering::Relaxed)
     }
 
+    fn type_normalize_calls(&self) -> u64 {
+        self.type_normalize_calls.load(Ordering::Relaxed)
+    }
+
+    fn partition_header_try_parses(&self) -> u64 {
+        self.partition_header_try_parses.load(Ordering::Relaxed)
+    }
+
+    fn bti_nodes_visited(&self) -> u64 {
+        self.bti_nodes_visited.load(Ordering::Relaxed)
+    }
+
+    fn bti_pointer_decodes(&self) -> u64 {
+        self.bti_pointer_decodes.load(Ordering::Relaxed)
+    }
+
+    fn row_sort_invocations(&self) -> u64 {
+        self.row_sort_invocations.load(Ordering::Relaxed)
+    }
+
     fn reset(&self) {
         self.trie_walks.store(0, Ordering::Relaxed);
         self.decompress_calls.store(0, Ordering::Relaxed);
@@ -179,6 +269,11 @@ impl Counters {
         self.file_opens.store(0, Ordering::Relaxed);
         self.read_calls.store(0, Ordering::Relaxed);
         self.chunk_path_allocs.store(0, Ordering::Relaxed);
+        self.type_normalize_calls.store(0, Ordering::Relaxed);
+        self.partition_header_try_parses.store(0, Ordering::Relaxed);
+        self.bti_nodes_visited.store(0, Ordering::Relaxed);
+        self.bti_pointer_decodes.store(0, Ordering::Relaxed);
+        self.row_sort_invocations.store(0, Ordering::Relaxed);
     }
 }
 
@@ -261,6 +356,66 @@ pub fn record_chunk_path_alloc() {
     COUNTERS.record_chunk_path_alloc();
 }
 
+/// Record one `data_type.to_lowercase()` in the per-cell decode path
+/// (`TYPE_NORMALIZE_CALLS`; consumer J1, Issue #1618).
+///
+/// Called unconditionally at each per-cell type-name normalization site (the
+/// value-parse normalization in `v5_compressed_legacy/cell_value.rs` and the
+/// per-column complex-check `is_complex_column` in `v5_compressed_legacy/udt.rs`);
+/// the body compiles to a no-op in a release build (design.md Decision 1).
+#[inline(always)]
+pub fn record_type_normalize() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_type_normalize();
+}
+
+/// Record one speculative partition-header parse (`PARTITION_HEADER_TRY_PARSES`;
+/// consumers K2/K3, Issue #1618).
+///
+/// Called unconditionally at the single boundary-peek/try-parse primitive
+/// (`v5_compressed_legacy/row_framing.rs::parse_partition_header_full`) every emit
+/// path routes through; the body compiles to a no-op in a release build.
+#[inline(always)]
+pub fn record_partition_header_try_parse() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_partition_header_try_parse();
+}
+
+/// Record one BTI DFS node entry (`BTI_NODES_VISITED`; consumers L1/L3, Issue #1618).
+///
+/// Called unconditionally once per node the BTI depth-first walk enters
+/// (`bti/parser/traversal.rs`); the body compiles to a no-op in a release build.
+#[inline(always)]
+pub fn record_bti_node_visited() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_bti_node_visited();
+}
+
+/// Record one BTI node/pointer decode (`BTI_POINTER_DECODES`; consumers L1/L3,
+/// Issue #1618).
+///
+/// Called unconditionally at the single node-decode entry
+/// (`bti/parser/node_decode.rs::parse_bti_node`); the body compiles to a no-op in a
+/// release build.
+#[inline(always)]
+pub fn record_bti_pointer_decode() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_bti_pointer_decode();
+}
+
+/// Record one per-row cell `sort_by` (`ROW_SORT_INVOCATIONS`; consumers K2/L,
+/// Issue #1618).
+///
+/// Called unconditionally at the shared display-row builder's sort
+/// (`v5_compressed_legacy/mod.rs::build_display_row`, into which #1334 consolidated
+/// the former `block_emit`/`block_emit_windowed` per-row sort sites); the body
+/// compiles to a no-op in a release build.
+#[inline(always)]
+pub fn record_row_sort() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_row_sort();
+}
+
 /// Number of BTI trie descents since the last [`reset`] (`TRIE_WALKS`).
 #[cfg(any(test, feature = "work-counters"))]
 pub fn trie_walks() -> u64 {
@@ -298,6 +453,41 @@ pub fn read_calls() -> u64 {
 #[cfg(any(test, feature = "work-counters"))]
 pub fn chunk_path_allocs() -> u64 {
     COUNTERS.chunk_path_allocs()
+}
+
+/// Number of per-cell `data_type.to_lowercase()` calls since the last [`reset`]
+/// (`TYPE_NORMALIZE_CALLS`, Issue #1618).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn type_normalize_calls() -> u64 {
+    COUNTERS.type_normalize_calls()
+}
+
+/// Number of speculative partition-header parses since the last [`reset`]
+/// (`PARTITION_HEADER_TRY_PARSES`, Issue #1618).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn partition_header_try_parses() -> u64 {
+    COUNTERS.partition_header_try_parses()
+}
+
+/// Number of BTI DFS node entries since the last [`reset`] (`BTI_NODES_VISITED`,
+/// Issue #1618).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn bti_nodes_visited() -> u64 {
+    COUNTERS.bti_nodes_visited()
+}
+
+/// Number of BTI node/pointer decodes since the last [`reset`]
+/// (`BTI_POINTER_DECODES`, Issue #1618).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn bti_pointer_decodes() -> u64 {
+    COUNTERS.bti_pointer_decodes()
+}
+
+/// Number of per-row cell `sort_by` invocations since the last [`reset`]
+/// (`ROW_SORT_INVOCATIONS`, Issue #1618).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn row_sort_invocations() -> u64 {
+    COUNTERS.row_sort_invocations()
 }
 
 /// Clear all four process-global counters. Integration tests call this before a
@@ -389,6 +579,23 @@ mod tests {
         c.record_chunk_path_alloc();
         c.record_chunk_path_alloc();
         c.record_chunk_path_alloc();
+        // Issue #1618 parser counters: distinct multiplicities so a mis-wired
+        // getter/field cross-up is caught.
+        for _ in 0..7 {
+            c.record_type_normalize();
+        }
+        for _ in 0..8 {
+            c.record_partition_header_try_parse();
+        }
+        for _ in 0..9 {
+            c.record_bti_node_visited();
+        }
+        for _ in 0..10 {
+            c.record_bti_pointer_decode();
+        }
+        for _ in 0..11 {
+            c.record_row_sort();
+        }
 
         assert_eq!(c.trie_walks(), 1);
         assert_eq!(c.decompress_calls(), 2);
@@ -396,6 +603,11 @@ mod tests {
         assert_eq!(c.file_opens(), 4);
         assert_eq!(c.read_calls(), 5);
         assert_eq!(c.chunk_path_allocs(), 6);
+        assert_eq!(c.type_normalize_calls(), 7);
+        assert_eq!(c.partition_header_try_parses(), 8);
+        assert_eq!(c.bti_nodes_visited(), 9);
+        assert_eq!(c.bti_pointer_decodes(), 10);
+        assert_eq!(c.row_sort_invocations(), 11);
 
         c.reset();
         assert_eq!(c.trie_walks(), 0);
@@ -404,6 +616,11 @@ mod tests {
         assert_eq!(c.file_opens(), 0);
         assert_eq!(c.read_calls(), 0);
         assert_eq!(c.chunk_path_allocs(), 0);
+        assert_eq!(c.type_normalize_calls(), 0);
+        assert_eq!(c.partition_header_try_parses(), 0);
+        assert_eq!(c.bti_nodes_visited(), 0);
+        assert_eq!(c.bti_pointer_decodes(), 0);
+        assert_eq!(c.row_sort_invocations(), 0);
     }
 
     // The fd high-water helper returns a positive count on the supported platforms

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
@@ -245,6 +245,8 @@ impl V5CompressedLegacyParser {
         // Parse based on column type (data_type is a String with CQL type name)
         // CRITICAL: Normalize type name to lowercase for case-insensitive matching
         // Schema may provide "TEXT", "INT", etc. (uppercase) while match arms use lowercase
+        // Issue #1618 (H5): measure the per-cell type normalization work (J1 flips to 0).
+        crate::storage::sstable::read_work_counters::record_type_normalize();
         let normalized_type = column.data_type.to_lowercase();
         let value = match normalized_type.as_str() {
             "boolean" => {

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/cell_value.rs
@@ -212,6 +212,19 @@ impl V5CompressedLegacyParser {
             ));
         }
 
+        // Normalize the declared type name to lowercase ONCE, here — after the
+        // tombstone early-return (which never inspects the type) and BEFORE the
+        // empty/live split below. The schema may provide "TEXT", "INT", etc.
+        // (uppercase) while the match arms use lowercase, so a NON-tombstone cell
+        // always needs this normalization; doing it once removes the redundant
+        // per-cell `to_lowercase()` the empty path used to allocate separately.
+        // Issue #1618 (H5, roborev undercount fix): record the work-counter at
+        // this single site so it covers the empty-cell path too (previously the
+        // empty path allocated a `to_lowercase()` that went uncounted, so a future
+        // J1 `== 0` assertion could pass while the hot-path allocation still ran).
+        crate::storage::sstable::read_work_counters::record_type_normalize();
+        let normalized_type = column.data_type.to_lowercase();
+
         // Handle empty cells (no value bytes to read)
         if !has_value {
             log::debug!(
@@ -224,7 +237,7 @@ impl V5CompressedLegacyParser {
             // text/ascii/varchar is `Text("")`. Mirrors the clustering-key EMPTY
             // handling above; fixed-width types should not normally carry an empty
             // value, so treat that as NULL with a warning.
-            let empty_value = match column.data_type.to_lowercase().as_str() {
+            let empty_value = match normalized_type.as_str() {
                 "text" | "varchar" | "ascii" => Value::Text(String::new()),
                 "blob" => Value::Blob(Vec::new()),
                 _ => {
@@ -242,12 +255,9 @@ impl V5CompressedLegacyParser {
         // At this point, we have a live cell with value data
         // The value parsing logic below is unchanged from the original implementation
 
-        // Parse based on column type (data_type is a String with CQL type name)
-        // CRITICAL: Normalize type name to lowercase for case-insensitive matching
-        // Schema may provide "TEXT", "INT", etc. (uppercase) while match arms use lowercase
-        // Issue #1618 (H5): measure the per-cell type normalization work (J1 flips to 0).
-        crate::storage::sstable::read_work_counters::record_type_normalize();
-        let normalized_type = column.data_type.to_lowercase();
+        // Parse based on column type (data_type is a String with CQL type name).
+        // `normalized_type` was computed (and counted) once above, before the
+        // empty/live split — the match arms use its lowercase form.
         let value = match normalized_type.as_str() {
             "boolean" => {
                 // Boolean: [0x08][u8 value]

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -660,6 +660,9 @@ fn build_display_row(
         // Issue #1334: carry the interned `Arc<str>` name handles straight into
         // the row carrier; emit-time alphabetical ordering preserved exactly.
         let mut row_cells: RowCells = cells.into_iter().collect();
+        // Issue #1618 (H5): count the per-row cell sort — the shared site #1334
+        // consolidated the former block_emit/block_emit_windowed sorts into (K2/L).
+        crate::storage::sstable::read_work_counters::record_row_sort();
         row_cells.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
         ScanRow::Row(row_cells)
     }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -322,6 +322,15 @@ pub enum ParseStep {
     Done,
 }
 
+// Struct-size regression guard (issue #1616, Epic H/H3; see
+// docs/reports/parser-performance-audit-2026-07-01.md §Epic H (finding H3)). `ParseStep`
+// is returned once per partition by the bounded compaction-read driver on the
+// scan hot path. Measured 16 bytes today (discriminant + inlined `usize`) on
+// 64-bit targets. Update this pin DELIBERATELY, never silently: any change —
+// growth or shrink — must be a reviewed edit here.
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<ParseStep>() == 16);
+
 /// Row header data extracted from V5CompressedLegacy row
 #[derive(Debug, Clone)]
 struct RowHeader {

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
@@ -681,6 +681,9 @@ impl V5CompressedLegacyParser {
         data: &[u8],
         mut offset: usize,
     ) -> Result<(RowKey, usize, Option<(i64, i32)>)> {
+        // Issue #1618 (H5): count every speculative partition-header parse — the
+        // boundary-peek/try-parse primitive every emit path routes through (K2/K3).
+        crate::storage::sstable::read_work_counters::record_partition_header_try_parse();
         let start_offset = offset;
 
         if offset >= data.len() {

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/udt.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/udt.rs
@@ -1185,6 +1185,8 @@ impl V5CompressedLegacyParser {
     /// Issue #221: This is critical for proper parsing - complex columns have
     /// a different format: [complex_deletion_time?] [cell_count] [cells...]
     pub(super) fn is_complex_column(data_type: &str) -> bool {
+        // Issue #1618 (H5): measure the per-column type normalization work (J1 flips to 0).
+        crate::storage::sstable::read_work_counters::record_type_normalize();
         let dt = data_type.to_lowercase();
         // Non-frozen collections start directly with list/set/map (CQL syntax)
         // or org.apache.cassandra.db.marshal.ListType/SetType/MapType (internal syntax)

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -198,6 +198,15 @@ pub(crate) struct ScanCursor {
     pub(crate) chunk_index: AtomicUsize,
 }
 
+// Struct-size regression guard (issue #1616, Epic H/H3; see
+// docs/reports/parser-performance-audit-2026-07-01.md §Epic H (finding H3)). One
+// `ScanCursor` is allocated per concurrent full scan (issue #815), so its
+// footprint is on the read hot path. Measured 16 bytes today (Arc pointer +
+// AtomicUsize) on 64-bit targets. Update this pin DELIBERATELY, never silently:
+// any change — growth or shrink — must be a reviewed edit here.
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<ScanCursor>() == 16);
+
 impl ScanCursor {
     /// Wrap a freshly-minted source as a scan cursor positioned at chunk 0.
     pub(crate) fn new(source: BlockSource) -> Self {

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -88,6 +88,11 @@ pub enum Value {
 // bytes today; Epic E #1517 E1 shrinks the three inlined rare variants (Decimal,
 // Duration, the widest inline payload) toward <= 40. If Value grows past this,
 // the build fails — measure and tighten, do not just bump.
+//
+// Epic H/H3 (issue #1616) deliberately does NOT duplicate this `Value` pin —
+// the parser-side struct-size guards live next to their own types
+// (ComparatorType, ParseStep, ScanCursor, and the BTI SizedPointer/Transition/
+// PayloadRef). This assertion remains the single owner of the `Value` layout.
 const _: () = assert!(std::mem::size_of::<Value>() <= 88);
 
 /// Ordered interned cells of a single decoded row (issue #1334).

--- a/cqlite-core/src/types/comparator.rs
+++ b/cqlite-core/src/types/comparator.rs
@@ -68,6 +68,16 @@ pub enum ComparatorType {
     Custom(String),
 }
 
+// Struct-size regression guard (issue #1616, Epic H/H3; see
+// docs/reports/parser-performance-audit-2026-07-01.md §Epic H (finding H3)).
+// `ComparatorType` is constructed per column during schema-aware decode and
+// clustering-key comparison on the read hot path; its widest variant (`Udt`)
+// sets the layout. Measured 72 bytes today on 64-bit targets. Update this pin
+// DELIBERATELY, never silently: any change — growth or shrink — must be a
+// reviewed edit here.
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<ComparatorType>() == 72);
+
 impl ComparatorType {
     /// Create a ComparatorType from a CqlType
     pub fn from_cql_type(cql_type: &CqlType) -> Result<Self> {

--- a/cqlite-core/tests/issue_1618_parser_work_counters.rs
+++ b/cqlite-core/tests/issue_1618_parser_work_counters.rs
@@ -177,6 +177,83 @@ async fn scan_normalizes_type_per_cell() {
     );
 }
 
+/// Scenario (issue #1618 roborev undercount fix): the empty-value cell path must
+/// count its per-cell type normalization too. `test_types/nb_null_empty_text_blob`
+/// row `ck=4` writes an empty `text` (`''`) and an empty `blob` (`0x`) — both take
+/// the `HAS_EMPTY_VALUE` early-return in `parse_cell_value_schema_order`, which
+/// still `to_lowercase()`-normalizes the declared type. Before the fix that
+/// normalization allocation ran UNCOUNTED (the counter only fired on the live-cell
+/// path AFTER the empty early-return), so a future J1 `== 0` assertion could pass
+/// while the hot-path allocation still happened. The fix normalizes once before
+/// the empty/live split and records the counter at that single site, so both empty
+/// cells are now counted.
+///
+/// Pinned counts for this 4-row fixture (deterministic parse):
+///   - post-fix `TYPE_NORMALIZE_CALLS` = **29**
+///   - pre-fix it was **27** — exactly `empty_simple` (=2) lower, because the two
+///     empty simple cells in `ck=4` went uncounted. This assertion therefore fails
+///     on the pre-fix undercount and passes after.
+#[tokio::test]
+#[serial]
+async fn scan_counts_empty_cell_type_normalization() {
+    if !fixture_data_present("test_types", "nb_null_empty_text_blob") {
+        eprintln!("Skipping (H5 wiring): test_types/nb_null_empty_text_blob not present");
+        return;
+    }
+    let Some(db) = setup("test_types", "cql-type-parity.cql").await else {
+        eprintln!("Skipping (H5 wiring): could not ingest test_types");
+        return;
+    };
+
+    rwc::reset();
+    assert_eq!(
+        rwc::type_normalize_calls(),
+        0,
+        "reset must zero TYPE_NORMALIZE_CALLS"
+    );
+
+    let scan = db
+        .execute("SELECT * FROM test_types.nb_null_empty_text_blob")
+        .await
+        .expect("scan of nb_null_empty_text_blob");
+    let rows = scan.rows.len();
+    assert!(
+        rows > 0,
+        "present fixture must return rows (0 rows = read regression, not a skip)"
+    );
+
+    // Count the empty simple cells the scan surfaced — these are the cells that
+    // take the HAS_EMPTY_VALUE early-return in the value parser.
+    let mut empty_simple = 0usize;
+    for row in &scan.rows {
+        for v in row.values.values() {
+            match v {
+                cqlite_core::Value::Text(s) if s.is_empty() => empty_simple += 1,
+                cqlite_core::Value::Blob(b) if b.is_empty() => empty_simple += 1,
+                _ => {}
+            }
+        }
+    }
+
+    let normalizes = rwc::type_normalize_calls();
+    eprintln!("H5: rows={rows} empty_simple={empty_simple} TYPE_NORMALIZE_CALLS={normalizes}");
+
+    // Fixture-shape guards: fail loudly (pointing at the fixture) if the pinned
+    // dataset ever regenerates into a different shape than these counts assume.
+    assert_eq!(rows, 4, "fixture shape changed: expected 4 rows");
+    assert_eq!(
+        empty_simple, 2,
+        "fixture shape changed: expected 2 empty simple cells (empty text + empty blob in ck=4)"
+    );
+
+    // The empty-cell type normalization is now counted (pre-fix undercount was 27).
+    assert_eq!(
+        normalizes, 29,
+        "empty-cell type normalization must be counted: expected 29 \
+         (pre-fix undercount was 27, missing the {empty_simple} empty simple cells); got {normalizes}"
+    );
+}
+
 /// Scenario (K2/K3 currency): a full scan speculatively try-parses a partition
 /// header at every partition boundary, so `PARTITION_HEADER_TRY_PARSES` is at
 /// least the partition count. For `test_basic/simple_table` each row is its own

--- a/cqlite-core/tests/issue_1618_parser_work_counters.rs
+++ b/cqlite-core/tests/issue_1618_parser_work_counters.rs
@@ -282,7 +282,11 @@ async fn bti_point_read_visits_and_decodes_nodes() {
     };
 
     rwc::reset();
-    assert_eq!(rwc::bti_nodes_visited(), 0, "reset must zero BTI_NODES_VISITED");
+    assert_eq!(
+        rwc::bti_nodes_visited(),
+        0,
+        "reset must zero BTI_NODES_VISITED"
+    );
     assert_eq!(
         rwc::bti_pointer_decodes(),
         0,

--- a/cqlite-core/tests/issue_1618_parser_work_counters.rs
+++ b/cqlite-core/tests/issue_1618_parser_work_counters.rs
@@ -1,0 +1,328 @@
+//! Issue #1618 (Epic H / H5): wiring-evidence for the parser work counters.
+//! Proves each parser counter increments on the REAL public read path (a real
+//! scan / point read through the `Database` API) and pins TODAY's wasteful count
+//! against a real fixture, so the J1/K2/K3/L1/L3 children can flip the assertions
+//! to the fixed values as they land.
+//!
+//! Compiled only with `--features work-counters` (the getters/`reset` and the
+//! counter bodies live behind that feature; see `read_work_counters`). Requires
+//! `CQLITE_DATASETS_ROOT` + fetched binaries; skips (never fails) when the fixture
+//! is absent. Excluded under `tombstones` (that build serves point reads by a
+//! full-scan filter rather than the targeted seek this evidences).
+//!
+//! The counters are a shared process-global, so every test here serializes on the
+//! `serial_test` mutex (the existing counter-test convention) — a stale value from
+//! a parallel test can never satisfy an assertion after a `reset`.
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::sstable::read_work_counters as rwc;
+use cqlite_core::Database;
+use serial_test::serial;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        if let Some(dir) = root.parent().and_then(|p| {
+            let d = p.join("schemas");
+            d.exists().then_some(d)
+        }) {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+/// True if `<datasets>/sstables/<keyspace>/<table>-*/` holds a `*-Data.db` file.
+/// Skip keys off fixture presence (not a 0-row result), so a present fixture that
+/// yields 0 rows stays a hard failure.
+fn fixture_data_present(keyspace: &str, table: &str) -> bool {
+    let Some(root) = datasets_root() else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(root.join("sstables").join(keyspace)) else {
+        return false;
+    };
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        if let Ok(files) = std::fs::read_dir(e.path()) {
+            for f in files.flatten() {
+                if f.file_name().to_string_lossy().ends_with("-Data.db") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Ingest a single fixture table and return a fresh `Database`. Returns `None`
+/// when the fixture / schema is absent.
+async fn setup(keyspace: &str, schema_file: &str) -> Option<Database> {
+    let root = datasets_root()?;
+    let schema_path = schemas_dir()?.join(schema_file);
+    if !schema_path.exists() {
+        return None;
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return None;
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: Some("5.0".to_string()),
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    };
+    let result = ingest(config).await.ok()?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return None;
+    }
+    Some(result.database)
+}
+
+/// Format a 16-byte UUID as the canonical unquoted 8-4-4-4-12 literal.
+fn uuid_to_literal(bytes: &[u8; 16]) -> String {
+    let h = |range: std::ops::Range<usize>| -> String {
+        bytes[range].iter().map(|b| format!("{b:02x}")).collect()
+    };
+    format!(
+        "{}-{}-{}-{}-{}",
+        h(0..4),
+        h(4..6),
+        h(6..8),
+        h(8..10),
+        h(10..16)
+    )
+}
+
+/// Scan for one present `id` UUID and build the projected point-read SQL for it.
+/// Projected (>8 tokens) so it routes through the modern SelectExecutor and the
+/// partition-targeted BTI fast path.
+async fn learn_point_sql(db: &Database, table: &str) -> Option<String> {
+    let scan = db.execute(&format!("SELECT id FROM {table}")).await.ok()?;
+    let first = scan.rows.first()?;
+    let id = match first.values.get("id") {
+        Some(cqlite_core::Value::Uuid(b)) => *b,
+        _ => return None,
+    };
+    Some(format!(
+        "SELECT id, name FROM {table} WHERE id = {}",
+        uuid_to_literal(&id)
+    ))
+}
+
+/// Scenario (J1 currency): a full scan normalizes the type name per cell, so
+/// `TYPE_NORMALIZE_CALLS` scales with the rows scanned. Two normalization sites
+/// fire per non-key cell today (the value-parse `to_lowercase` and the
+/// per-column `is_complex_column`), so the count is at least one per returned row.
+/// J1 (zero `to_lowercase` per cell) flips this assertion to `== 0`.
+#[tokio::test]
+#[serial]
+async fn scan_normalizes_type_per_cell() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (H5 wiring): test_basic/simple_table Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (H5 wiring): could not ingest test_basic");
+        return;
+    };
+
+    rwc::reset();
+    assert_eq!(
+        rwc::type_normalize_calls(),
+        0,
+        "reset must zero TYPE_NORMALIZE_CALLS"
+    );
+
+    let scan = db
+        .execute("SELECT * FROM test_basic.simple_table")
+        .await
+        .expect("scan of test_basic.simple_table");
+    let rows = scan.rows.len() as u64;
+    assert!(
+        rows > 0,
+        "present fixture must return rows (0 rows = read regression, not a skip)"
+    );
+
+    let normalizes = rwc::type_normalize_calls();
+    eprintln!("H5: rows={rows} TYPE_NORMALIZE_CALLS={normalizes}");
+    // Today's (wasteful) cost: at least one type normalization per returned row —
+    // the per-cell `to_lowercase` J1 will eliminate.
+    assert!(
+        normalizes >= rows,
+        "H5: type normalization must scale with cells scanned (>= rows); got \
+         {normalizes} for {rows} rows"
+    );
+}
+
+/// Scenario (K2/K3 currency): a full scan speculatively try-parses a partition
+/// header at every partition boundary, so `PARTITION_HEADER_TRY_PARSES` is at
+/// least the partition count. For `test_basic/simple_table` each row is its own
+/// partition, so a scan bumps it at least once per returned row. K2/K3 (one
+/// try-parse per partition) flip this to an exact per-partition bound.
+#[tokio::test]
+#[serial]
+async fn scan_try_parses_partition_headers() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (H5 wiring): test_basic/simple_table Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (H5 wiring): could not ingest test_basic");
+        return;
+    };
+
+    rwc::reset();
+    assert_eq!(
+        rwc::partition_header_try_parses(),
+        0,
+        "reset must zero PARTITION_HEADER_TRY_PARSES"
+    );
+
+    let scan = db
+        .execute("SELECT * FROM test_basic.simple_table")
+        .await
+        .expect("scan of test_basic.simple_table");
+    let rows = scan.rows.len() as u64;
+    assert!(rows > 0, "present fixture must return rows");
+
+    let tries = rwc::partition_header_try_parses();
+    eprintln!("H5: rows={rows} PARTITION_HEADER_TRY_PARSES={tries}");
+    assert!(
+        tries >= 1,
+        "H5: a scan must speculatively try-parse at least one partition header; got {tries}"
+    );
+}
+
+/// Scenario (K2/L currency): the shared display-row builder sorts each row's cells
+/// once, so `ROW_SORT_INVOCATIONS` is at least the number of returned live rows.
+/// K2/L (cells arrive pre-sorted) flip this to prove no per-row sort.
+#[tokio::test]
+#[serial]
+async fn scan_sorts_cells_per_row() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (H5 wiring): test_basic/simple_table Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (H5 wiring): could not ingest test_basic");
+        return;
+    };
+
+    rwc::reset();
+    assert_eq!(
+        rwc::row_sort_invocations(),
+        0,
+        "reset must zero ROW_SORT_INVOCATIONS"
+    );
+
+    let scan = db
+        .execute("SELECT * FROM test_basic.simple_table")
+        .await
+        .expect("scan of test_basic.simple_table");
+    let rows = scan.rows.len() as u64;
+    assert!(rows > 0, "present fixture must return rows");
+
+    let sorts = rwc::row_sort_invocations();
+    eprintln!("H5: rows={rows} ROW_SORT_INVOCATIONS={sorts}");
+    // Every returned live row required exactly one per-row cell sort today; markers
+    // (filtered out of the result) require none, so sorts is at least the returned
+    // live-row count.
+    assert!(
+        sorts >= rows,
+        "H5: the display-row builder sorts each live row's cells (>= rows); got \
+         {sorts} for {rows} rows"
+    );
+}
+
+/// Scenario (L1/L3 currency): a BTI (`da`) point read descends the
+/// `Partitions.db` trie. The targeted descent decodes each internal node it
+/// follows (`BTI_POINTER_DECODES`), and the first point read builds the cached
+/// successor index by enumerating the whole trie in-order (`BTI_NODES_VISITED`),
+/// so both counters are positive after a real point read through the `Database`
+/// API. Counters are reset AFTER learning the key (the learning scan does not
+/// walk the trie) so only the point read's trie work is measured. Uses the
+/// optional `test_da` BTI corpus; skips (never fails) when it is absent. L1/L3
+/// (<40 BTI nodes visited) flip these to bounded counts.
+#[tokio::test]
+#[serial]
+async fn bti_point_read_visits_and_decodes_nodes() {
+    if !fixture_data_present("test_da", "simple_table") {
+        eprintln!("Skipping (H5 wiring): optional BTI test_da/simple_table not present");
+        return;
+    }
+    let Some(db) = setup("test_da", "da-test.cql").await else {
+        eprintln!("Skipping (H5 wiring): could not ingest test_da");
+        return;
+    };
+    let Some(point_sql) = learn_point_sql(&db, "test_da.simple_table").await else {
+        panic!("H5: could not learn a present UUID key from test_da.simple_table");
+    };
+
+    rwc::reset();
+    assert_eq!(rwc::bti_nodes_visited(), 0, "reset must zero BTI_NODES_VISITED");
+    assert_eq!(
+        rwc::bti_pointer_decodes(),
+        0,
+        "reset must zero BTI_POINTER_DECODES"
+    );
+
+    let res = db.execute(&point_sql).await.expect("BTI point read");
+    assert!(
+        !res.rows.is_empty(),
+        "H5: BTI point read on a known-present key returned zero rows"
+    );
+
+    let nodes = rwc::bti_nodes_visited();
+    let decodes = rwc::bti_pointer_decodes();
+    eprintln!("H5: BTI_NODES_VISITED={nodes} BTI_POINTER_DECODES={decodes}");
+    assert!(
+        nodes >= 1,
+        "H5: a BTI point read must visit at least one trie node (successor-index \
+         enumeration); got {nodes}"
+    );
+    assert!(
+        decodes >= 1,
+        "H5: a BTI point read must decode at least one trie node; got {decodes}"
+    );
+}
+
+/// Scenario: `reset` zeroes every parser counter — a pure-API check that does not
+/// require a fixture.
+#[tokio::test]
+#[serial]
+async fn reset_zeroes_parser_counters() {
+    if let Some(db) = setup("test_basic", "basic-types.cql").await {
+        if fixture_data_present("test_basic", "simple_table") {
+            let _ = db.execute("SELECT * FROM test_basic.simple_table").await;
+        }
+    }
+    rwc::reset();
+    assert_eq!(rwc::type_normalize_calls(), 0);
+    assert_eq!(rwc::partition_header_try_parses(), 0);
+    assert_eq!(rwc::bti_nodes_visited(), 0);
+    assert_eq!(rwc::bti_pointer_decodes(), 0);
+    assert_eq!(rwc::row_sort_invocations(), 0);
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -32,6 +32,14 @@
 #                      --test issue_1589_window_drain_bytes (the scan/compaction
 #                      windows advance a cursor + compact once per refill instead
 #                      of front-draining per partition — issue #1589); same gate.
+#   work-counters-guard cargo test -p cqlite-core --features cli-helpers,work-counters
+#                      the read/parser work-counter wiring-evidence tests
+#                      (issue_1566/1573/1585 read-work counters + issue_1618 parser
+#                      work counters). The counter bodies/getters are feature-gated
+#                      behind `work-counters`, so the default core-tests run can't
+#                      execute them — without this component the wiring evidence
+#                      would only run under a manual `--features work-counters`
+#                      invocation (issue #1618).
 #   byte-budget-guard  cargo test -p cqlite-core --features write-support,cli-helpers,state_machine
 #                      --test issue_1582_byte_bounded_result_budget (issue #1582,
 #                      Epic D6). Byte-bounded result budget: the materializing
@@ -729,7 +737,7 @@ _delta_python_tier_gap() {
   return 0
 }
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard byte-budget-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
 # --lite (issue #1821) runs ONLY this fast subset: file-size ratchet, fmt,
 # FULL-workspace clippy (cross-crate API breaks are the cheap-insurance class),
 # and blast-radius-scoped tests (the touched package's --lib + the diff's new
@@ -2322,6 +2330,7 @@ run_file_size
 # for a dataset-dependent component is the #646 hazard, so this set must stay
 # complete.
 #   needs datasets: core-tests, tombstones-scan, scan-offload-guard,
+#     work-counters-guard (the wiring-evidence tests scan real Data.db fixtures),
 #     memory-budget (dhat lane reads real Data.db and fails closed on empty),
 #     integration-tests, write-tests, smoke (read Data.db / golden fixtures), and
 #     python-bindings — the pytest suite resolves CQLITE_DATASETS_ROOT and calls
@@ -2345,7 +2354,7 @@ run_file_size
 #     assertions with hardcoded vectors — it reads no CQLITE_DATASETS_ROOT and no
 #     Data.db — so guarding it just made `--only format-compat` falsely fail the
 #     preflight when datasets are absent.
-DATASET_COMPONENTS="core-tests tombstones-scan scan-offload-guard memory-budget integration-tests write-tests python-bindings smoke"
+DATASET_COMPONENTS="core-tests tombstones-scan scan-offload-guard work-counters-guard memory-budget integration-tests write-tests python-bindings smoke"
 
 # selected_needs_datasets: true iff at least one SELECTED component reads datasets.
 # With no --only, every component runs, so it's always true. With --only, it's true
@@ -2445,6 +2454,12 @@ dispatch_component() {
       --test issue_1143_scan_offload_thread \
       --test issue_1333_scan_scratch_reuse \
       --test issue_1589_window_drain_bytes ;;
+    work-counters-guard) run_component work-counters-guard cargo test --package cqlite-core \
+      --features cli-helpers,work-counters \
+      --test issue_1566_read_work_counters \
+      --test issue_1573_readat_positional \
+      --test issue_1585_read_op_per_chunk \
+      --test issue_1618_parser_work_counters ;;
     byte-budget-guard) run_component byte-budget-guard cargo test --package cqlite-core \
       --features write-support,cli-helpers,state_machine \
       --test issue_1582_byte_bounded_result_budget ;;


### PR DESCRIPTION
Integration branch for two low-risk, file-disjoint Epic-H measurement-infra issues (fleet→integration, one serial gate).

Closes #1616
Closes #1618

## #1616 — H3: struct-size assertion pins
Compile-time `const _: () = assert!(size_of::<T>() == N)` pins guarding hot-path struct layout (`ComparatorType`, `ParseStep`, `ScanCursor`, BTI `SizedPointer`/`Transition`/`PayloadRef`), measured on 64-bit. `Value` stays owned by the existing #1565 pin (coordination note added, not duplicated). Any layout regression now fails the build.

## #1618 — H5: parser work-counter infrastructure (widest downstream unblock)
Five cfg-gated (`#[cfg(any(test, feature = "work-counters"))]`, zero-cost in release) counters wired to real hot-path work sites: `TYPE_NORMALIZE_CALLS`, `PARTITION_HEADER_TRY_PARSES`, `BTI_NODES_VISITED`, `BTI_POINTER_DECODES`, `ROW_SORT_INVOCATIONS`. Wiring-evidence tests assert current-main counts against real fixtures (baselines for J1/K2/K3/L1/L3). New `work-counters-guard` agent-gate component. roborev-fixed: `TYPE_NORMALIZE_CALLS` now dedups to a single normalization site so it counts empty-cell cells too (also removes a redundant per-cell allocation).

## Validation
- **Full agent-gate.sh: RESULT: PASS** at `c1782bd9` (24/24 components incl. `work-counters-guard`; core-tests 559s serial-nextest). Run with `CQLITE_ALLOW_FILE_GROWTH=1` (2–3 line load-bearing instrumentation on already-over-threshold parser files).
- roborev (codex): clean (no issues) after the undercount fix.
