### PR TITLE
fix(#2103 live-run round 1): 6 harness blockers — kit fixes + flight-image dispatch

### DIFF
--- a/.github/workflows/flight-image.yml
+++ b/.github/workflows/flight-image.yml
@@ -2,8 +2,21 @@ name: cqlite-flight image
 
 # Build and publish the cqlite-flight Arrow Flight (gRPC) server container to
 # GHCR. Runs automatically on every v* release tag, and on demand via the
-# "Run workflow" button (workflow_dispatch) with a custom image tag — so you
-# can cut a one-off image without tagging a release.
+# "Run workflow" button (workflow_dispatch) two ways:
+#   - `version` (e.g. 0.13.1, no leading v): builds from the dispatched ref and
+#     pushes the SAME tag set a `v0.13.1` tag push would (vX.Y.Z + vX.Y) — use
+#     this to backfill/republish a release image when the tag-push run didn't
+#     produce one (issue #2117). `latest` is NOT moved unless `move_latest` is
+#     also set — a dispatch can build from an arbitrary ref, so silently
+#     retargeting the floating `latest` pointer would be surprising.
+#   - `image_tag` (e.g. dev, 0.13.0-rc1): a free-form one-off tag, unrelated to
+#     any release version. Ignored when `version` is set.
+#
+# Canonical tag scheme (issue #2117): every version tag this workflow emits is
+# v-prefixed (vX.Y.Z, vX.Y), matching this repo's own git tag convention
+# (v0.10.0, v0.11.0, ...). Older bare tags (0.13.0, 0.13) published before this
+# was normalized are left in place on GHCR (not deleted) but are not part of
+# the contract going forward — see cqlite-flight/README.md.
 #
 # The image exposes the Flight gRPC listener on :8815 and reads SSTables from a
 # directory mounted at runtime (--data-dir). The Trino connector is released
@@ -15,8 +28,16 @@ on:
       - 'v*'
   workflow_dispatch:
     inputs:
+      version:
+        description: 'Release version to publish (no leading v), e.g. 0.13.1 — mirrors a vX.Y.Z tag push (emits vX.Y.Z + vX.Y). Leave blank to use `image_tag` instead.'
+        type: string
+        required: false
+      move_latest:
+        description: 'Also move the `latest` tag to this build (only applies when `version` is set)'
+        type: boolean
+        default: false
       image_tag:
-        description: 'Tag to publish the image under (e.g. dev, 0.13.0-rc1)'
+        description: 'One-off custom tag, used only when `version` is blank (e.g. dev, 0.13.0-rc1)'
         required: true
         default: 'dev'
 
@@ -93,8 +114,10 @@ jobs:
         retention-days: 1
 
   # Assemble the per-arch digests into one multi-arch manifest list and apply
-  # the human tags. On a v* tag: vX.Y.Z, X.Y, and `latest` (non-prerelease).
-  # On a manual run: the `image_tag` input.
+  # the human tags. On a v* tag: vX.Y.Z, vX.Y, and `latest` (non-prerelease).
+  # On a manual `version` dispatch: the SAME vX.Y.Z + vX.Y set (`latest` only
+  # if `move_latest` is also set). On a manual `image_tag`-only dispatch (no
+  # `version`): just that one custom tag, unchanged from before.
   merge:
     name: Publish multi-arch image
     runs-on: ubuntu-latest
@@ -118,16 +141,85 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    # Resolve a single (version, major_minor, move_latest) triple for BOTH
+    # trigger types, so the tags step below has one uniform source of truth
+    # instead of duplicating semver-vs-raw logic per event. A tag push derives
+    # the version from the git ref; a manual dispatch derives it from the
+    # `version` input (blank means "use `image_tag` instead", the legacy
+    # one-off path). Inputs are read via env vars, never interpolated inline
+    # into the script, per this repo's command-injection guard (see
+    # trino-publish.yml's Resolve version step, which this mirrors).
+    - name: Resolve version and latest-move decision
+      id: version
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        REF_NAME: ${{ github.ref_name }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_MOVE_LATEST: ${{ inputs.move_latest }}
+      run: |
+        set -euo pipefail
+        if [ "$EVENT_NAME" = "push" ]; then
+          resolved="${REF_NAME#v}"
+        else
+          resolved="${INPUT_VERSION#v}"
+        fi
+
+        if [ -z "$resolved" ]; then
+          # workflow_dispatch with no `version` input: the legacy one-off
+          # `image_tag`-only path. No version/latest tags here — the raw
+          # `image_tag` tag below covers it.
+          {
+            echo "resolved="
+            echo "major_minor="
+            echo "move_latest=false"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Strict allowlist mirrors trino-publish.yml's Resolve version step:
+        # semver core with an optional pre-release suffix (e.g. 0.13.1,
+        # 0.13.1-rc1). Reject anything else so a crafted `version` input can't
+        # inject into the raw tag values computed below.
+        if ! printf '%s' "$resolved" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+          echo "::error::Refusing to publish: version '$resolved' is not a valid release version (expected ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$)"
+          exit 1
+        fi
+
+        major_minor="$(printf '%s' "$resolved" | cut -d. -f1,2)"
+
+        move_latest=false
+        if [ "$EVENT_NAME" = "push" ]; then
+          # Tag push: move `latest` for a stable release only (no `-`
+          # prerelease suffix) — same gate the prior
+          # `!contains(github.ref_name, '-')` expression implemented.
+          case "$resolved" in
+            *-*) move_latest=false ;;
+            *) move_latest=true ;;
+          esac
+        elif [ "$INPUT_MOVE_LATEST" = "true" ]; then
+          # Manual dispatch: never move `latest` unless explicitly requested —
+          # a dispatch can build from an arbitrary ref, so silently retargeting
+          # the floating `latest` pointer from an ad-hoc run would be
+          # surprising.
+          move_latest=true
+        fi
+
+        {
+          echo "resolved=$resolved"
+          echo "major_minor=$major_minor"
+          echo "move_latest=$move_latest"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Docker metadata (tags)
       id: meta
       uses: docker/metadata-action@v5
       with:
         images: ${{ env.REGISTRY_IMAGE }}
         tags: |
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=raw,value=latest,enable=${{ github.event_name == 'push' && !contains(github.ref_name, '-') }}
-          type=raw,value=${{ github.event.inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+          type=raw,value=v${{ steps.version.outputs.resolved }},enable=${{ steps.version.outputs.resolved != '' }},priority=900
+          type=raw,value=v${{ steps.version.outputs.major_minor }},enable=${{ steps.version.outputs.resolved != '' }},priority=800
+          type=raw,value=latest,enable=${{ steps.version.outputs.move_latest == 'true' }},priority=700
+          type=raw,value=${{ github.event.inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' && steps.version.outputs.resolved == '' }},priority=600
 
     - name: Log in to GHCR
       uses: docker/login-action@v3

--- a/cqlite-flight/README.md
+++ b/cqlite-flight/README.md
@@ -109,12 +109,41 @@ the manual workflow (see [below](#cutting-a-one-off-image-no-release-tag)):
 ghcr.io/pmcfadin/cqlite-flight
 ```
 
+**Canonical tag scheme (issue #2117):** every version tag is **v-prefixed**,
+matching this repo's own git tag convention (`v0.13.0`, `v0.13.1`, ...) and the
+version the connector JAR ships under on the release's git tag:
+
 | Tag | Points at |
 |-----|-----------|
-| `vX.Y.Z` | An exact release (e.g. `v0.13.0`). |
-| `X.Y` | The latest patch on a minor line (e.g. `0.13`). |
+| `vX.Y.Z` | An exact release (e.g. `v0.13.1`). |
+| `vX.Y` | The latest patch on a minor line (e.g. `v0.13`). |
 | `latest` | The most recent **stable** release (prereleases excluded). |
 | custom | One-off images cut via the manual workflow (see below). |
+
+The publishing contract: `.github/workflows/flight-image.yml` builds and pushes
+this set two ways —
+
+1. **Tag push** (`git push origin vX.Y.Z`): automatic, pushes `vX.Y.Z` + `vX.Y`,
+   and moves `latest` (unless the tag has a prerelease suffix, e.g. `v0.13.1-rc1`).
+2. **Manual dispatch with `version`** (`gh workflow run flight-image.yml -f
+   version=X.Y.Z`, no leading `v`): pushes the identical `vX.Y.Z` + `vX.Y` set a
+   tag push would. `latest` is **not** moved unless `move_latest=true` is also
+   passed — a dispatch can build from an arbitrary ref, so silently retargeting
+   the floating `latest` pointer would be surprising. Use this to backfill a
+   release image when the tag-push run didn't produce one (e.g. the connector
+   JAR published to Maven Central but the container never ran — issue #2117).
+
+A manual dispatch can *also* be given a free-form `image_tag` (e.g. `dev`,
+`0.13.0-rc1`) instead of `version`, for a one-off custom tag unrelated to any
+release — see [below](#cutting-a-one-off-image-no-release-tag). `image_tag` is
+ignored when `version` is set.
+
+**Historical inconsistency (issue #2117):** before this scheme was normalized,
+some releases were manually re-tagged by hand and ended up with a mix of
+v-prefixed and bare tags (`v0.12.0`; `v0.13.0` **and** bare `0.13.0`/`0.13`).
+Those older bare tags are left in place on GHCR (not deleted) but are **not**
+part of the contract — only `vX.Y.Z` / `vX.Y` / `latest` are current and
+guaranteed going forward.
 
 Once the GHCR package is public, pulling needs **no authentication** (no
 `docker login`):
@@ -158,13 +187,29 @@ architectures — it is pulled and run, and the publish fails unless the contain
 serves the Flight listener on `:8815` — so a tag that lands in GHCR is one that
 boots and serves.
 
+### Backfilling a release image
+
+If a `v*` tag was pushed (and the connector JAR published to Maven Central) but
+the `cqlite-flight` container was never built — the tag-triggered run didn't
+fire or failed silently (issue #2117) — republish it without cutting a new
+release, by dispatching the same workflow with the `version` input:
+
+```bash
+gh workflow run flight-image.yml --repo pmcfadin/cqlite -f version=0.13.1
+```
+
+This builds from the current default-branch ref and pushes the identical
+`v0.13.1` + `v0.13` tags a `v0.13.1` tag push would have produced. It does
+**not** move `latest` unless you also pass `-f move_latest=true` — pass that
+only if this backfilled version is genuinely the most recent stable release.
+
 ### Cutting a one-off image (no release tag)
 
 Maintainers can build and push an image on demand without tagging a release:
 run the **“cqlite-flight image”** GitHub Actions workflow via *Run workflow*
-(`workflow_dispatch`) and supply an `image_tag` (e.g. `dev`). It publishes
-`ghcr.io/pmcfadin/cqlite-flight:<image_tag>`. The same workflow also runs
-automatically on every `v*` tag.
+(`workflow_dispatch`) and supply an `image_tag` (e.g. `dev`), leaving `version`
+blank. It publishes `ghcr.io/pmcfadin/cqlite-flight:<image_tag>`. The same
+workflow also runs automatically on every `v*` tag.
 
 To build locally instead (requires Docker Buildx and a GHCR login with
 `write:packages`):

--- a/easy-db-lab-kits/cqlite-flight/README.md
+++ b/easy-db-lab-kits/cqlite-flight/README.md
@@ -155,3 +155,24 @@ never by resource name, matching the issue's requirement.
   Re-run the dry-run against the real lab cluster before first use.
 - **GHCR image pull**: the kit assumes the `ghcr.io/pmcfadin/cqlite-flight`
   package is public (no `imagePullSecrets` wired) per the image's own README.
+
+## Fast iteration with a dev image (outside the release train)
+
+When the harness surfaces a flight/core bug, iterate WITHOUT minting release
+versions — the `flight-image.yml` workflow's free-form `image_tag` dispatch is
+the dev channel, and it builds from any ref:
+
+```bash
+# 1. Build + push ghcr.io/pmcfadin/cqlite-flight:dev from your fix branch
+gh workflow run flight-image.yml --repo pmcfadin/cqlite \
+  --ref <fix-branch> -f image_tag=dev
+
+# 2. Roll the DaemonSet onto the rebuilt image (imagePullPolicy is Always,
+#    so a restart re-pulls the moving tag)
+kubectl rollout restart daemonset/cqlite-flight
+kubectl rollout status daemonset/cqlite-flight --timeout=180s
+```
+
+`dev` never touches `latest` or any `vX.Y*` tag; release images stay on the
+tag-push / `version`-dispatch path. If two people iterate at once, use
+distinct tags (`-f image_tag=dev-<yourname>`).

--- a/easy-db-lab-kits/cqlite-flight/README.md
+++ b/easy-db-lab-kits/cqlite-flight/README.md
@@ -85,10 +85,18 @@ The published image runs as a fixed non-root user (`uid 10001`, `useradd -r -u
 10001 flight` — see `cqlite-flight/Dockerfile`). On the host, Cassandra's data
 directory is owned by `cassandra:cassandra` at `uid/gid 999`
 (`useradd -m -u 999 cassandra` in `packer/cassandra/install/install_cassandra.sh`,
-"to match the cassandra-sidecar container image"). The manifest does **not**
-override `runAsUser`/`runAsGroup` (the image's own `USER flight` directive
-stands); it adds `supplementalGroups: [<data-gid>]` (default `999`) to the pod
-security context so the uid-10001 process can read files owned by gid 999.
+"to match the cassandra-sidecar container image").
+
+The manifest sets `runAsUser: 10001` / `runAsGroup: 10001` explicitly (issue
+#2118) — it does **not** rely on the image's own `USER flight` directive to
+satisfy `runAsNonRoot: true`. `USER flight` is a **name**, not a numeric uid;
+with `runAsNonRoot: true` and no numeric `runAsUser`, the kubelet cannot
+resolve "flight" to a uid to verify it's non-root and refuses to create the
+container (`CreateContainerConfigError`: "container has runAsNonRoot and
+image has non-numeric user (flight), cannot verify user is non-root"). Stating
+the uid numerically in the pod spec is what actually satisfies the check; it
+also adds `supplementalGroups: [<data-gid>]` (default `999`) so the uid-10001
+process can read files owned by gid 999.
 
 This assumes the host directory is at least group-readable
 (`rwxr-x---` or looser) for gid 999. `fsGroup` was deliberately **not** used —

--- a/easy-db-lab-kits/cqlite-flight/daemonset.yaml.template
+++ b/easy-db-lab-kits/cqlite-flight/daemonset.yaml.template
@@ -33,10 +33,18 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
-        # Do not override runAsUser/runAsGroup here — the image already runs as its
-        # fixed uid-10001 "flight" user (Dockerfile: `USER flight`). supplementalGroups
-        # adds the host GID that owns the Cassandra data dir so that uid can read it.
+        # The image's Dockerfile declares `USER flight` (a NAME, not a numeric
+        # uid: `useradd -r -u 10001 flight`). With runAsNonRoot: true but no
+        # numeric runAsUser, the kubelet cannot resolve "flight" to a uid to
+        # verify it is non-root, and refuses to create the container:
+        # "container has runAsNonRoot and image has non-numeric user (flight),
+        # cannot verify user is non-root" (issue #2118). runAsUser/runAsGroup
+        # must be stated numerically here to match the image's fixed identity.
+        # supplementalGroups adds the host GID that owns the Cassandra data
+        # dir so that uid can read it.
         runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
         supplementalGroups:
           - __CASSANDRA_DATA_GID__
       containers:

--- a/easy-db-lab-kits/cqlite-flight/daemonset.yaml.template
+++ b/easy-db-lab-kits/cqlite-flight/daemonset.yaml.template
@@ -50,6 +50,10 @@ spec:
       containers:
         - name: cqlite-flight
           image: "ghcr.io/pmcfadin/cqlite-flight:__TAG__"
+          # Always: the harness iterates on MOVING tags (dev, latest). The k8s
+          # default (IfNotPresent for non-latest tags) would pin the first pull
+          # of a reused tag forever and silently ignore rebuilt dev images.
+          imagePullPolicy: Always
           args:
             - "--data-dir=/data"
             - "--listen=0.0.0.0:__FLIGHT_PORT__"

--- a/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md
+++ b/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md
@@ -113,7 +113,33 @@ but this cqlite-trino connector build targets Trino SPI 481 ...
 Install the `trino` kit itself with `--version 481` (see Phase 1, step 3) — this
 overlay cannot rewrite the trino kit's own `values.yaml`.
 
+**[UPDATED after the first live run] Known upstream blocker at 481 — worker
+CrashLoopBackOff (#2116).** The easy-db-lab trino kit's
+`values.yaml.template` puts `web-ui.authentication.type` / `web-ui.user` in
+top-level `additionalConfigProperties`, which the Helm chart renders into
+BOTH coordinator and worker `config.properties`. `web-ui.*` is
+coordinator-only; at Trino 481 workers fail-fast on the unused properties:
+
+```
+ERROR io.trino.server.Server Configuration is invalid
+1) Configuration property 'web-ui.authentication.type' was not used
+```
+
+**Workaround (until fixed upstream — tracked with fix guidance in
+cqlite#2116):** after `trino` kit install, remove the two `web-ui.*` lines
+from the rendered `trino/values.yaml` and re-run the kit's `helm upgrade`
+(web-ui auth is irrelevant to a JDBC load test). Verify both `trino-worker`
+pods reach `Ready` before proceeding to step 4.
+
 ### 0.4 Flight kit preflight
+
+**[UPDATED after the first live run]** The first run of this plan hit
+`CreateContainerConfigError` on every `cqlite-flight` pod: `runAsNonRoot: true`
+was set without a numeric `runAsUser`, and the image's `USER flight` directive
+is a name, not a uid, so the kubelet couldn't verify non-root and refused to
+create the container (issue #2118, fixed — the manifest now pins
+`runAsUser: 10001` / `runAsGroup: 10001` explicitly). No command in this plan
+changes; this is now expected to just work.
 
 Before `easy-db-lab cqlite-flight start`:
 
@@ -207,6 +233,31 @@ kubectl get pods -l easydblab.com/kit=cqlite-flight -o wide
 ```
 
 ### 5. Install the trino-cqlite overlay (see [0.2](#02-kit-install-path-kit-source-add-not---from) for the naming subtlety)
+
+**[UPDATED after the first live run]** This step surfaced four bugs, all now
+fixed in the kit — no command below changes, but the *observed* behavior
+during this step does:
+
+- **#2120** — `cqlite start` never created the `cqlite-trino-plugin-src`
+  ConfigMap, so both pods sat `Init:0/1` with `FailedMount`. Fixed:
+  `bin/reapply-plugin-patch.sh` now creates/refreshes the ConfigMap before
+  patching either deployment, every time it runs.
+- **#2122** — the plugin-fetch init container's `gradle:9.1.0-jdk21` image
+  couldn't resolve the connector artifact (it requires JDK 25). Fixed: bumped
+  to `gradle:9.1.0-jdk25`.
+- **#2123** — the rendered catalog used `connector.name=cqlite`, but the
+  factory registers `cqlite_flight`, so the coordinator CrashLoopBackOff'd
+  with "No factory for connector 'cqlite'". Fixed: `connector.name=cqlite_flight`
+  (the catalog name stays `cqlite` — `SHOW CATALOGS` / `cqlite.<ks>.<tbl>` are
+  unaffected).
+- **#2119** — patching the coordinator's pod template (to add the plugin
+  initContainer) started a rollout that could never converge on this plan's
+  single app node: the new pod can't bind the coordinator's `hostPort: 8080`
+  while the old one still holds it. Fixed: the reapply script now deletes the
+  old coordinator pod **only when the patch actually changed something** (not
+  on a steady-state no-op re-apply) and waits for the rollout. **Expect the
+  `trino-coordinator` pod to be deleted and recreated once** during this step
+  on a fresh install — that is now expected, not a hang.
 
 ```bash
 DB0_IP=$($EDB ip db0 --private)

--- a/easy-db-lab-kits/trino-cqlite/README.md.template
+++ b/easy-db-lab-kits/trino-cqlite/README.md.template
@@ -24,11 +24,17 @@ coordinator/worker pods — Trino loads each plugin from its own isolated
 classloader directory (see `trino-connector/README.md`). Two ways to get
 there:
 
-1. **Init container** (chosen): a `gradle:9.1.0-jdk21` initContainer runs the
+1. **Init container** (chosen): a `gradle:9.1.0-jdk25` initContainer runs the
    throwaway `assemblePlugin` Sync recipe from `gradle-assemble-plugin/`
    against the published `in.mcfad:cqlite-trino:__CONNECTOR_VERSION__`
    artifact, writing the result to a shared `emptyDir` that's also mounted
-   into the main Trino container.
+   into the main Trino container. The init image's JDK level must stay in
+   lockstep with the connector's own build target — `trino-connector/build.gradle.kts`
+   targets **Java 25 / Trino SPI 481**, and the published artifact carries a
+   `org.gradle.jvm.version=25` Gradle capability attribute that a JDK-21
+   Gradle image cannot resolve at all (issue #2122). If
+   `trino-connector/build.gradle.kts`'s JDK target ever moves, bump
+   `INIT_IMAGE` in `bin/reapply-plugin-patch.sh` to match.
 2. Custom baked Trino image with the plugin pre-installed.
 
 Init container wins here: it needs no image-build/publish pipeline of its
@@ -165,7 +171,7 @@ directory, picked up automatically by the trino kit — see "Install order"):
 
 | Property | Value here | Notes |
 |---|---|---|
-| `connector.name` | `cqlite` | fixed |
+| `connector.name` | `cqlite_flight` | fixed — MUST equal the registered Trino connector factory name (`CqliteFlightConnectorFactory.getName()`), NOT this kit's catalog name. Setting it to `cqlite` crashes the coordinator at boot with "No factory for connector 'cqlite'" (issue #2123) |
 | `cqlite.sidecar-uri` | `__SIDECAR_URI__` | required; Sidecar runs as a hostNetwork DaemonSet on every db node (port 9043 fixed, no stable cluster Service) |
 | `cqlite.flight-port` | `__FLIGHT_PORT__` | matches the cqlite-flight kit's `--flight-port` |
 | `cqlite.local-datacenter` | *(commented out)* | edit `trino-catalog.properties` by hand + `../trino/bin/update-catalogs.sh` to set |

--- a/easy-db-lab-kits/trino-cqlite/bin/install.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/install.sh.template
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
-# Runs as part of `easy-db-lab kit install --kit cqlite --from <this dir> ...`
-# (no typed `install:` steps in kit.yaml, so this script is picked up per the
-# kit contract's "matching script in bin/" fallback).
+# NOT auto-run by `easy-db-lab kit install` (issue #2120): there are no typed
+# `install:` steps in kit.yaml, and — verified against the easy-db-lab kit
+# runner — it does NOT auto-execute a script merely named `install.sh` as an
+# install-phase hook. This script is kept ONLY for manual/standalone use
+# (e.g. hand-priming the ConfigMap before a `cqlite start` for inspection).
+#
+# The AUTHORITATIVE, always-executed path that creates/refreshes this
+# ConfigMap is `bin/reapply-plugin-patch.sh`'s `ensure_configmap()`, which
+# runs before every deployment patch — both from `bin/start.sh` and from this
+# kit's post-workload-start/post-workload-stop hooks. Do not rely on this
+# script running; if you change what gets created here, update
+# `ensure_configmap()` in `bin/reapply-plugin-patch.sh.template` to match.
 #
 # Creates the ConfigMap holding the throwaway assemblePlugin Gradle recipe
 # (gradle-assemble-plugin/) that bin/reapply-plugin-patch.sh mounts into an
 # initContainer to resolve the published `in.mcfad:cqlite-trino` artifact
 # from Maven Central at pod-start time. Nothing here touches the Trino
-# Deployments yet — that happens in `bin/start.sh`.
+# Deployments — that happens in `bin/start.sh` / `bin/reapply-plugin-patch.sh`.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
@@ -23,6 +23,18 @@
 #      (volumeMounts by mountPath), so re-applying identical content is a
 #      no-op against an already-patched Deployment.
 #
+# Also ensures the ConfigMap the initContainer mounts (${CONFIGMAP_NAME})
+# exists BEFORE either deployment is patched (issue #2120). Nothing else in
+# the `cqlite start` flow reliably creates it: `bin/install.sh` does, but it
+# is not wired as a kit `install:` hook and the easy-db-lab kit runner does
+# not auto-run a script merely named `install.sh` — so on the real
+# `kit install trino-cqlite` + `cqlite start` path it was never executed and
+# the mount failed with `configmap "cqlite-trino-plugin-src" not found`. This
+# script is the one thing guaranteed to run on every `cqlite start` AND on
+# every post-workload hook, so the create/refresh belongs here, not in
+# `install.sh` (kept only for manual/standalone convenience — see its own
+# header comment).
+#
 # Runs best-effort: if the trino kit isn't installed/running yet (or this
 # fires for an unrelated kit before trino ever starts), it skips quietly
 # rather than failing the triggering kit's own start/stop.
@@ -32,7 +44,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export KUBECONFIG="${SCRIPT_DIR}/../../__KUBECONFIG__"
 
 CONFIGMAP_NAME="cqlite-trino-plugin-src"
-INIT_IMAGE="gradle:9.1.0-jdk21"
+GRADLE_DIR="${SCRIPT_DIR}/../gradle-assemble-plugin"
+# JDK level MUST be >= the connector's own build target (Java 25 / Trino SPI
+# 481 — see trino-connector/build.gradle.kts: `trinoVersion = "481"` and its
+# toolchain languageVersion). The published `in.mcfad:cqlite-trino` artifact
+# carries a `org.gradle.jvm.version=25` capability attribute; a JDK-21 Gradle
+# (e.g. `gradle:9.1.0-jdk21`) REFUSES to resolve it at all ("Dependency
+# resolution is looking for a library compatible with JVM runtime version 21,
+# but ... is only compatible with JVM runtime version 25 or newer" — issue
+# #2122). Keep this in lockstep with the connector's JDK/trinoVersion target
+# going forward.
+INIT_IMAGE="gradle:9.1.0-jdk25"
 PLUGIN_MOUNT_PATH="/usr/lib/trino/plugin/cqlite_flight"
 # Same shell recipe as the connector's own documented assemblePlugin usage
 # (trino-connector/README.md "Maven Central / published artifact"): copy the
@@ -40,6 +62,45 @@ PLUGIN_MOUNT_PATH="/usr/lib/trino/plugin/cqlite_flight"
 # needs to write build/ and its cache), run assemblePlugin, then copy the
 # result into the shared emptyDir.
 INIT_SCRIPT='set -eu; mkdir -p /tmp/build; cp /workspace/build.gradle.kts /workspace/settings.gradle.kts /tmp/build/; cd /tmp/build; gradle --no-daemon --console=plain assemblePlugin; cp -r build/plugin/cqlite_flight/. /plugin-out/'
+
+# Issue #2120: create/refresh the ConfigMap the initContainer mounts BEFORE
+# either deployment is patched to reference it. Same recipe as
+# bin/install.sh (kept in sync deliberately) — idempotent create-or-update
+# via the dry-run|apply pattern, safe to run on every invocation.
+ensure_configmap() {
+  echo "cqlite plugin patch: ensuring ConfigMap ${CONFIGMAP_NAME} exists..."
+  kubectl create configmap "${CONFIGMAP_NAME}" \
+    --namespace default \
+    --from-file="${GRADLE_DIR}/build.gradle.kts" \
+    --from-file="${GRADLE_DIR}/settings.gradle.kts" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Issue #2119: the trino kit runs trino-coordinator with `hostPort: 8080`. On
+# a single app node, patching the pod template starts a rollout whose new pod
+# can never schedule while the old pod still holds that hostPort — the exact
+# deadlock the trino kit's own bin/start.sh already avoids for itself by
+# deleting the coordinator pod after a template change. Mirror that here, but
+# ONLY when this patch actually changed the pod template: `kubectl patch`
+# prints "... (no change)" when the strategic-merge patch was a no-op against
+# an already-patched Deployment, and re-applying identical content (the
+# steady-state case — this script fires on every kit start/stop) must NOT
+# bounce an already-healthy coordinator.
+bounce_coordinator_if_changed() {
+  local patch_output="$1"
+
+  if [[ "${patch_output}" == *"(no change)"* ]]; then
+    echo "    trino-coordinator pod template unchanged — not bouncing the pod."
+    return 0
+  fi
+
+  echo "    trino-coordinator pod template changed — deleting the old pod so the"
+  echo "    controller can recreate it on the now-free hostPort 8080..."
+  kubectl delete pod --namespace default \
+    -l 'app.kubernetes.io/name=trino,app.kubernetes.io/component=coordinator' \
+    --ignore-not-found
+  kubectl rollout status deployment/trino-coordinator --namespace default --timeout=180s
+}
 
 patch_deployment() {
   local dep="$1"
@@ -83,10 +144,17 @@ patch_deployment() {
         }
       ]
     }}}}')
-  kubectl patch deployment "${dep}" --namespace default --type=strategic -p="${patch}"
+  local patch_output
+  patch_output=$(kubectl patch deployment "${dep}" --namespace default --type=strategic -p="${patch}")
+  echo "    ${patch_output}"
+
+  if [ "${dep}" = "trino-coordinator" ]; then
+    bounce_coordinator_if_changed "${patch_output}"
+  fi
 }
 
 echo "cqlite plugin patch: reapplying to trino-coordinator/trino-worker (idempotent)..."
+ensure_configmap
 patch_deployment trino-coordinator
 patch_deployment trino-worker
 echo "cqlite plugin patch: done."

--- a/easy-db-lab-kits/trino-cqlite/trino-catalog.properties.template
+++ b/easy-db-lab-kits/trino-cqlite/trino-catalog.properties.template
@@ -1,12 +1,21 @@
 # Auto-discovered by the trino kit's own bin/update-catalogs.sh, which scans
 # every sibling kit directory for a `trino-catalog.properties` file (see
 # docs/user-guide/install-trino.md "Adding Trino Catalogs for Custom Kits").
-# The catalog name Trino registers this under is this kit's INSTALLED
-# DIRECTORY name, i.e. whatever `--kit <name>` was passed to
-# `easy-db-lab kit install --from ...` — install with `--kit cqlite` to get
-# the clean `cqlite.<keyspace>.<table>` catalog name used throughout the
-# connector's own docs (see this kit's README, "Install order").
-connector.name=cqlite
+#
+# Two DIFFERENT names are in play here — do not conflate them (issue #2123):
+#   - The CATALOG name (what you type in SQL, e.g. `cqlite.<ks>.<tbl>`) comes
+#     from this kit's INSTALLED DIRECTORY name, i.e. whatever `--kit <name>`
+#     was passed to `easy-db-lab kit install --from ...` — install with
+#     `--kit cqlite` to get the clean `cqlite.<keyspace>.<table>` addressing
+#     used throughout the connector's own docs (see this kit's README,
+#     "Install order"). It is NOT set by anything in this file.
+#   - `connector.name` below MUST equal the registered Trino connector
+#     factory name, `cqlite_flight` (`CqliteFlightConnectorFactory.getName()`
+#     — see `CqliteFlightConfig.java` javadoc). Trino resolves catalogs by
+#     looking up `connector.name` in its table of loaded factories; anything
+#     else (e.g. the catalog name `cqlite`) makes the coordinator CrashLoop at
+#     boot with "No factory for connector '...'".
+connector.name=cqlite_flight
 cqlite.sidecar-uri=__SIDECAR_URI__
 cqlite.flight-port=__FLIGHT_PORT__
 # Optional preferred datacenter for split placement. Left blank (commented)


### PR DESCRIPTION
Round-1 fixes for the blockers found in the first live 3-node run of the #2103 harness. Closes #2117, #2118, #2119, #2120, #2122, #2123 (see the two commit messages for per-issue root cause → fix → validation).

- Commit 1: five kit bugs (init-image JDK 25, connector.name=cqlite_flight, ConfigMap-before-patch wiring, coordinator bounce-on-change, numeric runAsUser) + test-plan callouts incl. the #2116 upstream workaround (comment-only routing per owner rule).
- Commit 2: flight-image workflow — dispatchable version publish, canonical v-prefixed tags, guarded latest. **Post-merge action: `gh workflow run flight-image.yml -f version=0.13.1` to backfill the missing container.**

Validation: shellcheck + actionlint clean; kubeconform valid; stubbed-kubectl scenario harness (ordering, bounce/no-bounce, graceful-skip). No Rust/Java in diff — no agent-gate; CI `required` lane is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)