### PR TITLE
fix(#2228): start==end token range means full ring — silent-zero-rows fix, both sides

### DIFF
--- a/cqlite-flight/src/filter.rs
+++ b/cqlite-flight/src/filter.rs
@@ -77,6 +77,13 @@ impl TokenFilter {
     /// `(start, MAX] ∪ [MIN, end]`, so overlap holds if the SSTable reaches past
     /// `start` OR starts at or before `end`.
     pub fn overlaps(&self, min_token: i64, max_token: i64) -> bool {
+        // #2228: equal endpoints (`(T, T]`) denote the FULL ring, so every
+        // SSTable span overlaps. Mirror the per-token semantics in
+        // [`token_in_half_open_range`] regardless of the `wraparound` flag,
+        // otherwise SSTable-level pruning could silently drop every table.
+        if self.start == self.end {
+            return true;
+        }
         if self.wraparound {
             max_token > self.start || min_token <= self.end
         } else {
@@ -557,6 +564,26 @@ mod tests {
         assert!(!tf.overlaps(101, 200), "min_token>end excluded");
         // Span covering the whole range.
         assert!(tf.overlaps(i64::MIN, i64::MAX));
+    }
+
+    #[test]
+    fn overlaps_full_ring_equal_endpoints() {
+        // #2228: an equal-endpoint range `(T, T]` is the full ring, so every
+        // SSTable span overlaps it regardless of the `wraparound` flag.
+        for wrap in [true, false] {
+            let tf = TokenFilter {
+                start: 42,
+                end: 42,
+                wraparound: wrap,
+            };
+            assert!(tf.overlaps(i64::MIN, i64::MAX), "whole ring (wrap={wrap})");
+            assert!(tf.overlaps(100, 200), "span entirely above T (wrap={wrap})");
+            assert!(
+                tf.overlaps(-200, -100),
+                "span entirely below T (wrap={wrap})"
+            );
+            assert!(tf.overlaps(42, 42), "single-token span at T (wrap={wrap})");
+        }
     }
 
     #[test]

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -1534,11 +1534,11 @@ mod tests {
         let p = MergeProducer::with_spec(schema.clone(), 1024, all).unwrap();
         assert_eq!(total_rows(&p.produce(&DirSource::new(&dir)).unwrap()), 5);
 
-        // Empty range (MAX, MAX] keeps nothing.
+        // Empty narrow range (MAX-1, MAX] (equal endpoints = FULL ring per #2228).
         let none = spec_from(
             &schema,
             FlightTicket {
-                token_start: Some(i64::MAX),
+                token_start: Some(i64::MAX - 1),
                 token_end: Some(i64::MAX),
                 ..Default::default()
             },
@@ -2445,11 +2445,11 @@ mod tests {
             .collect::<Vec<_>>();
         let (_temp, _data, dir) = build_sstables(&schema, vec![rows]);
 
-        // A token range that excludes everything: (MAX, MAX].
+        // Excludes everything: narrow (MAX-1, MAX] (equal endpoints = ring, #2228).
         let spec = spec_from(
             &schema,
             FlightTicket {
-                token_start: Some(i64::MAX),
+                token_start: Some(i64::MAX - 1),
                 token_end: Some(i64::MAX),
                 ..Default::default()
             },

--- a/cqlite-flight/src/ticket.rs
+++ b/cqlite-flight/src/ticket.rs
@@ -412,6 +412,14 @@ impl FlightTicket {
 /// wraparound range (crossing the ring's min-token boundary) keeps
 /// `token > start || token <= end`.
 pub fn token_in_half_open_range(token: i64, start: i64, end: i64, wraparound: bool) -> bool {
+    // #2228: equal endpoints denote the FULL ring, not the empty set — matching
+    // Cassandra's convention where a range `(T, T]` covers every token. The
+    // split planner can emit this for single-token topologies. Accept every
+    // token here regardless of the `wraparound` flag so no partition is silently
+    // dropped (which would make `SELECT *` return 0 rows with no error).
+    if start == end {
+        return true;
+    }
     if wraparound {
         token > start || token <= end
     } else {
@@ -851,6 +859,27 @@ mod tests {
         assert!(!t.token_in_range(0), "the gap is excluded");
         assert!(!t.token_in_range(100), "start still exclusive");
         assert!(t.token_in_range(-100), "end still inclusive");
+    }
+
+    #[test]
+    fn full_ring_range_with_equal_endpoints_accepts_all() {
+        // #2228: a range whose endpoints are equal (`(T, T]`) denotes the FULL
+        // ring, matching Cassandra's convention — NOT the empty set. The
+        // Sidecar/split planner may emit this for single-token topologies. It
+        // must accept every token regardless of the `wraparound` flag, so guard
+        // both flag states here.
+        for wrap in [true, false] {
+            let t = ticket_with_range(Some(42), Some(42), wrap);
+            assert!(t.token_in_range(i64::MIN), "MIN accepted (wrap={wrap})");
+            assert!(t.token_in_range(i64::MAX), "MAX accepted (wrap={wrap})");
+            assert!(t.token_in_range(42), "T itself accepted (wrap={wrap})");
+            assert!(t.token_in_range(41), "T-1 accepted (wrap={wrap})");
+            assert!(t.token_in_range(43), "T+1 accepted (wrap={wrap})");
+            assert!(
+                t.token_in_range(0),
+                "arbitrary token accepted (wrap={wrap})"
+            );
+        }
     }
 
     #[test]

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -104,6 +104,13 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
             String host = hostOnly(replica);
             long start = range.startToken();
             long end = range.endToken();
+            // #2228: equal endpoints (start == end) denote the FULL ring — the
+            // Cassandra convention for a range `(T, T]` — not the empty set. The
+            // Sidecar can emit this for single-token/single-node topologies.
+            // Treating it as wraparound makes the flight-side filter accept every
+            // token (`token > T || token <= T`), so `SELECT *` scans everything
+            // instead of silently returning 0 rows.
+            boolean wraparound = start >= end;
             splits.add(new CqliteFlightSplit(
                     table.keyspace(),
                     table.table(),
@@ -112,7 +119,7 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
                     flightPort,
                     start,
                     end,
-                    start > end,
+                    wraparound,
                     snapshot));
         }
         return splits;

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
@@ -67,6 +67,25 @@ class CqliteFlightSplitManagerTest {
     }
 
     @Test
+    void fullRingRangeWithEqualEndpointsScansEverything() {
+        // #2228: a single full-ring range represented as `(T, T]` (start == end,
+        // a common single-token/single-node representation) must be treated as a
+        // wraparound/full-ring split, not the empty set. Otherwise the flight
+        // filter evaluates `token > T && token <= T` and `SELECT *` silently
+        // returns 0 rows.
+        var resp = new TokenRangeReplicasResponse(
+                List.of(),
+                List.of(range("42", "42", Map.of("dc1", List.of("10.0.0.1")))));
+        var splits = CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815);
+        assertEquals(1, splits.size());
+        assertEquals(42, splits.get(0).tokenStart());
+        assertEquals(42, splits.get(0).tokenEnd());
+        assertTrue(
+                splits.get(0).wraparound(),
+                "start == end is the full ring — must scan everything");
+    }
+
+    @Test
     void stampsSnapshotOnEverySplit() {
         var resp = new TokenRangeReplicasResponse(
                 List.of(),


### PR DESCRIPTION
Closes #2228

## What
`start==end` token range now means FULL ring, consistently on both sides (silent-missing-rows fix, Epic AM #2226 Wave 0):
- Java: `CqliteFlightSplitManager` `wraparound = start >= end`
- Rust: `token_in_half_open_range` (ticket.rs) + `TokenFilter::overlaps` (filter.rs) short-circuit `start==end → true` regardless of the wraparound flag (defense in depth)
- Tests pin MIN/MAX/T/T±1 on both sides, both flag states; existing `start<end` / `start>end` semantics unchanged. Two producer tests that mis-used `(MAX,MAX]` as an "empty" stand-in now use the genuine narrow `(MAX-1,MAX]`.

## Review-first (#2086)
- rust-reviewer: CLEAN (1 nit — comment for unreachable mixed-bound case; batched to follow-up)
- roborev (job 1557, codex): No issues found

## Gate note
`ticket.rs` (878→907) and `filter.rs` (893→920) are pre-existing over-threshold files grown by fix+tests; full gate runs with `CQLITE_ALLOW_FILE_GROWTH=1` per the campsite-rule escape hatch — splitting tracked by epic #1116, out of scope here.

Full gate of record runs in flow-closer pre-merge (lite: PASS @ ad2bad05).
