### PR TITLE
fix(#2164): applyFilter translates TupleDomain summary — domain-shaped predicates now pushed to filterJson

### DIFF
--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -149,9 +149,17 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * post-filtering them — results are always correct; pushdown is a pure
      * optimization.
      *
-     * <p>The {@code TupleDomain} summary is returned unchanged (we do not consume
-     * it), and partial-AND pushdown leaves the untranslatable conjuncts in the
-     * residual expression.
+     * <p>Trino delivers simple, domain-expressible predicates (e.g. a single-partition
+     * point read {@code key = 'v'}) not in the expression but as a {@link
+     * io.trino.spi.predicate.TupleDomain} in {@code constraint.getSummary()}, leaving
+     * the expression {@code TRUE} (issue #2164). We therefore ALSO translate the
+     * summary into pushable nodes and merge (AND) them with the expression path's
+     * tree. The summary is still returned <em>unchanged</em> as the remaining filter:
+     * the server applies the pushed tree best-effort post-decode and Trino keeps its
+     * {@code ScanFilter} above, so {@code filterJson} is a pure optimization, never an
+     * enforcement guarantee (same honesty posture as {@code applyLimit}'s
+     * {@code limitGuaranteed = false}, #2129). Untranslatable expression conjuncts are
+     * returned as the residual expression.
      */
     @Override
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(
@@ -170,8 +178,14 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
 
         PredicateTreeTranslator.Result result =
                 PredicateTreeTranslator.translate(expression, constraint.getAssignments());
-        if (result.pushed().isEmpty()) {
-            return Optional.empty(); // nothing translatable to push
+
+        // Also translate the TupleDomain summary (how Trino actually delivers simple
+        // col = literal / IN / range predicates). Merge (AND) with the expression tree.
+        Optional<JsonNode> domainPushed =
+                PredicateTreeTranslator.translateSummary(constraint.getSummary());
+        Optional<JsonNode> newlyPushedOpt = combinePushed(result.pushed(), domainPushed);
+        if (newlyPushedOpt.isEmpty()) {
+            return Optional.empty(); // nothing translatable to push from either path
         }
 
         // Trino calls applyFilter iteratively, passing only the predicate at the
@@ -180,7 +194,7 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
         // with whatever the handle already carries. Replacing would silently drop
         // an earlier condition whose residual we already reported as satisfied,
         // returning too many rows.
-        JsonNode newlyPushed = result.pushed().get();
+        JsonNode newlyPushed = newlyPushedOpt.get();
         Optional<String> existing = table.filterJson();
         String newlyPushedJson = serialize(newlyPushed);
 
@@ -213,9 +227,25 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
 
         return Optional.of(new ConstraintApplicationResult<>(
                 newHandle,
-                constraint.getSummary(), // domain returned unchanged; we don't consume it
+                // The summary is returned UNCHANGED as the remaining (unenforced) filter:
+                // its predicates are pushed into filterJson only as a best-effort server-
+                // side optimization, so Trino must keep applying the full domain itself
+                // (honesty contract — filterJson is not an enforcement guarantee, #2164).
+                constraint.getSummary(),
                 remainingExpression,
                 false));
+    }
+
+    /**
+     * AND the expression-path and summary-path pushed trees, or return whichever is
+     * present (empty if neither). Kept tiny and pure so applyFilter stays readable.
+     */
+    private static Optional<JsonNode> combinePushed(
+            Optional<JsonNode> expressionPushed, Optional<JsonNode> domainPushed) {
+        if (expressionPushed.isPresent() && domainPushed.isPresent()) {
+            return Optional.of(PredicateTreeTranslator.and(expressionPushed.get(), domainPushed.get()));
+        }
+        return expressionPushed.isPresent() ? expressionPushed : domainPushed;
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/PredicateTreeTranslator.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/PredicateTreeTranslator.java
@@ -480,17 +480,26 @@ public final class PredicateTreeTranslator {
                     .map(v -> compareNode(col.name(), "Equal", v));
         }
         if (values.isDiscreteSet()) {
-            ArrayNode array = MAPPER.createArrayNode();
+            // Canonicalize: applyFilter's idempotence/accumulation guards compare
+            // SERIALIZED JSON, so the same logical multi-value domain must always emit
+            // byte-identical output regardless of the ValueSet's iteration order.
+            // Convert every element to its JSON scalar first, then sort by the
+            // serialized scalar string — a total, type-stable order that never depends
+            // on ValueSet internals (In is set membership; order is semantically free).
+            List<JsonNode> scalars = new ArrayList<>();
             for (Object element : values.getDiscreteSet()) {
                 Optional<JsonNode> v = constantToJson(type, element);
                 if (v.isEmpty()) {
                     return Optional.empty();
                 }
-                array.add(v.get());
+                scalars.add(v.get());
             }
-            if (array.isEmpty()) {
+            if (scalars.isEmpty()) {
                 return Optional.empty();
             }
+            scalars.sort(java.util.Comparator.comparing(JsonNode::toString));
+            ArrayNode array = MAPPER.createArrayNode();
+            scalars.forEach(array::add);
             ObjectNode node = MAPPER.createObjectNode();
             node.put("type", "In");
             node.put("column", col.name());

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/PredicateTreeTranslator.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/PredicateTreeTranslator.java
@@ -12,6 +12,11 @@ import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FunctionName;
 import io.trino.spi.expression.StandardFunctions;
 import io.trino.spi.expression.Variable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.DoubleType;
@@ -387,15 +392,208 @@ public final class PredicateTreeTranslator {
     }
 
     /**
+     * Translate a Trino {@code Constraint.getSummary()} {@link TupleDomain} into a
+     * pushable predicate tree (issue #2164).
+     *
+     * <p>Trino represents simple, domain-expressible predicates — e.g. a
+     * single-partition point read {@code key = '001.25.535688'} — as a
+     * {@link TupleDomain} in the summary, leaving {@code getExpression()} as
+     * {@code TRUE}. The {@link ConnectorExpression} path therefore finds nothing
+     * pushable, so this path converts each column {@link Domain} into the same
+     * {@code PredicateExpr} node shapes the expression path emits:
+     * <ul>
+     *   <li>single value → {@code Compare Equal},</li>
+     *   <li>discrete set → {@code In},</li>
+     *   <li>ranges → {@code Compare Gt/Gte/Lt/Lte} (a bounded range becomes an
+     *       {@code And} of two; multiple ranges become an {@code Or}).</li>
+     * </ul>
+     *
+     * <p>Capability gating mirrors the expression path EXACTLY (see
+     * {@link #translateCompare}): {@code NONE} pushes nothing; {@code EQUALITY}
+     * pushes only exact match / membership; ordering (ranges) requires
+     * {@code FULL}. A column whose domain also admits {@code NULL} is left entirely
+     * unpushed: the server applies the pushed filter destructively, so pushing only
+     * the non-null values would wrongly drop null rows. Anything not translatable
+     * stays unpushed (the caller returns the summary unchanged so Trino still
+     * enforces it — pushdown is a pure optimization).
+     *
+     * @return the pushable tree (columns ANDed in a stable, column-name order for
+     *     idempotent serialization), or empty if nothing is pushable
+     */
+    public static Optional<JsonNode> translateSummary(TupleDomain<ColumnHandle> summary) {
+        if (summary == null || summary.isAll() || summary.isNone()) {
+            return Optional.empty();
+        }
+        Optional<Map<ColumnHandle, Domain>> domains = summary.getDomains();
+        if (domains.isEmpty()) {
+            return Optional.empty();
+        }
+        // Sort by column name so the emitted AND has a deterministic shape regardless
+        // of the summary map's iteration order — required for the applyFilter
+        // idempotence guards (identical re-invocation must serialize identically).
+        List<Map.Entry<String, JsonNode>> named = new ArrayList<>();
+        for (Map.Entry<ColumnHandle, Domain> entry : domains.get().entrySet()) {
+            if (!(entry.getKey() instanceof CqliteFlightColumnHandle col)) {
+                continue; // unknown handle → leave to Trino
+            }
+            translateDomain(col, entry.getValue())
+                    .ifPresent(node -> named.add(Map.entry(col.name(), node)));
+        }
+        if (named.isEmpty()) {
+            return Optional.empty();
+        }
+        named.sort(Map.Entry.comparingByKey());
+        if (named.size() == 1) {
+            return Optional.of(named.get(0).getValue());
+        }
+        List<JsonNode> conjuncts = new ArrayList<>();
+        for (Map.Entry<String, JsonNode> e : named) {
+            conjuncts.add(e.getValue());
+        }
+        return Optional.of(andNode(conjuncts));
+    }
+
+    /** Translate ONE column's {@link Domain} into a pushable node, or empty. */
+    private static Optional<JsonNode> translateDomain(CqliteFlightColumnHandle col, Domain domain) {
+        PushdownCapability capability = col.capability();
+        if (capability == PushdownCapability.NONE || domain.isNone() || domain.isAll()) {
+            return Optional.empty();
+        }
+        // col IS NULL (only-null domain) is a definite, exact test — safe for
+        // EQUALITY and FULL, same as the expression path's IS NULL leaf.
+        if (domain.isOnlyNull()) {
+            ObjectNode node = MAPPER.createObjectNode();
+            node.put("type", "IsNull");
+            node.put("column", col.name());
+            return Optional.of(node);
+        }
+        // A domain that ALSO admits null (col = x OR col IS NULL): pushing just the
+        // values excludes null rows the predicate keeps → over-restrictive against a
+        // destructive server filter. Leave the whole column to Trino.
+        if (domain.isNullAllowed()) {
+            return Optional.empty();
+        }
+        ValueSet values = domain.getValues();
+        Type type = domain.getType();
+        if (values.isSingleValue()) {
+            return constantToJson(type, values.getSingleValue())
+                    .map(v -> compareNode(col.name(), "Equal", v));
+        }
+        if (values.isDiscreteSet()) {
+            ArrayNode array = MAPPER.createArrayNode();
+            for (Object element : values.getDiscreteSet()) {
+                Optional<JsonNode> v = constantToJson(type, element);
+                if (v.isEmpty()) {
+                    return Optional.empty();
+                }
+                array.add(v.get());
+            }
+            if (array.isEmpty()) {
+                return Optional.empty();
+            }
+            ObjectNode node = MAPPER.createObjectNode();
+            node.put("type", "In");
+            node.put("column", col.name());
+            node.set("values", array);
+            return Optional.of(node);
+        }
+        // Ranges → ordering comparisons; ordering is only safe for FULL columns
+        // (EQUALITY types like uuid order by the CQL type server-side, so an ordered
+        // push would filter incorrectly — identical to translateCompare's gate).
+        if (capability != PushdownCapability.FULL || !(values instanceof SortedRangeSet sorted)) {
+            return Optional.empty();
+        }
+        List<JsonNode> rangeNodes = new ArrayList<>();
+        for (Range range : sorted.getOrderedRanges()) {
+            Optional<JsonNode> node = translateRange(col.name(), type, range);
+            if (node.isEmpty()) {
+                return Optional.empty(); // all-or-nothing for this column's value set
+            }
+            rangeNodes.add(node.get());
+        }
+        if (rangeNodes.isEmpty()) {
+            return Optional.empty();
+        }
+        if (rangeNodes.size() == 1) {
+            return Optional.of(rangeNodes.get(0));
+        }
+        return Optional.of(orNode(rangeNodes)); // union of disjoint ranges
+    }
+
+    /** Translate one {@link Range} into a Compare (single value) or bounded And. */
+    private static Optional<JsonNode> translateRange(String column, Type type, Range range) {
+        if (range.isAll()) {
+            return Optional.empty();
+        }
+        if (range.isSingleValue()) {
+            return constantToJson(type, range.getSingleValue())
+                    .map(v -> compareNode(column, "Equal", v));
+        }
+        List<JsonNode> bounds = new ArrayList<>();
+        if (!range.isLowUnbounded()) {
+            Optional<JsonNode> v = constantToJson(type, range.getLowBoundedValue());
+            if (v.isEmpty()) {
+                return Optional.empty();
+            }
+            bounds.add(compareNode(column, range.isLowInclusive() ? "Gte" : "Gt", v.get()));
+        }
+        if (!range.isHighUnbounded()) {
+            Optional<JsonNode> v = constantToJson(type, range.getHighBoundedValue());
+            if (v.isEmpty()) {
+                return Optional.empty();
+            }
+            bounds.add(compareNode(column, range.isHighInclusive() ? "Lte" : "Lt", v.get()));
+        }
+        if (bounds.isEmpty()) {
+            return Optional.empty();
+        }
+        if (bounds.size() == 1) {
+            return Optional.of(bounds.get(0));
+        }
+        return Optional.of(andNode(bounds));
+    }
+
+    /** Build a {@code Compare} leaf node. */
+    private static ObjectNode compareNode(String column, String op, JsonNode value) {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("type", "Compare");
+        node.put("column", column);
+        node.put("op", op);
+        node.set("value", value);
+        return node;
+    }
+
+    /**
+     * Convert a domain's native Trino operand into the JSON scalar the server
+     * decodes, reusing the expression path's {@link #constantValue} type mapping so
+     * both paths emit identical wire values.
+     */
+    private static Optional<JsonNode> constantToJson(Type type, Object value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        return constantValue(new Constant(value, type));
+    }
+
+    /**
      * Combine two already-translated predicate trees with a logical {@code And},
      * flattening either side that is itself an {@code And} so repeated
-     * accumulation across {@code applyFilter} calls does not nest unboundedly.
+     * accumulation across {@code applyFilter} calls does not nest unboundedly, and
+     * dropping exact-duplicate conjuncts so re-pushing an already-present predicate
+     * (e.g. the unchanged {@code TupleDomain} summary re-passed every iteration) is
+     * a no-op rather than an ever-growing tree (issue #2164 idempotence).
      */
     public static JsonNode and(JsonNode left, JsonNode right) {
         List<JsonNode> children = new ArrayList<>();
         appendConjuncts(left, children);
         appendConjuncts(right, children);
-        return andNode(children);
+        List<JsonNode> deduped = new ArrayList<>();
+        for (JsonNode child : children) {
+            if (!deduped.contains(child)) {
+                deduped.add(child);
+            }
+        }
+        return andNode(deduped);
     }
 
     private static void appendConjuncts(JsonNode expr, List<JsonNode> out) {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataApplyFilterTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataApplyFilterTest.java
@@ -200,6 +200,37 @@ class CqliteFlightMetadataApplyFilterTest {
     }
 
     @Test
+    void multiValueSummaryEmitsCanonicalOrderAndGuardHolds() throws Exception {
+        // Roborev finding (#2166): the idempotence/accumulation guard compares
+        // SERIALIZED JSON, so the same logical multi-value domain must serialize
+        // byte-identically regardless of the ValueSet's iteration order. Build the
+        // SAME logical domain via two constructions with OPPOSITE insertion orders.
+        var forward = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                PK, Domain.multipleValues(VARCHAR,
+                        List.of(Slices.utf8Slice("a"), Slices.utf8Slice("b"), Slices.utf8Slice("c")))));
+        var reversed = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                PK, Domain.multipleValues(VARCHAR,
+                        List.of(Slices.utf8Slice("c"), Slices.utf8Slice("b"), Slices.utf8Slice("a")))));
+
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+        var first = metadata.applyFilter(null, handle, summaryOnly(forward)).orElseThrow();
+        String firstJson = ((CqliteFlightTableHandle) first.getHandle()).filterJson().orElseThrow();
+
+        // Emitted values array is in canonical sorted order (never ValueSet order).
+        JsonNode filter = MAPPER.readTree(firstJson);
+        assertEquals("In", filter.get("type").asText());
+        assertEquals("a", filter.get("values").get(0).asText());
+        assertEquals("b", filter.get("values").get(1).asText());
+        assertEquals("c", filter.get("values").get(2).asText());
+
+        // The reversed-order construction of the identical logical domain must hit
+        // the already-pushed guard: byte-identical serialization → Optional.empty()
+        // (no re-apply, no planner loop).
+        assertTrue(metadata.applyFilter(null, first.getHandle(), summaryOnly(reversed)).isEmpty(),
+                "identical logical IN domain (different construction order) must not re-apply");
+    }
+
+    @Test
     void numericRangeSummaryPushesComparison() throws Exception {
         // age > 10 delivered as a range domain.
         var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataApplyFilterTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataApplyFilterTest.java
@@ -12,7 +12,10 @@ import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.StandardFunctions;
 import io.trino.spi.expression.Variable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -125,6 +128,175 @@ class CqliteFlightMetadataApplyFilterTest {
         assertEquals("age", exprs.get(0).get("column").asText());
         assertEquals("Equal", exprs.get(1).get("op").asText());
         assertEquals("name", exprs.get(1).get("column").asText());
+    }
+
+    // ---- Domain-delivery path (issue #2164): Trino sends simple predicates as a
+    // ---- TupleDomain summary with getExpression()=TRUE, which the old applyFilter
+    // ---- ignored (filterJson stayed empty → full scan for a point read). ----
+
+    /** Column handles that ARE the TupleDomain keys (Trino keys the summary by ColumnHandle). */
+    private static final CqliteFlightColumnHandle PK =
+            new CqliteFlightColumnHandle("pk", VARCHAR, PushdownCapability.FULL);
+    private static final CqliteFlightColumnHandle AGE =
+            new CqliteFlightColumnHandle("age", BIGINT, PushdownCapability.FULL);
+    private static final CqliteFlightColumnHandle UUID_ID =
+            new CqliteFlightColumnHandle("id", VARCHAR, PushdownCapability.EQUALITY);
+    private static final CqliteFlightColumnHandle OPAQUE =
+            new CqliteFlightColumnHandle("blob_col", VARCHAR, PushdownCapability.NONE);
+
+    private Constraint summaryOnly(TupleDomain<ColumnHandle> summary) {
+        // How Trino actually delivers a domain-expressible predicate: it lives in the
+        // summary, the expression is TRUE.
+        return new Constraint(summary, Constant.TRUE, ASSIGN);
+    }
+
+    private JsonNode appliedFilter(Constraint constraint) throws Exception {
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+        var applied = metadata.applyFilter(null, handle, constraint).orElseThrow();
+        // The residual summary is returned UNCHANGED (unenforced): the server applies
+        // the pushed filter best-effort post-decode and Trino keeps its ScanFilter above.
+        assertEquals(constraint.getSummary(), applied.getRemainingFilter());
+        return MAPPER.readTree(
+                ((CqliteFlightTableHandle) applied.getHandle()).filterJson().orElseThrow());
+    }
+
+    @Test
+    void singleValueSummaryPushesEquality() throws Exception {
+        // key = '001.25.535688' delivered as a single-value varchar domain.
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                PK, Domain.singleValue(VARCHAR, Slices.utf8Slice("001.25.535688"))));
+        JsonNode filter = appliedFilter(summaryOnly(summary));
+        assertEquals("Compare", filter.get("type").asText());
+        assertEquals("pk", filter.get("column").asText());
+        assertEquals("Equal", filter.get("op").asText());
+        assertEquals("001.25.535688", filter.get("value").asText());
+    }
+
+    @Test
+    void singleValueSummaryReturnsSummaryUnenforced() throws Exception {
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                PK, Domain.singleValue(VARCHAR, Slices.utf8Slice("v"))));
+        Constraint constraint = summaryOnly(summary);
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+        var applied = metadata.applyFilter(null, handle, constraint).orElseThrow();
+        // Remaining domain == the FULL input summary: Trino keeps enforcing it (the
+        // pushdown is a best-effort optimization, not an enforcement guarantee).
+        assertEquals(constraint.getSummary(), applied.getRemainingFilter());
+        // Expression residual is TRUE (there was no expression predicate).
+        assertSame(Constant.TRUE, applied.getRemainingExpression().orElseThrow());
+    }
+
+    @Test
+    void multiValueSummaryPushesIn() throws Exception {
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                PK, Domain.multipleValues(VARCHAR,
+                        List.of(Slices.utf8Slice("a"), Slices.utf8Slice("b")))));
+        JsonNode filter = appliedFilter(summaryOnly(summary));
+        assertEquals("In", filter.get("type").asText());
+        assertEquals("pk", filter.get("column").asText());
+        assertEquals(2, filter.get("values").size());
+        assertEquals("a", filter.get("values").get(0).asText());
+        assertEquals("b", filter.get("values").get(1).asText());
+    }
+
+    @Test
+    void numericRangeSummaryPushesComparison() throws Exception {
+        // age > 10 delivered as a range domain.
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                AGE, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 10L)), false)));
+        JsonNode filter = appliedFilter(summaryOnly(summary));
+        assertEquals("Compare", filter.get("type").asText());
+        assertEquals("age", filter.get("column").asText());
+        assertEquals("Gt", filter.get("op").asText());
+        assertEquals(10L, filter.get("value").asLong());
+    }
+
+    @Test
+    void boundedRangeSummaryPushesAndOfComparisons() throws Exception {
+        // age BETWEEN 5 AND 10 → one range [5,10] → And(Gte 5, Lte 10).
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                AGE, Domain.create(
+                        ValueSet.ofRanges(Range.range(BIGINT, 5L, true, 10L, true)), false)));
+        JsonNode filter = appliedFilter(summaryOnly(summary));
+        assertEquals("And", filter.get("type").asText());
+        JsonNode exprs = filter.get("exprs");
+        assertEquals(2, exprs.size());
+        assertEquals("Gte", exprs.get(0).get("op").asText());
+        assertEquals(5L, exprs.get(0).get("value").asLong());
+        assertEquals("Lte", exprs.get(1).get("op").asText());
+        assertEquals(10L, exprs.get(1).get("value").asLong());
+    }
+
+    @Test
+    void noneCapabilitySummaryDoesNotPush() {
+        // A domain on a NONE-capability column is unpushable — must not push, must not throw.
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                OPAQUE, Domain.singleValue(VARCHAR, Slices.utf8Slice("x"))));
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+        assertTrue(metadata.applyFilter(null, handle, summaryOnly(summary)).isEmpty());
+    }
+
+    @Test
+    void rangeOnEqualityOnlyColumnDoesNotPush() {
+        // uuid/timeuuid surface as EQUALITY: ordering is NOT safe to push. A range
+        // domain on such a column must stay unpushed (left to Trino).
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                UUID_ID, Domain.create(
+                        ValueSet.ofRanges(Range.greaterThan(VARCHAR, Slices.utf8Slice("m"))), false)));
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+        assertTrue(metadata.applyFilter(null, handle, summaryOnly(summary)).isEmpty());
+    }
+
+    @Test
+    void equalityOnlyColumnSingleValueSummaryPushes() throws Exception {
+        // Exact match IS safe on an EQUALITY column (id = 'uuid-literal').
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                UUID_ID, Domain.singleValue(VARCHAR, Slices.utf8Slice("abc"))));
+        JsonNode filter = appliedFilter(summaryOnly(summary));
+        assertEquals("Compare", filter.get("type").asText());
+        assertEquals("id", filter.get("column").asText());
+        assertEquals("Equal", filter.get("op").asText());
+    }
+
+    @Test
+    void nullAllowedDomainDoesNotPush() {
+        // key = 'v' OR key IS NULL: pushing just the value would drop null rows
+        // (the server applies the filter destructively). Leave it entirely to Trino.
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                PK, Domain.create(ValueSet.of(VARCHAR, Slices.utf8Slice("v")), true)));
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+        assertTrue(metadata.applyFilter(null, handle, summaryOnly(summary)).isEmpty());
+    }
+
+    @Test
+    void domainSummaryIsIdempotent() throws Exception {
+        // Trino returns the summary unchanged, so it re-passes the SAME domain on the
+        // next iteration. Re-applying must NOT duplicate/loop.
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                PK, Domain.singleValue(VARCHAR, Slices.utf8Slice("v"))));
+        Constraint constraint = summaryOnly(summary);
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+        var first = metadata.applyFilter(null, handle, constraint).orElseThrow();
+        assertTrue(metadata.applyFilter(null, first.getHandle(), constraint).isEmpty(),
+                "re-applying an already-pushed domain must stop (no loop)");
+    }
+
+    @Test
+    void summaryAndExpressionMergeIntoOneFilter() throws Exception {
+        // age > 10 comes in the expression; name = 'x' comes in the summary. Both
+        // must land in the pushed tree (ANDed).
+        var expr = compare(StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME,
+                "age", BIGINT, 10L, BIGINT);
+        var nameHandle = new CqliteFlightColumnHandle("name", VARCHAR, PushdownCapability.FULL);
+        var summary = TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                nameHandle, Domain.singleValue(VARCHAR, Slices.utf8Slice("x"))));
+        ConnectorTableHandle handle = new CqliteFlightTableHandle("ks", "t", "ddl");
+        var applied = metadata.applyFilter(null, handle, new Constraint(summary, expr, ASSIGN))
+                .orElseThrow();
+        JsonNode filter = MAPPER.readTree(
+                ((CqliteFlightTableHandle) applied.getHandle()).filterJson().orElseThrow());
+        assertEquals("And", filter.get("type").asText());
+        assertEquals(2, filter.get("exprs").size(), "both expression and summary predicates pushed");
     }
 
     @Test


### PR DESCRIPTION
Closes #2164.

## Root cause
`applyFilter` read only `constraint.getExpression()` and returned `constraint.getSummary()` unchanged (":domain returned unchanged; we don't consume it"). But Trino delivers simple domain-expressible predicates — exactly `key = 'v'` on a varchar partition key — as a single-value **TupleDomain in the summary**, leaving `getExpression()` = `Constant.TRUE`. `PredicateTreeTranslator` (expression-tree only) found nothing → `applyFilter` returned `Optional.empty()` → `filterJson` empty → the flight server full-scanned every split for a single-partition point read.

## What changed (Java only, `trino-connector/`)
- **`PredicateTreeTranslator.translateSummary(TupleDomain)`** (new): per-column `Domain` → the SAME `PredicateExpr` node shapes the expression path emits — single value → `Compare Equal`, discrete set → `In`, ranges → `Compare Gt/Gte/Lt/Lte` (bounded range = `And` of two; multiple ranges = `Or`). Capability gating **mirrors `translateCompare` exactly**: `NONE` pushes nothing, `EQUALITY` pushes only exact match / `In` / `IsNull`, ordering (ranges) requires `FULL`. Columns are emitted in stable column-name order.
- **`applyFilter`**: translates the summary and **merges (AND)** it with the expression-path tree via `combinePushed`; the existing accumulation + termination guards, limit threading (`table.limit()`), and aggregated-handle decline are untouched.
- **`PredicateTreeTranslator.and()`**: now **dedups** exact-duplicate conjuncts, so the unchanged summary (re-passed every optimizer iteration) is idempotent instead of growing an ever-larger tree.

Wire format matches the server's internally-tagged `PredicateExpr` (`ticket.rs`) — same shapes the existing expression-path tests already emit; no new JSON invented.

## Enforced vs remaining (honesty contract — mirrors #2135/#2129 `limitGuaranteed=false`)
The summary is returned **UNCHANGED** as the remaining (unenforced) filter. The pushed `filterJson` is a **best-effort server-side optimization**: the server applies it post-decode and Trino keeps its `ScanFilter` above, so results are always correct even if a leaf is dropped server-side. Nothing here claims enforcement, so no over-restrictive push can lose rows. Null-admitting domains (`col = x OR col IS NULL`) are left **entirely unpushed** — the server filter is destructive, so pushing only the non-null values would wrongly drop null rows.

## Test evidence (TDD, fail-first)
New tests in `CqliteFlightMetadataApplyFilterTest` deliver predicates the way Trino does (summary + `Constant.TRUE` expression): single-value varchar, IN, numeric range, bounded range, expression+summary merge, plus negatives (NONE-capability, range-on-EQUALITY, null-allowed) and domain idempotence.

**Fail-first on the unmodified production code** (proves the gap):
```
8 tests failed (pushable-path assertions), e.g.
  singleValueSummaryPushesEquality()   FAILED  NoSuchElementException (filterJson empty)
  multiValueSummaryPushesIn()          FAILED  NoSuchElementException
  numericRangeSummaryPushesComparison()FAILED  NoSuchElementException
  summaryAndExpressionMergeIntoOneFilter() FAILED  AssertionFailedError
16 tests completed, 8 failed
```
The 3 negative tests already passed on unmodified code (they expect empty). After the fix, all pass.

**Gradle** (`./gradlew test`): `TOTAL tests=198 failures=0 errors=0 skipped=0`.

**Lite gate** (Rust untouched — Java-only diff):
```
RESULT: PASS
file-size PASS  fmt PASS  clippy PASS (260s)  scoped-tests PASS (239s)
```
Full `AGENT-GATE SUMMARY` runs once pre-merge in flow-closer.

## Scope notes
- Wire format forced **no compromises** — the summary path reuses the expression path's `constantValue` type mapping, so both emit identical operands.
- Follow-on (NOT in this PR, per the issue): derive split token bounds from a pushed partition-key equality (`murmur3(pk)`) so a point read prunes to ONE split instead of post-filtering all splits.
