### PR TITLE
fix(#2035): write-path non-frozen collection round-trip — header column order desync

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/stats_writer/serialization_header.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer/serialization_header.rs
@@ -9,8 +9,22 @@ use super::metadata::StatisticsMetadata;
 use super::{StatisticsWriter, DELETION_TIME_EPOCH, TIMESTAMP_EPOCH, TTL_EPOCH};
 use crate::error::Result;
 use crate::parser::vint::encode_vuint;
-use crate::schema::TableSchema;
+use crate::schema::{Column, TableSchema};
+use crate::storage::sstable::writer::data_writer::is_complex_column;
 use std::io::Write;
+
+/// SerializationHeader column ordering key (issue #2035).
+///
+/// Cassandra stores a `SerializationHeader`'s regular/static columns in
+/// `ColumnMetadata.comparisonOrder` order, where the `isComplex` bit (`1L << 60`)
+/// outranks the column name — so all SIMPLE columns precede all COMPLEX
+/// (non-frozen collection / non-frozen UDT) columns, then ties break by name.
+/// This is the SAME key the DATA writer uses for on-disk cell order
+/// (`column_order_key`), and the two MUST agree: the reader resolves each cell to
+/// its column by this header order, so any divergence desyncs the row.
+fn serialization_header_column_key(column: &Column) -> (bool, &str) {
+    (is_complex_column(&column.data_type), column.name.as_str())
+}
 
 impl StatisticsWriter {
     /// Build SERIALIZATION_HEADER component (MetadataType ordinal 3)
@@ -136,7 +150,16 @@ impl StatisticsWriter {
                 let ck_names: std::collections::HashSet<&str> =
                     s.clustering_keys.iter().map(|k| k.name.as_str()).collect();
 
-                // staticColumns: filter for is_static && not PK/CK, sorted alphabetically
+                // staticColumns: filter for is_static && not PK/CK, in Cassandra's
+                // SerializationHeader column order (issue #2035): SIMPLE columns
+                // before COMPLEX (non-frozen collection / non-frozen UDT), then by
+                // name. This is Cassandra's `ColumnMetadata.comparisonOrder` — the
+                // `isComplex` bit (`1L << 60`) outranks the name — and it MUST match
+                // the DATA writer's on-disk cell order (`column_order_key`), because
+                // the reader resolves each cell's column by this header order. A
+                // plain alphabetical sort desynced any row whose simple column sorts
+                // AFTER a complex column (dropping the collection + mis-decoding the
+                // next simple cell).
                 let mut static_cols: Vec<_> = s
                     .columns
                     .iter()
@@ -146,7 +169,9 @@ impl StatisticsWriter {
                             && !ck_names.contains(c.name.as_str())
                     })
                     .collect();
-                static_cols.sort_by(|a, b| a.name.cmp(&b.name));
+                static_cols.sort_by(|a, b| {
+                    serialization_header_column_key(a).cmp(&serialization_header_column_key(b))
+                });
                 buffer.write_all(&encode_vuint(static_cols.len() as u64))?;
                 for col in &static_cols {
                     // Column name: VUInt length + UTF-8 bytes
@@ -158,8 +183,12 @@ impl StatisticsWriter {
                     buffer.write_all(col_marshal.as_bytes())?;
                 }
 
-                // regularColumns: filter for !is_static && not PK/CK, sorted alphabetically
-                // Cassandra's SerializationHeader stores columns in natural order (alphabetical)
+                // regularColumns: filter for !is_static && not PK/CK, in Cassandra's
+                // SerializationHeader column order (issue #2035): SIMPLE columns
+                // before COMPLEX, then by name — Cassandra's
+                // `ColumnMetadata.comparisonOrder` (the `isComplex` bit `1L << 60`
+                // outranks the name). This MUST match the DATA writer's on-disk cell
+                // order (`column_order_key`); see the static-column note above.
                 let mut regular_cols: Vec<_> = s
                     .columns
                     .iter()
@@ -169,7 +198,9 @@ impl StatisticsWriter {
                             && !ck_names.contains(c.name.as_str())
                     })
                     .collect();
-                regular_cols.sort_by(|a, b| a.name.cmp(&b.name));
+                regular_cols.sort_by(|a, b| {
+                    serialization_header_column_key(a).cmp(&serialization_header_column_key(b))
+                });
                 buffer.write_all(&encode_vuint(regular_cols.len() as u64))?;
                 for col in &regular_cols {
                     buffer.write_all(&encode_vuint(col.name.len() as u64))?;

--- a/cqlite-core/src/storage/sstable/writer/stats_writer/serialization_header.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer/serialization_header.rs
@@ -9,22 +9,9 @@ use super::metadata::StatisticsMetadata;
 use super::{StatisticsWriter, DELETION_TIME_EPOCH, TIMESTAMP_EPOCH, TTL_EPOCH};
 use crate::error::Result;
 use crate::parser::vint::encode_vuint;
-use crate::schema::{Column, TableSchema};
-use crate::storage::sstable::writer::data_writer::is_complex_column;
+use crate::schema::TableSchema;
+use crate::storage::sstable::writer::data_writer::column_order_key;
 use std::io::Write;
-
-/// SerializationHeader column ordering key (issue #2035).
-///
-/// Cassandra stores a `SerializationHeader`'s regular/static columns in
-/// `ColumnMetadata.comparisonOrder` order, where the `isComplex` bit (`1L << 60`)
-/// outranks the column name — so all SIMPLE columns precede all COMPLEX
-/// (non-frozen collection / non-frozen UDT) columns, then ties break by name.
-/// This is the SAME key the DATA writer uses for on-disk cell order
-/// (`column_order_key`), and the two MUST agree: the reader resolves each cell to
-/// its column by this header order, so any divergence desyncs the row.
-fn serialization_header_column_key(column: &Column) -> (bool, &str) {
-    (is_complex_column(&column.data_type), column.name.as_str())
-}
 
 impl StatisticsWriter {
     /// Build SERIALIZATION_HEADER component (MetadataType ordinal 3)
@@ -169,9 +156,7 @@ impl StatisticsWriter {
                             && !ck_names.contains(c.name.as_str())
                     })
                     .collect();
-                static_cols.sort_by(|a, b| {
-                    serialization_header_column_key(a).cmp(&serialization_header_column_key(b))
-                });
+                static_cols.sort_by(|a, b| column_order_key(a).cmp(&column_order_key(b)));
                 buffer.write_all(&encode_vuint(static_cols.len() as u64))?;
                 for col in &static_cols {
                     // Column name: VUInt length + UTF-8 bytes
@@ -198,9 +183,7 @@ impl StatisticsWriter {
                             && !ck_names.contains(c.name.as_str())
                     })
                     .collect();
-                regular_cols.sort_by(|a, b| {
-                    serialization_header_column_key(a).cmp(&serialization_header_column_key(b))
-                });
+                regular_cols.sort_by(|a, b| column_order_key(a).cmp(&column_order_key(b)));
                 buffer.write_all(&encode_vuint(regular_cols.len() as u64))?;
                 for col in &regular_cols {
                     buffer.write_all(&encode_vuint(col.name.len() as u64))?;

--- a/cqlite-core/tests/issue_2035_collection_roundtrip.rs
+++ b/cqlite-core/tests/issue_2035_collection_roundtrip.rs
@@ -1,0 +1,243 @@
+//! Issue #2035: a freshly-written NON-FROZEN collection must round-trip through
+//! the WriteEngine → SSTable → KWayMerger merge reader.
+//!
+//! Before the fix, flushing a whole-column non-frozen `map`/`set` (or a lone
+//! per-element complex write) plus a trailing simple column silently DROPPED the
+//! collection column on read-back and MIS-DECODED the immediately-following
+//! simple cell (a complex-column framing miscount desynced the row byte cursor:
+//! `score=7` read back as `-8388609`, a 3-byte misread).
+//!
+//! This test writes the collection + trailing `score int` via the public
+//! WriteEngine, flushes to a single generation, then reads it back through
+//! `KWayMerger` and asserts (a) every collection element is present at the
+//! correct `cell_path` with the correct value and (b) the trailing simple column
+//! decodes to its exact written value (catching the byte desync).
+//!
+//! Run with:
+//!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!     cargo test --package cqlite-core --features write-support \
+//!     --test issue_2035_collection_roundtrip
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::merge::{KWayMerger, MergeStep, RowData};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+const KS: &str = "coll_ks";
+const TBL: &str = "coll_tbl";
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "attrs".to_string(),
+                data_type: "map<text, int>".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "labels".to_string(),
+                data_type: "set<int>".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "score".to_string(),
+                data_type: "int".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Collect the flushed `-big-Data.db` (or `-da-Data.db`) generation paths.
+fn data_files(dir: &std::path::Path) -> Vec<PathBuf> {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.ends_with("-Data.db"))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Read back the single flushed generation through `KWayMerger` and return the
+/// live cells of the first (only) row.
+fn read_back_cells(data_dir: &std::path::Path, schema: &TableSchema) -> Vec<CellSnapshot> {
+    let sstable_dir = data_dir.join(KS).join(TBL);
+    let paths = data_files(&sstable_dir);
+    assert_eq!(paths.len(), 1, "expected exactly one flushed generation");
+
+    let mut merger = KWayMerger::new(paths, schema).expect("KWayMerger open");
+    let mut all_cells = Vec::new();
+    while let MergeStep::Partition { rows, .. } = merger.step().expect("merge step") {
+        for entry in rows {
+            if let RowData::Live { cells } = &entry.row_data {
+                for c in cells {
+                    all_cells.push(CellSnapshot {
+                        column: c.column.clone(),
+                        value: c.value.clone(),
+                        cell_path: c.cell_path.clone(),
+                        is_complex_element: c.is_complex_element,
+                    });
+                }
+            }
+        }
+    }
+    all_cells
+}
+
+#[derive(Debug, Clone)]
+struct CellSnapshot {
+    column: String,
+    value: Value,
+    cell_path: Option<Vec<u8>>,
+    is_complex_element: bool,
+}
+
+#[test]
+fn nonfrozen_collection_plus_trailing_simple_column_roundtrips() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // ── Write one row: whole-column map + whole-column set + trailing int ──────
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    // Pinned timestamp — no wall-clock.
+    let ts = 1_700_000_000_000_000i64;
+    let ops = vec![
+        CellOperation::Write {
+            column: "attrs".to_string(),
+            value: Value::Map(vec![
+                (Value::Text("a".to_string()), Value::Integer(10)),
+                (Value::Text("b".to_string()), Value::Integer(20)),
+            ]),
+        },
+        CellOperation::Write {
+            column: "labels".to_string(),
+            value: Value::Set(vec![Value::Integer(100), Value::Integer(200)]),
+        },
+        CellOperation::Write {
+            column: "score".to_string(),
+            value: Value::Integer(7),
+        },
+    ];
+    engine
+        .write(Mutation::new(
+            TableId::new(KS, TBL),
+            pk,
+            None,
+            ops,
+            ts,
+            None,
+        ))
+        .expect("write");
+    rt.block_on(engine.flush())
+        .expect("flush")
+        .expect("generation produced");
+    rt.block_on(engine.close()).expect("close engine");
+
+    // ── Read back through the merge reader ────────────────────────────────────
+    let cells = read_back_cells(&data_dir, &schema);
+
+    // (b) Trailing simple column MUST decode to its exact written value. This is
+    // the byte-desync canary: before the fix `score` read back as -8388609.
+    let score = cells
+        .iter()
+        .find(|c| c.column == "score" && !c.is_complex_element)
+        .unwrap_or_else(|| panic!("score column missing on read-back; cells={cells:#?}"));
+    assert_eq!(
+        score.value,
+        Value::Integer(7),
+        "trailing simple column desynced (byte miscount in complex framing); cells={cells:#?}"
+    );
+
+    // (a) Every map element present at the correct cell_path with correct value.
+    // cell_path for map<text,int> = serialized key ("a"/"b" as UTF-8 bytes).
+    let attr_elems: Vec<&CellSnapshot> = cells
+        .iter()
+        .filter(|c| c.column == "attrs" && c.is_complex_element)
+        .collect();
+    assert_eq!(
+        attr_elems.len(),
+        2,
+        "map must read back as 2 per-element complex cells; cells={cells:#?}"
+    );
+    let attr_a = attr_elems
+        .iter()
+        .find(|c| c.cell_path.as_deref() == Some(b"a"))
+        .expect("map element a missing");
+    assert_eq!(attr_a.value, Value::Integer(10));
+    let attr_b = attr_elems
+        .iter()
+        .find(|c| c.cell_path.as_deref() == Some(b"b"))
+        .expect("map element b missing");
+    assert_eq!(attr_b.value, Value::Integer(20));
+
+    // set<int> elements: cell_path = serialized member (4-byte BE int), value empty.
+    let label_elems: Vec<&CellSnapshot> = cells
+        .iter()
+        .filter(|c| c.column == "labels" && c.is_complex_element)
+        .collect();
+    assert_eq!(
+        label_elems.len(),
+        2,
+        "set must read back as 2 per-element complex cells; cells={cells:#?}"
+    );
+    let has_path = |bytes: &[u8]| {
+        label_elems
+            .iter()
+            .any(|c| c.cell_path.as_deref() == Some(bytes))
+    };
+    assert!(
+        has_path(&100i32.to_be_bytes()),
+        "set member 100 missing; cells={cells:#?}"
+    );
+    assert!(
+        has_path(&200i32.to_be_bytes()),
+        "set member 200 missing; cells={cells:#?}"
+    );
+
+    drop(temp_dir);
+}

--- a/cqlite-core/tests/issue_2035_collection_roundtrip.rs
+++ b/cqlite-core/tests/issue_2035_collection_roundtrip.rs
@@ -13,6 +13,15 @@
 //! correct `cell_path` with the correct value and (b) the trailing simple column
 //! decodes to its exact written value (catching the byte desync).
 //!
+//! Why a cqlite-write → cqlite-read self-consistency check is the sufficient
+//! property here (no Cassandra golden fixture needed): the defect was an INTERNAL
+//! desync between CQLite's own SerializationHeader column order and its Data.db
+//! cell order — both produced by this same writer. A round-trip that recovers the
+//! collection `cell_path`s and the trailing simple `score == 7` canary directly
+//! exercises the exact header-order-vs-cell-order invariant that was broken.
+//! Cassandra-golden BYTE-parity of the SerializationHeader is covered separately
+//! by the compaction-byte-parity gate component.
+//!
 //! Run with:
 //!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 //!     cargo test --package cqlite-core --features write-support \


### PR DESCRIPTION
Fixes #2035 (P0). Write-path non-frozen collection round-trip was broken: a collection column was dropped and the next simple cell mis-decoded — because `serialization_header.rs` sorted columns pure-alphabetically while the data writer (`data_writer/encoding.rs`) and Cassandra `comparisonOrder` sort by `(isComplex, name)` (simple columns before complex). The two orders desynced, corrupting the round-trip. This blocks #1537 e2e.

## Fix
- Add `serialization_header_column_key(col) = (is_complex_column(&col.data_type), col.name)`; both static and regular column sorts in the stats serialization header now use it, matching `column_order_key` and Cassandra's comparisonOrder.

## Test
- New `cqlite-core/tests/issue_2035_collection_roundtrip.rs`: round-trips `map<text,int>` + `set<int>` + trailing simple `score int`; asserts cell_paths preserved and `score==7` canary. Revert-verified: FAILS pre-fix.

## Gate of record
```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.b3S8CC
commit: a495bd6f branch: issue-2035-collection-roundtrip dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (85s)
core-tests:        PASS (520s)
tombstones-scan:   PASS (34s)
scan-offload-guard: PASS (40s)
work-counters-guard: PASS (42s)
byte-budget-guard: PASS (6s)
memory-budget:     PASS (42s)
integration-tests: PASS (54s)
format-compat:     PASS (31s)
write-tests:       PASS (128s)
cli-tests:         PASS (139s)
compaction-byte-parity: PASS (9s)
python-bindings:   PASS (748s)
node-bindings:     PASS (460s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (7s)
binding-unwind-profile: PASS (0s)
tooling-tests:     PASS (33s)
minimal-build:     PASS (65s)
smoke:             PASS (49s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.b3S8CC
summary-file: /tmp/gate-2035-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Oracle-driven (Cassandra byte-order = truth); no OpenSpec. roborev(opus) in progress.