### PR TITLE
perf(#1817): partition-key hoist (decode once/partition) + internal FxHashMap row map

### DIFF
--- a/cqlite-core/src/query/mod.rs
+++ b/cqlite-core/src/query/mod.rs
@@ -75,7 +75,8 @@ pub use writetime_ttl_validator::{
 pub use select_ast::SelectStatement;
 #[cfg(feature = "state_machine")]
 pub use select_executor::{
-    build_row_from_scan, evaluate_leaf, evaluate_predicates, LeafOutcome, SelectExecutor,
+    build_row_from_scan, build_row_from_scan_cached, evaluate_leaf, evaluate_predicates,
+    LeafOutcome, PartitionKeyCache, SelectExecutor,
 };
 #[cfg(feature = "state_machine")]
 pub use select_optimizer::{

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -16,7 +16,7 @@
 
 use super::schemaless_point::classify_schemaless_point_lookup;
 use super::{
-    build_row_from_scan, classify_partition_lookup, collect_capped_materialized,
+    build_row_from_scan_cached, classify_partition_lookup, collect_capped_materialized,
     column_info_from_type_str, honest_targeted_path, parse_table_id, project_expr_reshapes_row,
     scan_pushdown_cap, select_has_writetime_ttl, sort_rows_by_token, validate_token_predicates,
     PartitionLookupOutcome, SSTablePredicate,
@@ -537,13 +537,22 @@ impl SelectExecutor {
             // count up front, so the metric reflects real scan work, while the
             // LIMIT/OFFSET `scan_cap` only bounds the per-row build/predicate work.
             // Counting ACCEPTED rows toward the cap never drops a matching row.
+            // Issue #1817: hoist the partition-key decode across the rows of a
+            // partition (the scan yields a partition's rows consecutively).
+            let mut pk_cache = super::PartitionKeyCache::default();
             collect_capped_materialized(
                 scan_results,
                 scan_cap,
                 predicates,
                 context,
                 |(key, value, cell_meta)| {
-                    let mut row = build_row_from_scan(key, value, projection, schema_opt)?;
+                    let mut row = build_row_from_scan_cached(
+                        key,
+                        value,
+                        projection,
+                        schema_opt,
+                        &mut pk_cache,
+                    )?;
                     // Attach per-cell metadata so evaluate_writetime_ttl can read it.
                     if !cell_meta.is_empty() {
                         row.set_cell_metadata(cell_meta);
@@ -722,12 +731,16 @@ impl SelectExecutor {
             // real scan), while the `scan_cap` only bounds per-row build work.
             // Counting ACCEPTED rows toward the cap (build_row_from_scan returns
             // None for tombstoned/null rows, Issue #191) never drops a match.
+            // Issue #1817: hoist the partition-key decode across a partition's rows.
+            let mut pk_cache = super::PartitionKeyCache::default();
             collect_capped_materialized(
                 scan_results,
                 scan_cap,
                 predicates,
                 context,
-                |(key, value)| build_row_from_scan(key, value, projection, schema_opt),
+                |(key, value)| {
+                    build_row_from_scan_cached(key, value, projection, schema_opt, &mut pk_cache)
+                },
             )?
         };
 

--- a/cqlite-core/src/query/select_executor/limit_pushdown/mod.rs
+++ b/cqlite-core/src/query/select_executor/limit_pushdown/mod.rs
@@ -21,8 +21,8 @@
 //! tombstone / null-row marker or a predicate miss can never under-deliver.
 
 use super::{
-    build_row_from_scan, evaluate_predicates, ExecutionContext, ExecutionStep, QueryRow, Result,
-    SSTablePredicate, SelectExecutor, TableId, TableSchema,
+    build_row_from_scan_cached, evaluate_predicates, ExecutionContext, ExecutionStep, QueryRow,
+    Result, SSTablePredicate, SelectExecutor, TableId, TableSchema,
 };
 use crate::query::select_ast::SelectClause;
 
@@ -211,12 +211,16 @@ impl SelectExecutor {
                 .storage
                 .scan(table, None, None, None, schema_opt)
                 .await?;
+            // Issue #1817: hoist the partition-key decode across a partition's rows.
+            let mut pk_cache = super::PartitionKeyCache::default();
             return collect_capped_materialized(
                 materialized,
                 Some(cap),
                 predicates,
                 context,
-                |(key, value)| build_row_from_scan(key, value, projection, schema_opt),
+                |(key, value)| {
+                    build_row_from_scan_cached(key, value, projection, schema_opt, &mut pk_cache)
+                },
             );
         }
 
@@ -236,12 +240,16 @@ impl SelectExecutor {
             .await?;
 
         let mut results = Vec::new();
+        // Issue #1817: hoist the partition-key decode across a partition's rows.
+        let mut pk_cache = super::PartitionKeyCache::default();
         while let Some(item) = scan_stream.recv().await {
             let (key, value) = item?;
             context.rows_processed += 1;
             context.scan_rows += 1;
 
-            let Some(row) = build_row_from_scan(key, value, projection, schema_opt) else {
+            let Some(row) =
+                build_row_from_scan_cached(key, value, projection, schema_opt, &mut pk_cache)
+            else {
                 continue;
             };
 
@@ -407,12 +415,16 @@ impl SelectExecutor {
             .storage
             .scan(table, None, None, None, schema_opt)
             .await?;
+        // Issue #1817: hoist the partition-key decode across a partition's rows.
+        let mut pk_cache = super::PartitionKeyCache::default();
         collect_capped_materialized(
             authoritative,
             Some(cap),
             predicates,
             context,
-            |(key, value)| build_row_from_scan(key, value, projection, schema_opt),
+            |(key, value)| {
+                build_row_from_scan_cached(key, value, projection, schema_opt, &mut pk_cache)
+            },
         )
     }
 
@@ -451,7 +463,7 @@ impl SelectExecutor {
             if expected.len() >= cap {
                 break;
             }
-            if let Some(row) = build_row_from_scan(key, value, projection, schema_opt) {
+            if let Some(row) = super::build_row_from_scan(key, value, projection, schema_opt) {
                 if evaluate_predicates(&row, predicates)? {
                     expected.push(row.key);
                 }

--- a/cqlite-core/src/query/select_executor/limit_pushdown/tests.rs
+++ b/cqlite-core/src/query/select_executor/limit_pushdown/tests.rs
@@ -1,6 +1,7 @@
+use super::super::build_row_from_scan;
 use super::{
-    build_row_from_scan, collect_capped_materialized, prefix_is_token_ordered, scan_pushdown_cap,
-    ExecutionContext, QueryRow,
+    collect_capped_materialized, prefix_is_token_ordered, scan_pushdown_cap, ExecutionContext,
+    QueryRow,
 };
 use crate::query::select_ast::{
     ColumnRef, ComparisonExpression, ComparisonOperator, ComparisonRightSide, OrderByClause,

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -91,7 +91,7 @@ use writetime_ttl::{
 // Public surface re-exports (kept identical to the pre-split module so
 // `query::mod`'s `pub use select_executor::{...}` resolves unchanged).
 pub use predicate::{evaluate_leaf, evaluate_predicates, LeafOutcome};
-pub use row_build::build_row_from_scan;
+pub use row_build::{build_row_from_scan, build_row_from_scan_cached, PartitionKeyCache};
 pub use writetime_ttl::{FixedClock, NowSeconds};
 
 // `validate_token_predicates` is used by the executor's scan paths.
@@ -115,6 +115,19 @@ thread_local! {
 #[cfg(test)]
 thread_local! {
     pub(crate) static SORT_KEY_EVALUATIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+// Test-only counter for the number of times the partition-key columns are
+// DECODED from the raw key bytes (issue #1817). With the per-partition
+// `PartitionKeyCache`, a partition-grouped scan of `rows` rows over `partitions`
+// distinct partitions increments this once per PARTITION (`O(partitions)`), not
+// once per row (`O(rows)`) as the pre-hoist per-row decode did. Same
+// thread-local rationale as `PROJECTION_NAME_DERIVATIONS`: `build_row_from_scan`
+// is synchronous, so the counter is read on the same thread that ran the builds.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static PARTITION_KEY_DECODES: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
 }
 
@@ -146,7 +159,13 @@ pub(super) fn partition_key_digest(key_bytes: &[u8]) -> u128 {
 /// digest collision between two DISTINCT partition keys — so the fast path is an
 /// `O(1)` digest hash plus a single byte compare, yet correctness never depends
 /// on collision absence.
-type PartitionCounts = HashMap<u128, Vec<(Vec<u8>, u64)>>;
+// Issue #1817 (E2/E8): FxHashMap on the hot PER PARTITION LIMIT counter map. The
+// key is the already-well-mixed 128-bit `partition_key_digest`, so re-SipHashing
+// it (the default `HashMap`) is wasted work; Fx is a fast integer mix. This map is
+// PURELY INTERNAL to the executor — it never crosses the public API surface (it
+// bookkeeps counts, not result rows), so switching its hasher is a hot-path win
+// with no public-type change (`QueryRow.values` stays `HashMap<Arc<str>, Value>`).
+type PartitionCounts = rustc_hash::FxHashMap<u128, Vec<(Vec<u8>, u64)>>;
 
 /// Admit one row under PER PARTITION LIMIT `count`, returning `true` when the
 /// row is within its partition's cap (and incrementing that partition's count).
@@ -986,7 +1005,7 @@ impl SelectExecutor {
     /// independent of digest collisions.
     fn execute_per_partition_limit(rows: Vec<QueryRow>, count: u64) -> Vec<QueryRow> {
         let mut out = Vec::with_capacity(rows.len());
-        let mut counts: PartitionCounts = HashMap::new();
+        let mut counts: PartitionCounts = PartitionCounts::default();
         for row in rows {
             let digest = partition_key_digest(&row.key.0);
             if admit_partition_row(&mut counts, digest, &row.key.0, count) {
@@ -1869,7 +1888,7 @@ mod tests {
     /// valid row is dropped when digests collide.
     #[test]
     fn per_partition_limit_exact_confirm_survives_digest_collision() {
-        let mut counts: PartitionCounts = HashMap::new();
+        let mut counts: PartitionCounts = PartitionCounts::default();
         // A single digest value shared by two genuinely distinct partitions.
         const COLLIDING: u128 = 0xDEAD_BEEF;
         let a = b"partition-a".as_slice();

--- a/cqlite-core/src/query/select_executor/row_build.rs
+++ b/cqlite-core/src/query/select_executor/row_build.rs
@@ -72,6 +72,34 @@ pub(super) fn column_info_from_type_str(
     col_info
 }
 
+/// A decoded partition's identity + its interned `(name, value)` partition-key
+/// columns (Issue #1817). The identity is the raw key bytes PAIRED WITH a cheap
+/// schema fingerprint (`pk_schema_fingerprint`), so a hit requires BOTH to match.
+/// Names are interned once per partition.
+type DecodedPartitionKey = (Arc<[u8]>, u64, Vec<(Arc<str>, Value)>);
+
+/// Cheap fingerprint of a schema's partition-key column list — the `(name, type,
+/// position)` of every partition-key column, in order (Issue #1817, roborev).
+///
+/// The decoded partition-key columns depend ONLY on the raw key bytes and this
+/// list, so two schemas with identical partition-key columns decode identically
+/// and may safely share a cache entry, while any difference (column names, types,
+/// count, order) yields a different fingerprint → a cache MISS and re-decode.
+/// This closes the cross-schema footgun where a cache reused across two tables
+/// whose partition keys share raw bytes but differ in schema would return columns
+/// decoded for the WRONG schema.
+fn pk_schema_fingerprint(schema: &crate::schema::TableSchema) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    schema.partition_keys.len().hash(&mut hasher);
+    for col in &schema.partition_keys {
+        col.name.hash(&mut hasher);
+        col.data_type.hash(&mut hasher);
+        col.position.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 /// Cross-row memoization of the decoded partition-key columns (Issue #1817).
 ///
 /// Partition-key column VALUES are constant within a partition, but
@@ -87,16 +115,19 @@ pub(super) fn column_info_from_type_str(
 ///
 /// If the input is NOT partition-ordered the cache simply misses and re-decodes,
 /// so correctness never depends on ordering — only the decode COUNT does.
-/// A decoded partition's key bytes paired with its interned `(name, value)`
-/// partition-key columns (Issue #1817). Names are interned once per partition.
-type DecodedPartitionKey = (Arc<[u8]>, Vec<(Arc<str>, Value)>);
-
+///
+/// A cache hit also requires the requesting schema's partition-key fingerprint to
+/// match the cached one (roborev): `PartitionKeyCache` is publicly re-exported and
+/// could be reused across tables whose partition keys share raw bytes but differ
+/// in schema — matching the fingerprint makes any such difference a MISS so the
+/// columns are never decoded for the wrong schema.
 #[derive(Default)]
 pub struct PartitionKeyCache {
-    /// Raw partition-key bytes of the last decoded partition and its decoded
-    /// `(interned name, value)` columns (unfiltered by projection — the
-    /// projection filter is applied when cloning into each row, so a cache entry
-    /// is reusable across queries with different projections).
+    /// Raw partition-key bytes + partition-key schema fingerprint of the last
+    /// decoded partition and its decoded `(interned name, value)` columns
+    /// (unfiltered by projection — the projection filter is applied when cloning
+    /// into each row, so a cache entry is reusable across queries with different
+    /// projections).
     decoded: Option<DecodedPartitionKey>,
 }
 
@@ -109,10 +140,10 @@ impl PartitionKeyCache {
         key_bytes: &Arc<[u8]>,
         schema: &crate::schema::TableSchema,
     ) -> &'a [(Arc<str>, Value)] {
-        let hit = self
-            .decoded
-            .as_ref()
-            .is_some_and(|(cached, _)| cached.as_ref() == key_bytes.as_ref());
+        let fingerprint = pk_schema_fingerprint(schema);
+        let hit = self.decoded.as_ref().is_some_and(|(cached, fp, _)| {
+            *fp == fingerprint && cached.as_ref() == key_bytes.as_ref()
+        });
         if !hit {
             // Test-only decode/name-derivation counter (Issue #1817): a cache MISS
             // is exactly one decode. A partition-grouped scan of N rows over P
@@ -145,10 +176,10 @@ impl PartitionKeyCache {
                     Vec::new()
                 }
             };
-            self.decoded = Some((Arc::clone(key_bytes), cols));
+            self.decoded = Some((Arc::clone(key_bytes), fingerprint, cols));
         }
         match &self.decoded {
-            Some((_, cols)) => cols,
+            Some((_, _, cols)) => cols,
             None => &[],
         }
     }
@@ -490,6 +521,42 @@ mod tests {
             "the single-use wrapper decodes once per call ({N}); the shared-cache \
              `build_row_from_scan_cached` is what makes a loop O(partitions)"
         );
+    }
+
+    /// Issue #1817 (roborev): `PartitionKeyCache` is publicly re-exported and could
+    /// be reused across tables whose partition keys happen to share the SAME raw key
+    /// bytes but have DIFFERENT schemas. A hit keyed only on the raw bytes would
+    /// return the columns decoded for the FIRST schema — silently wrong output for
+    /// the second. The schema-fingerprint guard makes the second call a cache MISS,
+    /// re-decoding for its own schema.
+    #[test]
+    fn pk_cache_reuse_across_schemas_does_not_leak_columns() {
+        // Both schemas have a single TEXT partition key, so the SAME raw key bytes
+        // decode to a valid TEXT value under either — but the COLUMN NAME differs
+        // (`id_a` vs `id_b`). A bytes-only cache would return `id_a` for schema B.
+        let schema_a = single_pk_schema("id_a", "text");
+        let schema_b = single_pk_schema("id_b", "text");
+        let key_bytes: Arc<[u8]> = Arc::from(b"shared-key".as_slice());
+
+        let mut cache = PartitionKeyCache::default();
+
+        // First call: schema A. Columns must be decoded for A.
+        let cols_a: Vec<(Arc<str>, Value)> = cache.columns_for(&key_bytes, &schema_a).to_vec();
+        assert_eq!(cols_a.len(), 1);
+        assert_eq!(cols_a[0].0.as_ref(), "id_a");
+        assert_eq!(cols_a[0].1, Value::Text("shared-key".to_string()));
+
+        // Second call: schema B with the SAME key bytes. Columns MUST reflect B
+        // (`id_b`), NOT the cached A columns (`id_a`).
+        let cols_b: Vec<(Arc<str>, Value)> = cache.columns_for(&key_bytes, &schema_b).to_vec();
+        assert_eq!(cols_b.len(), 1);
+        assert_eq!(
+            cols_b[0].0.as_ref(),
+            "id_b",
+            "roborev: a cache reused across schemas must NOT leak the first \
+             schema's partition-key column names — differing schema is a MISS"
+        );
+        assert_eq!(cols_b[0].1, Value::Text("shared-key".to_string()));
     }
 
     /// A suppressed marker (row tombstone / null row) yields no user-visible row.

--- a/cqlite-core/src/query/select_executor/row_build.rs
+++ b/cqlite-core/src/query/select_executor/row_build.rs
@@ -72,6 +72,88 @@ pub(super) fn column_info_from_type_str(
     col_info
 }
 
+/// Cross-row memoization of the decoded partition-key columns (Issue #1817).
+///
+/// Partition-key column VALUES are constant within a partition, but
+/// [`build_row_from_scan`] historically re-decoded them from the raw key bytes
+/// for EVERY row. Because a scan yields the rows of one partition consecutively
+/// (token-ordered full scans, partition-targeted lookups, and the Flight k-way
+/// merge all group a partition's rows), memoizing the last partition's decoded
+/// columns makes the byte-parse + name-intern happen ONCE per partition
+/// (`O(partitions)`) rather than once per row (`O(rows)`). The decoded values are
+/// `clone`d into each row (an `Arc` ref-count bump for the name + a `Value`
+/// clone — each row needs its own copy), so the materialized rows are
+/// byte-identical to the prior per-row decode.
+///
+/// If the input is NOT partition-ordered the cache simply misses and re-decodes,
+/// so correctness never depends on ordering — only the decode COUNT does.
+/// A decoded partition's key bytes paired with its interned `(name, value)`
+/// partition-key columns (Issue #1817). Names are interned once per partition.
+type DecodedPartitionKey = (Arc<[u8]>, Vec<(Arc<str>, Value)>);
+
+#[derive(Default)]
+pub struct PartitionKeyCache {
+    /// Raw partition-key bytes of the last decoded partition and its decoded
+    /// `(interned name, value)` columns (unfiltered by projection — the
+    /// projection filter is applied when cloning into each row, so a cache entry
+    /// is reusable across queries with different projections).
+    decoded: Option<DecodedPartitionKey>,
+}
+
+impl PartitionKeyCache {
+    /// Return the decoded partition-key columns for `key_bytes`, decoding through
+    /// the canonical codec (and interning names once) only on a cache MISS — i.e.
+    /// once per distinct partition when rows arrive partition-grouped.
+    fn columns_for<'a>(
+        &'a mut self,
+        key_bytes: &Arc<[u8]>,
+        schema: &crate::schema::TableSchema,
+    ) -> &'a [(Arc<str>, Value)] {
+        let hit = self
+            .decoded
+            .as_ref()
+            .is_some_and(|(cached, _)| cached.as_ref() == key_bytes.as_ref());
+        if !hit {
+            // Test-only decode/name-derivation counter (Issue #1817): a cache MISS
+            // is exactly one decode. A partition-grouped scan of N rows over P
+            // partitions increments this P times, not N — the O(partitions) pin.
+            #[cfg(test)]
+            super::PARTITION_KEY_DECODES.with(|c| c.set(c.get() + 1));
+
+            let cols = match crate::storage::partition_key_codec::decode_partition_key_columns(
+                key_bytes, schema,
+            ) {
+                // Intern each name into a shared `Arc<str>` ONCE (per partition),
+                // so cloning into a row is a ref-count bump, not a `String` alloc.
+                Ok(pk_columns) => pk_columns
+                    .into_iter()
+                    .map(|(name, value)| (Arc::<str>::from(name), value))
+                    .collect(),
+                // Surface — never silently swallow — a decode failure, so a
+                // missing partition-key column can't ship invisibly (Issue #586).
+                // Cache the empty result so a failing partition is not re-decoded
+                // (and not re-warned) once per row.
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to reconstruct partition-key columns from row key \
+                         (len={} bytes) for {}.{}: {}",
+                        key_bytes.len(),
+                        schema.keyspace,
+                        schema.table,
+                        e
+                    );
+                    Vec::new()
+                }
+            };
+            self.decoded = Some((Arc::clone(key_bytes), cols));
+        }
+        match &self.decoded {
+            Some((_, cols)) => cols,
+            None => &[],
+        }
+    }
+}
+
 /// Build a `QueryRow` from a single `(RowKey, ScanRow)` produced by storage scan,
 /// applying optional projection and synthesising partition-key columns from the
 /// raw key bytes when a schema is available.
@@ -91,11 +173,32 @@ pub(super) fn column_info_from_type_str(
 /// output parity. The `row` carries the decoded non-partition-key cells as the
 /// single [`ScanRow`] row carrier (issue #1334); partition-key columns are
 /// reconstructed from `key`.
+///
+/// This is a thin wrapper over [`build_row_from_scan_cached`] with a single-use
+/// [`PartitionKeyCache`], so a one-off build decodes the key exactly once (as
+/// before). Loops over many rows should call [`build_row_from_scan_cached`] with
+/// a shared cache to hoist the per-partition decode (Issue #1817).
 pub fn build_row_from_scan(
     key: RowKey,
     row: ScanRow,
     projection: &[String],
     schema: Option<&crate::schema::TableSchema>,
+) -> Option<QueryRow> {
+    let mut pk_cache = PartitionKeyCache::default();
+    build_row_from_scan_cached(key, row, projection, schema, &mut pk_cache)
+}
+
+/// [`build_row_from_scan`] with a caller-owned [`PartitionKeyCache`] that hoists
+/// the partition-key decode across the rows of a partition (Issue #1817).
+///
+/// The output is byte-identical to [`build_row_from_scan`] — the cache only
+/// avoids re-decoding the partition key for consecutive rows that share it.
+pub fn build_row_from_scan_cached(
+    key: RowKey,
+    row: ScanRow,
+    projection: &[String],
+    schema: Option<&crate::schema::TableSchema>,
+    pk_cache: &mut PartitionKeyCache,
 ) -> Option<QueryRow> {
     // Suppress tombstoned / absent rows from user-visible output. A row tombstone
     // or null row reaches here as `ScanRow::Marker` (Issue #505); it must never
@@ -121,30 +224,16 @@ pub fn build_row_from_scan(
         }
     }
     // Cassandra never serialises partition-key columns in the cell payload;
-    // reconstruct them from the raw row key when the schema is known. We
-    // decode through the canonical codec shared with the write engine so
-    // single-component (raw bytes) and composite (`[u16 len][bytes][0x00]`)
-    // keys are handled identically on both paths (Issue #586).
+    // reconstruct them from the raw row key when the schema is known. We decode
+    // through the canonical codec shared with the write engine so single-component
+    // (raw bytes) and composite (`[u16 len][bytes][0x00]`) keys are handled
+    // identically on both paths (Issue #586). Issue #1817: the decode is memoized
+    // per partition by `pk_cache`, so consecutive rows of a partition clone the
+    // already-decoded columns instead of re-parsing the key bytes.
     if let Some(schema) = schema {
-        match crate::storage::partition_key_codec::decode_partition_key_columns(&key.0, schema) {
-            Ok(pk_columns) => {
-                for (name, value) in pk_columns {
-                    if project(&name) {
-                        row_values.insert(name.into(), value);
-                    }
-                }
-            }
-            // Surface — never silently swallow — a decode failure, so a
-            // missing partition-key column can't ship invisibly (Issue #586).
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to reconstruct partition-key columns from row key \
-                     (len={} bytes) for {}.{}: {}",
-                    key.0.len(),
-                    schema.keyspace,
-                    schema.table,
-                    e
-                );
+        for (name, value) in pk_cache.columns_for(&key.0, schema) {
+            if project(name) {
+                row_values.insert(Arc::clone(name), value.clone());
             }
         }
     }
@@ -271,6 +360,135 @@ mod tests {
             "issue #1584: value map must be pre-sized to the decoded cell count \
              (>= 8), not grown from empty to the projected size; got capacity {}",
             row.values.capacity()
+        );
+    }
+
+    /// Issue #1817: partition-key columns are CONSTANT within a partition, so a
+    /// [`PartitionKeyCache`] shared across the rows of a partition must decode the
+    /// key ONCE (`O(partitions)`), not once per row (`O(rows)`). Pinned by the
+    /// deterministic `PARTITION_KEY_DECODES` counter — NOT a wall-clock bench.
+    ///
+    /// Red-first: with the pre-hoist per-row decode (or a fresh cache per row),
+    /// `N` rows of one partition would record `N` decodes; the shared cache makes
+    /// it exactly `1`. Output must stay byte-identical — every row still carries
+    /// the reconstructed `id` PK column plus its own regular cell.
+    #[test]
+    fn pk_decode_is_once_per_partition_not_per_row() {
+        use super::super::PARTITION_KEY_DECODES;
+
+        let schema = single_pk_schema("id", "text");
+        let key_bytes = b"partition-A".to_vec();
+        const N: usize = 50;
+
+        PARTITION_KEY_DECODES.with(|c| c.set(0));
+        let mut pk_cache = PartitionKeyCache::default();
+        let mut rows = Vec::with_capacity(N);
+        for i in 0..N {
+            let cells = ScanRow::Row(vec![(Arc::from("v"), Value::Integer(i as i32))]);
+            let row = build_row_from_scan_cached(
+                RowKey::new(key_bytes.clone()),
+                cells,
+                &[],
+                Some(&schema),
+                &mut pk_cache,
+            )
+            .expect("a live row must build");
+            rows.push(row);
+        }
+        let decodes = PARTITION_KEY_DECODES.with(|c| c.get());
+
+        assert_eq!(
+            decodes, 1,
+            "issue #1817: {N} rows of ONE partition must decode the partition key \
+             ONCE (O(partitions)), not once per row (would be {N})"
+        );
+        // Output byte-identical: every row has the reconstructed PK + its own cell.
+        assert_eq!(rows.len(), N);
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(
+                row.values.get("id"),
+                Some(&Value::Text("partition-A".to_string())),
+                "each row must carry the reconstructed PK column value"
+            );
+            assert_eq!(row.values.get("v"), Some(&Value::Integer(i as i32)));
+        }
+    }
+
+    /// Issue #1817: across `P` DISTINCT partitions (each with several rows), a
+    /// shared cache decodes exactly `P` times — the decode count tracks
+    /// `O(partitions)`, independent of the total row count. Rows are supplied
+    /// partition-grouped, as every scan/merge site delivers them.
+    #[test]
+    fn pk_decode_counts_partitions_not_rows() {
+        use super::super::PARTITION_KEY_DECODES;
+
+        let schema = single_pk_schema("id", "text");
+        const P: usize = 4;
+        const ROWS_PER_PART: usize = 10;
+
+        PARTITION_KEY_DECODES.with(|c| c.set(0));
+        let mut pk_cache = PartitionKeyCache::default();
+        let mut total_rows = 0;
+        for p in 0..P {
+            let key_bytes = format!("partition-{p}").into_bytes();
+            for r in 0..ROWS_PER_PART {
+                let cells = ScanRow::Row(vec![(Arc::from("v"), Value::Integer(r as i32))]);
+                let row = build_row_from_scan_cached(
+                    RowKey::new(key_bytes.clone()),
+                    cells,
+                    &[],
+                    Some(&schema),
+                    &mut pk_cache,
+                )
+                .expect("a live row must build");
+                assert_eq!(
+                    row.values.get("id"),
+                    Some(&Value::Text(format!("partition-{p}"))),
+                    "PK column reconstructed per partition"
+                );
+                total_rows += 1;
+            }
+        }
+        let decodes = PARTITION_KEY_DECODES.with(|c| c.get());
+
+        assert_eq!(total_rows, P * ROWS_PER_PART);
+        assert_eq!(
+            decodes,
+            P,
+            "issue #1817: decode count must be O(partitions) = {P}, not O(rows) = {}",
+            P * ROWS_PER_PART
+        );
+    }
+
+    /// Issue #1817 (control / red-anchor): the wrapper [`build_row_from_scan`]
+    /// uses a FRESH single-use cache each call, so calling it per row decodes per
+    /// row — this is exactly the O(rows) behavior the shared-cache hoist replaces.
+    /// It documents that the hoist requires threading ONE cache through the loop
+    /// (a per-row fresh cache is the pre-fix cost). Output is still byte-identical.
+    #[test]
+    fn build_row_from_scan_wrapper_decodes_per_call() {
+        use super::super::PARTITION_KEY_DECODES;
+
+        let schema = single_pk_schema("id", "text");
+        let key_bytes = b"partition-A".to_vec();
+        const N: usize = 20;
+
+        PARTITION_KEY_DECODES.with(|c| c.set(0));
+        for i in 0..N {
+            let cells = ScanRow::Row(vec![(Arc::from("v"), Value::Integer(i as i32))]);
+            let row =
+                build_row_from_scan(RowKey::new(key_bytes.clone()), cells, &[], Some(&schema))
+                    .expect("a live row must build");
+            assert_eq!(
+                row.values.get("id"),
+                Some(&Value::Text("partition-A".to_string()))
+            );
+        }
+        let decodes = PARTITION_KEY_DECODES.with(|c| c.get());
+        assert_eq!(
+            decodes, N,
+            "the single-use wrapper decodes once per call ({N}); the shared-cache \
+             `build_row_from_scan_cached` is what makes a loop O(partitions)"
         );
     }
 

--- a/cqlite-core/src/query/select_executor/stream_agg.rs
+++ b/cqlite-core/src/query/select_executor/stream_agg.rs
@@ -13,8 +13,9 @@ use super::aggregation::{
     init_aggregate_accumulators, update_aggregate, AggregationState,
 };
 use super::{
-    build_row_from_scan, classify_partition_lookup, evaluate_predicates, validate_token_predicates,
-    AccessPath, ExecutionContext, ExecutionStep, PartitionLookupOutcome, SelectExecutor,
+    build_row_from_scan_cached, classify_partition_lookup, evaluate_predicates,
+    validate_token_predicates, AccessPath, ExecutionContext, ExecutionStep, PartitionKeyCache,
+    PartitionLookupOutcome, SelectExecutor,
 };
 use crate::query::result::QueryRow;
 use crate::query::select_ast::WhereExpression;
@@ -164,12 +165,17 @@ impl SelectExecutor {
             .storage
             .scan_stream_batched(table, None, None, schema_opt, AGG_FOLD_SCAN_BUFFER)
             .await?;
+        // Issue #1817: hoist the partition-key decode across a partition's rows;
+        // the cache persists across batches (a partition may straddle a batch).
+        let mut pk_cache = PartitionKeyCache::default();
         while let Some(batch) = scan_stream.recv().await {
             for (key, value) in batch? {
                 context.rows_processed += 1;
                 context.scan_rows += 1;
 
-                let Some(row) = build_row_from_scan(key, value, projection, schema_opt) else {
+                let Some(row) =
+                    build_row_from_scan_cached(key, value, projection, schema_opt, &mut pk_cache)
+                else {
                     continue;
                 };
                 if !evaluate_predicates(&row, predicates)? {

--- a/cqlite-core/src/query/select_executor/streaming.rs
+++ b/cqlite-core/src/query/select_executor/streaming.rs
@@ -6,8 +6,9 @@
 //! directly; logic, ordering, and error handling are unchanged.
 
 use super::{
-    build_row_from_scan, classify_partition_lookup, evaluate_predicates, honest_targeted_path,
-    partition_key_digest, sort_rows_by_token, validate_token_predicates, PartitionLookupOutcome,
+    build_row_from_scan_cached, classify_partition_lookup, evaluate_predicates,
+    honest_targeted_path, partition_key_digest, sort_rows_by_token, validate_token_predicates,
+    PartitionKeyCache, PartitionLookupOutcome,
 };
 use super::{
     AccessPath, ExecutionStep, QueryRow, Result, SelectExecutor, StorageEngine, TableId,
@@ -106,11 +107,19 @@ impl SelectExecutor {
                             AccessPath::StreamingPartitionLookup,
                             engaged,
                         ));
+                        // Issue #1817: hoist the partition-key decode across a
+                        // partition's rows (a lookup returns one partition's rows).
+                        let mut pk_cache = PartitionKeyCache::default();
                         for (key, value) in rows {
                             let part_sig =
                                 per_partition_limit.map(|_| partition_key_digest(&key.0));
-                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
-                            else {
+                            let Some(row) = build_row_from_scan_cached(
+                                key,
+                                value,
+                                projection,
+                                schema_opt,
+                                &mut pk_cache,
+                            ) else {
                                 continue;
                             };
                             if !evaluate_predicates(&row, predicates)? {
@@ -175,11 +184,20 @@ impl SelectExecutor {
                             all_engaged,
                         ));
                         sort_rows_by_token(&mut combined);
+                        // Issue #1817: hoist the partition-key decode across a
+                        // partition's rows (combined is token-sorted, so a
+                        // partition's rows are contiguous).
+                        let mut pk_cache = PartitionKeyCache::default();
                         for (key, value) in combined {
                             let part_sig =
                                 per_partition_limit.map(|_| partition_key_digest(&key.0));
-                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
-                            else {
+                            let Some(row) = build_row_from_scan_cached(
+                                key,
+                                value,
+                                projection,
+                                schema_opt,
+                                &mut pk_cache,
+                            ) else {
                                 continue;
                             };
                             if !evaluate_predicates(&row, predicates)? {
@@ -241,14 +259,24 @@ impl SelectExecutor {
                         .scan_stream_batched(table, None, None, schema_opt, buffer_size)
                         .await?;
 
+                    // Issue #1817: hoist the partition-key decode across a
+                    // partition's rows. The cache persists ACROSS batches (a
+                    // partition may straddle a batch boundary), so a partition's
+                    // key is decoded once regardless of batching.
+                    let mut pk_cache = PartitionKeyCache::default();
                     while let Some(batch) = scan_stream.recv().await {
                         for (key, value) in batch? {
                             // Capture the partition-key digest before `key` is moved
                             // into row construction (only when needed).
                             let part_sig =
                                 per_partition_limit.map(|_| partition_key_digest(&key.0));
-                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
-                            else {
+                            let Some(row) = build_row_from_scan_cached(
+                                key,
+                                value,
+                                projection,
+                                schema_opt,
+                                &mut pk_cache,
+                            ) else {
                                 continue;
                             };
 

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -26,7 +26,9 @@ use arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
 
 use cqlite_core::export::{build_arrow_schema, rows_to_record_batch, ArrowConvertError};
-use cqlite_core::query::{build_row_from_scan, AccessPath, ColumnInfo, QueryRow};
+use cqlite_core::query::{
+    build_row_from_scan_cached, AccessPath, ColumnInfo, PartitionKeyCache, QueryRow,
+};
 use cqlite_core::schema::{CqlType, TableSchema};
 use cqlite_core::storage::write_engine::merge::{MergeStep, RowData};
 use cqlite_core::storage::write_engine::KWayMerger;
@@ -658,6 +660,9 @@ impl MergeProducer {
         let mut meter = ScanProgressMeter::new(progress, AccessPath::FullScan.label());
         let mut buffer: Vec<QueryRow> = Vec::with_capacity(self.batch_size);
         let mut emitted: u64 = 0;
+        // Issue #1817: one partition-key decode cache for the whole merge; each
+        // partition's rows arrive consecutively, so its key decodes once.
+        let mut pk_cache = PartitionKeyCache::default();
 
         'partitions: loop {
             if cancel.is_cancelled() {
@@ -679,7 +684,7 @@ impl MergeProducer {
                 // Build the FULL row so predicates can reference any column, even
                 // one projected out of the output. Output projection is applied
                 // separately via `self.columns` during Arrow conversion.
-                let Some(row) = self.entry_to_row(&key.key, entry.row_data) else {
+                let Some(row) = self.entry_to_row(&key.key, entry.row_data, &mut pk_cache) else {
                     continue;
                 };
                 // Count a row materialised/examined by the scan (BEFORE the
@@ -757,6 +762,9 @@ impl MergeProducer {
         cancel: &CancelFlag,
         state: &mut crate::agg::AggState,
     ) -> Result<(), ProducerError> {
+        // Issue #1817: one partition-key decode cache for the whole aggregate
+        // merge; each partition's rows arrive consecutively, so its key decodes once.
+        let mut pk_cache = PartitionKeyCache::default();
         loop {
             if cancel.is_cancelled() {
                 return Err(ProducerError::Cancelled);
@@ -771,7 +779,7 @@ impl MergeProducer {
                 }
             }
             for entry in rows {
-                let Some(row) = self.entry_to_row(&key.key, entry.row_data) else {
+                let Some(row) = self.entry_to_row(&key.key, entry.row_data, &mut pk_cache) else {
                     continue;
                 };
                 if let Some(filter) = &self.spec.filter {
@@ -790,7 +798,12 @@ impl MergeProducer {
     ///
     /// The row carries ALL columns (no projection) so predicate evaluation can
     /// reference any column; output projection is applied later via `self.columns`.
-    fn entry_to_row(&self, partition_key: &[u8], row_data: RowData) -> Option<QueryRow> {
+    fn entry_to_row(
+        &self,
+        partition_key: &[u8],
+        row_data: RowData,
+        pk_cache: &mut PartitionKeyCache,
+    ) -> Option<QueryRow> {
         let cells = match row_data {
             RowData::Live { cells } => cells,
             // Whole-row deletion: suppress from output.
@@ -810,7 +823,16 @@ impl MergeProducer {
             .collect();
 
         let key = RowKey::new(partition_key.to_vec());
-        build_row_from_scan(key, ScanRow::Row(row_cells), &[], Some(&self.schema))
+        // Issue #1817: reuse the caller's per-merge partition-key decode cache so a
+        // partition's rows (emitted consecutively by the k-way merger) decode the
+        // key once, not once per row. Output is byte-identical.
+        build_row_from_scan_cached(
+            key,
+            ScanRow::Row(row_cells),
+            &[],
+            Some(&self.schema),
+            pk_cache,
+        )
     }
 
     /// Merge `paths` WITHOUT the input prune, relying only on the per-partition


### PR DESCRIPTION
Closes #1817.

E2 follow-up (deferred from #1584, part of read-path perf epic E/#1517). Behavior-preserving perf — oracle-driven, pinned counter tests.

## What changed
1. **Partition-key hoist** — decode partition-key column values **once per partition** and reuse across that partition's rows (was per-row) via a `PartitionKeyCache`, threaded through all scan sites (execute.rs metadata + materialized scans, streaming.rs Targeted/MultiTargeted/Fallback branches, stream_agg, limit_pushdown, and the Flight producer k-way merge).
2. **Internal FxHashMap** on the per-partition counter/aggregation map only — **public `QueryRow.values` stays `std HashMap<Arc<str>, Value>`** (no public-API break; resolves the item-1 design concern the safe way per acceptance criterion b).

## Acceptance criteria
- [x] PK values decoded once per partition — counter tests `pk_decode_is_once_per_partition_not_per_row` (N=50 same-partition → decodes==1) and `pk_decode_counts_partitions_not_rows` (P=4 partitions × 10 rows → decodes==4) assert **O(partitions) not O(rows)**.
- [x] FxHashMap applied to hot-path map **without** a public-API break (internal-only; `QueryRow.values` unchanged) — item-1 rides here, not K3.
- [x] Row content/order/JSON byte-identical (asserted in the counter tests; 33-table parity via full gate).

## Review
- **rust-reviewer: clean** — cache invalidation sound by construction (exact-byte key compare; correctness independent of partition ordering); public API invariant confirmed.
- **roborev (job 3797): 1 Medium** — `PartitionKeyCache` ignored schema on a public re-exported surface (cross-schema same-key-bytes column leak). **Fixed** in `3024079e`: cache now keys on a `u64` schema fingerprint (partition-key column name/type/position) + raw bytes; differing schema is a miss and re-decodes. New pinned test `pk_cache_reuse_across_schemas_does_not_leak_columns` (fails before / passes after). Re-review clean (job 3799).

## Notes
- `CQLITE_ALLOW_FILE_GROWTH=1` required — `select_executor/mod.rs` (+19) and `cqlite-flight/producer.rs` (+22) are pre-existing ~3× over the file-size threshold; splitting is #1116/#1135 scope, not this perf change.
- Deferred nits (follow-up issue): `Arc::ptr_eq` fast-path before the cache-hit byte compare; `schemaless_point` uncached-wrapper cleanup (harmless — schema is `None`, no decode).
