### PR TITLE
perf(#1578): D2 — O(1) streaming global aggregates + MAX_RESULTS demotion + streaming table_id fix

### DIFF
--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -472,6 +472,7 @@ jobs:
             --test issue_992_ttl_tombstone_parity \
             --test issue_992_range_boundary_grammar \
             --test issue_993_wide_partition_promoted_index_parity \
+            --test issue_1578_scan_stream_stitch_table_id_regression \
             --test issue_819_differential_compaction \
             --test issue_933_range_tombstone_compaction \
             --test issue_694_writetime_ttl_parity \
@@ -664,6 +665,22 @@ jobs:
             -- --nocapture
           BASH
 
+      # Issue #1578 Finding 2: corpus-backed regression proving the
+      # scan_stream_windowed stitching branch no longer filters by
+      # table_ids_match. Uses the same test_big.wide_partition corpus fixture as
+      # the wide-partition promoted-index parity step above; needs cli-helpers
+      # (for the `ingestion` module) beyond that step's plain write-support.
+      - name: Run stitched scan_stream table_id regression test
+        id: stitch_table_id_regression
+        continue-on-error: true
+        run: |
+          bash scripts/ci/ci-timing-summary.sh measure "full stitched scan_stream table_id regression" -- bash <<'BASH'
+          set -euo pipefail
+          cargo test --package cqlite-core --features write-support,cli-helpers \
+            --test issue_1578_scan_stream_stitch_table_id_regression \
+            -- --nocapture
+          BASH
+
       - name: Run differential-compaction self-consistency tests
         id: differential_compaction_parity
         continue-on-error: true
@@ -720,6 +737,7 @@ jobs:
           - Static-row / clustering-bound parity (issue #991): ${{ steps.static_clustering_parity.outcome }}
           - TTL / tombstone / range-marker parity (issue #992): ${{ steps.ttl_tombstone_range_parity.outcome }}
           - Wide-partition promoted-index parity (issue #993): ${{ steps.wide_partition_promoted_index_parity.outcome }}
+          - Stitched scan_stream table_id regression (issue #1578): ${{ steps.stitch_table_id_regression.outcome }}
           - Differential-compaction self-consistency (issues #819/#933/#992): ${{ steps.differential_compaction_parity.outcome }}
           - WRITETIME / TTL / local-deletion-time parity (issue #694): ${{ steps.writetime_ttl_parity.outcome }}
           - V5CompressedLegacy compression / row-count parity: ${{ steps.v5_compressed_legacy_parity.outcome }}
@@ -766,7 +784,7 @@ jobs:
           retention-days: 14
 
       - name: Comment on PR (Success)
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.data_parity.outcome == 'success' && steps.index_parity.outcome == 'success' && steps.summary_parity.outcome == 'success' && steps.statistics_parity.outcome == 'success' && steps.toc_component_parity.outcome == 'success' && steps.index_db_strict_parity.outcome == 'success' && steps.statistics_db_strict_parity.outcome == 'success' && steps.compression_info_parity.outcome == 'success' && steps.compression_info_strict_parity.outcome == 'success' && steps.filter_db_parity.outcome == 'success' && steps.repaired_metadata_parity.outcome == 'success' && steps.row_framing_parity.outcome == 'success' && steps.static_clustering_parity.outcome == 'success' && steps.ttl_tombstone_range_parity.outcome == 'success' && steps.wide_partition_promoted_index_parity.outcome == 'success' && steps.differential_compaction_parity.outcome == 'success' && steps.writetime_ttl_parity.outcome == 'success' && steps.v5_compressed_legacy_parity.outcome == 'success'
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.data_parity.outcome == 'success' && steps.index_parity.outcome == 'success' && steps.summary_parity.outcome == 'success' && steps.statistics_parity.outcome == 'success' && steps.toc_component_parity.outcome == 'success' && steps.index_db_strict_parity.outcome == 'success' && steps.statistics_db_strict_parity.outcome == 'success' && steps.compression_info_parity.outcome == 'success' && steps.compression_info_strict_parity.outcome == 'success' && steps.filter_db_parity.outcome == 'success' && steps.repaired_metadata_parity.outcome == 'success' && steps.row_framing_parity.outcome == 'success' && steps.static_clustering_parity.outcome == 'success' && steps.ttl_tombstone_range_parity.outcome == 'success' && steps.wide_partition_promoted_index_parity.outcome == 'success' && steps.stitch_table_id_regression.outcome == 'success' && steps.differential_compaction_parity.outcome == 'success' && steps.writetime_ttl_parity.outcome == 'success' && steps.v5_compressed_legacy_parity.outcome == 'success'
         uses: actions/github-script@v8
         with:
           script: |
@@ -789,6 +807,7 @@ jobs:
             - Static-row / clustering-bound parity (issue #991): success
             - TTL / tombstone / range-marker parity (issue #992): success
             - Wide-partition promoted-index parity (issue #993): success
+            - Stitched scan_stream table_id regression (issue #1578): success
             - Differential-compaction parity (issues #819/#933/#992): success
             - WRITETIME / TTL / local-deletion-time parity (issue #694): success
             - V5CompressedLegacy compression / row-count parity: success
@@ -803,7 +822,7 @@ jobs:
             });
 
       - name: Comment on PR (Failure)
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success' || steps.toc_component_parity.outcome != 'success' || steps.index_db_strict_parity.outcome != 'success' || steps.statistics_db_strict_parity.outcome != 'success' || steps.compression_info_parity.outcome != 'success' || steps.compression_info_strict_parity.outcome != 'success' || steps.filter_db_parity.outcome != 'success' || steps.repaired_metadata_parity.outcome != 'success' || steps.row_framing_parity.outcome != 'success' || steps.static_clustering_parity.outcome != 'success' || steps.ttl_tombstone_range_parity.outcome != 'success' || steps.wide_partition_promoted_index_parity.outcome != 'success' || steps.differential_compaction_parity.outcome != 'success' || steps.writetime_ttl_parity.outcome != 'success' || steps.v5_compressed_legacy_parity.outcome != 'success')
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success' || steps.toc_component_parity.outcome != 'success' || steps.index_db_strict_parity.outcome != 'success' || steps.statistics_db_strict_parity.outcome != 'success' || steps.compression_info_parity.outcome != 'success' || steps.compression_info_strict_parity.outcome != 'success' || steps.filter_db_parity.outcome != 'success' || steps.repaired_metadata_parity.outcome != 'success' || steps.row_framing_parity.outcome != 'success' || steps.static_clustering_parity.outcome != 'success' || steps.ttl_tombstone_range_parity.outcome != 'success' || steps.wide_partition_promoted_index_parity.outcome != 'success' || steps.stitch_table_id_regression.outcome != 'success' || steps.differential_compaction_parity.outcome != 'success' || steps.writetime_ttl_parity.outcome != 'success' || steps.v5_compressed_legacy_parity.outcome != 'success')
         uses: actions/github-script@v8
         with:
           script: |
@@ -826,6 +845,7 @@ jobs:
             - Static-row / clustering-bound parity (issue #991): ${{ steps.static_clustering_parity.outcome }}
             - TTL / tombstone / range-marker parity (issue #992): ${{ steps.ttl_tombstone_range_parity.outcome }}
             - Wide-partition promoted-index parity (issue #993): ${{ steps.wide_partition_promoted_index_parity.outcome }}
+            - Stitched scan_stream table_id regression (issue #1578): ${{ steps.stitch_table_id_regression.outcome }}
             - Differential-compaction parity (issues #819/#933/#992): ${{ steps.differential_compaction_parity.outcome }}
             - WRITETIME / TTL / local-deletion-time parity (issue #694): ${{ steps.writetime_ttl_parity.outcome }}
             - V5CompressedLegacy compression / row-count parity: ${{ steps.v5_compressed_legacy_parity.outcome }}
@@ -849,6 +869,7 @@ jobs:
             cargo test --package cqlite-core --features write-support --test issue_991_static_clustering_parity -- --nocapture
             cargo test --package cqlite-core --features write-support --test issue_992_ttl_tombstone_parity --test issue_992_range_boundary_grammar -- --nocapture
             cargo test --package cqlite-core --features write-support --test issue_993_wide_partition_promoted_index_parity -- --nocapture
+            cargo test --package cqlite-core --features write-support,cli-helpers --test issue_1578_scan_stream_stitch_table_id_regression -- --nocapture
             cargo test --package cqlite-core --features write-support --test issue_819_differential_compaction --test issue_933_range_tombstone_compaction -- --nocapture
             cargo test --package cqlite-core --features write-support,cli-helpers --test issue_694_writetime_ttl_parity -- --nocapture
             cargo test --package cqlite-core --features write-support --test v5_compressed_legacy_parity_test --test v5_compressed_legacy_row_count_parity -- --nocapture
@@ -880,6 +901,7 @@ jobs:
             steps.static_clustering_parity.outcome != 'success' ||
             steps.ttl_tombstone_range_parity.outcome != 'success' ||
             steps.wide_partition_promoted_index_parity.outcome != 'success' ||
+            steps.stitch_table_id_regression.outcome != 'success' ||
             steps.differential_compaction_parity.outcome != 'success' ||
             steps.writetime_ttl_parity.outcome != 'success' ||
             steps.v5_compressed_legacy_parity.outcome != 'success'
@@ -903,6 +925,7 @@ jobs:
           echo "Static-row / clustering-bound parity: ${{ steps.static_clustering_parity.outcome }}"
           echo "TTL / tombstone / range-marker parity: ${{ steps.ttl_tombstone_range_parity.outcome }}"
           echo "Wide-partition promoted-index parity: ${{ steps.wide_partition_promoted_index_parity.outcome }}"
+          echo "Stitched scan_stream table_id regression: ${{ steps.stitch_table_id_regression.outcome }}"
           echo "Differential-compaction self-consistency: ${{ steps.differential_compaction_parity.outcome }}"
           echo "WRITETIME / TTL / local-deletion-time parity: ${{ steps.writetime_ttl_parity.outcome }}"
           echo "V5CompressedLegacy compression / row-count parity: ${{ steps.v5_compressed_legacy_parity.outcome }}"

--- a/cqlite-core/src/query/agg_stream_probe.rs
+++ b/cqlite-core/src/query/agg_stream_probe.rs
@@ -1,0 +1,87 @@
+//! Cfg-gated aggregate-buffering probe (issue #1578, Epic D / D2).
+//!
+//! # Why this exists
+//!
+//! D2 makes a GROUP-BY-free aggregate (`COUNT`/`MIN`/`MAX`/`SUM`/`AVG` with no
+//! `GROUP BY`) fold the scan stream into an O(1) accumulator instead of buffering
+//! the whole table into a `Vec<QueryRow>` before aggregating. A correct answer
+//! never proves *how much memory* the aggregate held — `COUNT(*)` returns the
+//! same number whether it streamed one row at a time or materialized the table.
+//! This probe makes the buffering observable so the O(1) claim is pinned the
+//! no-heuristics way: observe the *work* (rows resident in the aggregate input
+//! buffer), not just the result.
+//!
+//! # The counter
+//!
+//! - [`record_buffered_rows`] adds the number of rows a single **buffered**
+//!   aggregate input carried (the length of the `Vec<QueryRow>` fed into the
+//!   materializing `execute_aggregation`). The streaming fold path never calls
+//!   it, so a GROUP-BY-free aggregate driven by the fold records `0` regardless
+//!   of table size. On `main`/pre-D2 a `COUNT(*)` over N rows buffered all N and
+//!   recorded N — so the D2 memory guard (`buffered_rows() == 0` for a global
+//!   aggregate; flat across fixture sizes) flips red without the fold.
+//!
+//! # Zero overhead in release (same pattern as [`crate::storage::sstable::read_work_counters`])
+//!
+//! [`record_buffered_rows`] is an **unconditional** `#[inline(always)]` public
+//! function; its body is `#[cfg(any(test, feature = "work-counters"))]`. In a
+//! default/release build (no `work-counters`, no `cfg(test)`) the body is empty
+//! and optimizes away — no atomic is even linked. The getter + [`reset`] are
+//! `#[cfg(any(test, feature = "work-counters"))]`: in-crate unit tests reach them
+//! via the `test` cfg; integration tests in `tests/` enable the `work-counters`
+//! feature (they compile the lib WITHOUT its `test` cfg).
+
+#[cfg(any(test, feature = "work-counters"))]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process-global count of rows fed into the *buffered* aggregate input since the
+/// last [`reset`] (test/feature builds only).
+#[cfg(any(test, feature = "work-counters"))]
+static BUFFERED_ROWS: AtomicU64 = AtomicU64::new(0);
+
+/// Record that a buffered aggregate input carried `n` rows (`AGG_BUFFERED_ROWS`;
+/// consumer D2). Called unconditionally by the materializing `execute_aggregation`;
+/// the body compiles to a no-op in a release build.
+#[inline(always)]
+pub fn record_buffered_rows(n: u64) {
+    #[cfg(any(test, feature = "work-counters"))]
+    BUFFERED_ROWS.fetch_add(n, Ordering::Relaxed);
+    #[cfg(not(any(test, feature = "work-counters")))]
+    let _ = n;
+}
+
+/// Rows fed into the buffered aggregate input since the last [`reset`]
+/// (`AGG_BUFFERED_ROWS`). A GROUP-BY-free aggregate served by the D2 streaming
+/// fold records `0`.
+#[cfg(any(test, feature = "work-counters"))]
+pub fn buffered_rows() -> u64 {
+    BUFFERED_ROWS.load(Ordering::Relaxed)
+}
+
+/// Clear the process-global counter. Integration tests call this before a measured
+/// query so a stale value cannot satisfy a later assertion; because the global is
+/// shared, callers serialize on the shared test mutex (the counter-test convention).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn reset() {
+    BUFFERED_ROWS.store(0, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // Exercises the add/get/reset contract on the process-global. Serialized so it
+    // never overlaps another test mutating the same global.
+    #[test]
+    #[serial]
+    fn buffered_rows_round_trip_and_reset() {
+        reset();
+        assert_eq!(buffered_rows(), 0);
+        record_buffered_rows(5);
+        record_buffered_rows(7);
+        assert_eq!(buffered_rows(), 12);
+        reset();
+        assert_eq!(buffered_rows(), 0);
+    }
+}

--- a/cqlite-core/src/query/mod.rs
+++ b/cqlite-core/src/query/mod.rs
@@ -17,6 +17,7 @@
 // CQL is NOT SQL - it's a query language specifically designed for Cassandra's distributed architecture.
 
 pub mod access_path;
+pub mod agg_stream_probe;
 pub mod engine;
 pub(crate) mod engine_stats;
 pub mod executor;

--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -127,6 +127,25 @@ pub(super) enum AggregateValue {
     Max(Value),
 }
 
+/// Build the initial per-aggregate accumulators for one group. Shared by
+/// [`find_or_init_group`] (the buffered GROUP BY path) and the streaming
+/// GROUP-BY-free fold (issue #1578, D2) so the initial state — and thus the
+/// per-row update + finalize semantics — are defined in exactly one place.
+pub(super) fn init_aggregate_accumulators(
+    aggregates: &[AggregateComputation],
+) -> Vec<AggregateValue> {
+    aggregates
+        .iter()
+        .map(|c| match c.function {
+            AggregateType::Count => AggregateValue::Count(0),
+            AggregateType::Sum => AggregateValue::Sum(0.0),
+            AggregateType::Avg => AggregateValue::Avg { sum: 0.0, count: 0 },
+            AggregateType::Min => AggregateValue::Min(Value::Null),
+            AggregateType::Max => AggregateValue::Max(Value::Null),
+        })
+        .collect()
+}
+
 /// Build the GROUP BY key for `row`. With no GROUP BY, all rows hash into a
 /// single `[Null]` bucket (global aggregation).
 pub(super) fn build_group_key(row: &QueryRow, group_by_columns: &[String]) -> Vec<Value> {
@@ -164,16 +183,7 @@ pub(super) fn find_or_init_group(
             }
         }
     }
-    let initial: Vec<_> = aggregates
-        .iter()
-        .map(|c| match c.function {
-            AggregateType::Count => AggregateValue::Count(0),
-            AggregateType::Sum => AggregateValue::Sum(0.0),
-            AggregateType::Avg => AggregateValue::Avg { sum: 0.0, count: 0 },
-            AggregateType::Min => AggregateValue::Min(Value::Null),
-            AggregateType::Max => AggregateValue::Max(Value::Null),
-        })
-        .collect();
+    let initial = init_aggregate_accumulators(aggregates);
     let new_index = state.groups.len();
     state.groups.push((key, initial));
     state.group_index.entry(hash).or_default().push(new_index);

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -15,18 +15,15 @@
 
 use super::{
     build_row_from_scan, classify_partition_lookup, column_info_from_type_str, evaluate_predicates,
-    honest_targeted_path, parse_table_id, partition_key_digest, project_expr_reshapes_row,
-    select_has_writetime_ttl, sort_rows_by_token, validate_token_predicates,
-    PartitionLookupOutcome, SSTablePredicate,
+    honest_targeted_path, parse_table_id, project_expr_reshapes_row, select_has_writetime_ttl,
+    sort_rows_by_token, validate_token_predicates, PartitionLookupOutcome, SSTablePredicate,
 };
 use super::{
     AccessPath, ColumnInfo, ExecutionContext, ExecutionStep, FallbackReason, OptimizedQueryPlan,
-    ProjectionFlags, QueryResult, QueryRow, Result, SelectExecutor, StorageEngine, TableId,
-    TableSchema,
+    ProjectionFlags, QueryResult, QueryRow, Result, SelectExecutor, TableId, TableSchema,
 };
 use crate::query::result_budget::enforce_materialized_rows;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
 impl SelectExecutor {
     /// Execute an optimized query plan.
@@ -132,93 +129,109 @@ impl SelectExecutor {
             plan.execution_steps.clone()
         };
 
-        for step in &execution_steps {
-            match step {
-                ExecutionStep::SSTableScan {
-                    table,
-                    predicates,
-                    projection,
-                    ..
-                } => {
-                    let rows = self
-                        .execute_sstable_scan(
-                            table,
-                            predicates,
-                            projection,
-                            plan.statement.order_by.as_ref(),
-                            query_schema.as_deref(),
-                            &mut context,
-                        )
-                        .await?;
-                    intermediate_results = rows;
-                }
-                ExecutionStep::Filter { expression, .. } => {
-                    intermediate_results =
-                        self.execute_filter(intermediate_results, expression, &mut context)?;
-                }
-                ExecutionStep::Sort { order_by, .. } => {
-                    // Issue #1184: when the BIG reverse partition iterator already
-                    // produced the rows in descending clustering order, skip the
-                    // in-memory sort entirely (it remains the fallback otherwise).
-                    if !context.reverse_served {
+        // Issue #1578 (D2): fold a GROUP-BY-free aggregate over a full table scan
+        // into an O(1) accumulator instead of buffering the whole table here.
+        // Returns None for any plan shape it does not model (GROUP BY, targeted
+        // lookup, WRITETIME/TTL, or a Sort/Project/Limit step) → the buffered step
+        // loop below runs unchanged.
+        if let Some(rows) = self
+            .try_execute_global_aggregate(&execution_steps, query_schema.as_deref(), &mut context)
+            .await?
+        {
+            intermediate_results = rows;
+        } else {
+            for step in &execution_steps {
+                match step {
+                    ExecutionStep::SSTableScan {
+                        table,
+                        predicates,
+                        projection,
+                        ..
+                    } => {
+                        let rows = self
+                            .execute_sstable_scan(
+                                table,
+                                predicates,
+                                projection,
+                                plan.statement.order_by.as_ref(),
+                                query_schema.as_deref(),
+                                &mut context,
+                            )
+                            .await?;
+                        intermediate_results = rows;
+                    }
+                    ExecutionStep::Filter { expression, .. } => {
                         intermediate_results =
-                            self.execute_sort(intermediate_results, order_by, &mut context)?;
-                    } else {
-                        // Issue #1307 (hardening): skipping this Sort is sound ONLY
-                        // because `reverse_served` is set exclusively by
-                        // `targeted_partition_rows`, which serves the reverse
-                        // promoted-index iterator precisely when `statement.order_by`
-                        // requests the reverse of the stored clustering order — and
-                        // the planner emits EXACTLY ONE `Sort` step, cloned from that
-                        // same `statement.order_by` (see `select_optimizer.rs`). So
-                        // the reverse scan's ordering matches this step's `order_by`,
-                        // and skipping it drops a redundant sort rather than a
-                        // different ordering. What would break the invariant: a
-                        // multi-table / join plan (or any plan) that reused the flag
-                        // across a Sort NOT derived from the reverse-served scan's
-                        // `statement.order_by` — such a plan must clear
-                        // `reverse_served` before this step. The debug_assert pins
-                        // the property (the skipped Sort's key equals the statement's
-                        // order_by); it is debug-only and never alters release
-                        // behavior.
-                        debug_assert!(
-                            plan.statement.order_by.as_ref() == Some(order_by),
-                            "reverse_served Sort-skip invariant violated: the skipped \
+                            self.execute_filter(intermediate_results, expression, &mut context)?;
+                    }
+                    ExecutionStep::Sort { order_by, .. } => {
+                        // Issue #1184: when the BIG reverse partition iterator already
+                        // produced the rows in descending clustering order, skip the
+                        // in-memory sort entirely (it remains the fallback otherwise).
+                        if !context.reverse_served {
+                            intermediate_results =
+                                self.execute_sort(intermediate_results, order_by, &mut context)?;
+                        } else {
+                            // Issue #1307 (hardening): skipping this Sort is sound ONLY
+                            // because `reverse_served` is set exclusively by
+                            // `targeted_partition_rows`, which serves the reverse
+                            // promoted-index iterator precisely when `statement.order_by`
+                            // requests the reverse of the stored clustering order — and
+                            // the planner emits EXACTLY ONE `Sort` step, cloned from that
+                            // same `statement.order_by` (see `select_optimizer.rs`). So
+                            // the reverse scan's ordering matches this step's `order_by`,
+                            // and skipping it drops a redundant sort rather than a
+                            // different ordering. What would break the invariant: a
+                            // multi-table / join plan (or any plan) that reused the flag
+                            // across a Sort NOT derived from the reverse-served scan's
+                            // `statement.order_by` — such a plan must clear
+                            // `reverse_served` before this step. The debug_assert pins
+                            // the property (the skipped Sort's key equals the statement's
+                            // order_by); it is debug-only and never alters release
+                            // behavior.
+                            debug_assert!(
+                                plan.statement.order_by.as_ref() == Some(order_by),
+                                "reverse_served Sort-skip invariant violated: the skipped \
                              Sort's order_by must be the statement's order_by that drove \
                              the reverse-served scan (single-table plan); a plan whose \
                              Sort is not the reverse scan's matching Sort must clear \
                              reverse_served first",
-                        );
+                            );
+                        }
                     }
-                }
-                ExecutionStep::Aggregate { plan: agg_plan, .. } => {
-                    intermediate_results =
-                        self.execute_aggregation(intermediate_results, agg_plan, &mut context)?;
-                }
-                ExecutionStep::PerPartitionLimit { count } => {
-                    intermediate_results =
-                        Self::execute_per_partition_limit(intermediate_results, *count);
-                }
-                ExecutionStep::Limit { count, offset } => {
-                    intermediate_results =
-                        self.execute_limit(intermediate_results, *count, *offset, &mut context)?;
-                }
-                ExecutionStep::Project { columns } => {
-                    // Issue #1952 (round-6 fix): branch on whether the projection
-                    // RESHAPES the row. A plain-column Project only trims the
-                    // #1952-widened helper columns — route it through the
-                    // key-preserving `trim_projection` so the row keeps its real
-                    // RowKey / metadata and a sparse row's absent selected cell is
-                    // omitted rather than erroring. Only a reshaping / computed
-                    // projection (alias, arithmetic, aggregate, function,
-                    // writetime/ttl, collection-access) goes through
-                    // `execute_projection`, whose empty-RowKey + name-derivation is
-                    // correct for a computed row that has no natural stored key.
-                    intermediate_results = if columns.iter().any(project_expr_reshapes_row) {
-                        self.execute_projection(intermediate_results, columns, &mut context)?
-                    } else {
-                        self.trim_projection(intermediate_results, columns)
-                    };
+                    ExecutionStep::Aggregate { plan: agg_plan, .. } => {
+                        intermediate_results =
+                            self.execute_aggregation(intermediate_results, agg_plan, &mut context)?;
+                    }
+                    ExecutionStep::PerPartitionLimit { count } => {
+                        intermediate_results =
+                            Self::execute_per_partition_limit(intermediate_results, *count);
+                    }
+                    ExecutionStep::Limit { count, offset } => {
+                        intermediate_results = self.execute_limit(
+                            intermediate_results,
+                            *count,
+                            *offset,
+                            &mut context,
+                        )?;
+                    }
+                    ExecutionStep::Project { columns } => {
+                        // Issue #1952 (round-6 fix): branch on whether the projection
+                        // RESHAPES the row. A plain-column Project only trims the
+                        // #1952-widened helper columns — route it through the
+                        // key-preserving `trim_projection` so the row keeps its real
+                        // RowKey / metadata and a sparse row's absent selected cell is
+                        // omitted rather than erroring. Only a reshaping / computed
+                        // projection (alias, arithmetic, aggregate, function,
+                        // writetime/ttl, collection-access) goes through
+                        // `execute_projection`, whose empty-RowKey + name-derivation is
+                        // correct for a computed row that has no natural stored key.
+                        intermediate_results = if columns.iter().any(project_expr_reshapes_row) {
+                            self.execute_projection(intermediate_results, columns, &mut context)?
+                        } else {
+                            self.trim_projection(intermediate_results, columns)
+                        };
+                    }
                 }
             }
         }
@@ -242,10 +255,20 @@ impl SelectExecutor {
         //   * Does NOT cover the LEGACY point-lookup `QueryExecutor` path
         //     (`WHERE id = ?` short lookups route there, not through this modern
         //     executor) — deferred to the D6 redesign.
+        // Issue #1578 (D2): demote the row-count valve to a genuine safety valve.
+        // A query with an EXPLICIT `LIMIT` already bounds its own result, so it is
+        // exempt from the crude row-count ceiling (the user accepted the count);
+        // the byte budget still guards memory. Without an explicit LIMIT the valve
+        // remains a real net against unbounded materialization.
+        let effective_max_rows = if plan.statement.limit.is_some() {
+            usize::MAX
+        } else {
+            self.max_result_rows
+        };
         enforce_materialized_rows(
             &intermediate_results,
             self.max_result_bytes,
-            self.max_result_rows,
+            effective_max_rows,
         )?;
 
         let total_rows = intermediate_results.len() as u64;
@@ -343,305 +366,6 @@ impl SelectExecutor {
                 access_path: context.access_path.clone(),
             },
         })
-    }
-
-    /// Background task: Execute streaming scan and send rows through channel
-    pub(super) async fn execute_streaming_background(
-        storage: Arc<StorageEngine>,
-        // Issue #1587 (E5): schema resolved ONCE per query by `execute_streaming`
-        // and moved into this task — no per-scan-step registry lock + deep clone.
-        query_schema: Option<Arc<TableSchema>>,
-        _table_id: TableId,
-        execution_steps: Vec<ExecutionStep>,
-        tx: mpsc::Sender<Result<QueryRow>>,
-        buffer_size: usize,
-    ) -> Result<()> {
-        // Issue #581: LIMIT/OFFSET must be enforced by the producer in the
-        // streaming path. The `ExecutionStep::Limit` arm previously only logged a
-        // message and relied on a consumer that never applied it, so
-        // `execute_streaming` yielded the full result set regardless of LIMIT.
-        // Extract the bound up front (steps are ordered with Limit after the scan)
-        // and stop sending once it is satisfied — mirroring `execute_limit`
-        // (drain OFFSET, then truncate to `count`) row-by-row so the producer
-        // stops scanning early.
-        let limit = execution_steps.iter().find_map(|step| match step {
-            ExecutionStep::Limit { count, offset } => Some((*count, offset.unwrap_or(0))),
-            _ => None,
-        });
-        let (limit_count, mut offset_remaining) = match limit {
-            Some((count, offset)) => (Some(count), offset),
-            None => (None, 0),
-        };
-
-        // A `LIMIT 0` means no rows can ever be sent; return before scanning.
-        if limit_count == Some(0) {
-            return Ok(());
-        }
-
-        // Issue #757: PER PARTITION LIMIT caps rows per partition before the
-        // query-wide LIMIT/OFFSET. The scan yields rows grouped by partition
-        // key, so we track the current partition and reset the counter at each
-        // boundary. Issue #1590 (E8): the boundary is compared on the partition
-        // key's 128-bit `partition_key_digest` (a heap-free hash of the key bytes
-        // we already hold) as a FAST pre-check, then confirmed by EXACT byte
-        // equality against the current partition's raw bytes — stored ONCE when
-        // the boundary advances, never cloned per row. This keeps correctness
-        // independent of digest collisions (a collision between two DISTINCT
-        // partitions never shares a counter).
-        let per_partition_limit = execution_steps.iter().find_map(|step| match step {
-            ExecutionStep::PerPartitionLimit { count } => Some(*count),
-            _ => None,
-        });
-        let mut current_partition: Option<(u128, Vec<u8>)> = None;
-        let mut partition_count: u64 = 0;
-
-        let mut sent: u64 = 0;
-
-        for step in &execution_steps {
-            match step {
-                ExecutionStep::SSTableScan {
-                    table,
-                    predicates,
-                    projection,
-                    ..
-                } => {
-                    let schema_opt = query_schema.as_deref();
-
-                    // FINDING 2 (Issue #955 follow-up): reject a `token(...)` whose
-                    // columns are not the full partition key in declared order
-                    // before scanning (same rule as the materializing path).
-                    validate_token_predicates(predicates, schema_opt)?;
-
-                    // Issue #949: a fully-constrained `WHERE pk = ?` is served by a
-                    // partition-targeted lookup that prunes SSTables via bloom/BTI,
-                    // instead of streaming a scan over every SSTable. The resulting
-                    // rows are sent through the same per-row pipeline below
-                    // (predicates, PER PARTITION LIMIT, OFFSET, LIMIT). Note
-                    // `scan_partition` reconciles across SSTable generations like the
-                    // materializing `scan()` (last-write-wins + tombstone shadowing),
-                    // which is the authoritative read semantics; it does not merely
-                    // mirror `scan_stream`'s per-key merge.
-                    let lookup = classify_partition_lookup(predicates, schema_opt);
-                    if let PartitionLookupOutcome::Targeted(ref pk_bytes) = lookup {
-                        // Issue #960: the streaming analogue of the materializing
-                        // partition-targeted lookup. Epic #951 (honest paths): the
-                        // `tombstones` build's `scan_partition` is a full-scan +
-                        // retain with NO prune, reported via `engaged == false`; only
-                        // claim `StreamingPartitionLookup` when it really pruned.
-                        let (rows, engaged) =
-                            storage.scan_partition(table, pk_bytes, schema_opt).await?;
-                        crate::query::access_path::record(honest_targeted_path(
-                            AccessPath::StreamingPartitionLookup,
-                            engaged,
-                        ));
-                        for (key, value) in rows {
-                            let part_sig =
-                                per_partition_limit.map(|_| partition_key_digest(&key.0));
-                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
-                            else {
-                                continue;
-                            };
-                            if !evaluate_predicates(&row, predicates)? {
-                                continue;
-                            }
-                            if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                                // Fast digest pre-check, then EXACT byte confirm so a
-                                // digest collision between DISTINCT partitions never
-                                // shares a counter (issue #1590).
-                                let same = matches!(
-                                    &current_partition,
-                                    Some((d, bytes))
-                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
-                                );
-                                if !same {
-                                    // Clone the key bytes ONCE per boundary, not per row.
-                                    current_partition = Some((sig, row.key.0.clone()));
-                                    partition_count = 0;
-                                }
-                                if partition_count >= cap {
-                                    continue;
-                                }
-                                partition_count += 1;
-                            }
-                            if offset_remaining > 0 {
-                                offset_remaining -= 1;
-                                continue;
-                            }
-                            if tx.send(Ok(row)).await.is_err() {
-                                return Ok(());
-                            }
-                            sent += 1;
-                            if let Some(count) = limit_count {
-                                if sent >= count {
-                                    return Ok(());
-                                }
-                            }
-                        }
-                        // This SSTableScan step is fully served by the lookup.
-                        continue;
-                    }
-
-                    // Issue #955: `WHERE pk IN (...)` over the complete key is the
-                    // union of N partition-targeted lookups. Gather them, sort by
-                    // token to match full-scan order, then drive the same per-row
-                    // pipeline (predicates, PER PARTITION LIMIT, OFFSET, LIMIT).
-                    if let PartitionLookupOutcome::MultiTargeted(ref pk_keys) = lookup {
-                        // Epic #951 (honest paths): each lookup reports whether it
-                        // pruned. On the `tombstones` build every call full-scans
-                        // (`engaged == false`); claim `MultiPartitionLookup` only when
-                        // the lookups actually pruned, else report the honest fallback.
-                        let mut combined = Vec::new();
-                        let mut all_engaged = true;
-                        for pk_bytes in pk_keys {
-                            let (rows, engaged) =
-                                storage.scan_partition(table, pk_bytes, schema_opt).await?;
-                            all_engaged &= engaged;
-                            combined.extend(rows);
-                        }
-                        crate::query::access_path::record(honest_targeted_path(
-                            AccessPath::MultiPartitionLookup,
-                            all_engaged,
-                        ));
-                        sort_rows_by_token(&mut combined);
-                        for (key, value) in combined {
-                            let part_sig =
-                                per_partition_limit.map(|_| partition_key_digest(&key.0));
-                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
-                            else {
-                                continue;
-                            };
-                            if !evaluate_predicates(&row, predicates)? {
-                                continue;
-                            }
-                            if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                                // Fast digest pre-check, then EXACT byte confirm so a
-                                // digest collision between DISTINCT partitions never
-                                // shares a counter (issue #1590).
-                                let same = matches!(
-                                    &current_partition,
-                                    Some((d, bytes))
-                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
-                                );
-                                if !same {
-                                    // Clone the key bytes ONCE per boundary, not per row.
-                                    current_partition = Some((sig, row.key.0.clone()));
-                                    partition_count = 0;
-                                }
-                                if partition_count >= cap {
-                                    continue;
-                                }
-                                partition_count += 1;
-                            }
-                            if offset_remaining > 0 {
-                                offset_remaining -= 1;
-                                continue;
-                            }
-                            if tx.send(Ok(row)).await.is_err() {
-                                return Ok(());
-                            }
-                            sent += 1;
-                            if let Some(count) = limit_count {
-                                if sent >= count {
-                                    return Ok(());
-                                }
-                            }
-                        }
-                        // This SSTableScan step is fully served by the lookups.
-                        continue;
-                    }
-
-                    // Issue #960: the streaming path did not take a targeted
-                    // lookup; report the honest fallback reason. `lookup` is the
-                    // `Fallback` arm here (the `Targeted`/`MultiTargeted` arms
-                    // returned above via `continue`).
-                    if let PartitionLookupOutcome::Fallback(reason) = lookup {
-                        crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
-                    }
-
-                    // Issue #790: pull rows lazily from a bounded streaming scan
-                    // instead of materializing the full result `Vec`. The reader
-                    // parses one entry at a time into this channel, so live heap
-                    // stays bounded by `buffer_size` rather than O(result rows).
-                    let mut scan_stream = storage
-                        .scan_stream(table, None, None, schema_opt, buffer_size)
-                        .await?;
-
-                    while let Some(item) = scan_stream.recv().await {
-                        let (key, value) = item?;
-                        // Capture the partition-key digest before `key` is moved
-                        // into row construction (only when needed).
-                        let part_sig = per_partition_limit.map(|_| partition_key_digest(&key.0));
-                        let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
-                        else {
-                            continue;
-                        };
-
-                        if !evaluate_predicates(&row, predicates)? {
-                            continue;
-                        }
-
-                        // Apply PER PARTITION LIMIT: cap matching rows per
-                        // partition, before OFFSET/LIMIT (Cassandra semantics).
-                        if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                            // Fast digest pre-check, then EXACT byte confirm so a
-                            // digest collision between DISTINCT partitions never
-                            // shares a counter (issue #1590).
-                            let same = matches!(
-                                &current_partition,
-                                Some((d, bytes))
-                                    if *d == sig && bytes.as_slice() == row.key.0.as_slice()
-                            );
-                            if !same {
-                                // Clone the key bytes ONCE per boundary, not per row.
-                                current_partition = Some((sig, row.key.0.clone()));
-                                partition_count = 0;
-                            }
-                            if partition_count >= cap {
-                                continue;
-                            }
-                            partition_count += 1;
-                        }
-
-                        // Apply OFFSET: skip the first `offset_remaining` matches.
-                        if offset_remaining > 0 {
-                            offset_remaining -= 1;
-                            continue;
-                        }
-
-                        // Send row through channel (with backpressure). Consumer drop ends the scan.
-                        if tx.send(Ok(row)).await.is_err() {
-                            return Ok(());
-                        }
-                        sent += 1;
-
-                        // Apply LIMIT: stop scanning once `count` rows have been
-                        // sent. Dropping `scan_stream` here signals the producer
-                        // (via a closed channel) to stop parsing early.
-                        if let Some(count) = limit_count {
-                            if sent >= count {
-                                return Ok(());
-                            }
-                        }
-                    }
-                }
-                ExecutionStep::Limit { .. } | ExecutionStep::PerPartitionLimit { .. } => {
-                    // Enforced inline during the scan above (see the bounds
-                    // extracted before the loop).
-                }
-                // Projection and predicate filtering are pushed into SSTableScan above.
-                ExecutionStep::Project { .. } | ExecutionStep::Filter { .. } => {}
-                _ => {
-                    // Data-safety (issue #1694): log the step's variant name only,
-                    // never its contents (which carry query literals/values).
-                    log::warn!(
-                        "Streaming execution: skipping unsupported step {}",
-                        step.variant_name()
-                    );
-                }
-            }
-        }
-
-        Ok(())
     }
 
     /// Execute SSTable scan with predicate pushdown.

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -1,11 +1,12 @@
 //! Async pipeline entry points for the SELECT executor (issue #1174).
 //!
 //! This submodule continues the [`SelectExecutor`](super::SelectExecutor) `impl`
-//! with the three large `async` pipeline methods that drive query execution:
+//! with the large `async` pipeline methods that drive query execution:
 //! - [`SelectExecutor::execute`] — the materializing plan runner,
-//! - [`SelectExecutor::execute_streaming_background`] — the streaming producer
-//!   task spawned by `execute_streaming` (which stays in `mod.rs`),
 //! - [`SelectExecutor::execute_sstable_scan`] — the SSTable-scan step.
+//!
+//! (The streaming producer, `execute_streaming_background`, moved to the sibling
+//! `streaming` submodule in issue #1578's file-size split.)
 //!
 //! These were relocated verbatim from `mod.rs` (epic #1116 file-size split); the
 //! per-step helpers they call (`execute_filter`, `execute_sort`, etc.) and the

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -41,6 +41,8 @@ mod execute;
 mod lookup;
 mod predicate;
 mod row_build;
+mod stream_agg;
+mod streaming;
 mod value_ops;
 mod writetime_ttl;
 
@@ -54,7 +56,7 @@ use super::{
         QueryResultIterator, QueryRow, StreamingConfig,
     },
     select_ast::*,
-    select_optimizer::{AggregationPlan, ExecutionStep, OptimizedQueryPlan, SSTablePredicate},
+    select_optimizer::{ExecutionStep, OptimizedQueryPlan, SSTablePredicate},
 };
 use crate::{
     schema::{CqlType, SchemaManager, TableSchema},
@@ -66,9 +68,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-use aggregation::{
-    build_group_key, finalize_group, find_or_init_group, update_aggregate, AggregationState,
-};
 use lookup::{
     classify_partition_lookup, honest_targeted_path, sort_rows_by_token, PartitionLookupOutcome,
 };
@@ -461,9 +460,20 @@ impl SelectExecutor {
         // previous query cannot satisfy a test assertion against this one.
         crate::query::access_path::reset();
 
-        // Check if query requires full materialization (ORDER BY, GROUP BY, aggregates)
+        // Issue #1578 (D2): route ANY aggregate through `execute_and_stream`, which
+        // delegates to `execute`. For a GROUP-BY-free aggregate `execute` runs the
+        // O(1) fold (`try_execute_global_aggregate`) — no whole-table buffer — so
+        // the streaming API is no longer forced through a buffered path; for a
+        // GROUP BY it runs the (E5) materialized path. This must precede the
+        // `requires_materialization` check, which now returns `false` for a global
+        // aggregate (it does not require full materialization).
+        if plan.aggregation_plan.is_some() {
+            return self.execute_and_stream(plan, config).await;
+        }
+
+        // Check if query requires full materialization (ORDER BY, GROUP BY, projection trim)
         if self.requires_materialization(&plan) {
-            log::info!("Query requires materialization (ORDER BY/GROUP BY/aggregates), using execute-then-stream");
+            log::info!("Query requires materialization (ORDER BY/GROUP BY/projection trim), using execute-then-stream");
             return self.execute_and_stream(plan, config).await;
         }
 
@@ -565,7 +575,18 @@ impl SelectExecutor {
         for step in &plan.execution_steps {
             match step {
                 ExecutionStep::Sort { .. } => return true,
-                ExecutionStep::Aggregate { .. } => return true,
+                // Issue #1578 (D2): a GROUP-BY-free aggregate no longer requires
+                // full materialization — `execute` folds it into an O(1)
+                // accumulator (`try_execute_global_aggregate`). Only a GROUP BY
+                // aggregate still buffers (E5 territory). `execute_streaming`
+                // routes ALL aggregates to `execute_and_stream` explicitly (via the
+                // `aggregation_plan` check), so a global aggregate returning `false`
+                // here is still served correctly (through the folded `execute`).
+                ExecutionStep::Aggregate { plan: agg_plan, .. }
+                    if !agg_plan.group_by_columns.is_empty() =>
+                {
+                    return true
+                }
                 // The streaming producer (`execute_streaming_background`) IGNORES
                 // `Project`, so a `Project` step that changes the row's column SET
                 // or SHAPE must fall back to the materialized execute()-then-stream
@@ -917,59 +938,6 @@ impl SelectExecutor {
         });
 
         Ok(decorated.into_iter().map(|(_, row)| row).collect())
-    }
-
-    /// Execute the aggregation step. Splits naturally into three phases:
-    /// build group key, accumulate per-aggregate state, then finalize each
-    /// group into a result row.
-    fn execute_aggregation(
-        &self,
-        rows: Vec<QueryRow>,
-        agg_plan: &AggregationPlan,
-        _context: &mut ExecutionContext,
-    ) -> Result<Vec<QueryRow>> {
-        const PER_ROW_MEMORY_ESTIMATE_BYTES: usize = 100;
-        const DEFAULT_AGGREGATION_MEMORY_LIMIT: usize = 512 * 1024 * 1024;
-
-        // Issue #1578 (D2): record how many rows this buffered aggregate input
-        // carried, so the O(1) memory guard can prove a GROUP-BY-free aggregate
-        // served by the streaming fold buffers ZERO rows here (the fold never
-        // calls this method). Zero-overhead in release (probe body is cfg-gated).
-        crate::query::agg_stream_probe::record_buffered_rows(rows.len() as u64);
-
-        let mut agg_state = AggregationState {
-            groups: Vec::new(),
-            group_index: rustc_hash::FxHashMap::default(),
-            memory_usage_bytes: 0,
-            memory_limit_bytes: DEFAULT_AGGREGATION_MEMORY_LIMIT,
-        };
-
-        for row in rows {
-            let group_key = build_group_key(&row, &agg_plan.group_by_columns);
-            let group_index = find_or_init_group(&mut agg_state, group_key, &agg_plan.aggregates);
-            let group_aggregates = &mut agg_state.groups[group_index].1;
-
-            for (i, agg_comp) in agg_plan.aggregates.iter().enumerate() {
-                update_aggregate(&mut group_aggregates[i], agg_comp, &row);
-            }
-
-            agg_state.memory_usage_bytes += PER_ROW_MEMORY_ESTIMATE_BYTES;
-            if agg_state.memory_usage_bytes > agg_state.memory_limit_bytes {
-                return Err(Error::query_execution(
-                    "Aggregation memory limit exceeded".to_string(),
-                ));
-            }
-        }
-
-        let result_rows = agg_state
-            .groups
-            .into_iter()
-            .map(|(group_key, group_aggregates)| {
-                finalize_group(group_key, group_aggregates, agg_plan)
-            })
-            .collect();
-
-        Ok(result_rows)
     }
 
     /// Execute PER PARTITION LIMIT: keep at most `count` rows per partition,

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -16,12 +16,15 @@
 //! - [`value_ops`] — value comparison + arithmetic primitives,
 //! - [`predicate`] — SSTable leaf-predicate evaluation (public `evaluate_*`),
 //! - [`lookup`] — partition/clustering lookup classification,
-//! - [`aggregation`] — GROUP BY accumulation,
+//! - [`aggregation`] — GROUP BY accumulator state + shared per-row update helpers,
+//! - [`stream_agg`] — aggregation execution: the buffered `execute_aggregation`
+//!   and the O(1) streaming-fold `try_execute_global_aggregate` (issue #1578),
 //! - [`row_build`] — scan-row assembly (public `build_row_from_scan`),
 //! - [`writetime_ttl`] — WRITETIME/TTL projection + injectable clock,
-//! - [`execute`] — the three large `async` pipeline methods (`execute`,
-//!   `execute_streaming_background`, `execute_sstable_scan`) as an `impl`
-//!   continuation (issue #1174),
+//! - [`execute`] — the `async` pipeline methods `execute` and
+//!   `execute_sstable_scan` as an `impl` continuation (issue #1174),
+//! - [`streaming`] — the streaming producer task, `execute_streaming_background`
+//!   (split out of `execute` in issue #1578),
 //! - this `mod.rs` — the [`SelectExecutor`] orchestration and remaining
 //!   per-step helpers.
 //!

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -931,6 +931,12 @@ impl SelectExecutor {
         const PER_ROW_MEMORY_ESTIMATE_BYTES: usize = 100;
         const DEFAULT_AGGREGATION_MEMORY_LIMIT: usize = 512 * 1024 * 1024;
 
+        // Issue #1578 (D2): record how many rows this buffered aggregate input
+        // carried, so the O(1) memory guard can prove a GROUP-BY-free aggregate
+        // served by the streaming fold buffers ZERO rows here (the fold never
+        // calls this method). Zero-overhead in release (probe body is cfg-gated).
+        crate::query::agg_stream_probe::record_buffered_rows(rows.len() as u64);
+
         let mut agg_state = AggregationState {
             groups: Vec::new(),
             group_index: rustc_hash::FxHashMap::default(),

--- a/cqlite-core/src/query/select_executor/stream_agg.rs
+++ b/cqlite-core/src/query/select_executor/stream_agg.rs
@@ -1,0 +1,240 @@
+//! Aggregation execution for the SELECT executor (issue #1116 split; issue #1578).
+//!
+//! Two paths live here:
+//! - [`SelectExecutor::execute_aggregation`] — the buffered GROUP BY / global
+//!   aggregate accumulation over an already-materialized `Vec<QueryRow>`.
+//! - [`SelectExecutor::try_execute_global_aggregate`] — the issue #1578 (D2)
+//!   O(1) streaming fold: a GROUP-BY-free aggregate over a full table scan folds
+//!   each scanned row into a single running accumulator and drops the row, so
+//!   `COUNT(*)`/`MIN`/`MAX`/`SUM`/`AVG` never buffer the whole table.
+
+use super::aggregation::{
+    build_group_key, finalize_group, find_or_init_group, init_aggregate_accumulators,
+    update_aggregate, AggregationState,
+};
+use super::{
+    build_row_from_scan, classify_partition_lookup, evaluate_predicates, validate_token_predicates,
+    AccessPath, ExecutionContext, ExecutionStep, PartitionLookupOutcome, SelectExecutor,
+};
+use crate::query::result::QueryRow;
+use crate::query::select_ast::WhereExpression;
+use crate::query::select_optimizer::{AggregationPlan, SSTablePredicate};
+use crate::schema::TableSchema;
+use crate::{Error, Result, TableId, Value};
+
+/// Read-ahead window for the D2 aggregate fold's scan stream. The fold retains
+/// only the running accumulator, so this bounds the in-flight scan rows (not the
+/// result) — the same role `StreamingConfig::buffer_size` plays for the streaming
+/// producer.
+const AGG_FOLD_SCAN_BUFFER: usize = 1024;
+
+/// The plan shape eligible for the O(1) global-aggregate fold: one full-scan step,
+/// one GROUP-BY-free aggregate, and zero or more post-scan `Filter`s.
+struct GlobalAggregatePlan<'a> {
+    table: &'a TableId,
+    predicates: &'a [SSTablePredicate],
+    projection: &'a [String],
+    filters: Vec<&'a WhereExpression>,
+    agg_plan: &'a AggregationPlan,
+}
+
+impl SelectExecutor {
+    /// Execute the aggregation step over already-materialized rows. Splits
+    /// naturally into three phases: build group key, accumulate per-aggregate
+    /// state, then finalize each group into a result row.
+    pub(super) fn execute_aggregation(
+        &self,
+        rows: Vec<QueryRow>,
+        agg_plan: &AggregationPlan,
+        _context: &mut ExecutionContext,
+    ) -> Result<Vec<QueryRow>> {
+        const PER_ROW_MEMORY_ESTIMATE_BYTES: usize = 100;
+        const DEFAULT_AGGREGATION_MEMORY_LIMIT: usize = 512 * 1024 * 1024;
+
+        // Issue #1578 (D2): record how many rows this buffered aggregate input
+        // carried, so the O(1) memory guard can prove a GROUP-BY-free aggregate
+        // served by the streaming fold buffers ZERO rows here (the fold never
+        // calls this method). Zero-overhead in release (probe body is cfg-gated).
+        crate::query::agg_stream_probe::record_buffered_rows(rows.len() as u64);
+
+        let mut agg_state = AggregationState {
+            groups: Vec::new(),
+            group_index: rustc_hash::FxHashMap::default(),
+            memory_usage_bytes: 0,
+            memory_limit_bytes: DEFAULT_AGGREGATION_MEMORY_LIMIT,
+        };
+
+        for row in rows {
+            let group_key = build_group_key(&row, &agg_plan.group_by_columns);
+            let group_index = find_or_init_group(&mut agg_state, group_key, &agg_plan.aggregates);
+            let group_aggregates = &mut agg_state.groups[group_index].1;
+
+            for (i, agg_comp) in agg_plan.aggregates.iter().enumerate() {
+                update_aggregate(&mut group_aggregates[i], agg_comp, &row);
+            }
+
+            agg_state.memory_usage_bytes += PER_ROW_MEMORY_ESTIMATE_BYTES;
+            if agg_state.memory_usage_bytes > agg_state.memory_limit_bytes {
+                return Err(Error::query_execution(
+                    "Aggregation memory limit exceeded".to_string(),
+                ));
+            }
+        }
+
+        let result_rows = agg_state
+            .groups
+            .into_iter()
+            .map(|(group_key, group_aggregates)| {
+                finalize_group(group_key, group_aggregates, agg_plan)
+            })
+            .collect();
+
+        Ok(result_rows)
+    }
+
+    /// Issue #1578 (D2): if `steps` is a GROUP-BY-free aggregate over a FULL table
+    /// scan, fold the scan stream into an O(1) accumulator and return the single
+    /// finalized result row — instead of buffering the whole table into a
+    /// `Vec<QueryRow>` and calling [`Self::execute_aggregation`].
+    ///
+    /// Returns `Ok(None)` when the plan is NOT eligible — a GROUP BY (E5 territory),
+    /// a partition-targeted / multi-partition lookup (single/few small partitions
+    /// the buffered path handles fine), a WRITETIME/TTL cell-metadata projection,
+    /// or any `Sort`/`Project`/`Limit`/`PerPartitionLimit` step — and the caller
+    /// must use the buffered path. On the eligible path the per-row update and
+    /// finalize reuse the exact buffered-path helpers, so the answer is identical.
+    pub(super) async fn try_execute_global_aggregate(
+        &self,
+        steps: &[ExecutionStep],
+        schema_opt: Option<&TableSchema>,
+        context: &mut ExecutionContext,
+    ) -> Result<Option<Vec<QueryRow>>> {
+        // A WRITETIME/TTL projection needs the per-cell metadata scan, not this fold.
+        if context.projection_flags.include_cell_metadata {
+            return Ok(None);
+        }
+
+        let Some(eligible) = classify_global_aggregate(steps) else {
+            return Ok(None);
+        };
+        let GlobalAggregatePlan {
+            table,
+            predicates,
+            projection,
+            filters,
+            agg_plan,
+        } = eligible;
+
+        // A `token(...)` predicate must cover the full partition key (same rule as
+        // every scan path) before we scan/evaluate it.
+        validate_token_predicates(predicates, schema_opt)?;
+
+        // Only a full scan is folded. A targeted / multi-targeted lookup reads one
+        // or a few small partitions, so the buffered path's memory is already
+        // O(partition) — fall back and let it run unchanged.
+        let reason = match classify_partition_lookup(predicates, schema_opt) {
+            PartitionLookupOutcome::Fallback(reason) => reason,
+            PartitionLookupOutcome::Targeted(_) | PartitionLookupOutcome::MultiTargeted(_) => {
+                return Ok(None);
+            }
+        };
+
+        // Record the honest full-scan access path, exactly as the buffered scan
+        // step does, so observability/plan-family assertions are unchanged.
+        context.access_path = Some(AccessPath::FallbackFullScan { reason });
+        crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
+
+        let mut accumulators = init_aggregate_accumulators(&agg_plan.aggregates);
+        let mut folded_any = false;
+
+        let mut scan_stream = self
+            .storage
+            .scan_stream(table, None, None, schema_opt, AGG_FOLD_SCAN_BUFFER)
+            .await?;
+        while let Some(item) = scan_stream.recv().await {
+            let (key, value) = item?;
+            context.rows_processed += 1;
+            context.scan_rows += 1;
+
+            let Some(row) = build_row_from_scan(key, value, projection, schema_opt) else {
+                continue;
+            };
+            if !evaluate_predicates(&row, predicates)? {
+                continue;
+            }
+            // Apply any residual (non-pushed) WHERE as a per-row filter.
+            let mut keep = true;
+            for filter in &filters {
+                if !self.evaluate_where_expression(filter, &row)? {
+                    keep = false;
+                    break;
+                }
+            }
+            if !keep {
+                continue;
+            }
+
+            folded_any = true;
+            for (i, agg_comp) in agg_plan.aggregates.iter().enumerate() {
+                update_aggregate(&mut accumulators[i], agg_comp, &row);
+            }
+        }
+
+        // Preserve the buffered path's semantics exactly: an empty aggregate input
+        // produces NO group (0 result rows), not a synthetic COUNT=0 row. (The
+        // Cassandra one-row-for-empty divergence is a pre-existing behavior gap
+        // tracked outside this memory fix.)
+        if !folded_any {
+            return Ok(Some(Vec::new()));
+        }
+
+        let row = finalize_group(vec![Value::Null], accumulators, agg_plan);
+        Ok(Some(vec![row]))
+    }
+}
+
+/// Classify `steps` as an eligible GROUP-BY-free full-scan aggregate, returning
+/// the borrowed scan + aggregate + residual-filter references, or `None` when any
+/// step disqualifies it (see [`SelectExecutor::try_execute_global_aggregate`]).
+fn classify_global_aggregate(steps: &[ExecutionStep]) -> Option<GlobalAggregatePlan<'_>> {
+    let mut scan: Option<(&TableId, &[SSTablePredicate], &[String])> = None;
+    let mut agg_plan: Option<&AggregationPlan> = None;
+    let mut filters: Vec<&WhereExpression> = Vec::new();
+
+    for step in steps {
+        match step {
+            ExecutionStep::SSTableScan {
+                table,
+                predicates,
+                projection,
+                ..
+            } => {
+                if scan.is_some() {
+                    return None;
+                }
+                scan = Some((table, predicates.as_slice(), projection.as_slice()));
+            }
+            ExecutionStep::Aggregate { plan, .. } => {
+                // Only a GLOBAL aggregate (no GROUP BY), and only one.
+                if !plan.group_by_columns.is_empty() || agg_plan.is_some() {
+                    return None;
+                }
+                agg_plan = Some(plan);
+            }
+            ExecutionStep::Filter { expression, .. } => filters.push(expression),
+            // Sort / Project / Limit / PerPartitionLimit reshape or bound the result
+            // in ways the single-row fold does not model — use the buffered path.
+            _ => return None,
+        }
+    }
+
+    let (table, predicates, projection) = scan?;
+    let agg_plan = agg_plan?;
+    Some(GlobalAggregatePlan {
+        table,
+        predicates,
+        projection,
+        filters,
+        agg_plan,
+    })
+}

--- a/cqlite-core/src/query/select_executor/streaming.rs
+++ b/cqlite-core/src/query/select_executor/streaming.rs
@@ -1,0 +1,318 @@
+//! Streaming SELECT producer (`execute_streaming_background`) — issue #1578 split.
+//!
+//! Relocated verbatim from `execute.rs` (epic #1116 file-size split) so the
+//! materializing runner and the streaming producer live in separate files. As a
+//! child module of `select_executor` this reaches `mod.rs`'s private items
+//! directly; logic, ordering, and error handling are unchanged.
+
+use super::{
+    build_row_from_scan, classify_partition_lookup, evaluate_predicates, honest_targeted_path,
+    partition_key_digest, sort_rows_by_token, validate_token_predicates, PartitionLookupOutcome,
+};
+use super::{
+    AccessPath, ExecutionStep, QueryRow, Result, SelectExecutor, StorageEngine, TableId,
+    TableSchema,
+};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+impl SelectExecutor {
+    /// Background task: Execute streaming scan and send rows through channel
+    pub(super) async fn execute_streaming_background(
+        storage: Arc<StorageEngine>,
+        // Issue #1587 (E5): schema resolved ONCE per query by `execute_streaming`
+        // and moved into this task — no per-scan-step registry lock + deep clone.
+        query_schema: Option<Arc<TableSchema>>,
+        _table_id: TableId,
+        execution_steps: Vec<ExecutionStep>,
+        tx: mpsc::Sender<Result<QueryRow>>,
+        buffer_size: usize,
+    ) -> Result<()> {
+        // Issue #581: LIMIT/OFFSET must be enforced by the producer in the
+        // streaming path. The `ExecutionStep::Limit` arm previously only logged a
+        // message and relied on a consumer that never applied it, so
+        // `execute_streaming` yielded the full result set regardless of LIMIT.
+        // Extract the bound up front (steps are ordered with Limit after the scan)
+        // and stop sending once it is satisfied — mirroring `execute_limit`
+        // (drain OFFSET, then truncate to `count`) row-by-row so the producer
+        // stops scanning early.
+        let limit = execution_steps.iter().find_map(|step| match step {
+            ExecutionStep::Limit { count, offset } => Some((*count, offset.unwrap_or(0))),
+            _ => None,
+        });
+        let (limit_count, mut offset_remaining) = match limit {
+            Some((count, offset)) => (Some(count), offset),
+            None => (None, 0),
+        };
+
+        // A `LIMIT 0` means no rows can ever be sent; return before scanning.
+        if limit_count == Some(0) {
+            return Ok(());
+        }
+
+        // Issue #757: PER PARTITION LIMIT caps rows per partition before the
+        // query-wide LIMIT/OFFSET. The scan yields rows grouped by partition
+        // key, so we track the current partition and reset the counter at each
+        // boundary. Issue #1590 (E8): the boundary is compared on the partition
+        // key's 128-bit `partition_key_digest` (a heap-free hash of the key bytes
+        // we already hold) as a FAST pre-check, then confirmed by EXACT byte
+        // equality against the current partition's raw bytes — stored ONCE when
+        // the boundary advances, never cloned per row. This keeps correctness
+        // independent of digest collisions (a collision between two DISTINCT
+        // partitions never shares a counter).
+        let per_partition_limit = execution_steps.iter().find_map(|step| match step {
+            ExecutionStep::PerPartitionLimit { count } => Some(*count),
+            _ => None,
+        });
+        let mut current_partition: Option<(u128, Vec<u8>)> = None;
+        let mut partition_count: u64 = 0;
+
+        let mut sent: u64 = 0;
+
+        for step in &execution_steps {
+            match step {
+                ExecutionStep::SSTableScan {
+                    table,
+                    predicates,
+                    projection,
+                    ..
+                } => {
+                    let schema_opt = query_schema.as_deref();
+
+                    // FINDING 2 (Issue #955 follow-up): reject a `token(...)` whose
+                    // columns are not the full partition key in declared order
+                    // before scanning (same rule as the materializing path).
+                    validate_token_predicates(predicates, schema_opt)?;
+
+                    // Issue #949: a fully-constrained `WHERE pk = ?` is served by a
+                    // partition-targeted lookup that prunes SSTables via bloom/BTI,
+                    // instead of streaming a scan over every SSTable. The resulting
+                    // rows are sent through the same per-row pipeline below
+                    // (predicates, PER PARTITION LIMIT, OFFSET, LIMIT). Note
+                    // `scan_partition` reconciles across SSTable generations like the
+                    // materializing `scan()` (last-write-wins + tombstone shadowing),
+                    // which is the authoritative read semantics; it does not merely
+                    // mirror `scan_stream`'s per-key merge.
+                    let lookup = classify_partition_lookup(predicates, schema_opt);
+                    if let PartitionLookupOutcome::Targeted(ref pk_bytes) = lookup {
+                        // Issue #960: the streaming analogue of the materializing
+                        // partition-targeted lookup. Epic #951 (honest paths): the
+                        // `tombstones` build's `scan_partition` is a full-scan +
+                        // retain with NO prune, reported via `engaged == false`; only
+                        // claim `StreamingPartitionLookup` when it really pruned.
+                        let (rows, engaged) =
+                            storage.scan_partition(table, pk_bytes, schema_opt).await?;
+                        crate::query::access_path::record(honest_targeted_path(
+                            AccessPath::StreamingPartitionLookup,
+                            engaged,
+                        ));
+                        for (key, value) in rows {
+                            let part_sig =
+                                per_partition_limit.map(|_| partition_key_digest(&key.0));
+                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
+                            else {
+                                continue;
+                            };
+                            if !evaluate_predicates(&row, predicates)? {
+                                continue;
+                            }
+                            if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
+                                // Fast digest pre-check, then EXACT byte confirm so a
+                                // digest collision between DISTINCT partitions never
+                                // shares a counter (issue #1590).
+                                let same = matches!(
+                                    &current_partition,
+                                    Some((d, bytes))
+                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                                );
+                                if !same {
+                                    // Clone the key bytes ONCE per boundary, not per row.
+                                    current_partition = Some((sig, row.key.0.clone()));
+                                    partition_count = 0;
+                                }
+                                if partition_count >= cap {
+                                    continue;
+                                }
+                                partition_count += 1;
+                            }
+                            if offset_remaining > 0 {
+                                offset_remaining -= 1;
+                                continue;
+                            }
+                            if tx.send(Ok(row)).await.is_err() {
+                                return Ok(());
+                            }
+                            sent += 1;
+                            if let Some(count) = limit_count {
+                                if sent >= count {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                        // This SSTableScan step is fully served by the lookup.
+                        continue;
+                    }
+
+                    // Issue #955: `WHERE pk IN (...)` over the complete key is the
+                    // union of N partition-targeted lookups. Gather them, sort by
+                    // token to match full-scan order, then drive the same per-row
+                    // pipeline (predicates, PER PARTITION LIMIT, OFFSET, LIMIT).
+                    if let PartitionLookupOutcome::MultiTargeted(ref pk_keys) = lookup {
+                        // Epic #951 (honest paths): each lookup reports whether it
+                        // pruned. On the `tombstones` build every call full-scans
+                        // (`engaged == false`); claim `MultiPartitionLookup` only when
+                        // the lookups actually pruned, else report the honest fallback.
+                        let mut combined = Vec::new();
+                        let mut all_engaged = true;
+                        for pk_bytes in pk_keys {
+                            let (rows, engaged) =
+                                storage.scan_partition(table, pk_bytes, schema_opt).await?;
+                            all_engaged &= engaged;
+                            combined.extend(rows);
+                        }
+                        crate::query::access_path::record(honest_targeted_path(
+                            AccessPath::MultiPartitionLookup,
+                            all_engaged,
+                        ));
+                        sort_rows_by_token(&mut combined);
+                        for (key, value) in combined {
+                            let part_sig =
+                                per_partition_limit.map(|_| partition_key_digest(&key.0));
+                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
+                            else {
+                                continue;
+                            };
+                            if !evaluate_predicates(&row, predicates)? {
+                                continue;
+                            }
+                            if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
+                                // Fast digest pre-check, then EXACT byte confirm so a
+                                // digest collision between DISTINCT partitions never
+                                // shares a counter (issue #1590).
+                                let same = matches!(
+                                    &current_partition,
+                                    Some((d, bytes))
+                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                                );
+                                if !same {
+                                    // Clone the key bytes ONCE per boundary, not per row.
+                                    current_partition = Some((sig, row.key.0.clone()));
+                                    partition_count = 0;
+                                }
+                                if partition_count >= cap {
+                                    continue;
+                                }
+                                partition_count += 1;
+                            }
+                            if offset_remaining > 0 {
+                                offset_remaining -= 1;
+                                continue;
+                            }
+                            if tx.send(Ok(row)).await.is_err() {
+                                return Ok(());
+                            }
+                            sent += 1;
+                            if let Some(count) = limit_count {
+                                if sent >= count {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                        // This SSTableScan step is fully served by the lookups.
+                        continue;
+                    }
+
+                    // Issue #960: the streaming path did not take a targeted
+                    // lookup; report the honest fallback reason. `lookup` is the
+                    // `Fallback` arm here (the `Targeted`/`MultiTargeted` arms
+                    // returned above via `continue`).
+                    if let PartitionLookupOutcome::Fallback(reason) = lookup {
+                        crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
+                    }
+
+                    // Issue #790: pull rows lazily from a bounded streaming scan
+                    // instead of materializing the full result `Vec`. The reader
+                    // parses one entry at a time into this channel, so live heap
+                    // stays bounded by `buffer_size` rather than O(result rows).
+                    let mut scan_stream = storage
+                        .scan_stream(table, None, None, schema_opt, buffer_size)
+                        .await?;
+
+                    while let Some(item) = scan_stream.recv().await {
+                        let (key, value) = item?;
+                        // Capture the partition-key digest before `key` is moved
+                        // into row construction (only when needed).
+                        let part_sig = per_partition_limit.map(|_| partition_key_digest(&key.0));
+                        let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
+                        else {
+                            continue;
+                        };
+
+                        if !evaluate_predicates(&row, predicates)? {
+                            continue;
+                        }
+
+                        // Apply PER PARTITION LIMIT: cap matching rows per
+                        // partition, before OFFSET/LIMIT (Cassandra semantics).
+                        if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
+                            // Fast digest pre-check, then EXACT byte confirm so a
+                            // digest collision between DISTINCT partitions never
+                            // shares a counter (issue #1590).
+                            let same = matches!(
+                                &current_partition,
+                                Some((d, bytes))
+                                    if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                            );
+                            if !same {
+                                // Clone the key bytes ONCE per boundary, not per row.
+                                current_partition = Some((sig, row.key.0.clone()));
+                                partition_count = 0;
+                            }
+                            if partition_count >= cap {
+                                continue;
+                            }
+                            partition_count += 1;
+                        }
+
+                        // Apply OFFSET: skip the first `offset_remaining` matches.
+                        if offset_remaining > 0 {
+                            offset_remaining -= 1;
+                            continue;
+                        }
+
+                        // Send row through channel (with backpressure). Consumer drop ends the scan.
+                        if tx.send(Ok(row)).await.is_err() {
+                            return Ok(());
+                        }
+                        sent += 1;
+
+                        // Apply LIMIT: stop scanning once `count` rows have been
+                        // sent. Dropping `scan_stream` here signals the producer
+                        // (via a closed channel) to stop parsing early.
+                        if let Some(count) = limit_count {
+                            if sent >= count {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+                ExecutionStep::Limit { .. } | ExecutionStep::PerPartitionLimit { .. } => {
+                    // Enforced inline during the scan above (see the bounds
+                    // extracted before the loop).
+                }
+                // Projection and predicate filtering are pushed into SSTableScan above.
+                ExecutionStep::Project { .. } | ExecutionStep::Filter { .. } => {}
+                _ => {
+                    // Data-safety (issue #1694): log the step's variant name only,
+                    // never its contents (which carry query literals/values).
+                    log::warn!(
+                        "Streaming execution: skipping unsupported step {}",
+                        step.variant_name()
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -48,10 +48,6 @@ mod sequential;
 // `data_access::ClusteringSlice`).
 pub use model::ClusteringSlice;
 
-// Re-export for the sibling `scan_stream_windowed` module, which references
-// `data_access::table_ids_match` (unchanged path).
-pub(in crate::storage::sstable::reader) use model::table_ids_match;
-
 // Re-export the decompress-work counter so the sibling `scan_stream_windowed`
 // module (outside `data_access`) can increment it on the windowed-scan miss path
 // (issue #1567). `model` is a private submodule, so the raw path is not reachable

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -123,7 +123,6 @@
 //! NeedMore/Done straddle handling and final-chunk semantics, same
 //! `READ_SCAN_WINDOW_REFILL` counter. The only change is WHERE the CPU runs.
 
-use super::data_access::table_ids_match;
 use super::source::ScanCursor;
 use super::window_cursor::WindowCursor;
 use super::SSTableReader;
@@ -343,7 +342,8 @@ fn finish_blocking_drain(
 /// Inputs the blocking parse half needs that the I/O half resolves once up front
 /// (so the blocking task does not have to touch the async runtime).
 struct WindowParseCtx {
-    table_id: TableId,
+    // Issue #1578: no `table_id` — the stitch path does not filter by it (see the
+    // parse closure in `run_scan_stream_windowed`).
     start_key: Option<RowKey>,
     end_key: Option<RowKey>,
     schema: Option<crate::schema::TableSchema>,
@@ -364,7 +364,8 @@ impl SSTableReader {
     /// Precondition: `cursor`'s file is seeked to the start of the data section.
     pub(super) async fn run_scan_stream_windowed(
         self: Arc<Self>,
-        table_id: TableId,
+        // Issue #1578: unused — the stitch path does not filter by table_id.
+        _table_id: TableId,
         start_key: Option<RowKey>,
         end_key: Option<RowKey>,
         schema: Option<crate::schema::TableSchema>,
@@ -385,7 +386,6 @@ impl SSTableReader {
         // the blocking task never touches the async runtime. Schema resolution
         // matches the previous `parse_stitched_stream` resolution exactly.
         let ctx = WindowParseCtx {
-            table_id,
             start_key,
             end_key,
             schema: schema.or_else(|| self.get_table_schema(None)),
@@ -884,14 +884,13 @@ impl SSTableReader {
                 ctx.schema.as_ref(),
                 self,
                 at_final_chunk,
-                &mut |(entry_table_id, key, value, _ts)| {
-                    // Key-range + tombstone filters match the previous
-                    // `parse_stitched_stream`; the `table_ids_match` guard is the
-                    // ADDITIONAL filter the non-stitching `scan_stream` branch
-                    // also applies (a no-op for single-table SSTables).
-                    if !table_ids_match(&entry_table_id, &ctx.table_id) {
-                        return Ok(std::ops::ControlFlow::Continue(()));
-                    }
+                &mut |(_entry_table_id, key, value, _ts)| {
+                    // Issue #1578: this stitching path deliberately does NOT filter
+                    // by `table_ids_match` — it mirrors the authoritative
+                    // materializing `sequential_scan` stitch path, which skips it
+                    // because the nb parser may report header-default table_ids.
+                    // Applying it here dropped EVERY row of an nb SSTable whose parsed
+                    // table_id diverged from the query (e.g. CQLite-written output).
                     if let Some(start) = ctx.start_key.as_ref() {
                         if &key < start {
                             return Ok(std::ops::ControlFlow::Continue(()));

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_tests.rs
@@ -369,10 +369,6 @@ mod fixture_drain {
     /// is pre-filled and its sender dropped so `blocking_recv` never blocks.
     fn drain_count(reader: &SSTableReader, chunks: &[Vec<u8>], io_failed: bool) -> usize {
         let ctx = WindowParseCtx {
-            table_id: TableId::new(format!(
-                "{}.{}",
-                reader.header.keyspace, reader.header.table_name
-            )),
             start_key: None,
             end_key: None,
             schema: reader.get_table_schema(None),
@@ -410,10 +406,6 @@ mod fixture_drain {
     /// Build the same `WindowParseCtx` the I/O half resolves for this fixture.
     fn ctx_for(reader: &SSTableReader) -> WindowParseCtx {
         WindowParseCtx {
-            table_id: TableId::new(format!(
-                "{}.{}",
-                reader.header.keyspace, reader.header.table_name
-            )),
             start_key: None,
             end_key: None,
             schema: reader.get_table_schema(None),

--- a/cqlite-core/tests/issue_1578_aggregate_o1_memory.rs
+++ b/cqlite-core/tests/issue_1578_aggregate_o1_memory.rs
@@ -9,8 +9,39 @@
 //! On `main`/pre-D2 `COUNT(*)` over N rows buffered all N (`buffered_rows() == N`),
 //! so this guard flips red as the fixture grows. After D2 the fold buffers ZERO
 //! rows regardless of table size, so `buffered_rows()` stays `0` and is FLAT
-//! between a small and a large fixture. A companion `SELECT *` (which genuinely
-//! materializes) proves the probe is actually wired.
+//! between a small and a large fixture.
+//!
+//! ## Roborev follow-up: bounding the vacuity of `buffered_rows() == 0`
+//! (STATED VARIANT: behavioral pin, no production changes — see below)
+//!
+//! `count_star_buffers_o1_rows` proves the aggregate does NOT buffer rows, but by
+//! itself does not prove the query took `try_execute_global_aggregate` (the fold)
+//! specifically — a silent reroute to some OTHER codepath that also never calls
+//! `record_buffered_rows` would pass the same assertion. There is no existing
+//! test-visible observable that distinguishes "the fold ran" from "some other path
+//! ran and also never touched the probe" (the fold and the buffered
+//! `execute_aggregation` intentionally record the SAME honest `AccessPath`, and
+//! adding a fold-specific counter is production code, out of scope for this
+//! test-only round). So this file pins the claim BEHAVIORALLY instead:
+//! [`probe_is_wired_via_group_by_aggregate`] forces the classifier's GROUP BY
+//! reject branch (`!group_by_columns.is_empty()`) back onto the buffered path and
+//! asserts the probe fires there with the real row count.
+//!
+//! A tempting SECOND companion was attempted (forcing the classifier's OTHER
+//! reject branch, `PartitionLookupOutcome::Targeted`, via `WHERE id = ?` on the
+//! sole primary key) but turned out to be UNREACHABLE via the public SQL surface
+//! — see the comment above `probe_is_wired_via_group_by_aggregate` for why.
+//!
+//! Since the buffered path (`execute_aggregation`) is the ONLY caller of
+//! `record_buffered_rows`, and the GROUP BY companion proves it fires with the
+//! CORRECT row count when the classifier rejects the fold, a
+//! `count_star_buffers_o1_rows` reading of `0` over a NON-EMPTY table is strong
+//! evidence the fold ran (had `execute_aggregation` run instead, it would have
+//! recorded the real row count, exactly as that companion demonstrates) — not a
+//! coincidental zero from an unrelated reroute. The residual gap (a hypothetical
+//! SECOND codepath that also never touches the probe, distinct from both the fold
+//! and the buffered path) is NOT ruled out by a counter-only guard — closing it
+//! fully would need production instrumentation, out of scope here.
 //!
 //! The counter getter + reset live behind the `work-counters` feature; the counter
 //! is a shared process-global, so every test here serializes on a shared mutex.
@@ -135,9 +166,10 @@ async fn count_star_buffers_o1_rows() {
     );
 }
 
-/// Sanity: the probe is genuinely wired — a materializing `SELECT *` DOES buffer
-/// its rows, so a zero from the aggregate path above is a real O(1) result, not a
-/// dead counter.
+/// Companion 1 (see module doc): the probe is genuinely wired to the buffered
+/// path via the GROUP BY classifier-reject branch — a materializing `GROUP BY`
+/// aggregate DOES buffer its rows, so a zero from the global-aggregate path
+/// above is a real O(1) result, not a dead counter.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn probe_is_wired_via_group_by_aggregate() {
@@ -158,3 +190,18 @@ async fn probe_is_wired_via_group_by_aggregate() {
          O(1) assertion above is vacuous"
     );
 }
+
+// A tempting SECOND companion — `SELECT COUNT(*) FROM tbl WHERE id = ?` on the
+// sole PRIMARY KEY column, which `try_execute_global_aggregate` explicitly
+// excludes from the fold as a partition-TARGETED lookup — turns out to be
+// UNREACHABLE via the public SQL surface: `M2SelectValidator` (a pre-existing,
+// unrelated legacy validator that runs upstream of the modern optimizer/
+// executor) rejects ANY combination of a partition/primary-key equality WHERE
+// with an aggregate outright (`UnsupportedQuery("... M2 supports: SELECT with
+// partition/primary key equality and optional LIMIT ...")`), before the query
+// ever reaches `select_optimizer`/`select_executor`. So that classifier branch
+// cannot be exercised behaviorally through `Database::execute` without also
+// routing around M2 — out of scope for this test-only round. The GROUP BY
+// companion above (`probe_is_wired_via_group_by_aggregate`) is therefore the
+// ONE reachable behavioral pin; see the module doc for the vacuity bound it
+// establishes on its own.

--- a/cqlite-core/tests/issue_1578_aggregate_o1_memory.rs
+++ b/cqlite-core/tests/issue_1578_aggregate_o1_memory.rs
@@ -1,0 +1,158 @@
+//! Issue #1578 (Epic D / D2): a GROUP-BY-free aggregate must fold the scan stream
+//! into an O(1) accumulator, NOT buffer the whole table.
+//!
+//! This is the memory guard. It uses the cfg-gated aggregate-buffering probe
+//! (`cqlite_core::query::agg_stream_probe`) to observe the number of rows the
+//! aggregate held resident in its input buffer — the no-heuristics way to prove
+//! O(1): observe the *work*, not just the (identical) `COUNT(*)` answer.
+//!
+//! On `main`/pre-D2 `COUNT(*)` over N rows buffered all N (`buffered_rows() == N`),
+//! so this guard flips red as the fixture grows. After D2 the fold buffers ZERO
+//! rows regardless of table size, so `buffered_rows()` stays `0` and is FLAT
+//! between a small and a large fixture. A companion `SELECT *` (which genuinely
+//! materializes) proves the probe is actually wired.
+//!
+//! The counter getter + reset live behind the `work-counters` feature; the counter
+//! is a shared process-global, so every test here serializes on a shared mutex.
+//!
+//! Run:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine,work-counters \
+//!     --test issue_1578_aggregate_o1_memory
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::agg_stream_probe;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database};
+use serial_test::serial;
+use tempfile::TempDir;
+
+const KS: &str = "agg_mem_ks";
+const TBL: &str = "rows";
+
+fn schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{TBL} (\n  id int PRIMARY KEY,\n  v int\n);\n")
+}
+
+fn write_mutation(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "v".to_string(),
+        value: Value::Integer(id * 2),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+async fn open_with_n_rows(n: i32) -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, schema_cql()).expect("write schema file");
+
+    {
+        let data_dir = data_dir.clone();
+        let wal_dir = wal_dir.clone();
+        tokio::task::spawn_blocking(move || {
+            use cqlite_core::schema::parse_cql_schema;
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime");
+            let schema = parse_cql_schema(&schema_cql()).expect("parse schema");
+            let config = WriteEngineConfig::new(data_dir, wal_dir, schema);
+            let mut engine = WriteEngine::new(config).expect("engine");
+            for id in 0..n {
+                engine.write(write_mutation(id, 100 + id as i64)).expect("write");
+            }
+            rt.block_on(engine.flush())
+                .expect("flush")
+                .expect("must produce an SSTable");
+            rt.block_on(engine.close()).expect("close");
+        })
+        .await
+        .expect("fixture build task");
+    }
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest fixture");
+    (result.database, temp_dir)
+}
+
+async fn count_star_buffered_rows(db: &Database) -> u64 {
+    agg_stream_probe::reset();
+    let result = db
+        .execute(&format!("SELECT COUNT(*) FROM {KS}.{TBL}"))
+        .await
+        .expect("COUNT(*) executes");
+    assert_eq!(result.rows.len(), 1, "COUNT(*) yields one row");
+    agg_stream_probe::buffered_rows()
+}
+
+/// COUNT(*) peak resident rows is O(1): flat between a small and a large fixture,
+/// and near-zero — NOT proportional to row count.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn count_star_buffers_o1_rows() {
+    let (small_db, _s) = open_with_n_rows(50).await;
+    let (large_db, _l) = open_with_n_rows(2000).await;
+
+    let small_buffered = count_star_buffered_rows(&small_db).await;
+    let large_buffered = count_star_buffered_rows(&large_db).await;
+
+    // Flat across a 40x size difference — the discriminating property. On `main`
+    // this is 50 vs 2000 (proportional to rows); after D2 it is 0 vs 0.
+    assert_eq!(
+        small_buffered, large_buffered,
+        "Issue #1578: COUNT(*) buffered rows must be FLAT across fixture sizes \
+         (small={small_buffered}, large={large_buffered}); a size-proportional \
+         count means the whole table was materialized before aggregating"
+    );
+    // And O(1) in absolute terms (the fold holds only the accumulator).
+    assert!(
+        large_buffered <= 1,
+        "Issue #1578: COUNT(*) over 2000 rows must buffer O(1) rows, got {large_buffered}"
+    );
+}
+
+/// Sanity: the probe is genuinely wired — a materializing `SELECT *` DOES buffer
+/// its rows, so a zero from the aggregate path above is a real O(1) result, not a
+/// dead counter.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn probe_is_wired_via_group_by_aggregate() {
+    let (db, _tmp) = open_with_n_rows(300).await;
+
+    // A GROUP BY aggregate still materializes (E5 territory), so it buffers its
+    // input — proving the probe increments on the buffered path.
+    agg_stream_probe::reset();
+    let _ = db
+        .execute(&format!("SELECT v, COUNT(*) FROM {KS}.{TBL} GROUP BY v"))
+        .await
+        .expect("GROUP BY executes");
+    let grouped_buffered = agg_stream_probe::buffered_rows();
+    assert!(
+        grouped_buffered >= 300,
+        "Issue #1578: a buffered GROUP BY over 300 rows must record >= 300 buffered \
+         rows (got {grouped_buffered}); if this is 0 the probe is not wired and the \
+         O(1) assertion above is vacuous"
+    );
+}

--- a/cqlite-core/tests/issue_1578_aggregate_o1_memory.rs
+++ b/cqlite-core/tests/issue_1578_aggregate_o1_memory.rs
@@ -74,7 +74,9 @@ async fn open_with_n_rows(n: i32) -> (Database, TempDir) {
             let config = WriteEngineConfig::new(data_dir, wal_dir, schema);
             let mut engine = WriteEngine::new(config).expect("engine");
             for id in 0..n {
-                engine.write(write_mutation(id, 100 + id as i64)).expect("write");
+                engine
+                    .write(write_mutation(id, 100 + id as i64))
+                    .expect("write");
             }
             rt.block_on(engine.flush())
                 .expect("flush")

--- a/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
+++ b/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
@@ -10,6 +10,11 @@
 //!     which trips the valve at 4 > 2 even with an explicit LIMIT.
 //!   * `SELECT * ...` (no LIMIT) over 4 rows STILL errors — the valve remains a
 //!     genuine safety net for unbounded materialization.
+//!   * `SELECT * ... LIMIT 4` with a tiny `max_result_bytes` STILL errors with
+//!     `Error::ResultTooLarge` — the row-count valve is exempted for an explicit
+//!     LIMIT, but the BYTE budget (the primary guard, issue #1582) is NOT. This
+//!     pins the exact contract the demotion leans on: LIMIT bypasses the
+//!     secondary row-count valve only, never the byte ceiling.
 //!
 //! Run:
 //!   cargo test --package cqlite-core \
@@ -28,7 +33,7 @@ use cqlite_core::storage::write_engine::{
     CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
 };
 use cqlite_core::types::Value;
-use cqlite_core::{Config, Database};
+use cqlite_core::{Config, Database, Error};
 use tempfile::TempDir;
 
 const KS: &str = "limit_ks";
@@ -49,6 +54,16 @@ fn write_mutation(id: i32, ts: i64) -> Mutation {
 
 /// Open with `max_result_rows` lowered so a tiny fixture exercises the valve.
 async fn open_with_row_cap(n_rows: i32, max_result_rows: u64) -> (Database, TempDir) {
+    open_with_caps(n_rows, max_result_rows, None).await
+}
+
+/// Open with both `max_result_rows` and (optionally) `max_result_bytes` lowered,
+/// so a tiny fixture can exercise either guard independently.
+async fn open_with_caps(
+    n_rows: i32,
+    max_result_rows: u64,
+    max_result_bytes: Option<u64>,
+) -> (Database, TempDir) {
     let temp_dir = TempDir::new().unwrap();
     let data_dir = temp_dir.path().join("data");
     let wal_dir = temp_dir.path().join("wal");
@@ -83,6 +98,9 @@ async fn open_with_row_cap(n_rows: i32, max_result_rows: u64) -> (Database, Temp
 
     let mut core_config = Config::default();
     core_config.query.max_result_rows = max_result_rows;
+    if let Some(bytes) = max_result_bytes {
+        core_config.query.max_result_bytes = bytes;
+    }
 
     let result = ingest(IngestionConfig {
         schema_paths: vec![schema_path],
@@ -134,4 +152,31 @@ async fn no_limit_still_trips_row_count_valve() {
         msg.contains("too large") || msg.contains("limit"),
         "expected a result-too-large error, got: {err}"
     );
+}
+
+/// The LIMIT exemption is SCOPED to the row-count valve only: the byte budget
+/// (the primary guard, issue #1582) still fires `Error::ResultTooLarge` even on
+/// a LIMIT-bounded query. This is the exact contract the row-count demotion
+/// leans on — LIMIT does not blanket-exempt a query from EVERY materialization
+/// guard, only the crude row-count one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_limit_does_not_exempt_byte_budget() {
+    // Row-count valve is generous (100) so only the byte budget can trip;
+    // max_result_bytes is set far below what 4 rows require.
+    let (db, _tmp) = open_with_caps(4, 100, Some(4)).await;
+
+    let err = db
+        .execute(&format!("SELECT * FROM {KS}.{TBL} LIMIT 4"))
+        .await
+        .err()
+        .expect(
+            "Issue #1578: an explicit LIMIT exempts the ROW-COUNT valve only — \
+             the byte budget must still trip ResultTooLarge",
+        );
+    match err {
+        Error::ResultTooLarge { budget_bytes, .. } => {
+            assert_eq!(budget_bytes, 4, "byte budget must be the one we configured");
+        }
+        other => panic!("expected Error::ResultTooLarge, got: {other:?}"),
+    }
 }

--- a/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
+++ b/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
@@ -1,0 +1,135 @@
+//! Issue #1578 (Epic D / D2): the `max_result_rows` row-count valve is demoted to
+//! a safety valve — a query with an EXPLICIT `LIMIT` is exempt (the user bounded
+//! the result themselves), so a big-but-legal `SELECT ... LIMIT N` returns rows
+//! instead of erroring with the "result set too large" cliff.
+//!
+//! Rather than build a 1.5M-row fixture, this lowers `max_result_rows` to 2 via
+//! config (the documented "lower the constant via a test-visible mechanism") and
+//! proves:
+//!   * `SELECT * ... LIMIT 4` over 4 rows RETURNS 4 rows (exempt) — RED on `main`,
+//!     which trips the valve at 4 > 2 even with an explicit LIMIT.
+//!   * `SELECT * ...` (no LIMIT) over 4 rows STILL errors — the valve remains a
+//!     genuine safety net for unbounded materialization.
+//!
+//! Run:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine \
+//!     --test issue_1578_limit_exempts_max_results
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine",
+    not(feature = "tombstones")
+))]
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database};
+use tempfile::TempDir;
+
+const KS: &str = "limit_ks";
+const TBL: &str = "rows";
+
+fn schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{TBL} (\n  id int PRIMARY KEY,\n  v int\n);\n")
+}
+
+fn write_mutation(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "v".to_string(),
+        value: Value::Integer(id),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+/// Open with `max_result_rows` lowered so a tiny fixture exercises the valve.
+async fn open_with_row_cap(n_rows: i32, max_result_rows: u64) -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, schema_cql()).expect("write schema file");
+
+    {
+        let data_dir = data_dir.clone();
+        let wal_dir = wal_dir.clone();
+        tokio::task::spawn_blocking(move || {
+            use cqlite_core::schema::parse_cql_schema;
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime");
+            let schema = parse_cql_schema(&schema_cql()).expect("parse schema");
+            let config = WriteEngineConfig::new(data_dir, wal_dir, schema);
+            let mut engine = WriteEngine::new(config).expect("engine");
+            for id in 0..n_rows {
+                engine.write(write_mutation(id, 100 + id as i64)).expect("write");
+            }
+            rt.block_on(engine.flush())
+                .expect("flush")
+                .expect("must produce an SSTable");
+            rt.block_on(engine.close()).expect("close");
+        })
+        .await
+        .expect("fixture build task");
+    }
+
+    let mut core_config = Config::default();
+    core_config.query.max_result_rows = max_result_rows;
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config,
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest fixture");
+    (result.database, temp_dir)
+}
+
+/// A query with an EXPLICIT LIMIT is exempt from the row-count valve.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_limit_exempts_row_count_valve() {
+    let (db, _tmp) = open_with_row_cap(4, 2).await;
+
+    let result = db
+        .execute(&format!("SELECT * FROM {KS}.{TBL} LIMIT 4"))
+        .await
+        .expect(
+            "Issue #1578: an explicit LIMIT must exempt the query from the \
+             max_result_rows safety valve — LIMIT 4 over 4 rows must return rows, \
+             not error with 'result set too large'",
+        );
+    assert_eq!(
+        result.rows.len(),
+        4,
+        "LIMIT 4 over a 4-row table returns all 4 rows"
+    );
+}
+
+/// Without a LIMIT, the valve is still a genuine safety net.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn no_limit_still_trips_row_count_valve() {
+    let (db, _tmp) = open_with_row_cap(4, 2).await;
+
+    let err = db
+        .execute(&format!("SELECT * FROM {KS}.{TBL}"))
+        .await
+        .err()
+        .expect(
+            "Issue #1578: an UNBOUNDED SELECT over 4 rows with max_result_rows=2 \
+             must still trip the safety valve",
+        );
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("too large") || msg.contains("limit"),
+        "expected a result-too-large error, got: {err}"
+    );
+}

--- a/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
+++ b/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
@@ -68,7 +68,9 @@ async fn open_with_row_cap(n_rows: i32, max_result_rows: u64) -> (Database, Temp
             let config = WriteEngineConfig::new(data_dir, wal_dir, schema);
             let mut engine = WriteEngine::new(config).expect("engine");
             for id in 0..n_rows {
-                engine.write(write_mutation(id, 100 + id as i64)).expect("write");
+                engine
+                    .write(write_mutation(id, 100 + id as i64))
+                    .expect("write");
             }
             rt.block_on(engine.flush())
                 .expect("flush")

--- a/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
+++ b/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
@@ -16,6 +16,24 @@
 //!     pins the exact contract the demotion leans on: LIMIT bypasses the
 //!     secondary row-count valve only, never the byte ceiling.
 //!
+//! ## Roborev follow-up: pinning the demotion at NON-TRIVIAL scale
+//!
+//! The tests above use a 4-row fixture, which cannot by itself distinguish "the
+//! row-count valve is exempted" from "4 rows happens to fit under any reasonable
+//! byte budget regardless". Two more tests repeat the same shape over a
+//! few-thousand-row fixture (the existing write-engine generator, same pattern as
+//! `issue_1578_aggregate_o1_memory.rs`'s `open_with_n_rows`):
+//!
+//!   * `large_limit_returns_all_rows_at_scale` — a huge `LIMIT` (far above the row
+//!     count) with a tiny `max_result_rows` (10) but a GENEROUS `max_result_bytes`
+//!     succeeds and returns EXACTLY the fixture's row count — proving a huge LIMIT
+//!     at scale is not silently truncated by the (exempted) row-count valve, and
+//!     the returned count is bounded by the actual matching rows (no over-return).
+//!   * `tight_byte_budget_still_trips_at_scale` — the SAME huge `LIMIT` over the
+//!     SAME fixture, but with the byte budget dropped to a few bytes, still trips
+//!     `Error::ResultTooLarge` — proving the byte guard (the PRIMARY guard, issue
+//!     #1582) stays live at non-trivial row counts, not merely at 4 rows.
+//!
 //! Run:
 //!   cargo test --package cqlite-core \
 //!     --features write-support,cli-helpers,state_machine \
@@ -176,6 +194,81 @@ async fn explicit_limit_does_not_exempt_byte_budget() {
     match err {
         Error::ResultTooLarge { budget_bytes, .. } => {
             assert_eq!(budget_bytes, 4, "byte budget must be the one we configured");
+        }
+        other => panic!("expected Error::ResultTooLarge, got: {other:?}"),
+    }
+}
+
+/// Row count for the at-scale companion tests: a "few thousand" rows, per the
+/// roborev ask — large enough that a size-proportional row-count valve or a
+/// silently truncated LIMIT would be unmistakable, small enough to build fast in
+/// a test.
+const SCALE_ROWS: i32 = 3000;
+
+/// Roborev follow-up: a HUGE `LIMIT` (far above `SCALE_ROWS`) with a stingy
+/// `max_result_rows` but a GENEROUS `max_result_bytes` succeeds and returns
+/// EXACTLY the fixture's row count at non-trivial scale — the row-count valve's
+/// exemption is not an artifact of the earlier 4-row fixture, and the returned
+/// count is bounded by the actual matching rows (no truncation, no over-return).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn large_limit_returns_all_rows_at_scale() {
+    // max_result_rows=10 would trip immediately without the LIMIT exemption
+    // (SCALE_ROWS far exceeds it); max_result_bytes is generous (64 MiB) so only
+    // the exemption itself is under test, not an incidentally-tight byte budget.
+    let (db, _tmp) = open_with_caps(SCALE_ROWS, 10, Some(64 * 1024 * 1024)).await;
+
+    let result = db
+        .execute(&format!("SELECT * FROM {KS}.{TBL} LIMIT 1500000"))
+        .await
+        .expect(
+            "Issue #1578: a huge LIMIT over a few-thousand-row table with a \
+             generous byte budget must succeed despite a stingy max_result_rows \
+             — the row-count valve is exempted for an explicit LIMIT at scale, \
+             not just for a 4-row fixture",
+        );
+    assert_eq!(
+        result.rows.len(),
+        SCALE_ROWS as usize,
+        "LIMIT 1_500_000 over a {SCALE_ROWS}-row table must return EXACTLY \
+         {SCALE_ROWS} rows — bounded by the actual matching rows, neither \
+         truncated nor duplicated"
+    );
+}
+
+/// Roborev follow-up: the SAME huge-LIMIT query over the SAME
+/// non-trivial-scale fixture, but with the byte budget dropped to a few bytes,
+/// STILL trips `Error::ResultTooLarge` — the byte guard (issue #1582's primary
+/// guard) remains a live safety net at scale, not merely at 4 rows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tight_byte_budget_still_trips_at_scale() {
+    // max_result_rows is generous (far above SCALE_ROWS) so only the byte
+    // budget can trip; max_result_bytes is a handful of bytes, far below what
+    // SCALE_ROWS worth of (id, v) int pairs need.
+    let (db, _tmp) = open_with_caps(SCALE_ROWS, 1_000_000, Some(16)).await;
+
+    let err = db
+        .execute(&format!("SELECT * FROM {KS}.{TBL} LIMIT 1500000"))
+        .await
+        .err()
+        .expect(
+            "Issue #1578: a huge LIMIT over a few-thousand-row table with a \
+             tiny max_result_bytes must still trip the byte guard — LIMIT \
+             exempts only the row-count valve, never the byte ceiling, at any \
+             scale",
+        );
+    match err {
+        Error::ResultTooLarge {
+            budget_bytes, rows, ..
+        } => {
+            assert_eq!(
+                budget_bytes, 16,
+                "byte budget must be the one we configured"
+            );
+            assert!(
+                rows > 0,
+                "the byte guard must report a non-trivial row count at trip time \
+                 (got {rows}), confirming it evaluated the actual scaled result"
+            );
         }
         other => panic!("expected Error::ResultTooLarge, got: {other:?}"),
     }

--- a/cqlite-core/tests/issue_1578_scan_stream_stitch_table_id_regression.rs
+++ b/cqlite-core/tests/issue_1578_scan_stream_stitch_table_id_regression.rs
@@ -1,0 +1,195 @@
+//! Issue #1578 (Epic D / D2), roborev Finding 2: prove the STITCHING (chunk-
+//! spanning, compressed `nb`) branch of `run_scan_stream_windowed` no longer
+//! filters by `table_ids_match` — reintroducing that filter must fail this test
+//! loudly (a silent all-rows-dropped regression, not a subtle value diff).
+//!
+//! ## Why a dedicated corpus-backed test
+//!
+//! Every #1578 fixture (write-engine output, `issue_1578_*.rs`) is tiny and
+//! UNCOMPRESSED, so it takes the PLAIN block-by-block `scan_stream` path
+//! (`requires_chunk_stitching()` is `V5CompressedLegacy` + `nb` only) — which
+//! still applies `table_ids_match` unchanged. Those fixtures can never exercise
+//! the STITCHING branch this issue's fix touched, so they cannot catch a
+//! reintroduced filter there.
+//!
+//! This test instead uses the real, local-only Cassandra 5.0
+//! `test_big.wide_partition` fixture (114 LZ4 chunks over ~1.8 MB — genuinely
+//! multi-chunk, confirmed by reading `CompressionInfo.db` directly, independent
+//! of the code under test) and drives `SSTableReader::scan_stream` DIRECTLY
+//! (bypassing the ingest/executor layer entirely) with a `table_id` that
+//! deliberately DIVERGES from the reader's own header-derived table_id. Before
+//! this fix, the stitching branch's `table_ids_match` guard silently dropped
+//! EVERY row whose parsed entry table_id disagreed with the query — exactly
+//! what happens for a CQLite-written `nb` SSTable, whose header keyspace/table
+//! can diverge from the query. This test asserts the mismatched-table_id call
+//! still returns the full row count (matching an independent oracle: the
+//! ordinary `Database` path with the CORRECT table_id).
+//!
+//! ## Skip vs fail-closed (issue #1856 pattern)
+//!
+//! The fixture's `-Data.db`/`-CompressionInfo.db` binaries are local-only (not
+//! in the fetchable dataset asset). Absent, this test SKIPS (honest eprintln),
+//! never panics — EXCEPT under `CQLITE_PARITY_REQUIRE_DATASETS=1` (the required
+//! parity gate), where absence is a fail-closed panic so that gate can never
+//! green-pass without actually running this regression.
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::platform::Platform;
+use cqlite_core::storage::sstable::SSTableReader;
+use cqlite_core::{Config, TableId};
+use tempfile::TempDir;
+
+const REAL_FIXTURE_REL: &str = "sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294";
+const SCHEMA_CQL: &str =
+    "CREATE TABLE test_big.wide_partition (pk int, ck int, payload text, PRIMARY KEY (pk, ck));\n";
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn real_fixture_data_db() -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let data_db = root.join(REAL_FIXTURE_REL).join("nb-2-big-Data.db");
+    data_db.exists().then_some(data_db)
+}
+
+/// CI fail-closed switch (issue #1856). Locally (env unset) an absent fixture
+/// skips; the required parity gate sets this so absence hard-fails instead of
+/// silently green-passing.
+fn parity_datasets_required() -> bool {
+    std::env::var("CQLITE_PARITY_REQUIRE_DATASETS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn skip_or_fail_closed(reason: &str) {
+    if parity_datasets_required() {
+        panic!(
+            "stitched_scan_stream_ignores_table_id_mismatch: \
+             CQLITE_PARITY_REQUIRE_DATASETS=1 but {reason} — required parity gate cannot \
+             green-pass without running fail-closed (issue #1856)"
+        );
+    }
+    eprintln!("Skipping (stitched scan_stream table_id regression): {reason}");
+}
+
+/// Read `CompressionInfo.db` (sibling of `data_db`) and return `chunk_count`,
+/// independent of the code under test — an authoritative on-disk fact proving
+/// this fixture is genuinely multi-chunk, so the STITCHING branch (not the
+/// plain non-stitching path) is what `scan_stream` actually takes.
+fn chunk_count(data_db: &std::path::Path) -> u32 {
+    let info_path = data_db.with_file_name(
+        data_db
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("Data.db file name")
+            .replace("-Data.db", "-CompressionInfo.db"),
+    );
+    let b = std::fs::read(&info_path).expect("read CompressionInfo.db");
+    let mut o = 0usize;
+    let nlen = u16::from_be_bytes([b[o], b[o + 1]]) as usize;
+    o += 2 + nlen;
+    let option_count = u32::from_be_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]]);
+    o += 4;
+    for _ in 0..option_count {
+        let kl = u16::from_be_bytes([b[o], b[o + 1]]) as usize;
+        o += 2 + kl;
+        let vl = u16::from_be_bytes([b[o], b[o + 1]]) as usize;
+        o += 2 + vl;
+    }
+    o += 4 + 4 + 8; // chunk_length + max_compressed_length + data_length
+    u32::from_be_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]])
+}
+
+/// THE regression: `SSTableReader::scan_stream` driven with a table_id that
+/// deliberately diverges from the reader's own header-derived id must still
+/// return every row when the fixture takes the STITCHING branch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stitched_scan_stream_ignores_table_id_mismatch() {
+    let Some(data_db) = real_fixture_data_db() else {
+        skip_or_fail_closed("test_big.wide_partition -Data.db binary not present");
+        return;
+    };
+
+    // PROOF (on-disk, independent of the code under test): genuinely
+    // multi-chunk, so this exercises the stitching branch, not the plain path.
+    let chunks = chunk_count(&data_db);
+    assert!(
+        chunks > 1,
+        "Issue #1578 Finding 2: test_big.wide_partition must be multi-chunk to \
+         exercise the STITCHING branch (got {chunks} chunk(s)) — a single-chunk \
+         fixture would make this regression test vacuous"
+    );
+
+    // Oracle: the REAL row count via the ordinary Database path (correct
+    // table_id, ingested normally) — the authoritative full-table row count.
+    let temp = TempDir::new().unwrap();
+    let schema_path = temp.path().join("wide_partition.cql");
+    std::fs::write(&schema_path, SCHEMA_CQL).unwrap();
+    let root = datasets_root().expect("CQLITE_DATASETS_ROOT set (checked above)");
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir: root.join("sstables"),
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: Some("/test_big/".to_string()),
+    })
+    .await
+    .expect("ingest real test_big.wide_partition");
+    let oracle_rows = result
+        .database
+        .execute("SELECT pk, ck, payload FROM test_big.wide_partition")
+        .await
+        .expect("oracle full scan")
+        .rows
+        .len();
+    assert!(oracle_rows > 0, "oracle full scan must return rows");
+
+    // Open the reader DIRECTLY (bypassing ingest/executor) and confirm the
+    // on-disk format is the chunk-stitching `nb` format.
+    let cfg = Config::default();
+    let platform = Arc::new(Platform::new(&cfg).await.unwrap());
+    let reader = SSTableReader::open(&data_db, &cfg, platform)
+        .await
+        .expect("open reader");
+    assert_eq!(
+        reader.format_version().expect("format version"),
+        "nb",
+        "Issue #1578 Finding 2: fixture must be the chunk-stitching `nb` format"
+    );
+
+    // THE regression: drive `scan_stream` with a table_id that DELIBERATELY
+    // diverges from the fixture's own header-derived id
+    // ("test_big.wide_partition"). Before this fix, the stitching branch's
+    // `table_ids_match` guard silently dropped every row here.
+    let wrong_table_id = TableId::new("totally_different_ks.totally_different_table");
+    let mut rx = Arc::new(reader).scan_stream(wrong_table_id, None, None, None, 64);
+
+    let mut mismatched_rows = 0usize;
+    while let Some(item) = rx.recv().await {
+        item.expect("scan_stream row");
+        mismatched_rows += 1;
+    }
+
+    assert_eq!(
+        mismatched_rows, oracle_rows,
+        "Issue #1578 Finding 2: scan_stream() with a MISMATCHED table_id returned \
+         {mismatched_rows} rows, but the oracle (correct table_id) returned \
+         {oracle_rows} — reintroducing `table_ids_match` on the stitching branch \
+         would silently drop rows whenever the parsed entry table_id (header- \
+         derived) diverges from the query, exactly the CQLite-written-nb-SSTable \
+         bug this fix removed"
+    );
+    eprintln!(
+        "Issue #1578 Finding 2: stitched scan_stream returned {mismatched_rows} rows \
+         with a mismatched table_id (chunk_count={chunks}), matching the {oracle_rows}-row oracle"
+    );
+}

--- a/cqlite-core/tests/issue_1578_streaming_aggregate_multigen_parity.rs
+++ b/cqlite-core/tests/issue_1578_streaming_aggregate_multigen_parity.rs
@@ -1,0 +1,274 @@
+//! Issue #1578 (Epic D / D2), roborev Finding 1: the O(1) streaming aggregate
+//! fold must reconcile MULTIPLE SSTable generations identically to the
+//! materializing path — every other #1578 fixture flushes exactly ONCE, so
+//! nothing pins the fold's cross-generation reconciliation (`execute()`'s fold
+//! calls `storage.scan_stream`, which for >1 reader + a schema delegates to
+//! `merge_generations_for_read` — issue #957's LWW + tombstone-shadowing
+//! lockstep merge — rather than a naive per-reader concatenation that would
+//! double-count an overwritten row or resurrect a tombstoned one).
+//!
+//! ## Fixture (write + flush, then overwrite + delete + flush again, no compaction)
+//!
+//! Gen1 (ts=100): id=1 (v=10,  name="alpha"),  id=2 (v=20, name="bravo"),
+//!                id=3 (v=5,   name="charlie")
+//! Gen2 (ts=200): id=1 OVERWRITTEN (v=999, name="alpha2"),
+//!                id=2 ROW-DELETED,
+//!                id=4 NEW (v=40, name="delta")
+//!
+//! Reconciled live rows (computed BY HAND from the fixture, not from the code
+//! under test): id=1 (v=999, "alpha2"), id=3 (v=5, "charlie", unchanged from
+//! gen1), id=4 (v=40, "delta"). id=2 is gone (row tombstone shadows gen1).
+//!
+//!   COUNT(*)  = 3
+//!   COUNT(v)  = 3      (no NULLs among the 3 live rows)
+//!   SUM(v)    = 999 + 5 + 40 = 1044
+//!   MIN(v)    = 5
+//!   MAX(v)    = 999
+//!   AVG(v)    = 1044 / 3 = 348.0
+//!   MIN(name) = "alpha2"   ('a' < 'c' < 'd': alpha2 < charlie < delta)
+//!   MAX(name) = "delta"
+//!
+//! Both `execute()` (the O(1) fold) and `execute_streaming()` (routed through
+//! `execute_and_stream` -> `execute()` for any aggregate) must agree with each
+//! other AND with these hand-computed values.
+//!
+//! Run:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine \
+//!     --test issue_1578_streaming_aggregate_multigen_parity
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine",
+    not(feature = "tombstones")
+))]
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database};
+use tempfile::TempDir;
+
+const KS: &str = "agg_multigen_ks";
+const TBL: &str = "metrics";
+
+fn schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{TBL} (\n  id int PRIMARY KEY,\n  v int,\n  name text\n);\n")
+}
+
+fn write_row(id: i32, v: i32, name: &str, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![
+        CellOperation::Write {
+            column: "v".to_string(),
+            value: Value::Integer(v),
+        },
+        CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        },
+    ];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn delete_row(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    Mutation::new(
+        TableId::new(KS, TBL),
+        pk,
+        None,
+        vec![CellOperation::DeleteRow],
+        ts,
+        None,
+    )
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let n = e.file_name();
+            let n = n.to_string_lossy();
+            n.ends_with("-big-Data.db") || n.ends_with("-Data.db")
+        })
+        .count()
+}
+
+/// Build the 2-generation fixture described in the module doc under `data_dir`,
+/// with NO compaction between flushes — leaving two on-disk Data.db files.
+fn build_fixture(data_dir: &std::path::Path, wal_dir: &std::path::Path) {
+    use cqlite_core::schema::parse_cql_schema;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let schema = parse_cql_schema(&schema_cql()).expect("parse fixture schema");
+    let config = WriteEngineConfig::new(data_dir.to_path_buf(), wal_dir.to_path_buf(), schema);
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // Gen1: three rows.
+    for m in [
+        write_row(1, 10, "alpha", 100),
+        write_row(2, 20, "bravo", 100),
+        write_row(3, 5, "charlie", 100),
+    ] {
+        engine.write(m).expect("write gen1 row");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush gen1")
+        .expect("gen1 produced no SSTable");
+
+    // Gen2: overwrite id=1, row-delete id=2, add id=4.
+    engine
+        .write(write_row(1, 999, "alpha2", 200))
+        .expect("write gen2 overwrite");
+    engine.write(delete_row(2, 200)).expect("write gen2 delete");
+    engine
+        .write(write_row(4, 40, "delta", 200))
+        .expect("write gen2 new");
+    rt.block_on(engine.flush())
+        .expect("flush gen2")
+        .expect("gen2 produced no SSTable");
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    let sstable_dir = data_dir.join(KS).join(TBL);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        2,
+        "fixture must produce exactly 2 generations (no compaction)"
+    );
+}
+
+async fn open_multigen_db() -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, schema_cql()).expect("write schema file");
+
+    {
+        let data_dir = data_dir.clone();
+        let wal_dir = wal_dir.clone();
+        tokio::task::spawn_blocking(move || build_fixture(&data_dir, &wal_dir))
+            .await
+            .expect("fixture build task");
+    }
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest multi-generation fixture");
+    (result.database, temp_dir)
+}
+
+fn single_value(rows: &[cqlite_core::query::result::QueryRow]) -> Value {
+    assert_eq!(rows.len(), 1, "a global aggregate yields exactly one row");
+    let mut vals = rows[0].values.values();
+    let v = vals.next().cloned().expect("aggregate row has one value");
+    assert!(
+        vals.next().is_none(),
+        "a single-aggregate SELECT yields exactly one value in the row"
+    );
+    v
+}
+
+async fn agg_execute(db: &Database, sql: &str) -> Value {
+    let result = db.execute(sql).await.expect("execute aggregate");
+    single_value(&result.rows)
+}
+
+async fn agg_streaming(db: &Database, sql: &str) -> Value {
+    let mut iter = db
+        .execute_streaming(
+            sql,
+            StreamingConfig {
+                buffer_size: 1,
+                ..StreamingConfig::default()
+            },
+        )
+        .await
+        .expect("execute_streaming aggregate");
+    let mut rows = Vec::new();
+    while let Some(r) = iter.next_async().await {
+        rows.push(r.expect("streamed aggregate row"));
+    }
+    single_value(&rows)
+}
+
+/// Assert execute()/execute_streaming() agree across generations, and both
+/// equal the by-hand oracle from the module doc.
+async fn assert_agg(db: &Database, sql: &str, expected: Value) {
+    let e = agg_execute(db, sql).await;
+    let s = agg_streaming(db, sql).await;
+    assert_eq!(
+        e, s,
+        "Issue #1578 Finding 1: '{sql}' — execute()={e:?} != execute_streaming()={s:?} \
+         across a multi-generation fixture"
+    );
+    assert_eq!(
+        e, expected,
+        "Issue #1578 Finding 1: '{sql}' — result {e:?} != by-hand oracle {expected:?}"
+    );
+}
+
+/// Sanity: confirm the fixture reconciles to exactly the 3 live rows the
+/// module-doc oracle assumes. If this fails, the oracle values are meaningless.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multigen_fixture_reconciles_to_three_live_rows() {
+    let (db, _tmp) = open_multigen_db().await;
+    let result = db
+        .execute(&format!("SELECT * FROM {KS}.{TBL}"))
+        .await
+        .expect("execute SELECT *");
+    assert_eq!(
+        result.rows.len(),
+        3,
+        "multi-gen fixture must reconcile to 3 live rows (id=1 overwritten, \
+         id=2 deleted, id=3 unchanged, id=4 new)"
+    );
+}
+
+/// Core assertion: the O(1) streaming fold reconciles cross-generation exactly
+/// like the buffered/materializing path, matching the by-hand oracle.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_aggregate_multigen_parity() {
+    let (db, _tmp) = open_multigen_db().await;
+    let from = format!("FROM {KS}.{TBL}");
+
+    assert_agg(&db, &format!("SELECT COUNT(*) {from}"), Value::BigInt(3)).await;
+    assert_agg(&db, &format!("SELECT COUNT(v) {from}"), Value::BigInt(3)).await;
+    assert_agg(&db, &format!("SELECT SUM(v) {from}"), Value::Float(1044.0)).await;
+    assert_agg(&db, &format!("SELECT MIN(v) {from}"), Value::Integer(5)).await;
+    assert_agg(&db, &format!("SELECT MAX(v) {from}"), Value::Integer(999)).await;
+    assert_agg(
+        &db,
+        &format!("SELECT AVG(v) {from}"),
+        Value::Float(1044.0 / 3.0),
+    )
+    .await;
+    assert_agg(
+        &db,
+        &format!("SELECT MIN(name) {from}"),
+        Value::Text("alpha2".to_string()),
+    )
+    .await;
+    assert_agg(
+        &db,
+        &format!("SELECT MAX(name) {from}"),
+        Value::Text("delta".to_string()),
+    )
+    .await;
+}

--- a/cqlite-core/tests/issue_1578_streaming_aggregate_parity.rs
+++ b/cqlite-core/tests/issue_1578_streaming_aggregate_parity.rs
@@ -1,0 +1,295 @@
+//! Issue #1578 (Epic D / D2): a GROUP-BY-free aggregate
+//! (`COUNT`/`MIN`/`MAX`/`SUM`/`AVG` with no `GROUP BY`) folds the scan stream into
+//! an O(1) accumulator instead of buffering the whole table. This test pins the
+//! CORRECTNESS of that fold: for every aggregate × column-type × edge case, the
+//! materializing path (`Database::execute`) and the streaming path
+//! (`Database::execute_streaming`) must return the SAME single answer, and that
+//! answer must equal an independently-computed oracle.
+//!
+//! The parity axis (execute == execute_streaming) also holds on `main` (both route
+//! through `execute`), so this is a regression guard for the new fold path — after
+//! D2, `execute` drives the O(1) fold, so this exercises it directly.
+//!
+//! Guardrails checked here: COUNT(*) counts NULL rows but COUNT(col) does not; MIN/
+//! MAX use the Cassandra-matching value comparator; AVG is the sum+count pair; an
+//! empty table yields COUNT=0 and NULL extrema/sum/avg.
+//!
+//! Run:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine \
+//!     --test issue_1578_streaming_aggregate_parity
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine",
+    not(feature = "tombstones")
+))]
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database};
+use tempfile::TempDir;
+
+const KS: &str = "agg_ks";
+const TBL: &str = "metrics";
+
+fn schema_cql() -> String {
+    format!(
+        "CREATE TABLE {KS}.{TBL} (\n  id int PRIMARY KEY,\n  i int,\n  b bigint,\n  d double,\n  t text\n);\n"
+    )
+}
+
+/// One fixture row: `None` columns are simply not written (→ NULL / absent cell).
+#[derive(Clone)]
+struct Fx {
+    id: i32,
+    i: Option<i32>,
+    b: Option<i64>,
+    d: Option<f64>,
+    t: Option<&'static str>,
+}
+
+fn write_mutation(row: &Fx, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(row.id));
+    let mut ops = Vec::new();
+    if let Some(i) = row.i {
+        ops.push(CellOperation::Write {
+            column: "i".to_string(),
+            value: Value::Integer(i),
+        });
+    }
+    if let Some(b) = row.b {
+        ops.push(CellOperation::Write {
+            column: "b".to_string(),
+            value: Value::BigInt(b),
+        });
+    }
+    if let Some(d) = row.d {
+        ops.push(CellOperation::Write {
+            column: "d".to_string(),
+            value: Value::Float(d),
+        });
+    }
+    if let Some(t) = row.t {
+        ops.push(CellOperation::Write {
+            column: "t".to_string(),
+            value: Value::Text(t.to_string()),
+        });
+    }
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+/// Build a single-generation fixture and open the full query stack over it.
+async fn open_with_rows(rows: &[Fx]) -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, schema_cql()).expect("write schema file");
+
+    {
+        let data_dir = data_dir.clone();
+        let wal_dir = wal_dir.clone();
+        let rows = rows.to_vec();
+        tokio::task::spawn_blocking(move || {
+            use cqlite_core::schema::parse_cql_schema;
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime");
+            let schema = parse_cql_schema(&schema_cql()).expect("parse schema");
+            let config = WriteEngineConfig::new(data_dir, wal_dir, schema);
+            let mut engine = WriteEngine::new(config).expect("engine");
+            for (n, r) in rows.iter().enumerate() {
+                engine
+                    .write(write_mutation(r, 100 + n as i64))
+                    .expect("write row");
+            }
+            // A fixture with rows must flush a generation; an empty fixture skips.
+            let flushed = rt.block_on(engine.flush()).expect("flush");
+            if !rows.is_empty() {
+                flushed.expect("non-empty fixture must produce an SSTable");
+            }
+            rt.block_on(engine.close()).expect("close");
+        })
+        .await
+        .expect("fixture build task");
+    }
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest fixture");
+    (result.database, temp_dir)
+}
+
+/// Extract the single scalar of a one-aggregate result row.
+fn single_value(rows: &[cqlite_core::query::result::QueryRow]) -> Value {
+    assert_eq!(rows.len(), 1, "a global aggregate yields exactly one row");
+    let mut vals = rows[0].values.values();
+    let v = vals.next().cloned().expect("aggregate row has one value");
+    assert!(
+        vals.next().is_none(),
+        "a single-aggregate SELECT yields exactly one value in the row"
+    );
+    v
+}
+
+async fn agg_execute(db: &Database, sql: &str) -> Value {
+    let result = db.execute(sql).await.expect("execute aggregate");
+    single_value(&result.rows)
+}
+
+async fn agg_streaming(db: &Database, sql: &str) -> Value {
+    let mut iter = db
+        .execute_streaming(
+            sql,
+            StreamingConfig {
+                buffer_size: 4,
+                ..StreamingConfig::default()
+            },
+        )
+        .await
+        .expect("execute_streaming aggregate");
+    let mut rows = Vec::new();
+    while let Some(r) = iter.next_async().await {
+        rows.push(r.expect("streamed aggregate row"));
+    }
+    single_value(&rows)
+}
+
+/// Assert the streaming and materializing paths agree, and both equal `expected`.
+async fn assert_agg(db: &Database, sql: &str, expected: Value) {
+    let e = agg_execute(db, sql).await;
+    let s = agg_streaming(db, sql).await;
+    assert_eq!(
+        e, s,
+        "Issue #1578: '{sql}' — execute()={e:?} != execute_streaming()={s:?}"
+    );
+    assert_eq!(
+        e, expected,
+        "Issue #1578: '{sql}' — result {e:?} != oracle {expected:?}"
+    );
+}
+
+fn fixture_rows() -> Vec<Fx> {
+    vec![
+        Fx { id: 1, i: Some(10), b: Some(1000), d: Some(1.5), t: Some("charlie") },
+        Fx { id: 2, i: Some(-4), b: Some(-20), d: Some(0.25), t: Some("alpha") },
+        Fx { id: 3, i: None, b: Some(7), d: None, t: Some("delta") },
+        Fx { id: 4, i: Some(30), b: None, d: Some(9.75), t: None },
+        Fx { id: 5, i: Some(10), b: Some(50), d: Some(-2.0), t: Some("bravo") },
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_aggregate_parity_matrix() {
+    let rows = fixture_rows();
+    let (db, _tmp) = open_with_rows(&rows).await;
+
+    let from = format!("FROM {KS}.{TBL}");
+
+    // COUNT(*) counts every partition, including the NULL-column row.
+    assert_agg(&db, &format!("SELECT COUNT(*) {from}"), Value::BigInt(5)).await;
+    // COUNT(col) excludes NULLs: i is null in one row, b null in one, d null in one.
+    assert_agg(&db, &format!("SELECT COUNT(i) {from}"), Value::BigInt(4)).await;
+    assert_agg(&db, &format!("SELECT COUNT(b) {from}"), Value::BigInt(4)).await;
+    assert_agg(&db, &format!("SELECT COUNT(d) {from}"), Value::BigInt(4)).await;
+    assert_agg(&db, &format!("SELECT COUNT(t) {from}"), Value::BigInt(4)).await;
+
+    // MIN/MAX over int, bigint, double, text (Cassandra-matching comparator).
+    assert_agg(&db, &format!("SELECT MIN(i) {from}"), Value::Integer(-4)).await;
+    assert_agg(&db, &format!("SELECT MAX(i) {from}"), Value::Integer(30)).await;
+    assert_agg(&db, &format!("SELECT MIN(b) {from}"), Value::BigInt(-20)).await;
+    assert_agg(&db, &format!("SELECT MAX(b) {from}"), Value::BigInt(1000)).await;
+    assert_agg(&db, &format!("SELECT MIN(d) {from}"), Value::Float(-2.0)).await;
+    assert_agg(&db, &format!("SELECT MAX(d) {from}"), Value::Float(9.75)).await;
+    assert_agg(
+        &db,
+        &format!("SELECT MIN(t) {from}"),
+        Value::Text("alpha".to_string()),
+    )
+    .await;
+    assert_agg(
+        &db,
+        &format!("SELECT MAX(t) {from}"),
+        Value::Text("delta".to_string()),
+    )
+    .await;
+
+    // SUM (as f64) over each numeric type.
+    assert_agg(&db, &format!("SELECT SUM(i) {from}"), Value::Float(46.0)).await;
+    assert_agg(&db, &format!("SELECT SUM(b) {from}"), Value::Float(1037.0)).await;
+    assert_agg(&db, &format!("SELECT SUM(d) {from}"), Value::Float(9.5)).await;
+
+    // AVG = sum/count over the NON-NULL values (i: 46/4, d: 9.5/4).
+    assert_agg(&db, &format!("SELECT AVG(i) {from}"), Value::Float(46.0 / 4.0)).await;
+    assert_agg(&db, &format!("SELECT AVG(d) {from}"), Value::Float(9.5 / 4.0)).await;
+
+    // With a predicate: only rows with i >= 10 (ids 1,4,5 → i=10,30,10).
+    assert_agg(
+        &db,
+        &format!("SELECT COUNT(*) {from} WHERE i >= 10 ALLOW FILTERING"),
+        Value::BigInt(3),
+    )
+    .await;
+    assert_agg(
+        &db,
+        &format!("SELECT SUM(i) {from} WHERE i >= 10 ALLOW FILTERING"),
+        Value::Float(50.0),
+    )
+    .await;
+}
+
+/// Count the rows a query returns via each path, asserting the two paths agree.
+async fn assert_row_count_parity(db: &Database, sql: &str) -> usize {
+    let e = db.execute(sql).await.expect("execute").rows.len();
+    let mut iter = db
+        .execute_streaming(sql, StreamingConfig::default())
+        .await
+        .expect("execute_streaming");
+    let mut s = 0usize;
+    while let Some(r) = iter.next_async().await {
+        r.expect("streamed row");
+        s += 1;
+    }
+    assert_eq!(
+        e, s,
+        "Issue #1578: '{sql}' — execute() returned {e} rows, execute_streaming() {s}"
+    );
+    e
+}
+
+/// Empty-table: CQLite currently returns ZERO rows for a GROUP-BY-free aggregate
+/// over an empty table (an empty aggregate input produces no group), where
+/// Cassandra returns one row (COUNT=0, extrema NULL). That Cassandra divergence is
+/// a pre-existing behavior gap tracked OUTSIDE this memory fix (#1578). The
+/// in-scope guarantee here is that the O(1) fold path preserves that behavior and
+/// stays byte-consistent with the materializing path — both return 0 rows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_aggregate_empty_table_row_count_parity() {
+    let (db, _tmp) = open_with_rows(&[]).await;
+    let from = format!("FROM {KS}.{TBL}");
+
+    for agg in [
+        "COUNT(*)", "COUNT(i)", "MIN(i)", "MAX(t)", "SUM(i)", "AVG(i)",
+    ] {
+        let sql = format!("SELECT {agg} {from}");
+        assert_eq!(
+            assert_row_count_parity(&db, &sql).await,
+            0,
+            "Issue #1578: '{sql}' over an empty table returns 0 rows (current \
+             CQLite semantics; the fold must not diverge from the buffered path)"
+        );
+    }
+}

--- a/cqlite-core/tests/issue_1578_streaming_aggregate_parity.rs
+++ b/cqlite-core/tests/issue_1578_streaming_aggregate_parity.rs
@@ -184,11 +184,41 @@ async fn assert_agg(db: &Database, sql: &str, expected: Value) {
 
 fn fixture_rows() -> Vec<Fx> {
     vec![
-        Fx { id: 1, i: Some(10), b: Some(1000), d: Some(1.5), t: Some("charlie") },
-        Fx { id: 2, i: Some(-4), b: Some(-20), d: Some(0.25), t: Some("alpha") },
-        Fx { id: 3, i: None, b: Some(7), d: None, t: Some("delta") },
-        Fx { id: 4, i: Some(30), b: None, d: Some(9.75), t: None },
-        Fx { id: 5, i: Some(10), b: Some(50), d: Some(-2.0), t: Some("bravo") },
+        Fx {
+            id: 1,
+            i: Some(10),
+            b: Some(1000),
+            d: Some(1.5),
+            t: Some("charlie"),
+        },
+        Fx {
+            id: 2,
+            i: Some(-4),
+            b: Some(-20),
+            d: Some(0.25),
+            t: Some("alpha"),
+        },
+        Fx {
+            id: 3,
+            i: None,
+            b: Some(7),
+            d: None,
+            t: Some("delta"),
+        },
+        Fx {
+            id: 4,
+            i: Some(30),
+            b: None,
+            d: Some(9.75),
+            t: None,
+        },
+        Fx {
+            id: 5,
+            i: Some(10),
+            b: Some(50),
+            d: Some(-2.0),
+            t: Some("bravo"),
+        },
     ]
 }
 
@@ -233,8 +263,18 @@ async fn streaming_aggregate_parity_matrix() {
     assert_agg(&db, &format!("SELECT SUM(d) {from}"), Value::Float(9.5)).await;
 
     // AVG = sum/count over the NON-NULL values (i: 46/4, d: 9.5/4).
-    assert_agg(&db, &format!("SELECT AVG(i) {from}"), Value::Float(46.0 / 4.0)).await;
-    assert_agg(&db, &format!("SELECT AVG(d) {from}"), Value::Float(9.5 / 4.0)).await;
+    assert_agg(
+        &db,
+        &format!("SELECT AVG(i) {from}"),
+        Value::Float(46.0 / 4.0),
+    )
+    .await;
+    assert_agg(
+        &db,
+        &format!("SELECT AVG(d) {from}"),
+        Value::Float(9.5 / 4.0),
+    )
+    .await;
 
     // With a predicate: only rows with i >= 10 (ids 1,4,5 → i=10,30,10).
     assert_agg(

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2510,7 +2510,8 @@ dispatch_component() {
       --features write-support,cli-helpers,state_machine \
       --test issue_1582_byte_bounded_result_budget \
       --test issue_1578_streaming_aggregate_parity \
-      --test issue_1578_limit_exempts_max_results ;;
+      --test issue_1578_limit_exempts_max_results \
+      --test issue_1578_streaming_aggregate_multigen_parity ;;
     memory-budget) run_component memory-budget cargo test --package cqlite-core \
       --features cli-helpers,dhat-heap \
       --test memory_budget -- --test-threads=1 ;;

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2495,7 +2495,7 @@ dispatch_component() {
       --test issue_1085_tombstones_full_scan_parity ;;
     scan-offload-guard) run_component scan-offload-guard run_scan_offload_guard_cmd ;;
     work-counters-guard) run_component work-counters-guard cargo test --package cqlite-core \
-      --features cli-helpers,work-counters \
+      --features write-support,cli-helpers,state_machine,work-counters \
       --test issue_1566_read_work_counters \
       --test issue_1573_readat_positional \
       --test issue_1585_read_op_per_chunk \
@@ -2504,10 +2504,13 @@ dispatch_component() {
       --test issue_1642_positional_row_emit \
       --test issue_1570_key_offset_cache \
       --test issue_1575_candidate_key_hash_hoist \
-      --test issue_1576_range_short_circuit ;;
+      --test issue_1576_range_short_circuit \
+      --test issue_1578_aggregate_o1_memory ;;
     byte-budget-guard) run_component byte-budget-guard cargo test --package cqlite-core \
       --features write-support,cli-helpers,state_machine \
-      --test issue_1582_byte_bounded_result_budget ;;
+      --test issue_1582_byte_bounded_result_budget \
+      --test issue_1578_streaming_aggregate_parity \
+      --test issue_1578_limit_exempts_max_results ;;
     memory-budget) run_component memory-budget cargo test --package cqlite-core \
       --features cli-helpers,dhat-heap \
       --test memory_budget -- --test-threads=1 ;;


### PR DESCRIPTION
Closes #1578.

## What (D2 — Epic D #1516, read-path audit)
1. **O(1) streaming global aggregates**: GROUP-BY-free `COUNT/MIN/MAX/SUM/AVG` fold each row into a running accumulator off the scan stream (new `select_executor/stream_agg.rs`), reusing the buffered path's accumulator logic verbatim — answers byte-identical by construction. Eligibility fails safe: GROUP BY / Sort / Project / Limit / WRITETIME-TTL / targeted lookups all fall back to the buffered path (misrouting risk = slower, never wrong).
2. **`requires_materialization`**: Aggregate materializes only with GROUP BY; the streaming API stops being forced through the buffered path.
3. **MAX_RESULTS demoted to a safety valve**: explicit-LIMIT queries exempt the row-count valve only; the `max_result_bytes` byte budget still applies everywhere (pinned by `explicit_limit_does_not_exempt_byte_budget`).
4. **Cross-cutting fix (flagged in review)**: `scan_stream_windowed.rs` no longer applies `table_ids_match` on the stitched streaming path — the nb parser reports header-default table_ids, so the filter silently dropped ALL rows of CQLite-written SSTables. Mirrors the authoritative materializing `sequential_scan` stitched path (which deliberately skips it); file-level reader scoping is the real enforcement. Reviewer traced both paths and confirmed fail-safe. Likely fixes/overlaps #1897 (coordination note posted there).
5. #1116 splits in passing: `execute_streaming_background` → `streaming.rs`; `execute_aggregation` → `stream_agg.rs`.

## TDD (red-first)
- `count_star_buffers_o1_rows`: buffered-rows probe flat at 0 vs table size (was proportional: 50 vs 2000). Companion test proves the probe isn't dead (GROUP BY ≥300).
- `explicit_limit_exempts_row_count_valve`: was `QueryExecution("Result set too large…")`, now returns rows; `no_limit_still_trips_row_count_valve` stayed red-guarded.
- Aggregate parity matrix: COUNT/MIN/MAX/SUM/AVG × {int,bigint,double,text,predicate,NULLs,empty} — `execute` == `execute_streaming` == oracle. NaN comparator untouched (pre-existing shared comparator, both paths identical).

## Review
Internal `rust-reviewer` review-first: **APPROVE** (traced the `table_ids_match` hunk as a genuine correctness fix; should-fix docs + byte-budget pin test addressed in the polish round).

## Gate of record (run 2, @ 8f5a8164)
```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.8XCdKi
commit: 8f5a8164 branch: issue-1578-streaming-aggregates dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (2s)
core-tests:        PASS (163s)
tombstones-scan:   PASS (0s)
scan-offload-guard: PASS (2s)
work-counters-guard: PASS (12s)
byte-budget-guard: PASS (7s)
memory-budget:     PASS (4s)
integration-tests: PASS (1s)
format-compat:     PASS (0s)
write-tests:       PASS (31s)
cli-tests:         PASS (4s)
compaction-byte-parity: PASS (2s)
python-bindings:   PASS (107s)
node-bindings:     PASS (145s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (1s)
binding-unwind-profile: PASS (1s)
tooling-tests:     PASS (34s)
minimal-build:     PASS (1s)
smoke:             PASS (5s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.8XCdKi
summary-file: /tmp/gate-1578-summary-r2.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

**Transparency — gate run 1 (same commit) FAILED** on `core-tests`: `cold_mmap_mixed_p99_bounded_by_k_times_baseline` (tail-latency harness, 4020/4021 passed; p99 36.85× vs 12× bound). Triage: the documented #1930 load-flake class — the run coincided with a load-avg ~150 spike from sibling-lane lite gates; the harness passes 5/5 solo and core-tests PASS on the drained-box re-run above. Not a diff regression (this diff only removes per-row work on that path).

## Discovered (filed, not fixed here)
- #2069 — empty-table global aggregate returns 0 rows vs Cassandra's one row (fold preserves current semantics byte-for-byte; parity test documents divergence).
- #1897 — likely fixed by item 4; coordination note posted (residual: its self-built-fixture in-gate parity test).

Roborev: job 1488 (branch) — result posted before merge.
