### PR TITLE
test(#2232): cqlite-flight transport-level do_get tests — LIMIT, predicate+projection, live-mode file-set

### DIFF
--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -250,6 +250,14 @@ fn do_get_over_transport_real_compressed_fixture() {
 /// `data_dir` holds TWO `nb-*-big-Data.db` SSTables the server must k-way-merge.
 /// A single-SSTable fixture would let a broken merge pass the LIMIT test, so the
 /// >N rows MUST span ≥2 SSTables to catch a #2157-class early-stop break.
+///
+/// Key assignment is **interleaved** across the two flushes — EVEN-numbered keys
+/// (`k000000`, `k000002`, …) go to flush 1 and ODD-numbered keys (`k000001`,
+/// `k000003`, …) to flush 2. This is what makes the LIMIT test meaningful: after
+/// the merge sorts keys ascending, the first `N` rows for any `N >= 2`
+/// necessarily draw from BOTH generations, so an implementation that reads only
+/// one SSTable (or drops the second generation) can no longer return N rows and
+/// pass. [`key_index`]/the LIMIT test assert that span directly.
 fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::PathBuf) {
     assert!(
         total >= 4,
@@ -265,9 +273,10 @@ fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::P
         .enable_all()
         .build()
         .unwrap();
-    let half = total / 2;
     // Distinct keys with a fixed 6-digit width so string order == numeric order.
-    for i in 0..half {
+    // Flush 1 = even indices, flush 2 = odd indices, so the sorted first-N result
+    // interleaves rows from both SSTables (see the doc comment above).
+    for i in (0..total).step_by(2) {
         engine
             .write(write_row(&format!("k{i:06}"), &format!("v{i}"), 100))
             .expect("write");
@@ -275,7 +284,7 @@ fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::P
     rt.block_on(engine.flush())
         .expect("flush 1")
         .expect("info 1");
-    for i in half..total {
+    for i in (1..total).step_by(2) {
         engine
             .write(write_row(&format!("k{i:06}"), &format!("v{i}"), 100))
             .expect("write");
@@ -303,8 +312,8 @@ fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::P
     (temp, data_dir)
 }
 
-/// Count total rows and collect the values of the `key` column across all
-/// decoded batches. Used by the predicate/projection assertions.
+/// Collect the string values of the named `column` across all decoded batches.
+/// Used by the predicate/projection and LIMIT-span assertions.
 fn keys_of(batches: &[RecordBatch], column: &str) -> Vec<String> {
     let mut out = Vec::new();
     for batch in batches {
@@ -324,10 +333,22 @@ fn keys_of(batches: &[RecordBatch], column: &str) -> Vec<String> {
     out
 }
 
-/// **LIMIT enforcement over the wire.** A ticket with `limit: Some(N)` against a
-/// fixture holding >N rows spanning TWO SSTables must decode to EXACTLY N rows
-/// through the real gRPC transport. This catches a #2157-class early-stop break
-/// where the k-way merge fails to apply the cap after merging generations.
+/// Parse the numeric index `N` out of a `kNNNNNN` fixture key. Even indices were
+/// flushed to SSTable 1, odd indices to SSTable 2 (see [`build_multi_sstable_fixture`]).
+fn key_index(key: &str) -> usize {
+    key.strip_prefix('k')
+        .and_then(|n| n.parse().ok())
+        .unwrap_or_else(|| panic!("fixture key {key:?} must be of the form kNNNNNN"))
+}
+
+/// **LIMIT enforcement over the wire, PROVABLY across ≥2 SSTables.** A ticket with
+/// `limit: Some(N)` against a fixture holding >N rows must decode to EXACTLY N rows
+/// through the real gRPC transport. Because the fixture interleaves keys across two
+/// flushes (even → SSTable 1, odd → SSTable 2), the sorted first-N result MUST draw
+/// from BOTH generations — so we also assert the returned key set contains at least
+/// one flush-1 key AND at least one flush-2 key. This catches a #2157-class early-stop
+/// break where the k-way merge reads only one generation (which would still return N
+/// contiguous rows and pass a naive count-only assertion).
 #[test]
 fn do_get_over_transport_enforces_limit() {
     let total = 20usize;
@@ -343,10 +364,24 @@ fn do_get_over_transport_enforces_limit() {
 
     let svc = CqliteFlightService::new(data_dir, 8192);
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let rows = rt.block_on(do_get_rows_over_transport(svc, ticket));
+    let batches = rt.block_on(do_get_batches_over_transport(svc, ticket));
+
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(
         rows, limit as usize,
         "a LIMIT {limit} ticket over {total} rows across 2 SSTables must decode EXACTLY {limit} rows"
+    );
+
+    // The capped result must genuinely span both generations: at least one key
+    // from flush 1 (even index) AND at least one from flush 2 (odd index).
+    let keys = keys_of(&batches, "key");
+    assert_eq!(keys.len(), limit as usize, "one key per returned row");
+    let from_flush1 = keys.iter().any(|k| key_index(k) % 2 == 0);
+    let from_flush2 = keys.iter().any(|k| key_index(k) % 2 == 1);
+    assert!(
+        from_flush1 && from_flush2,
+        "capped LIMIT {limit} result must span BOTH SSTables (flush1={from_flush1}, \
+         flush2={from_flush2}); keys={keys:?}"
     );
 }
 

--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -10,8 +10,11 @@
 //! way the Trino client saw it.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::time::Duration;
 
+use arrow::array::{Array, StringArray};
+use arrow::record_batch::RecordBatch;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
 use arrow_flight::flight_service_client::FlightServiceClient;
@@ -112,6 +115,20 @@ fn ticket_bytes() -> Vec<u8> {
 /// `FlightRecordBatchStream`. Returns the decoded row count. Any malformed
 /// egress surfaces exactly as it did for the Trino client (a decode `Err`).
 async fn do_get_rows_over_transport(svc: CqliteFlightService, ticket: Vec<u8>) -> usize {
+    do_get_batches_over_transport(svc, ticket)
+        .await
+        .iter()
+        .map(|b| b.num_rows())
+        .sum()
+}
+
+/// Same real-transport round-trip as [`do_get_rows_over_transport`] but returns
+/// every decoded `RecordBatch` so a caller can assert on the actual column set
+/// and cell values (not just the row count).
+async fn do_get_batches_over_transport(
+    svc: CqliteFlightService,
+    ticket: Vec<u8>,
+) -> Vec<RecordBatch> {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let incoming = TcpIncoming::from_listener(listener, true, None).unwrap();
@@ -151,13 +168,12 @@ async fn do_get_rows_over_transport(svc: CqliteFlightService, ticket: Vec<u8>) -
     let stream = resp.into_inner().map(|r| r.map_err(FlightError::Tonic));
     let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
 
-    let mut rows = 0usize;
+    let mut batches = Vec::new();
     while let Some(batch) = rb.next().await {
-        let batch = batch.expect("decode flight batch over transport");
-        rows += batch.num_rows();
+        batches.push(batch.expect("decode flight batch over transport"));
     }
     server.abort();
-    rows
+    batches
 }
 
 /// Reproduces issue #2193: a 3-row nb-big table served over the real gRPC
@@ -228,4 +244,222 @@ fn do_get_over_transport_real_compressed_fixture() {
         rows > 0,
         "real compressed nb-big fixture must decode to > 0 rows over transport"
     );
+}
+
+/// Flush `total` rows across two separate memtable flushes so the resulting
+/// `data_dir` holds TWO `nb-*-big-Data.db` SSTables the server must k-way-merge.
+/// A single-SSTable fixture would let a broken merge pass the LIMIT test, so the
+/// >N rows MUST span ≥2 SSTables to catch a #2157-class early-stop break.
+fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::PathBuf) {
+    assert!(
+        total >= 4,
+        "need enough rows to span two flushes above a cap"
+    );
+    let schema = simple_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let half = total / 2;
+    // Distinct keys with a fixed 6-digit width so string order == numeric order.
+    for i in 0..half {
+        engine
+            .write(write_row(&format!("k{i:06}"), &format!("v{i}"), 100))
+            .expect("write");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush 1")
+        .expect("info 1");
+    for i in half..total {
+        engine
+            .write(write_row(&format!("k{i:06}"), &format!("v{i}"), 100))
+            .expect("write");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush 2")
+        .expect("info 2");
+
+    // Prove the fixture really produced ≥2 SSTables — otherwise the LIMIT test
+    // is not exercising the multi-SSTable early-stop it claims to.
+    let table_dir = data_dir.join(KS).join(TBL);
+    let data_files = std::fs::read_dir(&table_dir)
+        .expect("table dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .count();
+    assert!(
+        data_files >= 2,
+        "fixture must span ≥2 SSTables (found {data_files}) so LIMIT exercises the k-way merge",
+    );
+    (temp, data_dir)
+}
+
+/// Count total rows and collect the values of the `key` column across all
+/// decoded batches. Used by the predicate/projection assertions.
+fn keys_of(batches: &[RecordBatch], column: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let idx = batch
+            .schema()
+            .index_of(column)
+            .unwrap_or_else(|_| panic!("column {column} present in output"));
+        let arr = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("text column decodes as StringArray");
+        for i in 0..arr.len() {
+            out.push(arr.value(i).to_string());
+        }
+    }
+    out
+}
+
+/// **LIMIT enforcement over the wire.** A ticket with `limit: Some(N)` against a
+/// fixture holding >N rows spanning TWO SSTables must decode to EXACTLY N rows
+/// through the real gRPC transport. This catches a #2157-class early-stop break
+/// where the k-way merge fails to apply the cap after merging generations.
+#[test]
+fn do_get_over_transport_enforces_limit() {
+    let total = 20usize;
+    let limit = 7u64;
+    let (_temp, data_dir) = build_multi_sstable_fixture(total);
+    let ticket = serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+        "limit": limit,
+    }))
+    .unwrap();
+
+    let svc = CqliteFlightService::new(data_dir, 8192);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rows = rt.block_on(do_get_rows_over_transport(svc, ticket));
+    assert_eq!(
+        rows, limit as usize,
+        "a LIMIT {limit} ticket over {total} rows across 2 SSTables must decode EXACTLY {limit} rows"
+    );
+}
+
+/// **Predicate + projection over the wire.** A ticket carrying a v2 filter tree
+/// (`value = "v3"`) plus a single-column projection (`["value"]`) must decode to
+/// exactly the matching row, with ONLY the projected column present. This closes
+/// the gap where the transport tests previously asserted only `count > 0`.
+#[test]
+fn do_get_over_transport_applies_predicate_and_projection() {
+    let (_temp, data_dir) = build_multi_sstable_fixture(20);
+    // Filter on the `value` column for the row written as v3 (key k000003), and
+    // project only `value` so the row-key column must be absent from the output.
+    let ticket = serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+        "columns": ["value"],
+        "filter": {"type": "Compare", "column": "value", "op": "Equal", "value": "v3"},
+    }))
+    .unwrap();
+
+    let svc = CqliteFlightService::new(data_dir, 8192);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let batches = rt.block_on(do_get_batches_over_transport(svc, ticket));
+
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total_rows, 1,
+        "predicate value = 'v3' must select exactly one row over the wire"
+    );
+    let values = keys_of(&batches, "value");
+    assert_eq!(values, vec!["v3".to_string()], "the surviving row is v3");
+    // Projection: only `value` must be present, the `key` column projected out.
+    let schema = batches.first().expect("one batch").schema();
+    let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+    assert_eq!(
+        field_names,
+        vec!["value"],
+        "projection [\"value\"] must emit ONLY the value column, not key"
+    );
+}
+
+/// **live-mode file-set resolution.** A null-snapshot ticket against a table dir
+/// that contains BOTH a `snapshots/<name>/` subdir AND live `Data.db` files must
+/// read the LIVE set, never the snapshot. We build the live set with two rows and
+/// a snapshot with three DIFFERENT rows, so the decoded row count disambiguates
+/// which set the server actually read. This closes the read-mode server-behavior
+/// gap that was only field-level-tested.
+#[test]
+fn do_get_over_transport_reads_live_set_not_snapshot() {
+    // Live set: 2 rows in one SSTable.
+    let (_temp_live, live_dir) = build_fixture_n(2);
+    let live_table = live_dir.join(KS).join(TBL);
+
+    // Snapshot set: 5 rows (a distinct count) copied into snapshots/pinned/.
+    let (_temp_snap, snap_dir) = build_fixture_n(5);
+    let snap_table = snap_dir.join(KS).join(TBL);
+    let snapshot_dst = live_table.join("snapshots").join("pinned");
+    std::fs::create_dir_all(&snapshot_dst).expect("mk snapshot dir");
+    copy_sstable_components(&snap_table, &snapshot_dst);
+
+    // A null-snapshot ticket (live mode).
+    let ticket = serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+    }))
+    .unwrap();
+
+    let svc = CqliteFlightService::new(live_dir, 8192);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rows = rt.block_on(do_get_rows_over_transport(svc, ticket));
+    assert_eq!(
+        rows, 2,
+        "a null-snapshot (live) ticket must read the 2-row LIVE set, not the 5-row snapshot"
+    );
+}
+
+/// Flush `n` distinct rows into a fresh single-SSTable fixture and return its
+/// data dir. Like [`build_fixture`] but with a caller-chosen row count so two
+/// fixtures can carry disambiguating counts.
+fn build_fixture_n(n: usize) -> (tempfile::TempDir, std::path::PathBuf) {
+    let schema = simple_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for i in 0..n {
+        engine
+            .write(write_row(&format!("k{i:06}"), &format!("v{i}"), 100))
+            .expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    (temp, data_dir)
+}
+
+/// Copy every SSTable component file directly under `src` into `dst` (flat),
+/// mirroring how a Cassandra snapshot hardlinks the component set into
+/// `snapshots/<name>/`. Copies real bytes — never synthesizes SSTable content.
+fn copy_sstable_components(src: &Path, dst: &Path) {
+    for entry in std::fs::read_dir(src)
+        .expect("read source table dir")
+        .flatten()
+    {
+        let path = entry.path();
+        if path.is_file() {
+            let name = entry.file_name();
+            std::fs::copy(&path, dst.join(&name)).expect("copy component");
+        }
+    }
 }


### PR DESCRIPTION
Closes #2232. Part of Epic AM (#2226); coverage-lane items 1, 2, 6.

## What
Adds three transport-level integration tests to `cqlite-flight/tests/do_get_transport_test.rs`, all driving a real tonic loopback gRPC server + real `FlightServiceClient.do_get` + real `FlightRecordBatchStream` decode (true serialize→wire→deframe→decode path). The harness now returns decoded `RecordBatch`es so column/value assertions are real (previously only `count>0`).

- **`do_get_over_transport_enforces_limit`** — `limit=Some(7)` over 20 rows across ≥2 SSTables (fixture asserts `data_files >= 2`); asserts EXACTLY 7 rows AND that the returned key set spans BOTH flushes (interleaved even/odd keys → capped result provably crosses both generations). Guards #2157-class early-stop breaks.
- **`do_get_over_transport_applies_predicate_and_projection`** — filter `value=v3` + projection `columns=[value]`; asserts exactly 1 row, correct value, and only the projected column present (partition key projected out). Closes the "wire asserts only count>0" gap.
- **`do_get_over_transport_reads_live_set_not_snapshot`** — null-snapshot ticket against a dir with BOTH a `snapshots/pinned/` subdir (5 rows) and live Data.db (2 rows); asserts the server reads the LIVE set (exactly 2). Closes the read-mode server-behavior gap (previously field-only).

## Review-first
- rust-reviewer: no blockers; verified wiring-evidence, dataset-empty discipline, no-heuristics.
- roborev (codex, job 3805) + rust-reviewer both flagged the original LIMIT fixture (contiguous key ranges) wouldn't force a cross-SSTable read → fixed by interleaving keys + asserting the result spans both flushes.

Fixtures use real WriteEngine-flushed SSTables (no synthesized bytes). Tests require `CQLITE_DATASETS_ROOT`.