### PR TITLE
fix(#2262): aggregate path surfaces missing projected vector as an error

### DIFF
--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSource.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSource.java
@@ -3,6 +3,8 @@ package in.mcfad.cqlite.flight;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.trino.spi.Page;
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -69,7 +71,7 @@ public class CqliteFlightAggregatePageSource implements ConnectorPageSource {
             try (CqliteFlightClient.StreamHandle handle =
                     client.openStream(range.host(), range.port(), ticket)) {
                 while (handle.stream().next()) {
-                    accumulate(handle.stream().getRoot(), merger);
+                    accumulate(handle.stream().getRoot(), spec, merger);
                 }
             }
         }
@@ -100,21 +102,60 @@ public class CqliteFlightAggregatePageSource implements ConnectorPageSource {
                 aggregationNode);
     }
 
-    /** Read each partial row from one Arrow batch into the merger. */
-    private void accumulate(VectorSchemaRoot root, PartialAggregateMerger merger) {
+    /**
+     * Read each partial row from one Arrow batch into the merger. Package-private and
+     * static so {@code CqliteFlightAggregatePageSourceTest} exercises this exact
+     * production path with a real {@link VectorSchemaRoot} + {@link AggregationSpec}.
+     */
+    static void accumulate(VectorSchemaRoot root, AggregationSpec spec, PartialAggregateMerger merger) {
         int rows = root.getRowCount();
         List<String> groupBy = spec.groupBy();
+        List<AggregationSpec.Aggregate> aggregates = spec.aggregates();
+
+        // Resolve every projected vector ONCE, up front (issue #2262). A missing vector
+        // means the Flight server did not deliver a column the connector's aggregation
+        // projection expects (schema drift) — a hard error naming the column, NOT a
+        // silently null group key / partial-aggregate value that would corrupt the
+        // GROUP BY result set undetected. Mirrors ArrowToTrino.toPage's guard (#2238).
+        List<FieldVector> groupVectors = new ArrayList<>(groupBy.size());
+        for (String gc : groupBy) {
+            groupVectors.add(requireVector(root, gc));
+        }
+        List<FieldVector> aggregateVectors = new ArrayList<>(aggregates.size());
+        for (AggregationSpec.Aggregate a : aggregates) {
+            aggregateVectors.add(requireVector(root, a.output()));
+        }
+
         for (int r = 0; r < rows; r++) {
             List<Object> keyValues = new ArrayList<>(groupBy.size());
-            for (String gc : groupBy) {
-                keyValues.add(rawValue(root.getVector(gc), r));
+            for (FieldVector v : groupVectors) {
+                keyValues.add(rawValue(v, r));
             }
             Map<String, Object> partials = new HashMap<>();
-            for (AggregationSpec.Aggregate a : spec.aggregates()) {
-                partials.put(a.output(), rawValue(root.getVector(a.output()), r));
+            for (int i = 0; i < aggregates.size(); i++) {
+                partials.put(aggregates.get(i).output(), rawValue(aggregateVectors.get(i), r));
             }
             merger.combine(new PartialAggregateMerger.GroupKey(keyValues), partials);
         }
+    }
+
+    /**
+     * Resolve a projected group-by / aggregate-output vector, or fail loudly. An absent
+     * vector means the Flight server did not return a column the connector's aggregation
+     * projection expects (schema drift) — surfaced as a clear error naming the column
+     * (issue #2262), never masked as a silent all-null column.
+     */
+    private static FieldVector requireVector(VectorSchemaRoot root, String column) {
+        FieldVector vector = root.getVector(column);
+        if (vector == null) {
+            throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                    "Aggregate/group-by column '" + column
+                            + "' is missing from the delivered Arrow batch; "
+                            + "the server did not return a vector for this column "
+                            + "(schema drift between the connector aggregation "
+                            + "projection and the Flight server response)");
+        }
+        return vector;
     }
 
     /** Build the single output page, one block per requested column. */
@@ -174,7 +215,10 @@ public class CqliteFlightAggregatePageSource implements ConnectorPageSource {
 
     /** Read a raw Java value out of an Arrow vector at row {@code i}, or null. */
     private static Object rawValue(FieldVector vector, int i) {
-        if (vector == null || vector.isNull(i)) {
+        // Callers (accumulate via requireVector) guarantee vector != null — an absent
+        // projected vector is rejected upstream (issue #2262). A null CELL within the
+        // present vector is normal and still yields null here (no regression to #2238).
+        if (vector.isNull(i)) {
             return null;
         }
         return ArrowToTrino.readJavaValue(vector, i);

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceTest.java
@@ -2,6 +2,7 @@ package in.mcfad.cqlite.flight;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.BigintType;
@@ -19,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -103,6 +105,98 @@ class CqliteFlightAggregatePageSourceTest {
         assertEquals(2, countByPicos.size(), "two distinct time-of-day groups");
         assertEquals(5L, countByPicos.get(nine * 1_000L), "09:00 group merged 2 + 3 across ranges");
         assertEquals(1L, countByPicos.get(ten * 1_000L), "10:00 group");
+    }
+
+    /**
+     * Issue #2262: a projected group-by column absent from the delivered Arrow batch
+     * (schema drift between the connector aggregation projection and the Flight server
+     * response) must surface a clear error NAMING the column via the real
+     * {@link CqliteFlightAggregatePageSource#accumulate} path — not silently produce
+     * null group keys (a corrupted GROUP BY result set). Mirrors #2238's toPage guard.
+     */
+    @Test
+    void missingGroupByVectorRaisesNamingTheColumn() {
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Count, null, "agg0"));
+        var spec = new AggregationSpec(List.of("missing_gc"), aggregates);
+        var merger = new PartialAggregateMerger(aggregates);
+
+        try (BufferAllocator allocator = new RootAllocator()) {
+            // Batch delivers the aggregate output but NOT the projected group-by column.
+            BigIntVector count = new BigIntVector("agg0", allocator);
+            count.allocateNew(1);
+            count.set(0, 5L);
+            VectorSchemaRoot root = new VectorSchemaRoot(List.of(count));
+            root.setRowCount(1);
+
+            TrinoException ex = assertThrows(TrinoException.class,
+                    () -> CqliteFlightAggregatePageSource.accumulate(root, spec, merger));
+            assertTrue(ex.getMessage().contains("missing_gc"),
+                    "error must name the missing group-by column, was: " + ex.getMessage());
+            root.close();
+        }
+    }
+
+    /**
+     * Issue #2262 (aggregate-output arm): an aggregate-output vector absent from the
+     * delivered batch must likewise error naming the column — not silently produce null
+     * partial-aggregate values.
+     */
+    @Test
+    void missingAggregateOutputVectorRaisesNamingTheColumn() {
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Count, null, "agg_missing"));
+        var spec = new AggregationSpec(List.of("gc"), aggregates);
+        var merger = new PartialAggregateMerger(aggregates);
+
+        try (BufferAllocator allocator = new RootAllocator()) {
+            // Batch delivers the group-by column but NOT the aggregate output vector.
+            BigIntVector gc = new BigIntVector("gc", allocator);
+            gc.allocateNew(1);
+            gc.set(0, 7L);
+            VectorSchemaRoot root = new VectorSchemaRoot(List.of(gc));
+            root.setRowCount(1);
+
+            TrinoException ex = assertThrows(TrinoException.class,
+                    () -> CqliteFlightAggregatePageSource.accumulate(root, spec, merger));
+            assertTrue(ex.getMessage().contains("agg_missing"),
+                    "error must name the missing aggregate-output column, was: " + ex.getMessage());
+            root.close();
+        }
+    }
+
+    /**
+     * Guardrail (issue #2262, mirrors #2238): a null CELL within a PRESENT vector is
+     * normal and must still yield a null value with NO error — only an ENTIRELY absent
+     * vector errors. The group key is retained; the aggregate partial is a normal null.
+     */
+    @Test
+    void nullCellWithinPresentVectorStaysNullNotError() {
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Sum, "v", "agg0"));
+        var spec = new AggregationSpec(List.of("gc"), aggregates);
+        var merger = new PartialAggregateMerger(aggregates);
+
+        try (BufferAllocator allocator = new RootAllocator()) {
+            BigIntVector gc = new BigIntVector("gc", allocator);
+            BigIntVector agg0 = new BigIntVector("agg0", allocator);
+            gc.allocateNew(1);
+            agg0.allocateNew(1);
+            gc.set(0, 42L);
+            agg0.setNull(0); // null CELL within a PRESENT vector — a normal null, not drift
+            VectorSchemaRoot root = new VectorSchemaRoot(List.of(gc, agg0));
+            root.setRowCount(1);
+
+            // Must NOT throw: the present-vector null cell is normal null handling.
+            CqliteFlightAggregatePageSource.accumulate(root, spec, merger);
+
+            var groups = merger.finish();
+            assertEquals(1, groups.size(), "one group survives with its non-null key");
+            assertEquals(42L, groups.get(0).key().values().get(0), "group key read normally");
+            assertTrue(groups.get(0).outputs().get("agg0") == null,
+                    "sum of a single null partial stays null (no regression)");
+            root.close();
+        }
     }
 
     /** Mirror {@code accumulate()}: read one Arrow batch's group + count columns into the merger. */


### PR DESCRIPTION
Closes #2262

## Summary
Follow-up from #2238/#2263: `CqliteFlightAggregatePageSource.rawValue` had the identical
`vector == null || isNull` conflation fixed elsewhere in `ArrowToTrino.toBlock` — but here, for the
aggregation path, a missing projected vector (schema drift) silently produced null group keys /
partial-aggregate values instead of an error: a corrupted-looking-normal GROUP BY result set, not even
an obviously-wrong all-null column.

Fix: `rawValue` narrowed to only handle a null CELL within a present vector. New `requireVector` throws
`TrinoException(GENERIC_INTERNAL_ERROR)` naming the column when a vector is entirely absent, same
convention as #2238. `accumulate` resolves all group-by AND aggregate-output vectors up front via
`requireVector` before the row loop, covering both of the issue's named call sites with one guard.

## Review history (review-first, before any full gate)
- roborev: clean.
- `rust-reviewer`: clean — verified the up-front vector resolution is safe (no Arrow stream advance
  within one `accumulate` call, so hoisting changes nothing about per-row values), confirmed the one
  production call site was updated correctly, confirmed both entry points (group-by + aggregate-output)
  are covered with no residual unguarded path, confirmed the 3 new tests exercise the real code path
  with genuine `VectorSchemaRoot`s, and independently re-verified no third conflation instance remains
  in the module.

## Test plan
- [x] `missingGroupByVectorRaisesNamingTheColumn` / `missingAggregateOutputVectorRaisesNamingTheColumn`
      — real `VectorSchemaRoot` missing the respective vector, asserts `TrinoException` naming it
- [x] `nullCellWithinPresentVectorStaysNullNotError` — guardrail, no regression to normal null handling
- [x] Full `trino-connector` gradle suite green (257/257, 0 failures)
- [x] `scripts/agent-gate.sh --lite` PASS (no Rust files touched)
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — runs once via `flow-closer`