### PR TITLE
docs: worker AMI dependency bake sheet (issue #2140)

### DIFF
--- a/docs/scratch/worker-ami-bake-sheet.html
+++ b/docs/scratch/worker-ami-bake-sheet.html
@@ -1,0 +1,304 @@
+<title>CQLite Worker AMI — Bake Sheet</title>
+<style>
+  :root {
+    --bg: #F0EFEA;
+    --surface: #FBFAF6;
+    --surface-2: #F5F3EC;
+    --ink: #23201A;
+    --ink-soft: #514B40;
+    --muted: #746D5F;
+    --hair: #DCD7CA;
+    --accent: #8A6218;          /* brass — "golden image" */
+    --accent-soft: #f0e6cf;
+    --bake: #2F7D4F;            /* baked into the image */
+    --bake-bg: #e3efe6;
+    --boot: #266A85;           /* injected / done at first boot */
+    --boot-bg: #dfeaef;
+    --need: #AF4529;           /* bakeable — need install source */
+    --need-bg: #f5e3dc;
+    --mono: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #15140E;
+      --surface: #1F1D15;
+      --surface-2: #262319;
+      --ink: #ECE7DB;
+      --ink-soft: #C7C0B0;
+      --muted: #948C7B;
+      --hair: #322E21;
+      --accent: #D9A54A;
+      --accent-soft: #3a3016;
+      --bake: #62B888;
+      --bake-bg: #16281d;
+      --boot: #59ABC6;
+      --boot-bg: #142831;
+      --need: #E28162;
+      --need-bg: #2e1912;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #F0EFEA; --surface: #FBFAF6; --surface-2: #F5F3EC; --ink: #23201A; --ink-soft: #514B40;
+    --muted: #746D5F; --hair: #DCD7CA; --accent: #8A6218; --accent-soft: #f0e6cf;
+    --bake: #2F7D4F; --bake-bg: #e3efe6; --boot: #266A85; --boot-bg: #dfeaef; --need: #AF4529; --need-bg: #f5e3dc;
+  }
+  :root[data-theme="dark"] {
+    --bg: #15140E; --surface: #1F1D15; --surface-2: #262319; --ink: #ECE7DB; --ink-soft: #C7C0B0;
+    --muted: #948C7B; --hair: #322E21; --accent: #D9A54A; --accent-soft: #3a3016;
+    --bake: #62B888; --bake-bg: #16281d; --boot: #59ABC6; --boot-bg: #142831; --need: #E28162; --need-bg: #2e1912;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: var(--sans); line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 880px; margin: 0 auto; padding: clamp(1.2rem, 4vw, 3rem) clamp(1rem, 4vw, 2rem) 4rem; }
+
+  .eyebrow {
+    font-family: var(--mono); font-size: .7rem; letter-spacing: .18em; text-transform: uppercase;
+    color: var(--accent); font-weight: 600;
+  }
+  h1 {
+    font-family: var(--mono); font-weight: 600; text-wrap: balance;
+    font-size: clamp(1.5rem, 4.5vw, 2.15rem); line-height: 1.12; margin: .5rem 0 .4rem;
+    letter-spacing: -.01em;
+  }
+  .lede { color: var(--ink-soft); max-width: 62ch; margin: 0 0 1.4rem; font-size: 1.02rem; }
+
+  /* summary strip */
+  .summary { display: flex; flex-wrap: wrap; gap: .6rem; margin: 1.4rem 0 .5rem; }
+  .stat {
+    flex: 1 1 120px; background: var(--surface); border: 1px solid var(--hair); border-radius: 8px;
+    padding: .7rem .85rem;
+  }
+  .stat b { font-family: var(--mono); font-size: 1.5rem; font-weight: 600; display: block; line-height: 1; font-variant-numeric: tabular-nums; }
+  .stat.bake b { color: var(--bake); } .stat.boot b { color: var(--boot); } .stat.need b { color: var(--need); }
+  .stat span { font-size: .74rem; color: var(--muted); text-transform: uppercase; letter-spacing: .06em; font-family: var(--mono); }
+
+  /* legend */
+  .legend { display: flex; flex-wrap: wrap; gap: 1.1rem 1.4rem; padding: .9rem 1rem; margin: 1rem 0 2.2rem;
+    background: var(--surface-2); border: 1px dashed var(--hair); border-radius: 8px; }
+  .legend div { font-size: .82rem; color: var(--ink-soft); display: flex; align-items: baseline; gap: .5rem; }
+
+  .chip {
+    font-family: var(--mono); font-size: .64rem; font-weight: 600; letter-spacing: .08em; text-transform: uppercase;
+    padding: .18em .5em; border-radius: 4px; white-space: nowrap; display: inline-block;
+  }
+  .chip.bake { color: var(--bake); background: var(--bake-bg); }
+  .chip.boot { color: var(--boot); background: var(--boot-bg); }
+  .chip.need { color: var(--need); background: var(--need-bg); }
+
+  section { margin: 0 0 2rem; }
+  .sec-head { display: flex; align-items: baseline; gap: .6rem; border-bottom: 2px solid var(--accent);
+    padding-bottom: .45rem; margin-bottom: .2rem; }
+  .sec-head h2 { font-family: var(--mono); font-size: .95rem; font-weight: 600; letter-spacing: .04em;
+    text-transform: uppercase; margin: 0; }
+  .sec-head .num { font-family: var(--mono); font-size: .8rem; color: var(--accent); font-weight: 600; }
+  .sec-head .k { margin-left: auto; font-size: .74rem; color: var(--muted); font-family: var(--mono); }
+
+  .row { display: grid; grid-template-columns: 108px 1fr; gap: .3rem 1rem; padding: .8rem .2rem;
+    border-bottom: 1px solid var(--hair); align-items: start; }
+  .row:last-child { border-bottom: 0; }
+  .row .st { padding-top: .1rem; }
+  .row .name { font-family: var(--mono); font-weight: 600; font-size: .92rem; color: var(--ink); }
+  .row .name .ver { color: var(--accent); font-weight: 600; }
+  .row .note { color: var(--ink-soft); font-size: .88rem; margin-top: .15rem; }
+  .row .src { font-family: var(--mono); font-size: .72rem; color: var(--muted); }
+  .row .src::before { content: "› "; }
+
+  .callout { background: var(--need-bg); border: 1px solid var(--need); border-radius: 10px; padding: 1.1rem 1.2rem; margin: 2.4rem 0; }
+  .callout h2 { font-family: var(--mono); font-size: .92rem; text-transform: uppercase; letter-spacing: .05em;
+    margin: 0 0 .3rem; color: var(--need); }
+  .callout p { margin: .3rem 0 .8rem; color: var(--ink-soft); font-size: .9rem; }
+  .callout ul { margin: 0; padding-left: 0; list-style: none; display: grid; gap: .5rem; }
+  .callout li { font-size: .9rem; display: grid; grid-template-columns: 130px 1fr; gap: .8rem; align-items: baseline; }
+  .callout li code { font-family: var(--mono); font-weight: 600; color: var(--ink); }
+  .callout li span { color: var(--ink-soft); }
+
+  .dropped { background: var(--bake-bg); border: 1px solid transparent; border-radius: 10px; padding: 1rem 1.2rem; margin: 1.6rem 0; }
+  .dropped h2 { font-family: var(--mono); font-size: .85rem; text-transform: uppercase; letter-spacing: .05em;
+    margin: 0 0 .5rem; color: var(--bake); }
+  .dropped ul { margin: 0; padding-left: 1.1rem; display: grid; gap: .35rem; }
+  .dropped li { font-size: .88rem; color: var(--ink-soft); }
+  .dropped code { font-family: var(--mono); font-size: .84em; color: var(--ink); }
+
+  footer { margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid var(--hair);
+    font-family: var(--mono); font-size: .74rem; color: var(--muted); display: flex; flex-wrap: wrap; gap: .4rem 1rem; }
+
+  code.inl { font-family: var(--mono); font-size: .85em; background: var(--surface-2); padding: .05em .35em; border-radius: 3px; }
+
+  @media (max-width: 560px) {
+    .row { grid-template-columns: 1fr; }
+    .callout li { grid-template-columns: 1fr; gap: .1rem; }
+  }
+</style>
+
+<div class="wrap">
+  <p class="eyebrow">Worker AMI · build manifest</p>
+  <h1>CQLite worker — dependency bake sheet</h1>
+  <p class="lede">Everything a golden AMI needs so a fresh EC2 worker boots ready to run the delivery loop:
+    implement → gate → review → merge → finalize. Derived from a repo scan of
+    <code class="inl">bootstrap-agent-machine.sh</code>, <code class="inl">agent-gate.sh</code>,
+    the binding manifests, and the flow-* skills — not from memory.</p>
+
+  <div class="summary">
+    <div class="stat bake"><b>17</b><span>bake into image</span></div>
+    <div class="stat boot"><b>4</b><span>at first boot</span></div>
+    <div class="stat need"><b>5</b><span>need source</span></div>
+  </div>
+
+  <div class="legend">
+    <div><span class="chip bake">Bake</span> baked into the golden image (stable, non-secret)</div>
+    <div><span class="chip boot">Boot</span> done at first SSH / boot — auth, clone, datasets</div>
+    <div><span class="chip need">Need src</span> bakeable, but I need the install command from you</div>
+  </div>
+
+  <!-- LAYER 1 -->
+  <section>
+    <div class="sec-head"><span class="num">01</span><h2>Base OS &amp; system</h2><span class="k">Ubuntu x86-64</span></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">ubuntu 22.04/24.04 <span class="ver">x86-64</span></div>
+        <div class="note">x86, not Graviton — matches the prebuilt coverage tooling policy.</div>
+        <div class="src">docs/development/ci-toolchain-policy.md</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">gcc / <span class="ver">cc</span> + build-essential</div>
+        <div class="note">C compiler for the bundled <code class="inl">zstd</code> crate (compiles C source).</div>
+        <div class="src">Cargo.toml — zstd = "0.13"</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">g++ + cmake + pkg-config</div>
+        <div class="note">C++ toolchain for the bundled DuckDB amalgamation — only pulled by the
+          <code class="inl">duckdb-tests</code> feature (clippy skips it). Include for full CLI E2E coverage.</div>
+        <div class="src">cqlite-cli/Cargo.toml — duckdb "bundled"</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">bash <span class="ver">≥ 4.3</span></div>
+        <div class="note">Parallel gate lanes need <code class="inl">wait -n</code>; older bash → serial (~slower). Ubuntu ships 5.x, so free.</div>
+        <div class="src">gate-ops.md</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">python3</div>
+        <div class="note">Gate concurrency-cap daemon (<code class="inl">gate_slot_daemon.py</code>) + <code class="inl">delivery-telemetry.py</code>. Also the binding interpreter (below).</div>
+        <div class="src">gate-ops.md · scripts/delivery-telemetry.py</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">git · curl · coreutils</div>
+        <div class="note">Claim/worktree protocol, dataset fetch, and script plumbing (find/wc/tr/grep/sed).</div></div></div>
+  </section>
+
+  <!-- LAYER 2 -->
+  <section>
+    <div class="sec-head"><span class="num">02</span><h2>Rust toolchain</h2><span class="k">pinned 1.88.0</span></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">rustup + rustc <span class="ver">1.88.0</span></div>
+        <div class="note">Pinned channel; components <code class="inl">clippy</code> + <code class="inl">rustfmt</code>; target <code class="inl">wasm32-unknown-unknown</code> (M6). The 1.85 in Cargo.toml is only the MSRV floor.</div>
+        <div class="src">rust-toolchain.toml</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">sccache</div>
+        <div class="note"><code class="inl">cargo install sccache</code>. Compile cache — absent ≈ 25% slower fresh builds. Prime it during the Packer build (run one gate) and bake the warm cache.</div>
+        <div class="src">bootstrap-agent-machine.sh</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">cargo-nextest</div>
+        <div class="note"><code class="inl">cargo install cargo-nextest</code>. Parallel core tests — absent → serial <code class="inl">cargo test</code>.</div>
+        <div class="src">bootstrap-agent-machine.sh</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">cargo-llvm-cov / tarpaulin</div>
+        <div class="note">Coverage tools — install as <em>prebuilt pinned binaries</em> via <code class="inl">taiki-e/install-action</code>, never from source. Not core-gate; needed for coverage lanes.</div>
+        <div class="src">ci-toolchain-policy.md</div></div></div>
+  </section>
+
+  <!-- LAYER 3 -->
+  <section>
+    <div class="sec-head"><span class="num">03</span><h2>Binding runtimes</h2><span class="k">gate lanes</span></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">Python <span class="ver">≥ 3.9</span> + pip</div>
+        <div class="note">Drives the <code class="inl">python-bindings</code> gate lane: <code class="inl">maturin ≥1.7,&lt;2</code> + <code class="inl">pytest</code> in a venv at <code class="inl">target/agent-gate-venv</code> (pyo3 0.23, abi3-py39). Skips <em>loudly</em> if python3 is absent — so bake it or that lane validates nothing.</div>
+        <div class="src">bindings/python/pyproject.toml</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">Node.js <span class="ver">≥ 18</span> + npm</div>
+        <div class="note">Drives the <code class="inl">node-bindings</code> lane: <code class="inl">@napi-rs/cli ^3.5.1</code> build + scoped jest. Full suite wants <code class="inl">node --expose-gc</code>. Skips loudly if node is absent.</div>
+        <div class="src">bindings/node/package.json</div></div></div>
+    <div class="row"><div class="st"><span class="chip boot">Optional</span></div>
+      <div><div class="name">JDK 25 + Gradle 9.1.0</div>
+        <div class="note"><strong>Not a gate component</strong> — the Trino/Flight connector builds only in nightly/release CI. Skip unless you'll do connector work on this box (then Gradle's toolchain auto-provisions the JDK; wrapper is committed).</div>
+        <div class="src">trino-connector/build.gradle.kts</div></div></div>
+  </section>
+
+  <!-- LAYER 4 -->
+  <section>
+    <div class="sec-head"><span class="num">04</span><h2>Delivery-pipeline CLIs</h2><span class="k">the agents &amp; gates</span></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span><br><span class="chip boot" style="margin-top:.25rem">Boot</span></div>
+      <div><div class="name">gh <span class="ver">(GitHub CLI)</span></div>
+        <div class="note">Board dispatch (Path A). Binary bakes; <strong>auth at first boot</strong> via device flow — must include the <code class="inl">project</code> scope (<code class="inl">gh auth refresh -s project</code>). Watch the EMU account-switch gotcha.</div>
+        <div class="src">bootstrap-agent-machine.sh · flow-board</div></div></div>
+    <div class="row"><div class="st"><span class="chip need">Need src</span></div>
+      <div><div class="name">claude <span class="ver">(Claude Code)</span></div>
+        <div class="note">The worker/lead runtime itself. Bootstrap never installs it. Auth at first boot (enterprise SSO paste-back or setup-token). Set <code class="inl">CLAUDE_CONFIG_DIR</code> to isolate the worker identity.</div>
+        <div class="src">worker-supervisor.sh</div></div></div>
+    <div class="row"><div class="st"><span class="chip need">Need src</span></div>
+      <div><div class="name">codex</div>
+        <div class="note">roborev's review engine — <code class="inl">.roborev.toml</code> pins <code class="inl">agent = 'codex'</code>. This is <em>why</em> Codex is on the box. Bootstrap never installs it.</div>
+        <div class="src">.roborev.toml</div></div></div>
+    <div class="row"><div class="st"><span class="chip need">Need src</span></div>
+      <div><div class="name">roborev</div>
+        <div class="note">Mandatory pre-merge review; must be clean to merge. Config ships in-repo. Bootstrap only <em>checks</em> it (<code class="inl">roborev check-agents --agent codex</code>) — "install per your setup."</div>
+        <div class="src">.roborev.toml · bootstrap-agent-machine.sh</div></div></div>
+    <div class="row"><div class="st"><span class="chip need">Need src</span></div>
+      <div><div class="name">openspec / opsx</div>
+        <div class="note">Artifact system for design-driven work: <code class="inl">openspec new change</code> / <code class="inl">validate --strict</code> / <code class="inl">archive</code>. Config in-repo. Bootstrap ignores it. (Note: flow-activate references an <code class="inl">opsx:propose</code> skill not present in <code class="inl">.claude/skills/</code> — worth reconciling.)</div>
+        <div class="src">openspec/config.yaml · flow-activate</div></div></div>
+    <div class="row"><div class="st"><span class="chip need">Need src</span></div>
+      <div><div class="name">agent-notify <span class="ver">(optional)</span></div>
+        <div class="note">ntfy push for the unattended supervisor (merge / hold / breaker). Degrades to a no-op if absent — nice-to-have, not blocking.</div>
+        <div class="src">worker-supervisor.sh</div></div></div>
+  </section>
+
+  <!-- LAYER 5 -->
+  <section>
+    <div class="sec-head"><span class="num">05</span><h2>Data, config &amp; secrets</h2><span class="k">at boot / clone</span></div>
+    <div class="row"><div class="st"><span class="chip boot">Boot</span></div>
+      <div><div class="name">repo clone</div>
+        <div class="note"><code class="inl">git clone</code> brings the config free: <code class="inl">.roborev.toml</code>, <code class="inl">openspec/</code>, and <code class="inl">.claude/</code> skills + agents. Stateless by design — nothing to bake.</div></div></div>
+    <div class="row"><div class="st"><span class="chip boot">Boot</span></div>
+      <div><div class="name">test datasets <span class="ver">(datasets-v3)</span></div>
+        <div class="note"><code class="inl">bash test-data/scripts/fetch-datasets.sh</code> — curl + SHA256, ~tens of MB (small, not a heavy dump). Full gate <strong>fails closed</strong> without it (#2078). <code class="inl">CQLITE_DATASETS_ROOT</code> must end in <code class="inl">datasets</code> and point at the <em>main</em> checkout.</div>
+        <div class="src">test-data/scripts/fetch-datasets.sh</div></div></div>
+    <div class="row"><div class="st"><span class="chip boot">Boot</span></div>
+      <div><div class="name">auth credentials</div>
+        <div class="note">gh + claude + codex logins, done interactively over SSH — <strong>never baked into the AMI</strong>. Persist on the box's volume for its lifetime.</div></div></div>
+    <div class="row"><div class="st"><span class="chip bake">Bake</span></div>
+      <div><div class="name">environment defaults</div>
+        <div class="note">Bake into shell profile: <code class="inl">RUSTFLAGS="-D warnings"</code>, <code class="inl">SCCACHE_DIR</code>/<code class="inl">SCCACHE_CACHE_SIZE=30G</code>, gate cap vars. Set <code class="inl">CQLITE_DATASETS_ROOT</code> + <code class="inl">CLAUDE_CONFIG_DIR</code> at boot.</div>
+        <div class="src">gate-ops.md</div></div></div>
+  </section>
+
+  <!-- NEED FROM YOU -->
+  <div class="callout">
+    <h2>⛏ Need from you — install sources</h2>
+    <p>Five tools sit behind bootstrap's "install per your setup." Give me the install command for each and the Packer provisioner is complete. gh, rustup, sccache and nextest already have known install paths.</p>
+    <ul>
+      <li><code>roborev</code><span>cargo install from a git/registry URL? prebuilt binary? private package?</span></li>
+      <li><code>openspec</code><span>npm global, cargo install, or a downloaded binary?</span></li>
+      <li><code>codex</code><span>OpenAI Codex CLI — npm <code>@openai/codex</code>, or your enterprise's channel?</span></li>
+      <li><code>claude</code><span>native installer or npm <code>@anthropic-ai/claude-code</code>?</span></li>
+      <li><code>agent-notify</code><span>your own ntfy wrapper script, or a package? (optional — can skip)</span></li>
+    </ul>
+  </div>
+
+  <!-- DROPPED -->
+  <div class="dropped">
+    <h2>✓ Confirmed NOT needed — leaner than expected</h2>
+    <ul>
+      <li><strong>No JDK / Gradle</strong> — the Java connector isn't a gate component (nightly/release CI only).</li>
+      <li><strong>No Docker</strong> for the worker loop — datasets arrive by <code>curl</code>; Docker is regeneration/nightly-parity only.</li>
+      <li><strong>No system compression libs</strong> — lz4/snappy/deflate are pure-Rust crates; no <code>liblz4-dev</code> etc.</li>
+      <li><strong>No <code>protoc</code></strong> — arrow-flight/tonic use pre-generated bindings; no build-time codegen.</li>
+      <li><strong>No EBS dataset snapshot</strong> needed — the corpus is small enough to just fetch at boot.</li>
+    </ul>
+  </div>
+
+  <footer>
+    <span>Source: repo scan · pmcfadin/cqlite</span>
+    <span>Rust 1.88.0 · Py ≥3.9 · Node ≥18</span>
+    <span>Compiled 2026-07-07</span>
+  </footer>
+</div>


### PR DESCRIPTION
Visual dependency inventory for a CQLite delivery-worker golden AMI:
what to bake into the image, what to inject at first boot, and the five
CLIs whose install source is still needed. Companion reference for the
flow-groom issue #2140 (golden AMI + first-boot provisioning).

Claude-Session: https://claude.ai/code/session_01GxqVCRfqxCUzSWXN4HCfWS