### PR TITLE
docs(#2101): CLAUDE.md context-economy compaction — 661→~350 lines, cookbook extracted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,44 +1,51 @@
 # CLAUDE.md
 
-Guidance for Claude Code when working with CQLite.
+Guidance for Claude Code when working with CQLite. This file is loaded into every agent context —
+it holds the **rules and pointers**; recipes and examples live in `docs/development/dev-cookbook.md`.
 
 ## Project Overview
 
-CQLite is a Rust library for local Apache Cassandra SSTable access. It reads Cassandra 5.0 data files without cluster dependencies.
+CQLite is a Rust library for local Apache Cassandra SSTable access — it reads (and writes)
+Cassandra 5.0 data files without cluster dependencies.
 
-**Status**: v0.13.0 (Jul 2026) - the performance release. Core reading (M1), CLI (M2), Output Writers (M3), Python & Node.js Bindings (M4), and Write Support + STCS compaction (M5) are complete. v0.13.0 adds read-path constant-factor speedups (Epic E, C2), Node bindings throughput, byte-bounded result budgets (`Error::ResultTooLarge`), explicit `Database::refresh()`, and no-heuristics correctness fixes, on top of v0.12.0's byte-for-byte compaction parity vs Apache Cassandra, Arrow Flight + Trino connector, canonical BTI (`da`) write/read, CDC-style delta-export, and `WRITETIME()`/`TTL()` in `SELECT`. Next: M6 (WASM bindings), M7 (perf validation + v1.0).
+**Status**: v0.13.0 (Jul 2026) — the performance release. M1–M5 complete (core reading, CLI,
+output writers, Python + Node.js bindings, write support + STCS compaction). v0.12 delivered
+byte-for-byte compaction parity vs Apache Cassandra, Arrow Flight + Trino connector, canonical BTI
+(`da`) write/read, CDC-style delta-export. v0.13 adds read-path speedups, byte-bounded result
+budgets, `Database::refresh()`, and no-heuristics correctness fixes. Next: M6 (WASM bindings),
+M7 (perf validation + v1.0).
 
 ## Documentation
 
-### Primary Reference
-**SSTable Format**: `docs/sstables-definitive-guide/README.md` - Single source of truth
+- **SSTable format (single source of truth)**: `docs/sstables-definitive-guide/README.md` —
+  Ch.5 Data.db, Ch.6 Index.db/Summary.db, Ch.17 BTI, App.B encoding cheat sheet, App.F known limitations
+- **Agent doctrine (canonical site)**: https://pmcfadin.github.io/cqlite/agents-developing/ —
+  [gate contract](https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/),
+  [no-heuristics](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/),
+  [test data](https://pmcfadin.github.io/cqlite/agents-developing/test-data/),
+  [source map](https://pmcfadin.github.io/cqlite/agents-developing/source-map/),
+  [validation playbook](https://pmcfadin.github.io/cqlite/agents-developing/validation-playbook/),
+  [format debugging](https://pmcfadin.github.io/cqlite/agents-developing/format-debugging/),
+  [spec-driven audit](https://pmcfadin.github.io/cqlite/agents-developing/spec-driven-audit/),
+  [delivery pipeline](https://pmcfadin.github.io/cqlite/agents-developing/delivery-pipeline/),
+  [roborev findings](https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/)
+- **Gate deep mechanics** (sccache tuning, concurrency caps, disk hygiene, `--delta` internals):
+  `docs/development/gate-ops.md`
+- **CI toolchain policy** (issue #1990): `docs/development/ci-toolchain-policy.md` — workflows honor
+  `rust-toolchain.toml`; one advisory `future-rust-canary.yml` lane tracks latest stable; coverage
+  tools install prebuilt.
+- **Parity CI tiers**: `docs/development/parity-ci-tiers.md` (tier contracts; the
+  `exhaustive_regeneration` tier = weekly `exhaustive-regeneration.yml`, #1026) +
+  `docs/development/parity-release-checklist.md` (gates public parity claims).
+  `docs/reports/cassandra-test-parity.md` is a **committed derived artifact** of
+  `test-data/cassandra-parity-manifest.yml` (#1338): the SKIP-aware `parity-report` gate component
+  catches local staleness; the `parity-report-heal` job in `cassandra-parity.yml` self-heals
+  merge races via a regen PR (needs `PARITY_HEAL_TOKEN`; SKIPs with a notice if absent).
+- **Command cookbook** (CLI usage/modes, bindings build/test/examples, write support, delta-export,
+  profiling, feature-flag builds, fuzz runs): `docs/development/dev-cookbook.md`
+- Historical investigations: `docs/archive/issues/INDEX.md`; pass rates: `test-data/validation-matrix.md`
 
-Key chapters:
-- Ch.5: Data.db Format (rows, flags, V5CompressedLegacy)
-- Ch.6: Index.db/Summary.db (partition lookups)
-- Ch.17: BTI Formats (trie indexes)
-- Appendix B: Encoding Cheat Sheet (VInt, flags)
-- Appendix F: Known Limitations (what doesn't work yet)
-
-### Agent Developer Docs (canonical — site is source of truth)
-
-Full contributor doctrine is published at `https://pmcfadin.github.io/cqlite/agents-developing/`:
-- [Gate contract](https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/) — `scripts/agent-gate.sh`, summary-block format
-  - CI toolchain policy: `docs/development/ci-toolchain-policy.md` (issue #1990) — every product-validation workflow honors `rust-toolchain.toml` (omit `toolchain:` for setup actions that read it; `dtolnay/rust-toolchain@1.88.0` explicit since it can't); exactly ONE advisory `future-rust-canary.yml` lane tracks latest `stable`; coverage tools install prebuilt (`taiki-e/install-action`), never `cargo install` from source.
-  - Parity CI tier contracts: `docs/development/parity-ci-tiers.md` (what each Cassandra parity CI tier promises; gate-strength smoke/canonical-semantic/byte-for-byte) + `docs/development/parity-release-checklist.md` (gates public parity claims). Belongs alongside the gate-contract page on the `agents-developing/` site — mirror there when the site page lands (issue #1022).
-    - The `exhaustive_regeneration` tier is backed by `.github/workflows/exhaustive-regeneration.yml` (weekly + `workflow_dispatch`, never on PRs; issue #1026), which regenerates the corpus and runs `cargo run -p cassandra-parity -- corpus-audit` (hard-fails on corpus/manifest or provenance drift).
-    - `docs/reports/cassandra-test-parity.md` is a **committed derived artifact** rendered from `test-data/cassandra-parity-manifest.yml`. It can go stale on `main` via a **semantic merge race** (two manifest-changing PRs each regenerate correctly vs their base, but the squash-merge leaves the report rendered against a stale base) — no per-PR `--check` can catch this. Two safeguards (issue #1338): the SKIP-aware `parity-report` agent-gate component (`scripts/agent-gate.sh`) catches the single-PR forgot-to-regenerate case locally before push; the `parity-report-heal` push-to-`main` job in `.github/workflows/cassandra-parity.yml` self-heals the merge race by opening/updating a single regeneration PR from `auto/parity-report-regen` (never pushing to protected `main`). The heal job needs repo secret `PARITY_HEAL_TOKEN` (a PAT/App token with `contents`+`pull-requests` write) so the regen PR triggers CI — a PR opened by the default `GITHUB_TOKEN` gets no checks; absent the secret the job SKIPs with a `::notice::` (regenerate manually) instead of opening a check-less PR. See `docs/development/parity-ci-tiers.md`.
-- [No-heuristics mandate](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/) — authoritative metadata only (issue #28)
-- [Test data](https://pmcfadin.github.io/cqlite/agents-developing/test-data/) — fetching, dataset pins, CQLITE_DATASETS_ROOT
-- [Key source paths](https://pmcfadin.github.io/cqlite/agents-developing/source-map/) — parsers, writers, query engine, bindings
-- [sstabledump validation playbook](https://pmcfadin.github.io/cqlite/agents-developing/validation-playbook/) — JSONL goldens, parity tests, smoke
-- [Format debugging workflow](https://pmcfadin.github.io/cqlite/agents-developing/format-debugging/) — hex dumps, guide chapters, Appendix F
-
-### Project Documentation
-- `docs/archive/issues/INDEX.md` - Historical issue investigations
-- `test-data/validation-matrix.md` - Current test pass rates
-
-## Available Skills (Auto-invoked)
+## Available Skills (auto-invoked)
 
 Skills in `.claude/skills/` activate automatically when relevant:
 
@@ -47,24 +54,23 @@ Skills in `.claude/skills/` activate automatically when relevant:
 | `sstable-parsing` | Binary format parsing, hex dumps, compression |
 | `cql-type-system` | CQL type deserialization |
 | `rust-patterns` | Zero-copy, async I/O, memory efficiency |
-| `ci-cd-validation` | Pre-push checks, CI requirements |
-| `test-data-management` | Test SSTable generation, validation |
-| `rust-skills` | General idiomatic Rust (265 rules: ownership, errors, async, API design, anti-patterns); invoke with `/rust-skills` |
+| `rust-skills` | General idiomatic Rust (265 rules); invoke with `/rust-skills` |
 | `ci-cd-validation` | Tiered gate loop (lite iterate, full once), CI monitoring, merge-on-green |
+| `test-data-management` | Test SSTable generation, validation |
 
-**Delivery pipeline skills** (in `.claude/skills/`): `flow-groom` → `flow-activate` → `flow-implement` →
-`flow-address` → `flow-finalize`, plus `flow-board` (claim board + next thing). See
+**Delivery pipeline skills**: `flow-groom` → `flow-activate` → `flow-implement` → `flow-address` →
+`flow-finalize`, plus `flow-board` (claim board + next thing). See
 `docs/development/pm-operating-loop.md`. (`start-epic`/`pm-status` are deprecated pointers → flow-*.)
 
 ## Available Subagents
 
-Subagents in `.claude/agents/` for specialized tasks (pass an explicit `model` on spawn — the pinned
+Subagents in `.claude/agents/` — **always pass an explicit accessible `model` on spawn** (the pinned
 frontmatter model may be inaccessible):
 
 | Agent | Purpose |
 |-------|---------|
 | `flow-lead` | Delivery lead/PM — drives the flow-* pipeline, sequences the specialists |
-| `flow-closer` | Per-issue endgame owner — runs the ONE full gate of record → C → final roborev → merge-on-green → finalize in its own disposable context (issue #2084) |
+| `flow-closer` | Per-issue endgame owner — ONE full gate → C → final roborev → merge-on-green → finalize, in its own disposable context (#2084) |
 | `sstable-developer` | SSTable implementation, format debugging |
 | `rust-reviewer` | Read-only Rust code review, quality enforcement |
 | `test-validator` | Test execution, sstabledump parity, failure triage |
@@ -72,590 +78,260 @@ frontmatter model may be inaccessible):
 | `coverage-reviewer` | Test-quality review (meaningful, not just present) |
 | `compaction-parity-auditor` | Write/compaction byte-parity gap audit vs Cassandra |
 
-## Essential Commands
+## The Agent Gate — the only run that counts (issue #719)
+
+`scripts/agent-gate.sh` is THE pre-PR gate. Its `==== AGENT-GATE SUMMARY ====` block is the verdict;
+ad-hoc cargo runs never count. `scripts/agent-gate.sh --list` shows the component set.
+
+| Mode | Command | Use |
+|------|---------|-----|
+| **Full** — the gate of record | `scripts/agent-gate.sh` | ONCE per issue, immediately pre-merge, inside `flow-closer`. fmt, clippy `-D warnings`, core/integration/write/CLI tests, minimal-features build, smoke. Emits `AGENT-GATE SUMMARY`. |
+| **Lite** (#1821, ~1–5 min) | `scripts/agent-gate.sh --lite` | EVERY fix round. file-size + fmt + scoped clippy + blast-radius tests (touched package `--lib` + diff's new `--test` targets). Emits a DISTINCT `AGENT-GATE LITE SUMMARY` (MODE: lite) — can NEVER be pasted as the full SUMMARY. |
+| **Delta** (#1892) | `scripts/agent-gate.sh --delta <anchor-sha> --anchor-run-id <id>` (or `--anchor-summary-file <path>`) | Re-certify a post-full-PASS polish round whose diff is ONLY executable tests/docs (rust test code, python/node binding tests against an already-built module, `scripts/tests/*.sh`, `*.md`; #2081). FAILs CLOSED on anything else (src, scripts, workflows, `Cargo.*`, config, test-data, unbuilt node module) — never builds, never passes vacuously. Emits a DISTINCT `AGENT-GATE DELTA SUMMARY` naming the anchor; record BOTH it AND the anchor's full SUMMARY in the PR. NOT the gate of record. |
+
+**Required invocation — summary-file redirect, never raw stdout (issues #1175/#2079), full AND lite:**
 
 ```bash
-# Canonical agent gate (issue #719) - THE pre-PR gate for agents.
-# Runs fmt, clippy -D warnings, core tests (cli-helpers), integration tests,
-# write-support tests, CLI tests, minimal-features build, and smoke, then
-# emits a machine-checkable summary block. Paste that block verbatim when
-# reporting validation; ad-hoc cargo runs do not count as "the gate passed".
-#
-# clippy is SCOPED per-package (issue #1844): it lints the whole workspace with
-# -D warnings but does NOT compile the source-built DuckDB C++ amalgamation
-# (cqlite-cli `duckdb-tests`) or the OpenTelemetry/OTLP stack
-# (`observability`/`observability-testing`) — both were pure per-gate tax.
-# parquet/arrow stay linted. Coverage of the excluded features moves to nightly:
-# CQLITE_CLIPPY_FULL=1 runs the full `--workspace --all-targets --all-features`
-# matrix, which .github/workflows/gate.yml (nightly deep-check) sets.
-#
-# Missing-fixtures fail-closed (issue #2078): the FULL gate FAILs CLOSED when the
-# fetched validation corpus (test_basic/...) is absent, even though a fresh
-# worktree's committed byte-parity reference *-Data.db files keep the raw Data.db
-# count > 0 (previously a false PASS via SKIP). Opt-out:
-# AGENT_GATE_ALLOW_MISSING_FIXTURES=1 restores the lenient SKIP and stamps a
-# machine-checkable `missing-fixtures: OPT-OUT (...)` line in the SUMMARY, so an
-# intentional opt-out is visible in the pasted artifact; absent the opt-out, a
-# FAIL stamps `missing-fixtures: FAIL-CLOSED (#2078)` with the remedy: bash
-# test-data/scripts/fetch-datasets.sh. --lite/--only are unchanged (lenient).
-scripts/agent-gate.sh
-
-# FAST ITERATION gate (issue #1821) - NOT the gate of record.
-# Runs ONLY file-size + fmt + scoped workspace clippy (-D warnings, same #1844
-# duckdb/otel-excluded scoping as the full gate) +
-# blast-radius-scoped tests (the touched package's --lib + the diff's new --test
-# targets, mapped from `git diff --name-only origin/main...HEAD`; defaults to
-# `cqlite-core --lib` when no rust package is in the diff). ~1-5 min vs 12-25 min.
-# Use it on EVERY fix round of the implement/roborev loop. It emits a DISTINCT
-# "==== AGENT-GATE LITE SUMMARY ====" block (MODE: lite) that can NEVER be pasted
-# as the full SUMMARY, and its recovery default is .agent-gate-lite-summary.txt.
-# Lite NEVER replaces the full gate: run the full scripts/agent-gate.sh ONCE
-# before merge and it must PASS - that SUMMARY is the only run that counts.
-scripts/agent-gate.sh --lite
-
-# TEST/DOCS-ONLY DELTA RE-CERTIFICATION (issue #1892) - NOT the gate of record.
-# After a full-gate PASS at commit X, if the diff X..Y touches ONLY files the
-# re-cert can EXECUTE (rust cargo test code, python binding tests, Node.js
-# __test__/ tests run against an ALREADY-BUILT native module, scripts/tests/*.sh
-# self-tests, and/or docs — issue #2081 moved node/shell from refused to
-# executed), re-certify with --delta instead of forcing a whole new full gate.
-# It FAILs CLOSED on anything else (src, scripts, workflows, Cargo.*, config,
-# test-data, or an unbuilt node module — it NEVER builds with cargo and never
-# passes vacuously) and forces a fresh full gate. Emits a DISTINCT
-# "==== AGENT-GATE DELTA SUMMARY ====" block (MODE: delta) naming the gate of
-# record (the full PASS at X) + the anchor run-id, so it can NEVER be pasted as
-# a full SUMMARY. Record BOTH the anchor's full SUMMARY and this DELTA block in
-# the PR. Standing backstop: the nightly gate.yml deep-check re-runs the FULL
-# gate on main. Recovery default: .agent-gate-delta-summary.txt. Deep mechanics
-# + the delta-executors: line: docs/development/gate-ops.md.
-scripts/agent-gate.sh --delta <anchor-sha> --anchor-run-id <full-gate-run-id>
-#   # or, to read the anchor run-id from the recorded full SUMMARY:
-scripts/agent-gate.sh --delta <anchor-sha> --anchor-summary-file <path-to-full-SUMMARY>
-
-# The DEFAULT gate invocation — summary-file redirect, NOT raw stdout (issues
-# #1175, #2079). The SUMMARY block is the only gate text an agent retains; the
-# raw gate log (thousands of lines) must NEVER be read into a persistent agent
-# context. So the REQUIRED form everywhere — full gate AND each --lite round — is
-# a pre-chosen summary file + a redirect, then cat the file:
 AGENT_GATE_SUMMARY_FILE=/tmp/gate-summary.txt bash scripts/agent-gate.sh > gate.log 2>&1 < /dev/null
-cat /tmp/gate-summary.txt   # complete SUMMARY block; gate.log is never read into context
-# This is the default because it is also robust: under tee / a pty / background
-# capture, a leaked build-server or test daemon can hold the gate's stdout pipe
-# open and truncate (even fully lose) a streamed SUMMARY even though the gate
-# exited 0 — the file is complete regardless. Prefer run_in_background (or a long
-# timeout) so a subagent never idle-waits and gets watchdog-killed (#1855).
-# If you did not set AGENT_GATE_SUMMARY_FILE, the gate writes the same complete
-# block to the documented default $PWD/.agent-gate-summary.txt (gitignored;
-# --lite: .agent-gate-lite-summary.txt); cat that instead.
-# CONCURRENCY: that default is per-checkout; if you run multiple gates concurrently
-# IN THE SAME CHECKOUT, give each a unique AGENT_GATE_SUMMARY_FILE or they clobber
-# each other's artifact (separate worktrees are already isolated).
-# Fast self-test of the emission path:
-bash scripts/tests/test_agent_gate_summary.sh
+cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent retains; NEVER read gate.log
 ```
 
-Every SUMMARY block (full and `--lite`) carries a machine-checkable `accelerators:` line (sccache/nextest/lane-parallelism state) — treat degradation shown there as actionable, not scrollback noise.
+- Prefer `run_in_background` (or a long timeout) so a subagent never idle-waits and gets
+  watchdog-killed (#1855). A queued gate ≠ hung gate: under load it prints `waiting for gate slot`.
+- Defaults if `AGENT_GATE_SUMMARY_FILE` unset (per-checkout; give concurrent gates in ONE checkout
+  unique paths): `.agent-gate-summary.txt` / `.agent-gate-lite-summary.txt` / `.agent-gate-delta-summary.txt`.
+- clippy is scoped per-package (#1844): whole workspace `-D warnings` but skips the DuckDB
+  amalgamation + OTel stack; `CQLITE_CLIPPY_FULL=1` (nightly `gate.yml`) runs the full matrix.
+- The FULL gate FAILs CLOSED when the fetched validation corpus is absent (#2078);
+  `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` opts out visibly in the SUMMARY. Remedy:
+  `bash test-data/scripts/fetch-datasets.sh`. `--lite`/`--only` stay lenient.
+- Every SUMMARY carries an `accelerators:` line (sccache/nextest/lane state) — degradation there is
+  actionable, not noise. Self-test: `bash scripts/tests/test_agent_gate_summary.sh`.
 
-Deep gate operations (sccache tuning, concurrency-cap internals, disk hygiene, parallelism knobs, `--delta` mechanics): `docs/development/gate-ops.md`.
+## Core Commands
 
 ```bash
-# Build
 cargo build
-
-# Test (requires test data)
 env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test --package cqlite-core
-
-# Clippy (CI mode - must pass)
-env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features
-
-# Format
+env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features   # CI mode
 cargo fmt
-
-# Smoke test all tables
 bash test-data/scripts/smoke-test-all-tables.sh
-
-# Profiling loop (see docs/profiling.md)
-./scripts/profile.sh baseline        # save criterion baseline
-./scripts/profile.sh flame           # CPU flamegraphs (pprof, works in containers)
-./scripts/profile.sh heap            # dhat heap profile vs <128MB budget
-./scripts/profile.sh bench && ./scripts/profile.sh compare   # re-measure vs baseline
-./scripts/profile.sh report          # ranked bottleneck report + history.jsonl ledger
-
-# Run CLI
-cargo run --package cqlite-cli -- <command>
-
-# One-shot query mode (Issue #223)
-cargo run --package cqlite-cli -- \
-  --schema test-data/schemas/basic-types.cql \
-  --data-dir test-data/datasets/sstables \
-  --query "SELECT * FROM test_basic.simple_table LIMIT 5" \
-  --out json
-
-# Python bindings build and test
-cd bindings/python && maturin develop --profile dev  # Development build (debug; overrides the release-unwind firewall pin for a fast dev loop)
-cd bindings/python && maturin build --profile release-unwind  # Release wheel (panic-unwind firewall, issue #1440 — NOT --release, which is panic=abort)
-
-# Run Python tests - fast tests only (default, Issue #331)
-env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets pytest bindings/python/tests -v
-
-# Run all Python tests including slow (CLI parity, performance)
-env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets RUN_SLOW_TESTS=1 pytest bindings/python/tests -v
-
-# Run only slow tests (CLI parity and performance)
-env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets pytest bindings/python/tests -m slow -v
-
-# Exclude slow tests explicitly
-env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets pytest bindings/python/tests -m "not slow" -v
-
-# Python usage example
-python3 -c "
-import cqlite
-with cqlite.open('test-data/datasets/sstables', schema='test-data/schemas/basic-types.cql') as db:
-    for row in db.execute('SELECT * FROM test_basic.simple_table LIMIT 5'):
-        print(row.to_dict())
-"
-
-# Python Parquet export (Epic #682)
-python3 -c "
-import cqlite
-with cqlite.open('test-data/datasets/sstables', schema='test-data/schemas/basic-types.cql') as db:
-    rows = db.export_parquet('SELECT * FROM test_basic.simple_table', '/tmp/out.parquet',
-                             row_group_size=10000, compression='snappy')
-    print(f'Exported {rows} rows')
-"
-
-# Node.js bindings build and test (Issue #290, #296, #306)
-cd bindings/node && npm install && npm run build  # Build native module
-cd bindings/node && npm test                       # Run all tests (Jest)
-cd bindings/node && npm run test:watch             # Watch mode for development
-cd bindings/node && npm run test:coverage          # Run with coverage report
-
-# Node.js usage example (Issue #296 - Phase 2 complete)
-node -e "
-const { Database } = require('@cqlite/node');
-(async () => {
-  const db = await Database.open('test-data/datasets/sstables', {
-    schema: 'test-data/schemas/basic-types.cql'
-  });
-  const result = await db.executeNative('SELECT * FROM test_basic.simple_table LIMIT 5');
-  console.log('Rows:', result.rowCount);
-  for (const row of result.rows) {
-    console.log(row.name);
-  }
-  await db.close();
-})();
-"
-
-# Node.js Parquet export (Epic #682)
-node -e "
-const { Database } = require('@cqlite/node');
-(async () => {
-  const db = await Database.open('test-data/datasets/sstables', {
-    schema: 'test-data/schemas/basic-types.cql'
-  });
-  const rows = await db.exportParquet(
-    'SELECT * FROM test_basic.simple_table', '/tmp/out.parquet',
-    { rowGroupSize: 10000, compression: 'snappy' });
-  console.log('Exported', rows, 'rows');
-  await db.close();
-})();
-"
-
-# CLI with write support (Issue #392)
-cargo build --package cqlite-cli --features write-support
-
-# Write a mutation (requires --writable and --write-dir)
-cargo run --package cqlite-cli --features write-support -- \
-  --writable --write-dir /tmp/cqlite-write \
-  --schema test-data/schemas/basic-types.cql \
-  --mutation '{"table":{"keyspace":"test_basic","table":"simple_table"},"partition_key":[{"Uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}],"clustering_key":[],"operations":[{"Write":{"column":"name","value":{"Text":"Test"}}}],"timestamp_micros":1704067200000000}'
-
-# Flush memtable to SSTable
-cargo run --package cqlite-cli --features write-support -- \
-  --writable --write-dir /tmp/cqlite-write \
-  --schema test-data/schemas/basic-types.cql \
-  --flush
-
-# Issue #1253: a single combined invocation persists durably. `--execute` DML
-# now runs BEFORE the flush within the same invocation, so the inserted row
-# lands in Data.db (not just the WAL):
-cargo run --package cqlite-cli --features write-support -- \
-  --writable --write-dir /tmp/cqlite-write \
-  --schema test-data/schemas/basic-types.cql \
-  --execute "INSERT INTO test_basic.simple_table (id, name) VALUES (33333333-3333-3333-3333-333333333333, 'Carol')" \
-  --flush
-
-# Write subcommands
-cargo run --package cqlite-cli --features write-support -- \
-  maintenance --budget-ms 100 \
-  --writable --write-dir /tmp/cqlite-write \
-  --schema test-data/schemas/basic-types.cql
-
-cargo run --package cqlite-cli --features write-support -- \
-  write-stats \
-  --writable --write-dir /tmp/cqlite-write \
-  --schema test-data/schemas/basic-types.cql
-
-cargo run --package cqlite-cli --features write-support -- \
-  export-sstable /tmp/export --keyspace my_ks --table my_tbl \
-  --writable --write-dir /tmp/cqlite-write \
-  --schema test-data/schemas/basic-types.cql
-
-# Delta-export (CDC Parquet, Issue #705 / Epic #696 DS9) - requires --features delta-export
-# Schema must be a bare CREATE TABLE statement (no CREATE KEYSPACE / USE preamble).
-cargo build --package cqlite-cli --features delta-export
-
-# Export one SSTable generation as a delta-envelope Parquet file
-cargo run --package cqlite-cli --features delta-export -- \
-  delta-export test-data/datasets/sstables/test_basic/simple_table-<uuid> \
-  --schema test-data/schemas/simple_table.cql \
-  --out parquet \
-  -o /tmp/delta.parquet
-
-# With custom envelope prefix (to resolve __op/__ts column collisions)
-cargo run --package cqlite-cli --features delta-export -- \
-  delta-export test-data/datasets/sstables/test_basic/simple_table-<uuid> \
-  --schema test-data/schemas/simple_table.cql \
-  --out parquet \
-  -o /tmp/delta.parquet \
-  --envelope-prefix _cqlite_
-
-# Run delta-export integration tests
-env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
-  cargo test --package cqlite-cli --features delta-export --test delta_export_tests
+bash test-data/scripts/fetch-datasets.sh    # fetch real SSTable binaries (required for integration tests)
 ```
 
-### CLI Output Format Precedence
-
-- `--out` takes precedence over `--format` when both specified
-- `--query` is an alias for `--execute` (`-e`)
-- Environment variable: `CQLITE_OUT` sets default output format
-- `export` shows a determinate progress bar + ETA when `--limit N` is set (the only
-  authoritative total), a spinner otherwise, and emits no progress/summary when
-  `--quiet` or when stdout is piped/redirected (Issue #284).
-
-### CLI Modes (Issue #242)
-
-The CLI supports three modes with enhanced status display:
-
-**TUI Mode** (`cqlite tui`): Full terminal UI with status bar showing:
-```
-Health: OK | Mem: 24.5 MB | Data: 1.2 GB | Status: Ready | Mode: EDIT
-```
-
-**REPL Mode** (`cqlite repl`): Interactive shell with status line:
-```
-[OK] Mem: 24.5 MB | Data: 1.2 GB
-cqlite>
-```
-
-**One-shot Mode**: Direct query execution with `--execute` or `--query` flags.
-
-Status metrics refresh every 5 seconds. Status line disabled for piped output.
+Everything else (CLI usage/modes/output precedence, Python/Node build + test + examples, write
+support, delta-export, profiling, feature-flag builds, fuzz runs): `docs/development/dev-cookbook.md`.
 
 ## Workspace Structure
 
 ```
 cqlite-core/     # Core library (SSTable parsing, query engine)
 cqlite-cli/      # Command-line interface
-bindings/python/ # Python bindings (PyO3) - M4 complete
-bindings/node/   # Node.js bindings (napi-rs) - Phase 2 complete (Issue #296)
+bindings/python/ # Python bindings (PyO3) — M4 complete
+bindings/node/   # Node.js bindings (napi-rs) — Phase 3 complete
 test-data/       # Real Cassandra 5.0 SSTables for testing
 tools/           # sstabledump-validator, format-validator
+fuzz/            # cargo-fuzz crate — own workspace, EXCLUDED from the main one
 ```
 
-**Planned (M6)**: `bindings/wasm/` (WebAssembly bindings)
-
-For the full source map (parsers, writers, query engine, bindings layout), see
-[Key source paths](https://pmcfadin.github.io/cqlite/agents-developing/source-map/).
-
-### Python Bindings Structure
-
-```
-bindings/python/
-├── src/                    # PyO3 binding implementation
-│   ├── lib.rs             # Module initialization
-│   ├── database.rs        # Database class (open/close/execute)
-│   ├── result.rs          # QueryResult, Row, StreamingIterator
-│   ├── value.rs           # CQL to Python type conversions
-│   ├── error.rs           # Exception mapping
-│   ├── config.rs          # StreamingConfig, presets
-│   ├── runtime.rs         # Tokio runtime management
-│   ├── prepared.rs        # PreparedStatement bindings
-│   └── stats.rs           # DatabaseStats bindings
-├── python/cqlite/
-│   ├── __init__.py        # Python package wrapper
-│   └── __init__.pyi       # Type stubs for IDE support
-├── tests/                 # 17 test files, 360+ tests
-│   └── conftest.py        # Shared fixtures and path constants (Issue #330)
-├── pyproject.toml         # Maturin build configuration
-└── Cargo.toml             # Rust dependencies
-```
-
-### Node.js Bindings Structure
-
-```
-bindings/node/
-├── src/
-│   ├── lib.rs             # napi-rs entry point, module exports
-│   ├── database.rs        # Database class, QueryResult, ColumnInfo
-│   ├── streaming.rs       # StreamingResult for async iteration (Issue #305)
-│   ├── value.rs           # CQL to JavaScript type conversions
-│   └── error.rs           # Error mapping (cqlite_core::Error → napi::Error)
-├── lib/
-│   ├── index.js           # Enhanced entry point with error wrapper
-│   ├── index.d.ts         # Complete TypeScript definitions (Issue #312)
-│   └── error-wrapper.js   # JavaScript error enhancement layer
-├── __test__/              # 13 test files, 255 tests (Jest)
-├── jest.config.js         # Jest configuration
-├── Cargo.toml             # napi-rs dependencies
-├── package.json           # npm package config (@cqlite/node)
-└── index.d.ts             # Generated TypeScript definitions
-```
-
-**Status**: Phase 3 (Streaming) complete (Issue #305). Key APIs:
-- `Database.open(dataDir, options?)` — open with optional schema
-- `Database.execute(query)` — **deprecated** (removed next major; emits a `DeprecationWarning`); lossy legacy JSON (blob→base64 string, timestamp→ISO string, varint/decimal→bespoke strings) and slower. Use `executeNative()`
-- `Database.executeNative(query)` — native JS types (BigInt, Date, Buffer, Set, Map)
-- `Database.executeStreaming(query, config?)` — async iteration for large result sets
-- `Database.getStats()` / `Database.close()`
-
-For full Node.js API reference, TypeScript definitions, error codes, and streaming
-details, see `bindings/node/lib/index.d.ts` and the issue backlog (#290, #296–#314).
-
-### Python/Node.js Thread Safety and Output Parity
-
-**Python thread safety** (Issue #311, #805, #815): `Arc<Database>` + `AtomicBool`; GIL
-released during async ops; concurrent queries on the same database are safe without a
-warm-up. Full scans no longer share mutable file state: #815 removed the old
-`SSTableReader.scan_mutex` and gave every scan its own `ScanCursor` (independent
-file handle + chunk index), so N concurrent full scans run in parallel rather than
-serialized.
-
-**Python/CLI parity** (Issue #319): Python uses native types (v0.13 mapping:
-`timestamp`→`datetime`, `uuid`→`UUID`, `blob`→`bytes`, `time`→`int` ns since
-midnight, `duration`→`cqlite.Duration` — see the
-[v0.13 Migration Guide](docs/development/v0.13-migration-guide.md)); CLI uses JSON
-strings. Normalization required for comparison — see
-`bindings/python/tests/test_cli_parity.py`.
+**Planned (M6)**: `bindings/wasm/`. Full source map (parsers, writers, query engine, bindings
+layout, binding structure trees):
+[source map](https://pmcfadin.github.io/cqlite/agents-developing/source-map/) +
+`docs/development/dev-cookbook.md`.
 
 ## Development Standards
 
-### No-Heuristics Mandate
-Use authoritative metadata only — no type guessing. Schema-aware decoding when schema
-present. Legacy heuristics behind opt-in `experimental` feature flag only.
-See canonical doctrine: [no-heuristics mandate](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/)
+### No-heuristics mandate (issue #28)
+Authoritative metadata only — schema, else `Statistics.db`. No type guessing. Schema-aware decoding
+when schema present. Legacy heuristics live only behind the opt-in `experimental` feature flag.
+Doctrine: [no-heuristics](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/).
 
 ### Supported formats (version floor)
-CQLite targets Cassandra 5.0 — `na`+/`nb` BIG and `oa`/`da` BTI are in scope; pre-`na`
-(`ma`–`me`, Cassandra 3.x) is out of scope and SHALL NOT be introduced, supported, or
-reviewed for correctness (this guidance is for reviewers incl. roborev too). The floor is
-enforced in code: `BigVersionGates::from_version` rejects `< na` and `BtiVersionGates::from_version`
-rejects non-`da`, both with `Error::UnsupportedVersion`; `SSTableReader::open` propagates that
-error rather than falling back. Do not re-litigate pre-`na` "regressions."
+CQLite targets Cassandra 5.0 — `na`+/`nb` BIG and `oa`/`da` BTI in scope; pre-`na` (Cassandra 3.x)
+is out of scope and SHALL NOT be introduced or reviewed for correctness (reviewers incl. roborev).
+Enforced in code: `BigVersionGates::from_version` rejects `< na`, `BtiVersionGates::from_version`
+rejects non-`da` (`Error::UnsupportedVersion`); `SSTableReader::open` propagates. Do not re-litigate
+pre-`na` "regressions."
 
-### Write surface: CQLite writes UNCOMPRESSED SSTables (claim boundary, issue #1406)
-The production write surface (flush + compaction via `SSTableWriter`) emits
-**uncompressed** SSTables only and never emits a `CompressionInfo.db`. The
-compressed-write building blocks (`CompressedDataWriter`, `CompressionInfoWriter`)
-are built but **UNWIRED** — they exist solely to synthesize compressed fixtures for
-the read/decompress path, and carry zero Cassandra-side byte-parity coverage for a
-CQLite-emitted `CompressionInfo.db`. This is fail-closed in code: any attempt to
-configure compressed production writing returns `Error::UnsupportedFormat`
-(`SSTableWriter::with_compression` / `CompressionInfoWriter::guard_unsupported_production_write`).
-Do NOT claim CQLite emits compressed SSTables (parity manifest records this as
-`claim.blocked.compressed_sstable_writes`; the safe wording is
-`claim.safe.uncompressed_sstable_writes`). Wiring compressed writes (posture a) is
-tracked in issue #1406.
+### Write surface: UNCOMPRESSED SSTables only (claim boundary, issue #1406)
+The production write surface (flush + compaction via `SSTableWriter`) emits **uncompressed**
+SSTables and never a `CompressionInfo.db`. The compressed-write building blocks
+(`CompressedDataWriter`, `CompressionInfoWriter`) are built but **UNWIRED** — fixture-synthesis
+only, zero Cassandra-side parity coverage. Fail-closed in code: configuring compressed production
+writing returns `Error::UnsupportedFormat`. Do NOT claim CQLite emits compressed SSTables (manifest:
+`claim.blocked.compressed_sstable_writes`; safe wording `claim.safe.uncompressed_sstable_writes`).
+Wiring them (posture a) is issue #1406.
 
-### Code Quality
-- `RUSTFLAGS="-D warnings"` must pass
-- No `unwrap()`/`expect()` in library code
-- Use `thiserror` for errors
+### Code quality
+- `RUSTFLAGS="-D warnings"` must pass; no `unwrap()`/`expect()` in library code; `thiserror` for errors
 - Memory target: <128MB for large files
 
-### File Size (Campsite Rule)
-Keep files small so they are cheap and accurate to read/edit — agentic context cost
-scales directly with file size (a file must be read before it can be edited).
-- **Targets** (total lines, inline tests included): source `~800`, test files `~1500`.
-- The agent gate runs a **file-size ratchet** (`file-size` component): it lists changed
-  `.rs` files over threshold (advisory) and **FAILs if your change makes an
-  over-threshold file larger** (or pushes one over).
-- **When you touch an over-threshold file**, split it by responsibility as part of your
-  work — see epic #1116 (source split doctrine: `foo.rs` → `foo/mod.rs` + concern
-  submodules with re-exports; tests follow their code) and #1135 (test files: extract
-  shared fixtures, split by scenario).
-- You may always edit a big file; you just cannot silently grow it. If a split is
-  genuinely out of scope or too risky for the current change, re-run with
-  `CQLITE_ALLOW_FILE_GROWTH=1` to acknowledge and leave a note linking #1116/#1135.
+### File size (campsite rule)
+Keep files small — agentic context cost scales with file size. Targets (total lines, inline tests
+included): source `~800`, test files `~1500`. The gate's `file-size` ratchet FAILs if your change
+grows an over-threshold `.rs` file (or pushes one over). Touching an over-threshold file → split it
+by responsibility (source: epic #1116; tests: #1135). Genuinely out of scope → re-run with
+`CQLITE_ALLOW_FILE_GROWTH=1` and leave a note linking #1116/#1135.
 
 ### Testing
-- Integration tests use real SSTable data only
-- Validate against sstabledump output
-- JSONL reference files for parity checking
-- See [sstabledump validation playbook](https://pmcfadin.github.io/cqlite/agents-developing/validation-playbook/)
+- Integration tests use real SSTable data only; validate against `sstabledump` output via JSONL
+  reference files —
+  [validation playbook](https://pmcfadin.github.io/cqlite/agents-developing/validation-playbook/)
+- Never let a dataset-dependent test pass on an empty dataset (0-rows-when-present = failure)
 
 ### Fuzzing (issue #1614)
-- The parser fuzz harness lives at `fuzz/` — a **cargo-fuzz / libFuzzer** crate
-  that is its own workspace and is **excluded from the main workspace**, so
-  `scripts/agent-gate.sh` and every default `cargo build`/`clippy`/`test` neither
-  compile nor depend on it. Fuzzing needs **nightly** Rust and is **out of the
-  stable gate**.
-- Five targets prove the parser never panics/hangs/OOMs on arbitrary bytes
-  (returns `Ok` or `Err`): `fuzz_vint`, `fuzz_value_decode`, `fuzz_block_emit`,
-  `fuzz_bti`, `fuzz_schema_parse`. They reach `cqlite-core` internals via the
-  feature-gated `#[doc(hidden)] cqlite_core::fuzz_support` module (build with
-  `--features fuzz`), which keeps the default public API unchanged.
-- Run one target (needs `rustup toolchain install nightly` + `cargo install cargo-fuzz`):
-  ```bash
-  cd fuzz && cargo +nightly fuzz run fuzz_vint -- -max_total_time=45 -rss_limit_mb=2048 -timeout=25
-  ```
-  Or all targets: `fuzz/smoke.sh`. `fuzz_block_emit` fully exercises the
-  block-emit path only when `CQLITE_DATASETS_ROOT` points at the test datasets
-  (a real `test_basic/simple_table` fixture); otherwise it no-ops.
-- CI: `.github/workflows/fuzz.yml` runs a bounded per-target PR smoke lane and a
-  nightly long-run (both nightly + cargo-fuzz, isolated from the stable gate). A
-  crash fails the job and uploads the reproducer artifact; crashes are filed as
-  their own bug issues (not silently patched here).
-
-### Python E2E Test Architecture (Issue #323)
-
-**Primary E2E Tests** (`bindings/python/tests/`):
-- `test_parity.py`: Validates all 33 tables against JSONL golden files
-  - `TestRowCountParity`, `TestValueParity`, `TestE2ESummary`
-- `test_cli_parity.py`: Python vs CLI output equivalence
-
-**Known Issues** (tracked as XFail): none as of Dec 2025. Issue #493 (set element
-tombstones) is out-of-scope for v0.9.1.
+`fuzz/` is a cargo-fuzz/libFuzzer crate in its own workspace, excluded from the main one — the gate
+and default builds never compile it; fuzzing needs nightly and is out of the stable gate. Five
+targets prove the parser never panics/hangs/OOMs on arbitrary bytes. CI: `fuzz.yml` (PR smoke +
+nightly long-run); crashes are filed as bug issues. Run commands: `docs/development/dev-cookbook.md`.
 
 ## Test Data
 
-Location: `test-data/datasets/sstables/`
+Location: `test-data/datasets/sstables/` — keyspaces `test_basic` (8), `test_collections` (8),
+`test_timeseries` (9), `test_wide_rows` (8). **Pass rate: 100% (33/33, Dec 2025).**
 
-| Keyspace | Tables | Purpose |
-|----------|--------|---------|
-| test_basic | 8 | Simple types |
-| test_collections | 8 | Lists, sets, maps |
-| test_timeseries | 9 | Time-series patterns |
-| test_wide_rows | 8 | Wide partitions |
-
-**Current pass rate**: 100% (33/33 tables passing as of Dec 2025)
-
-### Fetching Test Data
-
-The git repository contains only JSONL reference files (for validation).
-To run integration tests with real SSTable data, fetch the binary files:
-
-```bash
-bash test-data/scripts/fetch-datasets.sh
-```
-
-Without Data.db files, query tests will pass but return 0 rows. See
-[Test data](https://pmcfadin.github.io/cqlite/agents-developing/test-data/) for
-dataset pins and cache-key rationale.
+The repo ships only JSONL reference files; fetch real binaries with
+`bash test-data/scripts/fetch-datasets.sh` and set `CQLITE_DATASETS_ROOT=$PWD/test-data/datasets`.
+Without Data.db files, query tests pass but return 0 rows. Dataset pins:
+[test data](https://pmcfadin.github.io/cqlite/agents-developing/test-data/).
 
 ## Feature Flags
 
-Default (cqlite-core): `all-compression`, `state_machine`
-
-| Feature | Description | In Defaults? |
-|---------|-------------|--------------|
-| `all-compression` | LZ4, Snappy, Deflate, Zstd support | Yes |
-| `state_machine` | Query engine and discovery | Yes |
-| `cli-helpers` | CLI-specific ingestion/REPL API (Issue #249) | No |
-| `parquet` | Embeddable Parquet export writer (Epic #682) | No |
-| `delta-scan` | CDC delta-record streaming API (Epic #696) | No |
-| `delta-export` | CLI `delta-export` subcommand (Issue #705) | No |
-| `metrics` | Performance metrics collection | No |
-| `experimental` | Experimental features | No |
-
-```bash
-# Minimal build (pure library, no query engine)
-cargo build --package cqlite-core --no-default-features --features all-compression
-
-# Build with CLI helpers for integration testing
-cargo build --package cqlite-core --features cli-helpers
-
-# Build/test core with the embeddable Parquet writer (Epic #682)
-cargo build --package cqlite-core --features parquet
-cargo test --package cqlite-core --features parquet
-```
+Default (cqlite-core): `all-compression`, `state_machine`.
+Non-default: `cli-helpers` (#249), `parquet` (#682), `delta-scan` / `delta-export` (#696/#705),
+`metrics`, `experimental`. Build recipes: `docs/development/dev-cookbook.md`.
 
 ## Troubleshooting
 
-**Missing test data**: Set `CQLITE_DATASETS_ROOT=$PWD/test-data/datasets`
-
-**Query tests return 0 rows**: Fetch SSTable Data.db files with `bash test-data/scripts/fetch-datasets.sh`
-
-**Clippy failures**: Run with `RUSTFLAGS="-D warnings"` to match CI
-
-**Parsing issues**: Check `docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md`
-
-**Python bindings won't build**: Ensure Rust 1.85+ and maturin are installed:
-```bash
-pip install maturin
-rustup update
-```
-
-**Python import errors**: Verify Python 3.9+ and rebuild bindings:
-```bash
-python3 --version  # Must be 3.9+
-cd bindings/python && maturin develop --profile dev
-```
-
-**Python tests skip or fail**: Ensure test data is available:
-```bash
-export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
-bash test-data/scripts/fetch-datasets.sh
-```
+- **Missing test data / 0 rows**: `export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets` +
+  `bash test-data/scripts/fetch-datasets.sh`
+- **Clippy failures**: run with `RUSTFLAGS="-D warnings"` to match CI
+- **Parsing issues**: `docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md`
+- **Python bindings**: Rust 1.85+, Python 3.9+, `pip install maturin`, then
+  `cd bindings/python && maturin develop --profile dev`
 
 ## Resources
 
 - **Definitive Guide**: `docs/sstables-definitive-guide/`
 - **Agent developer docs**: https://pmcfadin.github.io/cqlite/agents-developing/
-- **Project Issues**: https://github.com/pmcfadin/cqlite/issues
-- **Cassandra Source (local)**: `~/local_projects/cassandra` - Full Cassandra 5.0 codebase
-- **Cassandra Source (remote)**: https://github.com/apache/cassandra/tree/cassandra-5.0.0
+- **Issues**: https://github.com/pmcfadin/cqlite/issues
+- **Cassandra source**: `~/local_projects/cassandra` (local) /
+  https://github.com/apache/cassandra/tree/cassandra-5.0.0
 
-## Agent-team conventions
-- Implementers commit after each meaningful unit of work so roborev reviews land while context is fresh.
-- **The implement loop (issues #1821/#2084/#2086/#2087/#2088) — ONE coherent design, review before gate, gate once at the end:** `implement (TDD) → lite (each fix round) → rust-reviewer + roborev on the lite-green diff (review-first, DEFAULT) → fix (lite re-cert + diff-scoped targets, NEVER a full gate) → open PR → flow-closer {FULL gate ONCE → C → final roborev → merge-on-green → finalize}`. Use `scripts/agent-gate.sh --lite` (fmt + file-size + workspace clippy + blast-radius-scoped tests, ~1-5 min) on every fix round; it is the fast iteration loop, **NOT the gate of record**. Review runs BEFORE the first full gate (#2086) so the ONE full gate certifies already-reviewed code exactly once, immediately pre-merge (#2087); `--lite` NEVER replaces it. The full gate, C, the final roborev pass, and the merge all run inside the disposable **`flow-closer`** subagent (#2084) — the lead's context receives only its terminal packet (verdict, PR URL, summary-file path, ≤10 lines residual), never gate stdout or review churn. Its `==== AGENT-GATE SUMMARY ====` block is the only run that counts.
-- **Gate invocation is the summary-file redirect by DEFAULT, never raw stdout (issue #2079).** Every gate — full and each `--lite` round — runs as `AGENT_GATE_SUMMARY_FILE=<path> bash scripts/agent-gate.sh [--lite] > gate.log 2>&1 < /dev/null` then `cat <path>`. Never read raw gate stdout / `gate.log` into a persistent context; the SUMMARY block is the only gate text an agent retains.
-- **Test/docs-only delta re-certification (issue #1892): a post-gate polish round that touches ONLY executable tests/docs re-certifies with `--delta`, not a whole new full gate.** After a full-gate PASS at commit `X`, if the diff `X..Y` touches ONLY what the re-cert can EXECUTE — rust cargo test code (`.rs` under `tests/` dirs, `*_test(s).rs`), python binding tests (`bindings/python/tests/`, run by the #1893 python tier), Node.js binding tests (`bindings/node/__test__/*`, run against an ALREADY-BUILT native module), shell self-tests (`scripts/tests/*.sh`), and/or docs (`*.md` anywhere; TOP-LEVEL `docs/`, `website/`) — run `scripts/agent-gate.sh --delta X --anchor-run-id <X's full-gate run-id>` (or `--anchor-summary-file <path to X's full SUMMARY>`). It FAILs CLOSED — **anything** else in `X..Y` (src, scripts, workflows, `Cargo.*`, config, test-data, or an unbuilt node module, since issue #2081 moved node `__test__/` files and `scripts/tests/*.sh` from refused to executed) REFUSES the re-cert and forces a fresh full gate. On pass it runs file-size + fmt + the diff's changed test targets and emits a DISTINCT `==== AGENT-GATE DELTA SUMMARY ====` block (MODE: delta) carrying a `delta-executors:` line naming which executors ran. **Record BOTH artifacts in the PR:** the anchor's full SUMMARY (the gate of record) AND the `X..Y` DELTA block. The delta is NOT the gate of record and can never substitute for the full gate on a production change. The standing backstop is the nightly `.github/workflows/gate.yml` deep-check, which re-runs the FULL gate on `main` (owner condition, 2026-07-04). This closes the re-gate loophole where every roborev round on a Low test-robustness finding forced another 15–25 min full gate (e.g. #1853 burned 3 full gates and #1921 burned 2 on test/docs-only polish rounds). Deep `--delta` mechanics: `docs/development/gate-ops.md`.
-- **Review-first is the DEFAULT (issue #2086):** run `rust-reviewer` + roborev on the lite-green diff BEFORE the first full gate, so review discovers fixable problems before we pay for the 12-25 min gate. Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single call site AND no new surface — the narrow inverse of the old conditional). When in doubt, review.
-- **roborev findings are severity-triaged, blocker vs nit (issue #2088; rubric: `docs/development/roborev-severity.md`).** **Blockers** are fixed pre-merge — each re-triggers `fix → --lite gate (blast-radius-scoped, + any diff-relevant parity/integration target) → re-review` (issue #2087; NEVER a full gate per round). **Nits** never trigger a re-verify round: all nits from one PR's roborev pass are batched into ONE linked follow-up issue (labeled, referencing the PR) opened at merge time. When in doubt, blocker (the pre-merge full gate + CI backstop is not a net for a mis-graded blocker).
-- Stay within your assigned issue's scope; flag cross-cutting changes to the lead instead of editing another teammate's files.
-- An issue is "done" only when tests pass, coverage meets threshold, roborev is clean, and both the spec-auditor and coverage-reviewer sign off.
+## Agent-Team Conventions
+
+- Implementers commit after each meaningful unit of work so reviews land while context is fresh.
+- Stay within your assigned issue's scope; flag cross-cutting changes to the lead instead of editing
+  another teammate's files.
+- An issue is "done" only when tests pass, coverage meets threshold, roborev is clean, and both the
+  spec-auditor and coverage-reviewer sign off.
+
+### The implement loop (#1821/#2084/#2086/#2087/#2088) — ONE design, review before gate, gate once
+
+```
+implement (TDD) → --lite each fix round (summary-file redirect)
+  → rust-reviewer + roborev on the lite-green diff   (review-first, DEFAULT)
+  → fix rounds: --lite re-cert + diff-scoped targets  (NEVER a full gate per round)
+  → open PR
+  → flow-closer { FULL gate ONCE → C → final roborev → merge-on-green → finalize }
+```
+
+- **Review-first (#2086)**: review BEFORE the first full gate so the ONE gate certifies
+  already-reviewed code. Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single
+  call site AND no new surface). When in doubt, review.
+- **flow-closer (#2084)**: the full gate, C, the final roborev pass, and the merge run inside the
+  disposable `flow-closer` subagent — the lead retains only its terminal packet (verdict, PR URL,
+  summary-file path, ≤10 lines residual), never gate stdout or review churn.
+- **Severity triage (#2088, rubric `docs/development/roborev-severity.md`)**: roborev **blockers**
+  are fixed pre-merge — each re-triggers `fix → --lite → re-review` (#2087). **Nits** never trigger
+  a re-verify round: batch all of a PR's nits into ONE linked follow-up issue at merge time. When in
+  doubt, blocker. Every pre-roborev self-check class below is BLOCKER by definition.
+- **Post-gate polish (#1892)**: after a full PASS at `X`, a test/docs-only diff `X..Y` re-certifies
+  with `--delta` (fail-closed; see gate table above), never a repeat full gate. The nightly
+  `gate.yml` deep-check re-runs the FULL gate on `main` as the standing backstop.
+- `--lite` NEVER replaces the full gate — the full `AGENT-GATE SUMMARY` is the only run that counts.
 
 ### Pre-roborev self-check (common findings to pre-empt)
-`roborev_findings` is the #1 recurring delivery cost (telemetry retro). Before reporting an implementation done, scan your diff for these recurring finding classes and fix them up front — every one avoided is a review round saved. Full guidance: https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/. Findings are classified blocker vs nit per `docs/development/roborev-severity.md`; **every class listed below is BLOCKER-severity by definition** (correctness, data-parity, safety, no-heuristics, wiring-evidence, security) — fix them, they cannot ride to a nit follow-up.
-- **GitHub Actions command injection** — never interpolate `${{ inputs.* }}` / `${{ steps.*.outputs.* }}` directly into a `run:` shell (worst in a step holding secrets). Allowlist-validate the value fail-closed *before* any secret step, then pass it via a quoted env var (`-Pversion="$VAR"`), not inline `${{ }}`.
-- **clippy `manual_range_contains`** — `x >= a && x <= b` fails under `-D warnings`. Write `(a..=b).contains(&x)`.
-- **Integer overflow / saturation** — decoding into `i128`/fixed width and saturating (decimal unscaled values, scale math) loses data. Use `num_bigint::BigInt` (already a dep); bound the computation by comparing signs/adjusted-exponents *before* any large power-of-ten — never materialize `10^scale` with an unbounded exponent (DoS/OOM).
-- **Float ordering vs Java** — Rust `total_cmp` ≠ Java `Float/Double.compare`: Rust puts negative NaN first, Java sorts NaN last; also signed-zero differs. When matching Cassandra, use an explicit comparator (NaN last, `-0.0 < +0.0`).
-- **Wall-clock races in tests** — never assert a value sampled at one instant against a window captured at another (one-second boundary flakes). Capture the window to cover *all* sampled operations.
-- **No-heuristics violations** — never infer type/behavior from byte patterns; use authoritative schema/`Statistics.db` metadata (see no-heuristics mandate).
-- **Gitignored reference binaries / dirty-tree gate** — byte-parity tests silently SKIP in a clean checkout when `.db` references are gitignored. Force-add the tiny reference binaries (`git add -f`) and verify the test against a fresh `git worktree add --detach HEAD`, not the dirty tree.
+`roborev_findings` is the #1 recurring delivery cost. Full guidance:
+https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/
+- **GitHub Actions injection** — never interpolate `${{ inputs.* }}`/step outputs into `run:`;
+  allowlist-validate fail-closed before any secret step, pass via quoted env var.
+- **clippy `manual_range_contains`** — write `(a..=b).contains(&x)`.
+- **Integer overflow/saturation** — use `num_bigint::BigInt` for unscaled decimal math; compare
+  signs/adjusted-exponents first; never materialize `10^scale` with unbounded exponent.
+- **Float ordering vs Java** — `total_cmp` ≠ `Float/Double.compare`; use an explicit comparator
+  (NaN last, `-0.0 < +0.0`) when matching Cassandra.
+- **Wall-clock races in tests** — capture the time window to cover ALL sampled operations.
+- **No-heuristics violations** — never infer type/behavior from byte patterns.
+- **Gitignored reference binaries** — `git add -f` tiny parity references; verify against a fresh
+  `git worktree add --detach HEAD`, not the dirty tree.
 
 ### Spec-driven work (OpenSpec)
-- OpenSpec is the front door for **design-driven** new work (bindings/M6, query-engine surface, CLI/REPL UX, perf/M7, process). **Oracle-driven** bug fixes (SSTable parsing, compaction/tombstone parity, type decode) stay as a GitHub issue + a pinned parity test — no OpenSpec change.
-- Merge flow for a design-driven change: `apply → gate (correctness) → C (intent audit) → roborev (code) → merge → archive`. The intent audit **C** is the `spec-auditor` subagent anchored to `openspec/changes/<name>/specs/**`; it runs only after `scripts/agent-gate.sh` is green. **B** (optional) reuses `roborev-design-review-branch` with the change's artifacts as criteria — escalate when C reports `partial`, the change is high-stakes, or it touches doctrine.
-- An OpenSpec change is "done" only when the gate passes, **C reports PASS** (every requirement `satisfied` with a public-surface test as evidence; an `unmet`/uncovered/unjustified-`partial` requirement blocks merge), and roborev is clean — then `openspec archive`.
-- superpowers vs OpenSpec: superpowers are *techniques* (brainstorming, TDD, receiving-code-review); OpenSpec is the *artifact system + lifecycle*. They nest — `brainstorming` is the method inside `explore`; the OpenSpec proposal/design/tasks ARE the plan (no parallel `plan.md`). See https://pmcfadin.github.io/cqlite/agents-developing/spec-driven-audit/.
+- OpenSpec is the front door for **design-driven** work (bindings/M6, query-engine surface, CLI/REPL
+  UX, perf/M7, process). **Oracle-driven** bug fixes (SSTable parsing, compaction/tombstone parity,
+  type decode) stay a GitHub issue + pinned parity test — no OpenSpec change.
+- Merge flow (design-driven): `apply → gate → C (intent audit) → roborev → merge → archive`. **C** =
+  `spec-auditor` anchored to `openspec/changes/<name>/specs/**`, after the gate is green. **B**
+  (optional, `roborev-design-review-branch`) escalates when C reports `partial`, high stakes, or
+  doctrine is touched.
+- Done = gate PASS + **C PASS** (every requirement `satisfied` with a public-surface test as
+  evidence; `unmet`/uncovered/unjustified-`partial` blocks merge) + roborev clean → `openspec archive`.
+- superpowers are *techniques*; OpenSpec is the *artifact system* — the proposal/design/tasks ARE
+  the plan. See [spec-driven audit](https://pmcfadin.github.io/cqlite/agents-developing/spec-driven-audit/).
+
+### Wiring evidence
+A feature is done only when its public surface exercises it — a named surface + call chain + an
+end-to-end test. Green helper-only unit tests are not sufficient.
 
 ### Delivery pipeline (flow-lead)
-- The delivery lead is the **`flow-lead`** manager agent (the repo's default agent; `claude --agent flow-lead`). It orchestrates — it spawns and sequences the specialists (`sstable-developer`, `rust-reviewer`, `spec-auditor`/C, `test-validator`, `coverage-reviewer`) + roborev + `agent-gate.sh` — and does not write production code itself.
-- Pipeline verbs (skills): `flow-groom` → `flow-activate` (Seam 1: spec approval) → `flow-implement` (implement → review-first → open PR → `flow-closer`: gate → C → roborev → merge → finalize) → `flow-address` → `flow-finalize` (archive + cleanup + close); `flow-board` surfaces the single next thing. Full doctrine: https://pmcfadin.github.io/cqlite/agents-developing/delivery-pipeline/.
-- **The implement loop inside `flow-implement` (issues #1821/#2084/#2086/#2087/#2088).** `implement (TDD) → lite (each round, summary-file redirect) → rust-reviewer + roborev on the lite-green diff (review-first, DEFAULT) → fix (lite re-cert + diff-scoped targets, never a full gate) → open PR → **`flow-closer`** {FULL gate ONCE → C → final roborev → merge-on-green → finalize}`. Review runs before the first full gate (#2086); the ONE full gate of record runs once, immediately pre-merge, inside the disposable `flow-closer` subagent (#2084) which returns only a terminal packet so gate stdout / roborev churn never accretes in the lead session. roborev findings triaged blocker/nit (#2088, `docs/development/roborev-severity.md`): blockers fixed pre-merge with `--lite` re-cert (#2087), nits batched into one follow-up issue. **`--lite` NEVER replaces the full gate** — its `==== AGENT-GATE SUMMARY ====` block is the only run that counts. Rationale + measurement plan: `process_improvements.md`. **Post-gate polish rounds (issue #1892):** once the FULL gate has PASSed at `X`, a roborev/address round whose diff `X..Y` is test/docs-ONLY re-certifies with `scripts/agent-gate.sh --delta X --anchor-run-id <run-id>` (fail-closed on any production change) rather than repeating the full gate — record BOTH the anchor full SUMMARY and the DELTA block in the PR; the nightly `gate.yml` deep-check is the standing backstop.
-- **Inter-issue reset (issue #2085).** The lead is the only long-lived agent, so it compacts between issues: after each `flow-finalize` it carries ZERO prior-issue history (board renders, gate summaries, roborev findings, PR bodies, Seam-1 spec renders are dropped), re-hydrates the NEXT item from the **board alone**, and stays re-runnable from board + disk state at any point. Durable cross-issue lessons route to `MEMORY.md` / `process_improvements.md`, never the live window. Seam-1 spec bodies are NOT retained after approval — `spec-auditor` re-reads them from `openspec/changes/<slug>/`.
-- **1:1:1:1**: one issue ↔ one worktree/branch `issue-<N>-<slug>` ↔ one OpenSpec change `<slug>` ↔ one PR. The GitHub Project board `Status` field is the source of truth (one `P0`–`P3` per issue); `status:*` labels are decorative, NOT a dispatch source (Path A, #1886).
-- **Coordination & concurrency (Path A, #1886):** the GitHub Project board `Status` field is the **sole dispatch authority**; `status:*` labels are decorative/non-authoritative and MUST NOT be used to select or claim work. A session claims by **pushing the `issue-<N>-<slug>` branch to origin** (the cross-machine lock — assignee `@me` is identical for one user on two machines) + assignee + `Status=In Progress`, then re-reads. Newly created issues auto-land at `Status=Backlog` (Project built-in "item added → Backlog"). Default model is **one lead → subagents**; multiple independent sessions MUST use the claim protocol; never run N bare leads without it. **One worker per machine (#1930):** exactly one flow-lead worker runs per machine as the sole machine-load authority — it fans out to subagents but **serializes the full `agent-gate.sh` (concurrency = 1)** (the #1825 cap stops SIGKILL, not tail-latency flakes) and pre-claims by checking for **any** `issue-<N>-*` branch (any slug, not just its own). Cross-*machine* concurrency stays coordinated by the origin branch lock. The claiming session also maintains a liveness **heartbeat** (`scripts/flow/claim-heartbeat.sh beat <N>` — a cheap origin git ref, never a GitHub API call — refreshed at claim time and every stage transition) that `flow-board` uses for **deterministic reaping** (age > 4h AND no open PR), replacing the old "no recent commits" guess (issue #2089). For unattended/overnight runs, the **worker supervisor** (`scripts/local/worker-supervisor.sh`, issue #2090) recycles one worker process per issue (hard context bound = process exit; the worker writes a `.worker-last-iteration.json` marker then EXITs, never a second issue per session) with flock single-instance + preflight (load/disk/leftover-process/stop-file) + crash-loop breaker + budgets + ntfy notifications — see `docs/development/fleet-runbook.md`. **If the board is unreachable (`project` scope/auth), STOP and fix auth — do NOT dispatch from labels** (empty Ready = no work ready, not a cue to dredge labels). See the delivery-pipeline doc.
-- When spawning a subagent, pass an explicit accessible model (e.g. opus) — the pinned frontmatter model is not always accessible.
-- **Self-improvement loop (telemetry + retro).** The pipeline measures itself: `flow-finalize` stamps one record per completed issue into the append-only ledger `docs/reports/delivery-telemetry.jsonl` (schema `docs/reports/delivery-telemetry.schema.json`) via `scripts/delivery-telemetry.py record` — authoritative data only (GitHub timestamps → cycle time + phase durations; run-observed counters for claim collisions, rebases, gate pass/fail, roborev findings, rework; a counter not observed is an error, never a fabricated `0`). On a cadence the manager runs `delivery-telemetry.py retro` to rank recorded failures by a documented weighted tally (deterministic, not inferred) and file a deduped `flow-meta` improvement issue. The `delivery-telemetry` agent-gate component (SKIP-aware) covers the tool. Doctrine: `docs/development/pm-operating-loop.md`.
+- **`flow-lead`** orchestrates (the repo's default agent; `claude --agent flow-lead`) — it spawns
+  and sequences the specialists + roborev + the gate, and writes no production code. Verbs:
+  `flow-groom` → `flow-activate` (**Seam 1**: owner approves spec + design) → `flow-implement` (the
+  implement loop above) → `flow-address` → `flow-finalize`; `flow-board` = status + the single next
+  thing. Doctrine: [delivery pipeline](https://pmcfadin.github.io/cqlite/agents-developing/delivery-pipeline/).
+- **1:1:1:1**: one issue ↔ one worktree/branch `issue-<N>-<slug>` (branched from `origin/main`) ↔
+  one OpenSpec change `<slug>` ↔ one PR. Worktrees lack gitignored Data.db binaries — point
+  `CQLITE_DATASETS_ROOT` at the main repo's `test-data/datasets`.
+- **Board = sole dispatch authority (Path A, #1886)**: the GitHub Project `Status` field
+  (`Backlog/Ready/In Progress/In Review/Done`); exactly one `P0`–`P3` per issue. `status:*` labels
+  are decorative, NEVER a selection source. New issues auto-land at `Backlog`. Empty Ready column =
+  no work ready → STOP. Board unreachable (auth/scope) → STOP and fix auth; never label-dispatch.
+- **Claim protocol (cross-machine)**: claim = push the `issue-<N>-<slug>` branch to origin (THE
+  lock — assignee alone is not), set assignee + `Status=In Progress`, then re-read and proceed only
+  if you hold the branch. Maintain the liveness heartbeat
+  (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
+  `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).
+- **One worker per machine (#1930)**: one lead/worker session owns a box; it fans out subagents but
+  **serializes its own full gates** (the #1825 machine cap is a backstop, not a license) and
+  pre-claims by checking for ANY `issue-<N>-*` branch. Multiple independent sessions → separate
+  machines, each claim-protocol-gated; NEVER N bare leads without the protocol. Unattended runs:
+  `scripts/local/worker-supervisor.sh` (#2090; `docs/development/fleet-runbook.md`).
+- **Inter-issue reset (#2085)**: after each `flow-finalize` the lead drops ALL prior-issue context
+  (board renders, gate summaries, roborev findings, PR bodies, Seam-1 spec renders) and re-hydrates
+  the next item from **board + disk alone**. Seam-1 spec bodies are not retained after approval —
+  `spec-auditor` re-reads them from `openspec/changes/<slug>/`. Durable lessons → `MEMORY.md` /
+  `process_improvements.md`, never the live window.
+- Spawn subagents with an explicit accessible model (e.g. opus).
+- **Telemetry**: `flow-finalize` stamps one record per issue into
+  `docs/reports/delivery-telemetry.jsonl` via `scripts/delivery-telemetry.py record` — authoritative
+  data only (a counter not observed is an error, never a fabricated 0). On a cadence the manager
+  runs `retro` and files a deduped `flow-meta` issue. The SKIP-aware `delivery-telemetry` gate
+  component covers the tool. Doctrine: `docs/development/pm-operating-loop.md`.
+- **Keep doctrine current in the same change** — user-facing or workflow changes update CLAUDE.md
+  and the website `agents-developing/` page as part of the change.
 
-## Product-manager behavior (lead)
-- The lead acts as product manager: track epics and issues, prioritize, and keep work moving.
-- **Autonomy — auto-merge on green (default):** workers (and the lead) **merge their own PR autonomously** the moment the quality bar is met — `agent-gate.sh` PASS + **C** PASS (design-driven) + roborev clean — via `gh pr merge --squash --delete-branch` then `flow-finalize`. Do NOT wait for the owner to merge. The owner's spec approval (Seam 1) is the only standing human gate; merge is NOT a human gate. Escalate to the owner and **hold the merge** ONLY for: a genuine design-call roborev finding, a scope/product question, an unmet/uncovered requirement, or work outside the issue — and obey any manager `HOLD: merge after #N` order (block until #N lands). (This supersedes the prior "pre-authorized merge-on-green / merge is the owner's Seam 2" model.)
-- Autonomous GitHub writes still permitted within these limits: post comments; add/remove status labels; assign or reassign issues. Closing a fully-done non-epic issue with a merged linked PR (with a closing comment) is allowed; merging follows the model above.
-- Never close an epic, never change an issue's scope or title, and never make a product decision (ambiguous scope, conflicting requirements, tradeoffs) without me — collect those under a "NEEDS YOU" list and surface them.
-- Make every write traceable with a short comment so I can review or reverse it later.
+## Product-Manager Behavior (lead)
+
+- The lead acts as product manager: track epics and issues, prioritize, keep work moving.
+- **Autonomy — auto-merge on green (default)**: workers (and the lead) **merge their own PR** the
+  moment the quality bar is met — gate PASS + **C** PASS (design-driven) + roborev clean — via
+  `gh pr merge --squash --delete-branch`, then `flow-finalize`. Do NOT wait for the owner. Seam 1
+  (spec approval) is the only standing human gate. Escalate and **hold the merge** ONLY for: a
+  genuine design-call roborev finding, a scope/product question, an unmet/uncovered requirement, or
+  work outside the issue — and obey any `HOLD: merge after #N` order.
+- Autonomous GitHub writes within limits: comments; status labels; assign/reassign. Closing a
+  fully-done non-epic issue with a merged linked PR (+ closing comment) is allowed.
+- Never close an epic, change an issue's scope/title, or make a product decision (ambiguous scope,
+  conflicting requirements, tradeoffs) without the owner — collect under a "NEEDS YOU" list.
+- Every issue/PR number carries a brief description (`#1081 (multicell UDT)`, never bare `#1081`).
+- Make every write traceable with a short comment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,8 @@ ad-hoc cargo runs never count. `scripts/agent-gate.sh --list` shows the componen
 | Mode | Command | Use |
 |------|---------|-----|
 | **Full** — the gate of record | `scripts/agent-gate.sh` | ONCE per issue, immediately pre-merge, inside `flow-closer`. fmt, clippy `-D warnings`, core/integration/write/CLI tests, minimal-features build, smoke. Emits `AGENT-GATE SUMMARY`. |
-| **Lite** (#1821, ~1–5 min) | `scripts/agent-gate.sh --lite` | EVERY fix round. file-size + fmt + scoped clippy + blast-radius tests (touched package `--lib` + diff's new `--test` targets). Emits a DISTINCT `AGENT-GATE LITE SUMMARY` (MODE: lite) — can NEVER be pasted as the full SUMMARY. |
-| **Delta** (#1892) | `scripts/agent-gate.sh --delta <anchor-sha> --anchor-run-id <id>` (or `--anchor-summary-file <path>`) | Re-certify a post-full-PASS polish round whose diff is ONLY executable tests/docs (rust test code, python/node binding tests against an already-built module, `scripts/tests/*.sh`, `*.md`; #2081). FAILs CLOSED on anything else (src, scripts, workflows, `Cargo.*`, config, test-data, unbuilt node module) — never builds, never passes vacuously. Emits a DISTINCT `AGENT-GATE DELTA SUMMARY` naming the anchor; record BOTH it AND the anchor's full SUMMARY in the PR. NOT the gate of record. |
+| **Lite** (#1821, ~1–5 min) | `scripts/agent-gate.sh --lite` | EVERY fix round. file-size + fmt + scoped clippy + blast-radius tests (touched package `--lib` + diff's new `--test` targets, mapped from `git diff origin/main...HEAD`; defaults to `cqlite-core --lib` when no rust package is in the diff). Emits a DISTINCT `AGENT-GATE LITE SUMMARY` (MODE: lite) — can NEVER be pasted as the full SUMMARY. |
+| **Delta** (#1892) | `scripts/agent-gate.sh --delta <anchor-sha> --anchor-run-id <id>` (or `--anchor-summary-file <path>`) | Re-certify a post-full-PASS polish round whose diff is ONLY executable tests/docs (rust test code, python/node binding tests against an already-built module, `scripts/tests/*.sh`, `*.md`; #2081). FAILs CLOSED on anything else (src, scripts, workflows, `Cargo.*`, config, test-data, unbuilt node module) — never builds, never passes vacuously. Emits a DISTINCT `AGENT-GATE DELTA SUMMARY` naming the anchor + a `delta-executors:` line; record BOTH it AND the anchor's full SUMMARY in the PR. NOT the gate of record. |
 
 **Required invocation — summary-file redirect, never raw stdout (issues #1175/#2079), full AND lite:**
 
@@ -100,11 +100,14 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   watchdog-killed (#1855). A queued gate ≠ hung gate: under load it prints `waiting for gate slot`.
 - Defaults if `AGENT_GATE_SUMMARY_FILE` unset (per-checkout; give concurrent gates in ONE checkout
   unique paths): `.agent-gate-summary.txt` / `.agent-gate-lite-summary.txt` / `.agent-gate-delta-summary.txt`.
-- clippy is scoped per-package (#1844): whole workspace `-D warnings` but skips the DuckDB
-  amalgamation + OTel stack; `CQLITE_CLIPPY_FULL=1` (nightly `gate.yml`) runs the full matrix.
-- The FULL gate FAILs CLOSED when the fetched validation corpus is absent (#2078);
-  `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` opts out visibly in the SUMMARY. Remedy:
-  `bash test-data/scripts/fetch-datasets.sh`. `--lite`/`--only` stay lenient.
+- clippy is scoped per-package (#1844): whole workspace `-D warnings` but skips the source-built
+  DuckDB amalgamation (cqlite-cli `duckdb-tests`) + OTel stack (`observability`/
+  `observability-testing`); parquet/arrow stay linted. `CQLITE_CLIPPY_FULL=1` (nightly `gate.yml`)
+  runs the full matrix.
+- The FULL gate FAILs CLOSED when the fetched validation corpus is absent (#2078), stamping
+  `missing-fixtures: FAIL-CLOSED (#2078)`; `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` opts out visibly
+  (`missing-fixtures: OPT-OUT (...)`). Remedy: `bash test-data/scripts/fetch-datasets.sh`.
+  `--lite`/`--only` stay lenient.
 - Every SUMMARY carries an `accelerators:` line (sccache/nextest/lane state) — degradation there is
   actionable, not noise. Self-test: `bash scripts/tests/test_agent_gate_summary.sh`.
 
@@ -147,8 +150,9 @@ when schema present. Legacy heuristics live only behind the opt-in `experimental
 Doctrine: [no-heuristics](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/).
 
 ### Supported formats (version floor)
-CQLite targets Cassandra 5.0 — `na`+/`nb` BIG and `oa`/`da` BTI in scope; pre-`na` (Cassandra 3.x)
-is out of scope and SHALL NOT be introduced or reviewed for correctness (reviewers incl. roborev).
+CQLite targets Cassandra 5.0 — `na`+/`nb` BIG and `oa`/`da` BTI in scope; pre-`na` (`ma`–`me`,
+Cassandra 3.x) is out of scope and SHALL NOT be introduced, supported, or reviewed for correctness
+(reviewers incl. roborev).
 Enforced in code: `BigVersionGates::from_version` rejects `< na`, `BtiVersionGates::from_version`
 rejects non-`da` (`Error::UnsupportedVersion`); `SSTableReader::open` propagates. Do not re-litigate
 pre-`na` "regressions."
@@ -197,7 +201,7 @@ Without Data.db files, query tests pass but return 0 rows. Dataset pins:
 
 ## Feature Flags
 
-Default (cqlite-core): `all-compression`, `state_machine`.
+Default (cqlite-core): `all-compression` (LZ4, Snappy, Deflate, Zstd), `state_machine`.
 Non-default: `cli-helpers` (#249), `parquet` (#682), `delta-scan` / `delta-export` (#696/#705),
 `metrics`, `experimental`. Build recipes: `docs/development/dev-cookbook.md`.
 
@@ -243,7 +247,8 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   disposable `flow-closer` subagent — the lead retains only its terminal packet (verdict, PR URL,
   summary-file path, ≤10 lines residual), never gate stdout or review churn.
 - **Severity triage (#2088, rubric `docs/development/roborev-severity.md`)**: roborev **blockers**
-  are fixed pre-merge — each re-triggers `fix → --lite → re-review` (#2087). **Nits** never trigger
+  are fixed pre-merge — each re-triggers `fix → --lite (+ any diff-relevant parity/integration
+  target) → re-review` (#2087). **Nits** never trigger
   a re-verify round: batch all of a PR's nits into ONE linked follow-up issue at merge time. When in
   doubt, blocker. Every pre-roborev self-check class below is BLOCKER by definition.
 - **Post-gate polish (#1892)**: after a full PASS at `X`, a test/docs-only diff `X..Y` re-certifies
@@ -305,7 +310,10 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   **serializes its own full gates** (the #1825 machine cap is a backstop, not a license) and
   pre-claims by checking for ANY `issue-<N>-*` branch. Multiple independent sessions → separate
   machines, each claim-protocol-gated; NEVER N bare leads without the protocol. Unattended runs:
-  `scripts/local/worker-supervisor.sh` (#2090; `docs/development/fleet-runbook.md`).
+  `scripts/local/worker-supervisor.sh` (#2090) recycles ONE worker process per issue (hard context
+  bound = process exit; the worker writes `.worker-last-iteration.json` then EXITs — never a second
+  issue per session), with flock single-instance + preflight + crash-loop breaker + budgets + ntfy
+  (`docs/development/fleet-runbook.md`).
 - **Inter-issue reset (#2085)**: after each `flow-finalize` the lead drops ALL prior-issue context
   (board renders, gate summaries, roborev findings, PR bodies, Seam-1 spec renders) and re-hydrates
   the next item from **board + disk alone**. Seam-1 spec bodies are not retained after approval —
@@ -313,7 +321,8 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   `process_improvements.md`, never the live window.
 - Spawn subagents with an explicit accessible model (e.g. opus).
 - **Telemetry**: `flow-finalize` stamps one record per issue into
-  `docs/reports/delivery-telemetry.jsonl` via `scripts/delivery-telemetry.py record` — authoritative
+  `docs/reports/delivery-telemetry.jsonl` (schema `docs/reports/delivery-telemetry.schema.json`)
+  via `scripts/delivery-telemetry.py record` — authoritative
   data only (a counter not observed is an error, never a fabricated 0). On a cadence the manager
   runs `retro` and files a deduped `flow-meta` issue. The SKIP-aware `delivery-telemetry` gate
   component covers the tool. Doctrine: `docs/development/pm-operating-loop.md`.

--- a/docs/development/dev-cookbook.md
+++ b/docs/development/dev-cookbook.md
@@ -117,7 +117,7 @@ bindings/python/
 ├── python/cqlite/
 │   ├── __init__.py        # Python package wrapper
 │   └── __init__.pyi       # Type stubs for IDE support
-├── tests/                 # 17 test files, 360+ tests
+├── tests/                 # pytest suite (counts churn — `ls tests/test_*.py`)
 │   └── conftest.py        # Shared fixtures and path constants (Issue #330)
 ├── pyproject.toml         # Maturin build configuration
 └── Cargo.toml             # Rust dependencies
@@ -130,8 +130,8 @@ Primary E2E tests (`bindings/python/tests/`):
   - `TestRowCountParity`, `TestValueParity`, `TestE2ESummary`
 - `test_cli_parity.py`: Python vs CLI output equivalence
 
-Known issues (tracked as XFail): none as of Dec 2025. Issue #493 (set element
-tombstones) is out-of-scope for v0.9.1.
+Known issues (tracked as XFail): none currently (issue #493, set element tombstones,
+was the last and is closed).
 
 ## Node.js bindings
 
@@ -190,7 +190,7 @@ bindings/node/
 │   ├── index.js           # Enhanced entry point with error wrapper
 │   ├── index.d.ts         # Complete TypeScript definitions (Issue #312)
 │   └── error-wrapper.js   # JavaScript error enhancement layer
-├── __test__/              # 13 test files, 255 tests (Jest)
+├── __test__/              # Jest suite (counts churn — `ls __test__/*.test.js`)
 ├── jest.config.js         # Jest configuration
 ├── Cargo.toml             # napi-rs dependencies
 ├── package.json           # npm package config (@cqlite/node)

--- a/docs/development/dev-cookbook.md
+++ b/docs/development/dev-cookbook.md
@@ -1,0 +1,331 @@
+# CQLite Developer Cookbook
+
+Command reference and usage examples moved out of `CLAUDE.md` (issue #2101) to keep the per-session
+agent context lean. `CLAUDE.md` holds the rules; this file holds the recipes.
+
+For the agent gate (`scripts/agent-gate.sh`) see `CLAUDE.md` (contract) and
+`docs/development/gate-ops.md` (deep mechanics). For source layout see the
+[source map](https://pmcfadin.github.io/cqlite/agents-developing/source-map/).
+
+## Profiling loop
+
+See `docs/profiling.md`.
+
+```bash
+./scripts/profile.sh baseline        # save criterion baseline
+./scripts/profile.sh flame           # CPU flamegraphs (pprof, works in containers)
+./scripts/profile.sh heap            # dhat heap profile vs <128MB budget
+./scripts/profile.sh bench && ./scripts/profile.sh compare   # re-measure vs baseline
+./scripts/profile.sh report          # ranked bottleneck report + history.jsonl ledger
+```
+
+## CLI
+
+```bash
+# Run CLI
+cargo run --package cqlite-cli -- <command>
+
+# One-shot query mode (Issue #223)
+cargo run --package cqlite-cli -- \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 5" \
+  --out json
+```
+
+### Output format precedence
+
+- `--out` takes precedence over `--format` when both specified
+- `--query` is an alias for `--execute` (`-e`)
+- Environment variable: `CQLITE_OUT` sets default output format
+- `export` shows a determinate progress bar + ETA when `--limit N` is set (the only
+  authoritative total), a spinner otherwise, and emits no progress/summary when
+  `--quiet` or when stdout is piped/redirected (Issue #284).
+
+### CLI modes (Issue #242)
+
+The CLI supports three modes with enhanced status display:
+
+**TUI Mode** (`cqlite tui`): Full terminal UI with status bar showing:
+```
+Health: OK | Mem: 24.5 MB | Data: 1.2 GB | Status: Ready | Mode: EDIT
+```
+
+**REPL Mode** (`cqlite repl`): Interactive shell with status line:
+```
+[OK] Mem: 24.5 MB | Data: 1.2 GB
+cqlite>
+```
+
+**One-shot Mode**: Direct query execution with `--execute` or `--query` flags.
+
+Status metrics refresh every 5 seconds. Status line disabled for piped output.
+
+## Python bindings
+
+```bash
+# Build and test
+cd bindings/python && maturin develop --profile dev  # Development build (debug; overrides the release-unwind firewall pin for a fast dev loop)
+cd bindings/python && maturin build --profile release-unwind  # Release wheel (panic-unwind firewall, issue #1440 — NOT --release, which is panic=abort)
+
+# Run Python tests - fast tests only (default, Issue #331)
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets pytest bindings/python/tests -v
+
+# Run all Python tests including slow (CLI parity, performance)
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets RUN_SLOW_TESTS=1 pytest bindings/python/tests -v
+
+# Run only slow tests (CLI parity and performance)
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets pytest bindings/python/tests -m slow -v
+
+# Exclude slow tests explicitly
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets pytest bindings/python/tests -m "not slow" -v
+```
+
+```bash
+# Python usage example
+python3 -c "
+import cqlite
+with cqlite.open('test-data/datasets/sstables', schema='test-data/schemas/basic-types.cql') as db:
+    for row in db.execute('SELECT * FROM test_basic.simple_table LIMIT 5'):
+        print(row.to_dict())
+"
+
+# Python Parquet export (Epic #682)
+python3 -c "
+import cqlite
+with cqlite.open('test-data/datasets/sstables', schema='test-data/schemas/basic-types.cql') as db:
+    rows = db.export_parquet('SELECT * FROM test_basic.simple_table', '/tmp/out.parquet',
+                             row_group_size=10000, compression='snappy')
+    print(f'Exported {rows} rows')
+"
+```
+
+### Python bindings structure
+
+```
+bindings/python/
+├── src/                    # PyO3 binding implementation
+│   ├── lib.rs             # Module initialization
+│   ├── database.rs        # Database class (open/close/execute)
+│   ├── result.rs          # QueryResult, Row, StreamingIterator
+│   ├── value.rs           # CQL to Python type conversions
+│   ├── error.rs           # Exception mapping
+│   ├── config.rs          # StreamingConfig, presets
+│   ├── runtime.rs         # Tokio runtime management
+│   ├── prepared.rs        # PreparedStatement bindings
+│   └── stats.rs           # DatabaseStats bindings
+├── python/cqlite/
+│   ├── __init__.py        # Python package wrapper
+│   └── __init__.pyi       # Type stubs for IDE support
+├── tests/                 # 17 test files, 360+ tests
+│   └── conftest.py        # Shared fixtures and path constants (Issue #330)
+├── pyproject.toml         # Maturin build configuration
+└── Cargo.toml             # Rust dependencies
+```
+
+### Python E2E test architecture (Issue #323)
+
+Primary E2E tests (`bindings/python/tests/`):
+- `test_parity.py`: Validates all 33 tables against JSONL golden files
+  - `TestRowCountParity`, `TestValueParity`, `TestE2ESummary`
+- `test_cli_parity.py`: Python vs CLI output equivalence
+
+Known issues (tracked as XFail): none as of Dec 2025. Issue #493 (set element
+tombstones) is out-of-scope for v0.9.1.
+
+## Node.js bindings
+
+```bash
+# Build and test (Issue #290, #296, #306)
+cd bindings/node && npm install && npm run build  # Build native module
+cd bindings/node && npm test                       # Run all tests (Jest)
+cd bindings/node && npm run test:watch             # Watch mode for development
+cd bindings/node && npm run test:coverage          # Run with coverage report
+```
+
+```bash
+# Node.js usage example (Issue #296 - Phase 2 complete)
+node -e "
+const { Database } = require('@cqlite/node');
+(async () => {
+  const db = await Database.open('test-data/datasets/sstables', {
+    schema: 'test-data/schemas/basic-types.cql'
+  });
+  const result = await db.executeNative('SELECT * FROM test_basic.simple_table LIMIT 5');
+  console.log('Rows:', result.rowCount);
+  for (const row of result.rows) {
+    console.log(row.name);
+  }
+  await db.close();
+})();
+"
+
+# Node.js Parquet export (Epic #682)
+node -e "
+const { Database } = require('@cqlite/node');
+(async () => {
+  const db = await Database.open('test-data/datasets/sstables', {
+    schema: 'test-data/schemas/basic-types.cql'
+  });
+  const rows = await db.exportParquet(
+    'SELECT * FROM test_basic.simple_table', '/tmp/out.parquet',
+    { rowGroupSize: 10000, compression: 'snappy' });
+  console.log('Exported', rows, 'rows');
+  await db.close();
+})();
+"
+```
+
+### Node.js bindings structure
+
+```
+bindings/node/
+├── src/
+│   ├── lib.rs             # napi-rs entry point, module exports
+│   ├── database.rs        # Database class, QueryResult, ColumnInfo
+│   ├── streaming.rs       # StreamingResult for async iteration (Issue #305)
+│   ├── value.rs           # CQL to JavaScript type conversions
+│   └── error.rs           # Error mapping (cqlite_core::Error → napi::Error)
+├── lib/
+│   ├── index.js           # Enhanced entry point with error wrapper
+│   ├── index.d.ts         # Complete TypeScript definitions (Issue #312)
+│   └── error-wrapper.js   # JavaScript error enhancement layer
+├── __test__/              # 13 test files, 255 tests (Jest)
+├── jest.config.js         # Jest configuration
+├── Cargo.toml             # napi-rs dependencies
+├── package.json           # npm package config (@cqlite/node)
+└── index.d.ts             # Generated TypeScript definitions
+```
+
+**Status**: Phase 3 (Streaming) complete (Issue #305). Key APIs:
+- `Database.open(dataDir, options?)` — open with optional schema
+- `Database.execute(query)` — **deprecated** (removed next major; emits a `DeprecationWarning`); lossy legacy JSON (blob→base64 string, timestamp→ISO string, varint/decimal→bespoke strings) and slower. Use `executeNative()`
+- `Database.executeNative(query)` — native JS types (BigInt, Date, Buffer, Set, Map)
+- `Database.executeStreaming(query, config?)` — async iteration for large result sets
+- `Database.getStats()` / `Database.close()`
+
+For full Node.js API reference, TypeScript definitions, error codes, and streaming
+details, see `bindings/node/lib/index.d.ts` and the issue backlog (#290, #296–#314).
+
+## Python/Node thread safety and output parity
+
+**Python thread safety** (Issue #311, #805, #815): `Arc<Database>` + `AtomicBool`; GIL
+released during async ops; concurrent queries on the same database are safe without a
+warm-up. Full scans no longer share mutable file state: #815 removed the old
+`SSTableReader.scan_mutex` and gave every scan its own `ScanCursor` (independent
+file handle + chunk index), so N concurrent full scans run in parallel rather than
+serialized.
+
+**Python/CLI parity** (Issue #319): Python uses native types (v0.13 mapping:
+`timestamp`→`datetime`, `uuid`→`UUID`, `blob`→`bytes`, `time`→`int` ns since
+midnight, `duration`→`cqlite.Duration` — see the
+[v0.13 Migration Guide](v0.13-migration-guide.md)); CLI uses JSON
+strings. Normalization required for comparison — see
+`bindings/python/tests/test_cli_parity.py`.
+
+## Write support (CLI)
+
+```bash
+# Build with write support (Issue #392)
+cargo build --package cqlite-cli --features write-support
+
+# Write a mutation (requires --writable and --write-dir)
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql \
+  --mutation '{"table":{"keyspace":"test_basic","table":"simple_table"},"partition_key":[{"Uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}],"clustering_key":[],"operations":[{"Write":{"column":"name","value":{"Text":"Test"}}}],"timestamp_micros":1704067200000000}'
+
+# Flush memtable to SSTable
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql \
+  --flush
+
+# Issue #1253: a single combined invocation persists durably. `--execute` DML
+# now runs BEFORE the flush within the same invocation, so the inserted row
+# lands in Data.db (not just the WAL):
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql \
+  --execute "INSERT INTO test_basic.simple_table (id, name) VALUES (33333333-3333-3333-3333-333333333333, 'Carol')" \
+  --flush
+
+# Write subcommands
+cargo run --package cqlite-cli --features write-support -- \
+  maintenance --budget-ms 100 \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql
+
+cargo run --package cqlite-cli --features write-support -- \
+  write-stats \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql
+
+cargo run --package cqlite-cli --features write-support -- \
+  export-sstable /tmp/export --keyspace my_ks --table my_tbl \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql
+```
+
+## Delta-export (CDC Parquet, Issue #705 / Epic #696 DS9)
+
+Requires `--features delta-export`. Schema must be a bare `CREATE TABLE` statement
+(no `CREATE KEYSPACE` / `USE` preamble).
+
+```bash
+cargo build --package cqlite-cli --features delta-export
+
+# Export one SSTable generation as a delta-envelope Parquet file
+cargo run --package cqlite-cli --features delta-export -- \
+  delta-export test-data/datasets/sstables/test_basic/simple_table-<uuid> \
+  --schema test-data/schemas/simple_table.cql \
+  --out parquet \
+  -o /tmp/delta.parquet
+
+# With custom envelope prefix (to resolve __op/__ts column collisions)
+cargo run --package cqlite-cli --features delta-export -- \
+  delta-export test-data/datasets/sstables/test_basic/simple_table-<uuid> \
+  --schema test-data/schemas/simple_table.cql \
+  --out parquet \
+  -o /tmp/delta.parquet \
+  --envelope-prefix _cqlite_
+
+# Run delta-export integration tests
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+  cargo test --package cqlite-cli --features delta-export --test delta_export_tests
+```
+
+## Feature-flag builds
+
+```bash
+# Minimal build (pure library, no query engine)
+cargo build --package cqlite-core --no-default-features --features all-compression
+
+# Build with CLI helpers for integration testing
+cargo build --package cqlite-core --features cli-helpers
+
+# Build/test core with the embeddable Parquet writer (Epic #682)
+cargo build --package cqlite-core --features parquet
+cargo test --package cqlite-core --features parquet
+```
+
+## Fuzzing (issue #1614)
+
+Policy (nightly-only, out of the stable gate, workspace-excluded) is in `CLAUDE.md`. Run details:
+
+- Five targets prove the parser never panics/hangs/OOMs on arbitrary bytes
+  (returns `Ok` or `Err`): `fuzz_vint`, `fuzz_value_decode`, `fuzz_block_emit`,
+  `fuzz_bti`, `fuzz_schema_parse`. They reach `cqlite-core` internals via the
+  feature-gated `#[doc(hidden)] cqlite_core::fuzz_support` module (build with
+  `--features fuzz`), which keeps the default public API unchanged.
+- Run one target (needs `rustup toolchain install nightly` + `cargo install cargo-fuzz`):
+  ```bash
+  cd fuzz && cargo +nightly fuzz run fuzz_vint -- -max_total_time=45 -rss_limit_mb=2048 -timeout=25
+  ```
+  Or all targets: `fuzz/smoke.sh`. `fuzz_block_emit` fully exercises the
+  block-emit path only when `CQLITE_DATASETS_ROOT` points at the test datasets
+  (a real `test_basic/simple_table` fixture); otherwise it no-ops.
+- CI: `.github/workflows/fuzz.yml` runs a bounded per-target PR smoke lane and a
+  nightly long-run (both nightly + cargo-fuzz, isolated from the stable gate). A
+  crash fails the job and uploads the reproducer artifact; crashes are filed as
+  their own bug issues (not silently patched here).


### PR DESCRIPTION
Closes #2101.

## What
CLAUDE.md is loaded into every agent context at session start; it had grown to 661 lines by accretion. This PR compacts it to ~350 lines (rules + pointers) and extracts all usage recipes to a new `docs/development/dev-cookbook.md` — **zero information loss, zero workflow-semantics change** (no site-doctrine update required).

- **Deduped**: the implement loop was described twice near-verbatim (Agent-team conventions + Delivery pipeline) — now stated ONCE with review-first / flow-closer / severity-triage / `--delta` sub-bullets; `ci-cd-validation` skill row was listed twice.
- **Compressed**: the ~90-line gate comment block → a 3-mode table (Full/Lite/Delta) + invariants; the required summary-file-redirect invocation kept verbatim; `gate-ops.md` keeps deep mechanics. Parity-CI/toolchain narratives → rule + pointer.
- **Moved to the cookbook**: CLI usage/modes/output precedence, Python/Node build+test+examples (incl. Parquet), write-support recipes, delta-export, profiling loop, feature-flag builds, fuzz run commands, bindings structure trees, thread-safety/parity notes, Python E2E architecture.

## Verification
- **Zero-information-loss audit** (independent opus agent, old file vs new+cookbook): no critical rule/env-var/command lost. 8 flagged items restored in `aa76b281` — notably the worker-supervisor one-issue-per-process/EXIT rule, which lives NOWHERE else (fleet-runbook doesn't carry it), plus the `missing-fixtures:` stamp strings, clippy scoping package names, `all-compression` contents, lite blast-radius default, `delta-executors:` line, `ma`–`me` floor tags, telemetry schema path.
- **roborev (review-first, job 1496)**: 2 Low findings — stale snapshots inherited verbatim from the old file (test-file counts, "Dec 2025/v0.9.1" anchoring; #493 was cited as open but is CLOSED). Fixed in `63ba9698` with churn-proof pointers.
- **External anchors checked**: `sstable-developer.md` quotes the pre-roborev self-check heading by name — heading kept verbatim; `profile_report.py` / `delivery-telemetry.py` / agent references all still resolve.
- **Lite gates** (NOT the gate of record): PASS ×3 (`afd219d1`, `aa76b281`, `63ba9698`), accelerators all on.

The full gate of record runs pre-merge via flow-closer; its `==== AGENT-GATE SUMMARY ====` will be posted here.