### PR TITLE
fix(#2236): make trino-connector Arrow temporal mapping unit-aware (fail-closed on unsupported units)

### DIFF
--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
@@ -38,6 +38,7 @@ import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
 import java.util.HexFormat;
 import java.util.List;
@@ -78,13 +79,13 @@ public final class ArrowToTrino {
             case TinyintType t -> t.writeLong(builder, ((TinyIntVector) vector).get(i));
             case SmallintType t -> t.writeLong(builder, ((SmallIntVector) vector).get(i));
             case IntegerType t -> t.writeLong(builder, ((IntVector) vector).get(i));
-            case DateType t -> t.writeLong(builder, ((DateDayVector) vector).get(i));
+            case DateType t -> t.writeLong(builder, epochDay(vector, i));
             case BigintType t -> t.writeLong(builder, ((BigIntVector) vector).get(i));
             case RealType t -> t.writeLong(builder, Float.floatToRawIntBits(((Float4Vector) vector).get(i)));
             case DoubleType t -> t.writeDouble(builder, ((Float8Vector) vector).get(i));
             case TimestampWithTimeZoneType t -> t.writeLong(builder,
                     DateTimeEncoding.packDateTimeWithZone(
-                            ((TimeStampVector) vector).get(i), TimeZoneKey.UTC_KEY));
+                            epochMillis(vector, i), TimeZoneKey.UTC_KEY));
             case TimeType t -> t.writeLong(builder, timePicos(vector, i));
             case VarcharType t -> t.writeSlice(builder, varcharSlice(vector, i));
             case VarbinaryType t -> t.writeSlice(builder, binarySlice(vector, i));
@@ -111,8 +112,12 @@ public final class ArrowToTrino {
             case SmallIntVector v -> (long) v.get(i);
             case IntVector v -> (long) v.get(i);
             case BigIntVector v -> v.get(i);
+            // DATE → epoch-day; TIMESTAMP → epoch-milli. Both delegate to the same
+            // unit-aware helpers the scan path uses so a micros/nanos timestamp (or a
+            // DateMilli vector) is rejected with a clear typed error rather than read
+            // 1000x wrong or thrown as a raw ClassCastException.
             case DateDayVector v -> (long) v.get(i);
-            case TimeStampVector v -> v.get(i);
+            case TimeStampVector v -> epochMillis(v, i);
             // TIME → canonical nanoseconds-of-day (matches the unit writeJavaValue
             // reads back below). All Arrow time widths normalize to nanos here so
             // min/max longs compare correctly and GROUP BY keys stay equal.
@@ -188,6 +193,68 @@ public final class ArrowToTrino {
     /** Convert an Arrow time-of-day value to Trino's picoseconds-of-day encoding. */
     private static long timePicos(FieldVector vector, int i) {
         return nanosToPicos(timeNanos(vector, i));
+    }
+
+    /**
+     * Read an Arrow {@code Timestamp} value as epoch-milliseconds, honoring the
+     * vector's DECLARED {@link org.apache.arrow.vector.types.TimeUnit unit}
+     * (issue #2236). Trino's {@code TIMESTAMP_TZ_MILLIS} stores epoch-millis, so:
+     * <ul>
+     *   <li>MILLISECOND — identity (the pinned server unit).</li>
+     *   <li>SECOND — up-scale ×1000, overflow-guarded with {@link Math#multiplyExact}
+     *       (a value that cannot fit in a {@code long} of millis is a typed
+     *       {@code ArithmeticException} wrapped below, never a silent wrap).</li>
+     *   <li>MICROSECOND/NANOSECOND — fail closed: down-scaling drops sub-millisecond
+     *       precision, so we throw a clear typed error naming the unit rather than
+     *       silently misreading the value (formerly a 1000x/1_000_000x error).</li>
+     * </ul>
+     * {@link ArrowTypeMapper} rejects the unsupported units at planning time; this is
+     * the matching mid-scan guard so a drifted server can never be read wrong.
+     */
+    private static long epochMillis(FieldVector vector, int i) {
+        if (!(vector instanceof TimeStampVector ts)) {
+            throw new UnsupportedOperationException(
+                    "Cannot map Arrow vector " + vector.getClass().getSimpleName()
+                            + " to a Trino timestamp");
+        }
+        long raw = ts.get(i);
+        ArrowType.Timestamp type = (ArrowType.Timestamp) ts.getField().getType();
+        return switch (type.getUnit()) {
+            case MILLISECOND -> raw;
+            case SECOND -> {
+                try {
+                    yield Math.multiplyExact(raw, 1_000L);
+                } catch (ArithmeticException e) {
+                    throw new UnsupportedOperationException(
+                            "Arrow timestamp value " + raw
+                                    + "s overflows epoch-milliseconds when scaled to Trino "
+                                    + "TIMESTAMP_TZ_MILLIS", e);
+                }
+            }
+            case MICROSECOND, NANOSECOND -> throw new UnsupportedOperationException(
+                    "Arrow timestamp unit " + type.getUnit() + " is not supported by the "
+                            + "connector (Trino materializes TIMESTAMP at millisecond precision; "
+                            + "sub-millisecond units would be silently truncated) — the server "
+                            + "must emit Timestamp(MILLISECOND)");
+        };
+    }
+
+    /**
+     * Read an Arrow {@code Date} value as an epoch-day count for Trino {@link
+     * DateType} (issue #2236). Only DAY-unit dates ({@link DateDayVector}) are
+     * representable; a {@link org.apache.arrow.vector.DateMilliVector DateMilliVector}
+     * (millis-since-epoch) is rejected with a clear typed error rather than thrown as
+     * a raw {@code ClassCastException} — deriving a calendar day from a millis instant
+     * is timezone-ambiguous. The Rust server pins {@code Date32} (DAY).
+     */
+    private static long epochDay(FieldVector vector, int i) {
+        if (vector instanceof DateDayVector v) {
+            return v.get(i);
+        }
+        throw new UnsupportedOperationException(
+                "Cannot map Arrow vector " + vector.getClass().getSimpleName()
+                        + " to a Trino DATE (only DAY-unit Date32 / DateDayVector is "
+                        + "representable as an epoch-day; the server must emit Date32)");
     }
 
     /** VARBINARY may be backed by variable or fixed-size binary vectors. */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowTypeMapper.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowTypeMapper.java
@@ -101,14 +101,57 @@ public final class ArrowTypeMapper {
             case ArrowType.LargeUtf8 ignored -> VarcharType.VARCHAR;
             case ArrowType.Binary ignored -> VarbinaryType.VARBINARY;
             case ArrowType.FixedSizeBinary ignored -> VarbinaryType.VARBINARY;
-            case ArrowType.Date ignored -> DateType.DATE;
+            case ArrowType.Date date -> dateType(date);
             // CQL time → Arrow Time (Rust emits Time64(Nanosecond)); Trino has a
             // native TIME whose precision mirrors the Arrow unit.
             case ArrowType.Time t -> timeType(t);
-            case ArrowType.Timestamp ignored -> TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+            case ArrowType.Timestamp ts -> timestampType(ts);
             default -> null;
         };
         return Optional.ofNullable(mapped);
+    }
+
+    /**
+     * Map an Arrow {@code Date} unit to Trino {@link DateType} (epoch-day). Only
+     * {@link org.apache.arrow.vector.types.DateUnit#DAY DAY}-unit dates are
+     * representable: Trino DATE stores an epoch-day count, which is exactly what a
+     * DAY-unit Arrow date (and Cassandra's {@code date} type) already carries.
+     *
+     * <p>{@code DateMilli} (millisecond-since-epoch) is <b>rejected</b> (returns
+     * {@code null} → hidden by {@link #toTrinoOrEmpty} / typed error from
+     * {@link #toTrino}). Deriving a calendar day from a millis instant is timezone-
+     * ambiguous, so we fail closed rather than silently pick a day — and never let a
+     * {@code DateMilliVector} reach {@link ArrowToTrino} where the DAY-typed cast
+     * would throw a raw {@code ClassCastException}. The Rust server pins {@code Date32}
+     * (DAY); this hardens the Java side against drift.
+     */
+    private static Type dateType(ArrowType.Date date) {
+        return switch (date.getUnit()) {
+            case DAY -> DateType.DATE;
+            case MILLISECOND -> null;
+        };
+    }
+
+    /**
+     * Map an Arrow {@code Timestamp} unit to Trino {@link TimestampWithTimeZoneType}.
+     * The connector materializes timestamps at millisecond precision
+     * ({@code TIMESTAMP_TZ_MILLIS}), so:
+     * <ul>
+     *   <li>{@code MILLISECOND} — identity (the value is already millis; the pinned
+     *       server unit).</li>
+     *   <li>{@code SECOND} — representable: {@link ArrowToTrino} up-scales ×1000
+     *       exactly (overflow-guarded), no precision loss.</li>
+     *   <li>{@code MICROSECOND}/{@code NANOSECOND} — <b>rejected</b> (returns
+     *       {@code null}). Down-scaling to millis would silently drop sub-millisecond
+     *       precision, so we fail closed with a clear typed error rather than
+     *       misinterpret the value (a 1000x/1_000_000x error before this fix).</li>
+     * </ul>
+     */
+    private static Type timestampType(ArrowType.Timestamp ts) {
+        return switch (ts.getUnit()) {
+            case SECOND, MILLISECOND -> TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+            case MICROSECOND, NANOSECOND -> null;
+        };
     }
 
     /** Map an Arrow {@code Time} unit to the Trino {@link TimeType} of equal precision. */

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ArrowToTrinoTest {
@@ -232,6 +233,128 @@ class ArrowToTrinoTest {
             assertEquals(nanos * 1_000L, type.getLong(builder.build(), 0));
 
             nano.close();
+        }
+    }
+
+    @Test
+    void scanUpScalesSecondUnitTimestampToMillis() {
+        // A SECOND-unit timestamp column is mapped to TIMESTAMP_TZ_MILLIS; the scan
+        // path must up-scale the raw seconds ×1000 (lossless), not read them as millis
+        // — the pre-#2236 code packed the raw long, a 1000x error.
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var ts = new org.apache.arrow.vector.TimeStampSecTZVector("ts", allocator, "UTC");
+            ts.allocateNew(1);
+            long epochSeconds = 1_700_000_000L;
+            ts.set(0, epochSeconds);
+
+            var root = new VectorSchemaRoot(List.of(ts));
+            root.setRowCount(1);
+            var columns = List.of(new CqliteFlightColumnHandle(
+                    "ts", io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS));
+
+            Page page = ArrowToTrino.toPage(root, columns);
+            long packed = io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS
+                    .getLong(page.getBlock(0), 0);
+            assertEquals(epochSeconds * 1_000L,
+                    io.trino.spi.type.DateTimeEncoding.unpackMillisUtc(packed));
+
+            root.close();
+        }
+    }
+
+    @Test
+    void scanRejectsMicrosecondUnitTimestampAsTyped() {
+        // If the server ever drifts and emits a MICROSECOND timestamp vector into a
+        // TIMESTAMP_TZ_MILLIS column, the scan path must fail closed (typed error
+        // naming the unit) rather than silently read micros as millis (1000x wrong).
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var ts = new org.apache.arrow.vector.TimeStampMicroTZVector("ts", allocator, "UTC");
+            ts.allocateNew(1);
+            ts.set(0, 1_700_000_000_000_000L);
+
+            var root = new VectorSchemaRoot(List.of(ts));
+            root.setRowCount(1);
+            var columns = List.of(new CqliteFlightColumnHandle(
+                    "ts", io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS));
+
+            UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
+                    () -> ArrowToTrino.toPage(root, columns));
+            assertTrue(ex.getMessage().contains("MICROSECOND"), ex.getMessage());
+
+            root.close();
+        }
+    }
+
+    @Test
+    void readJavaValueRejectsNanosecondUnitTimestampAsTyped() {
+        // The aggregation finalize path reads a TIMESTAMP group/aggregate column via
+        // readJavaValue; a NANOSECOND vector must be rejected with a typed error, not
+        // read raw (1_000_000x wrong).
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var ts = new org.apache.arrow.vector.TimeStampNanoVector("ts", allocator);
+            ts.allocateNew(1);
+            ts.set(0, 1_700_000_000_000_000_000L);
+
+            UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
+                    () -> ArrowToTrino.readJavaValue(ts, 0));
+            assertTrue(ex.getMessage().contains("NANOSECOND"), ex.getMessage());
+
+            ts.close();
+        }
+    }
+
+    @Test
+    void readJavaValueUpScalesSecondUnitTimestamp() {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var ts = new org.apache.arrow.vector.TimeStampSecVector("ts", allocator);
+            ts.allocateNew(1);
+            ts.set(0, 1_700_000_000L);
+
+            assertEquals(1_700_000_000_000L, ArrowToTrino.readJavaValue(ts, 0));
+
+            ts.close();
+        }
+    }
+
+    @Test
+    void scanRejectsDateMilliVectorAsTypedNotClassCast() {
+        // A DateMilli vector (millis-since-epoch) reaching a DATE column previously
+        // threw a raw ClassCastException on the DateDayVector cast. It must now be a
+        // clear typed UnsupportedOperationException instead.
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var date = new org.apache.arrow.vector.DateMilliVector("d", allocator);
+            date.allocateNew(1);
+            date.set(0, 1_700_000_000_000L);
+
+            var root = new VectorSchemaRoot(List.of(date));
+            root.setRowCount(1);
+            var columns = List.of(new CqliteFlightColumnHandle(
+                    "d", io.trino.spi.type.DateType.DATE));
+
+            UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
+                    () -> ArrowToTrino.toPage(root, columns));
+            assertTrue(ex.getMessage().contains("DATE"), ex.getMessage());
+
+            root.close();
+        }
+    }
+
+    @Test
+    void scanReadsDayUnitDateAsEpochDay() {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            var date = new org.apache.arrow.vector.DateDayVector("d", allocator);
+            date.allocateNew(1);
+            date.set(0, 19_000);
+
+            var root = new VectorSchemaRoot(List.of(date));
+            root.setRowCount(1);
+            var columns = List.of(new CqliteFlightColumnHandle(
+                    "d", io.trino.spi.type.DateType.DATE));
+
+            Page page = ArrowToTrino.toPage(root, columns);
+            assertEquals(19_000, io.trino.spi.type.DateType.DATE.getInt(page.getBlock(0), 0));
+
+            root.close();
         }
     }
 

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowTypeMapperTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowTypeMapperTest.java
@@ -78,6 +78,41 @@ class ArrowTypeMapperTest {
     }
 
     @Test
+    void timestampMapsByDeclaredUnit() {
+        // The connector materializes TIMESTAMP at millisecond precision. MILLISECOND
+        // (the pinned server unit) and SECOND (up-scaled ×1000, lossless) are
+        // representable; MICROSECOND/NANOSECOND would lose sub-ms precision so they
+        // fail closed rather than silently misread (issue #2236, was a 1000x error).
+        assertEquals(io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS,
+                ArrowTypeMapper.toTrino(scalar("ts",
+                        new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"))));
+        assertEquals(io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS,
+                ArrowTypeMapper.toTrino(scalar("ts",
+                        new ArrowType.Timestamp(TimeUnit.SECOND, "UTC"))));
+
+        assertTrue(ArrowTypeMapper.toTrinoOrEmpty(scalar("ts",
+                new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"))).isEmpty());
+        assertTrue(ArrowTypeMapper.toTrinoOrEmpty(scalar("ts",
+                new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC"))).isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> ArrowTypeMapper.toTrino(
+                scalar("ts", new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC"))));
+    }
+
+    @Test
+    void dateMapsByDeclaredUnit() {
+        // DAY (epoch-day, the pinned Date32 server unit) is representable as Trino
+        // DATE; DateMilli (millis-since-epoch) is timezone-ambiguous → fail closed
+        // rather than let a wrong-typed vector cast throw a raw ClassCastException.
+        assertEquals(io.trino.spi.type.DateType.DATE,
+                ArrowTypeMapper.toTrino(scalar("d",
+                        new ArrowType.Date(org.apache.arrow.vector.types.DateUnit.DAY))));
+        assertTrue(ArrowTypeMapper.toTrinoOrEmpty(scalar("d",
+                new ArrowType.Date(org.apache.arrow.vector.types.DateUnit.MILLISECOND))).isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> ArrowTypeMapper.toTrino(
+                scalar("d", new ArrowType.Date(org.apache.arrow.vector.types.DateUnit.MILLISECOND))));
+    }
+
+    @Test
     void complexTypesAreRejectedAtPlanning() {
         // v1 supports scalar columns; collections/decimal must fail clearly at
         // planning rather than crash mid-scan (mapper↔ArrowToTrino stay in lockstep).


### PR DESCRIPTION
Closes #2236. Part of Epic AM (#2226), audit finding N8. Latent bug — correct today only because the Rust server pins `Timestamp(Millisecond, UTC)` + `Date32(DAY)` everywhere; this hardens the Java side against drift.

## Defect
`ArrowTypeMapper.java` mapped ANY `ArrowType.Timestamp` → `TIMESTAMP_TZ_MILLIS` regardless of declared `TimeUnit`; `ArrowToTrino.java` packed raw longs as millis; `ArrowType.Date` assumed DAY. If the server ever emits micros/nanos (or DateMilli), Java silently misreads by 1000×/1_000_000× or throws a raw ClassCastException — no schema check.

## Fix — unit-aware, fail-closed on unrepresentable units
- **Timestamp**: MILLISECOND = identity; SECOND = ×1000 (overflow-guarded via `Math.multiplyExact`, correct for negative epochs, typed error on genuine overflow); **MICROSECOND/NANOSECOND fail-closed** with a typed `UnsupportedOperationException` naming the unit (chosen over silent sub-ms truncation — safe default).
- **Date**: DAY = epoch-day; **DateMilli fail-closed** with a typed error (not a raw ClassCastException; deriving a calendar day from a millis instant is timezone-ambiguous).
- Both the **scan path** (`toPage`→`writeValue`→`epochMillis`/`epochDay`) and the **aggregation path** (`readJavaValue`) now branch on the declared unit read off `vector.getField().getType()`. Planning (`timestampType`/`dateType`) returns empty→hidden for unsupported units, symmetric with the scan-time typed error.

## Review-first
- Correctness review: APPROVE — conversion math correct (incl. negative epochs), both paths covered, fail-closed complete (typed errors, no ClassCastException), tests meaningful.
- roborev (codex, job 3828): No issues found.

7 new unit tests drive the real `toPage`/`readJavaValue` paths with actual Sec/Micro/Nano Timestamp + DateDay/DateMilli vectors, asserting exact converted values (SECOND ×1000) or the specific typed exception + unit name. BUILD SUCCESSFUL, 286 tests. No Rust changed (server still pins ms/Date32).

Design note for owner: micros/nanos fail-closed rather than down-converting (avoids silent precision loss); only fires on server drift.