### PR TITLE
fix(#1537): apply compaction TTL expiry to complex/collection/UDT elements

### DIFF
--- a/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
@@ -339,6 +339,16 @@ pub fn parse_enhanced_statistics_file<'a>(
                         if let Some(max_ts) = extras.max_timestamp {
                             timestamp_stats.max_timestamp = Some(max_ts);
                         }
+                        // Authoritative maxTTL (issue #1537): the inner nb walk only
+                        // decodes the EncodingStats minTTL baseline and honestly
+                        // leaves `max_ttl = None`. Recover the true maximum from the
+                        // STATS-extras walk so the compaction TTL-expiry LDT floor
+                        // (`compute_expiry_ttl_ldt_floor`) can lower the output's
+                        // min-LDT delta baseline below a creation-time (`ldt - ttl`)
+                        // tombstone. `None` (no expiring cells) stays `None`.
+                        if extras.max_ttl.is_some() {
+                            timestamp_stats.max_ttl = extras.max_ttl;
+                        }
                         extras.tombstone_drop_times
                     }
                     Err(e) => {

--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -958,6 +958,17 @@ pub struct StatsExtras {
     /// placeholder in [`crate::parser::enhanced_statistics_parser`], which
     /// silently reported the MIN write timestamp as the max.
     pub max_timestamp: Option<i64>,
+    /// Authoritative SSTable `maxTTL` (seconds) decoded from STATS field 9
+    /// (issue #1537). Cassandra's `MetadataCollector` seeds the TTL tracker with
+    /// `Cell.NO_TTL` (`0`) and updates it only from EXPIRING cells, so a maxTTL of
+    /// `0` means "no expiring cells" and is surfaced fail-closed as `None`. Any
+    /// positive value is the true maximum TTL across the SSTable's expiring cells.
+    /// The compaction TTL-expiry LDT floor (issue #1537,
+    /// [`crate::storage::write_engine::merge::compute_expiry_ttl_ldt_floor`]) needs
+    /// this authoritative maximum: the enhanced (nb) parser only decodes the
+    /// EncodingStats `minTTL` baseline and honestly leaves `max_ttl = None`, so
+    /// this best-effort STATS-extras walk is the only source of the true maximum.
+    pub max_ttl: Option<i64>,
 }
 
 impl Default for StatsExtras {
@@ -969,6 +980,7 @@ impl Default for StatsExtras {
             max_local_deletion_time: NO_DELETION_TIME,
             tombstone_drop_times: Vec::new(),
             max_timestamp: None,
+            max_ttl: None,
         }
     }
 }
@@ -1032,8 +1044,17 @@ pub fn parse_stats_extras(input: &[u8], gates: Option<&VersionGates>) -> Result<
     let raw_max_ldt = c.read_u32()?;
     let max_local_deletion_time = decode_max_local_deletion_time(raw_max_ldt, modern);
 
-    // 6. minTTL, maxTTL.
-    c.skip(4 + 4)?;
+    // 6. minTTL (skip), maxTTL (read). Both are `int` (4 bytes BE) in every
+    //    encoding (nb / oa / da). maxTTL is the authoritative maximum TTL across
+    //    the SSTable's expiring cells (issue #1537); `0` (Cassandra `Cell.NO_TTL`,
+    //    the tracker seed) means "no expiring cells" and is surfaced as `None`.
+    c.skip(4)?; // minTTL
+    let raw_max_ttl = c.read_i32()?;
+    let max_ttl = if raw_max_ttl > 0 {
+        Some(i64::from(raw_max_ttl))
+    } else {
+        None
+    };
 
     // 7. compressionRatio (f64).
     c.read_f64()?;
@@ -1045,6 +1066,7 @@ pub fn parse_stats_extras(input: &[u8], gates: Option<&VersionGates>) -> Result<
         max_local_deletion_time,
         tombstone_drop_times,
         max_timestamp,
+        max_ttl,
     })
 }
 
@@ -1210,17 +1232,19 @@ mod tests {
     /// modern (12-byte: `i64 point + i32 value`) layout per `modern`.
     fn synthetic_statistics_extras(modern: bool, raw_max_ldt: u32, bins: &[(i64, u64)]) -> Vec<u8> {
         // Default fixture: minTimestamp=100, maxTimestamp=200.
-        synthetic_statistics_extras_ts(modern, raw_max_ldt, bins, 100, 200)
+        synthetic_statistics_extras_ts(modern, raw_max_ldt, bins, 100, 200, 0)
     }
 
     /// Same as [`synthetic_statistics_extras`] but with explicit min/max write
-    /// timestamps (STATS field 4), for exercising `decode_max_timestamp` (#1729).
+    /// timestamps (STATS field 4), for exercising `decode_max_timestamp` (#1729),
+    /// and an explicit `max_ttl` (STATS field 9, issue #1537).
     fn synthetic_statistics_extras_ts(
         modern: bool,
         raw_max_ldt: u32,
         bins: &[(i64, u64)],
         min_timestamp: i64,
         max_timestamp: i64,
+        max_ttl: i32,
     ) -> Vec<u8> {
         let mut stats = Vec::new();
         // estimatedPartitionSize + estimatedCellPerPartitionCount (empty).
@@ -1237,7 +1261,7 @@ mod tests {
         stats.extend_from_slice(&raw_max_ldt.to_be_bytes());
         // minTTL, maxTTL.
         stats.extend_from_slice(&0i32.to_be_bytes());
-        stats.extend_from_slice(&0i32.to_be_bytes());
+        stats.extend_from_slice(&max_ttl.to_be_bytes());
         // compressionRatio (f64).
         stats.extend_from_slice(&(-1.0f64).to_be_bytes());
         // TombstoneHistogram: maxBinSize, size, then bins.
@@ -1504,6 +1528,33 @@ mod tests {
         assert!(extras.tombstone_drop_times.is_empty());
         // Default fixture: maxTimestamp=200 (NOT the min=100 placeholder). #1729.
         assert_eq!(extras.max_timestamp, Some(200));
+        // Default fixture: maxTTL=0 (no expiring cells) → None (#1537).
+        assert_eq!(extras.max_ttl, None);
+    }
+
+    #[test]
+    fn stats_extras_decodes_authoritative_max_ttl() {
+        // Issue #1537: the STATS-extras walk must surface the authoritative maxTTL
+        // (field 9) so the compaction TTL-expiry LDT floor can lower the output's
+        // min-LDT baseline below a creation-time (`ldt - ttl`) tombstone. A positive
+        // maxTTL is the true max; `0` (Cassandra `Cell.NO_TTL`) means "no expiring
+        // cells" and must surface as `None`.
+        let bytes =
+            synthetic_statistics_extras_ts(false, i32::MAX as u32, &[], 100, 200, 10_000_000);
+        let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(
+            extras.max_ttl,
+            Some(10_000_000),
+            "authoritative maxTTL must be decoded from STATS field 9"
+        );
+
+        // maxTTL == 0 → no expiring cells → None (fail-closed).
+        let none_bytes = synthetic_statistics_extras_ts(false, i32::MAX as u32, &[], 100, 200, 0);
+        let none_extras = parse_stats_extras(&none_bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(
+            none_extras.max_ttl, None,
+            "maxTTL of 0 (no expiring cells) must surface as None"
+        );
     }
 
     #[test]
@@ -1512,7 +1563,7 @@ mod tests {
         // true max (not the min placeholder the enhanced parser used to emit).
         let min_ts = 1_000_000i64;
         let max_ts = 5_000_000i64;
-        let bytes = synthetic_statistics_extras_ts(false, i32::MAX as u32, &[], min_ts, max_ts);
+        let bytes = synthetic_statistics_extras_ts(false, i32::MAX as u32, &[], min_ts, max_ts, 0);
         let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
         assert_eq!(
             extras.max_timestamp,
@@ -1531,7 +1582,8 @@ mod tests {
         // Fail-closed (#1729): Cassandra seeds the max tracker with
         // Long.MIN_VALUE; an SSTable with no recorded write timestamp
         // serializes that sentinel → surfaced as None, never a bogus max.
-        let bytes = synthetic_statistics_extras_ts(false, i32::MAX as u32, &[], i64::MAX, i64::MIN);
+        let bytes =
+            synthetic_statistics_extras_ts(false, i32::MAX as u32, &[], i64::MAX, i64::MIN, 0);
         let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
         assert_eq!(extras.max_timestamp, None);
     }

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -250,11 +250,19 @@ impl WriteEngine {
         // The output baseline must be ≤ all per-partition values from all inputs.
         let (baseline_min_ts, mut baseline_min_ldt, baseline_min_ttl) =
             merge::compute_baseline_min(&input_paths);
-        // Issue #1537: background compaction always runs expiry (Some(now_secs)),
-        // so an expired expiring cell converts to a creation-time (`ldt - ttl`)
-        // tombstone whose LDT sits BELOW the input-derived baseline. Lower the LDT
-        // baseline to a provably-safe floor so the DataWriter's unsigned LDT-delta
-        // never underflows. No-op when no input carries expiring cells.
+        // Issue #1537: unlike `compact_sstables_with_registry` — whose
+        // `now_secs: Option<i64>` parameter can be `None` (expiry disabled), so it
+        // gates the floor application on `now_secs.is_some()` — this WriteEngine
+        // path computes `now_secs` locally above as a plain `i64` (unwrap_or(0))
+        // and ALWAYS builds the merger with the literal `Some(now_secs)` (see the
+        // `KWayMerger::new_with_gc_and_registry` construction above). Expiry is
+        // therefore unconditionally active here, so no `is_some()` gate is needed
+        // (and `now_secs` is not an `Option`, so a literal mirror would not even
+        // compile). An expired expiring cell converts to a creation-time
+        // (`ldt - ttl`) tombstone whose LDT sits BELOW the input-derived baseline,
+        // so lower the LDT baseline to a provably-safe floor so the DataWriter's
+        // unsigned LDT-delta never underflows. No-op when no input carries
+        // expiring cells.
         if let Some(floor) = merge::compute_expiry_ttl_ldt_floor(&input_paths) {
             baseline_min_ldt = baseline_min_ldt.min(floor);
         }

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -248,8 +248,16 @@ impl WriteEngine {
         // Two-pass compaction (issue #729): compute output FINAL encoding baselines
         // by reading the minimum values from each input SSTable's Statistics.db.
         // The output baseline must be ≤ all per-partition values from all inputs.
-        let (baseline_min_ts, baseline_min_ldt, baseline_min_ttl) =
+        let (baseline_min_ts, mut baseline_min_ldt, baseline_min_ttl) =
             merge::compute_baseline_min(&input_paths);
+        // Issue #1537: background compaction always runs expiry (Some(now_secs)),
+        // so an expired expiring cell converts to a creation-time (`ldt - ttl`)
+        // tombstone whose LDT sits BELOW the input-derived baseline. Lower the LDT
+        // baseline to a provably-safe floor so the DataWriter's unsigned LDT-delta
+        // never underflows. No-op when no input carries expiring cells.
+        if let Some(floor) = merge::compute_expiry_ttl_ldt_floor(&input_paths) {
+            baseline_min_ldt = baseline_min_ldt.min(floor);
+        }
         writer.pre_seed_encoding_baselines(baseline_min_ts, baseline_min_ldt, baseline_min_ttl);
 
         // Increment generation for next operation

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1280,7 +1280,13 @@ pub(crate) fn compute_expiry_ttl_ldt_floor(input_paths: &[PathBuf]) -> Option<i3
             // Reinterpret the on-disk `min_deletion_time` bits as UNSIGNED GC-clock
             // seconds (mirrors `compute_baseline_min`) before subtracting the TTL.
             let min_ldt_unsigned = i64::from(ts_stats.min_deletion_time as u32);
-            let input_floor_i64 = min_ldt_unsigned - max_ttl;
+            // Clamp the floor at 0 before the `as i32` reinterpret. A well-formed
+            // GC-clock creation time (`ldt - ttl`) is always >= 0 — Cassandra never
+            // writes a pre-epoch localDeletionTime — so `max_ttl > min_deletion_time`
+            // (a negative floor) is impossible for real data. The clamp defends the
+            // `as i32` cast against a spurious negative bit pattern should a
+            // malformed input ever violate that pre-epoch assumption.
+            let input_floor_i64 = (min_ldt_unsigned - max_ttl).max(0);
             // Store back as the wrapped i32 GC-clock bit pattern (the DataWriter's
             // delta baseline representation).
             let input_floor = input_floor_i64 as i32;

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1247,7 +1247,7 @@ pub fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
 /// metadata-only conservatism — a lower min never wrongly purges); no active
 /// byte-parity golden exists for compaction TTL-expiry output (blocked on #1538).
 /// No-heuristics: derived solely from authoritative Statistics.db.
-pub fn compute_expiry_ttl_ldt_floor(input_paths: &[PathBuf]) -> Option<i32> {
+pub(crate) fn compute_expiry_ttl_ldt_floor(input_paths: &[PathBuf]) -> Option<i32> {
     let mut floor: Option<i32> = None;
     for data_path in input_paths {
         let stats_path = stats_path_for(data_path);

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1224,6 +1224,75 @@ pub fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
     (baseline_min_ts, baseline_min_ldt, baseline_min_ttl)
 }
 
+/// Expiry-aware LOWER bound for the compaction output's `min_local_deletion_time`
+/// delta baseline (issue #1537).
+///
+/// When expiry is active, an EXPIRED expiring cell converts to a tombstone whose
+/// `localDeletionTime` is the CREATION time `ldt - ttl` (Cassandra
+/// `AbstractCell.purge` → `localDeletionTime() - ttl()`) — STRICTLY BELOW the input's
+/// `min_deletion_time` (the EXPIRY instant `ldt`). Without lowering, the input-derived
+/// baseline from [`compute_baseline_min`] sits ABOVE that tombstone's LDT and the
+/// DataWriter's unsigned LDT-delta underflows (the below-baseline guard rejects it).
+///
+/// For each input carrying expiring cells (authoritative signal: a present, positive
+/// `max_ttl` — `EncodingStats` tracks TTL only for expiring cells),
+/// `min_deletion_time - max_ttl` is a PROVABLY-SAFE lower bound for every `ldt - ttl`
+/// (each cell has `ldt >= min_deletion_time`, `ttl <= max_ttl`), and `<=` every
+/// live/unchanged LDT too — so the delta never underflows and the output is a
+/// self-consistent, readable SSTable. Returns the min floor across inputs (wrapped
+/// `i32` GC-clock bits), or `None` when no input carries expiring cells (no-op).
+///
+/// NOTE (byte-parity, deferred to #1538): for MIXED-`ttl` inputs this floor can be
+/// conservatively lower than Cassandra's exact per-cell `min(ldt_i - ttl_i)` (a safe,
+/// metadata-only conservatism — a lower min never wrongly purges); no active
+/// byte-parity golden exists for compaction TTL-expiry output (blocked on #1538).
+/// No-heuristics: derived solely from authoritative Statistics.db.
+pub fn compute_expiry_ttl_ldt_floor(input_paths: &[PathBuf]) -> Option<i32> {
+    let mut floor: Option<i32> = None;
+    for data_path in input_paths {
+        let stats_path = stats_path_for(data_path);
+        if !stats_path.exists() {
+            continue;
+        }
+        let stats_bytes = match std::fs::read(&stats_path) {
+            Ok(b) => b,
+            Err(e) => {
+                log::warn!(
+                    "Could not read Statistics.db {:?} for expiry-TTL LDT floor: {}",
+                    stats_path,
+                    e
+                );
+                continue;
+            }
+        };
+        if let Ok((_, sstable_stats)) =
+            crate::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
+                &stats_bytes,
+                None,
+            )
+        {
+            let ts_stats = &sstable_stats.timestamp_stats;
+            // Authoritative "has expiring cells" signal: a present, positive
+            // `max_ttl` (EncodingStats tracks TTL only for expiring cells).
+            let Some(max_ttl) = ts_stats.max_ttl.filter(|&t| t > 0) else {
+                continue;
+            };
+            // Reinterpret the on-disk `min_deletion_time` bits as UNSIGNED GC-clock
+            // seconds (mirrors `compute_baseline_min`) before subtracting the TTL.
+            let min_ldt_unsigned = i64::from(ts_stats.min_deletion_time as u32);
+            let input_floor_i64 = min_ldt_unsigned - max_ttl;
+            // Store back as the wrapped i32 GC-clock bit pattern (the DataWriter's
+            // delta baseline representation).
+            let input_floor = input_floor_i64 as i32;
+            floor = Some(match floor {
+                Some(cur) => cur.min(input_floor),
+                None => input_floor,
+            });
+        }
+    }
+    floor
+}
+
 /// Compute the overlap-aware max-purgeable timestamp (#935, parity with
 /// Cassandra `CompactionController.maxPurgeableTimestamp`) for a PARTIAL
 /// compaction from the SSTables NOT included in it.
@@ -1832,7 +1901,17 @@ pub async fn compact_sstables_with_registry(
 
     // Two-pass compaction (issue #729): seed the output's encoding baselines from
     // the inputs' Statistics.db before writing any partition.
-    let (baseline_min_ts, baseline_min_ldt, baseline_min_ttl) = compute_baseline_min(&input_paths);
+    let (baseline_min_ts, mut baseline_min_ldt, baseline_min_ttl) =
+        compute_baseline_min(&input_paths);
+    // Issue #1537: when expiry is active, an expired expiring cell converts to a
+    // creation-time (`ldt - ttl`) tombstone whose LDT is BELOW the input-derived
+    // baseline; lower the LDT baseline to a provably-safe floor so the DataWriter's
+    // unsigned LDT-delta never underflows. No-op when no input carries expiring cells.
+    if now_secs.is_some() {
+        if let Some(floor) = compute_expiry_ttl_ldt_floor(&input_paths) {
+            baseline_min_ldt = baseline_min_ldt.min(floor);
+        }
+    }
     writer.pre_seed_encoding_baselines(baseline_min_ts, baseline_min_ldt, baseline_min_ttl);
 
     let mut stats = merger.merge(&mut writer)?;

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -39,6 +39,12 @@ use crate::storage::write_engine::reconcile_rules;
 
 use super::{CellData, ComplexDeletion, KWayMerger, MergeEntry, PurgeCounts, RowData};
 
+// Issue #1537: parity coverage that TTL expiry applies to complex/collection/UDT
+// elements (not only simple cells). Kept in its own file so `reconcile.rs` stays
+// within the campsite size target.
+#[cfg(test)]
+mod ttl_complex_tests;
+
 /// Per-cell reconcile key: `(column, cell_path)` so each element of a multi-cell
 /// column reconciles independently (epic #899). Simple cells have
 /// `cell_path == None`.
@@ -378,11 +384,19 @@ impl ReconcileState {
     /// from the value's byte shape). `now_secs` is the compaction's pinned
     /// evaluation instant (`None` disables expiry: a strict no-op).
     ///
-    /// A cell that is ALREADY a tombstone (`is_cell_tombstone`) is left
-    /// untouched (it has no live value to expire). A complex ELEMENT
-    /// (`is_complex_element`) is intentionally NOT expired here: element-level
-    /// expiry needs per-path handling and is out of scope for #1382 (simple
-    /// cells only); it falls through unchanged.
+    /// A cell that is ALREADY a tombstone (`is_cell_tombstone`, which also covers
+    /// an `is_deleted` complex-element tombstone) is left untouched — it has no
+    /// live value to expire.
+    ///
+    /// COMPLEX / COLLECTION / UDT ELEMENTS (#1537): an expiring ELEMENT of a
+    /// non-frozen complex column (`is_complex_element`) is expired here too, not
+    /// just simple cells (the #1382 scope gap — F2). Cassandra
+    /// `AbstractCell.purge(DeletionPurger, nowInSec)` treats an expired expiring
+    /// cell UNIFORMLY whether simple or complex: it converts it to
+    /// `BufferCell.tombstone(column, timestamp(), localDeletionTime(), path())` —
+    /// PRESERVING the element's cell path. So an expired element becomes an
+    /// element-level tombstone at the SAME path, carrying its own IS_DELETED flag
+    /// (epic #899), which the per-element writer emits as an element tombstone.
     ///
     /// LDT NORMALIZATION (#921 finding 2): on-disk `localDeletionTime` is an
     /// UNSIGNED 32-bit GC-clock second count carried as a wrapped `i32`;
@@ -393,9 +407,9 @@ impl ReconcileState {
             return; // Expiry disabled — strict no-op.
         };
         for cell in &mut self.surviving {
-            // Only simple LIVE expiring cells are candidates. A cell tombstone
-            // has no live value; a complex element is out of scope (#1382).
-            if cell.is_complex_element || KWayMerger::is_cell_tombstone(cell) {
+            // An existing tombstone (simple cell tombstone OR a complex-element
+            // tombstone via `is_deleted`) has no live value to expire.
+            if KWayMerger::is_cell_tombstone(cell) {
                 continue;
             }
             let (Some(_ttl), Some(ldt)) = (cell.ttl, cell.local_deletion_time) else {
@@ -404,25 +418,36 @@ impl ReconcileState {
             // Expired iff the expiry instant (unsigned GC-clock seconds) is
             // strictly before the pinned "now" — matching Cassandra's
             // `localDeletionTime < now` liveness check for an expiring cell.
-            if i64::from(ldt as u32) < now {
-                // Convert the expired live cell into a cell tombstone whose
-                // `localDeletionTime` IS the expiry instant and whose
-                // `markedForDeleteAt` is the cell's own write timestamp
-                // (unchanged). Step 3c then purges it exactly like any other
-                // cell tombstone once its LDT is < gcBefore and the overlap
-                // gate allows. `ttl` is cleared: a tombstone carries no TTL.
-                cell.value = crate::types::Value::Tombstone(crate::types::TombstoneInfo {
-                    deletion_time: cell.timestamp,
-                    tombstone_type: crate::types::TombstoneType::CellTombstone,
-                    local_deletion_time: i64::from(ldt as u32),
-                    ttl: None,
-                    range_start: None,
-                    range_end: None,
-                });
-                cell.ttl = None;
-                // Keep `cell.local_deletion_time` = the expiry instant so
-                // `cell_effective_ldt` and the writer preserve it verbatim.
+            if i64::from(ldt as u32) >= now {
+                continue; // Not yet expired.
             }
+            // Convert the expired live cell into a (cell / complex-element)
+            // tombstone whose `localDeletionTime` IS the expiry instant and whose
+            // `markedForDeleteAt` is the cell's own write timestamp (unchanged) —
+            // Cassandra `BufferCell.tombstone(column, timestamp(), localDeletionTime(),
+            // path())`. Step 3c then purges it exactly like any other cell
+            // tombstone once its LDT is < gcBefore and the overlap gate allows.
+            // `ttl` is cleared: a tombstone carries no TTL.
+            cell.value = crate::types::Value::Tombstone(crate::types::TombstoneInfo {
+                deletion_time: cell.timestamp,
+                tombstone_type: crate::types::TombstoneType::CellTombstone,
+                local_deletion_time: i64::from(ldt as u32),
+                ttl: None,
+                range_start: None,
+                range_end: None,
+            });
+            cell.ttl = None;
+            // A complex ELEMENT additionally carries its deletion via the
+            // authoritative IS_DELETED flag (epic #899). Set it so the per-element
+            // writer emits an element tombstone (preserving the element's
+            // cell_path, Cassandra `path()`) rather than a live element, and so the
+            // gc-grace purge's `cell.is_deleted` branch (Step 3c (a)) treats it as
+            // a purgeable complex-element tombstone. The cell path is untouched.
+            if cell.is_complex_element {
+                cell.is_deleted = true;
+            }
+            // Keep `cell.local_deletion_time` = the expiry instant so
+            // `cell_effective_ldt` and the writer preserve it verbatim.
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -393,10 +393,12 @@ impl ReconcileState {
     /// just simple cells (the #1382 scope gap — F2). Cassandra
     /// `AbstractCell.purge(DeletionPurger, nowInSec)` treats an expired expiring
     /// cell UNIFORMLY whether simple or complex: it converts it to
-    /// `BufferCell.tombstone(column, timestamp(), localDeletionTime(), path())` —
-    /// PRESERVING the element's cell path. So an expired element becomes an
-    /// element-level tombstone at the SAME path, carrying its own IS_DELETED flag
-    /// (epic #899), which the per-element writer emits as an element tombstone.
+    /// `BufferCell.tombstone(column, timestamp(), localDeletionTime() - ttl(), path())` —
+    /// PRESERVING the element's cell path and setting the tombstone's
+    /// `localDeletionTime` to `ldt - ttl` (the cell's creation time). So an
+    /// expired element becomes an element-level tombstone at the SAME path,
+    /// carrying its own IS_DELETED flag (epic #899), which the per-element writer
+    /// emits as an element tombstone.
     ///
     /// LDT NORMALIZATION (#921 finding 2): on-disk `localDeletionTime` is an
     /// UNSIGNED 32-bit GC-clock second count carried as a wrapped `i32`;
@@ -412,26 +414,43 @@ impl ReconcileState {
             if KWayMerger::is_cell_tombstone(cell) {
                 continue;
             }
-            let (Some(_ttl), Some(ldt)) = (cell.ttl, cell.local_deletion_time) else {
+            let (Some(ttl), Some(ldt)) = (cell.ttl, cell.local_deletion_time) else {
                 continue; // Not an authoritative expiring cell.
             };
-            // Expired iff the expiry instant (unsigned GC-clock seconds) is
-            // strictly before the pinned "now" — matching Cassandra's
-            // `localDeletionTime < now` liveness check for an expiring cell.
-            if i64::from(ldt as u32) >= now {
-                continue; // Not yet expired.
+            // PARITY — off-by-one at `now == ldt` (issue #1537). Cassandra
+            // `Cell.isLive(nowInSec)` (`Cell.java`) is LIVE iff
+            // `nowInSec < localDeletionTime`, so an expiring cell is EXPIRED iff
+            // `localDeletionTime <= nowInSec`. Keep the cell LIVE only when its
+            // expiry instant (unsigned GC-clock seconds) is STRICTLY in the
+            // future; `ldt == now` means already expired.
+            if i64::from(ldt as u32) > now {
+                continue; // Not yet expired (strictly-future expiry).
             }
+            // PARITY — tombstone `localDeletionTime` == `ldt - ttl` (issue #1537).
+            // Cassandra `AbstractCell.purge` converts an expired expiring cell via
+            // `BufferCell.tombstone(column, timestamp(), localDeletionTime() - ttl(),
+            // path())`. CQLite stores an expiring cell's on-disk
+            // `local_deletion_time` as the EXPIRY instant (`now + ttl`), so the
+            // parity-correct tombstone value is `ldt - ttl` = the cell's
+            // creation-time-in-seconds. gc grace is therefore measured from the
+            // cell's creation time (see the comment in `AbstractCell.purge`).
+            //
+            // GUARD: this cannot underflow for a VALID expiring cell — `ldt`
+            // (= creation + ttl) is always `>= ttl`. A `saturating_sub` on the
+            // unsigned seconds keeps a malformed pair from ever panicking (it
+            // floors at 0, an ancient/purgeable tombstone) with no `unwrap`.
+            let creation_secs: u32 = (ldt as u32).saturating_sub(ttl);
+            let tombstone_ldt: i64 = i64::from(creation_secs);
             // Convert the expired live cell into a (cell / complex-element)
-            // tombstone whose `localDeletionTime` IS the expiry instant and whose
-            // `markedForDeleteAt` is the cell's own write timestamp (unchanged) —
-            // Cassandra `BufferCell.tombstone(column, timestamp(), localDeletionTime(),
-            // path())`. Step 3c then purges it exactly like any other cell
-            // tombstone once its LDT is < gcBefore and the overlap gate allows.
-            // `ttl` is cleared: a tombstone carries no TTL.
+            // tombstone whose `localDeletionTime` is the creation-time instant
+            // (`ldt - ttl`) and whose `markedForDeleteAt` is the cell's own write
+            // timestamp (unchanged). Step 3c then purges it exactly like any other
+            // cell tombstone once its LDT is < gcBefore and the overlap gate
+            // allows. `ttl` is cleared: a tombstone carries no TTL.
             cell.value = crate::types::Value::Tombstone(crate::types::TombstoneInfo {
                 deletion_time: cell.timestamp,
                 tombstone_type: crate::types::TombstoneType::CellTombstone,
-                local_deletion_time: i64::from(ldt as u32),
+                local_deletion_time: tombstone_ldt,
                 ttl: None,
                 range_start: None,
                 range_end: None,
@@ -446,8 +465,15 @@ impl ReconcileState {
             if cell.is_complex_element {
                 cell.is_deleted = true;
             }
-            // Keep `cell.local_deletion_time` = the expiry instant so
-            // `cell_effective_ldt` and the writer preserve it verbatim.
+            // PARITY: the converted tombstone's `localDeletionTime` is the
+            // creation-time instant (`ldt - ttl`), so update `cell.local_deletion_time`
+            // to match. `cell_effective_ldt` prefers this field, so both the
+            // gc-grace purge (Step 3c) and the writer surface the creation-time
+            // LDT — measuring gc grace from creation, per `AbstractCell.purge`.
+            // Stored as the wrapped `i32` GC-clock value (re-widened unsigned by
+            // `cell_effective_ldt`); `creation_secs` fits `i32` for any real
+            // creation time.
+            cell.local_deletion_time = Some(creation_secs as i32);
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/reconcile/ttl_complex_tests.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile/ttl_complex_tests.rs
@@ -1,0 +1,333 @@
+//! Issue #1537: TTL expiry during compaction MUST apply to complex/collection/UDT
+//! ELEMENTS, not just simple cells.
+//!
+//! Follow-up from #1382 (roborev F2). #1382's [`ReconcileState::expire_ttl_cells`]
+//! skipped every `cell.is_complex_element`, so an expiring collection/UDT element
+//! whose authoritative on-disk `localDeletionTime` was already past the pinned
+//! evaluation instant survived a compaction as a LIVE expiring element instead of
+//! being turned into an element tombstone (and then purged past grace).
+//!
+//! ## Parity oracle
+//!
+//! Apache Cassandra `AbstractCell.purge(DeletionPurger, long nowInSec)` treats an
+//! EXPIRED expiring cell UNIFORMLY, simple cell or complex-column element:
+//!
+//! ```java
+//! if (!isLive(nowInSec)) {
+//!     if (purger.shouldPurge(timestamp(), localDeletionTime())) return null;   // purged
+//!     if (isExpiring()) {
+//!         // converts an expired expiring cell to a tombstone PRESERVING path()
+//!         Cell<?> newCell = BufferCell.tombstone(column, timestamp(), localDeletionTime(), path());
+//!         return purger.shouldPurge(timestamp(), localDeletionTime()) ? null : newCell;
+//!     }
+//! }
+//! return this;
+//! ```
+//!
+//! The crux for #1537 is `path()`: the converted tombstone KEEPS the element's
+//! cell path. So an expired collection element becomes an element-level tombstone
+//! at the SAME path, with `markedForDeleteAt` (the cell's own write timestamp) and
+//! `localDeletionTime` (the expiry instant) unchanged, and no live value. Once
+//! `localDeletionTime < gcBefore` (and the overlap gate allows) it is purged.
+//!
+//! ## What these tests exercise
+//!
+//! They drive the REAL production reconcile pipeline
+//! ([`KWayMerger::reconcile_cluster_with_overlap_counted`], the same entry the
+//! compactor's `merge_partition_rows` calls) with a PINNED `now_secs`/`gc_before`
+//! and a `MergeEntry` carrying an expiring complex-element [`CellData`] (the shape
+//! the reader surfaces for a non-frozen collection element on the compaction read
+//! path — epic #899). No wall clock is sampled: every threshold is pinned relative
+//! to the element's own on-disk `localDeletionTime`.
+//!
+//! The end-to-end write→flush→compact→read path is NOT exercised here: CQLite's
+//! WriteEngine→KWayMerger round-trip of a freshly WRITTEN non-frozen collection is
+//! independently broken (a whole-column map/set flush does not read back as
+//! per-element complex cells through the merge reader) — a WRITE-PATH gap outside
+//! #1537's reconcile scope. The reconcile-level parity here is the faithful,
+//! deterministic proof of the fix.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+
+use super::super::{CellData, KWayMerger, MergeEntry, PurgeCounts, RowData};
+use crate::storage::write_engine::mutation::DecoratedKey;
+use crate::types::{TombstoneType, Value};
+
+/// A decorated key from a single token byte.
+fn dk(byte: u8) -> DecoratedKey {
+    DecoratedKey::from_key_bytes(vec![byte]).expect("token")
+}
+
+/// An expiring ELEMENT of a non-frozen complex column, as the compaction reader
+/// surfaces it (epic #899): `is_complex_element == true`, an authoritative
+/// `cell_path`, live value, per-element `ttl` + `local_deletion_time`, and
+/// `is_deleted == false` (a live expiring element is NOT a tombstone).
+fn expiring_complex_element(
+    column: &str,
+    cell_path: &[u8],
+    value: Value,
+    has_empty_value: bool,
+    ts: i64,
+    ttl: u32,
+    ldt: i32,
+) -> CellData {
+    CellData {
+        column: column.to_string(),
+        value,
+        timestamp: ts,
+        ttl: Some(ttl),
+        cell_path: Some(cell_path.to_vec()),
+        local_deletion_time: Some(ldt),
+        is_complex_element: true,
+        is_deleted: false,
+        has_empty_value,
+    }
+}
+
+/// A plain live simple survivor cell so the row is never a phantom key-only drop.
+fn survivor(column: &str, v: i32, ts: i64) -> CellData {
+    CellData::new(column.to_string(), Value::Integer(v), ts)
+}
+
+/// Drive the production reconcile with pinned `now_secs`/`gc_before` (full
+/// compaction: `max_purgeable_timestamp == i64::MAX`), returning the surviving
+/// cells (or empty if the row is dropped whole).
+fn reconcile(
+    cells: Vec<CellData>,
+    row_ts: i64,
+    gc_before: Option<i64>,
+    now: Option<i64>,
+) -> Vec<CellData> {
+    let row = MergeEntry::new(0, dk(1), None, row_ts, RowData::Live { cells });
+    let mut purges = PurgeCounts::default();
+    let merged = KWayMerger::reconcile_cluster_with_overlap_counted(
+        None,
+        vec![row],
+        &HashMap::new(),
+        gc_before,
+        i64::MAX,
+        now,
+        &mut purges,
+    );
+    match merged {
+        Some(entry) => match entry.row_data {
+            RowData::Live { cells } => cells,
+            RowData::Tombstone { .. } => Vec::new(),
+        },
+        None => Vec::new(),
+    }
+}
+
+fn complex_element<'a>(cells: &'a [CellData], column: &str) -> Option<&'a CellData> {
+    cells
+        .iter()
+        .find(|c| c.column == column && c.cell_path.is_some())
+}
+
+fn has_survivor(cells: &[CellData], column: &str) -> bool {
+    cells
+        .iter()
+        .any(|c| c.column == column && matches!(c.value, Value::Integer(_)))
+}
+
+// ===========================================================================
+// Criterion 1 — MAP element expired within grace → element tombstone at path
+// ===========================================================================
+
+#[test]
+fn map_element_expired_within_grace_becomes_element_tombstone() {
+    let ldt: i32 = 1_600_000_000;
+    let cells = vec![
+        expiring_complex_element(
+            "props",
+            b"k1",
+            Value::Text("secret".to_string()),
+            false,
+            100,
+            60,
+            ldt,
+        ),
+        survivor("score", 7, 100),
+    ];
+    // Expired: now AFTER ldt. Within grace: gcBefore == ldt so `ldt < gcBefore`
+    // is false → the element tombstone is RETAINED.
+    let out = reconcile(cells, 100, Some(i64::from(ldt)), Some(i64::from(ldt) + 10));
+
+    let elem = complex_element(&out, "props").unwrap_or_else(|| {
+        panic!("expired-within-grace element must survive as a tombstone, got {out:?}")
+    });
+    // Cassandra `BufferCell.tombstone(..., path())`: element tombstone at the SAME
+    // path, no live value, TTL cleared, ldt/markedForDeleteAt preserved.
+    assert!(
+        elem.is_deleted,
+        "must carry the IS_DELETED element-tombstone flag"
+    );
+    assert_eq!(
+        elem.cell_path.as_deref(),
+        Some(b"k1".as_slice()),
+        "cell path (Cassandra `path()`) must be preserved"
+    );
+    assert!(elem.ttl.is_none(), "a tombstone carries no TTL");
+    assert_eq!(elem.timestamp, 100, "markedForDeleteAt == element write ts");
+    assert_eq!(
+        elem.local_deletion_time,
+        Some(ldt),
+        "localDeletionTime == expiry instant, preserved"
+    );
+    // The live value must NOT survive: it is wrapped as a CellTombstone.
+    assert_ne!(
+        elem.value,
+        Value::Text("secret".to_string()),
+        "the expired element's live value must not survive"
+    );
+    assert!(
+        matches!(&elem.value, Value::Tombstone(info)
+            if info.tombstone_type == TombstoneType::CellTombstone),
+        "expired element surfaces a CellTombstone value, got {:?}",
+        elem.value
+    );
+    assert!(
+        has_survivor(&out, "score"),
+        "the independent survivor cell stays live"
+    );
+}
+
+// ===========================================================================
+// Criterion 2 — MAP element expired past grace → purged entirely
+// ===========================================================================
+
+#[test]
+fn map_element_expired_past_grace_is_purged() {
+    let ldt: i32 = 1_600_000_000;
+    let cells = vec![
+        expiring_complex_element(
+            "props",
+            b"k1",
+            Value::Text("secret".to_string()),
+            false,
+            100,
+            60,
+            ldt,
+        ),
+        survivor("score", 7, 100),
+    ];
+    // Expired AND past grace: gcBefore STRICTLY > ldt → purged (full compaction →
+    // overlap gate +inf allows it).
+    let out = reconcile(
+        cells,
+        100,
+        Some(i64::from(ldt) + 1),
+        Some(i64::from(ldt) + 1000),
+    );
+
+    assert!(
+        complex_element(&out, "props").is_none(),
+        "expired-past-grace element must be purged entirely, got {out:?}"
+    );
+    assert!(
+        has_survivor(&out, "score"),
+        "purging only the expired element must leave the survivor cell present"
+    );
+}
+
+// ===========================================================================
+// Criterion 3 — live (un-expired) MAP element survives unchanged
+// ===========================================================================
+
+#[test]
+fn live_map_element_survives_unchanged() {
+    let ldt: i32 = 2_000_000_000; // far future
+    let cells = vec![
+        expiring_complex_element(
+            "props",
+            b"k1",
+            Value::Text("alive".to_string()),
+            false,
+            100,
+            10_000_000,
+            ldt,
+        ),
+        survivor("score", 7, 100),
+    ];
+    // now BEFORE the expiry instant → not expired.
+    let out = reconcile(
+        cells,
+        100,
+        Some(i64::from(ldt) - 100),
+        Some(i64::from(ldt) - 1),
+    );
+
+    let elem = complex_element(&out, "props")
+        .unwrap_or_else(|| panic!("un-expired element must survive, got {out:?}"));
+    assert!(!elem.is_deleted, "an un-expired element is not a tombstone");
+    assert_eq!(
+        elem.value,
+        Value::Text("alive".to_string()),
+        "live element keeps its value"
+    );
+    assert!(elem.ttl.is_some(), "live expiring element keeps its TTL");
+    assert_eq!(elem.local_deletion_time, Some(ldt), "LDT unchanged");
+}
+
+// ===========================================================================
+// Criterion 4 — SET member (empty value) expired within grace → element tombstone
+// ===========================================================================
+
+#[test]
+fn set_member_expired_within_grace_becomes_element_tombstone() {
+    let ldt: i32 = 1_600_000_000;
+    let cells = vec![
+        // A SET member: identity lives in the cell path, empty value.
+        expiring_complex_element("tags", b"member1", Value::Null, true, 100, 60, ldt),
+        survivor("score", 7, 100),
+    ];
+    let out = reconcile(cells, 100, Some(i64::from(ldt)), Some(i64::from(ldt) + 10));
+
+    let elem = complex_element(&out, "tags")
+        .unwrap_or_else(|| panic!("expired SET member must survive as a tombstone, got {out:?}"));
+    assert!(elem.is_deleted, "SET member tombstone carries IS_DELETED");
+    assert_eq!(
+        elem.cell_path.as_deref(),
+        Some(b"member1".as_slice()),
+        "SET member cell path preserved"
+    );
+    assert!(elem.ttl.is_none(), "a tombstone carries no TTL");
+    assert!(has_survivor(&out, "score"), "survivor stays live");
+}
+
+// ===========================================================================
+// Criterion 5 — expiry DISABLED (now_secs == None) is a strict no-op for a
+// complex element too (regression guard: the #1382 no-op invariant extends to
+// #1537's complex path).
+// ===========================================================================
+
+#[test]
+fn expiry_disabled_leaves_complex_element_live() {
+    let ldt: i32 = 1_600_000_000;
+    let cells = vec![expiring_complex_element(
+        "props",
+        b"k1",
+        Value::Text("secret".to_string()),
+        false,
+        100,
+        60,
+        ldt,
+    )];
+    // now_secs = None → expiry is a strict no-op even though the element is
+    // long-expired relative to any real clock.
+    let out = reconcile(cells, 100, None, None);
+    let elem = complex_element(&out, "props")
+        .unwrap_or_else(|| panic!("no-op expiry must leave the element live, got {out:?}"));
+    assert!(
+        !elem.is_deleted,
+        "no-op expiry must not tombstone the element"
+    );
+    assert_eq!(
+        elem.value,
+        Value::Text("secret".to_string()),
+        "value untouched"
+    );
+    assert_eq!(elem.ttl, Some(60), "ttl untouched");
+}

--- a/cqlite-core/src/storage/write_engine/merge/reconcile/ttl_complex_tests.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile/ttl_complex_tests.rs
@@ -16,19 +16,27 @@
 //! if (!isLive(nowInSec)) {
 //!     if (purger.shouldPurge(timestamp(), localDeletionTime())) return null;   // purged
 //!     if (isExpiring()) {
-//!         // converts an expired expiring cell to a tombstone PRESERVING path()
-//!         Cell<?> newCell = BufferCell.tombstone(column, timestamp(), localDeletionTime(), path());
-//!         return purger.shouldPurge(timestamp(), localDeletionTime()) ? null : newCell;
+//!         // converts an expired expiring cell to a tombstone PRESERVING path(),
+//!         // with localDeletionTime = localDeletionTime() - ttl() (creation time)
+//!         return BufferCell.tombstone(column, timestamp(), localDeletionTime() - ttl(), path())
+//!                          .purge(purger, nowInSec);
 //!     }
 //! }
 //! return this;
 //! ```
 //!
-//! The crux for #1537 is `path()`: the converted tombstone KEEPS the element's
-//! cell path. So an expired collection element becomes an element-level tombstone
-//! at the SAME path, with `markedForDeleteAt` (the cell's own write timestamp) and
-//! `localDeletionTime` (the expiry instant) unchanged, and no live value. Once
-//! `localDeletionTime < gcBefore` (and the overlap gate allows) it is purged.
+//! Two parity points for #1537:
+//! * `path()`: the converted tombstone KEEPS the element's cell path — an expired
+//!   collection element becomes an element-level tombstone at the SAME path, with
+//!   `markedForDeleteAt` (the cell's own write timestamp) unchanged and no live
+//!   value.
+//! * `localDeletionTime() - ttl()`: the tombstone's `localDeletionTime` is the
+//!   cell's CREATION time (`ldt - ttl`), NOT the expiry instant. CQLite stores the
+//!   on-disk `local_deletion_time` as `now + ttl` (the expiry instant), so the
+//!   parity-correct tombstone value is `ldt - ttl`. gc grace is therefore measured
+//!   from creation: once `ldt - ttl < gcBefore` (and the overlap gate allows) it
+//!   is purged. `Cell.isLive` is `nowInSec < localDeletionTime`, so a cell at
+//!   `now == ldt` is already EXPIRED (strictly-future keep-live).
 //!
 //! ## What these tests exercise
 //!
@@ -100,6 +108,18 @@ fn reconcile(
     gc_before: Option<i64>,
     now: Option<i64>,
 ) -> Vec<CellData> {
+    reconcile_with_purges(cells, row_ts, gc_before, now).0
+}
+
+/// Like [`reconcile`] but also returns the [`PurgeCounts`] the reconcile
+/// accrued, so a test can distinguish a genuine gc/overlap-safe purge (which
+/// increments `cell_tombstones`) from a bare reconciliation drop.
+fn reconcile_with_purges(
+    cells: Vec<CellData>,
+    row_ts: i64,
+    gc_before: Option<i64>,
+    now: Option<i64>,
+) -> (Vec<CellData>, PurgeCounts) {
     let row = MergeEntry::new(0, dk(1), None, row_ts, RowData::Live { cells });
     let mut purges = PurgeCounts::default();
     let merged = KWayMerger::reconcile_cluster_with_overlap_counted(
@@ -111,13 +131,14 @@ fn reconcile(
         now,
         &mut purges,
     );
-    match merged {
+    let out = match merged {
         Some(entry) => match entry.row_data {
             RowData::Live { cells } => cells,
             RowData::Tombstone { .. } => Vec::new(),
         },
         None => Vec::new(),
-    }
+    };
+    (out, purges)
 }
 
 fn complex_element<'a>(cells: &'a [CellData], column: &str) -> Option<&'a CellData> {
@@ -151,9 +172,15 @@ fn map_element_expired_within_grace_becomes_element_tombstone() {
         ),
         survivor("score", 7, 100),
     ];
-    // Expired: now AFTER ldt. Within grace: gcBefore == ldt so `ldt < gcBefore`
-    // is false → the element tombstone is RETAINED.
-    let out = reconcile(cells, 100, Some(i64::from(ldt)), Some(i64::from(ldt) + 10));
+    // Expired: now AFTER ldt. Within grace: the tombstone's effective LDT is the
+    // creation time `ldt - ttl` (parity), so pin gcBefore == `ldt - ttl` — then
+    // `(ldt - ttl) < gcBefore` is false → the element tombstone is RETAINED.
+    let out = reconcile(
+        cells,
+        100,
+        Some(i64::from(ldt) - 60),
+        Some(i64::from(ldt) + 10),
+    );
 
     let elem = complex_element(&out, "props").unwrap_or_else(|| {
         panic!("expired-within-grace element must survive as a tombstone, got {out:?}")
@@ -173,8 +200,9 @@ fn map_element_expired_within_grace_becomes_element_tombstone() {
     assert_eq!(elem.timestamp, 100, "markedForDeleteAt == element write ts");
     assert_eq!(
         elem.local_deletion_time,
-        Some(ldt),
-        "localDeletionTime == expiry instant, preserved"
+        Some(ldt - 60),
+        "localDeletionTime == creation time (ldt - ttl), Cassandra \
+         `AbstractCell.purge` `localDeletionTime() - ttl()`"
     );
     // The live value must NOT survive: it is wrapped as a CellTombstone.
     assert_ne!(
@@ -184,8 +212,9 @@ fn map_element_expired_within_grace_becomes_element_tombstone() {
     );
     assert!(
         matches!(&elem.value, Value::Tombstone(info)
-            if info.tombstone_type == TombstoneType::CellTombstone),
-        "expired element surfaces a CellTombstone value, got {:?}",
+            if info.tombstone_type == TombstoneType::CellTombstone
+                && info.local_deletion_time == i64::from(ldt - 60)),
+        "expired element surfaces a CellTombstone at creation-time LDT (ldt - ttl), got {:?}",
         elem.value
     );
     assert!(
@@ -213,18 +242,26 @@ fn map_element_expired_past_grace_is_purged() {
         ),
         survivor("score", 7, 100),
     ];
-    // Expired AND past grace: gcBefore STRICTLY > ldt → purged (full compaction →
-    // overlap gate +inf allows it).
-    let out = reconcile(
+    // Expired AND past grace: the tombstone's effective LDT is the creation time
+    // `ldt - ttl`, so gcBefore STRICTLY > `ldt - ttl` → purged (full compaction →
+    // overlap gate +inf allows it). Pin gcBefore at the tight creation-time
+    // boundary `ldt - ttl + 1`.
+    let (out, purges) = reconcile_with_purges(
         cells,
         100,
-        Some(i64::from(ldt) + 1),
+        Some(i64::from(ldt) - 60 + 1),
         Some(i64::from(ldt) + 1000),
     );
 
     assert!(
         complex_element(&out, "props").is_none(),
         "expired-past-grace element must be purged entirely, got {out:?}"
+    );
+    // Reviewer finding #4(b): assert this is a REAL gc/overlap-safe purge of a
+    // cell tombstone (issue #1037 counter), not a bare reconciliation drop.
+    assert_eq!(
+        purges.cell_tombstones, 1,
+        "expired-past-grace element must be counted as a purged cell tombstone"
     );
     assert!(
         has_survivor(&out, "score"),
@@ -283,11 +320,22 @@ fn set_member_expired_within_grace_becomes_element_tombstone() {
         expiring_complex_element("tags", b"member1", Value::Null, true, 100, 60, ldt),
         survivor("score", 7, 100),
     ];
-    let out = reconcile(cells, 100, Some(i64::from(ldt)), Some(i64::from(ldt) + 10));
+    // Within grace at the creation-time boundary: gcBefore == `ldt - ttl`.
+    let out = reconcile(
+        cells,
+        100,
+        Some(i64::from(ldt) - 60),
+        Some(i64::from(ldt) + 10),
+    );
 
     let elem = complex_element(&out, "tags")
         .unwrap_or_else(|| panic!("expired SET member must survive as a tombstone, got {out:?}"));
     assert!(elem.is_deleted, "SET member tombstone carries IS_DELETED");
+    assert_eq!(
+        elem.local_deletion_time,
+        Some(ldt - 60),
+        "SET member tombstone localDeletionTime == creation time (ldt - ttl)"
+    );
     assert_eq!(
         elem.cell_path.as_deref(),
         Some(b"member1".as_slice()),
@@ -330,4 +378,57 @@ fn expiry_disabled_leaves_complex_element_live() {
         "value untouched"
     );
     assert_eq!(elem.ttl, Some(60), "ttl untouched");
+}
+
+// ===========================================================================
+// Criterion 6 — off-by-one at `now == ldt` (issue #1537, Fix 2). Cassandra
+// `Cell.isLive(nowInSec)` is `nowInSec < localDeletionTime`, so a cell at
+// `now == ldt` is ALREADY EXPIRED. Before Fix 2 (`ldt >= now` kept it live) it
+// would have stayed a live element; after, it becomes an element tombstone.
+// ===========================================================================
+
+#[test]
+fn element_at_now_equals_ldt_expires() {
+    let ldt: i32 = 1_600_000_000;
+    let ttl: u32 = 60;
+    let cells = vec![
+        expiring_complex_element(
+            "props",
+            b"k1",
+            Value::Text("secret".to_string()),
+            false,
+            100,
+            ttl,
+            ldt,
+        ),
+        survivor("score", 7, 100),
+    ];
+    // now == ldt exactly. Within grace (gcBefore == creation time) so the
+    // resulting tombstone is retained and observable.
+    let out = reconcile(
+        cells,
+        100,
+        Some(i64::from(ldt) - i64::from(ttl)),
+        Some(i64::from(ldt)),
+    );
+
+    let elem = complex_element(&out, "props").unwrap_or_else(|| {
+        panic!("element at now == ldt must expire to a tombstone (isLive is strict <), got {out:?}")
+    });
+    assert!(
+        elem.is_deleted,
+        "at now == ldt the element is expired, not live (Fix 2)"
+    );
+    assert!(
+        matches!(&elem.value, Value::Tombstone(info)
+            if info.tombstone_type == TombstoneType::CellTombstone),
+        "at now == ldt the element surfaces a CellTombstone, got {:?}",
+        elem.value
+    );
+    assert_eq!(
+        elem.local_deletion_time,
+        Some(ldt - ttl as i32),
+        "tombstone localDeletionTime == creation time (ldt - ttl)"
+    );
+    assert!(has_survivor(&out, "score"), "survivor stays live");
 }

--- a/cqlite-core/tests/issue_1382_compaction_ttl_expiry.rs
+++ b/cqlite-core/tests/issue_1382_compaction_ttl_expiry.rs
@@ -5,10 +5,13 @@
 //! expire_ttl_cells → purge_gc_grace → build`) must treat an EXPIRED live cell
 //! (an expiring cell whose authoritative on-disk `localDeletionTime` is already
 //! past the pinned evaluation instant `now_secs`) as a tombstone — matching
-//! Cassandra (`ExpiringCell` / `TTLExpiryTest`), which sets the tombstone's
-//! `localDeletionTime` to the expiry instant and keeps `markedForDeleteAt` (the
-//! cell's own write timestamp) unchanged. Once `localDeletionTime < gcBefore`
-//! (and the overlap / max_purgeable gate allows) the cell is purged entirely.
+//! Cassandra `AbstractCell.purge`, which converts the expired cell via
+//! `BufferCell.tombstone(column, timestamp(), localDeletionTime() - ttl(), path())`:
+//! the tombstone's `localDeletionTime` is the CREATION time (`ldt - ttl`), and
+//! `markedForDeleteAt` (the cell's own write timestamp) is unchanged. `Cell.isLive`
+//! is `nowInSec < localDeletionTime`, so a cell at `now == ldt` is already expired.
+//! gc grace is measured from creation: once `(ldt - ttl) < gcBefore` (and the
+//! overlap / max_purgeable gate allows) the cell is purged entirely.
 //!
 //! Every test here drives the REAL public compaction surface
 //! ([`compact_sstables`]) with a PINNED `now_secs`/`gc_before_secs`, then reads
@@ -24,10 +27,11 @@
 //!
 //! ## Acceptance criteria (issue #1382)
 //!
-//!   1. `expired_within_grace_emitted_as_tombstone` — LDT past but `>= gcBefore`:
-//!      output keeps a cell tombstone, NOT the live value.
-//!   2. `expired_past_grace_purged_entirely` — LDT `< gcBefore`: the cell is
-//!      absent from the compacted output entirely (purged).
+//!   1. `expired_within_grace_emitted_as_tombstone` — expired but the tombstone's
+//!      creation-time LDT (`ldt - ttl`) is `>= gcBefore`: output keeps a cell
+//!      tombstone at that creation-time LDT, NOT the live value.
+//!   2. `expired_past_grace_purged_entirely` — creation-time LDT `< gcBefore`: the
+//!      cell is absent from the compacted output entirely (purged).
 //!   3. `live_ttl_cell_survives` — LDT in the future: emitted live with a
 //!      TTL and its value, and its LDT stays in the future (un-expired). The
 //!      compaction writer re-derives a surviving live TTL cell's LDT from the
@@ -289,11 +293,13 @@ fn expired_within_grace_emitted_as_tombstone() {
     assert!(!inputs.is_empty(), "expected an input SSTable");
 
     let ldt = expiring_name_ldt(&inputs, &schema);
-    // Expired: now is AFTER the expiry instant. Within grace: gcBefore <= ldt
-    // (so the tombstone survives the gc-grace purge). Pin gcBefore == ldt so the
-    // strict `ldt < gcBefore` purge test is false — the tombstone is retained.
+    // Expired: now is AFTER the expiry instant. The tombstone's effective LDT is
+    // the CREATION time `ldt - ttl` (parity, `AbstractCell.purge`
+    // `localDeletionTime() - ttl()`), so within grace means gcBefore <= `ldt - ttl`.
+    // Pin gcBefore == `ldt - ttl` so the strict `(ldt - ttl) < gcBefore` purge
+    // test is false — the tombstone is retained. (`write_ttl_row` uses ttl = 60.)
     let now_secs = ldt + 10;
-    let gc_before = Some(ldt); // ldt is NOT < gcBefore → retained (within grace)
+    let gc_before = Some(ldt - 60); // (ldt - ttl) is NOT < gcBefore → within grace
 
     compact(inputs, &out_dir, &schema, gc_before, Some(now_secs), true);
 
@@ -305,10 +311,12 @@ fn expired_within_grace_emitted_as_tombstone() {
     match &cell.value {
         Value::Tombstone(info) => {
             assert_eq!(info.tombstone_type, TombstoneType::CellTombstone);
-            // localDeletionTime == the expiry instant.
+            // localDeletionTime == the CREATION time (ldt - ttl), Cassandra
+            // `AbstractCell.purge` `localDeletionTime() - ttl()`.
             assert_eq!(
-                info.local_deletion_time, ldt,
-                "tombstone LDT == expiry instant"
+                info.local_deletion_time,
+                ldt - 60,
+                "tombstone LDT == creation time (ldt - ttl)"
             );
         }
         other => panic!("expected a CellTombstone, got live value {other:?}"),
@@ -345,10 +353,12 @@ fn expired_past_grace_purged_entirely() {
     );
     let inputs = discover_inputs(&in_dir);
     let ldt = expiring_name_ldt(&inputs, &schema);
-    // Expired AND past grace: gcBefore STRICTLY > ldt → purged. Full compaction
-    // (purge_safe=true) → overlap gate is +inf, so the purge is allowed.
+    // Expired AND past grace: the tombstone's effective LDT is the creation time
+    // `ldt - ttl`, so gcBefore STRICTLY > `ldt - ttl` → purged. Pin the tight
+    // creation-time boundary `ldt - ttl + 1`. Full compaction (purge_safe=true) →
+    // overlap gate is +inf, so the purge is allowed.
     let now_secs = ldt + 1000;
-    let gc_before = Some(ldt + 1); // ldt < gcBefore → purge
+    let gc_before = Some(ldt - 60 + 1); // (ldt - ttl) < gcBefore → purge
 
     compact(inputs, &out_dir, &schema, gc_before, Some(now_secs), true);
 
@@ -573,13 +583,19 @@ struct CorpusCell {
 }
 
 /// Reference TTL reconcile for a single cell given the authoritative on-disk
-/// `ldt` and the pinned `now_secs`/`gc_before`. Mirrors Cassandra: an expiring
-/// cell with `ldt < now` is a tombstone at `ldt`; a tombstone with
-/// `ldt < gcBefore` is purged (full compaction → overlap gate is +inf).
-fn reference_outcome(name: &str, ldt: i64, now_secs: i64, gc_before: i64) -> RefOutcome {
-    if ldt < now_secs {
-        // Expired → tombstone at ldt. Purged iff ldt < gcBefore.
-        if ldt < gc_before {
+/// `ldt` (the expiry instant), its `ttl`, and the pinned `now_secs`/`gc_before`.
+/// Mirrors Cassandra:
+///   * `Cell.isLive(nowInSec)` is `nowInSec < localDeletionTime`, so the cell is
+///     EXPIRED iff `ldt <= now` (a cell at `now == ldt` is already expired).
+///   * `AbstractCell.purge` converts the expired cell to a tombstone whose
+///     `localDeletionTime` is the CREATION time `ldt - ttl`
+///     (`localDeletionTime() - ttl()`), so it is PURGED iff `(ldt - ttl) < gcBefore`
+///     (full compaction → overlap gate is +inf).
+fn reference_outcome(name: &str, ldt: i64, ttl: i64, now_secs: i64, gc_before: i64) -> RefOutcome {
+    if ldt <= now_secs {
+        // Expired → tombstone at the creation time (ldt - ttl). Purged iff that
+        // creation-time LDT is strictly below gcBefore.
+        if ldt - ttl < gc_before {
             RefOutcome::Absent
         } else {
             RefOutcome::Tombstone
@@ -599,7 +615,6 @@ fn differential_compact_matches_reference_on_ttl_corpus() {
     let temp = TempDir::new().unwrap();
     let in_dir = temp.path().join("in");
     let wal_dir = temp.path().join("wal");
-    let out_dir = temp.path().join("out");
 
     // Mix of short TTLs (will be expired) and a huge TTL (stays live), across
     // several partitions.
@@ -642,79 +657,120 @@ fn differential_compact_matches_reference_on_ttl_corpus() {
         "every corpus cell must surface an on-disk localDeletionTime"
     );
 
-    // Pin now_secs above every short-TTL expiry but below the huge-TTL expiry,
-    // and gc_before between two clusters of the short LDTs so we get a mix of
-    // within-grace and past-grace outcomes.
-    let mut short_ldts: Vec<i64> = corpus
+    // The tombstone an expired cell collapses to carries the CREATION-time LDT
+    // (`ldt - ttl`, parity `AbstractCell.purge`) == the flush wall clock, which is
+    // ~equal across the batch and therefore NOT unique per cell. Map a surviving
+    // tombstone back to its corpus cell by its `markedForDeleteAt` (the cell's own
+    // write timestamp, unique per corpus cell = `100 + i`), which the conversion
+    // preserves verbatim.
+    let creation_by_name: HashMap<String, i64> = corpus
         .iter()
-        .filter(|c| c.ttl < 1_000_000)
-        .map(|c| ldt_by_name[&c.name])
+        .map(|c| (c.name.clone(), ldt_by_name[&c.name] - i64::from(c.ttl)))
         .collect();
-    short_ldts.sort_unstable();
-    assert!(short_ldts.len() >= 2, "need at least two short-TTL cells");
-    let max_short = *short_ldts.last().unwrap();
-    let mid = short_ldts[short_ldts.len() / 2];
+    let name_by_ts: HashMap<i64, String> =
+        corpus.iter().map(|c| (c.ts, c.name.clone())).collect();
 
-    let now_secs = max_short + 1_000; // expires every short-TTL cell
-    let gc_before = mid; // some short LDTs < gc_before (purged), some >= (tombstone)
+    // Pin now_secs above every short-TTL expiry but below the huge-TTL expiry so
+    // every short-TTL cell expires while the huge-TTL cells stay live.
+    let short: Vec<&CorpusCell> = corpus.iter().filter(|c| c.ttl < 1_000_000).collect();
+    assert!(short.len() >= 2, "need at least two short-TTL cells");
+    let max_short_ldt = short
+        .iter()
+        .map(|c| ldt_by_name[&c.name])
+        .max()
+        .expect("short-ttl cells present");
+    let now_secs = max_short_ldt + 1_000; // expires every short-TTL cell
 
-    compact(
-        inputs,
-        &out_dir,
-        &schema,
-        Some(gc_before),
-        Some(now_secs),
-        true,
-    );
+    // The tombstone an expired cell collapses to carries the CREATION-time LDT
+    // (`ldt - ttl` == the flush wall clock, per `write_ttl_row`), which is ~equal
+    // across the whole batch — so a SINGLE gc_before purges either all or none of
+    // the expired cells. To exercise within-grace AND past-grace we run TWO
+    // compactions against the same input: one with gc_before at/below every
+    // creation (expired → tombstone), one strictly above (expired → purged). Live
+    // cells survive in both. This keeps the differential faithful: each run's
+    // production output is compared cell-by-cell to `reference_outcome`.
+    let min_creation = *creation_by_name.values().min().expect("a creation time");
+    let max_creation = *creation_by_name.values().max().expect("a creation time");
 
-    // Build the actual outcome map from the compacted output.
-    let out_inputs = discover_inputs(&out_dir);
-    let out_cells = read_name_cells(&out_inputs, &schema, true);
-    let mut actual: HashMap<String, RefOutcome> = HashMap::new();
-    for c in &out_cells {
-        match &c.value {
-            Value::Text(v) => {
-                actual.insert(v.clone(), RefOutcome::Live(v.clone()));
-            }
-            Value::Tombstone(info) if info.tombstone_type == TombstoneType::CellTombstone => {
-                // Map a surviving tombstone back to its corpus cell by its LDT.
-                if let Some(name) = ldt_by_name
-                    .iter()
-                    .find(|(_, &l)| l == info.local_deletion_time)
-                    .map(|(n, _)| n.clone())
-                {
-                    actual.insert(name, RefOutcome::Tombstone);
+    // Map a compacted output directory back to per-cell outcomes.
+    let outcomes = |out_dir: &Path| -> HashMap<String, RefOutcome> {
+        let out_inputs = discover_inputs(out_dir);
+        let out_cells = read_name_cells(&out_inputs, &schema, true);
+        let mut actual: HashMap<String, RefOutcome> = HashMap::new();
+        for c in &out_cells {
+            match &c.value {
+                Value::Text(v) => {
+                    actual.insert(v.clone(), RefOutcome::Live(v.clone()));
                 }
+                Value::Tombstone(info) if info.tombstone_type == TombstoneType::CellTombstone => {
+                    // Map by `markedForDeleteAt` (the cell's own write timestamp,
+                    // unique per corpus cell), which the expiry conversion preserves.
+                    // Assert the tombstone's LDT is the parity-correct creation time.
+                    if let Some(name) = name_by_ts.get(&c.timestamp) {
+                        assert_eq!(
+                            info.local_deletion_time, creation_by_name[name],
+                            "tombstone for {name} must carry creation-time LDT (ldt - ttl)"
+                        );
+                        actual.insert(name.clone(), RefOutcome::Tombstone);
+                    }
+                }
+                _ => {}
             }
-            _ => {}
         }
-    }
+        actual
+    };
 
-    // Compare against the reference for EVERY corpus cell.
-    let mut saw_live = false;
-    let mut saw_tombstone = false;
-    let mut saw_absent = false;
-    for c in &corpus {
-        let ldt = ldt_by_name[&c.name];
-        let expected = reference_outcome(&c.name, ldt, now_secs, gc_before);
-        let got = actual.get(&c.name).cloned().unwrap_or(RefOutcome::Absent);
-        assert_eq!(
-            got, expected,
-            "cell {} (ldt={ldt}, now={now_secs}, gc_before={gc_before}): \
-             production output != reference TTL merge",
-            c.name
+    // Run one compaction with `gc_before` and assert production == reference for
+    // every corpus cell; return the set of outcomes observed.
+    let run = |run_tag: &str, gc_before: i64, out_dir: &Path| -> (bool, bool, bool) {
+        compact(
+            inputs.clone(),
+            out_dir,
+            &schema,
+            Some(gc_before),
+            Some(now_secs),
+            true,
         );
-        match expected {
-            RefOutcome::Live(_) => saw_live = true,
-            RefOutcome::Tombstone => saw_tombstone = true,
-            RefOutcome::Absent => saw_absent = true,
+        let actual = outcomes(out_dir);
+        let (mut live, mut tomb, mut absent) = (false, false, false);
+        for c in &corpus {
+            let ldt = ldt_by_name[&c.name];
+            let expected = reference_outcome(&c.name, ldt, i64::from(c.ttl), now_secs, gc_before);
+            let got = actual.get(&c.name).cloned().unwrap_or(RefOutcome::Absent);
+            assert_eq!(
+                got, expected,
+                "[{run_tag}] cell {} (ldt={ldt}, now={now_secs}, gc_before={gc_before}): \
+                 production output != reference TTL merge",
+                c.name
+            );
+            match expected {
+                RefOutcome::Live(_) => live = true,
+                RefOutcome::Tombstone => tomb = true,
+                RefOutcome::Absent => absent = true,
+            }
         }
-    }
-    // The corpus MUST exercise all three outcomes or the guard is vacuous.
-    assert!(saw_live, "corpus must include a surviving live cell");
+        (live, tomb, absent)
+    };
+
+    // Within-grace run: gc_before <= every creation → expired cells become
+    // retained tombstones; huge-TTL cells stay live.
+    let grace_dir = temp.path().join("out_grace");
+    let (live_g, tomb_g, absent_g) = run("within-grace", min_creation, &grace_dir);
+    assert!(live_g, "within-grace run must include a surviving live cell");
+    assert!(tomb_g, "within-grace run must include a retained tombstone");
     assert!(
-        saw_tombstone,
-        "corpus must include a within-grace tombstone"
+        !absent_g,
+        "within-grace run must NOT purge any cell (gc_before <= creation)"
     );
-    assert!(saw_absent, "corpus must include a purged (past-grace) cell");
+
+    // Past-grace run: gc_before strictly above every creation → expired cells are
+    // purged entirely; huge-TTL cells stay live.
+    let purge_dir = temp.path().join("out_purge");
+    let (live_p, tomb_p, absent_p) = run("past-grace", max_creation + 1, &purge_dir);
+    assert!(live_p, "past-grace run must include a surviving live cell");
+    assert!(absent_p, "past-grace run must purge the expired cells");
+    assert!(
+        !tomb_p,
+        "past-grace run must retain NO tombstone (gc_before > creation)"
+    );
 }

--- a/cqlite-core/tests/issue_1382_compaction_ttl_expiry.rs
+++ b/cqlite-core/tests/issue_1382_compaction_ttl_expiry.rs
@@ -667,8 +667,7 @@ fn differential_compact_matches_reference_on_ttl_corpus() {
         .iter()
         .map(|c| (c.name.clone(), ldt_by_name[&c.name] - i64::from(c.ttl)))
         .collect();
-    let name_by_ts: HashMap<i64, String> =
-        corpus.iter().map(|c| (c.ts, c.name.clone())).collect();
+    let name_by_ts: HashMap<i64, String> = corpus.iter().map(|c| (c.ts, c.name.clone())).collect();
 
     // Pin now_secs above every short-TTL expiry but below the huge-TTL expiry so
     // every short-TTL cell expires while the huge-TTL cells stay live.
@@ -756,7 +755,10 @@ fn differential_compact_matches_reference_on_ttl_corpus() {
     // retained tombstones; huge-TTL cells stay live.
     let grace_dir = temp.path().join("out_grace");
     let (live_g, tomb_g, absent_g) = run("within-grace", min_creation, &grace_dir);
-    assert!(live_g, "within-grace run must include a surviving live cell");
+    assert!(
+        live_g,
+        "within-grace run must include a surviving live cell"
+    );
     assert!(tomb_g, "within-grace run must include a retained tombstone");
     assert!(
         !absent_g,


### PR DESCRIPTION
Fixes #1537. Compaction TTL expiry was applied to simple cells only; complex/collection/UDT element cells were never expired. This extends expiry to those element cells with Cassandra parity.

## Fix
- Apply TTL expiry to complex/collection/UDT element cells during compaction (both the registry and WriteEngine merge paths).
- Off-by-one at `now == ldt` corrected to match Cassandra `Cell.isLive` (`nowInSec < localDeletionTime`).
- Expired expiring cell → creation-time tombstone with `localDeletionTime = ldt - ttl` per `AbstractCell.purge`.
- **Root-cause fix for the LDT-floor underflow:** decode the authoritative `maxTTL` from `Statistics.db` StatsMetadata field 9 (previously skipped / hardcoded `None` per #1653) so `compute_expiry_ttl_ldt_floor` (`min_deletion_time - max_ttl`, clamped ≥ 0) actually lowers the writer's unsigned LDT delta-baseline and never underflows.
- Consistent floor gating across both compaction sites (registry gates on `now_secs.is_some()`; WriteEngine is structurally always expiry-active — documented).

## Tests
- `issue_1382_compaction_ttl_expiry` incl. `differential_compact_matches_reference_on_ttl_corpus`: 6 passed / 0 failed.
- `ttl_complex_tests` + new authoritative-maxTTL parser unit test.

## Gate of record
```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.VHu4Gt
commit: 2c363123 branch: issue-1537-compaction-ttl-complex dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (2s)
core-tests:        PASS (515s)
tombstones-scan:   PASS (32s)
scan-offload-guard: PASS (36s)
work-counters-guard: PASS (40s)
byte-budget-guard: PASS (7s)
memory-budget:     PASS (39s)
integration-tests: PASS (52s)
format-compat:     PASS (30s)
write-tests:       PASS (130s)
cli-tests:         PASS (86s)
compaction-byte-parity: PASS (9s)
python-bindings:   PASS (351s)
node-bindings:     PASS (328s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (1s)
binding-unwind-profile: PASS (1s)
tooling-tests:     PASS (32s)
minimal-build:     PASS (0s)
smoke:             PASS (30s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.VHu4Gt
summary-file: /tmp/gate-1537c-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Oracle-driven (Cassandra compaction = truth); no OpenSpec. roborev(opus) clean. Unblocks #1538 (per-cell localDeletionTime byte-parity).