### PR TITLE
fix(#2235): fail-closed i32 offset guard for scalar Utf8/Binary arrow batches (borrow-before-clone)

### DIFF
--- a/cqlite-core/src/export/arrow_convert.rs
+++ b/cqlite-core/src/export/arrow_convert.rs
@@ -138,23 +138,32 @@ fn checked_value_bytes(total_bytes: usize) -> Result<(), ArrowConvertError> {
 
 /// Guard the cumulative byte length of a nullable `Utf8` column before handing
 /// it to `StringArray::from`. Saturating summation cannot itself overflow.
+///
+/// Generic over `AsRef<str>` so the wide-text scalar/element paths can guard on
+/// **borrowed** `&str`/`Cow<str>` slices of the already-materialized row values
+/// — the check runs before any owned copy is made, so the fail-closed path
+/// never clones ~2 GiB just to reject it (issue #2235).
 #[inline]
-fn checked_string_offsets(values: &[Option<String>]) -> Result<(), ArrowConvertError> {
+fn checked_string_offsets<S: AsRef<str>>(values: &[Option<S>]) -> Result<(), ArrowConvertError> {
     let total = values
         .iter()
         .flatten()
-        .fold(0usize, |acc, s| acc.saturating_add(s.len()));
+        .fold(0usize, |acc, s| acc.saturating_add(s.as_ref().len()));
     checked_value_bytes(total)
 }
 
 /// Guard the cumulative byte length of a nullable `Binary` column before
 /// handing it to `BinaryArray::from`. Saturating summation cannot overflow.
+///
+/// Generic over `AsRef<[u8]>` so callers can guard on **borrowed** `&[u8]`
+/// slices of the row values before any owned copy — see
+/// [`checked_string_offsets`] (issue #2235).
 #[inline]
-fn checked_binary_offsets(values: &[Option<&[u8]>]) -> Result<(), ArrowConvertError> {
+fn checked_binary_offsets<B: AsRef<[u8]>>(values: &[Option<B>]) -> Result<(), ArrowConvertError> {
     let total = values
         .iter()
         .flatten()
-        .fold(0usize, |acc, b| acc.saturating_add(b.len()));
+        .fold(0usize, |acc, b| acc.saturating_add(b.as_ref().len()));
     checked_value_bytes(total)
 }
 
@@ -631,12 +640,16 @@ pub(crate) fn build_typed_value_array(
             Ok(Arc::new(Float64Array::from(arr)))
         }
         CqlType::Text | CqlType::Ascii | CqlType::Varchar => {
-            let arr: Vec<Option<String>> = values
+            // Guard on BORROWED &str slices of the already-materialized row
+            // values — the i32-offset check runs before StringArray::from
+            // copies them, so the fail-closed path never clones ~2 GiB just to
+            // reject it (issue #2235).
+            let refs: Vec<Option<&str>> = values
                 .iter()
                 .filter_map(|opt| {
                     let v = unwrap_frozen_value(*opt)?;
                     Some(match v {
-                        Value::Text(s) => Ok(Some(s.clone())),
+                        Value::Text(s) => Ok(Some(s.as_str())),
                         Value::Null => Ok(None),
                         other => Err(ArrowConvertError::InvalidValue(format!(
                             "expected Text value in element, got {:?}",
@@ -644,17 +657,19 @@ pub(crate) fn build_typed_value_array(
                         ))),
                     })
                 })
-                .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
-            checked_string_offsets(&arr)?;
-            Ok(Arc::new(StringArray::from(arr)))
+                .collect::<Result<Vec<Option<&str>>, ArrowConvertError>>()?;
+            checked_string_offsets(&refs)?;
+            Ok(Arc::new(StringArray::from(refs)))
         }
         CqlType::Blob => {
-            let byte_slices: Vec<Option<Vec<u8>>> = values
+            // Guard on BORROWED &[u8] slices before BinaryArray::from copies
+            // them (issue #2235) — no owned Vec<u8> clone precedes the check.
+            let refs: Vec<Option<&[u8]>> = values
                 .iter()
                 .filter_map(|opt| {
                     let v = unwrap_frozen_value(*opt)?;
                     Some(match v {
-                        Value::Blob(b) => Ok(Some(b.clone())),
+                        Value::Blob(b) => Ok(Some(b.as_slice())),
                         Value::Null => Ok(None),
                         other => Err(ArrowConvertError::InvalidValue(format!(
                             "expected Blob value in element, got {:?}",
@@ -662,8 +677,7 @@ pub(crate) fn build_typed_value_array(
                         ))),
                     })
                 })
-                .collect::<Result<Vec<Option<Vec<u8>>>, ArrowConvertError>>()?;
-            let refs: Vec<Option<&[u8]>> = byte_slices.iter().map(|o| o.as_deref()).collect();
+                .collect::<Result<Vec<Option<&[u8]>>, ArrowConvertError>>()?;
             checked_binary_offsets(&refs)?;
             Ok(Arc::new(BinaryArray::from(refs)))
         }
@@ -1520,6 +1534,30 @@ fn build_string_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, A
         col.cql_type.as_ref().map(unwrap_frozen_type),
         Some(CqlType::Text | CqlType::Ascii | CqlType::Varchar)
     );
+    if strict_text {
+        // Authoritative wide-text column: values are raw `Value::Text` payloads
+        // (or null/error). Guard on BORROWED &str slices before StringArray::from
+        // copies them, so the fail-closed path never clones ~2 GiB of raw text
+        // just to reject it (issue #2235).
+        let refs: Vec<Option<&str>> = rows
+            .iter()
+            .map(
+                |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
+                    None | Some(Value::Null) => Ok(None),
+                    Some(Value::Text(s)) => Ok(Some(s.as_str())),
+                    Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                        "column '{}': expected Text value, got {:?}",
+                        col.name, other
+                    ))),
+                },
+            )
+            .collect::<Result<Vec<Option<&str>>, ArrowConvertError>>()?;
+        checked_string_offsets(&refs)?;
+        return Ok(Arc::new(StringArray::from(refs)));
+    }
+    // Opaque / untyped fallback: `format_value` produces NEW owned strings
+    // (small, computed representations — not a raw multi-GiB payload). The guard
+    // checks these already-materialized formatted strings.
     let values: Vec<Option<String>> = rows
         .iter()
         .map(
@@ -1527,14 +1565,7 @@ fn build_string_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, A
                 None => Ok(None),
                 Some(Value::Null) => Ok(None),
                 Some(Value::Text(s)) => Ok(Some(s.clone())),
-                // `Json` is only a valid string source on the opaque fallback;
-                // an authoritative text column must fail closed on it.
-                Some(Value::Json(j)) if !strict_text => Ok(Some(j.to_string())),
-                Some(other) if strict_text => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Text value, got {:?}",
-                    col.name, other
-                ))),
-                // Opaque / untyped fallback: format complex types as strings.
+                Some(Value::Json(j)) => Ok(Some(j.to_string())),
                 Some(other) => Ok(Some(ValueFormatter::format_value(other))),
             },
         )
@@ -2401,6 +2432,43 @@ mod tests {
         ));
         assert!(super::checked_value_bytes(0).is_ok());
         assert!(super::checked_value_bytes(1_000_000).is_ok());
+    }
+
+    /// (12e) Bounded fail-closed through the REAL typed Blob builder path.
+    /// We alias ONE 16 MiB blob `Value` across 128 rows (`Vec<Option<&Value>>`)
+    /// so the cumulative byte length is `128 * 16 MiB = i32::MAX + 1`, yet peak
+    /// RAM stays ~16 MiB. Post-#2235 the Blob arm guards on the borrowed `&[u8]`
+    /// slices BEFORE `BinaryArray::from` copies them, so it returns a typed
+    /// error without ever cloning ~2 GiB of owned `Vec<u8>` (the earlier
+    /// `b.clone()` path would have OOM'd/allocated 2 GiB before failing closed).
+    #[test]
+    fn typed_blob_builder_over_i32_max_fails_closed_without_2gib_clone() {
+        const CHUNK: usize = 16 * 1024 * 1024; // 16 MiB
+        const N: usize = 128; // 128 * 16 MiB = i32::MAX + 1
+        let big = Value::Blob(vec![0u8; CHUNK]);
+        let refs: Vec<Option<&Value>> = (0..N).map(|_| Some(&big)).collect();
+        let err = super::build_typed_value_array(&CqlType::Blob, &refs);
+        assert!(
+            matches!(err, Err(ArrowConvertError::InvalidValue(_))),
+            "Blob arm must fail closed at the i32 offset ceiling"
+        );
+    }
+
+    /// (12f) Bounded fail-closed through the REAL typed Text builder path.
+    /// Aliases ONE 16 MiB text `Value` across 128 rows: the arm guards on
+    /// borrowed `&str` before `StringArray::from` copies, so no ~2 GiB clone
+    /// precedes the typed error (issue #2235).
+    #[test]
+    fn typed_text_builder_over_i32_max_fails_closed_without_2gib_clone() {
+        const CHUNK: usize = 16 * 1024 * 1024; // 16 MiB
+        const N: usize = 128; // 128 * 16 MiB = i32::MAX + 1
+        let big = Value::Text("a".repeat(CHUNK));
+        let refs: Vec<Option<&Value>> = (0..N).map(|_| Some(&big)).collect();
+        let err = super::build_typed_value_array(&CqlType::Text, &refs);
+        assert!(
+            matches!(err, Err(ArrowConvertError::InvalidValue(_))),
+            "Text arm must fail closed at the i32 offset ceiling"
+        );
     }
 
     /// (12b) Genuine overflow reproduction through the exact `Vec<Option<&[u8]>>`

--- a/cqlite-core/src/export/arrow_convert.rs
+++ b/cqlite-core/src/export/arrow_convert.rs
@@ -108,6 +108,56 @@ fn checked_offset(len: usize) -> Result<i32, ArrowConvertError> {
     })
 }
 
+/// Fail closed when the **cumulative byte length** of a `Utf8`/`Binary` column
+/// would overflow the `i32`-backed value-offset buffer.
+///
+/// `StringArray`/`BinaryArray` (unlike their `Large*` siblings) store value
+/// end-offsets as `i32`. The offset of the last value equals the total byte
+/// length of the column; once that total crosses `i32::MAX` (2 GiB) the arrow
+/// builder either panics on the offset conversion or silently produces a
+/// non-monotonic/corrupt buffer. Flight/export batches are bounded by **row
+/// count** (default 8192), not bytes, so a batch of moderately wide text/blob
+/// values (e.g. ≥256 KiB each — all well within Cassandra's per-value limits)
+/// can cross this ceiling on a library data path. This returns
+/// [`ArrowConvertError::InvalidValue`] at that boundary instead. This is the
+/// scalar analogue of [`checked_offset`]'s List/Map element-count guard (issue
+/// #1486); see issue #2235. Normal-size columns take the identical fast path.
+#[inline]
+fn checked_value_bytes(total_bytes: usize) -> Result<(), ArrowConvertError> {
+    if total_bytes > i32::MAX as usize {
+        return Err(ArrowConvertError::InvalidValue(format!(
+            "cumulative Utf8/Binary byte length {} exceeds i32::MAX ({}); Arrow \
+             StringArray/BinaryArray value offsets are 32-bit — reduce the batch \
+             row count (byte-bounded batching) or export via LargeUtf8/LargeBinary",
+            total_bytes,
+            i32::MAX
+        )));
+    }
+    Ok(())
+}
+
+/// Guard the cumulative byte length of a nullable `Utf8` column before handing
+/// it to `StringArray::from`. Saturating summation cannot itself overflow.
+#[inline]
+fn checked_string_offsets(values: &[Option<String>]) -> Result<(), ArrowConvertError> {
+    let total = values
+        .iter()
+        .flatten()
+        .fold(0usize, |acc, s| acc.saturating_add(s.len()));
+    checked_value_bytes(total)
+}
+
+/// Guard the cumulative byte length of a nullable `Binary` column before
+/// handing it to `BinaryArray::from`. Saturating summation cannot overflow.
+#[inline]
+fn checked_binary_offsets(values: &[Option<&[u8]>]) -> Result<(), ArrowConvertError> {
+    let total = values
+        .iter()
+        .flatten()
+        .fold(0usize, |acc, b| acc.saturating_add(b.len()));
+    checked_value_bytes(total)
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -595,6 +645,7 @@ pub(crate) fn build_typed_value_array(
                     })
                 })
                 .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+            checked_string_offsets(&arr)?;
             Ok(Arc::new(StringArray::from(arr)))
         }
         CqlType::Blob => {
@@ -613,6 +664,7 @@ pub(crate) fn build_typed_value_array(
                 })
                 .collect::<Result<Vec<Option<Vec<u8>>>, ArrowConvertError>>()?;
             let refs: Vec<Option<&[u8]>> = byte_slices.iter().map(|o| o.as_deref()).collect();
+            checked_binary_offsets(&refs)?;
             Ok(Arc::new(BinaryArray::from(refs)))
         }
         CqlType::Timestamp => {
@@ -743,6 +795,7 @@ pub(crate) fn build_typed_value_array(
                     })
                 })
                 .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+            checked_string_offsets(&arr)?;
             Ok(Arc::new(StringArray::from(arr)))
         }
         CqlType::Uuid | CqlType::TimeUuid => {
@@ -779,6 +832,7 @@ pub(crate) fn build_typed_value_array(
                     })
                 })
                 .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+            checked_string_offsets(&arr)?;
             Ok(Arc::new(StringArray::from(arr)))
         }
         // ----------------------------------------------------------------
@@ -940,6 +994,7 @@ pub(crate) fn build_typed_value_array(
                         ))),
                     })
                     .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+                checked_string_offsets(&arr)?;
                 return Ok(Arc::new(StringArray::from(arr)));
             }
 
@@ -1049,6 +1104,7 @@ pub(crate) fn build_typed_value_array(
                         ))),
                     })
                     .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+                checked_string_offsets(&arr)?;
                 return Ok(Arc::new(StringArray::from(arr)));
             }
 
@@ -1137,6 +1193,7 @@ pub(crate) fn build_typed_value_array(
                     Some(v) => Some(ValueFormatter::format_value(v)),
                 })
                 .collect();
+            checked_string_offsets(&arr)?;
             Ok(Arc::new(StringArray::from(arr)))
         }
     }
@@ -1482,6 +1539,7 @@ fn build_string_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, A
             },
         )
         .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+    checked_string_offsets(&values)?;
     Ok(Arc::new(StringArray::from(values)))
 }
 
@@ -1500,6 +1558,7 @@ fn build_binary_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, A
             },
         )
         .collect::<Result<Vec<Option<&[u8]>>, ArrowConvertError>>()?;
+    checked_binary_offsets(&values)?;
     Ok(Arc::new(BinaryArray::from(values)))
 }
 
@@ -1699,6 +1758,7 @@ fn build_duration_utf8_array(
             },
         )
         .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+    checked_string_offsets(&values)?;
     Ok(Arc::new(StringArray::from(values)))
 }
 
@@ -1744,6 +1804,7 @@ fn build_inet_utf8_array(
             },
         )
         .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+    checked_string_offsets(&values)?;
     Ok(Arc::new(StringArray::from(values)))
 }
 
@@ -1775,6 +1836,7 @@ fn build_list_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, Arr
         }
     }
 
+    checked_string_offsets(&values)?;
     let values_array = Arc::new(StringArray::from(values)) as ArrayRef;
     let field = Arc::new(Field::new("item", ArrowDataType::Utf8, true));
     let offset_buffer = OffsetBuffer::new(offsets.into());
@@ -1819,6 +1881,8 @@ fn build_map_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, Arro
     }
 
     // Build struct array for entries
+    checked_string_offsets(&keys)?;
+    checked_string_offsets(&values)?;
     let key_array = Arc::new(StringArray::from(keys)) as ArrayRef;
     let value_array = Arc::new(StringArray::from(values)) as ArrayRef;
 
@@ -2317,6 +2381,89 @@ mod tests {
         assert_eq!(super::checked_offset(0).ok(), Some(0));
         assert_eq!(super::checked_offset(1).ok(), Some(1));
         assert_eq!(super::checked_offset(1_000_000).ok(), Some(1_000_000));
+    }
+
+    /// (12) Issue #2235: scalar `Utf8`/`Binary` cumulative-byte guard. Arrow
+    /// `StringArray`/`BinaryArray` store value end-offsets as `i32`; a batch
+    /// whose total value bytes cross `i32::MAX` (2 GiB) overflows the offset
+    /// buffer. Flight batches are row-bounded (8192), not byte-bounded, so wide
+    /// values reach this. The shared `checked_value_bytes` core fails closed at
+    /// the boundary — the scalar analogue of #1486's `checked_offset`. Tested
+    /// directly (no allocation): materializing 2 GiB of values is infeasible.
+    #[test]
+    fn checked_value_bytes_past_i32_max_is_error() {
+        // At the ceiling: i32::MAX bytes still fit the offset buffer.
+        assert!(super::checked_value_bytes(i32::MAX as usize).is_ok());
+        // One byte past the ceiling must fail closed (would overflow i32).
+        assert!(matches!(
+            super::checked_value_bytes(i32::MAX as usize + 1),
+            Err(ArrowConvertError::InvalidValue(_))
+        ));
+        assert!(super::checked_value_bytes(0).is_ok());
+        assert!(super::checked_value_bytes(1_000_000).is_ok());
+    }
+
+    /// (12b) Genuine overflow reproduction through the exact `Vec<Option<&[u8]>>`
+    /// input `build_binary_array` / the Blob arm hand to the guard. We alias ONE
+    /// 16 MiB buffer 128 times so the CUMULATIVE byte length is
+    /// `128 * 16 MiB = i32::MAX + 1` — crossing the ceiling with ~16 MiB of real
+    /// RAM instead of 2 GiB. On the unguarded path `BinaryArray::from(refs)`
+    /// panics/corrupts on the i32 offset; the guard returns a typed error first.
+    #[test]
+    fn scalar_binary_cumulative_bytes_over_i32_max_is_typed_error() {
+        const CHUNK: usize = 16 * 1024 * 1024; // 16 MiB
+        const N: usize = 128; // 128 * 16 MiB = 2_147_483_648 = i32::MAX + 1
+        let buf = vec![0u8; CHUNK];
+        let refs: Vec<Option<&[u8]>> = (0..N).map(|_| Some(buf.as_slice())).collect();
+        // Preconditions: this really crosses the ceiling (cheap RAM, huge sum).
+        let total: usize = refs.iter().flatten().map(|b| b.len()).sum();
+        assert_eq!(total, i32::MAX as usize + 1, "test must cross i32::MAX");
+        // The guard fails closed instead of letting the arrow builder overflow.
+        assert!(matches!(
+            super::checked_binary_offsets(&refs),
+            Err(ArrowConvertError::InvalidValue(_))
+        ));
+    }
+
+    /// (12c) String analogue of (12b): the same cumulative-byte guard on the
+    /// `Vec<Option<String>>` input every scalar/fallback Utf8 build funnels
+    /// through. Aliasing owned Strings is impossible, so drive
+    /// `checked_string_offsets` with a synthetic slice whose reported lengths
+    /// sum past `i32::MAX` — reproducing the offset overflow condition without
+    /// allocating 2 GiB. Just under the ceiling stays Ok.
+    #[test]
+    fn scalar_string_cumulative_bytes_over_i32_max_is_typed_error() {
+        // A tiny helper vec is not enough to cross 2 GiB; instead build a slice
+        // of empty strings plus one string whose len pushes the sum over. We
+        // avoid a real 2 GiB allocation by testing the summing wrapper on a
+        // just-fits vs just-over pair via `String::with_capacity`-free lengths.
+        // Fast path: total under the ceiling builds fine.
+        let ok = vec![Some("a".to_string()), None, Some("bc".to_string())];
+        assert!(super::checked_string_offsets(&ok).is_ok());
+        // Over the ceiling: proven via the shared core the wrapper delegates to.
+        assert!(matches!(
+            super::checked_value_bytes(i32::MAX as usize + 42),
+            Err(ArrowConvertError::InvalidValue(_))
+        ));
+    }
+
+    /// (12d) End-to-end regression: normal-size Text and Blob columns still
+    /// build unchanged through `rows_to_record_batch` (the Flight export path)
+    /// now that the byte guard sits inline.
+    #[test]
+    fn normal_scalar_text_and_blob_still_build_through_byte_guard() {
+        let text_cols = vec![col("t", DataType::Text, Some(CqlType::Text))];
+        let text_rows = vec![
+            row_one("t", Value::Text("hello".into())),
+            row_one("t", Value::Null),
+        ];
+        let batch = rows_to_record_batch(&text_cols, &text_rows).expect("text must build");
+        assert_eq!(batch.num_rows(), 2);
+
+        let blob_cols = vec![col("b", DataType::Blob, Some(CqlType::Blob))];
+        let blob_rows = vec![row_one("b", Value::Blob(vec![1, 2, 3, 4]))];
+        let batch = rows_to_record_batch(&blob_cols, &blob_rows).expect("blob must build");
+        assert_eq!(batch.num_rows(), 1);
     }
 
     /// (11c) End-to-end regression guard: a real, normal-size List/Map still

--- a/cqlite-core/src/export/arrow_convert.rs
+++ b/cqlite-core/src/export/arrow_convert.rs
@@ -30,6 +30,8 @@
 //! | tuple\<A,B,…\>    | `Struct(field_0:A, field_1:B, …)`     | Positional names; per-position types|
 //! | udt\<name\>       | `Struct(f1:T1, f2:T2, …)`             | Field names from schema; null OK  |
 
+use std::borrow::Cow;
+
 use crate::query::{ColumnInfo, QueryRow};
 use crate::schema::CqlType;
 use crate::types::{DataType, Value};
@@ -1555,23 +1557,27 @@ fn build_string_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, A
         checked_string_offsets(&refs)?;
         return Ok(Arc::new(StringArray::from(refs)));
     }
-    // Opaque / untyped fallback: `format_value` produces NEW owned strings
-    // (small, computed representations — not a raw multi-GiB payload). The guard
-    // checks these already-materialized formatted strings.
-    let values: Vec<Option<String>> = rows
+    // Opaque / untyped fallback. Raw `Value::Text` payloads can be multi-GiB, so
+    // represent them as BORROWED `Cow::Borrowed(&str)` and guard on the borrowed
+    // lengths before any owned copy is made (issue #2235). Only the small,
+    // computed `format_value`/`Json` representations are materialized as owned
+    // `Cow::Owned` strings — those are never a raw multi-GiB payload.
+    let values: Vec<Option<Cow<str>>> = rows
         .iter()
         .map(
             |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
                 None => Ok(None),
                 Some(Value::Null) => Ok(None),
-                Some(Value::Text(s)) => Ok(Some(s.clone())),
-                Some(Value::Json(j)) => Ok(Some(j.to_string())),
-                Some(other) => Ok(Some(ValueFormatter::format_value(other))),
+                Some(Value::Text(s)) => Ok(Some(Cow::Borrowed(s.as_str()))),
+                Some(Value::Json(j)) => Ok(Some(Cow::Owned(j.to_string()))),
+                Some(other) => Ok(Some(Cow::Owned(ValueFormatter::format_value(other)))),
             },
         )
-        .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
+        .collect::<Result<Vec<Option<Cow<str>>>, ArrowConvertError>>()?;
     checked_string_offsets(&values)?;
-    Ok(Arc::new(StringArray::from(values)))
+    Ok(Arc::new(StringArray::from_iter(
+        values.iter().map(|v| v.as_deref()),
+    )))
 }
 
 fn build_binary_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
@@ -2469,6 +2475,58 @@ mod tests {
             matches!(err, Err(ArrowConvertError::InvalidValue(_))),
             "Text arm must fail closed at the i32 offset ceiling"
         );
+    }
+
+    /// (12g) Bounded fail-closed through the OPAQUE/untyped Utf8 fallback
+    /// (`build_string_array`, `cql_type = None`). This branch used to `s.clone()`
+    /// each raw `Value::Text` payload into an owned `String` BEFORE the guard,
+    /// so a `DataType::Text` column with no cql_type could allocate ~2 GiB before
+    /// failing closed. Post-#2235 the fallback represents raw text as
+    /// `Cow::Borrowed(&str)` and guards on the borrowed lengths first. We
+    /// reproduce the exact `Vec<Option<Cow<str>>>` the fixed fallback builds by
+    /// aliasing ONE 16 MiB text across 128 entries (`128 * 16 MiB = i32::MAX + 1`)
+    /// — peak RAM ~16 MiB, not 2 GiB — and assert the shared guard returns a
+    /// typed error (never a 2 GiB clone, never a panic).
+    #[test]
+    fn opaque_text_fallback_over_i32_max_fails_closed_without_2gib_clone() {
+        use std::borrow::Cow;
+        const CHUNK: usize = 16 * 1024 * 1024; // 16 MiB
+        const N: usize = 128; // 128 * 16 MiB = i32::MAX + 1
+        let big = "a".repeat(CHUNK);
+        // Exactly the borrowed-Cow vector the untyped fallback now materializes
+        // for raw `Value::Text`, aliased so peak RAM stays ~16 MiB.
+        let refs: Vec<Option<Cow<str>>> =
+            (0..N).map(|_| Some(Cow::Borrowed(big.as_str()))).collect();
+        let total: usize = refs.iter().flatten().map(|s| s.len()).sum();
+        assert_eq!(total, i32::MAX as usize + 1, "test must cross i32::MAX");
+        assert!(
+            matches!(
+                super::checked_string_offsets(&refs),
+                Err(ArrowConvertError::InvalidValue(_))
+            ),
+            "opaque untyped Text fallback must fail closed at the i32 offset ceiling"
+        );
+    }
+
+    /// (12h) The opaque/untyped Utf8 fallback still round-trips raw `Value::Text`
+    /// verbatim (no cql_type) through `rows_to_record_batch` after the borrowed
+    /// guard reorder — the fix must not alter normal-size output.
+    #[test]
+    fn opaque_text_fallback_preserves_raw_text_verbatim() {
+        use arrow::array::StringArray;
+        let cols = vec![col("o", DataType::Text, None)];
+        let rows = vec![
+            row_one("o", Value::Text("verbatim".into())),
+            row_one("o", Value::Null),
+        ];
+        let batch = rows_to_record_batch(&cols, &rows).expect("opaque text must build");
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Utf8 array");
+        assert_eq!(arr.value(0), "verbatim");
+        assert!(arr.is_null(1));
     }
 
     /// (12b) Genuine overflow reproduction through the exact `Vec<Option<&[u8]>>`


### PR DESCRIPTION
Closes #2235. Part of Epic AM (#2226), audit finding N9. Scalar analogue of #1486 (which fenced only List/Map element counts).

## Defect
Scalar `StringArray`/`BinaryArray` builders in `cqlite-core/src/export/arrow_convert.rs` used i32-offset arrow builders with no cumulative-byte guard. Flight batches are bounded by ROW count (batch_size 8192), not bytes — 8192 rows of wide text/blob (each within Cassandra per-value limits) can cross i32::MAX cumulative bytes → arrow-rs panic/corruption instead of a typed error.

## Fix — chosen behavior: typed fail-closed error
Mirrors #1486's `checked_offset` fence. Adds `checked_value_bytes` + `checked_string_offsets`/`checked_binary_offsets` (generic over `AsRef`), wired into every scalar Text/Blob/Duration/Inet/Tuple/UDT/Custom arm + flat builders + list/map Utf8 values — all on the real `rows_to_record_batch`→`convert_to_arrays` path the Flight producer (`producer.rs:749,850`) and parquet export use. Over-limit batches now return `ArrowConvertError::InvalidValue`.

**Guard runs on BORROWED slices before any owned clone** (roborev-driven, 2 rounds): the typed Text/Blob arms, `build_string_array` strict-text, and the untyped `DataType::Text`/`cql_type=None` fallback all check cumulative byte length on `&str`/`&[u8]`/`Cow<str>` BEFORE materializing owned copies — so the fail-closed path is genuinely bounded (~peak MiB, not a ~2 GiB clone-then-fail).

## Review-first
- rust-reviewer: APPROVE — all 13 scalar build sites guarded, boundary correct (`==i32::MAX` ok, `+1` err), on the real export path.
- roborev (codex): 2 rounds found + drove the borrow-before-clone completeness (typed arms, then the untyped fallback); final pass clean (job 3821, no issues).

Tests: overflow tests alias a 16 MiB value ×128 to reach i32::MAX+1 cumulative at ~16 MiB peak RAM (not 2 GiB), asserting typed error not panic; + normal-size regression + verbatim round-trip. 36 guard tests pass.

Note: `CQLITE_ALLOW_FILE_GROWTH=1` used — `arrow_convert.rs` is pre-existing #1116 debt (2501 lines, ~590 test lines); splitting is out of scope for this focused bounds-guard fix.