### PR TITLE
fix(#2229): hide unsupported-type columns (warn once) + real CQL time mapping incl. aggregation path

### DIFF
--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -63,13 +63,24 @@ Building from this repo (`./gradlew installPlugin`) produces the same directory.
 
 The full stack works end-to-end: `SELECT` over `cqlite.<keyspace>.<table>`
 streams compaction-merged, token-range-deduped Arrow data back to Trino.
-Validated types include int/bigint/text/boolean/uuid/timestamp.
+Validated types include int/bigint/text/boolean/uuid/timestamp/date/time.
 
-**v1 type support:** scalar columns. Complex CQL types (collections, UDTs,
-tuples, decimal) are rejected at planning with a clear message rather than
-failing mid-scan. Cassandra's default 16 vnodes produce 16 splits per table
-(each reads the SSTable filtered by token range) — correct, with split
-consolidation a future optimization.
+**v1 type support:** scalar columns, including CQL `time` (mapped to Trino
+`TIME(9)`, nanosecond precision). Complex CQL types (collections, UDTs, tuples,
+decimal, varint) are not yet materializable.
+
+**Per-column degradation (issue #2229):** a column of an unsupported type no
+longer makes the whole table unqueryable. Such columns are *hidden* from the
+Trino schema — omitted from both the column handles and `DESCRIBE` — and a single
+warning per table names the hidden columns and their Arrow type. `SELECT *` and
+`SELECT`ing any supported column work normally; hidden columns cannot be
+referenced. If *every* column of a table is unsupported the table is genuinely
+unqueryable, so it fails fast with a clear `NOT_SUPPORTED` error rather than
+presenting a confusing zero-column table.
+
+Cassandra's default 16 vnodes produce 16 splits per table (each reads the SSTable
+filtered by token range) — correct, with split consolidation a future
+optimization.
 
 ### LIMIT pushdown (issue #2129)
 

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
@@ -113,6 +113,13 @@ public final class ArrowToTrino {
             case BigIntVector v -> v.get(i);
             case DateDayVector v -> (long) v.get(i);
             case TimeStampVector v -> v.get(i);
+            // TIME → canonical nanoseconds-of-day (matches the unit writeJavaValue
+            // reads back below). All Arrow time widths normalize to nanos here so
+            // min/max longs compare correctly and GROUP BY keys stay equal.
+            case TimeSecVector v -> timeNanos(v, i);
+            case TimeMilliVector v -> timeNanos(v, i);
+            case TimeMicroVector v -> timeNanos(v, i);
+            case TimeNanoVector v -> timeNanos(v, i);
             case Float4Vector v -> v.get(i);
             case Float8Vector v -> v.get(i);
             case VarCharVector v -> new String(v.get(i), java.nio.charset.StandardCharsets.UTF_8);
@@ -142,6 +149,10 @@ public final class ArrowToTrino {
             case DoubleType t -> t.writeDouble(builder, ((Number) value).doubleValue());
             case TimestampWithTimeZoneType t -> t.writeLong(builder,
                     DateTimeEncoding.packDateTimeWithZone(((Number) value).longValue(), TimeZoneKey.UTC_KEY));
+            // The merged value is canonical nanoseconds-of-day (see readJavaValue);
+            // Trino TIME wants picoseconds-of-day — the same nanos→picos conversion
+            // the scan path uses (timePicos → nanosToPicos).
+            case TimeType t -> t.writeLong(builder, nanosToPicos(((Number) value).longValue()));
             case VarcharType t -> t.writeSlice(builder, value instanceof byte[] b
                     ? Slices.wrappedBuffer(b) : Slices.utf8Slice((String) value));
             case VarbinaryType t -> t.writeSlice(builder, value instanceof byte[] b
@@ -152,20 +163,31 @@ public final class ArrowToTrino {
     }
 
     /**
-     * Convert an Arrow time-of-day value to Trino's picoseconds-of-day encoding.
-     * Rust emits CQL {@code time} as {@code Time64(Nanosecond)}; the other units
-     * are handled for completeness so the conversion mirrors whatever precision
-     * {@link ArrowTypeMapper} mapped the column to.
+     * Canonical connector-side representation of an Arrow time-of-day value:
+     * nanoseconds since midnight. Rust emits CQL {@code time} as
+     * {@code Time64(Nanosecond)}; the other widths are normalized here so the
+     * scan path, aggregation merging, and GROUP BY keys all share one unit
+     * regardless of whatever precision {@link ArrowTypeMapper} mapped the column to.
      */
-    private static long timePicos(FieldVector vector, int i) {
+    private static long timeNanos(FieldVector vector, int i) {
         return switch (vector) {
-            case TimeNanoVector v -> v.get(i) * 1_000L;
-            case TimeMicroVector v -> v.get(i) * 1_000_000L;
-            case TimeMilliVector v -> v.get(i) * 1_000_000_000L;
-            case TimeSecVector v -> v.get(i) * 1_000_000_000_000L;
+            case TimeNanoVector v -> v.get(i);
+            case TimeMicroVector v -> v.get(i) * 1_000L;
+            case TimeMilliVector v -> v.get(i) * 1_000_000L;
+            case TimeSecVector v -> v.get(i) * 1_000_000_000L;
             default -> throw new UnsupportedOperationException(
                     "Cannot map Arrow vector " + vector.getClass().getSimpleName() + " to TIME");
         };
+    }
+
+    /** Trino encodes TIME as picoseconds-of-day; nanos→picos is a single ×1000. */
+    private static long nanosToPicos(long nanos) {
+        return nanos * 1_000L;
+    }
+
+    /** Convert an Arrow time-of-day value to Trino's picoseconds-of-day encoding. */
+    private static long timePicos(FieldVector vector, int i) {
+        return nanosToPicos(timeNanos(vector, i));
     }
 
     /** VARBINARY may be backed by variable or fixed-size binary vectors. */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
@@ -12,6 +12,7 @@ import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.TinyintType;
@@ -28,6 +29,10 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.VarBinaryVector;
@@ -80,6 +85,7 @@ public final class ArrowToTrino {
             case TimestampWithTimeZoneType t -> t.writeLong(builder,
                     DateTimeEncoding.packDateTimeWithZone(
                             ((TimeStampVector) vector).get(i), TimeZoneKey.UTC_KEY));
+            case TimeType t -> t.writeLong(builder, timePicos(vector, i));
             case VarcharType t -> t.writeSlice(builder, varcharSlice(vector, i));
             case VarbinaryType t -> t.writeSlice(builder, binarySlice(vector, i));
             default -> throw new UnsupportedOperationException(
@@ -143,6 +149,23 @@ public final class ArrowToTrino {
             default -> throw new UnsupportedOperationException(
                     "Unsupported Trino type for merged-aggregate write: " + type);
         }
+    }
+
+    /**
+     * Convert an Arrow time-of-day value to Trino's picoseconds-of-day encoding.
+     * Rust emits CQL {@code time} as {@code Time64(Nanosecond)}; the other units
+     * are handled for completeness so the conversion mirrors whatever precision
+     * {@link ArrowTypeMapper} mapped the column to.
+     */
+    private static long timePicos(FieldVector vector, int i) {
+        return switch (vector) {
+            case TimeNanoVector v -> v.get(i) * 1_000L;
+            case TimeMicroVector v -> v.get(i) * 1_000_000L;
+            case TimeMilliVector v -> v.get(i) * 1_000_000_000L;
+            case TimeSecVector v -> v.get(i) * 1_000_000_000_000L;
+            default -> throw new UnsupportedOperationException(
+                    "Cannot map Arrow vector " + vector.getClass().getSimpleName() + " to TIME");
+        };
     }
 
     /** VARBINARY may be backed by variable or fixed-size binary vectors. */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowTypeMapper.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowTypeMapper.java
@@ -7,6 +7,7 @@ import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
@@ -14,6 +15,8 @@ import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
+
+import java.util.Optional;
 
 /**
  * Maps Arrow schema fields (as produced by the cqlite-flight server's
@@ -56,16 +59,33 @@ public final class ArrowTypeMapper {
         };
     }
 
-    /** Map one Arrow field to a Trino {@link Type}. */
+    /**
+     * Map one Arrow field to a Trino {@link Type}, throwing when the column's
+     * type is not supported. Callers that want to degrade per-column (hide the
+     * column rather than fail the whole table) should use {@link #toTrinoOrEmpty}.
+     */
     public static Type toTrino(Field field) {
+        return toTrinoOrEmpty(field).orElseThrow(() -> new UnsupportedOperationException(
+                "Unsupported Arrow type for column '" + field.getName() + "': " + field.getType()
+                        + " (the connector currently supports scalar columns)"));
+    }
+
+    /**
+     * Resolve a column's Trino {@link Type}, or {@link Optional#empty()} when the
+     * Arrow type is not one the connector can materialize (decimal, varint,
+     * list/set/map, tuple, UDT). {@link CqliteFlightMetadata} uses this to omit
+     * unsupported columns from the Trino schema (hide + warn) rather than making
+     * the entire table unqueryable.
+     */
+    public static Optional<Type> toTrinoOrEmpty(Field field) {
         // UUID is carried as FixedSizeBinary(16) tagged with the Arrow UUID
         // extension; surface it as VARCHAR (canonical hyphenated form).
         if (UUID_EXTENSION.equals(field.getMetadata().get(EXTENSION_KEY))) {
-            return VarcharType.VARCHAR;
+            return Optional.of(VarcharType.VARCHAR);
         }
 
         ArrowType type = field.getType();
-        return switch (type) {
+        Type mapped = switch (type) {
             case ArrowType.Bool ignored -> BooleanType.BOOLEAN;
             case ArrowType.Int i -> switch (i.getBitWidth()) {
                 case 8 -> TinyintType.TINYINT;
@@ -82,10 +102,22 @@ public final class ArrowTypeMapper {
             case ArrowType.Binary ignored -> VarbinaryType.VARBINARY;
             case ArrowType.FixedSizeBinary ignored -> VarbinaryType.VARBINARY;
             case ArrowType.Date ignored -> DateType.DATE;
+            // CQL time → Arrow Time (Rust emits Time64(Nanosecond)); Trino has a
+            // native TIME whose precision mirrors the Arrow unit.
+            case ArrowType.Time t -> timeType(t);
             case ArrowType.Timestamp ignored -> TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
-            default -> throw new UnsupportedOperationException(
-                    "Unsupported Arrow type for column '" + field.getName() + "': " + type
-                            + " (the connector currently supports scalar columns)");
+            default -> null;
+        };
+        return Optional.ofNullable(mapped);
+    }
+
+    /** Map an Arrow {@code Time} unit to the Trino {@link TimeType} of equal precision. */
+    private static TimeType timeType(ArrowType.Time time) {
+        return switch (time.getUnit()) {
+            case SECOND -> TimeType.TIME_SECONDS;
+            case MILLISECOND -> TimeType.TIME_MILLIS;
+            case MICROSECOND -> TimeType.TIME_MICROS;
+            case NANOSECOND -> TimeType.TIME_NANOS;
         };
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -1,5 +1,7 @@
 package in.mcfad.cqlite.flight;
 
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.AggregationApplicationResult;
 import io.trino.spi.connector.Assignment;
@@ -53,10 +55,19 @@ import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
  */
 public class CqliteFlightMetadata implements ConnectorMetadata {
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final System.Logger LOG = System.getLogger(CqliteFlightMetadata.class.getName());
     private final CqliteFlightConfig config;
     private final SidecarClient sidecar;
     private final CqliteFlightClient flight;
     private final SnapshotManager snapshots;
+
+    /**
+     * Tables for which the "hiding unsupported-type columns" warning has already
+     * been logged, so a table is warned about at most once (getColumnHandles and
+     * getTableMetadata both funnel through {@link #supportedFields}). Concurrent-safe
+     * for multi-threaded planning.
+     */
+    private final Set<SchemaTableName> warnedHiddenColumns = ConcurrentHashMap.newKeySet();
 
     /**
      * Per-{@code (keyspace, table)} memo of the non-aggregated logical row-count
@@ -1049,13 +1060,54 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
 
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle table) {
-        Schema schema = arrowSchema((CqliteFlightTableHandle) table);
+        CqliteFlightTableHandle handle = (CqliteFlightTableHandle) table;
+        SchemaTableName tableName = new SchemaTableName(handle.keyspace(), handle.table());
         Map<String, ColumnHandle> handles = new LinkedHashMap<>();
-        for (Field field : schema.getFields()) {
+        for (Field field : supportedFields(tableName, arrowSchema(handle), warnedHiddenColumns)) {
             handles.put(field.getName(), new CqliteFlightColumnHandle(
                     field.getName(), ArrowTypeMapper.toTrino(field), ArrowTypeMapper.capabilityOf(field)));
         }
         return handles;
+    }
+
+    /**
+     * Filter an Arrow schema down to the columns whose type the connector can
+     * materialize, hiding the rest from the Trino schema (owner decision, issue
+     * #2229: <em>hide + warn</em>). Columns of an unsupported type (decimal,
+     * varint, collections, tuples, UDTs) are omitted consistently from both the
+     * column handles and the table metadata, so DESCRIBE shows only supported
+     * columns and {@code SELECT *} succeeds. The first time a given table is seen
+     * with hidden columns, a single warning names them and their Arrow type.
+     *
+     * <p>When <em>every</em> column is unsupported the table is genuinely
+     * unqueryable, so we fail with a clear {@link StandardErrorCode#NOT_SUPPORTED}
+     * error rather than presenting a zero-column table (which Trino handles poorly
+     * and would silently return empty rows).
+     */
+    static List<Field> supportedFields(
+            SchemaTableName tableName, Schema schema, Set<SchemaTableName> warned) {
+        List<Field> supported = new ArrayList<>();
+        List<String> hidden = new ArrayList<>();
+        for (Field field : schema.getFields()) {
+            if (ArrowTypeMapper.toTrinoOrEmpty(field).isPresent()) {
+                supported.add(field);
+            } else {
+                hidden.add(field.getName() + " (arrow " + field.getType() + ")");
+            }
+        }
+        if (!hidden.isEmpty() && warned.add(tableName)) {
+            LOG.log(System.Logger.Level.WARNING,
+                    "Table " + tableName + ": hiding " + hidden.size()
+                            + " column(s) of unsupported type from the Trino schema: "
+                            + String.join(", ", hidden));
+        }
+        if (supported.isEmpty() && !schema.getFields().isEmpty()) {
+            throw new TrinoException(StandardErrorCode.NOT_SUPPORTED,
+                    "Table " + tableName + " has no Trino-supported columns; all "
+                            + schema.getFields().size() + " column(s) use unsupported CQL types: "
+                            + String.join(", ", hidden));
+        }
+        return supported;
     }
 
     @Override
@@ -1068,12 +1120,12 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table) {
         CqliteFlightTableHandle handle = (CqliteFlightTableHandle) table;
-        Schema schema = arrowSchema(handle);
+        SchemaTableName tableName = new SchemaTableName(handle.keyspace(), handle.table());
         List<ColumnMetadata> columns = new ArrayList<>();
-        for (Field field : schema.getFields()) {
+        for (Field field : supportedFields(tableName, arrowSchema(handle), warnedHiddenColumns)) {
             columns.add(new ColumnMetadata(field.getName(), ArrowTypeMapper.toTrino(field)));
         }
-        return new ConnectorTableMetadata(new SchemaTableName(handle.keyspace(), handle.table()), columns);
+        return new ConnectorTableMetadata(tableName, columns);
     }
 
     /**

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
@@ -140,6 +140,34 @@ class ArrowToTrinoTest {
     }
 
     @Test
+    void convertsTime64NanosToTrinoPicosOfDay() {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var time = new org.apache.arrow.vector.TimeNanoVector("t", allocator);
+            time.allocateNew(2);
+            // 13:14:15.123456789 → nanos-of-day.
+            long nanosOfDay = ((13L * 3600 + 14 * 60 + 15) * 1_000_000_000L) + 123_456_789L;
+            time.set(0, nanosOfDay);
+            time.setNull(1);
+
+            var root = new VectorSchemaRoot(List.of(time));
+            root.setRowCount(2);
+
+            var columns = List.of(
+                    new CqliteFlightColumnHandle("t", io.trino.spi.type.TimeType.TIME_NANOS));
+
+            Page page = ArrowToTrino.toPage(root, columns);
+            assertEquals(2, page.getPositionCount());
+
+            long picos = io.trino.spi.type.TimeType.TIME_NANOS.getLong(page.getBlock(0), 0);
+            // Trino TIME is picoseconds of day: nanos * 1000, exact.
+            assertEquals(nanosOfDay * 1_000L, picos);
+            assertTrue(page.getBlock(0).isNull(1));
+
+            root.close();
+        }
+    }
+
+    @Test
     void formatsUuidBytes() {
         byte[] bytes = new byte[16];
         bytes[15] = 1;

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
@@ -168,6 +168,74 @@ class ArrowToTrinoTest {
     }
 
     @Test
+    void readJavaValueNormalizesEveryTimeWidthToNanosOfDay() {
+        // The aggregation finalize path reads a TIME group/aggregate column via
+        // ArrowToTrino.readJavaValue (issue #2229). Every Arrow time width must
+        // normalize to the SAME canonical nanoseconds-of-day so GROUP BY keys and
+        // min/max longs compare correctly regardless of the mapped precision.
+        long secondsOfDay = 13L * 3600 + 14 * 60 + 15; // 13:14:15, exact on all widths
+        long nanos = secondsOfDay * 1_000_000_000L;
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var sec = new org.apache.arrow.vector.TimeSecVector("s", allocator);
+            var milli = new org.apache.arrow.vector.TimeMilliVector("ms", allocator);
+            var micro = new org.apache.arrow.vector.TimeMicroVector("us", allocator);
+            var nano = new org.apache.arrow.vector.TimeNanoVector("ns", allocator);
+            sec.allocateNew(1);
+            milli.allocateNew(1);
+            micro.allocateNew(1);
+            nano.allocateNew(1);
+            sec.set(0, (int) secondsOfDay);
+            milli.set(0, (int) (secondsOfDay * 1_000L));
+            micro.set(0, secondsOfDay * 1_000_000L);
+            nano.set(0, nanos);
+
+            assertEquals(nanos, ArrowToTrino.readJavaValue(sec, 0));
+            assertEquals(nanos, ArrowToTrino.readJavaValue(milli, 0));
+            assertEquals(nanos, ArrowToTrino.readJavaValue(micro, 0));
+            assertEquals(nanos, ArrowToTrino.readJavaValue(nano, 0));
+
+            sec.close();
+            milli.close();
+            micro.close();
+            nano.close();
+        }
+    }
+
+    @Test
+    void writeJavaValueEncodesTimeNanosAsTrinoPicos() {
+        // buildPage in the finalize path writes a merged TIME value (canonical nanos
+        // from readJavaValue) into a TimeType block via ArrowToTrino.writeJavaValue.
+        // Before #2229 this threw; it must encode picoseconds-of-day (nanos * 1000).
+        long nanos = ((13L * 3600 + 14 * 60 + 15) * 1_000_000_000L) + 123_456_789L;
+        var type = io.trino.spi.type.TimeType.TIME_NANOS;
+        io.trino.spi.block.BlockBuilder builder = type.createBlockBuilder(null, 1);
+        ArrowToTrino.writeJavaValue(type, nanos, builder);
+        io.trino.spi.block.Block block = builder.build();
+        assertEquals(nanos * 1_000L, type.getLong(block, 0), "TIME encoded as picos-of-day");
+    }
+
+    @Test
+    void timeReadWriteRoundTripsThroughFinalizePathUnits() {
+        // Reproduce exactly what accumulate() + buildPage() do to a TIME group
+        // column: read the Arrow value, then write it back into a Trino TimeType
+        // block. The round-trip must reproduce Trino's picoseconds-of-day encoding.
+        long nanos = ((1L * 3600 + 2 * 60 + 3) * 1_000_000_000L) + 456L;
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var nano = new org.apache.arrow.vector.TimeNanoVector("t", allocator);
+            nano.allocateNew(1);
+            nano.set(0, nanos);
+
+            Object read = ArrowToTrino.readJavaValue(nano, 0);
+            var type = io.trino.spi.type.TimeType.TIME_NANOS;
+            io.trino.spi.block.BlockBuilder builder = type.createBlockBuilder(null, 1);
+            ArrowToTrino.writeJavaValue(type, read, builder);
+            assertEquals(nanos * 1_000L, type.getLong(builder.build(), 0));
+
+            nano.close();
+        }
+    }
+
+    @Test
     void formatsUuidBytes() {
         byte[] bytes = new byte[16];
         bytes[15] = 1;

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowTypeMapperTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowTypeMapperTest.java
@@ -3,8 +3,10 @@ package in.mcfad.cqlite.flight;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.TimeType;
 import io.trino.spi.type.VarcharType;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -16,6 +18,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ArrowTypeMapperTest {
 
@@ -39,6 +42,29 @@ class ArrowTypeMapperTest {
         assertInstanceOf(io.trino.spi.type.RealType.class,
                 ArrowTypeMapper.toTrino(scalar("f",
                         new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE))));
+    }
+
+    @Test
+    void cqlTimeMapsToTrinoTime() {
+        // Rust emits CQL `time` as Time64(Nanosecond); it must surface as Trino
+        // TIME(9), not be hidden.
+        assertEquals(TimeType.TIME_NANOS,
+                ArrowTypeMapper.toTrino(scalar("t", new ArrowType.Time(TimeUnit.NANOSECOND, 64))));
+        // Other Arrow time units map to the Trino TIME of equal precision.
+        assertEquals(TimeType.TIME_MICROS,
+                ArrowTypeMapper.toTrino(scalar("t", new ArrowType.Time(TimeUnit.MICROSECOND, 64))));
+        assertEquals(TimeType.TIME_MILLIS,
+                ArrowTypeMapper.toTrino(scalar("t", new ArrowType.Time(TimeUnit.MILLISECOND, 32))));
+        assertEquals(TimeType.TIME_SECONDS,
+                ArrowTypeMapper.toTrino(scalar("t", new ArrowType.Time(TimeUnit.SECOND, 32))));
+    }
+
+    @Test
+    void toTrinoOrEmptyIsEmptyForUnsupportedAndPresentForSupported() {
+        Field decimal = scalar("d", new ArrowType.Decimal(38, 9, 128));
+        assertTrue(ArrowTypeMapper.toTrinoOrEmpty(decimal).isEmpty());
+        assertEquals(IntegerType.INTEGER,
+                ArrowTypeMapper.toTrinoOrEmpty(scalar("i", new ArrowType.Int(32, true))).orElseThrow());
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceTest.java
@@ -2,8 +2,20 @@ package in.mcfad.cqlite.flight;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.TimeType;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,5 +60,70 @@ class CqliteFlightAggregatePageSourceTest {
         JsonNode node = MAPPER.readTree(ticket);
 
         assertTrue(node.get("snapshot").isNull());
+    }
+
+    /**
+     * Issue #2229: a pushed-down {@code GROUP BY} on a TIME column must survive the
+     * finalize path. This reproduces exactly what {@code accumulate()} + {@code
+     * buildPage()} do to each range's Arrow batch — read every group/aggregate value
+     * with {@link ArrowToTrino#readJavaValue} into the {@link PartialAggregateMerger},
+     * then write each merged group's TIME key back with {@link ArrowToTrino#writeJavaValue}.
+     * Before the fix, {@code readJavaValue} threw on the {@code TimeNanoVector} group
+     * column and {@code writeJavaValue} had no TIME case; both would fail here.
+     */
+    @Test
+    void groupByTimeColumnSurvivesFinalizeReadMergeWrite() {
+        long nine = 9L * 3600 * 1_000_000_000L;  // 09:00:00
+        long ten = 10L * 3600 * 1_000_000_000L;  // 10:00:00
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Count, null, "agg0"));
+        var merger = new PartialAggregateMerger(aggregates);
+
+        try (BufferAllocator allocator = new RootAllocator()) {
+            // Two "ranges": range A has groups {09:00 -> count 2, 10:00 -> count 1},
+            // range B has {09:00 -> count 3}. Same TIME key must merge across ranges.
+            accumulateBatch(allocator, merger, new long[] {nine, ten}, new long[] {2L, 1L});
+            accumulateBatch(allocator, merger, new long[] {nine}, new long[] {3L});
+        }
+
+        // buildPage: write each merged group's TIME key + count into result blocks.
+        Map<Long, Long> countByPicos = new HashMap<>();
+        for (var g : merger.finish()) {
+            long timeNanos = (Long) g.key().values().get(0);
+            BlockBuilder timeBuilder = TimeType.TIME_NANOS.createBlockBuilder(null, 1);
+            ArrowToTrino.writeJavaValue(TimeType.TIME_NANOS, timeNanos, timeBuilder);
+            long picos = TimeType.TIME_NANOS.getLong(timeBuilder.build(), 0);
+
+            BlockBuilder countBuilder = BigintType.BIGINT.createBlockBuilder(null, 1);
+            ArrowToTrino.writeJavaValue(BigintType.BIGINT, g.outputs().get("agg0"), countBuilder);
+            long count = BigintType.BIGINT.getLong(countBuilder.build(), 0);
+            countByPicos.put(picos, count);
+        }
+
+        assertEquals(2, countByPicos.size(), "two distinct time-of-day groups");
+        assertEquals(5L, countByPicos.get(nine * 1_000L), "09:00 group merged 2 + 3 across ranges");
+        assertEquals(1L, countByPicos.get(ten * 1_000L), "10:00 group");
+    }
+
+    /** Mirror {@code accumulate()}: read one Arrow batch's group + count columns into the merger. */
+    private static void accumulateBatch(
+            BufferAllocator allocator, PartialAggregateMerger merger, long[] timeNanos, long[] counts) {
+        TimeNanoVector time = new TimeNanoVector("t", allocator);
+        BigIntVector count = new BigIntVector("agg0", allocator);
+        time.allocateNew(timeNanos.length);
+        count.allocateNew(counts.length);
+        for (int i = 0; i < timeNanos.length; i++) {
+            time.set(i, timeNanos[i]);
+            count.set(i, counts[i]);
+        }
+        VectorSchemaRoot root = new VectorSchemaRoot(List.of(time, count));
+        root.setRowCount(timeNanos.length);
+        for (int r = 0; r < timeNanos.length; r++) {
+            Object key = ArrowToTrino.readJavaValue(root.getVector("t"), r);
+            Map<String, Object> partials = new HashMap<>();
+            partials.put("agg0", ArrowToTrino.readJavaValue(root.getVector("agg0"), r));
+            merger.combine(new PartialAggregateMerger.GroupKey(List.of(key)), partials);
+        }
+        root.close();
     }
 }

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataColumnHidingTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataColumnHidingTest.java
@@ -1,0 +1,89 @@
+package in.mcfad.cqlite.flight;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.SchemaTableName;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Per-column degradation (issue #2229): unsupported-type columns are hidden from
+ * the Trino schema (owner decision: hide + warn), warned about once per table, and
+ * an all-unsupported table fails with a clear error.
+ */
+class CqliteFlightMetadataColumnHidingTest {
+
+    private static Field scalar(String name, ArrowType type) {
+        return new Field(name, FieldType.nullable(type), List.of());
+    }
+
+    private static List<String> names(List<Field> fields) {
+        List<String> out = new ArrayList<>();
+        for (Field f : fields) {
+            out.add(f.getName());
+        }
+        return out;
+    }
+
+    @Test
+    void unsupportedColumnsAreHiddenSupportedKeptInOrder() {
+        Field decimal = scalar("bal", new ArrowType.Decimal(38, 9, 128));
+        Field list = new Field("tags", FieldType.nullable(ArrowType.List.INSTANCE),
+                List.of(scalar("item", ArrowType.Utf8.INSTANCE)));
+        Schema schema = new Schema(List.of(
+                scalar("id", new ArrowType.Int(32, true)),
+                decimal,
+                scalar("name", ArrowType.Utf8.INSTANCE),
+                list,
+                scalar("t", new ArrowType.Time(org.apache.arrow.vector.types.TimeUnit.NANOSECOND, 64))));
+
+        Set<SchemaTableName> warned = ConcurrentHashMap.newKeySet();
+        SchemaTableName tn = new SchemaTableName("ks", "accounts");
+        List<Field> supported = CqliteFlightMetadata.supportedFields(tn, schema, warned);
+
+        // id, name, and time survive; decimal + list are hidden. Order preserved.
+        assertEquals(List.of("id", "name", "t"), names(supported));
+        // The table is warned about exactly once (set membership records it).
+        assertTrue(warned.contains(tn));
+        // Idempotent: a second call keeps the same result and does not re-warn.
+        List<Field> again = CqliteFlightMetadata.supportedFields(tn, schema, warned);
+        assertEquals(List.of("id", "name", "t"), names(again));
+        assertEquals(1, warned.size());
+    }
+
+    @Test
+    void allSupportedNeverWarns() {
+        Schema schema = new Schema(List.of(
+                scalar("id", new ArrowType.Int(32, true)),
+                scalar("name", ArrowType.Utf8.INSTANCE)));
+        Set<SchemaTableName> warned = ConcurrentHashMap.newKeySet();
+        SchemaTableName tn = new SchemaTableName("ks", "plain");
+        List<Field> supported = CqliteFlightMetadata.supportedFields(tn, schema, warned);
+        assertEquals(List.of("id", "name"), names(supported));
+        assertTrue(warned.isEmpty());
+    }
+
+    @Test
+    void allUnsupportedFailsWithClearError() {
+        Schema schema = new Schema(List.of(
+                scalar("bal", new ArrowType.Decimal(38, 9, 128)),
+                new Field("tags", FieldType.nullable(ArrowType.List.INSTANCE),
+                        List.of(scalar("item", ArrowType.Utf8.INSTANCE)))));
+        Set<SchemaTableName> warned = ConcurrentHashMap.newKeySet();
+        SchemaTableName tn = new SchemaTableName("ks", "opaque");
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightMetadata.supportedFields(tn, schema, warned));
+        assertTrue(ex.getMessage().contains("no Trino-supported columns"));
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/PartialAggregateMergerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/PartialAggregateMergerTest.java
@@ -188,6 +188,50 @@ class PartialAggregateMergerTest {
     }
 
     @Test
+    void minMaxOverTimeNanosCompareAsLongs() {
+        // TIME is carried as canonical nanoseconds-of-day (Long) through the finalize
+        // path (issue #2229). min/max across ranges must pick the right extreme by
+        // long order — 00:00:00.000000001 < 23:59:59.999999999.
+        long early = 1L;                                   // 00:00:00.000000001
+        long late = (24L * 3600 * 1_000_000_000L) - 1L;    // 23:59:59.999999999
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Min, "t", "agg0"),
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Max, "t", "agg1"));
+        var merger = new PartialAggregateMerger(aggregates);
+        var globalKey = new PartialAggregateMerger.GroupKey(List.of());
+        merger.combine(globalKey, row("agg0", late, "agg1", early));
+        merger.combine(globalKey, row("agg0", early, "agg1", late));
+
+        var out = merger.finish().get(0).outputs();
+        assertEquals(early, out.get("agg0"), "min(TIME) is the earliest time-of-day");
+        assertEquals(late, out.get("agg1"), "max(TIME) is the latest time-of-day");
+    }
+
+    @Test
+    void groupByTimeKeyMergesEqualNanosAndKeepsNullGroupSeparate() {
+        // GROUP BY on a TIME column: equal nanos-of-day keys merge across ranges;
+        // a null TIME group stays its own group (issue #2229).
+        long nine = 9L * 3600 * 1_000_000_000L; // 09:00:00
+        long ten = 10L * 3600 * 1_000_000_000L; // 10:00:00
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Count, null, "agg0"));
+        var merger = new PartialAggregateMerger(aggregates);
+        merger.combine(key(nine), row("agg0", 2L));
+        merger.combine(key(ten), row("agg0", 1L));
+        merger.combine(key(nine), row("agg0", 3L)); // same time-of-day → merges with the first
+        var nullKey = new PartialAggregateMerger.GroupKey(java.util.Arrays.asList((Object) null));
+        merger.combine(nullKey, row("agg0", 4L));
+
+        Map<Object, Long> byKey = new HashMap<>();
+        for (var g : merger.finish()) {
+            byKey.put(g.key().values().get(0), (Long) g.outputs().get("agg0"));
+        }
+        assertEquals(5L, byKey.get(nine), "09:00:00 group merged 2 + 3");
+        assertEquals(1L, byKey.get(ten), "10:00:00 group");
+        assertEquals(4L, byKey.get(null), "null TIME is its own group");
+    }
+
+    @Test
     void mergesDoubleSums() {
         var aggregates = List.of(
                 new AggregationSpec.Aggregate(AggregationSpec.Func.Sum, "x", "agg0"));


### PR DESCRIPTION
Closes #2229

## What
Per-column degradation for unsupported types + real CQL `time` mapping (Epic AM #2226 Wave 0). OWNER-decided UX: **hide + warn**.

- `CqliteFlightMetadata.supportedFields()`: unsupported-type columns hidden consistently from `getColumnHandles` + `getTableMetadata`; warning once per table per query (bounded, per-transaction metadata instance); all-columns-unsupported → clear `NOT_SUPPORTED` naming table + types, thrown only on access
- Pushdown-safe by construction: Trino can't name a column it can't see; empty-projection path never reads unsupported vectors
- CQL `time`: `ArrowTypeMapper` maps `ArrowType.Time` by unit (ns → TIME_NANOS); `ArrowToTrino` converts nanos-of-day → picos exactly, shared conversion helper; aggregation finalize path (`readJavaValue`/`writeJavaValue`) handles Time vectors — `GROUP BY time_col` is pushable today and previously hit both throw sites
- README documents hide+warn + TIME support

## Review-first (#2086)
- rust-reviewer: NITS-ONLY (batched: public-surface variant of the hiding test; Javadoc "once per table" wording)
- roborev job 1559: Medium — TIME missing from aggregate finalize path → FIXED in b2789647 (reachability confirmed: GROUP BY on TIME pushes; value-aggregates on TIME are capability-declined)
- roborev job 1561 (re-review): No issues found

Gradle: 213 tests / 0 failures. Full gate of record runs in flow-closer pre-merge (lite: PASS @ b2789647).
