### PR TITLE
fix(#1870,#2010): Cassandra float/double total ordering (NaN last, -0.0<+0.0) across all comparators

### DIFF
--- a/cqlite-core/src/float_cmp.rs
+++ b/cqlite-core/src/float_cmp.rs
@@ -1,0 +1,215 @@
+//! Total ordering for IEEE-754 floats matching Apache Cassandra.
+//!
+//! Cassandra orders `float`/`double` columns (ORDER BY, MIN, MAX, and
+//! partition/clustering comparison) with Java's `Double.compare` /
+//! `Float.compare` contract, which is a *total* order:
+//!
+//! * `NaN` sorts **last** — greater than every other value, including
+//!   `+Infinity`. All `NaN` bit-patterns compare **equal** to each other
+//!   (Java canonicalises via `doubleToLongBits`).
+//! * `-0.0 < +0.0` — the signed zeros are **distinct and ordered**, unlike the
+//!   IEEE `==` used by Rust's `partial_cmp` (which reports them Equal).
+//! * every other pair follows normal numeric order.
+//!
+//! We deliberately implement this explicitly rather than reuse
+//! [`f64::total_cmp`] (which places *negative* NaN first and orders signed
+//! zeros as `-0.0 < +0.0` but NaN-first, diverging from Java) or
+//! [`f64::partial_cmp`] (which returns `None` on NaN and reports `-0.0 == +0.0`).
+//! See the CLAUDE.md "float ordering vs Java" roborev-findings note and
+//! issues #1870 / #2010.
+
+use std::cmp::Ordering;
+
+/// Compare two `f64` values with Cassandra/Java `Double.compare` total-order
+/// semantics: `NaN` last (all `NaN`s equal), `-0.0 < +0.0`, else numeric.
+#[inline]
+pub(crate) fn cassandra_double_cmp(a: f64, b: f64) -> Ordering {
+    match a.partial_cmp(&b) {
+        // Finite (or infinite) comparison succeeded. `partial_cmp` reports
+        // `-0.0 == +0.0`; Java distinguishes them, so break that tie by sign.
+        Some(Ordering::Equal) => sign_bit_tiebreak(a, b),
+        Some(ord) => ord,
+        // `None` ⇒ at least one operand is NaN. NaN sorts last; two NaNs equal.
+        None => match (a.is_nan(), b.is_nan()) {
+            (true, true) => Ordering::Equal,
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+            // Unreachable: `partial_cmp` only yields `None` when a NaN is present.
+            (false, false) => Ordering::Equal,
+        },
+    }
+}
+
+/// Compare two `f32` values with Cassandra/Java `Float.compare` semantics.
+///
+/// Widening `f32`→`f64` is lossless and preserves NaN-ness and the sign of
+/// zero, so we reuse the `f64` comparator.
+#[inline]
+pub(crate) fn cassandra_float_cmp(a: f32, b: f32) -> Ordering {
+    cassandra_double_cmp(a as f64, b as f64)
+}
+
+/// When two floats compare Equal under IEEE rules, Java still orders `-0.0`
+/// before `+0.0` (their `doubleToLongBits` differ in the sign bit). Only the
+/// signed zeros reach this branch with differing sign bits; equal non-zero
+/// magnitudes always share a sign, so they stay `Equal`.
+#[inline]
+fn sign_bit_tiebreak(a: f64, b: f64) -> Ordering {
+    match (a.is_sign_negative(), b.is_sign_negative()) {
+        (true, false) => Ordering::Less,    // -0.0 < +0.0
+        (false, true) => Ordering::Greater, // +0.0 > -0.0
+        _ => Ordering::Equal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- f64 (CQL `double`) -------------------------------------------------
+
+    #[test]
+    fn nan_sorts_last_greater_than_infinity() {
+        assert_eq!(
+            cassandra_double_cmp(f64::NAN, f64::INFINITY),
+            Ordering::Greater
+        );
+        assert_eq!(
+            cassandra_double_cmp(f64::INFINITY, f64::NAN),
+            Ordering::Less
+        );
+        assert_eq!(cassandra_double_cmp(f64::NAN, 1.0), Ordering::Greater);
+        assert_eq!(cassandra_double_cmp(-1.0e300, f64::NAN), Ordering::Less);
+    }
+
+    #[test]
+    fn all_nan_bit_patterns_compare_equal() {
+        let quiet = f64::NAN;
+        // A distinct (signalling-ish / negative) NaN bit-pattern.
+        let other = f64::from_bits(0xFFF8_0000_0000_0001);
+        assert!(other.is_nan());
+        assert_eq!(cassandra_double_cmp(quiet, other), Ordering::Equal);
+        assert_eq!(cassandra_double_cmp(other, quiet), Ordering::Equal);
+        assert_eq!(cassandra_double_cmp(quiet, quiet), Ordering::Equal);
+    }
+
+    #[test]
+    fn signed_zero_is_ordered() {
+        assert_eq!(cassandra_double_cmp(-0.0, 0.0), Ordering::Less);
+        assert_eq!(cassandra_double_cmp(0.0, -0.0), Ordering::Greater);
+        assert_eq!(cassandra_double_cmp(-0.0, -0.0), Ordering::Equal);
+        assert_eq!(cassandra_double_cmp(0.0, 0.0), Ordering::Equal);
+    }
+
+    #[test]
+    fn normal_numeric_order_preserved() {
+        assert_eq!(cassandra_double_cmp(1.0, 2.0), Ordering::Less);
+        assert_eq!(cassandra_double_cmp(2.0, 1.0), Ordering::Greater);
+        assert_eq!(cassandra_double_cmp(-1.0, 1.0), Ordering::Less);
+        assert_eq!(cassandra_double_cmp(5.0, 5.0), Ordering::Equal);
+        assert_eq!(
+            cassandra_double_cmp(f64::NEG_INFINITY, f64::INFINITY),
+            Ordering::Less
+        );
+    }
+
+    /// The headline oracle: sorting the mixed input must yield
+    /// `[-Inf, -0.0, +0.0, 1.0, +Inf, NaN, NaN]`.
+    #[test]
+    fn full_sort_matches_cassandra_oracle_f64() {
+        let mut v = [
+            1.0,
+            f64::NAN,
+            -0.0,
+            0.0,
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            f64::NAN,
+        ];
+        v.sort_by(|a, b| cassandra_double_cmp(*a, *b));
+
+        assert_eq!(v[0], f64::NEG_INFINITY);
+        assert!(
+            v[1] == 0.0 && v[1].is_sign_negative(),
+            "index 1 must be -0.0"
+        );
+        assert!(
+            v[2] == 0.0 && v[2].is_sign_positive(),
+            "index 2 must be +0.0"
+        );
+        assert_eq!(v[3], 1.0);
+        assert_eq!(v[4], f64::INFINITY);
+        assert!(v[5].is_nan(), "index 5 must be NaN");
+        assert!(v[6].is_nan(), "index 6 must be NaN");
+    }
+
+    /// MIN over `{-0.0, +0.0}` must select `-0.0` (they are distinguished).
+    #[test]
+    fn min_of_signed_zeros_selects_negative_zero() {
+        let data = [0.0_f64, -0.0_f64];
+        let min = data
+            .iter()
+            .copied()
+            .min_by(|a, b| cassandra_double_cmp(*a, *b))
+            .unwrap();
+        assert!(min == 0.0 && min.is_sign_negative(), "MIN must be -0.0");
+    }
+
+    /// MIN over data containing NaN must NOT return NaN (NaN is the max).
+    #[test]
+    fn min_ignores_nan_max_is_nan() {
+        let data = [f64::NAN, 3.0, -2.0, f64::NAN, 10.0];
+        let min = data
+            .iter()
+            .copied()
+            .min_by(|a, b| cassandra_double_cmp(*a, *b))
+            .unwrap();
+        assert_eq!(min, -2.0);
+        let max = data
+            .iter()
+            .copied()
+            .max_by(|a, b| cassandra_double_cmp(*a, *b))
+            .unwrap();
+        assert!(max.is_nan(), "MAX must be NaN (sorts last)");
+    }
+
+    // ---- f32 (CQL `float`) --------------------------------------------------
+
+    #[test]
+    fn full_sort_matches_cassandra_oracle_f32() {
+        let mut v = [
+            1.0_f32,
+            f32::NAN,
+            -0.0,
+            0.0,
+            f32::NEG_INFINITY,
+            f32::INFINITY,
+            f32::NAN,
+        ];
+        v.sort_by(|a, b| cassandra_float_cmp(*a, *b));
+
+        assert_eq!(v[0], f32::NEG_INFINITY);
+        assert!(
+            v[1] == 0.0 && v[1].is_sign_negative(),
+            "index 1 must be -0.0"
+        );
+        assert!(
+            v[2] == 0.0 && v[2].is_sign_positive(),
+            "index 2 must be +0.0"
+        );
+        assert_eq!(v[3], 1.0);
+        assert_eq!(v[4], f32::INFINITY);
+        assert!(v[5].is_nan());
+        assert!(v[6].is_nan());
+    }
+
+    #[test]
+    fn f32_nan_last_and_signed_zero() {
+        assert_eq!(
+            cassandra_float_cmp(f32::NAN, f32::INFINITY),
+            Ordering::Greater
+        );
+        assert_eq!(cassandra_float_cmp(-0.0, 0.0), Ordering::Less);
+        assert_eq!(cassandra_float_cmp(f32::NAN, f32::NAN), Ordering::Equal);
+    }
+}

--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod config;
 pub mod cql;
 pub mod error;
+pub(crate) mod float_cmp;
 pub mod parser;
 // DISABLED FOR M1: Security and performance modules causing compilation errors
 // pub mod performance;

--- a/cqlite-core/src/query/executor.rs
+++ b/cqlite-core/src/query/executor.rs
@@ -631,9 +631,11 @@ impl QueryExecutor {
     /// Compare two values
     fn compare_values(&self, a: &Value, b: &Value) -> Result<Ordering> {
         use crate::float_cmp::cassandra_double_cmp as dcmp;
+        use crate::float_cmp::cassandra_float_cmp as fcmp;
         match (a, b) {
             (Value::Integer(a), Value::Integer(b)) => Ok(a.cmp(b)),
             (Value::Float(a), Value::Float(b)) => Ok(dcmp(*a, *b)), // Cassandra order #1870/#2010
+            (Value::Float32(a), Value::Float32(b)) => Ok(fcmp(*a, *b)), // Cassandra order #1870/#2010
             (Value::Text(a), Value::Text(b)) => Ok(a.cmp(b)),
             (Value::Boolean(a), Value::Boolean(b)) => Ok(a.cmp(b)),
             // UUID/TIMEUUID (both Value::Uuid): byte-wise, as Cassandra orders.
@@ -901,6 +903,34 @@ mod tests {
             )
             .unwrap();
         assert_eq!(result, Ordering::Less);
+
+        // Issue #1870/#2010: ORDER BY on a float(f32) column must order via the
+        // Cassandra total comparator, not collapse to Equal (missing arm bug).
+        assert_eq!(
+            executor
+                .compare_values(&Value::Float32(1.0), &Value::Float32(2.0))
+                .unwrap(),
+            Ordering::Less
+        );
+        // Signed zeros are distinct; NaN sorts last and equals itself.
+        assert_eq!(
+            executor
+                .compare_values(&Value::Float32(-0.0), &Value::Float32(0.0))
+                .unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            executor
+                .compare_values(&Value::Float32(f32::NAN), &Value::Float32(1.0))
+                .unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(
+            executor
+                .compare_values(&Value::Float32(f32::NAN), &Value::Float32(f32::NAN))
+                .unwrap(),
+            Ordering::Equal
+        );
     }
 
     #[tokio::test]

--- a/cqlite-core/src/query/executor.rs
+++ b/cqlite-core/src/query/executor.rs
@@ -630,13 +630,13 @@ impl QueryExecutor {
 
     /// Compare two values
     fn compare_values(&self, a: &Value, b: &Value) -> Result<Ordering> {
+        use crate::float_cmp::cassandra_double_cmp as dcmp;
         match (a, b) {
             (Value::Integer(a), Value::Integer(b)) => Ok(a.cmp(b)),
-            (Value::Float(a), Value::Float(b)) => Ok(a.partial_cmp(b).unwrap_or(Ordering::Equal)),
+            (Value::Float(a), Value::Float(b)) => Ok(dcmp(*a, *b)), // Cassandra order #1870/#2010
             (Value::Text(a), Value::Text(b)) => Ok(a.cmp(b)),
             (Value::Boolean(a), Value::Boolean(b)) => Ok(a.cmp(b)),
-            // UUID comparison: byte-wise (same as Cassandra's ordering).
-            // Covers both UUID and TIMEUUID columns — both are stored as Value::Uuid.
+            // UUID/TIMEUUID (both Value::Uuid): byte-wise, as Cassandra orders.
             (Value::Uuid(a), Value::Uuid(b)) => Ok(a.cmp(b)),
             (Value::Null, Value::Null) => Ok(Ordering::Equal),
             (Value::Null, _) => Ok(Ordering::Less),

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -1928,18 +1928,13 @@ mod tests {
     ///   * with NaN present, the decorated output is order-IDENTICAL to a direct
     ///     reference sort over the same keys and comparator (ASC and DESC) — the
     ///     core preservation guarantee; and
-    ///   * over a NaN-free float input (where the comparator IS a total order),
-    ///     finite keys are correctly ordered and signed zeros (-0.0 vs +0.0, which
-    ///     compare Equal) keep input order (stable).
+    ///   * over a NaN-free float input, finite keys are correctly ordered and the
+    ///     signed zeros are ORDERED (-0.0 < +0.0) per Cassandra/Java.
     ///
-    /// NOTE (pre-existing gaps, out of scope for #1587): `compare_values_ordering`
-    /// compares floats via `f64::partial_cmp` (NaN → Equal, -0.0 == +0.0). So it
-    /// does NOT reproduce Cassandra/Java float ordering (NaN sorted LAST,
-    /// -0.0 < +0.0), and — because a NaN key makes the comparator a NON-total
-    /// order — a NaN in the input leaves even the finite keys in an unspecified
-    /// order. This test therefore pins the ordering the decorate-sort ACTUALLY
-    /// preserves, not the (currently absent) Java semantics. Making ORDER BY match
-    /// Cassandra float ordering is a separate behavior change; reported separately.
+    /// As of issues #1870/#2010, `compare_values_ordering` uses the Cassandra/Java
+    /// `Double.compare` TOTAL order (`crate::float_cmp`): NaN sorts LAST (all NaN
+    /// bit-patterns equal) and -0.0 < +0.0. The comparator is therefore a total
+    /// order even with NaN present, so ORDER BY reproduces Cassandra's float order.
     #[tokio::test]
     async fn execute_sort_preserves_float_nan_signed_zero_ordering() {
         let executor = create_test_executor().await;
@@ -2009,11 +2004,10 @@ mod tests {
             );
         }
 
-        // --- Part B: NaN-free input → the comparator is a total order, so the
-        // decorate-sort must produce correct finite ordering and stable signed
-        // zeros. Tags 2 (-0.0) and 4 (+0.0) compare Equal (must keep input order).
+        // --- Part B: NaN-free input → correct finite ordering with the signed
+        // zeros ORDERED (-0.0 < +0.0, Cassandra/Java), not treated as equal.
         let no_nan: [(u8, f64); 5] = [(0, 2.0), (2, -0.0), (3, 1.0), (4, 0.0), (5, -1.0)];
-        // Ascending: -1.0, then -0.0 (tag 2) then +0.0 (tag 4) [stable tie], 1.0, 2.0.
+        // Ascending: -1.0, then -0.0 (tag 2) < +0.0 (tag 4), 1.0, 2.0.
         let asc = executor
             .execute_sort(
                 make_rows(&no_nan),
@@ -2026,7 +2020,8 @@ mod tests {
             vec![5, 2, 4, 3, 0],
             "ascending float order with stable signed zeros"
         );
-        // Descending: 2.0, 1.0, then -0.0/+0.0 (stable tie: 2 before 4), -1.0.
+        // Descending: 2.0, 1.0, then +0.0 (tag 4) > -0.0 (tag 2), -1.0.
+        // Cassandra/Java orders -0.0 < +0.0, so descending places +0.0 first.
         let desc = executor
             .execute_sort(
                 make_rows(&no_nan),
@@ -2036,8 +2031,8 @@ mod tests {
             .expect("sort must succeed");
         assert_eq!(
             tags(&desc),
-            vec![0, 3, 2, 4, 5],
-            "descending float order with stable signed zeros"
+            vec![0, 3, 4, 2, 5],
+            "descending float order with -0.0 < +0.0 (Cassandra/Java)"
         );
     }
 

--- a/cqlite-core/src/query/select_executor/value_ops.rs
+++ b/cqlite-core/src/query/select_executor/value_ops.rs
@@ -49,10 +49,12 @@ pub(super) fn compare_values_ordering(a: &Value, b: &Value) -> std::cmp::Orderin
 /// non-matching variants because it stringifies and would produce surprising
 /// orderings (e.g. `Text("9")` < `Text("10")` lexicographically).
 pub(super) fn try_compare_values(a: &Value, b: &Value) -> Result<std::cmp::Ordering> {
-    use std::cmp::Ordering;
     if same_numeric_family(a, b) {
         if let (Some(x), Some(y)) = (a.as_f64(), b.as_f64()) {
-            return Ok(x.partial_cmp(&y).unwrap_or(Ordering::Equal));
+            // Cassandra/Java `Double.compare` total order: NaN last, -0.0 < +0.0
+            // (issues #1870, #2010). Never `partial_cmp().unwrap_or(Equal)`,
+            // which collapses NaN and signed zeros to Equal.
+            return Ok(crate::float_cmp::cassandra_double_cmp(x, y));
         }
     }
     if std::mem::discriminant(a) == std::mem::discriminant(b) {
@@ -194,6 +196,114 @@ mod tests {
         assert_eq!(
             try_compare_values(&Value::Integer(5), &Value::Integer(5)).unwrap(),
             Ordering::Equal
+        );
+    }
+
+    /// The query ordering comparator (used by ORDER BY / MIN / MAX) must match
+    /// Cassandra/Java `Double.compare`: NaN last, -0.0 < +0.0 (issues #1870/#2010).
+    #[test]
+    fn compare_values_ordering_double_matches_cassandra() {
+        use std::cmp::Ordering;
+        let f = Value::Float; // f64 → CQL `double`
+        assert_eq!(
+            compare_values_ordering(&f(f64::NAN), &f(f64::INFINITY)),
+            Ordering::Greater,
+            "NaN sorts after +Infinity"
+        );
+        assert_eq!(
+            compare_values_ordering(&f(f64::NAN), &f(f64::NAN)),
+            Ordering::Equal,
+            "two NaNs compare equal"
+        );
+        assert_eq!(
+            compare_values_ordering(&f(-0.0), &f(0.0)),
+            Ordering::Less,
+            "-0.0 < +0.0"
+        );
+        assert_eq!(compare_values_ordering(&f(1.0), &f(2.0)), Ordering::Less);
+    }
+
+    /// Sorting `Value::Float` keys yields the Cassandra oracle order
+    /// `[-Inf, -0.0, +0.0, 1.0, +Inf, NaN, NaN]`.
+    #[test]
+    fn order_by_double_sort_matches_oracle() {
+        let mut v = vec![
+            Value::Float(1.0),
+            Value::Float(f64::NAN),
+            Value::Float(-0.0),
+            Value::Float(0.0),
+            Value::Float(f64::NEG_INFINITY),
+            Value::Float(f64::INFINITY),
+            Value::Float(f64::NAN),
+        ];
+        v.sort_by(compare_values_ordering);
+        let f = |i: usize| match v[i] {
+            Value::Float(x) => x,
+            _ => unreachable!(),
+        };
+        assert_eq!(f(0), f64::NEG_INFINITY);
+        assert!(f(1) == 0.0 && f(1).is_sign_negative(), "index 1 = -0.0");
+        assert!(f(2) == 0.0 && f(2).is_sign_positive(), "index 2 = +0.0");
+        assert_eq!(f(3), 1.0);
+        assert_eq!(f(4), f64::INFINITY);
+        assert!(f(5).is_nan() && f(6).is_nan(), "NaNs sort last");
+    }
+
+    /// `Value::Float32` (CQL `float`) shares the same ordering semantics.
+    #[test]
+    fn order_by_float32_sort_matches_oracle() {
+        let mut v = vec![
+            Value::Float32(f32::NAN),
+            Value::Float32(0.0),
+            Value::Float32(-0.0),
+            Value::Float32(f32::INFINITY),
+        ];
+        v.sort_by(compare_values_ordering);
+        let f = |i: usize| match v[i] {
+            Value::Float32(x) => x,
+            _ => unreachable!(),
+        };
+        assert!(f(0) == 0.0 && f(0).is_sign_negative(), "index 0 = -0.0");
+        assert!(f(1) == 0.0 && f(1).is_sign_positive(), "index 1 = +0.0");
+        assert_eq!(f(2), f32::INFINITY);
+        assert!(f(3).is_nan(), "NaN sorts last");
+    }
+
+    /// MIN/MAX (aggregation uses `compare_values_ordering`): MIN over signed
+    /// zeros selects -0.0; NaN never wins MIN but is the MAX.
+    #[test]
+    fn min_max_double_matches_cassandra() {
+        let data = [
+            Value::Float(f64::NAN),
+            Value::Float(3.0),
+            Value::Float(-0.0),
+            Value::Float(0.0),
+            Value::Float(-2.0),
+        ];
+        let min = data
+            .iter()
+            .min_by(|a, b| compare_values_ordering(a, b))
+            .unwrap();
+        assert!(matches!(min, Value::Float(x) if *x == -2.0), "MIN = -2.0");
+
+        let max = data
+            .iter()
+            .max_by(|a, b| compare_values_ordering(a, b))
+            .unwrap();
+        assert!(
+            matches!(max, Value::Float(x) if x.is_nan()),
+            "MAX = NaN (sorts last)"
+        );
+
+        // MIN over just the signed zeros picks -0.0.
+        let zeros = [Value::Float(0.0), Value::Float(-0.0)];
+        let zmin = zeros
+            .iter()
+            .min_by(|a, b| compare_values_ordering(a, b))
+            .unwrap();
+        assert!(
+            matches!(zmin, Value::Float(x) if *x == 0.0 && x.is_sign_negative()),
+            "MIN of {{-0.0, +0.0}} = -0.0"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/collection_order/scalar.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/collection_order/scalar.rs
@@ -129,11 +129,16 @@ fn reorder_timestamp_bytes(input: u64) -> u64 {
 ///
 /// Single source of truth: this DELEGATES to the crate-wide canonical
 /// comparator [`crate::float_cmp::cassandra_float_cmp`] (issues #1870/#2010).
-/// The two are semantically identical — for non-NaN operands `total_cmp` yields
-/// the numeric order with `-0.0 < +0.0`, exactly what the canonical comparator's
-/// `partial_cmp` + sign-bit tie-break produces; for NaN both give NaN-last /
-/// all-NaN-equal — so delegating preserves the SET/MAP element byte order that
-/// has byte-parity coverage. See float_cmp.rs.
+/// The delegation is byte-neutral: `cassandra_float_cmp` implements the SAME
+/// `Float.compare` semantics as the prior explicit Java-compare code here
+/// (compare non-NaN numerically with `-0.0 < +0.0`; sort EVERY NaN last and
+/// treat all NaN bit-patterns as equal), so the SET/MAP element byte order that
+/// has byte-parity coverage is preserved.
+///
+/// Note: `f32::total_cmp` is NOT a drop-in substitute — it sorts NEGATIVE NaN
+/// FIRST and orders NaN by bit pattern (not all-NaN-equal, not NaN-last), which
+/// would diverge from Cassandra. The canonical comparator is used precisely
+/// because it matches Java, not `total_cmp`. See float_cmp.rs.
 pub(super) fn compare_f32_java(x: f32, y: f32) -> Ordering {
     crate::float_cmp::cassandra_float_cmp(x, y)
 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/collection_order/scalar.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/collection_order/scalar.rs
@@ -124,29 +124,25 @@ fn reorder_timestamp_bytes(input: u64) -> u64 {
 }
 
 /// Java `Float.compare` total order for two `f32`, matching Cassandra
-/// `FloatType.compare` (issue #1275). Unlike Rust's `f32::total_cmp`, Java treats
-/// EVERY NaN (any payload/sign) as greater than every non-NaN value (NaN sorts
-/// last) and does NOT distinguish NaN bit-patterns; it also orders `-0.0 < +0.0`.
+/// `FloatType.compare` (issue #1275): EVERY NaN sorts last (all NaN
+/// bit-patterns equal) and `-0.0 < +0.0`.
+///
+/// Single source of truth: this DELEGATES to the crate-wide canonical
+/// comparator [`crate::float_cmp::cassandra_float_cmp`] (issues #1870/#2010).
+/// The two are semantically identical — for non-NaN operands `total_cmp` yields
+/// the numeric order with `-0.0 < +0.0`, exactly what the canonical comparator's
+/// `partial_cmp` + sign-bit tie-break produces; for NaN both give NaN-last /
+/// all-NaN-equal — so delegating preserves the SET/MAP element byte order that
+/// has byte-parity coverage. See float_cmp.rs.
 pub(super) fn compare_f32_java(x: f32, y: f32) -> Ordering {
-    match (x.is_nan(), y.is_nan()) {
-        (true, true) => Ordering::Equal,
-        (true, false) => Ordering::Greater,
-        (false, true) => Ordering::Less,
-        // Neither is NaN: total_cmp gives the numeric order with -0.0 < +0.0.
-        (false, false) => x.total_cmp(&y),
-    }
+    crate::float_cmp::cassandra_float_cmp(x, y)
 }
 
 /// Java `Double.compare` total order for two `f64`, matching Cassandra
 /// `DoubleType.compare` (issue #1275). See [`compare_f32_java`] for the NaN /
-/// signed-zero rules.
+/// signed-zero rules and the delegation rationale.
 pub(super) fn compare_f64_java(x: f64, y: f64) -> Ordering {
-    match (x.is_nan(), y.is_nan()) {
-        (true, true) => Ordering::Equal,
-        (true, false) => Ordering::Greater,
-        (false, true) => Ordering::Less,
-        (false, false) => x.total_cmp(&y),
-    }
+    crate::float_cmp::cassandra_double_cmp(x, y)
 }
 
 /// Scale-aware numeric comparison of two `decimal` values, matching Cassandra

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -809,8 +809,14 @@ fn compare_values(a: &Value, b: &Value) -> Result<Ordering> {
         (Integer(a), Integer(b)) => Ok(a.cmp(b)),
         (BigInt(a), BigInt(b)) => Ok(a.cmp(b)),
         (Counter(a), Counter(b)) => Ok(a.cmp(b)),
-        (Float32(a), Float32(b)) => Ok(a.partial_cmp(b).unwrap_or(Ordering::Equal)),
-        (Float(a), Float(b)) => Ok(a.partial_cmp(b).unwrap_or(Ordering::Equal)),
+        // Cassandra/Java total order (NaN last, -0.0 < +0.0) — NOT IEEE
+        // partial_cmp. This feeds ClusteringKey's `Ord`/`compare` (memtable
+        // BTreeMap key order + compaction merge), which requires a TOTAL order:
+        // a non-total order would let NaN compare Equal to everything
+        // (transitivity violation) and collapse -0.0/+0.0. See float_cmp.rs and
+        // issues #1870/#2010. Must agree with the reader's Value::partial_cmp.
+        (Float32(a), Float32(b)) => Ok(crate::float_cmp::cassandra_float_cmp(*a, *b)),
+        (Float(a), Float(b)) => Ok(crate::float_cmp::cassandra_double_cmp(*a, *b)),
         (Text(a), Text(b)) => Ok(a.cmp(b)),
         (Blob(a), Blob(b)) => Ok(a.cmp(b)),
         (Timestamp(a), Timestamp(b)) => Ok(a.cmp(b)),

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -536,7 +536,7 @@ impl PartitionKey {
 ///
 /// Stores the clustering key as a list of (column name, value) pairs.
 /// The order must match the schema's clustering key definition.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ClusteringKey {
     /// Column name and value pairs (in schema order)
     pub columns: Vec<(String, Value)>,
@@ -641,6 +641,20 @@ impl Ord for ClusteringKey {
 impl PartialOrd for ClusteringKey {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+// PartialEq is defined in terms of `Ord`, NOT derived. A derived `PartialEq`
+// would use `Value`'s IEEE-754 `PartialEq` (where `-0.0 == +0.0` and
+// `NaN != NaN`), which is inconsistent with `Ord`/`Eq` (issues #1870/#2010:
+// clustering comparison now uses the Cassandra/Java total order, where `-0.0`
+// and `+0.0` are distinct and `NaN == NaN`). Delegating to `cmp` keeps
+// PartialEq consistent with Ord/Eq (Rust contract) AND matches Cassandra row
+// identity for signed-zero and NaN clustering values. (`ClusteringKey` does
+// not derive `Hash`, so there is no eq/hash contract to uphold here.)
+impl PartialEq for ClusteringKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
     }
 }
 
@@ -1071,6 +1085,38 @@ mod tests {
         let ordering = ck1.compare(&ck2, &schema).unwrap();
         // DESC ordering reverses the comparison
         assert_eq!(ordering, Ordering::Greater);
+    }
+
+    // --- Issues #1870/#2010: PartialEq for ClusteringKey must be consistent
+    // with Ord/Eq (Cassandra total order), NOT IEEE-754 float equality. ---
+
+    #[test]
+    fn test_clustering_key_partial_eq_consistent_with_ord() {
+        // Signed zeros are DISTINCT under the Cassandra total order, so
+        // -0.0 must NOT equal +0.0 (a derived IEEE PartialEq would merge them).
+        let neg_zero = ClusteringKey::single("f", Value::Float(-0.0));
+        let pos_zero = ClusteringKey::single("f", Value::Float(0.0));
+        assert_eq!(neg_zero.cmp(&pos_zero), Ordering::Less);
+        assert_ne!(neg_zero, pos_zero);
+        assert_eq!(
+            neg_zero == pos_zero,
+            neg_zero.cmp(&pos_zero) == Ordering::Equal
+        );
+
+        // NaN is EQUAL to itself under the total order (a derived IEEE
+        // PartialEq would report NaN != NaN).
+        let nan_a = ClusteringKey::single("f", Value::Float(f64::NAN));
+        let nan_b = ClusteringKey::single("f", Value::Float(f64::NAN));
+        assert_eq!(nan_a.cmp(&nan_b), Ordering::Equal);
+        assert_eq!(nan_a, nan_b);
+
+        // Same invariants for the 32-bit float variant.
+        let f32_neg_zero = ClusteringKey::single("f", Value::Float32(-0.0));
+        let f32_pos_zero = ClusteringKey::single("f", Value::Float32(0.0));
+        assert_ne!(f32_neg_zero, f32_pos_zero);
+        let f32_nan_a = ClusteringKey::single("f", Value::Float32(f32::NAN));
+        let f32_nan_b = ClusteringKey::single("f", Value::Float32(f32::NAN));
+        assert_eq!(f32_nan_a, f32_nan_b);
     }
 
     // --- Issue #849: clustering reversal must not flip null/empty ordering ---

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -1043,6 +1043,19 @@ impl Value {
     }
 }
 
+/// Ordering for `Value`.
+///
+/// NOTE (contract split, #1870/#2010): this `PartialOrd` INTENTIONALLY diverges
+/// from the derived `PartialEq`. For `float`/`double` it uses the Cassandra/Java
+/// total order (`-0.0 < +0.0`, and every `NaN` sorts last and compares Equal to
+/// every other `NaN`), whereas `PartialEq` keeps IEEE semantics (`-0.0 == +0.0`,
+/// `NaN != NaN`). This is deliberate: ordering (ORDER BY / MIN / MAX / clustering
+/// order) must be a TOTAL order, while equality (GROUP BY) stays IEEE. As a
+/// result `partial_cmp` may report `Equal` where `eq` reports `false` (two NaNs)
+/// and vice-versa (`-0.0`/`+0.0`). If an `impl Ord for Value` is ever added it
+/// MUST reuse this comparator (never derive from `PartialEq`) and callers must
+/// not assume the `PartialOrd`/`PartialEq` consistency the std traits normally
+/// imply.
 impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         use crate::float_cmp::{cassandra_double_cmp as dcmp, cassandra_float_cmp as fcmp};

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -1045,6 +1045,7 @@ impl Value {
 
 impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use crate::float_cmp::{cassandra_double_cmp as dcmp, cassandra_float_cmp as fcmp};
         use std::cmp::Ordering;
         match (self, other) {
             (Value::Null, Value::Null) => Some(Ordering::Equal),
@@ -1055,7 +1056,7 @@ impl PartialOrd for Value {
             (Value::Integer(a), Value::Integer(b)) => a.partial_cmp(b),
             (Value::BigInt(a), Value::BigInt(b)) => a.partial_cmp(b),
             (Value::Counter(a), Value::Counter(b)) => a.partial_cmp(b),
-            (Value::Float(a), Value::Float(b)) => a.partial_cmp(b),
+            (Value::Float(a), Value::Float(b)) => Some(dcmp(*a, *b)),
             (Value::Text(a), Value::Text(b)) => a.partial_cmp(b),
             (Value::Blob(a), Value::Blob(b)) => a.partial_cmp(b),
             (Value::Timestamp(a), Value::Timestamp(b)) => a.partial_cmp(b),
@@ -1064,8 +1065,7 @@ impl PartialOrd for Value {
             (Value::Uuid(a), Value::Uuid(b)) => a.partial_cmp(b),
             (Value::TinyInt(a), Value::TinyInt(b)) => a.partial_cmp(b),
             (Value::SmallInt(a), Value::SmallInt(b)) => a.partial_cmp(b),
-            (Value::Float32(a), Value::Float32(b)) => a.partial_cmp(b),
-
+            (Value::Float32(a), Value::Float32(b)) => Some(fcmp(*a, *b)),
             (Value::Inet(a), Value::Inet(b)) => a.partial_cmp(b),
 
             // For complex types, compare by string representation

--- a/cqlite-core/src/types/comparator.rs
+++ b/cqlite-core/src/types/comparator.rs
@@ -472,8 +472,12 @@ impl ComparatorType {
 
     fn compare_float32(&self, left: &Value, right: &Value) -> Result<Ordering> {
         match (left, right) {
+            // Cassandra/Java total order (NaN last, -0.0 < +0.0), NOT IEEE
+            // partial_cmp — this is the schema-aware clustering-key read hot
+            // path and must agree with the writer's ClusteringKey ordering.
+            // See float_cmp.rs and issues #1870/#2010.
             (Value::Float32(l), Value::Float32(r)) => {
-                Ok(l.partial_cmp(r).unwrap_or(Ordering::Equal))
+                Ok(crate::float_cmp::cassandra_float_cmp(*l, *r))
             }
             _ => Err(Error::Schema(
                 "Type mismatch: expected float32 values".to_string(),
@@ -483,7 +487,9 @@ impl ComparatorType {
 
     fn compare_float(&self, left: &Value, right: &Value) -> Result<Ordering> {
         match (left.as_f64(), right.as_f64()) {
-            (Some(l), Some(r)) => Ok(l.partial_cmp(&r).unwrap_or(Ordering::Equal)),
+            // Cassandra/Java total order (NaN last, -0.0 < +0.0), NOT IEEE
+            // partial_cmp. See compare_float32 / float_cmp.rs (#1870/#2010).
+            (Some(l), Some(r)) => Ok(crate::float_cmp::cassandra_double_cmp(l, r)),
             _ => Err(Error::Schema(
                 "Type mismatch: expected float values".to_string(),
             )),

--- a/cqlite-core/tests/issue_1870_float_clustering_total_order.rs
+++ b/cqlite-core/tests/issue_1870_float_clustering_total_order.rs
@@ -1,0 +1,295 @@
+//! Read/write agreement for the Cassandra/Java float total order on CLUSTERING
+//! columns (issues #1870, #2010).
+//!
+//! Cassandra orders `float`/`double` clustering values with Java
+//! `Double.compare`/`Float.compare`: **NaN sorts last** (every NaN bit-pattern
+//! equal) and **`-0.0 < +0.0`**. This is a TOTAL order — required because the
+//! writer's [`ClusteringKey`] is an `Ord` key (memtable `BTreeMap` placement +
+//! compaction merge). A non-total order (IEEE `partial_cmp`) would let NaN
+//! compare `Equal` to everything (transitivity violation → mis-placed/dropped
+//! rows) and collapse `-0.0`/`+0.0`.
+//!
+//! Three comparators MUST agree for the same clustering values:
+//!   1. `ClusteringKey::compare` (schema-aware write/compaction path),
+//!   2. `ClusteringKey`'s `Ord::cmp` (schema-less memtable BTreeMap path),
+//!   3. `ComparatorType::compare` for `Float`/`Float32` (schema-aware READ hot
+//!      path), which must in turn agree with the reader's clustering-bound
+//!      check via `Value::partial_cmp`.
+//!
+//! Before the fix, sites (1)/(2) and the `ComparatorType` read path used IEEE
+//! `partial_cmp(..).unwrap_or(Equal)` (NaN → Equal, `-0.0 == +0.0`), so these
+//! assertions failed; after routing them through `crate::float_cmp` they pass.
+
+use std::cmp::Ordering;
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, TableSchema};
+use cqlite_core::storage::write_engine::ClusteringKey;
+use cqlite_core::types::{ComparatorType, Value};
+
+/// A negative quiet NaN (`total_cmp` would sort this FIRST; Java sorts it last).
+fn neg_nan_f64() -> f64 {
+    f64::from_bits(0xFFF8_0000_0000_0000)
+}
+fn neg_nan_f32() -> f32 {
+    f32::from_bits(0xFFC0_0000)
+}
+
+/// Single-`double`-clustering-column schema (ASC unless `desc`).
+fn double_schema(desc: bool) -> TableSchema {
+    single_clustering_schema("double", desc)
+}
+fn float_schema(desc: bool) -> TableSchema {
+    single_clustering_schema("float", desc)
+}
+fn single_clustering_schema(data_type: &str, desc: bool) -> TableSchema {
+    TableSchema {
+        keyspace: "ks".to_string(),
+        table: "t".to_string(),
+        partition_keys: vec![],
+        clustering_keys: vec![ClusteringColumn {
+            name: "c".to_string(),
+            data_type: data_type.to_string(),
+            position: 0,
+            order: if desc {
+                ClusteringOrder::Desc
+            } else {
+                ClusteringOrder::Asc
+            },
+        }],
+        columns: vec![],
+        comments: Default::default(),
+        dropped_columns: Default::default(),
+    }
+}
+
+fn ck(v: Value) -> ClusteringKey {
+    ClusteringKey::single("c", v)
+}
+
+// -------------------------------------------------------------------------
+// (1) ClusteringKey::compare (schema-aware write/compaction path).
+// -------------------------------------------------------------------------
+
+#[test]
+fn clustering_compare_double_nan_last_and_signed_zero() {
+    let schema = double_schema(false);
+    let nan = ck(Value::Float(neg_nan_f64()));
+    let inf = ck(Value::Float(f64::INFINITY));
+    let neg_zero = ck(Value::Float(-0.0));
+    let pos_zero = ck(Value::Float(0.0));
+
+    // NaN sorts after +Infinity (last).
+    assert_eq!(nan.compare(&inf, &schema).unwrap(), Ordering::Greater);
+    assert_eq!(inf.compare(&nan, &schema).unwrap(), Ordering::Less);
+    // Two NaNs (any bit-pattern) are Equal.
+    let nan2 = ck(Value::Float(f64::NAN));
+    assert_eq!(nan.compare(&nan2, &schema).unwrap(), Ordering::Equal);
+    // -0.0 < +0.0 (distinct, not IEEE-Equal).
+    assert_eq!(
+        neg_zero.compare(&pos_zero, &schema).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        pos_zero.compare(&neg_zero, &schema).unwrap(),
+        Ordering::Greater
+    );
+}
+
+#[test]
+fn clustering_compare_float32_nan_last_and_signed_zero() {
+    let schema = float_schema(false);
+    let nan = ck(Value::Float32(neg_nan_f32()));
+    let inf = ck(Value::Float32(f32::INFINITY));
+    let neg_zero = ck(Value::Float32(-0.0));
+    let pos_zero = ck(Value::Float32(0.0));
+
+    assert_eq!(nan.compare(&inf, &schema).unwrap(), Ordering::Greater);
+    assert_eq!(
+        neg_zero.compare(&pos_zero, &schema).unwrap(),
+        Ordering::Less
+    );
+    let nan2 = ck(Value::Float32(f32::NAN));
+    assert_eq!(nan.compare(&nan2, &schema).unwrap(), Ordering::Equal);
+}
+
+/// DESC reverses the total order (NaN sorts FIRST under DESC).
+#[test]
+fn clustering_compare_double_desc_reverses() {
+    let schema = double_schema(true);
+    let nan = ck(Value::Float(f64::NAN));
+    let inf = ck(Value::Float(f64::INFINITY));
+    assert_eq!(nan.compare(&inf, &schema).unwrap(), Ordering::Less);
+    let neg_zero = ck(Value::Float(-0.0));
+    let pos_zero = ck(Value::Float(0.0));
+    assert_eq!(
+        neg_zero.compare(&pos_zero, &schema).unwrap(),
+        Ordering::Greater
+    );
+}
+
+/// The headline oracle: sorting mixed doubles via `ClusteringKey::compare`
+/// yields `[-Inf, -0.0, +0.0, 1.0, +Inf, NaN]`.
+#[test]
+fn clustering_keys_sort_matches_oracle_double() {
+    let schema = double_schema(false);
+    let mut v = vec![
+        ck(Value::Float(1.0)),
+        ck(Value::Float(neg_nan_f64())),
+        ck(Value::Float(-0.0)),
+        ck(Value::Float(0.0)),
+        ck(Value::Float(f64::NEG_INFINITY)),
+        ck(Value::Float(f64::INFINITY)),
+    ];
+    v.sort_by(|a, b| a.compare(b, &schema).unwrap());
+    let got: Vec<Value> = v.into_iter().map(|k| k.columns[0].1.clone()).collect();
+    assert_eq!(got[0], Value::Float(f64::NEG_INFINITY));
+    assert!(matches!(got[1], Value::Float(f) if f == 0.0 && f.is_sign_negative()));
+    assert!(matches!(got[2], Value::Float(f) if f == 0.0 && f.is_sign_positive()));
+    assert_eq!(got[3], Value::Float(1.0));
+    assert_eq!(got[4], Value::Float(f64::INFINITY));
+    assert!(matches!(got[5], Value::Float(f) if f.is_nan()));
+}
+
+// -------------------------------------------------------------------------
+// (2) ClusteringKey Ord::cmp (schema-less memtable BTreeMap path).
+// -------------------------------------------------------------------------
+
+#[test]
+fn clustering_ord_is_total_over_nan_and_signed_zero() {
+    let nan = ck(Value::Float(f64::NAN));
+    let one = ck(Value::Float(1.0));
+    let neg_zero = ck(Value::Float(-0.0));
+    let pos_zero = ck(Value::Float(0.0));
+
+    // NaN is the maximum (sorts last), not Equal-to-everything.
+    assert_eq!(nan.cmp(&one), Ordering::Greater);
+    assert_eq!(one.cmp(&nan), Ordering::Less);
+    assert_eq!(nan.cmp(&ck(Value::Float(f64::NAN))), Ordering::Equal);
+    // Signed zeros distinct.
+    assert_eq!(neg_zero.cmp(&pos_zero), Ordering::Less);
+
+    // Total-order sanity in a BTreeSet: all distinct-by-order values retained,
+    // NaN present exactly once and last.
+    use std::collections::BTreeSet;
+    let set: BTreeSet<ClusteringKey> = [
+        ck(Value::Float(f64::NAN)),
+        ck(Value::Float(f64::NAN)),
+        ck(Value::Float(-0.0)),
+        ck(Value::Float(0.0)),
+        ck(Value::Float(1.0)),
+    ]
+    .into_iter()
+    .collect();
+    // NaN==NaN collapses the two NaNs; -0.0 and +0.0 are distinct ⇒ 4 entries.
+    assert_eq!(set.len(), 4);
+    let last = set.iter().next_back().unwrap();
+    assert!(matches!(last.columns[0].1, Value::Float(f) if f.is_nan()));
+}
+
+// -------------------------------------------------------------------------
+// (3) ComparatorType read hot path + read/write agreement.
+// -------------------------------------------------------------------------
+
+#[test]
+fn comparator_float_double_matches_java_total_order() {
+    let c = ComparatorType::Float; // CQL `double`
+    assert_eq!(
+        c.compare(&Value::Float(f64::NAN), &Value::Float(f64::INFINITY))
+            .unwrap(),
+        Ordering::Greater
+    );
+    assert_eq!(
+        c.compare(&Value::Float(-0.0), &Value::Float(0.0)).unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        c.compare(&Value::Float(f64::NAN), &Value::Float(f64::NAN))
+            .unwrap(),
+        Ordering::Equal
+    );
+}
+
+#[test]
+fn comparator_float32_matches_java_total_order() {
+    let c = ComparatorType::Float32; // CQL `float`
+    assert_eq!(
+        c.compare(
+            &Value::Float32(neg_nan_f32()),
+            &Value::Float32(f32::INFINITY)
+        )
+        .unwrap(),
+        Ordering::Greater
+    );
+    assert_eq!(
+        c.compare(&Value::Float32(-0.0), &Value::Float32(0.0))
+            .unwrap(),
+        Ordering::Less
+    );
+    assert_eq!(
+        c.compare(&Value::Float32(f32::NAN), &Value::Float32(f32::NAN))
+            .unwrap(),
+        Ordering::Equal
+    );
+}
+
+/// The core read/write-agreement guarantee: for every pair of `double`/`float`
+/// clustering values, the writer's `ClusteringKey::compare` (ASC), the
+/// schema-aware reader's `ComparatorType::compare`, and the reader's
+/// clustering-bound check (`Value::partial_cmp`) all yield the SAME ordering.
+#[test]
+fn read_write_comparators_agree_on_nan_and_signed_zero() {
+    let doubles = [
+        f64::NEG_INFINITY,
+        -1.0,
+        -0.0,
+        0.0,
+        1.0,
+        f64::INFINITY,
+        f64::NAN,
+        neg_nan_f64(),
+    ];
+    let schema = double_schema(false);
+    let cmp = ComparatorType::Float;
+    for &a in &doubles {
+        for &b in &doubles {
+            let va = Value::Float(a);
+            let vb = Value::Float(b);
+            let write_ord = ck(va.clone()).compare(&ck(vb.clone()), &schema).unwrap();
+            let read_ord = cmp.compare(&va, &vb).unwrap();
+            let bound_ord = va.partial_cmp(&vb).unwrap();
+            assert_eq!(
+                write_ord, read_ord,
+                "write vs read disagree for ({a:?}, {b:?})"
+            );
+            assert_eq!(
+                write_ord, bound_ord,
+                "write vs bound-check disagree for ({a:?}, {b:?})"
+            );
+        }
+    }
+
+    // Same for `float` (f32).
+    let floats = [
+        f32::NEG_INFINITY,
+        -1.0,
+        -0.0,
+        0.0,
+        1.0,
+        f32::INFINITY,
+        f32::NAN,
+        neg_nan_f32(),
+    ];
+    let fschema = float_schema(false);
+    let fcmp = ComparatorType::Float32;
+    for &a in &floats {
+        for &b in &floats {
+            let va = Value::Float32(a);
+            let vb = Value::Float32(b);
+            let write_ord = ck(va.clone()).compare(&ck(vb.clone()), &fschema).unwrap();
+            let read_ord = fcmp.compare(&va, &vb).unwrap();
+            let bound_ord = va.partial_cmp(&vb).unwrap();
+            assert_eq!(write_ord, read_ord, "f32 write vs read ({a:?}, {b:?})");
+            assert_eq!(write_ord, bound_ord, "f32 write vs bound ({a:?}, {b:?})");
+        }
+    }
+}


### PR DESCRIPTION
## Cassandra float/double total ordering

Closes #1870, closes #2010.

CQLite ordered f32/f64 via Rust IEEE `partial_cmp` (NaN→None/Equal, −0.0==+0.0), diverging from the oracle — Java `Double.compare`/`Float.compare`: **NaN sorts last** (all NaN bit-patterns equal), **−0.0 < +0.0**. This centralizes the correct comparator and routes every ordering path through it.

- **New `cqlite-core/src/float_cmp.rs`** — `cassandra_double_cmp`/`cassandra_float_cmp` (NaN last, all-NaN-equal, −0.0<+0.0; deliberately NOT `total_cmp`, which sorts negative-NaN first).
- **Routed through it:** ORDER BY + MIN/MAX (`select_executor/value_ops.rs`, `aggregation.rs`), legacy executor sort + range WHERE (`executor.rs`, both f64 **and** f32 arms), `Value::partial_cmp` (`types.rs`), write-side `ClusteringKey::compare` + its `Ord` (memtable BTreeMap key order, `mutation.rs`), schema-aware clustering comparator (`comparator.rs`). Collection-order `scalar.rs` (#1275) now **delegates** to the same source of truth (byte-neutral — verified).
- **ClusteringKey `PartialEq`** made consistent with `Ord` (delegates to `cmp()`), so it's Cassandra-correct (−0.0≠+0.0, NaN==NaN) and no longer violates the std Ord/Eq↔PartialEq contract.
- **Scope boundary:** `Value`'s IEEE `PartialEq` (GROUP BY grouping equality) is intentionally unchanged — GROUP BY-on-float parity with Cassandra's comparator grouping is tracked as follow-up **#2074**.

## Quality bar
- ✅ Full `scripts/agent-gate.sh` **RESULT: PASS** (23/23, commit `6a5e4296`, rebased on current main)
- ✅ roborev: 1 Low (GROUP BY-on-float grouping, pre-existing/out-of-scope) → tracked in #2074; no correctness/security/regression in this diff
- ✅ rust-reviewer review-first + re-review clean — caught & fixed a real incompleteness (missed write-side clustering comparator → read/write inconsistency) and the ClusteringKey PartialEq/Ord contract split BEFORE merge
- Tests: RED→GREEN oracle sorts (f32+f64, negative-NaN bit patterns, ±0.0, ±Inf) + a cross-product asserting write/schema-read/bound-check comparators all agree
