### PR TITLE
perf(#1649): L2 — zero-clone BTI DFS: reusable path buffer + visitor (O(N·D) key copies → O(results))

### DIFF
--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -17,7 +17,8 @@ pub use node::{
 pub use parser::{
     decode_bti_partition_payload, encode_clustering_bound_oss50,
     encode_clustering_bound_oss50_with_order, encode_partition_key_for_bti_trie,
-    iterate_partitions_in_bti_file, iterate_rows_for_partition, iterate_rows_in_bti_file,
+    iterate_partition_locations_in_bti_file, iterate_partitions_in_bti_file,
+    iterate_rows_for_partition, iterate_rows_in_bti_file,
     iterate_rows_in_bti_trie, lookup_partition_in_bti_file, lookup_raw_key_in_bti_partitions_db,
     resolve_rows_db_entry, select_row_index_blocks_for_range, BtiHeader, BtiIndexStats,
     BtiPartitionLocation, BtiRowIndexEntry, BtiRowIndexEntryWithKey, BtiRowIndexHeader,

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -18,11 +18,11 @@ pub use parser::{
     decode_bti_partition_payload, encode_clustering_bound_oss50,
     encode_clustering_bound_oss50_with_order, encode_partition_key_for_bti_trie,
     iterate_partition_locations_in_bti_file, iterate_partitions_in_bti_file,
-    iterate_rows_for_partition, iterate_rows_in_bti_file,
-    iterate_rows_in_bti_trie, lookup_partition_in_bti_file, lookup_raw_key_in_bti_partitions_db,
-    resolve_rows_db_entry, select_row_index_blocks_for_range, BtiHeader, BtiIndexStats,
-    BtiPartitionLocation, BtiRowIndexEntry, BtiRowIndexEntryWithKey, BtiRowIndexHeader,
-    PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE, FLAG_OPEN_MARKER,
+    iterate_rows_for_partition, iterate_rows_in_bti_file, iterate_rows_in_bti_trie,
+    lookup_partition_in_bti_file, lookup_raw_key_in_bti_partitions_db, resolve_rows_db_entry,
+    select_row_index_blocks_for_range, BtiHeader, BtiIndexStats, BtiPartitionLocation,
+    BtiRowIndexEntry, BtiRowIndexEntryWithKey, BtiRowIndexHeader, PartitionsParser, RowsParser,
+    FLAG_HAS_HASH_BYTE, FLAG_OPEN_MARKER,
 };
 // Crate-internal zero-copy slice walker (rust-reviewer #1574): consumed only by
 // the SSTable reader, so kept off cqlite-core's public semver surface. It takes a

--- a/cqlite-core/src/storage/sstable/bti/parser/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/mod.rs
@@ -93,4 +93,4 @@ pub(crate) use slice_walk::lookup_partition_in_bti_slice;
 // public semver surface like the slice walker.
 #[cfg(not(feature = "tombstones"))]
 pub(crate) use rows_floor::{rows_floor_block, rows_strict_ceiling_block};
-pub use traversal::iterate_partitions_in_bti_file;
+pub use traversal::{iterate_partition_locations_in_bti_file, iterate_partitions_in_bti_file};

--- a/cqlite-core/src/storage/sstable/bti/parser/traversal.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/traversal.rs
@@ -116,8 +116,17 @@ pub(super) fn ordered_children(node: &BtiNode) -> Vec<(u8, usize)> {
 }
 
 /// Generic in-order DFS over a BTI trie, decoding each node payload with
-/// `decode_payload` and pushing `(reconstructed_key, decoded_payload)` onto the
-/// result Vec in byte-comparable order.
+/// `decode_payload` and invoking `visit(&reconstructed_key, payload)` in
+/// byte-comparable order — the key is handed to the visitor as a **borrowed
+/// slice** into the single reusable path buffer, so nothing is copied per node.
+///
+/// This is the zero-clone core (issue #1649 / L2): a SINGLE mutable `path`
+/// accumulates the transition bytes from the root to the current node, and the
+/// visitor sees that borrow directly.  Callers that need an owned key call
+/// `.to_vec()` inside their visitor (paying **per emitted result**, never per
+/// child edge — [`dfs_collect_in_order`]); offset-only callers (e.g. the
+/// next-partition seek-bound resolver) drop the key and allocate **nothing**
+/// per node ([`dfs_collect_partition_locations`]).
 ///
 /// The traversal is iterative (explicit stack), bounds-checks every offset, and
 /// enforces a **visited-offset guard** plus three independent limits so corrupt or
@@ -153,21 +162,24 @@ pub(super) fn ordered_children(node: &BtiNode) -> Vec<(u8, usize)> {
 ///
 /// Each guard carries a distinct error message so corruption modes stay
 /// diagnosable.
-pub(crate) fn dfs_collect_in_order<T, F>(
+pub(crate) fn dfs_visit_in_order<T, F, V>(
     trie_data: &[u8],
     root_offset: usize,
     mut decode_payload: F,
-) -> BtiResult<Vec<(Vec<u8>, T)>>
+    mut visit: V,
+) -> BtiResult<()>
 where
     F: FnMut(&[u8], usize) -> BtiResult<Option<T>>,
+    V: FnMut(&[u8], T),
 {
     // Op-based iterative DFS.  A SINGLE mutable `path` accumulates the transition
     // bytes from the root down to the current node: `Enter` pushes a node's
-    // transition byte (and schedules the matching `Pop`), `Pop` backtracks it.  We
-    // clone `path` ONLY when emitting a payload (inherent to the owned return type,
-    // O(result size)), NEVER per child edge — this avoids the O(depth^2) prefix
-    // copying that a per-edge `key_bytes.clone()` incurs on long key paths (a
-    // 70 000-byte legal chain would otherwise copy ~2.45 GB; issue #1629 roborev).
+    // transition byte (and schedules the matching `Pop`), `Pop` backtracks it.  The
+    // visitor sees `path` as a BORROWED slice — we never copy it per node.  Owned-key
+    // callers copy inside the visitor (per emitted result); offset-only callers copy
+    // nothing.  This avoids the O(depth^2) prefix copying that a per-edge
+    // `key_bytes.clone()` incurs on long key paths (a 70 000-byte legal chain would
+    // otherwise copy ~2.45 GB; issue #1629 roborev).
     enum DfsOp {
         Enter {
             node_offset: usize,
@@ -180,7 +192,6 @@ where
         Pop,
     }
 
-    let mut results: Vec<(Vec<u8>, T)> = Vec::new();
     // The single reusable root→current-node transition-byte path.
     let mut path: Vec<u8> = Vec::new();
     let mut stack: Vec<DfsOp> = vec![DfsOp::Enter {
@@ -274,10 +285,11 @@ where
         visited[word] |= bit;
 
         // 1) Emit this node's own payload (if any) BEFORE descending — the key
-        //    terminating here sorts before any continuation.  Clone `path` ONLY
-        //    here (inherent to the owned result type), never per child edge.
+        //    terminating here sorts before any continuation.  The visitor receives
+        //    `path` as a borrowed slice; any copy is the visitor's choice (per
+        //    emitted result), never per child edge.
         if let Some(payload) = decode_payload(trie_data, node_offset)? {
-            results.push((path.clone(), payload));
+            visit(&path, payload);
         }
 
         // 2) Descend children in ASCENDING transition-byte order.  Because the
@@ -296,6 +308,26 @@ where
         }
     }
 
+    Ok(())
+}
+
+/// Thin owned-key wrapper over [`dfs_visit_in_order`]: collects
+/// `(reconstructed_key, decoded_payload)` in byte-comparable order.  Each result
+/// pays ONE `to_vec()` for its key (inherent to the owned return type), never a
+/// per-child-edge copy.  Offset-only callers should use [`dfs_visit_in_order`]
+/// directly (e.g. [`dfs_collect_partition_locations`]) to allocate nothing.
+pub(crate) fn dfs_collect_in_order<T, F>(
+    trie_data: &[u8],
+    root_offset: usize,
+    decode_payload: F,
+) -> BtiResult<Vec<(Vec<u8>, T)>>
+where
+    F: FnMut(&[u8], usize) -> BtiResult<Option<T>>,
+{
+    let mut results: Vec<(Vec<u8>, T)> = Vec::new();
+    dfs_visit_in_order(trie_data, root_offset, decode_payload, |key, payload| {
+        results.push((key.to_vec(), payload));
+    })?;
     Ok(results)
 }
 
@@ -308,6 +340,28 @@ pub(crate) fn dfs_collect_partition_entries(
     dfs_collect_in_order(trie_data, root_offset, |data, off| {
         read_node_payload(data, off)
     })
+}
+
+/// Offset-only counterpart to [`dfs_collect_partition_entries`]: enumerate every
+/// partition [`BtiPartitionLocation`] in byte-comparable order WITHOUT
+/// materializing the reconstructed token keys.
+///
+/// The reconstructed key is handed to the visitor as a borrowed slice and
+/// dropped, so a caller that needs only the locations (e.g. the next-partition
+/// seek-bound resolver in `partition_successor`) pays **zero** per-entry key-`Vec`
+/// allocations — only the single `Vec<BtiPartitionLocation>` grows (issue #1649).
+pub(crate) fn dfs_collect_partition_locations(
+    trie_data: &[u8],
+    root_offset: usize,
+) -> BtiResult<Vec<BtiPartitionLocation>> {
+    let mut locations: Vec<BtiPartitionLocation> = Vec::new();
+    dfs_visit_in_order(
+        trie_data,
+        root_offset,
+        |data, off| read_node_payload(data, off),
+        |_key, location| locations.push(location),
+    )?;
+    Ok(locations)
 }
 
 /// Enumerate **all** partitions in a real Cassandra 5.0 `Partitions.db` BTI file
@@ -329,6 +383,25 @@ pub fn iterate_partitions_in_bti_file<R: Read + Seek>(
     }
     let (trie_data, root_offset) = load_bti_trie_via_footer(reader)?;
     dfs_collect_partition_entries(&trie_data, root_offset)
+}
+
+/// Offset-only counterpart to [`iterate_partitions_in_bti_file`]: enumerate every
+/// partition [`BtiPartitionLocation`] in a real Cassandra 5.0 `Partitions.db` BTI
+/// file in byte-comparable order, WITHOUT reconstructing (or allocating) the
+/// token keys (issue #1649 / L2).
+///
+/// Use this when the reconstructed byte-comparable token key is not needed (the
+/// offsets are definitive) — the DFS then performs **zero** per-partition
+/// key-`Vec` allocations. Returns an empty Vec for a `< 8`-byte (e.g. empty) file.
+pub fn iterate_partition_locations_in_bti_file<R: Read + Seek>(
+    reader: &mut R,
+) -> BtiResult<Vec<BtiPartitionLocation>> {
+    let file_size = reader.seek(SeekFrom::End(0))?;
+    if file_size < 8 {
+        return Ok(Vec::new());
+    }
+    let (trie_data, root_offset) = load_bti_trie_via_footer(reader)?;
+    dfs_collect_partition_locations(&trie_data, root_offset)
 }
 
 #[cfg(test)]

--- a/cqlite-core/src/storage/sstable/bti/parser/traversal.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/traversal.rs
@@ -358,7 +358,7 @@ pub(crate) fn dfs_collect_partition_locations(
     dfs_visit_in_order(
         trie_data,
         root_offset,
-        |data, off| read_node_payload(data, off),
+        read_node_payload,
         |_key, location| locations.push(location),
     )?;
     Ok(locations)

--- a/cqlite-core/src/storage/sstable/reader/partition_successor.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_successor.rs
@@ -85,7 +85,7 @@ impl SSTableReader {
     /// [`bti_partition_offsets`]: Self::bti_partition_offsets
     fn bti_partition_offsets(&self) -> Result<&[u64]> {
         use crate::storage::sstable::bti::{
-            iterate_partitions_in_bti_file, resolve_rows_db_entry, BtiPartitionLocation,
+            iterate_partition_locations_in_bti_file, resolve_rows_db_entry, BtiPartitionLocation,
         };
 
         if let Some(cached) = self.bti_partition_offsets.get() {
@@ -104,15 +104,18 @@ impl SSTableReader {
         };
 
         let mut cursor = std::io::Cursor::new(partitions_db.as_slice());
-        let entries = iterate_partitions_in_bti_file(&mut cursor).map_err(|e| {
+        // Offset-only enumeration (issue #1649): we need only the partition
+        // locations here, never the reconstructed token keys, so this path
+        // performs zero per-partition key-`Vec` allocations.
+        let locations = iterate_partition_locations_in_bti_file(&mut cursor).map_err(|e| {
             Error::corruption(format!(
                 "BTI Partitions.db trie enumeration failed while resolving the \
                  next-partition seek bound: {e}"
             ))
         })?;
 
-        let mut offsets = Vec::with_capacity(entries.len());
-        for (_token_key, location) in entries {
+        let mut offsets = Vec::with_capacity(locations.len());
+        for location in locations {
             let off = match location {
                 BtiPartitionLocation::DataOffset(off) => off,
                 BtiPartitionLocation::RowsOffset(rows_offset) => {

--- a/cqlite-core/tests/test_issue_1649_bti_dfs_zero_clone.rs
+++ b/cqlite-core/tests/test_issue_1649_bti_dfs_zero_clone.rs
@@ -219,7 +219,10 @@ fn offset_only_matches_owned_on_real_test_da_fixtures() {
     // counts, so simply excluding overlap with the other test's window suffices.
     let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
-    let Some(root) = std::env::var("CQLITE_DATASETS_ROOT").ok().map(PathBuf::from) else {
+    let Some(root) = std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+    else {
         eprintln!("SKIP: CQLITE_DATASETS_ROOT not set; needs real BTI fixtures");
         return;
     };

--- a/cqlite-core/tests/test_issue_1649_bti_dfs_zero_clone.rs
+++ b/cqlite-core/tests/test_issue_1649_bti_dfs_zero_clone.rs
@@ -1,0 +1,233 @@
+//! Issue #1649 (L2): zero-clone BTI DFS — reusable path buffer + visitor.
+//!
+//! The BTI in-order DFS core ([`dfs_visit_in_order`]) hands each emitted node's
+//! reconstructed key to the visitor as a **borrowed slice** into a single reusable
+//! path buffer. Owned-key callers pay one `to_vec()` **per emitted result**
+//! ([`iterate_partitions_in_bti_file`]); offset-only callers
+//! ([`iterate_partition_locations_in_bti_file`]) drop the key and allocate
+//! **nothing per node**.
+//!
+//! This file installs a process-global counting allocator (its own test binary,
+//! so no parallel test pollutes the count) and proves, over a synthetic 500-leaf
+//! `Partitions.db` trie, that:
+//!
+//!   * the OWNED path allocates ~one key `Vec` per result (O(results)); and
+//!   * the OFFSET-ONLY path allocates a small CONSTANT independent of the leaf
+//!     count (only the trie load, the visited bitset, and log-bounded growth of
+//!     the stack + locations `Vec`).
+//!
+//! It also asserts byte-identical equivalence between the two paths (identical
+//! ordered `BtiPartitionLocation` sequences) on the synthetic trie AND on the
+//! real `test_da` `Partitions.db` fixtures.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use cqlite_core::storage::sstable::bti::{
+    iterate_partition_locations_in_bti_file, iterate_partitions_in_bti_file, BtiPartitionLocation,
+};
+
+/// Counts every allocation (not deallocation) over a tightly scoped window.
+struct CountingAlloc;
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+/// A `Partitions.db` PayloadOnly leaf: `[0x08(payloadBits=8), hash, position]`.
+/// `position = -1` (0xFF) → `DataOffset(0)`; a `PayloadOnly` leaf has no children,
+/// so it contributes ZERO heap allocations to the DFS.
+fn leaf() -> [u8; 3] {
+    [0x08, 0x00, (-1i8) as u8]
+}
+
+/// Build a two-level wide `Partitions.db` trie:
+///   root Sparse16 → 2 mid Sparse16 nodes → `leaves_per_branch` PayloadOnly leaves.
+///
+/// Total nodes = `1 + 2 + 2*leaves_per_branch`; total emitted results =
+/// `2*leaves_per_branch` (only the leaves carry a payload). Returns the complete
+/// in-memory file (trie bytes + 8-byte big-endian root-offset footer).
+///
+/// Sparse16 (ordinal 7) uses 2-byte backward deltas (reach ≤ 65535) so a branch's
+/// far leaves are reachable; the count byte caps a branch at 255 leaves.
+fn build_wide_partitions_db(leaves_per_branch: usize) -> Vec<u8> {
+    assert!(
+        (1..=255).contains(&leaves_per_branch),
+        "Sparse16 count is one byte (1..=255)"
+    );
+
+    let mut trie: Vec<u8> = Vec::new();
+
+    // Emit one branch: `leaves_per_branch` leaves followed by a Sparse16 mid node
+    // pointing back at each. Returns the mid node's absolute offset.
+    let emit_branch = |trie: &mut Vec<u8>| -> usize {
+        let mut leaf_offsets = Vec::with_capacity(leaves_per_branch);
+        for _ in 0..leaves_per_branch {
+            leaf_offsets.push(trie.len());
+            trie.extend_from_slice(&leaf());
+        }
+        let mid_off = trie.len();
+        // Sparse16 header + count.
+        trie.push(0x70);
+        trie.push(leaves_per_branch as u8);
+        // Transition bytes: distinct, ascending 0..leaves_per_branch (≤ 255).
+        for i in 0..leaves_per_branch {
+            trie.push(i as u8);
+        }
+        // Backward 2-byte deltas to each leaf.
+        for &leaf_off in &leaf_offsets {
+            let delta = (mid_off - leaf_off) as u16;
+            trie.extend_from_slice(&delta.to_be_bytes());
+        }
+        mid_off
+    };
+
+    let mid_a = emit_branch(&mut trie);
+    let mid_b = emit_branch(&mut trie);
+
+    // Root Sparse16 with two children (mid_a via 0x01, mid_b via 0x02).
+    let root_off = trie.len();
+    trie.push(0x70);
+    trie.push(0x02);
+    trie.push(0x01);
+    trie.push(0x02);
+    trie.extend_from_slice(&((root_off - mid_a) as u16).to_be_bytes());
+    trie.extend_from_slice(&((root_off - mid_b) as u16).to_be_bytes());
+
+    // 8-byte big-endian root-offset footer.
+    trie.extend_from_slice(&(root_off as u64).to_be_bytes());
+    trie
+}
+
+/// Upper bound on allocations for the OFFSET-ONLY DFS over the synthetic trie:
+/// trie load + visited bitset + a few Sparse `parse`/`ordered_children` Vecs +
+/// log-bounded growth of the DFS stack and the locations Vec. Crucially this does
+/// NOT scale with the 500 leaves. On `main` (no offset-only path, forced through
+/// the owned collector) this window allocates ~one key Vec per leaf (~500+),
+/// blowing this bound — the red→green guard.
+const MAX_OFFSET_ONLY_ALLOCS: usize = 64;
+
+#[test]
+fn offset_only_dfs_allocates_constant_not_per_leaf() {
+    const LEAVES_PER_BRANCH: usize = 250; // 500 leaves, 503 nodes total.
+    const RESULTS: usize = 2 * LEAVES_PER_BRANCH;
+
+    let file = build_wide_partitions_db(LEAVES_PER_BRANCH);
+
+    // ── OWNED path (baseline: O(results) key allocations) ────────────────────
+    // A fresh Cursor is built before each window so only the enumeration allocs
+    // are measured.
+    let mut owned_cursor = Cursor::new(file.clone());
+    let owned_baseline = ALLOCS.load(Ordering::Relaxed);
+    let entries = iterate_partitions_in_bti_file(&mut owned_cursor)
+        .expect("owned Partitions.db traversal must succeed");
+    let owned_allocs = ALLOCS.load(Ordering::Relaxed) - owned_baseline;
+
+    // ── OFFSET-ONLY path (the fix: constant allocations) ─────────────────────
+    let mut offset_cursor = Cursor::new(file);
+    let offset_baseline = ALLOCS.load(Ordering::Relaxed);
+    let locations = iterate_partition_locations_in_bti_file(&mut offset_cursor)
+        .expect("offset-only Partitions.db traversal must succeed");
+    let offset_allocs = ALLOCS.load(Ordering::Relaxed) - offset_baseline;
+    // ─────────────────────────────────────────────────────────────────────────
+
+    assert_eq!(entries.len(), RESULTS, "owned path must emit every leaf");
+    assert_eq!(
+        locations.len(),
+        RESULTS,
+        "offset-only path must emit every leaf"
+    );
+
+    // The owned path pays ~one key `Vec` per result — it scales with the leaf
+    // count. This documents the O(results) baseline the fix improves upon.
+    assert!(
+        owned_allocs >= RESULTS,
+        "owned path is expected to allocate >= {RESULTS} (one key Vec per result); got {owned_allocs}"
+    );
+
+    // The fix: the offset-only path allocates a small CONSTANT, independent of the
+    // 500 leaves. On `main` this is forced through the owned collector and would
+    // allocate ~{RESULTS}+, failing this bound.
+    assert!(
+        offset_allocs <= MAX_OFFSET_ONLY_ALLOCS,
+        "offset-only DFS over {RESULTS} leaves must allocate <= {MAX_OFFSET_ONLY_ALLOCS} \
+         (O(results) key clones regressed); got {offset_allocs}"
+    );
+
+    // The improvement is a large multiple, not a constant-factor tweak.
+    assert!(
+        offset_allocs * 4 < owned_allocs,
+        "offset-only ({offset_allocs}) must be far below owned ({owned_allocs})"
+    );
+
+    // Byte-identical equivalence on the synthetic trie: same ordered locations.
+    let owned_locations: Vec<BtiPartitionLocation> =
+        entries.into_iter().map(|(_key, loc)| loc).collect();
+    assert_eq!(
+        owned_locations, locations,
+        "offset-only and owned DFS must yield identical ordered location sequences"
+    );
+}
+
+/// Byte-identical equivalence on REAL `test_da` `Partitions.db` fixtures: the
+/// offset-only path yields exactly the owned path's ordered locations.
+///
+/// Guarded by `CQLITE_DATASETS_ROOT`; skips cleanly when the binary fixtures are
+/// absent so it never blocks CI running without test data.
+#[test]
+fn offset_only_matches_owned_on_real_test_da_fixtures() {
+    let Some(root) = std::env::var("CQLITE_DATASETS_ROOT").ok().map(PathBuf::from) else {
+        eprintln!("SKIP: CQLITE_DATASETS_ROOT not set; needs real BTI fixtures");
+        return;
+    };
+
+    let rels = [
+        "sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Partitions.db",
+        "sstables/test_da/collection_table-de2c155064e711f19ad401a8c8227b11/da-2-bti-Partitions.db",
+        "sstables/test_da/wide_table-9099a7c06c1811f19864870fb8444786/da-2-bti-Partitions.db",
+    ];
+
+    let mut checked = 0usize;
+    for rel in rels {
+        let path = root.join(rel);
+        let Ok(bytes) = std::fs::read(&path) else {
+            eprintln!("SKIP: BTI fixture not found at {path:?}");
+            continue;
+        };
+
+        let owned = iterate_partitions_in_bti_file(&mut Cursor::new(bytes.clone()))
+            .expect("owned Partitions.db traversal must succeed");
+        let offset_only = iterate_partition_locations_in_bti_file(&mut Cursor::new(bytes))
+            .expect("offset-only Partitions.db traversal must succeed");
+
+        let owned_locations: Vec<BtiPartitionLocation> =
+            owned.into_iter().map(|(_key, loc)| loc).collect();
+        assert_eq!(
+            owned_locations, offset_only,
+            "offset-only and owned DFS must match on {rel}"
+        );
+        assert!(!offset_only.is_empty(), "{rel} must yield >= 1 partition");
+        checked += 1;
+    }
+
+    if checked == 0 {
+        eprintln!("SKIP: no test_da Partitions.db fixtures were present");
+    }
+}

--- a/cqlite-core/tests/test_issue_1649_bti_dfs_zero_clone.rs
+++ b/cqlite-core/tests/test_issue_1649_bti_dfs_zero_clone.rs
@@ -7,9 +7,8 @@
 //! ([`iterate_partition_locations_in_bti_file`]) drop the key and allocate
 //! **nothing per node**.
 //!
-//! This file installs a process-global counting allocator (its own test binary,
-//! so no parallel test pollutes the count) and proves, over a synthetic 500-leaf
-//! `Partitions.db` trie, that:
+//! This file installs a process-global counting allocator and proves, over a
+//! synthetic 500-leaf `Partitions.db` trie, that:
 //!
 //!   * the OWNED path allocates ~one key `Vec` per result (O(results)); and
 //!   * the OFFSET-ONLY path allocates a small CONSTANT independent of the leaf
@@ -19,11 +18,22 @@
 //! It also asserts byte-identical equivalence between the two paths (identical
 //! ordered `BtiPartitionLocation` sequences) on the synthetic trie AND on the
 //! real `test_da` `Partitions.db` fixtures.
+//!
+//! `#[global_allocator]` counts allocations from **every** thread in the
+//! process, not just the current test's. This file has two `#[test]`s, and
+//! under the default multi-threaded test runner they can run concurrently in
+//! the SAME process — so the second test's file I/O / Vec growth could
+//! allocate inside the first test's counting window and inflate
+//! `offset_allocs`, flaking the `<= MAX_OFFSET_ONLY_ALLOCS` bound. `TEST_LOCK`
+//! serializes the two test bodies (each holds it for its FULL body, not just
+//! the counting window) so the measurement is race-free by construction, not
+//! by luck.
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 use cqlite_core::storage::sstable::bti::{
     iterate_partition_locations_in_bti_file, iterate_partitions_in_bti_file, BtiPartitionLocation,
@@ -50,6 +60,12 @@ unsafe impl GlobalAlloc for CountingAlloc {
 
 #[global_allocator]
 static GLOBAL: CountingAlloc = CountingAlloc;
+
+/// Serializes the two `#[test]`s in this file so neither's allocations can
+/// pollute the other's counting window (see the module doc comment). Poisoned
+/// (panicked-while-held) is treated as still-lockable — a prior test's panic
+/// must not spuriously fail an unrelated test via lock poisoning.
+static TEST_LOCK: Mutex<()> = Mutex::new(());
 
 /// A `Partitions.db` PayloadOnly leaf: `[0x08(payloadBits=8), hash, position]`.
 /// `position = -1` (0xFF) → `DataOffset(0)`; a `PayloadOnly` leaf has no children,
@@ -126,6 +142,10 @@ const MAX_OFFSET_ONLY_ALLOCS: usize = 64;
 
 #[test]
 fn offset_only_dfs_allocates_constant_not_per_leaf() {
+    // Hold for the WHOLE body: the counting window below must not race against
+    // the other test in this file (see module doc comment).
+    let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
     const LEAVES_PER_BRANCH: usize = 250; // 500 leaves, 503 nodes total.
     const RESULTS: usize = 2 * LEAVES_PER_BRANCH;
 
@@ -193,6 +213,12 @@ fn offset_only_dfs_allocates_constant_not_per_leaf() {
 /// absent so it never blocks CI running without test data.
 #[test]
 fn offset_only_matches_owned_on_real_test_da_fixtures() {
+    // Hold for the WHOLE body: this test's own allocations (file reads, Vec
+    // growth) must not run concurrently with the other test's counting window
+    // (see module doc comment). This test does not itself measure allocation
+    // counts, so simply excluding overlap with the other test's window suffices.
+    let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
     let Some(root) = std::env::var("CQLITE_DATASETS_ROOT").ok().map(PathBuf::from) else {
         eprintln!("SKIP: CQLITE_DATASETS_ROOT not set; needs real BTI fixtures");
         return;


### PR DESCRIPTION
Closes #1649 (L2, epic #1605 — BTI floor-walks / parser perf audit).

## What
- `bti/parser/traversal.rs`: DFS core split into `dfs_visit_in_order` — visitor `FnMut(&[u8], T)` borrowing the key from ONE reusable path buffer (descend = push edge bytes, backtrack = truncate) — with `dfs_collect_in_order` kept as a thin owned-key wrapper (`.to_vec()` per RESULT, not per node). New offset-only entry point `iterate_partition_locations_in_bti_file` allocates nothing per node.
- `reader/partition_successor.rs`: next-partition seek-bound resolver (already key-blind) migrated to the offset-only path.
- #1629's depth/total-work bounds and #1647's floor-walk untouched; all their tests green.

## Evidence (red-first)
- Counting-allocator test, 503-node synthetic trie: pre-fix offset path = **525 allocs** (FAILS the ≤64 bound) → visitor path = **25 allocs** (constant, doesn't scale with leaf count); owned wrapper = O(results).
- Byte-identical equivalence: owned vs offset-only sequences equal on synthetic + real `test_da` Partitions.db fixtures (3 tables, non-empty).
- Regression green: issue_832 (7), issue_909 (3), traversal/#1629 bounds (12), full bti lib (142).
- Lite PASS @ `67d9c73e`. Roborev + rust-reviewer in flight; full gate queued (serial slot) — SUMMARY posted before merge.

## Noted, out of scope
`ordered_children` still allocates one small Vec per internal node (O(nodes) on deep/narrow tries) — separate optimization touching #1647's shared consumer; described in the issue trail.