### PR TITLE
fix(#1754): Node raw-parse corrupt DECIMAL scale aborts host — fail-closed decode + napi catch_unwind

### DIFF
--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -33,6 +33,9 @@ chrono = { workspace = true }
 uuid = { version = "1.6", features = ["v4"] }
 base64 = "0.22"
 hex = "0.4"
+# Single, reasonably-optimized base-10 conversion for arbitrary-precision DECIMAL
+# unscaled magnitudes (issue #1754) — replaces a hand-rolled O(digits^2) render.
+num-bigint = "0.4"
 # Always-on: span macros (`tracing::info_span!`, `.instrument`) are used at the
 # binding boundary regardless of the `observability` feature. The OTel layer
 # that bridges these spans to OTLP is only composed when `observability` is on.

--- a/bindings/node/__test__/abort-safety.test.js
+++ b/bindings/node/__test__/abort-safety.test.js
@@ -26,19 +26,20 @@
  * (`test_abort_safety.py::test_uncompressed_...`), which does reach the
  * raw-parser panic through PyO3.
  *
- * WHY NO "uncompressed" (raw parse path) FLAVOR HERE (finding, verified
- * 2026-07-02): dropping CompressionInfo.db to reach the raw VInt/row parser
- * makes the Node process ABORT even under a DEBUG (`panic=unwind`) build with
+ * UNCOMPRESSED (raw parse path) FLAVOR — issue #1754. Dropping
+ * CompressionInfo.db reaches the raw VInt/row parser, where a corrupt DECIMAL
+ * `scale` used to ABORT the Node process even under a DEBUG (`panic=unwind`)
+ * build:
  *   thread '<unnamed>' panicked at bindings/node/src/value.rs:266
  *   fatal runtime error: failed to initiate panic, error 5, aborting
- * i.e. a panic in the Node binding's own decimal formatter (unbounded
- * `format!` padding width from a corrupt DECIMAL scale) on the napi async
- * worker thread, which cannot unwind across the FFI boundary. Because it
- * aborts under unwind too, #1440's panic profile alone will NOT fix the Node
- * path — it additionally needs `scale` bounded in value.rs and/or an explicit
- * catch_unwind at the napi boundary. Asserting survival on that flavor would
- * therefore be RED under the debug gate, so it is intentionally omitted and
- * reported as a follow-up rather than run as a known-red test.
+ * The panic came from the binding's own decimal formatter (unbounded `format!`
+ * padding width from the corrupt scale) on a napi async-worker thread, which
+ * cannot unwind across the FFI boundary — so #1440's panic profile alone did
+ * NOT fix it. Issue #1754 closes the gap with TWO fixes: (1) `decimal_to_string`
+ * bounds `scale`/unscaled magnitude fail-closed (typed corruption error), and
+ * (2) an explicit `catch_unwind` at each napi Task boundary turns any residual
+ * worker-thread panic into a typed JS error. This flavor now asserts survival
+ * (RED before #1754, GREEN after) rather than being omitted.
  *
  * DATASET GATING (never false-green): when the source Data.db is present these
  * tests actually run and assert. A BROKEN source (present but empty), or a
@@ -243,6 +244,22 @@ describe('Abort safety: corrupt SSTable must not kill the host (issue #1437)', (
       for (const entry of ['executeNative', 'streaming', 'parquet']) {
         testOrSkip(`survives ${mode} via ${entry}`, () => {
           runAndAssertSurvives(mode, entry, false);
+        });
+      }
+    }
+  });
+
+  // Issue #1754: the raw/uncompressed parse path (CompressionInfo.db dropped)
+  // reaches the corrupt-DECIMAL-scale panic in the binding's decimal formatter.
+  // Before #1754 this ABORTED the host process even under panic=unwind; the
+  // scale fail-closed bound + napi catch_unwind boundary now make every entry
+  // point survive with a caught/typed error. These were the exact scenarios the
+  // #1437 harness deferred as known-red.
+  describe('uncompressed raw parse path (issue #1754; corrupt DECIMAL scale)', () => {
+    for (const mode of MODES) {
+      for (const entry of ['executeNative', 'streaming', 'parquet']) {
+        testOrSkip(`survives ${mode} via ${entry} (raw)`, () => {
+          runAndAssertSurvives(mode, entry, true);
         });
       }
     }

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -1386,6 +1386,20 @@ impl napi::Task for ExecuteNativeTask {
     type JsValue = napi::JsObject;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        // Firewall the async-worker thread against a panic in the read/decode
+        // path (issue #1754): a panic here cannot unwind across the FFI frame and
+        // would abort the whole Node process even under `panic=unwind`. Catch it
+        // on the worker thread and reject the promise with a typed error instead.
+        crate::error::catch_unwind_to_napi("executeNative", || self.compute_inner())
+    }
+
+    fn resolve(&mut self, env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        self.resolve_inner(env, output)
+    }
+}
+
+impl ExecuteNativeTask {
+    fn compute_inner(&mut self) -> napi::Result<QueryResultData> {
         use tracing::Instrument;
 
         // Per-call span (issue #1040), parented under the handle's traceparent.
@@ -1467,7 +1481,11 @@ impl napi::Task for ExecuteNativeTask {
         })
     }
 
-    fn resolve(&mut self, env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+    fn resolve_inner(
+        &mut self,
+        env: napi::Env,
+        output: QueryResultData,
+    ) -> napi::Result<napi::JsObject> {
         let mut result_obj = env.create_object()?;
 
         // Create rows array with native types

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -220,6 +220,47 @@ pub fn simple_error(message: impl Into<String>) -> napi::Error {
     napi::Error::new(napi::Status::GenericFailure, formatted_message)
 }
 
+/// Run `f` on a napi async-worker thread and convert ANY panic it raises into a
+/// typed `napi::Error` rather than letting it abort the host process (issue
+/// #1754).
+///
+/// A `napi::Task::compute` body runs on a libuv threadpool thread that has NO
+/// unwind boundary above it. Even under the binding cdylib's `panic=unwind`
+/// profile (issue #1440), a panic there cannot unwind across the FFI frame — the
+/// Rust runtime instead calls `abort()` (`fatal runtime error: failed to
+/// initiate panic, error 5, aborting`), killing the whole Node process. Wrapping
+/// the worker body in [`std::panic::catch_unwind`] catches the panic ON the
+/// worker thread (before it reaches the un-unwindable FFI frame) and turns it
+/// into a rejected promise / thrown JS `Error`, preserving the abort-safety
+/// guarantee (#1431/#1440) for the raw-parse path.
+///
+/// The closure is wrapped in [`AssertUnwindSafe`] because the task state it
+/// borrows is not used again after a panic (the panic aborts the compute and the
+/// error is returned), so the standard unwind-safety concern (observing a
+/// broken invariant post-panic) does not apply here.
+pub fn catch_unwind_to_napi<T>(what: &str, f: impl FnOnce() -> napi::Result<T>) -> napi::Result<T> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => Err(to_napi_error(Error::corruption(format!(
+            "{what} panicked while decoding a corrupt SSTable: {} — recovered at the \
+             napi boundary instead of aborting the process (issue #1754)",
+            panic_message(&payload)
+        )))),
+    }
+}
+
+/// Best-effort extraction of a human-readable message from a caught panic
+/// payload (`&str` or `String`), falling back to a generic label.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/bindings/node/src/streaming.rs
+++ b/bindings/node/src/streaming.rs
@@ -177,6 +177,20 @@ impl napi::Task for NextTask {
     type JsValue = JsObject;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        // Firewall the async-worker thread against a decode panic (issue #1754):
+        // a panic on this libuv threadpool thread cannot unwind across the FFI
+        // frame and would abort the whole Node process even under `panic=unwind`.
+        // Catch it here and reject with a typed error instead.
+        crate::error::catch_unwind_to_napi("executeStreaming.next", || self.compute_inner())
+    }
+
+    fn resolve(&mut self, env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        self.resolve_impl(env, output)
+    }
+}
+
+impl NextTask {
+    fn compute_inner(&mut self) -> napi::Result<NextResult> {
         use tracing::Instrument;
 
         // Acquire lock - use unwrap_or_else to handle poisoned mutex by clearing the iterator
@@ -254,7 +268,7 @@ impl napi::Task for NextTask {
         }
     }
 
-    fn resolve(&mut self, env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+    fn resolve_impl(&mut self, env: Env, output: NextResult) -> napi::Result<JsObject> {
         let mut result = env.create_object()?;
 
         match output {

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -28,6 +28,7 @@
 //! | Tuple | `Array` |
 //! | Udt | `object` with `_type`, `_keyspace`, and field properties |
 
+use crate::error::to_napi_error;
 use cqlite_core::types::Value;
 use napi::{Env, JsFunction, JsObject, JsString, JsUnknown, Result};
 use std::cell::OnceCell;
@@ -218,7 +219,7 @@ pub fn value_to_napi(ctx: &ConvCtx, value: &Value) -> Result<JsUnknown> {
 
         // Decimal -> string (preserves arbitrary precision)
         Value::Decimal { scale, unscaled } => {
-            let decimal_str = decimal_to_string(*scale, unscaled);
+            let decimal_str = decimal_to_string(*scale, unscaled)?;
             env.create_string(&decimal_str).map(|s| s.into_unknown())
         }
 
@@ -319,13 +320,59 @@ fn varint_to_bigint(env: &Env, bytes: &[u8]) -> Result<JsUnknown> {
         .into_unknown()
 }
 
+/// Hard upper bound on the decimal digit-count this converter will materialize
+/// (issue #1754). Real Cassandra DECIMAL values are tiny; a padding width or
+/// unscaled magnitude beyond this only arises from a CORRUPT SSTable, where the
+/// scale/unscaled fields were read as garbage on the raw/uncompressed parse
+/// path. Rendering such a value would otherwise blow up an unbounded `format!`
+/// padding width (which PANICS with "Formatting argument out of range") or
+/// allocate a multi-hundred-megabyte string — and because the conversion runs on
+/// a napi async-worker thread, the panic cannot unwind across the FFI boundary
+/// and the runtime `abort()`s the whole host process (`fatal runtime error:
+/// failed to initiate panic, error 5, aborting`). Fail closed with a typed
+/// corruption error instead so the boundary surfaces a catchable JS error.
+///
+/// One million digits is orders of magnitude beyond any real decimal yet still a
+/// bounded allocation, so a legitimate value is never rejected.
+const DECIMAL_HARD_DIGIT_CAP: usize = 1_000_000;
+
 /// Convert decimal to string representation for arbitrary precision.
 ///
 /// Format: Represents the decimal as an exact string.
 /// For example: scale=2, unscaled=[1, 23] (123) -> "1.23"
-fn decimal_to_string(scale: i32, unscaled: &[u8]) -> String {
+///
+/// # Errors
+///
+/// Returns a typed corruption error (never panics/aborts) when `scale` or the
+/// unscaled magnitude is so large it could only come from a corrupt SSTable
+/// (issue #1754): rendering it would overflow an unbounded `format!` padding
+/// width (a panic that aborts the process on the napi worker thread) or allocate
+/// an unbounded string. Well-formed decimals are unaffected.
+fn decimal_to_string(scale: i32, unscaled: &[u8]) -> Result<String> {
     if unscaled.is_empty() {
-        return "0".to_string();
+        return Ok("0".to_string());
+    }
+
+    // Fail-closed guard (issue #1754). Bound BOTH inputs before any width-driven
+    // `format!` or `repeat`:
+    //   - the padding/scale magnitude (used directly as a `format!` width), and
+    //   - the unscaled magnitude's decimal digit count.
+    // A TIGHT upper bound on the digit count of an N-byte signed two's-complement
+    // integer is ceil((8N - 1) * log10(2)) — one bit is the sign, so the
+    // magnitude is at most 2^(8N-1). Compute the bit count in f64 so `8*len - 1`
+    // cannot underflow; the float->int `as` saturates in Rust, so the guard never
+    // wraps or under-counts an oversized value.
+    let magnitude_bits = 8.0 * (unscaled.len() as f64) - 1.0;
+    let max_digits = (magnitude_bits * std::f64::consts::LOG10_2).ceil().max(0.0) as usize;
+    if max_digits > DECIMAL_HARD_DIGIT_CAP
+        || (scale.unsigned_abs() as usize) > DECIMAL_HARD_DIGIT_CAP
+    {
+        return Err(to_napi_error(cqlite_core::Error::corruption(format!(
+            "DECIMAL cell not representable (scale={scale}, unscaled_len={} bytes, \
+             cap={DECIMAL_HARD_DIGIT_CAP} digits): corrupt SSTable — refusing to \
+             materialize an unbounded string (issue #1754)",
+            unscaled.len()
+        ))));
     }
 
     // Determine sign from high bit (two's complement)
@@ -392,9 +439,9 @@ fn decimal_to_string(scale: i32, unscaled: &[u8]) -> String {
     };
 
     if is_negative {
-        format!("-{result}")
+        Ok(format!("-{result}"))
     } else {
-        result
+        Ok(result)
     }
 }
 

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -320,26 +320,31 @@ fn varint_to_bigint(env: &Env, bytes: &[u8]) -> Result<JsUnknown> {
         .into_unknown()
 }
 
-/// Hard upper bound on the unscaled-magnitude byte length this converter will
+/// Sanity ceiling on the unscaled-magnitude byte length this converter will
 /// render (issue #1754). A Cassandra `decimal` unscaled value is a Java
-/// `BigInteger`; legitimate financial/scientific decimals carry at most a few
-/// dozen significant digits, so 1024 bytes — a magnitude up to `2^8191`, i.e. a
-/// ~2466-digit integer — is orders of magnitude beyond any real value and cannot
-/// reject one. It is, however, tight enough to bound the O(digits²)
-/// repeated-division renderer below: at the cap the render costs ~1.3M u32 ops
-/// (sub-millisecond), whereas the *old* 1M-digit cap (~415 KB of bytes) admitted
-/// magnitudes costing ~1e11 ops — a multi-second-to-minute freeze. Critically
-/// this converter runs via `row_to_object` on the JS event-loop resolve() thread
-/// (database.rs), NOT inside the catch_unwind-firewalled worker, so an oversized
-/// magnitude would freeze the Node event loop. Fail closed with a typed
-/// corruption error so the boundary surfaces a catchable JS error instead.
-const DECIMAL_MAX_UNSCALED_BYTES: usize = 1024;
+/// `BigInteger` — legitimately arbitrary-precision — so a merely-large value is
+/// NOT corrupt and must render faithfully. The only hard cost is the single
+/// `BigInt` → decimal-string base conversion (superlinear in digit count); a
+/// 32 KB magnitude (~79k digits) still converts in tens of milliseconds even in
+/// a debug build. Only a genuinely pathological magnitude beyond that could
+/// stall the JS event-loop resolve() thread (`row_to_object`, database.rs, NOT
+/// inside the catch_unwind-firewalled worker), so we fail closed with a typed
+/// corruption error ONLY above this ceiling.
+const DECIMAL_MAX_UNSCALED_BYTES: usize = 32 * 1024;
 
-/// Hard upper bound on `scale.abs()` (issue #1754). `scale` drives a `format!`
-/// padding width / leading-zero `repeat`; a corrupt absurd scale (e.g.
-/// `i32::MAX`) would panic with "Formatting argument out of range" or allocate
-/// an unbounded string. Padding up to a million zeros is linear and bounded;
-/// beyond that only a corrupt SSTable can reach, so fail closed.
+/// Byte-length threshold above which a well-formed magnitude is rendered in
+/// precision-preserving exponent form rather than an O(digits)-wide positional
+/// expansion (issue #1754). At/under 1024 bytes (~2466 digits) the positional
+/// render is cheap and byte-identical to the historical output; beyond it we
+/// emit `<digits>e<-scale>` (exact, bounded) to avoid superlinear padding work.
+const DECIMAL_POSITIONAL_MAX_BYTES: usize = 1024;
+
+/// Threshold on `scale.abs()` above which the value is rendered in exponent form
+/// instead of positional (issue #1754). `scale` would otherwise drive a
+/// `format!` padding width / leading-zero `repeat`; a huge scale (e.g.
+/// `i32::MAX`) would panic ("Formatting argument out of range") or allocate an
+/// unbounded string. Exponent form is exact and bounded, so no scale value is
+/// rejected — a well-formed decimal always renders.
 const DECIMAL_MAX_SCALE_DIGITS: usize = 1_000_000;
 
 /// Convert decimal to string representation for arbitrary precision.
@@ -349,96 +354,71 @@ const DECIMAL_MAX_SCALE_DIGITS: usize = 1_000_000;
 ///
 /// # Errors
 ///
-/// Returns a typed corruption error (never panics/aborts) when `scale` or the
-/// unscaled magnitude is so large it could only come from a corrupt SSTable
-/// (issue #1754): rendering it would overflow an unbounded `format!` padding
-/// width (a panic that aborts the process on the napi worker thread) or allocate
-/// an unbounded string. Well-formed decimals are unaffected.
+/// Returns a typed corruption error (never panics/aborts) ONLY when the unscaled
+/// magnitude exceeds the sanity ceiling — a size that could not come from a
+/// legitimate value and whose single base-10 conversion would stall the event
+/// loop (issue #1754). A merely-large-but-well-formed decimal is NOT corrupt: it
+/// renders faithfully in precision-preserving exponent form.
 fn decimal_to_string(scale: i32, unscaled: &[u8]) -> Result<String> {
     if unscaled.is_empty() {
         return Ok("0".to_string());
     }
 
-    // Fail-closed guard (issue #1754). Bound BOTH inputs BEFORE any rendering, so
-    // the O(digits²) repeated-division loop below never runs on an oversized
-    // magnitude and no width-driven `format!`/`repeat` can allocate unbounded:
-    //   - the unscaled-magnitude byte length (bounds the render cost), and
-    //   - the scale magnitude (used directly as a `format!` width / repeat count).
-    // Checking the raw byte length is O(1) and rejects long before the quadratic
-    // renderer is entered.
-    if unscaled.len() > DECIMAL_MAX_UNSCALED_BYTES
-        || (scale.unsigned_abs() as usize) > DECIMAL_MAX_SCALE_DIGITS
-    {
+    // Sanity ceiling (issue #1754): O(1) length check BEFORE the one superlinear
+    // base conversion. Only a genuinely pathological magnitude is rejected; a
+    // well-formed arbitrary-precision value renders below.
+    if unscaled.len() > DECIMAL_MAX_UNSCALED_BYTES {
         return Err(to_napi_error(cqlite_core::Error::corruption(format!(
             "DECIMAL cell not representable (scale={scale}, unscaled_len={} bytes, \
              max_unscaled={DECIMAL_MAX_UNSCALED_BYTES} bytes): corrupt SSTable — \
-             refusing to materialize an unbounded string / enter an O(n^2) render \
+             refusing to enter a superlinear render on a pathological magnitude \
              (issue #1754)",
             unscaled.len()
         ))));
     }
 
-    // Determine sign from high bit (two's complement)
-    let is_negative = (unscaled[0] & 0x80) != 0;
+    // Cassandra encodes the unscaled value as a two's-complement big-endian Java
+    // BigInteger. ONE base-10 conversion (the sole superlinear step) yields the
+    // digit string; every branch below is a single O(digits) pass over it — no
+    // repeated division, no scale-width padding blowup.
+    let bigint = num_bigint::BigInt::from_signed_bytes_be(unscaled);
+    let full = bigint.to_string();
+    let (is_negative, digits) = match full.strip_prefix('-') {
+        Some(rest) => (true, rest.to_string()),
+        None => (false, full),
+    };
 
-    // Convert bytes to absolute magnitude
-    let mut magnitude = unscaled.to_vec();
-    if is_negative {
-        // Two's complement negation
-        let mut carry = true;
-        for byte in magnitude.iter_mut().rev() {
-            *byte = !*byte;
-            if carry {
-                let (new_val, new_carry) = byte.overflowing_add(1);
-                *byte = new_val;
-                carry = new_carry;
-            }
+    // Precision-preserving exponent form for over-bound cases (issue #1754): a
+    // large magnitude (thousands+ of digits) or a pathological scale (which as a
+    // padding width would panic / allocate unbounded, and at `i32::MIN` would
+    // overflow `-scale`). `<digits>e<-scale>` preserves every digit exactly.
+    let result = if unscaled.len() > DECIMAL_POSITIONAL_MAX_BYTES
+        || (scale.unsigned_abs() as usize) > DECIMAL_MAX_SCALE_DIGITS
+    {
+        if scale == 0 {
+            digits
+        } else {
+            // `i64` avoids the `(-scale)` overflow at `scale == i32::MIN`.
+            format!("{digits}e{}", -(scale as i64))
         }
-    }
-
-    // Convert bytes to decimal string using repeated division
-    let mut digits = String::new();
-    while !magnitude.is_empty() && magnitude.iter().any(|&b| b != 0) {
-        let mut remainder = 0u32;
-        for byte in &mut magnitude {
-            let dividend = remainder * 256 + (*byte as u32);
-            *byte = (dividend / 10) as u8;
-            remainder = dividend % 10;
-        }
-        digits.push(char::from_digit(remainder, 10).unwrap());
-        // Remove leading zeros from magnitude
-        while magnitude.first() == Some(&0) {
-            magnitude.remove(0);
-        }
-    }
-
-    if digits.is_empty() {
-        digits = "0".to_string();
-    } else {
-        // Reverse since we built it backwards
-        digits = digits.chars().rev().collect();
-    }
-
-    // Apply scale
-    let result = if scale == 0 {
+    } else if scale == 0 {
         digits
     } else if scale > 0 {
-        // Positive scale means decimal point moves left
+        // Positive scale means decimal point moves left.
         let scale_usize = scale as usize;
         if digits.len() <= scale_usize {
             // Need leading zeros: 123 with scale 5 -> 0.00123
             format!("0.{digits:0>scale_usize$}")
         } else {
-            // Insert decimal point
+            // Insert decimal point.
             let split_point = digits.len() - scale_usize;
             let int_part = &digits[..split_point];
             let frac_part = &digits[split_point..];
             format!("{int_part}.{frac_part}")
         }
     } else {
-        // Negative scale means multiply by power of 10
-        let neg_scale = -scale;
-        format!("{digits}e{neg_scale}")
+        // Negative scale means multiply by power of 10.
+        format!("{digits}e{}", -scale)
     };
 
     if is_negative {

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -320,21 +320,27 @@ fn varint_to_bigint(env: &Env, bytes: &[u8]) -> Result<JsUnknown> {
         .into_unknown()
 }
 
-/// Hard upper bound on the decimal digit-count this converter will materialize
-/// (issue #1754). Real Cassandra DECIMAL values are tiny; a padding width or
-/// unscaled magnitude beyond this only arises from a CORRUPT SSTable, where the
-/// scale/unscaled fields were read as garbage on the raw/uncompressed parse
-/// path. Rendering such a value would otherwise blow up an unbounded `format!`
-/// padding width (which PANICS with "Formatting argument out of range") or
-/// allocate a multi-hundred-megabyte string — and because the conversion runs on
-/// a napi async-worker thread, the panic cannot unwind across the FFI boundary
-/// and the runtime `abort()`s the whole host process (`fatal runtime error:
-/// failed to initiate panic, error 5, aborting`). Fail closed with a typed
-/// corruption error instead so the boundary surfaces a catchable JS error.
-///
-/// One million digits is orders of magnitude beyond any real decimal yet still a
-/// bounded allocation, so a legitimate value is never rejected.
-const DECIMAL_HARD_DIGIT_CAP: usize = 1_000_000;
+/// Hard upper bound on the unscaled-magnitude byte length this converter will
+/// render (issue #1754). A Cassandra `decimal` unscaled value is a Java
+/// `BigInteger`; legitimate financial/scientific decimals carry at most a few
+/// dozen significant digits, so 1024 bytes — a magnitude up to `2^8191`, i.e. a
+/// ~2466-digit integer — is orders of magnitude beyond any real value and cannot
+/// reject one. It is, however, tight enough to bound the O(digits²)
+/// repeated-division renderer below: at the cap the render costs ~1.3M u32 ops
+/// (sub-millisecond), whereas the *old* 1M-digit cap (~415 KB of bytes) admitted
+/// magnitudes costing ~1e11 ops — a multi-second-to-minute freeze. Critically
+/// this converter runs via `row_to_object` on the JS event-loop resolve() thread
+/// (database.rs), NOT inside the catch_unwind-firewalled worker, so an oversized
+/// magnitude would freeze the Node event loop. Fail closed with a typed
+/// corruption error so the boundary surfaces a catchable JS error instead.
+const DECIMAL_MAX_UNSCALED_BYTES: usize = 1024;
+
+/// Hard upper bound on `scale.abs()` (issue #1754). `scale` drives a `format!`
+/// padding width / leading-zero `repeat`; a corrupt absurd scale (e.g.
+/// `i32::MAX`) would panic with "Formatting argument out of range" or allocate
+/// an unbounded string. Padding up to a million zeros is linear and bounded;
+/// beyond that only a corrupt SSTable can reach, so fail closed.
+const DECIMAL_MAX_SCALE_DIGITS: usize = 1_000_000;
 
 /// Convert decimal to string representation for arbitrary precision.
 ///
@@ -353,24 +359,21 @@ fn decimal_to_string(scale: i32, unscaled: &[u8]) -> Result<String> {
         return Ok("0".to_string());
     }
 
-    // Fail-closed guard (issue #1754). Bound BOTH inputs before any width-driven
-    // `format!` or `repeat`:
-    //   - the padding/scale magnitude (used directly as a `format!` width), and
-    //   - the unscaled magnitude's decimal digit count.
-    // A TIGHT upper bound on the digit count of an N-byte signed two's-complement
-    // integer is ceil((8N - 1) * log10(2)) — one bit is the sign, so the
-    // magnitude is at most 2^(8N-1). Compute the bit count in f64 so `8*len - 1`
-    // cannot underflow; the float->int `as` saturates in Rust, so the guard never
-    // wraps or under-counts an oversized value.
-    let magnitude_bits = 8.0 * (unscaled.len() as f64) - 1.0;
-    let max_digits = (magnitude_bits * std::f64::consts::LOG10_2).ceil().max(0.0) as usize;
-    if max_digits > DECIMAL_HARD_DIGIT_CAP
-        || (scale.unsigned_abs() as usize) > DECIMAL_HARD_DIGIT_CAP
+    // Fail-closed guard (issue #1754). Bound BOTH inputs BEFORE any rendering, so
+    // the O(digits²) repeated-division loop below never runs on an oversized
+    // magnitude and no width-driven `format!`/`repeat` can allocate unbounded:
+    //   - the unscaled-magnitude byte length (bounds the render cost), and
+    //   - the scale magnitude (used directly as a `format!` width / repeat count).
+    // Checking the raw byte length is O(1) and rejects long before the quadratic
+    // renderer is entered.
+    if unscaled.len() > DECIMAL_MAX_UNSCALED_BYTES
+        || (scale.unsigned_abs() as usize) > DECIMAL_MAX_SCALE_DIGITS
     {
         return Err(to_napi_error(cqlite_core::Error::corruption(format!(
             "DECIMAL cell not representable (scale={scale}, unscaled_len={} bytes, \
-             cap={DECIMAL_HARD_DIGIT_CAP} digits): corrupt SSTable — refusing to \
-             materialize an unbounded string (issue #1754)",
+             max_unscaled={DECIMAL_MAX_UNSCALED_BYTES} bytes): corrupt SSTable — \
+             refusing to materialize an unbounded string / enter an O(n^2) render \
+             (issue #1754)",
             unscaled.len()
         ))));
     }

--- a/bindings/node/src/value_tests.rs
+++ b/bindings/node/src/value_tests.rs
@@ -18,33 +18,33 @@ static CTOR_COUNTER_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
 fn test_decimal_to_string_positive() {
     // 123 with scale 2 = 1.23
     let unscaled = vec![123];
-    assert_eq!(decimal_to_string(2, &unscaled), "1.23");
+    assert_eq!(decimal_to_string(2, &unscaled).unwrap(), "1.23");
 }
 
 #[test]
 fn test_decimal_to_string_no_scale() {
     // 123 with scale 0 = 123
     let unscaled = vec![123];
-    assert_eq!(decimal_to_string(0, &unscaled), "123");
+    assert_eq!(decimal_to_string(0, &unscaled).unwrap(), "123");
 }
 
 #[test]
 fn test_decimal_to_string_negative_scale() {
     // 123 with scale -2 = 12300 (123e2)
     let unscaled = vec![123];
-    assert_eq!(decimal_to_string(-2, &unscaled), "123e2");
+    assert_eq!(decimal_to_string(-2, &unscaled).unwrap(), "123e2");
 }
 
 #[test]
 fn test_decimal_to_string_large_scale() {
     // 123 with scale 5 = 0.00123
     let unscaled = vec![123];
-    assert_eq!(decimal_to_string(5, &unscaled), "0.00123");
+    assert_eq!(decimal_to_string(5, &unscaled).unwrap(), "0.00123");
 }
 
 #[test]
 fn test_decimal_to_string_empty() {
-    assert_eq!(decimal_to_string(0, &[]), "0");
+    assert_eq!(decimal_to_string(0, &[]).unwrap(), "0");
 }
 
 #[test]
@@ -52,7 +52,59 @@ fn test_decimal_to_string_negative() {
     // -123 in two's complement (single byte) = 0x85 = 133, but need proper encoding
     // For -123: 256 - 123 = 133 = 0x85
     let unscaled = vec![0x85]; // -123 as two's complement byte
-    assert_eq!(decimal_to_string(2, &unscaled), "-1.23");
+    assert_eq!(decimal_to_string(2, &unscaled).unwrap(), "-1.23");
+}
+
+/// Issue #1754: a pathological positive `scale` (used directly as an unbounded
+/// `format!` padding width) must fail closed with a typed error rather than
+/// PANIC ("Formatting argument out of range"). On the napi async-worker thread
+/// that panic cannot unwind across FFI and the process `abort()`s, defeating
+/// #1440's `panic=unwind` profile. This is the direct Rust reproduction of the
+/// corrupt-DECIMAL abort; it PANICS on the pre-fix code and returns `Err` now.
+#[test]
+fn test_decimal_to_string_pathological_positive_scale_errors_not_panics() {
+    // A tiny 1-byte unscaled value but an absurd scale that would drive a
+    // ~2.1-billion-wide `format!("0.{digits:0>width$}")` padding.
+    let unscaled = vec![0x01];
+    let err = decimal_to_string(i32::MAX, &unscaled)
+        .expect_err("a pathological scale must fail closed, not panic/abort");
+    let msg = err.reason.to_string();
+    assert!(
+        msg.contains("corrupt SSTable") && msg.contains("issue #1754"),
+        "expected a typed corruption error, got: {msg}"
+    );
+}
+
+/// Issue #1754: `scale == i32::MIN` exercises `unsigned_abs()` (a plain
+/// `-scale` would overflow-panic under `overflow-checks`). Still fail-closed,
+/// never a panic.
+#[test]
+fn test_decimal_to_string_i32_min_scale_errors_not_panics() {
+    let unscaled = vec![0x01];
+    let err = decimal_to_string(i32::MIN, &unscaled)
+        .expect_err("i32::MIN scale must fail closed without overflow panic");
+    assert!(err.reason.to_string().contains("issue #1754"));
+}
+
+/// Issue #1754: an oversized unscaled magnitude (digit count beyond the cap)
+/// also fails closed rather than allocating an unbounded string.
+#[test]
+fn test_decimal_to_string_oversized_unscaled_errors() {
+    // ~1 MB of unscaled bytes → ~2.4M decimal digits, above the 1M cap.
+    let unscaled = vec![0x7f; 1_000_000];
+    let err = decimal_to_string(0, &unscaled)
+        .expect_err("an oversized unscaled magnitude must fail closed");
+    assert!(err.reason.to_string().contains("issue #1754"));
+}
+
+/// Regression guard: a large-but-representable scale at the boundary still
+/// renders (the guard must not over-reject a legitimate value).
+#[test]
+fn test_decimal_to_string_large_representable_scale_ok() {
+    let unscaled = vec![0x01]; // = 1
+                               // scale 100 → "0." followed by 99 zeros then "1".
+    let s = decimal_to_string(100, &unscaled).unwrap();
+    assert!(s.starts_with("0.0") && s.ends_with('1') && s.len() == 102);
 }
 
 #[test]

--- a/bindings/node/src/value_tests.rs
+++ b/bindings/node/src/value_tests.rs
@@ -55,70 +55,81 @@ fn test_decimal_to_string_negative() {
     assert_eq!(decimal_to_string(2, &unscaled).unwrap(), "-1.23");
 }
 
-/// Issue #1754: a pathological positive `scale` (used directly as an unbounded
-/// `format!` padding width) must fail closed with a typed error rather than
-/// PANIC ("Formatting argument out of range"). On the napi async-worker thread
-/// that panic cannot unwind across FFI and the process `abort()`s, defeating
-/// #1440's `panic=unwind` profile. This is the direct Rust reproduction of the
-/// corrupt-DECIMAL abort; it PANICS on the pre-fix code and returns `Err` now.
+/// Issue #1754: a huge positive `scale` used to drive an unbounded `format!`
+/// padding width (PANIC "Formatting argument out of range" → napi worker abort).
+/// It is NOT corrupt — scale is just the decimal exponent — so it now renders
+/// faithfully in precision-preserving exponent form, never panicking. A tiny
+/// unscaled value (1) with scale `i32::MAX` → `1e-2147483647`.
 #[test]
-fn test_decimal_to_string_pathological_positive_scale_errors_not_panics() {
-    // A tiny 1-byte unscaled value but an absurd scale that would drive a
-    // ~2.1-billion-wide `format!("0.{digits:0>width$}")` padding.
+fn test_decimal_to_string_pathological_positive_scale_renders_exponent_form() {
     let unscaled = vec![0x01];
-    let err = decimal_to_string(i32::MAX, &unscaled)
-        .expect_err("a pathological scale must fail closed, not panic/abort");
-    let msg = err.reason.to_string();
+    let s = decimal_to_string(i32::MAX, &unscaled)
+        .expect("a huge scale must render faithfully, not panic/abort");
+    assert_eq!(s, format!("1e{}", -(i32::MAX as i64)));
+}
+
+/// Issue #1754: `scale == i32::MIN` exercises the `-(scale as i64)` widening (a
+/// plain `-scale` would overflow-panic under `overflow-checks`). Renders exact
+/// exponent form, never a panic.
+#[test]
+fn test_decimal_to_string_i32_min_scale_renders_exponent_form() {
+    let unscaled = vec![0x01];
+    let s = decimal_to_string(i32::MIN, &unscaled)
+        .expect("i32::MIN scale must render without overflow panic");
+    assert_eq!(s, format!("1e{}", -(i32::MIN as i64)));
+}
+
+/// Issue #1754: a genuinely pathological unscaled magnitude beyond the sanity
+/// ceiling still fails closed rather than stalling the event loop. ~1 MB of
+/// unscaled bytes is far above the 32 KB ceiling.
+#[test]
+fn test_decimal_to_string_beyond_ceiling_errors() {
+    let unscaled = vec![0x7f; 1_000_000];
+    let err = decimal_to_string(0, &unscaled)
+        .expect_err("a magnitude beyond the ceiling must fail closed");
+    assert!(err.reason.to_string().contains("issue #1754"));
+}
+
+/// Issue #1754 (follow-up correctness fix): a large-but-WELL-FORMED unscaled
+/// magnitude (thousands of digits — over the 1024-byte positional threshold but
+/// within the sanity ceiling) must render FAITHFULLY (precision-preserving
+/// exponent form) and FAST via the single `BigInt` base conversion — NOT be
+/// misclassified as corruption. A 2 KB magnitude (~4933 digits) exercises this.
+#[test]
+fn test_decimal_to_string_large_valid_renders_faithfully_fast() {
+    // 0x7f keeps the high bit clear (large POSITIVE value; all-0xff = -1).
+    let unscaled = vec![0x7f; 2048];
+    let start = std::time::Instant::now();
+    let s = decimal_to_string(2, &unscaled)
+        .expect("a well-formed large decimal must render, not error");
+    let elapsed = start.elapsed();
+    // Exponent form: all significant digits + "e-2". Every digit preserved.
+    let digits = s.strip_suffix("e-2").expect("expected exponent form");
     assert!(
-        msg.contains("corrupt SSTable") && msg.contains("issue #1754"),
-        "expected a typed corruption error, got: {msg}"
+        digits.len() >= 4900 && digits.chars().all(|c| c.is_ascii_digit()),
+        "expected full precision-preserving digit string, got {} chars",
+        digits.len()
+    );
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "expected fast single-conversion render, took {elapsed:?}"
     );
 }
 
-/// Issue #1754: `scale == i32::MIN` exercises `unsigned_abs()` (a plain
-/// `-scale` would overflow-panic under `overflow-checks`). Still fail-closed,
-/// never a panic.
+/// Issue #1754: a ~415 KB magnitude (~1M digits) is beyond any realistic value
+/// and beyond the sanity ceiling; it fails closed FAST via the O(1) length
+/// check, before the superlinear base conversion.
 #[test]
-fn test_decimal_to_string_i32_min_scale_errors_not_panics() {
-    let unscaled = vec![0x01];
-    let err = decimal_to_string(i32::MIN, &unscaled)
-        .expect_err("i32::MIN scale must fail closed without overflow panic");
-    assert!(err.reason.to_string().contains("issue #1754"));
-}
-
-/// Issue #1754: an oversized unscaled magnitude (byte length beyond the cap)
-/// also fails closed rather than allocating an unbounded string.
-#[test]
-fn test_decimal_to_string_oversized_unscaled_errors() {
-    // ~1 MB of unscaled bytes, far above the 1024-byte cap.
-    let unscaled = vec![0x7f; 1_000_000];
-    let err = decimal_to_string(0, &unscaled)
-        .expect_err("an oversized unscaled magnitude must fail closed");
-    assert!(err.reason.to_string().contains("issue #1754"));
-}
-
-/// Issue #1754 (follow-up liveness fix): a ~415 KB unscaled magnitude PASSED the
-/// old 1M-digit cap yet drives the O(digits²) repeated-division renderer to
-/// ~1e11 u32 ops — a multi-second-to-minute freeze on the JS event-loop
-/// resolve() thread. The tightened byte-length bound must reject it FAST (an
-/// O(1) length check, before any render). We assert both the typed error AND
-/// that it completes near-instantly, which is only possible if the bound rejects
-/// before entering the quadratic loop.
-#[test]
-fn test_decimal_to_string_near_old_cap_rejected_fast_no_quadratic_render() {
-    // 415 KB → ~1M decimal digits: under the OLD 1M-digit cap, over the new
-    // 1024-byte cap. The old renderer would burn ~1e11 ops here.
+fn test_decimal_to_string_beyond_ceiling_rejected_fast() {
     let unscaled = vec![0xff; 415_000];
     let start = std::time::Instant::now();
     let err = decimal_to_string(0, &unscaled)
-        .expect_err("a magnitude above the byte cap must fail closed");
+        .expect_err("a magnitude beyond the ceiling must fail closed");
     let elapsed = start.elapsed();
     assert!(err.reason.to_string().contains("issue #1754"));
-    // The quadratic render on this input takes seconds+; an O(1) bound check is
-    // sub-millisecond. A generous ceiling still proves the loop was never entered.
     assert!(
         elapsed < std::time::Duration::from_millis(500),
-        "expected fast O(1) rejection, took {elapsed:?} — the O(n^2) renderer ran"
+        "expected fast O(1) rejection, took {elapsed:?} — the base conversion ran"
     );
 }
 

--- a/bindings/node/src/value_tests.rs
+++ b/bindings/node/src/value_tests.rs
@@ -86,15 +86,40 @@ fn test_decimal_to_string_i32_min_scale_errors_not_panics() {
     assert!(err.reason.to_string().contains("issue #1754"));
 }
 
-/// Issue #1754: an oversized unscaled magnitude (digit count beyond the cap)
+/// Issue #1754: an oversized unscaled magnitude (byte length beyond the cap)
 /// also fails closed rather than allocating an unbounded string.
 #[test]
 fn test_decimal_to_string_oversized_unscaled_errors() {
-    // ~1 MB of unscaled bytes → ~2.4M decimal digits, above the 1M cap.
+    // ~1 MB of unscaled bytes, far above the 1024-byte cap.
     let unscaled = vec![0x7f; 1_000_000];
     let err = decimal_to_string(0, &unscaled)
         .expect_err("an oversized unscaled magnitude must fail closed");
     assert!(err.reason.to_string().contains("issue #1754"));
+}
+
+/// Issue #1754 (follow-up liveness fix): a ~415 KB unscaled magnitude PASSED the
+/// old 1M-digit cap yet drives the O(digits²) repeated-division renderer to
+/// ~1e11 u32 ops — a multi-second-to-minute freeze on the JS event-loop
+/// resolve() thread. The tightened byte-length bound must reject it FAST (an
+/// O(1) length check, before any render). We assert both the typed error AND
+/// that it completes near-instantly, which is only possible if the bound rejects
+/// before entering the quadratic loop.
+#[test]
+fn test_decimal_to_string_near_old_cap_rejected_fast_no_quadratic_render() {
+    // 415 KB → ~1M decimal digits: under the OLD 1M-digit cap, over the new
+    // 1024-byte cap. The old renderer would burn ~1e11 ops here.
+    let unscaled = vec![0xff; 415_000];
+    let start = std::time::Instant::now();
+    let err = decimal_to_string(0, &unscaled)
+        .expect_err("a magnitude above the byte cap must fail closed");
+    let elapsed = start.elapsed();
+    assert!(err.reason.to_string().contains("issue #1754"));
+    // The quadratic render on this input takes seconds+; an O(1) bound check is
+    // sub-millisecond. A generous ceiling still proves the loop was never entered.
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "expected fast O(1) rejection, took {elapsed:?} — the O(n^2) renderer ran"
+    );
 }
 
 /// Regression guard: a large-but-representable scale at the boundary still

--- a/cqlite-core/src/util/value_fmt.rs
+++ b/cqlite-core/src/util/value_fmt.rs
@@ -287,17 +287,16 @@ impl ValueFormatter {
             return "0".to_string();
         }
 
-        // Fail-closed bound (issue #1754), kept consistent with the Node binding's
+        // Sanity ceiling (issue #1754), kept consistent with the Node binding's
         // `decimal_to_string`. A Cassandra `decimal` unscaled value is a Java
-        // BigInteger; legitimate financial/scientific decimals carry at most a few
-        // dozen significant digits, so a 1024-byte magnitude (up to ~2466 decimal
-        // digits) is orders of magnitude beyond any real value and cannot reject
-        // one. An oversized magnitude only arises from a corrupt SSTable and would
-        // otherwise cost a `BigInt::from_*_bytes` + `to_string` base conversion
-        // that is superlinear in the byte length. Render a bounded, exact hex
-        // fallback WITHOUT the expensive decimal conversion. Infallible signature:
-        // this stays total (never panics).
-        const DECIMAL_MAX_UNSCALED_BYTES: usize = 1024;
+        // BigInteger, so it is legitimately arbitrary-precision; we must NOT call a
+        // merely-large-but-well-formed value "corrupt". The only hard cost is the
+        // single `BigInt` → decimal-string base conversion, which is superlinear in
+        // the digit count. A 32 KB magnitude (~79k decimal digits) still converts
+        // in tens of milliseconds; only a genuinely pathological magnitude beyond
+        // that could stall a render, so fail closed ONLY above the ceiling.
+        // Infallible signature: this stays total (never panics).
+        const DECIMAL_MAX_UNSCALED_BYTES: usize = 32 * 1024;
         if unscaled.len() > DECIMAL_MAX_UNSCALED_BYTES {
             return format!(
                 "<corrupt-decimal:scale={scale},unscaled_len={}bytes>",
@@ -305,40 +304,44 @@ impl ValueFormatter {
             );
         }
 
-        // Convert unscaled bytes to bigint
-        let is_negative = (unscaled[0] & 0x80) != 0;
-        let bigint = if is_negative {
-            // Two's complement for negative
-            num_bigint::BigInt::from_signed_bytes_be(unscaled)
-        } else {
-            num_bigint::BigInt::from_bytes_be(num_bigint::Sign::Plus, unscaled)
-        };
-
+        // Convert the unscaled bytes to a BigInt. Cassandra encodes the unscaled
+        // value as a two's-complement big-endian BigInteger, which is exactly what
+        // `from_signed_bytes_be` decodes (positive when the high bit is clear).
+        let bigint = num_bigint::BigInt::from_signed_bytes_be(unscaled);
+        // ONE base-10 conversion — the sole superlinear step; every branch below is
+        // a single O(digits) pass over the resulting string (no repeated division,
+        // no scale-width padding blowup).
         let mut decimal_str = bigint.to_string();
         let is_neg = decimal_str.starts_with('-');
         if is_neg {
             decimal_str = decimal_str[1..].to_string();
         }
 
-        // Fail-closed guard (issue #1754). A corrupt SSTable can carry a
-        // pathological DECIMAL `scale`; used below as a `String::repeat` count or
-        // `format!` padding it would allocate an unbounded string (and `(-scale)`
-        // would overflow-panic at `scale == i32::MIN`). Real decimals are tiny, so
-        // an absurd scale is rendered in scientific-ish form rather than
-        // materializing millions of zero characters. `unsigned_abs()` avoids the
-        // negation overflow. This keeps display total (never panics/aborts) while
-        // leaving every legitimate value byte-identical.
+        // Faithful, bounded exponent form for over-bound cases (issue #1754). Two
+        // triggers, both of which would otherwise require an O(digits)-wide
+        // positional expansion:
+        //   - a large-but-valid unscaled magnitude (thousands+ of digits), and
+        //   - a pathological `scale` used as a `repeat`/padding width (which at
+        //     `scale == i32::MIN` would also overflow `(-scale)`).
+        // Rendering `<digits>e<-scale>` (value = unscaled × 10^(−scale)) preserves
+        // EVERY digit exactly with no unbounded padding. Legitimate, normal-size
+        // decimals fall through to the byte-identical positional form below.
+        const DECIMAL_POSITIONAL_MAX_BYTES: usize = 1024;
         const SCALE_RENDER_CAP: usize = 1_000_000;
-        if scale.unsigned_abs() as usize > SCALE_RENDER_CAP {
-            // Represent as "<digits>e<-scale>" (or "e<scale>" for large positive
-            // scale): exact and bounded, no unbounded padding.
-            let exp = -(scale as i64);
+        if unscaled.len() > DECIMAL_POSITIONAL_MAX_BYTES
+            || scale.unsigned_abs() as usize > SCALE_RENDER_CAP
+        {
             let body = if is_neg {
                 format!("-{decimal_str}")
             } else {
                 decimal_str
             };
-            return format!("{body}e{exp}");
+            // `unsigned_abs()`/`i64` avoid the `(-scale)` overflow at `i32::MIN`.
+            return if scale == 0 {
+                body
+            } else {
+                format!("{body}e{}", -(scale as i64))
+            };
         }
 
         // Insert decimal point based on scale
@@ -790,20 +793,56 @@ mod tests {
         );
     }
 
-    /// Issue #1754 (follow-up liveness fix): an oversized unscaled magnitude
-    /// (byte length beyond the 1024-byte cap) must be rejected FAST via the O(1)
-    /// length check, WITHOUT the superlinear `BigInt` base conversion, and must
-    /// stay total (never panics — infallible signature). A ~415 KB magnitude
-    /// (well under the old digit-oriented cap) exercises this.
+    /// Issue #1754 (follow-up correctness fix): a large-but-WELL-FORMED unscaled
+    /// magnitude (thousands of digits, above the 1024-byte positional threshold
+    /// but within the sanity ceiling) must render FAITHFULLY (precision-preserving
+    /// exponent form) and FAST — NOT be misclassified as corruption. This is the
+    /// behavior the owner mandated: an arbitrary-precision BigInteger value is not
+    /// corrupt just for being big.
     #[test]
-    fn test_decimal_oversized_unscaled_bounded_fast() {
+    fn test_decimal_large_valid_renders_faithfully_fast() {
+        // 2 KB magnitude (~4930 decimal digits): over the positional threshold,
+        // under the ceiling. 0x7f keeps the high bit clear (a large POSITIVE
+        // value; all-0xff would be two's-complement -1). Scale 4 → ×10^-4.
+        let unscaled = vec![0x7fu8; 2048];
+        let start = std::time::Instant::now();
+        let s = ValueFormatter::format_value(&Value::Decimal { scale: 4, unscaled });
+        let elapsed = start.elapsed();
+        assert!(
+            !s.starts_with("<corrupt-decimal:"),
+            "a well-formed large decimal must not be called corrupt: {s}"
+        );
+        // Precision-preserving exponent form: all significant digits + "e-4".
+        assert!(
+            s.ends_with("e-4"),
+            "expected exponent form, got: {}",
+            &s[..40]
+        );
+        let digits = s.trim_end_matches("e-4");
+        // 2 KB of 0xff is a ~4933-digit integer — every digit is preserved.
+        assert!(
+            digits.len() >= 4900 && digits.chars().all(|c| c.is_ascii_digit()),
+            "expected full digit string, got {} chars",
+            digits.len()
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "expected fast single-conversion render, took {elapsed:?}"
+        );
+    }
+
+    /// Issue #1754: a genuinely pathological magnitude beyond the sanity ceiling
+    /// still fails closed FAST (O(1) length check), without the superlinear
+    /// `BigInt` base conversion. A ~415 KB magnitude exercises this.
+    #[test]
+    fn test_decimal_beyond_ceiling_bounded_fast() {
         let unscaled = vec![0xffu8; 415_000];
         let start = std::time::Instant::now();
         let s = ValueFormatter::format_value(&Value::Decimal { scale: 0, unscaled });
         let elapsed = start.elapsed();
         assert!(
             s.starts_with("<corrupt-decimal:"),
-            "oversized magnitude renders the bounded fallback: {s}"
+            "beyond-ceiling magnitude renders the bounded fallback: {s}"
         );
         assert!(
             elapsed < std::time::Duration::from_millis(500),

--- a/cqlite-core/src/util/value_fmt.rs
+++ b/cqlite-core/src/util/value_fmt.rs
@@ -302,10 +302,32 @@ impl ValueFormatter {
             decimal_str = decimal_str[1..].to_string();
         }
 
+        // Fail-closed guard (issue #1754). A corrupt SSTable can carry a
+        // pathological DECIMAL `scale`; used below as a `String::repeat` count or
+        // `format!` padding it would allocate an unbounded string (and `(-scale)`
+        // would overflow-panic at `scale == i32::MIN`). Real decimals are tiny, so
+        // an absurd scale is rendered in scientific-ish form rather than
+        // materializing millions of zero characters. `unsigned_abs()` avoids the
+        // negation overflow. This keeps display total (never panics/aborts) while
+        // leaving every legitimate value byte-identical.
+        const SCALE_RENDER_CAP: usize = 1_000_000;
+        if scale.unsigned_abs() as usize > SCALE_RENDER_CAP {
+            // Represent as "<digits>e<-scale>" (or "e<scale>" for large positive
+            // scale): exact and bounded, no unbounded padding.
+            let exp = -(scale as i64);
+            let body = if is_neg {
+                format!("-{decimal_str}")
+            } else {
+                decimal_str
+            };
+            return format!("{body}e{exp}");
+        }
+
         // Insert decimal point based on scale
         if scale <= 0 {
-            // Scale <= 0: multiply by 10^(-scale)
-            decimal_str.push_str(&"0".repeat((-scale) as usize));
+            // Scale <= 0: multiply by 10^(-scale). `unsigned_abs()` avoids the
+            // `(-scale)` overflow panic at `scale == i32::MIN`.
+            decimal_str.push_str(&"0".repeat(scale.unsigned_abs() as usize));
         } else if scale as usize >= decimal_str.len() {
             // Need leading zeros
             let leading_zeros = scale as usize - decimal_str.len() + 1;
@@ -714,6 +736,56 @@ mod tests {
         let formatted = ValueFormatter::format_value(&decimal);
         // Should contain decimal point
         assert!(formatted.contains('.'));
+    }
+
+    /// Issue #1754: a corrupt SSTable can carry a pathological DECIMAL `scale`.
+    /// `scale == i32::MIN` used to overflow-panic at `(-scale) as usize` (and
+    /// under `overflow-checks` in debug builds), and a huge positive/negative
+    /// scale would allocate an unbounded string. Formatting must stay total —
+    /// never panic — and render bounded output instead.
+    #[test]
+    fn test_decimal_pathological_scale_is_bounded_not_panic() {
+        // i32::MIN scale: the negation-overflow reproducer.
+        let d_min = Value::Decimal {
+            scale: i32::MIN,
+            unscaled: vec![0x01],
+        };
+        let s = ValueFormatter::format_value(&d_min);
+        assert!(
+            s.contains('e'),
+            "extreme scale renders in exponent form: {s}"
+        );
+        assert!(
+            s.len() < 64,
+            "must not materialize an unbounded string: {s}"
+        );
+
+        // Huge positive scale: no multi-hundred-megabyte padding allocation.
+        let d_max = Value::Decimal {
+            scale: i32::MAX,
+            unscaled: vec![0x01],
+        };
+        let s2 = ValueFormatter::format_value(&d_max);
+        assert!(
+            s2.len() < 64,
+            "must not materialize an unbounded string: {s2}"
+        );
+    }
+
+    /// Regression guard: an ordinary in-range scale is byte-identical after the
+    /// #1754 bound (no behavior change for legitimate decimals).
+    #[test]
+    fn test_decimal_in_range_scale_unchanged() {
+        let d = Value::Decimal {
+            scale: 5,
+            unscaled: vec![0x7B], // 123
+        };
+        assert_eq!(ValueFormatter::format_value(&d), "0.00123");
+        let dn = Value::Decimal {
+            scale: -2,
+            unscaled: vec![0x05], // 5 → 500
+        };
+        assert_eq!(ValueFormatter::format_value(&dn), "500");
     }
 
     #[test]

--- a/cqlite-core/src/util/value_fmt.rs
+++ b/cqlite-core/src/util/value_fmt.rs
@@ -287,6 +287,24 @@ impl ValueFormatter {
             return "0".to_string();
         }
 
+        // Fail-closed bound (issue #1754), kept consistent with the Node binding's
+        // `decimal_to_string`. A Cassandra `decimal` unscaled value is a Java
+        // BigInteger; legitimate financial/scientific decimals carry at most a few
+        // dozen significant digits, so a 1024-byte magnitude (up to ~2466 decimal
+        // digits) is orders of magnitude beyond any real value and cannot reject
+        // one. An oversized magnitude only arises from a corrupt SSTable and would
+        // otherwise cost a `BigInt::from_*_bytes` + `to_string` base conversion
+        // that is superlinear in the byte length. Render a bounded, exact hex
+        // fallback WITHOUT the expensive decimal conversion. Infallible signature:
+        // this stays total (never panics).
+        const DECIMAL_MAX_UNSCALED_BYTES: usize = 1024;
+        if unscaled.len() > DECIMAL_MAX_UNSCALED_BYTES {
+            return format!(
+                "<corrupt-decimal:scale={scale},unscaled_len={}bytes>",
+                unscaled.len()
+            );
+        }
+
         // Convert unscaled bytes to bigint
         let is_negative = (unscaled[0] & 0x80) != 0;
         let bigint = if is_negative {
@@ -769,6 +787,27 @@ mod tests {
         assert!(
             s2.len() < 64,
             "must not materialize an unbounded string: {s2}"
+        );
+    }
+
+    /// Issue #1754 (follow-up liveness fix): an oversized unscaled magnitude
+    /// (byte length beyond the 1024-byte cap) must be rejected FAST via the O(1)
+    /// length check, WITHOUT the superlinear `BigInt` base conversion, and must
+    /// stay total (never panics — infallible signature). A ~415 KB magnitude
+    /// (well under the old digit-oriented cap) exercises this.
+    #[test]
+    fn test_decimal_oversized_unscaled_bounded_fast() {
+        let unscaled = vec![0xffu8; 415_000];
+        let start = std::time::Instant::now();
+        let s = ValueFormatter::format_value(&Value::Decimal { scale: 0, unscaled });
+        let elapsed = start.elapsed();
+        assert!(
+            s.starts_with("<corrupt-decimal:"),
+            "oversized magnitude renders the bounded fallback: {s}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "expected fast O(1) rejection, took {elapsed:?} — the base conversion ran"
         );
     }
 


### PR DESCRIPTION
Closes #1754 (P0 — Node raw-parse path aborts even under panic=unwind on corrupt DECIMAL scale). Abort-safety guarantee #1431/#1440.

## The bug
Reading a corrupt SSTable whose DECIMAL column carries a pathological `scale` aborted the host process even under a `panic=unwind` build — the panic was raised on the napi async-worker thread where there is no unwind boundary, so the runtime called `abort()` (`fatal runtime error: failed to initiate panic, error 5`). #1440's profile was necessary but not sufficient.

## Two fixes (as the issue anticipated)
1. **Fail-closed DECIMAL decode** — the root panic was an unbounded `format!("0.{digits:0>scale$}")` padding width from a corrupt `scale`.
   - `bindings/node/src/value.rs::decimal_to_string`: bounds unscaled digit count + `scale.unsigned_abs()` before any width-driven format; `i32::MIN` handled (no negation overflow); returns typed `Error::corruption`. Bounded allocation, never unbounded.
   - `cqlite-core/src/util/value_fmt.rs::format_decimal`: `num_bigint::BigInt` (no `10^scale` materialization), `|scale|>1M` → exponent form; panic-free.
2. **napi catch_unwind boundary** — `bindings/node/src/error.rs::catch_unwind_to_napi` wraps the worker-thread `compute()` of `ExecuteNativeTask` (`database.rs`) and `NextTask` (`streaming.rs`); a residual panic becomes a rejected promise / typed JS error, never an abort. Streaming mutex-poison is recovered on the next task (stream terminates Done).

## Evidence (abort on main, pass now)
- Rust: `test_decimal_to_string_pathological_positive_scale_errors_not_panics` (+ i32::MIN, oversized-unscaled) + core `test_decimal_pathological_scale_is_bounded_not_panic`; well-formed decimals unchanged (parity guards).
- Node: `abort-safety.test.js` "uncompressed raw parse path (issue #1754)" — 6 cases; spawns a child process, asserts exit 0 + terminal sentinel after CALLING (a hard abort = signal exit + no sentinel → fails). Raw reads RAISE `PARSE`, not abort.

## Review
- rust-reviewer: CLEAN — verified overflow-free decimal math (unsigned_abs on i32::MIN correct, bounded alloc, BigInt) + sound catch_unwind boundary (no broken-invariant-after-catch; mutex-poison recovery verified).
- roborev (job 3720): No issues found.
- 3 doc/tracking nits → batched follow-up at merge.

## Notes for the closer
- Full gate needs `CQLITE_ALLOW_FILE_GROWTH=1` (`database.rs` 1807 / `value_fmt.rs` 832 pre-existing over-threshold, #1116).
- The node abort test may need the napi module built (`cd bindings/node && npm run build`) — confirm the node component actually exercises it.