### PR TITLE
test(#2233): e2e LIMIT bounding + EXPLAIN pushdown asserts + per-query timeout hardening

### DIFF
--- a/trino-connector/docker/e2e-test.sh
+++ b/trino-connector/docker/e2e-test.sh
@@ -11,8 +11,52 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 COMPOSE=(docker compose -f "$ROOT/trino-connector/docker/docker-compose.yml")
 FAILURES=0
 
+# Per-query timeout (issue #2233): a product-side streaming hang (observed live —
+# Trino cancels an over-satisfied LIMIT split mid-stream and the connector's
+# do_get never unblocks/completes, per the task landing in Trino's own
+# system.runtime.tasks as CANCELING forever) must fail this script in minutes,
+# not hang a CI job or a dev box indefinitely. GNU `timeout` ships on every CI
+# runner (Linux); a macOS dev box may only have `gtimeout` (coreutils) or
+# neither — fall back to a manual background+kill wrapper so the bound still
+# holds everywhere instead of silently reverting to unbounded.
+QUERY_TIMEOUT_SECS=180
+TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
+run_with_timeout() {
+  local secs="$1"; shift
+  if [[ -n "$TIMEOUT_BIN" ]]; then
+    "$TIMEOUT_BIN" "$secs" "$@"
+    return $?
+  fi
+  "$@" &
+  local pid=$! waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if (( waited >= secs )); then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null
+      return 124
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid"
+}
+
 log()  { echo "── $* ──"; }
-trino() { "${COMPOSE[@]}" exec -T trino trino --execute "$1" 2>&1; }
+# Both query helpers route through run_with_timeout so a hang surfaces as a
+# clear FATAL message + fast exit rather than either an indefinite stall or an
+# opaque `set -e` abort from an unhandled non-zero command-substitution status.
+trino() {
+  local out rc=0
+  set +e
+  out="$(run_with_timeout "$QUERY_TIMEOUT_SECS" "${COMPOSE[@]}" exec -T trino trino --execute "$1" 2>&1)"
+  rc=$?
+  set -e
+  if [[ $rc -eq 124 ]]; then
+    echo "FATAL: query timed out after ${QUERY_TIMEOUT_SECS}s (possible product hang): $1" >&2
+    exit 1
+  fi
+  echo "$out"
+}
 
 assert_eq() {
   local desc="$1" expected="$2" actual="$3"
@@ -138,7 +182,18 @@ assert_eq "high-card group count"   '"10"'                                   "$(
 # Use count(*), which pushes without an inserted CAST projection (sum on an int
 # column gets a CAST that defeats single-Variable-arg pushdown — a separate,
 # pre-existing limitation unrelated to this gate).
-explain() { "${COMPOSE[@]}" exec -T trino trino --execute "EXPLAIN $1" 2>&1; }
+explain() {
+  local out rc=0
+  set +e
+  out="$(run_with_timeout "$QUERY_TIMEOUT_SECS" "${COMPOSE[@]}" exec -T trino trino --execute "EXPLAIN $1" 2>&1)"
+  rc=$?
+  set -e
+  if [[ $rc -eq 124 ]]; then
+    echo "FATAL: EXPLAIN timed out after ${QUERY_TIMEOUT_SECS}s (possible product hang): $1" >&2
+    exit 1
+  fi
+  echo "$out"
+}
 pushed()    { grep -q 'aggregationJson=Optional\[' <<<"$1"; }
 assert_pushed() {
   local desc="$1" plan="$2"
@@ -164,6 +219,30 @@ assert_filter_pushed() {
   local desc="$1" plan="$2"
   if filter_pushed "$plan"; then echo "PASS: $desc";
   else echo "FAIL: $desc — handle had filterJson=Optional.empty (predicate not pushed)"; echo "$plan"; FAILURES=$((FAILURES + 1)); fi
+}
+
+# LIMIT pushdown via EXPLAIN (#2129). A row-count assertion alone (e.g. `LIMIT 2`
+# -> 2 rows) is NOT proof the connector pushed the limit: Trino applies its own
+# Limit/LimitPartial above the scan regardless, so the count is correct even if
+# the connector silently stopped pushing (the exact #2233 regression this test
+# exists to catch) — Trino's own cap would still trim to the right count. The
+# scan's cqlite table handle is a Java record with no custom toString, so its
+# default rendering carries every field verbatim; `limit` is an `OptionalLong`,
+# whose JDK toString is `OptionalLong[N]` when present or `OptionalLong.empty`
+# when absent (verified: `CqliteFlightTableHandle` record field order, JDK
+# java.util.OptionalLong#toString) — the same handle-rendering probe already used
+# above for `aggregationJson`/`filterJson`.
+limit_pushed() { grep -q 'limit=OptionalLong\[' <<<"$1"; }
+assert_limit_pushed() {
+  local desc="$1" plan="$2"
+  if limit_pushed "$plan"; then echo "PASS: $desc";
+  else echo "FAIL: $desc — handle had limit=OptionalLong.empty (LIMIT not pushed)"; echo "$plan"; FAILURES=$((FAILURES + 1)); fi
+}
+assert_limit_not_pushed() {
+  local desc="$1" plan="$2"
+  if limit_pushed "$plan"; then
+    echo "FAIL: $desc — handle carried limit=OptionalLong[...] (unexpectedly pushed)"; echo "$plan"; FAILURES=$((FAILURES + 1));
+  else echo "PASS: $desc"; fi
 }
 
 # Low-cardinality GROUP BY device (ratio ≈ 0.2 < 0.5): PUSHED into the scan.
@@ -192,21 +271,42 @@ assert_filter_pushed "range score > 25 is pushed" \
 # bounding regression (LIMIT ignored, or a limit pushed past a residual filter)
 # was structurally invisible. events has 5 rows here (the ghost row below is not
 # flushed yet). count(*) over a LIMIT subquery is a deterministic scalar.
-log "assert LIMIT result bounding"
+#
+# The row-count alone does NOT prove pushdown: Trino keeps its own Limit above
+# the scan and would trim to the right count even if the connector silently
+# stopped pushing. Assert the EXPLAIN handle rendering FIRST (the actual
+# regression signal), and keep the row counts as a secondary correctness check.
+log "assert LIMIT pushdown (EXPLAIN) + result bounding"
+assert_limit_pushed "LIMIT 2 is pushed onto the scan handle" \
+  "$(explain 'SELECT id FROM cqlite.analytics.events LIMIT 2')"
 assert_eq "LIMIT 2 returns exactly 2 rows"       '"2"' \
   "$(trino 'SELECT count(*) FROM (SELECT id FROM cqlite.analytics.events LIMIT 2)')"
+assert_limit_pushed "LIMIT 100 is pushed onto the scan handle" \
+  "$(explain 'SELECT id FROM cqlite.analytics.events LIMIT 100')"
 assert_eq "LIMIT above table size returns all 5" '"5"' \
   "$(trino 'SELECT count(*) FROM (SELECT id FROM cqlite.analytics.events LIMIT 100)')"
 
 # LIMIT + partially-pushable predicate (audit finding N13). `score > 15` pushes;
 # `length(name) > 3` is a function call the connector cannot translate, so it
-# stays a Trino residual FilterNode ABOVE the scan. Soundness rests on Trino NOT
-# pushing the LIMIT below that residual (applyLimit is residual-unaware,
-# CqliteFlightMetadata.java) — else the server would cap early, before the residual
-# ran, and drop rows Trino can never recover. Rows with score>15:
-# bob(20,len3) carol(30,len5) dave(40,len4) erin(50,len4); length>3 drops bob, so
-# carol,dave,erin (3 rows) satisfy BOTH conjuncts.
-log "assert LIMIT + partially-pushable predicate correctness"
+# stays a Trino residual FilterNode ABOVE the scan. `CqliteFlightMetadata.applyLimit`
+# itself is residual-unaware (no check for an unpushed conjunct — verified by
+# reading its source), so the soundness guard against capping before the residual
+# runs is NOT in our code; it is Trino's planner, which — verified empirically
+# against a live EXPLAIN below — never calls `applyLimit` while an active residual
+# FilterNode sits between the LimitNode and the TableScanNode. So the correct,
+# observed signal here is `limit=OptionalLong.empty`: the connector-side limit is
+# NOT pushed, and Trino's own (un-pushed) Limit does the final cut post-residual.
+# Assert that directly, alongside the score>15 filter conjunct still pushing, and
+# keep the row counts as the order-independent parity check that the residual
+# (length(name) > 3) was actually still applied rather than silently dropped.
+# Rows with score>15: bob(20,len3) carol(30,len5) dave(40,len4) erin(50,len4);
+# length>3 drops bob, so carol,dave,erin (3 rows) satisfy BOTH conjuncts.
+log "assert LIMIT + partially-pushable predicate pushdown (EXPLAIN) + correctness"
+partial_plan="$(explain \
+  'SELECT id FROM cqlite.analytics.events WHERE score > 15 AND length(name) > 3 LIMIT 2')"
+assert_limit_not_pushed "partial-predicate LIMIT stays with Trino (residual filter blocks push)" \
+  "$partial_plan"
+assert_filter_pushed "partial-predicate score>15 conjunct is pushed"          "$partial_plan"
 # LIMIT 2 (< 3 qualifying): the full 2 rows must survive — fewer would be the
 # symptom of a LIMIT pushed below the residual filter.
 assert_eq "partial-predicate LIMIT 2 returns 2 rows"          '"2"' \

--- a/trino-connector/docker/e2e-test.sh
+++ b/trino-connector/docker/e2e-test.sh
@@ -32,7 +32,10 @@ run_with_timeout() {
   while kill -0 "$pid" 2>/dev/null; do
     if (( waited >= secs )); then
       kill -9 "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null
+      # Reap the killed child without letting its non-zero wait status trip
+      # errexit before `return 124` runs — self-contained regardless of the
+      # caller's current `set -e`/`set +e` state.
+      wait "$pid" 2>/dev/null || true
       return 124
     fi
     sleep 1
@@ -45,6 +48,9 @@ log()  { echo "── $* ──"; }
 # Both query helpers route through run_with_timeout so a hang surfaces as a
 # clear FATAL message + fast exit rather than either an indefinite stall or an
 # opaque `set -e` abort from an unhandled non-zero command-substitution status.
+# Returns the underlying query's real exit status (not just 0) so callers that
+# poll readiness via `if trino ...; then break; fi` keep working — only a
+# timeout (124) is special-cased to a hard, immediate script failure.
 trino() {
   local out rc=0
   set +e
@@ -56,6 +62,7 @@ trino() {
     exit 1
   fi
   echo "$out"
+  return "$rc"
 }
 
 assert_eq() {
@@ -98,7 +105,7 @@ log "bring up stack (builds cqlite-flight image; waits for healthy deps)"
 
 log "wait for Trino to accept queries"
 for i in $(seq 1 60); do
-  if "${COMPOSE[@]}" exec -T trino trino --execute "SELECT 1" >/dev/null 2>&1; then break; fi
+  if trino "SELECT 1" >/dev/null 2>&1; then break; fi
   sleep 5
   [[ $i -eq 60 ]] && { echo "Trino did not become ready"; exit 1; }
 done
@@ -109,8 +116,7 @@ log "load data + flush to SSTables"
 
 log "wait for the connector to resolve the table via Sidecar (CQL session warmup)"
 for i in $(seq 1 36); do
-  if "${COMPOSE[@]}" exec -T trino trino --execute \
-       "SELECT count(*) FROM cqlite.analytics.events" >/dev/null 2>&1; then break; fi
+  if trino "SELECT count(*) FROM cqlite.analytics.events" >/dev/null 2>&1; then break; fi
   sleep 5
   [[ $i -eq 36 ]] && { echo "connector never resolved analytics.events (Sidecar not ready)"; exit 1; }
 done
@@ -159,8 +165,7 @@ assert_eq "agg + predicate"         '"120"'                                  "$(
 # Globals always push regardless of the gate.
 log "wait for the connector to resolve analytics.readings"
 for i in $(seq 1 36); do
-  if "${COMPOSE[@]}" exec -T trino trino --execute \
-       "SELECT count(*) FROM cqlite.analytics.readings" >/dev/null 2>&1; then break; fi
+  if trino "SELECT count(*) FROM cqlite.analytics.readings" >/dev/null 2>&1; then break; fi
   sleep 5
   [[ $i -eq 36 ]] && { echo "connector never resolved analytics.readings"; exit 1; }
 done
@@ -193,6 +198,7 @@ explain() {
     exit 1
   fi
   echo "$out"
+  return "$rc"
 }
 pushed()    { grep -q 'aggregationJson=Optional\[' <<<"$1"; }
 assert_pushed() {

--- a/trino-connector/docker/e2e-test.sh
+++ b/trino-connector/docker/e2e-test.sh
@@ -244,12 +244,6 @@ assert_limit_pushed() {
   if limit_pushed "$plan"; then echo "PASS: $desc";
   else echo "FAIL: $desc — handle had limit=OptionalLong.empty (LIMIT not pushed)"; echo "$plan"; FAILURES=$((FAILURES + 1)); fi
 }
-assert_limit_not_pushed() {
-  local desc="$1" plan="$2"
-  if limit_pushed "$plan"; then
-    echo "FAIL: $desc — handle carried limit=OptionalLong[...] (unexpectedly pushed)"; echo "$plan"; FAILURES=$((FAILURES + 1));
-  else echo "PASS: $desc"; fi
-}
 
 # Low-cardinality GROUP BY device (ratio ≈ 0.2 < 0.5): PUSHED into the scan.
 assert_pushed     "low-card GROUP BY device is pushed" \
@@ -297,21 +291,21 @@ assert_eq "LIMIT above table size returns all 5" '"5"' \
 # stays a Trino residual FilterNode ABOVE the scan. `CqliteFlightMetadata.applyLimit`
 # itself is residual-unaware (no check for an unpushed conjunct — verified by
 # reading its source), so the soundness guard against capping before the residual
-# runs is NOT in our code; it is Trino's planner, which — verified empirically
-# against a live EXPLAIN below — never calls `applyLimit` while an active residual
-# FilterNode sits between the LimitNode and the TableScanNode. So the correct,
-# observed signal here is `limit=OptionalLong.empty`: the connector-side limit is
-# NOT pushed, and Trino's own (un-pushed) Limit does the final cut post-residual.
-# Assert that directly, alongside the score>15 filter conjunct still pushing, and
-# keep the row counts as the order-independent parity check that the residual
-# (length(name) > 3) was actually still applied rather than silently dropped.
-# Rows with score>15: bob(20,len3) carol(30,len5) dave(40,len4) erin(50,len4);
-# length>3 drops bob, so carol,dave,erin (3 rows) satisfy BOTH conjuncts.
+# runs is NOT in our code; it is Trino's planner. We do NOT assert the limit is
+# absent from the scan handle here: that would encode current planner behavior
+# (observed live: Trino never calls applyLimit while an active residual
+# FilterNode sits between Limit and the scan) as a connector CONTRACT — a future
+# valid plan could carry a non-guaranteed limit hint under a residual filter
+# (applyLimit's limitGuaranteed=false) and still be correct, which would then
+# break CI on a valid shape. Assert only what IS the contract: the pushable
+# score>15 conjunct pushes, and the row counts are the order-independent parity
+# check that the residual (length(name) > 3) was actually still applied rather
+# than silently dropped. Rows with score>15: bob(20,len3) carol(30,len5)
+# dave(40,len4) erin(50,len4); length>3 drops bob, so carol,dave,erin (3 rows)
+# satisfy BOTH conjuncts.
 log "assert LIMIT + partially-pushable predicate pushdown (EXPLAIN) + correctness"
 partial_plan="$(explain \
   'SELECT id FROM cqlite.analytics.events WHERE score > 15 AND length(name) > 3 LIMIT 2')"
-assert_limit_not_pushed "partial-predicate LIMIT stays with Trino (residual filter blocks push)" \
-  "$partial_plan"
 assert_filter_pushed "partial-predicate score>15 conjunct is pushed"          "$partial_plan"
 # LIMIT 2 (< 3 qualifying): the full 2 rows must survive — fewer would be the
 # symptom of a LIMIT pushed below the residual filter.

--- a/trino-connector/docker/e2e-test.sh
+++ b/trino-connector/docker/e2e-test.sh
@@ -152,6 +152,20 @@ assert_not_pushed() {
   else echo "PASS: $desc"; fi
 }
 
+# Filter pushdown (#2164): the cqlite table handle the scan prints carries
+# `filterJson=Optional[...]` when a predicate was translated and pushed into the
+# Flight ticket, or `filterJson=Optional.empty` when it stayed a pure Trino
+# residual. Same handle-toString probe as the aggregation gate above (the record
+# renders every component field), so it is a reliable per-predicate signal — and
+# unlike a count assertion it catches a SILENT pushdown loss (#2164-class): Trino
+# re-applies residuals, so a dropped pushdown still returns the right count.
+filter_pushed() { grep -q 'filterJson=Optional\[' <<<"$1"; }
+assert_filter_pushed() {
+  local desc="$1" plan="$2"
+  if filter_pushed "$plan"; then echo "PASS: $desc";
+  else echo "FAIL: $desc — handle had filterJson=Optional.empty (predicate not pushed)"; echo "$plan"; FAILURES=$((FAILURES + 1)); fi
+}
+
 # Low-cardinality GROUP BY device (ratio ≈ 0.2 < 0.5): PUSHED into the scan.
 assert_pushed     "low-card GROUP BY device is pushed" \
   "$(explain 'SELECT device, count(*) FROM cqlite.analytics.readings GROUP BY device')"
@@ -161,6 +175,46 @@ assert_not_pushed "high-card GROUP BY device,ts is left to Trino" \
 # Global aggregate always pushes regardless of the gate.
 assert_pushed     "global count(*) is pushed" \
   "$(explain 'SELECT count(*) FROM cqlite.analytics.readings')"
+
+# Predicate pushdown via EXPLAIN (#2164). Prove domain-shaped predicates are
+# actually PUSHED onto the scan handle, not merely count-correct: Trino re-applies
+# residuals and its own LIMIT, so a silent pushdown/bounding loss keeps the counts
+# right and would sail through every assert_eq above. `id = 3` arrives as a
+# TupleDomain summary (a partition point read); `score > 25` as an ordering
+# comparison — both must translate into `filterJson`.
+log "assert predicate pushdown via EXPLAIN (filterJson on the scan handle)"
+assert_filter_pushed "point read id = 3 is pushed" \
+  "$(explain 'SELECT name FROM cqlite.analytics.events WHERE id = 3')"
+assert_filter_pushed "range score > 25 is pushed" \
+  "$(explain 'SELECT name FROM cqlite.analytics.events WHERE score > 25')"
+
+# LIMIT bounding (#2129). No LIMIT query existed elsewhere in this script, so a
+# bounding regression (LIMIT ignored, or a limit pushed past a residual filter)
+# was structurally invisible. events has 5 rows here (the ghost row below is not
+# flushed yet). count(*) over a LIMIT subquery is a deterministic scalar.
+log "assert LIMIT result bounding"
+assert_eq "LIMIT 2 returns exactly 2 rows"       '"2"' \
+  "$(trino 'SELECT count(*) FROM (SELECT id FROM cqlite.analytics.events LIMIT 2)')"
+assert_eq "LIMIT above table size returns all 5" '"5"' \
+  "$(trino 'SELECT count(*) FROM (SELECT id FROM cqlite.analytics.events LIMIT 100)')"
+
+# LIMIT + partially-pushable predicate (audit finding N13). `score > 15` pushes;
+# `length(name) > 3` is a function call the connector cannot translate, so it
+# stays a Trino residual FilterNode ABOVE the scan. Soundness rests on Trino NOT
+# pushing the LIMIT below that residual (applyLimit is residual-unaware,
+# CqliteFlightMetadata.java) — else the server would cap early, before the residual
+# ran, and drop rows Trino can never recover. Rows with score>15:
+# bob(20,len3) carol(30,len5) dave(40,len4) erin(50,len4); length>3 drops bob, so
+# carol,dave,erin (3 rows) satisfy BOTH conjuncts.
+log "assert LIMIT + partially-pushable predicate correctness"
+# LIMIT 2 (< 3 qualifying): the full 2 rows must survive — fewer would be the
+# symptom of a LIMIT pushed below the residual filter.
+assert_eq "partial-predicate LIMIT 2 returns 2 rows"          '"2"' \
+  "$(trino 'SELECT count(*) FROM (SELECT id FROM cqlite.analytics.events WHERE score > 15 AND length(name) > 3 LIMIT 2)')"
+# LIMIT 5 (> 3 qualifying): exactly the 3 rows satisfying both conjuncts — if the
+# residual length filter were dropped, score>15 alone would yield 4 (incl. bob).
+assert_eq "partial-predicate LIMIT 5 applies residual (3 rows)" '"3"' \
+  "$(trino 'SELECT count(*) FROM (SELECT id FROM cqlite.analytics.events WHERE score > 15 AND length(name) > 3 LIMIT 5)')"
 
 # Proof it reads SSTables (not live CQL): an unflushed row must be invisible.
 log "assert SSTable semantics (memtable invisible until flush)"


### PR DESCRIPTION
Closes #2233

## What

Adds the missing e2e regression net for connector pushdown (Epic AM #2226, Wave 1):

- **LIMIT pushdown asserts (EXPLAIN-based)**: verifies the scan handle carries the pushed limit (`limit=OptionalLong[...]`) for fully-pushable queries — not just row counts, which Trino gets right even when pushdown regresses (roborev 1570 finding).
- **Filter pushdown asserts (EXPLAIN-based)**: `id = 3` and `score > 25` conjuncts appear in the handle's filter rendering.
- **Partial-predicate + LIMIT correctness**: pushed conjunct asserted in EXPLAIN + bounded row-count checks. (A negative "limit must be absent" assert was dropped as brittle — a non-guaranteed limit hint under a residual filter is a valid planner shape; roborev 1572.)
- **Per-query timeout hardening (180s, timeout/gtimeout/manual fallback)**: motivated by a live 35-min silent hang observed during this work — filed as #2264 (cqlite-flight do_get stall, Trino task stuck CANCELING). Readiness polls also routed through the wrapper; manual fallback proven to return 124 under `set -e`.

## Verification

- Local docker e2e (fresh stack, hardened script): **32/32 assertions PASS**. One pre-existing unrelated flake ("unflushed row invisible", memtable-flush timing) is outside this diff.
- Review-first: roborev jobs 1570/1571/1572 — all findings addressed (rounds above); diff is shell-only (no Rust surface).
- `flight-trino-e2e` CI lane is the verification of record on this PR.

Related: #2264 (product stall found + filed during this work).