### PR TITLE
perf(#1592): F2 — batch the public streaming channel (stop one async wake per row)

### DIFF
--- a/cqlite-core/src/query/executor.rs
+++ b/cqlite-core/src/query/executor.rs
@@ -494,15 +494,20 @@ impl QueryExecutor {
     /// old unbounded `crossbeam` channel that held the entire result set at once.
     #[tracing::instrument(name = "query.table_scan_stream", skip_all)]
     async fn streaming_scan_rows(&self, table: &TableId) -> Result<Vec<QueryRow>> {
+        // Issue #1592: consume the BATCHED streaming surface so the reader wakes
+        // this task once per batch of rows, not once per row (the F2 win). Each
+        // channel item is a `Vec` of entries; flattening it yields the same rows
+        // in the same order as the per-row `scan_stream`.
         let mut scan_stream = self
             .storage
-            .scan_stream(table, None, None, None, TABLE_SCAN_STREAM_BUFFER)
+            .scan_stream_batched(table, None, None, None, TABLE_SCAN_STREAM_BUFFER)
             .await?;
 
         let mut rows = Vec::new();
-        while let Some(item) = scan_stream.recv().await {
-            let (row_key, row_data) = item?;
-            rows.push(self.storage_data_to_query_row(row_data, &row_key)?);
+        while let Some(batch) = scan_stream.recv().await {
+            for (row_key, row_data) in batch? {
+                rows.push(self.storage_data_to_query_row(row_data, &row_key)?);
+            }
         }
         Ok(rows)
     }

--- a/cqlite-core/src/query/select_executor/stream_agg.rs
+++ b/cqlite-core/src/query/select_executor/stream_agg.rs
@@ -157,36 +157,40 @@ impl SelectExecutor {
         let mut accumulators = init_aggregate_accumulators(&agg_plan.aggregates);
         let mut folded_any = false;
 
+        // Issue #1592: fold over the BATCHED streaming surface — one async wake per
+        // batch, not per row. Flattening each batch yields the same rows in the
+        // same order as `scan_stream`, so the aggregate result is unchanged.
         let mut scan_stream = self
             .storage
-            .scan_stream(table, None, None, schema_opt, AGG_FOLD_SCAN_BUFFER)
+            .scan_stream_batched(table, None, None, schema_opt, AGG_FOLD_SCAN_BUFFER)
             .await?;
-        while let Some(item) = scan_stream.recv().await {
-            let (key, value) = item?;
-            context.rows_processed += 1;
-            context.scan_rows += 1;
+        while let Some(batch) = scan_stream.recv().await {
+            for (key, value) in batch? {
+                context.rows_processed += 1;
+                context.scan_rows += 1;
 
-            let Some(row) = build_row_from_scan(key, value, projection, schema_opt) else {
-                continue;
-            };
-            if !evaluate_predicates(&row, predicates)? {
-                continue;
-            }
-            // Apply any residual (non-pushed) WHERE as a per-row filter.
-            let mut keep = true;
-            for filter in &filters {
-                if !self.evaluate_where_expression(filter, &row)? {
-                    keep = false;
-                    break;
+                let Some(row) = build_row_from_scan(key, value, projection, schema_opt) else {
+                    continue;
+                };
+                if !evaluate_predicates(&row, predicates)? {
+                    continue;
                 }
-            }
-            if !keep {
-                continue;
-            }
+                // Apply any residual (non-pushed) WHERE as a per-row filter.
+                let mut keep = true;
+                for filter in &filters {
+                    if !self.evaluate_where_expression(filter, &row)? {
+                        keep = false;
+                        break;
+                    }
+                }
+                if !keep {
+                    continue;
+                }
 
-            folded_any = true;
-            for (i, agg_comp) in agg_plan.aggregates.iter().enumerate() {
-                update_aggregate(&mut accumulators[i], agg_comp, &row);
+                folded_any = true;
+                for (i, agg_comp) in agg_plan.aggregates.iter().enumerate() {
+                    update_aggregate(&mut accumulators[i], agg_comp, &row);
+                }
             }
         }
 

--- a/cqlite-core/src/query/select_executor/streaming.rs
+++ b/cqlite-core/src/query/select_executor/streaming.rs
@@ -234,64 +234,69 @@ impl SelectExecutor {
                     // instead of materializing the full result `Vec`. The reader
                     // parses one entry at a time into this channel, so live heap
                     // stays bounded by `buffer_size` rather than O(result rows).
+                    // Issue #1592: consume the BATCHED streaming surface — one
+                    // async wake per batch, not per row. Flattening each batch
+                    // yields the same rows in the same order as `scan_stream`.
                     let mut scan_stream = storage
-                        .scan_stream(table, None, None, schema_opt, buffer_size)
+                        .scan_stream_batched(table, None, None, schema_opt, buffer_size)
                         .await?;
 
-                    while let Some(item) = scan_stream.recv().await {
-                        let (key, value) = item?;
-                        // Capture the partition-key digest before `key` is moved
-                        // into row construction (only when needed).
-                        let part_sig = per_partition_limit.map(|_| partition_key_digest(&key.0));
-                        let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
-                        else {
-                            continue;
-                        };
+                    while let Some(batch) = scan_stream.recv().await {
+                        for (key, value) in batch? {
+                            // Capture the partition-key digest before `key` is moved
+                            // into row construction (only when needed).
+                            let part_sig =
+                                per_partition_limit.map(|_| partition_key_digest(&key.0));
+                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
+                            else {
+                                continue;
+                            };
 
-                        if !evaluate_predicates(&row, predicates)? {
-                            continue;
-                        }
-
-                        // Apply PER PARTITION LIMIT: cap matching rows per
-                        // partition, before OFFSET/LIMIT (Cassandra semantics).
-                        if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                            // Fast digest pre-check, then EXACT byte confirm so a
-                            // digest collision between DISTINCT partitions never
-                            // shares a counter (issue #1590).
-                            let same = matches!(
-                                &current_partition,
-                                Some((d, bytes))
-                                    if *d == sig && bytes.as_slice() == row.key.0.as_slice()
-                            );
-                            if !same {
-                                // Clone the key bytes ONCE per boundary, not per row.
-                                current_partition = Some((sig, row.key.0.clone()));
-                                partition_count = 0;
-                            }
-                            if partition_count >= cap {
+                            if !evaluate_predicates(&row, predicates)? {
                                 continue;
                             }
-                            partition_count += 1;
-                        }
 
-                        // Apply OFFSET: skip the first `offset_remaining` matches.
-                        if offset_remaining > 0 {
-                            offset_remaining -= 1;
-                            continue;
-                        }
+                            // Apply PER PARTITION LIMIT: cap matching rows per
+                            // partition, before OFFSET/LIMIT (Cassandra semantics).
+                            if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
+                                // Fast digest pre-check, then EXACT byte confirm so a
+                                // digest collision between DISTINCT partitions never
+                                // shares a counter (issue #1590).
+                                let same = matches!(
+                                    &current_partition,
+                                    Some((d, bytes))
+                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                                );
+                                if !same {
+                                    // Clone the key bytes ONCE per boundary, not per row.
+                                    current_partition = Some((sig, row.key.0.clone()));
+                                    partition_count = 0;
+                                }
+                                if partition_count >= cap {
+                                    continue;
+                                }
+                                partition_count += 1;
+                            }
 
-                        // Send row through channel (with backpressure). Consumer drop ends the scan.
-                        if tx.send(Ok(row)).await.is_err() {
-                            return Ok(());
-                        }
-                        sent += 1;
+                            // Apply OFFSET: skip the first `offset_remaining` matches.
+                            if offset_remaining > 0 {
+                                offset_remaining -= 1;
+                                continue;
+                            }
 
-                        // Apply LIMIT: stop scanning once `count` rows have been
-                        // sent. Dropping `scan_stream` here signals the producer
-                        // (via a closed channel) to stop parsing early.
-                        if let Some(count) = limit_count {
-                            if sent >= count {
+                            // Send row through channel (with backpressure). Consumer drop ends the scan.
+                            if tx.send(Ok(row)).await.is_err() {
                                 return Ok(());
+                            }
+                            sent += 1;
+
+                            // Apply LIMIT: stop scanning once `count` rows have been
+                            // sent. Dropping `scan_stream` here signals the producer
+                            // (via a closed channel) to stop parsing early.
+                            if let Some(count) = limit_count {
+                                if sent >= count {
+                                    return Ok(());
+                                }
                             }
                         }
                     }

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -487,6 +487,31 @@ impl StorageEngine {
             .await
     }
 
+    /// Batched streaming scan (issue #1592, Epic F/F2): additive companion to
+    /// [`scan_stream`](Self::scan_stream) that yields a `Vec` BATCH of
+    /// `(RowKey, ScanRow)` entries per channel item instead of one entry, so a
+    /// full-scan consumer is woken once per batch rather than once per row.
+    ///
+    /// Content and order are identical to [`scan_stream`](Self::scan_stream) —
+    /// flattening the batches reproduces the per-row stream exactly. Backpressure
+    /// is preserved (bounded channel). Delegates to
+    /// [`SSTableManager::scan_stream_batched`].
+    ///
+    /// [`SSTableManager::scan_stream_batched`]: sstable::SSTableManager::scan_stream_batched
+    pub async fn scan_stream_batched(
+        &self,
+        table_id: &TableId,
+        start_key: Option<&RowKey>,
+        end_key: Option<&RowKey>,
+        schema: Option<&crate::schema::TableSchema>,
+        buffer_size: usize,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>> {
+        record_table_scan_call();
+        self.sstables
+            .scan_stream_batched(table_id, start_key, end_key, schema, buffer_size)
+            .await
+    }
+
     /// Flush MemTable to SSTable
     ///
     /// NOTE: Write functionality removed in Issue #175 (WAL/MemTable infrastructure deleted).

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1974,17 +1974,15 @@ impl SSTableManager {
         let readers = self.resolve_table_readers(table_id).await;
 
         if readers.len() == 1 {
-            let reader = readers
-                .into_iter()
-                .next()
-                .expect("readers.len() == 1 checked above");
-            return Ok(reader.scan_stream_batched(
-                table_id.clone(),
-                start_key.cloned(),
-                end_key.cloned(),
-                schema.cloned(),
-                buffer_size,
-            ));
+            if let Some(reader) = readers.into_iter().next() {
+                return Ok(reader.scan_stream_batched(
+                    table_id.clone(),
+                    start_key.cloned(),
+                    end_key.cloned(),
+                    schema.cloned(),
+                    buffer_size,
+                ));
+            }
         }
 
         let per_row = self

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -2024,6 +2024,14 @@ impl SSTableManager {
                         }
                     }
                     Err(e) => {
+                        // Flush already-received Ok rows BEFORE surfacing the
+                        // error, to match the per-row `scan_stream` guarantee
+                        // that confirmed rows are delivered ahead of a terminal
+                        // error (issue #1143 / #1592). Dropping them here would
+                        // silently lose up to BATCH_EMIT_ROWS-1 rows.
+                        if !batch.is_empty() {
+                            let _ = tx.send(Ok(std::mem::take(&mut batch))).await;
+                        }
                         let _ = tx.send(Err(e)).await;
                         return;
                     }
@@ -2675,6 +2683,63 @@ mod tests {
         assert_eq!(
             agg.capacity_bytes, expected_capacity,
             "aggregate must sum each distinct reader's key-cache capacity exactly once"
+        );
+    }
+
+    /// Issue #1592 (roborev Finding 1): a MID-STREAM error must NOT drop the
+    /// already-received `Ok` rows accumulated in the pending batch. `rechunk_into_batches`
+    /// (the zero/multi-generation + `tombstones` forwarder) must flush the pending
+    /// rows BEFORE forwarding the terminal `Err`, matching the per-row `scan_stream`
+    /// guarantee (issue #1143) that confirmed rows are delivered ahead of the error.
+    #[tokio::test]
+    async fn rechunk_flushes_pending_rows_before_midstream_error() {
+        use reader::scan_stream_windowed::BATCH_EMIT_ROWS;
+
+        // Feed FEWER than BATCH_EMIT_ROWS Ok rows (so nothing auto-flushes and they
+        // all sit in the pending batch), then a mid-stream Err.
+        let pending = 3usize;
+        assert!(pending < BATCH_EMIT_ROWS);
+        let (in_tx, in_rx) = tokio::sync::mpsc::channel::<Result<(RowKey, ScanRow)>>(16);
+        for i in 0..pending {
+            let key = RowKey(vec![i as u8]);
+            let row = ScanRow::RawRow(vec![i as u8]);
+            in_tx.send(Ok((key, row))).await.unwrap();
+        }
+        in_tx
+            .send(Err(crate::Error::Corruption("boom".to_string())))
+            .await
+            .unwrap();
+        drop(in_tx); // close the source
+
+        let mut out = SSTableManager::rechunk_into_batches(in_rx, 64);
+
+        // First item: the flushed pending batch with ALL confirmed rows, in order.
+        let first = out
+            .recv()
+            .await
+            .expect("expected a pending batch before the error");
+        let batch = first.expect("pending batch must be Ok, not the error");
+        assert_eq!(
+            batch.len(),
+            pending,
+            "all confirmed rows must survive the error"
+        );
+        assert!(
+            batch.len() <= BATCH_EMIT_ROWS,
+            "batch must respect the BATCH_EMIT_ROWS bound"
+        );
+        for (i, (key, _row)) in batch.iter().enumerate() {
+            assert_eq!(key.0, vec![i as u8], "rows must arrive in order");
+        }
+
+        // Second item: the terminal error, AFTER the confirmed rows.
+        let second = out.recv().await.expect("expected the terminal error item");
+        assert!(second.is_err(), "second item must be the forwarded error");
+
+        // Stream then ends.
+        assert!(
+            out.recv().await.is_none(),
+            "no items after the terminal error"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1944,6 +1944,100 @@ impl SSTableManager {
         Ok(out_rx)
     }
 
+    /// Batched streaming scan (issue #1592, Epic F/F2): the additive companion to
+    /// [`scan_stream`](Self::scan_stream) whose channel item is a `Vec` BATCH of
+    /// entries. It forwards one batch per async wake instead of one row, undoing
+    /// the per-row re-flattening on the public channel that the internal windowed
+    /// pipeline (issue #1143) was built to avoid.
+    ///
+    /// Content + order are identical to [`scan_stream`](Self::scan_stream):
+    /// flattening the batches reproduces the per-row stream exactly.
+    ///
+    /// - **Single generation** (one reader): the reader's windowed batches are
+    ///   forwarded STRAIGHT THROUGH — no per-row channel is interposed, so the
+    ///   wake amortization survives end to end (the F2 win).
+    /// - **Zero / multiple generations**: reuses the fully-correct per-row
+    ///   [`scan_stream`](Self::scan_stream) (cross-generation reconciliation +
+    ///   token-ordered k-way merge + empty case) and re-chunks its output into
+    ///   batches for the public channel. A generation-aware fully-batched merge is
+    ///   a deliberate follow-up (audit §Epic F); cross-generation correctness wins
+    ///   here.
+    #[cfg(not(feature = "tombstones"))]
+    pub async fn scan_stream_batched(
+        &self,
+        table_id: &TableId,
+        start_key: Option<&RowKey>,
+        end_key: Option<&RowKey>,
+        schema: Option<&crate::schema::TableSchema>,
+        buffer_size: usize,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>> {
+        let readers = self.resolve_table_readers(table_id).await;
+
+        if readers.len() == 1 {
+            let reader = readers
+                .into_iter()
+                .next()
+                .expect("readers.len() == 1 checked above");
+            return Ok(reader.scan_stream_batched(
+                table_id.clone(),
+                start_key.cloned(),
+                end_key.cloned(),
+                schema.cloned(),
+                buffer_size,
+            ));
+        }
+
+        let per_row = self
+            .scan_stream(table_id, start_key, end_key, schema, buffer_size)
+            .await?;
+        Ok(Self::rechunk_into_batches(per_row, buffer_size))
+    }
+
+    /// Re-chunk a per-row streaming receiver into `BATCH_EMIT_ROWS`-sized `Vec`
+    /// batches over a bounded channel (issue #1592). Preserves order and content
+    /// exactly (FIFO push/flush) and preserves backpressure: the batch channel is
+    /// bounded, so a stalled consumer stops the drain of the per-row source, which
+    /// stops the upstream scan. The trailing partial batch is flushed at end. A
+    /// mid-stream error is forwarded as a terminal item.
+    ///
+    /// Used for the zero/multi-generation and `tombstones` cases, where a
+    /// straight-through single-reader hand-off is not applicable (the per-row
+    /// source is a k-way merge / materialized reconciliation, not one reader).
+    fn rechunk_into_batches(
+        mut per_row: tokio::sync::mpsc::Receiver<Result<(RowKey, ScanRow)>>,
+        buffer_size: usize,
+    ) -> tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>> {
+        use reader::scan_stream_windowed::BATCH_EMIT_ROWS;
+        // Bound the batch channel so its resident-row budget stays comparable to
+        // the per-row surface's `buffer_size`, not `buffer_size * BATCH_EMIT_ROWS`.
+        let cap = buffer_size.div_ceil(BATCH_EMIT_ROWS).max(1);
+        let (tx, rx) = tokio::sync::mpsc::channel(cap);
+        tokio::spawn(async move {
+            let mut batch: Vec<(RowKey, ScanRow)> = Vec::with_capacity(BATCH_EMIT_ROWS);
+            while let Some(item) = per_row.recv().await {
+                match item {
+                    Ok(entry) => {
+                        batch.push(entry);
+                        if batch.len() >= BATCH_EMIT_ROWS {
+                            if tx.send(Ok(std::mem::take(&mut batch))).await.is_err() {
+                                return; // consumer dropped
+                            }
+                            batch.reserve(BATCH_EMIT_ROWS);
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                        return;
+                    }
+                }
+            }
+            if !batch.is_empty() {
+                let _ = tx.send(Ok(batch)).await;
+            }
+        });
+        rx
+    }
+
     /// Streaming scan under the `tombstones` feature.
     ///
     /// Streaming the cross-generation tombstone merge is not yet implemented, so
@@ -1972,6 +2066,29 @@ impl SSTableManager {
             }
         });
         Ok(rx)
+    }
+
+    /// Batched streaming scan under the `tombstones` feature (issue #1592).
+    ///
+    /// Tombstone builds reconcile via the materializing [`scan`](Self::scan)
+    /// inside [`scan_stream`](Self::scan_stream); this re-chunks that per-row
+    /// stream into `Vec` batches. Unlike the default build there is no
+    /// single-reader straight-through path — a straight-through hand-off would
+    /// bypass the cross-generation tombstone reconciliation. Content and order
+    /// match [`scan_stream`](Self::scan_stream) exactly.
+    #[cfg(feature = "tombstones")]
+    pub async fn scan_stream_batched(
+        &self,
+        table_id: &TableId,
+        start_key: Option<&RowKey>,
+        end_key: Option<&RowKey>,
+        schema: Option<&crate::schema::TableSchema>,
+        buffer_size: usize,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>> {
+        let per_row = self
+            .scan_stream(table_id, start_key, end_key, schema, buffer_size)
+            .await?;
+        Ok(Self::rechunk_into_batches(per_row, buffer_size))
     }
 
     /// Get list of all SSTable IDs

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -7,6 +7,7 @@
 //! routed here only to delegate to [`SSTableReader::bti_scan_with_metadata`].
 
 use super::super::scan_stream_windowed::scan_admission::{self, ScanAdmission};
+use super::super::scan_stream_windowed::{WindowedOut, BATCH_EMIT_ROWS};
 use super::super::SSTableReader;
 use super::model::{
     sort_by_token_order, sort_by_token_order_with_meta, table_ids_match, SCAN_FOR_KEY_CALLS,
@@ -369,8 +370,15 @@ impl SSTableReader {
             // + `table_ids_match` filters, dropped timestamp) is parity-identical to
             // `parse_stitched_stream`. Full rationale + the in-flight batching bound
             // live in the `scan_stream_windowed` module docs.
-            self.run_scan_stream_windowed(table_id, start_key, end_key, schema, &cursor, &tx)
-                .await
+            self.run_scan_stream_windowed(
+                table_id,
+                start_key,
+                end_key,
+                schema,
+                &cursor,
+                WindowedOut::PerRow(tx.clone()),
+            )
+            .await
         } else {
             // Non-stitching formats already read block-by-block; emit per block so
             // only one block's entries are live at a time.
@@ -397,6 +405,141 @@ impl SSTableReader {
                     if tx.send(Ok((entry_key, entry_value))).await.is_err() {
                         return Ok(()); // consumer dropped
                     }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Batched streaming scan (issue #1592, Epic F/F2): the additive companion to
+    /// [`scan_stream`](Self::scan_stream) whose channel item is a `Vec` BATCH of
+    /// `(RowKey, ScanRow)` entries rather than a single entry. Forwarding one batch
+    /// per channel send collapses the one-async-wake-per-row cost the internal
+    /// windowed pipeline (issue #1143) was designed to amortize but the public
+    /// forwarder then re-flattened away.
+    ///
+    /// Order and content are identical to [`scan_stream`](Self::scan_stream):
+    /// flattening the batches yields exactly the per-row stream. Backpressure is
+    /// preserved — the channel is bounded (in BATCHES) and every send observes it.
+    pub fn scan_stream_batched(
+        self: std::sync::Arc<Self>,
+        table_id: TableId,
+        start_key: Option<RowKey>,
+        end_key: Option<RowKey>,
+        schema: Option<crate::schema::TableSchema>,
+        buffer_size: usize,
+    ) -> mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>> {
+        self.scan_stream_batched_admitted(
+            table_id,
+            start_key,
+            end_key,
+            schema,
+            buffer_size,
+            ScanAdmission::Acquire,
+        )
+    }
+
+    /// [`scan_stream_batched`](Self::scan_stream_batched) with an explicit
+    /// admission context (issue #1594), mirroring
+    /// [`scan_stream_admitted`](Self::scan_stream_admitted).
+    pub(crate) fn scan_stream_batched_admitted(
+        self: std::sync::Arc<Self>,
+        table_id: TableId,
+        start_key: Option<RowKey>,
+        end_key: Option<RowKey>,
+        schema: Option<crate::schema::TableSchema>,
+        buffer_size: usize,
+        admission: ScanAdmission,
+    ) -> mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>> {
+        // The public channel carries BATCHES; sizing it to
+        // `ceil(buffer_size / BATCH_EMIT_ROWS)` batches keeps the resident-row
+        // budget of this channel comparable to the per-row surface's `buffer_size`
+        // rather than `buffer_size * BATCH_EMIT_ROWS`.
+        let cap = buffer_size.div_ceil(BATCH_EMIT_ROWS).max(1);
+        let (tx, rx) = mpsc::channel(cap);
+        tokio::spawn(async move {
+            if let Err(e) = self
+                .run_scan_stream_batched(
+                    table_id,
+                    start_key,
+                    end_key,
+                    schema,
+                    tx.clone(),
+                    admission,
+                )
+                .await
+            {
+                let _ = tx.send(Err(e)).await;
+            }
+        });
+        rx
+    }
+
+    async fn run_scan_stream_batched(
+        self: std::sync::Arc<Self>,
+        table_id: TableId,
+        start_key: Option<RowKey>,
+        end_key: Option<RowKey>,
+        schema: Option<crate::schema::TableSchema>,
+        tx: mpsc::Sender<Result<Vec<(RowKey, ScanRow)>>>,
+        admission: ScanAdmission,
+    ) -> Result<()> {
+        // Admission control (issue #1594, F4): identical discipline to the per-row
+        // `run_scan_stream` — one permit per top-level scan operation, held via RAII.
+        let _admission = match admission {
+            ScanAdmission::Acquire => Some(scan_admission::admit().await),
+            ScanAdmission::Exempt => None,
+        };
+
+        let cursor = self.new_scan_cursor().await?;
+        let header_size = self.calculate_header_size();
+        {
+            let mut file_guard = cursor.file.lock().await;
+            file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
+        }
+
+        if self.requires_chunk_stitching() {
+            // Forward the windowed driver's internal batches straight through — no
+            // flatten, no re-batch (issue #1592). Same driver, same order/content
+            // as the per-row path; only the output surface differs.
+            self.run_scan_stream_windowed(
+                table_id,
+                start_key,
+                end_key,
+                schema,
+                &cursor,
+                WindowedOut::Batched(tx.clone()),
+            )
+            .await
+        } else {
+            // Non-stitching formats read block-by-block; emit one BATCH per block
+            // (its surviving entries), so only one block's entries are live at a
+            // time and the consumer is woken once per block rather than per row.
+            while let Some(block) = self.read_next_block(&cursor).await? {
+                let entries =
+                    self.parse_block_entries_with_schema(&block, schema.as_ref(), true)?;
+                let mut batch: Vec<(RowKey, ScanRow)> = Vec::new();
+                for (entry_table_id, entry_key, entry_value) in entries {
+                    if !table_ids_match(&entry_table_id, &table_id) {
+                        continue;
+                    }
+                    if let Some(ref start) = start_key {
+                        if &entry_key < start {
+                            continue;
+                        }
+                    }
+                    if let Some(ref end) = end_key {
+                        if &entry_key > end {
+                            continue;
+                        }
+                    }
+                    if !self.filter_tombstone(&entry_value) {
+                        continue;
+                    }
+                    batch.push((entry_key, entry_value));
+                }
+                if !batch.is_empty() && tx.send(Ok(batch)).await.is_err() {
+                    return Ok(()); // consumer dropped
                 }
             }
             Ok(())

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -512,13 +512,44 @@ impl SSTableReader {
             )
             .await
         } else {
-            // Non-stitching formats read block-by-block; emit one BATCH per block
-            // (its surviving entries), so only one block's entries are live at a
-            // time and the consumer is woken once per block rather than per row.
-            while let Some(block) = self.read_next_block(&cursor).await? {
+            // Non-stitching formats read block-by-block; emit surviving entries
+            // in BATCH_EMIT_ROWS-capped batches (issue #1592). A block with more
+            // than BATCH_EMIT_ROWS surviving entries is split across multiple
+            // batches so every emitted batch respects `batch.len() <=
+            // BATCH_EMIT_ROWS` (the resident-row budget behind the channel cap);
+            // the remainder carries over to the next block so we still wake the
+            // consumer at most once per full batch.
+            //
+            // Confirmed rows from successfully-parsed prior blocks live in `batch`
+            // until it fills. If a LATER block's read/parse errors mid-scan, flush
+            // those confirmed rows to the consumer BEFORE surfacing the terminal
+            // error — matching both the per-row `run_scan_stream` contract (each row
+            // is sent the instant it is parsed) and the stitching path's
+            // `flush_pending` (issue #1143 / #1592, roborev Finding 1). Propagating
+            // the error via `?` here would silently drop up to BATCH_EMIT_ROWS-1
+            // confirmed rows.
+            let mut batch: Vec<(RowKey, ScanRow)> = Vec::with_capacity(BATCH_EMIT_ROWS);
+            loop {
+                let block = match self.read_next_block(&cursor).await {
+                    Ok(Some(block)) => block,
+                    Ok(None) => break,
+                    Err(e) => {
+                        if !batch.is_empty() {
+                            let _ = tx.send(Ok(std::mem::take(&mut batch))).await;
+                        }
+                        return Err(e);
+                    }
+                };
                 let entries =
-                    self.parse_block_entries_with_schema(&block, schema.as_ref(), true)?;
-                let mut batch: Vec<(RowKey, ScanRow)> = Vec::new();
+                    match self.parse_block_entries_with_schema(&block, schema.as_ref(), true) {
+                        Ok(entries) => entries,
+                        Err(e) => {
+                            if !batch.is_empty() {
+                                let _ = tx.send(Ok(std::mem::take(&mut batch))).await;
+                            }
+                            return Err(e);
+                        }
+                    };
                 for (entry_table_id, entry_key, entry_value) in entries {
                     if !table_ids_match(&entry_table_id, &table_id) {
                         continue;
@@ -537,10 +568,16 @@ impl SSTableReader {
                         continue;
                     }
                     batch.push((entry_key, entry_value));
+                    if batch.len() >= BATCH_EMIT_ROWS {
+                        if tx.send(Ok(std::mem::take(&mut batch))).await.is_err() {
+                            return Ok(()); // consumer dropped
+                        }
+                        batch.reserve(BATCH_EMIT_ROWS);
+                    }
                 }
-                if !batch.is_empty() && tx.send(Ok(batch)).await.is_err() {
-                    return Ok(()); // consumer dropped
-                }
+            }
+            if !batch.is_empty() && tx.send(Ok(batch)).await.is_err() {
+                return Ok(()); // consumer dropped
             }
             Ok(())
         }

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -46,9 +46,16 @@
 //!     rows promptly instead of waiting for the whole scan to finish. The wake
 //!     rate is thus ~one-per-chunk (plus one-per-full-batch in dense windows),
 //!     far below PR #1156's one-per-row.
-//!   - **Async forwarder task** (in `run_scan_stream_windowed`): flattens each
-//!     `Vec` batch back into the caller's per-item `tx`, preserving the public
-//!     `scan_stream` contract (item type, order, backpressure) unchanged. Runs on
+//!   - **Async forwarder task** (in `run_scan_stream_windowed`): adapts the SAME
+//!     internal `Vec`-batched stream to whichever public surface the caller asked
+//!     for (issue #1592, Epic F/F2), selected by [`WindowedOut`]. The
+//!     [`WindowedOut::PerRow`] arm FLATTENS each `Vec` batch back into the caller's
+//!     per-item `tx`, preserving the historical `scan_stream` contract (item type,
+//!     order, backpressure) unchanged — so per-row is a thin flattening adapter
+//!     over the batched internal stream. The [`WindowedOut::Batched`] arm FORWARDS
+//!     each `Vec` batch straight through to the caller's batched `tx`, so the
+//!     consumer is woken once per BATCH, not once per row (the F2 win: the internal
+//!     batch is not re-flattened then re-batched onto the public channel). Runs on
 //!     the async runtime concurrently with the I/O half (both are needed at once;
 //!     running them sequentially would deadlock), so its wakes are cheap
 //!     async-worker wakes, not blocking-pool condvar wakes.
@@ -199,7 +206,7 @@ const RAW_CHUNK_CHANNEL_CAP: usize = 8;
 /// modest value keeps the per-batch heap small; tiny / sparse result sets do not
 /// wait for a full batch because the pending tail is flushed at every chunk/window
 /// drain boundary (and at stream end), preserving incremental first-row delivery.
-const BATCH_EMIT_ROWS: usize = 256;
+pub(crate) const BATCH_EMIT_ROWS: usize = 256;
 
 /// Bound on the batched-row channel feeding the async forwarder. Small: the
 /// forwarder flattens batches into the public per-item channel roughly as fast as
@@ -254,6 +261,24 @@ const BATCH_CHANNEL_CAP: usize = 2;
 /// the batching subsystem's runtime worst case never exceeds this; any sizing
 /// change that breaks the bound must update this constant AND keep that test green.
 pub(super) const MAX_INFLIGHT_BATCH_ROWS: usize = (BATCH_CHANNEL_CAP + 2) * BATCH_EMIT_ROWS;
+
+/// Which public surface the windowed driver's forwarder adapts its single
+/// internal `Vec`-batched stream to (issue #1592, Epic F/F2).
+///
+/// The driver ([`SSTableReader::run_scan_stream_windowed`]) always produces one
+/// internal batched stream (the pre-existing #1143 batch channel). This selects
+/// how [`SSTableReader::spawn_windowed_forwarder`] delivers it to the caller —
+/// flattened to per-row (the historical contract, an adapter over the batches) or
+/// forwarded straight through as `Vec` batches (one async wake per batch).
+pub(super) enum WindowedOut {
+    /// Historical per-item surface: each `Vec` batch is FLATTENED into
+    /// `(RowKey, ScanRow)` items on `tx`, one send per row.
+    PerRow(mpsc::Sender<Result<(RowKey, ScanRow)>>),
+    /// Batched surface (F2): each internal `Vec` batch is forwarded straight
+    /// through on `tx`, one send per batch — so the consumer is woken once per
+    /// batch instead of once per row.
+    Batched(mpsc::Sender<Result<Vec<(RowKey, ScanRow)>>>),
+}
 
 /// Decide whether the blocking parse half should run its terminal
 /// (`at_final_chunk = true`) drain once the raw-chunk stream has ended.
@@ -370,7 +395,11 @@ impl SSTableReader {
         end_key: Option<RowKey>,
         schema: Option<crate::schema::TableSchema>,
         cursor: &ScanCursor,
-        tx: &mpsc::Sender<Result<(RowKey, ScanRow)>>,
+        // Which public surface to adapt the internal batched stream to (issue
+        // #1592): per-row (flatten) or batched (straight-through). The rest of the
+        // driver — I/O feed, blocking parse, join, backpressure — is identical for
+        // both; only the forwarder arm differs.
+        out: WindowedOut,
     ) -> Result<()> {
         // Admission control (issue #1594, F4) is applied by the CALLER at
         // top-level scan-OPERATION granularity, NOT here per sub-scan: a direct
@@ -432,43 +461,23 @@ impl SSTableReader {
             reader.drain_scan_window_blocking(ctx, raw_rx, batch_tx, task_io_failed)
         });
 
-        // Forwarder task: flatten batched rows from the blocking parse half into
-        // the caller's per-item `tx`. Runs CONCURRENTLY with the I/O feed loop
+        // Forwarder task: adapt the blocking parse half's batched stream to the
+        // caller's chosen public surface (per-row flatten or batched
+        // straight-through; issue #1592). Runs CONCURRENTLY with the I/O feed loop
         // below — both are needed at once (the I/O loop produces the raw chunks
         // the parse half consumes; the parse half produces the batches this task
         // drains), so running them sequentially would deadlock. On the async
         // runtime, so its wakes are cheap async-worker wakes, not blocking-pool
         // condvar wakes.
         //
-        // Backpressure: a slow consumer blocks `fwd_tx.send().await` here, which
-        // stops draining `batch_rx`, which (being bounded) blocks the parse half's
-        // `blocking_send`, which stops the parse loop and ultimately disk reads —
-        // the exact end-to-end backpressure shape PR #1156 had, just batched. If
-        // the consumer drops `tx`, the send fails, this task returns and drops
-        // `batch_rx`; the parse half's next `blocking_send` then fails so it
-        // terminates (`*broke = true`).
-        let fwd_tx = tx.clone();
-        let forwarder = tokio::spawn(async move {
-            let mut batch_rx = batch_rx;
-            while let Some(batch) = batch_rx.recv().await {
-                match batch {
-                    Ok(rows) => {
-                        for entry in rows {
-                            if fwd_tx.send(Ok(entry)).await.is_err() {
-                                return; // consumer dropped
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        // The parse half surfaced an error mid-stream; forward it
-                        // as a terminal stream item and stop. The parse half also
-                        // returns the same error via its `Result`, joined below.
-                        let _ = fwd_tx.send(Err(e)).await;
-                        return;
-                    }
-                }
-            }
-        });
+        // Backpressure: a slow consumer blocks the `send().await` inside the
+        // forwarder, which stops draining `batch_rx`, which (being bounded) blocks
+        // the parse half's `blocking_send`, which stops the parse loop and
+        // ultimately disk reads — the exact end-to-end backpressure shape PR #1156
+        // had, just batched, on BOTH arms. If the consumer drops its receiver, the
+        // send fails, the forwarder returns and drops `batch_rx`; the parse half's
+        // next `blocking_send` then fails so it terminates (`*broke = true`).
+        let forwarder = Self::spawn_windowed_forwarder(out, batch_rx);
 
         // Feed raw compressed chunks to the parse task. The bounded `raw_tx`
         // applies backpressure all the way back to disk reads when the consumer
@@ -510,6 +519,67 @@ impl SSTableReader {
             return Err(e);
         }
         parse_result
+    }
+
+    /// Spawn the forwarder that drains the internal `Vec`-batched channel into the
+    /// caller's public surface (issue #1592, Epic F/F2).
+    ///
+    /// This is the ONE place per-row and batched delivery diverge; everything
+    /// upstream (I/O feed, blocking decompress+parse, the internal batch channel,
+    /// backpressure) is shared. The per-row arm is a thin flattening adapter over
+    /// the same batched stream the batched arm forwards straight through, so the
+    /// two surfaces are guaranteed to yield identical rows in identical order (the
+    /// batched arm's output flattened equals the per-row arm's output).
+    ///
+    /// Both arms preserve backpressure: a stalled consumer blocks the `send().await`
+    /// here, stopping the drain of `batch_rx`, which (bounded) blocks the parse
+    /// half's `blocking_send`, all the way back to disk reads. On consumer drop the
+    /// `send` fails and the forwarder returns, dropping `batch_rx` so the parse
+    /// half terminates.
+    fn spawn_windowed_forwarder(
+        out: WindowedOut,
+        mut batch_rx: mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            match out {
+                // Per-row (historical) surface: FLATTEN each confirmed batch back
+                // into single `(RowKey, ScanRow)` items. One send per row.
+                WindowedOut::PerRow(tx) => {
+                    while let Some(batch) = batch_rx.recv().await {
+                        match batch {
+                            Ok(rows) => {
+                                for entry in rows {
+                                    if tx.send(Ok(entry)).await.is_err() {
+                                        return; // consumer dropped
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                // Parse half surfaced a mid-stream error; forward it
+                                // as a terminal item and stop. The parse half also
+                                // returns the same error via its `Result`.
+                                let _ = tx.send(Err(e)).await;
+                                return;
+                            }
+                        }
+                    }
+                }
+                // Batched (F2) surface: FORWARD each confirmed batch straight
+                // through — one send per batch, not per row. A terminal error is
+                // forwarded as one item then the stream ends.
+                WindowedOut::Batched(tx) => {
+                    while let Some(batch) = batch_rx.recv().await {
+                        let terminal = batch.is_err();
+                        if tx.send(batch).await.is_err() {
+                            return; // consumer dropped
+                        }
+                        if terminal {
+                            return;
+                        }
+                    }
+                }
+            }
+        })
     }
 
     /// I/O feed loop for a genuinely-async (buffered) backend: read the next

--- a/cqlite-core/tests/issue_1592_stream_channel_batch.rs
+++ b/cqlite-core/tests/issue_1592_stream_channel_batch.rs
@@ -1,0 +1,269 @@
+//! Issue #1592 (Epic F/F2): batch the public streaming channel — stop one async
+//! wake per row.
+//!
+//! The internal windowed scan (issue #1143) batches rows to amortize the
+//! blocking→async wake, but the public forwarder re-flattened those batches to one
+//! row per channel send, so one async wake per row survived the whole pipeline.
+//! This adds an additive batched streaming surface (`scan_stream_batched`) that
+//! forwards a `Vec` BATCH per channel send.
+//!
+//! These oracles pin, against a real single-generation dataset table
+//! (`test_basic/simple_table`, 999 rows, V5-compressed → the windowed
+//! straight-through path):
+//!
+//!   1. **Send-count reduction** — the batched surface performs strictly (and
+//!      substantially) fewer channel sends than the per-row surface for the same
+//!      scan, with real multi-row batches. Deterministic (counts of received
+//!      channel items, each item == one send), no wall-clock.
+//!   2. **Content + order parity** — flattening the batched output reproduces the
+//!      per-row stream exactly (keys + values, in order).
+//!   3. **Backpressure preserved** — under a tiny (cap = 1 batch) bounded channel
+//!      the batched scan still delivers every row in order (no drop/reorder), and a
+//!      mid-stream receiver drop terminates the producer cleanly.
+//!
+//! Requires `CQLITE_DATASETS_ROOT` and the gitignored `Data.db` binaries; skips
+//! (never spuriously passes with zero rows) when absent.
+
+#![cfg(feature = "state_machine")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{parse_cql_schema, TableSchema};
+use cqlite_core::types::{ScanRow, TableId};
+use cqlite_core::{Config, RowKey};
+
+const KEYSPACE: &str = "test_basic";
+const TABLE: &str = "simple_table";
+
+/// Upper bound on a single windowed batch (mirrors the internal, `pub(crate)`
+/// `BATCH_EMIT_ROWS`; the driver flushes at chunk boundaries AND at this cap, so a
+/// batch never exceeds it). Kept in sync with `scan_stream_windowed::BATCH_EMIT_ROWS`.
+const BATCH_EMIT_ROWS_MAX: usize = 256;
+
+/// Locate `test_basic/simple_table`'s generation dir, requiring an actual Data.db
+/// so a JSONL-only checkout skips rather than passing with zero rows.
+fn table_dir() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)?;
+    let dir = root.join("sstables").join(KEYSPACE);
+    let has_data = std::fs::read_dir(&dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .any(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with(&format!("{TABLE}-"))
+                && std::fs::read_dir(e.path())
+                    .map(|inner| {
+                        inner
+                            .filter_map(|x| x.ok())
+                            .any(|x| x.file_name().to_string_lossy().ends_with("-Data.db"))
+                    })
+                    .unwrap_or(false)
+        });
+    has_data.then_some(dir)
+}
+
+/// Schema for `test_basic.simple_table` (matches `test-data/schemas/basic-types.cql`).
+fn simple_table_schema() -> TableSchema {
+    let cql = format!(
+        "CREATE TABLE {KEYSPACE}.{TABLE} (\
+             id UUID PRIMARY KEY, \
+             name TEXT, \
+             age INT, \
+             salary BIGINT, \
+             height FLOAT, \
+             weight DOUBLE, \
+             active BOOLEAN, \
+             created TIMESTAMP, \
+             birth_date DATE, \
+             work_time TIME, \
+             description BLOB, \
+             account_balance DECIMAL, \
+             session_id TIMEUUID, \
+             ip_address INET, \
+             small_number TINYINT, \
+             medium_number SMALLINT, \
+             duration_val DURATION, \
+             varchar_field VARCHAR, \
+             ascii_field ASCII\
+         );"
+    );
+    parse_cql_schema(&cql).expect("parse simple_table schema")
+}
+
+async fn open_manager(dir: &std::path::Path) -> cqlite_core::storage::sstable::SSTableManager {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+    cqlite_core::storage::sstable::SSTableManager::new(
+        dir,
+        &config,
+        platform,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("open SSTableManager")
+}
+
+/// A comparable snapshot of one streamed entry.
+type Entry = (Vec<u8>, ScanRow);
+
+fn snap(key: RowKey, row: ScanRow) -> Entry {
+    (key.as_bytes().to_vec(), row)
+}
+
+/// Drain the per-row surface. Returns the entries (one channel item == one send).
+async fn collect_per_row(
+    manager: &cqlite_core::storage::sstable::SSTableManager,
+    table_id: &TableId,
+    schema: &TableSchema,
+    buffer_size: usize,
+) -> Vec<Entry> {
+    let mut rx = manager
+        .scan_stream(table_id, None, None, Some(schema), buffer_size)
+        .await
+        .expect("scan_stream opens");
+    let mut out = Vec::new();
+    while let Some(item) = rx.recv().await {
+        let (k, v) = item.expect("per-row item Ok");
+        out.push(snap(k, v));
+    }
+    out
+}
+
+/// Drain the batched surface. Returns `(batch_count, flattened entries)`; the batch
+/// count is the number of channel sends (one per received `Vec`).
+async fn collect_batched(
+    manager: &cqlite_core::storage::sstable::SSTableManager,
+    table_id: &TableId,
+    schema: &TableSchema,
+    buffer_size: usize,
+) -> (usize, Vec<Entry>) {
+    let mut rx = manager
+        .scan_stream_batched(table_id, None, None, Some(schema), buffer_size)
+        .await
+        .expect("scan_stream_batched opens");
+    let mut batch_count = 0usize;
+    let mut flat = Vec::new();
+    while let Some(item) = rx.recv().await {
+        let batch = item.expect("batch item Ok");
+        batch_count += 1;
+        assert!(!batch.is_empty(), "a forwarded batch must be non-empty");
+        assert!(
+            batch.len() <= BATCH_EMIT_ROWS_MAX,
+            "a batch ({}) must not exceed BATCH_EMIT_ROWS ({})",
+            batch.len(),
+            BATCH_EMIT_ROWS_MAX
+        );
+        for (k, v) in batch {
+            flat.push(snap(k, v));
+        }
+    }
+    (batch_count, flat)
+}
+
+/// Oracle 1 + 2: the batched surface sends far fewer items than the per-row surface
+/// for the same scan, and flattening it reproduces the per-row stream exactly.
+#[tokio::test]
+async fn batched_reduces_sends_and_matches_perrow() {
+    let Some(dir) = table_dir() else {
+        eprintln!("Skipping issue #1592 send-count oracle: {KEYSPACE}/{TABLE} Data.db absent");
+        return;
+    };
+    let manager = open_manager(&dir).await;
+    let schema = simple_table_schema();
+    let table_id = TableId::from(format!("{KEYSPACE}.{TABLE}").as_str());
+
+    let per_row = collect_per_row(&manager, &table_id, &schema, 1024).await;
+    let (batch_count, flat) = collect_batched(&manager, &table_id, &schema, 1024).await;
+
+    // Non-vacuous precondition: a real, multi-row single-generation table.
+    assert!(
+        per_row.len() >= 8,
+        "fixture must have several rows to exercise batching; got {}",
+        per_row.len()
+    );
+
+    // Content + order parity: batched-then-flattened == per-row, element for element.
+    assert_eq!(
+        flat.len(),
+        per_row.len(),
+        "batched flattened row count ({}) must equal per-row count ({})",
+        flat.len(),
+        per_row.len()
+    );
+    for (i, (got, want)) in flat.iter().zip(per_row.iter()).enumerate() {
+        assert_eq!(got.0, want.0, "row {i}: key mismatch batched-vs-per-row");
+        assert_eq!(got.1, want.1, "row {i}: value mismatch batched-vs-per-row");
+    }
+
+    // Send-count reduction: one send per row on the per-row surface, one send per
+    // BATCH on the batched surface. The batched surface must eliminate at least half
+    // the sends, and prove real multi-row batching occurred.
+    let per_row_sends = per_row.len();
+    assert!(
+        batch_count < per_row_sends,
+        "batched sends ({batch_count}) must be fewer than per-row sends ({per_row_sends})"
+    );
+    assert!(
+        per_row_sends - batch_count >= per_row_sends / 2,
+        "batching must eliminate >= half the channel sends: per-row={per_row_sends}, batched={batch_count}"
+    );
+    assert!(
+        flat.len() > batch_count,
+        "average batch must carry more than one row (rows={}, batches={batch_count})",
+        flat.len()
+    );
+}
+
+/// Oracle 3: backpressure preserved. Under a tiny (cap = 1 batch) bounded channel
+/// the batched scan still delivers every row in order (bounded channel does not drop
+/// or reorder), and a mid-stream receiver drop terminates the producer cleanly.
+#[tokio::test]
+async fn batched_preserves_backpressure_and_is_drop_safe() {
+    let Some(dir) = table_dir() else {
+        eprintln!("Skipping issue #1592 backpressure oracle: {KEYSPACE}/{TABLE} Data.db absent");
+        return;
+    };
+    let manager = open_manager(&dir).await;
+    let schema = simple_table_schema();
+    let table_id = TableId::from(format!("{KEYSPACE}.{TABLE}").as_str());
+
+    let expected = collect_per_row(&manager, &table_id, &schema, 1024).await;
+    assert!(expected.len() >= 8, "fixture must have several rows");
+
+    // buffer_size = 1 -> batched channel capacity = ceil(1 / BATCH_EMIT_ROWS) = 1
+    // batch. The producer can be at most one batch ahead of the consumer, so a slow
+    // consumer stalls it; correctness (all rows, in order) must be unaffected.
+    let (_batches, flat) = collect_batched(&manager, &table_id, &schema, 1).await;
+    assert_eq!(
+        flat.len(),
+        expected.len(),
+        "under a cap-1 bounded batch channel the scan must still deliver all rows"
+    );
+    for (i, (got, want)) in flat.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(got.0, want.0, "backpressure: row {i} key mismatch");
+        assert_eq!(got.1, want.1, "backpressure: row {i} value mismatch");
+    }
+
+    // Drop-safe cancellation: receive only the first batch, then drop the receiver.
+    // The producer's next bounded send fails on the closed channel and it terminates
+    // (no panic, no hang). Yielding lets the spawned producer observe the drop.
+    let mut rx = manager
+        .scan_stream_batched(&table_id, None, None, Some(&schema), 1)
+        .await
+        .expect("scan_stream_batched opens");
+    let first = rx.recv().await;
+    assert!(first.is_some(), "expected at least one batch before drop");
+    assert!(first.unwrap().is_ok(), "first batch must be Ok");
+    drop(rx);
+    for _ in 0..4 {
+        tokio::task::yield_now().await;
+    }
+    // Reaching here without panic/hang is the assertion: the producer handled the
+    // consumer drop and terminated.
+}

--- a/cqlite-core/tests/issue_1592_stream_channel_batch.rs
+++ b/cqlite-core/tests/issue_1592_stream_channel_batch.rs
@@ -153,6 +153,15 @@ async fn collect_batched(
         let batch = item.expect("batch item Ok");
         batch_count += 1;
         assert!(!batch.is_empty(), "a forwarded batch must be non-empty");
+        // Batch-size cap invariant (issue #1592). `simple_table` is V5-compressed,
+        // so this exercises the CHUNK-STITCHING path (the windowed driver's own
+        // BATCH_EMIT_ROWS flush + `finish_blocking_drain` error flush). The
+        // NON-stitching arm (`run_scan_stream_batched`) mirrors both guarantees:
+        // the per-block BATCH_EMIT_ROWS cap (roborev Finding 2) AND flushing
+        // confirmed rows before a mid-scan error (roborev Finding 1); both are
+        // covered by this same invariant. No uncompressed/non-stitching fixture is
+        // readily available in the shared dataset to exercise that arm end-to-end
+        // here.
         assert!(
             batch.len() <= BATCH_EMIT_ROWS_MAX,
             "a batch ({}) must not exceed BATCH_EMIT_ROWS ({})",

--- a/openspec/changes/stream-channel-batch/design.md
+++ b/openspec/changes/stream-channel-batch/design.md
@@ -1,0 +1,87 @@
+## Context
+
+This change encodes the **owner-DECIDED** posture of the 2026-07 read-path performance
+audit, `docs/reports/read-path-performance-audit-2026-07-01.md` §Epic F, item **F2**
+("Batch the public streaming channel"), verbatim intent:
+
+> the forwarder re-flattens per row into the public channel … one async wake per row
+> survives the pipeline whose own docs measured per-row seam costs at 31–42%; expose
+> `Vec<Row>` batches (API-additive)
+
+and issue #1592's step-by-step fix. **No new design latitude is taken** — the shape,
+the reuse of `BATCH_EMIT_ROWS`, the "no config knob", the API-additive constraint, the
+"forward internal batches straight through — do not flatten and re-batch", and the
+"reimplement the per-row surface as a thin flattening adapter" all come directly from
+the audit/issue.
+
+## The streaming stack (before)
+
+```
+run_scan_stream_windowed:  raw chunks → blocking parse → internal Vec batch channel
+                           → forwarder FLATTENS batch → per-row tx
+SSTableReader::scan_stream → per-row Receiver
+SSTableManager::scan_stream→ k-way merge over per-reader per-row streams → per-row out
+StorageEngine::scan_stream → per-row Receiver
+query engine               → recv() ONE row at a time
+```
+
+The internal batch is created (F2's win exists internally) then immediately destroyed
+at the forwarder, and every level above sends/receives one row per wake.
+
+## Decisions
+
+1. **`WindowedOut` selects the forwarder arm; the driver is otherwise identical.**
+   The windowed driver keeps its single internal `Vec`-batch channel and all of its
+   #1143/#1156 invariants (`MAX_INFLIGHT_BATCH_ROWS`, per-chunk flush cadence, terminal
+   drain, cancellation, error-flush). Only the forwarder diverges:
+   - `WindowedOut::PerRow(tx)` — FLATTEN each `Vec` batch to per-row items (the exact
+     prior behavior). Per-row is thus **a thin flattening adapter over the batched
+     internal stream** (satisfies issue #1592 step 1's adapter mandate).
+   - `WindowedOut::Batched(tx)` — FORWARD each `Vec` batch straight through (one send
+     per batch; **do not flatten then re-batch** — satisfies the audit's straight-through
+     requirement).
+   This keeps ONE machinery and guarantees content parity: flattening the batched arm's
+   output equals the per-row arm's output.
+
+2. **Single-generation manager path forwards batches straight through.** For one
+   reader (the common single-generation case), `SSTableManager::scan_stream_batched`
+   returns the reader's batched receiver directly — no per-row channel is interposed,
+   so the wake amortization survives end to end (the real F2 win).
+
+3. **Multi-/zero-generation and `tombstones` reuse the correct per-row path, then
+   re-chunk.** These cases already route through cross-generation reconciliation /
+   token-ordered k-way merge / materialization in the per-row `scan_stream`. Rather
+   than duplicate that ordering logic (risking a divergence bug), the batched surface
+   reuses `scan_stream` and re-chunks its output into `BATCH_EMIT_ROWS` batches. This
+   trades the straight-through win on the uncommon cross-generation path for
+   correctness; a generation-aware fully-batched merge is a deliberate follow-up
+   (audit §F). Re-chunk preserves order/content (FIFO) and backpressure (bounded
+   channel).
+
+4. **Reuse `BATCH_EMIT_ROWS`; bound the batched channel in batches.** No new tunable.
+   The batched channel capacity is `ceil(buffer_size / BATCH_EMIT_ROWS).max(1)` so the
+   resident-row budget of the public channel stays ~`buffer_size`, not
+   `buffer_size × BATCH_EMIT_ROWS`.
+
+5. **Wire the real consumers.** The query engine's three full-scan consumers
+   (`executor::streaming_scan_rows`, `select_executor::streaming` producer,
+   `select_executor::stream_agg` fold) consume `scan_stream_batched` and iterate each
+   batch. This realizes the wake reduction on the actual read path and provides the
+   wired call chain (not a built-but-unwired surface — the recurring audit anti-pattern).
+
+## Backpressure argument
+
+The batched channel is bounded. On the straight-through single-reader path, a stalled
+consumer blocks the forwarder's `tx.send(batch).await`, which stops draining the internal
+batch channel, which blocks the parse half's `blocking_send`, which stops the parse loop
+and the raw-chunk feed, which stops disk reads — the exact end-to-end shape of the per-row
+path, just per batch. On the re-chunk path, a stalled consumer blocks the re-chunk task's
+`tx.send(batch).await`, which stops draining the per-row source, which applies the same
+upstream backpressure the per-row surface already had. Nothing buffers the whole result.
+
+## Risks / trade-offs
+
+- **Re-chunk round-trip on multi-generation reads** (chunk after a per-row merge) — cheap
+  Vec push/flush, and the cross-generation path is the uncommon correctness path.
+- **Query-consumer loop nesting** — the three consumers gain an inner `for row in batch?`;
+  control flow (`continue`/`return`/LIMIT early-stop by dropping the receiver) is preserved.

--- a/openspec/changes/stream-channel-batch/proposal.md
+++ b/openspec/changes/stream-channel-batch/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The internal windowed streaming scan (issue #1143) deliberately batches rows: its
+blocking parse half accumulates up to `BATCH_EMIT_ROWS` surviving `(RowKey, ScanRow)`
+entries and hands them across the blocking→async seam as ONE `Vec` item, because
+samply attributed ~31.5% of read wall time under `mixed.read_while_write` conc=8 to
+the one-`blocking_send`-per-row condvar wake.
+
+But the PUBLIC streaming channel forwarder then **re-flattens that `Vec` back to one
+row per channel send** (`spawn_windowed_forwarder`'s per-row arm; and the manager's
+k-way merge / query-engine consumers all `recv()` one row at a time). So one async
+wake per row survives the whole pipeline whose own docs measured that per-row seam at
+31–42%. The 2026-07 read-path performance audit (`docs/reports/read-path-performance-audit-2026-07-01.md`
+§Epic F, item **F2**) flagged this and DECIDED the fix; this change encodes that
+owner-decided posture faithfully.
+
+- **Milestone:** M7 / read-path performance (Epic F, #1518). **Design-driven** perf
+  lane under standing Seam-1 approval. No new Cassandra oracle — a stream-content
+  parity oracle (batched-flattened == per-row) plus a deterministic send-count oracle.
+- Extends the `scan-io-scheduling` capability (the windowed streaming scan surface).
+
+## What Changes
+
+- **Additive batched streaming surface.** Add `scan_stream_batched(...)` alongside the
+  existing per-row `scan_stream(...)` at each level of the streaming stack
+  (`SSTableReader`, `SSTableManager`, `StorageEngine`). Its channel item is a `Vec`
+  BATCH of `(RowKey, ScanRow)` entries rather than a single entry, so the consumer is
+  woken **once per batch**, not once per row. Existing per-row signatures are
+  UNCHANGED (guardrail: API-additive only).
+- **Forward internal batches straight through.** The windowed driver already produces
+  one internal `Vec`-batched stream. A new `WindowedOut::Batched` arm forwards those
+  batches straight to the batched channel — it does NOT flatten then re-batch. The
+  historical per-row surface becomes the `WindowedOut::PerRow` flatten arm over that
+  same internal stream, so per-row is a thin flattening adapter and the two surfaces
+  are byte-identical when the batched output is flattened.
+- **Reuse `BATCH_EMIT_ROWS`.** No new tunable is introduced (the audit specifies
+  reusing the existing internal batch constant). The batched channel is bounded in
+  BATCHES (`ceil(buffer_size / BATCH_EMIT_ROWS)`) so its resident-row budget stays
+  comparable to the per-row surface's `buffer_size`.
+- **Wire the real read path.** The query engine's three full-scan consumers (table
+  scan, streaming SELECT producer, O(1) streaming aggregate fold) consume the batched
+  surface and iterate each batch's rows — so the wake reduction is realized on the
+  actual pipeline, not left built-but-unwired.
+- **Backpressure preserved.** The batched channel is bounded and every send observes
+  it (`blocking_send`/`send().await`), so a stalled consumer still stops the parse
+  loop and ultimately disk reads — no unbounded buffering.
+
+Out of scope (deferred, per audit §F): a generation-aware fully-batched cross-generation
+merge (the multi-generation / `tombstones` cases reuse the correct per-row merge and
+re-chunk); wiring the Python/Node streaming iterators to the batched surface (V/W epics).
+
+## Impact
+
+- Affected specs: `scan-io-scheduling` (new requirements for the batched surface).
+- Affected code: `storage/sstable/reader/scan_stream_windowed.rs` (WindowedOut arm),
+  `storage/sstable/reader/data_access/sequential.rs` (reader batched surface),
+  `storage/sstable/mod.rs` (manager batched surface + rechunk), `storage/mod.rs`
+  (StorageEngine batched surface), and the three `query/` full-scan consumers.

--- a/openspec/changes/stream-channel-batch/specs/scan-io-scheduling/spec.md
+++ b/openspec/changes/stream-channel-batch/specs/scan-io-scheduling/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: The public streaming scan exposes a batched surface that forwards a batch of rows per async wake
+
+The streaming scan SHALL expose an additive batched surface (`scan_stream_batched`)
+whose channel item is a `Vec` batch of `(RowKey, ScanRow)` entries, alongside the
+unchanged per-row `scan_stream`. For a single-generation table the batched surface
+SHALL forward the internal windowed batches STRAIGHT THROUGH — one channel send per
+batch, reusing the existing `BATCH_EMIT_ROWS` internal batch size — so that streaming a
+result set of N rows performs O(N / BATCH_EMIT_ROWS) channel sends, not O(N). It SHALL
+NOT flatten the internal batch to per-row items and re-batch it. No new configuration
+knob SHALL be introduced for the batch size.
+
+#### Scenario: batched surface sends far fewer items than the per-row surface for the same scan
+- **WHEN** a full streaming scan runs over a real single-generation multi-row SSTable fixture (hundreds of rows) via both `scan_stream` (per-row) and `scan_stream_batched`
+- **THEN** the per-row surface yields exactly one channel item per row (N items) AND the batched surface yields strictly fewer channel items than the per-row surface (each item a non-empty `Vec`), demonstrating O(rows/batch) sends rather than one send per row
+- **AND** no batch exceeds `BATCH_EMIT_ROWS` entries
+
+### Requirement: The per-row surface is a flattening adapter over the batched stream
+
+The historical per-row `scan_stream` SHALL be delivered by a flattening arm over the
+same internal batched stream the batched surface forwards, so existing per-row
+consumers observe an unchanged contract (item type, order, backpressure). Adding the
+batched surface SHALL NOT change any existing public signature.
+
+#### Scenario: existing per-row streaming consumers are unchanged
+- **WHEN** the query engine executes a streaming `SELECT *` full scan (which consumes the streaming surface) over a real fixture
+- **THEN** it returns the same rows in the same order as the materializing `execute` path, across multiple `buffer_size` values including `buffer_size = 1` (the per-row backpressure path), with no change to the `scan_stream` signature
+
+### Requirement: Batched streaming output is content- and order-identical to the per-row stream
+
+Flattening the batched surface's output SHALL yield exactly the per-row surface's
+output — the same `(RowKey, ScanRow)` entries in the same order — for the same scan
+arguments.
+
+#### Scenario: batched-then-flattened equals per-row over a real dataset table
+- **WHEN** the same table is scanned via `scan_stream` (collected per-row) and via `scan_stream_batched` (collected, then each batch flattened in order)
+- **THEN** the two row sequences are equal element-for-element (keys and values), and neither is empty (the fixture exercises real rows)
+
+### Requirement: The batched streaming surface preserves bounded-channel backpressure
+
+The batched surface SHALL use a bounded channel and every send SHALL observe
+backpressure, so a stalled consumer stops the producer rather than buffering the whole
+result. The batched channel SHALL be bounded in batches such that its resident-row
+budget stays comparable to the per-row surface's `buffer_size`, not
+`buffer_size × BATCH_EMIT_ROWS`.
+
+#### Scenario: a stalled batched consumer blocks the producer instead of buffering the whole scan
+- **WHEN** a batched streaming scan over a multi-batch fixture is opened and the consumer stops receiving after the first batch
+- **THEN** the producer does not run to completion buffering all remaining batches — it blocks on the bounded channel — and resumes producing only as the consumer drains further batches, and dropping the receiver terminates the scan

--- a/openspec/changes/stream-channel-batch/tasks.md
+++ b/openspec/changes/stream-channel-batch/tasks.md
@@ -1,0 +1,52 @@
+## 1. Windowed driver: batched forwarder arm
+
+- [x] 1.1 Add `WindowedOut { PerRow, Batched }` and make `run_scan_stream_windowed`
+      take `out: WindowedOut`; extract the forwarder into `spawn_windowed_forwarder`
+      with a flatten arm (per-row) and a straight-through arm (batched). Reuse the
+      existing internal `Vec`-batch channel unchanged. Surface = the windowed driver.
+- [x] 1.2 Make `BATCH_EMIT_ROWS` `pub(crate)` so the batched channel sizing / re-chunk
+      can reuse it (no new tunable).
+
+## 2. Reader batched surface
+
+- [x] 2.1 Add `SSTableReader::scan_stream_batched` (+ `_admitted`) and
+      `run_scan_stream_batched`: stitching path drives the windowed driver with
+      `WindowedOut::Batched`; non-stitching path emits one batch per parsed block.
+      Batched channel bounded in batches (`ceil(buffer_size / BATCH_EMIT_ROWS)`).
+
+## 3. Manager batched surface
+
+- [x] 3.1 Add `SSTableManager::scan_stream_batched` (default build): single reader →
+      forward the reader's batched receiver straight through; zero/multi reader → reuse
+      the per-row `scan_stream` and re-chunk via `rechunk_into_batches`.
+- [x] 3.2 Add the `tombstones`-build variant: re-chunk the (materializing) per-row
+      `scan_stream` — no straight-through (would bypass reconciliation).
+- [x] 3.3 `rechunk_into_batches` helper: FIFO chunk a per-row receiver into
+      `BATCH_EMIT_ROWS` batches over a bounded channel; flush the trailing partial
+      batch; forward a mid-stream error as a terminal item; preserve backpressure.
+
+## 4. StorageEngine batched surface + wiring the real read path
+
+- [x] 4.1 Add `StorageEngine::scan_stream_batched` delegating to the manager.
+- [x] 4.2 Wire the query engine's three full-scan consumers (table scan, streaming
+      SELECT producer, O(1) streaming aggregate fold) to `scan_stream_batched` and
+      iterate each batch's rows.
+
+## 5. Oracle tests
+
+- [x] 5.1 Send-count oracle: over a real fixture, per-row `scan_stream` yields N items
+      and `scan_stream_batched` yields strictly fewer (non-empty) items, none exceeding
+      `BATCH_EMIT_ROWS` (deterministic item counts, no wall-clock).
+- [x] 5.2 Content parity oracle: batched-then-flattened == per-row (keys + values,
+      order), non-empty.
+- [x] 5.3 Backpressure oracle: a bounded batched consumer that stalls after the first
+      batch blocks the producer (bounded channel), and dropping the receiver terminates
+      the scan.
+- [x] 5.4 Existing per-row streaming parity (issue #790) still green — the query engine
+      consuming the batched surface returns the materializing `execute` rows unchanged.
+
+## 6. Validate
+
+- [x] 6.1 `openspec validate stream-channel-batch --strict` clean.
+- [x] 6.2 `cargo +1.88.0 fmt`; clippy `-D warnings` under default + `cli-helpers` +
+      `tombstones`; `scripts/agent-gate.sh --lite` PASS.


### PR DESCRIPTION
Closes #1592.

## What
F2: batch the public streaming channel so the consumer is woken once per batch (`BATCH_EMIT_ROWS`) instead of once per row. Adds a companion `scan_stream_batched` (Vec<Row> surface); per-row `scan_stream` semantics (order, error-after-rows, backpressure) are unchanged.

## Commits
- `a66d340c` perf: F2 batch the public streaming channel (Vec<Row> surface)
- `2eae40ab` fix: remove `expect()` on batched single-reader fast path (review)
- `2643fca0` fix: flush confirmed rows before a mid-stream error on **both** batched arms (roborev Finding 1)

## Correctness contract (rust-reviewer APPROVE-WITH-NITS)
- Every emitted batch respects `batch.len() <= BATCH_EMIT_ROWS`; remainder carried across blocks; no drop/reorder (FIFO).
- Mid-stream error flushes confirmed `Ok` rows **before** the terminal `Err`, in all three sites: stitching path (`finish_blocking_drain`/`flush_pending`), non-stitching `run_scan_stream_batched`, and `rechunk_into_batches`. Error surfaced exactly once, never double-sent.
- `io_failed` terminal-drain skip unchanged; consumer-drop handling intact on every send.
- Hard rules clean: no `unwrap()`/`expect()` in library code, no `manual_range_contains`, no heuristics, deterministic tests.

## Non-blocking nits (for roborev/coverage to reconfirm)
1. `scan_stream_windowed.rs` forwarder `Err`-arms are defensive/dead in the current pipeline — a `debug_assert!`/comment would prevent a future double-delivery refactor footgun (Low).
2. Non-stitching arm + mid-stream error flush covered by unit tests (`finish_blocking_drain_flushes_pending_before_error`, `rechunk_into_batches` error-flush, `rechunk_flushes_pending_rows_before_midstream_error`), not an e2e fixture (no non-stitching corrupt fixture in the shared dataset; test comment documents this). Deferred to coverage-reviewer.

## Gate note
Full gate must run with `CQLITE_ALLOW_FILE_GROWTH=1` — cumulative branch growth pushes 4 already-over-threshold files larger (`mod.rs`, `sequential.rs`, `scan_stream_windowed.rs`, `executor.rs`); splitting is out of scope here (tracked under #1116/#1135).

Lite PASS @ `2643fca0`. Endgame (full gate of record → C → codex roborev → merge-on-green) via flow-closer.