### PR TITLE
fix: wave-8 bundle — dataset skip-guard (#2065), single-compression builds (#1873), empty global aggregate (#2069)

### DIFF
--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -294,6 +294,43 @@ pub(super) fn finalize_group(
     }
 }
 
+/// Issue #2069: materialize the single result row of a GLOBAL aggregate (no
+/// GROUP BY) over ZERO input rows.
+///
+/// Cassandra's CQL semantics say a bare aggregate SELECT with no GROUP BY is a
+/// "global aggregate" and ALWAYS produces exactly one row, even over an empty
+/// table: `COUNT(*)`/`COUNT(col)` = `0`, and `MIN`/`MAX`/`SUM`/`AVG` = `NULL`
+/// (notably SUM of empty input is NULL, not `0`). This is DISTINCT from a
+/// GROUP BY query, which yields zero rows when there are no groups — the callers
+/// only reach this helper on the GROUP-BY-free path.
+///
+/// We cannot reuse [`init_aggregate_accumulators`] + [`finalize_group`] for this
+/// because a fresh `AggregateValue::Sum(0.0)` finalizes to `Float(0.0)`, whereas
+/// the empty-input answer must be `NULL`. This builds the row directly instead.
+pub(super) fn finalize_empty_global_aggregate(agg_plan: &AggregationPlan) -> QueryRow {
+    let mut row_values: HashMap<std::sync::Arc<str>, Value> =
+        HashMap::with_capacity(agg_plan.aggregates.len());
+
+    for agg_comp in &agg_plan.aggregates {
+        let result_value = match agg_comp.function {
+            // COUNT of empty input is 0 (BigInt, matching the non-empty finalize).
+            AggregateType::Count => Value::BigInt(0),
+            // SUM/AVG/MIN/MAX of empty input are NULL in Cassandra.
+            AggregateType::Sum | AggregateType::Avg | AggregateType::Min | AggregateType::Max => {
+                Value::Null
+            }
+        };
+        row_values.insert(agg_comp.alias.as_str().into(), result_value);
+    }
+
+    QueryRow {
+        values: row_values,
+        key: RowKey::new(vec![]),
+        metadata: Default::default(),
+        cell_metadata: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -358,6 +395,45 @@ mod tests {
              for {rows} rows / {groups_count} groups (linear scan would be ~{})",
             rows * groups_count / 2
         );
+    }
+
+    /// Issue #2069: the empty global-aggregate synthesizer emits COUNT = 0
+    /// (BigInt) and NULL for every other aggregate — SUM of empty is NULL, NOT
+    /// the `Float(0.0)` a fresh `Sum(0.0)` accumulator would finalize to.
+    #[test]
+    fn finalize_empty_global_aggregate_count_zero_others_null() {
+        let agg = |function, alias: &str| AggregateComputation {
+            function,
+            column: "x".to_string(),
+            alias: alias.to_string(),
+            distinct: false,
+        };
+        let plan = AggregationPlan {
+            group_by_columns: Vec::new(),
+            group_by_output_names: Vec::new(),
+            aggregates: vec![
+                agg(AggregateType::Count, "c"),
+                agg(AggregateType::Sum, "s"),
+                agg(AggregateType::Avg, "a"),
+                agg(AggregateType::Min, "mn"),
+                agg(AggregateType::Max, "mx"),
+            ],
+        };
+
+        let row = finalize_empty_global_aggregate(&plan);
+
+        assert_eq!(
+            row.values.get("c"),
+            Some(&Value::BigInt(0)),
+            "COUNT of empty input is 0"
+        );
+        for (alias, kind) in [("s", "SUM"), ("a", "AVG"), ("mn", "MIN"), ("mx", "MAX")] {
+            assert_eq!(
+                row.values.get(alias),
+                Some(&Value::Null),
+                "{kind} of empty input is NULL (not 0)"
+            );
+        }
     }
 
     /// The hash index must never merge distinct keys: `-0.0`/`+0.0` group

--- a/cqlite-core/src/query/select_executor/stream_agg.rs
+++ b/cqlite-core/src/query/select_executor/stream_agg.rs
@@ -9,8 +9,8 @@
 //!   `COUNT(*)`/`MIN`/`MAX`/`SUM`/`AVG` never buffer the whole table.
 
 use super::aggregation::{
-    build_group_key, finalize_group, find_or_init_group, init_aggregate_accumulators,
-    update_aggregate, AggregationState,
+    build_group_key, finalize_empty_global_aggregate, finalize_group, find_or_init_group,
+    init_aggregate_accumulators, update_aggregate, AggregationState,
 };
 use super::{
     build_row_from_scan, classify_partition_lookup, evaluate_predicates, validate_token_predicates,
@@ -79,6 +79,16 @@ impl SelectExecutor {
                     "Aggregation memory limit exceeded".to_string(),
                 ));
             }
+        }
+
+        // Issue #2069: a GLOBAL aggregate (no GROUP BY) always emits exactly one
+        // row, even when the input is empty. With rows present a single `[Null]`
+        // group is created above (see `build_group_key`); with zero rows no group
+        // exists yet, so synthesize the empty-input row (COUNT = 0, other
+        // aggregates NULL). A GROUP BY query is UNAFFECTED — it correctly returns
+        // zero rows when there are no groups.
+        if agg_state.groups.is_empty() && agg_plan.group_by_columns.is_empty() {
+            return Ok(vec![finalize_empty_global_aggregate(agg_plan)]);
         }
 
         let result_rows = agg_state
@@ -180,12 +190,16 @@ impl SelectExecutor {
             }
         }
 
-        // Preserve the buffered path's semantics exactly: an empty aggregate input
-        // produces NO group (0 result rows), not a synthetic COUNT=0 row. (The
-        // Cassandra one-row-for-empty divergence is a pre-existing behavior gap
-        // tracked outside this memory fix.)
+        // Issue #2069: a GLOBAL aggregate (no GROUP BY) ALWAYS produces exactly one
+        // result row, even over zero input rows. Cassandra returns COUNT = 0 and
+        // NULL for every other aggregate (SUM/AVG/MIN/MAX) of empty input, so when
+        // nothing folded we synthesize that single row rather than returning zero
+        // rows. This fold only handles the GROUP-BY-free case (see
+        // `classify_global_aggregate`), so it never affects a GROUP BY query, which
+        // correctly yields zero rows when there are no groups.
         if !folded_any {
-            return Ok(Some(Vec::new()));
+            let row = finalize_empty_global_aggregate(agg_plan);
+            return Ok(Some(vec![row]));
         }
 
         let row = finalize_group(vec![Value::Null], accumulators, agg_plan);

--- a/cqlite-core/src/storage/sstable/chunk_decompressor.rs
+++ b/cqlite-core/src/storage/sstable/chunk_decompressor.rs
@@ -374,6 +374,7 @@ impl ChunkDecompressor {
         }
     }
 
+    #[cfg(feature = "lz4")]
     fn decompress_lz4_chunk(&self, compressed_data: &[u8], chunk_index: usize) -> Result<Vec<u8>> {
         let file_info = match &self.data_file_path {
             Some(path) => format!(" in file {}", path),
@@ -451,6 +452,15 @@ impl ChunkDecompressor {
                 file_info
             ))),
         }
+    }
+
+    /// Decompress LZ4 chunk fallback when the `lz4` feature is disabled.
+    #[cfg(not(feature = "lz4"))]
+    fn decompress_lz4_chunk(&self, compressed_data: &[u8], chunk_index: usize) -> Result<Vec<u8>> {
+        let _ = (compressed_data, chunk_index); // Suppress unused warnings
+        Err(Error::UnsupportedFormat(
+            "LZ4 support not compiled in".to_string(),
+        ))
     }
 
     /// Decompress Snappy chunk - strict mode for modern formats
@@ -628,7 +638,10 @@ impl ChunkDecompressor {
     ///
     /// A cache hit does NOT increment this, so a repeated read of a resident chunk
     /// leaves it unchanged. Exposed for wiring-evidence tests (issue #1569).
-    #[cfg(test)]
+    ///
+    /// Consumed only by the lz4-gated multichunk round-trip tests, so it is gated to
+    /// match and stay dead-code-free under single-feature test builds (issue #1873).
+    #[cfg(all(test, feature = "lz4"))]
     pub(crate) fn decompress_call_count(&self) -> u64 {
         self.decompress_calls
     }
@@ -743,17 +756,23 @@ mod tests {
     /// `seek(SeekFrom::Current(0))`). Used to prove the chunk read path does not
     /// re-derive the immutable file size with a seek probe on every chunk
     /// (issue #1586).
+    ///
+    /// Only the lz4-gated multichunk tests construct it, so it is gated to match and
+    /// stay dead-code-free under single-feature test builds (issue #1873).
+    #[cfg(feature = "lz4")]
     struct SeekCountingReader {
         inner: std::io::Cursor<Vec<u8>>,
         seeks: std::rc::Rc<std::cell::Cell<usize>>,
     }
 
+    #[cfg(feature = "lz4")]
     impl std::io::Read for SeekCountingReader {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
             self.inner.read(buf)
         }
     }
 
+    #[cfg(feature = "lz4")]
     impl Seek for SeekCountingReader {
         fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
             self.seeks.set(self.seeks.get() + 1);

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -87,6 +87,11 @@ impl From<&str> for CompressionAlgorithm {
 ///
 /// # Security
 /// Prevents decompression bomb attacks by rejecting sizes > 128MB
+///
+/// Only the LZ4 small-block decompress path consumes this (the Snappy/Deflate/Zstd
+/// paths bound inline via `MAX_DECOMPRESSED_SIZE`), so it is gated to its sole caller
+/// to stay dead-code-free under single-feature builds (issue #1873).
+#[cfg(feature = "lz4")]
 fn validate_decompression_size(uncompressed_size: usize) -> Result<()> {
     if uncompressed_size > MAX_DECOMPRESSED_SIZE {
         return Err(Error::storage(format!(

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -2684,6 +2684,14 @@ mod tests {
 
     /// Resolve the on-disk table directory (the one holding `*-Data.db`) for
     /// `keyspace.table`, or `None` when datasets are absent (CI-lane skip).
+    ///
+    /// Skip keys off the `-Data.db` binary being present, NOT merely the table
+    /// directory existing: a clean worktree ships the JSONL references (so the
+    /// directory exists) but not the gitignored `-Data.db` binaries. Returning
+    /// `Some` for a binary-less directory would open zero readers and make the
+    /// caller's `readers.is_empty()` assertion PANIC instead of skip. Keeping the
+    /// gate on the binary preserves "present fixture that yields 0 readers is a
+    /// hard failure" (issue #2065, same doctrine as #1860).
     fn dataset_table_dir(keyspace: &str, table: &str) -> Option<PathBuf> {
         let datasets_root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
         let keyspace_dir = PathBuf::from(datasets_root).join("sstables").join(keyspace);
@@ -2691,11 +2699,22 @@ mod tests {
         for entry in std::fs::read_dir(&keyspace_dir).ok()?.flatten() {
             let path = entry.path();
             let file_name = path.file_name()?.to_str()?.to_string();
-            if path.is_dir() && file_name.starts_with(&table_prefix) {
+            if path.is_dir() && file_name.starts_with(&table_prefix) && dir_has_data_db(&path) {
                 return Some(path);
             }
         }
         None
+    }
+
+    /// True if `dir` holds a `*-Data.db` binary (the gitignored fixture data),
+    /// as opposed to only JSONL references. See `dataset_table_dir`.
+    fn dir_has_data_db(dir: &Path) -> bool {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
+        };
+        entries
+            .flatten()
+            .any(|f| f.file_name().to_string_lossy().ends_with("-Data.db"))
     }
 
     /// Issue #1571 (roborev Low, aggregate omission guard): `aggregate_key_cache_stats`

--- a/cqlite-core/tests/issue_1578_streaming_aggregate_parity.rs
+++ b/cqlite-core/tests/issue_1578_streaming_aggregate_parity.rs
@@ -310,26 +310,30 @@ async fn assert_row_count_parity(db: &Database, sql: &str) -> usize {
     e
 }
 
-/// Empty-table: CQLite currently returns ZERO rows for a GROUP-BY-free aggregate
-/// over an empty table (an empty aggregate input produces no group), where
-/// Cassandra returns one row (COUNT=0, extrema NULL). That Cassandra divergence is
-/// a pre-existing behavior gap tracked OUTSIDE this memory fix (#1578). The
-/// in-scope guarantee here is that the O(1) fold path preserves that behavior and
-/// stays byte-consistent with the materializing path — both return 0 rows.
+/// Empty-table (issue #2069): a GROUP-BY-free aggregate over an empty table is a
+/// GLOBAL aggregate and returns exactly ONE row in Cassandra — `COUNT` = 0 and
+/// `MIN`/`MAX`/`SUM`/`AVG` = NULL. Both the O(1) fold path and the materializing
+/// path must agree on that single row.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn streaming_aggregate_empty_table_row_count_parity() {
     let (db, _tmp) = open_with_rows(&[]).await;
     let from = format!("FROM {KS}.{TBL}");
 
-    for agg in [
-        "COUNT(*)", "COUNT(i)", "MIN(i)", "MAX(t)", "SUM(i)", "AVG(i)",
+    // COUNT of empty input is 0; every other aggregate of empty input is NULL.
+    for (agg, expected) in [
+        ("COUNT(*)", Value::BigInt(0)),
+        ("COUNT(i)", Value::BigInt(0)),
+        ("MIN(i)", Value::Null),
+        ("MAX(t)", Value::Null),
+        ("SUM(i)", Value::Null),
+        ("AVG(i)", Value::Null),
     ] {
         let sql = format!("SELECT {agg} {from}");
         assert_eq!(
             assert_row_count_parity(&db, &sql).await,
-            0,
-            "Issue #1578: '{sql}' over an empty table returns 0 rows (current \
-             CQLite semantics; the fold must not diverge from the buffered path)"
+            1,
+            "Issue #2069: '{sql}' over an empty table returns exactly one row"
         );
+        assert_agg(&db, &sql, expected).await;
     }
 }

--- a/cqlite-core/tests/issue_2069_global_aggregate_empty_table.rs
+++ b/cqlite-core/tests/issue_2069_global_aggregate_empty_table.rs
@@ -1,0 +1,231 @@
+//! Issue #2069: a GLOBAL aggregate (a bare aggregate SELECT with NO GROUP BY)
+//! over an EMPTY table must return exactly ONE row — matching Apache Cassandra
+//! CQL semantics — not zero rows.
+//!
+//! Oracle (Cassandra 5.0 CQL semantics):
+//!   - `COUNT(*)` / `COUNT(col)` over zero input rows = `0` (integer).
+//!   - `MIN`/`MAX`/`SUM`/`AVG` over zero input rows = `NULL` (SUM of empty is
+//!     NULL, NOT 0).
+//!   - A global aggregate (no GROUP BY) ALWAYS produces exactly one row, even
+//!     over zero input rows.
+//!   - A GROUP BY query is DIFFERENT: it produces zero rows when there are no
+//!     groups. This test pins that distinction as a regression guard.
+//!
+//! Both the O(1) streaming fold (`try_execute_global_aggregate`) and the buffered
+//! path (`execute_aggregation`) must satisfy the rule; the buffered path is
+//! exercised via a partition-targeted lookup that matches nothing.
+//!
+//! Run:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine \
+//!     --test issue_2069_global_aggregate_empty_table
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine",
+    not(feature = "tombstones")
+))]
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::QueryResult;
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database};
+use tempfile::TempDir;
+
+const KS: &str = "agg2069_ks";
+const TBL: &str = "metrics";
+
+fn schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{TBL} (\n  id int PRIMARY KEY,\n  i int,\n  t text\n);\n")
+}
+
+/// Build an EMPTY single-generation fixture (no rows) and open the full query
+/// stack over it. An empty fixture registers the schema but flushes no SSTable.
+async fn open_empty() -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, schema_cql()).expect("write schema file");
+
+    {
+        let data_dir = data_dir.clone();
+        let wal_dir = wal_dir.clone();
+        tokio::task::spawn_blocking(move || {
+            use cqlite_core::schema::parse_cql_schema;
+            use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime");
+            let schema = parse_cql_schema(&schema_cql()).expect("parse schema");
+            let config = WriteEngineConfig::new(data_dir, wal_dir, schema);
+            let mut engine = WriteEngine::new(config).expect("engine");
+            // An empty memtable flushes no generation; mirror the write path anyway.
+            let _ = rt.block_on(engine.flush()).expect("flush");
+            rt.block_on(engine.close()).expect("close");
+        })
+        .await
+        .expect("fixture build task");
+    }
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest fixture");
+    (result.database, temp_dir)
+}
+
+async fn run(db: &Database, sql: &str) -> QueryResult {
+    db.execute(sql).await.expect("execute query")
+}
+
+/// Look up the aggregate value in the single result row by its OUTPUT column
+/// name (the metadata name that pairs with the row value).
+fn value_by_column(result: &QueryResult, col_name: &str) -> Value {
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "global aggregate yields exactly one row"
+    );
+    result
+        .rows
+        .first()
+        .and_then(|r| r.values.get(col_name))
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+/// `SELECT COUNT(*) FROM <empty>` returns exactly one row whose value is 0.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn count_star_over_empty_table_is_one_row_zero() {
+    let (db, _tmp) = open_empty().await;
+
+    let result = run(&db, &format!("SELECT COUNT(*) FROM {KS}.{TBL}")).await;
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "issue #2069: COUNT(*) over an empty table returns exactly one row"
+    );
+    let v = result.rows[0]
+        .values
+        .values()
+        .next()
+        .cloned()
+        .expect("the one row has the COUNT value");
+    assert_eq!(
+        v,
+        Value::BigInt(0),
+        "issue #2069: COUNT(*) of empty input is 0"
+    );
+}
+
+/// `SELECT MIN(i), MAX(i), SUM(i), AVG(i), COUNT(*) FROM <empty>` returns exactly
+/// one row: the four extrema/sum/avg are NULL and COUNT is 0. The COUNT-vs-NULL
+/// distinction is the crux — SUM of empty is NULL, not 0.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multi_aggregate_over_empty_table_null_extrema_zero_count() {
+    let (db, _tmp) = open_empty().await;
+
+    let result = run(
+        &db,
+        &format!("SELECT MIN(i), MAX(i), SUM(i), AVG(i), COUNT(*) FROM {KS}.{TBL}"),
+    )
+    .await;
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "issue #2069: a global aggregate over an empty table returns exactly one row"
+    );
+
+    // Map each aggregate to its output column name so we assert per-function, not
+    // by positional guesswork.
+    let names: Vec<String> = result
+        .metadata
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    assert_eq!(
+        names.len(),
+        5,
+        "five aggregate output columns; got {names:?}"
+    );
+
+    // Independent of alias spelling: exactly one value must be BigInt(0) (COUNT)
+    // and the other four must be NULL.
+    let row = &result.rows[0];
+    let mut zero_count = 0usize;
+    let mut null_count = 0usize;
+    for name in &names {
+        match row
+            .values
+            .get(name.as_str())
+            .cloned()
+            .unwrap_or(Value::Null)
+        {
+            Value::BigInt(0) => zero_count += 1,
+            Value::Null => null_count += 1,
+            other => panic!(
+                "issue #2069: unexpected value {other:?} for column {name:?}; \
+                 empty global aggregate must be COUNT=0 + NULL extrema/sum/avg"
+            ),
+        }
+    }
+    assert_eq!(zero_count, 1, "exactly one COUNT(*)=0 value");
+    assert_eq!(
+        null_count, 4,
+        "MIN/MAX/SUM/AVG of empty input are all NULL (SUM of empty is NULL, not 0)"
+    );
+}
+
+/// The buffered aggregation path (`execute_aggregation`), not the O(1) fold,
+/// must obey the same rule. A `LIMIT` clause adds a step that disqualifies the
+/// streaming fold (`classify_global_aggregate` returns `None` for a `Limit`
+/// step), so a `COUNT(*) ... LIMIT n` over an empty full scan routes through the
+/// buffered path with zero input rows and must still emit one row with COUNT=0.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn count_star_buffered_path_over_empty_is_one_row_zero() {
+    let (db, _tmp) = open_empty().await;
+
+    let result = run(&db, &format!("SELECT COUNT(*) FROM {KS}.{TBL} LIMIT 5")).await;
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "issue #2069: buffered COUNT(*) over an empty table still returns one row"
+    );
+    let first_col = result.metadata.columns[0].name.clone();
+    let v = value_by_column(&result, &first_col);
+    assert_eq!(
+        v,
+        Value::BigInt(0),
+        "issue #2069: buffered COUNT(*) of empty input is 0"
+    );
+}
+
+/// Regression guard for the GLOBAL-vs-GROUP-BY distinction: a GROUP BY query over
+/// an empty table produces ZERO rows (there are no groups), UNLIKE the global
+/// aggregate. This must stay untouched by the #2069 fix.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn group_by_over_empty_table_is_zero_rows() {
+    let (db, _tmp) = open_empty().await;
+
+    let result = run(
+        &db,
+        &format!("SELECT id, COUNT(*) FROM {KS}.{TBL} GROUP BY id"),
+    )
+    .await;
+    assert_eq!(
+        result.rows.len(),
+        0,
+        "issue #2069: a GROUP BY query over an empty table returns zero rows \
+         (no groups) — only the GROUP-BY-free global aggregate emits a single row"
+    );
+}

--- a/cqlite-core/tests/issue_2069_global_aggregate_empty_table.rs
+++ b/cqlite-core/tests/issue_2069_global_aggregate_empty_table.rs
@@ -13,7 +13,7 @@
 //!
 //! Both the O(1) streaming fold (`try_execute_global_aggregate`) and the buffered
 //! path (`execute_aggregation`) must satisfy the rule; the buffered path is
-//! exercised via a partition-targeted lookup that matches nothing.
+//! exercised via a `LIMIT` clause that disqualifies the O(1) streaming fold.
 //!
 //! Run:
 //!   cargo test --package cqlite-core \

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2511,7 +2511,8 @@ dispatch_component() {
       --test issue_1582_byte_bounded_result_budget \
       --test issue_1578_streaming_aggregate_parity \
       --test issue_1578_limit_exempts_max_results \
-      --test issue_1578_streaming_aggregate_multigen_parity ;;
+      --test issue_1578_streaming_aggregate_multigen_parity \
+      --test issue_2069_global_aggregate_empty_table ;;
     memory-budget) run_component memory-budget cargo test --package cqlite-core \
       --features cli-helpers,dhat-heap \
       --test memory_budget -- --test-threads=1 ;;


### PR DESCRIPTION
Bundled three file-disjoint, oracle-driven lanes (fleet→integration, #1116). Each lite-PASS + review-clean individually; one solo full gate of record on the integration branch.

## Closes
- Closes #2065 — dataset skip-guard: `dataset_table_dir` now gated on `dir_has_data_db`, so the aggregate key-cache test skips (not panics) on clean worktrees; `assert!(!readers.is_empty())` preserved when Data.db present.
- Closes #1873 — single-compression-feature builds: `decompress_lz4_chunk` split into `#[cfg(feature="lz4")]` real impl + fallback returning `Error::UnsupportedFormat`; all 6 compression feature combos clean under `-D warnings`.
- Closes #2069 — empty global aggregate: `finalize_empty_global_aggregate` returns `COUNT→BigInt(0)`, `SUM/AVG/MIN/MAX→Null` (exhaustive match; not the Float(0.0) that init+finalize would yield). GROUP-BY-empty still 0 rows.

## Gate of record
`RESULT: PASS` — commit 408cc294, all 23 components green (full SUMMARY in first comment).

## Routing
Oracle-driven (Cassandra/decode source of truth + pinned tests). No OpenSpec.