### PR TITLE
feat(#2129): LIMIT pushdown — bounded per-split scans (connector applyLimit → ticket limit → do_get early stop)

### DIFF
--- a/cqlite-flight/src/filter.rs
+++ b/cqlite-flight/src/filter.rs
@@ -197,6 +197,10 @@ pub struct ScanSpec {
     pub filter: Option<FilterExpr>,
     /// Column projection; `None` emits all columns.
     pub projection: Option<Vec<String>>,
+    /// Row cap (issue #2129): emit at most this many rows for the scan, counted
+    /// AFTER token pruning and predicate filtering. `None` scans the full range.
+    /// Ignored on the aggregation path (partial rows already collapse the set).
+    pub limit: Option<u64>,
 }
 
 impl ScanSpec {
@@ -240,6 +244,7 @@ impl ScanSpec {
             token,
             filter,
             projection: ticket.columns.clone(),
+            limit: ticket.limit,
         })
     }
 }
@@ -581,6 +586,31 @@ mod tests {
     fn no_bounds_means_no_token_filter() {
         let spec = ScanSpec::from_ticket(&ticket_with(vec![]), &simple_schema()).unwrap();
         assert!(spec.token.is_none());
+    }
+
+    #[test]
+    fn limit_is_carried_from_ticket() {
+        // No limit on the ticket → None on the spec.
+        let spec = ScanSpec::from_ticket(&ticket_with(vec![]), &simple_schema()).unwrap();
+        assert_eq!(spec.limit, None);
+
+        // A ticket limit flows straight through (including the 0 edge).
+        let t = FlightTicket {
+            limit: Some(5),
+            ..ticket_with(vec![])
+        };
+        assert_eq!(
+            ScanSpec::from_ticket(&t, &simple_schema()).unwrap().limit,
+            Some(5)
+        );
+        let t = FlightTicket {
+            limit: Some(0),
+            ..ticket_with(vec![])
+        };
+        assert_eq!(
+            ScanSpec::from_ticket(&t, &simple_schema()).unwrap().limit,
+            Some(0)
+        );
     }
 
     #[test]

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -1404,7 +1404,11 @@ mod tests {
 
         let p = MergeProducer::with_spec(schema, 4, spec_with_limit(Some(100))).unwrap();
         let batches = p.produce(&DirSource::new(&dir)).unwrap();
-        assert_eq!(total_rows(&batches), 10, "LIMIT past the row count keeps all");
+        assert_eq!(
+            total_rows(&batches),
+            10,
+            "LIMIT past the row count keeps all"
+        );
     }
 
     #[test]

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -480,15 +480,30 @@ impl MergeProducer {
     /// `merger.step()`, so a cancel (e.g. client disconnect) stops the merge
     /// before collecting/reconciling the next partition — never after performing
     /// one more potentially large partition merge.
+    ///
+    /// LIMIT pushdown (issue #2129): when the scan carries a row cap
+    /// ([`ScanSpec::limit`](crate::filter::ScanSpec)), the merge stops as soon as
+    /// `limit` rows have been EMITTED. The cap is counted AFTER the token filter
+    /// and the predicate filter, so partitions outside the range and rows the
+    /// filter rejects never consume it — a filtered scan returns as many matching
+    /// rows as exist up to `limit`, never fewer. `limit == Some(0)` emits nothing
+    /// without stepping the merge at all. The cap applies per split; the connector
+    /// sets `limitGuaranteed = false` so Trino keeps a global `Limit` above.
     fn drive_merge(
         &self,
         merger: &mut dyn PartitionStepper,
         cancel: &CancelFlag,
         batches: &mut Vec<RecordBatch>,
     ) -> Result<(), ProducerError> {
+        let limit = self.spec.limit;
+        // A zero cap produces no rows without touching the merge.
+        if limit == Some(0) {
+            return Ok(());
+        }
         let mut buffer: Vec<QueryRow> = Vec::with_capacity(self.batch_size);
+        let mut emitted: u64 = 0;
 
-        loop {
+        'partitions: loop {
             if cancel.is_cancelled() {
                 return Err(ProducerError::Cancelled);
             }
@@ -518,8 +533,15 @@ impl MergeProducer {
                     }
                 }
                 buffer.push(row);
+                emitted += 1;
                 if buffer.len() >= self.batch_size {
                     batches.push(self.flush_buffer(&mut buffer)?);
+                }
+                // LIMIT reached (counted post-filter): stop the merge early.
+                if let Some(cap) = limit {
+                    if emitted >= cap {
+                        break 'partitions;
+                    }
                 }
             }
         }
@@ -1332,6 +1354,105 @@ mod tests {
         let p = MergeProducer::with_spec(schema, 1024, spec).unwrap();
         // 10 < score < 40 → 20, 30.
         assert_eq!(total_rows(&p.produce(&DirSource::new(&dir)).unwrap()), 2);
+    }
+
+    // ---- Issue #2129: LIMIT pushdown early-stop ----
+
+    /// Collect every `score` value across the produced batches (sorted).
+    fn scores_of(batches: &[RecordBatch]) -> Vec<i32> {
+        let mut out: Vec<i32> = Vec::new();
+        for b in batches {
+            let scores = b
+                .column_by_name("score")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow::array::Int32Array>()
+                .unwrap();
+            out.extend((0..scores.len()).map(|i| scores.value(i)));
+        }
+        out.sort_unstable();
+        out
+    }
+
+    fn spec_with_limit(limit: Option<u64>) -> ScanSpec {
+        ScanSpec {
+            limit,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn limit_below_row_count_stops_early() {
+        let schema = simple_schema();
+        let rows = (1..=10)
+            .map(|i| write_row(i, &format!("n{i}"), i, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+
+        let p = MergeProducer::with_spec(schema, 4, spec_with_limit(Some(3))).unwrap();
+        let batches = p.produce(&DirSource::new(&dir)).unwrap();
+        assert_eq!(total_rows(&batches), 3, "LIMIT 3 caps a 10-row table at 3");
+    }
+
+    #[test]
+    fn limit_above_row_count_returns_all_rows() {
+        let schema = simple_schema();
+        let rows = (1..=10)
+            .map(|i| write_row(i, &format!("n{i}"), i, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+
+        let p = MergeProducer::with_spec(schema, 4, spec_with_limit(Some(100))).unwrap();
+        let batches = p.produce(&DirSource::new(&dir)).unwrap();
+        assert_eq!(total_rows(&batches), 10, "LIMIT past the row count keeps all");
+    }
+
+    #[test]
+    fn limit_zero_emits_no_rows() {
+        let schema = simple_schema();
+        let rows = (1..=10)
+            .map(|i| write_row(i, &format!("n{i}"), i, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+
+        let p = MergeProducer::with_spec(schema, 4, spec_with_limit(Some(0))).unwrap();
+        let batches = p.produce(&DirSource::new(&dir)).unwrap();
+        assert_eq!(total_rows(&batches), 0, "LIMIT 0 emits nothing");
+    }
+
+    #[test]
+    fn limit_counts_rows_after_filtering() {
+        use crate::ticket::{FlightTicket, Predicate, PredicateOp};
+        use serde_json::json;
+        // Scores 10,20,30,40,50; `score > 25` keeps {30,40,50} (3 rows). A cap of
+        // 2 must return exactly 2 SURVIVING rows — proving filtered-out rows never
+        // consumed the cap (else we could get 0 or 1 matching row back).
+        let schema = simple_schema();
+        let rows = (1..=5)
+            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+
+        let mut spec = spec_from(
+            &schema,
+            FlightTicket {
+                predicates: vec![Predicate {
+                    column: "score".into(),
+                    op: PredicateOp::Gt,
+                    value: json!(25),
+                }],
+                ..Default::default()
+            },
+        );
+        spec.limit = Some(2);
+        let p = MergeProducer::with_spec(schema, 1024, spec).unwrap();
+        let batches = p.produce(&DirSource::new(&dir)).unwrap();
+        let survivors = scores_of(&batches);
+        assert_eq!(survivors.len(), 2, "cap counts only surviving rows");
+        assert!(
+            survivors.iter().all(|&s| s > 25),
+            "every returned row must satisfy the filter, got {survivors:?}"
+        );
     }
 
     #[test]

--- a/cqlite-flight/src/ticket.rs
+++ b/cqlite-flight/src/ticket.rs
@@ -262,6 +262,23 @@ pub struct FlightTicket {
     /// the partial schema instead of full rows. `None` keeps the row path.
     #[serde(default)]
     pub aggregation: Option<Aggregation>,
+    /// LIMIT pushdown (issue #2129). When `Some(n)`, the producer emits at most
+    /// `n` rows for this ticket, stopping the k-way merge as soon as the cap is
+    /// reached — turning `LIMIT k` into bounded per-split work instead of a full
+    /// range scan. The cap is applied AFTER token pruning and predicate
+    /// filtering, so pruned/filtered-out rows never consume it. Because each
+    /// split caps independently, the connector reports `limitGuaranteed = false`
+    /// and Trino keeps a global `Limit` above the scan to do the final cut.
+    /// Ignored when [`Self::aggregation`] is `Some` (the aggregate already
+    /// collapses the row set to partial rows). `None` scans the full range.
+    ///
+    /// Compat: the field is additive-optional — the ticket struct is NOT
+    /// `deny_unknown_fields`, so an old server silently ignores a `limit` from a
+    /// new connector (falling back to a correct full scan) and an old connector's
+    /// ticket defaults `limit` to `None` on a new server. Both directions are
+    /// safe; the only cost of skew is losing the bounding, never wrong rows.
+    #[serde(default)]
+    pub limit: Option<u64>,
 }
 
 impl Default for FlightTicket {
@@ -279,6 +296,7 @@ impl Default for FlightTicket {
             predicates: Vec::new(),
             filter: None,
             aggregation: None,
+            limit: None,
         }
     }
 }
@@ -450,10 +468,61 @@ mod tests {
             }],
             filter: None,
             aggregation: None,
+            limit: Some(5),
         };
         let bytes = ticket.to_bytes().expect("serialize");
         let back = FlightTicket::from_bytes(&bytes).expect("parse");
         assert_eq!(ticket, back);
+    }
+
+    // ---- Issue #2129: LIMIT pushdown wire format + compat ----
+
+    /// A ticket carrying `limit` parses it, and one omitting it defaults to
+    /// `None` (no bound → full scan). The field is plain JSON so the Java
+    /// connector emits `"limit": <n>`.
+    #[test]
+    fn limit_field_parses_and_defaults_to_none() {
+        let with_limit = json!({
+            "keyspace": "k", "table": "t",
+            "ddl": "CREATE TABLE k.t (id int PRIMARY KEY)",
+            "limit": 5
+        })
+        .to_string();
+        let t = FlightTicket::from_bytes(with_limit.as_bytes()).expect("parse");
+        assert_eq!(t.limit, Some(5));
+
+        // Absent → None (an old connector's ticket on a new server).
+        let t = FlightTicket::from_bytes(&minimal_json()).expect("parse");
+        assert_eq!(t.limit, None);
+
+        // limit: 0 is a distinct, valid value (SELECT ... LIMIT 0).
+        let zero = json!({
+            "keyspace": "k", "table": "t",
+            "ddl": "CREATE TABLE k.t (id int PRIMARY KEY)",
+            "limit": 0
+        })
+        .to_string();
+        let t = FlightTicket::from_bytes(zero.as_bytes()).expect("parse");
+        assert_eq!(t.limit, Some(0));
+    }
+
+    /// Compat posture (issue #2129): the ticket is NOT `deny_unknown_fields`, so
+    /// an UNKNOWN field (e.g. a future connector's addition seen by an older
+    /// server) is silently ignored rather than rejected. This proves the
+    /// additive-optional contract that makes `limit` safe to roll out in either
+    /// order (new connector ⇄ old server, old connector ⇄ new server).
+    #[test]
+    fn unknown_field_is_ignored_not_rejected() {
+        let raw = json!({
+            "keyspace": "k", "table": "t",
+            "ddl": "CREATE TABLE k.t (id int PRIMARY KEY)",
+            "limit": 7,
+            "some_future_field": {"nested": [1, 2, 3]}
+        })
+        .to_string();
+        let t = FlightTicket::from_bytes(raw.as_bytes())
+            .expect("unknown field must not fail the parse");
+        assert_eq!(t.limit, Some(7), "known fields still bind");
     }
 
     #[test]

--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -59,6 +59,7 @@ Building from this repo (`./gradlew installPlugin`) produces the same directory.
 | PageSource (Flight DoGet → Arrow → Trino Page) | done |
 | Projection pushdown (only requested columns streamed) | done |
 | Predicate pushdown (TupleDomain → ticket) | deferred (Trino post-filters; server supports it) |
+| LIMIT pushdown (per-split bounded scan) | done, tested (issue #2129) |
 
 The full stack works end-to-end: `SELECT` over `cqlite.<keyspace>.<table>`
 streams compaction-merged, token-range-deduped Arrow data back to Trino.
@@ -69,6 +70,36 @@ tuples, decimal) are rejected at planning with a clear message rather than
 failing mid-scan. Cassandra's default 16 vnodes produce 16 splits per table
 (each reads the SSTable filtered by token range) — correct, with split
 consolidation a future optimization.
+
+### LIMIT pushdown (issue #2129)
+
+`SELECT ... LIMIT k` pushes the row cap into the Flight ticket via
+`ConnectorMetadata.applyLimit`, so each split's `do_get` stops its k-way
+compaction-merge after `k` rows instead of scanning its entire token range.
+Without this, even `SELECT * ... LIMIT 5` full-scans and merges every SSTable
+(the reported ~235s over ~2M rows); with it, `LIMIT k` is bounded per-split work.
+
+Semantics:
+
+- **Per-split cap.** Each of the (token-range) splits independently caps at `k`
+  rows, so the union returned to Trino can exceed `k`. The connector therefore
+  returns `limitGuaranteed = false` and Trino keeps its `Limit`/`LimitPartial`
+  above the `TableScan` to do the final global cut — always correct.
+- **Counted after filtering.** The server applies the cap AFTER token pruning and
+  predicate filtering, so a filtered scan returns as many matching rows as exist
+  up to `k`, never fewer.
+- **Not pushed under aggregation.** An aggregated handle (`count`/`sum`/… with or
+  without `GROUP BY`) already collapses the row set; a row `LIMIT` there is
+  meaningless, so `applyLimit` declines and the server ignores `limit` if a ticket
+  ever carries both.
+
+**Version requirements.** LIMIT pushdown needs BOTH a connector and a
+cqlite-flight server that understand the ticket's `limit` field (connector +
+flight ≥ the release carrying #2129). The field is additive-optional and the
+Rust ticket is not `deny_unknown_fields`, so version skew is safe in either
+direction: an older server silently ignores `limit` (correct full scan, just
+unbounded), and an older connector never sets it (server defaults to no cap).
+Skew only forfeits the speedup — it never returns wrong rows.
 
 ## End-to-end stack (docker)
 

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -12,6 +12,7 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableVersion;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -198,8 +200,12 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             return Optional.empty();
         }
 
+        // Preserve any pushed-down LIMIT (#2129): this branch only runs for a
+        // non-aggregated handle, so aggregation/finalize stay empty, but a prior
+        // applyLimit's cap must NOT be dropped when the handle is rebuilt.
         CqliteFlightTableHandle newHandle = new CqliteFlightTableHandle(
-                table.keyspace(), table.table(), table.ddl(), Optional.of(filterJson));
+                table.keyspace(), table.table(), table.ddl(),
+                Optional.of(filterJson), Optional.empty(), Optional.empty(), table.limit());
 
         // The residual expression Trino must still evaluate (the untranslatable
         // conjuncts, ANDed). Empty residual => TRUE (fully pushed).
@@ -210,6 +216,53 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
                 constraint.getSummary(), // domain returned unchanged; we don't consume it
                 remainingExpression,
                 false));
+    }
+
+    /**
+     * Push a {@code LIMIT} down to the cqlite-flight server (issue #2129).
+     *
+     * <p>Records the row cap on the handle so every split's Flight ticket carries
+     * it and the server stops its k-way compaction-merge after {@code limit}
+     * post-filter rows — turning {@code LIMIT k} into bounded per-split work
+     * instead of a full range scan (the reported 235s {@code LIMIT 5}).
+     *
+     * <p>The returned {@link LimitApplicationResult} sets
+     * {@code limitGuaranteed = false}: each of the (token-range) splits caps at
+     * {@code limit} INDEPENDENTLY, so their union can exceed {@code limit}. This
+     * is the standard bounded-scan pattern — correct because Trino keeps its
+     * {@code Limit}/{@code LimitPartial} above the scan to do the final global
+     * cut. {@code precalculateStatistics = false}: we do not re-derive stats.
+     *
+     * <p>Declines (returns {@link Optional#empty()}) for an already-aggregated
+     * handle (the aggregate already collapses the row set; the server ignores a
+     * limit under aggregation), and is idempotent: if the handle already carries
+     * a cap at least as tight as {@code limit}, there is nothing new to push, so
+     * it returns empty and the optimizer stops iterating.
+     */
+    @Override
+    public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(
+            ConnectorSession session, ConnectorTableHandle handle, long limit) {
+        CqliteFlightTableHandle table = (CqliteFlightTableHandle) handle;
+
+        // A row cap under an aggregation is meaningless (partial rows already
+        // collapse the set) and the server ignores limit+aggregation — decline.
+        if (table.isAggregated()) {
+            return Optional.empty();
+        }
+
+        // Idempotency / termination: an existing cap at least as tight leaves
+        // nothing to improve. Returning empty stops the optimizer re-applying the
+        // same limit in a loop.
+        if (table.limit().isPresent() && table.limit().getAsLong() <= limit) {
+            return Optional.empty();
+        }
+
+        CqliteFlightTableHandle newHandle = new CqliteFlightTableHandle(
+                table.keyspace(), table.table(), table.ddl(),
+                table.filterJson(), table.aggregationJson(), table.finalizePlanJson(),
+                OptionalLong.of(limit));
+
+        return Optional.of(new LimitApplicationResult<>(newHandle, false, false));
     }
 
     private static String serialize(JsonNode node) {

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightPageSourceProvider.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightPageSourceProvider.java
@@ -73,7 +73,8 @@ public class CqliteFlightPageSourceProvider implements ConnectorPageSourceProvid
                 names.isEmpty() ? Optional.empty() : Optional.of(names),
                 List.of(), // legacy flat predicates unused; tree carried in filter
                 filter,
-                null); // non-aggregated scan: no aggregation pushed
+                null, // non-aggregated scan: no aggregation pushed
+                tableHandle.limit()); // LIMIT pushdown (#2129): per-split row cap
 
         return new CqliteFlightPageSource(client, flightSplit, projected, ticket);
     }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightTableHandle.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightTableHandle.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.trino.spi.connector.ConnectorTableHandle;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Identifies a table to scan. Carries the CQL DDL (fetched from Sidecar) so the
@@ -24,6 +25,14 @@ import java.util.Optional;
  * that fans out to all token ranges, pulls each range's PARTIAL aggregate, merges
  * them, and emits the fully merged result (Trino does not re-aggregate across
  * splits — see issue #841).
+ *
+ * <p>{@code limit} holds the row cap pushed down by
+ * {@link CqliteFlightMetadata#applyLimit} (issue #2129), or empty. When present,
+ * every split's Flight ticket carries it and the server stops its k-way merge
+ * after {@code limit} post-filter rows. The cap is applied PER SPLIT, so the
+ * connector returns {@code limitGuaranteed = false} and Trino keeps a global
+ * {@code Limit} above the scan. It is never set on an aggregated handle (the
+ * aggregate already collapses the row set).
  */
 public record CqliteFlightTableHandle(
         String keyspace,
@@ -31,17 +40,32 @@ public record CqliteFlightTableHandle(
         String ddl,
         Optional<String> filterJson,
         Optional<String> aggregationJson,
-        Optional<String> finalizePlanJson)
+        Optional<String> finalizePlanJson,
+        OptionalLong limit)
         implements ConnectorTableHandle {
 
     /** Convenience constructor for a handle with no pushed-down filter or aggregation. */
     public CqliteFlightTableHandle(String keyspace, String table, String ddl) {
-        this(keyspace, table, ddl, Optional.empty(), Optional.empty(), Optional.empty());
+        this(keyspace, table, ddl, Optional.empty(), Optional.empty(), Optional.empty(), OptionalLong.empty());
     }
 
     /** Convenience constructor for a handle carrying a filter but no aggregation. */
     public CqliteFlightTableHandle(String keyspace, String table, String ddl, Optional<String> filterJson) {
-        this(keyspace, table, ddl, filterJson, Optional.empty(), Optional.empty());
+        this(keyspace, table, ddl, filterJson, Optional.empty(), Optional.empty(), OptionalLong.empty());
+    }
+
+    /**
+     * Six-arg constructor (no limit) retained so existing call sites that predate
+     * LIMIT pushdown compile unchanged; defaults {@code limit} to empty.
+     */
+    public CqliteFlightTableHandle(
+            String keyspace,
+            String table,
+            String ddl,
+            Optional<String> filterJson,
+            Optional<String> aggregationJson,
+            Optional<String> finalizePlanJson) {
+        this(keyspace, table, ddl, filterJson, aggregationJson, finalizePlanJson, OptionalLong.empty());
     }
 
     /** True when this handle carries a pushed-down aggregation (the finalize-split path). */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/FlightTicketJson.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/FlightTicketJson.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Builds the JSON Flight ticket consumed by the cqlite-flight server
@@ -45,6 +46,35 @@ public final class FlightTicketJson {
             List<Predicate> predicates,
             JsonNode filter,
             JsonNode aggregation) {
+        return build(keyspace, table, ddl, snapshot, tokenStart, tokenEnd, wraparound,
+                columns, predicates, filter, aggregation, OptionalLong.empty());
+    }
+
+    /**
+     * Build the ticket JSON bytes, additionally carrying a row {@code limit}
+     * (issue #2129).
+     *
+     * @param limit a per-split row cap for the server to stop its merge early
+     *              (LIMIT pushdown), or {@link OptionalLong#empty()} to omit it —
+     *              matching the server's {@code #[serde(default)] Option<u64>}
+     *              (an omitted field parses as {@code None} = full scan). The cap
+     *              is applied server-side AFTER predicate filtering; because each
+     *              split caps independently, the connector sets
+     *              {@code limitGuaranteed = false}.
+     */
+    public static byte[] build(
+            String keyspace,
+            String table,
+            String ddl,
+            Optional<String> snapshot,
+            Optional<Long> tokenStart,
+            Optional<Long> tokenEnd,
+            boolean wraparound,
+            Optional<List<String>> columns,
+            List<Predicate> predicates,
+            JsonNode filter,
+            JsonNode aggregation,
+            OptionalLong limit) {
         ObjectNode root = MAPPER.createObjectNode();
         root.put("version", TICKET_VERSION);
         root.put("keyspace", keyspace);
@@ -75,6 +105,8 @@ public final class FlightTicketJson {
         if (aggregation != null) {
             root.set("aggregation", aggregation);
         }
+        // Omit when empty to match the server's #[serde(default)] Option<u64>.
+        limit.ifPresent(l -> root.put("limit", l));
         try {
             return MAPPER.writeValueAsBytes(root);
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataApplyLimitTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataApplyLimitTest.java
@@ -1,0 +1,122 @@
+package in.mcfad.cqlite.flight;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.LimitApplicationResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises {@link CqliteFlightMetadata#applyLimit} directly (issue #2129). No
+ * live Sidecar/Flight dependency — applyLimit only rewrites the table handle.
+ */
+class CqliteFlightMetadataApplyLimitTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final CqliteFlightMetadata metadata = new CqliteFlightMetadata(null, null, null);
+
+    private static String aggregationJson() {
+        return "{\"group_by\":[],"
+                + "\"aggregates\":[{\"func\":\"Count\",\"column\":null,\"output\":\"agg0\"}]}";
+    }
+
+    @Test
+    void pushesLimitOntoHandleWithLimitNotGuaranteed() {
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+
+        Optional<LimitApplicationResult<ConnectorTableHandle>> applied =
+                metadata.applyLimit(null, handle, 5);
+        assertTrue(applied.isPresent(), "a plain handle must accept a LIMIT push");
+
+        LimitApplicationResult<ConnectorTableHandle> result = applied.get();
+        // Per-split cap → the union across splits can exceed the limit, so Trino
+        // must keep its Limit above the scan.
+        assertFalse(result.isLimitGuaranteed(), "each split caps independently");
+        assertFalse(result.isPrecalculateStatistics());
+
+        CqliteFlightTableHandle newHandle = (CqliteFlightTableHandle) result.getHandle();
+        assertEquals(OptionalLong.of(5), newHandle.limit());
+    }
+
+    @Test
+    void ticketForLimitedHandleCarriesLimitField() throws Exception {
+        // The cap on the handle must reach the Flight ticket JSON that the split's
+        // page source sends to the server (the wire contract with the Rust side).
+        CqliteFlightTableHandle handle = (CqliteFlightTableHandle)
+                metadata.applyLimit(null, new CqliteFlightTableHandle("ks", "t", "ddl"), 5)
+                        .orElseThrow().getHandle();
+
+        byte[] ticket = FlightTicketJson.build(
+                "ks", "t", "ddl",
+                Optional.empty(), Optional.of(-100L), Optional.of(100L), false,
+                Optional.empty(), java.util.List.of(), null, null, handle.limit());
+        var root = MAPPER.readTree(ticket);
+        assertTrue(root.has("limit"), "ticket must carry the limit field");
+        assertEquals(5, root.get("limit").asLong());
+    }
+
+    @Test
+    void reappliesIdempotentlyWhenLimitAlreadyPresent() {
+        // First push records the cap; a second push with an EQUAL (or larger) cap
+        // has nothing to improve → empty, so the optimizer stops iterating.
+        ConnectorTableHandle plain = new CqliteFlightTableHandle("ks", "t", "ddl");
+        ConnectorTableHandle limited = metadata.applyLimit(null, plain, 5).orElseThrow().getHandle();
+
+        assertTrue(metadata.applyLimit(null, limited, 5).isEmpty(),
+                "re-applying the same limit must not loop");
+        assertTrue(metadata.applyLimit(null, limited, 10).isEmpty(),
+                "a looser limit adds nothing");
+
+        // A strictly tighter limit still improves the plan → pushed.
+        Optional<LimitApplicationResult<ConnectorTableHandle>> tighter =
+                metadata.applyLimit(null, limited, 2);
+        assertTrue(tighter.isPresent(), "a tighter limit is pushed");
+        assertEquals(OptionalLong.of(2),
+                ((CqliteFlightTableHandle) tighter.get().getHandle()).limit());
+    }
+
+    @Test
+    void declinesOnAggregatedHandle() {
+        // An aggregated handle already collapses the row set; the server ignores
+        // limit+aggregation, so a row LIMIT must not be pushed onto it.
+        CqliteFlightTableHandle aggregated = new CqliteFlightTableHandle(
+                "ks", "t", "ddl",
+                Optional.empty(), Optional.of(aggregationJson()),
+                Optional.of("{\"group_by\":[],\"outputs\":[]}"));
+        assertTrue(aggregated.isAggregated());
+        assertTrue(metadata.applyLimit(null, aggregated, 5).isEmpty(),
+                "no LIMIT push onto an aggregated handle");
+    }
+
+    @Test
+    void preservesLimitAcrossApplyFilter() throws Exception {
+        // applyLimit then applyFilter must NOT drop the cap when it rebuilds the
+        // handle (order-independence of the two pushdowns).
+        CqliteFlightTableHandle limited = (CqliteFlightTableHandle)
+                metadata.applyLimit(null, new CqliteFlightTableHandle("ks", "t", "ddl"), 5)
+                        .orElseThrow().getHandle();
+
+        var col = new CqliteFlightColumnHandle("age",
+                io.trino.spi.type.BigintType.BIGINT, PushdownCapability.FULL);
+        var predicate = new io.trino.spi.expression.Call(
+                io.trino.spi.type.BooleanType.BOOLEAN,
+                io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME,
+                java.util.List.of(
+                        new io.trino.spi.expression.Variable("age", io.trino.spi.type.BigintType.BIGINT),
+                        new io.trino.spi.expression.Constant(10L, io.trino.spi.type.BigintType.BIGINT)));
+        var constraint = new io.trino.spi.connector.Constraint(
+                io.trino.spi.predicate.TupleDomain.all(), predicate,
+                java.util.Map.of("age", col));
+
+        var filtered = (CqliteFlightTableHandle)
+                metadata.applyFilter(null, limited, constraint).orElseThrow().getHandle();
+        assertTrue(filtered.filterJson().isPresent(), "filter pushed");
+        assertEquals(OptionalLong.of(5), filtered.limit(), "limit survives applyFilter");
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/FlightTicketJsonTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/FlightTicketJsonTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -91,6 +92,34 @@ class FlightTicketJsonTest {
         assertEquals(0, node.get("predicates").size());
         // A null aggregation is omitted entirely (server's #[serde(default)] Option).
         assertFalse(node.has("aggregation"));
+        // The 11-arg overload omits `limit` (server's #[serde(default)] Option<u64>).
+        assertFalse(node.has("limit"));
+    }
+
+    @Test
+    void emitsLimitWhenPresentAndOmitsWhenEmpty() throws Exception {
+        // Present cap → `limit` field carries it (issue #2129).
+        byte[] withLimit = FlightTicketJson.build(
+                "ks", "t", "ddl",
+                Optional.empty(), Optional.empty(), Optional.empty(), false,
+                Optional.empty(), List.of(), null, null, OptionalLong.of(5));
+        JsonNode node = parse(withLimit);
+        assertTrue(node.has("limit"));
+        assertEquals(5, node.get("limit").asLong());
+
+        // limit == 0 is a distinct valid value, still emitted (SELECT ... LIMIT 0).
+        byte[] zero = FlightTicketJson.build(
+                "ks", "t", "ddl",
+                Optional.empty(), Optional.empty(), Optional.empty(), false,
+                Optional.empty(), List.of(), null, null, OptionalLong.of(0));
+        assertEquals(0, parse(zero).get("limit").asLong());
+
+        // Empty cap → field omitted (server defaults to None = full scan).
+        byte[] none = FlightTicketJson.build(
+                "ks", "t", "ddl",
+                Optional.empty(), Optional.empty(), Optional.empty(), false,
+                Optional.empty(), List.of(), null, null, OptionalLong.empty());
+        assertFalse(parse(none).has("limit"));
     }
 
     @Test


### PR DESCRIPTION
Closes #2129

## What

LIMIT pushdown end to end, so `SELECT ... LIMIT k` becomes bounded per-split work instead of a full range scan (the reported ~235s `LIMIT 5` over ~2M rows).

**Connector (Java):** `ConnectorMetadata.applyLimit` records an `OptionalLong limit` on `CqliteFlightTableHandle`; the non-aggregated split's Flight ticket stamps a `limit` field. Returns `LimitApplicationResult(handle, limitGuaranteed=false, precalculateStatistics=false)` — each split caps independently, so Trino keeps its global `Limit`/`LimitPartial` above the scan (always correct). `applyFilter` preserves the cap when it rebuilds the handle (order-independent). Declines on aggregated handles; idempotent re-application returns empty (a strictly tighter limit still pushes).

**Ticket protocol:** additive-optional `limit: Option<u64>` (`#[serde(default)]`). Connector omits the field when empty.

**Flight server (Rust):** `drive_merge` stops the k-way merge after `limit` rows, counted AFTER token pruning and predicate filtering (filtered-out rows never consume the cap); `limit == Some(0)` emits nothing without stepping the merge. The aggregation path never consults `limit` by construction.

## Ticket-compat posture

The Rust `FlightTicket` is NOT `deny_unknown_fields`, so the field is safe in both skew directions and I chose additive-optional (not fail-closed): an old server silently ignores `limit` from a new connector (correct full scan, just unbounded); an old connector's ticket defaults `limit` to `None` on a new server. Skew only forfeits the speedup, never returns wrong rows. Proven by `unknown_field_is_ignored_not_rejected` in `ticket.rs`.

## count(*) finding — already pushes down; NOT version skew

`SELECT count(*)` already pushes down on current main via `applyAggregation` (issue #841/#893) — test `CqliteFlightMetadataApplyAggregationTest.pushesCountStarGlobal` (`trino-connector/.../CqliteFlightMetadataApplyAggregationTest.java:62`) proves the ticket carries `{"func":"Count","column":null}`. The server side (`cqlite-flight/src/agg.rs`, added by #841 on 2026-06-20) is present at the `v0.13.0` tag (verified: `git cat-file -e v0.13.0:cqlite-flight/src/agg.rs` succeeds; the ticket `aggregation` field is present at that tag). So the live run's slowness was **not** connector/flight version skew — both 0.13.1 connector and v0.13.0 flight image support count pushdown.

The remaining slowness is inherent: counting reconciled live rows requires a full, tombstone/LWW-aware k-way merge-scan server-side (Statistics.db per-SSTable counts are pre-merge estimates, not the reconciled live-row count, so there is no metadata shortcut under snapshot read-mode). Pushdown already avoids streaming 2M rows to Trino; it cannot avoid reading them. **No duplication needed here** — a true fast count would be a separate approximate/stats-based feature.

## "Network closed at ~235s" note (finding, not a fix)

The connector sets **no deadline** on the `do_get` scan stream — `CqliteFlightClient.getStream` (`CqliteFlightClient.java:88`) passes no `CallOptions.timeout`; the only Flight deadline is the 3s planning-time `table_stats` DoAction. So the ~235s cut is **not** from the connector's Flight client. `MergeProducer` materializes all batches before streaming (Phase 1, `producer.rs`), so zero bytes flow to Trino for the entire merge — the most likely trigger is a no-data-flowing idle timeout on the long DoGet stream (gRPC/Flight infra between worker and flight pod, a k8s/LB idle timeout, or Trino's client-facing `query.client.timeout`). Confirming the exact timer needs coordinator/proxy logs. LIMIT pushdown removes the trigger by bounding the merge.

## Tests

- Rust (`cargo test -p cqlite-flight`): **135 pass, 0 fail** (8 new). New: ticket parse with/without limit + limit=0 + unknown-field ignored; `ScanSpec` carries limit; `drive_merge` early stop for limit<rows, limit>rows, limit=0, and limit-with-filter (filtered rows do not consume the cap).
- Java (`./gradlew test`): **187 pass, 0 fail**. New: `applyLimit` handle plumbing + `limitGuaranteed=false`, ticket JSON carries `limit`, idempotent re-application, decline on aggregated handle, limit survives `applyFilter`; `FlightTicketJson` emits/omits `limit`.

## file-size ratchet

`ticket.rs`, `filter.rs`, `producer.rs` were already over the 800-line src threshold before this change (tracked by splitting epics #1116/#1135). Splitting a 2397-line file is out of scope for a LIMIT feature, so the gate was run with `CQLITE_ALLOW_FILE_GROWTH=1` per the campsite-rule escape hatch.
