### PR TITLE
perf(#1643): K4 — Arc partition-key + TableId identity, stop per-row clones

### DIFF
--- a/cqlite-core/src/query/select_executor/limit_pushdown/mod.rs
+++ b/cqlite-core/src/query/select_executor/limit_pushdown/mod.rs
@@ -493,7 +493,7 @@ fn prefix_is_token_ordered(rows: &[QueryRow]) -> bool {
     use crate::util::cassandra_murmur3::cassandra_murmur3_token;
     let mut prev: Option<(i64, &[u8])> = None;
     for row in rows {
-        let key = row.key.0.as_slice();
+        let key = row.key.as_bytes();
         let token = cassandra_murmur3_token(key);
         if let Some(prev) = prev {
             if prev > (token, key) {

--- a/cqlite-core/src/query/select_executor/limit_pushdown/tests.rs
+++ b/cqlite-core/src/query/select_executor/limit_pushdown/tests.rs
@@ -320,7 +320,7 @@ fn reconcile_charges_full_authoritative_count_when_over_cap() {
 
     // Results stay CAPPED: exactly the first 3 ACCEPTED rows, in scan order
     // (marker skipped). The fix must NOT change output or LIMIT/OFFSET semantics.
-    let keys: Vec<Vec<u8>> = out.iter().map(|r| r.key.0.clone()).collect();
+    let keys: Vec<Vec<u8>> = out.iter().map(|r| r.key.as_bytes().to_vec()).collect();
     assert_eq!(
         keys,
         vec![b"k0".to_vec(), b"k1".to_vec(), b"k2".to_vec()],
@@ -356,7 +356,7 @@ fn reconcile_short_of_cap_returns_all_accepted() {
 
     let out = reconcile(authoritative, 100, &mut ctx);
 
-    let keys: Vec<Vec<u8>> = out.iter().map(|r| r.key.0.clone()).collect();
+    let keys: Vec<Vec<u8>> = out.iter().map(|r| r.key.as_bytes().to_vec()).collect();
     assert_eq!(keys, vec![b"k0".to_vec(), b"k1".to_vec()]);
     assert_eq!(
         ctx.scan_rows, decoded,
@@ -417,7 +417,7 @@ fn materialized_charges_full_decoded_count_not_the_cap() {
 
     // Results + per-row build work stay CAPPED (the fix must not change output
     // or LIMIT/OFFSET semantics).
-    let keys: Vec<Vec<u8>> = out.iter().map(|r| r.key.0.clone()).collect();
+    let keys: Vec<Vec<u8>> = out.iter().map(|r| r.key.as_bytes().to_vec()).collect();
     assert_eq!(
         keys,
         vec![b"k0".to_vec(), b"k1".to_vec(), b"k2".to_vec()],

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -1477,7 +1477,7 @@ mod tests {
             row_with_key(b),
         ];
         let out = SelectExecutor::execute_per_partition_limit(rows, 2);
-        let count = |p: &[u8]| out.iter().filter(|r| r.key.0 == p).count();
+        let count = |p: &[u8]| out.iter().filter(|r| r.key.as_bytes() == p).count();
         assert_eq!(
             count(a),
             2,
@@ -1593,8 +1593,8 @@ mod tests {
 
         // Key PRESERVED (the core regression): not the empty `vec![]`.
         assert_eq!(
-            r.key.0,
-            vec![7, 8, 9],
+            r.key.as_bytes(),
+            [7, 8, 9],
             "trim must preserve the real RowKey, not destroy it to vec![]"
         );
         // Row metadata preserved.
@@ -1650,7 +1650,7 @@ mod tests {
         let out = executor.trim_projection(vec![build_row()], &columns);
         assert_eq!(out.len(), 1);
         let r = &out[0];
-        assert_eq!(r.key.0, vec![1], "sparse row keeps its real key");
+        assert_eq!(r.key.as_bytes(), [1], "sparse row keeps its real key");
         assert_eq!(r.values.get("a"), Some(&Value::Integer(10)));
         assert!(
             !r.values.contains_key("b"),
@@ -1784,7 +1784,7 @@ mod tests {
             let mut out = Vec::with_capacity(rows.len());
             let mut counts: HashMap<Vec<u8>, u64> = HashMap::new();
             for row in rows {
-                let seen = counts.entry(row.key.0.clone()).or_insert(0);
+                let seen = counts.entry(row.key.as_bytes().to_vec()).or_insert(0);
                 if *seen < count {
                     *seen += 1;
                     out.push(row);
@@ -1972,7 +1972,8 @@ mod tests {
             access_path: None,
             reverse_served: false,
         };
-        let tags = |rows: &[QueryRow]| -> Vec<u8> { rows.iter().map(|r| r.key.0[0]).collect() };
+        let tags =
+            |rows: &[QueryRow]| -> Vec<u8> { rows.iter().map(|r| r.key.as_bytes()[0]).collect() };
 
         // --- Part A: NaN present → decorate-sort is order-identical to reference.
         // Tags 2 (-0.0) and 4 (+0.0) compare Equal; NaN appears twice (tags 1, 6).

--- a/cqlite-core/src/query/select_executor/streaming.rs
+++ b/cqlite-core/src/query/select_executor/streaming.rs
@@ -123,11 +123,11 @@ impl SelectExecutor {
                                 let same = matches!(
                                     &current_partition,
                                     Some((d, bytes))
-                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                                        if *d == sig && bytes.as_slice() == row.key.as_bytes()
                                 );
                                 if !same {
                                     // Clone the key bytes ONCE per boundary, not per row.
-                                    current_partition = Some((sig, row.key.0.clone()));
+                                    current_partition = Some((sig, row.key.as_bytes().to_vec()));
                                     partition_count = 0;
                                 }
                                 if partition_count >= cap {
@@ -192,11 +192,11 @@ impl SelectExecutor {
                                 let same = matches!(
                                     &current_partition,
                                     Some((d, bytes))
-                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                                        if *d == sig && bytes.as_slice() == row.key.as_bytes()
                                 );
                                 if !same {
                                     // Clone the key bytes ONCE per boundary, not per row.
-                                    current_partition = Some((sig, row.key.0.clone()));
+                                    current_partition = Some((sig, row.key.as_bytes().to_vec()));
                                     partition_count = 0;
                                 }
                                 if partition_count >= cap {
@@ -265,11 +265,11 @@ impl SelectExecutor {
                                 let same = matches!(
                                     &current_partition,
                                     Some((d, bytes))
-                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                                        if *d == sig && bytes.as_slice() == row.key.as_bytes()
                                 );
                                 if !same {
                                     // Clone the key bytes ONCE per boundary, not per row.
-                                    current_partition = Some((sig, row.key.0.clone()));
+                                    current_partition = Some((sig, row.key.as_bytes().to_vec()));
                                     partition_count = 0;
                                 }
                                 if partition_count >= cap {

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -131,7 +131,7 @@ pub(super) async fn merge_generations_for_read(
         let mut merger = KWayMerger::new(paths, &schema)?;
         let mut out = Vec::new();
         while let MergeStep::Partition { key, rows } = merger.step()? {
-            let row_key = RowKey(key.key.clone());
+            let row_key = RowKey::new(key.key.clone());
 
             // Partition-targeted point read (#1579): keep ONLY the target and stop.
             if let Some(ref target) = target_key {
@@ -221,7 +221,7 @@ pub(super) async fn merge_generations_for_read_with_metadata(
         for (row_key, _value, meta) in per_reader {
             for (column, cell_meta) in meta {
                 ttl_lookup
-                    .entry((row_key.0.clone(), column))
+                    .entry((row_key.as_bytes().to_vec(), column))
                     .and_modify(|existing| {
                         if cell_meta.write_timestamp_micros > existing.write_timestamp_micros {
                             *existing = cell_meta.clone();
@@ -242,7 +242,7 @@ pub(super) async fn merge_generations_for_read_with_metadata(
         let mut merger = KWayMerger::new(paths, &merge_schema)?;
         let mut out = Vec::new();
         while let MergeStep::Partition { key, rows } = merger.step()? {
-            let row_key = RowKey(key.key.clone());
+            let row_key = RowKey::new(key.key.clone());
 
             // Partition-targeted point read (#1579): keep ONLY the target and stop.
             if let Some(ref target) = target_for_merge {
@@ -291,7 +291,7 @@ pub(super) async fn merge_generations_for_read_with_metadata(
                 },
             );
         }
-        results.push((RowKey(key_bytes), value, meta_map));
+        results.push((RowKey::new(key_bytes), value, meta_map));
     }
 
     // Stable TOKEN-order sort (issue #1580), then LIMIT — identical ordering to the
@@ -405,7 +405,7 @@ pub(super) async fn stream_generations_for_read(
                 MergeStep::Complete => return,
             };
 
-            let row_key = RowKey(key.key.clone());
+            let row_key = RowKey::new(key.key.clone());
             if let Some(ref start) = start_key {
                 if &row_key < start {
                     continue;

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -2773,7 +2773,7 @@ mod tests {
         assert!(pending < BATCH_EMIT_ROWS);
         let (in_tx, in_rx) = tokio::sync::mpsc::channel::<Result<(RowKey, ScanRow)>>(16);
         for i in 0..pending {
-            let key = RowKey(vec![i as u8]);
+            let key = RowKey::new(vec![i as u8]);
             let row = ScanRow::RawRow(vec![i as u8]);
             in_tx.send(Ok((key, row))).await.unwrap();
         }
@@ -2801,7 +2801,7 @@ mod tests {
             "batch must respect the BATCH_EMIT_ROWS bound"
         );
         for (i, (key, _row)) in batch.iter().enumerate() {
-            assert_eq!(key.0, vec![i as u8], "rows must arrive in order");
+            assert_eq!(key.as_bytes(), [i as u8], "rows must arrive in order");
         }
 
         // Second item: the terminal error, AFTER the confirmed rows.

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit.rs
@@ -93,7 +93,7 @@ impl V5CompressedLegacyParser {
                     Err(_) => break,
                 };
 
-            let table_id = TableId(format!("{}.{}", self.keyspace, self.table_name));
+            let table_id = TableId::new(format!("{}.{}", self.keyspace, self.table_name));
             offset = next_data_offset;
             partition_index += 1;
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit_windowed.rs
@@ -922,7 +922,7 @@ impl<'a> TimestampPolicy<'a> {
         Self {
             parser,
             table_id: TableId::new(format!("{}.{}", parser.keyspace, parser.table_name)),
-            partition_key: RowKey(Vec::new()),
+            partition_key: RowKey::new(Vec::new()),
             shadow: None,
             static_cells: Vec::new(),
         }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/compaction.rs
@@ -375,7 +375,7 @@ impl<'a> CompactionPolicy<'a> {
     fn new(parser: &'a V5CompressedLegacyParser) -> Self {
         Self {
             parser,
-            partition_key: RowKey(Vec::new()),
+            partition_key: RowKey::new(Vec::new()),
             pending_range_start: None,
         }
     }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
@@ -733,7 +733,7 @@ impl V5CompressedLegacyParser {
         // The single legitimate key allocation: once per real header parse.
         let key_bytes = data[layout.key_range].to_vec();
         Ok((
-            RowKey(key_bytes),
+            RowKey::new(key_bytes),
             layout.next_offset,
             layout.partition_deletion,
         ))
@@ -1531,7 +1531,7 @@ mod tests {
 
         // Verify UUID bytes match
         let expected_uuid_bytes = hex::decode("15291a77d7394e738397b787442f3a1f").unwrap();
-        assert_eq!(row_key.0, expected_uuid_bytes);
+        assert_eq!(row_key.as_bytes(), expected_uuid_bytes.as_slice());
     }
 
     /// Issue #1006 (manifest: cass.data_db_decode.row_preamble_size_mismatch).
@@ -1854,7 +1854,7 @@ mod tests {
 
         // Verify correct partition key bytes
         let expected_uuid_bytes = hex::decode("245dff69026f45c6b68fba0c964df3c9").unwrap();
-        assert_eq!(row_key.0, expected_uuid_bytes);
+        assert_eq!(row_key.as_bytes(), expected_uuid_bytes.as_slice());
 
         // Verify offset: flags(1) + len(1) + uuid(16) + del_time(4) + unknown(8) = 30
         assert_eq!(offset, 30);

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -549,7 +549,7 @@ impl SSTableRowIteratorAdapter {
             row_timestamp,
             row_data,
         } = compaction_row;
-        let decorated_key = DecoratedKey::from_key_bytes(key.0)?;
+        let decorated_key = DecoratedKey::from_key_bytes(key.as_bytes().to_vec())?;
 
         // Issue #1072: a partition-level tombstone surfaces as a self-contained
         // carrier `MergeEntry` (empty live row + `partition_deletion`, no
@@ -9762,7 +9762,7 @@ mod issue_912_row_tombstone_clustering_identity {
     #[test]
     fn two_row_tombstones_do_not_collapse_in_merge() {
         let schema = clustered_schema();
-        let pk = RowKey(vec![0, 0, 0, 7]);
+        let pk = RowKey::new(vec![0, 0, 0, 7]);
 
         let e5 = SSTableRowIteratorAdapter::build_merge_entry(
             0,

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -1373,21 +1373,30 @@ impl fmt::Display for DataType {
     }
 }
 
-/// Row key type - used for indexing and sorting
+/// Row key type - used for indexing and sorting.
+///
+/// Issue #1643 (K4): the raw key bytes are stored behind an `Arc<[u8]>` so that
+/// the partition key, materialized ONCE when a partition header is parsed, can be
+/// shared across every row of that partition by a pointer bump instead of a
+/// per-row heap allocation. A 10k-row partition now allocates its key once, not
+/// 10k times. This is a pure ownership/allocation change: the bytes and the
+/// derived comparison order (`Ord`/`Eq`/`Hash` all delegate to the pointed-to
+/// `[u8]`) are byte-identical to the former `Vec<u8>` representation, and serde's
+/// `rc` feature keeps the wire format unchanged (a byte sequence).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct RowKey(pub Vec<u8>);
+pub struct RowKey(pub std::sync::Arc<[u8]>);
 
 impl RowKey {
     /// Create a new row key from bytes
     pub fn new(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+        Self(std::sync::Arc::from(bytes))
     }
 
     /// Create a row key from a value
     pub fn from_value(value: &Value) -> crate::Result<Self> {
         let bytes =
             bincode::serialize(value).map_err(|e| crate::Error::serialization(e.to_string()))?;
-        Ok(Self(bytes))
+        Ok(Self(std::sync::Arc::from(bytes)))
     }
 
     /// Get the byte representation
@@ -1404,40 +1413,62 @@ impl RowKey {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    /// Issue #1643: pointer to the shared key buffer. Two `RowKey`s cloned from
+    /// the same partition-key `Arc` return the SAME pointer, so a test can prove
+    /// rows of a partition share one allocation rather than re-materializing the
+    /// key per row. Not part of the value contract — for allocation assertions.
+    #[doc(hidden)]
+    pub fn buffer_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
+
+    /// Issue #1643: strong-count of the shared key buffer — proves that N rows of
+    /// a partition hold N pointer-clones of ONE `Arc`, not N distinct buffers.
+    #[doc(hidden)]
+    pub fn buffer_strong_count(&self) -> usize {
+        std::sync::Arc::strong_count(&self.0)
+    }
 }
 
 impl From<Vec<u8>> for RowKey {
     fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+        Self(std::sync::Arc::from(bytes))
     }
 }
 
 impl From<&[u8]> for RowKey {
     fn from(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
+        Self(std::sync::Arc::from(bytes))
     }
 }
 
 impl From<String> for RowKey {
     fn from(s: String) -> Self {
-        Self(s.into_bytes())
+        Self(std::sync::Arc::from(s.into_bytes()))
     }
 }
 
 impl From<&str> for RowKey {
     fn from(s: &str) -> Self {
-        Self(s.as_bytes().to_vec())
+        Self(std::sync::Arc::from(s.as_bytes()))
     }
 }
 
-/// Table identifier
+/// Table identifier.
+///
+/// Issue #1643 (K4): the `keyspace.table` name is stored behind an `Arc<str>` so
+/// the identity built once per partition header is shared across every emitted
+/// row by a pointer bump, not a per-row `String` clone / `format!`. Pure
+/// ownership change: `Display`, comparison order and serde wire format are
+/// byte-identical to the former `String` representation.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct TableId(pub String);
+pub struct TableId(pub std::sync::Arc<str>);
 
 impl TableId {
     /// Create a new table ID
     pub fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
+        Self(std::sync::Arc::from(name.into()))
     }
 
     /// Get the table name
@@ -1454,13 +1485,13 @@ impl fmt::Display for TableId {
 
 impl From<String> for TableId {
     fn from(name: String) -> Self {
-        Self(name)
+        Self(std::sync::Arc::from(name))
     }
 }
 
 impl From<&str> for TableId {
     fn from(name: &str) -> Self {
-        Self(name.to_string())
+        Self(std::sync::Arc::from(name))
     }
 }
 

--- a/cqlite-core/tests/compact_command.rs
+++ b/cqlite-core/tests/compact_command.rs
@@ -234,8 +234,10 @@ fn compact_sstables_merges_explicit_inputs_with_lww() {
     );
 
     // ids 6..=10 overlap; SSTable B (ts=200) wins over A (ts=100).
-    let by_pk: HashMap<Vec<u8>, cqlite_core::ScanRow> =
-        results.into_iter().map(|(k, v)| (k.0, v)).collect();
+    let by_pk: HashMap<Vec<u8>, cqlite_core::ScanRow> = results
+        .into_iter()
+        .map(|(k, v)| (k.as_bytes().to_vec(), v))
+        .collect();
     for id in 6_i32..=10 {
         let key: Vec<u8> = id.to_be_bytes().into();
         let row = by_pk

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -555,8 +555,10 @@ fn compaction_3_sstables_read_back_correctness() {
     );
 
     // Build a map of raw PK bytes → Value for per-PK assertions.
-    let result_map: HashMap<Vec<u8>, ScanRow> =
-        results.into_iter().map(|(k, v)| (k.0, v)).collect();
+    let result_map: HashMap<Vec<u8>, ScanRow> = results
+        .into_iter()
+        .map(|(k, v)| (k.as_bytes().to_vec(), v))
+        .collect();
 
     // Issue #505: PK 1..=5 must be ABSENT — row-deleted by SSTable C at ts=300.
     for id in 1_i32..=5 {
@@ -692,8 +694,10 @@ fn compaction_3_sstables_tombstone_shadowing() {
         .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
         .expect("post-compaction scan must not error");
 
-    let result_map: HashMap<Vec<u8>, ScanRow> =
-        results.into_iter().map(|(k, v)| (k.0, v)).collect();
+    let result_map: HashMap<Vec<u8>, ScanRow> = results
+        .into_iter()
+        .map(|(k, v)| (k.as_bytes().to_vec(), v))
+        .collect();
 
     // PK 1..=5 must be absent (row-deleted by C at ts=300).
     for id in 1_i32..=5 {
@@ -855,8 +859,10 @@ fn row_tombstone_shadows_live_row_after_compaction() {
         row_count
     );
 
-    let result_map: HashMap<Vec<u8>, ScanRow> =
-        results.into_iter().map(|(k, v)| (k.0, v)).collect();
+    let result_map: HashMap<Vec<u8>, ScanRow> = results
+        .into_iter()
+        .map(|(k, v)| (k.as_bytes().to_vec(), v))
+        .collect();
 
     // PK=1 must be ABSENT: the row tombstone at ts=300 shadows the live row at ts=100.
     let key_1: Vec<u8> = 1_i32.to_be_bytes().into();
@@ -1021,8 +1027,10 @@ fn row_deletion_coexists_with_newer_cell_after_compaction() {
         .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
         .expect("post-compaction scan");
 
-    let result_map: HashMap<Vec<u8>, ScanRow> =
-        results.into_iter().map(|(k, v)| (k.0, v)).collect();
+    let result_map: HashMap<Vec<u8>, ScanRow> = results
+        .into_iter()
+        .map(|(k, v)| (k.as_bytes().to_vec(), v))
+        .collect();
 
     let key_7: Vec<u8> = 7_i32.to_be_bytes().into();
     let pk7 = result_map.get(&key_7).unwrap_or_else(|| {
@@ -1178,8 +1186,10 @@ fn test_real_merger_delete_wins_at_equal_timestamp() {
         .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
         .expect("post-compaction scan");
 
-    let result_map: HashMap<Vec<u8>, ScanRow> =
-        results.into_iter().map(|(k, v)| (k.0, v)).collect();
+    let result_map: HashMap<Vec<u8>, ScanRow> = results
+        .into_iter()
+        .map(|(k, v)| (k.as_bytes().to_vec(), v))
+        .collect();
 
     // PK=1 must be ABSENT: equal-timestamp tombstone wins (Cassandra reconcile).
     let key_1: Vec<u8> = 1_i32.to_be_bytes().into();
@@ -1310,8 +1320,10 @@ fn disjoint_columns_survive_compaction() {
         .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
         .expect("post-compaction scan");
 
-    let result_map: HashMap<Vec<u8>, ScanRow> =
-        results.into_iter().map(|(k, v)| (k.0, v)).collect();
+    let result_map: HashMap<Vec<u8>, ScanRow> = results
+        .into_iter()
+        .map(|(k, v)| (k.as_bytes().to_vec(), v))
+        .collect();
 
     // Helper: extract a named text/int column from a row's Value::Map.
     fn find_col<'a>(row: &'a ScanRow, col: &str) -> Option<&'a Value> {

--- a/cqlite-core/tests/issue_1394_wal_double_replay_idempotence.rs
+++ b/cqlite-core/tests/issue_1394_wal_double_replay_idempotence.rs
@@ -262,7 +262,7 @@ fn scan_reconciled(
                     .into_iter()
                     .map(|(name, v)| (Value::Text(name.to_string()), v))
                     .collect();
-                (k.0, Value::Map(map))
+                (k.as_bytes().to_vec(), Value::Map(map))
             })
         })
         .collect();

--- a/cqlite-core/tests/issue_1535_writetime_ttl_tombstones.rs
+++ b/cqlite-core/tests/issue_1535_writetime_ttl_tombstones.rs
@@ -150,8 +150,10 @@ fn live_cell_writetime_and_ttl_resolve_under_tombstones() {
 
     assert_eq!(results.len(), 2, "expected the two live rows written");
 
-    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
-        results.into_iter().map(|(k, _v, m)| (k.0, m)).collect();
+    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> = results
+        .into_iter()
+        .map(|(k, _v, m)| (k.as_bytes().to_vec(), m))
+        .collect();
 
     for id in [1_i32, 2] {
         let meta = by_pk

--- a/cqlite-core/tests/issue_1643_arc_row_identity.rs
+++ b/cqlite-core/tests/issue_1643_arc_row_identity.rs
@@ -1,0 +1,177 @@
+//! Issue #1643 (K4): stop cloning the partition key + `TableId` per row.
+//!
+//! Before this change the partition identity was re-materialised per ROW — the
+//! `RowKey` (`Vec<u8>`) and the `TableId` (`String`) were deep-cloned at ~13
+//! per-row emit sites, so a 10k-row partition allocated its key 10k times.
+//!
+//! The fix makes `RowKey` an `Arc<[u8]>` and `TableId` an `Arc<str>`: the
+//! identity is materialised ONCE when the partition header is parsed, and every
+//! row of that partition holds a pointer-clone (an `Arc` strong-count bump, no
+//! byte allocation). This is a pure ownership/allocation change — the key bytes,
+//! the emitted values, and the comparison order are byte-identical to before.
+//!
+//! This test proves BOTH halves against a real multi-row-partition SSTable
+//! (`test_timeseries/sensor_data`, 2000 rows across 10 partitions, up to 220
+//! rows in one partition):
+//!
+//! 1. **Parity** — the rows read back are non-empty and every partition key is a
+//!    valid 16-byte UUID (the on-disk bytes), so the read path is exercised for
+//!    real, not vacuously.
+//! 2. **Allocation reduction** — for every partition with N>1 rows, all N
+//!    `RowKey`s share ONE backing buffer: identical `buffer_ptr()` AND the shared
+//!    `Arc` strong-count is >= N. Pre-change (a per-row `Vec<u8>` clone) each row
+//!    owned a DISTINCT buffer, so the pointers would differ and a strong-count
+//!    concept would not exist. Likewise all `TableId`s share one `Arc<str>`.
+
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::{Config, Platform};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn sensor_data_path() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let path = PathBuf::from(root).join(
+        "sstables/test_timeseries/sensor_data-6c698230a25111f0a3fef1a551383fb9/nb-1-big-Data.db",
+    );
+    path.exists().then_some(path)
+}
+
+#[tokio::test]
+async fn partition_key_and_table_id_shared_per_partition_not_cloned_per_row() {
+    let Some(path) = sensor_data_path() else {
+        // Local-only fixture (gitignored Data.db). Skip on ABSENCE only; when
+        // present a 0-row result below is a hard failure (never vacuous).
+        eprintln!("sensor_data Data.db absent; set CQLITE_DATASETS_ROOT — skipping");
+        return;
+    };
+
+    let config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&config)
+            .await
+            .expect("platform init must succeed"),
+    );
+    let reader = SSTableReader::open(&path, &config, platform)
+        .await
+        .expect("open sensor_data SSTable");
+
+    let entries = reader
+        .get_all_entries()
+        .await
+        .expect("get_all_entries must succeed");
+
+    // -- Non-vacuous: the fixture has 2000 rows across 10 partitions. --
+    assert!(
+        entries.len() >= 1000,
+        "expected the multi-row sensor_data fixture (~2000 rows), got {} — \
+         the read path was not exercised",
+        entries.len()
+    );
+
+    // Group rows by their partition-key bytes, keeping ONE representative RowKey
+    // per group plus the count. Two RowKeys are the "same partition" iff bytes
+    // are equal.
+    let mut by_partition: HashMap<Vec<u8>, (cqlite_core::RowKey, usize)> = HashMap::new();
+    let mut table_ids: Vec<cqlite_core::TableId> = Vec::new();
+    for (tid, key, _row) in &entries {
+        // Parity: every partition key is a 16-byte UUID (the raw on-disk bytes).
+        assert_eq!(
+            key.len(),
+            16,
+            "sensor_data partition key must be a 16-byte UUID; got {} bytes",
+            key.len()
+        );
+        let e = by_partition
+            .entry(key.as_bytes().to_vec())
+            .or_insert_with(|| (key.clone(), 0));
+        e.1 += 1;
+        table_ids.push(tid.clone());
+    }
+
+    // The fixture partitions the 2000 rows across ~10 UUID partitions, several
+    // with hundreds of rows. Require at least one genuinely multi-row partition,
+    // else the sharing assertion below would be vacuous.
+    let multi_row_partitions = by_partition.values().filter(|(_, n)| *n > 1).count();
+    assert!(
+        multi_row_partitions >= 1,
+        "expected >=1 multi-row partition to prove per-partition key sharing; \
+         found none across {} partitions",
+        by_partition.len()
+    );
+
+    // -- Allocation reduction, per partition. --
+    //
+    // Every row of a partition was emitted by pointer-cloning the ONE partition
+    // key `Arc` created when the header was parsed. So a second `RowKey` cloned
+    // from the same partition must point at the SAME buffer AND the shared
+    // strong-count must be >= that partition's row count. We prove the pointer
+    // identity by re-cloning a row's key and comparing buffer pointers to the
+    // representative we stored: `Arc::clone` never copies the bytes.
+    let mut checked_multi = 0usize;
+    for (_tid, key, _row) in &entries {
+        let (rep_key, count) = by_partition
+            .get(key.as_bytes())
+            .expect("every row's partition is grouped");
+        if *count <= 1 {
+            continue;
+        }
+        // Same partition => same backing buffer pointer (pointer-share, not a
+        // per-row byte copy). A pre-#1643 `Vec<u8>` clone would give each row a
+        // DISTINCT allocation and thus a different pointer here.
+        assert_eq!(
+            key.buffer_ptr(),
+            rep_key.buffer_ptr(),
+            "rows of the same partition must share ONE key buffer (pointer bump), \
+             not a per-row allocation"
+        );
+        checked_multi += 1;
+    }
+    assert!(
+        checked_multi > 1,
+        "expected to verify pointer-sharing across multiple rows of a partition, \
+         only checked {checked_multi}"
+    );
+
+    // The shared strong-count reflects that N rows hold N pointer-clones of ONE
+    // Arc (plus the representative + the outer entries Vec): it must exceed 1 for
+    // the largest multi-row partition — impossible under per-row deep clones.
+    let (biggest_bytes, (_, biggest_count)) = by_partition
+        .iter()
+        .max_by_key(|(_, (_, n))| *n)
+        .expect("at least one partition");
+    // Find any live RowKey of the biggest partition still owned by `entries`.
+    let live_key = entries
+        .iter()
+        .find(|(_, k, _)| k.as_bytes() == biggest_bytes.as_slice())
+        .map(|(_, k, _)| k)
+        .expect("biggest partition has a live row");
+    assert!(
+        live_key.buffer_strong_count() >= *biggest_count,
+        "the biggest partition has {biggest_count} rows; its shared key Arc \
+         strong-count is {}, which must be >= the row count (one Arc, N clones)",
+        live_key.buffer_strong_count()
+    );
+
+    // -- TableId identity is likewise shared (one Arc<str> per parse). --
+    assert!(!table_ids.is_empty(), "table ids collected");
+    let first_ptr = table_ids[0].name().as_ptr();
+    let shared_table_id = table_ids
+        .iter()
+        .filter(|t| t.name().as_ptr() == first_ptr)
+        .count();
+    assert!(
+        shared_table_id > 1,
+        "the TableId must be shared across rows (Arc<str> pointer bump); only {} \
+         of {} rows shared the same buffer",
+        shared_table_id,
+        table_ids.len()
+    );
+
+    // Parity: the shared table id names the fixture's keyspace.table.
+    assert!(
+        table_ids[0].name().ends_with("sensor_data"),
+        "table id should name the sensor_data table; got {}",
+        table_ids[0].name()
+    );
+}

--- a/cqlite-core/tests/issue_1743_row_ttl_expiring_cell.rs
+++ b/cqlite-core/tests/issue_1743_row_ttl_expiring_cell.rs
@@ -149,8 +149,10 @@ fn row_ttl_insert_round_trips_as_expiring_cell() {
 
     assert_eq!(results.len(), 1, "expected the single row written");
 
-    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> =
-        results.into_iter().map(|(k, _v, m)| (k.0, m)).collect();
+    let by_pk: HashMap<Vec<u8>, HashMap<String, CellWriteMetadata>> = results
+        .into_iter()
+        .map(|(k, _v, m)| (k.as_bytes().to_vec(), m))
+        .collect();
 
     let meta = by_pk
         .get(1_i32.to_be_bytes().as_slice())

--- a/cqlite-core/tests/issue_587_compaction_async_bridge.rs
+++ b/cqlite-core/tests/issue_587_compaction_async_bridge.rs
@@ -246,7 +246,10 @@ async fn run_compaction_from_async_context() {
     );
 
     // Spot-check that every original partition key survived the merge.
-    let keys: std::collections::HashSet<Vec<u8>> = results.into_iter().map(|(k, _)| k.0).collect();
+    let keys: std::collections::HashSet<Vec<u8>> = results
+        .into_iter()
+        .map(|(k, _)| k.as_bytes().to_vec())
+        .collect();
     for id in 1..=(SSTABLE_COUNT * ROWS_PER_SSTABLE) {
         let key: Vec<u8> = id.to_be_bytes().into();
         assert!(

--- a/cqlite-core/tests/issue_824_column_subset_and_filter.rs
+++ b/cqlite-core/tests/issue_824_column_subset_and_filter.rs
@@ -503,7 +503,7 @@ async fn absent_filter_db_reads_without_crash() {
 
     let want_pk: Vec<u8> = 7_i32.to_be_bytes().into();
     assert!(
-        results.iter().any(|(k, _)| k.0 == want_pk),
+        results.iter().any(|(k, _)| k.as_bytes() == want_pk),
         "partition pk=7 must be returned by a scan even with Filter.db absent; \
          got {} row(s)",
         results.len()

--- a/cqlite-core/tests/issue_848_tombstone_beats_expiring_roundtrip.rs
+++ b/cqlite-core/tests/issue_848_tombstone_beats_expiring_roundtrip.rs
@@ -186,7 +186,7 @@ fn run_case(tombstone_first: bool) {
     let pk_bytes = id.to_be_bytes().to_vec();
     let row = results
         .iter()
-        .find(|(k, _)| k.0 == pk_bytes)
+        .find(|(k, _)| k.as_bytes() == pk_bytes.as_slice())
         .map(|(_, v)| v.clone())
         .expect("row must be present (kept live by the `name` cell)");
 

--- a/cqlite-core/tests/issue_883_cross_generation_read_merge.rs
+++ b/cqlite-core/tests/issue_883_cross_generation_read_merge.rs
@@ -210,7 +210,7 @@ fn select_star_merges_generations_with_lww_and_tombstone_suppression() {
     // generations) and resurrected PK2/score@PK4 from gen1.
     let by_pk: HashMap<Vec<u8>, ScanRow> = results
         .iter()
-        .map(|(k, v)| (k.0.clone(), v.clone()))
+        .map(|(k, v)| (k.as_bytes().to_vec(), v.clone()))
         .collect();
 
     assert_eq!(

--- a/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
+++ b/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
@@ -214,7 +214,7 @@ fn metadata_scan_merges_generations_with_lww_and_tombstone_suppression() {
     // ── Reconciled state: live rows are exactly {1, 3, 4, 5, 6} ───────────────
     let by_pk: HashMap<Vec<u8>, (ScanRow, HashMap<String, CellWriteMetadata>)> = results
         .iter()
-        .map(|(k, v, m)| (k.0.clone(), (v.clone(), m.clone())))
+        .map(|(k, v, m)| (k.as_bytes().to_vec(), (v.clone(), m.clone())))
         .collect();
 
     assert_eq!(

--- a/cqlite-core/tests/issue_947_reconcile_parity.rs
+++ b/cqlite-core/tests/issue_947_reconcile_parity.rs
@@ -310,7 +310,7 @@ fn read_back(
         .expect("scan");
     results
         .into_iter()
-        .map(|(k, v)| (k.0, format!("{v:?}")))
+        .map(|(k, v)| (k.as_bytes().to_vec(), format!("{v:?}")))
         .collect()
 }
 

--- a/cqlite-core/tests/issue_957_metadata_range_bound_parity.rs
+++ b/cqlite-core/tests/issue_957_metadata_range_bound_parity.rs
@@ -140,11 +140,12 @@ fn pk_bytes(id: i32) -> Vec<u8> {
 }
 
 fn row_key(id: i32) -> RowKey {
-    RowKey(pk_bytes(id))
+    RowKey::new(pk_bytes(id))
 }
 
 fn id_of(key: &RowKey) -> i32 {
-    i32::from_be_bytes(key.0.clone().try_into().expect("4-byte int pk"))
+    let bytes: [u8; 4] = key.as_bytes().try_into().expect("4-byte int pk");
+    i32::from_be_bytes(bytes)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/cqlite-core/tests/issue_957_streaming_range_bound_parity.rs
+++ b/cqlite-core/tests/issue_957_streaming_range_bound_parity.rs
@@ -137,7 +137,7 @@ fn pk_bytes(id: i32) -> Vec<u8> {
 }
 
 fn row_key(id: i32) -> RowKey {
-    RowKey(pk_bytes(id))
+    RowKey::new(pk_bytes(id))
 }
 
 /// Drain a `scan_stream` receiver into a sorted (by key bytes) Vec.
@@ -147,7 +147,7 @@ async fn drain_stream(
     let mut out = Vec::new();
     while let Some(item) = rx.recv().await {
         let (k, v) = item.expect("streamed row should be Ok");
-        out.push((k.0, v));
+        out.push((k.as_bytes().to_vec(), v));
     }
     out.sort_by(|a, b| a.0.cmp(&b.0));
     out
@@ -232,7 +232,7 @@ async fn bounded_multi_generation_scan_stream_enforces_range_like_scan() {
     let unbounded_keys: Vec<i32> = {
         let mut ids: Vec<i32> = unbounded_scan
             .iter()
-            .map(|(k, _)| i32::from_be_bytes(k.0.clone().try_into().expect("4-byte int pk")))
+            .map(|(k, _)| i32::from_be_bytes(k.as_bytes().try_into().expect("4-byte int pk")))
             .collect();
         ids.sort_unstable();
         ids
@@ -255,7 +255,7 @@ async fn bounded_multi_generation_scan_stream_enforces_range_like_scan() {
     let bounded_scan_ids: Vec<i32> = {
         let mut ids: Vec<i32> = bounded_scan
             .iter()
-            .map(|(k, _)| i32::from_be_bytes(k.0.clone().try_into().expect("4-byte int pk")))
+            .map(|(k, _)| i32::from_be_bytes(k.as_bytes().try_into().expect("4-byte int pk")))
             .collect();
         ids.sort_unstable();
         ids
@@ -291,8 +291,10 @@ async fn bounded_multi_generation_scan_stream_enforces_range_like_scan() {
     );
 
     // scan and scan_stream must agree value-for-value, not just on key set.
-    let scan_map: BTreeMap<Vec<u8>, cqlite_core::ScanRow> =
-        bounded_scan.into_iter().map(|(k, v)| (k.0, v)).collect();
+    let scan_map: BTreeMap<Vec<u8>, cqlite_core::ScanRow> = bounded_scan
+        .into_iter()
+        .map(|(k, v)| (k.as_bytes().to_vec(), v))
+        .collect();
     let stream_map: BTreeMap<Vec<u8>, cqlite_core::ScanRow> = bounded_stream.into_iter().collect();
     assert_eq!(
         scan_map, stream_map,

--- a/cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs
+++ b/cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs
@@ -881,7 +881,7 @@ async fn forward_row_counts_by_pk() -> BTreeMap<Vec<u8>, usize> {
 
     let mut by_pk: BTreeMap<Vec<u8>, usize> = BTreeMap::new();
     for (_tid, key, _value) in &entries {
-        *by_pk.entry(key.0.clone()).or_default() += 1;
+        *by_pk.entry(key.as_bytes().to_vec()).or_default() += 1;
     }
     by_pk
 }

--- a/cqlite-core/tests/test_issue_827_streaming_parity.rs
+++ b/cqlite-core/tests/test_issue_827_streaming_parity.rs
@@ -477,11 +477,15 @@ async fn test_streaming_parity_multi_row_partition_chunk_straddle() {
     // that is not also duplicated in the Vec read (catches re-emission directly).
     let mut seen: HashMap<(Vec<u8>, i64), usize> = HashMap::new();
     for e in &stream_entries {
-        *seen.entry((e.key.0.clone(), e.row_timestamp)).or_insert(0) += 1;
+        *seen
+            .entry((e.key.as_bytes().to_vec(), e.row_timestamp))
+            .or_insert(0) += 1;
     }
     let mut want: HashMap<(Vec<u8>, i64), usize> = HashMap::new();
     for e in &vec_entries {
-        *want.entry((e.key.0.clone(), e.row_timestamp)).or_insert(0) += 1;
+        *want
+            .entry((e.key.as_bytes().to_vec(), e.row_timestamp))
+            .or_insert(0) += 1;
     }
     assert_eq!(
         seen, want,
@@ -506,7 +510,7 @@ async fn test_streaming_break_stops_early() {
     let mut collected: Vec<Vec<u8>> = Vec::new();
     reader
         .stream_all_partitions_for_compaction(Some(&schema), |row| {
-            collected.push(row.key.0);
+            collected.push(row.key.as_bytes().to_vec());
             if collected.len() >= 5 {
                 Ok(std::ops::ControlFlow::Break(()))
             } else {

--- a/cqlite-flight/src/agg.rs
+++ b/cqlite-flight/src/agg.rs
@@ -444,7 +444,7 @@ impl GroupState {
 
         QueryRow {
             values,
-            key: RowKey(Vec::new()),
+            key: RowKey::new(Vec::new()),
             metadata: Default::default(),
             cell_metadata: None,
         }
@@ -715,7 +715,7 @@ mod tests {
         values.insert("v".into(), Value::BigInt(v));
         QueryRow {
             values,
-            key: RowKey(Vec::new()),
+            key: RowKey::new(Vec::new()),
             metadata: Default::default(),
             cell_metadata: None,
         }
@@ -770,7 +770,7 @@ mod tests {
         values.insert("d".into(), Value::Float(d));
         QueryRow {
             values,
-            key: RowKey(Vec::new()),
+            key: RowKey::new(Vec::new()),
             metadata: Default::default(),
             cell_metadata: None,
         }

--- a/cqlite-flight/src/filter.rs
+++ b/cqlite-flight/src/filter.rs
@@ -492,7 +492,7 @@ mod tests {
         values.insert(column.into(), value);
         QueryRow {
             values,
-            key: cqlite_core::RowKey(Vec::new()),
+            key: cqlite_core::RowKey::new(Vec::new()),
             metadata: Default::default(),
             cell_metadata: None,
         }
@@ -501,7 +501,7 @@ mod tests {
     fn empty_row() -> QueryRow {
         QueryRow {
             values: std::collections::HashMap::new(),
-            key: cqlite_core::RowKey(Vec::new()),
+            key: cqlite_core::RowKey::new(Vec::new()),
             metadata: Default::default(),
             cell_metadata: None,
         }

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -626,7 +626,7 @@ impl MergeProducer {
             .map(|c| (std::sync::Arc::from(c.column.as_str()), c.value))
             .collect();
 
-        let key = RowKey(partition_key.to_vec());
+        let key = RowKey::new(partition_key.to_vec());
         build_row_from_scan(key, ScanRow::Row(row_cells), &[], Some(&self.schema))
     }
 


### PR DESCRIPTION
Closes #1643 (K4 — stop cloning partition key + TableId per row).

## What
`RowKey` now wraps `Arc<[u8]>` and `TableId` wraps `Arc<str>` (`cqlite-core/src/types.rs`). Partition identity is built **once per partition header** and rows hold `Arc` pointer-bump clones instead of re-allocating the key/table-id per row. A 10k-row partition previously allocated its key 10k times; now once.

## Clone sites eliminated (13 per-row → Arc pointer bumps)
- `block_emit.rs` L217/218, L347/442/475/510/596 (delta-scan pk)
- `block_emit_windowed.rs` L499/500, L1051/1052
- `compaction.rs` L439/490/508/571
Single legitimate key allocation stays once-per-header at `v5_compressed_legacy/row_framing.rs:734`.

## Invariants preserved (no semantic change)
- **Ordering/equality/hash unchanged**: derived `Ord`/`Eq`/`Hash` on `Arc<[u8]>`/`Arc<str>` delegate to the pointed-to bytes (value compare, NOT pointer identity). No manual impls anywhere.
- **Serde wire format identical**: serde `rc` feature enabled workspace-wide (`Cargo.toml:74`); `Arc<[u8]>`/`Arc<str>` serialize the pointed-to value, byte-identical to `Vec<u8>`/`String`. Flight/delta-export unaffected.
- No key bytes or comparison semantics changed.

## Evidence
`cqlite-core/tests/issue_1643_arc_row_identity.rs::partition_key_and_table_id_shared_per_partition_not_cloned_per_row` on real `test_timeseries/sensor_data` (2000 rows / 10 partitions): every row of a partition shares ONE key buffer (`buffer_ptr()` identical), strong-count ≥ partition row count, `TableId` `Arc<str>` shared; plus 16-byte UUID key parity, ≥1000 rows. Non-vacuous (sabotage-verified across all 2000 rows).

## Review
- rust-reviewer: no blockers (verified Ord/Eq/Hash value-compare + serde rc wire-format identity + Arc-sharing wiring + no sibling `.0` mutation).
- roborev (job 3681): 2 Mediums, both the intended public-API surface change (Arc field types) — all consumers migrated; refuted as breakage by static review + clean workspace clippy.
- `env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets`: **clean** (the sibling-crate check the scoped lite clippy misses).

## Notes for the closer
- Full gate needs `CQLITE_ALLOW_FILE_GROWTH=1` (pre-existing over-threshold `types.rs`/`select_executor`/`compaction_integration` — #1116/#1135 split debt, out of scope).
- 2 cosmetic nits to batch into a follow-up issue at merge: stale `Vec<u8>` comment `cqlite-cli/src/data_parser.rs:371`.