### PR TITLE
docs/tooling(#2293): complete feature-flag docs + de-stale quality-gate scripts (PR #2220 follow-ups)

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -67,11 +67,11 @@ run_clippy() {
         cd "$dir"
         
         # Align with CI (RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets
-        # --all-features). Root Cargo.toml sets pedantic/nursery = "allow"; do NOT re-deny them.
+        # --all-features). Root Cargo.toml sets pedantic/nursery/cargo = "allow"; do NOT
+        # re-deny them here.
         if ! cargo clippy --all-targets --all-features -- \
             -D warnings \
             -D clippy::all \
-            -D clippy::cargo \
             -D unused-imports \
             -D unused-variables \
             -D dead-code \

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -66,11 +66,11 @@ run_clippy() {
     if [ -d "$dir" ]; then
         cd "$dir"
         
+        # Align with CI (RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets
+        # --all-features). Root Cargo.toml sets pedantic/nursery = "allow"; do NOT re-deny them.
         if ! cargo clippy --all-targets --all-features -- \
             -D warnings \
             -D clippy::all \
-            -D clippy::pedantic \
-            -D clippy::nursery \
             -D clippy::cargo \
             -D unused-imports \
             -D unused-variables \
@@ -127,8 +127,10 @@ ORIGINAL_DIR=$(pwd)
 # Track failures
 FAILED=0
 
-# Check all workspace members
-WORKSPACE_MEMBERS=("cqlite-core" "cqlite-cli" "testing-framework" "tests")
+# Top-level workspace member crates to check (see root Cargo.toml [workspace].members;
+# nested/glob members bindings/*, tests/format-compatibility, examples, tools/* are omitted
+# from this simple cd-by-dir loop).
+WORKSPACE_MEMBERS=("cqlite-core" "cqlite-cli" "cqlite-flight" "tests")
 
 echo -e "${BLUE}=== Dead Code Detection ===${NC}"
 for member in "${WORKSPACE_MEMBERS[@]}"; do

--- a/.github/setup-quality-gates.sh
+++ b/.github/setup-quality-gates.sh
@@ -87,8 +87,10 @@ fi
 echo -e "${BLUE}Running initial code quality check...${NC}"
 FAILED=0
 
-# Check each workspace member
-WORKSPACE_MEMBERS=("cqlite-core" "cqlite-cli" "testing-framework" "tests")
+# Top-level workspace member crates to check (see root Cargo.toml [workspace].members;
+# nested/glob members bindings/*, tests/format-compatibility, examples, tools/* are omitted
+# from this simple cd-by-dir loop).
+WORKSPACE_MEMBERS=("cqlite-core" "cqlite-cli" "cqlite-flight" "tests")
 
 for member in "${WORKSPACE_MEMBERS[@]}"; do
     if [ -d "$member" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,10 +208,12 @@ Without Data.db files, query tests pass but return 0 rows. Dataset pins:
 
 ## Feature Flags
 
-Default (cqlite-core): `all-compression` (LZ4, Snappy, Deflate, Zstd), `state_machine`.
-Non-default: `cli-helpers` (#249), `parquet` (#682), `delta-scan` / `delta-export` (#696/#705),
-`legacy-heuristics` (opt-in pre-5.0 heuristic fallbacks, #28), `metrics`, `experimental` (bloom-filter
-tests + unimplemented write stubs). Build recipes: `docs/development/dev-cookbook.md`.
+Default (cqlite-core): `all-compression` (LZ4, Snappy, Deflate, Zstd), `state_machine`,
+`write-support` (#558). Non-default: `cli-helpers` (#249), `parquet` (#682), `delta-scan` /
+`delta-export` (#696/#705), `legacy-heuristics` (opt-in pre-5.0 heuristic fallbacks, #28), `metrics`,
+`experimental` (gates `Database::flush()`/`compact()`, the INSERT executor path, the schema JSON
+exporter, bloom-filter tests (#65), and the unimplemented `Storage::put`/`delete` stubs (#175)). Build
+recipes: `docs/development/dev-cookbook.md`.
 
 ## Troubleshooting
 

--- a/website/src/content/docs/agents-developing/no-heuristics.md
+++ b/website/src/content/docs/agents-developing/no-heuristics.md
@@ -88,7 +88,7 @@ the library must not invent values.
 | `state_machine` (default) | No |
 | `cli-helpers` | No |
 | `metrics` | No |
-| `experimental` | No (bloom-filter tests + write stubs, not heuristics) |
+| `experimental` | No (gates `flush()`/`compact()`, the INSERT executor path, the schema JSON exporter, bloom-filter tests, and unimplemented `Storage::put`/`delete` stubs — not heuristics) |
 | `legacy-heuristics` | Yes — explicitly opt-in |
 
 See [Key source paths](/cqlite/agents-developing/source-map/) for where type decoding lives in the codebase.

--- a/website/src/content/docs/user-docs/installation.md
+++ b/website/src/content/docs/user-docs/installation.md
@@ -171,8 +171,8 @@ Add `cqlite-core` to your `Cargo.toml`:
 cqlite-core = { git = "https://github.com/pmcfadin/cqlite.git" }
 ```
 
-Default features include `all-compression` (LZ4, Snappy, Deflate, Zstd) and
-`state_machine` (query engine). For a minimal build without the query engine:
+Default features include `all-compression` (LZ4, Snappy, Deflate, Zstd), `state_machine`
+(query engine), and `write-support` (write path). For a minimal build without the query engine:
 
 ```toml
 cqlite-core = { git = "…", default-features = false, features = ["all-compression"] }

--- a/website/src/content/docs/user-docs/installation.md
+++ b/website/src/content/docs/user-docs/installation.md
@@ -184,9 +184,10 @@ cqlite-core = { git = "…", default-features = false, features = ["all-compress
 |------|---------|-------------|
 | `all-compression` | yes | LZ4, Snappy, Deflate, Zstd support |
 | `state_machine` | yes | Query engine and schema-based discovery |
+| `write-support` | yes | Write path: SSTable writer + STCS compaction |
 | `cli-helpers` | no | CLI-specific ingestion and REPL API |
 | `metrics` | no | Performance metrics collection |
-| `experimental` | no | Experimental / unstable features |
+| `experimental` | no | Unstable/unfinished paths: `flush()`/`compact()`, the INSERT executor, the schema JSON exporter, bloom-filter tests, and unimplemented `Storage::put`/`delete` stubs |
 
 ## Verify your installation
 


### PR DESCRIPTION
Closes #2293

## Changes
Follow-ups verified during PR #2220 (legacy-heuristics attribution) review:
- **CLAUDE.md**: `write-support` listed as a default feature (matches `cqlite-core/Cargo.toml` `default = [...]`, #558); `experimental` annotation completed — gates `Database::flush()`/`compact()`, the INSERT executor path, the schema JSON exporter, bloom-filter tests (#65), and the unimplemented `Storage::put`/`delete` stubs (#175).
- **website** `agents-developing/no-heuristics.md` + `user-docs/installation.md`: same corrections mirrored (doctrine-currency rule); installation table + prose now include `write-support`.
- **`.github/hooks/pre-commit` + `.github/setup-quality-gates.sh`**: `WORKSPACE_MEMBERS` de-staled (removed nonexistent `testing-framework`; now cqlite-core/cqlite-cli/cqlite-flight/tests with a comment pointing at root Cargo.toml); dropped `-D clippy::pedantic`, `-D clippy::nursery`, and `-D clippy::cargo` — all three groups are `allow` in `[workspace.lints.clippy]`, so the hook now matches CI (`-D warnings` only).

Docs + shell only; no `.rs` touched.

## Quality
- Lite gate PASS each round (summary-file redirect; `/tmp/lite-2293.txt`).
- Review-first: roborev branch review clean ("No issues found"); rust-reviewer verified every doc claim against the actual cfg gates — no blockers; both findings (drop `-D clippy::cargo`, prose consistency) fixed in `a43ca1c5`.
- Full gate of record runs pre-merge per flow (#2084).

## Acceptance criteria (issue #2293)
All verified: defaults agreement, complete `experimental` annotation + website consistency, `rg testing-framework` empty on both scripts, no `-D pedantic/nursery` (or `cargo`), `bash -n` clean.