### PR TITLE
fix(#2264): make do_get backpressure cancellation-aware — producer no longer parks forever on client cancel (P1)

### DIFF
--- a/cqlite-flight/Cargo.toml
+++ b/cqlite-flight/Cargo.toml
@@ -19,6 +19,10 @@ arrow = { workspace = true, features = ["ipc"] }
 arrow-flight = "53"
 tonic = "0.12"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "time", "signal"] }
+# `CancellationToken` — an async-wakeable cooperative-cancellation signal so the
+# `do_get` merge producer's backpressure park (`ChannelSink::emit`) can race a
+# client disconnect instead of blocking forever in `blocking_send` (issue #2264).
+tokio-util = "0.7"
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/cqlite-flight/src/cancel.rs
+++ b/cqlite-flight/src/cancel.rs
@@ -13,17 +13,24 @@
 //! cancels its flag on `Drop` unless disarmed, so holding the guard inside the
 //! `do_get` future makes a future-drop (client disconnect) cancel the in-flight
 //! merge deterministically.
+//!
+//! Backing (issue #2264): the flag wraps a [`tokio_util::sync::CancellationToken`]
+//! rather than a bare `AtomicBool`. The polling API ([`CancelFlag::is_cancelled`])
+//! is unchanged for the between-step merge checks, but the token additionally
+//! exposes an ASYNC-WAKEABLE [`CancelFlag::cancelled`] future. The streaming sink
+//! races that future against the bounded-channel backpressure send
+//! (`ChannelSink::emit`), so a client disconnect wakes a producer otherwise parked
+//! forever in `blocking_send` — a bare `AtomicBool` has no waker and could only be
+//! observed between merge steps, never while blocked in a full channel.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 
 /// A cheap, cloneable cooperative-cancellation flag.
 ///
-/// All clones share one atomic, so cancelling any clone is observed by the
-/// merge loop polling another. `Relaxed` ordering is sufficient: this is a
-/// best-effort "stop soon" signal, not a lock guarding other memory.
+/// All clones share one [`CancellationToken`], so cancelling any clone is observed
+/// by the merge loop polling another AND wakes anyone awaiting [`Self::cancelled`].
 #[derive(Clone, Debug, Default)]
-pub struct CancelFlag(Arc<AtomicBool>);
+pub struct CancelFlag(CancellationToken);
 
 impl CancelFlag {
     /// Create a fresh, un-cancelled flag.
@@ -33,12 +40,24 @@ impl CancelFlag {
 
     /// Request cancellation. Idempotent.
     pub fn cancel(&self) {
-        self.0.store(true, Ordering::Relaxed);
+        self.0.cancel();
     }
 
-    /// Whether cancellation has been requested.
+    /// Whether cancellation has been requested. This is the between-step polling
+    /// API the merge loop uses; unchanged in semantics from the `AtomicBool`.
     pub fn is_cancelled(&self) -> bool {
-        self.0.load(Ordering::Relaxed)
+        self.0.is_cancelled()
+    }
+
+    /// An owned future that resolves when this flag is cancelled (issue #2264).
+    ///
+    /// Used by the streaming sink to race a client disconnect against a blocked
+    /// backpressure send, so a producer parked in `blocking_send` on a full
+    /// channel is woken by the cancellation rather than blocking forever. Owned
+    /// (not borrowed) so it can be moved into a `tokio::select!` on a blocking
+    /// thread's local runtime handle without borrowing `self`.
+    pub fn cancelled(&self) -> WaitForCancellationFutureOwned {
+        self.0.clone().cancelled_owned()
     }
 
     /// Arm a [`CancelGuard`] that cancels this flag when dropped (unless

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -340,6 +340,17 @@ fn method_attr(method: &'static str) -> (&'static str, AttrValue) {
     (catalog::attr::RPC_METHOD, AttrValue::StaticStr(method))
 }
 
+/// Read the current process-wide in-flight RPC level for `method` (issue #2264).
+///
+/// Exposes the same shared per-method counter that drives the `cqlite.rpc.in_flight`
+/// gauge, so an end-to-end test can assert that a `do_get` whose client stopped
+/// reading and disconnected releases its RPC accounting (the level returns to its
+/// pre-RPC baseline). Unknown method names resolve to the bounded catch-all slot
+/// (never panics), matching [`RpcMetrics::start`].
+pub fn in_flight_level(method: &str) -> i64 {
+    IN_FLIGHT[method_index(method)].load(Ordering::Relaxed)
+}
+
 /// Record an RPC failure into the error-rate signal (`cqlite.errors.total`,
 /// subsystem `flight`), emit a `tracing` log line, and mark the active span
 /// errored.

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -120,17 +120,50 @@ pub(crate) struct StreamProbe {
 struct ChannelSink {
     tx: mpsc::Sender<Result<RecordBatch, ProducerError>>,
     produced: Arc<AtomicUsize>,
+    /// The SAME cancel flag threaded through the merge (issue #2264). The
+    /// backpressure send below races this flag's async cancellation, so a client
+    /// disconnect wakes a producer otherwise parked forever in a full channel.
+    cancel: CancelFlag,
 }
 
 impl BatchSink for ChannelSink {
     fn emit(&mut self, batch: RecordBatch) -> Result<(), ProducerError> {
         self.produced.fetch_add(1, Ordering::Relaxed);
-        // `blocking_send` applies backpressure: it parks this blocking-pool thread
-        // while the channel is full, so the merge never runs ahead of the consumer
-        // by more than the channel capacity. `Err` == receiver dropped == cancel.
-        self.tx
-            .blocking_send(Ok(batch))
-            .map_err(|_| ProducerError::Cancelled)
+        // Cancellation-aware backpressure (issue #2264). `reserve()` still applies
+        // backpressure — it only resolves once the bounded channel has a free slot,
+        // so the merge never runs ahead of the consumer by more than the channel
+        // capacity. But unlike a bare `blocking_send` (which wakes ONLY on a freed
+        // permit or a dropped receiver, never on the cancel flag), this races the
+        // reservation against the flag's async cancellation. When a client
+        // disconnects mid-stream while the channel is full — the exact case where
+        // tonic/h2 may not promptly drop the receiver — the cancel arm fires and the
+        // producer stops instead of pinning a blocking-pool thread forever.
+        //
+        // `emit` runs on a `spawn_blocking` thread, which carries the runtime handle
+        // in TLS; `Handle::block_on` there is permitted (it is a blocking thread, not
+        // an async worker) and drives the `select!` to completion.
+        let handle = tokio::runtime::Handle::current();
+        let cancelled = self.cancel.cancelled();
+        handle.block_on(async {
+            tokio::select! {
+                // Bias the send arm so a ready permit is taken deterministically
+                // even if cancellation fires in the same poll — a batch that CAN be
+                // delivered without blocking is, keeping normal-path behaviour and
+                // the stream/collect byte-parity identical.
+                biased;
+                permit = self.tx.reserve() => match permit {
+                    // Receiver still present: deliver this batch.
+                    Ok(permit) => {
+                        permit.send(Ok(batch));
+                        Ok(())
+                    }
+                    // Receiver dropped (client gone): stop the merge.
+                    Err(_) => Err(ProducerError::Cancelled),
+                },
+                // Client disconnected while we were parked waiting for a slot.
+                _ = cancelled => Err(ProducerError::Cancelled),
+            }
+        })
     }
 }
 
@@ -204,6 +237,9 @@ pub(crate) fn spawn_streaming(
     // (client disconnect); `blocking_send` failure is the second, independent stop
     // signal. AA3 machinery (#1473) is reused, not replaced.
     let guard = cancel.drop_guard();
+    // Clone for the sink's cancellation-aware backpressure race (issue #2264); the
+    // remaining clone drives the between-step merge polling.
+    let sink_cancel = cancel.clone();
     let merge_cancel = cancel;
     let produced = probe.produced_batches.clone();
     // The incremental scan-progress seam (issue #2162) is threaded into the merge
@@ -216,7 +252,11 @@ pub(crate) fn spawn_streaming(
     // inside the closure catch_unwind guards, and unwinding drops it.
     let handle = tokio::task::spawn_blocking(move || {
         let error_tx = tx.clone();
-        let mut sink = ChannelSink { tx, produced };
+        let mut sink = ChannelSink {
+            tx,
+            produced,
+            cancel: sink_cancel,
+        };
         run_merge_catching_panics(&error_tx, move || {
             // `timer` enters `do_get` already in the `merge_setup` phase (the
             // caller transitioned `resolve` → `merge_setup` before spawning). The
@@ -233,7 +273,19 @@ pub(crate) fn spawn_streaming(
     });
 
     let inner = Box::pin(ReceiverStream { rx });
-    let metered = MeteredDoGetStream::new(inner, metrics, Some(guard), probe.clone());
+    // Belt-and-suspenders (issue #2264): hand the merge task's `AbortHandle` to the
+    // response stream so dropping it (client disconnect) also aborts the detached
+    // `spawn_blocking` at its next await point. The cancellation-aware send above
+    // is the core fix (abort alone cannot unpark a `blocking_send`); this is
+    // defense-in-depth for a task that has since moved past its send. The
+    // `JoinHandle` is still returned so tests await completion deterministically.
+    let metered = MeteredDoGetStream::new(
+        inner,
+        metrics,
+        Some(guard),
+        probe.clone(),
+        Some(handle.abort_handle()),
+    );
     (encode_do_get(metered, schema_ref, probe), handle)
 }
 
@@ -280,7 +332,7 @@ pub(crate) async fn build_aggregate_response(
 
     let iter = futures::stream::iter(batches.into_iter().map(Ok::<_, ProducerError>));
     let probe = StreamProbe::default();
-    let metered = MeteredDoGetStream::new(Box::pin(iter), metrics, None, probe.clone());
+    let metered = MeteredDoGetStream::new(Box::pin(iter), metrics, None, probe.clone(), None);
     Ok(encode_do_get(metered, schema_ref, probe))
 }
 
@@ -373,6 +425,10 @@ struct MeteredDoGetStream {
     /// Cancels the merge on drop unless disarmed; `None` for the aggregate route
     /// (already materialized — nothing to cancel).
     guard: Option<CancelGuard>,
+    /// Aborts the detached merge `spawn_blocking` task on Drop (issue #2264),
+    /// defense-in-depth beyond the cancellation-aware send + `CancelGuard`. `None`
+    /// for the aggregate route (already materialized — nothing to abort).
+    abort: Option<tokio::task::AbortHandle>,
     probe: StreamProbe,
     rows: u64,
     bytes: u64,
@@ -396,11 +452,13 @@ impl MeteredDoGetStream {
         metrics: RpcMetrics,
         guard: Option<CancelGuard>,
         probe: StreamProbe,
+        abort: Option<tokio::task::AbortHandle>,
     ) -> Self {
         Self {
             inner,
             metrics: Some(metrics),
             guard,
+            abort,
             probe,
             rows: 0,
             bytes: 0,
@@ -533,6 +591,16 @@ impl Drop for MeteredDoGetStream {
         // after this fn body runs). `finalize` is idempotent, so a stream that
         // already ended normally records nothing more here.
         self.finalize(false);
+
+        // Belt-and-suspenders (issue #2264): abort the detached merge task at its
+        // next await point. The cancellation-aware send is what actually unparks a
+        // producer blocked in the full channel (abort cannot interrupt a blocking
+        // `reserve`/send synchronously); this covers a task that has moved past its
+        // send but not yet observed the between-step cancel poll. Harmless for a
+        // task that already completed (abort of a finished task is a no-op).
+        if let Some(abort) = self.abort.take() {
+            abort.abort();
+        }
     }
 }
 

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -184,9 +184,19 @@ where
 {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(run)) {
         Ok(Ok(())) => {}
+        Ok(Err(ProducerError::Cancelled)) => {
+            // Do NOT forward a terminal `Cancelled` (issue #2264): cancellation
+            // means the client/receiver is already departing, so a `Cancelled`
+            // status has no value to deliver — and a bare, cancel-unaware
+            // `blocking_send` of it would park forever if this send raced ahead of
+            // the receiver's drop. Skipping it here makes liveness EXPLICIT rather
+            // than resting on `MeteredDoGetStream`'s implicit field-drop order (rx
+            // before guard), which a future field reorder could silently break.
+        }
         Ok(Err(e)) => {
-            // Forward a terminal error to the client (matches delta_scan error
-            // forwarding). Ignored if the receiver is already gone (client left).
+            // Forward a genuine terminal error to the client (matches delta_scan
+            // error forwarding). This applies normal bounded backpressure and
+            // resolves on read/disconnect; ignored if the receiver is already gone.
             let _ = tx.blocking_send(Err(e));
         }
         Err(payload) => {

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -255,7 +255,8 @@ fn do_get_stream_surfaces_panic_as_internal_status_not_eof() {
         );
         let inner = Box::pin(ReceiverStream { rx });
         let pr = probe();
-        let metered = MeteredDoGetStream::new(inner, RpcMetrics::start("do_get"), None, pr.clone());
+        let metered =
+            MeteredDoGetStream::new(inner, RpcMetrics::start("do_get"), None, pr.clone(), None);
         let mut stream = encode_do_get(metered, schema_ref, pr.clone());
 
         // First message is the schema; the panic must arrive as an `Err` Status
@@ -388,10 +389,12 @@ fn stream_batches_raw(producer: MergeProducer, paths: Vec<PathBuf>) -> Vec<Recor
         let (tx, mut rx) =
             mpsc::channel::<Result<RecordBatch, ProducerError>>(DO_GET_CHANNEL_CAPACITY);
         let cancel = CancelFlag::new();
+        let sink_cancel = cancel.clone();
         let handle = tokio::task::spawn_blocking(move || {
             let mut sink = ChannelSink {
                 tx,
                 produced: Arc::new(AtomicUsize::new(0)),
+                cancel: sink_cancel,
             };
             if let Err(e) = producer.produce_streaming(
                 paths,
@@ -918,6 +921,69 @@ fn count_value(batch: &RecordBatch) -> i64 {
         .downcast_ref::<arrow::array::Int64Array>()
         .expect("count is Int64")
         .value(0)
+}
+
+/// **Issue #2264 core regression.** `ChannelSink::emit` parked in the bounded
+/// channel (a full channel whose Receiver is kept ALIVE, so no send failure fires)
+/// must be UNPARKED by the shared cancel flag — the exact forever-park the bug
+/// filed. Fill the single-slot channel, spawn the merge sink `emit` on a blocking
+/// thread where it must park in `reserve()`, then cancel the flag. Within 3s the
+/// emit must return `Err(ProducerError::Cancelled)`.
+///
+/// FAILS on the pre-fix `emit` (bare `tx.blocking_send`): `blocking_send` wakes
+/// ONLY on a freed permit or a dropped receiver, NEVER on the cancel flag, so with
+/// the receiver held alive the task parks forever and this times out. PASSES after
+/// the fix because `emit` races `reserve()` against `cancel.cancelled()`.
+#[test]
+fn channel_sink_emit_unparks_on_cancel_when_receiver_alive() {
+    let schema = simple_schema();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        // Cap 1 so a single pre-filled batch fills the channel; keep `_rx` bound so
+        // the channel never closes (the send can only be released by cancellation).
+        let (tx, _rx) = mpsc::channel::<Result<RecordBatch, ProducerError>>(1);
+        let cancel = CancelFlag::new();
+
+        // A minimal 1-row batch matching `simple_schema`'s Arrow schema.
+        let batch = {
+            let producer = MergeProducer::new(schema.clone(), 1).unwrap();
+            let arrow_schema = Arc::new(producer.arrow_schema().unwrap());
+            let ncols = arrow_schema.fields().len();
+            let cols: Vec<arrow::array::ArrayRef> = arrow_schema
+                .fields()
+                .iter()
+                .map(|f| arrow::array::new_null_array(f.data_type(), 1))
+                .collect();
+            assert_eq!(cols.len(), ncols);
+            RecordBatch::try_new(arrow_schema, cols).unwrap()
+        };
+
+        // Fill the single slot so the sink's next emit must park in `reserve()`.
+        tx.send(Ok(batch.clone())).await.unwrap();
+
+        let sink_cancel = cancel.clone();
+        let emit_task = tokio::task::spawn_blocking(move || {
+            let mut sink = ChannelSink {
+                tx,
+                produced: Arc::new(AtomicUsize::new(0)),
+                cancel: sink_cancel,
+            };
+            sink.emit(batch)
+        });
+
+        // Let the emit park waiting for a permit, then cancel (client disconnect).
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        cancel.cancel();
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(3), emit_task).await;
+        let joined = outcome.expect("emit must return within 3s once cancelled, not park forever");
+        match joined.expect("emit task joins") {
+            Err(ProducerError::Cancelled) => {}
+            other => {
+                panic!("cancelled emit under backpressure must return Cancelled, got {other:?}")
+            }
+        }
+    });
 }
 
 /// A cancelled stream (one batch read, then dropped) attributes exactly the

--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -460,6 +460,159 @@ fn do_get_over_transport_reads_live_set_not_snapshot() {
     );
 }
 
+// ---- Issue #2264: a client that stops reading mid-stream must release the
+// ---- do_get merge producer (no forever-parked blocking_send under backpressure).
+
+/// Open a `do_get` response over the real transport, read `read_batches`
+/// batches, then DROP the client stream (and the whole client + channel) without
+/// draining it. Returns once the stream is dropped, leaving the server to observe
+/// the client disconnect. The server task is left running so the test can then
+/// observe the server-side in-flight accounting settle.
+async fn do_get_drop_after(
+    svc: CqliteFlightService,
+    ticket: Vec<u8>,
+    read_batches: usize,
+) -> tokio::task::JoinHandle<Result<(), tonic::transport::Error>> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from_listener(listener, true, None).unwrap();
+
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(FlightServiceServer::new(svc))
+            .serve_with_incoming(incoming)
+            .await
+    });
+
+    let endpoint = Channel::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect_timeout(Duration::from_secs(5));
+    let mut channel = None;
+    for _ in 0..50 {
+        if let Ok(c) = endpoint.connect().await {
+            channel = Some(c);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let channel = channel.expect("connect");
+
+    let mut client = FlightServiceClient::new(channel);
+    let resp = client
+        .do_get(Ticket::new(ticket))
+        .await
+        .expect("do_get rpc");
+    let stream = resp.into_inner().map(|r| r.map_err(FlightError::Tonic));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+
+    let mut read = 0usize;
+    while read < read_batches {
+        match rb.next().await {
+            Some(Ok(_batch)) => read += 1,
+            // Fewer batches than requested arrived before EOF/err — still a valid
+            // "client stops early" scenario; proceed to drop.
+            _ => break,
+        }
+    }
+    // Client stops reading and disconnects: drop the decode stream, the client,
+    // and the whole gRPC channel WITHOUT draining the remaining batches.
+    drop(rb);
+    drop(client);
+    server
+}
+
+/// Poll the process-wide `cqlite.rpc.in_flight` level for `do_get` until it drops
+/// to `<= baseline` or `timeout` elapses. Returns the final observed level.
+async fn await_in_flight_settled(baseline: i64, timeout: Duration) -> i64 {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let level = cqlite_flight::obs::in_flight_level("do_get");
+        if level <= baseline {
+            return level;
+        }
+        if std::time::Instant::now() >= deadline {
+            return level;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// **Issue #2264 repro (backpressure).** A multi-SSTable fixture with far more
+/// rows than the 4-slot `do_get` channel can hold, served with a tiny batch size
+/// so the merge producer fills the channel and PARKS in `blocking_send` while the
+/// client is still reading. The client reads two batches then DROPS the stream
+/// without draining. Within 5s the server-side `do_get` in-flight accounting must
+/// return to its pre-RPC baseline — proving the parked producer was released and
+/// the RPC did not leak.
+///
+/// On the UNFIXED code the merge producer parks forever in `tx.blocking_send`
+/// (which never polls the cancel flag), pinning a blocking-pool thread and
+/// holding the RPC accounting, so the in-flight level never returns to baseline
+/// and this times out.
+#[test]
+fn do_get_client_drop_midstream_releases_producer_under_backpressure() {
+    // batch_size = 1 → one row per batch; 200 rows across 2 SSTables produce far
+    // more batches than the 4-slot channel, so the producer must park in
+    // blocking_send after the client stops reading.
+    let total = 200usize;
+    let (_temp, data_dir) = build_multi_sstable_fixture(total);
+    let ticket = serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+    }))
+    .unwrap();
+
+    let svc = CqliteFlightService::new(data_dir, 1);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let baseline = cqlite_flight::obs::in_flight_level("do_get");
+        let server = do_get_drop_after(svc, ticket, 2).await;
+        let level = await_in_flight_settled(baseline, Duration::from_secs(5)).await;
+        assert!(
+            level <= baseline,
+            "do_get in-flight level must return to its {baseline} baseline within 5s after the \
+             client stops reading under backpressure (got {level}); a higher level means the \
+             merge producer is still parked in blocking_send"
+        );
+        server.abort();
+    });
+}
+
+/// **Issue #2264 repro (LIMIT-shaped).** A `LIMIT`-carrying ticket over a
+/// multi-SSTable fixture (the shape Trino issues, which stops reading once the
+/// limit is satisfied): the client reads one batch, satisfies its interest, and
+/// drops the stream. The server-side `do_get` in-flight accounting must return to
+/// baseline within 5s. Same forever-park failure mode on the unfixed code.
+#[test]
+fn do_get_limit_ticket_completes_promptly_after_client_stops_reading() {
+    let total = 200usize;
+    let (_temp, data_dir) = build_multi_sstable_fixture(total);
+    // A LIMIT larger than the channel but smaller than the table, so the producer
+    // still fills the channel and parks before the (capped) merge finishes.
+    let ticket = serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+        "limit": 50u64,
+    }))
+    .unwrap();
+
+    let svc = CqliteFlightService::new(data_dir, 1);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let baseline = cqlite_flight::obs::in_flight_level("do_get");
+        let server = do_get_drop_after(svc, ticket, 1).await;
+        let level = await_in_flight_settled(baseline, Duration::from_secs(5)).await;
+        assert!(
+            level <= baseline,
+            "LIMIT do_get in-flight level must return to its {baseline} baseline within 5s after \
+             the client stops reading (got {level})"
+        );
+        server.abort();
+    });
+}
+
 /// Flush `n` distinct rows into a fresh single-SSTable fixture and return its
 /// data dir. Like [`build_fixture`] but with a caller-chosen row count so two
 /// fixtures can carry disambiguating counts.


### PR DESCRIPTION
Closes #2264. Part of Epic AM (#2226). **P1** — prime suspect for the #2157 round-4 field LIMIT hang.

## Defect (code-verified)
When a Flight client (Trino) cancels/stops reading a `do_get` stream mid-flight (LIMIT queries do by design), the merge producer could park FOREVER in `tx.blocking_send(Ok(batch))` into the cap-4 channel. `blocking_send` wakes only on a freed permit / receiver drop — never on `CancelFlag` (a bare `AtomicBool`, no waker). The merge task is a detached `spawn_blocking` (can't abort). → producer pinned on a blocking thread, all tokio workers sleep, `cqlite_rpc_in_flight` leaks.

## Fix — cancellation-aware backpressure
- `cancel.rs`: `CancelFlag` now wraps `tokio_util::sync::CancellationToken`; `is_cancelled()` polling API unchanged (pre-step checks untouched); added async-wakeable `cancelled()`.
- `streaming.rs`: `ChannelSink::emit` races `tx.reserve()` vs `cancel.cancelled()` via `Handle::block_on` + biased `select!` — the token wakes the parked send. Token threaded through `spawn_streaming`. Belt-and-suspenders: `AbortHandle` retained in `MeteredDoGetStream`, aborted on Drop.
- Terminal-error forwarding (`run_merge_catching_panics`): explicitly skips forwarding `Cancelled` (departing receiver) so liveness no longer depends on `MeteredDoGetStream` field-drop order; genuine terminal errors unchanged.

## Review-first (rigorous — P1 concurrency)
- rust-reviewer: APPROVE — parked send genuinely unblocked (token fired by `CancelGuard::drop`); no nested-runtime panic (emit only on spawn_blocking threads); normal-path byte-identical; wiring-evidence acceptable.
- roborev: flagged a possible residual park at the terminal-error forward (High). Investigation determined it was unreachable (field-drop order closes rx before cancel fires) — but the guarantee was implicit, so hardened it explicit (skip forwarding Cancelled). roborev re-confirm (job 3861): No issues found.

## Tests (TDD)
`channel_sink_emit_unparks_on_cancel_when_receiver_alive` (cap-1 channel, receiver held alive, slot pre-filled so emit truly parks) — written FIRST, observed to FAIL/timeout on the unfixed bare-`blocking_send`, passes post-fix. This is the faithful deterministic repro of the exact mechanism. Two transport-level repros added as end-to-end regression coverage (they're green pre+post-fix because tonic drops the Receiver promptly over loopback — documented honestly). All 172 cqlite-flight tests green, existing normal-path + cooperative-cancel tests unmodified.

Guardrails honored: `DO_GET_CHANNEL_CAPACITY` + backpressure design unchanged; no unwrap/expect in library code. Unblocks #2157's owner-requested live field re-run (#2157 stays open until that field verdict).