### PR TITLE
fix(#2237): fail-closed token-ring coverage validation in Trino split planning (accepts both Sidecar ring forms)

### DIFF
--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -95,17 +95,33 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
      *
      * <p>Ranges are {@code (start, end]} — start exclusive, end inclusive (Cassandra
      * convention, see {@link ReplicaInfo}); a range with {@code start >= end} wraps the ring
-     * boundary. Because the ring is a circle, the canonical exact-tiling test is: sort ranges
-     * by start token; each range's {@code end} must equal the NEXT range's {@code start}
-     * (cycling the last range back to the first). For adjacent ranges {@code (a, b]} and
-     * {@code (b, c]}, the shared token {@code b} is the inclusive end of the first and the
-     * exclusive start of the second, so they meet with neither overlap nor gap. A single
-     * range with {@code start == end} is the whole ring ({@code (T, T]}, issue #2228) and
-     * trivially closes the cycle. Any deviation is classified — via a signed token comparison
-     * against the connecting boundary — as an overlap or a gap and named in the error.
+     * boundary. A full tiling is accepted in EITHER of the two forms the Sidecar emits:
+     *
+     * <ul>
+     *   <li><b>Unwrapped form</b> — the form the real Sidecar emits (see
+     *       {@code SidecarClientTest#parsesTokenRangeReplicasAndTokens}: {@code (MIN,0]} +
+     *       {@code (0,MAX]}): sorted ranges whose FIRST start is {@link Long#MIN_VALUE} and
+     *       whose LAST end is {@link Long#MAX_VALUE}, with no range wrapping. The chain
+     *       {@code (MIN, …] … (…, MAX]} spans the whole ring exactly once.</li>
+     *   <li><b>Wrap form</b> — a single range wraps the boundary and closes the circle: the
+     *       last (highest-start) range wraps ({@code start >= end}) and its inclusive end
+     *       equals the first range's exclusive start. A single {@code (T, T]} (issue #2228)
+     *       is the degenerate one-range case of this form (the whole ring).</li>
+     * </ul>
+     *
+     * <p>Both forms first require the interior to join perfectly: after sorting by start,
+     * each range's {@code end} equals the NEXT range's {@code start} (for adjacent
+     * {@code (a, b]} and {@code (b, c]} the shared token {@code b} is the inclusive end of
+     * the first and the exclusive start of the second — no overlap, no gap). Any deviation
+     * — interior, or at the ring-closing boundary — is classified via a signed token
+     * comparison as an overlap (double coverage → duplicate rows) or a gap (uncovered
+     * tokens → missing rows) and named in the error. Because at most ONE range may wrap and
+     * it must be the closing (last) range, more than one wrapping range, or a wrapping /
+     * full-ring range anywhere but last, is rejected as an overlap (it double-covers the
+     * ring). {@code null} or an empty list fails closed (would silently return 0 rows).
      */
     static void validateRingCoverage(List<ReplicaInfo> ranges) {
-        if (ranges.isEmpty()) {
+        if (ranges == null || ranges.isEmpty()) {
             throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
                     "Cassandra token-range topology returned no read-replica ranges, so the "
                             + "token ring is not covered; refusing to scan (would silently return "
@@ -114,28 +130,96 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         List<ReplicaInfo> sorted = new ArrayList<>(ranges);
         sorted.sort(Comparator.comparingLong(ReplicaInfo::startToken));
         int n = sorted.size();
+
+        // A valid tiling has AT MOST ONE wrapping range (start >= end), and it must be the
+        // closing (last, highest-start) range. Two wrapping ranges, or a wrap / full-ring
+        // (T,T] range anywhere but last, necessarily double-covers the ring -> overlap. This
+        // also closes a false-accept: an interior (T,T] full-ring range whose neighbours
+        // share its token would otherwise pass the adjacency check below.
+        int wrapCount = 0;
+        int lastWrapIndex = -1;
         for (int i = 0; i < n; i++) {
-            ReplicaInfo cur = sorted.get(i);
-            ReplicaInfo next = sorted.get((i + 1) % n);
-            long curEnd = cur.endToken();
-            long nextStart = next.startToken();
-            if (curEnd == nextStart) {
-                continue; // ranges meet exactly: no overlap, no gap
+            ReplicaInfo r = sorted.get(i);
+            if (r.startToken() >= r.endToken()) {
+                wrapCount++;
+                lastWrapIndex = i;
             }
-            // curEnd is the connecting boundary; nextStart is where the next range begins.
-            // For the closing (wraparound) pair, nextStart is the minimum start token, so the
-            // same signed comparison classifies the fault direction consistently.
-            String kind = Long.compare(curEnd, nextStart) > 0 ? "overlap" : "gap";
+        }
+        if (wrapCount > 1 || (wrapCount == 1 && lastWrapIndex != n - 1)) {
+            ReplicaInfo w = sorted.get(lastWrapIndex);
             throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
                     "Cassandra token-range topology does not tile the ring exactly once: "
-                            + kind + " between range (" + cur.start() + ", " + cur.end() + "] and "
-                            + "range (" + next.start() + ", " + next.end() + "] — range 1 ends at "
-                            + "token " + curEnd + " but range 2 starts at token " + nextStart
-                            + " (expected them to be equal). This risks "
-                            + ("overlap".equals(kind) ? "duplicate" : "missing")
-                            + " rows and is usually a transient topology transition "
-                            + "(bootstrap/decommission) — retry.");
+                            + "overlap — a ring-wrapping range (" + w.start() + ", " + w.end()
+                            + "] is not the single closing range, so it double-covers the ring. "
+                            + "This risks duplicate rows and is usually a transient topology "
+                            + "transition (bootstrap/decommission) — retry.");
         }
+
+        // Interior adjacency: each range's end must meet the next range's start exactly.
+        // Iterates consecutive pairs only (does NOT wrap the last back to the first); the
+        // ring is closed separately below so both coverage forms are handled.
+        for (int i = 0; i + 1 < n; i++) {
+            ReplicaInfo cur = sorted.get(i);
+            ReplicaInfo next = sorted.get(i + 1);
+            if (cur.endToken() != next.startToken()) {
+                throw tilingFault(cur, next, cur.endToken(), next.startToken());
+            }
+        }
+
+        ReplicaInfo first = sorted.get(0);
+        ReplicaInfo last = sorted.get(n - 1);
+        if (wrapCount == 0) {
+            // Unwrapped chain (first.start, last.end] — no range crosses the boundary.
+            // (a) Full coverage iff it spans (MIN, MAX].
+            if (first.startToken() == Long.MIN_VALUE && last.endToken() == Long.MAX_VALUE) {
+                return;
+            }
+            // Otherwise the ring boundary (past last.end, around to first.start) is uncovered
+            // — always a GAP; a non-wrapping chain can never double-cover the boundary.
+            throw ringBoundaryGap(last, first);
+        }
+        // wrapCount == 1 and it is the closing (last) range. (b) The circle closes iff the
+        // wrap's inclusive end meets the first range's exclusive start (subsumes the single
+        // (T, T] full ring). Otherwise the wrap end PAST first.start double-covers (overlap)
+        // or falls SHORT (gap) — the signed comparison classifies correctly here.
+        if (last.endToken() == first.startToken()) {
+            return;
+        }
+        throw tilingFault(last, first, last.endToken(), first.startToken());
+    }
+
+    /**
+     * The ring-closing GAP for an unwrapped chain that does not span the full {@code (MIN, MAX]}
+     * ring: the tokens past {@code last.end} around the boundary to {@code first.start} are owned
+     * by no range (→ missing rows). Reported as a gap regardless of token magnitudes because a
+     * non-wrapping chain cannot double-cover.
+     */
+    private static TrinoException ringBoundaryGap(ReplicaInfo last, ReplicaInfo first) {
+        return new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                "Cassandra token-range topology does not tile the ring exactly once: gap at the "
+                        + "ring boundary — the ranges cover only (" + first.start() + ", "
+                        + last.end() + "] and no range wraps to close the circle, so tokens past "
+                        + last.end() + " (around to " + first.start() + ") are uncovered. This "
+                        + "risks missing rows and is usually a transient topology transition "
+                        + "(bootstrap/decommission) — retry.");
+    }
+
+    /**
+     * Build the actionable typed error for a ring-tiling fault, classifying it as an overlap
+     * (double coverage → duplicate rows) when {@code curEnd} is past {@code nextStart}, else a
+     * gap (uncovered tokens → missing rows), naming the offending boundary.
+     */
+    private static TrinoException tilingFault(ReplicaInfo cur, ReplicaInfo next, long curEnd, long nextStart) {
+        String kind = Long.compare(curEnd, nextStart) > 0 ? "overlap" : "gap";
+        return new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                "Cassandra token-range topology does not tile the ring exactly once: "
+                        + kind + " between range (" + cur.start() + ", " + cur.end() + "] and "
+                        + "range (" + next.start() + ", " + next.end() + "] — range 1 ends at "
+                        + "token " + curEnd + " but range 2 starts at token " + nextStart
+                        + ". This risks "
+                        + ("overlap".equals(kind) ? "duplicate" : "missing")
+                        + " rows and is usually a transient topology transition "
+                        + "(bootstrap/decommission) — retry.");
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -1,5 +1,7 @@
 package in.mcfad.cqlite.flight;
 
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorSession;
@@ -10,6 +12,7 @@ import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedSplitSource;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +48,12 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
             Constraint constraint) {
         CqliteFlightTableHandle handle = (CqliteFlightTableHandle) table;
         TokenRangeReplicasResponse replicas = sidecar.tokenRangeReplicas(handle.keyspace());
+        // Ring-coverage guard (issue #2237): during Cassandra topology transitions
+        // (bootstrap/decommission) the Sidecar's read-replica ranges can transiently
+        // OVERLAP (→ duplicate rows) or GAP (→ missing rows), both silent. Verify the
+        // returned ranges tile the token ring exactly once BEFORE building splits and
+        // fail closed with an actionable error otherwise.
+        validateRingCoverage(replicas.readReplicas());
         // Read-mode wiring (issues #2105, #2227): in snapshot mode create (once per query)
         // a Sidecar snapshot on EVERY distinct replica host the scan's splits will read —
         // a snapshot PUT is instance-local, so a snapshot made only on the configured
@@ -75,6 +84,58 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         }
 
         return new FixedSplitSource(ranges);
+    }
+
+    /**
+     * Fail-closed ring-coverage guard (issue #2237). The Sidecar's read-replica ranges
+     * are expected to tile the Murmur3 token ring (signed 64-bit, a circle) EXACTLY once,
+     * but during topology transitions (bootstrap/decommission) they can transiently OVERLAP
+     * (silent duplicate rows) or GAP (silent missing rows). This verifies the exact tiling
+     * before any split is built and throws an actionable {@link TrinoException} otherwise.
+     *
+     * <p>Ranges are {@code (start, end]} — start exclusive, end inclusive (Cassandra
+     * convention, see {@link ReplicaInfo}); a range with {@code start >= end} wraps the ring
+     * boundary. Because the ring is a circle, the canonical exact-tiling test is: sort ranges
+     * by start token; each range's {@code end} must equal the NEXT range's {@code start}
+     * (cycling the last range back to the first). For adjacent ranges {@code (a, b]} and
+     * {@code (b, c]}, the shared token {@code b} is the inclusive end of the first and the
+     * exclusive start of the second, so they meet with neither overlap nor gap. A single
+     * range with {@code start == end} is the whole ring ({@code (T, T]}, issue #2228) and
+     * trivially closes the cycle. Any deviation is classified — via a signed token comparison
+     * against the connecting boundary — as an overlap or a gap and named in the error.
+     */
+    static void validateRingCoverage(List<ReplicaInfo> ranges) {
+        if (ranges.isEmpty()) {
+            throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                    "Cassandra token-range topology returned no read-replica ranges, so the "
+                            + "token ring is not covered; refusing to scan (would silently return "
+                            + "0 rows). This is usually a transient topology transition — retry.");
+        }
+        List<ReplicaInfo> sorted = new ArrayList<>(ranges);
+        sorted.sort(Comparator.comparingLong(ReplicaInfo::startToken));
+        int n = sorted.size();
+        for (int i = 0; i < n; i++) {
+            ReplicaInfo cur = sorted.get(i);
+            ReplicaInfo next = sorted.get((i + 1) % n);
+            long curEnd = cur.endToken();
+            long nextStart = next.startToken();
+            if (curEnd == nextStart) {
+                continue; // ranges meet exactly: no overlap, no gap
+            }
+            // curEnd is the connecting boundary; nextStart is where the next range begins.
+            // For the closing (wraparound) pair, nextStart is the minimum start token, so the
+            // same signed comparison classifies the fault direction consistently.
+            String kind = Long.compare(curEnd, nextStart) > 0 ? "overlap" : "gap";
+            throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                    "Cassandra token-range topology does not tile the ring exactly once: "
+                            + kind + " between range (" + cur.start() + ", " + cur.end() + "] and "
+                            + "range (" + next.start() + ", " + next.end() + "] — range 1 ends at "
+                            + "token " + curEnd + " but range 2 starts at token " + nextStart
+                            + " (expected them to be equal). This risks "
+                            + ("overlap".equals(kind) ? "duplicate" : "missing")
+                            + " rows and is usually a transient topology transition "
+                            + "(bootstrap/decommission) — retry.");
+        }
     }
 
     /**

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
@@ -2,6 +2,7 @@ package in.mcfad.cqlite.flight;
 
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
+import io.trino.spi.TrinoException;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CqliteFlightSplitManagerTest {
@@ -149,6 +151,73 @@ class CqliteFlightSplitManagerTest {
         Set<String> hosts = CqliteFlightSplitManager.distinctReplicaHosts(resp, "dc1");
         assertEquals(Set.of("2001:db8::5", "2001:db8::9"), hosts);
         assertEquals(hosts, splits.stream().map(CqliteFlightSplit::host).collect(java.util.stream.Collectors.toSet()));
+    }
+
+    private static final Map<String, List<String>> DC1 = Map.of("dc1", List.of("10.0.0.1:7000"));
+    private static final String MIN = Long.toString(Long.MIN_VALUE);
+
+    /**
+     * Ring-coverage guard (issue #2237): a set of ranges that tiles the Murmur3 ring
+     * exactly once — INCLUDING the wraparound range that crosses the ring boundary —
+     * is accepted and splits are built normally (happy-path behavior unchanged).
+     */
+    @Test
+    void exactTilingIncludingWraparoundAccepted() {
+        // (MIN,-100] (-100,0] (0,100] (100,MIN] — the last wraps (start 100 > end MIN)
+        // and its inclusive end MIN meets the first range's exclusive start MIN, closing
+        // the circle with neither overlap nor gap.
+        List<ReplicaInfo> tiling = List.of(
+                range(MIN, "-100", DC1),
+                range("-100", "0", DC1),
+                range("0", "100", DC1),
+                range("100", MIN, DC1));
+        // Does not throw.
+        CqliteFlightSplitManager.validateRingCoverage(tiling);
+        // Happy path still builds one split per range.
+        var resp = new TokenRangeReplicasResponse(List.of(), tiling);
+        assertEquals(4, CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815).size());
+    }
+
+    /** A single full-ring range `(T, T]` (issue #2228) trivially tiles the circle. */
+    @Test
+    void singleFullRingRangeAccepted() {
+        CqliteFlightSplitManager.validateRingCoverage(List.of(range("42", "42", DC1)));
+    }
+
+    /** Overlapping ranges are rejected with an actionable typed error naming the overlap. */
+    @Test
+    void overlappingRangesRejected() {
+        // (MIN,10] and (0,MIN]: sorted, (MIN,10] ends at 10 but the next range starts at 0
+        // (< 10) — the two share tokens (0,10] → overlap → duplicate rows.
+        List<ReplicaInfo> overlap = List.of(
+                range(MIN, "10", DC1),
+                range("0", MIN, DC1));
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightSplitManager.validateRingCoverage(overlap));
+        assertTrue(ex.getMessage().contains("overlap"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("duplicate"), ex.getMessage());
+    }
+
+    /** Gapped ranges are rejected with an actionable typed error naming the gap. */
+    @Test
+    void gappedRangesRejected() {
+        // (MIN,0] and (100,MIN]: sorted, (MIN,0] ends at 0 but the next starts at 100 (> 0)
+        // — tokens (0,100] are owned by no range → gap → missing rows.
+        List<ReplicaInfo> gapped = List.of(
+                range(MIN, "0", DC1),
+                range("100", MIN, DC1));
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightSplitManager.validateRingCoverage(gapped));
+        assertTrue(ex.getMessage().contains("gap"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("missing"), ex.getMessage());
+    }
+
+    /** Empty ranges fail closed rather than silently scanning nothing. */
+    @Test
+    void emptyRangesRejected() {
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightSplitManager.validateRingCoverage(List.of()));
+        assertTrue(ex.getMessage().contains("not covered"), ex.getMessage());
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
@@ -155,6 +155,29 @@ class CqliteFlightSplitManagerTest {
 
     private static final Map<String, List<String>> DC1 = Map.of("dc1", List.of("10.0.0.1:7000"));
     private static final String MIN = Long.toString(Long.MIN_VALUE);
+    private static final String MAX = Long.toString(Long.MAX_VALUE);
+
+    /**
+     * Ring-coverage guard (issue #2237): the UNWRAPPED full-coverage form the real Cassandra
+     * Sidecar emits — {@code (MIN,0]} + {@code (0,MAX]}, mirroring the fixture in
+     * {@code SidecarClientTest#parsesTokenRangeReplicasAndTokens} — spans the ring exactly once
+     * (first start == MIN, last end == MAX, no wrapping range) and MUST be accepted and build
+     * splits. This is the regression the fix closes: the old validator forced a wrap range and
+     * fail-closed on this healthy real-cluster topology.
+     */
+    @Test
+    void unwrappedFullCoverageFromSidecarAccepted() {
+        List<ReplicaInfo> tiling = List.of(
+                range(MIN, "0", DC1),
+                range("0", MAX, DC1));
+        // Does not throw — the unwrapped (MIN, MAX] tiling is full coverage.
+        CqliteFlightSplitManager.validateRingCoverage(tiling);
+        var resp = new TokenRangeReplicasResponse(List.of(), tiling);
+        var splits = CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815);
+        assertEquals(2, splits.size(), "one split per range for the healthy unwrapped ring");
+        assertFalse(splits.get(0).wraparound(), "no range wraps in the unwrapped form");
+        assertFalse(splits.get(1).wraparound(), "no range wraps in the unwrapped form");
+    }
 
     /**
      * Ring-coverage guard (issue #2237): a set of ranges that tiles the Murmur3 ring
@@ -212,11 +235,82 @@ class CqliteFlightSplitManagerTest {
         assertTrue(ex.getMessage().contains("missing"), ex.getMessage());
     }
 
+    /**
+     * A GAP at the ring boundary in the UNWRAPPED form (issue #2237): {@code (MIN,0]} +
+     * {@code (100,MAX]} covers only (MIN,0] and (100,MAX] — tokens (0,100] are owned by no
+     * range and no range wraps to close the circle → gap → missing rows → rejected.
+     */
+    @Test
+    void unwrappedBoundaryGapRejected() {
+        List<ReplicaInfo> gapped = List.of(
+                range(MIN, "0", DC1),
+                range("100", MAX, DC1));
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightSplitManager.validateRingCoverage(gapped));
+        assertTrue(ex.getMessage().contains("gap"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("missing"), ex.getMessage());
+    }
+
+    /**
+     * A GAP at the ring boundary because the ranges do not reach MIN/MAX and no range wraps:
+     * {@code (MIN,0]} alone leaves (0, MIN] (the whole rest of the ring) uncovered → gap.
+     */
+    @Test
+    void unwrappedNonFullSpanRejectedAsGap() {
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightSplitManager.validateRingCoverage(List.of(range(MIN, "0", DC1))));
+        assertTrue(ex.getMessage().contains("gap"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("missing"), ex.getMessage());
+    }
+
+    /**
+     * An OVERLAP at the ring boundary: {@code (MIN,0]} + a wrapping {@code (-50,MIN]} whose
+     * inclusive end MIN is BELOW the first start... the wrap's end past first.start double-covers
+     * tokens (-50, 0] → overlap → duplicate rows → rejected.
+     */
+    @Test
+    void wrapBoundaryOverlapRejected() {
+        List<ReplicaInfo> overlap = List.of(
+                range(MIN, "0", DC1),
+                range("-50", MIN, DC1));
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightSplitManager.validateRingCoverage(overlap));
+        assertTrue(ex.getMessage().contains("overlap"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("duplicate"), ex.getMessage());
+    }
+
+    /**
+     * Two wrapping ranges (or a wrap that is not the single closing range) double-cover the
+     * ring and are rejected as an overlap — closes the false-accept where an interior wrap /
+     * full-ring range could otherwise slip through the adjacency check.
+     */
+    @Test
+    void multipleWrappingRangesRejected() {
+        List<ReplicaInfo> twoWraps = List.of(
+                range("100", MIN, DC1),
+                range("200", "50", DC1));
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightSplitManager.validateRingCoverage(twoWraps));
+        assertTrue(ex.getMessage().contains("overlap"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("double-covers"), ex.getMessage());
+    }
+
     /** Empty ranges fail closed rather than silently scanning nothing. */
     @Test
     void emptyRangesRejected() {
         TrinoException ex = assertThrows(TrinoException.class,
                 () -> CqliteFlightSplitManager.validateRingCoverage(List.of()));
+        assertTrue(ex.getMessage().contains("not covered"), ex.getMessage());
+    }
+
+    /**
+     * NIT (issue #2237): a null read-replica list (CqliteFlightMetadata can pass one) is
+     * treated like empty — a fail-closed typed error, not a raw NullPointerException.
+     */
+    @Test
+    void nullRangesFailClosedNotNpe() {
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightSplitManager.validateRingCoverage(null));
         assertTrue(ex.getMessage().contains("not covered"), ex.getMessage());
     }
 


### PR DESCRIPTION
Closes #2237. Part of Epic AM (#2226), audit finding N10 (splits lane).

## Defect
`CqliteFlightSplitManager.getSplits` trusted `replicas.readReplicas()` to tile the Murmur3 ring exactly once. During topology transitions (bootstrap/decommission) ranges can transiently OVERLAP (→ silent duplicate rows) or GAP (→ silent missing rows) with no validation.

## Fix — validate ring coverage, fail closed, accept BOTH real ring representations
`validateRingCoverage(readReplicas())` runs before any split is built:
- Sort ranges by start; verify interior adjacency (`end[i]==start[i+1]`, `(start,end]` Cassandra convention) — catches interior overlap/gap.
- Close the ring accepting EITHER: **(a) unwrapped** (`wrapCount==0 && first.start==Long.MIN_VALUE && last.end==Long.MAX_VALUE`) — the form the Sidecar actually emits (per the repo's own `SidecarClientTest` fixture: `(MIN,0]`+`(0,MAX]`); OR **(b) single-wrap** (`wrapCount==1`, last range wraps, `last.end==first.start`) — subsumes single full-ring `(T,T]` (#2228).
- Pre-pass rejects `wrapCount>1` or a wrap range that isn't last (closes a false-accept where an interior wrap/`(T,T]` with token-sharing neighbors would slip through adjacency).
- Genuine overlap/gap/empty/null → fail closed with an actionable typed `TrinoException` naming the offending boundary + a transient-topology retry hint. Signed 64-bit tokens via `Long.compare` (no overflow).
- Happy-path split-building unchanged.

## Review-first (this went through a real blocker cycle)
- Initial version accepted ONLY the single-wrap form → roborev flagged (High) that it would FALSE-REJECT the Sidecar's actual unwrapped `(MIN,0]+(0,MAX]` form, failing every real query. Investigation confirmed via the repo's own `SidecarClientTest` fixture that the unwrapped form is real Sidecar output → genuine blocker.
- Fix accepts both forms + closed a self-found false-accept. Bidirectional correctness re-review: APPROVE (no false-reject on valid tilings, no false-accept on genuine overlap/gap, pre-pass verified correct). roborev re-confirm (job 3846): No issues found.

19 tests (incl. `unwrappedFullCoverageFromSidecarAccepted` mirroring the Sidecar fixture, boundary gap/overlap rejection, `multipleWrappingRangesRejected`, `nullRangesFailClosedNotNpe`). BUILD SUCCESSFUL. No Rust touched.