### PR TITLE
fix(#2103 live-run round 2): observability image + loadtest kit fixes

### DIFF
--- a/cqlite-flight/Dockerfile
+++ b/cqlite-flight/Dockerfile
@@ -8,7 +8,7 @@
 FROM rust:1.85-bookworm AS build
 WORKDIR /src
 COPY . .
-RUN cargo build --release -p cqlite-flight
+RUN cargo build --release -p cqlite-flight --features observability
 
 FROM debian:bookworm-slim
 RUN useradd -r -u 10001 flight

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -125,7 +125,10 @@ fn log_observability_status(enabled: bool, endpoint: &str) {
     }
     #[cfg(feature = "observability")]
     {
-        tracing::info!(endpoint, "observability enabled, exporting to OTLP endpoint");
+        tracing::info!(
+            endpoint,
+            "observability enabled, exporting to OTLP endpoint"
+        );
     }
     #[cfg(not(feature = "observability"))]
     {

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -33,14 +33,20 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // `ObservabilityConfig` is always compiled (it carries no OTel types), so
+    // reading it here works identically whether or not the `observability`
+    // feature is on. Snapshot the bits `log_observability_status` needs before
+    // moving `obs_cfg` into `init` below.
+    let obs_cfg = cqlite_core::observability::ObservabilityConfig::from_env();
+    let obs_enabled = obs_cfg.enabled;
+    let obs_endpoint = obs_cfg.endpoint.clone();
+
     // Initialise observability (issue #1041, epic #1031) BEFORE composing the
     // tracing subscriber, so `observability::tracing_layer()` returns the live
     // OTel export layer. The guard flushes/shuts down OTel on drop; hold it for
     // the whole process lifetime. With the `observability` feature off (or
     // CQLITE_OTEL_ENABLED unset) this is an inert no-op.
-    let _otel_guard = cqlite_core::observability::init(
-        cqlite_core::observability::ObservabilityConfig::from_env(),
-    )?;
+    let _otel_guard = cqlite_core::observability::init(obs_cfg)?;
     // Install the global W3C text-map propagator so incoming gRPC `traceparent`
     // metadata can be extracted into an OTel context and used to parent the
     // per-RPC spans (continuing a client's distributed trace into the service).
@@ -50,6 +56,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     init_tracing_subscriber();
+
+    // Issue #2128: the published image was previously built without
+    // `--features observability`, so `CQLITE_OTEL_ENABLED=true` was silently
+    // inert — no metrics, no traces, no error, nothing in the startup log to
+    // say why. Make the inert-vs-active state visible instead.
+    log_observability_status(obs_enabled, &obs_endpoint);
 
     let args = Args::parse();
     let listen = args.listen;
@@ -90,4 +102,57 @@ fn init_tracing_subscriber() {
 
     // `try_init` is tolerant of a subscriber already being set (e.g. in tests).
     let _ = registry.try_init();
+}
+
+/// Log the startup observability state so `CQLITE_OTEL_ENABLED=true` is never
+/// silently inert (issue #2128).
+///
+/// `enabled` / `endpoint` come from [`cqlite_core::observability::ObservabilityConfig::from_env`],
+/// which is always compiled regardless of the `observability` feature. Two
+/// outcomes, both logged only when `enabled`:
+///
+/// * Feature compiled IN — one `info` line naming the OTLP endpoint traces and
+///   metrics are being exported to.
+/// * Feature compiled OUT — one `warn` line: the binary honours none of the
+///   `CQLITE_OTEL_*` vars, so the operator isn't left wondering why
+///   VictoriaMetrics/Tempo stay empty.
+///
+/// A no-op when `enabled` is false (the default, and the common case for a
+/// build that never sets `CQLITE_OTEL_ENABLED`).
+fn log_observability_status(enabled: bool, endpoint: &str) {
+    if !enabled {
+        return;
+    }
+    #[cfg(feature = "observability")]
+    {
+        tracing::info!(endpoint, "observability enabled, exporting to OTLP endpoint");
+    }
+    #[cfg(not(feature = "observability"))]
+    {
+        let _ = endpoint;
+        tracing::warn!(
+            "CQLITE_OTEL_ENABLED is set but this binary was compiled without the \
+             `observability` feature — CQLITE_OTEL_* environment variables are inert; \
+             no metrics or traces will be exported"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_observability_status_disabled_is_a_noop() {
+        // Must never panic regardless of feature state, and there's nothing to
+        // assert beyond "it returns" — disabled is the common, silent case.
+        log_observability_status(false, "http://localhost:4317");
+    }
+
+    #[test]
+    fn log_observability_status_enabled_does_not_panic() {
+        // Exercises the active branch (info-line-with-feature or
+        // warn-line-without-feature depending on how this crate was built).
+        log_observability_status(true, "http://localhost:4317");
+    }
 }

--- a/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md
+++ b/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md
@@ -392,6 +392,32 @@ Compare the Cassandra-side CQL count against the `cqlite.${KEYSPACE}.${TABLE}`
 count Trino returns. They must match exactly; a mismatch here is Phase 5's
 "wrong row counts" class before you've even started the concurrent runs.
 
+**[UPDATED after the first live run]** The first run of this plan hit two
+`trino-loadtest` driver bugs before any query was ever issued, both now fixed
+— no command below changes:
+
+- **#2130** — the driver crashed immediately with
+  `ValueError: invalid literal for int() with base 10: 'tcp://10.43.73.27:8080'`.
+  Kubernetes auto-injects Docker-link-style Service env vars into every pod
+  (the Trino Helm chart creates a Service named `trino`, so every pod sees
+  `TRINO_PORT=tcp://<ip>:8080`), and the driver's argparse defaults called
+  `int()` on that at parser-construction time — before `start.sh`'s explicit
+  `--port` flag ever got a chance to win. Fixed: the driver now reads
+  `TRINO_LOADTEST_HOST`/`TRINO_LOADTEST_PORT`/`TRINO_LOADTEST_USER`/
+  `TRINO_LOADTEST_CATALOG` (namespaced, not the Kubernetes-reserved bare
+  names) and falls back to the documented default instead of raising on any
+  unparseable numeric env value.
+- **#2132** — with no `--queries-file` passed (the normal case for this
+  plan's built-in query set), `start.sh` failed before the pod was even
+  created: `error: error reading null: no such file or directory` /
+  `error: no objects passed to apply`. The easy-db-lab kit runner injects the
+  literal string `null` for an unset optional arg rather than leaving it
+  empty, and `[ -n "$VAR" ]` alone is true for `"null"`. Fixed: `start.sh`
+  now also rejects the literal `"null"` before treating the var as set. **The
+  loadtest start below no longer needs a `--queries-file` workaround** —
+  omitting it (as both runs in this plan do) now correctly falls through to
+  the built-in scan+aggregate query set.
+
 ### 13a. Run (a) — default `snapshot` mode: correctness/consistency run
 
 `cqlite.read-mode` defaults to `snapshot` — no catalog edit needed for this run.
@@ -464,6 +490,28 @@ sed -i.bak '/cqlite.read-mode=live/d' "$CLUSTER_DIR/cqlite/trino-catalog.propert
 ---
 
 ## Phase 4: OBSERVE / VERIFY
+
+**[UPDATED after the first live run]** The first run of this plan found **zero**
+`cqlite.rpc.*`/`cqlite_rpc_*` series in VictoriaMetrics and no flight traces in
+Tempo, despite a correct pod env (`CQLITE_OTEL_ENABLED=true`,
+`CQLITE_OTEL_ENDPOINT=http://localhost:4317` reachable) and no export errors in
+the flight log — **root cause: #2128**, the published `cqlite-flight` image was
+built without `--features observability`, so all the OTLP metric/trace code was
+compiled out and the env vars were silently inert. Fixed:
+`cqlite-flight/Dockerfile` now builds with `--features observability`.
+**The observability check below now expects an extra startup log line** —
+confirm it's present before checking VictoriaMetrics/Tempo (FIRST-RUN CHECK,
+not yet verified against a live cluster):
+
+```bash
+kubectl logs -l easydblab.com/kit=cqlite-flight --all-containers --prefix | grep -i observability
+```
+
+Expect one `observability enabled, exporting to OTLP endpoint` info line per
+pod, naming `endpoint=http://localhost:4317`. (If the image were ever
+published again without the feature, the fix also makes that case visible
+instead of silent: a `WARN` line stating the binary was compiled without
+`observability` and that `CQLITE_OTEL_*` vars are inert.)
 
 ### 14. Confirm `cqlite.rpc.*` metric names in VictoriaMetrics (FIRST-RUN CHECK)
 

--- a/easy-db-lab-kits/trino-loadtest/bin/start.sh.template
+++ b/easy-db-lab-kits/trino-loadtest/bin/start.sh.template
@@ -29,7 +29,13 @@ TRINO_LOADTEST_USER="${TARGET_JDBC_USER:-cqlite-loadtest}"
 
 QUERIES_FLAG=""
 CONFIGMAP_FILE_ARGS=(--from-file="driver.py=${SCRIPT_DIR}/../driver.py")
-if [ -n "${TRINO_LOADTEST_QUERIES_FILE:-}" ]; then
+# Issue #2132: an unset optional --queries-file arrives here as the literal
+# string "null" (the easy-db-lab kit runner injects "null", not empty, for an
+# unset arg whose kit.yaml default is ""), not an empty/unset var. `[ -n ... ]`
+# alone is true for "null", so it must be rejected explicitly — otherwise this
+# tries `--from-file=queries.txt=null` (no such file) and the whole configmap
+# pipeline produces nothing for `kubectl apply -f -` to consume.
+if [ -n "${TRINO_LOADTEST_QUERIES_FILE:-}" ] && [ "${TRINO_LOADTEST_QUERIES_FILE}" != "null" ]; then
   CONFIGMAP_FILE_ARGS+=(--from-file="queries.txt=${TRINO_LOADTEST_QUERIES_FILE}")
   QUERIES_FLAG="--queries-file /driver/queries.txt"
 fi

--- a/easy-db-lab-kits/trino-loadtest/bin/start.sh.template
+++ b/easy-db-lab-kits/trino-loadtest/bin/start.sh.template
@@ -14,11 +14,18 @@ if [ -z "${TARGET_HTTP_URL:-}" ]; then
   echo "Error: TARGET_HTTP_URL not set. Install with --target pointing at a running trino kit that exposes an http endpoint." >&2
   exit 1
 fi
-TRINO_HOST_PORT="${TARGET_HTTP_URL#http://}"
-TRINO_HOST_PORT="${TRINO_HOST_PORT#https://}"
-TRINO_HOST="${TRINO_HOST_PORT%%:*}"
-TRINO_PORT="${TRINO_HOST_PORT##*:}"
-TRINO_USER="${TARGET_JDBC_USER:-cqlite-loadtest}"
+# Named TRINO_LOADTEST_* (not bare TRINO_HOST/TRINO_PORT/TRINO_USER) for
+# consistency with driver.py's env-var names (issue #2130) — these are local
+# to this script and are never exported into the pod's own environment (there
+# is no `env:` stanza in the podspec below; they're passed as explicit
+# --host/--port/--user CLI flags), so the bare names were never actually
+# exposed to the Kubernetes Service-injection collision driver.py hit. Still,
+# consistent naming avoids future confusion when grepping for these vars.
+TRINO_LOADTEST_HOST_PORT="${TARGET_HTTP_URL#http://}"
+TRINO_LOADTEST_HOST_PORT="${TRINO_LOADTEST_HOST_PORT#https://}"
+TRINO_LOADTEST_HOST="${TRINO_LOADTEST_HOST_PORT%%:*}"
+TRINO_LOADTEST_PORT="${TRINO_LOADTEST_HOST_PORT##*:}"
+TRINO_LOADTEST_USER="${TARGET_JDBC_USER:-cqlite-loadtest}"
 
 QUERIES_FLAG=""
 CONFIGMAP_FILE_ARGS=(--from-file="driver.py=${SCRIPT_DIR}/../driver.py")
@@ -27,7 +34,7 @@ if [ -n "${TRINO_LOADTEST_QUERIES_FILE:-}" ]; then
   QUERIES_FLAG="--queries-file /driver/queries.txt"
 fi
 
-echo "Starting trino-loadtest: coordinator=${TRINO_HOST}:${TRINO_PORT}, ks=${TRINO_LOADTEST_KEYSPACE:-<none>}, tbl=${TRINO_LOADTEST_TABLE:-<none>}, threads=${THREADS}, duration=${DURATION}s, interval=${INTERVAL}s, traceparent=${TRACEPARENT}..."
+echo "Starting trino-loadtest: coordinator=${TRINO_LOADTEST_HOST}:${TRINO_LOADTEST_PORT}, ks=${TRINO_LOADTEST_KEYSPACE:-<none>}, tbl=${TRINO_LOADTEST_TABLE:-<none>}, threads=${THREADS}, duration=${DURATION}s, interval=${INTERVAL}s, traceparent=${TRACEPARENT}..."
 
 # Stage driver.py (and an optional queries file) into a labelled ConfigMap the
 # pod mounts read-only at /driver. Labelled so stop.sh's label-selector delete
@@ -63,7 +70,7 @@ spec:
         - >-
           pip install --quiet trino &&
           python /driver/driver.py
-          --host "${TRINO_HOST}" --port "${TRINO_PORT}" --user "${TRINO_USER}"
+          --host "${TRINO_LOADTEST_HOST}" --port "${TRINO_LOADTEST_PORT}" --user "${TRINO_LOADTEST_USER}"
           --ks "${TRINO_LOADTEST_KEYSPACE:-}" --tbl "${TRINO_LOADTEST_TABLE:-}"
           ${QUERIES_FLAG}
           --threads "${THREADS}" --duration "${DURATION}" --interval "${INTERVAL}"

--- a/easy-db-lab-kits/trino-loadtest/driver.py
+++ b/easy-db-lab-kits/trino-loadtest/driver.py
@@ -348,21 +348,60 @@ def _env_flag(name: str, default: bool = False) -> bool:
     return val.strip().lower() in ("1", "true", "yes", "on")
 
 
+def _int_env_default(name: str, default: int) -> int:
+    """Read an integer env-var default defensively (issue #2130).
+
+    Kubernetes injects Docker-link-style service env vars for every Service
+    in the namespace (e.g. a Service named ``trino`` makes
+    ``TRINO_PORT=tcp://10.43.x.x:8080`` available to every pod). Building an
+    argparse *default* by eagerly calling ``int()`` on such a value crashes
+    at parser-construction time — before the caller's explicit ``--port``
+    flag (which start.sh always passes) ever gets a chance to win. Falling
+    back to ``default`` on any parse failure keeps parser construction from
+    ever raising, regardless of what happens to be sitting in the env.
+    """
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
+def _float_env_default(name: str, default: float) -> float:
+    """Float counterpart of :func:`_int_env_default` — same defensive fallback."""
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except ValueError:
+        return default
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Concurrent read-load driver for a Trino coordinator's cqlite catalog")
-    parser.add_argument("--host", default=_env_default("TRINO_HOST", "localhost"))
-    parser.add_argument("--port", type=int, default=int(_env_default("TRINO_PORT", str(DEFAULT_PORT))))
-    parser.add_argument("--user", default=_env_default("TRINO_USER", DEFAULT_USER))
-    parser.add_argument("--catalog", default=_env_default("TRINO_CATALOG", DEFAULT_CATALOG))
+    # NOTE: the bare TRINO_HOST / TRINO_PORT / TRINO_USER / TRINO_CATALOG names
+    # are deliberately NOT used here (issue #2130) — Kubernetes auto-injects
+    # Docker-link-style env vars for every Service in the namespace (a Service
+    # named "trino" makes TRINO_PORT=tcp://<ip>:8080 available to every pod),
+    # which collides with exactly these generic names. Namespaced
+    # TRINO_LOADTEST_* names match the rest of this kit's env vars and avoid
+    # the collision entirely.
+    parser.add_argument("--host", default=_env_default("TRINO_LOADTEST_HOST", "localhost"))
+    parser.add_argument("--port", type=int, default=_int_env_default("TRINO_LOADTEST_PORT", DEFAULT_PORT))
+    parser.add_argument("--user", default=_env_default("TRINO_LOADTEST_USER", DEFAULT_USER))
+    parser.add_argument("--catalog", default=_env_default("TRINO_LOADTEST_CATALOG", DEFAULT_CATALOG))
     parser.add_argument("--ks", "--keyspace", dest="keyspace", default=_env_default("TRINO_LOADTEST_KEYSPACE", ""))
     parser.add_argument("--tbl", "--table", dest="table", default=_env_default("TRINO_LOADTEST_TABLE", ""))
     parser.add_argument("--queries-file", dest="queries_file", default=_env_default("TRINO_LOADTEST_QUERIES_FILE"))
-    parser.add_argument("--threads", type=int, default=int(_env_default("TRINO_LOADTEST_THREADS", "4")))
-    parser.add_argument("--duration", type=int, default=int(_env_default("TRINO_LOADTEST_DURATION", "60")))
+    parser.add_argument("--threads", type=int, default=_int_env_default("TRINO_LOADTEST_THREADS", 4))
+    parser.add_argument("--duration", type=int, default=_int_env_default("TRINO_LOADTEST_DURATION", 60))
     parser.add_argument(
         "--interval",
         type=float,
-        default=float(_env_default("TRINO_LOADTEST_INTERVAL", str(DEFAULT_INTERVAL_SECONDS))),
+        default=_float_env_default("TRINO_LOADTEST_INTERVAL", float(DEFAULT_INTERVAL_SECONDS)),
     )
     parser.add_argument(
         "--traceparent",

--- a/easy-db-lab-kits/trino-loadtest/test_driver.py
+++ b/easy-db-lab-kits/trino-loadtest/test_driver.py
@@ -20,7 +20,7 @@ import sys
 import tempfile
 import threading
 import traceback
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -322,6 +322,85 @@ def test_parse_args_defaults() -> None:
     assert args.traceparent is False
 
 
+class _env_var:  # noqa: N801 - small helper, lowercase-by-convention context manager
+    """Set ``name=value`` in os.environ for the duration of a ``with`` block,
+    restoring (or removing) whatever was there before on exit.
+
+    ``value=None`` means "ensure unset" for the duration of the block.
+    """
+
+    def __init__(self, name: str, value: Optional[str]) -> None:
+        self._name = name
+        self._value = value
+        self._old: Optional[str] = None
+
+    def __enter__(self) -> "_env_var":
+        self._old = os.environ.get(self._name)
+        if self._value is None:
+            os.environ.pop(self._name, None)
+        else:
+            os.environ[self._name] = self._value
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        if self._old is None:
+            os.environ.pop(self._name, None)
+        else:
+            os.environ[self._name] = self._old
+
+
+def test_env_default_port_falls_back_on_k8s_service_injection() -> None:
+    """Issue #2130: a K8s Service named "trino" injects
+    ``TRINO_PORT=tcp://<ip>:8080`` into every pod's environment. Parser
+    construction must never crash on that, and the driver must not read the
+    bare (unnamespaced) ``TRINO_PORT`` at all — only the renamed
+    ``TRINO_LOADTEST_PORT``.
+    """
+    with _env_var("TRINO_PORT", "tcp://10.43.73.27:8080"), _env_var("TRINO_LOADTEST_PORT", None):
+        args = driver.parse_args(["--ks", "a", "--tbl", "b"])
+        assert args.port == driver.DEFAULT_PORT
+
+
+def test_env_default_port_falls_back_on_malformed_namespaced_var() -> None:
+    """Simulates the easy-db-lab kit runner injecting a malformed value
+    directly into the namespaced var — the defensive int parse must fall
+    back to the default rather than raising at parser-construction time.
+    """
+    with _env_var("TRINO_LOADTEST_PORT", "tcp://10.0.0.1:8080"):
+        args = driver.parse_args(["--ks", "a", "--tbl", "b"])
+        assert args.port == driver.DEFAULT_PORT
+
+
+def test_env_default_port_uses_namespaced_var_when_valid() -> None:
+    with _env_var("TRINO_LOADTEST_PORT", "9999"):
+        args = driver.parse_args(["--ks", "a", "--tbl", "b"])
+        assert args.port == 9999
+
+
+def test_explicit_port_flag_wins_over_malformed_env() -> None:
+    """Even with a malformed TRINO_LOADTEST_PORT sitting in the env, an
+    explicit --port flag (as start.sh always passes) must win.
+    """
+    with _env_var("TRINO_LOADTEST_PORT", "tcp://10.0.0.1:8080"):
+        args = driver.parse_args(["--ks", "a", "--tbl", "b", "--port", "8080"])
+        assert args.port == 8080
+
+
+def test_int_env_default_helper_falls_back_on_bad_value() -> None:
+    with _env_var("CQLITE_TEST_INT_VAR", "not-an-int"):
+        assert driver._int_env_default("CQLITE_TEST_INT_VAR", 42) == 42
+
+
+def test_int_env_default_helper_parses_good_value() -> None:
+    with _env_var("CQLITE_TEST_INT_VAR", "7"):
+        assert driver._int_env_default("CQLITE_TEST_INT_VAR", 42) == 7
+
+
+def test_float_env_default_helper_falls_back_on_bad_value() -> None:
+    with _env_var("CQLITE_TEST_FLOAT_VAR", "not-a-float"):
+        assert driver._float_env_default("CQLITE_TEST_FLOAT_VAR", 5.0) == 5.0
+
+
 # --------------------------------------------------------------------------
 # run_worker() — the real concurrency logic, driven with a fake connection/exec
 # --------------------------------------------------------------------------
@@ -470,6 +549,25 @@ def main() -> int:
     check("validate_args: passes with ks and tbl", test_validate_args_passes_with_ks_and_tbl)
     check("validate_args: rejects bad numeric args", test_validate_args_rejects_bad_numbers)
     check("parse_args: defaults", test_parse_args_defaults)
+    check(
+        "parse_args: --port default ignores K8s-injected bare TRINO_PORT",
+        test_env_default_port_falls_back_on_k8s_service_injection,
+    )
+    check(
+        "parse_args: --port default falls back on malformed TRINO_LOADTEST_PORT",
+        test_env_default_port_falls_back_on_malformed_namespaced_var,
+    )
+    check(
+        "parse_args: --port default honours a valid TRINO_LOADTEST_PORT",
+        test_env_default_port_uses_namespaced_var_when_valid,
+    )
+    check(
+        "parse_args: explicit --port flag wins over malformed env",
+        test_explicit_port_flag_wins_over_malformed_env,
+    )
+    check("_int_env_default: falls back on unparseable value", test_int_env_default_helper_falls_back_on_bad_value)
+    check("_int_env_default: parses a valid value", test_int_env_default_helper_parses_good_value)
+    check("_float_env_default: falls back on unparseable value", test_float_env_default_helper_falls_back_on_bad_value)
     check("run_worker: deterministic success/error accounting", test_run_worker_records_success_and_error_deterministically)
     check("run_worker: closes the connection on exit", test_run_worker_closes_connection)
     check("run_worker: traceparent header set and varies per query", test_run_worker_generates_traceparent_header_when_enabled)


### PR DESCRIPTION
Round-2 batch of live-run harness fixes from epic #2103's first cluster run. Three issues, one fix each.

## #2128 — cqlite-flight image built without `--features observability`

**Root cause:** `cqlite-flight/Dockerfile` built the release binary without `--features observability`, so all OTLP metric/trace code (`obs.rs`, the `cqlite-core` observability exporter) was compiled out. `CQLITE_OTEL_ENABLED`/`CQLITE_OTEL_ENDPOINT` were honored only by code that wasn't in the binary — silently inert. Confirmed live: VictoriaMetrics had zero `cqlite.rpc.*` series, no export errors, and no observability-init line in the flight pod's startup log.

**Fix:**
- `cqlite-flight/Dockerfile` now builds with `--features observability` (confirmed `.github/workflows/flight-image.yml` builds only through this Dockerfile via `docker/build-push-action` — no other cargo invocation needed the flag).
- `cqlite-flight/src/main.rs`: read `ObservabilityConfig::from_env()` once (always compiled, independent of the feature) and log the resulting state right after the tracing subscriber is installed, via a new `log_observability_status()` helper, cfg-gated both ways — feature ON + `CQLITE_OTEL_ENABLED` truthy → `info` line naming the OTLP endpoint; feature OFF + truthy → `warn` line stating the binary was compiled without `observability` so the vars are inert. Disabled (the default) stays silent.

**Validation:** `cargo test -p cqlite-flight` (128 lib + 2 main tests) and `cargo test -p cqlite-flight --features observability` (130 lib + 2 main tests) both pass; `clippy -D warnings` clean both feature configs; `cargo build --release -p cqlite-flight --features observability` (what the Docker image now runs) compiles cleanly.

## #2130 — trino-loadtest driver crashes on K8s-injected TRINO_PORT

**Root cause:** `driver.py`'s argparse defaults eagerly called `int()`/`float()` on env-var lookups for `TRINO_HOST`/`TRINO_PORT`/`TRINO_USER`/`TRINO_CATALOG`. These generic names collide with Kubernetes' auto-injected Docker-link-style Service env vars — a Service named `trino` (from the Trino Helm chart, same namespace) makes every pod see `TRINO_PORT=tcp://10.43.x.x:8080`. Building an argparse *default* by calling `int()` on that crashes at parser-construction time, before `start.sh`'s explicit `--port` flag ever gets a chance to win. Confirmed live: the pod's only output was the `ValueError` traceback.

**Fix (both prongs):**
- Renamed the driver's env lookups to namespaced `TRINO_LOADTEST_HOST`/`TRINO_LOADTEST_PORT`/`TRINO_LOADTEST_USER`/`TRINO_LOADTEST_CATALOG`, consistent with the kit's other `TRINO_LOADTEST_*` vars.
- Added `_int_env_default()`/`_float_env_default()` helpers that try/except the parse and fall back to the default on any failure — covers all numeric env-backed defaults (threads/duration/interval too), not just port.
- `bin/start.sh.template`: renamed its own local shell vars to match (`TRINO_LOADTEST_HOST`/`PORT`/`USER`) for naming consistency — these are local/unexported and passed only as explicit `--host`/`--port`/`--user` flags, so functionally unaffected, but the mismatch was confusing.

**Validation:** `python3 test_driver.py` — 30/30 checks pass (23 baseline + 7 new: K8s-injected bare `TRINO_PORT` ignored, malformed namespaced var falls back, valid namespaced var honoured, explicit `--port` wins over malformed env, both helper functions' fallback behavior).

## #2132 — unset optional kit arg arrives as literal string "null"

**Root cause:** `start.sh` guarded the optional queries file with `[ -n "${TRINO_LOADTEST_QUERIES_FILE:-}" ]`. `kit.yaml` declares the default as `""`, but the easy-db-lab kit runner actually injects the literal string `"null"` for an unset optional arg — confirmed live with a debug echo. `[ -n "null" ]` is true, so the script ran `kubectl create configmap ... --from-file=queries.txt=null`, which failed, producing no manifest for `kubectl apply -f -` to consume. The pod was never created.

**Fix:** reject the literal `"null"` alongside the existing empty-string guard. Swept every other `easy-db-lab-kits/**/bin/*.sh.template` for the same exposure:
- `cqlite-flight/bin/{start,stop}.sh.template` — already safe: no `[ -n ]`-style env guards at all (args are literal `__PLACEHOLDER__` template substitutions, not bash env vars; every arg also has a non-empty default anyway).
- `trino-cqlite/bin/{install,reapply-plugin-patch,start,stop,uninstall}.sh.template` — no `[ -n ]`/`[ -z ]`-style optional-arg guards found. The one empty-default optional string (`--local-datacenter`) is templated only into a commented-out line (already inert by design).
- `trino-cqlite/bin/verify.sh.template` — has `[ -z ]` guards, but on positional CLI args from a human running the script directly, not kit-runner-injected env vars — the "null"-injection exposure doesn't apply.
- `trino-loadtest/bin/stop.sh.template` — no optional-arg consumption.

Also updated `easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md` with `[UPDATED after the first live run]` callouts for all three fixes (loadtest-phase callout before step 13a; observability-phase callout before step 14, documenting the new startup log line to check for).

**Validation:** `bash -n` + `shellcheck -x` clean on the modified template.

## Gate

```
==== AGENT-GATE LITE SUMMARY ====
commit: afdaae38 branch: issue-2128-round2-harness-fixes dirty: no
lite-scope: file-size fmt clippy scoped-tests (full gate NOT run — run it once before merge)
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (2s)
scoped-tests:      PASS (3s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Closes #2128
Closes #2130
Closes #2132