### PR TITLE
chore(gate-health): wave-6 — nextest counter-race #1946/#2006 + Node init dedup #1784 + Windows-CI docs #2007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,12 @@ byte-for-byte compaction parity — plus no-heuristics correctness fixes.
 
 ### Known Issues
 
-- **Node.js `Test (windows-latest)` CI leg** is failing and is **waived** for the
-  v0.13.0 release (best-effort, not release-gated) — tracked in [#2007](https://github.com/pmcfadin/cqlite/issues/2007).
+- **Node.js `Test (windows-latest)` CI leg** has 3 chronic, windows-only
+  test-suite failures (refresh generation-drop, write-smoke, execute-deprecation),
+  tracked in [#1979](https://github.com/pmcfadin/cqlite/issues/1979). Windows Node.js
+  CI is **best-effort, not a release gate**, so these were **waived** for the
+  v0.13.0 release (waiver tracked in [#2007](https://github.com/pmcfadin/cqlite/issues/2007)).
+  Linux and macOS Node.js CI are green and gating.
 - **Coverage Gate `(enforced)` (90%) leg** is not green and is **waived** for the
   v0.13.0 release; restoration is post-0.13 — tracked in [#2022](https://github.com/pmcfadin/cqlite/issues/2022).
 

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -773,13 +773,6 @@ impl Database {
         #[cfg(not(feature = "write-support"))]
         let _ = (writable, write_dir, flush_threshold); // suppress unused warning when feature off
 
-        // Eagerly build (and memoize) the shared async runtime so a resource-
-        // starved host surfaces the failure HERE at open() time as a catchable
-        // napi::Error, rather than deferring it to the first executeNative() /
-        // flushRun() / stream iteration that reaches `block_on` (issue #1438).
-        // Idempotent — later calls reuse the memoized runtime.
-        crate::runtime::try_get_runtime().map_err(runtime_init_error)?;
-
         Ok(Database {
             inner: Arc::new(db),
             closed: AtomicBool::new(false),

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -1115,7 +1115,15 @@ mod tests {
     /// is attempted (the function returns the compressed bytes only after the CRC
     /// verifies, so a corrupt chunk never reaches the caller's decompressor).
     /// Guardrail #1411: CRC-then-decompress ordering.
+    ///
+    /// This test does not assert on READ_CALLS, but each successful
+    /// `read_compressed_chunk_at` here calls `record_read()` and thus MUTATES the
+    /// process-global counter. Any test that reads OR mutates READ_CALLS must be
+    /// `#[serial]` (issue #1946/#2006): without it this sibling could increment the
+    /// counter concurrently with `..._records_one_read_per_chunk` and flake its
+    /// post-`reset` delta assertion.
     #[test]
+    #[serial_test::serial]
     fn read_compressed_chunk_at_verifies_crc_before_returning() {
         use crate::storage::sstable::compression_info::CompressionInfo;
 
@@ -1177,6 +1185,10 @@ mod tests {
     /// Counters are a shared process-global, so this test serializes on the
     /// `serial_test` mutex (the counter-test convention; issue #1071) — a stale
     /// value from a parallel test cannot satisfy an assertion after the `reset`.
+    /// INVARIANT (issue #1946/#2006): EVERY test in this binary that reads OR
+    /// mutates READ_CALLS (i.e. calls `record_read()` via `read_compressed_chunk_at`
+    /// / `read_nb_format_chunk_data`, or `rwc::read_calls()`/`rwc::reset()`) must be
+    /// `#[serial]`, or its increments contaminate this delta assertion.
     #[test]
     #[serial_test::serial]
     fn read_compressed_chunk_at_records_one_read_per_chunk() {

--- a/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
+++ b/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
@@ -18,9 +18,14 @@
 //!    (the slow-but-correct oracle). This is the correctness guard on the new path.
 //!
 //! The `SCAN_FOR_KEY_CALLS` / decompress counters are process-global, so every
-//! counter-observing test serializes on the `serial_test` mutex (the existing
-//! counter-test convention). Tests SKIP (never fail) when the binary fixture is
-//! absent; a present fixture that yields 0 rows stays a hard failure.
+//! test that TOUCHES them — whether it reads a delta (tests 1-2) OR merely
+//! mutates the counter as a side effect (the scan-fallback tests 5-6, whose
+//! `get()` on a dropped key increments `SCAN_FOR_KEY_CALLS`) — carries `#[serial]`
+//! so the whole set serializes on the `serial_test` mutex. `#[serial]` only
+//! serializes serial-annotated tests among themselves, so a NON-serial mutator
+//! left in this binary would race the delta assertions under nextest parallelism
+//! and flake them (issue #1946). Tests SKIP (never fail) when the binary fixture
+//! is absent; a present fixture that yields 0 rows stays a hard failure.
 //!
 //! ```bash
 //! CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
@@ -408,6 +413,7 @@ fn copy_component_set(data_db: &Path, dst_dir: &Path) -> PathBuf {
 }
 
 #[tokio::test]
+#[serial]
 async fn truncated_index_get_falls_back_to_scan() {
     let Some(dd) = big_data_db() else {
         eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
@@ -595,6 +601,7 @@ fn entry_end_offsets(buf: &[u8]) -> Option<Vec<usize>> {
 }
 
 #[tokio::test]
+#[serial]
 async fn boundary_truncated_index_get_falls_back_to_scan() {
     let Some(dd) = big_data_db() else {
         eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");


### PR DESCRIPTION
## Wave-6 — gate/release-health batch (4 file-disjoint lanes)

Closes #1946, closes #1784, closes #2006, closes #2007. Fleet→integration bundle (#1116): four file-disjoint oracle-driven lanes, one solo full gate, one PR. Marching toward v0.14 gate health.

### #1946 — flaky `present_key_get_does_not_sequential_scan` (nextest counter race)
Two non-serial sibling tests (`truncated_index_get_falls_back_to_scan` + boundary variant) mutate the global `SCAN_FOR_KEY_CALLS` counter concurrently with the delta-asserting tests. Marked them `#[serial]` + doc guard (any test reading/mutating the global counter must be `#[serial]`). Assertions unchanged; verified 3× race-free.

### #1784 — Node `Database::open()` duplicate runtime-init
Removed the redundant trailing `try_get_runtime()` (a #1438 concurrent-merge artifact on a memoized `OnceLock`). Kept the earlier fail-fast placement — init still happens exactly once at `open()` time, ordering unchanged. Node build + 425 tests pass.

### #2006 — flaky `block_io` `READ_CALLS` counter contamination
Contaminating sibling `read_compressed_chunk_at_verifies_crc_before_returning` mutated the global `READ_CALLS` without `#[serial]`. Marked it `#[serial]` + doc guard; audited the full module (both CRC tests are the complete READ_CALLS-touching set). Verified 3× race-free (37/37), non-vacuous.

### #2007 — docs: waived Windows Node.js CI note
CHANGELOG v0.13.0 Known Issues: documents the 3 chronic windows-only Node CI failures (refresh generation-drop, write-smoke, execute-deprecation, tracked #1979) as best-effort/waived, not release-gated. Docs-only.

## Quality bar
- ✅ Full `scripts/agent-gate.sh` **RESULT: PASS** (23/23, commit `223bcf4d`, accelerators on)
- ✅ roborev clean — "No issues found"
- Oracle-driven (no OpenSpec) → no C-audit required
