### PR TITLE
chore(#2273): extract shared missing-vector guard, fold in batched polish nits

### DIFF
--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
@@ -57,34 +57,51 @@ public final class ArrowToTrino {
         Block[] blocks = new Block[columns.size()];
         for (int c = 0; c < columns.size(); c++) {
             CqliteFlightColumnHandle col = columns.get(c);
-            FieldVector vector = root.getVector(col.name());
-            if (vector == null) {
-                // Issue #2238: the column was requested in the projection but is absent
-                // from the delivered batch — schema drift between the connector projection
-                // and its paired CQLite Flight server response. Surface it as a clear error
-                // naming the column instead of masking it as an all-null column (which would
-                // silently hide a real correctness bug).
-                //
-                // Error-code choice (issue #2270): GENERIC_INTERNAL_ERROR is deliberate.
-                // trino-spi's StandardErrorCode exposes no EXTERNAL-category code for "a
-                // connector's data source returned a contract-violating response" (its sole
-                // EXTERNAL code is UNSUPPORTED_TABLE_TYPE); every REMOTE_* code is
-                // ErrorType.INTERNAL_ERROR denoting Trino's own worker/exchange failures and
-                // would misdirect operators toward the cluster. The Flight server is CQLite's
-                // own paired component, so a projection/response mismatch is genuinely an
-                // internal contract bug in the CQLite stack — INTERNAL_ERROR is the correct
-                // category. A connector-specific ErrorCodeSupplier would be idiomatic but is
-                // out of scope here (follow-up #2273).
-                throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
-                        "Projected column '" + col.name()
-                                + "' is missing from the delivered Arrow batch; "
-                                + "the server did not return a vector for this column "
-                                + "(schema drift between the connector projection and "
-                                + "the Flight server response)");
-            }
+            // Absent projected column (schema drift) fails loudly — see requireVector.
+            FieldVector vector = requireVector(root, col.name(), "Projected column");
             blocks[c] = toBlock(col.type(), vector, rowCount);
         }
         return new Page(rowCount, blocks);
+    }
+
+    /**
+     * Resolve a projected vector from {@code root} by column name, or fail loudly. Shared
+     * missing-column guard for both read paths — the scalar/projection scan ({@link
+     * #toPage}) and the aggregate finalize path ({@code
+     * CqliteFlightAggregatePageSource.accumulate}) — so their logic and rationale live in
+     * one place (issue #2273).
+     *
+     * <p>An absent vector means the paired CQLite Flight server did not deliver a column
+     * the connector's projection expects: schema drift between the connector projection
+     * and the server response. It is surfaced as a clear error naming the column (issues
+     * #2238, #2262) instead of masked as a silent all-null column — masking would hide a
+     * real correctness bug (a spurious all-null projected column, or a corrupted GROUP BY
+     * result set). A null CELL within a PRESENT vector is normal and handled by callers,
+     * not here. {@code contextLabel} names the column's role in the thrown message (e.g.
+     * {@code "Projected column"} vs {@code "Aggregate group-by column"} / {@code
+     * "Aggregate output column"}) so the error stays specific to its call site.
+     *
+     * <p>Error-code choice (issue #2270): {@link StandardErrorCode#GENERIC_INTERNAL_ERROR}
+     * is deliberate. trino-spi's {@code StandardErrorCode} exposes no EXTERNAL-category
+     * code that fits "a connector's data source returned a contract-violating response"
+     * (e.g. {@code UNSUPPORTED_TABLE_TYPE} does not); every {@code REMOTE_*} code is {@code
+     * ErrorType.INTERNAL_ERROR} denoting Trino's own worker/exchange failures and would
+     * misdirect operators toward the cluster. The Flight server is CQLite's own paired
+     * component, so a projection/response mismatch is genuinely an internal contract bug in
+     * the CQLite stack — INTERNAL_ERROR is the correct category. A connector-specific
+     * {@code ErrorCodeSupplier} would be idiomatic but is out of scope.
+     */
+    public static FieldVector requireVector(VectorSchemaRoot root, String column, String contextLabel) {
+        FieldVector vector = root.getVector(column);
+        if (vector == null) {
+            throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                    contextLabel + " '" + column
+                            + "' is missing from the delivered Arrow batch; "
+                            + "the server did not return a vector for this column "
+                            + "(schema drift between the connector projection and "
+                            + "the Flight server response)");
+        }
+        return vector;
     }
 
     private static Block toBlock(Type type, FieldVector vector, int rowCount) {

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowToTrino.java
@@ -91,7 +91,7 @@ public final class ArrowToTrino {
      * the CQLite stack — INTERNAL_ERROR is the correct category. A connector-specific
      * {@code ErrorCodeSupplier} would be idiomatic but is out of scope.
      */
-    public static FieldVector requireVector(VectorSchemaRoot root, String column, String contextLabel) {
+    static FieldVector requireVector(VectorSchemaRoot root, String column, String contextLabel) {
         FieldVector vector = root.getVector(column);
         if (vector == null) {
             throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSource.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSource.java
@@ -3,8 +3,6 @@ package in.mcfad.cqlite.flight;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.trino.spi.Page;
-import io.trino.spi.StandardErrorCode;
-import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -128,18 +126,18 @@ public class CqliteFlightAggregatePageSource implements ConnectorPageSource {
         List<String> groupBy = spec.groupBy();
         List<AggregationSpec.Aggregate> aggregates = spec.aggregates();
 
-        // Resolve every projected vector ONCE, up front (issue #2262). A missing vector
-        // means the Flight server did not deliver a column the connector's aggregation
-        // projection expects (schema drift) — a hard error naming the column, NOT a
-        // silently null group key / partial-aggregate value that would corrupt the
-        // GROUP BY result set undetected. Mirrors ArrowToTrino.toPage's guard (#2238).
+        // Resolve every projected vector ONCE, up front (issue #2262), via the shared
+        // missing-column guard (issue #2273) — a missing vector is a hard error naming
+        // the column, NOT a silently null group key / partial-aggregate value that would
+        // corrupt the GROUP BY result set undetected. See ArrowToTrino#requireVector for
+        // the full schema-drift + error-code rationale (shared with ArrowToTrino#toPage).
         List<FieldVector> groupVectors = new ArrayList<>(groupBy.size());
         for (String gc : groupBy) {
-            groupVectors.add(requireVector(root, gc));
+            groupVectors.add(ArrowToTrino.requireVector(root, gc, "Aggregate group-by column"));
         }
         List<FieldVector> aggregateVectors = new ArrayList<>(aggregates.size());
         for (AggregationSpec.Aggregate a : aggregates) {
-            aggregateVectors.add(requireVector(root, a.output()));
+            aggregateVectors.add(ArrowToTrino.requireVector(root, a.output(), "Aggregate output column"));
         }
 
         for (int r = 0; r < rows; r++) {
@@ -153,33 +151,6 @@ public class CqliteFlightAggregatePageSource implements ConnectorPageSource {
             }
             merger.combine(new PartialAggregateMerger.GroupKey(keyValues), partials);
         }
-    }
-
-    /**
-     * Resolve a projected group-by / aggregate-output vector, or fail loudly. An absent
-     * vector means the Flight server did not return a column the connector's aggregation
-     * projection expects (schema drift) — surfaced as a clear error naming the column
-     * (issue #2262), never masked as a silent all-null column.
-     */
-    private static FieldVector requireVector(VectorSchemaRoot root, String column) {
-        FieldVector vector = root.getVector(column);
-        if (vector == null) {
-            // Error-code choice (issue #2270, mirrors ArrowToTrino#toPage): GENERIC_INTERNAL_ERROR
-            // is deliberate. trino-spi's StandardErrorCode has no EXTERNAL-category code for "a
-            // connector's data source returned a contract-violating response"; the REMOTE_* codes
-            // are all ErrorType.INTERNAL_ERROR for Trino's own worker/exchange failures and would
-            // misdirect operators. The Flight server is CQLite's own paired component, so an
-            // aggregation projection/response mismatch is genuinely an internal contract bug in the
-            // CQLite stack — INTERNAL_ERROR is the correct category. A shared connector-specific
-            // ErrorCodeSupplier is out of scope here (follow-up #2273).
-            throw new TrinoException(StandardErrorCode.GENERIC_INTERNAL_ERROR,
-                    "Aggregate/group-by column '" + column
-                            + "' is missing from the delivered Arrow batch; "
-                            + "the server did not return a vector for this column "
-                            + "(schema drift between the connector aggregation "
-                            + "projection and the Flight server response)");
-        }
-        return vector;
     }
 
     /** Build the single output page, one block per requested column. */

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
@@ -11,6 +11,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -315,10 +316,11 @@ class ArrowToTrinoTest {
     }
 
     @Test
-    void projectedColumnMissingBeforePresentVectorsRaisesNamingTheColumn() {
-        // Issue #2270: the missing column is projected FIRST/MIDDLE relative to the
-        // present vectors — the guard must fire on the by-name lookup regardless of
-        // projection position, not only when the absent column happens to be last.
+    void projectedColumnMissingFirstRaisesNamingTheColumn() {
+        // Issue #2270: the missing column is projected FIRST, before the present vectors
+        // — the guard must fire on the by-name lookup regardless of projection position,
+        // not only when the absent column happens to be last. (Middle position is covered
+        // by projectedColumnMissingInMiddleRaisesNamingTheColumn.)
         try (BufferAllocator allocator = new RootAllocator()) {
             IntVector id = new IntVector("id", allocator);
             BigIntVector big = new BigIntVector("big", allocator);
@@ -330,10 +332,41 @@ class ArrowToTrinoTest {
             var root = new VectorSchemaRoot(List.of(id, big));
             root.setRowCount(1);
 
-            // "missing_col" is projected FIRST, between/before delivered vectors.
+            // "missing_col" is projected FIRST, before the delivered vectors.
             var columns = List.of(
                     new CqliteFlightColumnHandle("missing_col", VarcharType.VARCHAR),
                     new CqliteFlightColumnHandle("id", IntegerType.INTEGER),
+                    new CqliteFlightColumnHandle("big", BigintType.BIGINT));
+
+            TrinoException ex = assertThrows(TrinoException.class,
+                    () -> ArrowToTrino.toPage(root, columns));
+            assertTrue(ex.getMessage().contains("missing_col"),
+                    "error must name the missing column, was: " + ex.getMessage());
+
+            root.close();
+        }
+    }
+
+    @Test
+    void projectedColumnMissingInMiddleRaisesNamingTheColumn() {
+        // Issue #2270: the missing column is projected in the MIDDLE, between two present
+        // vectors — the guard must still fire on the by-name lookup, and toPage must not
+        // silently emit an all-null block for it.
+        try (BufferAllocator allocator = new RootAllocator()) {
+            IntVector id = new IntVector("id", allocator);
+            BigIntVector big = new BigIntVector("big", allocator);
+            id.allocateNew(1);
+            big.allocateNew(1);
+            id.set(0, 10);
+            big.set(0, 100L);
+
+            var root = new VectorSchemaRoot(List.of(id, big));
+            root.setRowCount(1);
+
+            // "missing_col" is projected in the MIDDLE, between the delivered vectors.
+            var columns = List.of(
+                    new CqliteFlightColumnHandle("id", IntegerType.INTEGER),
+                    new CqliteFlightColumnHandle("missing_col", VarcharType.VARCHAR),
                     new CqliteFlightColumnHandle("big", BigintType.BIGINT));
 
             TrinoException ex = assertThrows(TrinoException.class,
@@ -351,7 +384,7 @@ class ArrowToTrinoTest {
         // projection must fail loudly (the first projected column is absent), never
         // silently produce all-null blocks.
         try (BufferAllocator allocator = new RootAllocator()) {
-            var root = new VectorSchemaRoot(List.<org.apache.arrow.vector.FieldVector>of());
+            var root = new VectorSchemaRoot(List.<FieldVector>of());
             root.setRowCount(0);
 
             var columns = List.of(

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowToTrinoTest.java
@@ -1,6 +1,7 @@
 package in.mcfad.cqlite.flight;
 
 import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.BooleanType;
@@ -16,7 +17,6 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import io.trino.spi.TrinoException;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceTest.java
@@ -110,8 +110,8 @@ class CqliteFlightAggregatePageSourceTest {
 
     /**
      * Issue #2262: a projected group-by column absent from the delivered Arrow batch
-     * (schema drift between the connector aggregation projection and the Flight server
-     * response) must surface a clear error NAMING the column via the real
+     * (schema drift between the connector projection and the Flight server response)
+     * must surface a clear error NAMING the column via the real
      * {@link CqliteFlightAggregatePageSource#accumulate} path — not silently produce
      * null group keys (a corrupted GROUP BY result set). Mirrors #2238's toPage guard.
      */

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightAggregatePageSourceTest.java
@@ -10,6 +10,7 @@ import io.trino.spi.type.TimeType;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TimeNanoVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.jupiter.api.Test;
@@ -197,6 +198,30 @@ class CqliteFlightAggregatePageSourceTest {
                     "sum of a single null partial stays null (no regression)");
             root.close();
         }
+    }
+
+    /**
+     * Issue #2273 (mirrors {@code ArrowToTrinoTest.emptyBatchWithNonEmptyProjectionRaisesNamingTheFirstColumn}):
+     * a {@link VectorSchemaRoot} with ZERO vectors against a non-empty aggregation
+     * projection must fail loudly via the now-shared {@link ArrowToTrino#requireVector}
+     * guard — the first projected group-by column is absent — never silently accumulate
+     * null group keys.
+     */
+    @Test
+    void emptyBatchWithNonEmptyAggregationRaisesNamingTheFirstColumn() {
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Count, null, "agg0"));
+        var spec = new AggregationSpec(List.of("gc"), aggregates);
+        var merger = new PartialAggregateMerger(aggregates);
+
+        VectorSchemaRoot root = new VectorSchemaRoot(List.<FieldVector>of());
+        root.setRowCount(0);
+
+        TrinoException ex = assertThrows(TrinoException.class,
+                () -> CqliteFlightAggregatePageSource.accumulate(root, spec, merger));
+        assertTrue(ex.getMessage().contains("gc"),
+                "error must name the missing group-by column, was: " + ex.getMessage());
+        root.close();
     }
 
     /** Mirror {@code accumulate()}: read one Arrow batch's group + count columns into the merger. */


### PR DESCRIPTION
Closes #2273

## Summary
DRY extraction follow-up from #2262/#2270's reviews: `ArrowToTrino.toPage` and
`CqliteFlightAggregatePageSource.requireVector` had near-duplicated missing-projected-vector guards
(same null-check, same `TrinoException`/`GENERIC_INTERNAL_ERROR`, near-identical justification
comments). Consolidated into one package-private `ArrowToTrino.requireVector(root, column,
contextLabel)`, called from both classes with call-site-specific context labels ("Projected column" /
"Aggregate group-by column" / "Aggregate output column" — the group-by-vs-output distinction is
preserved, not collapsed). The full rationale for keeping `GENERIC_INTERNAL_ERROR` now lives once, in
the shared helper's Javadoc.

Also folds in 6 previously-batched Low-severity nits from #2262/#2270's review-first passes: import
style, a mirrored empty-batch test on the aggregate side, splitting a dishonest "FIRST/MIDDLE" comment
into two genuine tests, softening a brittle SPI-enum claim, and (this PR's own review-first round)
dropping unnecessary `public` visibility + a stale doc comment + an import-order nit.

Pure refactor + test additions — no behavior change to the missing-vector detection semantics anywhere.

## Review history (review-first, before any full gate)
- Round 1 (roborev + rust-reviewer): clean/merge-with-followups. Both independently flagged the same
  visibility nit (`requireVector` was `public`, only needs package-private) plus two more cosmetic nits
  (a stale doc comment, a misordered import).
- Fixed all 3 inline rather than spawning another follow-up issue — this Trino polish cluster
  (#2238 → #2262/#2270 → #2273) had recursed enough.
- Round 2 (quick roborev confirmation on the mechanical fix — visibility keyword, comment text, import
  order; skipped a second full re-review given the trivial, easily-verified nature of the diff): clean.

## Test plan
- [x] `ArrowToTrinoTest` 18/18, `CqliteFlightAggregatePageSourceTest` 7/7 (both new tests genuine —
      exercise the real shared guard, not mocks)
- [x] Full `trino-connector` gradle suite green
- [x] `scripts/agent-gate.sh --lite` PASS (no Rust files touched)
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — runs once via `flow-closer`