### PR TITLE
perf(#1571,#1642,#1593): cache observability (B5) + positional row emit (K3) + blocking I/O off async (F3)

### DIFF
--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -917,9 +917,16 @@ class DatabaseStats:
     def memory_stats(self) -> dict[str, int]:
         """Memory and cache metrics.
 
-        Keys: 'block_cache_hits', 'block_cache_misses', 'row_cache_hits',
-              'row_cache_misses', 'total_memory_used', 'buffer_allocations',
-              'buffer_deallocations'
+        Keys: 'block_cache_hits', 'block_cache_misses', 'block_cache_evictions',
+              'block_cache_capacity_bytes', 'key_cache_hits', 'key_cache_misses',
+              'key_cache_evictions', 'key_cache_resident_bytes',
+              'key_cache_capacity_bytes', 'row_cache_hits', 'row_cache_misses',
+              'total_memory_used', 'buffer_allocations', 'buffer_deallocations'
+
+        The ``block_cache_*`` keys report the real B1 decompressed-chunk cache and
+        the ``key_cache_*`` keys the aggregated B4 key->partition-offset caches
+        (issue #1571). All values are real counters -- an idle/disabled cache
+        reports honest zeros, never a fabricated placeholder.
         """
         ...
 

--- a/bindings/python/src/stats.rs
+++ b/bindings/python/src/stats.rs
@@ -50,6 +50,15 @@ impl DatabaseStats {
         let mem = &stats.memory_stats;
         memory.set_item("block_cache_hits", mem.block_cache_hits)?;
         memory.set_item("block_cache_misses", mem.block_cache_misses)?;
+        // Issue #1571 (B5): honest cache observability — real chunk-cache
+        // evictions/capacity and the aggregated key-cache counters.
+        memory.set_item("block_cache_evictions", mem.block_cache_evictions)?;
+        memory.set_item("block_cache_capacity_bytes", mem.block_cache_capacity_bytes)?;
+        memory.set_item("key_cache_hits", mem.key_cache_hits)?;
+        memory.set_item("key_cache_misses", mem.key_cache_misses)?;
+        memory.set_item("key_cache_evictions", mem.key_cache_evictions)?;
+        memory.set_item("key_cache_resident_bytes", mem.key_cache_resident_bytes)?;
+        memory.set_item("key_cache_capacity_bytes", mem.key_cache_capacity_bytes)?;
         memory.set_item("row_cache_hits", mem.row_cache_hits)?;
         memory.set_item("row_cache_misses", mem.row_cache_misses)?;
         memory.set_item("total_memory_used", mem.total_memory_used)?;
@@ -94,11 +103,18 @@ impl DatabaseStats {
     /// Memory and cache statistics.
     ///
     /// Returns a dictionary containing:
-    /// - `block_cache_hits`: Number of block cache hits
+    /// - `block_cache_hits`: Number of block (decompressed-chunk) cache hits
     /// - `block_cache_misses`: Number of block cache misses
+    /// - `block_cache_evictions`: Chunk-cache entries evicted to stay within budget (B5, #1571)
+    /// - `block_cache_capacity_bytes`: Configured chunk-cache byte budget (B5, #1571)
+    /// - `key_cache_hits`: Aggregate key→partition-offset cache hits (B5, #1571)
+    /// - `key_cache_misses`: Aggregate key-cache misses (B5, #1571)
+    /// - `key_cache_evictions`: Aggregate key-cache evictions (B5, #1571)
+    /// - `key_cache_resident_bytes`: Aggregate key-cache resident bytes (B5, #1571)
+    /// - `key_cache_capacity_bytes`: Aggregate key-cache byte budget (B5, #1571)
     /// - `row_cache_hits`: Number of row cache hits
     /// - `row_cache_misses`: Number of row cache misses
-    /// - `total_memory_used`: Total memory used in bytes
+    /// - `total_memory_used`: Total memory used in bytes (chunk-cache resident bytes)
     /// - `buffer_allocations`: Number of buffer allocations
     /// - `buffer_deallocations`: Number of buffer deallocations
     #[getter]

--- a/cqlite-core/benches/fixtures/mod.rs
+++ b/cqlite-core/benches/fixtures/mod.rs
@@ -212,6 +212,24 @@ pub struct ReadDb {
 /// ingestion API ([`cqlite_core::ingestion::ingest`]).
 #[cfg(feature = "cli-helpers")]
 pub fn open_read_db(fx: &ReadFixture) -> ReadDb {
+    open_read_db_with_config(fx, cqlite_core::Config::default())
+}
+
+/// Open a fixture table with the memory-mapped scan backend forced on
+/// (`storage.use_mmap = true`), for the F3 cold-mixed-load tail gate (issue
+/// #1593). The mmap backend faults synchronously, so its scan reads are the ones
+/// F3 routes off the async worker pool.
+#[cfg(feature = "cli-helpers")]
+pub fn open_read_db_mmap(fx: &ReadFixture) -> ReadDb {
+    let mut cfg = cqlite_core::Config::default();
+    cfg.storage.use_mmap = true;
+    open_read_db_with_config(fx, cfg)
+}
+
+/// Open a fixture table with an explicit core [`cqlite_core::Config`]. Backs
+/// [`open_read_db`] (default config) and [`open_read_db_mmap`] (mmap forced on).
+#[cfg(feature = "cli-helpers")]
+pub fn open_read_db_with_config(fx: &ReadFixture, core_config: cqlite_core::Config) -> ReadDb {
     use cqlite_core::ingestion::{ingest, IngestionConfig};
 
     let src = table_dir(fx.keyspace, fx.table);
@@ -228,7 +246,7 @@ pub fn open_read_db(fx: &ReadFixture) -> ReadDb {
         schema_paths: vec![schema_path],
         data_dir: tmp.path().to_path_buf(),
         version_hint: Some("5.0".to_string()),
-        core_config: cqlite_core::Config::default(),
+        core_config,
         // Substring match on the full table-dir path; narrows discovery to the
         // single fixture table even though only one was copied.
         table_directory_filter: Some(format!("/{}/{}", fx.keyspace, fx.table)),

--- a/cqlite-core/benches/tail_latency/mod.rs
+++ b/cqlite-core/benches/tail_latency/mod.rs
@@ -220,9 +220,25 @@ fn uuid_to_literal(bytes: &[u8; 16]) -> String {
 /// the scan thread and the point-read stream for the process lifetime.
 #[cfg(feature = "cli-helpers")]
 pub fn setup(fx: &crate::fixtures::ReadFixture) -> (Arc<Database>, String) {
+    setup_from_db(crate::fixtures::open_read_db(fx).into_shared_db(), fx)
+}
+
+/// Like [`setup`] but over the memory-mapped scan backend (issue #1593, F3): the
+/// mmap cursor faults synchronously, so its scans are the ones F3 must keep off
+/// the async worker pool. Used by the cold-mixed-load tail gate.
+#[cfg(feature = "cli-helpers")]
+pub fn setup_mmap(fx: &crate::fixtures::ReadFixture) -> (Arc<Database>, String) {
+    setup_from_db(crate::fixtures::open_read_db_mmap(fx).into_shared_db(), fx)
+}
+
+/// Learn a present partition key from an already-opened shared `db`, build the
+/// projected point SQL, and run the two honesty guards. Backs both [`setup`]
+/// (buffered) and [`setup_mmap`] (mmap) so the two backends share identical
+/// key-learning and guard logic.
+#[cfg(feature = "cli-helpers")]
+fn setup_from_db(db: Arc<Database>, fx: &crate::fixtures::ReadFixture) -> (Arc<Database>, String) {
     use cqlite_core::Value;
 
-    let db = crate::fixtures::open_read_db(fx).into_shared_db();
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -328,6 +344,22 @@ pub fn run_point_read_stream(db: &Arc<Database>, sql: &str, n: usize, warmup: us
 /// actually completed at least one full pass (a wedged scan is a bug, not a pass).
 #[cfg(feature = "cli-helpers")]
 pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
+    run_backend(fx, false)
+}
+
+/// Cold-mixed-load harness over the memory-mapped scan backend (issue #1593, F3).
+/// Identical mixed-load shape to [`run`], but both the background scan and the
+/// point reads run against an mmap-backed `Database`, so the background scan's
+/// reads fault synchronously — the case F3 must keep off the async worker pool.
+/// The reported `p99_mixed_over_scan_free` ratio is the cold-mmap convoy number.
+#[cfg(feature = "cli-helpers")]
+pub fn run_mmap(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
+    run_backend(fx, true)
+}
+
+/// Shared mixed-load driver for [`run`] (buffered) and [`run_mmap`] (mmap).
+#[cfg(feature = "cli-helpers")]
+fn run_backend(fx: crate::fixtures::ReadFixture, mmap: bool) -> Option<HarnessReport> {
     if !crate::fixtures::fixture_present(&fx) {
         eprintln!(
             "tail_latency: fixture {} not present — skipping (fetch: bash test-data/scripts/fetch-datasets.sh)",
@@ -336,7 +368,7 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
         return None;
     }
 
-    let (db, sql) = setup(&fx);
+    let (db, sql) = if mmap { setup_mmap(&fx) } else { setup(&fx) };
 
     // Scan-free baseline first (no background contention).
     let scan_free_lat = run_point_read_stream(&db, &sql, MEASURED_N, WARMUP);

--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -606,9 +606,21 @@ impl Database {
 
     /// Get database statistics
     pub async fn stats(&self) -> Result<DatabaseStats> {
+        // The chunk-cache-derived block-cache fields come from the memory manager's
+        // live handle; the per-reader B4 key caches are aggregated here (issue
+        // #1571, B5) — this async site owns `storage` and reads live readers, so
+        // the aggregate is always current rather than a stale captured handle.
+        let mut memory_stats = self.memory.stats()?;
+        let key_cache = self.storage.key_cache_stats().await;
+        memory_stats.key_cache_hits = key_cache.hits;
+        memory_stats.key_cache_misses = key_cache.misses;
+        memory_stats.key_cache_evictions = key_cache.evictions;
+        memory_stats.key_cache_resident_bytes = key_cache.resident_bytes;
+        memory_stats.key_cache_capacity_bytes = key_cache.capacity_bytes;
+
         Ok(DatabaseStats {
             storage_stats: self.storage.stats().await?,
-            memory_stats: self.memory.stats()?,
+            memory_stats,
             #[cfg(feature = "state_machine")]
             query_stats: self.query.stats(),
         })

--- a/cqlite-core/src/memory/mod.rs
+++ b/cqlite-core/src/memory/mod.rs
@@ -66,6 +66,8 @@ impl MemoryManager {
         if let Some(cache) = &self.chunk_cache {
             stats.block_cache_hits = cache.hit_count();
             stats.block_cache_misses = cache.miss_count();
+            stats.block_cache_evictions = cache.eviction_count();
+            stats.block_cache_capacity_bytes = cache.budget_bytes();
             stats.total_memory_used = cache.resident_bytes();
         }
         Ok(stats)
@@ -137,6 +139,37 @@ pub struct MemoryStats {
     /// Block cache misses (real B1 cache miss count when wired).
     pub block_cache_misses: u64,
 
+    /// Block cache evictions: entries the B1 decompressed-chunk cache evicted to
+    /// stay within its byte budget (issue #1571, B5). Real `eviction_count()`
+    /// when wired; `0` (honest — no cache, no evictions) otherwise. High churn
+    /// relative to hits signals an undersized `block_cache_capacity_bytes`.
+    pub block_cache_evictions: u64,
+
+    /// Block cache configured byte budget (issue #1571, B5): the B1 cache's
+    /// `budget_bytes()` when wired, so a hit rate can be read against the budget
+    /// it was measured under; `0` when no cache is wired / block caching disabled.
+    pub block_cache_capacity_bytes: usize,
+
+    /// Key cache hits: aggregate across the per-reader B4 key→partition-offset
+    /// caches (issue #1571, B5). A hit lets a repeated point read skip the
+    /// `Index.db`/trie descent. Real summed counter; `0` when no reader is open.
+    pub key_cache_hits: u64,
+
+    /// Key cache misses: aggregate across the per-reader B4 caches (issue #1571).
+    pub key_cache_misses: u64,
+
+    /// Key cache evictions: aggregate across the per-reader B4 caches (issue
+    /// #1571) — entries evicted to stay within each reader's byte budget.
+    pub key_cache_evictions: u64,
+
+    /// Key cache resident bytes: aggregate approximate resident footprint of the
+    /// per-reader B4 caches (issue #1571).
+    pub key_cache_resident_bytes: usize,
+
+    /// Key cache capacity bytes: summed configured byte budget across the
+    /// per-reader B4 caches (issue #1571).
+    pub key_cache_capacity_bytes: usize,
+
     /// Row cache hits. Retained for shape compatibility; the row cache was
     /// deleted (issue #1568), so this reports `0` (full surface is Epic B / B5).
     pub row_cache_hits: u64,
@@ -162,6 +195,18 @@ impl MemoryStats {
         let total = self.block_cache_hits + self.block_cache_misses;
         if total > 0 {
             self.block_cache_hits as f64 / total as f64
+        } else {
+            0.0
+        }
+    }
+
+    /// Calculate the aggregate key-cache hit rate (issue #1571, B5) from the real
+    /// summed hit and miss counts. Returns `0.0` when there has been no key-cache
+    /// activity (honest — not a structural pin).
+    pub fn key_cache_hit_rate(&self) -> f64 {
+        let total = self.key_cache_hits + self.key_cache_misses;
+        if total > 0 {
+            self.key_cache_hits as f64 / total as f64
         } else {
             0.0
         }
@@ -193,6 +238,16 @@ mod tests {
         assert_eq!(stats.block_cache_misses, 0);
         assert_eq!(stats.total_memory_used, 0);
         assert_eq!(stats.block_cache_hit_rate(), 0.0);
+        // Issue #1571 (B5): every new cache-observability field reports an honest
+        // zero when no cache is wired — never a fabricated placeholder.
+        assert_eq!(stats.block_cache_evictions, 0);
+        assert_eq!(stats.block_cache_capacity_bytes, 0);
+        assert_eq!(stats.key_cache_hits, 0);
+        assert_eq!(stats.key_cache_misses, 0);
+        assert_eq!(stats.key_cache_evictions, 0);
+        assert_eq!(stats.key_cache_resident_bytes, 0);
+        assert_eq!(stats.key_cache_capacity_bytes, 0);
+        assert_eq!(stats.key_cache_hit_rate(), 0.0);
     }
 
     #[test]
@@ -218,5 +273,27 @@ mod tests {
             stats.block_cache_hit_rate() > 0.0,
             "a hit makes the reported rate non-zero (not structural 0.0)"
         );
+        // Issue #1571 (B5): capacity is the real budget; no eviction yet.
+        assert_eq!(stats.block_cache_capacity_bytes, cache.budget_bytes());
+        assert_eq!(stats.block_cache_evictions, 0);
+    }
+
+    #[test]
+    fn stats_bridge_reports_real_b1_eviction_count() {
+        // Issue #1571 (B5): a wired manager surfaces the chunk cache's real
+        // eviction count. Tiny budget on a single shard forces deterministic
+        // evictions.
+        let cache = Arc::new(DecompressedChunkCache::with_budget_and_shards(200, 1));
+        let manager = MemoryManager::with_chunk_cache(Arc::clone(&cache));
+        for i in 0..5u64 {
+            cache.insert(ChunkKey::new(1, i), vec![i as u8; 100]);
+        }
+        let stats = manager.stats().expect("stats");
+        assert_eq!(stats.block_cache_evictions, cache.eviction_count());
+        assert!(
+            stats.block_cache_evictions > 0,
+            "over-budget inserts must have evicted"
+        );
+        assert_eq!(stats.block_cache_capacity_bytes, cache.budget_bytes());
     }
 }

--- a/cqlite-core/src/memory/mod.rs
+++ b/cqlite-core/src/memory/mod.rs
@@ -131,6 +131,19 @@ pub(crate) fn estimate_value_size(value: &Value) -> usize {
 /// field names and types are preserved verbatim (issue #1568, AK6); only the
 /// *source* of the block-cache numbers changed — they now reflect the real B1
 /// [`DecompressedChunkCache`](crate::storage::cache::DecompressedChunkCache).
+///
+/// # Independent sampling (advisory observability)
+///
+/// The `block_cache_*` fields and the `key_cache_*` fields are sampled
+/// **independently and at different instants**: the block-cache figures come from
+/// the [`MemoryManager`] (its shared B1 chunk cache), while the key-cache figures
+/// are aggregated from the storage engine's per-reader B4 caches
+/// (`SSTableManager::aggregate_key_cache_stats`) in a separate step. Under
+/// concurrent read load the two groups can therefore reflect slightly different
+/// moments in time, so within a single `memory_stats` snapshot the block-cache vs
+/// key-cache figures are **not guaranteed to be mutually coherent**. Treat this as
+/// advisory observability (trends, rough ratios), not a transactionally-consistent
+/// point-in-time view of both caches.
 #[derive(Debug, Clone, Default)]
 pub struct MemoryStats {
     /// Block cache hits (real B1 cache hit count when wired).

--- a/cqlite-core/src/storage/cache/key_offset.rs
+++ b/cqlite-core/src/storage/cache/key_offset.rs
@@ -215,6 +215,9 @@ pub struct KeyOffsetCache {
     disabled: bool,
     hits: AtomicU64,
     misses: AtomicU64,
+    /// Cumulative count of entries evicted to stay within the byte budget
+    /// (issue #1571, B5). Relaxed atomic — advisory observability only.
+    evictions: AtomicU64,
 }
 
 impl std::fmt::Debug for KeyOffsetCache {
@@ -227,8 +230,23 @@ impl std::fmt::Debug for KeyOffsetCache {
             .field("resident_bytes", &self.resident_bytes())
             .field("hits", &self.hits.load(Ordering::Relaxed))
             .field("misses", &self.misses.load(Ordering::Relaxed))
+            .field("evictions", &self.evictions.load(Ordering::Relaxed))
             .finish()
     }
+}
+
+/// A point-in-time snapshot of one key cache's real observability counters
+/// (issue #1571, B5). Summed across live readers to build the process-level
+/// key-cache aggregate reported through `Database::stats().memory_stats`. Every
+/// field is a real counter/aggregate read from the live cache — never a
+/// fabricated placeholder.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct KeyCacheSnapshot {
+    pub hits: u64,
+    pub misses: u64,
+    pub evictions: u64,
+    pub resident_bytes: usize,
+    pub capacity_bytes: usize,
 }
 
 impl KeyOffsetCache {
@@ -261,6 +279,7 @@ impl KeyOffsetCache {
             disabled: false,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
         }
     }
 
@@ -277,6 +296,7 @@ impl KeyOffsetCache {
             disabled: true,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
         }
     }
 
@@ -344,14 +364,20 @@ impl KeyOffsetCache {
         // now most-recently-used, so `pop_lru` never targets it while other entries
         // remain. The `len() > 1` guard keeps the entry we just resolved resident
         // even if it alone exceeds the budget (documented: single oversized entry).
+        let mut evicted_here: u64 = 0;
         while guard.current_bytes > self.per_shard_bytes && guard.lru.len() > 1 {
             match guard.lru.pop_lru() {
                 Some((evicted_key, _)) => {
                     let reclaimed = entry_cost(evicted_key.len());
                     guard.current_bytes = guard.current_bytes.saturating_sub(reclaimed);
+                    evicted_here += 1;
                 }
                 None => break,
             }
+        }
+        drop(guard);
+        if evicted_here > 0 {
+            self.evictions.fetch_add(evicted_here, Ordering::Relaxed);
         }
     }
 
@@ -389,6 +415,28 @@ impl KeyOffsetCache {
     /// Cumulative cache misses (test/observability instrumentation).
     pub fn miss_count(&self) -> u64 {
         self.misses.load(Ordering::Relaxed)
+    }
+
+    /// Cumulative entries evicted to stay within budget (issue #1571, B5).
+    ///
+    /// Real relaxed-atomic counter; a [`disabled`](Self::disabled) no-op cache
+    /// never evicts and reports `0`.
+    pub fn eviction_count(&self) -> u64 {
+        self.evictions.load(Ordering::Relaxed)
+    }
+
+    /// A point-in-time snapshot of this cache's real observability counters,
+    /// summed across readers to build the process-level key-cache aggregate
+    /// (issue #1571, B5). Reads only relaxed atomics plus the per-shard locks
+    /// occupancy already uses — no new hot-path lock.
+    pub(crate) fn snapshot(&self) -> KeyCacheSnapshot {
+        KeyCacheSnapshot {
+            hits: self.hit_count(),
+            misses: self.miss_count(),
+            evictions: self.eviction_count(),
+            resident_bytes: self.resident_bytes(),
+            capacity_bytes: self.budget_bytes(),
+        }
     }
 }
 
@@ -445,6 +493,44 @@ mod tests {
         );
         assert_eq!(cache.len(), 2);
         assert!(cache.resident_bytes() <= cache.budget_bytes());
+    }
+
+    /// Issue #1571 (B5): the eviction counter reflects the real number of entries
+    /// evicted to stay within budget; the snapshot exposes the real numbers, and a
+    /// disabled cache reports honest zeros.
+    #[test]
+    fn eviction_count_and_snapshot_track_real_activity() {
+        // Single shard sized for exactly 2 five-byte keys.
+        let cache = KeyOffsetCache::with_budget_and_shards(budget_for(2, 5), 1);
+        assert_eq!(cache.eviction_count(), 0);
+
+        cache.insert(b"key-A".as_slice(), PartitionLoc::new(10, 100));
+        cache.insert(b"key-B".as_slice(), PartitionLoc::new(20, 200));
+        assert_eq!(cache.eviction_count(), 0, "still within budget");
+
+        // Each further distinct insert evicts exactly one LRU entry.
+        cache.insert(b"key-C".as_slice(), PartitionLoc::new(30, 300));
+        assert_eq!(cache.eviction_count(), 1);
+        cache.insert(b"key-D".as_slice(), PartitionLoc::new(40, 400));
+        assert_eq!(cache.eviction_count(), 2);
+
+        // One hit + one miss so the snapshot carries real counter values.
+        assert!(cache.get(b"key-D".as_slice()).is_some());
+        assert!(cache.get(b"absent".as_slice()).is_none());
+        let snap = cache.snapshot();
+        assert_eq!(snap.evictions, 2);
+        assert_eq!(snap.hits, 1);
+        assert_eq!(snap.misses, 1);
+        assert_eq!(snap.resident_bytes, cache.resident_bytes());
+        assert_eq!(snap.capacity_bytes, cache.budget_bytes());
+
+        // A disabled cache never evicts and reports honest zeros.
+        let disabled = KeyOffsetCache::disabled();
+        disabled.insert(b"k".as_slice(), PartitionLoc::new(1, 1));
+        let dsnap = disabled.snapshot();
+        assert_eq!(dsnap.evictions, 0);
+        assert_eq!(dsnap.resident_bytes, 0);
+        assert_eq!(dsnap.capacity_bytes, 0);
     }
 
     /// Task 1.2: BYTE bound — inserting more distinct equal-size keys than the

--- a/cqlite-core/src/storage/cache/mod.rs
+++ b/cqlite-core/src/storage/cache/mod.rs
@@ -36,6 +36,7 @@
 
 pub mod key_offset;
 
+pub(crate) use key_offset::KeyCacheSnapshot;
 pub use key_offset::{
     KeyOffsetCache, PartitionLoc, DEFAULT_KEY_CACHE_BYTES, DEFAULT_KEY_CACHE_SHARDS,
 };
@@ -136,6 +137,10 @@ pub struct DecompressedChunkCache {
     disabled: bool,
     hits: AtomicU64,
     misses: AtomicU64,
+    /// Cumulative count of entries evicted to stay within the byte budget
+    /// (issue #1571, B5). Relaxed atomic — advisory observability, never on a
+    /// fence-bearing path.
+    evictions: AtomicU64,
 }
 
 impl std::fmt::Debug for DecompressedChunkCache {
@@ -146,6 +151,7 @@ impl std::fmt::Debug for DecompressedChunkCache {
             .field("resident_bytes", &self.resident_bytes())
             .field("hits", &self.hits.load(Ordering::Relaxed))
             .field("misses", &self.misses.load(Ordering::Relaxed))
+            .field("evictions", &self.evictions.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -176,6 +182,7 @@ impl DecompressedChunkCache {
             disabled: false,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
         }
     }
 
@@ -195,6 +202,7 @@ impl DecompressedChunkCache {
             disabled: true,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
         }
     }
 
@@ -264,13 +272,19 @@ impl DecompressedChunkCache {
         // most-recently-used, so `pop_lru` never targets it while other entries
         // remain. The `len() > 1` guard keeps the chunk we just produced resident
         // even if it alone exceeds the budget (documented: single oversized entry).
+        let mut evicted_here: u64 = 0;
         while guard.current_bytes > self.budget_per_shard && guard.lru.len() > 1 {
             match guard.lru.pop_lru() {
                 Some((_, evicted)) => {
                     guard.current_bytes = guard.current_bytes.saturating_sub(evicted.len());
+                    evicted_here += 1;
                 }
                 None => break,
             }
+        }
+        drop(guard);
+        if evicted_here > 0 {
+            self.evictions.fetch_add(evicted_here, Ordering::Relaxed);
         }
         arc
     }
@@ -308,6 +322,14 @@ impl DecompressedChunkCache {
     /// Cumulative cache misses (test/observability instrumentation).
     pub fn miss_count(&self) -> u64 {
         self.misses.load(Ordering::Relaxed)
+    }
+
+    /// Cumulative entries evicted to stay within budget (issue #1571, B5).
+    ///
+    /// Real relaxed-atomic counter; a [`disabled`](Self::disabled) no-op cache
+    /// never evicts and reports `0`.
+    pub fn eviction_count(&self) -> u64 {
+        self.evictions.load(Ordering::Relaxed)
     }
 }
 
@@ -373,6 +395,37 @@ mod tests {
             "entry count must stay bounded (got {})",
             cache.len()
         );
+    }
+
+    /// Issue #1571 (B5): the eviction counter reflects the real number of entries
+    /// evicted to stay within budget, and an insert within budget increments it by
+    /// zero (no-fabrication).
+    #[test]
+    fn eviction_count_tracks_real_evictions() {
+        // Budget holds exactly 2 * 100-byte chunks.
+        let cache = DecompressedChunkCache::with_budget_and_shards(200, 1);
+        assert_eq!(cache.eviction_count(), 0, "fresh cache has evicted nothing");
+
+        cache.insert(ChunkKey::new(1, 0), chunk(0x00, 100));
+        cache.insert(ChunkKey::new(1, 1), chunk(0x01, 100));
+        // Still within budget (200 <= 200): no eviction yet.
+        assert_eq!(cache.eviction_count(), 0);
+
+        // Each further distinct insert pushes over budget → exactly one eviction.
+        cache.insert(ChunkKey::new(1, 2), chunk(0x02, 100));
+        assert_eq!(cache.eviction_count(), 1);
+        cache.insert(ChunkKey::new(1, 3), chunk(0x03, 100));
+        assert_eq!(cache.eviction_count(), 2);
+    }
+
+    /// A disabled no-op cache never evicts and reports a real zero.
+    #[test]
+    fn disabled_cache_reports_zero_evictions() {
+        let cache = DecompressedChunkCache::disabled();
+        for i in 0..10u64 {
+            cache.insert(ChunkKey::new(1, i), chunk(i as u8, 4096));
+        }
+        assert_eq!(cache.eviction_count(), 0);
     }
 
     /// A single entry larger than the budget is retained (never evict below one

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -528,6 +528,14 @@ impl StorageEngine {
         self.sstables.stats_chunk_cache()
     }
 
+    /// Process-level aggregate of the per-reader key→partition-offset caches
+    /// (issue #1571, B5), summed over live readers. Merged into
+    /// `Database::stats().memory_stats` so the B4 key cache's real
+    /// hits/misses/evictions/occupancy/capacity are observable.
+    pub(crate) async fn key_cache_stats(&self) -> crate::storage::cache::KeyCacheSnapshot {
+        self.sstables.aggregate_key_cache_stats().await
+    }
+
     /// Get storage statistics
     ///
     /// NOTE: Issue #176 removed compaction stats (compaction.rs deleted).

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -390,16 +390,34 @@ impl SSTableManager {
     /// (issue #1571, B5). Sums each reader's real observability counters (hits,
     /// misses, evictions, resident bytes, capacity bytes) into one snapshot.
     ///
-    /// Iterates the canonical by-id reader map (`self.readers`), which holds each
-    /// reader **exactly once** — the by-name `table_readers` map re-references the
-    /// same `Arc`s and would double-count, so it is deliberately not used here.
+    /// Counts each distinct reader **exactly once** by unioning the by-id
+    /// `self.readers` map and the by-name `table_readers` map and deduping on
+    /// `Arc::as_ptr` (roborev #1571 Low). Deduping is required for correctness in
+    /// **both** directions: (a) the two maps re-reference the same reader `Arc`s,
+    /// so a naive sum of both would double-count; (b) crucially, `self.readers` is
+    /// **not** a strict superset of `table_readers` — `SSTableId::from_filename`
+    /// keys the by-id map on the bare generation filename (e.g. `nb-1-big-Data.db`),
+    /// so two tables sharing that filename collide and the by-id map keeps only the
+    /// last-inserted reader while `table_readers` retains both under distinct keys.
+    /// Iterating `self.readers` alone would therefore **silently omit** the
+    /// overwritten reader's cache and under-count the aggregate. The pointer-dedup
+    /// union counts every physically-open reader once regardless of collisions.
     /// Every field is read from a live counter/aggregate — no fabricated values.
+    ///
+    /// Lock ordering matches every writer (`readers` before `table_readers`), so
+    /// acquiring both read guards here cannot deadlock.
     pub(crate) async fn aggregate_key_cache_stats(
         &self,
     ) -> crate::storage::cache::KeyCacheSnapshot {
         let readers = self.readers.read().await;
+        let table_readers = self.table_readers.read().await;
+        let mut seen: std::collections::HashSet<*const reader::SSTableReader> =
+            std::collections::HashSet::new();
         let mut agg = crate::storage::cache::KeyCacheSnapshot::default();
-        for reader in readers.values() {
+        for reader in readers.values().chain(table_readers.values().flatten()) {
+            if !seen.insert(Arc::as_ptr(reader)) {
+                continue; // already counted this physical reader
+            }
             let s = reader.key_offset_cache.snapshot();
             agg.hits = agg.hits.saturating_add(s.hits);
             agg.misses = agg.misses.saturating_add(s.misses);
@@ -2640,6 +2658,101 @@ mod tests {
         assert!(
             SSTableManager::fully_qualified_match(&table_readers, "ks_a.users"),
             "exact FQ key present → relaxed guard, applied only to the resolved (ks_a) set"
+        );
+    }
+
+    /// Resolve the on-disk table directory (the one holding `*-Data.db`) for
+    /// `keyspace.table`, or `None` when datasets are absent (CI-lane skip).
+    fn dataset_table_dir(keyspace: &str, table: &str) -> Option<PathBuf> {
+        let datasets_root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+        let keyspace_dir = PathBuf::from(datasets_root).join("sstables").join(keyspace);
+        let table_prefix = format!("{}-", table);
+        for entry in std::fs::read_dir(&keyspace_dir).ok()?.flatten() {
+            let path = entry.path();
+            let file_name = path.file_name()?.to_str()?.to_string();
+            if path.is_dir() && file_name.starts_with(&table_prefix) {
+                return Some(path);
+            }
+        }
+        None
+    }
+
+    /// Issue #1571 (roborev Low, aggregate omission guard): `aggregate_key_cache_stats`
+    /// must count every physically-open reader's key cache **exactly once**, even
+    /// though `self.readers` (by-id) is NOT a strict superset of `table_readers`
+    /// (by-name). `SSTableId::from_filename` keys the by-id map on the bare
+    /// generation filename (`nb-1-big-Data.db`), so two tables sharing that
+    /// filename collide: the by-id map keeps only the last-inserted reader while
+    /// `table_readers` retains both. This test reproduces that collision with two
+    /// real tables (both ship `nb-1-big-Data.db`) and proves the dedup-union
+    /// aggregate (a) is not fooled into omitting the reader reachable only by name
+    /// and (b) does not double-count the readers present in both maps. A pre-fix
+    /// `self.readers`-only aggregate would FAIL this (under-counting the omitted
+    /// reader's capacity).
+    #[tokio::test]
+    async fn test_aggregate_key_cache_counts_every_reader_exactly_once() {
+        // Two distinct real table directories whose Data.db share a generation
+        // filename → colliding SSTableId; skip when datasets are absent.
+        let Some(dir_a) = dataset_table_dir("test_basic", "simple_table") else {
+            eprintln!("skipping: CQLITE_DATASETS_ROOT / test_basic.simple_table absent");
+            return;
+        };
+        let Some(dir_b) = dataset_table_dir("test_basic", "counters") else {
+            eprintln!("skipping: CQLITE_DATASETS_ROOT / test_basic.counters absent");
+            return;
+        };
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.unwrap());
+        let storage_path = dir_a.parent().map(PathBuf::from).unwrap_or(dir_a.clone());
+        let manager = SSTableManager::new_from_discovered_paths(
+            &storage_path,
+            vec![dir_a, dir_b],
+            &config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Deduped set of physically-open readers across BOTH maps (by pointer),
+        // and the expected capacity sum computed independently of the aggregate.
+        let (by_id_len, distinct, expected_capacity) = {
+            let readers = manager.readers.read().await;
+            let table_readers = manager.table_readers.read().await;
+            assert!(!readers.is_empty(), "fixture present but no readers by-id");
+            assert!(
+                !table_readers.is_empty(),
+                "fixture present but no readers by-name"
+            );
+            let mut seen: std::collections::HashSet<*const reader::SSTableReader> =
+                std::collections::HashSet::new();
+            let mut expected_capacity = 0usize;
+            for r in readers.values().chain(table_readers.values().flatten()) {
+                if seen.insert(Arc::as_ptr(r)) {
+                    expected_capacity = expected_capacity
+                        .saturating_add(r.key_offset_cache.snapshot().capacity_bytes);
+                }
+            }
+            (readers.len(), seen.len(), expected_capacity)
+        };
+
+        // The collision reality this guards against: the by-id map holds strictly
+        // fewer readers than physically exist, so a `self.readers`-only aggregate
+        // would silently omit at least one reader's cache.
+        assert!(
+            by_id_len < distinct,
+            "expected an SSTableId collision (by-id map {by_id_len} < {distinct} distinct readers)"
+        );
+
+        // The dedup-union aggregate counts every distinct reader exactly once:
+        // capacity equals the independently-summed deduped capacity — neither
+        // under-counted (omission) nor over-counted (double-count).
+        let agg = manager.aggregate_key_cache_stats().await;
+        assert_eq!(
+            agg.capacity_bytes, expected_capacity,
+            "aggregate must sum each distinct reader's key-cache capacity exactly once"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -386,6 +386,30 @@ impl SSTableManager {
         }
     }
 
+    /// Process-level aggregate of the per-reader key→partition-offset caches
+    /// (issue #1571, B5). Sums each reader's real observability counters (hits,
+    /// misses, evictions, resident bytes, capacity bytes) into one snapshot.
+    ///
+    /// Iterates the canonical by-id reader map (`self.readers`), which holds each
+    /// reader **exactly once** — the by-name `table_readers` map re-references the
+    /// same `Arc`s and would double-count, so it is deliberately not used here.
+    /// Every field is read from a live counter/aggregate — no fabricated values.
+    pub(crate) async fn aggregate_key_cache_stats(
+        &self,
+    ) -> crate::storage::cache::KeyCacheSnapshot {
+        let readers = self.readers.read().await;
+        let mut agg = crate::storage::cache::KeyCacheSnapshot::default();
+        for reader in readers.values() {
+            let s = reader.key_offset_cache.snapshot();
+            agg.hits = agg.hits.saturating_add(s.hits);
+            agg.misses = agg.misses.saturating_add(s.misses);
+            agg.evictions = agg.evictions.saturating_add(s.evictions);
+            agg.resident_bytes = agg.resident_bytes.saturating_add(s.resident_bytes);
+            agg.capacity_bytes = agg.capacity_bytes.saturating_add(s.capacity_bytes);
+        }
+        agg
+    }
+
     /// Create a new SSTable manager
     pub async fn new(
         path: &Path,

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -110,10 +110,15 @@
 //!   former `block_emit`/`block_emit_windowed` sort sites into). **K3 (issue #1642)
 //!   delivered**: the decoder now emits cells positionally in serialization-header
 //!   column order (deterministic by CONSTRUCTION), so `build_display_row` performs
-//!   NO per-row sort and a full scan records `0` (on `main`/pre-K3 it was one per
-//!   returned live row). No production site calls [`record_row_sort`] anymore; the
-//!   counter is retained as a regression tripwire — any reintroduced per-row cell
-//!   sort must record it, flipping the K3 `== 0` scan assertions red.
+//!   NO per-row sort and a full scan of standard fixtures through the primary
+//!   decoder records `0` (on `main`/pre-K3 it was one per returned live row). The
+//!   only remaining callers are the two cold schema-less fallbacks in
+//!   `reader/parsing/mod.rs` (`extract_value_from_parsed_row_fallback` and
+//!   `extract_value_from_parsed_row_with_schema`), which sort recovered cells for a
+//!   deterministic emit order and DO record it — so the counter honestly counts
+//!   EVERY per-row cell sort. The primary V5 decoder path records `0`; the counter
+//!   is a regression tripwire — any reintroduced per-row cell sort on the primary
+//!   path must record it, flipping the K3 `== 0` scan assertions red.
 
 // The atomics, the process-global, the struct methods, the getters, and `reset`
 // exist ONLY in test/feature builds — a release build links none of them, which is
@@ -470,11 +475,15 @@ pub fn record_bti_pointer_decode() {
 /// Record one per-row cell `sort_by` (`ROW_SORT_INVOCATIONS`; consumer K3,
 /// Issue #1618 / #1642).
 ///
-/// **K3 (issue #1642) removed the caller**: the decoder emits cells positionally
-/// in serialization-header column order, so `build_display_row` no longer sorts and
-/// no production site calls this. It is kept (unconditional, zero-overhead in
-/// release per design.md Decision 1) as a regression tripwire — any future per-row
-/// cell sort must call it, which would flip the K3 `ROW_SORT_INVOCATIONS == 0` scan
+/// **K3 (issue #1642) removed the primary-path caller**: the decoder emits cells
+/// positionally in serialization-header column order, so `build_display_row` no
+/// longer sorts. The only remaining callers are the two cold schema-less fallbacks
+/// in `reader/parsing/mod.rs`, which sort recovered cells for a deterministic emit
+/// order and DO call this — so `ROW_SORT_INVOCATIONS` honestly counts EVERY per-row
+/// cell sort. It is kept (unconditional, zero-overhead in release per design.md
+/// Decision 1) as a regression tripwire — the K3 scan assertions exercise the
+/// primary V5 decoder (which records `0`), so any future per-row cell sort on that
+/// path must call this, which would flip the K3 `ROW_SORT_INVOCATIONS == 0` scan
 /// assertions red.
 #[inline(always)]
 pub fn record_row_sort() {

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -105,10 +105,15 @@
 //!   Consumer **L1/L3**: pairs with `BTI_NODES_VISITED` to prove the descent does not
 //!   re-decode nodes.
 //! - [`record_row_sort`] / [`row_sort_invocations`] — **`ROW_SORT_INVOCATIONS`**:
-//!   one per per-row cell `sort_by` at the shared display-row builder
+//!   the per-row cell `sort_by` gauge at the shared display-row builder
 //!   (`v5_compressed_legacy/mod.rs::build_display_row`, which #1334 consolidated the
-//!   former `block_emit`/`block_emit_windowed` sort sites into). Consumer **K2/L**:
-//!   flips to prove cells arrive pre-sorted (no per-row sort).
+//!   former `block_emit`/`block_emit_windowed` sort sites into). **K3 (issue #1642)
+//!   delivered**: the decoder now emits cells positionally in serialization-header
+//!   column order (deterministic by CONSTRUCTION), so `build_display_row` performs
+//!   NO per-row sort and a full scan records `0` (on `main`/pre-K3 it was one per
+//!   returned live row). No production site calls [`record_row_sort`] anymore; the
+//!   counter is retained as a regression tripwire — any reintroduced per-row cell
+//!   sort must record it, flipping the K3 `== 0` scan assertions red.
 
 // The atomics, the process-global, the struct methods, the getters, and `reset`
 // exist ONLY in test/feature builds — a release build links none of them, which is
@@ -462,13 +467,15 @@ pub fn record_bti_pointer_decode() {
     COUNTERS.record_bti_pointer_decode();
 }
 
-/// Record one per-row cell `sort_by` (`ROW_SORT_INVOCATIONS`; consumers K2/L,
-/// Issue #1618).
+/// Record one per-row cell `sort_by` (`ROW_SORT_INVOCATIONS`; consumer K3,
+/// Issue #1618 / #1642).
 ///
-/// Called unconditionally at the shared display-row builder's sort
-/// (`v5_compressed_legacy/mod.rs::build_display_row`, into which #1334 consolidated
-/// the former `block_emit`/`block_emit_windowed` per-row sort sites); the body
-/// compiles to a no-op in a release build.
+/// **K3 (issue #1642) removed the caller**: the decoder emits cells positionally
+/// in serialization-header column order, so `build_display_row` no longer sorts and
+/// no production site calls this. It is kept (unconditional, zero-overhead in
+/// release per design.md Decision 1) as a regression tripwire — any future per-row
+/// cell sort must call it, which would flip the K3 `ROW_SORT_INVOCATIONS == 0` scan
+/// assertions red.
 #[inline(always)]
 pub fn record_row_sort() {
     #[cfg(any(test, feature = "work-counters"))]

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -806,14 +806,30 @@ impl SSTableReader {
         &self,
         cursor: &ScanCursor,
     ) -> Result<Option<Vec<u8>>> {
+        self.read_next_block_parts(&cursor.file, &cursor.chunk_index)
+            .await
+    }
+
+    /// Read the next block from an explicit `(file, chunk_index)` pair rather than
+    /// a whole [`ScanCursor`] (issue #1593, F3).
+    ///
+    /// The windowed scan's `spawn_blocking` I/O loop for synchronously-faulting
+    /// backends (mmap / `O_DIRECT`) owns `Arc` clones of these two fields, not the
+    /// borrowed cursor, so it calls this directly. All other read state
+    /// (compression info, CRC digest, version, header size) lives on `&self`.
+    pub(in crate::storage::sstable::reader) async fn read_next_block_parts(
+        &self,
+        file: &std::sync::Arc<tokio::sync::Mutex<super::source::BlockSource>>,
+        chunk_index: &std::sync::atomic::AtomicUsize,
+    ) -> Result<Option<Vec<u8>>> {
         use super::block_io;
         block_io::read_next_block(
-            &cursor.file,
+            file,
             &self.header.cassandra_version,
             &self.config,
             &self.compression_info,
             self.crc_reader.as_deref(),
-            &cursor.chunk_index,
+            chunk_index,
             self.actual_header_size as u64,
         )
         .await

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -417,6 +417,11 @@ impl SSTableReader {
             return Ok(ScanRow::Marker(Value::Null));
         }
 
+        // Issue #1642 tripwire honesty: this schema-less fallback performs a per-row
+        // cell sort (the recovered cells arrive in no guaranteed order). Record it so
+        // `ROW_SORT_INVOCATIONS` honestly counts EVERY per-row sort — the primary V5
+        // decoder (which the K3 scan assertions exercise) still records 0.
+        crate::storage::sstable::read_work_counters::record_row_sort();
         row_cells.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
         Ok(ScanRow::Row(row_cells))
     }
@@ -643,6 +648,11 @@ impl SSTableReader {
             .into_iter()
             .map(|(name, value)| (std::sync::Arc::from(name.as_str()), value))
             .collect();
+        // Issue #1642 tripwire honesty: this cold schema-less fallback collects into
+        // an unordered `HashMap`, so it sorts here for a deterministic emit order.
+        // Record it so `ROW_SORT_INVOCATIONS` honestly counts EVERY per-row sort — the
+        // primary V5 decoder (which the K3 scan assertions exercise) still records 0.
+        crate::storage::sstable::read_work_counters::record_row_sort();
         row_cells.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
         Ok(ScanRow::Row(row_cells))
     }

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -633,8 +633,12 @@ impl SSTableReader {
 
         // Issue #1334: return the single `ScanRow` row carrier the read path
         // consumes (previously this path returned a `Value::Udt` stand-in because
-        // no row carrier existed). Names become interned `Arc<str>` handles; the
-        // emit-time alphabetical ordering matches the other scan producers.
+        // no row carrier existed). Names become interned `Arc<str>` handles.
+        // Issue #1642 (K3): the PRIMARY V5 decoder emits cells positionally in
+        // serialization-header (schema) column order. This is a COLD schema-less
+        // fallback that collects into an unordered `HashMap`, so it sorts here to
+        // get a deterministic emit order (SORTED, not header order). Both are
+        // deterministic; order is not user-visible (consumers are name-keyed).
         let mut row_cells: RowCells = columns
             .into_iter()
             .map(|(name, value)| (std::sync::Arc::from(name.as_str()), value))

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit.rs
@@ -105,7 +105,9 @@ impl V5CompressedLegacyParser {
                 PartitionShadow::open(now_secs, partition_deletion, clustering_reversed.clone())
             });
 
-            let mut static_cells: HashMap<Arc<str>, Value> = HashMap::new();
+            // Issue #1642 (K3): static cells accumulate as a positional `RowCells`
+            // vector, matching the decoder's positional emit. Metadata stays keyed.
+            let mut static_cells: RowCells = Vec::new();
             let mut static_cell_meta: HashMap<String, CellWriteMetadata> = HashMap::new();
             let mut row_count = 0;
 
@@ -174,7 +176,7 @@ impl V5CompressedLegacyParser {
                                     .is_some_and(|h| sh.row_hidden(h, &[]))
                             });
                             if static_hidden {
-                                static_cells = HashMap::new();
+                                static_cells = Vec::new();
                                 static_cell_meta = HashMap::new();
                             } else {
                                 static_cells = cells;
@@ -182,9 +184,8 @@ impl V5CompressedLegacyParser {
                             }
                         } else {
                             // Merge static cells / metadata into clustering row
-                            for (k, v) in &static_cells {
-                                cells.entry(k.clone()).or_insert_with(|| v.clone());
-                            }
+                            // (clustering-row-wins; positional, issue #1642).
+                            merge_static_cells(&mut cells, &static_cells);
                             for (k, v) in &static_cell_meta {
                                 row_cell_meta.entry(k.clone()).or_insert_with(|| v.clone());
                             }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit_windowed.rs
@@ -291,7 +291,8 @@ impl V5CompressedLegacyParser {
                     // values must be merged into each clustering row that follows in the partition.
                     //
                     // We accumulate static cells here and inject them into every clustering row.
-                    let mut static_cells: HashMap<Arc<str>, Value> = HashMap::new();
+                    // Issue #1642 (K3): positional `RowCells`, matching the decoder emit.
+                    let mut static_cells: RowCells = Vec::new();
                     let mut row_count = 0;
                     loop {
                         // Issue #954: stop at the clustering-slice end bound. The
@@ -452,15 +453,13 @@ impl V5CompressedLegacyParser {
                                             .as_ref()
                                             .is_some_and(|h| sh.row_hidden(h, &[]))
                                     });
-                                    static_cells =
-                                        if static_hidden { HashMap::new() } else { cells };
+                                    static_cells = if static_hidden { Vec::new() } else { cells };
                                     // Do NOT push to results — static rows are not result rows
                                     // Continue to next row/marker in partition
                                 } else {
-                                    // Merge static cells into this clustering row (Issue #480)
-                                    for (k, v) in &static_cells {
-                                        cells.entry(k.clone()).or_insert_with(|| v.clone());
-                                    }
+                                    // Merge static cells into this clustering row (Issue #480;
+                                    // positional, clustering-row-wins, issue #1642).
+                                    merge_static_cells(&mut cells, &static_cells);
 
                                     // Issue #1741: hide rows shadowed by a partition or
                                     // range tombstone, or expired by TTL, matching a
@@ -914,7 +913,8 @@ struct TimestampPolicy<'a> {
     /// Issue #1741 per-partition read-side shadow; `None` for physical reads.
     shadow: Option<PartitionShadow>,
     /// Issue #480 static cells accumulated for merge into each clustering row.
-    static_cells: HashMap<Arc<str>, Value>,
+    /// Issue #1642 (K3): positional `RowCells`, matching the decoder emit.
+    static_cells: RowCells,
 }
 
 impl<'a> TimestampPolicy<'a> {
@@ -924,7 +924,7 @@ impl<'a> TimestampPolicy<'a> {
             table_id: TableId::new(format!("{}.{}", parser.keyspace, parser.table_name)),
             partition_key: RowKey(Vec::new()),
             shadow: None,
-            static_cells: HashMap::new(),
+            static_cells: Vec::new(),
         }
     }
 }
@@ -1023,11 +1023,10 @@ impl SlidingPartitionPolicy for TimestampPolicy<'_> {
                             .as_ref()
                             .is_some_and(|h| sh.row_hidden(h, &[]))
                     });
-                    self.static_cells = if static_hidden { HashMap::new() } else { cells };
+                    self.static_cells = if static_hidden { Vec::new() } else { cells };
                 } else {
-                    for (k, v) in &self.static_cells {
-                        cells.entry(k.clone()).or_insert_with(|| v.clone());
-                    }
+                    // Positional, clustering-row-wins merge (issue #1642).
+                    merge_static_cells(&mut cells, &self.static_cells);
 
                     // Issue #1741: hide rows shadowed by a partition/range tombstone
                     // or expired by TTL (matching a Cassandra SELECT). No-op on the

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/compaction.rs
@@ -13,7 +13,7 @@ impl V5CompressedLegacyParser {
     /// (no cells, no tombstone) produces an empty `Live`.
     fn build_compaction_row_data(
         &self,
-        cells: HashMap<Arc<str>, Value>,
+        cells: RowCells,
         cell_meta: Option<HashMap<String, CellWriteMetadata>>,
         complex: CompactionComplexColumns,
         row_header_opt: &Option<RowHeader>,

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -685,21 +685,35 @@ fn row_has_non_key_cell(cells: &[(Arc<str>, Value)], schema: &TableSchema) -> bo
     })
 }
 
-/// Issue #1642 (K3): merge accumulated static-column cells into a clustering
-/// row's positional cell vector, CLUSTERING-ROW-WINS (a static cell is appended
-/// only when the clustering row does not already carry that column). This is the
-/// ordered-`Vec` analogue of the former `HashMap::entry(..).or_insert_with(..)`
-/// merge: static and regular columns are disjoint in Cassandra, so the membership
-/// check is defensive and the common effect is a concatenation. The static cells
-/// are appended AFTER the clustering row's own cells; the merged order is never
-/// user-visible (the query result is a name-keyed map, issue #1334) — this only
-/// preserves determinism-by-construction.
+/// Issue #1642 (K3): append accumulated static-column cells onto a clustering
+/// row's positional cell vector. This is an unconditional `extend` (O(n_static))
+/// — NOT a per-cell membership scan — because a static column name can NEVER
+/// collide with a name already in the clustering row's cells, so there is no
+/// clustering-row-wins conflict to resolve.
+///
+/// Disjointness proof (this codebase). `static_cells` is the cell vector of an
+/// IS_STATIC row; its names are exactly `RowColumnResolution::columns_for(true)`
+/// — header columns with `is_static == true` AND `!is_primary_key` AND
+/// `!is_clustering`. A static row has no clustering prefix, so it receives zero
+/// clustering-key pseudo-cells (row_data.rs: `clustering_values` is empty when
+/// static). A clustering row's `cells` names are the clustering-key pseudo-cells
+/// (issue #229) PLUS `columns_for(false)` — header columns with `is_static ==
+/// false` AND `!is_primary_key` AND `!is_clustering`. Every column has exactly
+/// one `is_static` value, so the `is_static == want_static` filter makes
+/// `columns_for(true)` and `columns_for(false)` name-disjoint; and
+/// `columns_for(true)` excludes clustering-key columns, so no static cell shares
+/// a clustering-key pseudo-cell name. Hence the two name sets are disjoint and
+/// the former membership guard could never fire.
+///
+/// Appending AFTER the clustering row's own cells keeps the merged order
+/// deterministic-by-construction (never user-visible: the query result is a
+/// name-keyed map, issue #1334).
 fn merge_static_cells(cells: &mut RowCells, static_cells: &RowCells) {
-    for (name, value) in static_cells {
-        if !cells.iter().any(|(existing, _)| existing == name) {
-            cells.push((Arc::clone(name), value.clone()));
-        }
-    }
+    cells.extend(
+        static_cells
+            .iter()
+            .map(|(name, value)| (Arc::clone(name), value.clone())),
+    );
 }
 
 /// Issue #932/#1741: build the user-facing `ScanRow` display value for a parsed

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -84,7 +84,7 @@ const MAX_TYPE_NESTING_DEPTH: usize = 10;
 /// always `Some` when `want_cell_metadata == true` and the row contains
 /// collection columns; always `None` when `want_cell_metadata == false`.
 type ParsedRow = (
-    HashMap<Arc<str>, Value>,
+    RowCells,
     Option<HashMap<String, CellWriteMetadata>>,
     Option<RowHeader>,
     usize,
@@ -669,12 +669,29 @@ const ROW_HAS_EXTENDED_FLAGS: u8 = 0x80;
 /// identity; they are NOT row data. A row carrying `HAS_DELETION` is a PURE row
 /// tombstone only when no such data cell survives — otherwise the row deletion
 /// COEXISTS with surviving (strictly-newer) cells and the row displays as live.
-fn row_has_non_key_cell(cells: &HashMap<Arc<str>, Value>, schema: &TableSchema) -> bool {
-    cells.keys().any(|name| {
+fn row_has_non_key_cell(cells: &[(Arc<str>, Value)], schema: &TableSchema) -> bool {
+    cells.iter().any(|(name, _)| {
         let name: &str = name;
         !schema.partition_keys.iter().any(|k| k.name == name)
             && !schema.clustering_keys.iter().any(|c| c.name == name)
     })
+}
+
+/// Issue #1642 (K3): merge accumulated static-column cells into a clustering
+/// row's positional cell vector, CLUSTERING-ROW-WINS (a static cell is appended
+/// only when the clustering row does not already carry that column). This is the
+/// ordered-`Vec` analogue of the former `HashMap::entry(..).or_insert_with(..)`
+/// merge: static and regular columns are disjoint in Cassandra, so the membership
+/// check is defensive and the common effect is a concatenation. The static cells
+/// are appended AFTER the clustering row's own cells; the merged order is never
+/// user-visible (the query result is a name-keyed map, issue #1334) — this only
+/// preserves determinism-by-construction.
+fn merge_static_cells(cells: &mut RowCells, static_cells: &RowCells) {
+    for (name, value) in static_cells {
+        if !cells.iter().any(|(existing, _)| existing == name) {
+            cells.push((Arc::clone(name), value.clone()));
+        }
+    }
 }
 
 /// Issue #932/#1741: build the user-facing `ScanRow` display value for a parsed
@@ -685,7 +702,7 @@ fn row_has_non_key_cell(cells: &HashMap<Arc<str>, Value>, schema: &TableSchema) 
 /// still carries surviving cells displays as a live `Row` (the deletion shadows
 /// only already-absent older cells). An empty cell set becomes a null marker.
 fn build_display_row(
-    cells: HashMap<Arc<str>, Value>,
+    cells: RowCells,
     row_header_opt: Option<&RowHeader>,
     schema: &TableSchema,
 ) -> ScanRow {
@@ -700,14 +717,12 @@ fn build_display_row(
     } else if cells.is_empty() {
         ScanRow::Marker(Value::Null)
     } else {
-        // Issue #1334: carry the interned `Arc<str>` name handles straight into
-        // the row carrier; emit-time alphabetical ordering preserved exactly.
-        let mut row_cells: RowCells = cells.into_iter().collect();
-        // Issue #1618 (H5): count the per-row cell sort — the shared site #1334
-        // consolidated the former block_emit/block_emit_windowed sorts into (K2/L).
-        crate::storage::sstable::read_work_counters::record_row_sort();
-        row_cells.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
-        ScanRow::Row(row_cells)
+        // Issue #1642 (K3): the decoder already emits cells positionally, in
+        // serialization-header (schema) column order — determinism comes from
+        // CONSTRUCTION, not a per-row sort. The former per-row `HashMap`
+        // allocation and alphabetical `sort_by` are gone; the interned
+        // `Arc<str>` name handles (#1334) move straight into the carrier.
+        ScanRow::Row(cells)
     }
 }
 
@@ -716,11 +731,16 @@ fn build_display_row(
 /// tombstone is currently OPEN in the partition, so the per-row clone is off the
 /// tombstone-free hot path. Returns fewer values than the clustering arity only
 /// for a malformed/partial row (missing clustering pseudo-cells).
-fn extract_clustering_values(cells: &HashMap<Arc<str>, Value>, schema: &TableSchema) -> Vec<Value> {
+fn extract_clustering_values(cells: &[(Arc<str>, Value)], schema: &TableSchema) -> Vec<Value> {
     schema
         .clustering_keys
         .iter()
-        .filter_map(|ck| cells.get(ck.name.as_str()).cloned())
+        .filter_map(|ck| {
+            cells
+                .iter()
+                .find(|(name, _)| name.as_ref() == ck.name.as_str())
+                .map(|(_, v)| v.clone())
+        })
         .collect()
 }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -308,6 +308,14 @@ impl<'a> RowColumnResolution<'a> {
         self.clustering.get(i)
     }
 
+    /// Number of interned clustering-key name handles (issue #1642). Used to
+    /// size the per-row cell `Vec` capacity hint: clustering-key cells are
+    /// pushed FIRST, before the data columns, so a clustered table would
+    /// otherwise reallocate once past the data-column-only hint.
+    pub(super) fn clustering_len(&self) -> usize {
+        self.clustering.len()
+    }
+
     /// The pre-resolved on-disk column ordering for a row of the given kind.
     pub(super) fn columns_for(&self, is_static: bool) -> &[ColumnToParse<'a>] {
         if is_static {

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_data.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_data.rs
@@ -60,9 +60,13 @@ impl V5CompressedLegacyParser {
         // alphabetically re-sorts each row. The interned column-name handle
         // (issue #1334) is a schema-owned `Arc<str>` shared across every cell/row,
         // so populating a cell with its name stays an `Arc::clone` refcount bump,
-        // NOT a per-cell heap `String` allocation. Pre-sized to the on-disk column
-        // count so the common case does not reallocate.
-        let mut cells: RowCells = Vec::with_capacity(resolution.columns_for(false).len());
+        // NOT a per-cell heap `String` allocation. Pre-sized to the on-disk data
+        // column count PLUS the clustering-key count so the common case does not
+        // reallocate — clustering-key cells are pushed FIRST (below), before the
+        // data columns, so sizing to data columns alone reallocates on a clustered
+        // table (issue #1642).
+        let mut cells: RowCells =
+            Vec::with_capacity(resolution.columns_for(false).len() + resolution.clustering_len());
         // Parallel per-cell write metadata map (populated alongside `cells`).
         // Only allocated when the caller actually needs WRITETIME/TTL metadata
         // (i.e. `want_cell_metadata == true`).  On the normal read path this stays

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_data.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_data.rs
@@ -54,11 +54,15 @@ impl V5CompressedLegacyParser {
         resolution: &RowColumnResolution,
         shadow: Option<&PartitionShadow>,
     ) -> Result<ParsedRow> {
-        // Cells map keyed by the interned column-name handle (issue #1334): the
-        // name is a schema-owned `Arc<str>` shared across every cell/row, so
-        // populating a cell with its name is an `Arc::clone` refcount bump, NOT a
-        // per-cell, per-row heap `String` allocation.
-        let mut cells: HashMap<Arc<str>, Value> = HashMap::new();
+        // Issue #1642 (K3): positional cell vector, built directly in
+        // serialization-header (schema) column order. Determinism comes from
+        // CONSTRUCTION — the emit path no longer allocates a per-row `HashMap` nor
+        // alphabetically re-sorts each row. The interned column-name handle
+        // (issue #1334) is a schema-owned `Arc<str>` shared across every cell/row,
+        // so populating a cell with its name stays an `Arc::clone` refcount bump,
+        // NOT a per-cell heap `String` allocation. Pre-sized to the on-disk column
+        // count so the common case does not reallocate.
+        let mut cells: RowCells = Vec::with_capacity(resolution.columns_for(false).len());
         // Parallel per-cell write metadata map (populated alongside `cells`).
         // Only allocated when the caller actually needs WRITETIME/TTL metadata
         // (i.e. `want_cell_metadata == true`).  On the normal read path this stays
@@ -147,7 +151,7 @@ impl V5CompressedLegacyParser {
                 // Issue #1334: reuse the interned clustering-key name handle
                 // (an `Arc::clone`) rather than cloning the schema `String`.
                 if let Some(name) = resolution.clustering_name(i) {
-                    cells.insert(Arc::clone(name), clustering_values[i].clone());
+                    cells.push((Arc::clone(name), clustering_values[i].clone()));
                 }
             }
         }
@@ -566,8 +570,9 @@ impl V5CompressedLegacyParser {
                                 if let Some(ref mut ccm_map) = complex_col_meta {
                                     ccm_map.insert(column.name.clone(), col_meta);
                                 }
-                                // Issue #1334: interned name handle (Arc::clone), no alloc.
-                                cells.insert(Arc::clone(&ctp.name), value);
+                                // Issue #1334/#1642: interned name handle (Arc::clone),
+                                // pushed positionally in schema column order.
+                                cells.push((Arc::clone(&ctp.name), value));
                             }
                         }
                         offset = new_offset;
@@ -733,8 +738,9 @@ impl V5CompressedLegacyParser {
                                     },
                                 );
                             }
-                            // Issue #1334: interned name handle (Arc::clone), no String alloc.
-                            cells.insert(Arc::clone(&ctp.name), value);
+                            // Issue #1334/#1642: interned name handle (Arc::clone),
+                            // pushed positionally in schema column order.
+                            cells.push((Arc::clone(&ctp.name), value));
                         }
                         offset = new_offset;
                     }
@@ -767,8 +773,8 @@ impl V5CompressedLegacyParser {
             columns_in_order.len()
         );
         log::debug!(
-            "V5CompressedLegacy: Cells HashMap keys: {:?}",
-            cells.keys().collect::<Vec<_>>()
+            "V5CompressedLegacy: Cell column names (positional order): {:?}",
+            cells.iter().map(|(name, _)| name).collect::<Vec<_>>()
         );
 
         debug!("V5CompressedLegacy: Parsed total of {} cells", cells.len());

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -443,31 +443,22 @@ impl SSTableReader {
         // Feed raw compressed chunks to the parse task. The bounded `raw_tx`
         // applies backpressure all the way back to disk reads when the consumer
         // (and thus the parse task) falls behind.
-        let mut io_err: Option<Error> = None;
-        loop {
-            match self.read_next_block(cursor).await {
-                Ok(Some(chunk)) => {
-                    if raw_tx.send(chunk).await.is_err() {
-                        // Parse task ended early (consumer dropped or parse
-                        // error). Stop reading; the task's result is canonical.
-                        break;
-                    }
-                }
-                Ok(None) => break, // EOF
-                Err(e) => {
-                    // Tell the parse half to SKIP the terminal final drain: the
-                    // stream is truncated, so the trailing window is partial and
-                    // must not be emitted. The store is sequenced before the
-                    // `drop(raw_tx)` the parse half synchronizes on.
-                    io_failed.store(true, Ordering::SeqCst);
-                    io_err = Some(e);
-                    break;
-                }
-            }
-        }
-        // Drop the sender so the blocking task sees EOF and runs its final drain
-        // (only if `io_failed` is still false — see the parse half).
-        drop(raw_tx);
+        //
+        // Determine the ACTUAL scan backend once (the per-scan cursor mutex is
+        // uncontended, so this lock is effectively free). A synchronously-faulting
+        // backend (mmap page fault / `O_DIRECT` `pread`) does its disk I/O
+        // *inside* `poll_read`, so reading it on an async worker blocks — and K
+        // concurrent cold scans pin the whole pool, stalling every warm point read
+        // (issue #1593, F3). Route such a backend's read loop off the async
+        // workers; the buffered backend is genuinely async (`tokio::fs`, reactor-
+        // driven) and stays inline on the runtime.
+        let faulting_backend = cursor.file.lock().await.faults_synchronously();
+
+        let io_err: Option<Error> = if faulting_backend {
+            Self::feed_raw_chunks_blocking(Arc::clone(&self), cursor, raw_tx, &io_failed).await
+        } else {
+            self.feed_raw_chunks_async(cursor, raw_tx, &io_failed).await
+        };
 
         // Join the parse task; its Result is the scan's Result. An I/O error
         // takes precedence (the task only saw a truncated stream). The parse task
@@ -489,6 +480,108 @@ impl SSTableReader {
             return Err(e);
         }
         parse_result
+    }
+
+    /// I/O feed loop for a genuinely-async (buffered) backend: read the next
+    /// compressed chunk on the async runtime and forward it over the bounded
+    /// `raw_tx`. `tokio::fs` reads are reactor-driven and non-blocking, so this
+    /// belongs inline on the worker (issue #1593, F3). Returns the terminal read
+    /// error, if any; consumes `raw_tx` so it drops on return, signalling EOF to
+    /// the parse half (only when `io_failed` stayed false — see the parse half).
+    async fn feed_raw_chunks_async(
+        &self,
+        cursor: &ScanCursor,
+        raw_tx: mpsc::Sender<Vec<u8>>,
+        io_failed: &Arc<AtomicBool>,
+    ) -> Option<Error> {
+        loop {
+            match self.read_next_block(cursor).await {
+                Ok(Some(chunk)) => {
+                    if raw_tx.send(chunk).await.is_err() {
+                        // Parse task ended early (consumer dropped or parse error).
+                        // Stop reading; the task's result is canonical.
+                        break;
+                    }
+                }
+                Ok(None) => break, // EOF
+                Err(e) => {
+                    // Tell the parse half to SKIP the terminal final drain: the
+                    // stream is truncated, so the trailing window is partial and
+                    // must not be emitted. The store is sequenced before the
+                    // `drop(raw_tx)` (on return) the parse half synchronizes on.
+                    io_failed.store(true, Ordering::SeqCst);
+                    return Some(e);
+                }
+            }
+        }
+        None
+        // `raw_tx` drops here on return, signalling clean EOF to the parse half.
+    }
+
+    /// I/O feed loop for a synchronously-faulting backend (mmap page fault /
+    /// `O_DIRECT` `pread`): run the WHOLE per-scan read loop on ONE
+    /// `spawn_blocking` thread so the blocking disk I/O never pins an async worker
+    /// (issue #1593, F3). One offload per scan (mirroring the parse half — never
+    /// per chunk, which would over-spawn; per-scan admission is F4's scope). Feeds
+    /// the same bounded `raw_tx` via `blocking_send` (backpressure preserved: a
+    /// full channel parks this thread). Consumes `raw_tx` (moved into the task) so
+    /// it drops when the task returns, signalling EOF exactly as the async loop.
+    async fn feed_raw_chunks_blocking(
+        reader: Arc<Self>,
+        cursor: &ScanCursor,
+        raw_tx: mpsc::Sender<Vec<u8>>,
+        io_failed: &Arc<AtomicBool>,
+    ) -> Option<Error> {
+        let io_file = Arc::clone(&cursor.file);
+        let io_chunk_index = Arc::clone(&cursor.chunk_index);
+        let io_failed_feed = Arc::clone(io_failed);
+        let feed = tokio::task::spawn_blocking(move || -> Option<Error> {
+            // Record the thread this scan's raw reads run on so a guard test can
+            // prove it is a spawn_blocking thread, NOT an async worker (F3).
+            // Compiled only under the non-default `scan-offload-probe` feature.
+            #[cfg(feature = "scan-offload-probe")]
+            probe::record_io_read_thread();
+            loop {
+                // SOUNDNESS (issue #1593): driving the async read under
+                // `futures::executor::block_on` on this blocking thread is sound
+                // ONLY because the mmap/`O_DIRECT` per-chunk read path touches no
+                // tokio reactor/timer primitive — the per-scan cursor `Mutex` is
+                // executor-agnostic (semaphore + wakers, no reactor);
+                // `MmapCursor`/`DirectCursor` `poll_*` are pure synchronous
+                // memory/`pread` ops; the CRC digest is preloaded in memory at
+                // open (no per-chunk `tokio::fs`); and the transient-retry re-seek
+                // uses no `tokio::time`. This branch is NEVER taken for the
+                // buffered backend (which needs the reactor). A nested tokio
+                // runtime or `block_in_place` would panic on a `spawn_blocking`
+                // thread; `futures::executor::block_on` is a plain thread-parking
+                // executor with no tokio involvement, so it does not.
+                match futures::executor::block_on(
+                    reader.read_next_block_parts(&io_file, &io_chunk_index),
+                ) {
+                    Ok(Some(chunk)) => {
+                        if raw_tx.blocking_send(chunk).is_err() {
+                            break; // consumer/parse ended early
+                        }
+                    }
+                    Ok(None) => break, // EOF
+                    Err(e) => {
+                        io_failed_feed.store(true, Ordering::SeqCst);
+                        return Some(e);
+                    }
+                }
+            }
+            None
+            // `raw_tx` drops here (moved into the closure), signalling clean EOF.
+        });
+        match feed.await {
+            Ok(e) => e,
+            Err(join_err) => {
+                io_failed.store(true, Ordering::SeqCst);
+                Some(Error::corruption(format!(
+                    "run_scan_stream_windowed: I/O feed task failed: {join_err}"
+                )))
+            }
+        }
     }
 
     /// Blocking parse half of the windowed streaming scan (issue #1143).

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -133,6 +133,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
+// Panic/early-exit drop-guard for the raw-chunk feed loops (roborev finding,
+// issue #1593). In a sibling file to keep this driver under the campsite-rule
+// size limit (epic #1116); re-exported privately so `use super::*` in the test
+// module resolves it.
+#[path = "scan_stream_windowed_guard.rs"]
+mod guard;
+use guard::FeedFailureGuard;
+
 /// Bound on the raw-compressed-chunk channel feeding the blocking parse task.
 ///
 /// This is the I/O-half → parse-half hand-off depth. It must stay small enough
@@ -494,6 +502,11 @@ impl SSTableReader {
         raw_tx: mpsc::Sender<Vec<u8>>,
         io_failed: &Arc<AtomicBool>,
     ) -> Option<Error> {
+        // Flip `io_failed` on any unwind so a panic in `read_next_block` cannot
+        // masquerade as a clean EOF and make the parse half emit a truncated
+        // trailing partition (roborev finding, issue #1593). Disarmed on the
+        // clean-EOF / consumer-ended exit below so the happy path is unchanged.
+        let mut panic_guard = FeedFailureGuard::armed(io_failed);
         loop {
             match self.read_next_block(cursor).await {
                 Ok(Some(chunk)) => {
@@ -514,6 +527,9 @@ impl SSTableReader {
                 }
             }
         }
+        // Clean EOF (or consumer ended early): leave `io_failed` false so the
+        // parse half runs its terminal drain exactly as before.
+        panic_guard.disarm();
         None
         // `raw_tx` drops here on return, signalling clean EOF to the parse half.
     }
@@ -536,6 +552,19 @@ impl SSTableReader {
         let io_chunk_index = Arc::clone(&cursor.chunk_index);
         let io_failed_feed = Arc::clone(io_failed);
         let feed = tokio::task::spawn_blocking(move || -> Option<Error> {
+            // Panic/early-exit guard (roborev finding, issue #1593). `raw_tx` is
+            // captured (moved) into this closure and drops when the closure
+            // returns OR unwinds; the parse half reads a `raw_tx` close with
+            // `io_failed == false` as a CLEAN EOF and runs its terminal drain. If
+            // this closure PANICS, `raw_tx` drops during unwind while the only
+            // other `io_failed = true` store (the `Err(join_err)` arm below) runs
+            // LATER — so the parse half would spuriously terminal-drain a
+            // truncated window. Arming this guard as a BODY-LOCAL flips
+            // `io_failed = true` on unwind BEFORE the captured `raw_tx` drops
+            // (body locals drop before a move closure's captured environment).
+            // Disarmed on the clean-EOF / consumer-ended exit so the happy path is
+            // byte-identical.
+            let mut panic_guard = FeedFailureGuard::armed(&io_failed_feed);
             // Record the thread this scan's raw reads run on so a guard test can
             // prove it is a spawn_blocking thread, NOT an async worker (F3).
             // Compiled only under the non-default `scan-offload-probe` feature.
@@ -570,6 +599,9 @@ impl SSTableReader {
                     }
                 }
             }
+            // Clean EOF (or consumer ended early): leave `io_failed` false so the
+            // parse half runs its terminal drain exactly as before.
+            panic_guard.disarm();
             None
             // `raw_tx` drops here (moved into the closure), signalling clean EOF.
         });

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_guard.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_guard.rs
@@ -1,0 +1,70 @@
+//! Panic/early-exit drop-guard for the windowed streaming scan's raw-chunk feed
+//! loops (roborev finding, issue #1593; see also issue #1143 finding 2).
+//!
+//! Kept in a sibling file so the parent `scan_stream_windowed` driver stays under
+//! the campsite-rule size limit (epic #1116). Included via `#[path = ...] mod
+//! guard;` + a private re-export, so `use super::*` in the parent's test module
+//! resolves [`FeedFailureGuard`] directly.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Drop-guard that flips `io_failed` to `true` on ANY early exit — including a
+/// PANIC/unwind — of a raw-chunk feed loop, UNLESS explicitly
+/// [`disarm`](Self::disarm)ed on the clean-EOF path.
+///
+/// # Why this exists
+///
+/// A feed loop MOVES `raw_tx` in and drops it on return. The blocking parse half
+/// treats a `raw_tx` close with `io_failed == false` as a CLEAN EOF and runs its
+/// terminal (`at_final_chunk = true`) drain, which parses the trailing window AS
+/// IF it were a complete final partition. The normal read-error path sets
+/// `io_failed = true` before returning, so that is handled. But if the feed
+/// closure PANICS, `raw_tx` is dropped during unwind and the only other place
+/// that sets `io_failed = true` — the `Err(join_err)` join arm — runs LATER, only
+/// after the (already-closed) task is joined. The parse half would then observe a
+/// spurious CLEAN EOF, run the terminal drain, and emit a TRUNCATED trailing
+/// partition as a row before the scan surfaces its `Err`.
+///
+/// Arming this guard as a BODY-LOCAL of the feed closure fixes the ordering: body
+/// locals are dropped BEFORE a `move` closure's captured environment, so on a
+/// panic the guard's `Drop` flips `io_failed = true` BEFORE the captured `raw_tx`
+/// drops. The parse half's `io_failed.load` (sequenced after the `raw_tx`-close
+/// happens-before) therefore observes the failure and correctly SKIPS the terminal
+/// drain — no spurious trailing partition.
+///
+/// The clean-EOF path (and the consumer-ended-early break, which is likewise not
+/// an I/O failure) reaches [`disarm`](Self::disarm), so a normal finish leaves
+/// `io_failed == false` and the terminal drain runs EXACTLY as before — the happy
+/// path is byte-identical. `Drop` uses only `AtomicBool::store`, which never
+/// panics, honoring the no-panic-in-`Drop` rule.
+pub(super) struct FeedFailureGuard<'a> {
+    io_failed: &'a AtomicBool,
+    armed: bool,
+}
+
+impl<'a> FeedFailureGuard<'a> {
+    /// Arm a guard over `io_failed` (starts armed; fires on drop unless disarmed).
+    pub(super) fn armed(io_failed: &'a AtomicBool) -> Self {
+        Self {
+            io_failed,
+            armed: true,
+        }
+    }
+
+    /// Disarm on the clean-EOF (or consumer-ended-early) path so a normal finish
+    /// leaves `io_failed == false`.
+    pub(super) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for FeedFailureGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            // SeqCst matches the explicit stores in the feed loops so the parse
+            // half's `io_failed.load` observes it via the raw_tx-close
+            // happens-before. `store` never panics (no-panic-in-Drop).
+            self.io_failed.store(true, Ordering::SeqCst);
+        }
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_probe.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_probe.rs
@@ -21,6 +21,11 @@ use std::thread::ThreadId;
 
 static ARMED: AtomicBool = AtomicBool::new(false);
 static LAST_PARSE_THREAD: Mutex<Option<ThreadId>> = Mutex::new(None);
+/// The [`ThreadId`] on which the scan's raw chunk READ last ran (issue #1593,
+/// F3). For a synchronously-faulting backend (mmap page fault / `O_DIRECT`
+/// `pread`) the read must run on a `spawn_blocking` thread, NOT an async worker;
+/// a guard test compares this against the enumerated async-worker set.
+static LAST_IO_READ_THREAD: Mutex<Option<ThreadId>> = Mutex::new(None);
 /// Number of times the per-partition scratch buffer GREW its backing store
 /// during the armed scan (issue #1333). With the scratch hoisted out of the
 /// per-partition loop and `.clear()`-reused this is a small bounded count
@@ -33,6 +38,9 @@ static SCRATCH_ALLOCS: AtomicUsize = AtomicUsize::new(0);
 /// count. Call from a test before driving a scan.
 pub fn arm() {
     if let Ok(mut g) = LAST_PARSE_THREAD.lock() {
+        *g = None;
+    }
+    if let Ok(mut g) = LAST_IO_READ_THREAD.lock() {
         *g = None;
     }
     SCRATCH_ALLOCS.store(0, Ordering::SeqCst);
@@ -57,6 +65,24 @@ pub(super) fn record_parse_thread() {
 /// The [`ThreadId`] recorded by the most recent parse, if any.
 pub fn recorded_parse_thread() -> Option<ThreadId> {
     LAST_PARSE_THREAD.lock().ok().and_then(|g| *g)
+}
+
+/// Record the current thread as the raw-chunk READ thread, if armed. Called from
+/// the windowed scan's I/O feed loop once per scan after the first chunk read
+/// (issue #1593, F3). For a synchronously-faulting backend this must be a
+/// `spawn_blocking` thread, not an async worker.
+pub(super) fn record_io_read_thread() {
+    if ARMED.load(Ordering::Relaxed) {
+        if let Ok(mut g) = LAST_IO_READ_THREAD.lock() {
+            *g = Some(std::thread::current().id());
+        }
+    }
+}
+
+/// The [`ThreadId`] on which the scan's raw chunk read last ran, if any (issue
+/// #1593, F3).
+pub fn recorded_io_read_thread() -> Option<ThreadId> {
+    LAST_IO_READ_THREAD.lock().ok().and_then(|g| *g)
 }
 
 /// Record that the per-partition scratch buffer's capacity changed from

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_probe.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_probe.rs
@@ -67,8 +67,8 @@ pub fn recorded_parse_thread() -> Option<ThreadId> {
     LAST_PARSE_THREAD.lock().ok().and_then(|g| *g)
 }
 
-/// Record the current thread as the raw-chunk READ thread, if armed. Called from
-/// the windowed scan's I/O feed loop once per scan after the first chunk read
+/// Record the current thread as the raw-chunk READ thread, if armed. Called
+/// once per scan, at the start of the feed loop (before the first chunk read)
 /// (issue #1593, F3). For a synchronously-faulting backend this must be a
 /// `spawn_blocking` thread, not an async worker.
 pub(super) fn record_io_read_thread() {

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_tests.rs
@@ -36,6 +36,114 @@ fn terminal_drain_skipped_iff_io_failed() {
     );
 }
 
+/// Issue #1593 (roborev) — the [`FeedFailureGuard`] semantics the panic-path fix
+/// rests on. An ARMED guard flips `io_failed` to `true` when dropped; a DISARMED
+/// guard leaves it untouched. A refactor that inverts the arm/disarm sense, drops
+/// the `Drop` impl, or forgets to disarm the clean-EOF path flips one of these.
+#[test]
+fn feed_failure_guard_fires_on_drop_iff_armed() {
+    // Armed guard dropped (the panic / early-exit case): io_failed becomes true.
+    let armed_flag = AtomicBool::new(false);
+    {
+        let _g = FeedFailureGuard::armed(&armed_flag);
+        // dropped at end of scope, still armed
+    }
+    assert!(
+        armed_flag.load(Ordering::SeqCst),
+        "Issue #1593: an ARMED FeedFailureGuard must set io_failed=true on drop \
+         (the panic/early-exit path), else the parse half would spuriously \
+         terminal-drain a truncated window"
+    );
+
+    // Disarmed guard dropped (the clean-EOF path): io_failed stays false so the
+    // terminal drain runs exactly as before.
+    let disarmed_flag = AtomicBool::new(false);
+    {
+        let mut g = FeedFailureGuard::armed(&disarmed_flag);
+        g.disarm();
+    }
+    assert!(
+        !disarmed_flag.load(Ordering::SeqCst),
+        "Issue #1593: a DISARMED FeedFailureGuard must leave io_failed false so the \
+         clean-EOF terminal drain still runs (happy path byte-identical)"
+    );
+}
+
+/// Issue #1593 (roborev) — the ORDERING the fix depends on: on a panic the
+/// body-local guard must flip `io_failed` to `true` BEFORE the feed closure's
+/// captured `raw_tx` drops during unwind (body locals drop before a `move`
+/// closure's captured environment). We cannot inject a panic into the real
+/// `read_next_block_parts` feed loop without a production test hook, so this test
+/// reproduces the exact drop-order scenario: a `move` closure that OWNS a sender
+/// analog (which, on drop, records the `io_failed` value it observes) and creates
+/// a body-local armed guard, then panics. If the guard fires before the captured
+/// sender drops — the property the real fix relies on — the sender observes
+/// `io_failed == true`, exactly what the parse half needs to skip the terminal
+/// drain.
+///
+/// INTEGRATION LIMITATION (documented): an end-to-end panic inside the live
+/// `feed_raw_chunks_blocking` `spawn_blocking` closure is not cleanly injectable
+/// without adding a production-only fault hook, so this proves the drop-order
+/// contract on a faithful stand-in rather than the live feed loop. The live wiring
+/// is a single `FeedFailureGuard::armed(&io_failed_feed)` body-local at the top of
+/// that closure (disarmed only on the clean-EOF exit), whose ordering guarantee is
+/// exactly what this test pins.
+#[test]
+fn feed_failure_guard_fires_before_captured_tx_drops_on_panic() {
+    use std::panic::AssertUnwindSafe;
+
+    // Sender analog: on drop, snapshots the io_failed value it can observe. In the
+    // real feed closure this is `raw_tx`, whose close is what the parse half reads.
+    struct RecordingTx<'a> {
+        io_failed: &'a AtomicBool,
+        observed_on_drop: &'a AtomicBool,
+    }
+    impl Drop for RecordingTx<'_> {
+        fn drop(&mut self) {
+            self.observed_on_drop
+                .store(self.io_failed.load(Ordering::SeqCst), Ordering::SeqCst);
+        }
+    }
+
+    let io_failed = AtomicBool::new(false);
+    let observed_on_drop = AtomicBool::new(false);
+    // The atomics stay OWNED by this frame so we can read them after the unwind.
+    // `&AtomicBool` is `Copy`, so the `move` closure captures these shared refs by
+    // copy (not the atomics), while `tx` is captured by move so it drops DURING
+    // the closure's unwind.
+    let io_failed_ref: &AtomicBool = &io_failed;
+    let tx = RecordingTx {
+        io_failed: io_failed_ref,
+        observed_on_drop: &observed_on_drop,
+    };
+
+    // A `move` closure capturing `tx` (like the feed closure captures `raw_tx`)
+    // with a BODY-LOCAL armed guard, that panics. AssertUnwindSafe because the
+    // shared &AtomicBool references are not UnwindSafe by default; the test does
+    // not observe any poisoned/half-updated state, only the post-unwind snapshot.
+    let result = std::panic::catch_unwind(AssertUnwindSafe(move || {
+        let _guard = FeedFailureGuard::armed(io_failed_ref);
+        // `tx` is captured by move; keep it live until the panic so its drop
+        // happens during unwind AFTER the body-local guard's drop.
+        let _keep = &tx;
+        panic!("simulated feed-closure panic");
+    }));
+
+    assert!(result.is_err(), "the closure must have panicked");
+    assert!(
+        io_failed.load(Ordering::SeqCst),
+        "Issue #1593: the guard must set io_failed=true during unwind"
+    );
+    assert!(
+        observed_on_drop.load(Ordering::SeqCst),
+        "Issue #1593 REGRESSION: the captured sender (raw_tx analog) observed \
+         io_failed=false when it dropped during unwind — the guard did NOT fire \
+         first. The parse half would then read a spurious CLEAN EOF and emit a \
+         truncated trailing partition. The body-local guard must drop (and set the \
+         flag) BEFORE the captured sender."
+    );
+}
+
 /// Issue #1143 finding 1 (roborev) — the batching in-flight bound is a single
 /// documented CONSTANT, derived purely from the batch sizing knobs, and is
 /// independent of the caller's `buffer_size`. This pins the algebra so a future

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -105,6 +105,28 @@ impl BlockSource {
         BlockSource::Direct(cursor)
     }
 
+    /// Whether reads from this backend BLOCK the calling thread synchronously
+    /// (issue #1593, F3). A memory map faults in cold pages with a disk read at
+    /// first access, and an `O_DIRECT`/`F_NOCACHE` cursor issues an uncached
+    /// blocking `pread`; both do that work synchronously inside `poll_read`, so a
+    /// scan reading them on a tokio async worker would starve the runtime. The
+    /// buffered backend, by contrast, is genuinely async (`tokio::fs`, reactor-
+    /// driven), so it returns `false` and its reads stay inline on the runtime.
+    ///
+    /// The windowed scan uses this to route a faulting backend's read loop onto a
+    /// `spawn_blocking` thread. Keying on the ACTUAL backend (not the configured
+    /// intent) matters: a `Direct` request that degrades to `Buffered` at open
+    /// returns `false` here and is read inline — never driven under a non-tokio
+    /// executor that lacks the reactor `tokio::fs` needs.
+    pub(crate) fn faults_synchronously(&self) -> bool {
+        match self {
+            BlockSource::Buffered { .. } => false,
+            BlockSource::Mapped(_) => true,
+            #[cfg(unix)]
+            BlockSource::Direct(_) => true,
+        }
+    }
+
     /// Returns `true` when this source is backed by a memory map.
     #[cfg(test)]
     pub(crate) fn is_mmap(&self) -> bool {
@@ -195,14 +217,19 @@ impl ScanSource {
 /// `&mut` access to seek/read the source.
 pub(crate) struct ScanCursor {
     pub(crate) file: Arc<Mutex<BlockSource>>,
-    pub(crate) chunk_index: AtomicUsize,
+    /// Wrapped in `Arc` (issue #1593, F3) so the windowed scan can hand the
+    /// chunk index to a `spawn_blocking` I/O loop for synchronously-faulting
+    /// backends while the cursor stays usable. `Arc<AtomicUsize>` is one pointer,
+    /// so `ScanCursor` remains two pointers wide (the 16-byte pin below holds).
+    pub(crate) chunk_index: Arc<AtomicUsize>,
 }
 
 // Struct-size regression guard (issue #1616, Epic H/H3; see
 // docs/reports/parser-performance-audit-2026-07-01.md §Epic H (finding H3)). One
 // `ScanCursor` is allocated per concurrent full scan (issue #815), so its
-// footprint is on the read hot path. Measured 16 bytes today (Arc pointer +
-// AtomicUsize) on 64-bit targets. Update this pin DELIBERATELY, never silently:
+// footprint is on the read hot path. Measured 16 bytes today (two pointers: the
+// `Arc<Mutex<BlockSource>>` file handle + the `Arc<AtomicUsize>` chunk index,
+// issue #1593) on 64-bit targets. Update this pin DELIBERATELY, never silently:
 // any change — growth or shrink — must be a reviewed edit here.
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<ScanCursor>() == 16);
@@ -212,7 +239,7 @@ impl ScanCursor {
     pub(crate) fn new(source: BlockSource) -> Self {
         Self {
             file: Arc::new(Mutex::new(source)),
-            chunk_index: AtomicUsize::new(0),
+            chunk_index: Arc::new(AtomicUsize::new(0)),
         }
     }
 }

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -100,10 +100,13 @@ const _: () = assert!(std::mem::size_of::<Value>() <= 88);
 /// Each entry is `(column_name, value)` where the name is a shared `Arc<str>`
 /// handle interned once by the row decoder. Carrying a cell's name into
 /// `QueryRow.values` is therefore a reference-count bump — NOT a per-cell heap
-/// `String` allocation. Entries are ordered exactly as the producer emits them:
-/// positionally, in serialization-header (schema) column order — deterministic by
-/// CONSTRUCTION, with no per-row sort (issue #1642 / K3). This order is NOT
-/// user-visible: the public query result (`QueryRow.values`) is a name-keyed map.
+/// `String` allocation. Entries are ordered exactly as the producer emits them,
+/// which is deterministic per producer: the PRIMARY V5 decoder emits positionally
+/// in serialization-header (schema) column order by CONSTRUCTION, with no per-row
+/// sort (issue #1642 / K3); the cold schema-less fallback paths collect into an
+/// unordered map and emit SORTED order. This order is NOT user-visible: the public
+/// query result (`QueryRow.values`) is a name-keyed map, so all consumers key by
+/// name regardless of producer.
 pub type RowCells = Vec<(Arc<str>, Value)>;
 
 /// Payload of a single scanned row as it crosses the storage → query boundary
@@ -120,10 +123,12 @@ pub type RowCells = Vec<(Arc<str>, Value)>;
 /// column values can never silently fall through to a non-row fallback.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScanRow {
-    /// A live row: its interned cells, ordered exactly as emitted (positionally,
-    /// in serialization-header column order — issue #1642 / K3). These cells are
-    /// ALREADY DECODED — a consumer surfaces them as-is (never re-decoding a cell
-    /// value). The order is not user-visible (the public result is name-keyed).
+    /// A live row: its interned cells, ordered exactly as emitted — the PRIMARY V5
+    /// decoder emits positionally in serialization-header column order (issue #1642
+    /// / K3), while cold schema-less fallback paths emit sorted order (both
+    /// deterministic). These cells are ALREADY DECODED — a consumer surfaces them
+    /// as-is (never re-decoding a cell value). The order is not user-visible (the
+    /// public result is name-keyed).
     Row(RowCells),
     /// A RAW, UNDECODED whole-row value carried with explicit provenance
     /// (issue #1334). Emitted only by the fallback producers — the `data_access`

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -100,8 +100,10 @@ const _: () = assert!(std::mem::size_of::<Value>() <= 88);
 /// Each entry is `(column_name, value)` where the name is a shared `Arc<str>`
 /// handle interned once by the row decoder. Carrying a cell's name into
 /// `QueryRow.values` is therefore a reference-count bump — NOT a per-cell heap
-/// `String` allocation. Entries are ordered exactly as the producer emits them
-/// (emit-time alphabetical by column name).
+/// `String` allocation. Entries are ordered exactly as the producer emits them:
+/// positionally, in serialization-header (schema) column order — deterministic by
+/// CONSTRUCTION, with no per-row sort (issue #1642 / K3). This order is NOT
+/// user-visible: the public query result (`QueryRow.values`) is a name-keyed map.
 pub type RowCells = Vec<(Arc<str>, Value)>;
 
 /// Payload of a single scanned row as it crosses the storage → query boundary
@@ -118,9 +120,10 @@ pub type RowCells = Vec<(Arc<str>, Value)>;
 /// column values can never silently fall through to a non-row fallback.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScanRow {
-    /// A live row: its interned cells, ordered exactly as emitted (emit-time
-    /// alphabetical by column name). These cells are ALREADY DECODED — a
-    /// consumer surfaces them as-is (never re-decoding a cell value).
+    /// A live row: its interned cells, ordered exactly as emitted (positionally,
+    /// in serialization-header column order — issue #1642 / K3). These cells are
+    /// ALREADY DECODED — a consumer surfaces them as-is (never re-decoding a cell
+    /// value). The order is not user-visible (the public result is name-keyed).
     Row(RowCells),
     /// A RAW, UNDECODED whole-row value carried with explicit provenance
     /// (issue #1334). Emitted only by the fallback producers — the `data_access`

--- a/cqlite-core/tests/dead_cache_delete_tests.rs
+++ b/cqlite-core/tests/dead_cache_delete_tests.rs
@@ -399,11 +399,25 @@ async fn stats_surface_disabled_caches_report_honest_zeros() {
     assert_eq!(ms.block_cache_evictions, 0);
     assert_eq!(ms.block_cache_capacity_bytes, 0);
     assert_eq!(ms.total_memory_used, 0);
+
+    // Key cache (B4): the SAME `block_cache.enabled == false` flag disables BOTH
+    // read caches — `storage::sstable::build_key_offset_cache` builds a
+    // `KeyOffsetCache::disabled()` (zero-capacity, no-op) when
+    // `block_cache.enabled == false`, exactly as `build_chunk_cache` no-ops the B1
+    // chunk cache. So this test's single flag verifies both. The self-verifying
+    // proof that the key cache is genuinely disabled is `capacity_bytes == 0`: a
+    // disabled cache has zero configured budget, which cannot be a coincidence of
+    // an idle-but-enabled cache (that would report its real non-zero budget). The
+    // zero hits/misses/evictions/resident then follow honestly from a no-op cache.
+    assert_eq!(
+        ms.key_cache_capacity_bytes, 0,
+        "block_cache.enabled=false disables the B4 key cache too (build_key_offset_cache \
+         → KeyOffsetCache::disabled()); a disabled cache reports zero capacity"
+    );
     assert_eq!(ms.key_cache_hits, 0);
     assert_eq!(ms.key_cache_misses, 0);
     assert_eq!(ms.key_cache_evictions, 0);
     assert_eq!(ms.key_cache_resident_bytes, 0);
-    assert_eq!(ms.key_cache_capacity_bytes, 0);
     assert_eq!(ms.key_cache_hit_rate(), 0.0);
 }
 

--- a/cqlite-core/tests/dead_cache_delete_tests.rs
+++ b/cqlite-core/tests/dead_cache_delete_tests.rs
@@ -275,6 +275,138 @@ async fn stats_block_cache_hit_rate_and_occupancy_are_real() {
     );
 }
 
+/// Issue #1571 (B5 — honest cache observability): after repeated point reads that
+/// exercise BOTH read caches, `Database::stats().memory_stats` surfaces the REAL
+/// hit/eviction/occupancy/capacity numbers for the B1 chunk cache AND the
+/// aggregated B4 key cache — never a fabricated placeholder. On pre-change code the
+/// new fields do not exist and the key cache is entirely absent from the surface.
+///
+/// A point lookup (`WHERE id = <uuid>`) routes through both the cache-consulting
+/// chunk-read site and the per-reader key→partition-offset cache, so a repeated
+/// identical read makes both caches report a real hit.
+#[cfg(feature = "cli-helpers")]
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn stats_surface_reports_real_chunk_and_key_cache_observability() {
+    let Some(_) = resolve_or_skip("test_basic", "simple_table") else {
+        return;
+    };
+    let Some(db) = open_fixture_db(
+        "test_basic",
+        "simple_table",
+        "basic-types.cql",
+        Config::default(),
+    )
+    .await
+    else {
+        return;
+    };
+
+    let scan = db
+        .execute("SELECT * FROM test_basic.simple_table")
+        .await
+        .expect("scan for a key");
+    assert!(
+        !scan.rows.is_empty(),
+        "fixture present but scan returned 0 rows"
+    );
+    let id = scan
+        .rows
+        .iter()
+        .find_map(|r| r.get("id").and_then(uuid_literal))
+        .expect("a row with a UUID id");
+
+    // Same point read twice: the second is served warm from both caches.
+    let q = format!("SELECT * FROM test_basic.simple_table WHERE id = {id}");
+    assert_eq!(db.execute(&q).await.expect("cold").rows.len(), 1);
+    assert_eq!(db.execute(&q).await.expect("warm").rows.len(), 1);
+
+    let ms = db.stats().await.expect("stats").memory_stats;
+
+    // Chunk cache (B1): real hits + non-zero hit rate + occupancy + a real budget.
+    assert!(
+        ms.block_cache_hits > 0 && ms.block_cache_hit_rate() > 0.0,
+        "repeat cached read must yield real, non-zero chunk-cache hits (got {} hits, rate {})",
+        ms.block_cache_hits,
+        ms.block_cache_hit_rate()
+    );
+    assert!(
+        ms.total_memory_used > 0,
+        "reported occupancy must track the B1 cache's real resident bytes"
+    );
+    assert!(
+        ms.block_cache_capacity_bytes > 0,
+        "an enabled chunk cache reports its real configured budget, not a placeholder"
+    );
+    // Evictions are a real counter; on a tiny fixture there is likely no eviction,
+    // so we assert only that hit rate is bounded (a real ratio), not fabricated.
+    assert!(
+        ms.block_cache_hit_rate() <= 1.0,
+        "hit rate is a real ratio in [0,1]"
+    );
+
+    // Key cache (B4), aggregated across readers: the second identical point read
+    // must have been served by the per-reader key cache → real hit + capacity.
+    assert!(
+        ms.key_cache_hits > 0 && ms.key_cache_hit_rate() > 0.0,
+        "repeat point read must yield real, non-zero key-cache hits (got {} hits, rate {})",
+        ms.key_cache_hits,
+        ms.key_cache_hit_rate()
+    );
+    assert!(
+        ms.key_cache_capacity_bytes > 0,
+        "an enabled key cache reports its real aggregated budget"
+    );
+    assert!(
+        ms.key_cache_hit_rate() <= 1.0,
+        "key-cache hit rate is a real ratio in [0,1]"
+    );
+}
+
+/// Issue #1571 (B5): with the read caches disabled, EVERY cache-observability
+/// field reports a real zero — the honest reflection of no caching, never a
+/// fabricated non-zero placeholder. Contrast the enabled test above.
+#[cfg(feature = "cli-helpers")]
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn stats_surface_disabled_caches_report_honest_zeros() {
+    let Some(_) = resolve_or_skip("test_basic", "simple_table") else {
+        return;
+    };
+    let mut config = Config::default();
+    config.memory.block_cache.enabled = false;
+    let Some(db) = open_fixture_db("test_basic", "simple_table", "basic-types.cql", config).await
+    else {
+        return;
+    };
+
+    let scan = db
+        .execute("SELECT * FROM test_basic.simple_table")
+        .await
+        .expect("scan for a key");
+    assert!(!scan.rows.is_empty(), "fixture present but 0 rows");
+    let id = scan
+        .rows
+        .iter()
+        .find_map(|r| r.get("id").and_then(uuid_literal))
+        .expect("a row with a UUID id");
+    let q = format!("SELECT * FROM test_basic.simple_table WHERE id = {id}");
+    assert_eq!(db.execute(&q).await.expect("first").rows.len(), 1);
+    assert_eq!(db.execute(&q).await.expect("second").rows.len(), 1);
+
+    let ms = db.stats().await.expect("stats").memory_stats;
+    assert_eq!(ms.block_cache_hits, 0);
+    assert_eq!(ms.block_cache_evictions, 0);
+    assert_eq!(ms.block_cache_capacity_bytes, 0);
+    assert_eq!(ms.total_memory_used, 0);
+    assert_eq!(ms.key_cache_hits, 0);
+    assert_eq!(ms.key_cache_misses, 0);
+    assert_eq!(ms.key_cache_evictions, 0);
+    assert_eq!(ms.key_cache_resident_bytes, 0);
+    assert_eq!(ms.key_cache_capacity_bytes, 0);
+    assert_eq!(ms.key_cache_hit_rate(), 0.0);
+}
+
 /// Issue #1568 (roborev F1): `block_cache.enabled == false` must GENUINELY
 /// disable caching, not be a decorative toggle. The contrast to
 /// `stats_block_cache_hit_rate_and_occupancy_are_real` (which opens with the
@@ -419,6 +551,15 @@ fn memory_stats_semver_shape_preserved() {
     let _: u64 = ms.buffer_deallocations;
     let _: f64 = ms.block_cache_hit_rate();
     let _: f64 = ms.row_cache_hit_rate();
+    // Issue #1571 (B5): additive observability fields (no existing field renamed).
+    let _: u64 = ms.block_cache_evictions;
+    let _: usize = ms.block_cache_capacity_bytes;
+    let _: u64 = ms.key_cache_hits;
+    let _: u64 = ms.key_cache_misses;
+    let _: u64 = ms.key_cache_evictions;
+    let _: usize = ms.key_cache_resident_bytes;
+    let _: usize = ms.key_cache_capacity_bytes;
+    let _: f64 = ms.key_cache_hit_rate();
 }
 
 /// Open a queryable `Database` over one fixture table, isolated in a temp dir so

--- a/cqlite-core/tests/issue_1593_io_offload_thread.rs
+++ b/cqlite-core/tests/issue_1593_io_offload_thread.rs
@@ -106,13 +106,29 @@ fn fixture_dir() -> Option<PathBuf> {
 /// Open the fixture with `use_mmap = true` so its scan uses the memory-mapped
 /// backend whose reads fault synchronously — the exact backend F3 must offload.
 async fn setup_db_mmap() -> Database {
+    let mut core_config = cqlite_core::Config::default();
+    core_config.storage.use_mmap = true;
+    setup_db_with_config(core_config).await
+}
+
+/// Open the fixture requesting the `Direct` (`O_DIRECT` / `F_NOCACHE`) backend,
+/// the OTHER synchronously-faulting backend F3 must offload (issue #1593). If the
+/// test filesystem refuses direct I/O the reader degrades to buffered at open
+/// (`faults_synchronously()` then returns false) — the calling test detects that
+/// via a `None` recorded I/O-read thread and skips rather than asserting on the
+/// buffered path.
+#[cfg(unix)]
+async fn setup_db_direct() -> Database {
+    let mut core_config = cqlite_core::Config::default();
+    core_config.storage.disk_access_mode = cqlite_core::config::DiskAccessMode::Direct;
+    setup_db_with_config(core_config).await
+}
+
+async fn setup_db_with_config(core_config: cqlite_core::Config) -> Database {
     let datasets_root = get_datasets_root().expect("CQLITE_DATASETS_ROOT");
     let schemas_dir = get_schemas_dir().expect("schemas dir");
     let schema_path = schemas_dir.join(SCHEMA_FILE);
     assert!(schema_path.exists(), "schema not found: {schema_path:?}");
-
-    let mut core_config = cqlite_core::Config::default();
-    core_config.storage.use_mmap = true;
 
     let config = IngestionConfig {
         schema_paths: vec![schema_path],
@@ -219,6 +235,86 @@ async fn mmap_scan_io_read_runs_off_async_worker_pool() {
          worker thread {io_read_thread:?} (one of {workers:?}) instead of a spawn_blocking \
          thread. mmap page faults / O_DIRECT preads block the polling thread inside poll_read, \
          so K concurrent cold scans would pin the whole async pool and stall warm point reads. \
+         Route the faulting-backend read loop onto spawn_blocking (F3)."
+    );
+}
+
+/// Companion to the mmap guard: the `Direct` (`O_DIRECT` / `F_NOCACHE`) backend is
+/// the OTHER `faults_synchronously()` backend that shares the identical
+/// `feed_raw_chunks_blocking` `spawn_blocking` feed path (coverage gap, roborev
+/// finding, issue #1593). It must likewise run its raw chunk read OFF the async
+/// worker pool.
+///
+/// UNIX-gated (there is no `O_DIRECT`/`F_NOCACHE` on non-unix). Direct I/O is NOT
+/// reliably provisionable in every test filesystem (tmpfs / overlayfs refuse
+/// `O_DIRECT`), and the reader degrades GRACEFULLY to buffered at open when it is
+/// refused. On that fallback the buffered feed runs inline on the async runtime by
+/// design (it is genuinely async and does NOT fault synchronously), and never
+/// records an I/O-read thread — so a recorded thread of `None` means "Direct was
+/// refused; buffered fallback in effect" and we SKIP (documented, not a silent
+/// omission) rather than asserting on a backend the environment could not provide.
+/// When Direct IS provisioned, the recorded read thread must be OFF the worker set,
+/// exactly like the mmap guard.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)] // keep == WORKER_THREADS
+async fn direct_scan_io_read_runs_off_async_worker_pool() {
+    let Some(_dir) = fixture_dir() else {
+        eprintln!(
+            "Skipping {KEYSPACE}.{TABLE}: no Data.db present (run fetch-datasets.sh). \
+             This guard is non-vacuous only with the real multi-chunk fixture."
+        );
+        return;
+    };
+
+    let workers = worker_thread_ids().await;
+    assert_eq!(
+        workers.len(),
+        WORKER_THREADS,
+        "expected to enumerate {WORKER_THREADS} distinct async worker threads, saw {}",
+        workers.len()
+    );
+
+    let db = setup_db_direct().await;
+    let sql = format!("SELECT * FROM {KEYSPACE}.{TABLE}");
+
+    scan_offload_probe::arm();
+    let rows = drain_one_scan(&db, &sql).await;
+    let io_read_thread = scan_offload_probe::recorded_io_read_thread();
+    scan_offload_probe::disarm();
+
+    // A present fixture must return rows regardless of backend.
+    assert!(
+        rows > 0,
+        "Issue #1593: {KEYSPACE}.{TABLE} is present but the streaming scan returned 0 rows — \
+         guard would be vacuous"
+    );
+
+    // No recorded I/O-read thread => the faulting-backend (spawn_blocking) feed
+    // path did not run: Direct was refused and the reader fell back to buffered
+    // (inline-on-async by design). Document and skip rather than fail — Direct is
+    // not reliably provisionable in every CI filesystem.
+    let Some(io_read_thread) = io_read_thread else {
+        eprintln!(
+            "Skipping Direct-backend offload assertion for {KEYSPACE}.{TABLE}: O_DIRECT/F_NOCACHE \
+             was refused here, so the reader degraded to the buffered (inline-on-async) backend \
+             (no I/O-read thread recorded). The Direct backend shares the identical \
+             feed_raw_chunks_blocking spawn_blocking path proven by the mmap guard \
+             (covered-by-construction); this environment could not exercise it directly."
+        );
+        return;
+    };
+
+    eprintln!(
+        "Issue #1593 Direct-backend I/O-offload guard: rows={rows} io_read_thread={io_read_thread:?} \
+         async_workers={workers:?}"
+    );
+
+    assert!(
+        !workers.contains(&io_read_thread),
+        "Issue #1593 REGRESSION: the Direct-backed windowed scan's raw chunk read ran on async \
+         worker thread {io_read_thread:?} (one of {workers:?}) instead of a spawn_blocking \
+         thread. O_DIRECT/F_NOCACHE preads block the polling thread inside poll_read, so K \
+         concurrent cold scans would pin the whole async pool and stall warm point reads. \
          Route the faulting-backend read loop onto spawn_blocking (F3)."
     );
 }

--- a/cqlite-core/tests/issue_1593_io_offload_thread.rs
+++ b/cqlite-core/tests/issue_1593_io_offload_thread.rs
@@ -1,0 +1,224 @@
+//! Issue #1593 (Epic F, F3): the windowed streaming scan must run its BLOCKING
+//! I/O — the raw chunk read on a synchronously-faulting backend (mmap page fault
+//! / `O_DIRECT` `pread`) — OFF the async worker pool, on a `spawn_blocking`
+//! thread.
+//!
+//! ## What this guards
+//!
+//! On the mmap and direct backends the disk I/O happens *inside* `poll_read`
+//! (`source.rs`), so reading them on a tokio async worker BLOCKS that worker for
+//! the duration of the disk read. `K` concurrent cold scans can pin every worker,
+//! stalling all warm point reads — the p99-diverges-under-mixed-load mechanism
+//! the July 2026 read-path audit (§Epic F / F3) named. The parse half was already
+//! moved to `spawn_blocking` (#1143); this closes the remaining gap on the I/O
+//! half for faulting backends.
+//!
+//! ## Why a thread-identity guard (not a wall-clock p99)
+//!
+//! Identical rationale to the #1143 parse-offload guard: absolute latency
+//! thresholds are machine-dependent and flaky, and the corpus fixtures are tiny,
+//! so a single scan never monopolizes a worker long enough to observe wall-clock
+//! starvation deterministically. This guard pins the MECHANISM directly: it
+//! records the `ThreadId` on which the scan's raw chunk read ran (via the
+//! `scan-offload-probe`, compiled only under the non-default feature so it never
+//! ships) and asserts that thread is NOT one of the async worker threads.
+//!   - inline-on-async-worker read (regressed / `main`): read runs ON a worker
+//!     → recorded thread is in the worker set → FAIL;
+//!   - `spawn_blocking` offload (fixed): read runs on a blocking-pool thread
+//!     → recorded thread is OUTSIDE the worker set → PASS.
+//!
+//! Requirements: `CQLITE_DATASETS_ROOT` pointing at `test-data/datasets` and the
+//! real multi-chunk `nb`-compressed fixture (skip-not-fail when absent; a present
+//! fixture returning zero rows is a FAILURE, never a vacuous pass).
+
+// Requires the non-default `scan-offload-probe` feature: it gates the probe
+// instrumentation this guard reads. The agent gate runs this binary with the
+// feature enabled.
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "scan-offload-probe"
+))]
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
+use std::thread::ThreadId;
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::sstable::reader::scan_stream_windowed::probe as scan_offload_probe;
+use cqlite_core::Database;
+
+const KEYSPACE: &str = "test_wide_rows";
+const TABLE: &str = "wide_partition_table";
+const SCHEMA_FILE: &str = "wide-rows.cql";
+/// Async worker threads on this test's runtime. MUST match the literal in the
+/// `#[tokio::test(... worker_threads = N)]` attribute below.
+const WORKER_THREADS: usize = 2;
+
+fn get_datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn get_schemas_dir() -> Option<PathBuf> {
+    if let Some(datasets_root) = get_datasets_root() {
+        if let Some(parent) = datasets_root.parent() {
+            let schemas_dir = parent.join("schemas");
+            if schemas_dir.exists() {
+                return Some(schemas_dir);
+            }
+        }
+    }
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    if schemas_dir.exists() {
+        return Some(schemas_dir);
+    }
+    None
+}
+
+/// Directory holding the fixture's SSTable components, if a Data.db is present.
+fn fixture_dir() -> Option<PathBuf> {
+    let root = get_datasets_root()?;
+    let table_root = root.join("sstables").join(KEYSPACE);
+    let entries = std::fs::read_dir(&table_root).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&format!("{TABLE}-"))
+            && entry.path().is_dir()
+            && std::fs::read_dir(entry.path()).ok()?.flatten().any(|f| {
+                f.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.ends_with("-Data.db"))
+            })
+        {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+/// Open the fixture with `use_mmap = true` so its scan uses the memory-mapped
+/// backend whose reads fault synchronously — the exact backend F3 must offload.
+async fn setup_db_mmap() -> Database {
+    let datasets_root = get_datasets_root().expect("CQLITE_DATASETS_ROOT");
+    let schemas_dir = get_schemas_dir().expect("schemas dir");
+    let schema_path = schemas_dir.join(SCHEMA_FILE);
+    assert!(schema_path.exists(), "schema not found: {schema_path:?}");
+
+    let mut core_config = cqlite_core::Config::default();
+    core_config.storage.use_mmap = true;
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir: datasets_root.join("sstables"),
+        version_hint: None,
+        core_config,
+        table_directory_filter: Some(format!("/{KEYSPACE}/")),
+    };
+    ingest(config)
+        .await
+        .expect("ingest wide_partition_table")
+        .database
+}
+
+/// Enumerate the runtime's async worker `ThreadId`s by parking exactly
+/// `WORKER_THREADS` tasks at a barrier so each must occupy a distinct worker.
+async fn worker_thread_ids() -> HashSet<ThreadId> {
+    let barrier = Arc::new(Barrier::new(WORKER_THREADS));
+    let mut handles = Vec::with_capacity(WORKER_THREADS);
+    for _ in 0..WORKER_THREADS {
+        let b = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            let id = std::thread::current().id();
+            b.wait();
+            id
+        }));
+    }
+    let mut ids = HashSet::new();
+    for h in handles {
+        ids.insert(h.await.expect("worker probe task"));
+    }
+    ids
+}
+
+/// Drain a single full streaming scan to completion, returning the row count.
+/// `buffer_size = 1` maximizes per-partition backpressure.
+async fn drain_one_scan(db: &Database, sql: &str) -> usize {
+    let config = StreamingConfig {
+        buffer_size: 1,
+        ..StreamingConfig::default()
+    };
+    let mut iter = db
+        .execute_streaming(sql, config)
+        .await
+        .expect("execute_streaming should succeed");
+    let mut n = 0usize;
+    while let Some(row) = iter.next_async().await {
+        row.expect("streamed row should be Ok");
+        n += 1;
+    }
+    n
+}
+
+/// The windowed streaming scan's blocking raw chunk read on an mmap backend must
+/// run off the async worker pool (on a `spawn_blocking` thread), not inline on a
+/// tokio worker.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)] // keep == WORKER_THREADS
+async fn mmap_scan_io_read_runs_off_async_worker_pool() {
+    let Some(_dir) = fixture_dir() else {
+        eprintln!(
+            "Skipping {KEYSPACE}.{TABLE}: no Data.db present (run fetch-datasets.sh). \
+             This guard is non-vacuous only with the real multi-chunk fixture."
+        );
+        return;
+    };
+
+    let workers = worker_thread_ids().await;
+    assert_eq!(
+        workers.len(),
+        WORKER_THREADS,
+        "expected to enumerate {WORKER_THREADS} distinct async worker threads, saw {}",
+        workers.len()
+    );
+
+    let db = setup_db_mmap().await;
+    let sql = format!("SELECT * FROM {KEYSPACE}.{TABLE}");
+
+    scan_offload_probe::arm();
+    let rows = drain_one_scan(&db, &sql).await;
+    let io_read_thread = scan_offload_probe::recorded_io_read_thread();
+    scan_offload_probe::disarm();
+
+    // Non-vacuous: a present fixture must return rows AND must have routed through
+    // the windowed (chunk-stitching) scan path that records the I/O read thread.
+    assert!(
+        rows > 0,
+        "Issue #1593: {KEYSPACE}.{TABLE} is present but the streaming scan returned 0 rows — \
+         guard would be vacuous"
+    );
+    let io_read_thread = io_read_thread.expect(
+        "Issue #1593: scan_offload_probe recorded no I/O read thread — either the windowed \
+         (chunk-stitching) scan path did not run, or the mmap backend was not selected \
+         (file below mmap_min_size_bytes?). The guard must exercise the faulting-backend feed.",
+    );
+
+    eprintln!(
+        "Issue #1593 I/O-offload guard: rows={rows} io_read_thread={io_read_thread:?} \
+         async_workers={workers:?}"
+    );
+
+    assert!(
+        !workers.contains(&io_read_thread),
+        "Issue #1593 REGRESSION: the mmap-backed windowed scan's raw chunk read ran on async \
+         worker thread {io_read_thread:?} (one of {workers:?}) instead of a spawn_blocking \
+         thread. mmap page faults / O_DIRECT preads block the polling thread inside poll_read, \
+         so K concurrent cold scans would pin the whole async pool and stall warm point reads. \
+         Route the faulting-backend read loop onto spawn_blocking (F3)."
+    );
+}

--- a/cqlite-core/tests/issue_1593_mmap_scan_parity.rs
+++ b/cqlite-core/tests/issue_1593_mmap_scan_parity.rs
@@ -1,0 +1,163 @@
+//! Issue #1593 (Epic F, F3): moving the mmap/`O_DIRECT` scan read off the async
+//! worker pool is a SCHEDULING change, not a data change — it must not perturb a
+//! single row.
+//!
+//! This parity guard scans the same real multi-chunk fixture twice — once via a
+//! reader opened with the memory-mapped backend (`use_mmap = true`, the faulting
+//! backend F3 now feeds on a `spawn_blocking` thread) and once via the default
+//! buffered backend (fed inline on the async runtime) — and asserts the two full
+//! streaming scans return the identical row set in the identical order.
+//!
+//! Skip-not-fail when the fixture Data.db is absent; a present fixture returning
+//! zero rows is a FAILURE (never a vacuous pass).
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::PathBuf;
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::{Database, Value};
+
+const KEYSPACE: &str = "test_wide_rows";
+const TABLE: &str = "wide_partition_table";
+const SCHEMA_FILE: &str = "wide-rows.cql";
+
+fn get_datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn get_schemas_dir() -> Option<PathBuf> {
+    if let Some(datasets_root) = get_datasets_root() {
+        if let Some(parent) = datasets_root.parent() {
+            let schemas_dir = parent.join("schemas");
+            if schemas_dir.exists() {
+                return Some(schemas_dir);
+            }
+        }
+    }
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    schemas_dir.exists().then_some(schemas_dir)
+}
+
+fn fixture_present() -> bool {
+    let Some(root) = get_datasets_root() else {
+        return false;
+    };
+    let table_root = root.join("sstables").join(KEYSPACE);
+    let Ok(entries) = std::fs::read_dir(&table_root) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&format!("{TABLE}-"))
+            && entry.path().is_dir()
+            && std::fs::read_dir(entry.path())
+                .ok()
+                .map(|mut d| {
+                    d.any(|f| {
+                        f.ok()
+                            .and_then(|f| f.file_name().to_str().map(|n| n.ends_with("-Data.db")))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+async fn open_db(use_mmap: bool) -> Database {
+    let datasets_root = get_datasets_root().expect("CQLITE_DATASETS_ROOT");
+    let schemas_dir = get_schemas_dir().expect("schemas dir");
+    let schema_path = schemas_dir.join(SCHEMA_FILE);
+    assert!(schema_path.exists(), "schema not found: {schema_path:?}");
+
+    let mut core_config = cqlite_core::Config::default();
+    core_config.storage.use_mmap = use_mmap;
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir: datasets_root.join("sstables"),
+        version_hint: None,
+        core_config,
+        table_directory_filter: Some(format!("/{KEYSPACE}/")),
+    };
+    ingest(config)
+        .await
+        .expect("ingest wide_partition_table")
+        .database
+}
+
+/// Collect the full streaming scan as an ordered list of `(partition_key, name)`
+/// where `name` is the first text/uuid-ish identity column present. We compare
+/// the *entire ordered projection dictionary* rather than a single column so the
+/// parity is over the whole row, not a proxy.
+async fn scan_rows(db: &Database, sql: &str) -> Vec<Vec<(String, String)>> {
+    let config = StreamingConfig {
+        buffer_size: 4,
+        ..StreamingConfig::default()
+    };
+    let mut iter = db
+        .execute_streaming(sql, config)
+        .await
+        .expect("execute_streaming");
+    let mut rows = Vec::new();
+    while let Some(row) = iter.next_async().await {
+        let row = row.expect("streamed row Ok");
+        let mut cols: Vec<(String, String)> = row
+            .values
+            .iter()
+            .map(|(k, v)| (k.to_string(), format_value(v)))
+            .collect();
+        cols.sort_by(|a, b| a.0.cmp(&b.0));
+        rows.push(cols);
+    }
+    rows
+}
+
+fn format_value(v: &Value) -> String {
+    // A stable, total textual rendering sufficient for equality comparison.
+    format!("{v:?}")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mmap_and_buffered_scans_return_identical_rows() {
+    if !fixture_present() {
+        eprintln!("Skipping {KEYSPACE}.{TABLE}: no Data.db present (run fetch-datasets.sh).");
+        return;
+    }
+
+    let sql = format!("SELECT * FROM {KEYSPACE}.{TABLE}");
+
+    let buffered_db = open_db(false).await;
+    let buffered_rows = scan_rows(&buffered_db, &sql).await;
+
+    let mmap_db = open_db(true).await;
+    let mmap_rows = scan_rows(&mmap_db, &sql).await;
+
+    assert!(
+        !buffered_rows.is_empty(),
+        "Issue #1593: {KEYSPACE}.{TABLE} present but buffered scan returned 0 rows — vacuous"
+    );
+    assert_eq!(
+        buffered_rows.len(),
+        mmap_rows.len(),
+        "Issue #1593: mmap scan row count {} != buffered {} — the F3 scheduling change altered \
+         the emitted row set",
+        mmap_rows.len(),
+        buffered_rows.len()
+    );
+    assert_eq!(
+        buffered_rows, mmap_rows,
+        "Issue #1593: mmap scan produced a different ordered row set than the buffered scan — \
+         the F3 scheduling change must be data-transparent"
+    );
+}

--- a/cqlite-core/tests/issue_1618_parser_work_counters.rs
+++ b/cqlite-core/tests/issue_1618_parser_work_counters.rs
@@ -376,12 +376,15 @@ async fn scan_boundary_peek_does_not_try_parse_per_row() {
     );
 }
 
-/// Scenario (K2/L currency): the shared display-row builder sorts each row's cells
-/// once, so `ROW_SORT_INVOCATIONS` is at least the number of returned live rows.
-/// K2/L (cells arrive pre-sorted) flip this to prove no per-row sort.
+/// Scenario (K3 delivered, issue #1642): the decoder emits each row's cells
+/// positionally in serialization-header column order, so the shared display-row
+/// builder performs NO per-row sort — `ROW_SORT_INVOCATIONS == 0` on a full scan.
+/// This flipped the former `>= rows` currency assertion when K3 landed; the
+/// dedicated wiring-evidence across column shapes lives in
+/// `issue_1642_positional_row_emit.rs`.
 #[tokio::test]
 #[serial]
-async fn scan_sorts_cells_per_row() {
+async fn scan_does_not_sort_cells_per_row() {
     if !fixture_data_present("test_basic", "simple_table") {
         eprintln!("Skipping (H5 wiring): test_basic/simple_table Data.db not present");
         return;
@@ -407,13 +410,11 @@ async fn scan_sorts_cells_per_row() {
 
     let sorts = rwc::row_sort_invocations();
     eprintln!("H5: rows={rows} ROW_SORT_INVOCATIONS={sorts}");
-    // Every returned live row required exactly one per-row cell sort today; markers
-    // (filtered out of the result) require none, so sorts is at least the returned
-    // live-row count.
-    assert!(
-        sorts >= rows,
-        "H5: the display-row builder sorts each live row's cells (>= rows); got \
-         {sorts} for {rows} rows"
+    // K3 (issue #1642): positional emit means zero per-row cell sorts. Any
+    // reintroduced per-row sort must call `record_row_sort` and would flip this red.
+    assert_eq!(
+        sorts, 0,
+        "K3: positional emit performs zero per-row cell sorts; got {sorts} for {rows} rows"
     );
 }
 

--- a/cqlite-core/tests/issue_1642_positional_row_emit.rs
+++ b/cqlite-core/tests/issue_1642_positional_row_emit.rs
@@ -1,0 +1,256 @@
+//! Issue #1642 (Epic K / K3): positional row emit — the row decoder builds each
+//! row's cells directly in serialization-header (schema) column order, so the
+//! shared display-row builder no longer allocates a per-row `HashMap` and no
+//! longer runs a per-row alphabetical `sort_by` to hide `HashMap` iteration
+//! nondeterminism. Determinism now comes from CONSTRUCTION.
+//!
+//! Wiring-evidence against real fixtures across the four column shapes
+//! (simple / static / collections / wide). The headline assertion is the H5
+//! `ROW_SORT_INVOCATIONS == 0` counter (Issue #1618): on `main`/pre-K3 the
+//! shared `build_display_row` bumped it once per returned live row, so these
+//! assertions FAIL before K3 lands and PASS after.
+//!
+//! Observable output is BYTE-IDENTICAL across K3: the public query result is a
+//! name-keyed `HashMap` (`QueryRow.values`), so the INTERNAL emit order is not
+//! user-visible — the 33-table parity/goldens harness is the end-to-end truth.
+//! This file additionally proves determinism-by-construction directly: two scans
+//! of the same fixture yield the identical column set with ZERO sort calls.
+//!
+//! Compiled only with `--features work-counters` (the getters/`reset` and the
+//! counter bodies live behind that feature; see `read_work_counters`). Requires
+//! `CQLITE_DATASETS_ROOT` + fetched binaries; skips (never fails) when a fixture
+//! is absent. Excluded under `tombstones` (that build serves reads via a
+//! full-scan filter path). Serialized on the shared counter mutex.
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::sstable::read_work_counters as rwc;
+use cqlite_core::Database;
+use serial_test::serial;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        if let Some(dir) = root.parent().and_then(|p| {
+            let d = p.join("schemas");
+            d.exists().then_some(d)
+        }) {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+/// True if `<datasets>/sstables/<keyspace>/<table>-*/` holds a `*-Data.db` file.
+/// Skip keys off fixture presence (not a 0-row result), so a present fixture that
+/// yields 0 rows stays a hard failure.
+fn fixture_data_present(keyspace: &str, table: &str) -> bool {
+    let Some(root) = datasets_root() else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(root.join("sstables").join(keyspace)) else {
+        return false;
+    };
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        if let Ok(files) = std::fs::read_dir(e.path()) {
+            for f in files.flatten() {
+                if f.file_name().to_string_lossy().ends_with("-Data.db") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Ingest a single fixture table and return a fresh `Database`. Returns `None`
+/// when the fixture / schema is absent.
+async fn setup(keyspace: &str, schema_file: &str) -> Option<Database> {
+    let root = datasets_root()?;
+    let schema_path = schemas_dir()?.join(schema_file);
+    if !schema_path.exists() {
+        return None;
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return None;
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: Some("5.0".to_string()),
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    };
+    let result = ingest(config).await.ok()?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return None;
+    }
+    Some(result.database)
+}
+
+/// Scan one table and return `(returned_row_count, row_sort_invocations)` measured
+/// around the scan. Resets the shared counter first so a parallel test's value can
+/// never satisfy the assertion (serialized by `#[serial]`).
+async fn scan_and_count_sorts(db: &Database, sql: &str) -> (u64, u64) {
+    rwc::reset();
+    assert_eq!(
+        rwc::row_sort_invocations(),
+        0,
+        "reset must zero ROW_SORT_INVOCATIONS"
+    );
+    let scan = db.execute(sql).await.expect("scan must succeed");
+    let rows = scan.rows.len() as u64;
+    let sorts = rwc::row_sort_invocations();
+    (rows, sorts)
+}
+
+/// K3 headline (simple table): a full scan returns live rows but performs ZERO
+/// per-row cell sorts — the decoder emits cells pre-ordered by construction.
+/// FAILS on `main`/pre-K3 (the shared builder sorts once per returned row).
+#[tokio::test]
+#[serial]
+async fn full_scan_does_no_per_row_sort_simple() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (K3 wiring): test_basic/simple_table Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (K3 wiring): could not ingest test_basic");
+        return;
+    };
+
+    let (rows, sorts) = scan_and_count_sorts(&db, "SELECT * FROM test_basic.simple_table").await;
+    eprintln!("K3: rows={rows} ROW_SORT_INVOCATIONS={sorts}");
+    assert!(rows > 0, "present fixture must return rows");
+    assert_eq!(
+        sorts, 0,
+        "K3: positional emit must perform ZERO per-row cell sorts on a full scan; \
+         got {sorts} for {rows} rows"
+    );
+}
+
+/// K3 across column shapes: static, collection, and wide-partition tables all
+/// emit rows with zero per-row sorts. Each shape is skipped independently when its
+/// fixture is absent (never fails on absence). A shape that IS present and returns
+/// rows must record zero sorts.
+#[tokio::test]
+#[serial]
+async fn positional_emit_across_column_shapes() {
+    // (keyspace, schema, table, sql) — one per column shape.
+    let cases = [
+        (
+            "test_basic",
+            "basic-types.cql",
+            "static_columns_table",
+            "SELECT * FROM test_basic.static_columns_table",
+        ),
+        (
+            "test_collections",
+            "collections.cql",
+            "collection_table",
+            "SELECT * FROM test_collections.collection_table",
+        ),
+        (
+            "test_wide_rows",
+            "wide-rows.cql",
+            "wide_partition_table",
+            "SELECT * FROM test_wide_rows.wide_partition_table",
+        ),
+    ];
+
+    let mut exercised = 0usize;
+    for (ks, schema, table, sql) in cases {
+        if !fixture_data_present(ks, table) {
+            eprintln!("Skipping shape {ks}.{table} (Data.db not present)");
+            continue;
+        }
+        let Some(db) = setup(ks, schema).await else {
+            eprintln!("Skipping shape {ks}.{table} (could not ingest)");
+            continue;
+        };
+        let (rows, sorts) = scan_and_count_sorts(&db, sql).await;
+        eprintln!("K3 shape {ks}.{table}: rows={rows} ROW_SORT_INVOCATIONS={sorts}");
+        assert!(rows > 0, "present fixture {ks}.{table} must return rows");
+        assert_eq!(
+            sorts, 0,
+            "K3: shape {ks}.{table} must perform ZERO per-row sorts; got {sorts} for {rows} rows"
+        );
+        exercised += 1;
+    }
+
+    if exercised == 0 {
+        eprintln!("Skipping (K3 wiring): no multi-shape fixtures present");
+    }
+}
+
+/// Determinism-by-construction: two independent scans of the same fixture yield
+/// the identical per-row column set, and BOTH perform zero per-row sorts. This is
+/// the guarantee that replaced the per-row alphabetical sort — the emit order is
+/// fixed by the serialization header, not by `HashMap` iteration.
+#[tokio::test]
+#[serial]
+async fn two_scans_identical_columns_without_sort() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (K3 wiring): test_basic/simple_table Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (K3 wiring): could not ingest test_basic");
+        return;
+    };
+
+    let sql = "SELECT * FROM test_basic.simple_table";
+
+    rwc::reset();
+    let scan_a = db.execute(sql).await.expect("first scan");
+    let sorts_a = rwc::row_sort_invocations();
+
+    rwc::reset();
+    let scan_b = db.execute(sql).await.expect("second scan");
+    let sorts_b = rwc::row_sort_invocations();
+
+    assert!(!scan_a.rows.is_empty(), "present fixture must return rows");
+    assert_eq!(
+        scan_a.rows.len(),
+        scan_b.rows.len(),
+        "two scans must return the same row count"
+    );
+    assert_eq!(sorts_a, 0, "first scan must perform zero per-row sorts");
+    assert_eq!(sorts_b, 0, "second scan must perform zero per-row sorts");
+
+    // The column SET per row is identical across scans (order in the public
+    // name-keyed result is not observable, so compare the canonical set).
+    let columns = |scan: &cqlite_core::QueryResult| -> Vec<BTreeSet<String>> {
+        scan.rows
+            .iter()
+            .map(|r| r.values.keys().map(|k| k.to_string()).collect())
+            .collect()
+    };
+    assert_eq!(
+        columns(&scan_a),
+        columns(&scan_b),
+        "two scans must surface the identical per-row column set"
+    );
+}

--- a/cqlite-core/tests/issue_1642_positional_row_emit.rs
+++ b/cqlite-core/tests/issue_1642_positional_row_emit.rs
@@ -206,9 +206,12 @@ async fn positional_emit_across_column_shapes() {
 }
 
 /// Determinism-by-construction: two independent scans of the same fixture yield
-/// the identical per-row column set, and BOTH perform zero per-row sorts. This is
-/// the guarantee that replaced the per-row alphabetical sort — the emit order is
-/// fixed by the serialization header, not by `HashMap` iteration.
+/// the identical per-row column SET, and BOTH perform zero per-row sorts (the
+/// per-row alphabetical sort that this change removed). This asserts stability of
+/// the surfaced column set plus the zero-sort guarantee; it does NOT observe emit
+/// ORDER, because the public result is a name-keyed map (issue #1334) whose
+/// key iteration order is not the positional emit order — cross-scan positional
+/// order is unobservable at this layer.
 #[tokio::test]
 #[serial]
 async fn two_scans_identical_columns_without_sort() {

--- a/cqlite-core/tests/tail_latency_harness.rs
+++ b/cqlite-core/tests/tail_latency_harness.rs
@@ -196,6 +196,51 @@ fn mixed_p99_bounded_by_k_times_baseline() {
     );
 }
 
+/// F3 cold-mixed-load gate (issue #1593): point-read p99 under a concurrent
+/// **mmap** background scan must stay within `K` × the scan-free baseline p99.
+///
+/// This is the ratio the F3 offload protects: on the mmap backend the background
+/// scan's reads fault synchronously, so before F3 they blocked the async workers
+/// and convoyed the foreground point reads; after F3 that read loop runs on a
+/// `spawn_blocking` thread and the convoy is bounded. Like the buffered convoy
+/// bound above, this gates on a **ratio** to a same-run baseline (never a
+/// wall-clock absolute), so shared-runner / oversubscribed-CPU noise cannot flap
+/// it. `K` is the same generous convoy headroom constant. The full `agent-gate.sh`
+/// runs components serially (issue #1825), so this is never measured under a
+/// competing gate on the same box. The deterministic thread-identity guard
+/// (`issue_1593_io_offload_thread.rs`) is the primary, timing-free F3 proof; this
+/// ratio bound is the secondary tail watch.
+#[cfg(feature = "cli-helpers")]
+#[serial_test::serial]
+#[test]
+fn cold_mmap_mixed_p99_bounded_by_k_times_baseline() {
+    use fixtures::ReadFixture;
+
+    if !fixtures::fixture_present(&ReadFixture::SIMPLE) {
+        eprintln!("tail_latency test: SIMPLE fixture absent — skipping (fetch datasets)");
+        return;
+    }
+
+    let report =
+        harness::run_mmap(ReadFixture::SIMPLE).expect("mmap harness run on present fixture");
+
+    assert!(report.mixed.p50 <= report.mixed.p99 && report.mixed.p99 <= report.mixed.p999);
+    assert!(
+        report.scan_free.p50 <= report.scan_free.p99
+            && report.scan_free.p99 <= report.scan_free.p999
+    );
+
+    let bound = K * (report.scan_free.p99 as f64);
+    assert!(
+        (report.mixed.p99 as f64) <= bound,
+        "cold mmap mixed p99 {} exceeded K({K}) * scan_free p99 {} = {bound} \
+         (p99_mixed_over_scan_free = {:.2}) — F3 offload regressed?",
+        report.mixed.p99,
+        report.scan_free.p99,
+        report.p99_mixed_over_scan_free
+    );
+}
+
 #[cfg(feature = "cli-helpers")]
 #[serial_test::serial]
 #[test]

--- a/openspec/changes/blocking-io-off-async/design.md
+++ b/openspec/changes/blocking-io-off-async/design.md
@@ -1,0 +1,83 @@
+# Design — Blocking I/O off async workers (F3)
+
+## Context
+
+`run_scan_stream_windowed` (`scan_stream_windowed.rs`) is a three-stage bounded pipeline:
+
+1. **Async I/O half** (in `run_scan_stream_windowed`): `loop { read_next_block(cursor).await → raw_tx.send(chunk).await }`.
+2. **Blocking parse half** (`drain_scan_window_blocking`, a `spawn_blocking` task, issue #1143): decompress + parse + batch → `batch_tx.blocking_send`.
+3. **Async forwarder** (a `tokio::spawn`): flatten batches into the caller's per-item channel.
+
+Stage 2's CPU is already off the async workers. Stage 1's **read** is the F3 gap: for the
+`Buffered` backend the read is real async `tokio::fs` I/O (reactor-driven, must stay on the
+runtime); for the `Mapped` and `Direct` backends `poll_read` performs the blocking work
+**synchronously** (mmap page-fault copy / `O_DIRECT` `pread`) and returns `Poll::Ready`, so
+the `await` never yields — it just blocks the polling worker for the duration of the disk
+I/O.
+
+## Decision: offload the whole per-scan I/O loop for faulting backends (mechanic (b))
+
+When the cursor's backend faults synchronously (`Mapped` / `Direct`), run the **entire**
+I/O feed loop on one dedicated `spawn_blocking` thread that reads chunks and hands them to
+the existing bounded `raw` channel via `blocking_send` (backpressure preserved: a full
+channel parks the blocking thread; the parse half drains it). The `Buffered` backend keeps
+the existing inline async loop unchanged.
+
+**One offload per scan, not per chunk.** Mirrors the parse half's single `spawn_blocking`.
+Per-chunk `spawn_blocking` would re-introduce the over-spawn cost F3's guardrail warns
+against ("do not degrade warm-path latency by over-spawning"; per-scan admission is F4).
+
+**Why `spawn_blocking` + `futures::executor::block_on`, not `block_in_place` or a nested tokio runtime:**
+
+- `tokio::task::block_in_place` panics on a current-thread runtime, and `scan_stream` is
+  reachable from current-thread runtimes (the CLI/bindings/harness build them). Not safe
+  universally.
+- `tokio::runtime::Handle::current().block_on(...)` and building a nested `Runtime` both
+  panic from within a runtime context (a `spawn_blocking` thread has the runtime context
+  entered). Not usable there.
+- `futures::executor::block_on` (crate already a dependency) is a plain thread-parking
+  executor with **no tokio involvement**, so it does not trip the nested-runtime guard and
+  drives the read future to completion on the blocking thread.
+
+**Soundness invariant (documented at the call site):** driving `read_next_block` under
+`futures::executor::block_on` is sound **only** because the mmap/direct per-chunk read path
+touches **no** tokio reactor/timer primitive: the per-scan cursor's `tokio::sync::Mutex` is
+executor-agnostic (semaphore + wakers, no reactor); the `MmapCursor`/`DirectCursor`
+`poll_read`/`poll_complete` are pure synchronous memory/`pread` ops; the CRC digest is
+preloaded into memory at open (`CrcDb` holds a `Vec<u32>`, no per-chunk `tokio::fs`); and
+`retry_transient_once` re-seeks + retries with **no** `tokio::time` sleep. This path is
+never taken for `Buffered` (which does use `tokio::fs` and stays on the reactor). The
+invariant is asserted structurally by the offload decision keying on the **actual** cursor
+backend, not the configured intent (a `Direct` request that falls back to `Buffered` at
+open is read inline, never under `block_on`).
+
+### Data ownership for the offload
+
+`spawn_blocking` requires `'static`. The loop needs: `Arc<Self>` (reader — clone), the
+cursor's `Arc<Mutex<BlockSource>>` (clone), the cursor's chunk index, the `raw_tx` sender
+(clone), and the `io_failed` flag (`Arc`). `ScanCursor::chunk_index` becomes
+`Arc<AtomicUsize>` so it can be shared into the blocking task while the cursor stays usable;
+this keeps `ScanCursor` at 16 bytes on 64-bit (two pointers), so the existing size pin holds
+unchanged. The blocking task returns the terminal `io_err` (if any); dropping the moved
+`raw_tx` when it returns still signals clean EOF to the parse half exactly as the async loop
+does.
+
+## Testing strategy (robust against flakiness — issue guardrail)
+
+The `mixed_p99_bounded_by_k_times_baseline` family is known to flake under CPU
+oversubscription, so the **primary gate is deterministic and timing-free**:
+
+- **Worker-starvation / offload thread-identity guard** (primary, deterministic): mirror the
+  #1143 parse-offload guard. On a fixed 2-worker runtime, open the real multi-chunk fixture
+  with `use_mmap = true`, arm a probe, run one full streaming scan, and assert the recorded
+  **I/O read thread** is NOT in the enumerated async-worker set. RED on `main` (read runs on
+  a worker); GREEN after the offload. No wall-clock threshold; compiled only under the
+  existing non-default `scan-offload-probe` feature so the instrumentation never ships.
+- **Correctness**: the mmap-backed streaming scan returns the identical row set as the
+  buffered-backed scan (proves the scheduling change did not perturb data).
+- **Cold-mixed-load harness ratio** (secondary): reuse the A2 harness with `use_mmap = true`
+  and assert `mixed.p99 <= K × scan_free.p99` — a **ratio** to a measured baseline captured
+  in the same window, never an absolute. Gated skip-not-fail without the fixture.
+
+The full `agent-gate.sh` runs components **serially** (capped machine-wide concurrency,
+issue #1825), so the ratio gate is never measured under a competing gate on the same box.

--- a/openspec/changes/blocking-io-off-async/proposal.md
+++ b/openspec/changes/blocking-io-off-async/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The July 2026 read-path audit (`docs/reports/read-path-performance-audit-2026-07-01.md`
+§Epic F, child **F3** — "Blocking I/O off async workers") found that on the **mmap** and
+**O_DIRECT** scan backends the blocking work runs **inline in `poll_read` on tokio worker
+threads** (`cqlite-core/src/storage/sstable/reader/source.rs` — the code comments admit
+it): an mmap page fault (cold data = a synchronous disk read inside a memory access) and an
+`O_DIRECT` `pread` block the async worker that polls them. `K` concurrent cold scans can
+pin **all** async workers, stalling every warm point read behind disk I/O — the
+p99-diverges-under-mixed-load mechanism the audit's capstone decision #2 turns on.
+
+The windowed streaming scan already offloads its CPU-bound **decompress + parse** half to a
+`spawn_blocking` thread (issue #1143), but the **I/O half** still `await`s
+`read_next_block` on the async runtime. For the buffered backend that read is genuinely
+async (`tokio::fs`, driven by the reactor — correct, leave it). For mmap/direct it is
+synchronous blocking work masquerading as an `await` that never yields, so it runs to
+completion on — and starves — the worker.
+
+**Routing: design-driven, owner-pre-decided.** The read-path performance audit is the
+source of truth and carries a standing owner Seam-1 approval (audit capstone §5 decision
+#2, 2026-07-01). This change encodes F3's locked posture with **no new design latitude**.
+The audit offered two mechanics: (a) land C2's sync-core `ReadAt` direction for the scan
+reads, or (b) route the faulting/blocking section through the blocking half. We take **(b)**
+(see `design.md` for why (a) is a larger refactor deliberately out of scope here).
+
+Milestone: **v0.14 perf wave** (Epic F, Wave 3, after C2). No change to any read result —
+this is a scheduling change, not a data change.
+
+## What Changes
+
+- The windowed streaming scan's **I/O feed loop** no longer runs the blocking chunk read on
+  an async worker when the scan backend faults synchronously (mmap / `O_DIRECT`). For those
+  backends the whole per-scan read loop runs on a dedicated `spawn_blocking` thread, feeding
+  the same bounded raw-chunk channel the parse half already consumes; the buffered backend's
+  genuinely-async read stays inline on the runtime.
+- A new **cold-mixed-load / worker-starvation gate** proves the mechanism directly and
+  deterministically (thread-identity, not wall-clock): under a real mmap-backed scan the
+  blocking chunk read executes on a `spawn_blocking` thread, **not** on any async worker
+  thread. This mirrors the existing #1143 parse-offload guard, so it inherits the same
+  no-flake, no-timing property.
+- The A2 mixed-load tail-latency harness gains a **ratio-bounded** (never wall-clock
+  absolute) assertion for the cold mmap backend, wired advisory→enforcing under the same
+  policy as the existing convoy bound.
+- The new gate component / `--test` target is wired into `scripts/agent-gate.sh` following
+  the existing scan-offload guard's pattern.
+
+## Non-goals
+
+- **Do NOT flip the `use_mmap` default.** Decision #2 gates the default flip on this gate
+  existing and proving a p99 win first; the buffered-vs-mmap comparison numbers are reported
+  to the owner separately. This change only makes the mmap/direct path non-starving.
+- **Blocking-pool admission control** (per-scan `spawn_blocking` count / semaphore capping)
+  is **F4's** scope, coordinated separately — not changed here.
+- **Hardware-sympathy advice** (`madvise`/`fadvise`) is **F6's** scope; the #1143 measured
+  "no madvise in Auto for scans" decision is left intact.
+- **The C2 sync-core `ReadAt` trait refactor** (mechanic (a)) is a separate architectural
+  change; this change does not undertake it.
+- No change to scan output: the emitted row set/order/tombstone filtering is byte-identical.

--- a/openspec/changes/blocking-io-off-async/specs/scan-io-scheduling/spec.md
+++ b/openspec/changes/blocking-io-off-async/specs/scan-io-scheduling/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Blocking scan I/O does not execute on an async worker thread
+
+The windowed streaming scan SHALL NOT run a synchronously-faulting backend's raw chunk read
+on any tokio async worker thread. When the scan reads from a backend that faults
+synchronously (a memory-mapped file, whose first access to a cold page is a blocking disk
+read, or an `O_DIRECT`/`F_NOCACHE` cursor, whose `pread` is a blocking uncached disk read),
+the raw chunk read SHALL execute on a `spawn_blocking` thread. The buffered backend's
+genuinely-async `tokio::fs` read SHALL continue to run inline on the async runtime (it is
+reactor-driven and non-blocking). The offload decision SHALL key on the scan cursor's ACTUAL
+backend, so a non-buffered request that gracefully degrades to buffered I/O at open is read
+inline and is never driven under a non-tokio executor.
+
+#### Scenario: mmap-backed scan reads off the async worker pool
+- **WHEN** a full streaming scan runs over a real multi-chunk SSTable fixture opened with `use_mmap = true`, on a fixed-size async worker runtime with the `scan-offload-probe` instrumentation armed
+- **THEN** the fixture returns a non-zero row count AND the `ThreadId` recorded for the scan's raw chunk read is not any of the enumerated async worker thread ids (it is a `spawn_blocking` thread)
+
+#### Scenario: buffered-backed scan read stays on the async runtime
+- **WHEN** a full streaming scan runs over the same fixture opened with the default buffered backend
+- **THEN** the scan completes and returns the identical row set, and the buffered read path is not offloaded (its genuinely-async `tokio::fs` read remains driven by the runtime reactor)
+
+### Requirement: The scheduling change preserves scan results exactly
+
+Moving the blocking read off the async workers SHALL NOT change any scan output. A windowed
+streaming scan over an mmap-backed reader SHALL emit the byte-identical row set, order, and
+tombstone filtering as the same scan over a buffered-backed reader, and the scan's error
+propagation (a mid-stream read error surfaces as a terminal stream item and suppresses the
+partial trailing-window emit) SHALL be unchanged.
+
+#### Scenario: mmap and buffered scans return identical rows
+- **WHEN** the same table is scanned once via a reader opened with `use_mmap = true` and once via a buffered reader
+- **THEN** the two scans return the same number of rows and the same row keys in the same order
+
+### Requirement: The mixed-load tail latency stays bounded by a ratio, not a wall clock
+
+The cold-mixed-load tail-latency gate SHALL bound the point-read p99 under a concurrent mmap
+scan by a MULTIPLE `K` of the measured scan-free baseline p99 captured in the same run, never
+by an absolute wall-clock threshold, so shared-runner / oversubscribed-CPU noise cannot flap
+it. The gate SHALL capture the measurement window such that the background scan is
+demonstrably live across all sampled point reads, and SHALL skip (not fail) when the fixture
+binary is absent while failing loudly if a present fixture yields zero rows.
+
+#### Scenario: cold mmap mixed-load p99 is within K× the scan-free baseline
+- **WHEN** the tail-latency harness runs point reads against an mmap-backed fixture both scan-free and under a continuous background full-table scan
+- **THEN** the mixed-load point-read p99 is at most `K ×` the scan-free baseline p99 measured in the same run, and the assertion is expressed as that ratio rather than any absolute nanosecond bound
+
+#### Scenario: the gate is deterministic about fixture presence
+- **WHEN** the fixture binary is not present in the datasets root
+- **THEN** the gate skips with a message rather than failing, and when the fixture IS present but returns zero rows the harness panics loudly rather than reporting a vacuous pass
+
+### Requirement: The offload gate is wired into the agent gate
+
+The deterministic worker-starvation / I/O-offload guard SHALL be executed by
+`scripts/agent-gate.sh` (added as a component or as a `--test` target of an existing
+component that already enables the required features), following the existing scan-offload
+guard's pattern, so the guard actually runs in the pre-merge gate rather than existing only
+as an un-invoked test.
+
+#### Scenario: the guard runs under the gate
+- **WHEN** `scripts/agent-gate.sh` executes
+- **THEN** the F3 I/O-offload guard test is among the tests it runs (built with the `scan-offload-probe` + `cli-helpers` features it requires), and a regression that runs the blocking read back on an async worker fails the gate

--- a/openspec/changes/blocking-io-off-async/tasks.md
+++ b/openspec/changes/blocking-io-off-async/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — Blocking I/O off async workers (F3)
+
+## 1. TDD: red guard first
+- [ ] 1.1 Add an I/O-read thread-identity probe hook to the `scan-offload-probe` module
+  (`record_io_read_thread` / `recorded_io_read_thread`), mirroring `record_parse_thread`.
+- [ ] 1.2 Write `tests/issue_1593_io_offload_thread.rs`: open the multi-chunk fixture with
+  `use_mmap = true`, run one full streaming scan on a fixed 2-worker runtime, assert the
+  recorded I/O read thread is NOT an async worker. Confirm it is RED on `main`.
+  *Surface exercised:* `SSTableReader::run_scan_stream_windowed` I/O half via `execute_streaming`.
+
+## 2. Implement the offload
+- [ ] 2.1 `source.rs`: add `BlockSource::faults_synchronously()` (Mapped/Direct → true,
+  Buffered → false); change `ScanCursor::chunk_index` to `Arc<AtomicUsize>` (size pin holds);
+  update `ScanCursor::new`.
+- [ ] 2.2 `data_access/mod.rs`: add `read_next_block_parts(&self, file, chunk_index)` and
+  delegate `read_next_block` to it (so the blocking loop can call it with shared Arcs).
+- [ ] 2.3 `scan_stream_windowed.rs`: determine the actual backend once (lock the cursor);
+  for a faulting backend run the I/O feed loop on one `spawn_blocking` task
+  (`futures::executor::block_on` + `blocking_send`, `io_failed` store, returns terminal
+  `io_err`); leave the buffered path as the existing inline async loop. Fire the
+  `record_io_read_thread` probe in the blocking loop. Document the reactor-free soundness
+  invariant at the `block_on` call site.
+
+## 3. Correctness + ratio harness
+- [ ] 3.1 Add a correctness test: mmap-backed scan returns the identical row set as buffered.
+- [ ] 3.2 Extend the A2 tail-latency harness with a cold-mmap ratio path (`mixed.p99 <= K ×
+  scan_free.p99`), skip-not-fail without the fixture; ratio only, never a wall-clock bound.
+
+## 4. Wire the gate
+- [ ] 4.1 Add the F3 offload guard to `scripts/agent-gate.sh` (component or `--test` on the
+  scan-offload component), built with `scan-offload-probe` + `cli-helpers`.
+
+## 5. Validate
+- [ ] 5.1 `openspec validate blocking-io-off-async --strict` clean.
+- [ ] 5.2 No `unwrap()`/`expect()` in library code; `RUSTFLAGS="-D warnings"` clean; minimal
+  and default and `cli-helpers` builds compile.
+- [ ] 5.3 `scripts/agent-gate.sh --lite` PASS each fix round; verify the p99 gate once in
+  isolation (never repeatedly under load).

--- a/openspec/changes/blocking-io-off-async/tasks.md
+++ b/openspec/changes/blocking-io-off-async/tasks.md
@@ -1,20 +1,20 @@
 # Tasks — Blocking I/O off async workers (F3)
 
 ## 1. TDD: red guard first
-- [ ] 1.1 Add an I/O-read thread-identity probe hook to the `scan-offload-probe` module
+- [x] 1.1 Add an I/O-read thread-identity probe hook to the `scan-offload-probe` module
   (`record_io_read_thread` / `recorded_io_read_thread`), mirroring `record_parse_thread`.
-- [ ] 1.2 Write `tests/issue_1593_io_offload_thread.rs`: open the multi-chunk fixture with
+- [x] 1.2 Write `tests/issue_1593_io_offload_thread.rs`: open the multi-chunk fixture with
   `use_mmap = true`, run one full streaming scan on a fixed 2-worker runtime, assert the
   recorded I/O read thread is NOT an async worker. Confirm it is RED on `main`.
   *Surface exercised:* `SSTableReader::run_scan_stream_windowed` I/O half via `execute_streaming`.
 
 ## 2. Implement the offload
-- [ ] 2.1 `source.rs`: add `BlockSource::faults_synchronously()` (Mapped/Direct → true,
+- [x] 2.1 `source.rs`: add `BlockSource::faults_synchronously()` (Mapped/Direct → true,
   Buffered → false); change `ScanCursor::chunk_index` to `Arc<AtomicUsize>` (size pin holds);
   update `ScanCursor::new`.
-- [ ] 2.2 `data_access/mod.rs`: add `read_next_block_parts(&self, file, chunk_index)` and
+- [x] 2.2 `data_access/mod.rs`: add `read_next_block_parts(&self, file, chunk_index)` and
   delegate `read_next_block` to it (so the blocking loop can call it with shared Arcs).
-- [ ] 2.3 `scan_stream_windowed.rs`: determine the actual backend once (lock the cursor);
+- [x] 2.3 `scan_stream_windowed.rs`: determine the actual backend once (lock the cursor);
   for a faulting backend run the I/O feed loop on one `spawn_blocking` task
   (`futures::executor::block_on` + `blocking_send`, `io_failed` store, returns terminal
   `io_err`); leave the buffered path as the existing inline async loop. Fire the
@@ -22,17 +22,17 @@
   invariant at the `block_on` call site.
 
 ## 3. Correctness + ratio harness
-- [ ] 3.1 Add a correctness test: mmap-backed scan returns the identical row set as buffered.
-- [ ] 3.2 Extend the A2 tail-latency harness with a cold-mmap ratio path (`mixed.p99 <= K ×
+- [x] 3.1 Add a correctness test: mmap-backed scan returns the identical row set as buffered.
+- [x] 3.2 Extend the A2 tail-latency harness with a cold-mmap ratio path (`mixed.p99 <= K ×
   scan_free.p99`), skip-not-fail without the fixture; ratio only, never a wall-clock bound.
 
 ## 4. Wire the gate
-- [ ] 4.1 Add the F3 offload guard to `scripts/agent-gate.sh` (component or `--test` on the
+- [x] 4.1 Add the F3 offload guard to `scripts/agent-gate.sh` (component or `--test` on the
   scan-offload component), built with `scan-offload-probe` + `cli-helpers`.
 
 ## 5. Validate
-- [ ] 5.1 `openspec validate blocking-io-off-async --strict` clean.
-- [ ] 5.2 No `unwrap()`/`expect()` in library code; `RUSTFLAGS="-D warnings"` clean; minimal
+- [x] 5.1 `openspec validate blocking-io-off-async --strict` clean.
+- [x] 5.2 No `unwrap()`/`expect()` in library code; `RUSTFLAGS="-D warnings"` clean; minimal
   and default and `cli-helpers` builds compile.
-- [ ] 5.3 `scripts/agent-gate.sh --lite` PASS each fix round; verify the p99 gate once in
+- [x] 5.3 `scripts/agent-gate.sh --lite` PASS each fix round; verify the p99 gate once in
   isolation (never repeatedly under load).

--- a/openspec/changes/cache-observability-stats/design.md
+++ b/openspec/changes/cache-observability-stats/design.md
@@ -1,0 +1,86 @@
+# Design — cache-observability-stats (issue #1571, B5)
+
+## Context
+
+Two live caches exist after B1/B3/B4:
+
+- `DecompressedChunkCache` (`cqlite-core/src/storage/cache/mod.rs`) — **shared per-manager**,
+  cloned into every reader; already exposes `hit_count()`, `miss_count()`, `resident_bytes()`,
+  `budget_bytes()`, `len()`. Missing: an eviction counter.
+- `KeyOffsetCache` (`cqlite-core/src/storage/cache/key_offset.rs`) — **per-reader**; exposes the
+  same accessors minus evictions. Missing: an eviction counter and any path to the public stats
+  surface.
+
+The public stats path is: `Database::stats()` → `DatabaseStats { storage_stats, memory_stats,
+query_stats }`. `memory_stats` comes from `MemoryManager::stats()`, and `MemoryManager` already
+holds an `Option<Arc<DecompressedChunkCache>>` (wired in `lib.rs` from `storage.chunk_cache()`).
+B3 (#1569) uses this handle to report the chunk cache's real hits/misses/occupancy.
+
+## Decisions
+
+### D1 — Eviction counters are relaxed atomics incremented at the eviction site
+
+Both caches evict inside `insert`'s `while … pop_lru()` loop. Increment a
+`evictions: AtomicU64` once per successful `pop_lru`, `Ordering::Relaxed` (stats are advisory; the
+hot path must not pay a fence). Expose `eviction_count()`. This mirrors the existing
+hits/misses discipline exactly.
+
+### D2 — Chunk-cache extras flow through the handle `MemoryManager` already holds
+
+`MemoryManager::stats()` reads `eviction_count()` and `budget_bytes()` off its
+`Option<Arc<DecompressedChunkCache>>` and fills the new `block_cache_evictions` /
+`block_cache_capacity_bytes` fields. No new coupling — the handle is already there. When the handle
+is absent (block caching disabled), the fields report real zeros (an absent cache has zero
+activity), consistent with the existing block_cache_hits behavior.
+
+### D3 — Key-cache stats are aggregated over the canonical by-id reader map, once per reader
+
+The key cache is per-reader, so a process-level number is the **sum over live readers**.
+`SSTableManager` iterates `self.readers` (the `HashMap<SSTableId, Arc<SSTableReader>>`), which holds
+**each reader exactly once** (the `table_readers` name→Vec map re-references the same Arcs and would
+double-count, so it is NOT used for aggregation). It reads each reader's
+`key_offset_cache` snapshot (hits, misses, evictions, resident bytes, capacity bytes) and sums
+them into a `KeyCacheAggregate`. Summing capacity across readers is the honest process-level
+resident-budget total (each reader's cache is independently bounded).
+
+The snapshot is read under the same per-shard locks the cache already uses (occupancy) plus relaxed
+atomic loads (counters) — no new global hot-path lock (Non-goal honored).
+
+### D4 — `Database::stats()` merges the key-cache aggregate into `memory_stats`
+
+`MemoryManager` does not hold reader handles (the caches are per-reader and churn on refresh), so
+the aggregate is captured **at stats() time** in `Database::stats()` — the async site that already
+assembles `DatabaseStats` and has access to `storage`. It calls `storage.key_cache_stats()` and
+writes the five `key_cache_*` fields onto the `MemoryStats` returned by `memory.stats()`. This keeps
+`MemoryStats` a single flat honest surface without giving `MemoryManager` reader coupling.
+
+### D5 — Additive-only `MemoryStats` shape
+
+New fields are appended; no existing field renamed/removed (semver). `MemoryStats` derives
+`Default`, so the additions get honest `0` defaults for constructors/tests. A `key_cache_hit_rate()`
+helper mirrors `block_cache_hit_rate()`.
+
+## Alternatives considered
+
+- **A new top-level `CacheStats` struct on `DatabaseStats`.** Rejected: heavier public surface than
+  needed and would fragment the cache numbers away from the block-cache numbers already living on
+  `MemoryStats`. Additive fields on `MemoryStats` are the minimal honest surface.
+- **Give `MemoryManager` a key-cache aggregator handle.** Rejected: key caches are per-reader and
+  churn on `refresh`; a captured handle would go stale. Aggregating at `stats()` time reads live
+  readers and is always current (D4).
+- **`Option<u64>` fields to distinguish "no cache" from "zero activity".** Rejected for consistency
+  with the existing `u64` block-cache fields and because a disabled/absent cache's real activity IS
+  zero — reporting `0` is honest, not fabricated. (The distinction "is a cache wired at all" is
+  already observable via `block_cache_capacity_bytes > 0`.)
+
+## Test strategy (TDD, RED first)
+
+- **Cache unit (chunk):** after forcing N evictions on a tiny-budget cache, `eviction_count() == N`.
+- **Cache unit (key):** same for `KeyOffsetCache`.
+- **Wiring / integration:** open a real dataset DB, do repeated point reads that hit the cache,
+  then assert `Database::stats().memory_stats` reports `block_cache_hits > 0`,
+  `block_cache_hit_rate() > 0`, `total_memory_used > 0`, and (for a keyed point read) the
+  `key_cache_*` aggregate reflects real activity. Fails on current `main` (fields do not exist /
+  key-cache never surfaced).
+- **No-fabrication:** an unwired `MemoryManager` and a DB with block-caching disabled report real
+  zeros across the new fields (no invented capacity).

--- a/openspec/changes/cache-observability-stats/proposal.md
+++ b/openspec/changes/cache-observability-stats/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The July 2026 read-path audit (`docs/reports/read-path-performance-audit-2026-07-01.md` §Epic B,
+child **B5**, #1571) found cache observability was dishonest: the reported hit rate was
+structurally pinned to `0.0` (the counted cache was never written), and `estimate_memory_usage`
+summed an always-empty map. B1 (#1567 / #1569) and B4 (#1570) since landed **real** caches
+(`DecompressedChunkCache`, `KeyOffsetCache`) with real hit/miss counters, and B3 (#1569) wired the
+chunk cache's hits/misses/occupancy through `MemoryStats`. But two honesty gaps remain before an
+operator can tune these caches:
+
+1. **No eviction counter on either cache.** The audit's observability requirement is
+   hit/miss/**eviction**/occupancy; neither cache counts evictions, so churn is invisible.
+2. **The B4 key cache is entirely absent from the public stats surface.** Its real
+   hits/misses/occupancy/capacity are never reported through `DatabaseStats`, so a per-reader
+   key-cache is un-tunable.
+3. **Capacity/budget is not reported** for either cache, so a hit rate cannot be interpreted
+   against the budget it was measured under.
+
+This is **Epic B / child B5 (#1571)**, capstone Wave 3 (last in Epic B). The audit is the
+**standing owner Seam-1 approval** for its children (2026-07-06 drain directive); this change does
+not re-open the design decision. It is **design-driven** (which counters to expose and how to
+aggregate a per-reader cache into a process-level surface has real latitude — no external oracle
+dictates the stats shape), so it goes through OpenSpec.
+
+**No-fabrication mandate (#28).** Every reported number SHALL be a real counter read from a live
+cache (relaxed atomics on the hot path) or a real aggregate over live caches — never a placeholder
+`0` standing in for "unknown". A genuinely idle/disabled/absent cache reports `0` because its real
+activity is zero, which is honest; the change adds no field whose value is invented.
+
+Milestone: **M7 (perf validation)** — v0.14 perf wave.
+
+## What Changes
+
+- **Add an eviction counter to `DecompressedChunkCache` (B1)** — a relaxed `AtomicU64` incremented
+  once per LRU eviction in `insert`, exposed via `eviction_count()`. (Hits/misses/occupancy/budget
+  accessors already exist.)
+- **Add an eviction counter to `KeyOffsetCache` (B4)** — the same relaxed `AtomicU64` +
+  `eviction_count()`, plus a `pub(crate)` snapshot accessor that reads all five real numbers
+  (hits, misses, evictions, resident bytes, capacity bytes) for aggregation.
+- **Aggregate the per-reader key caches** into a process-level snapshot: `SSTableManager` sums the
+  live counters over its canonical by-id reader map (each reader counted once — no double count),
+  surfaced through the storage layer to `Database::stats()`.
+- **Surface both caches additively through the existing `MemoryStats`** (semver-additive; no field
+  renamed or removed): add `block_cache_evictions`, `block_cache_capacity_bytes`, and the
+  `key_cache_{hits,misses,evictions,resident_bytes,capacity_bytes}` fields, plus a
+  `key_cache_hit_rate()` helper mirroring `block_cache_hit_rate()`.
+- **`MemoryManager::stats()` populates the chunk-cache extras** (evictions, capacity) from its live
+  chunk-cache handle; `Database::stats()` merges the key-cache aggregate into `memory_stats`.
+- **Document the metric names + meaning** where `DatabaseStats` is documented, and add the new
+  fields additively to the binding type stubs (`bindings/python/python/cqlite/__init__.pyi`,
+  `bindings/node/lib/index.d.ts`) where the stats surface is described.
+
+## Non-goals
+
+- **No new public stats struct or renamed/removed field** — strictly additive to `MemoryStats`
+  (semver). The `-> Result<MemoryStats>` shape of `MemoryManager::stats()` is preserved.
+- **No fabricated numbers** — a field is populated only from a real counter or a real aggregate.
+  A disabled/absent cache reports real zeros, never a placeholder standing in for unknown.
+- **No new config knob** — the change reports existing budgets, it does not add tunables.
+- **No hot-path lock for stats** — all counters are relaxed atomics; reading occupancy takes only
+  the per-shard locks the cache already uses, never a new global read lock on the hot path.
+- **No change to any read RESULT** — this is observation only; 33-table parity is unaffected.
+- **No new external crate dependency.**
+
+## Impact
+
+- **Public surface (`MemoryStats`):** additive fields only; existing consumers compile unchanged.
+- **Memory budget (<128MB):** unaffected — a handful of `AtomicU64`s.
+- **Binding surfaces (Python/Node):** type stubs updated additively where stats are documented; no
+  behavior change.
+- **Concurrency:** eviction counters are relaxed atomics; no new hot-path lock.

--- a/openspec/changes/cache-observability-stats/specs/cache-observability/spec.md
+++ b/openspec/changes/cache-observability-stats/specs/cache-observability/spec.md
@@ -1,0 +1,75 @@
+# cache-observability Specification
+
+## Purpose
+
+Define the honest cache-observability surface: the real hit/miss/eviction/occupancy/capacity numbers
+of the live read caches (B1 `DecompressedChunkCache`, B4 `KeyOffsetCache`) SHALL be reachable through
+the public `Database` statistics surface, with no fabricated or structurally-fixed values.
+
+## ADDED Requirements
+
+### Requirement: Each read cache counts evictions
+
+Both the decompressed-chunk cache (B1) and the key→partition-offset cache (B4) SHALL maintain a
+cumulative eviction counter that increments exactly once per entry evicted to stay within budget,
+exposed via an `eviction_count()` accessor. The counter SHALL be a relaxed atomic so the read hot
+path incurs no lock or fence for stats.
+
+#### Scenario: N budget-forced evictions report N
+
+- **GIVEN** a cache constructed with a byte budget that holds fewer than the entries to be inserted
+- **WHEN** enough distinct entries are inserted to force exactly N LRU evictions
+- **THEN** `eviction_count()` returns N
+- **AND** an insert that evicts nothing (within budget) leaves `eviction_count()` unchanged
+
+### Requirement: The public stats surface reports real chunk-cache observability
+
+`Database::stats().memory_stats` SHALL report the live decompressed-chunk cache's real hits, misses,
+evictions, resident-byte occupancy, and configured capacity. The hit rate SHALL be computed from the
+real hit and miss counts (never a structurally-fixed `0.0`). When block caching is disabled or no
+cache is wired, the reported numbers SHALL be real zeros (the cache's genuine activity), never a
+fabricated non-zero placeholder.
+
+#### Scenario: repeated cached reads report non-zero chunk-cache hits and hit rate
+
+- **GIVEN** an open database over a real dataset with block caching enabled
+- **WHEN** the same partition is point-read repeatedly so the chunk cache serves at least one hit
+- **THEN** `memory_stats.block_cache_hits > 0`
+- **AND** `memory_stats.block_cache_hit_rate() > 0.0`
+- **AND** `memory_stats.total_memory_used > 0` (resident decompressed bytes)
+- **AND** `memory_stats.block_cache_capacity_bytes` equals the cache's configured budget
+
+#### Scenario: eviction count surfaces through stats
+
+- **GIVEN** an open database whose chunk cache has evicted at least one entry under memory pressure
+- **THEN** `memory_stats.block_cache_evictions` equals the cache's real `eviction_count()`
+
+### Requirement: The public stats surface reports the aggregated key-cache observability
+
+`Database::stats().memory_stats` SHALL report the process-level aggregate of the per-reader
+key→partition-offset caches: summed hits, misses, evictions, resident bytes, and capacity bytes.
+Each live reader SHALL be counted exactly once (no double counting across the by-id and by-name
+reader maps). A `key_cache_hit_rate()` helper SHALL compute the rate from the aggregated hit and
+miss counts. Absent/disabled caches contribute real zeros.
+
+#### Scenario: repeated keyed point reads report real key-cache activity
+
+- **GIVEN** an open database over a real dataset with the read caches enabled
+- **WHEN** the same partition key is point-read repeatedly so the key cache serves at least one hit
+- **THEN** `memory_stats.key_cache_hits > 0`
+- **AND** `memory_stats.key_cache_hit_rate() > 0.0`
+- **AND** the reported aggregate equals the sum of the live per-reader caches' real counters
+
+### Requirement: Stats reporting fabricates nothing and takes no hot-path lock
+
+Every reported cache number SHALL be read from a real live counter (relaxed atomic) or a real
+aggregate over live caches; no field SHALL report a placeholder value standing in for an unknown.
+Reading the stats SHALL NOT acquire any lock on the read hot path beyond the per-shard locks the
+cache already uses to report occupancy.
+
+#### Scenario: an unwired memory manager reports honest zeros
+
+- **GIVEN** a `MemoryManager` constructed without a wired cache (`MemoryManager::new`)
+- **THEN** every new cache-observability field reports `0`
+- **AND** `block_cache_hit_rate()` and `key_cache_hit_rate()` return `0.0`
+- **AND** no field reports a non-zero value that was not read from a real counter

--- a/openspec/changes/cache-observability-stats/tasks.md
+++ b/openspec/changes/cache-observability-stats/tasks.md
@@ -1,0 +1,39 @@
+# Tasks — cache-observability-stats (issue #1571, B5)
+
+## 1. TDD tests first (write RED, then implement to green)
+- [ ] 1.1 Unit test (chunk cache, single shard, tiny budget): force N evictions → `eviction_count() == N`;
+      an insert within budget leaves it unchanged (no-fabrication).
+- [ ] 1.2 Unit test (key cache, single shard, tiny budget): same eviction-count assertion.
+- [ ] 1.3 `MemoryManager::stats()` unit: a wired manager reports the chunk cache's real
+      evictions + capacity; an unwired manager reports honest zeros for all new fields.
+- [ ] 1.4 Integration (real dataset): open DB → repeated point read of the same partition →
+      `Database::stats().memory_stats` shows `block_cache_hits > 0`, `block_cache_hit_rate() > 0`,
+      `total_memory_used > 0`, `block_cache_capacity_bytes > 0`, and the `key_cache_*` aggregate
+      reflects real activity. Must fail on current `main`.
+
+## 2. Eviction counters
+- [ ] 2.1 `DecompressedChunkCache`: add `evictions: AtomicU64`, increment per `pop_lru`, add
+      `eviction_count()`.
+- [ ] 2.2 `KeyOffsetCache`: add `evictions: AtomicU64`, increment per `pop_lru`, add
+      `eviction_count()` + a `pub(crate)` snapshot accessor (hits/misses/evictions/resident/capacity).
+
+## 3. Aggregate the per-reader key caches
+- [ ] 3.1 `SSTableManager::aggregate_key_cache_stats()` sums the snapshot over `self.readers`
+      (each reader once — not `table_readers`).
+- [ ] 3.2 `StorageEngine::key_cache_stats()` exposes it.
+
+## 4. Surface additively through MemoryStats
+- [ ] 4.1 Add fields: `block_cache_evictions`, `block_cache_capacity_bytes`,
+      `key_cache_{hits,misses,evictions,resident_bytes,capacity_bytes}`; `key_cache_hit_rate()`.
+- [ ] 4.2 `MemoryManager::stats()` fills the chunk-cache extras from its handle.
+- [ ] 4.3 `Database::stats()` merges `storage.key_cache_stats()` into `memory_stats`.
+
+## 5. Docs + bindings
+- [ ] 5.1 Document metric names + meaning where `MemoryStats`/`DatabaseStats` are documented.
+- [ ] 5.2 Additive type-stub notes in `bindings/python/python/cqlite/__init__.pyi` and
+      `bindings/node/lib/index.d.ts` where the stats surface is described.
+
+## 6. Gate
+- [ ] 6.1 `openspec validate cache-observability-stats --strict` clean.
+- [ ] 6.2 `scripts/agent-gate.sh --lite` PASS each fix round; `cargo +1.88.0 fmt --check` clean;
+      `RUSTFLAGS="-D warnings" cargo clippy -p cqlite-core --features cli-helpers` clean.

--- a/openspec/changes/positional-row-emit/design.md
+++ b/openspec/changes/positional-row-emit/design.md
@@ -1,0 +1,83 @@
+# Design — Positional row emit (K3)
+
+## Context
+
+`parse_row_data_with_offset_impl` decodes a clustering/static row's cells by
+iterating `RowColumnResolution::columns_for(is_static)` — already in
+serialization-header (schema) column order — and inserting each decoded value into
+a per-row `HashMap<Arc<str>, Value>`. Because a `HashMap` has nondeterministic
+iteration order, the shared `build_display_row` re-materializes the map into a
+`Vec` and `sort_by`-s it alphabetically per row so that scan output is
+deterministic. That is a per-row allocation + per-row sort on the hottest read
+path, entirely to undo the nondeterminism the `HashMap` introduced.
+
+The row carrier that crosses the storage → query boundary is already an ordered
+`RowCells = Vec<(Arc<str>, Value)>` (issue #1334); only the row's INTERNAL assembly
+used a `HashMap`.
+
+## Decision 1 — Build the row positionally; delete the sort
+
+The cell accumulator becomes a `RowCells` (`Vec`), pre-sized to the on-disk column
+count, populated by `push` in the existing column-iteration order. Because each
+column is visited exactly once and clustering pseudo-cells are pushed once before
+the loop, the vector has no duplicate keys — the same invariant the `HashMap`
+enforced implicitly. `build_display_row` then moves the already-ordered vector into
+`ScanRow::Row` with no `sort_by` and no `record_row_sort()`.
+
+**Determinism-by-construction:** two scans of the same fixture see the identical
+column-iteration order (it is fixed by the serialization header, not by a hash
+seed), so the emitted order is stable without any sort.
+
+**Observability:** the public query result is `QueryRow.values: HashMap<..>`
+(name-keyed) built in `build_row_from_scan`; the CLI display path
+(`data_parser.rs::to_string_vec`) reorders by an explicit `column_order`. Neither
+depends on `RowCells` order, so the change is byte-neutral. This is asserted by the
+33-table parity/goldens harness and directly by a two-scan column-set equality
+test.
+
+## Decision 2 — Positional static-cell merge (`merge_static_cells`)
+
+The former static-column merge used `HashMap::entry(k).or_insert_with(..)`
+("clustering-row-wins"). The `Vec` analogue appends a static cell only when the
+clustering row does not already carry that column (a linear membership check over a
+handful of columns). Static and regular columns are disjoint in Cassandra, so this
+is effectively a concatenation; the membership check preserves the exact
+clustering-row-wins precedence defensively. The merged order (clustering-row cells,
+then appended static cells) is never user-visible.
+
+## Decision 3 — Keep the metadata maps keyed
+
+`want_cell_metadata`'s `cell_meta`/`complex_col_meta` maps
+(`HashMap<String, _>`) and the `static_cell_meta` merge keep their current keying —
+they are cold, off the read hot path, and consumed by name. Only the value-cell
+carrier goes positional (the audit says "keep their current keying unless trivially
+unifiable"; unifying them is out of scope).
+
+## Decision 4 — Retain `ROW_SORT_INVOCATIONS` as a tripwire
+
+No production site calls `record_row_sort()` after this change. The counter is kept
+(unconditional, zero-overhead in release) as a regression tripwire, mirroring the
+J1 `TYPE_NORMALIZE_CALLS` treatment: any future per-row cell sort must record it,
+which would flip the `== 0` scan assertions red.
+
+## Risks & mitigations
+
+- **Risk: a hidden consumer relies on alphabetical `RowCells` order.** Mitigation:
+  audited every `ScanRow::Row`/`RowCells` consumer — `QueryRow.values` is a
+  name-keyed map, the CLI reorders by explicit `column_order`, compaction
+  re-sorts its own `SimpleCell`/`ComplexColumn` vectors by name, and the
+  schema-discovery sampler is order-agnostic. The 33-table parity + compaction
+  byte-parity suites are the end-to-end proof.
+- **Risk: `extract_clustering_values` `HashMap::get` → linear scan.** Mitigation:
+  clustering arity is tiny (single digits) and this runs only when a range
+  tombstone is open, off the tombstone-free hot path.
+
+## Alternatives considered
+
+- **Keep the `HashMap` but sort with a stable key once** — still pays the per-row
+  map allocation and a per-row sort; does not address the finding.
+- **Emit a positional `Vec<Value>` + a shared `Arc<[Arc<str>]>` header** (the
+  audit's "preferred" long-term shape) — a larger carrier-type change that ripples
+  into every `RowCells` consumer and overlaps K4/E5. Deferred; this change keeps
+  the existing `Vec<(Arc<str>, Value)>` carrier and only fixes its CONSTRUCTION,
+  which removes the map + sort with a contained blast radius.

--- a/openspec/changes/positional-row-emit/proposal.md
+++ b/openspec/changes/positional-row-emit/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+The July 2026 parser performance audit
+(`docs/reports/parser-performance-audit-2026-07-01.md`, Epic K finding **K3**, and
+its joint read-path E2 finding in `docs/reports/read-path-performance-audit-2026-07-01.md`)
+found the V5CompressedLegacy row-emit path builds each decoded row as a
+`HashMap<Arc<str>, Value>` and then **alphabetically re-sorts it on EVERY row**
+solely to hide `HashMap` iteration nondeterminism:
+
+- The decoder (`v5_compressed_legacy/row_data.rs`) inserts each cell into a per-row
+  `HashMap` even though it already iterates columns in serialization-header order.
+- The shared display-row builder (`v5_compressed_legacy/mod.rs::build_display_row`,
+  into which #1334 consolidated the former three `block_emit`/`block_emit_windowed`
+  sort sites) then allocates a `Vec`, bumps the H5 `ROW_SORT_INVOCATIONS` gauge, and
+  runs `sort_by(|a,b| a.name.cmp(b.name))` — once per returned live row.
+
+Cost: one throwaway per-row `HashMap` allocation + one per-row `sort_by` in every
+scan/compaction emit path. The schema already knows the column order
+(`columns_in_order` in `RowColumnResolution`); determinism should come from
+CONSTRUCTION, not from a per-row sort.
+
+**Routing: design-driven.** This is a hot-path mechanics change (change the row
+carrier's construction discipline), not an oracle-driven parse-correctness bug, so
+it is captured as an OpenSpec change per the spec-driven doctrine. The design and
+priority are owner-approved via the read-path/parser performance audit (standing
+owner Seam-1 approval, v0.14 perf wave); this change encodes that decision rather
+than re-litigating it.
+
+Milestone: **v0.14 performance wave** (Epic #1604, row/cell hot-loop mechanics).
+This is a **pure factoring** — identical observable output. The public query
+result (`QueryRow.values`) is a name-keyed `HashMap`, so the INTERNAL emit order is
+not user-visible. Parity is the proof: the 33-table sstabledump JSONL harness and
+the compaction byte-parity suite must stay green.
+
+## What Changes
+
+- **Change** the row-assembly carrier in `parse_row_data_with_offset_impl` from a
+  per-row `HashMap<Arc<str>, Value>` to a positional `RowCells`
+  (`Vec<(Arc<str>, Value)>`), pre-sized to the on-disk column count. Clustering
+  pseudo-cells (#229) and simple/complex data cells are `push`ed in
+  serialization-header column order — the loop already iterates in that order.
+- **Delete** the per-row `sort_by` and the `record_row_sort()` increment from
+  `build_display_row`; it now moves the already-ordered `RowCells` straight into
+  `ScanRow::Row`. `row_has_non_key_cell` and `extract_clustering_values` take
+  slices.
+- **Add** `merge_static_cells(&mut RowCells, &RowCells)` — the positional,
+  clustering-row-wins analogue of the former
+  `HashMap::entry(..).or_insert_with(..)` static-column merge — and switch the
+  `static_cells` accumulators in `block_emit`/`block_emit_windowed` to `RowCells`.
+- **Retain** the `ROW_SORT_INVOCATIONS` counter as a regression tripwire (no
+  production caller remains; any reintroduced per-row sort must record it).
+- **Add** a `work-counters` wiring test (`issue_1642_positional_row_emit.rs`)
+  asserting `ROW_SORT_INVOCATIONS == 0` on a full scan across the four column
+  shapes (simple / static / collections / wide) and two-scan
+  determinism-by-construction; flip the former `>= rows` currency assertion in
+  `issue_1618_parser_work_counters.rs` to `== 0`. Both FAIL on `main`.
+
+## Non-goals
+
+- **K4 (#1643) `Arc<RowKey>`/`Arc<TableId>` identity handles** — the next link in
+  the K-emit chain. This change does NOT fold in that work; where a K4 seam appears
+  it is left as a `TODO` referencing the owning issue.
+- **No change to the public row representation.** `QueryRow.values` stays a
+  name-keyed map; the observable query result (column values and the ordering the
+  public API presents) is byte-identical. Only the INTERNAL emit path goes
+  positional.
+- **No change to column-name case semantics** — no lowercasing or re-keying of
+  column names (the anti-pattern the audit explicitly forbids).
+- **Not** re-litigating the pre-`na` version floor or the no-heuristics mandate.

--- a/openspec/changes/positional-row-emit/specs/sstable-partition-emit/spec.md
+++ b/openspec/changes/positional-row-emit/specs/sstable-partition-emit/spec.md
@@ -1,0 +1,66 @@
+# sstable-partition-emit
+
+## ADDED Requirements
+
+### Requirement: Row cells are emitted positionally with no per-row HashMap or sort
+
+The V5CompressedLegacy row decoder SHALL assemble each decoded row's cells directly
+into an ordered `RowCells` (`Vec<(Arc<str>, Value)>`) in serialization-header
+(schema) column order — deterministic by CONSTRUCTION. It SHALL NOT allocate a
+per-row `HashMap` for cell assembly, and the shared display-row builder SHALL NOT
+perform a per-row `sort_by` (nor increment the `ROW_SORT_INVOCATIONS` gauge) to
+order a row's cells. The `ROW_SORT_INVOCATIONS` counter is retained as a regression
+tripwire; any reintroduced per-row cell sort SHALL record it.
+
+#### Scenario: A full scan performs zero per-row cell sorts
+
+- **GIVEN** a present fixture returning live rows (the simple, static-column,
+  collection, and wide-partition shapes)
+- **WHEN** a full scan decodes and emits every row through the shared display-row
+  builder
+- **THEN** `ROW_SORT_INVOCATIONS` recorded by the scan is exactly `0`, whereas on
+  the pre-K3 behavior the per-row `sort_by` made the count at least the returned
+  live-row count.
+
+#### Scenario: Emit order is deterministic by construction
+
+- **GIVEN** the same fixture scanned twice
+- **WHEN** each scan assembles rows positionally in serialization-header column
+  order
+- **THEN** the two scans surface the identical per-row column set with
+  `ROW_SORT_INVOCATIONS == 0` on both runs — determinism comes from the fixed
+  serialization-header order, not from a per-row sort.
+
+### Requirement: Positional emit preserves byte-identical observable output
+
+Positional row emit SHALL be a pure factoring with no change to observable output.
+Building rows positionally instead of via a per-row `HashMap` + alphabetical sort
+does not change results: the public query result (`QueryRow.values`) is a
+name-keyed map, so the INTERNAL `RowCells` order is not user-visible; the surfaced
+column values and the ordering the public API presents SHALL be unchanged.
+Column-name case semantics SHALL NOT change (no lowercasing or re-keying).
+
+#### Scenario: Parity harnesses stay green
+
+- **WHEN** the 33-table sstabledump JSONL parity harness and the compaction
+  byte-parity suite run with positional row emit
+- **THEN** both pass with output identical to the pre-refactor baseline (column
+  values and result ordering unchanged, compaction bytes unchanged).
+
+### Requirement: Static-column merge is positional and clustering-row-wins
+
+Merging accumulated static-column cells into a clustering row SHALL preserve the
+clustering-row-wins precedence: a static cell is included only when the clustering
+row does not already carry that column. The merge SHALL operate on the positional
+`RowCells` representation (the ordered analogue of the former
+`HashMap::entry(..).or_insert_with(..)`), and the merged order SHALL NOT be relied
+upon as user-visible.
+
+#### Scenario: Static columns merge into a clustering row without duplication
+
+- **GIVEN** a partition with a static row followed by clustering rows
+- **WHEN** each clustering row is emitted with the static cells merged in
+- **THEN** every static column appears exactly once per emitted clustering row, a
+  column present on the clustering row is not overwritten by the static value, and
+  the SELECT result for the static columns is identical to the pre-K3 output
+  (validated by the static-column parity fixtures).

--- a/openspec/changes/positional-row-emit/tasks.md
+++ b/openspec/changes/positional-row-emit/tasks.md
@@ -1,0 +1,51 @@
+# Tasks — Positional row emit (K3)
+
+## 1. Work-counter wiring test (TDD, write first)
+
+- [x] 1.1 Add `cqlite-core/tests/issue_1642_positional_row_emit.rs` (feature
+      `work-counters`): a full scan asserting `ROW_SORT_INVOCATIONS == 0` on the
+      simple table, across the static/collections/wide shapes, and a two-scan
+      determinism check (identical per-row column set, zero sorts on both scans).
+      FAILS on `main` (the shared builder sorts once per returned live row).
+- [x] 1.2 Flip the former `>= rows` currency assertion in
+      `issue_1618_parser_work_counters.rs` (`scan_sorts_cells_per_row`) to the K3
+      `== 0` reality (renamed `scan_does_not_sort_cells_per_row`).
+
+## 2. Positional construction
+
+- [x] 2.1 Change the `cells` accumulator in `parse_row_data_with_offset_impl` from
+      `HashMap<Arc<str>, Value>` to `RowCells` (pre-sized `Vec`); `push` clustering
+      pseudo-cells and simple/complex data cells in column order.
+- [x] 2.2 Change the `ParsedRow` tuple's first element to `RowCells`.
+
+## 3. Drop the per-row sort
+
+- [x] 3.1 `build_display_row` takes `RowCells`, moves it straight into
+      `ScanRow::Row` — no `Vec` re-collect, no `record_row_sort()`, no `sort_by`.
+- [x] 3.2 `row_has_non_key_cell`/`extract_clustering_values` take `&[(Arc<str>,
+      Value)]`.
+
+## 4. Positional static-cell merge
+
+- [x] 4.1 Add `merge_static_cells(&mut RowCells, &RowCells)` (clustering-row-wins).
+- [x] 4.2 Switch `static_cells` in `block_emit`/`block_emit_windowed` (locals +
+      the windowed `TimestampPolicy` field) to `RowCells`; replace the
+      `HashMap::entry(..).or_insert_with(..)` merges with `merge_static_cells`.
+- [x] 4.3 Update `build_compaction_row_data`'s `cells` parameter to `RowCells`.
+
+## 5. Counter + docs
+
+- [x] 5.1 Retain `ROW_SORT_INVOCATIONS` as a regression tripwire; update its
+      `read_work_counters.rs` doc to the J1-style "K3 removed the caller" note.
+- [x] 5.2 Update the `RowCells`/`ScanRow::Row` doc comments in `types.rs` (order is
+      now positional/serialization-header, not alphabetical; not user-visible).
+
+## 6. Gate wiring + validation
+
+- [x] 6.1 Add `--test issue_1642_positional_row_emit` to the `work-counters-guard`
+      component in `scripts/agent-gate.sh`.
+- [x] 6.2 `cargo +1.88.0 fmt --check` clean; `RUSTFLAGS="-D warnings" cargo clippy
+      -p cqlite-core --features cli-helpers` clean.
+- [x] 6.3 33-table sstabledump JSONL parity + compaction byte-parity green
+      (byte-identical observable output).
+- [x] 6.4 `openspec validate positional-row-emit --strict` clean.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -31,7 +31,11 @@
 #                      reallocated per partition — issue #1333) and
 #                      --test issue_1589_window_drain_bytes (the scan/compaction
 #                      windows advance a cursor + compact once per refill instead
-#                      of front-draining per partition — issue #1589); same gate.
+#                      of front-draining per partition — issue #1589); and the F3
+#                      I/O-offload guards --test issue_1593_io_offload_thread (an
+#                      mmap-backed scan's blocking raw chunk read runs off the async
+#                      worker pool) + --test issue_1593_mmap_scan_parity (that
+#                      scheduling change is data-transparent — issue #1593); same gate.
 #   work-counters-guard cargo test -p cqlite-core --features cli-helpers,work-counters
 #                      the read/parser work-counter wiring-evidence tests
 #                      (issue_1566/1573/1585 read-work counters + issue_1618 parser
@@ -2455,7 +2459,9 @@ dispatch_component() {
       --features cli-helpers,scan-offload-probe \
       --test issue_1143_scan_offload_thread \
       --test issue_1333_scan_scratch_reuse \
-      --test issue_1589_window_drain_bytes ;;
+      --test issue_1589_window_drain_bytes \
+      --test issue_1593_io_offload_thread \
+      --test issue_1593_mmap_scan_parity ;;
     work-counters-guard) run_component work-counters-guard cargo test --package cqlite-core \
       --features cli-helpers,work-counters \
       --test issue_1566_read_work_counters \

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2463,6 +2463,7 @@ dispatch_component() {
       --test issue_1585_read_op_per_chunk \
       --test issue_1597_compression_info_one_parse \
       --test issue_1618_parser_work_counters \
+      --test issue_1642_positional_row_emit \
       --test issue_1570_key_offset_cache \
       --test issue_1575_candidate_key_hash_hoist ;;
     byte-budget-guard) run_component byte-budget-guard cargo test --package cqlite-core \


### PR DESCRIPTION
Three file-disjoint read-path perf lanes bundled through one solo full gate (fleet→integration, #1116). v0.14 read-path performance wave (standing owner drain directive; designs pre-approved via docs/reports/read-path-performance-audit-2026-07-01.md). Each carries its own OpenSpec change; all three passed spec-auditor C and roborev.

## #1571 (B5) — honest cache observability
Real hit/miss/eviction/occupancy counters surfaced through `Database::stats()`/`MemoryStats` (+ Python bindings): added eviction counters to both caches, aggregated the (previously absent) per-reader key-cache stats. roborev caught a real under-count: `SSTableId::from_filename` collides for tables sharing a generation filename, so the by-id map isn't a superset — fixed via pointer-dedup (`Arc::as_ptr`) union of both reader maps, with a collision-reproducing test. Honest zeros when disabled (self-verifying `key_cache_capacity_bytes==0`). Semver-additive. OpenSpec: cache-observability-stats.

## #1642 (K3) — positional row emit
Replaced the per-row `HashMap<Arc<str>,Value>` + alphabetical `sort_by` with a positional `RowCells` Vec in serialization-header order (determinism by construction, no sort); `ROW_SORT_INVOCATIONS` 1000→0 on primary-decoder scans. Byte-identical output (consumers name-keyed / compaction re-sorts / CLI uses column_order). Static-cell merge is an unconditional `extend` justified by a static/regular column disjointness proof. Tripwire kept honest (schema-less fallbacks record their sorts). K4 not folded. OpenSpec: positional-row-emit.

## #1593 (F3) — blocking I/O off async workers
Moved sync-faulting mmap/`O_DIRECT` raw-chunk I/O onto a `spawn_blocking` thread (keeps reactor-driven Buffered inline; keys on the actual backend). Deterministic thread-identity guard (I/O read off the worker set; mmap + unix-gated Direct). Ratio-only p99 gate (K×same-run baseline). roborev caught a panic-path edge: added a `FeedFailureGuard` drop-guard so a feed-closure panic sets `io_failed` before `raw_tx` drops (no spurious truncated trailing partition). Query results unchanged (mmap-vs-buffered parity). Follow-up note on #1594 (F4 admission must bound the doubled blocking-thread footprint). OpenSpec: blocking-io-off-async.

## Validation
Full scripts/agent-gate.sh RESULT: PASS (23/23) at the bundle tip. spec-auditor C: PASS for all three. roborev: clean on all three (two real bugs caught+fixed pre-merge: #1571 collision under-count, #1593 panic-path guard).

Closes #1571
Closes #1642
Closes #1593