### PR TITLE
feat(#2241): split replica failover — ordered fallback replicas + connect-class retry, scan + aggregate paths

### DIFF
--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -41,6 +41,9 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
     testImplementation("io.trino:trino-spi:$trinoVersion")
+    // Optional<>-aware (de)serialization mirrors Trino's split codec so the
+    // CqliteFlightSplit JSON round-trip test (issue #2241) is faithful.
+    testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion")
     testImplementation(platform("org.junit:junit-bom:5.11.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSource.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSource.java
@@ -30,11 +30,17 @@ import java.util.Optional;
  * per group whose Arrow columns are [group_by cols..., one column per aggregate
  * output]. We accumulate, then build output blocks in the order of the requested
  * column handles using the {@link FinalizeAggregationPlan}.
+ *
+ * <p>Replica failover (issue #2241): each range's fan-out DoGet uses the shared {@link
+ * ReplicaFailoverStream} over that range's ordered {@link CqliteFlightSplit#replicaHosts()}, so
+ * a down primary fails over to the next replica owning the range before any of ITS partial rows
+ * are consumed. A range whose every replica is unreachable propagates loudly — an aggregate
+ * partial is never silently dropped.
  */
 public class CqliteFlightAggregatePageSource implements ConnectorPageSource {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final CqliteFlightClient client;
+    private final ReplicaFailoverStream.StreamOpener opener;
     private final CqliteFlightAggregateSplit split;
     private final List<CqliteFlightColumnHandle> columns;
     private final AggregationSpec spec;
@@ -46,7 +52,15 @@ public class CqliteFlightAggregatePageSource implements ConnectorPageSource {
             CqliteFlightClient client,
             CqliteFlightAggregateSplit split,
             List<CqliteFlightColumnHandle> columns) {
-        this.client = client;
+        this(ReplicaFailoverStream.adapt(client), split, columns);
+    }
+
+    /** Package-private seam: inject the opener directly for unit tests (issue #2241). */
+    CqliteFlightAggregatePageSource(
+            ReplicaFailoverStream.StreamOpener opener,
+            CqliteFlightAggregateSplit split,
+            List<CqliteFlightColumnHandle> columns) {
+        this.opener = opener;
         this.split = split;
         this.columns = columns;
         this.spec = parseSpec(split.aggregationJson());
@@ -65,13 +79,15 @@ public class CqliteFlightAggregatePageSource implements ConnectorPageSource {
         JsonNode filterNode = filter.map(CqliteFlightAggregatePageSource::parse).orElse(null);
         JsonNode aggregationNode = parse(split.aggregationJson());
 
-        // Fan out: one DoGet per range to its pinned replica, accumulating partials.
+        // Fan out: one DoGet per range, with availability failover across that range's ordered
+        // replica list (issue #2241) — a range's partial is never silently dropped: an
+        // unreachable range propagates loudly instead of being skipped.
         for (CqliteFlightSplit range : split.ranges()) {
             byte[] ticket = buildRangeTicket(range, filterNode, aggregationNode);
-            try (CqliteFlightClient.StreamHandle handle =
-                    client.openStream(range.host(), range.port(), ticket)) {
-                while (handle.stream().next()) {
-                    accumulate(handle.stream().getRoot(), spec, merger);
+            try (ReplicaFailoverStream stream =
+                    new ReplicaFailoverStream(range.replicaHosts(), range.port(), ticket, opener)) {
+                while (stream.next()) {
+                    accumulate(stream.getRoot(), spec, merger);
                 }
             }
         }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightPageSource.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightPageSource.java
@@ -9,10 +9,46 @@ import java.util.List;
 
 /**
  * Streams one split's Arrow Flight batches, converting each to a Trino page.
+ *
+ * <p>Replica failover (issue #2241): the split carries an ORDERED replica list
+ * ({@link CqliteFlightSplit#replicaHosts()}, primary first). Before the first batch is delivered,
+ * a connection-establishment/UNAVAILABLE-class failure ({@link ReplicaFailover#isConnectClass})
+ * fails over to the next replica that owns the range. Once ANY batch has been delivered the stream
+ * is committed: a later failure is fatal and never retried, because re-reading from another replica
+ * could duplicate already-emitted rows. If every replica is unreachable the query fails loudly —
+ * CQLite never returns a silent partial/empty result.
  */
 public class CqliteFlightPageSource implements ConnectorPageSource {
+
+    /** One replica's open batch stream — abstracted so failover is unit-testable off-cluster. */
+    interface BatchStream extends AutoCloseable {
+        /**
+         * Advance to the next batch; {@code false} at end of stream. The FIRST call performs the
+         * actual gRPC and may throw a connect-class failure that triggers failover.
+         */
+        boolean next();
+
+        VectorSchemaRoot getRoot();
+
+        @Override
+        void close();
+    }
+
+    /** Opens a {@link BatchStream} against one replica {@code host:port} for a ticket. */
+    @FunctionalInterface
+    interface StreamOpener {
+        BatchStream open(String host, int port, byte[] ticket);
+    }
+
     private final List<CqliteFlightColumnHandle> columns;
-    private final CqliteFlightClient.StreamHandle handle;
+    private final List<String> hosts;
+    private final int port;
+    private final byte[] ticket;
+    private final StreamOpener opener;
+
+    private BatchStream stream;
+    private int hostIndex;
+    private boolean started;
     private boolean finished;
     private long completedPositions;
 
@@ -21,8 +57,44 @@ public class CqliteFlightPageSource implements ConnectorPageSource {
             CqliteFlightSplit split,
             List<CqliteFlightColumnHandle> columns,
             byte[] ticket) {
+        this(split.replicaHosts(), split.port(), columns, ticket, adapt(client));
+    }
+
+    /** Package-private seam: inject the ordered host list + opener directly for unit tests. */
+    CqliteFlightPageSource(
+            List<String> hosts,
+            int port,
+            List<CqliteFlightColumnHandle> columns,
+            byte[] ticket,
+            StreamOpener opener) {
+        this.hosts = List.copyOf(hosts);
+        this.port = port;
         this.columns = columns;
-        this.handle = client.openStream(split.host(), split.port(), ticket);
+        this.ticket = ticket;
+        this.opener = opener;
+    }
+
+    /** The production opener: a real DoGet stream wrapped so failover sees a uniform interface. */
+    private static StreamOpener adapt(CqliteFlightClient client) {
+        return (host, port, ticket) -> {
+            CqliteFlightClient.StreamHandle handle = client.openStream(host, port, ticket);
+            return new BatchStream() {
+                @Override
+                public boolean next() {
+                    return handle.stream().next();
+                }
+
+                @Override
+                public VectorSchemaRoot getRoot() {
+                    return handle.stream().getRoot();
+                }
+
+                @Override
+                public void close() {
+                    handle.close();
+                }
+            };
+        };
     }
 
     @Override
@@ -30,20 +102,33 @@ public class CqliteFlightPageSource implements ConnectorPageSource {
         if (finished) {
             return null;
         }
-        try {
-            if (!handle.stream().next()) {
+        while (true) {
+            try {
+                if (stream == null) {
+                    stream = opener.open(hosts.get(hostIndex), port, ticket);
+                }
+                if (!stream.next()) {
+                    finished = true;
+                    return null;
+                }
+                VectorSchemaRoot root = stream.getRoot();
+                Page page = ArrowToTrino.toPage(root, columns);
+                completedPositions += page.getPositionCount();
+                started = true;
+                return SourcePage.create(page);
+            } catch (RuntimeException e) {
+                // Release the gRPC channel + Arrow buffers; Trino does not guarantee close() on
+                // the throw path.
+                closeStreamQuietly();
+                if (!started && hostIndex + 1 < hosts.size() && ReplicaFailover.isConnectClass(e)) {
+                    hostIndex++;
+                    continue; // fail over to the next replica that owns this range (#2241)
+                }
+                // Committed (rows already delivered) or no replica left, or a non-connect error:
+                // fail loudly — never a silent partial result.
                 finished = true;
-                return null;
+                throw e;
             }
-            VectorSchemaRoot root = handle.stream().getRoot();
-            Page page = ArrowToTrino.toPage(root, columns);
-            completedPositions += page.getPositionCount();
-            return SourcePage.create(page);
-        } catch (RuntimeException e) {
-            // Release the gRPC channel + Arrow buffers if streaming/conversion
-            // fails — Trino does not guarantee close() on the throw path.
-            close();
-            throw e;
         }
     }
 
@@ -70,6 +155,17 @@ public class CqliteFlightPageSource implements ConnectorPageSource {
     @Override
     public void close() {
         finished = true;
-        handle.close();
+        closeStreamQuietly();
+    }
+
+    private void closeStreamQuietly() {
+        if (stream != null) {
+            try {
+                stream.close();
+            } catch (RuntimeException ignore) {
+                // best-effort release
+            }
+            stream = null;
+        }
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightPageSource.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightPageSource.java
@@ -10,45 +10,15 @@ import java.util.List;
 /**
  * Streams one split's Arrow Flight batches, converting each to a Trino page.
  *
- * <p>Replica failover (issue #2241): the split carries an ORDERED replica list
- * ({@link CqliteFlightSplit#replicaHosts()}, primary first). Before the first batch is delivered,
- * a connection-establishment/UNAVAILABLE-class failure ({@link ReplicaFailover#isConnectClass})
- * fails over to the next replica that owns the range. Once ANY batch has been delivered the stream
- * is committed: a later failure is fatal and never retried, because re-reading from another replica
- * could duplicate already-emitted rows. If every replica is unreachable the query fails loudly —
- * CQLite never returns a silent partial/empty result.
+ * <p>Replica failover (issue #2241) is handled by the shared {@link ReplicaFailoverStream}: the
+ * split's ordered {@link CqliteFlightSplit#replicaHosts()} (primary first) are tried in order,
+ * failing over to the next replica on a connect-class failure before the first batch, and
+ * failing loudly once committed or when every replica is unreachable — CQLite never returns a
+ * silent partial/empty result.
  */
 public class CqliteFlightPageSource implements ConnectorPageSource {
-
-    /** One replica's open batch stream — abstracted so failover is unit-testable off-cluster. */
-    interface BatchStream extends AutoCloseable {
-        /**
-         * Advance to the next batch; {@code false} at end of stream. The FIRST call performs the
-         * actual gRPC and may throw a connect-class failure that triggers failover.
-         */
-        boolean next();
-
-        VectorSchemaRoot getRoot();
-
-        @Override
-        void close();
-    }
-
-    /** Opens a {@link BatchStream} against one replica {@code host:port} for a ticket. */
-    @FunctionalInterface
-    interface StreamOpener {
-        BatchStream open(String host, int port, byte[] ticket);
-    }
-
     private final List<CqliteFlightColumnHandle> columns;
-    private final List<String> hosts;
-    private final int port;
-    private final byte[] ticket;
-    private final StreamOpener opener;
-
-    private BatchStream stream;
-    private int hostIndex;
-    private boolean started;
+    private final ReplicaFailoverStream stream;
     private boolean finished;
     private long completedPositions;
 
@@ -57,7 +27,7 @@ public class CqliteFlightPageSource implements ConnectorPageSource {
             CqliteFlightSplit split,
             List<CqliteFlightColumnHandle> columns,
             byte[] ticket) {
-        this(split.replicaHosts(), split.port(), columns, ticket, adapt(client));
+        this(split.replicaHosts(), split.port(), columns, ticket, ReplicaFailoverStream.adapt(client));
     }
 
     /** Package-private seam: inject the ordered host list + opener directly for unit tests. */
@@ -66,35 +36,9 @@ public class CqliteFlightPageSource implements ConnectorPageSource {
             int port,
             List<CqliteFlightColumnHandle> columns,
             byte[] ticket,
-            StreamOpener opener) {
-        this.hosts = List.copyOf(hosts);
-        this.port = port;
+            ReplicaFailoverStream.StreamOpener opener) {
         this.columns = columns;
-        this.ticket = ticket;
-        this.opener = opener;
-    }
-
-    /** The production opener: a real DoGet stream wrapped so failover sees a uniform interface. */
-    private static StreamOpener adapt(CqliteFlightClient client) {
-        return (host, port, ticket) -> {
-            CqliteFlightClient.StreamHandle handle = client.openStream(host, port, ticket);
-            return new BatchStream() {
-                @Override
-                public boolean next() {
-                    return handle.stream().next();
-                }
-
-                @Override
-                public VectorSchemaRoot getRoot() {
-                    return handle.stream().getRoot();
-                }
-
-                @Override
-                public void close() {
-                    handle.close();
-                }
-            };
-        };
+        this.stream = new ReplicaFailoverStream(hosts, port, ticket, opener);
     }
 
     @Override
@@ -102,33 +46,20 @@ public class CqliteFlightPageSource implements ConnectorPageSource {
         if (finished) {
             return null;
         }
-        while (true) {
-            try {
-                if (stream == null) {
-                    stream = opener.open(hosts.get(hostIndex), port, ticket);
-                }
-                if (!stream.next()) {
-                    finished = true;
-                    return null;
-                }
-                VectorSchemaRoot root = stream.getRoot();
-                Page page = ArrowToTrino.toPage(root, columns);
-                completedPositions += page.getPositionCount();
-                started = true;
-                return SourcePage.create(page);
-            } catch (RuntimeException e) {
-                // Release the gRPC channel + Arrow buffers; Trino does not guarantee close() on
-                // the throw path.
-                closeStreamQuietly();
-                if (!started && hostIndex + 1 < hosts.size() && ReplicaFailover.isConnectClass(e)) {
-                    hostIndex++;
-                    continue; // fail over to the next replica that owns this range (#2241)
-                }
-                // Committed (rows already delivered) or no replica left, or a non-connect error:
-                // fail loudly — never a silent partial result.
+        try {
+            if (!stream.next()) {
                 finished = true;
-                throw e;
+                return null;
             }
+            VectorSchemaRoot root = stream.getRoot();
+            Page page = ArrowToTrino.toPage(root, columns);
+            completedPositions += page.getPositionCount();
+            return SourcePage.create(page);
+        } catch (RuntimeException e) {
+            // Release the gRPC channel + Arrow buffers; Trino does not guarantee close() on the
+            // throw path.
+            close();
+            throw e;
         }
     }
 
@@ -155,17 +86,6 @@ public class CqliteFlightPageSource implements ConnectorPageSource {
     @Override
     public void close() {
         finished = true;
-        closeStreamQuietly();
-    }
-
-    private void closeStreamQuietly() {
-        if (stream != null) {
-            try {
-                stream.close();
-            } catch (RuntimeException ignore) {
-                // best-effort release
-            }
-            stream = null;
-        }
+        stream.close();
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplit.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplit.java
@@ -3,19 +3,25 @@ package in.mcfad.cqlite.flight;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * One unit of work: scan a single token range from a single replica's
- * cqlite-flight endpoint. Pinning each range to exactly one replica is how
- * cross-replica duplication is avoided (PLAN §2).
+ * One unit of work: scan a single token range from a replica's cqlite-flight
+ * endpoint. Each range is still read from ONE replica at a time (so cross-replica
+ * duplication is avoided, PLAN §2), but the split carries an ORDERED replica list
+ * for availability failover (issue #2241): {@code host} is the primary; {@code
+ * fallbackHosts} are the range's other replica owners, in try order, that the page
+ * source may fail over to if the primary's Flight endpoint is unreachable.
  *
  * <p>{@code tokenStart} is exclusive, {@code tokenEnd} inclusive; {@code wraparound}
  * is set when the range crosses the ring's min-token boundary ({@code start > end}).
  *
  * <p>{@code snapshot} is the Sidecar snapshot name the ticket reads (issue #2105):
  * present in {@link ReadMode#SNAPSHOT}, {@link Optional#empty()} in {@link ReadMode#LIVE}.
+ * In snapshot mode a fallback is only listed here if its host also has the snapshot
+ * (issue #2227 creates it per replica host); in live mode every replica owner is eligible.
  */
 public record CqliteFlightSplit(
         String keyspace,
@@ -26,12 +32,50 @@ public record CqliteFlightSplit(
         long tokenStart,
         long tokenEnd,
         boolean wraparound,
-        Optional<String> snapshot)
+        Optional<String> snapshot,
+        List<String> fallbackHosts)
         implements ConnectorSplit {
+
+    /** Normalize the fallback list to an immutable copy (never null). */
+    public CqliteFlightSplit {
+        fallbackHosts = fallbackHosts == null ? List.of() : List.copyOf(fallbackHosts);
+    }
+
+    /**
+     * Backward-compatible construction with no availability fallbacks (single-replica
+     * split). Kept so existing call sites and tests compile unchanged.
+     */
+    public CqliteFlightSplit(
+            String keyspace,
+            String table,
+            String ddl,
+            String host,
+            int port,
+            long tokenStart,
+            long tokenEnd,
+            boolean wraparound,
+            Optional<String> snapshot) {
+        this(keyspace, table, ddl, host, port, tokenStart, tokenEnd, wraparound, snapshot, List.of());
+    }
+
+    /**
+     * The ordered replica list to try for this range (issue #2241): the primary
+     * {@link #host} first, then each {@link #fallbackHosts} entry in order.
+     */
+    public List<String> replicaHosts() {
+        List<String> all = new ArrayList<>(1 + fallbackHosts.size());
+        all.add(host);
+        all.addAll(fallbackHosts);
+        return all;
+    }
 
     @Override
     public List<HostAddress> getAddresses() {
-        // Soft locality hint: the replica serving this split.
-        return List.of(HostAddress.fromParts(host, port));
+        // Soft locality hints: every replica that can serve this split (#2241), primary first.
+        List<HostAddress> addrs = new ArrayList<>(1 + fallbackHosts.size());
+        for (String h : replicaHosts()) {
+            addrs.add(HostAddress.fromParts(h, port));
+        }
+        return addrs;
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -246,15 +246,32 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
             String localDatacenter,
             int flightPort,
             Optional<String> snapshot) {
+        // Availability failover (issue #2241): each split carries an ORDERED replica list
+        // (primary first, then the range's other owners) that the page source retries on a
+        // connect-class failure. In SNAPSHOT mode a fallback is only usable if its host also
+        // has the snapshot — issue #2227 creates the snapshot on exactly distinctReplicaHosts
+        // (the primary of each range) and fails closed, so reaching here in snapshot mode means
+        // every one of those hosts has it. Restrict fallbacks to that set; a range's primary is
+        // always in it. In LIVE mode (snapshot empty) every replica owner is eligible.
+        Set<String> snapshotHosts =
+                snapshot.isPresent() ? distinctReplicaHosts(replicas, localDatacenter) : null;
         List<CqliteFlightSplit> splits = new ArrayList<>();
         for (ReplicaInfo range : replicas.readReplicas()) {
-            String replica = pickReplica(range.replicasByDatacenter(), localDatacenter);
-            if (replica == null) {
+            // Sidecar returns replicas as "ip:storage_port"; the flight server listens on
+            // flightPort at the same host, so keep only the host. The ordered list's first
+            // entry is exactly the pickReplica choice (same local-DC-then-global ordering).
+            List<String> ordered = orderedReplicaHosts(range.replicasByDatacenter(), localDatacenter);
+            if (ordered.isEmpty()) {
                 continue; // range with no known replica — nothing to read
             }
-            // Sidecar returns replicas as "ip:storage_port"; the flight server
-            // listens on flightPort at the same host, so keep only the host.
-            String host = hostOnly(replica);
+            String host = ordered.get(0);
+            List<String> fallbacks = new ArrayList<>();
+            for (int i = 1; i < ordered.size(); i++) {
+                String candidate = ordered.get(i);
+                if (snapshotHosts == null || snapshotHosts.contains(candidate)) {
+                    fallbacks.add(candidate);
+                }
+            }
             long start = range.startToken();
             long end = range.endToken();
             // #2228: equal endpoints (start == end) denote the FULL ring — the
@@ -273,9 +290,41 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
                     start,
                     end,
                     wraparound,
-                    snapshot));
+                    snapshot,
+                    fallbacks));
         }
         return splits;
+    }
+
+    /**
+     * The range's replica hosts in try order (issue #2241): local-datacenter owners first
+     * (lexicographic by address), then every other datacenter's owners (lexicographic),
+     * mapped to bare hosts via {@link #hostOnly} and de-duplicated preserving order. The
+     * first element equals {@link #pickReplica}'s choice, so it is the split's primary and
+     * the rest are ordered availability fallbacks.
+     */
+    static List<String> orderedReplicaHosts(Map<String, List<String>> replicasByDatacenter, String localDatacenter) {
+        List<String> orderedAddresses = new ArrayList<>();
+        if (localDatacenter != null) {
+            List<String> local = replicasByDatacenter.get(localDatacenter);
+            if (local != null) {
+                local.stream().sorted().forEach(orderedAddresses::add);
+            }
+        }
+        replicasByDatacenter.entrySet().stream()
+                .filter(e -> !e.getKey().equals(localDatacenter))
+                .flatMap(e -> e.getValue().stream())
+                .sorted()
+                .forEach(orderedAddresses::add);
+        List<String> hosts = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (String address : orderedAddresses) {
+            String host = hostOnly(address);
+            if (seen.add(host)) {
+                hosts.add(host);
+            }
+        }
+        return hosts;
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -60,13 +60,27 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         // Sidecar's node leaves splits on other hosts reading a non-existent directory
         // (NotFound). We stamp the same snapshot name into every split's ticket so the whole
         // scan reads one immutable file set per host; in live mode this is Optional.empty().
-        // Fails closed — a create error on any host propagates (naming host + snapshot) and
-        // the query fails.
-        Set<String> replicaHosts = distinctReplicaHosts(replicas, config.localDatacenter());
+        // Fails closed — a create error on a PRIMARY host propagates (naming host + snapshot)
+        // and the query fails; that host must have the snapshot, no failover is possible without it.
+        Set<String> primaryHosts = distinctReplicaHosts(replicas, config.localDatacenter());
         Optional<String> snapshot =
-                snapshots.snapshotFor(session.getQueryId(), handle.keyspace(), handle.table(), replicaHosts);
-        List<CqliteFlightSplit> ranges =
-                buildSplits(handle, replicas, config.localDatacenter(), config.flightPort(), snapshot);
+                snapshots.snapshotFor(session.getQueryId(), handle.keyspace(), handle.table(), primaryHosts);
+        // Availability failover (issue #2241): a fallback host is only usable if IT ALSO has the
+        // snapshot. Roborev on #2241: restricting to `primaryHosts` here would only ever admit a
+        // fallback that happens to be some OTHER range's primary — a fallback-only host (never a
+        // primary anywhere) would be dropped even when its own snapshot creation would have
+        // succeeded, so a primary outage could still fail the scan despite another live replica
+        // owning the range. Instead, best-effort-create the snapshot on the FULL replica-owner
+        // union (every host in every range's replicaHosts()) and keep only the hosts that
+        // succeeded. Best-effort here is safe: every host in `primaryHosts` is already required
+        // above (fail-closed); only the EXTRA fallback-only hosts can be silently excluded, and a
+        // split simply won't list an excluded host as a fallback — never a silent partial result.
+        Set<String> availableHosts = snapshot.isPresent()
+                ? snapshots.availableHosts(session.getQueryId(), handle.keyspace(), handle.table(),
+                        allReplicaHosts(replicas, config.localDatacenter()))
+                : Set.of();
+        List<CqliteFlightSplit> ranges = buildSplits(
+                handle, replicas, config.localDatacenter(), config.flightPort(), snapshot, availableHosts);
 
         // Aggregated handle: Trino does not re-aggregate across splits, so return
         // ONE finalize split carrying all range→replica assignments. Its PageSource
@@ -235,10 +249,12 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
     }
 
     /**
-     * Pure split-building: one split per read-replica token range, each pinned to
-     * a single deterministically-chosen replica, all stamped with the same
-     * {@code snapshot} (issue #2105). Static for unit testing without a live Sidecar
-     * or Trino session.
+     * Convenience overload without explicit per-host snapshot-availability data: defaults the
+     * fallback-availability set to {@link #distinctReplicaHosts} (primaries only) — a
+     * conservative default for callers that stamp a snapshot name without wiring the real
+     * per-host availability. The live query path ({@link #getSplits}) always calls the 6-arg
+     * overload below with the FULL replica-owner availability set (issue #2241), which is NOT
+     * restricted to primaries.
      */
     public static List<CqliteFlightSplit> buildSplits(
             CqliteFlightTableHandle table,
@@ -246,15 +262,31 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
             String localDatacenter,
             int flightPort,
             Optional<String> snapshot) {
-        // Availability failover (issue #2241): each split carries an ORDERED replica list
-        // (primary first, then the range's other owners) that the page source retries on a
-        // connect-class failure. In SNAPSHOT mode a fallback is only usable if its host also
-        // has the snapshot — issue #2227 creates the snapshot on exactly distinctReplicaHosts
-        // (the primary of each range) and fails closed, so reaching here in snapshot mode means
-        // every one of those hosts has it. Restrict fallbacks to that set; a range's primary is
-        // always in it. In LIVE mode (snapshot empty) every replica owner is eligible.
-        Set<String> snapshotHosts =
-                snapshot.isPresent() ? distinctReplicaHosts(replicas, localDatacenter) : null;
+        return buildSplits(table, replicas, localDatacenter, flightPort, snapshot,
+                distinctReplicaHosts(replicas, localDatacenter));
+    }
+
+    /**
+     * Pure split-building: one split per read-replica token range, each pinned to a single
+     * deterministically-chosen replica, all stamped with the same {@code snapshot} (issue
+     * #2105). Static for unit testing without a live Sidecar or Trino session.
+     *
+     * <p>Availability failover (issue #2241): each split carries an ORDERED replica list
+     * (primary first, then the range's other owners) that the page source retries on a
+     * connect-class failure. In SNAPSHOT mode a fallback is only usable if its host is in
+     * {@code availableSnapshotHosts} — the set of hosts whose snapshot creation actually
+     * succeeded ({@link #getSplits} computes this over the FULL replica-owner union, not just
+     * primaries, so a fallback-only host is eligible whenever its own snapshot creation
+     * succeeded). In LIVE mode ({@code snapshot} empty) every replica owner is eligible and
+     * {@code availableSnapshotHosts} is ignored.
+     */
+    public static List<CqliteFlightSplit> buildSplits(
+            CqliteFlightTableHandle table,
+            TokenRangeReplicasResponse replicas,
+            String localDatacenter,
+            int flightPort,
+            Optional<String> snapshot,
+            Set<String> availableSnapshotHosts) {
         List<CqliteFlightSplit> splits = new ArrayList<>();
         for (ReplicaInfo range : replicas.readReplicas()) {
             // Sidecar returns replicas as "ip:storage_port"; the flight server listens on
@@ -268,7 +300,7 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
             List<String> fallbacks = new ArrayList<>();
             for (int i = 1; i < ordered.size(); i++) {
                 String candidate = ordered.get(i);
-                if (snapshotHosts == null || snapshotHosts.contains(candidate)) {
+                if (snapshot.isEmpty() || availableSnapshotHosts.contains(candidate)) {
                     fallbacks.add(candidate);
                 }
             }
@@ -341,6 +373,23 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
             if (replica != null) {
                 hosts.add(hostOnly(replica));
             }
+        }
+        return hosts;
+    }
+
+    /**
+     * The union of every replica host that owns ANY token range the scan will read (issue
+     * #2241) — primaries AND every other owner, per range via {@link #orderedReplicaHosts},
+     * deduplicated across ranges (insertion order). This is the full candidate set for
+     * best-effort per-host snapshot creation, so an availability-failover fallback is not
+     * silently restricted to {@link #distinctReplicaHosts} (primaries only): a fallback host
+     * that is never any range's primary must still be eligible when its own snapshot creation
+     * succeeds.
+     */
+    static Set<String> allReplicaHosts(TokenRangeReplicasResponse replicas, String localDatacenter) {
+        Set<String> hosts = new LinkedHashSet<>();
+        for (ReplicaInfo range : replicas.readReplicas()) {
+            hosts.addAll(orderedReplicaHosts(range.replicasByDatacenter(), localDatacenter));
         }
         return hosts;
     }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ReplicaFailover.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ReplicaFailover.java
@@ -1,0 +1,37 @@
+package in.mcfad.cqlite.flight;
+
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.FlightStatusCode;
+
+/**
+ * Replica-failover policy for split reads (issue #2241): which stream-open failures are safe to
+ * retry against the next replica in the split's ordered list.
+ */
+final class ReplicaFailover {
+    private ReplicaFailover() {}
+
+    /**
+     * True iff {@code error} (or a cause) is a connection-establishment /
+     * {@link FlightStatusCode#UNAVAILABLE}-class Flight failure — the endpoint is down or
+     * unreachable, so another replica that owns the range can serve the read. The status can be
+     * wrapped (the client rethrows runtime exceptions and wraps checked ones), so we walk the
+     * cause chain, mirroring {@code CqliteFlightMetadata#isNotHosting}.
+     *
+     * <p>This must be consulted ONLY before the split has delivered any batch: retrying after rows
+     * were consumed could duplicate them (a correctness bug), so a mid-stream failure — even an
+     * UNAVAILABLE one — is fatal at the call site regardless of this predicate.
+     */
+    static boolean isConnectClass(Throwable error) {
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            if (t instanceof FlightRuntimeException fre
+                    && fre.status() != null
+                    && fre.status().code() == FlightStatusCode.UNAVAILABLE) {
+                return true;
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return false;
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ReplicaFailoverStream.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ReplicaFailoverStream.java
@@ -1,0 +1,131 @@
+package in.mcfad.cqlite.flight;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+import java.util.List;
+
+/**
+ * Shared availability-failover retry loop (issue #2241) for a SINGLE range's batch stream: tries
+ * an ordered replica host list (primary first, then fallbacks) — as returned by {@link
+ * CqliteFlightSplit#replicaHosts()} — and fails over to the next host on a
+ * connection-establishment/UNAVAILABLE-class failure ({@link ReplicaFailover#isConnectClass})
+ * BEFORE any batch has been delivered FROM THIS STREAM. Once a batch has been delivered the
+ * stream is committed: a later failure is fatal and never retried, because re-reading from
+ * another replica could duplicate already-emitted rows. If every host is unreachable the caller
+ * sees the last connect failure propagate — loud, never a silent partial/empty result.
+ *
+ * <p>Used by both the per-split scan page source ({@link CqliteFlightPageSource}) and the
+ * aggregate finalize page source's per-range fan-out ({@link CqliteFlightAggregatePageSource}) —
+ * a single shared implementation so scan and aggregate paths get identical failover semantics.
+ */
+final class ReplicaFailoverStream implements AutoCloseable {
+
+    /** One replica's open batch stream — abstracted so failover is unit-testable off-cluster. */
+    interface BatchStream extends AutoCloseable {
+        /**
+         * Advance to the next batch; {@code false} at end of stream. The FIRST call performs the
+         * actual gRPC and may throw a connect-class failure that triggers failover.
+         */
+        boolean next();
+
+        VectorSchemaRoot getRoot();
+
+        @Override
+        void close();
+    }
+
+    /** Opens a {@link BatchStream} against one replica {@code host:port} for a ticket. */
+    @FunctionalInterface
+    interface StreamOpener {
+        BatchStream open(String host, int port, byte[] ticket);
+    }
+
+    private final List<String> hosts;
+    private final int port;
+    private final byte[] ticket;
+    private final StreamOpener opener;
+
+    private BatchStream stream;
+    private int hostIndex;
+    private boolean started;
+
+    ReplicaFailoverStream(List<String> hosts, int port, byte[] ticket, StreamOpener opener) {
+        this.hosts = List.copyOf(hosts);
+        this.port = port;
+        this.ticket = ticket;
+        this.opener = opener;
+    }
+
+    /**
+     * Advance to the next batch, transparently failing over to the next replica host on a
+     * connect-class failure before any batch of THIS stream has been delivered.
+     *
+     * @return {@code false} at end of stream
+     * @throws RuntimeException the underlying failure once no replica is left to try, or ANY
+     *                          failure (connect-class or not) once this stream is committed
+     */
+    boolean next() {
+        while (true) {
+            try {
+                if (stream == null) {
+                    stream = opener.open(hosts.get(hostIndex), port, ticket);
+                }
+                boolean hasNext = stream.next();
+                if (hasNext) {
+                    started = true;
+                }
+                return hasNext;
+            } catch (RuntimeException e) {
+                closeStreamQuietly();
+                if (!started && hostIndex + 1 < hosts.size() && ReplicaFailover.isConnectClass(e)) {
+                    hostIndex++;
+                    continue; // fail over to the next replica that owns this range (#2241)
+                }
+                throw e; // committed, no replica left, or a non-connect error: fail loudly
+            }
+        }
+    }
+
+    VectorSchemaRoot getRoot() {
+        return stream.getRoot();
+    }
+
+    @Override
+    public void close() {
+        closeStreamQuietly();
+    }
+
+    private void closeStreamQuietly() {
+        if (stream != null) {
+            try {
+                stream.close();
+            } catch (RuntimeException ignore) {
+                // best-effort release
+            }
+            stream = null;
+        }
+    }
+
+    /** The production opener: a real DoGet stream wrapped so failover sees a uniform interface. */
+    static StreamOpener adapt(CqliteFlightClient client) {
+        return (host, port, ticket) -> {
+            CqliteFlightClient.StreamHandle handle = client.openStream(host, port, ticket);
+            return new BatchStream() {
+                @Override
+                public boolean next() {
+                    return handle.stream().next();
+                }
+
+                @Override
+                public VectorSchemaRoot getRoot() {
+                    return handle.stream().getRoot();
+                }
+
+                @Override
+                public void close() {
+                    handle.close();
+                }
+            };
+        };
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -4,9 +4,11 @@ import in.mcfad.cqlite.flight.sidecar.HostSnapshotApis;
 import in.mcfad.cqlite.flight.sidecar.SidecarClient;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -88,6 +90,47 @@ public final class SnapshotManager {
             createOnHost(forQuery, new SnapshotKey(host, keyspace, table), name);
         }
         return Optional.of(name);
+    }
+
+    /**
+     * Best-effort per-host snapshot availability for a candidate host set (issue #2241):
+     * attempts creation (the same memoized per-(query, host, keyspace, table) fan-out as
+     * {@link #snapshotFor}, so a host already created there — e.g. a split's primary — resolves
+     * instantly with no duplicate PUT) on every host in {@code hosts}, but — unlike {@link
+     * #snapshotFor} — does NOT fail closed on an individual host's creation failure. A host
+     * whose creation fails is logged and excluded from the returned set; the caller ({@link
+     * CqliteFlightSplitManager#getSplits}) uses this to restrict availability-failover fallback
+     * lists to hosts that actually have the snapshot, without failing the whole query over an
+     * optional fallback host (a required PRIMARY host still fails closed via {@link
+     * #snapshotFor}).
+     *
+     * <p>In {@link ReadMode#LIVE} this is a no-op returning every candidate host unchanged
+     * (fallback restriction is meaningful only in snapshot mode).
+     *
+     * @param hosts every candidate replica host to check/create snapshot availability for
+     * @return the subset of {@code hosts} that have (or now have) the snapshot
+     */
+    public Set<String> availableHosts(String queryId, String keyspace, String table, Collection<String> hosts) {
+        if (readMode == ReadMode.LIVE) {
+            return Set.copyOf(hosts);
+        }
+        String name = snapshotName(queryId);
+        Map<SnapshotKey, CompletableFuture<String>> forQuery =
+                created.computeIfAbsent(queryId, q -> new ConcurrentHashMap<>());
+        Set<String> available = new LinkedHashSet<>();
+        for (String host : hosts) {
+            SnapshotKey key = new SnapshotKey(host, keyspace, table);
+            try {
+                createOnHost(forQuery, key, name);
+                available.add(host);
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING,
+                        () -> "Snapshot unavailable on replica host " + host + " for " + keyspace + "." + table
+                                + " (issue #2241): excluded from availability-failover fallback "
+                                + "candidates — " + e.getMessage());
+            }
+        }
+        return available;
     }
 
     /**

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceFailoverTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceFailoverTest.java
@@ -1,0 +1,179 @@
+package in.mcfad.cqlite.flight;
+
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.BigintType;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Replica failover on the aggregate finalize fan-out (issue #2241 roborev): the per-range DoGet
+ * in {@link CqliteFlightAggregatePageSource#getNextSourcePage} uses the same shared {@link
+ * ReplicaFailoverStream} as the scan path, so a down primary fails over to that range's next
+ * replica before any of its partial rows are consumed; an all-down range fails the whole query
+ * loudly (an aggregate partial must never be silently dropped); and a mid-stream failure after a
+ * range's first batch is committed is NOT retried.
+ */
+class CqliteFlightAggregatePageSourceFailoverTest {
+    private static final String DDL = "CREATE TABLE ks.t (id int PRIMARY KEY)";
+    private static final String AGGREGATION_JSON =
+            "{\"group_by\":[],\"aggregates\":[{\"func\":\"Count\",\"column\":null,\"output\":\"agg0\"}]}";
+    private static final String FINALIZE_JSON =
+            "{\"group_by\":[],"
+                    + "\"outputs\":[{\"result_name\":\"cnt\",\"kind\":\"DIRECT\",\"primary\":\"agg0\","
+                    + "\"secondary\":null}]}";
+    private static final List<CqliteFlightColumnHandle> COLUMNS =
+            List.of(new CqliteFlightColumnHandle("cnt", BigintType.BIGINT));
+
+    private static RuntimeException unavailable() {
+        return CallStatus.UNAVAILABLE.withDescription("connection refused").toRuntimeException();
+    }
+
+    private static CqliteFlightSplit range(String host, List<String> fallbacks) {
+        return new CqliteFlightSplit("ks", "t", DDL, host, 8815, -100L, 100L, false, Optional.empty(), fallbacks);
+    }
+
+    private static CqliteFlightAggregateSplit finalizeSplit(List<CqliteFlightSplit> ranges) {
+        return new CqliteFlightAggregateSplit(
+                "ks", "t", DDL, ranges, Optional.empty(), AGGREGATION_JSON, FINALIZE_JSON);
+    }
+
+    /** A batch stream yielding one count row once, optionally throwing at a chosen point. */
+    private static final class FakeStream implements ReplicaFailoverStream.BatchStream {
+        private final VectorSchemaRoot root;
+        private final RuntimeException throwOnFirstNext;
+        private final RuntimeException throwAfterFirstBatch;
+        private int nextCalls;
+
+        FakeStream(VectorSchemaRoot root, RuntimeException throwOnFirstNext, RuntimeException throwAfterFirstBatch) {
+            this.root = root;
+            this.throwOnFirstNext = throwOnFirstNext;
+            this.throwAfterFirstBatch = throwAfterFirstBatch;
+        }
+
+        @Override
+        public boolean next() {
+            nextCalls++;
+            if (nextCalls == 1) {
+                if (throwOnFirstNext != null) {
+                    throw throwOnFirstNext;
+                }
+                return true;
+            }
+            if (nextCalls == 2 && throwAfterFirstBatch != null) {
+                throw throwAfterFirstBatch;
+            }
+            return false;
+        }
+
+        @Override
+        public VectorSchemaRoot getRoot() {
+            return root;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static final class TrackingOpener implements ReplicaFailoverStream.StreamOpener {
+        private final Map<String, Supplier<ReplicaFailoverStream.BatchStream>> byHost;
+        final Map<String, Integer> opens = new LinkedHashMap<>();
+
+        TrackingOpener(Map<String, Supplier<ReplicaFailoverStream.BatchStream>> byHost) {
+            this.byHost = byHost;
+        }
+
+        @Override
+        public ReplicaFailoverStream.BatchStream open(String host, int port, byte[] ticket) {
+            opens.merge(host, 1, Integer::sum);
+            return byHost.get(host).get();
+        }
+    }
+
+    private static VectorSchemaRoot countRoot(BufferAllocator allocator, long count) {
+        BigIntVector v = new BigIntVector("agg0", allocator);
+        v.allocateNew(1);
+        v.set(0, count);
+        VectorSchemaRoot root = new VectorSchemaRoot(List.of(v));
+        root.setRowCount(1);
+        return root;
+    }
+
+    private static long resultCount(CqliteFlightAggregatePageSource source) {
+        SourcePage page = source.getNextSourcePage();
+        Page trinoPage = page.getPage();
+        Block block = trinoPage.getBlock(0);
+        return BigintType.BIGINT.getLong(block, 0);
+    }
+
+    @Test
+    void rangeFailsOverToNextReplicaWhenPrimaryUnreachable() {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            VectorSchemaRoot good = countRoot(allocator, 5L);
+            var opener = new TrackingOpener(new LinkedHashMap<>(Map.of(
+                    "downHost", () -> new FakeStream(null, unavailable(), null),
+                    "upHost", () -> new FakeStream(good, null, null))));
+            CqliteFlightAggregateSplit split =
+                    finalizeSplit(List.of(range("downHost", List.of("upHost"))));
+            var source = new CqliteFlightAggregatePageSource(opener, split, COLUMNS);
+
+            assertEquals(5L, resultCount(source), "the range's partial served by the fallback replica");
+            assertEquals(1, opener.opens.get("downHost"), "primary attempted once");
+            assertEquals(1, opener.opens.get("upHost"), "failed over to fallback exactly once");
+            good.close();
+        }
+    }
+
+    @Test
+    void allReplicasOfARangeUnreachableFailsTheWholeQueryLoudly() {
+        var opener = new TrackingOpener(new LinkedHashMap<>(Map.of(
+                "downA", () -> new FakeStream(null, unavailable(), null),
+                "downB", () -> new FakeStream(null, unavailable(), null))));
+        CqliteFlightAggregateSplit split =
+                finalizeSplit(List.of(range("downA", List.of("downB"))));
+        var source = new CqliteFlightAggregatePageSource(opener, split, COLUMNS);
+
+        // Loud failure — an aggregate partial must never be silently dropped (CQLite doctrine).
+        RuntimeException thrown = assertThrows(RuntimeException.class, source::getNextSourcePage);
+        assertTrue(ReplicaFailover.isConnectClass(thrown));
+        assertEquals(1, opener.opens.get("downA"));
+        assertEquals(1, opener.opens.get("downB"), "every replica of the range attempted before failing");
+    }
+
+    @Test
+    void doesNotFailOverOnMidStreamFailureAfterRangeRowsDelivered() {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            VectorSchemaRoot first = countRoot(allocator, 1L);
+            var opener = new TrackingOpener(new LinkedHashMap<>(Map.of(
+                    // Primary delivers a batch, then dies UNAVAILABLE mid-stream.
+                    "primary", () -> new FakeStream(first, null, unavailable()),
+                    "fallback", () -> new FakeStream(countRoot(allocator, 1L), null, null))));
+            CqliteFlightAggregateSplit split =
+                    finalizeSplit(List.of(range("primary", List.of("fallback"))));
+            var source = new CqliteFlightAggregatePageSource(opener, split, COLUMNS);
+
+            // The mid-stream UNAVAILABLE (after the range's first batch was consumed by
+            // accumulate()) must NOT trigger failover — retrying could duplicate rows.
+            assertThrows(RuntimeException.class, source::getNextSourcePage);
+            assertEquals(1, opener.opens.get("primary"));
+            assertNull(opener.opens.get("fallback"), "a committed range must never retry a fallback");
+            first.close();
+        }
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightPageSourceFailoverTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightPageSourceFailoverTest.java
@@ -37,7 +37,7 @@ class CqliteFlightPageSourceFailoverTest {
     }
 
     /** A batch stream that yields the given rows once, optionally throwing at a chosen point. */
-    private static final class FakeStream implements CqliteFlightPageSource.BatchStream {
+    private static final class FakeStream implements ReplicaFailoverStream.BatchStream {
         private final VectorSchemaRoot root;
         private final RuntimeException throwOnFirstNext;
         private final RuntimeException throwAfterFirstBatch;
@@ -77,16 +77,16 @@ class CqliteFlightPageSourceFailoverTest {
     }
 
     /** Tracks how many times each host was opened, so we can assert failover order + no over-reach. */
-    private static final class TrackingOpener implements CqliteFlightPageSource.StreamOpener {
-        private final Map<String, Supplier<CqliteFlightPageSource.BatchStream>> byHost;
+    private static final class TrackingOpener implements ReplicaFailoverStream.StreamOpener {
+        private final Map<String, Supplier<ReplicaFailoverStream.BatchStream>> byHost;
         final Map<String, Integer> opens = new LinkedHashMap<>();
 
-        TrackingOpener(Map<String, Supplier<CqliteFlightPageSource.BatchStream>> byHost) {
+        TrackingOpener(Map<String, Supplier<ReplicaFailoverStream.BatchStream>> byHost) {
             this.byHost = byHost;
         }
 
         @Override
-        public CqliteFlightPageSource.BatchStream open(String host, int port, byte[] ticket) {
+        public ReplicaFailoverStream.BatchStream open(String host, int port, byte[] ticket) {
             opens.merge(host, 1, Integer::sum);
             return byHost.get(host).get();
         }
@@ -137,9 +137,9 @@ class CqliteFlightPageSourceFailoverTest {
     void failsOverWhenPrimaryOpenThrowsUnavailable() {
         try (BufferAllocator allocator = new RootAllocator()) {
             VectorSchemaRoot good = bigintRoot(allocator, 42L);
-            var opener = new CqliteFlightPageSource.StreamOpener() {
+            var opener = new ReplicaFailoverStream.StreamOpener() {
                 @Override
-                public CqliteFlightPageSource.BatchStream open(String host, int port, byte[] ticket) {
+                public ReplicaFailoverStream.BatchStream open(String host, int port, byte[] ticket) {
                     if (host.equals("downHost")) {
                         throw unavailable(); // connection failed at establishment
                     }

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightPageSourceFailoverTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightPageSourceFailoverTest.java
@@ -1,0 +1,203 @@
+package in.mcfad.cqlite.flight;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.BigintType;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Replica failover on the scan page source (issue #2241): a down primary fails over to the next
+ * replica that owns the range BEFORE any batch is delivered; all-down fails loudly (never a silent
+ * empty result); and once rows have been delivered a later failure is NOT retried (retrying could
+ * duplicate rows — a correctness bug).
+ */
+class CqliteFlightPageSourceFailoverTest {
+    private static final byte[] TICKET = new byte[] {1, 2, 3};
+    private static final List<CqliteFlightColumnHandle> COLUMNS =
+            List.of(new CqliteFlightColumnHandle("v", BigintType.BIGINT));
+
+    private static RuntimeException unavailable() {
+        return CallStatus.UNAVAILABLE.withDescription("connection refused").toRuntimeException();
+    }
+
+    /** A batch stream that yields the given rows once, optionally throwing at a chosen point. */
+    private static final class FakeStream implements CqliteFlightPageSource.BatchStream {
+        private final VectorSchemaRoot root;
+        private final RuntimeException throwOnFirstNext;
+        private final RuntimeException throwAfterFirstBatch;
+        private int nextCalls;
+        boolean closed;
+
+        FakeStream(VectorSchemaRoot root, RuntimeException throwOnFirstNext, RuntimeException throwAfterFirstBatch) {
+            this.root = root;
+            this.throwOnFirstNext = throwOnFirstNext;
+            this.throwAfterFirstBatch = throwAfterFirstBatch;
+        }
+
+        @Override
+        public boolean next() {
+            nextCalls++;
+            if (nextCalls == 1) {
+                if (throwOnFirstNext != null) {
+                    throw throwOnFirstNext;
+                }
+                return true; // deliver the single batch
+            }
+            if (nextCalls == 2 && throwAfterFirstBatch != null) {
+                throw throwAfterFirstBatch; // mid-stream failure after a batch was delivered
+            }
+            return false; // end of stream
+        }
+
+        @Override
+        public VectorSchemaRoot getRoot() {
+            return root;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    /** Tracks how many times each host was opened, so we can assert failover order + no over-reach. */
+    private static final class TrackingOpener implements CqliteFlightPageSource.StreamOpener {
+        private final Map<String, Supplier<CqliteFlightPageSource.BatchStream>> byHost;
+        final Map<String, Integer> opens = new LinkedHashMap<>();
+
+        TrackingOpener(Map<String, Supplier<CqliteFlightPageSource.BatchStream>> byHost) {
+            this.byHost = byHost;
+        }
+
+        @Override
+        public CqliteFlightPageSource.BatchStream open(String host, int port, byte[] ticket) {
+            opens.merge(host, 1, Integer::sum);
+            return byHost.get(host).get();
+        }
+    }
+
+    private static VectorSchemaRoot bigintRoot(BufferAllocator allocator, long... values) {
+        BigIntVector v = new BigIntVector("v", allocator);
+        v.allocateNew(values.length);
+        for (int i = 0; i < values.length; i++) {
+            v.set(i, values[i]);
+        }
+        VectorSchemaRoot root = new VectorSchemaRoot(List.of(v));
+        root.setRowCount(values.length);
+        return root;
+    }
+
+    private static List<Long> drain(CqliteFlightPageSource source) {
+        List<Long> out = new ArrayList<>();
+        SourcePage page;
+        while ((page = source.getNextSourcePage()) != null) {
+            Block block = page.getBlock(0);
+            for (int r = 0; r < page.getPositionCount(); r++) {
+                out.add(BigintType.BIGINT.getLong(block, r));
+            }
+        }
+        return out;
+    }
+
+    @Test
+    void failsOverToNextReplicaWhenPrimaryUnreachable() {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            VectorSchemaRoot good = bigintRoot(allocator, 7L, 8L);
+            var opener = new TrackingOpener(new LinkedHashMap<>(Map.of(
+                    "downHost", () -> new FakeStream(null, unavailable(), null),
+                    "upHost", () -> new FakeStream(good, null, null))));
+            var source = new CqliteFlightPageSource(
+                    List.of("downHost", "upHost"), 8815, COLUMNS, TICKET, opener);
+
+            assertEquals(List.of(7L, 8L), drain(source), "rows served by the fallback replica");
+            assertTrue(source.isFinished());
+            assertEquals(1, opener.opens.get("downHost"), "primary attempted once");
+            assertEquals(1, opener.opens.get("upHost"), "failed over to fallback exactly once");
+            good.close();
+        }
+    }
+
+    @Test
+    void failsOverWhenPrimaryOpenThrowsUnavailable() {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            VectorSchemaRoot good = bigintRoot(allocator, 42L);
+            var opener = new CqliteFlightPageSource.StreamOpener() {
+                @Override
+                public CqliteFlightPageSource.BatchStream open(String host, int port, byte[] ticket) {
+                    if (host.equals("downHost")) {
+                        throw unavailable(); // connection failed at establishment
+                    }
+                    return new FakeStream(good, null, null);
+                }
+            };
+            var source = new CqliteFlightPageSource(
+                    List.of("downHost", "upHost"), 8815, COLUMNS, TICKET, opener);
+            assertEquals(List.of(42L), drain(source));
+            good.close();
+        }
+    }
+
+    @Test
+    void allReplicasUnreachableFailsLoudly() {
+        var opener = new TrackingOpener(new LinkedHashMap<>(Map.of(
+                "downA", () -> new FakeStream(null, unavailable(), null),
+                "downB", () -> new FakeStream(null, unavailable(), null))));
+        var source = new CqliteFlightPageSource(
+                List.of("downA", "downB"), 8815, COLUMNS, TICKET, opener);
+
+        // Loud failure — never a silent empty result (CQLite doctrine).
+        RuntimeException thrown = assertThrows(RuntimeException.class, source::getNextSourcePage);
+        assertTrue(ReplicaFailover.isConnectClass(thrown));
+        assertTrue(source.isFinished());
+        assertEquals(1, opener.opens.get("downA"));
+        assertEquals(1, opener.opens.get("downB"), "every replica attempted before failing");
+    }
+
+    @Test
+    void doesNotFailOverOnMidStreamFailureAfterRowsDelivered() {
+        try (BufferAllocator allocator = new RootAllocator()) {
+            VectorSchemaRoot first = bigintRoot(allocator, 1L);
+            var opener = new TrackingOpener(new LinkedHashMap<>(Map.of(
+                    // Primary delivers a batch, then dies UNAVAILABLE mid-stream.
+                    "primary", () -> new FakeStream(first, null, unavailable()),
+                    "fallback", () -> new FakeStream(bigintRoot(allocator, 1L), null, null))));
+            var source = new CqliteFlightPageSource(
+                    List.of("primary", "fallback"), 8815, COLUMNS, TICKET, opener);
+
+            // First page delivered from the primary.
+            assertEquals(List.of(1L), drainOne(source));
+            // The mid-stream UNAVAILABLE must NOT trigger failover (would duplicate the row).
+            assertThrows(RuntimeException.class, source::getNextSourcePage);
+            assertTrue(source.isFinished());
+            assertEquals(1, opener.opens.get("primary"));
+            assertNull(opener.opens.get("fallback"), "committed stream must never retry a fallback");
+            first.close();
+        }
+    }
+
+    private static List<Long> drainOne(CqliteFlightPageSource source) {
+        SourcePage page = source.getNextSourcePage();
+        List<Long> out = new ArrayList<>();
+        Block block = page.getBlock(0);
+        for (int r = 0; r < page.getPositionCount(); r++) {
+            out.add(BigintType.BIGINT.getLong(block, r));
+        }
+        return out;
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitFallbackTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitFallbackTest.java
@@ -1,0 +1,88 @@
+package in.mcfad.cqlite.flight;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.trino.spi.HostAddress;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The ordered replica fallback list on a split (issue #2241): {@code host} is the primary and
+ * {@code fallbackHosts} the availability alternates the page source may fail over to. Splits
+ * serialize between coordinator and workers, so the list must survive a JSON round-trip.
+ */
+class CqliteFlightSplitFallbackTest {
+    private static final String DDL = "CREATE TABLE ks.t (id int PRIMARY KEY)";
+
+    // Mirror Trino's split codec (airlift ObjectMapperProvider): serialize by FIELDS, not getters,
+    // so a ConnectorSplit round-trips its record components without invoking the interface's default
+    // methods (e.g. getRetainedSizeInBytes); Optional<>-aware via the jdk8 module (issue #2241).
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new Jdk8Module())
+            .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+            .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private static CqliteFlightSplit split(List<String> fallbacks) {
+        return new CqliteFlightSplit(
+                "ks", "t", DDL, "10.0.0.1", 8815, -100L, 100L, false, Optional.of("cqlite-q1"), fallbacks);
+    }
+
+    @Test
+    void replicaHostsArePrimaryThenFallbacksInOrder() {
+        CqliteFlightSplit s = split(List.of("10.0.0.2", "10.0.0.3"));
+        assertEquals(List.of("10.0.0.1", "10.0.0.2", "10.0.0.3"), s.replicaHosts());
+    }
+
+    @Test
+    void nineArgConstructorHasNoFallbacks() {
+        CqliteFlightSplit s = new CqliteFlightSplit(
+                "ks", "t", DDL, "10.0.0.1", 8815, -100L, 100L, false, Optional.empty());
+        assertEquals(List.of(), s.fallbackHosts());
+        assertEquals(List.of("10.0.0.1"), s.replicaHosts());
+    }
+
+    @Test
+    void getAddressesListsEveryReplicaPrimaryFirst() {
+        CqliteFlightSplit s = split(List.of("10.0.0.2", "10.0.0.3"));
+        assertEquals(
+                List.of(
+                        HostAddress.fromParts("10.0.0.1", 8815),
+                        HostAddress.fromParts("10.0.0.2", 8815),
+                        HostAddress.fromParts("10.0.0.3", 8815)),
+                s.getAddresses());
+    }
+
+    @Test
+    void fallbackListSurvivesJsonRoundTrip() throws Exception {
+        CqliteFlightSplit original = split(List.of("10.0.0.2", "10.0.0.3"));
+
+        byte[] json = MAPPER.writeValueAsBytes(original);
+        CqliteFlightSplit restored = MAPPER.readValue(json, CqliteFlightSplit.class);
+
+        assertEquals(original, restored, "whole split round-trips");
+        assertEquals(List.of("10.0.0.2", "10.0.0.3"), restored.fallbackHosts());
+        assertEquals(List.of("10.0.0.1", "10.0.0.2", "10.0.0.3"), restored.replicaHosts());
+        assertEquals(Optional.of("cqlite-q1"), restored.snapshot());
+    }
+
+    @Test
+    void emptyFallbackListSurvivesJsonRoundTrip() throws Exception {
+        CqliteFlightSplit original = new CqliteFlightSplit(
+                "ks", "t", DDL, "10.0.0.1", 8815, 0L, 50L, false, Optional.empty(), List.of());
+
+        byte[] json = MAPPER.writeValueAsBytes(original);
+        CqliteFlightSplit restored = MAPPER.readValue(json, CqliteFlightSplit.class);
+
+        assertEquals(original, restored);
+        assertTrue(restored.fallbackHosts().isEmpty());
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerSnapshotFailoverTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerSnapshotFailoverTest.java
@@ -1,0 +1,125 @@
+package in.mcfad.cqlite.flight;
+
+import in.mcfad.cqlite.flight.sidecar.HostSnapshotApis;
+import in.mcfad.cqlite.flight.sidecar.SidecarClient;
+import in.mcfad.cqlite.flight.sidecar.SnapshotApi;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces the exact wiring {@link CqliteFlightSplitManager#getSplits} performs (issue
+ * #2241 roborev): a per-host snapshot is created over the FULL replica-owner union — not just
+ * {@link CqliteFlightSplitManager#distinctReplicaHosts primaries} — so an availability-failover
+ * fallback that is never any range's primary is still eligible when its own snapshot creation
+ * succeeds, and is excluded (without failing the query) when it fails.
+ *
+ * <p>Before the fix, {@code buildSplits} restricted fallbacks to {@code distinctReplicaHosts}
+ * (primaries only), so a fallback host that never happened to be another range's primary was
+ * dropped even when a real per-host snapshot for it would have succeeded — a primary outage
+ * could still fail the scan despite another live replica owning the range.
+ */
+class CqliteFlightSplitManagerSnapshotFailoverTest {
+    private static final CqliteFlightTableHandle TABLE =
+            new CqliteFlightTableHandle("ks", "t", "CREATE TABLE ks.t (id int PRIMARY KEY)");
+
+    /** Records every create (prefixed with the host) and can be armed to throw per host. */
+    private static final class FakeSidecars implements HostSnapshotApis {
+        final List<String> creates = Collections.synchronizedList(new ArrayList<>());
+        volatile Set<String> failCreateHosts = Set.of();
+
+        @Override
+        public SnapshotApi forHost(String host) {
+            return new SnapshotApi() {
+                @Override
+                public void createSnapshot(String keyspace, String table, String name, Optional<String> ttl) {
+                    if (failCreateHosts.contains(host)) {
+                        throw new SidecarClient.SidecarException("boom on " + host, 500);
+                    }
+                    creates.add(host);
+                }
+
+                @Override
+                public void clearSnapshot(String keyspace, String table, String name) {}
+            };
+        }
+    }
+
+    private static ReplicaInfo range(String start, String end, Map<String, List<String>> byDc) {
+        return new ReplicaInfo(start, end, byDc);
+    }
+
+    /**
+     * Range A: primary 10.0.0.2, extra owner 10.0.0.9 (never any range's primary).
+     * Range B: primary 10.0.0.2 only.
+     */
+    private static TokenRangeReplicasResponse twoRangesWithNonPrimaryOwner() {
+        return new TokenRangeReplicasResponse(
+                List.of(),
+                List.of(
+                        range("-100", "0", Map.of("dc1", List.of("10.0.0.2:7000", "10.0.0.9:7000"))),
+                        range("0", "100", Map.of("dc1", List.of("10.0.0.2:7000")))));
+    }
+
+    /** Mirrors {@link CqliteFlightSplitManager#getSplits}'s snapshot-mode wiring exactly. */
+    private static List<CqliteFlightSplit> planSnapshotModeSplits(
+            TokenRangeReplicasResponse resp, SnapshotManager snapshots) {
+        Set<String> primaryHosts = CqliteFlightSplitManager.distinctReplicaHosts(resp, "dc1");
+        Optional<String> snapshot = snapshots.snapshotFor("q1", "ks", "t", primaryHosts);
+        Set<String> availableHosts = snapshots.availableHosts(
+                "q1", "ks", "t", CqliteFlightSplitManager.allReplicaHosts(resp, "dc1"));
+        return CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815, snapshot, availableHosts);
+    }
+
+    @Test
+    void fallbackThatIsNeverAPrimaryStillGetsSnapshottedAndSurvives() {
+        FakeSidecars fake = new FakeSidecars();
+        SnapshotManager snapshots = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
+        TokenRangeReplicasResponse resp = twoRangesWithNonPrimaryOwner();
+
+        List<CqliteFlightSplit> splits = planSnapshotModeSplits(resp, snapshots);
+
+        assertEquals("10.0.0.2", splits.get(0).host());
+        assertEquals(List.of("10.0.0.9"), splits.get(0).fallbackHosts(),
+                "non-primary owner survives because its OWN snapshot creation succeeded");
+        assertTrue(fake.creates.contains("10.0.0.9"),
+                "the snapshot must actually be created on the fallback-only host, not just primaries");
+    }
+
+    @Test
+    void fallbackWhoseSnapshotCreationFailsIsExcludedWithoutFailingTheQuery() {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failCreateHosts = Set.of("10.0.0.9"); // fallback-only host's create fails
+        SnapshotManager snapshots = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
+        TokenRangeReplicasResponse resp = twoRangesWithNonPrimaryOwner();
+
+        // Planning must NOT throw — only the primary (required) hosts are fail-closed.
+        List<CqliteFlightSplit> splits = planSnapshotModeSplits(resp, snapshots);
+
+        assertEquals("10.0.0.2", splits.get(0).host());
+        assertEquals(List.of(), splits.get(0).fallbackHosts(),
+                "excluded: its snapshot creation failed, so it cannot serve a snapshot-mode read");
+    }
+
+    @Test
+    void primarySnapshotCreationFailureStillFailsClosed() {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failCreateHosts = Set.of("10.0.0.2"); // the primary itself fails
+        SnapshotManager snapshots = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
+        TokenRangeReplicasResponse resp = twoRangesWithNonPrimaryOwner();
+
+        assertThrows(SidecarClient.SidecarException.class, () -> planSnapshotModeSplits(resp, snapshots),
+                "a REQUIRED (primary) host's snapshot failure must still fail the whole query (#2227)");
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
@@ -321,4 +321,88 @@ class CqliteFlightSplitManagerTest {
                 List.of(range("0", "100", Map.of())));
         assertTrue(CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815).isEmpty());
     }
+
+    /**
+     * Availability failover (issue #2241): in LIVE mode every other replica owner of a range is
+     * an ordered fallback (primary first). {@code orderedReplicaHosts} sorts by address and
+     * de-dups by host; the primary equals {@link CqliteFlightSplitManager#pickReplica}'s choice.
+     */
+    @Test
+    void liveModeCarriesAllOtherOwnersAsOrderedFallbacks() {
+        var resp = new TokenRangeReplicasResponse(
+                List.of(),
+                List.of(range("-100", "0",
+                        Map.of("dc1", List.of("10.0.0.3:7000", "10.0.0.2:7000", "10.0.0.4:7000")))));
+
+        var splits = CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815);
+        assertEquals(1, splits.size());
+        assertEquals("10.0.0.2", splits.get(0).host(), "primary = smallest address");
+        assertEquals(List.of("10.0.0.3", "10.0.0.4"), splits.get(0).fallbackHosts());
+        assertEquals(List.of("10.0.0.2", "10.0.0.3", "10.0.0.4"), splits.get(0).replicaHosts());
+    }
+
+    /**
+     * Snapshot-mode restriction (issue #2241 × #2227): a fallback is only usable if its host also
+     * has the snapshot. The snapshot is created on exactly {@code distinctReplicaHosts} (each
+     * range's primary), so a fallback that is not a primary of any range is dropped in snapshot
+     * mode but kept in live mode.
+     */
+    @Test
+    void snapshotModeRestrictsFallbacksToSnapshotHosts() {
+        var resp = new TokenRangeReplicasResponse(
+                List.of(),
+                List.of(
+                        // 10.0.0.9 owns range A but is never a primary → not a snapshot host.
+                        range("-100", "0", Map.of("dc1", List.of("10.0.0.2:7000", "10.0.0.9:7000"))),
+                        range("0", "100", Map.of("dc1", List.of("10.0.0.2:7000")))));
+
+        var snap = CqliteFlightSplitManager.buildSplits(
+                TABLE, resp, "dc1", 8815, java.util.Optional.of("cqlite-q1"));
+        // Range A primary 10.0.0.2; its only other owner 10.0.0.9 has no snapshot → no fallback.
+        assertEquals("10.0.0.2", snap.get(0).host());
+        assertEquals(List.of(), snap.get(0).fallbackHosts(), "non-snapshot host dropped as fallback");
+
+        // Live mode keeps 10.0.0.9 as a fallback (all owners eligible).
+        var live = CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815);
+        assertEquals(List.of("10.0.0.9"), live.get(0).fallbackHosts());
+    }
+
+    /**
+     * In snapshot mode a fallback that IS a primary of another range (hence a snapshot host) is
+     * kept — availability failover still works across ranges' primaries.
+     */
+    @Test
+    void snapshotModeKeepsFallbackThatIsAnotherRangesPrimary() {
+        var resp = new TokenRangeReplicasResponse(
+                List.of(),
+                List.of(
+                        range("-100", "0", Map.of("dc1", List.of("10.0.0.2:7000", "10.0.0.3:7000"))),
+                        range("0", "100", Map.of("dc1", List.of("10.0.0.3:7000")))));
+
+        var snap = CqliteFlightSplitManager.buildSplits(
+                TABLE, resp, "dc1", 8815, java.util.Optional.of("cqlite-q1"));
+        // 10.0.0.3 is range B's primary → a snapshot host → kept as range A's fallback.
+        assertEquals("10.0.0.2", snap.get(0).host());
+        assertEquals(List.of("10.0.0.3"), snap.get(0).fallbackHosts());
+    }
+
+    /**
+     * {@code orderedReplicaHosts} prefers local-DC owners (sorted), then every other DC's owners
+     * (sorted), mapping to bare hosts and de-duplicating in order. The first entry matches
+     * {@link CqliteFlightSplitManager#pickReplica}.
+     */
+    @Test
+    void orderedReplicaHostsPrefersLocalDcThenOthers() {
+        Map<String, List<String>> byDc = Map.of(
+                "dc1", List.of("10.0.1.5:7000", "10.0.1.2:7000"),
+                "dc2", List.of("10.0.2.9:7000"));
+
+        assertEquals(
+                List.of("10.0.1.2", "10.0.1.5", "10.0.2.9"),
+                CqliteFlightSplitManager.orderedReplicaHosts(byDc, "dc1"));
+        assertEquals(
+                "10.0.1.2",
+                CqliteFlightSplitManager.pickReplica(byDc, "dc1").split(":")[0],
+                "ordered head equals pickReplica");
+    }
 }

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ReplicaFailoverTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ReplicaFailoverTest.java
@@ -1,0 +1,48 @@
+package in.mcfad.cqlite.flight;
+
+import org.apache.arrow.flight.CallStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The failover-eligibility predicate (issue #2241): only connection-establishment/UNAVAILABLE
+ * failures are safe to retry on another replica; every other status (and non-Flight errors) is
+ * fatal at the call site.
+ */
+class ReplicaFailoverTest {
+
+    @Test
+    void unavailableIsConnectClass() {
+        assertTrue(ReplicaFailover.isConnectClass(
+                CallStatus.UNAVAILABLE.withDescription("connection refused").toRuntimeException()));
+    }
+
+    @Test
+    void notFoundIsNotConnectClass() {
+        // A responding endpoint that lacks the snapshot/table is NOT an availability failure —
+        // retrying elsewhere would mask a real error.
+        assertFalse(ReplicaFailover.isConnectClass(
+                CallStatus.NOT_FOUND.withDescription("no such table").toRuntimeException()));
+    }
+
+    @Test
+    void internalIsNotConnectClass() {
+        assertFalse(ReplicaFailover.isConnectClass(
+                CallStatus.INTERNAL.withDescription("server bug").toRuntimeException()));
+    }
+
+    @Test
+    void plainRuntimeExceptionIsNotConnectClass() {
+        assertFalse(ReplicaFailover.isConnectClass(new IllegalStateException("boom")));
+    }
+
+    @Test
+    void wrappedUnavailableCauseIsConnectClass() {
+        // The client rethrows runtime exceptions and wraps checked ones; the status can be nested.
+        RuntimeException wrapped = new IllegalStateException(
+                "openStream failed", CallStatus.UNAVAILABLE.toRuntimeException());
+        assertTrue(ReplicaFailover.isConnectClass(wrapped));
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerTest.java
@@ -172,6 +172,67 @@ class SnapshotManagerTest {
     }
 
     /**
+     * {@code availableHosts} (issue #2241): best-effort creates on every candidate host and
+     * returns the subset that succeeded — creating snapshots for hosts that were never
+     * {@code snapshotFor}'s required set (e.g. a fallback-only host that is never any range's
+     * primary), fixing the roborev finding that fallback restriction was primaries-only.
+     */
+    @Test
+    void availableHostsCreatesSnapshotOnEveryCandidateAndReturnsAllOnSuccess() {
+        FakeSidecars fake = new FakeSidecars();
+        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.of("6h"));
+
+        Set<String> available = mgr.availableHosts("q1", "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
+
+        assertEquals(Set.of("10.0.0.2", "10.0.0.9"), available);
+        assertEquals(List.of("10.0.0.2|ks.t/cqlite-q1/ttl=6h", "10.0.0.9|ks.t/cqlite-q1/ttl=6h"),
+                fake.creates.stream().sorted().toList());
+    }
+
+    /**
+     * A host whose creation fails is excluded from the returned set but does NOT propagate —
+     * unlike {@link SnapshotManager#snapshotFor}, this call never fails closed. Loud (fail-closed)
+     * behavior is reserved for REQUIRED (primary) hosts via {@code snapshotFor}.
+     */
+    @Test
+    void availableHostsExcludesFailedHostWithoutThrowing() {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failCreateHosts = Set.of("10.0.0.9");
+        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
+
+        Set<String> available = mgr.availableHosts("q1", "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
+
+        assertEquals(Set.of("10.0.0.2"), available, "the failed host is excluded, not propagated");
+    }
+
+    /**
+     * A host already created via {@code snapshotFor} (e.g. a range's primary, required and
+     * fail-closed) resolves instantly through {@code availableHosts} without a duplicate PUT —
+     * the memoized per-(query, host, keyspace, table) future is shared between both call paths.
+     */
+    @Test
+    void availableHostsReusesAlreadyCreatedSnapshotWithoutDuplicatePut() {
+        FakeSidecars fake = new FakeSidecars();
+        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
+
+        mgr.snapshotFor("q1", "ks", "t", List.of("10.0.0.2")); // required (primary) create
+        Set<String> available = mgr.availableHosts("q1", "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
+
+        assertEquals(Set.of("10.0.0.2", "10.0.0.9"), available);
+        assertEquals(1, fake.creates.stream().filter(c -> c.startsWith("10.0.0.2|")).count(),
+                "the already-created primary host is not PUT again");
+    }
+
+    @Test
+    void liveModeAvailableHostsReturnsAllCandidatesWithoutTouchingSidecar() {
+        FakeSidecars fake = new FakeSidecars();
+        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.LIVE, Optional.empty());
+
+        assertEquals(Set.of("h1", "h2"), mgr.availableHosts("q1", "ks", "t", List.of("h1", "h2")));
+        assertTrue(fake.creates.isEmpty(), "live mode touches no Sidecar");
+    }
+
+    /**
      * Concurrent callers for the same (query, host, keyspace, table) must PUT exactly once,
      * even while the (slow) create is in flight. The per-key-future memoization (issue #2113
      * / N5) moves the network call off the ConcurrentHashMap bin lock but keeps exactly-once


### PR DESCRIPTION
Closes #2241

## What (Epic AM #2226, splits lane F4 — availability, not correctness)

**Defect**: `pickReplica` pinned each range to exactly one replica; a single down Flight endpoint failed the whole query even when other replicas own the range.

**Fix**:
- `CqliteFlightSplit` carries an ordered replica-host list (primary = existing `pickReplica` choice, then the range's other owners, local-DC first); JSON round-trip covered.
- Shared `ReplicaFailoverStream`: ordered-host retry on connect-class/UNAVAILABLE failures ONLY, ONLY before the first batch of a range's stream. Once data is delivered, no retry (a mid-stream retry could duplicate rows). All hosts down → loud failure — never a silent empty/partial result.
- Both paths wired: `CqliteFlightPageSource` (scans) and `CqliteFlightAggregatePageSource` (aggregate finalize fan-out).
- Snapshot-mode constraint (coordinates with #2227): per-host snapshot creation now fans out to the FULL union of replica owners (`SnapshotManager.availableHosts()`, best-effort per fallback host, memoized); fallbacks are restricted to hosts whose snapshot exists. Primary snapshot failure still fails closed (#2227 semantics unchanged).

## Verification

- `./gradlew test`: 282 tests, 0 failures (+28 vs base across the three rounds).
- Review-first: roborev jobs 1574 (snapshot fan-out gap → fixed), 1575 (aggregate path gap → fixed), 1576 **clean**.
- New test files: `CqliteFlightSplitFallbackTest`, `ReplicaFailoverTest`, `CqliteFlightPageSourceFailoverTest`, `CqliteFlightAggregatePageSourceFailoverTest`, `CqliteFlightSplitManagerSnapshotFailoverTest`, + `SnapshotManagerTest` additions.

## Notes

- Test-only dependency added: `jackson-datatype-jdk8` in `trino-connector/build.gradle.kts` (Optional-aware split JSON round-trip); no runtime dependency, no new config knobs.