### PR TITLE
ci(#2156): auto-release Maven Central publishes + explicit dry_run dispatch

### DIFF
--- a/.github/workflows/trino-publish.yml
+++ b/.github/workflows/trino-publish.yml
@@ -4,19 +4,25 @@ name: Publish Trino Connector
 # every v* release tag, so the connector releases in lockstep with the crate and
 # the cqlite-flight image. The version is derived from the tag (v0.13.0 → 0.13.0).
 #
-# The publish is GATED on the Maven Central + GPG signing secrets being present:
-# a tag pushed before those secrets land must NOT fail the release run. Secrets
-# are not addressable in a job-level `if:`, so a guard step checks them and
-# exposes a boolean output that the publish step keys off; when absent the job
-# logs a notice and succeeds without publishing.
+# Automatic release (issue #2156): `trino-connector/build.gradle.kts` configures
+# `publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)`,
+# so a successful `./gradlew publishToMavenCentral` run here fully releases the
+# artifact — no manual "Publish" click in the Central Portal UI.
+#
+# Secrets are not addressable in a job-level `if:`, so a guard step checks the
+# Maven Central + GPG signing secrets and exposes a boolean output the publish
+# step keys off. THIS IS FAIL-CLOSED (issue #2156): if it's not an explicit
+# dry run and the secrets are absent, the job FAILS loudly rather than
+# succeeding with the Central publish silently skipped — a prior
+# `workflow_dispatch` run reported "success" while the Central step never ran,
+# which is exactly the failure mode this closes.
 #
 # A `workflow_dispatch` trigger allows exercising the publish on demand. Manual
 # runs have no tag to derive the version from, so the `version` input supplies
-# it. By default `dry_run` is true: the connector is published to the local
-# Maven repo (publishToMavenLocal) — no Central upload, no signing/Central
-# secrets needed — so the pipeline can be validated without cutting a release.
-# Set `dry_run=false` to perform the real Central publish (still gated on the
-# secrets being present, exactly like the tag path).
+# it. `dry_run` now DEFAULTS TO FALSE (issue #2156) — dry-run behavior (publish
+# only to the local Maven repo via publishToMavenLocal, no Central upload, no
+# secrets needed) must be explicitly requested with `dry_run=true`. Omitting
+# the flag means "really publish," gated on the secrets check above.
 
 on:
   push:
@@ -29,9 +35,9 @@ on:
         type: string
         required: true
       dry_run:
-        description: 'Dry run: publishToMavenLocal only (no Central upload, no secrets needed)'
+        description: 'Dry run: publishToMavenLocal only (no Central upload, no secrets needed). Must be set explicitly — omitting this means a real publish.'
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -113,6 +119,12 @@ jobs:
           PUBLISH_VERSION: ${{ steps.version.outputs.version }}
         run: ./gradlew --no-daemon publishToMavenCentral -Pversion="$PUBLISH_VERSION"
 
-      - name: Skip notice (secrets absent)
+      # Issue #2156: this used to be a "Skip notice" that logged and let the job
+      # succeed — that is exactly how a workflow_dispatch run reported "success"
+      # while the Central publish silently never happened. A skip that isn't an
+      # explicit dry run is now unmissable: the job FAILS instead of going green.
+      - name: Fail — Central publish skipped (secrets absent, not a dry run)
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.guard.outputs.should_publish != 'true' }}
-        run: echo "::notice::Maven Central secrets absent — skipping connector publish"
+        run: |
+          echo "::error::Maven Central secrets absent and this is not an explicit dry run (dry_run=true) — failing instead of silently skipping the connector publish. Set MAVEN_CENTRAL_USERNAME/MAVEN_CENTRAL_PASSWORD/SIGNING_KEY/SIGNING_PASSWORD, or dispatch with dry_run=true to validate the build without publishing."
+          exit 1

--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -76,8 +76,18 @@ tasks.withType<Test>().configureEach {
 // javadoc jars and a Central-compliant POM. `trino-spi` is compileOnly, so it is
 // absent from the POM's runtime scope; `flight-core` + `jackson-databind` are
 // `implementation`, so they appear as runtime dependencies.
+//
+// `automaticRelease = true` (issue #2156): the pinned 0.30.0 plugin's
+// `publishToMavenCentral(SonatypeHost, automaticRelease: Boolean)` overload
+// defaults `automaticRelease` to `false` when omitted — verified by decompiling
+// the cached 0.30.0 plugin jar: the Kotlin `$default` bridge loads `iconst_0`
+// (`false`) for the boolean slot when the caller doesn't pass it. That default
+// is why every prior publish (0.13.0/0.13.1/0.13.2) landed
+// VALIDATED-but-PENDING in Central Portal Deployments and needed a manual
+// Publish click. Passing `true` here makes a successful
+// `publishToMavenCentral` invocation release automatically — no portal step.
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
     coordinates("in.mcfad", "cqlite-trino", version.toString())
     configure(JavaLibrary(javadocJar = JavadocJar.Javadoc(), sourcesJar = true))
 


### PR DESCRIPTION
## Root cause

1. **Every publish landed VALIDATED-but-PENDING in Central Portal Deployments.**
   `trino-connector/build.gradle.kts` called `publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)`
   with no `automaticRelease` argument. Decompiling the pinned 0.30.0
   `com.vanniktech.maven.publish` plugin jar confirms the overload is
   `publishToMavenCentral(host: SonatypeHost, automaticRelease: Boolean)` and its
   Kotlin `$default` bridge loads `iconst_0` (`false`) for the boolean slot when
   the caller omits it — so every publish (0.13.0, 0.13.1, 0.13.2) required the
   owner to manually click Publish in the Central Portal.
2. **`workflow_dispatch` `dry_run` defaulted to `true`.** A dispatch that omitted
   the flag silently ran only `publishToMavenLocal` while the run reported
   `success` — bit us on the first 0.13.2 dispatch (Central step skipped,
   green checkmark).

## Fix

- `trino-connector/build.gradle.kts`: `publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)`.
  A successful `./gradlew publishToMavenCentral` now fully releases the
  artifact — no portal click.
- `.github/workflows/trino-publish.yml`:
  - `dry_run` input default flipped `true` → `false`; description now says
    explicitly that omitting it means a real publish.
  - The former "Skip notice (secrets absent)" step (which logged and let the
    job go green) is now `Fail — Central publish skipped (secrets absent, not
    a dry run)`: it `exit 1`s with an `::error::` whenever the Central publish
    is skipped for any reason other than an explicit `dry_run=true`.
  - Header comment rewritten to describe the new semantics (automatic release,
    no portal click; dry_run must be explicitly requested).
  - Preserved the existing `${{ inputs.* }}` → quoted `env:` pattern
    (`INPUT_VERSION`) — no raw input interpolation was added into any `run:`
    block.

## Validation

- `cd trino-connector && ./gradlew publishToMavenLocal` — `BUILD SUCCESSFUL`
  (JDK 25 toolchain auto-provisioned via the foojay resolver; host JDK is 17).
- `./gradlew tasks --group publishing` shows the expected publishing task set
  (`publish`, `publishToMavenLocal`, `publishAllPublicationsToMavenCentralRepository`,
  etc.); `./gradlew tasks --all` additionally surfaces a "Release tasks" group
  (`publishToMavenCentral`, `publishAndReleaseToMavenCentral`,
  `releaseRepository`) registered by the plugin regardless of the
  `automaticRelease` DSL value — the DSL flag controls what the
  `publishToMavenCentral` *task* itself does when it runs (auto-release vs.
  stage-only), not which tasks exist.
- `actionlint .github/workflows/trino-publish.yml` — clean (exit 0).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/trino-publish.yml'))"` — parses cleanly.
- Docs sweep (`rg` for "portal"/"PENDING"/"automaticRelease" across `docs/` and
  `trino-connector/README.md`) found no doc describing the manual portal-click
  step, so no doc content needed updating beyond the workflow's own comments.

Real proof lands with the next real version publish (expect no PENDING state
in the Central Portal, and a dispatch without `dry_run` to either really
publish or fail loudly instead of silently skipping).

Closes #2156