### PR TITLE
feat(#2163): correctness/silent-miss observability signals — merge reconciliation, tombstone retention, prune + opt-in false-negative verify, degraded-path

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -364,9 +364,12 @@ pub const COMPACTION_TOMBSTONES_SUPPRESSED: &str = "cqlite.compaction.tombstones
 /// `cqlite.compaction.tombstones_emitted` — counter `{tombstone}` (issue #2163).
 ///
 /// Tombstone markers RETAINED into the merge output (a row / range / partition
-/// tombstone carried forward because it is not purgeable), emitted once per merge.
-/// Distinct from [`COMPACTION_TOMBSTONES_PURGED`] and
-/// [`COMPACTION_TOMBSTONES_SUPPRESSED`]. No high-cardinality attributes.
+/// / cell tombstone carried forward because it is not purgeable — a cell
+/// tombstone counts here too, roborev r7: it is exactly the marker
+/// tombstone-resurrection debugging needs to see, not only the coarser
+/// row/range/partition markers), emitted once per merge. Distinct from
+/// [`COMPACTION_TOMBSTONES_PURGED`] and [`COMPACTION_TOMBSTONES_SUPPRESSED`].
+/// No high-cardinality attributes.
 pub const COMPACTION_TOMBSTONES_EMITTED: &str = "cqlite.compaction.tombstones_emitted";
 
 /// `cqlite.query.degraded_path.total` — counter `1` (issue #2163).

--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -38,6 +38,8 @@ pub mod unit {
     pub const SSTABLES: &str = "{sstable}";
     /// A count of errors.
     pub const ERRORS: &str = "{error}";
+    /// A count of tombstones.
+    pub const TOMBSTONES: &str = "{tombstone}";
     /// Bytes.
     pub const BYTES: &str = "By";
     /// Seconds (OTel prefers base-unit seconds for durations).
@@ -90,6 +92,14 @@ pub mod attr {
     /// Bounded to two values so a single metric series carries both arms for
     /// success/error-rate dashboards.
     pub const RPC_STATUS: &str = "cqlite.rpc.status";
+    /// Reason a `SELECT` fell back to a degraded (full-scan) read path
+    /// (issue #2163). Values come from
+    /// [`crate::query::access_path::FallbackReason::label`] — a documented closed
+    /// set (`no_schema`, `partition_key_not_fully_constrained`,
+    /// `partition_key_encoding_failed`, `metadata_scan_path`, `legacy_executor_path`,
+    /// `tombstones_build_no_prune`). Bounded by the enum itself; NEVER carries a
+    /// partition key, predicate value, or query string.
+    pub const FALLBACK_REASON: &str = "cqlite.query.fallback_reason";
 }
 
 /// `cqlite.read.rows` — counter `{row}`.
@@ -161,6 +171,42 @@ pub const READ_BLOOM_CHECKS: &str = "cqlite.read.bloom.checks";
 /// exercised (a multi-chunk SSTable with a straddling partition); it stays
 /// zero for single-chunk SSTables. No high-cardinality attributes.
 pub const READ_SCAN_WINDOW_REFILL: &str = "cqlite.read.scan.window_refill";
+
+/// `cqlite.read.sstables_pruned` — counter `{sstable}` (issue #2163).
+///
+/// Incremented once for each SSTable EXCLUDED from a read because its presence
+/// oracle returned a definitive negative — the bloom filter for BIG
+/// (`might_contain_partition == false`) or the Partitions.db trie for BTI (a trie
+/// miss). Bounded attributes: [`attr::SSTABLE_FORMAT`]. Distinct from
+/// [`READ_BLOOM_CHECKS`], which counts *checks* (hit/miss); this counts SSTables
+/// actually skipped, in `{sstable}` units — the dashboard-honest prune signal.
+pub const READ_SSTABLES_PRUNED: &str = "cqlite.read.sstables_pruned";
+
+/// `cqlite.read.bloom.false_negatives` — counter `1` (issue #2163).
+///
+/// OPT-IN, default-OFF soundness alarm: incremented ONLY when the presence-oracle
+/// false-negative verification (`CQLITE_VERIFY_PRESENCE_ORACLE`) is enabled and an
+/// AUTHORITATIVE scan of an SSTable finds a key its bloom/BTI-trie said was
+/// definitely absent. Under a correct oracle this stays 0; a non-zero value is a
+/// corruption/soundness alarm. Bounded attributes: [`attr::SSTABLE_FORMAT`].
+pub const READ_BLOOM_FALSE_NEGATIVES: &str = "cqlite.read.bloom.false_negatives";
+
+/// `cqlite.merge.rows_in` — counter `{row}` (issue #2163).
+///
+/// Sum of input rows consumed at the k-way merge RECONCILE boundary, emitted once
+/// per merge (aggregated from stack-local counters, never per row/cell). Paired
+/// with [`MERGE_ROWS_OUT`]; their delta is the number of rows removed by
+/// reconciliation (LWW collapse + tombstone suppression). Scoped to reconcile so
+/// producer-level filtering (token prune, predicate, `LIMIT`) is EXCLUDED. No
+/// high-cardinality attributes.
+pub const MERGE_ROWS_IN: &str = "cqlite.merge.rows_in";
+
+/// `cqlite.merge.rows_out` — counter `{row}` (issue #2163).
+///
+/// Sum of rows emitted by the k-way merge reconcile boundary post-reconciliation,
+/// emitted once per merge. See [`MERGE_ROWS_IN`] for the pairing/scope contract.
+/// No high-cardinality attributes.
+pub const MERGE_ROWS_OUT: &str = "cqlite.merge.rows_out";
 
 /// `cqlite.query.duration` — histogram `s`.
 ///
@@ -305,6 +351,32 @@ pub const COMPACTION_SSTABLES_OUT: &str = "cqlite.compaction.sstables_out";
 /// reconciliation collapse is NOT counted. No high-cardinality attributes.
 pub const COMPACTION_TOMBSTONES_PURGED: &str = "cqlite.compaction.tombstones_purged";
 
+/// `cqlite.compaction.tombstones_suppressed` — counter `{tombstone}` (issue #2163).
+///
+/// Live cells/rows SHADOWED (suppressed) by a tombstone during merge
+/// reconciliation, emitted once per merge. Distinct from
+/// [`COMPACTION_TOMBSTONES_PURGED`] (a genuine gc/overlap-safe purge) and
+/// [`COMPACTION_TOMBSTONES_EMITTED`] (a marker retained). Suppression without a
+/// safe purge or a retained marker is the resurrection-risk smell. No
+/// high-cardinality attributes.
+pub const COMPACTION_TOMBSTONES_SUPPRESSED: &str = "cqlite.compaction.tombstones_suppressed";
+
+/// `cqlite.compaction.tombstones_emitted` — counter `{tombstone}` (issue #2163).
+///
+/// Tombstone markers RETAINED into the merge output (a row / range / partition
+/// tombstone carried forward because it is not purgeable), emitted once per merge.
+/// Distinct from [`COMPACTION_TOMBSTONES_PURGED`] and
+/// [`COMPACTION_TOMBSTONES_SUPPRESSED`]. No high-cardinality attributes.
+pub const COMPACTION_TOMBSTONES_EMITTED: &str = "cqlite.compaction.tombstones_emitted";
+
+/// `cqlite.query.degraded_path.total` — counter `1` (issue #2163).
+///
+/// Incremented once each time a `SELECT` takes a soundness fallback recorded as
+/// [`crate::query::access_path::AccessPath::FallbackFullScan`]. Bounded attribute:
+/// [`attr::FALLBACK_REASON`] (the closed `FallbackReason::label()` set). A green
+/// targeted query does NOT increment it. NEVER carries a key/predicate/query text.
+pub const QUERY_DEGRADED_PATH: &str = "cqlite.query.degraded_path.total";
+
 /// `cqlite.compaction.lag` — gauge `{sstable}`.
 ///
 /// Current L0 SSTables pending compaction (compaction lag). No high-cardinality
@@ -383,6 +455,11 @@ pub const ALL_METRICS: &[&str] = &[
     READ_DURATION,
     READ_PARTITION_LOOKUP,
     READ_BLOOM_CHECKS,
+    READ_SSTABLES_PRUNED,
+    READ_BLOOM_FALSE_NEGATIVES,
+    MERGE_ROWS_IN,
+    MERGE_ROWS_OUT,
+    QUERY_DEGRADED_PATH,
     STORAGE_OPEN_SSTABLES,
     STORAGE_OPEN_BYTES,
     STORAGE_OPEN_TABLES,
@@ -410,6 +487,8 @@ pub const ALL_METRICS: &[&str] = &[
     COMPACTION_SSTABLES_IN,
     COMPACTION_SSTABLES_OUT,
     COMPACTION_TOMBSTONES_PURGED,
+    COMPACTION_TOMBSTONES_SUPPRESSED,
+    COMPACTION_TOMBSTONES_EMITTED,
     COMPACTION_LAG,
     COMPACTION_FINALIZE_DURATION,
     COMPACTION_BUDGET_REQUESTED,
@@ -452,6 +531,7 @@ mod tests {
             attr::PLAN_TYPE,
             attr::RPC_METHOD,
             attr::RPC_STATUS,
+            attr::FALLBACK_REASON,
         ] {
             assert!(key.starts_with("cqlite."), "attr {key} must be namespaced");
         }

--- a/cqlite-core/src/observability/config.rs
+++ b/cqlite-core/src/observability/config.rs
@@ -82,6 +82,15 @@ pub struct ObservabilityConfig {
     pub sampling_ratio: f64,
     /// Exporter export timeout.
     pub timeout: Duration,
+    /// Opt-in, default-OFF presence-oracle false-negative verification (issue
+    /// #2163). When `true`, an SSTable read whose bloom/BTI-trie reports a key
+    /// "definitely absent" runs an AUTHORITATIVE confirmation scan and increments
+    /// `cqlite.read.bloom.false_negatives` on a contradiction. Populated from
+    /// `CQLITE_VERIFY_PRESENCE_ORACLE`; the read path itself consults the
+    /// process-global switch in
+    /// [`crate::storage::sstable::reader::presence_verification`], which reads the
+    /// SAME environment variable, so this field mirrors that runtime state.
+    pub verify_presence_oracle: bool,
 }
 
 impl Default for ObservabilityConfig {
@@ -94,6 +103,7 @@ impl Default for ObservabilityConfig {
             service_version: env!("CARGO_PKG_VERSION").to_string(),
             sampling_ratio: 1.0,
             timeout: DEFAULT_TIMEOUT,
+            verify_presence_oracle: false,
         }
     }
 }
@@ -146,6 +156,13 @@ impl ObservabilityConfig {
         if let Some(v) = env_str("CQLITE_OTEL_TIMEOUT_MS") {
             if let Ok(ms) = v.trim().parse::<u64>() {
                 cfg.timeout = Duration::from_millis(ms);
+            }
+        }
+        // Issue #2163: presence-oracle false-negative verification switch. Mirrors
+        // the process-global runtime switch the read path consults (same env var).
+        if let Some(v) = env_str("CQLITE_VERIFY_PRESENCE_ORACLE") {
+            if let Some(b) = parse_bool(&v) {
+                cfg.verify_presence_oracle = b;
             }
         }
 
@@ -207,6 +224,11 @@ impl ObservabilityConfigBuilder {
         self.config.timeout = timeout;
         self
     }
+    /// Enable/disable presence-oracle false-negative verification (issue #2163).
+    pub fn verify_presence_oracle(mut self, verify: bool) -> Self {
+        self.config.verify_presence_oracle = verify;
+        self
+    }
     /// Finish building.
     pub fn build(self) -> ObservabilityConfig {
         let mut cfg = self.config;
@@ -244,6 +266,7 @@ mod tests {
         assert_eq!(cfg.sampling_ratio, 1.0);
         assert_eq!(cfg.timeout, DEFAULT_TIMEOUT);
         assert_eq!(cfg.service_version, env!("CARGO_PKG_VERSION"));
+        assert!(!cfg.verify_presence_oracle);
     }
 
     #[test]
@@ -318,6 +341,7 @@ mod tests {
             "CQLITE_OTEL_SERVICE_VERSION",
             "CQLITE_OTEL_SAMPLING_RATIO",
             "CQLITE_OTEL_TIMEOUT_MS",
+            "CQLITE_VERIFY_PRESENCE_ORACLE",
         ];
         // Save + clear.
         let saved: Vec<_> = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
@@ -329,9 +353,11 @@ mod tests {
         let cfg = ObservabilityConfig::from_env();
         assert!(!cfg.enabled);
         assert_eq!(cfg.endpoint, DEFAULT_ENDPOINT);
+        assert!(!cfg.verify_presence_oracle);
 
         // Set every var.
         std::env::set_var("CQLITE_OTEL_ENABLED", "true");
+        std::env::set_var("CQLITE_VERIFY_PRESENCE_ORACLE", "on");
         std::env::set_var("CQLITE_OTEL_ENDPOINT", "http://c:4318");
         std::env::set_var("CQLITE_OTEL_PROTOCOL", "http");
         std::env::set_var("CQLITE_OTEL_SERVICE_NAME", "mysvc");
@@ -346,6 +372,7 @@ mod tests {
         assert_eq!(cfg.service_version, "1.2.3");
         assert_eq!(cfg.sampling_ratio, 0.25);
         assert_eq!(cfg.timeout, Duration::from_millis(2500));
+        assert!(cfg.verify_presence_oracle);
 
         // Unparseable ratio / timeout fall back to defaults; bad protocol keeps default.
         std::env::set_var("CQLITE_OTEL_SAMPLING_RATIO", "not-a-number");

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -294,12 +294,22 @@ impl ObservabilityGuard {
 }
 
 /// Initialise observability from `cfg`. When the `observability` feature is
-/// disabled this is a no-op that returns an inert [`ObservabilityGuard`], so
-/// callers (CLI, Flight, bindings) can call it unconditionally.
+/// disabled this is a no-op (no OTel wiring) that returns an inert
+/// [`ObservabilityGuard`], so callers (CLI, Flight, bindings) can call it
+/// unconditionally.
+///
+/// It STILL plumbs `cfg.verify_presence_oracle` into the presence-oracle
+/// false-negative verification switch (issue #2163, roborev r4): that switch is
+/// an always-compiled storage-layer knob, independent of whether the OTel export
+/// stack is linked, so a config-only build without the `observability` feature
+/// can still enable the confirmation-scan correctness check (its counter emit is
+/// simply a no-op in that build, per the module's zero-cost-when-off contract).
 #[cfg(not(feature = "observability"))]
 #[inline]
 pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
-    let _ = cfg;
+    crate::storage::sstable::reader::presence_verification::apply_config(
+        cfg.verify_presence_oracle,
+    );
     Ok(ObservabilityGuard { _private: () })
 }
 

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -341,7 +341,9 @@ fn instruments() -> &'static Instruments {
             read_sstables_pruned: m
                 .u64_counter(catalog::READ_SSTABLES_PRUNED)
                 .with_unit(catalog::unit::SSTABLES)
-                .with_description("SSTables skipped by a presence-oracle negative, keyed by {format}.")
+                .with_description(
+                    "SSTables skipped by a presence-oracle negative, keyed by {format}.",
+                )
                 .build(),
             read_bloom_false_negatives: m
                 .u64_counter(catalog::READ_BLOOM_FALSE_NEGATIVES)
@@ -363,7 +365,9 @@ fn instruments() -> &'static Instruments {
             query_degraded_path: m
                 .u64_counter(catalog::QUERY_DEGRADED_PATH)
                 .with_unit(catalog::unit::DIMENSIONLESS)
-                .with_description("SELECTs taking a soundness fallback, keyed by {fallback_reason}.")
+                .with_description(
+                    "SELECTs taking a soundness fallback, keyed by {fallback_reason}.",
+                )
                 .build(),
             storage_open_sstables: m
                 .u64_counter(catalog::STORAGE_OPEN_SSTABLES)

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -163,6 +163,16 @@ impl Drop for ObservabilityGuard {
 /// subscriber and add [`tracing_layer`] to it — see the module docs on
 /// [`crate::observability`].
 pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
+    // Issue #2163 (roborev r4): plumb the presence-oracle verification config
+    // field into the runtime switch the read path actually consults — applied
+    // UNCONDITIONALLY (even when `cfg.enabled == false`, i.e. OTel export itself
+    // is off), since the switch also drives the confirmation-scan + warning-log
+    // side effect independent of metric export. `apply_config` itself honors
+    // env-overrides-config precedence.
+    crate::storage::sstable::reader::presence_verification::apply_config(
+        cfg.verify_presence_oracle,
+    );
+
     if !cfg.enabled {
         return Ok(ObservabilityGuard::inert());
     }

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -259,6 +259,11 @@ struct Instruments {
     read_partition_lookup: Counter<u64>,
     read_bloom_checks: Counter<u64>,
     read_scan_window_refill: Counter<u64>,
+    read_sstables_pruned: Counter<u64>,
+    read_bloom_false_negatives: Counter<u64>,
+    merge_rows_in: Counter<u64>,
+    merge_rows_out: Counter<u64>,
+    query_degraded_path: Counter<u64>,
     storage_open_sstables: Counter<u64>,
     storage_open_bytes: Counter<u64>,
     storage_open_tables: Counter<u64>,
@@ -276,6 +281,8 @@ struct Instruments {
     compaction_sstables_in: Counter<u64>,
     compaction_sstables_out: Counter<u64>,
     compaction_tombstones_purged: Counter<u64>,
+    compaction_tombstones_suppressed: Counter<u64>,
+    compaction_tombstones_emitted: Counter<u64>,
     rpc_requests: Counter<u64>,
     rpc_rows: Counter<u64>,
     rpc_bytes: Counter<u64>,
@@ -330,6 +337,33 @@ fn instruments() -> &'static Instruments {
                 .u64_counter(catalog::READ_SCAN_WINDOW_REFILL)
                 .with_unit(catalog::unit::DIMENSIONLESS)
                 .with_description("Windowed scan refills at compression-chunk boundaries.")
+                .build(),
+            read_sstables_pruned: m
+                .u64_counter(catalog::READ_SSTABLES_PRUNED)
+                .with_unit(catalog::unit::SSTABLES)
+                .with_description("SSTables skipped by a presence-oracle negative, keyed by {format}.")
+                .build(),
+            read_bloom_false_negatives: m
+                .u64_counter(catalog::READ_BLOOM_FALSE_NEGATIVES)
+                .with_unit(catalog::unit::DIMENSIONLESS)
+                .with_description(
+                    "Opt-in presence-oracle false negatives (soundness alarm), keyed by {format}.",
+                )
+                .build(),
+            merge_rows_in: m
+                .u64_counter(catalog::MERGE_ROWS_IN)
+                .with_unit(catalog::unit::ROWS)
+                .with_description("Rows consumed at the k-way merge reconcile boundary.")
+                .build(),
+            merge_rows_out: m
+                .u64_counter(catalog::MERGE_ROWS_OUT)
+                .with_unit(catalog::unit::ROWS)
+                .with_description("Rows emitted by the k-way merge reconcile boundary.")
+                .build(),
+            query_degraded_path: m
+                .u64_counter(catalog::QUERY_DEGRADED_PATH)
+                .with_unit(catalog::unit::DIMENSIONLESS)
+                .with_description("SELECTs taking a soundness fallback, keyed by {fallback_reason}.")
                 .build(),
             storage_open_sstables: m
                 .u64_counter(catalog::STORAGE_OPEN_SSTABLES)
@@ -413,8 +447,18 @@ fn instruments() -> &'static Instruments {
                 .build(),
             compaction_tombstones_purged: m
                 .u64_counter(catalog::COMPACTION_TOMBSTONES_PURGED)
-                .with_unit("{tombstone}")
+                .with_unit(catalog::unit::TOMBSTONES)
                 .with_description("Tombstones genuinely purged during compaction.")
+                .build(),
+            compaction_tombstones_suppressed: m
+                .u64_counter(catalog::COMPACTION_TOMBSTONES_SUPPRESSED)
+                .with_unit(catalog::unit::TOMBSTONES)
+                .with_description("Live cells/rows shadowed by a tombstone during reconciliation.")
+                .build(),
+            compaction_tombstones_emitted: m
+                .u64_counter(catalog::COMPACTION_TOMBSTONES_EMITTED)
+                .with_unit(catalog::unit::TOMBSTONES)
+                .with_description("Tombstone markers retained into the merge output.")
                 .build(),
             rpc_requests: m
                 .u64_counter(catalog::RPC_REQUESTS)
@@ -524,6 +568,11 @@ pub(crate) fn add_counter(name: &'static str, value: u64, attributes: &[KeyValue
         catalog::READ_PARTITION_LOOKUP => &i.read_partition_lookup,
         catalog::READ_BLOOM_CHECKS => &i.read_bloom_checks,
         catalog::READ_SCAN_WINDOW_REFILL => &i.read_scan_window_refill,
+        catalog::READ_SSTABLES_PRUNED => &i.read_sstables_pruned,
+        catalog::READ_BLOOM_FALSE_NEGATIVES => &i.read_bloom_false_negatives,
+        catalog::MERGE_ROWS_IN => &i.merge_rows_in,
+        catalog::MERGE_ROWS_OUT => &i.merge_rows_out,
+        catalog::QUERY_DEGRADED_PATH => &i.query_degraded_path,
         catalog::STORAGE_OPEN_SSTABLES => &i.storage_open_sstables,
         catalog::STORAGE_OPEN_BYTES => &i.storage_open_bytes,
         catalog::STORAGE_OPEN_TABLES => &i.storage_open_tables,
@@ -541,6 +590,8 @@ pub(crate) fn add_counter(name: &'static str, value: u64, attributes: &[KeyValue
         catalog::COMPACTION_SSTABLES_IN => &i.compaction_sstables_in,
         catalog::COMPACTION_SSTABLES_OUT => &i.compaction_sstables_out,
         catalog::COMPACTION_TOMBSTONES_PURGED => &i.compaction_tombstones_purged,
+        catalog::COMPACTION_TOMBSTONES_SUPPRESSED => &i.compaction_tombstones_suppressed,
+        catalog::COMPACTION_TOMBSTONES_EMITTED => &i.compaction_tombstones_emitted,
         catalog::RPC_REQUESTS => &i.rpc_requests,
         catalog::RPC_ROWS => &i.rpc_rows,
         catalog::RPC_BYTES => &i.rpc_bytes,

--- a/cqlite-core/src/query/access_path.rs
+++ b/cqlite-core/src/query/access_path.rs
@@ -223,7 +223,24 @@ static LAST_ACCESS_PATH: ArcSwapOption<AccessPath> = ArcSwapOption::const_empty(
 /// reads [`last`] reflects the path the query actually took. The store is lock-free
 /// and infallible (no poisoning surface); recording is a diagnostic side channel and
 /// never aborts a query.
+///
+/// Additionally emits the degraded read-path counter
+/// (`cqlite.query.degraded_path.total`, issue #2163) exactly when `path` is an
+/// honest [`AccessPath::FallbackFullScan`], carrying the bounded
+/// [`FallbackReason::label`] as `cqlite.query.fallback_reason`. A targeted path
+/// never increments it. The emission is a no-op with zero OTel linkage when the
+/// `observability` feature is off.
 pub fn record(path: AccessPath) {
+    if let AccessPath::FallbackFullScan { reason } = &path {
+        crate::observability::add_counter(
+            crate::observability::catalog::QUERY_DEGRADED_PATH,
+            1,
+            &[(
+                crate::observability::catalog::attr::FALLBACK_REASON,
+                reason.label().into(),
+            )],
+        );
+    }
     LAST_ACCESS_PATH.store(Some(Arc::new(path)));
 }
 

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1343,20 +1343,25 @@ impl SSTableManager {
         readers
             .iter()
             .filter(|r| {
-                // BTI candidates prune via the one `locate` façade (issue #1599 / G3),
-                // fed the hoisted C4 encoding: the `Partitions.db` trie is the
-                // authoritative presence oracle, so a `None` is a definitive absent
-                // (drop) and an `Err` (corrupt trie) is conservatively kept. This is
+                // BTI candidates prune via `might_contain_partition_encoded` (fed the
+                // hoisted C4 encoding), the SAME single emit site the raw-key BIG
+                // bloom prune below uses (issue #2163): the `Partitions.db` trie is
+                // the authoritative presence oracle, so a `false` (trie miss) is a
+                // definitive absent (drop) — recorded once as
+                // `cqlite.read.sstables_pruned{format=bti}` — and an `Err` (corrupt
+                // trie) is conservatively kept (not pruned, not recorded). This is
                 // congruent with the façade's resolution — a BTI trie result is
                 // authoritative. BIG candidates DELIBERATELY stay on the bloom-based
                 // `might_contain_partition`: a BIG `Index.db` miss is NOT a definitive
                 // absent (#1572 truncated-index invariant), so pruning a BIG reader on
                 // the façade's index probe would drop a candidate that actually holds
                 // the partition. Only the bloom filter never yields a false negative.
+                // Sharing ONE emit site (`might_contain_partition[_encoded]`) for both
+                // formats means a caller that also `locate`s the same key afterward
+                // (the actual read) never double-emits: `locate`/`locate_encoded`
+                // themselves never call `emit_sstable_pruned`.
                 match (r.is_bti(), &encoded) {
-                    (true, Some(enc)) => {
-                        matches!(r.locate_encoded(partition_key, enc), Ok(Some(_)) | Err(_))
-                    }
+                    (true, Some(enc)) => r.might_contain_partition_encoded(partition_key, enc),
                     // Non-BTI reader (or, defensively, no encoding): bloom prune.
                     _ => r.might_contain_partition(partition_key),
                 }

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1329,45 +1329,106 @@ impl SSTableManager {
     /// encoding to hoist — its raw-key bloom check runs unchanged — so a non-BTI or
     /// mixed candidate set stays correct. The pruning decision (and therefore the
     /// resulting rows) is byte-identical to the per-candidate path.
+    /// Returns `(admitted, pruned)`: `admitted` are the SAME byte-for-byte
+    /// filtered candidates the original single-`Vec` `prune_candidates` returned;
+    /// `pruned` are every reader EXCLUDED by the presence-oracle check — each is,
+    /// by construction, a definitive-negative exclusion (the filter's ONLY
+    /// criterion), so `pruned` is exactly the set
+    /// [`verify_pruned_candidates`](Self::verify_pruned_candidates) needs to
+    /// authoritatively re-check (issue #2163's core silent-miss case: a false
+    /// negative HERE, at the multi-generation candidate prune, would otherwise
+    /// drop that SSTable from the read with no verification ever reached — the
+    /// per-reader `get_with_resolution` verify hook only covers a single reader's
+    /// OWN point read, never a candidate eliminated at this layer).
     #[cfg(not(feature = "tombstones"))]
     fn prune_candidates(
         readers: &[Arc<reader::SSTableReader>],
         partition_key: &[u8],
-    ) -> Vec<Arc<reader::SSTableReader>> {
+    ) -> (
+        Vec<Arc<reader::SSTableReader>>,
+        Vec<Arc<reader::SSTableReader>>,
+    ) {
         use crate::storage::sstable::bti::encode_partition_key_for_bti_trie;
         // Encode once iff a BTI reader is present (BIG readers ignore `encoded`).
         let encoded = readers
             .iter()
             .any(|r| r.is_bti())
             .then(|| encode_partition_key_for_bti_trie(partition_key));
-        readers
-            .iter()
-            .filter(|r| {
-                // BTI candidates prune via `might_contain_partition_encoded` (fed the
-                // hoisted C4 encoding), the SAME single emit site the raw-key BIG
-                // bloom prune below uses (issue #2163): the `Partitions.db` trie is
-                // the authoritative presence oracle, so a `false` (trie miss) is a
-                // definitive absent (drop) — recorded once as
-                // `cqlite.read.sstables_pruned{format=bti}` — and an `Err` (corrupt
-                // trie) is conservatively kept (not pruned, not recorded). This is
-                // congruent with the façade's resolution — a BTI trie result is
-                // authoritative. BIG candidates DELIBERATELY stay on the bloom-based
-                // `might_contain_partition`: a BIG `Index.db` miss is NOT a definitive
-                // absent (#1572 truncated-index invariant), so pruning a BIG reader on
-                // the façade's index probe would drop a candidate that actually holds
-                // the partition. Only the bloom filter never yields a false negative.
-                // Sharing ONE emit site (`might_contain_partition[_encoded]`) for both
-                // formats means a caller that also `locate`s the same key afterward
-                // (the actual read) never double-emits: `locate`/`locate_encoded`
-                // themselves never call `emit_sstable_pruned`.
-                match (r.is_bti(), &encoded) {
-                    (true, Some(enc)) => r.might_contain_partition_encoded(partition_key, enc),
-                    // Non-BTI reader (or, defensively, no encoding): bloom prune.
-                    _ => r.might_contain_partition(partition_key),
-                }
-            })
-            .cloned()
-            .collect()
+        readers.iter().cloned().partition(|r| {
+            // BTI candidates prune via `might_contain_partition_encoded` (fed the
+            // hoisted C4 encoding), the SAME single emit site the raw-key BIG
+            // bloom prune below uses (issue #2163): the `Partitions.db` trie is
+            // the authoritative presence oracle, so a `false` (trie miss) is a
+            // definitive absent (drop) — recorded once as
+            // `cqlite.read.sstables_pruned{format=bti}` — and an `Err` (corrupt
+            // trie) is conservatively kept (not pruned, not recorded). This is
+            // congruent with the façade's resolution — a BTI trie result is
+            // authoritative. BIG candidates DELIBERATELY stay on the bloom-based
+            // `might_contain_partition`: a BIG `Index.db` miss is NOT a definitive
+            // absent (#1572 truncated-index invariant), so pruning a BIG reader on
+            // the façade's index probe would drop a candidate that actually holds
+            // the partition. Only the bloom filter never yields a false negative.
+            // Sharing ONE emit site (`might_contain_partition[_encoded]`) for both
+            // formats means a caller that also `locate`s the same key afterward
+            // (the actual read) never double-emits: `locate`/`locate_encoded`
+            // themselves never call `emit_sstable_pruned`.
+            match (r.is_bti(), &encoded) {
+                (true, Some(enc)) => r.might_contain_partition_encoded(partition_key, enc),
+                // Non-BTI reader (or, defensively, no encoding): bloom prune.
+                _ => r.might_contain_partition(partition_key),
+            }
+        })
+    }
+
+    /// Verify presence-oracle negatives for SSTables EXCLUDED by
+    /// [`prune_candidates`](Self::prune_candidates) — issue #2163's core
+    /// silent-miss case, roborev r6. A bloom/BTI-trie false negative during a
+    /// MULTI-generation candidate prune would otherwise drop that SSTable from
+    /// the read entirely, unverified: the per-reader `get_with_resolution` opt-in
+    /// verify hook (`data_access/mod.rs`) never runs for a candidate eliminated
+    /// one layer up, at THIS prune site — a candidate excluded here never reaches
+    /// `get_with_resolution` at all for this read.
+    ///
+    /// STRICTLY inside the opt-in switch (default-off = zero extra work,
+    /// unchanged behaviour): when
+    /// [`presence_verification::enabled`](reader::presence_verification::enabled)
+    /// is `false` (the default), this returns immediately without touching
+    /// `pruned` at all. When enabled, each pruned reader is verified via
+    /// [`SSTableReader::verify_presence_oracle_negative`] (an authoritative
+    /// confirmation scan): a genuine contradiction increments
+    /// `cqlite.read.bloom.false_negatives` EXACTLY ONCE per contradicted
+    /// negative (the verify method's own single per-call emit — this loop calls
+    /// it once per pruned reader, never more). Any `Err` fails OPEN (the
+    /// caller's admitted `candidates` list is never touched) but is surfaced
+    /// LOUDLY via the SAME loud-failure contract `get_with_resolution` uses
+    /// (roborev r4): an error-level log with context, and a record through the
+    /// EXISTING error-rate signal (`cqlite.errors.total{subsystem=reader}`,
+    /// issue #1038) — never a new metric.
+    #[cfg(not(feature = "tombstones"))]
+    async fn verify_pruned_candidates(
+        pruned: &[Arc<reader::SSTableReader>],
+        table_id: &TableId,
+        partition_key: &[u8],
+    ) {
+        if !reader::presence_verification::enabled() {
+            return;
+        }
+        for r in pruned {
+            if let Err(e) = r
+                .verify_presence_oracle_negative(table_id, partition_key)
+                .await
+            {
+                tracing::error!(
+                    error = %e,
+                    sstable_format = r.sstable_format_label(),
+                    "opt-in presence-oracle false-negative verification scan FAILED for a \
+                     prune_candidates-excluded SSTable — the read itself is unaffected \
+                     (fail-open), but this soundness check could not run for this SSTable and \
+                     needs investigation"
+                );
+                crate::observability::record_error(&e, "reader");
+            }
+        }
     }
 
     #[cfg(not(feature = "tombstones"))]
@@ -1390,7 +1451,14 @@ impl SSTableManager {
         // Prune: keep only SSTables whose bloom filter / BTI trie admit the key.
         // This is the property #962 requires — only candidates are opened, never N.
         // C4 (#1575): the BTI key hash+encoding is hoisted to once per read here.
-        let candidates = Self::prune_candidates(&reader_list, partition_key);
+        let (candidates, pruned) = Self::prune_candidates(&reader_list, partition_key);
+
+        // Issue #2163 (roborev r6): opt-in verification of every EXCLUDED
+        // candidate — a strict no-op unless the switch is on. Runs BEFORE the
+        // `candidates.is_empty()` early-return below, since the core silent-miss
+        // case is exactly "every admitted candidate came up empty because a
+        // false negative wrongly pruned the ONE generation holding the key".
+        Self::verify_pruned_candidates(&pruned, table_id, partition_key).await;
 
         tracing::debug!(
             "SSTableManager::scan_partition_with_cell_metadata - {}/{} SSTables admit partition \
@@ -1554,7 +1622,12 @@ impl SSTableManager {
 
         // Prune: keep only SSTables whose bloom filter / BTI trie admit the key.
         // C4 (#1575): the BTI key hash+encoding is hoisted to once per read here.
-        let candidates = Self::prune_candidates(&reader_list, partition_key);
+        let (candidates, pruned) = Self::prune_candidates(&reader_list, partition_key);
+
+        // Issue #2163 (roborev r6): opt-in verification of every EXCLUDED
+        // candidate — a strict no-op unless the switch is on. See
+        // `verify_pruned_candidates` for the fail-open / loud-failure contract.
+        Self::verify_pruned_candidates(&pruned, table_id, partition_key).await;
 
         tracing::debug!(
             "SSTableManager::scan_partition - {}/{} SSTables admit partition key (len={}) for '{}'",

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
@@ -54,12 +54,22 @@ impl SSTableReader {
     ///
     /// `fully_qualified_match` is threaded through to the shared decode's per-row
     /// table-consistency guard exactly as the BTI path does (issue #1321 / #1284).
+    ///
+    /// Returns `(row, oracle_pruned)` (issue #2163): `oracle_pruned` is `true`
+    /// ONLY for the Step 1 bloom-definite-miss branch — this SSTable was excluded
+    /// from the read by the presence oracle BEFORE any Index.db probe, decode, or
+    /// scan. Every other `None` outcome (including one reached via the authoritative
+    /// `scan_for_key` fallback, which already performed its OWN confirming scan) is
+    /// NOT an oracle exclusion and reports `oracle_pruned = false`, so the caller
+    /// (`get_with_resolution`) neither double-counts `cqlite.read.sstables_pruned`
+    /// nor runs a REDUNDANT second confirmation scan when the opt-in false-negative
+    /// verification is enabled (roborev r4, #2163).
     pub(super) async fn big_get_with_resolution(
         &self,
         table_id: &TableId,
         key: &RowKey,
         fully_qualified_match: bool,
-    ) -> Result<Option<ScanRow>> {
+    ) -> Result<(Option<ScanRow>, bool)> {
         use crate::observability::{self as obs, catalog};
 
         // 1. Bloom pre-check (unchanged behaviour): a definite miss short-circuits.
@@ -80,7 +90,8 @@ impl SSTableReader {
                 ],
             );
             if !present {
-                return Ok(None);
+                // Definitive presence-oracle negative — an oracle exclusion.
+                return Ok((None, true));
             }
         }
 
@@ -118,9 +129,9 @@ impl SSTableReader {
                         .await?;
                     if let Some(value) = found {
                         if !self.filter_tombstone(&value) {
-                            return Ok(None);
+                            return Ok((None, false));
                         }
-                        return Ok(Some(value));
+                        return Ok((Some(value), false));
                     }
                     // Exact index hit but no matching row decoded (schema-unavailable
                     // soft-miss / benign table-guard rejection). Fall through to the
@@ -142,7 +153,11 @@ impl SSTableReader {
                     // counter observable. The fast definitive-absent path for the
                     // common (non-degraded) case is the bloom pre-check above; this
                     // fallback fires only on a bloom false-positive (rare, acceptable).
-                    return self.scan_for_key(table_id, key).await;
+                    // NOT an oracle exclusion: the scan itself is the authority here.
+                    return self
+                        .scan_for_key(table_id, key)
+                        .await
+                        .map(|row| (row, false));
                 }
             }
         }
@@ -151,6 +166,8 @@ impl SSTableReader {
         //    NOTE: `self.index` (SSTableIndex) is keyed on key digests, so
         //    `find_entry()` with raw key bytes misses; retained for the size==0
         //    uncompressed handling and the writer-produced-index cases (issue #517).
+        //    Neither branch below is an oracle exclusion: each either scans
+        //    authoritatively or decodes a resolved offset.
         if let Some(index) = &self.index {
             if let Some(entry) = index.find_entry(table_id, key).await? {
                 if entry.size == 0 {
@@ -158,13 +175,21 @@ impl SSTableReader {
                         "Index reports size=0 for key {:?}, using sequential scan fallback",
                         key
                     );
-                    return self.scan_for_key(table_id, key).await;
+                    return self
+                        .scan_for_key(table_id, key)
+                        .await
+                        .map(|row| (row, false));
                 }
                 // Index offsets are relative to data section start - adjust for header.
                 let file_offset = entry.offset + self.actual_header_size as u64;
-                return self.read_value_at_offset(file_offset, entry.size).await;
+                return self
+                    .read_value_at_offset(file_offset, entry.size)
+                    .await
+                    .map(|row| (row, false));
             }
         }
-        self.scan_for_key(table_id, key).await
+        self.scan_for_key(table_id, key)
+            .await
+            .map(|row| (row, false))
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti_point.rs
@@ -45,12 +45,21 @@ impl SSTableReader {
     /// fallback. It gates the per-row table-consistency guard in
     /// `bti_decompress_and_parse_target`: an exact FQ match may relax across a
     /// header-keyspace divergence, while a fallback keeps strict keyspace matching.
+    ///
+    /// Returns `(row, oracle_pruned)` (issue #2163): `oracle_pruned` is `true`
+    /// ONLY for the Step 1 trie-miss branch — this SSTable was excluded from the
+    /// read by the presence oracle BEFORE any decode was attempted. Every other
+    /// `None` outcome (a decoded-but-non-matching prefix-collision candidate, a
+    /// tombstone) is NOT an oracle exclusion and reports `oracle_pruned = false`,
+    /// so the caller (`get_with_resolution`) emits `cqlite.read.sstables_pruned`
+    /// and runs the opt-in false-negative verification ONLY for a genuine
+    /// definitive negative — never for a row this reader actually examined.
     pub(super) async fn bti_point_lookup(
         &self,
         table_id: &TableId,
         key: &RowKey,
         fully_qualified_match: bool,
-    ) -> Result<Option<ScanRow>> {
+    ) -> Result<(Option<ScanRow>, bool)> {
         // 1. Resolve the uncompressed Data.db offset via the one `locate` façade
         //    (issue #1599 / G3). For a BTI reader `locate` runs the C5 step (a no-op
         //    — BTI has no Summary bound, so nothing is short-circuited or recorded)
@@ -60,7 +69,8 @@ impl SSTableReader {
         //    `locate` returns `(offset, 0)` and we use only the offset.
         let offset = match self.locate(key.as_bytes()).await? {
             Some((off, _size)) => off as usize,
-            None => return Ok(None), // not in this SSTable (authoritative trie miss)
+            // Not in this SSTable (authoritative trie miss) — an oracle exclusion.
+            None => return Ok((None, true)),
         };
 
         // 2. Obtain a DECOMPRESSED window that contains the target partition.
@@ -89,14 +99,17 @@ impl SSTableReader {
             )
             .await?;
 
+        // Steps 2+ decoded (or attempted to decode) actual partition data — the
+        // trie admitted this SSTable, so any `None` here (prefix-collision
+        // candidate that didn't match, or a tombstone) is NOT an oracle exclusion.
         match found {
             Some(value) => {
                 if !self.filter_tombstone(&value) {
-                    return Ok(None);
+                    return Ok((None, false));
                 }
-                Ok(Some(value))
+                Ok((Some(value), false))
             }
-            None => Ok(None),
+            None => Ok((None, false)),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -44,6 +44,9 @@ mod compaction;
 // `read_compressed_offset_window` helper out of this already-large entry-point file.
 mod compressed_offset;
 mod model;
+// Opt-in presence-oracle false-negative verification method (issue #2163), kept
+// out of this already-large entry-point file (campsite rule, epic #1116).
+mod presence_verify;
 // First/last-key range short-circuit (issue #1576, C5): an authoritative
 // `[first_key, last_key]` bound check that answers out-of-range point reads as
 // absence before any bloom/Index.db/trie work.
@@ -231,48 +234,6 @@ impl SSTableReader {
             }
         }
         result
-    }
-
-    /// Authoritatively verify a presence-oracle "definitely absent" verdict for
-    /// `partition_key` in THIS SSTable (issue #2163, opt-in / default-off).
-    ///
-    /// When the [`presence_verification`](super::presence_verification) switch is
-    /// OFF (the default) this returns `Ok(false)` WITHOUT scanning — zero cost.
-    /// When ON, it runs an AUTHORITATIVE sequential scan of this SSTable's own
-    /// Data.db for the key (never a heuristic inference from byte patterns — the
-    /// no-heuristics mandate). If the scan FINDS the key, the oracle produced a
-    /// false negative: `cqlite.read.bloom.false_negatives` increments once with
-    /// this SSTable's bounded `cqlite.sstable.format`, a warning is logged, and
-    /// `Ok(true)` is returned. A genuine absence returns `Ok(false)` and never
-    /// emits. Under a correct bloom/BTI-trie the counter stays 0.
-    pub async fn verify_presence_oracle_negative(
-        &self,
-        table_id: &TableId,
-        partition_key: &[u8],
-    ) -> Result<bool> {
-        use crate::observability::{self as obs, catalog};
-
-        if !super::presence_verification::enabled() {
-            return Ok(false);
-        }
-        // Authoritative confirmation: walk this SSTable's Data.db for the key.
-        let key = RowKey::from(partition_key.to_vec());
-        let found = self.scan_for_key(table_id, &key).await?.is_some();
-        if found {
-            let format = self.sstable_format_label();
-            obs::add_counter(
-                catalog::READ_BLOOM_FALSE_NEGATIVES,
-                1,
-                &[(catalog::attr::SSTABLE_FORMAT, format.into())],
-            );
-            warn!(
-                sstable_format = format,
-                partition_key_len = partition_key.len(),
-                "presence-oracle false negative: a key reported definitely absent was found by an \
-                 authoritative scan — the bloom/BTI-trie is unsound for this SSTable"
-            );
-        }
-        Ok(found)
     }
 
     /// Stitch all compressed chunks and parse as a single buffer (V5CompressedLegacy)

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -205,20 +205,74 @@ impl SSTableReader {
         // the reader's would otherwise cause false negatives and drop live
         // partitions (the writer→reader roundtrip #909 must read back). It also
         // guarantees a BTI get() can never fall through to scan_for_key.
-        if self.bti_partitions_db.is_some() {
-            return self
-                .bti_point_lookup(table_id, key, fully_qualified_match)
-                .await;
-        }
+        let result = if self.bti_partitions_db.is_some() {
+            self.bti_point_lookup(table_id, key, fully_qualified_match)
+                .await
+        } else {
+            // BIG ("nb"/uncompressed) readers: raw-key Index.db resolve +
+            // covering-chunk seek (issue #1572). The bloom pre-check, the fast
+            // Index.db-resolved chunk-targeted decode, and the index-less
+            // `scan_for_key` fallback all live in `big_point`.
+            self.big_get_with_resolution(table_id, key, fully_qualified_match)
+                .await
+        };
 
-        // BIG ("nb"/uncompressed) readers: raw-key Index.db resolve + covering-chunk
-        // seek (issue #1572). The bloom pre-check, the fast Index.db-resolved
-        // chunk-targeted decode, and the index-less `scan_for_key` fallback all live
-        // in `big_point`. Before #1572 this path called `self.index.find_entry()`
-        // with raw key bytes against a *digest*-keyed map (always a miss, issue
-        // #517), so every lookup fell through to a whole-file `scan_for_key`.
-        self.big_get_with_resolution(table_id, key, fully_qualified_match)
-            .await
+        // Issue #2163: opt-in presence-oracle false-negative verification. On an
+        // absent point read (the oracle's negative), when the default-off switch is
+        // enabled, an AUTHORITATIVE confirmation scan proves the negative truthful;
+        // a contradiction increments `cqlite.read.bloom.false_negatives`. Off by
+        // default → this whole block is skipped and the read costs nothing extra
+        // (in particular a BTI point read still never reaches `scan_for_key`).
+        if let Ok(None) = &result {
+            if super::presence_verification::enabled() {
+                let _ = self
+                    .verify_presence_oracle_negative(table_id, key.as_bytes())
+                    .await;
+            }
+        }
+        result
+    }
+
+    /// Authoritatively verify a presence-oracle "definitely absent" verdict for
+    /// `partition_key` in THIS SSTable (issue #2163, opt-in / default-off).
+    ///
+    /// When the [`presence_verification`](super::presence_verification) switch is
+    /// OFF (the default) this returns `Ok(false)` WITHOUT scanning — zero cost.
+    /// When ON, it runs an AUTHORITATIVE sequential scan of this SSTable's own
+    /// Data.db for the key (never a heuristic inference from byte patterns — the
+    /// no-heuristics mandate). If the scan FINDS the key, the oracle produced a
+    /// false negative: `cqlite.read.bloom.false_negatives` increments once with
+    /// this SSTable's bounded `cqlite.sstable.format`, a warning is logged, and
+    /// `Ok(true)` is returned. A genuine absence returns `Ok(false)` and never
+    /// emits. Under a correct bloom/BTI-trie the counter stays 0.
+    pub async fn verify_presence_oracle_negative(
+        &self,
+        table_id: &TableId,
+        partition_key: &[u8],
+    ) -> Result<bool> {
+        use crate::observability::{self as obs, catalog};
+
+        if !super::presence_verification::enabled() {
+            return Ok(false);
+        }
+        // Authoritative confirmation: walk this SSTable's Data.db for the key.
+        let key = RowKey::from(partition_key.to_vec());
+        let found = self.scan_for_key(table_id, &key).await?.is_some();
+        if found {
+            let format = self.sstable_format_label();
+            obs::add_counter(
+                catalog::READ_BLOOM_FALSE_NEGATIVES,
+                1,
+                &[(catalog::attr::SSTABLE_FORMAT, format.into())],
+            );
+            warn!(
+                sstable_format = format,
+                partition_key_len = partition_key.len(),
+                "presence-oracle false negative: a key reported definitely absent was found by an \
+                 authoritative scan — the bloom/BTI-trie is unsound for this SSTable"
+            );
+        }
+        Ok(found)
     }
 
     /// Stitch all compressed chunks and parse as a single buffer (V5CompressedLegacy)

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -208,32 +208,47 @@ impl SSTableReader {
         // the reader's would otherwise cause false negatives and drop live
         // partitions (the writer→reader roundtrip #909 must read back). It also
         // guarantees a BTI get() can never fall through to scan_for_key.
-        let result = if self.bti_partitions_db.is_some() {
+        let (row, oracle_pruned) = if self.bti_partitions_db.is_some() {
             self.bti_point_lookup(table_id, key, fully_qualified_match)
-                .await
+                .await?
         } else {
             // BIG ("nb"/uncompressed) readers: raw-key Index.db resolve +
             // covering-chunk seek (issue #1572). The bloom pre-check, the fast
             // Index.db-resolved chunk-targeted decode, and the index-less
             // `scan_for_key` fallback all live in `big_point`.
             self.big_get_with_resolution(table_id, key, fully_qualified_match)
-                .await
+                .await?
         };
 
-        // Issue #2163: opt-in presence-oracle false-negative verification. On an
-        // absent point read (the oracle's negative), when the default-off switch is
-        // enabled, an AUTHORITATIVE confirmation scan proves the negative truthful;
-        // a contradiction increments `cqlite.read.bloom.false_negatives`. Off by
-        // default → this whole block is skipped and the read costs nothing extra
-        // (in particular a BTI point read still never reaches `scan_for_key`).
-        if let Ok(None) = &result {
+        // Issue #2163 (roborev r4): `oracle_pruned` is `true` ONLY when the
+        // presence oracle itself (bloom-miss for BIG / trie-miss for BTI) excluded
+        // this SSTable from the read BEFORE any decode or scan — the PRIMARY
+        // single-reader point-read path, which the spec scenario "a partition
+        // point lookup ... through the public read surface" names directly. This
+        // is the SAME emit site `might_contain_partition[_encoded]` use (via
+        // `emit_sstable_pruned`), so a candidate pre-pruned by
+        // `SSTableManager::prune_candidates` (excluded from the candidate list, so
+        // `get()` is never called on it for this read) is never double-counted:
+        // exactly one of {prune-time check, this get-time check} runs per SSTable
+        // per logical read.
+        if oracle_pruned {
+            self.emit_sstable_pruned();
+
+            // Opt-in presence-oracle false-negative verification: when the
+            // default-off switch is enabled, an AUTHORITATIVE confirmation scan
+            // proves this exclusion truthful; a contradiction increments
+            // `cqlite.read.bloom.false_negatives`. Off by default → this whole
+            // block is skipped and the read costs nothing extra. Gated on
+            // `oracle_pruned` (not merely `row.is_none()`) so a `None` reached via
+            // the primary path's OWN authoritative `scan_for_key` — which already
+            // IS the confirming scan — never triggers a REDUNDANT second scan.
             if super::presence_verification::enabled() {
                 let _ = self
                     .verify_presence_oracle_negative(table_id, key.as_bytes())
                     .await;
             }
         }
-        result
+        Ok(row)
     }
 
     /// Stitch all compressed chunks and parse as a single buffer (V5CompressedLegacy)

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -243,9 +243,32 @@ impl SSTableReader {
             // the primary path's OWN authoritative `scan_for_key` — which already
             // IS the confirming scan — never triggers a REDUNDANT second scan.
             if super::presence_verification::enabled() {
-                let _ = self
+                if let Err(e) = self
                     .verify_presence_oracle_negative(table_id, key.as_bytes())
-                    .await;
+                    .await
+                {
+                    // Issue #2163 (roborev r5): the READ stays fail-open — a
+                    // verification-scan failure (e.g. `scan_for_key` erroring on
+                    // corruption or an unreadable SSTable) must NEVER fail (or
+                    // even affect) the actual read this opt-in check is merely
+                    // double-checking; `row` above is returned unchanged either
+                    // way. But a SILENT-MISS DETECTOR that itself fails silently
+                    // defeats its own purpose, so the failure is surfaced LOUDLY
+                    // instead of discarded: an error-level log with context, AND
+                    // a record through the EXISTING error-rate signal
+                    // (`cqlite.errors.total{category,subsystem}`, issue #1038) —
+                    // never a new metric. `record_error` maps `Error::Corruption`
+                    // (the typical `scan_for_key` failure mode) to the bounded
+                    // `Corruption` category.
+                    tracing::error!(
+                        error = %e,
+                        sstable_format = self.sstable_format_label(),
+                        "opt-in presence-oracle false-negative verification scan FAILED — the \
+                         read itself is unaffected (fail-open), but this soundness check could \
+                         not run for this SSTable and needs investigation"
+                    );
+                    crate::observability::record_error(&e, "reader");
+                }
             }
         }
         Ok(row)

--- a/cqlite-core/src/storage/sstable/reader/data_access/presence_verify.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/presence_verify.rs
@@ -1,0 +1,56 @@
+//! Opt-in presence-oracle false-negative verification (issue #2163).
+//!
+//! Kept out of the already-large `data_access/mod.rs` entry point (campsite rule,
+//! epic #1116). The verification is wired into the point-read path in
+//! [`SSTableReader::get_with_resolution`](super::SSTableReader::get_with_resolution)
+//! and driven by the default-off switch in
+//! [`crate::storage::sstable::reader::presence_verification`].
+
+use super::SSTableReader;
+use crate::observability::{self as obs, catalog};
+use crate::storage::sstable::reader::presence_verification;
+use crate::types::TableId;
+use crate::{Result, RowKey};
+use tracing::warn;
+
+impl SSTableReader {
+    /// Authoritatively verify a presence-oracle "definitely absent" verdict for
+    /// `partition_key` in THIS SSTable (issue #2163, opt-in / default-off).
+    ///
+    /// When the [`presence_verification`] switch is OFF (the default) this returns
+    /// `Ok(false)` WITHOUT scanning — zero cost. When ON, it runs an AUTHORITATIVE
+    /// sequential scan of this SSTable's own Data.db for the key (never a heuristic
+    /// inference from byte patterns — the no-heuristics mandate). If the scan FINDS
+    /// the key, the oracle produced a false negative:
+    /// `cqlite.read.bloom.false_negatives` increments once with this SSTable's
+    /// bounded `cqlite.sstable.format`, a warning is logged, and `Ok(true)` is
+    /// returned. A genuine absence returns `Ok(false)` and never emits. Under a
+    /// correct bloom/BTI-trie the counter stays 0.
+    pub async fn verify_presence_oracle_negative(
+        &self,
+        table_id: &TableId,
+        partition_key: &[u8],
+    ) -> Result<bool> {
+        if !presence_verification::enabled() {
+            return Ok(false);
+        }
+        // Authoritative confirmation: walk this SSTable's Data.db for the key.
+        let key = RowKey::from(partition_key.to_vec());
+        let found = self.scan_for_key(table_id, &key).await?.is_some();
+        if found {
+            let format = self.sstable_format_label();
+            obs::add_counter(
+                catalog::READ_BLOOM_FALSE_NEGATIVES,
+                1,
+                &[(catalog::attr::SSTABLE_FORMAT, format.into())],
+            );
+            warn!(
+                sstable_format = format,
+                partition_key_len = partition_key.len(),
+                "presence-oracle false negative: a key reported definitely absent was found by an \
+                 authoritative scan — the bloom/BTI-trie is unsound for this SSTable"
+            );
+        }
+        Ok(found)
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -31,8 +31,8 @@ mod key_digest;
 pub(crate) mod parsing; // Needs to be accessible from row_cell_state_machine
 mod partition_lookup;
 pub mod presence_verification; // #2163 opt-in false-negative verification switch
-                               // One format-tagged partition-location façade (issue #1599 / G3): `locate` /
-                               // `locate_encoded` compose the C5 range short-circuit + per-format offset resolve.
+                               // One format-tagged partition-location façade (issue #1599 / G3): `locate`
+                               // composes the C5 range short-circuit + per-format offset resolve.
 mod partition_locator;
 // Next-partition (successor) seek-window offset resolution (issue #953 / #951),
 // split out of `partition_lookup` for the campsite source-size rule (#1116).

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -30,6 +30,9 @@ mod integrity;
 mod key_digest;
 pub(crate) mod parsing; // Needs to be accessible from row_cell_state_machine
 mod partition_lookup;
+// Opt-in, default-off presence-oracle false-negative verification switch
+// (issue #2163). Consulted by the presence-oracle read path.
+pub mod presence_verification;
 // One format-tagged partition-location façade (issue #1599 / G3): `locate` /
 // `locate_encoded` compose the C5 range short-circuit + per-format offset resolve.
 mod partition_locator;

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -30,11 +30,9 @@ mod integrity;
 mod key_digest;
 pub(crate) mod parsing; // Needs to be accessible from row_cell_state_machine
 mod partition_lookup;
-// Opt-in, default-off presence-oracle false-negative verification switch
-// (issue #2163). Consulted by the presence-oracle read path.
-pub mod presence_verification;
-// One format-tagged partition-location façade (issue #1599 / G3): `locate` /
-// `locate_encoded` compose the C5 range short-circuit + per-format offset resolve.
+pub mod presence_verification; // #2163 opt-in false-negative verification switch
+                               // One format-tagged partition-location façade (issue #1599 / G3): `locate` /
+                               // `locate_encoded` compose the C5 range short-circuit + per-format offset resolve.
 mod partition_locator;
 // Next-partition (successor) seek-window offset resolution (issue #953 / #951),
 // split out of `partition_lookup` for the campsite source-size rule (#1116).

--- a/cqlite-core/src/storage/sstable/reader/partition_locator.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_locator.rs
@@ -21,11 +21,17 @@
 //!    guard, so `locate` is never reached for it and C5 is never double-recorded.
 //!    A DIRECT `locate` call (e.g. the parity test, or a future locate-first caller)
 //!    still records the short-circuit exactly once as step 1.
-//! 2. **The BIG candidate-prune stays BLOOM-based**, NOT routed through
-//!    [`locate_encoded`]: a BIG `Index.db` miss is not a definitive absent (#1572
-//!    truncated-index invariant), so pruning on an index miss would drop a candidate
-//!    that actually holds the partition. Only the BTI prune is congruent with the
-//!    façade's trie resolution and uses [`locate_encoded`].
+//! 2. **The BIG candidate-prune stays BLOOM-based**, NOT routed through `locate`: a
+//!    BIG `Index.db` miss is not a definitive absent (#1572 truncated-index
+//!    invariant), so pruning on an index miss would drop a candidate that actually
+//!    holds the partition. The BTI candidate-prune instead calls
+//!    [`SSTableReader::might_contain_partition_encoded`] (issue #2163): it shares
+//!    the SAME trie resolution `locate` uses AND emits
+//!    `cqlite.read.sstables_pruned{format=bti}` on a definitive trie-miss — the
+//!    single site where a BTI SSTable is excluded from a multi-generation read.
+//!    `locate` itself never emits that counter, so a caller that prunes via
+//!    `might_contain_partition_encoded` and then reads via `locate` never
+//!    double-emits.
 
 use super::SSTableReader;
 use crate::Result;
@@ -75,55 +81,5 @@ impl SSTableReader {
         }
         // BIG: the raw-key Index.db map resolves (offset, size).
         self.lookup_partition_with_index(partition_key).await
-    }
-
-    /// [`locate`](Self::locate) with a PRE-ENCODED BTI byte-comparable key, so a
-    /// multi-generation candidate prune hashes+encodes the key ONCE (issue #1575 /
-    /// C4) instead of once per candidate.
-    ///
-    /// **BTI-only by contract.** `encoded` MUST equal
-    /// `encode_partition_key_for_bti_trie(partition_key)`. The candidate-prune caller
-    /// (`SSTableManager::prune_candidates`) invokes this ONLY for BTI readers and
-    /// keeps BIG candidates on the bloom-based `might_contain_partition` — a BIG
-    /// `Index.db` miss is not a definitive absent (#1572), so a BIG reader must never
-    /// be pruned on this trie-resolution path. For a non-BTI reader this consults no
-    /// trie and returns `Ok(None)` (the `encoded` argument is unused); the caller's
-    /// BTI gate makes that unreachable.
-    ///
-    /// Semantics otherwise match [`locate`](Self::locate): the C5 step-1 guard runs
-    /// (a no-op for BTI, which has no Summary bound), then the pre-encoded trie
-    /// resolve. BTI records no size, so a hit is `Some((offset, 0))`.
-    ///
-    /// BTI-only: crate-internal (`pub(crate)`) and reached solely from the BTI branch
-    /// of `SSTableManager::prune_candidates`. Never call it for a BIG reader — a BIG
-    /// prune must stay on the bloom filter, and this path would report a misleading
-    /// `Ok(None)` "absent" for a BIG `Index.db` miss (#1572).
-    ///
-    /// Gated to mirror its sole caller `SSTableManager::prune_candidates`, which is
-    /// `cfg(not(tombstones))` (the `tombstones` build has no single-partition prune
-    /// fast path) — otherwise this would be dead code under `--features tombstones`.
-    #[cfg(not(feature = "tombstones"))]
-    pub(crate) fn locate_encoded(
-        &self,
-        partition_key: &[u8],
-        encoded: &[u8; 9],
-    ) -> Result<Option<(u64, u32)>> {
-        // BTI-only invariant: the sole caller (BTI branch of `prune_candidates`) gates
-        // on a BTI reader; a BIG reader here would yield a false-absent (see doc above).
-        debug_assert!(
-            self.bti_partitions_db.is_some(),
-            "locate_encoded is BTI-only; BIG prune must use the bloom filter"
-        );
-        // Step 1: C5 (single implementation). A no-op for BTI (no Summary bound), so
-        // this never short-circuits a BTI prune; kept for congruence with `locate`.
-        if self.partition_key_out_of_range(partition_key) {
-            crate::storage::sstable::read_work_counters::record_range_short_circuit();
-            return Ok(None);
-        }
-        // Step 2: pre-encoded BTI trie resolve (C4 hoist). Non-BTI readers return
-        // `Ok(None)` here, but the prune caller only ever reaches this on BTI.
-        Ok(self
-            .lookup_partition_via_bti_trie_encoded(partition_key, encoded)?
-            .map(|offset| (offset, 0)))
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -421,10 +421,16 @@ impl SSTableReader {
             // `lookup_partition_via_bti_trie` is the single common path that emits
             // READ_BLOOM_CHECKS for the BTI presence check — do NOT emit again here
             // or the metric would be double counted.
-            return matches!(
+            let present = matches!(
                 self.lookup_partition_via_bti_trie(partition_key),
                 Ok(Some(_)) | Err(_)
             );
+            if !present {
+                // Definitive trie miss → this SSTable is pruned from the read
+                // (issue #2163).
+                self.emit_sstable_pruned();
+            }
+            return present;
         }
         // BIG: only record READ_BLOOM_CHECKS when a bloom filter actually exists.
         // With no filter loaded we cannot prune, so we conservatively return `true`
@@ -447,10 +453,30 @@ impl SSTableReader {
                         ),
                     ],
                 );
+                if !present {
+                    // Bloom `might_contain == false` is a definitive negative →
+                    // this SSTable is pruned from the read (issue #2163).
+                    self.emit_sstable_pruned();
+                }
                 present
             }
             None => true,
         }
+    }
+
+    /// Emit `cqlite.read.sstables_pruned` for one SSTable excluded from a read by
+    /// a presence-oracle definitive negative (issue #2163). Carries the bounded
+    /// `cqlite.sstable.format` (`"big"`/`"bti"`); no-op when observability is off.
+    fn emit_sstable_pruned(&self) {
+        use crate::observability::{self as obs, catalog};
+        obs::add_counter(
+            catalog::READ_SSTABLES_PRUNED,
+            1,
+            &[(
+                catalog::attr::SSTABLE_FORMAT,
+                self.sstable_format_label().into(),
+            )],
+        );
     }
 
     /// `true` when this reader was opened on a BTI ("da") SSTable (its
@@ -476,10 +502,18 @@ impl SSTableReader {
     /// any trie parse error is treated conservatively as "maybe present".
     pub fn might_contain_partition_encoded(&self, partition_key: &[u8], encoded: &[u8; 9]) -> bool {
         if self.bti_partitions_db.is_some() {
-            return matches!(
+            let present = matches!(
                 self.lookup_partition_via_bti_trie_encoded(partition_key, encoded),
                 Ok(Some(_)) | Err(_)
             );
+            if !present {
+                // Definitive trie miss on the candidate-prune path → SSTable pruned
+                // (issue #2163). The BIG branch below delegates to
+                // `might_contain_partition`, which emits its own prune, so there is
+                // no double count.
+                self.emit_sstable_pruned();
+            }
+            return present;
         }
         // BIG: no BTI encoding to hoist — the bloom filter hashes the raw key.
         self.might_contain_partition(partition_key)

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -467,7 +467,12 @@ impl SSTableReader {
     /// Emit `cqlite.read.sstables_pruned` for one SSTable excluded from a read by
     /// a presence-oracle definitive negative (issue #2163). Carries the bounded
     /// `cqlite.sstable.format` (`"big"`/`"bti"`); no-op when observability is off.
-    fn emit_sstable_pruned(&self) {
+    ///
+    /// `pub(crate)` (not just this module) so the PRIMARY single-reader point-read
+    /// path (`get_with_resolution` in `data_access/mod.rs`) can call the SAME emit
+    /// site the candidate-prune helpers (`might_contain_partition[_encoded]`) use —
+    /// one implementation, no duplicated emission logic (roborev r4).
+    pub(crate) fn emit_sstable_pruned(&self) {
         use crate::observability::{self as obs, catalog};
         obs::add_counter(
             catalog::READ_SSTABLES_PRUNED,

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -417,6 +417,21 @@ impl SSTableReader {
         use crate::observability::{self as obs, catalog};
 
         if self.bti_partitions_db.is_some() {
+            // Issue #2163 (roborev r7): restore the C5 range short-circuit
+            // (`locate`'s Step 1) ahead of the trie probe. The r2 refactor
+            // removed `locate_encoded` (replaced by routing the candidate-prune
+            // path through these `might_contain_partition[_encoded]` helpers)
+            // and dropped this step for BTI, so an out-of-range key paid a
+            // pointless trie descent and never recorded
+            // `read_work_counters::record_range_short_circuit`. A no-op for a
+            // genuine BTI reader today (no Summary.db, so
+            // `partition_key_out_of_range` always returns `false`), but this
+            // restores exact step-ordering parity with `locate` for any
+            // degraded case and keeps the work-counter accounting consistent.
+            if self.partition_key_out_of_range(partition_key) {
+                crate::storage::sstable::read_work_counters::record_range_short_circuit();
+                return false;
+            }
             // BTI: trie miss is authoritative absence; any error is conservative.
             // `lookup_partition_via_bti_trie` is the single common path that emits
             // READ_BLOOM_CHECKS for the BTI presence check — do NOT emit again here
@@ -507,6 +522,17 @@ impl SSTableReader {
     /// any trie parse error is treated conservatively as "maybe present".
     pub fn might_contain_partition_encoded(&self, partition_key: &[u8], encoded: &[u8; 9]) -> bool {
         if self.bti_partitions_db.is_some() {
+            // Issue #2163 (roborev r7): restore the C5 range short-circuit
+            // (`locate`'s Step 1) ahead of the trie probe — see the identical
+            // restoration + rationale in `might_contain_partition`'s BTI branch.
+            // This is the candidate-prune path's OWN entry point (called from
+            // `SSTableManager::prune_candidates` for every BTI candidate), so
+            // restoring it here is what actually re-covers the multi-generation
+            // prune loop the old `locate_encoded` used to gate.
+            if self.partition_key_out_of_range(partition_key) {
+                crate::storage::sstable::read_work_counters::record_range_short_circuit();
+                return false;
+            }
             let present = matches!(
                 self.lookup_partition_via_bti_trie_encoded(partition_key, encoded),
                 Ok(Some(_)) | Err(_)

--- a/cqlite-core/src/storage/sstable/reader/presence_verification.rs
+++ b/cqlite-core/src/storage/sstable/reader/presence_verification.rs
@@ -1,0 +1,99 @@
+//! Opt-in, default-OFF presence-oracle false-negative verification switch
+//! (issue #2163).
+//!
+//! A presence oracle (the BIG bloom filter / BTI Partitions.db trie) must NEVER
+//! report a false negative: a "definitely absent" verdict for a key that is
+//! actually present would silently drop data. This switch turns on an
+//! AUTHORITATIVE confirmation scan of an SSTable whenever its oracle reports a
+//! key absent; a contradiction increments `cqlite.read.bloom.false_negatives`
+//! (see [`crate::observability::catalog::READ_BLOOM_FALSE_NEGATIVES`]). Under a
+//! correct oracle the counter stays 0 — a non-zero value is a corruption alarm.
+//!
+//! It is **off by default** and gated by an explicit runtime switch, because the
+//! confirmation scan is the one presence-oracle counter that costs real work. The
+//! switch is read once from the `CQLITE_VERIFY_PRESENCE_ORACLE` environment
+//! variable (booleans: `1/0`, `true/false`, `yes/no`, `on/off`), then cached. The
+//! `observability-testing`-gated [`set_enabled_for_testing`] lets the correctness
+//! tests toggle it deterministically without touching process env.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const UNINIT: u8 = 0;
+const OFF: u8 = 1;
+const ON: u8 = 2;
+
+/// Tri-state cache: `UNINIT` until first resolved from the environment, then
+/// pinned to `OFF`/`ON`. Test overrides store `OFF`/`ON` directly.
+static STATE: AtomicU8 = AtomicU8::new(UNINIT);
+
+/// Environment variable that enables the opt-in verification when truthy.
+pub const ENV_VAR: &str = "CQLITE_VERIFY_PRESENCE_ORACLE";
+
+fn parse_bool(s: &str) -> Option<bool> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Whether presence-oracle false-negative verification is enabled.
+///
+/// Resolves lazily from [`ENV_VAR`] on first call (default `false` when unset or
+/// unparseable), caching the result so subsequent reads are a single relaxed
+/// atomic load. Always `false` unless explicitly turned on — so the default
+/// production read path performs no confirmation scan and costs nothing beyond
+/// the existing presence check.
+pub fn enabled() -> bool {
+    match STATE.load(Ordering::Acquire) {
+        OFF => false,
+        ON => true,
+        _ => {
+            let value = std::env::var(ENV_VAR)
+                .ok()
+                .and_then(|v| parse_bool(&v))
+                .unwrap_or(false);
+            let encoded = if value { ON } else { OFF };
+            // Only the first resolver wins; a concurrent test override that already
+            // pinned the state is respected (compare_exchange fails, we re-read).
+            match STATE.compare_exchange(UNINIT, encoded, Ordering::AcqRel, Ordering::Acquire) {
+                Ok(_) => value,
+                Err(existing) => existing == ON,
+            }
+        }
+    }
+}
+
+/// Force the switch on/off for tests (issue #2163). Gated behind
+/// `observability-testing` so production builds never expose a runtime mutator;
+/// integration tests compile the library with that feature and toggle the switch
+/// deterministically around a flow.
+#[cfg(feature = "observability-testing")]
+pub fn set_enabled_for_testing(enabled: bool) {
+    STATE.store(if enabled { ON } else { OFF }, Ordering::Release);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bool_recognizes_bounded_forms() {
+        for t in ["1", "true", "TRUE", "yes", "on"] {
+            assert_eq!(parse_bool(t), Some(true), "{t}");
+        }
+        for f in ["0", "false", "no", "off"] {
+            assert_eq!(parse_bool(f), Some(false), "{f}");
+        }
+        assert_eq!(parse_bool("maybe"), None);
+    }
+
+    #[cfg(feature = "observability-testing")]
+    #[test]
+    fn test_override_toggles_state() {
+        set_enabled_for_testing(true);
+        assert!(enabled());
+        set_enabled_for_testing(false);
+        assert!(!enabled());
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/presence_verification.rs
+++ b/cqlite-core/src/storage/sstable/reader/presence_verification.rs
@@ -15,6 +15,18 @@
 //! variable (booleans: `1/0`, `true/false`, `yes/no`, `on/off`), then cached. The
 //! `observability-testing`-gated [`set_enabled_for_testing`] lets the correctness
 //! tests toggle it deterministically without touching process env.
+//!
+//! # Config plumbing + precedence (issue #2163, roborev r4)
+//!
+//! [`crate::observability::ObservabilityConfig::verify_presence_oracle`] is a
+//! PROGRAMMATIC way to set this switch (e.g. `ObservabilityConfig::builder()
+//! .verify_presence_oracle(true).build()`), for callers that construct config in
+//! code rather than through the environment. [`crate::observability::init`] calls
+//! [`apply_config`] with that field so the config value actually reaches this
+//! switch — it is not merely decorative. Precedence (conventional
+//! env-overrides-config, matching every other `ObservabilityConfig` field's own
+//! `from_env` behaviour): if [`ENV_VAR`] is explicitly set to a parseable boolean,
+//! it ALWAYS wins over the config value; otherwise the config value applies.
 
 use std::sync::atomic::{AtomicU8, Ordering};
 
@@ -62,6 +74,27 @@ pub fn enabled() -> bool {
             }
         }
     }
+}
+
+/// Apply an [`ObservabilityConfig`](crate::observability::ObservabilityConfig)-
+/// sourced enablement value to this runtime switch (issue #2163, roborev r4 —
+/// closes the "config field is decorative" gap).
+///
+/// [`ENV_VAR`], when explicitly set to a parseable boolean, ALWAYS takes
+/// precedence over `config_value` — the conventional env-overrides-config rule
+/// [`crate::observability::ObservabilityConfig::from_env`] already applies to
+/// every other field. Otherwise `config_value` becomes the switch's state. Called
+/// from [`crate::observability::init`] (both the `observability`-feature-enabled
+/// and inert builds) so a programmatic
+/// `ObservabilityConfig::builder().verify_presence_oracle(true).build()` actually
+/// flips the switch the read path consults. Idempotent and safe to call multiple
+/// times (e.g. across repeated `init` calls in a test process) — it always
+/// recomputes from scratch and FORCES the result into the shared state, so a
+/// later `init` call can still correct an earlier one.
+pub(crate) fn apply_config(config_value: bool) {
+    let env_value = std::env::var(ENV_VAR).ok().and_then(|v| parse_bool(&v));
+    let effective = env_value.unwrap_or(config_value);
+    STATE.store(if effective { ON } else { OFF }, Ordering::Release);
 }
 
 /// Force the switch on/off for tests (issue #2163). Gated behind

--- a/cqlite-core/src/storage/sstable/reverse_scan.rs
+++ b/cqlite-core/src/storage/sstable/reverse_scan.rs
@@ -43,7 +43,19 @@ impl SSTableManager {
         // (partition, clustering) row may appear in more than one, and reconciling
         // them is the in-memory-sort path's job (cross-generation last-write-wins).
         // C4 (#1575): the BTI key hash+encoding is hoisted to once per read here.
-        let candidates = Self::prune_candidates(&reader_list, partition_key);
+        //
+        // Issue #2163 (roborev r6): this seam does NOT call
+        // `verify_pruned_candidates` on its own `pruned` set — every
+        // `candidates.len() != 1` outcome (zero OR multiple admitted, which
+        // includes a false negative wrongly excluding the sole holder) falls
+        // through to `Ok(None)`, and the caller's fallback
+        // (`query::select_executor::lookup`) ALWAYS re-runs the SAME
+        // deterministic prune via `scan_partition_clustering`, which DOES call
+        // `verify_pruned_candidates` on the identical `reader_list`/`partition_key`
+        // (same bloom/trie state ⇒ byte-identical exclusion set). Verifying here
+        // too would re-scan the SAME excluded reader a second time in the same
+        // logical read — pure redundant work with no additional coverage.
+        let (candidates, _pruned) = Self::prune_candidates(&reader_list, partition_key);
         if candidates.len() != 1 {
             return Ok(None);
         }

--- a/cqlite-core/src/storage/sstable/reverse_scan.rs
+++ b/cqlite-core/src/storage/sstable/reverse_scan.rs
@@ -43,19 +43,35 @@ impl SSTableManager {
         // (partition, clustering) row may appear in more than one, and reconciling
         // them is the in-memory-sort path's job (cross-generation last-write-wins).
         // C4 (#1575): the BTI key hash+encoding is hoisted to once per read here.
+        let (candidates, pruned) = Self::prune_candidates(&reader_list, partition_key);
+
+        // Issue #2163 (roborev r7): verify pruned candidates ONLY on the
+        // `candidates.len() == 1` FAST PATH below — that branch serves the read
+        // DIRECTLY from `candidates[0]` via `big_reverse_partition_rows` and
+        // returns without ever reaching the caller's fallback. A false negative
+        // that wrongly excluded a co-holding generation on THIS branch is the
+        // silent-miss case the switch exists to catch: unverified, the read
+        // would (a) never confirm the wrongly-pruned reader's contradiction, AND
+        // (b) wrongly take the single-generation direct-serve path instead of
+        // the reconciling in-memory-sort fallback that would have merged both
+        // generations' rows. Strictly inside the opt-in switch (a no-op when
+        // disabled) and fail-open on `Err` (the same loud-error contract the
+        // other `verify_pruned_candidates` call sites use).
         //
-        // Issue #2163 (roborev r6): this seam does NOT call
-        // `verify_pruned_candidates` on its own `pruned` set — every
-        // `candidates.len() != 1` outcome (zero OR multiple admitted, which
-        // includes a false negative wrongly excluding the sole holder) falls
-        // through to `Ok(None)`, and the caller's fallback
-        // (`query::select_executor::lookup`) ALWAYS re-runs the SAME
-        // deterministic prune via `scan_partition_clustering`, which DOES call
-        // `verify_pruned_candidates` on the identical `reader_list`/`partition_key`
-        // (same bloom/trie state ⇒ byte-identical exclusion set). Verifying here
-        // too would re-scan the SAME excluded reader a second time in the same
-        // logical read — pure redundant work with no additional coverage.
-        let (candidates, _pruned) = Self::prune_candidates(&reader_list, partition_key);
+        // The `candidates.len() != 1` branch deliberately does NOT verify here:
+        // every such outcome (zero OR multiple admitted) returns `Ok(None)`, and
+        // the caller's fallback (`query::select_executor::lookup`) ALWAYS
+        // re-runs the SAME deterministic prune via `scan_partition_clustering`,
+        // which DOES call `verify_pruned_candidates` on the identical
+        // `reader_list`/`partition_key` (same bloom/trie state ⇒ byte-identical
+        // exclusion set). Verifying on BOTH branches would double-COUNT a
+        // contradicted negative (once here, once in the fallback) for the SAME
+        // logical read — so this call is gated to fire only where the fallback
+        // will never run.
+        if candidates.len() == 1 {
+            Self::verify_pruned_candidates(&pruned, table_id, partition_key).await;
+        }
+
         if candidates.len() != 1 {
             return Ok(None);
         }

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1975,11 +1975,22 @@ struct PurgeCounts {
     complex_deletions: u64,
     /// Partition-level tombstones purged (issue #1072).
     partition_tombstones: u64,
+    /// Live cells/rows SHADOWED (suppressed) by a tombstone during reconciliation
+    /// (issue #2163). NOT a purge — backs `cqlite.compaction.tombstones_suppressed`
+    /// and is deliberately EXCLUDED from [`Self::total`] (the purge total).
+    suppressed: u64,
+    /// Tombstone markers RETAINED into the merge output (issue #2163). NOT a
+    /// purge — backs `cqlite.compaction.tombstones_emitted` and is EXCLUDED from
+    /// [`Self::total`].
+    emitted: u64,
 }
 
 #[cfg(feature = "write-support")]
 impl PurgeCounts {
-    /// Total tombstones purged across every category.
+    /// Total tombstones GENUINELY PURGED across every category. The #2163
+    /// `suppressed` / `emitted` tallies are intentionally NOT included — they
+    /// count shadowing and retention, not purges, so `tombstones_purged`
+    /// semantics stay unchanged.
     fn total(self) -> u64 {
         self.cell_tombstones
             .saturating_add(self.row_tombstones)
@@ -2402,6 +2413,12 @@ impl KWayMerger {
         let mut max_partition_deletion: Option<(i64, i32)> = None;
         let mut partition_delete_key: Option<DecoratedKey> = None;
 
+        // Row-count reconciliation (issue #2163): rows entering the reconcile
+        // boundary. `rows` is moved by the loop below, so snapshot the count here.
+        // Emitted once per merge alongside `rows_out` (`merged.len()`) so the
+        // in/out delta is exactly the rows removed by reconciliation.
+        let rows_in = rows.len() as u64;
+
         for row in rows {
             if row.is_partition_delete_carrier() {
                 if let Some((mfda, ldt)) = row.partition_deletion {
@@ -2509,6 +2526,9 @@ impl KWayMerger {
                     continue;
                 }
             }
+            // Retained (non-purged) range-tombstone marker carried into the output
+            // (issue #2163): a tombstone marker emitted, not purged.
+            purges.emitted += 1;
             merged.push(
                 MergeEntry::new(
                     usize::MAX,
@@ -2547,6 +2567,9 @@ impl KWayMerger {
             if purge {
                 purges.partition_tombstones += 1;
             } else {
+                // Retained partition tombstone marker carried into the output
+                // (issue #2163): a tombstone marker emitted, not purged.
+                purges.emitted += 1;
                 merged.push(
                     MergeEntry::new(
                         usize::MAX,
@@ -2602,6 +2625,38 @@ impl KWayMerger {
             crate::observability::add_counter(
                 crate::observability::catalog::COMPACTION_TOMBSTONES_PURGED,
                 purged,
+                &[],
+            );
+        }
+
+        // Correctness / silent-miss signals (issue #2163), emitted once per merge
+        // alongside the purge total — never per row/cell. `suppressed` (live data
+        // shadowed by a tombstone) and `emitted` (tombstone markers retained) move
+        // independently of `tombstones_purged`; the row-count pair lets a dashboard
+        // see reconciliation drop ratio + volume.
+        if purges.suppressed > 0 {
+            crate::observability::add_counter(
+                crate::observability::catalog::COMPACTION_TOMBSTONES_SUPPRESSED,
+                purges.suppressed,
+                &[],
+            );
+        }
+        if purges.emitted > 0 {
+            crate::observability::add_counter(
+                crate::observability::catalog::COMPACTION_TOMBSTONES_EMITTED,
+                purges.emitted,
+                &[],
+            );
+        }
+        if rows_in > 0 {
+            crate::observability::add_counter(
+                crate::observability::catalog::MERGE_ROWS_IN,
+                rows_in,
+                &[],
+            );
+            crate::observability::add_counter(
+                crate::observability::catalog::MERGE_ROWS_OUT,
+                merged.len() as u64,
                 &[],
             );
         }
@@ -3378,8 +3433,8 @@ impl KWayMerger {
         }
         // Step 2b: complex-deletion strict-supersede + shadow-before-purge.
         state.apply_complex_deletions();
-        // Step 3: row-tombstone shadowing.
-        state.shadow_by_row_deletion();
+        // Step 3: row-tombstone shadowing (tallies #2163 suppression).
+        state.shadow_by_row_deletion(purges);
         // Step 3b: dropped-column filtering (captures the phantom-row guard).
         state.filter_dropped_columns(dropped_columns);
         // Step 3b′ (#1382): TTL expiry — convert expired live cells to cell
@@ -3389,8 +3444,9 @@ impl KWayMerger {
         state.expire_ttl_cells(now_secs);
         // Step 3c: gc_grace / overlap-aware tombstone purging (tallies #1037).
         state.purge_gc_grace(gc_before_secs, max_purgeable_timestamp, purges);
-        // Step 4: phantom-row guard + emit the merged entry.
-        state.build()
+        // Step 4: phantom-row guard + emit the merged entry (tallies #2163
+        // emitted row-tombstone markers).
+        state.build(purges)
     }
 
     /// Convert reconciled `CellData`s into writer `CellOperation`s (epic #899,

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -667,7 +667,15 @@ impl ReconcileState {
             // Step 3 already dropped the cells this deletion covers (ts <= row_del),
             // so the deletion shadows nothing within `surviving`.
             Some(match row_del {
-                Some(deletion_time) => live.with_row_deletion(deletion_time, row_del_ldt),
+                Some(deletion_time) => {
+                    // Issue #2163: this row-tombstone marker is RETAINED alongside
+                    // newer live cells (the common "retained-but-coexisting" case,
+                    // NOT the sole-output case below) — count it as emitted too, so
+                    // `tombstones_emitted` covers every marker that survives
+                    // reconciliation into the output, not only the row-absent case.
+                    purges.emitted += 1;
+                    live.with_row_deletion(deletion_time, row_del_ldt)
+                }
                 None => live,
             })
         } else if let Some(deletion_time) = row_del {

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -320,14 +320,24 @@ impl ReconcileState {
     /// `f66fa14f`). The output `after_row_del` is kept so the dropped-column
     /// stage (Step 3b) can tell whether its purge is what emptied the row of real
     /// data (phantom-row guard).
-    pub(super) fn shadow_by_row_deletion(&mut self) {
+    pub(super) fn shadow_by_row_deletion(&mut self, purges: &mut PurgeCounts) {
         let row_del = self.row_del;
         let winners = &mut self.winners;
         self.after_row_del = std::mem::take(&mut self.order)
             .into_iter()
             .filter_map(|cell_key| winners.remove(&cell_key))
             .filter(|cell| match row_del {
-                Some(d) => cell.timestamp > d,
+                Some(d) => {
+                    let survives = cell.timestamp > d;
+                    // Issue #2163: a LIVE cell dropped here was SHADOWED by the
+                    // row tombstone (suppressed) — count it, distinct from a
+                    // gc/overlap-safe purge. A cell that is itself a tombstone is
+                    // not "live data suppressed", so it is not counted.
+                    if !survives && !KWayMerger::is_cell_tombstone(cell) {
+                        purges.suppressed += 1;
+                    }
+                    survives
+                }
                 None => true,
             })
             .collect();
@@ -605,7 +615,7 @@ impl ReconcileState {
     ///
     /// Returns `None` for an empty group (the original `let key = key?`
     /// early-out) or a truly absent row.
-    pub(super) fn build(self) -> Option<MergeEntry> {
+    pub(super) fn build(self, purges: &mut PurgeCounts) -> Option<MergeEntry> {
         let ReconcileState {
             clustering_key,
             key,
@@ -663,6 +673,9 @@ impl ReconcileState {
         } else if let Some(deletion_time) = row_del {
             // No surviving data. If a row tombstone exists, keep the row shadowed
             // so downstream still emits the deletion (preserves #505/#498 absence).
+            // Issue #2163: this row-tombstone marker is RETAINED into the output —
+            // count it as emitted (a marker carried forward, not purged).
+            purges.emitted += 1;
             Some(MergeEntry::new(
                 run_index,
                 key,

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -658,6 +658,25 @@ impl ReconcileState {
         let purged_to_empty = had_data_before && !has_data_after;
         drop(ck_names);
 
+        // Issue #2163 (roborev r7): a cell tombstone (simple or complex-element,
+        // the SAME predicate `purge_gc_grace`'s retain closure uses) that
+        // SURVIVES into `surviving` — whether because gc-grace/overlap kept it,
+        // or because purging was inactive for this merge entirely (no
+        // `gc_before_secs`, e.g. an unbounded partial compaction) — is a marker
+        // RETAINED into the output, matching the row/range/partition tombstone
+        // "emitted" contract established above. Counted here from the FINAL
+        // surviving set (not inside `purge_gc_grace`'s conditional retain) so a
+        // merge with purging disabled still counts its retained cell
+        // tombstones; a cell tombstone always satisfies `is_data_cell` (it is
+        // never a clustering-key pseudo-cell), so its presence here already
+        // implies `purged_to_empty == false` and the row below is genuinely
+        // emitted with it intact.
+        let retained_cell_tombstones = surviving
+            .iter()
+            .filter(|cell| KWayMerger::is_cell_tombstone(cell) || cell.is_deleted)
+            .count() as u64;
+        purges.emitted += retained_cell_tombstones;
+
         // Attach the carried deletion metadata to whichever entry is emitted so it
         // is not dropped by reconciliation (#886 plumbing preservation).
         let has_carried_metadata = !complex_deletions.is_empty() || range_deletion.is_some();

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -322,6 +322,19 @@ impl ReconcileState {
     /// data (phantom-row guard).
     pub(super) fn shadow_by_row_deletion(&mut self, purges: &mut PurgeCounts) {
         let row_del = self.row_del;
+        // Issue #2163 (roborev r5): clustering-key pseudo-cells are intentionally
+        // RETAINED in the cell list for read-back (see `extract_clustering_key`
+        // and the `had_data_before` computation in `filter_dropped_columns`
+        // below) — they are not real data, so shadowing one must not inflate
+        // `tombstones_suppressed`. Build the SAME `is_data_cell` exclusion
+        // `filter_dropped_columns`/`build` already use, computed here (before the
+        // mutable `winners` borrow) so a clustering-key cell shadowed by the row
+        // tombstone is excluded from the count.
+        let ck_names: HashSet<&str> = self
+            .clustering_key
+            .as_ref()
+            .map(|ck| ck.columns.iter().map(|(n, _)| n.as_str()).collect())
+            .unwrap_or_default();
         let winners = &mut self.winners;
         self.after_row_del = std::mem::take(&mut self.order)
             .into_iter()
@@ -329,11 +342,16 @@ impl ReconcileState {
             .filter(|cell| match row_del {
                 Some(d) => {
                     let survives = cell.timestamp > d;
-                    // Issue #2163: a LIVE cell dropped here was SHADOWED by the
-                    // row tombstone (suppressed) — count it, distinct from a
-                    // gc/overlap-safe purge. A cell that is itself a tombstone is
-                    // not "live data suppressed", so it is not counted.
-                    if !survives && !KWayMerger::is_cell_tombstone(cell) {
+                    // Issue #2163: a LIVE DATA cell dropped here was SHADOWED by
+                    // the row tombstone (suppressed) — count it, distinct from a
+                    // gc/overlap-safe purge. A cell that is itself a tombstone,
+                    // or a clustering-key pseudo-cell (retained for read-back,
+                    // never real data), is not "live data suppressed" and is not
+                    // counted.
+                    if !survives
+                        && !KWayMerger::is_cell_tombstone(cell)
+                        && !ck_names.contains(cell.column.as_str())
+                    {
                         purges.suppressed += 1;
                     }
                     survives

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -158,6 +158,23 @@ fn correctness_signals_end_to_end() {
         );
     }
 
+    // --- Roborev blocker #2 (#2163): retained tombstone COEXISTING with a
+    // strictly-newer live cell must ALSO count as emitted (the `build()` branch
+    // distinct from the sole-tombstone-output case above; underreported before
+    // the fix — that branch never incremented `emitted`). ---
+    {
+        let mut flows = merge::run_row_tombstone_with_newer_cell_merge();
+        mc.reset();
+        merge::compact(&mut flows);
+        let m = mc.flush_and_collect();
+        assert!(
+            m.counter_sum(catalog::COMPACTION_TOMBSTONES_EMITTED) >= 1.0,
+            "a row tombstone retained alongside a newer surviving cell must count >=1 emitted; \
+             entry: {:?}",
+            m.find(catalog::COMPACTION_TOMBSTONES_EMITTED)
+        );
+    }
+
     // --- Requirement: SSTable-pruned-by-presence-oracle counter ---
     // A BIG (nb) SSTable with a bloom filter: probing definitely-absent keys makes
     // `might_contain_partition` return false, pruning the SSTable per probe.
@@ -200,6 +217,65 @@ fn correctness_signals_end_to_end() {
             ),
             expected_pruned as f64,
             "every prune must carry cqlite.sstable.format=big for a BIG fixture"
+        );
+    }
+
+    // --- SSTable-pruned counter, BTI (`da`) branch (roborev blocker #1, #2163) ---
+    // The BTI candidate-prune (`SSTableManager::prune_candidates`) routes through
+    // the SAME public `might_contain_partition_encoded` the fix wires the counter
+    // into — exercised here directly (the "lowest public level" the BTI trie-miss
+    // prune reaches) against a real `test_da` BTI fixture, proving the
+    // `format="bti"` scenario arm the spec requires.
+    {
+        use cqlite_core::storage::sstable::bti::encode_partition_key_for_bti_trie;
+
+        let reader = fixtures::open_bti_reader();
+        mc.reset();
+        let mut expected_pruned = 0u64;
+        for i in 0..64u32 {
+            // 16-byte pseudo-UUIDs that do not exist in the fixture (whose real
+            // partition keys are UUIDs from a fixed, disjoint byte pattern).
+            let key = [
+                0xDEu8,
+                0xAD,
+                0xBE,
+                0xEF,
+                0xFE,
+                0xED,
+                0xFA,
+                0xCE,
+                (i >> 8) as u8,
+                i as u8,
+                0xAB,
+                0xCD,
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+            ];
+            let encoded = encode_partition_key_for_bti_trie(&key);
+            if !reader.might_contain_partition_encoded(&key, &encoded) {
+                expected_pruned += 1;
+            }
+        }
+        let m = mc.flush_and_collect();
+        assert!(
+            expected_pruned >= 1,
+            "with 64 absent pseudo-UUID probes the BTI trie must report >=1 definitive miss"
+        );
+        assert_eq!(
+            m.counter_sum(catalog::READ_SSTABLES_PRUNED),
+            expected_pruned as f64,
+            "cqlite.read.sstables_pruned must increment once per definitively-absent BTI probe \
+             (the roborev-flagged gap: the candidate-prune path must emit for BTI too)"
+        );
+        assert_eq!(
+            m.sum_where(
+                catalog::READ_SSTABLES_PRUNED,
+                &[(catalog::attr::SSTABLE_FORMAT, "bti")],
+            ),
+            expected_pruned as f64,
+            "every BTI prune must carry cqlite.sstable.format=bti"
         );
     }
 
@@ -265,6 +341,114 @@ fn correctness_signals_end_to_end() {
             1.0,
             "the false negative must carry the offending SSTable's format"
         );
+        presence_verification::set_enabled_for_testing(false);
+        drop(rt);
+    }
+
+    // --- Roborev fold-in #3 (#2163): `get()`-level false-negative wiring ---
+    // Proves the verification switch is wired through the PUBLIC
+    // `get_with_resolution` read-path entry point end-to-end — not just callable
+    // on the `verify_presence_oracle_negative` method directly. Uses the
+    // process-global `scan_for_key_call_count()` (issue #831 pattern) as the
+    // observable proxy for "the authoritative confirmation scan ran": OFF must
+    // leave the count unchanged for an absent key; ON must increment it for the
+    // SAME key.
+    {
+        use cqlite_core::storage::sstable::reader::SSTableReader;
+        use cqlite_core::types::RowKey;
+
+        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(50);
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        // Search for an absent probe key whose token falls WITHIN this reader's
+        // authoritative Summary bound (else the C5 range short-circuit in
+        // `get_with_resolution` returns absence before ever reaching the
+        // presence-oracle / verify hook — a token-order fact independent of int
+        // order, so we search rather than assume). Verification is ON during the
+        // search. Accept ONLY a candidate whose scan-count delta is EXACTLY 1: that
+        // is the clean signature of "my verify hook ran its one confirmation scan
+        // and nothing else did" — a candidate that also trips the natural BIG
+        // resolution's OWN scan_for_key fallback (a rare bloom false-positive) would
+        // show delta 2 and is deliberately skipped, since re-probing it with
+        // verification OFF would then ALSO show a nonzero delta from that unrelated
+        // natural-fallback path, not from the switch.
+        presence_verification::set_enabled_for_testing(true);
+        let mut in_range_absent_key: Option<[u8; 4]> = None;
+        for candidate in 1_000_000i32..1_000_064 {
+            let key_bytes = candidate.to_be_bytes();
+            let before = SSTableReader::scan_for_key_call_count();
+            let res = rt
+                .block_on(reader.get_with_resolution(
+                    &table_id,
+                    &RowKey::from(key_bytes.to_vec()),
+                    false,
+                ))
+                .expect("get on candidate probe");
+            let after = SSTableReader::scan_for_key_call_count();
+            assert!(
+                res.is_none(),
+                "candidate {candidate} must be genuinely absent"
+            );
+            if after == before + 1 {
+                in_range_absent_key = Some(key_bytes);
+                break;
+            }
+        }
+        let absent_key = in_range_absent_key.expect(
+            "at least one of 64 candidates must land within the Summary bound (expected token \
+             coverage from 50 samples is ~96%) — proves the ON case reaches get_with_resolution's \
+             verify hook rather than being short-circuited by C5",
+        );
+
+        // (a) OFF: re-probing the SAME now-confirmed-in-range absent key must NOT
+        // run a confirmation scan.
+        presence_verification::set_enabled_for_testing(false);
+        let before = SSTableReader::scan_for_key_call_count();
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get with verification off");
+        let after = SSTableReader::scan_for_key_call_count();
+        assert!(res.is_none(), "the probe key must remain reported absent");
+        assert_eq!(
+            after, before,
+            "verification OFF must not run a confirmation scan through get_with_resolution"
+        );
+
+        // (b) ON: the SAME key, through the SAME public entry point, must run the
+        // confirmation scan (delta >= 1) — end-to-end wiring evidence — while the
+        // returned value is unchanged (a side-channel check only) and the
+        // false-negative counter stays 0 (a true negative).
+        presence_verification::set_enabled_for_testing(true);
+        mc.reset();
+        let before = SSTableReader::scan_for_key_call_count();
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get with verification on");
+        let after = SSTableReader::scan_for_key_call_count();
+        assert!(
+            res.is_none(),
+            "verification must not change the returned value for a true negative"
+        );
+        assert!(
+            after > before,
+            "verification ON must run a confirmation scan through get_with_resolution for the \
+             SAME key that showed no scan when OFF"
+        );
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            0.0,
+            "a true negative reached via get_with_resolution must not emit false_negatives"
+        );
+
         presence_verification::set_enabled_for_testing(false);
         drop(rt);
     }
@@ -348,6 +532,7 @@ mod merge {
                 col("id", "int", false),
                 col("seq", "int", false),
                 col("val", "text", true),
+                col("extra", "text", true),
             ],
             comments: HashMap::new(),
             dropped_columns: HashMap::new(),
@@ -421,7 +606,49 @@ mod merge {
         Flows { engine, _tmp: tmp }
     }
 
-    /// Drive maintenance compaction until a merge completes (or no work remains).
+    /// Roborev blocker #2 (#2163): a row tombstone RETAINED alongside a STRICTLY
+    /// NEWER live cell (the common "coexisting" case — `build()`'s
+    /// `!surviving.is_empty()` branch — distinct from `run_row_tombstone_merge`'s
+    /// sole-tombstone-output branch). Explicit `USING TIMESTAMP` pins the ordering
+    /// deterministically (no wall-clock race): INSERT `val` at t=1000, whole-row
+    /// DELETE at t=2000 (shadows `val`), then INSERT `extra` at t=3000 (survives the
+    /// deletion) — the row tombstone must still be carried into the merged output
+    /// via `with_row_deletion` alongside the surviving `extra` cell.
+    pub fn run_row_tombstone_with_newer_cell_merge() -> Flows {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let mut engine = open(tmp.path(), clustered_schema());
+        engine
+            .execute(
+                "INSERT INTO obs2163.events (id, seq, val) VALUES (2, 1, 'old') \
+                 USING TIMESTAMP 1000",
+            )
+            .expect("w1");
+        flush(&mut engine);
+        engine
+            .execute("DELETE FROM obs2163.events USING TIMESTAMP 2000 WHERE id = 2 AND seq = 1")
+            .expect("del");
+        flush(&mut engine);
+        engine
+            .execute(
+                "INSERT INTO obs2163.events (id, seq, extra) VALUES (2, 1, 'new') \
+                 USING TIMESTAMP 3000",
+            )
+            .expect("w2");
+        flush(&mut engine);
+        Flows { engine, _tmp: tmp }
+    }
+
+    /// Drive maintenance compaction to full convergence (every eligible merge
+    /// round completes, not just the first). A bucketed STCS policy may need MORE
+    /// THAN ONE `maintenance_step` round to combine 3+ generations down to one
+    /// SSTable (e.g. round 1 merges gens 1+2, round 2 merges that output with
+    /// gen 3) — breaking after the FIRST completed merge (the pre-#2163-fix-round
+    /// shape) would silently leave later generations unmerged. Only stop once a
+    /// round does NO work at all (nothing completed AND nothing pending): that is
+    /// the sole idle signal `maintenance_step` gives (`pending_compaction` reflects
+    /// an in-progress merge continuing past its budget, not "more candidates
+    /// exist" — see `maintenance.rs`), so an idle round with tiny test data means
+    /// every candidate has been folded in.
     pub fn compact(flows: &mut Flows) {
         // maintenance_step uses an internal block_on; call it OUTSIDE any runtime.
         let budget = std::time::Duration::from_secs(30);
@@ -430,10 +657,7 @@ mod merge {
                 .engine
                 .maintenance_step(budget)
                 .expect("maintenance_step");
-            if !report.completed_merges.is_empty() {
-                break;
-            }
-            if !report.pending_compaction {
+            if report.completed_merges.is_empty() && !report.pending_compaction {
                 break;
             }
         }
@@ -484,6 +708,36 @@ mod fixtures {
         let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
         rt.block_on(SSTableReader::open(&data_file, &config, platform))
             .expect("open reader")
+    }
+
+    /// Open a real BTI (`da`) fixture SSTable reader (has a `Partitions.db` trie —
+    /// the authoritative BTI presence oracle). Corpus: `test_da/simple_table-*`.
+    pub fn open_bti_reader() -> SSTableReader {
+        let parent = datasets_root().join("sstables").join("test_da");
+        let table_dir = std::fs::read_dir(&parent)
+            .unwrap_or_else(|e| panic!("read {}: {e} — fetch datasets first", parent.display()))
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_name().to_string_lossy().starts_with("simple_table-"))
+            .map(|e| e.path())
+            .expect("test_da/simple_table BTI fixture present");
+        let data_file = std::fs::read_dir(&table_dir)
+            .expect("read table dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .find(|p| p.to_string_lossy().ends_with("-Data.db"))
+            .expect("Data.db present");
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        let reader = rt
+            .block_on(SSTableReader::open(&data_file, &config, platform))
+            .expect("open BTI reader");
+        assert!(
+            reader.is_bti(),
+            "test_da/simple_table-* must open as a BTI reader (Partitions.db present)"
+        );
+        reader
     }
 
     fn writer_schema() -> TableSchema {
@@ -575,5 +829,62 @@ mod fixtures {
         );
         drop(rt);
         (reader, table_id, present_key, tmp)
+    }
+
+    /// Write `n` rows (ids `0..n`), flush, and open a schema-attached reader over
+    /// the produced Data.db. Used by the `get()`-level false-negative wiring test
+    /// (roborev fold-in #3, #2163), which needs an absent probe key whose token
+    /// falls WITHIN the reader's authoritative `[first_key, last_key]` Summary
+    /// bound (else the C5 range short-circuit in `get_with_resolution` returns
+    /// absence before ever reaching the presence-oracle / verify hook). `n` rows
+    /// spread the observed token span wide enough that a handful of far-outside-
+    /// range candidate ids (searched by the caller) are overwhelmingly likely to
+    /// land in-range by token, even though token order is unrelated to int order.
+    pub fn open_writer_reader_with_many_rows(
+        n: i32,
+    ) -> (SSTableReader, TableId, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = writer_schema();
+        let cfg = WriteEngineConfig::new(
+            tmp.path().join("data"),
+            tmp.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        for id in 0..n {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'row{id}')"
+                ))
+                .expect("write");
+        }
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let info = rt
+            .block_on(engine.flush())
+            .expect("flush")
+            .expect("sstable");
+        let data_file = info.data_path.clone();
+
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        let mut reader = rt
+            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
+            .expect("open reader");
+
+        let registry = rt
+            .block_on(SchemaRegistry::new(
+                SchemaRegistryConfig::default(),
+                platform.clone(),
+                config.clone(),
+            ))
+            .expect("build registry");
+        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
+            .expect("register schema");
+        let registry = Arc::new(tokio::sync::RwLock::new(registry));
+        rt.block_on(reader.attach_schema_registry(registry));
+        drop(rt);
+
+        (reader, TableId::from("rows"), tmp)
     }
 }

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -163,7 +163,7 @@ fn correctness_signals_end_to_end() {
     // `might_contain_partition` return false, pruning the SSTable per probe.
     {
         let reader = fixtures::open_big_reader();
-        let rt = tokio::runtime::Runtime::new().expect("rt");
+        // `might_contain_partition` is synchronous — no runtime needed here.
         // Count how many absent-key probes the oracle reports definitely-absent.
         mc.reset();
         let mut expected_pruned = 0u64;
@@ -183,7 +183,6 @@ fn correctness_signals_end_to_end() {
                 expected_pruned += 1;
             }
         }
-        drop(rt);
         let m = mc.flush_and_collect();
         assert!(
             expected_pruned >= 1,

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -1,0 +1,560 @@
+//! Correctness / silent-miss observability signals (issue #2163).
+//!
+//! Scenario coverage for the `correctness-signals` OpenSpec change. Every metric
+//! assertion drives a REAL read / merge / query through a public surface (a
+//! compaction via `WriteEngine::maintenance_step`, a point read via
+//! `SSTableReader`, a `SELECT` via `Database`) and asserts against the emitted
+//! catalog metrics captured by the shared in-memory OTLP exporter.
+//!
+//! # Why one serial metric test
+//!
+//! The production metric helpers record through a single process-global `Meter`
+//! bound on first use, so the in-memory meter provider is process-wide and uses
+//! DELTA temporality. Several of the #2163 counters (`cqlite.merge.rows_in`,
+//! `tombstones_suppressed`, …) carry NO disambiguating attribute, so ALL metric
+//! assertions here run in ONE serial test that `reset`s the capture immediately
+//! before each flow and `flush_and_collect`s immediately after — the same
+//! discipline `observability_correctness.rs` documents.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-core \
+//!   --features observability-testing,cli-helpers,write-support \
+//!   --test correctness_signals_2163
+//! ```
+
+#![cfg(all(feature = "observability-testing", feature = "write-support"))]
+
+use cqlite_core::observability::{self as obs, catalog, testing};
+use cqlite_core::storage::sstable::reader::presence_verification;
+
+// ---------------------------------------------------------------------------
+// Requirement: Catalog integrity — every added counter resolves to a
+// registered instrument (its declared unit), not the ad-hoc `_ =>` fallback.
+// ---------------------------------------------------------------------------
+
+fn assert_registered_unit(metrics: &testing::CapturedMetrics, name: &str, unit: &str) {
+    assert!(
+        metrics.contains(name),
+        "{name} must be collected; saw: {:?}",
+        metrics.entries().iter().map(|e| e.name.clone()).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        metrics.unit(name),
+        Some(unit),
+        "{name} must carry its registered unit {unit} (proves it hit the pre-registered \
+         instrument, not the ad-hoc fallback arm)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The single serial metric test.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn correctness_signals_end_to_end() {
+    let mc = testing::metrics_capture();
+
+    // --- Catalog integrity: every added counter dispatches to its instrument ---
+    mc.reset();
+    obs::add_counter(catalog::MERGE_ROWS_IN, 1, &[]);
+    obs::add_counter(catalog::MERGE_ROWS_OUT, 1, &[]);
+    obs::add_counter(catalog::COMPACTION_TOMBSTONES_SUPPRESSED, 1, &[]);
+    obs::add_counter(catalog::COMPACTION_TOMBSTONES_EMITTED, 1, &[]);
+    obs::add_counter(
+        catalog::READ_SSTABLES_PRUNED,
+        1,
+        &[(catalog::attr::SSTABLE_FORMAT, "big".into())],
+    );
+    obs::add_counter(
+        catalog::READ_BLOOM_FALSE_NEGATIVES,
+        1,
+        &[(catalog::attr::SSTABLE_FORMAT, "big".into())],
+    );
+    obs::add_counter(
+        catalog::QUERY_DEGRADED_PATH,
+        1,
+        &[(catalog::attr::FALLBACK_REASON, "no_schema".into())],
+    );
+    let m = mc.flush_and_collect();
+    assert_registered_unit(&m, catalog::MERGE_ROWS_IN, catalog::unit::ROWS);
+    assert_registered_unit(&m, catalog::MERGE_ROWS_OUT, catalog::unit::ROWS);
+    assert_registered_unit(
+        &m,
+        catalog::COMPACTION_TOMBSTONES_SUPPRESSED,
+        catalog::unit::TOMBSTONES,
+    );
+    assert_registered_unit(
+        &m,
+        catalog::COMPACTION_TOMBSTONES_EMITTED,
+        catalog::unit::TOMBSTONES,
+    );
+    assert_registered_unit(&m, catalog::READ_SSTABLES_PRUNED, catalog::unit::SSTABLES);
+    assert_registered_unit(
+        &m,
+        catalog::READ_BLOOM_FALSE_NEGATIVES,
+        catalog::unit::DIMENSIONLESS,
+    );
+    assert_registered_unit(&m, catalog::QUERY_DEGRADED_PATH, catalog::unit::DIMENSIONLESS);
+
+    // --- Requirement: Merge row-count reconciliation counters ---
+    // Two overlapping generations: partition id=1 appears in BOTH SSTables and
+    // LWW-collapses (2 in -> 1 out); id=2 and id=3 pass through. So the reconcile
+    // boundary sees N=4 rows in and M=3 out, delta=1 = the collapsed duplicate.
+    {
+        let mut flows = merge::run_overlapping_merge();
+        mc.reset();
+        merge::compact(&mut flows);
+        let m = mc.flush_and_collect();
+        let rows_in = m.counter_sum(catalog::MERGE_ROWS_IN);
+        let rows_out = m.counter_sum(catalog::MERGE_ROWS_OUT);
+        assert_eq!(
+            rows_in, 4.0,
+            "cqlite.merge.rows_in must equal the 4 rows consumed at reconcile; entry: {:?}",
+            m.find(catalog::MERGE_ROWS_IN)
+        );
+        assert_eq!(
+            rows_out, 3.0,
+            "cqlite.merge.rows_out must equal the 3 reconciled rows; entry: {:?}",
+            m.find(catalog::MERGE_ROWS_OUT)
+        );
+        assert_eq!(
+            rows_in - rows_out,
+            1.0,
+            "the in/out delta must equal the 1 row removed by reconciliation (LWW collapse)"
+        );
+    }
+
+    // --- Requirement: Tombstone suppression-vs-emission counters ---
+    // A newer whole-row tombstone shadows an older live cell in the same
+    // clustering slot: the live cell is SUPPRESSED and the retained tombstone
+    // marker is EMITTED, both independently of tombstones_purged.
+    {
+        let mut flows = merge::run_row_tombstone_merge();
+        mc.reset();
+        merge::compact(&mut flows);
+        let m = mc.flush_and_collect();
+        let suppressed = m.counter_sum(catalog::COMPACTION_TOMBSTONES_SUPPRESSED);
+        let emitted = m.counter_sum(catalog::COMPACTION_TOMBSTONES_EMITTED);
+        assert!(
+            suppressed >= 1.0,
+            "a row tombstone shadowing an older live cell must count >=1 suppressed; entry: {:?}",
+            m.find(catalog::COMPACTION_TOMBSTONES_SUPPRESSED)
+        );
+        assert!(
+            emitted >= 1.0,
+            "the retained row-tombstone marker must count >=1 emitted; entry: {:?}",
+            m.find(catalog::COMPACTION_TOMBSTONES_EMITTED)
+        );
+    }
+
+    // --- Requirement: SSTable-pruned-by-presence-oracle counter ---
+    // A BIG (nb) SSTable with a bloom filter: probing definitely-absent keys makes
+    // `might_contain_partition` return false, pruning the SSTable per probe.
+    {
+        let reader = fixtures::open_big_reader();
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        // Count how many absent-key probes the oracle reports definitely-absent.
+        mc.reset();
+        let mut expected_pruned = 0u64;
+        for i in 0..64u32 {
+            // 8-byte keys that do not exist in the (int-keyed) fixture table.
+            let key = [0xFEu8, 0xED, 0xFA, 0xCE, (i >> 8) as u8, i as u8, 0xAB, 0xCD];
+            if !reader.might_contain_partition(&key) {
+                expected_pruned += 1;
+            }
+        }
+        drop(rt);
+        let m = mc.flush_and_collect();
+        assert!(
+            expected_pruned >= 1,
+            "with 64 absent-key probes the bloom filter must report >=1 definitive miss"
+        );
+        assert_eq!(
+            m.counter_sum(catalog::READ_SSTABLES_PRUNED),
+            expected_pruned as f64,
+            "cqlite.read.sstables_pruned must increment once per definitely-absent probe"
+        );
+        assert_eq!(
+            m.sum_where(
+                catalog::READ_SSTABLES_PRUNED,
+                &[(catalog::attr::SSTABLE_FORMAT, "big")],
+            ),
+            expected_pruned as f64,
+            "every prune must carry cqlite.sstable.format=big for a BIG fixture"
+        );
+    }
+
+    // --- Requirement: Opt-in presence-oracle false-negative verification ---
+    {
+        let (reader, table_id, present_key, _tmp) =
+            fixtures::open_writer_reader_with_present_key();
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let absent_key = 0x7FFF_FFFFi32.to_be_bytes();
+
+        // (a) Verification OFF (default): a point read for an absent key performs no
+        // confirmation scan and never emits the false-negative counter.
+        presence_verification::set_enabled_for_testing(false);
+        mc.reset();
+        let got = rt
+            .block_on(reader.verify_presence_oracle_negative(&table_id, &absent_key))
+            .expect("verify off");
+        assert!(!got, "verification OFF must not run a confirmation scan");
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            0.0,
+            "verification OFF must never emit false_negatives"
+        );
+
+        // (b) Verification ON, a genuinely absent key: the authoritative scan runs,
+        // finds the key absent, and the counter stays 0.
+        presence_verification::set_enabled_for_testing(true);
+        mc.reset();
+        let got = rt
+            .block_on(reader.verify_presence_oracle_negative(&table_id, &absent_key))
+            .expect("verify on true-negative");
+        assert!(!got, "a genuinely absent key must not be a false negative");
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            0.0,
+            "a confirmed true negative must keep false_negatives at 0"
+        );
+
+        // (c) Verification ON, a PRESENT key fed to the verify path (a synthetic
+        // false negative — the oracle "said absent" for a key that IS present): the
+        // authoritative scan contradicts it and the counter increments by 1 with
+        // the SSTable's format.
+        mc.reset();
+        let got = rt
+            .block_on(reader.verify_presence_oracle_negative(&table_id, &present_key))
+            .expect("verify on contradiction");
+        assert!(got, "a present key must be reported as a contradicted negative");
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            1.0,
+            "a contradicted negative must increment false_negatives by exactly 1"
+        );
+        assert_eq!(
+            m.sum_where(
+                catalog::READ_BLOOM_FALSE_NEGATIVES,
+                &[(catalog::attr::SSTABLE_FORMAT, "big")],
+            ),
+            1.0,
+            "the false negative must carry the offending SSTable's format"
+        );
+        presence_verification::set_enabled_for_testing(false);
+        drop(rt);
+    }
+
+    // --- Requirement: Degraded read-path counter with bounded reason ---
+    // The executor records honest fallbacks through `access_path::record`, the
+    // public probe every fallback site funnels through. A fallback increments the
+    // counter with its bounded reason label; a targeted path never does.
+    {
+        use cqlite_core::query::access_path::{self, AccessPath, FallbackReason};
+        mc.reset();
+        access_path::record(AccessPath::FallbackFullScan {
+            reason: FallbackReason::NoSchema,
+        });
+        // A targeted path must NOT increment the degraded counter.
+        access_path::record(AccessPath::PartitionLookup);
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::QUERY_DEGRADED_PATH),
+            1.0,
+            "exactly one degraded increment for the single fallback (targeted path adds none)"
+        );
+        assert_eq!(
+            m.sum_where(
+                catalog::QUERY_DEGRADED_PATH,
+                &[(catalog::attr::FALLBACK_REASON, "no_schema")],
+            ),
+            1.0,
+            "the degraded increment must carry the bounded fallback_reason label"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Merge helpers (compaction over writer-produced SSTables).
+// ---------------------------------------------------------------------------
+
+mod merge {
+    use cqlite_core::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
+    use cqlite_core::storage::write_engine::{STCSPolicy, WriteEngine, WriteEngineConfig};
+    use std::collections::HashMap;
+
+    /// A live write engine + its temp dir (kept alive) after flushing the inputs.
+    pub struct Flows {
+        pub engine: WriteEngine,
+        _tmp: tempfile::TempDir,
+    }
+
+    fn pk_only_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "obs2163".to_string(),
+            table: "items".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                col("id", "int", false),
+                col("name", "text", true),
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn clustered_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "obs2163".to_string(),
+            table: "events".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "seq".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: Default::default(),
+            }],
+            columns: vec![
+                col("id", "int", false),
+                col("seq", "int", false),
+                col("val", "text", true),
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn col(name: &str, ty: &str, nullable: bool) -> Column {
+        Column {
+            name: name.to_string(),
+            data_type: ty.to_string(),
+            nullable,
+            default: None,
+            is_static: false,
+        }
+    }
+
+    fn open(dir: &std::path::Path, schema: TableSchema) -> WriteEngine {
+        let cfg = WriteEngineConfig::new(dir.join("data"), dir.join("wal"), schema);
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        engine
+            .set_merge_policy(Box::new(
+                STCSPolicy::new(2, 32, 0.5, 1.5, 0).expect("policy"),
+            ))
+            .expect("set policy");
+        engine
+    }
+
+    fn flush(engine: &mut WriteEngine) {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(engine.flush()).expect("flush").expect("sstable");
+    }
+
+    /// Two overlapping SSTables: id=1 in both (LWW-collapses), plus id=2 and id=3.
+    pub fn run_overlapping_merge() -> Flows {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let mut engine = open(tmp.path(), pk_only_schema());
+        engine
+            .execute("INSERT INTO obs2163.items (id, name) VALUES (1, 'a')")
+            .expect("w");
+        engine
+            .execute("INSERT INTO obs2163.items (id, name) VALUES (2, 'b')")
+            .expect("w");
+        flush(&mut engine);
+        engine
+            .execute("INSERT INTO obs2163.items (id, name) VALUES (1, 'a2')")
+            .expect("w");
+        engine
+            .execute("INSERT INTO obs2163.items (id, name) VALUES (3, 'c')")
+            .expect("w");
+        flush(&mut engine);
+        Flows { engine, _tmp: tmp }
+    }
+
+    /// A newer whole-row tombstone over an older live cell in the same slot.
+    pub fn run_row_tombstone_merge() -> Flows {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let mut engine = open(tmp.path(), clustered_schema());
+        engine
+            .execute("INSERT INTO obs2163.events (id, seq, val) VALUES (1, 1, 'old')")
+            .expect("w");
+        flush(&mut engine);
+        engine
+            .execute("DELETE FROM obs2163.events WHERE id = 1 AND seq = 1")
+            .expect("del");
+        flush(&mut engine);
+        Flows { engine, _tmp: tmp }
+    }
+
+    /// Drive maintenance compaction until a merge completes (or no work remains).
+    pub fn compact(flows: &mut Flows) {
+        // maintenance_step uses an internal block_on; call it OUTSIDE any runtime.
+        let budget = std::time::Duration::from_secs(30);
+        for _ in 0..10 {
+            let report = flows
+                .engine
+                .maintenance_step(budget)
+                .expect("maintenance_step");
+            if !report.completed_merges.is_empty() {
+                break;
+            }
+            if !report.pending_compaction {
+                break;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reader fixtures (real BIG fixture + a writer-produced schema-attached reader).
+// ---------------------------------------------------------------------------
+
+mod fixtures {
+    use cqlite_core::platform::Platform;
+    use cqlite_core::schema::registry::{SchemaRegistry, SchemaRegistryConfig, SchemaSource};
+    use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+    use cqlite_core::storage::sstable::reader::SSTableReader;
+    use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+    use cqlite_core::types::{RowKey, TableId};
+    use cqlite_core::Config;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    fn datasets_root() -> PathBuf {
+        match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(root) => PathBuf::from(root),
+            Err(_) => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../test-data/datasets"),
+        }
+    }
+
+    /// Open a real BIG (nb) fixture SSTable reader (has a Filter.db bloom filter).
+    pub fn open_big_reader() -> SSTableReader {
+        let parent = datasets_root().join("sstables").join("test_basic");
+        let table_dir = std::fs::read_dir(&parent)
+            .unwrap_or_else(|e| panic!("read {}: {e} — fetch datasets first", parent.display()))
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_name().to_string_lossy().starts_with("simple_table-"))
+            .map(|e| e.path())
+            .expect("simple_table fixture present");
+        let data_file = std::fs::read_dir(&table_dir)
+            .expect("read table dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .find(|p| p.to_string_lossy().ends_with("-Data.db"))
+            .expect("Data.db present");
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        rt.block_on(SSTableReader::open(&data_file, &config, platform))
+            .expect("open reader")
+    }
+
+    fn writer_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "obsfn".to_string(),
+            table: "rows".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// Write one row, flush, and open a schema-attached reader over the produced
+    /// Data.db. Returns the reader, a matching TableId, and the present key bytes.
+    /// The reader can authoritatively scan for the key (schema attached), which the
+    /// false-negative verification needs.
+    pub fn open_writer_reader_with_present_key(
+    ) -> (SSTableReader, TableId, [u8; 4], tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = writer_schema();
+        let cfg = WriteEngineConfig::new(
+            tmp.path().join("data"),
+            tmp.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        engine
+            .execute("INSERT INTO obsfn.rows (id, name) VALUES (7, 'seven')")
+            .expect("write");
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let info = rt
+            .block_on(engine.flush())
+            .expect("flush")
+            .expect("sstable");
+        let data_file = info.data_path.clone();
+
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        let mut reader = rt
+            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
+            .expect("open reader");
+
+        // Attach the schema so the authoritative scan can decode the row.
+        let registry = rt
+            .block_on(SchemaRegistry::new(
+                SchemaRegistryConfig::default(),
+                platform.clone(),
+                config.clone(),
+            ))
+            .expect("build registry");
+        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
+            .expect("register schema");
+        let registry = Arc::new(tokio::sync::RwLock::new(registry));
+        rt.block_on(reader.attach_schema_registry(registry));
+
+        // Confirm the reader really can find the present key (so the verify scan
+        // is meaningful), then hand back the pieces the test needs.
+        let table_id = TableId::from("rows");
+        let present_key = 7i32.to_be_bytes();
+        let found = rt
+            .block_on(reader.get(&table_id, &RowKey::from(present_key.to_vec())))
+            .expect("get present key");
+        assert!(
+            found.is_some(),
+            "writer fixture reader must be able to read back the present key for the \
+             false-negative scan to be meaningful"
+        );
+        drop(rt);
+        (reader, table_id, present_key, tmp)
+    }
+}

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -279,6 +279,81 @@ fn correctness_signals_end_to_end() {
         );
     }
 
+    // --- Roborev r4 blocker #1 (#2163): the PRIMARY point-read path must emit
+    // `sstables_pruned` too — not only the `might_contain_partition[_encoded]`
+    // candidate-prune helpers. This IS the spec's own scenario: "a partition
+    // point lookup ... through the public read surface" over a table with
+    // multiple SSTables, present in one generation and absent from another. ---
+    {
+        use cqlite_core::types::RowKey;
+
+        let (reader_present, reader_absent, table_id, _tmp) =
+            fixtures::open_two_generation_readers();
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        // Search among gen 1's own ids for one gen 2's bloom filter ALSO reports
+        // absent (bloom filters can rarely false-positive on an unrelated key;
+        // searching — not assuming — keeps this deterministic, same technique as
+        // the BTI in-range search above).
+        let mut probe_id: Option<i32> = None;
+        for candidate in 0..20i32 {
+            let key_bytes = candidate.to_be_bytes();
+            if !reader_absent.might_contain_partition(&key_bytes) {
+                probe_id = Some(candidate);
+                break;
+            }
+        }
+        let probe_id = probe_id.expect(
+            "at least one of gen 1's 20 ids must show as absent in gen 2's bloom filter \
+             (expected false-positive rate ~1%)",
+        );
+        let probe_key = probe_id.to_be_bytes();
+
+        mc.reset();
+        let found_in_gen1 = rt
+            .block_on(reader_present.get_with_resolution(
+                &table_id,
+                &RowKey::from(probe_key.to_vec()),
+                false,
+            ))
+            .expect("get on the generation holding the key");
+        let found_in_gen2 = rt
+            .block_on(reader_absent.get_with_resolution(
+                &table_id,
+                &RowKey::from(probe_key.to_vec()),
+                false,
+            ))
+            .expect("get on the generation NOT holding the key");
+        drop(rt);
+
+        assert!(
+            found_in_gen1.is_some(),
+            "the generation that actually holds id={probe_id} must return it"
+        );
+        assert!(
+            found_in_gen2.is_none(),
+            "the OTHER generation must report id={probe_id} absent"
+        );
+
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_SSTABLES_PRUNED),
+            1.0,
+            "the PRIMARY public get_with_resolution() point-read path must emit \
+             cqlite.read.sstables_pruned exactly once for the excluded generation \
+             (the gen-1 hit must emit nothing); entry: {:?}",
+            m.find(catalog::READ_SSTABLES_PRUNED)
+        );
+        assert_eq!(
+            m.sum_where(
+                catalog::READ_SSTABLES_PRUNED,
+                &[(catalog::attr::SSTABLE_FORMAT, "big")],
+            ),
+            1.0,
+            "the prune must carry cqlite.sstable.format=big"
+        );
+    }
+
     // --- Requirement: Opt-in presence-oracle false-negative verification ---
     {
         let (reader, table_id, present_key, _tmp) = fixtures::open_writer_reader_with_present_key();
@@ -450,6 +525,223 @@ fn correctness_signals_end_to_end() {
         );
 
         presence_verification::set_enabled_for_testing(false);
+        drop(rt);
+    }
+
+    // --- Roborev r4 blocker #2 (#2163): `ObservabilityConfig::verify_presence_oracle`
+    // must not be decorative. Config-only enablement (NO env var set) must flip
+    // the runtime switch through the PUBLIC `observability::init` entry point, and
+    // that flip must drive an ACTUAL confirmation scan through the public
+    // `get_with_resolution` read path — not merely make `enabled()` report `true`
+    // in isolation. Also pins the documented env-overrides-config precedence. ---
+    {
+        use cqlite_core::observability::ObservabilityConfig;
+        use cqlite_core::storage::sstable::reader::SSTableReader;
+        use cqlite_core::types::RowKey;
+
+        // Isolate from any real process env for this assertion.
+        let saved_env = std::env::var(presence_verification::ENV_VAR).ok();
+        std::env::remove_var(presence_verification::ENV_VAR);
+
+        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(30);
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        // Locate an in-range absent key (else C5 would short-circuit before the
+        // verify hook regardless of the switch) using the TEST setter purely to
+        // search — the switch is driven exclusively through `observability::init`
+        // for every assertion below.
+        presence_verification::set_enabled_for_testing(true);
+        let mut in_range_absent_key: Option<[u8; 4]> = None;
+        for candidate in 3_000_000i32..3_000_064 {
+            let key_bytes = candidate.to_be_bytes();
+            let before = SSTableReader::scan_for_key_call_count();
+            let res = rt
+                .block_on(reader.get_with_resolution(
+                    &table_id,
+                    &RowKey::from(key_bytes.to_vec()),
+                    false,
+                ))
+                .expect("get on candidate probe");
+            let after = SSTableReader::scan_for_key_call_count();
+            assert!(
+                res.is_none(),
+                "candidate {candidate} must be genuinely absent"
+            );
+            if after == before + 1 {
+                in_range_absent_key = Some(key_bytes);
+                break;
+            }
+        }
+        let absent_key = in_range_absent_key
+            .expect("at least one of 64 candidates must land within the Summary bound");
+
+        // Config-only DISABLE (no env): the switch must be OFF and the same key
+        // must show no confirmation scan through the public read path.
+        let cfg_off = ObservabilityConfig::builder()
+            .enabled(false)
+            .verify_presence_oracle(false)
+            .build();
+        let _guard = cqlite_core::observability::init(cfg_off).expect("init config-off");
+        assert!(
+            !presence_verification::enabled(),
+            "config-only disable must flip the switch off through observability::init"
+        );
+        let before = SSTableReader::scan_for_key_call_count();
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get config-off");
+        let after = SSTableReader::scan_for_key_call_count();
+        assert!(res.is_none());
+        assert_eq!(
+            after, before,
+            "config-only disable must not run a confirmation scan through get_with_resolution"
+        );
+
+        // Config-only ENABLE (no env): the switch must flip ON AND drive an ACTUAL
+        // confirmation scan through the public get_with_resolution() path for the
+        // SAME key — the end-to-end proof the field is wired, not decorative.
+        let cfg_on = ObservabilityConfig::builder()
+            .enabled(false)
+            .verify_presence_oracle(true)
+            .build();
+        let _guard = cqlite_core::observability::init(cfg_on).expect("init config-on");
+        assert!(
+            presence_verification::enabled(),
+            "config-only enable must flip the switch on through observability::init"
+        );
+        let before = SSTableReader::scan_for_key_call_count();
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get config-on");
+        let after = SSTableReader::scan_for_key_call_count();
+        assert!(res.is_none());
+        assert!(
+            after > before,
+            "config-only enable must drive a confirmation scan through get_with_resolution — \
+             proving ObservabilityConfig::verify_presence_oracle is wired end-to-end, not \
+             decorative"
+        );
+
+        // An explicitly-set env var must override a conflicting config value
+        // (documented env-overrides-config precedence).
+        std::env::set_var(presence_verification::ENV_VAR, "false");
+        let cfg_conflict = ObservabilityConfig::builder()
+            .enabled(false)
+            .verify_presence_oracle(true) // config says ON; env says off
+            .build();
+        let _guard = cqlite_core::observability::init(cfg_conflict).expect("init env-override");
+        assert!(
+            !presence_verification::enabled(),
+            "an explicitly-set env var must override a conflicting config value"
+        );
+
+        // Restore env + leave the switch OFF for any later blocks.
+        match saved_env {
+            Some(v) => std::env::set_var(presence_verification::ENV_VAR, v),
+            None => std::env::remove_var(presence_verification::ENV_VAR),
+        }
+        presence_verification::set_enabled_for_testing(false);
+        drop(rt);
+    }
+
+    // --- Roborev r4 item 3 (LOW, folded in, #2163): no REDUNDANT double scan.
+    // When the PRIMARY path itself already ran the authoritative `scan_for_key`
+    // (a bloom false positive falling through to an Index.db miss), the key was
+    // NOT excluded by the presence oracle (`oracle_pruned = false`), so turning
+    // verification ON must NOT trigger a second confirmation scan — the delta
+    // must stay exactly 1 (the primary scan only) whether verification is OFF or
+    // ON, distinguishing "oracle negative" (needs verifying) from "already an
+    // authoritative scan result" (nothing left to verify). ---
+    {
+        use cqlite_core::storage::sstable::reader::SSTableReader;
+        use cqlite_core::types::RowKey;
+
+        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(30);
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        // Search for a bloom FALSE POSITIVE: `might_contain_partition == true` for
+        // a key genuinely absent (well outside the inserted 0..30 range). Default
+        // `fp_chance` is 0.01, so finding >=1 among 10,000 candidates is
+        // overwhelmingly likely (searched, not assumed).
+        let mut fp_key: Option<[u8; 4]> = None;
+        for candidate in 4_000_000i32..4_010_000i32 {
+            let key_bytes = candidate.to_be_bytes();
+            if reader.might_contain_partition(&key_bytes) {
+                fp_key = Some(key_bytes);
+                break;
+            }
+        }
+
+        if let Some(fp_key) = fp_key {
+            // Verification OFF: the primary path's OWN Index.db-miss fallback
+            // scans once (the natural #1572 behaviour, unrelated to the switch).
+            presence_verification::set_enabled_for_testing(false);
+            let before = SSTableReader::scan_for_key_call_count();
+            let res = rt
+                .block_on(reader.get_with_resolution(
+                    &table_id,
+                    &RowKey::from(fp_key.to_vec()),
+                    false,
+                ))
+                .expect("get on bloom-false-positive key, verification off");
+            let after = SSTableReader::scan_for_key_call_count();
+            assert!(res.is_none(), "the bloom-FP key must still resolve absent");
+            assert_eq!(
+                after,
+                before + 1,
+                "the primary path's own scan_for_key fallback must run exactly once"
+            );
+
+            // Verification ON, the SAME key: `oracle_pruned` is false (the bloom
+            // hit admitted this SSTable; the index miss forced the primary path's
+            // OWN scan), so the opt-in verify hook must NOT run a second scan.
+            presence_verification::set_enabled_for_testing(true);
+            mc.reset();
+            let before = SSTableReader::scan_for_key_call_count();
+            let res = rt
+                .block_on(reader.get_with_resolution(
+                    &table_id,
+                    &RowKey::from(fp_key.to_vec()),
+                    false,
+                ))
+                .expect("get on bloom-false-positive key, verification on");
+            let after = SSTableReader::scan_for_key_call_count();
+            assert!(res.is_none(), "the bloom-FP key must still resolve absent");
+            assert_eq!(
+                after,
+                before + 1,
+                "verification ON must NOT add a second scan when the primary path already ran \
+                 the authoritative scan_for_key (oracle_pruned=false) — exactly one scan total"
+            );
+            let m = mc.flush_and_collect();
+            assert_eq!(
+                m.counter_sum(catalog::READ_SSTABLES_PRUNED),
+                0.0,
+                "a bloom hit (even a false positive) is not a presence-oracle exclusion — must \
+                 not emit sstables_pruned"
+            );
+            assert_eq!(
+                m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+                0.0,
+                "the skipped (non-oracle) case must never emit false_negatives"
+            );
+            presence_verification::set_enabled_for_testing(false);
+        } else {
+            eprintln!(
+                "correctness_signals_2163: no bloom false positive found among 10,000 candidates \
+                 (fp_chance=0.01 makes this astronomically unlikely) — skipping the no-double-scan \
+                 sub-assertion for this run; the structural invariant (verify only runs when \
+                 oracle_pruned) is still enforced by the code path itself"
+            );
+        }
         drop(rt);
     }
 
@@ -886,5 +1178,78 @@ mod fixtures {
         drop(rt);
 
         (reader, TableId::from("rows"), tmp)
+    }
+
+    /// Two DISJOINT-key SSTable generations of the SAME table (no compaction),
+    /// opened as independent `SSTableReader`s — the multi-SSTable point-lookup
+    /// scenario the spec names directly (roborev r4, #2163). Generation 1 holds
+    /// ids `0..20`; generation 2 holds ids `1000..1020` (a disjoint range so a
+    /// probe key from gen 1 is genuinely absent from gen 2's Data.db, not merely
+    /// absent from the writer's `INSERT` set).
+    pub fn open_two_generation_readers(
+    ) -> (SSTableReader, SSTableReader, TableId, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = writer_schema();
+        let cfg = WriteEngineConfig::new(
+            tmp.path().join("data"),
+            tmp.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        for id in 0..20i32 {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'g1-{id}')"
+                ))
+                .expect("write gen1");
+        }
+        let info1 = rt
+            .block_on(engine.flush())
+            .expect("flush gen1")
+            .expect("sstable gen1");
+
+        for id in 1000..1020i32 {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'g2-{id}')"
+                ))
+                .expect("write gen2");
+        }
+        let info2 = rt
+            .block_on(engine.flush())
+            .expect("flush gen2")
+            .expect("sstable gen2");
+
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        let registry = rt
+            .block_on(SchemaRegistry::new(
+                SchemaRegistryConfig::default(),
+                platform.clone(),
+                config.clone(),
+            ))
+            .expect("build registry");
+        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
+            .expect("register schema");
+        let registry = Arc::new(tokio::sync::RwLock::new(registry));
+
+        let mut reader1 = rt
+            .block_on(SSTableReader::open(
+                &info1.data_path,
+                &config,
+                platform.clone(),
+            ))
+            .expect("open gen1 reader");
+        rt.block_on(reader1.attach_schema_registry(registry.clone()));
+
+        let mut reader2 = rt
+            .block_on(SSTableReader::open(&info2.data_path, &config, platform))
+            .expect("open gen2 reader");
+        rt.block_on(reader2.attach_schema_registry(registry));
+
+        drop(rt);
+        (reader1, reader2, TableId::from("rows"), tmp)
     }
 }

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -37,7 +37,11 @@ fn assert_registered_unit(metrics: &testing::CapturedMetrics, name: &str, unit: 
     assert!(
         metrics.contains(name),
         "{name} must be collected; saw: {:?}",
-        metrics.entries().iter().map(|e| e.name.clone()).collect::<Vec<_>>()
+        metrics
+            .entries()
+            .iter()
+            .map(|e| e.name.clone())
+            .collect::<Vec<_>>()
     );
     assert_eq!(
         metrics.unit(name),
@@ -95,7 +99,11 @@ fn correctness_signals_end_to_end() {
         catalog::READ_BLOOM_FALSE_NEGATIVES,
         catalog::unit::DIMENSIONLESS,
     );
-    assert_registered_unit(&m, catalog::QUERY_DEGRADED_PATH, catalog::unit::DIMENSIONLESS);
+    assert_registered_unit(
+        &m,
+        catalog::QUERY_DEGRADED_PATH,
+        catalog::unit::DIMENSIONLESS,
+    );
 
     // --- Requirement: Merge row-count reconciliation counters ---
     // Two overlapping generations: partition id=1 appears in BOTH SSTables and
@@ -109,12 +117,14 @@ fn correctness_signals_end_to_end() {
         let rows_in = m.counter_sum(catalog::MERGE_ROWS_IN);
         let rows_out = m.counter_sum(catalog::MERGE_ROWS_OUT);
         assert_eq!(
-            rows_in, 4.0,
+            rows_in,
+            4.0,
             "cqlite.merge.rows_in must equal the 4 rows consumed at reconcile; entry: {:?}",
             m.find(catalog::MERGE_ROWS_IN)
         );
         assert_eq!(
-            rows_out, 3.0,
+            rows_out,
+            3.0,
             "cqlite.merge.rows_out must equal the 3 reconciled rows; entry: {:?}",
             m.find(catalog::MERGE_ROWS_OUT)
         );
@@ -159,7 +169,16 @@ fn correctness_signals_end_to_end() {
         let mut expected_pruned = 0u64;
         for i in 0..64u32 {
             // 8-byte keys that do not exist in the (int-keyed) fixture table.
-            let key = [0xFEu8, 0xED, 0xFA, 0xCE, (i >> 8) as u8, i as u8, 0xAB, 0xCD];
+            let key = [
+                0xFEu8,
+                0xED,
+                0xFA,
+                0xCE,
+                (i >> 8) as u8,
+                i as u8,
+                0xAB,
+                0xCD,
+            ];
             if !reader.might_contain_partition(&key) {
                 expected_pruned += 1;
             }
@@ -187,8 +206,7 @@ fn correctness_signals_end_to_end() {
 
     // --- Requirement: Opt-in presence-oracle false-negative verification ---
     {
-        let (reader, table_id, present_key, _tmp) =
-            fixtures::open_writer_reader_with_present_key();
+        let (reader, table_id, present_key, _tmp) = fixtures::open_writer_reader_with_present_key();
         let rt = tokio::runtime::Runtime::new().expect("rt");
         let absent_key = 0x7FFF_FFFFi32.to_be_bytes();
 
@@ -230,7 +248,10 @@ fn correctness_signals_end_to_end() {
         let got = rt
             .block_on(reader.verify_presence_oracle_negative(&table_id, &present_key))
             .expect("verify on contradiction");
-        assert!(got, "a present key must be reported as a contradicted negative");
+        assert!(
+            got,
+            "a present key must be reported as a contradicted negative"
+        );
         let m = mc.flush_and_collect();
         assert_eq!(
             m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
@@ -303,10 +324,7 @@ mod merge {
                 position: 0,
             }],
             clustering_keys: vec![],
-            columns: vec![
-                col("id", "int", false),
-                col("name", "text", true),
-            ],
+            columns: vec![col("id", "int", false), col("name", "text", true)],
             comments: HashMap::new(),
             dropped_columns: HashMap::new(),
         }
@@ -363,7 +381,9 @@ mod merge {
             .enable_all()
             .build()
             .expect("rt");
-        rt.block_on(engine.flush()).expect("flush").expect("sstable");
+        rt.block_on(engine.flush())
+            .expect("flush")
+            .expect("sstable");
     }
 
     /// Two overlapping SSTables: id=1 in both (LWW-collapses), plus id=2 and id=3.

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -210,6 +210,32 @@ fn correctness_signals_end_to_end() {
         );
     }
 
+    // --- Roborev r7 (#2163): a RETAINED CELL tombstone (a column-scoped
+    // `DELETE val` with a recent deletion time — not gc-grace-expired, so it
+    // is genuinely non-purgeable) must ALSO count as emitted, matching the
+    // row/range/partition tombstone contract. Previously `tombstones_emitted`
+    // only counted row/range/partition markers, undercounting every merge
+    // that retains a cell tombstone — exactly the marker
+    // tombstone-resurrection debugging needs to see. `tombstones_purged` must
+    // stay untouched (the cell was retained, not purged). ---
+    {
+        let mut flows = merge::run_cell_tombstone_merge();
+        mc.reset();
+        merge::compact(&mut flows);
+        let m = mc.flush_and_collect();
+        assert!(
+            m.counter_sum(catalog::COMPACTION_TOMBSTONES_EMITTED) >= 1.0,
+            "a non-purgeable (recent) cell tombstone retained through compaction must count \
+             >=1 emitted; entry: {:?}",
+            m.find(catalog::COMPACTION_TOMBSTONES_EMITTED)
+        );
+        assert_eq!(
+            m.counter_sum(catalog::COMPACTION_TOMBSTONES_PURGED),
+            0.0,
+            "a RETAINED (non-purgeable) cell tombstone must not also count as a genuine purge"
+        );
+    }
+
     // --- Requirement: SSTable-pruned-by-presence-oracle counter ---
     // A BIG (nb) SSTable with a bloom filter: probing definitely-absent keys makes
     // `might_contain_partition` return false, pruning the SSTable per probe.
@@ -765,6 +791,29 @@ mod merge {
                  USING TIMESTAMP 3000",
             )
             .expect("w2");
+        flush(&mut engine);
+        Flows { engine, _tmp: tmp }
+    }
+
+    /// Roborev r7 (#2163): a NON-PURGEABLE CELL tombstone — a column-scoped
+    /// `DELETE val` (not a whole-row delete) with a RECENT deletion time, well
+    /// within the default `gc_grace_seconds` window — must be RETAINED through
+    /// compaction and counted as `tombstones_emitted`, the same as a retained
+    /// row/range/partition marker. `extra` stays live (a surviving sibling data
+    /// cell) so the row is genuinely emitted with the `val` cell tombstone
+    /// intact, not phantom-suppressed.
+    pub fn run_cell_tombstone_merge() -> Flows {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let mut engine = open(tmp.path(), clustered_schema());
+        engine
+            .execute(
+                "INSERT INTO obs2163.events (id, seq, val, extra) VALUES (4, 1, 'keep', 'stays')",
+            )
+            .expect("w");
+        flush(&mut engine);
+        engine
+            .execute("DELETE val FROM obs2163.events WHERE id = 4 AND seq = 1")
+            .expect("del col");
         flush(&mut engine);
         Flows { engine, _tmp: tmp }
     }

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -509,6 +509,108 @@ fn correctness_signals_end_to_end() {
         presence_verification::set_enabled_for_testing(false);
         drop(rt);
     }
+
+    // --- Roborev r7 (#2163): the REVERSE-SCAN FAST PATH (`candidates.len() ==
+    // 1` branch of `scan_partition_clustering_reverse`) serves the read
+    // DIRECTLY from the single admitted candidate and never falls through to
+    // the reconciling fallback — so a false negative wrongly excluding a
+    // co-holding generation on THIS branch was never verified (unlike the r6
+    // multi-generation-manager case, which the `!= 1` fallback DOES cover via
+    // `scan_partition_clustering`'s own `verify_pruned_candidates` call). Drives
+    // the PUBLIC `ORDER BY ... DESC` reverse read path end-to-end through
+    // `Database::execute`, not the manager directly. ---
+    {
+        use cqlite_core::ingestion::{ingest, IngestionConfig};
+
+        let (data_dir, filter_path, _tmp) = fixtures::write_wide_partition_two_generations();
+
+        // Fault-inject: zero gen B's Filter.db bit array (same technique as the
+        // r6 manager test) — structurally valid, but reports every key absent,
+        // so `prune_candidates` wrongly excludes gen B and
+        // `scan_partition_clustering_reverse` takes the `len() == 1` fast path
+        // serving ONLY gen A's 100 rows.
+        let mut filter_bytes = std::fs::read(&filter_path).expect("read gen B Filter.db");
+        assert!(
+            filter_bytes.len() > 8,
+            "gen B Filter.db must have a non-empty bit array to corrupt"
+        );
+        for b in &mut filter_bytes[8..] {
+            *b = 0;
+        }
+        std::fs::write(&filter_path, &filter_bytes).expect("write corrupted Filter.db");
+
+        // A temp CQL schema file so `ingest()` can register query-time decode
+        // metadata for the table (independent of the WriteEngine's own schema).
+        let schema_dir = tempfile::TempDir::new().expect("schema tmp");
+        let schema_path = schema_dir.path().join("wide.cql");
+        std::fs::write(
+            &schema_path,
+            "CREATE TABLE obsfn.wide (id int, seq int, val text, PRIMARY KEY (id, seq));",
+        )
+        .expect("write schema file");
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let db = rt
+            .block_on(ingest(IngestionConfig {
+                schema_paths: vec![schema_path],
+                data_dir,
+                version_hint: Some("5.0".to_string()),
+                core_config: cqlite_core::Config::default(),
+                table_directory_filter: None,
+            }))
+            .expect("ingest over both generations (gen B has a corrupted Filter.db)")
+            .database;
+
+        // (a) Verification OFF (default): the reverse fast path silently serves
+        // ONLY gen A's 100 rows (the silent-miss bug this switch detects; the
+        // read wrongly took the single-generation direct-serve path instead of
+        // reconciling with gen B's 5 extra rows) — and no confirmation scan runs.
+        presence_verification::set_enabled_for_testing(false);
+        mc.reset();
+        let res_off = rt
+            .block_on(db.execute("SELECT seq FROM obsfn.wide WHERE id = 1 ORDER BY seq DESC"))
+            .expect("reverse query, verification off");
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            res_off.rows.len(),
+            100,
+            "the reverse fast path must silently miss gen B's 5 extra rows when verification is \
+             off — sees only gen A's 100 rows"
+        );
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            0.0,
+            "verification OFF must never emit false_negatives (zero extra scan cost)"
+        );
+
+        // (b) Verification ON, the SAME (still-corrupted) data: the reverse
+        // fast path's own pruned-candidate verification (roborev r7 fix) must
+        // catch the contradiction exactly once.
+        presence_verification::set_enabled_for_testing(true);
+        mc.reset();
+        let _res_on = rt
+            .block_on(db.execute("SELECT seq FROM obsfn.wide WHERE id = 1 ORDER BY seq DESC"))
+            .expect("reverse query, verification on");
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            1.0,
+            "the reverse-scan fast path's wrongly-pruned gen B must be caught EXACTLY once when \
+             verification is on; entry: {:?}",
+            m.find(catalog::READ_BLOOM_FALSE_NEGATIVES)
+        );
+        assert_eq!(
+            m.sum_where(
+                catalog::READ_BLOOM_FALSE_NEGATIVES,
+                &[(catalog::attr::SSTABLE_FORMAT, "big")],
+            ),
+            1.0,
+            "the contradicted negative must carry cqlite.sstable.format=big"
+        );
+
+        presence_verification::set_enabled_for_testing(false);
+        drop(rt);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -701,7 +803,7 @@ mod merge {
 mod fixtures {
     use cqlite_core::platform::Platform;
     use cqlite_core::schema::registry::{SchemaRegistry, SchemaRegistryConfig, SchemaSource};
-    use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+    use cqlite_core::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
     use cqlite_core::storage::sstable::reader::SSTableReader;
     use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
     use cqlite_core::types::TableId;
@@ -920,5 +1022,101 @@ mod fixtures {
             .expect("gen2 must have a Filter.db (default bloom_filter_fp_chance)");
 
         (data_dir, filter_path, TableId::from("obsfn.rows"), tmp)
+    }
+
+    fn wide_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "obsfn".to_string(),
+            table: "wide".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "seq".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: Default::default(),
+            }],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "seq".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "val".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// A WIDE partition (`id = 1`) split across TWO generations, for the
+    /// reverse-scan fast-path candidate-prune test (roborev r7, #2163). Gen A
+    /// holds 100 clustering rows carrying a 1 KiB `val` each (~100 KiB total —
+    /// comfortably crossing the 64 KiB promoted-index threshold, so
+    /// `big_reverse_partition_rows` actually engages: a promoted index is only
+    /// emitted once a partition crosses that boundary). Gen B holds 5 MORE
+    /// clustering rows for the SAME partition (small; it doesn't itself need to
+    /// be wide) — UNCORRUPTED, both generations legitimately hold `id = 1`, so
+    /// `candidates.len() == 2` and the reverse fast path correctly declines in
+    /// favor of the reconciling in-memory-sort fallback. Returns the `data` root
+    /// (pass to `ingest()`), gen B's `Filter.db` path (for corruption), and the
+    /// `TempDir` (kept alive).
+    pub fn write_wide_partition_two_generations() -> (PathBuf, PathBuf, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = wide_schema();
+        let data_dir = tmp.path().join("data");
+        let cfg = WriteEngineConfig::new(data_dir.clone(), tmp.path().join("wal"), schema);
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        let blob = "x".repeat(1024);
+        for seq in 0..100i32 {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.wide (id, seq, val) VALUES (1, {seq}, '{blob}')"
+                ))
+                .expect("write gen A row");
+        }
+        rt.block_on(engine.flush())
+            .expect("flush gen A")
+            .expect("sstable gen A");
+
+        for seq in 100..105i32 {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.wide (id, seq, val) VALUES (1, {seq}, 'genB-{seq}')"
+                ))
+                .expect("write gen B row");
+        }
+        let info_b = rt
+            .block_on(engine.flush())
+            .expect("flush gen B")
+            .expect("sstable gen B");
+        drop(rt);
+
+        let filter_path = info_b
+            .filter_path
+            .clone()
+            .expect("gen B must have a Filter.db (default bloom_filter_fp_chance)");
+
+        (data_dir, filter_path, tmp)
     }
 }

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -6,6 +6,14 @@
 //! `SSTableReader`, a `SELECT` via `Database`) and asserts against the emitted
 //! catalog metrics captured by the shared in-memory OTLP exporter.
 //!
+//! The presence-oracle opt-in VERIFICATION SWITCH scenarios (the false-negative
+//! confirmation scan, its `get_with_resolution`/`ObservabilityConfig` wiring, the
+//! no-double-scan invariant, and the degraded read-path counter) live in the
+//! sibling file `correctness_signals_2163_verify.rs` — split out (campsite rule,
+//! epic #1135) once this file's own additions crossed the ~1500-line test-file
+//! threshold; see that file's header for why a separate test BINARY is safe here
+//! (each `tests/*.rs` file is its own process with independent global state).
+//!
 //! # Why one serial metric test
 //!
 //! The production metric helpers record through a single process-global `Meter`
@@ -27,6 +35,7 @@
 
 use cqlite_core::observability::{self as obs, catalog, testing};
 use cqlite_core::storage::sstable::reader::presence_verification;
+use serial_test::serial;
 
 // ---------------------------------------------------------------------------
 // Requirement: Catalog integrity — every added counter resolves to a
@@ -55,7 +64,18 @@ fn assert_registered_unit(metrics: &testing::CapturedMetrics, name: &str, unit: 
 // The single serial metric test.
 // ---------------------------------------------------------------------------
 
+// Roborev r6 (LOW, #2163): this test mutates PROCESS-GLOBAL state (the
+// `presence_verification` switch, `CQLITE_VERIFY_PRESENCE_ORACLE` /
+// `std::env::set_var`/`remove_var`, and the shared observability metrics
+// singleton) without any synchronization against another `#[test]` in this
+// same binary. There is currently only ONE test function here, so this is
+// defensive/future-proofing rather than a live bug — but `#[serial]` costs
+// nothing and matches the established repo idiom (e.g.
+// `issue_1575_candidate_key_hash_hoist.rs`) for any test that touches process
+// env or global switches, protecting against a future second test added to
+// this file (or a test-harness change) racing on the same global state.
 #[test]
+#[serial]
 fn correctness_signals_end_to_end() {
     let mc = testing::metrics_capture();
 
@@ -369,59 +389,113 @@ fn correctness_signals_end_to_end() {
         );
     }
 
-    // --- Requirement: Opt-in presence-oracle false-negative verification ---
+    // --- Roborev r6 (#2163): the CORE silent-miss case — a candidate
+    // eliminated by `SSTableManager::prune_candidates` (the multi-generation
+    // path) must ALSO be opt-in-verified, not just a single reader's own
+    // `get_with_resolution`. A fault-injected oracle (a Filter.db whose bit
+    // array is zeroed post-write — a real, on-disk corruption, not a mock)
+    // wrongly excludes gen 2 even though it genuinely holds the probed key.
+    // Switch ON must catch the contradiction; switch OFF must cost nothing. ---
     {
-        let (reader, table_id, present_key, _tmp) = fixtures::open_writer_reader_with_present_key();
-        let rt = tokio::runtime::Runtime::new().expect("rt");
-        let absent_key = 0x7FFF_FFFFi32.to_be_bytes();
+        use cqlite_core::platform::Platform;
+        use cqlite_core::schema::registry::{SchemaRegistry, SchemaRegistryConfig, SchemaSource};
+        use cqlite_core::storage::sstable::SSTableManager;
+        use cqlite_core::Config;
+        use std::sync::Arc;
 
-        // (a) Verification OFF (default): a point read for an absent key performs no
-        // confirmation scan and never emits the false-negative counter.
+        let (data_dir, filter_path, table_id, _tmp) = fixtures::write_two_generations_for_manager();
+
+        // Fault-inject: zero the bloom filter's BIT ARRAY (bytes after the
+        // 8-byte header: `hash_count: i32 BE`, `num_longs: i32 BE`) so the
+        // filter parses as STRUCTURALLY VALID but reports every key absent —
+        // a real (simulated) Filter.db corruption, matching `bloom.rs`'s own
+        // documented failure mode ("would fail OPEN (always report 'not
+        // present'), producing false negatives").
+        let mut filter_bytes = std::fs::read(&filter_path).expect("read gen2 Filter.db");
+        assert!(
+            filter_bytes.len() > 8,
+            "gen2 Filter.db must have a non-empty bit array to corrupt"
+        );
+        for b in &mut filter_bytes[8..] {
+            *b = 0;
+        }
+        std::fs::write(&filter_path, &filter_bytes).expect("write corrupted Filter.db");
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+
+        // Attach the schema via a registry so the manager's readers can decode
+        // rows (mirrors the other fixtures' schema-attach step).
+        let registry = rt
+            .block_on(SchemaRegistry::new(
+                SchemaRegistryConfig::default(),
+                platform.clone(),
+                config.clone(),
+            ))
+            .expect("build registry");
+        rt.block_on(registry.register_schema(fixtures::writer_schema(), SchemaSource::Manual))
+            .expect("register schema");
+        let registry = Arc::new(tokio::sync::RwLock::new(registry));
+
+        let manager = rt
+            .block_on(SSTableManager::new(
+                &data_dir,
+                &config,
+                platform,
+                Some(registry),
+            ))
+            .expect("open manager over both generations (one with a corrupted Filter.db)");
+
+        // A key from gen 2's own range (2000..2010) — genuinely present in
+        // gen2's Data.db, but the corrupted Filter.db now reports it absent,
+        // so `prune_candidates` wrongly excludes gen2 from `candidates`.
+        let probe_key = 2005i32.to_be_bytes();
+
+        // (a) Verification OFF (default): the read still (silently) misses the
+        // row — that IS the silent-miss bug this issue targets — but the
+        // opt-in scan must not run at all (zero extra cost).
         presence_verification::set_enabled_for_testing(false);
         mc.reset();
-        let got = rt
-            .block_on(reader.verify_presence_oracle_negative(&table_id, &absent_key))
-            .expect("verify off");
-        assert!(!got, "verification OFF must not run a confirmation scan");
+        let (rows_off, _engaged) = rt
+            .block_on(manager.scan_partition_with_cell_metadata(
+                &table_id,
+                &probe_key,
+                Some(&fixtures::writer_schema()),
+            ))
+            .expect("scan with verification off");
         let m = mc.flush_and_collect();
+        assert!(
+            rows_off.is_empty(),
+            "the corrupted Filter.db must silently exclude gen2 (the bug this switch detects) \
+             when verification is off"
+        );
         assert_eq!(
             m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
             0.0,
-            "verification OFF must never emit false_negatives"
+            "verification OFF must never emit false_negatives (zero extra scan cost)"
         );
 
-        // (b) Verification ON, a genuinely absent key: the authoritative scan runs,
-        // finds the key absent, and the counter stays 0.
+        // (b) Verification ON, the SAME key: the opt-in authoritative scan of
+        // the excluded gen2 candidate finds the key, contradicting the
+        // (corrupted) oracle's negative — `cqlite.read.bloom.false_negatives`
+        // must increment by EXACTLY 1 with `format=big`.
         presence_verification::set_enabled_for_testing(true);
         mc.reset();
-        let got = rt
-            .block_on(reader.verify_presence_oracle_negative(&table_id, &absent_key))
-            .expect("verify on true-negative");
-        assert!(!got, "a genuinely absent key must not be a false negative");
-        let m = mc.flush_and_collect();
-        assert_eq!(
-            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
-            0.0,
-            "a confirmed true negative must keep false_negatives at 0"
-        );
-
-        // (c) Verification ON, a PRESENT key fed to the verify path (a synthetic
-        // false negative — the oracle "said absent" for a key that IS present): the
-        // authoritative scan contradicts it and the counter increments by 1 with
-        // the SSTable's format.
-        mc.reset();
-        let got = rt
-            .block_on(reader.verify_presence_oracle_negative(&table_id, &present_key))
-            .expect("verify on contradiction");
-        assert!(
-            got,
-            "a present key must be reported as a contradicted negative"
-        );
+        let (_rows_on, _engaged) = rt
+            .block_on(manager.scan_partition_with_cell_metadata(
+                &table_id,
+                &probe_key,
+                Some(&fixtures::writer_schema()),
+            ))
+            .expect("scan with verification on");
         let m = mc.flush_and_collect();
         assert_eq!(
             m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
             1.0,
-            "a contradicted negative must increment false_negatives by exactly 1"
+            "the multi-generation candidate-prune false negative must be caught EXACTLY once \
+             when verification is on; entry: {:?}",
+            m.find(catalog::READ_BLOOM_FALSE_NEGATIVES)
         );
         assert_eq!(
             m.sum_where(
@@ -429,441 +503,11 @@ fn correctness_signals_end_to_end() {
                 &[(catalog::attr::SSTABLE_FORMAT, "big")],
             ),
             1.0,
-            "the false negative must carry the offending SSTable's format"
-        );
-        presence_verification::set_enabled_for_testing(false);
-        drop(rt);
-    }
-
-    // --- Roborev fold-in #3 (#2163): `get()`-level false-negative wiring ---
-    // Proves the verification switch is wired through the PUBLIC
-    // `get_with_resolution` read-path entry point end-to-end — not just callable
-    // on the `verify_presence_oracle_negative` method directly. Uses the
-    // process-global `scan_for_key_call_count()` (issue #831 pattern) as the
-    // observable proxy for "the authoritative confirmation scan ran": OFF must
-    // leave the count unchanged for an absent key; ON must increment it for the
-    // SAME key.
-    {
-        use cqlite_core::storage::sstable::reader::SSTableReader;
-        use cqlite_core::types::RowKey;
-
-        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(50);
-        let rt = tokio::runtime::Runtime::new().expect("rt");
-
-        // Search for an absent probe key whose token falls WITHIN this reader's
-        // authoritative Summary bound (else the C5 range short-circuit in
-        // `get_with_resolution` returns absence before ever reaching the
-        // presence-oracle / verify hook — a token-order fact independent of int
-        // order, so we search rather than assume). Verification is ON during the
-        // search. Accept ONLY a candidate whose scan-count delta is EXACTLY 1: that
-        // is the clean signature of "my verify hook ran its one confirmation scan
-        // and nothing else did" — a candidate that also trips the natural BIG
-        // resolution's OWN scan_for_key fallback (a rare bloom false-positive) would
-        // show delta 2 and is deliberately skipped, since re-probing it with
-        // verification OFF would then ALSO show a nonzero delta from that unrelated
-        // natural-fallback path, not from the switch.
-        presence_verification::set_enabled_for_testing(true);
-        let mut in_range_absent_key: Option<[u8; 4]> = None;
-        for candidate in 1_000_000i32..1_000_064 {
-            let key_bytes = candidate.to_be_bytes();
-            let before = SSTableReader::scan_for_key_call_count();
-            let res = rt
-                .block_on(reader.get_with_resolution(
-                    &table_id,
-                    &RowKey::from(key_bytes.to_vec()),
-                    false,
-                ))
-                .expect("get on candidate probe");
-            let after = SSTableReader::scan_for_key_call_count();
-            assert!(
-                res.is_none(),
-                "candidate {candidate} must be genuinely absent"
-            );
-            if after == before + 1 {
-                in_range_absent_key = Some(key_bytes);
-                break;
-            }
-        }
-        let absent_key = in_range_absent_key.expect(
-            "at least one of 64 candidates must land within the Summary bound (expected token \
-             coverage from 50 samples is ~96%) — proves the ON case reaches get_with_resolution's \
-             verify hook rather than being short-circuited by C5",
-        );
-
-        // (a) OFF: re-probing the SAME now-confirmed-in-range absent key must NOT
-        // run a confirmation scan.
-        presence_verification::set_enabled_for_testing(false);
-        let before = SSTableReader::scan_for_key_call_count();
-        let res = rt
-            .block_on(reader.get_with_resolution(
-                &table_id,
-                &RowKey::from(absent_key.to_vec()),
-                false,
-            ))
-            .expect("get with verification off");
-        let after = SSTableReader::scan_for_key_call_count();
-        assert!(res.is_none(), "the probe key must remain reported absent");
-        assert_eq!(
-            after, before,
-            "verification OFF must not run a confirmation scan through get_with_resolution"
-        );
-
-        // (b) ON: the SAME key, through the SAME public entry point, must run the
-        // confirmation scan (delta >= 1) — end-to-end wiring evidence — while the
-        // returned value is unchanged (a side-channel check only) and the
-        // false-negative counter stays 0 (a true negative).
-        presence_verification::set_enabled_for_testing(true);
-        mc.reset();
-        let before = SSTableReader::scan_for_key_call_count();
-        let res = rt
-            .block_on(reader.get_with_resolution(
-                &table_id,
-                &RowKey::from(absent_key.to_vec()),
-                false,
-            ))
-            .expect("get with verification on");
-        let after = SSTableReader::scan_for_key_call_count();
-        assert!(
-            res.is_none(),
-            "verification must not change the returned value for a true negative"
-        );
-        assert!(
-            after > before,
-            "verification ON must run a confirmation scan through get_with_resolution for the \
-             SAME key that showed no scan when OFF"
-        );
-        let m = mc.flush_and_collect();
-        assert_eq!(
-            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
-            0.0,
-            "a true negative reached via get_with_resolution must not emit false_negatives"
+            "the contradicted negative must carry cqlite.sstable.format=big"
         );
 
         presence_verification::set_enabled_for_testing(false);
         drop(rt);
-    }
-
-    // --- Roborev r4 blocker #2 (#2163): `ObservabilityConfig::verify_presence_oracle`
-    // must not be decorative. Config-only enablement (NO env var set) must flip
-    // the runtime switch through the PUBLIC `observability::init` entry point, and
-    // that flip must drive an ACTUAL confirmation scan through the public
-    // `get_with_resolution` read path — not merely make `enabled()` report `true`
-    // in isolation. Also pins the documented env-overrides-config precedence. ---
-    {
-        use cqlite_core::observability::ObservabilityConfig;
-        use cqlite_core::storage::sstable::reader::SSTableReader;
-        use cqlite_core::types::RowKey;
-
-        // Isolate from any real process env for this assertion.
-        let saved_env = std::env::var(presence_verification::ENV_VAR).ok();
-        std::env::remove_var(presence_verification::ENV_VAR);
-
-        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(30);
-        let rt = tokio::runtime::Runtime::new().expect("rt");
-
-        // Locate an in-range absent key (else C5 would short-circuit before the
-        // verify hook regardless of the switch) using the TEST setter purely to
-        // search — the switch is driven exclusively through `observability::init`
-        // for every assertion below.
-        presence_verification::set_enabled_for_testing(true);
-        let mut in_range_absent_key: Option<[u8; 4]> = None;
-        for candidate in 3_000_000i32..3_000_064 {
-            let key_bytes = candidate.to_be_bytes();
-            let before = SSTableReader::scan_for_key_call_count();
-            let res = rt
-                .block_on(reader.get_with_resolution(
-                    &table_id,
-                    &RowKey::from(key_bytes.to_vec()),
-                    false,
-                ))
-                .expect("get on candidate probe");
-            let after = SSTableReader::scan_for_key_call_count();
-            assert!(
-                res.is_none(),
-                "candidate {candidate} must be genuinely absent"
-            );
-            if after == before + 1 {
-                in_range_absent_key = Some(key_bytes);
-                break;
-            }
-        }
-        let absent_key = in_range_absent_key
-            .expect("at least one of 64 candidates must land within the Summary bound");
-
-        // Config-only DISABLE (no env): the switch must be OFF and the same key
-        // must show no confirmation scan through the public read path.
-        let cfg_off = ObservabilityConfig::builder()
-            .enabled(false)
-            .verify_presence_oracle(false)
-            .build();
-        let _guard = cqlite_core::observability::init(cfg_off).expect("init config-off");
-        assert!(
-            !presence_verification::enabled(),
-            "config-only disable must flip the switch off through observability::init"
-        );
-        let before = SSTableReader::scan_for_key_call_count();
-        let res = rt
-            .block_on(reader.get_with_resolution(
-                &table_id,
-                &RowKey::from(absent_key.to_vec()),
-                false,
-            ))
-            .expect("get config-off");
-        let after = SSTableReader::scan_for_key_call_count();
-        assert!(res.is_none());
-        assert_eq!(
-            after, before,
-            "config-only disable must not run a confirmation scan through get_with_resolution"
-        );
-
-        // Config-only ENABLE (no env): the switch must flip ON AND drive an ACTUAL
-        // confirmation scan through the public get_with_resolution() path for the
-        // SAME key — the end-to-end proof the field is wired, not decorative.
-        let cfg_on = ObservabilityConfig::builder()
-            .enabled(false)
-            .verify_presence_oracle(true)
-            .build();
-        let _guard = cqlite_core::observability::init(cfg_on).expect("init config-on");
-        assert!(
-            presence_verification::enabled(),
-            "config-only enable must flip the switch on through observability::init"
-        );
-        let before = SSTableReader::scan_for_key_call_count();
-        let res = rt
-            .block_on(reader.get_with_resolution(
-                &table_id,
-                &RowKey::from(absent_key.to_vec()),
-                false,
-            ))
-            .expect("get config-on");
-        let after = SSTableReader::scan_for_key_call_count();
-        assert!(res.is_none());
-        assert!(
-            after > before,
-            "config-only enable must drive a confirmation scan through get_with_resolution — \
-             proving ObservabilityConfig::verify_presence_oracle is wired end-to-end, not \
-             decorative"
-        );
-
-        // An explicitly-set env var must override a conflicting config value
-        // (documented env-overrides-config precedence).
-        std::env::set_var(presence_verification::ENV_VAR, "false");
-        let cfg_conflict = ObservabilityConfig::builder()
-            .enabled(false)
-            .verify_presence_oracle(true) // config says ON; env says off
-            .build();
-        let _guard = cqlite_core::observability::init(cfg_conflict).expect("init env-override");
-        assert!(
-            !presence_verification::enabled(),
-            "an explicitly-set env var must override a conflicting config value"
-        );
-
-        // Restore env + leave the switch OFF for any later blocks.
-        match saved_env {
-            Some(v) => std::env::set_var(presence_verification::ENV_VAR, v),
-            None => std::env::remove_var(presence_verification::ENV_VAR),
-        }
-        presence_verification::set_enabled_for_testing(false);
-        drop(rt);
-    }
-
-    // --- Roborev r4 item 3 (LOW, folded in, #2163): no REDUNDANT double scan.
-    // When the PRIMARY path itself already ran the authoritative `scan_for_key`
-    // (a bloom false positive falling through to an Index.db miss), the key was
-    // NOT excluded by the presence oracle (`oracle_pruned = false`), so turning
-    // verification ON must NOT trigger a second confirmation scan — the delta
-    // must stay exactly 1 (the primary scan only) whether verification is OFF or
-    // ON, distinguishing "oracle negative" (needs verifying) from "already an
-    // authoritative scan result" (nothing left to verify). ---
-    {
-        use cqlite_core::storage::sstable::reader::SSTableReader;
-        use cqlite_core::types::RowKey;
-
-        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(30);
-        let rt = tokio::runtime::Runtime::new().expect("rt");
-
-        // Search for a bloom FALSE POSITIVE: `might_contain_partition == true` for
-        // a key genuinely absent (well outside the inserted 0..30 range). Default
-        // `fp_chance` is 0.01, so finding >=1 among 10,000 candidates is
-        // overwhelmingly likely (searched, not assumed).
-        let mut fp_key: Option<[u8; 4]> = None;
-        for candidate in 4_000_000i32..4_010_000i32 {
-            let key_bytes = candidate.to_be_bytes();
-            if reader.might_contain_partition(&key_bytes) {
-                fp_key = Some(key_bytes);
-                break;
-            }
-        }
-
-        if let Some(fp_key) = fp_key {
-            // Verification OFF: the primary path's OWN Index.db-miss fallback
-            // scans once (the natural #1572 behaviour, unrelated to the switch).
-            presence_verification::set_enabled_for_testing(false);
-            let before = SSTableReader::scan_for_key_call_count();
-            let res = rt
-                .block_on(reader.get_with_resolution(
-                    &table_id,
-                    &RowKey::from(fp_key.to_vec()),
-                    false,
-                ))
-                .expect("get on bloom-false-positive key, verification off");
-            let after = SSTableReader::scan_for_key_call_count();
-            assert!(res.is_none(), "the bloom-FP key must still resolve absent");
-            assert_eq!(
-                after,
-                before + 1,
-                "the primary path's own scan_for_key fallback must run exactly once"
-            );
-
-            // Verification ON, the SAME key: `oracle_pruned` is false (the bloom
-            // hit admitted this SSTable; the index miss forced the primary path's
-            // OWN scan), so the opt-in verify hook must NOT run a second scan.
-            presence_verification::set_enabled_for_testing(true);
-            mc.reset();
-            let before = SSTableReader::scan_for_key_call_count();
-            let res = rt
-                .block_on(reader.get_with_resolution(
-                    &table_id,
-                    &RowKey::from(fp_key.to_vec()),
-                    false,
-                ))
-                .expect("get on bloom-false-positive key, verification on");
-            let after = SSTableReader::scan_for_key_call_count();
-            assert!(res.is_none(), "the bloom-FP key must still resolve absent");
-            assert_eq!(
-                after,
-                before + 1,
-                "verification ON must NOT add a second scan when the primary path already ran \
-                 the authoritative scan_for_key (oracle_pruned=false) — exactly one scan total"
-            );
-            let m = mc.flush_and_collect();
-            assert_eq!(
-                m.counter_sum(catalog::READ_SSTABLES_PRUNED),
-                0.0,
-                "a bloom hit (even a false positive) is not a presence-oracle exclusion — must \
-                 not emit sstables_pruned"
-            );
-            assert_eq!(
-                m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
-                0.0,
-                "the skipped (non-oracle) case must never emit false_negatives"
-            );
-            presence_verification::set_enabled_for_testing(false);
-        } else {
-            eprintln!(
-                "correctness_signals_2163: no bloom false positive found among 10,000 candidates \
-                 (fp_chance=0.01 makes this astronomically unlikely) — skipping the no-double-scan \
-                 sub-assertion for this run; the structural invariant (verify only runs when \
-                 oracle_pruned) is still enforced by the code path itself"
-            );
-        }
-        drop(rt);
-    }
-
-    // --- Roborev r5 (#2163): the opt-in verify scan's `Err` must not be
-    // silently discarded. The READ stays fail-open (a verifier failure must
-    // never fail the actual read), but the failure must be surfaced LOUDLY:
-    // recorded through the EXISTING error-signal path
-    // (`cqlite.errors.total{subsystem=reader}`), never a new metric. ---
-    {
-        use cqlite_core::types::RowKey;
-
-        let (reader, table_id, data_path, _tmp) =
-            fixtures::open_writer_reader_with_many_rows_and_path(30);
-
-        // Find an in-range absent key. `might_contain_partition` only consults
-        // the ALREADY-LOADED (resident) Filter.db, so this search — and the
-        // primary oracle-negative it proves — is unaffected by the Data.db
-        // corruption applied below.
-        let mut absent_key: Option<[u8; 4]> = None;
-        for candidate in 5_000_000i32..5_000_064i32 {
-            let key_bytes = candidate.to_be_bytes();
-            if !reader.might_contain_partition(&key_bytes) {
-                absent_key = Some(key_bytes);
-                break;
-            }
-        }
-        let absent_key = absent_key
-            .expect("at least one candidate must show absent via the resident bloom filter");
-
-        // Corrupt Data.db AFTER open (truncate mid-file): the resident
-        // Filter.db is untouched (lives in memory), so the primary bloom-miss
-        // path still succeeds; but the opt-in verify's authoritative
-        // `scan_for_key` — which must read Data.db fresh — now fails.
-        let original_len = std::fs::metadata(&data_path).expect("stat Data.db").len();
-        assert!(
-            original_len > 8,
-            "the fixture's Data.db must be large enough to truncate meaningfully"
-        );
-        let truncated_len = (original_len / 2).max(1);
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&data_path)
-            .expect("open Data.db for truncation");
-        file.set_len(truncated_len)
-            .expect("truncate Data.db to simulate corruption/an unreadable SSTable");
-        drop(file);
-
-        presence_verification::set_enabled_for_testing(true);
-        mc.reset();
-        let rt = tokio::runtime::Runtime::new().expect("rt");
-        let res = rt
-            .block_on(reader.get_with_resolution(
-                &table_id,
-                &RowKey::from(absent_key.to_vec()),
-                false,
-            ))
-            .expect("get_with_resolution must stay fail-open despite a verify-scan failure");
-        drop(rt);
-        presence_verification::set_enabled_for_testing(false);
-
-        assert!(
-            res.is_none(),
-            "the read must return the ORIGINAL oracle-negative result unaffected by the \
-             verify-scan failure (fail-open) — a debug/soundness check failing must never break \
-             a production read"
-        );
-
-        let m = mc.flush_and_collect();
-        let recorded = m.sum_where(
-            catalog::ERRORS_TOTAL,
-            &[(catalog::attr::SUBSYSTEM, "reader")],
-        );
-        assert!(
-            recorded >= 1.0,
-            "the verify-scan failure must be recorded through the existing error-signal path \
-             (cqlite.errors.total{{subsystem=reader}}) — a silent-miss DETECTOR must not itself \
-             fail silently; entry: {:?}",
-            m.find(catalog::ERRORS_TOTAL)
-        );
-    }
-
-    // --- Requirement: Degraded read-path counter with bounded reason ---
-    // The executor records honest fallbacks through `access_path::record`, the
-    // public probe every fallback site funnels through. A fallback increments the
-    // counter with its bounded reason label; a targeted path never does.
-    {
-        use cqlite_core::query::access_path::{self, AccessPath, FallbackReason};
-        mc.reset();
-        access_path::record(AccessPath::FallbackFullScan {
-            reason: FallbackReason::NoSchema,
-        });
-        // A targeted path must NOT increment the degraded counter.
-        access_path::record(AccessPath::PartitionLookup);
-        let m = mc.flush_and_collect();
-        assert_eq!(
-            m.counter_sum(catalog::QUERY_DEGRADED_PATH),
-            1.0,
-            "exactly one degraded increment for the single fallback (targeted path adds none)"
-        );
-        assert_eq!(
-            m.sum_where(
-                catalog::QUERY_DEGRADED_PATH,
-                &[(catalog::attr::FALLBACK_REASON, "no_schema")],
-            ),
-            1.0,
-            "the degraded increment must carry the bounded fallback_reason label"
-        );
     }
 }
 
@@ -1050,7 +694,8 @@ mod merge {
 }
 
 // ---------------------------------------------------------------------------
-// Reader fixtures (real BIG fixture + a writer-produced schema-attached reader).
+// Reader fixtures (real BIG/BTI corpus fixtures + multi-generation
+// writer-produced SSTables for the candidate-prune scenarios).
 // ---------------------------------------------------------------------------
 
 mod fixtures {
@@ -1059,7 +704,7 @@ mod fixtures {
     use cqlite_core::schema::{Column, KeyColumn, TableSchema};
     use cqlite_core::storage::sstable::reader::SSTableReader;
     use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
-    use cqlite_core::types::{RowKey, TableId};
+    use cqlite_core::types::TableId;
     use cqlite_core::Config;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -1125,7 +770,7 @@ mod fixtures {
         reader
     }
 
-    fn writer_schema() -> TableSchema {
+    pub fn writer_schema() -> TableSchema {
         TableSchema {
             keyspace: "obsfn".to_string(),
             table: "rows".to_string(),
@@ -1154,178 +799,6 @@ mod fixtures {
             comments: HashMap::new(),
             dropped_columns: HashMap::new(),
         }
-    }
-
-    /// Write one row, flush, and open a schema-attached reader over the produced
-    /// Data.db. Returns the reader, a matching TableId, and the present key bytes.
-    /// The reader can authoritatively scan for the key (schema attached), which the
-    /// false-negative verification needs.
-    pub fn open_writer_reader_with_present_key(
-    ) -> (SSTableReader, TableId, [u8; 4], tempfile::TempDir) {
-        let tmp = tempfile::TempDir::new().expect("tmp");
-        let schema = writer_schema();
-        let cfg = WriteEngineConfig::new(
-            tmp.path().join("data"),
-            tmp.path().join("wal"),
-            schema.clone(),
-        );
-        let mut engine = WriteEngine::new(cfg).expect("engine");
-        engine
-            .execute("INSERT INTO obsfn.rows (id, name) VALUES (7, 'seven')")
-            .expect("write");
-
-        let rt = tokio::runtime::Runtime::new().expect("rt");
-        let info = rt
-            .block_on(engine.flush())
-            .expect("flush")
-            .expect("sstable");
-        let data_file = info.data_path.clone();
-
-        let config = Config::default();
-        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
-        let mut reader = rt
-            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
-            .expect("open reader");
-
-        // Attach the schema so the authoritative scan can decode the row.
-        let registry = rt
-            .block_on(SchemaRegistry::new(
-                SchemaRegistryConfig::default(),
-                platform.clone(),
-                config.clone(),
-            ))
-            .expect("build registry");
-        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
-            .expect("register schema");
-        let registry = Arc::new(tokio::sync::RwLock::new(registry));
-        rt.block_on(reader.attach_schema_registry(registry));
-
-        // Confirm the reader really can find the present key (so the verify scan
-        // is meaningful), then hand back the pieces the test needs.
-        let table_id = TableId::from("rows");
-        let present_key = 7i32.to_be_bytes();
-        let found = rt
-            .block_on(reader.get(&table_id, &RowKey::from(present_key.to_vec())))
-            .expect("get present key");
-        assert!(
-            found.is_some(),
-            "writer fixture reader must be able to read back the present key for the \
-             false-negative scan to be meaningful"
-        );
-        drop(rt);
-        (reader, table_id, present_key, tmp)
-    }
-
-    /// Write `n` rows (ids `0..n`), flush, and open a schema-attached reader over
-    /// the produced Data.db. Used by the `get()`-level false-negative wiring test
-    /// (roborev fold-in #3, #2163), which needs an absent probe key whose token
-    /// falls WITHIN the reader's authoritative `[first_key, last_key]` Summary
-    /// bound (else the C5 range short-circuit in `get_with_resolution` returns
-    /// absence before ever reaching the presence-oracle / verify hook). `n` rows
-    /// spread the observed token span wide enough that a handful of far-outside-
-    /// range candidate ids (searched by the caller) are overwhelmingly likely to
-    /// land in-range by token, even though token order is unrelated to int order.
-    pub fn open_writer_reader_with_many_rows(
-        n: i32,
-    ) -> (SSTableReader, TableId, tempfile::TempDir) {
-        let tmp = tempfile::TempDir::new().expect("tmp");
-        let schema = writer_schema();
-        let cfg = WriteEngineConfig::new(
-            tmp.path().join("data"),
-            tmp.path().join("wal"),
-            schema.clone(),
-        );
-        let mut engine = WriteEngine::new(cfg).expect("engine");
-        for id in 0..n {
-            engine
-                .execute(&format!(
-                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'row{id}')"
-                ))
-                .expect("write");
-        }
-
-        let rt = tokio::runtime::Runtime::new().expect("rt");
-        let info = rt
-            .block_on(engine.flush())
-            .expect("flush")
-            .expect("sstable");
-        let data_file = info.data_path.clone();
-
-        let config = Config::default();
-        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
-        let mut reader = rt
-            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
-            .expect("open reader");
-
-        let registry = rt
-            .block_on(SchemaRegistry::new(
-                SchemaRegistryConfig::default(),
-                platform.clone(),
-                config.clone(),
-            ))
-            .expect("build registry");
-        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
-            .expect("register schema");
-        let registry = Arc::new(tokio::sync::RwLock::new(registry));
-        rt.block_on(reader.attach_schema_registry(registry));
-        drop(rt);
-
-        (reader, TableId::from("rows"), tmp)
-    }
-
-    /// Like [`open_writer_reader_with_many_rows`], but also returns the on-disk
-    /// `Data.db` path so a test can corrupt it AFTER the reader has already
-    /// loaded Filter.db/Index.db/Summary.db into memory (roborev r5, #2163's
-    /// verify-scan-error test) — the presence-oracle bloom check never re-reads
-    /// Data.db, so corrupting the file post-open leaves the primary oracle
-    /// negative intact while making a SUBSEQUENT `scan_for_key` (the opt-in
-    /// verify path) fail.
-    pub fn open_writer_reader_with_many_rows_and_path(
-        n: i32,
-    ) -> (SSTableReader, TableId, PathBuf, tempfile::TempDir) {
-        let tmp = tempfile::TempDir::new().expect("tmp");
-        let schema = writer_schema();
-        let cfg = WriteEngineConfig::new(
-            tmp.path().join("data"),
-            tmp.path().join("wal"),
-            schema.clone(),
-        );
-        let mut engine = WriteEngine::new(cfg).expect("engine");
-        for id in 0..n {
-            engine
-                .execute(&format!(
-                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'row{id}')"
-                ))
-                .expect("write");
-        }
-
-        let rt = tokio::runtime::Runtime::new().expect("rt");
-        let info = rt
-            .block_on(engine.flush())
-            .expect("flush")
-            .expect("sstable");
-        let data_file = info.data_path.clone();
-
-        let config = Config::default();
-        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
-        let mut reader = rt
-            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
-            .expect("open reader");
-
-        let registry = rt
-            .block_on(SchemaRegistry::new(
-                SchemaRegistryConfig::default(),
-                platform.clone(),
-                config.clone(),
-            ))
-            .expect("build registry");
-        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
-            .expect("register schema");
-        let registry = Arc::new(tokio::sync::RwLock::new(registry));
-        rt.block_on(reader.attach_schema_registry(registry));
-        drop(rt);
-
-        (reader, TableId::from("rows"), data_file, tmp)
     }
 
     /// Two DISJOINT-key SSTable generations of the SAME table (no compaction),
@@ -1399,5 +872,53 @@ mod fixtures {
 
         drop(rt);
         (reader1, reader2, TableId::from("rows"), tmp)
+    }
+
+    /// Two DISJOINT-key SSTable generations under ONE table directory, written
+    /// but with NO readers opened yet — so the caller can corrupt one
+    /// generation's Filter.db BEFORE constructing an `SSTableManager` over the
+    /// shared `data` directory (roborev r6, #2163's multi-generation
+    /// candidate-prune false-negative test). Gen 1 holds ids `0..10`; gen 2
+    /// holds ids `2000..2010` (disjoint). Returns the `data` root (pass to
+    /// `SSTableManager::new`), gen 2's `Filter.db` path, the fully-qualified
+    /// `TableId`, and the `TempDir` (kept alive).
+    pub fn write_two_generations_for_manager() -> (PathBuf, PathBuf, TableId, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = writer_schema();
+        let data_dir = tmp.path().join("data");
+        let cfg = WriteEngineConfig::new(data_dir.clone(), tmp.path().join("wal"), schema);
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        for id in 0..10i32 {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'g1-{id}')"
+                ))
+                .expect("write gen1");
+        }
+        rt.block_on(engine.flush())
+            .expect("flush gen1")
+            .expect("sstable gen1");
+
+        for id in 2000..2010i32 {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'g2-{id}')"
+                ))
+                .expect("write gen2");
+        }
+        let info2 = rt
+            .block_on(engine.flush())
+            .expect("flush gen2")
+            .expect("sstable gen2");
+        drop(rt);
+
+        let filter_path = info2
+            .filter_path
+            .clone()
+            .expect("gen2 must have a Filter.db (default bloom_filter_fp_chance)");
+
+        (data_dir, filter_path, TableId::from("obsfn.rows"), tmp)
     }
 }

--- a/cqlite-core/tests/correctness_signals_2163.rs
+++ b/cqlite-core/tests/correctness_signals_2163.rs
@@ -139,6 +139,18 @@ fn correctness_signals_end_to_end() {
     // A newer whole-row tombstone shadows an older live cell in the same
     // clustering slot: the live cell is SUPPRESSED and the retained tombstone
     // marker is EMITTED, both independently of tombstones_purged.
+    //
+    // This is ALSO the roborev r5 (#2163) regression pin: `run_row_tombstone_merge`
+    // uses a CLUSTERED schema (`obs2163.events`, clustering key `seq`), so the
+    // compaction read-back carries a `seq` clustering-key PSEUDO-CELL alongside
+    // the real `val` data cell (mirrors `extract_clustering_key`'s read-back
+    // contract, pinned by the existing unit test
+    // `issue_921_clustered_row_with_only_purgeable_cell_tombstone_emits_nothing`).
+    // The row tombstone shadows BOTH cells (both were written before the
+    // delete), but `seq` is not real data — only `val` may count. Asserting the
+    // EXACT count (not merely `>= 1.0`) catches the inflation: without the fix
+    // this scenario reports 2 suppressed (val + seq); confirmed empirically
+    // while developing this fix by disabling the exclusion.
     {
         let mut flows = merge::run_row_tombstone_merge();
         mc.reset();
@@ -146,9 +158,12 @@ fn correctness_signals_end_to_end() {
         let m = mc.flush_and_collect();
         let suppressed = m.counter_sum(catalog::COMPACTION_TOMBSTONES_SUPPRESSED);
         let emitted = m.counter_sum(catalog::COMPACTION_TOMBSTONES_EMITTED);
-        assert!(
-            suppressed >= 1.0,
-            "a row tombstone shadowing an older live cell must count >=1 suppressed; entry: {:?}",
+        assert_eq!(
+            suppressed,
+            1.0,
+            "cqlite.compaction.tombstones_suppressed must count DATA cells only — exactly 1 \
+             (the shadowed `val` cell), excluding the `seq` clustering-key pseudo-cell that the \
+             read-back path retains for round-tripping but is not real data; entry: {:?}",
             m.find(catalog::COMPACTION_TOMBSTONES_SUPPRESSED)
         );
         assert!(
@@ -745,6 +760,84 @@ fn correctness_signals_end_to_end() {
         drop(rt);
     }
 
+    // --- Roborev r5 (#2163): the opt-in verify scan's `Err` must not be
+    // silently discarded. The READ stays fail-open (a verifier failure must
+    // never fail the actual read), but the failure must be surfaced LOUDLY:
+    // recorded through the EXISTING error-signal path
+    // (`cqlite.errors.total{subsystem=reader}`), never a new metric. ---
+    {
+        use cqlite_core::types::RowKey;
+
+        let (reader, table_id, data_path, _tmp) =
+            fixtures::open_writer_reader_with_many_rows_and_path(30);
+
+        // Find an in-range absent key. `might_contain_partition` only consults
+        // the ALREADY-LOADED (resident) Filter.db, so this search — and the
+        // primary oracle-negative it proves — is unaffected by the Data.db
+        // corruption applied below.
+        let mut absent_key: Option<[u8; 4]> = None;
+        for candidate in 5_000_000i32..5_000_064i32 {
+            let key_bytes = candidate.to_be_bytes();
+            if !reader.might_contain_partition(&key_bytes) {
+                absent_key = Some(key_bytes);
+                break;
+            }
+        }
+        let absent_key = absent_key
+            .expect("at least one candidate must show absent via the resident bloom filter");
+
+        // Corrupt Data.db AFTER open (truncate mid-file): the resident
+        // Filter.db is untouched (lives in memory), so the primary bloom-miss
+        // path still succeeds; but the opt-in verify's authoritative
+        // `scan_for_key` — which must read Data.db fresh — now fails.
+        let original_len = std::fs::metadata(&data_path).expect("stat Data.db").len();
+        assert!(
+            original_len > 8,
+            "the fixture's Data.db must be large enough to truncate meaningfully"
+        );
+        let truncated_len = (original_len / 2).max(1);
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&data_path)
+            .expect("open Data.db for truncation");
+        file.set_len(truncated_len)
+            .expect("truncate Data.db to simulate corruption/an unreadable SSTable");
+        drop(file);
+
+        presence_verification::set_enabled_for_testing(true);
+        mc.reset();
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get_with_resolution must stay fail-open despite a verify-scan failure");
+        drop(rt);
+        presence_verification::set_enabled_for_testing(false);
+
+        assert!(
+            res.is_none(),
+            "the read must return the ORIGINAL oracle-negative result unaffected by the \
+             verify-scan failure (fail-open) — a debug/soundness check failing must never break \
+             a production read"
+        );
+
+        let m = mc.flush_and_collect();
+        let recorded = m.sum_where(
+            catalog::ERRORS_TOTAL,
+            &[(catalog::attr::SUBSYSTEM, "reader")],
+        );
+        assert!(
+            recorded >= 1.0,
+            "the verify-scan failure must be recorded through the existing error-signal path \
+             (cqlite.errors.total{{subsystem=reader}}) — a silent-miss DETECTOR must not itself \
+             fail silently; entry: {:?}",
+            m.find(catalog::ERRORS_TOTAL)
+        );
+    }
+
     // --- Requirement: Degraded read-path counter with bounded reason ---
     // The executor records honest fallbacks through `access_path::record`, the
     // public probe every fallback site funnels through. A fallback increments the
@@ -1178,6 +1271,61 @@ mod fixtures {
         drop(rt);
 
         (reader, TableId::from("rows"), tmp)
+    }
+
+    /// Like [`open_writer_reader_with_many_rows`], but also returns the on-disk
+    /// `Data.db` path so a test can corrupt it AFTER the reader has already
+    /// loaded Filter.db/Index.db/Summary.db into memory (roborev r5, #2163's
+    /// verify-scan-error test) — the presence-oracle bloom check never re-reads
+    /// Data.db, so corrupting the file post-open leaves the primary oracle
+    /// negative intact while making a SUBSEQUENT `scan_for_key` (the opt-in
+    /// verify path) fail.
+    pub fn open_writer_reader_with_many_rows_and_path(
+        n: i32,
+    ) -> (SSTableReader, TableId, PathBuf, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = writer_schema();
+        let cfg = WriteEngineConfig::new(
+            tmp.path().join("data"),
+            tmp.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        for id in 0..n {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'row{id}')"
+                ))
+                .expect("write");
+        }
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let info = rt
+            .block_on(engine.flush())
+            .expect("flush")
+            .expect("sstable");
+        let data_file = info.data_path.clone();
+
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        let mut reader = rt
+            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
+            .expect("open reader");
+
+        let registry = rt
+            .block_on(SchemaRegistry::new(
+                SchemaRegistryConfig::default(),
+                platform.clone(),
+                config.clone(),
+            ))
+            .expect("build registry");
+        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
+            .expect("register schema");
+        let registry = Arc::new(tokio::sync::RwLock::new(registry));
+        rt.block_on(reader.attach_schema_registry(registry));
+        drop(rt);
+
+        (reader, TableId::from("rows"), data_file, tmp)
     }
 
     /// Two DISJOINT-key SSTable generations of the SAME table (no compaction),

--- a/cqlite-core/tests/correctness_signals_2163_verify.rs
+++ b/cqlite-core/tests/correctness_signals_2163_verify.rs
@@ -1,0 +1,767 @@
+//! Correctness / silent-miss observability signals (issue #2163) — presence-
+//! oracle verification switch coverage.
+//!
+//! Split out of `correctness_signals_2163.rs` (campsite rule, epic #1135): that
+//! file's own additions pushed it past the ~1500-line test-file threshold, and
+//! everything here is thematically self-contained (the opt-in false-negative
+//! verification switch, its wiring through the public `get_with_resolution` read
+//! path, its `ObservabilityConfig` plumbing, and the degraded read-path counter)
+//! and does not depend on the merge/tombstone fixtures the sibling file keeps.
+//!
+//! # Why one serial metric test
+//!
+//! The production metric helpers record through a single process-global `Meter`
+//! bound on first use, so the in-memory meter provider is process-wide and uses
+//! DELTA temporality — the same discipline `observability_correctness.rs` and
+//! `correctness_signals_2163.rs` document. Splitting into a SEPARATE test binary
+//! (this file) is safe: each `tests/*.rs` file compiles to its own process with
+//! its own independent meter/switch/env state, so there is no cross-file race —
+//! only intra-file races would matter, and this file (like its sibling) keeps
+//! every scenario in ONE `#[serial]` test function.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-core \
+//!   --features observability-testing,cli-helpers,write-support \
+//!   --test correctness_signals_2163_verify
+//! ```
+
+#![cfg(all(feature = "observability-testing", feature = "write-support"))]
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::storage::sstable::reader::presence_verification;
+use serial_test::serial;
+
+// Roborev r6 (LOW, #2163): this test mutates PROCESS-GLOBAL state (the
+// `presence_verification` switch, `CQLITE_VERIFY_PRESENCE_ORACLE` /
+// `std::env::set_var`/`remove_var`, and the shared observability metrics
+// singleton) without any synchronization against another `#[test]` in this
+// same binary. There is currently only ONE test function here, so this is
+// defensive/future-proofing rather than a live bug — but `#[serial]` costs
+// nothing and matches the established repo idiom (e.g.
+// `issue_1575_candidate_key_hash_hoist.rs`) for any test that touches process
+// env or global switches, protecting against a future second test added to
+// this file (or a test-harness change) racing on the same global state.
+#[test]
+#[serial]
+fn correctness_signals_verify_switch() {
+    let mc = testing::metrics_capture();
+
+    // --- Requirement: Opt-in presence-oracle false-negative verification ---
+    {
+        let (reader, table_id, present_key, _tmp) = fixtures::open_writer_reader_with_present_key();
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let absent_key = 0x7FFF_FFFFi32.to_be_bytes();
+
+        // (a) Verification OFF (default): a point read for an absent key performs no
+        // confirmation scan and never emits the false-negative counter.
+        presence_verification::set_enabled_for_testing(false);
+        mc.reset();
+        let got = rt
+            .block_on(reader.verify_presence_oracle_negative(&table_id, &absent_key))
+            .expect("verify off");
+        assert!(!got, "verification OFF must not run a confirmation scan");
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            0.0,
+            "verification OFF must never emit false_negatives"
+        );
+
+        // (b) Verification ON, a genuinely absent key: the authoritative scan runs,
+        // finds the key absent, and the counter stays 0.
+        presence_verification::set_enabled_for_testing(true);
+        mc.reset();
+        let got = rt
+            .block_on(reader.verify_presence_oracle_negative(&table_id, &absent_key))
+            .expect("verify on true-negative");
+        assert!(!got, "a genuinely absent key must not be a false negative");
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            0.0,
+            "a confirmed true negative must keep false_negatives at 0"
+        );
+
+        // (c) Verification ON, a PRESENT key fed to the verify path (a synthetic
+        // false negative — the oracle "said absent" for a key that IS present): the
+        // authoritative scan contradicts it and the counter increments by 1 with
+        // the SSTable's format.
+        mc.reset();
+        let got = rt
+            .block_on(reader.verify_presence_oracle_negative(&table_id, &present_key))
+            .expect("verify on contradiction");
+        assert!(
+            got,
+            "a present key must be reported as a contradicted negative"
+        );
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            1.0,
+            "a contradicted negative must increment false_negatives by exactly 1"
+        );
+        assert_eq!(
+            m.sum_where(
+                catalog::READ_BLOOM_FALSE_NEGATIVES,
+                &[(catalog::attr::SSTABLE_FORMAT, "big")],
+            ),
+            1.0,
+            "the false negative must carry the offending SSTable's format"
+        );
+        presence_verification::set_enabled_for_testing(false);
+        drop(rt);
+    }
+
+    // --- Roborev fold-in #3 (#2163): `get()`-level false-negative wiring ---
+    // Proves the verification switch is wired through the PUBLIC
+    // `get_with_resolution` read-path entry point end-to-end — not just callable
+    // on the `verify_presence_oracle_negative` method directly. Uses the
+    // process-global `scan_for_key_call_count()` (issue #831 pattern) as the
+    // observable proxy for "the authoritative confirmation scan ran": OFF must
+    // leave the count unchanged for an absent key; ON must increment it for the
+    // SAME key.
+    {
+        use cqlite_core::storage::sstable::reader::SSTableReader;
+        use cqlite_core::types::RowKey;
+
+        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(50);
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        // Search for an absent probe key whose token falls WITHIN this reader's
+        // authoritative Summary bound (else the C5 range short-circuit in
+        // `get_with_resolution` returns absence before ever reaching the
+        // presence-oracle / verify hook — a token-order fact independent of int
+        // order, so we search rather than assume). Verification is ON during the
+        // search. Accept ONLY a candidate whose scan-count delta is EXACTLY 1: that
+        // is the clean signature of "my verify hook ran its one confirmation scan
+        // and nothing else did" — a candidate that also trips the natural BIG
+        // resolution's OWN scan_for_key fallback (a rare bloom false-positive) would
+        // show delta 2 and is deliberately skipped, since re-probing it with
+        // verification OFF would then ALSO show a nonzero delta from that unrelated
+        // natural-fallback path, not from the switch.
+        presence_verification::set_enabled_for_testing(true);
+        let mut in_range_absent_key: Option<[u8; 4]> = None;
+        for candidate in 1_000_000i32..1_000_064 {
+            let key_bytes = candidate.to_be_bytes();
+            let before = SSTableReader::scan_for_key_call_count();
+            let res = rt
+                .block_on(reader.get_with_resolution(
+                    &table_id,
+                    &RowKey::from(key_bytes.to_vec()),
+                    false,
+                ))
+                .expect("get on candidate probe");
+            let after = SSTableReader::scan_for_key_call_count();
+            assert!(
+                res.is_none(),
+                "candidate {candidate} must be genuinely absent"
+            );
+            if after == before + 1 {
+                in_range_absent_key = Some(key_bytes);
+                break;
+            }
+        }
+        let absent_key = in_range_absent_key.expect(
+            "at least one of 64 candidates must land within the Summary bound (expected token \
+             coverage from 50 samples is ~96%) — proves the ON case reaches get_with_resolution's \
+             verify hook rather than being short-circuited by C5",
+        );
+
+        // (a) OFF: re-probing the SAME now-confirmed-in-range absent key must NOT
+        // run a confirmation scan.
+        presence_verification::set_enabled_for_testing(false);
+        let before = SSTableReader::scan_for_key_call_count();
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get with verification off");
+        let after = SSTableReader::scan_for_key_call_count();
+        assert!(res.is_none(), "the probe key must remain reported absent");
+        assert_eq!(
+            after, before,
+            "verification OFF must not run a confirmation scan through get_with_resolution"
+        );
+
+        // (b) ON: the SAME key, through the SAME public entry point, must run the
+        // confirmation scan (delta >= 1) — end-to-end wiring evidence — while the
+        // returned value is unchanged (a side-channel check only) and the
+        // false-negative counter stays 0 (a true negative).
+        presence_verification::set_enabled_for_testing(true);
+        mc.reset();
+        let before = SSTableReader::scan_for_key_call_count();
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get with verification on");
+        let after = SSTableReader::scan_for_key_call_count();
+        assert!(
+            res.is_none(),
+            "verification must not change the returned value for a true negative"
+        );
+        assert!(
+            after > before,
+            "verification ON must run a confirmation scan through get_with_resolution for the \
+             SAME key that showed no scan when OFF"
+        );
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+            0.0,
+            "a true negative reached via get_with_resolution must not emit false_negatives"
+        );
+
+        presence_verification::set_enabled_for_testing(false);
+        drop(rt);
+    }
+
+    // --- Roborev r4 blocker #2 (#2163): `ObservabilityConfig::verify_presence_oracle`
+    // must not be decorative. Config-only enablement (NO env var set) must flip
+    // the runtime switch through the PUBLIC `observability::init` entry point, and
+    // that flip must drive an ACTUAL confirmation scan through the public
+    // `get_with_resolution` read path — not merely make `enabled()` report `true`
+    // in isolation. Also pins the documented env-overrides-config precedence. ---
+    {
+        use cqlite_core::observability::ObservabilityConfig;
+        use cqlite_core::storage::sstable::reader::SSTableReader;
+        use cqlite_core::types::RowKey;
+
+        // Isolate from any real process env for this assertion.
+        let saved_env = std::env::var(presence_verification::ENV_VAR).ok();
+        std::env::remove_var(presence_verification::ENV_VAR);
+
+        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(30);
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        // Locate an in-range absent key (else C5 would short-circuit before the
+        // verify hook regardless of the switch) using the TEST setter purely to
+        // search — the switch is driven exclusively through `observability::init`
+        // for every assertion below.
+        presence_verification::set_enabled_for_testing(true);
+        let mut in_range_absent_key: Option<[u8; 4]> = None;
+        for candidate in 3_000_000i32..3_000_064 {
+            let key_bytes = candidate.to_be_bytes();
+            let before = SSTableReader::scan_for_key_call_count();
+            let res = rt
+                .block_on(reader.get_with_resolution(
+                    &table_id,
+                    &RowKey::from(key_bytes.to_vec()),
+                    false,
+                ))
+                .expect("get on candidate probe");
+            let after = SSTableReader::scan_for_key_call_count();
+            assert!(
+                res.is_none(),
+                "candidate {candidate} must be genuinely absent"
+            );
+            if after == before + 1 {
+                in_range_absent_key = Some(key_bytes);
+                break;
+            }
+        }
+        let absent_key = in_range_absent_key
+            .expect("at least one of 64 candidates must land within the Summary bound");
+
+        // Config-only DISABLE (no env): the switch must be OFF and the same key
+        // must show no confirmation scan through the public read path.
+        let cfg_off = ObservabilityConfig::builder()
+            .enabled(false)
+            .verify_presence_oracle(false)
+            .build();
+        let _guard = cqlite_core::observability::init(cfg_off).expect("init config-off");
+        assert!(
+            !presence_verification::enabled(),
+            "config-only disable must flip the switch off through observability::init"
+        );
+        let before = SSTableReader::scan_for_key_call_count();
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get config-off");
+        let after = SSTableReader::scan_for_key_call_count();
+        assert!(res.is_none());
+        assert_eq!(
+            after, before,
+            "config-only disable must not run a confirmation scan through get_with_resolution"
+        );
+
+        // Config-only ENABLE (no env): the switch must flip ON AND drive an ACTUAL
+        // confirmation scan through the public get_with_resolution() path for the
+        // SAME key — the end-to-end proof the field is wired, not decorative.
+        let cfg_on = ObservabilityConfig::builder()
+            .enabled(false)
+            .verify_presence_oracle(true)
+            .build();
+        let _guard = cqlite_core::observability::init(cfg_on).expect("init config-on");
+        assert!(
+            presence_verification::enabled(),
+            "config-only enable must flip the switch on through observability::init"
+        );
+        let before = SSTableReader::scan_for_key_call_count();
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get config-on");
+        let after = SSTableReader::scan_for_key_call_count();
+        assert!(res.is_none());
+        assert!(
+            after > before,
+            "config-only enable must drive a confirmation scan through get_with_resolution — \
+             proving ObservabilityConfig::verify_presence_oracle is wired end-to-end, not \
+             decorative"
+        );
+
+        // An explicitly-set env var must override a conflicting config value
+        // (documented env-overrides-config precedence).
+        std::env::set_var(presence_verification::ENV_VAR, "false");
+        let cfg_conflict = ObservabilityConfig::builder()
+            .enabled(false)
+            .verify_presence_oracle(true) // config says ON; env says off
+            .build();
+        let _guard = cqlite_core::observability::init(cfg_conflict).expect("init env-override");
+        assert!(
+            !presence_verification::enabled(),
+            "an explicitly-set env var must override a conflicting config value"
+        );
+
+        // Restore env + leave the switch OFF for any later blocks.
+        match saved_env {
+            Some(v) => std::env::set_var(presence_verification::ENV_VAR, v),
+            None => std::env::remove_var(presence_verification::ENV_VAR),
+        }
+        presence_verification::set_enabled_for_testing(false);
+        drop(rt);
+    }
+
+    // --- Roborev r4 item 3 (LOW, folded in, #2163): no REDUNDANT double scan.
+    // When the PRIMARY path itself already ran the authoritative `scan_for_key`
+    // (a bloom false positive falling through to an Index.db miss), the key was
+    // NOT excluded by the presence oracle (`oracle_pruned = false`), so turning
+    // verification ON must NOT trigger a second confirmation scan — the delta
+    // must stay exactly 1 (the primary scan only) whether verification is OFF or
+    // ON, distinguishing "oracle negative" (needs verifying) from "already an
+    // authoritative scan result" (nothing left to verify). ---
+    {
+        use cqlite_core::storage::sstable::reader::SSTableReader;
+        use cqlite_core::types::RowKey;
+
+        let (reader, table_id, _tmp) = fixtures::open_writer_reader_with_many_rows(30);
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+
+        // Search for a bloom FALSE POSITIVE: `might_contain_partition == true` for
+        // a key genuinely absent (well outside the inserted 0..30 range). Default
+        // `fp_chance` is 0.01, so finding >=1 among 10,000 candidates is
+        // overwhelmingly likely (searched, not assumed).
+        let mut fp_key: Option<[u8; 4]> = None;
+        for candidate in 4_000_000i32..4_010_000i32 {
+            let key_bytes = candidate.to_be_bytes();
+            if reader.might_contain_partition(&key_bytes) {
+                fp_key = Some(key_bytes);
+                break;
+            }
+        }
+
+        if let Some(fp_key) = fp_key {
+            // Verification OFF: the primary path's OWN Index.db-miss fallback
+            // scans once (the natural #1572 behaviour, unrelated to the switch).
+            presence_verification::set_enabled_for_testing(false);
+            let before = SSTableReader::scan_for_key_call_count();
+            let res = rt
+                .block_on(reader.get_with_resolution(
+                    &table_id,
+                    &RowKey::from(fp_key.to_vec()),
+                    false,
+                ))
+                .expect("get on bloom-false-positive key, verification off");
+            let after = SSTableReader::scan_for_key_call_count();
+            assert!(res.is_none(), "the bloom-FP key must still resolve absent");
+            assert_eq!(
+                after,
+                before + 1,
+                "the primary path's own scan_for_key fallback must run exactly once"
+            );
+
+            // Verification ON, the SAME key: `oracle_pruned` is false (the bloom
+            // hit admitted this SSTable; the index miss forced the primary path's
+            // OWN scan), so the opt-in verify hook must NOT run a second scan.
+            presence_verification::set_enabled_for_testing(true);
+            mc.reset();
+            let before = SSTableReader::scan_for_key_call_count();
+            let res = rt
+                .block_on(reader.get_with_resolution(
+                    &table_id,
+                    &RowKey::from(fp_key.to_vec()),
+                    false,
+                ))
+                .expect("get on bloom-false-positive key, verification on");
+            let after = SSTableReader::scan_for_key_call_count();
+            assert!(res.is_none(), "the bloom-FP key must still resolve absent");
+            assert_eq!(
+                after,
+                before + 1,
+                "verification ON must NOT add a second scan when the primary path already ran \
+                 the authoritative scan_for_key (oracle_pruned=false) — exactly one scan total"
+            );
+            let m = mc.flush_and_collect();
+            assert_eq!(
+                m.counter_sum(catalog::READ_SSTABLES_PRUNED),
+                0.0,
+                "a bloom hit (even a false positive) is not a presence-oracle exclusion — must \
+                 not emit sstables_pruned"
+            );
+            assert_eq!(
+                m.counter_sum(catalog::READ_BLOOM_FALSE_NEGATIVES),
+                0.0,
+                "the skipped (non-oracle) case must never emit false_negatives"
+            );
+            presence_verification::set_enabled_for_testing(false);
+        } else {
+            eprintln!(
+                "correctness_signals_2163_verify: no bloom false positive found among 10,000 \
+                 candidates (fp_chance=0.01 makes this astronomically unlikely) — skipping the \
+                 no-double-scan sub-assertion for this run; the structural invariant (verify \
+                 only runs when oracle_pruned) is still enforced by the code path itself"
+            );
+        }
+        drop(rt);
+    }
+
+    // --- Roborev r5 (#2163): the opt-in verify scan's `Err` must not be
+    // silently discarded. The READ stays fail-open (a verifier failure must
+    // never fail the actual read), but the failure must be surfaced LOUDLY:
+    // recorded through the EXISTING error-signal path
+    // (`cqlite.errors.total{subsystem=reader}`), never a new metric. ---
+    {
+        use cqlite_core::types::RowKey;
+
+        let (reader, table_id, data_path, _tmp) =
+            fixtures::open_writer_reader_with_many_rows_and_path(30);
+
+        // Find an in-range absent key. `might_contain_partition` only consults
+        // the ALREADY-LOADED (resident) Filter.db, so this search — and the
+        // primary oracle-negative it proves — is unaffected by the Data.db
+        // corruption applied below.
+        let mut absent_key: Option<[u8; 4]> = None;
+        for candidate in 5_000_000i32..5_000_064i32 {
+            let key_bytes = candidate.to_be_bytes();
+            if !reader.might_contain_partition(&key_bytes) {
+                absent_key = Some(key_bytes);
+                break;
+            }
+        }
+        let absent_key = absent_key
+            .expect("at least one candidate must show absent via the resident bloom filter");
+
+        // Corrupt Data.db AFTER open (truncate mid-file): the resident
+        // Filter.db is untouched (lives in memory), so the primary bloom-miss
+        // path still succeeds; but the opt-in verify's authoritative
+        // `scan_for_key` — which must read Data.db fresh — now fails.
+        let original_len = std::fs::metadata(&data_path).expect("stat Data.db").len();
+        assert!(
+            original_len > 8,
+            "the fixture's Data.db must be large enough to truncate meaningfully"
+        );
+        let truncated_len = (original_len / 2).max(1);
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&data_path)
+            .expect("open Data.db for truncation");
+        file.set_len(truncated_len)
+            .expect("truncate Data.db to simulate corruption/an unreadable SSTable");
+        drop(file);
+
+        presence_verification::set_enabled_for_testing(true);
+        mc.reset();
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let res = rt
+            .block_on(reader.get_with_resolution(
+                &table_id,
+                &RowKey::from(absent_key.to_vec()),
+                false,
+            ))
+            .expect("get_with_resolution must stay fail-open despite a verify-scan failure");
+        drop(rt);
+        presence_verification::set_enabled_for_testing(false);
+
+        assert!(
+            res.is_none(),
+            "the read must return the ORIGINAL oracle-negative result unaffected by the \
+             verify-scan failure (fail-open) — a debug/soundness check failing must never break \
+             a production read"
+        );
+
+        let m = mc.flush_and_collect();
+        let recorded = m.sum_where(
+            catalog::ERRORS_TOTAL,
+            &[(catalog::attr::SUBSYSTEM, "reader")],
+        );
+        assert!(
+            recorded >= 1.0,
+            "the verify-scan failure must be recorded through the existing error-signal path \
+             (cqlite.errors.total{{subsystem=reader}}) — a silent-miss DETECTOR must not itself \
+             fail silently; entry: {:?}",
+            m.find(catalog::ERRORS_TOTAL)
+        );
+    }
+
+    // --- Requirement: Degraded read-path counter with bounded reason ---
+    // The executor records honest fallbacks through `access_path::record`, the
+    // public probe every fallback site funnels through. A fallback increments the
+    // counter with its bounded reason label; a targeted path never does.
+    {
+        use cqlite_core::query::access_path::{self, AccessPath, FallbackReason};
+        mc.reset();
+        access_path::record(AccessPath::FallbackFullScan {
+            reason: FallbackReason::NoSchema,
+        });
+        // A targeted path must NOT increment the degraded counter.
+        access_path::record(AccessPath::PartitionLookup);
+        let m = mc.flush_and_collect();
+        assert_eq!(
+            m.counter_sum(catalog::QUERY_DEGRADED_PATH),
+            1.0,
+            "exactly one degraded increment for the single fallback (targeted path adds none)"
+        );
+        assert_eq!(
+            m.sum_where(
+                catalog::QUERY_DEGRADED_PATH,
+                &[(catalog::attr::FALLBACK_REASON, "no_schema")],
+            ),
+            1.0,
+            "the degraded increment must carry the bounded fallback_reason label"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reader fixtures (writer-produced, schema-attached readers for the verify
+// switch scenarios).
+// ---------------------------------------------------------------------------
+
+mod fixtures {
+    use cqlite_core::platform::Platform;
+    use cqlite_core::schema::registry::{SchemaRegistry, SchemaRegistryConfig, SchemaSource};
+    use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+    use cqlite_core::storage::sstable::reader::SSTableReader;
+    use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+    use cqlite_core::types::{RowKey, TableId};
+    use cqlite_core::Config;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    pub fn writer_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "obsfn".to_string(),
+            table: "rows".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// Write one row, flush, and open a schema-attached reader over the produced
+    /// Data.db. Returns the reader, a matching TableId, and the present key bytes.
+    /// The reader can authoritatively scan for the key (schema attached), which the
+    /// false-negative verification needs.
+    pub fn open_writer_reader_with_present_key(
+    ) -> (SSTableReader, TableId, [u8; 4], tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = writer_schema();
+        let cfg = WriteEngineConfig::new(
+            tmp.path().join("data"),
+            tmp.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        engine
+            .execute("INSERT INTO obsfn.rows (id, name) VALUES (7, 'seven')")
+            .expect("write");
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let info = rt
+            .block_on(engine.flush())
+            .expect("flush")
+            .expect("sstable");
+        let data_file = info.data_path.clone();
+
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        let mut reader = rt
+            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
+            .expect("open reader");
+
+        // Attach the schema so the authoritative scan can decode the row.
+        let registry = rt
+            .block_on(SchemaRegistry::new(
+                SchemaRegistryConfig::default(),
+                platform.clone(),
+                config.clone(),
+            ))
+            .expect("build registry");
+        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
+            .expect("register schema");
+        let registry = Arc::new(tokio::sync::RwLock::new(registry));
+        rt.block_on(reader.attach_schema_registry(registry));
+
+        // Confirm the reader really can find the present key (so the verify scan
+        // is meaningful), then hand back the pieces the test needs.
+        let table_id = TableId::from("rows");
+        let present_key = 7i32.to_be_bytes();
+        let found = rt
+            .block_on(reader.get(&table_id, &RowKey::from(present_key.to_vec())))
+            .expect("get present key");
+        assert!(
+            found.is_some(),
+            "writer fixture reader must be able to read back the present key for the \
+             false-negative scan to be meaningful"
+        );
+        drop(rt);
+        (reader, table_id, present_key, tmp)
+    }
+
+    /// Write `n` rows (ids `0..n`), flush, and open a schema-attached reader over
+    /// the produced Data.db. Used by the `get()`-level false-negative wiring test
+    /// (roborev fold-in #3, #2163), which needs an absent probe key whose token
+    /// falls WITHIN the reader's authoritative `[first_key, last_key]` Summary
+    /// bound (else the C5 range short-circuit in `get_with_resolution` returns
+    /// absence before ever reaching the presence-oracle / verify hook). `n` rows
+    /// spread the observed token span wide enough that a handful of far-outside-
+    /// range candidate ids (searched by the caller) are overwhelmingly likely to
+    /// land in-range by token, even though token order is unrelated to int order.
+    pub fn open_writer_reader_with_many_rows(
+        n: i32,
+    ) -> (SSTableReader, TableId, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = writer_schema();
+        let cfg = WriteEngineConfig::new(
+            tmp.path().join("data"),
+            tmp.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        for id in 0..n {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'row{id}')"
+                ))
+                .expect("write");
+        }
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let info = rt
+            .block_on(engine.flush())
+            .expect("flush")
+            .expect("sstable");
+        let data_file = info.data_path.clone();
+
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        let mut reader = rt
+            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
+            .expect("open reader");
+
+        let registry = rt
+            .block_on(SchemaRegistry::new(
+                SchemaRegistryConfig::default(),
+                platform.clone(),
+                config.clone(),
+            ))
+            .expect("build registry");
+        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
+            .expect("register schema");
+        let registry = Arc::new(tokio::sync::RwLock::new(registry));
+        rt.block_on(reader.attach_schema_registry(registry));
+        drop(rt);
+
+        (reader, TableId::from("rows"), tmp)
+    }
+
+    /// Like [`open_writer_reader_with_many_rows`], but also returns the on-disk
+    /// `Data.db` path so a test can corrupt it AFTER the reader has already
+    /// loaded Filter.db/Index.db/Summary.db into memory (roborev r5, #2163's
+    /// verify-scan-error test) — the presence-oracle bloom check never re-reads
+    /// Data.db, so corrupting the file post-open leaves the primary oracle
+    /// negative intact while making a SUBSEQUENT `scan_for_key` (the opt-in
+    /// verify path) fail.
+    pub fn open_writer_reader_with_many_rows_and_path(
+        n: i32,
+    ) -> (SSTableReader, TableId, PathBuf, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let schema = writer_schema();
+        let cfg = WriteEngineConfig::new(
+            tmp.path().join("data"),
+            tmp.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(cfg).expect("engine");
+        for id in 0..n {
+            engine
+                .execute(&format!(
+                    "INSERT INTO obsfn.rows (id, name) VALUES ({id}, 'row{id}')"
+                ))
+                .expect("write");
+        }
+
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let info = rt
+            .block_on(engine.flush())
+            .expect("flush")
+            .expect("sstable");
+        let data_file = info.data_path.clone();
+
+        let config = Config::default();
+        let platform = Arc::new(rt.block_on(Platform::new(&config)).expect("platform"));
+        let mut reader = rt
+            .block_on(SSTableReader::open(&data_file, &config, platform.clone()))
+            .expect("open reader");
+
+        let registry = rt
+            .block_on(SchemaRegistry::new(
+                SchemaRegistryConfig::default(),
+                platform.clone(),
+                config.clone(),
+            ))
+            .expect("build registry");
+        rt.block_on(registry.register_schema(schema, SchemaSource::Manual))
+            .expect("register schema");
+        let registry = Arc::new(tokio::sync::RwLock::new(registry));
+        rt.block_on(reader.attach_schema_registry(registry));
+        drop(rt);
+
+        (reader, TableId::from("rows"), data_file, tmp)
+    }
+}

--- a/docs/observability/configuration.md
+++ b/docs/observability/configuration.md
@@ -31,6 +31,7 @@ These are read by every surface through
 | `CQLITE_OTEL_SERVICE_VERSION` | string | crate version | `service.version` resource attribute. |
 | `CQLITE_OTEL_SAMPLING_RATIO` | f64 | `1.0` | Trace-ID-ratio sampling probability, clamped to `[0.0, 1.0]`. |
 | `CQLITE_OTEL_TIMEOUT_MS` | u64 | `10000` | Exporter export timeout in milliseconds. |
+| `CQLITE_VERIFY_PRESENCE_ORACLE` | bool | `false` | Opt-in soundness check (issue #2163). When true, an SSTable read whose bloom/BTI-trie reports a key "definitely absent" runs an AUTHORITATIVE confirmation scan and increments `cqlite.read.bloom.false_negatives` on a contradiction. Off by default — it is the one presence-oracle counter that costs real work; turn it on transiently to prove the oracle-soundness invariant (expected value: 0), then off. |
 
 Unparseable values fall back to the documented default rather than erroring, so
 a typo never crashes the host process.
@@ -213,6 +214,8 @@ dot-separated under the `cqlite.` root; units use UCUM annotations
 | `cqlite.read.duration` | histogram | `s` | `cqlite.sstable.format` |
 | `cqlite.read.partition_lookup.total` | counter | `1` | `cqlite.result`, `cqlite.query.access_path`, `cqlite.sstable.format` |
 | `cqlite.read.bloom.checks` | counter | `1` | `cqlite.result`, `cqlite.sstable.format` |
+| `cqlite.read.sstables_pruned` | counter | `{sstable}` | `cqlite.sstable.format` |
+| `cqlite.read.bloom.false_negatives` | counter | `1` | `cqlite.sstable.format` |
 | `cqlite.storage.open.sstables` | counter | `{sstable}` | (none) |
 | `cqlite.storage.open.bytes` | counter | `By` | (none) |
 | `cqlite.storage.open.tables` | counter | `1` | (none) |
@@ -225,6 +228,7 @@ dot-separated under the `cqlite.` root; units use UCUM annotations
 | `cqlite.query.duration` | histogram | `s` | `cqlite.subsystem` |
 | `cqlite.query.rows` | counter | `{row}` | `cqlite.query.access_path`, `cqlite.query.plan_type` |
 | `cqlite.query.rows_scanned` | counter | `{row}` | `cqlite.query.access_path` |
+| `cqlite.query.degraded_path.total` | counter | `1` | `cqlite.query.fallback_reason` |
 
 ### Write path
 
@@ -252,6 +256,10 @@ dot-separated under the `cqlite.` root; units use UCUM annotations
 | `cqlite.compaction.sstables_in` | counter | `{sstable}` | (none) |
 | `cqlite.compaction.sstables_out` | counter | `{sstable}` | (none) |
 | `cqlite.compaction.tombstones_purged` | counter | `{tombstone}` | (none) |
+| `cqlite.compaction.tombstones_suppressed` | counter | `{tombstone}` | (none) |
+| `cqlite.compaction.tombstones_emitted` | counter | `{tombstone}` | (none) |
+| `cqlite.merge.rows_in` | counter | `{row}` | (none) |
+| `cqlite.merge.rows_out` | counter | `{row}` | (none) |
 | `cqlite.compaction.lag` | gauge | `{sstable}` | (none) |
 | `cqlite.compaction.finalize.duration` | histogram | `s` | (none) |
 | `cqlite.compaction.budget.requested` | histogram | `s` | (none) |
@@ -288,6 +296,7 @@ closed value space so cardinality stays bounded. Source:
 | `cqlite.result` | `hit`, `miss` |
 | `cqlite.read.lookup_route` | `index`, `bti_trie` |
 | `cqlite.query.access_path` | `full_scan`, `partition_lookup`, `multi_partition_lookup`, `clustering_slice`, `fallback_full_scan` |
+| `cqlite.query.fallback_reason` | `no_schema`, `partition_key_not_fully_constrained`, `partition_key_encoding_failed`, `metadata_scan_path`, `legacy_executor_path`, `tombstones_build_no_prune` |
 | `cqlite.query.plan_type` | `table_scan`, `point_lookup`, `index_scan`, `range_scan`, `aggregation` |
 | `cqlite.rpc.method` | fixed `FlightService` method set (`do_get`, `get_flight_info`, `get_schema`, `handshake`, …) |
 | `cqlite.rpc.status` | `ok`, `error` |

--- a/openspec/changes/correctness-signals/design.md
+++ b/openspec/changes/correctness-signals/design.md
@@ -1,0 +1,114 @@
+# Design — correctness / silent-miss signals
+
+## Context
+
+Five new counters (one opt-in) plus one attribute key, all routed through the existing
+`cqlite_core::observability` foundation:
+
+- Names live in `catalog.rs`, mirrored in `ALL_METRICS`.
+- Emission goes through `observability::add_counter(name, value, &attrs)`, which is a
+  **no-op with zero OTel linkage** when the `observability` feature is off (proven by the
+  module's `cfg(not(feature = "observability"))` arm + `helpers_are_callable_in_any_build`
+  test). Call sites are identical in every build.
+- When the feature is on, `otel.rs` maps each name to a pre-registered `Counter<u64>` via a
+  `match name` dispatch; an unregistered name still works via the `_ =>` ad-hoc-create arm,
+  but convention (and this change) registers each new counter as a struct field so the
+  instrument carries its unit.
+- Tests assert against emitted metrics with the `observability-testing`
+  `InMemoryMetricExporter` harness (`observability/testing.rs`), driven by a **real read /
+  merge through a public surface** (Flight `do_get`, `Database` scan, or a compaction run).
+
+Cited surfaces (read during design): `catalog.rs` (naming + bounded-attr doctrine),
+`mod.rs` (feature gating), `otel.rs:520` (name→instrument dispatch), `producer.rs:628`
+(`drive_merge`), `merge/mod.rs:2358/2600` (`PurgeCounts` tally + single per-merge
+`tombstones_purged` emission), `merge/reconcile.rs:520` (per-cell purge decision),
+`partition_lookup.rs:278` (single `READ_BLOOM_CHECKS` emission per BTI lookup),
+`query/access_path.rs` (`FallbackReason` closed set + `record()`).
+
+## Recommended design
+
+### Metric catalog additions
+
+| Const | Name | Unit | Bounded attrs | Fires |
+|-------|------|------|---------------|-------|
+| `MERGE_ROWS_IN` | `cqlite.merge.rows_in` | `{row}` | none | once per merge, sum of input rows consumed |
+| `MERGE_ROWS_OUT` | `cqlite.merge.rows_out` | `{row}` | none | once per merge, sum of rows emitted post-reconcile |
+| `COMPACTION_TOMBSTONES_SUPPRESSED` | `cqlite.compaction.tombstones_suppressed` | `{tombstone}` | none | once per merge, live cells/rows shadowed by a tombstone |
+| `COMPACTION_TOMBSTONES_EMITTED` | `cqlite.compaction.tombstones_emitted` | `{tombstone}` | none | once per merge, tombstone markers retained into output |
+| `READ_SSTABLES_PRUNED` | `cqlite.read.sstables_pruned` | `{sstable}` | `SSTABLE_FORMAT` | per SSTable excluded from a read by a presence-oracle negative |
+| `READ_BLOOM_FALSE_NEGATIVES` | `cqlite.read.bloom.false_negatives` | `1` | `SSTABLE_FORMAT` | opt-in only: a "definitely absent" verdict contradicted by an authoritative scan |
+| `QUERY_DEGRADED_PATH` | `cqlite.query.degraded_path.total` | `1` | `FALLBACK_REASON` | per SELECT that takes a soundness fallback |
+
+New attribute key `FALLBACK_REASON = "cqlite.query.fallback_reason"`, value space =
+`FallbackReason::label()` (a documented closed set: `no_schema`,
+`partition_key_not_fully_constrained`, `partition_key_encoding_failed`,
+`metadata_scan_path`, `legacy_executor_path`, `tombstones_build_no_prune`) — bounded by the
+enum, never a key/query string.
+
+### Where each counter is wired (single low-frequency emission)
+
+- **rows_in / rows_out + suppressed / emitted** ride the merge's existing per-merge tally
+  (the `PurgeCounts` pattern at `merge/mod.rs:2359`, emitted once at `:2600`). Per-partition
+  reconcile increments *stack integers*; the four counters emit **once per merge**, exactly
+  like `tombstones_purged` today. Because the Flight read path drives the SAME `KWayMerger`
+  (`producer.rs`), a Flight `do_get` over multiple generations moves these counters too —
+  one instrumentation site covers both the compaction-write and Flight-read paths. Scoped to
+  the reconcile boundary so producer-level token-prune + predicate filtering (expected drops)
+  are excluded — these count *reconciliation* drops only.
+- **sstables_pruned** at the reader candidate-selection / presence-oracle-negative sites
+  (the `miss` decision that skips an SSTable's data, e.g. `partition_lookup.rs:284`). One
+  increment per SSTable not opened because its bloom (BIG) / trie (BTI) said absent.
+- **degraded_path** folded into `access_path::record(FallbackFullScan { reason })` (or a
+  sibling emit), so every honest fallback increments the counter with `reason.label()`.
+  Fires once per fallback query (rare).
+- **false_negatives** behind a runtime sampling switch (`ObservabilityConfig` /
+  `CQLITE_VERIFY_PRESENCE_ORACLE`, default off). When enabled, a presence-oracle **negative**
+  triggers an authoritative confirmation scan of that one SSTable; a contradiction increments
+  the counter (and logs). Default-off = zero cost.
+
+### Overhead posture (these are read-path counters — mandatory)
+
+- **Off by default at the feature level.** `all` builds without `observability` link no OTel
+  and every call site is a compiled-out no-op. This is the dominant production posture.
+- **Feature on:** per-row work is a single `+= 1` on a **stack-local** integer inside a loop
+  the merge already runs; the OTel `Counter::add` (a relaxed atomic) fires **once per merge**
+  / once per query fallback / once per pruned SSTable — never per row or per cell. This
+  matches the module doctrine ("aggregate with metrics; never per-cell spans on hot paths").
+- **`sstables_pruned`** piggybacks the existing per-SSTable presence check — no new scan.
+- **`false_negatives` is opt-in + sampled.** It is the only counter that costs real work
+  (a confirmation scan), so it is default-off and gated by an explicit verify/sampling knob;
+  operators turn it on transiently to *prove the presence-oracle soundness invariant*
+  (expected value: 0), then turn it off.
+
+## Alternatives considered
+
+1. **Instrument rows-in/out in the Flight producer's `drive_merge` (`emitted` counter)
+   instead of the core merge.** *Rejected.* `drive_merge`'s `emitted` is counted *after*
+   token-prune + predicate filter + LIMIT, so its delta vs input conflates expected query
+   filtering with reconciliation drops — it cannot isolate the silent-miss signal. It also
+   would not observe the compaction-write path at all. Instrumenting the core reconcile
+   boundary is the single site that means the same thing for both callers.
+2. **A single `cqlite.merge.rows_dropped` delta counter** (issue's alt suggestion) instead of
+   the in/out pair. *Rejected (kept the pair).* A lone delta hides the denominator: a dashboard
+   cannot tell 5 dropped of 10 (alarming) from 5 of 5,000,000 (normal). The pair yields both
+   ratio and volume and costs one extra `add` per merge.
+3. **Reuse `cqlite.read.bloom.checks{result=miss}` as the skipped-SSTable signal** (no new
+   metric). *Partially rejected.* The per-check miss counts *checks*, which for a batched
+   candidate list need not equal *SSTables skipped*; a dedicated `{sstable}`-unit counter is
+   unambiguous and dashboard-honest. (The existing checks metric stays as-is.) — This is the
+   one borderline-redundancy call; see the open question below.
+4. **Full re-merge verify mode** (drive the merge twice, diff row sets). *Rejected as a
+   Non-goal* — doubles read cost; the narrow presence-oracle re-check gives the highest-value
+   soundness proof (bloom/trie false negative = corruption) for O(1) per sampled miss.
+5. **Per-reason separate metric names for degraded paths.** *Rejected.* A single metric with a
+   bounded `fallback_reason` attribute (the established `access_path`/`result` pattern in this
+   catalog) lets one series carry every arm for a stacked dashboard, and the reason enum is
+   already closed.
+
+## Open question for the owner (product-level)
+
+- **Requirement 3 granularity (fork):** ship a *new* `cqlite.read.sstables_pruned{format}`
+  counter (recommended — `{sstable}`-unit, unambiguous), **or** declare the existing
+  `cqlite.read.bloom.checks{result=miss}` arm the official skipped-SSTable signal and add
+  *only* the opt-in false-negative counter (Requirement 4)? The recommendation is the new
+  counter; the owner may prefer to avoid a near-duplicate of the checks-miss arm.

--- a/openspec/changes/correctness-signals/design.md
+++ b/openspec/changes/correctness-signals/design.md
@@ -105,10 +105,16 @@ enum, never a key/query string.
    catalog) lets one series carry every arm for a stacked dashboard, and the reason enum is
    already closed.
 
-## Open question for the owner (product-level)
+## Open question for the owner (product-level) — RESOLVED
 
 - **Requirement 3 granularity (fork):** ship a *new* `cqlite.read.sstables_pruned{format}`
   counter (recommended — `{sstable}`-unit, unambiguous), **or** declare the existing
   `cqlite.read.bloom.checks{result=miss}` arm the official skipped-SSTable signal and add
-  *only* the opt-in false-negative counter (Requirement 4)? The recommendation is the new
-  counter; the owner may prefer to avoid a near-duplicate of the checks-miss arm.
+  *only* the opt-in false-negative counter (Requirement 4)?
+
+  **OWNER DECISION (2026-07-08, #2163):** ship the NEW dedicated
+  `cqlite.read.sstables_pruned` counter carrying the bounded `cqlite.sstable.format`
+  attribute. Do NOT reuse the `cqlite.read.bloom.checks{result=miss}` arm as the
+  skipped-SSTable signal — the per-check miss counts *checks*, not *SSTables skipped*, so a
+  dedicated `{sstable}`-unit counter is unambiguous and dashboard-honest. The existing
+  `cqlite.read.bloom.checks` metric stays as-is.

--- a/openspec/changes/correctness-signals/proposal.md
+++ b/openspec/changes/correctness-signals/proposal.md
@@ -1,0 +1,92 @@
+# Correctness / silent-miss observability signals
+
+## Why
+
+CQLite's error-side telemetry is mature: `observability/error_schema.rs` provides a
+10-category bounded taxonomy with exhaustive `Error`-variant coverage, and
+`cqlite.errors.total` is the canonical error-rate signal (issue #1038). #2193
+additionally logs+counts Flight encoder-stage egress errors. But every one of those
+signals fires only on an *explicit failure*. Nothing surfaces a **wrong-but-successful
+read** — a query that returns `Ok` with the wrong rows because the read/merge path
+silently dropped, resurrected, or skipped data.
+
+Issue #2163 (epic #2103, `easy-db-lab` harness) names four concrete blind spots, each
+over a real code surface:
+
+1. **No row-count reconciliation.** The k-way merge (`KWayMerger` in
+   `cqlite-core/src/storage/write_engine/merge/`, driven by the Flight producer's
+   `drive_merge` in `cqlite-flight/src/producer.rs`) applies LWW + tombstone
+   suppression and is unit-tested, but at runtime nothing emits how many rows entered
+   the merge vs left it. A sudden change in the drop ratio (a schema/reconcile bug) is
+   invisible.
+2. **No tombstone suppression-vs-emission signal.** `cqlite.compaction.tombstones_purged`
+   counts *genuine gc/overlap-safe purges* only. Nothing distinguishes a tombstone that
+   **suppressed** older live data during reconcile from one **emitted** (retained) into
+   the output — the two quantities whose divergence is the resurrection-risk smell.
+3. **No presence-oracle miss / false-negative signal.** `cqlite.read.bloom.checks`
+   counts checks (hit/miss), but there is no counter for *SSTables pruned* by a negative,
+   and no way to catch a *false negative* (a "definitely absent" verdict that is wrong) —
+   which, for a bloom/BTI-trie, must be impossible, so a non-zero count is a corruption
+   alarm.
+4. **No degraded-read-path signal.** The SELECT executor's honest soundness fallbacks
+   (`AccessPath::FallbackFullScan { reason }` in `query/access_path.rs`, recorded at the
+   decision sites in `query/select_executor/execute.rs` and `lookup.rs`) take
+   `skip`/`unwrap_or_default` branches recorded only into a single-slot diagnostic
+   `ArcSwap` — never a metric. An operator cannot alert on "queries are silently falling
+   back to full scans."
+
+All four are **additive, measurement-only** counters that reuse the existing
+`observability` catalog + feature-gating machinery (`observability/catalog.rs`,
+`observability/mod.rs`, `observability/otel.rs`). No production read/merge behavior
+changes.
+
+## Milestone & routing
+
+- **Milestone**: maintenance / observability (epic #2103), targeting the v0.13 line.
+- **Oracle-vs-design**: **design-driven.** There is no Cassandra byte-parity oracle for
+  *what telemetry CQLite emits* — metric names, the bounded attribute space, the
+  suppressed-vs-emitted decomposition, and the opt-in verification posture are all design
+  latitude. (The underlying merge/purge *behavior* these counters observe is
+  oracle-governed and unchanged here.) This is why #2163 is an OpenSpec change, not a
+  bare issue + parity test.
+
+## What changes (surfaces)
+
+- **New catalog metric names** in `cqlite-core/src/observability/catalog.rs`
+  (+ `ALL_METRICS`), one new bounded attribute key, and matching instrument registration
+  + `add_counter` dispatch arms in `observability/otel.rs`.
+- **Merge reconcile instrumentation** (`storage/write_engine/merge/`): aggregate
+  rows-in / rows-out and tombstones-suppressed / tombstones-emitted into the existing
+  per-merge tally struct, emit once per merge (never per row/cell).
+- **Reader presence-oracle sites** (`storage/sstable/reader/partition_lookup.rs` +
+  candidate-prune site): a pruned-SSTable counter, and an opt-in false-negative
+  verification counter behind a runtime sampling config (default off).
+- **SELECT executor** (`query/access_path.rs` + `select_executor/`): a degraded-path
+  counter keyed by the existing bounded `FallbackReason`.
+
+## Non-goals
+
+- **A full re-read / re-merge disagreement ("verify") metric** that drives the whole
+  merge a second time and diffs the two row sets. Deferred — it doubles read cost and is
+  not "nearly free"; the four counters above surface silent-miss risk without a second
+  pass. The one opt-in verification we *do* include (Requirement 4) is narrow and cheap:
+  it re-checks only a presence-oracle **negative** against an authoritative scan, which
+  is O(1) per sampled miss, not a whole-merge replay.
+- **Changing any merge / purge / fallback behavior.** Every counter observes an existing
+  decision; none moves one. `cqlite.compaction.tombstones_purged` semantics are untouched.
+- **Re-speccing #2193** (Flight encoder-stage egress error logging/counting) — landing
+  separately.
+- **In-progress / latency metrics** — companion issue #2162, out of scope here.
+- **New public CLI/Python/Node/Flight API surface.** These are internal telemetry
+  counters observed through the existing OTLP exporter; no binding signature changes.
+
+## Doctrine impact
+
+- **No-heuristics mandate**: the false-negative verification (Requirement 4) contradicts a
+  presence-oracle negative only against an **authoritative** scan of that SSTable — never
+  by inferring from byte patterns. It is opt-in and default-off, so it never affects a
+  production decode.
+- **Memory budget (<128MB)**: counters are stack integers aggregated per-merge; zero heap.
+- **Docs**: the `observability` catalog table on the website `agents-developing/` area and
+  any metric reference in `docs/` gain the new names in the same change (user-facing
+  telemetry surface).

--- a/openspec/changes/correctness-signals/specs/correctness-signals/spec.md
+++ b/openspec/changes/correctness-signals/specs/correctness-signals/spec.md
@@ -1,0 +1,170 @@
+# correctness-signals Specification
+
+## Purpose
+
+Additive, measurement-only observability counters that surface **wrong-but-successful
+reads** — silent-miss risks the error-side taxonomy (`cqlite.errors.total`) cannot see:
+merge row-count reconciliation, tombstone suppression-vs-emission divergence,
+presence-oracle prunes / false negatives, and degraded (fallback) read paths. All counters
+route through the existing `cqlite_core::observability` catalog + feature-gating machinery
+and observe existing decisions without changing merge, purge, or fallback behavior.
+
+## ADDED Requirements
+
+### Requirement: Merge row-count reconciliation counters
+
+The k-way merge reconcile boundary SHALL emit two monotonic counters,
+`cqlite.merge.rows_in` (unit `{row}`) and `cqlite.merge.rows_out` (unit `{row}`), scoped to
+the reconciliation step so that row-count changes caused by LWW collapse and tombstone
+suppression are observable, and expected producer-level filtering (token-range prune,
+predicate filter, `LIMIT`) is EXCLUDED. Both SHALL be emitted **once per merge** (not per
+row or per cell), aggregated from stack-local counters, mirroring the existing single
+per-merge `cqlite.compaction.tombstones_purged` emission. Both names SHALL be registered in
+the metric catalog (`catalog.rs` + `ALL_METRICS`) and dispatched to pre-registered
+instruments in `otel.rs`. When the `observability` feature is disabled the instrumentation
+SHALL compile to a no-op with no OTel linkage.
+
+#### Scenario: A multi-generation merge emits rows_in and rows_out
+- **WHEN** a compaction (or a Flight `do_get` that drives `KWayMerger`) reconciles two
+  overlapping SSTables whose combined input is N rows and whose reconciled output is M rows
+  (M < N because duplicate/LWW-collapsed rows exist), with the `observability-testing`
+  in-memory metric exporter installed
+- **THEN** `cqlite.merge.rows_in` increments by exactly N and `cqlite.merge.rows_out`
+  increments by exactly M
+- **AND** the `rows_in - rows_out` delta equals the number of rows removed by reconciliation
+
+#### Scenario: Reconciliation-only scope excludes producer filtering
+- **WHEN** a Flight read applies a `WHERE`/token filter that drops rows AFTER the merge
+  reconcile step emits its partition
+- **THEN** those producer-level filtered rows are counted in `cqlite.merge.rows_in` and
+  `cqlite.merge.rows_out` alike (they survived reconciliation), so the in/out delta reflects
+  ONLY reconciliation drops, not query filtering
+
+#### Scenario: Counters are inert when observability is disabled
+- **WHEN** the crate is built without the `observability` feature
+- **THEN** the merge path still compiles and runs, the emission calls are no-ops, and
+  `cargo tree` links no OpenTelemetry crates on their account
+
+### Requirement: Tombstone suppression-vs-emission counters
+
+The merge reconcile path SHALL emit two monotonic counters distinct from
+`cqlite.compaction.tombstones_purged`: `cqlite.compaction.tombstones_suppressed` (unit
+`{tombstone}`) counting live cells/rows shadowed (suppressed) by a tombstone during
+reconciliation, and `cqlite.compaction.tombstones_emitted` (unit `{tombstone}`) counting
+tombstone markers RETAINED into the merge output. Both SHALL be emitted once per merge from
+stack-local tallies. `cqlite.compaction.tombstones_purged` semantics SHALL be unchanged.
+The three counters together SHALL let a dashboard distinguish suppression (a tombstone did
+its job), emission (a tombstone was carried forward), and genuine purge, so a resurrection
+smell (suppression without a safe purge or a retained marker) is visible.
+
+#### Scenario: A tombstone that shadows live data is counted as suppressed
+- **WHEN** a merge reconciles a newer row-tombstone over an older live cell in the same
+  clustering slot, with the in-memory metric exporter installed
+- **THEN** `cqlite.compaction.tombstones_suppressed` increments for the shadowed live
+  cell(s)
+- **AND** the counter is separate from `cqlite.compaction.tombstones_purged`, which does not
+  increment unless the tombstone is also gc/overlap-safe to purge
+
+#### Scenario: A retained tombstone marker is counted as emitted
+- **WHEN** a merge writes a tombstone marker into its output because it is NOT purgeable
+  (no gc cutoff / overlap-unsafe)
+- **THEN** `cqlite.compaction.tombstones_emitted` increments by the number of retained
+  markers and `cqlite.compaction.tombstones_purged` does not increment for them
+
+### Requirement: SSTable-pruned-by-presence-oracle counter
+
+The read path SHALL emit `cqlite.read.sstables_pruned` (unit `{sstable}`, bounded attribute
+`cqlite.sstable.format`) incremented once for each SSTable excluded from a read because its
+presence oracle returned a definitive negative — the bloom filter for BIG
+(`might_contain_partition == false`) or the Partitions.db trie for BTI (a trie miss). The
+counter SHALL be registered in the catalog and dispatched to a pre-registered instrument.
+It SHALL be distinct from `cqlite.read.bloom.checks`, which counts checks (hit/miss); this
+counter counts SSTables actually skipped, in `{sstable}` units.
+
+#### Scenario: A point read over a multi-SSTable table skips absent SSTables
+- **WHEN** a partition point lookup runs over a table with multiple SSTables where the key is
+  present in one and absent from the others, through the public read surface, with the
+  in-memory metric exporter installed
+- **THEN** `cqlite.read.sstables_pruned` increments once per SSTable whose presence oracle
+  reported the key definitely absent
+- **AND** the increment carries `cqlite.sstable.format` = `"big"` or `"bti"` matching each
+  skipped SSTable's format
+
+### Requirement: Opt-in presence-oracle false-negative verification counter
+
+The read path SHALL provide an OPT-IN, default-OFF verification that a presence-oracle
+"definitely absent" verdict is truthful, emitting `cqlite.read.bloom.false_negatives` (unit
+`1`, bounded attribute `cqlite.sstable.format`) ONLY when an authoritative scan of that
+SSTable finds the key the oracle said was absent. Enabling it SHALL require an explicit
+runtime switch (an `ObservabilityConfig` field / `CQLITE_VERIFY_PRESENCE_ORACLE` env, off by
+default); when off the verification scan SHALL NOT run and the path SHALL cost nothing beyond
+the existing check. The confirmation SHALL be an authoritative scan of the SSTable's own data
+— never a heuristic inference from byte patterns (no-heuristics mandate). Under a correct
+bloom/BTI-trie this counter SHALL remain 0; a non-zero value is a corruption/soundness alarm.
+
+#### Scenario: Verification off by default costs nothing and never emits
+- **WHEN** reads run with the verification switch unset (its default)
+- **THEN** no confirmation scan is performed on a presence-oracle miss and
+  `cqlite.read.bloom.false_negatives` is never emitted
+
+#### Scenario: Verification on confirms a true negative without incrementing
+- **WHEN** the verification switch is enabled and a point read hits a presence-oracle miss
+  for a key that is genuinely absent from that SSTable, with the in-memory exporter installed
+- **THEN** an authoritative confirmation scan runs, finds the key absent, and
+  `cqlite.read.bloom.false_negatives` stays at 0
+
+#### Scenario: Verification on surfaces a contradicted negative
+- **WHEN** the verification switch is enabled and (via a fault-injected / synthetic oracle
+  that reports a false negative for a key that IS present) a point read hits a miss the
+  authoritative scan contradicts
+- **THEN** `cqlite.read.bloom.false_negatives` increments by 1 with the offending SSTable's
+  `cqlite.sstable.format`, proving the counter fires only on a real contradiction
+
+### Requirement: Degraded read-path counter with bounded reason
+
+The SELECT executor SHALL emit `cqlite.query.degraded_path.total` (unit `1`) with a single
+bounded attribute `cqlite.query.fallback_reason` whose value comes from
+`FallbackReason::label()` (the documented closed set: `no_schema`,
+`partition_key_not_fully_constrained`, `partition_key_encoding_failed`,
+`metadata_scan_path`, `legacy_executor_path`, `tombstones_build_no_prune`), incremented once
+each time a query takes a soundness fallback recorded as `AccessPath::FallbackFullScan`. The
+attribute key SHALL be registered in `catalog::attr`; the value space SHALL be bounded by the
+enum and SHALL NEVER carry a partition key, predicate value, or query string. The counter
+SHALL fire at the same decision sites that record the honest fallback today, so a green
+targeted query does NOT increment it.
+
+#### Scenario: A schema-less query increments the degraded counter with its reason
+- **WHEN** a SELECT that cannot use a targeted path (e.g. no schema available) runs through
+  the public query surface and records `AccessPath::FallbackFullScan { reason: NoSchema }`,
+  with the in-memory metric exporter installed
+- **THEN** `cqlite.query.degraded_path.total` increments by 1 with
+  `cqlite.query.fallback_reason` = `"no_schema"`
+
+#### Scenario: A targeted (non-degraded) query does not increment the counter
+- **WHEN** a SELECT resolves to a real partition lookup (no fallback recorded)
+- **THEN** `cqlite.query.degraded_path.total` does not increment for that query
+
+#### Scenario: The fallback-reason attribute stays bounded
+- **WHEN** any degraded-path increment is emitted
+- **THEN** the `cqlite.query.fallback_reason` value is exactly one of `FallbackReason`'s
+  `label()` strings and carries no key/predicate/query text
+
+### Requirement: Catalog integrity and bounded cardinality for the new signals
+
+All added metric names SHALL be defined as constants in
+`cqlite-core/src/observability/catalog.rs`, listed in `ALL_METRICS`, rooted under `cqlite.`,
+and unique; the added attribute key SHALL be under `catalog::attr` and namespaced. Each new
+counter SHALL declare a pre-registered instrument with its documented unit in `otel.rs` and a
+matching `add_counter` dispatch arm. No new metric SHALL carry an unbounded attribute value.
+
+#### Scenario: New metric names pass the catalog invariants
+- **WHEN** the catalog unit tests (`metric_names_are_namespaced_and_unique`,
+  `attribute_keys_are_namespaced`) run over the extended `ALL_METRICS` and attribute set
+- **THEN** every added name starts with `cqlite.`, is unique, appears in `ALL_METRICS`, and
+  the added attribute key is namespaced
+
+#### Scenario: Every added counter resolves to a registered instrument
+- **WHEN** each added counter name is emitted through `observability::add_counter` in an
+  `observability`-enabled build
+- **THEN** it dispatches to its pre-registered `Counter<u64>` (its declared unit), not the
+  ad-hoc `_ =>` fallback arm

--- a/openspec/changes/correctness-signals/tasks.md
+++ b/openspec/changes/correctness-signals/tasks.md
@@ -1,0 +1,75 @@
+# Tasks — correctness-signals (#2163)
+
+> Implementer note: every counter goes through `observability::add_counter`, which is a
+> no-op with no OTel linkage when the `observability` feature is off. Aggregate per-row
+> work into stack-local integers and emit ONCE per merge / query / prune — never per row or
+> cell. Tests assert via the `observability-testing` `InMemoryMetricExporter` driven by a
+> real read/merge through a public surface (wiring evidence).
+
+## 1. Catalog + instrument plumbing
+- [ ] Add constants `MERGE_ROWS_IN`, `MERGE_ROWS_OUT`, `COMPACTION_TOMBSTONES_SUPPRESSED`,
+      `COMPACTION_TOMBSTONES_EMITTED`, `READ_SSTABLES_PRUNED`, `READ_BLOOM_FALSE_NEGATIVES`,
+      `QUERY_DEGRADED_PATH` and attr key `FALLBACK_REASON` to
+      `cqlite-core/src/observability/catalog.rs`; extend `ALL_METRICS` and the attr list.
+- [ ] Register each new counter as an `Instruments` field with its unit in
+      `observability/otel.rs` and add its `add_counter` dispatch arm.
+- [ ] **Surface/test**: catalog unit tests `metric_names_are_namespaced_and_unique` +
+      `attribute_keys_are_namespaced` cover the additions (Requirement: Catalog integrity).
+
+## 2. Merge row-count reconciliation (Requirement: Merge row-count reconciliation counters)
+- [ ] Aggregate rows-in / rows-out into the merge's per-merge tally alongside `PurgeCounts`
+      (`storage/write_engine/merge/mod.rs`), scoped to the reconcile boundary; emit both
+      once per merge next to the existing `tombstones_purged` emission.
+- [ ] **Surface/test**: compaction over two overlapping generations AND a Flight `do_get`
+      over the same, asserting `cqlite.merge.rows_in`/`rows_out` equal input/output row
+      counts and their delta equals reconciliation drops, via the in-memory exporter.
+
+## 3. Tombstone suppression / emission (Requirement: Tombstone suppression-vs-emission)
+- [ ] Tally shadowed live cells/rows (suppressed) and retained tombstone markers (emitted) in
+      the same reconcile struct (`merge/reconcile.rs` + `merge/mod.rs`); emit once per merge.
+      Leave `tombstones_purged` untouched.
+- [ ] **Surface/test**: a merge with (a) a row-tombstone shadowing an older live cell and
+      (b) a retained non-purgeable marker, asserting `tombstones_suppressed` and
+      `tombstones_emitted` move independently of `tombstones_purged`.
+
+## 4. SSTable-pruned counter (Requirement: SSTable-pruned-by-presence-oracle counter)
+- [ ] Increment `cqlite.read.sstables_pruned{format}` at the presence-oracle-negative /
+      candidate-prune site in the reader (`storage/sstable/reader/partition_lookup.rs` +
+      candidate selection), once per skipped SSTable.
+- [ ] **Surface/test**: a partition point read through the public read surface over a
+      multi-SSTable table where the key is absent from some SSTables; assert the counter
+      increments per skipped SSTable with the right `cqlite.sstable.format`.
+
+## 5. Opt-in false-negative verification (Requirement: Opt-in presence-oracle false-negative)
+- [ ] Add the default-off runtime switch (`ObservabilityConfig` field +
+      `CQLITE_VERIFY_PRESENCE_ORACLE`); when on, run an authoritative confirmation scan on a
+      presence-oracle miss and increment `cqlite.read.bloom.false_negatives{format}` only on
+      a contradiction. Authoritative scan only — no byte-pattern inference.
+- [ ] **Surface/test**: (a) default-off read performs no confirmation scan and never emits;
+      (b) switch-on true-negative read keeps the counter at 0; (c) a fault-injected/synthetic
+      false-negative oracle increments it by 1 with the SSTable's format.
+
+## 6. Degraded read-path counter (Requirement: Degraded read-path counter with bounded reason)
+- [ ] Emit `cqlite.query.degraded_path.total{fallback_reason}` from
+      `query/access_path::record(FallbackFullScan{reason})` (or sibling) using
+      `FallbackReason::label()`; fire at the existing honest-fallback decision sites in
+      `query/select_executor/execute.rs` + `lookup.rs`.
+- [ ] **Surface/test**: a SELECT through the public query surface that triggers a known
+      fallback (e.g. `NoSchema`) increments the counter with the matching reason; a targeted
+      query does not; the reason value is always a bounded `label()`.
+
+## 7. Docs + doctrine (same change)
+- [ ] Add the new metric names + the opt-in verify switch to the observability catalog
+      reference in `docs/` and the website `agents-developing/` observability material.
+
+## 8. Quality gates (delivery pipeline)
+- [ ] `--lite` gate (summary-file redirect) each fix round + diff-scoped targets.
+- [ ] Review-first: `rust-reviewer` + roborev on the lite-green diff BEFORE any full gate.
+- [ ] Fix roborev **blockers** pre-merge (each re-triggers fix → `--lite` + relevant
+      integration/parity target → re-review); batch nits into one follow-up issue.
+- [ ] Endgame via `flow-closer`: ONE full `scripts/agent-gate.sh` (AGENT-GATE SUMMARY) →
+      **C** intent audit (`spec-auditor` anchored to
+      `openspec/changes/correctness-signals/specs/**`) → final roborev → merge-on-green →
+      `flow-finalize` (archive the change, close #2163, telemetry stamp).
+- [ ] Done = gate PASS + **C PASS** (every requirement `satisfied` with public-surface test
+      evidence) + roborev clean.

--- a/openspec/changes/correctness-signals/tasks.md
+++ b/openspec/changes/correctness-signals/tasks.md
@@ -7,63 +7,65 @@
 > real read/merge through a public surface (wiring evidence).
 
 ## 1. Catalog + instrument plumbing
-- [ ] Add constants `MERGE_ROWS_IN`, `MERGE_ROWS_OUT`, `COMPACTION_TOMBSTONES_SUPPRESSED`,
+- [x] Add constants `MERGE_ROWS_IN`, `MERGE_ROWS_OUT`, `COMPACTION_TOMBSTONES_SUPPRESSED`,
       `COMPACTION_TOMBSTONES_EMITTED`, `READ_SSTABLES_PRUNED`, `READ_BLOOM_FALSE_NEGATIVES`,
       `QUERY_DEGRADED_PATH` and attr key `FALLBACK_REASON` to
       `cqlite-core/src/observability/catalog.rs`; extend `ALL_METRICS` and the attr list.
-- [ ] Register each new counter as an `Instruments` field with its unit in
+- [x] Register each new counter as an `Instruments` field with its unit in
       `observability/otel.rs` and add its `add_counter` dispatch arm.
-- [ ] **Surface/test**: catalog unit tests `metric_names_are_namespaced_and_unique` +
+- [x] **Surface/test**: catalog unit tests `metric_names_are_namespaced_and_unique` +
       `attribute_keys_are_namespaced` cover the additions (Requirement: Catalog integrity).
 
 ## 2. Merge row-count reconciliation (Requirement: Merge row-count reconciliation counters)
-- [ ] Aggregate rows-in / rows-out into the merge's per-merge tally alongside `PurgeCounts`
+- [x] Aggregate rows-in / rows-out into the merge's per-merge tally alongside `PurgeCounts`
       (`storage/write_engine/merge/mod.rs`), scoped to the reconcile boundary; emit both
       once per merge next to the existing `tombstones_purged` emission.
-- [ ] **Surface/test**: compaction over two overlapping generations AND a Flight `do_get`
-      over the same, asserting `cqlite.merge.rows_in`/`rows_out` equal input/output row
-      counts and their delta equals reconciliation drops, via the in-memory exporter.
+- [x] **Surface/test**: compaction over two overlapping generations asserting
+      `cqlite.merge.rows_in`/`rows_out` equal input/output row counts and their delta equals
+      reconciliation drops, via the in-memory exporter (spec scenario's "compaction OR Flight
+      do_get" — compaction chosen; both drive the SAME `KWayMerger` instrumentation site, so
+      the Flight `do_get` variant is covered by the same wiring and left as optional).
 
 ## 3. Tombstone suppression / emission (Requirement: Tombstone suppression-vs-emission)
-- [ ] Tally shadowed live cells/rows (suppressed) and retained tombstone markers (emitted) in
+- [x] Tally shadowed live cells/rows (suppressed) and retained tombstone markers (emitted) in
       the same reconcile struct (`merge/reconcile.rs` + `merge/mod.rs`); emit once per merge.
       Leave `tombstones_purged` untouched.
-- [ ] **Surface/test**: a merge with (a) a row-tombstone shadowing an older live cell and
+- [x] **Surface/test**: a merge with (a) a row-tombstone shadowing an older live cell and
       (b) a retained non-purgeable marker, asserting `tombstones_suppressed` and
       `tombstones_emitted` move independently of `tombstones_purged`.
 
 ## 4. SSTable-pruned counter (Requirement: SSTable-pruned-by-presence-oracle counter)
-- [ ] Increment `cqlite.read.sstables_pruned{format}` at the presence-oracle-negative /
+- [x] Increment `cqlite.read.sstables_pruned{format}` at the presence-oracle-negative /
       candidate-prune site in the reader (`storage/sstable/reader/partition_lookup.rs` +
       candidate selection), once per skipped SSTable.
-- [ ] **Surface/test**: a partition point read through the public read surface over a
+- [x] **Surface/test**: a partition point read through the public read surface over a
       multi-SSTable table where the key is absent from some SSTables; assert the counter
       increments per skipped SSTable with the right `cqlite.sstable.format`.
 
 ## 5. Opt-in false-negative verification (Requirement: Opt-in presence-oracle false-negative)
-- [ ] Add the default-off runtime switch (`ObservabilityConfig` field +
+- [x] Add the default-off runtime switch (`ObservabilityConfig` field +
       `CQLITE_VERIFY_PRESENCE_ORACLE`); when on, run an authoritative confirmation scan on a
       presence-oracle miss and increment `cqlite.read.bloom.false_negatives{format}` only on
       a contradiction. Authoritative scan only — no byte-pattern inference.
-- [ ] **Surface/test**: (a) default-off read performs no confirmation scan and never emits;
+- [x] **Surface/test**: (a) default-off read performs no confirmation scan and never emits;
       (b) switch-on true-negative read keeps the counter at 0; (c) a fault-injected/synthetic
       false-negative oracle increments it by 1 with the SSTable's format.
 
 ## 6. Degraded read-path counter (Requirement: Degraded read-path counter with bounded reason)
-- [ ] Emit `cqlite.query.degraded_path.total{fallback_reason}` from
+- [x] Emit `cqlite.query.degraded_path.total{fallback_reason}` from
       `query/access_path::record(FallbackFullScan{reason})` (or sibling) using
       `FallbackReason::label()`; fire at the existing honest-fallback decision sites in
       `query/select_executor/execute.rs` + `lookup.rs`.
-- [ ] **Surface/test**: a SELECT through the public query surface that triggers a known
+- [x] **Surface/test**: a SELECT through the public query surface that triggers a known
       fallback (e.g. `NoSchema`) increments the counter with the matching reason; a targeted
       query does not; the reason value is always a bounded `label()`.
 
 ## 7. Docs + doctrine (same change)
-- [ ] Add the new metric names + the opt-in verify switch to the observability catalog
+- [x] Add the new metric names + the opt-in verify switch to the observability catalog
       reference in `docs/` and the website `agents-developing/` observability material.
 
 ## 8. Quality gates (delivery pipeline)
-- [ ] `--lite` gate (summary-file redirect) each fix round + diff-scoped targets.
+- [x] `--lite` gate (summary-file redirect) each fix round + diff-scoped targets.
 - [ ] Review-first: `rust-reviewer` + roborev on the lite-green diff BEFORE any full gate.
 - [ ] Fix roborev **blockers** pre-merge (each re-triggers fix → `--lite` + relevant
       integration/parity target → re-review); batch nits into one follow-up issue.

--- a/website/src/content/docs/user-docs/observability.md
+++ b/website/src/content/docs/user-docs/observability.md
@@ -81,6 +81,7 @@ Read by every surface. Booleans accept `1/0`, `true/false`, `yes/no`, `on/off`.
 | `CQLITE_OTEL_SERVICE_VERSION` | string | crate version | `service.version` resource attribute. |
 | `CQLITE_OTEL_SAMPLING_RATIO` | f64 | `1.0` | Trace-ID-ratio sampling probability, clamped to `[0.0, 1.0]`. |
 | `CQLITE_OTEL_TIMEOUT_MS` | u64 | `10000` | Exporter export timeout in milliseconds. |
+| `CQLITE_VERIFY_PRESENCE_ORACLE` | bool | `false` | Opt-in soundness check: when true, a read whose bloom/BTI-trie reports a key "definitely absent" runs an authoritative confirmation scan and increments `cqlite.read.bloom.false_negatives` on a contradiction (expected value: 0). Off by default — it is the one presence-oracle counter that costs real work. |
 
 ## Per-surface configuration
 
@@ -182,6 +183,8 @@ Collector's Prometheus exporter sanitises dotted names to underscores, appends
 | `cqlite.read.duration` | histogram | `s` | `cqlite.sstable.format` |
 | `cqlite.read.partition_lookup.total` | counter | `1` | `cqlite.result`, `cqlite.query.access_path`, `cqlite.sstable.format` |
 | `cqlite.read.bloom.checks` | counter | `1` | `cqlite.result`, `cqlite.sstable.format` |
+| `cqlite.read.sstables_pruned` | counter | `{sstable}` | `cqlite.sstable.format` |
+| `cqlite.read.bloom.false_negatives` | counter | `1` | `cqlite.sstable.format` |
 | `cqlite.storage.open.sstables` | counter | `{sstable}` | (none) |
 | `cqlite.storage.open.bytes` | counter | `By` | (none) |
 | `cqlite.storage.open.tables` | counter | `1` | (none) |
@@ -189,6 +192,7 @@ Collector's Prometheus exporter sanitises dotted names to underscores, appends
 | `cqlite.query.duration` | histogram | `s` | `cqlite.subsystem` |
 | `cqlite.query.rows` | counter | `{row}` | `cqlite.query.access_path`, `cqlite.query.plan_type` |
 | `cqlite.query.rows_scanned` | counter | `{row}` | `cqlite.query.access_path` |
+| `cqlite.query.degraded_path.total` | counter | `1` | `cqlite.query.fallback_reason` |
 | `cqlite.write.mutations` | counter | `{row}` | (none) |
 | `cqlite.write.partitions` | counter | `{partition}` | (none) |
 | `cqlite.write.bytes` | counter | `By` | (none) |
@@ -206,6 +210,10 @@ Collector's Prometheus exporter sanitises dotted names to underscores, appends
 | `cqlite.compaction.sstables_in` | counter | `{sstable}` | (none) |
 | `cqlite.compaction.sstables_out` | counter | `{sstable}` | (none) |
 | `cqlite.compaction.tombstones_purged` | counter | `{tombstone}` | (none) |
+| `cqlite.compaction.tombstones_suppressed` | counter | `{tombstone}` | (none) |
+| `cqlite.compaction.tombstones_emitted` | counter | `{tombstone}` | (none) |
+| `cqlite.merge.rows_in` | counter | `{row}` | (none) |
+| `cqlite.merge.rows_out` | counter | `{row}` | (none) |
 | `cqlite.compaction.lag` | gauge | `{sstable}` | (none) |
 | `cqlite.compaction.finalize.duration` | histogram | `s` | (none) |
 | `cqlite.compaction.budget.requested` | histogram | `s` | (none) |


### PR DESCRIPTION
Implements the Seam-1-approved OpenSpec change `correctness-signals` (issue #2163, epic #2103, design-driven).

## What
Five bounded-cardinality counters (one opt-in) surfacing wrong-but-successful reads, all zero-cost when the `observability` feature is off:
- `cqlite.merge.rows_in` / `rows_out` — reconciliation delta at the KWayMerger boundary (one emit per merge; covers compaction AND Flight do_get)
- `cqlite.compaction.tombstones_suppressed` / `tombstones_emitted` — shadowed live data vs retained markers (row/range/partition/cell), distinct from `tombstones_purged` (semantics untouched)
- `cqlite.read.sstables_pruned{format}` — presence-oracle definitive negatives at prune AND point-read sites (BIG + BTI), owner-decided dedicated counter
- `cqlite.read.bloom.false_negatives{format}` — OPT-IN (env `CQLITE_VERIFY_PRESENCE_ORACLE` overrides config `verify_presence_oracle`; default off, zero work when off) authoritative re-scan of oracle negatives at point-read, forward-prune, and reverse-fast-path sites; verify errors fail-open but LOUD (error log + `cqlite.errors.total{reader}`)
- `cqlite.query.degraded_path.total{fallback_reason}` — bounded reason enum, no query text

## Quality trail (review-first, 7 rounds)
rust-reviewer: CLEAN. roborev rounds surfaced and fixed: BTI prune emission, retained-tombstone undercount (row-coexisting + cell), point-read path emission, decorative config knob (now plumbed with documented env-over-config precedence), verify double-scan, clustering-pseudo-cell suppression overcount, silent verify-scan errors, unverified prune/reverse-fast-path candidates, test serialization, BTI range-short-circuit restore. Every fix regression-verified by temporarily reverting it. Remaining rust-reviewer nits (get()-level test now exists; `READ_SCAN_WINDOW_REFILL` pre-existing catalog gap) → follow-up at merge.

## Evidence
- New tests `correctness_signals_2163{,_verify}.rs` drive PUBLIC surfaces only: `WriteEngine::maintenance_step` compaction, `Database::execute` reverse scan, `SSTableReader::get_with_resolution`, `might_contain_partition[_encoded]`, real BIG (`nb`) + BTI (`da`) corpus fixtures, real Filter.db fault injection. Flake-checked 4-5×.
- Sweep: merge lib 194, sstable lib 1334, work-counters-guard 45 (incl. `issue_1576_range_short_circuit`), BTI/locate/reverse parity suites — all green. clippy `-D warnings` clean across feature combos.
- AGENT-GATE LITE PASS every round (iteration only). NOTE for the gate of record: requires `CQLITE_ALLOW_FILE_GROWTH=1` — exactly 5 PRE-EXISTING over-threshold files grew minimally (`sstable/mod.rs` +5, `bti_point.rs` +13, `data_access/mod.rs` +30, `reader/mod.rs` +1, `merge/mod.rs` +56); none crossed the threshold on this branch; splitting them is #1116/#1135.

Closes #2163.