### PR TITLE
perf(#1596): F6 item 3 — clamp direct-I/O prefetch window to ≥2×(chunk+CRC), 4K-aligned (partial)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -36,6 +36,10 @@ mod read_at;
 // Concurrency scenarios for the ReadAt point-read migration (issue #1573).
 #[cfg(test)]
 mod read_at_point_tests;
+// Direct-I/O read-ahead window sizing (issue #1596, Epic F / F6): clamps a
+// sub-chunk `direct_io_prefetch_bytes` so one compression chunk never straddles
+// more than two aligned refills.
+mod prefetch_window;
 // sync-fallback registry-schema pre-resolution (issue #1692)
 #[cfg(feature = "state_machine")]
 mod registry_schema;
@@ -897,10 +901,20 @@ impl SSTableReader {
     ) -> Result<(BlockSource, ScanSource)> {
         // With prefetch off, use the minimal aligned read-ahead the direct
         // backend still requires (a single block, rounded up inside the cursor).
+        // Otherwise clamp the configured window so a sub-chunk
+        // `direct_io_prefetch_bytes` cannot make one compression chunk straddle
+        // many aligned refills (issue #1596, F6). The actual per-SSTable chunk
+        // length is not parsed yet at this open-time construction site, so the
+        // clamp floors against Cassandra's default 64 KiB chunk — which fully
+        // protects the default case (and the 1 MiB default window is already
+        // above the floor, so the clamp is a no-op there).
         let direct_window = if matches!(prefetch, PrefetchMode::Off) {
             1
         } else {
-            prefetch_bytes
+            prefetch_window::clamp_direct_prefetch_window(
+                prefetch_bytes,
+                prefetch_window::DEFAULT_COMPRESSION_CHUNK_BYTES,
+            )
         };
         match mode {
             DiskAccessMode::Buffered => Self::open_buffered_sources(path, file_size).await,

--- a/cqlite-core/src/storage/sstable/reader/prefetch_window.rs
+++ b/cqlite-core/src/storage/sstable/reader/prefetch_window.rs
@@ -1,0 +1,148 @@
+//! Direct-I/O read-ahead window sizing (issue #1596, Epic F / F6).
+//!
+//! The direct-I/O scan cursor ([`DirectCursor`](super::source::DirectCursor))
+//! refills an *aligned* read-ahead window with one `pread` per refill, then hands
+//! sub-ranges of that window to the chunk reader. Each on-disk compression chunk
+//! is `chunk_size` payload bytes + a trailing 4-byte CRC32, so the record the
+//! chunk reader consumes in one shot is `chunk_size + 4` bytes.
+//!
+//! If the configured window (`direct_io_prefetch_bytes`) is SMALLER than one
+//! chunk record, a single chunk read straddles multiple window refills — read
+//! amplification: `ceil(record / window)` `pread`s for what should be one. Worse,
+//! a window that is not a small multiple of the record makes the straddle count
+//! fluctuate as chunks drift across window boundaries.
+//!
+//! [`clamp_direct_prefetch_window`] removes that pathology at *source
+//! construction* (the audit F6 fix): it floors the window at `2 × (chunk_size +
+//! 4)` and keeps 4K alignment. With a window ≥ 2 records, any one chunk record
+//! spans at most two aligned windows, so per-chunk refills are bounded to
+//! `ceil(record / window) + 1 = 2` regardless of where the record falls. The
+//! default window (1 MiB) already exceeds this for the default 64 KiB chunk, so
+//! the clamp only bites when a caller sets `direct_io_prefetch_bytes` below a
+//! chunk — turning a silent amplification into the intended single-window read.
+
+/// I/O alignment (bytes) for direct reads — mirrors `source::DIRECT_IO_ALIGN` and
+/// `read_at::DIRECT_IO_ALIGN`. Kept here (non-`cfg`) so window sizing is available
+/// on every platform (the direct backend degrades to buffered off-Unix, but the
+/// window value is still computed at the shared call site).
+pub(crate) const DIRECT_IO_ALIGN: usize = 4096;
+
+/// Cassandra's default compression chunk length (`chunk_length_in_kb: 64`). Used
+/// as the chunk-size basis for the window floor at reader open, where the actual
+/// per-SSTable `CompressionInfo.chunk_length` is not yet parsed. This fully
+/// protects the common (default-chunk) case; a caller that both picks a larger
+/// custom chunk AND a deliberately tiny window retains that explicit choice.
+pub(crate) const DEFAULT_COMPRESSION_CHUNK_BYTES: usize = 64 * 1024;
+
+/// Clamp/round a requested direct-I/O prefetch window so a single compression
+/// chunk record never straddles more than two aligned refills.
+///
+/// Returns `max(prefetch_bytes, 2 × (chunk_size + 4))`, never below one alignment
+/// unit, rounded UP to [`DIRECT_IO_ALIGN`]. All arithmetic saturates (a
+/// near-`usize::MAX` `chunk_size`/`prefetch_bytes` yields the largest aligned
+/// value rather than overflowing), so the caller's downstream aligned allocation
+/// simply fails and falls back to buffered I/O instead of panicking.
+pub(crate) fn clamp_direct_prefetch_window(prefetch_bytes: usize, chunk_size: usize) -> usize {
+    // On-disk record = payload + trailing 4-byte CRC32.
+    let record = chunk_size.saturating_add(4);
+    // Two records so any one record spans at most two aligned windows.
+    let floor = record.saturating_mul(2);
+    let want = prefetch_bytes.max(floor).max(DIRECT_IO_ALIGN);
+    want.checked_next_multiple_of(DIRECT_IO_ALIGN)
+        .unwrap_or(usize::MAX & !(DIRECT_IO_ALIGN - 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Model the direct cursor's per-chunk refill count: reading a record of
+    /// `record` bytes through an aligned `window`, worst-case starting offset,
+    /// costs `ceil(record / window) + 1` refills (the `+1` for a record that
+    /// straddles a window boundary). This mirrors `DirectCursor::ensure_buffered`
+    /// without needing `O_DIRECT`, so the amplification invariant is testable on
+    /// every platform.
+    fn worst_case_refills(window: usize, record: usize) -> usize {
+        record.div_ceil(window) + 1
+    }
+
+    /// RED-first invariant (issue #1596 TDD): a prefetch window SMALLER than one
+    /// chunk record amplifies reads (this is the "fails today" state the audit
+    /// calls out), and the F6 clamp restores the `≤ ceil(chunk/window)+1 = 2`
+    /// bound. Both halves are asserted against the same `worst_case_refills`
+    /// model so the clamp's effect is falsifiable, not asserted by fiat.
+    #[test]
+    fn clamp_bounds_per_chunk_refills_to_two() {
+        let chunk = DEFAULT_COMPRESSION_CHUNK_BYTES;
+        let record = chunk + 4;
+
+        // A deliberately tiny window (below one chunk) — the misconfiguration the
+        // audit targets. Worst case it straddles many refills (> 2): read amp.
+        let tiny = 8 * 1024;
+        assert!(
+            worst_case_refills(tiny, record) > 2,
+            "an unclamped sub-chunk window must amplify (>2 refills/chunk); \
+             got {} for window={} record={}",
+            worst_case_refills(tiny, record),
+            tiny,
+            record
+        );
+
+        // After the clamp the window holds ≥ 2 records, so any one record spans
+        // at most two aligned windows: refills bounded to exactly 2.
+        let clamped = clamp_direct_prefetch_window(tiny, chunk);
+        assert!(
+            clamped >= 2 * record,
+            "clamped window must hold >= 2 records: {clamped} < {}",
+            2 * record
+        );
+        assert_eq!(
+            worst_case_refills(clamped, record),
+            2,
+            "clamped window must bound per-chunk refills to ceil(chunk/window)+1 = 2"
+        );
+    }
+
+    #[test]
+    fn clamp_result_is_4k_aligned_and_at_least_floor() {
+        for &(pf, chunk) in &[
+            (0usize, 64 * 1024usize),
+            (1, 64 * 1024),
+            (8 * 1024, 64 * 1024),
+            (4095, 4096),
+            (1024 * 1024, 64 * 1024), // default window already above floor
+            (128 * 1024, 256 * 1024), // larger custom chunk
+        ] {
+            let w = clamp_direct_prefetch_window(pf, chunk);
+            assert_eq!(w % DIRECT_IO_ALIGN, 0, "window {w} not 4K-aligned");
+            assert!(
+                w >= 2 * (chunk + 4),
+                "window {w} below floor 2*(chunk+4)={} (chunk={chunk})",
+                2 * (chunk + 4)
+            );
+            assert!(w >= pf, "window {w} dropped below requested {pf}");
+            assert!(w >= DIRECT_IO_ALIGN, "window {w} below one alignment unit");
+        }
+    }
+
+    /// A window already larger than the floor is preserved (only rounded up to
+    /// alignment) — the clamp never SHRINKS a well-sized window.
+    #[test]
+    fn clamp_preserves_large_windows() {
+        let big = 4 * 1024 * 1024;
+        assert_eq!(
+            clamp_direct_prefetch_window(big, DEFAULT_COMPRESSION_CHUNK_BYTES),
+            big,
+            "an already-aligned window above the floor is returned unchanged"
+        );
+    }
+
+    /// Saturating arithmetic: a pathological `chunk_size`/`prefetch_bytes` near
+    /// `usize::MAX` yields the largest aligned value, never a panic/overflow.
+    #[test]
+    fn clamp_saturates_on_overflow() {
+        let w = clamp_direct_prefetch_window(usize::MAX, usize::MAX);
+        assert_eq!(w % DIRECT_IO_ALIGN, 0, "saturated window must stay aligned");
+        assert_eq!(w, usize::MAX & !(DIRECT_IO_ALIGN - 1));
+    }
+}


### PR DESCRIPTION
Part of #1596 (F6, Epic F #1518) — **partial: item 3 of 4** (does NOT close the issue; items 1/2/4 are withheld under F6's measure-first guardrail pending owner decisions — see the NEEDS-OWNER comment on #1596).

## What (item 3: prefetch rounding)
`direct_io_prefetch_bytes` could be smaller than a compression chunk, so one chunk straddled multiple window refills. New `pub(crate) clamp_direct_prefetch_window` (`reader/prefetch_window.rs`) floors the window at 2× (chunk + 4-byte CRC), 4K-aligned, saturating arithmetic throughout; applied in `build_block_sources` for non-Off prefetch modes. `PrefetchMode::Off` untouched.

**Deterministic evidence (not wall-clock):** worst-case refills per 64KiB+4 record: 8KiB window = 10 refills → clamped (135168, 4K-aligned) = 2 refills, meeting the F6 bound ≤ ceil(chunk/window)+1. Red-first: a no-op clamp fails the invariant test (10 ≠ 2).

## Withheld (measure-first — evidence on the issue)
- Item 1 MADV_RANDOM: point source shares the scan source's `Arc<Mmap>`; advising it would violate #1143. Needs a dedicated 2nd mmap + Linux cold-cache bench → owner call.
- Item 2 fadvise(SEQUENTIAL): no `posix_fadvise` on macOS (unmeasurable locally); proper home `source.rs` is over the ratchet → owner call + #1116 split.
- Item 4 fast-lz4: cargo features are additive — an opt-OUT of safe-decode would make some non-default build silently unsafe. Needs a design decision. (CRC-before-decompress already pinned by `read_compressed_chunk_at_verifies_crc_before_returning`.)

## Notes
- `reader/mod.rs` +14 lines (pre-existing over threshold) acknowledged via `CQLITE_ALLOW_FILE_GROWTH=1` per #1116 doctrine; split debt noted on the issue (block_io.rs 2141 / mod.rs 1374 / source.rs 857).
- Roborev: job 1487 clean ("No issues found"; const-duplication documented, low-severity).

## Gate of record (@ 5e196da3)
```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.JzATyA
commit: 5e196da3 branch: issue-1596-hardware-sympathy dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (4s)
core-tests:        PASS (630s)
tombstones-scan:   PASS (32s)
scan-offload-guard: PASS (141s)
work-counters-guard: PASS (60s)
byte-budget-guard: PASS (7s)
memory-budget:     PASS (47s)
integration-tests: PASS (72s)
format-compat:     PASS (43s)
write-tests:       PASS (150s)
cli-tests:         PASS (201s)
compaction-byte-parity: PASS (8s)
python-bindings:   PASS (643s)
node-bindings:     PASS (562s)
delivery-telemetry: PASS (1s)
parity-report:     PASS (6s)
binding-unwind-profile: PASS (0s)
tooling-tests:     PASS (33s)
minimal-build:     PASS (65s)
smoke:             PASS (52s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.JzATyA
summary-file: /tmp/gate-1596-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```
