### PR TITLE
harness(#2158,#2159): coordinator strategy:Recreate + decoupled cqlite catalog registration

### DIFF
--- a/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md
+++ b/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md
@@ -236,7 +236,9 @@ kubectl get pods -l easydblab.com/kit=cqlite-flight -o wide
 
 **[UPDATED after the first live run]** This step surfaced four bugs, all now
 fixed in the kit — no command below changes, but the *observed* behavior
-during this step does:
+during this step does. **[UPDATED after the second live run]** two more bugs
+(#2158, #2159) surfaced on a re-run after #2119's fix proved insufficient —
+see those two entries below, both now fixed:
 
 - **#2120** — `cqlite start` never created the `cqlite-trino-plugin-src`
   ConfigMap, so both pods sat `Init:0/1` with `FailedMount`. Fixed:
@@ -253,11 +255,37 @@ during this step does:
 - **#2119** — patching the coordinator's pod template (to add the plugin
   initContainer) started a rollout that could never converge on this plan's
   single app node: the new pod can't bind the coordinator's `hostPort: 8080`
-  while the old one still holds it. Fixed: the reapply script now deletes the
-  old coordinator pod **only when the patch actually changed something** (not
-  on a steady-state no-op re-apply) and waits for the rollout. **Expect the
-  `trino-coordinator` pod to be deleted and recreated once** during this step
-  on a fresh install — that is now expected, not a hang.
+  while the old one still holds it. First fix attempt: the reapply script
+  deleted the old coordinator pod **only when the patch actually changed
+  something**. **[UPDATED after the second live run]** That delete-pod fix
+  was insufficient — under `strategy: RollingUpdate` the surviving
+  ReplicaSet just recreates the deleted pod and re-grabs `hostPort: 8080`,
+  reproducing the deadlock (**#2158**). The kit now ensures
+  `strategy: Recreate` on `trino-coordinator` before every pod-template patch
+  (`bin/reapply-plugin-patch.sh`), so the controller tears down the old pod
+  before starting the new one. **Expect the `trino-coordinator` pod to be
+  recreated once** during this step on a fresh install — that is now
+  expected, not a hang. This manual workaround is no longer needed:
+  ```bash
+  # no longer required — the kit ensures strategy: Recreate itself
+  kubectl patch deployment trino-coordinator -p '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'
+  ```
+- **#2159** — **[UPDATED after the second live run]** when `cqlite start`
+  aborted on the #2158 deadlock above, the `cqlite` Trino catalog was never
+  registered, because registration relied entirely on the trino kit's
+  `post-workload-start` hook firing on a *clean* completion — a partial
+  failure left `SHOW CATALOGS` without `cqlite` and no automatic recovery
+  path. Fixed: `bin/start.sh` and `bin/verify.sh` both now call
+  `bin/ensure-catalog-registered.sh`, which checks `SHOW CATALOGS` and, if
+  `cqlite` is missing, registers it by invoking the trino kit's own
+  `bin/update-catalogs.sh` directly. The manual recovery recipe from the
+  first live run is no longer needed:
+  ```bash
+  # no longer required — bin/start.sh / bin/verify.sh self-heal this
+  bash trino/bin/update-catalogs.sh
+  ```
+  Re-running `easy-db-lab cqlite start` (or `bin/verify.sh`) alone now
+  recovers a partial failure with no manual steps.
 
 ```bash
 DB0_IP=$($EDB ip db0 --private)

--- a/easy-db-lab-kits/trino-cqlite/README.md.template
+++ b/easy-db-lab-kits/trino-cqlite/README.md.template
@@ -124,12 +124,18 @@ this; it falls out of the POM's dependency scoping for free. Do not add
    `SELECT * FROM cqlite.<keyspace>.<table>` (not a quoted
    `"trino-cqlite".<keyspace>.<table>`) work.
    `cqlite start` patches `trino-coordinator`/`trino-worker` with the plugin
-   initContainer + volume, waits for the rollout, and — as a side effect of
-   any kit starting — triggers the trino kit's own `post-workload-start` hook,
-   which re-runs `trino/bin/update-catalogs.sh` and picks up this kit's
-   `trino-catalog.properties` (sibling-directory auto-discovery; see
+   initContainer + volume, waits for the rollout, and then verifies the
+   `cqlite` catalog is registered — normally a side effect of any kit starting
+   triggering the trino kit's own `post-workload-start` hook (which re-runs
+   `trino/bin/update-catalogs.sh` and picks up this kit's
+   `trino-catalog.properties`; sibling-directory auto-discovery, see
    `docs/user-guide/install-trino.md` "Adding Trino Catalogs for Custom
-   Kits"). No manual catalog step is needed.
+   Kits"). If that hook never fired — e.g. `cqlite start` aborted partway
+   through on the #2158 coordinator deadlock — `bin/start.sh` registers the
+   catalog itself by invoking `trino/bin/update-catalogs.sh` directly (issue
+   #2159; see `bin/ensure-catalog-registered.sh`), so no manual catalog step
+   is ever needed and a partial failure is recoverable by simply re-running
+   `easy-db-lab cqlite start` (or `bin/verify.sh`, which runs the same check).
 3. **cqlite-flight** must be running on the db nodes this connector reads
    from (see `../cqlite-flight/README.md` if present) — it is what actually
    serves Arrow Flight; this overlay only wires the Trino side.
@@ -149,6 +155,37 @@ re-patching unconditionally on every `trino start`
 any kit event) re-run `bin/reapply-plugin-patch.sh`, which is a cheap,
 idempotent `kubectl patch --type=strategic` — safe to run on every event,
 even ones unrelated to Trino or Cassandra.
+
+## Resiliency: coordinator rollout strategy (issue #2158)
+
+The trino kit runs `trino-coordinator` with `hostPort: 8080`. On a single app
+node, a `strategy: RollingUpdate` (the Helm chart's default, with maxSurge)
+can **never** converge once the pod template changes: the surge pod can't
+bind `hostPort: 8080` while the old pod still holds it, and the old
+ReplicaSet just keeps recreating that old pod — deleting the stuck pod alone
+doesn't help (this was the insufficient #2119 fix). `bin/reapply-plugin-patch.sh`
+now ensures `strategy: Recreate` (`rollingUpdate: null`) on
+`trino-coordinator` before every pod-template patch, idempotently. Because
+the Helm chart doesn't template a `strategy` field at all, this out-of-band
+patch survives every subsequent `helm upgrade` from `trino/bin/update-catalogs.sh`
+once applied. With `Recreate`, the controller tears down the old pod before
+starting the new one, so `hostPort: 8080` is always free — no manual pod
+deletion needed.
+
+## Resiliency: catalog registration is decoupled from a clean start (issue #2159)
+
+Catalog registration used to depend entirely on the trino kit's
+`post-workload-start` hook firing, which only happens on a **clean**
+`cqlite start`/`stop` (of this or any other kit). If `cqlite start` aborted
+partway — e.g. on the #2158 deadlock above — the hook never ran and the
+`cqlite` catalog was left unregistered with no automatic recovery path.
+`bin/start.sh` now calls `bin/ensure-catalog-registered.sh` after the plugin
+rollout: it checks `SHOW CATALOGS` on the coordinator and, if `cqlite` is
+missing, registers it itself by invoking the trino kit's own
+`bin/update-catalogs.sh` (never edited, only invoked). `bin/verify.sh` runs
+the same check first. Net effect: a partial `cqlite start` failure is
+recoverable by simply re-running `easy-db-lab cqlite start` or `bin/verify.sh`
+— no manual `update-catalogs.sh` invocation required.
 
 ## Verify
 

--- a/easy-db-lab-kits/trino-cqlite/bin/ensure-catalog-registered.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/ensure-catalog-registered.sh.template
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Issue #2159: verify the cqlite Trino catalog is registered, and self-heal by
+# invoking the trino kit's OWN bin/update-catalogs.sh (calling it is fine;
+# this repo never edits it) if it is not.
+#
+# Registration normally happens as a side effect of the trino kit's
+# post-workload-start hook firing when ANY kit (including this one) finishes
+# starting. That hook never runs if `cqlite start` aborts partway through —
+# e.g. the #2158 coordinator rollout deadlock — leaving the cqlite catalog
+# unregistered with no clear next step. This script decouples "the plugin
+# patch/rollout succeeded" from "the catalog is registered": both
+# `bin/start.sh` (after the rollout) and `bin/verify.sh` (before running
+# checks) call it, so a prior partial failure is recoverable by re-running
+# EITHER `easy-db-lab cqlite start` or `bin/verify.sh`, with no manual steps.
+#
+# Usage: ensure-catalog-registered.sh   (no args)
+# Exit 0: cqlite catalog confirmed registered (already, or after self-heal).
+# Exit 1: could not confirm/self-heal — the printed message names the exact
+#         failing step and what to rerun.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export KUBECONFIG="${SCRIPT_DIR}/../../__KUBECONFIG__"
+
+# Sibling kit directory layout (same pattern as bin/uninstall.sh.template's
+# TRINO_UPDATE_CATALOGS): this kit installs as a directory next to the trino
+# kit's own installed directory.
+TRINO_UPDATE_CATALOGS="${SCRIPT_DIR}/../../trino/bin/update-catalogs.sh"
+
+catalog_registered() {
+  local coord_pod
+  coord_pod=$(kubectl get pods --namespace default \
+    -l 'app.kubernetes.io/name=trino,app.kubernetes.io/component=coordinator' \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [ -z "${coord_pod}" ]; then
+    return 1
+  fi
+  kubectl exec --namespace default "${coord_pod}" -- trino --execute "SHOW CATALOGS" 2>/dev/null \
+    | grep -qx '"cqlite"'
+}
+
+echo "cqlite catalog: checking registration..."
+if catalog_registered; then
+  echo "  OK: cqlite catalog is registered."
+  exit 0
+fi
+
+echo "  cqlite catalog NOT registered. This can happen when a prior 'cqlite start' aborted"
+echo "  before the trino kit's post-workload-start hook fired (issue #2159) — e.g. the #2158"
+echo "  coordinator rollout deadlock."
+
+if [ ! -x "${TRINO_UPDATE_CATALOGS}" ]; then
+  echo "ERROR [ensure-catalog-registered: self-heal unavailable]: trino kit's bin/update-catalogs.sh" >&2
+  echo "  not found or not executable at ${TRINO_UPDATE_CATALOGS}." >&2
+  echo "  Is the trino kit installed as a sibling directory named 'trino'? Rerun:" >&2
+  echo "    easy-db-lab trino start" >&2
+  echo "  then rerun 'easy-db-lab cqlite start' (or bin/verify.sh) to retry registration." >&2
+  exit 1
+fi
+
+echo "  Registering it now via the trino kit's own update-catalogs.sh..."
+if ! "${TRINO_UPDATE_CATALOGS}"; then
+  echo "ERROR [ensure-catalog-registered: update-catalogs.sh failed]: see the error above." >&2
+  echo "  Fix the reported problem, then rerun 'easy-db-lab cqlite start' (or bin/verify.sh)" >&2
+  echo "  to retry catalog registration." >&2
+  exit 1
+fi
+
+echo "  Re-checking catalog registration..."
+if catalog_registered; then
+  echo "  OK: cqlite catalog is now registered."
+  exit 0
+fi
+
+echo "ERROR [ensure-catalog-registered: still absent after update-catalogs.sh]: the cqlite" >&2
+echo "  catalog is still not registered. Check that cqlite/trino-catalog.properties exists" >&2
+echo "  next to this kit's other rendered files and matches update-catalogs.sh's glob, then" >&2
+echo "  rerun 'easy-db-lab cqlite start' (or bin/verify.sh)." >&2
+exit 1

--- a/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
@@ -76,30 +76,39 @@ ensure_configmap() {
     --dry-run=client -o yaml | kubectl apply -f -
 }
 
-# Issue #2119: the trino kit runs trino-coordinator with `hostPort: 8080`. On
-# a single app node, patching the pod template starts a rollout whose new pod
-# can never schedule while the old pod still holds that hostPort — the exact
-# deadlock the trino kit's own bin/start.sh already avoids for itself by
-# deleting the coordinator pod after a template change. Mirror that here, but
-# ONLY when this patch actually changed the pod template: `kubectl patch`
-# prints "... (no change)" when the strategic-merge patch was a no-op against
-# an already-patched Deployment, and re-applying identical content (the
-# steady-state case — this script fires on every kit start/stop) must NOT
-# bounce an already-healthy coordinator.
-bounce_coordinator_if_changed() {
-  local patch_output="$1"
+# Issue #2158 (supersedes the #2119 delete-pod workaround): the trino kit runs
+# trino-coordinator with `hostPort: 8080` under `strategy: RollingUpdate` +
+# maxSurge. On a single app node that deadlocks *unconditionally* once the pod
+# template changes — the surge pod can never bind hostPort:8080 while the old
+# ReplicaSet (still desired=1) holds it, and deleting the stuck pod (#2119)
+# doesn't help because the surviving ReplicaSet just recreates it. The only
+# fix is `strategy: Recreate`: the controller then terminates the old pod
+# BEFORE creating the new one, so hostPort:8080 is always free when the new
+# pod needs it. Ensure this on every invocation, BEFORE the pod-template patch
+# below — cheap and idempotent (`kubectl get -o jsonpath` short-circuits to a
+# no-op patch when already Recreate). Helm-templated fields don't include
+# `strategy`, so this out-of-band patch survives the trino kit's own
+# `helm upgrade` (via its bin/update-catalogs.sh hook) once applied.
+ensure_recreate_strategy() {
+  local dep="$1"
 
-  if [[ "${patch_output}" == *"(no change)"* ]]; then
-    echo "    trino-coordinator pod template unchanged — not bouncing the pod."
+  if ! kubectl get deployment "${dep}" --namespace default >/dev/null 2>&1; then
     return 0
   fi
 
-  echo "    trino-coordinator pod template changed — deleting the old pod so the"
-  echo "    controller can recreate it on the now-free hostPort 8080..."
-  kubectl delete pod --namespace default \
-    -l 'app.kubernetes.io/name=trino,app.kubernetes.io/component=coordinator' \
-    --ignore-not-found
-  kubectl rollout status deployment/trino-coordinator --namespace default --timeout=180s
+  local current_strategy
+  current_strategy=$(kubectl get deployment "${dep}" --namespace default \
+    -o jsonpath='{.spec.strategy.type}')
+  if [ "${current_strategy}" = "Recreate" ]; then
+    echo "  - deployment/${dep}: strategy already Recreate — no change."
+    return 0
+  fi
+
+  echo "  - deployment/${dep}: setting strategy to Recreate (issue #2158 — a"
+  echo "    hostPort-bound single-replica deployment can never complete a"
+  echo "    RollingUpdate surge on a single app node)..."
+  kubectl patch deployment "${dep}" --namespace default \
+    -p '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'
 }
 
 patch_deployment() {
@@ -108,6 +117,10 @@ patch_deployment() {
   if ! kubectl get deployment "${dep}" --namespace default >/dev/null 2>&1; then
     echo "  - deployment/${dep} not found (trino kit not running here yet) — skipping"
     return 0
+  fi
+
+  if [ "${dep}" = "trino-coordinator" ]; then
+    ensure_recreate_strategy "${dep}"
   fi
 
   echo "  - patching deployment/${dep} (container: ${dep})..."
@@ -148,8 +161,14 @@ patch_deployment() {
   patch_output=$(kubectl patch deployment "${dep}" --namespace default --type=strategic -p="${patch}")
   echo "    ${patch_output}"
 
-  if [ "${dep}" = "trino-coordinator" ]; then
-    bounce_coordinator_if_changed "${patch_output}"
+  if [ "${dep}" = "trino-coordinator" ] && [[ "${patch_output}" != *"(no change)"* ]]; then
+    # With strategy: Recreate now ensured above, the controller itself tears
+    # down the old pod before creating the new one on this template change —
+    # no manual `kubectl delete pod` needed (that was the insufficient #2119
+    # workaround). Just wait for the rollout to converge.
+    echo "    trino-coordinator pod template changed — waiting for the Recreate"
+    echo "    rollout (old pod terminates, then the new one starts)..."
+    kubectl rollout status deployment/trino-coordinator --namespace default --timeout=180s
   fi
 }
 

--- a/easy-db-lab-kits/trino-cqlite/bin/start.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/start.sh.template
@@ -50,7 +50,19 @@ echo ""
 echo "cqlite plugin loaded into trino-coordinator/trino-worker at"
 echo "  /usr/lib/trino/plugin/cqlite_flight"
 echo ""
-echo "The cqlite catalog is registered by the trino kit's own post-workload-start hook, which"
-echo "just fired (it re-runs trino/bin/update-catalogs.sh on ANY kit start, including this one)."
+
+# Issue #2159: don't just assume the trino kit's post-workload-start hook (which
+# re-runs trino/bin/update-catalogs.sh on ANY kit start, including this one) fired
+# and registered the catalog — verify it, and self-heal if it didn't. Independent
+# of plugin-patch/rollout success above, so a prior partial 'cqlite start' failure
+# (e.g. the #2158 coordinator deadlock aborting before this point) is recoverable
+# by simply re-running 'cqlite start'.
+if ! "${SCRIPT_DIR}/ensure-catalog-registered.sh"; then
+  echo "ERROR: cqlite plugin loaded, but catalog registration failed — see the" >&2
+  echo "  'ensure-catalog-registered' message above for the exact failing step and" >&2
+  echo "  what to rerun." >&2
+  exit 1
+fi
+
 echo "Verify with:"
 echo "  ${SCRIPT_DIR}/verify.sh <keyspace> <table>"

--- a/easy-db-lab-kits/trino-cqlite/bin/verify.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/verify.sh.template
@@ -18,6 +18,15 @@ export KUBECONFIG="${SCRIPT_DIR}/../../__KUBECONFIG__"
 KEYSPACE="${1:-}"
 TABLE="${2:-}"
 
+# Issue #2159: verify (and self-heal) catalog registration BEFORE running any
+# check below, so this script alone can recover a 'cqlite start' that aborted
+# before the trino kit's post-workload-start hook registered the catalog.
+if ! "${SCRIPT_DIR}/ensure-catalog-registered.sh"; then
+  echo "ERROR: cqlite catalog registration check/self-heal failed — see the" >&2
+  echo "  'ensure-catalog-registered' message above for the exact failing step." >&2
+  exit 1
+fi
+
 COORD_POD=$(kubectl get pods --namespace default \
   -l 'app.kubernetes.io/name=trino,app.kubernetes.io/component=coordinator' \
   -o jsonpath='{.items[0].metadata.name}')


### PR DESCRIPTION
## Round-2 harness fixes (epic #2103, second live run)

Two our-side fixes in `easy-db-lab-kits/trino-cqlite/` — shell/yaml/markdown only, no Rust. The upstream trino kit's scripts (`trino/bin/update-catalogs.sh`) are only invoked, never edited.

Closes #2158
Closes #2159

### #2158 — coordinator hostPort:8080 rollout deadlock: `strategy: Recreate`

The #2119 delete-pod workaround was insufficient: under `strategy: RollingUpdate` + maxSurge on a single app node, the surge pod can never bind `hostPort: 8080` while the old ReplicaSet holds it, and deleting the stuck pod just gets it recreated by the surviving ReplicaSet.

`bin/reapply-plugin-patch.sh.template` now has an idempotent `ensure_recreate_strategy()` that runs **before** every coordinator pod-template patch:

```
kubectl patch deployment trino-coordinator -p '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'
```

(short-circuits to a no-op when `.spec.strategy.type` is already `Recreate`). This is the exact patch that unblocked the live run. Since the Helm chart doesn't template a `strategy` field, the out-of-band patch survives every subsequent `helm upgrade` from the trino kit's hook. The #2119 `kubectl delete pod` step is **removed** — with Recreate the controller tears down the old pod itself; the script just waits for the rollout when the template actually changed.

### #2159 — cqlite catalog registration decoupled from a clean `cqlite start`

Registration used to depend entirely on the trino kit's `post-workload-start` hook firing on clean completion — a `cqlite start` aborted mid-way (e.g. on the #2158 deadlock) left `SHOW CATALOGS` without `cqlite` and no automatic recovery.

New `bin/ensure-catalog-registered.sh.template`:
- checks `SHOW CATALOGS` on the coordinator pod for `cqlite`
- if absent, self-heals by invoking the trino kit's own `bin/update-catalogs.sh` (sibling-directory path, same as `uninstall.sh` already uses), then re-verifies
- fails with explicit messages naming the failing step (trino kit missing / update-catalogs failed / still absent) and exactly what to rerun

Wired into:
- `bin/start.sh.template` — after the rollout, independent of the plugin-patch path
- `bin/verify.sh.template` — as a preflight before any check

Net effect: a partial `cqlite start` failure is recoverable by re-running `easy-db-lab cqlite start` **or** `bin/verify.sh` with no manual steps.

### Docs

- `test-plans/cqlite-flight-loadtest-3node.md` step 5: `[UPDATED after the second live run]` callouts — the #2119 entry now records that its fix was insufficient and superseded by #2158's `strategy: Recreate`, and a new #2159 entry marks both manual workaround recipes (`kubectl patch ... Recreate`, `bash trino/bin/update-catalogs.sh`) as no longer required.
- `trino-cqlite/README.md.template`: install-order step 2 updated + two new Resiliency sections (#2158 rollout strategy, #2159 decoupled catalog registration).

### Evidence

- Lite gate (form-only for a no-Rust diff; defaulted to `cqlite-core --lib`): **`RESULT: PASS`** — file-size PASS, fmt PASS, clippy PASS (205s), scoped-tests PASS (260s); summary file `/tmp/gate-lite-2158.txt`.
- `shellcheck -s bash` clean on all 7 `bin/*.sh.template` files (no findings, including the new `ensure-catalog-registered.sh.template`; the `__X__` template placeholders produced no false positives).
- `bash -n` clean on all modified/new templates.
