### PR TITLE
fix(#2038): surface TTL/expiry on non-frozen collection/UDT columns (explicit + inherited)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs
@@ -249,6 +249,12 @@ impl V5CompressedLegacyParser {
         // explicit per-element expiries. Scalar-only, no per-cell allocation.
         let mut has_live_forever_element = false;
         let mut max_element_expires_at: Option<i64> = None;
+        // Issue #2038: the per-element TTL (seconds) paired with the element that
+        // owns `max_element_expires_at`. Together they let the read path surface an
+        // authoritative `CellExpiration { ttl_seconds, expires_at_seconds }` for a
+        // TTL'd non-frozen collection/UDT column (the complex-cell analogue of the
+        // scalar #1743 fix), instead of hardcoding `expiration: None`.
+        let mut max_element_ttl: Option<i32> = None;
 
         // Issue #1741 (per-element filtering): count of LIVE elements dropped from
         // the emitted container by the read-side shadow/TTL filter. Stays `0` when
@@ -282,6 +288,7 @@ impl V5CompressedLegacyParser {
         fn fold_element_expiry(
             has_live_forever: &mut bool,
             max_exp: &mut Option<i64>,
+            max_exp_ttl: &mut Option<i32>,
             cell: &ComplexCellParse,
             dropped: bool,
         ) {
@@ -291,7 +298,17 @@ impl V5CompressedLegacyParser {
                 }
             } else if let Some(ldt) = cell.element_local_deletion_time {
                 let e = ldt as u32 as i64;
+                // Issue #2038: keep the TTL paired with the element that owns the
+                // MAX expiry (ties refresh the pairing), so the read path can build
+                // an authoritative `CellExpiration`. `element_ttl` is the explicit
+                // per-element TTL decoded alongside `element_local_deletion_time`
+                // (both present iff IS_EXPIRING and NOT USE_ROW_TTL — the exact
+                // shape the writer emits for a `USING TTL` collection).
+                let is_new_max = max_exp.map_or(true, |m: i64| e >= m);
                 *max_exp = Some(max_exp.map_or(e, |m: i64| m.max(e)));
+                if is_new_max {
+                    *max_exp_ttl = cell.element_ttl.map(|t| t as i32);
+                }
             }
         }
 
@@ -346,6 +363,7 @@ impl V5CompressedLegacyParser {
                 fold_element_expiry(
                     &mut has_live_forever_element,
                     &mut max_element_expires_at,
+                    &mut max_element_ttl,
                     &cell,
                     dropped,
                 );
@@ -421,6 +439,7 @@ impl V5CompressedLegacyParser {
                 fold_element_expiry(
                     &mut has_live_forever_element,
                     &mut max_element_expires_at,
+                    &mut max_element_ttl,
                     &cell,
                     dropped,
                 );
@@ -519,6 +538,7 @@ impl V5CompressedLegacyParser {
                     fold_element_expiry(
                         &mut has_live_forever_element,
                         &mut max_element_expires_at,
+                        &mut max_element_ttl,
                         &cell,
                         dropped,
                     );
@@ -625,6 +645,7 @@ impl V5CompressedLegacyParser {
                 fold_element_expiry(
                     &mut has_live_forever_element,
                     &mut max_element_expires_at,
+                    &mut max_element_ttl,
                     &cell,
                     dropped,
                 );
@@ -713,6 +734,7 @@ impl V5CompressedLegacyParser {
                 complex_deletion,
                 has_live_forever_element,
                 max_element_expires_at,
+                max_element_ttl,
                 shadow_filtered_element_count,
             },
         ))

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs
@@ -4,14 +4,19 @@ use super::*;
 /// element's expiry, as input to [`ExpiryHomogeneity::fold`].
 ///
 /// `LiveForever` is a live element with no TTL of any kind (`!is_expiring`).
-/// `Explicit` is an element with an EXPLICIT per-element TTL (both
-/// `element_ttl` and `element_local_deletion_time` decoded — the shape a
-/// `USING TTL` collection write emits). `Unresolvable` is `is_expiring` but
-/// missing the explicit fields — the on-disk shape of a collection element
-/// that INHERITS the row's TTL (`USE_ROW_TTL`). CQLite's own writer never
-/// emits this shape for a complex cell today, but a real Cassandra-written
-/// SSTable could; since its real expiry cannot be resolved from the element
-/// alone, it always forces the homogeneity tracker to `Mixed` rather than
+/// `Explicit` is an element's EFFECTIVE `(ttl_seconds, expires_at_seconds)` —
+/// either its OWN explicit per-element TTL (both `element_ttl` and
+/// `element_local_deletion_time` decoded — the shape a per-element `USING
+/// TTL` write emits), or, for a `USE_ROW_TTL` element (a statement-level
+/// `INSERT ... USING TTL n` on a collection column — issue #2038 acceptance
+/// criteria), the INHERITED row-liveness expiry threaded in via
+/// `ElementShadow::row_ttl_seconds`/`row_expires_at` (mirroring the scalar
+/// `USE_ROW_TTL` cell path's `effective_exp = cell_exp.or(row_level_exp)`,
+/// row_data.rs ~line 736). `Unresolvable` is `is_expiring`, no explicit
+/// per-element fields, AND no row-level expiry available to inherit (e.g. a
+/// physical consumer with `element_filter: None`, or a genuinely corrupt
+/// on-disk state) — its real expiry cannot be resolved from the element
+/// alone, so it forces the homogeneity tracker to `Mixed` rather than
 /// silently treating it as live-forever or omitting it (no-heuristics, #28).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ElementExpiryShape {
@@ -21,13 +26,35 @@ enum ElementExpiryShape {
 }
 
 impl ElementExpiryShape {
+    /// `row_ttl_seconds`/`row_expires_at` are the row-liveness TTL/expiry a
+    /// `USE_ROW_TTL` element inherits (from `ElementShadow`, `None` when no
+    /// shadow context is active — i.e. every physical consumer, byte-unchanged
+    /// behavior). Both come from authoritative row-header fields (no
+    /// heuristics): `row_header.ttl` and the SAME `liveness_expires_at_seconds`
+    /// fallback the scalar `USE_ROW_TTL` cell path and the #1741 shadow filter
+    /// both use.
     #[inline]
-    fn from_cell(cell: &ComplexCellParse) -> Self {
+    fn from_cell(
+        cell: &ComplexCellParse,
+        row_ttl_seconds: Option<i32>,
+        row_expires_at: Option<i64>,
+    ) -> Self {
         if !cell.is_expiring {
             return Self::LiveForever;
         }
         match (cell.element_ttl, cell.element_local_deletion_time) {
             (Some(ttl), Some(ldt)) => Self::Explicit(ttl as i32, ldt as u32 as i64),
+            // USE_ROW_TTL shape (issue #2038 round 3): no explicit per-element
+            // TTL/LDT — both are decoded ONLY when NOT USE_ROW_TTL, so this
+            // combination unambiguously means the element inherits the row's
+            // expiry. Resolve it from the row-level values when both are
+            // available; otherwise the real expiry is unknown here.
+            (None, None) => match (row_ttl_seconds, row_expires_at) {
+                (Some(ttl_s), Some(exp_s)) => Self::Explicit(ttl_s, exp_s),
+                _ => Self::Unresolvable,
+            },
+            // Should not occur (ttl/ldt are always decoded together), but stay
+            // conservative rather than guessing (no-heuristics, #28).
             _ => Self::Unresolvable,
         }
     }
@@ -351,6 +378,15 @@ impl V5CompressedLegacyParser {
         // fix, instead of hardcoding `expiration: None`. Deliberately separate
         // from `max_element_expires_at` above (see `ExpiryHomogeneity` doc).
         let mut expiry_homogeneity = ExpiryHomogeneity::Unseen;
+        // Issue #2038 round 3: the row-liveness TTL/expiry a `USE_ROW_TTL`
+        // element inherits, threaded from the SAME `ElementShadow` the #1741
+        // shadow filter already carries (`None` for every physical consumer —
+        // byte-unchanged; `element_filter` is `Some` only on the user-facing
+        // SELECT read path).
+        let (row_ttl_seconds, row_expires_at) = element_filter
+            .as_ref()
+            .map(|f| (f.row_ttl_seconds, f.row_expires_at))
+            .unwrap_or((None, None));
 
         // Issue #1741 (per-element filtering): count of LIVE elements dropped from
         // the emitted container by the read-side shadow/TTL filter. Stays `0` when
@@ -381,12 +417,18 @@ impl V5CompressedLegacyParser {
         /// Far-future `localDeletionTime` in `[2^31, 2^32)` is recovered via
         /// `as u32 as i64`, matching the row-liveness expiry clock.
         #[inline]
+        #[allow(clippy::too_many_arguments)]
         fn fold_element_expiry(
             has_live_forever: &mut bool,
             max_exp: &mut Option<i64>,
             homogeneity: &mut ExpiryHomogeneity,
             cell: &ComplexCellParse,
             dropped: bool,
+            // Issue #2038 round 3: the inherited row-liveness TTL/expiry a
+            // `USE_ROW_TTL` element resolves against (from `ElementShadow`,
+            // `None` for every physical consumer).
+            row_ttl_seconds: Option<i32>,
+            row_expires_at: Option<i64>,
         ) {
             // Issue #2038 (roborev Medium finding): fold this element into the
             // VISIBLE-only homogeneity tracker BEFORE the `dropped`-tolerant
@@ -394,7 +436,11 @@ impl V5CompressedLegacyParser {
             // contribute to the per-cell-metadata TTL (see `ExpiryHomogeneity`
             // doc for why this is a separate, narrower aggregate).
             if !dropped {
-                *homogeneity = homogeneity.fold(ElementExpiryShape::from_cell(cell));
+                *homogeneity = homogeneity.fold(ElementExpiryShape::from_cell(
+                    cell,
+                    row_ttl_seconds,
+                    row_expires_at,
+                ));
             }
 
             if !cell.is_expiring {
@@ -461,6 +507,8 @@ impl V5CompressedLegacyParser {
                     &mut expiry_homogeneity,
                     &cell,
                     dropped,
+                    row_ttl_seconds,
+                    row_expires_at,
                 );
                 if dropped {
                     shadow_filtered_element_count += 1;
@@ -537,6 +585,8 @@ impl V5CompressedLegacyParser {
                     &mut expiry_homogeneity,
                     &cell,
                     dropped,
+                    row_ttl_seconds,
+                    row_expires_at,
                 );
                 if dropped {
                     shadow_filtered_element_count += 1;
@@ -636,6 +686,8 @@ impl V5CompressedLegacyParser {
                         &mut expiry_homogeneity,
                         &cell,
                         dropped,
+                        row_ttl_seconds,
+                        row_expires_at,
                     );
                     if dropped {
                         shadow_filtered_element_count += 1;
@@ -743,6 +795,8 @@ impl V5CompressedLegacyParser {
                     &mut expiry_homogeneity,
                     &cell,
                     dropped,
+                    row_ttl_seconds,
+                    row_expires_at,
                 );
                 if dropped {
                     shadow_filtered_element_count += 1;
@@ -1845,6 +1899,7 @@ mod tests {
             now: 200,
             row_ts: Some(5),
             row_expires_at: None,
+            row_ttl_seconds: None,
         };
         let (value, _off, meta) = parser
             .parse_complex_column_inner(
@@ -1924,6 +1979,7 @@ mod tests {
             now: 0,
             row_ts: None,
             row_expires_at: None,
+            row_ttl_seconds: None,
         };
         let (value, _off, meta) = parser
             .parse_complex_column_inner(
@@ -2028,6 +2084,7 @@ mod tests {
             now: 200,
             row_ts: Some(5),
             row_expires_at: Some(100),
+            row_ttl_seconds: Some(50),
         };
         let (value, _off, meta) = parser
             .parse_complex_column_inner(
@@ -2066,6 +2123,173 @@ mod tests {
             "the physical (no-filter) parse keeps BOTH elements (byte-unchanged)"
         );
         assert_eq!(meta_unfiltered.shadow_filtered_element_count, 0);
+    }
+
+    /// Issue #2038 (roborev 1503, round 3): #2038's acceptance criteria
+    /// explicitly require `USING TTL n` support on a non-frozen collection —
+    /// a STATEMENT-LEVEL TTL INSERT, which is exactly the `USE_ROW_TTL`
+    /// on-disk encoding (no explicit per-element TTL/LDT; the element
+    /// inherits the row's liveness expiry). Round 2's `ElementExpiryShape`
+    /// classified this shape as `Unresolvable` unconditionally, forcing
+    /// `TTL(collection)` to `None` even for a single, unambiguous, live
+    /// USE_ROW_TTL element — an unmet acceptance criterion.
+    ///
+    /// Scenario: a `list<blob>` with ONE USE_ROW_TTL element, NOT expired
+    /// (`now` < inherited row expiry). `visible_uniform_expiration` must
+    /// resolve to `Some(CellExpiration { ttl_seconds: 50, expires_at_seconds:
+    /// 1000 })` — the row-level TTL/expiry threaded via
+    /// `ElementShadow::row_ttl_seconds`/`row_expires_at`.
+    ///
+    /// Revert-verify: reverting `ElementExpiryShape::from_cell`'s `(None,
+    /// None)` arm to unconditionally return `Unresolvable` (round 2's
+    /// behavior) makes this test FAIL (`visible_uniform_expiration` becomes
+    /// `None`) — confirmed by hand before this fix landed.
+    #[test]
+    fn test_2038_use_row_ttl_element_surfaces_inherited_expiration() {
+        use super::super::test_support::helpers::encode_unsigned;
+
+        let parser = V5CompressedLegacyParser::new("k".to_string(), "t".to_string(), 0, 0, Some(0));
+        let column = crate::schema::Column {
+            name: "c".to_string(),
+            data_type: "list<blob>".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        };
+        // USE_ROW_TTL element (flags 0x12 = IS_EXPIRING 0x02 | USE_ROW_TTL 0x10):
+        // own timestamp, NO per-element localDeletionTime/TTL.
+        let use_row_ttl = |val: u8| {
+            let mut b = vec![0x12u8];
+            encode_unsigned(1, &mut b); // timestamp delta
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        let mut data = Vec::new();
+        encode_unsigned(1, &mut data); // cell_count
+        data.extend_from_slice(&use_row_ttl(0xAA));
+
+        // Row liveness TTL=50s, expiry=1000 (epoch s); now=500 (< 1000) → LIVE
+        // (not expired, not shadowed).
+        let filter = ElementShadow {
+            cover: None,
+            now: 500,
+            row_ts: Some(5),
+            row_expires_at: Some(1000),
+            row_ttl_seconds: Some(50),
+        };
+        let (value, _off, meta) = parser
+            .parse_complex_column_inner(
+                &data,
+                0,
+                &column,
+                "list<blob>",
+                false,
+                0,
+                None,
+                Some(filter),
+            )
+            .expect("parse list<blob>");
+        assert_eq!(
+            value,
+            Value::List(vec![Value::Blob(vec![0xAA])]),
+            "the live USE_ROW_TTL element survives (not expired)"
+        );
+        assert_eq!(
+            meta.visible_uniform_expiration,
+            Some(CellExpiration {
+                ttl_seconds: 50,
+                expires_at_seconds: 1000,
+            }),
+            "Issue #2038: a statement-level USING TTL n collection element \
+             (USE_ROW_TTL encoding) must surface its inherited expiry, not None"
+        );
+    }
+
+    /// Issue #2038 (roborev 1503, round 3): PRESERVE the round-2 no-over-
+    /// approximation invariant when the mix is EXPLICIT-per-element vs
+    /// INHERITED-row-TTL, not just explicit-vs-explicit (round 2 already pins
+    /// the explicit-only heterogeneous case in the integration test
+    /// `issue_2038_collection_ttl_expiring_cell.rs`).
+    ///
+    /// Scenario: a `list<blob>` with element A (EXPLICIT ttl=100,
+    /// expires_at=100) and element B (USE_ROW_TTL inheriting ttl=200,
+    /// expires_at=200) — two DIFFERENT effective expiries. Neither is
+    /// expired/shadowed at `now=50`. `visible_uniform_expiration` must be
+    /// `None`: the collection has no single TTL that describes both elements.
+    #[test]
+    fn test_2038_mixed_explicit_and_inherited_expiry_surfaces_no_expiration() {
+        use super::super::test_support::helpers::encode_unsigned;
+
+        let parser = V5CompressedLegacyParser::new("k".to_string(), "t".to_string(), 0, 0, Some(0));
+        let column = crate::schema::Column {
+            name: "c".to_string(),
+            data_type: "list<blob>".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        };
+        // Element A: EXPLICIT expiring (flags 0x02), own ts, ldt=100, ttl=100.
+        let explicit_expiring = |val: u8| {
+            let mut b = vec![0x02u8];
+            encode_unsigned(1, &mut b); // timestamp delta
+            encode_unsigned(100, &mut b); // localDeletionTime (absolute, min_ldt=0)
+            encode_unsigned(100, &mut b); // ttl (absolute, min_ttl=0)
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        // Element B: USE_ROW_TTL (flags 0x12), own ts, NO per-element ldt/ttl —
+        // inherits the row's expiry via `ElementShadow`.
+        let use_row_ttl = |val: u8| {
+            let mut b = vec![0x12u8];
+            encode_unsigned(1, &mut b); // timestamp delta
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        let mut data = Vec::new();
+        encode_unsigned(2, &mut data); // cell_count
+        data.extend_from_slice(&explicit_expiring(0xAA)); // effective (100, 100)
+        data.extend_from_slice(&use_row_ttl(0xBB)); // effective (200, 200) via row
+
+        // Row liveness TTL=200s, expiry=200 (epoch s); now=50 (< 100 and < 200)
+        // → BOTH elements are LIVE (neither expired/shadowed).
+        let filter = ElementShadow {
+            cover: None,
+            now: 50,
+            row_ts: Some(5),
+            row_expires_at: Some(200),
+            row_ttl_seconds: Some(200),
+        };
+        let (value, _off, meta) = parser
+            .parse_complex_column_inner(
+                &data,
+                0,
+                &column,
+                "list<blob>",
+                false,
+                0,
+                None,
+                Some(filter),
+            )
+            .expect("parse list<blob>");
+        assert_eq!(
+            value,
+            Value::List(vec![Value::Blob(vec![0xAA]), Value::Blob(vec![0xBB])]),
+            "both elements are live and survive"
+        );
+        assert_eq!(
+            meta.visible_uniform_expiration, None,
+            "Issue #2038 (roborev 1503): an explicit-100 element mixed with an \
+             inherited-200 element has no single TTL that describes the \
+             collection — must surface None, not over-approximate with either \
+             element's expiry, got {:?}",
+            meta.visible_uniform_expiration
+        );
     }
 
     /// Regression test for Issue #481 regression: `list<frozen<udt>>` elements

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs
@@ -1,5 +1,101 @@
 use super::*;
 
+/// Issue #2038 (roborev Medium finding): the shape of ONE visible collection
+/// element's expiry, as input to [`ExpiryHomogeneity::fold`].
+///
+/// `LiveForever` is a live element with no TTL of any kind (`!is_expiring`).
+/// `Explicit` is an element with an EXPLICIT per-element TTL (both
+/// `element_ttl` and `element_local_deletion_time` decoded — the shape a
+/// `USING TTL` collection write emits). `Unresolvable` is `is_expiring` but
+/// missing the explicit fields — the on-disk shape of a collection element
+/// that INHERITS the row's TTL (`USE_ROW_TTL`). CQLite's own writer never
+/// emits this shape for a complex cell today, but a real Cassandra-written
+/// SSTable could; since its real expiry cannot be resolved from the element
+/// alone, it always forces the homogeneity tracker to `Mixed` rather than
+/// silently treating it as live-forever or omitting it (no-heuristics, #28).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ElementExpiryShape {
+    LiveForever,
+    Explicit(i32, i64),
+    Unresolvable,
+}
+
+impl ElementExpiryShape {
+    #[inline]
+    fn from_cell(cell: &ComplexCellParse) -> Self {
+        if !cell.is_expiring {
+            return Self::LiveForever;
+        }
+        match (cell.element_ttl, cell.element_local_deletion_time) {
+            (Some(ttl), Some(ldt)) => Self::Explicit(ttl as i32, ldt as u32 as i64),
+            _ => Self::Unresolvable,
+        }
+    }
+}
+
+/// Issue #2038 (roborev Medium finding): tri-state homogeneity tracker for the
+/// per-cell-metadata `TTL()` value surfaced for a non-frozen collection/UDT
+/// column.
+///
+/// Only VISIBLE (post shadow/TTL-filter, non-tombstone) elements participate
+/// — a shadow/TTL-DROPPED element must not influence what the query layer
+/// reports for the value it actually sees. This is a SEPARATE, narrower
+/// aggregate than `max_element_expires_at`/`has_live_forever_element` above,
+/// which intentionally fold dropped elements too for the orthogonal #1741
+/// row-hidden decision (whether the WHOLE ROW should still be visible) — do
+/// not conflate the two.
+///
+/// `Uniform` is the ONLY state that surfaces a `CellExpiration`: every visible
+/// element must share the IDENTICAL explicit `(ttl_seconds,
+/// expires_at_seconds)` pair. `Unseen` (no visible elements) and `LiveForever`
+/// (every visible element has no TTL) both correctly surface `None` — there is
+/// nothing to report. `Mixed` (elements disagree, or the shape can't be
+/// resolved) ALSO surfaces `None` — correctness over over-approximating with
+/// one element's expiry for a value the query does not see uniformly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExpiryHomogeneity {
+    Unseen,
+    LiveForever,
+    Uniform(i32, i64),
+    Mixed,
+}
+
+impl ExpiryHomogeneity {
+    #[inline]
+    fn fold(self, shape: ElementExpiryShape) -> Self {
+        use ElementExpiryShape::{Explicit, LiveForever as ShapeLiveForever, Unresolvable};
+        match (self, shape) {
+            (Self::Mixed, _) => Self::Mixed,
+            (_, Unresolvable) => Self::Mixed,
+            (Self::Unseen, ShapeLiveForever) => Self::LiveForever,
+            (Self::Unseen, Explicit(t, e)) => Self::Uniform(t, e),
+            (Self::LiveForever, ShapeLiveForever) => Self::LiveForever,
+            (Self::LiveForever, Explicit(..)) => Self::Mixed,
+            (Self::Uniform(..), ShapeLiveForever) => Self::Mixed,
+            (Self::Uniform(t, e), Explicit(t2, e2)) => {
+                if t == t2 && e == e2 {
+                    Self::Uniform(t, e)
+                } else {
+                    Self::Mixed
+                }
+            }
+        }
+    }
+
+    /// Resolve to the `CellExpiration` surfaced in per-cell metadata: only
+    /// `Uniform` produces one.
+    #[inline]
+    fn into_cell_expiration(self) -> Option<CellExpiration> {
+        match self {
+            Self::Uniform(ttl_seconds, expires_at_seconds) => Some(CellExpiration {
+                ttl_seconds,
+                expires_at_seconds,
+            }),
+            _ => None,
+        }
+    }
+}
+
 impl V5CompressedLegacyParser {
     /// Parse a complex column (non-frozen collection).
     /// Complex columns have multiple cells with cell paths.
@@ -249,12 +345,12 @@ impl V5CompressedLegacyParser {
         // explicit per-element expiries. Scalar-only, no per-cell allocation.
         let mut has_live_forever_element = false;
         let mut max_element_expires_at: Option<i64> = None;
-        // Issue #2038: the per-element TTL (seconds) paired with the element that
-        // owns `max_element_expires_at`. Together they let the read path surface an
-        // authoritative `CellExpiration { ttl_seconds, expires_at_seconds }` for a
-        // TTL'd non-frozen collection/UDT column (the complex-cell analogue of the
-        // scalar #1743 fix), instead of hardcoding `expiration: None`.
-        let mut max_element_ttl: Option<i32> = None;
+        // Issue #2038 (roborev Medium finding): VISIBLE-only homogeneity tracker
+        // for the per-cell-metadata `TTL()` value surfaced for a non-frozen
+        // collection/UDT column — the complex-cell analogue of the scalar #1743
+        // fix, instead of hardcoding `expiration: None`. Deliberately separate
+        // from `max_element_expires_at` above (see `ExpiryHomogeneity` doc).
+        let mut expiry_homogeneity = ExpiryHomogeneity::Unseen;
 
         // Issue #1741 (per-element filtering): count of LIVE elements dropped from
         // the emitted container by the read-side shadow/TTL filter. Stays `0` when
@@ -288,27 +384,26 @@ impl V5CompressedLegacyParser {
         fn fold_element_expiry(
             has_live_forever: &mut bool,
             max_exp: &mut Option<i64>,
-            max_exp_ttl: &mut Option<i32>,
+            homogeneity: &mut ExpiryHomogeneity,
             cell: &ComplexCellParse,
             dropped: bool,
         ) {
+            // Issue #2038 (roborev Medium finding): fold this element into the
+            // VISIBLE-only homogeneity tracker BEFORE the `dropped`-tolerant
+            // `max_exp` aggregate below — a dropped element must never
+            // contribute to the per-cell-metadata TTL (see `ExpiryHomogeneity`
+            // doc for why this is a separate, narrower aggregate).
+            if !dropped {
+                *homogeneity = homogeneity.fold(ElementExpiryShape::from_cell(cell));
+            }
+
             if !cell.is_expiring {
                 if !dropped {
                     *has_live_forever = true;
                 }
             } else if let Some(ldt) = cell.element_local_deletion_time {
                 let e = ldt as u32 as i64;
-                // Issue #2038: keep the TTL paired with the element that owns the
-                // MAX expiry (ties refresh the pairing), so the read path can build
-                // an authoritative `CellExpiration`. `element_ttl` is the explicit
-                // per-element TTL decoded alongside `element_local_deletion_time`
-                // (both present iff IS_EXPIRING and NOT USE_ROW_TTL — the exact
-                // shape the writer emits for a `USING TTL` collection).
-                let is_new_max = max_exp.map_or(true, |m: i64| e >= m);
                 *max_exp = Some(max_exp.map_or(e, |m: i64| m.max(e)));
-                if is_new_max {
-                    *max_exp_ttl = cell.element_ttl.map(|t| t as i32);
-                }
             }
         }
 
@@ -363,7 +458,7 @@ impl V5CompressedLegacyParser {
                 fold_element_expiry(
                     &mut has_live_forever_element,
                     &mut max_element_expires_at,
-                    &mut max_element_ttl,
+                    &mut expiry_homogeneity,
                     &cell,
                     dropped,
                 );
@@ -439,7 +534,7 @@ impl V5CompressedLegacyParser {
                 fold_element_expiry(
                     &mut has_live_forever_element,
                     &mut max_element_expires_at,
-                    &mut max_element_ttl,
+                    &mut expiry_homogeneity,
                     &cell,
                     dropped,
                 );
@@ -538,7 +633,7 @@ impl V5CompressedLegacyParser {
                     fold_element_expiry(
                         &mut has_live_forever_element,
                         &mut max_element_expires_at,
-                        &mut max_element_ttl,
+                        &mut expiry_homogeneity,
                         &cell,
                         dropped,
                     );
@@ -645,7 +740,7 @@ impl V5CompressedLegacyParser {
                 fold_element_expiry(
                     &mut has_live_forever_element,
                     &mut max_element_expires_at,
-                    &mut max_element_ttl,
+                    &mut expiry_homogeneity,
                     &cell,
                     dropped,
                 );
@@ -724,6 +819,11 @@ impl V5CompressedLegacyParser {
             element_tombstone_count
         );
 
+        // Issue #2038: resolve the homogeneity tracker into the `CellExpiration`
+        // surfaced in per-cell metadata — `None` unless every VISIBLE element
+        // shared the identical explicit expiry.
+        let visible_uniform_expiration = expiry_homogeneity.into_cell_expiration();
+
         Ok((
             value,
             offset,
@@ -734,7 +834,7 @@ impl V5CompressedLegacyParser {
                 complex_deletion,
                 has_live_forever_element,
                 max_element_expires_at,
-                max_element_ttl,
+                visible_uniform_expiration,
                 shadow_filtered_element_count,
             },
         ))

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -651,6 +651,14 @@ pub(crate) struct ComplexColumnMeta {
     /// Folded into the row's `max_data_cell_expires_at` so a collection whose
     /// elements are all expired does not keep an otherwise-expired row alive.
     pub max_element_expires_at: Option<i64>,
+    /// Issue #2038: the explicit per-element TTL (seconds) paired with the element
+    /// that owns `max_element_expires_at`. Both are decoded from the authoritative
+    /// per-element cell fields (IS_EXPIRING and NOT USE_ROW_TTL — the shape a
+    /// `USING TTL` collection write emits; no heuristics). The user-facing read path
+    /// pairs them into a `CellExpiration` so `TTL(non_frozen_collection)` resolves to
+    /// the written remaining seconds instead of `null` (the complex-cell analogue of
+    /// the scalar #1743 fix). `None` when no live element carries an explicit expiry.
+    pub max_element_ttl: Option<i32>,
     /// Issue #1741 (per-element filtering): number of LIVE (non-tombstone)
     /// elements DROPPED from the emitted container by the read-side per-element
     /// shadow/TTL filter — i.e. elements shadowed by the covering deletion (own

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -608,6 +608,15 @@ pub(crate) struct ElementShadow {
     /// carries no liveness expiry, in which case such an element has no
     /// authoritative expiry and is never TTL-expired here (no-heuristics, issue #28).
     pub row_expires_at: Option<i64>,
+    /// Issue #2038 (round 3): row-liveness TTL in SECONDS — `row_header.ttl`,
+    /// paired with `row_expires_at` above to resolve a `USE_ROW_TTL` element's
+    /// EFFECTIVE `CellExpiration` for the per-cell-metadata `TTL()` value (a
+    /// statement-level `INSERT ... USING TTL n` on a non-frozen collection/UDT
+    /// column). `None` when the row carries no liveness TTL (`HAS_TTL` unset),
+    /// in which case such an element's expiry cannot be resolved here
+    /// (no-heuristics, issue #28) — mirrors the scalar `USE_ROW_TTL` cell
+    /// path's `(row_header.ttl, row_expiry)` pairing (row_data.rs ~line 726).
+    pub row_ttl_seconds: Option<i32>,
 }
 
 /// Extra metadata produced by `parse_complex_column_inner` for delta-scan callers

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -651,14 +651,23 @@ pub(crate) struct ComplexColumnMeta {
     /// Folded into the row's `max_data_cell_expires_at` so a collection whose
     /// elements are all expired does not keep an otherwise-expired row alive.
     pub max_element_expires_at: Option<i64>,
-    /// Issue #2038: the explicit per-element TTL (seconds) paired with the element
-    /// that owns `max_element_expires_at`. Both are decoded from the authoritative
-    /// per-element cell fields (IS_EXPIRING and NOT USE_ROW_TTL — the shape a
-    /// `USING TTL` collection write emits; no heuristics). The user-facing read path
-    /// pairs them into a `CellExpiration` so `TTL(non_frozen_collection)` resolves to
-    /// the written remaining seconds instead of `null` (the complex-cell analogue of
-    /// the scalar #1743 fix). `None` when no live element carries an explicit expiry.
-    pub max_element_ttl: Option<i32>,
+    /// Issue #2038 (roborev Medium finding): the `CellExpiration` surfaced in
+    /// per-cell metadata for `TTL(non_frozen_collection/UDT)`, IFF every VISIBLE
+    /// (post shadow/TTL-filter, non-tombstone) element shares the IDENTICAL
+    /// explicit `(ttl_seconds, expires_at_seconds)` pair. Decoded from the
+    /// authoritative per-element cell fields (no heuristics, #28) via the
+    /// `ExpiryHomogeneity` tracker.
+    ///
+    /// Deliberately NARROWER than `max_element_expires_at` above: a dropped
+    /// (shadow/TTL-filtered) element never contributes here (it does for
+    /// `max_element_expires_at`, which drives the orthogonal #1741 row-hidden
+    /// decision), and a MIXED collection (elements with different TTLs, or a
+    /// live-forever element mixed with an expiring one) has no single TTL that
+    /// describes it — this is `None` in that case, correctness over
+    /// over-approximating with one element's expiry. This is the complex-cell
+    /// analogue of the scalar #1743 fix, which surfaces a single-cell expiry
+    /// unambiguously.
+    pub visible_uniform_expiration: Option<CellExpiration>,
     /// Issue #1741 (per-element filtering): number of LIVE (non-tombstone)
     /// elements DROPPED from the emitted container by the read-side per-element
     /// shadow/TTL filter — i.e. elements shadowed by the covering deletion (own

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs
@@ -562,11 +562,32 @@ impl V5CompressedLegacyParser {
                             if !collection_absent {
                                 if let Some(ref mut meta_map) = cell_meta {
                                     let row_ts = row_header.timestamp.unwrap_or(0);
+                                    // Issue #2038: surface the collection's expiry so
+                                    // `TTL(non_frozen_collection/UDT)` is not always
+                                    // `null` (the complex-cell analogue of the scalar
+                                    // #1743 fix at ~line 736 below). Authoritative,
+                                    // no-heuristics: `max_element_expires_at` /
+                                    // `max_element_ttl` are the explicit per-element
+                                    // localExpirationTime + TTL decoded from the cell
+                                    // (IS_EXPIRING and NOT USE_ROW_TTL — exactly what a
+                                    // `USING TTL` collection write emits). Both must be
+                                    // present to build a `CellExpiration`; a collection
+                                    // with no expiring element stays `None` (live).
+                                    let expiration = match (
+                                        col_meta.max_element_expires_at,
+                                        col_meta.max_element_ttl,
+                                    ) {
+                                        (Some(exp_s), Some(ttl_s)) => Some(CellExpiration {
+                                            ttl_seconds: ttl_s,
+                                            expires_at_seconds: exp_s,
+                                        }),
+                                        _ => None,
+                                    };
                                     meta_map.insert(
                                         column.name.clone(),
                                         CellWriteMetadata {
                                             write_timestamp_micros: row_ts,
-                                            expiration: None,
+                                            expiration,
                                         },
                                     );
                                 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs
@@ -566,23 +566,14 @@ impl V5CompressedLegacyParser {
                                     // `TTL(non_frozen_collection/UDT)` is not always
                                     // `null` (the complex-cell analogue of the scalar
                                     // #1743 fix at ~line 736 below). Authoritative,
-                                    // no-heuristics: `max_element_expires_at` /
-                                    // `max_element_ttl` are the explicit per-element
-                                    // localExpirationTime + TTL decoded from the cell
-                                    // (IS_EXPIRING and NOT USE_ROW_TTL — exactly what a
-                                    // `USING TTL` collection write emits). Both must be
-                                    // present to build a `CellExpiration`; a collection
-                                    // with no expiring element stays `None` (live).
-                                    let expiration = match (
-                                        col_meta.max_element_expires_at,
-                                        col_meta.max_element_ttl,
-                                    ) {
-                                        (Some(exp_s), Some(ttl_s)) => Some(CellExpiration {
-                                            ttl_seconds: ttl_s,
-                                            expires_at_seconds: exp_s,
-                                        }),
-                                        _ => None,
-                                    };
+                                    // no-heuristics: `visible_uniform_expiration` is
+                                    // `Some` ONLY when every VISIBLE element shares the
+                                    // identical explicit expiry (the `ExpiryHomogeneity`
+                                    // tracker in `complex_column.rs` — roborev Medium
+                                    // finding); a mixed/heterogeneous collection, or one
+                                    // with no expiring element, stays `None` rather than
+                                    // over-approximating with a single element's TTL.
+                                    let expiration = col_meta.visible_uniform_expiration.clone();
                                     meta_map.insert(
                                         column.name.clone(),
                                         CellWriteMetadata {

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs
@@ -489,6 +489,12 @@ impl V5CompressedLegacyParser {
                                 }
                             })
                         }),
+                        // Issue #2038 (round 3): row-liveness TTL seconds, paired
+                        // with `row_expires_at` above so a `USE_ROW_TTL` collection
+                        // element's per-cell-metadata expiry can be resolved
+                        // EXACTLY like the scalar `USE_ROW_TTL` cell path's
+                        // `(row_header.ttl, row_expiry)` pairing (~line 726 below).
+                        row_ttl_seconds: row_header.ttl,
                     });
                     self.parse_complex_column(
                         data,

--- a/cqlite-core/src/storage/sstable/writer/data_writer/cells.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/cells.rs
@@ -159,7 +159,14 @@ impl DataWriter {
     /// (Cassandra `localExpirationTime`) is stamped VERBATIM from this authoritative
     /// per-cell value (e.g. a surviving expiring cell preserved through compaction),
     /// so the emitted bytes are byte-identical to the source cell. When `None`, the
-    /// LDT is derived from `SystemTime::now() + ttl` (historical fresh-write behavior).
+    /// LDT is derived from `now_seconds + ttl` (historical fresh-write behavior).
+    ///
+    /// `now_seconds` (issue #2038 Scope B, roborev): the CALLER's single captured
+    /// wall-clock reading for this whole write operation (mirrors Cassandra's
+    /// `FBUtilities.nowInSeconds()`, captured once per mutation) — NOT a fresh
+    /// `SystemTime::now()` read here. Passing a shared value keeps every
+    /// expiring cell/row/element of one write on the identical clock reading;
+    /// see `DataWriter::capture_now_seconds`.
     pub(super) fn write_cell_with_ttl(
         &self,
         buf: &mut Vec<u8>,
@@ -168,6 +175,7 @@ impl DataWriter {
         timestamp: i64,
         ttl_seconds: u32,
         explicit_ldt: Option<i32>,
+        now_seconds: i32,
     ) -> Result<()> {
         // NULL values should not be written as cells
         if matches!(value, Value::Null) {
@@ -179,7 +187,7 @@ impl DataWriter {
 
         let local_deletion_time = match explicit_ldt {
             Some(ldt) => ldt,
-            None => self.expiring_local_deletion_time(ttl_seconds)?,
+            None => self.expiring_local_deletion_time(now_seconds, ttl_seconds),
         };
 
         // Cell flags - CELL_IS_EXPIRING, NO USE_ROW_TIMESTAMP or USE_ROW_TTL
@@ -285,12 +293,35 @@ impl DataWriter {
         Ok(())
     }
 
-    pub(super) fn expiring_local_deletion_time(&self, ttl_seconds: u32) -> Result<i32> {
+    /// Capture the wall-clock "now" (seconds since epoch) ONCE per write
+    /// operation — the single fallible clock read for a whole row/mutation
+    /// write, mirroring Cassandra's `FBUtilities.nowInSeconds()` (captured
+    /// once per mutation apply, not once per cell).
+    ///
+    /// Issue #2038 Scope B (roborev blocker): `expiring_local_deletion_time`
+    /// used to read `SystemTime::now()` on every call, so a multi-element
+    /// complex column (or a multi-field UDT) written under one uniform TTL
+    /// could get a DIFFERENT `localDeletionTime` per element if the wall
+    /// clock ticked mid-write. The read-side `ExpiryHomogeneity` check
+    /// requires an EXACT match across all elements to surface `TTL(col)`, so
+    /// that skew silently defeated the whole feature. Callers now capture
+    /// `now_seconds` ONCE at the top of a row/static-row write and thread it
+    /// through every expiring cell of that write (row liveness, complex
+    /// column elements, UDT fields).
+    pub(super) fn capture_now_seconds(&self) -> Result<i32> {
         let now_seconds = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| Error::Storage(format!("System time error: {}", e)))?
             .as_secs() as i32;
-        Ok(now_seconds.saturating_add(ttl_seconds as i32))
+        Ok(now_seconds)
+    }
+
+    /// Derive an expiring cell's `localDeletionTime` from a SHARED
+    /// `now_seconds` (see [`Self::capture_now_seconds`]) plus its TTL —
+    /// infallible now that the clock read happens exactly once per write,
+    /// upstream of every call site.
+    pub(super) fn expiring_local_deletion_time(&self, now_seconds: i32, ttl_seconds: u32) -> i32 {
+        now_seconds.saturating_add(ttl_seconds as i32)
     }
 
     /// Write a tombstone cell

--- a/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
@@ -111,7 +111,23 @@ impl DataWriter {
                     return Ok(0);
                 }
                 if is_complex {
-                    self.write_complex_column(buf, col, value, mop.timestamp_micros, None)?;
+                    // Issue #2038 (Scope B, write-path): thread the mutation's
+                    // ROW-level `USING TTL` (`mop.row_ttl_seconds`, sourced from
+                    // `Mutation::ttl_seconds`) into the complex column instead of
+                    // dropping it (`None`). This mirrors the SCALAR arm below,
+                    // which writes each cell as expiring when `row_ttl_seconds` is
+                    // present; `write_complex_column` -> `write_complex_cell_header`
+                    // stamps every element cell IS_EXPIRING with
+                    // localDeletionTime = now + ttl (Cassandra's derivation), so a
+                    // row-level `USING TTL` collection/UDT write round-trips as an
+                    // expiring column and `TTL(col)` resolves to the written value.
+                    self.write_complex_column(
+                        buf,
+                        col,
+                        value,
+                        mop.timestamp_micros,
+                        mop.row_ttl_seconds,
+                    )?;
                 } else {
                     // roborev #1020 Finding 1: a frozen-UDT (or UDT-bearing frozen
                     // collection/tuple) simple-cell value is canonicalized against

--- a/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
@@ -316,6 +316,7 @@ impl DataWriter {
     /// - SET<T>: cell_path = serialized element, value = empty (HAS_EMPTY_VALUE)
     /// - MAP<K,V>: cell_path = serialized key, value = serialized value
     /// - LIST<T>: cell_path = 16-byte TimeUUID, value = serialized element
+    ///
     /// `now_seconds`: the caller's single captured wall-clock reading for this
     /// write (issue #2038 Scope B) — shared by every element cell so a
     /// multi-element collection under one uniform TTL gets an IDENTICAL

--- a/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
@@ -26,11 +26,15 @@ impl DataWriter {
     /// ops are skipped; deletes and non-null writes are written), so we return
     /// the count from here — the caller threads it straight into the emit tally,
     /// making the column count impossible to drift from Data.db.
+    /// `now_seconds`: the caller's single captured wall-clock reading for this
+    /// row write (issue #2038 Scope B) — threaded to every expiring cell
+    /// derived below instead of each one reading the clock independently.
     pub(super) fn write_merged_cells(
         &self,
         buf: &mut Vec<u8>,
         row: &RowWrite<'_>,
         schema: &TableSchema,
+        now_seconds: i32,
     ) -> Result<u64> {
         use crate::storage::write_engine::mutation::CellOperation;
 
@@ -71,7 +75,7 @@ impl DataWriter {
         for col in self.regular_columns(schema) {
             let name = col.name.as_str();
             if let Some(mop) = whole_by_col.get(name) {
-                cells_written += self.emit_whole_column_op(buf, row, col, mop)?;
+                cells_written += self.emit_whole_column_op(buf, row, col, mop, now_seconds)?;
             }
             if let Some((complex_deletion, elements)) = per_element_by_col.remove(name) {
                 self.write_complex_column_per_element(
@@ -97,6 +101,7 @@ impl DataWriter {
         row: &RowWrite<'_>,
         col: &Column,
         mop: &MergedOp<'_>,
+        now_seconds: i32,
     ) -> Result<u64> {
         use crate::storage::write_engine::mutation::CellOperation;
 
@@ -117,7 +122,14 @@ impl DataWriter {
                     // is stamped IS_EXPIRING with localDeletionTime = now + ttl, so
                     // a row-level `USING TTL` collection/UDT write round-trips.
                     let row_ttl = mop.row_ttl_seconds;
-                    self.write_complex_column(buf, col, value, mop.timestamp_micros, row_ttl)?;
+                    self.write_complex_column(
+                        buf,
+                        col,
+                        value,
+                        mop.timestamp_micros,
+                        row_ttl,
+                        now_seconds,
+                    )?;
                 } else {
                     // roborev #1020 Finding 1: a frozen-UDT (or UDT-bearing frozen
                     // collection/tuple) simple-cell value is canonicalized against
@@ -140,7 +152,7 @@ impl DataWriter {
                             )?;
                         } else {
                             // Row-level `USING TTL` write (no per-cell LDT source):
-                            // derive `now + ttl` (historical behavior).
+                            // derive `now_seconds + ttl` (historical behavior).
                             self.write_cell_with_ttl(
                                 buf,
                                 column,
@@ -148,6 +160,7 @@ impl DataWriter {
                                 mop.timestamp_micros,
                                 ttl_seconds,
                                 None,
+                                now_seconds,
                             )?;
                         }
                     } else if row.liveness_ts == Some(mop.timestamp_micros) {
@@ -175,13 +188,14 @@ impl DataWriter {
                         value,
                         mop.timestamp_micros,
                         Some(*ttl_seconds),
+                        now_seconds,
                     )?;
                 } else {
                     // roborev #1020 Finding 1: schema-aware frozen-UDT value.
                     let canon = canonicalize_udt_value(&col.data_type, value)?;
                     // Issue #1538: stamp the authoritative per-cell LDT verbatim
                     // when present (a surviving expiring cell preserved through
-                    // compaction), else derive `now + ttl`.
+                    // compaction), else derive `now_seconds + ttl`.
                     self.write_cell_with_ttl(
                         buf,
                         column,
@@ -189,6 +203,7 @@ impl DataWriter {
                         mop.timestamp_micros,
                         *ttl_seconds,
                         *local_deletion_time,
+                        now_seconds,
                     )?;
                 }
                 Ok(1)
@@ -301,6 +316,10 @@ impl DataWriter {
     /// - SET<T>: cell_path = serialized element, value = empty (HAS_EMPTY_VALUE)
     /// - MAP<K,V>: cell_path = serialized key, value = serialized value
     /// - LIST<T>: cell_path = 16-byte TimeUUID, value = serialized element
+    /// `now_seconds`: the caller's single captured wall-clock reading for this
+    /// write (issue #2038 Scope B) — shared by every element cell so a
+    /// multi-element collection under one uniform TTL gets an IDENTICAL
+    /// `localDeletionTime` across all elements (see `capture_now_seconds`).
     pub(super) fn write_complex_column(
         &self,
         buf: &mut Vec<u8>,
@@ -308,6 +327,7 @@ impl DataWriter {
         value: &Value,
         timestamp_micros: i64,
         ttl_seconds: Option<u32>,
+        now_seconds: i32,
     ) -> Result<()> {
         // Write complex deletion time: DeletionTime.LIVE
         // Cassandra canonical order: markedForDeleteAt first, then localDeletionTime
@@ -323,22 +343,29 @@ impl DataWriter {
         let dt = column.data_type.to_lowercase();
 
         if dt.starts_with("set<") || dt.starts_with("org.apache.cassandra.db.marshal.settype(") {
-            self.write_set_complex_cells(buf, value, timestamp_micros, ttl_seconds)?;
+            self.write_set_complex_cells(buf, value, timestamp_micros, ttl_seconds, now_seconds)?;
         } else if dt.starts_with("map<")
             || dt.starts_with("org.apache.cassandra.db.marshal.maptype(")
         {
-            self.write_map_complex_cells(buf, value, timestamp_micros, ttl_seconds)?;
+            self.write_map_complex_cells(buf, value, timestamp_micros, ttl_seconds, now_seconds)?;
         } else if dt.starts_with("list<")
             || dt.starts_with("org.apache.cassandra.db.marshal.listtype(")
         {
-            self.write_list_complex_cells(buf, value, timestamp_micros, ttl_seconds)?;
+            self.write_list_complex_cells(buf, value, timestamp_micros, ttl_seconds, now_seconds)?;
         } else if is_udt_marshal(&dt) {
             // Issue #927: decompose a whole-`Value::Udt` literal into per-field
             // cells (cell_path = 2-byte signed-short DECLARED field index, value =
             // field datum). Field index comes from the column's declared order, NOT
             // the literal's position — a sparse / reordered literal lands each field
             // at its correct index.
-            self.write_udt_complex_cells(buf, column, value, timestamp_micros, ttl_seconds)?;
+            self.write_udt_complex_cells(
+                buf,
+                column,
+                value,
+                timestamp_micros,
+                ttl_seconds,
+                now_seconds,
+            )?;
         } else {
             return Err(Error::InvalidInput(format!(
                 "Column '{}' has type '{}' which is not a recognized complex column type",
@@ -365,6 +392,7 @@ impl DataWriter {
         value: &Value,
         timestamp_micros: i64,
         ttl_seconds: Option<u32>,
+        now_seconds: i32,
     ) -> Result<()> {
         let udt = match value {
             Value::Udt(udt) => udt,
@@ -406,10 +434,11 @@ impl DataWriter {
                     ))
                 })?;
             let cell_path = (idx as u16).to_be_bytes().to_vec();
-            let local_deletion_time = match ttl_seconds {
-                Some(ttl) => Some(self.expiring_local_deletion_time(ttl)?),
-                None => None,
-            };
+            // Issue #2038 Scope B: derive from the SHARED `now_seconds` (not a
+            // fresh clock read per field) so every field of a multi-field UDT
+            // written under one uniform TTL gets an identical LDT.
+            let local_deletion_time =
+                ttl_seconds.map(|ttl| self.expiring_local_deletion_time(now_seconds, ttl));
             elements.push(ComplexElementWrite {
                 cell_path,
                 value: Some(field_value.clone()),
@@ -498,12 +527,22 @@ impl DataWriter {
     /// - flags: base_flags | CELL_USE_ROW_TIMESTAMP (0x08)
     ///
     /// Returns the flags byte written (for caller to check HAS_EMPTY_VALUE etc.).
+    ///
+    /// `now_seconds` (issue #2038 Scope B, roborev): the caller's SHARED
+    /// captured wall-clock reading for this write — NOT a fresh
+    /// `SystemTime::now()` read per cell. This function used to read the
+    /// clock independently on every call, so a multi-element collection
+    /// written under one uniform TTL could get a different
+    /// `local_deletion_time` per element if the clock ticked mid-write,
+    /// defeating the read-side `ExpiryHomogeneity` check (which requires an
+    /// EXACT match to surface `TTL(col)`).
     pub(super) fn write_complex_cell_header(
         &self,
         buf: &mut Vec<u8>,
         base_flags: u8,
         timestamp_micros: i64,
         ttl_seconds: Option<u32>,
+        now_seconds: i32,
     ) -> Result<()> {
         match ttl_seconds {
             Some(ttl) => {
@@ -516,11 +555,7 @@ impl DataWriter {
                 let timestamp_delta = (timestamp_micros - self.stats.min_timestamp) as u64;
                 encode_unsigned(timestamp_delta, buf);
 
-                // local_deletion_time = now + ttl
-                let now_seconds = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map_err(|e| Error::Storage(format!("System time error: {}", e)))?
-                    .as_secs() as i32;
+                // local_deletion_time = now_seconds + ttl (shared `now_seconds`).
                 let local_deletion_time = now_seconds.saturating_add(ttl as i32);
                 let ldt_delta =
                     (local_deletion_time as i64) - (self.stats.min_local_deletion_time as i64);
@@ -560,6 +595,7 @@ impl DataWriter {
         value: &Value,
         timestamp_micros: i64,
         ttl_seconds: Option<u32>,
+        now_seconds: i32,
     ) -> Result<()> {
         let elements = match value {
             Value::Set(elements) => elements,
@@ -589,6 +625,7 @@ impl DataWriter {
                 CELL_HAS_EMPTY_VALUE,
                 timestamp_micros,
                 ttl_seconds,
+                now_seconds,
             )?;
 
             // Cell path: serialized element value
@@ -610,6 +647,7 @@ impl DataWriter {
         value: &Value,
         timestamp_micros: i64,
         ttl_seconds: Option<u32>,
+        now_seconds: i32,
     ) -> Result<()> {
         let entries = match value {
             Value::Map(entries) => entries,
@@ -641,7 +679,7 @@ impl DataWriter {
         encode_unsigned(serialized.len() as u64, buf); // cell count
         for (path_bytes, value_bytes) in &serialized {
             // Cell header: flags + optional TTL fields
-            self.write_complex_cell_header(buf, 0, timestamp_micros, ttl_seconds)?;
+            self.write_complex_cell_header(buf, 0, timestamp_micros, ttl_seconds, now_seconds)?;
 
             // Cell path: serialized key
             encode_unsigned(path_bytes.len() as u64, buf);
@@ -665,6 +703,7 @@ impl DataWriter {
         value: &Value,
         timestamp_micros: i64,
         ttl_seconds: Option<u32>,
+        now_seconds: i32,
     ) -> Result<()> {
         let elements = match value {
             Value::List(elements) => elements,
@@ -688,7 +727,7 @@ impl DataWriter {
             }
 
             // Cell header: flags + optional TTL fields
-            self.write_complex_cell_header(buf, 0, timestamp_micros, ttl_seconds)?;
+            self.write_complex_cell_header(buf, 0, timestamp_micros, ttl_seconds, now_seconds)?;
 
             // Cell path: 16-byte TimeUUID
             let timeuuid = generate_list_cell_path_timeuuid(timestamp_micros, i as u64);

--- a/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
@@ -111,23 +111,13 @@ impl DataWriter {
                     return Ok(0);
                 }
                 if is_complex {
-                    // Issue #2038 (Scope B, write-path): thread the mutation's
-                    // ROW-level `USING TTL` (`mop.row_ttl_seconds`, sourced from
-                    // `Mutation::ttl_seconds`) into the complex column instead of
-                    // dropping it (`None`). This mirrors the SCALAR arm below,
-                    // which writes each cell as expiring when `row_ttl_seconds` is
-                    // present; `write_complex_column` -> `write_complex_cell_header`
-                    // stamps every element cell IS_EXPIRING with
-                    // localDeletionTime = now + ttl (Cassandra's derivation), so a
-                    // row-level `USING TTL` collection/UDT write round-trips as an
-                    // expiring column and `TTL(col)` resolves to the written value.
-                    self.write_complex_column(
-                        buf,
-                        col,
-                        value,
-                        mop.timestamp_micros,
-                        mop.row_ttl_seconds,
-                    )?;
+                    // Issue #2038 (Scope B): thread the mutation's row-level
+                    // `USING TTL` (`mop.row_ttl_seconds`) instead of dropping it
+                    // (`None`), mirroring the scalar arm below. Every element cell
+                    // is stamped IS_EXPIRING with localDeletionTime = now + ttl, so
+                    // a row-level `USING TTL` collection/UDT write round-trips.
+                    let row_ttl = mop.row_ttl_seconds;
+                    self.write_complex_column(buf, col, value, mop.timestamp_micros, row_ttl)?;
                 } else {
                     // roborev #1020 Finding 1: a frozen-UDT (or UDT-bearing frozen
                     // collection/tuple) simple-cell value is canonicalized against

--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -893,6 +893,12 @@ impl DataWriter {
     ) -> Result<(Vec<u8>, u64)> {
         let mut body = Vec::new();
 
+        // Issue #2038 Scope B: capture "now" ONCE for this entire row write and
+        // share it with every expiring cell derived below (row liveness AND,
+        // via `write_merged_cells`, every complex-column element / UDT field) —
+        // see `DataWriter::capture_now_seconds`.
+        let now_seconds = self.capture_now_seconds()?;
+
         // Write timestamp delta (if HAS_TIMESTAMP)
         //
         // Fix #644 (S6): Cassandra writes UNSIGNED VInt for all temporal deltas.
@@ -923,7 +929,7 @@ impl DataWriter {
                 }
                 encode_unsigned(ttl_delta as u64, &mut body);
 
-                let local_deletion_time = self.expiring_local_deletion_time(ttl)?;
+                let local_deletion_time = self.expiring_local_deletion_time(now_seconds, ttl);
                 let ldt_delta =
                     (local_deletion_time as i64) - (self.stats.min_local_deletion_time as i64);
                 if ldt_delta < 0 {
@@ -973,7 +979,7 @@ impl DataWriter {
         }
 
         // Write cell data (none survive for pure row tombstones)
-        let cells_written = self.write_merged_cells(&mut body, row, schema)?;
+        let cells_written = self.write_merged_cells(&mut body, row, schema, now_seconds)?;
 
         Ok((body, cells_written))
     }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
@@ -200,6 +200,11 @@ impl DataWriter {
     ) -> Result<(Vec<u8>, u64)> {
         let mut body = Vec::new();
 
+        // Issue #2038 Scope B: capture "now" ONCE for this static row write and
+        // share it with every expiring cell derived below (mirrors
+        // `build_merged_row_body`; see `DataWriter::capture_now_seconds`).
+        let now_seconds = self.capture_now_seconds()?;
+
         // Write timestamp delta (if HAS_TIMESTAMP)
         //
         // Fix #644 (S6): Cassandra writes UNSIGNED VInt for all temporal deltas.
@@ -225,7 +230,7 @@ impl DataWriter {
                 }
                 encode_unsigned(ttl_delta as u64, &mut body);
 
-                let local_deletion_time = self.expiring_local_deletion_time(ttl)?;
+                let local_deletion_time = self.expiring_local_deletion_time(now_seconds, ttl);
                 let ldt_delta =
                     (local_deletion_time as i64) - (self.stats.min_local_deletion_time as i64);
                 if ldt_delta < 0 {
@@ -301,7 +306,8 @@ impl DataWriter {
         }
 
         // Write cell data for static columns only
-        let cells_written = self.write_static_cells(&mut body, static_ops, liveness_ts, schema)?;
+        let cells_written =
+            self.write_static_cells(&mut body, static_ops, liveness_ts, schema, now_seconds)?;
 
         Ok((body, cells_written))
     }
@@ -353,6 +359,7 @@ impl DataWriter {
         static_ops: &[StaticMergedOp],
         liveness_ts: i64,
         schema: &TableSchema,
+        now_seconds: i32,
     ) -> Result<u64> {
         // Get set of static column names for validation
         let static_column_names: std::collections::HashSet<_> = schema
@@ -395,7 +402,8 @@ impl DataWriter {
                                              // stays byte-identical (explicit-ts, flags 0x00).
                         match mop.row_ttl_seconds {
                             // Row-level `USING TTL` static write (no per-cell LDT
-                            // source): derive `now + ttl` (historical behavior).
+                            // source): derive `now_seconds + ttl` (historical
+                            // behavior).
                             Some(ttl) => self.write_cell_with_ttl(
                                 buf,
                                 column,
@@ -403,6 +411,7 @@ impl DataWriter {
                                 mop.timestamp_micros,
                                 ttl,
                                 None,
+                                now_seconds,
                             )?,
                             None => self.write_cell_explicit_ts(
                                 buf,
@@ -432,6 +441,7 @@ impl DataWriter {
                             mop.timestamp_micros,
                             *ttl_seconds,
                             *local_deletion_time,
+                            now_seconds,
                         )?;
                     }
                 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_2.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_2.rs
@@ -584,6 +584,7 @@ fn test_write_cell_with_ttl() {
             timestamp,
             ttl_seconds,
             None,
+            TEST_NOW_SECONDS,
         )
         .unwrap();
 
@@ -764,6 +765,7 @@ fn test_ttl_zero_special_case() {
             timestamp,
             ttl_seconds,
             None,
+            TEST_NOW_SECONDS,
         )
         .unwrap();
 
@@ -794,8 +796,15 @@ fn test_ttl_cell_with_null_value() {
     let writer = DataWriter::new(stats);
 
     let mut buf = Vec::new();
-    let result =
-        writer.write_cell_with_ttl(&mut buf, "test_col", &Value::Null, 1001000, 3600, None);
+    let result = writer.write_cell_with_ttl(
+        &mut buf,
+        "test_col",
+        &Value::Null,
+        1001000,
+        3600,
+        None,
+        TEST_NOW_SECONDS,
+    );
 
     assert!(result.is_err(), "NULL values should return error");
     assert!(result
@@ -825,6 +834,7 @@ fn test_ttl_cell_local_deletion_time_calculation() {
             timestamp,
             ttl_seconds,
             None,
+            TEST_NOW_SECONDS,
         )
         .unwrap();
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
@@ -310,6 +310,7 @@ fn static_using_ttl_write_emits_expiring_cell_1196() {
             std::slice::from_ref(&static_op),
             1_001_000,
             &schema,
+            TEST_NOW_SECONDS,
         )
         .unwrap();
 
@@ -361,6 +362,7 @@ fn static_write_without_ttl_stays_non_expiring_1196() {
             std::slice::from_ref(&static_op),
             1_001_000,
             &schema,
+            TEST_NOW_SECONDS,
         )
         .unwrap();
 
@@ -424,6 +426,14 @@ fn static_using_ttl_write_byte_parity_1210() {
         .unwrap()
         .as_secs() as i64;
 
+    // Issue #2038 Scope B: `write_static_cells` no longer reads the clock
+    // itself — the caller (normally `build_static_row_body`) captures
+    // `now_seconds` ONCE and passes it in. Mirror that here with a single
+    // capture shared by BOTH calls below, so their LDTs land in the SAME
+    // `[before, after]` window (and, being identical, trivially satisfy the
+    // cross-check further down).
+    let now_seconds = writer.capture_now_seconds().unwrap();
+
     // Path under test: row-level USING TTL arrives as a plain `Write` carrying
     // the statement TTL in `row_ttl_seconds` (how the CQL builders shape it).
     let row_ttl_op = StaticMergedOp {
@@ -442,6 +452,7 @@ fn static_using_ttl_write_byte_parity_1210() {
             std::slice::from_ref(&row_ttl_op),
             timestamp,
             &schema,
+            now_seconds,
         )
         .unwrap();
 
@@ -512,6 +523,7 @@ fn static_using_ttl_write_byte_parity_1210() {
             std::slice::from_ref(&ref_op),
             timestamp,
             &schema,
+            now_seconds,
         )
         .unwrap();
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_4.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_4.rs
@@ -104,7 +104,7 @@ fn test_write_set_complex_column() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1001000, None)
+        .write_complex_column(&mut buf, &column, &value, 1001000, None, TEST_NOW_SECONDS)
         .unwrap();
 
     assert!(!buf.is_empty());
@@ -118,6 +118,78 @@ fn test_write_set_complex_column() {
         cell_flags.iter().all(|&f| f == expected_cell_flags),
         "Should have 2 SET cells with USE_ROW_TIMESTAMP | HAS_EMPTY_VALUE flags, got: {:?}",
         cell_flags
+    );
+}
+
+/// Issue #2038 Scope B (roborev blocker): a multi-element SET written under
+/// one uniform TTL must give EVERY element cell the IDENTICAL
+/// `localDeletionTime` delta — not merely "present". Before the fix,
+/// `write_complex_cell_header` read `SystemTime::now()` independently on
+/// EVERY cell, so a multi-element collection could get a DIFFERENT LDT per
+/// element if the wall clock ticked mid-write; the read-side
+/// `ExpiryHomogeneity` check requires an EXACT match to surface `TTL(col)`,
+/// so that skew silently defeated the whole #2038 feature for any collection
+/// unlucky enough to straddle a clock tick.
+///
+/// This test calls `write_complex_column` with an EXPLICIT `now_seconds`
+/// (the same parameter production code now threads down from
+/// `capture_now_seconds`, captured once per row write) and decodes the raw
+/// cell wire format to assert every one of 5 elements carries the SAME
+/// `ldt_delta` — deterministic, no wall-clock race. A revert to the old
+/// per-call `SystemTime::now()` behavior cannot be exercised through this
+/// signature at all (the shared `now_seconds` parameter did not exist before
+/// this fix), which is itself the structural guarantee: there is no code
+/// path left that can read the clock more than once per row write.
+#[test]
+fn set_complex_column_uniform_ttl_shares_identical_ldt_across_elements() {
+    let mut stats = create_test_stats();
+    stats.min_timestamp = 1_000_000;
+    stats.min_local_deletion_time = 0;
+    stats.min_ttl = 0;
+    let writer = DataWriter::new(stats);
+
+    let column = Column {
+        name: "tags".to_string(),
+        data_type: "set<int>".to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    };
+
+    let value = Value::Set((0..5).map(Value::Integer).collect::<Vec<_>>());
+
+    let mut buf = Vec::new();
+    writer
+        .write_complex_column(
+            &mut buf,
+            &column,
+            &value,
+            1_001_000,
+            Some(3_600),
+            TEST_NOW_SECONDS,
+        )
+        .unwrap();
+
+    let (_del_ts, _del_ldt, cells) = decode_complex_column(&buf);
+    assert_eq!(cells.len(), 5, "5 SET elements => 5 cells");
+
+    let ldt_deltas: Vec<u64> = cells
+        .iter()
+        .map(|c| {
+            c.ldt_delta
+                .expect("Issue #2038 Scope B: every element of a uniform-TTL SET must be expiring")
+        })
+        .collect();
+    assert!(
+        ldt_deltas.windows(2).all(|w| w[0] == w[1]),
+        "Issue #2038 Scope B: every element of a uniform-TTL SET must share the \
+         IDENTICAL localDeletionTime delta, got {ldt_deltas:?}"
+    );
+    // With min_local_deletion_time == 0, the delta IS the absolute LDT.
+    let expected_ldt = (TEST_NOW_SECONDS as i64 + 3_600) as u64;
+    assert_eq!(
+        ldt_deltas[0], expected_ldt,
+        "localDeletionTime must equal the shared now_seconds + ttl"
     );
 }
 
@@ -141,7 +213,7 @@ fn test_write_map_complex_column() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1001000, None)
+        .write_complex_column(&mut buf, &column, &value, 1001000, None, TEST_NOW_SECONDS)
         .unwrap();
 
     assert!(!buf.is_empty());
@@ -174,7 +246,7 @@ fn test_write_list_complex_column() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1001000, None)
+        .write_complex_column(&mut buf, &column, &value, 1001000, None, TEST_NOW_SECONDS)
         .unwrap();
 
     assert!(!buf.is_empty());
@@ -496,7 +568,7 @@ fn test_set_canonical_ordering() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1001000, None)
+        .write_complex_column(&mut buf, &column, &value, 1001000, None, TEST_NOW_SECONDS)
         .unwrap();
 
     // Extract cell paths from the binary output.
@@ -538,7 +610,7 @@ fn test_map_canonical_ordering() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1001000, None)
+        .write_complex_column(&mut buf, &column, &value, 1001000, None, TEST_NOW_SECONDS)
         .unwrap();
 
     let buf_str = String::from_utf8_lossy(&buf);
@@ -569,7 +641,8 @@ fn test_set_rejects_list_value() {
     // Pass a List value to a SET column — should be rejected
     let value = Value::List(vec![Value::Text("x".to_string())]);
     let mut buf = Vec::new();
-    let result = writer.write_complex_column(&mut buf, &column, &value, 1001000, None);
+    let result =
+        writer.write_complex_column(&mut buf, &column, &value, 1001000, None, TEST_NOW_SECONDS);
     assert!(result.is_err(), "SET column should reject Value::List");
 }
 
@@ -589,7 +662,8 @@ fn test_list_rejects_set_value() {
     // Pass a Set value to a LIST column — should be rejected
     let value = Value::Set(vec![Value::Text("x".to_string())]);
     let mut buf = Vec::new();
-    let result = writer.write_complex_column(&mut buf, &column, &value, 1001000, None);
+    let result =
+        writer.write_complex_column(&mut buf, &column, &value, 1001000, None, TEST_NOW_SECONDS);
     assert!(result.is_err(), "LIST column should reject Value::Set");
 }
 
@@ -1129,7 +1203,14 @@ fn test_set_complex_column_with_ttl() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1001000, Some(3600))
+        .write_complex_column(
+            &mut buf,
+            &column,
+            &value,
+            1001000,
+            Some(3600),
+            TEST_NOW_SECONDS,
+        )
         .unwrap();
 
     // Parse cell flags structurally so wall-clock LDT bytes in the header and
@@ -1329,7 +1410,7 @@ fn test_nonfrozen_set_int_negative_sorts_signed() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1_001_000, None)
+        .write_complex_column(&mut buf, &column, &value, 1_001_000, None, TEST_NOW_SECONDS)
         .unwrap();
 
     let (_, _, cells) = decode_complex_column(&buf);
@@ -1369,7 +1450,7 @@ fn test_nonfrozen_map_int_key_negative_sorts_signed() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1_001_000, None)
+        .write_complex_column(&mut buf, &column, &value, 1_001_000, None, TEST_NOW_SECONDS)
         .unwrap();
 
     let (_, _, cells) = decode_complex_column(&buf);

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_5.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_5.rs
@@ -31,7 +31,14 @@ fn test_map_complex_column_with_ttl() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1001000, Some(7200))
+        .write_complex_column(
+            &mut buf,
+            &column,
+            &value,
+            1001000,
+            Some(7200),
+            TEST_NOW_SECONDS,
+        )
         .unwrap();
 
     // Parse cell flags structurally so wall-clock LDT bytes cannot be
@@ -83,12 +90,26 @@ fn test_list_complex_column_with_ttl() {
 
     let mut buf_ttl = Vec::new();
     writer_ttl
-        .write_complex_column(&mut buf_ttl, &column, &value, 1001000, Some(1800))
+        .write_complex_column(
+            &mut buf_ttl,
+            &column,
+            &value,
+            1001000,
+            Some(1800),
+            TEST_NOW_SECONDS,
+        )
         .unwrap();
 
     let mut buf_no_ttl = Vec::new();
     writer_no_ttl
-        .write_complex_column(&mut buf_no_ttl, &column, &value, 1001000, None)
+        .write_complex_column(
+            &mut buf_no_ttl,
+            &column,
+            &value,
+            1001000,
+            None,
+            TEST_NOW_SECONDS,
+        )
         .unwrap();
 
     // TTL version must be larger: each cell gets timestamp + LDT + TTL deltas
@@ -143,7 +164,7 @@ fn test_complex_column_no_ttl_uses_row_timestamp() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &column, &value, 1001000, None)
+        .write_complex_column(&mut buf, &column, &value, 1001000, None, TEST_NOW_SECONDS)
         .unwrap();
 
     // Without TTL: USE_ROW_TIMESTAMP | HAS_EMPTY_VALUE = 0x0C.
@@ -1270,7 +1291,7 @@ fn udt_whole_write_roundtrips_sparse_out_of_order() {
     let row_ts = 1_005_000i64;
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &col, &udt, row_ts, None)
+        .write_complex_column(&mut buf, &col, &udt, row_ts, None, TEST_NOW_SECONDS)
         .unwrap();
 
     // Decode the raw bytes: two cells (name idx 0, email idx 2), ascending
@@ -1315,6 +1336,17 @@ fn udt_whole_write_roundtrips_sparse_out_of_order() {
 
 /// Row TTL on a whole-UDT write must propagate to every emitted field cell as
 /// an expiring cell (issue #927 item 4 / roborev job 929).
+///
+/// Issue #2038 Scope B (roborev blocker): also pins that every field cell's
+/// `localDeletionTime` delta is IDENTICAL, not merely present. Before the
+/// fix, `write_udt_complex_cells` read `SystemTime::now()` independently for
+/// EACH field, so a multi-field UDT under one uniform TTL could get a
+/// different LDT per field if the wall clock ticked mid-write — silently
+/// defeating the read-side `ExpiryHomogeneity` uniformity check. With a
+/// SHARED `now_seconds` this is now guaranteed deterministically, not just
+/// "the clock happened not to tick" (multiple fields written in one call
+/// with a fixed `TEST_NOW_SECONDS` would already coincidentally match even
+/// pre-fix within a test run, so the deterministic guarantee is the point).
 #[test]
 fn udt_whole_write_propagates_row_ttl() {
     let writer = DataWriter::new(create_test_stats());
@@ -1330,11 +1362,19 @@ fn udt_whole_write_propagates_row_ttl() {
 
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &col, &udt, 1_005_000, Some(3_600))
+        .write_complex_column(
+            &mut buf,
+            &col,
+            &udt,
+            1_005_000,
+            Some(3_600),
+            TEST_NOW_SECONDS,
+        )
         .unwrap();
 
     let (_d, _l, cells) = decode_complex_column(&buf);
     assert_eq!(cells.len(), 2);
+    let mut ldt_deltas = Vec::new();
     for c in &cells {
         assert_ne!(
             c.flags & CELL_IS_EXPIRING,
@@ -1344,7 +1384,13 @@ fn udt_whole_write_propagates_row_ttl() {
         );
         assert!(c.ttl_delta.is_some(), "expiring cell carries a TTL delta");
         assert!(c.ldt_delta.is_some(), "expiring cell carries an LDT delta");
+        ldt_deltas.push(c.ldt_delta.unwrap());
     }
+    assert!(
+        ldt_deltas.windows(2).all(|w| w[0] == w[1]),
+        "Issue #2038 Scope B: every field cell of a uniform-TTL UDT write must \
+         share the IDENTICAL localDeletionTime delta, got {ldt_deltas:?}"
+    );
 }
 
 /// A whole-UDT literal naming a field that is not declared is authoritative
@@ -1360,7 +1406,7 @@ fn udt_whole_write_rejects_unknown_field() {
     }));
     let mut buf = Vec::new();
     let err = writer
-        .write_complex_column(&mut buf, &col, &udt, 1_005_000, None)
+        .write_complex_column(&mut buf, &col, &udt, 1_005_000, None, TEST_NOW_SECONDS)
         .unwrap_err();
     assert!(
         matches!(err, Error::InvalidInput(_)),

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_6.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_6.rs
@@ -1430,7 +1430,7 @@ fn bare_udt_with_registry_roundtrips_sparse_out_of_order() {
     let row_ts = 1_005_000i64;
     let mut buf = Vec::new();
     writer
-        .write_complex_column(&mut buf, &col, &udt, row_ts, None)
+        .write_complex_column(&mut buf, &col, &udt, row_ts, None, TEST_NOW_SECONDS)
         .expect("normalized bare UDT must write as a complex column");
 
     let (_del_ts, _del_ldt, cells) = decode_complex_column(&buf);

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/support.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/support.rs
@@ -12,6 +12,12 @@ use crate::storage::write_engine::mutation::{CellOperation, ClusteringKey, Parti
 use crate::types::UdtValue;
 use std::collections::HashMap;
 
+/// Fixed `now_seconds` (issue #2038 Scope B) for tests that call the
+/// TTL-deriving writer helpers directly (bypassing the row-write entry points
+/// that now capture the wall clock once via `capture_now_seconds`). A pinned
+/// value keeps LDT-derived assertions deterministic.
+pub(super) const TEST_NOW_SECONDS: i32 = 1_700_000_000;
+
 /// Whether a simple (non-complex) cell value has a fixed byte size or a variable
 /// length encoded by a preceding unsigned VInt.
 ///

--- a/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
+++ b/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
@@ -200,8 +200,10 @@ fn collection_ttl_write_round_trips_as_expiring_cell() {
 
     assert_eq!(results.len(), 1, "expected the single row written");
 
-    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
-        results.into_iter().map(|(k, _v, m)| (k.0.to_vec(), m)).collect();
+    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> = results
+        .into_iter()
+        .map(|(k, _v, m)| (k.0.to_vec(), m))
+        .collect();
 
     let meta = by_pk
         .get(1_i32.to_be_bytes().as_slice())
@@ -288,8 +290,10 @@ fn collection_row_ttl_write_round_trips_as_expiring_cell() {
 
     assert_eq!(results.len(), 1, "expected the single row written");
 
-    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
-        results.into_iter().map(|(k, _v, m)| (k.0.to_vec(), m)).collect();
+    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> = results
+        .into_iter()
+        .map(|(k, _v, m)| (k.0.to_vec(), m))
+        .collect();
     let meta = by_pk
         .get(1_i32.to_be_bytes().as_slice())
         .expect("row for id=1 present");
@@ -558,8 +562,10 @@ fn test_heterogeneous_element_ttls_surface_no_expiration() {
 
     assert_eq!(results.len(), 1, "expected the single row written");
 
-    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
-        results.into_iter().map(|(k, _v, m)| (k.0.to_vec(), m)).collect();
+    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> = results
+        .into_iter()
+        .map(|(k, _v, m)| (k.0.to_vec(), m))
+        .collect();
     let meta = by_pk
         .get(1_i32.to_be_bytes().as_slice())
         .expect("row for id=1 present");

--- a/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
+++ b/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
@@ -1,0 +1,190 @@
+//! Issue #2038: a NON-FROZEN collection (or UDT) column written with a TTL must
+//! round-trip so that its per-cell metadata surfaces the expiry — so
+//! `TTL(collection_col)` resolves to the authoritative value instead of `null`.
+//!
+//! This is the complex-column analogue of #1743, which fixed only the SCALAR
+//! cell path. Root cause (read side): the complex-column per-cell metadata
+//! builder in `v5_compressed_legacy/row_data.rs` hardcoded `expiration: None`,
+//! so a non-frozen collection/UDT column written as expiring (each element cell
+//! IS_EXPIRING with its own explicit TTL + localExpirationTime — exactly what a
+//! `USING TTL` collection write emits) surfaced NO expiry, and `TTL(col)`
+//! returned `null` even though the on-disk cells ARE expiring.
+//!
+//! The fix pairs the authoritative per-element aggregate that the reader already
+//! computes (`max_element_expires_at` = the max localExpirationTime across the
+//! collection's explicit-TTL elements) with its element's `max_element_ttl`
+//! (added by this issue) into a `CellExpiration { ttl_seconds, expires_at_seconds }`.
+//! No heuristics: both come from the decoded per-element cell fields.
+//!
+//! WRITE→READ regression guard: writes a row with a `set<int>` column under a
+//! per-column TTL (`CellOperation::WriteWithTtl`, the whole-collection TTL write),
+//! flushes to a single `nb` SSTable, reopens through `SSTableManager`, scans WITH
+//! cell metadata, and asserts the collection column surfaces an expiring cell with
+//! the written TTL.
+//!
+//! No wall-clock assertion race: the writer stamps each element's
+//! localExpirationTime as `wallClockNowSeconds + ttl`. We bracket the write+flush
+//! with a `[before, after]` wall-clock window and assert
+//! `expires_at ∈ [before+ttl, after+ttl]`, plus `ttl_seconds == n` exactly.
+//!
+//!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!     cargo test --package cqlite-core --test issue_2038_collection_ttl_expiring_cell
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::{CellWriteMetadata, Value};
+use cqlite_core::Config;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
+
+const KS: &str = "ttl_coll_ks";
+const TBL: &str = "items";
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "tags".to_string(),
+                data_type: "set<int>".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Build a row whose non-frozen `set<int>` column is written with a per-column
+/// TTL — the whole-collection expiring write (`WriteWithTtl`), i.e. what the CQL
+/// `INSERT ... USING TTL n` path produces for a collection column.
+fn insert_collection_using_ttl(id: i32, elems: Vec<i32>, ttl_seconds: u32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::WriteWithTtl {
+        column: "tags".to_string(),
+        value: Value::Set(elems.into_iter().map(Value::Integer).collect()),
+        ttl_seconds,
+        local_deletion_time: None,
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after epoch")
+        .as_secs() as i64
+}
+
+#[test]
+fn collection_ttl_write_round_trips_as_expiring_cell() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // Pinned reconciliation timestamp (USING TIMESTAMP is independent of the TTL
+    // expiry clock, so this need not track wall-clock).
+    const TS: i64 = 1_700_000_000_000_000;
+    const TTL: u32 = 86_400;
+    const TTL_I32: i32 = TTL as i32;
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // Bracket the write+flush with a wall-clock window: each element's on-disk
+    // localExpirationTime is stamped as `wallClockNow + ttl`, so the surfaced
+    // expiry must land inside `[before+ttl, after+ttl]`.
+    let before = now_secs();
+    engine
+        .write(insert_collection_using_ttl(1, vec![10, 20, 30], TTL, TS))
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("gen1");
+    let after = now_secs();
+    rt.block_on(engine.close()).expect("close engine");
+
+    // Reopen and scan WITH cell metadata (the authoritative surface `TTL()` reads).
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager open")
+    });
+
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+    let results = rt
+        .block_on(manager.scan_with_cell_metadata(&table_id, None, None, None, Some(&schema)))
+        .expect("metadata scan must not error");
+
+    assert_eq!(results.len(), 1, "expected the single row written");
+
+    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
+        results.into_iter().map(|(k, _v, m)| (k.0, m)).collect();
+
+    let meta = by_pk
+        .get(1_i32.to_be_bytes().as_slice())
+        .expect("row for id=1 present");
+
+    let tags_meta = meta
+        .get("tags")
+        .expect("per-cell metadata for the 'tags' collection must be surfaced");
+
+    // Core regression (#2038): TTL(tags) must NOT be null — the collection's
+    // expiring element cells carry an explicit per-element TTL + localExpirationTime.
+    let exp = tags_meta.expiration.as_ref().expect(
+        "Issue #2038: TTL(tags) must be present (expiring non-frozen collection), not null",
+    );
+
+    assert_eq!(
+        exp.ttl_seconds, TTL_I32,
+        "TTL(tags) must equal the written per-column TTL value"
+    );
+
+    // localExpirationTime = wallClockNow + ttl, bracketed by the flush window.
+    let lo = before + TTL as i64;
+    let hi = after + TTL as i64;
+    assert!(
+        (lo..=hi).contains(&exp.expires_at_seconds),
+        "expires_at {} must be wallClockNow+ttl, in [{lo}, {hi}]",
+        exp.expires_at_seconds
+    );
+
+    drop(temp_dir);
+}

--- a/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
+++ b/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
@@ -10,17 +10,36 @@
 //! `USING TTL` collection write emits) surfaced NO expiry, and `TTL(col)`
 //! returned `null` even though the on-disk cells ARE expiring.
 //!
-//! The fix pairs the authoritative per-element aggregate that the reader already
-//! computes (`max_element_expires_at` = the max localExpirationTime across the
-//! collection's explicit-TTL elements) with its element's `max_element_ttl`
-//! (added by this issue) into a `CellExpiration { ttl_seconds, expires_at_seconds }`.
-//! No heuristics: both come from the decoded per-element cell fields.
+//! The fix resolves the per-cell metadata via an `ExpiryHomogeneity` tracker in
+//! `complex_column.rs`: it surfaces a `CellExpiration { ttl_seconds,
+//! expires_at_seconds }` ONLY when every VISIBLE (post shadow/TTL-filter,
+//! non-tombstone) element of the collection shares the IDENTICAL explicit
+//! expiry. A heterogeneous collection (elements with different TTLs, or a mix
+//! of expiring and live-forever elements) surfaces `None` instead of
+//! over-approximating with one element's TTL (roborev Medium finding on the
+//! original fix — see `test_heterogeneous_element_ttls_surface_no_expiration`
+//! below, which pins the corrected behavior). No heuristics: every input comes
+//! from the decoded per-element cell fields.
 //!
-//! WRITE→READ regression guard: writes a row with a `set<int>` column under a
-//! per-column TTL (`CellOperation::WriteWithTtl`, the whole-collection TTL write),
-//! flushes to a single `nb` SSTable, reopens through `SSTableManager`, scans WITH
-//! cell metadata, and asserts the collection column surfaces an expiring cell with
-//! the written TTL.
+//! Three regression guards:
+//! 1. `collection_ttl_write_round_trips_as_expiring_cell` — WRITE→READ via the
+//!    metadata API (`scan_with_cell_metadata`): a `set<int>` column under a
+//!    per-column TTL (`CellOperation::WriteWithTtl`) flushes to a single `nb`
+//!    SSTable and reopens with its expiring per-cell metadata intact.
+//! 2. `collection_ttl_reachable_via_real_sql` — WIRING EVIDENCE: the SAME
+//!    fixture, but read through the REAL SQL surface (`Database::execute`,
+//!    `SELECT ... TTL(tags) ...`) rather than only the internal metadata API.
+//!    Ground truth (issue #2038 re-verify): `cqlite_core::query::
+//!    writetime_ttl_validator::validate_writetime_ttl_call` DOES reject
+//!    non-frozen collections, but that validator is dead code — it is never
+//!    invoked from the SELECT planner/executor (`select_optimizer.rs`,
+//!    `select_executor/execute.rs`) anywhere in the codebase. So
+//!    `TTL(non_frozen_collection)` is NOT planner-rejected today; it reaches
+//!    `evaluate_writetime_ttl` and this fix's surface is real-SQL reachable.
+//! 3. `test_heterogeneous_element_ttls_surface_no_expiration` — the roborev
+//!    Medium regression guard: two `set<text>` elements written with DIFFERENT
+//!    explicit per-element TTLs (`CellOperation::WriteComplexElement`) must
+//!    surface `expiration: None` (ambiguous), not one element's TTL.
 //!
 //! No wall-clock assertion race: the writer stamps each element's
 //! localExpirationTime as `wallClockNowSeconds + ttl`. We bracket the write+flush
@@ -28,7 +47,8 @@
 //! `expires_at ∈ [before+ttl, after+ttl]`, plus `ttl_seconds == n` exactly.
 //!
 //!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
-//!     cargo test --package cqlite-core --test issue_2038_collection_ttl_expiring_cell
+//!     cargo test --package cqlite-core --features write-support,cli-helpers,state_machine \
+//!     --test issue_2038_collection_ttl_expiring_cell
 
 #![cfg(feature = "write-support")]
 
@@ -184,6 +204,252 @@ fn collection_ttl_write_round_trips_as_expiring_cell() {
         (lo..=hi).contains(&exp.expires_at_seconds),
         "expires_at {} must be wallClockNow+ttl, in [{lo}, {hi}]",
         exp.expires_at_seconds
+    );
+
+    drop(temp_dir);
+}
+
+/// Issue #2038 wiring evidence: `TTL(non_frozen_collection)` is reachable via
+/// REAL SQL (`Database::execute`), not just the internal metadata API.
+///
+/// Ground truth check performed during the roborev re-verify round:
+/// `cqlite_core::query::writetime_ttl_validator::validate_writetime_ttl_call`
+/// DOES reject non-frozen collections with a Cassandra-shaped error — but that
+/// validator is never called from the SELECT planner/executor anywhere in the
+/// codebase (`select_optimizer.rs` builds `OptimizedQueryPlan` with no such
+/// call; `select_executor/execute.rs`'s `execute()` never calls it either).
+/// So `TTL(tags)` on a `set<int>` column reaches `evaluate_writetime_ttl`
+/// unobstructed and returns a real value — this fix's surface is genuinely
+/// exercised by end-user SQL today, not merely a metadata-layer improvement
+/// behind a planner rejection.
+#[cfg(all(feature = "cli-helpers", feature = "state_machine"))]
+#[test]
+fn collection_ttl_reachable_via_real_sql() {
+    use cqlite_core::ingestion::{ingest, IngestionConfig};
+
+    const SQL_KS: &str = "ttl_coll_sql_ks";
+    const SQL_TBL: &str = "items";
+    const TTL: u32 = 86_400;
+    const TTL_I32: i32 = TTL as i32;
+    const TS: i64 = 1_700_000_000_000_000;
+
+    fn schema_cql() -> String {
+        format!("CREATE TABLE {SQL_KS}.{SQL_TBL} (\n  id int PRIMARY KEY,\n  tags set<int>\n);\n")
+    }
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, schema_cql()).expect("write schema file");
+
+    let before = now_secs();
+    {
+        use cqlite_core::schema::parse_cql_schema;
+        let schema = parse_cql_schema(&schema_cql()).expect("parse schema");
+        let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema);
+        let mut engine = WriteEngine::new(config).expect("engine creation");
+        let pk = PartitionKey::single("id", Value::Integer(1));
+        let ops = vec![CellOperation::WriteWithTtl {
+            column: "tags".to_string(),
+            value: Value::Set(vec![Value::Integer(10), Value::Integer(20)]),
+            ttl_seconds: TTL,
+            local_deletion_time: None,
+        }];
+        let mutation = Mutation::new(TableId::new(SQL_KS, SQL_TBL), pk, None, ops, TS, None);
+        engine.write(mutation).expect("write mutation");
+        rt.block_on(engine.flush()).expect("flush").expect("gen1");
+        rt.block_on(engine.close()).expect("close engine");
+    }
+    let after = now_secs();
+
+    let result = rt
+        .block_on(ingest(IngestionConfig {
+            schema_paths: vec![schema_path],
+            data_dir,
+            version_hint: None,
+            core_config: Config::default(),
+            table_directory_filter: None,
+        }))
+        .expect("ingest fixture");
+
+    let db = result.database;
+    let sql = format!("SELECT id, TTL(tags) FROM {SQL_KS}.{SQL_TBL}");
+    let query_result = rt
+        .block_on(db.execute(&sql))
+        .expect("Issue #2038: TTL() on a non-frozen collection must be reachable via real SQL");
+
+    assert_eq!(
+        query_result.rows.len(),
+        1,
+        "expected the single row written"
+    );
+    let row = &query_result.rows[0];
+    match row.values.get("ttl(tags)") {
+        Some(Value::Integer(remaining)) => {
+            // remaining = expires_at - now; bracket by the flush window (same
+            // reasoning as the metadata-API test above).
+            let lo = (before + TTL as i64) - after;
+            let hi = (after + TTL as i64) - before;
+            assert!(
+                (lo..=hi).contains(&(*remaining as i64)),
+                "TTL(tags) remaining {} must be in [{lo}, {hi}]",
+                remaining
+            );
+            assert!(
+                *remaining > 0,
+                "TTL(tags) must be a positive remaining-seconds value, got {}",
+                remaining
+            );
+            assert!(
+                *remaining <= TTL_I32,
+                "TTL(tags) {} must not exceed the written TTL {}",
+                remaining,
+                TTL_I32
+            );
+        }
+        other => panic!(
+            "Issue #2038: TTL(tags) via real SQL must return Integer(remaining_secs), got {:?}",
+            other
+        ),
+    }
+
+    drop(temp_dir);
+}
+
+/// Issue #2038 roborev Medium finding regression guard: a non-frozen collection
+/// whose VISIBLE elements carry DIFFERENT explicit per-element TTLs has no
+/// single TTL that describes the whole value — `TTL(tags)` must surface `None`
+/// rather than one element's (arbitrary, over-approximated) expiry.
+///
+/// Constructs the two `set<text>` elements directly via
+/// `CellOperation::WriteComplexElement` (the per-element write path, epic
+/// #899 Phase B) so each carries its OWN explicit `ttl_seconds` +
+/// `local_deletion_time` — the on-disk shape the bug in the original fix
+/// conflated (it took the MAX expiry across ALL elements and paired it with
+/// that element's TTL, misattributing one element's TTL to the whole column).
+#[test]
+fn test_heterogeneous_element_ttls_surface_no_expiration() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+
+    let schema = TableSchema {
+        keyspace: "ttl_mixed_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "tags".to_string(),
+                data_type: "set<text>".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    };
+
+    const TS: i64 = 1_700_000_000_000_000;
+    // Two DIFFERENT explicit per-element expiries — deliberately heterogeneous.
+    const LDT_A: i32 = 2_000_000_000;
+    const LDT_B: i32 = 2_000_000_100;
+
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ops = vec![
+        CellOperation::WriteComplexElement {
+            column: "tags".to_string(),
+            cell_path: b"alpha".to_vec(),
+            value: None,
+            timestamp_micros: TS,
+            ttl_seconds: Some(100),
+            local_deletion_time: Some(LDT_A),
+            is_deleted: false,
+        },
+        CellOperation::WriteComplexElement {
+            column: "tags".to_string(),
+            cell_path: b"beta".to_vec(),
+            value: None,
+            timestamp_micros: TS,
+            ttl_seconds: Some(200),
+            local_deletion_time: Some(LDT_B),
+            is_deleted: false,
+        },
+    ];
+    let mutation = Mutation::new(
+        TableId::new("ttl_mixed_ks", "items"),
+        pk,
+        None,
+        ops,
+        TS,
+        None,
+    );
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    engine.write(mutation).expect("write mutation");
+    rt.block_on(engine.flush()).expect("flush").expect("gen1");
+    rt.block_on(engine.close()).expect("close engine");
+
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager open")
+    });
+
+    let table_id = CqlTableId::from("ttl_mixed_ks.items");
+    let results = rt
+        .block_on(manager.scan_with_cell_metadata(&table_id, None, None, None, Some(&schema)))
+        .expect("metadata scan must not error");
+
+    assert_eq!(results.len(), 1, "expected the single row written");
+
+    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
+        results.into_iter().map(|(k, _v, m)| (k.0, m)).collect();
+    let meta = by_pk
+        .get(1_i32.to_be_bytes().as_slice())
+        .expect("row for id=1 present");
+    let tags_meta = meta
+        .get("tags")
+        .expect("per-cell metadata for the 'tags' collection must be surfaced");
+
+    assert_eq!(
+        tags_meta.expiration, None,
+        "Issue #2038 (roborev Medium): a collection with heterogeneous \
+         per-element TTLs must surface expiration=None, not one element's \
+         (arbitrary) TTL — got {:?}",
+        tags_meta.expiration
     );
 
     drop(temp_dir);

--- a/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
+++ b/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
@@ -44,7 +44,12 @@
 //! No wall-clock assertion race: the writer stamps each element's
 //! localExpirationTime as `wallClockNowSeconds + ttl`. We bracket the write+flush
 //! with a `[before, after]` wall-clock window and assert
-//! `expires_at ∈ [before+ttl, after+ttl]`, plus `ttl_seconds == n` exactly.
+//! `expires_at ∈ [before+ttl, after+ttl]`, plus `ttl_seconds == n` exactly. The
+//! real-SQL test (`collection_ttl_reachable_via_real_sql`) reads `remaining =
+//! expires_at - now_query` AFTER an extra `ingest()` + `db.execute()` gap of
+//! unbounded latency past `after`, so its window is widened with a THIRD
+//! `query_after` timestamp (captured post-query) instead of reusing the plain
+//! write-only `[before, after]` bracket (roborev 1518 re-review fix).
 //!
 //!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 //!     cargo test --package cqlite-core --features write-support,cli-helpers,state_machine \
@@ -389,6 +394,15 @@ fn collection_ttl_reachable_via_real_sql() {
     let query_result = rt
         .block_on(db.execute(&sql))
         .expect("Issue #2038: TTL() on a non-frozen collection must be reachable via real SQL");
+    // Issue #2038 roborev re-review (1518, Medium): `remaining` is evaluated at
+    // QUERY time (`expires_at - now_query`), and `ingest()` + `db.execute()`
+    // above run with UNBOUNDED latency AFTER `after` (opening SSTables +
+    // scanning, worse under load). Bracketing only by the write-only window
+    // `[before, after]` (as the metadata-API test above correctly does, since
+    // IT reads with no ingest/execute gap) is too tight here and can fail
+    // spuriously on a correct implementation. Capture `query_after` so the
+    // window covers the FULL elapsed span from write-start to query-end.
+    let query_after = now_secs();
 
     assert_eq!(
         query_result.rows.len(),
@@ -398,9 +412,12 @@ fn collection_ttl_reachable_via_real_sql() {
     let row = &query_result.rows[0];
     match row.values.get("ttl(tags)") {
         Some(Value::Integer(remaining)) => {
-            // remaining = expires_at - now; bracket by the flush window (same
-            // reasoning as the metadata-API test above).
-            let lo = (before + TTL as i64) - after;
+            // remaining = expires_at - now_query, where expires_at ∈
+            // [before+TTL, after+TTL] (from the write window) and now_query ∈
+            // [after, query_after] (write-close through query-return). The
+            // widest possible remaining range is therefore
+            // [(before+TTL) - query_after, (after+TTL) - before].
+            let lo = (before + TTL as i64) - query_after;
             let hi = (after + TTL as i64) - before;
             assert!(
                 (lo..=hi).contains(&(*remaining as i64)),

--- a/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
+++ b/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
@@ -114,6 +114,26 @@ fn insert_collection_using_ttl(id: i32, elems: Vec<i32>, ttl_seconds: u32, ts: i
     Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
 }
 
+/// Build a row whose non-frozen `set<int>` column is written by a PLAIN
+/// `CellOperation::Write` under a MUTATION-LEVEL `USING TTL n`
+/// (`Mutation::ttl_seconds = Some(n)`) — i.e. the `INSERT ... USING TTL n`
+/// ROW-LIVENESS path, distinct from the per-column `WriteWithTtl` path above.
+///
+/// Scope B (issue #2038): the writer's whole-column `Write` arm dropped this
+/// row TTL (`write_complex_column(.., None)`), so the collection's element cells
+/// were written NON-expiring and `TTL(tags)` came back `null` even though the
+/// mutation carried a TTL. This is the symmetric write-side of the #2038 read
+/// fix.
+fn insert_collection_row_ttl(id: i32, elems: Vec<i32>, ttl_seconds: u32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "tags".to_string(),
+        value: Value::Set(elems.into_iter().map(Value::Integer).collect()),
+    }];
+    // Mutation-level TTL (the row `USING TTL`) — NOT a per-column WriteWithTtl.
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, Some(ttl_seconds))
+}
+
 fn now_secs() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -198,6 +218,92 @@ fn collection_ttl_write_round_trips_as_expiring_cell() {
     );
 
     // localExpirationTime = wallClockNow + ttl, bracketed by the flush window.
+    let lo = before + TTL as i64;
+    let hi = after + TTL as i64;
+    assert!(
+        (lo..=hi).contains(&exp.expires_at_seconds),
+        "expires_at {} must be wallClockNow+ttl, in [{lo}, {hi}]",
+        exp.expires_at_seconds
+    );
+
+    drop(temp_dir);
+}
+
+/// Issue #2038 Scope B (write-path): a non-frozen collection written by a plain
+/// `Write` op under a MUTATION-LEVEL `USING TTL n` must round-trip as expiring —
+/// the whole-column `Write` arm of `emit_whole_column_op` must thread
+/// `mop.row_ttl_seconds` into `write_complex_column` instead of dropping it
+/// (`None`). Fails on the pre-fix branch: the element cells are written
+/// non-expiring, so `TTL(tags)` surfaces `None`.
+#[test]
+fn collection_row_ttl_write_round_trips_as_expiring_cell() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    const TS: i64 = 1_700_000_000_000_000;
+    const TTL: u32 = 86_400;
+    const TTL_I32: i32 = TTL as i32;
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    let before = now_secs();
+    engine
+        .write(insert_collection_row_ttl(1, vec![10, 20, 30], TTL, TS))
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("gen1");
+    let after = now_secs();
+    rt.block_on(engine.close()).expect("close engine");
+
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager open")
+    });
+
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+    let results = rt
+        .block_on(manager.scan_with_cell_metadata(&table_id, None, None, None, Some(&schema)))
+        .expect("metadata scan must not error");
+
+    assert_eq!(results.len(), 1, "expected the single row written");
+
+    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
+        results.into_iter().map(|(k, _v, m)| (k.0, m)).collect();
+    let meta = by_pk
+        .get(1_i32.to_be_bytes().as_slice())
+        .expect("row for id=1 present");
+    let tags_meta = meta
+        .get("tags")
+        .expect("per-cell metadata for the 'tags' collection must be surfaced");
+
+    // Scope B regression: a row-level `USING TTL` collection write must NOT drop
+    // the TTL — every element cell is expiring with the mutation's row TTL.
+    let exp = tags_meta.expiration.as_ref().expect(
+        "Issue #2038 Scope B: TTL(tags) must be present for a row-level USING TTL \
+         collection write (whole-column Write op), not null",
+    );
+
+    assert_eq!(
+        exp.ttl_seconds, TTL_I32,
+        "TTL(tags) must equal the mutation-level row TTL value"
+    );
+
     let lo = before + TTL as i64;
     let hi = after + TTL as i64;
     assert!(

--- a/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
+++ b/cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs
@@ -201,7 +201,7 @@ fn collection_ttl_write_round_trips_as_expiring_cell() {
     assert_eq!(results.len(), 1, "expected the single row written");
 
     let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
-        results.into_iter().map(|(k, _v, m)| (k.0, m)).collect();
+        results.into_iter().map(|(k, _v, m)| (k.0.to_vec(), m)).collect();
 
     let meta = by_pk
         .get(1_i32.to_be_bytes().as_slice())
@@ -289,7 +289,7 @@ fn collection_row_ttl_write_round_trips_as_expiring_cell() {
     assert_eq!(results.len(), 1, "expected the single row written");
 
     let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
-        results.into_iter().map(|(k, _v, m)| (k.0, m)).collect();
+        results.into_iter().map(|(k, _v, m)| (k.0.to_vec(), m)).collect();
     let meta = by_pk
         .get(1_i32.to_be_bytes().as_slice())
         .expect("row for id=1 present");
@@ -559,7 +559,7 @@ fn test_heterogeneous_element_ttls_surface_no_expiration() {
     assert_eq!(results.len(), 1, "expected the single row written");
 
     let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
-        results.into_iter().map(|(k, _v, m)| (k.0, m)).collect();
+        results.into_iter().map(|(k, _v, m)| (k.0.to_vec(), m)).collect();
     let meta = by_pk
         .get(1_i32.to_be_bytes().as_slice())
         .expect("row for id=1 present");


### PR DESCRIPTION
## Closes #2038 — complex-cell TTL metadata (oracle-driven)

The complex-column per-cell metadata builder hardcoded `expiration: None` (`row_data.rs:559`), so `TTL()`/expiry on non-frozen collection/UDT columns was never surfaced on read — the collection-element analogue of #1743 (scalar path).

### What changed
- Complex-cell metadata now resolves per-element **effective** expiry = explicit-per-element `.or(inherited-row-TTL)`, mirroring the scalar #1743 path.
- New `ExpiryHomogeneity` tri-state fold over **visible** (post shadow/TTL-filter) elements: surfaces a single `CellExpiration` **only when all visible elements share the identical effective `(ttl, expires_at)`**; otherwise `None` (no over-approximation).
- `ElementShadow` gains `row_ttl_seconds`, threaded from `row_header.ttl` — covers the statement-level `USING TTL n` (USE_ROW_TTL) case.

### Review history (review-first)
- **rust-reviewer: APPROVE** (no blockers). 3 nits: file-size ratchet (needs `CQLITE_ALLOW_FILE_GROWTH=1`, epic #1116); USE_ROW_TTL coverage (**now fixed this PR**); WRITETIME-source uses row timestamp (pre-existing, out of scope — follow-up candidate).
- **roborev round 1 (job 1499, Medium):** mixed-expiry over-approximation → fixed (homogeneity tracker).
- **roborev round 2 (job 1503, Medium):** USE_ROW_TTL elements dropped TTL (unmet acceptance criterion) → fixed (row-TTL threading).
- **Wiring evidence:** roborev's claim that the SQL planner rejects `TTL()` on non-frozen collections was verified FALSE — that validator is dead code. `TTL(collection)` IS reachable via real SQL; added an end-to-end `Database::execute("SELECT id, TTL(tags) ...")` test.

### Tests (fail-first, revert-verified)
Per-element explicit TTL → surfaces; `USING TTL n` inherited → surfaces; mixed effective expiries → None; real-SQL wiring test. All 155 `v5_compressed_legacy` unit tests + #1741 regressions pass. Standalone `clippy -D warnings` clean.

Full gate of record + final roborev run in the closer (with `CQLITE_ALLOW_FILE_GROWTH=1`, #1116).