### PR TITLE
test-data(#1935): strip TTL from 5 corpus tables + TTL-aware CLI asserts (code half; binary regen CI-gated)

### DIFF
--- a/bindings/python/tests/test_cli_parity.py
+++ b/bindings/python/tests/test_cli_parity.py
@@ -468,6 +468,12 @@ class TestCLIParityBasic:
             ("multi_partition_table", 10),
             ("uncompressed_table", 10),
             ("compression_test_table", 10),
+            # NOTE (issue #1935): the second tuple element is the query LIMIT, not
+            # an expected row count. `ttl_test_table` KEEPS its TTL (the #1853
+            # seam) so every fixture row is wall-clock-expired and BOTH the Python
+            # binding and the CLI return 0 LIVE rows — this test asserts Python==CLI
+            # equality, which holds at 0 (and will still hold post-regen). It never
+            # hardcodes a row count.
             ("ttl_test_table", 10),
             ("static_columns_table", 10),  # Issue resolved
         ],
@@ -546,6 +552,13 @@ class TestCLIParityTimeseries:
             ("sensor_data", 10),
             ("event_store", 10),
             ("user_sessions", 10),
+            # NOTE (issue #1935): the second tuple element is the query LIMIT, not
+            # an expected row count. `app_metrics`, `log_entries` and `tick_data`
+            # had `default_time_to_live` REMOVED from the schema; until the corpus
+            # binaries are regenerated WITHOUT TTL (CI-owned), the shipped fixtures
+            # are wall-clock-expired so BOTH Python and CLI return 0 LIVE rows. This
+            # test asserts Python==CLI equality, which holds at 0 today and will
+            # still hold once the regenerated fixtures return their physical rows.
             ("app_metrics", 10),
             ("log_entries", 10),
             ("stock_prices", 10),

--- a/cqlite-cli/tests/comprehensive_select_test.rs
+++ b/cqlite-cli/tests/comprehensive_select_test.rs
@@ -23,7 +23,7 @@
 #![allow(clippy::all)]
 
 use rstest::rstest;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 // =============================================================================
@@ -250,6 +250,229 @@ fn run_table_test(keyspace: &str, table: &str, schema_file: &str) {
     );
 }
 
+/// The query LIMIT used by `run_select_query` — expected live counts are capped
+/// to this since the CLI SELECT is `... LIMIT 10`.
+const SELECT_LIMIT: usize = 10;
+
+/// Locate the `*-Data.db.jsonl` sstabledump golden for `keyspace.table`.
+/// Returns `None` when the datasets root, the table directory, or the golden is
+/// absent (so callers can distinguish "no fixture" from "0 live rows").
+fn find_golden_jsonl(keyspace: &str, table: &str) -> Option<PathBuf> {
+    let ks_dir = get_datasets_root().join("sstables").join(keyspace);
+    let table_dir = std::fs::read_dir(&ks_dir).ok()?.flatten().find_map(|e| {
+        let name = e.file_name();
+        let s = name.to_str()?;
+        // Directory names are `<table>-<uuid>`; match the exact table prefix.
+        if s.starts_with(&format!("{}-", table)) {
+            Some(e.path())
+        } else {
+            None
+        }
+    })?;
+    std::fs::read_dir(&table_dir).ok()?.flatten().find_map(|e| {
+        let name = e.file_name();
+        let s = name.to_str()?;
+        (s.ends_with("-Data.db.jsonl")).then(|| e.path())
+    })
+}
+
+/// Count rows in a sstabledump JSONL golden that are LIVE under Cassandra
+/// `SELECT` semantics at the current wall clock — the same TTL-aware logic the
+/// Python/Node parity harnesses use (`count_live_rows_in_jsonl`). A row is
+/// excluded when: it is a range-tombstone marker (`type != "row"`), a row
+/// tombstone (deletion_info with no cells), or its row-liveness TTL has elapsed
+/// and no non-deleted cell keeps it alive (explicit future per-cell expiry, or a
+/// live-forever cell marked by its own `tstamp`). Returns `None` on read error.
+fn count_live_golden_rows(jsonl_path: &Path) -> Option<usize> {
+    use chrono::{DateTime, Utc};
+
+    let content = std::fs::read_to_string(jsonl_path).ok()?;
+    let now = Utc::now();
+
+    let parse_expires = |v: Option<&serde_json::Value>| -> Option<DateTime<Utc>> {
+        v.and_then(|x| x.as_str())
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&Utc))
+    };
+
+    let mut total = 0_usize;
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let partition: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let Some(rows) = partition["rows"].as_array() else {
+            continue;
+        };
+        for row in rows {
+            if row["type"].as_str() != Some("row") {
+                continue;
+            }
+            let cells = row["cells"].as_array().cloned().unwrap_or_default();
+            if !row["deletion_info"].is_null() && cells.is_empty() {
+                continue;
+            }
+
+            let liveness = &row["liveness_info"];
+            let row_expires = parse_expires(Some(&liveness["expires_at"]));
+            let has_ttl = !liveness["ttl"].is_null();
+            if has_ttl && row_expires.is_some_and(|exp| exp <= now) {
+                // Row-liveness TTL elapsed: survives only if a non-deleted cell
+                // keeps it alive (explicit future per-cell expiry, or a
+                // live-forever cell marked by its own `tstamp`).
+                let cell_still_live = cells.iter().any(|cell| {
+                    if !cell["deletion_info"].is_null() {
+                        return false;
+                    }
+                    match parse_expires(Some(&cell["expires_at"])) {
+                        Some(cell_exp) => cell_exp > now,
+                        None => !cell["tstamp"].is_null(),
+                    }
+                });
+                if !cell_still_live {
+                    continue;
+                }
+            }
+            total += 1;
+        }
+    }
+    Some(total)
+}
+
+/// TTL-aware table test (issue #1935). Instead of asserting `row_count > 0`
+/// (wrong for a wall-clock-expired TTL fixture), assert the CLI's live row count
+/// equals the golden-derived expected LIVE count, capped at the query LIMIT.
+/// Preserves the missing-fixture guard: 0 live rows is only accepted when the
+/// golden is present AND non-empty, so an absent/empty dataset still surfaces as
+/// a skip (no fixture) rather than a false pass.
+fn run_ttl_aware_table_test(keyspace: &str, table: &str, schema_file: &str) {
+    if !ensure_test_data_available() {
+        return;
+    }
+
+    let Some(golden_path) = find_golden_jsonl(keyspace, table) else {
+        eprintln!(
+            "SKIP: {}.{}: no sstabledump JSONL golden found; cannot derive TTL-aware expectation",
+            keyspace, table
+        );
+        return;
+    };
+
+    let Some(physical_rows) = count_golden_physical_rows(&golden_path) else {
+        eprintln!(
+            "SKIP: {}.{}: could not read golden {}",
+            keyspace,
+            table,
+            golden_path.display()
+        );
+        return;
+    };
+    // Guard against a vacuous pass on an empty golden (issue #1853 finding):
+    // 0 live rows must provably mean "expired", not "nothing was written".
+    if physical_rows == 0 {
+        eprintln!(
+            "SKIP: {}.{}: golden has 0 physical rows (empty fixture)",
+            keyspace, table
+        );
+        return;
+    }
+
+    let Some(live_rows) = count_live_golden_rows(&golden_path) else {
+        eprintln!("SKIP: {}.{}: could not parse golden", keyspace, table);
+        return;
+    };
+    let expected = live_rows.min(SELECT_LIMIT);
+
+    let result = run_select_query(keyspace, table, schema_file);
+
+    eprintln!(
+        "=== {}.{} (TTL-aware) === exit={:?} valid_json={} rows={:?} expected_live={} (physical={})",
+        keyspace,
+        table,
+        result.exit_code,
+        result.is_valid_json,
+        result.row_count,
+        expected,
+        physical_rows
+    );
+
+    assert_eq!(
+        result.exit_code,
+        Some(0),
+        "{}.{}: Expected exit code 0, got {:?}. STDERR: {}",
+        keyspace,
+        table,
+        result.exit_code,
+        &result.stderr[..result.stderr.len().min(500)]
+    );
+
+    assert!(
+        result.is_valid_json,
+        "{}.{}: Expected valid JSON array output. Got: {}...",
+        keyspace,
+        table,
+        &result.stdout[..result.stdout.len().min(200)]
+    );
+
+    assert_eq!(
+        result.row_count.unwrap_or(0),
+        expected,
+        "{}.{}: TTL-aware live row-count mismatch: CLI returned {:?}, golden-derived expected {} \
+         (capped at LIMIT {}; physical golden rows {}). A TTL fixture returning 0 LIVE rows is \
+         CORRECT when all rows are wall-clock-expired — see issue #1935/#1853.",
+        keyspace,
+        table,
+        result.row_count,
+        expected,
+        SELECT_LIMIT,
+        physical_rows
+    );
+
+    assert!(
+        !result.has_errors,
+        "{}.{}: Found {} ERROR messages in stderr. This indicates parsing failures.\nSTDERR:\n{}",
+        keyspace,
+        table,
+        result.error_count,
+        &result.stderr[..result.stderr.len().min(2000)]
+    );
+
+    assert!(
+        !result.has_invalid_data,
+        "{}.{}: Output contains invalid data markers.\nOutput sample:\n{}",
+        keyspace,
+        table,
+        &result.stdout[..result.stdout.len().min(500)]
+    );
+}
+
+/// Count total physical `type == "row"` entries in the golden (no TTL/tombstone
+/// filtering) — used only to prove the fixture is non-empty so a 0-live result
+/// can be attributed to expiry rather than a missing/empty fixture.
+fn count_golden_physical_rows(jsonl_path: &Path) -> Option<usize> {
+    let content = std::fs::read_to_string(jsonl_path).ok()?;
+    let mut total = 0_usize;
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let partition: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if let Some(rows) = partition["rows"].as_array() {
+            total += rows
+                .iter()
+                .filter(|r| r["type"].as_str() == Some("row"))
+                .count();
+        }
+    }
+    Some(total)
+}
+
 // =============================================================================
 // test_basic Keyspace Tests (8 tables)
 // =============================================================================
@@ -261,8 +484,11 @@ fn run_table_test(keyspace: &str, table: &str, schema_file: &str) {
 #[case("counters")]
 #[case("multi_partition_table")]
 #[case("static_columns_table")] // Issue #255: STATIC column schema parsing
-#[case("ttl_test_table")]
 #[case("uncompressed_table")]
+// NOTE: `ttl_test_table` is intentionally NOT here — it KEEPS its TTL (the #1853
+// seam) so its rows are all wall-clock-expired and a SELECT correctly returns 0
+// LIVE rows. It is covered by `test_select_ttl_aware` below, which derives the
+// expected LIVE count from the golden instead of asserting `> 0`. See issue #1935.
 #[cfg(feature = "state_machine")]
 fn test_select_test_basic(#[case] table: &str) {
     run_table_test("test_basic", table, "basic-types.cql");
@@ -291,18 +517,47 @@ fn test_select_test_collections(#[case] table: &str) {
 // =============================================================================
 
 #[rstest]
-#[case("app_metrics")]
 #[case("event_store")]
-#[case("log_entries")]
 #[case("sensor_data")]
 #[case("stock_prices")]
-#[case("tick_data")]
 #[case("time_bucketed_counters")] // Issue #256: Counter table returns 0 rows
 #[case("user_activity")]
 #[case("user_sessions")]
+// NOTE: `app_metrics`, `log_entries`, `tick_data` are covered by
+// `test_select_ttl_aware` below (issue #1935). Their `default_time_to_live` was
+// removed from the schema; until the corpus binaries are regenerated WITHOUT TTL
+// (CI-owned), the shipped fixtures are wall-clock-expired and a SELECT returns 0
+// LIVE rows. The TTL-aware assertion derives the expected LIVE count from the
+// golden, so it passes both before regen (expected 0) and after (expected > 0).
 #[cfg(feature = "state_machine")]
 fn test_select_test_timeseries(#[case] table: &str) {
     run_table_test("test_timeseries", table, "time-series.cql");
+}
+
+// =============================================================================
+// TTL-aware tables (issue #1935 / #1896 cluster A)
+// =============================================================================
+//
+// These tables carry (or carried) a `default_time_to_live`, so their shipped
+// fixtures may be entirely wall-clock-expired — a Cassandra `SELECT` (and the
+// reader, via #1790 read-time TTL shadowing) then returns 0 LIVE rows. Asserting
+// `row_count > 0` is therefore WRONG for them. Instead we derive the expected
+// LIVE row count from the sstabledump JSONL golden (the same TTL-aware logic the
+// Python/Node parity harnesses use) and assert the CLI matches it (capped at the
+// query LIMIT). This is robust across the pending corpus regeneration:
+//   - `test_basic.ttl_test_table` KEEPS its TTL (the #1853 seam) → expected 0.
+//   - `app_metrics`/`log_entries`/`tick_data` had TTL removed from the schema;
+//     pre-regen goldens are expired (expected 0), post-regen goldens carry no
+//     TTL (expected = physical count). Either way the derived expectation tracks
+//     the fixture, so the test never goes stale on a hardcoded number.
+#[rstest]
+#[case("test_basic", "ttl_test_table", "basic-types.cql")]
+#[case("test_timeseries", "app_metrics", "time-series.cql")]
+#[case("test_timeseries", "log_entries", "time-series.cql")]
+#[case("test_timeseries", "tick_data", "time-series.cql")]
+#[cfg(feature = "state_machine")]
+fn test_select_ttl_aware(#[case] keyspace: &str, #[case] table: &str, #[case] schema_file: &str) {
+    run_ttl_aware_table_test(keyspace, table, schema_file);
 }
 
 // =============================================================================
@@ -401,12 +656,38 @@ fn test_all_tables_summary() {
         ),
     ];
 
+    // TTL-carrying tables can legitimately return 0 LIVE rows (all rows
+    // wall-clock-expired) — for them "success" means the CLI's live count equals
+    // the golden-derived expectation, not `> 0` (issue #1935).
+    let is_ttl_aware = |ks: &str, tbl: &str| {
+        matches!(
+            (ks, tbl),
+            ("test_basic", "ttl_test_table")
+                | ("test_timeseries", "app_metrics")
+                | ("test_timeseries", "log_entries")
+                | ("test_timeseries", "tick_data")
+        )
+    };
+
     for (keyspace, schema, tables) in test_configs {
         for table in tables {
             let result = run_select_query(keyspace, table, schema);
             let full_name = format!("{}.{}", keyspace, table);
 
-            if result.is_success() {
+            let success = if is_ttl_aware(keyspace, table) {
+                let expected = find_golden_jsonl(keyspace, table)
+                    .and_then(|p| count_live_golden_rows(&p))
+                    .map(|n| n.min(SELECT_LIMIT));
+                result.exit_code == Some(0)
+                    && result.is_valid_json
+                    && !result.has_errors
+                    && !result.has_invalid_data
+                    && expected.is_some_and(|e| result.row_count.unwrap_or(0) == e)
+            } else {
+                result.is_success()
+            };
+
+            if success {
                 passed.push(full_name);
             } else {
                 failed.push((

--- a/cqlite-core/tests/issue_694_writetime_ttl_parity.rs
+++ b/cqlite-core/tests/issue_694_writetime_ttl_parity.rs
@@ -1130,10 +1130,15 @@ async fn writetime_parity_test_wide_rows_product_catalog() {
 //   "BTI (da) read support not yet implemented"
 //
 // Therefore no da-format TTL parity test is included.  The readable TTL
-// fixtures used above are:
-//   - test_basic.ttl_test_table  (nb, TTL=86400, expires_at checked)
-//   - test_timeseries.app_metrics (nb, TTL=2592000 — WRITETIME-only tested above)
-//   - test_timeseries.log_entries (nb, TTL=604800 — WRITETIME-only tested above)
+// fixture used above is:
+//   - test_basic.ttl_test_table  (nb, TTL=86400, expires_at checked) — this table
+//     intentionally KEEPS its default_time_to_live as the dedicated #1853 seam.
+//
+// NOTE (issue #1935 / #1896 cluster A): app_metrics/log_entries/tick_data and the
+// da/oa ttl_table fixtures had their default_time_to_live REMOVED (the TTLs
+// time-bombed those fixtures); they are regenerated WITHOUT TTL by the CI corpus
+// pipeline. Only test_basic.ttl_test_table remains a TTL fixture — its pinned-now
+// override seam above makes its coverage time-proof.
 //
 // See test-data/validation-matrix.md §"WRITETIME/TTL parity (issue #694)" for
 // the documented gap.

--- a/test-data/REGEN-NOTES-1935.md
+++ b/test-data/REGEN-NOTES-1935.md
@@ -1,0 +1,73 @@
+# Issue #1935 — TTL corpus regeneration notes (#1896 cluster A, owner-decided)
+
+Owner decision (2026-07-08, ref #1896): strip `default_time_to_live` from the
+five TTL-carrying corpus tables that time-bombed the fixtures, **keep**
+`test_basic.ttl_test_table` with its TTL as the dedicated #1853 seam.
+
+## What is DONE in this PR (local, reviewable — no binary regen)
+
+1. **Schema edits** — `default_time_to_live` removed (and no `USING TTL` inserts
+   exist for these tables):
+   - `test-data/schemas/time-series.cql` — `app_metrics` (was 2592000),
+     `log_entries` (was 604800), `tick_data` (was 86400).
+   - `test-data/schemas/da-test.cql` — `ttl_table` (was 86400).
+   - `test-data/schemas/oa-test.cql` — `ttl_table` (was 86400).
+   - `test-data/schemas/basic-types.cql` — `ttl_test_table` **UNCHANGED**
+     (keeps `default_time_to_live = 86400`; it is the #1853 seam).
+   - `test-data/scripts/regenerate-datasets.sh` — comment updated (no TTL).
+2. **Test assertions** made TTL-aware / robust:
+   - `cqlite-cli/tests/comprehensive_select_test.rs` — the four TTL tables
+     (`ttl_test_table`, `app_metrics`, `log_entries`, `tick_data`) moved out of the
+     `> 0` row-count cases into `test_select_ttl_aware`, which derives the expected
+     LIVE count from the sstabledump JSONL golden (same TTL-aware logic as the
+     Python/Node parity harnesses) and asserts the CLI matches it, capped at the
+     query LIMIT. Passes at 0 today (all rows wall-clock-expired) and will track
+     the regenerated physical count automatically. Guards against a vacuous pass by
+     requiring the golden to have > 0 physical rows.
+   - `bindings/python/tests/test_cli_parity.py` — clarifying comments only; the
+     `(table, 10)` tuples are query LIMITs, not counts, and the test asserts
+     Python==CLI equality (holds at 0 and post-regen). No hardcoded count existed.
+   - The Python `test_parity.py::test_row_count` and Node `parity.test.js` already
+     derive TTL-aware expected counts from goldens — no change needed; they
+     auto-adjust after regeneration.
+3. **#1853 seam preserved** — `cqlite-core/tests/issue_694_writetime_ttl_parity.rs`
+   is UNTOUCHED (only a trailing doc comment updated); both
+   `writetime_parity_test_basic_ttl_test_table` (pinned-now) and
+   `ttl_test_table_fully_expired_returns_zero_live_rows_at_wall_clock` (wall-clock)
+   still cover `test_basic.ttl_test_table` with TTL.
+
+## What is CI-GATED / owner-owned (NOT done here)
+
+The whole-corpus binary regeneration (rm -rf + fresh UUIDs + new release asset +
+dataset-pin bump) is owned by CI + owner. Exact recipe:
+
+1. **Regenerate binaries** — run the `exhaustive-regeneration.yml` workflow
+   (`workflow_dispatch`), which runs `test-data/scripts/regenerate-datasets.sh`
+   against real Cassandra 5, then `cassandra-parity -- corpus-audit` (must be
+   clean) and refreshes JSONL goldens. It packages the corpus to compute the asset
+   name + SHA256 but by design does NOT publish.
+2. **Publish the asset** — `test-data/scripts/publish_datasets.sh --type full
+   --tag datasets-v3` (uploads `cassandra5-small-full.tar.gz` with `--clobber`;
+   version lives in the TAG, not the filename — but the fetch pin keys on the
+   versioned asset name `cassandra5-small-full-v3.5.tar.gz`, so cut/upload the v3.5
+   asset). Mind the macOS tar AppleDouble gotcha when packing.
+3. **Bump the dataset pin** — `test-data/scripts/bump-dataset-pin.sh
+   --new-sha <sha256-of-new-asset> --new-asset cassandra5-small-full-v3.5.tar.gz`
+   (never tag-only: `DATASET_TAG` / `DATASET_ASSET` / `DATASET_SHA256` must ALL be
+   set consistently across `.github/workflows/*.yml` and
+   `test-data/scripts/fetch-datasets.sh`). Current pin: `datasets-v3` /
+   `cassandra5-small-full-v3.4.tar.gz` /
+   `3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33`.
+   Do NOT invent a SHA — it does not exist until the asset is built.
+4. **Round-trip verify** — `bash test-data/scripts/fetch-datasets.sh` pulls the
+   new asset, verifies the SHA, and the parity/CLI tests then see the regenerated
+   (no-TTL) fixtures returning their physical row counts.
+
+## Expected outcome after regen
+
+- `app_metrics`, `log_entries`, `tick_data`, `test_da.ttl_table`,
+  `test_oa.ttl_table` return their physical (non-expired) row counts.
+- `test_basic.ttl_test_table` still returns 0 LIVE rows at wall clock (TTL kept) —
+  covered by the #1853 seam, not by a `> 0` assertion.
+- Node CI `parity.test.js`, Python `test_parity.py`, CLI `comprehensive_select`,
+  and `sstabledump-parity` all green (the TTL-aware assertions track the goldens).

--- a/test-data/schemas/da-test.cql
+++ b/test-data/schemas/da-test.cql
@@ -33,10 +33,11 @@ CREATE TABLE IF NOT EXISTS collection_table (
     properties MAP<TEXT, TEXT>
 ) WITH compression = {'class': 'LZ4Compressor'};
 
--- 3. TTL rows
+-- 3. Formerly-TTL rows (issue #1935, #1896 cluster A owner decision:
+--    default_time_to_live removed — it time-bombed the fixture so every row read
+--    as expired. Table name kept for corpus stability; regenerated WITHOUT TTL.)
 CREATE TABLE IF NOT EXISTS ttl_table (
     id UUID PRIMARY KEY,
     data TEXT,
     expiring_value INT
-) WITH compression = {'class': 'LZ4Compressor'}
-  AND default_time_to_live = 86400;
+) WITH compression = {'class': 'LZ4Compressor'};

--- a/test-data/schemas/oa-test.cql
+++ b/test-data/schemas/oa-test.cql
@@ -51,13 +51,15 @@ CREATE TABLE IF NOT EXISTS udt_table (
     large_field TEXT
 ) WITH compression = {'class': 'LZ4Compressor'};
 
--- 4. TTL rows (mirrors test_basic.ttl_test_table)
+-- 4. Formerly-TTL rows (issue #1935, #1896 cluster A owner decision:
+--    default_time_to_live removed — it time-bombed the fixture so every row read
+--    as expired. Table name kept for corpus stability; regenerated WITHOUT TTL.
+--    test_basic.ttl_test_table intentionally KEEPS its TTL for the #1853 seam.)
 CREATE TABLE IF NOT EXISTS ttl_table (
     id UUID PRIMARY KEY,
     data TEXT,
     expiring_value INT
-) WITH compression = {'class': 'LZ4Compressor'}
-  AND default_time_to_live = 86400;
+) WITH compression = {'class': 'LZ4Compressor'};
 
 -- 5. Static columns (mirrors test_basic.static_columns_table)
 CREATE TABLE IF NOT EXISTS static_table (

--- a/test-data/schemas/time-series.cql
+++ b/test-data/schemas/time-series.cql
@@ -1,6 +1,9 @@
 -- Time Series Schema for CQL Test Data Generation
--- Optimized for time-based data with TTLs and time window compaction
+-- Optimized for time-based data with time window compaction
 -- Issue #18: Docker-based test data generation
+-- Issue #1935 (#1896 cluster A): default_time_to_live removed from app_metrics,
+--   log_entries and tick_data — the TTLs time-bombed the fixtures (every row read
+--   as expired). Regenerated WITHOUT TTL for stable row-count parity.
 
 -- Create keyspace for time series testing
 CREATE KEYSPACE IF NOT EXISTS test_timeseries WITH replication = {
@@ -29,7 +32,9 @@ CREATE TABLE IF NOT EXISTS sensor_data (
   }
   AND clustering ORDER BY (timestamp DESC);
 
--- Application metrics with TTL
+-- Application metrics (TTL removed — issue #1935, #1896 cluster A owner decision:
+-- default_time_to_live time-bombed the fixture so every row read as expired.
+-- Regenerated WITHOUT TTL for stable, time-proof row-count parity.)
 CREATE TABLE IF NOT EXISTS app_metrics (
     application_id TEXT,
     metric_name TEXT,
@@ -44,8 +49,7 @@ CREATE TABLE IF NOT EXISTS app_metrics (
     'compaction_window_unit': 'MINUTES',
     'compaction_window_size': 30
   }
-  AND clustering ORDER BY (timestamp DESC)
-  AND default_time_to_live = 2592000; -- 30 days
+  AND clustering ORDER BY (timestamp DESC);
 
 -- User activity tracking
 CREATE TABLE IF NOT EXISTS user_activity (
@@ -105,8 +109,7 @@ CREATE TABLE IF NOT EXISTS log_entries (
     'compaction_window_unit': 'HOURS',
     'compaction_window_size': 6
   }
-  AND clustering ORDER BY (log_id DESC)
-  AND default_time_to_live = 604800; -- 7 days
+  AND clustering ORDER BY (log_id DESC); -- TTL removed (issue #1935, #1896 cluster A)
 
 -- Event sourcing table
 CREATE TABLE IF NOT EXISTS event_store (
@@ -169,5 +172,4 @@ CREATE TABLE IF NOT EXISTS tick_data (
     'compaction_window_unit': 'MINUTES',
     'compaction_window_size': 1
   }
-  AND clustering ORDER BY (tick_id ASC)
-  AND default_time_to_live = 86400; -- 1 day
+  AND clustering ORDER BY (tick_id ASC); -- TTL removed (issue #1935, #1896 cluster A)

--- a/test-data/scripts/regenerate-datasets.sh
+++ b/test-data/scripts/regenerate-datasets.sh
@@ -503,7 +503,7 @@ try:
             "INSERT INTO udt_table (id, name, address, large_field) VALUES (%s,%s,%s,%s)",
             (uuid.uuid4(), f"person_{random.randint(1,100)}", addr, "x" * 200))
 
-    # ttl_table (schema has default_time_to_live=86400)
+    # ttl_table (TTL removed — issue #1935; regenerated WITHOUT default_time_to_live)
     for _ in range(15):
         session.execute(
             "INSERT INTO ttl_table (id, data, expiring_value) VALUES (%s,%s,%s)",
@@ -593,7 +593,7 @@ try:
              [random.randint(1, 100) for _ in range(random.randint(1, 4))],
              {f"k{i}": f"v{i}" for i in range(random.randint(1, 3))}))
 
-    # ttl_table (schema has default_time_to_live=86400)
+    # ttl_table (TTL removed — issue #1935; regenerated WITHOUT default_time_to_live)
     for _ in range(15):
         session.execute(
             "INSERT INTO ttl_table (id, data, expiring_value) VALUES (%s,%s,%s)",

--- a/test-data/validation-matrix.md
+++ b/test-data/validation-matrix.md
@@ -205,9 +205,22 @@ validated against Cassandra 5 sstabledump — see "BTI write-path parity" below.
 A da-format TTL WRITETIME parity test remains future work.)
 
 Readable TTL fixtures tested above:
-- `test_basic.ttl_test_table` (nb, default_time_to_live=86400) — WRITETIME+TTL both validated
-- `test_timeseries.app_metrics` (nb, default_time_to_live=2592000) — not separately tested (WRITETIME parity covered via sensor_data test above)
-- `test_timeseries.log_entries` (nb, default_time_to_live=604800) — not separately tested
+- `test_basic.ttl_test_table` (nb, default_time_to_live=86400) — WRITETIME+TTL both validated.
+  **KEPT WITH TTL** (issue #1935, #1896 cluster A owner decision) as the dedicated
+  #1853 seam: its pinned-now override test proves read-time TTL shadowing, and its
+  wall-clock test proves an all-expired fixture returns 0 LIVE rows.
+- `test_timeseries.app_metrics` (was default_time_to_live=2592000) — WRITETIME parity covered via sensor_data test above
+- `test_timeseries.log_entries` (was default_time_to_live=604800) — not separately tested
+
+> Issue #1935 (#1896 cluster A): `default_time_to_live` was REMOVED from the schemas
+> of `test_timeseries.app_metrics`, `log_entries`, `tick_data`, `test_da.ttl_table`
+> and `test_oa.ttl_table` — the TTLs time-bombed those fixtures (every row read as
+> expired → 0 LIVE rows, breaking `> 0` row-count assertions once the TTL elapsed).
+> They are regenerated WITHOUT TTL by the CI corpus-regeneration pipeline (dataset
+> pin bump pending). `test_basic.ttl_test_table` intentionally keeps its TTL for the
+> #1853 seam. Until the binaries are regenerated the shipped fixtures still read as
+> expired; the CLI/parity harnesses derive the expected LIVE count from the golden,
+> so they pass at 0 now and will track the regenerated physical count automatically.
 
 No new SSTable fixtures were generated for this issue (Docker/Cassandra required for new data).
 


### PR DESCRIPTION
Part of #1935 (P1) — the durable fix for #1853-class TTL-fixture time bombs (owner decision on #1896, 2026-07-08). This is the **code/schema half; the binary regeneration + v3.5 dataset asset is CI-gated** (recipe in `test-data/REGEN-NOTES-1935.md`) and NOT in this PR. #1935 stays OPEN after merge for the CI regen follow-on.

## What changed
- **Schemas — TTL stripped** from `test_timeseries.{app_metrics,log_entries,tick_data}`, `test_da.ttl_table`, `test_oa.ttl_table`.
- **`test_basic.ttl_test_table` KEEPS its TTL** — the dedicated #1853 seam (`issue_694_writetime_ttl_parity.rs`). Seam assertions untouched (doc-comment only).
- **CLI `comprehensive_select_test.rs`:** the 4 TTL tables moved out of `row_count>0` into `test_select_ttl_aware`, which independently derives the expected LIVE count from the sstabledump golden and `assert_eq!`s it to CQLite's output (real cross-check, guards against empty-golden/0-physical vacuous pass). No hardcoded counts — auto-tracks post-regen physical counts.
- `test_cli_parity.py`: comment-only (the `(table,10)` are LIMITs). Python/Node harnesses already derive TTL-aware counts.

## Why merge-standalone-safe (rust-reviewer verdict)
`default_time_to_live` is a write/table property, NOT a read-path input — the reader decodes per-cell TTL from the v3.4 binaries themselves. Dropping it from the schema is inert for reading the currently-pinned fixtures: at v3.4 all 5 tables' binaries still carry TTL → reader shadows → 0 live; the TTL-aware goldens also yield 0 → tests match. This PR is *corrective*: it removes the old `>0` assertions on expired TTL fixtures (the time-bomb) → converts a red/soon-red lane to green NOW, independent of the v3.5 asset. No lane cross-checks schema-TTL against the binaries for these tables.

## Review
- rust-reviewer: **PASS**, 0 blockers, MERGE-STANDALONE-SAFE. #1853 seam confirmed preserved; no-vacuous-pass confirmed.
- NITS (non-blocking): `test_select_ttl_aware` SKIPs on absent golden vs `issue_694`'s fail-closed under `CQLITE_PARITY_REQUIRE_DATASETS=1` (asymmetric absence semantics; gate `missing-fixtures` fail-closed covers it); ensure the CI regen job emits the `-v3.5` asset name the pin keys on.

## Residual (keeps #1935 open)
CI-gated: run `exhaustive-regeneration.yml` → `publish_datasets.sh` (v3.5) → `bump-dataset-pin.sh` (TAG/ASSET/SHA256) → `fetch-datasets.sh` round-trip. Then the 5 tables' binaries are actually non-TTL and #1935's dataset-pin AC is met.