### PR TITLE
feat(#1476): streaming do_get — bounded-channel egress, first rows before merge completion (AB1)

### DIFF
--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -17,6 +17,7 @@ pub mod producer;
 pub mod service;
 pub mod shutdown;
 pub mod stats;
+pub mod streaming;
 pub mod ticket;
 
 #[cfg(test)]

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -82,6 +82,18 @@ pub enum ProducerError {
         /// Which ticket field produced the escaping path (`table`/`snapshot`).
         field: &'static str,
     },
+    /// The merge panicked on the blocking pool while streaming (issue #1476,
+    /// roborev B1). Forwarded into the channel as a terminal error so a
+    /// mid-stream panic surfaces as a gRPC `internal` `Status` — never a
+    /// silently truncated, clean `Ok` end-of-stream (a dropped `tx` from a
+    /// panicking task looks identical to "the merge finished" to a consumer
+    /// unless this is forwarded explicitly).
+    #[error("merge task panicked: {message}")]
+    Panicked {
+        /// Best-effort panic payload message (`&str`/`String` payloads are
+        /// extracted verbatim; anything else is a fixed placeholder).
+        message: String,
+    },
 }
 
 /// Source of the SSTable `Data.db` files to merge for one table.

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -471,8 +471,28 @@ impl MergeProducer {
     /// the response stream — a missing table stays a clean `not_found`, not a
     /// mid-stream error. Runs blocking filesystem I/O; call off the async reactor.
     pub fn resolve_paths(&self, source: &dyn SstableSource) -> Result<Vec<PathBuf>, ProducerError> {
+        self.resolve_paths_cancellable(source, &CancelFlag::new())
+    }
+
+    /// Like [`Self::resolve_paths`], but cooperatively cancellable (issue #1476,
+    /// roborev F1): the pre-change single merge `spawn_blocking` was covered by a
+    /// `CancelGuard` across its ENTIRE await, so a client disconnect during that
+    /// call stopped the work. The streaming rewrite's separate eager-setup phase
+    /// (discovery + token prune, which can be slow over MANY SSTables) needs the
+    /// same coverage — otherwise a disconnect before the response stream even
+    /// exists leaves this phase running to completion, pinning a blocking-pool
+    /// thread under churn. Polls `cancel` before listing and (via
+    /// [`Self::prune_paths_cancellable`]) once per SSTable during the prune.
+    pub fn resolve_paths_cancellable(
+        &self,
+        source: &dyn SstableSource,
+        cancel: &CancelFlag,
+    ) -> Result<Vec<PathBuf>, ProducerError> {
+        if cancel.is_cancelled() {
+            return Err(ProducerError::Cancelled);
+        }
         let paths = source.data_paths()?;
-        self.prune_paths(paths)
+        self.prune_paths_cancellable(paths, cancel)
     }
 
     /// Merge already-resolved (data-listed + token-pruned) `paths` into a `Vec`
@@ -520,20 +540,40 @@ impl MergeProducer {
     /// (fail open) whenever its sibling `Summary.db` is missing or unreadable, so
     /// pruning can never drop an SSTable that might contain matching partitions.
     pub(crate) fn prune_paths(&self, paths: Vec<PathBuf>) -> Result<Vec<PathBuf>, ProducerError> {
+        self.prune_paths_cancellable(paths, &CancelFlag::new())
+    }
+
+    /// Like [`Self::prune_paths`], but polls `cancel` before each per-SSTable
+    /// `Summary.db` read (issue #1476, roborev F1) — the only potentially I/O-heavy
+    /// per-item work in path resolution, and so the natural cancellation boundary
+    /// for a table with many SSTables. A fresh, never-cancelled [`CancelFlag`]
+    /// (as `prune_paths` passes) makes this identical to the original
+    /// filter-based implementation.
+    pub(crate) fn prune_paths_cancellable(
+        &self,
+        paths: Vec<PathBuf>,
+        cancel: &CancelFlag,
+    ) -> Result<Vec<PathBuf>, ProducerError> {
         let Some(token) = &self.spec.token else {
             return Ok(paths);
         };
 
         let total = paths.len();
-        let kept: Vec<PathBuf> = paths
-            .into_iter()
-            .filter(|path| match sstable_token_span(path) {
+        let mut kept: Vec<PathBuf> = Vec::with_capacity(total);
+        for path in paths {
+            if cancel.is_cancelled() {
+                return Err(ProducerError::Cancelled);
+            }
+            let keep = match sstable_token_span(&path) {
                 // Span known: keep only if it overlaps the split's range.
                 Some((min_token, max_token)) => token.overlaps(min_token, max_token),
                 // Span unknown (missing/unreadable Summary.db): fail open.
                 None => true,
-            })
-            .collect();
+            };
+            if keep {
+                kept.push(path);
+            }
+        }
 
         tracing::debug!(
             kept = kept.len(),
@@ -1009,6 +1049,76 @@ mod tests {
         assert!(
             batches.is_empty(),
             "no output batch is produced when cancelled before the first step"
+        );
+    }
+
+    // ---- Issue #1476 roborev F1: cancellable path resolution/prune ------------
+
+    /// [`MergeProducer::resolve_paths_cancellable`] must reject an
+    /// already-cancelled flag BEFORE even listing the directory — the fast-path
+    /// check `do_get_setup`'s eager phase relies on to stop instantly on a
+    /// disconnect that fires the setup-phase `CancelGuard` before the blocking
+    /// task starts.
+    #[test]
+    fn resolve_paths_cancellable_rejects_before_listing() {
+        let schema = simple_schema();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+        let producer = MergeProducer::new(schema, 1024).unwrap();
+
+        let cancelled = CancelFlag::new();
+        cancelled.cancel();
+        let err = producer
+            .resolve_paths_cancellable(&DirSource::new(&dir), &cancelled)
+            .expect_err("pre-cancelled resolution aborts");
+        assert!(
+            matches!(err, ProducerError::Cancelled),
+            "expected ProducerError::Cancelled, got {err:?}"
+        );
+    }
+
+    /// [`MergeProducer::prune_paths_cancellable`] must stop BEFORE reading any
+    /// SSTable's `Summary.db` when pre-cancelled — proven against a REAL
+    /// multi-SSTable, token-filtered spec where an uncancelled run would read
+    /// every one (same token-filter setup as the plain `prune_paths` coverage),
+    /// so this isn't a vacuous check against an empty/no-op path.
+    #[test]
+    fn prune_paths_cancellable_stops_before_any_summary_read_when_pre_cancelled() {
+        use crate::ticket::FlightTicket;
+        let schema = simple_schema();
+        let rows = (1..=5)
+            .map(|i| write_row(i, &format!("n{i}"), i, 100))
+            .collect::<Vec<_>>();
+        // Two SSTables so the prune loop has more than one item to (not) visit.
+        let (_temp, _data, dir) =
+            build_sstables(&schema, vec![rows[..2].to_vec(), rows[2..].to_vec()]);
+
+        let spec = spec_from(
+            &schema,
+            FlightTicket {
+                token_start: Some(i64::MIN),
+                token_end: Some(i64::MAX),
+                ..Default::default()
+            },
+        );
+        let producer = MergeProducer::with_spec(schema, 1024, spec).unwrap();
+        let paths = DirSource::new(&dir).data_paths().unwrap();
+        assert_eq!(paths.len(), 2, "fixture has two SSTables to prune over");
+
+        // Baseline: uncancelled, a full-ring token filter keeps both.
+        let cancelled = CancelFlag::new();
+        let kept = producer
+            .prune_paths_cancellable(paths.clone(), &cancelled)
+            .expect("uncancelled prune succeeds");
+        assert_eq!(kept.len(), 2, "full-ring token filter keeps every SSTable");
+
+        // Pre-cancelled: must abort before visiting the first path.
+        cancelled.cancel();
+        let err = producer
+            .prune_paths_cancellable(paths, &cancelled)
+            .expect_err("pre-cancelled prune aborts");
+        assert!(
+            matches!(err, ProducerError::Cancelled),
+            "expected ProducerError::Cancelled, got {err:?}"
         );
     }
 

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -10,9 +10,15 @@
 //! clustering and regular columns taken from the decoded cells, row/cell
 //! tombstones suppressed.
 //!
-//! Phase 1 collects all batches in memory; this matches the merge engine, which
-//! already drains every input SSTable into memory (see `merge.rs` issue #591).
-//! True streaming is a later optimization.
+//! The retained `produce`/`produce_cancellable` collect all batches into a `Vec`
+//! (the byte-identity parity oracle + aggregate path). The streaming `do_get`
+//! path (issue #1476) drives the SAME merge through [`produce_streaming`], which
+//! emits each batch into a bounded channel via a [`BatchSink`] as it is produced
+//! — bounding resident payload to the channel capacity, independent of result
+//! size. Batch emission is factored behind [`BatchSink`] so both paths share one
+//! merge loop.
+//!
+//! [`produce_streaming`]: MergeProducer::produce_streaming
 
 use std::path::{Path, PathBuf};
 
@@ -295,6 +301,32 @@ impl PartitionStepper for KWayMerger {
     }
 }
 
+/// Sink for record batches emitted by the merge loop (issue #1476).
+///
+/// The merge is driven once by [`MergeProducer::drive_merge`]; the sink decides
+/// what happens to each batch. The retained collect path uses [`CollectSink`]
+/// (push into a `Vec`, the byte-identity parity oracle); the streaming `do_get`
+/// path (see `crate::streaming`) sends each batch into a bounded channel as it is
+/// produced. A sink `emit` may report [`ProducerError::Cancelled`] to stop the
+/// merge — the streaming sink returns it when the consumer (client) is gone.
+pub(crate) trait BatchSink {
+    /// Accept one produced batch, or return [`ProducerError::Cancelled`] to stop
+    /// the merge (the consumer has disconnected).
+    fn emit(&mut self, batch: RecordBatch) -> Result<(), ProducerError>;
+}
+
+/// Collect-into-`Vec` sink — the retained, byte-identical parity path used by
+/// [`MergeProducer::produce`]/[`produce_cancellable`](MergeProducer::produce_cancellable),
+/// the aggregate route, and the existing tests. Never signals cancellation.
+pub(crate) struct CollectSink<'a>(pub(crate) &'a mut Vec<RecordBatch>);
+
+impl BatchSink for CollectSink<'_> {
+    fn emit(&mut self, batch: RecordBatch) -> Result<(), ProducerError> {
+        self.0.push(batch);
+        Ok(())
+    }
+}
+
 impl MergeProducer {
     /// Build an unfiltered producer for `schema` (emits all rows and columns).
     pub fn new(schema: TableSchema, batch_size: usize) -> Result<Self, ProducerError> {
@@ -419,6 +451,57 @@ impl MergeProducer {
         self.merge_paths(paths, &CancelFlag::new())
     }
 
+    /// Resolve and token-prune the SSTable `Data.db` paths for `source`.
+    ///
+    /// Surfaces the discovery `NotFound` (missing table) eagerly and performs the
+    /// (potentially I/O-heavy) `Summary.db` token prune, so the streaming `do_get`
+    /// path (issue #1476) can settle these fallible/blocking steps BEFORE opening
+    /// the response stream — a missing table stays a clean `not_found`, not a
+    /// mid-stream error. Runs blocking filesystem I/O; call off the async reactor.
+    pub fn resolve_paths(&self, source: &dyn SstableSource) -> Result<Vec<PathBuf>, ProducerError> {
+        let paths = source.data_paths()?;
+        self.prune_paths(paths)
+    }
+
+    /// Merge already-resolved (data-listed + token-pruned) `paths` into a `Vec`
+    /// of Arrow batches, cooperatively cancellable. Used by the aggregate `do_get`
+    /// route, whose bounded per-group output stays materialized (issue #1476).
+    pub fn produce_from_resolved(
+        &self,
+        paths: Vec<PathBuf>,
+        cancel: &CancelFlag,
+    ) -> Result<Vec<RecordBatch>, ProducerError> {
+        self.merge_paths(paths, cancel)
+    }
+
+    /// Whether this producer emits partial-aggregate rows (issue #841). The
+    /// streaming `do_get` path keeps aggregation materialized (bounded output).
+    pub fn is_aggregating(&self) -> bool {
+        self.agg.is_some()
+    }
+
+    /// Stream the row-merge of already-resolved `paths` into `sink` (issue #1476),
+    /// one batch at a time, instead of collecting into a `Vec`. `paths` MUST come
+    /// from [`Self::resolve_paths`] (already token-pruned). The merge stops when
+    /// `sink.emit` reports [`ProducerError::Cancelled`] (client gone) or `cancel`
+    /// is set — both within a bounded number of merge steps.
+    ///
+    /// Aggregation is NOT streamed here (its output is bounded); the service routes
+    /// aggregating tickets to [`Self::produce_from_resolved`]. Called defensively,
+    /// this returns without emitting for an aggregating producer.
+    pub(crate) fn produce_streaming(
+        &self,
+        paths: Vec<PathBuf>,
+        cancel: &CancelFlag,
+        sink: &mut dyn BatchSink,
+    ) -> Result<(), ProducerError> {
+        if self.agg.is_some() || paths.is_empty() {
+            return Ok(());
+        }
+        let mut merger = KWayMerger::new(paths, &self.schema).map_err(ProducerError::Merge)?;
+        self.drive_merge(&mut merger, cancel, sink)
+    }
+
     /// Prune `paths` to those whose token span overlaps the spec's token range.
     ///
     /// Returns `paths` unchanged when there is no token filter. A path is kept
@@ -470,7 +553,8 @@ impl MergeProducer {
         }
 
         let mut merger = KWayMerger::new(paths, &self.schema).map_err(ProducerError::Merge)?;
-        self.drive_merge(&mut merger, cancel, &mut batches)?;
+        let mut sink = CollectSink(&mut batches);
+        self.drive_merge(&mut merger, cancel, &mut sink)?;
         Ok(batches)
     }
 
@@ -493,7 +577,7 @@ impl MergeProducer {
         &self,
         merger: &mut dyn PartitionStepper,
         cancel: &CancelFlag,
-        batches: &mut Vec<RecordBatch>,
+        sink: &mut dyn BatchSink,
     ) -> Result<(), ProducerError> {
         let limit = self.spec.limit;
         // A zero cap produces no rows without touching the merge.
@@ -535,7 +619,7 @@ impl MergeProducer {
                 buffer.push(row);
                 emitted += 1;
                 if buffer.len() >= self.batch_size {
-                    batches.push(self.flush_buffer(&mut buffer)?);
+                    sink.emit(self.flush_buffer(&mut buffer)?)?;
                 }
                 // LIMIT reached (counted post-filter): stop the merge early.
                 if let Some(cap) = limit {
@@ -547,7 +631,7 @@ impl MergeProducer {
         }
 
         if !buffer.is_empty() {
-            batches.push(self.flush_buffer(&mut buffer)?);
+            sink.emit(self.flush_buffer(&mut buffer)?)?;
         }
         Ok(())
     }
@@ -894,9 +978,13 @@ mod tests {
         let cancelled = CancelFlag::new();
         cancelled.cancel();
         let mut batches = Vec::new();
-        let err = producer
-            .drive_merge(&mut counting, &cancelled, &mut batches)
-            .expect_err("pre-cancelled merge aborts");
+        // Scope the sink so its `&mut batches` borrow ends before we inspect it.
+        let err = {
+            let mut sink = CollectSink(&mut batches);
+            producer
+                .drive_merge(&mut counting, &cancelled, &mut sink)
+                .expect_err("pre-cancelled merge aborts")
+        };
 
         assert!(
             matches!(err, ProducerError::Cancelled),

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -450,50 +450,54 @@ impl CqliteFlightService {
     }
 
     /// Eager, fallible `do_get` setup shared by the row and aggregate paths: parse
-    /// the ticket, build the producer + Arrow schema, and resolve + token-prune the
-    /// SSTable paths off the async reactor (the prune reads `Summary.db` files).
-    /// A missing table surfaces as `not_found` here, before any stream opens.
+    /// the ticket, build the producer + Arrow schema, resolve the table's on-disk
+    /// directory, and token-prune the SSTable paths. A missing table surfaces as
+    /// `not_found` here, before any stream opens.
     ///
-    /// `cancel` is polled inside the blocking discovery/prune task (issue #1476,
-    /// roborev F1) so a client disconnect during this (potentially slow, many-
-    /// SSTable) phase stops it instead of running to completion.
+    /// The ENTIRE fallible sequence — schema/producer construction,
+    /// `DirSource::resolve` (filesystem `is_dir`/`read_dir`, including the
+    /// Cassandra `<table>-<uuid>` layout scan), and the token-prune (reads a
+    /// sibling `Summary.db` per SSTable) — runs in ONE `spawn_blocking` closure
+    /// (issue #1476, roborev round 3). Pre-change, ALL filesystem access for
+    /// `do_get` ran inside the blocking task; letting any of it run on the async
+    /// request task instead would stall the gRPC reactor for unrelated RPCs under
+    /// slow/busy storage. `cancel` is polled inside this same closure (issue
+    /// #1476, roborev F1) so a client disconnect during setup stops it instead of
+    /// running to completion; `do_get_inner`'s `CancelGuard` still covers this
+    /// whole `.await` for the future-drop case.
     async fn do_get_setup(
         &self,
         request: Request<Ticket>,
         cancel: &CancelFlag,
     ) -> Result<DoGetSetup, Status> {
         let ticket = FlightTicket::from_bytes(&request.into_inner().ticket)?;
-        let producer = self.build_producer(&ticket)?;
-        let schema_ref = Arc::new(producer.arrow_schema()?);
-        let source = DirSource::resolve(
-            &self.data_dir,
-            &ticket.keyspace,
-            &ticket.table,
-            ticket.snapshot.as_deref(),
-        )?;
-        let aggregating = producer.is_aggregating();
-
-        // Return the producer back out of the blocking task (it is moved in to run
-        // the blocking discovery/prune, then reused for the merge) — avoids an Arc
-        // and its Sync bound.
+        let svc = self.clone();
         let resolve_cancel = cancel.clone();
-        let (producer, paths) = tokio::task::spawn_blocking(move || {
-            let paths = producer.resolve_paths_cancellable(&source, &resolve_cancel);
-            (producer, paths)
+
+        tokio::task::spawn_blocking(move || -> Result<DoGetSetup, Status> {
+            let producer = svc.build_producer(&ticket)?;
+            let schema_ref = Arc::new(producer.arrow_schema()?);
+            let source = DirSource::resolve(
+                &svc.data_dir,
+                &ticket.keyspace,
+                &ticket.table,
+                ticket.snapshot.as_deref(),
+            )?;
+            let aggregating = producer.is_aggregating();
+            // A cancellation here surfaces as `ProducerError::Cancelled`, mapped
+            // by `From<ProducerError> for Status` to `Status::aborted` — the same
+            // clean, expected-abort class as a merge-stage cancellation.
+            let paths = producer.resolve_paths_cancellable(&source, &resolve_cancel)?;
+
+            Ok(DoGetSetup {
+                producer,
+                schema_ref,
+                paths,
+                aggregating,
+            })
         })
         .await
-        .map_err(|e| Status::internal(format!("path resolution panicked: {e}")))?;
-        // A cancellation here surfaces as `ProducerError::Cancelled`, mapped by
-        // `From<ProducerError> for Status` to `Status::aborted` — the same clean,
-        // expected-abort class as a merge-stage cancellation.
-        let paths = paths?;
-
-        Ok(DoGetSetup {
-            producer,
-            schema_ref,
-            paths,
-            aggregating,
-        })
+        .map_err(|e| Status::internal(format!("do_get setup panicked: {e}")))?
     }
 
     /// Body of [`FlightService::do_action`], run inside the RPC span (issue #944).

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -30,6 +30,7 @@ use tonic::{Request, Response, Status, Streaming};
 use cqlite_core::schema::{parse_cql_schema, TableSchema};
 use tracing::Instrument;
 
+use crate::cancel::CancelFlag;
 use crate::filter::{FilterError, ScanSpec};
 use crate::obs::{rpc_span, RpcMetrics};
 use crate::producer::{DirSource, MergeProducer, ProducerError};
@@ -392,13 +393,27 @@ impl CqliteFlightService {
         request: Request<Ticket>,
         metrics: RpcMetrics,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, (Status, RpcMetrics)> {
+        // Cancellation (issue #1476, roborev F1): pre-change, the single merge
+        // `spawn_blocking` was covered by a `CancelGuard` held across its whole
+        // `.await`, so a client disconnect during that call stopped the work. The
+        // streaming rewrite splits eager setup (path discovery/token-prune, which
+        // reads a `Summary.db` per SSTable and can be slow over many of them) from
+        // the merge stage; ONE `CancelFlag` now spans both so a disconnect during
+        // EITHER phase stops it — `setup_guard` covers the setup await (disarmed
+        // once setup succeeds; a still-armed guard cancels on this future's drop),
+        // and the SAME flag hands off to the merge stage under a fresh guard
+        // (`spawn_streaming`/`build_aggregate_response`) covering the stream's
+        // lifetime, exactly as before this fix.
+        let cancel = CancelFlag::new();
+        let mut setup_guard = cancel.drop_guard();
         // Fallible eager setup: parse the ticket, build the producer + schema, and
         // resolve/token-prune the SSTable paths off the reactor. A missing table
         // surfaces here as a clean `not_found` BEFORE the stream opens.
-        let setup = match self.do_get_setup(request).await {
+        let setup = match self.do_get_setup(request, &cancel).await {
             Ok(setup) => setup,
             Err(status) => return Err((status, metrics)),
         };
+        setup_guard.disarm();
         let DoGetSetup {
             producer,
             schema_ref,
@@ -410,8 +425,10 @@ impl CqliteFlightService {
             // Aggregate output is bounded (one row per group): keep materializing
             // and serve it as a stream, unchanged in content (issue #1476).
             return Ok(Response::new(
-                crate::streaming::build_aggregate_response(producer, paths, schema_ref, metrics)
-                    .await?,
+                crate::streaming::build_aggregate_response(
+                    producer, paths, schema_ref, metrics, cancel,
+                )
+                .await?,
             ));
         }
 
@@ -427,6 +444,7 @@ impl CqliteFlightService {
             metrics,
             crate::streaming::DO_GET_CHANNEL_CAPACITY,
             crate::streaming::StreamProbe::default(),
+            cancel,
         );
         Ok(Response::new(stream))
     }
@@ -435,7 +453,15 @@ impl CqliteFlightService {
     /// the ticket, build the producer + Arrow schema, and resolve + token-prune the
     /// SSTable paths off the async reactor (the prune reads `Summary.db` files).
     /// A missing table surfaces as `not_found` here, before any stream opens.
-    async fn do_get_setup(&self, request: Request<Ticket>) -> Result<DoGetSetup, Status> {
+    ///
+    /// `cancel` is polled inside the blocking discovery/prune task (issue #1476,
+    /// roborev F1) so a client disconnect during this (potentially slow, many-
+    /// SSTable) phase stops it instead of running to completion.
+    async fn do_get_setup(
+        &self,
+        request: Request<Ticket>,
+        cancel: &CancelFlag,
+    ) -> Result<DoGetSetup, Status> {
         let ticket = FlightTicket::from_bytes(&request.into_inner().ticket)?;
         let producer = self.build_producer(&ticket)?;
         let schema_ref = Arc::new(producer.arrow_schema()?);
@@ -450,12 +476,16 @@ impl CqliteFlightService {
         // Return the producer back out of the blocking task (it is moved in to run
         // the blocking discovery/prune, then reused for the merge) — avoids an Arc
         // and its Sync bound.
+        let resolve_cancel = cancel.clone();
         let (producer, paths) = tokio::task::spawn_blocking(move || {
-            let paths = producer.resolve_paths(&source);
+            let paths = producer.resolve_paths_cancellable(&source, &resolve_cancel);
             (producer, paths)
         })
         .await
         .map_err(|e| Status::internal(format!("path resolution panicked: {e}")))?;
+        // A cancellation here surfaces as `ProducerError::Cancelled`, mapped by
+        // `From<ProducerError> for Status` to `Status::aborted` — the same clean,
+        // expected-abort class as a merge-stage cancellation.
         let paths = paths?;
 
         Ok(DoGetSetup {
@@ -663,6 +693,96 @@ mod tests {
             Err(e) => e,
         };
         assert_eq!(err.code(), tonic::Code::NotFound, "got: {err:?}");
+    }
+
+    // ---- Issue #1476 roborev F1: setup-phase cancellation ----------------------
+
+    /// Pre-change, the single merge `spawn_blocking` was covered by a
+    /// `CancelGuard` across its whole `.await`, so a disconnect during that call
+    /// stopped the work. `do_get_setup`'s eager path discovery/token-prune phase
+    /// (its OWN, separate `spawn_blocking`) must honor the SAME cancellation
+    /// contract: a flag already cancelled when setup runs (the worst case of a
+    /// disconnect firing the setup-phase `CancelGuard` at or before the very
+    /// start of the blocking task) must stop resolution rather than run the
+    /// discovery/prune to completion, surfacing as a clean `Aborted` — never a
+    /// server fault and never a resolved path list.
+    ///
+    /// Uses a token-range ticket over multiple SSTables so an UNCANCELLED run
+    /// would genuinely read every sibling `Summary.db` during the prune (see
+    /// `prune_paths_cancellable`), proving this isn't a vacuous check against an
+    /// empty/no-op path.
+    #[test]
+    fn do_get_setup_honors_cancellation_before_resolution() {
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) = build_sstables(
+            &schema,
+            vec![
+                vec![write_row(1, "a", 1, 100), write_row(2, "b", 2, 100)],
+                vec![write_row(3, "c", 3, 100), write_row(4, "d", 4, 100)],
+            ],
+        );
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let mut t = ticket(KS, TBL);
+        // A concrete (full-ring) token range so `ScanSpec.token` is `Some(..)` and
+        // `prune_paths_cancellable`'s per-SSTable loop actually runs.
+        t.token_start = Some(i64::MIN);
+        t.token_end = Some(i64::MAX);
+
+        let result = rt.block_on(async {
+            // Simulates the setup-phase `CancelGuard` having already fired (the
+            // client disconnected) by the time the blocking resolution task runs.
+            let cancel = CancelFlag::new();
+            cancel.cancel();
+            let bytes = t.to_bytes().unwrap();
+            svc.do_get_setup(Request::new(Ticket::new(bytes)), &cancel)
+                .await
+        });
+        let err = match result {
+            Ok(_) => panic!("a cancelled setup must not resolve/return paths"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err.code(),
+            tonic::Code::Aborted,
+            "cancellation must surface as Aborted (ProducerError::Cancelled → Status::aborted), \
+             got: {err:?}"
+        );
+    }
+
+    /// Baseline for the test above: the SAME token-range ticket, WITHOUT
+    /// cancellation, resolves normally — proving the cancelled case above is a
+    /// genuine early stop, not just "this ticket always errors."
+    #[test]
+    fn do_get_setup_resolves_normally_without_cancellation() {
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) = build_sstables(
+            &schema,
+            vec![
+                vec![write_row(1, "a", 1, 100), write_row(2, "b", 2, 100)],
+                vec![write_row(3, "c", 3, 100), write_row(4, "d", 4, 100)],
+            ],
+        );
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let mut t = ticket(KS, TBL);
+        t.token_start = Some(i64::MIN);
+        t.token_end = Some(i64::MAX);
+
+        let setup = rt.block_on(async {
+            let cancel = CancelFlag::new();
+            let bytes = t.to_bytes().unwrap();
+            svc.do_get_setup(Request::new(Ticket::new(bytes)), &cancel)
+                .await
+        });
+        let setup = setup.expect("uncancelled setup resolves");
+        assert_eq!(
+            setup.paths.len(),
+            2,
+            "a full-ring token filter keeps both SSTables"
+        );
     }
 
     // ---- Issue #1430: end-to-end path-traversal rejection (wiring evidence) ----

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -70,7 +70,10 @@ impl From<ProducerError> for Status {
             ProducerError::Discovery { .. }
             | ProducerError::Merge(_)
             | ProducerError::Convert(_)
-            | ProducerError::Predicate(_) => Status::internal(msg),
+            | ProducerError::Predicate(_)
+            // A panic on the blocking pool (issue #1476, roborev B1) is a server
+            // fault surfaced mid-stream, same class as any other internal error.
+            | ProducerError::Panicked { .. } => Status::internal(msg),
         }
     }
 }

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -19,22 +19,17 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema as ArrowSchema;
 use arrow::ipc::writer::IpcWriteOptions;
-use arrow::record_batch::RecordBatch;
-use arrow_flight::encode::FlightDataEncoderBuilder;
-use arrow_flight::error::FlightError;
 use arrow_flight::flight_service_server::FlightService;
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
     HandshakeRequest, HandshakeResponse, PollInfo, PutResult, SchemaAsIpc, SchemaResult, Ticket,
 };
 use futures::Stream;
-use futures::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 
 use cqlite_core::schema::{parse_cql_schema, TableSchema};
 use tracing::Instrument;
 
-use crate::cancel::CancelFlag;
 use crate::filter::{FilterError, ScanSpec};
 use crate::obs::{rpc_span, RpcMetrics};
 use crate::producer::{DirSource, MergeProducer, ProducerError};
@@ -104,6 +99,17 @@ impl From<StatsError> for Status {
             StatsError::Discovery { .. } => Status::internal(msg),
         }
     }
+}
+
+/// Resolved, ready-to-serve `do_get` inputs produced by the eager setup step
+/// (issue #1476): the built producer, its Arrow schema, the token-pruned SSTable
+/// paths, and whether the ticket aggregates. Kept together so the row and
+/// aggregate response builders share one setup path.
+struct DoGetSetup {
+    producer: MergeProducer,
+    schema_ref: Arc<ArrowSchema>,
+    paths: Vec<PathBuf>,
+    aggregating: bool,
 }
 
 /// Flight service over a node-local SSTable data directory.
@@ -197,15 +203,23 @@ impl FlightService for CqliteFlightService {
         request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
         let span = rpc_span("do_get", &request);
-        let mut metrics = RpcMetrics::start("do_get");
-        // Run the read body AND finish() within the RPC span so the core
-        // query.execute / read-path spans nest under `flight.do_get`, and so
-        // error/status recording in finish() tags this span (not a stale current
-        // span after `.instrument` completes). The merge eagerly drains SSTables
-        // into memory, so the row/byte totals are known here and attributed here.
-        async {
-            let result = self.do_get_inner(request, &mut metrics).await;
-            finish(&mut metrics, result)
+        let metrics = RpcMetrics::start("do_get");
+        // The merge now STREAMS through a bounded channel (issue #1476): batches
+        // reach the wire while it is still running, so the row/byte totals are not
+        // known here. `metrics` moves INTO the response stream, which accumulates
+        // per batch and records the terminal RPC counters when the stream ends
+        // (including the emitted prefix for a cancelled stream). On a setup error
+        // (before the stream exists) the metrics come back so we record the error
+        // and close the RPC within this span.
+        async move {
+            match self.do_get_inner(request, metrics).await {
+                Ok(response) => Ok(response),
+                Err((status, metrics)) => {
+                    crate::obs::record_status_error(&status);
+                    drop(metrics);
+                    Err(status)
+                }
+            }
         }
         .instrument(span)
         .await
@@ -366,13 +380,59 @@ impl CqliteFlightService {
         Ok(Response::new(schema_result))
     }
 
-    /// Body of [`FlightService::do_get`], run inside the RPC span. Reports the
-    /// rows + payload bytes produced by the merge into `metrics`.
+    /// Body of [`FlightService::do_get`], run inside the RPC span. Streams the
+    /// merge through a bounded channel (issue #1476). On a setup error (before the
+    /// response stream exists) `metrics` is returned so the caller can record the
+    /// error; on success `metrics` moves into the stream (recorded at stream end).
     async fn do_get_inner(
         &self,
         request: Request<Ticket>,
-        metrics: &mut RpcMetrics,
-    ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        metrics: RpcMetrics,
+    ) -> Result<Response<<Self as FlightService>::DoGetStream>, (Status, RpcMetrics)> {
+        // Fallible eager setup: parse the ticket, build the producer + schema, and
+        // resolve/token-prune the SSTable paths off the reactor. A missing table
+        // surfaces here as a clean `not_found` BEFORE the stream opens.
+        let setup = match self.do_get_setup(request).await {
+            Ok(setup) => setup,
+            Err(status) => return Err((status, metrics)),
+        };
+        let DoGetSetup {
+            producer,
+            schema_ref,
+            paths,
+            aggregating,
+        } = setup;
+
+        if aggregating {
+            // Aggregate output is bounded (one row per group): keep materializing
+            // and serve it as a stream, unchanged in content (issue #1476).
+            return Ok(Response::new(
+                crate::streaming::build_aggregate_response(producer, paths, schema_ref, metrics)
+                    .await?,
+            ));
+        }
+
+        // Row path: the merge runs on the blocking pool and sends each batch into a
+        // bounded channel; the response wraps the receiver. Peak resident payload
+        // is O(channel capacity · batch_size), not O(result). The merge task handle
+        // is detached (dropping it does not cancel `spawn_blocking`; a dropped
+        // response stream cancels the merge cooperatively).
+        let (stream, _merge_handle) = crate::streaming::spawn_streaming(
+            producer,
+            paths,
+            schema_ref,
+            metrics,
+            crate::streaming::DO_GET_CHANNEL_CAPACITY,
+            crate::streaming::StreamProbe::default(),
+        );
+        Ok(Response::new(stream))
+    }
+
+    /// Eager, fallible `do_get` setup shared by the row and aggregate paths: parse
+    /// the ticket, build the producer + Arrow schema, and resolve + token-prune the
+    /// SSTable paths off the async reactor (the prune reads `Summary.db` files).
+    /// A missing table surfaces as `not_found` here, before any stream opens.
+    async fn do_get_setup(&self, request: Request<Ticket>) -> Result<DoGetSetup, Status> {
         let ticket = FlightTicket::from_bytes(&request.into_inner().ticket)?;
         let producer = self.build_producer(&ticket)?;
         let schema_ref = Arc::new(producer.arrow_schema()?);
@@ -382,52 +442,25 @@ impl CqliteFlightService {
             &ticket.table,
             ticket.snapshot.as_deref(),
         )?;
+        let aggregating = producer.is_aggregating();
 
-        // The merge drains SSTables into memory and is CPU-bound — run it off the
-        // async runtime so it cannot stall the gRPC reactor. A missing table
-        // directory surfaces as `not_found`; an existing table with no SSTables
-        // yields an empty result (schema only).
-        //
-        // Cancellation (issue #1473): `spawn_blocking` is NOT cancelled when this
-        // future is dropped, so a client that disconnects mid-`do_get` would
-        // otherwise leave the merge running to completion, pinning a blocking-pool
-        // thread. We hold a `CancelGuard` across the `.await`: if the future is
-        // dropped (client gone) the guard cancels the flag, and the merge loop —
-        // which polls it between partition steps — aborts early with `Aborted`.
-        // On success we disarm the guard (the merge is done; nothing to cancel).
-        // The merge fully materializes its batches BEFORE the response stream is
-        // built, so the future-drop during this `.await` is the meaningful
-        // cancellation point; wrapping the post-materialization stream would have
-        // nothing left to cancel.
-        let cancel = CancelFlag::new();
-        let mut guard = cancel.drop_guard();
-        let merge_cancel = cancel.clone();
-        let batches = tokio::task::spawn_blocking(move || {
-            producer.produce_cancellable(&source, &merge_cancel)
+        // Return the producer back out of the blocking task (it is moved in to run
+        // the blocking discovery/prune, then reused for the merge) — avoids an Arc
+        // and its Sync bound.
+        let (producer, paths) = tokio::task::spawn_blocking(move || {
+            let paths = producer.resolve_paths(&source);
+            (producer, paths)
         })
         .await
-        .map_err(|e| Status::internal(format!("merge task panicked: {e}")))??;
-        guard.disarm();
+        .map_err(|e| Status::internal(format!("path resolution panicked: {e}")))?;
+        let paths = paths?;
 
-        // Attribute rows + in-memory payload bytes to this RPC. `get_array_memory_size`
-        // is the buffer footprint of the batch (pre-IPC framing) — a bounded, cheap
-        // count, never the payload contents.
-        let rows: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
-        let bytes: u64 = batches
-            .iter()
-            .map(|b| b.get_array_memory_size() as u64)
-            .sum();
-        metrics.add_rows_bytes(rows, bytes);
-
-        // `with_schema` emits the Arrow schema as the first Flight message even
-        // when no record batches follow, so an empty result still carries the schema.
-        let input = futures::stream::iter(batches.into_iter().map(Ok::<RecordBatch, FlightError>));
-        let encoded = FlightDataEncoderBuilder::new()
-            .with_schema(schema_ref)
-            .build(input)
-            .map(|res| res.map_err(|e| Status::internal(e.to_string())));
-
-        Ok(Response::new(Box::pin(encoded)))
+        Ok(DoGetSetup {
+            producer,
+            schema_ref,
+            paths,
+            aggregating,
+        })
     }
 
     /// Body of [`FlightService::do_action`], run inside the RPC span (issue #944).
@@ -496,7 +529,10 @@ mod tests {
         build_sstables, simple_schema, total_rows, write_row, KS, SIMPLE_DDL, TBL,
     };
     use arrow::array::Array;
+    use arrow::record_batch::RecordBatch;
     use arrow_flight::decode::FlightRecordBatchStream;
+    use arrow_flight::error::FlightError;
+    use futures::StreamExt;
 
     fn ticket(keyspace: &str, table: &str) -> FlightTicket {
         FlightTicket {

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -26,6 +26,7 @@ use arrow_flight::FlightData;
 use futures::{Stream, StreamExt};
 use tokio::sync::mpsc;
 use tonic::Status;
+use tracing::Span;
 
 use crate::cancel::{CancelFlag, CancelGuard};
 use crate::obs::RpcMetrics;
@@ -160,7 +161,12 @@ fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
 /// deterministically).
 ///
 /// `paths` MUST come from [`MergeProducer::resolve_paths`] (already token-pruned),
-/// so the fallible discovery/prune has already surfaced upstream.
+/// so the fallible discovery/prune has already surfaced upstream. `cancel` is
+/// the SAME flag threaded through the caller's eager-setup phase (issue #1476,
+/// roborev F1) — one flag, one cancellation story spanning setup + merge; the
+/// caller's setup-phase guard is expected to already be disarmed by the time
+/// this runs, so the fresh guard armed here is the only one live from this
+/// point on.
 pub(crate) fn spawn_streaming(
     producer: MergeProducer,
     paths: Vec<PathBuf>,
@@ -168,12 +174,12 @@ pub(crate) fn spawn_streaming(
     metrics: RpcMetrics,
     capacity: usize,
     probe: StreamProbe,
+    cancel: CancelFlag,
 ) -> (DoGetStream, tokio::task::JoinHandle<()>) {
     let (tx, rx) = mpsc::channel::<Result<RecordBatch, ProducerError>>(capacity.max(1));
     // The shared cancel flag stops the merge when this response stream is dropped
     // (client disconnect); `blocking_send` failure is the second, independent stop
     // signal. AA3 machinery (#1473) is reused, not replaced.
-    let cancel = CancelFlag::new();
     let guard = cancel.drop_guard();
     let merge_cancel = cancel;
     let produced = probe.produced_batches.clone();
@@ -198,14 +204,18 @@ pub(crate) fn spawn_streaming(
 /// Materialize the (bounded) aggregate output and serve it as a stream, unchanged
 /// in content (issue #1476: the aggregate route keeps materializing — one row per
 /// group). The same accounting wrapper attributes rows/bytes at stream end.
+///
+/// `cancel` is the SAME flag threaded through the caller's eager-setup phase
+/// (roborev F1) — see [`spawn_streaming`]'s doc for why one flag spans both
+/// phases.
 pub(crate) async fn build_aggregate_response(
     producer: MergeProducer,
     paths: Vec<PathBuf>,
     schema_ref: Arc<ArrowSchema>,
     metrics: RpcMetrics,
+    cancel: CancelFlag,
 ) -> Result<DoGetStream, (Status, RpcMetrics)> {
     // Cancellation during materialization mirrors the pre-change guard-across-await.
-    let cancel = CancelFlag::new();
     let mut guard = cancel.drop_guard();
     let merge_cancel = cancel;
     let result =
@@ -287,6 +297,17 @@ struct MeteredDoGetStream {
     rows: u64,
     bytes: u64,
     errored: bool,
+    /// The `flight.do_get` RPC span, captured via [`Span::current`] at
+    /// construction time — while still executing inside the `do_get` wrapper's
+    /// `.instrument(span)`-wrapped future, so it correctly resolves to that RPC
+    /// span. Re-entered around every `poll_next` and around `Drop`'s finalize
+    /// (issue #1476 roborev F2): once `do_get` itself returns the `Response`,
+    /// later polls of THIS stream happen entirely outside the instrumented
+    /// future, so `record_status_error`'s `Span::current()`-based OTel error
+    /// marking would otherwise land on no span (or a stale, unrelated one) —
+    /// this makes mid-stream error/cancellation observability land on the same
+    /// span as an eager-setup error always did.
+    span: Span,
 }
 
 impl MeteredDoGetStream {
@@ -304,6 +325,7 @@ impl MeteredDoGetStream {
             rows: 0,
             bytes: 0,
             errored: false,
+            span: Span::current(),
         }
     }
 
@@ -336,6 +358,14 @@ impl Stream for MeteredDoGetStream {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+        // Roborev F2: re-enter the captured `do_get` span so any observability
+        // recorded during this poll (error marking, span-current lookups)
+        // attributes to the RPC span, not whatever happens to be ambient on the
+        // task currently driving this stream. Cloned first (cheap — `Span` is an
+        // `Arc` handle) so `Entered`'s borrow doesn't pin `this` immutably while
+        // the match arms below need `&mut this`.
+        let span = this.span.clone();
+        let _entered = span.enter();
         match this.inner.as_mut().poll_next(cx) {
             Poll::Ready(Some(Ok(batch))) => {
                 this.rows = this.rows.saturating_add(batch.num_rows() as u64);
@@ -368,6 +398,12 @@ impl Stream for MeteredDoGetStream {
 
 impl Drop for MeteredDoGetStream {
     fn drop(&mut self) {
+        // Roborev F2: enter the RPC span so a drop-triggered finalize (early
+        // client disconnect) still attributes under `flight.do_get` (cloned
+        // first for the same reason as `poll_next` — avoid pinning `self`
+        // immutably while `finalize` needs `&mut self`).
+        let span = self.span.clone();
+        let _entered = span.enter();
         // Early drop (client disconnect): attribute the emitted prefix, then the
         // still-armed guard cancels the merge. `finalize` is idempotent, so a
         // stream that already ended normally records nothing more here.

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -37,20 +37,43 @@ pub(crate) type DoGetStream =
 
 /// `do_get` channel capacity, in batches.
 ///
-/// Peak resident record-batch payload is bounded to roughly `(K + 2) · batch_size`
-/// — `K` batches queued in the channel, one being built by the merge, and one held
-/// in the encoder — regardless of the total result size. Deliberately a small
-/// named constant, not a config knob: the 2026-07 platform audit's "don't add
-/// tunables without a consumer" lesson applies; issue #2162 can motivate one later.
+/// Peak resident record-batch payload is bounded to roughly
+/// `(DO_GET_CHANNEL_CAPACITY + IN_FLIGHT_ALLOWANCE) · batch_size`, regardless of
+/// the total result size. Deliberately a small named constant, not a config
+/// knob: the 2026-07 platform audit's "don't add tunables without a consumer"
+/// lesson applies; issue #2162 can motivate one later.
 pub(crate) const DO_GET_CHANNEL_CAPACITY: usize = 4;
+
+/// Structural slack beyond [`DO_GET_CHANNEL_CAPACITY`] that the merge's
+/// `produced_batches` counter can legitimately reach, given the exact instant a
+/// consumer observes it (roborev N1 — the doc and the test bound must share one
+/// derivation so they cannot drift):
+///
+/// - **+1 send-in-flight**: [`ChannelSink::emit`] increments the counter BEFORE
+///   `blocking_send`, so one produced batch can be counted while still blocked
+///   trying to enter an already-full channel.
+/// - **+1 encoder prefetch**: `FlightDataEncoderBuilder`'s stream can pull one
+///   batch out of the channel into its own internal state ahead of yielding it
+///   to the gRPC consumer, freeing a channel slot the producer immediately fills.
+/// - **+1 scheduling slack**: absorbs Tokio scheduling nondeterminism between the
+///   test reading its observation messages and reading the counter (e.g. via
+///   `yield_now`), without which the bound would be exact-timing-dependent.
+///
+/// Test-only (`#[cfg(test)]`): this is a test-observation bound, not a value any
+/// production code branches on — the doc comment above is the production-facing
+/// derivation; this constant just keeps the tests from drifting from it.
+#[cfg(test)]
+pub(crate) const IN_FLIGHT_ALLOWANCE: usize = 3;
 
 /// Test-only observability handle for the streaming path.
 ///
 /// The counters are always maintained (the writes are cheap `Relaxed` atomics),
 /// so production simply passes a throwaway [`StreamProbe::default`]. Tests inject
-/// their own to assert the memory bound (batches produced) and metrics
-/// attribution (rows/bytes fed to [`RpcMetrics`]) without reaching into private
-/// state.
+/// their own to assert the memory bound (batches produced), metrics attribution
+/// (rows/bytes fed to [`RpcMetrics`]), and that a mid-stream error reaches the
+/// error-observability hook (roborev B2) — without reaching into private state
+/// or depending on the `observability` feature's OTel counters, which are a
+/// genuine no-op when the feature is off (see `cqlite_core::observability::record_error`).
 #[derive(Clone, Default)]
 pub(crate) struct StreamProbe {
     /// Batches the merge has pushed toward the channel (bounded by the backpressure).
@@ -59,6 +82,11 @@ pub(crate) struct StreamProbe {
     rows: Arc<AtomicU64>,
     /// Payload bytes attributed to metrics at stream end.
     bytes: Arc<AtomicU64>,
+    /// Incremented once per mid-stream error, alongside the
+    /// `crate::obs::record_status_error` call (roborev B2) — proves the error
+    /// arm reaches the same error-observability hook `do_get`'s eager-setup
+    /// errors always did, independent of whether OTel counters are compiled in.
+    errors_recorded: Arc<AtomicUsize>,
 }
 
 /// Sink that sends each merged batch into the bounded `do_get` channel.
@@ -80,6 +108,49 @@ impl BatchSink for ChannelSink {
         self.tx
             .blocking_send(Ok(batch))
             .map_err(|_| ProducerError::Cancelled)
+    }
+}
+
+/// Run `run` (the merge body) under [`std::panic::catch_unwind`], forwarding
+/// either the merge's own error or a caught panic as a terminal `Err` into `tx`
+/// (issue #1476, roborev B1).
+///
+/// Without this, a panic inside `spawn_blocking` simply drops `tx` when the
+/// blocking task unwinds; the receiver then sees a normal, clean channel close
+/// — indistinguishable from "the merge finished successfully" — so the client
+/// (and Trino) would silently read a TRUNCATED result as a complete one. Forcing
+/// every panic through the channel as [`ProducerError::Panicked`] makes it
+/// surface as a gRPC `Status::internal` on every profile (this is a correctness
+/// fix; `panic=abort` release profiles mask the symptom only in production).
+fn run_merge_catching_panics<F>(tx: &mpsc::Sender<Result<RecordBatch, ProducerError>>, run: F)
+where
+    F: FnOnce() -> Result<(), ProducerError>,
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(run)) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            // Forward a terminal error to the client (matches delta_scan error
+            // forwarding). Ignored if the receiver is already gone (client left).
+            let _ = tx.blocking_send(Err(e));
+        }
+        Err(payload) => {
+            let message = panic_message(payload.as_ref());
+            let _ = tx.blocking_send(Err(ProducerError::Panicked { message }));
+        }
+    }
+}
+
+/// Best-effort extraction of a panic payload's message: the two payload shapes
+/// `std::panic!`/`.unwrap()`/`.expect()` actually produce (`&'static str` and
+/// `String`) are read verbatim; any other payload type gets a fixed placeholder
+/// (never a guess at its structure).
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
     }
 }
 
@@ -108,13 +179,15 @@ pub(crate) fn spawn_streaming(
     let produced = probe.produced_batches.clone();
 
     // Run the CPU-bound merge off the async runtime; it sends batches as it goes.
+    // `error_tx` is a clone kept OUTSIDE the (potentially unwound) merge closure so
+    // a panic can still report through it — `sink` (holding the other clone) lives
+    // inside the closure catch_unwind guards, and unwinding drops it.
     let handle = tokio::task::spawn_blocking(move || {
+        let error_tx = tx.clone();
         let mut sink = ChannelSink { tx, produced };
-        if let Err(e) = producer.produce_streaming(paths, &merge_cancel, &mut sink) {
-            // Forward a terminal error to the client (matches delta_scan error
-            // forwarding). Ignored if the receiver is already gone (client left).
-            let _ = sink.tx.blocking_send(Err(e));
-        }
+        run_merge_catching_panics(&error_tx, move || {
+            producer.produce_streaming(paths, &merge_cancel, &mut sink)
+        });
     });
 
     let inner = Box::pin(ReceiverStream { rx });
@@ -276,6 +349,11 @@ impl Stream for MeteredDoGetStream {
                 this.disarm_guard();
                 this.finalize(false);
                 let status = Status::from(err);
+                // Roborev B2: pre-change `do_get` ran `record_status_error` for
+                // EVERY error (service.rs `finish`); a mid-stream error must hit the
+                // same error-observability path, not just the per-RPC OK/error flag.
+                crate::obs::record_status_error(&status);
+                this.probe.errors_recorded.fetch_add(1, Ordering::Relaxed);
                 Poll::Ready(Some(Err(FlightError::ExternalError(Box::new(status)))))
             }
             Poll::Ready(None) => {
@@ -298,488 +376,5 @@ impl Drop for MeteredDoGetStream {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::producer::DirSource;
-    use crate::testutil::{build_sstables, simple_schema, write_row};
-    use cqlite_core::schema::TableSchema;
-
-    /// Build a fixture with `n` single-row partitions across two SSTables so the
-    /// merge has real per-partition work and, at `batch_size = 1`, yields `n`
-    /// batches.
-    fn many_partition_fixture(n: i32) -> (tempfile::TempDir, std::path::PathBuf, TableSchema) {
-        let schema = simple_schema();
-        let half = n / 2;
-        let a: Vec<_> = (1..=half).map(|i| write_row(i, "a", i, 100)).collect();
-        let b: Vec<_> = (half + 1..=n).map(|i| write_row(i, "b", i, 100)).collect();
-        let (temp, _data, dir) = build_sstables(&schema, vec![a, b]);
-        (temp, dir, schema)
-    }
-
-    /// Resolve the pruned paths for a producer over `dir` (mirrors the service's
-    /// eager `resolve_paths` step).
-    fn resolved(producer: &MergeProducer, dir: &std::path::Path) -> Vec<PathBuf> {
-        producer.resolve_paths(&DirSource::new(dir)).unwrap()
-    }
-
-    fn probe() -> StreamProbe {
-        StreamProbe::default()
-    }
-
-    /// Read exactly one item from the response stream (the first Flight message is
-    /// the schema; the second carries the first record batch), proving a batch is
-    /// available before the merge has run to completion.
-    async fn read_one(stream: &mut DoGetStream) -> Option<Result<FlightData, Status>> {
-        stream.next().await
-    }
-
-    // ---- Task 1.1: do_get emits batches incrementally --------------------------
-
-    /// The first batch is available while the merge is still running: after pulling
-    /// one message, the producer has emitted far fewer than the full-scan batch
-    /// count (bounded by the channel capacity + in-flight allowance).
-    ///
-    /// FAILS on pre-change `main`: there is no `spawn_streaming`/streaming producer
-    /// there — `do_get` materializes every batch before the first is available, so
-    /// the produced count would equal the full result.
-    #[test]
-    fn first_batch_available_before_merge_completes() {
-        let n = 40;
-        let (_temp, dir, schema) = many_partition_fixture(n);
-        let producer = MergeProducer::with_spec(
-            schema,
-            1, // batch_size = 1 → one batch per partition row
-            crate::filter::ScanSpec::default(),
-        )
-        .unwrap();
-        let paths = resolved(&producer, &dir);
-        let schema_ref = Arc::new(producer.arrow_schema().unwrap());
-
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            let pr = probe();
-            let (mut stream, handle) = spawn_streaming(
-                producer,
-                paths,
-                schema_ref,
-                RpcMetrics::start("do_get"),
-                DO_GET_CHANNEL_CAPACITY,
-                pr.clone(),
-            );
-            // Pull the first message (schema) then the first batch.
-            let _schema_msg = read_one(&mut stream).await.expect("schema message");
-            let _first_batch = read_one(&mut stream).await.expect("first batch");
-
-            let produced = pr.produced_batches.load(Ordering::Relaxed);
-            assert!(
-                produced < n as usize,
-                "streaming must not materialize all {n} batches before batch 1 \
-                 (produced={produced})"
-            );
-            assert!(
-                produced <= DO_GET_CHANNEL_CAPACITY + 3,
-                "producer must stay within the channel bound (produced={produced})"
-            );
-
-            drop(stream);
-            let _ = handle.await;
-        });
-    }
-
-    // ---- Task 1.2: peak resident payload is bounded ----------------------------
-
-    /// A slow consumer that reads one batch and pauses does not let the producer
-    /// run ahead: it blocks after at most capacity + in-flight allowance batches,
-    /// independent of the total result size.
-    ///
-    /// FAILS on pre-change `main`: all batches materialize regardless of consumer
-    /// progress (no bounded channel exists).
-    #[test]
-    fn slow_consumer_bounds_produced_batches() {
-        let n = 60;
-        let (_temp, dir, schema) = many_partition_fixture(n);
-        let producer =
-            MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
-        let paths = resolved(&producer, &dir);
-        let schema_ref = Arc::new(producer.arrow_schema().unwrap());
-
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            let pr = probe();
-            let (mut stream, handle) = spawn_streaming(
-                producer,
-                paths,
-                schema_ref,
-                RpcMetrics::start("do_get"),
-                DO_GET_CHANNEL_CAPACITY,
-                pr.clone(),
-            );
-            let _schema_msg = read_one(&mut stream).await.expect("schema");
-            let _first = read_one(&mut stream).await.expect("first batch");
-
-            // Give the producer every opportunity to run ahead, then assert it is
-            // still bounded — it physically cannot exceed the channel allowance.
-            tokio::task::yield_now().await;
-            let produced = pr.produced_batches.load(Ordering::Relaxed);
-            assert!(
-                produced <= DO_GET_CHANNEL_CAPACITY + 3,
-                "slow consumer: produced {produced} exceeds the channel bound"
-            );
-
-            drop(stream);
-            let _ = handle.await;
-        });
-    }
-
-    // ---- Task 1.3: consumer disconnect stops the merge -------------------------
-
-    /// Dropping the response stream after the first batch stops the merge: the
-    /// producer never emits all partitions and the blocking task exits.
-    ///
-    /// FAILS on pre-change `main`: `do_get` runs the merge to completion before the
-    /// stream exists, so a drop cannot cut it short.
-    #[test]
-    fn dropping_stream_cancels_merge() {
-        let n = 60;
-        let (_temp, dir, schema) = many_partition_fixture(n);
-        let producer =
-            MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
-        let paths = resolved(&producer, &dir);
-        let schema_ref = Arc::new(producer.arrow_schema().unwrap());
-
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            let pr = probe();
-            let (mut stream, handle) = spawn_streaming(
-                producer,
-                paths,
-                schema_ref,
-                RpcMetrics::start("do_get"),
-                DO_GET_CHANNEL_CAPACITY,
-                pr.clone(),
-            );
-            let _schema_msg = read_one(&mut stream).await.expect("schema");
-            let _first = read_one(&mut stream).await.expect("first batch");
-
-            // Client disconnects: drop the stream, then await the merge task. It
-            // must terminate (send failure + cancel flag) rather than run to
-            // completion.
-            drop(stream);
-            handle.await.expect("merge task joins after cancellation");
-
-            let produced = pr.produced_batches.load(Ordering::Relaxed);
-            assert!(
-                produced < n as usize,
-                "merge must stop early on disconnect (produced={produced} of {n})"
-            );
-        });
-    }
-
-    // ---- Task 2.3 / Requirement 4: stream/collect byte-identity ----------------
-
-    fn collect_batches(producer: &MergeProducer, dir: &std::path::Path) -> Vec<RecordBatch> {
-        producer.produce(&DirSource::new(dir)).unwrap()
-    }
-
-    async fn drain_stream(stream: DoGetStream) -> Vec<RecordBatch> {
-        use arrow_flight::decode::FlightRecordBatchStream;
-        let mapped = stream.map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
-        let mut rb = FlightRecordBatchStream::new_from_flight_data(mapped);
-        let mut out = Vec::new();
-        while let Some(batch) = rb.next().await {
-            out.push(batch.expect("decode batch"));
-        }
-        out
-    }
-
-    /// Drive the streaming producer path and collect the raw batches it emits into
-    /// the channel (pre-encode). This is the true parity seam the spec names —
-    /// `produce_streaming` vs the retained `produce` collect path — without the
-    /// Flight encoder's response-schema injection (a uniform presentation concern
-    /// applied identically to every `do_get`).
-    fn stream_batches_raw(producer: MergeProducer, paths: Vec<PathBuf>) -> Vec<RecordBatch> {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            let (tx, mut rx) =
-                mpsc::channel::<Result<RecordBatch, ProducerError>>(DO_GET_CHANNEL_CAPACITY);
-            let cancel = CancelFlag::new();
-            let handle = tokio::task::spawn_blocking(move || {
-                let mut sink = ChannelSink {
-                    tx,
-                    produced: Arc::new(AtomicUsize::new(0)),
-                };
-                if let Err(e) = producer.produce_streaming(paths, &cancel, &mut sink) {
-                    let _ = sink.tx.blocking_send(Err(e));
-                }
-            });
-            let mut out = Vec::new();
-            while let Some(item) = rx.recv().await {
-                out.push(item.expect("streamed batch is ok"));
-            }
-            let _ = handle.await;
-            out
-        })
-    }
-
-    /// The streamed batches are byte-identical to the collect-path batches for a
-    /// given spec: same schema, batch boundaries, and row content.
-    fn assert_stream_collect_parity(spec: crate::filter::ScanSpec, dir: &std::path::Path) {
-        let schema = simple_schema();
-        let collect_producer = MergeProducer::with_spec(schema.clone(), 4, spec.clone()).unwrap();
-        let expected = collect_batches(&collect_producer, dir);
-
-        let stream_producer = MergeProducer::with_spec(schema, 4, spec).unwrap();
-        let paths = resolved(&stream_producer, dir);
-        let streamed = stream_batches_raw(stream_producer, paths);
-
-        assert_eq!(
-            streamed.len(),
-            expected.len(),
-            "batch count (boundaries) must match"
-        );
-        for (s, e) in streamed.iter().zip(expected.iter()) {
-            assert_eq!(
-                s, e,
-                "streamed batch must be byte-identical to collect batch"
-            );
-        }
-    }
-
-    #[test]
-    fn stream_collect_parity_no_constraints() {
-        let schema = simple_schema();
-        let rows = (1..=10)
-            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
-            .collect::<Vec<_>>();
-        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
-        assert_stream_collect_parity(crate::filter::ScanSpec::default(), &dir);
-    }
-
-    #[test]
-    fn stream_collect_parity_limit_mid_batch() {
-        let schema = simple_schema();
-        let rows = (1..=10)
-            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
-            .collect::<Vec<_>>();
-        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
-        let spec = crate::filter::ScanSpec {
-            limit: Some(5),
-            ..Default::default()
-        };
-        assert_stream_collect_parity(spec, &dir);
-    }
-
-    #[test]
-    fn stream_collect_parity_predicate() {
-        use crate::ticket::{FlightTicket, Predicate, PredicateOp};
-        let schema = simple_schema();
-        let rows = (1..=10)
-            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
-            .collect::<Vec<_>>();
-        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
-        let ticket = FlightTicket {
-            predicates: vec![Predicate {
-                column: "score".into(),
-                op: PredicateOp::Gte,
-                value: serde_json::json!(40),
-            }],
-            ..Default::default()
-        };
-        let spec = crate::filter::ScanSpec::from_ticket(&ticket, &schema).unwrap();
-        assert_stream_collect_parity(spec, &dir);
-    }
-
-    #[test]
-    fn stream_collect_parity_token_range() {
-        use crate::ticket::FlightTicket;
-        let schema = simple_schema();
-        let rows = (1..=10)
-            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
-            .collect::<Vec<_>>();
-        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
-        let ticket = FlightTicket {
-            token_start: Some(i64::MIN),
-            token_end: Some(0),
-            ..Default::default()
-        };
-        let spec = crate::filter::ScanSpec::from_ticket(&ticket, &schema).unwrap();
-        assert_stream_collect_parity(spec, &dir);
-    }
-
-    // ---- Requirement 5: rows/bytes metrics reflect what was emitted ------------
-
-    /// A fully-consumed stream attributes the same rows/bytes the collect path
-    /// would for the same ticket.
-    #[test]
-    fn metrics_parity_on_full_consumption() {
-        let schema = simple_schema();
-        let rows = (1..=10)
-            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
-            .collect::<Vec<_>>();
-        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
-
-        let producer =
-            MergeProducer::with_spec(schema.clone(), 4, crate::filter::ScanSpec::default())
-                .unwrap();
-        let expected = collect_batches(&producer, &dir);
-        let expected_rows: u64 = expected.iter().map(|b| b.num_rows() as u64).sum();
-        let expected_bytes: u64 = expected
-            .iter()
-            .map(|b| b.get_array_memory_size() as u64)
-            .sum();
-
-        let stream_producer =
-            MergeProducer::with_spec(schema, 4, crate::filter::ScanSpec::default()).unwrap();
-        let paths = resolved(&stream_producer, &dir);
-        let schema_ref = Arc::new(stream_producer.arrow_schema().unwrap());
-
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let pr = probe();
-        let pr_check = pr.clone();
-        rt.block_on(async move {
-            let (stream, handle) = spawn_streaming(
-                stream_producer,
-                paths,
-                schema_ref,
-                RpcMetrics::start("do_get"),
-                DO_GET_CHANNEL_CAPACITY,
-                pr,
-            );
-            let _ = drain_stream(stream).await;
-            let _ = handle.await;
-        });
-
-        assert_eq!(
-            pr_check.rows.load(Ordering::Relaxed),
-            expected_rows,
-            "fully-consumed rows must match the collect path"
-        );
-        assert_eq!(
-            pr_check.bytes.load(Ordering::Relaxed),
-            expected_bytes,
-            "fully-consumed bytes must match the collect path"
-        );
-        assert!(expected_rows > 0, "fixture must produce rows");
-    }
-
-    // ---- Requirement 6: aggregate path keeps materializing (unchanged content) -
-
-    /// An aggregation ticket over a multi-SSTable table serves its bounded
-    /// per-group output as a stream, byte-identical to the retained collect path
-    /// (`produce`). The aggregate route does NOT stream row-by-row — it keeps
-    /// materializing — but is still wrapped in a stream.
-    #[test]
-    fn aggregate_path_matches_collect_content() {
-        use crate::ticket::{AggFunc, AggregateSpec, Aggregation};
-        let schema = simple_schema();
-        // Two SSTables, 7 distinct partitions total after LWW (id=1 rewritten).
-        let (_temp, dir, _schema) = {
-            let a: Vec<_> = (1..=4).map(|i| write_row(i, "a", i, 100)).collect();
-            let b: Vec<_> = (4..=7).map(|i| write_row(i, "b", i, 200)).collect();
-            let (t, _d, dir) = build_sstables(&schema, vec![a, b]);
-            (t, dir, schema.clone())
-        };
-        let agg = Aggregation {
-            group_by: vec![],
-            aggregates: vec![AggregateSpec {
-                func: AggFunc::Count,
-                column: None,
-                output: "cnt".into(),
-            }],
-        };
-
-        // Collect path (the oracle): produce the partial aggregate directly.
-        let collect_producer = MergeProducer::with_spec(schema.clone(), 4, Default::default())
-            .unwrap()
-            .with_aggregation(&agg)
-            .unwrap();
-        let expected = collect_producer.produce(&DirSource::new(&dir)).unwrap();
-        assert_eq!(
-            expected.len(),
-            1,
-            "global aggregation emits one partial batch"
-        );
-        let expected_cnt = count_value(&expected[0]);
-
-        // Streaming service path (build_aggregate_response) — same content.
-        let stream_producer = MergeProducer::with_spec(schema, 4, Default::default())
-            .unwrap()
-            .with_aggregation(&agg)
-            .unwrap();
-        assert!(stream_producer.is_aggregating());
-        let paths = resolved(&stream_producer, &dir);
-        let schema_ref = Arc::new(stream_producer.arrow_schema().unwrap());
-
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let streamed = rt.block_on(async move {
-            let stream = match build_aggregate_response(
-                stream_producer,
-                paths,
-                schema_ref,
-                RpcMetrics::start("do_get"),
-            )
-            .await
-            {
-                Ok(stream) => stream,
-                Err((status, _metrics)) => panic!("aggregate response failed: {status}"),
-            };
-            drain_stream(stream).await
-        });
-        assert_eq!(streamed.len(), 1, "aggregate output stays one batch");
-        assert_eq!(
-            count_value(&streamed[0]),
-            expected_cnt,
-            "streamed aggregate content matches the collect path"
-        );
-    }
-
-    /// Read the single global-`count(*)` partial value from a one-row batch.
-    fn count_value(batch: &RecordBatch) -> i64 {
-        use arrow::array::Array;
-        let col = batch.column_by_name("cnt").expect("cnt column");
-        col.as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .expect("count is Int64")
-            .value(0)
-    }
-
-    /// A cancelled stream (one batch read, then dropped) attributes exactly the
-    /// emitted prefix — not the full table.
-    #[test]
-    fn metrics_attribute_emitted_prefix_on_cancel() {
-        let n = 60;
-        let (_temp, dir, schema) = many_partition_fixture(n);
-        let producer =
-            MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
-        let paths = resolved(&producer, &dir);
-        let schema_ref = Arc::new(producer.arrow_schema().unwrap());
-
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let pr = probe();
-        let pr_check = pr.clone();
-        rt.block_on(async move {
-            let (mut stream, handle) = spawn_streaming(
-                producer,
-                paths,
-                schema_ref,
-                RpcMetrics::start("do_get"),
-                DO_GET_CHANNEL_CAPACITY,
-                pr,
-            );
-            let _schema_msg = read_one(&mut stream).await.expect("schema");
-            let _first = read_one(&mut stream).await.expect("first batch");
-            drop(stream);
-            let _ = handle.await;
-        });
-
-        // The metered stream yielded exactly one batch (one row at batch_size=1)
-        // before the drop, so metrics attribute that single-row prefix — far below
-        // the full table.
-        let rows = pr_check.rows.load(Ordering::Relaxed);
-        assert_eq!(
-            rows, 1,
-            "cancelled stream attributes only the emitted prefix"
-        );
-        assert!(rows < n as u64);
-    }
-}
+#[path = "streaming_tests.rs"]
+mod tests;

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -404,9 +404,32 @@ impl Drop for MeteredDoGetStream {
         // immutably while `finalize` needs `&mut self`).
         let span = self.span.clone();
         let _entered = span.enter();
+
+        // Roborev round 4: `self.metrics` is still `Some` here ONLY when this
+        // stream is being dropped BEFORE it ever reached its own terminal poll
+        // (normal end via `Poll::Ready(None)`, or an error via
+        // `Poll::Ready(Some(Err(_)))`) — i.e. an unclean early drop, the client
+        // disconnecting mid-stream. Both of those poll_next arms call
+        // `finalize`, which `take()`s `metrics`, so a stream that already ended
+        // (successfully or with a recorded error) always has `metrics == None`
+        // by the time `Drop` runs — this check can never double-record.
+        //
+        // Pre-change, a disconnect surfaced as `aborted` through the handler's
+        // `Err` path and hit `record_status_error` there; the streaming rewrite
+        // must not let that vanish from the flight error-rate signal / RPC-span
+        // error marking just because the failure now arrives via `Drop` instead
+        // of a returned `Err`.
+        if self.metrics.is_some() {
+            let status =
+                Status::aborted("do_get stream dropped before completion (client disconnected)");
+            crate::obs::record_status_error(&status);
+            self.probe.errors_recorded.fetch_add(1, Ordering::Relaxed);
+        }
+
         // Early drop (client disconnect): attribute the emitted prefix, then the
-        // still-armed guard cancels the merge. `finalize` is idempotent, so a
-        // stream that already ended normally records nothing more here.
+        // still-armed guard cancels the merge (dropped as a struct field right
+        // after this fn body runs). `finalize` is idempotent, so a stream that
+        // already ended normally records nothing more here.
         self.finalize(false);
     }
 }

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -1,0 +1,785 @@
+//! Streaming `do_get` egress (issue #1476, AB1).
+//!
+//! `do_get` no longer runs the whole compaction merge to completion and collects
+//! every [`RecordBatch`] into a `Vec` before the first byte reaches the client.
+//! Instead the merge runs on the blocking pool and sends each batch into a bounded
+//! [`tokio::sync::mpsc`] channel as it is produced; the gRPC response wraps the
+//! receiver. First batches reach the wire while the merge is still running, and
+//! peak resident payload is bounded to the channel capacity + a small in-flight
+//! allowance — independent of the total result size. This mirrors the proven
+//! `cqlite-core` `delta_scan/scan.rs` bounded-channel pattern.
+//!
+//! The retained `produce`/`produce_cancellable` collect path remains the
+//! byte-identity parity oracle and serves the aggregate route (bounded output).
+
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::datatypes::Schema as ArrowSchema;
+use arrow::record_batch::RecordBatch;
+use arrow_flight::encode::FlightDataEncoderBuilder;
+use arrow_flight::error::FlightError;
+use arrow_flight::FlightData;
+use futures::{Stream, StreamExt};
+use tokio::sync::mpsc;
+use tonic::Status;
+
+use crate::cancel::{CancelFlag, CancelGuard};
+use crate::obs::RpcMetrics;
+use crate::producer::{BatchSink, MergeProducer, ProducerError};
+
+/// Boxed server response stream (matches `service::BoxStream<FlightData>`).
+pub(crate) type DoGetStream =
+    Pin<Box<dyn Stream<Item = Result<FlightData, Status>> + Send + 'static>>;
+
+/// `do_get` channel capacity, in batches.
+///
+/// Peak resident record-batch payload is bounded to roughly `(K + 2) · batch_size`
+/// — `K` batches queued in the channel, one being built by the merge, and one held
+/// in the encoder — regardless of the total result size. Deliberately a small
+/// named constant, not a config knob: the 2026-07 platform audit's "don't add
+/// tunables without a consumer" lesson applies; issue #2162 can motivate one later.
+pub(crate) const DO_GET_CHANNEL_CAPACITY: usize = 4;
+
+/// Test-only observability handle for the streaming path.
+///
+/// The counters are always maintained (the writes are cheap `Relaxed` atomics),
+/// so production simply passes a throwaway [`StreamProbe::default`]. Tests inject
+/// their own to assert the memory bound (batches produced) and metrics
+/// attribution (rows/bytes fed to [`RpcMetrics`]) without reaching into private
+/// state.
+#[derive(Clone, Default)]
+pub(crate) struct StreamProbe {
+    /// Batches the merge has pushed toward the channel (bounded by the backpressure).
+    produced_batches: Arc<AtomicUsize>,
+    /// Rows attributed to metrics at stream end (== emitted prefix on cancel).
+    rows: Arc<AtomicU64>,
+    /// Payload bytes attributed to metrics at stream end.
+    bytes: Arc<AtomicU64>,
+}
+
+/// Sink that sends each merged batch into the bounded `do_get` channel.
+///
+/// A send failure means the receiver (client) is gone: report
+/// [`ProducerError::Cancelled`] so the merge stops within a bounded number of
+/// steps (composing with the #1473 `CancelFlag`).
+struct ChannelSink {
+    tx: mpsc::Sender<Result<RecordBatch, ProducerError>>,
+    produced: Arc<AtomicUsize>,
+}
+
+impl BatchSink for ChannelSink {
+    fn emit(&mut self, batch: RecordBatch) -> Result<(), ProducerError> {
+        self.produced.fetch_add(1, Ordering::Relaxed);
+        // `blocking_send` applies backpressure: it parks this blocking-pool thread
+        // while the channel is full, so the merge never runs ahead of the consumer
+        // by more than the channel capacity. `Err` == receiver dropped == cancel.
+        self.tx
+            .blocking_send(Ok(batch))
+            .map_err(|_| ProducerError::Cancelled)
+    }
+}
+
+/// Spawn the row-merge of already-resolved `paths` streaming into a bounded
+/// channel, returning the encoded `do_get` response stream and the merge task
+/// handle (production drops the handle; tests await it to observe cancellation
+/// deterministically).
+///
+/// `paths` MUST come from [`MergeProducer::resolve_paths`] (already token-pruned),
+/// so the fallible discovery/prune has already surfaced upstream.
+pub(crate) fn spawn_streaming(
+    producer: MergeProducer,
+    paths: Vec<PathBuf>,
+    schema_ref: Arc<ArrowSchema>,
+    metrics: RpcMetrics,
+    capacity: usize,
+    probe: StreamProbe,
+) -> (DoGetStream, tokio::task::JoinHandle<()>) {
+    let (tx, rx) = mpsc::channel::<Result<RecordBatch, ProducerError>>(capacity.max(1));
+    // The shared cancel flag stops the merge when this response stream is dropped
+    // (client disconnect); `blocking_send` failure is the second, independent stop
+    // signal. AA3 machinery (#1473) is reused, not replaced.
+    let cancel = CancelFlag::new();
+    let guard = cancel.drop_guard();
+    let merge_cancel = cancel;
+    let produced = probe.produced_batches.clone();
+
+    // Run the CPU-bound merge off the async runtime; it sends batches as it goes.
+    let handle = tokio::task::spawn_blocking(move || {
+        let mut sink = ChannelSink { tx, produced };
+        if let Err(e) = producer.produce_streaming(paths, &merge_cancel, &mut sink) {
+            // Forward a terminal error to the client (matches delta_scan error
+            // forwarding). Ignored if the receiver is already gone (client left).
+            let _ = sink.tx.blocking_send(Err(e));
+        }
+    });
+
+    let inner = Box::pin(ReceiverStream { rx });
+    let metered = MeteredDoGetStream::new(inner, metrics, Some(guard), probe);
+    (encode_do_get(metered, schema_ref), handle)
+}
+
+/// Materialize the (bounded) aggregate output and serve it as a stream, unchanged
+/// in content (issue #1476: the aggregate route keeps materializing — one row per
+/// group). The same accounting wrapper attributes rows/bytes at stream end.
+pub(crate) async fn build_aggregate_response(
+    producer: MergeProducer,
+    paths: Vec<PathBuf>,
+    schema_ref: Arc<ArrowSchema>,
+    metrics: RpcMetrics,
+) -> Result<DoGetStream, (Status, RpcMetrics)> {
+    // Cancellation during materialization mirrors the pre-change guard-across-await.
+    let cancel = CancelFlag::new();
+    let mut guard = cancel.drop_guard();
+    let merge_cancel = cancel;
+    let result =
+        tokio::task::spawn_blocking(move || producer.produce_from_resolved(paths, &merge_cancel))
+            .await;
+    guard.disarm();
+
+    let batches = match result {
+        Ok(Ok(batches)) => batches,
+        Ok(Err(e)) => return Err((Status::from(e), metrics)),
+        Err(e) => {
+            return Err((
+                Status::internal(format!("aggregate merge task panicked: {e}")),
+                metrics,
+            ))
+        }
+    };
+
+    let iter = futures::stream::iter(batches.into_iter().map(Ok::<_, ProducerError>));
+    let metered = MeteredDoGetStream::new(Box::pin(iter), metrics, None, StreamProbe::default());
+    Ok(encode_do_get(metered, schema_ref))
+}
+
+/// Wrap a `RecordBatch` stream in the Flight encoder. `with_schema` emits the
+/// Arrow schema as the first message even for an empty result, so a schema-only
+/// response still carries the schema.
+fn encode_do_get(
+    batch_stream: impl Stream<Item = Result<RecordBatch, FlightError>> + Send + 'static,
+    schema_ref: Arc<ArrowSchema>,
+) -> DoGetStream {
+    let encoded = FlightDataEncoderBuilder::new()
+        .with_schema(schema_ref)
+        .build(batch_stream)
+        .map(|res| res.map_err(flight_error_to_status));
+    Box::pin(encoded)
+}
+
+/// Recover a [`Status`] from an encoder [`FlightError`], preserving the gRPC code
+/// of a producer error surfaced mid-stream (e.g. `aborted` for a cancelled merge,
+/// `not_found`, `invalid_argument`) instead of flattening everything to internal.
+fn flight_error_to_status(e: FlightError) -> Status {
+    match e {
+        FlightError::ExternalError(boxed) => match boxed.downcast::<Status>() {
+            Ok(status) => *status,
+            Err(other) => Status::internal(other.to_string()),
+        },
+        other => Status::internal(other.to_string()),
+    }
+}
+
+/// Minimal [`Stream`] adapter over a bounded [`mpsc::Receiver`] (the crate has no
+/// `tokio-stream` dependency; `poll_recv` is all we need).
+struct ReceiverStream<T> {
+    rx: mpsc::Receiver<T>,
+}
+
+impl<T> Stream for ReceiverStream<T> {
+    type Item = T;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+/// Accounting + cancellation wrapper around the `do_get` batch stream.
+///
+/// Accumulates rows/bytes per batch as they pass toward the encoder and attributes
+/// them to [`RpcMetrics`] at stream end — a fully-consumed stream records the same
+/// totals the collect path would; a stream dropped early (client disconnect)
+/// attributes exactly the emitted prefix. It also owns the merge's [`CancelGuard`]
+/// so dropping the response stream cancels the merge (issue #1476 / #1473).
+struct MeteredDoGetStream {
+    inner: Pin<Box<dyn Stream<Item = Result<RecordBatch, ProducerError>> + Send + 'static>>,
+    /// Taken (and dropped, emitting terminal metrics) exactly once at finalization.
+    metrics: Option<RpcMetrics>,
+    /// Cancels the merge on drop unless disarmed; `None` for the aggregate route
+    /// (already materialized — nothing to cancel).
+    guard: Option<CancelGuard>,
+    probe: StreamProbe,
+    rows: u64,
+    bytes: u64,
+    errored: bool,
+}
+
+impl MeteredDoGetStream {
+    fn new(
+        inner: Pin<Box<dyn Stream<Item = Result<RecordBatch, ProducerError>> + Send + 'static>>,
+        metrics: RpcMetrics,
+        guard: Option<CancelGuard>,
+        probe: StreamProbe,
+    ) -> Self {
+        Self {
+            inner,
+            metrics: Some(metrics),
+            guard,
+            probe,
+            rows: 0,
+            bytes: 0,
+            errored: false,
+        }
+    }
+
+    /// Attribute the accumulated rows/bytes to metrics (and the probe) and record
+    /// the terminal RPC status. Idempotent: `metrics` is taken exactly once, so a
+    /// normal end followed by drop (or vice versa) records only once.
+    fn finalize(&mut self, ok: bool) {
+        if let Some(mut metrics) = self.metrics.take() {
+            metrics.add_rows_bytes(self.rows, self.bytes);
+            if ok {
+                metrics.ok();
+            }
+            self.probe.rows.store(self.rows, Ordering::Relaxed);
+            self.probe.bytes.store(self.bytes, Ordering::Relaxed);
+            // Dropping `metrics` here emits the terminal RPC counters/histogram.
+        }
+    }
+
+    /// The merge is finished (completed or errored); disarm so we do not cancel a
+    /// flag whose task has already exited.
+    fn disarm_guard(&mut self) {
+        if let Some(guard) = self.guard.as_mut() {
+            guard.disarm();
+        }
+    }
+}
+
+impl Stream for MeteredDoGetStream {
+    type Item = Result<RecordBatch, FlightError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(batch))) => {
+                this.rows = this.rows.saturating_add(batch.num_rows() as u64);
+                this.bytes = this
+                    .bytes
+                    .saturating_add(batch.get_array_memory_size() as u64);
+                Poll::Ready(Some(Ok(batch)))
+            }
+            Poll::Ready(Some(Err(err))) => {
+                this.errored = true;
+                this.disarm_guard();
+                this.finalize(false);
+                let status = Status::from(err);
+                Poll::Ready(Some(Err(FlightError::ExternalError(Box::new(status)))))
+            }
+            Poll::Ready(None) => {
+                this.disarm_guard();
+                this.finalize(!this.errored);
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for MeteredDoGetStream {
+    fn drop(&mut self) {
+        // Early drop (client disconnect): attribute the emitted prefix, then the
+        // still-armed guard cancels the merge. `finalize` is idempotent, so a
+        // stream that already ended normally records nothing more here.
+        self.finalize(false);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::producer::DirSource;
+    use crate::testutil::{build_sstables, simple_schema, write_row};
+    use cqlite_core::schema::TableSchema;
+
+    /// Build a fixture with `n` single-row partitions across two SSTables so the
+    /// merge has real per-partition work and, at `batch_size = 1`, yields `n`
+    /// batches.
+    fn many_partition_fixture(n: i32) -> (tempfile::TempDir, std::path::PathBuf, TableSchema) {
+        let schema = simple_schema();
+        let half = n / 2;
+        let a: Vec<_> = (1..=half).map(|i| write_row(i, "a", i, 100)).collect();
+        let b: Vec<_> = (half + 1..=n).map(|i| write_row(i, "b", i, 100)).collect();
+        let (temp, _data, dir) = build_sstables(&schema, vec![a, b]);
+        (temp, dir, schema)
+    }
+
+    /// Resolve the pruned paths for a producer over `dir` (mirrors the service's
+    /// eager `resolve_paths` step).
+    fn resolved(producer: &MergeProducer, dir: &std::path::Path) -> Vec<PathBuf> {
+        producer.resolve_paths(&DirSource::new(dir)).unwrap()
+    }
+
+    fn probe() -> StreamProbe {
+        StreamProbe::default()
+    }
+
+    /// Read exactly one item from the response stream (the first Flight message is
+    /// the schema; the second carries the first record batch), proving a batch is
+    /// available before the merge has run to completion.
+    async fn read_one(stream: &mut DoGetStream) -> Option<Result<FlightData, Status>> {
+        stream.next().await
+    }
+
+    // ---- Task 1.1: do_get emits batches incrementally --------------------------
+
+    /// The first batch is available while the merge is still running: after pulling
+    /// one message, the producer has emitted far fewer than the full-scan batch
+    /// count (bounded by the channel capacity + in-flight allowance).
+    ///
+    /// FAILS on pre-change `main`: there is no `spawn_streaming`/streaming producer
+    /// there — `do_get` materializes every batch before the first is available, so
+    /// the produced count would equal the full result.
+    #[test]
+    fn first_batch_available_before_merge_completes() {
+        let n = 40;
+        let (_temp, dir, schema) = many_partition_fixture(n);
+        let producer = MergeProducer::with_spec(
+            schema,
+            1, // batch_size = 1 → one batch per partition row
+            crate::filter::ScanSpec::default(),
+        )
+        .unwrap();
+        let paths = resolved(&producer, &dir);
+        let schema_ref = Arc::new(producer.arrow_schema().unwrap());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            let pr = probe();
+            let (mut stream, handle) = spawn_streaming(
+                producer,
+                paths,
+                schema_ref,
+                RpcMetrics::start("do_get"),
+                DO_GET_CHANNEL_CAPACITY,
+                pr.clone(),
+            );
+            // Pull the first message (schema) then the first batch.
+            let _schema_msg = read_one(&mut stream).await.expect("schema message");
+            let _first_batch = read_one(&mut stream).await.expect("first batch");
+
+            let produced = pr.produced_batches.load(Ordering::Relaxed);
+            assert!(
+                produced < n as usize,
+                "streaming must not materialize all {n} batches before batch 1 \
+                 (produced={produced})"
+            );
+            assert!(
+                produced <= DO_GET_CHANNEL_CAPACITY + 3,
+                "producer must stay within the channel bound (produced={produced})"
+            );
+
+            drop(stream);
+            let _ = handle.await;
+        });
+    }
+
+    // ---- Task 1.2: peak resident payload is bounded ----------------------------
+
+    /// A slow consumer that reads one batch and pauses does not let the producer
+    /// run ahead: it blocks after at most capacity + in-flight allowance batches,
+    /// independent of the total result size.
+    ///
+    /// FAILS on pre-change `main`: all batches materialize regardless of consumer
+    /// progress (no bounded channel exists).
+    #[test]
+    fn slow_consumer_bounds_produced_batches() {
+        let n = 60;
+        let (_temp, dir, schema) = many_partition_fixture(n);
+        let producer =
+            MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
+        let paths = resolved(&producer, &dir);
+        let schema_ref = Arc::new(producer.arrow_schema().unwrap());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            let pr = probe();
+            let (mut stream, handle) = spawn_streaming(
+                producer,
+                paths,
+                schema_ref,
+                RpcMetrics::start("do_get"),
+                DO_GET_CHANNEL_CAPACITY,
+                pr.clone(),
+            );
+            let _schema_msg = read_one(&mut stream).await.expect("schema");
+            let _first = read_one(&mut stream).await.expect("first batch");
+
+            // Give the producer every opportunity to run ahead, then assert it is
+            // still bounded — it physically cannot exceed the channel allowance.
+            tokio::task::yield_now().await;
+            let produced = pr.produced_batches.load(Ordering::Relaxed);
+            assert!(
+                produced <= DO_GET_CHANNEL_CAPACITY + 3,
+                "slow consumer: produced {produced} exceeds the channel bound"
+            );
+
+            drop(stream);
+            let _ = handle.await;
+        });
+    }
+
+    // ---- Task 1.3: consumer disconnect stops the merge -------------------------
+
+    /// Dropping the response stream after the first batch stops the merge: the
+    /// producer never emits all partitions and the blocking task exits.
+    ///
+    /// FAILS on pre-change `main`: `do_get` runs the merge to completion before the
+    /// stream exists, so a drop cannot cut it short.
+    #[test]
+    fn dropping_stream_cancels_merge() {
+        let n = 60;
+        let (_temp, dir, schema) = many_partition_fixture(n);
+        let producer =
+            MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
+        let paths = resolved(&producer, &dir);
+        let schema_ref = Arc::new(producer.arrow_schema().unwrap());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            let pr = probe();
+            let (mut stream, handle) = spawn_streaming(
+                producer,
+                paths,
+                schema_ref,
+                RpcMetrics::start("do_get"),
+                DO_GET_CHANNEL_CAPACITY,
+                pr.clone(),
+            );
+            let _schema_msg = read_one(&mut stream).await.expect("schema");
+            let _first = read_one(&mut stream).await.expect("first batch");
+
+            // Client disconnects: drop the stream, then await the merge task. It
+            // must terminate (send failure + cancel flag) rather than run to
+            // completion.
+            drop(stream);
+            handle.await.expect("merge task joins after cancellation");
+
+            let produced = pr.produced_batches.load(Ordering::Relaxed);
+            assert!(
+                produced < n as usize,
+                "merge must stop early on disconnect (produced={produced} of {n})"
+            );
+        });
+    }
+
+    // ---- Task 2.3 / Requirement 4: stream/collect byte-identity ----------------
+
+    fn collect_batches(producer: &MergeProducer, dir: &std::path::Path) -> Vec<RecordBatch> {
+        producer.produce(&DirSource::new(dir)).unwrap()
+    }
+
+    async fn drain_stream(stream: DoGetStream) -> Vec<RecordBatch> {
+        use arrow_flight::decode::FlightRecordBatchStream;
+        let mapped = stream.map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
+        let mut rb = FlightRecordBatchStream::new_from_flight_data(mapped);
+        let mut out = Vec::new();
+        while let Some(batch) = rb.next().await {
+            out.push(batch.expect("decode batch"));
+        }
+        out
+    }
+
+    /// Drive the streaming producer path and collect the raw batches it emits into
+    /// the channel (pre-encode). This is the true parity seam the spec names —
+    /// `produce_streaming` vs the retained `produce` collect path — without the
+    /// Flight encoder's response-schema injection (a uniform presentation concern
+    /// applied identically to every `do_get`).
+    fn stream_batches_raw(producer: MergeProducer, paths: Vec<PathBuf>) -> Vec<RecordBatch> {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            let (tx, mut rx) =
+                mpsc::channel::<Result<RecordBatch, ProducerError>>(DO_GET_CHANNEL_CAPACITY);
+            let cancel = CancelFlag::new();
+            let handle = tokio::task::spawn_blocking(move || {
+                let mut sink = ChannelSink {
+                    tx,
+                    produced: Arc::new(AtomicUsize::new(0)),
+                };
+                if let Err(e) = producer.produce_streaming(paths, &cancel, &mut sink) {
+                    let _ = sink.tx.blocking_send(Err(e));
+                }
+            });
+            let mut out = Vec::new();
+            while let Some(item) = rx.recv().await {
+                out.push(item.expect("streamed batch is ok"));
+            }
+            let _ = handle.await;
+            out
+        })
+    }
+
+    /// The streamed batches are byte-identical to the collect-path batches for a
+    /// given spec: same schema, batch boundaries, and row content.
+    fn assert_stream_collect_parity(spec: crate::filter::ScanSpec, dir: &std::path::Path) {
+        let schema = simple_schema();
+        let collect_producer = MergeProducer::with_spec(schema.clone(), 4, spec.clone()).unwrap();
+        let expected = collect_batches(&collect_producer, dir);
+
+        let stream_producer = MergeProducer::with_spec(schema, 4, spec).unwrap();
+        let paths = resolved(&stream_producer, dir);
+        let streamed = stream_batches_raw(stream_producer, paths);
+
+        assert_eq!(
+            streamed.len(),
+            expected.len(),
+            "batch count (boundaries) must match"
+        );
+        for (s, e) in streamed.iter().zip(expected.iter()) {
+            assert_eq!(
+                s, e,
+                "streamed batch must be byte-identical to collect batch"
+            );
+        }
+    }
+
+    #[test]
+    fn stream_collect_parity_no_constraints() {
+        let schema = simple_schema();
+        let rows = (1..=10)
+            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+        assert_stream_collect_parity(crate::filter::ScanSpec::default(), &dir);
+    }
+
+    #[test]
+    fn stream_collect_parity_limit_mid_batch() {
+        let schema = simple_schema();
+        let rows = (1..=10)
+            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+        let spec = crate::filter::ScanSpec {
+            limit: Some(5),
+            ..Default::default()
+        };
+        assert_stream_collect_parity(spec, &dir);
+    }
+
+    #[test]
+    fn stream_collect_parity_predicate() {
+        use crate::ticket::{FlightTicket, Predicate, PredicateOp};
+        let schema = simple_schema();
+        let rows = (1..=10)
+            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+        let ticket = FlightTicket {
+            predicates: vec![Predicate {
+                column: "score".into(),
+                op: PredicateOp::Gte,
+                value: serde_json::json!(40),
+            }],
+            ..Default::default()
+        };
+        let spec = crate::filter::ScanSpec::from_ticket(&ticket, &schema).unwrap();
+        assert_stream_collect_parity(spec, &dir);
+    }
+
+    #[test]
+    fn stream_collect_parity_token_range() {
+        use crate::ticket::FlightTicket;
+        let schema = simple_schema();
+        let rows = (1..=10)
+            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+        let ticket = FlightTicket {
+            token_start: Some(i64::MIN),
+            token_end: Some(0),
+            ..Default::default()
+        };
+        let spec = crate::filter::ScanSpec::from_ticket(&ticket, &schema).unwrap();
+        assert_stream_collect_parity(spec, &dir);
+    }
+
+    // ---- Requirement 5: rows/bytes metrics reflect what was emitted ------------
+
+    /// A fully-consumed stream attributes the same rows/bytes the collect path
+    /// would for the same ticket.
+    #[test]
+    fn metrics_parity_on_full_consumption() {
+        let schema = simple_schema();
+        let rows = (1..=10)
+            .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+            .collect::<Vec<_>>();
+        let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+
+        let producer =
+            MergeProducer::with_spec(schema.clone(), 4, crate::filter::ScanSpec::default())
+                .unwrap();
+        let expected = collect_batches(&producer, &dir);
+        let expected_rows: u64 = expected.iter().map(|b| b.num_rows() as u64).sum();
+        let expected_bytes: u64 = expected
+            .iter()
+            .map(|b| b.get_array_memory_size() as u64)
+            .sum();
+
+        let stream_producer =
+            MergeProducer::with_spec(schema, 4, crate::filter::ScanSpec::default()).unwrap();
+        let paths = resolved(&stream_producer, &dir);
+        let schema_ref = Arc::new(stream_producer.arrow_schema().unwrap());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let pr = probe();
+        let pr_check = pr.clone();
+        rt.block_on(async move {
+            let (stream, handle) = spawn_streaming(
+                stream_producer,
+                paths,
+                schema_ref,
+                RpcMetrics::start("do_get"),
+                DO_GET_CHANNEL_CAPACITY,
+                pr,
+            );
+            let _ = drain_stream(stream).await;
+            let _ = handle.await;
+        });
+
+        assert_eq!(
+            pr_check.rows.load(Ordering::Relaxed),
+            expected_rows,
+            "fully-consumed rows must match the collect path"
+        );
+        assert_eq!(
+            pr_check.bytes.load(Ordering::Relaxed),
+            expected_bytes,
+            "fully-consumed bytes must match the collect path"
+        );
+        assert!(expected_rows > 0, "fixture must produce rows");
+    }
+
+    // ---- Requirement 6: aggregate path keeps materializing (unchanged content) -
+
+    /// An aggregation ticket over a multi-SSTable table serves its bounded
+    /// per-group output as a stream, byte-identical to the retained collect path
+    /// (`produce`). The aggregate route does NOT stream row-by-row — it keeps
+    /// materializing — but is still wrapped in a stream.
+    #[test]
+    fn aggregate_path_matches_collect_content() {
+        use crate::ticket::{AggFunc, AggregateSpec, Aggregation};
+        let schema = simple_schema();
+        // Two SSTables, 7 distinct partitions total after LWW (id=1 rewritten).
+        let (_temp, dir, _schema) = {
+            let a: Vec<_> = (1..=4).map(|i| write_row(i, "a", i, 100)).collect();
+            let b: Vec<_> = (4..=7).map(|i| write_row(i, "b", i, 200)).collect();
+            let (t, _d, dir) = build_sstables(&schema, vec![a, b]);
+            (t, dir, schema.clone())
+        };
+        let agg = Aggregation {
+            group_by: vec![],
+            aggregates: vec![AggregateSpec {
+                func: AggFunc::Count,
+                column: None,
+                output: "cnt".into(),
+            }],
+        };
+
+        // Collect path (the oracle): produce the partial aggregate directly.
+        let collect_producer = MergeProducer::with_spec(schema.clone(), 4, Default::default())
+            .unwrap()
+            .with_aggregation(&agg)
+            .unwrap();
+        let expected = collect_producer.produce(&DirSource::new(&dir)).unwrap();
+        assert_eq!(
+            expected.len(),
+            1,
+            "global aggregation emits one partial batch"
+        );
+        let expected_cnt = count_value(&expected[0]);
+
+        // Streaming service path (build_aggregate_response) — same content.
+        let stream_producer = MergeProducer::with_spec(schema, 4, Default::default())
+            .unwrap()
+            .with_aggregation(&agg)
+            .unwrap();
+        assert!(stream_producer.is_aggregating());
+        let paths = resolved(&stream_producer, &dir);
+        let schema_ref = Arc::new(stream_producer.arrow_schema().unwrap());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let streamed = rt.block_on(async move {
+            let stream = match build_aggregate_response(
+                stream_producer,
+                paths,
+                schema_ref,
+                RpcMetrics::start("do_get"),
+            )
+            .await
+            {
+                Ok(stream) => stream,
+                Err((status, _metrics)) => panic!("aggregate response failed: {status}"),
+            };
+            drain_stream(stream).await
+        });
+        assert_eq!(streamed.len(), 1, "aggregate output stays one batch");
+        assert_eq!(
+            count_value(&streamed[0]),
+            expected_cnt,
+            "streamed aggregate content matches the collect path"
+        );
+    }
+
+    /// Read the single global-`count(*)` partial value from a one-row batch.
+    fn count_value(batch: &RecordBatch) -> i64 {
+        use arrow::array::Array;
+        let col = batch.column_by_name("cnt").expect("cnt column");
+        col.as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .expect("count is Int64")
+            .value(0)
+    }
+
+    /// A cancelled stream (one batch read, then dropped) attributes exactly the
+    /// emitted prefix — not the full table.
+    #[test]
+    fn metrics_attribute_emitted_prefix_on_cancel() {
+        let n = 60;
+        let (_temp, dir, schema) = many_partition_fixture(n);
+        let producer =
+            MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
+        let paths = resolved(&producer, &dir);
+        let schema_ref = Arc::new(producer.arrow_schema().unwrap());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let pr = probe();
+        let pr_check = pr.clone();
+        rt.block_on(async move {
+            let (mut stream, handle) = spawn_streaming(
+                producer,
+                paths,
+                schema_ref,
+                RpcMetrics::start("do_get"),
+                DO_GET_CHANNEL_CAPACITY,
+                pr,
+            );
+            let _schema_msg = read_one(&mut stream).await.expect("schema");
+            let _first = read_one(&mut stream).await.expect("first batch");
+            drop(stream);
+            let _ = handle.await;
+        });
+
+        // The metered stream yielded exactly one batch (one row at batch_size=1)
+        // before the drop, so metrics attribute that single-row prefix — far below
+        // the full table.
+        let rows = pr_check.rows.load(Ordering::Relaxed);
+        assert_eq!(
+            rows, 1,
+            "cancelled stream attributes only the emitted prefix"
+        );
+        assert!(rows < n as u64);
+    }
+}

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -71,6 +71,7 @@ fn first_batch_available_before_merge_completes() {
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
             pr.clone(),
+            CancelFlag::new(),
         );
         // Pull the first message (schema) then the first batch.
         let _schema_msg = read_one(&mut stream).await.expect("schema message");
@@ -118,6 +119,7 @@ fn slow_consumer_bounds_produced_batches() {
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
             pr.clone(),
+            CancelFlag::new(),
         );
         let _schema_msg = read_one(&mut stream).await.expect("schema");
         let _first = read_one(&mut stream).await.expect("first batch");
@@ -161,6 +163,7 @@ fn dropping_stream_cancels_merge() {
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
             pr.clone(),
+            CancelFlag::new(),
         );
         let _schema_msg = read_one(&mut stream).await.expect("schema");
         let _first = read_one(&mut stream).await.expect("first batch");
@@ -436,6 +439,7 @@ fn metrics_parity_on_full_consumption() {
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
             pr,
+            CancelFlag::new(),
         );
         let _ = drain_stream(stream).await;
         let _ = handle.await;
@@ -509,6 +513,7 @@ fn aggregate_path_matches_collect_content() {
             paths,
             schema_ref,
             RpcMetrics::start("do_get"),
+            CancelFlag::new(),
         )
         .await
         {
@@ -556,6 +561,7 @@ fn metrics_attribute_emitted_prefix_on_cancel() {
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
             pr,
+            CancelFlag::new(),
         );
         let _schema_msg = read_one(&mut stream).await.expect("schema");
         let _first = read_one(&mut stream).await.expect("first batch");

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -456,6 +456,13 @@ fn metrics_parity_on_full_consumption() {
         "fully-consumed bytes must match the collect path"
     );
     assert!(expected_rows > 0, "fixture must produce rows");
+    // Roborev round 4: a normal, fully-consumed completion must NOT record an
+    // error — only an actual mid-stream error or an unclean early drop does.
+    assert_eq!(
+        pr_check.errors_recorded.load(Ordering::Relaxed),
+        0,
+        "normal completion must not record an error"
+    );
 }
 
 // ---- Requirement 6: aggregate path keeps materializing (unchanged content) -
@@ -541,7 +548,10 @@ fn count_value(batch: &RecordBatch) -> i64 {
 }
 
 /// A cancelled stream (one batch read, then dropped) attributes exactly the
-/// emitted prefix — not the full table.
+/// emitted prefix — not the full table, and records exactly ONE error (roborev
+/// round 4: pre-change a disconnect surfaced as `aborted` through the handler's
+/// `Err` path and hit the same error-observability hook as any other failure —
+/// `Drop` must reproduce that, not let a disconnect vanish from the signal).
 #[test]
 fn metrics_attribute_emitted_prefix_on_cancel() {
     let n = 60;
@@ -578,4 +588,10 @@ fn metrics_attribute_emitted_prefix_on_cancel() {
         "cancelled stream attributes only the emitted prefix"
     );
     assert!(rows < n as u64);
+    assert_eq!(
+        pr_check.errors_recorded.load(Ordering::Relaxed),
+        1,
+        "an early drop (client disconnect) must record exactly one error, \
+         same as a returned Err used to before this rewrite"
+    );
 }

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -1,0 +1,575 @@
+//! Tests for `crate::streaming` (issue #1476, AB1).
+//!
+//! Split out of `streaming.rs` to keep the production module under the
+//! campsite file-size threshold (`~800` source lines) — this file is a test
+//! module (loaded via `#[path]` from `streaming.rs`), well under the `~1500`
+//! test-file threshold. See epic #1116/#1135.
+
+use super::*;
+use crate::producer::DirSource;
+use crate::testutil::{build_sstables, simple_schema, write_row};
+use cqlite_core::schema::TableSchema;
+
+/// Build a fixture with `n` single-row partitions across two SSTables so the
+/// merge has real per-partition work and, at `batch_size = 1`, yields `n`
+/// batches.
+fn many_partition_fixture(n: i32) -> (tempfile::TempDir, std::path::PathBuf, TableSchema) {
+    let schema = simple_schema();
+    let half = n / 2;
+    let a: Vec<_> = (1..=half).map(|i| write_row(i, "a", i, 100)).collect();
+    let b: Vec<_> = (half + 1..=n).map(|i| write_row(i, "b", i, 100)).collect();
+    let (temp, _data, dir) = build_sstables(&schema, vec![a, b]);
+    (temp, dir, schema)
+}
+
+/// Resolve the pruned paths for a producer over `dir` (mirrors the service's
+/// eager `resolve_paths` step).
+fn resolved(producer: &MergeProducer, dir: &std::path::Path) -> Vec<PathBuf> {
+    producer.resolve_paths(&DirSource::new(dir)).unwrap()
+}
+
+fn probe() -> StreamProbe {
+    StreamProbe::default()
+}
+
+/// Read exactly one item from the response stream (the first Flight message is
+/// the schema; the second carries the first record batch), proving a batch is
+/// available before the merge has run to completion.
+async fn read_one(stream: &mut DoGetStream) -> Option<Result<FlightData, Status>> {
+    stream.next().await
+}
+
+// ---- Task 1.1: do_get emits batches incrementally --------------------------
+
+/// The first batch is available while the merge is still running: after pulling
+/// one message, the producer has emitted far fewer than the full-scan batch
+/// count (bounded by the channel capacity + in-flight allowance).
+///
+/// FAILS on pre-change `main`: there is no `spawn_streaming`/streaming producer
+/// there — `do_get` materializes every batch before the first is available, so
+/// the produced count would equal the full result.
+#[test]
+fn first_batch_available_before_merge_completes() {
+    let n = 40;
+    let (_temp, dir, schema) = many_partition_fixture(n);
+    let producer = MergeProducer::with_spec(
+        schema,
+        1, // batch_size = 1 → one batch per partition row
+        crate::filter::ScanSpec::default(),
+    )
+    .unwrap();
+    let paths = resolved(&producer, &dir);
+    let schema_ref = Arc::new(producer.arrow_schema().unwrap());
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let pr = probe();
+        let (mut stream, handle) = spawn_streaming(
+            producer,
+            paths,
+            schema_ref,
+            RpcMetrics::start("do_get"),
+            DO_GET_CHANNEL_CAPACITY,
+            pr.clone(),
+        );
+        // Pull the first message (schema) then the first batch.
+        let _schema_msg = read_one(&mut stream).await.expect("schema message");
+        let _first_batch = read_one(&mut stream).await.expect("first batch");
+
+        let produced = pr.produced_batches.load(Ordering::Relaxed);
+        assert!(
+            produced < n as usize,
+            "streaming must not materialize all {n} batches before batch 1 \
+             (produced={produced})"
+        );
+        assert!(
+            produced <= DO_GET_CHANNEL_CAPACITY + IN_FLIGHT_ALLOWANCE,
+            "producer must stay within the channel bound (produced={produced})"
+        );
+
+        drop(stream);
+        let _ = handle.await;
+    });
+}
+
+// ---- Task 1.2: peak resident payload is bounded ----------------------------
+
+/// A slow consumer that reads one batch and pauses does not let the producer
+/// run ahead: it blocks after at most capacity + in-flight allowance batches,
+/// independent of the total result size.
+///
+/// FAILS on pre-change `main`: all batches materialize regardless of consumer
+/// progress (no bounded channel exists).
+#[test]
+fn slow_consumer_bounds_produced_batches() {
+    let n = 60;
+    let (_temp, dir, schema) = many_partition_fixture(n);
+    let producer = MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
+    let paths = resolved(&producer, &dir);
+    let schema_ref = Arc::new(producer.arrow_schema().unwrap());
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let pr = probe();
+        let (mut stream, handle) = spawn_streaming(
+            producer,
+            paths,
+            schema_ref,
+            RpcMetrics::start("do_get"),
+            DO_GET_CHANNEL_CAPACITY,
+            pr.clone(),
+        );
+        let _schema_msg = read_one(&mut stream).await.expect("schema");
+        let _first = read_one(&mut stream).await.expect("first batch");
+
+        // Give the producer every opportunity to run ahead, then assert it is
+        // still bounded — it physically cannot exceed the channel allowance.
+        tokio::task::yield_now().await;
+        let produced = pr.produced_batches.load(Ordering::Relaxed);
+        assert!(
+            produced <= DO_GET_CHANNEL_CAPACITY + IN_FLIGHT_ALLOWANCE,
+            "slow consumer: produced {produced} exceeds the channel bound"
+        );
+
+        drop(stream);
+        let _ = handle.await;
+    });
+}
+
+// ---- Task 1.3: consumer disconnect stops the merge -------------------------
+
+/// Dropping the response stream after the first batch stops the merge: the
+/// producer never emits all partitions and the blocking task exits.
+///
+/// FAILS on pre-change `main`: `do_get` runs the merge to completion before the
+/// stream exists, so a drop cannot cut it short.
+#[test]
+fn dropping_stream_cancels_merge() {
+    let n = 60;
+    let (_temp, dir, schema) = many_partition_fixture(n);
+    let producer = MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
+    let paths = resolved(&producer, &dir);
+    let schema_ref = Arc::new(producer.arrow_schema().unwrap());
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let pr = probe();
+        let (mut stream, handle) = spawn_streaming(
+            producer,
+            paths,
+            schema_ref,
+            RpcMetrics::start("do_get"),
+            DO_GET_CHANNEL_CAPACITY,
+            pr.clone(),
+        );
+        let _schema_msg = read_one(&mut stream).await.expect("schema");
+        let _first = read_one(&mut stream).await.expect("first batch");
+
+        // Client disconnects: drop the stream, then await the merge task. It
+        // must terminate (send failure + cancel flag) rather than run to
+        // completion.
+        drop(stream);
+        handle.await.expect("merge task joins after cancellation");
+
+        let produced = pr.produced_batches.load(Ordering::Relaxed);
+        assert!(
+            produced < n as usize,
+            "merge must stop early on disconnect (produced={produced} of {n})"
+        );
+    });
+}
+
+// ---- Roborev B1: a panic mid-merge is a terminal error, not a silent EOF ---
+
+/// [`run_merge_catching_panics`] must forward a caught panic as
+/// [`ProducerError::Panicked`] into the channel, never let it close silently
+/// (which would be indistinguishable downstream from "the merge finished
+/// successfully" — the exact silent-truncation class roborev B1 flagged).
+// No tokio runtime needed: `run_merge_catching_panics` uses `blocking_send`
+// (mirroring how it actually runs, inside `spawn_blocking`), and
+// `blocking_recv` panics only INSIDE an async context — a plain `#[test]`
+// (no runtime at all) is the correct way to exercise it directly.
+#[test]
+fn panicking_merge_forwards_a_terminal_error_not_silent_close() {
+    let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, ProducerError>>(1);
+    run_merge_catching_panics(&tx, || -> Result<(), ProducerError> {
+        panic!("synthetic mid-merge panic (test)");
+    });
+    drop(tx);
+
+    match rx.blocking_recv() {
+        Some(Err(ProducerError::Panicked { message })) => {
+            assert!(
+                message.contains("synthetic mid-merge panic"),
+                "panic message must be forwarded, got: {message}"
+            );
+        }
+        other => {
+            panic!("a panic must forward ProducerError::Panicked, not a silent close: {other:?}")
+        }
+    }
+    // No spurious extra item after the terminal error.
+    assert!(rx.blocking_recv().is_none());
+}
+
+/// End-to-end through the actual `do_get` response-stream stack
+/// (`ReceiverStream` → `MeteredDoGetStream` → `encode_do_get`): a panic mid-merge
+/// must surface as `Status::internal`, never a clean, silently-truncated EOF —
+/// this is the client-visible symptom roborev B1 named. Also proves roborev
+/// B2: the error arm reaches the `record_status_error` hook exactly once
+/// (observed via `StreamProbe`, which does not depend on the `observability`
+/// feature's OTel counters).
+#[test]
+fn do_get_stream_surfaces_panic_as_internal_status_not_eof() {
+    let schema = simple_schema();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let (tx, rx) = mpsc::channel::<Result<RecordBatch, ProducerError>>(DO_GET_CHANNEL_CAPACITY);
+        // Simulate the merge panicking on the blocking pool.
+        let handle = tokio::task::spawn_blocking(move || {
+            run_merge_catching_panics(&tx, || -> Result<(), ProducerError> {
+                panic!("synthetic mid-merge panic (test)");
+            });
+        });
+
+        let schema_ref = Arc::new(
+            MergeProducer::new(schema, 4)
+                .unwrap()
+                .arrow_schema()
+                .unwrap(),
+        );
+        let inner = Box::pin(ReceiverStream { rx });
+        let pr = probe();
+        let metered = MeteredDoGetStream::new(inner, RpcMetrics::start("do_get"), None, pr.clone());
+        let mut stream = encode_do_get(metered, schema_ref);
+
+        // First message is the schema; the panic must arrive as an `Err` Status
+        // (not the stream simply ending after the schema).
+        let _schema_msg = stream.next().await.expect("schema message");
+        match stream.next().await {
+            Some(Err(status)) => {
+                assert_eq!(
+                    status.code(),
+                    tonic::Code::Internal,
+                    "panic must map to Status::internal, got: {status:?}"
+                );
+            }
+            other => {
+                panic!("a mid-merge panic must surface as Status::internal, not {other:?}")
+            }
+        }
+        let _ = handle.await;
+
+        assert_eq!(
+            pr.errors_recorded.load(Ordering::Relaxed),
+            1,
+            "the mid-stream error must reach record_status_error exactly once (B2)"
+        );
+    });
+}
+
+// ---- Task 2.3 / Requirement 4: stream/collect byte-identity ----------------
+
+fn collect_batches(producer: &MergeProducer, dir: &std::path::Path) -> Vec<RecordBatch> {
+    producer.produce(&DirSource::new(dir)).unwrap()
+}
+
+async fn drain_stream(stream: DoGetStream) -> Vec<RecordBatch> {
+    use arrow_flight::decode::FlightRecordBatchStream;
+    let mapped = stream.map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(mapped);
+    let mut out = Vec::new();
+    while let Some(batch) = rb.next().await {
+        out.push(batch.expect("decode batch"));
+    }
+    out
+}
+
+/// Drive the streaming producer path and collect the raw batches it emits into
+/// the channel (pre-encode). This is the true parity seam the spec names —
+/// `produce_streaming` vs the retained `produce` collect path — without the
+/// Flight encoder's response-schema injection (a uniform presentation concern
+/// applied identically to every `do_get`).
+fn stream_batches_raw(producer: MergeProducer, paths: Vec<PathBuf>) -> Vec<RecordBatch> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let (tx, mut rx) =
+            mpsc::channel::<Result<RecordBatch, ProducerError>>(DO_GET_CHANNEL_CAPACITY);
+        let cancel = CancelFlag::new();
+        let handle = tokio::task::spawn_blocking(move || {
+            let mut sink = ChannelSink {
+                tx,
+                produced: Arc::new(AtomicUsize::new(0)),
+            };
+            if let Err(e) = producer.produce_streaming(paths, &cancel, &mut sink) {
+                let _ = sink.tx.blocking_send(Err(e));
+            }
+        });
+        let mut out = Vec::new();
+        while let Some(item) = rx.recv().await {
+            out.push(item.expect("streamed batch is ok"));
+        }
+        let _ = handle.await;
+        out
+    })
+}
+
+/// The streamed batches are byte-identical to the collect-path batches for a
+/// given spec: same schema, batch boundaries, and row content.
+fn assert_stream_collect_parity(spec: crate::filter::ScanSpec, dir: &std::path::Path) {
+    let schema = simple_schema();
+    let collect_producer = MergeProducer::with_spec(schema.clone(), 4, spec.clone()).unwrap();
+    let expected = collect_batches(&collect_producer, dir);
+
+    let stream_producer = MergeProducer::with_spec(schema, 4, spec).unwrap();
+    let paths = resolved(&stream_producer, dir);
+    let streamed = stream_batches_raw(stream_producer, paths);
+
+    assert_eq!(
+        streamed.len(),
+        expected.len(),
+        "batch count (boundaries) must match"
+    );
+    for (s, e) in streamed.iter().zip(expected.iter()) {
+        assert_eq!(
+            s, e,
+            "streamed batch must be byte-identical to collect batch"
+        );
+    }
+}
+
+#[test]
+fn stream_collect_parity_no_constraints() {
+    let schema = simple_schema();
+    let rows = (1..=10)
+        .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+        .collect::<Vec<_>>();
+    let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+    assert_stream_collect_parity(crate::filter::ScanSpec::default(), &dir);
+}
+
+#[test]
+fn stream_collect_parity_limit_mid_batch() {
+    let schema = simple_schema();
+    let rows = (1..=10)
+        .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+        .collect::<Vec<_>>();
+    let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+    let spec = crate::filter::ScanSpec {
+        limit: Some(5),
+        ..Default::default()
+    };
+    assert_stream_collect_parity(spec, &dir);
+}
+
+#[test]
+fn stream_collect_parity_predicate() {
+    use crate::ticket::{FlightTicket, Predicate, PredicateOp};
+    let schema = simple_schema();
+    let rows = (1..=10)
+        .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+        .collect::<Vec<_>>();
+    let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+    let ticket = FlightTicket {
+        predicates: vec![Predicate {
+            column: "score".into(),
+            op: PredicateOp::Gte,
+            value: serde_json::json!(40),
+        }],
+        ..Default::default()
+    };
+    let spec = crate::filter::ScanSpec::from_ticket(&ticket, &schema).unwrap();
+    assert_stream_collect_parity(spec, &dir);
+}
+
+#[test]
+fn stream_collect_parity_token_range() {
+    use crate::ticket::FlightTicket;
+    let schema = simple_schema();
+    let rows = (1..=10)
+        .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+        .collect::<Vec<_>>();
+    let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+    let ticket = FlightTicket {
+        token_start: Some(i64::MIN),
+        token_end: Some(0),
+        ..Default::default()
+    };
+    let spec = crate::filter::ScanSpec::from_ticket(&ticket, &schema).unwrap();
+    assert_stream_collect_parity(spec, &dir);
+}
+
+// ---- Requirement 5: rows/bytes metrics reflect what was emitted ------------
+
+/// A fully-consumed stream attributes the same rows/bytes the collect path
+/// would for the same ticket.
+#[test]
+fn metrics_parity_on_full_consumption() {
+    let schema = simple_schema();
+    let rows = (1..=10)
+        .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+        .collect::<Vec<_>>();
+    let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
+
+    let producer =
+        MergeProducer::with_spec(schema.clone(), 4, crate::filter::ScanSpec::default()).unwrap();
+    let expected = collect_batches(&producer, &dir);
+    let expected_rows: u64 = expected.iter().map(|b| b.num_rows() as u64).sum();
+    let expected_bytes: u64 = expected
+        .iter()
+        .map(|b| b.get_array_memory_size() as u64)
+        .sum();
+
+    let stream_producer =
+        MergeProducer::with_spec(schema, 4, crate::filter::ScanSpec::default()).unwrap();
+    let paths = resolved(&stream_producer, &dir);
+    let schema_ref = Arc::new(stream_producer.arrow_schema().unwrap());
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let pr = probe();
+    let pr_check = pr.clone();
+    rt.block_on(async move {
+        let (stream, handle) = spawn_streaming(
+            stream_producer,
+            paths,
+            schema_ref,
+            RpcMetrics::start("do_get"),
+            DO_GET_CHANNEL_CAPACITY,
+            pr,
+        );
+        let _ = drain_stream(stream).await;
+        let _ = handle.await;
+    });
+
+    assert_eq!(
+        pr_check.rows.load(Ordering::Relaxed),
+        expected_rows,
+        "fully-consumed rows must match the collect path"
+    );
+    assert_eq!(
+        pr_check.bytes.load(Ordering::Relaxed),
+        expected_bytes,
+        "fully-consumed bytes must match the collect path"
+    );
+    assert!(expected_rows > 0, "fixture must produce rows");
+}
+
+// ---- Requirement 6: aggregate path keeps materializing (unchanged content) -
+
+/// An aggregation ticket over a multi-SSTable table serves its bounded
+/// per-group output as a stream, byte-identical to the retained collect path
+/// (`produce`). The aggregate route does NOT stream row-by-row — it keeps
+/// materializing — but is still wrapped in a stream.
+#[test]
+fn aggregate_path_matches_collect_content() {
+    use crate::ticket::{AggFunc, AggregateSpec, Aggregation};
+    let schema = simple_schema();
+    // Two SSTables, 7 distinct partitions total after LWW (id=1 rewritten).
+    let (_temp, dir, _schema) = {
+        let a: Vec<_> = (1..=4).map(|i| write_row(i, "a", i, 100)).collect();
+        let b: Vec<_> = (4..=7).map(|i| write_row(i, "b", i, 200)).collect();
+        let (t, _d, dir) = build_sstables(&schema, vec![a, b]);
+        (t, dir, schema.clone())
+    };
+    let agg = Aggregation {
+        group_by: vec![],
+        aggregates: vec![AggregateSpec {
+            func: AggFunc::Count,
+            column: None,
+            output: "cnt".into(),
+        }],
+    };
+
+    // Collect path (the oracle): produce the partial aggregate directly.
+    let collect_producer = MergeProducer::with_spec(schema.clone(), 4, Default::default())
+        .unwrap()
+        .with_aggregation(&agg)
+        .unwrap();
+    let expected = collect_producer.produce(&DirSource::new(&dir)).unwrap();
+    assert_eq!(
+        expected.len(),
+        1,
+        "global aggregation emits one partial batch"
+    );
+    let expected_cnt = count_value(&expected[0]);
+
+    // Streaming service path (build_aggregate_response) — same content.
+    let stream_producer = MergeProducer::with_spec(schema, 4, Default::default())
+        .unwrap()
+        .with_aggregation(&agg)
+        .unwrap();
+    assert!(stream_producer.is_aggregating());
+    let paths = resolved(&stream_producer, &dir);
+    let schema_ref = Arc::new(stream_producer.arrow_schema().unwrap());
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let streamed = rt.block_on(async move {
+        let stream = match build_aggregate_response(
+            stream_producer,
+            paths,
+            schema_ref,
+            RpcMetrics::start("do_get"),
+        )
+        .await
+        {
+            Ok(stream) => stream,
+            Err((status, _metrics)) => panic!("aggregate response failed: {status}"),
+        };
+        drain_stream(stream).await
+    });
+    assert_eq!(streamed.len(), 1, "aggregate output stays one batch");
+    assert_eq!(
+        count_value(&streamed[0]),
+        expected_cnt,
+        "streamed aggregate content matches the collect path"
+    );
+}
+
+/// Read the single global-`count(*)` partial value from a one-row batch.
+fn count_value(batch: &RecordBatch) -> i64 {
+    use arrow::array::Array;
+    let col = batch.column_by_name("cnt").expect("cnt column");
+    col.as_any()
+        .downcast_ref::<arrow::array::Int64Array>()
+        .expect("count is Int64")
+        .value(0)
+}
+
+/// A cancelled stream (one batch read, then dropped) attributes exactly the
+/// emitted prefix — not the full table.
+#[test]
+fn metrics_attribute_emitted_prefix_on_cancel() {
+    let n = 60;
+    let (_temp, dir, schema) = many_partition_fixture(n);
+    let producer = MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
+    let paths = resolved(&producer, &dir);
+    let schema_ref = Arc::new(producer.arrow_schema().unwrap());
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let pr = probe();
+    let pr_check = pr.clone();
+    rt.block_on(async move {
+        let (mut stream, handle) = spawn_streaming(
+            producer,
+            paths,
+            schema_ref,
+            RpcMetrics::start("do_get"),
+            DO_GET_CHANNEL_CAPACITY,
+            pr,
+        );
+        let _schema_msg = read_one(&mut stream).await.expect("schema");
+        let _first = read_one(&mut stream).await.expect("first batch");
+        drop(stream);
+        let _ = handle.await;
+    });
+
+    // The metered stream yielded exactly one batch (one row at batch_size=1)
+    // before the drop, so metrics attribute that single-row prefix — far below
+    // the full table.
+    let rows = pr_check.rows.load(Ordering::Relaxed);
+    assert_eq!(
+        rows, 1,
+        "cancelled stream attributes only the emitted prefix"
+    );
+    assert!(rows < n as u64);
+}

--- a/openspec/changes/streaming-do-get/design.md
+++ b/openspec/changes/streaming-do-get/design.md
@@ -1,0 +1,81 @@
+# Design — streaming do_get (issue #1476)
+
+## Chosen: bounded-channel producer→stream seam (Option A)
+
+Convert the ONE eager seam — `Vec<RecordBatch>` collection between
+`MergeProducer` and the gRPC response stream — into a bounded
+`tokio::sync::mpsc` channel, leaving the (already lazy) merge machinery and the
+Flight wire encoding untouched.
+
+### Producer side (`cqlite-flight/src/producer.rs`)
+
+- Add `MergeProducer::produce_streaming(&self, source, cancel: &CancelFlag,
+  tx: mpsc::Sender<Result<RecordBatch, ProducerError>>)` (exact signature at
+  implementer's discretion; the contract is the requirements, not the shape).
+- Refactor `drive_merge` so batch emission is a sink call rather than
+  `batches.push(...)` (producer.rs:538,550). The `Vec`-returning
+  `produce`/`produce_cancellable` become the "collect sink" callers — they MUST
+  keep byte-identical behavior (they are the parity oracle and serve the
+  aggregate path and existing tests).
+- `tx.blocking_send(...)` returning `Err` means the receiver (client) is gone:
+  treat as cancellation — stop the merge, return. This composes with the #1473
+  `CancelFlag` polled before each `merger.step()`; both paths stop the merge
+  within a bounded number of steps.
+- Errors mid-merge are sent INTO the channel (`Err(ProducerError)`) so the
+  client sees a Status, matching `delta_scan/scan.rs:60-75`'s error forwarding.
+
+### Service side (`cqlite-flight/src/service.rs` `do_get_inner`, ~371-431)
+
+- Replace `spawn_blocking → Vec` (405-409) with:
+  `let (tx, rx) = mpsc::channel(K)`; spawn the merge on `spawn_blocking`
+  sending into `tx`; build the response from `ReceiverStream::new(rx)` through
+  the existing `FlightDataEncoderBuilder.with_schema(...)` (424-428). The gRPC
+  signature (`DoGetStream` = `BoxStream`) is unchanged.
+- **K (channel capacity in batches):** a small named const (e.g. 4), documented
+  as "peak resident payload ≈ (K + 2) · batch_size" (one batch being built, K
+  queued, one in the encoder). Not a config knob in this change — the 2026-07
+  platform audit's "~40/60 knobs decorative" lesson says don't add tunables
+  without a consumer; #2162 can motivate one later.
+- **Cancellation:** the existing `CancelGuard`-across-one-await (402-410) no
+  longer covers the stream lifetime. The shared `CancelFlag` moves into a guard
+  owned by the response stream (cancel on stream drop), and send-failure gives
+  the second, independent stop signal. AA3 machinery (#1473) is reused, not
+  replaced.
+- **Metrics:** rows/bytes accumulate per batch as they pass to the encoder
+  (e.g. an `inspect` layer or counter in the forwarding adapter) and
+  `metrics.add_rows_bytes` records at stream end — cancelled streams attribute
+  what was actually emitted. This is the one genuine restructure; it is also
+  the seam #2162 (incremental observability) will build on.
+
+### What stays
+
+- `aggregate_paths` keeps materializing (small, one row per group) and is
+  wrapped in `stream::iter` — explicit requirement, not an accident.
+- Existing service tests (`do_get_streams_merged_rows`,
+  `do_get_missing_table_is_not_found`) already consume a stream and keep
+  passing; producer `Vec` tests (limit/token/predicate) stay valid against the
+  retained collect path.
+
+## Alternatives considered
+
+- **B — async-ify the merge itself** (make `PartitionStepper` an async Stream
+  end-to-end): touches the core write-engine merge used by compaction, far
+  larger blast radius, and buys nothing — the merge is already lazy behind a
+  bounded channel per input; the only eager seam is the collection Vec. Rejected.
+- **C — unbounded channel + encoder backpressure**: loses the memory bound this
+  change exists to establish (a slow consumer would buffer the whole table —
+  the audit's exact complaint, relocated). Rejected.
+- **D — chunked materialization (produce N batches, flush, repeat)**: still
+  blocks time-to-first-row on chunk boundaries, adds a tuning knob, and is
+  strictly dominated by A. Rejected.
+
+## Risks / notes
+
+- The blocking-pool thread is held for the stream's lifetime under a slow
+  consumer (backpressure blocks in `blocking_send`). That is the intended
+  behavior (bounded memory traded for a parked thread) and is bounded by the
+  existing blocking-pool admission work (#2063 covers the eager path's pool
+  admission; a parked-on-send thread is strictly cheaper than today's
+  merge-to-completion thread).
+- Byte-identity between streamed and collected output is the parity oracle and
+  gets a dedicated test across limit/filter/token cases.

--- a/openspec/changes/streaming-do-get/proposal.md
+++ b/openspec/changes/streaming-do-get/proposal.md
@@ -1,0 +1,73 @@
+# Streaming do_get — eliminate the materialize-then-emit wall (issue #1476, AB1)
+
+## Why
+
+Flight `do_get` runs the entire k-way merge to completion and collects **every**
+`RecordBatch` into a `Vec` before the first byte reaches the client
+(`cqlite-flight/src/service.rs:405-409`, `producer.rs` `merge_paths`/`drive_merge`).
+Server memory is O(split result) per call × N concurrent consumers — the <128MB
+budget is unbounded here — and time-to-first-row equals time-to-last-row.
+
+The 2026-07-07 round-2 lab run (epic #2103, finding #2157) hit this wall live:
+`count(*)` and full scans produced **zero bytes for minutes** (235s idle-timeout
+disconnects upstream; 26-minute `do_get` root spans in Tempo) while
+`cqlite_rpc_in_flight_ratio` climbed and nothing completed.
+
+Pre-activation fact-finding (2026-07-07, recorded on #2157) narrowed the scope:
+
+- The core k-way merge is **already streaming** — construction is O(#SSTables),
+  a bounded 256-entry channel feeds each input, and `drive_merge` steps one
+  partition at a time. The eager part is ONLY the `Vec<RecordBatch>` collection
+  seam between producer and gRPC stream.
+- The #2135 LIMIT early-stop **already works** (empirical: limit=5 → 5 merge
+  steps, ~13ms). This change does NOT claim to fix LIMIT latency; the lab's
+  24-min LIMIT 5 is attributed to image skew (dev image predating #2135) and is
+  re-tested independently.
+- Predicate pushdown's `filterJson=Optional.empty` gap is **#2164** (connector,
+  separate oracle-driven bug), not this change.
+
+- **Milestone:** M7 / export-path performance. Epic AB #1467 child AB1 (#1476).
+  **Design-driven** — owner decision 2026-07-01 (capstone #5): full streaming
+  rewrite GO immediately, AA3 cancellation machinery (#1473, landed) rides it.
+- **Creates capability** `flight-streaming-egress`.
+
+## What Changes
+
+- **Additive streaming producer surface.** `MergeProducer` gains a streaming
+  produce method that sends each `RecordBatch` into a bounded channel as the
+  merge yields it, instead of pushing into a `Vec`. The existing `Vec`-returning
+  `produce`/`produce_cancellable` remain (aggregate path + tests + parity oracle).
+- **`do_get` streams through a bounded channel.** `service.rs` replaces the
+  `spawn_blocking → Vec` block with a bounded `tokio::sync::mpsc::channel(K)`:
+  the merge runs on the blocking pool sending batches; the gRPC response wraps
+  the receiver stream. First batches reach the wire while the merge is still
+  running; peak resident payload is O(K · batch_size), not O(split result).
+  Mirrors the proven `delta_scan/scan.rs` bounded-channel pattern.
+- **Consumer-driven cancellation.** A dropped client (receiver dropped) makes the
+  producer's send fail → the merge stops within a bounded number of steps,
+  composing with the existing #1473 `CancelFlag` (polled before each step).
+- **Metrics accounting moves to the stream.** rows/bytes attribution
+  (`metrics.add_rows_bytes`, today summed after full materialization) accumulates
+  per emitted batch and is recorded when the stream ends — including partial
+  attribution for cancelled streams (what was actually emitted).
+- **Aggregate path unchanged.** `aggregate_paths` output is one row per group —
+  inherently small — and keeps materializing; its `Vec` is wrapped in a stream.
+
+## Non-goals
+
+- **LIMIT pushdown latency** — already delivered by #2135 and verified fast; the
+  lab symptom is handled as image-skew retest on #2157.
+- **Predicate pushdown** (`filterJson` TupleDomain gap) — issue #2164.
+- **Split token-bound derivation from PK equality** — follow-on noted on #2164.
+- **Incremental read-path observability** (#2162) — sequenced after this change;
+  this change deliberately leaves the per-batch metrics seam it needs.
+- **Streaming the aggregate path** — bounded output, no benefit.
+- **Connector (Java) changes** — the Flight wire protocol is already a stream;
+  Trino consumes incrementally today. No ticket/wire format change.
+- **Core merge-engine changes** — the merge is already lazy; only the
+  producer→gRPC seam changes.
+
+## Doctrine impact
+
+None to CLAUDE.md/site. `docs/reports/performance-audit-program-2026-07.md`
+posture (decision #5) is being executed, not changed.

--- a/openspec/changes/streaming-do-get/specs/flight-streaming-egress/spec.md
+++ b/openspec/changes/streaming-do-get/specs/flight-streaming-egress/spec.md
@@ -1,0 +1,92 @@
+# flight-streaming-egress
+
+## ADDED Requirements
+
+### Requirement: do_get emits batches incrementally
+
+`FlightService::do_get` SHALL make the first `RecordBatch` available to the
+client before the underlying merge has run to completion, for any result
+spanning more than one batch.
+
+#### Scenario: first batch arrives while the merge is still running
+
+- **GIVEN** a table whose SSTables merge into at least 3 record batches
+- **WHEN** a client opens `do_get` and reads the first record batch
+- **THEN** the merge has NOT yet performed the steps for the remaining
+  partitions (observed via a merge-step/work counter), and the remaining
+  batches subsequently arrive with byte-identical total content
+- **AND** this test FAILS on pre-change `main` (where the first batch is only
+  available after all merge steps complete)
+
+### Requirement: peak resident payload is bounded, independent of result size
+
+The `do_get` path SHALL bound resident record-batch payload to a fixed number
+of batches (channel capacity + in-flight allowance), independent of the total
+result size, applying backpressure to the merge when the consumer is slow.
+
+#### Scenario: slow consumer does not grow server memory
+
+- **GIVEN** a table producing at least 4× the channel capacity in batches
+- **WHEN** a client reads ONE batch and then pauses
+- **THEN** the producer blocks after at most (channel capacity + in-flight
+  allowance) further batches — verified by a batch-count/work-counter budget
+  (or alloc-budget) assertion that FAILS on pre-change `main`, where all
+  batches materialize regardless of consumer progress
+
+### Requirement: consumer disconnect stops the merge
+
+A dropped `do_get` client SHALL stop the underlying merge within a bounded
+number of merge steps, via send-failure and/or the #1473 cancel flag.
+
+#### Scenario: dropping the stream cancels the merge
+
+- **GIVEN** an in-progress `do_get` over a multi-batch table
+- **WHEN** the client drops the response stream after the first batch
+- **THEN** the merge terminates without completing the remaining partitions
+  (work counter strictly below the full-scan step count) and the blocking task
+  exits; no batch is produced after cancellation beyond the bounded allowance
+
+### Requirement: streamed output is byte-identical to collected output
+
+The concatenated streamed batches SHALL be byte-identical to the batches
+returned by the retained collect path (`produce`/`produce_cancellable`) for
+any ticket, including limit, predicate-filter, and token-range cases.
+
+#### Scenario: stream/collect parity across ticket shapes
+
+- **GIVEN** fixtures exercising: no constraints, `limit=N` mid-batch,
+  a predicate filter, and a token-range restriction
+- **WHEN** the same ticket is executed through the streaming path and the
+  collect path
+- **THEN** row content, row order, schema, and batch boundaries are identical
+
+### Requirement: rows/bytes metrics reflect what was emitted
+
+RPC rows/bytes attribution for `do_get` SHALL equal the collected-path totals
+for a fully consumed stream, and SHALL equal the actually-emitted subset for a
+cancelled stream.
+
+#### Scenario: metrics parity on full consumption
+
+- **GIVEN** a multi-batch `do_get` fully consumed by the client
+- **WHEN** the stream completes
+- **THEN** recorded rows/bytes equal the pre-change materialized accounting for
+  the same ticket
+
+#### Scenario: cancelled stream attributes the emitted prefix
+
+- **GIVEN** a client that reads one batch and disconnects
+- **WHEN** the merge stops
+- **THEN** recorded rows/bytes cover exactly the batches handed to the encoder,
+  not the full table
+
+### Requirement: aggregate path keeps materializing
+
+The aggregate (`aggregate_paths`) route SHALL continue to materialize its
+bounded per-group output and serve it as a stream, unchanged in content.
+
+#### Scenario: aggregation results unchanged
+
+- **GIVEN** an aggregation ticket over a multi-SSTable table
+- **WHEN** `do_get` executes it before and after this change
+- **THEN** the emitted partial-aggregate batches are identical

--- a/openspec/changes/streaming-do-get/tasks.md
+++ b/openspec/changes/streaming-do-get/tasks.md
@@ -74,6 +74,18 @@
       now span-wrapped) — `tracing::Span` has no cheap "is this span active"
       test hook, so this is exercised via the unchanged behavioral assertions
       rather than a new span-presence assertion.
+- [x] 3.7 Review-first fix round 3 (roborev re-review, 1 new Medium): `do_get_setup`
+      still ran `DirSource::resolve` (filesystem `is_dir`/`read_dir`, incl. the
+      `<table>-<uuid>` layout scan) and producer/schema construction on the async
+      request task BEFORE entering `spawn_blocking` — pre-change ALL filesystem
+      access ran inside the blocking task; under slow/busy storage this stalls the
+      gRPC reactor for unrelated RPCs. Fixed by moving the ENTIRE fallible setup
+      sequence (producer/schema construction, `DirSource::resolve`,
+      `resolve_paths_cancellable`) into ONE `spawn_blocking` closure returning
+      `Result<DoGetSetup, Status>`; `do_get_inner`'s `CancelGuard` still covers the
+      whole `.await` unchanged. Pure refactor — no behavior/signature change, so
+      all existing tests (incl. the round-2 F1 tests) cover it unchanged;
+      `cargo test -p cqlite-flight` stayed at 151 passed.
 
 ## 4. Verification & delivery
 

--- a/openspec/changes/streaming-do-get/tasks.md
+++ b/openspec/changes/streaming-do-get/tasks.md
@@ -41,16 +41,31 @@
       `metrics_attribute_emitted_prefix_on_cancel`).
 - [x] 3.4 Aggregate path: `build_aggregate_response` wraps the materialized output
       in `stream::iter`; `streaming::tests::aggregate_path_matches_collect_content`.
+- [x] 3.5 Review-first fix round (rust-reviewer APPROVE-with-Importants + roborev
+      FAIL, 2 Medium): **B1** a panic in the blocking merge task dropped `tx`
+      silently (clean EOF read as success) — fixed via `run_merge_catching_panics`
+      (`catch_unwind` + new `ProducerError::Panicked`, mapped to
+      `Status::internal`); tests `panicking_merge_forwards_a_terminal_error_not_silent_close`,
+      `do_get_stream_surfaces_panic_as_internal_status_not_eof`. **B2** mid-stream
+      errors skipped `crate::obs::record_status_error` — fixed in
+      `MeteredDoGetStream`'s error arm; observed via `StreamProbe.errors_recorded`
+      in the same panic test. **N1** in-flight allowance de-duplicated into
+      `IN_FLIGHT_ALLOWANCE` (test-only const, doc + tests share one derivation).
 
 ## 4. Verification & delivery
 
 - [x] 4.1 `--lite` each fix round (summary-file redirect); serialized own runs.
 - [x] 4.1a File-size ratchet: the new streaming machinery lives in the new
-      `streaming.rs` (785 lines, under threshold). The irreducible seam additions
-      grow `producer.rs` (2397→2485) and `service.rs` (857→893) — both already far
-      over the 800-line threshold BEFORE this change (needs the #1116/#1135 split,
-      out of scope here). Moving the sinks out would push `streaming.rs` over 800,
-      strictly worse. Lite re-run with `CQLITE_ALLOW_FILE_GROWTH=1` → PASS.
+      `streaming.rs`. The irreducible seam additions grow `producer.rs`
+      (2397→2497) and `service.rs` (857→896) — both already far over the
+      800-line threshold BEFORE this change (needs the #1116/#1135 split, out of
+      scope here). During the B1/B2/N1 fix round `streaming.rs` itself grew past
+      800 (954 lines) with the new panic/error-observability tests; split its
+      `#[cfg(test)] mod tests` out into a sibling `streaming_tests.rs` (via
+      `#[path = "streaming_tests.rs"] mod tests;`) — `streaming.rs` is now 380
+      lines (source), `streaming_tests.rs` 575 (test file, well under 1500).
+      Lite re-run with `CQLITE_ALLOW_FILE_GROWTH=1` (for the still-over-threshold
+      producer.rs/service.rs only) → PASS.
 - [ ] 4.2 Review-first: `rust-reviewer` + roborev on the lite-green diff.
 - [x] 4.3 Existing flight tests green (`do_get_streams_merged_rows`,
       `do_get_missing_table_is_not_found`, producer limit/token/predicate) — full

--- a/openspec/changes/streaming-do-get/tasks.md
+++ b/openspec/changes/streaming-do-get/tasks.md
@@ -45,6 +45,12 @@
 ## 4. Verification & delivery
 
 - [x] 4.1 `--lite` each fix round (summary-file redirect); serialized own runs.
+- [x] 4.1a File-size ratchet: the new streaming machinery lives in the new
+      `streaming.rs` (785 lines, under threshold). The irreducible seam additions
+      grow `producer.rs` (2397→2485) and `service.rs` (857→893) — both already far
+      over the 800-line threshold BEFORE this change (needs the #1116/#1135 split,
+      out of scope here). Moving the sinks out would push `streaming.rs` over 800,
+      strictly worse. Lite re-run with `CQLITE_ALLOW_FILE_GROWTH=1` → PASS.
 - [ ] 4.2 Review-first: `rust-reviewer` + roborev on the lite-green diff.
 - [x] 4.3 Existing flight tests green (`do_get_streams_merged_rows`,
       `do_get_missing_table_is_not_found`, producer limit/token/predicate) — full

--- a/openspec/changes/streaming-do-get/tasks.md
+++ b/openspec/changes/streaming-do-get/tasks.md
@@ -51,6 +51,29 @@
       `MeteredDoGetStream`'s error arm; observed via `StreamProbe.errors_recorded`
       in the same panic test. **N1** in-flight allowance de-duplicated into
       `IN_FLIGHT_ALLOWANCE` (test-only const, doc + tests share one derivation).
+- [x] 3.6 Review-first fix round 2 (roborev re-review, 2 new Mediums — both
+      regressions vs pre-change behavior): **F1** `do_get_setup`'s eager
+      path-resolution/prune `spawn_blocking` had no `CancelGuard` (pre-change the
+      single merge `spawn_blocking` was covered end-to-end) — fixed by creating
+      ONE `CancelFlag` in `do_get_inner` BEFORE setup, holding a `CancelGuard`
+      across the setup `.await` (disarmed on success), and handing the SAME flag
+      into `spawn_streaming`/`build_aggregate_response` for the merge stage; new
+      `MergeProducer::resolve_paths_cancellable`/`prune_paths_cancellable` poll
+      the flag before listing and once per SSTable during the token-span prune.
+      Tests: `service::tests::do_get_setup_honors_cancellation_before_resolution`
+      (+ `_resolves_normally_without_cancellation` baseline),
+      `producer::tests::resolve_paths_cancellable_rejects_before_listing`,
+      `producer::tests::prune_paths_cancellable_stops_before_any_summary_read_when_pre_cancelled`.
+      **F2** mid-stream `record_status_error` ran outside the `flight.do_get`
+      span once `do_get` itself had returned (later `poll_next`s happen outside
+      the `.instrument(span)`-wrapped future) — fixed by capturing
+      `Span::current()` into `MeteredDoGetStream` at construction (while still
+      inside the instrumented future) and re-entering it around `poll_next` and
+      `Drop`'s finalize; covered by the existing
+      `metrics_attribute_emitted_prefix_on_cancel`/panic tests (same call sites,
+      now span-wrapped) — `tracing::Span` has no cheap "is this span active"
+      test hook, so this is exercised via the unchanged behavioral assertions
+      rather than a new span-presence assertion.
 
 ## 4. Verification & delivery
 
@@ -62,10 +85,12 @@
       scope here). During the B1/B2/N1 fix round `streaming.rs` itself grew past
       800 (954 lines) with the new panic/error-observability tests; split its
       `#[cfg(test)] mod tests` out into a sibling `streaming_tests.rs` (via
-      `#[path = "streaming_tests.rs"] mod tests;`) — `streaming.rs` is now 380
-      lines (source), `streaming_tests.rs` 575 (test file, well under 1500).
-      Lite re-run with `CQLITE_ALLOW_FILE_GROWTH=1` (for the still-over-threshold
-      producer.rs/service.rs only) → PASS.
+      `#[path = "streaming_tests.rs"] mod tests;`) — `streaming.rs` is now 416
+      lines (source), `streaming_tests.rs` 581 (test file, well under 1500),
+      after fix round 2's F1/F2 additions. `producer.rs`/`service.rs` continue
+      growing from their pre-existing over-threshold baseline (now 2607/1016) —
+      out of scope (#1116/#1135). Lite re-run with `CQLITE_ALLOW_FILE_GROWTH=1`
+      (for producer.rs/service.rs only) → PASS.
 - [ ] 4.2 Review-first: `rust-reviewer` + roborev on the lite-green diff.
 - [x] 4.3 Existing flight tests green (`do_get_streams_merged_rows`,
       `do_get_missing_table_is_not_found`, producer limit/token/predicate) — full

--- a/openspec/changes/streaming-do-get/tasks.md
+++ b/openspec/changes/streaming-do-get/tasks.md
@@ -86,6 +86,27 @@
       whole `.await` unchanged. Pure refactor — no behavior/signature change, so
       all existing tests (incl. the round-2 F1 tests) cover it unchanged;
       `cargo test -p cqlite-flight` stayed at 151 passed.
+- [x] 3.8 Review-first fix round 4 (roborev, 1 blocker + 1 triaged NIT deferred
+      to a follow-up issue, not fixed): **blocker** — an early stream drop
+      (client disconnect) finalized `RpcMetrics` but never called
+      `record_status_error`, so a disconnect vanished from the flight error-rate
+      signal / RPC-span error marking (pre-change a disconnect surfaced as
+      `aborted` through the handler's `Err` path and DID hit that hook). Fixed
+      in `MeteredDoGetStream`'s `Drop`: `self.metrics.is_some()` at drop-time
+      distinguishes an unclean early drop (neither `poll_next` terminal arm ran)
+      from an already-finalized stream (normal end or an already-recorded
+      mid-stream error) — idempotent via the same `metrics.take()` guard
+      `finalize` already used, so no double-recording. Extended
+      `metrics_attribute_emitted_prefix_on_cancel` (asserts `errors_recorded ==
+      1` on early drop) and `metrics_parity_on_full_consumption` (asserts
+      `errors_recorded == 0` on normal completion); the existing panic test's
+      `errors_recorded == 1` assertion continues to pass unchanged (no double
+      count from the later `Drop`). **NIT, deferred** —
+      `producer.rs` `data_paths()`/`table_base_dir()`'s `read_dir` calls are not
+      cancellation-aware; NOT a regression (pre-change resolution was equally
+      uncancellable inside the same blocking task) and enumeration is
+      milliseconds vs multi-second merges — left as-is, to be batched into a
+      follow-up issue at merge time per the nit-batching policy.
 
 ## 4. Verification & delivery
 

--- a/openspec/changes/streaming-do-get/tasks.md
+++ b/openspec/changes/streaming-do-get/tasks.md
@@ -1,0 +1,52 @@
+# Tasks — streaming-do-get (issue #1476)
+
+## 1. TDD guards (fail on main first)
+
+- [ ] 1.1 Incremental-emission test: `do_get` over a ≥3-batch fixture; assert a
+      merge-step/work counter shows remaining steps pending when batch 1 is
+      readable. Surface: `FlightService::do_get` via `FlightRecordBatchStream`.
+      MUST FAIL on pre-change main; record the failure output.
+- [ ] 1.2 Slow-consumer bound test: read one batch, pause; assert producer
+      blocked at ≤ capacity + allowance batches (batch-count budget). MUST FAIL
+      on main. Surface: `do_get`.
+- [ ] 1.3 Disconnect-cancels test: drop the stream after batch 1; assert merge
+      work counter < full-scan steps and task exit (extends the #1473 test).
+      Surface: `do_get`.
+
+## 2. Producer refactor (`cqlite-flight/src/producer.rs`)
+
+- [ ] 2.1 Extract batch emission in `drive_merge` behind a sink; retain
+      `produce`/`produce_cancellable` as the collect sink (byte-identical).
+- [ ] 2.2 Add the streaming produce entry point sending
+      `Result<RecordBatch, ProducerError>` into a bounded channel;
+      send-failure ⇒ stop merge (cancellation), compose with `CancelFlag`.
+- [ ] 2.3 Stream/collect parity test across no-constraint / limit / predicate /
+      token tickets (Requirement: byte-identical). Surface: both produce paths.
+
+## 3. Service wiring (`cqlite-flight/src/service.rs`)
+
+- [ ] 3.1 `do_get_inner`: bounded `mpsc::channel(K)` (named const, documented
+      memory bound), merge on `spawn_blocking`, response from the receiver
+      stream through the existing encoder; schema-first behavior preserved for
+      empty results. Surface: `FlightService::do_get` (gRPC, end-to-end).
+- [ ] 3.2 Move `CancelFlag` guard to stream lifetime (cancel on drop + on send
+      failure); remove the now-obsolete single-await guard comment block.
+- [ ] 3.3 Move rows/bytes accounting to per-batch accumulation recorded at
+      stream end, incl. cancelled-prefix attribution (Requirement: metrics).
+      Surface: RPC metrics observed in service tests.
+- [ ] 3.4 Aggregate path: wrap materialized output in `stream::iter`; add the
+      unchanged-content test (Requirement: aggregate).
+
+## 4. Verification & delivery
+
+- [ ] 4.1 `--lite` each fix round (summary-file redirect); serialize own runs.
+- [ ] 4.2 Review-first: `rust-reviewer` + roborev on the lite-green diff.
+- [ ] 4.3 Existing flight tests green (`do_get_streams_merged_rows`,
+      `do_get_missing_table_is_not_found`, producer limit/token/predicate).
+- [ ] 4.4 flow-closer endgame: ONE full `scripts/agent-gate.sh` (summary-file
+      redirect) → C intent audit (`spec-auditor` vs this change's `specs/**`)
+      → final roborev → merge-on-green → finalize (telemetry stamp, archive,
+      board Done, worktree/branch cleanup).
+- [ ] 4.5 Post-merge: rebuild `ghcr.io/pmcfadin/cqlite-flight:dev`; note on
+      #2157 that the streaming fix is live for the next lab run (pods must
+      restart to re-pull).

--- a/openspec/changes/streaming-do-get/tasks.md
+++ b/openspec/changes/streaming-do-get/tasks.md
@@ -2,47 +2,53 @@
 
 ## 1. TDD guards (fail on main first)
 
-- [ ] 1.1 Incremental-emission test: `do_get` over a ≥3-batch fixture; assert a
-      merge-step/work counter shows remaining steps pending when batch 1 is
-      readable. Surface: `FlightService::do_get` via `FlightRecordBatchStream`.
-      MUST FAIL on pre-change main; record the failure output.
-- [ ] 1.2 Slow-consumer bound test: read one batch, pause; assert producer
-      blocked at ≤ capacity + allowance batches (batch-count budget). MUST FAIL
-      on main. Surface: `do_get`.
-- [ ] 1.3 Disconnect-cancels test: drop the stream after batch 1; assert merge
-      work counter < full-scan steps and task exit (extends the #1473 test).
-      Surface: `do_get`.
+- [x] 1.1 Incremental-emission test: `streaming::tests::first_batch_available_before_merge_completes`
+      — asserts the produced-batch counter is `< n` (and within the channel bound)
+      once batch 1 is readable. FAILS on main (the streaming API is absent —
+      captured compile failure: `no method resolve_paths/is_aggregating`,
+      `unresolved import BatchSink`).
+- [x] 1.2 Slow-consumer bound test:
+      `streaming::tests::slow_consumer_bounds_produced_batches` — reads one batch,
+      yields, asserts produced ≤ capacity + allowance. FAILS on main.
+- [x] 1.3 Disconnect-cancels test: `streaming::tests::dropping_stream_cancels_merge`
+      — drops the stream after batch 1, awaits the merge task, asserts produced
+      `< n`. FAILS on main.
 
 ## 2. Producer refactor (`cqlite-flight/src/producer.rs`)
 
-- [ ] 2.1 Extract batch emission in `drive_merge` behind a sink; retain
-      `produce`/`produce_cancellable` as the collect sink (byte-identical).
-- [ ] 2.2 Add the streaming produce entry point sending
-      `Result<RecordBatch, ProducerError>` into a bounded channel;
-      send-failure ⇒ stop merge (cancellation), compose with `CancelFlag`.
-- [ ] 2.3 Stream/collect parity test across no-constraint / limit / predicate /
-      token tickets (Requirement: byte-identical). Surface: both produce paths.
+- [x] 2.1 Extracted batch emission in `drive_merge` behind `BatchSink`; the
+      retained `produce`/`produce_cancellable` use `CollectSink` (byte-identical).
+- [x] 2.2 Added `MergeProducer::produce_streaming` sending
+      `Result<RecordBatch, ProducerError>` into a bounded channel via `ChannelSink`;
+      send-failure ⇒ `ProducerError::Cancelled` (composes with `CancelFlag`).
+- [x] 2.3 Stream/collect parity tests
+      (`streaming::tests::stream_collect_parity_{no_constraints,limit_mid_batch,predicate,token_range}`)
+      compare raw streamed batches to the collect path — byte-identical.
 
 ## 3. Service wiring (`cqlite-flight/src/service.rs`)
 
-- [ ] 3.1 `do_get_inner`: bounded `mpsc::channel(K)` (named const, documented
-      memory bound), merge on `spawn_blocking`, response from the receiver
-      stream through the existing encoder; schema-first behavior preserved for
-      empty results. Surface: `FlightService::do_get` (gRPC, end-to-end).
-- [ ] 3.2 Move `CancelFlag` guard to stream lifetime (cancel on drop + on send
-      failure); remove the now-obsolete single-await guard comment block.
-- [ ] 3.3 Move rows/bytes accounting to per-batch accumulation recorded at
-      stream end, incl. cancelled-prefix attribution (Requirement: metrics).
-      Surface: RPC metrics observed in service tests.
-- [ ] 3.4 Aggregate path: wrap materialized output in `stream::iter`; add the
-      unchanged-content test (Requirement: aggregate).
+- [x] 3.1 `do_get_inner`: `spawn_streaming` builds a bounded
+      `mpsc::channel(DO_GET_CHANNEL_CAPACITY)` (named const, documented bound),
+      merge on `spawn_blocking`, response from the receiver stream through the
+      existing encoder. `do_get_setup` resolves paths eagerly so a missing table
+      stays `not_found` and empty results stay schema-only (existing tests green).
+- [x] 3.2 `CancelFlag` guard moved to the stream lifetime (`MeteredDoGetStream`
+      owns the `CancelGuard`: cancel on drop, disarm on normal end) + send-failure
+      is the second stop signal; the obsolete single-await guard block is removed.
+- [x] 3.3 rows/bytes accounting moved to per-batch accumulation in
+      `MeteredDoGetStream`, recorded at stream end incl. cancelled-prefix
+      (`streaming::tests::metrics_parity_on_full_consumption`,
+      `metrics_attribute_emitted_prefix_on_cancel`).
+- [x] 3.4 Aggregate path: `build_aggregate_response` wraps the materialized output
+      in `stream::iter`; `streaming::tests::aggregate_path_matches_collect_content`.
 
 ## 4. Verification & delivery
 
-- [ ] 4.1 `--lite` each fix round (summary-file redirect); serialize own runs.
+- [x] 4.1 `--lite` each fix round (summary-file redirect); serialized own runs.
 - [ ] 4.2 Review-first: `rust-reviewer` + roborev on the lite-green diff.
-- [ ] 4.3 Existing flight tests green (`do_get_streams_merged_rows`,
-      `do_get_missing_table_is_not_found`, producer limit/token/predicate).
+- [x] 4.3 Existing flight tests green (`do_get_streams_merged_rows`,
+      `do_get_missing_table_is_not_found`, producer limit/token/predicate) — full
+      `cargo test -p cqlite-flight` = 145 passed.
 - [ ] 4.4 flow-closer endgame: ONE full `scripts/agent-gate.sh` (summary-file
       redirect) → C intent audit (`spec-auditor` vs this change's `specs/**`)
       → final roborev → merge-on-green → finalize (telemetry stamp, archive,


### PR DESCRIPTION
## Summary
Implements the owner-approved OpenSpec change `streaming-do-get` (Seam-1 approved 2026-07-07): converts Flight `do_get` from materialize-then-emit (`Vec<RecordBatch>` collected before the first byte) to a bounded-channel stream — first batches reach the wire while the merge is still running; peak resident payload is O(K·batch_size) independent of result size; a dropped client stops the merge.

Closes #1476. Epic AB #1467 (streaming egress). Lab evidence: #2157 (round-2 harness — 235s zero-byte idle timeouts, 26-min do_get spans).

## Spec / requirement → test (all requirements from `openspec/changes/streaming-do-get/specs/flight-streaming-egress/spec.md`)
| Requirement | Test |
|---|---|
| incremental emission | `first_batch_available_before_merge_completes` |
| bounded peak payload | `slow_consumer_bounds_produced_batches` |
| disconnect stops merge | `dropping_stream_cancels_merge` |
| stream/collect byte-identity | `stream_collect_parity_{no_constraints,limit_mid_batch,predicate,token_range}` |
| metrics reflect emitted | `metrics_parity_on_full_consumption`, `metrics_attribute_emitted_prefix_on_cancel` |
| aggregate keeps materializing | `aggregate_path_matches_collect_content` |

TDD fail-first: tests reject main both structurally (streaming API absent) and behaviorally (bound assertions reject a materialize-then-send stub).

## Review-first history (4 rounds, all findings fixed pre-PR)
- rust-reviewer (opus): APPROVE; I1 panic→silent-truncation + N1 bound-const → FIXED; I2 (spec scenarios proven at spawn_streaming — do_get delegates with zero intervening logic) left for the C intent audit by design.
- roborev r1: panic silent-EOF + mid-stream record_status_error → FIXED (catch_unwind → ProducerError::Panicked → Status::internal; error arm records).
- roborev r2: setup-phase CancelGuard gap + RPC-span attribution → FIXED (one flag across setup+stream; span carried into MeteredDoGetStream).
- roborev r3: DirSource::resolve FS work on the gRPC reactor → FIXED (entire setup in one guarded spawn_blocking).
- roborev r4: early-drop not recorded as error → FIXED (Drop records Status::aborted once, double-record-proof). Second r4 finding (read_dir not cancel-aware) triaged NIT — NOT a regression (pre-change resolution equally uncancellable; enumeration is ms vs multi-second merges); batched to follow-up at merge.

## Evidence
- `cargo test -p cqlite-flight`: 151 passed; clippy `-D warnings` clean.
- Lite gate: RESULT: PASS at `a3a417db` (CQLITE_ALLOW_FILE_GROWTH=1 solely for pre-existing over-threshold producer.rs/service.rs — #1116; new code isolated in streaming.rs 439 / streaming_tests.rs 597).
- Full gate of record + C intent audit + final roborev run in flow-closer before merge.

## Non-goals honored
No connector/Java changes; predicate pushdown was #2164 (merged separately); aggregate path materializes by spec; no new config knobs; #2162 (incremental observability) sequenced after, rides this change's per-batch metrics seam.