### PR TITLE
fix(#2264): cooperative scan cancellation through cqlite-core read paths — LIMIT queries abort promptly on client cancel

### DIFF
--- a/bindings/node/__test__/typescript-definitions.test.js
+++ b/bindings/node/__test__/typescript-definitions.test.js
@@ -237,6 +237,14 @@ describe('TypeScript Definitions (Issue #312)', () => {
       expect(dtsContent).toMatch(/type\s+ErrorCode[\s\S]*?\|\s*['"]PARSE['"]/);
     });
 
+    test('should include CANCELLED error code (issue #2264)', () => {
+      expect(dtsContent).toMatch(/type\s+ErrorCode[\s\S]*?\|\s*['"]CANCELLED['"]/);
+    });
+
+    test('should include Cancelled error category (issue #2264)', () => {
+      expect(dtsContent).toMatch(/type\s+ErrorCategory[\s\S]*?\|\s*['"]Cancelled['"]/);
+    });
+
     test('CqliteError should extend Error', () => {
       expect(dtsContent).toMatch(/interface\s+CqliteError\s+extends\s+Error\b/);
     });

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -791,7 +791,8 @@ export type ErrorCode =
   | 'CONSTRAINT'   // Constraint violations
   | 'TRANSACTION'  // Transaction errors
   | 'PLATFORM'     // Platform-specific errors (WASM)
-  | 'INTERNAL';    // Internal errors
+  | 'INTERNAL'     // Internal errors
+  | 'CANCELLED';   // Cooperative scan cancellation (issue #2264 — never 'IO')
 
 /**
  * Error category names for CQLite errors.
@@ -813,7 +814,8 @@ export type ErrorCategory =
   | 'Constraint'
   | 'Transaction'
   | 'Platform'
-  | 'Internal';
+  | 'Internal'
+  | 'Cancelled';
 
 /**
  * CQLite error interface.

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -537,6 +537,7 @@ mod tests {
                 Error::Compaction(_) => {}
                 Error::Internal(_) => {}
                 Error::Parse(_) => {}
+                Error::Cancelled => {}
 
                 // Write-dir lock conflict — Concurrency category, maps to CONCURRENCY code
                 Error::WriteDirLocked { .. } => {

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -28,6 +28,7 @@
 //! | Transaction | `TRANSACTION` | (original) |
 //! | Platform | `PLATFORM` | (original) |
 //! | Internal | `INTERNAL` | (original) |
+//! | Cancelled | `CANCELLED` | `CancelledError:` (issue #2264 — never `IO`) |
 //!
 //! # Example
 //!
@@ -83,6 +84,10 @@ pub fn category_to_code(category: ErrorCategory) -> &'static str {
         ErrorCategory::Transaction => "TRANSACTION",
         ErrorCategory::Platform => "PLATFORM",
         ErrorCategory::Internal => "INTERNAL",
+        // Issue #2264: a cooperative cancellation gets its OWN code — it must
+        // never fall through to (or be confused with) `IO`, a genuine
+        // transport/filesystem failure.
+        ErrorCategory::Cancelled => "CANCELLED",
     }
 }
 
@@ -95,6 +100,7 @@ fn category_to_prefix(category: ErrorCategory) -> Option<&'static str> {
         ErrorCategory::Data => Some("ParseError"),
         ErrorCategory::Configuration => Some("ValueError"),
         ErrorCategory::Logic => Some("RuntimeError"),
+        ErrorCategory::Cancelled => Some("CancelledError"),
         // Other categories don't have special prefixes
         _ => None,
     }
@@ -517,6 +523,13 @@ mod tests {
                 Error::InvalidState(_) => {
                     assert_eq!(err.category(), ErrorCategory::Logic);
                 }
+                // Issue #2264: a cooperative cancellation must classify as
+                // `Cancelled` — NEVER `System` (which `category_to_code` maps
+                // to the misleading "IO" JS code).
+                Error::Cancelled => {
+                    assert_eq!(err.category(), ErrorCategory::Cancelled);
+                    assert_eq!(category_to_code(err.category()), "CANCELLED");
+                }
 
                 // All other variants are handled by category
                 Error::Serialization { .. } => {}
@@ -537,7 +550,6 @@ mod tests {
                 Error::Compaction(_) => {}
                 Error::Internal(_) => {}
                 Error::Parse(_) => {}
-                Error::Cancelled => {}
 
                 // Write-dir lock conflict — Concurrency category, maps to CONCURRENCY code
                 Error::WriteDirLocked { .. } => {
@@ -554,6 +566,7 @@ mod tests {
             Error::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "test")),
             Error::Schema("test".to_string()),
             Error::Corruption("test".to_string()),
+            Error::Cancelled,
         ];
 
         for err in &test_errors {
@@ -581,6 +594,7 @@ mod tests {
             ErrorCategory::Transaction,
             ErrorCategory::Platform,
             ErrorCategory::Internal,
+            ErrorCategory::Cancelled,
         ];
 
         for category in categories {

--- a/bindings/python/python/cqlite/__init__.py
+++ b/bindings/python/python/cqlite/__init__.py
@@ -14,6 +14,7 @@ from cqlite._cqlite import (
     SchemaError,
     QueryError,
     ParseError,
+    CancelledError,
     # Configuration
     StreamingConfig,
     memory_optimized,
@@ -54,6 +55,7 @@ __all__ = [
     "SchemaError",
     "QueryError",
     "ParseError",
+    "CancelledError",
     # Configuration
     "StreamingConfig",
     "memory_optimized",

--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -41,6 +41,10 @@ class ParseError(CqliteError):
     """Raised when CQL query parsing fails."""
     ...
 
+class CancelledError(CqliteError):
+    """Raised when a cooperatively-cancelled operation aborts (issue #2264)."""
+    ...
+
 # Configuration
 class StreamingConfig:
     """Configuration for streaming query execution.

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -33,6 +33,12 @@ create_exception!(cqlite, QueryError, CqliteError);
 // CQL parsing errors (CqlParse variant)
 create_exception!(cqlite, ParseError, CqliteError);
 
+// A cooperative cancellation / abort (issue #2264). Dedicated so a cancelled
+// scan is never mislabeled as (or silently folded into) a generic CqliteError
+// — callers can `except cqlite.CancelledError` precisely, matching the Node
+// binding's dedicated `CANCELLED` code.
+create_exception!(cqlite, CancelledError, CqliteError);
+
 /// Register all exception types with the Python module.
 ///
 /// This function must be called during module initialization to make
@@ -42,6 +48,7 @@ pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("SchemaError", m.py().get_type::<SchemaError>())?;
     m.add("QueryError", m.py().get_type::<QueryError>())?;
     m.add("ParseError", m.py().get_type::<ParseError>())?;
+    m.add("CancelledError", m.py().get_type::<CancelledError>())?;
     Ok(())
 }
 
@@ -61,6 +68,7 @@ pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 /// | `Configuration`, `InvalidInput` | `ValueError` (builtin) |
 /// | `Timeout` | `TimeoutError` (builtin) |
 /// | `Memory` | `MemoryError` (builtin) |
+/// | `Cancelled` | `CancelledError` (issue #2264 — never `IOError`) |
 /// | All others | `CqliteError` (base) |
 pub fn to_py_err(err: cqlite_core::Error) -> PyErr {
     let message = err.to_string();
@@ -102,6 +110,11 @@ pub fn to_py_err(err: cqlite_core::Error) -> PyErr {
         // Write-dir lock conflict -> CqliteError with clear message
         // The formatted message already contains the path and advice
         cqlite_core::Error::WriteDirLocked { .. } => CqliteError::new_err(message),
+
+        // A cooperative cancellation -> dedicated CancelledError (issue #2264),
+        // NOT the base CqliteError (would be indistinguishable from any other
+        // failure) and NEVER IOError (not a transport/filesystem failure).
+        cqlite_core::Error::Cancelled => CancelledError::new_err(message),
 
         // All other errors -> CqliteError (base exception)
         // See test_error_mapping_completeness() for the complete list of unmapped variants
@@ -263,6 +276,22 @@ mod tests {
         });
     }
 
+    /// Issue #2264: a cooperative cancellation must surface as a DEDICATED
+    /// `CancelledError`, and explicitly NEVER as `IOError` (the pre-fix
+    /// behaviour: `Error::Cancelled` fell into `ErrorCategory::System`).
+    #[test]
+    fn test_cancelled_maps_to_cancellederror_not_ioerror() {
+        let py_err = to_py_err(Error::Cancelled);
+
+        Python::with_gil(|py| {
+            assert!(py_err.is_instance_of::<CancelledError>(py));
+            assert!(
+                !py_err.is_instance_of::<PyIOError>(py),
+                "a cooperative cancellation must never surface as IOError"
+            );
+        });
+    }
+
     #[test]
     fn test_other_errors_map_to_cqliteerror() {
         // Test several "other" error types that should map to base CqliteError
@@ -337,6 +366,7 @@ mod tests {
     /// | `Timeout` | `TimeoutError` (builtin) | Operation timeouts |
     /// | `Memory` | `MemoryError` (builtin) | Memory allocation |
     /// | `InvalidState` | `RuntimeError` (builtin) | Invalid state (e.g., closed DB) |
+    /// | `Cancelled` | `CancelledError` | Cooperative abort (issue #2264) — never `IOError` |
     /// | `Serialization` | `CqliteError` (base) | Unmapped - generic error |
     /// | `Corruption` | `CqliteError` (base) | Unmapped - generic error |
     /// | `InvalidFormat` | `CqliteError` (base) | Unmapped - generic error |
@@ -379,6 +409,7 @@ mod tests {
                 Error::Timeout(_) => { /* Maps to PyTimeoutError */ }
                 Error::Memory(_) => { /* Maps to PyMemoryError */ }
                 Error::InvalidState(_) => { /* Maps to PyRuntimeError */ }
+                Error::Cancelled => { /* Maps to CancelledError (issue #2264) — NEVER IOError */ }
 
                 // === Unmapped variants (fall through to base CqliteError) ===
                 Error::Serialization { .. } => { /* Maps to CqliteError */ }
@@ -399,7 +430,6 @@ mod tests {
                 Error::Compaction(_) => { /* Maps to CqliteError */ }
                 Error::Internal(_) => { /* Maps to CqliteError */ }
                 Error::Parse(_) => { /* Maps to CqliteError */ }
-                Error::Cancelled => { /* Maps to CqliteError (issue #2264) */ }
 
                 // Write-dir lock conflict — maps to CqliteError with clear message
                 Error::WriteDirLocked { .. } => { /* Maps to CqliteError */ }
@@ -421,6 +451,7 @@ mod tests {
                 message: "test".to_string(),
                 source: None,
             },
+            Error::Cancelled,
         ];
 
         for err in &test_errors {

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -399,6 +399,7 @@ mod tests {
                 Error::Compaction(_) => { /* Maps to CqliteError */ }
                 Error::Internal(_) => { /* Maps to CqliteError */ }
                 Error::Parse(_) => { /* Maps to CqliteError */ }
+                Error::Cancelled => { /* Maps to CqliteError (issue #2264) */ }
 
                 // Write-dir lock conflict — maps to CqliteError with clear message
                 Error::WriteDirLocked { .. } => { /* Maps to CqliteError */ }

--- a/cqlite-core/src/error.rs
+++ b/cqlite-core/src/error.rs
@@ -176,6 +176,15 @@ pub enum Error {
     /// Unsupported query error
     #[error("Unsupported query: {0}")]
     UnsupportedQuery(String),
+
+    /// The operation was cooperatively cancelled (issue #2264).
+    ///
+    /// Raised by a long-running scan (e.g. the compaction streaming read) when
+    /// its cancellation token is tripped — a client disconnect propagated from
+    /// the Flight `do_get` path. Distinct from a genuine failure so callers can
+    /// treat it as a clean, expected abort rather than corruption.
+    #[error("Operation cancelled")]
+    Cancelled,
 }
 
 impl Error {
@@ -377,6 +386,9 @@ impl Error {
             Error::InvalidState(_) => false,
             Error::Timeout(_) => false,
             Error::UnsupportedQuery(_) => false,
+            // A cancelled operation is deliberate, not a transient fault: re-running
+            // it would just be cancelled again. The caller decides whether to retry.
+            Error::Cancelled => false,
         }
     }
 
@@ -422,6 +434,7 @@ impl Error {
             Error::InvalidState(_) => ErrorCategory::Logic,
             Error::Timeout(_) => ErrorCategory::System,
             Error::UnsupportedQuery(_) => ErrorCategory::Query,
+            Error::Cancelled => ErrorCategory::System,
         }
     }
 }

--- a/cqlite-core/src/error.rs
+++ b/cqlite-core/src/error.rs
@@ -434,7 +434,7 @@ impl Error {
             Error::InvalidState(_) => ErrorCategory::Logic,
             Error::Timeout(_) => ErrorCategory::System,
             Error::UnsupportedQuery(_) => ErrorCategory::Query,
-            Error::Cancelled => ErrorCategory::System,
+            Error::Cancelled => ErrorCategory::Cancelled,
         }
     }
 }
@@ -470,6 +470,10 @@ pub enum ErrorCategory {
     Platform,
     /// Internal errors
     Internal,
+    /// A cooperative cancellation / abort (issue #2264). Distinct from
+    /// `System` (I/O, memory) so a cancelled operation is never mislabeled as
+    /// a transport/IO failure by a consumer that switches on category.
+    Cancelled,
 }
 
 impl fmt::Display for ErrorCategory {
@@ -489,6 +493,7 @@ impl fmt::Display for ErrorCategory {
             ErrorCategory::Transaction => "Transaction",
             ErrorCategory::Platform => "Platform",
             ErrorCategory::Internal => "Internal",
+            ErrorCategory::Cancelled => "Cancelled",
         };
         write!(f, "{}", name)
     }
@@ -711,6 +716,9 @@ mod tests {
             Error::write_dir_locked("/tmp/test").category(),
             ErrorCategory::Concurrency
         );
+        // Issue #2264: a cooperative cancellation must NEVER classify as
+        // `System` (which downstream bindings map to an I/O error code).
+        assert_eq!(Error::Cancelled.category(), ErrorCategory::Cancelled);
     }
 
     #[test]
@@ -758,6 +766,7 @@ mod tests {
         assert_eq!(ErrorCategory::Transaction.to_string(), "Transaction");
         assert_eq!(ErrorCategory::Platform.to_string(), "Platform");
         assert_eq!(ErrorCategory::Internal.to_string(), "Internal");
+        assert_eq!(ErrorCategory::Cancelled.to_string(), "Cancelled");
     }
 
     #[test]

--- a/cqlite-core/src/observability/error_schema.rs
+++ b/cqlite-core/src/observability/error_schema.rs
@@ -20,6 +20,7 @@
 //! | `Concurrency`  | `concurrency`    | `Concurrency`, `Transaction`                                       |
 //! | `Constraints`  | `constraints`    | `ConstraintViolation`, `AlreadyExists`                            |
 //! | `Query`        | `query`          | `QueryExecution`, `UnsupportedQuery`, `InvalidInput`             |
+//! | `Cancelled`    | `cancelled`      | `Cancelled` (issue #2264 — a cooperative abort, never `Io`)       |
 //! | `Other`        | `other`          | `Configuration`, `InvalidState`, `InvalidOperation`, `NotFound`,  |
 //! |                |                  | `Internal`, `Wasm`, and any future variant (catch-all)            |
 //!
@@ -60,6 +61,11 @@ pub enum ErrorCategory {
     Constraints,
     /// Query execution / unsupported queries / bad input.
     Query,
+    /// A cooperative cancellation / abort (issue #2264). Kept distinct from
+    /// `Other` (and never `Io`) so dashboards can see cancellation rate
+    /// separately from genuine errors — a cancelled `do_get` is an expected
+    /// outcome, not a fault.
+    Cancelled,
     /// Everything else (configuration, internal, platform, catch-all).
     Other,
 }
@@ -78,6 +84,7 @@ impl ErrorCategory {
             ErrorCategory::Concurrency => "concurrency",
             ErrorCategory::Constraints => "constraints",
             ErrorCategory::Query => "query",
+            ErrorCategory::Cancelled => "cancelled",
             ErrorCategory::Other => "other",
         }
     }
@@ -93,6 +100,7 @@ impl ErrorCategory {
         ErrorCategory::Concurrency,
         ErrorCategory::Constraints,
         ErrorCategory::Query,
+        ErrorCategory::Cancelled,
         ErrorCategory::Other,
     ];
 }
@@ -137,6 +145,10 @@ pub(crate) fn classify(err: &Error) -> ErrorCategory {
         | Error::UnsupportedQuery(_)
         | Error::InvalidInput(_) => ErrorCategory::Query,
 
+        // Issue #2264: a cooperative cancellation is an expected outcome, not a
+        // fault — kept out of both `Io` and the `Other` catch-all.
+        Error::Cancelled => ErrorCategory::Cancelled,
+
         // Catch-all for the remaining variants and any future additions. Listed
         // explicitly (no wildcard arm besides wasm) so that adding a new Error
         // variant forces a compile decision here.
@@ -144,7 +156,6 @@ pub(crate) fn classify(err: &Error) -> ErrorCategory {
         | Error::InvalidState(_)
         | Error::InvalidOperation(_)
         | Error::NotFound(_)
-        | Error::Cancelled
         | Error::Internal(_) => ErrorCategory::Other,
 
         #[cfg(target_arch = "wasm32")]
@@ -231,5 +242,10 @@ mod tests {
         assert_eq!(Error::invalid_operation("o").obs_category(), Other);
         assert_eq!(Error::not_found("n").obs_category(), Other);
         assert_eq!(Error::internal("i").obs_category(), Other);
+
+        // Issue #2264: a cooperative cancellation must be its OWN bucket, not
+        // `Io` (misleading — it is not a transport failure) and not lumped into
+        // the generic `Other` catch-all (would hide cancellation rate).
+        assert_eq!(Error::Cancelled.obs_category(), Cancelled);
     }
 }

--- a/cqlite-core/src/observability/error_schema.rs
+++ b/cqlite-core/src/observability/error_schema.rs
@@ -144,6 +144,7 @@ pub(crate) fn classify(err: &Error) -> ErrorCategory {
         | Error::InvalidState(_)
         | Error::InvalidOperation(_)
         | Error::NotFound(_)
+        | Error::Cancelled
         | Error::Internal(_) => ErrorCategory::Other,
 
         #[cfg(target_arch = "wasm32")]

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -2,6 +2,8 @@
 
 /// Shared, bytes-bounded, sharded decompressed-chunk cache (issue #1567).
 pub mod cache;
+/// Cooperative cancellation for long-running synchronous scans (issue #2264).
+pub mod scan_cancel;
 pub mod sstable;
 
 // Canonical partition-key (de)serialization, shared by the read (query) path

--- a/cqlite-core/src/storage/scan_cancel.rs
+++ b/cqlite-core/src/storage/scan_cancel.rs
@@ -1,0 +1,84 @@
+//! Cooperative cancellation for long-running synchronous scans (issue #2264).
+//!
+//! The compaction streaming read (`stream_all_partitions_for_compaction`) walks
+//! a whole Data.db on a detached producer thread. For an index-less
+//! (Summary.db-absent) SSTable that walk fully materialises every partition in
+//! one uninterruptible pass — so a Flight `do_get` whose client has disconnected
+//! keeps burning CPU until a coarse ~1–2 min backstop reaps it, ignoring the
+//! cancellation the transport already received.
+//!
+//! [`ScanCancel`] is a cheap, cloneable flag the scan polls at a bounded interval
+//! (every N partitions). It is deliberately a bare `AtomicBool` — the scan runs
+//! on a plain `std::thread` with no async runtime, so it cannot poll an
+//! async-wakeable token. The Flight layer bridges its own
+//! `tokio_util::CancellationToken`-backed `CancelFlag` onto one of these so a
+//! single `cancel()` trips both the async channel-race (PR #2282) AND this
+//! synchronous scan poll.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// A cheap, cloneable cooperative-cancellation flag for synchronous scans.
+///
+/// All clones share one `AtomicBool`, so cancelling any clone is observed by a
+/// scan polling another. A default (never-cancelled) flag makes every threaded
+/// call site a no-op, so non-cancellable callers pass `ScanCancel::default()`.
+#[derive(Clone, Debug, Default)]
+pub struct ScanCancel(Arc<AtomicBool>);
+
+impl ScanCancel {
+    /// Create a fresh, un-cancelled flag.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Request cancellation. Idempotent.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    /// Return `Err(Error::Cancelled)` if cancellation has been requested, else
+    /// `Ok(())`. The polling helper scan loops call at a bounded interval.
+    pub fn check(&self) -> crate::Result<()> {
+        if self.is_cancelled() {
+            Err(crate::Error::Cancelled)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_uncancelled_and_cancels() {
+        let c = ScanCancel::new();
+        assert!(!c.is_cancelled());
+        assert!(c.check().is_ok());
+        c.cancel();
+        assert!(c.is_cancelled());
+        assert!(matches!(c.check(), Err(crate::Error::Cancelled)));
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let a = ScanCancel::new();
+        let b = a.clone();
+        a.cancel();
+        assert!(b.is_cancelled(), "cancel on one clone is seen by another");
+    }
+
+    #[test]
+    fn default_is_never_cancelled() {
+        let c = ScanCancel::default();
+        assert!(!c.is_cancelled());
+        assert!(c.check().is_ok());
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -611,6 +611,14 @@ impl SSTableReader {
 
         let mut chunk_count = 0;
         while let Some(compressed_chunk) = self.read_next_block(&cursor).await? {
+            // Cooperative cancellation (issue #2264, roborev round 3): a poll
+            // every 256 chunks catches the edge case `drain_compaction_window`'s
+            // per-PARTITION poll cannot — a single partition so wide it spans
+            // hundreds of chunks without ever completing (so the drain loop's
+            // counter never advances).
+            if chunk_count & 0xFF == 0 {
+                self.scan_cancel.check()?;
+            }
             let decompressed_chunk = if compressed_chunk.len() >= max_compressed_length {
                 // Stored uncompressed by Cassandra — pass the raw bytes through.
                 tracing::debug!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -564,8 +564,16 @@ impl SSTableReader {
         // Non-stitching formats are single-block / small: emit via the
         // materialising iterator with ts=0 (matches the Vec-variant fallback).
         if !self.requires_chunk_stitching() {
+            // The heavy, previously-uninterruptible work is inside
+            // `iterate_all_partitions` (→ `sequential_scan` → the block parser),
+            // which now polls `scan_cancel` per partition (issue #2264). Poll again
+            // per emitted row so a cancel that lands during the drain of the
+            // already-materialised Vec is also honoured promptly.
             let entries = self.iterate_all_partitions().await?;
-            for (key, value) in entries {
+            for (i, (key, value)) in entries.into_iter().enumerate() {
+                if i & 0xFF == 0 {
+                    self.scan_cancel.check()?;
+                }
                 let row =
                     super::super::compaction_row::CompactionRow::from_legacy_value(key, value, 0);
                 match emit(row)? {
@@ -683,10 +691,20 @@ impl SSTableReader {
         F: FnMut(super::super::compaction_row::CompactionRow) -> Result<std::ops::ControlFlow<()>>,
     {
         use crate::storage::sstable::reader::parsing::ParseStep;
+        let mut drained: usize = 0;
         loop {
             if *broke || window.is_empty() {
                 return Ok(());
             }
+            // Cooperative cancellation (issue #2264): for a chunk-stitched ('nb')
+            // SSTable this is the per-partition hot loop the compaction stream (and
+            // thus a Flight `do_get`) spends its time in. Poll the reader's cancel
+            // token at a bounded interval so a disconnected client abandons the
+            // walk within milliseconds instead of the coarse ~1–2 min backstop.
+            if drained & 0xFF == 0 {
+                self.scan_cancel.check()?;
+            }
+            drained += 1;
             let mut local_break = false;
             let step = parser.parse_one_partition_for_compaction(
                 window.as_slice(),

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -397,14 +397,24 @@ fn datasets_root() -> Option<std::path::PathBuf> {
 /// `test_basic.multi_partition_table`: a real fixture with Summary.db +
 /// Index.db present and at least one Summary.db entry (confirmed during
 /// investigation for this test).
+///
+/// Only returns a candidate whose Summary.db AND Index.db sidecars both exist —
+/// they are what let `SSTableReader::open` populate `summary_reader`/
+/// `index_reader`, the precondition for `iterate_all_partitions` to take the
+/// index-backed branch this test exercises. A Data.db-only snapshot is skipped
+/// (returns `None`) rather than driving the test down the sequential-scan
+/// fallback, where the poll under test never runs.
 fn real_index_backed_fixture() -> Option<std::path::PathBuf> {
     let base = datasets_root()?.join("sstables/test_basic");
     for entry in std::fs::read_dir(&base).ok()?.flatten() {
         let name = entry.file_name();
         let name = name.to_string_lossy();
         if name.starts_with("multi_partition_table-") {
-            let candidate = entry.path().join("nb-1-big-Data.db");
-            if candidate.is_file() {
+            let dir = entry.path();
+            let candidate = dir.join("nb-1-big-Data.db");
+            let summary = dir.join("nb-1-big-Summary.db");
+            let index = dir.join("nb-1-big-Index.db");
+            if candidate.is_file() && summary.is_file() && index.is_file() {
                 return Some(candidate);
             }
         }
@@ -427,8 +437,14 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
     };
     let mut reader = open_reader(&data_path).await;
 
-    // Non-vacuity: the loop body must actually run at least once, or disabling
-    // the poll would trivially leave `index_probes()` at 0 regardless.
+    // ------------------------------------------------------------------
+    // Guard 1 (structural): the reader must actually hold BOTH an
+    // `index_reader` and a non-empty `summary_reader`, or the index-backed
+    // `if let Some(summary_reader)` loop in `iterate_all_partitions` is never
+    // entered and the whole call falls through to `sequential_scan` — a path
+    // with its OWN (pre-existing, unrelated) poll. Without this, the fixture
+    // could satisfy the test vacuously via the fallback, recording zero probes
+    // whether or not THIS poll exists.
     let entry_count = reader
         .summary_reader
         .as_ref()
@@ -438,7 +454,40 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
         entry_count > 0,
         "fixture must have at least one Summary.db entry for this test to be non-vacuous"
     );
+    assert!(
+        reader.index_reader.is_some(),
+        "fixture must load an Index.db reader — otherwise iterate_all_partitions \
+         cannot take the index-backed branch this test targets (issue #2264)"
+    );
 
+    // ------------------------------------------------------------------
+    // Guard 2 (behavioural, the real fail-if-vacuous check): an UNCANCELLED
+    // pass over this exact fixture must record index probes > 0. Each iteration
+    // of the index-backed loop calls `lookup_partition_with_index`, which
+    // records exactly one probe per real Index.db lookup. A nonzero count here
+    // proves the per-entry loop body — the one guarded by the poll under test —
+    // is genuinely executed for this fixture (it does not silently resolve via
+    // the sequential-scan fallback with zero probes). If a future fixture/refactor
+    // stopped exercising the index-backed branch, THIS assertion fails, so the
+    // pre-cancelled assertion below can never pass vacuously.
+    crate::storage::sstable::read_work_counters::reset();
+    let uncancelled = open_reader(&data_path).await;
+    let uncancelled_result = uncancelled.iterate_all_partitions().await;
+    assert!(
+        uncancelled_result.is_ok(),
+        "the uncancelled index-backed scan must succeed: {uncancelled_result:?}"
+    );
+    let uncancelled_probes = crate::storage::sstable::read_work_counters::index_probes();
+    assert!(
+        uncancelled_probes > 0,
+        "the index-backed branch must be exercised — an uncancelled scan over this \
+         fixture recorded zero Index.db probes, meaning the loop this test targets is \
+         never entered (the test would pass vacuously). Got {uncancelled_probes}"
+    );
+
+    // ------------------------------------------------------------------
+    // The actual assertion: a pre-cancelled scan must record ZERO probes —
+    // the poll aborts BEFORE the loop attempts even the first Index.db lookup.
     crate::storage::sstable::read_work_counters::reset();
     let cancel = ScanCancel::new();
     cancel.cancel();

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -1,0 +1,211 @@
+//! Issue #2264 — the compaction streaming scan must observe a cooperative
+//! cancel token and abandon a multi-partition Data.db WITHOUT running to
+//! completion.
+//!
+//! World 2 (field-proven): an index-less (Summary.db-absent) SSTable is handed
+//! to `stream_all_partitions_for_compaction` as one contiguous block whose
+//! parser loops over EVERY partition in a single uninterruptible pass on a
+//! detached producer thread. A cancelled Flight `do_get` could not stop it — the
+//! merge's between-step poll never runs because it is parked waiting for the
+//! producer, and PR #2282's channel race never reaches the CPU-bound loop.
+//!
+//! These tests drive the reader scan DIRECTLY (no `KWayMerger`, so the merge's
+//! own between-step poll is absent) — the reader's `scan_cancel` poll is the
+//! ONLY thing that can abort the walk here, so a green test proves THIS fix, not
+//! the pre-existing between-step check.
+
+use crate::schema::{Column, KeyColumn, TableSchema};
+use crate::storage::scan_cancel::ScanCancel;
+use crate::storage::sstable::reader::SSTableReader;
+use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+use crate::types::Value;
+use crate::{Config, Platform};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "test_table".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn mutation(id: i32) -> Mutation {
+    Mutation::new(
+        TableId::new("test_ks", "test_table"),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(format!("v{id}")),
+        }],
+        1_000_000 + id as i64,
+        None,
+    )
+}
+
+/// Write `n` single-row partitions to a fresh uncompressed SSTable, then strip
+/// the `Summary.db`/`Index.db`/`Filter.db` sidecars to reproduce the field's
+/// index-less snapshot (only Data.db + Statistics.db remain). Returns the temp
+/// dir (keep alive) and the `Data.db` path.
+async fn index_less_fixture(n: i32) -> (TempDir, std::path::PathBuf) {
+    let schema = schema();
+    let temp = TempDir::new().unwrap();
+    let mut writer =
+        crate::storage::sstable::writer::SSTableWriter::new(temp.path().to_path_buf(), 1, &schema)
+            .unwrap();
+
+    // Write in token order (the writer enforces it).
+    let mut keyed: Vec<_> = (1..=n)
+        .map(|id| {
+            let m = mutation(id);
+            let key = m.decorated_key(&schema).unwrap();
+            (key, m)
+        })
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+    for (key, m) in keyed {
+        writer.write_partition(key, vec![m]).unwrap();
+    }
+    let info = writer.finish().await.unwrap();
+    let data_path = info.data_path.clone();
+
+    // Strip the partition-index sidecars so the reader takes the full-scan
+    // fallback the field hit — the fix must be correct for legitimately
+    // index-less inputs (Phase C snapshot-completeness is filed separately).
+    for entry in std::fs::read_dir(temp.path()).unwrap().flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.ends_with("-Summary.db")
+            || name.ends_with("-Index.db")
+            || name.ends_with("-Filter.db")
+        {
+            std::fs::remove_file(entry.path()).unwrap();
+        }
+    }
+    (temp, data_path)
+}
+
+async fn open_reader(data_path: &std::path::Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.unwrap());
+    SSTableReader::open(data_path, &config, platform).await.unwrap()
+}
+
+/// Positive control (non-vacuity): with a never-cancelled token the scan streams
+/// EVERY partition. Proves the fixture really has `TOTAL` partitions on the
+/// full-scan path, so the cancellation tests below are cutting real work short.
+#[tokio::test(flavor = "multi_thread")]
+async fn uncancelled_scan_streams_all_partitions() {
+    const TOTAL: i32 = 1000;
+    let (_temp, data_path) = index_less_fixture(TOTAL).await;
+    let reader = open_reader(&data_path).await;
+
+    let mut count = 0usize;
+    let result = reader
+        .stream_all_partitions_for_compaction(Some(&schema()), |_row| {
+            count += 1;
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .await;
+
+    assert!(result.is_ok(), "uncancelled scan must succeed: {result:?}");
+    assert_eq!(
+        count, TOTAL as usize,
+        "the full-scan path must stream every partition"
+    );
+}
+
+/// A token tripped BEFORE the scan starts aborts it at the very first poll —
+/// zero partitions emitted, a clean `Cancelled` error. The scan does NOT run to
+/// completion (which the positive control proves is 1000 partitions), so this is
+/// the fix, not a fast fixture. FAILS on pre-fix code: without the `scan_cancel`
+/// poll the scan ignores the token and returns `Ok` with all 1000 partitions.
+#[tokio::test(flavor = "multi_thread")]
+async fn pre_cancelled_scan_aborts_at_first_poll() {
+    const TOTAL: i32 = 1000;
+    let (_temp, data_path) = index_less_fixture(TOTAL).await;
+    let mut reader = open_reader(&data_path).await;
+
+    let cancel = ScanCancel::new();
+    cancel.cancel();
+    reader.set_scan_cancel(cancel);
+
+    let mut count = 0usize;
+    let result = reader
+        .stream_all_partitions_for_compaction(Some(&schema()), |_row| {
+            count += 1;
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(crate::Error::Cancelled)),
+        "a pre-cancelled scan must abort with Error::Cancelled, got {result:?}"
+    );
+    assert_eq!(
+        count, 0,
+        "a pre-cancelled scan must not materialise a single partition"
+    );
+}
+
+/// A token tripped MID-scan (from the emit callback, after a bounded number of
+/// partitions) aborts within one poll interval instead of finishing — the
+/// World-2 analogue of PR #2282's channel test. Proves the CPU-bound loop itself
+/// polls the token, not just the boundaries. FAILS on pre-fix code (no poll →
+/// runs to completion, `count == TOTAL`, `Ok`).
+#[tokio::test(flavor = "multi_thread")]
+async fn mid_scan_cancel_aborts_before_finishing() {
+    const TOTAL: i32 = 2000;
+    const TRIP_AT: usize = 300;
+    let (_temp, data_path) = index_less_fixture(TOTAL).await;
+    let mut reader = open_reader(&data_path).await;
+
+    let cancel = ScanCancel::new();
+    reader.set_scan_cancel(cancel.clone());
+
+    let mut count = 0usize;
+    let result = reader
+        .stream_all_partitions_for_compaction(Some(&schema()), |_row| {
+            count += 1;
+            if count == TRIP_AT {
+                cancel.cancel();
+            }
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(crate::Error::Cancelled)),
+        "a mid-scan cancel must abort with Error::Cancelled, got {result:?}"
+    );
+    assert!(
+        count >= TRIP_AT && count < TOTAL as usize,
+        "must abort after the trip point but well before the full {TOTAL} partitions, got {count}"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -22,6 +22,12 @@
 //! own between-step poll is absent) — the reader's `scan_cancel` poll is the
 //! ONLY thing that can abort the walk here, so a green test proves THIS fix, not
 //! the pre-existing between-step check.
+//!
+//! The final test in this file (`pre_cancelled_scan_does_not_probe_index_on_
+//! index_backed_path`, roborev round 3) instead calls `iterate_all_partitions`
+//! directly against a REAL Cassandra fixture (`CQLITE_DATASETS_ROOT`) — see its
+//! doc comment for why a synthesized `SSTableWriter` fixture cannot exercise
+//! that resolution mode.
 
 use crate::schema::{Column, KeyColumn, TableSchema};
 use crate::storage::scan_cancel::ScanCancel;
@@ -78,11 +84,10 @@ fn mutation(id: i32) -> Mutation {
     )
 }
 
-/// Write `n` single-row partitions to a fresh uncompressed SSTable, then strip
-/// the `Summary.db`/`Index.db`/`Filter.db` sidecars to reproduce the field's
-/// index-less snapshot (only Data.db + Statistics.db remain). Returns the temp
-/// dir (keep alive) and the `Data.db` path.
-async fn index_less_fixture(n: i32) -> (TempDir, std::path::PathBuf) {
+/// Write `n` single-row partitions to a fresh uncompressed SSTable, keeping
+/// EVERY emitted component (Summary.db/Index.db/Filter.db included). Returns
+/// the temp dir (keep alive) and the `Data.db` path.
+async fn write_fixture(n: i32) -> (TempDir, std::path::PathBuf) {
     let schema = schema();
     let temp = TempDir::new().unwrap();
     let mut writer =
@@ -103,6 +108,15 @@ async fn index_less_fixture(n: i32) -> (TempDir, std::path::PathBuf) {
     }
     let info = writer.finish().await.unwrap();
     let data_path = info.data_path.clone();
+    (temp, data_path)
+}
+
+/// Write `n` single-row partitions to a fresh uncompressed SSTable, then strip
+/// the `Summary.db`/`Index.db`/`Filter.db` sidecars to reproduce the field's
+/// index-less snapshot (only Data.db + Statistics.db remain). Returns the temp
+/// dir (keep alive) and the `Data.db` path.
+async fn index_less_fixture(n: i32) -> (TempDir, std::path::PathBuf) {
+    let (temp, data_path) = write_fixture(n).await;
 
     // Strip the partition-index sidecars so the reader takes the full-scan
     // fallback the field hit — the fix must be correct for legitimately
@@ -340,5 +354,107 @@ async fn mid_scan_cancel_aborts_before_finishing() {
     assert!(
         count >= TRIP_AT && count < TOTAL as usize,
         "must abort after the trip point but well before the full {TOTAL} partitions, got {count}"
+    );
+}
+
+/// The Summary.db/Index.db-PRESENT resolution mode (roborev round 3, issue
+/// #2264): `iterate_all_partitions` (`partition_lookup.rs`) has TWO resolution
+/// modes — the index-backed per-entry lookup (this poll's target) and the
+/// `sequential_scan` fallback (already covered above via `index_less_fixture`,
+/// which strips Summary/Index/Filter).
+///
+/// Reaching a FULLY-RESOLVED index-backed pass (`results.len() ==
+/// entries.len()`, needed for `iterate_all_partitions` to actually RETURN the
+/// index-backed result instead of falling through) needs a REAL Cassandra
+/// fixture: investigation for this test found `SSTableWriter`-produced
+/// Summary.db/Index.db pairs never fully resolve — `lookup_partition_with_index`
+/// DOES find a byte-identical key, but the resolved `PartitionIndexEntry`'s
+/// `data_offset`/`data_size` are degenerate (`(0, 0)`) for CQLite's own writer
+/// output, a pre-existing gap unrelated to #2264 (NOT fixed here — filed
+/// separately). So `write_fixture`'s output cannot exercise the FULLY-RESOLVED
+/// branch, and `iterate_all_partitions` returns one materialised `Vec` with no
+/// emit callback — a cancelled call has no partition-count observable either
+/// way, so the callback-based "trip at partition N" technique the other tests
+/// use does not apply here.
+///
+/// This proves the loop's poll instead via the process-global
+/// `read_work_counters::index_probes()` counter (same oracle technique as
+/// `chunk_cache_wiring_tests.rs`): a pre-cancelled call over a REAL fixture with
+/// at least one Summary.db entry must record ZERO Index.db probes — proving the
+/// poll aborts BEFORE the loop attempts even the FIRST lookup. Disabling ONLY
+/// this poll lets `lookup_partition_with_index` run for entry 0 (recording a
+/// probe) before the function falls through to `sequential_scan`'s (unrelated,
+/// pre-existing) poll for the SAME final `Err(Cancelled)` — so the probe-count
+/// assertion, not the `Err` alone, discriminates this specific poll from the
+/// downstream fallback's. `#[serial]`: the counter is process-global.
+fn datasets_root() -> Option<std::path::PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .filter(|p| p.is_dir())
+}
+
+/// `test_basic.multi_partition_table`: a real fixture with Summary.db +
+/// Index.db present and at least one Summary.db entry (confirmed during
+/// investigation for this test).
+fn real_index_backed_fixture() -> Option<std::path::PathBuf> {
+    let base = datasets_root()?.join("sstables/test_basic");
+    for entry in std::fs::read_dir(&base).ok()?.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("multi_partition_table-") {
+            let candidate = entry.path().join("nb-1-big-Data.db");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Skip (not fail) when the real fixture binary is absent — matches the
+/// established convention (`issue_1594_fanout_deadlock_test.rs` et al.) for
+/// tests needing `CQLITE_DATASETS_ROOT`'s local-only binaries.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
+    let Some(data_path) = real_index_backed_fixture() else {
+        eprintln!(
+            "Skipping (index-backed cancel poll): real multi_partition_table \
+             fixture not present (set CQLITE_DATASETS_ROOT)"
+        );
+        return;
+    };
+    let mut reader = open_reader(&data_path).await;
+
+    // Non-vacuity: the loop body must actually run at least once, or disabling
+    // the poll would trivially leave `index_probes()` at 0 regardless.
+    let entry_count = reader
+        .summary_reader
+        .as_ref()
+        .map(|s| s.get_entries().len())
+        .unwrap_or(0);
+    assert!(
+        entry_count > 0,
+        "fixture must have at least one Summary.db entry for this test to be non-vacuous"
+    );
+
+    crate::storage::sstable::read_work_counters::reset();
+    let cancel = ScanCancel::new();
+    cancel.cancel();
+    reader.set_scan_cancel(cancel);
+
+    let result = reader.iterate_all_partitions().await;
+
+    assert!(
+        matches!(result, Err(crate::Error::Cancelled)),
+        "a pre-cancelled index-backed scan must abort with Error::Cancelled, got {result:?}"
+    );
+    assert_eq!(
+        crate::storage::sstable::read_work_counters::index_probes(),
+        0,
+        "the index-backed loop's poll must abort BEFORE attempting even the first \
+         Index.db lookup — a nonzero probe count means the loop ran ahead of the \
+         cancel check (issue #2264, roborev round 3)"
     );
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -3,11 +3,20 @@
 //! completion.
 //!
 //! World 2 (field-proven): an index-less (Summary.db-absent) SSTable is handed
-//! to `stream_all_partitions_for_compaction` as one contiguous block whose
-//! parser loops over EVERY partition in a single uninterruptible pass on a
-//! detached producer thread. A cancelled Flight `do_get` could not stop it — the
-//! merge's between-step poll never runs because it is parked waiting for the
-//! producer, and PR #2282's channel race never reaches the CPU-bound loop.
+//! to `stream_all_partitions_for_compaction`, whose parser loops over EVERY
+//! partition in a single uninterruptible pass on a detached producer thread. A
+//! cancelled Flight `do_get` could not stop it — the merge's between-step poll
+//! never runs because it is parked waiting for the producer, and PR #2282's
+//! channel race never reaches the CPU-bound loop.
+//!
+//! This file's fixtures are SSTableWriter-produced, filename-tagged 'nb', which
+//! `requires_chunk_stitching()` routes to `stream_all_partitions_for_compaction`'s
+//! STITCHING branch (`drain_compaction_window`, `compaction.rs`) regardless of
+//! whether the file is actually compressed — that is the loop these tests
+//! exercise and pin. The field's specific `V5_0Uncompressed`-tagged snapshot
+//! instead takes the NON-stitching branch (`sequential.rs` /
+//! `block_emit_windowed.rs`), a structurally distinct loop with its own poll,
+//! covered by no test in THIS file.
 //!
 //! These tests drive the reader scan DIRECTLY (no `KWayMerger`, so the merge's
 //! own between-step poll is absent) — the reader's `scan_cancel` poll is the
@@ -119,6 +128,121 @@ async fn open_reader(data_path: &std::path::Path) -> SSTableReader {
         .unwrap()
 }
 
+/// Build a GENUINELY LZ4-compressed 'nb' fixture (roborev, issue #2264): the
+/// production write surface emits uncompressed SSTables only (issue #1406), so
+/// this "repacks" an `index_less_fixture`'s output through the fixture-synthesis
+/// building blocks `CompressedDataWriter`/`CompressionInfoWriter` — the SAME
+/// technique `issue_953_multichunk_cell_seek.rs` uses on a real fixture, applied
+/// here to a synthesized one so the test needs no `CQLITE_DATASETS_ROOT`.
+///
+/// The existing three tests above never make `self.compression_reader.is_some()`
+/// true, so `stream_all_partitions_for_compaction`'s actual
+/// `Compression::decompress` call (`compaction.rs`) — and the `drain_
+/// compaction_window` poll immediately around it — go untested; a refactor could
+/// silently drop that poll with all three tests still green. A small chunk size
+/// forces MANY chunks over the raw data section, so the scan makes many
+/// decompress calls before finishing.
+#[cfg(feature = "lz4")]
+async fn compressed_fixture(n: i32) -> (TempDir, std::path::PathBuf) {
+    use crate::storage::sstable::writer::{
+        create_compressor, CompressedDataWriter, CompressionAlgorithm, CompressionInfoWriter,
+    };
+
+    // Deliberately tiny so a modest partition count still yields many chunks.
+    const REPACK_CHUNK_SIZE: usize = 256;
+
+    let (temp, data_path) = index_less_fixture(n).await;
+
+    // Read the raw (uncompressed) data section back exactly as the reader would
+    // see it — skip past `calculate_header_size()` bytes (0 for headerless 'nb').
+    let header_size = open_reader(&data_path).await.calculate_header_size();
+    let raw = std::fs::read(&data_path).unwrap();
+    let data_section = &raw[header_size..];
+
+    let compressor = create_compressor(CompressionAlgorithm::Lz4).unwrap();
+    let mut writer = CompressedDataWriter::with_chunk_size(compressor, REPACK_CHUNK_SIZE);
+    writer.write(data_section).unwrap();
+    let (compressed, metadata) = writer.finish().unwrap();
+    assert!(
+        metadata.chunk_count() > 1,
+        "fixture must span multiple chunks to exercise repeated decompress calls, got {}",
+        metadata.chunk_count()
+    );
+
+    // Overwrite Data.db with the compressed chunk stream (headerless 'nb' has no
+    // prefix to preserve) and write the matching CompressionInfo.db sidecar so
+    // `SSTableReader::open` picks up a real `compression_reader`.
+    std::fs::write(&data_path, &compressed).unwrap();
+    let base = data_path
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .trim_end_matches("-Data");
+    let compression_info_path = data_path
+        .parent()
+        .unwrap()
+        .join(format!("{base}-CompressionInfo.db"));
+    CompressionInfoWriter::new(compression_info_path.clone())
+        .write(&metadata)
+        .unwrap();
+    assert!(
+        compression_info_path.exists(),
+        "CompressionInfo.db must be written so the reader takes the compressed path"
+    );
+
+    // A stale CRC.db (checksums the ORIGINAL uncompressed bytes) is now
+    // meaningless — the reader only loads it when `compression_info.is_none()`
+    // (so it is not even consulted once CompressionInfo.db exists), but remove it
+    // for hygiene so nothing could reference mismatched checksums.
+    for entry in std::fs::read_dir(temp.path()).unwrap().flatten() {
+        if entry.file_name().to_string_lossy().ends_with("-CRC.db") {
+            std::fs::remove_file(entry.path()).unwrap();
+        }
+    }
+
+    (temp, data_path)
+}
+
+/// The stitching-path analogue of `mid_scan_cancel_aborts_before_finishing`,
+/// over a GENUINELY LZ4-compressed fixture (roborev, issue #2264): proves the
+/// `drain_compaction_window` poll fires even when each partition step requires a
+/// real `Compression::decompress` call, not just the "no compression_reader" /
+/// raw-chunk shape the other tests exercise. FAILS on pre-fix code the same way:
+/// no poll → the scan runs to completion (`count == TOTAL`, `Ok`).
+#[cfg(feature = "lz4")]
+#[tokio::test(flavor = "multi_thread")]
+async fn mid_scan_cancel_aborts_on_compressed_stitching_path() {
+    const TOTAL: i32 = 2000;
+    const TRIP_AT: usize = 300;
+    let (_temp, data_path) = compressed_fixture(TOTAL).await;
+    let mut reader = open_reader(&data_path).await;
+
+    let cancel = ScanCancel::new();
+    reader.set_scan_cancel(cancel.clone());
+
+    let mut count = 0usize;
+    let result = reader
+        .stream_all_partitions_for_compaction(Some(&schema()), |_row| {
+            count += 1;
+            if count == TRIP_AT {
+                cancel.cancel();
+            }
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(crate::Error::Cancelled)),
+        "a mid-scan cancel on the compressed stitching path must abort with \
+         Error::Cancelled, got {result:?}"
+    );
+    assert!(
+        count >= TRIP_AT && count < TOTAL as usize,
+        "must abort after the trip point but well before the full {TOTAL} partitions, got {count}"
+    );
+}
+
 /// Positive control (non-vacuity): with a never-cancelled token the scan streams
 /// EVERY partition. Proves the fixture really has `TOTAL` partitions on the
 /// full-scan path, so the cancellation tests below are cutting real work short.
@@ -178,9 +302,16 @@ async fn pre_cancelled_scan_aborts_at_first_poll() {
 
 /// A token tripped MID-scan (from the emit callback, after a bounded number of
 /// partitions) aborts within one poll interval instead of finishing — the
-/// World-2 analogue of PR #2282's channel test. Proves the CPU-bound loop itself
-/// polls the token, not just the boundaries. FAILS on pre-fix code (no poll →
-/// runs to completion, `count == TOTAL`, `Ok`).
+/// World-2 analogue of PR #2282's channel test. This fixture is filename-tagged
+/// 'nb', so `requires_chunk_stitching()` is true and the scan takes the
+/// STITCHING branch: the cancel is caught by `drain_compaction_window`'s
+/// per-partition poll (`compaction.rs`, between successive
+/// `parse_one_partition_for_compaction` calls), NOT by the non-stitching
+/// materialization poll in `block_emit_windowed.rs`/`sequential.rs` — those cover
+/// a DIFFERENT reader code path (an index-less SSTable that is ALSO not
+/// filename-tagged 'nb', e.g. `V5_0Uncompressed`) and are exercised by no test in
+/// this file. FAILS on pre-fix code (no poll → runs to completion, `count ==
+/// TOTAL`, `Ok`).
 #[tokio::test(flavor = "multi_thread")]
 async fn mid_scan_cancel_aborts_before_finishing() {
     const TOTAL: i32 = 2000;

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -114,7 +114,9 @@ async fn index_less_fixture(n: i32) -> (TempDir, std::path::PathBuf) {
 async fn open_reader(data_path: &std::path::Path) -> SSTableReader {
     let config = Config::default();
     let platform = Arc::new(Platform::new(&config).await.unwrap());
-    SSTableReader::open(data_path, &config, platform).await.unwrap()
+    SSTableReader::open(data_path, &config, platform)
+        .await
+        .unwrap()
 }
 
 /// Positive control (non-vacuity): with a never-cancelled token the scan streams

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -36,6 +36,13 @@ mod big_promoted_crc_tests;
 // `tests/`.
 #[cfg(test)]
 mod chunk_cache_wiring_tests;
+// In-crate proof that the compaction streaming scan polls the reader's
+// cooperative cancel token and abandons a multi-partition Data.db mid-scan
+// (issue #2264 — the World-2 un-cancellable full-materialise loop). Needs the
+// `pub(crate)` `set_scan_cancel` + `stream_all_partitions_for_compaction`, so it
+// cannot live in `tests/`.
+#[cfg(all(test, feature = "write-support"))]
+mod compaction_cancel_tests;
 // BIG ("nb"/uncompressed) point lookup: raw-key Index.db resolve + covering-chunk
 // seek (issue #1572), replacing the whole-file scan_for_key fallback.
 mod big_point;

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -861,6 +861,11 @@ impl SSTableReader {
         // Non-stitching path for other formats
         let mut block_count = 0;
         while let Some(block) = self.read_next_block(&cursor).await? {
+            // Cooperative cancellation (issue #2264): an index-less (Summary.db
+            // absent) SSTable materialises EVERY partition here in one pass; poll
+            // the token per block so a cancelled Flight `do_get` abandons the walk
+            // promptly instead of running to completion under the ~1–2 min backstop.
+            self.scan_cancel.check()?;
             block_count += 1;
             tracing::debug!(
                 "SSTableReader::sequential_scan - Read block {}, size {} bytes",

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -881,6 +881,18 @@ impl SSTableReader {
             );
 
             for (i, (entry_table_id, entry_key, entry_value)) in entries.iter().enumerate() {
+                // Cooperative cancellation (issue #2264, roborev): the per-block
+                // poll above fires ONCE per `read_next_block` call, but an
+                // uncompressed/BTI-direct block returns the WHOLE data section as
+                // one contiguous unit (per `read_next_block_impl`'s doc comment) —
+                // so for that shape `entries` alone can number in the hundreds of
+                // thousands. Poll again here at the SAME 256-entry cadence used
+                // elsewhere so materialisation honours the interval regardless of
+                // how large a single block turned out to be, independent of
+                // whichever inner parser branch produced `entries`.
+                if i & 0xFF == 0 {
+                    self.scan_cancel.check()?;
+                }
                 tracing::debug!(
                     "SSTableReader::sequential_scan - Block {} entry {}: table_id='{}', key={:?}",
                     block_count,

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -823,6 +823,7 @@ impl SSTableReader {
             #[cfg(feature = "state_machine")]
             registry_schema: None, // Resolved by resolve_registry_schema() at wiring time (#1692)
             udt_registry: None, // Will be set when available for UDT-aware parsing
+            scan_cancel: crate::storage::scan_cancel::ScanCancel::default(), // #2264: set via set_scan_cancel
             compression_info: compression_info.map(Arc::new),
             crc_reader,
             verified_uncompressed_chunks: std::sync::Mutex::new(std::collections::HashSet::new()),
@@ -1222,6 +1223,18 @@ impl SSTableReader {
             self.header.keyspace,
             self.header.table_name
         );
+    }
+
+    /// Wire a cooperative-cancellation token into this reader's long-running
+    /// scans (issue #2264).
+    ///
+    /// The compaction streaming read and its sequential-scan fallback poll this
+    /// token at a bounded interval, so a cancelled Flight `do_get` abandons an
+    /// otherwise uninterruptible full-Data.db walk within milliseconds instead of
+    /// waiting out the coarse ~1–2 min transport backstop. Idempotent; the last
+    /// token set wins. Readers never wired keep the default never-cancel flag.
+    pub fn set_scan_cancel(&mut self, cancel: crate::storage::scan_cancel::ScanCancel) {
+        self.scan_cancel = cancel;
     }
 
     /// Get reader statistics

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/block_emit_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/block_emit_windowed.rs
@@ -100,6 +100,18 @@ impl V5CompressedLegacyParser {
         let mut partition_index = 0;
         let mut skipped_partitions = 0;
         while offset < data.len() {
+            // Cooperative cancellation (issue #2264): an uncompressed, index-less
+            // SSTable is returned to the scan as ONE contiguous block, so this loop
+            // is the 400k+-partition hot loop that the compaction streaming read
+            // (and thus a Flight `do_get`) spends its whole time in. Poll the
+            // reader's cancel token at a bounded interval so a disconnected client
+            // abandons the walk within milliseconds instead of running to
+            // completion under the coarse ~1–2 min backstop. Every 256 partitions
+            // keeps the relaxed-atomic load negligible against the per-partition
+            // parse cost.
+            if partition_index & 0xFF == 0 {
+                reader.scan_cancel.check()?;
+            }
             tracing::debug!(
                 "V5CompressedLegacy: === PARTITION {} at offset {} (block size: {}) ===",
                 partition_index,

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction.rs
@@ -264,10 +264,19 @@ impl V5CompressedLegacyParser {
 
         let mut offset = 0;
         let mut skipped_partitions = 0;
+        let mut partition_index: usize = 0;
 
         let broke = std::cell::Cell::new(false);
 
         while offset < data.len() {
+            // Cooperative cancellation (issue #2264): poll the reader's cancel
+            // token at a bounded interval so a compressed, index-less SSTable's
+            // compaction stream (a Flight `do_get`) abandons promptly on client
+            // disconnect rather than draining the whole window under the backstop.
+            if partition_index & 0xFF == 0 {
+                reader.scan_cancel.check()?;
+            }
+            partition_index += 1;
             // Capture the partition-start offset BEFORE parsing this partition so
             // every row emitted for it is tagged with the same authoritative
             // decompressed-Data.db position.

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -574,7 +574,21 @@ impl SSTableReader {
             let entries = summary_reader.get_entries();
             let mut results = Vec::new();
 
-            for entry in entries {
+            for entry in entries.iter() {
+                // Cooperative cancellation (issue #2264, roborev round 3): with
+                // Summary.db PRESENT, this per-entry index-random-read loop is the
+                // O(partitions) work a Flight `do_get` spends its time in — the
+                // outer poll in `stream_all_partitions_for_compaction`'s
+                // non-stitching branch fires only ONCE, AFTER this whole loop (and
+                // the whole `Vec`) has already been materialised. Poll EVERY
+                // entry (not the 256-cadence used for raw in-memory partition
+                // loops elsewhere): Summary.db already samples ~1-in-128 raw
+                // partitions, and each entry here costs a real Index.db lookup +
+                // Data.db decompress/parse — orders of magnitude more expensive
+                // per iteration than a byte-parse step, so checking every entry
+                // adds negligible overhead while keeping the observed latency
+                // bound proportionate to that per-entry cost.
+                self.scan_cancel.check()?;
                 // Use Summary.db entry to find the corresponding Index.db entry
                 if let Some(_index_reader) = &self.index_reader {
                     // The summary entry provides a position in Index.db

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -314,6 +314,15 @@ pub struct SSTableReader {
     pub(super) registry_schema: Option<Arc<TableSchema>>,
     /// UDT registry for UDT-aware parsing (cached for sync access)
     pub(crate) udt_registry: Option<UdtRegistry>,
+    /// Cooperative cancellation for long-running scans (issue #2264).
+    ///
+    /// Polled at a bounded interval inside the compaction streaming read and its
+    /// sequential-scan fallback so a Flight `do_get` whose client disconnected
+    /// abandons the (otherwise uninterruptible, fully-materialising) walk
+    /// promptly instead of burning CPU until the coarse ~1–2 min backstop. The
+    /// default is a never-cancelled flag, so readers opened without a wired token
+    /// behave exactly as before. Set via [`SSTableReader::set_scan_cancel`].
+    pub(crate) scan_cancel: crate::storage::scan_cancel::ScanCancel,
     /// CompressionInfo metadata for chunked decompression (if compressed)
     pub compression_info: Option<Arc<CompressionInfo>>,
     /// `CRC.db` per-chunk checksums for read-time integrity of **uncompressed**

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -414,6 +414,7 @@ impl SSTableRowIteratorAdapter {
         run_index: usize,
         schema: &TableSchema,
         udt_registry: Option<crate::schema::UdtRegistry>,
+        scan_cancel: crate::storage::scan_cancel::ScanCancel,
     ) -> Result<Self> {
         let path_buf = path.to_path_buf();
         let schema = schema.clone();
@@ -423,7 +424,7 @@ impl SSTableRowIteratorAdapter {
         // Spawn the producer thread. It owns a fresh Tokio runtime so it never
         // collides with any runtime on the calling thread (Issue #587).
         let producer = std::thread::spawn(move || {
-            Self::producer_thread(path_buf, run_index, schema, udt_registry, sender);
+            Self::producer_thread(path_buf, run_index, schema, udt_registry, scan_cancel, sender);
         });
 
         Ok(Self {
@@ -449,6 +450,7 @@ impl SSTableRowIteratorAdapter {
         run_index: usize,
         schema: TableSchema,
         udt_registry: Option<crate::schema::UdtRegistry>,
+        scan_cancel: crate::storage::scan_cancel::ScanCancel,
         sender: std::sync::mpsc::SyncSender<std::result::Result<MergeEntry, String>>,
     ) {
         // Drive the streaming read on an owned Tokio runtime (Issue #587): the
@@ -499,6 +501,13 @@ impl SSTableRowIteratorAdapter {
                 if let Some(registry) = udt_registry {
                     reader.set_udt_registry(registry);
                 }
+
+                // Issue #2264: wire the cooperative-cancellation token so the
+                // (uninterruptible, fully-materialising for index-less inputs)
+                // compaction scan below abandons promptly when the Flight
+                // `do_get` driving this merge is cancelled. Default (never-cancel)
+                // for callers that pass `ScanCancel::default()`.
+                reader.set_scan_cancel(scan_cancel);
 
                 // Pass the schema so the parser uses the real clustering column
                 // names; the header-inferred fallback uses generic names like
@@ -2030,6 +2039,26 @@ impl KWayMerger {
         Self::new_with_gc(input_paths, schema, None, None)
     }
 
+    /// Like [`KWayMerger::new`], but wires a cooperative
+    /// [`ScanCancel`](crate::storage::scan_cancel::ScanCancel) into every input
+    /// reader's compaction scan (issue #2264). Used by the Flight `do_get` merge
+    /// so a client disconnect abandons an in-flight, index-less full-Data.db walk
+    /// within milliseconds instead of the ~1–2 min transport backstop.
+    pub fn new_cancellable(
+        input_paths: Vec<PathBuf>,
+        schema: &TableSchema,
+        scan_cancel: crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<Self> {
+        Self::new_with_gc_and_registry_cancellable(
+            input_paths,
+            schema,
+            None,
+            None,
+            None,
+            scan_cancel,
+        )
+    }
+
     /// Create a new k-way merger with explicit purge parameters.
     ///
     /// Identical to [`KWayMerger::new`] but threads an explicit gc_grace cutoff
@@ -2069,6 +2098,34 @@ impl KWayMerger {
         now_secs: Option<i64>,
         udt_registry: Option<crate::schema::UdtRegistry>,
     ) -> Result<Self> {
+        Self::new_with_gc_and_registry_cancellable(
+            input_paths,
+            schema,
+            gc_before_secs,
+            now_secs,
+            udt_registry,
+            crate::storage::scan_cancel::ScanCancel::default(),
+        )
+    }
+
+    /// K-way merge constructor that opens the input SSTables under a cooperative
+    /// [`ScanCancel`](crate::storage::scan_cancel::ScanCancel) (issue #2264).
+    ///
+    /// The token is wired onto every per-run reader so the compaction scan each
+    /// run's producer thread drives — which, for an index-less (Summary.db
+    /// absent) SSTable, otherwise fully materialises the whole Data.db in one
+    /// uninterruptible pass — polls it at a bounded interval and abandons the walk
+    /// promptly when a driving Flight `do_get` is cancelled. `new`/`new_with_gc*`
+    /// delegate here with a never-cancelled default token, so non-Flight callers
+    /// are unaffected.
+    pub fn new_with_gc_and_registry_cancellable(
+        input_paths: Vec<PathBuf>,
+        schema: &TableSchema,
+        gc_before_secs: Option<i64>,
+        now_secs: Option<i64>,
+        udt_registry: Option<crate::schema::UdtRegistry>,
+        scan_cancel: crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<Self> {
         if input_paths.is_empty() {
             return Err(Error::InvalidInput(
                 "K-way merge requires at least one input file".to_string(),
@@ -2087,8 +2144,13 @@ impl KWayMerger {
         // (issue #1234).
         let mut runs = Vec::with_capacity(input_paths.len());
         for (run_index, path) in input_paths.iter().enumerate() {
-            let adapter =
-                SSTableRowIteratorAdapter::open(path, run_index, schema, udt_registry.clone())?;
+            let adapter = SSTableRowIteratorAdapter::open(
+                path,
+                run_index,
+                schema,
+                udt_registry.clone(),
+                scan_cancel.clone(),
+            )?;
             runs.push(RunReader::new(Box::new(adapter)));
         }
 

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -424,7 +424,14 @@ impl SSTableRowIteratorAdapter {
         // Spawn the producer thread. It owns a fresh Tokio runtime so it never
         // collides with any runtime on the calling thread (Issue #587).
         let producer = std::thread::spawn(move || {
-            Self::producer_thread(path_buf, run_index, schema, udt_registry, scan_cancel, sender);
+            Self::producer_thread(
+                path_buf,
+                run_index,
+                schema,
+                udt_registry,
+                scan_cancel,
+                sender,
+            );
         });
 
         Ok(Self {

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -377,9 +377,39 @@ pub(crate) use async_bridge::block_on_async;
 #[cfg(feature = "write-support")]
 struct SSTableRowIteratorAdapter {
     /// Receiving end of the bounded channel fed by the producer thread.
-    receiver: std::sync::mpsc::Receiver<std::result::Result<MergeEntry, String>>,
+    receiver: std::sync::mpsc::Receiver<std::result::Result<MergeEntry, MergeProducerError>>,
     /// JoinHandle for the producer thread (held so the thread is joined on drop).
     _producer: std::thread::JoinHandle<()>,
+}
+
+/// Channel-safe error payload sent from a producer thread to the merge (issue
+/// #2264).
+///
+/// The producer thread runs the reader's compaction scan under `Result<_,
+/// crate::Error>`, but `crate::Error` is not `Clone` and the channel item is
+/// consumed once anyway, so this small enum is the minimal payload that
+/// SURVIVES the thread boundary while still distinguishing a cooperative
+/// cancellation (`Error::Cancelled`) from every other failure. Without this,
+/// stringifying every error the same way would make a genuine I/O/corruption
+/// error indistinguishable from a cancelled scan at the receiving end — exactly
+/// the ambiguity `SSTableRowIterator::next` and `drive_merge` must NOT have.
+#[cfg(feature = "write-support")]
+#[derive(Debug)]
+enum MergeProducerError {
+    /// The scan was cooperatively cancelled (`Error::Cancelled`).
+    Cancelled,
+    /// Any other failure, stringified (matches the pre-#2264 behaviour).
+    Other(String),
+}
+
+#[cfg(feature = "write-support")]
+impl From<Error> for MergeProducerError {
+    fn from(e: Error) -> Self {
+        match e {
+            Error::Cancelled => MergeProducerError::Cancelled,
+            other => MergeProducerError::Other(other.to_string()),
+        }
+    }
 }
 
 /// Number of pre-fetched `MergeEntry` objects buffered per source in the
@@ -458,7 +488,7 @@ impl SSTableRowIteratorAdapter {
         schema: TableSchema,
         udt_registry: Option<crate::schema::UdtRegistry>,
         scan_cancel: crate::storage::scan_cancel::ScanCancel,
-        sender: std::sync::mpsc::SyncSender<std::result::Result<MergeEntry, String>>,
+        sender: std::sync::mpsc::SyncSender<std::result::Result<MergeEntry, MergeProducerError>>,
     ) {
         // Drive the streaming read on an owned Tokio runtime (Issue #587): the
         // producer owns its single-purpose runtime, so the blocking
@@ -528,7 +558,7 @@ impl SSTableRowIteratorAdapter {
                         Some(&schema_for_reader),
                         |compaction_row| {
                             let msg = Self::build_merge_entry(run_index, compaction_row, &schema)
-                                .map_err(|e| e.to_string());
+                                .map_err(MergeProducerError::from);
                             match sender.send(msg) {
                                 Ok(()) => Ok(std::ops::ControlFlow::Continue(())),
                                 Err(_) => Ok(std::ops::ControlFlow::Break(())),
@@ -540,8 +570,9 @@ impl SSTableRowIteratorAdapter {
         })();
 
         if let Err(e) = stream_result {
-            // Forward the error; ignore send failure (consumer may have dropped).
-            let _ = error_sender.send(Err(e.to_string()));
+            // Forward the error (preserving `Cancelled` distinctly, issue #2264);
+            // ignore send failure (consumer may have dropped).
+            let _ = error_sender.send(Err(MergeProducerError::from(e)));
         }
         // Channel closed naturally when sender is dropped here.
     }
@@ -992,7 +1023,12 @@ impl SSTableRowIterator for SSTableRowIteratorAdapter {
     fn next(&mut self) -> Option<Result<MergeEntry>> {
         match self.receiver.recv() {
             Ok(Ok(entry)) => Some(Ok(entry)),
-            Ok(Err(msg)) => Some(Err(Error::Storage(format!(
+            // Issue #2264: reconstruct `Error::Cancelled` distinctly so a
+            // cancelled scan is never confused with a genuine I/O/corruption
+            // error at the merge/producer boundary — `drive_merge` matches on
+            // the variant, not on a side-channel flag.
+            Ok(Err(MergeProducerError::Cancelled)) => Some(Err(Error::Cancelled)),
+            Ok(Err(MergeProducerError::Other(msg))) => Some(Err(Error::Storage(format!(
                 "streaming merge producer error: {}",
                 msg
             )))),

--- a/cqlite-flight/src/cancel.rs
+++ b/cqlite-flight/src/cancel.rs
@@ -23,14 +23,25 @@
 //! forever in `blocking_send` — a bare `AtomicBool` has no waker and could only be
 //! observed between merge steps, never while blocked in a full channel.
 
+use cqlite_core::storage::scan_cancel::ScanCancel;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 
 /// A cheap, cloneable cooperative-cancellation flag.
 ///
 /// All clones share one [`CancellationToken`], so cancelling any clone is observed
 /// by the merge loop polling another AND wakes anyone awaiting [`Self::cancelled`].
+///
+/// It ALSO carries a shared synchronous [`ScanCancel`] (issue #2264): the merge's
+/// per-run producer threads run a CPU-bound compaction scan on a plain
+/// `std::thread` with no async runtime, so they cannot poll the async token —
+/// they poll the `ScanCancel` instead. [`Self::cancel`] trips both, so ONE
+/// cancellation stops both the async channel-send race (PR #2282) AND the
+/// synchronous full-Data.db walk of an index-less SSTable.
 #[derive(Clone, Debug, Default)]
-pub struct CancelFlag(CancellationToken);
+pub struct CancelFlag {
+    token: CancellationToken,
+    scan_cancel: ScanCancel,
+}
 
 impl CancelFlag {
     /// Create a fresh, un-cancelled flag.
@@ -38,15 +49,24 @@ impl CancelFlag {
         Self::default()
     }
 
-    /// Request cancellation. Idempotent.
+    /// Request cancellation. Idempotent. Trips both the async token and the
+    /// synchronous [`ScanCancel`] (issue #2264).
     pub fn cancel(&self) {
-        self.0.cancel();
+        self.token.cancel();
+        self.scan_cancel.cancel();
+    }
+
+    /// The shared synchronous [`ScanCancel`] to wire into a cqlite-core
+    /// compaction merge (issue #2264). Cancelling this flag (or a clone) trips
+    /// the returned token, so a merge scan polling it abandons promptly.
+    pub fn scan_cancel(&self) -> ScanCancel {
+        self.scan_cancel.clone()
     }
 
     /// Whether cancellation has been requested. This is the between-step polling
     /// API the merge loop uses; unchanged in semantics from the `AtomicBool`.
     pub fn is_cancelled(&self) -> bool {
-        self.0.is_cancelled()
+        self.token.is_cancelled()
     }
 
     /// An owned future that resolves when this flag is cancelled (issue #2264).
@@ -57,7 +77,7 @@ impl CancelFlag {
     /// (not borrowed) so it can be moved into a `tokio::select!` on a blocking
     /// thread's local runtime handle without borrowing `self`.
     pub fn cancelled(&self) -> WaitForCancellationFutureOwned {
-        self.0.clone().cancelled_owned()
+        self.token.clone().cancelled_owned()
     }
 
     /// Arm a [`CancelGuard`] that cancels this flag when dropped (unless

--- a/cqlite-flight/src/cancel.rs
+++ b/cqlite-flight/src/cancel.rs
@@ -157,4 +157,37 @@ mod tests {
             "a disarmed guard must not cancel on drop"
         );
     }
+
+    #[test]
+    fn cancel_trips_the_shared_scan_cancel() {
+        // Issue #2264: the ScanCancel handed to a cqlite-core merge must observe a
+        // cancellation of the owning flag (or any clone), so the CPU-bound scan
+        // poll fires. Snapshot the token BEFORE cancelling — a merge already
+        // holds its handle when the client later disconnects.
+        let flag = CancelFlag::new();
+        let scan = flag.scan_cancel();
+        assert!(!scan.is_cancelled(), "fresh scan token is not cancelled");
+        flag.clone().cancel();
+        assert!(
+            scan.is_cancelled(),
+            "cancelling a clone must trip the previously-handed-out scan token"
+        );
+        assert!(flag.is_cancelled(), "and the async token too");
+    }
+
+    #[test]
+    fn drop_guard_trips_the_shared_scan_cancel() {
+        // The future-drop (client disconnect) path must also reach the sync scan
+        // token, not just the async channel race.
+        let flag = CancelFlag::new();
+        let scan = flag.scan_cancel();
+        {
+            let _guard = flag.drop_guard();
+            assert!(!scan.is_cancelled());
+        }
+        assert!(
+            scan.is_cancelled(),
+            "dropping an armed guard must trip the scan token"
+        );
+    }
 }

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -590,7 +590,12 @@ impl MergeProducer {
         if self.agg.is_some() || paths.is_empty() {
             return Ok(());
         }
-        let mut merger = KWayMerger::new(paths, &self.schema).map_err(ProducerError::Merge)?;
+        // Issue #2264: wire the shared synchronous cancel token into the merge so
+        // each run's producer thread (which fully materialises an index-less
+        // SSTable in one uninterruptible pass) abandons promptly on client
+        // disconnect, instead of the ~1–2 min transport backstop.
+        let mut merger = KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
+            .map_err(ProducerError::Merge)?;
         on_merger_built();
         self.drive_merge(&mut merger, cancel, sink, progress)
     }
@@ -687,7 +692,8 @@ impl MergeProducer {
             return Ok(batches);
         }
 
-        let mut merger = KWayMerger::new(paths, &self.schema).map_err(ProducerError::Merge)?;
+        let mut merger = KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
+            .map_err(ProducerError::Merge)?;
         let mut sink = CollectSink(&mut batches);
         // Collect path (parity oracle): a private seam — no external observer, but
         // the same incremental counter emission runs (issue #2162).
@@ -738,8 +744,19 @@ impl MergeProducer {
             if cancel.is_cancelled() {
                 return Err(ProducerError::Cancelled);
             }
-            let MergeStep::Partition { key, rows } = merger.step().map_err(ProducerError::Merge)?
-            else {
+            // A step error while cancellation is set is the cancelled scan
+            // surfacing (issue #2264): the per-run producer thread's compaction
+            // scan aborted with `Error::Cancelled` and closed its channel. Map it
+            // to the clean `Cancelled` abort rather than an opaque `Merge` error so
+            // the client sees `aborted`, not `internal`.
+            let step = merger.step().map_err(|e| {
+                if cancel.is_cancelled() {
+                    ProducerError::Cancelled
+                } else {
+                    ProducerError::Merge(e)
+                }
+            })?;
+            let MergeStep::Partition { key, rows } = step else {
                 break;
             };
             // Token-range filter: drop whole partitions outside the split's range.
@@ -806,7 +823,9 @@ impl MergeProducer {
         let mut state = plan.new_state();
 
         if !paths.is_empty() {
-            let mut merger = KWayMerger::new(paths, &self.schema).map_err(ProducerError::Merge)?;
+            let mut merger =
+                KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
+                    .map_err(ProducerError::Merge)?;
             self.drive_aggregate(plan, &mut merger, cancel, &mut state)?;
         }
 

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -857,8 +857,16 @@ impl MergeProducer {
             if cancel.is_cancelled() {
                 return Err(ProducerError::Cancelled);
             }
-            let MergeStep::Partition { key, rows } = merger.step().map_err(ProducerError::Merge)?
-            else {
+            // Map by VARIANT, not by racing the cancel flag (mirrors
+            // `drive_merge`, issue #2264 roborev): a real I/O/corruption error
+            // that happens to land while a client is disconnecting must never
+            // be masked as a clean `Cancelled` abort — only a genuine
+            // `Error::Cancelled` maps to `ProducerError::Cancelled`.
+            let step = merger.step().map_err(|e| match e {
+                cqlite_core::Error::Cancelled => ProducerError::Cancelled,
+                other => ProducerError::Merge(other),
+            })?;
+            let MergeStep::Partition { key, rows } = step else {
                 break;
             };
             if let Some(token) = &self.spec.token {
@@ -1147,6 +1155,23 @@ mod tests {
             matches!(err, ProducerError::Cancelled),
             "expected ProducerError::Cancelled, got {err:?}"
         );
+    }
+
+    /// A [`PartitionStepper`] that, on its first `step()`, sets a [`CancelFlag`]
+    /// (simulating a client disconnect landing concurrently with a step) AND
+    /// returns a genuine (non-`Cancelled`) `cqlite_core::Error` — the exact race
+    /// issue #2264's roborev fix targets: mapping by ERROR VARIANT, not by
+    /// racing `cancel.is_cancelled()` against ANY step error, so this genuine
+    /// error is never masked as a clean `Cancelled` abort.
+    struct CancellingErrorStepper {
+        cancel: CancelFlag,
+    }
+
+    impl PartitionStepper for CancellingErrorStepper {
+        fn step(&mut self) -> Result<MergeStep, cqlite_core::Error> {
+            self.cancel.cancel();
+            Err(cqlite_core::Error::Storage("genuine I/O failure".into()))
+        }
     }
 
     /// A [`PartitionStepper`] that counts `step()` calls, so a test can prove the
@@ -2548,6 +2573,43 @@ mod tests {
             .downcast_ref::<arrow::array::Int32Array>()
             .unwrap()
             .clone()
+    }
+
+    /// Issue #2264 roborev: `drive_aggregate` must map `merger.step()`'s error
+    /// by VARIANT, not by racing `cancel.is_cancelled()` against ANY step error.
+    /// [`CancellingErrorStepper`] reproduces the exact race — the cancel flag
+    /// becomes `true` AS PART OF the same `step()` call that returns a genuine
+    /// (non-`Cancelled`) error, simulating a client disconnect landing
+    /// concurrently with an unrelated I/O failure. FAILS on the pre-fix mapping
+    /// (`if cancel.is_cancelled() { Cancelled } else { Merge(e) }`, checked
+    /// AFTER the step returns): it would see `is_cancelled() == true` and wrongly
+    /// return `Cancelled`, masking the real error.
+    #[test]
+    fn aggregate_genuine_error_is_not_masked_as_cancelled() {
+        let schema = simple_schema();
+        let agg = Aggregation {
+            group_by: vec![],
+            aggregates: vec![count_star("agg0")],
+        };
+        let producer = agg_producer(schema, ScanSpec::default(), agg);
+        let plan = producer.agg.as_ref().expect("aggregation plan set");
+        let mut state = plan.new_state();
+
+        let cancel = CancelFlag::new();
+        let mut stepper = CancellingErrorStepper {
+            cancel: cancel.clone(),
+        };
+
+        let err = producer
+            .drive_aggregate(plan, &mut stepper, &cancel, &mut state)
+            .expect_err("a genuine step error must abort drive_aggregate");
+
+        assert!(cancel.is_cancelled(), "the stepper did set the cancel flag");
+        assert!(
+            matches!(err, ProducerError::Merge(_)),
+            "a genuine step error concurrent with cancellation must surface as \
+             ProducerError::Merge, not be masked as Cancelled — got {err:?}"
+        );
     }
 
     /// Global `count(*)` over N rows → exactly one partial row, count = N.

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -823,9 +823,8 @@ impl MergeProducer {
         let mut state = plan.new_state();
 
         if !paths.is_empty() {
-            let mut merger =
-                KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
-                    .map_err(ProducerError::Merge)?;
+            let mut merger = KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
+                .map_err(ProducerError::Merge)?;
             self.drive_aggregate(plan, &mut merger, cancel, &mut state)?;
         }
 

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -744,17 +744,17 @@ impl MergeProducer {
             if cancel.is_cancelled() {
                 return Err(ProducerError::Cancelled);
             }
-            // A step error while cancellation is set is the cancelled scan
-            // surfacing (issue #2264): the per-run producer thread's compaction
-            // scan aborted with `Error::Cancelled` and closed its channel. Map it
-            // to the clean `Cancelled` abort rather than an opaque `Merge` error so
-            // the client sees `aborted`, not `internal`.
-            let step = merger.step().map_err(|e| {
-                if cancel.is_cancelled() {
-                    ProducerError::Cancelled
-                } else {
-                    ProducerError::Merge(e)
-                }
+            // Map by VARIANT, not by racing the cancel flag (roborev, issue
+            // #2264): the per-run producer thread's compaction scan now
+            // propagates a genuine `Error::Cancelled` (preserved through the
+            // channel via `MergeProducerError`, not stringified) when it observes
+            // `scan_cancel`. Matching the variant directly means a real
+            // I/O/corruption error that happens to race a client disconnect is
+            // NEVER masked as a clean `Cancelled` abort — only an actual
+            // cancellation maps to `ProducerError::Cancelled`.
+            let step = merger.step().map_err(|e| match e {
+                cqlite_core::Error::Cancelled => ProducerError::Cancelled,
+                other => ProducerError::Merge(other),
             })?;
             let MergeStep::Partition { key, rows } = step else {
                 break;


### PR DESCRIPTION
Closes #2264. Part of Epic AM #2226. **P1 — the last remaining field blocker** (round-5 #2286: with reads fixed, `SELECT * FROM keyvalue LIMIT 5` hung ~2 min then ABANDONED).

## Root cause (Phase-A, field-proven)
With `Summary.db` absent (the field's snapshot shape, see #2295), `iterate_all_partitions` falls to `sequential_scan`, which **fully materializes all 414k+ partitions** (clones + sort) in one synchronous pass on a **detached producer thread** — before emitting a row. `LIMIT` truncates only after; the merge parks in its first `recv()`; flight's `CancelFlag` never reached cqlite-core (PR #2282 guarded the channel layer, which this path never touches). The server *receives* the client RST_STREAM but nothing polls. Thread dumps + h2 traces on #2286/#2264.

## Fix layers
- **`ScanCancel`** (new, `cqlite-core/src/storage/scan_cancel.rs`) + `Error::Cancelled`, polled at 256-cadence at unit boundaries in ALL read loops reachable from the merge path: sequential materialization (per-partition, block-size-independent), stitching drain + windowed block emit, index/Summary-backed iteration, outer chunk-read loop. Audited: no uncancellable O(partitions) loop remains on the do_get path.
- **Typed merge channel** (`MergeProducerError{Cancelled,Other}`): the old `String` channel stringified `Error::Cancelled` away — itself a masking bug.
- **Variant-based mapping** in `drive_merge` AND `drive_aggregate`: only `Error::Cancelled` → `ProducerError::Cancelled`; genuine errors stay `Merge(e)` (never masked by a racing disconnect).
- **Dedicated error category**: Node `CANCELLED`/`CancelledError` (was misleading `IO`), Python `CancelledError` exception (+ fixed missing package re-export, live-verified via maturin + 429/429 pytest), obs `error_schema` bucket.
- Write/compaction path insulated: default no-op `ScanCancel`; only flight's three `KWayMerger` sites pass a live token.

## Tests (fail-first throughout)
`compaction_cancel_tests.rs`: positive control, pre-cancelled, mid-scan sequential, **compressed/stitching** (LZ4-repacked fixture; verified by poll-removal → 3 tests fail), **index-backed** (Summary-present fixture, `index_probes()` oracle); `aggregate_genuine_error_is_not_masked_as_cancelled` (fails pre-fix); PR #2282's channel tests untouched and green. 48/48 producer tests.

## Review-first
rust-reviewer (opus): no blocking findings — clean boundary aborts, write path insulated, thread lifecycle verified. roborev 1583/1584/1586: all findings fixed in-round (variant mapping, per-partition polls, error category, index-backed coverage, aggregate mapping).

## Notes
- Full gate needs `CQLITE_ALLOW_FILE_GROWTH=1`: minimal poll lines grow 6 pre-existing over-threshold files (splits tracked by #1116).
- Pre-existing finding to file separately: CQLite-written Summary/Index pairs never fully resolve (silent sequential fallback) — surfaced during index-backed test work.
- Field closure: round-6 `LIMIT 5` on a loaded cluster returns in seconds (#2286 checklist; #2157 closes on the same verdict). Perf amplifier tracked in #2295.