### PR TITLE
perf(#1641,#1575): non-allocating partition-boundary peek (K2) + hoist per-candidate BTI key rehash (C4 pt1)

### DIFF
--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -25,8 +25,10 @@ pub use parser::{
     PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE, FLAG_OPEN_MARKER,
 };
 // Crate-internal zero-copy slice walker (rust-reviewer #1574): consumed only by
-// the SSTable reader, so kept off cqlite-core's public semver surface.
-pub(crate) use parser::lookup_raw_key_in_bti_partitions_slice;
+// the SSTable reader, so kept off cqlite-core's public semver surface. The
+// pre-encoded `lookup_partition_in_bti_slice` variant lets the reader hoist the
+// key hash+encoding out of the candidate-prune loop (issue #1575 / C4).
+pub(crate) use parser::{lookup_partition_in_bti_slice, lookup_raw_key_in_bti_partitions_slice};
 
 use crate::parser::header::CassandraVersion;
 use std::collections::HashMap;

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -25,10 +25,10 @@ pub use parser::{
     PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE, FLAG_OPEN_MARKER,
 };
 // Crate-internal zero-copy slice walker (rust-reviewer #1574): consumed only by
-// the SSTable reader, so kept off cqlite-core's public semver surface. The
-// pre-encoded `lookup_partition_in_bti_slice` variant lets the reader hoist the
-// key hash+encoding out of the candidate-prune loop (issue #1575 / C4).
-pub(crate) use parser::{lookup_partition_in_bti_slice, lookup_raw_key_in_bti_partitions_slice};
+// the SSTable reader, so kept off cqlite-core's public semver surface. It takes a
+// PRE-ENCODED byte-comparable key so callers hoist the key hash+encoding out of the
+// candidate-prune loop (issue #1575 / C4).
+pub(crate) use parser::lookup_partition_in_bti_slice;
 
 use crate::parser::header::CassandraVersion;
 use std::collections::HashMap;

--- a/cqlite-core/src/storage/sstable/bti/parser/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/mod.rs
@@ -80,9 +80,8 @@ pub use rows::{
 // Crate-internal only: the zero-copy slice walker's sole consumers are the
 // SSTable reader (partition_lookup / data_access::bti). Kept off the public
 // semver surface (rust-reviewer #1574). `lookup_partition_in_bti_slice` takes a
-// pre-encoded byte-comparable key so the reader can hoist the Murmur3 hash +
-// encoding out of the candidate-prune loop (issue #1575 / C4).
-pub(crate) use slice_walk::{
-    lookup_partition_in_bti_slice, lookup_raw_key_in_bti_partitions_slice,
-};
+// PRE-ENCODED byte-comparable key so callers hoist the Murmur3 hash + encoding
+// (issue #1575 / C4): every BTI partition lookup now encodes then walks via this
+// single primitive.
+pub(crate) use slice_walk::lookup_partition_in_bti_slice;
 pub use traversal::iterate_partitions_in_bti_file;

--- a/cqlite-core/src/storage/sstable/bti/parser/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/mod.rs
@@ -79,8 +79,10 @@ pub use rows::{
 };
 // Crate-internal only: the zero-copy slice walker's sole consumers are the
 // SSTable reader (partition_lookup / data_access::bti). Kept off the public
-// semver surface (rust-reviewer #1574). `lookup_partition_in_bti_slice` stays
-// `pub(crate)` at its canonical module path (used by its sibling + tests), with
-// no re-export since nothing outside `slice_walk` consumes it.
-pub(crate) use slice_walk::lookup_raw_key_in_bti_partitions_slice;
+// semver surface (rust-reviewer #1574). `lookup_partition_in_bti_slice` takes a
+// pre-encoded byte-comparable key so the reader can hoist the Murmur3 hash +
+// encoding out of the candidate-prune loop (issue #1575 / C4).
+pub(crate) use slice_walk::{
+    lookup_partition_in_bti_slice, lookup_raw_key_in_bti_partitions_slice,
+};
 pub use traversal::iterate_partitions_in_bti_file;

--- a/cqlite-core/src/storage/sstable/bti/parser/partitions.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/partitions.rs
@@ -550,6 +550,12 @@ pub fn lookup_partition_in_bti_file<R: Read + Seek>(
 pub fn encode_partition_key_for_bti_trie(raw_key_bytes: &[u8]) -> [u8; 9] {
     use crate::util::cassandra_murmur3::cassandra_murmur3_token;
 
+    // C4 work-counter (KEY_HASH_CALLS, issue #1575): one per Murmur3 hash + encoding
+    // of a query key. C4 hoists this call out of the candidate-prune loop so a
+    // multi-generation point read records exactly 1 (not one per candidate). No-op in
+    // release builds (read_work_counters design.md Decision 1).
+    crate::storage::sstable::read_work_counters::record_key_hash();
+
     let token: i64 = cassandra_murmur3_token(raw_key_bytes);
     let bc: u64 = (token as u64) ^ 0x8000_0000_0000_0000u64;
     let bc_bytes = bc.to_be_bytes();

--- a/cqlite-core/src/storage/sstable/bti/parser/slice_walk.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/slice_walk.rs
@@ -20,7 +20,7 @@
 use crate::{error::Error, storage::sstable::bti::node::BtiResult};
 
 use super::node_decode::{classify_node_nibble, read_12bit_packed, read_be_unsigned};
-use super::partitions::{encode_partition_key_for_bti_trie, walk_bti_trie, BtiPartitionLocation};
+use super::partitions::{walk_bti_trie, BtiPartitionLocation};
 
 /// Resolve the absolute trie offset of the child reachable from the node at
 /// `node_offset` via `search_byte`, decoding ONLY that one child pointer in place.
@@ -264,18 +264,6 @@ pub(crate) fn lookup_partition_in_bti_slice(
         )));
     }
     walk_bti_trie(&file_bytes[..trie_size], root_offset as usize, encoded_key)
-}
-
-/// Look up a raw partition key in a resident `Partitions.db` buffer using the
-/// `Murmur3Partitioner` byte-comparable encoding, WITHOUT copying the trie.
-///
-/// Zero-copy analogue of [`super::partitions::lookup_raw_key_in_bti_partitions_db`].
-pub(crate) fn lookup_raw_key_in_bti_partitions_slice(
-    file_bytes: &[u8],
-    raw_key_bytes: &[u8],
-) -> BtiResult<Option<BtiPartitionLocation>> {
-    let encoded = encode_partition_key_for_bti_trie(raw_key_bytes);
-    lookup_partition_in_bti_slice(file_bytes, &encoded)
 }
 
 #[cfg(test)]

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1056,6 +1056,39 @@ impl SSTableManager {
     /// the partition-targeted metadata access path is genuinely engaged. The
     /// `tombstones`-build counterpart returns `false` (no prune; full metadata
     /// scan + retain) so the caller reports an honest fallback (Epic #951).
+    /// Prune a reader snapshot to the candidate generations that admit
+    /// `partition_key`, hoisting the BTI key hash+encoding to ONCE per read instead
+    /// of once per candidate (issue #1575 / C4).
+    ///
+    /// When ANY candidate is a BTI ("da") reader, the Murmur3-based byte-comparable
+    /// trie key is computed a SINGLE time and reused for every candidate's trie
+    /// prune (`might_contain_partition_encoded`); on `main` each candidate re-encoded
+    /// the same key, so an N-generation fan-out paid N identical Murmur3 hashes
+    /// (`KEY_HASH_CALLS == N`) where C4 pays 1. A BIG (`nb`) candidate has no BTI
+    /// encoding to hoist — its raw-key bloom check runs unchanged — so a non-BTI or
+    /// mixed candidate set stays correct. The pruning decision (and therefore the
+    /// resulting rows) is byte-identical to the per-candidate path.
+    #[cfg(not(feature = "tombstones"))]
+    fn prune_candidates(
+        readers: &[Arc<reader::SSTableReader>],
+        partition_key: &[u8],
+    ) -> Vec<Arc<reader::SSTableReader>> {
+        use crate::storage::sstable::bti::encode_partition_key_for_bti_trie;
+        // Encode once iff a BTI reader is present (BIG readers ignore `encoded`).
+        let encoded = readers
+            .iter()
+            .any(|r| r.is_bti())
+            .then(|| encode_partition_key_for_bti_trie(partition_key));
+        readers
+            .iter()
+            .filter(|r| match &encoded {
+                Some(enc) => r.might_contain_partition_encoded(partition_key, enc),
+                None => r.might_contain_partition(partition_key),
+            })
+            .cloned()
+            .collect()
+    }
+
     #[cfg(not(feature = "tombstones"))]
     pub async fn scan_partition_with_cell_metadata(
         &self,
@@ -1075,11 +1108,8 @@ impl SSTableManager {
 
         // Prune: keep only SSTables whose bloom filter / BTI trie admit the key.
         // This is the property #962 requires — only candidates are opened, never N.
-        let candidates: Vec<Arc<reader::SSTableReader>> = reader_list
-            .iter()
-            .filter(|r| r.might_contain_partition(partition_key))
-            .cloned()
-            .collect();
+        // C4 (#1575): the BTI key hash+encoding is hoisted to once per read here.
+        let candidates = Self::prune_candidates(&reader_list, partition_key);
 
         log::debug!(
             "SSTableManager::scan_partition_with_cell_metadata - {}/{} SSTables admit partition \
@@ -1233,11 +1263,8 @@ impl SSTableManager {
         }
 
         // Prune: keep only SSTables whose bloom filter / BTI trie admit the key.
-        let candidates: Vec<Arc<reader::SSTableReader>> = reader_list
-            .iter()
-            .filter(|r| r.might_contain_partition(partition_key))
-            .cloned()
-            .collect();
+        // C4 (#1575): the BTI key hash+encoding is hoisted to once per read here.
+        let candidates = Self::prune_candidates(&reader_list, partition_key);
 
         log::debug!(
             "SSTableManager::scan_partition - {}/{} SSTables admit partition key (len={}) for '{}'",

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -45,6 +45,13 @@
 //!   descent (`lookup_partition_via_bti_trie`). Consumers **C3** (single-walk point
 //!   lookup) and **C4** (hoist the trie rehash out of the loop): both must prove a
 //!   point lookup descends the trie exactly once.
+//! - [`record_key_hash`] / [`key_hash_calls`] — **`KEY_HASH_CALLS`**: one per
+//!   Murmur3 hash + BTI byte-comparable encoding of a query partition key
+//!   (`encode_partition_key_for_bti_trie`). Consumer **C4** (hoist per-candidate
+//!   rehashing): a multi-generation `WHERE pk = ?` point read must hash+encode the
+//!   query key exactly ONCE per read (the encoding is identical for every candidate
+//!   SSTable), not once per candidate. On `main`/pre-C4 the candidate-prune loop
+//!   re-encoded per candidate (N hashes for N generations); after C4 it is 1.
 //! - [`record_decompress`] / [`decompress_calls`] — **`DECOMPRESS_CALLS`**: one per
 //!   compression-chunk decompress (`Compressor::decompress`). Consumers **B1**
 //!   (chunk cache — a cache hit must skip the decompress) and **E3** (copy-chain —
@@ -162,6 +169,11 @@ struct Counters {
     /// open must parse `CompressionInfo.db` exactly once (was 2 — a legacy
     /// `parse_binary` plus the modern `parse`).
     compression_info_parses: AtomicU64,
+    /// Query-key Murmur3 hash + BTI byte-comparable encodings (`KEY_HASH_CALLS`,
+    /// Issue #1575 / C4) — one per `encode_partition_key_for_bti_trie`. Consumer C4:
+    /// a multi-candidate point read hashes+encodes the key ONCE (hoisted out of the
+    /// candidate-prune loop), not once per candidate generation.
+    key_hash_calls: AtomicU64,
 }
 
 #[cfg(any(test, feature = "work-counters"))]
@@ -180,6 +192,7 @@ impl Counters {
             bti_pointer_decodes: AtomicU64::new(0),
             row_sort_invocations: AtomicU64::new(0),
             compression_info_parses: AtomicU64::new(0),
+            key_hash_calls: AtomicU64::new(0),
         }
     }
 
@@ -232,6 +245,10 @@ impl Counters {
         self.compression_info_parses.fetch_add(1, Ordering::Relaxed);
     }
 
+    fn record_key_hash(&self) {
+        self.key_hash_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
     fn trie_walks(&self) -> u64 {
         self.trie_walks.load(Ordering::Relaxed)
     }
@@ -280,6 +297,10 @@ impl Counters {
         self.compression_info_parses.load(Ordering::Relaxed)
     }
 
+    fn key_hash_calls(&self) -> u64 {
+        self.key_hash_calls.load(Ordering::Relaxed)
+    }
+
     fn reset(&self) {
         self.trie_walks.store(0, Ordering::Relaxed);
         self.decompress_calls.store(0, Ordering::Relaxed);
@@ -293,6 +314,7 @@ impl Counters {
         self.bti_pointer_decodes.store(0, Ordering::Relaxed);
         self.row_sort_invocations.store(0, Ordering::Relaxed);
         self.compression_info_parses.store(0, Ordering::Relaxed);
+        self.key_hash_calls.store(0, Ordering::Relaxed);
     }
 }
 
@@ -449,6 +471,20 @@ pub fn record_compression_info_parse() {
     COUNTERS.record_compression_info_parse();
 }
 
+/// Record one query-key Murmur3 hash + BTI byte-comparable encoding
+/// (`KEY_HASH_CALLS`; consumer C4, Issue #1575).
+///
+/// Called unconditionally at the single BTI key-encoding site
+/// (`bti::parser::partitions::encode_partition_key_for_bti_trie`, which computes the
+/// Murmur3 token); the body compiles to a no-op in a release build (design.md
+/// Decision 1). C4 hoists this out of the candidate-prune loop so a multi-generation
+/// point read records exactly 1 (not one per candidate).
+#[inline(always)]
+pub fn record_key_hash() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_key_hash();
+}
+
 /// Number of BTI trie descents since the last [`reset`] (`TRIE_WALKS`).
 #[cfg(any(test, feature = "work-counters"))]
 pub fn trie_walks() -> u64 {
@@ -528,6 +564,13 @@ pub fn row_sort_invocations() -> u64 {
 #[cfg(any(test, feature = "work-counters"))]
 pub fn compression_info_parses() -> u64 {
     COUNTERS.compression_info_parses()
+}
+
+/// Number of query-key Murmur3 hash + BTI encodings since the last [`reset`]
+/// (`KEY_HASH_CALLS`, Issue #1575 / C4).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn key_hash_calls() -> u64 {
+    COUNTERS.key_hash_calls()
 }
 
 /// Clear all four process-global counters. Integration tests call this before a
@@ -639,6 +682,9 @@ mod tests {
         for _ in 0..12 {
             c.record_compression_info_parse();
         }
+        for _ in 0..13 {
+            c.record_key_hash();
+        }
 
         assert_eq!(c.trie_walks(), 1);
         assert_eq!(c.decompress_calls(), 2);
@@ -652,6 +698,7 @@ mod tests {
         assert_eq!(c.bti_pointer_decodes(), 10);
         assert_eq!(c.row_sort_invocations(), 11);
         assert_eq!(c.compression_info_parses(), 12);
+        assert_eq!(c.key_hash_calls(), 13);
 
         c.reset();
         assert_eq!(c.trie_walks(), 0);
@@ -666,6 +713,7 @@ mod tests {
         assert_eq!(c.bti_pointer_decodes(), 0);
         assert_eq!(c.row_sort_invocations(), 0);
         assert_eq!(c.compression_info_parses(), 0);
+        assert_eq!(c.key_hash_calls(), 0);
     }
 
     // The fd high-water helper returns a positive count on the supported platforms

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -295,8 +295,9 @@ impl SSTableReader {
         schema: Option<&crate::schema::TableSchema>,
     ) -> Result<Option<ClusteringRowWindow>> {
         use crate::storage::sstable::bti::{
-            iterate_rows_for_partition, lookup_raw_key_in_bti_partitions_slice,
-            resolve_rows_db_entry, select_row_index_blocks_for_range, BtiPartitionLocation,
+            encode_partition_key_for_bti_trie, iterate_rows_for_partition,
+            lookup_partition_in_bti_slice, resolve_rows_db_entry,
+            select_row_index_blocks_for_range, BtiPartitionLocation,
         };
 
         let (Some(partitions_db), Some(rows_db)) = (&self.bti_partitions_db, &self.bti_rows_db)
@@ -308,8 +309,11 @@ impl SSTableReader {
         // a per-partition row index we can seek within; a NARROW partition
         // (DataOffset) has none, so decode it in full.
         // Issue #1574 (C3): walk the resident trie buffer in place (no whole-file copy).
+        // Issue #1575 (C4): encode the raw key then walk with the pre-encoded key via
+        // the single `lookup_partition_in_bti_slice` primitive every BTI lookup shares.
+        let encoded = encode_partition_key_for_bti_trie(partition_key);
         let rows_offset =
-            match lookup_raw_key_in_bti_partitions_slice(partitions_db.as_slice(), partition_key)
+            match lookup_partition_in_bti_slice(partitions_db.as_slice(), &encoded)
                 .map_err(|e| {
                     Error::corruption(format!(
                         "BTI clustering seek: Partitions.db trie lookup failed (key len={}): {}",

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -312,19 +312,18 @@ impl SSTableReader {
         // Issue #1575 (C4): encode the raw key then walk with the pre-encoded key via
         // the single `lookup_partition_in_bti_slice` primitive every BTI lookup shares.
         let encoded = encode_partition_key_for_bti_trie(partition_key);
-        let rows_offset =
-            match lookup_partition_in_bti_slice(partitions_db.as_slice(), &encoded)
-                .map_err(|e| {
-                    Error::corruption(format!(
-                        "BTI clustering seek: Partitions.db trie lookup failed (key len={}): {}",
-                        partition_key.len(),
-                        e
-                    ))
-                })? {
-                Some(BtiPartitionLocation::RowsOffset(off)) => off as usize,
-                // NARROW partition or absent key: no row index to narrow with.
-                Some(BtiPartitionLocation::DataOffset(_)) | None => return Ok(None),
-            };
+        let rows_offset = match lookup_partition_in_bti_slice(partitions_db.as_slice(), &encoded)
+            .map_err(|e| {
+                Error::corruption(format!(
+                    "BTI clustering seek: Partitions.db trie lookup failed (key len={}): {}",
+                    partition_key.len(),
+                    e
+                ))
+            })? {
+            Some(BtiPartitionLocation::RowsOffset(off)) => off as usize,
+            // NARROW partition or absent key: no row index to narrow with.
+            Some(BtiPartitionLocation::DataOffset(_)) | None => return Ok(None),
+        };
 
         // Resolve the per-partition row-index entry and enumerate its blocks in
         // ascending byte-comparable (clustering) order.

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -808,6 +808,9 @@ use partition_shadow::{clustering_reversed_flags, PartitionShadow};
 // #1741: shared partition-header need-more classifier used by both sliding
 // parsers (`block_emit_windowed` + `compaction`) via their `use super::*` glob.
 use row_framing::PartitionHeaderReadiness;
+// #1641 (K2): non-allocating partition-boundary peek result, used to reimplement
+// `peek_is_partition_header` without a per-row header try-parse.
+use row_framing::BoundaryPeek;
 
 #[cfg(test)]
 mod test_support;
@@ -834,6 +837,12 @@ mod regression_1741h_tests;
 
 #[cfg(test)]
 mod regression_1741k_tests;
+
+// Issue #1641 (Epic K, finding K2): drift guard for the non-allocating
+// partition-boundary peek — `peek_partition_boundary == Header` ⟺ the old
+// allocating semantics (`!marker && parse_partition_header_full.is_ok()`).
+#[cfg(test)]
+mod regression_1641_boundary_peek_tests;
 
 impl V5CompressedLegacyParser {
     /// Create a new V5CompressedLegacy parser
@@ -926,11 +935,17 @@ impl V5CompressedLegacyParser {
         self.min_local_deletion_time != NO_DELETION_TIME
     }
 
-    /// Try to parse partition header at offset WITHOUT consuming it.
+    /// Whether the bytes at `offset` begin a new partition header, WITHOUT
+    /// consuming them.
     ///
-    /// This performs a full parse attempt to determine if the bytes at offset
-    /// represent a valid partition header. This is the NO-HEURISTICS approach:
-    /// we actually try to parse the structure instead of guessing based on byte patterns.
+    /// This is the NO-HEURISTICS approach: we validate the actual structure
+    /// instead of guessing from byte patterns. Issue #1641 (K2) made it
+    /// non-allocating — it delegates to [`peek_partition_boundary`], which shares
+    /// the structural walk of `parse_partition_header_full` (via
+    /// `scan_partition_header`) but copies no key, builds no error string, and
+    /// records no `PARTITION_HEADER_TRY_PARSES`. The boolean result is identical
+    /// to the former allocating implementation (marker pre-check + full-parse
+    /// `is_ok`), proved by the `peek_matches_full_parse` proptest.
     ///
     /// # Arguments
     /// * `data` - Binary data buffer
@@ -942,21 +957,13 @@ impl V5CompressedLegacyParser {
     ///
     /// # Visibility
     /// Exposed for integration testing to validate partition boundary detection
+    ///
+    /// [`peek_partition_boundary`]: Self::peek_partition_boundary
     #[doc(hidden)]
     pub fn peek_is_partition_header(&self, data: &[u8], offset: usize) -> bool {
-        // Issue #229 FIX: Check for END_OF_PARTITION marker FIRST
-        //
-        // The END_OF_PARTITION marker (0x01) can be misinterpreted as a valid partition
-        // header because parse_partition_header doesn't validate flags semantically.
-        // We must explicitly reject END_OF_PARTITION (0x01) and IS_MARKER (0x02) here.
-        if offset < data.len() {
-            let flags = data[offset];
-            if Self::is_end_of_partition(flags) || Self::is_range_tombstone_marker(flags) {
-                return false; // These are markers, not partition headers
-            }
-        }
-
-        // Try to actually parse the partition header
-        self.parse_partition_header(data, offset).is_ok()
+        matches!(
+            self.peek_partition_boundary(data, offset),
+            BoundaryPeek::Header
+        )
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -940,12 +940,15 @@ impl V5CompressedLegacyParser {
     ///
     /// This is the NO-HEURISTICS approach: we validate the actual structure
     /// instead of guessing from byte patterns. Issue #1641 (K2) made it
-    /// non-allocating — it delegates to [`peek_partition_boundary`], which shares
-    /// the structural walk of `parse_partition_header_full` (via
-    /// `scan_partition_header`) but copies no key, builds no error string, and
-    /// records no `PARTITION_HEADER_TRY_PARSES`. The boolean result is identical
-    /// to the former allocating implementation (marker pre-check + full-parse
-    /// `is_ok`), proved by the `peek_matches_full_parse` proptest.
+    /// non-allocating on the fast-reject paths — it delegates to
+    /// [`peek_partition_boundary`], which shares the structural walk of
+    /// `parse_partition_header_full` (via `scan_partition_header`) but always
+    /// skips the success-path key `to_vec` and the `PARTITION_HEADER_TRY_PARSES`
+    /// counter. The marker pre-check and readiness gate allocate nothing; the
+    /// strict scan on a `Ready` buffer may still build a discarded error string
+    /// on a structural mismatch. The boolean result is identical to the former
+    /// allocating implementation (marker pre-check + full-parse `is_ok`), proved
+    /// by the `peek_matches_full_parse` proptest.
     ///
     /// # Arguments
     /// * `data` - Binary data buffer

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1641_boundary_peek_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1641_boundary_peek_tests.rs
@@ -1,0 +1,170 @@
+//! Issue #1641 (Epic K, finding K2): drift guard for the non-allocating
+//! partition-boundary peek.
+//!
+//! The per-row emit loop asks "do the bytes here begin a new partition header?"
+//! after every row. K2 replaced the FULL allocating try-parse (throwaway key
+//! `to_vec` + `format!` error strings + a `PARTITION_HEADER_TRY_PARSES`
+//! increment) with the non-allocating
+//! [`V5CompressedLegacyParser::peek_partition_boundary`], which shares the
+//! structural walk of `parse_partition_header_full` via `scan_partition_header`.
+//!
+//! The single hazard is DRIFT: a cheap peek that accepts a header the real parser
+//! rejects (or vice-versa) desyncs the scan — a new bug class. This proptest pins
+//! the exact equivalence the boundary detector must uphold for ARBITRARY bytes:
+//!
+//! ```text
+//! peek == Header  ⟺  (data[offset] is NOT an END_OF_PARTITION / range-tombstone
+//!                      marker)  AND  parse_partition_header_full(..).is_ok()
+//! ```
+//!
+//! on both the oa/da (`hasUIntDeletionTime`) and nb (signed 12-byte) DeletionTime
+//! forms — the two structural variants the peek must classify identically to the
+//! full parse. That right-hand side is precisely the former allocating
+//! `peek_is_partition_header` (marker pre-check + full-parse `is_ok`), so this
+//! also proves `peek_is_partition_header` returns the same boolean it did on
+//! `main`.
+
+use super::row_framing::BoundaryPeek;
+use super::V5CompressedLegacyParser;
+use crate::storage::sstable::version_gate::{BigVersionGates, BtiVersionGates, VersionGates};
+use proptest::prelude::*;
+use std::sync::Arc;
+
+/// Parser on the oa (BIG, `hasUIntDeletionTime`) path.
+fn oa_parser() -> V5CompressedLegacyParser {
+    let gates = VersionGates::Big(BigVersionGates::from_version("oa").expect("oa gates"));
+    V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, Some(0))
+        .with_version_gates(Arc::new(gates))
+}
+
+/// Parser on the da (BTI, `hasUIntDeletionTime`) path.
+fn da_parser() -> V5CompressedLegacyParser {
+    let gates = VersionGates::Bti(BtiVersionGates::from_version("da").expect("da gates"));
+    V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, Some(0))
+        .with_version_gates(Arc::new(gates))
+}
+
+/// Parser on the nb (BIG, signed 12-byte DeletionTime) path — `new`'s default.
+fn nb_parser() -> V5CompressedLegacyParser {
+    V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, Some(0))
+}
+
+/// The old (`main`) boolean semantics of `peek_is_partition_header`: the leading
+/// byte is not a marker AND the FULL allocating parse succeeds. K2 must reproduce
+/// this exactly.
+fn old_peek_semantics(parser: &V5CompressedLegacyParser, data: &[u8], offset: usize) -> bool {
+    if let Some(&flags) = data.get(offset) {
+        if V5CompressedLegacyParser::is_end_of_partition(flags)
+            || V5CompressedLegacyParser::is_range_tombstone_marker(flags)
+        {
+            return false;
+        }
+    }
+    parser.parse_partition_header_full(data, offset).is_ok()
+}
+
+/// Assert the peek⟺parse equivalence at every offset in `data` for one parser.
+/// Returns a `proptest` `TestCaseError` on mismatch (via `prop_assert_eq!`).
+fn assert_equivalence(parser: &V5CompressedLegacyParser, data: &[u8]) -> Result<(), TestCaseError> {
+    // Check offset 0 (the boundary the emit loop actually peeks) plus a few
+    // interior offsets, and one-past-the-end (must be `NeedMoreBytes`).
+    for offset in 0..=data.len() {
+        let peek = parser.peek_partition_boundary(data, offset);
+        let is_header = matches!(peek, BoundaryPeek::Header);
+        let expected = old_peek_semantics(parser, data, offset);
+        prop_assert_eq!(
+            is_header,
+            expected,
+            "peek==Header must equal (!marker && full_parse.is_ok()) at offset {} for bytes {:?}",
+            offset,
+            data
+        );
+        // `peek_is_partition_header` must return the same boolean.
+        prop_assert_eq!(
+            parser.peek_is_partition_header(data, offset),
+            expected,
+            "peek_is_partition_header must match old semantics at offset {}",
+            offset
+        );
+        // Offset past the end is always NeedMoreBytes (never a false Header).
+        if offset >= data.len() {
+            prop_assert_eq!(peek, BoundaryPeek::NeedMoreBytes);
+        }
+    }
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(4000))]
+
+    /// Arbitrary short byte slices: exercises truncated / malformed / marker /
+    /// valid-header shapes uniformly across all three DeletionTime variants.
+    #[test]
+    fn peek_matches_full_parse_arbitrary(bytes in proptest::collection::vec(any::<u8>(), 0..40)) {
+        assert_equivalence(&oa_parser(), &bytes)?;
+        assert_equivalence(&da_parser(), &bytes)?;
+        assert_equivalence(&nb_parser(), &bytes)?;
+    }
+
+    /// Structured near-header bytes: a plausible `flags(1) | key_len(1) | key |
+    /// deletion` prefix so a meaningful fraction of cases are ACCEPTED headers
+    /// (keeps the equivalence non-vacuous on the `Header` branch), including the
+    /// oa/da LIVE-sentinel and DELETED forms and truncations thereof.
+    #[test]
+    fn peek_matches_full_parse_structured(
+        flags in any::<u8>(),
+        key_len in 0u8..12,
+        key in proptest::collection::vec(any::<u8>(), 0..12),
+        del in proptest::collection::vec(any::<u8>(), 0..14),
+    ) {
+        let mut bytes = Vec::with_capacity(2 + key.len() + del.len());
+        bytes.push(flags);
+        bytes.push(key_len);
+        bytes.extend_from_slice(&key);
+        bytes.extend_from_slice(&del);
+        assert_equivalence(&oa_parser(), &bytes)?;
+        assert_equivalence(&da_parser(), &bytes)?;
+        assert_equivalence(&nb_parser(), &bytes)?;
+    }
+}
+
+/// Deterministic sanity: a well-formed LIVE oa/da header (0x80 sentinel) peeks as
+/// `Header`; flipping the sentinel to a non-`0x80` high-bit byte the full parser
+/// rejects peeks as `NotHeader` (NOT `Header`) — the strict structural rule the
+/// peek must NOT weaken. And a header truncated before its full DeletionTime peeks
+/// as `NeedMoreBytes`.
+#[test]
+fn live_oa_header_and_strict_sentinel_and_truncation() {
+    let mut header = vec![0x00u8, 0x04];
+    header.extend_from_slice(&42i32.to_be_bytes());
+    header.push(super::row_framing::OA_IS_LIVE_DELETION); // 0x80 LIVE
+
+    for parser in [oa_parser(), da_parser()] {
+        assert_eq!(
+            parser.peek_partition_boundary(&header, 0),
+            BoundaryPeek::Header,
+            "a complete LIVE oa/da header is a boundary"
+        );
+        assert!(parser.peek_is_partition_header(&header, 0));
+
+        // Non-0x80 high-bit byte: readiness treats it as a present 1-byte form,
+        // but the strict scan rejects it (only 0x80 is a valid LIVE byte) => NOT
+        // a header. The peek must NOT accept what the full parser rejects.
+        let mut bad = header.clone();
+        *bad.last_mut().unwrap() = 0x81;
+        assert_eq!(
+            parser.peek_partition_boundary(&bad, 0),
+            BoundaryPeek::NotHeader,
+            "an illegal oa/da IS_LIVE byte is not a header (no weakened validation)"
+        );
+        assert!(parser.parse_partition_header_full(&bad, 0).is_err());
+
+        // Truncated before the deletion discriminator: NeedMoreBytes.
+        let truncated = &header[..header.len() - 1];
+        assert_eq!(
+            parser.peek_partition_boundary(truncated, 0),
+            BoundaryPeek::NeedMoreBytes,
+            "a header missing its DeletionTime byte needs more bytes"
+        );
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
@@ -917,12 +917,16 @@ impl V5CompressedLegacyParser {
     /// Non-allocating partition-BOUNDARY peek (issue #1641, K2).
     ///
     /// Answers "do the bytes at `offset` begin a new partition header?" for the
-    /// post-row emit loop WITHOUT allocating a throwaway key, building error
-    /// strings, or incrementing `PARTITION_HEADER_TRY_PARSES`. It reaches the same
-    /// verdict the old allocating `peek_is_partition_header` did — proved by the
-    /// `#[cfg(test)]` proptest (`Header` ⟺ `!marker && parse.is_ok()`).
+    /// post-row emit loop while skipping the success-path key `to_vec` and the
+    /// `PARTITION_HEADER_TRY_PARSES` counter that the full parse incurs. The
+    /// fast-reject paths (marker pre-check + readiness gate) allocate nothing at
+    /// all; only the strict scan on a `Ready` buffer may still build a discarded
+    /// `format!` error string on a structural mismatch (inside
+    /// `scan_partition_header`). It reaches the same verdict the old allocating
+    /// `peek_is_partition_header` did — proved by the `#[cfg(test)]` proptest
+    /// (`Header` ⟺ `!marker && parse.is_ok()`).
     ///
-    /// Algorithm (all non-allocating, no gauge):
+    /// Algorithm (fast-reject paths allocate nothing; no gauge on any path):
     /// 1. Marker pre-check (issue #229): an END_OF_PARTITION (`0x01`) or
     ///    range-tombstone (IS_MARKER) leading byte is never a partition header;
     ///    an offset past the buffer end is `NeedMoreBytes`.

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
@@ -28,6 +28,46 @@ pub(super) enum PartitionHeaderReadiness {
     Malformed,
 }
 
+/// Result of the non-allocating partition-BOUNDARY peek (issue #1641, K2).
+///
+/// The post-row emit loop asks "does the next thing begin a new partition
+/// header?" after every row. On `main` that ran the FULL allocating
+/// [`V5CompressedLegacyParser::parse_partition_header_full`] as a trial (throwaway
+/// key `to_vec` + eager `format!` error strings + a `PARTITION_HEADER_TRY_PARSES`
+/// increment) purely to learn a boolean. This enum is returned by
+/// [`V5CompressedLegacyParser::peek_partition_boundary`], which reaches the same
+/// verdict by READING bytes — no allocation, no error strings, no gauge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BoundaryPeek {
+    /// The bytes at the offset are structurally a partition header — i.e. the
+    /// full parser would return `Ok` here. The caller runs the real
+    /// (allocating) parse exactly once, at this confirmed start.
+    Header,
+    /// Definitely NOT a partition header at this offset: the leading byte is an
+    /// END_OF_PARTITION / range-tombstone marker, the key length is zero, or the
+    /// header is structurally invalid (e.g. an illegal oa/da IS_LIVE byte) so the
+    /// full parser would return `Err` on the complete bytes.
+    NotHeader,
+    /// The header — or, for an oa/da deleted partition, its full `DeletionTime` —
+    /// is not entirely present yet (truncated / split across a chunk boundary).
+    /// The caller should request more bytes rather than decide.
+    NeedMoreBytes,
+}
+
+/// Byte-offset layout of a structurally-valid partition header, produced WITHOUT
+/// allocating the key (issue #1641, K2). Shared by the allocating full parser and
+/// the non-allocating boundary peek so their structural rules cannot drift.
+struct PartitionHeaderLayout {
+    /// Range of the partition key bytes within the input buffer (not copied).
+    key_range: std::ops::Range<usize>,
+    /// Offset immediately after the header (start of the first row / marker).
+    next_offset: usize,
+    /// Partition-level deletion `(markedForDeleteAt µs, localDeletionTime s)`, or
+    /// `None` for a live partition. Same contract as
+    /// [`V5CompressedLegacyParser::parse_partition_header_full`].
+    partition_deletion: Option<(i64, i32)>,
+}
+
 impl V5CompressedLegacyParser {
     /// Decide whether the leading partition header in `data` is fully present.
     ///
@@ -679,11 +719,42 @@ impl V5CompressedLegacyParser {
     pub fn parse_partition_header_full(
         &self,
         data: &[u8],
-        mut offset: usize,
+        offset: usize,
     ) -> Result<(RowKey, usize, Option<(i64, i32)>)> {
         // Issue #1618 (H5): count every speculative partition-header parse — the
-        // boundary-peek/try-parse primitive every emit path routes through (K2/K3).
+        // real allocating parse, which runs once per partition at a confirmed
+        // start. The per-row BOUNDARY peek (issue #1641, K2) does NOT come through
+        // here: it uses the non-allocating `peek_partition_boundary`, which shares
+        // the structural walk below via `scan_partition_header` but records no
+        // gauge and copies no key.
         crate::storage::sstable::read_work_counters::record_partition_header_try_parse();
+
+        let layout = self.scan_partition_header(data, offset)?;
+        // The single legitimate key allocation: once per real header parse.
+        let key_bytes = data[layout.key_range].to_vec();
+        Ok((
+            RowKey(key_bytes),
+            layout.next_offset,
+            layout.partition_deletion,
+        ))
+    }
+
+    /// Structural walk of a partition header WITHOUT allocating the key or
+    /// recording the `PARTITION_HEADER_TRY_PARSES` gauge (issue #1641, K2).
+    ///
+    /// This is the single structural authority: [`parse_partition_header_full`]
+    /// wraps it (gauge + key `to_vec`), and [`peek_partition_boundary`] uses it as
+    /// the boundary detector. Every validation and every `Err` message is
+    /// identical to the former inline body of `parse_partition_header_full`, so a
+    /// peek can never accept a header the full parser rejects (no drift).
+    ///
+    /// [`parse_partition_header_full`]: Self::parse_partition_header_full
+    /// [`peek_partition_boundary`]: Self::peek_partition_boundary
+    fn scan_partition_header(
+        &self,
+        data: &[u8],
+        mut offset: usize,
+    ) -> Result<PartitionHeaderLayout> {
         let start_offset = offset;
 
         if offset >= data.len() {
@@ -730,7 +801,10 @@ impl V5CompressedLegacyParser {
                 offset, key_len, data.len()
             )));
         }
-        let key_bytes = data[offset..offset + key_len].to_vec();
+        // Record the key's byte RANGE — no copy here. The allocation happens
+        // once, in `parse_partition_header_full`, at a confirmed header start
+        // (issue #1641, K2); the boundary peek needs no key at all.
+        let key_range = offset..offset + key_len;
         offset += key_len;
 
         // Partition-level DeletionTime deserialization.
@@ -825,9 +899,6 @@ impl V5CompressedLegacyParser {
             }
         }
 
-        // Create RowKey from partition key bytes
-        let row_key = RowKey(key_bytes);
-
         debug!(
             "V5CompressedLegacy: Parsed partition header at offset {}, consumed {} bytes, \
              partition_deletion={:?}",
@@ -836,7 +907,55 @@ impl V5CompressedLegacyParser {
             partition_deletion
         );
 
-        Ok((row_key, offset, partition_deletion))
+        Ok(PartitionHeaderLayout {
+            key_range,
+            next_offset: offset,
+            partition_deletion,
+        })
+    }
+
+    /// Non-allocating partition-BOUNDARY peek (issue #1641, K2).
+    ///
+    /// Answers "do the bytes at `offset` begin a new partition header?" for the
+    /// post-row emit loop WITHOUT allocating a throwaway key, building error
+    /// strings, or incrementing `PARTITION_HEADER_TRY_PARSES`. It reaches the same
+    /// verdict the old allocating `peek_is_partition_header` did — proved by the
+    /// `#[cfg(test)]` proptest (`Header` ⟺ `!marker && parse.is_ok()`).
+    ///
+    /// Algorithm (all non-allocating, no gauge):
+    /// 1. Marker pre-check (issue #229): an END_OF_PARTITION (`0x01`) or
+    ///    range-tombstone (IS_MARKER) leading byte is never a partition header;
+    ///    an offset past the buffer end is `NeedMoreBytes`.
+    /// 2. Completeness gate via the shared #1741 [`partition_header_readiness`]
+    ///    classifier: `Incomplete` → `NeedMoreBytes`, `Malformed` → `NotHeader`.
+    /// 3. Under `Ready` every header byte is present, so a [`scan_partition_header`]
+    ///    failure is a genuine STRUCTURAL rejection (e.g. an illegal oa/da IS_LIVE
+    ///    byte), never truncation: `Ok` → `Header`, `Err` → `NotHeader`.
+    ///
+    /// [`partition_header_readiness`]: Self::partition_header_readiness
+    /// [`scan_partition_header`]: Self::scan_partition_header
+    pub(super) fn peek_partition_boundary(&self, data: &[u8], offset: usize) -> BoundaryPeek {
+        // Step 1: marker / end-of-buffer pre-check.
+        match data.get(offset) {
+            None => return BoundaryPeek::NeedMoreBytes,
+            Some(&flags) => {
+                if Self::is_end_of_partition(flags) || Self::is_range_tombstone_marker(flags) {
+                    return BoundaryPeek::NotHeader;
+                }
+            }
+        }
+
+        // Step 2 + 3: completeness gate, then the strict shared structural scan.
+        // `offset < data.len()` holds (step 1 returned on `None`), so the subslice
+        // is valid and zero-cost.
+        match self.partition_header_readiness(&data[offset..]) {
+            PartitionHeaderReadiness::Incomplete => BoundaryPeek::NeedMoreBytes,
+            PartitionHeaderReadiness::Malformed => BoundaryPeek::NotHeader,
+            PartitionHeaderReadiness::Ready => match self.scan_partition_header(data, offset) {
+                Ok(_) => BoundaryPeek::Header,
+                Err(_) => BoundaryPeek::NotHeader,
+            },
+        }
     }
 
     /// Parse a range tombstone marker in full, returning the decoded bound values,

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -101,9 +101,66 @@ impl SSTableReader {
     ///
     /// [`resolve_rows_db_entry`]: crate::storage::sstable::bti::resolve_rows_db_entry
     pub fn lookup_partition_via_bti_trie(&self, partition_key: &[u8]) -> Result<Option<u64>> {
+        use crate::storage::sstable::bti::encode_partition_key_for_bti_trie;
+
+        // Not a BTI reader — no trie to consult (no descent, no encode, no count).
+        if self.bti_partitions_db.is_none() {
+            return Ok(None);
+        }
+
+        // Issue #1574 (C3) single walk: reuse the prune's resolution for the seek —
+        // a pure function of the immutable trie + key. Checked BEFORE the encode so
+        // a memo hit costs neither a trie descent NOR a Murmur3 key hash. A
+        // stale/absent slot simply misses and re-walks. The presence-oracle
+        // observability is preserved: a memo hit still records the presence decision.
+        if let Some(resolved) = self.bti_lookup_memo_get(partition_key) {
+            Self::emit_bti_presence_counters(resolved.is_some());
+            return Ok(resolved);
+        }
+
+        // Issue #1575 (C4): encode ONCE here (Murmur3 hash + byte-comparable
+        // encoding, `KEY_HASH_CALLS`). The multi-candidate prune path instead calls
+        // `lookup_partition_via_bti_trie_encoded` with a single hoisted encoding so N
+        // candidate generations share ONE hash rather than re-hashing per candidate.
+        let encoded = encode_partition_key_for_bti_trie(partition_key);
+        self.bti_trie_resolve(partition_key, &encoded)
+    }
+
+    /// Resolve a BTI partition using a PRE-ENCODED byte-comparable key, so the
+    /// Murmur3 hash + encoding is computed once per read and reused across every
+    /// candidate SSTable's prune instead of being recomputed per candidate
+    /// (issue #1575 / C4). `encoded` MUST equal
+    /// `encode_partition_key_for_bti_trie(partition_key)`; the caller
+    /// (`SSTableManager`'s candidate prune) computes it exactly once. Semantics are
+    /// otherwise identical to [`lookup_partition_via_bti_trie`]: same same-key memo,
+    /// same presence-oracle observability, same resolved offset. A non-BTI reader
+    /// returns `Ok(None)` (the `encoded` argument is simply unused).
+    pub fn lookup_partition_via_bti_trie_encoded(
+        &self,
+        partition_key: &[u8],
+        encoded: &[u8; 9],
+    ) -> Result<Option<u64>> {
+        if self.bti_partitions_db.is_none() {
+            return Ok(None);
+        }
+        if let Some(resolved) = self.bti_lookup_memo_get(partition_key) {
+            Self::emit_bti_presence_counters(resolved.is_some());
+            return Ok(resolved);
+        }
+        self.bti_trie_resolve(partition_key, encoded)
+    }
+
+    /// Shared BTI trie descent for a pre-encoded key — the body behind both
+    /// [`lookup_partition_via_bti_trie`] and
+    /// [`lookup_partition_via_bti_trie_encoded`]. The caller has already confirmed
+    /// this is a BTI reader and consulted the same-key memo; this records the single
+    /// `TRIE_WALKS`, walks the resident trie buffer with the pre-encoded key, emits
+    /// the presence-oracle counters, and stores the memo. It never re-encodes the
+    /// key (no `KEY_HASH_CALLS`), which is the property C4 hoists.
+    fn bti_trie_resolve(&self, partition_key: &[u8], encoded: &[u8; 9]) -> Result<Option<u64>> {
         use crate::observability::{self as obs, catalog};
         use crate::storage::sstable::bti::{
-            lookup_raw_key_in_bti_partitions_slice, resolve_rows_db_entry, BtiPartitionLocation,
+            lookup_partition_in_bti_slice, resolve_rows_db_entry, BtiPartitionLocation,
         };
 
         let span = tracing::debug_span!(
@@ -113,20 +170,9 @@ impl SSTableReader {
         let _entered = span.enter();
 
         let Some(partitions_db) = &self.bti_partitions_db else {
-            // Not a BTI reader — no trie to consult (no descent, no count).
+            // Not a BTI reader — no trie to descend (defensive; caller pre-checks).
             return Ok(None);
         };
-
-        // Issue #1574 (C3) single walk: a single-candidate point read descends the
-        // SAME trie for the SAME key twice (candidate prune then seek). Reuse the
-        // prune's resolution — a pure function of the immutable trie + key — so the
-        // seek returns without a second descent (`TRIE_WALKS` stays 1 per read). A
-        // stale/absent slot simply misses and re-walks. The presence-oracle
-        // observability is preserved: a memo hit still records the presence decision.
-        if let Some(resolved) = self.bti_lookup_memo_get(partition_key) {
-            Self::emit_bti_presence_counters(resolved.is_some());
-            return Ok(resolved);
-        }
 
         // A5 read-work counter (TRIE_WALKS; consumers C3/C4): one per real trie
         // descent — counted only once we have a `Partitions.db` to descend, so a
@@ -135,16 +181,16 @@ impl SSTableReader {
         crate::storage::sstable::read_work_counters::record_trie_walk();
 
         // Issue #1574 (C3): walk the resident `Arc<Vec<u8>>` trie buffer in place —
-        // no per-lookup whole-file copy (the former `Cursor` + `read_exact`).
+        // no per-lookup whole-file copy. Issue #1575 (C4): with the PRE-ENCODED key,
+        // so the encode is not repeated per candidate.
         let lookup =
-            lookup_raw_key_in_bti_partitions_slice(partitions_db.as_slice(), partition_key)
-                .map_err(|e| {
-                    Error::corruption(format!(
-                        "BTI Partitions.db trie lookup failed for partition key (len={}): {}",
-                        partition_key.len(),
-                        e
-                    ))
-                });
+            lookup_partition_in_bti_slice(partitions_db.as_slice(), encoded).map_err(|e| {
+                Error::corruption(format!(
+                    "BTI Partitions.db trie lookup failed for partition key (len={}): {}",
+                    partition_key.len(),
+                    e
+                ))
+            });
         let lookup = match lookup {
             Ok(v) => v,
             Err(e) => {
@@ -462,6 +508,38 @@ impl SSTableReader {
             }
             None => true,
         }
+    }
+
+    /// `true` when this reader was opened on a BTI ("da") SSTable (its
+    /// `Partitions.db` trie is resident). Used by the candidate-prune loop to decide
+    /// whether to hoist the BTI key encoding once per read (issue #1575 / C4).
+    pub fn is_bti(&self) -> bool {
+        self.bti_partitions_db.is_some()
+    }
+
+    /// Candidate-prune presence check using a PRE-ENCODED BTI byte-comparable key,
+    /// so a multi-generation `WHERE pk = ?` read hashes+encodes the key ONCE (the
+    /// encoding is identical for every candidate) instead of once per candidate
+    /// (issue #1575 / C4).
+    ///
+    /// `encoded` MUST equal `encode_partition_key_for_bti_trie(partition_key)`,
+    /// computed once by the caller. For a BTI reader this consults the trie with the
+    /// pre-encoded key (no re-hash); for a BIG reader (no `Partitions.db`) it falls
+    /// back to the raw-key [`might_contain_partition`] path (the bloom filter is
+    /// keyed on the raw key — there is no BTI encoding to hoist), so a mixed or
+    /// non-BTI candidate set stays correct. Semantics match
+    /// [`might_contain_partition`]: `false` is definitive absence; a BTI trie hit may
+    /// be a safe prefix-collision false positive re-verified by the partition scan;
+    /// any trie parse error is treated conservatively as "maybe present".
+    pub fn might_contain_partition_encoded(&self, partition_key: &[u8], encoded: &[u8; 9]) -> bool {
+        if self.bti_partitions_db.is_some() {
+            return matches!(
+                self.lookup_partition_via_bti_trie_encoded(partition_key, encoded),
+                Ok(Some(_)) | Err(_)
+            );
+        }
+        // BIG: no BTI encoding to hoist — the bloom filter hashes the raw key.
+        self.might_contain_partition(partition_key)
     }
 
     /// Enhanced partition lookup using schema-driven key digest computation

--- a/cqlite-core/src/storage/sstable/reverse_scan.rs
+++ b/cqlite-core/src/storage/sstable/reverse_scan.rs
@@ -17,9 +17,7 @@
 
 #![cfg(not(feature = "tombstones"))]
 
-use std::sync::Arc;
-
-use super::{reader, SSTableManager};
+use super::SSTableManager;
 use crate::schema::TableSchema;
 use crate::types::{ScanRow, TableId};
 use crate::{Result, RowKey};
@@ -44,11 +42,8 @@ impl SSTableManager {
         // covers ONLY the single-generation case: with several generations the same
         // (partition, clustering) row may appear in more than one, and reconciling
         // them is the in-memory-sort path's job (cross-generation last-write-wins).
-        let candidates: Vec<Arc<reader::SSTableReader>> = reader_list
-            .iter()
-            .filter(|r| r.might_contain_partition(partition_key))
-            .cloned()
-            .collect();
+        // C4 (#1575): the BTI key hash+encoding is hoisted to once per read here.
+        let candidates = Self::prune_candidates(&reader_list, partition_key);
         if candidates.len() != 1 {
             return Ok(None);
         }

--- a/cqlite-core/tests/issue_1575_candidate_key_hash_hoist.rs
+++ b/cqlite-core/tests/issue_1575_candidate_key_hash_hoist.rs
@@ -1,0 +1,307 @@
+//! Issue #1575 (Epic C / C4): the query partition key is Murmur3-hashed + BTI
+//! byte-comparable-encoded EXACTLY ONCE per read, not once per candidate SSTable.
+//!
+//! # What this proves
+//!
+//! A multi-generation `WHERE pk = ?` point read prunes every candidate SSTable's
+//! `Partitions.db` trie. On `main` the SAME query key was re-encoded (Murmur3 hash
+//! + byte-comparable encoding) once per candidate — an N-generation fan-out paid N
+//! identical hashes. C4 hoists the encode to ONCE per read (the encoding is
+//! independent of which SSTable is being pruned), so `KEY_HASH_CALLS == 1` across
+//! the fan-out. The per-SSTable trie WALK is unchanged (each candidate's trie must
+//! still be consulted); only the redundant per-candidate rehash is removed.
+//!
+//! # Wiring evidence
+//!
+//! - **Reader-level fan-out** (the RED-on-main proof): N DISTINCT `SSTableReader`s on
+//!   the real BTI `test_da/simple_table` fixture simulate an N-generation candidate
+//!   set (each owns its own C3 same-key memo, so nothing coalesces the encode across
+//!   them). The pre-C4 per-candidate path (`might_contain_partition`, retained)
+//!   records `KEY_HASH_CALLS == N`; the C4 hoisted path
+//!   (`might_contain_partition_encoded` fed one precomputed key) records exactly 1 —
+//!   with byte-identical prune decisions (same admitted set).
+//! - **Manager path** (public `Database` API): a real point read through the query
+//!   engine hashes the key exactly once (`SSTableManager::prune_candidates` computes
+//!   the BTI encoding a single time), and still returns the expected rows.
+//!
+//! Compiled only with `--features cli-helpers,work-counters` (the counter
+//! getters/`reset` live behind `work-counters`; the ingest helper behind
+//! `cli-helpers`). Requires `CQLITE_DATASETS_ROOT` + the optional `test_da` corpus;
+//! skips (never fails) when absent. Excluded under `tombstones` (that build serves
+//! point reads by a full-scan filter rather than the targeted prune+seek path).
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::sstable::bti::encode_partition_key_for_bti_trie;
+use cqlite_core::storage::sstable::read_work_counters as rwc;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::{Config, Database, Value};
+use serial_test::serial;
+
+/// A simulated N-generation candidate fan-out. The C4 property (one hash, not one
+/// per candidate) holds for any N > 1; 32 mirrors the audit's worst-case example.
+const FANOUT: usize = 32;
+
+/// `[0x22; 16]` is a present partition in `test_da/simple_table` (Data.db offset 0;
+/// see `issue_755_bti_trie_point_lookup.rs`).
+const PRESENT_KEY: [u8; 16] = [0x22u8; 16];
+
+/// A UUID that is (with overwhelming probability) absent from the fixture.
+const ABSENT_KEY: [u8; 16] = [0xEEu8; 16];
+
+// ---------------------------------------------------------------------------
+// Fixture helpers (mirror issue_831 / issue_1574)
+// ---------------------------------------------------------------------------
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// Locate the `da-*-bti-Data.db` for `test_da/simple_table`, requiring the sibling
+/// `Partitions.db` trie, or `None` if the binary fixture is absent.
+fn da_data_db_path() -> Option<PathBuf> {
+    let base = datasets_root()?.join("sstables").join("test_da");
+    let table_dir = std::fs::read_dir(&base)
+        .ok()?
+        .flatten()
+        .find(|e| e.file_name().to_string_lossy().starts_with("simple_table-"))
+        .map(|e| e.path())?;
+    let has_partitions = std::fs::read_dir(&table_dir).ok()?.flatten().any(|e| {
+        let s = e.file_name().to_string_lossy().to_string();
+        s.starts_with("da-") && s.ends_with("-bti-Partitions.db")
+    });
+    if !has_partitions {
+        return None;
+    }
+    std::fs::read_dir(&table_dir).ok()?.flatten().find_map(|e| {
+        let s = e.file_name().to_string_lossy().to_string();
+        (s.starts_with("da-") && s.ends_with("-bti-Data.db")).then(|| e.path())
+    })
+}
+
+async fn open_reader(data_db: &Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = std::sync::Arc::new(
+        cqlite_core::platform::Platform::new(&config)
+            .await
+            .expect("Platform::new"),
+    );
+    SSTableReader::open(data_db, &config, platform)
+        .await
+        .expect("SSTableReader::open must succeed for BTI Data.db with Partitions.db present")
+}
+
+/// Open `n` INDEPENDENT readers (fresh, empty C3 memos each) on the same fixture —
+/// a faithful stand-in for `n` distinct SSTable generations of the same table.
+async fn open_fanout(data_db: &Path, n: usize) -> Vec<SSTableReader> {
+    let mut readers = Vec::with_capacity(n);
+    for _ in 0..n {
+        readers.push(open_reader(data_db).await);
+    }
+    readers
+}
+
+// ---------------------------------------------------------------------------
+// Reader-level fan-out: the RED-on-main proof (N hashes → 1)
+// ---------------------------------------------------------------------------
+
+/// Scenario: a present key is hashed once across the candidate fan-out.
+#[tokio::test]
+#[serial]
+async fn present_key_hashed_once_across_fanout() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP (C4): test_da/simple_table BTI fixture not available");
+        return;
+    };
+
+    // Two independent fan-outs so each measurement starts from empty memos.
+    let set_old = open_fanout(&data_db, FANOUT).await;
+    let set_new = open_fanout(&data_db, FANOUT).await;
+    assert!(
+        set_old.iter().chain(set_new.iter()).all(|r| r.is_bti()),
+        "C4: the test_da/simple_table fixture must be a BTI reader"
+    );
+
+    // Pre-C4 per-candidate path (retained `might_contain_partition`): each distinct
+    // candidate re-encodes the SAME key.
+    rwc::reset();
+    let hits_old = set_old
+        .iter()
+        .filter(|r| r.might_contain_partition(&PRESENT_KEY))
+        .count();
+    let per_candidate_hashes = rwc::key_hash_calls();
+
+    // C4 hoisted path: encode ONCE, reuse the encoded key for every candidate.
+    rwc::reset();
+    let encoded = encode_partition_key_for_bti_trie(&PRESENT_KEY); // the ONLY hash
+    let hits_new = set_new
+        .iter()
+        .filter(|r| r.might_contain_partition_encoded(&PRESENT_KEY, &encoded))
+        .count();
+    let hoisted_hashes = rwc::key_hash_calls();
+    let hoisted_walks = rwc::trie_walks();
+
+    // Byte-identical prune decision: a present key is admitted by every candidate on
+    // both paths.
+    assert_eq!(
+        hits_old, FANOUT,
+        "present key admitted by every candidate (old path)"
+    );
+    assert_eq!(
+        hits_new, FANOUT,
+        "C4 hoisted prune admits the identical candidate set"
+    );
+
+    assert_eq!(
+        per_candidate_hashes, FANOUT as u64,
+        "pre-C4 waste: the per-candidate prune re-hashes the SAME key once per \
+         candidate (this is what C4 removes); got {per_candidate_hashes}"
+    );
+    assert_eq!(
+        hoisted_hashes, 1,
+        "C4: the query key is Murmur3-hashed + BTI-encoded EXACTLY ONCE across a \
+         {FANOUT}-generation fan-out; got {hoisted_hashes}"
+    );
+    assert!(
+        hoisted_walks >= FANOUT as u64,
+        "the per-SSTable trie WALK is unchanged — every candidate's trie is still \
+         consulted (only the hash is hoisted); got {hoisted_walks} for {FANOUT} candidates"
+    );
+}
+
+/// Scenario: an absent key is also hashed once across the fan-out (definitive
+/// absence per candidate, single hash).
+#[tokio::test]
+#[serial]
+async fn absent_key_hashed_once_across_fanout() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP (C4): test_da/simple_table BTI fixture not available");
+        return;
+    };
+
+    let set_new = open_fanout(&data_db, FANOUT).await;
+
+    rwc::reset();
+    let encoded = encode_partition_key_for_bti_trie(&ABSENT_KEY); // the ONLY hash
+    let hits = set_new
+        .iter()
+        .filter(|r| r.might_contain_partition_encoded(&ABSENT_KEY, &encoded))
+        .count();
+    let hoisted_hashes = rwc::key_hash_calls();
+
+    assert_eq!(
+        hits, 0,
+        "C4: an absent key is definitive trie absence in every candidate"
+    );
+    assert_eq!(
+        hoisted_hashes, 1,
+        "C4: an absent-key fan-out still hashes the query key exactly once; got {hoisted_hashes}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Manager path: the public query engine hashes the key once (wiring evidence)
+// ---------------------------------------------------------------------------
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        if let Some(dir) = root.parent().and_then(|p| {
+            let d = p.join("schemas");
+            d.exists().then_some(d)
+        }) {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup_db() -> Option<Database> {
+    let root = datasets_root()?;
+    let schema_path = schemas_dir()?.join("da-test.cql");
+    if !schema_path.exists() {
+        return None;
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return None;
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: Some("5.0".to_string()),
+        core_config: Config::default(),
+        table_directory_filter: Some("/test_da/".to_string()),
+    };
+    let result = ingest(config).await.ok()?;
+    (result.schema_load_result.schemas_loaded > 0).then_some(result.database)
+}
+
+fn uuid_to_literal(bytes: &[u8; 16]) -> String {
+    let h = |range: std::ops::Range<usize>| -> String {
+        bytes[range].iter().map(|b| format!("{b:02x}")).collect()
+    };
+    format!(
+        "{}-{}-{}-{}-{}",
+        h(0..4),
+        h(4..6),
+        h(6..8),
+        h(8..10),
+        h(10..16)
+    )
+}
+
+/// Scenario: a real point read through the query engine hashes the key once.
+#[tokio::test]
+#[serial]
+async fn manager_point_read_hashes_key_once() {
+    if da_data_db_path().is_none() {
+        eprintln!("SKIP (C4): test_da/simple_table BTI fixture not available");
+        return;
+    }
+    let Some(db) = setup_db().await else {
+        eprintln!("SKIP (C4): could not ingest test_da");
+        return;
+    };
+
+    // Learn a present id via a scan (also opens the reader).
+    let scan = db
+        .execute("SELECT id FROM test_da.simple_table")
+        .await
+        .expect("scan");
+    let Some(Value::Uuid(id)) = scan.rows.first().and_then(|r| r.values.get("id")).cloned() else {
+        panic!("C4: could not learn a present UUID key from test_da.simple_table");
+    };
+    let point_sql = format!(
+        "SELECT id, name FROM test_da.simple_table WHERE id = {}",
+        uuid_to_literal(&id)
+    );
+
+    // Measure only the point read's key hashing.
+    rwc::reset();
+    assert_eq!(rwc::key_hash_calls(), 0, "reset must zero KEY_HASH_CALLS");
+    let res = db.execute(&point_sql).await.expect("BTI point read");
+
+    assert!(
+        !res.rows.is_empty(),
+        "C4: BTI point read on a known-present key returned zero rows"
+    );
+    assert_eq!(
+        rwc::key_hash_calls(),
+        1,
+        "C4: the manager point-read path hashes+encodes the query key exactly once; got {}",
+        rwc::key_hash_calls()
+    );
+}

--- a/cqlite-core/tests/issue_1575_candidate_key_hash_hoist.rs
+++ b/cqlite-core/tests/issue_1575_candidate_key_hash_hoist.rs
@@ -4,9 +4,9 @@
 //! # What this proves
 //!
 //! A multi-generation `WHERE pk = ?` point read prunes every candidate SSTable's
-//! `Partitions.db` trie. On `main` the SAME query key was re-encoded (Murmur3 hash
-//! + byte-comparable encoding) once per candidate — an N-generation fan-out paid N
-//! identical hashes. C4 hoists the encode to ONCE per read (the encoding is
+//! `Partitions.db` trie. On `main` the SAME query key was re-encoded (a Murmur3
+//! hash and byte-comparable encoding) once per candidate — an N-generation fan-out
+//! paid N identical hashes. C4 hoists the encode to ONCE per read (the encoding is
 //! independent of which SSTable is being pruned), so `KEY_HASH_CALLS == 1` across
 //! the fan-out. The per-SSTable trie WALK is unchanged (each candidate's trie must
 //! still be consulted); only the redundant per-candidate rehash is removed.

--- a/cqlite-core/tests/issue_1618_parser_work_counters.rs
+++ b/cqlite-core/tests/issue_1618_parser_work_counters.rs
@@ -292,6 +292,90 @@ async fn scan_try_parses_partition_headers() {
     );
 }
 
+/// Scenario (K2 DELIVERED): the per-row partition-BOUNDARY peek is now
+/// non-allocating (`peek_partition_boundary`) and does NOT run the full
+/// `parse_partition_header_full` (no key `to_vec`, no `PARTITION_HEADER_TRY_PARSES`
+/// increment). So on a genuinely WIDE-partition fixture — `test_timeseries/
+/// sensor_data` has ~200 rows per `sensor_id` partition — a full scan try-parses a
+/// partition header once per PARTITION (at a confirmed start), not once per ROW.
+///
+/// The assertion brackets the count as a per-partition bound:
+/// `distinct_partitions <= PARTITION_HEADER_TRY_PARSES < rows`. On `main` the
+/// per-row peek made the count `>= rows` (each of the ~200 rows/partition
+/// try-parsed), so `tries < rows` FAILS there and PASSES after K2. The lower bound
+/// (`>= distinct_partitions`) keeps it non-vacuous: every partition's header is
+/// still really parsed at least once.
+#[tokio::test]
+#[serial]
+async fn scan_boundary_peek_does_not_try_parse_per_row() {
+    if !fixture_data_present("test_timeseries", "sensor_data") {
+        eprintln!("Skipping (K2 wiring): test_timeseries/sensor_data Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_timeseries", "time-series.cql").await else {
+        eprintln!("Skipping (K2 wiring): could not ingest test_timeseries");
+        return;
+    };
+
+    rwc::reset();
+    assert_eq!(
+        rwc::partition_header_try_parses(),
+        0,
+        "reset must zero PARTITION_HEADER_TRY_PARSES"
+    );
+
+    let scan = db
+        .execute("SELECT * FROM test_timeseries.sensor_data")
+        .await
+        .expect("scan of test_timeseries.sensor_data");
+    let rows = scan.rows.len() as u64;
+    assert!(
+        rows > 0,
+        "present fixture must return rows (0 rows = read regression, not a skip)"
+    );
+
+    // Distinct partitions = distinct `sensor_id` (the partition key) values.
+    let mut partitions = std::collections::HashSet::new();
+    for row in &scan.rows {
+        if let Some(cqlite_core::Value::Uuid(b)) = row.values.get("sensor_id") {
+            partitions.insert(*b);
+        }
+    }
+    let distinct_partitions = partitions.len() as u64;
+    assert!(
+        distinct_partitions >= 1,
+        "fixture shape: sensor_data must expose at least one sensor_id partition"
+    );
+    // Genuinely wide: many more rows than partitions (otherwise `tries < rows`
+    // could not distinguish per-row from per-partition). Guards the fixture shape.
+    assert!(
+        rows >= distinct_partitions * 2,
+        "fixture shape changed: expected a WIDE fixture (rows {rows} >= 2 * partitions \
+         {distinct_partitions}); K2's per-row-vs-per-partition claim is only testable when wide"
+    );
+
+    let tries = rwc::partition_header_try_parses();
+    eprintln!(
+        "K2: rows={rows} distinct_partitions={distinct_partitions} \
+         PARTITION_HEADER_TRY_PARSES={tries}"
+    );
+
+    // K2 headline: the boundary peek stopped try-parsing per row, so the full
+    // parse now runs per PARTITION, not per row. FAILS on `main` (tries >= rows).
+    assert!(
+        tries < rows,
+        "K2: a scan must try-parse partition headers fewer times than it returns \
+         rows (per-partition, not per-row); got tries={tries} rows={rows}"
+    );
+    // Non-vacuous lower bound: each partition's header is really parsed at least
+    // once, so the count is at least the distinct-partition count.
+    assert!(
+        tries >= distinct_partitions,
+        "K2: every partition's header must be parsed at least once; got tries={tries} \
+         distinct_partitions={distinct_partitions}"
+    );
+}
+
 /// Scenario (K2/L currency): the shared display-row builder sorts each row's cells
 /// once, so `ROW_SORT_INVOCATIONS` is at least the number of returned live rows.
 /// K2/L (cells arrive pre-sorted) flip this to prove no per-row sort.

--- a/openspec/changes/hoist-candidate-key-rehash/design.md
+++ b/openspec/changes/hoist-candidate-key-rehash/design.md
@@ -1,0 +1,78 @@
+# Design — hoist-candidate-key-rehash (C4, issue #1575)
+
+## Context
+
+`WHERE pk = ?` against a BTI table prunes the reader snapshot to the candidate generations
+that admit the key before decoding any Data.db bytes. The prune calls
+`SSTableReader::might_contain_partition(raw_key)` per candidate. For BTI that routes to
+`lookup_partition_via_bti_trie` → `encode_partition_key_for_bti_trie(raw_key)`, whose Murmur3
+token + byte-comparable encoding is a pure function of the key. Recomputing it per candidate
+wastes N-1 hashes on an N-generation fan-out.
+
+C3 (#1574) already added a reader-local same-key memo so a SINGLE candidate's prune+seek
+descends the trie once. But the memo is per-reader: N distinct generations each miss their
+own memo and each re-encode the key. The encoding, unlike the trie walk, is
+SSTable-independent, so it should be computed once per read and threaded to every candidate.
+
+## Decisions
+
+### Decision 1 — Pre-encoded lookup entry point, hoisted at the manager
+
+Add `SSTableReader::might_contain_partition_encoded(raw_key, encoded: &[u8; 9])` and
+`lookup_partition_via_bti_trie_encoded(raw_key, encoded)`, which accept a PRE-ENCODED
+byte-comparable key and skip `encode_partition_key_for_bti_trie`. Both share the same private
+`bti_trie_resolve(raw_key, encoded)` body as the raw-key entry point (which now encodes once
+then delegates), so there is a single trie-descent implementation — the memo, the presence
+counters, the `TRIE_WALKS` accounting, and the resolved offset are byte-identical to the
+raw-key path.
+
+`SSTableManager::prune_candidates(readers, raw_key)` computes the encoding EXACTLY ONCE
+(guarded by `readers.iter().any(is_bti)` so a pure-BIG table pays nothing) and reuses it for
+every candidate. The three prune sites call this helper. A BIG reader ignores the `encoded`
+argument and runs its raw-key bloom check, so mixed/non-BTI sets are correct.
+
+Alternative rejected: caching the encoding on the reader. That is a cross-lookup cache (Epic
+B/B4) with lifetime/invalidation concerns; hoisting to one local variable per read is
+minimal and self-evidently correct.
+
+### Decision 2 — `KEY_HASH_CALLS` counter (A5 pattern, zero-overhead release)
+
+Add `KEY_HASH_CALLS` to `read_work_counters` following the existing issue #1566 pattern:
+unconditional `record_key_hash()` free function whose body is `#[cfg(any(test, feature =
+"work-counters"))]` (a no-op, not even an atomic, in release), incremented at the single
+Murmur3 site inside `encode_partition_key_for_bti_trie`. This makes the hoist provable — a
+multi-generation fan-out records 1, and the retained per-candidate path records N — the
+no-heuristics way (observe the work, not just the result). No production call site is
+`#[cfg]`-gated, so release codegen is unchanged.
+
+### Decision 3 — Wiring evidence keyed on distinct-memo readers
+
+The RED-on-main proof opens N INDEPENDENT `SSTableReader`s on the real BTI
+`test_da/simple_table` fixture (each with its own empty C3 memo — a faithful stand-in for N
+generations). Cloning one `Arc<Reader>` N times would share one memo and coalesce the
+encode, masking the fan-out; distinct readers do not. The pre-C4 path records
+`KEY_HASH_CALLS == N`; the hoisted path records 1, with byte-identical prune decisions. A
+public-`Database`-API point read additionally proves the manager wiring hashes once.
+
+## Risks / invariants
+
+- **Parity (no-heuristics).** `lookup_partition_in_bti_slice(slice, encoded)` is the exact
+  zero-copy walker C3 introduced; feeding it `encode_partition_key_for_bti_trie(raw_key)` is
+  identical to the raw-key `lookup_raw_key_in_bti_partitions_slice(slice, raw_key)` it
+  replaces on the prune path (the latter just encodes then calls the former). Pinned
+  `test_da` offsets and 33-table `da` parity are unchanged.
+- **Presence-oracle ordering preserved.** BTI still branches to the trie before any
+  bloom/Index.db path; the trie miss stays definitive absence; `READ_BLOOM_CHECKS` /
+  `READ_PARTITION_LOOKUP` emission is unchanged.
+
+## Deferred (remaining C4 work, out of this change)
+
+The audit's C4 line also calls for replacing the first-targeted-read whole-trie DFS successor
+enumeration (`partition_lookup.rs::bti_partition_offsets`, memoized in a `OnceLock`) with
+LOCAL successor resolution (a next-greater trie walk, O(depth)) and single-DFS concurrency
+hardening. This is deferred: it is BTI-oracle-sensitive (a wrong seek end-bound silently
+truncates a partition read), and a correct next-greater walk spans all six node-type families
+(Single/Sparse/Dense variants) — a substantial, higher-risk change that warrants its own
+focused review and golden coverage, exceeding this MINIMAL hash-hoist change. The current
+enumeration remains memoized and correct; the scaling/concurrency rewrite is carried as
+follow-up C4 work.

--- a/openspec/changes/hoist-candidate-key-rehash/proposal.md
+++ b/openspec/changes/hoist-candidate-key-rehash/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+A multi-generation `WHERE pk = ?` point read against Cassandra 5.0 BTI (`da`) SSTables
+re-hashes the SAME query partition key once per candidate SSTable, documented in the July
+2026 read-path performance audit (`docs/reports/read-path-performance-audit-2026-07-01.md`
+§Epic C, finding **C4**; child of Epic C #1515, issue #1575):
+
+- The candidate-prune loop calls `might_contain_partition` per candidate reader
+  (`storage/sstable/mod.rs`, `storage/sstable/reverse_scan.rs`). For a BTI reader that
+  routes to `lookup_partition_via_bti_trie` → `encode_partition_key_for_bti_trie`
+  (`bti/parser/partitions.rs`), which computes a **Murmur3 token + byte-comparable
+  encoding** of the raw key. That encoding is a pure function of the key ALONE — it does not
+  depend on which SSTable is being pruned — yet it is recomputed once per candidate. With N
+  generations that is N identical Murmur3 hashes per read where 1 suffices.
+
+This is design-driven read-path performance work under the standing owner Seam-1 approval
+(2026-07-06 read-path-audit drain directive); routing = **design**. Target milestone:
+**v0.14 performance wave** (Epic C, Wave 3 capstone).
+
+Audit facts that constrain the design (no-heuristics, byte-faithful):
+
+- The `Partitions.db` trie is the **authoritative** presence oracle for BTI (no bloom
+  filter); a trie miss is definitive absence. The prune decision (the admitted candidate
+  set) and the resolved offsets MUST be byte-identical before/after — the pinned
+  `test_da/simple_table` leaves at trie offsets 0/3/6 resolve to Data.db offsets 0/63/125,
+  and the full 33-table `da` parity is the correctness oracle.
+- The per-SSTable trie WALK is legitimately per-candidate (each generation has its own
+  trie); only the key **hash+encoding** is redundant across candidates. This change hoists
+  the hash, NOT the walk.
+
+## What Changes
+
+- **Hoist the BTI key hash+encoding out of the candidate-prune loop.** Compute the
+  byte-comparable trie key ONCE per read (only when a BTI candidate is present) and reuse it
+  for every candidate's prune, via a new pre-encoded lookup entry point
+  (`SSTableReader::might_contain_partition_encoded` →
+  `lookup_partition_via_bti_trie_encoded`, backed by the existing zero-copy
+  `lookup_partition_in_bti_slice`). The three candidate-prune sites
+  (`scan_partition_with_cell_metadata`, `scan_partition_clustering`,
+  `scan_partition_clustering_reverse`) route through one `SSTableManager::prune_candidates`
+  helper. A BIG (`nb`) candidate has no BTI encoding to hoist — its raw-key bloom check runs
+  unchanged — so a non-BTI or mixed candidate set stays correct.
+- **Measure it.** Add a cfg-gated `KEY_HASH_CALLS` read-work counter (issue #1566 / A5
+  pattern, zero-overhead in release) incremented at the single BTI key-encoding site, so the
+  hoist is provable: a multi-generation fan-out records exactly 1, not N.
+
+## Non-goals
+
+- **No on-disk format change; no writer change.** Read-path only; `da` BTI byte layout
+  untouched. The prune decision and resolved offsets are byte-identical.
+- **Local successor / no-whole-table-DFS partition-bound resolution is DEFERRED** (a
+  distinct follow-up). C4's audit line pairs the hash-hoist with replacing the first-read
+  whole-trie DFS successor enumeration (`partition_lookup.rs::bti_partition_offsets`) with a
+  local next-greater trie walk (and single-DFS concurrency hardening). That is
+  BTI-oracle-sensitive (a wrong seek bound silently truncates a partition read) and requires
+  either a substantial new next-greater traversal over all 6 node-type families or an
+  open-time precompute with its own blast radius — beyond this MINIMAL change. It is carried
+  as remaining C4 work (see design.md "Deferred") so the risky rewrite gets its own focused
+  review; the current enumeration is already memoized and correct.
+- **No general key/offset cache (that is Epic B/B4).** The hoist reuses ONE encoding within a
+  single read; it is not a cross-lookup cache.
+- **No pre-`na` support**; Cassandra 5.0 `da` BTI only.

--- a/openspec/changes/hoist-candidate-key-rehash/specs/bti-candidate-prune/spec.md
+++ b/openspec/changes/hoist-candidate-key-rehash/specs/bti-candidate-prune/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: A multi-candidate BTI point read hashes the query key exactly once
+A `WHERE pk = ?` point read against a set of BTI (`da`) candidate SSTables SHALL compute the
+Murmur3 hash + byte-comparable encoding of the query partition key EXACTLY ONCE per read,
+regardless of how many candidate generations are pruned — not once per candidate. The
+encoding SHALL be hoisted out of the candidate-prune loop and reused for every candidate's
+trie prune. A pre-encoded prune entry point (`might_contain_partition_encoded`) that accepts
+the already-encoded key SHALL be provided, and a work counter (`KEY_HASH_CALLS`) incremented
+at the single BTI key-encoding site SHALL make the property verifiable.
+
+#### Scenario: The query key is hashed once across an N-generation fan-out
+- **WHEN** a present partition key is pruned across N distinct BTI candidate readers (each
+  with an independent same-key memo) via the hoisted pre-encoded prune, with the read-work
+  counters reset immediately before
+- **THEN** the `KEY_HASH_CALLS` counter reads exactly 1
+- **AND** pruning the SAME N candidates via the retained per-candidate raw-key path reads
+  `KEY_HASH_CALLS == N` (the redundant per-candidate rehash this change removes)
+
+#### Scenario: An absent key is also hashed once across the fan-out
+- **WHEN** an absent partition key is pruned across N distinct BTI candidate readers via the
+  hoisted pre-encoded prune, with the counters reset immediately before
+- **THEN** the `KEY_HASH_CALLS` counter reads exactly 1
+- **AND** every candidate reports definitive trie absence (the key is admitted by none)
+
+#### Scenario: A real point read through the query engine hashes the key once
+- **WHEN** a known-present key is point-read through the public `Database` query API against
+  a BTI SSTable, with the counters reset immediately before
+- **THEN** the `KEY_HASH_CALLS` counter reads exactly 1
+- **AND** the read returns the expected rows
+
+### Requirement: The hoisted prune is byte-identical to the per-candidate prune
+Hoisting the key encoding SHALL NOT change the pruning decision or the resolved partition
+location. The set of candidates admitted by the pre-encoded prune SHALL equal the set
+admitted by the per-candidate raw-key prune for the same key, and the `Partitions.db` trie
+SHALL remain the authoritative presence oracle for BTI (a trie miss is definitive absence).
+The per-SSTable trie walk SHALL remain per-candidate (only the key hash is hoisted, not the
+walk), and the pinned `test_da/simple_table` resolved offsets (0/63/125) SHALL be unchanged.
+
+#### Scenario: The hoisted prune admits the identical candidate set
+- **WHEN** the same present key is pruned across the same N BTI candidates via both the
+  hoisted pre-encoded path and the retained per-candidate raw-key path
+- **THEN** both admit all N candidates (identical decision)
+- **AND** the hoisted path still records at least N trie walks (one per candidate), proving
+  only the hash — not the walk — was hoisted
+
+#### Scenario: A BIG candidate is pruned unchanged
+- **WHEN** a candidate reader is BIG (`nb`) rather than BTI (it has no `Partitions.db`
+  encoding to hoist)
+- **THEN** the pre-encoded prune falls back to its raw-key bloom check, so a non-BTI or mixed
+  candidate set is pruned exactly as before

--- a/openspec/changes/hoist-candidate-key-rehash/tasks.md
+++ b/openspec/changes/hoist-candidate-key-rehash/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — hoist-candidate-key-rehash (C4, issue #1575)
+
+## 1. Measurement first (A5 counter)
+- [x] 1.1 Add the `KEY_HASH_CALLS` read-work counter (`record_key_hash` / `key_hash_calls`)
+      to `storage/sstable/read_work_counters.rs`, following the issue #1566 zero-overhead
+      pattern; extend the local-`Counters` round-trip unit test with a distinct multiplicity.
+- [x] 1.2 Increment it at the single BTI key-encoding site
+      (`bti/parser/partitions.rs::encode_partition_key_for_bti_trie`, the Murmur3 call).
+
+## 2. TDD tests (RED without the hoist, GREEN with it)
+- [x] 2.1 Reader-level fan-out (`tests/issue_1575_candidate_key_hash_hoist.rs`,
+      `cli-helpers,work-counters`, fixture-gated): N INDEPENDENT `SSTableReader`s on
+      `test_da/simple_table`; the retained per-candidate `might_contain_partition` records
+      `KEY_HASH_CALLS == N`, the hoisted `might_contain_partition_encoded` fed one
+      precomputed key records 1, with an identical admitted set. Present + absent scenarios.
+- [x] 2.2 Manager path: a real `WHERE id = <uuid>` point read through the public `Database`
+      API records `KEY_HASH_CALLS == 1` and returns the expected rows.
+
+## 3. Implement the hoist
+- [x] 3.1 Re-export the pre-encoded zero-copy walker `lookup_partition_in_bti_slice`
+      (`bti/parser/mod.rs`, `bti/mod.rs`, `pub(crate)`).
+- [x] 3.2 Refactor `lookup_partition_via_bti_trie` into: raw-key entry (memo-check, encode
+      once, delegate), pre-encoded entry `lookup_partition_via_bti_trie_encoded`, and shared
+      private `bti_trie_resolve(raw_key, encoded)`; add `is_bti` +
+      `might_contain_partition_encoded` (`reader/partition_lookup.rs`).
+- [x] 3.3 Add `SSTableManager::prune_candidates` (encode once iff any BTI candidate; reuse
+      across all) and route the three prune sites through it
+      (`scan_partition_with_cell_metadata`, `scan_partition_clustering`,
+      `scan_partition_clustering_reverse`); drop the now-unused `Arc`/`reader` imports in
+      `reverse_scan.rs`.
+
+## 4. Gate + parity
+- [x] 4.1 Add `--test issue_1575_candidate_key_hash_hoist` to the `work-counters-guard`
+      gate component (`scripts/agent-gate.sh`) + its comment.
+- [x] 4.2 `cargo +1.88.0 fmt` clean; C3 (`issue_1574`) and counter (`issue_1566`) tests still
+      green; `scripts/agent-gate.sh --lite` PASS.
+
+## 5. Deferred (see design.md "Deferred")
+- [ ] 5.1 Local successor / no-whole-table-DFS partition-bound resolution (next-greater trie
+      walk + single-DFS concurrency hardening) — carried as remaining C4 work; BTI
+      oracle-sensitive, warrants its own focused review.

--- a/openspec/changes/nonalloc-partition-boundary-peek/design.md
+++ b/openspec/changes/nonalloc-partition-boundary-peek/design.md
@@ -1,0 +1,115 @@
+# Design — Non-allocating partition-boundary peek (K2)
+
+## Context
+
+`parse_partition_header_full` (`v5_compressed_legacy/row_framing.rs`) is the
+single partition-header parse primitive. It does three things: (1) records the H5
+`PARTITION_HEADER_TRY_PARSES` gauge, (2) validates the header structure (bounds,
+non-zero `u8` key length, per-format DeletionTime framing incl. the oa/da
+strict-`0x80` LIVE-sentinel rule), and (3) allocates the partition key
+(`data[..].to_vec()` → `RowKey`) and returns it.
+
+The emit loop uses this as a boundary detector after every row via
+`peek_is_partition_header`, which prepends a marker-flag reject (END_OF_PARTITION
+`0x01` / IS_MARKER `0x02`, issue #229) and then calls the full parser and throws
+away everything but the `Ok`/`Err` bit. That means every row pays (1) + (2) + (3)
+just to learn a boolean.
+
+K1 (#1640) already extracted the completeness classifier
+`partition_header_readiness` → `{ Ready, Incomplete, Malformed }` (issue #1741),
+computed WITHOUT consuming/allocating, used to size the need-more decision for
+split chunks. K2 reuses that classifier for the peek's truncation judgment and
+adds the missing piece: a non-allocating STRUCTURAL scan shared with the full
+parser.
+
+## Goals
+
+- The post-row boundary peek allocates nothing and records no
+  `PARTITION_HEADER_TRY_PARSES`.
+- The peek's accept/reject decision is byte-for-byte identical to the old
+  `peek_is_partition_header` for every input (no drift, no weakened validation).
+- The real key allocation + gauge increment happen once per partition (at a
+  confirmed start), not once per row.
+
+## Decisions
+
+### D1 — One shared structural scan (`scan_partition_header`)
+
+Extract the exact byte walk of `parse_partition_header_full` into a private
+`scan_partition_header(data, offset) -> Result<PartitionHeaderLayout>`, where
+`PartitionHeaderLayout { key_range: Range<usize>, next_offset, partition_deletion }`
+carries byte OFFSETS (not an allocated key). It performs every validation the old
+full parser did and returns the identical `Error` on every failure path.
+
+- `parse_partition_header_full` becomes: record the gauge → `scan_partition_header`
+  → `data[layout.key_range].to_vec()` → `RowKey`. Its observable behavior (values
+  AND error messages) is unchanged.
+- The peek calls `scan_partition_header` (no gauge, no `to_vec`).
+
+This is the drift-proofing the audit demands ("derive both from the same helper
+where possible so they cannot drift"): a single structural authority means the
+peek can never accept what the parser rejects.
+
+### D2 — `peek_partition_boundary -> BoundaryPeek`
+
+```
+BoundaryPeek { Header, NotHeader, NeedMoreBytes }
+```
+
+Algorithm (all non-allocating, no gauge):
+
+1. `data.get(offset)`: `None` → `NeedMoreBytes` (past end). Otherwise if the byte
+   is an END_OF_PARTITION or range-tombstone marker → `NotHeader` (issue #229 —
+   markers are not partition headers; preserves the old peek's pre-check).
+2. `partition_header_readiness(&data[offset..])` (the #1741 completeness gate):
+   `Incomplete` → `NeedMoreBytes`; `Malformed` → `NotHeader`.
+3. `Ready` guarantees every header byte is present, so a `scan_partition_header`
+   failure here is a genuine STRUCTURAL rejection (e.g. an invalid oa/da IS_LIVE
+   byte), never truncation: `Ok` → `Header`, `Err` → `NotHeader`.
+
+`peek_is_partition_header` becomes
+`matches!(peek_partition_boundary(..), BoundaryPeek::Header)`.
+
+**Equivalence to the old boolean (proved by the proptest):** the old bool was
+`!marker && parse_partition_header_full(..).is_ok()`. Under step 2, a non-`Ready`
+verdict maps exactly to a full-parse failure (truncation → `Incomplete`; zero key
+length → `Malformed`); under `Ready` the shared `scan_partition_header` is the
+same structural test the full parser runs. So `Header` ⟺ old `true` for every
+input, including the oa/da byte `0x81` that `readiness` treats as a present
+1-byte deletion form but the strict scan rejects (→ `NotHeader`, matching the old
+`Err`).
+
+### D3 — Reuse `partition_header_readiness` for the truncation split
+
+Rather than teach `scan_partition_header` to distinguish "truncated" from
+"malformed" (a second error taxonomy that could itself drift), the peek delegates
+the completeness judgment to the already-tested #1741 classifier and only runs
+the strict scan under `Ready`. Under `Ready` the scan cannot fail from
+truncation, so the `Err → NotHeader` mapping is unambiguous. The double read of
+the tiny header (readiness walks to the discriminator; scan walks the whole
+header) is still non-allocating and vastly cheaper than the old
+`to_vec`+`format!`+gauge per row.
+
+### D4 — File-size campsite
+
+The new code lands in `row_framing.rs` (already over the ratchet). The extraction
+replaces the inline body of `parse_partition_header_full` with the shared helper +
+two thin wrappers, so net growth is small; the diff is acknowledged with
+`CQLITE_ALLOW_FILE_GROWTH=1` (splitting the 108KB `row_framing.rs` is out of scope
+for this localized change — tracked by the #1116 source-split doctrine).
+
+## Risks
+
+- **A peek that accepts what the parser rejects** would mis-detect a boundary and
+  desync the scan (a new bug class). Mitigation: D1's single shared scan + D2's
+  proptest (`Header` ⟺ `!marker && parse.is_ok()`) over arbitrary byte prefixes
+  for both DeletionTime forms.
+- **Parity regression from a subtle scan slip.** Mitigation: `scan_partition_header`
+  is transcribed line-for-line from the full parser (same errors); the
+  multi-partition sstabledump harness + compaction byte-parity suite are the
+  invariant.
+
+## Migration
+
+Pure internal refactor. No public API, on-disk format, or config change. New
+surfaces are `pub(super)` only.

--- a/openspec/changes/nonalloc-partition-boundary-peek/proposal.md
+++ b/openspec/changes/nonalloc-partition-boundary-peek/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+The July 2026 parser performance audit
+(`docs/reports/parser-performance-audit-2026-07-01.md`, Epic K finding **K2**)
+found the V5CompressedLegacy partition-BOUNDARY peek — the "is the next thing a
+new partition header?" check the emit loop runs **after every row** — implemented
+as a FULL allocating partition-header try-parse:
+
+- `peek_is_partition_header` calls `parse_partition_header_full`, which
+  (a) allocates a throwaway partition key `to_vec`, (b) increments the H5
+  `PARTITION_HEADER_TRY_PARSES` gauge, and (c) constructs eager `format!(..)`
+  error strings that are used purely as a "not a header" control-flow sentinel.
+
+Cost: one throwaway key allocation + up to one error-string allocation **per
+row** in every scan/compaction emit path (the driver's post-row boundary peek at
+`partition_driver.rs`, plus the `block_emit`/`block_emit_windowed` peeks). For a
+wide partition the peek runs once per row while a real header parse is needed only
+once per partition.
+
+**Routing: design-driven.** This is a hot-path mechanics change (introduce a
+non-allocating peek primitive + a shared structural classifier), not an
+oracle-driven parse-correctness bug, so it is captured as an OpenSpec change per
+the spec-driven doctrine. The design and priority are owner-approved via the
+read-path/parser performance audit (standing owner Seam-1 approval, v0.14 perf
+wave); this change encodes that decision rather than re-litigating it.
+
+Milestone: **v0.14 performance wave** (Epic #1604, row/cell hot-loop mechanics).
+This is a **pure factoring** — identical observable output. Parity is the proof:
+the multi-partition sstabledump JSONL harness and the compaction byte-parity
+suite must stay green (row ordering and partition boundaries byte-identical).
+
+## What Changes
+
+- **Add** a non-allocating boundary peek `peek_partition_boundary(data, offset)
+  -> BoundaryPeek` where `BoundaryPeek` is a small `{ Header, NotHeader,
+  NeedMoreBytes }` enum. It performs the same structural checks (marker-flag
+  rejection, key-length plausibility, DeletionTime framing) by reading bytes and
+  returning the enum — **no `to_vec`, no `format!`, no `Err`-as-control-flow, no
+  `PARTITION_HEADER_TRY_PARSES` increment.**
+- **Extract** the exact structural walk of `parse_partition_header_full` into one
+  shared non-allocating helper (`scan_partition_header` → byte-range layout) that
+  BOTH the full parser and the peek derive from, so a peek can never accept what
+  the full parser rejects (no drift, no new heuristic).
+- **Rewrite** `peek_is_partition_header` as a thin wrapper over
+  `peek_partition_boundary` (unchanged boolean semantics for every existing
+  caller). The real `parse_partition_header_full` (which legitimately allocates
+  the key + increments the gauge) runs ONLY at a confirmed partition start, once
+  per partition.
+- **Add** a proptest proving `peek_partition_boundary == Header` ⟺ (not a
+  marker AND `parse_partition_header_full == Ok`) on the same prefix, for both the
+  oa/da and nb DeletionTime forms — the drift guard.
+- **Add** a work-counter wiring test scanning a genuinely wide-partition fixture
+  (`test_timeseries/sensor_data`, ~200 rows/partition) asserting
+  `PARTITION_HEADER_TRY_PARSES` is bounded by the partition count, not the row
+  count (FAILS on `main`, where the per-row peek try-parses).
+
+## Non-goals
+
+- **K3 (#1642) positional row emit** and **K4 (#1643) `Arc` key handles** — the
+  rest of the K-emit chain. K2 does NOT fold in that work; where a K3/K4 seam
+  appears it is left as a `TODO` referencing the owning issue.
+- **No emit-semantics change of any kind** — no change to row ordering, partition
+  boundary detection outcomes, tombstone handling, or any observable output. This
+  is a factoring; the parity gates are the proof.
+- **Not** weakening any validation the full parse performs at a true boundary
+  (the peek's structural rules are IDENTICAL to the full parser's, derived from
+  the same helper).
+- **Not** re-litigating the pre-`na` version floor or the no-heuristics mandate.

--- a/openspec/changes/nonalloc-partition-boundary-peek/specs/sstable-partition-emit/spec.md
+++ b/openspec/changes/nonalloc-partition-boundary-peek/specs/sstable-partition-emit/spec.md
@@ -1,0 +1,65 @@
+# sstable-partition-emit
+
+## ADDED Requirements
+
+### Requirement: Partition-boundary peek is non-allocating
+
+The post-row partition-boundary detection SHALL be a non-allocating peek that reads bytes and returns a small `BoundaryPeek` enum (`Header`, `NotHeader`, `NeedMoreBytes`) to decide whether the next bytes begin a new partition header. It SHALL NOT allocate a
+throwaway partition key, SHALL NOT construct error strings as a control-flow
+sentinel, and SHALL NOT increment the `PARTITION_HEADER_TRY_PARSES` gauge. The
+real allocating partition-header parse (`parse_partition_header_full`) SHALL run
+only at a confirmed partition start, once per partition.
+
+#### Scenario: A full scan try-parses per partition, not per row
+
+- **GIVEN** a genuinely wide-partition fixture (many rows per partition)
+- **WHEN** a full scan runs through the emit loop and the boundary peek fires
+  after every row
+- **THEN** `PARTITION_HEADER_TRY_PARSES` recorded by the scan is strictly less
+  than the returned row count and at least the distinct-partition count (a
+  per-partition bound), whereas on the pre-K2 behavior the per-row peek makes the
+  count at least the row count.
+
+### Requirement: Boundary peek does not full-parse the header to detect a boundary
+
+The boundary peek SHALL derive its accept/reject decision from the SAME structural
+walk the full partition-header parser uses (a shared non-allocating helper), so
+the peek can never accept a header the full parser would reject and never rejects
+one it would accept. The peek SHALL NOT weaken any validation the full parse
+performs at a true boundary.
+
+#### Scenario: Peek accepts exactly what the full parser accepts
+
+- **GIVEN** an arbitrary byte prefix and a parser on either the oa/da or the nb
+  DeletionTime form
+- **WHEN** the boundary peek and the full partition-header parse both run at the
+  same offset
+- **THEN** the peek returns `Header` if and only if the leading byte is not an
+  END_OF_PARTITION or range-tombstone marker AND the full parser returns `Ok`,
+  and `peek_is_partition_header` returns that same boolean (a proptest asserts
+  this equivalence, so the cheap peek and the real parse cannot drift).
+
+#### Scenario: Truncated boundary reports NeedMoreBytes without a false parse
+
+- **GIVEN** a partition-header prefix split across a chunk boundary (the header —
+  or, for an oa/da deleted partition, its full DeletionTime — is not entirely
+  present)
+- **WHEN** the boundary peek runs at that offset
+- **THEN** it returns `NeedMoreBytes` (never `Header`), allocating nothing and
+  recording no `PARTITION_HEADER_TRY_PARSES`, so the caller can request more
+  bytes rather than mis-detecting or mis-parsing the boundary.
+
+### Requirement: Emit output is byte-identical across the peek refactor
+
+Replacing the allocating peek with the non-allocating peek SHALL be a pure
+factoring with no change to observable emit output: partition boundary detection
+outcomes, row ordering, and every parsed value SHALL be unchanged, and
+`parse_partition_header_full` SHALL still return identical values and identical
+error messages.
+
+#### Scenario: Parity harnesses stay green
+
+- **WHEN** the multi-partition sstabledump JSONL parity harness and the compaction
+  byte-parity suite run with the non-allocating peek
+- **THEN** both pass with output identical to the pre-refactor baseline (row order
+  and partition boundaries byte-identical).

--- a/openspec/changes/nonalloc-partition-boundary-peek/tasks.md
+++ b/openspec/changes/nonalloc-partition-boundary-peek/tasks.md
@@ -1,0 +1,57 @@
+# Tasks — Non-allocating partition-boundary peek (K2)
+
+## 1. Drift-guard proptest (TDD, write first)
+
+- [ ] 1.1 Add a proptest asserting, for arbitrary byte slices and both the oa/da
+      and nb parsers, that `peek_partition_boundary(data, 0) == Header` ⟺
+      (`data[0]` is NOT an END_OF_PARTITION/range-tombstone marker AND
+      `parse_partition_header_full(data, 0).is_ok()`), and that
+      `peek_is_partition_header` returns the same boolean. Un-writable on `main`
+      (there is no non-allocating peek); becomes writable once it exists.
+
+## 2. Wide-partition work-counter wiring test (TDD, write first)
+
+- [ ] 2.1 Add a `work-counters` scan test over `test_timeseries/sensor_data`
+      (~200 rows/partition) asserting `PARTITION_HEADER_TRY_PARSES` after a full
+      scan is `< rows` and `>= distinct partitions` (the per-partition bound).
+      FAILS on `main` (the per-row peek try-parses ⇒ count `>= rows`); PASSES
+      after K2. Skip-keys off fixture presence (0 rows stays a hard failure).
+
+## 3. Shared structural scan
+
+- [ ] 3.1 Add private `PartitionHeaderLayout { key_range, next_offset,
+      partition_deletion }` and extract `scan_partition_header(data, offset) ->
+      Result<PartitionHeaderLayout>` from `parse_partition_header_full` — the exact
+      byte walk, minus the gauge and the key `to_vec`, producing identical errors.
+- [ ] 3.2 Reduce `parse_partition_header_full` to: record the gauge →
+      `scan_partition_header` → `to_vec` the key range → `RowKey`. Values and
+      error messages unchanged.
+
+## 4. Non-allocating peek
+
+- [ ] 4.1 Add `BoundaryPeek { Header, NotHeader, NeedMoreBytes }` +
+      `peek_partition_boundary(data, offset)` (marker pre-check → #1741 readiness
+      gate → strict `scan_partition_header` under `Ready`). No gauge, no alloc.
+- [ ] 4.2 Rewrite `peek_is_partition_header` as
+      `matches!(peek_partition_boundary(..), BoundaryPeek::Header)`; every existing
+      caller (driver post-row peek + `block_emit`/`block_emit_windowed`) is
+      unchanged and now allocation-free.
+
+## 5. Surfaces named / roborev pre-empt
+
+- [ ] 5.1 New surfaces (`pub(super)`): `BoundaryPeek`, `peek_partition_boundary`;
+      private `PartitionHeaderLayout`, `scan_partition_header`. No public (`pub`)
+      API change; `peek_is_partition_header` signature unchanged.
+- [ ] 5.2 Pre-roborev self-check: peek accept/reject byte-identical to `main`
+      (proptest); no `unwrap`/`expect` in library code; no-heuristics (structural
+      scan, not byte-pattern guessing); no `manual_range_contains`; no dangling
+      refs; no wall-clock races in the added tests; minimal-features build clean.
+
+## 6. Validation
+
+- [ ] 6.1 `openspec validate nonalloc-partition-boundary-peek --strict` — clean.
+- [ ] 6.2 Fast iteration gate (`scripts/agent-gate.sh --lite`) PASS each round.
+- [ ] 6.3 Full `scripts/agent-gate.sh` PASS (run by the lead) — multi-partition
+      sstabledump parity + compaction byte-parity green (row order + boundaries
+      byte-identical).
+- [ ] 6.4 Intent audit **C** (spec-auditor) PASS + roborev clean before merge.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -35,7 +35,8 @@
 #   work-counters-guard cargo test -p cqlite-core --features cli-helpers,work-counters
 #                      the read/parser work-counter wiring-evidence tests
 #                      (issue_1566/1573/1585 read-work counters + issue_1618 parser
-#                      work counters). The counter bodies/getters are feature-gated
+#                      work counters + issue_1575 candidate-key hash hoist). The
+#                      counter bodies/getters are feature-gated
 #                      behind `work-counters`, so the default core-tests run can't
 #                      execute them — without this component the wiring evidence
 #                      would only run under a manual `--features work-counters`
@@ -2460,7 +2461,8 @@ dispatch_component() {
       --test issue_1573_readat_positional \
       --test issue_1585_read_op_per_chunk \
       --test issue_1597_compression_info_one_parse \
-      --test issue_1618_parser_work_counters ;;
+      --test issue_1618_parser_work_counters \
+      --test issue_1575_candidate_key_hash_hoist ;;
     byte-budget-guard) run_component byte-budget-guard cargo test --package cqlite-core \
       --features write-support,cli-helpers,state_machine \
       --test issue_1582_byte_bounded_result_budget ;;


### PR DESCRIPTION
Two file-disjoint read-path perf lanes bundled through one solo full gate (fleet→integration, #1116). v0.14 read-path performance wave (standing owner drain directive; designs pre-approved via docs/reports/read-path-performance-audit-2026-07-01.md). Each carries its own OpenSpec change; both passed spec-auditor C and roborev.

## #1641 (K2) — non-allocating partition-boundary peek
Boundary detection no longer runs the full allocating header try-parse (throwaway key `to_vec` + `format!` + gauge) just to learn a boolean. Extracted a shared non-allocating `scan_partition_header` (byte-range layout) that BOTH the full parse and the new `peek_partition_boundary`/`BoundaryPeek` use — one structural authority, so peek can't drift from parse. `PARTITION_HEADER_TRY_PARSES` 2010→10 on a real wide fixture. peek⟺parse proven boolean-identical by a 4000-case drift proptest (oa/da/nb + truncation→NeedMoreBytes). Byte-identical emit. No pub API change. OpenSpec: nonalloc-partition-boundary-peek. (Note: the spec's "SHALL NOT construct error strings" prong is slightly over-claimed — the Ready+structural-mismatch scan path can build a discarded `format!`; the per-row hot reject is allocation-free and the code docs were corrected. Non-blocking spec-wording drift.)

## #1575 (C4 part 1) — hoist per-candidate BTI key rehash
A multi-generation `WHERE pk=?` re-hashed the same key once per candidate SSTable; the Murmur3 token + BTI encoding is a function of the key alone, so it's now hoisted to once-per-read via `SSTableManager::prune_candidates` (encodes once iff any candidate is BTI, reused across all). `KEY_HASH_CALLS` 1-per-read proven by a 32-reader fan-out test (defeats the C3 memo, RED-on-main) + a public `Database::execute` test. Byte-identical prune decisions/offsets (admitted-set identity asserted). Deleted the orphaned `lookup_raw_key_in_bti_partitions_slice` (rerouted its last consumer byte-identically). The C4 successor-resolution half is explicitly deferred (Non-goals → follow-up #2058). OpenSpec: hoist-candidate-key-rehash. (Non-blocking: a dedicated mixed BTI+BIG prune test would close the BIG-fallback branch explicitly; pure-BIG is covered by the existing parity suite.)

## Validation
Full scripts/agent-gate.sh RESULT: PASS (23/23) at the bundle tip. spec-auditor C: PASS for both. roborev: clean on both.

Closes #1641
Closes #1575