### PR TITLE
fix(#1917): multi-candidate concat fallbacks sort by Murmur3 token order, not raw bytes

### DIFF
--- a/cqlite-core/src/query/select_executor/lookup.rs
+++ b/cqlite-core/src/query/select_executor/lookup.rs
@@ -363,9 +363,7 @@ pub(super) fn classify_clustering_slice(
 /// rows arrive contiguously from a single `scan_partition` call.
 pub(super) fn sort_rows_by_token(rows: &mut [(RowKey, ScanRow)]) {
     rows.sort_by(|a, b| {
-        let ta = crate::util::cassandra_murmur3::cassandra_murmur3_token(&a.0 .0);
-        let tb = crate::util::cassandra_murmur3::cassandra_murmur3_token(&b.0 .0);
-        ta.cmp(&tb).then_with(|| a.0 .0.cmp(&b.0 .0))
+        crate::util::cassandra_murmur3::cmp_partition_keys_by_token(&a.0 .0, &b.0 .0)
     });
 }
 

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -91,6 +91,7 @@ use tokio::sync::{Mutex, RwLock};
 use self::tombstone_merger::{EntryMetadata, GenerationValue, TombstoneMerger};
 use crate::platform::Platform;
 use crate::types::CellWriteMetadata;
+use crate::util::cassandra_murmur3::cmp_partition_keys_by_token;
 use crate::{types::TableId, Config, Result, RowKey, ScanRow};
 
 /// Maximum directory depth when scanning for SSTable files.
@@ -1461,20 +1462,9 @@ impl SSTableManager {
             results.retain(matches_key);
             all_results.append(&mut results);
         }
-        // A single candidate's rows already come back in on-disk order, which IS
-        // Cassandra token-ring order, so leave it sort-free. Concatenating more than
-        // one candidate must re-merge into that same canonical global order: Murmur3
-        // token first, raw key bytes as tiebreak (mod.rs:880-884 / #1580 flag raw-byte
-        // re-sorting as the WRONG global order). Route through the one shared
-        // comparator so this metadata path, the streaming k-way merge, and the IN
-        // fan-out (`sort_rows_by_token`) all return identical row order (#1917).
+        // #1917: concat sorts token-ring order via shared cmp (raw-byte = wrong order, #1580).
         if candidates.len() > 1 {
-            all_results.sort_by(|a, b| {
-                crate::util::cassandra_murmur3::cmp_partition_keys_by_token(
-                    a.0.as_bytes(),
-                    b.0.as_bytes(),
-                )
-            });
+            all_results.sort_by(|a, b| cmp_partition_keys_by_token(a.0.as_bytes(), b.0.as_bytes()));
         }
         work_counters::add_partitions_parsed(all_results.len() as u64);
         Ok((all_results, true))
@@ -1674,20 +1664,9 @@ impl SSTableManager {
             };
             all_results.append(&mut results);
         }
-        // A single candidate's rows already come back in on-disk order, which IS
-        // Cassandra token-ring order, so leave it sort-free. Concatenating more than
-        // one candidate must re-merge into that same canonical global order: Murmur3
-        // token first, raw key bytes as tiebreak (mod.rs:880-884 / #1580 flag raw-byte
-        // re-sorting as the WRONG global order). Route through the one shared
-        // comparator so this path, the streaming k-way merge, and the IN fan-out
-        // (`sort_rows_by_token`) all return identical row order (#1917).
+        // #1917: concat sorts token-ring order via shared cmp (raw-byte = wrong order, #1580).
         if candidates.len() > 1 {
-            all_results.sort_by(|a, b| {
-                crate::util::cassandra_murmur3::cmp_partition_keys_by_token(
-                    a.0.as_bytes(),
-                    b.0.as_bytes(),
-                )
-            });
+            all_results.sort_by(|a, b| cmp_partition_keys_by_token(a.0.as_bytes(), b.0.as_bytes()));
         }
         work_counters::add_partitions_parsed(all_results.len() as u64);
         Ok((all_results, clustering_engaged))

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -91,6 +91,7 @@ use tokio::sync::{Mutex, RwLock};
 use self::tombstone_merger::{EntryMetadata, GenerationValue, TombstoneMerger};
 use crate::platform::Platform;
 use crate::types::CellWriteMetadata;
+#[cfg(not(feature = "tombstones"))] // #1917 concat fallbacks; tombstones uses k-way merge
 use crate::util::cassandra_murmur3::cmp_partition_keys_by_token;
 use crate::{types::TableId, Config, Result, RowKey, ScanRow};
 

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1461,10 +1461,20 @@ impl SSTableManager {
             results.retain(matches_key);
             all_results.append(&mut results);
         }
-        // A single candidate's rows already come back in on-disk key order; only
-        // concatenating more than one candidate needs a re-sort to merge them.
+        // A single candidate's rows already come back in on-disk order, which IS
+        // Cassandra token-ring order, so leave it sort-free. Concatenating more than
+        // one candidate must re-merge into that same canonical global order: Murmur3
+        // token first, raw key bytes as tiebreak (mod.rs:880-884 / #1580 flag raw-byte
+        // re-sorting as the WRONG global order). Route through the one shared
+        // comparator so this metadata path, the streaming k-way merge, and the IN
+        // fan-out (`sort_rows_by_token`) all return identical row order (#1917).
         if candidates.len() > 1 {
-            all_results.sort_by(|a, b| a.0.cmp(&b.0));
+            all_results.sort_by(|a, b| {
+                crate::util::cassandra_murmur3::cmp_partition_keys_by_token(
+                    a.0.as_bytes(),
+                    b.0.as_bytes(),
+                )
+            });
         }
         work_counters::add_partitions_parsed(all_results.len() as u64);
         Ok((all_results, true))
@@ -1664,10 +1674,20 @@ impl SSTableManager {
             };
             all_results.append(&mut results);
         }
-        // A single candidate's rows already come back in on-disk key order; only
-        // concatenating more than one candidate needs a re-sort to merge them.
+        // A single candidate's rows already come back in on-disk order, which IS
+        // Cassandra token-ring order, so leave it sort-free. Concatenating more than
+        // one candidate must re-merge into that same canonical global order: Murmur3
+        // token first, raw key bytes as tiebreak (mod.rs:880-884 / #1580 flag raw-byte
+        // re-sorting as the WRONG global order). Route through the one shared
+        // comparator so this path, the streaming k-way merge, and the IN fan-out
+        // (`sort_rows_by_token`) all return identical row order (#1917).
         if candidates.len() > 1 {
-            all_results.sort_by(|a, b| a.0.cmp(&b.0));
+            all_results.sort_by(|a, b| {
+                crate::util::cassandra_murmur3::cmp_partition_keys_by_token(
+                    a.0.as_bytes(),
+                    b.0.as_bytes(),
+                )
+            });
         }
         work_counters::add_partitions_parsed(all_results.len() as u64);
         Ok((all_results, clustering_engaged))

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1463,7 +1463,7 @@ impl SSTableManager {
             results.retain(matches_key);
             all_results.append(&mut results);
         }
-        // #1917: concat sorts token-ring order via shared cmp (raw-byte = wrong order, #1580).
+        // #1917: rows here already share `partition_key` (prior retain) so this is a no-op today; kept for future multi-partition safety + parity with the IN fan-out / streaming scan's token order (raw-byte = #1580 wrong-order).
         if candidates.len() > 1 {
             all_results.sort_by(|a, b| cmp_partition_keys_by_token(a.0.as_bytes(), b.0.as_bytes()));
         }
@@ -1665,7 +1665,7 @@ impl SSTableManager {
             };
             all_results.append(&mut results);
         }
-        // #1917: concat sorts token-ring order via shared cmp (raw-byte = wrong order, #1580).
+        // #1917: rows here already share `partition_key` (prior retain) so this is a no-op today; kept for future multi-partition safety + parity with the IN fan-out / streaming scan's token order (raw-byte = #1580 wrong-order).
         if candidates.len() > 1 {
             all_results.sort_by(|a, b| cmp_partition_keys_by_token(a.0.as_bytes(), b.0.as_bytes()));
         }

--- a/cqlite-core/src/storage/sstable/scan_merge.rs
+++ b/cqlite-core/src/storage/sstable/scan_merge.rs
@@ -105,6 +105,10 @@ struct Candidate {
 }
 
 impl Candidate {
+    // Same token-then-raw-bytes rule as `cmp_partition_keys_by_token`
+    // (`util/cassandra_murmur3.rs`) plus a `reader_idx` tiebreak for k-way merge
+    // stability; expressed independently here since the k-way merge state isn't a
+    // pairwise `(key_a, key_b)` comparison the shared comparator can drop into.
     fn cmp(&self, other: &Self) -> Ordering {
         #[cfg(any(test, feature = "metrics"))]
         SCAN_KEY_COMPARISONS.with(|c| c.set(c.get().wrapping_add(1)));
@@ -216,6 +220,11 @@ pub(crate) fn kway_merge_token_order<T>(
 /// cross-generation merge paths, which are themselves `#[cfg(feature =
 /// "write-support")]`. Without the gate this is dead code in the minimal build
 /// and fails `-D warnings`.
+///
+/// Expresses the same token-then-raw-bytes rule as
+/// [`cmp_partition_keys_by_token`](crate::util::cassandra_murmur3::cmp_partition_keys_by_token)
+/// independently (pre-computed tokens over a batch, not a pairwise comparator) —
+/// keep both in sync if the tiebreak rule ever changes.
 #[cfg(feature = "write-support")]
 pub(crate) fn sort_by_token_order<E>(
     results: &mut Vec<E>,

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -116,6 +116,26 @@ pub fn cassandra_murmur3_token(data: &[u8]) -> i64 {
     normalize(h1)
 }
 
+/// Compare two raw partition keys by Cassandra's canonical global (token-ring)
+/// order: Murmur3 token first, raw key bytes as a deterministic tiebreak.
+///
+/// This is THE cross-partition order Cassandra presents rows in, and the single
+/// authoritative definition shared by every access path that concatenates rows
+/// from more than one source:
+/// - the streaming k-way merge (`sstable/mod.rs`, #1580),
+/// - the `WHERE pk IN (...)` fan-out (`select_executor::lookup::sort_rows_by_token`,
+///   #955), and
+/// - the multi-candidate `scan_partition` / metadata concat fallbacks (#1917).
+///
+/// Raw-byte order alone is the WRONG global order (it differs from token order for
+/// almost all key sets), so all of the above route through this comparator to keep
+/// row order identical regardless of which path served the query.
+pub fn cmp_partition_keys_by_token(a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+    cassandra_murmur3_token(a)
+        .cmp(&cassandra_murmur3_token(b))
+        .then_with(|| a.cmp(b))
+}
+
 /// Compute `DecoratedKey.filterHashLowerBits()` for a raw partition key, matching
 /// Cassandra 5.0's `org.apache.cassandra.db.DecoratedKey`.
 ///
@@ -164,6 +184,96 @@ fn fmix64(mut value: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cmp::Ordering;
+
+    // ---------------------------------------------------------------
+    // Issue #1917 — the canonical global-order comparator shared by every
+    // multi-source concat path (streaming k-way merge #1580, IN fan-out #955,
+    // scan_partition/metadata concat fallbacks). These prove the comparator IS
+    // Cassandra token-ring order and that it genuinely DIFFERS from raw-byte
+    // order (the order the concat sites used before #1917 — the "wrong global
+    // order" flagged by #1580).
+    // ---------------------------------------------------------------
+
+    /// A deterministic key set whose raw-byte order inverts token order, so the
+    /// two comparators cannot be conflated. Keys are simple ASCII partition keys.
+    fn inverting_key_set() -> Vec<Vec<u8>> {
+        (0u32..24)
+            .map(|i| format!("pk{i:03}").into_bytes())
+            .collect()
+    }
+
+    #[test]
+    fn cmp_by_token_matches_token_then_raw_bytes() {
+        // The comparator is exactly: token first, raw bytes as tiebreak.
+        for a in inverting_key_set() {
+            for b in inverting_key_set() {
+                let expected = cassandra_murmur3_token(&a)
+                    .cmp(&cassandra_murmur3_token(&b))
+                    .then_with(|| a.cmp(&b));
+                assert_eq!(
+                    cmp_partition_keys_by_token(&a, &b),
+                    expected,
+                    "comparator diverged from token-then-bytes for {a:?} vs {b:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cmp_by_token_is_a_total_order_consistent_with_sorting() {
+        // Sorting a shuffled key set with the comparator yields non-decreasing
+        // tokens (byte-order within equal-token ties) — the order all concat
+        // paths now agree on.
+        let mut keys = inverting_key_set();
+        keys.reverse();
+        keys.sort_by(|a, b| cmp_partition_keys_by_token(a, b));
+        for w in keys.windows(2) {
+            let ta = cassandra_murmur3_token(&w[0]);
+            let tb = cassandra_murmur3_token(&w[1]);
+            assert!(
+                ta < tb || (ta == tb && w[0] <= w[1]),
+                "sorted order not monotonic in token: {:?}(t={ta}) then {:?}(t={tb})",
+                w[0],
+                w[1],
+            );
+        }
+    }
+
+    #[test]
+    fn token_order_differs_from_raw_byte_order() {
+        // Regression guard for #1917: token order is NOT raw-byte order. The old
+        // concat sites re-sorted by `a.0.cmp(&b.0)` (raw bytes); this asserts that
+        // order genuinely differs from the token order Cassandra presents, so the
+        // swap is observable, not cosmetic.
+        let keys = inverting_key_set();
+
+        let mut by_bytes = keys.clone();
+        by_bytes.sort();
+
+        let mut by_token = keys.clone();
+        by_token.sort_by(|a, b| cmp_partition_keys_by_token(a, b));
+
+        assert_ne!(
+            by_bytes,
+            by_token,
+            "expected raw-byte order to differ from token order for {} keys",
+            keys.len()
+        );
+
+        // And prove at least one adjacent pair actually inverts.
+        let inverts = keys.iter().enumerate().any(|(i, a)| {
+            keys.iter().skip(i + 1).any(|b| {
+                let token_ord = cmp_partition_keys_by_token(a, b);
+                let byte_ord = a.as_slice().cmp(b.as_slice());
+                token_ord != Ordering::Equal && byte_ord != Ordering::Equal && token_ord != byte_ord
+            })
+        });
+        assert!(
+            inverts,
+            "no inverting pair found — key set is a poor regression guard"
+        );
+    }
 
     // ---------------------------------------------------------------
     // Test vectors verified against a running Cassandra 5.0 instance.


### PR DESCRIPTION
Closes #1917

## Problem
Two multi-candidate concat fallbacks in `cqlite-core/src/storage/sstable/mod.rs` re-sorted concatenated per-candidate results by raw partition-key bytes instead of Cassandra's canonical Murmur3 token order — inconsistent with the IN fan-out (`sort_rows_by_token`) and the token-ordered full-table scan (#1580's `kway_merge_token_order`).

## Fix
- New shared `cmp_partition_keys_by_token` comparator in `cqlite-core/src/util/cassandra_murmur3.rs` (Murmur3 token first, raw-byte tiebreak) — the single authoritative global-order rule.
- Both concat sort sites (`mod.rs`) and `select_executor/lookup.rs`'s `sort_rows_by_token` now delegate to it — dedup of what were 3 independently-expressed sort implementations into 1.

## Important finding (surfaced during implementation, verified by review)
Both fixed call sites filter every candidate's rows via `retain(matches_key)` before the sort, guaranteeing single-partition input — so the comparator swap is a **behavior-preserving no-op at these two specific sites today** (all keys compare Equal, stable sort preserves order regardless of comparator). This is documented honestly in-line at both sites rather than overclaiming an observable fix.

This is still correct and worth landing:
- The new shared comparator **is** exercised end-to-end through the pre-existing IN fan-out (`execute.rs:609`) and streaming scan (`streaming.rs:177`) paths, satisfying wiring-evidence doctrine for the new code.
- Removes the misleading raw-byte sort #1580 already flagged as "wrong global order."
- Future-proofs: correct-by-construction if these fallback paths ever receive multi-partition candidates.
- Regression tests (`cassandra_murmur3.rs`) prove token order genuinely differs from raw-byte order for a realistic key set.

## Review
- `rust-reviewer`: verified the no-op-today claim by reading the call graph, confirmed the new comparator has real end-to-end wiring elsewhere, requested one comment fix (done — comments now state the actual single-partition invariant instead of implying an observable fix here).
- roborev: clean, no issues found.

## Gate
LITE gate: PASS. Full gate + C + final roborev + merge-on-green run by `flow-closer`.