### PR TITLE
docs: correct legacy-heuristics feature-flag attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ layout, binding structure trees):
 
 ### No-heuristics mandate (issue #28)
 Authoritative metadata only — schema, else `Statistics.db`. No type guessing. Schema-aware decoding
-when schema present. Legacy heuristics live only behind the opt-in `experimental` feature flag.
+when schema present. Legacy heuristics live only behind the opt-in `legacy-heuristics` feature flag.
 Doctrine: [no-heuristics](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/).
 
 ### Supported formats (version floor)
@@ -203,7 +203,8 @@ Without Data.db files, query tests pass but return 0 rows. Dataset pins:
 
 Default (cqlite-core): `all-compression` (LZ4, Snappy, Deflate, Zstd), `state_machine`.
 Non-default: `cli-helpers` (#249), `parquet` (#682), `delta-scan` / `delta-export` (#696/#705),
-`metrics`, `experimental`. Build recipes: `docs/development/dev-cookbook.md`.
+`legacy-heuristics` (opt-in pre-5.0 heuristic fallbacks, #28), `metrics`, `experimental` (bloom-filter
+tests + unimplemented write stubs). Build recipes: `docs/development/dev-cookbook.md`.
 
 ## Troubleshooting
 

--- a/website/src/content/docs/agents-developing/no-heuristics.md
+++ b/website/src/content/docs/agents-developing/no-heuristics.md
@@ -15,7 +15,7 @@ from value patterns. Guessing produced silent wrong answers on valid Cassandra d
 
 - When a schema is present, use it for all type decoding. Schema-aware decoding is not optional.
 - When no schema is present, use the serialization metadata embedded in `Statistics.db` (encoding stats, column definitions). Do not fall back to type guessing.
-- Legacy heuristics (blob fallback, type inference from byte patterns) exist only behind the `experimental` feature flag and are disabled by default.
+- Legacy heuristics (blob fallback, type inference from byte patterns) exist only behind the `legacy-heuristics` feature flag and are disabled by default.
 
 ## What this means in practice
 
@@ -30,14 +30,14 @@ let value = stats.column_type("name")?.decode(bytes)?;
 
 **Not allowed:**
 ```rust
-// Guess type from value — forbidden without feature flag
+// Guess type from value — forbidden without the `legacy-heuristics` feature
 if bytes.len() == 16 { return Ok(CqlValue::Uuid(...)) }
 if bytes.starts_with(b"\x00") { return Ok(CqlValue::Int(...)) }
 ```
 
-**Behind the `experimental` flag only:**
+**Behind the `legacy-heuristics` flag only:**
 ```rust
-#[cfg(feature = "experimental")]
+#[cfg(feature = "legacy-heuristics")]
 fn decode_with_fallback(bytes: &[u8]) -> CqlValue {
     // Heuristic fallback — acceptable only here
 }
@@ -52,7 +52,7 @@ on real production data.
 
 The one test that exercises legacy blob fallback
 (`test_legacy_format_allows_blob_fallback_with_feature`) is explicitly excluded from
-the default `core-tests` gate run. It requires `--features experimental` and is
+the default `core-tests` gate run. It requires `--features legacy-heuristics` and is
 intentionally not in CI defaults.
 
 ## Code quality requirements
@@ -88,7 +88,8 @@ the library must not invent values.
 | `state_machine` (default) | No |
 | `cli-helpers` | No |
 | `metrics` | No |
-| `experimental` | Yes — explicitly opt-in |
+| `experimental` | No (bloom-filter tests + write stubs, not heuristics) |
+| `legacy-heuristics` | Yes — explicitly opt-in |
 
 See [Key source paths](/cqlite/agents-developing/source-map/) for where type decoding lives in the codebase.
 The full feature-flags table and feature-gated test notes are in [Gate Contract](/cqlite/agents-developing/gate-contract/).


### PR DESCRIPTION
## Related Issue
- Related to #28 (no-heuristics mandate)

## Changes Made
Corrects a documentation inaccuracy. The no-heuristics doctrine stated that legacy heuristic fallbacks live behind the `experimental` feature flag. They are gated by the dedicated `legacy-heuristics` feature; `experimental` gates bloom-filter tests and the unimplemented write stubs (`Storage::put`/`delete`), not heuristics.

- `CLAUDE.md`: fix the No-heuristics mandate sentence; list `legacy-heuristics`
  in the feature-flag section and annotate `experimental`.
- `website/.../no-heuristics.md`: update the four `experimental` references and
  the feature table.

Verified against the code: the text-decode fallback in:
`cqlite-core/src/parser/types/mod.rs` and the legacy paths in
`row_cell_state_machine.rs` gate on `legacy-heuristics`, and
`test_legacy_format_allows_blob_fallback_with_feature`
(`cqlite-core/tests/P0_4_modern_format_rejection_tests.rs`) requires
`--features legacy-heuristics`.

### Type of Change
- [x] Documentation update

### Component(s) Affected
- [x] Documentation

## Testing
Docs-only (markdown); no code affected, so the Rust gate does not apply.
- Local pre-merge mode used: not run (docs-only)

## Public Surface & Wiring Evidence
- [ ] This PR adds/changes feature or performance behavior — N/A, pure docs.

## Checklist
- [x] Follows the project's style guidelines
- [x] Self-reviewed
- [x] Documentation updated (this is the doc change)
- [x] No new warnings (docs-only)

## Additional Notes
Follow-ups spotted while verifying, intentionally out of scope here: the
`CLAUDE.md` feature list omits the default `write-support`; and
`.github/hooks/pre-commit` + `setup-quality-gates.sh` reference a removed
`testing-framework` member and deny `clippy::pedantic/nursery` (contradicting
the workspace `allow`). Happy to file/fix separately.