### PR TITLE
fix(#2202): SUM/AVG preserve Cassandra integral result types (int/bigint/tinyint/smallint)

### DIFF
--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -537,8 +537,10 @@ mod tests {
         row.values.get("r").cloned().expect("result present")
     }
 
-    /// SUM over integral inputs preserves the integral result type and value
-    /// (issue #2202): int/smallint/tinyint → `Value::Integer`, bigint → BigInt.
+    /// SUM over integral inputs preserves the ARGUMENT's own integral type and
+    /// value (issue #2202, `AggregateFcts.java`): int → `Value::Integer`,
+    /// bigint → `Value::BigInt`, and — Cassandra does NOT promote these —
+    /// smallint → `Value::SmallInt`, tinyint → `Value::TinyInt`.
     #[test]
     fn sum_integral_inputs_preserve_integral_result() {
         assert_eq!(
@@ -565,8 +567,8 @@ mod tests {
                 Some(CqlType::SmallInt),
                 &[Value::SmallInt(100), Value::SmallInt(50)],
             ),
-            Value::Integer(150),
-            "SUM(smallint) promotes to Value::Integer (int)"
+            Value::SmallInt(150),
+            "SUM(smallint) stays Value::SmallInt — Cassandra does not promote to int"
         );
         assert_eq!(
             run_scalar_agg(
@@ -574,8 +576,8 @@ mod tests {
                 Some(CqlType::TinyInt),
                 &[Value::TinyInt(40), Value::TinyInt(2)],
             ),
-            Value::Integer(42),
-            "SUM(tinyint) promotes to Value::Integer (int)"
+            Value::TinyInt(42),
+            "SUM(tinyint) stays Value::TinyInt — Cassandra does not promote to int"
         );
     }
 
@@ -643,13 +645,53 @@ mod tests {
             Value::Float(1.5),
             "AVG(double) divides in f64",
         );
+        // Issue #2202: AVG(smallint)/AVG(tinyint) stay their own narrow width —
+        // Cassandra does not promote them to int.
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Avg,
+                Some(CqlType::SmallInt),
+                &[Value::SmallInt(10), Value::SmallInt(21)],
+            ),
+            Value::SmallInt(15),
+            "AVG(smallint) integer division stays smallint"
+        );
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Avg,
+                Some(CqlType::TinyInt),
+                &[Value::TinyInt(10), Value::TinyInt(21)],
+            ),
+            Value::TinyInt(15),
+            "AVG(tinyint) integer division stays tinyint"
+        );
     }
 
     /// Integral SUM overflow WRAPS (Cassandra's two's-complement Java semantics),
-    /// never saturating or panicking. `int` wraps at the i32 boundary; `bigint`
-    /// wraps at the i64 boundary.
+    /// never saturating or panicking, at EACH type's OWN width: `tinyint` wraps
+    /// at the i8 boundary, `smallint` at i16, `int` at i32, `bigint` at i64.
     #[test]
     fn sum_integral_overflow_wraps() {
+        // i8::MAX + 1 wraps to i8::MIN (tinyint stays tinyint, no promotion).
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::TinyInt),
+                &[Value::TinyInt(i8::MAX), Value::TinyInt(1)],
+            ),
+            Value::TinyInt(i8::MIN),
+            "SUM(tinyint) wraps at the i8 boundary"
+        );
+        // i16::MAX + 1 wraps to i16::MIN (smallint stays smallint).
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::SmallInt),
+                &[Value::SmallInt(i16::MAX), Value::SmallInt(1)],
+            ),
+            Value::SmallInt(i16::MIN),
+            "SUM(smallint) wraps at the i16 boundary"
+        );
         // i32::MAX + 1 wraps to i32::MIN.
         assert_eq!(
             run_scalar_agg(

--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -7,7 +7,9 @@
 
 use super::super::select_ast::AggregateType;
 use super::super::select_optimizer::{AggregateComputation, AggregationPlan};
+use super::numeric_acc::NumericAcc;
 use super::value_ops::compare_values_ordering;
+use crate::schema::CqlType;
 use crate::{
     query::result::QueryRow,
     types::{RowKey, Value},
@@ -121,8 +123,8 @@ fn hash_one_value<H: Hasher>(v: &Value, h: &mut H) {
 #[derive(Debug, Clone)]
 pub(super) enum AggregateValue {
     Count(u64),
-    Sum(f64),
-    Avg { sum: f64, count: u64 },
+    Sum(NumericAcc),
+    Avg { acc: NumericAcc, count: u64 },
     Min(Value),
     Max(Value),
 }
@@ -131,17 +133,31 @@ pub(super) enum AggregateValue {
 /// [`find_or_init_group`] (the buffered GROUP BY path) and the streaming
 /// GROUP-BY-free fold (issue #1578, D2) so the initial state — and thus the
 /// per-row update + finalize semantics — are defined in exactly one place.
+///
+/// Issue #2202: `result_types[i]` is the aggregate's resolved RESULT CQL type
+/// (from `select_naming::aggregate_result_cql_type`, the SAME source the result
+/// metadata uses), parallel to `aggregates`. It fixes each SUM/AVG accumulator's
+/// numeric domain (integral vs floating) up front, so the emitted value variant
+/// matches the metadata type even for an all-null group that folds no input.
 pub(super) fn init_aggregate_accumulators(
     aggregates: &[AggregateComputation],
+    result_types: &[Option<CqlType>],
 ) -> Vec<AggregateValue> {
     aggregates
         .iter()
-        .map(|c| match c.function {
-            AggregateType::Count => AggregateValue::Count(0),
-            AggregateType::Sum => AggregateValue::Sum(0.0),
-            AggregateType::Avg => AggregateValue::Avg { sum: 0.0, count: 0 },
-            AggregateType::Min => AggregateValue::Min(Value::Null),
-            AggregateType::Max => AggregateValue::Max(Value::Null),
+        .enumerate()
+        .map(|(i, c)| {
+            let result_type = result_types.get(i).and_then(|t| t.as_ref());
+            match c.function {
+                AggregateType::Count => AggregateValue::Count(0),
+                AggregateType::Sum => AggregateValue::Sum(NumericAcc::init(result_type)),
+                AggregateType::Avg => AggregateValue::Avg {
+                    acc: NumericAcc::init(result_type),
+                    count: 0,
+                },
+                AggregateType::Min => AggregateValue::Min(Value::Null),
+                AggregateType::Max => AggregateValue::Max(Value::Null),
+            }
         })
         .collect()
 }
@@ -172,6 +188,7 @@ pub(super) fn find_or_init_group(
     state: &mut AggregationState,
     key: Vec<Value>,
     aggregates: &[AggregateComputation],
+    result_types: &[Option<CqlType>],
 ) -> usize {
     let hash = hash_group_key(&key);
     if let Some(candidates) = state.group_index.get(&hash) {
@@ -183,7 +200,7 @@ pub(super) fn find_or_init_group(
             }
         }
     }
-    let initial = init_aggregate_accumulators(aggregates);
+    let initial = init_aggregate_accumulators(aggregates, result_types);
     let new_index = state.groups.len();
     state.groups.push((key, initial));
     state.group_index.entry(hash).or_default().push(new_index);
@@ -215,15 +232,21 @@ pub(super) fn update_aggregate(
                 *count += 1;
             }
         }
-        AggregateValue::Sum(sum) => {
-            if let Some(v) = value.and_then(Value::as_f64) {
-                *sum += v;
+        AggregateValue::Sum(acc) => {
+            if let Some(v) = value {
+                if !v.is_null() {
+                    acc.add(v);
+                }
             }
         }
-        AggregateValue::Avg { sum, count } => {
-            if let Some(v) = value.and_then(Value::as_f64) {
-                *sum += v;
-                *count += 1;
+        AggregateValue::Avg { acc, count } => {
+            if let Some(v) = value {
+                // Count only inputs the accumulator's numeric domain accepts, so
+                // AVG's divisor matches SUM's contributor set — a `0` still
+                // counts (issue #2202).
+                if !v.is_null() && acc.add(v) {
+                    *count += 1;
+                }
             }
         }
         AggregateValue::Min(min_val) => {
@@ -273,10 +296,13 @@ pub(super) fn finalize_group(
     for (i, agg_comp) in agg_plan.aggregates.iter().enumerate() {
         let result_value = match &group_aggregates[i] {
             AggregateValue::Count(count) => Value::BigInt(*count as i64),
-            AggregateValue::Sum(sum) => Value::Float(*sum),
-            AggregateValue::Avg { sum, count } => {
+            // Issue #2202: emit the value variant matching the accumulator's
+            // numeric domain (int/bigint/double), which was fixed from the
+            // resolved result type, so it agrees with the result metadata type.
+            AggregateValue::Sum(acc) => acc.finalize_sum(),
+            AggregateValue::Avg { acc, count } => {
                 if *count > 0 {
-                    Value::Float(sum / (*count as f64))
+                    acc.finalize_avg(*count)
                 } else {
                     Value::Null
                 }
@@ -305,7 +331,7 @@ pub(super) fn finalize_group(
 /// only reach this helper on the GROUP-BY-free path.
 ///
 /// We cannot reuse [`init_aggregate_accumulators`] + [`finalize_group`] for this
-/// because a fresh `AggregateValue::Sum(0.0)` finalizes to `Float(0.0)`, whereas
+/// because a fresh SUM accumulator finalizes to a typed zero (`0`/`0.0`), whereas
 /// the empty-input answer must be `NULL`. This builds the row directly instead.
 pub(super) fn finalize_empty_global_aggregate(agg_plan: &AggregationPlan) -> QueryRow {
     let mut row_values: HashMap<std::sync::Arc<str>, Value> =
@@ -375,7 +401,7 @@ mod tests {
         for r in 0..repeats {
             for g in 0..groups_count {
                 let key = vec![Value::Integer(g as i32)];
-                let idx = find_or_init_group(&mut state, key, &plan.aggregates);
+                let idx = find_or_init_group(&mut state, key, &plan.aggregates, &[]);
                 // Groups are created on first pass in ascending order.
                 assert_eq!(idx, g, "row (repeat {r}, group {g}) maps to a stable index");
             }
@@ -445,18 +471,244 @@ mod tests {
         let mut state = new_state();
 
         // -0.0 and +0.0 are `==` → same group.
-        let i0 = find_or_init_group(&mut state, vec![Value::Float(0.0)], &plan.aggregates);
-        let i1 = find_or_init_group(&mut state, vec![Value::Float(-0.0)], &plan.aggregates);
+        let i0 = find_or_init_group(&mut state, vec![Value::Float(0.0)], &plan.aggregates, &[]);
+        let i1 = find_or_init_group(&mut state, vec![Value::Float(-0.0)], &plan.aggregates, &[]);
         assert_eq!(i0, i1, "-0.0 and +0.0 must land in the same group");
 
         // Two NaN keys are never `==` → two distinct groups.
-        let n0 = find_or_init_group(&mut state, vec![Value::Float(f64::NAN)], &plan.aggregates);
-        let n1 = find_or_init_group(&mut state, vec![Value::Float(f64::NAN)], &plan.aggregates);
+        let n0 = find_or_init_group(
+            &mut state,
+            vec![Value::Float(f64::NAN)],
+            &plan.aggregates,
+            &[],
+        );
+        let n1 = find_or_init_group(
+            &mut state,
+            vec![Value::Float(f64::NAN)],
+            &plan.aggregates,
+            &[],
+        );
         assert_ne!(n0, n1, "each NaN key forms its own group (NaN != NaN)");
 
         // Same-value different-variant keys stay separate.
-        let a = find_or_init_group(&mut state, vec![Value::Integer(1)], &plan.aggregates);
-        let b = find_or_init_group(&mut state, vec![Value::BigInt(1)], &plan.aggregates);
+        let a = find_or_init_group(&mut state, vec![Value::Integer(1)], &plan.aggregates, &[]);
+        let b = find_or_init_group(&mut state, vec![Value::BigInt(1)], &plan.aggregates, &[]);
         assert_ne!(a, b, "Integer(1) and BigInt(1) are distinct groups");
+    }
+
+    // ---- Issue #2202: SUM/AVG integral result-type preservation ----
+
+    /// Build a single-group (global) plan with one SUM or AVG over column `col`.
+    fn scalar_agg_plan(function: AggregateType, col: &str) -> AggregationPlan {
+        AggregationPlan {
+            group_by_columns: Vec::new(),
+            group_by_output_names: Vec::new(),
+            aggregates: vec![AggregateComputation {
+                function,
+                column: col.to_string(),
+                alias: "r".to_string(),
+                distinct: false,
+            }],
+        }
+    }
+
+    /// Drive `init → update per value → finalize_group` for one scalar aggregate
+    /// with a resolved result type, returning the emitted result value.
+    fn run_scalar_agg(
+        function: AggregateType,
+        result_type: Option<CqlType>,
+        values: &[Value],
+    ) -> Value {
+        let plan = scalar_agg_plan(function, "v");
+        let result_types = vec![result_type];
+        let mut accs = init_aggregate_accumulators(&plan.aggregates, &result_types);
+        for v in values {
+            let row = QueryRow {
+                values: [(std::sync::Arc::<str>::from("v"), v.clone())]
+                    .into_iter()
+                    .collect(),
+                key: RowKey::new(vec![]),
+                metadata: Default::default(),
+                cell_metadata: None,
+            };
+            update_aggregate(&mut accs[0], &plan.aggregates[0], &row);
+        }
+        let row = finalize_group(vec![Value::Null], accs, &plan);
+        row.values.get("r").cloned().expect("result present")
+    }
+
+    /// SUM over integral inputs preserves the integral result type and value
+    /// (issue #2202): int/smallint/tinyint → `Value::Integer`, bigint → BigInt.
+    #[test]
+    fn sum_integral_inputs_preserve_integral_result() {
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::Int),
+                &[Value::Integer(1), Value::Integer(2), Value::Integer(3)],
+            ),
+            Value::Integer(6),
+            "SUM(int) emits Value::Integer, not a float"
+        );
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::BigInt),
+                &[Value::BigInt(10), Value::BigInt(20)],
+            ),
+            Value::BigInt(30),
+            "SUM(bigint) emits Value::BigInt"
+        );
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::SmallInt),
+                &[Value::SmallInt(100), Value::SmallInt(50)],
+            ),
+            Value::Integer(150),
+            "SUM(smallint) promotes to Value::Integer (int)"
+        );
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::TinyInt),
+                &[Value::TinyInt(40), Value::TinyInt(2)],
+            ),
+            Value::Integer(42),
+            "SUM(tinyint) promotes to Value::Integer (int)"
+        );
+    }
+
+    /// SUM over float/double inputs still yields `Value::Float` (double) — no
+    /// regression from the pre-#2202 behaviour.
+    #[test]
+    fn sum_float_inputs_stay_double() {
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::Double),
+                &[Value::Float(1.5), Value::Float(2.25)],
+            ),
+            Value::Float(3.75),
+        );
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::Float),
+                &[Value::Float32(1.0), Value::Float32(2.0)],
+            ),
+            Value::Float(3.0),
+            "SUM(float) stays double (Value::Float)"
+        );
+    }
+
+    /// AVG uses integer division for integral inputs and preserves the result
+    /// type; bigint stays wide; float/double divide in f64.
+    #[test]
+    fn avg_integral_uses_integer_division_and_preserves_type() {
+        // AVG(int) of [1, 2] = 1 (integer division truncates, like Cassandra).
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Avg,
+                Some(CqlType::Int),
+                &[Value::Integer(1), Value::Integer(2)],
+            ),
+            Value::Integer(1),
+        );
+        // A zero still counts toward AVG's divisor.
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Avg,
+                Some(CqlType::Int),
+                &[Value::Integer(0), Value::Integer(0), Value::Integer(3)],
+            ),
+            Value::Integer(1),
+            "AVG counts zeros: 3/3 = 1"
+        );
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Avg,
+                Some(CqlType::BigInt),
+                &[Value::BigInt(10), Value::BigInt(21)],
+            ),
+            Value::BigInt(15),
+            "AVG(bigint) integer division stays bigint"
+        );
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Avg,
+                Some(CqlType::Double),
+                &[Value::Float(1.0), Value::Float(2.0)],
+            ),
+            Value::Float(1.5),
+            "AVG(double) divides in f64",
+        );
+    }
+
+    /// Integral SUM overflow WRAPS (Cassandra's two's-complement Java semantics),
+    /// never saturating or panicking. `int` wraps at the i32 boundary; `bigint`
+    /// wraps at the i64 boundary.
+    #[test]
+    fn sum_integral_overflow_wraps() {
+        // i32::MAX + 1 wraps to i32::MIN.
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::Int),
+                &[Value::Integer(i32::MAX), Value::Integer(1)],
+            ),
+            Value::Integer(i32::MIN),
+            "SUM(int) wraps at the i32 boundary"
+        );
+        // i64::MAX + 1 wraps to i64::MIN.
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::BigInt),
+                &[Value::BigInt(i64::MAX), Value::BigInt(1)],
+            ),
+            Value::BigInt(i64::MIN),
+            "SUM(bigint) wraps at the i64 boundary"
+        );
+    }
+
+    /// NULLs are ignored by SUM/AVG; an all-null group's SUM finalizes to the
+    /// typed zero (matching its result-type metadata) and AVG (count 0) is NULL.
+    #[test]
+    fn sum_avg_ignore_nulls_typed_zero_and_null() {
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                Some(CqlType::Int),
+                &[Value::Null, Value::Integer(5), Value::Null],
+            ),
+            Value::Integer(5),
+            "SUM ignores NULLs"
+        );
+        assert_eq!(
+            run_scalar_agg(AggregateType::Sum, Some(CqlType::Int), &[Value::Null]),
+            Value::Integer(0),
+            "all-null int SUM group is a typed integer zero (not a float)"
+        );
+        assert_eq!(
+            run_scalar_agg(AggregateType::Avg, Some(CqlType::Int), &[Value::Null]),
+            Value::Null,
+            "AVG over no counted inputs is NULL"
+        );
+    }
+
+    /// With an unknown argument type (no schema), SUM/AVG fall back to the
+    /// floating domain → `Value::Float` (double), consistent with the `double`
+    /// result metadata `aggregate_result_cql_type` returns for `None`.
+    #[test]
+    fn sum_avg_unknown_type_falls_back_to_double() {
+        assert_eq!(
+            run_scalar_agg(
+                AggregateType::Sum,
+                None,
+                &[Value::Integer(1), Value::Integer(2)],
+            ),
+            Value::Float(3.0),
+        );
     }
 }

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -212,8 +212,12 @@ impl SelectExecutor {
                         }
                     }
                     ExecutionStep::Aggregate { plan: agg_plan, .. } => {
-                        intermediate_results =
-                            self.execute_aggregation(intermediate_results, agg_plan, &mut context)?;
+                        intermediate_results = self.execute_aggregation(
+                            intermediate_results,
+                            agg_plan,
+                            query_schema.as_deref(),
+                            &mut context,
+                        )?;
                     }
                     ExecutionStep::PerPartitionLimit { count } => {
                         intermediate_results =

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -43,6 +43,7 @@ mod aggregation;
 mod execute;
 mod limit_pushdown;
 mod lookup;
+mod numeric_acc;
 mod predicate;
 mod row_build;
 mod schemaless_point;
@@ -2478,21 +2479,20 @@ mod tests {
         assert_eq!(cols[0].data_type, crate::types::DataType::BigInt);
     }
 
-    /// Issue #1941: SUM/AVG report `double` — CQLite's aggregation accumulates all
-    /// numeric input into an f64 and `finalize_group` emits `Value::Float`, so the
-    /// metadata type MUST be `double` to match the produced value (never the
-    /// argument column's `int` type, and never `Text`).
+    /// Issue #2202: SUM/AVG preserve Cassandra's integral result type — over the
+    /// `int` column `amount` they report `int` (the `Value::Integer` emitted),
+    /// never `double`; over `double` `price` they stay `double`. (AVG shares the
+    /// SUM metadata path; its int typing is pinned end-to-end in
+    /// `issue_2202_sum_avg_result_type` + `select_naming`.)
     #[tokio::test]
-    async fn aggregate_sum_and_avg_report_double() {
-        let sum = agg_result_columns("SELECT SUM(amount) FROM ks.t").await;
-        assert_eq!(sum.len(), 1);
-        assert_eq!(sum[0].cql_type, Some(CqlType::Double));
-        assert_eq!(sum[0].data_type, crate::types::DataType::Float);
-
-        let avg = agg_result_columns("SELECT AVG(amount) FROM ks.t").await;
-        assert_eq!(avg.len(), 1);
-        assert_eq!(avg[0].cql_type, Some(CqlType::Double));
-        assert_eq!(avg[0].data_type, crate::types::DataType::Float);
+    async fn aggregate_sum_and_avg_preserve_integral_type() {
+        use crate::types::DataType;
+        let i = agg_result_columns("SELECT SUM(amount) FROM ks.t").await;
+        assert_eq!(i[0].cql_type, Some(CqlType::Int));
+        assert_eq!(i[0].data_type, DataType::Integer);
+        let d = agg_result_columns("SELECT SUM(price) FROM ks.t").await;
+        assert_eq!(d[0].cql_type, Some(CqlType::Double));
+        assert_eq!(d[0].data_type, DataType::Float);
     }
 
     /// Issue #1941: MIN/MAX preserve the ARGUMENT column's type (the value is

--- a/cqlite-core/src/query/select_executor/numeric_acc.rs
+++ b/cqlite-core/src/query/select_executor/numeric_acc.rs
@@ -1,0 +1,100 @@
+//! Numeric accumulation domain for SUM/AVG (issue #2202).
+//!
+//! Split from `aggregation.rs` (campsite rule, epic #1116) so the accumulator's
+//! type-preserving arithmetic lives in one small, self-contained place.
+
+use crate::schema::CqlType;
+use crate::types::Value;
+
+/// Numeric accumulation domain for SUM/AVG (issue #2202). The domain is fixed at
+/// group-init time from the aggregate's resolved RESULT CQL type (the SAME
+/// `select_naming::sum_avg_result_cql_type` the result metadata is built from),
+/// so the emitted value variant can never disagree with the metadata type.
+#[derive(Debug, Clone)]
+pub(super) enum NumericAcc {
+    /// Integral SUM/AVG. `sum` accumulates in `i64` with Cassandra's two's-
+    /// complement WRAPPING overflow (Java integer/long semantics) — never
+    /// saturating or panicking. `wide` distinguishes the `bigint`/`counter`
+    /// result (emitted as `Value::BigInt`, wraps at the i64 boundary) from the
+    /// `int`/`smallint`/`tinyint` result (emitted as `Value::Integer`, truncated
+    /// to i32 on finalize).
+    ///
+    /// Wrapping equivalence: modular (two's-complement) addition is associative,
+    /// so accumulating narrow inputs in i64 with `wrapping_add` and truncating to
+    /// i32 at the end yields exactly Java's step-wise i32-wrapped sum
+    /// (`(x mod 2^64) mod 2^32 == x mod 2^32`). AVG uses i64 integer division
+    /// (truncating toward zero, matching Java); an AVG over `bigint` whose i64
+    /// sum overflows i64 can diverge from Cassandra's BigInteger AVG — an extreme
+    /// edge (summing enough near-i64::MAX values) that real data never hits.
+    Integral { sum: i64, wide: bool },
+    /// Floating SUM/AVG (`float`/`double`/`decimal`/`varint`/unknown argument) —
+    /// accumulated in `f64` and emitted as `Value::Float` (`double`), matching
+    /// CQLite's pre-#2202 behaviour with no regression.
+    Floating(f64),
+}
+
+impl NumericAcc {
+    /// Initialize the accumulation domain from the aggregate's resolved result
+    /// CQL type. `int`/`smallint`/`tinyint` → narrow integral, `bigint`/`counter`
+    /// → wide integral, everything else (incl. an unknown/`None` type) → floating.
+    /// Mirrors [`crate::query::select_naming::sum_avg_result_cql_type`].
+    pub(super) fn init(result_type: Option<&CqlType>) -> Self {
+        match result_type {
+            Some(CqlType::TinyInt | CqlType::SmallInt | CqlType::Int) => NumericAcc::Integral {
+                sum: 0,
+                wide: false,
+            },
+            Some(CqlType::BigInt | CqlType::Counter) => NumericAcc::Integral { sum: 0, wide: true },
+            _ => NumericAcc::Floating(0.0),
+        }
+    }
+
+    /// Fold one non-null input value into the accumulator, returning whether the
+    /// value was accepted (converted in this domain). Integral domains read
+    /// `as_i64` and wrap; the floating domain reads `as_f64`. A value that does
+    /// not convert (wrong variant for the domain) is ignored and returns `false`,
+    /// exactly as the prior `as_f64`-only path ignored non-numeric inputs. AVG
+    /// increments its count only on an accepted value, so a `0` still counts.
+    pub(super) fn add(&mut self, value: &Value) -> bool {
+        match self {
+            NumericAcc::Integral { sum, .. } => match value.as_i64() {
+                Some(v) => {
+                    *sum = sum.wrapping_add(v);
+                    true
+                }
+                None => false,
+            },
+            NumericAcc::Floating(sum) => match value.as_f64() {
+                Some(v) => {
+                    *sum += v;
+                    true
+                }
+                None => false,
+            },
+        }
+    }
+
+    /// The finalized SUM value: integral domains emit `Value::Integer` (narrow,
+    /// i32-truncated) or `Value::BigInt` (wide); the floating domain emits
+    /// `Value::Float`.
+    pub(super) fn finalize_sum(&self) -> Value {
+        match self {
+            NumericAcc::Integral { sum, wide: false } => Value::Integer(*sum as i32),
+            NumericAcc::Integral { sum, wide: true } => Value::BigInt(*sum),
+            NumericAcc::Floating(sum) => Value::Float(*sum),
+        }
+    }
+
+    /// The finalized AVG value over `count` inputs (`count > 0`). Integral
+    /// domains use i64 integer division (truncating toward zero, like Java) and
+    /// emit the matching narrow/wide variant; the floating domain divides in f64.
+    pub(super) fn finalize_avg(&self, count: u64) -> Value {
+        match self {
+            NumericAcc::Integral { sum, wide: false } => {
+                Value::Integer((sum / count as i64) as i32)
+            }
+            NumericAcc::Integral { sum, wide: true } => Value::BigInt(sum / count as i64),
+            NumericAcc::Floating(sum) => Value::Float(sum / count as f64),
+        }
+    }
+}

--- a/cqlite-core/src/query/select_executor/numeric_acc.rs
+++ b/cqlite-core/src/query/select_executor/numeric_acc.rs
@@ -6,6 +6,39 @@
 use crate::schema::CqlType;
 use crate::types::Value;
 
+/// The integral width SUM/AVG accumulates and narrows to at finalize (issue
+/// #2202). Cassandra's `AggregateFcts.java` returns the SAME type as the
+/// argument for every integral column — it does NOT promote `tinyint`/
+/// `smallint` to `int` (its own docs warn of an overflow risk precisely
+/// because the result stays the input's narrow width).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IntWidth {
+    /// `tinyint` — narrows to `Value::TinyInt` (i8), wraps at the i8 boundary.
+    Byte,
+    /// `smallint` — narrows to `Value::SmallInt` (i16), wraps at the i16 boundary.
+    Short,
+    /// `int` — narrows to `Value::Integer` (i32), wraps at the i32 boundary.
+    Int,
+    /// `bigint`/`counter` — `Value::BigInt` (i64) directly, no narrowing.
+    Long,
+}
+
+impl IntWidth {
+    /// Narrow a wide (`i64`) accumulator to this width's `Value` variant. `as`
+    /// truncation is Rust's two's-complement narrowing cast — the same
+    /// semantics as Java's narrowing primitive conversion (`(byte) x`/
+    /// `(short) x`/`(int) x`) that Cassandra's own aggregate functions use, so
+    /// this is exact parity, not an approximation.
+    fn narrow(self, sum: i64) -> Value {
+        match self {
+            IntWidth::Byte => Value::TinyInt(sum as i8),
+            IntWidth::Short => Value::SmallInt(sum as i16),
+            IntWidth::Int => Value::Integer(sum as i32),
+            IntWidth::Long => Value::BigInt(sum),
+        }
+    }
+}
+
 /// Numeric accumulation domain for SUM/AVG (issue #2202). The domain is fixed at
 /// group-init time from the aggregate's resolved RESULT CQL type (the SAME
 /// `select_naming::sum_avg_result_cql_type` the result metadata is built from),
@@ -14,19 +47,19 @@ use crate::types::Value;
 pub(super) enum NumericAcc {
     /// Integral SUM/AVG. `sum` accumulates in `i64` with Cassandra's two's-
     /// complement WRAPPING overflow (Java integer/long semantics) — never
-    /// saturating or panicking. `wide` distinguishes the `bigint`/`counter`
-    /// result (emitted as `Value::BigInt`, wraps at the i64 boundary) from the
-    /// `int`/`smallint`/`tinyint` result (emitted as `Value::Integer`, truncated
-    /// to i32 on finalize).
+    /// saturating or panicking — and narrows to `width` only at finalize.
     ///
     /// Wrapping equivalence: modular (two's-complement) addition is associative,
-    /// so accumulating narrow inputs in i64 with `wrapping_add` and truncating to
-    /// i32 at the end yields exactly Java's step-wise i32-wrapped sum
-    /// (`(x mod 2^64) mod 2^32 == x mod 2^32`). AVG uses i64 integer division
-    /// (truncating toward zero, matching Java); an AVG over `bigint` whose i64
-    /// sum overflows i64 can diverge from Cassandra's BigInteger AVG — an extreme
-    /// edge (summing enough near-i64::MAX values) that real data never hits.
-    Integral { sum: i64, wide: bool },
+    /// so accumulating in i64 with `wrapping_add` and truncating to the narrow
+    /// width at the end yields exactly the same result as wrapping at every
+    /// step in that narrow width (`(x mod 2^64) mod 2^n == x mod 2^n`). This
+    /// also matches Cassandra's OWN implementation: its AVG aggregates sum in a
+    /// Java `long` and narrow only at `compute()`, exactly like this. AVG uses
+    /// i64 integer division on the wide sum (truncating toward zero, matching
+    /// Java) before narrowing; an AVG over `bigint` whose i64 sum overflows i64
+    /// can diverge from Cassandra's BigInteger AVG — an extreme edge (summing
+    /// enough near-i64::MAX values) that real data never hits.
+    Integral { sum: i64, width: IntWidth },
     /// Floating SUM/AVG (`float`/`double`/`decimal`/`varint`/unknown argument) —
     /// accumulated in `f64` and emitted as `Value::Float` (`double`), matching
     /// CQLite's pre-#2202 behaviour with no regression.
@@ -35,18 +68,19 @@ pub(super) enum NumericAcc {
 
 impl NumericAcc {
     /// Initialize the accumulation domain from the aggregate's resolved result
-    /// CQL type. `int`/`smallint`/`tinyint` → narrow integral, `bigint`/`counter`
-    /// → wide integral, everything else (incl. an unknown/`None` type) → floating.
+    /// CQL type. `tinyint`/`smallint`/`int` each get their OWN narrow integral
+    /// width (Cassandra does not promote them); `bigint`/`counter` → wide
+    /// integral; everything else (incl. an unknown/`None` type) → floating.
     /// Mirrors [`crate::query::select_naming::sum_avg_result_cql_type`].
     pub(super) fn init(result_type: Option<&CqlType>) -> Self {
-        match result_type {
-            Some(CqlType::TinyInt | CqlType::SmallInt | CqlType::Int) => NumericAcc::Integral {
-                sum: 0,
-                wide: false,
-            },
-            Some(CqlType::BigInt | CqlType::Counter) => NumericAcc::Integral { sum: 0, wide: true },
-            _ => NumericAcc::Floating(0.0),
-        }
+        let width = match result_type {
+            Some(CqlType::TinyInt) => IntWidth::Byte,
+            Some(CqlType::SmallInt) => IntWidth::Short,
+            Some(CqlType::Int) => IntWidth::Int,
+            Some(CqlType::BigInt | CqlType::Counter) => IntWidth::Long,
+            _ => return NumericAcc::Floating(0.0),
+        };
+        NumericAcc::Integral { sum: 0, width }
     }
 
     /// Fold one non-null input value into the accumulator, returning whether the
@@ -74,26 +108,32 @@ impl NumericAcc {
         }
     }
 
-    /// The finalized SUM value: integral domains emit `Value::Integer` (narrow,
-    /// i32-truncated) or `Value::BigInt` (wide); the floating domain emits
-    /// `Value::Float`.
+    /// The finalized SUM value: integral domains narrow the wide `i64` sum to
+    /// their own width (`Value::TinyInt`/`SmallInt`/`Integer`/`BigInt`); the
+    /// floating domain emits `Value::Float`.
     pub(super) fn finalize_sum(&self) -> Value {
         match self {
-            NumericAcc::Integral { sum, wide: false } => Value::Integer(*sum as i32),
-            NumericAcc::Integral { sum, wide: true } => Value::BigInt(*sum),
+            NumericAcc::Integral { sum, width } => width.narrow(*sum),
             NumericAcc::Floating(sum) => Value::Float(*sum),
         }
     }
 
-    /// The finalized AVG value over `count` inputs (`count > 0`). Integral
-    /// domains use i64 integer division (truncating toward zero, like Java) and
-    /// emit the matching narrow/wide variant; the floating domain divides in f64.
+    /// The finalized AVG value over `count` accepted inputs. Integral domains
+    /// divide the wide `i64` sum by `count` (integer division, truncating
+    /// toward zero, like Java) and narrow to their own width; the floating
+    /// domain divides in f64.
+    ///
+    /// Precondition: `count > 0` — every caller (`finalize_group`,
+    /// `finalize_empty_global_aggregate`) checks this first, so an empty group
+    /// never reaches here; asserted rather than guarded so a future caller
+    /// cannot silently reintroduce a divide-by-zero panic.
     pub(super) fn finalize_avg(&self, count: u64) -> Value {
+        debug_assert!(
+            count > 0,
+            "finalize_avg requires at least one accepted input"
+        );
         match self {
-            NumericAcc::Integral { sum, wide: false } => {
-                Value::Integer((sum / count as i64) as i32)
-            }
-            NumericAcc::Integral { sum, wide: true } => Value::BigInt(sum / count as i64),
+            NumericAcc::Integral { sum, width } => width.narrow(sum / count as i64),
             NumericAcc::Floating(sum) => Value::Float(sum / count as f64),
         }
     }

--- a/cqlite-core/src/query/select_executor/stream_agg.rs
+++ b/cqlite-core/src/query/select_executor/stream_agg.rs
@@ -12,6 +12,7 @@ use super::aggregation::{
     build_group_key, finalize_empty_global_aggregate, finalize_group, find_or_init_group,
     init_aggregate_accumulators, update_aggregate, AggregationState,
 };
+use super::row_build::parse_cql_type_str;
 use super::{
     build_row_from_scan_cached, classify_partition_lookup, evaluate_predicates,
     validate_token_predicates, AccessPath, ExecutionContext, ExecutionStep, PartitionKeyCache,
@@ -19,9 +20,40 @@ use super::{
 };
 use crate::query::result::QueryRow;
 use crate::query::select_ast::WhereExpression;
+use crate::query::select_naming::aggregate_result_cql_type;
 use crate::query::select_optimizer::{AggregationPlan, SSTablePredicate};
-use crate::schema::TableSchema;
+use crate::schema::{CqlType, TableSchema};
 use crate::{Error, Result, TableId, Value};
+
+/// Resolve each aggregate's RESULT CQL type (parallel to `agg_plan.aggregates`)
+/// from the schema, using the SAME `aggregate_result_cql_type` the result
+/// metadata is built from (issue #2202). This fixes each SUM/AVG accumulator's
+/// numeric domain (integral vs floating) so the emitted value variant can never
+/// disagree with the metadata type — and it is resolved ONCE per query, then
+/// shared across every group's accumulator init.
+fn resolve_aggregate_result_types(
+    agg_plan: &AggregationPlan,
+    schema: Option<&TableSchema>,
+) -> Vec<Option<CqlType>> {
+    agg_plan
+        .aggregates
+        .iter()
+        .map(|agg| {
+            // `*` (COUNT(*)) has no argument column; SUM/AVG never take `*`.
+            let arg_type = if agg.column == "*" {
+                None
+            } else {
+                schema.and_then(|s| {
+                    s.columns
+                        .iter()
+                        .find(|c| c.name == agg.column)
+                        .and_then(|c| parse_cql_type_str(&c.data_type))
+                })
+            };
+            aggregate_result_cql_type(&agg.function, arg_type)
+        })
+        .collect()
+}
 
 /// Read-ahead window for the D2 aggregate fold's scan stream. The fold retains
 /// only the running accumulator, so this bounds the in-flight scan rows (not the
@@ -47,6 +79,7 @@ impl SelectExecutor {
         &self,
         rows: Vec<QueryRow>,
         agg_plan: &AggregationPlan,
+        schema_opt: Option<&TableSchema>,
         _context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
         const PER_ROW_MEMORY_ESTIMATE_BYTES: usize = 100;
@@ -65,9 +98,18 @@ impl SelectExecutor {
             memory_limit_bytes: DEFAULT_AGGREGATION_MEMORY_LIMIT,
         };
 
+        // Issue #2202: resolve the per-aggregate result types ONCE, then reuse for
+        // every group's accumulator init (drives integral vs floating SUM/AVG).
+        let result_types = resolve_aggregate_result_types(agg_plan, schema_opt);
+
         for row in rows {
             let group_key = build_group_key(&row, &agg_plan.group_by_columns);
-            let group_index = find_or_init_group(&mut agg_state, group_key, &agg_plan.aggregates);
+            let group_index = find_or_init_group(
+                &mut agg_state,
+                group_key,
+                &agg_plan.aggregates,
+                &result_types,
+            );
             let group_aggregates = &mut agg_state.groups[group_index].1;
 
             for (i, agg_comp) in agg_plan.aggregates.iter().enumerate() {
@@ -155,7 +197,10 @@ impl SelectExecutor {
         context.access_path = Some(AccessPath::FallbackFullScan { reason });
         crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
 
-        let mut accumulators = init_aggregate_accumulators(&agg_plan.aggregates);
+        // Issue #2202: fix each SUM/AVG accumulator's numeric domain from the
+        // resolved result types (same source as the result metadata).
+        let result_types = resolve_aggregate_result_types(agg_plan, schema_opt);
+        let mut accumulators = init_aggregate_accumulators(&agg_plan.aggregates, &result_types);
         let mut folded_any = false;
 
         // Issue #1592: fold over the BATCHED streaming surface — one async wake per

--- a/cqlite-core/src/query/select_naming.rs
+++ b/cqlite-core/src/query/select_naming.rs
@@ -135,14 +135,16 @@ pub(crate) fn result_column_name(expr: &SelectExpression, index: usize) -> Strin
 /// CQLite's executor actually emits in `finalize_group`
 /// (`select_executor::aggregation`):
 ///   * `COUNT(*)` / `COUNT(col)` → `bigint` (emitted `Value::BigInt`)
-///   * `SUM(_)` / `AVG(_)`       → the integral RESULT type Cassandra promotes
-///     the argument to (issue #2202): `int`/`smallint`/`tinyint` → `int`,
-///     `bigint`/`counter` → `bigint`; every other numeric argument — `float`,
-///     `double`, `decimal`, `varint`, or an unknown/unresolved argument — →
-///     `double`. The executor accumulates integrally (i64, Cassandra wrapping)
-///     for the integral cases and in `f64` otherwise, and `finalize_group` emits
-///     the matching `Value` variant, so this metadata type never lies about the
-///     produced value (the #1941 invariant).
+///   * `SUM(_)` / `AVG(_)`       → the RESULT type Cassandra returns for the
+///     argument (issue #2202, `AggregateFcts.java`): every INTEGRAL argument
+///     (`tinyint`/`smallint`/`int`/`bigint`/`counter`) returns THE SAME type
+///     back — Cassandra does NOT promote `tinyint`/`smallint` to `int`; every
+///     other numeric argument — `float`, `double`, `decimal`, `varint`, or an
+///     unknown/unresolved argument — → `double`. The executor accumulates
+///     integrally (`i64`, Cassandra wrapping, narrowed to the argument's own
+///     width at finalize) for the integral cases and in `f64` otherwise, and
+///     `finalize_group` emits the matching `Value` variant, so this metadata
+///     type never lies about the produced value (the #1941 invariant).
 ///   * `MIN(col)` / `MAX(col)`   → the argument column's type (the value is
 ///     cloned through unchanged)
 ///
@@ -165,18 +167,21 @@ pub(crate) fn aggregate_result_cql_type(
     }
 }
 
-/// Cassandra's SUM/AVG result-type promotion (issue #2202): integral argument
-/// types promote to the integral result Cassandra returns (`int`/`smallint`/
-/// `tinyint` → `int`; `bigint`/`counter` → `bigint`), and every other numeric
-/// argument (`float`, `double`, `decimal`, `varint`) — plus an unknown argument
-/// — yields `double`, preserving CQLite's prior float behaviour with no
-/// regression. This is the SINGLE source of truth the executor's accumulator
+/// Cassandra's SUM/AVG result-type rule (issue #2202, verified against
+/// `AggregateFcts.java`): EVERY integral argument type returns THE SAME type —
+/// `tinyint`→`tinyint`, `smallint`→`smallint`, `int`→`int`, `bigint`/`counter`→
+/// `bigint`. Cassandra does NOT promote the narrow integral types to `int`
+/// (its own docs warn of overflow risk precisely because the result stays the
+/// input's narrow width). Every other numeric argument (`float`, `double`,
+/// `decimal`, `varint`) — plus an unknown argument — yields `double`,
+/// preserving CQLite's prior float behaviour with no regression. This is the
+/// SINGLE source of truth the executor's accumulator
 /// (`init_aggregate_accumulators`) also consults, so the emitted value variant
 /// and the result metadata type can never disagree.
 pub(crate) fn sum_avg_result_cql_type(arg_type: Option<CqlType>) -> CqlType {
     match arg_type {
-        Some(CqlType::TinyInt | CqlType::SmallInt | CqlType::Int) => CqlType::Int,
-        Some(CqlType::BigInt | CqlType::Counter) => CqlType::BigInt,
+        Some(t @ (CqlType::TinyInt | CqlType::SmallInt | CqlType::Int | CqlType::BigInt)) => t,
+        Some(CqlType::Counter) => CqlType::BigInt,
         _ => CqlType::Double,
     }
 }
@@ -292,11 +297,12 @@ mod tests {
     }
 
     /// Issue #1941/#2202: aggregate result type comes from the function (+
-    /// argument type), never a name lookup. COUNT → bigint; SUM/AVG promote the
-    /// integral argument to Cassandra's integral result (int/smallint/tinyint →
-    /// int, bigint/counter → bigint) and fall back to double for float/double/
-    /// unknown; MIN/MAX preserve the argument type and are the ONLY variants that
-    /// return `None` when the argument type is unknown.
+    /// argument type), never a name lookup. COUNT → bigint; SUM/AVG return the
+    /// SAME integral type back for every integral argument (Cassandra does NOT
+    /// promote tinyint/smallint to int — verified against `AggregateFcts.java`)
+    /// and fall back to double for float/double/unknown; MIN/MAX preserve the
+    /// argument type and are the ONLY variants that return `None` when the
+    /// argument type is unknown.
     #[test]
     fn aggregate_result_cql_type_derives_from_function_and_argument() {
         assert_eq!(
@@ -304,7 +310,8 @@ mod tests {
             Some(CqlType::BigInt),
             "COUNT is bigint regardless of any argument type"
         );
-        // Issue #2202: SUM/AVG preserve Cassandra's integral result types.
+        // Issue #2202: SUM/AVG preserve Cassandra's narrow integral result types —
+        // NO promotion to int for tinyint/smallint.
         assert_eq!(
             aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::Int)),
             Some(CqlType::Int),
@@ -317,13 +324,13 @@ mod tests {
         );
         assert_eq!(
             aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::SmallInt)),
-            Some(CqlType::Int),
-            "SUM(smallint) promotes to int"
+            Some(CqlType::SmallInt),
+            "SUM(smallint) stays smallint (Cassandra does not promote to int)"
         );
         assert_eq!(
             aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::TinyInt)),
-            Some(CqlType::Int),
-            "SUM(tinyint) promotes to int"
+            Some(CqlType::TinyInt),
+            "SUM(tinyint) stays tinyint (Cassandra does not promote to int)"
         );
         assert_eq!(
             aggregate_result_cql_type(&AggregateType::Avg, Some(CqlType::Int)),
@@ -334,6 +341,21 @@ mod tests {
             aggregate_result_cql_type(&AggregateType::Avg, Some(CqlType::BigInt)),
             Some(CqlType::BigInt),
             "AVG(bigint) is bigint"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Avg, Some(CqlType::SmallInt)),
+            Some(CqlType::SmallInt),
+            "AVG(smallint) stays smallint"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Avg, Some(CqlType::TinyInt)),
+            Some(CqlType::TinyInt),
+            "AVG(tinyint) stays tinyint"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::Counter)),
+            Some(CqlType::BigInt),
+            "SUM(counter) is bigint"
         );
         // Float/double inputs still return double (no regression).
         assert_eq!(

--- a/cqlite-core/src/query/select_naming.rs
+++ b/cqlite-core/src/query/select_naming.rs
@@ -135,24 +135,49 @@ pub(crate) fn result_column_name(expr: &SelectExpression, index: usize) -> Strin
 /// CQLite's executor actually emits in `finalize_group`
 /// (`select_executor::aggregation`):
 ///   * `COUNT(*)` / `COUNT(col)` → `bigint` (emitted `Value::BigInt`)
-///   * `SUM(_)` / `AVG(_)`       → `double` (CQLite accumulates every numeric
-///     input into an `f64` and emits `Value::Float`, so the metadata type MUST
-///     be `double` to describe the produced value rather than lie about it)
+///   * `SUM(_)` / `AVG(_)`       → the integral RESULT type Cassandra promotes
+///     the argument to (issue #2202): `int`/`smallint`/`tinyint` → `int`,
+///     `bigint`/`counter` → `bigint`; every other numeric argument — `float`,
+///     `double`, `decimal`, `varint`, or an unknown/unresolved argument — →
+///     `double`. The executor accumulates integrally (i64, Cassandra wrapping)
+///     for the integral cases and in `f64` otherwise, and `finalize_group` emits
+///     the matching `Value` variant, so this metadata type never lies about the
+///     produced value (the #1941 invariant).
 ///   * `MIN(col)` / `MAX(col)`   → the argument column's type (the value is
 ///     cloned through unchanged)
 ///
 /// `arg_type` is the pre-resolved CQL type of the aggregate's argument column
-/// (from the schema); it is consulted ONLY for MIN/MAX. Returns `None` solely
-/// for a MIN/MAX whose argument type is unknown (no schema, or the argument is
-/// not a resolvable column), leaving the caller's existing untyped fallback.
+/// (from the schema); it drives the SUM/AVG promotion above and the MIN/MAX
+/// passthrough. Returns `None` solely for a MIN/MAX whose argument type is
+/// unknown (no schema, or the argument is not a resolvable column), leaving the
+/// caller's existing untyped fallback — SUM/AVG always resolve to a concrete
+/// type (`double` when the argument is unknown).
 pub(crate) fn aggregate_result_cql_type(
     function: &AggregateType,
     arg_type: Option<CqlType>,
 ) -> Option<CqlType> {
     match function {
         AggregateType::Count => Some(CqlType::BigInt),
-        AggregateType::Sum | AggregateType::Avg => Some(CqlType::Double),
+        // Issue #2202: preserve Cassandra's integral SUM/AVG result types instead
+        // of collapsing every numeric input to `double`.
+        AggregateType::Sum | AggregateType::Avg => Some(sum_avg_result_cql_type(arg_type)),
         AggregateType::Min | AggregateType::Max => arg_type,
+    }
+}
+
+/// Cassandra's SUM/AVG result-type promotion (issue #2202): integral argument
+/// types promote to the integral result Cassandra returns (`int`/`smallint`/
+/// `tinyint` → `int`; `bigint`/`counter` → `bigint`), and every other numeric
+/// argument (`float`, `double`, `decimal`, `varint`) — plus an unknown argument
+/// — yields `double`, preserving CQLite's prior float behaviour with no
+/// regression. This is the SINGLE source of truth the executor's accumulator
+/// (`init_aggregate_accumulators`) also consults, so the emitted value variant
+/// and the result metadata type can never disagree.
+pub(crate) fn sum_avg_result_cql_type(arg_type: Option<CqlType>) -> CqlType {
+    match arg_type {
+        Some(CqlType::TinyInt | CqlType::SmallInt | CqlType::Int) => CqlType::Int,
+        Some(CqlType::BigInt | CqlType::Counter) => CqlType::BigInt,
+        _ => CqlType::Double,
     }
 }
 
@@ -266,10 +291,12 @@ mod tests {
         assert!(aggregate_arg_source_columns(&col("value")).is_empty());
     }
 
-    /// Issue #1941: aggregate result type comes from the function (+ argument
-    /// type for MIN/MAX), never a name lookup. COUNT → bigint; SUM/AVG → double
-    /// (CQLite emits `Value::Float`); MIN/MAX preserve the argument type and are
-    /// the ONLY variants that return `None` when the argument type is unknown.
+    /// Issue #1941/#2202: aggregate result type comes from the function (+
+    /// argument type), never a name lookup. COUNT → bigint; SUM/AVG promote the
+    /// integral argument to Cassandra's integral result (int/smallint/tinyint →
+    /// int, bigint/counter → bigint) and fall back to double for float/double/
+    /// unknown; MIN/MAX preserve the argument type and are the ONLY variants that
+    /// return `None` when the argument type is unknown.
     #[test]
     fn aggregate_result_cql_type_derives_from_function_and_argument() {
         assert_eq!(
@@ -277,13 +304,53 @@ mod tests {
             Some(CqlType::BigInt),
             "COUNT is bigint regardless of any argument type"
         );
+        // Issue #2202: SUM/AVG preserve Cassandra's integral result types.
         assert_eq!(
             aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::Int)),
-            Some(CqlType::Double)
+            Some(CqlType::Int),
+            "SUM(int) is int"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::BigInt)),
+            Some(CqlType::BigInt),
+            "SUM(bigint) is bigint"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::SmallInt)),
+            Some(CqlType::Int),
+            "SUM(smallint) promotes to int"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::TinyInt)),
+            Some(CqlType::Int),
+            "SUM(tinyint) promotes to int"
         );
         assert_eq!(
             aggregate_result_cql_type(&AggregateType::Avg, Some(CqlType::Int)),
-            Some(CqlType::Double)
+            Some(CqlType::Int),
+            "AVG(int) is int"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Avg, Some(CqlType::BigInt)),
+            Some(CqlType::BigInt),
+            "AVG(bigint) is bigint"
+        );
+        // Float/double inputs still return double (no regression).
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Sum, Some(CqlType::Double)),
+            Some(CqlType::Double),
+            "SUM(double) stays double"
+        );
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Avg, Some(CqlType::Float)),
+            Some(CqlType::Double),
+            "AVG(float) is double (no regression)"
+        );
+        // Unknown SUM/AVG argument → double (never None, unlike MIN/MAX).
+        assert_eq!(
+            aggregate_result_cql_type(&AggregateType::Sum, None),
+            Some(CqlType::Double),
+            "SUM with unknown argument falls back to double"
         );
         assert_eq!(
             aggregate_result_cql_type(&AggregateType::Min, Some(CqlType::Int)),

--- a/cqlite-core/tests/issue_1578_streaming_aggregate_multigen_parity.rs
+++ b/cqlite-core/tests/issue_1578_streaming_aggregate_multigen_parity.rs
@@ -24,7 +24,7 @@
 //!   SUM(v)    = 999 + 5 + 40 = 1044
 //!   MIN(v)    = 5
 //!   MAX(v)    = 999
-//!   AVG(v)    = 1044 / 3 = 348.0
+//!   AVG(v)    = 1044 / 3 = 348   (v is int → integer division, issue #2202)
 //!   MIN(name) = "alpha2"   ('a' < 'c' < 'd': alpha2 < charlie < delta)
 //!   MAX(name) = "delta"
 //!
@@ -250,15 +250,11 @@ async fn streaming_aggregate_multigen_parity() {
 
     assert_agg(&db, &format!("SELECT COUNT(*) {from}"), Value::BigInt(3)).await;
     assert_agg(&db, &format!("SELECT COUNT(v) {from}"), Value::BigInt(3)).await;
-    assert_agg(&db, &format!("SELECT SUM(v) {from}"), Value::Float(1044.0)).await;
+    // Issue #2202: v is int → SUM(int) → int, AVG(int) → int (integer division).
+    assert_agg(&db, &format!("SELECT SUM(v) {from}"), Value::Integer(1044)).await;
     assert_agg(&db, &format!("SELECT MIN(v) {from}"), Value::Integer(5)).await;
     assert_agg(&db, &format!("SELECT MAX(v) {from}"), Value::Integer(999)).await;
-    assert_agg(
-        &db,
-        &format!("SELECT AVG(v) {from}"),
-        Value::Float(1044.0 / 3.0),
-    )
-    .await;
+    assert_agg(&db, &format!("SELECT AVG(v) {from}"), Value::Integer(348)).await;
     assert_agg(
         &db,
         &format!("SELECT MIN(name) {from}"),

--- a/cqlite-core/tests/issue_1578_streaming_aggregate_parity.rs
+++ b/cqlite-core/tests/issue_1578_streaming_aggregate_parity.rs
@@ -257,18 +257,16 @@ async fn streaming_aggregate_parity_matrix() {
     )
     .await;
 
-    // SUM (as f64) over each numeric type.
-    assert_agg(&db, &format!("SELECT SUM(i) {from}"), Value::Float(46.0)).await;
-    assert_agg(&db, &format!("SELECT SUM(b) {from}"), Value::Float(1037.0)).await;
+    // SUM preserves the integral result type (issue #2202): SUM(int) → int,
+    // SUM(bigint) → bigint; SUM(double) stays double.
+    assert_agg(&db, &format!("SELECT SUM(i) {from}"), Value::Integer(46)).await;
+    assert_agg(&db, &format!("SELECT SUM(b) {from}"), Value::BigInt(1037)).await;
     assert_agg(&db, &format!("SELECT SUM(d) {from}"), Value::Float(9.5)).await;
 
-    // AVG = sum/count over the NON-NULL values (i: 46/4, d: 9.5/4).
-    assert_agg(
-        &db,
-        &format!("SELECT AVG(i) {from}"),
-        Value::Float(46.0 / 4.0),
-    )
-    .await;
+    // AVG = sum/count over the NON-NULL values. Integral AVG uses Cassandra's
+    // integer division (issue #2202): AVG(int) = 46/4 = 11 (truncated), not 11.5.
+    // AVG(double) still divides in f64 (9.5/4).
+    assert_agg(&db, &format!("SELECT AVG(i) {from}"), Value::Integer(11)).await;
     assert_agg(
         &db,
         &format!("SELECT AVG(d) {from}"),
@@ -286,7 +284,7 @@ async fn streaming_aggregate_parity_matrix() {
     assert_agg(
         &db,
         &format!("SELECT SUM(i) {from} WHERE i >= 10 ALLOW FILTERING"),
-        Value::Float(50.0),
+        Value::Integer(50),
     )
     .await;
 }

--- a/cqlite-core/tests/issue_1871_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1871_aggregate_arg_projection.rs
@@ -80,7 +80,8 @@ async fn setup(schema_file: &str, keyspace_filter: &str) -> Result<Database, Str
 }
 
 /// Numeric view of an aggregate result `Value`, normalizing the BIGINT-typed
-/// `MIN`/`MAX` clone and the `f64` `SUM`/`AVG` into one comparable type.
+/// `MIN`/`MAX`/`SUM`/`AVG` (issue #2202: SUM/AVG over a BIGINT column stay
+/// `bigint`, using integer division for AVG) into one comparable type.
 fn as_num(v: &Value) -> f64 {
     v.as_f64()
         .unwrap_or_else(|| panic!("aggregate result must be numeric, got {v:?}"))
@@ -144,8 +145,10 @@ async fn ungrouped_numeric_aggregates_match_reference() {
         (agg(&result, 0, "Sum_value") - 51_641_479.0).abs() < EPS,
         "global SUM(value)"
     );
+    // Issue #2202: AVG over a BIGINT column uses integer division (truncated):
+    // 51_641_479 / 100 = 516_414 (not 516_414.79).
     assert!(
-        (agg(&result, 0, "Avg_value") - 516_414.79).abs() < EPS,
+        (agg(&result, 0, "Avg_value") - 516_414.0).abs() < EPS,
         "global AVG(value)"
     );
     assert!(
@@ -183,11 +186,14 @@ async fn grouped_numeric_aggregates_match_reference_per_group() {
         .await
         .expect("grouped numeric-aggregate query must execute");
 
-    // (category, sum, avg, min, max)
+    // (category, sum, avg, min, max). Issue #2202: value is BIGINT, so SUM/AVG
+    // stay bigint and AVG is integer division (truncated toward zero):
+    //   A: 18_785_439 / 36 = 521_817   B: 17_144_227 / 36 = 476_228
+    //   C: 15_711_813 / 28 = 561_136
     let expected: [(&str, f64, f64, f64, f64); 3] = [
-        ("A", 18_785_439.0, 521_817.75, 42_438.0, 990_685.0),
-        ("B", 17_144_227.0, 476_228.527_777_78, 34_344.0, 941_836.0),
-        ("C", 15_711_813.0, 561_136.178_571_43, 73_596.0, 979_921.0),
+        ("A", 18_785_439.0, 521_817.0, 42_438.0, 990_685.0),
+        ("B", 17_144_227.0, 476_228.0, 34_344.0, 941_836.0),
+        ("C", 15_711_813.0, 561_136.0, 73_596.0, 979_921.0),
     ];
 
     assert_eq!(

--- a/cqlite-core/tests/issue_1872_aggregate_to_json_values.rs
+++ b/cqlite-core/tests/issue_1872_aggregate_to_json_values.rs
@@ -156,7 +156,8 @@ async fn sum_aggregate_to_json_carries_value_under_stable_name() {
     let value = first_row.get("Sum_value").unwrap_or_else(|| {
         panic!("issue #1872: to_json must key SUM by `Sum_value`; row was {first_row}")
     });
-    // BIGINT summed as f64 → JSON number equal to the reference sum.
+    // SUM over a BIGINT column stays bigint (issue #2202) → JSON number equal to
+    // the reference sum.
     let got = value
         .as_f64()
         .unwrap_or_else(|| panic!("issue #1872: `Sum_value` must be numeric, not {value}"));

--- a/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
+++ b/cqlite-core/tests/issue_1952_aggregate_arg_projection.rs
@@ -118,7 +118,7 @@ async fn grouped_sum_with_selected_dimension_is_exact() {
         let got = agg_value(&result.rows, cat, "Sum_value");
         assert_eq!(
             got,
-            Some(&Value::Float(sum as f64)),
+            Some(&Value::BigInt(sum)),
             "SUM(value) for category {cat}; scan projection must include the \
              aggregate argument column `value`",
         );
@@ -229,7 +229,7 @@ async fn grouped_sum_with_unselected_dimension_is_per_group() {
         let got = agg_value(&result.rows, cat, "Sum_value");
         assert_eq!(
             got,
-            Some(&Value::Float(sum as f64)),
+            Some(&Value::BigInt(sum)),
             "SUM(value) for category {cat}; GROUP BY column `category` must be \
              scanned even though it is not in the SELECT clause",
         );
@@ -310,7 +310,7 @@ async fn single_sum_filtered_by_unselected_where_column_is_exact() {
     let sum = result.rows[0].values.get("Sum_value");
     assert_eq!(
         sum,
-        Some(&Value::Float(18_785_439.0)),
+        Some(&Value::BigInt(18_785_439)),
         "SUM(value) WHERE category = 'A' must equal the category-A total; the WHERE \
          column `category` must be in the scan projection so the predicate backstop \
          can evaluate it (pre-fix: `category` filtered out → every row rejected → \
@@ -346,7 +346,7 @@ async fn single_sum_filtered_by_unselected_and_agg_arg_columns_is_exact() {
     assert_eq!(result.rows.len(), 1, "an ungrouped SUM returns one row");
     assert_eq!(
         result.rows[0].values.get("Sum_value"),
-        Some(&Value::Float(12_520_796.0)),
+        Some(&Value::BigInt(12_520_796)),
         "SUM(value) WHERE category = 'A' AND value > 500000 must equal the exact \
          filtered subtotal; `category` (WHERE-only) must be scanned alongside \
          `value` (the aggregate argument)",
@@ -388,7 +388,7 @@ async fn grouped_sum_filtered_by_agg_arg_column_is_per_group() {
     for &(cat, sum) in filtered {
         assert_eq!(
             agg_value(&result.rows, cat, "Sum_value"),
-            Some(&Value::Float(sum as f64)),
+            Some(&Value::BigInt(sum)),
             "SUM(value) WHERE value > 500000 for category {cat} must be the exact \
              per-group filtered subtotal",
         );

--- a/cqlite-core/tests/issue_2202_sum_avg_result_type.rs
+++ b/cqlite-core/tests/issue_2202_sum_avg_result_type.rs
@@ -1,0 +1,216 @@
+//! Issue #2202: SUM/AVG must preserve Cassandra's integral result TYPE (not
+//! collapse every numeric input to `double`), and the result metadata type must
+//! match the value variant CQLite actually emits (the #1941 invariant).
+//!
+//! Cassandra 5.0 promotion this pins:
+//!   * SUM/AVG over `int`      → `int`     (`Value::Integer`)
+//!   * SUM/AVG over `bigint`   → `bigint`  (`Value::BigInt`)
+//!   * SUM/AVG over `double`   → `double`  (`Value::Float`, no regression)
+//!   * SUM/AVG over `float`    → `double`  (`Value::Float`, no regression)
+//!
+//! AVG over an integral column uses integer division (truncated toward zero).
+//!
+//! Exercised THROUGH the public `Database::execute` surface on real Cassandra 5.0
+//! fixtures (`test_basic`): BIGINT `value` (`multi_partition_table`), INT
+//! `row_value` (`static_columns_table`), and DOUBLE `weight` / FLOAT `height`
+//! (`simple_table`). Requires `CQLITE_DATASETS_ROOT` + fetched Data.db binaries;
+//! skips loudly (never a false 0-row pass) when a fixture is absent.
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::QueryResult;
+use cqlite_core::schema::CqlType;
+use cqlite_core::types::{DataType, Value};
+use cqlite_core::Database;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup() -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join("basic-types.cql");
+    if !schema_path.exists() {
+        return Err(format!("basic-types.cql not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some("/test_basic/".to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+/// The single (global-aggregate) result row plus its one aggregate column's
+/// metadata `(cql_type, data_type)` and the emitted `Value`.
+async fn run_scalar_aggregate(db: &Database, sql: &str) -> (Option<CqlType>, DataType, Value) {
+    let result: QueryResult = db
+        .execute(sql)
+        .await
+        .unwrap_or_else(|e| panic!("query `{sql}` must execute: {e}"));
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "global aggregate `{sql}` yields exactly one row"
+    );
+    assert_eq!(
+        result.metadata.columns.len(),
+        1,
+        "single-aggregate SELECT `{sql}` has one result column"
+    );
+    let col = &result.metadata.columns[0];
+    let value = result.rows[0]
+        .values
+        .get(col.name.as_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "`{sql}`: metadata column {:?} MUST be a row value key",
+                col.name
+            )
+        })
+        .clone();
+    (col.cql_type.clone(), col.data_type.clone(), value)
+}
+
+/// The #1941 invariant: the metadata `(cql_type, data_type)` must describe the
+/// SAME variant as the emitted value. Assert the exact expected variant AND that
+/// metadata agrees with it.
+fn assert_type_matches_value(
+    label: &str,
+    cql_type: Option<CqlType>,
+    data_type: DataType,
+    value: &Value,
+    expect_cql: CqlType,
+    expect_data: DataType,
+) {
+    assert_eq!(cql_type, Some(expect_cql), "{label}: metadata cql_type");
+    assert_eq!(data_type, expect_data, "{label}: metadata data_type");
+    let variant_ok = matches!(
+        (&data_type, value),
+        (DataType::Integer, Value::Integer(_))
+            | (DataType::BigInt, Value::BigInt(_))
+            | (DataType::Float, Value::Float(_))
+    );
+    assert!(
+        variant_ok,
+        "{label}: metadata type {data_type:?} must match emitted value variant, got {value:?}"
+    );
+}
+
+/// SUM/AVG over a BIGINT column stay `bigint` (value + metadata), and AVG uses
+/// integer division. Values pinned to the committed golden reference
+/// (`multi_partition_table`: sum 51_641_479, count 100 → avg 516_414).
+#[tokio::test]
+async fn sum_avg_bigint_column_is_bigint() {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping sum_avg_bigint_column_is_bigint: {e}");
+            return;
+        }
+    };
+    let tbl = "test_basic.multi_partition_table";
+
+    let (cql, dt, v) = run_scalar_aggregate(&db, &format!("SELECT SUM(value) FROM {tbl}")).await;
+    assert_type_matches_value(
+        "SUM(bigint)",
+        cql,
+        dt,
+        &v,
+        CqlType::BigInt,
+        DataType::BigInt,
+    );
+    assert_eq!(v, Value::BigInt(51_641_479), "SUM(bigint) value");
+
+    let (cql, dt, v) = run_scalar_aggregate(&db, &format!("SELECT AVG(value) FROM {tbl}")).await;
+    assert_type_matches_value(
+        "AVG(bigint)",
+        cql,
+        dt,
+        &v,
+        CqlType::BigInt,
+        DataType::BigInt,
+    );
+    assert_eq!(
+        v,
+        Value::BigInt(516_414),
+        "AVG(bigint) is integer division: 51_641_479 / 100 = 516_414 (truncated)"
+    );
+}
+
+/// SUM/AVG over an INT column are `int` (value + metadata) — never `double`.
+#[tokio::test]
+async fn sum_avg_int_column_is_int() {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping sum_avg_int_column_is_int: {e}");
+            return;
+        }
+    };
+    let tbl = "test_basic.static_columns_table";
+
+    let (cql, dt, v) =
+        run_scalar_aggregate(&db, &format!("SELECT SUM(row_value) FROM {tbl}")).await;
+    assert_type_matches_value("SUM(int)", cql, dt, &v, CqlType::Int, DataType::Integer);
+
+    let (cql, dt, v) =
+        run_scalar_aggregate(&db, &format!("SELECT AVG(row_value) FROM {tbl}")).await;
+    assert_type_matches_value("AVG(int)", cql, dt, &v, CqlType::Int, DataType::Integer);
+}
+
+/// SUM/AVG over FLOAT/DOUBLE columns still return `double` (`Value::Float`) — the
+/// pre-#2202 behaviour is preserved with no regression.
+#[tokio::test]
+async fn sum_avg_float_double_columns_stay_double() {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping sum_avg_float_double_columns_stay_double: {e}");
+            return;
+        }
+    };
+    let tbl = "test_basic.simple_table";
+
+    for sql in [
+        format!("SELECT SUM(weight) FROM {tbl}"), // DOUBLE
+        format!("SELECT AVG(weight) FROM {tbl}"),
+        format!("SELECT SUM(height) FROM {tbl}"), // FLOAT → double
+        format!("SELECT AVG(height) FROM {tbl}"),
+    ] {
+        let (cql, dt, v) = run_scalar_aggregate(&db, &sql).await;
+        assert_type_matches_value(&sql, cql, dt, &v, CqlType::Double, DataType::Float);
+    }
+}

--- a/cqlite-core/tests/issue_2202_sum_avg_result_type.rs
+++ b/cqlite-core/tests/issue_2202_sum_avg_result_type.rs
@@ -1,20 +1,28 @@
-//! Issue #2202: SUM/AVG must preserve Cassandra's integral result TYPE (not
-//! collapse every numeric input to `double`), and the result metadata type must
-//! match the value variant CQLite actually emits (the #1941 invariant).
+//! Issue #2202: SUM/AVG must preserve Cassandra's result TYPE (not collapse
+//! every numeric input to `double`), and the result metadata type must match
+//! the value variant CQLite actually emits (the #1941 invariant).
 //!
-//! Cassandra 5.0 promotion this pins:
-//!   * SUM/AVG over `int`      → `int`     (`Value::Integer`)
-//!   * SUM/AVG over `bigint`   → `bigint`  (`Value::BigInt`)
-//!   * SUM/AVG over `double`   → `double`  (`Value::Float`, no regression)
-//!   * SUM/AVG over `float`    → `double`  (`Value::Float`, no regression)
+//! Cassandra 5.0's rule this pins (`AggregateFcts.java`): SUM/AVG return the
+//! SAME type as an integral argument — NO promotion of `tinyint`/`smallint` to
+//! `int`:
+//!   * SUM/AVG over `tinyint`  → `tinyint`  (`Value::TinyInt`)
+//!   * SUM/AVG over `smallint` → `smallint` (`Value::SmallInt`)
+//!   * SUM/AVG over `int`      → `int`      (`Value::Integer`)
+//!   * SUM/AVG over `bigint`   → `bigint`   (`Value::BigInt`)
+//!   * SUM/AVG over `double`   → `double`   (`Value::Float`, no regression)
+//!   * SUM/AVG over `float`    → `double`   (`Value::Float`, no regression)
 //!
 //! AVG over an integral column uses integer division (truncated toward zero).
+//! SUM over a narrow integral column WRAPS at that column's own width (two's
+//! complement, Java semantics) — the `tinyint`/`smallint` case below exercises
+//! a REAL i8/i16 overflow-wrap on the fixture data, not a synthetic boundary.
 //!
 //! Exercised THROUGH the public `Database::execute` surface on real Cassandra 5.0
 //! fixtures (`test_basic`): BIGINT `value` (`multi_partition_table`), INT
-//! `row_value` (`static_columns_table`), and DOUBLE `weight` / FLOAT `height`
-//! (`simple_table`). Requires `CQLITE_DATASETS_ROOT` + fetched Data.db binaries;
-//! skips loudly (never a false 0-row pass) when a fixture is absent.
+//! `row_value` (`static_columns_table`), TINYINT `small_number` / SMALLINT
+//! `medium_number` / DOUBLE `weight` / FLOAT `height` (`simple_table`). Requires
+//! `CQLITE_DATASETS_ROOT` + fetched Data.db binaries; skips loudly (never a
+//! false 0-row pass) when a fixture is absent.
 
 #![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
 
@@ -119,7 +127,9 @@ fn assert_type_matches_value(
     assert_eq!(data_type, expect_data, "{label}: metadata data_type");
     let variant_ok = matches!(
         (&data_type, value),
-        (DataType::Integer, Value::Integer(_))
+        (DataType::TinyInt, Value::TinyInt(_))
+            | (DataType::SmallInt, Value::SmallInt(_))
+            | (DataType::Integer, Value::Integer(_))
             | (DataType::BigInt, Value::BigInt(_))
             | (DataType::Float, Value::Float(_))
     );
@@ -189,6 +199,86 @@ async fn sum_avg_int_column_is_int() {
     let (cql, dt, v) =
         run_scalar_aggregate(&db, &format!("SELECT AVG(row_value) FROM {tbl}")).await;
     assert_type_matches_value("AVG(int)", cql, dt, &v, CqlType::Int, DataType::Integer);
+}
+
+/// SUM/AVG over TINYINT/SMALLINT columns stay their OWN narrow width — Cassandra
+/// does NOT promote them to `int`. `simple_table.small_number` (tinyint) is
+/// dense enough (1000 rows) that its real SUM naturally overflows the i8 range,
+/// so this exercises a REAL wrap, not a synthetic boundary case. Reference
+/// values computed by hand from the committed JSONL golden
+/// (`nb-1-big-Data.db.jsonl`): sum(small_number) = 61_456 → wraps to 16 (i8);
+/// avg(small_number) = 61_456 / 1000 = 61 (fits, no wrap); sum(medium_number) =
+/// 15_459_417 → wraps to -7_079 (i16); avg(medium_number) = 15_459 (fits).
+#[tokio::test]
+async fn sum_avg_tinyint_smallint_columns_stay_narrow_and_wrap() {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping sum_avg_tinyint_smallint_columns_stay_narrow_and_wrap: {e}");
+            return;
+        }
+    };
+    let tbl = "test_basic.simple_table";
+
+    let (cql, dt, v) =
+        run_scalar_aggregate(&db, &format!("SELECT SUM(small_number) FROM {tbl}")).await;
+    assert_type_matches_value(
+        "SUM(tinyint)",
+        cql,
+        dt,
+        &v,
+        CqlType::TinyInt,
+        DataType::TinyInt,
+    );
+    assert_eq!(
+        v,
+        Value::TinyInt(16),
+        "SUM(tinyint): real sum 61_456 wraps at the i8 boundary to 16"
+    );
+
+    let (cql, dt, v) =
+        run_scalar_aggregate(&db, &format!("SELECT AVG(small_number) FROM {tbl}")).await;
+    assert_type_matches_value(
+        "AVG(tinyint)",
+        cql,
+        dt,
+        &v,
+        CqlType::TinyInt,
+        DataType::TinyInt,
+    );
+    assert_eq!(v, Value::TinyInt(61), "AVG(tinyint): 61_456 / 1000 = 61");
+
+    let (cql, dt, v) =
+        run_scalar_aggregate(&db, &format!("SELECT SUM(medium_number) FROM {tbl}")).await;
+    assert_type_matches_value(
+        "SUM(smallint)",
+        cql,
+        dt,
+        &v,
+        CqlType::SmallInt,
+        DataType::SmallInt,
+    );
+    assert_eq!(
+        v,
+        Value::SmallInt(-7_079),
+        "SUM(smallint): real sum 15_459_417 wraps at the i16 boundary to -7_079"
+    );
+
+    let (cql, dt, v) =
+        run_scalar_aggregate(&db, &format!("SELECT AVG(medium_number) FROM {tbl}")).await;
+    assert_type_matches_value(
+        "AVG(smallint)",
+        cql,
+        dt,
+        &v,
+        CqlType::SmallInt,
+        DataType::SmallInt,
+    );
+    assert_eq!(
+        v,
+        Value::SmallInt(15_459),
+        "AVG(smallint): 15_459_417 / 1000 = 15_459"
+    );
 }
 
 /// SUM/AVG over FLOAT/DOUBLE columns still return `double` (`Value::Float`) — the


### PR DESCRIPTION
Closes #2202

## Summary
CQLite's SUM/AVG aggregates collapsed every numeric input to `f64`/`Value::Float`. This restores
Cassandra parity:
- `SUM(int)`→`int`, `SUM(bigint)`/`SUM(counter)`→`bigint`, `AVG(int)`→`int`, `AVG(bigint)`→`bigint`
- `SUM(tinyint)`→`tinyint` (wraps at i8), `SUM(smallint)`→`smallint` (wraps at i16), and their AVGs
  stay narrow too — verified against Cassandra 5.0's actual `AggregateFcts.java` (separate
  `ByteType`/`ShortType` narrow aggregates; return type == input type)
- `SUM`/`AVG` over float/double inputs unchanged (still `double`)
- Result metadata type always matches the emitted `Value` variant (the #1941 invariant) — both are
  derived from the same `aggregate_result_cql_type` resolution, so they cannot diverge
- Integral overflow wraps (Java/Cassandra two's-complement semantics), never panics/saturates

## Review history (review-first, before any full gate)
- Round 1 (`rust-reviewer` + roborev): found the tinyint/smallint→int promotion was wrong — verified
  against Cassandra's real source and fixed.
- Round 2 (re-verify): `rust-reviewer` hand-checked the wrap-math goldens independently — clean.
  roborev raised a theoretical AVG per-step-vs-wide-sum divergence concern; investigated against the
  raw Cassandra source (`AvgAggregate`, lines 1014-1067 of `AggregateFcts.java`) — AVG uses a wide
  `long sum` accumulator (never narrowed per-step) with integer division, narrowing only the final
  quotient — exactly what this PR's `NumericAcc::finalize_avg` does. Finding closed as investigated/
  not-applicable with the source excerpt on record (`roborev show 9`).

## Test plan
- [x] `cqlite-core/tests/issue_2202_sum_avg_result_type.rs` — real-dataset (`test_basic.simple_table`)
      coverage for int/bigint/double/float/tinyint/smallint SUM+AVG, including genuine i8/i16 overflow
      wraps (not synthetic boundaries)
- [x] Unit tests in `aggregation.rs`/`select_naming.rs` pin type resolution, overflow wrapping, and
      metadata/value coupling
- [x] `scripts/agent-gate.sh --lite` PASS (fmt, scoped clippy, blast-radius tests) at every round
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — runs once via `flow-closer`