### PR TITLE
test(#1871,#1872): GROUP BY aggregate value-parity regression guards (fixes already on main)

### DIFF
--- a/cqlite-core/tests/issue_1871_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1871_aggregate_arg_projection.rs
@@ -1,0 +1,223 @@
+//! Issue #1871: aggregate-ARGUMENT columns must be included in the SSTable scan
+//! projection, or `SUM`/`AVG`/`MIN`/`MAX` read a filtered-away column and compute
+//! from missing inputs (0/null).
+//!
+//! Root cause (pre-existing on main before the #1952 fix,
+//! `select_optimizer::extract_projection_columns` /
+//! `select_naming::aggregate_arg_source_columns`): a non-star aggregate's
+//! argument column (`value` in `SUM(value)`) was NOT added to
+//! `SSTableScan.projection`, so `build_row_from_scan` filtered the cell out and
+//! `update_aggregate` saw a missing column — `SUM`/`AVG` → 0/null, `MIN`/`MAX` →
+//! null, `COUNT(col)` → 0. `COUNT(*)` (no argument column) was unaffected.
+//!
+//! These tests exercise the fix THROUGH the public `Database::execute` surface on
+//! a real Cassandra 5.0 fixture and validate the aggregate VALUES against a
+//! hand-computed reference derived from the committed JSONL golden (parity is
+//! truth — not merely "non-null"), both GROUPED and UNGROUPED.
+//!
+//! Ground truth — `test_basic.multi_partition_table`, BIGINT `value` per
+//! `category` clustering value (100 single-row partitions), computed from
+//! `nb-1-big-Data.db.jsonl`:
+//!   category A: count 36, sum 18_785_439, min 42_438, max 990_685, avg 521_817.75
+//!   category B: count 36, sum 17_144_227, min 34_344, max 941_836, avg 476_228.527_777…
+//!   category C: count 28, sum 15_711_813, min 73_596, max 979_921, avg 561_136.178_571…
+//!   ALL (global): count 100, sum 51_641_479, min 34_344, max 990_685, avg 516_414.79
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::QueryResult;
+use cqlite_core::types::Value;
+use cqlite_core::Database;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup(schema_file: &str, keyspace_filter: &str) -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join(schema_file);
+    if !schema_path.exists() {
+        return Err(format!("{schema_file} not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(keyspace_filter.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+/// Numeric view of an aggregate result `Value`, normalizing the BIGINT-typed
+/// `MIN`/`MAX` clone and the `f64` `SUM`/`AVG` into one comparable type.
+fn as_num(v: &Value) -> f64 {
+    v.as_f64()
+        .unwrap_or_else(|| panic!("aggregate result must be numeric, got {v:?}"))
+}
+
+/// Read one aggregate result `Value` from a row by its derived output key (the
+/// SAME key `finalize_group` emits, e.g. `Sum_value`). Fails loudly on a missing
+/// or null value — the whole point of #1871 is that these must NOT be null.
+fn agg(result: &QueryResult, row_idx: usize, key: &str) -> f64 {
+    let row = result.rows.get(row_idx).unwrap_or_else(|| {
+        panic!(
+            "expected result row {row_idx}; got {} rows",
+            result.rows.len()
+        )
+    });
+    let value = row.values.get(key).unwrap_or_else(|| {
+        panic!(
+            "issue #1871: aggregate `{key}` MUST be a row value key; keys were {:?}",
+            row.values.keys().collect::<Vec<_>>()
+        )
+    });
+    assert!(
+        !value.is_null(),
+        "issue #1871: aggregate `{key}` read null — its argument column was dropped \
+         from the scan projection; row keys were {:?}",
+        row.values.keys().collect::<Vec<_>>()
+    );
+    as_num(value)
+}
+
+const EPS: f64 = 1e-3;
+
+/// UNGROUPED (global) `SUM`/`AVG`/`MIN`/`MAX`/`COUNT(col)` over the BIGINT `value`
+/// column must equal the hand-computed reference, proving the aggregate argument
+/// column reaches the scan even with no GROUP BY.
+#[tokio::test]
+async fn ungrouped_numeric_aggregates_match_reference() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT SUM(value), AVG(value), MIN(value), MAX(value), COUNT(value) \
+             FROM test_basic.multi_partition_table",
+        )
+        .await
+        .expect("ungrouped numeric-aggregate query must execute");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "a global (no GROUP BY) aggregate yields exactly one row"
+    );
+
+    assert!(
+        (agg(&result, 0, "Sum_value") - 51_641_479.0).abs() < EPS,
+        "global SUM(value)"
+    );
+    assert!(
+        (agg(&result, 0, "Avg_value") - 516_414.79).abs() < EPS,
+        "global AVG(value)"
+    );
+    assert!(
+        (agg(&result, 0, "Min_value") - 34_344.0).abs() < EPS,
+        "global MIN(value)"
+    );
+    assert!(
+        (agg(&result, 0, "Max_value") - 990_685.0).abs() < EPS,
+        "global MAX(value)"
+    );
+    assert!(
+        (agg(&result, 0, "Count_value") - 100.0).abs() < EPS,
+        "global COUNT(value)"
+    );
+}
+
+/// GROUPED `SUM`/`AVG`/`MIN`/`MAX` over `value`, grouped by `category`, must equal
+/// the per-group hand-computed reference for EVERY group — the exact scenario in
+/// the #1871 report (`SELECT category, SUM(value) ... GROUP BY category`).
+#[tokio::test]
+async fn grouped_numeric_aggregates_match_reference_per_group() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, SUM(value), AVG(value), MIN(value), MAX(value) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("grouped numeric-aggregate query must execute");
+
+    // (category, sum, avg, min, max)
+    let expected: [(&str, f64, f64, f64, f64); 3] = [
+        ("A", 18_785_439.0, 521_817.75, 42_438.0, 990_685.0),
+        ("B", 17_144_227.0, 476_228.527_777_78, 34_344.0, 941_836.0),
+        ("C", 15_711_813.0, 561_136.178_571_43, 73_596.0, 979_921.0),
+    ];
+
+    assert_eq!(
+        result.rows.len(),
+        expected.len(),
+        "GROUP BY category must yield exactly one row per distinct category"
+    );
+
+    for (cat, sum, avg, min, max) in expected {
+        let row_idx = result
+            .rows
+            .iter()
+            .position(|r| matches!(r.values.get("category"), Some(Value::Text(t)) if t == cat))
+            .unwrap_or_else(|| panic!("issue #1871: missing group row for category {cat}"));
+
+        assert!(
+            (agg(&result, row_idx, "Sum_value") - sum).abs() < EPS,
+            "SUM(value) for category {cat}"
+        );
+        assert!(
+            (agg(&result, row_idx, "Avg_value") - avg).abs() < EPS,
+            "AVG(value) for category {cat}"
+        );
+        assert!(
+            (agg(&result, row_idx, "Min_value") - min).abs() < EPS,
+            "MIN(value) for category {cat}"
+        );
+        assert!(
+            (agg(&result, row_idx, "Max_value") - max).abs() < EPS,
+            "MAX(value) for category {cat}"
+        );
+    }
+}

--- a/cqlite-core/tests/issue_1872_aggregate_to_json_values.rs
+++ b/cqlite-core/tests/issue_1872_aggregate_to_json_values.rs
@@ -1,0 +1,225 @@
+//! Issue #1872: `to_json` must render aggregate output columns under a stable
+//! name carrying the real VALUE — not null.
+//!
+//! Root cause (pre-existing on main before the #1763 fix): `get_result_columns`
+//! named an unaliased aggregate `col_N`, while `finalize_group` keyed the row
+//! value map by the DERIVED alias (e.g. `Sum_value`, `Count(*)`). `to_json`
+//! (`QueryResult::row_to_json_deterministic`) looks each field up by
+//! `metadata.columns[i].name`, so the lookup missed and the aggregate rendered as
+//! `"col_N": null` even though the value WAS present under the derived-alias key.
+//! The fix routes BOTH the metadata name (`result_column_name`) and the row value
+//! key (`finalize_group` via the aggregation plan alias) through ONE
+//! `select_naming::aggregate_output_name` source, so they can never disagree.
+//!
+//! The #1763 suite already pins the invariant + `to_json` parity for `COUNT(*)`.
+//! This suite extends it to a NON-COUNT aggregate (`SUM`) and asserts the JSON
+//! carries the correct numeric VALUE under a stable non-`col_N` name, plus the
+//! `metadata.columns` keys == row value keys invariant restated at the JSON edge.
+//!
+//! Ground truth (`test_basic.multi_partition_table`, BIGINT `value`, from the
+//! committed JSONL golden): global SUM(value) = 51_641_479, COUNT(*) = 100.
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::Database;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup(schema_file: &str, keyspace_filter: &str) -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join(schema_file);
+    if !schema_path.exists() {
+        return Err(format!("{schema_file} not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(keyspace_filter.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+/// `execute()` + `to_json()`: a non-COUNT aggregate (`SUM(value)`) renders under
+/// its derived name carrying the correct numeric value — never `col_N: null`.
+#[tokio::test]
+async fn sum_aggregate_to_json_carries_value_under_stable_name() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT SUM(value) FROM test_basic.multi_partition_table")
+        .await
+        .expect("SUM(value) must execute");
+
+    // Invariant restated at the JSON edge: every metadata column name is a row key.
+    let row = result.rows.first().expect("SUM query yields one row");
+    for col in &result.metadata.columns {
+        assert!(
+            !col.name.starts_with("col_"),
+            "issue #1872: aggregate metadata name must not be synthetic col_N; got {:?}",
+            col.name
+        );
+        assert!(
+            row.values.contains_key(col.name.as_str()),
+            "issue #1872: metadata column {:?} MUST be a row value key; keys were {:?}",
+            col.name,
+            row.values.keys().collect::<Vec<_>>()
+        );
+    }
+
+    let json = result.to_json();
+    let first_row = json
+        .get("rows")
+        .and_then(|r| r.as_array())
+        .and_then(|a| a.first())
+        .expect("to_json must emit one row");
+
+    // The derived name for an unaliased SUM over `value`.
+    let value = first_row.get("Sum_value").unwrap_or_else(|| {
+        panic!("issue #1872: to_json must key SUM by `Sum_value`; row was {first_row}")
+    });
+    // BIGINT summed as f64 → JSON number equal to the reference sum.
+    let got = value
+        .as_f64()
+        .unwrap_or_else(|| panic!("issue #1872: `Sum_value` must be numeric, not {value}"));
+    assert!(
+        (got - 51_641_479.0).abs() < 1e-3,
+        "issue #1872: to_json `Sum_value` must carry the real SUM (51_641_479), got {got}"
+    );
+    assert!(
+        first_row.get("col_0").is_none(),
+        "issue #1872: to_json must not contain a synthetic col_0 field; row was {first_row}"
+    );
+}
+
+/// Aliased non-COUNT aggregate: `SUM(value) AS total_value` renders under the
+/// alias in `to_json`, still carrying the value.
+#[tokio::test]
+async fn aliased_sum_aggregate_to_json_uses_alias() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT SUM(value) AS total_value FROM test_basic.multi_partition_table")
+        .await
+        .expect("aliased SUM must execute");
+
+    let json = result.to_json();
+    let first_row = json
+        .get("rows")
+        .and_then(|r| r.as_array())
+        .and_then(|a| a.first())
+        .expect("to_json must emit one row");
+
+    let value = first_row.get("total_value").unwrap_or_else(|| {
+        panic!(
+            "issue #1872: to_json must key the aliased SUM by `total_value`; row was {first_row}"
+        )
+    });
+    let got = value
+        .as_f64()
+        .unwrap_or_else(|| panic!("issue #1872: `total_value` must be numeric, not {value}"));
+    assert!(
+        (got - 51_641_479.0).abs() < 1e-3,
+        "issue #1872: aliased SUM to_json must carry the real SUM, got {got}"
+    );
+}
+
+/// GROUP BY through `to_json`: each group's per-group SUM renders under the
+/// aggregate name AND the grouped dimension under its own name — no null field,
+/// no synthetic col_N (the full row is JSON-visible, not just the value map).
+#[tokio::test]
+async fn grouped_sum_to_json_all_fields_named_and_valued() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, SUM(value) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("grouped SUM must execute");
+
+    // (category, per-group sum) — from the golden.
+    let expected = [
+        ("A", 18_785_439.0),
+        ("B", 17_144_227.0),
+        ("C", 15_711_813.0),
+    ];
+
+    let json = result.to_json();
+    let rows = json
+        .get("rows")
+        .and_then(|r| r.as_array())
+        .expect("to_json rows array");
+    assert_eq!(rows.len(), expected.len(), "one JSON row per category");
+
+    for (cat, sum) in expected {
+        let obj = rows
+            .iter()
+            .find(|r| r.get("category").and_then(|c| c.as_str()) == Some(cat))
+            .unwrap_or_else(|| panic!("issue #1872: missing JSON row for category {cat}"));
+        let got = obj
+            .get("Sum_value")
+            .and_then(|v| v.as_f64())
+            .unwrap_or_else(|| panic!("issue #1872: category {cat} missing numeric `Sum_value`"));
+        assert!(
+            (got - sum).abs() < 1e-3,
+            "issue #1872: category {cat} to_json SUM must be {sum}, got {got}"
+        );
+        assert!(
+            obj.get("col_0").is_none() && obj.get("col_1").is_none(),
+            "issue #1872: no synthetic col_N field in {obj}"
+        );
+    }
+}

--- a/cqlite-core/tests/issue_1872_aggregate_to_json_values.rs
+++ b/cqlite-core/tests/issue_1872_aggregate_to_json_values.rs
@@ -26,6 +26,32 @@ use std::path::{Path, PathBuf};
 use cqlite_core::ingestion::{ingest, IngestionConfig};
 use cqlite_core::Database;
 
+/// Extract the `name` field of every entry in `to_json()`'s serialized
+/// `"columns"` metadata array — i.e. what `metadata.columns` actually
+/// serializes to, NOT the row payload.
+///
+/// This is the guard against a false-positive hole (roborev finding on this
+/// PR): `row_to_json_deterministic` falls back to serializing the row's raw
+/// value map (sorted keys) whenever `metadata.columns` is EMPTY, so asserting
+/// only on `to_json()["rows"]` can pass even if the metadata/naming contract
+/// regressed to empty metadata — the fallback path would still produce
+/// `Sum_value`/`total_value` fields from the row map, masking the regression.
+/// Asserting the serialized `"columns"` array explicitly proves the name came
+/// from the metadata path, not the fallback.
+fn json_column_names(json: &serde_json::Value) -> Vec<String> {
+    json.get("columns")
+        .and_then(|c| c.as_array())
+        .unwrap_or_else(|| panic!("to_json must emit a `columns` array; json was {json}"))
+        .iter()
+        .map(|c| {
+            c.get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or_else(|| panic!("each columns[] entry must have a `name`; got {c}"))
+                .to_string()
+        })
+        .collect()
+}
+
 fn datasets_root() -> Option<PathBuf> {
     std::env::var("CQLITE_DATASETS_ROOT")
         .ok()
@@ -107,6 +133,19 @@ async fn sum_aggregate_to_json_carries_value_under_stable_name() {
     }
 
     let json = result.to_json();
+
+    // Guard against the false-positive hole: assert the serialized `columns`
+    // metadata section itself carries the aggregate name — proving the JSON
+    // field name below comes from the metadata path, not the row-map fallback
+    // that `row_to_json_deterministic` uses when `metadata.columns` is empty.
+    let meta_names = json_column_names(&json);
+    assert_eq!(
+        meta_names,
+        vec!["Sum_value".to_string()],
+        "issue #1872: to_json's serialized `columns` metadata must name the \
+         aggregate `Sum_value` (not empty/col_N); got {meta_names:?}"
+    );
+
     let first_row = json
         .get("rows")
         .and_then(|r| r.as_array())
@@ -149,6 +188,18 @@ async fn aliased_sum_aggregate_to_json_uses_alias() {
         .expect("aliased SUM must execute");
 
     let json = result.to_json();
+
+    // Guard against the false-positive hole: the serialized `columns` metadata
+    // section must name the aggregate `total_value` (the alias), not fall back
+    // to an empty/synthetic name that the row-map fallback would mask.
+    let meta_names = json_column_names(&json);
+    assert_eq!(
+        meta_names,
+        vec!["total_value".to_string()],
+        "issue #1872: to_json's serialized `columns` metadata must name the \
+         aliased aggregate `total_value`; got {meta_names:?}"
+    );
+
     let first_row = json
         .get("rows")
         .and_then(|r| r.as_array())
@@ -198,6 +249,19 @@ async fn grouped_sum_to_json_all_fields_named_and_valued() {
     ];
 
     let json = result.to_json();
+
+    // Guard against the false-positive hole: the serialized `columns` metadata
+    // section must name BOTH the grouped dimension and the aggregate, in
+    // SELECT order, proving the JSON field names below come from the metadata
+    // path rather than the row-map fallback that would mask empty metadata.
+    let meta_names = json_column_names(&json);
+    assert_eq!(
+        meta_names,
+        vec!["category".to_string(), "Sum_value".to_string()],
+        "issue #1872: to_json's serialized `columns` metadata must name the \
+         grouped dimension and aggregate; got {meta_names:?}"
+    );
+
     let rows = json
         .get("rows")
         .and_then(|r| r.as_array())


### PR DESCRIPTION
## Closes #1871 and #1872 — deferred acceptance tests (test-only)

Both root causes were **already fixed on `origin/main`** (#1871 by #1952/PR #1971; #1872 by #1763/PR #1953). The issues stayed open because their dedicated **value-parity acceptance tests** were deferred (the #1587 test flagged SUM/AVG/MIN/MAX + to_json as "reported separately"). This PR delivers those two guards. **No src changed.**

### #1871 — aggregate-argument columns projected into scan
Guard: `cqlite-core/tests/issue_1871_aggregate_arg_projection.rs`. `SELECT category, SUM/AVG/MIN/MAX(value) ... GROUP BY category` returns correct non-null aggregates, grouped + global. **Parity: value-for-value** vs hand-computed ground truth from `test_basic/multi_partition_table` JSONL (e.g. group A sum 18,785,439 / avg 521,817.75 / min 42,438 / max 990,685; global count 100).
Revert-verify: neutering `aggregate_arg_source_columns` union (select_optimizer.rs:686 / select_naming.rs:75) → grouped test FAILS; restored → PASS.

### #1872 — to_json aggregate column naming
Guard: `cqlite-core/tests/issue_1872_aggregate_to_json_values.rs`. `execute()`+`to_json()` emits correct aggregate values; `metadata.columns` keys == row value keys.
Revert-verify: reverting `result_column_name` aggregate branch to `col_N` (select_naming.rs:116) → unaliased SUM tests FAIL; restored → PASS.

All 5 tests green. Public-surface (execute/to_json), wiring-evidence-complete, no wall-clock assertions.

### Note (out of scope)
A pre-existing clippy `err_expect` error in `cqlite-core/tests/issue_1578_limit_exempts_max_results.rs` exists on `origin/main` (surfaced by standalone `--all-targets` clippy; the gate's clippy scoping doesn't flag it, so #1583's full gate passed with it present). Untouched here; flagging for a separate main-health cleanup.

Full gate of record + final roborev run in the closer.