### PR TITLE
chore(#1658): M4 hygiene — prune pre-na statistics narrative + cold-open metadata bench + TOC-walk metric

### DIFF
--- a/cqlite-core/benches/open.rs
+++ b/cqlite-core/benches/open.rs
@@ -16,6 +16,11 @@
 //!   when the `test_da` corpus is absent.
 //! - `mem/open_n_readers` — opens `N` readers over the BIG fixture and records the
 //!   process RSS after, so G3 has a before/after per-reader memory gauge.
+//! - `open/metadata_parse_big` / `open/metadata_parse_bti` — the FULL Statistics.db
+//!   metadata parse cost per open (header + SerializationHeader + STATS post-passes;
+//!   issue #1658), plus the **repeated-TOC-walk count per open** via
+//!   `parser::toc_walk_metrics`. The BTI variant skip-registers when `test_da` is
+//!   absent.
 //!
 //! # Honesty (parity-is-truth)
 //!
@@ -74,6 +79,22 @@ fn data_db_path(fx: &fixtures::ReadFixture) -> Option<std::path::PathBuf> {
         .unwrap_or_else(|e| panic!("cannot read fixture dir {}: {e}", dir.display()))
         .filter_map(|e| e.ok())
         .find(|e| e.file_name().to_string_lossy().ends_with("-Data.db"));
+    entry.map(|e| e.path())
+}
+
+/// Locate the `*-Statistics.db` file inside a present fixture's table directory.
+/// Returns `None` when absent (caller skip-registers) and panics only on a
+/// genuinely broken directory it could not read.
+#[cfg(feature = "cli-helpers")]
+fn statistics_db_path(fx: &fixtures::ReadFixture) -> Option<std::path::PathBuf> {
+    if !fixtures::fixture_present(fx) {
+        return None;
+    }
+    let dir = fixtures::table_dir(fx.keyspace, fx.table);
+    let entry = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("cannot read fixture dir {}: {e}", dir.display()))
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_name().to_string_lossy().ends_with("-Statistics.db"));
     entry.map(|e| e.path())
 }
 
@@ -315,6 +336,129 @@ fn bench_mem_open_n_readers(c: &mut Criterion) {
     group.finish();
 }
 
+/// `open/metadata_parse` — the FULL Statistics.db metadata parse cost per open
+/// (issue #1658). This is the `Statistics.db` half of a cold open: parse the
+/// nb-format header, walk the TOC for the SerializationHeader offset, decode the
+/// EncodingStats + SerializationHeader columns, and run the best-effort STATS
+/// post-passes (`read_table_counts` + `parse_stats_extras`). It reads the whole
+/// `*-Statistics.db` file ONCE, then benches the pure in-memory parse so the
+/// number isolates parse cost from disk I/O.
+///
+/// It also records the **repeated-TOC-walk count per open** — how many times the
+/// Statistics.db TOC is walked during a single metadata parse — via the
+/// `parser::toc_walk_metrics` counter (reset before one parse, read after). This
+/// surfaces the `enhanced_statistics_parser/mod.rs:187`/`:345` redundancy (issue
+/// #1658 AC) as a measured integer rather than a guess.
+///
+/// Skip-registers (no group) when the fixture / Statistics.db is absent; panics
+/// at setup when a present Statistics.db fails to parse (present-but-broken).
+#[cfg(feature = "cli-helpers")]
+fn bench_metadata_parse(
+    c: &mut Criterion,
+    fx: fixtures::ReadFixture,
+    bench_name: &str,
+    ledger: &mut Vec<(String, f64, String)>,
+) {
+    let Some(path) = statistics_db_path(&fx) else {
+        eprintln!(
+            "open/{bench_name}: fixture {} Statistics.db not present — skipping (skip-register)",
+            fx.qualified()
+        );
+        return;
+    };
+    let buffer = std::fs::read(&path)
+        .unwrap_or_else(|e| panic!("cannot read Statistics.db {}: {e}", path.display()));
+    // Gates match the file's real on-disk version (nb / da) — the same derivation
+    // `StatisticsReader::open` uses; a below-floor/unparseable descriptor is a
+    // present-but-broken setup and panics rather than recording a bogus number.
+    let gates = cqlite_core::storage::sstable::version_gate::VersionGates::from_path(&path)
+        .unwrap_or_else(|e| {
+            panic!(
+                "open/{bench_name}: could not derive VersionGates from {} — {e}",
+                path.display()
+            )
+        });
+
+    // Setup guard: one parse must succeed (present-but-broken → panic). `is_ok()`
+    // is read inside each call so the borrowed-buffer result never escapes.
+    if !parse_statistics_ok(&buffer, &gates) {
+        panic!(
+            "open/{bench_name}: Statistics.db {} present but the metadata parse failed — \
+             a broken component would make this a misleading measurement",
+            path.display()
+        );
+    }
+
+    // Repeated-TOC-walk count for ONE metadata parse (issue #1658 AC). Reset the
+    // process-wide counter, do exactly one parse, then read it.
+    cqlite_core::parser::toc_walk_metrics::reset_toc_walk_count();
+    let _ = parse_statistics_ok(&buffer, &gates);
+    let toc_walks_per_open = cqlite_core::parser::toc_walk_metrics::toc_walk_count();
+    eprintln!(
+        "open/{bench_name}: TOC walks per metadata parse = {toc_walks_per_open} (issue #1658)"
+    );
+    ledger.push((
+        format!("{bench_name}_toc_walks_per_open"),
+        toc_walks_per_open as f64,
+        "count".to_string(),
+    ));
+
+    // Manual median of the metadata parse (appended to the ledger).
+    let mut samples = Vec::with_capacity(MEDIAN_SAMPLES);
+    for _ in 0..MEDIAN_SAMPLES {
+        let t0 = std::time::Instant::now();
+        let ok = parse_statistics_ok(&buffer, &gates);
+        samples.push(t0.elapsed().as_nanos());
+        std::hint::black_box(ok);
+    }
+    ledger.push((
+        format!("{bench_name}_median_ns"),
+        median_ns(samples),
+        "ns".to_string(),
+    ));
+
+    let mut group = c.benchmark_group("open");
+    group.bench_function(bench_name, |bch| {
+        bch.iter(|| std::hint::black_box(parse_statistics_ok(&buffer, &gates)));
+    });
+    group.finish();
+}
+
+/// Parse `buffer` as an nb-format Statistics.db with `gates` and return only
+/// whether it succeeded — the borrowed-buffer `Ok` result never escapes, so the
+/// caller can reuse `buffer` across iterations without a lifetime tangle.
+#[cfg(feature = "cli-helpers")]
+fn parse_statistics_ok(
+    buffer: &[u8],
+    gates: &cqlite_core::storage::sstable::version_gate::VersionGates,
+) -> bool {
+    cqlite_core::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
+        buffer,
+        Some(gates),
+    )
+    .is_ok()
+}
+
+/// `open/metadata_parse_big` over the always-present BIG (`nb`) fixture, plus
+/// `open/metadata_parse_bti` over the optional BTI (`da`) fixture.
+#[cfg(feature = "cli-helpers")]
+fn bench_metadata_parse_all(c: &mut Criterion) {
+    let mut ledger = Vec::new();
+    bench_metadata_parse(
+        c,
+        fixtures::ReadFixture::SIMPLE,
+        "metadata_parse_big",
+        &mut ledger,
+    );
+    bench_metadata_parse(
+        c,
+        fixtures::ReadFixture::SIMPLE_BTI,
+        "metadata_parse_bti",
+        &mut ledger,
+    );
+    append_ledger(&ledger);
+}
+
 /// Append `metrics` under the `open` bench id, best-effort (log, never fail).
 #[cfg(feature = "cli-helpers")]
 fn append_ledger(metrics: &[(String, f64, String)]) {
@@ -342,7 +486,7 @@ fn append_ledger(metrics: &[(String, f64, String)]) {
 criterion_group!(
     name = benches;
     config = profiling::configure();
-    targets = bench_cold_big, bench_cold_bti, bench_mem_open_n_readers
+    targets = bench_cold_big, bench_cold_bti, bench_mem_open_n_readers, bench_metadata_parse_all
 );
 
 #[cfg(not(feature = "cli-helpers"))]

--- a/cqlite-core/src/parser/enhanced_statistics_parser/header.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser/header.rs
@@ -87,6 +87,8 @@ pub fn parse_nb_format_header(input: &[u8]) -> IResult<&[u8], StatisticsHeader> 
 ///
 /// Returns the offset to the HEADER component (SerializationHeader), or None if not found.
 pub(super) fn parse_statistics_toc_for_header_offset(input: &[u8]) -> Option<usize> {
+    // Count this TOC walk (issue #1658 A5 bench instrumentation — no decode effect).
+    super::super::toc_walk_metrics::record_toc_walk();
     if input.len() < 8 {
         log::debug!("Statistics.db too small for TOC: {} bytes", input.len());
         return None;

--- a/cqlite-core/src/parser/mod.rs
+++ b/cqlite-core/src/parser/mod.rs
@@ -127,6 +127,7 @@ pub mod repair_metadata;
 pub mod statistics;
 #[cfg(test)]
 pub mod statistics_test;
+pub mod toc_walk_metrics;
 pub mod types;
 #[cfg(test)]
 pub mod udt_tests;

--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -199,6 +199,8 @@ struct StatsComponentBounds {
 ///     invalid (offset past EOF, inverted, or zero-length) — fail closed so a
 ///     corrupt `Statistics.db` is never silently reported as unrepaired.
 fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> {
+    // Count this TOC walk (issue #1658 A5 bench instrumentation — no decode effect).
+    crate::parser::toc_walk_metrics::record_toc_walk();
     // A malformed or truncated TOC must FAIL CLOSED rather than be silently
     // reported as "no STATS component" (which would misreport corrupt repair
     // metadata as the unrepaired default). `Ok(None)` is reserved exclusively

--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -268,11 +268,13 @@ pub struct PartitionSizeBucket {
 ///       metadata1(4) + metadata2(4) + metadata3(4) + checksum(4) = 32 bytes
 ///     - Authoritative marker: version == 4
 ///
-/// Any other version number is unsupported and results in a parse error. The
-/// `1..=3` branch below is retained only so this standalone helper fails
-/// gracefully rather than misclassifying a lower version; pre-`na` (Cassandra
-/// 3.x/4.x, `ma`–`me`) is OUT OF SCOPE per the version floor and SHALL NOT be
-/// relied on for correctness.
+/// This function successfully parses `1..=3` headers (pre-`na`, Cassandra
+/// 3.x/4.x) but those versions are UNSUPPORTED and OUT OF SCOPE per the version
+/// floor — they are REJECTED downstream by `BigVersionGates::from_version` /
+/// `SSTableReader::open` with `Error::UnsupportedVersion`, not here. The `1..=3`
+/// branch exists only so this standalone helper can parse a header structure
+/// without misclassifying a lower version; it SHALL NOT be relied on for
+/// correctness. Other versions (0, 5+) return a parse error.
 pub fn parse_statistics_header(input: &[u8]) -> IResult<&[u8], StatisticsHeader> {
     let (remaining, version) = be_u32(input)?;
 

--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -259,22 +259,20 @@ pub struct PartitionSizeBucket {
 
 /// Parse the Statistics.db file header with authoritative format detection.
 ///
-/// CQLite targets Cassandra 5.0 (`na`+/`nb` BIG and `oa`/`da` BTI); the
-/// supported Statistics.db header is the **version-4 `nb`** layout:
+/// CQLite targets Cassandra 5.0 (`na`+/`nb` BIG, `oa`/`da` BTI); the supported
+/// header is the **version-4 `nb`** layout (the one the reader open path
+/// exercises via `enhanced_statistics_parser`):
 ///
-/// - **Version 4**: 'nb' (new big) enhanced-statistics header (Cassandra 5.0+)
+/// - **Version 4**: 'nb' enhanced-statistics header (Cassandra 5.0+)
 ///     - Structure: version(4) + statistics_kind(4) + reserved(4) + data_length(4) +
 ///       metadata1(4) + metadata2(4) + metadata3(4) + checksum(4) = 32 bytes
 ///     - Authoritative marker: version == 4
-///     - This is the format the reader open path exercises (via
-///       `enhanced_statistics_parser`).
 ///
-/// Any other version number is unsupported and results in a parse error.
-///
-/// The `1..=3` branch below is retained only so this standalone header parser
-/// fails gracefully rather than misclassifying a lower version; it is NOT a
-/// supported format target. Pre-`na` (Cassandra 3.x/4.x, `ma`–`me`) is out of
-/// scope per the version floor and SHALL NOT be relied on for correctness.
+/// Any other version number is unsupported and results in a parse error. The
+/// `1..=3` branch below is retained only so this standalone helper fails
+/// gracefully rather than misclassifying a lower version; pre-`na` (Cassandra
+/// 3.x/4.x, `ma`–`me`) is OUT OF SCOPE per the version floor and SHALL NOT be
+/// relied on for correctness.
 pub fn parse_statistics_header(input: &[u8]) -> IResult<&[u8], StatisticsHeader> {
     let (remaining, version) = be_u32(input)?;
 

--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -257,31 +257,34 @@ pub struct PartitionSizeBucket {
     pub cumulative_percentage: f64,
 }
 
-/// Parse the Statistics.db file header with authoritative format detection
+/// Parse the Statistics.db file header with authoritative format detection.
 ///
-/// Statistics.db format is definitively identified by the version field:
-/// - **Version 4**: 'nb' (new big) format - Cassandra 5.0+ enhanced statistics
+/// CQLite targets Cassandra 5.0 (`na`+/`nb` BIG and `oa`/`da` BTI); the
+/// supported Statistics.db header is the **version-4 `nb`** layout:
+///
+/// - **Version 4**: 'nb' (new big) enhanced-statistics header (Cassandra 5.0+)
 ///     - Structure: version(4) + statistics_kind(4) + reserved(4) + data_length(4) +
 ///       metadata1(4) + metadata2(4) + metadata3(4) + checksum(4) = 32 bytes
 ///     - Authoritative marker: version == 4
-///     - Used by: Cassandra 5.0+ with 'nb' SSTable format
-///
-/// - **Versions 1-3**: Legacy format - pre-Cassandra 5.0 statistics
-///     - Structure: version(4) + table_id(16) + section_count(4) + file_size(8) + checksum(4) = 36 bytes
-///     - Authoritative marker: version in range 1..=3
-///     - Used by: Cassandra 3.x and 4.x
+///     - This is the format the reader open path exercises (via
+///       `enhanced_statistics_parser`).
 ///
 /// Any other version number is unsupported and results in a parse error.
+///
+/// The `1..=3` branch below is retained only so this standalone header parser
+/// fails gracefully rather than misclassifying a lower version; it is NOT a
+/// supported format target. Pre-`na` (Cassandra 3.x/4.x, `ma`–`me`) is out of
+/// scope per the version floor and SHALL NOT be relied on for correctness.
 pub fn parse_statistics_header(input: &[u8]) -> IResult<&[u8], StatisticsHeader> {
     let (remaining, version) = be_u32(input)?;
 
     match version {
-        // nb-format: Cassandra 5.0+ enhanced statistics (version 4)
-        // This is the authoritative format identifier - no heuristics needed
+        // nb-format: Cassandra 5.0+ enhanced statistics (version 4).
+        // The authoritative format identifier — no heuristics needed.
         4 => parse_nb_format_header(remaining, version),
 
-        // Legacy format: Cassandra 3.x/4.x statistics (versions 1-3)
-        // Definitively identified by version range
+        // Out-of-scope lower versions: parsed only so this standalone helper
+        // fails gracefully; not a supported format (see fn doc / version floor).
         1..=3 => parse_legacy_format_header(remaining, version),
 
         // Unknown/unsupported version - fail explicitly
@@ -330,11 +333,16 @@ fn parse_nb_format_header(input: &[u8], version: u32) -> IResult<&[u8], Statisti
     ))
 }
 
-/// Parse legacy format (versions 1-3) Statistics.db header
+/// Parse a version-1..=3 Statistics.db header.
 ///
-/// Format structure (Cassandra 3.x/4.x):
+/// OUT OF SCOPE (pre-`na`, Cassandra 3.x/4.x). This parser exists only so
+/// [`parse_statistics_header`] fails gracefully on a lower version rather than
+/// misclassifying it as `nb`; CQLite does not open pre-`na` SSTables and this
+/// path is not covered for correctness (version floor).
+///
+/// Byte layout of that header:
 /// ```text
-/// [0..4]   version: u32          = 1, 2, or 3 (legacy format identifier)
+/// [0..4]   version: u32          = 1, 2, or 3
 /// [4..20]  table_id: [u8; 16]    (UUID of the table)
 /// [20..24] section_count: u32    (number of statistics sections)
 /// [24..32] file_size: u64        (total file size)

--- a/cqlite-core/src/parser/toc_walk_metrics.rs
+++ b/cqlite-core/src/parser/toc_walk_metrics.rs
@@ -11,27 +11,59 @@
 //! real number rather than a guess. It is NOT a decoding heuristic: nothing in
 //! the parse path reads the count, so it has no effect on correctness (#28).
 //!
-//! The increment is a single `Relaxed` atomic add — negligible on the open path.
-
-use std::sync::atomic::{AtomicU64, Ordering};
-
-/// Process-wide count of Statistics.db TOC walks since the last reset.
-static TOC_WALKS: AtomicU64 = AtomicU64::new(0);
+//! The instrumentation is gated behind `cli-helpers` (roborev #1658): the
+//! counter is only read by the cli-helpers-gated bench, so production builds
+//! (default features) carry zero overhead — `record_toc_walk()` compiles to an
+//! empty inline no-op.
 
 /// Record that a Statistics.db TOC was walked once. Called at each TOC-walk site.
+/// Gated behind cli-helpers so production builds carry zero overhead (roborev #1658).
 #[inline]
+#[cfg(feature = "cli-helpers")]
 pub(crate) fn record_toc_walk() {
-    TOC_WALKS.fetch_add(1, Ordering::Relaxed);
+    gated::TOC_WALKS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 }
 
-/// Read the current TOC-walk count (process-wide, since the last reset).
+/// No-op in production builds (when cli-helpers is disabled).
+#[inline]
+#[cfg(not(feature = "cli-helpers"))]
+pub(crate) fn record_toc_walk() {
+    // Empty — zero overhead in default/production builds.
+}
+
+// The counter and its accessors are only compiled when cli-helpers is enabled
+// (the bench that reads them is also gated on cli-helpers).
+#[cfg(feature = "cli-helpers")]
+mod gated {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Process-wide count of Statistics.db TOC walks since the last reset.
+    pub(super) static TOC_WALKS: AtomicU64 = AtomicU64::new(0);
+
+    /// Read the current TOC-walk count (process-wide, since the last reset).
+    pub fn toc_walk_count() -> u64 {
+        TOC_WALKS.load(Ordering::Relaxed)
+    }
+
+    /// Reset the TOC-walk counter to zero and return the value it held. Lets a
+    /// caller (e.g. the cold-open bench) measure the walks of a single open in
+    /// isolation: reset, do one open, then read `toc_walk_count()`.
+    pub fn reset_toc_walk_count() -> u64 {
+        TOC_WALKS.swap(0, Ordering::Relaxed)
+    }
+}
+
+#[cfg(feature = "cli-helpers")]
+pub use gated::{reset_toc_walk_count, toc_walk_count};
+
+// When cli-helpers is disabled, provide stub functions so the bench module
+// (which is itself gated on cli-helpers) still compiles if accidentally reached.
+#[cfg(not(feature = "cli-helpers"))]
 pub fn toc_walk_count() -> u64 {
-    TOC_WALKS.load(Ordering::Relaxed)
+    0
 }
 
-/// Reset the TOC-walk counter to zero and return the value it held. Lets a
-/// caller (e.g. the cold-open bench) measure the walks of a single open in
-/// isolation: reset, do one open, then read `toc_walk_count()`.
+#[cfg(not(feature = "cli-helpers"))]
 pub fn reset_toc_walk_count() -> u64 {
-    TOC_WALKS.swap(0, Ordering::Relaxed)
+    0
 }

--- a/cqlite-core/src/parser/toc_walk_metrics.rs
+++ b/cqlite-core/src/parser/toc_walk_metrics.rs
@@ -1,0 +1,37 @@
+//! Minimal process-wide counter for Statistics.db Table-of-Contents (TOC) walks
+//! (issue #1658, epic #1606).
+//!
+//! The metadata stack re-walks the Statistics.db TOC several times during a
+//! single SSTable open — once to locate the `HEADER` (SerializationHeader)
+//! offset (`enhanced_statistics_parser::header::parse_statistics_toc_for_header_offset`)
+//! and again inside `repair_metadata::stats_component_bounds`, which
+//! `read_table_counts` and `parse_stats_extras` each invoke while building
+//! `SSTableStatistics`. This counter lets the A5 cold-open bench
+//! (`benches/open.rs`) MEASURE that redundancy so a fix can be scoped against a
+//! real number rather than a guess. It is NOT a decoding heuristic: nothing in
+//! the parse path reads the count, so it has no effect on correctness (#28).
+//!
+//! The increment is a single `Relaxed` atomic add — negligible on the open path.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process-wide count of Statistics.db TOC walks since the last reset.
+static TOC_WALKS: AtomicU64 = AtomicU64::new(0);
+
+/// Record that a Statistics.db TOC was walked once. Called at each TOC-walk site.
+#[inline]
+pub(crate) fn record_toc_walk() {
+    TOC_WALKS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Read the current TOC-walk count (process-wide, since the last reset).
+pub fn toc_walk_count() -> u64 {
+    TOC_WALKS.load(Ordering::Relaxed)
+}
+
+/// Reset the TOC-walk counter to zero and return the value it held. Lets a
+/// caller (e.g. the cold-open bench) measure the walks of a single open in
+/// isolation: reset, do one open, then read `toc_walk_count()`.
+pub fn reset_toc_walk_count() -> u64 {
+    TOC_WALKS.swap(0, Ordering::Relaxed)
+}


### PR DESCRIPTION
Closes #1658 (M4 — hygiene bundle, reduced). Part of epic #1606.

## Part (a) — prune stale pre-`na` narrative (doc-only)
`cqlite-core/src/parser/statistics.rs` carried a "Versions 1-3" (Cassandra 3.x) narrative that contradicted the enforced `na`+ version floor. Rewrote the `parse_statistics_header`/`parse_legacy_format_header` docs to describe only the supported `nb` reality; the `1..=3` branch is documented as OUT OF SCOPE (pre-`na`). Doc corrected for accuracy: those versions PARSE (`Ok`) here but are REJECTED downstream by `BigVersionGates::from_version`/`SSTableReader::open` (`Error::UnsupportedVersion`) — not at parse. No parsing behavior changed; the `1..=3` branch itself is unchanged.

## Part (b) — cold-open metadata parse cost → A5 bench (#1566)
Added `metadata_parse_big` + `metadata_parse_bti` bench entries to `cqlite-core/benches/open.rs` measuring full Statistics.db metadata parse per open, plus a `toc_walk_metrics` counter at the two TOC-walk sites (`enhanced_statistics_parser/header.rs`, `repair_metadata.rs`).

**Baseline:** 3 TOC walks per metadata parse (both nb and da); parse ~3.47 µs (nb) / ~1.20 µs (da). The 3× TOC redundancy is material → filed follow-up fix issue **#2148** (parse TOC once, thread offsets). MEASURE-only here, per the issue's "do not fix the TOC re-walk" constraint.

**Overhead:** the TOC counter is a no-op unless `cli-helpers` is enabled — production/default builds carry ZERO instrumentation overhead; the bench (which reads the counter) runs under `--features cli-helpers`. The bench is `harness=false` + `cli-helpers`-gated → never in the default test/gate run.

## Review
- rust-reviewer: CLEAN (TOC counter behavior-neutral pure observation; statistics.rs doc-only; bench sound + not in gate run; no unwrap in lib code).
- roborev (job 3708): 2 Lows — (1) always-on production instrumentation → FIXED (now cli-helpers-gated, zero prod overhead); (2) doc contract accuracy on `1..=3` → FIXED.

## Notes for the closer
- Full gate needs `CQLITE_ALLOW_FILE_GROWTH=1` (both touched src files are pre-existing over-threshold, #1116 split debt; net additions are the 2-line instrumentation + comment rewrite).