### PR TITLE
fix(#2238): ArrowToTrino surfaces a clear error for a missing projected column

### DIFF
--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
@@ -2,6 +2,8 @@ package in.mcfad.cqlite.flight;
 
 import io.airlift.slice.Slices;
 import io.trino.spi.Page;
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.BigintType;
@@ -56,15 +58,30 @@ public final class ArrowToTrino {
         for (int c = 0; c < columns.size(); c++) {
             CqliteFlightColumnHandle col = columns.get(c);
             FieldVector vector = root.getVector(col.name());
+            if (vector == null) {
+                // Issue #2238: the column was requested in the projection but is absent
+                // from the delivered batch — server/connector schema drift. Surface it
+                // as a clear error naming the column instead of masking it as an
+                // all-null column (which would silently hide a real correctness bug).
+                throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                        "Projected column '" + col.name()
+                                + "' is missing from the delivered Arrow batch; "
+                                + "the server did not return a vector for this column "
+                                + "(schema drift between the connector projection and "
+                                + "the Flight server response)");
+            }
             blocks[c] = toBlock(col.type(), vector, rowCount);
         }
         return new Page(rowCount, blocks);
     }
 
     private static Block toBlock(Type type, FieldVector vector, int rowCount) {
+        // Callers (toPage) guarantee {@code vector != null}; an absent projected
+        // column is rejected upstream (issue #2238). A null CELL within the present
+        // vector is normal and still yields an appended null below.
         BlockBuilder builder = type.createBlockBuilder(null, rowCount);
         for (int i = 0; i < rowCount; i++) {
-            if (vector == null || vector.isNull(i)) {
+            if (vector.isNull(i)) {
                 builder.appendNull();
                 continue;
             }

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
@@ -15,6 +15,7 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import io.trino.spi.TrinoException;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -286,6 +287,34 @@ class ArrowToTrinoTest {
     }
 
     @Test
+    void projectedColumnAbsentFromBatchRaisesNamingTheColumn() {
+        // Issue #2238: a column requested in the projection but missing from the
+        // delivered Arrow batch (server/connector schema drift) must surface a clear
+        // error naming the column — NOT be masked as a silent all-null column.
+        try (BufferAllocator allocator = new RootAllocator()) {
+            IntVector id = new IntVector("id", allocator);
+            id.allocateNew(2);
+            id.set(0, 10);
+            id.set(1, 20);
+
+            var root = new VectorSchemaRoot(List.of(id));
+            root.setRowCount(2);
+
+            // "missing_col" is projected but never delivered in the batch.
+            var columns = List.of(
+                    new CqliteFlightColumnHandle("id", IntegerType.INTEGER),
+                    new CqliteFlightColumnHandle("missing_col", VarcharType.VARCHAR));
+
+            TrinoException ex = assertThrows(TrinoException.class,
+                    () -> ArrowToTrino.toPage(root, columns));
+            assertTrue(ex.getMessage().contains("missing_col"),
+                    "error must name the missing column, was: " + ex.getMessage());
+
+            root.close();
+        }
+    }
+
+    @Test
     void readJavaValueRejectsNanosecondUnitTimestampAsTyped() {
         // The aggregation finalize path reads a TIMESTAMP group/aggregate column via
         // readJavaValue; a NANOSECOND vector must be rejected with a typed error, not
@@ -353,6 +382,28 @@ class ArrowToTrinoTest {
 
             Page page = ArrowToTrino.toPage(root, columns);
             assertEquals(19_000, io.trino.spi.type.DateType.DATE.getInt(page.getBlock(0), 0));
+
+            root.close();
+        }
+    }
+
+    @Test
+    void nullValueWithinPresentVectorStaysNullNotError() {
+        // Guardrail (issue #2238): a null CELL within a delivered vector is normal and
+        // must still yield an appended null — only an ENTIRELY absent vector errors.
+        try (BufferAllocator allocator = new RootAllocator()) {
+            IntVector id = new IntVector("id", allocator);
+            id.allocateNew(2);
+            id.set(0, 10);
+            id.setNull(1);
+
+            var root = new VectorSchemaRoot(List.of(id));
+            root.setRowCount(2);
+
+            var columns = List.of(new CqliteFlightColumnHandle("id", IntegerType.INTEGER));
+            Page page = ArrowToTrino.toPage(root, columns);
+            assertEquals(10, IntegerType.INTEGER.getInt(page.getBlock(0), 0));
+            assertTrue(page.getBlock(0).isNull(1), "null cell must stay null, not error");
 
             root.close();
         }


### PR DESCRIPTION
Closes #2238

## Summary
`ArrowToTrino.toBlock` treated a projected column whose Arrow vector is entirely absent from the
delivered batch the same as a null cell within a present vector — silently appending null for every
row instead of surfacing the underlying server/connector schema drift. Fix:
- `toPage` now throws `TrinoException(GENERIC_INTERNAL_ERROR, ...)` naming the missing column when
  `root.getVector(col.name())` returns null, before any `Page`/`Block` is built.
- `toBlock`'s null-check is narrowed to only handle `vector.isNull(i)` (a null cell in a present
  vector) — the missing-vector case can no longer reach it (private method, single call site).

## Review history (review-first, before any full gate)
- roborev: clean.
- `rust-reviewer`: clean/merge-with-followups. Confirmed the exception fires before any partial
  state leaks, confirmed `toBlock` can never see a null vector post-fix, confirmed both new tests
  exercise the real code path (not isolated helpers) and are directional opposites of each other.
  Found the IDENTICAL conflation unpatched in a sibling file (`CqliteFlightAggregatePageSource.java`,
  the aggregation read path) — filed as follow-up #2262, not fixed here (1:1:1:1).

## Test plan
- [x] `ArrowToTrinoTest.java`: `projectedColumnAbsentFromBatchRaisesNamingTheColumn` (real
      `VectorSchemaRoot` missing a projected vector, asserts `TrinoException` naming the column)
- [x] `ArrowToTrinoTest.java`: `nullValueWithinPresentVectorStaysNullNotError` (guardrail — null
      cell in a present vector still appends null, no regression)
- [x] Full `trino-connector` gradle test suite green (9/9 in `ArrowToTrinoTest`, full module PASS)
- [x] `scripts/agent-gate.sh --lite` PASS (no Rust files touched; Trino connector has no gate
      component today)
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — runs once via `flow-closer`