### PR TITLE
perf(#2240): reuse tokio runtime + Platform across token-prune loop (per-request, not per-SSTable)

### DIFF
--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -241,33 +241,66 @@ fn generation_of(path: &Path) -> u64 {
         .unwrap_or(0)
 }
 
+/// A reusable async driver for the token prune (issue #2240).
+///
+/// [`sstable_token_span`] needs a tokio runtime (to drive the async
+/// `SummaryReader::open`) and a [`Platform`](cqlite_core::Platform). Building
+/// both is pure setup cost; doing it per SSTable made a many-SSTable prune under
+/// concurrent `do_get` load pay that cost once per file per split (a #2157 stall
+/// suspect). This bundles them so [`MergeProducer::prune_paths_cancellable`] can
+/// construct ONCE per prune request and reuse across every SSTable in the loop.
+///
+/// The runtime is a single current-thread runtime; the prune loop is a sync
+/// caller (it runs on a `spawn_blocking` thread), so driving many sequential
+/// `block_on` calls off one runtime is safe — no nested-runtime panic and no
+/// cross-thread `Send` requirement.
+struct PruneRuntime {
+    runtime: tokio::runtime::Runtime,
+    platform: std::sync::Arc<cqlite_core::Platform>,
+}
+
+impl PruneRuntime {
+    /// Build the runtime + platform once. Returns `None` on any construction
+    /// failure so the caller can fail open (keep every path) exactly as the
+    /// old per-file path did when it could not build its runtime/platform.
+    fn new() -> Option<Self> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .ok()?;
+        let platform = std::sync::Arc::new(
+            runtime
+                .block_on(cqlite_core::Platform::new(&cqlite_core::Config::default()))
+                .ok()?,
+        );
+        Some(Self { runtime, platform })
+    }
+}
+
 /// Read an SSTable's `[minToken, maxToken]` span from its sibling `Summary.db`.
 ///
 /// SSTables store partitions in token order, so the first key carries the
 /// minimum token and the last key the maximum. The `Summary.db` path is derived
 /// by replacing the `-Data.db` suffix. Returns `None` on any failure (missing
 /// file, parse error, unparseable name) so callers can fail open.
-fn sstable_token_span(data_path: &Path) -> Option<(i64, i64)> {
+///
+/// The runtime + platform are supplied by the caller (see [`PruneRuntime`]) and
+/// reused across every SSTable in a prune, rather than rebuilt per file.
+fn sstable_token_span(data_path: &Path, rt: &PruneRuntime) -> Option<(i64, i64)> {
     let name = data_path.file_name()?.to_str()?;
     if !name.ends_with("-Data.db") {
         return None;
     }
     let summary_path = data_path.with_file_name(name.replace("-Data.db", "-Summary.db"));
 
-    // `SummaryReader::open` is async; drive it on a short-lived current-thread
-    // runtime. The prune is a one-shot, low-frequency step per DoGet split.
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .ok()?;
-    let platform = runtime
-        .block_on(cqlite_core::Platform::new(&cqlite_core::Config::default()))
-        .ok()?;
-    let reader = runtime
+    // `SummaryReader::open` is async; drive it on the shared current-thread
+    // runtime. `block_on` is called sequentially per SSTable — safe reuse.
+    let reader = rt
+        .runtime
         .block_on(
             cqlite_core::storage::sstable::summary_reader::SummaryReader::open(
                 &summary_path,
-                std::sync::Arc::new(platform),
+                std::sync::Arc::clone(&rt.platform),
             ),
         )
         .ok()?;
@@ -571,16 +604,32 @@ impl MergeProducer {
             return Ok(paths);
         };
 
+        // Honour a pre-cancel before any setup, so a cancelled prune does ZERO
+        // work (as the pre-change per-file loop did — its first act was this
+        // same cancel poll, before building anything).
+        if cancel.is_cancelled() {
+            return Err(ProducerError::Cancelled);
+        }
+
         let total = paths.len();
         let mut kept: Vec<PathBuf> = Vec::with_capacity(total);
+
+        // Build the async driver (tokio runtime + Platform) ONCE per prune and
+        // reuse it for every SSTable (issue #2240), instead of rebuilding it per
+        // file. If it cannot be built, `rt` is `None` and every path fails open
+        // below — identical to the old per-file behaviour when construction
+        // failed. Constructed AFTER the token/empty/cancel guards so neither an
+        // unfiltered nor a cancelled prune pays the setup cost.
+        let rt = PruneRuntime::new();
         for path in paths {
             if cancel.is_cancelled() {
                 return Err(ProducerError::Cancelled);
             }
-            let keep = match sstable_token_span(&path) {
+            let keep = match rt.as_ref().and_then(|rt| sstable_token_span(&path, rt)) {
                 // Span known: keep only if it overlaps the split's range.
                 Some((min_token, max_token)) => token.overlaps(min_token, max_token),
-                // Span unknown (missing/unreadable Summary.db): fail open.
+                // Span unknown (missing/unreadable Summary.db, or no runtime):
+                // fail open.
                 None => true,
             };
             if keep {
@@ -2026,6 +2075,40 @@ mod tests {
             kept.contains(&paths[0]),
             "path with missing Summary.db must be kept (fail open)"
         );
+    }
+
+    /// (e) Issue #2240: a SINGLE reused [`PruneRuntime`] reads every SSTable's
+    /// span identically to the pre-change per-file construction (`span_of`
+    /// builds its own runtime + Platform each call). This proves the hoisted,
+    /// reused runtime yields byte-identical prune inputs — no behaviour change —
+    /// while constructing the runtime + Platform ONCE for the whole loop.
+    #[test]
+    fn prune_runtime_is_reused_across_sstables_with_identical_spans() {
+        let schema = simple_schema();
+        // Three SSTables so one reused runtime drives several block_on calls.
+        let (_temp, _data, dir) = build_sstables(
+            &schema,
+            vec![
+                vec![write_row(1, "a", 10, 100)],
+                vec![write_row(2, "b", 20, 100)],
+                vec![write_row(3, "c", 30, 100)],
+            ],
+        );
+        let paths = DirSource::new(&dir).data_paths().unwrap();
+        assert_eq!(paths.len(), 3, "fixture has three SSTables");
+
+        // Build the driver ONCE and reuse it for every file.
+        let rt = PruneRuntime::new().expect("prune runtime builds");
+        for path in &paths {
+            let reused = sstable_token_span(path, &rt).expect("reused span read");
+            // `span_of` constructs a fresh runtime + Platform per call — the
+            // pre-change behaviour — so equality proves the reuse is faithful.
+            let per_file = span_of(path);
+            assert_eq!(
+                reused, per_file,
+                "reused-runtime span must equal per-file-runtime span"
+            );
+        }
     }
 
     // ---- Issue #834: nested predicate pushdown (OR/NOT/IS NULL) ----

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -611,6 +611,12 @@ impl MergeProducer {
             return Err(ProducerError::Cancelled);
         }
 
+        // Empty input: no SSTables to inspect, so skip all setup. As with
+        // the pre-hoist per-file loop, an empty list built no runtime at all.
+        if paths.is_empty() {
+            return Ok(paths);
+        }
+
         let total = paths.len();
         let mut kept: Vec<PathBuf> = Vec::with_capacity(total);
 
@@ -2109,6 +2115,21 @@ mod tests {
                 "reused-runtime span must equal per-file-runtime span"
             );
         }
+    }
+
+    /// (f) Issue #2240: a token-filtered prune of an EMPTY path list returns
+    /// empty and does zero setup — the empty guard short-circuits before any
+    /// `PruneRuntime` (tokio runtime + Platform) is constructed.
+    #[test]
+    fn prune_empty_paths_returns_empty_without_setup() {
+        let schema = simple_schema();
+        // A token filter is present, so the prune does NOT take the no-token
+        // early return — it reaches the empty guard.
+        let spec = spec_with_token(i64::MIN, i64::MAX);
+        assert!(spec.token.is_some(), "token filter must be set");
+        let producer = MergeProducer::with_spec(schema, 1024, spec).unwrap();
+        let kept = producer.prune_paths(Vec::new()).unwrap();
+        assert!(kept.is_empty(), "empty input prunes to empty");
     }
 
     // ---- Issue #834: nested predicate pushdown (OR/NOT/IS NULL) ----


### PR DESCRIPTION
Closes #2240. Part of Epic AM (#2226), do_get lifecycle lane (NEW-3). A #2157-stall suspect.

## Defect
`sstable_token_span` (`cqlite-flight/src/producer.rs`) built a brand-new tokio current-thread runtime AND a fresh Platform for EVERY SSTable, on EVERY token-filtered do_get (via `prune_paths_cancellable`). Many-SSTable tables under concurrent do_get load paid repeated per-file setup cost — pure setup-phase overhead. Correctness unaffected (fails open).

## Fix
Hoist runtime+Platform into a `PruneRuntime` built ONCE per prune request and reused for every `block_on` across the prune loop.
- **Correctness unchanged**: prune results provably identical — the span is computed from the deterministic Summary.db read + token decode, independent of which runtime drives it.
- **Reuse safe**: sole production caller is `service.rs` `do_get_setup` → `spawn_blocking` (sync context), so sequential `block_on` on one current-thread runtime cannot hit a nested-runtime panic; the pre-change code already called `block_on` from the same sync fns.
- **Cancellation preserved**: pre-setup cancel poll + per-file poll retained.
- **Fail-open preserved**: `PruneRuntime::new()` → `None` on construction failure keeps every path (identical to old per-file behavior).
- **Empty-input guard** (roborev): `if paths.is_empty() { return Ok(paths); }` before construction — restores pre-hoist zero-setup on empty input.

## Review-first
- rust-reviewer: APPROVE — prune results unchanged, reuse safe on the verified spawn_blocking path, cancellation + fail-open exact, test meaningful.
- roborev (codex): flagged empty-paths wasted-construction (Medium) → fixed with the empty guard; re-confirm job 3843 = No issues found.

Tests: `prune_runtime_is_reused_across_sstables_with_identical_spans` (reuse across 3 SSTables, spans == per-file oracle) + `prune_empty_paths_returns_empty_without_setup`; 168-test cqlite-flight suite green. `CQLITE_ALLOW_FILE_GROWTH=1` (producer.rs pre-existing #1116 over-threshold; focused perf fix).