### PR TITLE
perf(#1579): D3 — stream the multi-generation merge (O(partition) memory, no collect+sort)

### DIFF
--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -33,8 +33,9 @@
 //! Extracted from `sstable/mod.rs` (issue #1116 campsite split): behaviour of the
 //! two materializing helpers is unchanged apart from the new `target_key`
 //! partition-targeting parameter (issue #1579, point-read path).
-
-#![cfg(feature = "write-support")]
+//!
+//! The whole module is gated on `write-support` at its `mod` declaration in the
+//! parent (`sstable/mod.rs`).
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -49,6 +50,11 @@ use super::{reader, scan_merge};
 use crate::storage::write_engine::merge::{KWayMerger, MergeEntry, MergeStep, RowData};
 use crate::types::{CellWriteMetadata, TableId as CqlTableId};
 use crate::{Result, RowCells, RowKey, ScanRow, Value};
+
+/// One reconciled metadata row inside the merge task, before per-cell metadata is
+/// attached: `(partition key bytes, ScanRow row carrier, [(column,
+/// write_timestamp_micros)])`.
+type MergedMetaRow = (Vec<u8>, ScanRow, Vec<(String, i64)>);
 
 /// Convert one reconciled partition's merge rows into the live scan rows the read
 /// path emits: drop cell tombstones, drop row tombstones, drop rows left empty.
@@ -232,9 +238,7 @@ pub(super) async fn merge_generations_for_read_with_metadata(
     let end_key = owned_end;
     let target_for_merge = target_bytes;
 
-    // (key bytes, ScanRow row carrier, [(column, write_timestamp_micros)]).
-    type MergedRow = (Vec<u8>, ScanRow, Vec<(String, i64)>);
-    let merged_rows = tokio::task::spawn_blocking(move || -> Result<Vec<MergedRow>> {
+    let merged_rows = tokio::task::spawn_blocking(move || -> Result<Vec<MergedMetaRow>> {
         let mut merger = KWayMerger::new(paths, &merge_schema)?;
         let mut out = Vec::new();
         while let MergeStep::Partition { key, rows } = merger.step()? {
@@ -300,11 +304,7 @@ pub(super) async fn merge_generations_for_read_with_metadata(
 /// live cells plus each surviving cell's `(column, write_timestamp)`. Shared by the
 /// range and point-targeted branches of the metadata merge so the tombstone
 /// filtering + timestamp capture live once.
-fn push_metadata_rows(
-    key_bytes: &[u8],
-    rows: Vec<MergeEntry>,
-    out: &mut Vec<(Vec<u8>, ScanRow, Vec<(String, i64)>)>,
-) {
+fn push_metadata_rows(key_bytes: &[u8], rows: Vec<MergeEntry>, out: &mut Vec<MergedMetaRow>) {
     for entry in rows {
         if let RowData::Live { cells } = entry.row_data {
             let mut row_cells: RowCells = Vec::with_capacity(cells.len());

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -1,0 +1,436 @@
+//! Cross-generation read reconciliation for the SSTable manager (issues #883,
+//! #885, #957, #1579).
+//!
+//! When a table directory holds more than one SSTable generation, plain
+//! concatenation of each reader's live rows is wrong: the same
+//! `(partition, clustering)` row can appear in several generations, and a
+//! row/cell tombstone in a newer generation suppresses only its OWN generation's
+//! copy — so concatenation duplicates overwritten rows and resurrects rows deleted
+//! in a later generation. These helpers reconcile across generations with the
+//! authoritative [`KWayMerger`](crate::storage::write_engine::KWayMerger) — the
+//! same last-write-wins + tombstone-shadowing logic compaction uses — so the read
+//! path returns Cassandra's merged, deduplicated, tombstone-honouring result.
+//!
+//! Three drivers, ONE reconciliation kernel (the merger's `step()`):
+//!
+//! - [`merge_generations_for_read`] — materializing plain read (`scan`,
+//!   partition-targeted point reads). Collects the reconciled rows into a `Vec`
+//!   in Cassandra token order.
+//! - [`merge_generations_for_read_with_metadata`] — the `WRITETIME`/`TTL`
+//!   projection sibling; additionally surfaces the winning cell's per-cell write
+//!   metadata.
+//! - [`stream_generations_for_read`] — the STREAMING plain read (`scan_stream`,
+//!   issue #1579 / D3). Feeds each stepped partition straight into a bounded
+//!   channel instead of collecting the whole table, so live heap is O(one
+//!   partition + channel) and time-to-first-row is O(first partition), not
+//!   O(full merge).
+//!
+//! All three yield partitions in the merger's `DecoratedKey` order = `(token,
+//! key)`, which is byte-identical to [`scan_merge::sort_by_token_order`]. The
+//! materializing paths still apply that stable sort as a no-op guard; the
+//! streaming path relies on the merger's order directly (issue #1579).
+//!
+//! Extracted from `sstable/mod.rs` (issue #1116 campsite split): behaviour of the
+//! two materializing helpers is unchanged apart from the new `target_key`
+//! partition-targeting parameter (issue #1579, point-read path).
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[cfg(not(feature = "tombstones"))]
+use tokio::sync::{mpsc, oneshot};
+
+#[cfg(not(feature = "tombstones"))]
+use super::stream_merge_probe;
+use super::{reader, scan_merge};
+use crate::storage::write_engine::merge::{KWayMerger, MergeEntry, MergeStep, RowData};
+use crate::types::{CellWriteMetadata, TableId as CqlTableId};
+use crate::{Result, RowCells, RowKey, ScanRow, Value};
+
+/// Convert one reconciled partition's merge rows into the live scan rows the read
+/// path emits: drop cell tombstones, drop row tombstones, drop rows left empty.
+///
+/// The single emission kernel shared by the materializing plain merge and the
+/// streaming driver so tombstone filtering can never drift between them (issue
+/// #1334: emit the interned-name `ScanRow` carrier the read path consumes).
+fn partition_live_rows(row_key: &RowKey, rows: Vec<MergeEntry>) -> Vec<(RowKey, ScanRow)> {
+    let mut out = Vec::new();
+    for entry in rows {
+        match entry.row_data {
+            RowData::Live { cells } => {
+                let row_cells: RowCells = cells
+                    .into_iter()
+                    .filter(|c| !matches!(c.value, Value::Tombstone(_)))
+                    .map(|c| (Arc::from(c.column.as_str()), c.value))
+                    .collect();
+                if !row_cells.is_empty() {
+                    out.push((row_key.clone(), ScanRow::Row(row_cells)));
+                }
+            }
+            // Row tombstone: the row is deleted across all generations — suppress.
+            RowData::Tombstone { .. } => {}
+        }
+    }
+    out
+}
+
+/// Reconcile multiple SSTable generations into the single authoritative live-row
+/// set, returning them materialized in Cassandra token order (issue #883).
+///
+/// This drives the same [`KWayMerger`](crate::storage::write_engine::KWayMerger)
+/// the compaction path uses, so reconciliation is byte-for-byte the
+/// last-write-wins + tombstone-shadowing logic (`merge_partition_rows`): per-cell
+/// LWW by write timestamp, row/cell tombstones shadow older cells, and
+/// fully-deleted rows are dropped. The merger manages its own reader
+/// threads/runtimes internally, so it runs on a blocking task.
+///
+/// `start_key`/`end_key` bound the merged output to the same inclusive
+/// `[start_key, end_key]` key range the per-reader
+/// [`scan`](reader::SSTableReader::scan) applies (skip `key < start`, skip
+/// `key > end`, using `RowKey`'s `Ord`) — Issue #957. The range filter runs
+/// before `limit`, matching the per-reader scan order (range then limit).
+///
+/// `target_key` restricts the output to a SINGLE partition (the point-read path,
+/// issue #1579): keep only the partition whose raw key bytes equal `target_key`
+/// and STOP as soon as it is found. Partition keys are unique in the merger's
+/// output, so once the target is seen nothing later can match — this avoids
+/// converting every other partition to `ScanRow` and decoding past the target,
+/// while remaining byte-identical to the caller's former
+/// `retain(|r| r.key == partition_key)`. `target_key` and the range bounds are
+/// not combined by any current caller (point reads pass `None`/`None` bounds).
+///
+/// With `None` target and `None`/`None` bounds the output is byte-for-byte the
+/// full reconciled set.
+pub(super) async fn merge_generations_for_read(
+    reader_list: &[Arc<reader::SSTableReader>],
+    schema: &crate::schema::TableSchema,
+    start_key: Option<&RowKey>,
+    end_key: Option<&RowKey>,
+    limit: Option<usize>,
+    target_key: Option<&RowKey>,
+) -> Result<Vec<(RowKey, ScanRow)>> {
+    // Own the bounds/target so the merge body can use them without borrowing
+    // across the await; cheap clone of the key bytes.
+    let start_key = start_key.cloned();
+    let end_key = end_key.cloned();
+    let target_key = target_key.map(|k| k.as_bytes().to_vec());
+
+    let paths = ordered_generation_paths(reader_list);
+    let schema = schema.clone();
+
+    let mut merged = tokio::task::spawn_blocking(move || -> Result<Vec<(RowKey, ScanRow)>> {
+        let mut merger = KWayMerger::new(paths, &schema)?;
+        let mut out = Vec::new();
+        while let MergeStep::Partition { key, rows } = merger.step()? {
+            let row_key = RowKey(key.key.clone());
+
+            // Partition-targeted point read (#1579): keep ONLY the target and stop.
+            if let Some(ref target) = target_key {
+                if row_key.as_bytes() != target.as_slice() {
+                    continue;
+                }
+                out.extend(partition_live_rows(&row_key, rows));
+                break;
+            }
+
+            // Full / range scan: inclusive [start, end] on `RowKey` order (#957).
+            if let Some(ref start) = start_key {
+                if &row_key < start {
+                    continue;
+                }
+            }
+            if let Some(ref end) = end_key {
+                if &row_key > end {
+                    continue;
+                }
+            }
+            out.extend(partition_live_rows(&row_key, rows));
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| crate::Error::Storage(format!("cross-generation read merge task: {e}")))??;
+
+    // Match the plain-scan contract: the merger already emits partitions in
+    // Cassandra token order with clustering rows contiguous within a partition.
+    // Preserve that with a stable TOKEN-order sort (issue #1580), then apply
+    // LIMIT. The sort is a no-op ordering-wise when the input is already
+    // token-ordered; it only guards against a stray divergence.
+    scan_merge::sort_by_token_order(&mut merged, limit, |(k, _)| k);
+    Ok(merged)
+}
+
+/// Metadata-aware sibling of [`merge_generations_for_read`] for the
+/// `WRITETIME(col)` / `TTL(col)` projection path (Issue #885).
+///
+/// Reconciles multiple SSTable generations with the same
+/// [`KWayMerger`](crate::storage::write_engine::KWayMerger) (per-cell LWW +
+/// row/cell tombstone shadowing) and additionally surfaces the **winning** cell's
+/// per-cell write metadata:
+///
+/// - `write_timestamp_micros` comes straight from the winning `CellData`
+///   (`reconcile_cluster` keeps each surviving cell's own timestamp), so it is the
+///   WRITETIME of the cell that actually won cross-generation LWW.
+/// - `expiration` (TTL) is recovered best-effort from the per-reader
+///   `scan_with_cell_metadata` outputs: for each surviving `(key, column)` we take
+///   the newest reader-surfaced metadata and attach its expiration only when its
+///   timestamp matches the merge winner. Absent/mismatched ⇒ `None`.
+///
+/// `start_key`/`end_key`/`target_key`/`limit` behave exactly as in
+/// [`merge_generations_for_read`], keeping this definitionally in lockstep with
+/// the plain helper. When `target_key` is `Some`, the best-effort TTL scan is also
+/// bounded to that single partition (issue #1579, point-read path).
+pub(super) async fn merge_generations_for_read_with_metadata(
+    reader_list: &[Arc<reader::SSTableReader>],
+    schema: &crate::schema::TableSchema,
+    start_key: Option<&RowKey>,
+    end_key: Option<&RowKey>,
+    limit: Option<usize>,
+    target_key: Option<&RowKey>,
+) -> Result<Vec<(RowKey, ScanRow, HashMap<String, CellWriteMetadata>)>> {
+    // Own the bounds so the merge body can use them without borrowing across the
+    // await; cheap clone of the key bytes. Mirrors the plain helper.
+    let owned_start = start_key.cloned();
+    let owned_end = end_key.cloned();
+    let target_bytes = target_key.map(|k| k.as_bytes().to_vec());
+
+    // Best-effort TTL source: gather each reader's own per-cell metadata and keep,
+    // per (row-key bytes, column), the entry with the newest write timestamp. The
+    // merger surfaces accurate WRITETIME but no TTL, so this recovers expiration
+    // for the winning cell when the reader format carries it. For a point read the
+    // scan is bounded to the target partition (#1579); otherwise to the read range.
+    let table_id = CqlTableId::from(format!("{}.{}", schema.keyspace, schema.table).as_str());
+    let mut ttl_lookup: HashMap<(Vec<u8>, String), CellWriteMetadata> = HashMap::new();
+    for reader in reader_list {
+        let (ttl_start, ttl_end): (Option<&RowKey>, Option<&RowKey>) = match target_key {
+            Some(t) => (Some(t), Some(t)),
+            None => (owned_start.as_ref(), owned_end.as_ref()),
+        };
+        let per_reader = reader
+            .scan_with_cell_metadata(&table_id, ttl_start, ttl_end, None, Some(schema))
+            .await?;
+        for (row_key, _value, meta) in per_reader {
+            for (column, cell_meta) in meta {
+                ttl_lookup
+                    .entry((row_key.0.clone(), column))
+                    .and_modify(|existing| {
+                        if cell_meta.write_timestamp_micros > existing.write_timestamp_micros {
+                            *existing = cell_meta.clone();
+                        }
+                    })
+                    .or_insert(cell_meta);
+            }
+        }
+    }
+
+    let paths = ordered_generation_paths(reader_list);
+    let merge_schema = schema.clone();
+    let start_key = owned_start;
+    let end_key = owned_end;
+    let target_for_merge = target_bytes;
+
+    // (key bytes, ScanRow row carrier, [(column, write_timestamp_micros)]).
+    type MergedRow = (Vec<u8>, ScanRow, Vec<(String, i64)>);
+    let merged_rows = tokio::task::spawn_blocking(move || -> Result<Vec<MergedRow>> {
+        let mut merger = KWayMerger::new(paths, &merge_schema)?;
+        let mut out = Vec::new();
+        while let MergeStep::Partition { key, rows } = merger.step()? {
+            let row_key = RowKey(key.key.clone());
+
+            // Partition-targeted point read (#1579): keep ONLY the target and stop.
+            if let Some(ref target) = target_for_merge {
+                if row_key.as_bytes() != target.as_slice() {
+                    continue;
+                }
+                push_metadata_rows(&key.key, rows, &mut out);
+                break;
+            }
+
+            // Full / range scan: inclusive [start, end] on `RowKey` order (#957).
+            if let Some(ref start) = start_key {
+                if &row_key < start {
+                    continue;
+                }
+            }
+            if let Some(ref end) = end_key {
+                if &row_key > end {
+                    continue;
+                }
+            }
+            push_metadata_rows(&key.key, rows, &mut out);
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| crate::Error::Storage(format!("cross-generation metadata merge task: {e}")))??;
+
+    // Attach per-cell metadata: WRITETIME from the merge winner, TTL recovered from
+    // the reader lookup only when its timestamp matches the winner.
+    let mut results: Vec<(RowKey, ScanRow, HashMap<String, CellWriteMetadata>)> =
+        Vec::with_capacity(merged_rows.len());
+    for (key_bytes, value, timestamps) in merged_rows {
+        let mut meta_map: HashMap<String, CellWriteMetadata> =
+            HashMap::with_capacity(timestamps.len());
+        for (column, write_ts) in timestamps {
+            let expiration = ttl_lookup
+                .get(&(key_bytes.clone(), column.clone()))
+                .filter(|m| m.write_timestamp_micros == write_ts)
+                .and_then(|m| m.expiration.clone());
+            meta_map.insert(
+                column,
+                CellWriteMetadata {
+                    write_timestamp_micros: write_ts,
+                    expiration,
+                },
+            );
+        }
+        results.push((RowKey(key_bytes), value, meta_map));
+    }
+
+    // Stable TOKEN-order sort (issue #1580), then LIMIT — identical ordering to the
+    // plain merge path; the metadata payload rides in the tuple's tail.
+    scan_merge::sort_by_token_order(&mut results, limit, |(k, _, _)| k);
+    Ok(results)
+}
+
+/// Convert one reconciled partition's merge rows into metadata-carrying rows: the
+/// live cells plus each surviving cell's `(column, write_timestamp)`. Shared by the
+/// range and point-targeted branches of the metadata merge so the tombstone
+/// filtering + timestamp capture live once.
+fn push_metadata_rows(
+    key_bytes: &[u8],
+    rows: Vec<MergeEntry>,
+    out: &mut Vec<(Vec<u8>, ScanRow, Vec<(String, i64)>)>,
+) {
+    for entry in rows {
+        if let RowData::Live { cells } = entry.row_data {
+            let mut row_cells: RowCells = Vec::with_capacity(cells.len());
+            let mut timestamps: Vec<(String, i64)> = Vec::with_capacity(cells.len());
+            for c in cells {
+                // Drop cell tombstones: a deleted column is absent.
+                if matches!(c.value, Value::Tombstone(_)) {
+                    continue;
+                }
+                timestamps.push((c.column.clone(), c.timestamp));
+                row_cells.push((Arc::from(c.column.as_str()), c.value));
+            }
+            if !row_cells.is_empty() {
+                out.push((key_bytes.to_vec(), ScanRow::Row(row_cells), timestamps));
+            }
+        }
+        // Row tombstones suppress the row entirely (no emission).
+    }
+}
+
+/// STREAMING cross-generation reconciliation for `scan_stream` (issue #1579 / D3).
+///
+/// Runs the authoritative [`KWayMerger`](crate::storage::write_engine::KWayMerger)
+/// on a blocking task and feeds each stepped partition's live rows STRAIGHT into a
+/// bounded channel via `blocking_send` (backpressure preserved), instead of
+/// collecting the entire reconciled table, sorting it, and dribbling it. Live heap
+/// is therefore O(one partition + channel), and the first row is available after
+/// the first partition rather than after the whole merge.
+///
+/// Reconciliation is byte-identical to [`merge_generations_for_read`] (shared
+/// `partition_live_rows` kernel), and the emission order is the merger's
+/// `DecoratedKey` = `(token, key)` order — byte-identical to the collect+sort
+/// path's [`scan_merge::sort_by_token_order`] output (issue #1579 ordering
+/// guardrail).
+///
+/// Construction (`KWayMerger::new`, which opens the input files) happens on the
+/// blocking task; its success/failure is signalled back over a oneshot BEFORE any
+/// streaming, so the caller can FALL BACK to the lazy per-reader streaming merge on
+/// a construction error exactly as the materializing `scan` falls back to
+/// concatenation. A runtime `step()` error mid-stream is delivered as an `Err`
+/// item on the channel (the consumer sees it), matching the lazy path's read-error
+/// behaviour.
+#[cfg(not(feature = "tombstones"))]
+pub(super) async fn stream_generations_for_read(
+    reader_list: &[Arc<reader::SSTableReader>],
+    schema: &crate::schema::TableSchema,
+    start_key: Option<&RowKey>,
+    end_key: Option<&RowKey>,
+    buffer_size: usize,
+) -> Result<mpsc::Receiver<Result<(RowKey, ScanRow)>>> {
+    let start_key = start_key.cloned();
+    let end_key = end_key.cloned();
+    let paths = ordered_generation_paths(reader_list);
+    let schema = schema.clone();
+
+    let (ready_tx, ready_rx) = oneshot::channel::<Result<()>>();
+    let (out_tx, out_rx) = mpsc::channel::<Result<(RowKey, ScanRow)>>(buffer_size.max(1));
+
+    tokio::task::spawn_blocking(move || {
+        let mut merger = match KWayMerger::new(paths, &schema) {
+            Ok(m) => {
+                // Signal readiness; if the caller already dropped, stop.
+                if ready_tx.send(Ok(())).is_err() {
+                    return;
+                }
+                m
+            }
+            Err(e) => {
+                // Let the caller fall back to the lazy per-reader streaming merge.
+                let _ = ready_tx.send(Err(e));
+                return;
+            }
+        };
+
+        loop {
+            let step = match merger.step() {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = out_tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+            let (key, rows) = match step {
+                MergeStep::Partition { key, rows } => (key, rows),
+                MergeStep::Complete => return,
+            };
+
+            let row_key = RowKey(key.key.clone());
+            if let Some(ref start) = start_key {
+                if &row_key < start {
+                    continue;
+                }
+            }
+            if let Some(ref end) = end_key {
+                if &row_key > end {
+                    continue;
+                }
+            }
+
+            let live = partition_live_rows(&row_key, rows);
+            // Issue #1579: the streaming producer holds ONE partition's rows
+            // resident at a time — record the window (not the whole table) so the
+            // memory guard observes O(window).
+            stream_merge_probe::record_resident(live.len() as u64);
+            for entry in live {
+                if out_tx.blocking_send(Ok(entry)).is_err() {
+                    return; // consumer dropped
+                }
+            }
+        }
+    });
+
+    match ready_rx.await {
+        Ok(Ok(())) => Ok(out_rx),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(crate::Error::Storage(
+            "cross-generation streaming merge task ended before signalling readiness".to_string(),
+        )),
+    }
+}
+
+/// The merger expects inputs ordered newest → oldest (run_index 0 = newest) for
+/// its stable tie-break; the reader `Vec` order is discovery-dependent, so sort
+/// explicitly by generation descending and collect the input `Data.db` paths.
+fn ordered_generation_paths(reader_list: &[Arc<reader::SSTableReader>]) -> Vec<PathBuf> {
+    let mut ordered: Vec<&Arc<reader::SSTableReader>> = reader_list.iter().collect();
+    ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
+    ordered.iter().map(|r| r.file_path.clone()).collect()
+}

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -347,6 +347,19 @@ fn push_metadata_rows(key_bytes: &[u8], rows: Vec<MergeEntry>, out: &mut Vec<Mer
 /// concatenation. A runtime `step()` error mid-stream is delivered as an `Err`
 /// item on the channel (the consumer sees it), matching the lazy path's read-error
 /// behaviour.
+///
+/// This is a deliberate, documented error-path asymmetry (issue #1579): the
+/// caller's fallback-to-concatenation only ever applies to the CONSTRUCTION
+/// failure above (nothing has been streamed yet, so falling back cannot mix
+/// reconciled and unreconciled rows). A `step()` failure after some partitions
+/// were already emitted downstream is NEVER retried/fallen-back — it ends the
+/// stream via the `Err` channel item instead. That is safer than it sounds: the
+/// materializing `merge_generations_for_read` has no equivalent mid-collection
+/// failure signal — a `step()` error there simply propagates the whole call as
+/// `Err` before any partial `Vec` is returned to the caller. The streaming
+/// driver's `Err` item preserves the same "no half-reconciled result surfaces
+/// silently" guarantee while still letting the caller observe exactly how many
+/// good rows it already received.
 #[cfg(not(feature = "tombstones"))]
 pub(super) async fn stream_generations_for_read(
     reader_list: &[Arc<reader::SSTableReader>],

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -40,6 +40,7 @@ pub mod row_cell_state_machine;
 /// Cross-SSTable scan ordering: k-way merge in Cassandra token order (issue #1580).
 mod scan_merge;
 pub mod statistics_reader;
+pub mod stream_merge_probe; // Multi-generation streaming-merge resident-rows probe (issue #1579, D3).
 #[cfg(feature = "tombstones")]
 pub mod tombstone_merger;
 pub mod validation;
@@ -2045,6 +2046,10 @@ impl SSTableManager {
                              (materialized for streaming)",
                             merged.len()
                         );
+                        // Issue #1579 (D3): the eager path holds the WHOLE reconciled
+                        // table resident before dribbling — record that as the resident
+                        // high-water mark so the memory guard observes O(table).
+                        stream_merge_probe::record_resident(merged.len() as u64);
                         let (tx, rx) = tokio::sync::mpsc::channel(buffer_size.max(1));
                         tokio::spawn(async move {
                             for entry in merged {

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -10,6 +10,8 @@ pub mod compression_info;
 pub mod directory;
 pub mod directory_integration_tests;
 pub mod format_detector;
+#[cfg(feature = "write-support")]
+mod generation_merge; // Cross-generation read reconciliation (issues #883/#885/#957/#1579).
 pub mod header_spec;
 pub mod index;
 pub mod index_reader;
@@ -90,11 +92,6 @@ use self::tombstone_merger::{EntryMetadata, GenerationValue, TombstoneMerger};
 use crate::platform::Platform;
 use crate::types::CellWriteMetadata;
 use crate::{types::TableId, Config, Result, RowKey, ScanRow};
-// `RowCells`/`Value` are only referenced by the write-support merge read path
-// (`merge_generations_for_read` and the metadata scan); gate the import so the
-// minimal build does not flag them unused (issue #1334).
-#[cfg(feature = "write-support")]
-use crate::{RowCells, Value};
 
 /// Maximum directory depth when scanning for SSTable files.
 ///
@@ -971,9 +968,15 @@ impl SSTableManager {
         #[cfg(feature = "write-support")]
         if reader_list.len() > 1 {
             if let Some(schema) = schema {
-                match self
-                    .merge_generations_for_read(&reader_list, schema, start_key, end_key, limit)
-                    .await
+                match generation_merge::merge_generations_for_read(
+                    &reader_list,
+                    schema,
+                    start_key,
+                    end_key,
+                    limit,
+                    None,
+                )
+                .await
                 {
                     Ok(merged) => {
                         log::debug!(
@@ -1120,8 +1123,8 @@ impl SSTableManager {
     /// Reconciliation mirrors `scan_partition`:
     /// - More than one candidate generation (write-support + schema): drive the
     ///   authoritative k-way merge via
-    ///   [`merge_generations_for_read_with_metadata`](Self::merge_generations_for_read_with_metadata)
-    ///   over JUST the candidates, then retain this partition's rows. This preserves
+    ///   `generation_merge::merge_generations_for_read_with_metadata` TARGETED to
+    ///   just this partition. This preserves
     ///   per-cell cross-generation LWW / tombstone shadowing for WRITETIME/TTL
     ///   (Issue #885) on the targeted path.
     /// - Otherwise: decode each candidate via the reader's metadata path and retain
@@ -1215,20 +1218,29 @@ impl SSTableManager {
 
         // Multiple candidate generations may hold the same partition; reconcile
         // with the same authoritative metadata-aware k-way merge the full metadata
-        // scan uses (write-support only, schema present), then keep just this
-        // partition's rows. This preserves per-cell cross-generation WRITETIME/TTL.
+        // scan uses (write-support only, schema present), TARGETED to just this
+        // partition (issue #1579): the merge keeps only `partition_key`'s rows and
+        // stops as soon as it finds them, byte-identical to the former
+        // full-merge-then-`retain(matches_key)` but without materializing every
+        // other partition. This preserves per-cell cross-generation WRITETIME/TTL.
         #[cfg(feature = "write-support")]
         if candidates.len() > 1 {
             if let Some(schema) = schema {
-                match self
-                    .merge_generations_for_read_with_metadata(&candidates, schema, None, None, None)
-                    .await
+                let target = RowKey::new(partition_key.to_vec());
+                match generation_merge::merge_generations_for_read_with_metadata(
+                    &candidates,
+                    schema,
+                    None,
+                    None,
+                    None,
+                    Some(&target),
+                )
+                .await
                 {
-                    Ok(mut merged) => {
-                        merged.retain(matches_key);
+                    Ok(merged) => {
                         // Work-counter gate (Issue #958): the merge parsed every
-                        // surviving candidate; `merged` (post-retain) is exactly the
-                        // partitions this lookup returns.
+                        // surviving candidate; `merged` (already the target partition
+                        // only) is exactly the partitions this lookup returns.
                         work_counters::add_sstables_scanned(candidates.len() as u64);
                         work_counters::add_partitions_parsed(merged.len() as u64);
                         return Ok((merged, true));
@@ -1367,21 +1379,28 @@ impl SSTableManager {
 
         // Multiple candidate generations may hold the same partition; reconcile
         // with the same authoritative k-way merge the full scan uses (write-support
-        // only), then keep just this partition's rows.
+        // only), TARGETED to just this partition (issue #1579): the merge keeps only
+        // `partition_key`'s rows and stops as soon as it finds them, byte-identical
+        // to the former full-merge-then-`retain(matches_key)` but without
+        // materializing every other partition.
         #[cfg(feature = "write-support")]
         if candidates.len() > 1 {
             if let Some(schema) = schema {
-                match self
-                    // Partition-targeted: no key range; `retain(matches_key)` below
-                    // is a stricter single-partition filter than any range bound.
-                    .merge_generations_for_read(&candidates, schema, None, None, None)
-                    .await
+                let target = RowKey::new(partition_key.to_vec());
+                match generation_merge::merge_generations_for_read(
+                    &candidates,
+                    schema,
+                    None,
+                    None,
+                    None,
+                    Some(&target),
+                )
+                .await
                 {
-                    Ok(mut merged) => {
-                        merged.retain(matches_key);
+                    Ok(merged) => {
                         // Work-counter gate (Issue #958): the k-way merge parsed
-                        // every surviving candidate, and `merged` (post-retain) is
-                        // exactly the partitions this lookup returns.
+                        // every surviving candidate, and `merged` (already the target
+                        // partition only) is exactly the partitions this lookup returns.
                         work_counters::add_sstables_scanned(candidates.len() as u64);
                         work_counters::add_partitions_parsed(merged.len() as u64);
                         // The cross-generation merge decodes full partitions; the
@@ -1532,285 +1551,6 @@ impl SSTableManager {
         !table_name.contains('.') || table_readers.contains_key(table_name)
     }
 
-    /// Reconcile multiple SSTable generations of one table into the single
-    /// authoritative live-row set, matching Cassandra read semantics (Issue #883).
-    ///
-    /// Plain `scan` concatenates each reader's live rows, which is only correct
-    /// for a single generation. With several generations in a table directory
-    /// (successive flushes), the same `(partition, clustering)` row can appear in
-    /// more than one generation, and a row/cell deleted in a later generation is
-    /// suppressed only inside the generation that holds its tombstone — so the
-    /// older generation's copy leaks back into the result.
-    ///
-    /// This drives the same [`KWayMerger`](crate::storage::write_engine::KWayMerger)
-    /// the compaction path uses, so reconciliation is byte-for-byte the
-    /// last-write-wins + tombstone-shadowing logic (`merge_partition_rows`):
-    /// per-cell LWW by write timestamp, row/cell tombstones shadow older cells,
-    /// and fully-deleted rows are dropped. The merger manages its own reader
-    /// threads/runtimes internally, so it runs on a blocking task.
-    ///
-    /// Requires a schema (cells carry no column names on disk) and the
-    /// `write-support` feature (the merger lives in the write engine). Callers
-    /// fall back to concatenation when either is unavailable.
-    ///
-    /// `start_key`/`end_key` bound the merged output to the same inclusive
-    /// `[start_key, end_key]` key range the per-reader [`scan`](reader::SSTableReader::scan)
-    /// applies (skip `key < start`, skip `key > end`, using `RowKey`'s `Ord`), so a
-    /// bounded multi-generation read returns only the requested range rather than the
-    /// full reconciled table (Issue #957). The range filter runs before `limit`, matching
-    /// the per-reader scan order (range then limit). With `None`/`None` bounds the output
-    /// is byte-for-byte the full reconciled set, unchanged from before.
-    #[cfg(feature = "write-support")]
-    async fn merge_generations_for_read(
-        &self,
-        reader_list: &[Arc<reader::SSTableReader>],
-        schema: &crate::schema::TableSchema,
-        start_key: Option<&RowKey>,
-        end_key: Option<&RowKey>,
-        limit: Option<usize>,
-    ) -> Result<Vec<(RowKey, ScanRow)>> {
-        use crate::storage::write_engine::merge::{KWayMerger, MergeStep, RowData};
-
-        // Own the bounds so the merge body (and any later filtering) can use them
-        // without borrowing across the await; cheap clone of the key bytes.
-        let start_key = start_key.cloned();
-        let end_key = end_key.cloned();
-
-        // The merger expects inputs ordered newest → oldest (run_index 0 = newest)
-        // for its stable tie-break; the reader Vec order is discovery-dependent, so
-        // sort explicitly by generation descending.
-        let mut ordered: Vec<&Arc<reader::SSTableReader>> = reader_list.iter().collect();
-        ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
-        let paths: Vec<PathBuf> = ordered.iter().map(|r| r.file_path.clone()).collect();
-        let schema = schema.clone();
-
-        let mut merged = tokio::task::spawn_blocking(move || -> Result<Vec<(RowKey, ScanRow)>> {
-            let mut merger = KWayMerger::new(paths, &schema)?;
-            let mut out = Vec::new();
-            while let MergeStep::Partition { key, rows } = merger.step()? {
-                // Enforce the same inclusive `[start_key, end_key]` range the
-                // per-reader scan applies (Issue #957): skip `key < start` and
-                // `key > end`, comparing with the identical `RowKey` ordering used
-                // for the final sort. Filtering at the partition key drops every
-                // out-of-range row before it is materialized.
-                let row_key = RowKey(key.key.clone());
-                if let Some(ref start) = start_key {
-                    if &row_key < start {
-                        continue;
-                    }
-                }
-                if let Some(ref end) = end_key {
-                    if &row_key > end {
-                        continue;
-                    }
-                }
-                for entry in rows {
-                    match entry.row_data {
-                        RowData::Live { cells } => {
-                            // Drop cell tombstones: a deleted column must be
-                            // absent from the merged row, not surfaced. Issue
-                            // #1334: emit the interned-name `ScanRow` carrier
-                            // the read path consumes.
-                            let row_cells: RowCells = cells
-                                .into_iter()
-                                .filter(|c| !matches!(c.value, Value::Tombstone(_)))
-                                .map(|c| (Arc::from(c.column.as_str()), c.value))
-                                .collect();
-                            if !row_cells.is_empty() {
-                                out.push((row_key.clone(), ScanRow::Row(row_cells)));
-                            }
-                        }
-                        // Row tombstone: the row is deleted across all
-                        // generations — suppress it entirely.
-                        RowData::Tombstone { .. } => {}
-                    }
-                }
-            }
-            Ok(out)
-        })
-        .await
-        .map_err(|e| crate::Error::Storage(format!("cross-generation read merge task: {e}")))??;
-
-        // Match the plain-scan contract: the merger already emits partitions in
-        // Cassandra token order with clustering rows contiguous within a
-        // partition. Preserve that with a stable TOKEN-order sort (issue #1580) —
-        // NOT a raw-key-byte sort, which would re-break the token ordering — then
-        // apply LIMIT. The sort is a no-op ordering-wise when the merger's output
-        // is already token-ordered; it only guards against a stray divergence.
-        scan_merge::sort_by_token_order(&mut merged, limit, |(k, _)| k);
-        Ok(merged)
-    }
-
-    /// Metadata-aware sibling of [`merge_generations_for_read`](Self::merge_generations_for_read)
-    /// for the `WRITETIME(col)` / `TTL(col)` projection path (Issue #885).
-    ///
-    /// Reconciles multiple SSTable generations into the authoritative live-row set
-    /// with the same [`KWayMerger`](crate::storage::write_engine::KWayMerger)
-    /// (per-cell LWW + row/cell tombstone shadowing), and additionally surfaces the
-    /// **winning** cell's per-cell write metadata in the
-    /// [`CellWriteMetadata`](crate::types::CellWriteMetadata) shape
-    /// `scan_with_cell_metadata` returns:
-    ///
-    /// - `write_timestamp_micros` comes straight from the winning `CellData`
-    ///   (`reconcile_cluster` keeps each surviving cell's own timestamp), so it is
-    ///   the WRITETIME of the cell that actually won cross-generation LWW — not an
-    ///   arbitrary generation's.
-    /// - `expiration` (TTL) is recovered best-effort from the per-reader
-    ///   `scan_with_cell_metadata` outputs: the merger's compaction iterator does
-    ///   not carry per-cell TTL, so for each surviving `(key, column)` we take the
-    ///   newest reader-surfaced metadata and attach its expiration only when its
-    ///   timestamp matches the merge winner. Absent/mismatched ⇒ `None` (no TTL),
-    ///   which is the same answer the plain read gives for a cell without TTL.
-    ///
-    /// Requires a schema and the `write-support` feature; callers fall back to
-    /// per-reader concatenation when either is unavailable.
-    ///
-    /// `start_key`/`end_key` bound the merged output to the same inclusive
-    /// `[start_key, end_key]` key range as the non-metadata
-    /// [`merge_generations_for_read`](Self::merge_generations_for_read) (skip
-    /// `key < start`, skip `key > end`, using `RowKey`'s `Ord`), so a bounded
-    /// multi-generation metadata read returns only the requested range rather than
-    /// the full reconciled table (Issue #957). The range filter runs before `limit`,
-    /// matching the per-reader scan order (range then limit). With `None`/`None`
-    /// bounds the output is byte-for-byte the full reconciled set, unchanged from
-    /// before. This stays definitionally in lockstep with the plain helper.
-    ///
-    /// Available whenever `write-support` is on — the `tombstones` build reuses the
-    /// identical `KWayMerger` reconciliation so `WRITETIME(col)` / `TTL(col)` resolve
-    /// from the authoritative winning cell there too (Issue #1535). Nothing in this
-    /// body depends on the tombstones GC path; it only needs the merger.
-    #[cfg(feature = "write-support")]
-    async fn merge_generations_for_read_with_metadata(
-        &self,
-        reader_list: &[Arc<reader::SSTableReader>],
-        schema: &crate::schema::TableSchema,
-        start_key: Option<&RowKey>,
-        end_key: Option<&RowKey>,
-        limit: Option<usize>,
-    ) -> Result<Vec<(RowKey, ScanRow, HashMap<String, CellWriteMetadata>)>> {
-        use crate::storage::write_engine::merge::{KWayMerger, MergeStep, RowData};
-        use crate::types::TableId as CqlTableId;
-
-        // Own the bounds so the merge body can use them without borrowing across
-        // the await; cheap clone of the key bytes. Mirrors the plain helper.
-        let start_key = start_key.cloned();
-        let end_key = end_key.cloned();
-
-        // Best-effort TTL source: gather each reader's own per-cell metadata and
-        // keep, per (row-key bytes, column), the entry with the newest write
-        // timestamp. The merger surfaces accurate WRITETIME but no TTL, so this
-        // recovers expiration for the winning cell when the reader format carries
-        // it (V5CompressedLegacy / BTI). Keyed by raw key bytes so it lines up with
-        // the merger's `DecoratedKey` partition bytes.
-        let table_id = CqlTableId::from(format!("{}.{}", schema.keyspace, schema.table).as_str());
-        let mut ttl_lookup: HashMap<(Vec<u8>, String), CellWriteMetadata> = HashMap::new();
-        for reader in reader_list {
-            let per_reader = reader
-                .scan_with_cell_metadata(&table_id, None, None, None, Some(schema))
-                .await?;
-            for (row_key, _value, meta) in per_reader {
-                for (column, cell_meta) in meta {
-                    ttl_lookup
-                        .entry((row_key.0.clone(), column))
-                        .and_modify(|existing| {
-                            if cell_meta.write_timestamp_micros > existing.write_timestamp_micros {
-                                *existing = cell_meta.clone();
-                            }
-                        })
-                        .or_insert(cell_meta);
-                }
-            }
-        }
-
-        // Drive the authoritative merge (newest → oldest), mirroring the plain
-        // `merge_generations_for_read` path, but keep each winning cell's timestamp.
-        let mut ordered: Vec<&Arc<reader::SSTableReader>> = reader_list.iter().collect();
-        ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
-        let paths: Vec<PathBuf> = ordered.iter().map(|r| r.file_path.clone()).collect();
-        let merge_schema = schema.clone();
-
-        // Returns (key bytes, ScanRow row carrier, [(column, write_timestamp_micros)]).
-        type MergedRow = (Vec<u8>, ScanRow, Vec<(String, i64)>);
-        let merged_rows = tokio::task::spawn_blocking(move || -> Result<Vec<MergedRow>> {
-            let mut merger = KWayMerger::new(paths, &merge_schema)?;
-            let mut out = Vec::new();
-            while let MergeStep::Partition { key, rows } = merger.step()? {
-                // Enforce the same inclusive `[start_key, end_key]` range as the
-                // non-metadata `merge_generations_for_read` (Issue #957): skip
-                // `key < start` and `key > end`, comparing with the identical
-                // `RowKey` ordering used for the final sort. Filtering at the
-                // partition key drops every out-of-range row before it is
-                // materialized.
-                let row_key = RowKey(key.key.clone());
-                if let Some(ref start) = start_key {
-                    if &row_key < start {
-                        continue;
-                    }
-                }
-                if let Some(ref end) = end_key {
-                    if &row_key > end {
-                        continue;
-                    }
-                }
-                for entry in rows {
-                    if let RowData::Live { cells } = entry.row_data {
-                        // Issue #1334: emit the interned-name `ScanRow` carrier
-                        // the read path consumes.
-                        let mut row_cells: RowCells = Vec::with_capacity(cells.len());
-                        let mut timestamps: Vec<(String, i64)> = Vec::with_capacity(cells.len());
-                        for c in cells {
-                            // Drop cell tombstones: a deleted column is absent.
-                            if matches!(c.value, Value::Tombstone(_)) {
-                                continue;
-                            }
-                            timestamps.push((c.column.clone(), c.timestamp));
-                            row_cells.push((Arc::from(c.column.as_str()), c.value));
-                        }
-                        if !row_cells.is_empty() {
-                            out.push((key.key.clone(), ScanRow::Row(row_cells), timestamps));
-                        }
-                    }
-                    // Row tombstones suppress the row entirely (no emission).
-                }
-            }
-            Ok(out)
-        })
-        .await
-        .map_err(|e| {
-            crate::Error::Storage(format!("cross-generation metadata merge task: {e}"))
-        })??;
-
-        // Attach per-cell metadata: WRITETIME from the merge winner, TTL recovered
-        // from the reader lookup only when its timestamp matches the winner.
-        let mut results: Vec<(RowKey, ScanRow, HashMap<String, CellWriteMetadata>)> =
-            Vec::with_capacity(merged_rows.len());
-        for (key_bytes, value, timestamps) in merged_rows {
-            let mut meta_map: HashMap<String, CellWriteMetadata> =
-                HashMap::with_capacity(timestamps.len());
-            for (column, write_ts) in timestamps {
-                let expiration = ttl_lookup
-                    .get(&(key_bytes.clone(), column.clone()))
-                    .filter(|m| m.write_timestamp_micros == write_ts)
-                    .and_then(|m| m.expiration.clone());
-                meta_map.insert(
-                    column,
-                    CellWriteMetadata {
-                        write_timestamp_micros: write_ts,
-                        expiration,
-                    },
-                );
-            }
-            results.push((RowKey(key_bytes), value, meta_map));
-        }
-
-        // Match the plain-scan contract: stable TOKEN-order sort (issue #1580),
-        // not a raw-key-byte sort, then apply LIMIT. The metadata payload rides
-        // along in the tuple's tail, which `sort_by_token_order` orders by
-        // (token, key) — identical ordering to the plain merge path.
-        scan_merge::sort_by_token_order(&mut results, limit, |(k, _, _)| k);
-        Ok(results)
-    }
-
     /// Scan a table and return per-cell write metadata alongside row values.
     ///
     /// Used when `ProjectionFlags::include_cell_metadata` is set (issue #693 — the
@@ -1855,15 +1595,15 @@ impl SSTableManager {
         #[cfg(feature = "write-support")]
         if reader_list.len() > 1 {
             if let Some(schema) = schema {
-                match self
-                    .merge_generations_for_read_with_metadata(
-                        &reader_list,
-                        schema,
-                        start_key,
-                        end_key,
-                        limit,
-                    )
-                    .await
+                match generation_merge::merge_generations_for_read_with_metadata(
+                    &reader_list,
+                    schema,
+                    start_key,
+                    end_key,
+                    limit,
+                    None,
+                )
+                .await
                 {
                     Ok(merged) => return Ok(merged),
                     Err(e) => {
@@ -2000,20 +1740,28 @@ impl SSTableManager {
     /// row/cell tombstone in a newer generation suppresses only its own
     /// generation's copy — so a pure key-ordered merge would emit overwritten
     /// rows twice and resurrect rows deleted in a later generation. `scan` avoids
-    /// this by routing the multi-generation case through
-    /// [`merge_generations_for_read`](Self::merge_generations_for_read) (the same
-    /// LWW + tombstone-shadowing k-way merge compaction uses); this streaming path
-    /// must reconcile identically or `execute()` and `execute_streaming()` diverge.
+    /// this by routing the multi-generation case through the authoritative
+    /// `KWayMerger` (the same LWW + tombstone-shadowing k-way merge compaction
+    /// uses); this streaming path must reconcile identically or `execute()` and
+    /// `execute_streaming()` diverge.
     ///
-    /// So, mirroring the `tombstones`-variant `scan_stream` (which delegates
-    /// wholesale to the materializing `scan`), the multi-generation case here
-    /// materializes the reconciled rows via `merge_generations_for_read` and
-    /// forwards them through the same bounded channel. This trades the O(rows)
-    /// streaming memory win for cross-generation correctness; a fully-streaming,
-    /// generation-aware merge (preserving the bounded-memory property across
-    /// generations) is a larger follow-up. The single-generation /
-    /// no-schema / no-`write-support` cases keep the lazy streaming merge, which
-    /// already matches `scan`'s concat path exactly and preserves LIMIT/backpressure.
+    /// # Streaming the multi-generation merge (Issue #1579 / D3)
+    ///
+    /// The multi-generation case runs
+    /// [`generation_merge::stream_generations_for_read`], which drives that same
+    /// `KWayMerger` on a blocking task and feeds each stepped partition's live
+    /// rows STRAIGHT into the bounded channel via `blocking_send` (backpressure
+    /// preserved) — instead of collecting the ENTIRE reconciled table, sorting it,
+    /// and only then dribbling it (the pre-D3 behaviour). Live heap is therefore
+    /// O(one partition + channel), and time-to-first-row is O(first partition),
+    /// not O(full merge). The merger already emits partitions in `(token, key)`
+    /// order, byte-identical to `scan`'s `sort_by_token_order`, so the emitted
+    /// order is unchanged (issue #1579 ordering guardrail). On a merger
+    /// CONSTRUCTION error the driver reports back so this path FALLS BACK to the
+    /// lazy per-reader streaming merge, mirroring `scan`'s fall-back-to-concat. The
+    /// single-generation / no-schema / no-`write-support` cases keep the lazy
+    /// streaming merge, which already matches `scan`'s concat path exactly and
+    /// preserves LIMIT/backpressure.
     #[cfg(not(feature = "tombstones"))]
     pub async fn scan_stream(
         &self,
@@ -2036,34 +1784,26 @@ impl SSTableManager {
         #[cfg(feature = "write-support")]
         if readers.len() > 1 {
             if let Some(schema) = schema {
-                match self
-                    .merge_generations_for_read(&readers, schema, start_key, end_key, None)
-                    .await
+                match generation_merge::stream_generations_for_read(
+                    &readers,
+                    schema,
+                    start_key,
+                    end_key,
+                    buffer_size,
+                )
+                .await
                 {
-                    Ok(merged) => {
+                    Ok(rx) => {
                         log::debug!(
-                            "SSTableManager::scan_stream - cross-generation merge produced {} rows \
-                             (materialized for streaming)",
-                            merged.len()
+                            "SSTableManager::scan_stream - cross-generation merge streaming \
+                             (O(window), not materialized)"
                         );
-                        // Issue #1579 (D3): the eager path holds the WHOLE reconciled
-                        // table resident before dribbling — record that as the resident
-                        // high-water mark so the memory guard observes O(table).
-                        stream_merge_probe::record_resident(merged.len() as u64);
-                        let (tx, rx) = tokio::sync::mpsc::channel(buffer_size.max(1));
-                        tokio::spawn(async move {
-                            for entry in merged {
-                                if tx.send(Ok(entry)).await.is_err() {
-                                    break; // consumer dropped
-                                }
-                            }
-                        });
                         return Ok(rx);
                     }
                     Err(e) => {
-                        // Never fail a read because the merge path hit an
-                        // unsupported format; fall back to the lazy streaming
-                        // merge, matching `scan`'s fall-back-to-concatenation.
+                        // Never fail a read because the merge could not be
+                        // constructed (unsupported format); fall back to the lazy
+                        // streaming merge, matching `scan`'s fall-back-to-concatenation.
                         log::warn!(
                             "SSTableManager::scan_stream - cross-generation merge failed for '{}' ({}); \
                              falling back to lazy per-reader streaming merge",

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1783,6 +1783,11 @@ impl SSTableManager {
         // result.
         #[cfg(feature = "write-support")]
         if readers.len() > 1 {
+            // No schema: cross-generation LWW/tombstone reconciliation needs the
+            // schema to drive the KWayMerger, so this deliberately falls through to
+            // the lazy per-reader token-merge below — matching `scan`'s identical
+            // no-schema fallback (both accept the documented Issue #883 concat
+            // limitation rather than reconciling without a schema).
             if let Some(schema) = schema {
                 match generation_merge::stream_generations_for_read(
                     &readers,
@@ -1804,6 +1809,23 @@ impl SSTableManager {
                         // Never fail a read because the merge could not be
                         // constructed (unsupported format); fall back to the lazy
                         // streaming merge, matching `scan`'s fall-back-to-concatenation.
+                        //
+                        // Error-path asymmetry, intentional (issue #1579): this `Err`
+                        // is ONLY the merger-CONSTRUCTION failure (`KWayMerger::new`,
+                        // signalled back before any row is streamed), so falling back
+                        // here can never emit a partially-merged, mis-reconciled
+                        // result — the streaming task has not sent anything yet. A
+                        // `step()` error occurring MID-merge (after some partitions
+                        // were already streamed to the caller) is NOT retried here;
+                        // it is delivered downstream as an `Err` item on the output
+                        // channel (see `stream_generations_for_read`), ending the
+                        // stream at that point. That is deliberately SAFER than the
+                        // materializing `scan`'s fallback, which — if it could fail
+                        // partway through populating its `Vec` — would have no way to
+                        // signal "these rows are reconciled, the rest are not"; the
+                        // streaming channel's `Err` item gives the caller an honest,
+                        // unambiguous cutoff instead of silently returning a
+                        // half-reconciled table.
                         log::warn!(
                             "SSTableManager::scan_stream - cross-generation merge failed for '{}' ({}); \
                              falling back to lazy per-reader streaming merge",

--- a/cqlite-core/src/storage/sstable/stream_merge_probe.rs
+++ b/cqlite-core/src/storage/sstable/stream_merge_probe.rs
@@ -1,0 +1,94 @@
+//! Cfg-gated multi-generation streaming-merge resident-rows probe (issue #1579,
+//! Epic D / D3).
+//!
+//! # Why this exists
+//!
+//! D3 makes `scan_stream` over more than one SSTable generation feed each
+//! reconciled partition from the k-way merger STRAIGHT into the bounded output
+//! channel, instead of collecting the ENTIRE reconciled table into a `Vec`,
+//! sorting it, and only then dribbling it down the channel. A correct answer
+//! never proves *how much memory* the merge held resident — the same rows come
+//! out either way. This probe makes the peak resident set observable so the
+//! O(window) claim is pinned the no-heuristics way: observe the *work* (rows the
+//! streaming producer held resident at once), not just the result.
+//!
+//! # The counter
+//!
+//! - [`record_resident`] raises a process-global high-water mark to `n` — the
+//!   number of rows the streaming producer had materialized-but-not-yet-drained
+//!   at one instant. The streaming driver reports each stepped partition's row
+//!   count (its resident window is one partition at a time). The pre-D3 eager
+//!   path reported `merged.len()` — the whole reconciled table — so the peak was
+//!   proportional to the row count and the D3 memory guard
+//!   (`peak_resident` FLAT across fixture sizes) flips red without the streaming
+//!   rework.
+//!
+//! # Zero overhead in release (same pattern as [`crate::query::agg_stream_probe`])
+//!
+//! [`record_resident`] is an **unconditional** `#[inline(always)]` public
+//! function; its body is `#[cfg(any(test, feature = "work-counters"))]`. In a
+//! default/release build (no `work-counters`, no `cfg(test)`) the body is empty
+//! and optimizes away — no atomic is even linked. The getter + [`reset`] are
+//! `#[cfg(any(test, feature = "work-counters"))]`: in-crate unit tests reach them
+//! via the `test` cfg; integration tests in `tests/` enable the `work-counters`
+//! feature (they compile the lib WITHOUT its `test` cfg).
+
+#[cfg(any(test, feature = "work-counters"))]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process-global high-water mark of rows the streaming multi-generation merge
+/// held resident at one instant since the last [`reset`] (test/feature builds
+/// only).
+#[cfg(any(test, feature = "work-counters"))]
+static PEAK_RESIDENT: AtomicU64 = AtomicU64::new(0);
+
+/// Record that the streaming multi-generation merge held `n` rows resident at
+/// one instant, raising the process-global high-water mark. Called
+/// unconditionally by the streaming merge driver; the body compiles to a no-op
+/// in a release build.
+#[inline(always)]
+pub fn record_resident(n: u64) {
+    #[cfg(any(test, feature = "work-counters"))]
+    PEAK_RESIDENT.fetch_max(n, Ordering::Relaxed);
+    #[cfg(not(any(test, feature = "work-counters")))]
+    let _ = n;
+}
+
+/// Peak resident rows the streaming multi-generation merge held at one instant
+/// since the last [`reset`]. Streaming holds one partition at a time, so this is
+/// FLAT across fixture sizes; the pre-D3 eager path reported the whole table.
+#[cfg(any(test, feature = "work-counters"))]
+pub fn peak_resident() -> u64 {
+    PEAK_RESIDENT.load(Ordering::Relaxed)
+}
+
+/// Clear the process-global high-water mark. Integration tests call this before a
+/// measured stream so a stale value cannot satisfy a later assertion; because the
+/// global is shared, callers serialize on the shared test mutex (the counter-test
+/// convention).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn reset() {
+    PEAK_RESIDENT.store(0, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // Exercises the max/get/reset contract on the process-global. Serialized so it
+    // never overlaps another test mutating the same global.
+    #[test]
+    #[serial]
+    fn peak_resident_high_water_and_reset() {
+        reset();
+        assert_eq!(peak_resident(), 0);
+        record_resident(5);
+        record_resident(3); // lower value does not lower the high-water mark
+        assert_eq!(peak_resident(), 5);
+        record_resident(9);
+        assert_eq!(peak_resident(), 9);
+        reset();
+        assert_eq!(peak_resident(), 0);
+    }
+}

--- a/cqlite-core/tests/issue_1579_streaming_multigen_memory.rs
+++ b/cqlite-core/tests/issue_1579_streaming_multigen_memory.rs
@@ -122,7 +122,9 @@ async fn open_two_gen(n: i32) -> (Database, TempDir) {
                     .expect("write g2 overwrite");
             }
             for id in (0..n).step_by(7) {
-                engine.write(delete_mutation(id, 300)).expect("write g2 del");
+                engine
+                    .write(delete_mutation(id, 300))
+                    .expect("write g2 del");
             }
             rt.block_on(engine.flush())
                 .expect("flush g2")

--- a/cqlite-core/tests/issue_1579_streaming_multigen_memory.rs
+++ b/cqlite-core/tests/issue_1579_streaming_multigen_memory.rs
@@ -1,0 +1,203 @@
+//! Issue #1579 (Epic D / D3): streaming the multi-generation merge must hold
+//! only O(window) rows resident — one reconciled partition at a time — NOT
+//! collect the whole reconciled table before emitting.
+//!
+//! This is the memory guard. It uses the cfg-gated streaming-merge probe
+//! (`cqlite_core::storage::sstable::stream_merge_probe`) to observe the PEAK
+//! number of rows the streaming producer held resident at one instant — the
+//! no-heuristics way to prove O(window): observe the *work*, not just the
+//! (identical) row set.
+//!
+//! On `main`/pre-D3 `scan_stream` over >1 generation collected the ENTIRE
+//! reconciled result into a `Vec`, sorted it, and only then dribbled it — so the
+//! resident high-water mark was `merged.len()`, proportional to the table, and
+//! this guard flips red as the fixture grows. After D3 the driver feeds each
+//! stepped partition straight into the channel, so the peak is one partition's
+//! width — FLAT between a small and a large fixture, and O(1) for single-row
+//! partitions.
+//!
+//! The counter getter + reset live behind the `work-counters` feature; the
+//! counter is a shared process-global, so every test here serializes on a shared
+//! mutex.
+//!
+//! Run:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine,work-counters \
+//!     --test issue_1579_streaming_multigen_memory
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::sstable::stream_merge_probe;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database};
+use serial_test::serial;
+use tempfile::TempDir;
+
+const KS: &str = "stream_mem_ks";
+const TBL: &str = "rows";
+
+fn schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{TBL} (\n  id int PRIMARY KEY,\n  v int\n);\n")
+}
+
+fn write_mutation(id: i32, v: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "v".to_string(),
+        value: Value::Integer(v),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn delete_mutation(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    Mutation::new(
+        TableId::new(KS, TBL),
+        pk,
+        None,
+        vec![CellOperation::DeleteRow],
+        ts,
+        None,
+    )
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let n = e.file_name();
+            let n = n.to_string_lossy();
+            n.ends_with("-big-Data.db") || n.ends_with("-Data.db")
+        })
+        .count()
+}
+
+/// Build a TWO-generation fixture of `n` single-row partitions. gen2 overwrites
+/// every 5th partition and deletes every 7th (so reconciliation — not mere
+/// concatenation — runs), leaving two Data.db files on disk.
+async fn open_two_gen(n: i32) -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, schema_cql()).expect("write schema file");
+
+    {
+        let data_dir = data_dir.clone();
+        let wal_dir = wal_dir.clone();
+        tokio::task::spawn_blocking(move || {
+            use cqlite_core::schema::parse_cql_schema;
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime");
+            let schema = parse_cql_schema(&schema_cql()).expect("parse schema");
+            let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+            let mut engine = WriteEngine::new(config).expect("engine");
+
+            // gen1: n rows.
+            for id in 0..n {
+                engine.write(write_mutation(id, id, 100)).expect("write g1");
+            }
+            rt.block_on(engine.flush())
+                .expect("flush g1")
+                .expect("g1 must produce an SSTable");
+
+            // gen2: overwrites + deletes across generations.
+            for id in (0..n).step_by(5) {
+                engine
+                    .write(write_mutation(id, id * 2, 200))
+                    .expect("write g2 overwrite");
+            }
+            for id in (0..n).step_by(7) {
+                engine.write(delete_mutation(id, 300)).expect("write g2 del");
+            }
+            rt.block_on(engine.flush())
+                .expect("flush g2")
+                .expect("g2 must produce an SSTable");
+            rt.block_on(engine.close()).expect("close");
+
+            assert_eq!(
+                count_data_files(&data_dir.join(KS).join(TBL)),
+                2,
+                "fixture must produce exactly 2 generations (no compaction)"
+            );
+        })
+        .await
+        .expect("fixture build task");
+    }
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest fixture");
+    (result.database, temp_dir)
+}
+
+/// Drain the whole stream (buffer_size = 1 to force per-row backpressure so the
+/// producer cannot race ahead and hide its resident window) and return the peak
+/// resident rows the streaming merge held.
+async fn stream_peak_resident(db: &Database) -> u64 {
+    stream_merge_probe::reset();
+    let config = StreamingConfig {
+        buffer_size: 1,
+        ..StreamingConfig::default()
+    };
+    let mut iter = db
+        .execute_streaming(&format!("SELECT * FROM {KS}.{TBL}"), config)
+        .await
+        .expect("execute_streaming");
+    let mut count = 0u64;
+    while let Some(row) = iter.next_async().await {
+        row.expect("streamed row Ok");
+        count += 1;
+    }
+    assert!(count > 0, "fixture must yield rows");
+    stream_merge_probe::peak_resident()
+}
+
+/// Streaming a multi-generation table holds O(window) rows resident: the peak is
+/// FLAT across a 40x size difference and O(1) in absolute terms (single-row
+/// partitions ⇒ one row at a time). On `main`/pre-D3 the eager collect+sort held
+/// the WHOLE table, so the peak was proportional to row count.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn streaming_multigen_merge_is_o_window() {
+    let (small_db, _s) = open_two_gen(40).await;
+    let (large_db, _l) = open_two_gen(1600).await;
+
+    let small_peak = stream_peak_resident(&small_db).await;
+    let large_peak = stream_peak_resident(&large_db).await;
+
+    // Flat across a 40x size difference — the discriminating property. On `main`
+    // this is ~40 vs ~1600 (proportional to rows); after D3 it is 1 vs 1.
+    assert_eq!(
+        small_peak, large_peak,
+        "Issue #1579: streaming multi-generation merge peak resident rows must be FLAT \
+         across fixture sizes (small={small_peak}, large={large_peak}); a size-proportional \
+         peak means the whole reconciled table was materialized before streaming"
+    );
+    // And O(1) in absolute terms (one single-row partition resident at a time).
+    assert!(
+        large_peak <= 1,
+        "Issue #1579: streaming 1600 single-row partitions must hold O(1) rows resident, \
+         got {large_peak}"
+    );
+}

--- a/cqlite-core/tests/issue_1579_streaming_multigen_order.rs
+++ b/cqlite-core/tests/issue_1579_streaming_multigen_order.rs
@@ -160,7 +160,10 @@ async fn open_db(data_dir: std::path::PathBuf, schema_path: std::path::PathBuf) 
 /// The ordered comparison key: `(token, raw key bytes)` — exactly what
 /// `sort_by_token_order` orders by.
 fn order_key(key: &RowKey) -> (i64, Vec<u8>) {
-    (cassandra_murmur3_token(key.as_bytes()), key.as_bytes().to_vec())
+    (
+        cassandra_murmur3_token(key.as_bytes()),
+        key.as_bytes().to_vec(),
+    )
 }
 
 /// Collect streamed rows IN EMITTED ORDER (no re-sort) so the raw stream order is
@@ -187,7 +190,10 @@ async fn collect_streaming_ordered(
     rows
 }
 
-async fn collect_execute_sorted(db: &Database, sql: &str) -> Vec<(Vec<u8>, HashMap<Arc<str>, Value>)> {
+async fn collect_execute_sorted(
+    db: &Database,
+    sql: &str,
+) -> Vec<(Vec<u8>, HashMap<Arc<str>, Value>)> {
     let result = db.execute(sql).await.expect("execute should succeed");
     let mut rows: Vec<(Vec<u8>, HashMap<Arc<str>, Value>)> = result
         .rows

--- a/cqlite-core/tests/issue_1579_streaming_multigen_order.rs
+++ b/cqlite-core/tests/issue_1579_streaming_multigen_order.rs
@@ -1,0 +1,308 @@
+//! Issue #1579 (Epic D / D3): streaming the multi-generation merge must emit
+//! rows in the SAME order the pre-D3 collect+sort path emitted — Cassandra token
+//! order `(murmur3_token(key), key)`.
+//!
+//! ## What D3 changes
+//!
+//! Pre-D3, `SSTableManager::scan_stream` over >1 generation collected the ENTIRE
+//! reconciled result from the `KWayMerger`, ran `sort_by_token_order`, and only
+//! then dribbled it down the channel. D3 feeds each stepped partition from the
+//! merger STRAIGHT into the channel. The merger already yields partitions in
+//! `DecoratedKey` order = `(token, key)`, which is byte-identical to what
+//! `sort_by_token_order` produced — so removing the collect+sort must NOT change
+//! the emitted order.
+//!
+//! ## What this test asserts
+//!
+//! Over a genuinely multi-generation fixture (overwrite AND row-tombstone across
+//! generations, several partitions whose token order differs from their numeric
+//! key order), the streamed rows come out in NON-DECREASING `(token, key)` order
+//! — the exact order `sort_by_token_order` yields. This is the byte-identical
+//! ordering guardrail: if the merger's step order ever diverged from token order,
+//! this pins it red. It also cross-checks that the streamed SET+VALUES match the
+//! materializing `execute` path (the reconciliation oracle), so "same order" is
+//! not vacuously satisfied by a wrong/empty result.
+//!
+//! Excluded under `tombstones` (that build's `scan_stream` delegates to the
+//! materializing `scan`, so the streaming order is a non-issue there).
+//!
+//! Run with:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine \
+//!     --test issue_1579_streaming_multigen_order
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine",
+    not(feature = "tombstones")
+))]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
+use cqlite_core::{Config, Database, RowKey};
+use tempfile::TempDir;
+
+const KS: &str = "order_ks";
+const TBL: &str = "items";
+
+fn make_schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{TBL} (\n  id int PRIMARY KEY,\n  name text,\n  score int\n);\n")
+}
+
+fn write_row(id: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![
+        CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        },
+        CellOperation::Write {
+            column: "score".to_string(),
+            value: Value::Integer(score),
+        },
+    ];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn delete_row(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    Mutation::new(
+        TableId::new(KS, TBL),
+        pk,
+        None,
+        vec![CellOperation::DeleteRow],
+        ts,
+        None,
+    )
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let n = e.file_name();
+            let n = n.to_string_lossy();
+            n.ends_with("-big-Data.db") || n.ends_with("-Data.db")
+        })
+        .count()
+}
+
+/// Build a two-generation fixture: gen1 then gen2 flushed with no compaction, so
+/// two Data.db files remain and the read path must reconcile across generations.
+fn build_two_generation_fixture(
+    data_dir: &std::path::Path,
+    wal_dir: &std::path::Path,
+    gen1: &[Mutation],
+    gen2: &[Mutation],
+) {
+    use cqlite_core::schema::parse_cql_schema;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let schema = parse_cql_schema(&make_schema_cql()).expect("parse fixture schema");
+    let config = WriteEngineConfig::new(data_dir.to_path_buf(), wal_dir.to_path_buf(), schema);
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    for m in gen1 {
+        engine.write(m.clone()).expect("write gen1 row");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush gen1")
+        .expect("gen1 produced no SSTable");
+
+    for m in gen2 {
+        engine.write(m.clone()).expect("write gen2 row");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush gen2")
+        .expect("gen2 produced no SSTable");
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    let sstable_dir = data_dir.join(KS).join(TBL);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        2,
+        "fixture must produce exactly 2 generations (no compaction)"
+    );
+}
+
+async fn open_db(data_dir: std::path::PathBuf, schema_path: std::path::PathBuf) -> Database {
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest multi-generation fixture");
+    assert!(
+        result.schema_load_result.schemas_loaded >= 1,
+        "schema must load"
+    );
+    result.database
+}
+
+/// The ordered comparison key: `(token, raw key bytes)` — exactly what
+/// `sort_by_token_order` orders by.
+fn order_key(key: &RowKey) -> (i64, Vec<u8>) {
+    (cassandra_murmur3_token(key.as_bytes()), key.as_bytes().to_vec())
+}
+
+/// Collect streamed rows IN EMITTED ORDER (no re-sort) so the raw stream order is
+/// observable.
+async fn collect_streaming_ordered(
+    db: &Database,
+    sql: &str,
+    buffer_size: usize,
+) -> Vec<(RowKey, HashMap<Arc<str>, Value>)> {
+    let config = StreamingConfig {
+        buffer_size,
+        ..StreamingConfig::default()
+    };
+    let mut iter = db
+        .execute_streaming(sql, config)
+        .await
+        .expect("execute_streaming should succeed");
+
+    let mut rows = Vec::new();
+    while let Some(row) = iter.next_async().await {
+        let row = row.expect("streamed row should be Ok");
+        rows.push((row.key, row.values));
+    }
+    rows
+}
+
+async fn collect_execute_sorted(db: &Database, sql: &str) -> Vec<(Vec<u8>, HashMap<Arc<str>, Value>)> {
+    let result = db.execute(sql).await.expect("execute should succeed");
+    let mut rows: Vec<(Vec<u8>, HashMap<Arc<str>, Value>)> = result
+        .rows
+        .into_iter()
+        .map(|r| (r.key.as_bytes().to_vec(), r.values))
+        .collect();
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    rows
+}
+
+/// The gen1/gen2 mutation split shared by the assertions below. Several
+/// partitions (ids 1..=8) whose murmur3 token order differs from numeric order,
+/// with a cross-generation OVERWRITE (id=3) and a cross-generation row-TOMBSTONE
+/// (id=6) so reconciliation is genuinely exercised, not just concatenation.
+fn gen1() -> Vec<Mutation> {
+    (1..=8)
+        .map(|id| write_row(id, &format!("n{id}-v1"), id * 10, 100))
+        .collect()
+}
+
+fn gen2() -> Vec<Mutation> {
+    vec![
+        write_row(3, "n3-v2", 999, 200), // overwrite id=3 (newer ts wins)
+        delete_row(6, 300),              // row-tombstone id=6 (suppressed)
+        write_row(9, "n9-v2", 90, 200),  // brand-new partition id=9
+    ]
+}
+
+async fn open_fixture_db() -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, make_schema_cql()).expect("write schema file");
+
+    {
+        let data_dir = data_dir.clone();
+        let wal_dir = wal_dir.clone();
+        tokio::task::spawn_blocking(move || {
+            build_two_generation_fixture(&data_dir, &wal_dir, &gen1(), &gen2())
+        })
+        .await
+        .expect("fixture build task");
+    }
+
+    let db = open_db(data_dir, schema_path).await;
+    (db, temp_dir)
+}
+
+/// The streamed multi-generation rows come out in non-decreasing `(token, key)`
+/// order — byte-identical to the pre-D3 `sort_by_token_order` emission order —
+/// across buffer sizes (including `buffer_size = 1`, per-row backpressure).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streamed_multigen_rows_are_in_token_order() {
+    let (db, temp_dir) = open_fixture_db().await;
+    let sql = format!("SELECT * FROM {KS}.{TBL}");
+
+    for buffer_size in [1usize, 4, 1024] {
+        let streamed = collect_streaming_ordered(&db, &sql, buffer_size).await;
+
+        // Reconciliation sanity: id=3 overwritten (one row), id=6 tombstoned
+        // (absent), id=9 added ⇒ 8 live partitions (1,2,3,4,5,7,8,9).
+        assert_eq!(
+            streamed.len(),
+            8,
+            "Issue #1579: expected 8 reconciled rows (buffer_size={buffer_size}), got {}",
+            streamed.len()
+        );
+
+        // The core guardrail: emitted order is non-decreasing (token, key).
+        for pair in streamed.windows(2) {
+            let a = order_key(&pair[0].0);
+            let b = order_key(&pair[1].0);
+            assert!(
+                a <= b,
+                "Issue #1579: streamed rows out of token order (buffer_size={buffer_size}): \
+                 {a:?} then {b:?} — the streaming merge must emit in the same \
+                 (token, key) order the pre-D3 collect+sort path produced"
+            );
+        }
+    }
+
+    drop(temp_dir);
+}
+
+/// The streamed SET+VALUES equal the materializing `execute` path — the
+/// reconciliation oracle — so the token-order assertion above is not vacuously
+/// satisfied by a wrong or empty result. (Order-independent: both sides sorted by
+/// raw key before comparison; the raw stream ORDER is pinned by the test above.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streamed_multigen_rows_match_materializing_execute() {
+    let (db, temp_dir) = open_fixture_db().await;
+    let sql = format!("SELECT * FROM {KS}.{TBL}");
+
+    let expected = collect_execute_sorted(&db, &sql).await;
+
+    for buffer_size in [1usize, 4, 1024] {
+        let mut streamed: Vec<(Vec<u8>, HashMap<Arc<str>, Value>)> =
+            collect_streaming_ordered(&db, &sql, buffer_size)
+                .await
+                .into_iter()
+                .map(|(k, v)| (k.as_bytes().to_vec(), v))
+                .collect();
+        streamed.sort_by(|a, b| a.0.cmp(&b.0));
+
+        assert_eq!(
+            streamed.len(),
+            expected.len(),
+            "Issue #1579: streamed row count (buffer_size={buffer_size}) diverged from execute"
+        );
+        for (i, (got, want)) in streamed.iter().zip(expected.iter()).enumerate() {
+            assert_eq!(got.0, want.0, "Issue #1579: row {i} key mismatch");
+            assert_eq!(got.1, want.1, "Issue #1579: row {i} value mismatch");
+        }
+    }
+
+    drop(temp_dir);
+}


### PR DESCRIPTION
Closes #1579 (D3, epic D #1516 — 2026-07 read-path audit).

## What
`scan_stream` on a multi-generation table no longer collects + sorts the entire reconciled result before emitting:
- `storage/sstable/generation_merge.rs` (NEW): three drivers over ONE reconciliation kernel (`KWayMerger::step()`) — the D3 streaming driver (`spawn_blocking` + `blocking_send` per stepped partition into the bounded channel, oneshot for construction-failure fallback), plus the two materializing drivers moved verbatim (+`target_key`).
- `storage/sstable/mod.rs`: −255 lines (campsite split); multi-gen `scan_stream` branch → streaming driver; multi-candidate point reads pass `target_key` and stop decode-everything-then-retain (safe partial — see follow-up).
- `stream_merge_probe.rs` (NEW): cfg-gated resident-rows high-water probe, zero release overhead.

## Guardrails held
Tombstone/overwrite reconciliation untouched (lives in KWayMerger); bounded channels + fallback on unsupported format preserved.

## Evidence
- Memory: RED on eager path (peak resident 34 vs 1371, proportional to table) → GREEN streaming (1 vs 1, flat across a 40× fixture).
- Ordering: byte-identical to the old collect+sort — merger emits `(token, key)` order using the same murmur3 token fn the sort used; pinned by a non-decreasing-order assert + set/value parity vs the materializing `execute` oracle.
- Regression suites green: issue_957 (×3), issue_883/885 cross-gen merge, issue_958, issue_962, issue_694/1535 WRITETIME/TTL.
- Lite PASS @ `1140b2de` (also clippy-clean under tombstones/write-support/minimal feature configs).
- Roborev + rust-reviewer in flight; FULL gate queued (serial) — SUMMARY posted before merge.