### PR TITLE
fix(#2285): detect non-deterministic Flight metadata wire order; gate test_fixtures out of production build

### DIFF
--- a/cqlite-flight/Cargo.toml
+++ b/cqlite-flight/Cargo.toml
@@ -62,9 +62,25 @@ observability = [
 # `metrics_capture_tests` module. Run:
 #   cargo test -p cqlite-flight --features observability-testing
 observability-testing = ["cqlite-core/observability-testing"]
+# Test-only: compile the shared byte-pin infrastructure (`test_fixtures` — the
+# single-source-of-truth `keyvalue` field shape + the wire-metadata-order guard,
+# issues #2283/#2285). Kept OUT of the default build so this fixture/guard code
+# never ships in the production `cqlite-flight` library or binary. Enabled
+# automatically for the `examples/`/`tests/` targets via the self-referential
+# dev-dependency below (Cargo unifies features, so `cargo test`/`cargo build
+# --examples` build the lib with `test-util` on), following the same
+# feature-declaration convention as `observability-testing`.
+test-util = []
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Self-referential dev-dependency enabling the `test-util` feature, so the
+# `examples/emit_arrow_golden.rs` example and the `tests/*` integration targets
+# can reach `cqlite_flight::test_fixtures` (the shared `keyvalue` byte-pin
+# fixture + wire-metadata guard) WITHOUT that module being reachable from a real
+# consumer of the published library. `cargo test`/`cargo build --examples`
+# unify this feature onto the lib build; `cargo build`/the binary do not.
+cqlite-flight = { path = ".", features = ["test-util"] }
 # The golden emitter (`examples/emit_arrow_golden.rs`) length-delimit-encodes
 # the encoder's `FlightData` protobuf messages to a golden file, and the
 # transport test (`tests/do_get_transport_test.rs`) length-delimit-DECODES that

--- a/cqlite-flight/examples/emit_arrow_golden.rs
+++ b/cqlite-flight/examples/emit_arrow_golden.rs
@@ -264,6 +264,11 @@ fn emit_flightdata_golden(out: &Path) -> Result<(), Box<dyn std::error::Error>> 
     // with what the golden and the real-transport pin actually exercise.
     let producer = MergeProducer::new(schema, fx::KEYVALUE_BATCH_SIZE)?;
     let wire_schema = Arc::new(producer.arrow_schema()?);
+    // Byte-pin safety gate (issue #2285): this golden is byte-compared on the wire
+    // (unlike the semantically-decoded `all_scalars.arrows`), so its schema must
+    // NOT carry a field whose metadata order is process-random. Fail regeneration
+    // loudly if a future fixture introduces a >= 2-metadata-key field.
+    fx::assert_wire_deterministic_metadata(&wire_schema)?;
     let table_dir = data_dir.join(fx::KEYVALUE_KS).join(fx::KEYVALUE_TBL);
     let batches = producer.produce(&DirSource::new(table_dir))?;
 

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -20,11 +20,16 @@ pub mod shutdown;
 pub mod stats;
 pub mod streaming;
 
-// Shared field-shape fixture (issue #2283): the single source of truth for the
-// `cassandra_easy_stress.keyvalue` shape used by BOTH the golden emitter example
-// and the transport byte-pin test. `#[doc(hidden)]` keeps it out of the public
+// Shared byte-pin infrastructure (issues #2283/#2285): the single source of
+// truth for the `cassandra_easy_stress.keyvalue` field shape AND the
+// wire-metadata-order guard, used by BOTH the golden emitter example and the
+// transport byte-pin test. Gated behind the default-off `test-util` feature so
+// this test-only code never compiles into the production library/binary (it is
+// enabled for the `examples/`/`tests/` targets via the self-referential
+// dev-dependency in `Cargo.toml`). `#[doc(hidden)]` keeps it out of the public
 // docs; it must be `pub` (not `pub(crate)`) because both callers are separate
 // crates linked against this library.
+#[cfg(feature = "test-util")]
 #[doc(hidden)]
 pub mod test_fixtures;
 

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -437,22 +437,21 @@ impl MergeProducer {
                     .as_ref()
                     .map(pushdown_capability)
                     .unwrap_or("none");
-                // NOTE on metadata ORDER (not addressed here — see #2285): the
-                // final WIRE order of this `HashMap`'s entries is NOT guaranteed
-                // stable across process runs once a field carries >= 2 metadata
-                // entries, since `Field::with_metadata` stores a `HashMap` as-is
-                // and arrow-ipc's `metadata_to_fb` iterates it unsorted
-                // (confirmed against arrow-schema/arrow-ipc 53.4.1 source) — a
-                // sort/canonicalization pass would need to happen at the actual
-                // wire boundary (or upstream in arrow-rs), not here, so no such
-                // pass is attempted in this function. Harmless for the
-                // `keyvalue` byte-pin golden specifically because those columns
-                // carry exactly one metadata entry each (order-trivial), but
-                // schemas with extension-typed columns (e.g. uuid:
-                // `ARROW:extension:name` + `cqlite:pushdown`, 2 entries — see
-                // `all_scalars`'s `c_uuid` column) are NOT covered by that
-                // trivial case, and their wire order is genuinely
-                // hash-seed-dependent until #2285 lands.
+                // NOTE on metadata ORDER (issue #2285, resolved as a documented
+                // limitation): the final WIRE order of this `HashMap`'s entries is
+                // NOT stable across process runs once a field carries >= 2 metadata
+                // entries, because `Field::with_metadata` stores a `HashMap` as-is
+                // and arrow-ipc's `metadata_to_fb` iterates it UNSORTED (confirmed
+                // against arrow-schema/arrow-ipc 53.4.1). This is a fundamental
+                // arrow-rs limitation with no public hook to control wire order, so
+                // NO sort pass is attempted here — it could not survive to the wire
+                // anyway. This is HARMLESS for live `do_get` (Arrow decodes metadata
+                // by key, order-independently) and for the `keyvalue` byte-pin
+                // golden (its fields carry exactly one metadata entry each). To stop
+                // anyone byte-pinning a >= 2-metadata-key field (e.g. uuid columns:
+                // `ARROW:extension:name` + `cqlite:pushdown`), the byte-pin call
+                // sites gate on `test_fixtures::assert_wire_deterministic_metadata`,
+                // which fails loudly for such a schema.
                 let mut metadata = field.metadata().clone();
                 metadata.insert("cqlite:pushdown".to_string(), capability.to_string());
                 field.as_ref().clone().with_metadata(metadata)

--- a/cqlite-flight/src/test_fixtures.rs
+++ b/cqlite-flight/src/test_fixtures.rs
@@ -1,4 +1,11 @@
-//! Shared field-shape fixture — the single source of truth (issue #2283).
+//! Shared byte-pin infrastructure — the single source of truth (issues
+//! #2283/#2285).
+//!
+//! Two responsibilities, both scoped to byte-pinned / golden-comparison
+//! contexts: (1) the drift-sensitive `keyvalue` field shape used by both byte-pin
+//! callers (below), and (2) [`assert_wire_deterministic_metadata`] — the guard
+//! that fails LOUDLY if a schema about to be byte-pinned carries a field whose
+//! on-wire metadata order is not deterministic across process runs (#2285).
 //!
 //! The `cassandra_easy_stress.keyvalue` shape (issue #2193) is exercised by TWO
 //! independent callers that MUST stay byte-for-byte in lockstep:
@@ -24,6 +31,7 @@
 
 use std::collections::HashMap;
 
+use arrow::datatypes::Schema as ArrowSchema;
 use cqlite_core::schema::{Column, KeyColumn, TableSchema};
 use cqlite_core::storage::write_engine::{CellOperation, Mutation, PartitionKey, TableId};
 use cqlite_core::types::Value;
@@ -95,4 +103,143 @@ pub fn keyvalue_mutations() -> Vec<Mutation> {
         .iter()
         .map(|(key, value)| keyvalue_write(key, value))
         .collect()
+}
+
+// ---- Wire-metadata-order guard (issue #2285) -----------------------------------
+
+/// The maximum number of metadata entries a `Field` may carry while its on-wire
+/// order stays deterministic across process runs.
+///
+/// **Why 1 (and not more):** arrow-ipc's schema serialiser
+/// (`arrow-ipc/src/convert.rs::metadata_to_fb`, confirmed against 53.4.1) builds
+/// the `custom_metadata` flatbuffer vector by iterating `Field::metadata()`
+/// UNSORTED, and `arrow_schema::Field` stores metadata ONLY as a
+/// `std::collections::HashMap<String, String>` (settable solely via
+/// `with_metadata`/`set_metadata`, both `HashMap`-typed) — there is NO public
+/// hook to control `custom_metadata` ordering, so no re-ordering pass at the
+/// schema level survives to the wire. Rust's default `HashMap` hasher
+/// (`RandomState`) is randomly seeded per process, so a field with >= 2 metadata
+/// entries serialises them in a process-random order. A field with 0 or 1 entries
+/// is order-trivial and therefore byte-stable across runs.
+///
+/// This is a **fundamental arrow-rs limitation**: making the wire order
+/// deterministic would require either a manual flatbuffer re-encode of the
+/// post-encoded IPC schema message (effectively re-implementing the encoder,
+/// far out of scope) or an upstream arrow-rs change to sort in `metadata_to_fb`.
+/// Rather than a fix that does not actually work, [`assert_wire_deterministic_metadata`]
+/// DETECTS-and-REJECTS: it fails loudly so no one can silently add a flaky
+/// byte-compared golden for a field carrying >= 2 metadata keys.
+pub const MAX_WIRE_DETERMINISTIC_FIELD_METADATA: usize = 1;
+
+/// A field carries more metadata entries than have a deterministic on-wire order
+/// (see [`MAX_WIRE_DETERMINISTIC_FIELD_METADATA`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonDeterministicWireMetadata {
+    /// Name of the offending field.
+    pub field: String,
+    /// Its metadata keys, sorted for a stable, readable message.
+    pub keys: Vec<String>,
+}
+
+impl std::fmt::Display for NonDeterministicWireMetadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "field {:?} carries {} metadata entries {:?}, whose on-wire order is \
+             NOT deterministic across process runs (arrow-ipc iterates Field \
+             metadata as an unsorted HashMap — see issue #2285); such a field \
+             must not back a byte-compared golden",
+            self.field,
+            self.keys.len(),
+            self.keys,
+        )
+    }
+}
+
+impl std::error::Error for NonDeterministicWireMetadata {}
+
+/// Assert `schema` is safe to use in a BYTE-PINNED / golden-comparison context:
+/// every field carries at most [`MAX_WIRE_DETERMINISTIC_FIELD_METADATA`] metadata
+/// entries, so its `custom_metadata` wire order is deterministic across process
+/// runs (issue #2285).
+///
+/// Call this at every point that GENERATES or byte-compares a golden (the golden
+/// emitter, the transport byte-pin test). It is intentionally NOT called on the
+/// general `arrow_schema()` path: a live `do_get` response legitimately carries
+/// fields with two or more metadata entries (e.g. uuid columns with both the
+/// arrow extension name and `cqlite:pushdown`), which are fine for the SEMANTIC
+/// decode that the `all_scalars.arrows` golden uses — only BYTE comparison is
+/// order-sensitive.
+pub fn assert_wire_deterministic_metadata(
+    schema: &ArrowSchema,
+) -> Result<(), NonDeterministicWireMetadata> {
+    for field in schema.fields() {
+        if field.metadata().len() > MAX_WIRE_DETERMINISTIC_FIELD_METADATA {
+            let mut keys: Vec<String> = field.metadata().keys().cloned().collect();
+            keys.sort();
+            return Err(NonDeterministicWireMetadata {
+                field: field.name().clone(),
+                keys,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field};
+
+    /// The fail-fast fires for a field with >= 2 metadata entries — the exact
+    /// shape (uuid: `ARROW:extension:name` + `cqlite:pushdown`) whose wire order
+    /// is hash-seed-dependent (#2285). This is the guard's whole reason to exist.
+    #[test]
+    fn rejects_field_with_two_metadata_entries() {
+        let mut md = HashMap::new();
+        md.insert("ARROW:extension:name".to_string(), "arrow.uuid".to_string());
+        md.insert("cqlite:pushdown".to_string(), "equality".to_string());
+        let field = Field::new("id", DataType::FixedSizeBinary(16), true).with_metadata(md);
+        let schema = ArrowSchema::new(vec![field]);
+
+        let err = assert_wire_deterministic_metadata(&schema)
+            .expect_err("a field with 2 metadata entries must be rejected");
+        assert_eq!(err.field, "id");
+        assert_eq!(
+            err.keys,
+            vec![
+                "ARROW:extension:name".to_string(),
+                "cqlite:pushdown".to_string()
+            ],
+            "keys are reported sorted for a stable message"
+        );
+    }
+
+    /// A field with a single metadata entry (order-trivial) is accepted — this is
+    /// the `keyvalue` byte-pin golden's shape (`cqlite:pushdown` only).
+    #[test]
+    fn accepts_field_with_single_metadata_entry() {
+        let mut md = HashMap::new();
+        md.insert("cqlite:pushdown".to_string(), "full".to_string());
+        let field = Field::new("value", DataType::Utf8, true).with_metadata(md);
+        let schema = ArrowSchema::new(vec![field]);
+        assert!(
+            assert_wire_deterministic_metadata(&schema).is_ok(),
+            "a 1-metadata-entry field is order-trivial and byte-stable"
+        );
+    }
+
+    /// The actual `keyvalue` wire schema the byte-pin golden is built from must be
+    /// guard-clean — proving the guard does not regress the committed golden and
+    /// that the `keyvalue` case really is the safe single-entry shape.
+    #[test]
+    fn keyvalue_wire_schema_is_byte_pin_safe() {
+        let producer =
+            crate::producer::MergeProducer::new(keyvalue_schema(), KEYVALUE_BATCH_SIZE).unwrap();
+        let schema = producer.arrow_schema().unwrap();
+        assert!(
+            assert_wire_deterministic_metadata(&schema).is_ok(),
+            "the keyvalue byte-pin golden schema must have <= 1 metadata entry per field"
+        );
+    }
 }

--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -235,6 +235,18 @@ fn do_get_over_transport_emits_schema_then_recordbatch() {
 #[test]
 fn do_get_over_transport_matches_committed_golden() {
     let (_temp, data_dir) = build_fixture();
+
+    // Byte-pin safety gate (issue #2285): a field with >= 2 metadata entries has a
+    // process-random on-wire metadata order, which would make this byte comparison
+    // flaky. Assert the fixture's wire schema is guard-clean BEFORE relying on a
+    // byte-identical match, so a future 2-metadata-key fixture fails loudly here
+    // rather than flaking intermittently across CI runs.
+    let producer =
+        cqlite_flight::producer::MergeProducer::new(fx::keyvalue_schema(), fx::KEYVALUE_BATCH_SIZE)
+            .expect("build keyvalue producer");
+    fx::assert_wire_deterministic_metadata(&producer.arrow_schema().expect("wire schema"))
+        .expect("keyvalue byte-pin schema must have deterministic wire metadata order");
+
     let svc = CqliteFlightService::new(data_dir, 8192);
     let rt = tokio::runtime::Runtime::new().unwrap();
     let wire = rt.block_on(do_get_raw_flight_data_over_transport(svc, ticket_bytes()));


### PR DESCRIPTION
Closes #2285

## Summary
1. **Metadata wire-order fix — detect-and-reject (verified, not a workaround-of-convenience)**:
   investigated the pinned arrow-rs 53.4.1 source directly (`arrow-schema::Field` stores metadata
   only as a `HashMap`, no ordered accessor exists; `arrow-ipc::metadata_to_fb` iterates that
   `HashMap` unsorted onto the wire) and confirmed there is genuinely no public hook to control final
   wire order — a real fix would require re-encoding IPC messages or an upstream arrow-rs change,
   both out of scope. Added `assert_wire_deterministic_metadata`, which fails loudly (named field +
   sorted keys in the error) if a byte-pinned schema has any field with ≥2 metadata entries. Wired
   into the golden emitter and the transport byte-pin test, BEFORE encoding — so a bad fixture fails
   at regen/test time, never silently producing a flaky committed golden. `all_scalars.arrows`
   (legitimately 2-key uuid fields, decoded semantically not byte-compared) is correctly left
   ungated.
2. **`test_fixtures` production-binary-bloat fix**: gated behind a new default-off `test-util`
   Cargo feature, enabled via a self-referential `[dev-dependencies]` entry (mirrors this crate's
   existing `observability-testing` pattern) — confirmed `cargo build -p cqlite-flight` (no dev-deps)
   now excludes it from the production artifact.

## Review history (review-first, before any full gate)
- roborev: clean, one Low nit — the guard only walks top-level fields, not nested
  `Struct`/`List<Struct>` child metadata. Currently harmless (no nested-metadata byte-pinned fixture
  exists), documented as a known scope limitation rather than fixed (this issue-chain
  #2193→#2262/#2270→#2273→#2283→#2285 has already gone through enough follow-up rounds on adjacent
  metadata-ordering nits — accepting this one as a documented limitation rather than opening a 6th
  linked issue).
- `rust-reviewer`: clean. Independently re-verified the "no real fix possible" claim from the same
  pinned source (confirmed no ordered accessor / no hook exists), verified guard placement fires
  before encoding at both call sites, verified `all_scalars` is correctly ungated by checking its
  actual downstream semantic-decode consumption, verified the feature-gate excludes the module from
  production builds without leaking into the default dependency graph. One optional nit (the
  transport test's guard checks a separately-constructed-but-structurally-identical schema rather
  than the literal live service schema) — low risk, accepted as-is.

## Test plan
- [x] `rejects_field_with_two_metadata_entries` / `accepts_field_with_single_metadata_entry` /
      `keyvalue_wire_schema_is_byte_pin_safe` — exercise the real guard against the actual committed
      golden's schema
- [x] Full `cqlite-flight` suite green (167 lib + 9 transport, including
      `do_get_over_transport_matches_committed_golden` — confirms zero wire-byte regression)
- [x] Production build (`cargo build -p cqlite-flight`, no features) confirmed excludes
      `test_fixtures`
- [x] `scripts/agent-gate.sh --lite` PASS
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — runs once via `flow-closer`