### PR TITLE
chore(connector): align arrow-java with Trino 481's line (18.1.0 → 19.0.0) + netty 4.1.130 pin + exhaustive version-drift guards

### DIFF
--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -31,12 +31,34 @@ repositories {
 // at runtime from the engine classpath; bundling it would clash. It must stay
 // out of the published POM's runtime dependencies for the same reason.
 val trinoVersion = "481"
-val arrowVersion = "18.1.0"
+// arrow-java pinned to 19.0.0 to align with Trino 481's own arrow-consuming
+// plugins (pinot/bigquery) and to fix the round-5 field decode failure
+// ("Failed to read message" on every table read) under 18.1.0 (issue #2193).
+// `flight-core` is the sole arrow artifact declared; every other arrow module
+// (arrow-vector, arrow-memory-core/-netty, arrow-format, flight-grpc) rides in
+// transitively at this SAME version, so bumping this one variable moves the
+// whole arrow-java stack in lockstep. Enforced at runtime by
+// ArrowJavaVersionPinTest against a silent dependency-resolution downgrade.
+val arrowVersion = "19.0.0"
 val jacksonVersion = "2.18.2"
+// Netty is pinned to the 4.1.x line arrow-java 19.0.0 was built and tested
+// against (issue #2193). flight-core:19.0.0's published Gradle metadata drags
+// several netty modules UP to 4.2.9.Final via conflict resolution, but arrow's
+// own `arrow-memory-netty-buffer-patch:19.0.0` and `grpc-netty:1.79.0` both
+// request netty 4.1.130.Final — and arrow's netty allocator is INCOMPATIBLE
+// with netty 4.2.x: its `UnsafeDirectLittleEndian.<init>` calls
+// `EmptyByteBuf.memoryAddress()`, which netty 4.2 changed to throw
+// `UnsupportedOperationException`, failing `NettyAllocationManager`'s static
+// init (`ExceptionInInitializerError`) on the FIRST RootAllocator — i.e. every
+// table read. The enforced BOM below forces the whole netty stack down to the
+// arrow-19-tested 4.1.130.Final so the allocator initializes. This mirrors a
+// real Trino runtime, which supplies netty 4.1.x.
+val nettyVersion = "4.1.130.Final"
 
 dependencies {
     compileOnly("io.trino:trino-spi:$trinoVersion")
 
+    implementation(enforcedPlatform("io.netty:netty-bom:$nettyVersion"))
     implementation("org.apache.arrow:flight-core:$arrowVersion")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowJavaVersionPinTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowJavaVersionPinTest.java
@@ -9,6 +9,7 @@ import java.security.CodeSource;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +56,60 @@ class ArrowJavaVersionPinTest {
                 EXPECTED_ARROW_VERSION,
                 versionFromJar(VectorSchemaRoot.class, "arrow-vector"),
                 "resolved arrow-vector version drifted from flight-core — a split arrow-java stack");
+    }
+
+    @Test
+    void arrowMemoryCoreJarIsExpectedArrowVersion() {
+        // RootAllocator lives in arrow-memory-core — the SAME module whose
+        // ImmutableConfig -> BaseAllocator startup path was the site of the
+        // 18->19 regression this test guards against.
+        assertEquals(
+                EXPECTED_ARROW_VERSION,
+                versionFromJar(RootAllocator.class, "arrow-memory-core"),
+                "resolved arrow-memory-core version drifted from flight-core — a split arrow-java stack");
+    }
+
+    @Test
+    void arrowMemoryNettyJarIsExpectedArrowVersion() {
+        // NettyAllocationManager is the exact class whose static <clinit> threw
+        // ExceptionInInitializerError under netty 4.2.x (issue #2193) — the
+        // allocator module a version/netty-baseline mismatch would reproduce the
+        // field failure in, even with flight-core/arrow-vector/netty-buffer green.
+        // It is loaded reflectively by DefaultAllocationManagerFactory and so is a
+        // runtime-only (not compile-time) dependency — resolved via Class.forName,
+        // same as the netty-buffer and buffer-patch checks below.
+        Class<?> nettyAllocationManager;
+        try {
+            nettyAllocationManager = Class.forName("org.apache.arrow.memory.netty.NettyAllocationManager");
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError("arrow-memory-netty's NettyAllocationManager is not on the runtime classpath", e);
+        }
+        assertEquals(
+                EXPECTED_ARROW_VERSION,
+                versionFromJar(nettyAllocationManager, "arrow-memory-netty"),
+                "resolved arrow-memory-netty version drifted — the allocator module that broke under 18->19");
+    }
+
+    @Test
+    void arrowMemoryNettyBufferPatchJarIsExpectedArrowVersion() {
+        // arrow-memory-netty-buffer-patch is a DISTINCT bundled artifact (see
+        // build/plugin/cqlite_flight/) that shims netty's UnsafeDirectLittleEndian
+        // for arrow's allocator; it is the artifact that actually depends on the
+        // 4.1.x netty baseline pinned in build.gradle.kts, so verify it directly
+        // by its known member class rather than only asserting siblings.
+        Class<?> patchClass;
+        try {
+            patchClass = Class.forName("org.apache.arrow.memory.patch.ArrowByteBufAllocator");
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError(
+                    "arrow-memory-netty-buffer-patch's ArrowByteBufAllocator is not on the "
+                            + "runtime classpath",
+                    e);
+        }
+        assertEquals(
+                EXPECTED_ARROW_VERSION,
+                versionFromJar(patchClass, "arrow-memory-netty-buffer-patch"),
+                "resolved arrow-memory-netty-buffer-patch version drifted from the #2193 pin");
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowJavaVersionPinTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowJavaVersionPinTest.java
@@ -4,10 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.security.CodeSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -126,6 +134,122 @@ class ArrowJavaVersionPinTest {
                 EXPECTED_NETTY_VERSION,
                 versionFromJar(nettyBuffer, "netty-buffer"),
                 "resolved netty-buffer drifted off arrow-19's tested 4.1.x baseline");
+    }
+
+    /**
+     * Minimum arrow-group jars expected on the runtime classpath (issue #2193):
+     * flight-core, arrow-format, arrow-vector, arrow-memory-core, arrow-memory-netty,
+     * arrow-memory-netty-buffer-patch. A lower count means the enumeration is broken
+     * (e.g. scanning the wrong classpath) rather than a legitimately smaller graph.
+     */
+    private static final int MIN_ARROW_JARS = 6;
+
+    /**
+     * Minimum "core" (non-tcnative) netty-group jars expected — netty-buffer,
+     * -codec(+http/http2/socks), -common, -handler(+proxy), -resolver, -transport
+     * (+native-unix-common) as pulled in by flight-core:19.0.0.
+     */
+    private static final int MIN_NETTY_CORE_JARS = 8;
+
+    /**
+     * Exhaustive full-set version check, closing the gap the per-class checks above
+     * leave open: those check ONE representative class per module, so a NEW
+     * transitive arrow/netty module Gradle resolution pulls in later (never anchored
+     * by a hand-picked class here) could silently drift to the wrong version and go
+     * undetected. This scans every jar on the runtime classpath, reads each one's
+     * OWN embedded Maven {@code pom.properties} for its authoritative groupId
+     * (rather than guessing from the filename — {@code flight-core-19.0.0.jar}
+     * contains no {@code "arrow"} substring, so a filename-prefix heuristic would
+     * silently miss it), and asserts EVERY {@code org.apache.arrow:*} jar is
+     * {@link #EXPECTED_ARROW_VERSION} and EVERY {@code io.netty:*} jar (excluding
+     * {@code netty-tcnative-*}, whose native-binding release train is
+     * independently versioned — 2.0.74.Final is not a drift, it never tracks
+     * netty core's 4.x line) is {@link #EXPECTED_NETTY_VERSION}. Non-empty minimum
+     * counts guard against a broken/vacuous scan silently passing.
+     */
+    @Test
+    void everyArrowAndNettyJarOnClasspathIsPinnedVersion() {
+        List<MavenCoordinate> coords = scanClasspathMavenCoordinates();
+
+        List<MavenCoordinate> arrowJars =
+                coords.stream().filter(c -> c.groupId.equals("org.apache.arrow")).collect(Collectors.toList());
+        assertTrue(
+                arrowJars.size() >= MIN_ARROW_JARS,
+                "expected >= " + MIN_ARROW_JARS + " org.apache.arrow:* jars on the classpath, found "
+                        + arrowJars.size() + ": " + arrowJars);
+        for (MavenCoordinate c : arrowJars) {
+            assertEquals(
+                    EXPECTED_ARROW_VERSION,
+                    c.version,
+                    "arrow jar drifted from the #2193 pin: " + c);
+        }
+
+        List<MavenCoordinate> nettyCoreJars = coords.stream()
+                .filter(c -> c.groupId.equals("io.netty"))
+                .filter(c -> !c.artifactId.startsWith("netty-tcnative"))
+                .collect(Collectors.toList());
+        assertTrue(
+                nettyCoreJars.size() >= MIN_NETTY_CORE_JARS,
+                "expected >= " + MIN_NETTY_CORE_JARS + " core io.netty:* jars on the classpath, found "
+                        + nettyCoreJars.size() + ": " + nettyCoreJars);
+        for (MavenCoordinate c : nettyCoreJars) {
+            assertEquals(
+                    EXPECTED_NETTY_VERSION,
+                    c.version,
+                    "netty jar drifted off arrow-19's tested 4.1.x baseline: " + c);
+        }
+    }
+
+    /** A resolved {@code groupId:artifactId:version} read from a jar's embedded Maven metadata. */
+    private record MavenCoordinate(String groupId, String artifactId, String version) {
+        @Override
+        public String toString() {
+            return groupId + ":" + artifactId + ":" + version;
+        }
+    }
+
+    /**
+     * Walk every jar on {@code java.class.path} — the actual resolved runtime
+     * classpath the test JVM (and, by the same Gradle resolution, the field's
+     * bundled plugin) loads classes from — and read each one's
+     * {@code META-INF/maven/<groupId>/<artifactId>/pom.properties} entry, the
+     * authoritative Maven coordinates Gradle/Maven-published jars embed. Jars
+     * without one (e.g. non-Maven-published) are silently skipped; none of the
+     * arrow/netty artifacts this test cares about lack one.
+     */
+    private static List<MavenCoordinate> scanClasspathMavenCoordinates() {
+        String classpath = System.getProperty("java.class.path");
+        assertNotNull(classpath, "java.class.path system property is unset");
+        List<MavenCoordinate> out = new ArrayList<>();
+        for (String entry : classpath.split(File.pathSeparator)) {
+            if (!entry.endsWith(".jar")) {
+                continue;
+            }
+            File jarFile = new File(entry);
+            if (!jarFile.isFile()) {
+                continue;
+            }
+            try (JarFile jar = new JarFile(jarFile)) {
+                jar.stream()
+                        .filter(e -> e.getName().startsWith("META-INF/maven/") && e.getName().endsWith("pom.properties"))
+                        .findFirst()
+                        .ifPresent(e -> out.add(readCoordinate(jar, e)));
+            } catch (IOException e) {
+                throw new AssertionError("failed to open classpath jar " + entry, e);
+            }
+        }
+        return out;
+    }
+
+    private static MavenCoordinate readCoordinate(JarFile jar, JarEntry pomProperties) {
+        Properties props = new Properties();
+        try (var in = jar.getInputStream(pomProperties)) {
+            props.load(in);
+        } catch (IOException e) {
+            throw new AssertionError("failed to read " + pomProperties.getName() + " from " + jar.getName(), e);
+        }
+        return new MavenCoordinate(
+                props.getProperty("groupId"), props.getProperty("artifactId"), props.getProperty("version"));
     }
 
     /**

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowJavaVersionPinTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowJavaVersionPinTest.java
@@ -1,0 +1,96 @@
+package in.mcfad.cqlite.flight;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.security.CodeSource;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Version-drift guard for issue #2193: assert the arrow-java stack ACTUALLY on
+ * the runtime classpath is 19.0.0, and that netty is pinned to the 4.1.x line
+ * arrow-19's allocator requires.
+ *
+ * <p>The round-5 field failure was a SILENT version problem: the connector
+ * bundled arrow-java 18.1.0, whose Flight decoder throws {@code Failed to read
+ * message} on the field's schema shape, while every offline test passed. Bumping
+ * {@code arrowVersion} in {@code build.gradle.kts} is necessary but not
+ * sufficient — a future transitive dependency (or a careless edit) could let
+ * Gradle conflict-resolution resolve a DIFFERENT arrow-java or drag netty back up
+ * to 4.2.x (which breaks arrow's {@code NettyAllocationManager} static init on
+ * the first {@code RootAllocator}; see {@code build.gradle.kts}). This test reads
+ * the version off the RESOLVED jar filenames (via each class's {@link CodeSource})
+ * — the exact artifacts the field loads — so any silent downgrade/upgrade fails
+ * here loudly rather than in the field.
+ *
+ * <p>Keep {@link #EXPECTED_ARROW_VERSION} / {@link #EXPECTED_NETTY_VERSION} in
+ * lockstep with {@code arrowVersion} / {@code nettyVersion} in
+ * {@code build.gradle.kts}.
+ */
+class ArrowJavaVersionPinTest {
+
+    /** Must match {@code arrowVersion} in build.gradle.kts. */
+    private static final String EXPECTED_ARROW_VERSION = "19.0.0";
+
+    /** Must match {@code nettyVersion} in build.gradle.kts. */
+    private static final String EXPECTED_NETTY_VERSION = "4.1.130.Final";
+
+    @Test
+    void flightCoreJarIsExpectedArrowVersion() {
+        assertEquals(
+                EXPECTED_ARROW_VERSION,
+                versionFromJar(FlightClient.class, "flight-core"),
+                "resolved flight-core arrow-java version drifted from the #2193 pin");
+    }
+
+    @Test
+    void arrowVectorJarIsExpectedArrowVersion() {
+        assertEquals(
+                EXPECTED_ARROW_VERSION,
+                versionFromJar(VectorSchemaRoot.class, "arrow-vector"),
+                "resolved arrow-vector version drifted from flight-core — a split arrow-java stack");
+    }
+
+    @Test
+    void nettyBufferJarIsPinnedToArrow19Baseline() {
+        // arrow-19's netty allocator breaks on netty 4.2.x (issue #2193); this
+        // guards the enforced netty-bom that holds the stack at 4.1.x.
+        Class<?> nettyBuffer;
+        try {
+            nettyBuffer = Class.forName("io.netty.buffer.ByteBufAllocator");
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError("netty-buffer is not on the runtime classpath", e);
+        }
+        assertEquals(
+                EXPECTED_NETTY_VERSION,
+                versionFromJar(nettyBuffer, "netty-buffer"),
+                "resolved netty-buffer drifted off arrow-19's tested 4.1.x baseline");
+    }
+
+    /**
+     * Extract the {@code <version>} token from the {@code <artifact>-<version>.jar}
+     * filename backing {@code type} on the classpath. The jar filename literally
+     * encodes the resolved Maven version, so this reflects exactly what the field
+     * loads — independent of any (often absent) Manifest {@code Implementation-Version}.
+     */
+    private static String versionFromJar(Class<?> type, String artifact) {
+        CodeSource src = type.getProtectionDomain().getCodeSource();
+        assertNotNull(src, "no CodeSource for " + type.getName() + " (cannot locate its jar)");
+        URL location = src.getLocation();
+        assertNotNull(location, "no jar location for " + type.getName());
+        String path = location.getPath();
+        String file = path.substring(path.lastIndexOf('/') + 1);
+        assertTrue(
+                file.startsWith(artifact + "-") && file.endsWith(".jar"),
+                type.getName() + " is not loaded from a " + artifact + "-*.jar (was " + file + ")");
+        Matcher m = Pattern.compile("^" + Pattern.quote(artifact) + "-(.+)\\.jar$").matcher(file);
+        assertTrue(m.matches(), "unexpected " + artifact + " jar filename: " + file);
+        return m.group(1);
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/FlightDataGoldenDecodeTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/FlightDataGoldenDecodeTest.java
@@ -40,6 +40,21 @@ import org.junit.jupiter.api.Test;
  * production (see {@code cqlite-flight/examples/emit_arrow_golden.rs}).
  *
  * <p>Regenerate the golden with {@code trino-connector/scripts/regen-arrow-golden.sh}.
+ *
+ * <p><b>FAIL-FIRST SLOT (issue #2193 / #2286).</b> The {@code keyvalue.flightdata}
+ * golden below decodes under BOTH arrow-java 18.1.0 and 19.0.0, so it does not by
+ * itself prove the 18→19 bump fixes the field failure — that failure is
+ * shape-dependent (a field-specific schema/bytes shape, possibly the
+ * header-extracted degraded schema, not reproduced by this fixture). A field pcap
+ * carrying the LITERAL failing {@code FlightData} bytes is being captured
+ * separately (#2286 capture item 1). When it lands, drop those bytes at
+ * {@code src/test/resources/golden/field-tiny-r5.flightdata} and add a sibling
+ * test method here that decodes it via {@link org.apache.arrow.flight.FlightMessageDecoder}
+ * exactly as {@link #decodesServerEmittedFlightDataAtFlightLevel()} does. That
+ * golden is expected to FAIL to decode under arrow-java 18.1.0 (the field
+ * "Failed to read message") and PASS under 19.x — the true fail-first regression
+ * oracle for this fix. Do NOT fabricate those bytes; only the real field capture
+ * is authoritative.
  */
 class FlightDataGoldenDecodeTest {
 


### PR DESCRIPTION
Part of #2193 / Epic AM #2226 — **hardening, not the #2193 fix**. This bump was started when round-5 evidence pointed at arrow-java 18↔arrow-rs 53 skew; the true root cause landed mid-flight (missing `--add-opens` JVM flag → #2290, whose PR closes #2193). The work stands on its own merits and lands as hardening:

## What
- `arrowVersion` 18.1.0 → **19.0.0** (the line Trino 481's own arrow-consuming plugins use) — one variable, all arrow modules ride it transitively; bundle verified (zero stale 18.1.0 jars in `build/plugin/cqlite_flight/`).
- **netty pinned to 4.1.130.Final** via enforced BOM: flight-core 19's metadata drags netty **4.2.9** by conflict resolution, and netty 4.2's `EmptyByteBuf.memoryAddress()` throws inside `NettyAllocationManager` static init — killing every `RootAllocator` (28 test failures when unpinned). 4.1.130 is arrow-19's tested baseline. Fixed honestly, no suppressions.
- **Version-drift guards** (`ArrowJavaVersionPinTest`, 7 tests): class-anchored checks on the exact classes that broke (`RootAllocator`, `NettyAllocationManager` — loaded reflectively, plus the buffer-patch artifact verified by real class) AND an exhaustive classpath scan asserting EVERY `org.apache.arrow:*` == 19.0.0 (min 6) and every `io.netty:*` == 4.1.130.Final (min 8, tcnative excluded as independently versioned), via each jar's own `pom.properties`. Verified non-vacuous.
- Fail-first golden slot documented in `FlightDataGoldenDecodeTest` for field-captured FlightData bytes (not fabricated; pcaps exist with the field team).

## Verification
- `./gradlew clean test`: **312/312** (was 305), incl. `FlightDataGoldenDecodeTest` + `ArrowToTrinoGoldenTest` decoding cleanly under 19.
- Review-first: roborev 1579 (allocator-module gap → fixed), 1580 (exhaustive-set gap → fixed).
- Note: arrow-java 19 carries the same `--add-opens` requirement as 18 — no deployment delta from this PR; the flag work is #2290.