### PR TITLE
fix(#1538): preserve per-cell localDeletionTime for surviving TTL cells (compaction byte-parity)

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/data_writer/cells.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/cells.rs
@@ -154,6 +154,12 @@ impl DataWriter {
     ///
     /// CRITICAL: TTL cells MUST NOT use USE_ROW_TIMESTAMP or USE_ROW_TTL flags.
     /// They need explicit timestamp and TTL deltas.
+    ///
+    /// `explicit_ldt` (issue #1538): when `Some`, the cell's `localDeletionTime`
+    /// (Cassandra `localExpirationTime`) is stamped VERBATIM from this authoritative
+    /// per-cell value (e.g. a surviving expiring cell preserved through compaction),
+    /// so the emitted bytes are byte-identical to the source cell. When `None`, the
+    /// LDT is derived from `SystemTime::now() + ttl` (historical fresh-write behavior).
     pub(super) fn write_cell_with_ttl(
         &self,
         buf: &mut Vec<u8>,
@@ -161,6 +167,7 @@ impl DataWriter {
         value: &Value,
         timestamp: i64,
         ttl_seconds: u32,
+        explicit_ldt: Option<i32>,
     ) -> Result<()> {
         // NULL values should not be written as cells
         if matches!(value, Value::Null) {
@@ -170,7 +177,10 @@ impl DataWriter {
             )));
         }
 
-        let local_deletion_time = self.expiring_local_deletion_time(ttl_seconds)?;
+        let local_deletion_time = match explicit_ldt {
+            Some(ldt) => ldt,
+            None => self.expiring_local_deletion_time(ttl_seconds)?,
+        };
 
         // Cell flags - CELL_IS_EXPIRING, NO USE_ROW_TIMESTAMP or USE_ROW_TTL
         let mut flags = CELL_IS_EXPIRING;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
@@ -133,12 +133,15 @@ impl DataWriter {
                                 ttl_seconds,
                             )?;
                         } else {
+                            // Row-level `USING TTL` write (no per-cell LDT source):
+                            // derive `now + ttl` (historical behavior).
                             self.write_cell_with_ttl(
                                 buf,
                                 column,
                                 value,
                                 mop.timestamp_micros,
                                 ttl_seconds,
+                                None,
                             )?;
                         }
                     } else if row.liveness_ts == Some(mop.timestamp_micros) {
@@ -153,6 +156,7 @@ impl DataWriter {
                 column,
                 value,
                 ttl_seconds,
+                local_deletion_time,
             } => {
                 // Skip NULL values - they are represented by absence in the bitmap
                 if matches!(value, Value::Null) {
@@ -169,12 +173,16 @@ impl DataWriter {
                 } else {
                     // roborev #1020 Finding 1: schema-aware frozen-UDT value.
                     let canon = canonicalize_udt_value(&col.data_type, value)?;
+                    // Issue #1538: stamp the authoritative per-cell LDT verbatim
+                    // when present (a surviving expiring cell preserved through
+                    // compaction), else derive `now + ttl`.
                     self.write_cell_with_ttl(
                         buf,
                         column,
                         canon.as_ref(),
                         mop.timestamp_micros,
                         *ttl_seconds,
+                        *local_deletion_time,
                     )?;
                 }
                 Ok(1)

--- a/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
@@ -394,12 +394,15 @@ impl DataWriter {
                                              // forever) — a data-liveness regression. The no-TTL path
                                              // stays byte-identical (explicit-ts, flags 0x00).
                         match mop.row_ttl_seconds {
+                            // Row-level `USING TTL` static write (no per-cell LDT
+                            // source): derive `now + ttl` (historical behavior).
                             Some(ttl) => self.write_cell_with_ttl(
                                 buf,
                                 column,
                                 value,
                                 mop.timestamp_micros,
                                 ttl,
+                                None,
                             )?,
                             None => self.write_cell_explicit_ts(
                                 buf,
@@ -414,18 +417,21 @@ impl DataWriter {
                     column,
                     value,
                     ttl_seconds,
+                    local_deletion_time,
                 } => {
                     // Only write if it's a static column
                     if static_column_names.contains(column) && !matches!(value, Value::Null) {
                         cells_written += 1;
                         // roborev #1020 Finding 1: schema-aware frozen-UDT value.
                         let canon = canonicalize_static_value(schema, column, value)?;
+                        // Issue #1538: honor the authoritative per-cell LDT verbatim.
                         self.write_cell_with_ttl(
                             buf,
                             column,
                             canon.as_ref(),
                             mop.timestamp_micros,
                             *ttl_seconds,
+                            *local_deletion_time,
                         )?;
                     }
                 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_2.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_2.rs
@@ -583,6 +583,7 @@ fn test_write_cell_with_ttl() {
             &Value::Text("test".to_string()),
             timestamp,
             ttl_seconds,
+            None,
         )
         .unwrap();
 
@@ -630,6 +631,7 @@ fn test_row_with_ttl_cells() {
                 column: "name".to_string(),
                 value: Value::Text("Alice".to_string()),
                 ttl_seconds: 7200,
+                local_deletion_time: None,
             },
             CellOperation::Write {
                 column: "age".to_string(),
@@ -679,11 +681,13 @@ fn test_row_with_multiple_ttl_cells() {
                 column: "name".to_string(),
                 value: Value::Text("Alice".to_string()),
                 ttl_seconds: 3600, // 1 hour
+                local_deletion_time: None,
             },
             CellOperation::WriteWithTtl {
                 column: "age".to_string(),
                 value: Value::Integer(30),
                 ttl_seconds: 7200, // 2 hours (different TTL)
+                local_deletion_time: None,
             },
         ],
         1001000,
@@ -723,6 +727,7 @@ fn test_mixed_ttl_and_regular_cells() {
                 column: "age".to_string(),
                 value: Value::Integer(30),
                 ttl_seconds: 7200,
+                local_deletion_time: None,
             },
         ],
         1001000,
@@ -758,6 +763,7 @@ fn test_ttl_zero_special_case() {
             &Value::Text("test".to_string()),
             timestamp,
             ttl_seconds,
+            None,
         )
         .unwrap();
 
@@ -788,7 +794,8 @@ fn test_ttl_cell_with_null_value() {
     let writer = DataWriter::new(stats);
 
     let mut buf = Vec::new();
-    let result = writer.write_cell_with_ttl(&mut buf, "test_col", &Value::Null, 1001000, 3600);
+    let result =
+        writer.write_cell_with_ttl(&mut buf, "test_col", &Value::Null, 1001000, 3600, None);
 
     assert!(result.is_err(), "NULL values should return error");
     assert!(result
@@ -817,6 +824,7 @@ fn test_ttl_cell_local_deletion_time_calculation() {
             &Value::Text("test".to_string()),
             timestamp,
             ttl_seconds,
+            None,
         )
         .unwrap();
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
@@ -499,6 +499,7 @@ fn static_using_ttl_write_byte_parity_1210() {
             column: "s".to_string(),
             value: value.clone(),
             ttl_seconds: ttl,
+            local_deletion_time: None,
         },
         timestamp_micros: timestamp,
         cell_local_deletion_time: 0,

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_4.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_4.rs
@@ -977,6 +977,7 @@ fn test_write_with_ttl_complex_column() {
                 Value::Text("b".to_string()),
             ]),
             ttl_seconds: 3600,
+            local_deletion_time: None,
         }],
         1001000,
         None,

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -659,17 +659,32 @@ impl SSTableWriter {
                 match op {
                     crate::storage::write_engine::mutation::CellOperation::WriteWithTtl {
                         ttl_seconds,
+                        local_deletion_time,
                         ..
                     } => {
                         // Track TTL
                         self.stats.update_ttl(*ttl_seconds as i32);
-                        // CRITICAL: TTL cells need local_deletion_time tracked
-                        // local_deletion_time = now + ttl
-                        let now_seconds = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .map(|d| d.as_secs() as i32)
-                            .unwrap_or(0);
-                        let local_deletion_time = now_seconds.saturating_add(*ttl_seconds as i32);
+                        // CRITICAL: TTL cells need local_deletion_time tracked so the
+                        // per-cell LDT delta (`ldt - min_local_deletion_time`) written
+                        // by `write_cell_with_ttl` never underflows.
+                        //
+                        // Issue #1538: honor the authoritative per-cell LDT VERBATIM
+                        // when present (a surviving expiring cell preserved through
+                        // compaction), exactly as `write_cell_with_ttl` will stamp it,
+                        // so the seeded baseline and the emitted bytes agree. A per-cell
+                        // LDT below the wall-clock-derived value would otherwise
+                        // underflow the unsigned delta. `None` keeps the historical
+                        // `now + ttl` derivation.
+                        let local_deletion_time = match local_deletion_time {
+                            Some(ldt) => *ldt,
+                            None => {
+                                let now_seconds = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_secs() as i32)
+                                    .unwrap_or(0);
+                                now_seconds.saturating_add(*ttl_seconds as i32)
+                            }
+                        };
                         self.stats.update_local_deletion_time(local_deletion_time);
                     }
                     op @ (crate::storage::write_engine::mutation::CellOperation::Delete { .. }
@@ -1009,16 +1024,28 @@ impl SSTableWriter {
                 match op {
                     crate::storage::write_engine::mutation::CellOperation::WriteWithTtl {
                         ttl_seconds,
+                        local_deletion_time,
                         ..
                     } => {
                         let ttl = *ttl_seconds as i32;
                         if ttl > 0 {
                             min_ttl = min_ttl.min(ttl);
-                            let now_seconds = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .map(|d| d.as_secs() as i32)
-                                .unwrap_or(0);
-                            let ldt = now_seconds.saturating_add(ttl);
+                            // Issue #1538: the encoding baseline must match the LDT
+                            // the expiring cell will ACTUALLY be written with, else
+                            // the unsigned delta underflows. An authoritative
+                            // per-cell `local_deletion_time: Some(L)` is emitted with
+                            // `L` verbatim (a surviving expiring cell preserved
+                            // through compaction); `None` derives `now + ttl`.
+                            let ldt = match local_deletion_time {
+                                Some(l) => *l,
+                                None => {
+                                    let now_seconds = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map(|d| d.as_secs() as i32)
+                                        .unwrap_or(0);
+                                    now_seconds.saturating_add(ttl)
+                                }
+                            };
                             min_ldt = min_ldt.min(ldt);
                         }
                     }

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -337,11 +337,7 @@ impl Memtable {
                 .len()
                 .saturating_add(Self::estimate_value_size(value))
                 .saturating_add(8), // +8 for overhead
-            CellOperation::WriteWithTtl {
-                column,
-                value,
-                ttl_seconds: _,
-            } => {
+            CellOperation::WriteWithTtl { column, value, .. } => {
                 // TTL cells: same as Write + 4 bytes for TTL + 4 bytes for local_deletion_time
                 column
                     .len()

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -3472,10 +3472,18 @@ impl KWayMerger {
                     }
                 }
                 if let Some(ttl) = cell.ttl {
+                    // #1538: preserve the SOURCE expiring cell's authoritative
+                    // on-disk `localDeletionTime` (= writetime_s + ttl) so a live
+                    // TTL cell that survives THIS compaction is re-emitted
+                    // byte-identically — the writer stamps this LDT verbatim
+                    // instead of recomputing `now + ttl` (which would drift by the
+                    // compaction wall-clock skew). `None` (LDT not surfaced by the
+                    // reader) leaves the writer's historical derivation in place.
                     CellOperation::WriteWithTtl {
                         column: cell.column,
                         value: cell.value,
                         ttl_seconds: ttl,
+                        local_deletion_time: cell.local_deletion_time,
                     }
                 } else {
                     CellOperation::Write {
@@ -8980,6 +8988,7 @@ mod issue_822_merge_ordering_semantics {
                 column: "v".to_string(),
                 value: Value::Text("expiring-if-buggy".to_string()),
                 ttl_seconds: 3600,
+                local_deletion_time: None,
             }],
             TS,
             None,
@@ -9132,6 +9141,7 @@ mod issue_822_merge_ordering_semantics {
                 column: "v".to_string(),
                 value: Value::Text("expiring-if-buggy".to_string()),
                 ttl_seconds: 3600,
+                local_deletion_time: None,
             }],
             TS,
             None,

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -304,8 +304,14 @@ pub enum CellOperation {
         /// `now + ttl`), so the fresh CQL/WAL `USING TTL` write paths that build
         /// a `WriteWithTtl` without a surfaced source LDT are unchanged.
         ///
-        /// `#[serde(default)]` keeps backward compatibility with `WriteWithTtl`
-        /// values serialized before this field existed (e.g. older WAL records).
+        /// `#[serde(default)]` only helps SELF-DESCRIBING formats (e.g. the JSON
+        /// `--mutation` CLI input), where a missing field is defaulted by name.
+        /// It does NOT provide WAL back-compat: the WAL uses bincode, a
+        /// non-self-describing positional format that IGNORES `#[serde(default)]`,
+        /// so upgrade-replay of pre-#1538 `WriteWithTtl` records is handled by the
+        /// pre-#1538 mirror layouts in `wal.rs` (`PreCellLdtWriteTtlMutation` /
+        /// `PreCellLdtWriteTtlCellOperation`), not by this attribute. Do not delete
+        /// those mirrors on the assumption this attribute covers the WAL.
         ///
         /// [`cells_to_cell_operations`]: crate::storage::write_engine::merge
         /// [`CellData::local_deletion_time`]: crate::storage::write_engine::merge::CellData::local_deletion_time

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -285,6 +285,32 @@ pub enum CellOperation {
         value: Value,
         /// Time-to-live in seconds
         ttl_seconds: u32,
+        /// Authoritative per-cell `localDeletionTime` (seconds since the Unix
+        /// epoch, the on-disk GC clock) for this expiring cell — Cassandra's
+        /// `localExpirationTime`, equal to `writetime_seconds + ttl_seconds`
+        /// (issue #1538).
+        ///
+        /// When `Some`, the writer stamps the emitting expiring cell with this
+        /// LDT VERBATIM rather than deriving one from `SystemTime::now() + ttl`.
+        /// The compaction merge→rewrite path
+        /// ([`cells_to_cell_operations`]) sets it from the SOURCE cell's own
+        /// authoritative on-disk LDT ([`CellData::local_deletion_time`]) so a
+        /// live expiring cell that survives a compaction is re-emitted
+        /// byte-identically (its `localDeletionTime` is preserved, not
+        /// recomputed from the compaction wall clock — mirror of #921's
+        /// Delete-path precedent).
+        ///
+        /// `None` preserves the historical behavior (the writer derives
+        /// `now + ttl`), so the fresh CQL/WAL `USING TTL` write paths that build
+        /// a `WriteWithTtl` without a surfaced source LDT are unchanged.
+        ///
+        /// `#[serde(default)]` keeps backward compatibility with `WriteWithTtl`
+        /// values serialized before this field existed (e.g. older WAL records).
+        ///
+        /// [`cells_to_cell_operations`]: crate::storage::write_engine::merge
+        /// [`CellData::local_deletion_time`]: crate::storage::write_engine::merge::CellData::local_deletion_time
+        #[serde(default)]
+        local_deletion_time: Option<i32>,
     },
     /// Delete a specific column
     Delete {

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -305,8 +305,9 @@ fn set_secure_permissions(_file: &File) -> Result<()> {
 /// misaligns.
 ///
 /// This mirror enum reproduces the EXACT pre-#921 variant order and shapes so a
-/// record written by an older binary round-trips. Only `Delete` differs (no
-/// `local_deletion_time`). It MUST stay in lockstep with [`CellOperation`]:
+/// record written by an older binary round-trips. `Delete` differs (no
+/// `local_deletion_time`, pre-#921) and `WriteWithTtl` differs (no per-cell
+/// `local_deletion_time`, pre-#1538). It MUST stay in lockstep with [`CellOperation`]:
 /// variant order is the bincode discriminant, so any reordering / insertion in
 /// the live enum must be reflected here or legacy decoding breaks.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -345,6 +346,8 @@ impl From<LegacyCellOperation> for CellOperation {
     fn from(op: LegacyCellOperation) -> Self {
         match op {
             LegacyCellOperation::Write { column, value } => CellOperation::Write { column, value },
+            // Pre-#1538 expiring cell: no surfaced source LDT, so the writer
+            // derives `now + ttl` (historical behavior).
             LegacyCellOperation::WriteWithTtl {
                 column,
                 value,
@@ -353,6 +356,7 @@ impl From<LegacyCellOperation> for CellOperation {
                 column,
                 value,
                 ttl_seconds,
+                local_deletion_time: None,
             },
             // Pre-#921 cell tombstone: no surfaced source LDT, so the writer
             // derives it from the enclosing mutation (historical behavior).

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -773,6 +773,17 @@ impl From<PreCellLdtWriteTtlMutation> for Mutation {
 /// (D), (C), (B), (A). Each maps to the current [`Mutation`]/[`CellOperation`]
 /// with the newer fields upgraded to their historical defaults (`None`).
 fn decode_mutation(bytes: &[u8]) -> std::result::Result<Mutation, bincode::Error> {
+    // RESIDUAL RISK (inherent to the versionless, positional bincode WAL): because
+    // the current-layout decode is tried FIRST and we return on its first `Ok(..)`,
+    // correctness for a pre-version record relies on that current-layout decode
+    // ERRORING rather than succeeding-but-wrong. #1538 widened `WriteWithTtl` 3->4
+    // fields, so a pre-#1538 record's trailing byte can be positionally misread as
+    // the new `Option<i32>` tag; there is no GENERAL guarantee every such record's
+    // trailing bytes form an invalid tag (the mirror tests only prove the realistic
+    // cases, e.g. WriteWithTtl followed by Delete). This is NOT a new bug — the same
+    // succeed-but-wrong hazard already applies to layouts A-D — just a new instance.
+    // The structural mitigation (a per-record version tag / length-prefixed op
+    // envelope) is tracked in issue #2054; do NOT attempt it here.
     match bincode::deserialize::<Mutation>(bytes) {
         Ok(mutation) => Ok(mutation),
         Err(current_err) => {

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -591,20 +591,195 @@ impl From<PreCellWriteTimestampsMutation> for Mutation {
     }
 }
 
+/// On-disk cell-op layout immediately before Issue #1538 (i.e. post-#921,
+/// pre-#1538 — the shape [`CellOperation`] had for the entire #921..#1538 span,
+/// covering the post-#932/pre-#1018 (D), post-#921/pre-#932 (C), and
+/// post-#1018/pre-#1538 eras).
+///
+/// Issue #1538 appended a trailing `local_deletion_time: Option<i32>` field to
+/// [`CellOperation::WriteWithTtl`], turning its on-disk shape from
+/// `{ column, value, ttl_seconds }` into `{ column, value, ttl_seconds,
+/// local_deletion_time }`. Because the WAL has no per-record version field and
+/// bincode is positional, a record whose ops were written by a pre-#1538 binary
+/// encodes a 3-field `WriteWithTtl` with NO bytes for the new field, so decoding
+/// it with the current [`CellOperation`] reads the following operation's bytes as
+/// the missing `Option` and misaligns the whole record.
+///
+/// This mirror reproduces the EXACT pre-#1538 variant order and shapes — it is
+/// the current [`CellOperation`] with ONLY `WriteWithTtl` reverted to 3 fields.
+/// Crucially the `Delete` variant keeps its post-#921 `{ column,
+/// local_deletion_time }` shape (unlike the older [`LegacyCellOperation`], whose
+/// pre-#921 `Delete { column }` would misdecode a real mixed
+/// `WriteWithTtl` + `Delete` record — e.g. `UPDATE … USING TTL SET a=1, b=null`),
+/// so every op of a pre-#1538 record round-trips faithfully. It MUST stay in
+/// lockstep with [`CellOperation`]: variant order is the bincode discriminant.
+#[derive(serde::Serialize, serde::Deserialize)]
+enum PreCellLdtWriteTtlCellOperation {
+    Write {
+        column: String,
+        value: crate::types::Value,
+    },
+    /// Pre-#1538 expiring cell: no per-cell `local_deletion_time` field.
+    WriteWithTtl {
+        column: String,
+        value: crate::types::Value,
+        ttl_seconds: u32,
+    },
+    /// Post-#921 `Delete` carries its per-cell `local_deletion_time` (current shape).
+    Delete {
+        column: String,
+        local_deletion_time: Option<i32>,
+    },
+    DeleteRow,
+    WriteComplexElement {
+        column: String,
+        cell_path: Vec<u8>,
+        value: Option<crate::types::Value>,
+        timestamp_micros: i64,
+        ttl_seconds: Option<u32>,
+        local_deletion_time: Option<i32>,
+        is_deleted: bool,
+    },
+    ComplexDeletion {
+        column: String,
+        marked_for_delete_at: i64,
+        local_deletion_time: i32,
+    },
+}
+
+impl From<PreCellLdtWriteTtlCellOperation> for CellOperation {
+    fn from(op: PreCellLdtWriteTtlCellOperation) -> Self {
+        match op {
+            PreCellLdtWriteTtlCellOperation::Write { column, value } => {
+                CellOperation::Write { column, value }
+            }
+            // Pre-#1538 expiring cell: no surfaced source LDT, so the writer
+            // derives `now + ttl` (historical behavior).
+            PreCellLdtWriteTtlCellOperation::WriteWithTtl {
+                column,
+                value,
+                ttl_seconds,
+            } => CellOperation::WriteWithTtl {
+                column,
+                value,
+                ttl_seconds,
+                local_deletion_time: None,
+            },
+            PreCellLdtWriteTtlCellOperation::Delete {
+                column,
+                local_deletion_time,
+            } => CellOperation::Delete {
+                column,
+                local_deletion_time,
+            },
+            PreCellLdtWriteTtlCellOperation::DeleteRow => CellOperation::DeleteRow,
+            PreCellLdtWriteTtlCellOperation::WriteComplexElement {
+                column,
+                cell_path,
+                value,
+                timestamp_micros,
+                ttl_seconds,
+                local_deletion_time,
+                is_deleted,
+            } => CellOperation::WriteComplexElement {
+                column,
+                cell_path,
+                value,
+                timestamp_micros,
+                ttl_seconds,
+                local_deletion_time,
+                is_deleted,
+            },
+            PreCellLdtWriteTtlCellOperation::ComplexDeletion {
+                column,
+                marked_for_delete_at,
+                local_deletion_time,
+            } => CellOperation::ComplexDeletion {
+                column,
+                marked_for_delete_at,
+                local_deletion_time,
+            },
+        }
+    }
+}
+
+/// On-disk `Mutation` layout post-Issue #1018, pre-Issue #1538 (layout (E)).
+///
+/// Issue #1538 appended `local_deletion_time` to
+/// [`CellOperation::WriteWithTtl`] (inside `operations: Vec<CellOperation>`). A
+/// record written by the immediately-preceding (post-#1018, pre-#1538) binary
+/// carries ALL current mutation-level trailing fields (`local_deletion_time`,
+/// `row_tombstone`, `cell_write_timestamps`) but encodes any `WriteWithTtl` op
+/// with the pre-#1538 3-field shape. Decoding it as the current [`Mutation`]
+/// (whose `WriteWithTtl` now expects a 4th field) misaligns: bincode either
+/// errors, or worse succeeds-but-wrong by reading the tag byte of the following
+/// mutation field as the missing `Option` — silent corruption. This mirror is
+/// identical to the current [`Mutation`] field-for-field, with only `operations`
+/// swapped to [`PreCellLdtWriteTtlCellOperation`], so such records replay
+/// faithfully with `WriteWithTtl.local_deletion_time = None`.
+///
+/// The field order MUST stay in lockstep with [`Mutation`].
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PreCellLdtWriteTtlMutation {
+    table: TableId,
+    partition_key: PartitionKey,
+    clustering_key: Option<ClusteringKey>,
+    operations: Vec<PreCellLdtWriteTtlCellOperation>,
+    timestamp_micros: i64,
+    ttl_seconds: Option<u32>,
+    partition_tombstone: Option<PartitionTombstone>,
+    range_tombstones: Vec<RangeTombstone>,
+    local_deletion_time: Option<i32>,
+    row_tombstone: Option<(i64, i32)>,
+    cell_write_timestamps: Option<std::collections::HashMap<String, i64>>,
+}
+
+impl From<PreCellLdtWriteTtlMutation> for Mutation {
+    fn from(m: PreCellLdtWriteTtlMutation) -> Self {
+        Mutation {
+            table: m.table,
+            partition_key: m.partition_key,
+            clustering_key: m.clustering_key,
+            operations: m.operations.into_iter().map(CellOperation::from).collect(),
+            timestamp_micros: m.timestamp_micros,
+            ttl_seconds: m.ttl_seconds,
+            partition_tombstone: m.partition_tombstone,
+            range_tombstones: m.range_tombstones,
+            local_deletion_time: m.local_deletion_time,
+            row_tombstone: m.row_tombstone,
+            cell_write_timestamps: m.cell_write_timestamps,
+        }
+    }
+}
+
 /// Deserialize a `Mutation` from WAL bytes, tolerating records written by an
 /// older binary that predates the `Mutation::local_deletion_time` field
-/// (Issue #764) or the `CellOperation::Delete::local_deletion_time` field
-/// (Issue #921).
+/// (Issue #764), the `CellOperation::Delete::local_deletion_time` field
+/// (Issue #921), the `Mutation::row_tombstone` (Issue #932) /
+/// `cell_write_timestamps` (Issue #1018) fields, or the
+/// `CellOperation::WriteWithTtl::local_deletion_time` field (Issue #1538).
 ///
-/// Attempts the layouts most-recent-first: current (C), then layout (B)
-/// (post-#764/pre-#921: mutation LDT present, old `Delete` op shape), then
-/// layout (A) (pre-#764: no mutation LDT, old `Delete` op shape). Each maps to
-/// the current [`Mutation`]/[`CellOperation`] with `Delete.local_deletion_time
-/// = None`, while layout (B) additionally preserves the mutation-level LDT.
+/// Attempts the layouts most-recent-first (each subsequent layout has fewer
+/// trailing fields / an older op shape): current, then layout (E) (post-#1018/
+/// pre-#1538: all current mutation fields but a 3-field `WriteWithTtl`), then
+/// (D), (C), (B), (A). Each maps to the current [`Mutation`]/[`CellOperation`]
+/// with the newer fields upgraded to their historical defaults (`None`).
 fn decode_mutation(bytes: &[u8]) -> std::result::Result<Mutation, bincode::Error> {
     match bincode::deserialize::<Mutation>(bytes) {
         Ok(mutation) => Ok(mutation),
         Err(current_err) => {
+            // Layout (E): post-#1018, pre-#1538 — ALL current mutation-level
+            // trailing fields present, but `WriteWithTtl` ops carry the pre-#1538
+            // 3-field shape. Tried FIRST among the fallbacks because it has the
+            // most trailing fields (same count as the current layout), so a
+            // pre-#1538 `WriteWithTtl` record decodes here rather than misaligning
+            // under the fewer-trailing-field mirrors below. A current record never
+            // reaches this block (the current layout above already decoded it), and
+            // an older (D/C/B/A) record lacks bytes for the extra trailing field(s)
+            // and errors out of this mirror into the correct one below.
+            if let Ok(m) = bincode::deserialize::<PreCellLdtWriteTtlMutation>(bytes) {
+                return Ok(Mutation::from(m));
+            }
             // Layout (D): post-#932, pre-#1018 — current op shapes + mutation LDT
             // + `row_tombstone` but no trailing `cell_write_timestamps`. Tried
             // first so a #932-era record decodes correctly rather than misaligning
@@ -2455,6 +2630,171 @@ mod tests {
                 assert_eq!(value, &Value::Text("Carol".to_string()));
             }
             other => panic!("expected Write, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wal_decodes_layout_e_pre_1538_write_with_ttl_preserving_trailing_fields() {
+        // Layout (E): post-#1018 / pre-#1538. Issue #1538 appended
+        // `local_deletion_time: Option<i32>` to `CellOperation::WriteWithTtl`
+        // (inside `operations: Vec<CellOperation>`). A record written by the
+        // immediately-preceding binary carries ALL current mutation-level trailing
+        // fields (`local_deletion_time`, `row_tombstone`, `cell_write_timestamps`)
+        // but encodes `WriteWithTtl` with the pre-#1538 3-field shape. Decoding it
+        // as the current `Mutation` (whose `WriteWithTtl` now expects a 4th field)
+        // misaligns.
+        //
+        // The `WriteWithTtl` is placed FIRST, followed by a `Delete` carrying an
+        // explicit post-#921 `local_deletion_time: Some(..)`. This exercises two
+        // things at once: (1) the missing per-op LDT byte genuinely misaligns a
+        // naive current decode of the trailing op, and (2) the mirror must use the
+        // post-#921 `Delete { column, local_deletion_time }` shape — reusing the
+        // pre-#921 `LegacyCellOperation::Delete { column }` here would misdecode
+        // this real mixed record (e.g. `UPDATE … USING TTL SET a=1, b=null`).
+        let pre1538 = PreCellLdtWriteTtlMutation {
+            table: TableId::new("ks", "tbl"),
+            partition_key: PartitionKey::single("id", Value::Integer(17)),
+            clustering_key: None,
+            operations: vec![
+                PreCellLdtWriteTtlCellOperation::WriteWithTtl {
+                    column: "session".to_string(),
+                    value: Value::Text("abc".to_string()),
+                    ttl_seconds: 3600,
+                },
+                PreCellLdtWriteTtlCellOperation::Delete {
+                    column: "dropped_col".to_string(),
+                    local_deletion_time: Some(1_710_000_000),
+                },
+            ],
+            timestamp_micros: 1_710_000_000_000_000,
+            ttl_seconds: None,
+            partition_tombstone: None,
+            range_tombstones: Vec::new(),
+            local_deletion_time: Some(1_710_000_001),
+            row_tombstone: Some((1_710_000_002_000_000, 1_710_000_002)),
+            cell_write_timestamps: Some(
+                [("session".to_string(), 1_710_000_003_000_000)]
+                    .into_iter()
+                    .collect(),
+            ),
+        };
+
+        // Bytes as written by a post-#1018/pre-#1538 binary.
+        let pre1538_bytes = bincode::serialize(&pre1538).unwrap();
+
+        // Sanity: the current `Mutation` layout cannot FAITHFULLY decode these
+        // bytes. The pre-#1538 `WriteWithTtl` (first in the list) has no
+        // `local_deletion_time` byte, so a current decode either errors or
+        // misaligns — it can never recover the two-op mutation faithfully. This is
+        // what forces the layout (E) compat path to run (and guards against a
+        // silent "succeed-but-wrong" current decode).
+        let current_attempt = bincode::deserialize::<Mutation>(&pre1538_bytes);
+        let current_recovers_faithfully = matches!(
+            &current_attempt,
+            Ok(m) if m.operations.len() == 2
+                && matches!(&m.operations[0],
+                    CellOperation::WriteWithTtl { column, ttl_seconds, .. }
+                    if column == "session" && *ttl_seconds == 3600)
+                && matches!(&m.operations[1],
+                    CellOperation::Delete { column, local_deletion_time }
+                    if column == "dropped_col" && *local_deletion_time == Some(1_710_000_000))
+                && m.local_deletion_time == Some(1_710_000_001)
+                && m.row_tombstone == Some((1_710_000_002_000_000, 1_710_000_002))
+        );
+        assert!(
+            !current_recovers_faithfully,
+            "current layout must NOT faithfully decode a layout (E) record; \
+             otherwise the (E) compat path is never exercised / a pre-#1538 \
+             WriteWithTtl record would decode-but-wrong"
+        );
+
+        // The (E) compat layout must recover the record: the pre-#1538
+        // WriteWithTtl upgraded to `local_deletion_time: None`, the Delete's
+        // post-#921 LDT preserved, and ALL mutation-level trailing fields intact.
+        let decoded = decode_mutation(&pre1538_bytes).expect("layout (E) record must decode");
+        assert_eq!(decoded.timestamp_micros, 1_710_000_000_000_000);
+        assert_eq!(decoded.local_deletion_time, Some(1_710_000_001));
+        assert_eq!(
+            decoded.row_tombstone,
+            Some((1_710_000_002_000_000, 1_710_000_002))
+        );
+        assert_eq!(
+            decoded.cell_write_timestamps.as_ref().and_then(|m| m
+                .get("session")
+                .copied()),
+            Some(1_710_000_003_000_000)
+        );
+        assert_eq!(decoded.operations.len(), 2);
+        match &decoded.operations[0] {
+            CellOperation::WriteWithTtl {
+                column,
+                value,
+                ttl_seconds,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "session");
+                assert_eq!(value, &Value::Text("abc".to_string()));
+                assert_eq!(*ttl_seconds, 3600);
+                // pre-#1538 WriteWithTtl had no surfaced source LDT → None.
+                assert_eq!(*local_deletion_time, None);
+            }
+            other => panic!("expected WriteWithTtl, got {other:?}"),
+        }
+        match &decoded.operations[1] {
+            CellOperation::Delete {
+                column,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "dropped_col");
+                // The Delete's post-#921 per-cell LDT must survive — a pre-#921
+                // LegacyCellOperation mirror would have corrupted this.
+                assert_eq!(*local_deletion_time, Some(1_710_000_000));
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wal_current_write_with_ttl_ldt_decodes_via_current_layout() {
+        // Guard the other direction: a CURRENT record whose `WriteWithTtl` carries
+        // an explicit `local_deletion_time: Some(..)` (the #1538 compaction path)
+        // must still decode via the current layout (layout 1) and round-trip that
+        // LDT verbatim — adding the layout (E) fallback must NOT regress it.
+        let temp_dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(temp_dir.path()).unwrap();
+
+        let mut mutation = Mutation::new(
+            TableId::new("ks", "tbl"),
+            PartitionKey::single("id", Value::Integer(19)),
+            None,
+            vec![CellOperation::WriteWithTtl {
+                column: "session".to_string(),
+                value: Value::Text("xyz".to_string()),
+                ttl_seconds: 7200,
+                local_deletion_time: Some(1_720_007_200),
+            }],
+            1_720_000_000_000_000,
+            None,
+        );
+        mutation.local_deletion_time = Some(1_720_000_000);
+        wal.append(&mutation).unwrap();
+        wal.sync().unwrap();
+
+        let mutations = wal.replay().unwrap().mutations;
+        assert_eq!(mutations.len(), 1);
+        assert_eq!(mutations[0].local_deletion_time, Some(1_720_000_000));
+        match &mutations[0].operations[0] {
+            CellOperation::WriteWithTtl {
+                column,
+                ttl_seconds,
+                local_deletion_time,
+                ..
+            } => {
+                assert_eq!(column, "session");
+                assert_eq!(*ttl_seconds, 7200);
+                assert_eq!(*local_deletion_time, Some(1_720_007_200));
+            }
+            other => panic!("expected WriteWithTtl, got {other:?}"),
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -516,7 +516,11 @@ struct PreRowTombstoneMutation {
     table: TableId,
     partition_key: PartitionKey,
     clustering_key: Option<ClusteringKey>,
-    operations: Vec<CellOperation>,
+    // Layout (C) predates #1538, so its on-disk `WriteWithTtl` is the 3-field
+    // shape. Decode ops through the pre-#1538 mirror (which keeps the post-#921
+    // `Delete { column, local_deletion_time }` shape this layout carries), NOT
+    // the current 4-field `CellOperation`, which would positionally misalign.
+    operations: Vec<PreCellLdtWriteTtlCellOperation>,
     timestamp_micros: i64,
     ttl_seconds: Option<u32>,
     partition_tombstone: Option<PartitionTombstone>,
@@ -530,7 +534,7 @@ impl From<PreRowTombstoneMutation> for Mutation {
             table: m.table,
             partition_key: m.partition_key,
             clustering_key: m.clustering_key,
-            operations: m.operations,
+            operations: m.operations.into_iter().map(CellOperation::from).collect(),
             timestamp_micros: m.timestamp_micros,
             ttl_seconds: m.ttl_seconds,
             partition_tombstone: m.partition_tombstone,
@@ -563,7 +567,11 @@ struct PreCellWriteTimestampsMutation {
     table: TableId,
     partition_key: PartitionKey,
     clustering_key: Option<ClusteringKey>,
-    operations: Vec<CellOperation>,
+    // Layout (D) predates #1538, so its on-disk `WriteWithTtl` is the 3-field
+    // shape. Decode ops through the pre-#1538 mirror (which keeps the post-#921
+    // `Delete { column, local_deletion_time }` shape this layout carries), NOT
+    // the current 4-field `CellOperation`, which would positionally misalign.
+    operations: Vec<PreCellLdtWriteTtlCellOperation>,
     timestamp_micros: i64,
     ttl_seconds: Option<u32>,
     partition_tombstone: Option<PartitionTombstone>,
@@ -578,7 +586,7 @@ impl From<PreCellWriteTimestampsMutation> for Mutation {
             table: m.table,
             partition_key: m.partition_key,
             clustering_key: m.clustering_key,
-            operations: m.operations,
+            operations: m.operations.into_iter().map(CellOperation::from).collect(),
             timestamp_micros: m.timestamp_micros,
             ttl_seconds: m.ttl_seconds,
             partition_tombstone: m.partition_tombstone,
@@ -2749,6 +2757,200 @@ mod tests {
                 // The Delete's post-#921 per-cell LDT must survive — a pre-#921
                 // LegacyCellOperation mirror would have corrupted this.
                 assert_eq!(*local_deletion_time, Some(1_710_000_000));
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wal_decodes_layout_c_pre_1538_write_with_ttl_no_row_tombstone() {
+        // Layout (C): post-#921 / pre-#932 (and therefore also pre-#1538). The
+        // mutation-level `local_deletion_time` trailing field is PRESENT, but the
+        // record predates #932's trailing `row_tombstone` AND #1018's trailing
+        // `cell_write_timestamps`, so NEITHER trailing field exists on disk. Its
+        // `WriteWithTtl` op is the pre-#1538 3-field shape, while its `Delete`
+        // carries the post-#921 `local_deletion_time`. Serialized here with the
+        // production (C) mirror, which now IS this exact era shape (3-field
+        // `WriteWithTtl` ops via `PreCellLdtWriteTtlCellOperation`, no trailing
+        // row-tombstone / cell-write-timestamps).
+        let era_c = PreRowTombstoneMutation {
+            table: TableId::new("ks", "tbl"),
+            partition_key: PartitionKey::single("id", Value::Integer(21)),
+            clustering_key: None,
+            operations: vec![
+                PreCellLdtWriteTtlCellOperation::WriteWithTtl {
+                    column: "session".to_string(),
+                    value: Value::Text("cee".to_string()),
+                    ttl_seconds: 900,
+                },
+                PreCellLdtWriteTtlCellOperation::Delete {
+                    column: "dropped_col".to_string(),
+                    local_deletion_time: Some(1_650_000_000),
+                },
+            ],
+            timestamp_micros: 1_650_000_000_000_000,
+            ttl_seconds: None,
+            partition_tombstone: None,
+            range_tombstones: Vec::new(),
+            local_deletion_time: Some(1_650_000_001),
+        };
+
+        // Bytes as written by a post-#921/pre-#932 binary.
+        let era_c_bytes = bincode::serialize(&era_c).unwrap();
+
+        // Sanity: the current `Mutation` layout cannot FAITHFULLY decode these
+        // bytes. The pre-#1538 3-field `WriteWithTtl` (first in the list) has no
+        // per-op `local_deletion_time` byte, so a current decode misaligns and can
+        // never recover the two-op mutation faithfully. This is what makes the
+        // silent-corruption gap real, and forces a compat mirror to run.
+        let current_attempt = bincode::deserialize::<Mutation>(&era_c_bytes);
+        let current_recovers_faithfully = matches!(
+            &current_attempt,
+            Ok(m) if m.operations.len() == 2
+                && matches!(&m.operations[0],
+                    CellOperation::WriteWithTtl { column, ttl_seconds, .. }
+                    if column == "session" && *ttl_seconds == 900)
+                && matches!(&m.operations[1],
+                    CellOperation::Delete { column, local_deletion_time }
+                    if column == "dropped_col" && *local_deletion_time == Some(1_650_000_000))
+        );
+        assert!(
+            !current_recovers_faithfully,
+            "current layout must NOT faithfully decode a layout (C) record; \
+             otherwise a pre-#1538 WriteWithTtl would decode-but-wrong (silent \
+             corruption gap)"
+        );
+
+        // The (C) mirror must recover the record: the pre-#1538 `WriteWithTtl`
+        // upgraded to `local_deletion_time: None`, the `Delete`'s post-#921 LDT
+        // preserved, mutation LDT preserved, and — critically for ladder ordering
+        // — NO trailing `row_tombstone` / `cell_write_timestamps` (both None),
+        // proving the record landed on (C), not the more-trailing-field (D)/(E)
+        // mirrors.
+        let decoded = decode_mutation(&era_c_bytes).expect("layout (C) record must decode");
+        assert_eq!(decoded.timestamp_micros, 1_650_000_000_000_000);
+        assert_eq!(decoded.local_deletion_time, Some(1_650_000_001));
+        assert_eq!(decoded.row_tombstone, None);
+        assert_eq!(decoded.cell_write_timestamps, None);
+        assert_eq!(decoded.operations.len(), 2);
+        match &decoded.operations[0] {
+            CellOperation::WriteWithTtl {
+                column,
+                value,
+                ttl_seconds,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "session");
+                assert_eq!(value, &Value::Text("cee".to_string()));
+                assert_eq!(*ttl_seconds, 900);
+                assert_eq!(*local_deletion_time, None);
+            }
+            other => panic!("expected WriteWithTtl, got {other:?}"),
+        }
+        match &decoded.operations[1] {
+            CellOperation::Delete {
+                column,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "dropped_col");
+                assert_eq!(*local_deletion_time, Some(1_650_000_000));
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wal_decodes_layout_d_pre_1538_write_with_ttl_with_row_tombstone() {
+        // Layout (D): post-#932 / pre-#1018 (and therefore also pre-#1538). The
+        // mutation-level `local_deletion_time` AND the #932 trailing
+        // `row_tombstone` are PRESENT, but the record predates #1018's trailing
+        // `cell_write_timestamps` (absent on disk). Its `WriteWithTtl` op is the
+        // pre-#1538 3-field shape, while its `Delete` carries the post-#921
+        // `local_deletion_time`. Serialized here with the production (D) mirror,
+        // which now IS this exact era shape (3-field `WriteWithTtl` ops, trailing
+        // `row_tombstone` but no `cell_write_timestamps`).
+        let era_d = PreCellWriteTimestampsMutation {
+            table: TableId::new("ks", "tbl"),
+            partition_key: PartitionKey::single("id", Value::Integer(23)),
+            clustering_key: None,
+            operations: vec![
+                PreCellLdtWriteTtlCellOperation::WriteWithTtl {
+                    column: "session".to_string(),
+                    value: Value::Text("dee".to_string()),
+                    ttl_seconds: 1800,
+                },
+                PreCellLdtWriteTtlCellOperation::Delete {
+                    column: "dropped_col".to_string(),
+                    local_deletion_time: Some(1_680_000_000),
+                },
+            ],
+            timestamp_micros: 1_680_000_000_000_000,
+            ttl_seconds: None,
+            partition_tombstone: None,
+            range_tombstones: Vec::new(),
+            local_deletion_time: Some(1_680_000_001),
+            row_tombstone: Some((1_680_000_002_000_000, 1_680_000_002)),
+        };
+
+        // Bytes as written by a post-#932/pre-#1018 binary.
+        let era_d_bytes = bincode::serialize(&era_d).unwrap();
+
+        // Sanity: the current `Mutation` layout cannot FAITHFULLY decode these
+        // bytes — the pre-#1538 3-field `WriteWithTtl` (first op) misaligns the
+        // decode (silent-corruption gap).
+        let current_attempt = bincode::deserialize::<Mutation>(&era_d_bytes);
+        let current_recovers_faithfully = matches!(
+            &current_attempt,
+            Ok(m) if m.operations.len() == 2
+                && matches!(&m.operations[0],
+                    CellOperation::WriteWithTtl { column, ttl_seconds, .. }
+                    if column == "session" && *ttl_seconds == 1800)
+                && matches!(&m.operations[1],
+                    CellOperation::Delete { column, local_deletion_time }
+                    if column == "dropped_col" && *local_deletion_time == Some(1_680_000_000))
+                && m.row_tombstone == Some((1_680_000_002_000_000, 1_680_000_002))
+        );
+        assert!(
+            !current_recovers_faithfully,
+            "current layout must NOT faithfully decode a layout (D) record; \
+             otherwise a pre-#1538 WriteWithTtl would decode-but-wrong (silent \
+             corruption gap)"
+        );
+
+        // The (D) mirror must recover the record: `WriteWithTtl` LDT upgraded to
+        // None, `Delete` LDT preserved, mutation LDT preserved, the #932
+        // `row_tombstone` preserved, and — proving it landed on (D) not (E) — NO
+        // trailing `cell_write_timestamps` (None).
+        let decoded = decode_mutation(&era_d_bytes).expect("layout (D) record must decode");
+        assert_eq!(decoded.timestamp_micros, 1_680_000_000_000_000);
+        assert_eq!(decoded.local_deletion_time, Some(1_680_000_001));
+        assert_eq!(
+            decoded.row_tombstone,
+            Some((1_680_000_002_000_000, 1_680_000_002))
+        );
+        assert_eq!(decoded.cell_write_timestamps, None);
+        assert_eq!(decoded.operations.len(), 2);
+        match &decoded.operations[0] {
+            CellOperation::WriteWithTtl {
+                column,
+                value,
+                ttl_seconds,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "session");
+                assert_eq!(value, &Value::Text("dee".to_string()));
+                assert_eq!(*ttl_seconds, 1800);
+                assert_eq!(*local_deletion_time, None);
+            }
+            other => panic!("expected WriteWithTtl, got {other:?}"),
+        }
+        match &decoded.operations[1] {
+            CellOperation::Delete {
+                column,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "dropped_col");
+                assert_eq!(*local_deletion_time, Some(1_680_000_000));
             }
             other => panic!("expected Delete, got {other:?}"),
         }

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -2727,9 +2727,10 @@ mod tests {
             Some((1_710_000_002_000_000, 1_710_000_002))
         );
         assert_eq!(
-            decoded.cell_write_timestamps.as_ref().and_then(|m| m
-                .get("session")
-                .copied()),
+            decoded
+                .cell_write_timestamps
+                .as_ref()
+                .and_then(|m| m.get("session").copied()),
             Some(1_710_000_003_000_000)
         );
         assert_eq!(decoded.operations.len(), 2);

--- a/cqlite-core/tests/issue_1382_compaction_ttl_expiry.rs
+++ b/cqlite-core/tests/issue_1382_compaction_ttl_expiry.rs
@@ -20,10 +20,10 @@
 //! written (writer stamps `flush_now + ttl`), so each test READS that
 //! authoritative LDT back from the input, then pins `now_secs`/`gc_before`
 //! RELATIVE to it — the expiry / purge DECISIONS never sample a wall clock.
-//! (The one value the compaction writer re-derives at write time is a surviving
-//! LIVE TTL cell's output LDT — `compaction_flush_wall_clock + ttl`, since no
-//! per-cell LDT rides on `WriteWithTtl`; criterion 3 therefore asserts only that
-//! the survivor stays un-expired, never a byte-identical LDT — see #1387.)
+//! (Issue #1538: `WriteWithTtl` now carries the source cell's authoritative
+//! per-cell LDT, threaded verbatim through the compaction merge→writer, so a
+//! surviving LIVE TTL cell's output LDT EQUALS its input LDT byte-for-byte —
+//! criterion 3 asserts that equality.)
 //!
 //! ## Acceptance criteria (issue #1382)
 //!
@@ -33,11 +33,10 @@
 //!   2. `expired_past_grace_purged_entirely` — creation-time LDT `< gcBefore`: the
 //!      cell is absent from the compacted output entirely (purged).
 //!   3. `live_ttl_cell_survives` — LDT in the future: emitted live with a
-//!      TTL and its value, and its LDT stays in the future (un-expired). The
-//!      compaction writer re-derives a surviving live TTL cell's LDT from the
-//!      compaction flush wall clock + ttl (no per-cell LDT rides on
-//!      `WriteWithTtl`), so this test does NOT assert a byte-identical LDT for
-//!      the survivor — that byte-parity is deferred to the #1387 byte-oracle.
+//!      TTL and its value, and its LDT stays in the future (un-expired). Issue
+//!      #1538: the surviving cell's LDT is preserved byte-identically (the source
+//!      per-cell LDT threads verbatim through the merge→writer), so this test
+//!      asserts the output LDT EQUALS the input LDT.
 //!   4. `expired_past_grace_retained_under_overlap_gate` — expired-past-grace but
 //!      a PARTIAL compaction with an EXCLUDED overlapping SSTable holding older
 //!      data under the same key: the tombstone is RETAINED (max_purgeable gate).
@@ -112,6 +111,7 @@ fn write_ttl_row(id: i32, ck: i32, name: &str, ttl_seconds: u32, ts: i64) -> Mut
             column: "name".to_string(),
             value: Value::Text(name.to_string()),
             ttl_seconds,
+            local_deletion_time: None,
         }],
         ts,
         None,
@@ -407,16 +407,12 @@ fn live_ttl_cell_survives() {
         "value survives live"
     );
     assert!(cell.ttl.is_some(), "TTL preserved");
-    // The cell is genuinely un-expired: its `localDeletionTime` is still in the
-    // future relative to the pinned evaluation instant. We do NOT assert
-    // byte-identical LDT here: the compaction writer re-derives a surviving live
-    // TTL cell's LDT as `compaction_flush_wall_clock + ttl` (there is no
-    // per-cell LDT carried on `CellOperation::WriteWithTtl`), so the output LDT
-    // is >= the input LDT by exactly the wall-clock skew between the original
-    // flush and the compaction flush (0 within a second, 1 across a second
-    // boundary — asserting equality here is a wall-clock race). Byte-identical
-    // LDT preservation for a surviving live TTL cell is a public-API extension
-    // deferred with the Cassandra byte-oracle work (#1387).
+    // Issue #1538: the surviving live TTL cell is now re-emitted BYTE-IDENTICALLY.
+    // `CellOperation::WriteWithTtl` carries the source cell's authoritative per-cell
+    // `localDeletionTime`, and the compaction merge→writer threads it VERBATIM
+    // (`cells_to_cell_operations` → `write_cell_with_ttl`) instead of re-deriving
+    // `compaction_flush_wall_clock + ttl`. The output LDT therefore EQUALS the input
+    // LDT exactly (no wall-clock skew), meeting #1382 crit-3 literally.
     let out_ldt = cell
         .local_deletion_time
         .map(|l| i64::from(l as u32))
@@ -425,9 +421,10 @@ fn live_ttl_cell_survives() {
         out_ldt > now_secs,
         "surviving cell must be un-expired (LDT {out_ldt} > now {now_secs})"
     );
-    assert!(
-        out_ldt >= ldt,
-        "writer never stamps an LDT earlier than the source (out {out_ldt} >= src {ldt})"
+    assert_eq!(
+        out_ldt, ldt,
+        "surviving live TTL cell's LDT is preserved byte-identically through compaction \
+         (out {out_ldt} == src {ldt}), #1538"
     );
 }
 

--- a/cqlite-core/tests/issue_1535_writetime_ttl_tombstones.rs
+++ b/cqlite-core/tests/issue_1535_writetime_ttl_tombstones.rs
@@ -94,6 +94,7 @@ fn write_row_with_ttl(id: i32, name: &str, score: i32, ttl_seconds: u32, ts: i64
             column: "score".to_string(),
             value: Value::Integer(score),
             ttl_seconds,
+            local_deletion_time: None,
         },
     ];
     Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)

--- a/cqlite-core/tests/issue_1538_ttl_cell_ldt_parity.rs
+++ b/cqlite-core/tests/issue_1538_ttl_cell_ldt_parity.rs
@@ -1,0 +1,279 @@
+//! Issue #1538: a surviving live TTL cell must be re-emitted byte-identically
+//! after compaction — `CellOperation::WriteWithTtl` carries an authoritative
+//! per-cell `localDeletionTime`.
+//!
+//! Cassandra serializes an expiring cell with BOTH its `ttl` AND its
+//! `localExpirationTime` (= `writetime_seconds + ttl`). Before #1538 the CQLite
+//! writer derived the expiring cell's `localDeletionTime` from
+//! `SystemTime::now() + ttl` and the compaction merge dropped the source cell's
+//! LDT entirely (`cells_to_cell_operations` built `WriteWithTtl { column, value,
+//! ttl_seconds }`), so a live TTL cell that survived a compaction was re-stamped
+//! with a fresh `now + ttl` LDT — NOT byte-identical to the source cell / to
+//! Cassandra's compaction output.
+//!
+//! These tests pin the invariant with an AUTHORITATIVE, DETERMINISTIC per-cell
+//! LDT (no wall-clock sampling): a `WriteWithTtl` carrying an explicit
+//! `local_deletion_time` is stamped VERBATIM, and a live TTL cell that survives a
+//! compaction keeps that exact LDT.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::merge::{compact_sstables, CellData, MergeStep, RowData};
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, KWayMerger, Mutation, PartitionKey, TableId, WriteEngine,
+    WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+// A writetime clearly in the past + a large TTL, so the pinned expiration
+// (`writetime_s + ttl`) is deterministic and distinct from any wall-clock
+// `now + ttl` the buggy writer would derive at flush/compaction time.
+const WRITETIME_MICROS: i64 = 1_600_000_000_000_000; // 2020-09-13T12:26:40Z
+const TTL_SECONDS: u32 = 10_000_000;
+// Authoritative per-cell localDeletionTime = writetime_seconds + ttl.
+const PINNED_LDT: i32 = (WRITETIME_MICROS / 1_000_000) as i32 + TTL_SECONDS as i32; // 1_610_000_000
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "ttl_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![col("id", "int"), col("ck", "int"), col("name", "text")],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn col(name: &str, ty: &str) -> Column {
+    Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
+}
+
+/// A row whose `name` cell is an expiring cell carrying an AUTHORITATIVE pinned
+/// per-cell `localDeletionTime` (issue #1538).
+fn pinned_ttl_row(id: i32, ck: i32, name: &str) -> Mutation {
+    Mutation::new(
+        TableId::new("ttl_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::WriteWithTtl {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+            ttl_seconds: TTL_SECONDS,
+            local_deletion_time: Some(PINNED_LDT),
+        }],
+        WRITETIME_MICROS,
+        None,
+    )
+}
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+}
+
+fn flush_batch(data_dir: &Path, wal_dir: &Path, schema: &TableSchema, muts: Vec<Mutation>) {
+    let config = WriteEngineConfig::new(
+        data_dir.to_path_buf(),
+        wal_dir.to_path_buf(),
+        schema.clone(),
+    );
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for m in muts {
+        engine.write(m).expect("write mutation");
+    }
+    let r = rt();
+    r.block_on(engine.flush()).expect("flush").expect("info");
+    r.block_on(engine.close()).expect("close engine");
+}
+
+fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
+    let mut found: Vec<(u64, PathBuf)> = Vec::new();
+    collect(dir, &mut found, 8);
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+fn collect(dir: &Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
+    if depth == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in entries.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            collect(&p, out, depth - 1);
+        } else if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+            if name.ends_with("-big-Data.db") {
+                let gen = name
+                    .split('-')
+                    .nth(1)
+                    .and_then(|g| g.parse::<u64>().ok())
+                    .unwrap_or(0);
+                out.push((gen, p));
+            }
+        }
+    }
+}
+
+/// Read every surviving `name` cell back through the merge read path with expiry
+/// DISABLED (`now_secs = None`) so the RAW on-disk cell state (including its
+/// authoritative `localDeletionTime`) is observed.
+fn read_name_cells(inputs: &[PathBuf], schema: &TableSchema) -> Vec<CellData> {
+    let non_empty: Vec<PathBuf> = inputs
+        .iter()
+        .filter(|p| std::fs::metadata(p).map(|m| m.len() > 0).unwrap_or(false))
+        .cloned()
+        .collect();
+    if non_empty.is_empty() {
+        return Vec::new();
+    }
+    let mut merger = KWayMerger::new_with_gc(non_empty, schema, None, None)
+        .expect("merger")
+        .with_purge_safe(false);
+    let mut cells = Vec::new();
+    loop {
+        match merger.step().expect("step") {
+            MergeStep::Complete => break,
+            MergeStep::Partition { rows, .. } => {
+                for entry in rows {
+                    if let RowData::Live { cells: row_cells } = &entry.row_data {
+                        for c in row_cells {
+                            if c.column == "name" {
+                                cells.push(c.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    cells
+}
+
+fn ldt_of(cell: &CellData) -> i32 {
+    cell.local_deletion_time
+        .expect("expiring cell must carry a localDeletionTime")
+}
+
+// ===========================================================================
+// (1) Direct flush: WriteWithTtl stamps the authoritative per-cell LDT verbatim
+// ===========================================================================
+
+#[test]
+fn write_with_ttl_stamps_authoritative_local_deletion_time() {
+    let temp = TempDir::new().unwrap();
+    let in_dir = temp.path().join("in");
+    let wal_dir = temp.path().join("wal");
+    let schema = make_schema();
+
+    flush_batch(
+        &in_dir,
+        &wal_dir,
+        &schema,
+        vec![pinned_ttl_row(1, 0, "alive")],
+    );
+    let inputs = discover_inputs(&in_dir);
+    assert!(!inputs.is_empty(), "expected an input SSTable");
+
+    let cells = read_name_cells(&inputs, &schema);
+    assert_eq!(cells.len(), 1, "expected exactly one name cell");
+    assert_eq!(cells[0].value, Value::Text("alive".to_string()));
+    assert_eq!(cells[0].ttl, Some(TTL_SECONDS), "TTL preserved");
+    // The on-disk localDeletionTime is the AUTHORITATIVE pinned value, NOT a
+    // wall-clock-derived `now + ttl`.
+    assert_eq!(
+        ldt_of(&cells[0]),
+        PINNED_LDT,
+        "WriteWithTtl must stamp the authoritative per-cell localDeletionTime verbatim \
+         (got {}, expected {PINNED_LDT})",
+        ldt_of(&cells[0])
+    );
+}
+
+// ===========================================================================
+// (2) A surviving live TTL cell keeps its EXACT LDT through a compaction
+// ===========================================================================
+
+#[test]
+fn surviving_live_ttl_cell_ldt_preserved_through_compaction() {
+    let temp = TempDir::new().unwrap();
+    let in_dir = temp.path().join("in");
+    let wal_dir = temp.path().join("wal");
+    let out_dir = temp.path().join("out");
+    let schema = make_schema();
+
+    flush_batch(
+        &in_dir,
+        &wal_dir,
+        &schema,
+        vec![pinned_ttl_row(1, 0, "alive")],
+    );
+    let inputs = discover_inputs(&in_dir);
+    assert!(!inputs.is_empty(), "expected an input SSTable");
+
+    // Sanity: the input carries the authoritative LDT.
+    let in_ldt = ldt_of(&read_name_cells(&inputs, &schema)[0]);
+    assert_eq!(in_ldt, PINNED_LDT, "input cell carries the pinned LDT");
+
+    // Pin the compaction evaluation instant strictly BEFORE the expiration so the
+    // cell is genuinely live (survives). `gc_before` well below the creation time
+    // (`ldt - ttl`) keeps any purge gate inert. No wall-clock is sampled.
+    let now_secs = i64::from(PINNED_LDT) - 1;
+    let gc_before = Some(i64::from(PINNED_LDT) - i64::from(TTL_SECONDS) - 1);
+
+    rt().block_on(compact_sstables(
+        inputs,
+        &out_dir,
+        &schema,
+        1,
+        gc_before,
+        Some(now_secs),
+        true,
+    ))
+    .expect("compaction succeeds");
+
+    let out_inputs = discover_inputs(&out_dir);
+    let cells = read_name_cells(&out_inputs, &schema);
+    assert_eq!(cells.len(), 1, "live TTL cell must survive compaction");
+    assert_eq!(
+        cells[0].value,
+        Value::Text("alive".to_string()),
+        "value survives live"
+    );
+    assert_eq!(cells[0].ttl, Some(TTL_SECONDS), "TTL preserved");
+    // The whole point of #1538: the surviving cell's localDeletionTime is the
+    // ORIGINAL per-cell value, byte-identical to the source — NOT recomputed from
+    // the compaction wall clock.
+    assert_eq!(
+        ldt_of(&cells[0]),
+        PINNED_LDT,
+        "surviving live TTL cell must keep its authoritative localDeletionTime \
+         through compaction (got {}, expected {PINNED_LDT})",
+        ldt_of(&cells[0])
+    );
+}

--- a/cqlite-core/tests/issue_848_tombstone_beats_expiring_roundtrip.rs
+++ b/cqlite-core/tests/issue_848_tombstone_beats_expiring_roundtrip.rs
@@ -99,6 +99,7 @@ fn expiring_write(id: i32, ttl: u32, ts: i64) -> Mutation {
             column: "v".to_string(),
             value: Value::Text("expiring-if-buggy".to_string()),
             ttl_seconds: ttl,
+            local_deletion_time: None,
         },
     ];
     Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)

--- a/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
+++ b/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
@@ -96,6 +96,7 @@ fn write_name_only_ttl(id: i32, name: &str, ttl_seconds: u32, ts: i64) -> Mutati
         column: "name".to_string(),
         value: Value::Text(name.to_string()),
         ttl_seconds,
+        local_deletion_time: None,
     }];
     Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
 }

--- a/cqlite-core/tests/issue_947_reconcile_parity.rs
+++ b/cqlite-core/tests/issue_947_reconcile_parity.rs
@@ -116,6 +116,7 @@ fn write_ttl(col: &str, v: &str, ttl: u32) -> CellOperation {
         column: col.to_string(),
         value: Value::Text(v.to_string()),
         ttl_seconds: ttl,
+        local_deletion_time: None,
     }
 }
 

--- a/cqlite-core/tests/issue_990_data_db_row_framing_parity.rs
+++ b/cqlite-core/tests/issue_990_data_db_row_framing_parity.rs
@@ -654,6 +654,7 @@ fn cell_flag_expiring_explicit_ttl() {
         column: "a".to_string(),
         value: Value::Text("temp".to_string()),
         ttl_seconds: 3600,
+        local_deletion_time: None,
     }];
     let loc = single_cell_flags(det_stats(), ops, None);
     fail_flag(loc, CELL_IS_EXPIRING, "expiring cell (explicit TTL)");

--- a/cqlite-core/tests/write_integration.rs
+++ b/cqlite-core/tests/write_integration.rs
@@ -464,6 +464,7 @@ async fn test_ttl_cells() -> Result<()> {
             column: "value".to_string(),
             value: Value::Text("expires in 5 minutes".to_string()),
             ttl_seconds: 300, // 5 minutes
+            local_deletion_time: None,
         }];
         Mutation::new(table_id, pk, None, ops, 1000001, None)
     };
@@ -477,6 +478,7 @@ async fn test_ttl_cells() -> Result<()> {
             column: "value".to_string(),
             value: Value::Text("cell TTL overrides mutation TTL".to_string()),
             ttl_seconds: 60, // 1 minute (overrides mutation TTL)
+            local_deletion_time: None,
         }];
         Mutation::new(table_id, pk, None, ops, 1000002, Some(7200)) // 2 hours mutation TTL
     };
@@ -985,6 +987,7 @@ async fn test_mixed_operations_in_partition() -> Result<()> {
             column: "value".to_string(),
             value: Value::Text("version 2 with TTL".to_string()),
             ttl_seconds: 3600,
+            local_deletion_time: None,
         }],
         1000001,
         None,


### PR DESCRIPTION
Fixes #1538 (P0). A live (non-expired) expiring cell that survived compaction was re-stamped with a fresh `now + ttl` localDeletionTime instead of its authoritative on-disk value, so it was not byte-identical to Cassandra's compaction output.

## Fix
- Add authoritative `local_deletion_time: Option<i32>` (= writetime_seconds + ttl) to `CellOperation::WriteWithTtl` (`#[serde(default)]`; mirrors #921's Delete-path precedent). `Some` ⇒ stamped verbatim; `None` ⇒ historical `now+ttl` (fresh CQL/WAL `USING TTL` writes unchanged).
- Preserve the source cell's on-disk LDT through the compaction merge, the data writer (regular/static/complex), and **both** stats-seeding paths so `min_local_deletion_time` matches the emitted bytes (avoids the #1537 unsigned-LDT-delta underflow).

## WAL back-compat (two review-first rounds hardened this)
- Added pre-#1538 decode mirror layouts **C/D/E** (`PreCellLdtWriteTtlMutation` + a dedicated `PreCellLdtWriteTtlCellOperation` enum that keeps post-#921 `Delete`), so an upgrade-replayed WAL record with a 3-field `WriteWithTtl` decodes faithfully (→ `None`) instead of silently corrupting. Ladder ordering (E→D→C→B→A, most→fewest trailing fields) verified; current records still decode via layout 1. Regression tests for each layer.
- Residual versionless-WAL succeed-but-wrong risk (inherent to positional bincode, applies to all layouts) documented; structural mitigation tracked in **#2054**.

## Tests
- New `issue_1538_ttl_cell_ldt_parity.rs`: pins PINNED_LDT=1_610_000_000, deterministically distinct from `now+ttl`; direct-flush + compaction round-trips; verified failing pre-fix.
- Tightened `issue_1382` crit-3 `live_ttl_cell_survives` from `>=` to `==`. 50 WAL lib tests + issue_1382 green.

## Gate of record
```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.cXgnzc
commit: 445fabc8 branch: issue-1538-ttl-cell-byte-parity dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (1s)
fmt:               PASS (3s)
clippy:            PASS (2s)
core-tests:        PASS (577s)
tombstones-scan:   PASS (32s)
scan-offload-guard: PASS (37s)
work-counters-guard: PASS (42s)
byte-budget-guard: PASS (8s)
memory-budget:     PASS (41s)
integration-tests: PASS (50s)
format-compat:     PASS (27s)
write-tests:       PASS (136s)
cli-tests:         PASS (89s)
compaction-byte-parity: PASS (10s)
python-bindings:   PASS (387s)
node-bindings:     PASS (354s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (1s)
binding-unwind-profile: PASS (1s)
tooling-tests:     PASS (32s)
minimal-build:     PASS (0s)
smoke:             PASS (30s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.cXgnzc
summary-file: /tmp/gate-1538c-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Oracle-driven (Cassandra compaction = truth); no OpenSpec. roborev(opus): 2 Low doc-accuracy findings, both cleared. Follow-up: #2054 (WAL versioning).