### PR TITLE
fix(#2193): arrow-java --add-opens — kit jvm.config provisioning + connector fail-fast + docs

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,54 @@
+Closes #2193
+
+## Problem
+
+On JDK 17+, arrow-java's `MemoryUtil.<clinit>` requires the JVM flag
+`--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`. Trino 481's stock
+`jvm.config` does **not** carry it, and the k8s `trino-cqlite` kit did not add it. So the CQLite
+Flight connector's first Arrow off-heap touch (`new RootAllocator()`) died in the static
+initializer, and every `do_get` on the read path then failed far downstream with a cryptic
+`Failed to read message` — with nothing pointing operators at the real cause. Adding the flag and
+restarting Trino makes the whole read path work.
+
+## Fix (one PR, three layers)
+
+1. **k8s kit provisions the flag** — `easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template`
+   now injects `JAVA_TOOL_OPTIONS=--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`
+   into both the `trino-coordinator` and `trino-worker` container specs, via the same always-run
+   strategic-merge patch (`patch_deployment`). `JAVA_TOOL_OPTIONS` is additive (the JVM appends it to
+   the launcher args) so it doesn't require reproducing/version-tracking the image's whole stock
+   `jvm.config` the way a file-mount would; strategic merge keys `env` by name, so re-applying the
+   fixed value is a no-op (idempotent).
+
+2. **Connector fail-fast** — new `ArrowMemoryPreflight.verify()` runs once at connector construction
+   (before the first `RootAllocator`). It probes Arrow memory init in a try-with-resources allocator
+   (side-effect-free when the flag is present), and on a `MemoryUtil` init failure raises a Trino
+   `CONFIGURATION_INVALID` error naming the **exact** missing flag and the `jvm.config` remedy.
+   Unrelated errors pass through untouched (never masked).
+
+3. **Docs** — a "Required JVM configuration" section in `trino-connector/README.md` and
+   `website/src/content/docs/user-docs/flight-trino.md` documents the flag, why (arrow-java JDK17+
+   module access for off-heap), and the fail-fast behavior.
+
+## Why the docker e2e never caught this (the blind spot)
+
+The docker e2e passes without the fix because `docker/docker-compose.yml` mounts
+`docker/trino/jvm.config`, and that file already contained an add-opens flag (the looser
+`...=ALL-UNNAMED` form). So local e2e exercised a Trino that always had the module opened, while the
+kit-based deployment — and any other deployment shape that starts from Trino's stock `jvm.config` —
+had no such flag and broke on the first frame. The e2e's own jvm.config masked the failure it was
+supposed to guard. That is exactly why the **connector-side fail-fast probe (layer 2)** is the
+durable protection: it fires at catalog load on *any* deployment shape, regardless of how (or
+whether) `jvm.config` was provisioned, turning a cryptic read-time `Failed to read message` into an
+actionable configuration error. (I also aligned `docker/trino/jvm.config` to the exact arrow-java
+form so the docker stack, the kit, and the fail-fast message all name the identical flag.)
+
+## Verification
+
+- `cd trino-connector && ./gradlew test` — GREEN (313 tests, 0 failures), including the new
+  `ArrowMemoryPreflightTest` (8 cases: message names the exact flag, classifier matches
+  MemoryUtil-init failures by message and by stack frame, arrow-init → `CONFIGURATION_INVALID`,
+  unrelated errors rethrown unchanged, and `verify()` passes side-effect-free when the flag is
+  present in the Gradle test JVM).
+- Kit template: `shellcheck` clean; jq patch validated to emit the correct `env` entry; idempotent
+  by strategic-merge semantics.

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,4 +1,5 @@
 Closes #2193
+Closes #2290
 
 ## Problem
 
@@ -45,10 +46,22 @@ form so the docker stack, the kit, and the fail-fast message all name the identi
 
 ## Verification
 
-- `cd trino-connector && ./gradlew test` — GREEN (313 tests, 0 failures), including the new
-  `ArrowMemoryPreflightTest` (8 cases: message names the exact flag, classifier matches
+- `cd trino-connector && ./gradlew test` — GREEN (314 tests, 0 failures), including the new
+  `ArrowMemoryPreflightTest` (9 cases: message names the exact flag, classifier matches
   MemoryUtil-init failures by message and by stack frame, arrow-init → `CONFIGURATION_INVALID`,
-  unrelated errors rethrown unchanged, and `verify()` passes side-effect-free when the flag is
-  present in the Gradle test JVM).
+  unrelated errors rethrown unchanged, a 2-node cause-cycle terminates without hang/misclassification,
+  and `verify()` passes side-effect-free — forcing a 1-byte off-heap `ArrowBuf` allocation so the probe
+  truly exercises the `MemoryUtil` path — when the flag is present in the Gradle test JVM).
 - Kit template: `shellcheck` clean; jq patch validated to emit the correct `env` entry; idempotent
   by strategic-merge semantics.
+
+## Review hardening (addressed in-branch)
+
+- The preflight probe now forces a 1-byte off-heap `ArrowBuf` allocation, so it genuinely exercises the
+  `MemoryUtil`/java.nio path a bare `RootAllocator` could skip.
+- The kit **appends** to `JAVA_TOOL_OPTIONS` if-absent rather than clobbering an existing literal value,
+  and when the var is sourced via `valueFrom`/`envFrom` it emits a loud actionable warning and skips the
+  literal overwrite (the connector fail-fast probe is the backstop).
+- The cause-chain walk is now bounded so any cyclic cause chain terminates.
+
+Non-blocking follow-up nits (uninstall flag-strip; two additional test branches) are batched in #2296.

--- a/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
@@ -67,16 +67,45 @@ INIT_SCRIPT='set -eu; mkdir -p /tmp/build; cp /workspace/build.gradle.kts /works
 # java.nio module opened to it on JDK 17+. Trino 481's stock jvm.config does
 # NOT carry this flag, so without it the CQLite Flight connector's first Arrow
 # off-heap touch dies and every do_get fails downstream with a cryptic
-# "Failed to read message". We inject the arrow-java-documented flag via
-# JAVA_TOOL_OPTIONS rather than a jvm.config file-mount: mounting a single file
-# at /etc/trino/jvm.config would REPLACE the image's whole stock jvm.config
-# (forcing us to reproduce + version-track every stock line), whereas
-# JAVA_TOOL_OPTIONS is purely ADDITIVE — the JVM appends it to the launcher's
-# args. It is idempotent under strategic merge (env entries merge by name, so
-# re-applying identical content is a no-op) and applies to coordinator AND
-# worker alike (see patch_deployment). The connector also fails fast at catalog
-# load if the flag is somehow still absent (ArrowMemoryPreflight, #2290).
+# "Failed to read message". We inject the arrow-java-documented flag via a k8s
+# JAVA_TOOL_OPTIONS env var rather than a jvm.config file-mount: mounting a
+# single file at /etc/trino/jvm.config would REPLACE the image's whole stock
+# jvm.config (forcing us to reproduce + version-track every stock line),
+# whereas JAVA_TOOL_OPTIONS is additive at the JVM launcher level — the JVM
+# appends its contents to the launcher's args.
+#
+# IMPORTANT: a strategic-merge env entry keyed by name REPLACES the container's
+# existing JAVA_TOOL_OPTIONS value wholesale — it is NOT additive at the k8s
+# env level. The trino kit (or the operator) may already set JAVA_TOOL_OPTIONS
+# for other reasons, so we must NOT clobber it. compute_java_tool_options()
+# therefore reads the container's current JAVA_TOOL_OPTIONS from the live
+# Deployment and appends our flag only when it is absent, preserving any
+# existing value and never duplicating on re-run (idempotent). Applied to
+# coordinator AND worker alike (see patch_deployment). The connector also fails
+# fast at catalog load if the flag is somehow still absent
+# (ArrowMemoryPreflight, #2290).
 ARROW_ADD_OPENS='--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED'
+
+# Compute the JAVA_TOOL_OPTIONS value to set on ${dep}'s container: read the
+# container's current value from the live Deployment spec and append
+# ARROW_ADD_OPENS only if the flag isn't already present. Preserves any
+# pre-existing value; idempotent (a value that already carries the flag is
+# returned unchanged, so the subsequent strategic-merge patch is a no-op).
+compute_java_tool_options() {
+  local dep="$1"
+  local existing
+  existing=$(kubectl get deployment "${dep}" --namespace default \
+    -o jsonpath="{.spec.template.spec.containers[?(@.name=='${dep}')].env[?(@.name=='JAVA_TOOL_OPTIONS')].value}" \
+    2>/dev/null || true)
+
+  if [ -z "${existing}" ]; then
+    printf '%s' "${ARROW_ADD_OPENS}"
+  elif printf '%s' "${existing}" | grep -qF -- "${ARROW_ADD_OPENS}"; then
+    printf '%s' "${existing}"
+  else
+    printf '%s %s' "${existing}" "${ARROW_ADD_OPENS}"
+  fi
+}
 
 # Issue #2120: create/refresh the ConfigMap the initContainer mounts BEFORE
 # either deployment is patched to reference it. Same recipe as
@@ -139,6 +168,8 @@ patch_deployment() {
   fi
 
   echo "  - patching deployment/${dep} (container: ${dep})..."
+  local java_tool_options
+  java_tool_options=$(compute_java_tool_options "${dep}")
   local patch
   patch=$(jq -n \
     --arg cm "${CONFIGMAP_NAME}" \
@@ -146,7 +177,7 @@ patch_deployment() {
     --arg mount "${PLUGIN_MOUNT_PATH}" \
     --arg container "${dep}" \
     --arg script "${INIT_SCRIPT}" \
-    --arg addopens "${ARROW_ADD_OPENS}" \
+    --arg javatooloptions "${java_tool_options}" \
     '{spec:{template:{spec:{
       volumes: [
         {name:"cqlite-plugin-src", configMap:{name:$cm}},
@@ -167,10 +198,14 @@ patch_deployment() {
       containers: [
         {
           name:$container,
-          # Additive Arrow add-opens flag (#2193/#2290). Strategic merge keys env
-          # entries by name, so a fixed value re-applies as a no-op (idempotent).
+          # JAVA_TOOL_OPTIONS carrying the Arrow add-opens flag (#2193/#2290),
+          # computed by compute_java_tool_options as <existing> + our flag (or
+          # <existing> unchanged if already present). A strategic-merge env entry
+          # keyed by name REPLACES the whole value, so we must supply the full
+          # append-if-absent result here — that keeps it idempotent and never
+          # clobbers a pre-existing JAVA_TOOL_OPTIONS.
           env: [
-            {name:"JAVA_TOOL_OPTIONS", value:$addopens}
+            {name:"JAVA_TOOL_OPTIONS", value:$javatooloptions}
           ],
           volumeMounts: [
             {name:"cqlite-plugin-dir", mountPath:$mount, readOnly:true}

--- a/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
@@ -63,6 +63,21 @@ PLUGIN_MOUNT_PATH="/usr/lib/trino/plugin/cqlite_flight"
 # result into the shared emptyDir.
 INIT_SCRIPT='set -eu; mkdir -p /tmp/build; cp /workspace/build.gradle.kts /workspace/settings.gradle.kts /tmp/build/; cd /tmp/build; gradle --no-daemon --console=plain assemblePlugin; cp -r build/plugin/cqlite_flight/. /plugin-out/'
 
+# Issues #2193/#2290: arrow-java's MemoryUtil static initializer needs the
+# java.nio module opened to it on JDK 17+. Trino 481's stock jvm.config does
+# NOT carry this flag, so without it the CQLite Flight connector's first Arrow
+# off-heap touch dies and every do_get fails downstream with a cryptic
+# "Failed to read message". We inject the arrow-java-documented flag via
+# JAVA_TOOL_OPTIONS rather than a jvm.config file-mount: mounting a single file
+# at /etc/trino/jvm.config would REPLACE the image's whole stock jvm.config
+# (forcing us to reproduce + version-track every stock line), whereas
+# JAVA_TOOL_OPTIONS is purely ADDITIVE — the JVM appends it to the launcher's
+# args. It is idempotent under strategic merge (env entries merge by name, so
+# re-applying identical content is a no-op) and applies to coordinator AND
+# worker alike (see patch_deployment). The connector also fails fast at catalog
+# load if the flag is somehow still absent (ArrowMemoryPreflight, #2290).
+ARROW_ADD_OPENS='--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED'
+
 # Issue #2120: create/refresh the ConfigMap the initContainer mounts BEFORE
 # either deployment is patched to reference it. Same recipe as
 # bin/install.sh (kept in sync deliberately) — idempotent create-or-update
@@ -131,6 +146,7 @@ patch_deployment() {
     --arg mount "${PLUGIN_MOUNT_PATH}" \
     --arg container "${dep}" \
     --arg script "${INIT_SCRIPT}" \
+    --arg addopens "${ARROW_ADD_OPENS}" \
     '{spec:{template:{spec:{
       volumes: [
         {name:"cqlite-plugin-src", configMap:{name:$cm}},
@@ -151,6 +167,11 @@ patch_deployment() {
       containers: [
         {
           name:$container,
+          # Additive Arrow add-opens flag (#2193/#2290). Strategic merge keys env
+          # entries by name, so a fixed value re-applies as a no-op (idempotent).
+          env: [
+            {name:"JAVA_TOOL_OPTIONS", value:$addopens}
+          ],
           volumeMounts: [
             {name:"cqlite-plugin-dir", mountPath:$mount, readOnly:true}
           ]

--- a/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
+++ b/easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template
@@ -78,19 +78,36 @@ INIT_SCRIPT='set -eu; mkdir -p /tmp/build; cp /workspace/build.gradle.kts /works
 # existing JAVA_TOOL_OPTIONS value wholesale — it is NOT additive at the k8s
 # env level. The trino kit (or the operator) may already set JAVA_TOOL_OPTIONS
 # for other reasons, so we must NOT clobber it. compute_java_tool_options()
-# therefore reads the container's current JAVA_TOOL_OPTIONS from the live
-# Deployment and appends our flag only when it is absent, preserving any
+# therefore reads the container's current LITERAL JAVA_TOOL_OPTIONS value from
+# the live Deployment and appends our flag only when it is absent, preserving any
 # existing value and never duplicating on re-run (idempotent). Applied to
-# coordinator AND worker alike (see patch_deployment). The connector also fails
-# fast at catalog load if the flag is somehow still absent
-# (ArrowMemoryPreflight, #2290).
+# coordinator AND worker alike (see patch_deployment).
+#
+# The operator may instead source JAVA_TOOL_OPTIONS INDIRECTLY — via `valueFrom`
+# on that env var, or via a container `envFrom` (ConfigMap/Secret ref). A literal
+# `value:` patch would silently drop that sourced value, so we do NOT overwrite
+# it: java_tool_options_sourced() detects the indirect case per-container and
+# patch_deployment then WARNS loudly and SKIPS the literal env patch for that
+# container (leaving the operator's sourced value intact), applying only the
+# volumes/initContainer/volumeMount. The connector also fails fast at catalog
+# load if the flag is somehow still absent (ArrowMemoryPreflight, #2290) — that
+# probe is the backstop for the skipped/indirect case.
 ARROW_ADD_OPENS='--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED'
 
-# Compute the JAVA_TOOL_OPTIONS value to set on ${dep}'s container: read the
-# container's current value from the live Deployment spec and append
-# ARROW_ADD_OPENS only if the flag isn't already present. Preserves any
+# Compute the literal JAVA_TOOL_OPTIONS value to set on ${dep}'s container: read
+# the container's current literal `env[].value` from the live Deployment spec and
+# append ARROW_ADD_OPENS only if the flag isn't already present. Preserves any
 # pre-existing value; idempotent (a value that already carries the flag is
 # returned unchanged, so the subsequent strategic-merge patch is a no-op).
+#
+# NOTE: this only handles a LITERAL `env[].value`. If JAVA_TOOL_OPTIONS is
+# instead sourced indirectly — via `valueFrom` on that env var, or via any
+# `envFrom` on the container (ConfigMap/Secret ref) — the literal value read
+# here is empty, and blindly writing a literal `value:` would CLOBBER the
+# operator's sourced JVM options. That case is detected separately by
+# java_tool_options_sourced() and handled in patch_deployment (warn + skip the
+# literal env patch), so this function is only ever consulted for the literal
+# path.
 compute_java_tool_options() {
   local dep="$1"
   local existing
@@ -105,6 +122,28 @@ compute_java_tool_options() {
   else
     printf '%s %s' "${existing}" "${ARROW_ADD_OPENS}"
   fi
+}
+
+# Detect whether ${dep}'s container gets JAVA_TOOL_OPTIONS from an INDIRECT
+# source we must not overwrite: either a `valueFrom` on the JAVA_TOOL_OPTIONS env
+# entry, or any `envFrom` (ConfigMap/Secret ref) on the container that could
+# supply it. Returns 0 (true) when sourced indirectly, 1 otherwise. In the true
+# case patch_deployment SKIPS the literal env patch and warns loudly, so the
+# operator's sourced value is left intact (the ArrowMemoryPreflight fail-fast
+# probe remains the backstop for a genuinely-missing flag).
+java_tool_options_sourced() {
+  local dep="$1"
+  local spec
+  spec=$(kubectl get deployment "${dep}" --namespace default -o json 2>/dev/null || true)
+  if [ -z "${spec}" ]; then
+    return 1
+  fi
+  printf '%s' "${spec}" | jq -e --arg c "${dep}" '
+    [ .spec.template.spec.containers[] | select(.name==$c) | (
+        (((.env // []) | map(select(.name=="JAVA_TOOL_OPTIONS")) | any(has("valueFrom"))))
+        or (((.envFrom // []) | length) > 0)
+    ) ] | any
+  ' >/dev/null 2>&1
 }
 
 # Issue #2120: create/refresh the ConfigMap the initContainer mounts BEFORE
@@ -168,8 +207,28 @@ patch_deployment() {
   fi
 
   echo "  - patching deployment/${dep} (container: ${dep})..."
-  local java_tool_options
-  java_tool_options=$(compute_java_tool_options "${dep}")
+  # Decide how to handle JAVA_TOOL_OPTIONS. If the operator sources it indirectly
+  # (valueFrom / envFrom), a literal `value:` in our strategic-merge patch would
+  # silently drop their JVM options — so in that case we WARN and omit the env
+  # entry entirely from the patch (leaving the sourced value intact), applying
+  # only the volumes/initContainer/volumeMount. Otherwise we set the literal
+  # append-if-absent value as before.
+  local inject_env="true"
+  local java_tool_options=""
+  if java_tool_options_sourced "${dep}"; then
+    inject_env="false"
+    echo "  ! WARNING: container '${dep}' sources JAVA_TOOL_OPTIONS indirectly" >&2
+    echo "    (via valueFrom and/or envFrom). NOT auto-injecting the Arrow" >&2
+    echo "    '${ARROW_ADD_OPENS}'" >&2
+    echo "    flag, because writing a literal env value would clobber the" >&2
+    echo "    operator's sourced JVM options. ACTION REQUIRED: add" >&2
+    echo "    '${ARROW_ADD_OPENS}'" >&2
+    echo "    to that JAVA_TOOL_OPTIONS source (the referenced ConfigMap/Secret)" >&2
+    echo "    yourself. The connector's ArrowMemoryPreflight probe (#2290) will" >&2
+    echo "    fail fast at catalog load if the flag is genuinely missing." >&2
+  else
+    java_tool_options=$(compute_java_tool_options "${dep}")
+  fi
   local patch
   patch=$(jq -n \
     --arg cm "${CONFIGMAP_NAME}" \
@@ -178,6 +237,7 @@ patch_deployment() {
     --arg container "${dep}" \
     --arg script "${INIT_SCRIPT}" \
     --arg javatooloptions "${java_tool_options}" \
+    --argjson injectenv "${inject_env}" \
     '{spec:{template:{spec:{
       volumes: [
         {name:"cqlite-plugin-src", configMap:{name:$cm}},
@@ -196,21 +256,23 @@ patch_deployment() {
         }
       ],
       containers: [
+        (
         {
           name:$container,
-          # JAVA_TOOL_OPTIONS carrying the Arrow add-opens flag (#2193/#2290),
-          # computed by compute_java_tool_options as <existing> + our flag (or
-          # <existing> unchanged if already present). A strategic-merge env entry
-          # keyed by name REPLACES the whole value, so we must supply the full
-          # append-if-absent result here — that keeps it idempotent and never
-          # clobbers a pre-existing JAVA_TOOL_OPTIONS.
-          env: [
-            {name:"JAVA_TOOL_OPTIONS", value:$javatooloptions}
-          ],
           volumeMounts: [
             {name:"cqlite-plugin-dir", mountPath:$mount, readOnly:true}
           ]
         }
+        # JAVA_TOOL_OPTIONS carrying the Arrow add-opens flag (#2193/#2290),
+        # computed by compute_java_tool_options as <existing> + our flag (or
+        # <existing> unchanged if already present). A strategic-merge env entry
+        # keyed by name REPLACES the whole value, so we supply the full
+        # append-if-absent result here — idempotent and never clobbers a
+        # pre-existing LITERAL JAVA_TOOL_OPTIONS. Omitted entirely when the value
+        # is sourced via valueFrom/envFrom ($injectenv=false), so we never
+        # overwrite an indirectly-sourced value with a literal.
+        + (if $injectenv then {env:[{name:"JAVA_TOOL_OPTIONS", value:$javatooloptions}]} else {} end)
+        )
       ]
     }}}}')
   local patch_output

--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -177,6 +177,28 @@ docker compose exec trino trino
 trino> SELECT * FROM cqlite.<keyspace>.<table> LIMIT 10;
 ```
 
+## Required JVM configuration (Arrow off-heap, JDK 17+)
+
+The connector uses Apache Arrow (`flight-core`) for off-heap columnar buffers. On JDK 17+
+arrow-java's `MemoryUtil` initializer needs the `java.nio` module opened to it, via this **exact**
+flag in Trino's `jvm.config`:
+
+```
+--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+```
+
+Trino 481's stock `jvm.config` does **not** include it. Without the flag, the first Arrow off-heap
+touch throws `ExceptionInInitializerError` in `MemoryUtil.<clinit>`, and every `do_get` on the
+Flight read path then fails far downstream with a cryptic `Failed to read message`.
+
+**Fail-fast:** the connector probes Arrow memory initialization once at catalog load
+(`ArrowMemoryPreflight`, before any query). If the flag is missing it raises a Trino
+`CONFIGURATION_INVALID` error naming this exact flag and the `jvm.config` remedy — instead of the
+opaque read-time failure. Add the flag to **every** coordinator and worker and restart.
+
+The bundled docker stack sets this in [`docker/trino/jvm.config`](docker/trino/jvm.config), and the
+k8s `trino-cqlite` kit injects it into both the coordinator and worker deployments automatically.
+
 ## Catalog configuration
 
 Catalog properties (`etc/catalog/cqlite.properties`):

--- a/trino-connector/docker/trino/jvm.config
+++ b/trino-connector/docker/trino/jvm.config
@@ -12,6 +12,8 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
-# Apache Arrow (Flight) off-heap memory access on JDK 17+.
---add-opens=java.base/java.nio=ALL-UNNAMED
+# Apache Arrow (Flight) off-heap memory access on JDK 17+ (issues #2193/#2290).
+# Use arrow-java's documented form so it matches the connector's fail-fast
+# remedy message (ArrowMemoryPreflight) and the k8s kit exactly.
+--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
 --enable-native-access=ALL-UNNAMED

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowMemoryPreflight.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowMemoryPreflight.java
@@ -2,6 +2,7 @@ package in.mcfad.cqlite.flight;
 
 import io.trino.spi.StandardErrorCode;
 import io.trino.spi.TrinoException;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.RootAllocator;
 
 /**
@@ -24,8 +25,9 @@ import org.apache.arrow.memory.RootAllocator;
  * {@code jvm.config} remedy — so the operator sees an actionable message at catalog load instead of
  * a masked read-time failure.
  *
- * <p>The probe is side-effect-free when the flag IS present: it opens a {@link RootAllocator} solely
- * to trigger {@code MemoryUtil} initialization and closes it immediately (try-with-resources).
+ * <p>The probe is side-effect-free when the flag IS present: it opens a {@link RootAllocator} and
+ * allocates a 1-byte off-heap {@link ArrowBuf} solely to force {@code MemoryUtil} initialization
+ * along the real off-heap/DirectByteBuffer path, then closes both immediately (try-with-resources).
  */
 final class ArrowMemoryPreflight {
     /** The exact arrow-java-documented flag that must be present in Trino's {@code jvm.config}. */
@@ -40,10 +42,13 @@ final class ArrowMemoryPreflight {
      * message names the exact missing flag and the {@code jvm.config} remedy.
      */
     static void verify() {
-        try (RootAllocator probe = new RootAllocator()) {
-            // Constructing the allocator forces MemoryUtil.<clinit>. Success => the flag is present;
-            // the allocator is closed immediately by try-with-resources, so the probe has no effect.
-            assert probe != null;
+        try (RootAllocator probe = new RootAllocator();
+                ArrowBuf ignored = probe.buffer(1)) {
+            // Constructing the allocator AND allocating a 1-byte off-heap buffer forces
+            // MemoryUtil.<clinit> along the real DirectByteBuffer/off-heap path (a bare RootAllocator
+            // may not). Success => the flag is present; both are closed immediately by
+            // try-with-resources, so the probe has no lasting effect.
+            assert ignored != null;
         } catch (LinkageError | RuntimeException e) {
             throwIfArrowMemoryInit(e);
         }
@@ -73,7 +78,11 @@ final class ArrowMemoryPreflight {
      * static initializer — matched by message text or by a {@code MemoryUtil} frame in a stack trace.
      */
     static boolean isArrowMemoryInitFailure(Throwable failure) {
-        for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+        // Bounded walk: cap the depth so a self-referential (A->A) OR multi-node (A->B->A) cause
+        // cycle can never make this loop forever.
+        int depth = 0;
+        for (Throwable cause = failure; cause != null && depth < MAX_CAUSE_CHAIN_DEPTH;
+                cause = cause.getCause(), depth++) {
             String message = cause.getMessage();
             if (message != null && message.contains("MemoryUtil")) {
                 return true;
@@ -83,12 +92,12 @@ final class ArrowMemoryPreflight {
                     return true;
                 }
             }
-            if (cause.getCause() == cause) {
-                break;
-            }
         }
         return false;
     }
+
+    /** Hard cap on how many links of a Throwable cause chain to walk (guards against cause cycles). */
+    private static final int MAX_CAUSE_CHAIN_DEPTH = 50;
 
     /**
      * Build the operator-facing remedy message. Always names {@value #REQUIRED_ADD_OPENS} verbatim so

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowMemoryPreflight.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/ArrowMemoryPreflight.java
@@ -1,0 +1,111 @@
+package in.mcfad.cqlite.flight;
+
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
+import org.apache.arrow.memory.RootAllocator;
+
+/**
+ * Fail-fast preflight for arrow-java's off-heap memory initialization (issues #2193, #2290).
+ *
+ * <p>On JDK 17+ arrow-java's {@code org.apache.arrow.memory.util.MemoryUtil} static initializer
+ * needs the {@code java.nio} module opened to it via the JVM flag
+ * {@value #REQUIRED_ADD_OPENS}. When the flag is absent, {@code MemoryUtil.<clinit>} throws an
+ * {@link ExceptionInInitializerError} on the FIRST Arrow off-heap touch (here, constructing a
+ * {@link RootAllocator}); every later touch throws {@link NoClassDefFoundError} because the class
+ * failed to initialize. On the Flight read path this surfaces far downstream as a cryptic
+ * {@code Failed to read message} on the first {@code do_get} frame, with nothing pointing at the
+ * real cause.
+ *
+ * <p>Trino 481's stock {@code jvm.config} does not carry the flag, and deployment kits that do not
+ * inject it (e.g. the k8s {@code trino-cqlite} kit before #2290) leave every query broken. This
+ * preflight runs once, at connector construction (before any split/query), probes the exact
+ * initialization arrow-java would perform, and on failure raises a {@link
+ * StandardErrorCode#CONFIGURATION_INVALID} error naming the exact missing flag and the
+ * {@code jvm.config} remedy — so the operator sees an actionable message at catalog load instead of
+ * a masked read-time failure.
+ *
+ * <p>The probe is side-effect-free when the flag IS present: it opens a {@link RootAllocator} solely
+ * to trigger {@code MemoryUtil} initialization and closes it immediately (try-with-resources).
+ */
+final class ArrowMemoryPreflight {
+    /** The exact arrow-java-documented flag that must be present in Trino's {@code jvm.config}. */
+    static final String REQUIRED_ADD_OPENS =
+            "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED";
+
+    private ArrowMemoryPreflight() {}
+
+    /**
+     * Probe arrow-java off-heap memory initialization. Returns normally (and leaves no allocator
+     * open) when the required JVM flag is present; otherwise throws a {@link TrinoException} whose
+     * message names the exact missing flag and the {@code jvm.config} remedy.
+     */
+    static void verify() {
+        try (RootAllocator probe = new RootAllocator()) {
+            // Constructing the allocator forces MemoryUtil.<clinit>. Success => the flag is present;
+            // the allocator is closed immediately by try-with-resources, so the probe has no effect.
+            assert probe != null;
+        } catch (LinkageError | RuntimeException e) {
+            throwIfArrowMemoryInit(e);
+        }
+    }
+
+    /**
+     * If {@code failure} is (or is caused by) an arrow-java {@code MemoryUtil} initialization
+     * failure, throw an actionable {@link TrinoException}; otherwise rethrow {@code failure}
+     * unchanged so unrelated errors are never masked. Package-private for direct unit testing of
+     * both the arrow-init path and the pass-through path without manipulating JVM flags.
+     */
+    static void throwIfArrowMemoryInit(Throwable failure) {
+        if (isArrowMemoryInitFailure(failure)) {
+            throw new TrinoException(StandardErrorCode.CONFIGURATION_INVALID, formatMessage(failure), failure);
+        }
+        if (failure instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (failure instanceof Error error) {
+            throw error;
+        }
+        throw new RuntimeException(failure);
+    }
+
+    /**
+     * True when {@code failure} (or any cause in its chain) points at arrow-java's {@code MemoryUtil}
+     * static initializer — matched by message text or by a {@code MemoryUtil} frame in a stack trace.
+     */
+    static boolean isArrowMemoryInitFailure(Throwable failure) {
+        for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+            String message = cause.getMessage();
+            if (message != null && message.contains("MemoryUtil")) {
+                return true;
+            }
+            for (StackTraceElement frame : cause.getStackTrace()) {
+                if (frame.getClassName().contains("MemoryUtil")) {
+                    return true;
+                }
+            }
+            if (cause.getCause() == cause) {
+                break;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Build the operator-facing remedy message. Always names {@value #REQUIRED_ADD_OPENS} verbatim so
+     * an operator can copy it straight into {@code jvm.config}.
+     */
+    static String formatMessage(Throwable failure) {
+        String detail = "unknown cause";
+        if (failure != null) {
+            detail = failure.getClass().getSimpleName();
+            if (failure.getMessage() != null) {
+                detail = detail + ": " + failure.getMessage();
+            }
+        }
+        return "CQLite Flight connector cannot initialize Apache Arrow off-heap memory (" + detail + "). "
+                + "arrow-java requires the java.nio module to be opened to it on JDK 17+. "
+                + "Add this exact line to Trino's jvm.config and restart every coordinator and worker:\n    "
+                + REQUIRED_ADD_OPENS + "\n"
+                + "See the connector README section \"Required JVM configuration\" for details.";
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
@@ -29,6 +29,11 @@ public class CqliteFlightConnector implements Connector {
         // + port (uniform across the hostNetwork Sidecar DaemonSet) and the split host.
         this.snapshots = new SnapshotManager(
                 HostSnapshotApis.fromBaseUri(config.sidecarUri()), config.readMode(), config.snapshotTtl());
+        // Fail fast at catalog load if arrow-java's off-heap memory init is broken by a missing JVM
+        // flag (issues #2193, #2290) — otherwise every do_get dies far downstream with a cryptic
+        // "Failed to read message". Runs before the first RootAllocator (the earliest Arrow touch)
+        // and is a no-op when the flag is present.
+        ArrowMemoryPreflight.verify();
         this.allocator = new RootAllocator();
         this.flight = new CqliteFlightClient(allocator);
     }

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowMemoryPreflightTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowMemoryPreflightTest.java
@@ -86,6 +86,46 @@ class ArrowMemoryPreflightTest {
         assertSame(original, rethrown);
     }
 
+    /**
+     * A Throwable whose cause is redirectable so tests can build a cause cycle without reflection
+     * ({@link Throwable#initCause} forbids cycles at runtime). Its stack trace is empty, so it never
+     * matches the MemoryUtil frame heuristic.
+     */
+    private static final class CyclicThrowable extends RuntimeException {
+        private transient Throwable redirected;
+
+        CyclicThrowable(String message) {
+            super(message);
+            setStackTrace(new StackTraceElement[0]);
+        }
+
+        void setCauseNode(Throwable next) {
+            this.redirected = next;
+        }
+
+        @Override
+        public synchronized Throwable getCause() {
+            return redirected;
+        }
+    }
+
+    @Test
+    void twoNodeCauseCycleTerminatesAndIsNotMisclassified() {
+        // A -> B -> A: a 2-node cause cycle. The classifier must terminate (bounded walk) and, since
+        // neither node points at MemoryUtil, must return false rather than hang or misclassify.
+        // assertTimeoutPreemptively guards against a regression to an unbounded walk.
+        org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(
+                java.time.Duration.ofSeconds(5),
+                () -> {
+                    CyclicThrowable a = new CyclicThrowable("node A: unrelated");
+                    CyclicThrowable b = new CyclicThrowable("node B: unrelated");
+                    a.setCauseNode(b);
+                    b.setCauseNode(a);
+                    assertFalse(ArrowMemoryPreflight.isArrowMemoryInitFailure(a),
+                            "a 2-node cause cycle with no MemoryUtil frame must not be classified as arrow-init");
+                });
+    }
+
     @Test
     void verifyPassesWhenFlagPresent() {
         // The Gradle test JVM carries the add-opens flag, so the real probe must succeed and leave

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowMemoryPreflightTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ArrowMemoryPreflightTest.java
@@ -1,0 +1,95 @@
+package in.mcfad.cqlite.flight;
+
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fail-fast arrow-java memory preflight (issues #2193, #2290): the probe must raise an actionable
+ * Trino configuration error — naming the EXACT missing JVM flag — when arrow-java's {@code MemoryUtil}
+ * static initializer fails, and must pass unrelated errors through untouched so it never masks a
+ * different bug.
+ *
+ * <p>The Gradle test JVM sets the add-opens flag (build.gradle.kts), so {@link
+ * ArrowMemoryPreflight#verify()} succeeds here; the flag-absent path is exercised by driving the
+ * classifier/formatter with a synthesized arrow-init failure rather than manipulating live JVM flags.
+ */
+class ArrowMemoryPreflightTest {
+
+    private static ExceptionInInitializerError memoryUtilInitFailure() {
+        // Mirror the real failure shape: MemoryUtil.<clinit> throws, wrapped by the JVM in an
+        // ExceptionInInitializerError whose stack frame is in ...memory.util.MemoryUtil.
+        RuntimeException clinit = new RuntimeException(
+                "Failed to initialize MemoryUtil: java.nio not open to org.apache.arrow.memory.core");
+        clinit.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("org.apache.arrow.memory.util.MemoryUtil", "<clinit>", "MemoryUtil.java", 1)
+        });
+        return new ExceptionInInitializerError(clinit);
+    }
+
+    @Test
+    void messageNamesTheExactMissingFlag() {
+        String message = ArrowMemoryPreflight.formatMessage(memoryUtilInitFailure());
+        assertTrue(message.contains(
+                        "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"),
+                "remedy must name the exact arrow-java-documented flag");
+        assertTrue(message.contains("jvm.config"), "remedy must point at jvm.config");
+        assertEquals("--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED",
+                ArrowMemoryPreflight.REQUIRED_ADD_OPENS);
+    }
+
+    @Test
+    void classifiesMemoryUtilInitFailureByStackFrame() {
+        assertTrue(ArrowMemoryPreflight.isArrowMemoryInitFailure(memoryUtilInitFailure()));
+    }
+
+    @Test
+    void classifiesMemoryUtilFailureByMessage() {
+        assertTrue(ArrowMemoryPreflight.isArrowMemoryInitFailure(
+                new NoClassDefFoundError("Could not initialize class org.apache.arrow.memory.util.MemoryUtil")));
+    }
+
+    @Test
+    void unrelatedFailureIsNotClassified() {
+        assertFalse(ArrowMemoryPreflight.isArrowMemoryInitFailure(
+                new IllegalStateException("some other connector bug")));
+    }
+
+    @Test
+    void arrowInitFailureBecomesConfigurationInvalid() {
+        TrinoException thrown = assertThrows(TrinoException.class,
+                () -> ArrowMemoryPreflight.throwIfArrowMemoryInit(memoryUtilInitFailure()));
+        assertEquals(StandardErrorCode.CONFIGURATION_INVALID.toErrorCode(), thrown.getErrorCode());
+        assertTrue(thrown.getMessage().contains(
+                "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"));
+    }
+
+    @Test
+    void unrelatedRuntimeExceptionIsRethrownUnchanged() {
+        IllegalStateException original = new IllegalStateException("unrelated boom");
+        IllegalStateException rethrown = assertThrows(IllegalStateException.class,
+                () -> ArrowMemoryPreflight.throwIfArrowMemoryInit(original));
+        assertSame(original, rethrown, "unrelated errors must pass through untouched, never masked");
+    }
+
+    @Test
+    void unrelatedErrorIsRethrownUnchanged() {
+        OutOfMemoryError original = new OutOfMemoryError("heap");
+        OutOfMemoryError rethrown = assertThrows(OutOfMemoryError.class,
+                () -> ArrowMemoryPreflight.throwIfArrowMemoryInit(original));
+        assertSame(original, rethrown);
+    }
+
+    @Test
+    void verifyPassesWhenFlagPresent() {
+        // The Gradle test JVM carries the add-opens flag, so the real probe must succeed and leave
+        // no allocator open (side-effect-free happy path).
+        ArrowMemoryPreflight.verify();
+    }
+}

--- a/website/src/content/docs/user-docs/flight-trino.md
+++ b/website/src/content/docs/user-docs/flight-trino.md
@@ -235,6 +235,27 @@ tasks.register<Sync>("assemblePlugin") {
 flight-core + jackson + transitive deps). `trino-spi` is intentionally **not** a
 runtime dependency — Trino supplies it from the engine classpath.
 
+### Required JVM configuration (Arrow off-heap, JDK 17+)
+
+The connector reads Flight batches into off-heap Apache Arrow buffers. On JDK 17+
+arrow-java's `MemoryUtil` initializer needs the `java.nio` module opened to it, so
+Trino's `jvm.config` **must** contain this exact line:
+
+```
+--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+```
+
+Trino 481's stock `jvm.config` does not include it. Without the flag the first
+Arrow off-heap touch fails in `MemoryUtil.<clinit>`, and every `do_get` then dies
+downstream with an opaque `Failed to read message`. Add the flag to **every**
+coordinator and worker, then restart.
+
+The connector fails fast to make this actionable: it probes Arrow memory
+initialization once at catalog load and, if the flag is missing, raises a Trino
+`CONFIGURATION_INVALID` error naming this exact flag and the `jvm.config` remedy —
+rather than surfacing the cryptic read-time error. The bundled docker stack and
+the k8s `trino-cqlite` kit both configure the flag for you.
+
 ### Catalog configuration and read mode
 
 Configure a catalog in `etc/catalog/cqlite.properties`. The first line must select


### PR DESCRIPTION
Closes #2193
Closes #2290

## Problem

On JDK 17+, arrow-java's `MemoryUtil.<clinit>` requires the JVM flag
`--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`. Trino 481's stock
`jvm.config` does **not** carry it, and the k8s `trino-cqlite` kit did not add it. So the CQLite
Flight connector's first Arrow off-heap touch (`new RootAllocator()`) died in the static
initializer, and every `do_get` on the read path then failed far downstream with a cryptic
`Failed to read message` — with nothing pointing operators at the real cause. Adding the flag and
restarting Trino makes the whole read path work.

## Fix (one PR, three layers)

1. **k8s kit provisions the flag** — `easy-db-lab-kits/trino-cqlite/bin/reapply-plugin-patch.sh.template`
   now injects `JAVA_TOOL_OPTIONS=--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`
   into both the `trino-coordinator` and `trino-worker` container specs, via the same always-run
   strategic-merge patch (`patch_deployment`). `JAVA_TOOL_OPTIONS` is additive (the JVM appends it to
   the launcher args) so it doesn't require reproducing/version-tracking the image's whole stock
   `jvm.config` the way a file-mount would; strategic merge keys `env` by name, so re-applying the
   fixed value is a no-op (idempotent).

2. **Connector fail-fast** — new `ArrowMemoryPreflight.verify()` runs once at connector construction
   (before the first `RootAllocator`). It probes Arrow memory init in a try-with-resources allocator
   (side-effect-free when the flag is present), and on a `MemoryUtil` init failure raises a Trino
   `CONFIGURATION_INVALID` error naming the **exact** missing flag and the `jvm.config` remedy.
   Unrelated errors pass through untouched (never masked).

3. **Docs** — a "Required JVM configuration" section in `trino-connector/README.md` and
   `website/src/content/docs/user-docs/flight-trino.md` documents the flag, why (arrow-java JDK17+
   module access for off-heap), and the fail-fast behavior.

## Why the docker e2e never caught this (the blind spot)

The docker e2e passes without the fix because `docker/docker-compose.yml` mounts
`docker/trino/jvm.config`, and that file already contained an add-opens flag (the looser
`...=ALL-UNNAMED` form). So local e2e exercised a Trino that always had the module opened, while the
kit-based deployment — and any other deployment shape that starts from Trino's stock `jvm.config` —
had no such flag and broke on the first frame. The e2e's own jvm.config masked the failure it was
supposed to guard. That is exactly why the **connector-side fail-fast probe (layer 2)** is the
durable protection: it fires at catalog load on *any* deployment shape, regardless of how (or
whether) `jvm.config` was provisioned, turning a cryptic read-time `Failed to read message` into an
actionable configuration error. (I also aligned `docker/trino/jvm.config` to the exact arrow-java
form so the docker stack, the kit, and the fail-fast message all name the identical flag.)

## Verification

- `cd trino-connector && ./gradlew test` — GREEN (314 tests, 0 failures), including the new
  `ArrowMemoryPreflightTest` (9 cases: message names the exact flag, classifier matches
  MemoryUtil-init failures by message and by stack frame, arrow-init → `CONFIGURATION_INVALID`,
  unrelated errors rethrown unchanged, a 2-node cause-cycle terminates without hang/misclassification,
  and `verify()` passes side-effect-free — forcing a 1-byte off-heap `ArrowBuf` allocation so the probe
  truly exercises the `MemoryUtil` path — when the flag is present in the Gradle test JVM).
- Kit template: `shellcheck` clean; jq patch validated to emit the correct `env` entry; idempotent
  by strategic-merge semantics.

## Review hardening (addressed in-branch)

- The preflight probe now forces a 1-byte off-heap `ArrowBuf` allocation, so it genuinely exercises the
  `MemoryUtil`/java.nio path a bare `RootAllocator` could skip.
- The kit **appends** to `JAVA_TOOL_OPTIONS` if-absent rather than clobbering an existing literal value,
  and when the var is sourced via `valueFrom`/`envFrom` it emits a loud actionable warning and skips the
  literal overwrite (the connector fail-fast probe is the backstop).
- The cause-chain walk is now bounded so any cyclic cause chain terminates.

Non-blocking follow-up nits (uninstall flag-strip; two additional test branches) are batched in #2296.
