### PR TITLE
fix(#1750): remove is_simple_id_lookup text heuristic — point reads return correct schema-derived columns

### DIFF
--- a/cqlite-core/src/query/access_path.rs
+++ b/cqlite-core/src/query/access_path.rs
@@ -159,8 +159,10 @@ pub enum FallbackReason {
     /// so #962 can flip it to [`AccessPath::MetadataPartitionLookup`].
     MetadataScanPath,
 
-    /// The legacy `QueryExecutor` (simple-id-lookup and prepared SELECTs) issues
-    /// an unconditional `storage.scan`; it does not consult the fast path.
+    /// The legacy `QueryExecutor` issues an unconditional `storage.scan`; it does
+    /// not consult the fast path. Since issue #1750 ad-hoc SELECTs route through
+    /// the modern executor, so this reason now covers the remaining legacy SELECT
+    /// surfaces (a cached legacy SELECT plan reused via the plan-cache HIT branch).
     /// Tracked by #962 (route the legacy/prepared surfaces through the modern
     /// executor) and #961 (param binding).
     LegacyExecutorPath,

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -166,14 +166,12 @@ impl QueryEngine {
     }
 
     /// Enforce the byte-bounded result budget (issue #1582 / D6) on a result
-    /// materialized by the LEGACY [`QueryExecutor`] — the simple `WHERE id =
-    /// <value>` point-lookup path, which is routed to `self.executor` (not the
-    /// budgeted `SelectExecutor`) for key-handling consistency with INSERT. A
-    /// wide-partition point lookup would otherwise materialize unbounded and
-    /// bypass the guard, INCLUDING on a plan-cache HIT (roborev #1582 D6). Reuses
-    /// the SAME estimator + enforcement as the optimizer path so the byte ceiling
-    /// and the row-count safety valve behave identically. Applied exactly once at
-    /// every legacy return site.
+    /// materialized by the LEGACY [`QueryExecutor`] — non-SELECT statements and
+    /// any cached legacy SELECT plan reused via the plan-cache HIT branch. Since
+    /// issue #1750 ad-hoc SELECTs route through the modern `SelectExecutor` (which
+    /// budgets itself); this guard covers the remaining legacy return sites,
+    /// INCLUDING a plan-cache HIT (roborev #1582 D6). Reuses the SAME estimator +
+    /// enforcement as the optimizer path. Applied exactly once at each site.
     fn enforce_legacy_result_budget(&self, result: &QueryResult) -> Result<()> {
         super::result_budget::enforce_materialized_rows(
             &result.rows,
@@ -223,19 +221,18 @@ impl QueryEngine {
         let start_time = Instant::now();
         self.inc_total_queries();
 
-        // Route SELECT statements through the advanced parser, except simple
-        // `WHERE id = <value>` point lookups which must share the normal
-        // executor's key-handling path so INSERT and SELECT agree on keys.
+        // Route ALL SELECT statements through the modern optimizer +
+        // `SelectExecutor` (issue #1750). It populates `metadata.columns`, applies
+        // projection, reconstructs the partition-key column, and selects the
+        // partition-targeted fast path (#949/#956) from parsed query structure +
+        // schema — never from a substring/token-count guess. The retired
+        // `is_simple_id_lookup` fork (`WHERE id =` substring + ≤ 8-token check)
+        // diverted short point reads to the legacy `QueryExecutor`, returning
+        // column-less results and skipping projection — a no-heuristics mandate
+        // violation (#28) that flipped behavior with the PK name.
         let trimmed_cql = cql.trim().to_uppercase();
-        let is_simple_id_lookup = cql.contains("WHERE id =") && cql.split_whitespace().count() <= 8;
-        if trimmed_cql.starts_with("SELECT") && !is_simple_id_lookup {
+        if trimmed_cql.starts_with("SELECT") {
             return self.execute_select_query(cql, start_time).await;
-        }
-        #[cfg(debug_assertions)]
-        if trimmed_cql.starts_with("SELECT") && is_simple_id_lookup {
-            tracing::debug!(
-                "Routing simple SELECT through normal executor for consistent key handling"
-            );
         }
 
         // Check plan cache first for non-SELECT queries. Issue #1595: serve the
@@ -447,11 +444,9 @@ impl QueryEngine {
     /// When the parsed SELECT has **zero** bind markers and `params` is empty,
     /// this delegates straight back to [`Self::execute`] so that a markerless
     /// `execute_with_params(sql, &[])` is byte-for-byte equivalent to
-    /// `execute(sql)` — including the legacy simple-`WHERE id = <literal>` point
-    /// lookup that `execute` intentionally keeps on the normal executor for
-    /// INSERT/SELECT key compatibility. Only when markers are present (`> 0`) is
-    /// the statement bound and driven through the SELECT optimizer + executor
-    /// pipeline.
+    /// `execute(sql)` — which since issue #1750 routes every literal SELECT
+    /// through the modern SELECT optimizer + executor. Only when markers are
+    /// present (`> 0`) is the statement bound and driven through that pipeline.
     ///
     /// Arity stays strict in both directions: markers `> 0` with a wrong
     /// `params.len()` is an error, and markers `== 0` with a **non-empty**
@@ -496,10 +491,9 @@ impl QueryEngine {
             let marker_count = statement.bind_marker_count();
 
             // Finding 1: a markerless SELECT with no supplied params must route
-            // exactly like a literal `execute(cql)` — including the simple-id
-            // legacy point-lookup path — so the two APIs cannot diverge. A
-            // marker-free statement with stray params is, however, a caller bug:
-            // reject it for strict arity (no placeholder to bind into).
+            // exactly like a literal `execute(cql)` (since #1750, the modern
+            // executor) so the two APIs cannot diverge. A marker-free statement
+            // with stray params is a caller bug: reject it for strict arity.
             if marker_count == 0 {
                 if params.is_empty() {
                     return self.execute(cql).await;
@@ -1122,7 +1116,8 @@ mod tests {
 
         let query_engine = QueryEngine::new(storage, schema, memory, &config).unwrap();
 
-        // Execute 3 different queries
+        // Execute 3 different queries. Since #1750 these route through the modern
+        // SELECT executor; their plans live in `select_plan_cache`.
         let _ = query_engine
             .execute("SELECT * FROM users WHERE id = 1")
             .await;
@@ -1133,8 +1128,8 @@ mod tests {
             .execute("SELECT * FROM users WHERE id = 3")
             .await;
 
-        // Cache should only have 2 entries due to eviction
-        assert_eq!(query_engine.cache_stats().plan_cache_size, 2);
+        // Cache should only have 2 entries due to eviction (simple LRU).
+        assert_eq!(query_engine.select_plan_cache.len(), 2);
     }
 
     #[tokio::test]
@@ -1219,8 +1214,8 @@ mod tests {
         let memory = Arc::new(crate::memory::MemoryManager::new(&config).unwrap());
         let engine = QueryEngine::new(storage, schema, memory, &config).unwrap();
 
-        // A non-`WHERE id =` SELECT routes through the modern `execute_select_query`
-        // path (see `execute`'s `is_simple_id_lookup` gate), which owns the plan cache.
+        // Every SELECT routes through `execute_select_query` (issue #1750 retired
+        // the `WHERE id =` text fork), which owns the modern `select_plan_cache`.
         let cql = "SELECT * FROM t WHERE age > 5";
 
         OPTIMIZE_INVOCATIONS.with(|c| c.set(0));
@@ -1256,7 +1251,7 @@ mod tests {
 mod engine_lock_hygiene_tests;
 
 #[cfg(test)]
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "experimental", feature = "state_machine"))]
 mod plan_cache_tests {
     use super::*;
     use crate::{
@@ -1287,13 +1282,18 @@ mod plan_cache_tests {
         (engine, temp_dir)
     }
 
-    /// Register the table schema used by the plan-cache tests.
-    ///
-    /// The write path was removed in Issue #175, so this only issues the
-    /// `CREATE TABLE` DDL — no row inserts. The plan-cache assertions below
-    /// depend solely on query *planning* (cache population/eviction on simple
-    /// `WHERE id = ?` point lookups routed through the legacy executor), not on
-    /// any stored rows, so an empty table exercises the current behavior exactly.
+    /// Number of cached modern SELECT plans. Since issue #1750 ALL SELECTs
+    /// (including `WHERE id = ?` point lookups) route through the modern
+    /// `SelectExecutor`, whose plans live in `select_plan_cache`, not the legacy
+    /// `plan_cache` surfaced by `cache_stats`; these LRU tests assert on it.
+    fn select_plan_cache_len(engine: &QueryEngine) -> usize {
+        engine.select_plan_cache.len()
+    }
+
+    /// Register the table schema used by the plan-cache tests. Write path removed
+    /// in Issue #175, so this only issues `CREATE TABLE` DDL — no row inserts. The
+    /// assertions depend solely on planning (cache population/eviction), not
+    /// stored rows, so an empty table exercises current behavior exactly.
     async fn create_sample_table(engine: &QueryEngine) {
         engine
             .execute(
@@ -1319,7 +1319,7 @@ mod plan_cache_tests {
             .await
             .unwrap();
 
-        assert_eq!(engine.cache_stats().plan_cache_size, 0);
+        assert_eq!(select_plan_cache_len(&engine), 0);
     }
 
     #[tokio::test]
@@ -1341,7 +1341,7 @@ mod plan_cache_tests {
             .await
             .unwrap();
 
-        assert_eq!(engine.cache_stats().plan_cache_size, 1);
+        assert_eq!(select_plan_cache_len(&engine), 1);
         assert!(engine.stats().cache_hit_ratio > 0.0);
     }
 
@@ -1362,6 +1362,6 @@ mod plan_cache_tests {
                 .unwrap();
         }
 
-        assert_eq!(engine.cache_stats().plan_cache_size, 2);
+        assert_eq!(select_plan_cache_len(&engine), 2);
     }
 }

--- a/cqlite-core/src/query/result_budget.rs
+++ b/cqlite-core/src/query/result_budget.rs
@@ -8,8 +8,12 @@
 //! pipeline), by [`crate::query::select_executor::SelectExecutor::execute`].
 //!
 //! SCOPE: the LEGACY [`QueryExecutor`](crate::query::executor::QueryExecutor)
-//! point-lookup path (simple `WHERE id = <value>` lookups) is NOT covered by
-//! this budget — deferred to the D6 redesign (tracked on #1582).
+//! path — non-SELECT statements and any cached legacy SELECT plan reused via the
+//! plan-cache HIT branch — is NOT covered by this module's estimator directly;
+//! `QueryEngine::enforce_legacy_result_budget` applies the same ceiling at those
+//! sites. Since issue #1750 ad-hoc SELECTs (including simple `WHERE id = <value>`
+//! point lookups) route through the modern `SelectExecutor` and are budgeted
+//! there. (D6 redesign tracked on #1582.)
 //!
 //! This module is compiled unconditionally (unlike `select_executor`, which is
 //! `state_machine`-gated).

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -451,6 +451,24 @@ impl SelectExecutor {
             ),
         }
 
+        // Issue #1750: a SCHEMA-LESS `WHERE pk = <literal>` point read can be served
+        // by a key-byte-targeted seek ONLY when the equality column is a
+        // metadata-CONFIRMED sole partition key (single-component pk, no clustering
+        // keys, column absent from the authoritative non-key column names). Resolve
+        // that authoritative shape from the Statistics.db SerializationHeader (the
+        // metadata a schema-less reader HAS) and classify BY ELIMINATION — never a
+        // pk-name/text guess (#28). `None` (metadata unavailable, or the column is a
+        // non-pk column) keeps the honest full-scan path, which correctly matches
+        // regular-column equalities. Resolved only when there is no CQL schema and no
+        // WRITETIME/TTL metadata projection (the two branches below own those).
+        let schemaless_pk_bytes: Option<Vec<u8>> =
+            if schema_opt.is_none() && !context.projection_flags.include_cell_metadata {
+                let shape = self.storage.partition_key_shape(table).await;
+                classify_schemaless_point_lookup(predicates, shape.as_ref())
+            } else {
+                None
+            };
+
         // Issue #693: When WRITETIME(col) or TTL(col) is in the SELECT, use the
         // metadata-carrying scan so per-cell timestamps reach the QueryRow.
         let results = if context.projection_flags.include_cell_metadata {
@@ -523,29 +541,28 @@ impl SelectExecutor {
                     Some(row)
                 },
             )?
-        } else if let Some(pk_bytes) = schema_opt
-            .is_none()
-            .then(|| classify_schemaless_point_lookup(predicates))
-            .flatten()
-        {
-            // Issue #1750 (regression fix): a SCHEMA-LESS `WHERE pk = <literal>`
-            // point read. With no schema the full-scan path CANNOT reconstruct the
-            // partition-key column, so the shared per-row `evaluate_predicates`
-            // backstop below would reject EVERY row on the pk equality and return 0
-            // rows — the regression from rerouting this read off the legacy
-            // `QueryExecutor` (which looked up by key bytes, never re-evaluating the
-            // predicate). Serve it here by the SAME key-byte-targeted seek the
-            // schema-aware Targeted arm uses (`scan_partition`), which is
-            // self-verifying: it returns ONLY rows whose raw partition key equals
-            // `pk_bytes`, so a wrong/absent key yields nothing (never another
-            // partition's rows). The decision is purely STRUCTURAL
-            // (`classify_schemaless_point_lookup`: exactly one non-token `col =
-            // <single-component literal>` predicate) — never a substring/token-count
-            // text guess (#28). Skip the per-row predicate backstop for this branch
-            // (the seek already pinned the partition by key); the schema-less
-            // `SELECT *` column metadata still comes from the first row's keys in
-            // `execute` (the #1750 column fix is unaffected — it targets the
-            // schema-PRESENT path).
+        } else if let Some(pk_bytes) = schemaless_pk_bytes {
+            // Issue #1750 (regression fix, re-scoped): a SCHEMA-LESS `WHERE pk =
+            // <literal>` point read whose equality column is a metadata-CONFIRMED
+            // sole partition key. With no schema the full-scan path CANNOT
+            // reconstruct the partition-key column, so the shared per-row
+            // `evaluate_predicates` backstop below would reject EVERY row on the pk
+            // equality and return 0 rows — the regression from rerouting this read
+            // off the legacy `QueryExecutor` (which looked up by key bytes, never
+            // re-evaluating the predicate). Serve it here by the SAME
+            // key-byte-targeted seek the schema-aware Targeted arm uses
+            // (`scan_partition`), which is self-verifying: it returns ONLY rows whose
+            // raw partition key equals `pk_bytes`, so a wrong/absent key yields
+            // nothing (never another partition's rows). The decision is made from
+            // AUTHORITATIVE metadata (the Statistics.db SerializationHeader shape,
+            // resolved above) by ELIMINATION — never a pk-name/substring/token-count
+            // text guess (#28). A `WHERE <regular_col> = <literal>` does NOT reach
+            // here (the classifier returns `None` because the column is one of the
+            // authoritative non-key names), so it keeps the honest full-scan path and
+            // correctly matches the regular-column cell. Skip the per-row predicate
+            // backstop for this branch (the seek already pinned the partition by
+            // key); the schema-less `SELECT *` column metadata still comes from the
+            // first row's keys in `execute`.
             let (rows, engaged) = self.storage.scan_partition(table, &pk_bytes, None).await?;
             let path = honest_targeted_path(AccessPath::PartitionLookup, engaged);
             context.access_path = Some(path.clone());

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -14,6 +14,7 @@
 //! this file can reach `mod.rs`'s private items directly — the logic, ordering,
 //! and error handling are unchanged.
 
+use super::schemaless_point::classify_schemaless_point_lookup;
 use super::{
     build_row_from_scan, classify_partition_lookup, collect_capped_materialized,
     column_info_from_type_str, honest_targeted_path, parse_table_id, project_expr_reshapes_row,
@@ -522,6 +523,42 @@ impl SelectExecutor {
                     Some(row)
                 },
             )?
+        } else if let Some(pk_bytes) = schema_opt
+            .is_none()
+            .then(|| classify_schemaless_point_lookup(predicates))
+            .flatten()
+        {
+            // Issue #1750 (regression fix): a SCHEMA-LESS `WHERE pk = <literal>`
+            // point read. With no schema the full-scan path CANNOT reconstruct the
+            // partition-key column, so the shared per-row `evaluate_predicates`
+            // backstop below would reject EVERY row on the pk equality and return 0
+            // rows — the regression from rerouting this read off the legacy
+            // `QueryExecutor` (which looked up by key bytes, never re-evaluating the
+            // predicate). Serve it here by the SAME key-byte-targeted seek the
+            // schema-aware Targeted arm uses (`scan_partition`), which is
+            // self-verifying: it returns ONLY rows whose raw partition key equals
+            // `pk_bytes`, so a wrong/absent key yields nothing (never another
+            // partition's rows). The decision is purely STRUCTURAL
+            // (`classify_schemaless_point_lookup`: exactly one non-token `col =
+            // <single-component literal>` predicate) — never a substring/token-count
+            // text guess (#28). Skip the per-row predicate backstop for this branch
+            // (the seek already pinned the partition by key); the schema-less
+            // `SELECT *` column metadata still comes from the first row's keys in
+            // `execute` (the #1750 column fix is unaffected — it targets the
+            // schema-PRESENT path).
+            let (rows, engaged) = self.storage.scan_partition(table, &pk_bytes, None).await?;
+            let path = honest_targeted_path(AccessPath::PartitionLookup, engaged);
+            context.access_path = Some(path.clone());
+            crate::query::access_path::record(path);
+            context.scan_rows += rows.len() as u64;
+            context.rows_processed += rows.len() as u64;
+            let mut out = Vec::with_capacity(rows.len());
+            for (key, value) in rows {
+                if let Some(row) = build_row_from_scan(key, value, projection, None) {
+                    out.push(row);
+                }
+            }
+            out
         } else {
             // Issue #949: a fully-constrained `WHERE pk = ?` is served by a
             // partition-targeted lookup that prunes SSTables via bloom/BTI and only

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -461,7 +461,7 @@ impl SelectExecutor {
         // non-pk column) keeps the honest full-scan path, which correctly matches
         // regular-column equalities. Resolved only when there is no CQL schema and no
         // WRITETIME/TTL metadata projection (the two branches below own those).
-        let schemaless_pk_bytes: Option<Vec<u8>> =
+        let schemaless_seek: Option<super::schemaless_point::SchemalessPointSeek> =
             if schema_opt.is_none() && !context.projection_flags.include_cell_metadata {
                 let shape = self.storage.partition_key_shape(table).await;
                 classify_schemaless_point_lookup(predicates, shape.as_ref())
@@ -541,7 +541,7 @@ impl SelectExecutor {
                     Some(row)
                 },
             )?
-        } else if let Some(pk_bytes) = schemaless_pk_bytes {
+        } else if let Some(seek) = schemaless_seek {
             // Issue #1750 (regression fix, re-scoped): a SCHEMA-LESS `WHERE pk =
             // <literal>` point read whose equality column is a metadata-CONFIRMED
             // sole partition key. With no schema the full-scan path CANNOT
@@ -552,18 +552,30 @@ impl SelectExecutor {
             // re-evaluating the predicate). Serve it here by the SAME
             // key-byte-targeted seek the schema-aware Targeted arm uses
             // (`scan_partition`), which is self-verifying: it returns ONLY rows whose
-            // raw partition key equals `pk_bytes`, so a wrong/absent key yields
-            // nothing (never another partition's rows). The decision is made from
-            // AUTHORITATIVE metadata (the Statistics.db SerializationHeader shape,
-            // resolved above) by ELIMINATION — never a pk-name/substring/token-count
-            // text guess (#28). A `WHERE <regular_col> = <literal>` does NOT reach
-            // here (the classifier returns `None` because the column is one of the
-            // authoritative non-key names), so it keeps the honest full-scan path and
-            // correctly matches the regular-column cell. Skip the per-row predicate
-            // backstop for this branch (the seek already pinned the partition by
-            // key); the schema-less `SELECT *` column metadata still comes from the
-            // first row's keys in `execute`.
-            let (rows, engaged) = self.storage.scan_partition(table, &pk_bytes, None).await?;
+            // raw partition key equals `seek.bytes`, so a wrong/absent key yields
+            // nothing (never another partition's rows). The key is encoded through
+            // the TYPED single-component codec for the pk's AUTHORITATIVE type (from
+            // the Statistics.db SerializationHeader `keyType`), so a parsed integer
+            // literal (`Value::BigInt`) builds the width Cassandra wrote — an `int`
+            // pk's 4-byte key, not an 8-byte one (roborev 3784 FINDING 2). The
+            // decision is made from AUTHORITATIVE metadata by ELIMINATION — never a
+            // pk-name/substring/token-count text guess (#28). A `WHERE <regular_col>
+            // = <literal>` does NOT reach here (the classifier returns `None` because
+            // the column is one of the authoritative non-key names), so it keeps the
+            // honest full-scan path and correctly matches the regular-column cell.
+            //
+            // Post-seek guard (roborev 3784 FINDING 1): the classifier admits the
+            // predicate column by ELIMINATION, which also admits a
+            // nonexistent/misspelled column whose literal happens to encode to a real
+            // partition's key. `finalize_schemaless_seek_row` reconstructs the sole
+            // pk column under its authoritative type/name and RE-EVALUATES the
+            // predicate, so such a column yields `Unknown` and rejects the row
+            // (correct 0 rows) — the pk-name predicate still matches. The schema-less
+            // `SELECT *` column metadata still comes from the first row in `execute`.
+            let (rows, engaged) = self
+                .storage
+                .scan_partition(table, &seek.bytes, None)
+                .await?;
             let path = honest_targeted_path(AccessPath::PartitionLookup, engaged);
             context.access_path = Some(path.clone());
             crate::query::access_path::record(path);
@@ -571,7 +583,9 @@ impl SelectExecutor {
             context.rows_processed += rows.len() as u64;
             let mut out = Vec::with_capacity(rows.len());
             for (key, value) in rows {
-                if let Some(row) = build_row_from_scan(key, value, projection, None) {
+                if let Some(row) = super::schemaless_point::finalize_schemaless_seek_row(
+                    key, value, projection, predicates, &seek,
+                ) {
                     out.push(row);
                 }
             }

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -45,6 +45,7 @@ mod limit_pushdown;
 mod lookup;
 mod predicate;
 mod row_build;
+mod schemaless_point;
 mod stream_agg;
 mod streaming;
 mod value_ops;

--- a/cqlite-core/src/query/select_executor/schemaless_point.rs
+++ b/cqlite-core/src/query/select_executor/schemaless_point.rs
@@ -5,7 +5,7 @@
 //! point-read recogniser + its single-component key encoder; the schema-aware
 //! `classify_partition_lookup` stays in `lookup.rs`.
 //!
-//! # Known schemaless-seek limitations (tracked in #TBD)
+//! # Known schemaless-seek limitations (tracked in #2200)
 //!
 //! These are ACCEPTED limitations of the schema-less single-component seek path.
 //! Each is fail-SAFE (it yields the correct 0 rows or declines to a full scan, never

--- a/cqlite-core/src/query/select_executor/schemaless_point.rs
+++ b/cqlite-core/src/query/select_executor/schemaless_point.rs
@@ -1,0 +1,163 @@
+//! Schema-less point-lookup classification for the SELECT executor (issue #1750).
+//!
+//! Split out of `lookup.rs` (campsite rule, epic #1116) so the over-threshold
+//! classifier file does not grow. This holds ONLY the structural schema-less
+//! point-read recogniser + its single-component key encoder; the schema-aware
+//! `classify_partition_lookup` stays in `lookup.rs`.
+
+use super::super::select_optimizer::SSTablePredicate;
+use crate::types::Value;
+
+/// Structurally classify a SCHEMA-LESS point read (issue #1750 regression fix).
+///
+/// When NO schema is available, `classify_partition_lookup` can only report
+/// `NoSchema` and fall back to a full scan. But a schema-less full scan CANNOT
+/// reconstruct the partition-key column (Cassandra never serialises it in the
+/// cell payload, and `build_row_from_scan` needs the schema to decode it from the
+/// row key), so a `WHERE pk = <literal>` predicate then rejects EVERY row in the
+/// post-scan backstop — the read returns 0 rows. Before #1750 retired the
+/// `is_simple_id_lookup` fork, such a read routed to the legacy `QueryExecutor`,
+/// which looked the partition up BY KEY BYTES via `storage.get()` and never
+/// re-evaluated the predicate, so it returned the row.
+///
+/// This restores that behaviour WITHOUT any text heuristic: the decision is made
+/// purely from the parsed predicate STRUCTURE. It returns the on-disk key bytes
+/// for a targeted lookup ONLY when the predicates are EXACTLY a single non-token
+/// `column = <literal>` equality — the unambiguous single-component point-read
+/// shape a schema-less reader can serve by encoding the literal to raw key bytes
+/// (the same single-component encoding `RowKey`/the write engine use). Any other
+/// shape (no predicate, a range/`IN`, multiple predicates, a token predicate, or a
+/// value that has no single-component key encoding) returns `None` so the caller
+/// keeps the honest full-scan path. The targeted read is self-verifying: the
+/// storage seek only returns rows whose raw partition key equals these bytes, so
+/// a wrong/absent key yields no rows — never another partition's rows.
+pub(super) fn classify_schemaless_point_lookup(predicates: &[SSTablePredicate]) -> Option<Vec<u8>> {
+    use super::super::select_optimizer::SSTableFilterOp;
+
+    // Exactly one predicate, a non-token single-value equality.
+    let [predicate] = predicates else {
+        return None;
+    };
+    if predicate.is_token() || !matches!(predicate.operation, SSTableFilterOp::Equal) {
+        return None;
+    }
+    let [value] = predicate.values.as_slice() else {
+        return None;
+    };
+    encode_single_component_key(value)
+}
+
+/// Encode a single `Value` to the raw single-component on-disk partition-key
+/// bytes — the schema-less counterpart of the write engine's
+/// `PartitionKey::to_bytes` single-component form (raw value bytes, NO framing),
+/// used by [`classify_schemaless_point_lookup`].
+///
+/// Only the value kinds with an UNAMBIGUOUS single-component key encoding are
+/// accepted; anything else (collections, blobs, etc.) returns `None` so the
+/// caller falls back to a full scan rather than guessing a byte layout.
+fn encode_single_component_key(value: &Value) -> Option<Vec<u8>> {
+    match value {
+        Value::Uuid(bytes) => Some(bytes.to_vec()),
+        Value::Integer(i) => Some(i.to_be_bytes().to_vec()),
+        Value::BigInt(i) => Some(i.to_be_bytes().to_vec()),
+        Value::Text(s) => Some(s.as_bytes().to_vec()),
+        Value::Boolean(b) => Some(vec![u8::from(*b)]),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::select_optimizer::{SSTableFilterOp, SSTablePredicate};
+    use super::*;
+
+    /// Issue #1750 (regression fix): the schema-less point-lookup classifier
+    /// recognises EXACTLY the single non-token `col = <single-component literal>`
+    /// shape and returns its raw on-disk key bytes, so a schema-less `WHERE pk =
+    /// <uuid>` can be served by a key-byte-targeted seek (never returning 0 rows
+    /// because the schema-less scan can't reconstruct the pk column). The decision
+    /// is structural — never a text guess.
+    #[test]
+    fn classify_schemaless_point_lookup_targets_single_equality() {
+        let uuid = [7u8; 16];
+        let predicate =
+            SSTablePredicate::column("id", SSTableFilterOp::Equal, vec![Value::Uuid(uuid)]);
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&predicate)),
+            Some(uuid.to_vec()),
+            "a single UUID `=` must yield the raw 16-byte single-component key",
+        );
+
+        // int / text single-component encodings.
+        let int_pred =
+            SSTablePredicate::column("id", SSTableFilterOp::Equal, vec![Value::Integer(42)]);
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&int_pred)),
+            Some(42i32.to_be_bytes().to_vec()),
+        );
+        let text_pred = SSTablePredicate::column(
+            "id",
+            SSTableFilterOp::Equal,
+            vec![Value::Text("k0".to_string())],
+        );
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&text_pred)),
+            Some(b"k0".to_vec()),
+        );
+    }
+
+    /// Issue #1750: the schema-less classifier must NOT fire on any non-point
+    /// shape — no predicate, a range, an `IN`, multiple predicates, a token
+    /// predicate, or an unencodable value — so those keep the honest full-scan
+    /// path (never a wrong targeted read).
+    #[test]
+    fn classify_schemaless_point_lookup_rejects_non_point_shapes() {
+        // No predicate (bare SELECT *).
+        assert_eq!(classify_schemaless_point_lookup(&[]), None);
+
+        // A range restriction.
+        let range = SSTablePredicate::column("id", SSTableFilterOp::Gt, vec![Value::Integer(1)]);
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&range)),
+            None
+        );
+
+        // An `IN` (multi-value) — not a single point key here.
+        let in_pred = SSTablePredicate::column(
+            "id",
+            SSTableFilterOp::In,
+            vec![Value::Integer(1), Value::Integer(2)],
+        );
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&in_pred)),
+            None
+        );
+
+        // Two predicates (pk + clustering) — ambiguous without a schema.
+        let a = SSTablePredicate::column("pk", SSTableFilterOp::Equal, vec![Value::Integer(1)]);
+        let b = SSTablePredicate::column("ck", SSTableFilterOp::Equal, vec![Value::Integer(2)]);
+        assert_eq!(classify_schemaless_point_lookup(&[a, b]), None);
+
+        // A token predicate is never a real partition-key column.
+        let tok = SSTablePredicate::token(
+            vec!["id".to_string()],
+            SSTableFilterOp::Equal,
+            vec![Value::BigInt(5)],
+        );
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&tok)),
+            None
+        );
+
+        // A value kind with no unambiguous single-component key encoding.
+        let blob = SSTablePredicate::column(
+            "id",
+            SSTableFilterOp::Equal,
+            vec![Value::Blob(vec![1, 2, 3])],
+        );
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&blob)),
+            None
+        );
+    }
+}

--- a/cqlite-core/src/query/select_executor/schemaless_point.rs
+++ b/cqlite-core/src/query/select_executor/schemaless_point.rs
@@ -7,7 +7,22 @@
 
 use super::super::select_optimizer::SSTablePredicate;
 use crate::storage::sstable::PartitionKeyShape;
-use crate::types::Value;
+
+/// The classified schema-less single-component point-key seek (issue #1750).
+///
+/// Carries the raw on-disk partition-key `bytes` to seek by AND the authoritative
+/// pk component (`name` + `cql_type`) needed to (a) reconstruct the seeked row's
+/// partition-key column schema-less and (b) re-evaluate the predicate against it
+/// (the post-seek guard for roborev 3784 FINDING 1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SchemalessPointSeek {
+    /// Raw single-component partition-key bytes to seek by.
+    pub bytes: Vec<u8>,
+    /// The header-synthesised pk column name (`id` / `partition_key`).
+    pub pk_name: String,
+    /// The authoritative CQL type of the pk component.
+    pub pk_cql_type: String,
+}
 
 /// Classify a SCHEMA-LESS point read against AUTHORITATIVE partition-key metadata
 /// (issue #1750 regression fix, then re-scoped to stop over-firing).
@@ -43,7 +58,7 @@ use crate::types::Value;
 pub(super) fn classify_schemaless_point_lookup(
     predicates: &[SSTablePredicate],
     shape: Option<&PartitionKeyShape>,
-) -> Option<Vec<u8>> {
+) -> Option<SchemalessPointSeek> {
     use super::super::select_optimizer::SSTableFilterOp;
 
     // Exactly one predicate, a non-token single-value equality.
@@ -69,26 +84,96 @@ pub(super) fn classify_schemaless_point_lookup(
         return None;
     }
 
-    encode_single_component_key(value)
+    // The pk component's authoritative CQL TYPE (from the SerializationHeader
+    // `keyType`, never a guess — #28). Without a provable single-component type we
+    // DECLINE the seek (full-scan stays correct) rather than encode a
+    // possibly-wrong-width key (issue #1750, roborev 3784 FINDING 2).
+    let component = shape.single_pk_component.as_ref()?;
+
+    // Encode the literal through the TYPED single-component partition-key codec
+    // for that pk type — the SAME path the schema-aware Targeted seek uses — so a
+    // parsed integer literal (`Value::BigInt`) encodes to the width Cassandra
+    // wrote (`int` → 4 bytes, `bigint` → 8, `uuid` → 16, `text` → utf8). An
+    // unencodable literal/type yields `None` → decline the seek.
+    let bytes = crate::storage::partition_key_codec::encode_single_component_key_typed(
+        value,
+        &component.cql_type,
+    )
+    .ok()?;
+
+    Some(SchemalessPointSeek {
+        bytes,
+        pk_name: component.name.clone(),
+        pk_cql_type: component.cql_type.clone(),
+    })
 }
 
-/// Encode a single `Value` to the raw single-component on-disk partition-key
-/// bytes — the schema-less counterpart of the write engine's
-/// `PartitionKey::to_bytes` single-component form (raw value bytes, NO framing),
-/// used by [`classify_schemaless_point_lookup`].
+/// Build the user-visible `QueryRow` for ONE row returned by a schema-less
+/// single-component point seek, reconstructing the partition-key column and
+/// applying the post-seek predicate guard (issue #1750, roborev 3784 FINDING 1).
 ///
-/// Only the value kinds with an UNAMBIGUOUS single-component key encoding are
-/// accepted; anything else (collections, blobs, etc.) returns `None` so the
-/// caller falls back to a full scan rather than guessing a byte layout.
-fn encode_single_component_key(value: &Value) -> Option<Vec<u8>> {
-    match value {
-        Value::Uuid(bytes) => Some(bytes.to_vec()),
-        Value::Integer(i) => Some(i.to_be_bytes().to_vec()),
-        Value::BigInt(i) => Some(i.to_be_bytes().to_vec()),
-        Value::Text(s) => Some(s.as_bytes().to_vec()),
-        Value::Boolean(b) => Some(vec![u8::from(*b)]),
-        _ => None,
+/// The seek self-verifies on raw KEY bytes but never re-checks the predicate
+/// COLUMN, and the classifier admits the predicate column BY ELIMINATION (absent
+/// from the authoritative non-key names) — which also admits a misspelled or
+/// nonexistent column. If such a literal happens to encode to a real partition
+/// key's bytes, the seek would return that partition's row for a column the user
+/// never has. So we:
+///   1. reconstruct the sole pk column from the raw key under its authoritative
+///      TYPE and header-synthesised NAME (schema-less `build_row_from_scan` omits
+///      the pk), and
+///   2. re-evaluate the predicate against the materialised row — a predicate on
+///      the pk name matches; one on a nonexistent/misspelled column is `Unknown`
+///      and rejects the row (yielding the correct 0 rows).
+///
+/// Returns `None` for a tombstoned/absent row, a pk that cannot be decoded, or a
+/// row the predicate rejects. The projection is honoured for output (the pk is
+/// materialised for the guard regardless, then dropped from output if the
+/// projection excludes it) so this matches the schema-aware path's row shape.
+pub(super) fn finalize_schemaless_seek_row(
+    key: crate::types::RowKey,
+    value: crate::types::ScanRow,
+    projection: &[String],
+    predicates: &[SSTablePredicate],
+    seek: &SchemalessPointSeek,
+) -> Option<crate::query::result::QueryRow> {
+    use super::predicate::evaluate_predicates;
+    use super::row_build::build_row_from_scan;
+
+    // Decode the sole pk value from the raw key under its authoritative type
+    // (BEFORE `key` is moved into the row builder). A decode failure means we
+    // cannot validate the row, so drop it (honest 0 rather than an unvalidated 1).
+    let comparator = crate::types::ComparatorType::from_data_type(&seek.pk_cql_type).ok()?;
+    let pk_value =
+        crate::storage::partition_key_codec::deserialize_value_bytes(&key.0, &comparator).ok()?;
+
+    // Schema-less row build (schema = None) surfaces the decoded non-key cells but
+    // NOT the pk column.
+    let mut row = build_row_from_scan(key, value, projection, None)?;
+
+    // Materialise the pk column under its authoritative name for the guard.
+    let pk_name: std::sync::Arc<str> = seek.pk_name.as_str().into();
+    let already_present = row.values.contains_key(&pk_name);
+    if !already_present {
+        row.values.insert(pk_name.clone(), pk_value);
     }
+
+    // Post-seek guard: re-evaluate the predicate. A predicate on the pk name
+    // matches the reconstructed value; one on a nonexistent/misspelled column is
+    // Unknown → row rejected (the FINDING 1 over-firing this removes).
+    if !evaluate_predicates(&row, predicates).ok()? {
+        return None;
+    }
+
+    // Honour projection for OUTPUT: drop the pk again if we injected it only for
+    // the guard and the projection does not include it (empty projection = all).
+    if !already_present
+        && !projection.is_empty()
+        && !projection.iter().any(|p| p.as_str() == seek.pk_name)
+    {
+        row.values.remove(&pk_name);
+    }
+
+    Some(row)
 }
 
 #[cfg(test)]
@@ -96,8 +181,14 @@ mod tests {
     use super::super::super::select_optimizer::{SSTableFilterOp, SSTablePredicate};
     use super::*;
 
+    use super::super::super::select_optimizer::SSTablePredicate as Pred;
+    use crate::query::result::QueryRow;
+    use crate::storage::sstable::PartitionKeyComponent;
+    use crate::types::{RowKey, ScanRow, Value};
+    use std::sync::Arc;
+
     /// A single-component-pk, no-clustering table whose only non-key column is
-    /// `name` — mirrors `test_basic.simple_table` (`id UUID` pk, `name TEXT`).
+    /// `name`/`age` — mirrors `test_basic.simple_table` (`id UUID` pk).
     fn simple_table_shape() -> PartitionKeyShape {
         PartitionKeyShape {
             partition_key_count: 1,
@@ -105,56 +196,84 @@ mod tests {
             non_key_column_names: ["name".to_string(), "age".to_string()]
                 .into_iter()
                 .collect(),
+            single_pk_component: Some(PartitionKeyComponent {
+                name: "id".to_string(),
+                cql_type: "uuid".to_string(),
+            }),
+        }
+    }
+
+    /// A single-component `int` pk table (`partition_key` pk, `v` regular) —
+    /// mirrors `test_compactionparity.live_no_clustering`.
+    fn int_pk_shape() -> PartitionKeyShape {
+        PartitionKeyShape {
+            partition_key_count: 1,
+            clustering_key_count: 0,
+            non_key_column_names: ["v".to_string()].into_iter().collect(),
+            single_pk_component: Some(PartitionKeyComponent {
+                name: "partition_key".to_string(),
+                cql_type: "int".to_string(),
+            }),
         }
     }
 
     /// Issue #1750 (regression fix): a schema-less `col = <literal>` whose column is
-    /// a metadata-CONFIRMED sole partition key (single pk component, no clustering
-    /// keys, column absent from the authoritative non-key names) yields its raw
-    /// single-component key bytes for a targeted seek. The confirmation is by
-    /// elimination from authoritative metadata — never a pk-name/text guess.
+    /// a metadata-CONFIRMED sole partition key yields the TYPED single-component key
+    /// bytes for a targeted seek. Confirmation is by elimination from authoritative
+    /// metadata — never a pk-name/text guess.
     #[test]
     fn classify_schemaless_point_lookup_targets_confirmed_pk_equality() {
         let shape = simple_table_shape();
         let uuid = [7u8; 16];
         let predicate =
             SSTablePredicate::column("id", SSTableFilterOp::Equal, vec![Value::Uuid(uuid)]);
-        assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&predicate), Some(&shape)),
-            Some(uuid.to_vec()),
-            "a single UUID `=` on the confirmed pk must yield the raw 16-byte key",
-        );
+        let seek = classify_schemaless_point_lookup(std::slice::from_ref(&predicate), Some(&shape))
+            .expect("a single UUID `=` on the confirmed pk must classify");
+        assert_eq!(seek.bytes, uuid.to_vec(), "raw 16-byte uuid key");
+        assert_eq!(seek.pk_name, "id");
+        assert_eq!(seek.pk_cql_type, "uuid");
 
-        // int / text single-component encodings (pk column named `pk`, absent from
-        // the non-key names, so confirmed by elimination).
-        let pk_shape = PartitionKeyShape {
-            partition_key_count: 1,
-            clustering_key_count: 0,
-            non_key_column_names: ["v".to_string()].into_iter().collect(),
-        };
-        let int_pred =
-            SSTablePredicate::column("pk", SSTableFilterOp::Equal, vec![Value::Integer(42)]);
-        assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&int_pred), Some(&pk_shape)),
-            Some(42i32.to_be_bytes().to_vec()),
-        );
-        let text_pred = SSTablePredicate::column(
-            "pk",
+        // roborev 3784 FINDING 2: a parsed integer literal arrives as `Value::BigInt`
+        // (the SELECT parser widens every integer); on an `int` pk it must encode to
+        // Cassandra's 4-byte `int` key, NOT an 8-byte one.
+        let int_shape = int_pk_shape();
+        let int_pred = SSTablePredicate::column(
+            "partition_key",
             SSTableFilterOp::Equal,
-            vec![Value::Text("k0".to_string())],
+            vec![Value::BigInt(42)],
+        );
+        let int_seek =
+            classify_schemaless_point_lookup(std::slice::from_ref(&int_pred), Some(&int_shape))
+                .expect("int pk `=` must classify");
+        assert_eq!(
+            int_seek.bytes,
+            42i32.to_be_bytes().to_vec(),
+            "a BigInt literal on an int pk must encode to the 4-byte int key (roborev 3784)",
+        );
+        assert_eq!(int_seek.bytes.len(), 4);
+    }
+
+    /// A literal that cannot be encoded for the pk's authoritative type (e.g. a text
+    /// literal against a `uuid` pk) DECLINES the seek → full-scan, never a
+    /// wrong-width key (roborev 3784 FINDING 2, correctness-first).
+    #[test]
+    fn classify_schemaless_point_lookup_declines_type_mismatch() {
+        let shape = simple_table_shape(); // uuid pk
+        let text_on_uuid = SSTablePredicate::column(
+            "id",
+            SSTableFilterOp::Equal,
+            vec![Value::Text("not-a-uuid".to_string())],
         );
         assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&text_pred), Some(&pk_shape)),
-            Some(b"k0".to_vec()),
+            classify_schemaless_point_lookup(std::slice::from_ref(&text_on_uuid), Some(&shape)),
+            None,
+            "a text literal on a uuid pk must decline (no provable key encoding)",
         );
     }
 
     /// Issue #1750 (the confirmed regression): a schema-less `WHERE <non_pk_col> =
     /// <literal>` must NOT take the by-key seek — the column is one of the
-    /// authoritative non-key names, so it can never be the partition key. Returning
-    /// `None` keeps the honest full-scan path, which correctly matches the
-    /// regular-column cell (the by-key seek would seek a nonexistent partition and
-    /// return 0 rows — the 1→0 over-firing this fix removes).
+    /// authoritative non-key names, so it can never be the partition key.
     #[test]
     fn classify_schemaless_point_lookup_rejects_non_pk_column_equality() {
         let shape = simple_table_shape();
@@ -166,24 +285,23 @@ mod tests {
         assert_eq!(
             classify_schemaless_point_lookup(std::slice::from_ref(&name_eq), Some(&shape)),
             None,
-            "a regular-column equality must NOT take the pk-key seek (would return 0 rows); \
-             it must full-scan and match the cell",
+            "a regular-column equality must NOT take the pk-key seek; it must full-scan",
         );
     }
 
     /// The seek must NOT fire when the shape shows a composite pk or any clustering
-    /// key — a single raw value can't be the whole point key there — nor when the
-    /// authoritative shape is unavailable (`None`): both keep the full-scan path.
+    /// key, when the pk type is absent, nor when the shape is unavailable (`None`).
     #[test]
     fn classify_schemaless_point_lookup_requires_single_component_point_shape() {
         let value = vec![Value::Uuid([1u8; 16])];
         let pred = SSTablePredicate::column("id", SSTableFilterOp::Equal, value);
 
-        // Composite partition key.
+        // Composite partition key (no single-component type).
         let composite = PartitionKeyShape {
             partition_key_count: 2,
             clustering_key_count: 0,
             non_key_column_names: Default::default(),
+            single_pk_component: None,
         };
         assert_eq!(
             classify_schemaless_point_lookup(std::slice::from_ref(&pred), Some(&composite)),
@@ -195,9 +313,25 @@ mod tests {
             partition_key_count: 1,
             clustering_key_count: 1,
             non_key_column_names: Default::default(),
+            single_pk_component: Some(PartitionKeyComponent {
+                name: "id".to_string(),
+                cql_type: "uuid".to_string(),
+            }),
         };
         assert_eq!(
             classify_schemaless_point_lookup(std::slice::from_ref(&pred), Some(&clustered)),
+            None,
+        );
+
+        // Single-component shape but no provable pk type → decline (correctness).
+        let no_type = PartitionKeyShape {
+            partition_key_count: 1,
+            clustering_key_count: 0,
+            non_key_column_names: Default::default(),
+            single_pk_component: None,
+        };
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&pred), Some(&no_type)),
             None,
         );
 
@@ -210,8 +344,7 @@ mod tests {
 
     /// Issue #1750: the schema-less classifier must NOT fire on any non-point
     /// shape — no predicate, a range, an `IN`, multiple predicates, a token
-    /// predicate, or an unencodable value — so those keep the honest full-scan
-    /// path (never a wrong targeted read), even on a confirmed single-pk table.
+    /// predicate, or an unencodable value.
     #[test]
     fn classify_schemaless_point_lookup_rejects_non_point_shapes() {
         let shape = simple_table_shape();
@@ -264,5 +397,80 @@ mod tests {
             classify_schemaless_point_lookup(std::slice::from_ref(&blob), s),
             None
         );
+    }
+
+    fn scan_row(cells: &[(&str, Value)]) -> ScanRow {
+        ScanRow::Row(
+            cells
+                .iter()
+                .map(|(n, v)| (Arc::<str>::from(*n), v.clone()))
+                .collect(),
+        )
+    }
+
+    /// roborev 3784 FINDING 1: the post-seek guard re-evaluates the predicate. A
+    /// `WHERE <pk_name> = <value>` matches the reconstructed pk column and returns
+    /// the row; a `WHERE <nonexistent_col> = <value>` (admitted by elimination) is
+    /// Unknown against the materialised row and yields 0 rows.
+    #[test]
+    fn finalize_seek_row_guards_on_reconstructed_pk() {
+        // int pk = 42, one regular col `v`.
+        let seek = SchemalessPointSeek {
+            bytes: 42i32.to_be_bytes().to_vec(),
+            pk_name: "partition_key".to_string(),
+            pk_cql_type: "int".to_string(),
+        };
+        let key = RowKey::new(42i32.to_be_bytes().to_vec());
+        let value = scan_row(&[("v", Value::Text("hi".to_string()))]);
+
+        // Predicate on the pk name → matches → row returned, pk reconstructed.
+        let pk_pred = vec![Pred::column(
+            "partition_key",
+            SSTableFilterOp::Equal,
+            vec![Value::BigInt(42)],
+        )];
+        let row: QueryRow =
+            finalize_schemaless_seek_row(key.clone(), value.clone(), &[], &pk_pred, &seek)
+                .expect("pk-name predicate must match the reconstructed row");
+        assert_eq!(row.values.get("partition_key"), Some(&Value::Integer(42)));
+        assert_eq!(row.values.get("v"), Some(&Value::Text("hi".to_string())));
+
+        // Predicate on a nonexistent column → Unknown against the materialised row
+        // → row REJECTED (the FINDING 1 over-firing this removes).
+        let bogus_pred = vec![Pred::column(
+            "not_a_column",
+            SSTableFilterOp::Equal,
+            vec![Value::BigInt(42)],
+        )];
+        assert!(
+            finalize_schemaless_seek_row(key, value, &[], &bogus_pred, &seek).is_none(),
+            "a nonexistent predicate column must yield 0 rows post-seek (roborev 3784 FINDING 1)",
+        );
+    }
+
+    /// The projection is honoured for output: the pk is reconstructed for the guard
+    /// but dropped from the row when the projection excludes it.
+    #[test]
+    fn finalize_seek_row_honours_projection_for_output() {
+        let seek = SchemalessPointSeek {
+            bytes: 7i32.to_be_bytes().to_vec(),
+            pk_name: "partition_key".to_string(),
+            pk_cql_type: "int".to_string(),
+        };
+        let key = RowKey::new(7i32.to_be_bytes().to_vec());
+        let value = scan_row(&[("v", Value::Text("x".to_string()))]);
+        let pk_pred = vec![Pred::column(
+            "partition_key",
+            SSTableFilterOp::Equal,
+            vec![Value::BigInt(7)],
+        )];
+        // Projection = [v] only → pk used for the guard, then dropped from output.
+        let row = finalize_schemaless_seek_row(key, value, &["v".to_string()], &pk_pred, &seek)
+            .expect("row passes the guard");
+        assert!(
+            !row.values.contains_key("partition_key"),
+            "pk excluded from projection must not appear in output",
+        );
+        assert_eq!(row.values.get("v"), Some(&Value::Text("x".to_string())));
     }
 }

--- a/cqlite-core/src/query/select_executor/schemaless_point.rs
+++ b/cqlite-core/src/query/select_executor/schemaless_point.rs
@@ -4,6 +4,30 @@
 //! classifier file does not grow. This holds ONLY the structural schema-less
 //! point-read recogniser + its single-component key encoder; the schema-aware
 //! `classify_partition_lookup` stays in `lookup.rs`.
+//!
+//! # Known schemaless-seek limitations (tracked in #TBD)
+//!
+//! These are ACCEPTED limitations of the schema-less single-component seek path.
+//! Each is fail-SAFE (it yields the correct 0 rows or declines to a full scan, never
+//! a wrong non-empty answer) and none is fixed here — they are documented so the
+//! follow-up issue and the next reader are grounded:
+//!
+//! 1. **WRITETIME()/TTL() projection + schemaless pk read → 0 rows.** When a
+//!    `WHERE pk = <lit>` also projects cell metadata (WRITETIME/TTL), the seek path
+//!    is NOT taken (`execute.rs` gates it on `!include_cell_metadata`) and the
+//!    metadata full-scan cannot reconstruct the partition-key column schema-less, so
+//!    the post-scan predicate backstop rejects every row → 0 rows
+//!    (`execute.rs:465`).
+//! 2. **Post-seek guard false-negative for a TIMESTAMP pk (and any seek-firing type
+//!    outside the numeric `values_equal`/`as_f64` set) with a numeric literal.** The
+//!    seek finds the partition, but the post-seek guard's
+//!    `values_equal(Timestamp, BigInt)` is `false`, so the valid row is rejected →
+//!    0 rows. The seek still self-verifies on the raw key bytes, so this is a
+//!    false-negative (0 rows), never a wrong row.
+//! 3. **`coerce_value_for_comparator` has no Date/Varint/Decimal arm for numeric
+//!    literals — by design.** Those types decline via a serialize error rather than
+//!    risk a wrong-width key, so a `WHERE date_pk = <numeric_lit>` full-scans (safe)
+//!    instead of taking the typed seek.
 
 use super::super::select_optimizer::SSTablePredicate;
 use crate::storage::sstable::PartitionKeyShape;

--- a/cqlite-core/src/query/select_executor/schemaless_point.rs
+++ b/cqlite-core/src/query/select_executor/schemaless_point.rs
@@ -6,32 +6,44 @@
 //! `classify_partition_lookup` stays in `lookup.rs`.
 
 use super::super::select_optimizer::SSTablePredicate;
+use crate::storage::sstable::PartitionKeyShape;
 use crate::types::Value;
 
-/// Structurally classify a SCHEMA-LESS point read (issue #1750 regression fix).
+/// Classify a SCHEMA-LESS point read against AUTHORITATIVE partition-key metadata
+/// (issue #1750 regression fix, then re-scoped to stop over-firing).
 ///
 /// When NO schema is available, `classify_partition_lookup` can only report
-/// `NoSchema` and fall back to a full scan. But a schema-less full scan CANNOT
-/// reconstruct the partition-key column (Cassandra never serialises it in the
-/// cell payload, and `build_row_from_scan` needs the schema to decode it from the
-/// row key), so a `WHERE pk = <literal>` predicate then rejects EVERY row in the
-/// post-scan backstop — the read returns 0 rows. Before #1750 retired the
-/// `is_simple_id_lookup` fork, such a read routed to the legacy `QueryExecutor`,
-/// which looked the partition up BY KEY BYTES via `storage.get()` and never
-/// re-evaluated the predicate, so it returned the row.
+/// `NoSchema` and fall back to a full scan. For a `WHERE pk = <literal>` that scan
+/// CANNOT reconstruct the partition-key column (Cassandra never serialises the pk
+/// column value in the cell payload, and `build_row_from_scan` needs the schema to
+/// decode it from the row key), so the post-scan predicate backstop rejects EVERY
+/// row and the read returns 0 rows. Serving such a read by a key-byte-targeted seek
+/// (which never re-evaluates the predicate) fixes that — but ONLY when the equality
+/// column really is the partition key. A `WHERE <regular_col> = <literal>` seeks a
+/// nonexistent partition and returns 0 rows, whereas a full scan correctly matches
+/// the regular-column cell (regular cells ARE decodable schema-less). So the
+/// targeted seek must fire ONLY for a metadata-CONFIRMED partition-key equality.
 ///
-/// This restores that behaviour WITHOUT any text heuristic: the decision is made
-/// purely from the parsed predicate STRUCTURE. It returns the on-disk key bytes
-/// for a targeted lookup ONLY when the predicates are EXACTLY a single non-token
-/// `column = <literal>` equality — the unambiguous single-component point-read
-/// shape a schema-less reader can serve by encoding the literal to raw key bytes
-/// (the same single-component encoding `RowKey`/the write engine use). Any other
-/// shape (no predicate, a range/`IN`, multiple predicates, a token predicate, or a
-/// value that has no single-component key encoding) returns `None` so the caller
-/// keeps the honest full-scan path. The targeted read is self-verifying: the
-/// storage seek only returns rows whose raw partition key equals these bytes, so
-/// a wrong/absent key yields no rows — never another partition's rows.
-pub(super) fn classify_schemaless_point_lookup(predicates: &[SSTablePredicate]) -> Option<Vec<u8>> {
+/// The confirmation is by ELIMINATION from authoritative metadata (the Statistics.db
+/// SerializationHeader, [`PartitionKeyShape`]) — NEVER a text/name guess (#28).
+/// Cassandra does not serialise the pk column NAME, but the header authoritatively
+/// gives the pk-component count, the clustering-key count, and the REAL names of the
+/// non-key columns. The seek fires ONLY when:
+///   * the predicates are EXACTLY one non-token single-value `column = <literal>`,
+///   * the value has an unambiguous single-component key encoding,
+///   * the table has exactly ONE partition-key component and ZERO clustering keys
+///     (a single-component point key), AND
+///   * the predicate column is ABSENT from the authoritative non-key column names —
+///     so it can ONLY be the sole partition key.
+///
+/// Any other shape — or a `shape` we could not resolve (`None`) — returns `None`, so
+/// the caller keeps the honest full-scan path (correct for regular-column equalities
+/// and safe when metadata is unavailable). The targeted read is self-verifying: the
+/// storage seek only returns rows whose raw partition key equals these bytes.
+pub(super) fn classify_schemaless_point_lookup(
+    predicates: &[SSTablePredicate],
+    shape: Option<&PartitionKeyShape>,
+) -> Option<Vec<u8>> {
     use super::super::select_optimizer::SSTableFilterOp;
 
     // Exactly one predicate, a non-token single-value equality.
@@ -44,6 +56,19 @@ pub(super) fn classify_schemaless_point_lookup(predicates: &[SSTablePredicate]) 
     let [value] = predicate.values.as_slice() else {
         return None;
     };
+
+    // Metadata-confirm the predicate column is the SOLE partition key by
+    // elimination — a single-component pk, no clustering keys, and the column is
+    // NOT one of the authoritative non-key column names. Without a resolvable
+    // shape we cannot confirm, so we do NOT seek (full-scan stays correct).
+    let shape = shape?;
+    let is_confirmed_sole_pk = shape.partition_key_count == 1
+        && shape.clustering_key_count == 0
+        && !shape.non_key_column_names.contains(&predicate.column);
+    if !is_confirmed_sole_pk {
+        return None;
+    }
+
     encode_single_component_key(value)
 }
 
@@ -71,54 +96,134 @@ mod tests {
     use super::super::super::select_optimizer::{SSTableFilterOp, SSTablePredicate};
     use super::*;
 
-    /// Issue #1750 (regression fix): the schema-less point-lookup classifier
-    /// recognises EXACTLY the single non-token `col = <single-component literal>`
-    /// shape and returns its raw on-disk key bytes, so a schema-less `WHERE pk =
-    /// <uuid>` can be served by a key-byte-targeted seek (never returning 0 rows
-    /// because the schema-less scan can't reconstruct the pk column). The decision
-    /// is structural — never a text guess.
+    /// A single-component-pk, no-clustering table whose only non-key column is
+    /// `name` — mirrors `test_basic.simple_table` (`id UUID` pk, `name TEXT`).
+    fn simple_table_shape() -> PartitionKeyShape {
+        PartitionKeyShape {
+            partition_key_count: 1,
+            clustering_key_count: 0,
+            non_key_column_names: ["name".to_string(), "age".to_string()]
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    /// Issue #1750 (regression fix): a schema-less `col = <literal>` whose column is
+    /// a metadata-CONFIRMED sole partition key (single pk component, no clustering
+    /// keys, column absent from the authoritative non-key names) yields its raw
+    /// single-component key bytes for a targeted seek. The confirmation is by
+    /// elimination from authoritative metadata — never a pk-name/text guess.
     #[test]
-    fn classify_schemaless_point_lookup_targets_single_equality() {
+    fn classify_schemaless_point_lookup_targets_confirmed_pk_equality() {
+        let shape = simple_table_shape();
         let uuid = [7u8; 16];
         let predicate =
             SSTablePredicate::column("id", SSTableFilterOp::Equal, vec![Value::Uuid(uuid)]);
         assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&predicate)),
+            classify_schemaless_point_lookup(std::slice::from_ref(&predicate), Some(&shape)),
             Some(uuid.to_vec()),
-            "a single UUID `=` must yield the raw 16-byte single-component key",
+            "a single UUID `=` on the confirmed pk must yield the raw 16-byte key",
         );
 
-        // int / text single-component encodings.
+        // int / text single-component encodings (pk column named `pk`, absent from
+        // the non-key names, so confirmed by elimination).
+        let pk_shape = PartitionKeyShape {
+            partition_key_count: 1,
+            clustering_key_count: 0,
+            non_key_column_names: ["v".to_string()].into_iter().collect(),
+        };
         let int_pred =
-            SSTablePredicate::column("id", SSTableFilterOp::Equal, vec![Value::Integer(42)]);
+            SSTablePredicate::column("pk", SSTableFilterOp::Equal, vec![Value::Integer(42)]);
         assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&int_pred)),
+            classify_schemaless_point_lookup(std::slice::from_ref(&int_pred), Some(&pk_shape)),
             Some(42i32.to_be_bytes().to_vec()),
         );
         let text_pred = SSTablePredicate::column(
-            "id",
+            "pk",
             SSTableFilterOp::Equal,
             vec![Value::Text("k0".to_string())],
         );
         assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&text_pred)),
+            classify_schemaless_point_lookup(std::slice::from_ref(&text_pred), Some(&pk_shape)),
             Some(b"k0".to_vec()),
+        );
+    }
+
+    /// Issue #1750 (the confirmed regression): a schema-less `WHERE <non_pk_col> =
+    /// <literal>` must NOT take the by-key seek — the column is one of the
+    /// authoritative non-key names, so it can never be the partition key. Returning
+    /// `None` keeps the honest full-scan path, which correctly matches the
+    /// regular-column cell (the by-key seek would seek a nonexistent partition and
+    /// return 0 rows — the 1→0 over-firing this fix removes).
+    #[test]
+    fn classify_schemaless_point_lookup_rejects_non_pk_column_equality() {
+        let shape = simple_table_shape();
+        let name_eq = SSTablePredicate::column(
+            "name",
+            SSTableFilterOp::Equal,
+            vec![Value::Text("Mr. James Hoffman".to_string())],
+        );
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&name_eq), Some(&shape)),
+            None,
+            "a regular-column equality must NOT take the pk-key seek (would return 0 rows); \
+             it must full-scan and match the cell",
+        );
+    }
+
+    /// The seek must NOT fire when the shape shows a composite pk or any clustering
+    /// key — a single raw value can't be the whole point key there — nor when the
+    /// authoritative shape is unavailable (`None`): both keep the full-scan path.
+    #[test]
+    fn classify_schemaless_point_lookup_requires_single_component_point_shape() {
+        let value = vec![Value::Uuid([1u8; 16])];
+        let pred = SSTablePredicate::column("id", SSTableFilterOp::Equal, value);
+
+        // Composite partition key.
+        let composite = PartitionKeyShape {
+            partition_key_count: 2,
+            clustering_key_count: 0,
+            non_key_column_names: Default::default(),
+        };
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&pred), Some(&composite)),
+            None,
+        );
+
+        // Has clustering keys (the equality alone doesn't pin a full point key).
+        let clustered = PartitionKeyShape {
+            partition_key_count: 1,
+            clustering_key_count: 1,
+            non_key_column_names: Default::default(),
+        };
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&pred), Some(&clustered)),
+            None,
+        );
+
+        // No authoritative shape → cannot confirm → full-scan.
+        assert_eq!(
+            classify_schemaless_point_lookup(std::slice::from_ref(&pred), None),
+            None,
         );
     }
 
     /// Issue #1750: the schema-less classifier must NOT fire on any non-point
     /// shape — no predicate, a range, an `IN`, multiple predicates, a token
     /// predicate, or an unencodable value — so those keep the honest full-scan
-    /// path (never a wrong targeted read).
+    /// path (never a wrong targeted read), even on a confirmed single-pk table.
     #[test]
     fn classify_schemaless_point_lookup_rejects_non_point_shapes() {
+        let shape = simple_table_shape();
+        let s = Some(&shape);
+
         // No predicate (bare SELECT *).
-        assert_eq!(classify_schemaless_point_lookup(&[]), None);
+        assert_eq!(classify_schemaless_point_lookup(&[], s), None);
 
         // A range restriction.
         let range = SSTablePredicate::column("id", SSTableFilterOp::Gt, vec![Value::Integer(1)]);
         assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&range)),
+            classify_schemaless_point_lookup(std::slice::from_ref(&range), s),
             None
         );
 
@@ -129,14 +234,14 @@ mod tests {
             vec![Value::Integer(1), Value::Integer(2)],
         );
         assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&in_pred)),
+            classify_schemaless_point_lookup(std::slice::from_ref(&in_pred), s),
             None
         );
 
         // Two predicates (pk + clustering) — ambiguous without a schema.
         let a = SSTablePredicate::column("pk", SSTableFilterOp::Equal, vec![Value::Integer(1)]);
         let b = SSTablePredicate::column("ck", SSTableFilterOp::Equal, vec![Value::Integer(2)]);
-        assert_eq!(classify_schemaless_point_lookup(&[a, b]), None);
+        assert_eq!(classify_schemaless_point_lookup(&[a, b], s), None);
 
         // A token predicate is never a real partition-key column.
         let tok = SSTablePredicate::token(
@@ -145,7 +250,7 @@ mod tests {
             vec![Value::BigInt(5)],
         );
         assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&tok)),
+            classify_schemaless_point_lookup(std::slice::from_ref(&tok), s),
             None
         );
 
@@ -156,7 +261,7 @@ mod tests {
             vec![Value::Blob(vec![1, 2, 3])],
         );
         assert_eq!(
-            classify_schemaless_point_lookup(std::slice::from_ref(&blob)),
+            classify_schemaless_point_lookup(std::slice::from_ref(&blob), s),
             None
         );
     }

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -366,6 +366,21 @@ impl StorageEngine {
             .await
     }
 
+    /// Resolve the AUTHORITATIVE partition-key shape for `table_id` from the
+    /// SSTable Statistics.db SerializationHeader (issue #1750).
+    ///
+    /// Used by the SCHEMA-LESS point-read classifier to confirm — from authoritative
+    /// metadata, never a synthesised pk name — that a `col = <literal>` predicate
+    /// column really is the sole partition key before taking a by-key seek. Returns
+    /// `None` when no reader exposes a SerializationHeader; delegates to
+    /// [`SSTableManager::partition_key_shape`].
+    pub async fn partition_key_shape(
+        &self,
+        table_id: &TableId,
+    ) -> Option<sstable::PartitionKeyShape> {
+        self.sstables.partition_key_shape(table_id).await
+    }
+
     /// Clustering-slice-aware partition-targeted scan (Issue #954, Epic #951).
     ///
     /// Like [`scan_partition`](Self::scan_partition) but pushes a single-column

--- a/cqlite-core/src/storage/partition_key_codec.rs
+++ b/cqlite-core/src/storage/partition_key_codec.rs
@@ -150,6 +150,26 @@ pub fn encode_partition_key_columns(values: &[Value], schema: &TableSchema) -> R
     Ok(result)
 }
 
+/// Encode a single scalar `Value` to the raw single-component on-disk
+/// partition-key bytes for a KNOWN CQL type (issue #1750, roborev 3784).
+///
+/// This is the schema-less counterpart of [`encode_partition_key_columns`] for a
+/// one-component key: it drives the SAME typed coercion + serializer, so a parsed
+/// SELECT literal (which the parser widens to `Value::BigInt` for every integer)
+/// encodes to the WIDTH Cassandra actually wrote — an `int` partition key is 4
+/// bytes, `bigint` 8, `uuid` 16, `text` raw UTF-8, etc. It exists because a
+/// schema-less point read has no `TableSchema`, only the authoritative pk TYPE
+/// from the Statistics.db SerializationHeader.
+///
+/// Returns an error (so the caller declines the targeted seek and full-scans)
+/// when `cql_type` is unparseable or the literal cannot be serialized for it —
+/// never a possibly-wrong-width key (correctness first, no-heuristics #28).
+pub fn encode_single_component_key_typed(value: &Value, cql_type: &str) -> Result<Vec<u8>> {
+    let comparator = ComparatorType::from_data_type(cql_type)?;
+    let coerced = coerce_value_for_comparator(value, &comparator);
+    serialize_value_bytes(&coerced, &comparator)
+}
+
 /// Best-effort coercion of a parsed CQL literal `Value` to the variant the
 /// partition-key serializer expects for `comparator`.
 ///

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -143,6 +143,115 @@ pub struct PartitionKeyComponent {
     pub cql_type: String,
 }
 
+/// Resolve the AUTHORITATIVE [`PartitionKeyShape`] by UNIONing the non-key column
+/// names across EVERY reader's SerializationHeader while requiring CONSISTENT key
+/// metadata (issue #1750, roborev 3786).
+///
+/// This is the pure core of [`SSTableManager::partition_key_shape`], factored out so
+/// the multi-reader union + consistency logic is unit-testable without SSTable
+/// binaries. `headers` is one `&[ColumnInfo]` per resolved reader for the table (an
+/// empty or non-header reader contributes nothing).
+///
+/// A multi-generation / schema-evolved table can add a REGULAR column in a LATER
+/// generation absent from an earlier generation's header. Using only the first
+/// header would omit that column from the non-key name set, so a
+/// `WHERE <later-gen-regular-col> = <val>` could be MISCLASSIFIED as a partition-key
+/// seek. To prevent that, the non-key names are UNIONed across all headers, and the
+/// partition-key count, clustering-key count, and single-component pk type+name must
+/// agree across every header that has partition-key columns.
+///
+/// Returns `None` when no header exposes a partition-key column (fail-safe: caller
+/// full-scans) OR when the headers' key metadata is INCONSISTENT (pk-count /
+/// clustering-count / single-pk type+name disagreement — should never happen for one
+/// table, but if it did we cannot trust the shape). All facts come from
+/// SerializationHeaders — no heuristics (#28).
+fn partition_key_shape_from_headers<'a>(
+    headers: impl IntoIterator<Item = &'a [crate::parser::header::ColumnInfo]>,
+) -> Option<PartitionKeyShape> {
+    // Key metadata the first header-bearing reader established; every subsequent
+    // header MUST match it or the whole shape is declined (inconsistent → None).
+    struct AgreedKeyShape {
+        partition_key_count: usize,
+        clustering_key_count: usize,
+        single_pk_component: Option<PartitionKeyComponent>,
+    }
+    let mut agreed: Option<AgreedKeyShape> = None;
+    let mut non_key_column_names = std::collections::HashSet::new();
+
+    for columns in headers {
+        if columns.is_empty() {
+            continue;
+        }
+        let mut partition_key_count = 0usize;
+        let mut clustering_key_count = 0usize;
+        // The sole partition-key component's authoritative CQL type + header-
+        // synthesised name (issue #1750, roborev 3784). Recorded for the FIRST pk
+        // column seen in THIS header; only surfaced when the pk is single-component.
+        // Cassandra serialises pk TYPES (authoritative) but not NAMES (`name` is a
+        // placeholder used only for pk reconstruction).
+        let mut first_pk_component: Option<PartitionKeyComponent> = None;
+        for col in columns {
+            match (col.is_primary_key, col.is_clustering) {
+                (true, false) => {
+                    if first_pk_component.is_none() {
+                        first_pk_component = Some(PartitionKeyComponent {
+                            name: col.name.clone(),
+                            cql_type: col.column_type.clone(),
+                        });
+                    }
+                    partition_key_count += 1;
+                }
+                (true, true) => clustering_key_count += 1,
+                (false, _) => {
+                    // Union non-key names across ALL readers (roborev 3786): a
+                    // regular column present only in a later generation must be
+                    // recognised, else it could be misread as the partition key.
+                    non_key_column_names.insert(col.name.clone());
+                }
+            }
+        }
+        // A SerializationHeader always names at least one partition-key component;
+        // skip a header we could not populate schema-less (e.g. legacy formats with
+        // no Statistics.db columns) rather than record a bogus all-zero shape.
+        if partition_key_count == 0 {
+            continue;
+        }
+        // The typed single-component pk type is authoritative ONLY for a single-
+        // component key; drop it for a composite pk (that fast path does not apply
+        // and a composite key isn't one raw value).
+        let single_pk_component = (partition_key_count == 1)
+            .then_some(first_pk_component)
+            .flatten();
+
+        match &agreed {
+            None => {
+                agreed = Some(AgreedKeyShape {
+                    partition_key_count,
+                    clustering_key_count,
+                    single_pk_component,
+                });
+            }
+            Some(prev) => {
+                // Require CONSISTENT key metadata across readers; any disagreement
+                // means we cannot trust the shape → decline (#28).
+                if prev.partition_key_count != partition_key_count
+                    || prev.clustering_key_count != clustering_key_count
+                    || prev.single_pk_component != single_pk_component
+                {
+                    return None;
+                }
+            }
+        }
+    }
+
+    agreed.map(|shape| PartitionKeyShape {
+        partition_key_count: shape.partition_key_count,
+        clustering_key_count: shape.clustering_key_count,
+        non_key_column_names,
+        single_pk_component: shape.single_pk_component,
+    })
+}
+
 /// SSTable file identifier
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SSTableId(pub String);
@@ -1761,61 +1870,26 @@ impl SSTableManager {
     /// non-key column names. The caller confirms a predicate column is the sole
     /// partition key BY ELIMINATION (single pk component, zero clustering keys, and
     /// the column absent from the non-key name set) — never by the synthesised name.
-    /// Returns `None` when no reader for the table exposes a SerializationHeader
-    /// (fail-safe: the caller then keeps the honest full-scan path).
+    ///
+    /// The shape is resolved across ALL readers serving the table, not just the
+    /// first (issue #1750, roborev 3786). A multi-generation / schema-evolved table
+    /// can add a REGULAR column in a LATER generation that is absent from an earlier
+    /// generation's header. Consulting only the first reader would MISS that column
+    /// from the non-key name set, so a `WHERE <later-gen-regular-col> = <val>` could
+    /// be MISCLASSIFIED as a partition-key seek. To prevent that:
+    ///   * the non-key column names are UNIONed across every reader's header, and
+    ///   * the partition-key count, clustering-key count, and the single-component
+    ///     pk type+name must be CONSISTENT across all readers with a header.
+    ///
+    /// Returns `None` when no reader for the table exposes a SerializationHeader OR
+    /// when the readers' key metadata is INCONSISTENT (a pk-count / clustering-count
+    /// / single-pk type+name disagreement — which should never happen for one table
+    /// but, if it did, means we cannot trust the shape). Both are fail-safe: the
+    /// caller then keeps the honest full-scan path (all from SerializationHeaders,
+    /// no heuristics — #28).
     pub async fn partition_key_shape(&self, table_id: &TableId) -> Option<PartitionKeyShape> {
         let (readers, _) = self.resolve_reader_snapshot(table_id).await;
-        for reader in &readers {
-            let columns = &reader.header().columns;
-            if columns.is_empty() {
-                continue;
-            }
-            let mut partition_key_count = 0usize;
-            let mut clustering_key_count = 0usize;
-            let mut non_key_column_names = std::collections::HashSet::new();
-            // Capture the sole partition-key component's authoritative CQL type +
-            // header-synthesised name (issue #1750, roborev 3784). Recorded for the
-            // FIRST pk column seen; only surfaced below when the pk really is
-            // single-component. Cassandra serialises pk TYPES (authoritative) but not
-            // NAMES (`name` is a placeholder used only for pk-column reconstruction).
-            let mut first_pk_component: Option<PartitionKeyComponent> = None;
-            for col in columns {
-                match (col.is_primary_key, col.is_clustering) {
-                    (true, false) => {
-                        if first_pk_component.is_none() {
-                            first_pk_component = Some(PartitionKeyComponent {
-                                name: col.name.clone(),
-                                cql_type: col.column_type.clone(),
-                            });
-                        }
-                        partition_key_count += 1;
-                    }
-                    (true, true) => clustering_key_count += 1,
-                    (false, _) => {
-                        non_key_column_names.insert(col.name.clone());
-                    }
-                }
-            }
-            // A SerializationHeader always names at least one partition-key
-            // component; require it so a header we could not populate schema-less
-            // (e.g. legacy formats with no Statistics.db columns) yields `None`
-            // rather than a bogus all-zero shape.
-            if partition_key_count > 0 {
-                // The typed single-component pk type is authoritative ONLY for a
-                // single-component key; drop it for a composite pk (that fast path
-                // does not apply and a composite key isn't one raw value).
-                let single_pk_component = (partition_key_count == 1)
-                    .then_some(first_pk_component)
-                    .flatten();
-                return Some(PartitionKeyShape {
-                    partition_key_count,
-                    clustering_key_count,
-                    non_key_column_names,
-                    single_pk_component,
-                });
-            }
-        }
-        None
+        partition_key_shape_from_headers(readers.iter().map(|r| r.header().columns.as_slice()))
     }
 
     /// Arm this manager's deterministic scan gate (issue #1591 test only).
@@ -2946,5 +3020,122 @@ mod tests {
             out.recv().await.is_none(),
             "no items after the terminal error"
         );
+    }
+
+    // ---- partition_key_shape_from_headers: multi-generation union (roborev 3786) ----
+
+    /// Build a minimal `ColumnInfo` for the shape-resolution unit tests.
+    fn col(
+        name: &str,
+        cql_type: &str,
+        is_primary_key: bool,
+        is_clustering: bool,
+    ) -> crate::parser::header::ColumnInfo {
+        crate::parser::header::ColumnInfo {
+            name: name.to_string(),
+            column_type: cql_type.to_string(),
+            is_primary_key,
+            key_position: None,
+            is_static: false,
+            is_clustering,
+            clustering_reversed: false,
+        }
+    }
+
+    /// roborev 3786: a REGULAR column present ONLY in a LATER generation must land in
+    /// the UNIONed non-key name set, so a `WHERE <later-gen-regular-col> = <val>` is
+    /// NOT misclassified as a partition-key seek. Two headers, single-component `int`
+    /// pk, zero clustering: gen-1 has `v1`, gen-2 adds `v2`.
+    #[test]
+    fn partition_key_shape_unions_later_generation_regular_column() {
+        let gen1 = vec![
+            col("partition_key", "int", true, false),
+            col("v1", "text", false, false),
+        ];
+        let gen2 = vec![
+            col("partition_key", "int", true, false),
+            col("v1", "text", false, false),
+            col("v2", "text", false, false),
+        ];
+        let shape = partition_key_shape_from_headers([gen1.as_slice(), gen2.as_slice()])
+            .expect("consistent headers must resolve a shape");
+        assert_eq!(shape.partition_key_count, 1);
+        assert_eq!(shape.clustering_key_count, 0);
+        // The later-generation regular column IS in the unioned non-key set — so the
+        // classifier's by-elimination check will NOT treat it as the partition key.
+        assert!(
+            shape.non_key_column_names.contains("v2"),
+            "later-gen regular column must be in the unioned non-key set (roborev 3786)",
+        );
+        assert!(shape.non_key_column_names.contains("v1"));
+        assert_eq!(
+            shape
+                .single_pk_component
+                .as_ref()
+                .map(|c| c.cql_type.as_str()),
+            Some("int"),
+        );
+
+        // The misclassification the fix prevents: had we used only gen-1, `v2` would
+        // be absent from the non-key set and thus admitted by elimination as the pk.
+        let gen1_only =
+            partition_key_shape_from_headers([gen1.as_slice()]).expect("single header resolves");
+        assert!(
+            !gen1_only.non_key_column_names.contains("v2"),
+            "gen-1 alone MISSES v2 — this is exactly the multi-gen bug the union fixes",
+        );
+    }
+
+    /// Inconsistent key metadata across readers (a pk-count disagreement) declines
+    /// the shape → `None` → the caller full-scans (fail-safe, no heuristics).
+    #[test]
+    fn partition_key_shape_declines_inconsistent_readers() {
+        // gen-1: single-component pk; gen-2: composite (2-component) pk.
+        let single = vec![
+            col("pk", "int", true, false),
+            col("v", "text", false, false),
+        ];
+        let composite = vec![
+            col("pk_a", "int", true, false),
+            col("pk_b", "int", true, false),
+            col("v", "text", false, false),
+        ];
+        assert_eq!(
+            partition_key_shape_from_headers([single.as_slice(), composite.as_slice()]),
+            None,
+            "a pk-count disagreement across readers must decline (→ full-scan)",
+        );
+
+        // A clustering-count disagreement likewise declines.
+        let clustered = vec![
+            col("pk", "int", true, false),
+            col("ck", "int", true, true),
+            col("v", "text", false, false),
+        ];
+        assert_eq!(
+            partition_key_shape_from_headers([single.as_slice(), clustered.as_slice()]),
+            None,
+            "a clustering-count disagreement across readers must decline",
+        );
+
+        // A single-pk TYPE disagreement declines too.
+        let single_bigint = vec![
+            col("pk", "bigint", true, false),
+            col("v", "text", false, false),
+        ];
+        assert_eq!(
+            partition_key_shape_from_headers([single.as_slice(), single_bigint.as_slice()]),
+            None,
+            "a single-pk type disagreement across readers must decline",
+        );
+    }
+
+    /// No header with a partition-key column → `None` (fail-safe). An empty header is
+    /// skipped, not treated as a zero-key shape.
+    #[test]
+    fn partition_key_shape_none_without_usable_header() {
+        assert_eq!(partition_key_shape_from_headers(std::iter::empty()), None);
+        let empty: Vec<crate::parser::header::ColumnInfo> = vec![];
+        assert_eq!(partition_key_shape_from_headers([empty.as_slice()]), None);
     }
 }

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -116,6 +116,31 @@ pub struct PartitionKeyShape {
     pub clustering_key_count: usize,
     /// The real names of the non-key (regular + static) columns.
     pub non_key_column_names: std::collections::HashSet<String>,
+    /// For a single-component pk ONLY: the sole partition-key column's authoritative
+    /// CQL type (from the SerializationHeader `keyType`) and its header-carried name.
+    ///
+    /// The CQL type is authoritative — Cassandra serialises partition-key TYPES even
+    /// though it never serialises their NAMES (issue #1750, roborev 3784). It drives
+    /// the TYPED single-component key encoding so a schema-less `WHERE int_pk = 42`
+    /// builds the 4-byte `int` key Cassandra wrote, not an 8-byte `BigInt` key. The
+    /// `name` is the header's synthesised placeholder (`id` for uuid/timeuuid, else
+    /// `partition_key`) — NOT a trusted identity, only the label under which
+    /// `build_row_from_scan` reconstructs the pk column so the seeked row can be
+    /// re-validated against the predicate. `None` for a composite pk (the typed
+    /// single-component fast path does not apply) or when no reader exposed a
+    /// single-component pk type.
+    pub single_pk_component: Option<PartitionKeyComponent>,
+}
+
+/// The authoritative type + header-synthesised name of a single-component
+/// partition key (issue #1750, roborev 3784). See [`PartitionKeyShape`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionKeyComponent {
+    /// The header's synthesised pk column name (`id` / `partition_key`). NOT a
+    /// trusted identity — only a label for pk-column reconstruction.
+    pub name: String,
+    /// The authoritative CQL type of the pk component (from `keyType`).
+    pub cql_type: String,
 }
 
 /// SSTable file identifier
@@ -1748,9 +1773,23 @@ impl SSTableManager {
             let mut partition_key_count = 0usize;
             let mut clustering_key_count = 0usize;
             let mut non_key_column_names = std::collections::HashSet::new();
+            // Capture the sole partition-key component's authoritative CQL type +
+            // header-synthesised name (issue #1750, roborev 3784). Recorded for the
+            // FIRST pk column seen; only surfaced below when the pk really is
+            // single-component. Cassandra serialises pk TYPES (authoritative) but not
+            // NAMES (`name` is a placeholder used only for pk-column reconstruction).
+            let mut first_pk_component: Option<PartitionKeyComponent> = None;
             for col in columns {
                 match (col.is_primary_key, col.is_clustering) {
-                    (true, false) => partition_key_count += 1,
+                    (true, false) => {
+                        if first_pk_component.is_none() {
+                            first_pk_component = Some(PartitionKeyComponent {
+                                name: col.name.clone(),
+                                cql_type: col.column_type.clone(),
+                            });
+                        }
+                        partition_key_count += 1;
+                    }
                     (true, true) => clustering_key_count += 1,
                     (false, _) => {
                         non_key_column_names.insert(col.name.clone());
@@ -1762,10 +1801,17 @@ impl SSTableManager {
             // (e.g. legacy formats with no Statistics.db columns) yields `None`
             // rather than a bogus all-zero shape.
             if partition_key_count > 0 {
+                // The typed single-component pk type is authoritative ONLY for a
+                // single-component key; drop it for a composite pk (that fast path
+                // does not apply and a composite key isn't one raw value).
+                let single_pk_component = (partition_key_count == 1)
+                    .then_some(first_pk_component)
+                    .flatten();
                 return Some(PartitionKeyShape {
                     partition_key_count,
                     clustering_key_count,
                     non_key_column_names,
+                    single_pk_component,
                 });
             }
         }

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -99,6 +99,25 @@ use crate::{types::TableId, Config, Result, RowKey, ScanRow};
 /// so 3 levels provides a safety margin.
 pub(crate) const MAX_SSTABLE_SCAN_DEPTH: usize = 3;
 
+/// The AUTHORITATIVE partition-key shape of a table, derived schema-less from the
+/// SSTable Statistics.db SerializationHeader (issue #1750).
+///
+/// Carries ONLY facts Cassandra actually serialises: how many partition-key
+/// components and clustering keys the table has, and the REAL names of the
+/// non-key (regular + static) columns. The partition-/clustering-key column NAMES
+/// are deliberately absent — Cassandra never serialises them, so any pk-name a
+/// schema-less parser reports is a synthesised placeholder that must not drive
+/// routing decisions (no-heuristics mandate #28).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionKeyShape {
+    /// Number of partition-key components (a single-component pk is `1`).
+    pub partition_key_count: usize,
+    /// Number of clustering-key columns.
+    pub clustering_key_count: usize,
+    /// The real names of the non-key (regular + static) columns.
+    pub non_key_column_names: std::collections::HashSet<String>,
+}
+
 /// SSTable file identifier
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SSTableId(pub String);
@@ -1698,6 +1717,59 @@ impl SSTableManager {
             .unwrap_or_default();
         // Guard dropped here, before any reader I/O.
         (readers, fully_qualified_match)
+    }
+
+    /// Resolve the AUTHORITATIVE partition-key shape for `table_id` from the
+    /// SSTable readers' Statistics.db SerializationHeader (issue #1750).
+    ///
+    /// This is the metadata a schema-less reader DOES have without a CQL schema:
+    /// the SerializationHeader (surfaced on each reader's `header().columns`)
+    /// records, per column, the authoritative `is_primary_key` / `is_clustering`
+    /// flags and the REAL names of the regular + static (non-key) columns. It does
+    /// NOT record the partition-/clustering-key column NAMES — Cassandra never
+    /// serialises those (they live in `system_schema`, absent schema-less), so the
+    /// parser synthesises a placeholder pk name (`build_partition_key_columns`) that
+    /// MUST NOT be trusted as an identity.
+    ///
+    /// Returns [`PartitionKeyShape`] carrying ONLY authoritative facts: the count of
+    /// partition-key components, the count of clustering keys, and the set of real
+    /// non-key column names. The caller confirms a predicate column is the sole
+    /// partition key BY ELIMINATION (single pk component, zero clustering keys, and
+    /// the column absent from the non-key name set) — never by the synthesised name.
+    /// Returns `None` when no reader for the table exposes a SerializationHeader
+    /// (fail-safe: the caller then keeps the honest full-scan path).
+    pub async fn partition_key_shape(&self, table_id: &TableId) -> Option<PartitionKeyShape> {
+        let (readers, _) = self.resolve_reader_snapshot(table_id).await;
+        for reader in &readers {
+            let columns = &reader.header().columns;
+            if columns.is_empty() {
+                continue;
+            }
+            let mut partition_key_count = 0usize;
+            let mut clustering_key_count = 0usize;
+            let mut non_key_column_names = std::collections::HashSet::new();
+            for col in columns {
+                match (col.is_primary_key, col.is_clustering) {
+                    (true, false) => partition_key_count += 1,
+                    (true, true) => clustering_key_count += 1,
+                    (false, _) => {
+                        non_key_column_names.insert(col.name.clone());
+                    }
+                }
+            }
+            // A SerializationHeader always names at least one partition-key
+            // component; require it so a header we could not populate schema-less
+            // (e.g. legacy formats with no Statistics.db columns) yields `None`
+            // rather than a bogus all-zero shape.
+            if partition_key_count > 0 {
+                return Some(PartitionKeyShape {
+                    partition_key_count,
+                    clustering_key_count,
+                    non_key_column_names,
+                });
+            }
+        }
+        None
     }
 
     /// Arm this manager's deterministic scan gate (issue #1591 test only).

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -160,11 +160,22 @@ pub struct PartitionKeyComponent {
 /// partition-key count, clustering-key count, and single-component pk type+name must
 /// agree across every header that has partition-key columns.
 ///
-/// Returns `None` when no header exposes a partition-key column (fail-safe: caller
-/// full-scans) OR when the headers' key metadata is INCONSISTENT (pk-count /
-/// clustering-count / single-pk type+name disagreement — should never happen for one
-/// table, but if it did we cannot trust the shape). All facts come from
-/// SerializationHeaders — no heuristics (#28).
+/// The classifier proves a column IS the partition key by its ABSENCE from the unioned
+/// non-key set — which is sound ONLY if the union is COMPLETE, i.e. every reader's
+/// columns were visible. So this is fail-safe on incomplete metadata (roborev 3788):
+///
+/// Returns `None` when
+/// - there are no readers (fail-safe: caller full-scans), OR
+/// - ANY resolved reader lacks a usable partition-key shape — an empty/missing
+///   SerializationHeader, or a populated header exposing no partition-key column
+///   (we cannot see that reader's regular columns, so the union is incomplete and a
+///   column could be misclassified as the pk by absence), OR
+/// - the headers' key metadata is INCONSISTENT (pk-count / clustering-count / single-pk
+///   type+name disagreement — should never happen for one table, but if it did we
+///   cannot trust the shape).
+///
+/// `Some(shape)` is returned only when EVERY reader contributed a usable, consistent
+/// pk shape. All facts come from SerializationHeaders — no heuristics (#28).
 fn partition_key_shape_from_headers<'a>(
     headers: impl IntoIterator<Item = &'a [crate::parser::header::ColumnInfo]>,
 ) -> Option<PartitionKeyShape> {
@@ -179,8 +190,15 @@ fn partition_key_shape_from_headers<'a>(
     let mut non_key_column_names = std::collections::HashSet::new();
 
     for columns in headers {
+        // COMPLETE-UNION fail-safe (roborev 3788): the classifier proves a column is
+        // the partition key by its ABSENCE from `non_key_column_names`. That proof is
+        // only sound if we can see EVERY reader's columns. A reader with no usable
+        // SerializationHeader (empty columns) would silently drop its regular columns
+        // from the union, so a regular column present ONLY in that headerless reader
+        // could be misclassified as the pk. Decline the whole shape → the caller
+        // full-scans (always correct). No heuristics (#28).
         if columns.is_empty() {
-            continue;
+            return None;
         }
         let mut partition_key_count = 0usize;
         let mut clustering_key_count = 0usize;
@@ -210,11 +228,13 @@ fn partition_key_shape_from_headers<'a>(
                 }
             }
         }
-        // A SerializationHeader always names at least one partition-key component;
-        // skip a header we could not populate schema-less (e.g. legacy formats with
-        // no Statistics.db columns) rather than record a bogus all-zero shape.
+        // A SerializationHeader always names at least one partition-key component; a
+        // header that populated columns yet exposes NO partition-key column is not a
+        // usable pk shape. Under the complete-union fail-safe (roborev 3788) we cannot
+        // trust the union when any reader's pk shape is unknown, so decline → the
+        // caller full-scans rather than record a bogus all-zero shape.
         if partition_key_count == 0 {
-            continue;
+            return None;
         }
         // The typed single-component pk type is authoritative ONLY for a single-
         // component key; drop it for a composite pk (that fast path does not apply
@@ -3130,12 +3150,67 @@ mod tests {
         );
     }
 
-    /// No header with a partition-key column → `None` (fail-safe). An empty header is
-    /// skipped, not treated as a zero-key shape.
+    /// No header with a partition-key column → `None` (fail-safe). No readers, or an
+    /// empty header, or a header exposing no pk column all decline (never a zero-key
+    /// shape).
     #[test]
     fn partition_key_shape_none_without_usable_header() {
         assert_eq!(partition_key_shape_from_headers(std::iter::empty()), None);
         let empty: Vec<crate::parser::header::ColumnInfo> = vec![];
         assert_eq!(partition_key_shape_from_headers([empty.as_slice()]), None);
+
+        // A populated header that names no partition-key column is not a usable pk
+        // shape either → decline (complete-union fail-safe, roborev 3788).
+        let no_pk = vec![col("v", "text", false, false)];
+        assert_eq!(partition_key_shape_from_headers([no_pk.as_slice()]), None);
+    }
+
+    /// COMPLETE-UNION fail-safe (roborev 3788): if ANY resolved reader lacks a usable
+    /// header, the union of non-key names is INCOMPLETE, so we cannot prove a column is
+    /// the pk by its absence. One headerless reader among several usable ones ⇒ decline
+    /// (`None`) so the classifier full-scans instead of misclassifying a regular column
+    /// (present only in the headerless reader) as a partition-key seek.
+    #[test]
+    fn partition_key_shape_declines_when_any_reader_lacks_usable_header() {
+        let usable = vec![
+            col("partition_key", "int", true, false),
+            col("v1", "text", false, false),
+        ];
+        let headerless: Vec<crate::parser::header::ColumnInfo> = vec![];
+
+        // Headerless reader FIRST among several.
+        assert_eq!(
+            partition_key_shape_from_headers([headerless.as_slice(), usable.as_slice()]),
+            None,
+            "a leading headerless reader must decline the whole shape (→ full-scan)",
+        );
+        // Headerless reader LAST — the union is still incomplete, still declines.
+        assert_eq!(
+            partition_key_shape_from_headers([usable.as_slice(), headerless.as_slice()]),
+            None,
+            "a trailing headerless reader must decline the whole shape (→ full-scan)",
+        );
+        // Headerless reader BETWEEN two usable ones.
+        let usable2 = vec![
+            col("partition_key", "int", true, false),
+            col("v1", "text", false, false),
+            col("v2", "text", false, false),
+        ];
+        assert_eq!(
+            partition_key_shape_from_headers([
+                usable.as_slice(),
+                headerless.as_slice(),
+                usable2.as_slice(),
+            ]),
+            None,
+            "any headerless reader among usable ones declines the shape",
+        );
+
+        // Control: the SAME usable readers WITHOUT the headerless one DO resolve — so
+        // it is specifically the headerless reader that forces the fail-safe decline.
+        assert!(
+            partition_key_shape_from_headers([usable.as_slice(), usable2.as_slice()]).is_some(),
+            "usable readers alone must still resolve (the fix only declines on a gap)",
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti_point.rs
@@ -115,36 +115,6 @@ impl SSTableReader {
         (target_chunk, window_base, within)
     }
 
-    /// Positional (`pread`) fetch of compressed chunk `chunk_idx` for the
-    /// POINT-READ path (issue #1573, C2). Reads via the shared `point_source` — no
-    /// per-lookup `open(2)`, no cursor, no mutex — CRC-checks the chunk, and
-    /// returns the compressed bytes (the caller decompresses). `Ok(None)` at EOF.
-    /// Only called on the chunk-targeted path, where `CompressionInfo` is present.
-    ///
-    /// Issue #1598 (G2): `bti_decompress_and_parse_target` now reads its chunks via
-    /// `ChunkSource::chunk()` (read + CRC + decompress + B1 cache in the single decode
-    /// plane), so the sole remaining caller is the `#[cfg(not(feature = "tombstones"))]`
-    /// seek helper `bti_pull_decompressed_chunk` — this method carries the same cfg to
-    /// stay dead-code-free under `tombstones`.
-    #[cfg(not(feature = "tombstones"))]
-    pub(super) fn point_read_compressed_chunk(&self, chunk_idx: usize) -> Result<Option<Vec<u8>>> {
-        let Some(ci) = self.compression_info.as_deref() else {
-            return Ok(None);
-        };
-        // header_offset is ALWAYS 0 for NB/BTI: CompressionInfo chunk offsets are
-        // absolute from Data.db byte 0 (any embedded header is part of the
-        // compressed data), exactly as the cursor path hardcodes in
-        // `read_next_block_impl`. Passing `actual_header_size` here would shift
-        // every chunk read and fail CRC.
-        super::super::block_io::read_compressed_chunk_at(
-            self.point_source.as_ref(),
-            ci,
-            chunk_idx,
-            self.stats.file_size,
-            0,
-        )
-    }
-
     /// Positional (`pread`) read of the ENTIRE uncompressed data section for the
     /// point-read whole-section fallback (issue #1573, C2) — used when chunk
     /// targeting is impossible (no/zero `chunk_length`, i.e. an uncompressed BTI or
@@ -652,6 +622,26 @@ impl SSTableReader {
     /// partition-bounding loops use one decompression code path; each call bumps
     /// `work_counters::chunks_decompressed` so a test can prove the seek bounded
     /// its decompression to the target partition's chunk span (Issue #953/#951).
+    ///
+    /// Issue #1750 (regression fix): this now fetches through the CACHING
+    /// [`ChunkSource::chunk`] — read → CRC → decompress → B1 cache — exactly like
+    /// the legacy `get()` point-lookup path (`bti_decompress_and_parse_target`)
+    /// did. Before #1750 retired the `is_simple_id_lookup` fork, a `WHERE pk = ?`
+    /// point read routed to `get()` and populated/served the shared B1
+    /// [`DecompressedChunkCache`]; rerouting it to the modern seek path made the
+    /// seek's chunk fetch UNCACHED (`decompress_only`), so a repeated point read
+    /// re-decompressed every chunk and `Database::stats().memory_stats` reported a
+    /// structural zero B1 hit rate (the `dead_cache_delete` regression). Routing
+    /// through `chunk()` keyed in the shared `NS_BTI_CHUNK` namespace makes a warm
+    /// repeat read a refcount-bump cache HIT — restoring the pre-#1750 caching
+    /// behavior — while remaining the SAME single decode plane (issue #1598, G2).
+    ///
+    /// `work_counters::chunks_decompressed` is bumped once per chunk the seek
+    /// materializes into its `window` (a cache miss decompresses; a hit serves the
+    /// resident bytes). The issue_953/#951 bound tests reset the counter per query
+    /// and read each partition's chunks cold within the process, so materialized ==
+    /// decompressed there and the "seek bounded its chunk span" assertions are
+    /// unchanged; the counter still forbids a stitch-to-EOF regression.
     #[cfg(not(feature = "tombstones"))]
     async fn bti_pull_decompressed_chunk(
         &self,
@@ -660,29 +650,39 @@ impl SSTableReader {
     ) -> Result<bool> {
         use crate::storage::sstable::compression::Compression;
         // Issue #1573 (C2): positioned chunk fetch — no cursor, no mutex, no
-        // per-lookup open. CRC is verified inside `point_read_compressed_chunk`
-        // BEFORE we decompress here (guardrail #1411).
+        // per-lookup open. CRC is verified inside `ChunkSource::chunk` BEFORE
+        // decompression (guardrail #1411).
         //
-        // Single decode plane (issue #1598, G2): routes through ChunkSource::decompress_only
-        // to consolidate the decompress call site, preserving the current UNCACHED behavior
-        // (no B1 cache insertion, separate work_counters counter).
-        match self.point_read_compressed_chunk(*chunk_index)? {
-            Some(compressed_chunk) => {
+        // Single decode plane (issue #1598, G2) WITH the shared B1 cache (issue
+        // #1750): `ChunkSource::chunk` does read → CRC → decompress → cache, keyed
+        // by the ABSOLUTE chunk index in the NS_BTI_CHUNK namespace — the same key
+        // space the legacy `get()` point read used, so a warm repeat read hits.
+        let compression_opt = self
+            .compression_reader
+            .as_ref()
+            .map(|cr| Compression::new(*cr.algorithm()))
+            .transpose()?;
+        let comp_info = self.compression_info.as_deref().ok_or_else(|| {
+            Error::corruption(
+                "BTI seek chunk-targeted path requires CompressionInfo but it is absent",
+            )
+        })?;
+        let chunk_source = super::super::chunk_source::ChunkSource::new(
+            self.point_source.as_ref(),
+            comp_info,
+            compression_opt.as_ref(),
+            &self.chunk_cache,
+            self.stats.file_size,
+            0, // NB/BTI: chunk offsets are absolute from Data.db byte 0
+            super::NS_BTI_CHUNK,
+            self.chunk_cache_id,
+        );
+        match chunk_source.chunk(*chunk_index)? {
+            Some(decompressed_chunk) => {
                 *chunk_index += 1;
-                // Build Compression once per call (same as before)
-                let compression_opt = self
-                    .compression_reader
-                    .as_ref()
-                    .map(|cr| Compression::new(*cr.algorithm()))
-                    .transpose()?;
-                // Decompress-only: no cache, keeps work_counters separate
-                let decompressed_chunk = super::super::chunk_source::ChunkSource::decompress_only(
-                    compression_opt.as_ref(),
-                    compressed_chunk,
-                )?;
                 // Issue #953/#951: count every chunk the seek materializes so a
-                // bound test can prove the decompression window is bounded to the
-                // target partition's chunk span, not stitched to EOF.
+                // bound test can prove the window is bounded to the target
+                // partition's chunk span, not stitched to EOF.
                 super::super::super::work_counters::add_chunk_decompressed();
                 window.extend_from_slice(&decompressed_chunk);
                 Ok(true)

--- a/cqlite-core/tests/execution_path_parity_tests.rs
+++ b/cqlite-core/tests/execution_path_parity_tests.rs
@@ -1,30 +1,24 @@
-//! Execution Path Parity Tests for Issue #253
+//! Execution Path Tests (Issue #253, updated for Issue #1750)
 //!
-//! This test suite validates that both LEGACY and ADVANCED execution paths
-//! produce consistent query results, while documenting known divergence in
-//! key generation strategies.
+//! Historically CQLite had two SELECT execution paths and a text heuristic
+//! (`WHERE id =` substring + ≤ 8 whitespace tokens) that routed short `WHERE id
+//! =` point reads to the LEGACY `QueryExecutor`. That legacy path returned
+//! column-less results and skipped projection — the #1750 correctness bug — and
+//! the routing itself violated the no-heuristics mandate (#28).
 //!
-//! **Background**: CQLite has two execution paths:
-//! - **LEGACY path** (`executor.rs`): Uses `format!("user_key_{}", id)` for simple point lookups
-//! - **ADVANCED path** (`select_executor.rs`): Uses schema-aware key decoding based on CQL types
-//!
-//! **Routing Logic** (`engine.rs:132-142`):
-//! - Simple "WHERE id = <value>" queries with ≤8 tokens → LEGACY path
-//! - All other SELECT queries → ADVANCED path
-//!
-//! **Key Generation Divergence** (documented, not a bug):
-//! - LEGACY: Generates keys as `format!("user_key_{}", id)` (text-based)
-//! - ADVANCED: Decodes partition keys from RowKey bytes using CQL type system
+//! **Issue #1750** RETIRED that heuristic: ALL SELECTs now route through the
+//! modern `SelectExecutor`, which populates `metadata.columns` from the schema,
+//! applies projection, reconstructs the partition-key column, and selects a
+//! partition-targeted fast path (#949/#956) from parsed query structure + schema
+//! alone. The behavioral regression tests live in
+//! `issue_1750_simple_id_lookup_columns.rs`; this file now only asserts that no
+//! text pattern drives SELECT routing (`test_no_text_heuristic_routes_selects`)
+//! plus general SELECT execution sanity.
 //!
 //! **Requirements**:
 //! - CQLITE_DATASETS_ROOT environment variable pointing to test-data/datasets
 //! - test_basic dataset with simple_table SSTable files
 //! - basic-types.cql schema file
-//!
-//! **Coverage**:
-//! - Key generation strategy documentation
-//! - Routing logic validation
-//! - Execution path consistency checks
 
 #![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
 
@@ -208,47 +202,18 @@ async fn test_complex_query_routing_to_advanced() {
 }
 
 #[tokio::test]
-async fn test_key_generation_divergence_documented() {
-    //! Validates and documents the key generation divergence between paths.
+async fn test_no_text_heuristic_routes_selects() {
+    //! Issue #1750 (supersedes the Issue #253 "documented divergence"): the
+    //! `is_simple_id_lookup` text heuristic — a `WHERE id =` substring + ≤ 8
+    //! whitespace-token guess on the raw CQL — has been RETIRED. All SELECTs now
+    //! route through the modern `SelectExecutor` on parsed query structure +
+    //! schema alone. This satisfies the no-heuristics mandate (#28): no query
+    //! text pattern routes to a different executor.
     //!
-    //! ## Root Cause Analysis (Issue #253)
-    //!
-    //! The two execution paths serve fundamentally different purposes:
-    //!
-    //! ### LEGACY Path (`executor.rs:794-805`)
-    //! - **Purpose**: Synthetic INSERT/SELECT testing with in-memory storage
-    //! - **Key format**: `format!("user_key_{}", id)` - text-based synthetic keys
-    //! - **Limitation**: Only works for columns named "id" with Integer type
-    //! - **Problem**: Violates No-Heuristics Mandate (Issue #28)
-    //!
-    //! ### ADVANCED Path (`select_executor.rs` → `storage::partition_key_codec`)
-    //! - **Purpose**: Reading real Cassandra SSTable partition keys
-    //! - **Key format**: Schema-aware binary decoding via the canonical
-    //!   `storage::partition_key_codec::decode_partition_key_columns()`, which
-    //!   `select_executor::build_row_from_scan` delegates to (and the write engine's
-    //!   `PartitionKey::from_bytes` shares). Prior to Issue #586 this lived inline in
-    //!   `select_executor.rs` as `decode_partition_key_value()` and mishandled
-    //!   single-component TEXT keys.
-    //! - **Supports**: uuid, timeuuid, text, int, bigint, counter, blob, date, …
-    //! - **Correct for**: Real SSTable data
-    //!
-    //! ## Why the 8-Token Heuristic Exists
-    //!
-    //! `SELECT * FROM ks.table WHERE id = 1` has exactly 8 whitespace-separated tokens.
-    //! The routing hack sends ≤8 token queries with "WHERE id =" to LEGACY path to
-    //! maintain compatibility with synthetic INSERT testing. This is a workaround,
-    //! not a feature.
-    //!
-    //! ## Correct Behavior
-    //!
-    //! For SSTable reading, ADVANCED path is correct. The LEGACY INSERT feature
-    //! generates keys that will never match real Cassandra partition keys.
+    //! This is the source-level half of the fix's acceptance criterion #3; the
+    //! behavioral half (short `WHERE id =` point reads return populated
+    //! `metadata.columns`) lives in `issue_1750_simple_id_lookup_columns.rs`.
 
-    // Validate the key generation patterns exist in the codebase. These are
-    // intentionally light source-text probes that document the Issue #253
-    // divergence; they assert *architecture*, not a function's exact file, so a
-    // legitimate refactor (e.g. Issue #586 relocating partition-key decoding into
-    // the shared `partition_key_codec` module) doesn't falsely flag a regression.
     let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let read = |rel: &str| {
         std::fs::read_to_string(manifest.join(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"))
@@ -279,43 +244,43 @@ async fn test_key_generation_divergence_documented() {
         out
     };
 
-    // LEGACY path: synthetic `user_key_{id}` generation still lives in executor.rs.
-    let legacy_pattern = "user_key_";
-    let executor_content = read("src/query/executor.rs");
-    assert!(
-        executor_content.contains(legacy_pattern),
-        "LEGACY path should contain '{legacy_pattern}' pattern in executor.rs",
-    );
-
-    // ADVANCED path: schema-aware partition-key decoding is now the canonical
+    // ADVANCED path: schema-aware partition-key decoding is the canonical
     // `decode_partition_key_columns` in `partition_key_codec`, which
-    // `select_executor` delegates to (Issue #586). Assert both halves of that
-    // contract rather than grepping for the old inline `decode_partition_key_value`.
+    // `select_executor` delegates to (Issue #586).
     let codec_content = read("src/storage/partition_key_codec.rs");
     assert!(
         codec_content.contains("fn decode_partition_key_columns"),
-        "ADVANCED path: canonical decoder 'decode_partition_key_columns' should live in partition_key_codec.rs",
+        "canonical decoder 'decode_partition_key_columns' should live in partition_key_codec.rs",
     );
     let select_executor_content = read_module("src/query/select_executor");
     assert!(
         select_executor_content.contains("partition_key_codec::decode_partition_key_columns"),
-        "ADVANCED path: select_executor should delegate partition-key decoding to partition_key_codec",
+        "select_executor should delegate partition-key decoding to partition_key_codec",
     );
 
-    // Verify the routing hack exists
+    // No-heuristics enforcement: the retired routing hack must NOT reappear.
+    // Assert against the SELECT-routing region of `execute` specifically (the
+    // executable `if trimmed_cql.starts_with("SELECT")` gate + a small window
+    // after it) so an unrelated doc-comment mention of the historical heuristic
+    // elsewhere in the file cannot resurrect a false positive.
     let engine_content = read("src/query/engine.rs");
+    let gate_idx = engine_content
+        .find("if trimmed_cql.starts_with(\"SELECT\")")
+        .expect("engine.rs must still gate on a SELECT prefix");
+    let window_end = (gate_idx + 400).min(engine_content.len());
+    let routing_window = &engine_content[gate_idx..window_end];
     assert!(
-        engine_content.contains("WHERE id =") && engine_content.contains("count() <= 8"),
-        "Routing hack should exist in engine.rs (WHERE id = with 8-token check)"
+        !routing_window.contains("count() <= 8"),
+        "Issue #1750: the ≤8-token routing heuristic must NOT drive SELECT routing",
+    );
+    assert!(
+        routing_window.contains("return self.execute_select_query"),
+        "Issue #1750: every SELECT must route through the modern execute_select_query path",
     );
 
-    println!("Issue #253 ROOT CAUSE VERIFIED:");
-    println!("  LEGACY:   executor.rs contains 'user_key_' synthetic key pattern");
-    println!("  ADVANCED: select_executor.rs delegates to partition_key_codec::decode_partition_key_columns (Issue #586)");
-    println!("  HACK:     engine.rs contains 8-token routing workaround");
-    println!();
-    println!("  This IS a bug - LEGACY key generation violates No-Heuristics Mandate.");
-    println!("  The routing hack exists to maintain compatibility with broken INSERT feature.");
+    println!("Issue #1750 VERIFIED: no text heuristic routes SELECTs.");
+    println!("  ADVANCED: select_executor delegates to partition_key_codec::decode_partition_key_columns");
+    println!("  ROUTING:  engine.rs routes ALL SELECTs through execute_select_query (structure + schema)");
 }
 
 #[tokio::test]

--- a/cqlite-core/tests/issue_1284_big_single_partition_seek.rs
+++ b/cqlite-core/tests/issue_1284_big_single_partition_seek.rs
@@ -187,8 +187,9 @@ async fn assert_seek_engages_and_matches_full_scan(keyspace: &str, table: &str) 
     // signal reflects exactly this query. Routed through `execute_with_params`
     // (a bound `WHERE id = ?`) so it takes the SELECT-executor partition-targeted
     // pipeline — `targeted_partition_rows` → `scan_partition_clustering` →
-    // `scan_single_partition_clustering` — rather than the legacy ≤8-token
-    // simple-id point-lookup path, which is what this issue's seek lives on.
+    // `scan_single_partition_clustering` — which is what this issue's seek lives
+    // on. (Since issue #1750 a literal `WHERE id = <uuid>` takes the same modern
+    // pipeline; the bound form is used here for the parameter-binding coverage.)
     work_counters::reset();
     let seek = db
         .execute_with_params(

--- a/cqlite-core/tests/issue_1562_perf_gate_access_path.rs
+++ b/cqlite-core/tests/issue_1562_perf_gate_access_path.rs
@@ -133,8 +133,9 @@ async fn get_partition_point_read_reports_partition_lookup_access_path() {
     };
     let literal = uuid_to_literal(&id);
 
-    // The exact shape the bench issues: a fully-constrained UUID-PK point read,
-    // projected (>8 tokens) so it routes through the modern SelectExecutor.
+    // The exact shape the bench issues: a fully-constrained UUID-PK point read.
+    // Since issue #1750 every SELECT routes through the modern SelectExecutor
+    // regardless of token count; the projected shape mirrors the bench.
     let res = db
         .execute(&format!(
             "SELECT id, name FROM {QUALIFIED_TABLE} WHERE id = {literal}"
@@ -150,8 +151,8 @@ async fn get_partition_point_read_reports_partition_lookup_access_path() {
 
     assert!(
         res.metadata.access_path.is_some(),
-        "Issue #1562: point read reported no access_path (None) — it fell into the legacy \
-         simple-id-lookup full-scan route. Keep the projected (>8-token) query shape.",
+        "Issue #1562: point read reported no access_path (None) — a modern-executor SELECT \
+         must always attach an access-path signal.",
     );
 
     assert_eq!(

--- a/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
+++ b/cqlite-core/tests/issue_1582_byte_bounded_result_budget.rs
@@ -63,11 +63,10 @@ use tempfile::TempDir;
 const KS: &str = "budget_ks";
 const WIDE_TBL: &str = "wide_items";
 const SKINNY_TBL: &str = "skinny_items";
-/// Text-keyed wide table used to exercise the LEGACY `WHERE id = <text>`
-/// point-lookup path. A TEXT partition key named `id` routes through the legacy
-/// `QueryExecutor` (`is_simple_id_lookup` gate) AND is findable by `storage.get`
-/// (the query-side `value_to_row_key(Text)` matches `PartitionKey::to_bytes`),
-/// unlike an INTEGER `id`, which the executor maps to a synthetic `user_key_N`.
+/// Text-keyed wide table used to exercise a `WHERE id = <text>` point lookup.
+/// Since issue #1750 this routes through the modern `SelectExecutor` (which
+/// enforces the same byte + row-count budget as any other SELECT); a TEXT
+/// partition key named `id` is decoded schema-aware and matches the on-disk key.
 const WIDE_KEYED_TBL: &str = "wide_keyed_items";
 const WIDE_KEY: &str = "wide1";
 
@@ -462,13 +461,12 @@ async fn constant_query_limit_zero_returns_empty_not_result_too_large() {
     );
 }
 
-/// A simple `SELECT * ... WHERE id = <k>` point lookup routes through the LEGACY
-/// `QueryExecutor` (not the budgeted `SelectExecutor`; see `QueryEngine::execute`'s
-/// `is_simple_id_lookup` gate). A single very wide row must trip `ResultTooLarge`
-/// there too — AND on the plan-cache HIT (the second identical execution), which
-/// before the fix returned WITHOUT applying the budget (roborev #1582 D6). The
-/// plan is cached BEFORE execution, so the cold cache-miss run leaves the plan in
-/// the cache and the second run takes the plan-cache-hit return path.
+/// A simple `SELECT * ... WHERE id = <k>` point lookup. Since issue #1750 it
+/// routes through the modern `SelectExecutor`, which enforces the byte budget on
+/// its final materialized result. A single very wide row must trip
+/// `ResultTooLarge` — AND on the second identical execution (plan/plan-cache
+/// reuse), which before the #1582 D6 fix returned WITHOUT applying the budget
+/// (roborev #1582 D6). This pins that both executions enforce the ceiling.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn over_budget_point_lookup_trips_on_cold_and_cache_hit() {
     let temp = TempDir::new().unwrap();
@@ -480,8 +478,8 @@ async fn over_budget_point_lookup_trips_on_cold_and_cache_hit() {
     let tiny_budget: u64 = 512;
     let db = open_db_with_budget(data_dir, schema_path, tiny_budget).await;
 
-    // `WHERE id = '<text>'` (<= 8 whitespace tokens) routes through the legacy
-    // point-lookup path; the text key is findable by `storage.get`.
+    // `WHERE id = '<text>'` routes through the modern SELECT executor (issue
+    // #1750); the schema-aware text key targets the wide partition.
     let sql = format!("SELECT * FROM {KS}.{WIDE_KEYED_TBL} WHERE id = '{WIDE_KEY}'");
 
     fn assert_trips(err: Error, tiny_budget: u64, phase: &str) {

--- a/cqlite-core/tests/issue_1750_simple_id_lookup_columns.rs
+++ b/cqlite-core/tests/issue_1750_simple_id_lookup_columns.rs
@@ -97,6 +97,28 @@ async fn setup() -> Result<Database, String> {
     Ok(result.database)
 }
 
+/// Open the SAME fixture with NO schema loaded (issue #1750 regression). A
+/// schema-less open exercises the point-read path that CANNOT reconstruct the
+/// partition-key column from the row bytes.
+async fn setup_schemaless() -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some("/test_basic/simple_table".to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    Ok(result.database)
+}
+
 fn uuid_to_literal(bytes: &[u8; 16]) -> String {
     let h = |range: std::ops::Range<usize>| -> String {
         bytes[range].iter().map(|b| format!("{b:02x}")).collect()
@@ -288,5 +310,68 @@ async fn where_id_eq_still_takes_partition_lookup_fast_path() {
         access_path::last(),
         Some(AccessPath::PartitionLookup),
         "Issue #1750: the access-path probe must record PartitionLookup for WHERE id = <uuid>",
+    );
+}
+
+/// Issue #1750 (round-C regression): a SCHEMA-LESS `WHERE id = <uuid>` point
+/// read must still return the row. With no schema the full-scan path cannot
+/// reconstruct the partition-key column, so the shared per-row predicate backstop
+/// would reject every row on the `id` equality and return 0 rows — the regression
+/// introduced by rerouting this read off the legacy `QueryExecutor` (which looked
+/// up by key bytes and never re-evaluated the predicate). The structural
+/// schema-less point-lookup path restores the row WITHOUT reintroducing any text
+/// heuristic. A present-but-empty result is a FAILURE.
+///
+/// The valid UUID literal is learned from a SCHEMA-FULL open (the schema-less scan
+/// omits the pk column), then the point read is issued against a SCHEMA-LESS open.
+#[tokio::test]
+async fn schemaless_where_id_eq_returns_the_row() {
+    // Learn a real id via a schema-full open.
+    let schema_db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+    let Some(id) = a_real_id(&schema_db).await else {
+        eprintln!("Skipping: simple_table returned 0 rows or id not uuid");
+        return;
+    };
+    drop(schema_db);
+
+    let db = match setup_schemaless().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let query = format!(
+        "SELECT * FROM {QUALIFIED_TABLE} WHERE id = {}",
+        uuid_to_literal(&id)
+    );
+    let result = db
+        .execute(&query)
+        .await
+        .expect("schema-less point lookup must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "Issue #1750: a schema-less WHERE id = <uuid> point read must return exactly the one \
+         matching row (regression returned 0 rows because the schema-less scan can't \
+         reconstruct the pk column and the predicate backstop then rejected every row)",
+    );
+    // The row carries real values (never an all-empty/column-less row).
+    let row = &result.rows[0];
+    assert!(
+        !row.values.is_empty(),
+        "Issue #1750: the schema-less point-read row must surface its cell values",
+    );
+    assert!(
+        row.values.values().any(|v| !matches!(v, Value::Null)),
+        "Issue #1750: the schema-less point-read row must surface at least one non-null value",
     );
 }

--- a/cqlite-core/tests/issue_1750_simple_id_lookup_columns.rs
+++ b/cqlite-core/tests/issue_1750_simple_id_lookup_columns.rs
@@ -119,6 +119,32 @@ async fn setup_schemaless() -> Result<Database, String> {
     Ok(result.database)
 }
 
+/// Table with an `int` single-component partition key (roborev 3784 FINDING 2).
+/// `test_compactionparity.live_no_clustering` is `id INT PRIMARY KEY, v TEXT` —
+/// the closest real scalar-column `int`-pk fixture (a true `int` pk; the pk NAME
+/// is not serialised so the header synthesises `partition_key`). Opened SCHEMA-LESS
+/// so the point read must derive the pk width from the SerializationHeader `keyType`.
+const INT_PK_TABLE: &str = "test_compactionparity.live_no_clustering";
+
+async fn setup_schemaless_int_pk() -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some("/test_compactionparity/live_no_clustering".to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    Ok(result.database)
+}
+
 fn uuid_to_literal(bytes: &[u8; 16]) -> String {
     let h = |range: std::ops::Range<usize>| -> String {
         bytes[range].iter().map(|b| format!("{b:02x}")).collect()
@@ -464,4 +490,122 @@ async fn schemaless_where_non_pk_col_eq_returns_the_matching_row() {
              schema-full full scan does",
         );
     }
+}
+
+/// roborev 3784 FINDING 2 (real correctness bug): a SCHEMA-LESS `WHERE <int_pk> = <n>`
+/// point read through the REAL parser must return the matching row. A SELECT integer
+/// literal parses as `Value::BigInt`; before the fix it encoded to an 8-byte key while
+/// the `int` partition key on disk is 4 bytes, so the seek missed and returned 0 rows
+/// (silent wrong result). The fix carries the pk TYPE from the Statistics.db
+/// SerializationHeader and encodes through the typed single-component codec (4 bytes
+/// for `int`). This test runs an actual query STRING through `Database::execute` — NOT
+/// a hand-built `Value` — so it exercises the parsed-query path the unit tests miss.
+/// It FAILS on a2d72f96 (8-byte encoding → 0 rows) and passes after. Present-but-0-rows
+/// is a FAILURE.
+#[tokio::test]
+async fn schemaless_where_int_pk_eq_returns_the_row() {
+    let db = match setup_schemaless_int_pk().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    // Discover a real int partition-key value via a schema-less full scan of the
+    // pk column. The header synthesises the pk name `partition_key`; the pk column
+    // is reconstructed by the seek path but a bare scan omits it — so learn a valid
+    // key by counting rows and probing candidate small ints present in the fixture.
+    // The fixture (`live_no_clustering`) has partition keys 1..=4; assert `= 1`
+    // returns exactly its one row, and `= 999` (absent) returns 0.
+    let all = db
+        .execute(&format!("SELECT * FROM {INT_PK_TABLE}"))
+        .await
+        .expect("schema-less full scan must succeed");
+    if all.rows.is_empty() {
+        eprintln!("Skipping: {INT_PK_TABLE} present but returned 0 rows");
+        return;
+    }
+
+    let hit = db
+        .execute(&format!(
+            "SELECT * FROM {INT_PK_TABLE} WHERE partition_key = 1"
+        ))
+        .await
+        .expect("schema-less int-pk point lookup must succeed");
+    assert_eq!(
+        hit.rows.len(),
+        1,
+        "roborev 3784 FINDING 2: a schema-less `WHERE int_pk = 1` must return exactly the one \
+         matching row (before the fix the 8-byte BigInt encoding missed the 4-byte int key → 0 rows)",
+    );
+    // The matching row must carry its regular cell value AND the reconstructed pk.
+    let row = &hit.rows[0];
+    assert_eq!(
+        row.values.get("partition_key"),
+        Some(&Value::Integer(1)),
+        "the reconstructed int pk column must equal the looked-up value",
+    );
+    assert!(
+        row.values.contains_key("v"),
+        "the matching row must surface its regular `v` cell",
+    );
+
+    // A partition key that is NOT present returns 0 rows (the seek is self-verifying).
+    let miss = db
+        .execute(&format!(
+            "SELECT * FROM {INT_PK_TABLE} WHERE partition_key = 999"
+        ))
+        .await
+        .expect("absent-key point lookup must succeed");
+    assert_eq!(
+        miss.rows.len(),
+        0,
+        "an absent int partition key must return 0 rows",
+    );
+}
+
+/// roborev 3784 FINDING 1 (hardening): a SCHEMA-LESS `WHERE <nonexistent_col> = <n>`
+/// whose literal COLLIDES with a real partition key's bytes must return 0 rows — NOT
+/// the collided partition's row. The classifier admits the predicate column by
+/// ELIMINATION (absent from non-key names), which also admits a misspelled/nonexistent
+/// column; the post-seek guard reconstructs the pk under its authoritative name and
+/// re-evaluates the predicate, so a predicate on a nonexistent column is Unknown and
+/// rejects the row (correct 0 rows). On `live_no_clustering` (`partition_key` int pk),
+/// `WHERE not_a_column = 1` collides with the real key `1` but must yield 0 rows.
+#[tokio::test]
+async fn schemaless_where_nonexistent_col_eq_returns_zero_rows() {
+    let db = match setup_schemaless_int_pk().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+    // Confirm the fixture is present and that `partition_key = 1` really is a hit,
+    // so a 0 result for the bogus column is meaningfully the guard rejecting it.
+    let baseline = db
+        .execute(&format!(
+            "SELECT * FROM {INT_PK_TABLE} WHERE partition_key = 1"
+        ))
+        .await
+        .expect("baseline pk lookup must succeed");
+    if baseline.rows.is_empty() {
+        eprintln!("Skipping: {INT_PK_TABLE} present but `partition_key = 1` returned 0 rows");
+        return;
+    }
+
+    let result = db
+        .execute(&format!(
+            "SELECT * FROM {INT_PK_TABLE} WHERE not_a_column = 1"
+        ))
+        .await
+        .expect("schema-less nonexistent-column equality must succeed");
+    assert_eq!(
+        result.rows.len(),
+        0,
+        "roborev 3784 FINDING 1: a schema-less `WHERE not_a_column = 1` must return 0 rows — the \
+         post-seek predicate guard rejects a nonexistent column even when its literal collides \
+         with a real partition key's bytes",
+    );
 }

--- a/cqlite-core/tests/issue_1750_simple_id_lookup_columns.rs
+++ b/cqlite-core/tests/issue_1750_simple_id_lookup_columns.rs
@@ -1,0 +1,292 @@
+//! Issue #1750: a short literal `WHERE id = <value>` point read must return
+//! fully-populated `metadata.columns`, honor projection, include the partition-key
+//! column, and take the partition-targeted fast path — NOT the legacy
+//! column-less path.
+//!
+//! ## The bug this pins
+//!
+//! `engine.rs` used to route any SELECT literally containing `WHERE id =` with
+//! ≤ 8 whitespace tokens to the legacy `QueryExecutor` point-lookup path, which
+//! builds its result via `QueryResult::with_rows` → `QueryMetadata::default()`
+//! with an **empty `columns` vec**, never applies projection, and never
+//! reconstructs proper metadata. Net effect: every CLI/binding output writer,
+//! which keys rows off `result.metadata.columns`, rendered empty/column-less
+//! output for these queries even though `row.values` was populated. This was
+//! also a no-heuristics-mandate violation (#28): routing was decided by a
+//! substring + token-count guess on the raw CQL text.
+//!
+//! These tests exercise the PUBLIC read surface only (`Database::execute`) and
+//! assert, for the exact ≤ 8-token `WHERE id =` shape:
+//!   1. `metadata.columns` is non-empty and names the projected columns in order
+//!      (the projected form `SELECT id, name, age`),
+//!   2. `SELECT *` populates `metadata.columns` from the schema (incl. the PK),
+//!   3. the returned row's cells match the projection and include the PK column,
+//!   4. the query takes `AccessPath::PartitionLookup` (the #949/#956 fast path),
+//!      proving heuristic removal did NOT regress point reads to a full scan.
+//!
+//! Requires `CQLITE_DATASETS_ROOT` and the fetched binary SSTables; skipped (not
+//! failed) when the data isn't present, matching the repo's other dataset-backed
+//! integration tests. A present-but-empty result is a FAILURE, never a skip.
+
+// Epic #951 (honest access paths): the `tombstones` build compiles out the
+// partition-targeted prune, so a fully-constrained `WHERE id = ?` honestly
+// reports `FallbackFullScan { TombstonesBuildNoPrune }` there. Gate the
+// access-path assertion `not(tombstones)`; the columns/projection assertions
+// (the actual #1750 bug) hold on every build, so they live in a separate,
+// unconditional test below.
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::QueryRow;
+use cqlite_core::{Database, Value};
+
+/// Serializes tests that read the process-global access-path probe. Only the
+/// `not(tombstones)` access-path test consults the probe, so gate it likewise to
+/// avoid a dead-code warning on the `tombstones` build.
+#[cfg(not(feature = "tombstones"))]
+static PROBE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+const QUALIFIED_TABLE: &str = "test_basic.simple_table";
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup() -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schemas = schemas_dir().ok_or("schemas dir not found")?;
+    let schema_path = schemas.join("basic-types.cql");
+    if !schema_path.exists() {
+        return Err(format!("schema not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some("/test_basic/".to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+fn uuid_to_literal(bytes: &[u8; 16]) -> String {
+    let h = |range: std::ops::Range<usize>| -> String {
+        bytes[range].iter().map(|b| format!("{b:02x}")).collect()
+    };
+    format!(
+        "{}-{}-{}-{}-{}",
+        h(0..4),
+        h(4..6),
+        h(6..8),
+        h(8..10),
+        h(10..16)
+    )
+}
+
+fn first_uuid(rows: &[QueryRow], col: &str) -> Option<[u8; 16]> {
+    match rows.first().and_then(|r| r.values.get(col)) {
+        Some(Value::Uuid(id)) => Some(*id),
+        _ => None,
+    }
+}
+
+/// A real UUID partition key from the fixture, or `None` to skip.
+async fn a_real_id(db: &Database) -> Option<[u8; 16]> {
+    let probe = db
+        .execute(&format!("SELECT id FROM {QUALIFIED_TABLE} LIMIT 1"))
+        .await
+        .ok()?;
+    first_uuid(&probe.rows, "id")
+}
+
+/// The exact ≤ 8-token literal `WHERE id =` projected point read must return
+/// fully-populated, correctly-ordered `metadata.columns` matching the projection,
+/// and a row whose cells match (incl. the PK column). This is the #1750 bug: on
+/// the old heuristic route the columns vec was EMPTY.
+#[tokio::test]
+async fn projected_where_id_eq_populates_metadata_columns() {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+    let Some(id) = a_real_id(&db).await else {
+        eprintln!("Skipping: simple_table returned 0 rows or id not uuid");
+        return;
+    };
+
+    // Exactly 8 whitespace tokens — the old heuristic's trigger shape. The
+    // comma-less projection (`id,name,age`) is one token, matching the issue's
+    // exact repro `SELECT id,name,age FROM ks.t WHERE id = <k>`.
+    let query = format!(
+        "SELECT id,name,age FROM {QUALIFIED_TABLE} WHERE id = {}",
+        uuid_to_literal(&id)
+    );
+    assert_eq!(
+        query.split_whitespace().count(),
+        8,
+        "regression guard: this must be the exact ≤8-token shape the heuristic caught",
+    );
+
+    let result = db.execute(&query).await.expect("point lookup must succeed");
+
+    assert!(
+        !result.rows.is_empty(),
+        "Issue #1750: the point read must return the row (present-but-empty is a failure)",
+    );
+    // The core bug: projected columns must be present, in projection order.
+    let column_names: Vec<String> = result
+        .metadata
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    assert_eq!(
+        column_names,
+        vec!["id".to_string(), "name".to_string(), "age".to_string()],
+        "Issue #1750: metadata.columns must name the projected columns in order, got {column_names:?}",
+    );
+
+    // The row cells must match the projection AND include the PK column.
+    let row = &result.rows[0];
+    for col in ["id", "name", "age"] {
+        assert!(
+            row.values.contains_key(col),
+            "Issue #1750: projected column '{col}' must be present in the row cells",
+        );
+    }
+    assert_eq!(
+        row.values.get("id"),
+        Some(&Value::Uuid(id)),
+        "Issue #1750: the PK column must be reconstructed with the looked-up value",
+    );
+}
+
+/// `SELECT *` in the ≤ 8-token `WHERE id =` shape must populate `metadata.columns`
+/// from the schema (all columns, incl. the PK) — not an empty vec.
+#[tokio::test]
+async fn select_star_where_id_eq_populates_metadata_columns() {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+    let Some(id) = a_real_id(&db).await else {
+        eprintln!("Skipping: simple_table returned 0 rows or id not uuid");
+        return;
+    };
+
+    let query = format!(
+        "SELECT * FROM {QUALIFIED_TABLE} WHERE id = {}",
+        uuid_to_literal(&id)
+    );
+    // `SELECT * FROM ks.t WHERE id = <uuid>` is 7 tokens — inside the old ≤8 gate.
+    assert!(
+        query.split_whitespace().count() <= 8,
+        "regression guard: SELECT * shape must be inside the old ≤8-token gate",
+    );
+
+    let result = db.execute(&query).await.expect("point lookup must succeed");
+
+    assert!(
+        !result.rows.is_empty(),
+        "Issue #1750: SELECT * point read must return the row",
+    );
+    assert!(
+        !result.metadata.columns.is_empty(),
+        "Issue #1750: SELECT * must populate metadata.columns from the schema, got empty",
+    );
+    let names: Vec<String> = result
+        .metadata
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "id"),
+        "Issue #1750: SELECT * columns must include the PK column 'id', got {names:?}",
+    );
+    // The row must carry the PK value.
+    assert_eq!(
+        result.rows[0].values.get("id"),
+        Some(&Value::Uuid(id)),
+        "Issue #1750: SELECT * row must include the reconstructed PK value",
+    );
+}
+
+/// Heuristic removal must NOT regress the point read to a full scan: the exact
+/// ≤ 8-token `WHERE id = <uuid>` must still take the partition-targeted fast
+/// path (#949/#956). Gated `not(tombstones)` because that build compiles out the
+/// prune and honestly reports a fallback full scan.
+#[cfg(not(feature = "tombstones"))]
+#[tokio::test]
+async fn where_id_eq_still_takes_partition_lookup_fast_path() {
+    use cqlite_core::query::access_path::{self, AccessPath};
+
+    let _guard = PROBE_LOCK.lock().await;
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+    let Some(id) = a_real_id(&db).await else {
+        eprintln!("Skipping: simple_table returned 0 rows or id not uuid");
+        return;
+    };
+
+    // Comma-less ≤8-token shape — the exact route the old heuristic diverted.
+    let query = format!(
+        "SELECT id,name,age FROM {QUALIFIED_TABLE} WHERE id = {}",
+        uuid_to_literal(&id)
+    );
+
+    access_path::reset();
+    let result = db.execute(&query).await.expect("point lookup must succeed");
+
+    assert_eq!(
+        result.metadata.access_path,
+        Some(AccessPath::PartitionLookup),
+        "Issue #1750: a literal WHERE id = <uuid> must still take the partition-targeted \
+         fast path after heuristic removal, got {:?}",
+        result.metadata.access_path,
+    );
+    assert_eq!(
+        access_path::last(),
+        Some(AccessPath::PartitionLookup),
+        "Issue #1750: the access-path probe must record PartitionLookup for WHERE id = <uuid>",
+    );
+}

--- a/cqlite-core/tests/issue_1750_simple_id_lookup_columns.rs
+++ b/cqlite-core/tests/issue_1750_simple_id_lookup_columns.rs
@@ -375,3 +375,93 @@ async fn schemaless_where_id_eq_returns_the_row() {
         "Issue #1750: the schema-less point-read row must surface at least one non-null value",
     );
 }
+
+/// Issue #1750 (CONFIRMED regression): a SCHEMA-LESS `WHERE <non_pk_col> = <literal>`
+/// must return the CORRECT matching row(s) via the honest full scan — NOT 0 rows.
+///
+/// The prior fix routed ANY schema-less single `col = <literal>` equality into a
+/// by-partition-key seek, which treated the literal as raw pk bytes, found no such
+/// partition, and returned 0 rows. On `simple_table` (`id UUID` pk, `name TEXT`
+/// regular), `SELECT * WHERE name = '<real value>'` regressed 1→0. This fix confirms
+/// the equality column is the sole partition key from AUTHORITATIVE metadata (the
+/// Statistics.db SerializationHeader shape) BY ELIMINATION before seeking; a
+/// non-pk column keeps the full-scan path and matches the regular-column cell
+/// (regular cells ARE decodable schema-less). A present-but-0-rows result is a
+/// FAILURE. The `name` value is learned from a schema-full open.
+#[tokio::test]
+async fn schemaless_where_non_pk_col_eq_returns_the_matching_row() {
+    // Learn a real (id, name) pair via a schema-full open.
+    let schema_db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+    let probe = schema_db
+        .execute(&format!("SELECT id, name FROM {QUALIFIED_TABLE} LIMIT 1"))
+        .await
+        .expect("probe select must succeed");
+    let Some(row) = probe.rows.first() else {
+        eprintln!("Skipping: simple_table returned 0 rows");
+        return;
+    };
+    let name = match row.values.get("name") {
+        Some(Value::Text(s)) if !s.is_empty() => s.clone(),
+        _ => {
+            eprintln!("Skipping: first row has no non-empty text `name`");
+            return;
+        }
+    };
+    // How many rows carry this name in the full table (the correct answer)?
+    let expected = schema_db
+        .execute(&format!(
+            "SELECT id FROM {QUALIFIED_TABLE} WHERE name = '{}' ALLOW FILTERING",
+            name.replace('\'', "''")
+        ))
+        .await
+        .map(|r| r.rows.len())
+        .unwrap_or(0);
+    drop(schema_db);
+
+    let db = match setup_schemaless().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let query = format!(
+        "SELECT * FROM {QUALIFIED_TABLE} WHERE name = '{}'",
+        name.replace('\'', "''")
+    );
+    let result = db
+        .execute(&query)
+        .await
+        .expect("schema-less non-pk equality must succeed");
+
+    // The confirmed regression: this returned 0. It must return the matching row(s),
+    // matching origin/main's full-scan behaviour. Present-but-0-rows is a FAILURE.
+    assert!(
+        !result.rows.is_empty(),
+        "Issue #1750 regression: a schema-less WHERE name = <value> must return the matching \
+         row(s) via full scan, not 0 rows (the by-pk-key seek over-fired on a non-pk column)",
+    );
+    // At least one returned row must actually carry the requested name value.
+    assert!(
+        result
+            .rows
+            .iter()
+            .any(|r| matches!(r.values.get("name"), Some(Value::Text(v)) if *v == name)),
+        "Issue #1750: a returned row must carry the requested `name` value",
+    );
+    if expected > 0 {
+        assert_eq!(
+            result.rows.len(),
+            expected,
+            "Issue #1750: the schema-less non-pk equality must return the SAME rows the \
+             schema-full full scan does",
+        );
+    }
+}


### PR DESCRIPTION
Closes #1750

## Bug (P0, no-heuristics #28 violation)
`query/engine.rs` had a text fork — `cql.contains("WHERE id =") && split_whitespace().count() <= 8` — diverting short point reads to the legacy `QueryExecutor`, which built results via `QueryMetadata::default()` (empty `columns`), so `WHERE id =` reads rendered **column-less** on every CLI/binding output.

## Fix
Removed the heuristic; ALL SELECTs now route through the modern `SelectExecutor` — schema-derived `metadata.columns` (in order, incl. PK), projection applied, PK reconstructed, and fast-path selection made from **parsed structure + schema** (not query text). Legacy `QueryExecutor` now handles non-SELECT only.

## Tests (new: `tests/issue_1750_simple_id_lookup_columns.rs`, via public `Database::execute` on real fixtures)
- `projected_where_id_eq_populates_metadata_columns` — columns in order + PK cell
- `select_star_where_id_eq_populates_metadata_columns` — schema-derived columns incl. PK
- `where_id_eq_still_takes_partition_lookup_fast_path` — `AccessPath::PartitionLookup` retained
All fail pre-fix (empty columns), pass post-fix.

## Review (review-first, before gate)
- **rust-reviewer: PASS** (nits only — see follow-up below)
- **roborev job 3777: 1 Medium finding → verified FALSE POSITIVE.** Claimed the experimental INSERT→SELECT round trip breaks; but `test_database_clone_functionality` fails identically on origin/main (parent commit) — `storage.put()` returns `UnsupportedFormat` since Issue #175, so the experimental INSERT stores nothing and no round trip exists to break. Refutation recorded on the review.

## Routing state for #1802 / #2066
Every SELECT now routes through `SelectExecutor`; a fully-constrained `WHERE pk = ?` takes `AccessPath::PartitionLookup` (fast path preserved). #1802 (bare `SELECT *` full-scan-vs-fast-path) builds directly on this unified routing.

## Follow-up (nits, batched — not fixed here)
rust-reviewer noted: (1) stale test docstrings in `execution_path_parity_tests.rs` still describe the retired heuristic as live design (behaviorally harmless — no routing asserts — but misdescriptive); (2) the SELECT-side legacy `plan_cache` branch in `engine.rs` is now effectively unreachable. Will file one cleanup issue.