### PR TITLE
fix(#1941): derive aggregate result metadata types from function + argument, not schema name lookup

### DIFF
--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -1306,6 +1306,53 @@ impl SelectExecutor {
                     // metadata and row keys can never diverge (never `col_N`).
                     let column_name = crate::query::select_naming::result_column_name(expr, i);
 
+                    // Issue #1941: an aggregate's result TYPE is derived from the
+                    // aggregate function + argument type, NOT from a schema lookup
+                    // of its output name/alias. Detect the aggregate via the parsed
+                    // AST (no string-matching — no-heuristics mandate) BEFORE the
+                    // name-based lookup below, which otherwise mis-typed
+                    // `COUNT(*) AS value` as the `value` column's type and fell back
+                    // to `Text` for any name matching no column.
+                    if let Some(agg) = crate::query::select_naming::unwrap_aggregate(expr) {
+                        // Resolve the argument column's schema type for MIN/MAX
+                        // (COUNT/SUM/AVG ignore it). `aggregate_column_and_alias`
+                        // yields "*" for `COUNT(*)` / any star argument.
+                        let (arg_col, _) =
+                            crate::query::select_naming::aggregate_column_and_alias(agg);
+                        let arg_cql_type = if arg_col == "*" {
+                            None
+                        } else {
+                            schema_opt.and_then(|schema| {
+                                schema
+                                    .columns
+                                    .iter()
+                                    .find(|c| c.name == arg_col)
+                                    .and_then(|c| parse_cql_type_str(&c.data_type))
+                            })
+                        };
+                        let cql_type_opt = crate::query::select_naming::aggregate_result_cql_type(
+                            &agg.function,
+                            arg_cql_type,
+                        );
+                        let data_type = cql_type_opt
+                            .as_ref()
+                            .map(cql_type_to_data_type)
+                            .unwrap_or(crate::types::DataType::Text);
+                        let mut col_info = ColumnInfo {
+                            name: column_name,
+                            data_type,
+                            nullable: true,
+                            position: i,
+                            table_name: None,
+                            cql_type: None,
+                        };
+                        if let Some(cql_type) = cql_type_opt {
+                            col_info = col_info.with_cql_type(cql_type);
+                        }
+                        columns.push(col_info);
+                        continue;
+                    }
+
                     // Look up CQL type for this column in the schema (Issue #674).
                     let cql_type_opt = schema_opt.and_then(|schema| {
                         schema
@@ -2338,5 +2385,109 @@ mod tests {
             "a reordered select with no helper columns (same column set) must \
              stream directly"
         );
+    }
+
+    /// Issue #1941: execute `sql` end-to-end against a registry table that has a
+    /// `value` INT column (to exercise the alias-collision case) plus numeric
+    /// columns, and return the result metadata columns. The aggregate path runs
+    /// through the REAL `execute()` metadata build (`get_result_columns` with the
+    /// resolved schema), so assertions here prove `metadata.columns[i]` typing on
+    /// the actual query path, not a helper in isolation.
+    async fn agg_result_columns(sql: &str) -> Vec<ColumnInfo> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.unwrap());
+        let storage = Arc::new(
+            StorageEngine::open(
+                temp_dir.path(),
+                &config,
+                platform.clone(),
+                #[cfg(feature = "state_machine")]
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
+        schema
+            .parse_and_register_cql_schema(
+                "CREATE TABLE ks.t (id int PRIMARY KEY, value int, amount int, price double)",
+            )
+            .await
+            .expect("schema registers");
+        let executor = SelectExecutor::new(schema.clone(), storage.clone());
+        let optimizer =
+            crate::query::select_optimizer::SelectOptimizer::new(schema.clone(), storage.clone());
+        let statement = crate::query::select_parser::parse_select(sql).unwrap();
+        let plan = optimizer.optimize(statement).await.unwrap();
+        executor
+            .execute(plan)
+            .await
+            .expect("query executes")
+            .metadata
+            .columns
+    }
+
+    /// Issue #1941: `COUNT(*) AS value` MUST report a `bigint` count result type
+    /// even though the table has a real `value INT` column. Pre-fix the metadata
+    /// type was resolved by looking the aggregate's output NAME up in the schema,
+    /// so the alias collided with column `value` and reported `int`.
+    #[tokio::test]
+    async fn aggregate_count_alias_collision_reports_bigint_not_column_type() {
+        let cols = agg_result_columns("SELECT COUNT(*) AS value FROM ks.t").await;
+        assert_eq!(cols.len(), 1);
+        assert_eq!(
+            cols[0].name, "value",
+            "alias names the column (issue #1763)"
+        );
+        assert_eq!(
+            cols[0].cql_type,
+            Some(CqlType::BigInt),
+            "COUNT is bigint regardless of a same-named `value INT` column (#1941)"
+        );
+        assert_eq!(cols[0].data_type, crate::types::DataType::BigInt);
+    }
+
+    /// Issue #1941: a bare `COUNT(*)` whose derived name matches no schema column
+    /// must be `bigint`, not the old `Text` fallback.
+    #[tokio::test]
+    async fn aggregate_count_star_reports_bigint_not_text_fallback() {
+        let cols = agg_result_columns("SELECT COUNT(*) FROM ks.t").await;
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].cql_type, Some(CqlType::BigInt));
+        assert_eq!(cols[0].data_type, crate::types::DataType::BigInt);
+    }
+
+    /// Issue #1941: SUM/AVG report `double` — CQLite's aggregation accumulates all
+    /// numeric input into an f64 and `finalize_group` emits `Value::Float`, so the
+    /// metadata type MUST be `double` to match the produced value (never the
+    /// argument column's `int` type, and never `Text`).
+    #[tokio::test]
+    async fn aggregate_sum_and_avg_report_double() {
+        let sum = agg_result_columns("SELECT SUM(amount) FROM ks.t").await;
+        assert_eq!(sum.len(), 1);
+        assert_eq!(sum[0].cql_type, Some(CqlType::Double));
+        assert_eq!(sum[0].data_type, crate::types::DataType::Float);
+
+        let avg = agg_result_columns("SELECT AVG(amount) FROM ks.t").await;
+        assert_eq!(avg.len(), 1);
+        assert_eq!(avg[0].cql_type, Some(CqlType::Double));
+        assert_eq!(avg[0].data_type, crate::types::DataType::Float);
+    }
+
+    /// Issue #1941: MIN/MAX preserve the ARGUMENT column's type (the value is
+    /// cloned through unchanged) — `MIN(amount)` over an `int` column is `int`,
+    /// `MAX(price)` over a `double` column is `double`.
+    #[tokio::test]
+    async fn aggregate_min_max_report_argument_type() {
+        let min_int = agg_result_columns("SELECT MIN(amount) FROM ks.t").await;
+        assert_eq!(min_int.len(), 1);
+        assert_eq!(min_int[0].cql_type, Some(CqlType::Int));
+        assert_eq!(min_int[0].data_type, crate::types::DataType::Integer);
+
+        let max_double = agg_result_columns("SELECT MAX(price) FROM ks.t").await;
+        assert_eq!(max_double.len(), 1);
+        assert_eq!(max_double[0].cql_type, Some(CqlType::Double));
+        assert_eq!(max_double[0].data_type, crate::types::DataType::Float);
     }
 }

--- a/cqlite-core/src/query/select_naming.rs
+++ b/cqlite-core/src/query/select_naming.rs
@@ -10,6 +10,7 @@
 //! synthetic `col_N`.
 
 use super::select_ast::*;
+use crate::schema::CqlType;
 
 /// The scan-projection column name for a SELECT expression, or `None` when the
 /// expression does not name a stored column (aggregates, literals, arithmetic).
@@ -124,6 +125,37 @@ pub(crate) fn result_column_name(expr: &SelectExpression, index: usize) -> Strin
     }
 }
 
+/// Derive the CQL result type of an aggregate from the aggregate FUNCTION and
+/// its argument's schema type — never from a schema lookup of the aggregate's
+/// output name/alias (issue #1941). The name-lookup approach mis-typed
+/// `COUNT(*) AS value` as the `value` column's type and fell back to `Text` for
+/// any aggregate whose derived name matched no column.
+///
+/// Oracle — Cassandra's aggregate type rules, reconciled with the value type
+/// CQLite's executor actually emits in `finalize_group`
+/// (`select_executor::aggregation`):
+///   * `COUNT(*)` / `COUNT(col)` → `bigint` (emitted `Value::BigInt`)
+///   * `SUM(_)` / `AVG(_)`       → `double` (CQLite accumulates every numeric
+///     input into an `f64` and emits `Value::Float`, so the metadata type MUST
+///     be `double` to describe the produced value rather than lie about it)
+///   * `MIN(col)` / `MAX(col)`   → the argument column's type (the value is
+///     cloned through unchanged)
+///
+/// `arg_type` is the pre-resolved CQL type of the aggregate's argument column
+/// (from the schema); it is consulted ONLY for MIN/MAX. Returns `None` solely
+/// for a MIN/MAX whose argument type is unknown (no schema, or the argument is
+/// not a resolvable column), leaving the caller's existing untyped fallback.
+pub(crate) fn aggregate_result_cql_type(
+    function: &AggregateType,
+    arg_type: Option<CqlType>,
+) -> Option<CqlType> {
+    match function {
+        AggregateType::Count => Some(CqlType::BigInt),
+        AggregateType::Sum | AggregateType::Avg => Some(CqlType::Double),
+        AggregateType::Min | AggregateType::Max => arg_type,
+    }
+}
+
 /// Resolve `(column, alias)` for an aggregate. `COUNT(*)` and any aggregate
 /// referencing `*` yields `("*", "Func(*)")`; a single named column yields
 /// `(name, "Func_name")`; anything else falls back to `("*", "Func")`.
@@ -232,6 +264,42 @@ mod tests {
         assert_eq!(aggregate_arg_source_columns(&aliased), vec!["value"]);
         // Plain columns / non-aggregates contribute no aggregate-argument columns.
         assert!(aggregate_arg_source_columns(&col("value")).is_empty());
+    }
+
+    /// Issue #1941: aggregate result type comes from the function (+ argument
+    /// type for MIN/MAX), never a name lookup. COUNT → bigint; SUM/AVG → double
+    /// (CQLite emits `Value::Float`); MIN/MAX preserve the argument type and are
+    /// the ONLY variants that return `None` when the argument type is unknown.
+    #[test]
+    fn aggregate_result_cql_type_derives_from_function_and_argument() {
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Count, Some(CqlType::Int)),
+            Some(CqlType::BigInt),
+            "COUNT is bigint regardless of any argument type"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::Int)),
+            Some(CqlType::Double)
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Avg, Some(CqlType::Int)),
+            Some(CqlType::Double)
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Min, Some(CqlType::Int)),
+            Some(CqlType::Int),
+            "MIN preserves the argument column's type"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Max, Some(CqlType::Double)),
+            Some(CqlType::Double)
+        );
+        // Only MIN/MAX with an unknown argument type stay untyped.
+        assert_eq!(aggregate_result_cql_type(&AggregateType::Min, None), None);
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Count, None),
+            Some(CqlType::BigInt)
+        );
     }
 
     /// A non-aggregate expression is not an aggregate name and falls back to the


### PR DESCRIPTION
Closes #1941

## Problem
Aggregate result metadata **types** were derived by looking up the aggregate's output NAME in the table schema. An alias colliding with a real column (e.g. `SELECT COUNT(*) AS value` where `value` is also a column) inherited that column's type; a non-matching name fell back to `Text`.

## Fix
Detect aggregate expressions via the existing parsed-AST helpers (`unwrap_aggregate`, `aggregate_column_and_alias`) BEFORE the schema name-lookup in `get_result_columns`, and derive the metadata type from the aggregate function + argument type via a new `aggregate_result_cql_type` helper (`select_naming.rs`):
- COUNT → BigInt
- SUM/AVG → Double (matches what CQLite's `finalize_group` accumulator actually emits — `Value::Float` — rather than Cassandra's `SUM(int)→int`; metadata now describes the produced value)
- MIN/MAX → the argument column's type

No SQL text re-parsing/string-matching — reuses the same AST facts the aggregation plan already keys off.

## Testing
4 new end-to-end tests through `execute()` (real schema + real query plan), red-before-green, plus a unit test for the helper. All pass. `RUSTFLAGS="-D warnings"` clippy clean, no `unwrap()`/`expect()` in library code.

## Review
- `rust-reviewer`: approve, nothing blocking (one cosmetic non-blocking dedup suggestion, deferred to the #1116 file-split epic).
- roborev: clean (one low-severity parity note on SUM/AVG→Double vs Cassandra's SUM(int)→int, already reasoned through in the code comment — metadata intentionally matches CQLite's actual f64 accumulator output, not a bug).

## Known pre-existing gaps (not regressions, not touched by this diff)
- MIN/MAX argument-type resolution only searches `schema.columns` (same limitation the old name-lookup path had) — a MIN/MAX over a partition/clustering-key column argument falls back to `Text`.
- SUM does not narrow to the argument's integer type (accumulator is always f64) — separate from this metadata fix.

## Gate
LITE gate: PASS (`CQLITE_ALLOW_FILE_GROWTH=1` used — `select_executor/mod.rs` was already ~2342 lines pre-existing, epic #1116 debt; net growth from this diff is ~150 lines, all germane). Full gate + C + final roborev + merge-on-green run by `flow-closer`.