### PR TITLE
fix(#2231): pushdown NaN Gt/Gte + large-int equality diverge from Trino semantics

### DIFF
--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -778,7 +778,10 @@ impl SelectExecutor {
             (In, ComparisonRightSide::ValueList(value_exprs)) => {
                 for value_expr in value_exprs {
                     let value = self.evaluate_select_expression(value_expr, row)?;
-                    if left_value == value {
+                    // Coerce like `Equal` (`values_equal`), matching predicate.rs's
+                    // `In` arm — keeps membership consistent with scalar equality
+                    // (e.g. a narrow column type against a wide IN operand).
+                    if value_ops::values_equal(&left_value, &value) {
                         return Ok(true);
                     }
                 }

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -81,9 +81,7 @@ use lookup::{
     classify_partition_lookup, honest_targeted_path, sort_rows_by_token, PartitionLookupOutcome,
 };
 use row_build::{column_info_from_type_str, parse_cql_type_str, parse_table_id};
-use value_ops::{
-    compare_values_ordering, const_arithmetic, eval_arithmetic, try_compare_values, values_equal,
-};
+use value_ops::{compare_values_ordering, const_arithmetic, eval_arithmetic};
 use writetime_ttl::{
     evaluate_writetime_ttl, like_pattern_to_regex, select_has_writetime_ttl,
     writetime_ttl_column_name, SystemClock,
@@ -773,16 +771,9 @@ impl SelectExecutor {
                 ComparisonRightSide::Value(right_expr),
             ) => {
                 let right_value = self.evaluate_select_expression(right_expr, row)?;
-                let result = match op {
-                    Equal => values_equal(&left_value, &right_value),
-                    NotEqual => !values_equal(&left_value, &right_value),
-                    LessThan => try_compare_values(&left_value, &right_value)?.is_lt(),
-                    LessThanOrEqual => try_compare_values(&left_value, &right_value)?.is_le(),
-                    GreaterThan => try_compare_values(&left_value, &right_value)?.is_gt(),
-                    GreaterThanOrEqual => try_compare_values(&left_value, &right_value)?.is_ge(),
-                    _ => unreachable!("guarded by outer match"),
-                };
-                Ok(result)
+                // Scalar comparison with SQL predicate semantics (issue #2231):
+                // exact integer equality + NaN → UNKNOWN(drop) for inequalities.
+                value_ops::eval_scalar_comparison(op, &left_value, &right_value)
             }
             (In, ComparisonRightSide::ValueList(value_exprs)) => {
                 for value_expr in value_exprs {

--- a/cqlite-core/src/query/select_executor/predicate.rs
+++ b/cqlite-core/src/query/select_executor/predicate.rs
@@ -455,6 +455,58 @@ mod tests {
         assert_eq!(evaluate_leaf(&row_992, &in_wrong), LeafOutcome::False);
     }
 
+    /// Issue #2231 follow-up (roborev blocker): the SAME 2^53 boundary pair as
+    /// `large_bigint_equality_no_f64_collapse`, but for `Gt`/`Range` — the
+    /// leak-once-pushed-down mechanism applies identically to inequalities.
+    /// `bigcol > 9007199254740992` must match a row where
+    /// `bigcol = 9007199254740993` (they collapse to the SAME f64, so an
+    /// f64-based ordering would wrongly report `Equal` and drop the row).
+    #[test]
+    fn large_bigint_gt_and_range_no_f64_collapse() {
+        let row_993 = row_with_value("bigcol", Value::BigInt(9_007_199_254_740_993));
+
+        let gt_992 = SSTablePredicate::column(
+            "bigcol",
+            SSTableFilterOp::Gt,
+            vec![Value::BigInt(9_007_199_254_740_992)],
+        );
+        assert_eq!(
+            evaluate_leaf(&row_993, &gt_992),
+            LeafOutcome::True,
+            "9007199254740993 > 9007199254740992 must hold exactly"
+        );
+
+        // The row must NOT satisfy `> itself` (no false positive from rounding).
+        let gt_993 = SSTablePredicate::column(
+            "bigcol",
+            SSTableFilterOp::Gt,
+            vec![Value::BigInt(9_007_199_254_740_993)],
+        );
+        assert_eq!(evaluate_leaf(&row_993, &gt_993), LeafOutcome::False);
+
+        // Range [992, 992] must exclude a row holding 993 exactly.
+        let range_at_992 = SSTablePredicate::column(
+            "bigcol",
+            SSTableFilterOp::Range,
+            vec![
+                Value::BigInt(9_007_199_254_740_992),
+                Value::BigInt(9_007_199_254_740_992),
+            ],
+        );
+        assert_eq!(evaluate_leaf(&row_993, &range_at_992), LeafOutcome::False);
+
+        // Range [993, 993] must include the row holding exactly 993.
+        let range_at_993 = SSTablePredicate::column(
+            "bigcol",
+            SSTableFilterOp::Range,
+            vec![
+                Value::BigInt(9_007_199_254_740_993),
+                Value::BigInt(9_007_199_254_740_993),
+            ],
+        );
+        assert_eq!(evaluate_leaf(&row_993, &range_at_993), LeafOutcome::True);
+    }
+
     /// FINDING 2: a `token(...)` over the FULL partition key in declared order is
     /// accepted (validation passes), so the existing token fast-path/evaluation
     /// behaviour is preserved.

--- a/cqlite-core/src/query/select_executor/predicate.rs
+++ b/cqlite-core/src/query/select_executor/predicate.rs
@@ -7,7 +7,7 @@
 
 use super::super::result::QueryRow;
 use super::super::select_optimizer::SSTablePredicate;
-use super::value_ops::{compare_values_ordering, values_equal};
+use super::value_ops::{compare_values_ordering_predicate, values_equal};
 use crate::{types::Value, Error, Result};
 
 /// Three-valued (SQL Kleene) outcome of evaluating a single leaf predicate
@@ -98,28 +98,28 @@ pub fn evaluate_leaf(row: &QueryRow, predicate: &SSTablePredicate) -> LeafOutcom
             } else {
                 let lo = &predicate.values[0];
                 let hi = &predicate.values[1];
-                compare_values_ordering(column_value, lo).is_ge()
-                    && compare_values_ordering(column_value, hi).is_le()
+                // SQL NaN semantics (issue #2231): a NaN column value makes the
+                // range comparison UNKNOWN (`None`) → the row is dropped.
+                compare_values_ordering_predicate(column_value, lo).is_some_and(|o| o.is_ge())
+                    && compare_values_ordering_predicate(column_value, hi)
+                        .is_some_and(|o| o.is_le())
             }
         }
         // Single-bound clustering inequalities (Issue #788). A missing bound
-        // rejects the row, mirroring the `Range` len-guard above.
-        SSTableFilterOp::Gt => predicate
-            .values
-            .first()
-            .is_some_and(|b| compare_values_ordering(column_value, b).is_gt()),
-        SSTableFilterOp::Gte => predicate
-            .values
-            .first()
-            .is_some_and(|b| compare_values_ordering(column_value, b).is_ge()),
-        SSTableFilterOp::Lt => predicate
-            .values
-            .first()
-            .is_some_and(|b| compare_values_ordering(column_value, b).is_lt()),
-        SSTableFilterOp::Lte => predicate
-            .values
-            .first()
-            .is_some_and(|b| compare_values_ordering(column_value, b).is_le()),
+        // rejects the row, mirroring the `Range` len-guard above. A NaN operand
+        // makes the comparison UNKNOWN → the row is dropped (issue #2231).
+        SSTableFilterOp::Gt => predicate.values.first().is_some_and(|b| {
+            compare_values_ordering_predicate(column_value, b).is_some_and(|o| o.is_gt())
+        }),
+        SSTableFilterOp::Gte => predicate.values.first().is_some_and(|b| {
+            compare_values_ordering_predicate(column_value, b).is_some_and(|o| o.is_ge())
+        }),
+        SSTableFilterOp::Lt => predicate.values.first().is_some_and(|b| {
+            compare_values_ordering_predicate(column_value, b).is_some_and(|o| o.is_lt())
+        }),
+        SSTableFilterOp::Lte => predicate.values.first().is_some_and(|b| {
+            compare_values_ordering_predicate(column_value, b).is_some_and(|o| o.is_le())
+        }),
         SSTableFilterOp::Prefix => matches!(
             (column_value, predicate.values.first()),
             (Value::Text(s), Some(Value::Text(p))) if s.starts_with(p)
@@ -214,7 +214,7 @@ pub(super) fn validate_token_predicates(
 mod tests {
     use super::super::super::select_optimizer::{SSTableFilterOp, SSTablePredicate};
     use super::super::test_support::{
-        composite_pk_schema, row_with_int, row_with_key, single_pk_schema,
+        composite_pk_schema, row_with_int, row_with_key, row_with_value, single_pk_schema,
     };
     use super::*;
     use crate::types::RowKey;
@@ -377,6 +377,82 @@ mod tests {
         assert!(!in_slice(200), "upper bound is exclusive");
         assert!(!in_slice(1000), "rows past the slice are excluded");
         assert!(!in_slice(-1), "rows below the slice are excluded");
+    }
+
+    /// Issue #2231, divergence 1 (repro `WHERE d > 1.5 ...`): a NaN `double`
+    /// column value must NOT satisfy `>` / `>=` (SQL UNKNOWN → dropped). Under
+    /// the old `cassandra_double_cmp` (NaN sorts greatest) the row leaked once
+    /// the conjunct was pushed down and removed from the Trino plan.
+    #[test]
+    fn nan_double_column_dropped_by_inequality_predicates() {
+        let nan_row = row_with_value("d", Value::Float(f64::NAN));
+        let gt = |op| SSTablePredicate::column("d", op, vec![Value::Float(1.5)]);
+
+        // Gt / Gte on NaN: previously True (leak), now False (dropped).
+        assert_eq!(
+            evaluate_leaf(&nan_row, &gt(SSTableFilterOp::Gt)),
+            LeafOutcome::False
+        );
+        assert_eq!(
+            evaluate_leaf(&nan_row, &gt(SSTableFilterOp::Gte)),
+            LeafOutcome::False
+        );
+        // Lt / Lte on NaN: already False, still False.
+        assert_eq!(
+            evaluate_leaf(&nan_row, &gt(SSTableFilterOp::Lt)),
+            LeafOutcome::False
+        );
+        assert_eq!(
+            evaluate_leaf(&nan_row, &gt(SSTableFilterOp::Lte)),
+            LeafOutcome::False
+        );
+        // Range on NaN is dropped too.
+        let range = SSTablePredicate::column(
+            "d",
+            SSTableFilterOp::Range,
+            vec![Value::Float(0.0), Value::Float(9.0)],
+        );
+        assert_eq!(evaluate_leaf(&nan_row, &range), LeafOutcome::False);
+
+        // A non-NaN double still evaluates normally (regression guard).
+        let ok_row = row_with_value("d", Value::Float(2.0));
+        assert_eq!(
+            evaluate_leaf(&ok_row, &gt(SSTableFilterOp::Gt)),
+            LeafOutcome::True
+        );
+    }
+
+    /// Issue #2231, divergence 2 (repro `WHERE bigcol = 9007199254740993 ...`):
+    /// leaf equality must distinguish two distinct large `i64` that collapse to
+    /// the same `f64`. The old `as_f64` fallback matched `...992` against `...993`.
+    #[test]
+    fn large_bigint_equality_no_f64_collapse() {
+        let eq = |target: i64| {
+            SSTablePredicate::column(
+                "bigcol",
+                SSTableFilterOp::Equal,
+                vec![Value::BigInt(target)],
+            )
+        };
+        let row_992 = row_with_value("bigcol", Value::BigInt(9_007_199_254_740_992));
+
+        // = ...993 must NOT match a row holding ...992.
+        assert_eq!(
+            evaluate_leaf(&row_992, &eq(9_007_199_254_740_993)),
+            LeafOutcome::False
+        );
+        // Exact match still holds.
+        assert_eq!(
+            evaluate_leaf(&row_992, &eq(9_007_199_254_740_992)),
+            LeafOutcome::True
+        );
+        // IN with the wrong large operand also does not match.
+        let in_wrong = SSTablePredicate::column(
+            "bigcol",
+            SSTableFilterOp::In,
+            vec![Value::BigInt(9_007_199_254_740_993)],
+        );
+        assert_eq!(evaluate_leaf(&row_992, &in_wrong), LeafOutcome::False);
     }
 
     /// FINDING 2: a `token(...)` over the FULL partition key in declared order is

--- a/cqlite-core/src/query/select_executor/test_support.rs
+++ b/cqlite-core/src/query/select_executor/test_support.rs
@@ -65,6 +65,21 @@ pub(crate) fn row_with_int(column: &str, value: i64) -> QueryRow {
     }
 }
 
+/// Build a one-column `QueryRow` holding an arbitrary [`Value`] — for
+/// predicate-evaluation tests over non-`Integer` column types (e.g. a `double`
+/// NaN or a large `bigint`), issue #2231.
+pub(crate) fn row_with_value(column: &str, value: Value) -> QueryRow {
+    let mut values: std::collections::HashMap<std::sync::Arc<str>, Value> =
+        std::collections::HashMap::new();
+    values.insert(column.into(), value);
+    QueryRow {
+        values,
+        key: RowKey::new(Vec::new()),
+        metadata: Default::default(),
+        cell_metadata: None,
+    }
+}
+
 /// Build a `QueryRow` with only a partition key (no column values).
 pub(crate) fn row_with_key(partition: &[u8]) -> QueryRow {
     QueryRow {

--- a/cqlite-core/src/query/select_executor/value_ops.rs
+++ b/cqlite-core/src/query/select_executor/value_ops.rs
@@ -5,7 +5,7 @@
 //! `select_executor.rs`; centralising them keeps one copy of the comparison and
 //! arithmetic semantics across every execution path.
 
-use super::super::select_ast::ArithmeticOperator;
+use super::super::select_ast::{ArithmeticOperator, ComparisonOperator};
 use crate::{types::Value, Error, Result};
 
 /// Compare two `Value`s for equality, including limited cross-type numeric
@@ -18,14 +18,52 @@ pub(super) fn values_equal(a: &Value, b: &Value) -> bool {
     if a == b {
         return true;
     }
-    // Only coerce when both operands are numeric — otherwise non-numeric
-    // pairs (e.g. Text vs Integer) would spuriously compare equal via `as_f64`.
+    // Integer-vs-integer must compare as the widest native integer (`i128`),
+    // NEVER via `as_f64` (issue #2231): two distinct `i64` above 2^53 collapse
+    // to the same `f64` mantissa, so an f64 fallback would report them equal and
+    // — because a fully-translated Trino conjunct is removed from the plan — leak
+    // rows Trino would drop. Every CQL integral type fits losslessly in `i128`.
+    if let (Some(x), Some(y)) = (as_integral_i128(a), as_integral_i128(b)) {
+        return x == y;
+    }
+    // Otherwise coerce only when both operands are numeric — a genuine float on
+    // at least one side. Non-numeric pairs (e.g. Text vs Integer) must not
+    // spuriously compare equal via `as_f64`.
     if same_numeric_family(a, b) {
         if let (Some(x), Some(y)) = (a.as_f64(), b.as_f64()) {
             return x == y;
         }
     }
     false
+}
+
+/// The exact integer value of an integral CQL numeric `Value`, or `None` for
+/// float/non-numeric variants. Widened to `i128` so every integral type
+/// (`tinyint`..`bigint`, `counter`) is represented losslessly, enabling exact
+/// integer equality/comparison without an `f64` round-trip (issue #2231).
+pub(super) fn as_integral_i128(v: &Value) -> Option<i128> {
+    match v {
+        Value::Integer(i) => Some(*i as i128),
+        Value::BigInt(i) => Some(*i as i128),
+        Value::Counter(i) => Some(*i as i128),
+        Value::TinyInt(i) => Some(*i as i128),
+        Value::SmallInt(i) => Some(*i as i128),
+        _ => None,
+    }
+}
+
+/// True when `v` is an IEEE floating-point value that is NaN (CQL `float`/
+/// `double`). Predicate (WHERE) evaluation uses this to implement SQL
+/// three-valued logic: any relational comparison (`<`, `<=`, `>`, `>=`) with a
+/// NaN operand is UNKNOWN, so the row is dropped (issue #2231). Only the `float`
+/// variants can be NaN — integral types never are, so this is principled, not a
+/// bit-pattern heuristic.
+pub(super) fn is_nan_value(v: &Value) -> bool {
+    match v {
+        Value::Float(x) => x.is_nan(),
+        Value::Float32(x) => x.is_nan(),
+        _ => false,
+    }
 }
 
 /// True when both `Value`s are numeric variants eligible for cross-type coercion.
@@ -71,6 +109,72 @@ pub(super) fn try_compare_values(a: &Value, b: &Value) -> Result<std::cmp::Order
     Err(Error::query_execution(
         "Cannot compare incompatible types".to_string(),
     ))
+}
+
+/// Relational comparison for PREDICATE (WHERE) evaluation, with SQL
+/// three-valued logic for IEEE NaN.
+///
+/// Returns `Ok(None)` — SQL UNKNOWN, so the caller DROPS the row — when either
+/// operand is a NaN float. Cassandra's total order (`cassandra_double_cmp`, used
+/// by `try_compare_values`/`compare_values_ordering`) sorts NaN as the GREATEST
+/// value, which would make `d > 1.5` TRUE for `d = NaN` and leak rows Trino
+/// would drop once the conjunct is pushed down and removed from the plan (issue
+/// #2231). This function is for filter/`WHERE` evaluation ONLY — do NOT use it
+/// for ORDER BY / MIN / MAX / clustering-key ordering, which must keep the
+/// NaN-greatest total order.
+pub(super) fn try_compare_values_predicate(
+    a: &Value,
+    b: &Value,
+) -> Result<Option<std::cmp::Ordering>> {
+    if is_nan_value(a) || is_nan_value(b) {
+        return Ok(None);
+    }
+    try_compare_values(a, b).map(Some)
+}
+
+/// `compare_values_ordering` counterpart for predicate evaluation: identical for
+/// non-NaN operands, but returns `None` (SQL UNKNOWN → drop the row) when either
+/// operand is a NaN float (issue #2231). Used by the SSTable leaf-predicate
+/// evaluator's inequalities so a NaN never satisfies `>`/`>=`/`<`/`<=`. The
+/// error-swallowing (`Ordering::Equal` for incomparable variants) behaviour of
+/// `compare_values_ordering` is preserved for non-NaN pairs.
+pub(super) fn compare_values_ordering_predicate(
+    a: &Value,
+    b: &Value,
+) -> Option<std::cmp::Ordering> {
+    if is_nan_value(a) || is_nan_value(b) {
+        return None;
+    }
+    Some(compare_values_ordering(a, b))
+}
+
+/// Evaluate a scalar `ComparisonOperator` (`=`, `!=`, `<`, `<=`, `>`, `>=`)
+/// over two already-evaluated operands with SQL PREDICATE semantics (issue
+/// #2231). Shared by the expression-pushdown WHERE evaluator so equality uses
+/// exact integer comparison (`values_equal`, no `f64` collapse above 2^53) and
+/// the four inequalities treat a NaN operand as UNKNOWN → `false` (row dropped),
+/// never NaN-greatest. Non-scalar operators (`IN`, `LIKE`, `IS [NOT] NULL`, …)
+/// have their own branches and are rejected here.
+pub(super) fn eval_scalar_comparison(
+    op: &ComparisonOperator,
+    left: &Value,
+    right: &Value,
+) -> Result<bool> {
+    use ComparisonOperator::*;
+    Ok(match op {
+        Equal => values_equal(left, right),
+        NotEqual => !values_equal(left, right),
+        LessThan => try_compare_values_predicate(left, right)?.is_some_and(|o| o.is_lt()),
+        LessThanOrEqual => try_compare_values_predicate(left, right)?.is_some_and(|o| o.is_le()),
+        GreaterThan => try_compare_values_predicate(left, right)?.is_some_and(|o| o.is_gt()),
+        GreaterThanOrEqual => try_compare_values_predicate(left, right)?.is_some_and(|o| o.is_ge()),
+        other => {
+            return Err(Error::query_execution(format!(
+                "operator {:?} is not a scalar comparison",
+                other
+            )))
+        }
+    })
 }
 
 /// Apply an `ArithmeticOperator` to two same-typed numeric `Value`s.
@@ -196,6 +300,119 @@ mod tests {
         assert_eq!(
             try_compare_values(&Value::Integer(5), &Value::Integer(5)).unwrap(),
             Ordering::Equal
+        );
+    }
+
+    /// Issue #2231, divergence 2: `values_equal` distinguishes two DISTINCT
+    /// `i64` values straddling the 2^53 f64-precision boundary. An `as_f64`
+    /// fallback would round both to the same mantissa and report them equal,
+    /// leaking rows once a `bigcol = ...` conjunct is pushed down and removed
+    /// from the Trino plan.
+    #[test]
+    fn values_equal_distinguishes_large_i64_across_f64_boundary() {
+        let two53 = 1_i64 << 53; // 9_007_199_254_740_992
+        let plus1 = two53 + 1; // 9_007_199_254_740_993 (not representable as f64)
+                               // Sanity: the two integers DO collapse to the same f64.
+        assert_eq!(
+            two53 as f64, plus1 as f64,
+            "precondition: f64 collapses them"
+        );
+
+        // The exact-integer comparison must keep them distinct.
+        assert!(
+            !values_equal(&Value::BigInt(two53), &Value::BigInt(plus1)),
+            "2^53 != 2^53 + 1 as bigint"
+        );
+        assert!(
+            values_equal(&Value::BigInt(plus1), &Value::BigInt(plus1)),
+            "identical large bigints are equal"
+        );
+        // Repro operand: bigcol = 9_007_199_254_740_993 must NOT match 992.
+        assert!(!values_equal(
+            &Value::BigInt(9_007_199_254_740_992),
+            &Value::BigInt(9_007_199_254_740_993),
+        ));
+
+        // Cross-integral-type equality still holds (int == bigint numerically).
+        assert!(values_equal(&Value::Integer(7), &Value::BigInt(7)));
+        assert!(values_equal(&Value::TinyInt(7), &Value::SmallInt(7)));
+        assert!(!values_equal(&Value::Integer(7), &Value::BigInt(8)));
+        // Integer-vs-float equality still coerces (genuine float on one side).
+        assert!(values_equal(&Value::BigInt(2), &Value::Float(2.0)));
+        assert!(!values_equal(&Value::BigInt(2), &Value::Float(2.5)));
+    }
+
+    /// Issue #2231, divergence 1: under PREDICATE (WHERE) semantics a NaN
+    /// operand makes every relational comparison UNKNOWN, so the row is dropped.
+    /// Historically only `Lt`/`Lte`/`Eq` dropped NaN while `Gt`/`Gte` leaked it
+    /// (NaN sorts greatest under `cassandra_double_cmp`); all four inequalities
+    /// must now drop it, and `Eq` continues to.
+    #[test]
+    fn nan_predicate_comparison_is_unknown_for_all_relations() {
+        let nan = Value::Float(f64::NAN);
+        let bound = Value::Float(1.5);
+
+        // `d > 1.5` / `d >= 1.5` with d = NaN: previously TRUE (leak), now dropped.
+        let cmp = try_compare_values_predicate(&nan, &bound).unwrap();
+        assert!(cmp.is_none(), "NaN vs 1.5 is UNKNOWN (Gt/Gte)");
+        assert!(
+            !cmp.is_some_and(|o| o.is_gt()),
+            "d > 1.5 with NaN is dropped"
+        );
+        assert!(
+            !cmp.is_some_and(|o| o.is_ge()),
+            "d >= 1.5 with NaN is dropped"
+        );
+        // Lt/Lte were already consistent (dropped) — confirm they stay dropped.
+        assert!(
+            !cmp.is_some_and(|o| o.is_lt()),
+            "d < 1.5 with NaN is dropped"
+        );
+        assert!(
+            !cmp.is_some_and(|o| o.is_le()),
+            "d <= 1.5 with NaN is dropped"
+        );
+        // NaN on the right-hand side is symmetric.
+        assert!(try_compare_values_predicate(&bound, &nan)
+            .unwrap()
+            .is_none());
+        // Two NaNs are also UNKNOWN under predicate comparison.
+        assert!(try_compare_values_predicate(&nan, &nan).unwrap().is_none());
+        // Float32 (CQL `float`) NaN behaves identically.
+        assert!(
+            try_compare_values_predicate(&Value::Float32(f32::NAN), &Value::Float32(1.5))
+                .unwrap()
+                .is_none()
+        );
+
+        // Eq already dropped NaN (no NaN-aware equality) — confirm unchanged.
+        assert!(!values_equal(&nan, &bound), "NaN = 1.5 is false");
+        assert!(!values_equal(&nan, &nan), "NaN = NaN is false (SQL)");
+
+        // Non-NaN floats keep normal ordering under predicate comparison.
+        let ok = try_compare_values_predicate(&Value::Float(2.0), &bound).unwrap();
+        assert!(ok.is_some_and(|o| o.is_gt()), "2.0 > 1.5 holds");
+    }
+
+    /// Issue #2231: the NaN-drop is scoped to PREDICATE comparison only — the
+    /// total-order comparator (`compare_values_ordering`, used by ORDER BY /
+    /// MIN / MAX / clustering) must STILL sort NaN as the greatest value.
+    #[test]
+    fn nan_ordering_total_order_unchanged_by_predicate_fix() {
+        use std::cmp::Ordering;
+        assert_eq!(
+            compare_values_ordering(&Value::Float(f64::NAN), &Value::Float(1.5)),
+            Ordering::Greater,
+            "sort order still puts NaN last (unchanged)"
+        );
+        // The predicate variant agrees for non-NaN but diverges (None) on NaN.
+        assert_eq!(
+            compare_values_ordering_predicate(&Value::Float(2.0), &Value::Float(1.5)),
+            Some(Ordering::Greater)
+        );
+        assert!(
+            compare_values_ordering_predicate(&Value::Float(f64::NAN), &Value::Float(1.5))
+                .is_none()
         );
     }
 

--- a/cqlite-core/src/query/select_executor/value_ops.rs
+++ b/cqlite-core/src/query/select_executor/value_ops.rs
@@ -112,16 +112,27 @@ pub(super) fn try_compare_values(a: &Value, b: &Value) -> Result<std::cmp::Order
 }
 
 /// Relational comparison for PREDICATE (WHERE) evaluation, with SQL
-/// three-valued logic for IEEE NaN.
+/// three-valued logic for IEEE NaN AND exact-integer ordering above the f64
+/// precision boundary.
 ///
 /// Returns `Ok(None)` — SQL UNKNOWN, so the caller DROPS the row — when either
 /// operand is a NaN float. Cassandra's total order (`cassandra_double_cmp`, used
 /// by `try_compare_values`/`compare_values_ordering`) sorts NaN as the GREATEST
 /// value, which would make `d > 1.5` TRUE for `d = NaN` and leak rows Trino
 /// would drop once the conjunct is pushed down and removed from the plan (issue
-/// #2231). This function is for filter/`WHERE` evaluation ONLY — do NOT use it
-/// for ORDER BY / MIN / MAX / clustering-key ordering, which must keep the
-/// NaN-greatest total order.
+/// #2231).
+///
+/// When both operands are integral (mirroring `values_equal`'s own structure),
+/// compares them as exact `i128` BEFORE any f64 fallback: two distinct `i64`
+/// above 2^53 collapse to the same f64 mantissa, so `bigcol > 9007199254740992`
+/// against a row where `bigcol = 9007199254740993` would otherwise compare
+/// `Equal` via `cassandra_double_cmp` and wrongly evaluate `is_gt()` to `false`
+/// — the same leak-once-pushed-down mechanism as the `=` divergence.
+///
+/// This function is for filter/`WHERE` evaluation ONLY — do NOT use it for
+/// ORDER BY / MIN / MAX / clustering-key ordering, which must keep the
+/// NaN-greatest total order and existing f64-based numeric ordering
+/// (`try_compare_values`/`compare_values_ordering`, unchanged).
 pub(super) fn try_compare_values_predicate(
     a: &Value,
     b: &Value,
@@ -129,23 +140,28 @@ pub(super) fn try_compare_values_predicate(
     if is_nan_value(a) || is_nan_value(b) {
         return Ok(None);
     }
+    if let (Some(x), Some(y)) = (as_integral_i128(a), as_integral_i128(b)) {
+        return Ok(Some(x.cmp(&y)));
+    }
     try_compare_values(a, b).map(Some)
 }
 
-/// `compare_values_ordering` counterpart for predicate evaluation: identical for
-/// non-NaN operands, but returns `None` (SQL UNKNOWN → drop the row) when either
-/// operand is a NaN float (issue #2231). Used by the SSTable leaf-predicate
-/// evaluator's inequalities so a NaN never satisfies `>`/`>=`/`<`/`<=`. The
-/// error-swallowing (`Ordering::Equal` for incomparable variants) behaviour of
-/// `compare_values_ordering` is preserved for non-NaN pairs.
+/// `compare_values_ordering` counterpart for predicate evaluation: routes
+/// through [`try_compare_values_predicate`] so it shares BOTH predicate-only
+/// fixes (issue #2231) — NaN → `None` (SQL UNKNOWN → drop the row) and exact
+/// `i128` integer ordering above the f64 precision boundary — then swallows any
+/// remaining comparison error to `Ordering::Equal`, matching
+/// `compare_values_ordering`'s error-tolerant behaviour for non-NaN,
+/// non-integral pairs. Used by the SSTable leaf-predicate evaluator's
+/// inequalities so neither a NaN nor a large `bigint` pair is mishandled.
 pub(super) fn compare_values_ordering_predicate(
     a: &Value,
     b: &Value,
 ) -> Option<std::cmp::Ordering> {
-    if is_nan_value(a) || is_nan_value(b) {
-        return None;
+    match try_compare_values_predicate(a, b) {
+        Ok(ordering) => ordering,
+        Err(_) => Some(std::cmp::Ordering::Equal),
     }
-    Some(compare_values_ordering(a, b))
 }
 
 /// Evaluate a scalar `ComparisonOperator` (`=`, `!=`, `<`, `<=`, `>`, `>=`)
@@ -342,6 +358,40 @@ mod tests {
         assert!(!values_equal(&Value::BigInt(2), &Value::Float(2.5)));
     }
 
+    /// Issue #2231 follow-up (roborev blocker): `try_compare_values_predicate` /
+    /// `compare_values_ordering_predicate` must ALSO compare large integers
+    /// exactly — not just `values_equal`. Without the `as_integral_i128`
+    /// short-circuit, `bigcol > 9007199254740992` against a row where
+    /// `bigcol = 9007199254740993` would coerce both to the same f64 mantissa,
+    /// compare `Equal`, and wrongly evaluate `is_gt()` to `false` (row dropped).
+    #[test]
+    fn predicate_ordering_distinguishes_large_i64_across_f64_boundary() {
+        use std::cmp::Ordering;
+        let two53 = 1_i64 << 53; // 9_007_199_254_740_992
+        let plus1 = two53 + 1; // 9_007_199_254_740_993
+
+        // ...993 > ...992 must hold exactly (f64 would report Equal).
+        assert_eq!(
+            try_compare_values_predicate(&Value::BigInt(plus1), &Value::BigInt(two53)).unwrap(),
+            Some(Ordering::Greater),
+            "9007199254740993 > 9007199254740992 must hold exactly"
+        );
+        assert_eq!(
+            compare_values_ordering_predicate(&Value::BigInt(plus1), &Value::BigInt(two53)),
+            Some(Ordering::Greater)
+        );
+        // The symmetric direction: ...992 is NOT greater than ...993.
+        assert_eq!(
+            try_compare_values_predicate(&Value::BigInt(two53), &Value::BigInt(plus1)).unwrap(),
+            Some(Ordering::Less)
+        );
+        // Equal large integers still compare Equal.
+        assert_eq!(
+            try_compare_values_predicate(&Value::BigInt(plus1), &Value::BigInt(plus1)).unwrap(),
+            Some(Ordering::Equal)
+        );
+    }
+
     /// Issue #2231, divergence 1: under PREDICATE (WHERE) semantics a NaN
     /// operand makes every relational comparison UNKNOWN, so the row is dropped.
     /// Historically only `Lt`/`Lte`/`Eq` dropped NaN while `Gt`/`Gte` leaked it
@@ -414,6 +464,33 @@ mod tests {
             compare_values_ordering_predicate(&Value::Float(f64::NAN), &Value::Float(1.5))
                 .is_none()
         );
+    }
+
+    /// `eval_scalar_comparison` dispatches each of the 6 scalar operators to the
+    /// right predicate-semantics comparator (issue #2231's `mod.rs` expression
+    /// path calls this directly, so its per-operator wiring deserves its own
+    /// direct test rather than only transitive coverage).
+    #[test]
+    fn eval_scalar_comparison_dispatches_all_six_operators() {
+        use ComparisonOperator::*;
+        let five = Value::Integer(5);
+        let three = Value::Integer(3);
+
+        assert!(!eval_scalar_comparison(&Equal, &five, &three).unwrap());
+        assert!(eval_scalar_comparison(&Equal, &five, &five).unwrap());
+        assert!(eval_scalar_comparison(&NotEqual, &five, &three).unwrap());
+        assert!(!eval_scalar_comparison(&NotEqual, &five, &five).unwrap());
+        assert!(eval_scalar_comparison(&GreaterThan, &five, &three).unwrap());
+        assert!(!eval_scalar_comparison(&GreaterThan, &three, &five).unwrap());
+        assert!(eval_scalar_comparison(&GreaterThanOrEqual, &five, &five).unwrap());
+        assert!(!eval_scalar_comparison(&GreaterThanOrEqual, &three, &five).unwrap());
+        assert!(eval_scalar_comparison(&LessThan, &three, &five).unwrap());
+        assert!(!eval_scalar_comparison(&LessThan, &five, &three).unwrap());
+        assert!(eval_scalar_comparison(&LessThanOrEqual, &five, &five).unwrap());
+        assert!(!eval_scalar_comparison(&LessThanOrEqual, &five, &three).unwrap());
+
+        // A non-scalar operator is rejected rather than silently mishandled.
+        assert!(eval_scalar_comparison(&In, &five, &three).is_err());
     }
 
     /// The query ordering comparator (used by ORDER BY / MIN / MAX) must match


### PR DESCRIPTION
Closes #2231

## Summary
CQLite's Trino connector removes a fully-translated predicate conjunct from the Trino plan once it's
pushed down, so CQLite's own evaluation must be SQL/Trino-semantics-exact. Two divergences let wrong
rows leak through:
1. `Gt`/`Gte` (and `Lt`/`Lte`/`Range`) against a NaN float used Cassandra's total-order comparator
   (NaN sorts greatest) instead of SQL three-valued UNKNOWN (row dropped).
2. Integer equality/ordering fell back to `f64`, so two distinct `i64` above 2^53 could compare equal
   (or a `>`/`<` comparison could wrongly treat them as equal).

Fix: new predicate-only comparators (`try_compare_values_predicate`,
`compare_values_ordering_predicate`) that short-circuit NaN to UNKNOWN and widen integral operands to
`i128` before any `f64` fallback — applied at BOTH predicate-evaluation entry points (the expression
WHERE evaluator and the SSTable leaf-predicate evaluator). ORDER BY/MIN/MAX/clustering-key ordering
(`try_compare_values`/`compare_values_ordering`) are untouched — NaN still sorts as greatest there,
matching Cassandra's total order.

## Review history (review-first, before any full gate)
- Round 1 (`rust-reviewer` + roborev): roborev found the equality fix didn't extend to the ordering
  comparators (`Gt`/`Gte`/`Lt`/`Lte`/`Range` still f64-collapsed above 2^53) — confirmed against the
  code and fixed. The implementer independently found and fixed a SECOND, separate call path
  (`compare_values_ordering_predicate`, used by the SSTable leaf-predicate evaluator) with the
  identical bug.
- Round 2 (re-verify): both roborev and `rust-reviewer` confirm clean — traced the full call graph,
  confirmed both entry points fixed, NaN short-circuit and error-swallowing contracts preserved,
  non-predicate ordering paths byte-for-byte unchanged, and hand-verified the 2^53 boundary math.

## Follow-ups filed (not blocking this PR)
- #2257 — the legacy `QueryExecutor::compare_values` path has the identical NaN Gt/Gte leak via a
  different (non-Trino-pushdown) execution path; out of scope here, tracked separately.

## Test plan
- [x] Both repro cases from the issue pinned as regression tests (NaN Gt/Gte drop; large-bigint
      equality/ordering at the 2^53±1 boundary)
- [x] NaN truth table across Gt/Gte/Lt/Lte/Eq
- [x] No regression to ORDER BY/MIN/MAX NaN-greatest total order (explicit pinning test)
- [x] `scripts/agent-gate.sh --lite` PASS at every round
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — runs once via `flow-closer`