### PR TITLE
fix(#2257): legacy QueryExecutor drops NaN under Gt/Gte/Lt/Lte WHERE predicates

### DIFF
--- a/cqlite-core/src/query/executor.rs
+++ b/cqlite-core/src/query/executor.rs
@@ -634,24 +634,32 @@ impl QueryExecutor {
     /// sibling of the Trino-pushdown fix #2231).
     ///
     /// Returns `Ok(None)` — SQL UNKNOWN, so the caller DROPS the row — when
-    /// either operand is a NaN float. It delegates to the SHARED, principled
-    /// predicate comparator `value_ops::try_compare_values_predicate` (the same
-    /// one #2231 introduced), which drops NaN and compares large integers
-    /// exactly (`i128`, no `f64` collapse). On `Err` (genuinely incomparable
-    /// operands, e.g. `Null` vs a value, or two disjoint non-numeric types) it
-    /// falls back to this path's own [`Self::compare_values`], preserving the
-    /// legacy executor's established `Null`-vs-value ordering and its
-    /// same-type/incomparable-type error semantics — the fix is scoped to the
-    /// NaN-predicate leak only, exactly like #2231.
+    /// either operand is a NaN float (issue #2257, the legacy-executor sibling
+    /// of the Trino-pushdown fix #2231). Otherwise delegates to
+    /// [`Self::compare_values`] UNCHANGED.
+    ///
+    /// Deliberately does NOT route through `value_ops::try_compare_values_predicate`
+    /// for the non-NaN case: that shared helper also does cross-numeric
+    /// coercion (`Integer` vs `BigInt`/`Float` via `as_f64`, exact `i128` for
+    /// integrals) that this legacy path has never had — `compare_values` only
+    /// matches identical variants and `Err`s on any cross-numeric pair. Since
+    /// WHERE-clause literals commonly parse as `Value::Integer` regardless of
+    /// the column's actual CQL type, falling through to that coercion would
+    /// silently turn a previously-hard-`Err` query into a successful (and
+    /// unvalidated against real Cassandra semantics) comparison — a functional
+    /// widening this issue does not ask for. The fix is scoped to EXACTLY the
+    /// NaN-predicate leak: same-type/incomparable-type error semantics and
+    /// `Null`-vs-value ordering are untouched.
     ///
     /// This is for filter/`WHERE` evaluation ONLY. ORDER BY / sort
     /// ([`Self::apply_sort_step`]) still uses [`Self::compare_values`] directly,
     /// keeping the Cassandra NaN-greatest total order unchanged.
     fn predicate_ordering(&self, a: &Value, b: &Value) -> Result<Option<Ordering>> {
-        match crate::query::select_executor::value_ops::try_compare_values_predicate(a, b) {
-            Ok(ordering) => Ok(ordering),
-            Err(_) => self.compare_values(a, b).map(Some),
+        use crate::query::select_executor::value_ops::is_nan_value;
+        if is_nan_value(a) || is_nan_value(b) {
+            return Ok(None);
         }
+        self.compare_values(a, b).map(Some)
     }
 
     /// Compare two values
@@ -1113,6 +1121,44 @@ mod tests {
             Some(Ordering::Less),
             "Null < value ordering preserved (legacy semantics)"
         );
+    }
+
+    /// Issue #2257 review-first finding (roborev/rust-reviewer, converging):
+    /// `predicate_ordering` must NOT widen this legacy path's comparison
+    /// semantics beyond the NaN-predicate fix. `compare_values` never coerced
+    /// cross-numeric variants (`Integer` vs `BigInt`/`Float`) — it `Err`s for
+    /// any pair that isn't identical-variant, `Null`, or a same-type numeric —
+    /// and WHERE-clause literals commonly parse as `Value::Integer` regardless
+    /// of the column's real CQL type, so this is a live case, not a corner.
+    /// `predicate_ordering` must reproduce that exact `Err`, never silently
+    /// coerce via the broader `value_ops` predicate comparator.
+    #[tokio::test]
+    async fn predicate_ordering_still_errs_on_cross_numeric_pairs() {
+        let (_tmp, executor, _) = make_executor().await;
+
+        // Integer vs BigInt: pinned pre-#2257 behavior is a hard error, not a
+        // silently-coerced numeric comparison.
+        assert!(executor
+            .predicate_ordering(&Value::Integer(5), &Value::BigInt(5))
+            .is_err());
+        // Integer vs Float: same — no coercion, must error exactly like
+        // `compare_values` always did.
+        assert!(executor
+            .predicate_ordering(&Value::Integer(5), &Value::Float(5.0))
+            .is_err());
+
+        // The identical pairs behave the same via evaluate_condition's `>`
+        // arm: a query-execution error surfaces, it is not silently satisfied
+        // or silently dropped.
+        let mut m = HashMap::new();
+        m.insert("bigcol".to_string(), Value::Integer(5));
+        let row = QueryRow::with_values(RowKey::new(vec![1]), m);
+        let cond = Condition {
+            column: "bigcol".to_string(),
+            operator: ComparisonOperator::GreaterThan,
+            value: Value::BigInt(3),
+        };
+        assert!(executor.evaluate_condition(&row, &cond).is_err());
     }
 
     // -- indexes_used access-path reporting (issue #760, Epic #756) --------

--- a/cqlite-core/src/query/executor.rs
+++ b/cqlite-core/src/query/executor.rs
@@ -603,22 +603,18 @@ impl QueryExecutor {
         match condition.operator {
             ComparisonOperator::Equal => Ok(row_value == &condition.value),
             ComparisonOperator::NotEqual => Ok(row_value != &condition.value),
-            ComparisonOperator::LessThan => Ok(matches!(
-                self.compare_values(row_value, &condition.value)?,
-                Ordering::Less
-            )),
-            ComparisonOperator::LessThanOrEqual => Ok(matches!(
-                self.compare_values(row_value, &condition.value)?,
-                Ordering::Less | Ordering::Equal
-            )),
-            ComparisonOperator::GreaterThan => Ok(matches!(
-                self.compare_values(row_value, &condition.value)?,
-                Ordering::Greater
-            )),
-            ComparisonOperator::GreaterThanOrEqual => Ok(matches!(
-                self.compare_values(row_value, &condition.value)?,
-                Ordering::Greater | Ordering::Equal
-            )),
+            ComparisonOperator::LessThan => Ok(self
+                .predicate_ordering(row_value, &condition.value)?
+                .is_some_and(|o| o == Ordering::Less)),
+            ComparisonOperator::LessThanOrEqual => Ok(self
+                .predicate_ordering(row_value, &condition.value)?
+                .is_some_and(|o| matches!(o, Ordering::Less | Ordering::Equal))),
+            ComparisonOperator::GreaterThan => Ok(self
+                .predicate_ordering(row_value, &condition.value)?
+                .is_some_and(|o| o == Ordering::Greater)),
+            ComparisonOperator::GreaterThanOrEqual => Ok(self
+                .predicate_ordering(row_value, &condition.value)?
+                .is_some_and(|o| matches!(o, Ordering::Greater | Ordering::Equal))),
             // Simplified IN / NOT IN: treat as equality / inequality for now.
             ComparisonOperator::In => Ok(row_value == &condition.value),
             ComparisonOperator::NotIn => Ok(row_value != &condition.value),
@@ -630,6 +626,31 @@ impl QueryExecutor {
                 (Value::Text(row_text), Value::Text(pattern)) => Ok(!row_text.contains(pattern)),
                 _ => Ok(true),
             },
+        }
+    }
+
+    /// Ordering for WHERE-predicate inequalities (`<`, `<=`, `>`, `>=`), with
+    /// SQL three-valued logic for IEEE NaN (issue #2257 — the legacy-executor
+    /// sibling of the Trino-pushdown fix #2231).
+    ///
+    /// Returns `Ok(None)` — SQL UNKNOWN, so the caller DROPS the row — when
+    /// either operand is a NaN float. It delegates to the SHARED, principled
+    /// predicate comparator `value_ops::try_compare_values_predicate` (the same
+    /// one #2231 introduced), which drops NaN and compares large integers
+    /// exactly (`i128`, no `f64` collapse). On `Err` (genuinely incomparable
+    /// operands, e.g. `Null` vs a value, or two disjoint non-numeric types) it
+    /// falls back to this path's own [`Self::compare_values`], preserving the
+    /// legacy executor's established `Null`-vs-value ordering and its
+    /// same-type/incomparable-type error semantics — the fix is scoped to the
+    /// NaN-predicate leak only, exactly like #2231.
+    ///
+    /// This is for filter/`WHERE` evaluation ONLY. ORDER BY / sort
+    /// ([`Self::apply_sort_step`]) still uses [`Self::compare_values`] directly,
+    /// keeping the Cassandra NaN-greatest total order unchanged.
+    fn predicate_ordering(&self, a: &Value, b: &Value) -> Result<Option<Ordering>> {
+        match crate::query::select_executor::value_ops::try_compare_values_predicate(a, b) {
+            Ok(ordering) => Ok(ordering),
+            Err(_) => self.compare_values(a, b).map(Some),
         }
     }
 
@@ -960,6 +981,138 @@ mod tests {
             value: Value::Text("test".to_string()),
         };
         assert!(executor.evaluate_condition(&row, &condition).unwrap());
+    }
+
+    /// Issue #2257 (legacy-executor sibling of #2231): a NaN `double`/`float`
+    /// must NOT satisfy `>`/`>=`/`<`/`<=` under WHERE-predicate evaluation.
+    /// Historically `Gt`/`Gte` leaked the NaN row because `compare_values`
+    /// (correctly) sorts NaN as the GREATEST value for ORDER BY. All four
+    /// inequalities must now drop it; `=` was already false for NaN.
+    #[tokio::test]
+    async fn evaluate_condition_drops_nan_for_all_relations() {
+        let (_tmp, executor, _) = make_executor().await;
+
+        let row_of = |v: Value| {
+            let mut m = HashMap::new();
+            m.insert("d".to_string(), v);
+            QueryRow::with_values(RowKey::new(vec![1]), m)
+        };
+        let cond = |op: ComparisonOperator, v: Value| Condition {
+            column: "d".to_string(),
+            operator: op,
+            value: v,
+        };
+
+        for nan in [Value::Float(f64::NAN), Value::Float32(f32::NAN)] {
+            let bound = match nan {
+                Value::Float(_) => Value::Float(1.5),
+                _ => Value::Float32(1.5),
+            };
+            let row = row_of(nan.clone());
+            use ComparisonOperator::*;
+            for op in [
+                GreaterThan,
+                GreaterThanOrEqual,
+                LessThan,
+                LessThanOrEqual,
+                Equal,
+            ] {
+                assert!(
+                    !executor
+                        .evaluate_condition(&row, &cond(op.clone(), bound.clone()))
+                        .unwrap(),
+                    "NaN must not satisfy {:?} (issue #2257)",
+                    op
+                );
+            }
+
+            // Finite operands still evaluate normally on the same path.
+            let two = match nan {
+                Value::Float(_) => Value::Float(2.0),
+                _ => Value::Float32(2.0),
+            };
+            let finite_row = row_of(two);
+            assert!(executor
+                .evaluate_condition(
+                    &finite_row,
+                    &cond(ComparisonOperator::GreaterThan, bound.clone())
+                )
+                .unwrap());
+            assert!(!executor
+                .evaluate_condition(&finite_row, &cond(ComparisonOperator::LessThan, bound))
+                .unwrap());
+        }
+    }
+
+    /// Issue #2257 end-to-end (within the live legacy path): a filter step of
+    /// `d > 1.5` — the reachable-from-`engine.rs` entry point routes through
+    /// `execute()` → `apply_execution_steps` → `apply_filter_step` →
+    /// `evaluate_condition` — must DROP the `d = NaN` row and keep the finite
+    /// `d = 2.0` row. This is the `d > 1.5 OR name = 'zzz'` repro's load-bearing
+    /// conjunct (the OR is combined above this per-condition evaluator).
+    #[tokio::test]
+    async fn apply_filter_step_drops_nan_row_for_gt() {
+        use super::super::planner::{ParallelizationInfo, StepType};
+        let (_tmp, executor, _) = make_executor().await;
+
+        let mk = |d: f64| {
+            let mut m = HashMap::new();
+            m.insert("d".to_string(), Value::Float(d));
+            m.insert("name".to_string(), Value::Text("aaa".to_string()));
+            QueryRow::with_values(RowKey::new(vec![1]), m)
+        };
+        let rows = vec![mk(f64::NAN), mk(2.0), mk(0.5)];
+
+        let step = ExecutionStep {
+            step_type: StepType::Filter,
+            columns: Vec::new(),
+            conditions: vec![Condition {
+                column: "d".to_string(),
+                operator: ComparisonOperator::GreaterThan,
+                value: Value::Float(1.5),
+            }],
+            cost: 0.0,
+            parallelization: ParallelizationInfo {
+                can_parallelize: false,
+                suggested_threads: 1,
+                partition_key: None,
+            },
+        };
+
+        let out = executor.apply_filter_step(rows, &step).unwrap();
+        // Only the finite 2.0 row survives: NaN dropped (was leaked pre-fix),
+        // 0.5 correctly excluded by `> 1.5`.
+        assert_eq!(out.len(), 1, "only d=2.0 survives d > 1.5");
+        assert!(matches!(out[0].values.get("d"), Some(Value::Float(x)) if *x == 2.0));
+    }
+
+    /// Issue #2257 guardrail: the ORDER BY / sort comparator (`compare_values`,
+    /// used by `apply_sort_step`) must be UNCHANGED — NaN still sorts GREATEST.
+    /// The predicate fix is scoped to WHERE evaluation only.
+    #[tokio::test]
+    async fn sort_order_nan_greatest_unchanged() {
+        let (_tmp, executor, _) = make_executor().await;
+        assert_eq!(
+            executor
+                .compare_values(&Value::Float(f64::NAN), &Value::Float(1.5))
+                .unwrap(),
+            Ordering::Greater,
+            "sort order still puts NaN last (unchanged by #2257)"
+        );
+        // But the predicate helper drops it.
+        assert!(executor
+            .predicate_ordering(&Value::Float(f64::NAN), &Value::Float(1.5))
+            .unwrap()
+            .is_none());
+        // Null-vs-value ordering is preserved via the compare_values fallback
+        // (predicate helper must not regress it to an error/Equal).
+        assert_eq!(
+            executor
+                .predicate_ordering(&Value::Null, &Value::Integer(5))
+                .unwrap(),
+            Some(Ordering::Less),
+            "Null < value ordering preserved (legacy semantics)"
+        );
     }
 
     // -- indexes_used access-path reporting (issue #760, Epic #756) --------

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -49,7 +49,7 @@ mod row_build;
 mod schemaless_point;
 mod stream_agg;
 mod streaming;
-mod value_ops;
+pub(in crate::query) mod value_ops;
 mod writetime_ttl;
 
 #[cfg(test)]

--- a/cqlite-core/src/query/select_executor/value_ops.rs
+++ b/cqlite-core/src/query/select_executor/value_ops.rs
@@ -58,7 +58,7 @@ pub(super) fn as_integral_i128(v: &Value) -> Option<i128> {
 /// NaN operand is UNKNOWN, so the row is dropped (issue #2231). Only the `float`
 /// variants can be NaN — integral types never are, so this is principled, not a
 /// bit-pattern heuristic.
-pub(super) fn is_nan_value(v: &Value) -> bool {
+pub(in crate::query) fn is_nan_value(v: &Value) -> bool {
     match v {
         Value::Float(x) => x.is_nan(),
         Value::Float32(x) => x.is_nan(),
@@ -133,7 +133,7 @@ pub(super) fn try_compare_values(a: &Value, b: &Value) -> Result<std::cmp::Order
 /// ORDER BY / MIN / MAX / clustering-key ordering, which must keep the
 /// NaN-greatest total order and existing f64-based numeric ordering
 /// (`try_compare_values`/`compare_values_ordering`, unchanged).
-pub(in crate::query) fn try_compare_values_predicate(
+pub(super) fn try_compare_values_predicate(
     a: &Value,
     b: &Value,
 ) -> Result<Option<std::cmp::Ordering>> {

--- a/cqlite-core/src/query/select_executor/value_ops.rs
+++ b/cqlite-core/src/query/select_executor/value_ops.rs
@@ -133,7 +133,7 @@ pub(super) fn try_compare_values(a: &Value, b: &Value) -> Result<std::cmp::Order
 /// ORDER BY / MIN / MAX / clustering-key ordering, which must keep the
 /// NaN-greatest total order and existing f64-based numeric ordering
 /// (`try_compare_values`/`compare_values_ordering`, unchanged).
-pub(super) fn try_compare_values_predicate(
+pub(in crate::query) fn try_compare_values_predicate(
     a: &Value,
     b: &Value,
 ) -> Result<Option<std::cmp::Ordering>> {


### PR DESCRIPTION
Closes #2257

## Summary
Issue #2231 fixed a NaN-under-Gt/Gte predicate-evaluation bug in the Trino pushdown path
(`select_executor::value_ops`) — a NaN operand incorrectly satisfied `>`/`>=` because the comparator
used Cassandra's NaN-greatest total order (meant for sorting), not SQL three-valued UNKNOWN semantics.
The identical bug existed, unfixed, in the legacy `QueryExecutor` (`executor.rs`), which is still LIVE
(reachable from `engine.rs` for some point reads) — so it's a real, user-facing divergence for direct
CQLite SELECT queries independent of Trino.

Fix: new `predicate_ordering` helper in `executor.rs`, scoped strictly to the NaN case (checks
`is_nan_value` on both operands, drops the row via `Ok(None)` for either being NaN) and delegates to the
existing `self.compare_values` UNCHANGED for every other case. `Equal`/`NotEqual` were already NaN-safe
(native `==`). `apply_sort_step`/ORDER BY untouched — NaN-greatest total order preserved there.

## Review history (review-first, before any full gate)
- Round 1 (roborev Medium + `rust-reviewer`, converging independently): the initial approach routed
  through the shared `value_ops::try_compare_values_predicate`, which ALSO does cross-numeric coercion
  (`Integer` vs `BigInt`/`Float`) that legacy `compare_values` never had — silently turning previously
  hard-`Err`ing comparisons into coerced successes. Undocumented, untested scope creep beyond the NaN
  fix. Fixed by tightening `predicate_ordering` to intercept ONLY NaN and otherwise delegate to
  `compare_values` completely unchanged.
- Round 2 (re-verify): both roborev and `rust-reviewer` confirm clean — traced the control flow to
  confirm the widening is gone (cross-numeric pairs reach the original `Err` path, not the coercion
  path), confirmed the new regression test would have genuinely failed against the pre-fix code (not a
  tautology), confirmed the visibility revert breaks no other caller.

## Test plan
- [x] `evaluate_condition_drops_nan_for_all_relations` — NaN truth test across Gt/Gte/Lt/Lte/Eq
- [x] `apply_filter_step_drops_nan_row_for_gt` — end-to-end through the real live path
      (`apply_filter_step` → `evaluate_condition`), reproducing the issue's `d > 1.5 OR name = 'zzz'` shape
- [x] `sort_order_nan_greatest_unchanged` — guardrail, ORDER BY/sort semantics untouched
- [x] `predicate_ordering_still_errs_on_cross_numeric_pairs` — pins that cross-numeric-type comparisons
      still hard-`Err` exactly as before (the scope-creep this PR avoids)
- [x] `scripts/agent-gate.sh --lite` PASS at every round
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — runs once via `flow-closer`