### PR TITLE
test(#2283): cqlite-flight golden fixture hardening — shared fixture + honest metadata-order caveat

### DIFF
--- a/cqlite-flight/examples/emit_arrow_golden.rs
+++ b/cqlite-flight/examples/emit_arrow_golden.rs
@@ -48,19 +48,14 @@ use cqlite_core::storage::write_engine::{
 use cqlite_core::types::Value;
 
 use cqlite_flight::producer::{DirSource, MergeProducer};
+// The field-shape `keyvalue` fixture (schema/rows/mutations/batch size) is the
+// single source of truth shared with `tests/do_get_transport_test.rs` so the
+// golden this example emits and the wire bytes that test byte-compares against it
+// can never drift apart (issue #2283).
+use cqlite_flight::test_fixtures as fx;
 
 const KS: &str = "golden_ks";
 const TBL: &str = "all_scalars";
-
-/// The FIELD failure shape (issue #2193): the cassandra-easy-stress `keyvalue`
-/// table — a text partition key + a single text value column, no clustering key.
-/// This is the exact header-extracted `nb` shape the round-3/4 field run fails on.
-const FIELD_KS: &str = "cassandra_easy_stress";
-const FIELD_TBL: &str = "keyvalue";
-/// The 3 rows the field `tiny` table holds; values pinned so the Java decode
-/// assertion can hard-code them. Row order in the output is the server's token
-/// order, so the Java side asserts the value SET, not positional order.
-const FIELD_ROWS: [(&str, &str); 3] = [("k1", "1"), ("k2", "2"), ("k3", "3")];
 
 /// A partition-keyed table with one column of every supported scalar CQL type.
 /// PK is `id int`; the rest are regular columns so a single mutation can write a
@@ -197,51 +192,6 @@ fn mutations() -> Vec<Mutation> {
     vec![full, nulls]
 }
 
-/// The field-shape `keyvalue` schema (issue #2193): `key text` partition key +
-/// `value text` regular column, no clustering key.
-fn field_schema() -> TableSchema {
-    let col = |name: &str, nullable: bool| Column {
-        name: name.into(),
-        data_type: "text".into(),
-        nullable,
-        default: None,
-        is_static: false,
-    };
-    TableSchema {
-        keyspace: FIELD_KS.into(),
-        table: FIELD_TBL.into(),
-        partition_keys: vec![KeyColumn {
-            name: "key".into(),
-            data_type: "text".into(),
-            position: 0,
-        }],
-        clustering_keys: vec![],
-        columns: vec![col("key", false), col("value", true)],
-        comments: HashMap::new(),
-        dropped_columns: HashMap::new(),
-    }
-}
-
-/// One `Write` mutation per field row: partition key `key`, regular column `value`.
-fn field_mutations() -> Vec<Mutation> {
-    FIELD_ROWS
-        .iter()
-        .map(|(key, value)| {
-            Mutation::new(
-                TableId::new(FIELD_KS, FIELD_TBL),
-                PartitionKey::single("key", Value::Text((*key).into())),
-                None,
-                vec![CellOperation::Write {
-                    column: "value".into(),
-                    value: Value::Text((*value).into()),
-                }],
-                100,
-                None,
-            )
-        })
-        .collect()
-}
-
 /// Flush `mutations` into a fresh single-SSTable write-engine fixture under a
 /// temp dir; return the temp handle (kept alive by the caller) and the data dir.
 fn build_fixture(
@@ -304,24 +254,24 @@ fn emit_arrows_golden(out: &Path) -> Result<(), Box<dyn std::error::Error>> {
 /// .build(batch_stream)`), then length-delimits the resulting protobuf
 /// `FlightData` messages so arrow-java can split and Flight-decode them.
 fn emit_flightdata_golden(out: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = field_schema();
-    let (_temp, data_dir) = build_fixture(&schema, field_mutations())?;
+    let schema = fx::keyvalue_schema();
+    let (_temp, data_dir) = build_fixture(&schema, fx::keyvalue_mutations())?;
 
     // Same producer + wire schema (carrying the `cqlite:pushdown` field metadata)
-    // the server's `do_get` uses. `batch_size = 8192` matches BOTH the field
+    // the server's `do_get` uses. `KEYVALUE_BATCH_SIZE` matches BOTH the field
     // flight image AND `do_get_transport_test.rs`'s `CqliteFlightService::new`
     // batch size, so a future larger fixture's batch boundaries stay aligned
     // with what the golden and the real-transport pin actually exercise.
-    let producer = MergeProducer::new(schema, 8192)?;
+    let producer = MergeProducer::new(schema, fx::KEYVALUE_BATCH_SIZE)?;
     let wire_schema = Arc::new(producer.arrow_schema()?);
-    let table_dir = data_dir.join(FIELD_KS).join(FIELD_TBL);
+    let table_dir = data_dir.join(fx::KEYVALUE_KS).join(fx::KEYVALUE_TBL);
     let batches = producer.produce(&DirSource::new(table_dir))?;
 
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-    if total_rows != FIELD_ROWS.len() {
+    if total_rows != fx::KEYVALUE_ROWS.len() {
         return Err(format!(
             "expected {} field fixture rows, got {total_rows}",
-            FIELD_ROWS.len()
+            fx::KEYVALUE_ROWS.len()
         )
         .into());
     }

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -19,6 +19,15 @@ pub mod service;
 pub mod shutdown;
 pub mod stats;
 pub mod streaming;
+
+// Shared field-shape fixture (issue #2283): the single source of truth for the
+// `cassandra_easy_stress.keyvalue` shape used by BOTH the golden emitter example
+// and the transport byte-pin test. `#[doc(hidden)]` keeps it out of the public
+// docs; it must be `pub` (not `pub(crate)`) because both callers are separate
+// crates linked against this library.
+#[doc(hidden)]
+pub mod test_fixtures;
+
 pub mod ticket;
 
 #[cfg(test)]

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -437,25 +437,24 @@ impl MergeProducer {
                     .as_ref()
                     .map(pushdown_capability)
                     .unwrap_or("none");
-                // Assemble in a BTreeMap for deterministic ASSEMBLY order. NOTE:
-                // this does NOT guarantee final WIRE order — `Field::with_metadata`
-                // re-collects into its own HashMap before IPC serialization, and
-                // arrow-ipc's `metadata_to_fb` iterates that HashMap unsorted
-                // (confirmed against arrow-schema/arrow-ipc 53.4.1 source). So this
-                // BTreeMap step has NO observable effect on wire bytes today, for
-                // ANY field, regardless of entry count — it's a placeholder pending
-                // #2285's real fix (a canonicalization pass at the wire boundary, or
-                // upstream arrow-rs sorting). It's harmless for the `keyvalue`
-                // byte-pin golden specifically because those columns carry exactly
-                // one metadata entry each (order-trivial), but schemas with
-                // extension-typed columns (e.g. uuid: `ARROW:extension:name` +
-                // `cqlite:pushdown`, 2 entries — see `all_scalars`'s `c_uuid`
-                // column) are NOT covered by that trivial case, and their wire
-                // order is genuinely hash-seed-dependent until #2285 lands.
-                let mut metadata: std::collections::BTreeMap<String, String> =
-                    field.metadata().clone().into_iter().collect();
+                // NOTE on metadata ORDER (not addressed here — see #2285): the
+                // final WIRE order of this `HashMap`'s entries is NOT guaranteed
+                // stable across process runs once a field carries >= 2 metadata
+                // entries, since `Field::with_metadata` stores a `HashMap` as-is
+                // and arrow-ipc's `metadata_to_fb` iterates it unsorted
+                // (confirmed against arrow-schema/arrow-ipc 53.4.1 source) — a
+                // sort/canonicalization pass would need to happen at the actual
+                // wire boundary (or upstream in arrow-rs), not here, so no such
+                // pass is attempted in this function. Harmless for the
+                // `keyvalue` byte-pin golden specifically because those columns
+                // carry exactly one metadata entry each (order-trivial), but
+                // schemas with extension-typed columns (e.g. uuid:
+                // `ARROW:extension:name` + `cqlite:pushdown`, 2 entries — see
+                // `all_scalars`'s `c_uuid` column) are NOT covered by that
+                // trivial case, and their wire order is genuinely
+                // hash-seed-dependent until #2285 lands.
+                let mut metadata = field.metadata().clone();
                 metadata.insert("cqlite:pushdown".to_string(), capability.to_string());
-                let metadata: std::collections::HashMap<_, _> = metadata.into_iter().collect();
                 field.as_ref().clone().with_metadata(metadata)
             })
             .collect();

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -437,8 +437,13 @@ impl MergeProducer {
                     .as_ref()
                     .map(pushdown_capability)
                     .unwrap_or("none");
-                let mut metadata = field.metadata().clone();
+                // Assemble metadata in a BTreeMap so key order is canonical and
+                // independent of the per-process HashMap hasher seed as fixtures
+                // gain >1 entry (issue #2283); `with_metadata` takes a HashMap.
+                let mut metadata: std::collections::BTreeMap<String, String> =
+                    field.metadata().clone().into_iter().collect();
                 metadata.insert("cqlite:pushdown".to_string(), capability.to_string());
+                let metadata: std::collections::HashMap<_, _> = metadata.into_iter().collect();
                 field.as_ref().clone().with_metadata(metadata)
             })
             .collect();

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -437,9 +437,13 @@ impl MergeProducer {
                     .as_ref()
                     .map(pushdown_capability)
                     .unwrap_or("none");
-                // Assemble metadata in a BTreeMap so key order is canonical and
-                // independent of the per-process HashMap hasher seed as fixtures
-                // gain >1 entry (issue #2283); `with_metadata` takes a HashMap.
+                // Assemble in a BTreeMap for deterministic ASSEMBLY order — NOTE:
+                // this does NOT guarantee final wire order for fields with >= 2
+                // metadata keys, since arrow_schema::Field::with_metadata
+                // re-collects into its own HashMap before IPC serialization
+                // (arrow-ipc's metadata_to_fb iterates that HashMap unsorted).
+                // Safe today only because every field here carries exactly one
+                // metadata entry (order-trivial). See #2285 for the real fix.
                 let mut metadata: std::collections::BTreeMap<String, String> =
                     field.metadata().clone().into_iter().collect();
                 metadata.insert("cqlite:pushdown".to_string(), capability.to_string());

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -437,13 +437,21 @@ impl MergeProducer {
                     .as_ref()
                     .map(pushdown_capability)
                     .unwrap_or("none");
-                // Assemble in a BTreeMap for deterministic ASSEMBLY order — NOTE:
-                // this does NOT guarantee final wire order for fields with >= 2
-                // metadata keys, since arrow_schema::Field::with_metadata
-                // re-collects into its own HashMap before IPC serialization
-                // (arrow-ipc's metadata_to_fb iterates that HashMap unsorted).
-                // Safe today only because every field here carries exactly one
-                // metadata entry (order-trivial). See #2285 for the real fix.
+                // Assemble in a BTreeMap for deterministic ASSEMBLY order. NOTE:
+                // this does NOT guarantee final WIRE order — `Field::with_metadata`
+                // re-collects into its own HashMap before IPC serialization, and
+                // arrow-ipc's `metadata_to_fb` iterates that HashMap unsorted
+                // (confirmed against arrow-schema/arrow-ipc 53.4.1 source). So this
+                // BTreeMap step has NO observable effect on wire bytes today, for
+                // ANY field, regardless of entry count — it's a placeholder pending
+                // #2285's real fix (a canonicalization pass at the wire boundary, or
+                // upstream arrow-rs sorting). It's harmless for the `keyvalue`
+                // byte-pin golden specifically because those columns carry exactly
+                // one metadata entry each (order-trivial), but schemas with
+                // extension-typed columns (e.g. uuid: `ARROW:extension:name` +
+                // `cqlite:pushdown`, 2 entries — see `all_scalars`'s `c_uuid`
+                // column) are NOT covered by that trivial case, and their wire
+                // order is genuinely hash-seed-dependent until #2285 lands.
                 let mut metadata: std::collections::BTreeMap<String, String> =
                     field.metadata().clone().into_iter().collect();
                 metadata.insert("cqlite:pushdown".to_string(), capability.to_string());

--- a/cqlite-flight/src/test_fixtures.rs
+++ b/cqlite-flight/src/test_fixtures.rs
@@ -1,0 +1,98 @@
+//! Shared field-shape fixture — the single source of truth (issue #2283).
+//!
+//! The `cassandra_easy_stress.keyvalue` shape (issue #2193) is exercised by TWO
+//! independent callers that MUST stay byte-for-byte in lockstep:
+//!
+//! * `examples/emit_arrow_golden.rs` — emits the committed `keyvalue.flightdata`
+//!   golden the Java `FlightDataGoldenDecodeTest` decodes, and
+//! * `tests/do_get_transport_test.rs` — whose
+//!   `do_get_over_transport_matches_committed_golden` byte-compares the LIVE wire
+//!   bytes against that same golden.
+//!
+//! When these two definitions live apart, drift in either silently breaks (or
+//! silently "fixes") the byte-identical pin, defeating its purpose. Both callers
+//! are separate crates linked against this library, so the shared fixture has to
+//! be reachable through the public surface — a `pub(crate)` module or a
+//! `tests/common` module would NOT reach the example. It is `#[doc(hidden)]` so
+//! it stays out of the documented API while remaining callable.
+//!
+//! Only the drift-sensitive *field shape* (keyspace/table/columns, the canonical
+//! rows, timestamp, batch size, and the mutation set) lives here. The temp-dir
+//! flush plumbing stays local to each caller because it depends on `tempfile`
+//! (a dev-dependency), and is generic (schema-in, data-dir-out) rather than
+//! shape-specific.
+
+use std::collections::HashMap;
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{CellOperation, Mutation, PartitionKey, TableId};
+use cqlite_core::types::Value;
+
+/// Keyspace of the field-shape fixture (the round-3 cassandra-easy-stress run).
+pub const KEYVALUE_KS: &str = "cassandra_easy_stress";
+/// Table of the field-shape fixture.
+pub const KEYVALUE_TBL: &str = "keyvalue";
+/// The DDL the connector ticket carries for the field-shape fixture: a text
+/// partition key + a single text value column, no clustering key.
+pub const KEYVALUE_DDL: &str =
+    "CREATE TABLE cassandra_easy_stress.keyvalue (key text PRIMARY KEY, value text)";
+/// The 3 canonical `(key, value)` rows. Pinned so the Java decode assertion can
+/// hard-code them; row order in the output is the server's token order, so the
+/// Java side asserts the value SET rather than positional order.
+pub const KEYVALUE_ROWS: [(&str, &str); 3] = [("k1", "1"), ("k2", "2"), ("k3", "3")];
+/// Write timestamp for every fixture row (a fixed, deterministic value — NOT
+/// wall-clock — so the golden stays byte-stable).
+pub const KEYVALUE_TIMESTAMP: i64 = 100;
+/// Producer/service batch size. `8192` matches the field flight image so all 3
+/// rows land in one final-flush batch — the exact shape that failed in the
+/// round-3 run — and keeps the golden and the live-transport pin aligned.
+pub const KEYVALUE_BATCH_SIZE: usize = 8192;
+
+/// The field-shape `keyvalue` schema: `key text` partition key + `value text`
+/// regular column, no clustering key.
+pub fn keyvalue_schema() -> TableSchema {
+    let col = |name: &str, nullable: bool| Column {
+        name: name.into(),
+        data_type: "text".into(),
+        nullable,
+        default: None,
+        is_static: false,
+    };
+    TableSchema {
+        keyspace: KEYVALUE_KS.into(),
+        table: KEYVALUE_TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "key".into(),
+            data_type: "text".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![col("key", false), col("value", true)],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// One `Write` mutation for `(key, value)` at [`KEYVALUE_TIMESTAMP`]: partition
+/// key `key`, regular column `value`.
+pub fn keyvalue_write(key: &str, value: &str) -> Mutation {
+    Mutation::new(
+        TableId::new(KEYVALUE_KS, KEYVALUE_TBL),
+        PartitionKey::single("key", Value::Text(key.into())),
+        None,
+        vec![CellOperation::Write {
+            column: "value".into(),
+            value: Value::Text(value.into()),
+        }],
+        KEYVALUE_TIMESTAMP,
+        None,
+    )
+}
+
+/// One `Write` mutation per [`KEYVALUE_ROWS`] entry.
+pub fn keyvalue_mutations() -> Vec<Mutation> {
+    KEYVALUE_ROWS
+        .iter()
+        .map(|(key, value)| keyvalue_write(key, value))
+        .collect()
+}

--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -9,7 +9,6 @@
 //! `FlightRecordBatchStream`, so a malformed egress message surfaces the same
 //! way the Trino client saw it.
 
-use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
@@ -26,70 +25,26 @@ use prost::Message as _;
 use tonic::transport::server::TcpIncoming;
 use tonic::transport::{Channel, Server};
 
-use cqlite_core::schema::{Column, KeyColumn, TableSchema};
-use cqlite_core::storage::write_engine::{
-    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
-};
-use cqlite_core::types::Value;
+use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
 use cqlite_flight::service::CqliteFlightService;
-
-const KS: &str = "cassandra_easy_stress";
-const TBL: &str = "keyvalue";
-// The exact cassandra-easy-stress KeyValue shape from the round-3 field run:
-// a text partition key + a single text value column, no clustering key.
-const DDL: &str = "CREATE TABLE cassandra_easy_stress.keyvalue (key text PRIMARY KEY, value text)";
-
-fn simple_schema() -> TableSchema {
-    let col = |name: &str, ty: &str, nullable: bool| Column {
-        name: name.into(),
-        data_type: ty.into(),
-        nullable,
-        default: None,
-        is_static: false,
-    };
-    TableSchema {
-        keyspace: KS.into(),
-        table: TBL.into(),
-        partition_keys: vec![KeyColumn {
-            name: "key".into(),
-            data_type: "text".into(),
-            position: 0,
-        }],
-        clustering_keys: vec![],
-        columns: vec![col("key", "text", false), col("value", "text", true)],
-        comments: HashMap::new(),
-        dropped_columns: HashMap::new(),
-    }
-}
-
-fn write_row(key: &str, value: &str, ts: i64) -> Mutation {
-    Mutation::new(
-        TableId::new(KS, TBL),
-        PartitionKey::single("key", Value::Text(key.into())),
-        None,
-        vec![CellOperation::Write {
-            column: "value".into(),
-            value: Value::Text(value.into()),
-        }],
-        ts,
-        None,
-    )
-}
+// The field-shape `keyvalue` fixture (keyspace/table/DDL, columns, the canonical
+// k1/k2/k3 rows, timestamp, batch size) is the single source of truth shared with
+// `examples/emit_arrow_golden.rs`, so the committed golden this test byte-compares
+// against and the wire bytes it produces can never drift apart (issue #2283).
+use cqlite_flight::test_fixtures as fx;
 
 /// Flush the 3-row single-SSTable fixture (matching the field `tiny` table:
-/// a small flushed table that reads cleanly) and return its data dir.
+/// a small flushed table that reads cleanly) and return its data dir. Uses the
+/// SAME mutations the golden emitter flushes ([`fx::keyvalue_mutations`]) so the
+/// byte-identical golden cross-check stays honest.
 fn build_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
-    let schema = simple_schema();
+    let schema = fx::keyvalue_schema();
     let temp = tempfile::TempDir::new().unwrap();
     let data_dir = temp.path().join("data");
     let wal_dir = temp.path().join("wal");
     let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
     let mut engine = WriteEngine::new(config).expect("engine");
-    for m in [
-        write_row("k1", "1", 100),
-        write_row("k2", "2", 100),
-        write_row("k3", "3", 100),
-    ] {
+    for m in fx::keyvalue_mutations() {
         engine.write(m).expect("write");
     }
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -105,9 +60,9 @@ fn build_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
 /// would send. The server's `from_bytes` applies serde defaults for the rest.
 fn ticket_bytes() -> Vec<u8> {
     serde_json::to_vec(&serde_json::json!({
-        "keyspace": KS,
-        "table": TBL,
-        "ddl": DDL,
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
     }))
     .unwrap()
 }
@@ -389,7 +344,7 @@ fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::P
         total >= 4,
         "need enough rows to span two flushes above a cap"
     );
-    let schema = simple_schema();
+    let schema = fx::keyvalue_schema();
     let temp = tempfile::TempDir::new().unwrap();
     let data_dir = temp.path().join("data");
     let wal_dir = temp.path().join("wal");
@@ -404,7 +359,7 @@ fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::P
     // interleaves rows from both SSTables (see the doc comment above).
     for i in (0..total).step_by(2) {
         engine
-            .write(write_row(&format!("k{i:06}"), &format!("v{i}"), 100))
+            .write(fx::keyvalue_write(&format!("k{i:06}"), &format!("v{i}")))
             .expect("write");
     }
     rt.block_on(engine.flush())
@@ -412,7 +367,7 @@ fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::P
         .expect("info 1");
     for i in (1..total).step_by(2) {
         engine
-            .write(write_row(&format!("k{i:06}"), &format!("v{i}"), 100))
+            .write(fx::keyvalue_write(&format!("k{i:06}"), &format!("v{i}")))
             .expect("write");
     }
     rt.block_on(engine.flush())
@@ -421,7 +376,7 @@ fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, std::path::P
 
     // Prove the fixture really produced ≥2 SSTables — otherwise the LIMIT test
     // is not exercising the multi-SSTable early-stop it claims to.
-    let table_dir = data_dir.join(KS).join(TBL);
+    let table_dir = data_dir.join(fx::KEYVALUE_KS).join(fx::KEYVALUE_TBL);
     let data_files = std::fs::read_dir(&table_dir)
         .expect("table dir")
         .filter_map(|e| e.ok())
@@ -481,9 +436,9 @@ fn do_get_over_transport_enforces_limit() {
     let limit = 7u64;
     let (_temp, data_dir) = build_multi_sstable_fixture(total);
     let ticket = serde_json::to_vec(&serde_json::json!({
-        "keyspace": KS,
-        "table": TBL,
-        "ddl": DDL,
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
         "limit": limit,
     }))
     .unwrap();
@@ -521,9 +476,9 @@ fn do_get_over_transport_applies_predicate_and_projection() {
     // Filter on the `value` column for the row written as v3 (key k000003), and
     // project only `value` so the row-key column must be absent from the output.
     let ticket = serde_json::to_vec(&serde_json::json!({
-        "keyspace": KS,
-        "table": TBL,
-        "ddl": DDL,
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
         "columns": ["value"],
         "filter": {"type": "Compare", "column": "value", "op": "Equal", "value": "v3"},
     }))
@@ -560,20 +515,20 @@ fn do_get_over_transport_applies_predicate_and_projection() {
 fn do_get_over_transport_reads_live_set_not_snapshot() {
     // Live set: 2 rows in one SSTable.
     let (_temp_live, live_dir) = build_fixture_n(2);
-    let live_table = live_dir.join(KS).join(TBL);
+    let live_table = live_dir.join(fx::KEYVALUE_KS).join(fx::KEYVALUE_TBL);
 
     // Snapshot set: 5 rows (a distinct count) copied into snapshots/pinned/.
     let (_temp_snap, snap_dir) = build_fixture_n(5);
-    let snap_table = snap_dir.join(KS).join(TBL);
+    let snap_table = snap_dir.join(fx::KEYVALUE_KS).join(fx::KEYVALUE_TBL);
     let snapshot_dst = live_table.join("snapshots").join("pinned");
     std::fs::create_dir_all(&snapshot_dst).expect("mk snapshot dir");
     copy_sstable_components(&snap_table, &snapshot_dst);
 
     // A null-snapshot ticket (live mode).
     let ticket = serde_json::to_vec(&serde_json::json!({
-        "keyspace": KS,
-        "table": TBL,
-        "ddl": DDL,
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
     }))
     .unwrap();
 
@@ -683,9 +638,9 @@ fn do_get_client_drop_midstream_releases_producer_under_backpressure() {
     let total = 200usize;
     let (_temp, data_dir) = build_multi_sstable_fixture(total);
     let ticket = serde_json::to_vec(&serde_json::json!({
-        "keyspace": KS,
-        "table": TBL,
-        "ddl": DDL,
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
     }))
     .unwrap();
 
@@ -717,9 +672,9 @@ fn do_get_limit_ticket_completes_promptly_after_client_stops_reading() {
     // A LIMIT larger than the channel but smaller than the table, so the producer
     // still fills the channel and parks before the (capped) merge finishes.
     let ticket = serde_json::to_vec(&serde_json::json!({
-        "keyspace": KS,
-        "table": TBL,
-        "ddl": DDL,
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
         "limit": 50u64,
     }))
     .unwrap();
@@ -743,7 +698,7 @@ fn do_get_limit_ticket_completes_promptly_after_client_stops_reading() {
 /// data dir. Like [`build_fixture`] but with a caller-chosen row count so two
 /// fixtures can carry disambiguating counts.
 fn build_fixture_n(n: usize) -> (tempfile::TempDir, std::path::PathBuf) {
-    let schema = simple_schema();
+    let schema = fx::keyvalue_schema();
     let temp = tempfile::TempDir::new().unwrap();
     let data_dir = temp.path().join("data");
     let wal_dir = temp.path().join("wal");
@@ -751,7 +706,7 @@ fn build_fixture_n(n: usize) -> (tempfile::TempDir, std::path::PathBuf) {
     let mut engine = WriteEngine::new(config).expect("engine");
     for i in 0..n {
         engine
-            .write(write_row(&format!("k{i:06}"), &format!("v{i}"), 100))
+            .write(fx::keyvalue_write(&format!("k{i:06}"), &format!("v{i}")))
             .expect("write");
     }
     let rt = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
Closes #2283

## Summary
Follow-up hardening from #2193's review:
1. **Fixture duplication fixed**: extracted the shared `cassandra_easy_stress.keyvalue` field-shape
   fixture (schema, rows, timestamp, batch size, mutations) into `cqlite_flight::test_fixtures`
   (`#[doc(hidden)] pub mod`, required since the golden-emitting example and the transport test are
   separate crate targets). Both call sites migrated; no orphaned duplicate definitions remain.
2. **Metadata-ordering caveat documented honestly**: attempted a `BTreeMap` assembly step for field
   metadata determinism, but confirmed (against the pinned `arrow-schema`/`arrow-ipc` 53.4.1 source)
   that it has zero effect on final wire bytes — `Field::with_metadata` re-collects into its own
   `HashMap` before IPC serialization, and `metadata_to_fb` iterates that unsorted. Removed the inert
   round-trip; kept a precise doc comment explaining the real gap and why it's currently harmless
   (single-metadata-key fields are order-trivial) but NOT generally safe (multi-key fields like the
   `all_scalars` uuid column ARE hash-seed-dependent on the wire today).

## Review history (review-first — 4 rounds, unusually many for a small PR, all substantive)
- Round 1 (roborev + `rust-reviewer`): both independently confirmed the self-flagged caveat was real
  (traced to exact source lines) — the initial `BTreeMap` fix was a no-op for wire order.
- Round 2: comment fix attempt #1 — still overclaimed a general safety property ("every field here
  carries exactly one metadata entry") that's false for UUID-bearing schemas.
- Round 3: precise comment rewrite, scoped correctly to what's actually true (fixture-specific safety,
  not general).
- Round 4: simplification — since the `BTreeMap` round-trip does nothing, removed it as dead code
  rather than leaving a maintenance trap; final roborev pass clean.
- Follow-up **#2285** filed for the real fix (wire-boundary canonicalization or upstream arrow-rs
  sorting) plus a batched nit (`test_fixtures`'s `pub mod` compiling into production builds).

## Test plan
- [x] `do_get_over_transport_matches_committed_golden` + all 9 `cqlite-flight` transport tests green
      (confirms golden bytes genuinely unchanged throughout all 4 rounds)
- [x] `scripts/agent-gate.sh --lite` PASS at every round
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — runs once via `flow-closer`