### PR TITLE
test(#1742): query-semantics parity oracle distinct from physical-dump goldens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,13 @@ by responsibility (source: epic #1116; tests: #1135). Genuinely out of scope →
   reference files —
   [validation playbook](https://pmcfadin.github.io/cqlite/agents-developing/validation-playbook/)
 - Never let a dataset-dependent test pass on an empty dataset (0-rows-when-present = failure)
+- **Two parity oracles (issue #1742)**: *physical-dump parity* (the `*-Data.db.jsonl` sstabledump
+  goldens) enumerates every on-disk cell INCLUDING tombstones/deleted/expired-TTL rows, so it CANNOT
+  catch a read-time-reconciliation bug (both sides keep the shadowed rows → green while a real
+  `SELECT` diverges). *Query-semantics parity* (`test-data/query-semantics-oracle.json`, gate
+  component `query-semantics-oracle`, test `query_semantics_oracle_parity.rs`) records the
+  post-reconciliation result set of a canonical `SELECT` at a PINNED `now` (never wall-clock). Add
+  the correct oracle for the property under test; correctness of `SELECT` output needs the semantic one.
 
 ### Fuzzing (issue #1614)
 `fuzz/` is a cargo-fuzz/libFuzzer crate in its own workspace, excluded from the main one — the gate

--- a/cqlite-core/tests/query_semantics_oracle_parity.rs
+++ b/cqlite-core/tests/query_semantics_oracle_parity.rs
@@ -1,0 +1,351 @@
+//! Issue #1742: the QUERY-SEMANTICS parity oracle.
+//!
+//! A parity lane DISTINCT from the physical sstabledump JSONL goldens. The
+//! physical goldens (`*-Data.db.jsonl`) enumerate every on-disk cell — including
+//! tombstones, deleted rows, and expired-but-uncompacted TTL cells — so a
+//! row-count/value comparison against them structurally CANNOT catch a
+//! read-time-reconciliation bug: when CQLite fails to reconcile, both sides
+//! still contain the shadowed/expired rows and parity passes while a real
+//! Cassandra `SELECT` diverges. That is exactly the P0 (#1741) this oracle guards
+//! against regressing.
+//!
+//! This test compares CQLite `SELECT` output to the POST-RECONCILIATION result
+//! set a real Cassandra returns, recorded per-fixture in
+//! `test-data/query-semantics-oracle.json`. TTL expiry is evaluated at a PINNED
+//! `now` (per case) via the debug-only `CQLITE_TTL_NOW_OVERRIDE_SECS` reader seam,
+//! so it is deterministic and never wall-clock-flaky.
+//!
+//! Anti-empty-pass / SKIP contract:
+//!   * Each case carries a non-empty `expected_rows`, so a 0-row (unreconciled-or-
+//!     broken) result FAILS loudly — it can never green-pass empty.
+//!   * `physical_row_count` is re-derived from the committed golden JSONL and
+//!     asserted, proving the fixture's rows are physically present on disk.
+//!   * When the committed fixture (or its `*.db` binaries) is absent, the case
+//!     SKIPs cleanly — UNLESS `CQLITE_REQUIRE_FIXTURES=1` (the agent-gate
+//!     component sets it), in which case an absent/empty fixture is a hard FAIL
+//!     (fail-closed) so the gate lane can never green-pass without running.
+//!
+//! Cases run sequentially inside ONE async test so the process-global TTL-now env
+//! seam is never mutated concurrently by a sibling test in this binary.
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::types::Value;
+use cqlite_core::Database;
+use serde::Deserialize;
+
+/// Debug-only reader seam (see `now_clock.rs`): pins the read-time TTL "now"
+/// clock (epoch seconds) so a long-expired fixture is read deterministically
+/// "as of" the oracle's pinned evaluation time.
+const TTL_NOW_OVERRIDE_ENV: &str = "CQLITE_TTL_NOW_OVERRIDE_SECS";
+
+/// Fail-closed switch: when set, an absent/empty committed fixture is a hard
+/// failure instead of a clean skip (the agent-gate `query-semantics-oracle`
+/// component sets it, matching `compaction-byte-parity`).
+fn require_fixtures() -> bool {
+    std::env::var("CQLITE_REQUIRE_FIXTURES")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Oracle model (test-data/query-semantics-oracle.json)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct Oracle {
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    id: String,
+    keyspace: String,
+    #[allow(dead_code)]
+    table: String,
+    fixture_dir_prefix: String,
+    sstable_prefix: String,
+    schema: String,
+    query: String,
+    pinned_now_secs: i64,
+    physical_row_count: usize,
+    /// Ordered map per row so JSON author-order is preserved for readable diffs.
+    expected_rows: Vec<serde_json::Map<String, serde_json::Value>>,
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+/// Repo root = the parent of this crate's manifest dir (`<repo>/cqlite-core`).
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cqlite-core has a parent repo dir")
+        .to_path_buf()
+}
+
+/// The `sstables/` root. Prefer `CQLITE_DATASETS_ROOT` when it actually holds the
+/// committed keyspace; otherwise fall back to the in-repo committed corpus (these
+/// fixtures are committed, not gitignored, so the repo copy is always present).
+fn sstables_root(keyspace: &str) -> Option<PathBuf> {
+    let candidates = [
+        std::env::var("CQLITE_DATASETS_ROOT")
+            .ok()
+            .map(|r| PathBuf::from(r).join("sstables")),
+        Some(repo_root().join("test-data").join("datasets").join("sstables")),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|root| root.join(keyspace).is_dir())
+}
+
+fn schema_path(file: &str) -> Option<PathBuf> {
+    let candidates = [
+        std::env::var("CQLITE_DATASETS_ROOT")
+            .ok()
+            .and_then(|r| PathBuf::from(r).parent().map(|p| p.join("schemas").join(file))),
+        Some(repo_root().join("test-data").join("schemas").join(file)),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|p| p.exists())
+}
+
+fn fixture_dir(sstables_root: &Path, keyspace: &str, prefix: &str) -> Option<PathBuf> {
+    let ks_dir = sstables_root.join(keyspace);
+    std::fs::read_dir(&ks_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(prefix))
+                    .unwrap_or(false)
+        })
+}
+
+/// Count `type == "row"` entries in the committed sstabledump JSONL golden
+/// (anti-empty-pass: proves the physical rows are really on disk).
+fn golden_row_count(dir: &Path, sstable_prefix: &str) -> Option<usize> {
+    let jsonl = dir.join(format!("{sstable_prefix}-Data.db.jsonl"));
+    let text = std::fs::read_to_string(&jsonl).ok()?;
+    let mut total = 0usize;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line).ok()?;
+        if let Some(rows) = v.get("rows").and_then(|r| r.as_array()) {
+            total += rows
+                .iter()
+                .filter(|r| r.get("type").and_then(|t| t.as_str()) == Some("row"))
+                .count();
+        }
+    }
+    Some(total)
+}
+
+// ---------------------------------------------------------------------------
+// Value normalization (authoritative, never a byte-pattern guess)
+// ---------------------------------------------------------------------------
+
+/// Map a decoded scalar `Value` to plain JSON so it compares directly against the
+/// oracle's authored scalars. Unsupported types are a hard error (never silently
+/// mis-compared) — the oracle only uses int/text today; extend explicitly.
+fn value_to_json(v: &Value) -> Result<serde_json::Value, String> {
+    use serde_json::json;
+    Ok(match v {
+        Value::Null => serde_json::Value::Null,
+        Value::Boolean(b) => json!(b),
+        Value::Integer(i) => json!(i),
+        Value::BigInt(i) | Value::Counter(i) => json!(i),
+        Value::SmallInt(i) => json!(i),
+        Value::TinyInt(i) => json!(i),
+        Value::Float(f) => json!(f),
+        Value::Text(s) => json!(s),
+        other => return Err(format!("unsupported oracle scalar {other:?}")),
+    })
+}
+
+async fn open_db(sstables_dir: &Path, schema: &Path, keyspace: &str) -> Result<Database, String> {
+    let cfg = IngestionConfig {
+        schema_paths: vec![schema.to_path_buf()],
+        data_dir: sstables_dir.to_path_buf(),
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    };
+    let result = ingest(cfg).await.map_err(|e| format!("ingestion: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".into());
+    }
+    Ok(result.database)
+}
+
+/// Normalize a result set into a sorted, comparable form (row order is not
+/// asserted; the oracle compares as a multiset keyed by the projected columns).
+fn normalize(rows: Vec<serde_json::Map<String, serde_json::Value>>) -> Vec<String> {
+    let mut out: Vec<String> = rows
+        .into_iter()
+        .map(|m| {
+            let sorted: BTreeMap<_, _> = m.into_iter().collect();
+            serde_json::to_string(&sorted).unwrap_or_default()
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// One case: returns Ok(true) if it ran a comparison, Ok(false) if it SKIPped.
+async fn run_case(case: &Case) -> Result<bool, String> {
+    let Some(root) = sstables_root(&case.keyspace) else {
+        let msg = format!("case {}: keyspace {} absent", case.id, case.keyspace);
+        if require_fixtures() {
+            return Err(format!("REQUIRE_FIXTURES: {msg}"));
+        }
+        eprintln!("SKIP {msg}");
+        return Ok(false);
+    };
+    let Some(dir) = fixture_dir(&root, &case.keyspace, &case.fixture_dir_prefix) else {
+        let msg = format!("case {}: fixture dir {}* absent", case.id, case.fixture_dir_prefix);
+        if require_fixtures() {
+            return Err(format!("REQUIRE_FIXTURES: {msg}"));
+        }
+        eprintln!("SKIP {msg}");
+        return Ok(false);
+    };
+    let data_db = dir.join(format!("{}-Data.db", case.sstable_prefix));
+    if !data_db.exists() {
+        let msg = format!("case {}: {} not fetched", case.id, data_db.display());
+        if require_fixtures() {
+            return Err(format!("REQUIRE_FIXTURES: {msg}"));
+        }
+        eprintln!("SKIP {msg}");
+        return Ok(false);
+    }
+    let Some(schema) = schema_path(&case.schema) else {
+        let msg = format!("case {}: schema {} absent", case.id, case.schema);
+        if require_fixtures() {
+            return Err(format!("REQUIRE_FIXTURES: {msg}"));
+        }
+        eprintln!("SKIP {msg}");
+        return Ok(false);
+    };
+
+    // Anti-empty-pass: the physical rows really exist on disk, and the oracle's
+    // declared physical count matches the committed golden.
+    let golden = golden_row_count(&dir, &case.sstable_prefix)
+        .ok_or_else(|| format!("case {}: golden JSONL missing/unreadable", case.id))?;
+    if golden != case.physical_row_count {
+        return Err(format!(
+            "case {}: golden physical row count {golden} != oracle physical_row_count {}",
+            case.id, case.physical_row_count
+        ));
+    }
+    // The oracle never asserts fewer physical rows than the semantic result —
+    // a shadowing/expiry oracle only ever HIDES rows a physical dump shows.
+    if golden < case.expected_rows.len() {
+        return Err(format!(
+            "case {}: physical rows {golden} < expected semantic rows {}",
+            case.id,
+            case.expected_rows.len()
+        ));
+    }
+
+    // Pin the read-time TTL clock for this case (removed after execute, before the
+    // next case, so no case leaks its pin — single-threaded within this test).
+    // Ingest points at the whole `sstables/` root, filtered to the keyspace.
+    std::env::set_var(TTL_NOW_OVERRIDE_ENV, case.pinned_now_secs.to_string());
+    let db = match open_db(&root, &schema, &case.keyspace).await {
+        Ok(db) => db,
+        Err(e) => {
+            std::env::remove_var(TTL_NOW_OVERRIDE_ENV);
+            return Err(format!("case {}: {e}", case.id));
+        }
+    };
+
+    let exec = db.execute(&case.query).await;
+    std::env::remove_var(TTL_NOW_OVERRIDE_ENV);
+    let result = exec.map_err(|e| format!("case {}: SELECT failed: {e}", case.id))?;
+
+    // Project each result row to the oracle's declared columns.
+    let cols: Vec<String> = case
+        .expected_rows
+        .first()
+        .map(|r| r.keys().cloned().collect())
+        .unwrap_or_default();
+    let mut actual: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
+    for row in &result.rows {
+        let mut m = serde_json::Map::new();
+        for col in &cols {
+            let v = row
+                .values
+                .get(col.as_str())
+                .ok_or_else(|| format!("case {}: result row missing column {col}", case.id))?;
+            m.insert(col.clone(), value_to_json(v).map_err(|e| format!("case {}: {e}", case.id))?);
+        }
+        actual.push(m);
+    }
+
+    let expected = normalize(case.expected_rows.clone());
+    let got = normalize(actual);
+    if expected != got {
+        return Err(format!(
+            "case {} ({}): query-semantics MISMATCH\n  query: {}\n  pinned_now_secs: {}\n  physical rows on disk: {golden}\n  expected ({} rows): {:#?}\n  got      ({} rows): {:#?}",
+            case.id,
+            case.keyspace,
+            case.query,
+            case.pinned_now_secs,
+            expected.len(),
+            expected,
+            got.len(),
+            got,
+        ));
+    }
+    eprintln!(
+        "PASS case {} — semantic {} rows (physical dump had {golden}); reconciliation applied",
+        case.id,
+        got.len()
+    );
+    Ok(true)
+}
+
+#[tokio::test]
+async fn query_semantics_oracle_matches_cassandra_select() {
+    let oracle_path = repo_root().join("test-data").join("query-semantics-oracle.json");
+    let text = std::fs::read_to_string(&oracle_path)
+        .unwrap_or_else(|e| panic!("read oracle {}: {e}", oracle_path.display()));
+    let oracle: Oracle = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("parse oracle {}: {e}", oracle_path.display()));
+    assert!(!oracle.cases.is_empty(), "oracle must define at least one case");
+
+    let mut ran = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    for case in &oracle.cases {
+        match run_case(case).await {
+            Ok(true) => ran += 1,
+            Ok(false) => {}
+            Err(e) => failures.push(e),
+        }
+    }
+
+    assert!(failures.is_empty(), "query-semantics oracle failures:\n{}", failures.join("\n\n"));
+
+    if require_fixtures() {
+        assert!(
+            ran > 0,
+            "CQLITE_REQUIRE_FIXTURES=1 but no oracle case ran (fixtures absent) — fail-closed"
+        );
+    } else if ran == 0 {
+        eprintln!("SKIP query_semantics_oracle: no fixtures present (set CQLITE_REQUIRE_FIXTURES=1 to fail-close)");
+    }
+}

--- a/cqlite-core/tests/query_semantics_oracle_parity.rs
+++ b/cqlite-core/tests/query_semantics_oracle_parity.rs
@@ -16,8 +16,14 @@
 //! so it is deterministic and never wall-clock-flaky.
 //!
 //! Anti-empty-pass / SKIP contract:
-//!   * Each case carries a non-empty `expected_rows`, so a 0-row (unreconciled-or-
-//!     broken) result FAILS loudly — it can never green-pass empty.
+//!   * Each case carries a non-empty `expected_rows`, OR explicitly opts into a
+//!     legitimate zero-row outcome via `expect_empty: true` (e.g. "every row was
+//!     shadowed"). A case with empty `expected_rows` and no `expect_empty` opt-in
+//!     is a hard FAIL — it is never allowed to silently collapse the compared
+//!     column set to `[]` and pass vacuously regardless of what the reader
+//!     returns. `expect_empty: true` additionally requires `physical_row_count >
+//!     0`, proving rows really existed on disk and were reconciled away rather
+//!     than an empty/misconfigured fixture masquerading as "reconciled to zero".
 //!   * `physical_row_count` is re-derived from the committed golden JSONL and
 //!     asserted, proving the fixture's rows are physically present on disk.
 //!   * When the committed fixture (or its `*.db` binaries) is absent, the case
@@ -74,6 +80,13 @@ struct Case {
     physical_row_count: usize,
     /// Ordered map per row so JSON author-order is preserved for readable diffs.
     expected_rows: Vec<serde_json::Map<String, serde_json::Value>>,
+    /// Explicit opt-in for a case whose correct semantic result is ZERO rows
+    /// (e.g. every physical row was shadowed/expired). Required whenever
+    /// `expected_rows` is empty — see the module doc's anti-empty-pass contract.
+    /// Defaults to `false` so an author who forgets to fill in `expected_rows`
+    /// gets a loud failure, never a silent vacuous pass.
+    #[serde(default)]
+    expect_empty: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -211,6 +224,30 @@ fn normalize(rows: Vec<serde_json::Map<String, serde_json::Value>>) -> Vec<Strin
 
 /// One case: returns Ok(true) if it ran a comparison, Ok(false) if it SKIPped.
 async fn run_case(case: &Case) -> Result<bool, String> {
+    // Anti-empty-pass config validation (independent of fixture presence): an
+    // empty `expected_rows` must be an explicit, provable opt-in — never an
+    // accident that silently collapses the compared column set to `[]` and
+    // passes vacuously regardless of what the reader returns.
+    if case.expected_rows.is_empty() {
+        if !case.expect_empty {
+            return Err(format!(
+                "case {}: expected_rows is empty but expect_empty is not set — a \
+                 case expecting zero semantic rows must opt in explicitly via \
+                 expect_empty: true (an unopted-in empty expected_rows would \
+                 silently pass vacuously regardless of what the reader returns)",
+                case.id
+            ));
+        }
+        if case.physical_row_count == 0 {
+            return Err(format!(
+                "case {}: expect_empty is set but physical_row_count is 0 — \
+                 expect_empty must prove rows existed on disk and were \
+                 reconciled away, not just an empty/misconfigured fixture",
+                case.id
+            ));
+        }
+    }
+
     let Some(root) = sstables_root(&case.keyspace) else {
         let msg = format!("case {}: keyspace {} absent", case.id, case.keyspace);
         if require_fixtures() {
@@ -327,6 +364,64 @@ async fn run_case(case: &Case) -> Result<bool, String> {
         got.len()
     );
     Ok(true)
+}
+
+/// A synthetic `Case` for the guard-enforcement tests below. Uses placeholder
+/// paths/queries that are never reached — `run_case` must reject these cases
+/// during the config-validation check at the top, before any fixture I/O.
+fn synthetic_case(
+    id: &str,
+    expected_rows_len_zero: bool,
+    expect_empty: bool,
+    physical_row_count: usize,
+) -> Case {
+    Case {
+        id: id.to_string(),
+        keyspace: "does_not_matter".to_string(),
+        table: "does_not_matter".to_string(),
+        fixture_dir_prefix: "does_not_matter".to_string(),
+        sstable_prefix: "does_not_matter".to_string(),
+        schema: "does_not_matter.cql".to_string(),
+        query: "SELECT 1".to_string(),
+        pinned_now_secs: 0,
+        physical_row_count,
+        expected_rows: if expected_rows_len_zero {
+            Vec::new()
+        } else {
+            vec![serde_json::Map::new()]
+        },
+        expect_empty,
+    }
+}
+
+/// Issue #1742 review finding: an empty `expected_rows` without the explicit
+/// `expect_empty` opt-in must FAIL LOUDLY, never silently collapse the compared
+/// column set to `[]` and pass vacuously.
+#[tokio::test]
+async fn empty_expected_rows_without_opt_in_fails_loudly() {
+    let case = synthetic_case("synthetic_empty_no_optin", true, false, 5);
+    let err = run_case(&case).await.expect_err(
+        "an empty expected_rows without expect_empty must fail loudly, not vacuously pass",
+    );
+    assert!(
+        err.contains("expect_empty"),
+        "error must name the missing opt-in, got: {err}"
+    );
+}
+
+/// `expect_empty: true` still requires proof that physical rows existed and
+/// were reconciled away — `physical_row_count == 0` is an empty/misconfigured
+/// fixture, not a legitimate "reconciled to zero" case.
+#[tokio::test]
+async fn expect_empty_requires_nonzero_physical_row_count() {
+    let case = synthetic_case("synthetic_empty_zero_physical", true, true, 0);
+    let err = run_case(&case)
+        .await
+        .expect_err("expect_empty with physical_row_count == 0 must fail loudly");
+    assert!(
+        err.contains("physical_row_count"),
+        "error must name the missing proof, got: {err}"
+    );
 }
 
 #[tokio::test]

--- a/cqlite-core/tests/query_semantics_oracle_parity.rs
+++ b/cqlite-core/tests/query_semantics_oracle_parity.rs
@@ -96,7 +96,12 @@ fn sstables_root(keyspace: &str) -> Option<PathBuf> {
         std::env::var("CQLITE_DATASETS_ROOT")
             .ok()
             .map(|r| PathBuf::from(r).join("sstables")),
-        Some(repo_root().join("test-data").join("datasets").join("sstables")),
+        Some(
+            repo_root()
+                .join("test-data")
+                .join("datasets")
+                .join("sstables"),
+        ),
     ];
     candidates
         .into_iter()
@@ -106,15 +111,14 @@ fn sstables_root(keyspace: &str) -> Option<PathBuf> {
 
 fn schema_path(file: &str) -> Option<PathBuf> {
     let candidates = [
-        std::env::var("CQLITE_DATASETS_ROOT")
-            .ok()
-            .and_then(|r| PathBuf::from(r).parent().map(|p| p.join("schemas").join(file))),
+        std::env::var("CQLITE_DATASETS_ROOT").ok().and_then(|r| {
+            PathBuf::from(r)
+                .parent()
+                .map(|p| p.join("schemas").join(file))
+        }),
         Some(repo_root().join("test-data").join("schemas").join(file)),
     ];
-    candidates
-        .into_iter()
-        .flatten()
-        .find(|p| p.exists())
+    candidates.into_iter().flatten().find(|p| p.exists())
 }
 
 fn fixture_dir(sstables_root: &Path, keyspace: &str, prefix: &str) -> Option<PathBuf> {
@@ -216,7 +220,10 @@ async fn run_case(case: &Case) -> Result<bool, String> {
         return Ok(false);
     };
     let Some(dir) = fixture_dir(&root, &case.keyspace, &case.fixture_dir_prefix) else {
-        let msg = format!("case {}: fixture dir {}* absent", case.id, case.fixture_dir_prefix);
+        let msg = format!(
+            "case {}: fixture dir {}* absent",
+            case.id, case.fixture_dir_prefix
+        );
         if require_fixtures() {
             return Err(format!("REQUIRE_FIXTURES: {msg}"));
         }
@@ -291,7 +298,10 @@ async fn run_case(case: &Case) -> Result<bool, String> {
                 .values
                 .get(col.as_str())
                 .ok_or_else(|| format!("case {}: result row missing column {col}", case.id))?;
-            m.insert(col.clone(), value_to_json(v).map_err(|e| format!("case {}: {e}", case.id))?);
+            m.insert(
+                col.clone(),
+                value_to_json(v).map_err(|e| format!("case {}: {e}", case.id))?,
+            );
         }
         actual.push(m);
     }
@@ -321,12 +331,17 @@ async fn run_case(case: &Case) -> Result<bool, String> {
 
 #[tokio::test]
 async fn query_semantics_oracle_matches_cassandra_select() {
-    let oracle_path = repo_root().join("test-data").join("query-semantics-oracle.json");
+    let oracle_path = repo_root()
+        .join("test-data")
+        .join("query-semantics-oracle.json");
     let text = std::fs::read_to_string(&oracle_path)
         .unwrap_or_else(|e| panic!("read oracle {}: {e}", oracle_path.display()));
     let oracle: Oracle = serde_json::from_str(&text)
         .unwrap_or_else(|e| panic!("parse oracle {}: {e}", oracle_path.display()));
-    assert!(!oracle.cases.is_empty(), "oracle must define at least one case");
+    assert!(
+        !oracle.cases.is_empty(),
+        "oracle must define at least one case"
+    );
 
     let mut ran = 0usize;
     let mut failures: Vec<String> = Vec::new();
@@ -338,7 +353,11 @@ async fn query_semantics_oracle_matches_cassandra_select() {
         }
     }
 
-    assert!(failures.is_empty(), "query-semantics oracle failures:\n{}", failures.join("\n\n"));
+    assert!(
+        failures.is_empty(),
+        "query-semantics oracle failures:\n{}",
+        failures.join("\n\n")
+    );
 
     if require_fixtures() {
         assert!(

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1024,7 +1024,7 @@ _python_build_verify_venv() {
   return 3
 }
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
 # --lite (issue #1821) runs ONLY this fast subset: file-size ratchet, fmt,
 # FULL-workspace clippy (cross-crate API breaks are the cheap-insurance class),
 # and blast-radius-scoped tests (the touched package's --lib + the diff's new
@@ -1700,6 +1700,54 @@ run_compaction_byte_parity() {
       env CQLITE_DATASETS_ROOT="'"$CQLITE_DATASETS_ROOT"'" \
         cargo test -p cqlite-core --features write-support \
           --test issue_1019_static_dropped_collection_compaction_parity' >"$log" 2>&1; then
+    status=PASS
+  else
+    status=FAIL
+    echo "--- [$name] FAILED; last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+  fi
+  end=$(date +%s)
+  record_result "$name" "$status" "$((end - start))"
+  echo ">>> [$name] $status ($((end - start))s)"
+}
+
+# query-semantics-oracle: the QUERY-SEMANTICS parity lane (issue #1742), DISTINCT
+# from the physical sstabledump JSONL goldens. The physical goldens enumerate every
+# on-disk cell (tombstones, deleted rows, expired-but-uncompacted TTL cells), so a
+# row-count/value comparison against them structurally CANNOT catch a read-time-
+# reconciliation regression: when the reader fails to reconcile, both sides still
+# contain the shadowed/expired rows and parity passes while a real Cassandra SELECT
+# diverges (the #1741 read-path P0). This lane instead compares CQLite SELECT output
+# to the POST-RECONCILIATION result set recorded in test-data/query-semantics-oracle.json,
+# evaluating TTL at a PINNED `now` per case (deterministic, never wall-clock-flaky).
+#
+# Fixture policy: the three real Cassandra 5.0.2 fixtures it reads
+# (test_compaction_tombstone_ttl/{ttl_expired_live,shadow_row_delete,rt_cross_gen})
+# are COMMITTED to git, so the lane runs fail-closed (CQLITE_REQUIRE_FIXTURES=1): an
+# absent/present-but-0-row fixture is a hard FAIL, never a silent skip. The whole
+# component SKIPs (loud, never silent PASS) only when CQLITE_DATASETS_ROOT is unset or
+# the committed keyspace is absent (a minimal checkout). NOT in DATASET_COMPONENTS: it
+# is self-guarding, so it must not trip the hard dataset preflight.
+run_query_semantics_oracle() {
+  local name=query-semantics-oracle
+  if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
+    return 0
+  fi
+  local log="$LOG_DIR/$name.log"
+  local start end status
+  start=$(date +%s)
+  local committed_ks="${CQLITE_DATASETS_ROOT:-}/sstables/test_compaction_tombstone_ttl"
+  if [ -z "${CQLITE_DATASETS_ROOT:-}" ] || [ ! -d "$committed_ks" ]; then
+    status=SKIP
+    echo ">>> [$name] SKIP (CQLITE_DATASETS_ROOT unset or committed test_compaction_tombstone_ttl fixtures absent)"
+    record_result "$name" "$status" 0
+    return 0
+  fi
+  echo ">>> [$name] query-semantics parity oracle vs Cassandra SELECT (#1742)"
+  if env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+      cargo test -p cqlite-core --features "state_machine cli-helpers" \
+        --test query_semantics_oracle_parity >"$log" 2>&1; then
     status=PASS
   else
     status=FAIL
@@ -3282,6 +3330,7 @@ dispatch_component() {
   [ "$rc" -eq 0 ] || exit "$rc"
   check_no_unexpected_zero_tests "Pass 2 (write-support)" "$log2"' ;;
     compaction-byte-parity) run_compaction_byte_parity ;;
+    query-semantics-oracle) run_query_semantics_oracle ;;
     python-bindings) run_python_bindings ;;
     node-bindings) run_node_bindings ;;
     delivery-telemetry) run_delivery_telemetry ;;

--- a/test-data/query-semantics-oracle.json
+++ b/test-data/query-semantics-oracle.json
@@ -1,0 +1,103 @@
+{
+  "doc": [
+    "Query-semantics parity oracle (issue #1742).",
+    "",
+    "This file is a DIFFERENT oracle from the physical sstabledump JSONL goldens",
+    "(`*-Data.db.jsonl`). The physical goldens enumerate every on-disk cell —",
+    "INCLUDING tombstones, deleted rows, and expired-but-uncompacted TTL cells.",
+    "Row-count/value parity against a physical dump therefore CANNOT catch a",
+    "read-time-reconciliation bug: when CQLite fails to reconcile, both sides still",
+    "contain the shadowed/expired rows and parity passes while a real Cassandra",
+    "SELECT diverges (issue #1741, the read-path P0 this oracle guards against",
+    "regressing).",
+    "",
+    "Each case below records the POST-RECONCILIATION result set a real Cassandra",
+    "`SELECT` returns for a canonical query, evaluated at a PINNED `now`",
+    "(`pinned_now_secs`, epoch seconds) so TTL expiry is deterministic and never",
+    "wall-clock-flaky. The reader honors the pin via the debug-only",
+    "`CQLITE_TTL_NOW_OVERRIDE_SECS` seam (see `now_clock.rs`).",
+    "",
+    "`physical_row_count` is the count of `type == \"row\"` entries in the committed",
+    "sstabledump golden — an anti-empty-pass sanity check AND (where it exceeds",
+    "`expected_rows.len()`) a direct demonstration of the physical-vs-semantic gap",
+    "this oracle exists to close.",
+    "",
+    "Consumed by cqlite-core/tests/query_semantics_oracle_parity.rs."
+  ],
+  "oracle_version": 1,
+  "provenance": {
+    "cassandra_version": "5.0.2",
+    "cassandra_git_sha": "f278f6774fc76465c182041e081982105c3e7dbb",
+    "fixture_generation_command": "bash test-data/scripts/generate-compaction-tombstone-ttl-parity.sh",
+    "note": [
+      "All three fixtures below are REAL Apache Cassandra 5.0.2 SSTables committed",
+      "to the repo (test-data/datasets/sstables/test_compaction_tombstone_ttl/**),",
+      "with provenance already tracked in test-data/cassandra-parity-manifest.yml",
+      "(scenarios cass.compaction.*shadow_row_delete / *ttl_expired_live /",
+      "*rt_cross_gen). They are post-major-compaction (nb-3-big) fixtures and still",
+      "present the physical-vs-semantic divergence (a physical dump enumerates the",
+      "surviving row/RT/expired markers that a SELECT hides).",
+      "",
+      "GAP (issue #1742 AC2): a dedicated SINGLE-generation (pre-compaction) fixture",
+      "carrying coexisting partition-deletion + older LIVE rows, a range tombstone",
+      "with a LIVE row INSIDE its bounds, and an expired TTL cell whose VALUE is",
+      "still on disk requires generating uncompacted SSTables from a live Cassandra",
+      "container (autocompaction disabled, single flush). Docker/Cassandra was not",
+      "available in the implementing sandbox, so no such fixture is added here.",
+      "Tracked for real-Cassandra regeneration in the issue #1742 follow-up."
+    ]
+  },
+  "cases": [
+    {
+      "id": "ttl_expired_live__select_star",
+      "keyspace": "test_compaction_tombstone_ttl",
+      "table": "ttl_expired_live",
+      "fixture_dir_prefix": "ttl_expired_live-",
+      "sstable_prefix": "nb-3-big",
+      "schema": "compaction-tombstone-ttl-parity.cql",
+      "query": "SELECT id, ck, v FROM test_compaction_tombstone_ttl.ttl_expired_live",
+      "reconciliation": ["ttl_expiry"],
+      "pinned_now_secs": 1782950400,
+      "pinned_now_note": "2026-07-01T23:56:40Z — AFTER row ck=1's TTL expiry (expires_at 2026-07-01T23:54:23Z, epoch 1782950063); row ck=2 has no TTL so it stays live at any now.",
+      "physical_row_count": 2,
+      "expected_rows": [
+        { "id": 1, "ck": 2, "v": "b-1-2" }
+      ]
+    },
+    {
+      "id": "shadow_row_delete__select_star",
+      "keyspace": "test_compaction_tombstone_ttl",
+      "table": "shadow_row_delete",
+      "fixture_dir_prefix": "shadow_row_delete-",
+      "sstable_prefix": "nb-3-big",
+      "schema": "compaction-tombstone-ttl-parity.cql",
+      "query": "SELECT id, ck, v FROM test_compaction_tombstone_ttl.shadow_row_delete",
+      "reconciliation": ["row_deletion"],
+      "pinned_now_secs": 1782950400,
+      "pinned_now_note": "No TTL in this fixture; pin is fixed for determinism only. Row (id=1, ck=1) is a ROW tombstone (no live cells) and must be hidden.",
+      "physical_row_count": 4,
+      "expected_rows": [
+        { "id": 1, "ck": 2, "v": "a-1-2" },
+        { "id": 1, "ck": 3, "v": "b-1-3" },
+        { "id": 2, "ck": 0, "v": "a-2-0" }
+      ]
+    },
+    {
+      "id": "rt_cross_gen__select_star",
+      "keyspace": "test_compaction_tombstone_ttl",
+      "table": "rt_cross_gen",
+      "fixture_dir_prefix": "rt_cross_gen-",
+      "sstable_prefix": "nb-3-big",
+      "schema": "compaction-tombstone-ttl-parity.cql",
+      "query": "SELECT id, ck, v FROM test_compaction_tombstone_ttl.rt_cross_gen",
+      "reconciliation": ["range_tombstone"],
+      "pinned_now_secs": 1782950400,
+      "pinned_now_note": "No TTL; pin fixed for determinism. A range tombstone covers clustering [10,25]; the live rows sit at ck=5 and ck=30 (OUTSIDE the RT), so both survive — this pins that the RT open/close markers are skipped and do not wrongly shadow rows outside their bounds. A LIVE-row-INSIDE-RT case needs the single-gen fixture noted in provenance.gap.",
+      "physical_row_count": 2,
+      "expected_rows": [
+        { "id": 1, "ck": 5, "v": "a-1-5" },
+        { "id": 1, "ck": 30, "v": "b-1-30" }
+      ]
+    }
+  ]
+}

--- a/website/src/content/docs/agents-developing/validation-playbook.md
+++ b/website/src/content/docs/agents-developing/validation-playbook.md
@@ -11,6 +11,48 @@ Cassandra tool that produces authoritative JSON from SSTable files. Golden JSONL
 are committed alongside the binary SSTables so CI can run parity checks without a live
 Cassandra cluster.
 
+## Two oracles: physical-dump parity vs query-semantics parity
+
+There are **two independent parity oracles**, and they answer different questions.
+Confusing them hides read-time-reconciliation bugs (issue #1741/#1742):
+
+| | **Physical-dump parity** | **Query-semantics parity** |
+|---|---|---|
+| Oracle | `*-Data.db.jsonl` (sstabledump `-l`) | `test-data/query-semantics-oracle.json` |
+| What it captures | Every cell **physically on disk** — *including* tombstones, deleted rows, and expired-but-uncompacted TTL cells | The **post-reconciliation result set** a real Cassandra `SELECT` returns |
+| Question answered | "Did CQLite parse the bytes the same as Cassandra wrote them?" | "Does a CQLite `SELECT` return what a Cassandra `SELECT` returns?" |
+| TTL / tombstone rows | Present (enumerated) | Absent (shadowed / expired away) |
+| Test lane | the seven `golden_path_*` integration tests, Python/Node parity | `cqlite-core/tests/query_semantics_oracle_parity.rs` (gate component `query-semantics-oracle`) |
+
+**Why both are needed.** A physical dump enumerates shadowed/expired rows, so a
+row-count/value comparison against it **structurally cannot catch a read-time
+reconciliation bug**: when CQLite fails to apply partition deletions, range
+tombstones, or TTL expiry, *both* sides still contain those rows and physical parity
+passes green — while a real `SELECT` diverges. `test_basic.ttl_test_table`'s golden
+holds all 100 expired rows; CQLite returned all 100; physical parity was green; a real
+Cassandra `SELECT` returns 0. That gap is exactly what the query-semantics oracle
+closes.
+
+The query-semantics oracle records, per fixture, the canonical `SELECT` and its
+expected result set evaluated at a **pinned `now`** (`pinned_now_secs`, epoch seconds)
+so TTL expiry is deterministic — never wall-clock-flaky. The reader honors the pin via
+the debug-only `CQLITE_TTL_NOW_OVERRIDE_SECS` seam (`now_clock.rs`). Each case carries a
+non-empty `expected_rows` and re-asserts the committed golden's physical row count, so a
+0-row or unreconciled result fails loudly (anti-empty-pass) and the divergence
+(physical count > semantic count) is visible in the test output.
+
+Run it directly:
+
+```bash
+env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+  cargo test -p cqlite-core --features "state_machine cli-helpers" \
+  --test query_semantics_oracle_parity -- --nocapture
+```
+
+`CQLITE_REQUIRE_FIXTURES=1` (which the gate component sets) makes an absent/empty
+fixture a **hard failure**; without it, a minimal checkout that lacks the committed
+`test_compaction_tombstone_ttl` fixtures SKIPs loudly.
+
 ## Golden JSONL files
 
 Every Data.db in the dataset has a companion `.jsonl` file containing


### PR DESCRIPTION
Closes #1742

## Problem
Parity goldens are physical sstabledump dumps that enumerate on-disk cells including tombstones/expired/shadowed rows. Row-count/value parity against these goldens is blind to read-time reconciliation bugs (both sides include shadowed data, so parity stays green even when CQLite fails to apply TTL/partition-deletion/RT visibility).

## Fix
- `test-data/query-semantics-oracle.json` — new oracle distinct from physical goldens: per-fixture canonical SELECT + expected **post-reconciliation** result set + a pinned `now` (deterministic TTL evaluation, no wall-clock).
- `cqlite-core/tests/query_semantics_oracle_parity.rs` — the comparison lane, with an enforced (not just documented) anti-empty-pass guard: a case must have non-empty `expected_rows` OR opt in via `expect_empty: true` (which additionally requires `physical_row_count > 0`, proving real rows existed and were reconciled away, not a misconfigured fixture).
- `scripts/agent-gate.sh` — new `query-semantics-oracle` SKIP-aware, fail-closed gate component (modeled on `compaction-byte-parity`).
- Docs — validation-playbook + CLAUDE.md distinguish physical-dump vs query-semantics parity.

Demonstrates the gap it closes: physical dump 2/4/2 rows vs semantic SELECT 1/3/2 rows (TTL expiry / row-deletion / RT-skip).

## Real-Cassandra fixtures
No Docker on this machine — reuses 3 already-committed real Cassandra 5.0.2 fixtures (provenance already in `cassandra-parity-manifest.yml`). A dedicated single-generation coexisting-shadowed fixture (AC2's full ask) needs container regen — filed as follow-up **#2183**.

## Review
- `rust-reviewer`: one real finding (anti-empty-pass guard was convention-only) — **fixed**, with 2 new negative tests proving it now fails loudly. Two nits deferred to **#2184**.
- roborev: 2 rounds, both clean (only low-severity doc/consistency nits, both folded into #2184).

## Gate
LITE gate: PASS. Full gate + C (against issue ACs, no OpenSpec) + final roborev + merge-on-green run by `flow-closer`.