### PR TITLE
perf(#1647): L1 — Rows.db separatorFloor/ceiling trie walk (42→10 BTI nodes, 2→1 entry resolves per point read)

### DIFF
--- a/cqlite-core/benches/fixtures/mod.rs
+++ b/cqlite-core/benches/fixtures/mod.rs
@@ -165,6 +165,19 @@ impl ReadFixture {
         schema_file: "time-series.cql",
     };
 
+    /// `test_da.wide_table` — the BTI (`da`) WIDE-partition fixture: `PRIMARY KEY
+    /// (pk, ck)`, `int` pk, 3 partitions (pk=1/2/3) each holding 300 clustering
+    /// rows (ck=0..299) whose per-partition `Rows.db` trie indexes 38 row-index
+    /// blocks. The single-column clustering seek fixture for the L1 floor-walk
+    /// benches (issue #1647). **Optional** — the `test_da` corpus is not present in
+    /// every checkout, so benches MUST guard on [`fixture_present`] and skip-register
+    /// when absent. Uses the `wide-table-bti.cql` schema.
+    pub const WIDE_BTI: ReadFixture = ReadFixture {
+        keyspace: "test_da",
+        table: "wide_table",
+        schema_file: "wide-table-bti.cql",
+    };
+
     /// `test_collections.collection_table` — lists/sets/maps. The type-heavy
     /// decode fixture (isolates deserialization cost).
     pub const TYPE_HEAVY: ReadFixture = ReadFixture {

--- a/cqlite-core/benches/read.rs
+++ b/cqlite-core/benches/read.rs
@@ -270,6 +270,64 @@ fn bench_clustering_slice(c: &mut Criterion) {
     group.finish();
 }
 
+/// Shared driver for the BTI (`da`) single-column clustering-seek benches
+/// (issue #1647 / L1). Runs a fully-constrained `WHERE pk = 1 AND <clustering>`
+/// query against `test_da.wide_table`, whose per-partition `Rows.db` trie indexes
+/// 38 row-index blocks. Post-L1 the read locates its block(s) with an
+/// O(key-length) separator-floor walk instead of materializing every block, so
+/// these benches are the sensitive read benches for a regression back to the
+/// enumerate-then-filter path. **Optional fixture**: registers nothing when the
+/// `test_da` corpus is absent, so the bench binary still runs everywhere.
+#[cfg(feature = "cli-helpers")]
+fn bench_clustering_bti(c: &mut Criterion, clustering: &str, bench_name: &str) {
+    let fx = fixtures::ReadFixture::WIDE_BTI;
+    if !fixtures::fixture_present(&fx) {
+        eprintln!("skip {bench_name}: optional BTI test_da/wide_table fixture not present");
+        return;
+    }
+    let loaded = fixtures::open_read_db(&fx);
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let sql = format!(
+        "SELECT pk, ck, payload FROM {} WHERE pk = 1 AND {clustering}",
+        fx.qualified()
+    );
+
+    let setup = rt
+        .block_on(loaded.db.execute(&sql))
+        .unwrap_or_else(|e| panic!("{bench_name} setup query failed: {e}"));
+    let rows_measured = setup.rows.len() as u64;
+    assert!(
+        rows_measured > 0,
+        "{bench_name}: `{sql}` returned zero rows — fixtures not fetched?",
+    );
+
+    let mut group = c.benchmark_group("read");
+    group.throughput(Throughput::Elements(rows_measured));
+    group.bench_function(bench_name, |bch| {
+        bch.iter(|| {
+            let res = rt
+                .block_on(loaded.db.execute(black_box(&sql)))
+                .expect("bti clustering seek");
+            black_box(res.rows.len())
+        });
+    });
+    group.finish();
+}
+
+/// Bench: BTI single-partition clustering POINT read (`ck = 150`) — the L1
+/// separator-floor fast path (issue #1647). Registers as `read/clustering_point_bti`.
+#[cfg(feature = "cli-helpers")]
+fn bench_clustering_point_bti(c: &mut Criterion) {
+    bench_clustering_bti(c, "ck = 150", "clustering_point_bti");
+}
+
+/// Bench: BTI single-partition clustering RANGE read (`ck in [100, 110)`) — floor
+/// + strict-ceiling walk (issue #1647). Registers as `read/clustering_range_bti`.
+#[cfg(feature = "cli-helpers")]
+fn bench_clustering_range_bti(c: &mut Criterion) {
+    bench_clustering_bti(c, "ck >= 100 AND ck < 110", "clustering_range_bti");
+}
+
 /// Bench: full-table scan of simple_table.
 ///
 /// `SELECT * FROM test_basic.simple_table` streams all ~999 rows.
@@ -407,6 +465,8 @@ criterion_group!(
               bench_get_partition_bti,
               bench_point_lookup_repeated,
               bench_clustering_slice,
+              bench_clustering_point_bti,
+              bench_clustering_range_bti,
               bench_full_scan,
               bench_type_heavy,
               bench_scan_partition_dense_stream

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -29,7 +29,9 @@ pub use parser::{
 // candidate-prune loop (issue #1575 / C4).
 pub(crate) use parser::lookup_partition_in_bti_slice;
 // Crate-internal O(key-length) Rows.db floor/ceiling walks (issue #1647 / L1),
-// consumed only by the reader's clustering-window path.
+// consumed only by the reader's clustering-window path (compiled out under
+// `tombstones`).
+#[cfg(not(feature = "tombstones"))]
 pub(crate) use parser::{rows_floor_block, rows_strict_ceiling_block};
 
 use crate::parser::header::CassandraVersion;

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -28,6 +28,9 @@ pub use parser::{
 // PRE-ENCODED byte-comparable key so callers hoist the key hash+encoding out of the
 // candidate-prune loop (issue #1575 / C4).
 pub(crate) use parser::lookup_partition_in_bti_slice;
+// Crate-internal O(key-length) Rows.db floor/ceiling walks (issue #1647 / L1),
+// consumed only by the reader's clustering-window path.
+pub(crate) use parser::{rows_floor_block, rows_strict_ceiling_block};
 
 use crate::parser::header::CassandraVersion;
 use std::collections::HashMap;

--- a/cqlite-core/src/storage/sstable/bti/parser/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/mod.rs
@@ -89,6 +89,8 @@ pub use rows::{
 pub(crate) use slice_walk::lookup_partition_in_bti_slice;
 // Crate-internal only: the O(key-length) Rows.db floor/ceiling walks (issue #1647
 // / L1). Their sole consumer is the SSTable reader's clustering-window path
-// (data_access::bti); kept off the public semver surface like the slice walker.
+// (data_access::bti), which is compiled out under `tombstones`; kept off the
+// public semver surface like the slice walker.
+#[cfg(not(feature = "tombstones"))]
 pub(crate) use rows_floor::{rows_floor_block, rows_strict_ceiling_block};
 pub use traversal::iterate_partitions_in_bti_file;

--- a/cqlite-core/src/storage/sstable/bti/parser/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/mod.rs
@@ -49,6 +49,8 @@
 //!   partition iterator.
 //! - [`rows`]        — `Rows.db` `RowIndexReader.IndexInfo` / `TrieIndexEntry`
 //!   decode, row iteration, and range-block selection.
+//! - [`rows_floor`]  — O(key-length) `separatorFloor` / strict-ceiling `Rows.db`
+//!   walks (issue #1647 / L1) + the shared per-node payload primitive.
 //! - [`encoding`]    — Cassandra OSS50 byte-comparable clustering-bound encoders.
 //! - [`reader`]      — the stateful `BtiHeader` / `PartitionsParser` /
 //!   `RowsParser` navigators, their iterators, and `BtiIndexStats`.
@@ -58,6 +60,7 @@ mod node_decode;
 mod partitions;
 mod reader;
 mod rows;
+mod rows_floor;
 mod slice_walk;
 mod traversal;
 
@@ -84,4 +87,8 @@ pub use rows::{
 // (issue #1575 / C4): every BTI partition lookup now encodes then walks via this
 // single primitive.
 pub(crate) use slice_walk::lookup_partition_in_bti_slice;
+// Crate-internal only: the O(key-length) Rows.db floor/ceiling walks (issue #1647
+// / L1). Their sole consumer is the SSTable reader's clustering-window path
+// (data_access::bti); kept off the public semver surface like the slice walker.
+pub(crate) use rows_floor::{rows_floor_block, rows_strict_ceiling_block};
 pub use traversal::iterate_partitions_in_bti_file;

--- a/cqlite-core/src/storage/sstable/bti/parser/rows.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/rows.rs
@@ -30,8 +30,7 @@
 use crate::{error::Error, storage::sstable::bti::node::BtiResult};
 use std::io::{Read, Seek, SeekFrom};
 
-use super::node_decode::parse_bti_node;
-use super::partitions::{payload_start_in_node, sized_ints_read_from_slice};
+use super::partitions::sized_ints_read_from_slice;
 use super::traversal::{dfs_collect_in_order, load_bti_trie_via_footer};
 
 #[allow(unused_imports)] // referenced in doc-links
@@ -252,66 +251,17 @@ pub fn decode_bti_row_payload(
     })
 }
 
-/// Read the `BtiRowIndexEntry` from the payload attached to a `Rows.db` node at
-/// `node_offset`, or `None` if the node carries no payload.
-///
-/// Structurally parallels
-/// [`read_node_payload`](super::partitions::read_node_payload) but decodes the
-/// Rows.db payload format via [`decode_bti_row_payload`].
-fn read_row_node_payload(
-    trie_data: &[u8],
-    node_offset: usize,
-) -> BtiResult<Option<BtiRowIndexEntry>> {
-    if node_offset >= trie_data.len() {
-        return Err(Error::Parse(format!(
-            "Rows.db payload read: node_offset {node_offset} out of bounds"
-        )));
-    }
-
-    let header_byte = trie_data[node_offset];
-    let ordinal = (header_byte >> 4) & 0x0F;
-    let payload_flags = header_byte & 0x0F;
-
-    // SingleNoPayload variants (ordinals 1, 3) carry their delta in the low
-    // nibble and never have a payload.  See `read_node_payload`.
-    if ordinal == 1 || ordinal == 3 {
-        return Ok(None);
-    }
-
-    if ordinal == 0 {
-        if payload_flags == 0 {
-            return Err(Error::Parse(
-                "Rows.db PayloadOnly node has zero payload_flags".to_string(),
-            ));
-        }
-        let payload_start = node_offset + 1;
-        Ok(Some(decode_bti_row_payload(
-            trie_data,
-            payload_start,
-            payload_flags,
-        )?))
-    } else if payload_flags != 0 {
-        // Slice must start at the node (see note in `read_node_payload`).
-        let node = parse_bti_node(&trie_data[node_offset..], node_offset as u64)?;
-        let payload_start = payload_start_in_node(&node, trie_data, node_offset)?;
-        Ok(Some(decode_bti_row_payload(
-            trie_data,
-            payload_start,
-            payload_flags,
-        )?))
-    } else {
-        Ok(None)
-    }
-}
-
 /// Enumerate every row-index entry in a `Rows.db` trie (rooted at `root_offset`)
 /// in byte-comparable order: `(reconstructed_clustering_key, BtiRowIndexEntry)`.
+///
+/// The per-node payload primitive lives in [`super::rows_floor`], alongside the
+/// O(key-length) floor/ceiling walks that share it (issue #1647 / L1).
 pub(crate) fn dfs_collect_row_entries(
     trie_data: &[u8],
     root_offset: usize,
 ) -> BtiResult<Vec<(Vec<u8>, BtiRowIndexEntry)>> {
     dfs_collect_in_order(trie_data, root_offset, |data, off| {
-        read_row_node_payload(data, off)
+        super::rows_floor::read_row_node_payload(data, off)
     })
 }
 
@@ -403,6 +353,9 @@ pub struct BtiRowIndexHeader {
 /// implausible, the vint fields are truncated, or the recovered trie root falls
 /// outside `rows_db`.
 pub fn resolve_rows_db_entry(rows_db: &[u8], rows_offset: usize) -> BtiResult<BtiRowIndexHeader> {
+    // Issue #1647 (L1): count every `TrieIndexEntry.deserialize` so the clustering
+    // read path can prove it resolves the per-partition entry EXACTLY once.
+    crate::storage::sstable::read_work_counters::record_rows_db_entry_resolve();
     if rows_offset + 2 > rows_db.len() {
         return Err(Error::Parse(format!(
             "Rows.db entry: rows_offset {rows_offset} + 2 (key length) exceeds file size {}",

--- a/cqlite-core/src/storage/sstable/bti/parser/rows_floor.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/rows_floor.rs
@@ -1,0 +1,509 @@
+//! O(key-length) `Rows.db` separator-floor / strict-ceiling trie walks (issue
+//! #1647 / L1).
+//!
+//! A `Rows.db` row-index trie stores **separators**, not block start keys: the
+//! separator `s_i` labels the boundary at the START of block `i`, and block `i`
+//! covers the half-open clustering interval `[s_i, s_{i+1})`.  Cassandra locates
+//! the block for a clustering key `K` with a downward `separatorFloor(K)` walk
+//! (`org.apache.cassandra.io.sstable.format.bti.RowIndexReader#separatorFloor`,
+//! built on `Walker#prefixAndNeighbours`) that visits O(len(K)) nodes — NOT by
+//! enumerating every block.  Before L1, CQLite's clustering read path materialized
+//! ALL row-index blocks (a full DFS) and then linearly filtered them; on the
+//! acceptance fixture that is ~42 visited nodes per read regardless of how few
+//! blocks a slice touches.
+//!
+//! This module provides the two authoritative walks the clustering-window path
+//! needs, each a byte-by-byte descent that tracks only the closest lesser/greater
+//! branch (never a collection of all blocks):
+//!
+//! - [`rows_floor_block`] — `separatorFloor(K)`: the block whose interval contains
+//!   `K` (the largest separator `<= K`), or `None` when `K` sorts below the first
+//!   separator (the "implicit first block" at the partition body start).
+//! - [`rows_strict_ceiling_block`] — the block with the smallest separator
+//!   **strictly greater** than `K` (`K`'s successor block), or `None` when `K`
+//!   sorts at/after the last separator (the window then runs to the partition end).
+//!
+//! Both are byte-for-byte equivalent to selecting from the full ascending
+//! `(separator, block)` list ([`super::rows::iterate_rows_in_bti_trie`] +
+//! [`super::rows::select_row_index_blocks_for_range`]); that enumerate-then-filter
+//! path is retained for genuine full-partition enumeration.
+//!
+//! Reference: cassandra-5.0.0 `Walker.java` (`follow` / `prefixAndNeighbours` /
+//! `goMin` / `goMax`), `RowIndexReader.java` (`separatorFloor`);
+//! docs/sstables-definitive-guide chapter 17.
+
+use crate::{error::Error, storage::sstable::bti::node::BtiResult};
+
+use super::node_decode::parse_bti_node;
+use super::partitions::{parse_bti_node_for_traversal, payload_start_in_node};
+use super::rows::{decode_bti_row_payload, BtiRowIndexEntry};
+use super::traversal::ordered_children;
+
+/// Read the `BtiRowIndexEntry` from the payload attached to a `Rows.db` node at
+/// `node_offset`, or `None` if the node carries no payload.
+///
+/// Structurally parallels
+/// [`read_node_payload`](super::partitions::read_node_payload) but decodes the
+/// Rows.db payload format via [`decode_bti_row_payload`].  Shared by the
+/// full-partition DFS ([`super::rows::dfs_collect_row_entries`]) and the
+/// floor/ceiling walks below.
+pub(super) fn read_row_node_payload(
+    trie_data: &[u8],
+    node_offset: usize,
+) -> BtiResult<Option<BtiRowIndexEntry>> {
+    if node_offset >= trie_data.len() {
+        return Err(Error::Parse(format!(
+            "Rows.db payload read: node_offset {node_offset} out of bounds"
+        )));
+    }
+
+    let header_byte = trie_data[node_offset];
+    let ordinal = (header_byte >> 4) & 0x0F;
+    let payload_flags = header_byte & 0x0F;
+
+    // SingleNoPayload variants (ordinals 1, 3) carry their delta in the low
+    // nibble and never have a payload.  See `read_node_payload`.
+    if ordinal == 1 || ordinal == 3 {
+        return Ok(None);
+    }
+
+    if ordinal == 0 {
+        if payload_flags == 0 {
+            return Err(Error::Parse(
+                "Rows.db PayloadOnly node has zero payload_flags".to_string(),
+            ));
+        }
+        let payload_start = node_offset + 1;
+        Ok(Some(decode_bti_row_payload(
+            trie_data,
+            payload_start,
+            payload_flags,
+        )?))
+    } else if payload_flags != 0 {
+        // Slice must start at the node (see note in `read_node_payload`).
+        let node = parse_bti_node(&trie_data[node_offset..], node_offset as u64)?;
+        let payload_start = payload_start_in_node(&node, trie_data, node_offset)?;
+        Ok(Some(decode_bti_row_payload(
+            trie_data,
+            payload_start,
+            payload_flags,
+        )?))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Result of searching a node's ascending child list for the next key byte
+/// (mirrors `TrieNode.search`).  `insertion` is the number of children whose
+/// transition byte is `< b` (the lower-bound index); `exact` is the child index
+/// when some child's byte equals `b`.
+///
+/// For `b == END_OF_STREAM` (key exhausted, which sorts below every real 0..=255
+/// transition byte) the result is `{ insertion: 0, exact: None }`, exactly as
+/// Cassandra's `search` returns `-1` for the end-of-stream sentinel.
+struct ChildSearch {
+    /// Number of children with transition byte strictly `< b` (lower bound).
+    insertion: usize,
+    /// The child index when `children[i].byte == b`, else `None`.
+    exact: Option<usize>,
+}
+
+/// Locate `b` in the node's ascending `(byte, child)` children.
+fn search_children(children: &[(u8, usize)], b: Option<u8>) -> ChildSearch {
+    let Some(byte) = b else {
+        // END_OF_STREAM sorts below every real transition byte.
+        return ChildSearch {
+            insertion: 0,
+            exact: None,
+        };
+    };
+    // Children are ascending by byte; find the first index with byte >= `byte`.
+    let insertion = children.partition_point(|&(cb, _)| cb < byte);
+    let exact = match children.get(insertion) {
+        Some(&(cb, _)) if cb == byte => Some(insertion),
+        _ => None,
+    };
+    ChildSearch { insertion, exact }
+}
+
+/// Descend to the MAXIMUM (rightmost) leaf under `node_offset` and return its
+/// row-index payload (mirrors `Walker#goMax`, always following the last child
+/// until a leaf, then reading the payload).
+fn go_max_payload(trie_data: &[u8], mut node_offset: usize) -> BtiResult<BtiRowIndexEntry> {
+    let mut steps = 0usize;
+    loop {
+        record_visit(trie_data, &mut steps)?;
+        let node = parse_bti_node_for_traversal(trie_data, node_offset)?;
+        match ordered_children(&node).last() {
+            Some(&(_, child)) => node_offset = child,
+            None => break,
+        }
+    }
+    read_row_node_payload(trie_data, node_offset)?.ok_or_else(|| {
+        Error::Parse(format!(
+            "Rows.db floor: max leaf at offset {node_offset} carries no row-index payload \
+             (corrupt trie)"
+        ))
+    })
+}
+
+/// Descend to the MINIMUM (leftmost) key under `node_offset` and return its
+/// row-index payload (mirrors `Walker#goMin`, stopping at the first node that
+/// carries a payload, else following the first child to a leaf).
+fn go_min_payload(trie_data: &[u8], mut node_offset: usize) -> BtiResult<BtiRowIndexEntry> {
+    let mut steps = 0usize;
+    loop {
+        record_visit(trie_data, &mut steps)?;
+        if let Some(payload) = read_row_node_payload(trie_data, node_offset)? {
+            return Ok(payload);
+        }
+        let node = parse_bti_node_for_traversal(trie_data, node_offset)?;
+        match ordered_children(&node).first() {
+            Some(&(_, child)) => node_offset = child,
+            None => {
+                return Err(Error::Parse(format!(
+                    "Rows.db ceiling: min leaf at offset {node_offset} carries no row-index \
+                     payload (corrupt trie)"
+                )))
+            }
+        }
+    }
+}
+
+/// Count one visited node and enforce the acyclic total-work bound: an acyclic
+/// trie has each node on a downward path occupy `>= 1` byte, so a walk that visits
+/// more nodes than the trie has bytes is proof of a cycle/corruption. Mirrors the
+/// DFS bound in [`super::traversal`].
+#[inline]
+fn record_visit(trie_data: &[u8], steps: &mut usize) -> BtiResult<()> {
+    crate::storage::sstable::read_work_counters::record_bti_node_visited();
+    *steps = steps.saturating_add(1);
+    if *steps > trie_data.len().saturating_add(1) {
+        return Err(Error::Parse(format!(
+            "Rows.db walk exceeded total work bound ({} nodes > trie size {}; corrupt or \
+             cyclic trie)",
+            *steps,
+            trie_data.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Compute `separatorFloor(target_key)`: the row-index block whose half-open
+/// clustering interval `[s_i, s_{i+1})` contains `target_key` — i.e. the block for
+/// the largest separator `<= target_key`.
+///
+/// Returns `Ok(None)` when `target_key` sorts strictly below the first stored
+/// separator: there is no stored block for it, only the trie-implicit first block
+/// at the partition body start (the caller decodes from rel 0 in that case; see
+/// `select_row_index_blocks_for_range`'s "implicit first block" note and
+/// `reader/data_access/bti.rs`).
+///
+/// This is byte-for-byte equivalent to taking the block with the maximum
+/// separator `<= target_key` from the full ascending `(separator, block)` list,
+/// but visits only O(len(target_key)) nodes.  Mirrors
+/// `RowIndexReader#separatorFloor` (`prefixAndNeighbours` + `goMax(lesserBranch)`).
+pub(crate) fn rows_floor_block(
+    trie_data: &[u8],
+    root_offset: usize,
+    target_key: &[u8],
+) -> BtiResult<Option<BtiRowIndexEntry>> {
+    // `payload` holds the closest prefix separator payload; `lesser_branch` holds
+    // the closest strictly-lesser subtree root (mirrors `prefixAndNeighbours`).
+    let mut payload: Option<BtiRowIndexEntry> = None;
+    let mut lesser_branch: Option<usize> = None;
+    let mut node_offset = root_offset;
+    let mut key_idx = 0usize;
+    let mut steps = 0usize;
+
+    loop {
+        record_visit(trie_data, &mut steps)?;
+        let node = parse_bti_node_for_traversal(trie_data, node_offset)?;
+        let children = ordered_children(&node);
+
+        let b = target_key.get(key_idx).copied();
+        key_idx += 1;
+        let ChildSearch { insertion, exact } = search_children(&children, b);
+
+        if insertion == 0 {
+            // `search` in {0 (exact-first), -1 (below all)}: the current node's
+            // separator is still a valid prefix floor candidate — keep it.
+            if let Some(p) = read_row_node_payload(trie_data, node_offset)? {
+                payload = Some(p);
+            }
+        } else {
+            // A strictly-lesser child exists: it (its max) is a closer floor than
+            // the current prefix, so record it and drop the prefix candidate.
+            lesser_branch = Some(children[insertion - 1].1);
+            payload = None;
+        }
+
+        match exact {
+            // Exact transition: descend and keep matching the key.
+            Some(i) => node_offset = children[i].1,
+            // No exact transition: the walk ends here.
+            None => break,
+        }
+    }
+
+    if let Some(p) = payload {
+        return Ok(Some(p));
+    }
+    // No prefix separator matched: the floor is the maximum of the closest lesser
+    // branch (or `None` — `target_key` sorts below the first separator).
+    match lesser_branch {
+        Some(lb) => Ok(Some(go_max_payload(trie_data, lb)?)),
+        None => Ok(None),
+    }
+}
+
+/// Compute the block with the smallest separator **strictly greater** than
+/// `target_key` (`target_key`'s successor block).
+///
+/// Returns `Ok(None)` when `target_key` sorts at or after the last separator: no
+/// stored block follows it, so the caller's row-body window runs to the partition
+/// end. Used to bound the END of a clustering slice's decode window: the exclusive
+/// window end is the successor of `floor(end)`, which equals the smallest separator
+/// strictly greater than `end`.
+///
+/// Byte-for-byte equivalent to the minimum separator `> target_key` in the full
+/// ascending list, but visits only O(len(target_key)) nodes.  Mirrors
+/// `Walker#followWithGreater` + `goMin(greaterBranch)`.
+pub(crate) fn rows_strict_ceiling_block(
+    trie_data: &[u8],
+    root_offset: usize,
+    target_key: &[u8],
+) -> BtiResult<Option<BtiRowIndexEntry>> {
+    // `greater_branch` holds the closest subtree whose keys are all > target_key.
+    let mut greater_branch: Option<usize> = None;
+    let mut node_offset = root_offset;
+    let mut key_idx = 0usize;
+    let mut steps = 0usize;
+
+    loop {
+        record_visit(trie_data, &mut steps)?;
+        let node = parse_bti_node_for_traversal(trie_data, node_offset)?;
+        let children = ordered_children(&node);
+
+        let b = target_key.get(key_idx).copied();
+        key_idx += 1;
+        let ChildSearch { insertion, exact } = search_children(&children, b);
+
+        // The child immediately greater than the search position: exact match at
+        // `i` -> child `i+1`; no exact match -> child at `insertion`. A deeper
+        // greater branch shares a longer prefix with the key, so its minimum is a
+        // closer successor — overwrite when the current node has one.
+        let greater_idx = match exact {
+            Some(i) => i + 1,
+            None => insertion,
+        };
+        if greater_idx < children.len() {
+            greater_branch = Some(children[greater_idx].1);
+        }
+
+        match exact {
+            Some(i) => node_offset = children[i].1,
+            None => break,
+        }
+    }
+
+    match greater_branch {
+        Some(gb) => Ok(Some(go_min_payload(trie_data, gb)?)),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::rows::{iterate_rows_in_bti_trie, select_row_index_blocks_for_range};
+    use super::*;
+
+    /// A `Rows.db` PayloadOnly leaf with no open marker (payloadBits=1): a
+    /// single-byte SizedInts Data.db position (value 0..=127).
+    fn row_leaf(pos: u8) -> Vec<u8> {
+        assert!(pos <= 127, "use a 1-byte SizedInts position");
+        vec![0x01, pos] // ordinal=0, payloadBits=1 (no FLAG_OPEN_MARKER)
+    }
+
+    /// Build a Rows.db-style trie whose separators are the single bytes `seps`
+    /// (ascending), each mapping to a distinct 1-byte payload position. Returns
+    /// `(trie_bytes, root_offset)`. Uses a Sparse8 root over single-byte leaves,
+    /// so every separator is exactly one byte — the canonical single-column
+    /// clustering shape.
+    fn make_trie(seps: &[u8]) -> (Vec<u8>, usize) {
+        let mut trie = Vec::new();
+        let mut leaf_offsets = Vec::new();
+        for (i, _) in seps.iter().enumerate() {
+            leaf_offsets.push(trie.len() as u64);
+            // distinct positions 1,2,3,... so payloads are identifiable.
+            trie.extend_from_slice(&row_leaf((i + 1) as u8));
+        }
+        let root = trie.len() as u64;
+        trie.push(0x50); // Sparse8
+        trie.push(seps.len() as u8); // count
+        for &s in seps {
+            trie.push(s);
+        }
+        for &off in &leaf_offsets {
+            trie.push((root - off) as u8);
+        }
+        (trie, root as usize)
+    }
+
+    /// The floor walk equals the maximum stored separator `<= key` (or `None`
+    /// below the first separator), for EVERY boundary class.
+    #[test]
+    fn floor_matches_enumerate_and_filter() {
+        let seps = [0x10u8, 0x20, 0x30, 0x40];
+        let (trie, root) = make_trie(&seps);
+        let all = iterate_rows_in_bti_trie(&trie, root).unwrap();
+        assert_eq!(all.len(), 4);
+
+        // Oracle: the block for the largest separator <= key, else None.
+        let oracle = |key: &[u8]| -> Option<u64> {
+            all.iter()
+                .filter(|(sep, _)| sep.as_slice() <= key)
+                .last()
+                .map(|(_, e)| e.data_offset)
+        };
+
+        // exact matches, between-block keys, before-first, after-last, multi-byte.
+        let probes: &[&[u8]] = &[
+            &[0x00],
+            &[0x0F],
+            &[0x10],
+            &[0x18],
+            &[0x20],
+            &[0x2F],
+            &[0x30],
+            &[0x40],
+            &[0x41],
+            &[0xFF],
+            &[0x10, 0x00],
+            &[0x30, 0x99],
+            &[],
+        ];
+        for key in probes {
+            let got = rows_floor_block(&trie, root, key)
+                .unwrap()
+                .map(|e| e.data_offset);
+            assert_eq!(got, oracle(key), "floor mismatch for key {key:02x?}");
+        }
+    }
+
+    /// The strict-ceiling walk equals the minimum stored separator `> key` (or
+    /// `None` at/after the last separator), for EVERY boundary class.
+    #[test]
+    fn strict_ceiling_matches_enumerate_and_filter() {
+        let seps = [0x10u8, 0x20, 0x30, 0x40];
+        let (trie, root) = make_trie(&seps);
+        let all = iterate_rows_in_bti_trie(&trie, root).unwrap();
+
+        let oracle = |key: &[u8]| -> Option<u64> {
+            all.iter()
+                .find(|(sep, _)| sep.as_slice() > key)
+                .map(|(_, e)| e.data_offset)
+        };
+
+        let probes: &[&[u8]] = &[
+            &[0x00],
+            &[0x0F],
+            &[0x10],
+            &[0x18],
+            &[0x20],
+            &[0x30],
+            &[0x40],
+            &[0x41],
+            &[0xFF],
+            &[0x10, 0x00],
+            &[],
+        ];
+        for key in probes {
+            let got = rows_strict_ceiling_block(&trie, root, key)
+                .unwrap()
+                .map(|e| e.data_offset);
+            assert_eq!(got, oracle(key), "ceiling mismatch for key {key:02x?}");
+        }
+    }
+
+    /// End-to-end `[body_start, body_end)` window equivalence: for every `(start,
+    /// end)` the new floor+ceiling window equals the pre-L1 enumerate-then-select
+    /// window, byte-for-byte. This is the exact oracle `bti_clustering_row_window`
+    /// relies on — modelled here with `has_static == false` (the synthetic trie has
+    /// no static row), so `body_start` narrows whenever the start is not below the
+    /// first separator.
+    #[test]
+    fn window_bounds_match_select_row_index_blocks() {
+        const END_INF: usize = usize::MAX;
+        let seps = [0x10u8, 0x20, 0x30, 0x40];
+        let (trie, root) = make_trie(&seps);
+        let all = iterate_rows_in_bti_trie(&trie, root).unwrap();
+        let first_sep = all.first().map(|(sep, _)| sep.clone()).unwrap();
+
+        let probes: &[u8] = &[0x00, 0x0F, 0x10, 0x18, 0x20, 0x30, 0x40, 0x41, 0xFF];
+        for &s in probes {
+            for &e in probes {
+                if s > e {
+                    continue;
+                }
+                let start = [s];
+                let end = [e];
+
+                // Pre-L1 window (transcribed from the old bti_clustering_row_window
+                // block-selection math, has_static == false).
+                let blocks = select_row_index_blocks_for_range(&all, &start, &end);
+                let includes_implicit = start.as_slice() < first_sep.as_slice();
+                let pre: Option<(usize, usize)> = if blocks.is_empty() {
+                    // blocks empty <=> range below the first separator (implicit).
+                    assert!(includes_implicit, "empty selection must be implicit-first");
+                    let first_off = all.first().map(|(_, b)| b.data_offset as usize).unwrap();
+                    Some((0, first_off))
+                } else {
+                    let body_start = if includes_implicit {
+                        0
+                    } else {
+                        blocks.iter().map(|b| b.data_offset as usize).min().unwrap()
+                    };
+                    let last = blocks.iter().map(|b| b.data_offset).max().unwrap();
+                    let body_end = all
+                        .iter()
+                        .map(|(_, b)| b.data_offset)
+                        .filter(|&o| o > last)
+                        .min()
+                        .map(|o| o as usize)
+                        .unwrap_or(END_INF);
+                    Some((body_start, body_end))
+                };
+
+                // New window (floor + strict-ceiling walks, has_static == false).
+                let floor = rows_floor_block(&trie, root, &start).unwrap();
+                let ceil = rows_strict_ceiling_block(&trie, root, &end).unwrap();
+                let body_start = match &floor {
+                    Some(b) => b.data_offset as usize, // not implicit => floor narrows
+                    None => 0,                         // implicit-first => partition body start
+                };
+                let body_end = ceil.map(|b| b.data_offset as usize).unwrap_or(END_INF);
+                let new = Some((body_start, body_end));
+
+                assert_eq!(new, pre, "window mismatch for start {s:02x} end {e:02x}");
+            }
+        }
+    }
+
+    /// A key path longer than the separators (deep prefix) still floors correctly,
+    /// and an out-of-bounds/empty trie errors cleanly rather than panicking.
+    #[test]
+    fn floor_deep_key_and_bad_root() {
+        let seps = [0x10u8, 0x20];
+        let (trie, root) = make_trie(&seps);
+        // Long key beyond 0x20 floors to the last separator.
+        let got = rows_floor_block(&trie, root, &[0x30, 0x40, 0x50])
+            .unwrap()
+            .map(|e| e.data_offset);
+        assert_eq!(got, Some(2));
+
+        // Out-of-bounds root errors, no panic.
+        assert!(rows_floor_block(&trie, trie.len() + 100, &[0x10]).is_err());
+        assert!(rows_strict_ceiling_block(&[], 0, &[0x10]).is_err());
+    }
+}

--- a/cqlite-core/src/storage/sstable/bti/parser/rows_floor.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/rows_floor.rs
@@ -35,8 +35,16 @@
 use crate::{error::Error, storage::sstable::bti::node::BtiResult};
 
 use super::node_decode::parse_bti_node;
-use super::partitions::{parse_bti_node_for_traversal, payload_start_in_node};
+use super::partitions::payload_start_in_node;
 use super::rows::{decode_bti_row_payload, BtiRowIndexEntry};
+
+// The floor/ceiling walks (and these two imports) are consumed ONLY by the
+// clustering-window path, which is compiled out under `tombstones` (that build
+// serves reads via a full-scan filter). `read_row_node_payload` below is always
+// compiled — the full-partition DFS uses it in every build.
+#[cfg(not(feature = "tombstones"))]
+use super::partitions::parse_bti_node_for_traversal;
+#[cfg(not(feature = "tombstones"))]
 use super::traversal::ordered_children;
 
 /// Read the `BtiRowIndexEntry` from the payload attached to a `Rows.db` node at
@@ -93,6 +101,7 @@ pub(super) fn read_row_node_payload(
     }
 }
 
+#[cfg(not(feature = "tombstones"))]
 /// Result of searching a node's ascending child list for the next key byte
 /// (mirrors `TrieNode.search`).  `insertion` is the number of children whose
 /// transition byte is `< b` (the lower-bound index); `exact` is the child index
@@ -108,6 +117,7 @@ struct ChildSearch {
     exact: Option<usize>,
 }
 
+#[cfg(not(feature = "tombstones"))]
 /// Locate `b` in the node's ascending `(byte, child)` children.
 fn search_children(children: &[(u8, usize)], b: Option<u8>) -> ChildSearch {
     let Some(byte) = b else {
@@ -126,6 +136,7 @@ fn search_children(children: &[(u8, usize)], b: Option<u8>) -> ChildSearch {
     ChildSearch { insertion, exact }
 }
 
+#[cfg(not(feature = "tombstones"))]
 /// Descend to the MAXIMUM (rightmost) leaf under `node_offset` and return its
 /// row-index payload (mirrors `Walker#goMax`, always following the last child
 /// until a leaf, then reading the payload).
@@ -147,6 +158,7 @@ fn go_max_payload(trie_data: &[u8], mut node_offset: usize) -> BtiResult<BtiRowI
     })
 }
 
+#[cfg(not(feature = "tombstones"))]
 /// Descend to the MINIMUM (leftmost) key under `node_offset` and return its
 /// row-index payload (mirrors `Walker#goMin`, stopping at the first node that
 /// carries a payload, else following the first child to a leaf).
@@ -170,6 +182,7 @@ fn go_min_payload(trie_data: &[u8], mut node_offset: usize) -> BtiResult<BtiRowI
     }
 }
 
+#[cfg(not(feature = "tombstones"))]
 /// Count one visited node and enforce the acyclic total-work bound: an acyclic
 /// trie has each node on a downward path occupy `>= 1` byte, so a walk that visits
 /// more nodes than the trie has bytes is proof of a cycle/corruption. Mirrors the
@@ -189,6 +202,7 @@ fn record_visit(trie_data: &[u8], steps: &mut usize) -> BtiResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "tombstones"))]
 /// Compute `separatorFloor(target_key)`: the row-index block whose half-open
 /// clustering interval `[s_i, s_{i+1})` contains `target_key` — i.e. the block for
 /// the largest separator `<= target_key`.
@@ -257,6 +271,7 @@ pub(crate) fn rows_floor_block(
     }
 }
 
+#[cfg(not(feature = "tombstones"))]
 /// Compute the block with the smallest separator **strictly greater** than
 /// `target_key` (`target_key`'s successor block).
 ///
@@ -313,6 +328,7 @@ pub(crate) fn rows_strict_ceiling_block(
     }
 }
 
+#[cfg(not(feature = "tombstones"))]
 #[cfg(test)]
 mod tests {
     use super::super::rows::{iterate_rows_in_bti_trie, select_row_index_blocks_for_range};
@@ -363,7 +379,7 @@ mod tests {
         let oracle = |key: &[u8]| -> Option<u64> {
             all.iter()
                 .filter(|(sep, _)| sep.as_slice() <= key)
-                .last()
+                .next_back()
                 .map(|(_, e)| e.data_offset)
         };
 

--- a/cqlite-core/src/storage/sstable/bti/parser/rows_floor.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/rows_floor.rs
@@ -366,6 +366,98 @@ mod tests {
         (trie, root as usize)
     }
 
+    /// A `Rows.db` PayloadOnly leaf carrying an OPEN range-tombstone marker
+    /// (`FLAG_OPEN_MARKER` set, payloadBits = `1 | 8 = 9`): a 1-byte SizedInts
+    /// Data.db position followed by a NON-live MODERN DA `DeletionTime`
+    /// (`markedForDeleteAt` i64 BE, `localDeletionTime` u32 BE — see
+    /// `decode_da_deletion_time`). `markedForDeleteAt`'s leading byte is `0x00`
+    /// (not the `0x80` LIVE sentinel), so this always decodes to
+    /// `open_marker.is_some()`.
+    fn row_leaf_with_open_marker(pos: u8) -> Vec<u8> {
+        assert!(pos <= 127, "use a 1-byte SizedInts position");
+        let mut v = vec![0x09u8, pos]; // ordinal=0, payloadBits=9 (FLAG_OPEN_MARKER set)
+        v.extend_from_slice(&1_000i64.to_be_bytes()); // markedForDeleteAt (non-live)
+        v.extend_from_slice(&500u32.to_be_bytes()); // localDeletionTime
+        v
+    }
+
+    /// Like [`make_trie`] but the leaf at `marker_index` carries an OPEN
+    /// range-tombstone marker ([`row_leaf_with_open_marker`]); every other leaf
+    /// is marker-free ([`row_leaf`]). Used to pin the floor-block-ONLY
+    /// narrowing intent (rust-reviewer follow-up, issue #1647): the caller's
+    /// open-marker correctness guard (`data_access::bti::bti_clustering_row_window`)
+    /// inspects ONLY the returned floor block's `open_marker`, never every block
+    /// in the partition.
+    fn make_trie_with_marker(seps: &[u8], marker_index: usize) -> (Vec<u8>, usize) {
+        let mut trie = Vec::new();
+        let mut leaf_offsets = Vec::new();
+        for (i, _) in seps.iter().enumerate() {
+            leaf_offsets.push(trie.len() as u64);
+            if i == marker_index {
+                trie.extend_from_slice(&row_leaf_with_open_marker((i + 1) as u8));
+            } else {
+                trie.extend_from_slice(&row_leaf((i + 1) as u8));
+            }
+        }
+        let root = trie.len() as u64;
+        trie.push(0x50); // Sparse8
+        trie.push(seps.len() as u8); // count
+        for &s in seps {
+            trie.push(s);
+        }
+        for &off in &leaf_offsets {
+            trie.push((root - off) as u8);
+        }
+        (trie, root as usize)
+    }
+
+    /// Build a Rows.db-style trie with MULTI-BYTE (composite) separators
+    /// sharing a common first byte, spanning TWO trie levels: `sep0=[0x10,0x05]`
+    /// -> pos 1, `sep1=[0x10,0x0A]` -> pos 2 (both under first byte `0x10`, via
+    /// an intermediate Sparse8 node), `sep2=[0x20,0x03]` -> pos 3 (under first
+    /// byte `0x20`, via an intermediate Single8 node). Exercises the prefix-floor
+    /// walk's multi-byte descent plus a genuine 2-hop `go_max`/`go_min` traversal
+    /// through an intermediate (non-leaf) node — the single-byte [`make_trie`]
+    /// above only ever has ONE level, so `go_max`/`go_min` land on a leaf in one
+    /// hop. Returns `(trie_bytes, root_offset)`.
+    fn make_composite_trie() -> (Vec<u8>, usize) {
+        let mut trie = Vec::new();
+        let leaf1 = trie.len() as u64; // sep0=[0x10,0x05] -> pos 1
+        trie.extend_from_slice(&row_leaf(1));
+        let leaf2 = trie.len() as u64; // sep1=[0x10,0x0A] -> pos 2
+        trie.extend_from_slice(&row_leaf(2));
+        let leaf3 = trie.len() as u64; // sep2=[0x20,0x03] -> pos 3
+        trie.extend_from_slice(&row_leaf(3));
+
+        // Intermediate A: Sparse8 (no payload) routing second byte {0x05, 0x0A}
+        // under first byte 0x10.
+        let node_a = trie.len() as u64;
+        trie.push(0x50); // Sparse8, payload_flags=0
+        trie.push(0x02); // count=2
+        trie.push(0x05);
+        trie.push(0x0A);
+        trie.push((node_a - leaf1) as u8);
+        trie.push((node_a - leaf2) as u8);
+
+        // Intermediate B: Single8 (no payload) routing second byte 0x03 under
+        // first byte 0x20.
+        let node_b = trie.len() as u64;
+        trie.push(0x20); // Single8, payload_flags=0
+        trie.push(0x03); // transition byte
+        trie.push((node_b - leaf3) as u8);
+
+        // Root: Sparse8 (no payload) routing first byte {0x10, 0x20}.
+        let root = trie.len() as u64;
+        trie.push(0x50);
+        trie.push(0x02);
+        trie.push(0x10);
+        trie.push(0x20);
+        trie.push((root - node_a) as u8);
+        trie.push((root - node_b) as u8);
+
+        (trie, root as usize)
+    }
+
     /// The floor walk equals the maximum stored separator `<= key` (or `None`
     /// below the first separator), for EVERY boundary class.
     #[test]
@@ -521,5 +613,126 @@ mod tests {
         // Out-of-bounds root errors, no panic.
         assert!(rows_floor_block(&trie, trie.len() + 100, &[0x10]).is_err());
         assert!(rows_strict_ceiling_block(&[], 0, &[0x10]).is_err());
+    }
+
+    /// Pin the floor-block-ONLY narrowing intent (rust-reviewer follow-up, issue
+    /// #1647): the clustering-window correctness guard in
+    /// `data_access::bti::bti_clustering_row_window` inspects ONLY the returned
+    /// floor block's `open_marker` — it never scans every block in the
+    /// partition. Confirmed against Cassandra
+    /// `SSTableIterator.ForwardIndexedReader.setForSlice` (which reads
+    /// `separatorFloor(...).openDeletion` exclusively) and
+    /// `BtiFormatPartitionWriter` (which stores a CUMULATIVE `startOpenMarker`
+    /// per block, so the floor block's own marker already reflects any deletion
+    /// open at the window start — a marker recorded on an EARLIER block is
+    /// carried forward onto every later block it still covers, so there is
+    /// nothing left to observe on a block that is not the floor).
+    #[test]
+    fn floor_block_open_marker_is_the_only_signal_the_guard_needs() {
+        let seps = [0x10u8, 0x20, 0x30];
+        // The MIDDLE block (sep=0x20) carries the open marker; sep=0x10/0x30
+        // do not.
+        let (trie, root) = make_trie_with_marker(&seps, 1);
+
+        // (a) A query whose floor IS the marker-carrying block observes
+        // `open_marker.is_some()` — exactly the signal the guard's
+        // fallback-to-`Ok(None)` branch keys off.
+        let floor_on_marker_block = rows_floor_block(&trie, root, &[0x25]).unwrap().unwrap();
+        assert_eq!(
+            floor_on_marker_block.data_offset, 2,
+            "floor(0x25) must be the sep=0x20 block"
+        );
+        assert!(
+            floor_on_marker_block.open_marker.is_some(),
+            "the floor-block-only guard needs open_marker to survive on the \
+             block it actually returns"
+        );
+
+        // (b) A query whose floor is a DIFFERENT (non-floor-for-this-query)
+        // block — even though the marker-carrying block still exists later in
+        // the same partition — observes `open_marker.is_none()`: the marker on
+        // a block that ISN'T the floor never leaks into the returned entry, so
+        // the guard does NOT fall back and the window still narrows.
+        let floor_before_marker_block = rows_floor_block(&trie, root, &[0x15]).unwrap().unwrap();
+        assert_eq!(
+            floor_before_marker_block.data_offset, 1,
+            "floor(0x15) must be the sep=0x10 block"
+        );
+        assert!(
+            floor_before_marker_block.open_marker.is_none(),
+            "a marker on a NON-floor block must not leak into the returned \
+             floor entry (the guard must not spuriously fall back)"
+        );
+    }
+
+    /// Multi-byte (composite) separator coverage (rust-reviewer follow-up,
+    /// issue #1647): [`make_trie`] above only ever emits single-byte
+    /// separators via a one-level Sparse8 root, so `go_max`/`go_min` always
+    /// land on a leaf in a single hop. This pins the SAME floor/ceiling
+    /// equivalence oracle over [`make_composite_trie`]'s two-level, multi-byte
+    /// separators, which forces a genuine multi-byte prefix-follow PLUS a
+    /// real 2-hop `go_max_payload`/`go_min_payload` descent through an
+    /// intermediate (non-leaf) node for the `[0x18]` probe.
+    #[test]
+    fn floor_and_ceiling_multi_byte_separators() {
+        let (trie, root) = make_composite_trie();
+        let all = iterate_rows_in_bti_trie(&trie, root).unwrap();
+        assert_eq!(
+            all.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+            vec![vec![0x10, 0x05], vec![0x10, 0x0A], vec![0x20, 0x03]],
+            "composite trie must yield the 3 multi-byte separators in byte order"
+        );
+
+        let floor_oracle = |key: &[u8]| -> Option<u64> {
+            all.iter()
+                .filter(|(sep, _)| sep.as_slice() <= key)
+                .next_back()
+                .map(|(_, e)| e.data_offset)
+        };
+        let ceil_oracle = |key: &[u8]| -> Option<u64> {
+            all.iter()
+                .find(|(sep, _)| sep.as_slice() > key)
+                .map(|(_, e)| e.data_offset)
+        };
+
+        // Exact matches on both bytes, between-separator probes (including one
+        // sharing only the first byte, `0x18`, which forces a multi-hop
+        // go_max/go_min descent through the intermediate node), before-first,
+        // after-last, and deeper-than-any-leaf-key probes.
+        let probes: &[&[u8]] = &[
+            &[0x00],
+            &[0x10],
+            &[0x10, 0x00],
+            &[0x10, 0x05],
+            &[0x10, 0x07],
+            &[0x10, 0x0A],
+            &[0x10, 0xFF],
+            &[0x18],
+            &[0x20],
+            &[0x20, 0x00],
+            &[0x20, 0x03],
+            &[0x20, 0x03, 0x00],
+            &[0x20, 0xFF],
+            &[0xFF],
+            &[],
+        ];
+        for key in probes {
+            let floor = rows_floor_block(&trie, root, key)
+                .unwrap()
+                .map(|e| e.data_offset);
+            assert_eq!(
+                floor,
+                floor_oracle(key),
+                "floor mismatch for composite key {key:02x?}"
+            );
+            let ceil = rows_strict_ceiling_block(&trie, root, key)
+                .unwrap()
+                .map(|e| e.data_offset);
+            assert_eq!(
+                ceil,
+                ceil_oracle(key),
+                "ceiling mismatch for composite key {key:02x?}"
+            );
+        }
     }
 }

--- a/cqlite-core/src/storage/sstable/bti/parser/traversal.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/traversal.rs
@@ -76,7 +76,11 @@ pub(crate) fn load_bti_trie_via_footer<R: Read + Seek>(
 ///
 /// `Sparse` transitions are returned in their stored order; the parser preserves
 /// the on-disk ascending order, and we sort defensively.
-fn ordered_children(node: &BtiNode) -> Vec<(u8, usize)> {
+///
+/// Shared with [`super::rows_floor`], whose O(key-length) floor/ceiling walk
+/// follows the SAME ascending `(transition_byte, absolute_child_offset)` child
+/// order the DFS uses (issue #1647 / L1).
+pub(super) fn ordered_children(node: &BtiNode) -> Vec<(u8, usize)> {
     match &node.data {
         BtiNodeData::PayloadOnly { .. } => Vec::new(),
         BtiNodeData::Single { transition } => {

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -206,6 +206,13 @@ struct Counters {
     /// exactly one short-circuit; an in-range read records zero (the bound never
     /// fires, so the normal presence path runs).
     range_short_circuits: AtomicU64,
+    /// Per-partition `Rows.db` row-index entry deserializations
+    /// (`ROWS_DB_ENTRY_RESOLVES`, Issue #1647 / L1) — one per
+    /// `bti::parser::resolve_rows_db_entry` (`TrieIndexEntry.deserialize`). Consumer
+    /// L1: a single BTI clustering read must resolve the per-partition entry EXACTLY
+    /// once (the pre-L1 window path resolved it twice — once directly, once inside
+    /// `iterate_rows_for_partition`).
+    rows_db_entry_resolves: AtomicU64,
 }
 
 #[cfg(any(test, feature = "work-counters"))]
@@ -227,6 +234,7 @@ impl Counters {
             index_probes: AtomicU64::new(0),
             key_hash_calls: AtomicU64::new(0),
             range_short_circuits: AtomicU64::new(0),
+            rows_db_entry_resolves: AtomicU64::new(0),
         }
     }
 
@@ -291,6 +299,10 @@ impl Counters {
         self.range_short_circuits.fetch_add(1, Ordering::Relaxed);
     }
 
+    fn record_rows_db_entry_resolve(&self) {
+        self.rows_db_entry_resolves.fetch_add(1, Ordering::Relaxed);
+    }
+
     fn trie_walks(&self) -> u64 {
         self.trie_walks.load(Ordering::Relaxed)
     }
@@ -351,6 +363,10 @@ impl Counters {
         self.range_short_circuits.load(Ordering::Relaxed)
     }
 
+    fn rows_db_entry_resolves(&self) -> u64 {
+        self.rows_db_entry_resolves.load(Ordering::Relaxed)
+    }
+
     fn reset(&self) {
         self.trie_walks.store(0, Ordering::Relaxed);
         self.decompress_calls.store(0, Ordering::Relaxed);
@@ -367,6 +383,7 @@ impl Counters {
         self.index_probes.store(0, Ordering::Relaxed);
         self.key_hash_calls.store(0, Ordering::Relaxed);
         self.range_short_circuits.store(0, Ordering::Relaxed);
+        self.rows_db_entry_resolves.store(0, Ordering::Relaxed);
     }
 }
 
@@ -572,6 +589,19 @@ pub fn record_range_short_circuit() {
     COUNTERS.record_range_short_circuit();
 }
 
+/// Record one per-partition `Rows.db` row-index entry deserialization
+/// (`ROWS_DB_ENTRY_RESOLVES`; consumer L1, Issue #1647).
+///
+/// Called unconditionally at the single `TrieIndexEntry.deserialize` site
+/// (`bti::parser::rows::resolve_rows_db_entry`); the body compiles to a no-op in a
+/// release build (design.md Decision 1). L1 collapses the clustering-window path's
+/// double resolve to one, so a warm-cache clustering read records exactly 1.
+#[inline(always)]
+pub fn record_rows_db_entry_resolve() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_rows_db_entry_resolve();
+}
+
 /// Number of BTI trie descents since the last [`reset`] (`TRIE_WALKS`).
 #[cfg(any(test, feature = "work-counters"))]
 pub fn trie_walks() -> u64 {
@@ -672,6 +702,13 @@ pub fn key_hash_calls() -> u64 {
 #[cfg(any(test, feature = "work-counters"))]
 pub fn range_short_circuits() -> u64 {
     COUNTERS.range_short_circuits()
+}
+
+/// Number of per-partition `Rows.db` row-index entry deserializations since the
+/// last [`reset`] (`ROWS_DB_ENTRY_RESOLVES`, Issue #1647 / L1).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn rows_db_entry_resolves() -> u64 {
+    COUNTERS.rows_db_entry_resolves()
 }
 
 /// Clear all four process-global counters. Integration tests call this before a
@@ -794,6 +831,11 @@ mod tests {
         for _ in 0..15 {
             c.record_range_short_circuit();
         }
+        // Issue #1647 Rows.db entry-resolve counter: multiplicity 16, distinct
+        // from every sibling so a mis-wired getter/field cross-up is caught.
+        for _ in 0..16 {
+            c.record_rows_db_entry_resolve();
+        }
 
         assert_eq!(c.trie_walks(), 1);
         assert_eq!(c.decompress_calls(), 2);
@@ -810,6 +852,7 @@ mod tests {
         assert_eq!(c.index_probes(), 13);
         assert_eq!(c.key_hash_calls(), 14);
         assert_eq!(c.range_short_circuits(), 15);
+        assert_eq!(c.rows_db_entry_resolves(), 16);
 
         c.reset();
         assert_eq!(c.trie_walks(), 0);
@@ -827,6 +870,7 @@ mod tests {
         assert_eq!(c.index_probes(), 0);
         assert_eq!(c.key_hash_calls(), 0);
         assert_eq!(c.range_short_circuits(), 0);
+        assert_eq!(c.rows_db_entry_resolves(), 0);
     }
 
     // The fd high-water helper returns a positive count on the supported platforms

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -295,9 +295,9 @@ impl SSTableReader {
         schema: Option<&crate::schema::TableSchema>,
     ) -> Result<Option<ClusteringRowWindow>> {
         use crate::storage::sstable::bti::{
-            encode_partition_key_for_bti_trie, iterate_rows_for_partition,
-            lookup_partition_in_bti_slice, resolve_rows_db_entry,
-            select_row_index_blocks_for_range, BtiPartitionLocation,
+            encode_partition_key_for_bti_trie, lookup_partition_in_bti_slice,
+            resolve_rows_db_entry, rows_floor_block, rows_strict_ceiling_block,
+            BtiPartitionLocation,
         };
 
         let (Some(partitions_db), Some(rows_db)) = (&self.bti_partitions_db, &self.bti_rows_db)
@@ -325,25 +325,17 @@ impl SSTableReader {
             Some(BtiPartitionLocation::DataOffset(_)) | None => return Ok(None),
         };
 
-        // Resolve the per-partition row-index entry and enumerate its blocks in
-        // ascending byte-comparable (clustering) order.
+        // Resolve the per-partition row-index entry ONCE (issue #1647 / L1: the
+        // pre-L1 path resolved it HERE and again inside `iterate_rows_for_partition`,
+        // discarding the first). `header.trie_root` roots the O(key-length)
+        // floor/ceiling walks below, so a clustering read never materializes every
+        // row-index block.
         let header = resolve_rows_db_entry(rows_db.as_slice(), rows_offset).map_err(|e| {
             Error::corruption(format!(
                 "BTI clustering seek: Rows.db entry at RowsOffset({rows_offset}) unreadable: {e}"
             ))
         })?;
-        let (_header2, entries) = iterate_rows_for_partition(rows_db.as_slice(), rows_offset)
-            .map_err(|e| {
-                Error::corruption(format!(
-                    "BTI clustering seek: Rows.db trie at RowsOffset({rows_offset}) unreadable: {e}"
-                ))
-            })?;
-        // `iterate_rows_for_partition` re-resolves the header internally; keep the
-        // first `header` (identical) for `block_count`/`data_position`.
-        let _ = header;
-        if entries.is_empty() {
-            return Ok(None);
-        }
+        let root = header.trie_root;
 
         // Per-column reverse order for the FIRST clustering column (single-column
         // scope per #954). A missing/absent schema treats it as ascending.
@@ -358,124 +350,105 @@ impl SSTableReader {
 
         // Encode the CQL bounds into the PHYSICAL byte-comparable order the row
         // index uses, normalizing for a DESC first clustering column (issue #954
-        // High-severity correctness fix). `select_row_index_blocks_for_range`
-        // operates purely in physical (on-disk, byte-comparable) order, so the CQL
-        // lower/upper bounds must be mapped to the physical-lower/physical-upper
-        // sides before block selection. For a DESC column those roles SWAP (see
-        // `physical_byte_bounds_for_slice`). An un-encodable bound makes the
-        // narrowing unsafe → decode the whole partition (honest fallback).
+        // High-severity correctness fix). The floor/ceiling walks operate purely in
+        // physical (on-disk, byte-comparable) order, so the CQL lower/upper bounds
+        // must be mapped to the physical-lower/physical-upper sides before the walk.
+        // For a DESC column those roles SWAP (see `physical_byte_bounds_for_slice`).
+        // An un-encodable bound makes the narrowing unsafe → decode the whole
+        // partition (honest fallback).
         let Some((start_bytes, end_bytes)) = physical_byte_bounds_for_slice(slice, &is_reversed)?
         else {
             return Ok(None);
         };
 
-        // CORRECTNESS GUARD (no-heuristics, never wrong results): a row-index block
-        // carrying an `open_marker` (FLAG_OPEN_MARKER) means a range tombstone is
-        // OPEN at that block boundary — a deletion opened in an earlier block can
-        // still shadow rows inside the requested slice. Narrowing the decode skips
-        // the rows (and the range-marker bytes) before the slice, which would drop
-        // that open deletion and risk resurrecting a deleted row. The post-scan
-        // backstop only FILTERS rows, it cannot re-apply a missed range tombstone.
-        // So when ANY block in this partition's row index carries an open marker we
-        // fall back to a full-partition decode (correct, just unnarrowed). The
-        // common wide-partition slice (no range tombstones) is unaffected.
-        if entries.iter().any(|(_sep, b)| b.open_marker.is_some()) {
+        // Locate the row-body window with two O(key-length) separator walks instead
+        // of materializing every row-index block then linearly filtering (issue
+        // #1647 / L1). Both mirror Cassandra `RowIndexReader.separatorFloor`:
+        //   - floor(start): the block whose half-open interval `[s_i, s_{i+1})`
+        //     contains the physical-lower bound (largest separator `<= start`), i.e.
+        //     the first block that can hold a row of the slice. `None` when `start`
+        //     sorts below the FIRST separator — the trie-implicit first block at the
+        //     partition body start (issue #1968), which no stored walk can return.
+        //   - strict_ceiling(end): the block with the smallest separator strictly
+        //     `> end` = the EXCLUSIVE window end (the successor of `floor(end)`).
+        //     `None` when the slice reaches the last block (window runs to the
+        //     partition end).
+        // These reproduce the pre-L1 `select_row_index_blocks_for_range` window
+        // (min selected-block start .. successor of max selected-block) EXACTLY, by
+        // construction, for every boundary class (see the rows_floor unit tests).
+        let floor_block =
+            rows_floor_block(rows_db.as_slice(), root, &start_bytes).map_err(|e| {
+                Error::corruption(format!(
+                "BTI clustering seek: Rows.db floor walk at RowsOffset({rows_offset}) failed: {e}"
+            ))
+            })?;
+        let ceil_block =
+            rows_strict_ceiling_block(rows_db.as_slice(), root, &end_bytes).map_err(|e| {
+                Error::corruption(format!(
+                    "BTI clustering seek: Rows.db ceiling walk at RowsOffset({rows_offset}) \
+                     failed: {e}"
+                ))
+            })?;
+
+        // The static row precedes the clustering rows and must be merged into each
+        // emitted clustering row, so we may only fast-forward PAST it when the table
+        // has NO static columns; otherwise decode from the partition body start
+        // (`body_start_rel = 0`) so the static prefix is seen (the END bound still
+        // narrows). (`test_da.wide_table` has no static columns, so the start narrows
+        // too.)
+        let has_static = schema
+            .map(|s| s.columns.iter().any(|c| c.is_static))
+            .unwrap_or(false);
+
+        // IMPLICIT FIRST BLOCK (issue #1968): a `start` below the first separator
+        // selects the implicit block at the partition body start, which no walk can
+        // return. `rows_floor_block` returns `None` in exactly that case, so it IS
+        // the implicit-first signal; the decode must then begin at rel 0 or the
+        // earliest clustering rows are dropped.
+        let includes_implicit_first_block = floor_block.is_none();
+
+        // The start narrows to the floor block only when NEITHER a static row NOR the
+        // implicit first block forces decoding from rel 0.
+        let narrows_start = !has_static && !includes_implicit_first_block;
+
+        // CORRECTNESS GUARD (no-heuristics, never wrong results): FLAG_OPEN_MARKER on
+        // the floor block's `IndexInfo` means a range tombstone is OPEN at the START
+        // of the narrowed window — a deletion opened in an earlier block still shadows
+        // rows inside the slice. Skipping earlier blocks would drop that range-open
+        // marker and risk resurrecting a deleted row (the post-scan backstop only
+        // FILTERS rows, it cannot re-apply a missed range tombstone). Per Cassandra
+        // `RowIndexReader.IndexInfo.openDeletion`, the marker on the floor block fully
+        // captures any deletion open at the window start, so this is the exact, tight
+        // guard: when it fires (only relevant when the start actually narrows) fall
+        // back to a full-partition decode. When the decode already starts at rel 0
+        // (static / implicit-first) no earlier block is skipped, so no guard is
+        // needed. (`test_da.wide_table` has no range tombstones.)
+        if narrows_start
+            && floor_block
+                .as_ref()
+                .map(|b| b.open_marker.is_some())
+                .unwrap_or(false)
+        {
             debug!(
-                "BTI clustering seek: partition row index has open range-tombstone marker(s); \
-                 decoding full partition to preserve range-deletion semantics (no narrowing)"
+                "BTI clustering seek: floor row-index block carries an open range-tombstone \
+                 marker; decoding full partition to preserve range-deletion semantics (no \
+                 narrowing)"
             );
             return Ok(None);
         }
 
-        let blocks = select_row_index_blocks_for_range(&entries, &start_bytes, &end_bytes);
-
-        // IMPLICIT FIRST BLOCK (issue #1968). A `Rows.db` row-index trie stores a
-        // separator per block EXCEPT the first: the block covering keys BELOW the
-        // first separator lives at the partition body start and has NO trie entry
-        // (mirroring Cassandra `RowIndexReader.separatorFloor`, which returns the
-        // partition start for a key below the first separator). Consequently
-        // `select_row_index_blocks_for_range` — which operates purely over the
-        // stored (separator, block) entries — can NEVER return that implicit block.
-        //
-        // The requested range overlaps the implicit first block iff its
-        // physical-lower bound sorts strictly BELOW the first separator
-        // (`start_bytes < entries[0].sep`). The canonical trigger is an OPEN lower
-        // bound (`ck < N` / `ck <= N`), whose physical-lower sentinel is `-∞` = the
-        // empty slice `b""`, but a closed lower bound below the first separator
-        // (`ck >= 2 AND ck < 20`, `ck = 0`) hits it too. When the range includes
-        // that block the earliest clustering rows precede every stored block, so the
-        // decode MUST begin at the partition body start (rel 0) or those rows are
-        // silently dropped (the pre-fix bug returned `ck=8..19` for `ck < 20`).
-        // Bind the first stored entry ONCE and reuse it for both the predicate and
-        // the entirely-within-implicit-block window below, so the window end can
-        // never diverge from the predicate (no `usize::MAX` over-read fallback).
-        let first_entry = entries.first();
-        let includes_implicit_first_block = first_entry
-            .map(|(sep, _)| start_bytes.as_slice() < sep.as_slice())
-            .unwrap_or(false);
-
-        if blocks.is_empty() {
-            // `includes_implicit_first_block` is true only when `first_entry` is
-            // `Some`; the `if let` makes that invariant explicit and reuses the exact
-            // entry that satisfied the predicate (its start is the window end).
-            if let (true, Some((_sep, first_block))) = (includes_implicit_first_block, first_entry)
-            {
-                // The range lies ENTIRELY within the implicit first block (its
-                // physical-upper is also below the first separator, e.g. `ck <= 3`
-                // or `ck = 0`): no stored block overlaps, but the implicit block
-                // does. Narrow to [partition body start, first stored block start);
-                // the post-scan backstop trims to the exact predicate.
-                return Ok(Some(ClusteringRowWindow {
-                    body_start_rel: 0,
-                    body_end_rel: first_block.data_offset as usize,
-                }));
-            }
-            // No block (implicit or stored) overlaps the range. The slice may still
-            // select rows that share the floor block's separator boundary; to stay
-            // correct we fall back to a full-partition decode rather than risk
-            // dropping a row.
-            return Ok(None);
-        }
-
-        // Row-body byte window = [first selected block start, end of the LAST
-        // selected block). The block `data_offset` is relative to the partition
-        // start (the same domain the parser sees for `window[within..]`). The end
-        // is the start of the FIRST block AFTER the last selected one (or +∞ via
-        // the partition end when the last selected block is the partition's last).
-        // The static row precedes the clustering rows and must be merged into each
-        // emitted clustering row, so we may only fast-forward PAST it when the
-        // table has NO static columns. With a static column present, decode from
-        // the partition body start (`body_start_rel = 0`) so the static prefix is
-        // seen; the END bound still narrows the decode. (The acceptance fixture
-        // `test_da.wide_table` has no static columns, so the start narrows too.)
-        let has_static = schema
-            .map(|s| s.columns.iter().any(|c| c.is_static))
-            .unwrap_or(false);
-        // Start at the earliest selected STORED block — UNLESS the table has a
-        // static row, or the range also covers the implicit first block (issue
-        // #1968); either case must decode from the partition body start (rel 0) so
-        // the static prefix / the implicit block's rows are seen. The END bound
-        // still narrows the decode in both cases.
-        let body_start_rel = if has_static || includes_implicit_first_block {
-            0
-        } else {
-            blocks
-                .iter()
-                .map(|b| b.data_offset as usize)
-                .min()
-                .unwrap_or(0)
+        // body_start_rel: the floor block's offset when the start narrows, else the
+        // partition body start (rel 0). The block `data_offset` is relative to the
+        // partition start (the same domain the parser sees for `window[within..]`).
+        let body_start_rel = match &floor_block {
+            Some(b) if narrows_start => b.data_offset as usize,
+            _ => 0,
         };
-        let last_selected_off = blocks.iter().map(|b| b.data_offset).max().unwrap_or(0);
-        // The exclusive end is the next block's start strictly greater than the
-        // last selected block; if none, the window runs to the partition end
-        // (`usize::MAX` is clamped by the caller against the authoritative
-        // partition end / data-section length).
-        let body_end_rel = entries
-            .iter()
-            .map(|(_sep, b)| b.data_offset)
-            .filter(|&off| off > last_selected_off)
-            .min()
-            .map(|off| off as usize)
+        // body_end_rel: the exclusive successor block start, or the partition end
+        // (`usize::MAX`, clamped by the caller against the authoritative partition
+        // end / data-section length) when the slice reaches the last block.
+        let body_end_rel = ceil_block
+            .map(|b| b.data_offset as usize)
             .unwrap_or(usize::MAX);
 
         Ok(Some(ClusteringRowWindow {

--- a/cqlite-core/tests/issue_1647_rows_floor_walk.rs
+++ b/cqlite-core/tests/issue_1647_rows_floor_walk.rs
@@ -1,0 +1,204 @@
+//! Issue #1647 (Epic L / L1): a BTI (`da`) clustering read locates its row-index
+//! block(s) with an O(key-length) `Rows.db` separator-floor walk instead of
+//! materializing EVERY row-index block and linearly filtering.
+//!
+//! Wiring evidence, driven through the public `Database` API against the BTI
+//! wide-partition fixture `test_da.wide_table` (`PRIMARY KEY (pk, ck)`, int pk, 3
+//! partitions pk=1/2/3, each 300 rows ck=0..299). Each partition's `Rows.db` trie
+//! indexes **38** row-index blocks, so the pre-L1 enumerate-then-filter path
+//! visited ~42 BTI nodes per clustering read (a full DFS) and deserialized the
+//! per-partition `TrieIndexEntry` TWICE. This test pins the two work-counter
+//! invariants L1 delivers:
+//!
+//!   1. **`BTI_NODES_VISITED < 40`** on a point clustering read — the floor/ceiling
+//!      walks visit O(len(ck)) nodes, not O(blocks). (Pre-L1: ~42, a full DFS.)
+//!   2. **`ROWS_DB_ENTRY_RESOLVES == 1`** per clustering read — the window path
+//!      resolves the per-partition entry ONCE (pre-L1: 2 — once directly, once
+//!      inside `iterate_rows_for_partition`).
+//!
+//! Both counters are measured AFTER a warm-up read so the reader's per-reader
+//! next-partition successor cache (`bti_partition_offsets`, which itself enumerates
+//! the Partitions.db trie and resolves each wide partition's entry) is already
+//! populated — otherwise the FIRST clustering read would carry that one-time
+//! enumeration's nodes/resolves. The measured read therefore reflects only the
+//! clustering-window work, which is exactly what L1 optimizes.
+//!
+//! Compiled only with `--features work-counters` (the counter getters/`reset` live
+//! behind it). Requires `CQLITE_DATASETS_ROOT` + the optional `test_da` corpus;
+//! skips (never fails) when absent. Excluded under `tombstones` (that build serves
+//! reads by a full-scan filter, compiling out the clustering seek).
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::sstable::read_work_counters as rwc;
+use cqlite_core::Database;
+use serial_test::serial;
+
+const QUALIFIED_TABLE: &str = "test_da.wide_table";
+const KEYSPACE_FILTER: &str = "/test_da/";
+/// The pre-L1 full-DFS node-visit count for one partition's 38-block row-index
+/// trie is 42; the floor+ceiling walks stay well under this bound.
+const NODES_BOUND: u64 = 40;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn skip_or_db() -> Option<Database> {
+    let root = datasets_root()?;
+    let schema_path = schemas_dir()?.join("wide-table-bti.cql");
+    if !schema_path.exists() {
+        eprintln!("Skipping (L1): wide-table-bti.cql schema not found");
+        return None;
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        eprintln!("Skipping (L1): sstables dir not found");
+        return None;
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(KEYSPACE_FILTER.to_string()),
+    };
+    let result = ingest(config).await.ok()?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        eprintln!("Skipping (L1): no schemas loaded");
+        return None;
+    }
+    Some(result.database)
+}
+
+/// Read the full pk=1 partition to (a) confirm the Data.db is fetched and (b) warm
+/// the reader's next-partition successor cache, so the measured clustering reads
+/// carry only the clustering-window work. Returns false to SKIP when 0 rows come
+/// back (binaries not fetched).
+async fn warm_up(db: &Database) -> bool {
+    let full = db
+        .execute(&format!(
+            "SELECT pk, ck FROM {QUALIFIED_TABLE} WHERE pk = 1"
+        ))
+        .await
+        .expect("warm-up full partition read must succeed");
+    if full.rows.is_empty() {
+        eprintln!("Skipping (L1): wide_table returned 0 rows (Data.db not fetched?)");
+        return false;
+    }
+    assert_eq!(
+        full.rows.len(),
+        300,
+        "fixture invariant: pk=1 must hold 300 clustering rows",
+    );
+    true
+}
+
+/// A point clustering read (`ck = 150`) visits fewer than 40 BTI nodes and
+/// resolves the per-partition `Rows.db` entry exactly once.
+#[tokio::test]
+#[serial]
+async fn point_clustering_read_walks_floor_not_all_blocks() {
+    let Some(db) = skip_or_db().await else {
+        return;
+    };
+    if !warm_up(&db).await {
+        return;
+    }
+
+    rwc::reset();
+    let res = db
+        .execute(&format!(
+            "SELECT pk, ck, payload FROM {QUALIFIED_TABLE} WHERE pk = 1 AND ck = 150"
+        ))
+        .await
+        .expect("point clustering read must succeed");
+
+    // Correctness first: the exact row is returned.
+    assert_eq!(
+        res.rows.len(),
+        1,
+        "L1: `pk = 1 AND ck = 150` must return exactly the one matching row",
+    );
+
+    let nodes = rwc::bti_nodes_visited();
+    let resolves = rwc::rows_db_entry_resolves();
+    println!("L1 point read: bti_nodes_visited={nodes} rows_db_entry_resolves={resolves}");
+
+    assert!(
+        nodes > 0 && nodes < NODES_BOUND,
+        "L1: a point clustering read must visit (0, {NODES_BOUND}) BTI nodes via the \
+         separator-floor walk; got {nodes} (pre-L1 full DFS over 38 blocks visited ~42)",
+    );
+    assert_eq!(
+        resolves, 1,
+        "L1: the clustering-window path must resolve the per-partition Rows.db entry \
+         EXACTLY once; got {resolves} (pre-L1 resolved it twice)",
+    );
+}
+
+/// A bounded range clustering read (`ck >= 100 AND ck < 110`) also floors in
+/// O(key-length) — the forward window end is a strict-ceiling walk, not a scan of
+/// every block.
+#[tokio::test]
+#[serial]
+async fn range_clustering_read_walks_floor_not_all_blocks() {
+    let Some(db) = skip_or_db().await else {
+        return;
+    };
+    if !warm_up(&db).await {
+        return;
+    }
+
+    rwc::reset();
+    let res = db
+        .execute(&format!(
+            "SELECT pk, ck, payload FROM {QUALIFIED_TABLE} WHERE pk = 1 AND ck >= 100 AND ck < 110"
+        ))
+        .await
+        .expect("range clustering read must succeed");
+
+    assert_eq!(
+        res.rows.len(),
+        10,
+        "L1: `ck in [100, 110)` must return exactly ck=100..=109",
+    );
+
+    let nodes = rwc::bti_nodes_visited();
+    let resolves = rwc::rows_db_entry_resolves();
+    println!("L1 range read: bti_nodes_visited={nodes} rows_db_entry_resolves={resolves}");
+
+    assert!(
+        nodes > 0 && nodes < NODES_BOUND,
+        "L1: a range clustering read must visit (0, {NODES_BOUND}) BTI nodes via the \
+         floor + strict-ceiling walks; got {nodes} (pre-L1 full DFS visited ~42)",
+    );
+    assert_eq!(
+        resolves, 1,
+        "L1: the clustering-window path must resolve the per-partition Rows.db entry \
+         EXACTLY once; got {resolves} (pre-L1 resolved it twice)",
+    );
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2505,7 +2505,8 @@ dispatch_component() {
       --test issue_1570_key_offset_cache \
       --test issue_1575_candidate_key_hash_hoist \
       --test issue_1576_range_short_circuit \
-      --test issue_1578_aggregate_o1_memory ;;
+      --test issue_1578_aggregate_o1_memory \
+      --test issue_1647_rows_floor_walk ;;
     byte-budget-guard) run_component byte-budget-guard cargo test --package cqlite-core \
       --features write-support,cli-helpers,state_machine \
       --test issue_1582_byte_bounded_result_budget \


### PR DESCRIPTION
Closes #1647 (L1, epic L #1605 — 2026-07 parser perf audit).

## What
Replaces the pre-L1 full-DFS over the Rows.db row-index trie with Cassandra's exact `RowIndexReader#separatorFloor` semantics (`Walker#prefixAndNeighbours` + `goMax`, window end via `followWithGreater` + `goMin`):
- `bti/parser/rows_floor.rs` (NEW): floor/strict-ceiling walks + shared `read_row_node_payload`, with floor==max-separator-≤-key / ceiling==min-separator->-key equivalence tests vs the pre-L1 path.
- `reader/data_access/bti.rs`: `bti_clustering_row_window` resolves the Rows.db entry ONCE (was 2×) and walks floor+ceiling instead of full DFS; open-marker fallback guard narrowed to the floor block (the exact Cassandra `IndexInfo.openDeletion` semantic).
- New `ROWS_DB_ENTRY_RESOLVES` work counter; wiring-evidence test `issue_1647_rows_floor_walk.rs` added to the gate's `work-counters-guard`.
- Benches: `clustering_point_bti` / `clustering_range_bti` on `test_da.wide_table`.

## Evidence
- Red-first: on pre-L1 code, point read = 42 BTI nodes / 2 resolves (asserts FAIL); with fix = **10 nodes / 1 resolve** (point and range).
- Wall-time ~neutral (LZ4-dominated fixture); the work counters are the decisive evidence.
- Parity regressions green: issue_954/953/1968/832/909 suites.
- Lite gate PASS @ `7d97df37`. Roborev job 1492 in flight; FULL gate queued (serial, behind #1581) — SUMMARY posted before merge.

## Note for reviewers
The open-marker fallback narrowing (any-block → floor-block-only) is an intentional, strictly-narrower behavior change matching Cassandra; rust-reviewer pass requested specifically on that.