### PR TITLE
fix(#1773): fail-closed CRC validation on the compressed offset-read path

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
@@ -70,6 +70,13 @@ impl SSTableReader {
             // per-chunk CRC32 is checked HERE, before decompression. header_offset is
             // 0 for nb/BTI (CompressionInfo chunk offsets are absolute from Data.db
             // byte 0), matching the cursor and BTI point-read paths (issue #1573 C2).
+            //
+            // Fail CLOSED (issue #1773 roborev): for a VALID offset+size every chunk
+            // in `first_chunk..=last_chunk` exists, so a `None` (EOF) here means the
+            // requested range does not actually fit in this compressed Data.db — a
+            // corrupt/out-of-range offset or size. Returning the partial `assembled`
+            // bytes as `Ok` would silently truncate; this must surface as a typed,
+            // non-recoverable corruption error instead.
             let Some(compressed) = block_io::read_compressed_chunk_at(
                 self.point_source.as_ref(),
                 comp_info,
@@ -78,7 +85,10 @@ impl SSTableReader {
                 0,
             )?
             else {
-                break; // EOF — no further chunks to cover the requested window.
+                return Err(Error::corruption(format!(
+                    "compressed offset read requires chunk {chunk_idx} past EOF for range \
+                     [{start}, {end}) — corrupt or out-of-range offset/size"
+                )));
             };
 
             // Incompressible-chunk fallback (Bug #639, epic #970): Cassandra stores a
@@ -97,14 +107,25 @@ impl SSTableReader {
             assembled.extend_from_slice(&decompressed);
         }
 
-        // Slice the requested window out of the assembled uncompressed chunk bytes,
-        // clamped to what actually decoded (a short final chunk yields fewer bytes).
+        // Slice the requested window out of the assembled uncompressed chunk bytes.
+        //
+        // Fail CLOSED (issue #1773 roborev): for a VALID offset+size the assembled
+        // chunks fully cover `[start, end)`. If they do not — a short final chunk, or
+        // `within_start` itself past what decoded — the offset/size is corrupt or
+        // out-of-range; return a typed corruption error rather than truncating to
+        // `Ok(partial)` / `Ok(empty)`.
         let window_base = first_chunk * chunk_length;
         let within_start = start - window_base;
-        if within_start >= assembled.len() {
-            return Ok(Vec::new());
+        let requested_end = end - window_base;
+        if requested_end > assembled.len() {
+            return Err(Error::corruption(format!(
+                "compressed offset read range [{start}, {end}) is short by {} bytes after \
+                 decompressing chunks {first_chunk}..={last_chunk} (assembled {} bytes) — \
+                 corrupt or out-of-range offset/size",
+                requested_end - assembled.len(),
+                assembled.len()
+            )));
         }
-        let within_end = (end - window_base).min(assembled.len());
-        Ok(assembled[within_start..within_end].to_vec())
+        Ok(assembled[within_start..requested_end].to_vec())
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
@@ -1,0 +1,110 @@
+//! CRC-validated compressed offset-read window (issue #1773).
+//!
+//! The compressed offset-read point-lookup path
+//! ([`read_value_at_offset`](super::super::SSTableReader::read_value_at_offset) →
+//! `get_cached_data`) used to read `size` raw bytes at an offset and LZ4-decompress
+//! them WITHOUT validating the trailing 4-byte inline per-chunk CRC32 — re-introducing
+//! the #1411 CRC bypass on a latent path (unreachable today via `get`, but live the
+//! moment `find_entry` hits for a compressed table). This module carries the helper
+//! that routes that case through the shared CRC-enforcing chunk reader.
+
+use std::sync::atomic::Ordering;
+
+use crate::storage::sstable::reader::SSTableReader;
+use crate::{Error, Result};
+
+impl SSTableReader {
+    /// Decompress the uncompressed byte window `[block_offset, block_offset + size)`
+    /// out of a COMPRESSED Data.db, validating each covering chunk's authoritative
+    /// inline per-chunk CRC32 BEFORE decompression (issue #1773).
+    ///
+    /// Reuses [`read_compressed_chunk_at`] — the positional, CRC-enforcing chunk
+    /// reader also used by the BTI point-read path — so the CRC-then-decompress
+    /// ordering (guardrail #1411) is honored on this path too: a bit-flipped chunk
+    /// surfaces the SAME typed `Error::InvalidFormat` (naming the chunk index +
+    /// offset) that scan / `scan_for_key` return, never garbage. No heuristics: the
+    /// authoritative CRC trailer is checked, never inferred.
+    ///
+    /// [`read_compressed_chunk_at`]: super::super::block_io::read_compressed_chunk_at
+    pub(super) async fn read_compressed_offset_window(
+        &self,
+        comp_info: &crate::storage::sstable::compression_info::CompressionInfo,
+        block_offset: u64,
+        size: u32,
+    ) -> Result<Vec<u8>> {
+        use super::super::block_io;
+        use crate::storage::sstable::compression::Compression;
+
+        let chunk_length = comp_info.chunk_length as usize;
+        if chunk_length == 0 {
+            return Err(Error::corruption(
+                "CompressionInfo chunk_length is zero; cannot map a Data.db offset to a \
+                 compressed chunk"
+                    .to_string(),
+            ));
+        }
+
+        let start = block_offset as usize;
+        let end = start.checked_add(size as usize).ok_or_else(|| {
+            Error::corruption(format!(
+                "compressed offset read range [{start}, +{size}) overflows"
+            ))
+        })?;
+        // `size >= 1` (callers reject size == 0), so `end > start` and `end - 1`
+        // never underflows; `first_chunk <= last_chunk`.
+        let first_chunk = start / chunk_length;
+        let last_chunk = (end - 1) / chunk_length;
+
+        let max_compressed_length = comp_info.max_compressed_length as usize;
+        let compression = self
+            .compression_reader
+            .as_ref()
+            .map(|r| Compression::new(*r.algorithm()))
+            .transpose()?;
+
+        let mut assembled = Vec::with_capacity(
+            last_chunk.saturating_sub(first_chunk).saturating_add(1) * chunk_length,
+        );
+        for chunk_idx in first_chunk..=last_chunk {
+            // CRC-validated compressed bytes (guardrail #1411): the trailing inline
+            // per-chunk CRC32 is checked HERE, before decompression. header_offset is
+            // 0 for nb/BTI (CompressionInfo chunk offsets are absolute from Data.db
+            // byte 0), matching the cursor and BTI point-read paths (issue #1573 C2).
+            let Some(compressed) = block_io::read_compressed_chunk_at(
+                self.point_source.as_ref(),
+                comp_info,
+                chunk_idx,
+                self.stats.file_size,
+                0,
+            )?
+            else {
+                break; // EOF — no further chunks to cover the requested window.
+            };
+
+            // Incompressible-chunk fallback (Bug #639, epic #970): Cassandra stores a
+            // chunk RAW (not compressed) when its compressed length would meet or
+            // exceed `max_compressed_length`; those bytes are already plaintext.
+            // Authority: CompressedSequentialWriter.java:160-177.
+            let decompressed = if compressed.len() >= max_compressed_length {
+                compressed
+            } else if let Some(compression) = &compression {
+                let out = compression.decompress(&compressed)?;
+                super::model::DECOMPRESS_CALLS.fetch_add(1, Ordering::Relaxed);
+                out
+            } else {
+                compressed
+            };
+            assembled.extend_from_slice(&decompressed);
+        }
+
+        // Slice the requested window out of the assembled uncompressed chunk bytes,
+        // clamped to what actually decoded (a short final chunk yields fewer bytes).
+        let window_base = first_chunk * chunk_length;
+        let within_start = start - window_base;
+        if within_start >= assembled.len() {
+            return Ok(Vec::new());
+        }
+        let within_end = (end - window_base).min(assembled.len());
+        Ok(assembled[within_start..within_end].to_vec())
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -438,9 +438,6 @@ impl SSTableReader {
 
     /// Read value at a specific offset with caching
     pub async fn read_value_at_offset(&self, offset: u64, size: u32) -> Result<Option<ScanRow>> {
-        use crate::parser::header::CassandraVersion;
-        use crate::storage::sstable::compression::Compression;
-
         // Size must be non-zero for offset-based reading
         if size == 0 {
             return Err(Error::corruption(format!(
@@ -458,48 +455,11 @@ impl SSTableReader {
         // (compressed tables / BTI / absent-CRC.db warn-and-proceed).
         self.verify_uncompressed_range(offset, size).await?;
 
-        // Use cached reading with metrics tracking
-        let buffer = self.get_cached_data(offset, size).await?;
-
-        // Decompress if needed
-        let data = if let Some(compression_reader) = &self.compression_reader {
-            let compression = Compression::new(*compression_reader.algorithm())?;
-            match compression.decompress(&buffer) {
-                Ok(decompressed) => {
-                    debug!(
-                        "Successfully decompressed {} bytes to {} bytes",
-                        buffer.len(),
-                        decompressed.len()
-                    );
-                    decompressed
-                }
-                Err(e) => {
-                    // For modern formats (4.x/5.x), decompression failure is an error
-                    if self.header.cassandra_version != CassandraVersion::Legacy {
-                        return Err(Error::corruption(format!(
-                            "Decompression failed for modern format at offset={}, size={}, algorithm={:?}: {}",
-                            offset,
-                            size,
-                            compression_reader.algorithm(),
-                            e
-                        )));
-                    } else {
-                        // Only allow fallback for legacy formats
-                        warn!(
-                            "Decompression failed for legacy format ({}), using raw data",
-                            e
-                        );
-                        debug!(
-                            "First 32 bytes of raw data: {:02x?}",
-                            &buffer[..std::cmp::min(32, buffer.len())]
-                        );
-                        buffer
-                    }
-                }
-            }
-        } else {
-            buffer
-        };
+        // `get_cached_data` returns the final DECODED window: CRC-validated +
+        // decompressed for a compressed Data.db (issue #1773), or the CRC.db-verified
+        // raw bytes for an uncompressed one. There is no second decode here — doing so
+        // used to double-decompress the compressed path (and skip its inline CRC).
+        let data = self.get_cached_data(offset, size).await?;
 
         // Preserve raw data until schema is available. Pre-#1334 this offset-read
         // placeholder returned a bare `Value::Blob` of the row's raw value bytes,
@@ -541,9 +501,6 @@ impl SSTableReader {
     ///
     /// [`DecompressedChunkCache`]: crate::storage::cache::DecompressedChunkCache
     async fn get_cached_data(&self, block_offset: u64, size: u32) -> Result<Vec<u8>> {
-        use crate::parser::header::CassandraVersion;
-        use crate::storage::sstable::compression::Compression;
-
         // The shared B1 cache tracks its own hit/miss counters (issue #1567); the
         // dead per-reader `record_cache_hit`/`record_cache_miss` atomics were
         // removed (issue #1568).
@@ -552,34 +509,25 @@ impl SSTableReader {
             return Ok(hit.to_vec());
         }
 
-        // Read from disk (counted so a repeat read can prove zero underlying reads).
-        // Positioned read on the shared point source (issue #1573, C2): no cursor
-        // mutex is held across this I/O, so concurrent point reads do not convoy.
-        model::CHUNK_READ_CALLS.fetch_add(1, Ordering::Relaxed);
-        let mut buffer = vec![0u8; size as usize];
-        self.point_source.read_exact_at(block_offset, &mut buffer)?;
-
-        // Decompress if needed
-        let data = if let Some(compression_reader) = &self.compression_reader {
-            let compression = Compression::new(*compression_reader.algorithm())?;
-            match compression.decompress(&buffer) {
-                Ok(decompressed) => {
-                    model::DECOMPRESS_CALLS.fetch_add(1, Ordering::Relaxed);
-                    decompressed
-                }
-                Err(e) => {
-                    // Handle decompression errors based on format
-                    if self.header.cassandra_version != CassandraVersion::Legacy {
-                        return Err(Error::corruption(format!(
-                            "Decompression failed at offset={}, size={}: {}",
-                            block_offset, size, e
-                        )));
-                    } else {
-                        buffer // Fall back to raw data for legacy formats
-                    }
-                }
-            }
+        // Produce the final DECOMPRESSED, integrity-verified window for this offset.
+        let data = if let Some(comp_info) = self.compression_info.as_deref() {
+            // COMPRESSED offset read (issue #1773): the authoritative inline per-chunk
+            // CRC32 MUST be validated before decompression. Reuse the shared
+            // CRC-enforcing chunk reader rather than reading `size` raw bytes and
+            // blindly LZ4-decoding them — the latter re-introduced the exact #1411
+            // CRC bypass (a bit-flipped chunk decoding to garbage instead of the
+            // typed Error::InvalidFormat that scan/scan_for_key surface).
+            self.read_compressed_offset_window(comp_info, block_offset, size)
+                .await?
         } else {
+            // UNCOMPRESSED offset read. Positioned read on the shared point source
+            // (issue #1573, C2): no cursor mutex is held across this I/O, so
+            // concurrent point reads do not convoy. The covering CRC.db chunks were
+            // already verified by `verify_uncompressed_range` before we got here
+            // (issue #1396), so these bytes are integrity-checked too.
+            model::CHUNK_READ_CALLS.fetch_add(1, Ordering::Relaxed);
+            let mut buffer = vec![0u8; size as usize];
+            self.point_source.read_exact_at(block_offset, &mut buffer)?;
             buffer
         };
 
@@ -587,6 +535,97 @@ impl SSTableReader {
         // return an owned copy (this site's callers consume a Vec).
         let arc = self.chunk_cache.insert(key, data);
         Ok(arc.to_vec())
+    }
+
+    /// Decompress the uncompressed byte window `[block_offset, block_offset + size)`
+    /// out of a COMPRESSED Data.db, validating each covering chunk's authoritative
+    /// inline per-chunk CRC32 BEFORE decompression (issue #1773).
+    ///
+    /// Reuses [`block_io::read_compressed_chunk_at`] — the positional, CRC-enforcing
+    /// chunk reader also used by the BTI point-read path — so the CRC-then-decompress
+    /// ordering (guardrail #1411) is honored on this path too: a bit-flipped chunk
+    /// surfaces the SAME typed `Error::InvalidFormat` (naming the chunk index +
+    /// offset) that scan / `scan_for_key` return, never garbage. No heuristics: the
+    /// authoritative CRC trailer is checked, never inferred.
+    async fn read_compressed_offset_window(
+        &self,
+        comp_info: &crate::storage::sstable::compression_info::CompressionInfo,
+        block_offset: u64,
+        size: u32,
+    ) -> Result<Vec<u8>> {
+        use super::block_io;
+        use crate::storage::sstable::compression::Compression;
+
+        let chunk_length = comp_info.chunk_length as usize;
+        if chunk_length == 0 {
+            return Err(Error::corruption(
+                "CompressionInfo chunk_length is zero; cannot map a Data.db offset to a \
+                 compressed chunk"
+                    .to_string(),
+            ));
+        }
+
+        let start = block_offset as usize;
+        let end = start.checked_add(size as usize).ok_or_else(|| {
+            Error::corruption(format!(
+                "compressed offset read range [{start}, +{size}) overflows"
+            ))
+        })?;
+        // `size >= 1` (callers reject size == 0), so `end > start` and `end - 1`
+        // never underflows; `first_chunk <= last_chunk`.
+        let first_chunk = start / chunk_length;
+        let last_chunk = (end - 1) / chunk_length;
+
+        let max_compressed_length = comp_info.max_compressed_length as usize;
+        let compression = self
+            .compression_reader
+            .as_ref()
+            .map(|r| Compression::new(*r.algorithm()))
+            .transpose()?;
+
+        let mut assembled =
+            Vec::with_capacity(last_chunk.saturating_sub(first_chunk).saturating_add(1) * chunk_length);
+        for chunk_idx in first_chunk..=last_chunk {
+            // CRC-validated compressed bytes (guardrail #1411): the trailing inline
+            // per-chunk CRC32 is checked HERE, before decompression. header_offset is
+            // 0 for nb/BTI (CompressionInfo chunk offsets are absolute from Data.db
+            // byte 0), matching the cursor and BTI point-read paths (issue #1573 C2).
+            let Some(compressed) = block_io::read_compressed_chunk_at(
+                self.point_source.as_ref(),
+                comp_info,
+                chunk_idx,
+                self.stats.file_size,
+                0,
+            )?
+            else {
+                break; // EOF — no further chunks to cover the requested window.
+            };
+
+            // Incompressible-chunk fallback (Bug #639, epic #970): Cassandra stores a
+            // chunk RAW (not compressed) when its compressed length would meet or
+            // exceed `max_compressed_length`; those bytes are already plaintext.
+            // Authority: CompressedSequentialWriter.java:160-177.
+            let decompressed = if compressed.len() >= max_compressed_length {
+                compressed
+            } else if let Some(compression) = &compression {
+                let out = compression.decompress(&compressed)?;
+                model::DECOMPRESS_CALLS.fetch_add(1, Ordering::Relaxed);
+                out
+            } else {
+                compressed
+            };
+            assembled.extend_from_slice(&decompressed);
+        }
+
+        // Slice the requested window out of the assembled uncompressed chunk bytes,
+        // clamped to what actually decoded (a short final chunk yields fewer bytes).
+        let window_base = first_chunk * chunk_length;
+        let within_start = start - window_base;
+        if within_start >= assembled.len() {
+            return Ok(Vec::new());
+        }
+        let within_end = (end - window_base).min(assembled.len());
+        Ok(assembled[within_start..within_end].to_vec())
     }
 
     /// Verify the `CRC.db` chunk(s) covering the uncompressed Data.db byte range

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -66,7 +66,7 @@ use crate::{Error, Result, RowKey};
 use std::io::SeekFrom;
 use std::sync::atomic::Ordering;
 use tokio::io::AsyncSeekExt;
-use tracing::{debug, warn};
+use tracing::warn;
 
 // Per-site cache key namespaces (design D4): fold a site discriminator into the
 // sstable-identity field of [`ChunkKey`] so numerically-overlapping keys from

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -37,6 +37,9 @@ mod chunk_cache_wiring_tests;
 // seek (issue #1572), replacing the whole-file scan_for_key fallback.
 mod big_point;
 mod compaction;
+// CRC-validated compressed offset-read window (issue #1773): keeps the
+// `read_compressed_offset_window` helper out of this already-large entry-point file.
+mod compressed_offset;
 mod model;
 // First/last-key range short-circuit (issue #1576, C5): an authoritative
 // `[first_key, last_key]` bound check that answers out-of-range point reads as
@@ -535,97 +538,6 @@ impl SSTableReader {
         // return an owned copy (this site's callers consume a Vec).
         let arc = self.chunk_cache.insert(key, data);
         Ok(arc.to_vec())
-    }
-
-    /// Decompress the uncompressed byte window `[block_offset, block_offset + size)`
-    /// out of a COMPRESSED Data.db, validating each covering chunk's authoritative
-    /// inline per-chunk CRC32 BEFORE decompression (issue #1773).
-    ///
-    /// Reuses [`block_io::read_compressed_chunk_at`] — the positional, CRC-enforcing
-    /// chunk reader also used by the BTI point-read path — so the CRC-then-decompress
-    /// ordering (guardrail #1411) is honored on this path too: a bit-flipped chunk
-    /// surfaces the SAME typed `Error::InvalidFormat` (naming the chunk index +
-    /// offset) that scan / `scan_for_key` return, never garbage. No heuristics: the
-    /// authoritative CRC trailer is checked, never inferred.
-    async fn read_compressed_offset_window(
-        &self,
-        comp_info: &crate::storage::sstable::compression_info::CompressionInfo,
-        block_offset: u64,
-        size: u32,
-    ) -> Result<Vec<u8>> {
-        use super::block_io;
-        use crate::storage::sstable::compression::Compression;
-
-        let chunk_length = comp_info.chunk_length as usize;
-        if chunk_length == 0 {
-            return Err(Error::corruption(
-                "CompressionInfo chunk_length is zero; cannot map a Data.db offset to a \
-                 compressed chunk"
-                    .to_string(),
-            ));
-        }
-
-        let start = block_offset as usize;
-        let end = start.checked_add(size as usize).ok_or_else(|| {
-            Error::corruption(format!(
-                "compressed offset read range [{start}, +{size}) overflows"
-            ))
-        })?;
-        // `size >= 1` (callers reject size == 0), so `end > start` and `end - 1`
-        // never underflows; `first_chunk <= last_chunk`.
-        let first_chunk = start / chunk_length;
-        let last_chunk = (end - 1) / chunk_length;
-
-        let max_compressed_length = comp_info.max_compressed_length as usize;
-        let compression = self
-            .compression_reader
-            .as_ref()
-            .map(|r| Compression::new(*r.algorithm()))
-            .transpose()?;
-
-        let mut assembled =
-            Vec::with_capacity(last_chunk.saturating_sub(first_chunk).saturating_add(1) * chunk_length);
-        for chunk_idx in first_chunk..=last_chunk {
-            // CRC-validated compressed bytes (guardrail #1411): the trailing inline
-            // per-chunk CRC32 is checked HERE, before decompression. header_offset is
-            // 0 for nb/BTI (CompressionInfo chunk offsets are absolute from Data.db
-            // byte 0), matching the cursor and BTI point-read paths (issue #1573 C2).
-            let Some(compressed) = block_io::read_compressed_chunk_at(
-                self.point_source.as_ref(),
-                comp_info,
-                chunk_idx,
-                self.stats.file_size,
-                0,
-            )?
-            else {
-                break; // EOF — no further chunks to cover the requested window.
-            };
-
-            // Incompressible-chunk fallback (Bug #639, epic #970): Cassandra stores a
-            // chunk RAW (not compressed) when its compressed length would meet or
-            // exceed `max_compressed_length`; those bytes are already plaintext.
-            // Authority: CompressedSequentialWriter.java:160-177.
-            let decompressed = if compressed.len() >= max_compressed_length {
-                compressed
-            } else if let Some(compression) = &compression {
-                let out = compression.decompress(&compressed)?;
-                model::DECOMPRESS_CALLS.fetch_add(1, Ordering::Relaxed);
-                out
-            } else {
-                compressed
-            };
-            assembled.extend_from_slice(&decompressed);
-        }
-
-        // Slice the requested window out of the assembled uncompressed chunk bytes,
-        // clamped to what actually decoded (a short final chunk yields fewer bytes).
-        let window_base = first_chunk * chunk_length;
-        let within_start = start - window_base;
-        if within_start >= assembled.len() {
-            return Ok(Vec::new());
-        }
-        let within_end = (end - window_base).min(assembled.len());
-        Ok(assembled[within_start..within_end].to_vec())
     }
 
     /// Verify the `CRC.db` chunk(s) covering the uncompressed Data.db byte range

--- a/cqlite-core/tests/issue_1773_compressed_offset_crc.rs
+++ b/cqlite-core/tests/issue_1773_compressed_offset_crc.rs
@@ -35,6 +35,7 @@
 //! on a present fixture fails regardless of the env flag.
 
 use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::types::ScanRow;
 use cqlite_core::{Config, Error, Platform};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -182,6 +183,120 @@ async fn compressed_offset_read_on_clean_chunk_returns_some() {
         Err(e) => panic!(
             "compressed offset read on the CLEAN lz4_table chunk must succeed \
              (CRC valid, decodable), got Err: {e}"
+        ),
+    }
+}
+
+/// Unwrap a `read_value_at_offset` `Ok(Some(_))` to its raw bytes, panicking on any
+/// other shape (the offset-read path only ever emits `ScanRow::RawRow`, issue #1334).
+fn raw_bytes(row: ScanRow) -> Vec<u8> {
+    match row {
+        ScanRow::RawRow(bytes) => bytes,
+        other => panic!("expected ScanRow::RawRow from the offset-read path, got {other:?}"),
+    }
+}
+
+/// `lz4_table`'s `CompressionInfo.db` declares `chunk_length = 16384` (0x4000) — the
+/// boundary between compressed chunk 0 and chunk 1 of the uncompressed Data.db.
+const CHUNK_BOUNDARY: u64 = 16384;
+
+/// Roborev follow-up (issue #1773 HIGH blocker) — a window that STRADDLES a chunk
+/// boundary must be assembled from BOTH covering chunks in full, never silently
+/// truncated to whichever chunk decoded first. Proven without an external oracle: the
+/// straddling read's bytes must equal the concatenation of two independently-verified
+/// single-chunk reads covering the same two half-windows.
+#[tokio::test]
+async fn compressed_offset_read_spans_chunk_boundary_matches_single_chunk_reads() {
+    let Some(path) = fixture_or_gate(CLEAN_DATA_DB) else {
+        return;
+    };
+    let reader = open_reader(&path).await;
+
+    // Half A: last 4 bytes of chunk 0. Half B: first 4 bytes of chunk 1.
+    let half_a = raw_bytes(
+        reader
+            .read_value_at_offset(CHUNK_BOUNDARY - 4, 4)
+            .await
+            .expect("chunk-0-only read must succeed")
+            .expect("chunk-0-only read must return Some"),
+    );
+    let half_b = raw_bytes(
+        reader
+            .read_value_at_offset(CHUNK_BOUNDARY, 4)
+            .await
+            .expect("chunk-1-only read must succeed")
+            .expect("chunk-1-only read must return Some"),
+    );
+    assert_eq!(half_a.len(), 4);
+    assert_eq!(half_b.len(), 4);
+
+    // The spanning read covers the exact same 8 bytes across both chunks.
+    let spanning = raw_bytes(
+        reader
+            .read_value_at_offset(CHUNK_BOUNDARY - 4, 8)
+            .await
+            .expect("multi-chunk spanning read must succeed")
+            .expect("multi-chunk spanning read must return Some"),
+    );
+
+    assert_eq!(
+        spanning.len(),
+        8,
+        "spanning read must return the FULL requested length (8 bytes), not a partial \
+         window truncated to a single chunk"
+    );
+    let mut expected = half_a;
+    expected.extend_from_slice(&half_b);
+    assert_eq!(
+        spanning, expected,
+        "spanning read must equal the concatenation of the two half-windows it covers \
+         (proves multi-chunk assembly, not silent truncation to one chunk)"
+    );
+}
+
+/// Roborev follow-up (issue #1773 HIGH blocker) — an offset+size that extends past the
+/// end of the compressed Data.db's covering chunks MUST fail closed with a typed
+/// corruption error, never `Ok` with partial or empty bytes. `200000` is well past
+/// `lz4_table`'s last valid chunk (12 chunks of `chunk_length=16384`, chunk index 12
+/// does not exist), so this exercises the "requires chunk N past EOF" guard.
+///
+/// FAILS on pre-fix code: `read_compressed_chunk_at` returning `None` mid-range used
+/// to `break` and return whatever partial `assembled` bytes existed (here: none, since
+/// the very first covering chunk is already past EOF) as `Ok(Vec::new())` — this test
+/// asserts `Err` instead.
+#[tokio::test]
+async fn compressed_offset_read_past_eof_errors_not_partial() {
+    let Some(path) = fixture_or_gate(CLEAN_DATA_DB) else {
+        return;
+    };
+    let reader = open_reader(&path).await;
+
+    let result = reader.read_value_at_offset(200_000, 16).await;
+
+    match result {
+        Err(err) => {
+            assert!(
+                !err.is_recoverable(),
+                "past-EOF compressed offset read must be a non-recoverable error, got \
+                 recoverable: {err}"
+            );
+            let msg = err.to_string();
+            assert!(
+                msg.to_lowercase().contains("eof")
+                    || msg.to_lowercase().contains("chunk")
+                    || msg.to_lowercase().contains("corrupt"),
+                "past-EOF error should identify itself as an out-of-range/corrupt chunk \
+                 read, got: {msg}"
+            );
+        }
+        Ok(None) => panic!(
+            "compressed offset read past EOF returned Ok(None); it must fail closed \
+             with a typed corruption error (issue #1773 roborev)."
+        ),
+        Ok(Some(v)) => panic!(
+            "compressed offset read past EOF returned Ok(Some({v:?})) — partial/garbage \
+             data past the end of the compressed chunks; it must fail closed with a \
+             typed corruption error (issue #1773 roborev)."
         ),
     }
 }

--- a/cqlite-core/tests/issue_1773_compressed_offset_crc.rs
+++ b/cqlite-core/tests/issue_1773_compressed_offset_crc.rs
@@ -1,0 +1,187 @@
+//! Issue #1773 — the COMPRESSED offset-read point-lookup path
+//! (`SSTableReader::read_value_at_offset` → `get_cached_data`) MUST validate the
+//! authoritative inline per-chunk CRC32 before decompressing, surfacing the SAME
+//! typed, non-recoverable `Error::InvalidFormat` that the scan / `scan_for_key`
+//! paths already return (the #1411 guardrail).
+//!
+//! ## Why this exists (latent, defensive)
+//!
+//! For a compressed `nb` table the offset-read path is currently unreachable via
+//! `get` (Index.db is keyed by Murmur3 digests, so `find_entry` misses and `get`
+//! falls through to `scan_for_key`, whose CRC bypass #1411 already fixed). But the
+//! offset path itself — reached directly here — used to read `size` raw bytes at an
+//! offset and LZ4-decompress them WITHOUT stripping/validating the trailing 4-byte
+//! inline per-chunk CRC32. A future change that makes `find_entry` hit for a
+//! compressed table would re-introduce the exact #1411 bypass: a bit-flipped chunk
+//! LZ4-decodes to garbage instead of surfacing the typed CRC error.
+//!
+//! These tests drive corrupt/clean input DIRECTLY through the public offset entry
+//! `read_value_at_offset` (bypassing the digest-index miss that hides the path from
+//! `get`), proving the CRC check is on the ACTUAL offset path.
+//!
+//! ## Fixture (real Cassandra 5.0.2 bytes, one deterministic bit flip)
+//!
+//! Reuses the #1411 oracle:
+//! `corruption/test_comp_corrupt/data_db_bit_flip/nb-1-big-Data.db` — a single-bit
+//! flip inside the FIRST LZ4 compressed chunk (chunk 0) of `test_comp/lz4_table`,
+//! a single-partition table whose whole payload lives in chunk 0. Apache Cassandra
+//! 5.0.2 `sstableverify -e` rejects this exact file.
+//!
+//! ## Fixture-gating (issue #1094 doctrine)
+//!
+//! Skip-clean when the corpus binary is absent; `CQLITE_REQUIRE_FIXTURES=1` turns
+//! that skip into a hard failure. A fixture that is present but no longer corrupt
+//! (regen rot) FAILS unconditionally — the corrupt test asserts `Err`, so an `Ok`
+//! on a present fixture fails regardless of the env flag.
+
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::{Config, Error, Platform};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Relative path of the corrupt COMPRESSED Data.db under the datasets root.
+const CORRUPT_DATA_DB: &str = "corruption/test_comp_corrupt/data_db_bit_flip/nb-1-big-Data.db";
+
+/// Relative path of the CLEAN source Data.db the corrupt fixture was derived from.
+const CLEAN_DATA_DB: &str =
+    "sstables/test_comp/lz4_table-25801a0071a911f19b3225f9984c6a77/nb-1-big-Data.db";
+
+/// An offset+size that lands wholly inside chunk 0 (which holds the entire single
+/// partition of `lz4_table`). The exact window is immaterial: chunk 0's inline CRC
+/// covers the whole chunk, so any read touching it must validate that CRC.
+const CHUNK0_OFFSET: u64 = 0;
+const CHUNK0_SIZE: u32 = 16;
+
+/// `true` when the full-dataset/nightly lanes demand the corpus be present.
+fn require_fixtures() -> bool {
+    matches!(
+        std::env::var("CQLITE_REQUIRE_FIXTURES").ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE")
+    )
+}
+
+/// Locate the datasets root, honoring `CQLITE_DATASETS_ROOT` with a worktree fallback.
+fn datasets_root() -> Option<PathBuf> {
+    if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        let p = PathBuf::from(root);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    let fallback = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(|p| p.join("test-data/datasets"))?;
+    fallback.is_dir().then_some(fallback)
+}
+
+/// Resolve a fixture path, applying the fail-closed gate (issue #1094):
+/// present → `Some(path)`; absent + `CQLITE_REQUIRE_FIXTURES=1` → panic; else `None`.
+fn fixture_or_gate(rel: &str) -> Option<PathBuf> {
+    let path = datasets_root().map(|r| r.join(rel));
+    match path {
+        Some(p) if p.is_file() => Some(p),
+        _ => {
+            assert!(
+                !require_fixtures(),
+                "CQLITE_REQUIRE_FIXTURES=1 but the fixture is absent: {rel}. \
+                 Fetch the corpus (test-data/scripts/fetch-datasets.sh)."
+            );
+            eprintln!("SKIP: fixture absent ({rel}); set CQLITE_REQUIRE_FIXTURES=1 to enforce.");
+            None
+        }
+    }
+}
+
+async fn open_reader(path: &Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&config)
+            .await
+            .expect("platform init should succeed"),
+    );
+    SSTableReader::open(path, &config, platform).await.expect(
+        "opening the (structurally valid) corrupt Data.db should succeed; \
+         corruption is in a chunk payload, not the header",
+    )
+}
+
+/// Assert an error is the typed, non-recoverable per-chunk CRC corruption that names
+/// the corrupt chunk index + on-disk offset — identical to the scan/`scan_for_key`
+/// paths' surfacing (issue #1411).
+fn assert_typed_chunk_corruption(err: &Error) {
+    assert!(
+        !err.is_recoverable(),
+        "chunk CRC-mismatch must be a non-recoverable error, got recoverable: {err}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("chunk 0"),
+        "corruption error must name the chunk index ('chunk 0'), got: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("offset") && msg.contains("0x0"),
+        "corruption error must name the chunk offset (0x0), got: {msg}"
+    );
+    assert!(
+        msg.to_uppercase().contains("CRC"),
+        "corruption error should identify the CRC mismatch, got: {msg}"
+    );
+}
+
+/// Issue #1773 — the compressed OFFSET-READ path itself surfaces the typed per-chunk
+/// CRC corruption. Drives `read_value_at_offset` directly (bypassing the digest-index
+/// miss that hides this path from `get`), so this asserts the CRC check is on the
+/// real offset path — NOT `Ok(None)`, NOT garbage `Ok(Some(_))`.
+///
+/// FAILS on pre-fix code: the old path read raw bytes and blindly decompressed,
+/// yielding a generic decode error / garbage, never a "chunk 0 ... CRC" error.
+#[tokio::test]
+async fn compressed_offset_read_into_corrupt_chunk_errors_with_typed_crc() {
+    let Some(path) = fixture_or_gate(CORRUPT_DATA_DB) else {
+        return;
+    };
+    let reader = open_reader(&path).await;
+
+    let result = reader
+        .read_value_at_offset(CHUNK0_OFFSET, CHUNK0_SIZE)
+        .await;
+
+    match result {
+        Err(err) => assert_typed_chunk_corruption(&err),
+        Ok(None) => panic!(
+            "compressed offset read into the corrupt chunk returned Ok(None); it must \
+             return a typed per-chunk CRC corruption error (issue #1773)."
+        ),
+        Ok(Some(v)) => panic!(
+            "compressed offset read into the corrupt chunk returned Ok(Some({v:?})) — \
+             garbage from a bit-flipped chunk; it must return a typed CRC error (issue #1773)."
+        ),
+    }
+}
+
+/// Issue #1773 CLEAN-fixture control — the SAME offset read on the healthy source
+/// SSTable returns `Ok(Some(_))`. Proves the corrupt-fixture `Err` above is the CRC
+/// corruption surfacing on a decoded-then-CRC-validated chunk, not a read that fails
+/// for every input (which would make the corrupt assertion vacuous).
+#[tokio::test]
+async fn compressed_offset_read_on_clean_chunk_returns_some() {
+    let Some(path) = fixture_or_gate(CLEAN_DATA_DB) else {
+        return;
+    };
+    let reader = open_reader(&path).await;
+
+    match reader
+        .read_value_at_offset(CHUNK0_OFFSET, CHUNK0_SIZE)
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => panic!(
+            "compressed offset read on the CLEAN lz4_table chunk returned Ok(None); \
+             the chunk must decode (else the corrupt-fixture assertion is vacuous)."
+        ),
+        Err(e) => panic!(
+            "compressed offset read on the CLEAN lz4_table chunk must succeed \
+             (CRC valid, decodable), got Err: {e}"
+        ),
+    }
+}


### PR DESCRIPTION
Fixes a latent #1411-class CRC-bypass on the **compressed offset-read path**.

## Problem
`read_value_at_offset` → `get_cached_data` → the compressed-offset window read did **not** validate the inline per-chunk CRC32, and could return `Ok(partial/empty)` on a missing/past-EOF chunk or a short assembled window — a silent fail-open on corrupt or out-of-range compressed data.

## Fix
- New `read_compressed_offset_window` in `data_access/compressed_offset.rs` reuses `block_io::read_compressed_chunk_at`, so the inline per-chunk CRC32 is validated on the offset path exactly as on the streaming path.
- **Fails closed** with a typed `Error::corruption` on a missing/past-EOF chunk or a short assembled window (no more `Ok(partial/empty)`).
- Removed a redundant double-decompression.

## Tests (4, all fail-first confirmed)
- corrupt chunk → typed CRC error
- clean chunk → `Ok(Some(..))`
- multi-chunk boundary window assembly
- past-EOF chunk → typed `Err`

Closes #1773.