### PR TITLE
chore(infra): #2035 telemetry stamp + pin roborev to claude-code/opus

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,7 +1,7 @@
 # Default agent for this repo when no workflow-specific agent is set.
-agent = 'codex'
+agent = 'claude-code'
 # Default model for this repo when no workflow-specific model is set.
-model = 'gpt-5.5'
+model = 'opus'
 # Backup agent for this repo if the primary agent fails.
 backup_agent = ''
 # Backup model for this repo if the primary model fails.
@@ -38,7 +38,7 @@ snapshot_dir = ''
 post_commit_review = 'branch'
 reuse_review_session_lookback = 3
 # Agent override for standard review in this repo.
-review_agent = 'codex'
+review_agent = 'claude-code'
 # Agent override for fast review in this repo.
 review_agent_fast = ''
 # Agent override for standard review in this repo.
@@ -62,7 +62,7 @@ refine_agent_thorough = ''
 # Agent override for maximum refine in this repo.
 refine_agent_maximum = ''
 # Model override for standard review in this repo.
-review_model = 'gpt-5.5'
+review_model = 'opus'
 # Model override for fast review in this repo.
 review_model_fast = ''
 # Model override for standard review in this repo.


### PR DESCRIPTION
Two small infra changes:
1. **telemetry(#2035)**: stamp the delivery ledger for the merged collection round-trip fix (PR #2045). Main is PR-protected, so the finalize stamp lands here.
2. **chore(infra)**: pin `.roborev.toml` to `claude-code`/`opus` (was `codex`/`gpt-5.5`, which 404s and isn't on PATH). Durability fix so fresh worktrees stop inheriting the broken config. (Owner order 2026-07-05: roborev code review = opus.)

No source/test changes; gate not required (docs/config only).