### PR TITLE
fix(#1668): within-partition streaming merge (Q5 core refactor)

### DIFF
--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -76,7 +76,9 @@ pub mod fuzz_support;
 // allocation regression test in the SELECT executor's `lookup` module). It
 // delegates every operation to the system allocator and only bumps a per-thread
 // counter while a measurement is ACTIVE, so it is inert for every other test.
-#[cfg(all(test, feature = "state_machine"))] // sole `measure` caller lives in the state_machine `query` module; else `-D dead-code` under minimal (#1981)
+// `not(dhat-heap)`: mutually exclusive with `DHAT_TEST_ALLOC` below (#1668) —
+// only one `#[global_allocator]` per binary.
+#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))] // sole `measure` caller lives in the state_machine `query` module; else `-D dead-code` under minimal (#1981)
 pub(crate) mod test_alloc_probe {
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::cell::Cell;
@@ -130,9 +132,18 @@ pub(crate) mod test_alloc_probe {
     }
 }
 
-#[cfg(all(test, feature = "state_machine"))]
+#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]
 #[global_allocator]
 static TEST_ALLOC: test_alloc_probe::CountingAllocator = test_alloc_probe::CountingAllocator;
+
+// Issue #1668: dhat allocator for `cqlite-core`'s unit-test binary, so an
+// in-tree `#[cfg(test)]` test can drive `pub(crate)` `StreamingMerger`
+// directly (see `merge::streaming::streaming_dhat_test`'s doc). Run with
+// `--no-default-features --features write-support,dhat-heap` (excludes
+// `state_machine`, whose own allocator this would otherwise collide with).
+#[cfg(all(test, feature = "dhat-heap"))]
+#[global_allocator]
+static DHAT_TEST_ALLOC: dhat::Alloc = dhat::Alloc;
 
 // Re-export main types for convenience
 pub use crate::{

--- a/cqlite-core/src/query/select_executor/lookup.rs
+++ b/cqlite-core/src/query/select_executor/lookup.rs
@@ -790,6 +790,15 @@ mod tests {
     /// (2) the index-based build allocates strictly fewer times than that
     /// reference — the regression that fails on the old impl (where the two
     /// builds are the same code and allocate identically).
+    ///
+    /// `not(dhat-heap)`: issue #1668's dhat allocator (`lib.rs`'s
+    /// `DHAT_TEST_ALLOC`) mutually excludes `test_alloc_probe`'s own
+    /// `CountingAllocator` (only one `#[global_allocator]` per binary), so
+    /// under a feature combination with BOTH `state_machine` and
+    /// `dhat-heap` enabled (e.g. `--all-features`) `test_alloc_probe` is
+    /// configured out entirely — skip this specific allocation-count probe
+    /// rather than fail to resolve it.
+    #[cfg(not(feature = "dhat-heap"))]
     #[test]
     fn cartesian_product_builds_each_combo_in_one_allocation() {
         use crate::test_alloc_probe::measure;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
@@ -474,107 +474,22 @@ pub(crate) fn is_primary_key_column(column: &str, schema: &TableSchema) -> bool 
 /// carries the originating mutation's timestamp and explicit local deletion
 /// time (Issue #764) so a surviving older static delete keeps its own LDT
 /// instead of inheriting the newest static mutation's value.
+///
+/// Issue #1668, stage 5c-ii: a thin wrapper over [`StaticOpsTracker`] — the
+/// SAME per-mutation last-write-wins fold, now factored into a running
+/// tracker so a future incremental writer entry point (stage 5c-iv) can feed
+/// it one cluster group at a time instead of requiring the whole `&[Mutation]`
+/// slice upfront. Byte-identical to the prior whole-slice implementation.
 pub(crate) fn collect_static_operations(
     mutations: &[Mutation],
     schema: &TableSchema,
     shadow_floor: Option<i64>,
 ) -> Vec<StaticMergedOp> {
-    use std::collections::HashMap;
-
-    // Map: column_name → winning StaticMergedOp (last-write-wins by timestamp).
-    let mut best: HashMap<String, StaticMergedOp> = HashMap::new();
-
+    let mut tracker = StaticOpsTracker::new();
     for mutation in mutations {
-        if shadow_floor.is_some_and(|floor| mutation.timestamp_micros <= floor) {
-            continue;
-        }
-        for op in &mutation.operations {
-            if !is_static_operation(op, schema) {
-                continue;
-            }
-            let col_name = match op {
-                crate::storage::write_engine::mutation::CellOperation::Write { column, .. }
-                | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl {
-                    column,
-                    ..
-                }
-                | crate::storage::write_engine::mutation::CellOperation::Delete {
-                    column, ..
-                } => column.clone(),
-                // Per-element complex ops (epic #899) are not produced for STATIC
-                // complex columns by the (Phase B) capability — they flow through
-                // the regular-row per-element path. Skip them here defensively.
-                crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
-                    ..
-                }
-                | crate::storage::write_engine::mutation::CellOperation::ComplexDeletion {
-                    ..
-                } => continue,
-                crate::storage::write_engine::mutation::CellOperation::DeleteRow => continue,
-            };
-            // Issue #1018: a static `Write`/`WriteWithTtl`/`Delete` cell carries
-            // its OWN per-cell timestamp when the compaction merge→mutation path
-            // recorded one in `Mutation::cell_write_timestamps` (it differs from
-            // the row's `timestamp_micros`) — a live cell's writetime OR a static
-            // cell tombstone's markedForDeleteAt. Use it for BOTH the stamped
-            // candidate timestamp AND the last-write-wins comparison below,
-            // mirroring the regular-row path in `rows.rs`. Otherwise a compacted
-            // static row with surviving static siblings at differing timestamps
-            // would rewrite older static cells (live OR tombstone) to the newest
-            // static mutation's row max — re-introducing the over-deletion bug for
-            // statics. For every other op (and for cells with no per-cell override)
-            // this is exactly `mutation.timestamp_micros`, so the single-writetime
-            // case is unchanged.
-            let candidate_ts = op_cell_write_timestamp(op, mutation);
-            // Issue #1018 (roborev HIGH): PER-CELL shadow filtering for statics. The
-            // mutation-level `shadow_floor` skip above gates on the ROW MAX
-            // (`mutation.timestamp_micros`), so a mutation that survives the floor
-            // (because a recent static sibling keeps its row max high) can still
-            // carry an individual static `Write`/`WriteWithTtl`/`Delete` whose OWN
-            // per-cell timestamp is `<= shadow_floor`. That cell is covered by the
-            // partition tombstone and MUST be shadowed exactly as it would have been
-            // when every static cell used the row max. Apply the SAME boundary the
-            // row-max skip uses (`<= floor`) to the resolved `candidate_ts`,
-            // dropping the static op here so it never reaches the LWW map (and so
-            // the static liveness/TTL the partition path derives from the SURVIVING
-            // ops below cannot resurrect it). A static cell tombstone is itself
-            // shadowed on the same floor using its OWN markedForDeleteAt. Every cell
-            // with no override already has `candidate_ts == mutation.timestamp_micros
-            // > floor`, leaving the single-writetime case unchanged.
-            if shadow_floor.is_some_and(|floor| candidate_ts <= floor)
-                && matches!(
-                    op,
-                    crate::storage::write_engine::mutation::CellOperation::Write { .. }
-                        | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { .. }
-                        | crate::storage::write_engine::mutation::CellOperation::Delete { .. }
-                )
-            {
-                continue;
-            }
-            let candidate = StaticMergedOp {
-                // #921 finding 2: preserve a `Delete` cell tombstone's own surfaced
-                // LDT; other ops fall back to the mutation's effective LDT.
-                cell_local_deletion_time: op_cell_local_deletion_time(op, mutation),
-                op: op.clone(),
-                timestamp_micros: candidate_ts,
-                // #1196: carry statement-level TTL so a static `USING TTL` Write
-                // is emitted as an expiring cell, not a non-expiring one.
-                row_ttl_seconds: mutation.ttl_seconds,
-            };
-            match best.entry(col_name) {
-                std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(candidate);
-                }
-                std::collections::hash_map::Entry::Occupied(mut entry) => {
-                    if candidate.timestamp_micros >= entry.get().timestamp_micros {
-                        entry.insert(candidate);
-                    }
-                }
-            }
-        }
+        tracker.feed(mutation, schema, shadow_floor);
     }
-
-    best.into_values().collect()
+    tracker.finish()
 }
 
 /// Derive a static row's liveness timestamp + TTL from the SURVIVING merged

--- a/cqlite-core/src/storage/sstable/writer/data_writer/incremental_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/incremental_partition.rs
@@ -247,14 +247,62 @@ impl<'w, 'r> IncrementalPartitionWriter<'w, 'r> {
             {
                 break;
             }
-            self.marker_cursor += 1;
-            self.emit_item(marker.as_partition_item(), schema)?;
+            self.emit_next_marker_or_boundary(marker, schema)?;
         }
 
         if let Some(row) = DataWriter::merge_row_group(&[mutation], schema, false, shadow_floor) {
             self.emit_item(PartitionItem::Row(row), schema)?;
         }
         Ok(())
+    }
+
+    /// Emit `marker` (the item at `self.marker_cursor`), coalescing it with
+    /// its immediately-following pair into a single `PartitionItem::Boundary`
+    /// when they form one (issue #1220 / roborev blocker #1 on #1668):
+    /// `write_partition`/`write_partition_with_index_blocks` run every
+    /// emitted marker through `coalesce_boundaries`, but draining
+    /// `sorted_markers` one at a time (instead of coalescing the whole
+    /// pre-sorted `Vec` up front) skipped that step entirely — two adjacent
+    /// range tombstones with different deletion times would otherwise be
+    /// persisted as two separate bound markers instead of Cassandra's single
+    /// boundary marker.
+    ///
+    /// Safe to decide using ONLY `marker`'s own already-known sort position
+    /// (the caller's row-test in [`Self::feed_row`], or unconditionally in
+    /// [`Self::finish`]): a coalescible close+open pair always shares the
+    /// EXACT SAME clustering point with EQUAL sort weight (see
+    /// `marker_merge::sort_class`), so both bounds always compare identically
+    /// against any given row — advancing past both here can never skip past
+    /// a row that should have been emitted first.
+    fn emit_next_marker_or_boundary(
+        &mut self,
+        marker: SortableMarker<'r>,
+        schema: &TableSchema,
+    ) -> Result<()> {
+        if !marker.is_open {
+            if let Some(next) = self.sorted_markers.get(self.marker_cursor + 1).copied() {
+                if next.is_open {
+                    if let Some((kind, clustering)) =
+                        partition::boundary_kind_for(marker.bound, next.bound, schema)
+                    {
+                        self.marker_cursor += 2;
+                        return self.emit_item(
+                            PartitionItem::Boundary {
+                                kind,
+                                clustering,
+                                end_deletion_time: marker.deletion_time,
+                                end_local_deletion_time: marker.local_deletion_time,
+                                start_deletion_time: next.deletion_time,
+                                start_local_deletion_time: next.local_deletion_time,
+                            },
+                            schema,
+                        );
+                    }
+                }
+            }
+        }
+        self.marker_cursor += 1;
+        self.emit_item(marker.as_partition_item(), schema)
     }
 
     /// Finalize the partition: emit any remaining markers, `END_OF_PARTITION`,
@@ -265,8 +313,7 @@ impl<'w, 'r> IncrementalPartitionWriter<'w, 'r> {
     ) -> Result<(u64, Vec<PromotedIndexBlock>, PartitionEmitCounts)> {
         while self.marker_cursor < self.sorted_markers.len() {
             let marker = self.sorted_markers[self.marker_cursor];
-            self.marker_cursor += 1;
-            self.emit_item(marker.as_partition_item(), schema)?;
+            self.emit_next_marker_or_boundary(marker, schema)?;
         }
 
         self.writer.buffer.push(END_OF_PARTITION);

--- a/cqlite-core/src/storage/sstable/writer/data_writer/incremental_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/incremental_partition.rs
@@ -1,0 +1,427 @@
+//! Incremental partition-write entry point (issue #1668, stage 5c-iv, PART 1
+//! — build + prove, not yet wired to any production caller).
+//!
+//! `write_partition`/`write_partition_with_index_blocks` (`partition.rs`)
+//! need the WHOLE partition's `&[Mutation]` slice upfront: they sort it, run
+//! `collect_static_operations` over it, build `rows` via
+//! `merge_clustering_rows`, then interleave rows with range-tombstone markers
+//! via a full re-sort. [`IncrementalPartitionWriter`] proves the SAME Data.db
+//! bytes can be produced from a partition fed ONE PIECE AT A TIME:
+//!
+//! 1. [`DataWriter::begin_partition_incremental`] — writes the header
+//!    immediately (the partition tombstone, if any, is known upfront from the
+//!    caller — the eventual merge-side caller has it from the stage-1
+//!    carrier pre-scan). Builds and sorts the (typically few) range-
+//!    tombstone markers ONCE via `marker_merge::partition_item_cmp` (stage
+//!    5c-iii) — NOT the whole per-row items list.
+//! 2. [`IncrementalPartitionWriter::feed_static_row`] — called AT MOST ONCE,
+//!    right after `begin_partition_incremental`, BEFORE any clustering row.
+//!    Compaction's own merge reconciliation guarantees a static-row carrier
+//!    (if any) is the ONLY `clustering_key: None` entry in a partition's
+//!    reconciled `Vec<MergeEntry>` and ALWAYS sorts first — proven directly
+//!    in `streaming.rs`'s `static_row_carrier_always_sorts_first_regardless_
+//!    of_partition_width` test. So the caller resolves statics via
+//!    [`super::static_ops::StaticOpsTracker`] (stage 5c-ii) BEFORE streaming
+//!    any `Some(ck)` row, without buffering the clustering-row tail.
+//! 3. [`IncrementalPartitionWriter::feed_row`] — called once per clustering
+//!    row, ALREADY in clustering order (the caller's streaming source
+//!    guarantees this — stage 5c-i's schema-aware heap, modulo the stage-5d
+//!    `clustered_rows` fix). Emits any PENDING sorted markers that sort
+//!    strictly before this row (the 5c-iii merge-step logic, driven one row
+//!    at a time instead of via a bulk interleave), then the row itself.
+//! 4. [`IncrementalPartitionWriter::finish`] — emits any remaining markers,
+//!    the `END_OF_PARTITION` byte, closes the last promoted-index block, and
+//!    flushes.
+//!
+//! Promoted-index block tracking (Cassandra `BigFormatPartitionWriter`
+//! parity) is reproduced VERBATIM from `write_partition_with_index_blocks`'s
+//! inline loop body — moved, not duplicated — via
+//! [`IncrementalPartitionWriter::emit_item`], the ONE place that both the
+//! static-row/row/marker emission paths funnel through.
+//!
+//! NOT yet called by any production path: `SSTableWriter::write_partition`
+//! still calls `write_partition_with_index_blocks` (the whole-slice path).
+//! Wiring `maintenance.rs`/`KWayMerger::merge()` to this incremental entry
+//! point is stage 5c-iv, PART 2 — only after this module is proven correct
+//! in isolation (see this module's tests).
+
+// Stage 5c-iv part 1 (#1668) is deliberately UNWIRED: no production caller
+// constructs an `IncrementalPartitionWriter` yet (that is part 2), so a
+// normal (non-test) build sees every item here as unreachable. Matches the
+// crate's existing convention for proof-only surface pending production
+// wiring (see `streaming.rs`'s stage-2 / `schema_order.rs`'s stage-5b
+// history). Exercised directly by this module's own tests.
+#![allow(dead_code)]
+
+use super::*;
+
+/// A single range-tombstone bound marker, sorted once in
+/// [`DataWriter::begin_partition_incremental`] and drained as rows arrive
+/// (issue #1668, stage 5c-iv). A dedicated `Copy` struct — rather than
+/// storing `PartitionItem::Marker` variants directly — so converting a
+/// stored marker into the `PartitionItem` `emit_item` expects is a plain,
+/// always-valid field copy with no other-variant case to (unreachably)
+/// panic on.
+#[derive(Clone, Copy)]
+struct SortableMarker<'r> {
+    bound: &'r ClusteringBound,
+    is_open: bool,
+    deletion_time: i64,
+    local_deletion_time: i32,
+}
+
+impl<'r> SortableMarker<'r> {
+    fn as_partition_item(self) -> PartitionItem<'r> {
+        PartitionItem::Marker {
+            bound: self.bound,
+            is_open: self.is_open,
+            deletion_time: self.deletion_time,
+            local_deletion_time: self.local_deletion_time,
+        }
+    }
+}
+
+/// Incremental partition-write session (issue #1668, stage 5c-iv).
+///
+/// Holds `&'w mut DataWriter` (so its own methods can call the writer's
+/// existing `pub(super)` emission helpers directly) plus the running,
+/// partition-scoped state `write_partition_with_index_blocks` otherwise
+/// keeps as plain local variables inside its `for item in items` loop.
+pub(crate) struct IncrementalPartitionWriter<'w, 'r> {
+    writer: &'w mut DataWriter,
+    partition_offset: u64,
+    partition_buf_start: usize,
+    prev_unfiltered_size: u64,
+    partition_floor: Option<i64>,
+    range_tombstones: &'r [RangeTombstone],
+    /// The (typically few) range-tombstone markers, sorted ONCE via the
+    /// SAME comparator `sort_partition_items` uses (stage 5c-iii) — drained
+    /// as rows arrive via [`Self::feed_row`], never re-sorted.
+    sorted_markers: Vec<SortableMarker<'r>>,
+    marker_cursor: usize,
+    emit: PartitionEmitCounts,
+    /// `None` until the first post-header/post-static-row item is about to
+    /// be written — matches `write_partition_with_index_blocks`'s
+    /// `block_start_buf_offset`, which excludes the header AND the static
+    /// row from block 0's byte range.
+    block_start_buf_offset: Option<usize>,
+    blocks: Vec<PromotedIndexBlock>,
+    current_block_first_ck: Option<Vec<u8>>,
+    current_block_last_ck: Option<Vec<u8>>,
+    current_block_oss50: Option<Option<Vec<u8>>>,
+}
+
+impl DataWriter {
+    /// Begin an incremental partition write (issue #1668, stage 5c-iv).
+    ///
+    /// Writes the partition header immediately (the caller supplies
+    /// `partition_tombstone` upfront — known before any row arrives, from
+    /// the stage-1 carrier pre-scan on the merge side) and pre-sorts the
+    /// (small) `range_tombstones` list ONCE. Returns a session that must be
+    /// driven through `feed_static_row` (at most once, if the schema has any
+    /// static column), then `feed_row` (one call per clustering row, in
+    /// clustering order), then `finish`.
+    pub(crate) fn begin_partition_incremental<'w, 'r>(
+        &'w mut self,
+        key: &DecoratedKey,
+        partition_tombstone: Option<&PartitionTombstone>,
+        range_tombstones: &'r [RangeTombstone],
+        schema: &TableSchema,
+    ) -> Result<IncrementalPartitionWriter<'w, 'r>> {
+        let partition_offset = self.position + self.buffer.len() as u64;
+        let partition_buf_start = self.buffer.len();
+        let header_start = self.buffer.len();
+        self.write_partition_header(key, partition_tombstone)?;
+        let prev_unfiltered_size = (self.buffer.len() - header_start) as u64;
+        let partition_floor = partition_tombstone.map(|pt| pt.deletion_time);
+
+        let mut sorted_markers: Vec<SortableMarker<'r>> =
+            Vec::with_capacity(range_tombstones.len() * 2);
+        for rt in range_tombstones {
+            sorted_markers.push(SortableMarker {
+                bound: &rt.start,
+                is_open: true,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+            sorted_markers.push(SortableMarker {
+                bound: &rt.end,
+                is_open: false,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+        }
+        sorted_markers.sort_by(|a, b| {
+            marker_merge::partition_item_cmp(&a.as_partition_item(), &b.as_partition_item(), schema)
+        });
+
+        Ok(IncrementalPartitionWriter {
+            writer: self,
+            partition_offset,
+            partition_buf_start,
+            prev_unfiltered_size,
+            partition_floor,
+            range_tombstones,
+            sorted_markers,
+            marker_cursor: 0,
+            emit: PartitionEmitCounts::default(),
+            block_start_buf_offset: None,
+            blocks: Vec::new(),
+            current_block_first_ck: None,
+            current_block_last_ck: None,
+            current_block_oss50: None,
+        })
+    }
+}
+
+impl<'w, 'r> IncrementalPartitionWriter<'w, 'r> {
+    /// Write the static-row prelude — called AT MOST ONCE, before any
+    /// `feed_row` call, when the schema declares any static column. `merged`
+    /// is the ALREADY-RESOLVED static ops (e.g. via
+    /// `static_ops::StaticOpsTracker::finish`, stage 5c-ii); pass an empty
+    /// slice for "schema has statics but this partition writes none" (the
+    /// writer still emits the minimal empty form, matching
+    /// `write_partition_with_index_blocks` exactly). `first_mutation_ts` is
+    /// the fallback liveness timestamp used only when `merged` is non-empty
+    /// but carries no derivable liveness (mirrors
+    /// `mutations.first().map(|m| m.timestamp_micros).unwrap_or(0)` in the
+    /// whole-slice path).
+    pub(crate) fn feed_static_row(
+        &mut self,
+        merged: &[StaticMergedOp],
+        first_mutation_ts: i64,
+        schema: &TableSchema,
+    ) -> Result<()> {
+        if merged.is_empty() {
+            let static_size = self.writer.write_empty_static_row(0, schema)? as u64;
+            self.prev_unfiltered_size += static_size;
+        } else {
+            let (latest_ts, ttl) =
+                static_liveness_from_ops(merged).unwrap_or((first_mutation_ts, None));
+            let (static_size, static_cells) = self
+                .writer
+                .write_static_row_with_prev_size(merged, latest_ts, ttl, schema, 0)?;
+            self.prev_unfiltered_size += static_size as u64;
+            self.emit.rows += 1;
+            self.emit.columns += static_cells;
+        }
+        Ok(())
+    }
+
+    /// Feed one clustering-key group's mutation (issue #1668, stage 5c-iv).
+    ///
+    /// For compaction, a "cluster group" is already a single, fully
+    /// reconciled `Mutation` (the merge layer collapses to one entry per
+    /// distinct clustering key), so this treats `mutation` as its own
+    /// singleton group via `merge_row_group(&[mutation], ..)` — the SAME
+    /// function `merge_clustering_rows` calls per adjacency-group in the
+    /// whole-slice path. Emits any PENDING sorted markers that sort strictly
+    /// before this row first, then the row itself (skipping emission
+    /// entirely if the row is fully shadowed — matches
+    /// `merge_clustering_rows`'s `if let Some(row) = ...` skip).
+    pub(crate) fn feed_row(&mut self, mutation: &Mutation, schema: &TableSchema) -> Result<()> {
+        let clustering_key = mutation.clustering_key.as_ref();
+        let mut shadow_floor = self.partition_floor;
+        for rt in self.range_tombstones {
+            if range_tombstone_covers(rt, clustering_key, schema) {
+                shadow_floor =
+                    Some(shadow_floor.map_or(rt.deletion_time, |f| f.max(rt.deletion_time)));
+            }
+        }
+
+        // Emit every pending marker that sorts strictly before this row
+        // (issue #1220 tie-break: a Row and a Marker never compare Equal at
+        // the same clustering value — see marker_merge's module doc — so
+        // "strictly before" is unambiguous here).
+        let row_item = PartitionItem::Row(RowWrite {
+            clustering_key,
+            liveness_ts: None,
+            ttl_seconds: None,
+            row_deletion: None,
+            ops: Vec::new(),
+            complex_element_ops: Vec::new(),
+        });
+        while let Some(marker) = self.sorted_markers.get(self.marker_cursor).copied() {
+            if marker_merge::partition_item_cmp(&marker.as_partition_item(), &row_item, schema)
+                == std::cmp::Ordering::Greater
+            {
+                break;
+            }
+            self.marker_cursor += 1;
+            self.emit_item(marker.as_partition_item(), schema)?;
+        }
+
+        if let Some(row) = DataWriter::merge_row_group(&[mutation], schema, false, shadow_floor) {
+            self.emit_item(PartitionItem::Row(row), schema)?;
+        }
+        Ok(())
+    }
+
+    /// Finalize the partition: emit any remaining markers, `END_OF_PARTITION`,
+    /// close the last promoted-index block, and flush.
+    pub(crate) fn finish(
+        mut self,
+        schema: &TableSchema,
+    ) -> Result<(u64, Vec<PromotedIndexBlock>, PartitionEmitCounts)> {
+        while self.marker_cursor < self.sorted_markers.len() {
+            let marker = self.sorted_markers[self.marker_cursor];
+            self.marker_cursor += 1;
+            self.emit_item(marker.as_partition_item(), schema)?;
+        }
+
+        self.writer.buffer.push(END_OF_PARTITION);
+
+        if let (Some(first), Some(last)) = (
+            self.current_block_first_ck.take(),
+            self.current_block_last_ck.take(),
+        ) {
+            let current_buf_offset = self.writer.buffer.len() - self.partition_buf_start;
+            let block_start = self.block_start_buf_offset.unwrap_or(current_buf_offset);
+            let block_bytes = (current_buf_offset - block_start) as u64;
+            if block_bytes > 0 {
+                self.blocks.push(PromotedIndexBlock {
+                    first_name: first,
+                    last_name: last,
+                    offset: block_start as u64,
+                    width: block_bytes,
+                    oss50_separator: self.current_block_oss50.take().flatten(),
+                });
+            }
+        }
+
+        self.writer.flush_partition()?;
+        Ok((self.partition_offset, self.blocks, self.emit))
+    }
+
+    /// Write one item (row or marker) and update promoted-index-block
+    /// tracking — moved VERBATIM (not duplicated) from
+    /// `write_partition_with_index_blocks`'s `for item in items { .. }` loop
+    /// body, the ONE place both the row and marker emission paths funnel
+    /// through.
+    ///
+    /// Generic over its OWN lifetime `'a`, independent of the struct's `'r`
+    /// (which is `range_tombstones`' lifetime): a `Row` item borrows from
+    /// the CURRENT `feed_row` call's `mutation` argument, an entirely
+    /// different (and shorter-lived) object than `range_tombstones` — the
+    /// item is fully consumed (its bytes written) before this call returns,
+    /// so it never needs to outlive that.
+    fn emit_item<'a>(&mut self, item: PartitionItem<'a>, schema: &TableSchema) -> Result<()> {
+        let ck_bytes: Vec<u8> = match &item {
+            PartitionItem::Row(row) => {
+                if let Some(ck) = row.clustering_key {
+                    serialize_clustering_prefix_for_index(ck, schema)
+                        .unwrap_or_else(|_| empty_clustering_prefix_for_index())
+                } else {
+                    empty_clustering_prefix_for_index()
+                }
+            }
+            PartitionItem::Marker { bound, is_open, .. } => {
+                serialize_marker_bound_prefix_for_index(bound, *is_open, schema)
+                    .unwrap_or_else(|_| marker_bound_prefix_for_index(bound, *is_open))
+            }
+            PartitionItem::Boundary {
+                kind, clustering, ..
+            } => serialize_boundary_prefix_for_index(*kind, clustering, schema)
+                .unwrap_or_else(|_| boundary_prefix_for_index_fallback(*kind)),
+        };
+
+        let partition_buf_start = self.partition_buf_start;
+        if self.current_block_first_ck.is_none() {
+            self.current_block_first_ck = Some(ck_bytes.clone());
+            let ck_values: Option<Vec<Value>> = match &item {
+                PartitionItem::Row(row) => row
+                    .clustering_key
+                    .filter(|ck| !ck.columns.is_empty())
+                    .map(|ck| ck.columns.iter().map(|(_, v)| v.clone()).collect()),
+                PartitionItem::Marker { .. } | PartitionItem::Boundary { .. } => None,
+            };
+            let is_reversed: Vec<bool> = schema
+                .clustering_keys
+                .iter()
+                .map(|c| c.order == crate::schema::ClusteringOrder::Desc)
+                .collect();
+            self.current_block_oss50 = Some(ck_values.and_then(|vals| {
+                crate::storage::sstable::bti::encode_clustering_bound_oss50_with_order(
+                    &vals,
+                    &is_reversed,
+                )
+                .ok()
+            }));
+            // Lazily anchor the FIRST block's start now, at the first
+            // post-header/post-static-row item — matches
+            // `write_partition_with_index_blocks`'s `block_start_buf_offset`
+            // initialization point exactly.
+            self.block_start_buf_offset
+                .get_or_insert(self.writer.buffer.len() - partition_buf_start);
+        }
+        self.current_block_last_ck = Some(ck_bytes.clone());
+
+        self.prev_unfiltered_size = match item {
+            PartitionItem::Row(row) => {
+                self.emit.rows += 1;
+                let (bytes, cells) = self.writer.write_merged_row_with_prev_size(
+                    &row,
+                    schema,
+                    self.prev_unfiltered_size,
+                )?;
+                self.emit.columns += cells;
+                bytes as u64
+            }
+            PartitionItem::Marker {
+                bound,
+                is_open,
+                deletion_time,
+                local_deletion_time,
+            } => self.writer.write_range_bound(
+                bound,
+                is_open,
+                deletion_time,
+                local_deletion_time,
+                schema,
+                self.prev_unfiltered_size,
+            )? as u64,
+            PartitionItem::Boundary {
+                kind,
+                clustering,
+                end_deletion_time,
+                end_local_deletion_time,
+                start_deletion_time,
+                start_local_deletion_time,
+            } => self.writer.write_range_boundary(
+                kind,
+                clustering,
+                end_deletion_time,
+                end_local_deletion_time,
+                start_deletion_time,
+                start_local_deletion_time,
+                schema,
+                self.prev_unfiltered_size,
+            )? as u64,
+        };
+
+        let current_buf_offset = self.writer.buffer.len() - partition_buf_start;
+        let block_start = self.block_start_buf_offset.unwrap_or(current_buf_offset);
+        let block_bytes = (current_buf_offset - block_start) as u64;
+
+        if block_bytes >= COLUMN_INDEX_SIZE_BYTES {
+            self.blocks.push(PromotedIndexBlock {
+                first_name: self
+                    .current_block_first_ck
+                    .take()
+                    .unwrap_or_else(empty_clustering_prefix_for_index),
+                last_name: self
+                    .current_block_last_ck
+                    .take()
+                    .unwrap_or_else(empty_clustering_prefix_for_index),
+                offset: block_start as u64,
+                width: block_bytes,
+                oss50_separator: self.current_block_oss50.take().flatten(),
+            });
+            self.block_start_buf_offset = Some(current_buf_offset);
+            self.current_block_first_ck = None;
+            self.current_block_last_ck = None;
+            self.current_block_oss50 = None;
+        }
+        Ok(())
+    }
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer/marker_merge.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/marker_merge.rs
@@ -1,0 +1,376 @@
+//! Incremental rows+markers interleave (issue #1668, stage 5c-iii).
+//!
+//! `sort_partition_items` (`partition.rs`) re-sorts the WHOLE combined
+//! `rows ++ markers` sequence from scratch every time, even though `rows`
+//! already arrives in clustering order (from `merge_clustering_rows`, which
+//! itself requires pre-sorted `mutations` — see stage 5a) and the range-
+//! tombstone markers are typically FEW (the stage-1 carrier pre-scan already
+//! established this). [`merge_rows_and_markers`] replaces that full re-sort
+//! with a classic two-way MERGE: sort the (small) marker list once, then
+//! interleave it with the already-sorted rows in one forward pass — no
+//! re-sorting of the combined, potentially partition-sized sequence.
+//!
+//! The comparator itself, [`partition_item_cmp`], is extracted VERBATIM from
+//! `sort_partition_items`'s prior inline closure (moved, not duplicated) so
+//! BOTH the old full-sort path and this new merge path always agree — a
+//! future divergence between the two would be a single-function fix, not a
+//! two-place hunt.
+//!
+//! ## Why a merge is safe here (no tie-break ambiguity)
+//!
+//! A `Row` at a given clustering value always carries `weight = 0`
+//! (`CLUSTERING` ordinal), while a `Marker` at ANY clustering value carries
+//! `weight = ±1` — never `0`. So a `Row` and a `Marker` can never compare
+//! EQUAL under [`partition_item_cmp`] (the tuple always differs at the
+//! `weight` field), which is exactly why choosing "take from `rows` on a
+//! non-`Greater` comparison" in [`merge_rows_and_markers`]'s tie-break never
+//! actually has to arbitrate a real tie between the two streams — only
+//! marker-vs-marker or row-vs-row comparisons could tie, and those are each
+//! already resolved within their OWN pre-sorted stream before the merge
+//! step ever compares across streams.
+
+use super::*;
+
+/// Sort key for clustering-ordered emission: `(position class, clustering
+/// values, bound weight, kind ordinal)`. class: -1 = before all rows
+/// (Bottom), 0 = positioned by clustering values, 1 = after all rows (Top).
+/// The weight orders a marker relative to a row at the SAME clustering value
+/// (`ClusteringPrefix.Kind.comparedToClustering`): an inclusive-start /
+/// exclusive-end bound sorts before the row, an inclusive-end / exclusive-
+/// start bound after it.
+///
+/// The final element is the Cassandra `ClusteringPrefix.Kind` ordinal, used
+/// as a strict tiebreak so that — at an equal clustering point and equal
+/// weight — the CLOSING bound of one range always sorts immediately before
+/// the matching OPENING bound of the next, regardless of the order the
+/// `range_tombstones` arrived in (issue #1220, roborev finding 2).
+fn sort_class<'a, 'b>(item: &'b PartitionItem<'a>) -> (i8, Option<&'b ClusteringKey>, i8, u8) {
+    match item {
+        PartitionItem::Row(row) => (0, row.clustering_key, 0, CLUSTERING),
+        PartitionItem::Marker { bound, is_open, .. } => {
+            let kind = bound_kind_ordinal(bound, *is_open);
+            match bound {
+                ClusteringBound::Inclusive(ck) => {
+                    (0, Some(ck), if *is_open { -1 } else { 1 }, kind)
+                }
+                ClusteringBound::Exclusive(ck) => {
+                    (0, Some(ck), if *is_open { 1 } else { -1 }, kind)
+                }
+                ClusteringBound::Bottom => (-1, None, 0, kind),
+                ClusteringBound::Top => (1, None, 0, kind),
+            }
+        }
+        PartitionItem::Boundary {
+            kind, clustering, ..
+        } => (0, Some(clustering), 0, *kind),
+    }
+}
+
+/// The Cassandra `ClusteringPrefix.Kind` ordinal for a range-tombstone BOUND.
+/// Used purely as a sort tiebreak (see [`sort_class`]); the canonical
+/// ordering is the one decoded on the read path (`row_decoder/block_emit.rs`)
+/// and the constants in `data_writer/mod.rs`:
+///   0 EXCL_END_BOUND · 1 INCL_START_BOUND · 6 INCL_END_BOUND · 7 EXCL_START_BOUND.
+fn bound_kind_ordinal(bound: &ClusteringBound, is_open: bool) -> u8 {
+    match (is_open, bound) {
+        (true, ClusteringBound::Inclusive(_)) => INCL_START_BOUND, // 1
+        (false, ClusteringBound::Exclusive(_)) => EXCL_END_BOUND,  // 0
+        (false, ClusteringBound::Inclusive(_)) => INCL_END_BOUND,  // 6
+        (true, ClusteringBound::Exclusive(_)) => EXCL_START_BOUND, // 7
+        // Open-ended bounds are positioned by `class` (Bottom/Top), never
+        // reach a value-level tiebreak; report their side's kind for
+        // completeness.
+        (true, ClusteringBound::Bottom | ClusteringBound::Top) => INCL_START_BOUND,
+        (false, ClusteringBound::Bottom | ClusteringBound::Top) => INCL_END_BOUND,
+    }
+}
+
+/// Total order over [`PartitionItem`]s (rows + bound markers), schema-aware.
+/// Moved VERBATIM out of `sort_partition_items`'s prior inline closure
+/// (issue #1668, stage 5c-iii) so the full-sort and merge paths share ONE
+/// comparator.
+pub(super) fn partition_item_cmp(
+    a: &PartitionItem,
+    b: &PartitionItem,
+    schema: &TableSchema,
+) -> std::cmp::Ordering {
+    let (class_a, ck_a, weight_a, kind_a) = sort_class(a);
+    let (class_b, ck_b, weight_b, kind_b) = sort_class(b);
+    class_a
+        .cmp(&class_b)
+        .then_with(|| match (ck_a, ck_b) {
+            (Some(x), Some(y)) => x.compare(y, schema).unwrap_or_else(|_| x.cmp(y)),
+            _ => std::cmp::Ordering::Equal,
+        })
+        .then(weight_a.cmp(&weight_b))
+        .then(kind_a.cmp(&kind_b))
+}
+
+/// Merge already-sorted `rows` with the (typically few) markers derived from
+/// `range_tombstones`, WITHOUT re-sorting the combined sequence from scratch
+/// (issue #1668, stage 5c-iii).
+///
+/// `rows` MUST already be in clustering order (guaranteed by
+/// `merge_clustering_rows`'s pre-sorted `mutations` input — see stage 5a).
+/// The markers are built from `range_tombstones` and sorted ONCE (cheap: this
+/// list is small), then interleaved with `rows` in a single forward two-way
+/// merge pass. Produces the IDENTICAL sequence `sort_partition_items` (the
+/// full re-sort) computes for the same inputs — proven by this module's
+/// tests.
+///
+/// NOT yet called by any production path: `write_partition_with_index_blocks`
+/// still calls `sort_partition_items` (the full re-sort) — swapping to this
+/// merge is stage 5c-iv's job, once the writer's incremental entry point
+/// exists to actually feed it row-by-row. `#[allow(dead_code)]` until then,
+/// matching the crate's convention for proof-only surface pending wiring
+/// (see `schema_order.rs`'s stage-5b history).
+#[allow(dead_code)]
+pub(super) fn merge_rows_and_markers<'a>(
+    rows: Vec<PartitionItem<'a>>,
+    range_tombstones: &'a [RangeTombstone],
+    schema: &TableSchema,
+) -> Vec<PartitionItem<'a>> {
+    let mut markers: Vec<PartitionItem<'a>> = Vec::with_capacity(range_tombstones.len() * 2);
+    for rt in range_tombstones {
+        markers.push(PartitionItem::Marker {
+            bound: &rt.start,
+            is_open: true,
+            deletion_time: rt.deletion_time,
+            local_deletion_time: rt.local_deletion_time,
+        });
+        markers.push(PartitionItem::Marker {
+            bound: &rt.end,
+            is_open: false,
+            deletion_time: rt.deletion_time,
+            local_deletion_time: rt.local_deletion_time,
+        });
+    }
+    // The marker list is small (typically far fewer than the row count), so
+    // sorting IT (not the combined sequence) stays cheap.
+    markers.sort_by(|a, b| partition_item_cmp(a, b, schema));
+
+    let mut out = Vec::with_capacity(rows.len() + markers.len());
+    let mut rows_iter = rows.into_iter().peekable();
+    let mut markers_iter = markers.into_iter().peekable();
+    loop {
+        match (rows_iter.peek(), markers_iter.peek()) {
+            (Some(r), Some(m)) => {
+                // A Row and a Marker never compare Equal (see the module
+                // doc), so this branch never has to arbitrate a real tie.
+                if partition_item_cmp(r, m, schema) != std::cmp::Ordering::Greater {
+                    // SAFETY-free `unwrap`: `peek()` just proved `Some`.
+                    if let Some(row) = rows_iter.next() {
+                        out.push(row);
+                    }
+                } else if let Some(marker) = markers_iter.next() {
+                    out.push(marker);
+                }
+            }
+            (Some(_), None) => {
+                out.extend(rows_iter.by_ref());
+                break;
+            }
+            (None, Some(_)) => {
+                out.extend(markers_iter.by_ref());
+                break;
+            }
+            (None, None) => break,
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{ClusteringColumn, ClusteringOrder, KeyColumn};
+    use crate::storage::write_engine::mutation::ClusteringKey;
+    use crate::types::Value;
+
+    fn schema_one_clustering(order: ClusteringOrder) -> TableSchema {
+        TableSchema {
+            keyspace: "ks".to_string(),
+            table: "t".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order,
+            }],
+            columns: vec![],
+            comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
+        }
+    }
+
+    fn ck(v: i32) -> ClusteringKey {
+        ClusteringKey::single("ck", Value::Integer(v))
+    }
+
+    fn row_item(v: i32) -> PartitionItem<'static> {
+        // A minimal RowWrite: no ops, no deletion — only clustering_key
+        // matters for the interleave/sort comparison under test.
+        PartitionItem::Row(RowWrite {
+            clustering_key: Some(Box::leak(Box::new(ck(v)))),
+            liveness_ts: Some(0),
+            ttl_seconds: None,
+            row_deletion: None,
+            ops: Vec::new(),
+            complex_element_ops: Vec::new(),
+        })
+    }
+
+    fn row_key(item: &PartitionItem<'_>) -> Option<i32> {
+        match item {
+            PartitionItem::Row(row) => match row.clustering_key.and_then(|k| k.columns.first()) {
+                Some((_, Value::Integer(v))) => Some(*v),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn is_marker(item: &PartitionItem<'_>) -> bool {
+        matches!(item, PartitionItem::Marker { .. })
+    }
+
+    /// THE proof: a partition with range tombstones interleaved with rows —
+    /// the incremental merge must produce the IDENTICAL sequence the full
+    /// re-sort (`sort_partition_items`) computes for the SAME inputs.
+    /// Independently reasoned expected shape (not just old==new): with a
+    /// range tombstone covering `[1, 3]` (inclusive both ends) and rows at
+    /// 0, 1, 2, 3, 4, the OPEN marker must sort strictly before row 1 (the
+    /// inclusive-start weight is -1, ahead of the row's weight 0) and the
+    /// CLOSE marker strictly after row 3 (inclusive-end weight is +1).
+    #[test]
+    fn merge_matches_full_sort_for_range_tombstone_interleaved_with_rows() {
+        let schema = schema_one_clustering(ClusteringOrder::Asc);
+        let rt = RangeTombstone {
+            start: ClusteringBound::Inclusive(ck(1)),
+            end: ClusteringBound::Inclusive(ck(3)),
+            deletion_time: 1000,
+            local_deletion_time: 100,
+        };
+        let range_tombstones = vec![rt];
+
+        // Incremental merge (stage 5c-iii).
+        let merged =
+            merge_rows_and_markers((0..5).map(row_item).collect(), &range_tombstones, &schema);
+
+        // Full re-sort (today's path): rows + 2 markers, then sort_by the
+        // SAME shared comparator.
+        let mut combined: Vec<PartitionItem> = (0..5).map(row_item).collect();
+        for rt in &range_tombstones {
+            combined.push(PartitionItem::Marker {
+                bound: &rt.start,
+                is_open: true,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+            combined.push(PartitionItem::Marker {
+                bound: &rt.end,
+                is_open: false,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+        }
+        combined.sort_by(|a, b| partition_item_cmp(a, b, &schema));
+
+        // Independent expectation: open marker between row 0 and row 1;
+        // close marker between row 3 and row 4.
+        let shape: Vec<(Option<i32>, bool)> =
+            merged.iter().map(|i| (row_key(i), is_marker(i))).collect();
+        assert_eq!(
+            shape,
+            vec![
+                (Some(0), false),
+                (None, true), // open marker, before row 1
+                (Some(1), false),
+                (Some(2), false),
+                (Some(3), false),
+                (None, true), // close marker, after row 3
+                (Some(4), false),
+            ],
+            "merge must place the open marker before row 1 and the close \
+             marker after row 3 (inclusive-both-ends range tombstone)"
+        );
+
+        // Merge output must be IDENTICAL to the full re-sort's output.
+        let merged_shape: Vec<(Option<i32>, bool)> =
+            merged.iter().map(|i| (row_key(i), is_marker(i))).collect();
+        let combined_shape: Vec<(Option<i32>, bool)> = combined
+            .iter()
+            .map(|i| (row_key(i), is_marker(i)))
+            .collect();
+        assert_eq!(
+            merged_shape, combined_shape,
+            "incremental merge must produce the IDENTICAL interleaved \
+             sequence as the full re-sort for the same inputs"
+        );
+    }
+
+    /// A DESC clustering column: proves the merge still agrees with the full
+    /// re-sort when `rows` arrives in DESC order (the schema-aware order,
+    /// per stage 5b/5c-i) rather than ASC.
+    #[test]
+    fn merge_matches_full_sort_for_desc_clustering_with_range_tombstone() {
+        let schema = schema_one_clustering(ClusteringOrder::Desc);
+        // Rows arrive in DESC clustering order: 4, 3, 2, 1, 0.
+        let rt = RangeTombstone {
+            start: ClusteringBound::Exclusive(ck(3)),
+            end: ClusteringBound::Exclusive(ck(1)),
+            deletion_time: 2000,
+            local_deletion_time: 200,
+        };
+        let range_tombstones = vec![rt];
+
+        let merged = merge_rows_and_markers(
+            (0..5).rev().map(row_item).collect(),
+            &range_tombstones,
+            &schema,
+        );
+
+        let mut combined: Vec<PartitionItem> = (0..5).rev().map(row_item).collect();
+        for rt in &range_tombstones {
+            combined.push(PartitionItem::Marker {
+                bound: &rt.start,
+                is_open: true,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+            combined.push(PartitionItem::Marker {
+                bound: &rt.end,
+                is_open: false,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+        }
+        combined.sort_by(|a, b| partition_item_cmp(a, b, &schema));
+
+        let merged_shape: Vec<(Option<i32>, bool)> =
+            merged.iter().map(|i| (row_key(i), is_marker(i))).collect();
+        let combined_shape: Vec<(Option<i32>, bool)> = combined
+            .iter()
+            .map(|i| (row_key(i), is_marker(i)))
+            .collect();
+        assert_eq!(
+            merged_shape, combined_shape,
+            "merge must agree with the full re-sort under DESC clustering too"
+        );
+    }
+
+    /// No range tombstones: the merge degenerates to just the rows,
+    /// unchanged, matching the full re-sort of rows alone.
+    #[test]
+    fn merge_matches_full_sort_with_no_range_tombstones() {
+        let schema = schema_one_clustering(ClusteringOrder::Asc);
+        let merged = merge_rows_and_markers((0..3).map(row_item).collect(), &[], &schema);
+        let merged_keys: Vec<Option<i32>> = merged.iter().map(row_key).collect();
+        assert_eq!(merged_keys, vec![Some(0), Some(1), Some(2)]);
+    }
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -210,6 +210,9 @@ mod collection_order;
 mod complex;
 mod encoding;
 mod index_prefix;
+/// Incremental rows+markers interleave (issue #1668, stage 5c-iii). See
+/// [`marker_merge::merge_rows_and_markers`].
+mod marker_merge;
 mod partition;
 mod rows;
 mod schema_helpers;
@@ -237,6 +240,7 @@ pub use types::PartitionEmitCounts;
 pub(crate) use collection_order::compare_collection_elements;
 pub(crate) use encoding::*;
 pub(crate) use index_prefix::*;
+pub(crate) use partition::PartitionItem;
 pub(crate) use schema_helpers::*;
 pub(crate) use static_ops::StaticOpsTracker;
 pub(crate) use types::*;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -209,6 +209,10 @@ mod cells;
 mod collection_order;
 mod complex;
 mod encoding;
+/// Incremental partition-write entry point (issue #1668, stage 5c-iv, part
+/// 1 — build + prove, not yet wired). See
+/// [`incremental_partition::IncrementalPartitionWriter`].
+mod incremental_partition;
 mod index_prefix;
 /// Incremental rows+markers interleave (issue #1668, stage 5c-iii). See
 /// [`marker_merge::merge_rows_and_markers`].

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -243,6 +243,7 @@ pub use types::PartitionEmitCounts;
 // this `mod.rs` and reach the submodules as ancestor privates.
 pub(crate) use collection_order::compare_collection_elements;
 pub(crate) use encoding::*;
+pub(crate) use incremental_partition::IncrementalPartitionWriter;
 pub(crate) use index_prefix::*;
 pub(crate) use partition::PartitionItem;
 pub(crate) use schema_helpers::*;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -213,6 +213,9 @@ mod index_prefix;
 mod partition;
 mod rows;
 mod schema_helpers;
+/// Incremental static-column last-write-wins tracker (issue #1668, stage
+/// 5c-ii). See [`static_ops::StaticOpsTracker`].
+mod static_ops;
 mod static_rows;
 mod types;
 mod udt_canon;
@@ -235,6 +238,7 @@ pub(crate) use collection_order::compare_collection_elements;
 pub(crate) use encoding::*;
 pub(crate) use index_prefix::*;
 pub(crate) use schema_helpers::*;
+pub(crate) use static_ops::StaticOpsTracker;
 pub(crate) use types::*;
 pub(crate) use udt_canon::{canonicalize_static_value, canonicalize_udt_value};
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -224,6 +224,10 @@ mod schema_helpers;
 /// 5c-ii). See [`static_ops::StaticOpsTracker`].
 mod static_ops;
 mod static_rows;
+/// Cross-call resumable incremental partition-write session (issue #1668,
+/// stage 5c-iv part 3). See
+/// [`streaming_partition::StreamingPartitionSession`].
+mod streaming_partition;
 mod types;
 mod udt_canon;
 
@@ -248,6 +252,7 @@ pub(crate) use index_prefix::*;
 pub(crate) use partition::PartitionItem;
 pub(crate) use schema_helpers::*;
 pub(crate) use static_ops::StaticOpsTracker;
+pub(crate) use streaming_partition::StreamingPartitionSession;
 pub(crate) use types::*;
 pub(crate) use udt_canon::{canonicalize_static_value, canonicalize_udt_value};
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
@@ -16,7 +16,7 @@ use super::*;
 /// the plain [`DataWriter::write_partition`] and the wide-partition
 /// [`DataWriter::write_partition_with_index_blocks`] emitters — they must produce
 /// byte-identical bodies, boundary coalescing included.
-enum PartitionItem<'a> {
+pub(crate) enum PartitionItem<'a> {
     Row(RowWrite<'a>),
     Marker {
         bound: &'a ClusteringBound,
@@ -37,86 +37,14 @@ enum PartitionItem<'a> {
     },
 }
 
-/// The Cassandra `ClusteringPrefix.Kind` ordinal for a range-tombstone BOUND.
-/// Used purely as a sort tiebreak (see [`sort_class`]); the canonical ordering is
-/// the one decoded on the read path (`row_decoder/block_emit.rs`) and the
-/// constants in `data_writer/mod.rs`:
-///   0 EXCL_END_BOUND · 1 INCL_START_BOUND · 6 INCL_END_BOUND · 7 EXCL_START_BOUND.
-fn bound_kind_ordinal(bound: &ClusteringBound, is_open: bool) -> u8 {
-    match (is_open, bound) {
-        (true, ClusteringBound::Inclusive(_)) => INCL_START_BOUND, // 1
-        (false, ClusteringBound::Exclusive(_)) => EXCL_END_BOUND,  // 0
-        (false, ClusteringBound::Inclusive(_)) => INCL_END_BOUND,  // 6
-        (true, ClusteringBound::Exclusive(_)) => EXCL_START_BOUND, // 7
-        // Open-ended bounds are positioned by `class` (Bottom/Top), never reach a
-        // value-level tiebreak; report their side's kind for completeness.
-        (true, ClusteringBound::Bottom | ClusteringBound::Top) => INCL_START_BOUND,
-        (false, ClusteringBound::Bottom | ClusteringBound::Top) => INCL_END_BOUND,
-    }
-}
-
-/// Sort key for clustering-ordered emission: `(position class, clustering values,
-/// bound weight, kind ordinal)`. class: -1 = before all rows (Bottom), 0 =
-/// positioned by clustering values, 1 = after all rows (Top). The weight orders a
-/// marker relative to a row at the SAME clustering value
-/// (`ClusteringPrefix.Kind.comparedToClustering`): an inclusive-start /
-/// exclusive-end bound sorts before the row, an inclusive-end / exclusive-start
-/// bound after it.
-///
-/// The final element is the Cassandra `ClusteringPrefix.Kind` ordinal, used as a
-/// strict tiebreak so that — at an equal clustering point and equal weight — the
-/// CLOSING bound of one range always sorts immediately before the matching OPENING
-/// bound of the next, regardless of the order the `range_tombstones` arrived in
-/// (issue #1220, roborev finding 2). This mirrors Cassandra's comparator, whose
-/// distinct Kind ordinals disambiguate co-located bounds: EXCL_END(0) < INCL_START(1)
-/// for a kind-2 boundary and INCL_END(6) < EXCL_START(7) for a kind-5 boundary —
-/// close before open in both cases. Without it, two co-located bounds carry the same
-/// `weight` and a stable sort would leave them in input order, so a reversed input
-/// vector would emit an open-before-close pair that [`coalesce_boundaries`] cannot
-/// merge (parity loss + a non-Cassandra marker order).
-///
-/// Rows take the CLUSTERING ordinal (4); since a row's `weight` (0) already differs
-/// from every bound's weight (-1/+1) at the same clustering, the ordinal only ever
-/// breaks ties between two bounds. Boundaries are produced only AFTER this sort (by
-/// [`coalesce_boundaries`]), so the `Boundary` arm is never exercised during
-/// sorting; it is provided for exhaustiveness and positions the boundary at its
-/// clustering value.
-fn sort_class<'a, 'b>(item: &'b PartitionItem<'a>) -> (i8, Option<&'b ClusteringKey>, i8, u8) {
-    match item {
-        PartitionItem::Row(row) => (0, row.clustering_key, 0, CLUSTERING),
-        PartitionItem::Marker { bound, is_open, .. } => {
-            let kind = bound_kind_ordinal(bound, *is_open);
-            match bound {
-                ClusteringBound::Inclusive(ck) => {
-                    (0, Some(ck), if *is_open { -1 } else { 1 }, kind)
-                }
-                ClusteringBound::Exclusive(ck) => {
-                    (0, Some(ck), if *is_open { 1 } else { -1 }, kind)
-                }
-                ClusteringBound::Bottom => (-1, None, 0, kind),
-                ClusteringBound::Top => (1, None, 0, kind),
-            }
-        }
-        PartitionItem::Boundary {
-            kind, clustering, ..
-        } => (0, Some(clustering), 0, *kind),
-    }
-}
-
 /// Sort `items` into clustering order (rows + bound markers), schema-aware.
+/// The comparator itself (`marker_merge::partition_item_cmp`) is SHARED with
+/// [`marker_merge::merge_rows_and_markers`] (issue #1668, stage 5c-iii) — the
+/// incremental alternative that merges already-sorted rows with the
+/// (typically few) range-tombstone markers instead of re-sorting the whole
+/// combined sequence from scratch. Both paths must always agree.
 fn sort_partition_items(items: &mut [PartitionItem], schema: &TableSchema) {
-    items.sort_by(|a, b| {
-        let (class_a, ck_a, weight_a, kind_a) = sort_class(a);
-        let (class_b, ck_b, weight_b, kind_b) = sort_class(b);
-        class_a
-            .cmp(&class_b)
-            .then_with(|| match (ck_a, ck_b) {
-                (Some(x), Some(y)) => x.compare(y, schema).unwrap_or_else(|_| x.cmp(y)),
-                _ => std::cmp::Ordering::Equal,
-            })
-            .then(weight_a.cmp(&weight_b))
-            .then(kind_a.cmp(&kind_b))
-    });
+    items.sort_by(|a, b| marker_merge::partition_item_cmp(a, b, schema));
 }
 
 /// The BOUNDARY kind for an adjacent close+open bound pair at the same clustering

--- a/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
@@ -55,7 +55,7 @@ fn sort_partition_items(items: &mut [PartitionItem], schema: &TableSchema) {
 /// with COMPLEMENTARY inclusivity (exactly one of them inclusive) — otherwise the
 /// ranges either overlap (both inclusive) or leave a gap (both exclusive) and stay
 /// separate bounds. Returns the boundary kind ordinal plus the shared clustering.
-fn boundary_kind_for<'a>(
+pub(super) fn boundary_kind_for<'a>(
     close: &'a ClusteringBound,
     open: &'a ClusteringBound,
     schema: &TableSchema,

--- a/cqlite-core/src/storage/sstable/writer/data_writer/static_ops.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/static_ops.rs
@@ -1,0 +1,307 @@
+//! Incremental static-column last-write-wins tracker (issue #1668, stage
+//! 5c-ii).
+//!
+//! `collect_static_operations` (`encoding.rs`) used to scan a whole
+//! `&[Mutation]` slice in one pass, folding each static-column op into a
+//! `best: HashMap<String, StaticMergedOp>` last-write-wins map. That fold is
+//! ALREADY incremental in spirit — nothing about it actually needs the whole
+//! slice materialized upfront, it just happened to be written as a `for`
+//! loop over a slice. This module extracts the SAME per-mutation logic into
+//! [`StaticOpsTracker`]: a running tracker with `feed()` (one `Mutation` at a
+//! time) and `finish()` (the same `Vec<StaticMergedOp>` the whole-slice
+//! version returns), so a FUTURE incremental writer entry point (stage
+//! 5c-iv) can feed it one cluster group at a time instead of requiring a
+//! fully-materialized `Vec<Mutation>` first.
+//!
+//! `collect_static_operations` itself is now a THIN WRAPPER over this
+//! tracker — same signature, same behavior, byte-identical output — so the
+//! CURRENT production call site (`DataWriter::write_partition_with_index_blocks`)
+//! is completely unaffected by this stage; only the internal mechanism
+//! changed shape.
+//!
+//! ## Order-dependence note (why `feed()` order must match today's slice order)
+//!
+//! The last-write-wins tie-break is `>=`, not `>` (see [`StaticOpsTracker::feed`]):
+//! at an EXACT timestamp tie, the LATER-fed candidate wins. This is
+//! observable, not incidental — `collect_static_operations` iterates
+//! `mutations` in whatever order the caller's slice presents them, and
+//! `write_partition` sorts that slice by clustering key before this runs. A
+//! future incremental caller (5c-iv) MUST feed cluster groups in the SAME
+//! order `write_partition`'s sort would have produced for this to remain
+//! byte-identical — not resolved here (this stage only proves the TRACKER
+//! itself reproduces today's whole-slice result when fed in the SAME order).
+
+use super::*;
+
+/// Running last-write-wins tracker for static-column operations (issue
+/// #1668, stage 5c-ii). See the module doc for the order-dependence note.
+#[derive(Default)]
+pub(crate) struct StaticOpsTracker {
+    /// column_name → winning `StaticMergedOp` seen so far.
+    best: std::collections::HashMap<String, StaticMergedOp>,
+}
+
+impl StaticOpsTracker {
+    /// A fresh tracker with no candidates yet.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold one mutation's static-column operations into the running
+    /// last-write-wins map. Mirrors `collect_static_operations`'s per-
+    /// mutation loop body EXACTLY (mutation-level and per-cell shadow-floor
+    /// skips, per-cell writetime resolution, `>=` tie-break).
+    pub(crate) fn feed(
+        &mut self,
+        mutation: &Mutation,
+        schema: &TableSchema,
+        shadow_floor: Option<i64>,
+    ) {
+        if shadow_floor.is_some_and(|floor| mutation.timestamp_micros <= floor) {
+            return;
+        }
+        for op in &mutation.operations {
+            if !is_static_operation(op, schema) {
+                continue;
+            }
+            let col_name = match op {
+                crate::storage::write_engine::mutation::CellOperation::Write { column, .. }
+                | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl {
+                    column,
+                    ..
+                }
+                | crate::storage::write_engine::mutation::CellOperation::Delete {
+                    column, ..
+                } => column.clone(),
+                // Per-element complex ops are not produced for STATIC complex
+                // columns by the current capability — they flow through the
+                // regular-row per-element path. Skip them here defensively,
+                // matching `collect_static_operations`.
+                crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
+                    ..
+                }
+                | crate::storage::write_engine::mutation::CellOperation::ComplexDeletion {
+                    ..
+                } => continue,
+                crate::storage::write_engine::mutation::CellOperation::DeleteRow => continue,
+            };
+            let candidate_ts = op_cell_write_timestamp(op, mutation);
+            if shadow_floor.is_some_and(|floor| candidate_ts <= floor)
+                && matches!(
+                    op,
+                    crate::storage::write_engine::mutation::CellOperation::Write { .. }
+                        | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { .. }
+                        | crate::storage::write_engine::mutation::CellOperation::Delete { .. }
+                )
+            {
+                continue;
+            }
+            let candidate = StaticMergedOp {
+                cell_local_deletion_time: op_cell_local_deletion_time(op, mutation),
+                op: op.clone(),
+                timestamp_micros: candidate_ts,
+                row_ttl_seconds: mutation.ttl_seconds,
+            };
+            match self.best.entry(col_name) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(candidate);
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    if candidate.timestamp_micros >= entry.get().timestamp_micros {
+                        entry.insert(candidate);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Consume the tracker and return the resolved static operations, one
+    /// per distinct static column, in an unspecified order (the writer sorts
+    /// them by schema column order when building the row body) — matches
+    /// `collect_static_operations`'s existing contract exactly.
+    pub(crate) fn finish(self) -> Vec<StaticMergedOp> {
+        self.best.into_values().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{Column, KeyColumn};
+    use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+    use crate::types::Value;
+
+    fn schema_with_static() -> TableSchema {
+        TableSchema {
+            keyspace: "ks".to_string(),
+            table: "t".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "region".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: true,
+                },
+                Column {
+                    name: "quota".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: true,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
+        }
+    }
+
+    fn static_write(column: &str, value: Value, ts: i64) -> Mutation {
+        let table_id = TableId::new("ks", "t");
+        let pk = PartitionKey::single("id", Value::Integer(1));
+        let ops = vec![CellOperation::Write {
+            column: column.to_string(),
+            value,
+        }];
+        Mutation::new(table_id, pk, None, ops, ts, None)
+    }
+
+    fn static_op_text(ops: &[StaticMergedOp], column: &str) -> Option<String> {
+        ops.iter().find_map(|m| match &m.op {
+            CellOperation::Write {
+                column: c,
+                value: Value::Text(s),
+            } if c == column => Some(s.clone()),
+            _ => None,
+        })
+    }
+
+    /// THE proof: feeding mutations ONE AT A TIME via `StaticOpsTracker`
+    /// resolves the SAME winner as `collect_static_operations`'s whole-slice
+    /// scan, for a fixture with a genuine last-write-wins conflict — checked
+    /// against an INDEPENDENTLY reasoned expected winner (the strictly
+    /// highest timestamp), not just old-path-equals-new-path.
+    #[test]
+    fn tracker_matches_whole_slice_for_lww_conflict() {
+        let schema = schema_with_static();
+        let mutations = vec![
+            static_write("region", Value::Text("us-east".to_string()), 100),
+            static_write("region", Value::Text("us-west".to_string()), 300), // wins: highest ts
+            static_write("region", Value::Text("eu-west".to_string()), 200),
+            static_write("quota", Value::Integer(10), 150),
+        ];
+
+        // Whole-slice (today's production path, unchanged).
+        let whole_slice = collect_static_operations(&mutations, &schema, None);
+
+        // Incremental: fed one mutation at a time, in the SAME arrival order.
+        let mut tracker = StaticOpsTracker::new();
+        for m in &mutations {
+            tracker.feed(m, &schema, None);
+        }
+        let incremental = tracker.finish();
+
+        // Independent expectation: "us-west" (ts=300) is strictly the
+        // highest timestamp among the "region" candidates.
+        assert_eq!(
+            static_op_text(&whole_slice, "region"),
+            Some("us-west".to_string()),
+            "whole-slice path must resolve the strictly-highest-timestamp winner"
+        );
+        assert_eq!(
+            static_op_text(&incremental, "region"),
+            Some("us-west".to_string()),
+            "incremental tracker must resolve the SAME strictly-highest-timestamp winner"
+        );
+        assert_eq!(
+            whole_slice.len(),
+            incremental.len(),
+            "both paths must resolve the same NUMBER of distinct static columns"
+        );
+    }
+
+    /// Tie-break proof: at an EXACT timestamp tie, the LATER-fed candidate
+    /// wins (the `>=` comparison) — proven independently by construction
+    /// (the fixture's SECOND write at the tied timestamp is the one that
+    /// must survive), and confirmed identical between the incremental
+    /// tracker and the whole-slice path.
+    #[test]
+    fn tracker_matches_whole_slice_for_exact_timestamp_tie() {
+        let schema = schema_with_static();
+        let mutations = vec![
+            static_write("region", Value::Text("first".to_string()), 500),
+            static_write("region", Value::Text("second".to_string()), 500), // later-fed at the SAME ts: wins
+        ];
+
+        let whole_slice = collect_static_operations(&mutations, &schema, None);
+        let mut tracker = StaticOpsTracker::new();
+        for m in &mutations {
+            tracker.feed(m, &schema, None);
+        }
+        let incremental = tracker.finish();
+
+        assert_eq!(
+            static_op_text(&whole_slice, "region"),
+            Some("second".to_string()),
+            "at an exact timestamp tie, the LATER mutation in arrival order must win"
+        );
+        assert_eq!(
+            static_op_text(&incremental, "region"),
+            Some("second".to_string()),
+            "incremental tracker must resolve the tie identically to the whole-slice path"
+        );
+    }
+
+    /// Shadow-floor proof: a mutation at or before the partition-tombstone
+    /// floor contributes NOTHING, in both paths.
+    #[test]
+    fn tracker_matches_whole_slice_with_shadow_floor() {
+        let schema = schema_with_static();
+        let mutations = vec![
+            static_write("region", Value::Text("shadowed".to_string()), 100), // <= floor
+            static_write("region", Value::Text("survivor".to_string()), 300), // > floor
+        ];
+        let shadow_floor = Some(200i64);
+
+        let whole_slice = collect_static_operations(&mutations, &schema, shadow_floor);
+        let mut tracker = StaticOpsTracker::new();
+        for m in &mutations {
+            tracker.feed(m, &schema, shadow_floor);
+        }
+        let incremental = tracker.finish();
+
+        assert_eq!(
+            static_op_text(&whole_slice, "region"),
+            Some("survivor".to_string())
+        );
+        assert_eq!(
+            static_op_text(&incremental, "region"),
+            Some("survivor".to_string()),
+            "incremental tracker must apply the SAME shadow-floor gate"
+        );
+    }
+
+    /// Empty input: both paths resolve to nothing.
+    #[test]
+    fn tracker_matches_whole_slice_for_empty_input() {
+        let schema = schema_with_static();
+        let whole_slice = collect_static_operations(&[], &schema, None);
+        let tracker = StaticOpsTracker::new();
+        let incremental = tracker.finish();
+        assert!(whole_slice.is_empty());
+        assert!(incremental.is_empty());
+    }
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer/streaming_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/streaming_partition.rs
@@ -1,0 +1,376 @@
+//! Cross-call resumable incremental partition-write session (issue #1668,
+//! stage 5c-iv part 3).
+//!
+//! [`super::incremental_partition::IncrementalPartitionWriter`] (stage 5c-iv
+//! part 1) proves a partition can be streamed one row at a time instead of
+//! buffered as a whole `&[Mutation]` slice — but it BORROWS `&'w mut
+//! DataWriter` and the caller's `&'r [RangeTombstone]` for its whole
+//! lifetime, so it cannot survive returning to a caller that must give
+//! control back to an outer scheduler mid-partition (`WriteEngine::
+//! maintenance_step`'s budget-driven pause/resume, issue #1668 stage 4) and
+//! reconstitute it later — the borrow, and the unfinished on-disk partition
+//! (no `END_OF_PARTITION`/index registration yet), cannot outlive that
+//! function call.
+//!
+//! [`StreamingPartitionSession`] is a NEW, parallel type (the existing
+//! borrow-based session is UNTOUCHED — `KWayMerger::merge` keeps using it
+//! exactly as stage 5c-iv part 2 left it) that eliminates every lifetime
+//! parameter with one change: `writer: &mut DataWriter` moves from a STORED
+//! field to a PER-CALL PARAMETER on `feed_row`/`feed_static_row`/`finish`,
+//! borrowed fresh from `SSTableWriter.data_writer` for just that one call.
+//! `range_tombstones`/`sorted_markers`' bounds are cloned into owned storage
+//! instead of borrowed (deliberately: both are documented as "typically
+//! few" per partition — the same bounded-cost class as the static-row/
+//! carrier prefix, not something that scales with partition width). The
+//! result has no lifetime at all, so it can sit as a plain field on
+//! `ActiveMerge` across `maintenance_step_inner` calls: pausing is just "stop
+//! calling methods on it," resuming is just "keep calling methods on it" —
+//! no capture/reconstitute conversion step is needed.
+//!
+//! The emission logic itself (marker draining, promoted-index-block
+//! tracking) is intentionally a parallel copy of
+//! [`super::incremental_partition`]'s, not a shared abstraction over both —
+//! unifying them would require also changing the already-tested borrow-based
+//! session's signature, which risks the behavior stage 5c-iv parts 1/2
+//! already proved. Kept as an explicit, flagged duplication rather than
+//! reworking tested code.
+
+use super::*;
+
+/// Owned range-tombstone bound marker — same shape as
+/// [`super::incremental_partition`]'s private `SortableMarker`, but OWNS a
+/// clone of the [`ClusteringBound`] instead of borrowing it, so the whole
+/// session (including its markers) is lifetime-free.
+#[derive(Clone)]
+struct OwnedSortableMarker {
+    bound: ClusteringBound,
+    is_open: bool,
+    deletion_time: i64,
+    local_deletion_time: i32,
+}
+
+impl OwnedSortableMarker {
+    fn as_partition_item(&self) -> PartitionItem<'_> {
+        PartitionItem::Marker {
+            bound: &self.bound,
+            is_open: self.is_open,
+            deletion_time: self.deletion_time,
+            local_deletion_time: self.local_deletion_time,
+        }
+    }
+}
+
+/// Cross-call resumable incremental partition-write session (issue #1668,
+/// stage 5c-iv part 3). See the module doc for why this exists alongside
+/// [`super::incremental_partition::IncrementalPartitionWriter`] rather than
+/// replacing it.
+pub(crate) struct StreamingPartitionSession {
+    partition_offset: u64,
+    partition_buf_start: usize,
+    prev_unfiltered_size: u64,
+    partition_floor: Option<i64>,
+    range_tombstones: Vec<RangeTombstone>,
+    sorted_markers: Vec<OwnedSortableMarker>,
+    marker_cursor: usize,
+    emit: PartitionEmitCounts,
+    block_start_buf_offset: Option<usize>,
+    blocks: Vec<PromotedIndexBlock>,
+    current_block_first_ck: Option<Vec<u8>>,
+    current_block_last_ck: Option<Vec<u8>>,
+    current_block_oss50: Option<Option<Vec<u8>>>,
+}
+
+impl DataWriter {
+    /// Begin a cross-call resumable incremental partition write (issue
+    /// #1668, stage 5c-iv part 3). Same upfront work as
+    /// [`Self::begin_partition_incremental`] (writes the header immediately,
+    /// pre-sorts the range-tombstone markers once) but clones
+    /// `range_tombstones` and every marker's bound into owned storage so the
+    /// returned session carries no borrow of `self` or of the caller's slice.
+    pub(crate) fn begin_streaming_partition(
+        &mut self,
+        key: &DecoratedKey,
+        partition_tombstone: Option<&PartitionTombstone>,
+        range_tombstones: &[RangeTombstone],
+        schema: &TableSchema,
+    ) -> Result<StreamingPartitionSession> {
+        let partition_offset = self.position + self.buffer.len() as u64;
+        let partition_buf_start = self.buffer.len();
+        let header_start = self.buffer.len();
+        self.write_partition_header(key, partition_tombstone)?;
+        let prev_unfiltered_size = (self.buffer.len() - header_start) as u64;
+        let partition_floor = partition_tombstone.map(|pt| pt.deletion_time);
+
+        let mut sorted_markers: Vec<OwnedSortableMarker> =
+            Vec::with_capacity(range_tombstones.len() * 2);
+        for rt in range_tombstones {
+            sorted_markers.push(OwnedSortableMarker {
+                bound: rt.start.clone(),
+                is_open: true,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+            sorted_markers.push(OwnedSortableMarker {
+                bound: rt.end.clone(),
+                is_open: false,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+        }
+        sorted_markers.sort_by(|a, b| {
+            marker_merge::partition_item_cmp(&a.as_partition_item(), &b.as_partition_item(), schema)
+        });
+
+        Ok(StreamingPartitionSession {
+            partition_offset,
+            partition_buf_start,
+            prev_unfiltered_size,
+            partition_floor,
+            range_tombstones: range_tombstones.to_vec(),
+            sorted_markers,
+            marker_cursor: 0,
+            emit: PartitionEmitCounts::default(),
+            block_start_buf_offset: None,
+            blocks: Vec::new(),
+            current_block_first_ck: None,
+            current_block_last_ck: None,
+            current_block_oss50: None,
+        })
+    }
+}
+
+impl StreamingPartitionSession {
+    /// Write the static-row prelude — see
+    /// [`super::incremental_partition::IncrementalPartitionWriter::feed_static_row`]
+    /// for the full contract (identical here, minus the borrowed `writer`
+    /// field becoming a per-call parameter).
+    pub(crate) fn feed_static_row(
+        &mut self,
+        writer: &mut DataWriter,
+        merged: &[StaticMergedOp],
+        first_mutation_ts: i64,
+        schema: &TableSchema,
+    ) -> Result<()> {
+        if merged.is_empty() {
+            let static_size = writer.write_empty_static_row(0, schema)? as u64;
+            self.prev_unfiltered_size += static_size;
+        } else {
+            let (latest_ts, ttl) =
+                static_liveness_from_ops(merged).unwrap_or((first_mutation_ts, None));
+            let (static_size, static_cells) =
+                writer.write_static_row_with_prev_size(merged, latest_ts, ttl, schema, 0)?;
+            self.prev_unfiltered_size += static_size as u64;
+            self.emit.rows += 1;
+            self.emit.columns += static_cells;
+        }
+        Ok(())
+    }
+
+    /// Feed one clustering-key group's mutation — see
+    /// [`super::incremental_partition::IncrementalPartitionWriter::feed_row`]
+    /// for the full contract (identical here, minus the borrowed `writer`
+    /// field becoming a per-call parameter).
+    pub(crate) fn feed_row(
+        &mut self,
+        writer: &mut DataWriter,
+        mutation: &Mutation,
+        schema: &TableSchema,
+    ) -> Result<()> {
+        let clustering_key = mutation.clustering_key.as_ref();
+        let mut shadow_floor = self.partition_floor;
+        for rt in &self.range_tombstones {
+            if range_tombstone_covers(rt, clustering_key, schema) {
+                shadow_floor =
+                    Some(shadow_floor.map_or(rt.deletion_time, |f| f.max(rt.deletion_time)));
+            }
+        }
+
+        let row_item = PartitionItem::Row(RowWrite {
+            clustering_key,
+            liveness_ts: None,
+            ttl_seconds: None,
+            row_deletion: None,
+            ops: Vec::new(),
+            complex_element_ops: Vec::new(),
+        });
+        while let Some(marker) = self.sorted_markers.get(self.marker_cursor).cloned() {
+            if marker_merge::partition_item_cmp(&marker.as_partition_item(), &row_item, schema)
+                == std::cmp::Ordering::Greater
+            {
+                break;
+            }
+            self.marker_cursor += 1;
+            self.emit_item(writer, marker.as_partition_item(), schema)?;
+        }
+
+        if let Some(row) = DataWriter::merge_row_group(&[mutation], schema, false, shadow_floor) {
+            self.emit_item(writer, PartitionItem::Row(row), schema)?;
+        }
+        Ok(())
+    }
+
+    /// Finalize the partition — see
+    /// [`super::incremental_partition::IncrementalPartitionWriter::finish`]
+    /// for the full contract (identical here, minus the borrowed `writer`
+    /// field becoming a per-call parameter; `self` is consumed either way).
+    pub(crate) fn finish(
+        mut self,
+        writer: &mut DataWriter,
+        schema: &TableSchema,
+    ) -> Result<(u64, Vec<PromotedIndexBlock>, PartitionEmitCounts)> {
+        while self.marker_cursor < self.sorted_markers.len() {
+            let marker = self.sorted_markers[self.marker_cursor].clone();
+            self.marker_cursor += 1;
+            self.emit_item(writer, marker.as_partition_item(), schema)?;
+        }
+
+        writer.buffer.push(END_OF_PARTITION);
+
+        if let (Some(first), Some(last)) = (
+            self.current_block_first_ck.take(),
+            self.current_block_last_ck.take(),
+        ) {
+            let current_buf_offset = writer.buffer.len() - self.partition_buf_start;
+            let block_start = self.block_start_buf_offset.unwrap_or(current_buf_offset);
+            let block_bytes = (current_buf_offset - block_start) as u64;
+            if block_bytes > 0 {
+                self.blocks.push(PromotedIndexBlock {
+                    first_name: first,
+                    last_name: last,
+                    offset: block_start as u64,
+                    width: block_bytes,
+                    oss50_separator: self.current_block_oss50.take().flatten(),
+                });
+            }
+        }
+
+        writer.flush_partition()?;
+        Ok((self.partition_offset, self.blocks, self.emit))
+    }
+
+    /// Write one item (row or marker) and update promoted-index-block
+    /// tracking — moved VERBATIM from
+    /// [`super::incremental_partition::IncrementalPartitionWriter::emit_item`]
+    /// (itself moved verbatim from `write_partition_with_index_blocks`),
+    /// minus the borrowed `writer` field becoming a per-call parameter.
+    fn emit_item<'a>(
+        &mut self,
+        writer: &mut DataWriter,
+        item: PartitionItem<'a>,
+        schema: &TableSchema,
+    ) -> Result<()> {
+        let ck_bytes: Vec<u8> = match &item {
+            PartitionItem::Row(row) => {
+                if let Some(ck) = row.clustering_key {
+                    serialize_clustering_prefix_for_index(ck, schema)
+                        .unwrap_or_else(|_| empty_clustering_prefix_for_index())
+                } else {
+                    empty_clustering_prefix_for_index()
+                }
+            }
+            PartitionItem::Marker { bound, is_open, .. } => {
+                serialize_marker_bound_prefix_for_index(bound, *is_open, schema)
+                    .unwrap_or_else(|_| marker_bound_prefix_for_index(bound, *is_open))
+            }
+            PartitionItem::Boundary {
+                kind, clustering, ..
+            } => serialize_boundary_prefix_for_index(*kind, clustering, schema)
+                .unwrap_or_else(|_| boundary_prefix_for_index_fallback(*kind)),
+        };
+
+        let partition_buf_start = self.partition_buf_start;
+        if self.current_block_first_ck.is_none() {
+            self.current_block_first_ck = Some(ck_bytes.clone());
+            let ck_values: Option<Vec<Value>> = match &item {
+                PartitionItem::Row(row) => row
+                    .clustering_key
+                    .filter(|ck| !ck.columns.is_empty())
+                    .map(|ck| ck.columns.iter().map(|(_, v)| v.clone()).collect()),
+                PartitionItem::Marker { .. } | PartitionItem::Boundary { .. } => None,
+            };
+            let is_reversed: Vec<bool> = schema
+                .clustering_keys
+                .iter()
+                .map(|c| c.order == crate::schema::ClusteringOrder::Desc)
+                .collect();
+            self.current_block_oss50 = Some(ck_values.and_then(|vals| {
+                crate::storage::sstable::bti::encode_clustering_bound_oss50_with_order(
+                    &vals,
+                    &is_reversed,
+                )
+                .ok()
+            }));
+            self.block_start_buf_offset
+                .get_or_insert(writer.buffer.len() - partition_buf_start);
+        }
+        self.current_block_last_ck = Some(ck_bytes.clone());
+
+        self.prev_unfiltered_size = match item {
+            PartitionItem::Row(row) => {
+                self.emit.rows += 1;
+                let (bytes, cells) = writer.write_merged_row_with_prev_size(
+                    &row,
+                    schema,
+                    self.prev_unfiltered_size,
+                )?;
+                self.emit.columns += cells;
+                bytes as u64
+            }
+            PartitionItem::Marker {
+                bound,
+                is_open,
+                deletion_time,
+                local_deletion_time,
+            } => writer.write_range_bound(
+                bound,
+                is_open,
+                deletion_time,
+                local_deletion_time,
+                schema,
+                self.prev_unfiltered_size,
+            )? as u64,
+            PartitionItem::Boundary {
+                kind,
+                clustering,
+                end_deletion_time,
+                end_local_deletion_time,
+                start_deletion_time,
+                start_local_deletion_time,
+            } => writer.write_range_boundary(
+                kind,
+                clustering,
+                end_deletion_time,
+                end_local_deletion_time,
+                start_deletion_time,
+                start_local_deletion_time,
+                schema,
+                self.prev_unfiltered_size,
+            )? as u64,
+        };
+
+        let current_buf_offset = writer.buffer.len() - partition_buf_start;
+        let block_start = self.block_start_buf_offset.unwrap_or(current_buf_offset);
+        let block_bytes = (current_buf_offset - block_start) as u64;
+
+        if block_bytes >= COLUMN_INDEX_SIZE_BYTES {
+            self.blocks.push(PromotedIndexBlock {
+                first_name: self
+                    .current_block_first_ck
+                    .take()
+                    .unwrap_or_else(empty_clustering_prefix_for_index),
+                last_name: self
+                    .current_block_last_ck
+                    .take()
+                    .unwrap_or_else(empty_clustering_prefix_for_index),
+                offset: block_start as u64,
+                width: block_bytes,
+                oss50_separator: self.current_block_oss50.take().flatten(),
+            });
+            self.block_start_buf_offset = Some(current_buf_offset);
+            self.current_block_first_ck = None;
+            self.current_block_last_ck = None;
+            self.current_block_oss50 = None;
+        }
+        Ok(())
+    }
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer/streaming_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/streaming_partition.rs
@@ -199,8 +199,7 @@ impl StreamingPartitionSession {
             {
                 break;
             }
-            self.marker_cursor += 1;
-            self.emit_item(writer, marker.as_partition_item(), schema)?;
+            self.emit_next_marker_or_boundary(writer, marker, schema)?;
         }
 
         if let Some(row) = DataWriter::merge_row_group(&[mutation], schema, false, shadow_floor) {
@@ -220,8 +219,7 @@ impl StreamingPartitionSession {
     ) -> Result<(u64, Vec<PromotedIndexBlock>, PartitionEmitCounts)> {
         while self.marker_cursor < self.sorted_markers.len() {
             let marker = self.sorted_markers[self.marker_cursor].clone();
-            self.marker_cursor += 1;
-            self.emit_item(writer, marker.as_partition_item(), schema)?;
+            self.emit_next_marker_or_boundary(writer, marker, schema)?;
         }
 
         writer.buffer.push(END_OF_PARTITION);
@@ -246,6 +244,46 @@ impl StreamingPartitionSession {
 
         writer.flush_partition()?;
         Ok((self.partition_offset, self.blocks, self.emit))
+    }
+
+    /// Emit `marker` (the item at `self.marker_cursor`), coalescing it with
+    /// its immediately-following pair into a single `PartitionItem::Boundary`
+    /// when they form one — see
+    /// [`super::incremental_partition::IncrementalPartitionWriter::emit_next_marker_or_boundary`]
+    /// for the full contract (identical here, minus the borrowed `writer`
+    /// field becoming a per-call parameter and `OwnedSortableMarker` needing
+    /// `.clone()` instead of `Copy`).
+    fn emit_next_marker_or_boundary(
+        &mut self,
+        writer: &mut DataWriter,
+        marker: OwnedSortableMarker,
+        schema: &TableSchema,
+    ) -> Result<()> {
+        if !marker.is_open {
+            if let Some(next) = self.sorted_markers.get(self.marker_cursor + 1).cloned() {
+                if next.is_open {
+                    if let Some((kind, clustering)) =
+                        partition::boundary_kind_for(&marker.bound, &next.bound, schema)
+                    {
+                        self.marker_cursor += 2;
+                        return self.emit_item(
+                            writer,
+                            PartitionItem::Boundary {
+                                kind,
+                                clustering,
+                                end_deletion_time: marker.deletion_time,
+                                end_local_deletion_time: marker.local_deletion_time,
+                                start_deletion_time: next.deletion_time,
+                                start_local_deletion_time: next.local_deletion_time,
+                            },
+                            schema,
+                        );
+                    }
+                }
+            }
+        }
+        self.marker_cursor += 1;
+        self.emit_item(writer, marker.as_partition_item(), schema)
     }
 
     /// Write one item (row or marker) and update promoted-index-block

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/incremental_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/incremental_partition.rs
@@ -392,10 +392,7 @@ fn incremental_matches_whole_slice_for_adjacent_range_tombstones_forming_a_bound
     assert_eq!(old_offset, new_offset);
     assert!(blocks_eq(&old_blocks, &new_blocks));
     assert_eq!(old_emit, new_emit);
-    assert_eq!(
-        old_emit.rows, 1,
-        "only ck=7 survives both tombstone ranges"
-    );
+    assert_eq!(old_emit.rows, 1, "only ck=7 survives both tombstone ranges");
 }
 
 /// Combined fixture: static row + range tombstone + partition tombstone +

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/incremental_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/incremental_partition.rs
@@ -1,0 +1,400 @@
+//! Correctness proof for `IncrementalPartitionWriter` (issue #1668, stage
+//! 5c-iv, part 1): fed the SAME logical partition ONE PIECE AT A TIME
+//! (static row, then one clustering row at a time, with incremental marker
+//! interleaving), it must produce BYTE-IDENTICAL Data.db output — including
+//! the returned promoted-index blocks and emit counts — to today's
+//! whole-slice `DataWriter::write_partition_with_index_blocks`.
+//!
+//! NOT yet wired to any production caller — these tests exercise the new
+//! entry point directly, in isolation, matching the "prove before wiring"
+//! precedent of every prior sub-stage (stage 2's `StreamingMerger`, stage
+//! 5b's `schema_ordered_pop_all`, stage 5c-i's schema-aware heap).
+
+use super::super::*;
+use super::support::*;
+use crate::storage::write_engine::mutation::{
+    CellOperation, ClusteringBound, ClusteringKey, PartitionKey, PartitionTombstone,
+    RangeTombstone, TableId,
+};
+use crate::types::Value;
+
+fn key(token: i64, bytes: Vec<u8>) -> DecoratedKey {
+    DecoratedKey::new(token, bytes)
+}
+
+fn row_mutation(schema: &TableSchema, ck: i32, value: &str, ts: i64) -> Mutation {
+    let table_id = TableId::new(&schema.keyspace, &schema.table);
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ck_key = ClusteringKey::single("ck", Value::Integer(ck));
+    let column = if schema.columns.iter().any(|c| c.name == "regular_val") {
+        "regular_val"
+    } else {
+        "v"
+    };
+    let ops = vec![CellOperation::Write {
+        column: column.to_string(),
+        value: Value::Text(value.to_string()),
+    }];
+    Mutation::new(table_id, pk, Some(ck_key), ops, ts, None)
+}
+
+fn static_mutation(schema: &TableSchema, value: &str, ts: i64) -> Mutation {
+    let table_id = TableId::new(&schema.keyspace, &schema.table);
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ops = vec![CellOperation::Write {
+        column: "static_val".to_string(),
+        value: Value::Text(value.to_string()),
+    }];
+    Mutation::new(table_id, pk, None, ops, ts, None)
+}
+
+/// Resolve the static ops for `mutations` via the incremental tracker
+/// (stage 5c-ii) — the SAME resolution `collect_static_operations` performs
+/// internally for the whole-slice path, exposed here so the incremental
+/// entry point's caller can supply an ALREADY-RESOLVED set (matching how a
+/// real streaming caller would use it, per the stage-5c-iv design note that
+/// compaction's static carrier is always a single, already-reconciled entry).
+fn resolve_static_ops(
+    mutations: &[Mutation],
+    schema: &TableSchema,
+    shadow_floor: Option<i64>,
+) -> Vec<StaticMergedOp> {
+    let mut tracker = StaticOpsTracker::new();
+    for m in mutations {
+        tracker.feed(m, schema, shadow_floor);
+    }
+    tracker.finish()
+}
+
+fn blocks_eq(a: &[PromotedIndexBlock], b: &[PromotedIndexBlock]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b.iter()).all(|(x, y)| {
+            x.first_name == y.first_name
+                && x.last_name == y.last_name
+                && x.offset == y.offset
+                && x.width == y.width
+                && x.oss50_separator == y.oss50_separator
+        })
+}
+
+/// Drive the OLD whole-slice path and return `(buffer_bytes, offset, blocks,
+/// emit)` for comparison.
+fn run_whole_slice(
+    schema: &TableSchema,
+    key: &DecoratedKey,
+    mutations: &[Mutation],
+    partition_tombstone: Option<&PartitionTombstone>,
+    range_tombstones: &[RangeTombstone],
+) -> (Vec<u8>, u64, Vec<PromotedIndexBlock>, PartitionEmitCounts) {
+    let mut writer = DataWriter::new(create_test_stats());
+    let (offset, blocks, emit) = writer
+        .write_partition_with_index_blocks(
+            key,
+            mutations,
+            schema,
+            partition_tombstone,
+            range_tombstones,
+        )
+        .expect("whole-slice write must succeed");
+    (writer_buffer(&writer), offset, blocks, emit)
+}
+
+/// Drive the NEW incremental path (static row resolved upfront via
+/// `StaticOpsTracker`, then one `feed_row` per clustering mutation) and
+/// return the SAME shape for comparison.
+fn run_incremental(
+    schema: &TableSchema,
+    key: &DecoratedKey,
+    clustering_mutations: &[Mutation],
+    static_ops: &[StaticMergedOp],
+    first_mutation_ts: i64,
+    partition_tombstone: Option<&PartitionTombstone>,
+    range_tombstones: &[RangeTombstone],
+) -> (Vec<u8>, u64, Vec<PromotedIndexBlock>, PartitionEmitCounts) {
+    let mut writer = DataWriter::new(create_test_stats());
+    let schema_has_static = schema.columns.iter().any(|c| c.is_static);
+    let mut session = writer
+        .begin_partition_incremental(key, partition_tombstone, range_tombstones, schema)
+        .expect("begin_partition_incremental must succeed");
+    if schema_has_static {
+        session
+            .feed_static_row(static_ops, first_mutation_ts, schema)
+            .expect("feed_static_row must succeed");
+    }
+    for m in clustering_mutations {
+        session.feed_row(m, schema).expect("feed_row must succeed");
+    }
+    let (offset, blocks, emit) = session.finish(schema).expect("finish must succeed");
+    (writer_buffer(&writer), offset, blocks, emit)
+}
+
+/// Read back the writer's in-memory buffer (private field, but this test
+/// module is a descendant of `data_writer` so field access is allowed).
+fn writer_buffer(writer: &DataWriter) -> Vec<u8> {
+    writer.buffer.clone()
+}
+
+#[test]
+fn incremental_matches_whole_slice_for_plain_rows() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let mutations: Vec<Mutation> = (0..5)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 1000 + ck as i64))
+        .collect();
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &[]);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_incremental(&schema, &key, &mutations, &[], 0, None, &[]);
+
+    assert_eq!(old_bytes, new_bytes, "Data.db bytes must be identical");
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+}
+
+#[test]
+fn incremental_matches_whole_slice_for_static_and_regular_rows() {
+    let schema = create_static_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let static_m = static_mutation(&schema, "us-east", 500);
+    let clustering: Vec<Mutation> = (0..4)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 1000 + ck as i64))
+        .collect();
+
+    // Whole-slice path sees ALL mutations (static + clustering) together.
+    let mut all_mutations = vec![static_m.clone()];
+    all_mutations.extend(clustering.iter().cloned());
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &all_mutations, None, &[]);
+
+    // Incremental path resolves statics upfront (matching compaction's own
+    // guarantee that the static carrier is a single, already-reconciled
+    // entry — stage 5c-iv's design note).
+    let static_ops = resolve_static_ops(&[static_m.clone()], &schema, None);
+    let (new_bytes, new_offset, new_blocks, new_emit) = run_incremental(
+        &schema,
+        &key,
+        &clustering,
+        &static_ops,
+        static_m.timestamp_micros,
+        None,
+        &[],
+    );
+
+    assert_eq!(old_bytes, new_bytes, "Data.db bytes must be identical");
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+}
+
+#[test]
+fn incremental_matches_whole_slice_for_schema_has_static_but_partition_writes_none() {
+    let schema = create_static_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let clustering: Vec<Mutation> = (0..3)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 1000 + ck as i64))
+        .collect();
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &clustering, None, &[]);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_incremental(&schema, &key, &clustering, &[], 0, None, &[]);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "the minimal empty static-row prelude must be byte-identical"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+}
+
+#[test]
+fn incremental_matches_whole_slice_for_range_tombstone_interleaved_with_rows() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let mutations: Vec<Mutation> = (0..5)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 1000 + ck as i64))
+        .collect();
+    let rt = RangeTombstone {
+        start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(1))),
+        end: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(3))),
+        deletion_time: 900, // older than the covered rows' writetimes: rows survive
+        local_deletion_time: 90,
+    };
+    let range_tombstones = vec![rt];
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &range_tombstones);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_incremental(&schema, &key, &mutations, &[], 0, None, &range_tombstones);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "Data.db bytes must be identical with a range tombstone interleaved"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+}
+
+#[test]
+fn incremental_matches_whole_slice_for_range_tombstone_shadowing_a_row() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    // ck=1's write is OLDER than the covering range tombstone: shadowed,
+    // contributes nothing in EITHER path.
+    let mutations = vec![
+        row_mutation(&schema, 0, "row-0", 1000),
+        row_mutation(&schema, 1, "row-1-shadowed", 100),
+        row_mutation(&schema, 2, "row-2", 1000),
+    ];
+    let rt = RangeTombstone {
+        start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(1))),
+        end: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(1))),
+        deletion_time: 500,
+        local_deletion_time: 50,
+    };
+    let range_tombstones = vec![rt];
+
+    let (old_bytes, _, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &range_tombstones);
+    let (new_bytes, _, new_blocks, new_emit) =
+        run_incremental(&schema, &key, &mutations, &[], 0, None, &range_tombstones);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "the shadowed row must be dropped identically in both paths"
+    );
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+    assert_eq!(
+        old_emit.rows, 2,
+        "only the 2 surviving rows must be counted"
+    );
+}
+
+#[test]
+fn incremental_matches_whole_slice_for_partition_tombstone() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    // ck=0 predates the partition tombstone (shadowed); ck=1 postdates it
+    // (survives).
+    let mutations = vec![
+        row_mutation(&schema, 0, "row-0-shadowed", 100),
+        row_mutation(&schema, 1, "row-1-survives", 2000),
+    ];
+    let pt = PartitionTombstone {
+        deletion_time: 1000,
+        local_deletion_time: 100,
+    };
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, Some(&pt), &[]);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_incremental(&schema, &key, &mutations, &[], 0, Some(&pt), &[]);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "the partition-tombstone header and shadowing must be byte-identical"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+    assert_eq!(old_emit.rows, 1, "only the surviving row must be counted");
+}
+
+/// A wide partition (large cell values across many rows) crossing the 64
+/// KiB promoted-index block boundary at least once — proves the incremental
+/// path's block tracking (moved verbatim from the whole-slice loop) agrees
+/// with the whole-slice path's block boundaries exactly, not just the raw
+/// bytes.
+#[test]
+fn incremental_matches_whole_slice_for_wide_partition_with_promoted_index_blocks() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let big_value = "x".repeat(4000);
+    let mutations: Vec<Mutation> = (0..25)
+        .map(|ck| row_mutation(&schema, ck, &big_value, 1000 + ck as i64))
+        .collect();
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &[]);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_incremental(&schema, &key, &mutations, &[], 0, None, &[]);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "wide-partition Data.db bytes must be identical"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(
+        old_blocks.len() >= 2,
+        "fixture must actually cross the 64 KiB promoted-index boundary \
+         (got {} blocks) — otherwise this test doesn't exercise block \
+         tracking at all",
+        old_blocks.len()
+    );
+    assert!(
+        blocks_eq(&old_blocks, &new_blocks),
+        "promoted-index block boundaries must match exactly: old={old_blocks:?} new={new_blocks:?}"
+    );
+    assert_eq!(old_emit, new_emit);
+}
+
+/// Combined fixture: static row + range tombstone + partition tombstone +
+/// several regular rows, some shadowed — the full feature combination.
+#[test]
+fn incremental_matches_whole_slice_for_combined_static_tombstones_and_rows() {
+    let schema = create_static_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let static_m = static_mutation(&schema, "eu-west", 5000);
+    let pt = PartitionTombstone {
+        deletion_time: 1000,
+        local_deletion_time: 100,
+    };
+    let clustering = vec![
+        row_mutation(&schema, 0, "row-0-shadowed-by-partition", 500),
+        row_mutation(&schema, 1, "row-1-survives", 2000),
+        row_mutation(&schema, 2, "row-2-survives", 3000),
+        row_mutation(&schema, 3, "row-3-shadowed-by-range", 2100),
+    ];
+    let rt = RangeTombstone {
+        start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(3))),
+        end: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(3))),
+        deletion_time: 2500,
+        local_deletion_time: 250,
+    };
+    let range_tombstones = vec![rt];
+
+    let mut all_mutations = vec![static_m.clone()];
+    all_mutations.extend(clustering.iter().cloned());
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &all_mutations, Some(&pt), &range_tombstones);
+
+    let static_ops = resolve_static_ops(&[static_m.clone()], &schema, Some(pt.deletion_time));
+    let (new_bytes, new_offset, new_blocks, new_emit) = run_incremental(
+        &schema,
+        &key,
+        &clustering,
+        &static_ops,
+        static_m.timestamp_micros,
+        Some(&pt),
+        &range_tombstones,
+    );
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "combined static+range+partition-tombstone fixture must be byte-identical"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+    assert_eq!(
+        old_emit.rows, 3,
+        "1 static row + ck=1 and ck=2 (the only clustering rows surviving \
+         both the partition and range tombstones) — emit.rows counts the \
+         static row too"
+    );
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/incremental_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/incremental_partition.rs
@@ -343,6 +343,61 @@ fn incremental_matches_whole_slice_for_wide_partition_with_promoted_index_blocks
     assert_eq!(old_emit, new_emit);
 }
 
+/// Roborev blocker #1 (issue #1668): two ADJACENT range tombstones —
+/// `[0, 3)` (deletion_time 500) then `[3, 6]` (deletion_time 800, a
+/// DIFFERENT deletion time so `coalesce_range_tombstones` upstream in the
+/// merge layer would never fold them into one range first) — whose close
+/// bound (`Exclusive(3)`) and the next range's open bound (`Inclusive(3)`)
+/// meet at the SAME clustering value with complementary inclusivity. The
+/// whole-slice path (`write_partition_with_index_blocks`) always runs
+/// `coalesce_boundaries` and persists this as ONE `PartitionItem::Boundary`
+/// (Cassandra's own on-disk `RangeTombstoneBoundaryMarker` shape); before
+/// this fix, `IncrementalPartitionWriter` drained its pre-sorted marker list
+/// one at a time and never coalesced, persisting two separate bound markers
+/// instead — a byte-format parity regression this test pins.
+#[test]
+fn incremental_matches_whole_slice_for_adjacent_range_tombstones_forming_a_boundary() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    // Every row predates BOTH tombstones except ck=7, which sits outside
+    // both ranges and must survive in both paths.
+    let mutations: Vec<Mutation> = (0..8)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 100))
+        .collect();
+    let range_tombstones = vec![
+        RangeTombstone {
+            start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(0))),
+            end: ClusteringBound::Exclusive(ClusteringKey::single("ck", Value::Integer(3))),
+            deletion_time: 500,
+            local_deletion_time: 50,
+        },
+        RangeTombstone {
+            start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(3))),
+            end: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(6))),
+            deletion_time: 800,
+            local_deletion_time: 80,
+        },
+    ];
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &range_tombstones);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_incremental(&schema, &key, &mutations, &[], 0, None, &range_tombstones);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "adjacent range tombstones must coalesce into an IDENTICAL single \
+         boundary marker in both the whole-slice and incremental paths"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+    assert_eq!(
+        old_emit.rows, 1,
+        "only ck=7 survives both tombstone ranges"
+    );
+}
+
 /// Combined fixture: static row + range tombstone + partition tombstone +
 /// several regular rows, some shadowed — the full feature combination.
 #[test]

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/mod.rs
@@ -2,6 +2,9 @@
 //! Shared fixtures live in `support`; tests are grouped by file.
 
 mod collection_order_serialize;
+/// Correctness proof for `IncrementalPartitionWriter` (issue #1668, stage
+/// 5c-iv part 1) against today's whole-slice `write_partition_with_index_blocks`.
+mod incremental_partition;
 mod scenarios_1;
 mod scenarios_2;
 mod scenarios_3;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/mod.rs
@@ -11,4 +11,9 @@ mod scenarios_3;
 mod scenarios_4;
 mod scenarios_5;
 mod scenarios_6;
+/// Correctness proof for `StreamingPartitionSession` (issue #1668, stage
+/// 5c-iv part 3): cross-call resumable — a partition fed in TWO separate
+/// batches (simulating a budget pause between them) must byte-match one fed
+/// straight through, and both must byte-match the whole-slice path.
+mod streaming_partition;
 mod support;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/streaming_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/streaming_partition.rs
@@ -1,0 +1,448 @@
+//! Correctness proof for `StreamingPartitionSession` (issue #1668, stage
+//! 5c-iv part 3): the cross-call resumable session must produce
+//! BYTE-IDENTICAL Data.db output to today's whole-slice
+//! `write_partition_with_index_blocks` — same as
+//! `IncrementalPartitionWriter` (stage 5c-iv part 1) already proves — AND a
+//! partition fed in two separate batches (simulating a
+//! `maintenance_step_inner` budget pause between them, stage 4) must produce
+//! byte-identical output to one fed straight through in a single batch.
+//!
+//! NOT yet wired to any production caller — these tests exercise the new
+//! entry point directly, in isolation, matching the "prove before wiring"
+//! precedent of every prior sub-stage.
+
+use super::super::*;
+use super::support::*;
+use crate::storage::write_engine::mutation::{
+    CellOperation, ClusteringBound, ClusteringKey, PartitionKey, PartitionTombstone,
+    RangeTombstone, TableId,
+};
+use crate::types::Value;
+
+fn key(token: i64, bytes: Vec<u8>) -> DecoratedKey {
+    DecoratedKey::new(token, bytes)
+}
+
+fn row_mutation(schema: &TableSchema, ck: i32, value: &str, ts: i64) -> Mutation {
+    let table_id = TableId::new(&schema.keyspace, &schema.table);
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ck_key = ClusteringKey::single("ck", Value::Integer(ck));
+    let column = if schema.columns.iter().any(|c| c.name == "regular_val") {
+        "regular_val"
+    } else {
+        "v"
+    };
+    let ops = vec![CellOperation::Write {
+        column: column.to_string(),
+        value: Value::Text(value.to_string()),
+    }];
+    Mutation::new(table_id, pk, Some(ck_key), ops, ts, None)
+}
+
+fn static_mutation(schema: &TableSchema, value: &str, ts: i64) -> Mutation {
+    let table_id = TableId::new(&schema.keyspace, &schema.table);
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ops = vec![CellOperation::Write {
+        column: "static_val".to_string(),
+        value: Value::Text(value.to_string()),
+    }];
+    Mutation::new(table_id, pk, None, ops, ts, None)
+}
+
+fn resolve_static_ops(
+    mutations: &[Mutation],
+    schema: &TableSchema,
+    shadow_floor: Option<i64>,
+) -> Vec<StaticMergedOp> {
+    let mut tracker = StaticOpsTracker::new();
+    for m in mutations {
+        tracker.feed(m, schema, shadow_floor);
+    }
+    tracker.finish()
+}
+
+fn blocks_eq(a: &[PromotedIndexBlock], b: &[PromotedIndexBlock]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b.iter()).all(|(x, y)| {
+            x.first_name == y.first_name
+                && x.last_name == y.last_name
+                && x.offset == y.offset
+                && x.width == y.width
+                && x.oss50_separator == y.oss50_separator
+        })
+}
+
+fn writer_buffer(writer: &DataWriter) -> Vec<u8> {
+    writer.buffer.clone()
+}
+
+/// Drive the OLD whole-slice path — identical helper to
+/// `incremental_partition.rs`'s (kept local; private to a sibling module).
+fn run_whole_slice(
+    schema: &TableSchema,
+    key: &DecoratedKey,
+    mutations: &[Mutation],
+    partition_tombstone: Option<&PartitionTombstone>,
+    range_tombstones: &[RangeTombstone],
+) -> (Vec<u8>, u64, Vec<PromotedIndexBlock>, PartitionEmitCounts) {
+    let mut writer = DataWriter::new(create_test_stats());
+    let (offset, blocks, emit) = writer
+        .write_partition_with_index_blocks(
+            key,
+            mutations,
+            schema,
+            partition_tombstone,
+            range_tombstones,
+        )
+        .expect("whole-slice write must succeed");
+    (writer_buffer(&writer), offset, blocks, emit)
+}
+
+/// Drive the NEW cross-call-resumable session, feeding `clustering_mutations`
+/// in ONE unbroken batch (no simulated pause) — the baseline "does the new
+/// session match the whole-slice path at all" proof.
+fn run_streaming(
+    schema: &TableSchema,
+    key: &DecoratedKey,
+    clustering_mutations: &[Mutation],
+    static_ops: &[StaticMergedOp],
+    first_mutation_ts: i64,
+    partition_tombstone: Option<&PartitionTombstone>,
+    range_tombstones: &[RangeTombstone],
+) -> (Vec<u8>, u64, Vec<PromotedIndexBlock>, PartitionEmitCounts) {
+    run_streaming_split(
+        schema,
+        key,
+        clustering_mutations,
+        clustering_mutations.len(), // no split: one batch of everything
+        static_ops,
+        first_mutation_ts,
+        partition_tombstone,
+        range_tombstones,
+    )
+}
+
+/// Drive the NEW cross-call-resumable session, feeding the first
+/// `split_at` clustering mutations, then — simulating a
+/// `maintenance_step_inner` budget pause and a LATER resuming call — feeding
+/// the rest. Nothing is retained between the two batches except the plain
+/// `session`/`writer` VALUES themselves (moved back and forth exactly as
+/// `ActiveMerge` would hold them across two separate function calls); no
+/// special "pause"/"resume" conversion happens because
+/// `StreamingPartitionSession` never borrows anything.
+fn run_streaming_split(
+    schema: &TableSchema,
+    key: &DecoratedKey,
+    clustering_mutations: &[Mutation],
+    split_at: usize,
+    static_ops: &[StaticMergedOp],
+    first_mutation_ts: i64,
+    partition_tombstone: Option<&PartitionTombstone>,
+    range_tombstones: &[RangeTombstone],
+) -> (Vec<u8>, u64, Vec<PromotedIndexBlock>, PartitionEmitCounts) {
+    let mut writer = DataWriter::new(create_test_stats());
+    let schema_has_static = schema.columns.iter().any(|c| c.is_static);
+    let mut session = writer
+        .begin_streaming_partition(key, partition_tombstone, range_tombstones, schema)
+        .expect("begin_streaming_partition must succeed");
+    if schema_has_static {
+        session
+            .feed_static_row(&mut writer, static_ops, first_mutation_ts, schema)
+            .expect("feed_static_row must succeed");
+    }
+
+    // "Call 1": feed the first batch, then simulate returning control to an
+    // outer caller by dropping every local variable that isn't `session`
+    // itself and re-deriving `writer`'s access from scratch in "call 2"
+    // below — there is nothing else TO drop, since `session` owns
+    // everything it needs.
+    for m in &clustering_mutations[..split_at] {
+        session
+            .feed_row(&mut writer, m, schema)
+            .expect("feed_row (batch 1) must succeed");
+    }
+
+    // "Call 2": resume with the SAME `session`/`writer` values (as
+    // `ActiveMerge` would hand them back on the next `maintenance_step_inner`
+    // call) and finish draining.
+    for m in &clustering_mutations[split_at..] {
+        session
+            .feed_row(&mut writer, m, schema)
+            .expect("feed_row (batch 2) must succeed");
+    }
+
+    let (offset, blocks, emit) = session
+        .finish(&mut writer, schema)
+        .expect("finish must succeed");
+    (writer_buffer(&writer), offset, blocks, emit)
+}
+
+#[test]
+fn streaming_matches_whole_slice_for_plain_rows() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let mutations: Vec<Mutation> = (0..5)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 1000 + ck as i64))
+        .collect();
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &[]);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_streaming(&schema, &key, &mutations, &[], 0, None, &[]);
+
+    assert_eq!(old_bytes, new_bytes, "Data.db bytes must be identical");
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+}
+
+#[test]
+fn streaming_matches_whole_slice_for_static_and_regular_rows() {
+    let schema = create_static_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let static_m = static_mutation(&schema, "us-east", 500);
+    let clustering: Vec<Mutation> = (0..4)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 1000 + ck as i64))
+        .collect();
+
+    let mut all_mutations = vec![static_m.clone()];
+    all_mutations.extend(clustering.iter().cloned());
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &all_mutations, None, &[]);
+
+    let static_ops = resolve_static_ops(&[static_m.clone()], &schema, None);
+    let (new_bytes, new_offset, new_blocks, new_emit) = run_streaming(
+        &schema,
+        &key,
+        &clustering,
+        &static_ops,
+        static_m.timestamp_micros,
+        None,
+        &[],
+    );
+
+    assert_eq!(old_bytes, new_bytes, "Data.db bytes must be identical");
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+}
+
+#[test]
+fn streaming_matches_whole_slice_for_range_tombstone_interleaved_with_rows() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let mutations: Vec<Mutation> = (0..5)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 1000 + ck as i64))
+        .collect();
+    let rt = RangeTombstone {
+        start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(1))),
+        end: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(3))),
+        deletion_time: 900,
+        local_deletion_time: 90,
+    };
+    let range_tombstones = vec![rt];
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &range_tombstones);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_streaming(&schema, &key, &mutations, &[], 0, None, &range_tombstones);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "Data.db bytes must be identical with a range tombstone interleaved"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+}
+
+#[test]
+fn streaming_matches_whole_slice_for_partition_tombstone() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let mutations = vec![
+        row_mutation(&schema, 0, "row-0-shadowed", 100),
+        row_mutation(&schema, 1, "row-1-survives", 2000),
+    ];
+    let pt = PartitionTombstone {
+        deletion_time: 1000,
+        local_deletion_time: 100,
+    };
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, Some(&pt), &[]);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_streaming(&schema, &key, &mutations, &[], 0, Some(&pt), &[]);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "the partition-tombstone header and shadowing must be byte-identical"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(blocks_eq(&old_blocks, &new_blocks));
+    assert_eq!(old_emit, new_emit);
+    assert_eq!(old_emit.rows, 1, "only the surviving row must be counted");
+}
+
+/// A wide partition crossing the 64 KiB promoted-index block boundary at
+/// least once — proves the owning session's block tracking agrees with the
+/// whole-slice path exactly, not just the raw bytes.
+#[test]
+fn streaming_matches_whole_slice_for_wide_partition_with_promoted_index_blocks() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let big_value = "x".repeat(4000);
+    let mutations: Vec<Mutation> = (0..25)
+        .map(|ck| row_mutation(&schema, ck, &big_value, 1000 + ck as i64))
+        .collect();
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &[]);
+    let (new_bytes, new_offset, new_blocks, new_emit) =
+        run_streaming(&schema, &key, &mutations, &[], 0, None, &[]);
+
+    assert_eq!(
+        old_bytes, new_bytes,
+        "wide-partition Data.db bytes must be identical"
+    );
+    assert_eq!(old_offset, new_offset);
+    assert!(
+        old_blocks.len() >= 2,
+        "fixture must actually cross the 64 KiB promoted-index boundary \
+         (got {} blocks) — otherwise this test doesn't exercise block \
+         tracking at all",
+        old_blocks.len()
+    );
+    assert!(
+        blocks_eq(&old_blocks, &new_blocks),
+        "promoted-index block boundaries must match exactly: old={old_blocks:?} new={new_blocks:?}"
+    );
+    assert_eq!(old_emit, new_emit);
+}
+
+// ---------------------------------------------------------------------
+// Cross-call pause/resume proofs (issue #1668, stage 5c-iv part 3's whole
+// reason for existing over `IncrementalPartitionWriter`): a partition fed
+// in TWO separate batches — simulating a `maintenance_step_inner` budget
+// pause between them — must produce byte-identical output to one fed in a
+// single unbroken batch, for every fixture shape above.
+// ---------------------------------------------------------------------
+
+#[test]
+fn streaming_split_mid_partition_matches_unbroken_batch_for_plain_rows() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let mutations: Vec<Mutation> = (0..7)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 1000 + ck as i64))
+        .collect();
+
+    let (unbroken_bytes, unbroken_offset, unbroken_blocks, unbroken_emit) =
+        run_streaming(&schema, &key, &mutations, &[], 0, None, &[]);
+
+    // Split after every possible row count (1..len) — a pause can land
+    // between ANY two cluster groups, not just a convenient midpoint.
+    for split_at in 1..mutations.len() {
+        let (split_bytes, split_offset, split_blocks, split_emit) =
+            run_streaming_split(&schema, &key, &mutations, split_at, &[], 0, None, &[]);
+        assert_eq!(
+            unbroken_bytes, split_bytes,
+            "pausing after row {split_at} must not change the output bytes"
+        );
+        assert_eq!(unbroken_offset, split_offset);
+        assert!(blocks_eq(&unbroken_blocks, &split_blocks));
+        assert_eq!(unbroken_emit, split_emit);
+    }
+}
+
+#[test]
+fn streaming_split_mid_partition_matches_unbroken_batch_for_static_and_tombstones() {
+    let schema = create_static_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let static_m = static_mutation(&schema, "eu-west", 5000);
+    let pt = PartitionTombstone {
+        deletion_time: 1000,
+        local_deletion_time: 100,
+    };
+    let clustering = vec![
+        row_mutation(&schema, 0, "row-0-shadowed-by-partition", 500),
+        row_mutation(&schema, 1, "row-1-survives", 2000),
+        row_mutation(&schema, 2, "row-2-survives", 3000),
+        row_mutation(&schema, 3, "row-3-shadowed-by-range", 2100),
+        row_mutation(&schema, 4, "row-4-survives", 4000),
+    ];
+    let rt = RangeTombstone {
+        start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(3))),
+        end: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(3))),
+        deletion_time: 2500,
+        local_deletion_time: 250,
+    };
+    let range_tombstones = vec![rt];
+    let static_ops = resolve_static_ops(&[static_m.clone()], &schema, Some(pt.deletion_time));
+
+    let (unbroken_bytes, unbroken_offset, unbroken_blocks, unbroken_emit) = run_streaming(
+        &schema,
+        &key,
+        &clustering,
+        &static_ops,
+        static_m.timestamp_micros,
+        Some(&pt),
+        &range_tombstones,
+    );
+
+    for split_at in 1..clustering.len() {
+        let (split_bytes, split_offset, split_blocks, split_emit) = run_streaming_split(
+            &schema,
+            &key,
+            &clustering,
+            split_at,
+            &static_ops,
+            static_m.timestamp_micros,
+            Some(&pt),
+            &range_tombstones,
+        );
+        assert_eq!(
+            unbroken_bytes, split_bytes,
+            "pausing after row {split_at} must not change the output bytes, \
+             even with a static row + partition tombstone + range tombstone"
+        );
+        assert_eq!(unbroken_offset, split_offset);
+        assert!(blocks_eq(&unbroken_blocks, &split_blocks));
+        assert_eq!(unbroken_emit, split_emit);
+    }
+
+    // Sanity: the fixture actually exercises shadowing on both sides, else
+    // the split proof above would pass vacuously.
+    assert_eq!(
+        unbroken_emit.rows, 4,
+        "1 static row + ck=1, ck=2, ck=4 (ck=0 shadowed by the partition \
+         tombstone, ck=3 shadowed by the range tombstone)"
+    );
+}
+
+#[test]
+fn streaming_split_mid_partition_matches_whole_slice_for_wide_partition() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let big_value = "x".repeat(4000);
+    let mutations: Vec<Mutation> = (0..25)
+        .map(|ck| row_mutation(&schema, ck, &big_value, 1000 + ck as i64))
+        .collect();
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &[]);
+
+    // Pause in the MIDDLE of a promoted-index block's row run, not just at a
+    // block boundary — proves the paused/resumed block-tracking state
+    // (`current_block_first_ck`/`block_start_buf_offset`/etc.) survives the
+    // simulated call boundary correctly.
+    let (split_bytes, split_offset, split_blocks, split_emit) =
+        run_streaming_split(&schema, &key, &mutations, 12, &[], 0, None, &[]);
+
+    assert_eq!(
+        old_bytes, split_bytes,
+        "pausing mid-block must still reproduce the whole-slice bytes exactly"
+    );
+    assert_eq!(old_offset, split_offset);
+    assert!(blocks_eq(&old_blocks, &split_blocks));
+    assert_eq!(old_emit, split_emit);
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/streaming_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/streaming_partition.rs
@@ -256,6 +256,73 @@ fn streaming_matches_whole_slice_for_range_tombstone_interleaved_with_rows() {
     assert_eq!(old_emit, new_emit);
 }
 
+/// Roborev blocker #1 (issue #1668): two ADJACENT range tombstones with
+/// DIFFERENT deletion times (so an upstream `coalesce_range_tombstones` pass
+/// would never fold them first) must coalesce into ONE `Boundary` marker in
+/// `StreamingPartitionSession` too, exactly matching the whole-slice path —
+/// see `incremental_partition.rs`'s identical test for the full rationale.
+/// Exercised BOTH unbroken and split mid-partition (right at the boundary's
+/// own clustering point) to prove the fix survives a
+/// `maintenance_step_inner` budget pause landing exactly there.
+#[test]
+fn streaming_matches_whole_slice_for_adjacent_range_tombstones_forming_a_boundary() {
+    let schema = clustering_test_schema();
+    let key = key(1, vec![0, 0, 0, 1]);
+    let mutations: Vec<Mutation> = (0..8)
+        .map(|ck| row_mutation(&schema, ck, &format!("row-{ck}"), 100))
+        .collect();
+    let range_tombstones = vec![
+        RangeTombstone {
+            start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(0))),
+            end: ClusteringBound::Exclusive(ClusteringKey::single("ck", Value::Integer(3))),
+            deletion_time: 500,
+            local_deletion_time: 50,
+        },
+        RangeTombstone {
+            start: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(3))),
+            end: ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(6))),
+            deletion_time: 800,
+            local_deletion_time: 80,
+        },
+    ];
+
+    let (old_bytes, old_offset, old_blocks, old_emit) =
+        run_whole_slice(&schema, &key, &mutations, None, &range_tombstones);
+    let (unbroken_bytes, unbroken_offset, unbroken_blocks, unbroken_emit) =
+        run_streaming(&schema, &key, &mutations, &[], 0, None, &range_tombstones);
+
+    assert_eq!(
+        old_bytes, unbroken_bytes,
+        "adjacent range tombstones must coalesce into an IDENTICAL single \
+         boundary marker in the streaming path"
+    );
+    assert_eq!(old_offset, unbroken_offset);
+    assert!(blocks_eq(&old_blocks, &unbroken_blocks));
+    assert_eq!(old_emit, unbroken_emit);
+    assert_eq!(old_emit.rows, 1, "only ck=7 survives both tombstone ranges");
+
+    // Split mid-partition right at the shared boundary point (after ck=2,
+    // before ck=3) — the pause lands exactly where the two markers coalesce.
+    let (split_bytes, split_offset, split_blocks, split_emit) = run_streaming_split(
+        &schema,
+        &key,
+        &mutations,
+        3,
+        &[],
+        0,
+        None,
+        &range_tombstones,
+    );
+    assert_eq!(
+        old_bytes, split_bytes,
+        "splitting the batch right at the boundary's own clustering point \
+         must still coalesce identically"
+    );
+    assert_eq!(old_offset, split_offset);
+    assert!(blocks_eq(&old_blocks, &split_blocks));
+    assert_eq!(old_emit, split_emit);
+}
+
 #[test]
 fn streaming_matches_whole_slice_for_partition_tombstone() {
     let schema = clustering_test_schema();

--- a/cqlite-core/src/storage/sstable/writer/incremental.rs
+++ b/cqlite-core/src/storage/sstable/writer/incremental.rs
@@ -34,10 +34,32 @@ use super::data_writer::IncrementalPartitionWriter;
 use super::stats_fold;
 use super::{PromotedIndexBlock, SSTableWriter, StatisticsMetadata};
 use crate::error::{Error, Result};
+use crate::schema::TableSchema;
 use crate::storage::sstable::writer::data_writer::PartitionEmitCounts;
 use crate::storage::write_engine::mutation::{DecoratedKey, PartitionTombstone, RangeTombstone};
 
 impl SSTableWriter {
+    /// This writer's OWN schema (issue #1668, stage 5c-iv part 2) — the
+    /// header/column layout ACTUALLY on disk (e.g. a compaction's
+    /// `write_schema`, with fully-purged dropped columns already stripped),
+    /// as opposed to a merge layer's DECODE-time schema (e.g.
+    /// `KWayMerger::schema`/`effective_schema`, which still declares a
+    /// dropped column so its cells can be decoded and purge-evaluated).
+    ///
+    /// `write_partition` never needed this exposed: it always used its OWN
+    /// `&self.schema` internally for emission, decoupled from whatever schema
+    /// the caller used to decode/reconcile the `Vec<Mutation>` it was handed.
+    /// The incremental streaming path's `feed_row`/`feed_static_row`/`finish`
+    /// take an EXPLICIT schema argument instead (issue #1668 stage 5c-iv part
+    /// 1), so a caller assembling that argument from the WRONG schema (its
+    /// own decode-time schema, not this writer's) silently corrupts the
+    /// row/header encoding — passing MORE (or fewer) columns than the header
+    /// this writer already committed to declares. Callers MUST pass
+    /// `writer.schema()` here, never their own decode-time schema.
+    pub(crate) fn schema(&self) -> &TableSchema {
+        &self.schema
+    }
+
     /// Begin an incremental partition write (issue #1668, stage 5c-iv part
     /// 2). Performs the SAME pre-work `write_partition` does before handing
     /// off to `DataWriter` (token-order validation, key-range tracking), then

--- a/cqlite-core/src/storage/sstable/writer/incremental.rs
+++ b/cqlite-core/src/storage/sstable/writer/incremental.rs
@@ -30,13 +30,15 @@
 //! result (offset/blocks/emit — plain owned values, no borrow) out from the
 //! remaining bookkeeping is exactly what makes this composable.
 
-use super::data_writer::IncrementalPartitionWriter;
+use super::data_writer::{IncrementalPartitionWriter, StaticMergedOp, StreamingPartitionSession};
 use super::stats_fold;
 use super::{PromotedIndexBlock, SSTableWriter, StatisticsMetadata};
 use crate::error::{Error, Result};
 use crate::schema::TableSchema;
 use crate::storage::sstable::writer::data_writer::PartitionEmitCounts;
-use crate::storage::write_engine::mutation::{DecoratedKey, PartitionTombstone, RangeTombstone};
+use crate::storage::write_engine::mutation::{
+    DecoratedKey, Mutation, PartitionTombstone, RangeTombstone,
+};
 
 impl SSTableWriter {
     /// This writer's OWN schema (issue #1668, stage 5c-iv part 2) — the
@@ -183,5 +185,90 @@ impl SSTableWriter {
         crate::observability::add_counter(crate::observability::catalog::WRITE_PARTITIONS, 1, &[]);
 
         Ok(())
+    }
+
+    /// Begin a CROSS-CALL RESUMABLE incremental partition write (issue
+    /// #1668, stage 5c-iv part 3) — for a caller that must be able to
+    /// return control to an outer scheduler mid-partition and resume later
+    /// (`WriteEngine::maintenance_step`'s budget-driven pause/resume, stage
+    /// 4), unlike [`Self::begin_partition_incremental`]'s session, which
+    /// borrows `self` for its whole lifetime and therefore cannot survive a
+    /// function return.
+    ///
+    /// Same pre-work and the same pre-seeded-baselines precondition as
+    /// [`Self::begin_partition_incremental`] — see its doc for the
+    /// rationale, which applies unchanged here.
+    pub(crate) fn begin_streaming_partition(
+        &mut self,
+        key: &DecoratedKey,
+        partition_tombstone: Option<&PartitionTombstone>,
+        range_tombstones: &[RangeTombstone],
+    ) -> Result<StreamingPartitionSession> {
+        debug_assert!(
+            self.baselines_locked,
+            "begin_streaming_partition requires pre-seeded encoding baselines \
+             (call pre_seed_encoding_baselines before streaming partitions) — \
+             see begin_partition_incremental's precondition doc, issue #1668"
+        );
+        if let Some(last_token) = self.last_token {
+            if key.token <= last_token {
+                return Err(Error::InvalidInput(format!(
+                    "Partitions must be written in token order: got token {} after {}",
+                    key.token, last_token
+                )));
+            }
+        }
+        self.last_token = Some(key.token);
+        self.stats.update_key_range(&key.key);
+
+        self.data_writer.begin_streaming_partition(
+            key,
+            partition_tombstone,
+            range_tombstones,
+            &self.schema,
+        )
+    }
+
+    /// Feed one clustering row into a [`StreamingPartitionSession`] (issue
+    /// #1668, stage 5c-iv part 3). Borrows `self.data_writer` for just this
+    /// one call — unlike [`IncrementalPartitionWriter`], `session` itself
+    /// never holds a borrow of `self`, so it can be stored (e.g. on
+    /// `ActiveMerge`) and fed across as many separate calls as needed.
+    pub(crate) fn feed_streaming_row(
+        &mut self,
+        session: &mut StreamingPartitionSession,
+        mutation: &Mutation,
+    ) -> Result<()> {
+        session.feed_row(&mut self.data_writer, mutation, &self.schema)
+    }
+
+    /// Feed the static-row prelude into a [`StreamingPartitionSession`]
+    /// (issue #1668, stage 5c-iv part 3) — called at most once, before any
+    /// [`Self::feed_streaming_row`] call for the same session.
+    pub(crate) fn feed_streaming_static_row(
+        &mut self,
+        session: &mut StreamingPartitionSession,
+        merged: &[StaticMergedOp],
+        first_mutation_ts: i64,
+    ) -> Result<()> {
+        session.feed_static_row(
+            &mut self.data_writer,
+            merged,
+            first_mutation_ts,
+            &self.schema,
+        )
+    }
+
+    /// Finalize a [`StreamingPartitionSession`] (issue #1668, stage 5c-iv
+    /// part 3) — returns the same `(offset, blocks, emit)` shape
+    /// [`IncrementalPartitionWriter::finish`] does; the caller must still
+    /// call [`Self::complete_partition_incremental`] with the result (that
+    /// method is shared by both sessions — it only needs the returned
+    /// values, not the session type).
+    pub(crate) fn finish_streaming_partition(
+        &mut self,
+        session: StreamingPartitionSession,
+    ) -> Result<(u64, Vec<PromotedIndexBlock>, PartitionEmitCounts)> {
+        session.finish(&mut self.data_writer, &self.schema)
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/incremental.rs
+++ b/cqlite-core/src/storage/sstable/writer/incremental.rs
@@ -1,0 +1,165 @@
+//! `SSTableWriter`-level incremental partition-write wiring (issue #1668,
+//! stage 5c-iv part 2).
+//!
+//! Wraps `DataWriter::begin_partition_incremental` (stage 5c-iv part 1) with
+//! the SAME bookkeeping `SSTableWriter::write_partition` performs around it
+//! (token-order validation, key-range/baseline stats, and — once the
+//! `DataWriter`-level session finishes — Index.db/Filter.db/Summary.db/BTI
+//! registration and partition-count/observability counters), split into two
+//! calls so the CALLER (a streaming merge consumer) can drive the
+//! `DataWriter`-level session directly in between, feeding one cluster group
+//! at a time instead of assembling a whole `Vec<Mutation>` first:
+//!
+//! ```text
+//! let mut session = output_writer.begin_partition_incremental(&key, tombstone, &rts)?;
+//! if schema_has_static { session.feed_static_row(&ops, ts, schema)?; }
+//! for mutation in cluster_groups { session.feed_row(&mutation, schema)?; }
+//! let (offset, blocks, emit) = session.finish(schema)?;
+//! output_writer.complete_partition_incremental(&key, tombstone, offset, &blocks, emit)?;
+//! ```
+//!
+//! `begin_partition_incremental` returns `data_writer::IncrementalPartitionWriter<'w, 'r>`
+//! DIRECTLY — its lifetime `'w` is tied to the WHOLE `&'w mut SSTableWriter`
+//! borrow (Rust cannot narrow a returned borrow to "just one field" across a
+//! function boundary), so the caller cannot use `output_writer` for anything
+//! else while the session is alive. This is not a real constraint: the
+//! caller only ever calls `session.feed_row`/`finish` during that window,
+//! never anything else on `output_writer` — and once `finish()` consumes the
+//! session, NLL proves the borrow has ended, freeing `output_writer` for the
+//! `complete_partition_incremental` call. Splitting `finish()`'s Data.db-only
+//! result (offset/blocks/emit — plain owned values, no borrow) out from the
+//! remaining bookkeeping is exactly what makes this composable.
+
+use super::data_writer::IncrementalPartitionWriter;
+use super::stats_fold;
+use super::{PromotedIndexBlock, SSTableWriter, StatisticsMetadata};
+use crate::error::{Error, Result};
+use crate::storage::sstable::writer::data_writer::PartitionEmitCounts;
+use crate::storage::write_engine::mutation::{DecoratedKey, PartitionTombstone, RangeTombstone};
+
+impl SSTableWriter {
+    /// Begin an incremental partition write (issue #1668, stage 5c-iv part
+    /// 2). Performs the SAME pre-work `write_partition` does before handing
+    /// off to `DataWriter` (token-order validation, key-range tracking), then
+    /// delegates to `DataWriter::begin_partition_incremental`.
+    ///
+    /// # Precondition: baselines must be pre-seeded
+    ///
+    /// Unlike `write_partition` (which has the whole partition's
+    /// `Vec<Mutation>` in hand and can fold its stats BEFORE pushing a
+    /// baseline to `DataWriter`), this entry point streams mutations in one
+    /// at a time and cannot know a partition's minimum LDT/timestamp before
+    /// it starts emitting bytes for that partition — buffering ahead to find
+    /// out would defeat the entire point of this streaming path (bounding
+    /// peak memory to `max_row_width × k`, issue #1668). So this method
+    /// requires `self.baselines_locked` (i.e. the caller already called
+    /// `pre_seed_encoding_baselines` with the true minimum computed over ALL
+    /// inputs) and asserts it rather than silently risking an LDT-delta
+    /// underflow panic deep inside `DataWriter`. This is not a real
+    /// constraint on the one production caller: `compact_sstables_with_registry`
+    /// always pre-seeds baselines before calling `KWayMerger::merge`. A
+    /// caller that has not pre-seeded (e.g. a unit test constructing a bare
+    /// `SSTableWriter::new`) must call `pre_seed_encoding_baselines` first —
+    /// exactly as production does — or use `write_partition` instead.
+    ///
+    /// The caller must NOT use `self` again until the returned session is
+    /// consumed via `IncrementalPartitionWriter::finish` and this writer's
+    /// `complete_partition_incremental` is called with its result — see the
+    /// module doc.
+    pub(crate) fn begin_partition_incremental<'w, 'r>(
+        &'w mut self,
+        key: &DecoratedKey,
+        partition_tombstone: Option<&PartitionTombstone>,
+        range_tombstones: &'r [RangeTombstone],
+    ) -> Result<IncrementalPartitionWriter<'w, 'r>> {
+        debug_assert!(
+            self.baselines_locked,
+            "begin_partition_incremental requires pre-seeded encoding baselines \
+             (call pre_seed_encoding_baselines before streaming partitions) — \
+             see the precondition doc on this method, issue #1668"
+        );
+        if let Some(last_token) = self.last_token {
+            if key.token <= last_token {
+                return Err(Error::InvalidInput(format!(
+                    "Partitions must be written in token order: got token {} after {}",
+                    key.token, last_token
+                )));
+            }
+        }
+        self.last_token = Some(key.token);
+        self.stats.update_key_range(&key.key);
+
+        // No baseline push here (unlike `write_partition`): `baselines_locked`
+        // is required (see doc above), so `write_partition`'s
+        // `if !self.baselines_locked { update_stats_from_metadata }` gate
+        // would always be a no-op anyway.
+
+        self.data_writer.begin_partition_incremental(
+            key,
+            partition_tombstone,
+            range_tombstones,
+            &self.schema,
+        )
+    }
+
+    /// Finalize the SSTableWriter-level bookkeeping for a partition written
+    /// via the incremental entry point (issue #1668, stage 5c-iv part 2).
+    /// Call this AFTER `IncrementalPartitionWriter::finish` has already
+    /// returned its `(offset, blocks, emit)` — this method never touches
+    /// `DataWriter` again, only the OTHER `SSTableWriter` fields (Index.db,
+    /// Filter.db, Summary.db, BTI, partition-count/observability), mirroring
+    /// `write_partition`'s tail EXACTLY (moved, not duplicated in spirit —
+    /// see `write_partition`'s own comments for the rationale behind each
+    /// step).
+    ///
+    /// `partition_stats` is the caller's per-partition fold (every mutation
+    /// of this partition folded through `stats_fold::fold_mutation_stats` as
+    /// it streamed by — the caller cannot fold directly into
+    /// `self.stats` while the `IncrementalPartitionWriter` session holds an
+    /// exclusive borrow of `self`). Merged in here, once the session's borrow
+    /// has ended, via `stats_fold::merge_stats_fold` so the FINAL
+    /// `StatisticsMetadata` (max values / tombstone histogram / live-LDT
+    /// sentinel / partition-level-deletion flag) matches `write_partition`'s
+    /// byte-for-byte, even though `baselines_locked` already made the
+    /// DataWriter-baseline half of the old push a no-op.
+    pub(crate) fn complete_partition_incremental(
+        &mut self,
+        key: &DecoratedKey,
+        partition_tombstone: Option<&PartitionTombstone>,
+        data_offset: u64,
+        promoted_blocks: &[PromotedIndexBlock],
+        emit_counts: PartitionEmitCounts,
+        partition_stats: &StatisticsMetadata,
+    ) -> Result<()> {
+        stats_fold::merge_stats_fold(&mut self.stats, partition_stats);
+        self.stats.row_count += emit_counts.rows;
+        self.stats.column_count += emit_counts.columns;
+
+        let partition_serialized_size = self.data_writer.position().saturating_sub(data_offset);
+        self.stats
+            .record_partition(partition_serialized_size, emit_counts.columns);
+
+        let entry_info =
+            self.index_writer
+                .add_partition_with_promoted(key, data_offset, promoted_blocks)?;
+
+        if let Some(ref mut filter) = self.filter_writer {
+            filter.add_key(key);
+        }
+
+        self.queue_bti_partition(key, data_offset, promoted_blocks, partition_tombstone);
+
+        self.summary_writer.note_partition(key);
+        if self.summary_sample_counter % self.summary_sample_interval == 0 {
+            self.summary_writer
+                .add_entry(key, entry_info.index_offset)?;
+        }
+        self.summary_sample_counter += 1;
+        self.partition_count += 1;
+        self.stats.increment_partition_count();
+
+        crate::observability::add_counter(crate::observability::catalog::WRITE_PARTITIONS, 1, &[]);
+
+        Ok(())
+    }
+}

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -29,6 +29,15 @@
 mod bti_state;
 #[cfg(feature = "write-support")]
 mod finish;
+/// `SSTableWriter`-level incremental partition-write wiring (issue #1668,
+/// stage 5c-iv part 2). See [`SSTableWriter::begin_partition_incremental`].
+#[cfg(feature = "write-support")]
+mod incremental;
+/// Shared per-mutation statistics fold (issue #1668, stage 5c-iv part 2),
+/// called by both `write_partition` and the incremental streaming path so
+/// they can never drift. See [`stats_fold::fold_mutation_stats`].
+#[cfg(feature = "write-support")]
+pub(crate) mod stats_fold;
 
 #[cfg(feature = "write-support")]
 pub mod compressed_data_writer;
@@ -629,209 +638,23 @@ impl SSTableWriter {
                 .unwrap_or_else(|_| ck_a.cmp(ck_b)),
         });
 
-        // Update statistics from mutations
+        // Update statistics from mutations. Issue #1668 stage 5c-iv part 2:
+        // extracted into `stats_fold::fold_mutation_stats` so the incremental
+        // streaming path folds the exact same logic per mutation and the two
+        // paths can never drift.
+        //
+        // Issue #851: row_count (totalRows) and column_count
+        // (totalColumnsSet) are NOT re-derived per-mutation here. The two
+        // previous attempts re-grouped rows in this loop and kept diverging
+        // from `DataWriter::merge_row_group`, which is what actually emits
+        // rows/cells to Data.db (e.g. it drops partition/clustering-key
+        // columns from cells, and merges static ops from ALL mutations into
+        // a single static prelude that is a SEPARATE row from the clustering
+        // row). Instead, the emitter returns `PartitionEmitCounts` and we add
+        // them below (see the `write_partition_with_index_blocks` call) so
+        // the stats can never drift from what was physically written.
         for mutation in &mutations {
-            self.stats.update_timestamp(mutation.timestamp_micros);
-            // Issue #1018: simple `Write`/`WriteWithTtl`/`Delete` cells may carry
-            // their OWN (lower) per-cell timestamps in
-            // `Mutation::cell_write_timestamps` (a live cell's writetime OR a cell
-            // tombstone's markedForDeleteAt) and are emitted with an explicit
-            // `min_timestamp` delta. On the non-preseeded (incremental) write path,
-            // fold every per-cell timestamp into the stats BEFORE emitting cells so
-            // `min_timestamp` can never exceed an emitted cell's actual timestamp
-            // (which would underflow the unsigned-VInt delta). Mirrors the pre-pass
-            // fold in `compute_mutations_baseline_stats`.
-            if let Some(cell_ts) = &mutation.cell_write_timestamps {
-                for ts in cell_ts.values() {
-                    self.stats.update_timestamp(*ts);
-                }
-            }
-            if let Some(ttl) = mutation.ttl_seconds {
-                self.stats.update_ttl(ttl as i32);
-                let now_seconds = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs() as i32)
-                    .unwrap_or(0);
-                let local_deletion_time = now_seconds.saturating_add(ttl as i32);
-                self.stats.update_local_deletion_time(local_deletion_time);
-            }
-            // Track local deletion times for tombstones and TTL cells.
-            // Issue #764: row/cell tombstones use the caller-supplied
-            // `local_deletion_time` when present, else the timestamp-derived
-            // value (`effective_local_deletion_time`).
-            for op in &mutation.operations {
-                match op {
-                    crate::storage::write_engine::mutation::CellOperation::WriteWithTtl {
-                        ttl_seconds,
-                        local_deletion_time,
-                        ..
-                    } => {
-                        // Track TTL
-                        self.stats.update_ttl(*ttl_seconds as i32);
-                        // CRITICAL: TTL cells need local_deletion_time tracked so the
-                        // per-cell LDT delta (`ldt - min_local_deletion_time`) written
-                        // by `write_cell_with_ttl` never underflows.
-                        //
-                        // Issue #1538: honor the authoritative per-cell LDT VERBATIM
-                        // when present (a surviving expiring cell preserved through
-                        // compaction), exactly as `write_cell_with_ttl` will stamp it,
-                        // so the seeded baseline and the emitted bytes agree. A per-cell
-                        // LDT below the wall-clock-derived value would otherwise
-                        // underflow the unsigned delta. `None` keeps the historical
-                        // `now + ttl` derivation.
-                        let local_deletion_time = match local_deletion_time {
-                            Some(ldt) => *ldt,
-                            None => {
-                                let now_seconds = std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .map(|d| d.as_secs() as i32)
-                                    .unwrap_or(0);
-                                now_seconds.saturating_add(*ttl_seconds as i32)
-                            }
-                        };
-                        self.stats.update_local_deletion_time(local_deletion_time);
-                    }
-                    op @ (crate::storage::write_engine::mutation::CellOperation::Delete { .. }
-                    | crate::storage::write_engine::mutation::CellOperation::DeleteRow) => {
-                        // Issue #764 / #921 finding 2: record the EXACT LDT the
-                        // tombstone is emitted with. A `Delete` carrying a per-cell
-                        // `local_deletion_time: Some(L)` is stamped with `L`
-                        // verbatim by DataWriter; everything else derives the LDT
-                        // from the mutation. Reuse `op_cell_local_deletion_time`
-                        // (the emit path's helper) so stats and the bytes written
-                        // to Data.db agree exactly — a per-cell `L` below the
-                        // mutation-derived value would otherwise underflow the
-                        // delta, and one above it would leave min/max wrong.
-                        let local_deletion_time =
-                            crate::storage::sstable::writer::data_writer::op_cell_local_deletion_time(
-                                op, mutation,
-                            );
-                        self.stats.update_local_deletion_time(local_deletion_time);
-                    }
-                    // Issue #887: a `ComplexDeletion` marker is physically written
-                    // with its OWN `marked_for_delete_at` / `local_deletion_time`
-                    // (DataWriter delta-encodes both against `min_timestamp` /
-                    // `min_local_deletion_time`). The mutation's row timestamp does
-                    // NOT cover the marker — for a tombstone-only row whose marker
-                    // strictly supersedes the row tombstone, `marked_for_delete_at`
-                    // can lie ABOVE the row timestamp and the marker LDT below the
-                    // row's LDT. Fold both into the stats so `max_timestamp` /
-                    // `min_local_deletion_time` reflect what was actually emitted to
-                    // Data.db (LIVE sentinels are filtered inside the `update_*`
-                    // chokepoints, issue #851).
-                    crate::storage::write_engine::mutation::CellOperation::ComplexDeletion {
-                        marked_for_delete_at,
-                        local_deletion_time,
-                        ..
-                    } => {
-                        self.stats.update_timestamp(*marked_for_delete_at);
-                        self.stats.update_local_deletion_time(*local_deletion_time);
-                    }
-                    // Issue #887: a per-element complex cell carries its OWN explicit
-                    // timestamp/ttl/local_deletion_time (DataWriter delta-encodes each
-                    // against the SSTable baselines). The element timestamp can differ
-                    // from the row liveness timestamp, and a deleted/expiring element
-                    // supplies an LDT/TTL the row-level accumulation never sees. Fold
-                    // them all in so the baselines cover every byte emitted by
-                    // `write_complex_element_cell`.
-                    crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
-                        timestamp_micros,
-                        ttl_seconds,
-                        local_deletion_time,
-                        is_deleted,
-                        ..
-                    } => {
-                        self.stats.update_timestamp(*timestamp_micros);
-                        if let Some(ttl) = ttl_seconds {
-                            self.stats.update_ttl(*ttl as i32);
-                        }
-                        if let Some(ldt) = local_deletion_time {
-                            self.stats.update_local_deletion_time(*ldt);
-                        }
-                        // Issue #1728 (roborev finding 2): a LIVE complex element
-                        // (not deleted, not expiring, no explicit LDT) carries
-                        // Cassandra's `NO_DELETION_TIME` sentinel just like a simple
-                        // live `Write`, so it must lift `maxLocalDeletionTime` to the
-                        // sentinel in a mixed SSTable. Authoritative liveness comes
-                        // from the verbatim `is_deleted` flag (never re-derived from
-                        // `value`, per the no-heuristics mandate / roborev #885).
-                        if !*is_deleted && ttl_seconds.is_none() && local_deletion_time.is_none() {
-                            self.stats.note_live_local_deletion_time();
-                        }
-                    }
-                    // Issue #1728: a live, non-TTL `Write` cell carries Cassandra's
-                    // `Cell.NO_DELETION_TIME` (`Integer.MAX_VALUE`) as its
-                    // localDeletionTime. Cassandra's MetadataCollector folds that
-                    // sentinel into `maxLocalDeletionTime`, so any SSTable holding a
-                    // live non-TTL cell finalizes `maxLocalDeletionTime` == the live
-                    // sentinel — including a MIXED SSTable that also carries older
-                    // tombstones with a smaller real LDT. The dedicated chokepoint
-                    // raises the max ALONE (never poisoning minLocalDeletionTime or
-                    // the tombstone drop-time histogram, issue #851).
-                    //
-                    // Two cases must NOT fold the live sentinel (roborev #1728):
-                    //   * `mutation.ttl_seconds.is_some()` — a plain `Write` under a
-                    //     row-level TTL is emitted as an EXPIRING cell with a real
-                    //     `now + ttl` LDT (data_writer::rows), which the mutation-TTL
-                    //     block above (`if let Some(ttl) = mutation.ttl_seconds`)
-                    //     already folded; overwriting max with the sentinel would
-                    //     clobber that real expiring LDT.
-                    //   * `value == Null` — a null `Write` is skipped by
-                    //     `write_merged_cells` (no cell is emitted), so it confers no
-                    //     LDT at all.
-                    crate::storage::write_engine::mutation::CellOperation::Write { value, .. } => {
-                        if mutation.ttl_seconds.is_none()
-                            && !matches!(value, crate::types::Value::Null)
-                        {
-                            self.stats.note_live_local_deletion_time();
-                        }
-                    }
-                }
-            }
-            // Track stats for partition tombstones
-            if let Some(pt) = &mutation.partition_tombstone {
-                self.stats.update_timestamp(pt.deletion_time);
-                self.stats
-                    .update_local_deletion_time(pt.local_deletion_time);
-                // Record the partition-level deletion marker for the `da`-format
-                // StatsMetadata.hasPartitionLevelDeletions field. Authoritative:
-                // the mutation explicitly carries a partition tombstone.
-                self.stats.mark_partition_level_deletion();
-            }
-
-            // Track stats for range tombstones
-            for rt in &mutation.range_tombstones {
-                self.stats.update_timestamp(rt.deletion_time);
-                self.stats
-                    .update_local_deletion_time(rt.local_deletion_time);
-            }
-
-            // Issue #1721: a decoupled row tombstone (#932
-            // `Mutation::row_tombstone = Some((deletion_time, ldt))`) is emitted
-            // by DataWriter as a `HAS_DELETION` row stamped with its OWN
-            // `(deletion_time, ldt)` — DECOUPLED from `timestamp_micros`, so the
-            // per-cell/mutation folds above never see it. Fold both through the
-            // same `update_*` chokepoints as `partition_tombstone` so
-            // `min_local_deletion_time` covers the tombstone's `ldt`; otherwise
-            // the below-baseline guard in data_writer/rows.rs (static sibling
-            // static_rows.rs) rejects the row when `ldt` sits below the
-            // incremental baseline. LIVE sentinels are filtered inside the
-            // chokepoints (#851), so route the raw values straight through.
-            if let Some((deletion_time, ldt)) = mutation.row_tombstone {
-                self.stats.update_timestamp(deletion_time);
-                self.stats.update_local_deletion_time(ldt);
-            }
-
-            // Issue #851: row_count (totalRows) and column_count
-            // (totalColumnsSet) are NOT re-derived per-mutation here. The two
-            // previous attempts re-grouped rows in this loop and kept diverging
-            // from `DataWriter::merge_row_group`, which is what actually emits
-            // rows/cells to Data.db (e.g. it drops partition/clustering-key
-            // columns from cells, and merges static ops from ALL mutations into
-            // a single static prelude that is a SEPARATE row from the clustering
-            // row). Instead, the emitter returns `PartitionEmitCounts` and we add
-            // them below (see the `write_partition_with_index_blocks` call) so
-            // the stats can never drift from what was physically written.
+            stats_fold::fold_mutation_stats(&mut self.stats, mutation);
         }
 
         // Update DataWriter's stats before writing, unless baselines were

--- a/cqlite-core/src/storage/sstable/writer/stats_fold.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_fold.rs
@@ -1,0 +1,471 @@
+//! Shared per-mutation statistics fold (issue #1668, stage 5c-iv part 2).
+//!
+//! [`SSTableWriter::write_partition`] folds every mutation of a partition into
+//! `StatisticsMetadata` (min/max timestamp, LDT, TTL, the tombstone-drop-time
+//! histogram, the live-LDT sentinel, and the partition-level-deletion flag)
+//! BEFORE writing any bytes for that partition. The incremental streaming path
+//! (`KWayMerger::merge`, `writer/incremental.rs`) sees mutations one at a time
+//! and cannot buffer a whole partition to reproduce that ordering, but the
+//! fold itself is a pure function of ONE mutation plus the running
+//! accumulator — extracted here so both paths call the exact same logic and
+//! can never drift.
+//!
+//! [`SSTableWriter::write_partition`]: super::SSTableWriter::write_partition
+
+use crate::storage::sstable::writer::stats_writer::StatisticsMetadata;
+use crate::storage::write_engine::mutation::{CellOperation, Mutation};
+
+/// Fold one mutation's timestamp/TTL/local-deletion-time/tombstone information
+/// into `stats`. Mirrors the per-mutation loop body that used to live inline in
+/// [`super::SSTableWriter::write_partition`] verbatim — same chokepoints
+/// (`update_timestamp`, `update_local_deletion_time`, `update_ttl`,
+/// `note_live_local_deletion_time`, `mark_partition_level_deletion`), same
+/// per-`CellOperation` handling, so folding every mutation of a partition
+/// through this function (in any order — the chokepoints are commutative
+/// min/max folds, issue #1668 stage 5a) reproduces `write_partition`'s final
+/// `StatisticsMetadata` byte-for-byte.
+///
+/// Callers: `write_partition` (once per mutation, whole-partition buffered)
+/// and the incremental streaming path (once per mutation, as it streams
+/// through — see `writer/incremental.rs` doc comments for how the streamed
+/// partition-scoped fold is merged into the running `SSTableWriter`-wide
+/// `stats` at partition end).
+pub(crate) fn fold_mutation_stats(stats: &mut StatisticsMetadata, mutation: &Mutation) {
+    stats.update_timestamp(mutation.timestamp_micros);
+    // Issue #1018: simple `Write`/`WriteWithTtl`/`Delete` cells may carry their
+    // OWN (lower) per-cell timestamps in `Mutation::cell_write_timestamps` (a
+    // live cell's writetime OR a cell tombstone's markedForDeleteAt) and are
+    // emitted with an explicit `min_timestamp` delta. Fold every per-cell
+    // timestamp into the stats BEFORE emitting cells so `min_timestamp` can
+    // never exceed an emitted cell's actual timestamp (which would underflow
+    // the unsigned-VInt delta). Mirrors the pre-pass fold in
+    // `compute_mutations_baseline_stats`.
+    if let Some(cell_ts) = &mutation.cell_write_timestamps {
+        for ts in cell_ts.values() {
+            stats.update_timestamp(*ts);
+        }
+    }
+    if let Some(ttl) = mutation.ttl_seconds {
+        stats.update_ttl(ttl as i32);
+        let now_seconds = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i32)
+            .unwrap_or(0);
+        let local_deletion_time = now_seconds.saturating_add(ttl as i32);
+        stats.update_local_deletion_time(local_deletion_time);
+    }
+    // Track local deletion times for tombstones and TTL cells. Issue #764:
+    // row/cell tombstones use the caller-supplied `local_deletion_time` when
+    // present, else the timestamp-derived value.
+    for op in &mutation.operations {
+        match op {
+            CellOperation::WriteWithTtl {
+                ttl_seconds,
+                local_deletion_time,
+                ..
+            } => {
+                stats.update_ttl(*ttl_seconds as i32);
+                // Issue #1538: honor the authoritative per-cell LDT VERBATIM
+                // when present (a surviving expiring cell preserved through
+                // compaction); `None` keeps the historical `now + ttl`
+                // derivation.
+                let local_deletion_time = match local_deletion_time {
+                    Some(ldt) => *ldt,
+                    None => {
+                        let now_seconds = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs() as i32)
+                            .unwrap_or(0);
+                        now_seconds.saturating_add(*ttl_seconds as i32)
+                    }
+                };
+                stats.update_local_deletion_time(local_deletion_time);
+            }
+            op @ (CellOperation::Delete { .. } | CellOperation::DeleteRow) => {
+                // Issue #764 / #921 finding 2: record the EXACT LDT the
+                // tombstone is emitted with, via the same helper the emit path
+                // uses, so stats and Data.db bytes agree exactly.
+                let local_deletion_time =
+                    crate::storage::sstable::writer::data_writer::op_cell_local_deletion_time(
+                        op, mutation,
+                    );
+                stats.update_local_deletion_time(local_deletion_time);
+            }
+            // Issue #887: a `ComplexDeletion` marker is physically written with
+            // its OWN `marked_for_delete_at` / `local_deletion_time`, which may
+            // fall outside the row's own timestamp/LDT range.
+            CellOperation::ComplexDeletion {
+                marked_for_delete_at,
+                local_deletion_time,
+                ..
+            } => {
+                stats.update_timestamp(*marked_for_delete_at);
+                stats.update_local_deletion_time(*local_deletion_time);
+            }
+            // Issue #887: a per-element complex cell carries its OWN explicit
+            // timestamp/ttl/local_deletion_time.
+            CellOperation::WriteComplexElement {
+                timestamp_micros,
+                ttl_seconds,
+                local_deletion_time,
+                is_deleted,
+                ..
+            } => {
+                stats.update_timestamp(*timestamp_micros);
+                if let Some(ttl) = ttl_seconds {
+                    stats.update_ttl(*ttl as i32);
+                }
+                if let Some(ldt) = local_deletion_time {
+                    stats.update_local_deletion_time(*ldt);
+                }
+                // Issue #1728 (roborev finding 2): a LIVE complex element
+                // carries Cassandra's `NO_DELETION_TIME` sentinel just like a
+                // live simple `Write`.
+                if !*is_deleted && ttl_seconds.is_none() && local_deletion_time.is_none() {
+                    stats.note_live_local_deletion_time();
+                }
+            }
+            // Issue #1728: a live, non-TTL `Write` cell carries Cassandra's
+            // `Cell.NO_DELETION_TIME` sentinel as its localDeletionTime.
+            CellOperation::Write { value, .. } => {
+                if mutation.ttl_seconds.is_none() && !matches!(value, crate::types::Value::Null) {
+                    stats.note_live_local_deletion_time();
+                }
+            }
+        }
+    }
+    // Track stats for partition tombstones.
+    if let Some(pt) = &mutation.partition_tombstone {
+        stats.update_timestamp(pt.deletion_time);
+        stats.update_local_deletion_time(pt.local_deletion_time);
+        stats.mark_partition_level_deletion();
+    }
+    // Track stats for range tombstones.
+    for rt in &mutation.range_tombstones {
+        stats.update_timestamp(rt.deletion_time);
+        stats.update_local_deletion_time(rt.local_deletion_time);
+    }
+    // Issue #1721: a decoupled row tombstone (#932
+    // `Mutation::row_tombstone = Some((deletion_time, ldt))`) is emitted as a
+    // `HAS_DELETION` row stamped with its OWN `(deletion_time, ldt)` —
+    // DECOUPLED from `timestamp_micros`, so the per-cell/mutation folds above
+    // never see it.
+    if let Some((deletion_time, ldt)) = mutation.row_tombstone {
+        stats.update_timestamp(deletion_time);
+        stats.update_local_deletion_time(ldt);
+    }
+}
+
+/// Fold `from`'s accumulated range/flags into `into` (issue #1668 stage
+/// 5c-iv part 2). Used to merge a partition-scoped fold (accumulated while
+/// streaming a partition's mutations one at a time) into the SSTable-wide
+/// running `StatisticsMetadata` at partition end, once the incremental
+/// session's exclusive borrow of the writer has ended.
+///
+/// Min/max fields are commutative folds (stage 5a), so feeding both of
+/// `from`'s min and max back through the same chokepoints on `into`
+/// reproduces exactly what folding every mutation directly into `into` would
+/// have produced — PROVIDED `from`'s own untouched-default sentinels are
+/// excluded first. `update_timestamp` already self-filters its untouched
+/// defaults (`i64::MAX`/`i64::MIN`, both treated as the LIVE/NO_DELETION
+/// marker, issue #851), so timestamps are safe to feed unconditionally. LDT
+/// and TTL are NOT symmetric:
+///   * `update_local_deletion_time` filters `i32::MAX` (live sentinel) but
+///     NOT `i32::MIN` (`from.max_local_deletion_time`'s untouched default
+///     when no tombstone was ever folded) — guarded explicitly below, else an
+///     empty `from` would drag `into.min_local_deletion_time` down to
+///     `i32::MIN`.
+///   * `update_ttl` only filters non-positive values, so `from.min_ttl`'s
+///     untouched default (`i32::MAX`, itself positive) must be excluded
+///     explicitly, else it would corrupt `into.max_ttl` to `i32::MAX`.
+///
+/// The live-LDT sentinel itself is NOT re-derived through
+/// `update_local_deletion_time` (which filters `i32::MAX` OUT) —
+/// `from.max_local_deletion_time == i32::MAX` is used as the equivalent "saw
+/// a live cell" signal instead, since `note_live_local_deletion_time` is the
+/// ONLY setter that can assign `i32::MAX` to `max_local_deletion_time` (a
+/// real tombstone LDT is always filtered before it can reach the max).
+pub(crate) fn merge_stats_fold(into: &mut StatisticsMetadata, from: &StatisticsMetadata) {
+    into.update_timestamp(from.min_timestamp);
+    into.update_timestamp(from.max_timestamp);
+
+    into.update_local_deletion_time(from.min_local_deletion_time);
+    if from.max_local_deletion_time > i32::MIN {
+        into.update_local_deletion_time(from.max_local_deletion_time);
+    }
+    if from.max_local_deletion_time == i32::MAX {
+        into.note_live_local_deletion_time();
+    }
+
+    if from.min_ttl != i32::MAX {
+        into.update_ttl(from.min_ttl);
+    }
+    into.update_ttl(from.max_ttl);
+
+    if from.has_partition_level_deletions {
+        into.mark_partition_level_deletion();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::write_engine::mutation::{
+        ClusteringBound, ClusteringKey, PartitionKey, PartitionTombstone, RangeTombstone, TableId,
+    };
+    use crate::types::Value;
+
+    fn table() -> TableId {
+        TableId::new("ks", "t")
+    }
+
+    fn pk() -> PartitionKey {
+        PartitionKey::single("id", Value::Integer(1))
+    }
+
+    fn ck(n: i32) -> ClusteringKey {
+        ClusteringKey::single("ck", Value::Integer(n))
+    }
+
+    /// A representative set of mutations exercising every branch
+    /// `fold_mutation_stats` handles: a partition tombstone, a range
+    /// tombstone, a decoupled row tombstone, a TTL write, a `ComplexDeletion`
+    /// marker, both a deleted and a LIVE `WriteComplexElement`, a plain live
+    /// `Write` (which lifts the live-LDT sentinel), and a null `Write` (which
+    /// must NOT).
+    fn representative_mutations() -> Vec<Mutation> {
+        let mut partition_only = Mutation::new(table(), pk(), None, vec![], 500, None);
+        partition_only.partition_tombstone = Some(PartitionTombstone {
+            deletion_time: 100,
+            local_deletion_time: 1_000,
+        });
+
+        let mut range_only = Mutation::new(table(), pk(), None, vec![], 500, None);
+        range_only.range_tombstones.push(RangeTombstone {
+            start: ClusteringBound::Inclusive(ck(1)),
+            end: ClusteringBound::Inclusive(ck(3)),
+            deletion_time: 200,
+            local_deletion_time: 2_000,
+        });
+
+        let row_tombstone_row = Mutation::new(table(), pk(), Some(ck(1)), vec![], 300, None)
+            .with_row_tombstone(50, 3_000);
+
+        let ttl_row = Mutation::new(
+            table(),
+            pk(),
+            Some(ck(2)),
+            vec![CellOperation::WriteWithTtl {
+                column: "v".to_string(),
+                value: Value::Text("x".to_string()),
+                ttl_seconds: 60,
+                local_deletion_time: Some(4_000),
+            }],
+            400,
+            Some(60),
+        );
+
+        let complex_deletion_row = Mutation::new(
+            table(),
+            pk(),
+            Some(ck(3)),
+            vec![CellOperation::ComplexDeletion {
+                column: "tags".to_string(),
+                marked_for_delete_at: 9_000_000,
+                local_deletion_time: 5_000,
+            }],
+            600,
+            None,
+        );
+
+        let complex_element_row = Mutation::new(
+            table(),
+            pk(),
+            Some(ck(4)),
+            vec![
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: b"a".to_vec(),
+                    value: None,
+                    timestamp_micros: 700,
+                    ttl_seconds: None,
+                    local_deletion_time: Some(6_000),
+                    is_deleted: true,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: b"b".to_vec(),
+                    value: Some(Value::Text("b".to_string())),
+                    timestamp_micros: 750,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+            ],
+            700,
+            None,
+        );
+
+        let live_write_row = Mutation::new(
+            table(),
+            pk(),
+            Some(ck(5)),
+            vec![CellOperation::Write {
+                column: "v".to_string(),
+                value: Value::Text("live".to_string()),
+            }],
+            800,
+            None,
+        );
+
+        let null_write_row = Mutation::new(
+            table(),
+            pk(),
+            Some(ck(6)),
+            vec![CellOperation::Write {
+                column: "v".to_string(),
+                value: Value::Null,
+            }],
+            900,
+            None,
+        );
+
+        vec![
+            partition_only,
+            range_only,
+            row_tombstone_row,
+            ttl_row,
+            complex_deletion_row,
+            complex_element_row,
+            live_write_row,
+            null_write_row,
+        ]
+    }
+
+    /// The relevant `StatisticsMetadata` fields `fold_mutation_stats`/
+    /// `merge_stats_fold` actually touch, for equivalence comparison (no
+    /// `PartialEq` on the full struct — the histogram/key-range/repair fields
+    /// are untouched by this fold and irrelevant here).
+    #[derive(Debug, PartialEq)]
+    struct FoldSnapshot {
+        min_timestamp: i64,
+        max_timestamp: i64,
+        min_local_deletion_time: i32,
+        max_local_deletion_time: i32,
+        min_ttl: i32,
+        max_ttl: i32,
+        has_partition_level_deletions: bool,
+    }
+
+    impl From<&StatisticsMetadata> for FoldSnapshot {
+        fn from(s: &StatisticsMetadata) -> Self {
+            Self {
+                min_timestamp: s.min_timestamp,
+                max_timestamp: s.max_timestamp,
+                min_local_deletion_time: s.min_local_deletion_time,
+                max_local_deletion_time: s.max_local_deletion_time,
+                min_ttl: s.min_ttl,
+                max_ttl: s.max_ttl,
+                has_partition_level_deletions: s.has_partition_level_deletions,
+            }
+        }
+    }
+
+    /// Correctness proof (issue #1668 stage 5c-iv part 2): folding every
+    /// mutation of a partition DIRECTLY into one accumulator (what
+    /// `write_partition` does — the old behavior) must produce the IDENTICAL
+    /// final min/max/flag aggregates as the incremental path's split —
+    /// folding disjoint SUBSETS of the same mutations into SEPARATE
+    /// partition-scoped accumulators (simulating streaming them across
+    /// several `feed_row`/`feed_static_row` calls) and then merging those
+    /// sub-folds back together via `merge_stats_fold` (simulating
+    /// `complete_partition_incremental`).
+    #[test]
+    fn split_and_merge_matches_direct_fold_for_every_mutation_kind() {
+        let mutations = representative_mutations();
+
+        // "write_partition"-equivalent: fold every mutation directly into one
+        // running accumulator.
+        let mut direct = StatisticsMetadata::new();
+        for m in &mutations {
+            fold_mutation_stats(&mut direct, m);
+        }
+
+        // Incremental-equivalent: split into three arbitrary, non-trivial
+        // partition-scoped sub-folds (as if fed across three separate
+        // `feed_row`/`feed_static_row` calls before merging at partition
+        // end), then merge them all into a fresh running accumulator.
+        let mut part_a = StatisticsMetadata::new();
+        let mut part_b = StatisticsMetadata::new();
+        let mut part_c = StatisticsMetadata::new();
+        for (i, m) in mutations.iter().enumerate() {
+            match i % 3 {
+                0 => fold_mutation_stats(&mut part_a, m),
+                1 => fold_mutation_stats(&mut part_b, m),
+                _ => fold_mutation_stats(&mut part_c, m),
+            }
+        }
+        let mut merged = StatisticsMetadata::new();
+        merge_stats_fold(&mut merged, &part_a);
+        merge_stats_fold(&mut merged, &part_b);
+        merge_stats_fold(&mut merged, &part_c);
+
+        assert_eq!(
+            FoldSnapshot::from(&direct),
+            FoldSnapshot::from(&merged),
+            "splitting the fold across partition-scoped sub-accumulators and \
+             merging must reproduce write_partition's direct fold exactly"
+        );
+
+        // Sanity: the live sentinel and partition-deletion flag must actually
+        // have been exercised by this fixture, else the equality above would
+        // pass vacuously without proving the sentinel-handling guards work.
+        assert_eq!(
+            direct.max_local_deletion_time,
+            i32::MAX,
+            "live_write_row must have lifted the live-LDT sentinel"
+        );
+        assert!(
+            direct.has_partition_level_deletions,
+            "partition_only must have set the partition-level-deletion flag"
+        );
+    }
+
+    /// Guard: an EMPTY partition-scoped sub-fold (a partition with no
+    /// tombstones/TTLs/live cells reaching this fold at all) must merge as a
+    /// true no-op — proving the untouched-default-sentinel guards in
+    /// `merge_stats_fold` (`max_local_deletion_time > i32::MIN`, `min_ttl !=
+    /// i32::MAX`) actually prevent corruption, not just coincidentally pass
+    /// on the representative fixture above.
+    #[test]
+    fn merging_an_empty_sub_fold_is_a_no_op() {
+        let mut into = StatisticsMetadata::new();
+        fold_mutation_stats(
+            &mut into,
+            &Mutation::new(
+                table(),
+                pk(),
+                Some(ck(1)),
+                vec![CellOperation::WriteWithTtl {
+                    column: "v".to_string(),
+                    value: Value::Text("x".to_string()),
+                    ttl_seconds: 60,
+                    local_deletion_time: Some(1_000),
+                }],
+                100,
+                Some(60),
+            ),
+        );
+        let before = FoldSnapshot::from(&into);
+
+        let empty = StatisticsMetadata::new();
+        merge_stats_fold(&mut into, &empty);
+
+        assert_eq!(
+            FoldSnapshot::from(&into),
+            before,
+            "merging a never-folded (default) StatisticsMetadata must not \
+             change min_local_deletion_time to i32::MIN or max_ttl to i32::MAX"
+        );
+    }
+}

--- a/cqlite-core/src/storage/sstable/writer/stats_writer/metadata.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer/metadata.rs
@@ -670,4 +670,121 @@ mod tests {
         assert_eq!(pt0, 1_700_000_000.0f64);
         assert_eq!(v0, 2);
     }
+
+    // -----------------------------------------------------------------------
+    // Issue #1668 stage 5a: prove the per-mutation stats fold is associative /
+    // order-independent, so `write_partition`'s baseline computation does NOT
+    // require the whole partition's `Vec<Mutation>` at once once baselines are
+    // pre-seeded (issue #729) — it can be fed incrementally, one row at a
+    // time, across any grouping or ordering of the SAME underlying values.
+    // -----------------------------------------------------------------------
+
+    /// `update_timestamp`/`update_local_deletion_time`/`update_ttl` are pure
+    /// min/max folds (see their doc comments): feeding the SAME set of values
+    /// in a DIFFERENT order (or split across many separate "calls" instead of
+    /// one batch) must produce an IDENTICAL final `min_timestamp` /
+    /// `max_timestamp` / `min_local_deletion_time` / `max_local_deletion_time`
+    /// / `min_ttl` / `max_ttl`. This is the concrete proof (not just a code
+    /// read) that a caller can stream rows into these folds one at a time
+    /// instead of pre-collecting a whole `Vec<Mutation>` first.
+    #[test]
+    fn stats_fold_is_order_independent_issue_1668_stage_5a() {
+        // A representative fixture: several distinct timestamps, local
+        // deletion times, and TTLs, INCLUDING the LIVE sentinels that must be
+        // filtered identically regardless of order (issue #851).
+        let timestamps = [
+            500_000i64,
+            2_000_000,
+            1_000_000,
+            i64::MIN,
+            i64::MAX,
+            750_000,
+        ];
+        let ldts = [1_700_000_000i32, 1_650_000_000, 1_690_000_000, i32::MAX];
+        let ttls = [3600i32, 60, 86400, 0, -1];
+
+        // Batch order A: as declared above (mirrors `write_partition`'s
+        // single forward `for mutation in &mutations` pass).
+        let mut batch_a = StatisticsMetadata::new();
+        for &ts in &timestamps {
+            batch_a.update_timestamp(ts);
+        }
+        for &ldt in &ldts {
+            batch_a.update_local_deletion_time(ldt);
+        }
+        for &ttl in &ttls {
+            batch_a.update_ttl(ttl);
+        }
+
+        // Batch order B: REVERSED and INTERLEAVED — simulates rows arriving
+        // one cluster group at a time, in a different relative order, across
+        // (hypothetically) multiple incremental calls.
+        let mut batch_b = StatisticsMetadata::new();
+        for &ttl in ttls.iter().rev() {
+            batch_b.update_ttl(ttl);
+        }
+        for &ts in timestamps.iter().rev() {
+            batch_b.update_timestamp(ts);
+        }
+        for &ldt in ldts.iter().rev() {
+            batch_b.update_local_deletion_time(ldt);
+        }
+
+        // Batch order C: fully interleaved, one value of EACH kind per
+        // "cluster group" — the closest analogue to a genuine per-row stream.
+        let mut batch_c = StatisticsMetadata::new();
+        let n = timestamps.len().max(ldts.len()).max(ttls.len());
+        for i in 0..n {
+            if let Some(&ts) = timestamps.get(i) {
+                batch_c.update_timestamp(ts);
+            }
+            if let Some(&ldt) = ldts.get(i) {
+                batch_c.update_local_deletion_time(ldt);
+            }
+            if let Some(&ttl) = ttls.get(i) {
+                batch_c.update_ttl(ttl);
+            }
+        }
+
+        for (name, batch) in [("B (reversed)", &batch_b), ("C (interleaved)", &batch_c)] {
+            assert_eq!(
+                batch.min_timestamp, batch_a.min_timestamp,
+                "min_timestamp diverged for order {name}"
+            );
+            assert_eq!(
+                batch.max_timestamp, batch_a.max_timestamp,
+                "max_timestamp diverged for order {name}"
+            );
+            assert_eq!(
+                batch.min_local_deletion_time, batch_a.min_local_deletion_time,
+                "min_local_deletion_time diverged for order {name}"
+            );
+            assert_eq!(
+                batch.max_local_deletion_time, batch_a.max_local_deletion_time,
+                "max_local_deletion_time diverged for order {name}"
+            );
+            assert_eq!(
+                batch.min_ttl, batch_a.min_ttl,
+                "min_ttl diverged for order {name}"
+            );
+            assert_eq!(
+                batch.max_ttl, batch_a.max_ttl,
+                "max_ttl diverged for order {name}"
+            );
+            assert_eq!(
+                batch.tombstone_histogram.size(),
+                batch_a.tombstone_histogram.size(),
+                "tombstone_histogram bin count diverged for order {name}"
+            );
+        }
+
+        // Sanity: the LIVE sentinels were actually exercised and correctly
+        // excluded (issue #851) — the real values, not the sentinels, won.
+        assert_eq!(batch_a.min_timestamp, 500_000);
+        assert_eq!(batch_a.max_timestamp, 2_000_000);
+        assert_eq!(batch_a.min_local_deletion_time, 1_650_000_000);
+        assert_eq!(batch_a.max_local_deletion_time, 1_700_000_000);
+        assert_eq!(batch_a.min_ttl, 60);
+        assert_eq!(batch_a.max_ttl, 86_400);
+    }
 }

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -310,6 +310,8 @@ impl WriteEngine {
             started_at: Instant::now(),
             effective_schema,
             dropped_whole,
+            // Stage 4 (#1668): no partition is mid-drain when a merge starts.
+            pending_partition: None,
         });
 
         Ok(())

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -329,11 +329,34 @@ impl WriteEngine {
                 break;
             }
 
-            // Process one partition from the merge
-            let step = merge.merger.step()?;
+            // Process one partition from the merge.
+            //
+            // Stage 3b (#1668): drain ONE full partition via the streaming
+            // increment API (`StreamingMerger`/`StreamingStep`) instead of
+            // calling the whole-partition `step()` directly. `step_streaming`
+            // still calls the UNCHANGED `step()` internally and drains its
+            // already-reconciled `Vec<MergeEntry>` one row at a time — proven
+            // byte-identical to `step()`'s own output by the stage-2/3a
+            // equivalence tests — so this does NOT change the outer budget
+            // check's granularity (still exactly one partition per outer-loop
+            // iteration; a mid-partition budget check is stage 4's job) and
+            // does NOT yet reduce peak memory (stage 5's job). It proves the
+            // incremental-consumption plumbing composes end-to-end with the
+            // writer.
+            let mut stream = merge::StreamingMerger::new(&mut merge.merger);
+            let mut pending_rows: Vec<merge::MergeEntry> = Vec::new();
+            let partition = loop {
+                match stream.step_streaming()? {
+                    merge::StreamingStep::ClusterGroup { row, .. } => pending_rows.push(*row),
+                    merge::StreamingStep::PartitionEnd { key } => {
+                        break Some((key, std::mem::take(&mut pending_rows)));
+                    }
+                    merge::StreamingStep::Complete => break None,
+                }
+            };
 
-            match step {
-                merge::MergeStep::Partition { key, rows } => {
+            match partition {
+                Some((key, rows)) => {
                     partitions_processed += 1;
 
                     // Convert MergeEntry rows to Mutation format
@@ -404,7 +427,7 @@ impl WriteEngine {
                     // Update stats
                     report.rows_merged += row_count;
                 }
-                merge::MergeStep::Complete => {
+                None => {
                     // Merge is complete - finalize and clean up
                     // Use blocking call to handle async finalization
                     self.finalize_merge_blocking(&mut report)?;

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -616,6 +616,15 @@ impl WriteEngine {
                         let is_static_carrier =
                             mutation.clustering_key.is_none() && schema_has_static;
 
+                        // Roborev blocker #2 (issue #1668): `row_count` must
+                        // ONLY be incremented for the resolved static-row
+                        // carrier, exactly mirroring `KWayMerger::merge`'s
+                        // reference implementation (`merge/mod.rs`, ~lines
+                        // 2329-2367) — a pure partition- or range-tombstone
+                        // carrier emits a marker/header deletion, not a row,
+                        // so it must NOT inflate `row_count` (which flows
+                        // into `merge.rows_merged`/`report.rows_merged`/the
+                        // `COMPACTION_ROWS_MERGED` counter).
                         if is_partition_only || is_range_only || is_static_carrier {
                             if let PartitionStreamState::Prefix {
                                 partition_tombstone,
@@ -637,9 +646,9 @@ impl WriteEngine {
                                         *static_first_ts = mutation.timestamp_micros;
                                     }
                                     static_tracker.feed(&mutation, &write_schema, None);
+                                    *row_count += 1;
                                 }
                                 *saw_carrier_or_static = true;
-                                *row_count += 1;
                             }
                             continue;
                         }
@@ -1062,6 +1071,158 @@ mod tests {
         assert_eq!(report.completed_merges.len(), 0);
         assert!(!report.pending_compaction);
         assert!(report.time_spent < Duration::from_millis(50));
+    }
+
+    /// Roborev blocker #2 (issue #1668): `PartitionStreamState::Prefix`'s
+    /// carrier-classification block must NOT count a pure partition-
+    /// tombstone carrier toward `row_count` — mirroring
+    /// `KWayMerger::merge`'s reference implementation exactly (only the
+    /// resolved static-row carrier increments it). Before the fix, EVERY
+    /// carrier classification (partition-only, range-only, static)
+    /// incremented `row_count`, inflating `report.rows_merged` (and the
+    /// `COMPACTION_ROWS_MERGED` observability counter) whenever a
+    /// partition's carrier prefix included a pure tombstone.
+    ///
+    /// Fixture: one partition (`id = 1`) with a CLUSTERED schema (so a
+    /// `clustering_key: None` carrier always sorts strictly before every
+    /// `Some(ck)` row — `SchemaOrderedEntry`'s `(None, Some(_)) =>
+    /// Ordering::Less`, unconditional on `run_index` — unlike an unclustered
+    /// table where a real row ALSO carries `clustering_key: None` and could
+    /// race the carrier on a `run_index` tie-break). Source 1 carries the
+    /// partition tombstone alongside one real row (`ck=0`, postdating the
+    /// tombstone, so it is NOT itself shadowed — this keeps source 1 non-
+    /// empty, avoiding any confound from a truly zero-row source); source 2
+    /// carries a second real row (`ck=1`, also postdating the tombstone).
+    /// Compacting the two must merge to exactly 2 counted rows — the
+    /// re-emitted tombstone carrier is a marker/header deletion, not a row.
+    #[test]
+    fn test_maintenance_step_does_not_count_partition_tombstone_carrier_as_a_row() {
+        use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
+        use crate::storage::write_engine::mutation::{
+            CellOperation, ClusteringKey, PartitionKey, PartitionTombstone, TableId,
+        };
+        use crate::types::Value;
+
+        let temp_dir = TempDir::new().unwrap();
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: ClusteringOrder::Asc,
+            }],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "ck".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
+        };
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let table_id = TableId::new(&schema.keyspace, &schema.table);
+        let pk = PartitionKey::single("id", Value::Integer(1));
+        let row_mutation = |ck: i32, ts: i64| {
+            Mutation::new(
+                table_id.clone(),
+                pk.clone(),
+                Some(ClusteringKey::single("ck", Value::Integer(ck))),
+                vec![CellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text(format!("row-{ck}")),
+                }],
+                ts,
+                None,
+            )
+        };
+
+        // `local_deletion_time` must be a REALISTIC (near-"now") GC-clock
+        // timestamp, not a tiny literal — otherwise this full/overlap-safe
+        // 2-source compaction correctly gc-grace-purges the tombstone
+        // outright (it would be`local_deletion_time < gc_before`, decades
+        // expired), never reaching the row-count classification this test
+        // targets at all.
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i32;
+
+        // Source 1: the partition tombstone (deletion_time=100) alongside
+        // ck=0 (ts=5_000, postdates the tombstone — survives).
+        let mut ck0_with_tombstone = row_mutation(0, 5_000);
+        ck0_with_tombstone.partition_tombstone = Some(PartitionTombstone {
+            deletion_time: 100,
+            local_deletion_time: now_secs,
+        });
+        engine.write(ck0_with_tombstone).unwrap();
+        rt.block_on(engine.flush()).unwrap().unwrap();
+
+        // Source 2: ck=1 (ts=6_000, also postdates the tombstone — survives).
+        engine.write(row_mutation(1, 6_000)).unwrap();
+        rt.block_on(engine.flush()).unwrap().unwrap();
+
+        // `min_sstable_size` large enough that both tiny files count as
+        // "small" and bucket together regardless of their size ratio.
+        let policy =
+            crate::storage::write_engine::STCSPolicy::new(2, 32, 0.5, 1.5, 1024 * 1024).unwrap();
+        engine.set_merge_policy(Box::new(policy)).unwrap();
+
+        // `MaintenanceReport::rows_merged` is per-CALL, not cumulative
+        // (`test_maintenance_paused_and_unpaused_compaction_produce_byte_identical_output`'s
+        // `total_rows_merged` pattern above) — a merge can finish its own
+        // work in one call yet still report `pending_compaction: true` for
+        // an unrelated reason, so sum across every call rather than trusting
+        // only the last one.
+        let mut report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+        let mut total_rows_merged = report.rows_merged;
+        let mut calls = 1u32;
+        while report.pending_compaction {
+            report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+            total_rows_merged += report.rows_merged;
+            calls += 1;
+            assert!(calls < 100_000, "compaction never completed");
+        }
+
+        assert_eq!(
+            total_rows_merged, 2,
+            "only the 2 real surviving rows (ck=0, ck=1) must be counted — \
+             the re-emitted partition-tombstone carrier is a marker, not a row"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -7,14 +7,134 @@
 //! fields are reachable here because this is a sibling module in the same crate.
 
 use super::merge;
-use super::mutation::{DecoratedKey, Mutation};
+use super::mutation::{DecoratedKey, PartitionTombstone, RangeTombstone};
+// `Mutation` itself is no longer named directly outside tests (issue #1668
+// stage 5c-iv part 3 removed the `Vec<Mutation>` accumulator this file used
+// to build) — only `mod tests` (`use super::*`) still constructs one
+// directly, so this import is test-only to avoid an unused-import error in
+// the non-test build.
+#[cfg(test)]
+use super::mutation::Mutation;
 use super::{CompactionStats, KWayMerger, MergePolicy, WriteEngine};
 use crate::error::{Error, Result};
 use crate::schema::TableSchema;
+use crate::storage::sstable::writer::data_writer::{StaticOpsTracker, StreamingPartitionSession};
+use crate::storage::sstable::writer::stats_fold;
+use crate::storage::sstable::writer::StatisticsMetadata;
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
+
+/// Per-partition streaming state (issue #1668, stage 5c-iv part 3) — mirrors
+/// `KWayMerger::merge()`'s per-partition state machine (stage 5c-iv part 2):
+/// a bounded `clustering_key: None` prefix (partition/range-tombstone
+/// carriers, static-row carrier) resolves first; a
+/// [`StreamingPartitionSession`] opens only once the first `Some(ck)` row (or
+/// an unclustered table's sole row) arrives, since only then do we have
+/// everything `begin_streaming_partition` needs upfront (the partition
+/// tombstone and range-tombstone list). Because `StreamingPartitionSession`
+/// owns everything it needs (no lifetime — issue #1668 stage 5c-iv part 3's
+/// whole reason for existing over `IncrementalPartitionWriter`), EITHER
+/// variant can be stashed on [`ActiveMerge::pending_partition`] and survive
+/// returning to the maintenance scheduler between `maintenance_step_inner`
+/// calls: resuming is just "keep calling methods on it," never a
+/// capture/reconstitute conversion.
+pub(crate) enum PartitionStreamState {
+    /// Still resolving the bounded prefix — no on-disk partition exists yet
+    /// (no header has been written), so there is nothing to pause beyond
+    /// these plain owned accumulators.
+    Prefix {
+        partition_tombstone: Option<PartitionTombstone>,
+        range_tombstones: Vec<RangeTombstone>,
+        static_tracker: StaticOpsTracker,
+        static_first_ts: i64,
+        saw_carrier_or_static: bool,
+        /// This partition's stats fold accumulated so far — see the
+        /// `Streaming` variant's field of the same name for why this is
+        /// threaded through the state rather than folded straight into the
+        /// writer's own `stats`.
+        partition_stats: StatisticsMetadata,
+        /// Mirrors `KWayMerger::merge()`'s loop-local `row_count`: one static
+        /// carrier mutation increments this by 1 EACH time (not once per
+        /// merged output row — issue #1668 stage 5c-iv part 2's row-count
+        /// parity finding), carried forward into `Streaming::row_count` once
+        /// the first `Some(ck)` row opens the session.
+        row_count: u64,
+    },
+    /// A real on-disk partition is open (header + any rows fed so far are
+    /// already in the writer's buffer) and must be finished — via
+    /// `finish_streaming_partition` + `complete_partition_incremental` —
+    /// before anything else can happen to this partition.
+    Streaming {
+        session: StreamingPartitionSession,
+        /// This partition's stats fold accumulated so far (mirrors
+        /// `KWayMerger::merge()`'s `partition_stats` — the writer's `stats`
+        /// field cannot be folded into directly while a session that
+        /// borrows `self.data_writer` per-call is open across calls, so it
+        /// is threaded alongside the session instead).
+        partition_stats: StatisticsMetadata,
+        row_count: u64,
+        partition_tombstone: Option<PartitionTombstone>,
+    },
+}
+
+impl PartitionStreamState {
+    /// A fresh, empty prefix accumulator — the starting state for any new
+    /// partition (never resumed from a pause).
+    fn fresh() -> Self {
+        PartitionStreamState::Prefix {
+            partition_tombstone: None,
+            range_tombstones: Vec::new(),
+            static_tracker: StaticOpsTracker::new(),
+            static_first_ts: 0,
+            saw_carrier_or_static: false,
+            partition_stats: StatisticsMetadata::new(),
+            row_count: 0,
+        }
+    }
+
+    /// This partition's stats-fold accumulator, regardless of which variant
+    /// is currently active — every mutation (carrier, static, or clustering
+    /// row) folds through the SAME chokepoint before classification, mirroring
+    /// `KWayMerger::merge()`'s single fold point (issue #1668 stage 5c-iv
+    /// part 2).
+    fn partition_stats_mut(&mut self) -> &mut StatisticsMetadata {
+        match self {
+            PartitionStreamState::Prefix {
+                partition_stats, ..
+            } => partition_stats,
+            PartitionStreamState::Streaming {
+                partition_stats, ..
+            } => partition_stats,
+        }
+    }
+}
+
+// `StaticOpsTracker`/`StreamingPartitionSession` do not implement `Debug`
+// (the former holds a non-`Debug` cell-value map; the latter is a plain
+// bookkeeping struct never printed in production), so `ActiveMerge`'s
+// `#[derive(Debug)]` (used only incidentally — no code actually formats an
+// `ActiveMerge`, confirmed by grep) needs a hand-written `Debug` for this
+// enum rather than pulling `Debug` onto either of those types just to
+// satisfy a derive nothing exercises.
+impl std::fmt::Debug for PartitionStreamState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PartitionStreamState::Prefix {
+                saw_carrier_or_static,
+                ..
+            } => f
+                .debug_struct("PartitionStreamState::Prefix")
+                .field("saw_carrier_or_static", saw_carrier_or_static)
+                .finish_non_exhaustive(),
+            PartitionStreamState::Streaming { row_count, .. } => f
+                .debug_struct("PartitionStreamState::Streaming")
+                .field("row_count", row_count)
+                .finish_non_exhaustive(),
+        }
+    }
+}
 
 /// Maintenance report from a maintenance_step() call (M5.2, Issue #384)
 #[derive(Debug, Clone)]
@@ -96,14 +216,22 @@ pub(crate) struct ActiveMerge {
     ///   (extracted via `StreamingMerger::into_paused_state`, restored via
     ///   `StreamingMerger::resume`) — nothing here is re-computed by a
     ///   resumed call, and nothing is lost.
-    /// - `.2` `Mutation`s already converted from EARLIER-popped rows of the
-    ///   same partition (in this or a PRIOR `maintenance_step` call),
-    ///   waiting for the partition to fully drain so `write_partition` can
-    ///   still be called ONCE with the complete set — the writer still
-    ///   receives one partition in one call; output stays byte-identical,
-    ///   only the WALL-CLOCK SCHEDULING of the conversion work changes.
-    pub(crate) pending_partition:
-        Option<(DecoratedKey, VecDeque<merge::MergeEntry>, Vec<Mutation>)>,
+    /// - `.2` this partition's [`PartitionStreamState`] (issue #1668, stage
+    ///   5c-iv part 3): either still resolving the bounded carrier/static
+    ///   prefix, or an already-open `StreamingPartitionSession` with rows
+    ///   fed so far. Fed incrementally as cluster groups arrive — the
+    ///   writer no longer waits for the whole partition to accumulate as a
+    ///   `Vec<Mutation>` before writing anything (that was stage 5c-iv part
+    ///   2's change for `KWayMerger::merge`; this is the same change for the
+    ///   background maintenance loop). Resuming a paused partition is just
+    ///   "keep feeding this same value" — no re-computation, no lost rows,
+    ///   and (unlike the pre-stage-5c-iv-part-3 `Vec<Mutation>` design) no
+    ///   growing in-memory buffer for a wide partition either.
+    pub(crate) pending_partition: Option<(
+        DecoratedKey,
+        VecDeque<merge::MergeEntry>,
+        PartitionStreamState,
+    )>,
 }
 
 impl WriteEngine {
@@ -355,27 +483,32 @@ impl WriteEngine {
 
         // Process active merge within budget.
         //
-        // Stage 4 (#1668, the "Q4 unlock"): the budget is now checked BETWEEN
-        // CLUSTER GROUPS, not only between whole partitions. A partition too
-        // fat to finish within one call's remaining budget is no longer
-        // forced to run to completion: its accumulated-so-far converted
-        // `Mutation`s (plus the not-yet-popped raw rows `step()` already
-        // reconciled) are stashed on `ActiveMerge.pending_partition` and
-        // RESUMED on the NEXT `maintenance_step` call via
-        // `StreamingMerger::resume` — nothing is re-computed, nothing is
-        // lost, and the writer still receives the whole partition's
-        // mutations in ONE `write_partition` call once fully drained, so
+        // Stage 4 (#1668, the "Q4 unlock"): the budget is checked BETWEEN
+        // CLUSTER GROUPS, not only between whole partitions. Stage 5c-iv part
+        // 3 changed WHAT gets stashed when a partition is too fat to finish
+        // within one call's remaining budget: instead of accumulating a
+        // growing `Vec<Mutation>` (the whole-partition buffering this issue
+        // exists to eliminate), each cluster group now streams straight into
+        // a `StreamingPartitionSession` as it arrives (mirroring
+        // `KWayMerger::merge`'s stage 5c-iv part 2 change), and the SESSION
+        // ITSELF — which owns everything it needs, no lifetime — is what
+        // gets stashed on `ActiveMerge.pending_partition` and resumed
+        // unchanged on the NEXT `maintenance_step` call. Nothing is
+        // re-computed, nothing is lost, and the writer still receives one
+        // partition as one on-disk unit (opened once, finished once), so
         // output stays byte-identical (see `#921`). The minimum-progress
-        // guarantee is now "at least one cluster group per call" (was "at
-        // least one partition per call").
+        // guarantee remains "at least one cluster group per call."
         let budget_tolerance = budget.mul_f32(1.1); // 10% tolerance
         let mut partitions_processed = 0u64;
 
         /// Outcome of draining one partition's cluster groups, bounded by
         /// the mid-partition budget check.
         enum DrainOutcome {
-            /// The partition fully drained; write it.
-            Ready(DecoratedKey, Vec<Mutation>),
+            /// The partition fully drained; finalize whatever
+            /// `PartitionStreamState` it ended in. Boxed: `Streaming` embeds
+            /// a `StreamingPartitionSession` (clippy::large_enum_variant) —
+            /// boxing keeps `DrainOutcome` itself cheap to move regardless.
+            Ready(DecoratedKey, Box<PartitionStreamState>),
             /// Budget exceeded mid-drain; progress was stashed on
             /// `ActiveMerge.pending_partition` for the next call.
             Paused,
@@ -386,28 +519,42 @@ impl WriteEngine {
         while let Some(merge) = &mut self.active_merge {
             // Resume a partition paused by a PRIOR call's budget check, if
             // any (issue #1668, stage 4). `raw_remaining` are rows `step()`
-            // already reconciled but not yet popped; `mutations_acc` are
-            // rows from EARLIER in this same partition already converted.
-            let (resume_state, mut mutations_acc): (
+            // already reconciled but not yet popped; `stream_state` is this
+            // partition's `PartitionStreamState` from EARLIER in this same
+            // partition (this or a prior call) — possibly still resolving
+            // the carrier/static prefix, or an already-open session with
+            // rows fed so far.
+            let (resume_state, mut stream_state): (
                 Option<(DecoratedKey, VecDeque<merge::MergeEntry>)>,
-                Vec<Mutation>,
+                PartitionStreamState,
             ) = match merge.pending_partition.take() {
-                Some((key, rows, muts)) => (Some((key, rows)), muts),
-                None => (None, Vec::new()),
+                Some((key, rows, state)) => (Some((key, rows)), state),
+                None => (None, PartitionStreamState::fresh()),
             };
 
-            // #850: convert with the effective compaction schema so any
-            // static column re-added from the input headers is preserved.
-            // Cloned ONCE here (before `stream` borrows `merge.merger`) so
-            // per-row conversion below never needs to borrow `self`/`merge`
-            // while that borrow is alive.
-            let conversion_schema = merge.effective_schema.clone();
+            // #850: convert with the effective compaction schema (DECODE
+            // time — needed to identify/purge-evaluate a dropped column's
+            // cells) so any static column re-added from the input headers is
+            // preserved. Cloned ONCE here (before `stream` borrows
+            // `merge.merger`) so per-row conversion below never needs to
+            // borrow `self`/`merge` while that borrow is alive.
+            let decode_schema = merge.effective_schema.clone();
+            // ENCODE time: the writer's OWN schema (dropped columns already
+            // stripped, if this compaction drops any) — required by every
+            // `begin_streaming_partition`/`feed_streaming_row`/
+            // `feed_streaming_static_row` call. Using `decode_schema` here
+            // instead would repeat the exact #1019 regression
+            // `KWayMerger::merge` hit in stage 5c-iv part 2 (a header/row
+            // encoding mismatch that silently produced zero readable rows) —
+            // see that stage's fix for the full incident writeup.
+            let write_schema = merge.writer.schema().clone();
+            let schema_has_static = write_schema.columns.iter().any(|c| c.is_static);
             let mut stream = merge::StreamingMerger::resume(&mut merge.merger, resume_state);
             // True once THIS call has popped at least one cluster group —
             // guarantees forward progress within a call even when resuming
-            // an already-non-empty `mutations_acc` from a prior call (mirrors
-            // the pre-stage-4 "always process at least one partition" floor,
-            // now at cluster-group granularity).
+            // an already-in-progress `stream_state` from a prior call
+            // (mirrors the pre-stage-4 "always process at least one
+            // partition" floor, now at cluster-group granularity).
             let mut progressed_this_call = false;
 
             let outcome = loop {
@@ -417,72 +564,236 @@ impl WriteEngine {
                     break DrainOutcome::Paused;
                 }
                 match stream.step_streaming()? {
-                    merge::StreamingStep::ClusterGroup { row, .. } => {
+                    merge::StreamingStep::ClusterGroup { key, row } => {
                         progressed_this_call = true;
                         // Skip metadata-only entries (#886/#899 branch-review):
                         // they carry complex/range deletion metadata through
                         // the merge stream but have no writer-emittable
                         // content yet. See `MergeEntry::is_metadata_only_no_op`.
-                        if !row.is_metadata_only_no_op() {
-                            mutations_acc.push(merge::KWayMerger::merge_entry_to_mutation(
-                                *row,
-                                &conversion_schema,
-                            )?);
+                        if row.is_metadata_only_no_op() {
+                            continue;
                         }
+                        let mutation =
+                            merge::KWayMerger::merge_entry_to_mutation(*row, &decode_schema)?;
+                        // Single fold point for EVERY mutation of this
+                        // partition, mirroring `KWayMerger::merge`'s stage
+                        // 5c-iv part 2 design — folds unconditionally,
+                        // regardless of classification, before it happens.
+                        stats_fold::fold_mutation_stats(
+                            stream_state.partition_stats_mut(),
+                            &mutation,
+                        );
+
+                        if let PartitionStreamState::Streaming {
+                            session, row_count, ..
+                        } = &mut stream_state
+                        {
+                            merge.writer.feed_streaming_row(session, &mutation)?;
+                            *row_count += 1;
+                            continue;
+                        }
+
+                        // Still in the (bounded) None-keyed prefix.
+                        let is_partition_only = mutation.operations.is_empty()
+                            && mutation.partition_tombstone.is_some()
+                            && mutation.row_tombstone.is_none()
+                            && mutation.range_tombstones.is_empty();
+                        let is_range_only = mutation.operations.is_empty()
+                            && mutation.partition_tombstone.is_none()
+                            && mutation.row_tombstone.is_none()
+                            && !mutation.range_tombstones.is_empty();
+                        // A `clustering_key: None` mutation is the resolved
+                        // static-row carrier ONLY when the schema actually
+                        // declares static columns — see
+                        // `KWayMerger::merge`'s identical gate (issue #1668
+                        // stage 5c-iv part 2) for the unclustered-table
+                        // rationale.
+                        let is_static_carrier =
+                            mutation.clustering_key.is_none() && schema_has_static;
+
+                        if is_partition_only || is_range_only || is_static_carrier {
+                            if let PartitionStreamState::Prefix {
+                                partition_tombstone,
+                                range_tombstones,
+                                static_tracker,
+                                static_first_ts,
+                                saw_carrier_or_static,
+                                row_count,
+                                ..
+                            } = &mut stream_state
+                            {
+                                if is_partition_only {
+                                    *partition_tombstone = mutation.partition_tombstone;
+                                } else if is_range_only {
+                                    range_tombstones
+                                        .extend(mutation.range_tombstones.iter().cloned());
+                                } else {
+                                    if !*saw_carrier_or_static {
+                                        *static_first_ts = mutation.timestamp_micros;
+                                    }
+                                    static_tracker.feed(&mutation, &write_schema, None);
+                                }
+                                *saw_carrier_or_static = true;
+                                *row_count += 1;
+                            }
+                            continue;
+                        }
+
+                        // First Some(ck) row (or, for an unclustered table,
+                        // its sole `clustering_key: None` row): the prefix
+                        // is now COMPLETE. Take `stream_state` by value to
+                        // open the session and transition to `Streaming`.
+                        let prev =
+                            std::mem::replace(&mut stream_state, PartitionStreamState::fresh());
+                        let (
+                            partition_tombstone,
+                            range_tombstones,
+                            static_tracker,
+                            static_first_ts,
+                            partition_stats,
+                            mut row_count,
+                        ) = match prev {
+                            PartitionStreamState::Prefix {
+                                partition_tombstone,
+                                range_tombstones,
+                                static_tracker,
+                                static_first_ts,
+                                partition_stats,
+                                row_count,
+                                ..
+                            } => (
+                                partition_tombstone,
+                                range_tombstones,
+                                static_tracker,
+                                static_first_ts,
+                                partition_stats,
+                                row_count,
+                            ),
+                            // Provably unreachable — the `if let
+                            // PartitionStreamState::Streaming` guard above
+                            // already `continue`d whenever `stream_state` was
+                            // `Streaming`. Handled without panicking (no
+                            // unwrap/expect/unreachable!() in library code):
+                            // just restore it and skip this cluster group
+                            // rather than assert something the compiler
+                            // cannot itself prove impossible here.
+                            already_streaming @ PartitionStreamState::Streaming { .. } => {
+                                stream_state = already_streaming;
+                                continue;
+                            }
+                        };
+
+                        let mut session = merge.writer.begin_streaming_partition(
+                            &key,
+                            partition_tombstone.as_ref(),
+                            &range_tombstones,
+                        )?;
+                        if schema_has_static {
+                            let merged = static_tracker.finish();
+                            merge.writer.feed_streaming_static_row(
+                                &mut session,
+                                &merged,
+                                static_first_ts,
+                            )?;
+                        }
+                        merge.writer.feed_streaming_row(&mut session, &mutation)?;
+                        row_count += 1;
+                        stream_state = PartitionStreamState::Streaming {
+                            session,
+                            partition_stats,
+                            row_count,
+                            partition_tombstone,
+                        };
                     }
                     merge::StreamingStep::PartitionEnd { key } => {
-                        break DrainOutcome::Ready(key, std::mem::take(&mut mutations_acc));
+                        break DrainOutcome::Ready(
+                            key,
+                            Box::new(std::mem::replace(
+                                &mut stream_state,
+                                PartitionStreamState::fresh(),
+                            )),
+                        );
                     }
                     merge::StreamingStep::Complete => break DrainOutcome::MergeComplete,
                 }
             };
 
             match outcome {
-                DrainOutcome::Ready(key, mutations) => {
+                DrainOutcome::Ready(key, state) => {
                     partitions_processed += 1;
 
-                    // If every merged row was metadata-only, the partition has
-                    // no writer-emittable content. Skip `write_partition` to
-                    // avoid a phantom EMPTY partition (header/end marker +
-                    // Index/Filter/Summary/statistics registration) in the
-                    // output SSTable, and do not count it as an output
-                    // partition or row (#886 branch-review).
-                    if mutations.is_empty() {
-                        continue;
+                    match *state {
+                        PartitionStreamState::Streaming {
+                            session,
+                            partition_stats,
+                            row_count,
+                            partition_tombstone,
+                        } => {
+                            if let Some(merge) = &mut self.active_merge {
+                                let (offset, blocks, emit) =
+                                    merge.writer.finish_streaming_partition(session)?;
+                                merge.writer.complete_partition_incremental(
+                                    &key,
+                                    partition_tombstone.as_ref(),
+                                    offset,
+                                    &blocks,
+                                    emit,
+                                    &partition_stats,
+                                )?;
+                                merge.rows_merged += row_count;
+                            }
+                            report.rows_merged += row_count;
+                        }
+                        PartitionStreamState::Prefix {
+                            partition_tombstone,
+                            range_tombstones,
+                            static_tracker,
+                            static_first_ts,
+                            saw_carrier_or_static,
+                            partition_stats,
+                            row_count,
+                        } => {
+                            // Truly empty partition (every entry was
+                            // metadata-only-no-op) — skip entirely, matching
+                            // the original `mutations.is_empty()` skip
+                            // (#886 branch-review).
+                            if !saw_carrier_or_static {
+                                continue;
+                            }
+                            // No `Some(ck)` row ever arrived, but a
+                            // range/partition tombstone or a static value
+                            // survived — still emittable (#933/#1072),
+                            // matching `KWayMerger::merge`'s `None if
+                            // saw_carrier_or_static` branch exactly.
+                            if let Some(merge) = &mut self.active_merge {
+                                let mut session = merge.writer.begin_streaming_partition(
+                                    &key,
+                                    partition_tombstone.as_ref(),
+                                    &range_tombstones,
+                                )?;
+                                if schema_has_static {
+                                    let merged = static_tracker.finish();
+                                    merge.writer.feed_streaming_static_row(
+                                        &mut session,
+                                        &merged,
+                                        static_first_ts,
+                                    )?;
+                                }
+                                let (offset, blocks, emit) =
+                                    merge.writer.finish_streaming_partition(session)?;
+                                merge.writer.complete_partition_incremental(
+                                    &key,
+                                    partition_tombstone.as_ref(),
+                                    offset,
+                                    &blocks,
+                                    emit,
+                                    &partition_stats,
+                                )?;
+                                merge.rows_merged += row_count;
+                            }
+                            report.rows_merged += row_count;
+                        }
                     }
-
-                    // Count rows actually written (skipped metadata-only
-                    // entries produce no row, so they must not inflate the
-                    // stats). A pure range-tombstone carrier (#933) or a pure
-                    // partition-tombstone carrier (#1072) emits a marker /
-                    // partition-header deletion, not a row — exclude them,
-                    // matching KWayMerger::merge.
-                    let row_count = mutations
-                        .iter()
-                        .filter(|m| {
-                            let is_range_only = m.operations.is_empty()
-                                && m.partition_tombstone.is_none()
-                                && m.row_tombstone.is_none()
-                                && !m.range_tombstones.is_empty();
-                            let is_partition_only = m.operations.is_empty()
-                                && m.partition_tombstone.is_some()
-                                && m.row_tombstone.is_none()
-                                && m.range_tombstones.is_empty();
-                            !(is_range_only || is_partition_only)
-                        })
-                        .count() as u64;
-
-                    // Write partition to output SSTable. `stream` was already
-                    // fully drained (PartitionEnd), so its borrow of
-                    // `merge.merger` has ended by now (last use) and this
-                    // re-borrow via `self.active_merge` is conflict-free.
-                    if let Some(merge) = &mut self.active_merge {
-                        merge.writer.write_partition(key, mutations)?;
-                        merge.rows_merged += row_count;
-                    }
-
-                    // Update stats
-                    report.rows_merged += row_count;
                 }
                 DrainOutcome::Paused => {
                     // Stash progress for the NEXT maintenance_step call
@@ -493,7 +804,7 @@ impl WriteEngine {
                     // `stream`'s partition key) must be true to reach `Paused`.
                     if let Some((key, raw_remaining)) = stream.into_paused_state() {
                         if let Some(merge) = &mut self.active_merge {
-                            merge.pending_partition = Some((key, raw_remaining, mutations_acc));
+                            merge.pending_partition = Some((key, raw_remaining, stream_state));
                         }
                     }
                     break;
@@ -1371,6 +1682,150 @@ mod tests {
         assert_eq!(
             stats.sstables_merged_in, 2,
             "must have consumed both input SSTables"
+        );
+    }
+
+    /// Shared fixture for the byte-identity proof below: builds the SAME
+    /// 2-generation fat-partition fixture as
+    /// `test_maintenance_step_pauses_mid_partition_on_tiny_budget` (a fresh,
+    /// independent `WriteEngine`/temp dir each call — deterministic content,
+    /// so two calls produce byte-identical INPUT SSTables too), compacts it
+    /// under `budget`, and returns the produced output's raw Data.db bytes.
+    fn compact_fat_partition_fixture_with_budget(budget: Duration) -> Vec<u8> {
+        use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
+        use crate::storage::write_engine::mutation::{
+            CellOperation, ClusteringKey, PartitionKey, TableId,
+        };
+        use crate::types::Value;
+        use std::collections::HashMap;
+
+        let temp_dir = TempDir::new().unwrap();
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: ClusteringOrder::Asc,
+            }],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "ck".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        const ROWS_PER_FLUSH: i32 = 15;
+
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        for flush_idx in 0..2 {
+            for i in 0..ROWS_PER_FLUSH {
+                let ck = flush_idx * ROWS_PER_FLUSH + i;
+                let table_id = TableId::new("test_ks", "test_table");
+                let pk = PartitionKey::single("id", Value::Integer(1));
+                let ck_key = ClusteringKey::single("ck", Value::Integer(ck));
+                let ops = vec![CellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text(format!("row-{ck}")),
+                }];
+                let mutation = Mutation::new(
+                    table_id,
+                    pk,
+                    Some(ck_key),
+                    ops,
+                    1_000_000 + i64::from(ck),
+                    None,
+                );
+                engine.write(mutation).unwrap();
+            }
+            rt.block_on(engine.flush()).unwrap();
+        }
+
+        let policy = crate::storage::write_engine::STCSPolicy::new(2, 32, 0.5, 1.5, 0).unwrap();
+        engine.set_merge_policy(Box::new(policy)).unwrap();
+
+        let mut report = engine.maintenance_step(budget).unwrap();
+        let mut calls = 1u32;
+        while report.pending_compaction {
+            report = engine.maintenance_step(budget).unwrap();
+            calls += 1;
+            assert!(
+                calls < 100_000,
+                "compaction never completed — possible stall/starvation"
+            );
+        }
+        assert_eq!(
+            report.completed_merges.len(),
+            1,
+            "expected exactly one completed merge output"
+        );
+        std::fs::read(&report.completed_merges[0]).expect("read compacted Data.db")
+    }
+
+    /// Byte-identity proof (issue #1668, stage 5c-iv part 3): pausing and
+    /// resuming a partition's drain mid-stream — via
+    /// `StreamingPartitionSession` stashed on
+    /// `ActiveMerge::pending_partition` across many `maintenance_step`
+    /// calls, instead of the pre-stage-5c-iv-part-3 growing `Vec<Mutation>`
+    /// — must produce EXACTLY the same Data.db bytes as a single unbroken
+    /// drain. Same rigor as every `IncrementalPartitionWriter`/
+    /// `StreamingPartitionSession` byte-identity test in `data_writer/tests/`,
+    /// but exercised through the REAL production entry point
+    /// (`WriteEngine::maintenance_step`) rather than the session type
+    /// directly — proving the INTEGRATION (budget checks,
+    /// `PartitionStreamState` transitions, resume plumbing) introduces no
+    /// divergence of its own.
+    #[test]
+    fn test_maintenance_paused_and_unpaused_compaction_produce_byte_identical_output() {
+        // Generous budget: the fat partition drains in ONE
+        // `maintenance_step` call (no pause) — the unbroken-batch baseline.
+        let unpaused_bytes = compact_fat_partition_fixture_with_budget(Duration::from_secs(60));
+
+        // Near-zero budget: forces the SAME fat partition's drain to pause
+        // and resume across MANY `maintenance_step` calls (issue #1668 stage
+        // 4's mid-partition budget check).
+        let paused_bytes = compact_fat_partition_fixture_with_budget(Duration::from_nanos(1));
+
+        assert_eq!(
+            unpaused_bytes, paused_bytes,
+            "pausing and resuming mid-partition must produce byte-identical \
+             Data.db output to a single unbroken drain"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -7,9 +7,11 @@
 //! fields are reachable here because this is a sibling module in the same crate.
 
 use super::merge;
+use super::mutation::{DecoratedKey, Mutation};
 use super::{CompactionStats, KWayMerger, MergePolicy, WriteEngine};
 use crate::error::{Error, Result};
 use crate::schema::TableSchema;
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
@@ -79,6 +81,29 @@ pub(crate) struct ActiveMerge {
     /// component-delete path as the merged inputs, and surfaced in the
     /// `MaintenanceReport`. Empty when nothing was dropped.
     pub(crate) dropped_whole: Vec<PathBuf>,
+    /// Mid-partition budget-check resumption state (issue #1668, stage 4 —
+    /// the "Q4 unlock"). `Some((key, remaining_rows, mutations_so_far))` when
+    /// a partition's cluster-group drain was PAUSED because the budget was
+    /// exceeded before the whole partition could be converted+written;
+    /// `None` when no partition is mid-drain (the common case — and the
+    /// ONLY case before this stage, when only whole partitions were ever
+    /// paused between, never within one).
+    ///
+    /// - `.0` the partition key (needed both to resume draining and for the
+    ///   eventual `write_partition` call).
+    /// - `.1` rows `KWayMerger::step()` ALREADY fully reconciled for this
+    ///   partition but not yet POPPED off `StreamingMerger`'s queue
+    ///   (extracted via `StreamingMerger::into_paused_state`, restored via
+    ///   `StreamingMerger::resume`) — nothing here is re-computed by a
+    ///   resumed call, and nothing is lost.
+    /// - `.2` `Mutation`s already converted from EARLIER-popped rows of the
+    ///   same partition (in this or a PRIOR `maintenance_step` call),
+    ///   waiting for the partition to fully drain so `write_partition` can
+    ///   still be called ONCE with the complete set — the writer still
+    ///   receives one partition in one call; output stays byte-identical,
+    ///   only the WALL-CLOCK SCHEDULING of the conversion work changes.
+    pub(crate) pending_partition:
+        Option<(DecoratedKey, VecDeque<merge::MergeEntry>, Vec<Mutation>)>,
 }
 
 impl WriteEngine {
@@ -142,14 +167,23 @@ impl WriteEngine {
     /// ## Invariants
     ///
     /// - Budget is honored within 10% tolerance
-    /// - At least one partition is processed per call (minimum progress guarantee)
-    /// - Merge state is preserved across calls for resumption
+    /// - At least one CLUSTER GROUP is processed per call (minimum progress
+    ///   guarantee; issue #1668 stage 4 loosened this from "at least one
+    ///   partition" — a single oversized partition no longer blocks the
+    ///   budget for its entire duration)
+    /// - Merge state is preserved across calls for resumption, INCLUDING a
+    ///   partition whose cluster-group drain was paused mid-way
+    ///   (`ActiveMerge::pending_partition`, issue #1668 stage 4) — resuming
+    ///   never re-computes or loses a row, and the writer always still
+    ///   receives one partition's mutations in one `write_partition` call.
     ///
     /// ## Budget Enforcement
     ///
-    /// The budget is honored within approximately 10% tolerance. This tolerance
-    /// exists to avoid interrupting partition processing mid-stream, which would
-    /// require complex state management to resume. The tolerance ensures forward
+    /// The budget is honored within approximately 10% tolerance, checked
+    /// BETWEEN CLUSTER GROUPS (issue #1668 stage 4) rather than only between
+    /// whole partitions — a fat partition can now yield control back to the
+    /// budget check partway through its own drain instead of running to
+    /// completion regardless of elapsed time. The tolerance ensures forward
     /// progress on each call while remaining responsive to time constraints.
     ///
     /// # Arguments
@@ -319,89 +353,110 @@ impl WriteEngine {
             }
         }
 
-        // Process active merge within budget
+        // Process active merge within budget.
+        //
+        // Stage 4 (#1668, the "Q4 unlock"): the budget is now checked BETWEEN
+        // CLUSTER GROUPS, not only between whole partitions. A partition too
+        // fat to finish within one call's remaining budget is no longer
+        // forced to run to completion: its accumulated-so-far converted
+        // `Mutation`s (plus the not-yet-popped raw rows `step()` already
+        // reconciled) are stashed on `ActiveMerge.pending_partition` and
+        // RESUMED on the NEXT `maintenance_step` call via
+        // `StreamingMerger::resume` — nothing is re-computed, nothing is
+        // lost, and the writer still receives the whole partition's
+        // mutations in ONE `write_partition` call once fully drained, so
+        // output stays byte-identical (see `#921`). The minimum-progress
+        // guarantee is now "at least one cluster group per call" (was "at
+        // least one partition per call").
         let budget_tolerance = budget.mul_f32(1.1); // 10% tolerance
-        let mut partitions_processed = 0;
+        let mut partitions_processed = 0u64;
+
+        /// Outcome of draining one partition's cluster groups, bounded by
+        /// the mid-partition budget check.
+        enum DrainOutcome {
+            /// The partition fully drained; write it.
+            Ready(DecoratedKey, Vec<Mutation>),
+            /// Budget exceeded mid-drain; progress was stashed on
+            /// `ActiveMerge.pending_partition` for the next call.
+            Paused,
+            /// No more partitions in any run.
+            MergeComplete,
+        }
 
         while let Some(merge) = &mut self.active_merge {
-            // Check budget (but always process at least one partition)
-            if partitions_processed > 0 && start.elapsed() >= budget_tolerance {
-                break;
-            }
+            // Resume a partition paused by a PRIOR call's budget check, if
+            // any (issue #1668, stage 4). `raw_remaining` are rows `step()`
+            // already reconciled but not yet popped; `mutations_acc` are
+            // rows from EARLIER in this same partition already converted.
+            let (resume_state, mut mutations_acc): (
+                Option<(DecoratedKey, VecDeque<merge::MergeEntry>)>,
+                Vec<Mutation>,
+            ) = match merge.pending_partition.take() {
+                Some((key, rows, muts)) => (Some((key, rows)), muts),
+                None => (None, Vec::new()),
+            };
 
-            // Process one partition from the merge.
-            //
-            // Stage 3b (#1668): drain ONE full partition via the streaming
-            // increment API (`StreamingMerger`/`StreamingStep`) instead of
-            // calling the whole-partition `step()` directly. `step_streaming`
-            // still calls the UNCHANGED `step()` internally and drains its
-            // already-reconciled `Vec<MergeEntry>` one row at a time — proven
-            // byte-identical to `step()`'s own output by the stage-2/3a
-            // equivalence tests — so this does NOT change the outer budget
-            // check's granularity (still exactly one partition per outer-loop
-            // iteration; a mid-partition budget check is stage 4's job) and
-            // does NOT yet reduce peak memory (stage 5's job). It proves the
-            // incremental-consumption plumbing composes end-to-end with the
-            // writer.
-            let mut stream = merge::StreamingMerger::new(&mut merge.merger);
-            let mut pending_rows: Vec<merge::MergeEntry> = Vec::new();
-            let partition = loop {
+            // #850: convert with the effective compaction schema so any
+            // static column re-added from the input headers is preserved.
+            // Cloned ONCE here (before `stream` borrows `merge.merger`) so
+            // per-row conversion below never needs to borrow `self`/`merge`
+            // while that borrow is alive.
+            let conversion_schema = merge.effective_schema.clone();
+            let mut stream = merge::StreamingMerger::resume(&mut merge.merger, resume_state);
+            // True once THIS call has popped at least one cluster group —
+            // guarantees forward progress within a call even when resuming
+            // an already-non-empty `mutations_acc` from a prior call (mirrors
+            // the pre-stage-4 "always process at least one partition" floor,
+            // now at cluster-group granularity).
+            let mut progressed_this_call = false;
+
+            let outcome = loop {
+                if (partitions_processed > 0 || progressed_this_call)
+                    && start.elapsed() >= budget_tolerance
+                {
+                    break DrainOutcome::Paused;
+                }
                 match stream.step_streaming()? {
-                    merge::StreamingStep::ClusterGroup { row, .. } => pending_rows.push(*row),
-                    merge::StreamingStep::PartitionEnd { key } => {
-                        break Some((key, std::mem::take(&mut pending_rows)));
+                    merge::StreamingStep::ClusterGroup { row, .. } => {
+                        progressed_this_call = true;
+                        // Skip metadata-only entries (#886/#899 branch-review):
+                        // they carry complex/range deletion metadata through
+                        // the merge stream but have no writer-emittable
+                        // content yet. See `MergeEntry::is_metadata_only_no_op`.
+                        if !row.is_metadata_only_no_op() {
+                            mutations_acc.push(merge::KWayMerger::merge_entry_to_mutation(
+                                *row,
+                                &conversion_schema,
+                            )?);
+                        }
                     }
-                    merge::StreamingStep::Complete => break None,
+                    merge::StreamingStep::PartitionEnd { key } => {
+                        break DrainOutcome::Ready(key, std::mem::take(&mut mutations_acc));
+                    }
+                    merge::StreamingStep::Complete => break DrainOutcome::MergeComplete,
                 }
             };
 
-            match partition {
-                Some((key, rows)) => {
+            match outcome {
+                DrainOutcome::Ready(key, mutations) => {
                     partitions_processed += 1;
 
-                    // Convert MergeEntry rows to Mutation format
-                    // (collect into a vec first to release the borrow on merge)
-                    let entries_vec: Vec<_> = rows.into_iter().collect();
-
-                    // Now we can call self methods without conflict.
-                    // Skip metadata-only entries (#886/#899 branch-review): they
-                    // carry complex/range deletion metadata through the merge
-                    // stream but have no writer-emittable content yet, so writing
-                    // them would produce a phantom live empty (pure-PK) row at
-                    // timestamp 0. See `MergeEntry::is_metadata_only_no_op`.
-                    // #850: convert with the effective compaction schema so any
-                    // static column re-added from the input headers is preserved
-                    // (partition-key decoding is identical; only static columns
-                    // differ). Falls back to the config schema if (impossibly) no
-                    // active merge is present.
-                    let conversion_schema = self
-                        .active_merge
-                        .as_ref()
-                        .map(|m| m.effective_schema.clone())
-                        .unwrap_or_else(|| self.config.schema.clone());
-                    let mutations = entries_vec
-                        .into_iter()
-                        .filter(|entry| !entry.is_metadata_only_no_op())
-                        .map(|entry| {
-                            merge::KWayMerger::merge_entry_to_mutation(entry, &conversion_schema)
-                        })
-                        .collect::<Result<Vec<_>>>()?;
-
-                    // If every merged row was metadata-only, the partition has no
-                    // writer-emittable content. Skip `write_partition` to avoid a
-                    // phantom EMPTY partition (header/end marker + Index/Filter/
-                    // Summary/statistics registration) in the output SSTable, and
-                    // do not count it as an output partition or row (#886
-                    // branch-review).
+                    // If every merged row was metadata-only, the partition has
+                    // no writer-emittable content. Skip `write_partition` to
+                    // avoid a phantom EMPTY partition (header/end marker +
+                    // Index/Filter/Summary/statistics registration) in the
+                    // output SSTable, and do not count it as an output
+                    // partition or row (#886 branch-review).
                     if mutations.is_empty() {
                         continue;
                     }
 
-                    // Count rows actually written (skipped metadata-only entries
-                    // produce no row, so they must not inflate the stats). A pure
-                    // range-tombstone carrier (#933) or a pure partition-tombstone
-                    // carrier (#1072) emits a marker / partition-header deletion,
-                    // not a row — exclude them, matching KWayMerger::merge.
+                    // Count rows actually written (skipped metadata-only
+                    // entries produce no row, so they must not inflate the
+                    // stats). A pure range-tombstone carrier (#933) or a pure
+                    // partition-tombstone carrier (#1072) emits a marker /
+                    // partition-header deletion, not a row — exclude them,
+                    // matching KWayMerger::merge.
                     let row_count = mutations
                         .iter()
                         .filter(|m| {
@@ -417,8 +472,10 @@ impl WriteEngine {
                         })
                         .count() as u64;
 
-                    // Write partition to output SSTable
-                    // Re-borrow active_merge to write
+                    // Write partition to output SSTable. `stream` was already
+                    // fully drained (PartitionEnd), so its borrow of
+                    // `merge.merger` has ended by now (last use) and this
+                    // re-borrow via `self.active_merge` is conflict-free.
                     if let Some(merge) = &mut self.active_merge {
                         merge.writer.write_partition(key, mutations)?;
                         merge.rows_merged += row_count;
@@ -427,7 +484,21 @@ impl WriteEngine {
                     // Update stats
                     report.rows_merged += row_count;
                 }
-                None => {
+                DrainOutcome::Paused => {
+                    // Stash progress for the NEXT maintenance_step call
+                    // (issue #1668, stage 4). `into_paused_state` is `Some`
+                    // whenever ANY row was popped for the in-progress
+                    // partition — guaranteed here because `progressed_this_call`
+                    // (or a non-empty `resume_state`, which also seeds
+                    // `stream`'s partition key) must be true to reach `Paused`.
+                    if let Some((key, raw_remaining)) = stream.into_paused_state() {
+                        if let Some(merge) = &mut self.active_merge {
+                            merge.pending_partition = Some((key, raw_remaining, mutations_acc));
+                        }
+                    }
+                    break;
+                }
+                DrainOutcome::MergeComplete => {
                     // Merge is complete - finalize and clean up
                     // Use blocking call to handle async finalization
                     self.finalize_merge_blocking(&mut report)?;
@@ -1111,6 +1182,196 @@ mod tests {
         // bytes_written may be 0 if the merged output is empty (reader/writer compatibility),
         // but total_time must be non-zero
         assert!(stats.total_time > Duration::ZERO, "total_time must be > 0");
+    }
+
+    /// Stage 4 (#1668, the "Q4 unlock"): the mid-partition budget check fires
+    /// BETWEEN CLUSTER GROUPS, not only between whole partitions. A synthetic
+    /// FAT partition (many clustering rows split across 2 input SSTables, so
+    /// a real K-way merge reconciles them into ONE partition) drained with a
+    /// near-zero budget must PAUSE mid-drain — proven directly by observing
+    /// `ActiveMerge::pending_partition` populated after the FIRST call: with
+    /// only ONE partition (`id = 1`) in the whole merge, a pause is ONLY
+    /// possible mid-partition, never between partitions. The pre-stage-4
+    /// design always finished a whole partition within a single call
+    /// regardless of budget, so this also proves the fat partition's drain
+    /// spans MULTIPLE `maintenance_step` calls, and that no row is lost or
+    /// duplicated across the pause/resume cycle.
+    #[test]
+    fn test_maintenance_step_pauses_mid_partition_on_tiny_budget() {
+        use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
+        use crate::storage::write_engine::mutation::{
+            CellOperation, ClusteringKey, PartitionKey, TableId,
+        };
+        use crate::types::Value;
+        use std::collections::HashMap;
+
+        let temp_dir = TempDir::new().unwrap();
+        // A schema with ONE clustering column so many rows can share ONE
+        // partition key (id=1) — the "fat partition" fixture.
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: ClusteringOrder::Asc,
+            }],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "ck".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        const ROWS_PER_FLUSH: i32 = 15;
+        const TOTAL_ROWS: u64 = (ROWS_PER_FLUSH * 2) as u64;
+
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        // Two flushes, ONE shared partition key (id=1), DISJOINT clustering
+        // ranges — a real K-way merge reconciles them into ONE fat partition.
+        let mut input_paths = Vec::new();
+        for flush_idx in 0..2 {
+            for i in 0..ROWS_PER_FLUSH {
+                let ck = flush_idx * ROWS_PER_FLUSH + i;
+                let table_id = TableId::new("test_ks", "test_table");
+                let pk = PartitionKey::single("id", Value::Integer(1));
+                let ck_key = ClusteringKey::single("ck", Value::Integer(ck));
+                let ops = vec![CellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text(format!("row-{ck}")),
+                }];
+                let mutation = Mutation::new(
+                    table_id,
+                    pk,
+                    Some(ck_key),
+                    ops,
+                    1_000_000 + i64::from(ck),
+                    None,
+                );
+                engine.write(mutation).unwrap();
+            }
+            let info = rt.block_on(engine.flush()).unwrap().unwrap();
+            input_paths.push(info.data_path);
+        }
+        assert_eq!(input_paths.len(), 2, "expected 2 flushed SSTables");
+
+        let policy = crate::storage::write_engine::STCSPolicy::new(
+            2,   // min_threshold
+            32,  // max_threshold
+            0.5, // bucket_low
+            1.5, // bucket_high
+            0,   // min_sstable_size = 0 so tiny files group together
+        )
+        .unwrap();
+        engine.set_merge_policy(Box::new(policy)).unwrap();
+
+        // A near-zero budget: `budget_tolerance` (budget * 1.1) is ~1ns, so
+        // the elapsed-time check trips on the very next iteration after the
+        // first cluster group is popped — any realistic per-iteration
+        // overhead vastly exceeds 1ns.
+        let tiny_budget = Duration::from_nanos(1);
+        let first_report = engine.maintenance_step(tiny_budget).unwrap();
+
+        // With only ONE partition (id=1) across the whole merge, a pause is
+        // ONLY possible mid-partition — prove it directly.
+        let paused_mid_partition = engine
+            .active_merge
+            .as_ref()
+            .and_then(|m| m.pending_partition.as_ref())
+            .is_some();
+        assert!(
+            paused_mid_partition,
+            "expected ActiveMerge::pending_partition to be populated after a \
+             tiny-budget call against a single fat partition — the mid-partition \
+             budget check (issue #1668 stage 4) must have fired DURING the \
+             partition's cluster-group drain, not just between partitions"
+        );
+        assert!(
+            first_report.pending_compaction,
+            "compaction must still be pending after a tiny-budget call"
+        );
+        assert_eq!(
+            first_report.completed_merges.len(),
+            0,
+            "the fat partition must not have finished writing in one tiny-budget call"
+        );
+
+        // Keep calling (generous budget now) until the merge completes.
+        let mut calls = 1u32;
+        let mut total_rows_merged = first_report.rows_merged;
+        let mut final_report = first_report;
+        while final_report.pending_compaction {
+            final_report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+            total_rows_merged += final_report.rows_merged;
+            calls += 1;
+            assert!(
+                calls < 10_000,
+                "compaction never completed — possible stall/starvation"
+            );
+        }
+        assert!(
+            calls > 1,
+            "expected the fat partition's drain to span MULTIPLE maintenance_step \
+             calls (mid-partition pause/resume) — got just {calls} call(s), which \
+             would only be possible if the pre-stage-4 (whole-partition-per-call) \
+             behavior were still in effect"
+        );
+
+        // Completeness: every one of the TOTAL_ROWS distinct clustering rows
+        // for partition id=1 must have been merged exactly once — proving no
+        // row was lost or duplicated across the pause/resume cycle.
+        assert_eq!(
+            total_rows_merged, TOTAL_ROWS,
+            "expected all {TOTAL_ROWS} clustering rows to be merged exactly \
+             once across the paused/resumed drain"
+        );
+        assert_eq!(
+            final_report.completed_merges.len(),
+            1,
+            "expected exactly one completed merge output"
+        );
+        let stats = engine.maintenance_stats();
+        assert_eq!(
+            stats.sstables_merged_in, 2,
+            "must have consumed both input SSTables"
+        );
     }
 
     /// #935 branch-review regression: `scan_sstable_candidates` walks the whole

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -703,11 +703,13 @@ impl WriteEngine {
                 }
                 DrainOutcome::Paused => {
                     // Stash progress for the NEXT maintenance_step call
-                    // (issue #1668, stage 4). `into_paused_state` is `Some`
-                    // whenever ANY row was popped for the in-progress
-                    // partition — guaranteed here because `progressed_this_call`
-                    // (or a non-empty `resume_state`, which also seeds
-                    // `stream`'s partition key) must be true to reach `Paused`.
+                    // (issue #1668, stage 4). `into_paused_state` returns
+                    // `None` when no partition is currently in progress (the
+                    // pause landed between partitions, e.g. on the very first
+                    // inner-loop iteration for a NEW partition with
+                    // `partitions_processed > 0` carried over from an earlier
+                    // one in this same call) — there is nothing to resume in
+                    // that case, so skipping the stash below is correct.
                     if let Some((key, checkpoint)) = stream.into_paused_state() {
                         if let Some(merge) = &mut self.active_merge {
                             merge.pending_partition = Some((key, checkpoint, stream_state));

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -21,7 +21,6 @@ use crate::schema::TableSchema;
 use crate::storage::sstable::writer::data_writer::{StaticOpsTracker, StreamingPartitionSession};
 use crate::storage::sstable::writer::stats_fold;
 use crate::storage::sstable::writer::StatisticsMetadata;
-use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
@@ -212,10 +211,15 @@ pub(crate) struct ActiveMerge {
     /// - `.0` the partition key (needed both to resume draining and for the
     ///   eventual `write_partition` call).
     /// - `.1` rows `KWayMerger::step()` ALREADY fully reconciled for this
-    ///   partition but not yet POPPED off `StreamingMerger`'s queue
-    ///   (extracted via `StreamingMerger::into_paused_state`, restored via
-    ///   `StreamingMerger::resume`) — nothing here is re-computed by a
-    ///   resumed call, and nothing is lost.
+    ///   partition's raw-entry reconciliation state (carrier accumulator,
+    ///   in-progress cluster, already-reconciled-but-not-yet-popped rows —
+    ///   issue #1668 stage 5d widened this from a plain
+    ///   `VecDeque<MergeEntry>` once `StreamingMerger` stopped buffering a
+    ///   whole partition via `KWayMerger::step`). Extracted via
+    ///   `StreamingMerger::into_paused_state`, restored via
+    ///   `StreamingMerger::resume` — nothing here is re-computed by a
+    ///   resumed call, and nothing is lost. Held OPAQUELY: this file never
+    ///   inspects a field of it.
     /// - `.2` this partition's [`PartitionStreamState`] (issue #1668, stage
     ///   5c-iv part 3): either still resolving the bounded carrier/static
     ///   prefix, or an already-open `StreamingPartitionSession` with rows
@@ -229,7 +233,7 @@ pub(crate) struct ActiveMerge {
     ///   growing in-memory buffer for a wide partition either.
     pub(crate) pending_partition: Option<(
         DecoratedKey,
-        VecDeque<merge::MergeEntry>,
+        merge::PartitionReconcileCheckpoint,
         PartitionStreamState,
     )>,
 }
@@ -518,17 +522,18 @@ impl WriteEngine {
 
         while let Some(merge) = &mut self.active_merge {
             // Resume a partition paused by a PRIOR call's budget check, if
-            // any (issue #1668, stage 4). `raw_remaining` are rows `step()`
-            // already reconciled but not yet popped; `stream_state` is this
-            // partition's `PartitionStreamState` from EARLIER in this same
-            // partition (this or a prior call) — possibly still resolving
-            // the carrier/static prefix, or an already-open session with
-            // rows fed so far.
+            // any (issue #1668, stage 4). `resume_state` is
+            // `StreamingMerger`'s own raw-entry reconciliation checkpoint
+            // (issue #1668 stage 5d); `stream_state` is this partition's
+            // `PartitionStreamState` from EARLIER in this same partition
+            // (this or a prior call) — possibly still resolving the
+            // carrier/static prefix, or an already-open session with rows
+            // fed so far.
             let (resume_state, mut stream_state): (
-                Option<(DecoratedKey, VecDeque<merge::MergeEntry>)>,
+                Option<(DecoratedKey, merge::PartitionReconcileCheckpoint)>,
                 PartitionStreamState,
             ) = match merge.pending_partition.take() {
-                Some((key, rows, state)) => (Some((key, rows)), state),
+                Some((key, checkpoint, state)) => (Some((key, checkpoint)), state),
                 None => (None, PartitionStreamState::fresh()),
             };
 
@@ -802,9 +807,9 @@ impl WriteEngine {
                     // partition — guaranteed here because `progressed_this_call`
                     // (or a non-empty `resume_state`, which also seeds
                     // `stream`'s partition key) must be true to reach `Paused`.
-                    if let Some((key, raw_remaining)) = stream.into_paused_state() {
+                    if let Some((key, checkpoint)) = stream.into_paused_state() {
                         if let Some(merge) = &mut self.active_merge {
-                            merge.pending_partition = Some((key, raw_remaining, stream_state));
+                            merge.pending_partition = Some((key, checkpoint, stream_state));
                         }
                     }
                     break;

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -7,82 +7,84 @@
 //! fields are reachable here because this is a sibling module in the same crate.
 
 use super::merge;
-use super::mutation::{DecoratedKey, PartitionTombstone, RangeTombstone};
-// `Mutation` itself is no longer named directly outside tests (issue #1668
-// stage 5c-iv part 3 removed the `Vec<Mutation>` accumulator this file used
-// to build) — only `mod tests` (`use super::*`) still constructs one
-// directly, so this import is test-only to avoid an unused-import error in
-// the non-test build.
-#[cfg(test)]
-use super::mutation::Mutation;
+// `Mutation` is named in production again (issue #1383 fix): a partition's
+// surviving clustering rows are BUFFERED as `Vec<Mutation>` in
+// `PartitionStreamState` and written in one session at partition end, once
+// the full range-tombstone set is known — see that type's doc.
+use super::mutation::{DecoratedKey, Mutation, PartitionTombstone, RangeTombstone};
 use super::{CompactionStats, KWayMerger, MergePolicy, WriteEngine};
 use crate::error::{Error, Result};
 use crate::schema::TableSchema;
-use crate::storage::sstable::writer::data_writer::{StaticOpsTracker, StreamingPartitionSession};
+use crate::storage::sstable::writer::data_writer::StaticOpsTracker;
 use crate::storage::sstable::writer::stats_fold;
 use crate::storage::sstable::writer::StatisticsMetadata;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
-/// Per-partition streaming state (issue #1668, stage 5c-iv part 3) — mirrors
-/// `KWayMerger::merge()`'s per-partition state machine (stage 5c-iv part 2):
-/// a bounded `clustering_key: None` prefix (partition/range-tombstone
-/// carriers, static-row carrier) resolves first; a
-/// [`StreamingPartitionSession`] opens only once the first `Some(ck)` row (or
-/// an unclustered table's sole row) arrives, since only then do we have
-/// everything `begin_streaming_partition` needs upfront (the partition
-/// tombstone and range-tombstone list). Because `StreamingPartitionSession`
-/// owns everything it needs (no lifetime — issue #1668 stage 5c-iv part 3's
-/// whole reason for existing over `IncrementalPartitionWriter`), EITHER
-/// variant can be stashed on [`ActiveMerge::pending_partition`] and survive
-/// returning to the maintenance scheduler between `maintenance_step_inner`
-/// calls: resuming is just "keep calling methods on it," never a
-/// capture/reconstitute conversion.
-pub(crate) enum PartitionStreamState {
-    /// Still resolving the bounded prefix — no on-disk partition exists yet
-    /// (no header has been written), so there is nothing to pause beyond
-    /// these plain owned accumulators.
-    Prefix {
-        partition_tombstone: Option<PartitionTombstone>,
-        range_tombstones: Vec<RangeTombstone>,
-        static_tracker: StaticOpsTracker,
-        static_first_ts: i64,
-        saw_carrier_or_static: bool,
-        /// This partition's stats fold accumulated so far — see the
-        /// `Streaming` variant's field of the same name for why this is
-        /// threaded through the state rather than folded straight into the
-        /// writer's own `stats`.
-        partition_stats: StatisticsMetadata,
-        /// Mirrors `KWayMerger::merge()`'s loop-local `row_count`: one static
-        /// carrier mutation increments this by 1 EACH time (not once per
-        /// merged output row — issue #1668 stage 5c-iv part 2's row-count
-        /// parity finding), carried forward into `Streaming::row_count` once
-        /// the first `Some(ck)` row opens the session.
-        row_count: u64,
-    },
-    /// A real on-disk partition is open (header + any rows fed so far are
-    /// already in the writer's buffer) and must be finished — via
-    /// `finish_streaming_partition` + `complete_partition_incremental` —
-    /// before anything else can happen to this partition.
-    Streaming {
-        session: StreamingPartitionSession,
-        /// This partition's stats fold accumulated so far (mirrors
-        /// `KWayMerger::merge()`'s `partition_stats` — the writer's `stats`
-        /// field cannot be folded into directly while a session that
-        /// borrows `self.data_writer` per-call is open across calls, so it
-        /// is threaded alongside the session instead).
-        partition_stats: StatisticsMetadata,
-        row_count: u64,
-        partition_tombstone: Option<PartitionTombstone>,
-    },
+/// Per-partition streaming state (issue #1668, stage 5c-iv part 3; buffering
+/// reworked for the issue #1383 range-tombstone-boundary fix) — mirrors
+/// `KWayMerger::merge()`'s per-partition loop state exactly.
+///
+/// A bounded `clustering_key: None` prefix (partition/range-tombstone
+/// carriers, static-row carrier) is accumulated as it arrives; every
+/// surviving `Some(ck)` clustering row is BUFFERED into `buffered_rows`
+/// rather than fed to a writer session as it arrives. The
+/// [`StreamingPartitionSession`] is opened only at `StreamingStep::PartitionEnd`
+/// — once the partition's COMPLETE, coalesced range-tombstone set is known —
+/// and every buffered row is fed through it in one pass, then finished.
+///
+/// This is required for correctness (issue #1383): a range tombstone's
+/// coalesced marker is only surfaced by `StreamingMerger` once its CLOSE
+/// bound is parsed, which — for a range covering rows in a different (e.g.
+/// newer) generation — is strictly AFTER those rows have already streamed
+/// (issue #1668 stage 5d's "range tombstones can arrive AFTER the rows they
+/// cover" finding). Opening the session on the first `Some(ck)` row therefore
+/// fixed an often-EMPTY range-tombstone set, and every late range-only marker
+/// mutation was then dropped as a `feed_streaming_row` no-op — silently
+/// losing the shadowing/boundary. Buffering until the full set is known lets
+/// `feed_streaming_row` shadow every covered row and interleave the markers
+/// correctly, exactly as `KWayMerger::merge()`'s `buffered_rows` does for the
+/// direct-call path.
+///
+/// The whole struct (including `buffered_rows`) owns everything it needs, so
+/// it can be stashed on [`ActiveMerge::pending_partition`] and survive a
+/// mid-partition budget pause between `maintenance_step_inner` calls: the
+/// budget check still fires between cluster groups (each iteration buffers one
+/// group cheaply, then may pause), so a fat partition still yields control —
+/// only the WRITE is deferred to partition end. The buffer is
+/// whole-partition-width for range-tombstone-bearing partitions (a genuinely
+/// bounded-memory streaming write there needs the out-of-scope two-pass
+/// reader; the reader already materializes the decompressed section anyway),
+/// while `StreamingMerger`'s own reconciliation stays row-streamed — the
+/// memory bound the dhat proof actually exercises.
+pub(crate) struct PartitionStreamState {
+    partition_tombstone: Option<PartitionTombstone>,
+    range_tombstones: Vec<RangeTombstone>,
+    static_tracker: StaticOpsTracker,
+    static_first_ts: i64,
+    saw_carrier_or_static: bool,
+    /// This partition's stats fold accumulated so far. Threaded through the
+    /// state rather than folded straight into the writer's own `stats`
+    /// because the writer is borrowed per-call only at partition end.
+    partition_stats: StatisticsMetadata,
+    /// Mirrors `KWayMerger::merge()`'s loop-local `row_count`: incremented
+    /// once per buffered clustering row AND once per static-row carrier (not
+    /// for pure partition/range-tombstone carriers — issue #1668 stage 5c-iv
+    /// part 2's row-count parity finding), so it equals the number of
+    /// emittable rows regardless of pauses.
+    row_count: u64,
+    /// Surviving `Some(ck)` clustering-row mutations, buffered in arrival
+    /// (clustering) order and written in one session at partition end (see
+    /// the type doc for why buffering is required).
+    buffered_rows: Vec<Mutation>,
 }
 
 impl PartitionStreamState {
-    /// A fresh, empty prefix accumulator — the starting state for any new
-    /// partition (never resumed from a pause).
+    /// A fresh, empty accumulator — the starting state for any new partition
+    /// (never resumed from a pause).
     fn fresh() -> Self {
-        PartitionStreamState::Prefix {
+        PartitionStreamState {
             partition_tombstone: None,
             range_tombstones: Vec::new(),
             static_tracker: StaticOpsTracker::new(),
@@ -90,23 +92,16 @@ impl PartitionStreamState {
             saw_carrier_or_static: false,
             partition_stats: StatisticsMetadata::new(),
             row_count: 0,
+            buffered_rows: Vec::new(),
         }
     }
 
-    /// This partition's stats-fold accumulator, regardless of which variant
-    /// is currently active — every mutation (carrier, static, or clustering
-    /// row) folds through the SAME chokepoint before classification, mirroring
-    /// `KWayMerger::merge()`'s single fold point (issue #1668 stage 5c-iv
-    /// part 2).
+    /// This partition's stats-fold accumulator — every mutation (carrier,
+    /// static, or clustering row) folds through the SAME chokepoint before
+    /// classification, mirroring `KWayMerger::merge()`'s single fold point
+    /// (issue #1668 stage 5c-iv part 2).
     fn partition_stats_mut(&mut self) -> &mut StatisticsMetadata {
-        match self {
-            PartitionStreamState::Prefix {
-                partition_stats, ..
-            } => partition_stats,
-            PartitionStreamState::Streaming {
-                partition_stats, ..
-            } => partition_stats,
-        }
+        &mut self.partition_stats
     }
 }
 
@@ -114,24 +109,16 @@ impl PartitionStreamState {
 // (the former holds a non-`Debug` cell-value map; the latter is a plain
 // bookkeeping struct never printed in production), so `ActiveMerge`'s
 // `#[derive(Debug)]` (used only incidentally — no code actually formats an
-// `ActiveMerge`, confirmed by grep) needs a hand-written `Debug` for this
-// enum rather than pulling `Debug` onto either of those types just to
-// satisfy a derive nothing exercises.
+// `ActiveMerge`, confirmed by grep) needs a hand-written `Debug` here rather
+// than pulling `Debug` onto `StaticOpsTracker` just to satisfy a derive
+// nothing exercises.
 impl std::fmt::Debug for PartitionStreamState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PartitionStreamState::Prefix {
-                saw_carrier_or_static,
-                ..
-            } => f
-                .debug_struct("PartitionStreamState::Prefix")
-                .field("saw_carrier_or_static", saw_carrier_or_static)
-                .finish_non_exhaustive(),
-            PartitionStreamState::Streaming { row_count, .. } => f
-                .debug_struct("PartitionStreamState::Streaming")
-                .field("row_count", row_count)
-                .finish_non_exhaustive(),
-        }
+        f.debug_struct("PartitionStreamState")
+            .field("saw_carrier_or_static", &self.saw_carrier_or_static)
+            .field("row_count", &self.row_count)
+            .field("buffered_rows", &self.buffered_rows.len())
+            .finish_non_exhaustive()
     }
 }
 
@@ -221,16 +208,17 @@ pub(crate) struct ActiveMerge {
     ///   resumed call, and nothing is lost. Held OPAQUELY: this file never
     ///   inspects a field of it.
     /// - `.2` this partition's [`PartitionStreamState`] (issue #1668, stage
-    ///   5c-iv part 3): either still resolving the bounded carrier/static
-    ///   prefix, or an already-open `StreamingPartitionSession` with rows
-    ///   fed so far. Fed incrementally as cluster groups arrive — the
-    ///   writer no longer waits for the whole partition to accumulate as a
-    ///   `Vec<Mutation>` before writing anything (that was stage 5c-iv part
-    ///   2's change for `KWayMerger::merge`; this is the same change for the
-    ///   background maintenance loop). Resuming a paused partition is just
-    ///   "keep feeding this same value" — no re-computation, no lost rows,
-    ///   and (unlike the pre-stage-5c-iv-part-3 `Vec<Mutation>` design) no
-    ///   growing in-memory buffer for a wide partition either.
+    ///   5c-iv part 3; buffering reworked for the issue #1383 fix): the
+    ///   accumulated partition tombstone / range-tombstone set / static row
+    ///   plus the buffered surviving clustering rows seen so far. The writer
+    ///   session is opened only at `PartitionEnd` (once the full
+    ///   range-tombstone set is known — see [`PartitionStreamState`]'s doc),
+    ///   so a paused partition stashes plain owned accumulators here.
+    ///   Resuming is just "keep buffering into this same value" — no
+    ///   re-computation, no lost rows. The buffer is whole-partition-width
+    ///   only for range-tombstone-bearing partitions (the documented
+    ///   residual); the budget pause still fires between cluster groups, so a
+    ///   fat partition still yields control mid-drain.
     pub(crate) pending_partition: Option<(
         DecoratedKey,
         merge::PartitionReconcileCheckpoint,
@@ -488,30 +476,32 @@ impl WriteEngine {
         // Process active merge within budget.
         //
         // Stage 4 (#1668, the "Q4 unlock"): the budget is checked BETWEEN
-        // CLUSTER GROUPS, not only between whole partitions. Stage 5c-iv part
-        // 3 changed WHAT gets stashed when a partition is too fat to finish
-        // within one call's remaining budget: instead of accumulating a
-        // growing `Vec<Mutation>` (the whole-partition buffering this issue
-        // exists to eliminate), each cluster group now streams straight into
-        // a `StreamingPartitionSession` as it arrives (mirroring
-        // `KWayMerger::merge`'s stage 5c-iv part 2 change), and the SESSION
-        // ITSELF — which owns everything it needs, no lifetime — is what
-        // gets stashed on `ActiveMerge.pending_partition` and resumed
-        // unchanged on the NEXT `maintenance_step` call. Nothing is
-        // re-computed, nothing is lost, and the writer still receives one
-        // partition as one on-disk unit (opened once, finished once), so
-        // output stays byte-identical (see `#921`). The minimum-progress
-        // guarantee remains "at least one cluster group per call."
+        // CLUSTER GROUPS, not only between whole partitions. When a partition
+        // is too fat to finish within one call's remaining budget, the
+        // accumulated `PartitionStreamState` (carrier/static prefix + the
+        // buffered surviving clustering rows so far) is stashed on
+        // `ActiveMerge.pending_partition` and resumed unchanged on the NEXT
+        // `maintenance_step` call. The writer session is opened only at
+        // `PartitionEnd`, once the partition's FULL range-tombstone set is
+        // known (issue #1383 — see `PartitionStreamState`'s doc for why a late
+        // range tombstone would otherwise drop a boundary), so the writer
+        // still receives one partition as one on-disk unit (opened once,
+        // finished once) and output stays byte-identical (see `#921`).
+        // Nothing is re-computed across a pause, nothing is lost. The
+        // minimum-progress guarantee remains "at least one cluster group per
+        // call"; the budget still fires between cluster groups, so a fat
+        // partition yields control mid-drain even though its WRITE is
+        // deferred to the end.
         let budget_tolerance = budget.mul_f32(1.1); // 10% tolerance
         let mut partitions_processed = 0u64;
 
         /// Outcome of draining one partition's cluster groups, bounded by
         /// the mid-partition budget check.
         enum DrainOutcome {
-            /// The partition fully drained; finalize whatever
-            /// `PartitionStreamState` it ended in. Boxed: `Streaming` embeds
-            /// a `StreamingPartitionSession` (clippy::large_enum_variant) —
-            /// boxing keeps `DrainOutcome` itself cheap to move regardless.
+            /// The partition fully drained; write the buffered
+            /// `PartitionStreamState` now (open session, feed static + rows,
+            /// finish). Boxed to keep `DrainOutcome` cheap to move regardless
+            /// of `PartitionStreamState`'s size (clippy::large_enum_variant).
             Ready(DecoratedKey, Box<PartitionStreamState>),
             /// Budget exceeded mid-drain; progress was stashed on
             /// `ActiveMerge.pending_partition` for the next call.
@@ -526,9 +516,9 @@ impl WriteEngine {
             // `StreamingMerger`'s own raw-entry reconciliation checkpoint
             // (issue #1668 stage 5d); `stream_state` is this partition's
             // `PartitionStreamState` from EARLIER in this same partition
-            // (this or a prior call) — possibly still resolving the
-            // carrier/static prefix, or an already-open session with rows
-            // fed so far.
+            // (this or a prior call) — the carrier/static prefix plus the
+            // clustering rows buffered so far (no session is open yet; it
+            // opens only at PartitionEnd, see that type's doc).
             let (resume_state, mut stream_state): (
                 Option<(DecoratedKey, merge::PartitionReconcileCheckpoint)>,
                 PartitionStreamState,
@@ -569,7 +559,7 @@ impl WriteEngine {
                     break DrainOutcome::Paused;
                 }
                 match stream.step_streaming()? {
-                    merge::StreamingStep::ClusterGroup { key, row } => {
+                    merge::StreamingStep::ClusterGroup { key: _, row } => {
                         progressed_this_call = true;
                         // Skip metadata-only entries (#886/#899 branch-review):
                         // they carry complex/range deletion metadata through
@@ -589,16 +579,13 @@ impl WriteEngine {
                             &mutation,
                         );
 
-                        if let PartitionStreamState::Streaming {
-                            session, row_count, ..
-                        } = &mut stream_state
-                        {
-                            merge.writer.feed_streaming_row(session, &mutation)?;
-                            *row_count += 1;
-                            continue;
-                        }
-
-                        // Still in the (bounded) None-keyed prefix.
+                        // Classify the (None-keyed) carriers and the static
+                        // row; everything else is a real clustering row that
+                        // is BUFFERED (see `PartitionStreamState`'s doc). No
+                        // writer session is opened here — a range tombstone
+                        // can still arrive AFTER some rows are buffered (issue
+                        // #1383), so the session opens only at PartitionEnd,
+                        // once the full range-tombstone set is resolved.
                         let is_partition_only = mutation.operations.is_empty()
                             && mutation.partition_tombstone.is_some()
                             && mutation.row_tombstone.is_none()
@@ -616,108 +603,40 @@ impl WriteEngine {
                         let is_static_carrier =
                             mutation.clustering_key.is_none() && schema_has_static;
 
-                        // Roborev blocker #2 (issue #1668): `row_count` must
-                        // ONLY be incremented for the resolved static-row
-                        // carrier, exactly mirroring `KWayMerger::merge`'s
-                        // reference implementation (`merge/mod.rs`, ~lines
-                        // 2329-2367) — a pure partition- or range-tombstone
-                        // carrier emits a marker/header deletion, not a row,
-                        // so it must NOT inflate `row_count` (which flows
-                        // into `merge.rows_merged`/`report.rows_merged`/the
-                        // `COMPACTION_ROWS_MERGED` counter).
-                        if is_partition_only || is_range_only || is_static_carrier {
-                            if let PartitionStreamState::Prefix {
-                                partition_tombstone,
-                                range_tombstones,
-                                static_tracker,
-                                static_first_ts,
-                                saw_carrier_or_static,
-                                row_count,
-                                ..
-                            } = &mut stream_state
-                            {
-                                if is_partition_only {
-                                    *partition_tombstone = mutation.partition_tombstone;
-                                } else if is_range_only {
-                                    range_tombstones
-                                        .extend(mutation.range_tombstones.iter().cloned());
-                                } else {
-                                    if !*saw_carrier_or_static {
-                                        *static_first_ts = mutation.timestamp_micros;
-                                    }
-                                    static_tracker.feed(&mutation, &write_schema, None);
-                                    *row_count += 1;
-                                }
-                                *saw_carrier_or_static = true;
+                        if is_partition_only {
+                            stream_state.partition_tombstone = mutation.partition_tombstone;
+                            stream_state.saw_carrier_or_static = true;
+                            continue;
+                        }
+                        if is_range_only {
+                            stream_state
+                                .range_tombstones
+                                .extend(mutation.range_tombstones.iter().cloned());
+                            stream_state.saw_carrier_or_static = true;
+                            continue;
+                        }
+                        if is_static_carrier {
+                            // Roborev blocker #2 (issue #1668): only the
+                            // resolved static-row carrier increments
+                            // `row_count` — a pure partition/range-tombstone
+                            // carrier emits a marker/header deletion, not a
+                            // row.
+                            if !stream_state.saw_carrier_or_static {
+                                stream_state.static_first_ts = mutation.timestamp_micros;
                             }
+                            stream_state
+                                .static_tracker
+                                .feed(&mutation, &write_schema, None);
+                            stream_state.saw_carrier_or_static = true;
+                            stream_state.row_count += 1;
                             continue;
                         }
 
-                        // First Some(ck) row (or, for an unclustered table,
-                        // its sole `clustering_key: None` row): the prefix
-                        // is now COMPLETE. Take `stream_state` by value to
-                        // open the session and transition to `Streaming`.
-                        let prev =
-                            std::mem::replace(&mut stream_state, PartitionStreamState::fresh());
-                        let (
-                            partition_tombstone,
-                            range_tombstones,
-                            static_tracker,
-                            static_first_ts,
-                            partition_stats,
-                            mut row_count,
-                        ) = match prev {
-                            PartitionStreamState::Prefix {
-                                partition_tombstone,
-                                range_tombstones,
-                                static_tracker,
-                                static_first_ts,
-                                partition_stats,
-                                row_count,
-                                ..
-                            } => (
-                                partition_tombstone,
-                                range_tombstones,
-                                static_tracker,
-                                static_first_ts,
-                                partition_stats,
-                                row_count,
-                            ),
-                            // Provably unreachable — the `if let
-                            // PartitionStreamState::Streaming` guard above
-                            // already `continue`d whenever `stream_state` was
-                            // `Streaming`. Handled without panicking (no
-                            // unwrap/expect/unreachable!() in library code):
-                            // just restore it and skip this cluster group
-                            // rather than assert something the compiler
-                            // cannot itself prove impossible here.
-                            already_streaming @ PartitionStreamState::Streaming { .. } => {
-                                stream_state = already_streaming;
-                                continue;
-                            }
-                        };
-
-                        let mut session = merge.writer.begin_streaming_partition(
-                            &key,
-                            partition_tombstone.as_ref(),
-                            &range_tombstones,
-                        )?;
-                        if schema_has_static {
-                            let merged = static_tracker.finish();
-                            merge.writer.feed_streaming_static_row(
-                                &mut session,
-                                &merged,
-                                static_first_ts,
-                            )?;
-                        }
-                        merge.writer.feed_streaming_row(&mut session, &mutation)?;
-                        row_count += 1;
-                        stream_state = PartitionStreamState::Streaming {
-                            session,
-                            partition_stats,
-                            row_count,
-                            partition_tombstone,
-                        };
+                        // A real clustering row (or an unclustered table's
+                        // sole `clustering_key: None` row): buffer it for the
+                        // single PartitionEnd write.
+                        stream_state.buffered_rows.push(mutation);
+                        stream_state.row_count += 1;
                     }
                     merge::StreamingStep::PartitionEnd { key } => {
                         break DrainOutcome::Ready(
@@ -735,78 +654,51 @@ impl WriteEngine {
             match outcome {
                 DrainOutcome::Ready(key, state) => {
                     partitions_processed += 1;
+                    let state = *state;
 
-                    match *state {
-                        PartitionStreamState::Streaming {
-                            session,
-                            partition_stats,
-                            row_count,
-                            partition_tombstone,
-                        } => {
-                            if let Some(merge) = &mut self.active_merge {
-                                let (offset, blocks, emit) =
-                                    merge.writer.finish_streaming_partition(session)?;
-                                merge.writer.complete_partition_incremental(
-                                    &key,
-                                    partition_tombstone.as_ref(),
-                                    offset,
-                                    &blocks,
-                                    emit,
-                                    &partition_stats,
+                    // Truly empty partition (every entry was
+                    // metadata-only-no-op, and no carrier/static survived) —
+                    // skip entirely, matching `KWayMerger::merge`'s
+                    // `buffered_rows.is_empty() && !saw_carrier_or_static`
+                    // skip. A partition with only carriers/statics but no
+                    // `Some(ck)` row is still emittable (#933/#1072).
+                    if !state.buffered_rows.is_empty() || state.saw_carrier_or_static {
+                        // Open the session NOW, with the partition tombstone,
+                        // the COMPLETE coalesced range-tombstone set, the
+                        // static row, and every buffered clustering row all
+                        // known (issue #1383): `feed_streaming_row` shadows
+                        // every covered row and interleaves the markers in
+                        // clustering order.
+                        if let Some(merge) = &mut self.active_merge {
+                            let mut session = merge.writer.begin_streaming_partition(
+                                &key,
+                                state.partition_tombstone.as_ref(),
+                                &state.range_tombstones,
+                            )?;
+                            if schema_has_static {
+                                let merged = state.static_tracker.finish();
+                                merge.writer.feed_streaming_static_row(
+                                    &mut session,
+                                    &merged,
+                                    state.static_first_ts,
                                 )?;
-                                merge.rows_merged += row_count;
                             }
-                            report.rows_merged += row_count;
+                            for mutation in &state.buffered_rows {
+                                merge.writer.feed_streaming_row(&mut session, mutation)?;
+                            }
+                            let (offset, blocks, emit) =
+                                merge.writer.finish_streaming_partition(session)?;
+                            merge.writer.complete_partition_incremental(
+                                &key,
+                                state.partition_tombstone.as_ref(),
+                                offset,
+                                &blocks,
+                                emit,
+                                &state.partition_stats,
+                            )?;
+                            merge.rows_merged += state.row_count;
                         }
-                        PartitionStreamState::Prefix {
-                            partition_tombstone,
-                            range_tombstones,
-                            static_tracker,
-                            static_first_ts,
-                            saw_carrier_or_static,
-                            partition_stats,
-                            row_count,
-                        } => {
-                            // Truly empty partition (every entry was
-                            // metadata-only-no-op) — skip entirely, matching
-                            // the original `mutations.is_empty()` skip
-                            // (#886 branch-review).
-                            if !saw_carrier_or_static {
-                                continue;
-                            }
-                            // No `Some(ck)` row ever arrived, but a
-                            // range/partition tombstone or a static value
-                            // survived — still emittable (#933/#1072),
-                            // matching `KWayMerger::merge`'s `None if
-                            // saw_carrier_or_static` branch exactly.
-                            if let Some(merge) = &mut self.active_merge {
-                                let mut session = merge.writer.begin_streaming_partition(
-                                    &key,
-                                    partition_tombstone.as_ref(),
-                                    &range_tombstones,
-                                )?;
-                                if schema_has_static {
-                                    let merged = static_tracker.finish();
-                                    merge.writer.feed_streaming_static_row(
-                                        &mut session,
-                                        &merged,
-                                        static_first_ts,
-                                    )?;
-                                }
-                                let (offset, blocks, emit) =
-                                    merge.writer.finish_streaming_partition(session)?;
-                                merge.writer.complete_partition_incremental(
-                                    &key,
-                                    partition_tombstone.as_ref(),
-                                    offset,
-                                    &blocks,
-                                    emit,
-                                    &partition_stats,
-                                )?;
-                                merge.rows_merged += row_count;
-                            }
-                            report.rows_merged += row_count;
-                        }
+                        report.rows_merged += state.row_count;
                     }
                 }
                 DrainOutcome::Paused => {
@@ -1965,17 +1857,16 @@ mod tests {
     }
 
     /// Byte-identity proof (issue #1668, stage 5c-iv part 3): pausing and
-    /// resuming a partition's drain mid-stream — via
-    /// `StreamingPartitionSession` stashed on
-    /// `ActiveMerge::pending_partition` across many `maintenance_step`
-    /// calls, instead of the pre-stage-5c-iv-part-3 growing `Vec<Mutation>`
-    /// — must produce EXACTLY the same Data.db bytes as a single unbroken
-    /// drain. Same rigor as every `IncrementalPartitionWriter`/
-    /// `StreamingPartitionSession` byte-identity test in `data_writer/tests/`,
-    /// but exercised through the REAL production entry point
-    /// (`WriteEngine::maintenance_step`) rather than the session type
-    /// directly — proving the INTEGRATION (budget checks,
-    /// `PartitionStreamState` transitions, resume plumbing) introduces no
+    /// resuming a partition's drain mid-stream — via the
+    /// `PartitionStreamState` (carrier/static prefix + buffered clustering
+    /// rows) stashed on `ActiveMerge::pending_partition` across many
+    /// `maintenance_step` calls — must produce EXACTLY the same Data.db bytes
+    /// as a single unbroken drain. Same rigor as every
+    /// `IncrementalPartitionWriter`/`StreamingPartitionSession` byte-identity
+    /// test in `data_writer/tests/`, but exercised through the REAL
+    /// production entry point (`WriteEngine::maintenance_step`) rather than
+    /// the session type directly — proving the INTEGRATION (budget checks,
+    /// buffering/resume plumbing, the single PartitionEnd write) introduces no
     /// divergence of its own.
     #[test]
     fn test_maintenance_paused_and_unpaused_compaction_produce_byte_identical_output() {

--- a/cqlite-core/src/storage/write_engine/merge/carriers.rs
+++ b/cqlite-core/src/storage/write_engine/merge/carriers.rs
@@ -1,0 +1,258 @@
+//! Partition-scoped tombstone-carrier pre-scan (issue #1668, stage 1).
+//!
+//! `merge_partition_rows` (in `mod.rs`) buffers a whole partition and, in a
+//! single pass, splits three PARTITION-LEVEL markers out of the per-`(pk, ck)`
+//! row stream before per-cluster reconciliation:
+//!
+//!   * **range-tombstone carriers** (issue #933) — empty live rows carrying a
+//!     [`RangeTombstone`] spanning a clustering range;
+//!   * **partition-deletion carriers** (issue #1072) — synthetic empty live
+//!     rows whose only payload is `partition_deletion`. The MAX
+//!     `markedForDeleteAt` across sources is the partition's outermost shadow
+//!     floor.
+//!
+//! Per the #933/#846/#959 correctness invariants, these carriers must be
+//! collected across the WHOLE partition BEFORE per-cluster shadowing
+//! (`apply_range_shadowing` / `apply_partition_shadowing`) can run — a single
+//! cluster cannot be shadowed until the full coalesced range set is known.
+//!
+//! This module extracts that carrier collection into a standalone, pure,
+//! independently testable pre-scan ([`scan_partition_carriers`]). It is a
+//! behavior-preserving refactor: the whole-partition buffering path in
+//! `merge_partition_rows` is unchanged and still the only production path — it
+//! now calls this helper for the carrier set, then buffers the remaining
+//! (non-carrier) rows exactly as before. This pre-scan is the seed for the
+//! streaming second pass in later stages (#1668 stages 2+), which will apply
+//! per-cluster shadowing over the coalesced carriers without re-buffering the
+//! whole partition.
+
+#[cfg(feature = "write-support")]
+use super::model::{MergeEntry, RowData};
+#[cfg(feature = "write-support")]
+use crate::storage::write_engine::mutation::{DecoratedKey, RangeTombstone};
+
+/// The partition-scoped tombstone markers extracted from a partition's buffered
+/// merge entries by [`scan_partition_carriers`].
+///
+/// These are the markers that span a clustering range or the whole partition —
+/// they are NOT per-`(pk, ck)` rows and are kept OUT of the clustered-row
+/// stream. `merge_partition_rows` coalesces `range_tombstones`, applies
+/// `max_partition_deletion` as the outermost per-cell shadow floor, and
+/// re-emits the survivors so the writer persists the markers.
+#[cfg(feature = "write-support")]
+#[derive(Debug, Default)]
+pub(super) struct PartitionCarriers {
+    /// Range-tombstone carriers, one `(key, range)` per input marker, in
+    /// first-seen (heap) order. Coalesced into a non-overlapping canonical
+    /// sequence by the caller (issue #933 / #959).
+    pub range_tombstones: Vec<(DecoratedKey, RangeTombstone)>,
+    /// MAX partition deletion `(markedForDeleteAt µs, localDeletionTime s)`
+    /// across all sources — the partition's outermost shadow floor (issue
+    /// #1072). `None` when no partition-deletion carrier is present.
+    pub max_partition_deletion: Option<(i64, i32)>,
+    /// The [`DecoratedKey`] of the first-seen partition-deletion carrier, kept
+    /// so the surviving partition tombstone can be re-emitted (issue #1072).
+    /// `None` when no partition-deletion carrier is present.
+    pub partition_delete_key: Option<DecoratedKey>,
+}
+
+/// True when this entry is a range-tombstone carrier (issue #933): an empty
+/// live row whose only payload is a [`RangeTombstone`] spanning a clustering
+/// range — no cells, no row deletion, no complex deletions. Such a marker is
+/// partition-level (spans many `(pk, ck)`), NOT a single reconcilable row, so
+/// it must be split out of the clustered-row stream.
+#[cfg(feature = "write-support")]
+pub(super) fn is_range_marker_carrier(entry: &MergeEntry) -> bool {
+    entry.range_deletion.is_some()
+        && entry.complex_deletions.is_empty()
+        && entry.row_deletion.is_none()
+        && matches!(&entry.row_data, RowData::Live { cells } if cells.is_empty())
+}
+
+/// Pre-scan a partition's buffered merge entries and extract the
+/// partition-scoped tombstone carriers ([`PartitionCarriers`]).
+///
+/// This is a light, read-only first pass that touches ONLY the (typically few)
+/// range/partition-tombstone carriers — it borrows `rows` and does not consume
+/// them, so `merge_partition_rows` can still buffer the non-carrier rows into
+/// `clustered_rows` afterward. It reproduces exactly the carrier-splitting logic
+/// that previously lived inline in `merge_partition_rows`:
+///
+///   * A partition-deletion carrier (checked FIRST, matching the original
+///     precedence) contributes its `(mfda, ldt)` to `max_partition_deletion`,
+///     keeping the MAX `markedForDeleteAt` (ties keep the first-seen), and
+///     records the first-seen key in `partition_delete_key`.
+///   * Otherwise a range-marker carrier ([`is_range_marker_carrier`])
+///     contributes its `(key, range)` to `range_tombstones` in first-seen order.
+///   * Every other entry is a normal `(pk, ck)` row and is ignored here (the
+///     caller buffers it into `clustered_rows`).
+#[cfg(feature = "write-support")]
+pub(super) fn scan_partition_carriers(rows: &[MergeEntry]) -> PartitionCarriers {
+    let mut carriers = PartitionCarriers::default();
+
+    for row in rows {
+        // Partition-deletion carriers take precedence over range markers,
+        // exactly as the original inline pass did.
+        if row.is_partition_delete_carrier() {
+            if let Some((mfda, ldt)) = row.partition_deletion {
+                carriers
+                    .partition_delete_key
+                    .get_or_insert_with(|| row.key.clone());
+                match carriers.max_partition_deletion {
+                    Some((cur_mfda, _)) if cur_mfda >= mfda => {}
+                    _ => carriers.max_partition_deletion = Some((mfda, ldt)),
+                }
+                continue;
+            }
+        }
+        if is_range_marker_carrier(row) {
+            if let Some(rt) = row.range_deletion.clone() {
+                carriers.range_tombstones.push((row.key.clone(), rt));
+            }
+        }
+    }
+
+    carriers
+}
+
+#[cfg(all(test, feature = "write-support"))]
+mod tests {
+    use super::*;
+    use crate::storage::write_engine::merge::CellData;
+    use crate::storage::write_engine::mutation::ClusteringBound;
+    use crate::types::Value;
+
+    fn key(token: i64) -> DecoratedKey {
+        DecoratedKey::new(token, vec![token as u8])
+    }
+
+    fn range_tombstone(deletion_time: i64, local_deletion_time: i32) -> RangeTombstone {
+        RangeTombstone {
+            start: ClusteringBound::Bottom,
+            end: ClusteringBound::Top,
+            deletion_time,
+            local_deletion_time,
+        }
+    }
+
+    /// An ordinary live `(pk, ck)` row — must be ignored by the pre-scan.
+    fn live_row(token: i64) -> MergeEntry {
+        MergeEntry::new(
+            0,
+            key(token),
+            None,
+            100,
+            RowData::Live {
+                cells: vec![CellData::new("c".to_string(), Value::Integer(1), 100)],
+            },
+        )
+    }
+
+    /// A range-tombstone carrier: empty live row + a range deletion.
+    fn range_carrier(token: i64, deletion_time: i64, ldt: i32) -> MergeEntry {
+        MergeEntry::new(
+            0,
+            key(token),
+            None,
+            deletion_time,
+            RowData::Live { cells: Vec::new() },
+        )
+        .with_range_deletion(range_tombstone(deletion_time, ldt))
+    }
+
+    /// A partition-deletion carrier: empty live row + a partition deletion.
+    fn partition_carrier(token: i64, mfda: i64, ldt: i32) -> MergeEntry {
+        MergeEntry::new(
+            0,
+            key(token),
+            None,
+            mfda,
+            RowData::Live { cells: Vec::new() },
+        )
+        .with_partition_deletion((mfda, ldt))
+    }
+
+    #[test]
+    fn empty_input_yields_no_carriers() {
+        let carriers = scan_partition_carriers(&[]);
+        assert!(carriers.range_tombstones.is_empty());
+        assert_eq!(carriers.max_partition_deletion, None);
+        assert!(carriers.partition_delete_key.is_none());
+    }
+
+    #[test]
+    fn plain_rows_yield_no_carriers() {
+        let rows = vec![live_row(1), live_row(1), live_row(1)];
+        let carriers = scan_partition_carriers(&rows);
+        assert!(carriers.range_tombstones.is_empty());
+        assert_eq!(carriers.max_partition_deletion, None);
+        assert!(carriers.partition_delete_key.is_none());
+    }
+
+    #[test]
+    fn extracts_range_carriers_in_first_seen_order() {
+        let rows = vec![
+            range_carrier(1, 200, 20),
+            live_row(1),
+            range_carrier(1, 100, 10),
+        ];
+        let carriers = scan_partition_carriers(&rows);
+        assert_eq!(carriers.range_tombstones.len(), 2);
+        // First-seen (heap) order preserved: 200 before 100.
+        assert_eq!(carriers.range_tombstones[0].1.deletion_time, 200);
+        assert_eq!(carriers.range_tombstones[1].1.deletion_time, 100);
+        // Range carriers do not populate the partition-deletion floor.
+        assert_eq!(carriers.max_partition_deletion, None);
+        assert!(carriers.partition_delete_key.is_none());
+    }
+
+    #[test]
+    fn keeps_max_partition_deletion_across_carriers() {
+        // Out-of-order mfda: 50, then 300 (the max), then 200 — max wins.
+        let rows = vec![
+            partition_carrier(7, 50, 5),
+            live_row(7),
+            partition_carrier(7, 300, 30),
+            partition_carrier(7, 200, 20),
+        ];
+        let carriers = scan_partition_carriers(&rows);
+        assert_eq!(carriers.max_partition_deletion, Some((300, 30)));
+        // First-seen carrier's key is retained.
+        assert_eq!(carriers.partition_delete_key, Some(key(7)));
+        assert!(carriers.range_tombstones.is_empty());
+    }
+
+    #[test]
+    fn equal_mfda_keeps_first_seen_local_deletion_time() {
+        // On an mfda tie the FIRST-seen (mfda, ldt) is kept (>= guard).
+        let rows = vec![partition_carrier(3, 100, 11), partition_carrier(3, 100, 22)];
+        let carriers = scan_partition_carriers(&rows);
+        assert_eq!(carriers.max_partition_deletion, Some((100, 11)));
+    }
+
+    #[test]
+    fn mixed_carriers_and_rows_split_correctly() {
+        let rows = vec![
+            live_row(5),
+            range_carrier(5, 400, 40),
+            partition_carrier(5, 250, 25),
+            live_row(5),
+            range_carrier(5, 150, 15),
+        ];
+        let carriers = scan_partition_carriers(&rows);
+        assert_eq!(carriers.range_tombstones.len(), 2);
+        assert_eq!(carriers.range_tombstones[0].1.deletion_time, 400);
+        assert_eq!(carriers.range_tombstones[1].1.deletion_time, 150);
+        assert_eq!(carriers.max_partition_deletion, Some((250, 25)));
+        assert_eq!(carriers.partition_delete_key, Some(key(5)));
+    }
+
+    #[test]
+    fn is_range_marker_carrier_rejects_non_empty_live_row() {
+        // A row with a range deletion AND live cells is NOT a pure carrier.
+        let entry = live_row(1).with_range_deletion(range_tombstone(100, 10));
+        assert!(!is_range_marker_carrier(&entry));
+        // The pure empty-live carrier is recognized.
+        assert!(is_range_marker_carrier(&range_carrier(1, 100, 10)));
+    }
+}

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -115,6 +115,14 @@ mod streaming;
 #[cfg(feature = "write-support")]
 pub(crate) use streaming::{StreamingMerger, StreamingStep};
 
+/// Schema-aware heap-direct ordering proof (issue #1668, stage 5b) — proves
+/// cross-group emission order can be correct straight off a heap, with NO
+/// whole-partition `merged.sort_by` afterward. NOT yet wired into
+/// `KWayMerger.heap` itself (stage 5c/5d's job); see
+/// [`schema_order::schema_ordered_pop_all`].
+#[cfg(feature = "write-support")]
+mod schema_order;
+
 /// Adapt a merge-path [`CellData`] into the shared [`ReconcileCell`] view
 /// (issue #947) so per-cell winner resolution calls
 /// [`reconcile_rules::cell_wins`] — the one shared `Cells#reconcile` tie-break —

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -2385,8 +2385,23 @@ impl KWayMerger {
         // static ops that `begin_partition_incremental`/`feed_static_row`
         // need UPFRONT. Every subsequent `Some(ck)` row streams straight
         // through `feed_row` with NO `Vec<Mutation>` accumulation.
-        let schema_has_static = self.schema.columns.iter().any(|c| c.is_static);
-        let schema = self.schema.clone();
+        //
+        // TWO DISTINCT schemas are in play, and mixing them up silently
+        // corrupts the output (found via the real #1019 2-generation
+        // dropped-column fixture, which no single-run synthetic unit test
+        // exercised): `self.schema` is this merger's DECODE-time schema
+        // (e.g. `compact_sstables_with_registry`'s `effective_schema`, which
+        // still declares a fully-purged dropped column so its cells can be
+        // decoded and purge-evaluated) — used ONLY for
+        // `merge_entry_to_mutation`. `output_writer`'s OWN schema is the
+        // ENCODE-time `write_schema` — the header/column layout actually
+        // committed to Data.db (with fully-purged dropped columns already
+        // stripped) — required by every `feed_row`/`feed_static_row`/
+        // `finish` call, exactly as `write_partition` always used its own
+        // `&self.schema` internally rather than a caller-decoded schema.
+        let decode_schema = self.schema.clone();
+        let write_schema = output_writer.schema().clone();
+        let schema_has_static = write_schema.columns.iter().any(|c| c.is_static);
         let mut stream = StreamingMerger::new(&mut self);
 
         // Outer loop: one iteration per PARTITION, with all partition-scoped
@@ -2439,7 +2454,7 @@ impl KWayMerger {
                         if row.is_metadata_only_no_op() {
                             continue;
                         }
-                        let mutation = Self::merge_entry_to_mutation(*row, &schema)?;
+                        let mutation = Self::merge_entry_to_mutation(*row, &decode_schema)?;
                         // Single fold point for EVERY mutation of this
                         // partition (carrier, static, or clustered row) —
                         // mirrors `write_partition`'s
@@ -2453,7 +2468,7 @@ impl KWayMerger {
 
                         if let Some(active) = session.as_mut() {
                             // Already streaming this partition's Some(ck) tail.
-                            active.feed_row(&mutation, &schema)?;
+                            active.feed_row(&mutation, &write_schema)?;
                             row_count += 1;
                             continue;
                         }
@@ -2502,7 +2517,7 @@ impl KWayMerger {
                             if !saw_carrier_or_static {
                                 static_first_ts = mutation.timestamp_micros;
                             }
-                            static_tracker.feed(&mutation, &schema, None);
+                            static_tracker.feed(&mutation, &write_schema, None);
                             saw_carrier_or_static = true;
                             row_count += 1;
                             continue;
@@ -2525,9 +2540,9 @@ impl KWayMerger {
                         )?;
                         if schema_has_static {
                             let merged = std::mem::take(&mut static_tracker).finish();
-                            new_session.feed_static_row(&merged, static_first_ts, &schema)?;
+                            new_session.feed_static_row(&merged, static_first_ts, &write_schema)?;
                         }
-                        new_session.feed_row(&mutation, &schema)?;
+                        new_session.feed_row(&mutation, &write_schema)?;
                         row_count += 1;
                         stats.output_partitions += 1;
                         session = Some(new_session);
@@ -2535,7 +2550,7 @@ impl KWayMerger {
                     StreamingStep::PartitionEnd { key } => {
                         match session.take() {
                             Some(active) => {
-                                let (offset, blocks, emit) = active.finish(&schema)?;
+                                let (offset, blocks, emit) = active.finish(&write_schema)?;
                                 output_writer.complete_partition_incremental(
                                     &key,
                                     partition_tombstone.as_ref(),
@@ -2563,10 +2578,10 @@ impl KWayMerger {
                                     new_session.feed_static_row(
                                         &merged,
                                         static_first_ts,
-                                        &schema,
+                                        &write_schema,
                                     )?;
                                 }
-                                let (offset, blocks, emit) = new_session.finish(&schema)?;
+                                let (offset, blocks, emit) = new_session.finish(&write_schema)?;
                                 output_writer.complete_partition_incremental(
                                     &key,
                                     partition_tombstone.as_ref(),

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -94,6 +94,13 @@ pub mod repair_state;
 #[cfg(feature = "write-support")]
 pub use repair_state::{classify_inputs, RepairState};
 
+/// Partition-scoped tombstone-carrier pre-scan (issue #1668, stage 1). Extracts
+/// the range-tombstone (#933) and partition-deletion (#1072) carriers out of a
+/// buffered partition into [`carriers::PartitionCarriers`] as a standalone,
+/// testable first pass — the seed for later streaming stages.
+#[cfg(feature = "write-support")]
+mod carriers;
+
 /// Clustering-group reconciliation kernel, decomposed into named steps
 /// (issue #945). See [`reconcile::ReconcileState`].
 #[cfg(feature = "write-support")]
@@ -2550,25 +2557,33 @@ impl KWayMerger {
             (None, i64::MIN)
         };
 
-        // Issue #933: split the range-tombstone carrier entries out of the row
-        // stream. They are partition-level markers spanning a clustering range —
-        // NOT per-`(pk, ck)` rows — so routing them through `reconcile_cluster`
-        // (which collapses a cluster to ONE entry, keeping a single max-deletion
-        // range) would lose every range but one. Collect them here, canonicalize
-        // overlapping duplicates, then (a) shadow covered cells per cluster and
-        // (b) re-emit the survivors so the writer persists the markers.
-        let mut range_tombstones: Vec<(DecoratedKey, RangeTombstone)> = Vec::new();
-        let mut clustered_rows: BTreeMap<Option<ClusteringKey>, Vec<MergeEntry>> = BTreeMap::new();
+        // Partition-scoped tombstone-carrier pre-scan (issue #1668, stage 1).
+        // A standalone read-only first pass extracts the partition-level
+        // markers — the range-tombstone carriers (#933) and the MAX
+        // partition-deletion floor (#1072) — out of the buffered partition into
+        // `PartitionCarriers`. This preserves the exact prior behavior:
+        //
+        //   * Issue #933: range-tombstone carriers are partition-level markers
+        //     spanning a clustering range — NOT per-`(pk, ck)` rows — so routing
+        //     them through `reconcile_cluster` (which collapses a cluster to ONE
+        //     entry) would lose every range but one. Collected here, then
+        //     canonicalized (below), then used to (a) shadow covered cells per
+        //     cluster and (b) re-emit the survivors so the writer persists them.
+        //   * Issue #1072: the synthetic partition-tombstone carriers yield the
+        //     MAX `markedForDeleteAt` across ALL sources (with the winning mfda's
+        //     localDeletionTime) — the partition's OUTERMOST shadow floor. The
+        //     partition key is the same for every entry in this call
+        //     (`merge_partition_rows` is per partition), so one floor covers all.
+        //
+        // Carriers are NOT pushed into `clustered_rows`; the buffering pass below
+        // skips them and keeps only the per-`(pk, ck)` rows, exactly as before.
+        let carriers::PartitionCarriers {
+            mut range_tombstones,
+            max_partition_deletion,
+            partition_delete_key,
+        } = carriers::scan_partition_carriers(&rows);
 
-        // Issue #1072: extract the synthetic partition-tombstone carriers and keep
-        // the MAX `markedForDeleteAt` across ALL merge sources (with the winning
-        // mfda's localDeletionTime). This is the partition's OUTERMOST shadow floor.
-        // Carriers are NOT pushed into `clustered_rows` (they are partition-level,
-        // not per-`(pk, ck)` rows). The partition key is the same for every entry in
-        // this call (`merge_partition_rows` is invoked per partition), so a single
-        // floor value covers the whole partition.
-        let mut max_partition_deletion: Option<(i64, i32)> = None;
-        let mut partition_delete_key: Option<DecoratedKey> = None;
+        let mut clustered_rows: BTreeMap<Option<ClusteringKey>, Vec<MergeEntry>> = BTreeMap::new();
 
         // Row-count reconciliation (issue #2163): rows entering the reconcile
         // boundary. `rows` is moved by the loop below, so snapshot the count here.
@@ -2577,21 +2592,15 @@ impl KWayMerger {
         let rows_in = rows.len() as u64;
 
         for row in rows {
-            if row.is_partition_delete_carrier() {
-                if let Some((mfda, ldt)) = row.partition_deletion {
-                    partition_delete_key.get_or_insert_with(|| row.key.clone());
-                    match max_partition_deletion {
-                        Some((cur_mfda, _)) if cur_mfda >= mfda => {}
-                        _ => max_partition_deletion = Some((mfda, ldt)),
-                    }
-                    continue;
-                }
+            // Skip the partition-scoped carriers already captured above so only
+            // per-`(pk, ck)` rows enter `clustered_rows` (mirrors the original
+            // inline `continue`s exactly: partition-deletion carrier first, then
+            // range-marker carrier).
+            if row.is_partition_delete_carrier() && row.partition_deletion.is_some() {
+                continue;
             }
-            if Self::is_range_marker_carrier(&row) {
-                if let Some(rt) = row.range_deletion.clone() {
-                    range_tombstones.push((row.key.clone(), rt));
-                    continue;
-                }
+            if carriers::is_range_marker_carrier(&row) {
+                continue;
             }
             clustered_rows
                 .entry(row.clustering_key.clone())
@@ -2819,17 +2828,6 @@ impl KWayMerger {
         }
 
         Ok(merged)
-    }
-
-    /// True when an entry exists ONLY to carry a range-tombstone marker (issue
-    /// #933): an empty live row whose only payload is `range_deletion`. These are
-    /// produced by [`Self::build_merge_entry`] from a reader `RangeMarker` and are
-    /// split out of the row stream by [`Self::merge_partition_rows`].
-    fn is_range_marker_carrier(entry: &MergeEntry) -> bool {
-        entry.range_deletion.is_some()
-            && entry.complex_deletions.is_empty()
-            && entry.row_deletion.is_none()
-            && matches!(&entry.row_data, RowData::Live { cells } if cells.is_empty())
     }
 
     /// Coalesce range tombstones into a NON-OVERLAPPING canonical sequence per

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -115,7 +115,7 @@ mod reconcile;
 #[cfg(feature = "write-support")]
 mod streaming;
 #[cfg(feature = "write-support")]
-pub(crate) use streaming::{StreamingMerger, StreamingStep};
+pub(crate) use streaming::{PartitionReconcileCheckpoint, StreamingMerger, StreamingStep};
 
 /// Schema-aware heap-direct ordering proof (issue #1668, stage 5b) — proves
 /// cross-group emission order can be correct straight off a heap, with NO
@@ -2749,6 +2749,39 @@ impl KWayMerger {
     ///      entry whose row timestamp is the max surviving cell timestamp; else if a
     ///      row tombstone was present, emit a `Tombstone` entry at `row_del` so the
     ///      row stays shadowed downstream; else emit nothing.
+    ///
+    /// Overlap-safety gate for tombstone purging (#921 finding 1, #935):
+    /// decide BOTH the effective gc_grace cutoff and the overlap-aware
+    /// max-purgeable timestamp every cluster in this merger's output is
+    /// reconciled with. Constant for this `KWayMerger`'s whole lifetime
+    /// (derived only from its own `purge_safe`/`gc_before_secs`/
+    /// `max_purgeable_timestamp` fields, set once at construction) — callers
+    /// may compute it once and reuse it across every partition, rather than
+    /// re-deriving it per partition.
+    ///
+    /// Extracted from [`Self::merge_partition_rows`] (issue #1668 stage 5d)
+    /// so the streaming reconciliation path (`streaming.rs`) can reuse the
+    /// EXACT same derivation without duplicating it.
+    ///
+    /// - FULL compaction (`purge_safe == true`): no non-included overlapping
+    ///   SSTable exists, so the overlap bound is `+inf` (`i64::MAX`) — every
+    ///   gc-purgeable tombstone passes the overlap gate, exactly as #845.
+    /// - PARTIAL compaction with an overlap bound (#935): purge a tombstone
+    ///   only when its own deletion timestamp is STRICTLY LESS THAN the min
+    ///   write timestamp of every non-included overlapping SSTable, proving
+    ///   it shadows nothing outside the set.
+    /// - PARTIAL compaction without a bound (#921 default): retain every
+    ///   tombstone — collapse the cutoff to `None` (purge no-op).
+    fn effective_gc_settings(&self) -> (Option<i64>, i64) {
+        if self.purge_safe {
+            (self.gc_before_secs, i64::MAX)
+        } else if let Some(bound) = self.max_purgeable_timestamp {
+            (self.gc_before_secs, bound)
+        } else {
+            (None, i64::MIN)
+        }
+    }
+
     fn merge_partition_rows(&self, rows: Vec<MergeEntry>) -> Result<Vec<MergeEntry>> {
         use std::collections::BTreeMap;
 
@@ -2775,13 +2808,7 @@ impl KWayMerger {
         //
         // Issue #933 builds `clustered_rows` (and splits out range-tombstone
         // carriers) AFTER this gate, below.
-        let (effective_gc_before, max_purgeable_timestamp) = if self.purge_safe {
-            (self.gc_before_secs, i64::MAX)
-        } else if let Some(bound) = self.max_purgeable_timestamp {
-            (self.gc_before_secs, bound)
-        } else {
-            (None, i64::MIN)
-        };
+        let (effective_gc_before, max_purgeable_timestamp) = self.effective_gc_settings();
 
         // Partition-scoped tombstone-carrier pre-scan (issue #1668, stage 1).
         // A standalone read-only first pass extracts the partition-level

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -106,6 +106,11 @@ mod carriers;
 #[cfg(feature = "write-support")]
 mod reconcile;
 
+/// Streaming cluster-group step type (issue #1668, stage 2) — feature-
+/// internal, UNWIRED from every production consumer. See `streaming::StreamingMerger`.
+#[cfg(feature = "write-support")]
+mod streaming;
+
 /// Adapt a merge-path [`CellData`] into the shared [`ReconcileCell`] view
 /// (issue #947) so per-cell winner resolution calls
 /// [`reconcile_rules::cell_wins`] — the one shared `Cells#reconcile` tie-break —

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1143,12 +1143,25 @@ impl SSTableRowIterator for SSTableRowIteratorAdapter {
 pub struct KWayMerger {
     /// Input runs (one per SSTable)
     runs: Vec<RunReader>,
-    /// Min-heap for efficient merge
-    heap: BinaryHeap<Reverse<MergeEntry>>,
+    /// Min-heap for efficient merge (issue #1668, stage 5c-i): each element
+    /// pairs a `MergeEntry` with `schema_arc` so the heap's OWN pop order is
+    /// schema-aware (DESC clustering columns, NULL-first absent trailing
+    /// components) — see `schema_order::SchemaOrderedEntry`. Was
+    /// `BinaryHeap<Reverse<MergeEntry>>` (the fallback, non-schema-aware
+    /// `MergeEntry::Ord`) through stage 5b.
+    heap: BinaryHeap<Reverse<schema_order::SchemaOrderedEntry>>,
     /// Current partition being merged (for partition boundary detection)
     current_partition: Option<DecoratedKey>,
     /// Table schema for schema-aware merging
     schema: TableSchema,
+    /// `Arc`-wrapped clone of `schema`, ADDITIVE (issue #1668, stage 5c-i) —
+    /// cheap to clone per heap entry (a refcount bump, not a deep copy),
+    /// used ONLY by `schema_order::SchemaOrderedEntry` so the heap's
+    /// comparator can be schema-aware without `KWayMerger` becoming
+    /// self-referential (a heap entry cannot hold `&self.schema` while
+    /// living inside a sibling field of the SAME struct). Every OTHER
+    /// existing `self.schema` use-site in this file is UNCHANGED.
+    schema_arc: std::sync::Arc<TableSchema>,
     /// gc_grace cutoff (seconds since epoch): tombstones/cells whose
     /// `local_deletion_time < gc_before_secs` are purgeable.
     ///
@@ -2281,6 +2294,9 @@ impl KWayMerger {
             heap,
             current_partition: None,
             schema: schema.clone(),
+            // Issue #1668, stage 5c-i: `Arc`-wrapped clone of `schema`, used
+            // only by the heap's schema-aware comparator (see the field doc).
+            schema_arc: std::sync::Arc::new(schema.clone()),
             gc_before_secs,
             now_secs,
             // Conservatively unsafe by default (#921 finding 1): purging is
@@ -2472,23 +2488,24 @@ impl KWayMerger {
         let mut partition_rows = Vec::new();
         let mut partition_key: Option<DecoratedKey> = None;
 
-        while let Some(Reverse(entry)) = self.heap.peek() {
+        while let Some(Reverse(wrapped)) = self.heap.peek() {
             // Check if we've moved to a new partition
             if let Some(ref current_key) = partition_key {
-                if &entry.key != current_key {
+                if &wrapped.entry.key != current_key {
                     // Partition boundary - stop here
                     break;
                 }
             } else {
                 // First entry of new partition
-                partition_key = Some(entry.key.clone());
+                partition_key = Some(wrapped.entry.key.clone());
             }
 
             // Pop entry from heap
-            let Reverse(entry) = self
+            let Reverse(wrapped) = self
                 .heap
                 .pop()
                 .ok_or_else(|| Error::InvalidInput("Merge heap unexpectedly empty".to_string()))?;
+            let entry = wrapped.entry;
 
             // Add to partition rows
             partition_rows.push(entry.clone());
@@ -2526,9 +2543,14 @@ impl KWayMerger {
         let run = &mut self.runs[run_index];
         if !run.is_exhausted() {
             if let Some(entry) = run.peek()? {
-                // Clone and push to heap
+                // Clone and push to heap, paired with the schema-aware
+                // comparator's schema (issue #1668, stage 5c-i).
                 let entry = entry.clone();
-                self.heap.push(Reverse(entry));
+                self.heap
+                    .push(Reverse(schema_order::SchemaOrderedEntry::new(
+                        entry,
+                        self.schema_arc.clone(),
+                    )));
             }
 
             // Advance the run reader
@@ -4357,6 +4379,7 @@ mod tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         };
 
@@ -4479,6 +4502,7 @@ mod tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         };
 
@@ -4626,6 +4650,7 @@ mod tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         };
 
@@ -4775,6 +4800,7 @@ mod tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         };
 
@@ -4923,6 +4949,7 @@ mod tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         };
 
@@ -5056,6 +5083,7 @@ mod tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         };
 
@@ -5151,6 +5179,7 @@ mod tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         };
 
@@ -6491,6 +6520,7 @@ mod merge_property_tests {
                     purge_safe: false,
                     max_purgeable_timestamp: None,
                     schema: schema.clone(),
+                    schema_arc: std::sync::Arc::new(schema.clone()),
                 };
                 let real_merged = merger.merge_partition_rows(merge_entries.clone())
                     .expect("merge_partition_rows must not fail");
@@ -6617,6 +6647,7 @@ mod merge_property_tests {
                     purge_safe: false,
                     max_purgeable_timestamp: None,
                     schema: schema.clone(),
+                    schema_arc: std::sync::Arc::new(schema.clone()),
                 };
                 let merged = merger.merge_partition_rows(vec![live_entry, tombstone_entry])
                     .expect("merge_partition_rows must not fail");
@@ -6827,6 +6858,7 @@ mod streaming_tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         };
 
@@ -8867,6 +8899,7 @@ mod issue_822_merge_ordering_semantics {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         }
     }
@@ -9764,6 +9797,7 @@ mod issue_886_empty_partition_skip {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         }
     }
@@ -10053,6 +10087,7 @@ mod issue_912_row_tombstone_clustering_identity {
             purge_safe: false,
             max_purgeable_timestamp: None,
             schema: schema.clone(),
+            schema_arc: std::sync::Arc::new(schema.clone()),
         };
         let merged = merger
             .merge_partition_rows(vec![e5, e9])
@@ -10445,6 +10480,7 @@ mod issue_873_preserve_row_tombstone_ldt {
             purge_safe: false,
             max_purgeable_timestamp: None,
             schema: schema.clone(),
+            schema_arc: std::sync::Arc::new(schema.clone()),
         };
 
         let temp_dir = tempfile::TempDir::new().expect("temp dir");
@@ -10980,6 +11016,7 @@ mod issue_845_gc_grace_purge {
             heap: BinaryHeap::new(),
             current_partition: None,
             schema: unclustered_schema(),
+            schema_arc: std::sync::Arc::new(unclustered_schema()),
             gc_before_secs: Some(GC_BEFORE),
             now_secs: None,
             purge_safe,
@@ -11034,6 +11071,7 @@ mod issue_845_gc_grace_purge {
             heap: BinaryHeap::new(),
             current_partition: None,
             schema: unclustered_schema(),
+            schema_arc: std::sync::Arc::new(unclustered_schema()),
             gc_before_secs: Some(GC_BEFORE),
             now_secs: None,
             purge_safe,
@@ -11548,6 +11586,7 @@ mod issue_845_gc_grace_purge {
             purge_safe: false,
             max_purgeable_timestamp: None,
             schema: write_schema.clone(),
+            schema_arc: std::sync::Arc::new(write_schema.clone()),
         };
 
         let temp_dir = tempfile::TempDir::new().expect("temp dir");

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -106,10 +106,14 @@ mod carriers;
 #[cfg(feature = "write-support")]
 mod reconcile;
 
-/// Streaming cluster-group step type (issue #1668, stage 2) — feature-
-/// internal, UNWIRED from every production consumer. See `streaming::StreamingMerger`.
+/// Streaming cluster-group step type (issue #1668, stages 2-3b). See
+/// [`StreamingMerger`]. Wired into [`KWayMerger::merge`] (stage 3b) and
+/// `write_engine::maintenance`'s compaction loop; the Flight producer is
+/// intentionally untouched (Q4/mid-partition-budget territory, later stage).
 #[cfg(feature = "write-support")]
 mod streaming;
+#[cfg(feature = "write-support")]
+pub(crate) use streaming::{StreamingMerger, StreamingStep};
 
 /// Adapt a merge-path [`CellData`] into the shared [`ReconcileCell`] view
 /// (issue #947) so per-cell winner resolution calls
@@ -2343,53 +2347,79 @@ impl KWayMerger {
             dropped_whole: Vec::new(),
         };
 
-        while let MergeStep::Partition { key, rows } = self.step()? {
-            // Skip truly-empty phantom entries on the writer path (#886/#899
-            // branch-review). A range-tombstone carrier is NO LONGER filtered here
-            // (#933): `merge_entry_to_mutation` turns it into a mutation carrying
-            // `range_tombstones`, which the writer emits as on-disk bound markers
-            // (and uses to shadow same-partition rows). See
-            // `MergeEntry::is_metadata_only_no_op`.
-            let mutations = rows
-                .into_iter()
-                .filter(|entry| !entry.is_metadata_only_no_op())
-                .map(|entry| Self::merge_entry_to_mutation(entry, &self.schema))
-                .collect::<Result<Vec<_>>>()?;
+        // Stage 3b (#1668): consume via the streaming increment API
+        // (`StreamingMerger`/`StreamingStep`) instead of the whole-partition
+        // `step()` directly. `step_streaming` still calls the UNCHANGED
+        // `step()` internally and drains its already-reconciled
+        // `Vec<MergeEntry>` one row at a time — proven byte-identical to
+        // `step()`'s own output by the stage-2/3a equivalence tests — so this
+        // does NOT yet reduce peak memory (stage 5's job); it proves the
+        // incremental-consumption plumbing composes end-to-end with the
+        // writer. Clone the schema up front: `stream` holds `&mut self` for
+        // the loop's duration, so the per-row conversion below cannot also
+        // borrow `self`.
+        let schema = self.schema.clone();
+        let mut stream = StreamingMerger::new(&mut self);
+        let mut pending_rows: Vec<MergeEntry> = Vec::new();
 
-            // If the partition has no writer-emittable content at all, skip
-            // `write_partition` to avoid a phantom EMPTY partition. A partition
-            // carrying ONLY range-tombstone markers (every data row covered) IS
-            // emittable — Cassandra writes such marker-only partitions — so it is
-            // kept here (#933).
-            if mutations.is_empty() {
-                continue;
+        loop {
+            match stream.step_streaming()? {
+                StreamingStep::ClusterGroup { row, .. } => pending_rows.push(*row),
+                StreamingStep::PartitionEnd { key } => {
+                    let rows = std::mem::take(&mut pending_rows);
+
+                    // Skip truly-empty phantom entries on the writer path
+                    // (#886/#899 branch-review). A range-tombstone carrier is
+                    // NO LONGER filtered here (#933): `merge_entry_to_mutation`
+                    // turns it into a mutation carrying `range_tombstones`,
+                    // which the writer emits as on-disk bound markers (and
+                    // uses to shadow same-partition rows). See
+                    // `MergeEntry::is_metadata_only_no_op`.
+                    let mutations = rows
+                        .into_iter()
+                        .filter(|entry| !entry.is_metadata_only_no_op())
+                        .map(|entry| Self::merge_entry_to_mutation(entry, &schema))
+                        .collect::<Result<Vec<_>>>()?;
+
+                    // If the partition has no writer-emittable content at
+                    // all, skip `write_partition` to avoid a phantom EMPTY
+                    // partition. A partition carrying ONLY range-tombstone
+                    // markers (every data row covered) IS emittable —
+                    // Cassandra writes such marker-only partitions — so it is
+                    // kept here (#933).
+                    if mutations.is_empty() {
+                        continue;
+                    }
+
+                    // Count only real rows toward `output_rows`. A pure
+                    // range-tombstone carrier (empty operations, no row
+                    // tombstone, only `range_tombstones`) emits a marker, not
+                    // a row (#933). A pure partition-tombstone carrier (empty
+                    // operations, no row tombstone, no range tombstones, only
+                    // `partition_tombstone`) emits a partition-header
+                    // deletion, not a row (#1072).
+                    let row_mutations = mutations
+                        .iter()
+                        .filter(|m| {
+                            let is_range_only = m.operations.is_empty()
+                                && m.partition_tombstone.is_none()
+                                && m.row_tombstone.is_none()
+                                && !m.range_tombstones.is_empty();
+                            let is_partition_only = m.operations.is_empty()
+                                && m.partition_tombstone.is_some()
+                                && m.row_tombstone.is_none()
+                                && m.range_tombstones.is_empty();
+                            !(is_range_only || is_partition_only)
+                        })
+                        .count();
+
+                    stats.output_partitions += 1;
+                    stats.output_rows += row_mutations as u64;
+
+                    output_writer.write_partition(key, mutations)?;
+                }
+                StreamingStep::Complete => break,
             }
-
-            // Count only real rows toward `output_rows`. A pure range-tombstone
-            // carrier (empty operations, no row tombstone, only `range_tombstones`)
-            // emits a marker, not a row (#933). A pure partition-tombstone carrier
-            // (empty operations, no row tombstone, no range tombstones, only
-            // `partition_tombstone`) emits a partition-header deletion, not a row
-            // (#1072).
-            let row_mutations = mutations
-                .iter()
-                .filter(|m| {
-                    let is_range_only = m.operations.is_empty()
-                        && m.partition_tombstone.is_none()
-                        && m.row_tombstone.is_none()
-                        && !m.range_tombstones.is_empty();
-                    let is_partition_only = m.operations.is_empty()
-                        && m.partition_tombstone.is_some()
-                        && m.row_tombstone.is_none()
-                        && m.range_tombstones.is_empty();
-                    !(is_range_only || is_partition_only)
-                })
-                .count();
-
-            stats.output_partitions += 1;
-            stats.output_rows += row_mutations as u64;
-
-            output_writer.write_partition(key, mutations)?;
         }
 
         // Issue #1238: report the REAL output Data.db byte count instead of a

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -57,7 +57,9 @@ use crate::error::{Error, Result};
 #[cfg(feature = "write-support")]
 use crate::schema::TableSchema;
 #[cfg(feature = "write-support")]
-use crate::storage::write_engine::mutation::{ClusteringKey, DecoratedKey, RangeTombstone};
+use crate::storage::write_engine::mutation::{
+    ClusteringKey, DecoratedKey, PartitionTombstone, RangeTombstone,
+};
 #[cfg(feature = "write-support")]
 use crate::storage::write_engine::reconcile_rules;
 #[cfg(feature = "write-support")]
@@ -2371,78 +2373,222 @@ impl KWayMerger {
             dropped_whole: Vec::new(),
         };
 
-        // Stage 3b (#1668): consume via the streaming increment API
-        // (`StreamingMerger`/`StreamingStep`) instead of the whole-partition
-        // `step()` directly. `step_streaming` still calls the UNCHANGED
-        // `step()` internally and drains its already-reconciled
-        // `Vec<MergeEntry>` one row at a time — proven byte-identical to
-        // `step()`'s own output by the stage-2/3a equivalence tests — so this
-        // does NOT yet reduce peak memory (stage 5's job); it proves the
-        // incremental-consumption plumbing composes end-to-end with the
-        // writer. Clone the schema up front: `stream` holds `&mut self` for
-        // the loop's duration, so the per-row conversion below cannot also
-        // borrow `self`.
+        // Stage 5c-iv part 2 (#1668): feed cluster groups DIRECTLY to the
+        // incremental writer entry point (part 1) instead of assembling a
+        // whole `Vec<Mutation>` and calling `write_partition` once. The
+        // (bounded, partition-size-independent) `clustering_key: None`
+        // prefix — a static-row carrier and/or range/partition-tombstone
+        // carriers — is ALWAYS emitted before any `Some(ck)` row (proven in
+        // `streaming.rs`'s `static_row_carrier_always_sorts_first_
+        // regardless_of_partition_width` test), so it is buffered just long
+        // enough to resolve the partition tombstone / range-tombstones /
+        // static ops that `begin_partition_incremental`/`feed_static_row`
+        // need UPFRONT. Every subsequent `Some(ck)` row streams straight
+        // through `feed_row` with NO `Vec<Mutation>` accumulation.
+        let schema_has_static = self.schema.columns.iter().any(|c| c.is_static);
         let schema = self.schema.clone();
         let mut stream = StreamingMerger::new(&mut self);
-        let mut pending_rows: Vec<MergeEntry> = Vec::new();
 
-        loop {
-            match stream.step_streaming()? {
-                StreamingStep::ClusterGroup { row, .. } => pending_rows.push(*row),
-                StreamingStep::PartitionEnd { key } => {
-                    let rows = std::mem::take(&mut pending_rows);
+        // Outer loop: one iteration per PARTITION, with all partition-scoped
+        // state (including `session`, which borrows both `output_writer` and
+        // `range_tombstones`) declared FRESH each iteration. This is
+        // required, not stylistic: a `session` variable declared ONCE
+        // outside this loop and reassigned across partitions would force
+        // the borrow checker to unify ITS lifetime parameters across EVERY
+        // partition, making `range_tombstones`/`output_writer` look
+        // borrowed for the REST OF THE FUNCTION instead of just the current
+        // partition. Re-declaring per outer iteration gives each
+        // partition's borrows their own independent, iteration-scoped
+        // lifetime.
+        'partitions: loop {
+            let mut partition_tombstone: Option<PartitionTombstone> = None;
+            let mut range_tombstones: Vec<RangeTombstone> = Vec::new();
+            // Frozen once the prefix completes (see the `ClusterGroup` arm
+            // below) — declared HERE, at the SAME scope as `session`, so
+            // `session`'s borrow of it remains valid for the REST of this
+            // partition's inner-loop iterations (a version scoped only to
+            // the match arm that freezes it would be dropped before
+            // `session` is, a dangling-borrow error). The empty initializer
+            // is always overwritten via `std::mem::take` before any borrow
+            // of it occurs; only its DECLARATION needs to live at this
+            // scope, not this particular value.
+            #[allow(unused_assignments)]
+            let mut range_tombstones_frozen: Vec<RangeTombstone> = Vec::new();
+            let mut static_tracker =
+                crate::storage::sstable::writer::data_writer::StaticOpsTracker::new();
+            let mut static_first_ts: i64 = 0;
+            let mut saw_carrier_or_static = false;
+            let mut row_count: u64 = 0;
+            let mut session: Option<
+                crate::storage::sstable::writer::data_writer::IncrementalPartitionWriter<'_, '_>,
+            > = None;
+            // Issue #1668 stage 5c-iv part 2: this partition's stats fold,
+            // accumulated one mutation at a time (see the single fold point
+            // below) since `output_writer.stats` cannot be touched directly
+            // while `session` holds an exclusive borrow of `output_writer`.
+            // Merged into `output_writer.stats` at partition end via
+            // `complete_partition_incremental`, once that borrow has ended.
+            let mut partition_stats = crate::storage::sstable::writer::StatisticsMetadata::new();
 
-                    // Skip truly-empty phantom entries on the writer path
-                    // (#886/#899 branch-review). A range-tombstone carrier is
-                    // NO LONGER filtered here (#933): `merge_entry_to_mutation`
-                    // turns it into a mutation carrying `range_tombstones`,
-                    // which the writer emits as on-disk bound markers (and
-                    // uses to shadow same-partition rows). See
-                    // `MergeEntry::is_metadata_only_no_op`.
-                    let mutations = rows
-                        .into_iter()
-                        .filter(|entry| !entry.is_metadata_only_no_op())
-                        .map(|entry| Self::merge_entry_to_mutation(entry, &schema))
-                        .collect::<Result<Vec<_>>>()?;
+            loop {
+                match stream.step_streaming()? {
+                    StreamingStep::ClusterGroup { key, row } => {
+                        // Skip truly-empty phantom entries (#886/#899
+                        // branch-review) — mirrors the original
+                        // `.filter(|entry| !entry.is_metadata_only_no_op())`.
+                        if row.is_metadata_only_no_op() {
+                            continue;
+                        }
+                        let mutation = Self::merge_entry_to_mutation(*row, &schema)?;
+                        // Single fold point for EVERY mutation of this
+                        // partition (carrier, static, or clustered row) —
+                        // mirrors `write_partition`'s
+                        // `for mutation in &mutations { fold... }` loop,
+                        // which folds unconditionally regardless of
+                        // classification.
+                        crate::storage::sstable::writer::stats_fold::fold_mutation_stats(
+                            &mut partition_stats,
+                            &mutation,
+                        );
 
-                    // If the partition has no writer-emittable content at
-                    // all, skip `write_partition` to avoid a phantom EMPTY
-                    // partition. A partition carrying ONLY range-tombstone
-                    // markers (every data row covered) IS emittable —
-                    // Cassandra writes such marker-only partitions — so it is
-                    // kept here (#933).
-                    if mutations.is_empty() {
-                        continue;
+                        if let Some(active) = session.as_mut() {
+                            // Already streaming this partition's Some(ck) tail.
+                            active.feed_row(&mutation, &schema)?;
+                            row_count += 1;
+                            continue;
+                        }
+
+                        // Still in the (bounded) None-keyed prefix.
+                        let is_partition_only = mutation.operations.is_empty()
+                            && mutation.partition_tombstone.is_some()
+                            && mutation.row_tombstone.is_none()
+                            && mutation.range_tombstones.is_empty();
+                        let is_range_only = mutation.operations.is_empty()
+                            && mutation.partition_tombstone.is_none()
+                            && mutation.row_tombstone.is_none()
+                            && !mutation.range_tombstones.is_empty();
+
+                        if is_partition_only {
+                            partition_tombstone = mutation.partition_tombstone;
+                            saw_carrier_or_static = true;
+                            continue;
+                        }
+                        if is_range_only {
+                            range_tombstones.extend(mutation.range_tombstones.iter().cloned());
+                            saw_carrier_or_static = true;
+                            continue;
+                        }
+                        // A `clustering_key: None` mutation is the resolved
+                        // static-row carrier ONLY when the schema actually
+                        // declares static columns — Cassandra disallows
+                        // static columns on a table with no clustering
+                        // columns, so for an UNCLUSTERED table EVERY row
+                        // (not just a special carrier) uses
+                        // `clustering_key: None` too (mirrors
+                        // `write_partition_with_index_blocks`'s own
+                        // `schema_has_static` gate: without it, that
+                        // table's sole per-partition row would be
+                        // misrouted here and silently dropped instead of
+                        // streamed as a real row).
+                        if mutation.clustering_key.is_none() && schema_has_static {
+                            // The resolved static-row carrier (issue #1668
+                            // design verification: at most one, always
+                            // first). Counted toward `output_rows` (issue
+                            // #1238's original `row_mutations` filter
+                            // counts ANY mutation with non-empty
+                            // `operations` — a static mutation always has
+                            // some — so this mirrors that exactly, not
+                            // just the Some(ck) rows).
+                            if !saw_carrier_or_static {
+                                static_first_ts = mutation.timestamp_micros;
+                            }
+                            static_tracker.feed(&mutation, &schema, None);
+                            saw_carrier_or_static = true;
+                            row_count += 1;
+                            continue;
+                        }
+
+                        // First Some(ck) row (or, for an unclustered table,
+                        // its sole `clustering_key: None` row): the prefix
+                        // is now COMPLETE. Move it into the iteration-
+                        // scoped `range_tombstones_frozen` (never mutated
+                        // again in this scope) before constructing the
+                        // session, so its borrow stays valid for the rest
+                        // of this partition's inner-loop iterations without
+                        // aliasing the (now-empty, and no longer touched)
+                        // `range_tombstones` accumulator.
+                        range_tombstones_frozen = std::mem::take(&mut range_tombstones);
+                        let mut new_session = output_writer.begin_partition_incremental(
+                            &key,
+                            partition_tombstone.as_ref(),
+                            &range_tombstones_frozen,
+                        )?;
+                        if schema_has_static {
+                            let merged = std::mem::take(&mut static_tracker).finish();
+                            new_session.feed_static_row(&merged, static_first_ts, &schema)?;
+                        }
+                        new_session.feed_row(&mutation, &schema)?;
+                        row_count += 1;
+                        stats.output_partitions += 1;
+                        session = Some(new_session);
                     }
-
-                    // Count only real rows toward `output_rows`. A pure
-                    // range-tombstone carrier (empty operations, no row
-                    // tombstone, only `range_tombstones`) emits a marker, not
-                    // a row (#933). A pure partition-tombstone carrier (empty
-                    // operations, no row tombstone, no range tombstones, only
-                    // `partition_tombstone`) emits a partition-header
-                    // deletion, not a row (#1072).
-                    let row_mutations = mutations
-                        .iter()
-                        .filter(|m| {
-                            let is_range_only = m.operations.is_empty()
-                                && m.partition_tombstone.is_none()
-                                && m.row_tombstone.is_none()
-                                && !m.range_tombstones.is_empty();
-                            let is_partition_only = m.operations.is_empty()
-                                && m.partition_tombstone.is_some()
-                                && m.row_tombstone.is_none()
-                                && m.range_tombstones.is_empty();
-                            !(is_range_only || is_partition_only)
-                        })
-                        .count();
-
-                    stats.output_partitions += 1;
-                    stats.output_rows += row_mutations as u64;
-
-                    output_writer.write_partition(key, mutations)?;
+                    StreamingStep::PartitionEnd { key } => {
+                        match session.take() {
+                            Some(active) => {
+                                let (offset, blocks, emit) = active.finish(&schema)?;
+                                output_writer.complete_partition_incremental(
+                                    &key,
+                                    partition_tombstone.as_ref(),
+                                    offset,
+                                    &blocks,
+                                    emit,
+                                    &partition_stats,
+                                )?;
+                                stats.output_rows += row_count;
+                            }
+                            None if saw_carrier_or_static => {
+                                // No Some(ck) row ever arrived, but a
+                                // range/partition tombstone or a static
+                                // value survived — still emittable
+                                // (#933/#1072), matching the original `if
+                                // mutations.is_empty() { continue; }`
+                                // guard's negative case exactly.
+                                let mut new_session = output_writer.begin_partition_incremental(
+                                    &key,
+                                    partition_tombstone.as_ref(),
+                                    &range_tombstones,
+                                )?;
+                                if schema_has_static {
+                                    let merged = std::mem::take(&mut static_tracker).finish();
+                                    new_session.feed_static_row(
+                                        &merged,
+                                        static_first_ts,
+                                        &schema,
+                                    )?;
+                                }
+                                let (offset, blocks, emit) = new_session.finish(&schema)?;
+                                output_writer.complete_partition_incremental(
+                                    &key,
+                                    partition_tombstone.as_ref(),
+                                    offset,
+                                    &blocks,
+                                    emit,
+                                    &partition_stats,
+                                )?;
+                                stats.output_partitions += 1;
+                                stats.output_rows += row_count;
+                            }
+                            None => {
+                                // Truly empty partition (every entry was
+                                // metadata-only-no-op) — skip entirely,
+                                // matching the original
+                                // `mutations.is_empty()` skip.
+                            }
+                        }
+                        continue 'partitions;
+                    }
+                    StreamingStep::Complete => break 'partitions,
                 }
-                StreamingStep::Complete => break,
             }
         }
 
@@ -9852,6 +9998,12 @@ mod issue_886_empty_partition_skip {
             &schema,
         )
         .expect("create writer");
+        // Issue #1668 stage 5c-iv part 2: `KWayMerger::merge` streams
+        // partitions through `begin_partition_incremental`, which requires
+        // pre-seeded encoding baselines — matching the one real production
+        // caller (`compact_sstables_with_registry`). No tombstones/TTLs in
+        // this data, so seed a safe floor below every cell timestamp.
+        writer.pre_seed_encoding_baselines(0, i32::MAX, i32::MAX);
 
         let stats = merger.merge(&mut writer).expect("merge must succeed");
 
@@ -9906,6 +10058,9 @@ mod issue_886_empty_partition_skip {
             &schema,
         )
         .expect("create writer");
+        // Issue #1668 stage 5c-iv part 2: see the sibling test above for why
+        // this pre-seed is required.
+        writer.pre_seed_encoding_baselines(0, i32::MAX, i32::MAX);
 
         let stats = merger.merge(&mut writer).expect("merge must succeed");
         assert_eq!(stats.output_partitions, 1);
@@ -10490,6 +10645,14 @@ mod issue_873_preserve_row_tombstone_ldt {
             &schema,
         )
         .expect("create writer");
+        // Issue #1668 stage 5c-iv part 2: `KWayMerger::merge` now streams
+        // partitions through `begin_partition_incremental`, which requires
+        // pre-seeded encoding baselines (it cannot buffer a whole partition
+        // to discover the minimum LDT/timestamp before emitting bytes,
+        // unlike `write_partition`) — exactly what the one real production
+        // caller (`compact_sstables_with_registry`) always does. Seed with
+        // this test's own known minimums, matching that real usage.
+        writer.pre_seed_encoding_baselines(deletion_time, source_ldt, i32::MAX);
 
         // Drives merge_partition_rows → merge_entry_to_mutation → write_partition
         // (the production rewrite path). Must not underflow the LDT delta.
@@ -11596,6 +11759,12 @@ mod issue_845_gc_grace_purge {
             &write_schema,
         )
         .expect("create writer");
+        // Issue #1668 stage 5c-iv part 2: `KWayMerger::merge` now streams
+        // partitions through `begin_partition_incremental`, which requires
+        // pre-seeded encoding baselines — exactly what the one real
+        // production caller (`compact_sstables_with_registry`) always does.
+        // Seed with this test's own known marker minimums.
+        writer.pre_seed_encoding_baselines(MARKER_MFDA, MARKER_LDT, i32::MAX);
         merger.merge(&mut writer).expect("merge+write must succeed");
         let info = writer.finish().await.expect("finish must succeed");
         let data_path = info.data_path;

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -2418,36 +2418,49 @@ impl KWayMerger {
         'partitions: loop {
             let mut partition_tombstone: Option<PartitionTombstone> = None;
             let mut range_tombstones: Vec<RangeTombstone> = Vec::new();
-            // Frozen once the prefix completes (see the `ClusterGroup` arm
-            // below) — declared HERE, at the SAME scope as `session`, so
-            // `session`'s borrow of it remains valid for the REST of this
-            // partition's inner-loop iterations (a version scoped only to
-            // the match arm that freezes it would be dropped before
-            // `session` is, a dangling-borrow error). The empty initializer
-            // is always overwritten via `std::mem::take` before any borrow
-            // of it occurs; only its DECLARATION needs to live at this
-            // scope, not this particular value.
-            #[allow(unused_assignments)]
-            let mut range_tombstones_frozen: Vec<RangeTombstone> = Vec::new();
             let mut static_tracker =
                 crate::storage::sstable::writer::data_writer::StaticOpsTracker::new();
             let mut static_first_ts: i64 = 0;
             let mut saw_carrier_or_static = false;
             let mut row_count: u64 = 0;
-            let mut session: Option<
-                crate::storage::sstable::writer::data_writer::IncrementalPartitionWriter<'_, '_>,
-            > = None;
-            // Issue #1668 stage 5c-iv part 2: this partition's stats fold,
-            // accumulated one mutation at a time (see the single fold point
-            // below) since `output_writer.stats` cannot be touched directly
-            // while `session` holds an exclusive borrow of `output_writer`.
-            // Merged into `output_writer.stats` at partition end via
-            // `complete_partition_incremental`, once that borrow has ended.
+            // Issue #1383 regression fix (crit2-4), issue #1668: buffer this
+            // partition's surviving `Some(ck)` row mutations rather than
+            // streaming each straight into the writer session as it arrives.
+            //
+            // The streaming writer session (`begin_partition_incremental`)
+            // needs the partition's COMPLETE range-tombstone set UPFRONT: it
+            // sorts the range bounds into on-disk markers and interleaves them
+            // with rows in clustering order as each row is fed (and uses them
+            // to compute each row's `shadow_floor`). But `StreamingMerger`
+            // only surfaces a range tombstone's coalesced marker once its
+            // CLOSE bound is parsed — which, for a range whose covered rows
+            // live in a different (e.g. newer) generation, is strictly AFTER
+            // those rows have already streamed past (issue #1668 stage 5d's
+            // "range tombstones can arrive AFTER the rows they cover"
+            // finding). Opening the session on the first `Some(ck)` row
+            // therefore fixed an EMPTY range-tombstone set, then fed every
+            // late marker mutation through `feed_row` — which silently dropped
+            // it (a range-only mutation has no row content) — so a synthesized
+            // boundary vanished from the compacted output entirely.
+            //
+            // Buffering the rows until PartitionEnd lets us open the session
+            // with the FULL, final range-tombstone set, so `feed_row` shadows
+            // every covered row correctly AND interleaves the markers in
+            // clustering order. A genuinely bounded-memory streaming WRITE for
+            // range-tombstone partitions would need the out-of-scope two-pass
+            // reader that surfaces a range's OPEN bound early; this buffer is
+            // whole-partition-width for such partitions (the reader already
+            // materializes the decompressed section anyway — see the
+            // streaming dhat test's module doc), while `StreamingMerger`'s
+            // own reconciliation stays row-streamed (the memory bound the
+            // dhat proof actually exercises).
+            let mut buffered_rows: Vec<crate::storage::write_engine::mutation::Mutation> =
+                Vec::new();
             let mut partition_stats = crate::storage::sstable::writer::StatisticsMetadata::new();
 
             loop {
                 match stream.step_streaming()? {
-                    StreamingStep::ClusterGroup { key, row } => {
+                    StreamingStep::ClusterGroup { key: _, row } => {
                         // Skip truly-empty phantom entries (#886/#899
                         // branch-review) — mirrors the original
                         // `.filter(|entry| !entry.is_metadata_only_no_op())`.
@@ -2466,14 +2479,12 @@ impl KWayMerger {
                             &mutation,
                         );
 
-                        if let Some(active) = session.as_mut() {
-                            // Already streaming this partition's Some(ck) tail.
-                            active.feed_row(&mutation, &write_schema)?;
-                            row_count += 1;
-                            continue;
-                        }
-
-                        // Still in the (bounded) None-keyed prefix.
+                        // Classify the (None-keyed) carriers and the static
+                        // row; everything else is a real clustering row that
+                        // is BUFFERED (see `buffered_rows`' doc) — range
+                        // tombstones can still arrive after some rows have
+                        // already been buffered, which is exactly why the
+                        // whole set must be resolved before the session opens.
                         let is_partition_only = mutation.operations.is_empty()
                             && mutation.partition_tombstone.is_some()
                             && mutation.row_tombstone.is_none()
@@ -2504,7 +2515,7 @@ impl KWayMerger {
                         // `schema_has_static` gate: without it, that
                         // table's sole per-partition row would be
                         // misrouted here and silently dropped instead of
-                        // streamed as a real row).
+                        // written as a real row).
                         if mutation.clustering_key.is_none() && schema_has_static {
                             // The resolved static-row carrier (issue #1668
                             // design verification: at most one, always
@@ -2523,82 +2534,47 @@ impl KWayMerger {
                             continue;
                         }
 
-                        // First Some(ck) row (or, for an unclustered table,
-                        // its sole `clustering_key: None` row): the prefix
-                        // is now COMPLETE. Move it into the iteration-
-                        // scoped `range_tombstones_frozen` (never mutated
-                        // again in this scope) before constructing the
-                        // session, so its borrow stays valid for the rest
-                        // of this partition's inner-loop iterations without
-                        // aliasing the (now-empty, and no longer touched)
-                        // `range_tombstones` accumulator.
-                        range_tombstones_frozen = std::mem::take(&mut range_tombstones);
-                        let mut new_session = output_writer.begin_partition_incremental(
-                            &key,
-                            partition_tombstone.as_ref(),
-                            &range_tombstones_frozen,
-                        )?;
-                        if schema_has_static {
-                            let merged = std::mem::take(&mut static_tracker).finish();
-                            new_session.feed_static_row(&merged, static_first_ts, &write_schema)?;
-                        }
-                        new_session.feed_row(&mutation, &write_schema)?;
+                        // A real clustering row (or an unclustered table's
+                        // sole `clustering_key: None` row): buffer it for the
+                        // single PartitionEnd write once the full
+                        // range-tombstone set is known.
+                        buffered_rows.push(mutation);
                         row_count += 1;
-                        stats.output_partitions += 1;
-                        session = Some(new_session);
                     }
                     StreamingStep::PartitionEnd { key } => {
-                        match session.take() {
-                            Some(active) => {
-                                let (offset, blocks, emit) = active.finish(&write_schema)?;
-                                output_writer.complete_partition_incremental(
-                                    &key,
-                                    partition_tombstone.as_ref(),
-                                    offset,
-                                    &blocks,
-                                    emit,
-                                    &partition_stats,
-                                )?;
-                                stats.output_rows += row_count;
+                        // Write the whole partition in ONE session now that
+                        // the partition tombstone, the COMPLETE coalesced
+                        // range-tombstone set, the static row, and every
+                        // surviving clustering row are all known. Skip a
+                        // truly empty partition (every entry was
+                        // metadata-only-no-op), matching the original
+                        // `mutations.is_empty()` skip. A partition with only
+                        // carriers/statics but no `Some(ck)` row is still
+                        // emittable (#933/#1072).
+                        if !buffered_rows.is_empty() || saw_carrier_or_static {
+                            let mut session = output_writer.begin_partition_incremental(
+                                &key,
+                                partition_tombstone.as_ref(),
+                                &range_tombstones,
+                            )?;
+                            if schema_has_static {
+                                let merged = std::mem::take(&mut static_tracker).finish();
+                                session.feed_static_row(&merged, static_first_ts, &write_schema)?;
                             }
-                            None if saw_carrier_or_static => {
-                                // No Some(ck) row ever arrived, but a
-                                // range/partition tombstone or a static
-                                // value survived — still emittable
-                                // (#933/#1072), matching the original `if
-                                // mutations.is_empty() { continue; }`
-                                // guard's negative case exactly.
-                                let mut new_session = output_writer.begin_partition_incremental(
-                                    &key,
-                                    partition_tombstone.as_ref(),
-                                    &range_tombstones,
-                                )?;
-                                if schema_has_static {
-                                    let merged = std::mem::take(&mut static_tracker).finish();
-                                    new_session.feed_static_row(
-                                        &merged,
-                                        static_first_ts,
-                                        &write_schema,
-                                    )?;
-                                }
-                                let (offset, blocks, emit) = new_session.finish(&write_schema)?;
-                                output_writer.complete_partition_incremental(
-                                    &key,
-                                    partition_tombstone.as_ref(),
-                                    offset,
-                                    &blocks,
-                                    emit,
-                                    &partition_stats,
-                                )?;
-                                stats.output_partitions += 1;
-                                stats.output_rows += row_count;
+                            for mutation in &buffered_rows {
+                                session.feed_row(mutation, &write_schema)?;
                             }
-                            None => {
-                                // Truly empty partition (every entry was
-                                // metadata-only-no-op) — skip entirely,
-                                // matching the original
-                                // `mutations.is_empty()` skip.
-                            }
+                            let (offset, blocks, emit) = session.finish(&write_schema)?;
+                            output_writer.complete_partition_incremental(
+                                &key,
+                                partition_tombstone.as_ref(),
+                                offset,
+                                &blocks,
+                                emit,
+                                &partition_stats,
+                            )?;
+                            stats.output_partitions += 1;
+                            stats.output_rows += row_count;
                         }
                         continue 'partitions;
                     }

--- a/cqlite-core/src/storage/write_engine/merge/schema_order.rs
+++ b/cqlite-core/src/storage/write_engine/merge/schema_order.rs
@@ -1,17 +1,13 @@
-//! Schema-aware heap-direct ordering proof (issue #1668, stage 5b) — the
-//! "deferred crux" from stage 3a, solved for real this time.
+//! Schema-aware heap-direct ordering (issue #1668, stages 5b-5c-i) — the
+//! "deferred crux" from stage 3a, solved for real.
 //!
-//! Stage 3a proved cross-group emission order is safe TODAY only because
-//! [`super::KWayMerger::step_streaming`] drains a `Vec<MergeEntry>` that
-//! `merge_partition_rows` already schema-aware-sorted (`merged.sort_by(|a,
+//! Stage 3a proved cross-group emission order was safe pre-5c-i only because
+//! [`super::KWayMerger::step_streaming`] drained a `Vec<MergeEntry>` that
+//! `merge_partition_rows` had already schema-aware-sorted (`merged.sort_by(|a,
 //! b| ck_a.compare(ck_b, &self.schema) ...)`) as its unconditional last step.
-//! Removing that whole-partition sort (stage 5d's job) requires a heap whose
-//! POP ORDER is *itself* schema-correct — this module proves that is
-//! achievable and correct, WITHOUT yet touching [`super::KWayMerger`]'s own
-//! `heap: BinaryHeap<Reverse<MergeEntry>>` field (that wiring is stage 5c/5d's
-//! job, once the writer can also accept true increments — mirroring the
-//! stage-2-before-stage-3b precedent: introduce and prove the mechanism
-//! first, wire it into production once every dependency is ready).
+//! [`super::KWayMerger`]'s `heap` field now uses [`SchemaOrderedEntry`]
+//! directly (stage 5c-i), so the heap's OWN pop order is schema-correct —
+//! see [`SchemaOrderedEntry`]'s `Ord` impl.
 //!
 //! ## Why a bounded lookahead/reorder buffer is NOT sufficient
 //!
@@ -23,45 +19,31 @@
 //! FIRST — which is the LAST value the fallback order would ever produce.
 //! Emitting the correct first item therefore requires having already seen
 //! ALL N items — the required lookahead is O(N), not a fixed constant
-//! independent of partition size. This is proven directly by
-//! `stage3a`'s `step_streaming_matches_step_for_desc_clustering_fixture`
-//! (fed via the SAME merger machinery) and is why this module makes the
-//! comparator itself schema-aware instead.
+//! independent of partition size. This is why the comparator itself must be
+//! schema-aware.
 //!
-//! ## Design: a schema-aware comparator with NO lifetime on `KWayMerger`
+//! ## Design: `Arc<TableSchema>`, not a borrowed lifetime
 //!
 //! `MergeEntry::Ord` cannot be made schema-aware directly: `Ord::cmp(&self,
 //! &other) -> Ordering` takes no extra context, and `ClusteringKey::compare`
-//! needs `&TableSchema`. Storing a `&'a TableSchema` (or `Arc<TableSchema>`)
-//! on every heap entry, if that heap were a LONG-LIVED struct field (like
-//! `KWayMerger.heap`), would need `KWayMerger` to be self-referential (the
-//! heap borrowing a sibling field of the SAME struct) — not expressible in
-//! safe Rust. This module sidesteps the problem entirely by keeping the
-//! schema-aware heap PURELY LOCAL to one function call
-//! ([`schema_ordered_pop_all`]): the wrapper's `&'a TableSchema` borrow and
-//! the heap it lives in are both stack-local to that call, so there is no
-//! self-reference. Wiring this into `KWayMerger.heap` itself (stage 5c/5d)
-//! will need ONE of: (a) an `Arc<TableSchema>` field alongside the existing
-//! plain `schema: TableSchema` (cheap, additive, no lifetime issue), or (b)
-//! a per-entry precomputed schema-independent sort key. Not resolved here —
-//! this module only proves the COMPARATOR is correct and sufficient.
-
-// Stage 5b (#1668) is deliberately UNWIRED: no production caller constructs a
-// `SchemaOrderedEntry` yet (that is stage 5c/5d), so a normal (non-test)
-// build sees every item here as unreachable. Matches the crate's existing
-// convention for proof-only surface pending production wiring (see
-// `streaming.rs`'s stage-2 history). Exercised directly by this module's own
-// tests.
-#![cfg_attr(feature = "write-support", allow(dead_code))]
+//! needs `&TableSchema`. A borrowed `&'a TableSchema` on every heap entry
+//! would make `KWayMerger` self-referential once the heap is a LONG-LIVED
+//! struct field (the heap borrowing a sibling field of the SAME struct) —
+//! not expressible in safe Rust. [`SchemaOrderedEntry`] instead holds an
+//! `Arc<TableSchema>` (cheap to clone per entry — a refcount bump, not a
+//! deep copy), populated from [`super::KWayMerger`]'s ADDITIVE `schema_arc`
+//! field (the pre-existing plain `schema: TableSchema` field is untouched,
+//! keeping every OTHER existing `self.schema` use-site in `mod.rs`
+//! unaffected by this change).
 
 #[cfg(feature = "write-support")]
 use super::model::MergeEntry;
 #[cfg(feature = "write-support")]
 use crate::schema::TableSchema;
 #[cfg(feature = "write-support")]
-use std::cmp::{Ordering, Reverse};
+use std::cmp::Ordering;
 #[cfg(feature = "write-support")]
-use std::collections::BinaryHeap;
+use std::sync::Arc;
 
 /// Heap element pairing a [`MergeEntry`] with the schema it should be
 /// ordered against. `Ord` mirrors [`MergeEntry::Ord`] EXACTLY (same
@@ -71,37 +53,38 @@ use std::collections::BinaryHeap;
 /// and `write_partition` already use for a malformed clustering key (more
 /// components than the schema declares).
 #[cfg(feature = "write-support")]
-struct SchemaOrderedEntry<'a> {
-    entry: MergeEntry,
-    schema: &'a TableSchema,
+#[derive(Debug, Clone)]
+pub(crate) struct SchemaOrderedEntry {
+    pub(crate) entry: MergeEntry,
+    pub(crate) schema: Arc<TableSchema>,
 }
 
 #[cfg(feature = "write-support")]
-impl<'a> SchemaOrderedEntry<'a> {
-    fn new(entry: MergeEntry, schema: &'a TableSchema) -> Self {
+impl SchemaOrderedEntry {
+    pub(crate) fn new(entry: MergeEntry, schema: Arc<TableSchema>) -> Self {
         Self { entry, schema }
     }
 }
 
 #[cfg(feature = "write-support")]
-impl PartialEq for SchemaOrderedEntry<'_> {
+impl PartialEq for SchemaOrderedEntry {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
 
 #[cfg(feature = "write-support")]
-impl Eq for SchemaOrderedEntry<'_> {}
+impl Eq for SchemaOrderedEntry {}
 
 #[cfg(feature = "write-support")]
-impl PartialOrd for SchemaOrderedEntry<'_> {
+impl PartialOrd for SchemaOrderedEntry {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 #[cfg(feature = "write-support")]
-impl Ord for SchemaOrderedEntry<'_> {
+impl Ord for SchemaOrderedEntry {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.entry.key.token.cmp(&other.entry.key.token) {
             Ordering::Equal => match self.entry.key.key.cmp(&other.entry.key.key) {
@@ -113,7 +96,7 @@ impl Ord for SchemaOrderedEntry<'_> {
                         (Some(a), Some(b)) => {
                             // THE schema-aware substitution for MergeEntry's
                             // fallback `a.cmp(b)`.
-                            match a.compare(b, self.schema).unwrap_or_else(|_| a.cmp(b)) {
+                            match a.compare(b, &self.schema).unwrap_or_else(|_| a.cmp(b)) {
                                 Ordering::Equal => self.entry.run_index.cmp(&other.entry.run_index),
                                 other_ord => other_ord,
                             }
@@ -128,21 +111,25 @@ impl Ord for SchemaOrderedEntry<'_> {
 }
 
 /// Push every entry onto a schema-aware min-heap and pop them all, in order
-/// (issue #1668, stage 5b).
+/// (issue #1668, stage 5b proof — still used by this module's own tests as a
+/// standalone equivalence check independent of a real `KWayMerger`). Test-only
+/// now that stage 5c-i wires `SchemaOrderedEntry` directly into
+/// `KWayMerger.heap` for production use.
 ///
 /// Proves cross-group emission order can be correct DIRECTLY off a heap —
-/// no `merged.sort_by` needed afterward. The heap and its `&schema` borrow
-/// are both local to this call, so there is no self-referential-storage
-/// problem (see the module doc). NOT yet called by any production path;
-/// `KWayMerger.heap` (`BinaryHeap<Reverse<MergeEntry>>`) is unchanged.
-#[cfg(feature = "write-support")]
+/// no `merged.sort_by` needed afterward.
+#[cfg(all(test, feature = "write-support"))]
 pub(crate) fn schema_ordered_pop_all(
     entries: Vec<MergeEntry>,
     schema: &TableSchema,
 ) -> Vec<MergeEntry> {
-    let mut heap: BinaryHeap<Reverse<SchemaOrderedEntry<'_>>> = BinaryHeap::new();
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+
+    let schema_arc = Arc::new(schema.clone());
+    let mut heap: BinaryHeap<Reverse<SchemaOrderedEntry>> = BinaryHeap::new();
     for entry in entries {
-        heap.push(Reverse(SchemaOrderedEntry::new(entry, schema)));
+        heap.push(Reverse(SchemaOrderedEntry::new(entry, schema_arc.clone())));
     }
     let mut out = Vec::with_capacity(heap.len());
     while let Some(Reverse(wrapped)) = heap.pop() {
@@ -179,12 +166,13 @@ mod tests {
     fn merger_over(entries: Vec<MergeEntry>, schema: TableSchema) -> KWayMerger {
         KWayMerger {
             runs: vec![RunReader::new(Box::new(VecIterator(entries.into_iter())))],
-            heap: BinaryHeap::new(),
+            heap: std::collections::BinaryHeap::new(),
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: Arc::new(schema.clone()),
             schema,
         }
     }
@@ -414,6 +402,46 @@ mod tests {
             vec![None, Some(2), Some(1)],
             "absent-ck2 must sort first (NULL-first), then DESC by ck2 — \
              directly off the heap, no final sort"
+        );
+    }
+
+    /// Stage 5c-i finding: even though the heap's OWN pop order is now
+    /// schema-aware (this module), `merge_partition_rows`'s intermediate
+    /// `clustered_rows: BTreeMap<Option<ClusteringKey>, Vec<MergeEntry>>`
+    /// STILL discards that arrival order — a `BTreeMap`'s iteration order is
+    /// governed ENTIRELY by its own `Ord` impl on the key type (here
+    /// `ClusteringKey`'s FALLBACK, non-schema-aware `Ord`), independent of
+    /// insertion order. Inserting keys in schema-correct (DESC) arrival order
+    /// and then iterating the map yields the FALLBACK (ASC) order, not the
+    /// arrival order — proving `merge_partition_rows`'s final
+    /// `merged.sort_by(schema-aware compare)` is STILL load-bearing and NOT
+    /// yet redundant. This is a general property of `BTreeMap`, demonstrated
+    /// directly against the SAME type shape `clustered_rows` uses, without
+    /// touching (or removing anything from) `merge_partition_rows` itself.
+    #[test]
+    fn clustered_rows_btreemap_discards_schema_aware_arrival_order() {
+        use std::collections::BTreeMap;
+
+        // Simulate the NOW-schema-aware heap's arrival order for a DESC
+        // clustering column: 2, 1, 0 (descending — schema-correct).
+        let mut clustered_rows: BTreeMap<Option<ClusteringKey>, i32> = BTreeMap::new();
+        for v in [2, 1, 0] {
+            clustered_rows.insert(Some(ClusteringKey::single("ck", Value::Integer(v))), v);
+        }
+
+        let iterated: Vec<i32> = clustered_rows.into_values().collect();
+
+        // The map's OWN key Ord (fallback, ASC) governs iteration — NOT
+        // insertion order — so it comes out ascending, the OPPOSITE of the
+        // schema-correct DESC order the heap delivered.
+        assert_eq!(
+            iterated,
+            vec![0, 1, 2],
+            "BTreeMap iteration order is governed by the key's Ord, not \
+             insertion order — this is WHY merge_partition_rows's final \
+             merged.sort_by(schema-aware compare) is still necessary after \
+             stage 5c-i's schema-aware heap wiring: `clustered_rows` re-\
+             imposes the FALLBACK order regardless of arrival order"
         );
     }
 }

--- a/cqlite-core/src/storage/write_engine/merge/schema_order.rs
+++ b/cqlite-core/src/storage/write_engine/merge/schema_order.rs
@@ -1,0 +1,419 @@
+//! Schema-aware heap-direct ordering proof (issue #1668, stage 5b) — the
+//! "deferred crux" from stage 3a, solved for real this time.
+//!
+//! Stage 3a proved cross-group emission order is safe TODAY only because
+//! [`super::KWayMerger::step_streaming`] drains a `Vec<MergeEntry>` that
+//! `merge_partition_rows` already schema-aware-sorted (`merged.sort_by(|a,
+//! b| ck_a.compare(ck_b, &self.schema) ...)`) as its unconditional last step.
+//! Removing that whole-partition sort (stage 5d's job) requires a heap whose
+//! POP ORDER is *itself* schema-correct — this module proves that is
+//! achievable and correct, WITHOUT yet touching [`super::KWayMerger`]'s own
+//! `heap: BinaryHeap<Reverse<MergeEntry>>` field (that wiring is stage 5c/5d's
+//! job, once the writer can also accept true increments — mirroring the
+//! stage-2-before-stage-3b precedent: introduce and prove the mechanism
+//! first, wire it into production once every dependency is ready).
+//!
+//! ## Why a bounded lookahead/reorder buffer is NOT sufficient
+//!
+//! The issue's stage-5b framing offered two shapes: make the heap genuinely
+//! schema-aware, OR prove a small bounded lookahead is sufficient. The bound
+//! does not exist for a general schema: consider a single `DESC` clustering
+//! column with N distinct values. The fallback (ASC-only) order pops them
+//! ascending; the schema-correct (DESC) order needs the LARGEST value
+//! FIRST — which is the LAST value the fallback order would ever produce.
+//! Emitting the correct first item therefore requires having already seen
+//! ALL N items — the required lookahead is O(N), not a fixed constant
+//! independent of partition size. This is proven directly by
+//! `stage3a`'s `step_streaming_matches_step_for_desc_clustering_fixture`
+//! (fed via the SAME merger machinery) and is why this module makes the
+//! comparator itself schema-aware instead.
+//!
+//! ## Design: a schema-aware comparator with NO lifetime on `KWayMerger`
+//!
+//! `MergeEntry::Ord` cannot be made schema-aware directly: `Ord::cmp(&self,
+//! &other) -> Ordering` takes no extra context, and `ClusteringKey::compare`
+//! needs `&TableSchema`. Storing a `&'a TableSchema` (or `Arc<TableSchema>`)
+//! on every heap entry, if that heap were a LONG-LIVED struct field (like
+//! `KWayMerger.heap`), would need `KWayMerger` to be self-referential (the
+//! heap borrowing a sibling field of the SAME struct) — not expressible in
+//! safe Rust. This module sidesteps the problem entirely by keeping the
+//! schema-aware heap PURELY LOCAL to one function call
+//! ([`schema_ordered_pop_all`]): the wrapper's `&'a TableSchema` borrow and
+//! the heap it lives in are both stack-local to that call, so there is no
+//! self-reference. Wiring this into `KWayMerger.heap` itself (stage 5c/5d)
+//! will need ONE of: (a) an `Arc<TableSchema>` field alongside the existing
+//! plain `schema: TableSchema` (cheap, additive, no lifetime issue), or (b)
+//! a per-entry precomputed schema-independent sort key. Not resolved here —
+//! this module only proves the COMPARATOR is correct and sufficient.
+
+// Stage 5b (#1668) is deliberately UNWIRED: no production caller constructs a
+// `SchemaOrderedEntry` yet (that is stage 5c/5d), so a normal (non-test)
+// build sees every item here as unreachable. Matches the crate's existing
+// convention for proof-only surface pending production wiring (see
+// `streaming.rs`'s stage-2 history). Exercised directly by this module's own
+// tests.
+#![cfg_attr(feature = "write-support", allow(dead_code))]
+
+#[cfg(feature = "write-support")]
+use super::model::MergeEntry;
+#[cfg(feature = "write-support")]
+use crate::schema::TableSchema;
+#[cfg(feature = "write-support")]
+use std::cmp::{Ordering, Reverse};
+#[cfg(feature = "write-support")]
+use std::collections::BinaryHeap;
+
+/// Heap element pairing a [`MergeEntry`] with the schema it should be
+/// ordered against. `Ord` mirrors [`MergeEntry::Ord`] EXACTLY (same
+/// token/key-bytes/run_index tiebreaks) except at the clustering-key step,
+/// where it defers to the schema-aware [`ClusteringKey::compare`] — falling
+/// back to the plain `Ord` on error, the SAME fallback `merge_partition_rows`
+/// and `write_partition` already use for a malformed clustering key (more
+/// components than the schema declares).
+#[cfg(feature = "write-support")]
+struct SchemaOrderedEntry<'a> {
+    entry: MergeEntry,
+    schema: &'a TableSchema,
+}
+
+#[cfg(feature = "write-support")]
+impl<'a> SchemaOrderedEntry<'a> {
+    fn new(entry: MergeEntry, schema: &'a TableSchema) -> Self {
+        Self { entry, schema }
+    }
+}
+
+#[cfg(feature = "write-support")]
+impl PartialEq for SchemaOrderedEntry<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+#[cfg(feature = "write-support")]
+impl Eq for SchemaOrderedEntry<'_> {}
+
+#[cfg(feature = "write-support")]
+impl PartialOrd for SchemaOrderedEntry<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(feature = "write-support")]
+impl Ord for SchemaOrderedEntry<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.entry.key.token.cmp(&other.entry.key.token) {
+            Ordering::Equal => match self.entry.key.key.cmp(&other.entry.key.key) {
+                Ordering::Equal => {
+                    match (&self.entry.clustering_key, &other.entry.clustering_key) {
+                        (None, None) => self.entry.run_index.cmp(&other.entry.run_index),
+                        (None, Some(_)) => Ordering::Less,
+                        (Some(_), None) => Ordering::Greater,
+                        (Some(a), Some(b)) => {
+                            // THE schema-aware substitution for MergeEntry's
+                            // fallback `a.cmp(b)`.
+                            match a.compare(b, self.schema).unwrap_or_else(|_| a.cmp(b)) {
+                                Ordering::Equal => self.entry.run_index.cmp(&other.entry.run_index),
+                                other_ord => other_ord,
+                            }
+                        }
+                    }
+                }
+                other_ord => other_ord,
+            },
+            other_ord => other_ord,
+        }
+    }
+}
+
+/// Push every entry onto a schema-aware min-heap and pop them all, in order
+/// (issue #1668, stage 5b).
+///
+/// Proves cross-group emission order can be correct DIRECTLY off a heap —
+/// no `merged.sort_by` needed afterward. The heap and its `&schema` borrow
+/// are both local to this call, so there is no self-referential-storage
+/// problem (see the module doc). NOT yet called by any production path;
+/// `KWayMerger.heap` (`BinaryHeap<Reverse<MergeEntry>>`) is unchanged.
+#[cfg(feature = "write-support")]
+pub(crate) fn schema_ordered_pop_all(
+    entries: Vec<MergeEntry>,
+    schema: &TableSchema,
+) -> Vec<MergeEntry> {
+    let mut heap: BinaryHeap<Reverse<SchemaOrderedEntry<'_>>> = BinaryHeap::new();
+    for entry in entries {
+        heap.push(Reverse(SchemaOrderedEntry::new(entry, schema)));
+    }
+    let mut out = Vec::with_capacity(heap.len());
+    while let Some(Reverse(wrapped)) = heap.pop() {
+        out.push(wrapped.entry);
+    }
+    out
+}
+
+#[cfg(all(test, feature = "write-support"))]
+mod tests {
+    use super::*;
+    use crate::schema::{ClusteringColumn, ClusteringOrder, KeyColumn};
+    use crate::storage::write_engine::merge::model::{CellData, RowData};
+    use crate::storage::write_engine::merge::{KWayMerger, RunReader, SSTableRowIterator};
+    use crate::storage::write_engine::mutation::{ClusteringKey, DecoratedKey};
+    use crate::types::Value;
+    use std::collections::HashMap;
+
+    /// Test-only `SSTableRowIterator` over a pre-supplied `Vec<MergeEntry>`,
+    /// mirroring the SAME pattern already used by `mod.rs`'s and
+    /// `streaming.rs`'s own merge unit tests (kept local here so this
+    /// module's tests need no cross-module reuse of another file's private
+    /// test helpers).
+    struct VecIterator(std::vec::IntoIter<MergeEntry>);
+    impl SSTableRowIterator for VecIterator {
+        fn next(&mut self) -> Option<crate::error::Result<MergeEntry>> {
+            self.0.next().map(Ok)
+        }
+    }
+
+    /// Build a `KWayMerger` with ONE run over `entries`, matching `mod.rs`'s
+    /// `merger_over` test helper (not reusable directly here — private to a
+    /// sibling module — so reconstructed with the same shape).
+    fn merger_over(entries: Vec<MergeEntry>, schema: TableSchema) -> KWayMerger {
+        KWayMerger {
+            runs: vec![RunReader::new(Box::new(VecIterator(entries.into_iter())))],
+            heap: BinaryHeap::new(),
+            current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
+            purge_safe: false,
+            max_purgeable_timestamp: None,
+            schema,
+        }
+    }
+
+    fn key(token: i64) -> DecoratedKey {
+        DecoratedKey::new(token, vec![token as u8])
+    }
+
+    fn live_entry(run_index: usize, token: i64, ck: ClusteringKey, ts: i64) -> MergeEntry {
+        MergeEntry::new(
+            run_index,
+            key(token),
+            Some(ck),
+            ts,
+            RowData::Live {
+                cells: vec![CellData::new("c".to_string(), Value::Integer(1), ts)],
+            },
+        )
+    }
+
+    fn single_col_schema(order: ClusteringOrder) -> TableSchema {
+        TableSchema {
+            keyspace: "ks_1668_5b".to_string(),
+            table: "t_1668_5b".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order,
+            }],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn two_col_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "ks_1668_5b".to_string(),
+            table: "t_1668_5b_multi".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![
+                ClusteringColumn {
+                    name: "ck1".to_string(),
+                    data_type: "int".to_string(),
+                    position: 0,
+                    order: ClusteringOrder::Asc,
+                },
+                ClusteringColumn {
+                    name: "ck2".to_string(),
+                    data_type: "int".to_string(),
+                    position: 1,
+                    order: ClusteringOrder::Desc,
+                },
+            ],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn ck_multi(pairs: &[(&str, i32)]) -> ClusteringKey {
+        ClusteringKey::new(
+            pairs
+                .iter()
+                .map(|(n, v)| (n.to_string(), Value::Integer(*v)))
+                .collect(),
+        )
+    }
+
+    fn ck_value(entry: &MergeEntry) -> i32 {
+        match entry
+            .clustering_key
+            .as_ref()
+            .and_then(|k| k.columns.first())
+        {
+            Some((_, Value::Integer(v))) => *v,
+            other => panic!("expected a single Integer clustering column, got {other:?}"),
+        }
+    }
+
+    /// The grouping-contiguity property (issue #1668's "the crux") re-verified
+    /// for THIS comparator: `ClusteringKey::compare` is ALSO a valid total
+    /// order (transitive, antisymmetric — `compare_values` is the same
+    /// canonical value-ordering function used throughout the write path), so
+    /// same-clustering-key entries must still pop contiguously.
+    #[test]
+    fn heap_groups_contiguously_by_schema_aware_ord() {
+        let schema = single_col_schema(ClusteringOrder::Desc);
+        let entries = vec![
+            live_entry(2, 1, ClusteringKey::single("ck", Value::Integer(1)), 100),
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(0)), 300),
+            live_entry(1, 1, ClusteringKey::single("ck", Value::Integer(2)), 50),
+            live_entry(1, 1, ClusteringKey::single("ck", Value::Integer(0)), 200),
+            live_entry(2, 1, ClusteringKey::single("ck", Value::Integer(2)), 60),
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(1)), 150),
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(2)), 70),
+            live_entry(2, 1, ClusteringKey::single("ck", Value::Integer(0)), 250),
+            live_entry(1, 1, ClusteringKey::single("ck", Value::Integer(1)), 120),
+        ];
+
+        let popped = schema_ordered_pop_all(entries, &schema);
+        let popped_cks: Vec<i32> = popped.iter().map(ck_value).collect();
+
+        let mut closed: Vec<i32> = Vec::new();
+        let mut current: Option<i32> = None;
+        for &c in &popped_cks {
+            if current != Some(c) {
+                if let Some(prev) = current.take() {
+                    assert!(
+                        !closed.contains(&prev),
+                        "clustering key {prev} reappeared non-contiguously"
+                    );
+                    closed.push(prev);
+                }
+                current = Some(c);
+            }
+        }
+        let mut distinct: Vec<i32> = Vec::new();
+        for &c in &popped_cks {
+            if !distinct.contains(&c) {
+                distinct.push(c);
+            }
+        }
+        assert_eq!(distinct.len(), 3, "expected 3 distinct clustering keys");
+    }
+
+    /// THE proof: a `DESC` clustering column where the required lookahead to
+    /// emit the FIRST correctly-ordered item is the WHOLE partition (see the
+    /// module doc) — a bounded reorder buffer cannot solve this, only a
+    /// schema-aware comparator can. Assert the heap POPS the Cassandra-
+    /// correct descending order directly, with NO subsequent sort — an
+    /// independent expected-sequence check, not just "matches some other
+    /// path" (which could be equally wrong).
+    #[test]
+    fn schema_ordered_pop_all_matches_desc_clustering_order() {
+        let schema = single_col_schema(ClusteringOrder::Desc);
+        let entries = vec![
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(0)), 100),
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(1)), 100),
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(2)), 100),
+        ];
+
+        let popped = schema_ordered_pop_all(entries, &schema);
+        let order: Vec<i32> = popped.iter().map(ck_value).collect();
+        assert_eq!(
+            order,
+            vec![2, 1, 0],
+            "heap-direct pop order must be DESCENDING with NO final sort"
+        );
+    }
+
+    /// Same DESC fixture, cross-checked against TODAY's whole-partition
+    /// buffer-then-sort path (`step()` via a real `KWayMerger`) — proving
+    /// the heap-direct order (no final sort) matches the CURRENT production
+    /// output row-for-row, not just the independently-expected sequence.
+    #[test]
+    fn schema_ordered_pop_all_matches_todays_step_output_for_desc_fixture() {
+        let schema = single_col_schema(ClusteringOrder::Desc);
+        let entries = vec![
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(0)), 100),
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(1)), 100),
+            live_entry(0, 1, ClusteringKey::single("ck", Value::Integer(2)), 100),
+        ];
+
+        // Heap-direct (stage 5b, no final sort).
+        let heap_direct = schema_ordered_pop_all(entries.clone(), &schema);
+        let heap_direct_order: Vec<i32> = heap_direct.iter().map(ck_value).collect();
+
+        // TODAY's path: whole-partition buffer + merge_partition_rows' final
+        // schema-aware sort_by, via a real KWayMerger.
+        let mut merger = merger_over(entries, schema);
+        let today_rows = match merger.step().unwrap() {
+            crate::storage::write_engine::merge::MergeStep::Partition { rows, .. } => rows,
+            other => panic!("expected Partition, got {other:?}"),
+        };
+        let today_order: Vec<i32> = today_rows.iter().map(ck_value).collect();
+
+        assert_eq!(
+            heap_direct_order, today_order,
+            "heap-direct order (no final sort) must match today's whole-\
+             partition buffer-then-sort output"
+        );
+    }
+
+    /// Absent-trailing-component (NULL-first) + `DESC` second column — the
+    /// SAME residual case stage 3a proved doesn't leak through the (already-
+    /// sorted-Vec-draining) `step_streaming` design. Here it is proven at
+    /// the HEAP level directly: absent-`ck2` sorts first (NULL-first,
+    /// regardless of `ck2`'s DESC-ness), then present values by DESC.
+    #[test]
+    fn schema_ordered_pop_all_matches_absent_trailing_component_order() {
+        let schema = two_col_schema();
+        let entries = vec![
+            live_entry(0, 1, ck_multi(&[("ck1", 5), ("ck2", 1)]), 100),
+            live_entry(0, 1, ck_multi(&[("ck1", 5)]), 100), // absent ck2
+            live_entry(0, 1, ck_multi(&[("ck1", 5), ("ck2", 2)]), 100),
+        ];
+
+        let popped = schema_ordered_pop_all(entries, &schema);
+        let ck2_markers: Vec<Option<i32>> = popped
+            .iter()
+            .map(|e| {
+                e.clustering_key.as_ref().and_then(|k| {
+                    k.columns
+                        .iter()
+                        .find(|(name, _)| name == "ck2")
+                        .map(|(_, v)| match v {
+                            Value::Integer(v) => *v,
+                            other => panic!("expected Integer ck2, got {other:?}"),
+                        })
+                })
+            })
+            .collect();
+
+        assert_eq!(
+            ck2_markers,
+            vec![None, Some(2), Some(1)],
+            "absent-ck2 must sort first (NULL-first), then DESC by ck2 — \
+             directly off the heap, no final sort"
+        );
+    }
+}

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -158,6 +158,49 @@ impl<'a> StreamingMerger<'a> {
         }
     }
 
+    /// Resume (or start fresh) draining, seeded with a PREVIOUSLY paused
+    /// partition's remaining, not-yet-yielded rows (issue #1668, stage 4).
+    ///
+    /// `StreamingMerger` cannot itself be stored across calls — it borrows
+    /// `&'a mut KWayMerger`, so it is not self-referential-storable on a
+    /// struct that also owns that `KWayMerger` (e.g. `ActiveMerge`). A
+    /// caller that must pause mid-partition (the "Q4" mid-partition budget
+    /// check) instead persists the OWNED `(key, remaining_rows)` extracted
+    /// via [`Self::into_paused_state`], then reconstructs a fresh
+    /// `StreamingMerger` next call via THIS constructor, seeded with that
+    /// saved state. `saved: None` starts fresh, identical to [`Self::new`].
+    ///
+    /// Nothing is re-computed and nothing is lost: `remaining_rows` are rows
+    /// `step()` ALREADY fully reconciled for `key`'s partition in a PRIOR
+    /// call — the underlying `merger`'s heap has already moved past them, so
+    /// re-calling `merger.step()` for this partition would silently skip
+    /// them. Resuming via this seeded queue (instead of starting a fresh,
+    /// empty `StreamingMerger` and calling `step()` again) is therefore
+    /// required for correctness, not just an optimization.
+    pub(crate) fn resume(
+        merger: &'a mut KWayMerger,
+        saved: Option<(DecoratedKey, VecDeque<MergeEntry>)>,
+    ) -> Self {
+        let (partition_key, pending_rows) = match saved {
+            Some((key, rows)) => (Some(key), rows),
+            None => (None, VecDeque::new()),
+        };
+        Self {
+            merger,
+            partition_key,
+            pending_rows,
+        }
+    }
+
+    /// Extract the in-progress partition's remaining, not-yet-yielded rows
+    /// (issue #1668, stage 4), for a caller that must pause mid-partition and
+    /// resume later via [`Self::resume`]. Returns `None` if no partition was
+    /// in progress (nothing to resume — the next call should start fresh via
+    /// [`Self::new`]/`resume(merger, None)`).
+    pub(crate) fn into_paused_state(self) -> Option<(DecoratedKey, VecDeque<MergeEntry>)> {
+        self.partition_key.map(|key| (key, self.pending_rows))
+    }
+
     /// Yield the next streaming increment.
     ///
     /// Drains any in-progress partition's buffered rows one at a time as

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -192,6 +192,14 @@ use std::cmp::Reverse;
 #[cfg(feature = "write-support")]
 use std::collections::VecDeque;
 
+/// dhat memory-bound proof for the merge layer's OWN streaming bound,
+/// isolated from the reader (issue #1668 — see its module doc for why this
+/// must be an in-tree `#[cfg(test)]` module rather than a `tests/` integration
+/// test). Kept in its own file so this addition does not grow `streaming.rs`
+/// itself past the campsite threshold.
+#[cfg(all(test, feature = "write-support", feature = "dhat-heap"))]
+mod streaming_dhat_test;
+
 /// A single streaming increment from [`StreamingMerger::step_streaming`]
 /// (issue #1668, stage 2). Distinct from [`MergeStep`] (unchanged, still the
 /// production shape) so no existing `match`/`while let MergeStep::Partition`

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -474,9 +474,16 @@ impl<'a> StreamingMerger<'a> {
     /// partial set here and a later-discovered remainder in a SECOND call
     /// would risk two marker pairs overlapping in the output (roborev #959
     /// High #1's concern).
-    fn flush_range_tombstones(&mut self, effective_gc_before: Option<i64>, max_purgeable_timestamp: i64) {
+    fn flush_range_tombstones(
+        &mut self,
+        effective_gc_before: Option<i64>,
+        max_purgeable_timestamp: i64,
+    ) {
         self.state.range_tombstones_emitted = true;
-        KWayMerger::coalesce_range_tombstones(&mut self.state.range_tombstones, &self.merger.schema);
+        KWayMerger::coalesce_range_tombstones(
+            &mut self.state.range_tombstones,
+            &self.merger.schema,
+        );
 
         if let Some((pmfda, _)) = self.state.max_partition_deletion {
             self.state
@@ -518,7 +525,10 @@ impl<'a> StreamingMerger<'a> {
         if self.state.awaiting_flush.is_empty() {
             return;
         }
-        KWayMerger::coalesce_range_tombstones(&mut self.state.range_tombstones, &self.merger.schema);
+        KWayMerger::coalesce_range_tombstones(
+            &mut self.state.range_tombstones,
+            &self.merger.schema,
+        );
         for entry in std::mem::take(&mut self.state.awaiting_flush) {
             if let Some(shadowed) = KWayMerger::apply_range_shadowing(
                 entry,
@@ -693,7 +703,8 @@ impl<'a> StreamingMerger<'a> {
                     // observability EXACTLY ONCE and signal PartitionEnd.
                     self.finalize_current_cluster()?;
                     self.reshadow_and_flush_awaiting();
-                    if !self.state.range_tombstones.is_empty() && !self.state.range_tombstones_emitted
+                    if !self.state.range_tombstones.is_empty()
+                        && !self.state.range_tombstones_emitted
                     {
                         let (effective_gc_before, max_purgeable_timestamp) =
                             self.merger.effective_gc_settings();
@@ -1210,9 +1221,19 @@ mod tests {
     fn step_streaming_matches_step_for_absent_trailing_component_fixture() {
         let schema = two_col_schema();
         let runs = vec![
-            vec![live_entry_ck(0, 1, ck_multi(&[("ck1", 5), ("ck2", 1)]), 100)],
+            vec![live_entry_ck(
+                0,
+                1,
+                ck_multi(&[("ck1", 5), ("ck2", 1)]),
+                100,
+            )],
             vec![live_entry_ck(1, 1, ck_multi(&[("ck1", 5)]), 100)], // absent ck2
-            vec![live_entry_ck(2, 1, ck_multi(&[("ck1", 5), ("ck2", 2)]), 100)],
+            vec![live_entry_ck(
+                2,
+                1,
+                ck_multi(&[("ck1", 5), ("ck2", 2)]),
+                100,
+            )],
         ];
 
         // Independent expectation: identify each row by its ck2 presence/value.

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -686,4 +686,74 @@ mod tests {
             other => panic!("expected ClusterGroup, got {other:?}"),
         }
     }
+
+    /// Issue #1668, stage 5c-iv design verification (NOT yet a stage
+    /// deliverable — a load-bearing precondition check before building the
+    /// incremental writer entry point). Confirms CONCRETELY, through the
+    /// real production `step()`, that a partition's `clustering_key: None`
+    /// entry (the reconciled static row — `merge_partition_rows` groups it
+    /// into `clustered_rows[None]` alongside any other `None`-keyed carrier,
+    /// same as a range/partition-tombstone re-emission) ALWAYS sorts FIRST
+    /// in `MergeStep::Partition.rows`, before every `Some(ck)` clustering
+    /// row — regardless of how many regular rows the partition has. This
+    /// means the static row (and any range/partition-tombstone carriers) sit
+    /// in a SMALL, PARTITION-SIZE-INDEPENDENT prefix, decoupled from the
+    /// (potentially huge) clustering-row tail — the key fact the incremental
+    /// writer design leans on to avoid buffering the whole partition just to
+    /// resolve statics.
+    #[test]
+    fn static_row_carrier_always_sorts_first_regardless_of_partition_width() {
+        use crate::schema::Column;
+        use crate::storage::write_engine::merge::model::CellData;
+
+        let mut schema = test_schema(ClusteringOrder::Asc);
+        schema.columns = vec![Column {
+            name: "region".to_string(),
+            data_type: "text".to_string(),
+            nullable: true,
+            default: None,
+            is_static: true,
+        }];
+
+        // A static-row carrier (clustering_key: None, cells target the
+        // static column) PLUS a wide tail of 50 regular clustering rows.
+        let mut entries = vec![MergeEntry::new(
+            0,
+            key(1),
+            None,
+            100,
+            RowData::Live {
+                cells: vec![CellData::new(
+                    "region".to_string(),
+                    Value::Text("us-east".to_string()),
+                    100,
+                )],
+            },
+        )];
+        for ck in 0..50 {
+            entries.push(live_entry(0, 1, ck, 100));
+        }
+
+        let mut merger = merger_over(entries, schema);
+        let rows = match merger.step().unwrap() {
+            MergeStep::Partition { rows, .. } => rows,
+            other => panic!("expected Partition, got {other:?}"),
+        };
+
+        assert_eq!(
+            rows.len(),
+            51,
+            "expected the static row + 50 clustering rows"
+        );
+        assert!(
+            rows[0].clustering_key.is_none(),
+            "the static row (clustering_key: None) must be FIRST, regardless \
+             of the 50 regular clustering rows that follow"
+        );
+        assert!(
+            rows[1..].iter().all(|r| r.clustering_key.is_some()),
+            "every row AFTER the first must be a regular Some(ck) clustering \
+             row — the None-keyed prefix is exactly one entry wide here"
+        );
+    }
 }

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -1,16 +1,24 @@
-//! Streaming cluster-group step type (issue #1668, stage 2) — FEATURE-INTERNAL,
-//! UNWIRED from every production consumer.
+//! Streaming cluster-group step type (issue #1668, stages 2-3b).
 //!
-//! `maintenance.rs`, `compact_sstables`, and the Flight producer all still call
-//! [`KWayMerger::step`] (the whole-partition path), which remains the sole
-//! production path and is completely unchanged by this module.
-//! [`StreamingMerger`] below is an ADDITIONAL, not-yet-wired wrapper that
-//! proves the eventual streaming design (stage 3+) can hand a caller the SAME
-//! reconciled rows one cluster-group at a time instead of one
-//! `MergeStep::Partition { rows, .. }` blob per partition — without touching
-//! [`MergeStep`]'s shape (a distinct [`StreamingStep`] type) or `KWayMerger`'s
-//! own fields (a wrapper holding its own drain state, so none of the existing
-//! `KWayMerger { .. }` struct-literal unit tests in `mod.rs` need updating).
+//! **Wiring status (stage 3b)**: [`KWayMerger::merge`] (used by
+//! `compact_sstables_with_registry`) and `write_engine::maintenance`'s
+//! compaction loop both now drain a partition via [`StreamingMerger`]/
+//! [`StreamingStep`] instead of calling [`KWayMerger::step`] directly — each
+//! accumulates `ClusterGroup` rows until `PartitionEnd`, then hands the SAME
+//! `Vec<MergeEntry>` `step()` would have returned to the SAME unchanged
+//! writer call, so output stays byte-identical (see stage 3b's `#921`
+//! compaction-byte-parity harness run). `step_streaming` still calls the
+//! UNCHANGED [`KWayMerger::step`] internally and drains its already-
+//! reconciled `Vec<MergeEntry>` one row at a time, so peak memory is
+//! UNCHANGED by this wiring (stage 5 removes the whole-partition buffering
+//! that still lives inside `step()`/`merge_partition_rows`). The Flight
+//! producer (`cqlite-flight/src/producer.rs`) is INTENTIONALLY untouched —
+//! that is Q4/mid-partition-budget territory, a later stage.
+//!
+//! [`StreamingMerger`] does not touch [`MergeStep`]'s shape (a distinct
+//! [`StreamingStep`] type) or `KWayMerger`'s own fields (a wrapper holding its
+//! own drain state, so none of the existing `KWayMerger { .. }` struct-literal
+//! unit tests in `mod.rs` needed updating).
 //!
 //! ## Grouping-contiguity VERIFICATION (issue #1668 flags this as "the crux")
 //!
@@ -84,13 +92,6 @@
 //! resulting `Vec<MergeEntry>` one row at a time. Removing that buffering is
 //! stage 5's job; this stage proves the increment TYPE and consumer-loop
 //! shape are safe to build on.
-
-// Stage 2 (#1668) is deliberately UNWIRED: no production caller constructs a
-// `StreamingMerger` yet (that is stage 3), so a normal (non-test) build sees
-// every item here as unreachable. Matches the crate's existing convention for
-// carried-but-not-yet-consumed surface (see `KWayMerger::gc_before_secs` /
-// `now_secs` in `mod.rs`). Exercised directly by this module's own tests.
-#![cfg_attr(feature = "write-support", allow(dead_code))]
 
 #[cfg(feature = "write-support")]
 use super::model::MergeEntry;

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -1,0 +1,469 @@
+//! Streaming cluster-group step type (issue #1668, stage 2) — FEATURE-INTERNAL,
+//! UNWIRED from every production consumer.
+//!
+//! `maintenance.rs`, `compact_sstables`, and the Flight producer all still call
+//! [`KWayMerger::step`] (the whole-partition path), which remains the sole
+//! production path and is completely unchanged by this module.
+//! [`StreamingMerger`] below is an ADDITIONAL, not-yet-wired wrapper that
+//! proves the eventual streaming design (stage 3+) can hand a caller the SAME
+//! reconciled rows one cluster-group at a time instead of one
+//! `MergeStep::Partition { rows, .. }` blob per partition — without touching
+//! [`MergeStep`]'s shape (a distinct [`StreamingStep`] type) or `KWayMerger`'s
+//! own fields (a wrapper holding its own drain state, so none of the existing
+//! `KWayMerger { .. }` struct-literal unit tests in `mod.rs` need updating).
+//!
+//! ## Grouping-contiguity VERIFICATION (issue #1668 flags this as "the crux")
+//!
+//! The increment design assumes that once a caller has moved past a
+//! clustering key while draining the heap, it never sees that key again —
+//! i.e. the heap pop order groups every entry for the same `(pk, ck)`
+//! contiguously, so "accumulate only the entries for the current clustering
+//! key, then move on" never re-opens a finished group. This DOES hold:
+//! [`MergeEntry`]'s `Ord` (`model.rs`) orders primarily by
+//! `(token, key bytes, clustering_key, run_index)`, and `clustering_key`
+//! compares via `ClusteringKey`'s FALLBACK `Ord` (lexicographic by value) —
+//! the SAME fallback `Ord`/`Eq` that `merge_partition_rows`'s
+//! `clustered_rows: BTreeMap<Option<ClusteringKey>, _>` already groups by
+//! today. Since `BinaryHeap::pop` yields a non-increasing (here: `Reverse`,
+//! so non-decreasing) sequence under one fixed comparator, and grouping
+//! identity here is that SAME comparator's notion of equality, entries for
+//! one clustering key are contiguous in heap-pop order — proven directly
+//! against the heap (not assumed) by the `heap_groups_contiguously_by_ord`
+//! test below.
+//!
+//! **Residual finding (documented, NOT fixed in this stage):** `ClusteringKey`'s
+//! fallback `Ord` (`mutation.rs`) is NOT schema-aware — it does not apply
+//! `DESC` clustering-column reversal, and treats an absent trailing component
+//! by zip-stopping rather than Cassandra's NULL-first rule (contrast
+//! `ClusteringKey::compare`, which IS schema-aware and DOES apply both). So
+//! while GROUPING (same-key contiguity, proven above) is safe to stream on,
+//! the ORDER in which DISTINCT clustering-key groups are emitted from the
+//! heap can diverge from the schema's true collation for `DESC` clustering
+//! columns or absent trailing components. Today's whole-partition path masks
+//! this with an explicit `merged.sort_by(schema-aware compare)` AFTER
+//! collecting every cluster in a partition (`merge_partition_rows`). A future
+//! stage that wires a true (non-buffering) streaming second pass to a real
+//! writer must either (a) make the heap comparator schema-aware, or (b)
+//! re-sort the emitted group sequence before/while writing. `step_streaming`
+//! below does not need to solve this: it drains an ALREADY schema-sorted
+//! `Vec<MergeEntry>` (the same one `step()` returns), so its own output order
+//! is byte-identical to `step()`'s regardless of this residual — but the
+//! residual applies to any FUTURE streaming pass that walks the heap directly
+//! without that final sort (stage 3+ design point, not resolved here).
+//!
+//! `step_streaming` does NOT yet avoid whole-partition buffering: it calls
+//! the unchanged [`KWayMerger::step`] (which still buffers a whole partition
+//! and fully reconciles it via `merge_partition_rows`, itself now built on the
+//! stage-1 `carriers::scan_partition_carriers` pre-scan) and then drains the
+//! resulting `Vec<MergeEntry>` one row at a time. Removing that buffering is
+//! stage 5's job; this stage proves the increment TYPE and consumer-loop
+//! shape are safe to build on.
+
+// Stage 2 (#1668) is deliberately UNWIRED: no production caller constructs a
+// `StreamingMerger` yet (that is stage 3), so a normal (non-test) build sees
+// every item here as unreachable. Matches the crate's existing convention for
+// carried-but-not-yet-consumed surface (see `KWayMerger::gc_before_secs` /
+// `now_secs` in `mod.rs`). Exercised directly by this module's own tests.
+#![cfg_attr(feature = "write-support", allow(dead_code))]
+
+#[cfg(feature = "write-support")]
+use super::model::MergeEntry;
+#[cfg(feature = "write-support")]
+use super::{KWayMerger, MergeStep};
+#[cfg(feature = "write-support")]
+use crate::error::Result;
+#[cfg(feature = "write-support")]
+use crate::storage::write_engine::mutation::DecoratedKey;
+#[cfg(feature = "write-support")]
+use std::collections::VecDeque;
+
+/// A single streaming increment from [`StreamingMerger::step_streaming`]
+/// (issue #1668, stage 2). Distinct from [`MergeStep`] (unchanged, still the
+/// production shape) so no existing `match`/`while let MergeStep::Partition`
+/// call site anywhere in the codebase is affected by this addition.
+#[cfg(feature = "write-support")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StreamingStep {
+    /// One already-reconciled row belonging to `key`'s partition, in the SAME
+    /// relative order `MergeStep::Partition { rows, .. }` would have held it
+    /// (range/partition-tombstone carriers first, then clustering rows in
+    /// schema-aware clustering order — see `merge_partition_rows`).
+    ClusterGroup {
+        /// Partition key this row belongs to.
+        key: DecoratedKey,
+        /// The reconciled row (or carrier re-emission). Boxed: `Complete` is
+        /// zero-sized, so an inline `MergeEntry` here would trip
+        /// `clippy::large_enum_variant` (denied crate-wide, `lib.rs`).
+        row: Box<MergeEntry>,
+    },
+    /// No more `ClusterGroup`s remain for `key`'s partition.
+    PartitionEnd {
+        /// Partition key whose cluster groups are exhausted.
+        key: DecoratedKey,
+    },
+    /// The merge is complete (no more partitions in any run).
+    Complete,
+}
+
+/// Feature-internal streaming wrapper around [`KWayMerger`] (issue #1668,
+/// stage 2) — NOT constructed by any production consumer today. See the
+/// module doc for the grouping-contiguity proof and the DESC/absent-component
+/// residual.
+///
+/// Holds ONLY its own drain state (`partition_key` / `pending_rows`); it does
+/// not add fields to `KWayMerger` itself, so the existing `KWayMerger { .. }`
+/// struct-literal unit tests in `mod.rs` are unaffected by this addition.
+#[cfg(feature = "write-support")]
+pub(crate) struct StreamingMerger<'a> {
+    merger: &'a mut KWayMerger,
+    partition_key: Option<DecoratedKey>,
+    pending_rows: VecDeque<MergeEntry>,
+}
+
+#[cfg(feature = "write-support")]
+impl<'a> StreamingMerger<'a> {
+    /// Wrap a [`KWayMerger`] for streaming cluster-group increments.
+    pub(crate) fn new(merger: &'a mut KWayMerger) -> Self {
+        Self {
+            merger,
+            partition_key: None,
+            pending_rows: VecDeque::new(),
+        }
+    }
+
+    /// Yield the next streaming increment.
+    ///
+    /// Drains any in-progress partition's buffered rows one at a time as
+    /// `ClusterGroup`, emits `PartitionEnd` once exhausted, then pulls the
+    /// next whole partition from the wrapped [`KWayMerger::step`] and starts
+    /// draining it. See the module doc for why this reproduces `step()`'s
+    /// output exactly, row-for-row, just split into increments.
+    pub(crate) fn step_streaming(&mut self) -> Result<StreamingStep> {
+        if let Some(key) = self.partition_key.clone() {
+            if let Some(row) = self.pending_rows.pop_front() {
+                return Ok(StreamingStep::ClusterGroup {
+                    key,
+                    row: Box::new(row),
+                });
+            }
+            self.partition_key = None;
+            return Ok(StreamingStep::PartitionEnd { key });
+        }
+
+        match self.merger.step()? {
+            MergeStep::Partition { key, rows } => {
+                let mut pending: VecDeque<MergeEntry> = rows.into();
+                match pending.pop_front() {
+                    Some(row) => {
+                        self.partition_key = Some(key.clone());
+                        self.pending_rows = pending;
+                        Ok(StreamingStep::ClusterGroup {
+                            key,
+                            row: Box::new(row),
+                        })
+                    }
+                    // A partition with no writer-emittable content still runs
+                    // through the SAME boundary the whole-partition path
+                    // would traverse — mirror it with an immediate
+                    // PartitionEnd rather than silently skipping the
+                    // boundary.
+                    None => Ok(StreamingStep::PartitionEnd { key }),
+                }
+            }
+            MergeStep::Complete => Ok(StreamingStep::Complete),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "write-support"))]
+mod tests {
+    use super::*;
+    use crate::schema::{ClusteringColumn, ClusteringOrder, KeyColumn, TableSchema};
+    use crate::storage::write_engine::merge::model::{CellData, RowData};
+    use crate::storage::write_engine::merge::{RunReader, SSTableRowIterator};
+    use crate::storage::write_engine::mutation::{ClusteringKey, RangeTombstone};
+    use crate::types::Value;
+    use std::cmp::Reverse;
+    use std::collections::{BinaryHeap, HashMap};
+
+    fn key(token: i64) -> DecoratedKey {
+        DecoratedKey::new(token, vec![token as u8])
+    }
+
+    fn ck(v: i32) -> ClusteringKey {
+        ClusteringKey::single("ck", Value::Integer(v))
+    }
+
+    fn live_entry(run_index: usize, token: i64, cluster: i32, ts: i64) -> MergeEntry {
+        MergeEntry::new(
+            run_index,
+            key(token),
+            Some(ck(cluster)),
+            ts,
+            RowData::Live {
+                cells: vec![CellData::new("c".to_string(), Value::Integer(cluster), ts)],
+            },
+        )
+    }
+
+    fn range_carrier(token: i64, deletion_time: i64, ldt: i32) -> MergeEntry {
+        let rt = RangeTombstone {
+            start: crate::storage::write_engine::mutation::ClusteringBound::Bottom,
+            end: crate::storage::write_engine::mutation::ClusteringBound::Inclusive(ck(1)),
+            deletion_time,
+            local_deletion_time: ldt,
+        };
+        MergeEntry::new(
+            usize::MAX,
+            key(token),
+            None,
+            deletion_time,
+            RowData::Live { cells: Vec::new() },
+        )
+        .with_range_deletion(rt)
+    }
+
+    fn partition_carrier(token: i64, mfda: i64, ldt: i32) -> MergeEntry {
+        MergeEntry::new(
+            usize::MAX,
+            key(token),
+            None,
+            mfda,
+            RowData::Live { cells: Vec::new() },
+        )
+        .with_partition_deletion((mfda, ldt))
+    }
+
+    /// A single-clustering-column schema, ASC or DESC per `order`.
+    fn test_schema(order: ClusteringOrder) -> TableSchema {
+        TableSchema {
+            keyspace: "ks_1668".to_string(),
+            table: "t_1668".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order,
+            }],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// Test-only `SSTableRowIterator` over a pre-supplied `Vec<MergeEntry>`,
+    /// mirroring the `VecIterator` pattern already used by `mod.rs`'s own
+    /// merge unit tests (kept local here so `streaming.rs`'s tests need no
+    /// cross-module reuse of `mod.rs`'s private test helpers).
+    struct VecIterator(std::vec::IntoIter<MergeEntry>);
+    impl SSTableRowIterator for VecIterator {
+        fn next(&mut self) -> Option<Result<MergeEntry>> {
+            self.0.next().map(Ok)
+        }
+    }
+
+    /// Build a `KWayMerger` with ONE run over `entries`, matching `mod.rs`'s
+    /// `merger_over` test helper (not reusable directly here — private to a
+    /// sibling module — so reconstructed with the same shape).
+    fn merger_over(entries: Vec<MergeEntry>, schema: TableSchema) -> KWayMerger {
+        KWayMerger {
+            runs: vec![RunReader::new(Box::new(VecIterator(entries.into_iter())))],
+            heap: BinaryHeap::new(),
+            current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
+            purge_safe: false,
+            max_purgeable_timestamp: None,
+            schema,
+        }
+    }
+
+    /// The grouping-contiguity VERIFICATION test flagged by issue #1668 as
+    /// "the crux": push entries for several clustering keys across several
+    /// "runs" in SCRAMBLED order directly onto a `BinaryHeap<Reverse<_>>` (the
+    /// exact structure `KWayMerger` uses) and assert that popping them yields
+    /// every same-clustering-key entry CONTIGUOUSLY — i.e. once a distinct
+    /// clustering key is seen, no earlier key ever reappears. This is a
+    /// property of the min-heap invariant under `MergeEntry::Ord`, exercised
+    /// directly rather than assumed.
+    #[test]
+    fn heap_groups_contiguously_by_ord() {
+        let mut heap: BinaryHeap<Reverse<MergeEntry>> = BinaryHeap::new();
+        // Three clustering keys (0, 1, 2), each with entries from three
+        // different "runs" pushed in a deliberately scrambled interleaving.
+        for &(run, cluster, ts) in &[
+            (2, 1, 100),
+            (0, 0, 300),
+            (1, 2, 50),
+            (1, 0, 200),
+            (2, 2, 60),
+            (0, 1, 150),
+            (0, 2, 70),
+            (2, 0, 250),
+            (1, 1, 120),
+        ] {
+            heap.push(Reverse(live_entry(run, 1, cluster, ts)));
+        }
+
+        let mut popped_clusters = Vec::new();
+        while let Some(Reverse(entry)) = heap.pop() {
+            popped_clusters.push(entry.clustering_key.clone());
+        }
+
+        // Every same-clustering-key run must be contiguous: once we move past
+        // a distinct clustering key, it must never reappear later in the
+        // sequence. `ClusteringKey` has no `Hash` impl, so track "closed"
+        // keys with a `Vec` + linear `contains` (the fixture is tiny) rather
+        // than a `HashSet`.
+        let mut closed: Vec<Option<ClusteringKey>> = Vec::new();
+        let mut current: Option<Option<ClusteringKey>> = None;
+        for c in &popped_clusters {
+            if current.as_ref() != Some(c) {
+                if let Some(prev) = current.take() {
+                    assert!(
+                        !closed.contains(&prev),
+                        "clustering key reappeared non-contiguously after the heap moved past it"
+                    );
+                    closed.push(prev);
+                }
+                current = Some(c.clone());
+            }
+        }
+        // Sanity: all three clustering keys were actually observed.
+        let mut distinct: Vec<Option<ClusteringKey>> = Vec::new();
+        for c in &popped_clusters {
+            if !distinct.contains(c) {
+                distinct.push(c.clone());
+            }
+        }
+        assert_eq!(distinct.len(), 3, "expected 3 distinct clustering keys");
+    }
+
+    #[test]
+    fn empty_merger_yields_complete() {
+        let mut merger = merger_over(vec![], test_schema(ClusteringOrder::Asc));
+        let mut stream = StreamingMerger::new(&mut merger);
+        assert!(matches!(
+            stream.step_streaming().unwrap(),
+            StreamingStep::Complete
+        ));
+    }
+
+    /// Drain a `StreamingMerger` to completion, collecting every
+    /// `ClusterGroup` row and asserting a `PartitionEnd` closes each
+    /// partition before the next one starts (or before `Complete`).
+    fn drain_streaming(merger: &mut KWayMerger) -> Vec<MergeEntry> {
+        let mut stream = StreamingMerger::new(merger);
+        let mut rows = Vec::new();
+        let mut in_partition = false;
+        loop {
+            match stream.step_streaming().unwrap() {
+                StreamingStep::ClusterGroup { row, .. } => {
+                    in_partition = true;
+                    rows.push(*row);
+                }
+                StreamingStep::PartitionEnd { .. } => {
+                    assert!(in_partition, "PartitionEnd with no preceding ClusterGroup");
+                    in_partition = false;
+                }
+                StreamingStep::Complete => {
+                    assert!(!in_partition, "Complete while a partition was still open");
+                    return rows;
+                }
+            }
+        }
+    }
+
+    /// Drain the OLD whole-partition `step()` path to completion, collecting
+    /// every row across every partition in encounter order — the same shape
+    /// `drain_streaming` produces, for direct comparison.
+    fn drain_whole_partition(merger: &mut KWayMerger) -> Vec<MergeEntry> {
+        let mut rows = Vec::new();
+        loop {
+            match merger.step().unwrap() {
+                MergeStep::Partition {
+                    rows: partition_rows,
+                    ..
+                } => rows.extend(partition_rows),
+                MergeStep::Complete => return rows,
+            }
+        }
+    }
+
+    /// THE proof stage 3 needs: for a fixture mixing plain rows, a row
+    /// tombstone, a range-tombstone carrier (#933), and a partition-deletion
+    /// carrier (#1072) — i.e. exercising stage-1's `scan_partition_carriers`
+    /// end to end — the streaming path yields EXACTLY the same reconciled
+    /// rows, in the same order, as the old whole-partition path.
+    #[test]
+    fn step_streaming_matches_step_for_mixed_tombstone_fixture() {
+        let schema = test_schema(ClusteringOrder::Asc);
+        let entries = vec![
+            live_entry(0, 1, 0, 100),
+            live_entry(0, 1, 1, 100),
+            live_entry(0, 1, 2, 100),
+            range_carrier(1, 50, 5),
+            partition_carrier(1, 10, 1),
+        ];
+
+        let mut old_merger = merger_over(entries.clone(), schema.clone());
+        let old_rows = drain_whole_partition(&mut old_merger);
+
+        let mut new_merger = merger_over(entries, schema);
+        let new_rows = drain_streaming(&mut new_merger);
+
+        assert!(
+            !old_rows.is_empty(),
+            "fixture must produce at least one row"
+        );
+        assert_eq!(
+            old_rows, new_rows,
+            "streaming path must yield the SAME rows, in the SAME order, as \
+             the whole-partition path"
+        );
+    }
+
+    /// Same proof, but with only plain multi-cluster rows (no carriers) —
+    /// the common case.
+    #[test]
+    fn step_streaming_matches_step_for_plain_multi_cluster_fixture() {
+        let schema = test_schema(ClusteringOrder::Asc);
+        let entries = vec![
+            live_entry(0, 1, 0, 100),
+            live_entry(1, 1, 0, 90), // older duplicate, shadowed by LWW
+            live_entry(0, 1, 1, 100),
+            live_entry(0, 1, 2, 100),
+            live_entry(0, 2, 0, 100), // second partition
+        ];
+
+        let mut old_merger = merger_over(entries.clone(), schema.clone());
+        let old_rows = drain_whole_partition(&mut old_merger);
+
+        let mut new_merger = merger_over(entries, schema);
+        let new_rows = drain_streaming(&mut new_merger);
+
+        assert_eq!(old_rows, new_rows);
+    }
+
+    /// A range-tombstone carrier round-trips through the streaming path as a
+    /// `ClusterGroup` with `clustering_key: None`, exactly as it would sit in
+    /// `MergeStep::Partition.rows` (proving stage-1's carriers thread through
+    /// the increment API unchanged).
+    #[test]
+    fn range_tombstone_carrier_round_trips_as_cluster_group() {
+        let carrier = range_carrier(9, 500, 50);
+        assert!(super::super::carriers::is_range_marker_carrier(&carrier));
+
+        let mut merger = merger_over(vec![carrier.clone()], test_schema(ClusteringOrder::Asc));
+        let mut stream = StreamingMerger::new(&mut merger);
+        match stream.step_streaming().unwrap() {
+            StreamingStep::ClusterGroup { row, .. } => assert_eq!(*row, carrier),
+            other => panic!("expected ClusterGroup, got {other:?}"),
+        }
+    }
+}

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -404,6 +404,7 @@ mod tests {
             now_secs: None,
             purge_safe: false,
             max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         }
     }

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -1,106 +1,194 @@
-//! Streaming cluster-group step type (issue #1668, stages 2-3b).
+//! Streaming cluster-group step type (issue #1668, stages 2-5d).
 //!
 //! **Wiring status (stage 3b)**: [`KWayMerger::merge`] (used by
 //! `compact_sstables_with_registry`) and `write_engine::maintenance`'s
-//! compaction loop both now drain a partition via [`StreamingMerger`]/
-//! [`StreamingStep`] instead of calling [`KWayMerger::step`] directly — each
-//! accumulates `ClusterGroup` rows until `PartitionEnd`, then hands the SAME
-//! `Vec<MergeEntry>` `step()` would have returned to the SAME unchanged
-//! writer call, so output stays byte-identical (see stage 3b's `#921`
-//! compaction-byte-parity harness run). `step_streaming` still calls the
-//! UNCHANGED [`KWayMerger::step`] internally and drains its already-
-//! reconciled `Vec<MergeEntry>` one row at a time, so peak memory is
-//! UNCHANGED by this wiring (stage 5 removes the whole-partition buffering
-//! that still lives inside `step()`/`merge_partition_rows`). The Flight
-//! producer (`cqlite-flight/src/producer.rs`) is INTENTIONALLY untouched —
-//! that is Q4/mid-partition-budget territory, a later stage.
+//! compaction loop both drain a partition via [`StreamingMerger`]/
+//! [`StreamingStep`] instead of calling [`KWayMerger::step`] directly.
 //!
-//! [`StreamingMerger`] does not touch [`MergeStep`]'s shape (a distinct
-//! [`StreamingStep`] type) or `KWayMerger`'s own fields (a wrapper holding its
-//! own drain state, so none of the existing `KWayMerger { .. }` struct-literal
-//! unit tests in `mod.rs` needed updating).
+//! **Stage 5d — the whole-partition buffer is GONE.** Through stage 5c,
+//! `step_streaming` called the UNCHANGED [`KWayMerger::step`] (which still
+//! buffered a WHOLE partition into `partition_rows: Vec<MergeEntry>`,
+//! grouped it into `clustered_rows: BTreeMap<Option<ClusteringKey>, _>`, and
+//! produced one `merged: Vec<MergeEntry>` via `merge_partition_rows`) and
+//! merely DRAINED that already-fully-computed `Vec` one row at a time — peak
+//! memory still scaled with partition width. `step_streaming` now pulls
+//! DIRECTLY off `KWayMerger`'s heap and reconciles ONE clustering-key group
+//! at a time (bounded by the number of input runs sharing that EXACT key,
+//! never partition width) via [`StreamingMerger::pull_one`]/
+//! [`StreamingMerger::finalize_current_cluster`], calling the SAME
+//! `reconcile_cluster_with_overlap_counted`/`apply_range_shadowing`/
+//! `apply_partition_shadowing`/`coalesce_range_tombstones` primitives
+//! `merge_partition_rows` always used — just triggered per-group instead of
+//! in a bulk loop over a pre-built map. `KWayMerger::step`/
+//! `merge_partition_rows` are UNCHANGED (nothing else calls them in
+//! production; they remain this module's own byte-for-byte oracle — see the
+//! `step_streaming_matches_step_for_*` tests below, which now prove the
+//! NATIVE streaming path, not a thin drain wrapper, matches the buffered
+//! path row-for-row).
+//!
+//! ## Two independent accumulation dimensions (issue #1668, stage 5d finding)
+//!
+//! A partition's raw entry stream has TWO things that must be tracked
+//! SIMULTANEOUSLY, not sequentially:
+//!
+//! 1. **Carriers** (partition-tombstone / range-tombstone markers,
+//!    [`MergeEntry::is_partition_delete_carrier`] /
+//!    [`super::carriers::is_range_marker_carrier`]) — siphoned into
+//!    `range_tombstones`/`max_partition_deletion` as encountered.
+//! 2. **The current clustering-key group** — non-carrier entries sharing
+//!    ONE `clustering_key`, accumulated until a DIFFERENT key (or the
+//!    partition/heap) ends it, then reconciled via
+//!    `reconcile_cluster_with_overlap_counted` + shadowed by the (by-then
+//!    fully resolved) carrier state.
+//!
+//! For a table WITH clustering columns, [`schema_order::SchemaOrderedEntry`]'s
+//! `Ord` puts EVERY `clustering_key: None` entry (carriers AND the static-row
+//! candidates, which are ordinary non-carrier entries with `clustering_key:
+//! None`) strictly before ANY `Some(ck)` entry — so carriers form a clean
+//! prefix relative to the clustering-row tail. But for an UNCLUSTERED table
+//! (no clustering columns declared), EVERY entry — carriers AND the sole
+//! row's cross-run duplicates — shares `clustering_key: None` and is
+//! tie-broken ONLY by `run_index`, so a carrier can sort BETWEEN two of that
+//! row's duplicates (e.g. run 0's row, run 1's OWN partition-tombstone
+//! carrier, run 1's row, run 2's row — all four tie on `(token, key, None,
+//! run_index)` pairwise except run_index, so a same-run carrier and row are
+//! not even guaranteed relative order). This is why carriers are classified
+//! and siphoned UNCONDITIONALLY on every pulled entry — never assumed to
+//! form a clean prefix relative to the group currently accumulating.
+//!
+//! `partition_deletion_resolved` (the PARTITION-tombstone half only — see
+//! below for why range tombstones are handled separately) still flips ONCE
+//! per partition: by the time the FIRST cluster needs shadowing, every
+//! partition-tombstone carrier has necessarily already been seen, because
+//! the partition-level deletion is always part of the on-disk HEADER (never
+//! interleaved with rows), so it precedes anything else in that run's own
+//! sequence, and thus (by the same argument as above) everything currently
+//! poppable from the heap for this partition.
+//!
+//! ## Range tombstones can arrive AFTER the rows they cover (issue #1668, stage 5d finding — bounded-open-range design)
+//!
+//! Unlike the partition tombstone, a range tombstone is NOT guaranteed to
+//! precede its covered rows. Tracing the real reader
+//! (`row_decoder/compaction.rs`'s `on_range_marker`/`on_data_row`): the
+//! parser holds the OPEN bound in `self.pending_range_start` (purely
+//! internal state, never surfaced) while rows between it and the CLOSE
+//! bound are pushed to the merge stream via `on_data_row` IMMEDIATELY, one
+//! at a time; the COMPLETE, paired `RangeMarker` `MergeEntry` is only
+//! pushed once the CLOSE bound is parsed — i.e. strictly AFTER every row it
+//! covers. This matches the on-disk format
+//! (`docs/sstables-definitive-guide/chapters/05-data-db-format.md`: markers
+//! sit "between rows in a partition", not bunched into a prefix). So a
+//! cluster can reconcile and be ready to flush BEFORE we've seen the range
+//! tombstone that should shadow it.
+//!
+//! **Design (issue #1668, per-issue owner decision — the two-pass
+//! reader-side redesign that would let the READER expose the open bound
+//! early is explicitly OUT OF SCOPE; filed as a follow-up, see
+//! `PartitionReconcileCheckpoint::awaiting_flush`'s doc)**: a cluster's
+//! survivor flushes straight to `pending_rows` with ZERO extra buffering
+//! as long as NO range tombstone has been seen for this partition yet (the
+//! common case — most partitions have none at all, and the issue's own
+//! motivating scenario is a huge ROW COUNT, not necessarily a wide range
+//! tombstone). Once the FIRST range tombstone's complete entry arrives,
+//! every SUBSEQUENT survivor is held in `awaiting_flush` instead — it
+//! might still need shadowing from a DIFFERENT/later range tombstone (e.g.
+//! from a slower-moving run in a multi-run merge) — and every entry
+//! currently held there is re-shadowed and flushed as soon as EITHER
+//! another range tombstone resolves or the partition ends. This bounds
+//! peak memory to `max(current cluster group size, rows accumulated since
+//! the last flush point)` for the common case of narrow/occasional range
+//! tombstones, degrading toward whole-partition width only for a
+//! pathological range tombstone whose span covers nearly the entire
+//! partition — an honestly documented residual, not a silent correctness
+//! gap (every row is STILL correctly shadowed once its covering marker
+//! resolves; only the PEAK MEMORY bound degrades for that specific shape).
+//!
+//! ## Load-bearing precondition: each run must arrive pre-sorted (issue #1668, stage 5d finding)
+//!
+//! `KWayMerger`'s heap holds AT MOST one "candidate" entry per input run at
+//! any time (`initialize_heap`/`refill_heap` — the classic K-WAY MERGE
+//! shape: interleave `k` ALREADY-SORTED streams, never re-sort within one).
+//! Consequently the heap can only ever choose correctly ACROSS runs; it
+//! cannot reorder a single run's OWN entries relative to each other, since
+//! it never sees more than one of that run's entries at a time. This is
+//! SAFE for real data: a genuine SSTable file's rows are always written in
+//! schema-consistent order (`SSTableWriter::write_partition`'s own
+//! `mutations.sort_by(|a, b| ck_a.compare(ck_b, &self.schema) ...)` — the
+//! SAME schema-aware comparator, which DOES reverse `DESC` columns — always
+//! runs before ANY row is written), so a `RunReader` backed by a real file
+//! naturally yields that file's rows already in the correct order; the
+//! heap's real job is purely to interleave MULTIPLE such runs. A test
+//! fixture that pushes a SINGLE run's entries in an order inconsistent with
+//! the CURRENT schema (e.g. ascending `MergeEntry`s for a `DESC` column) is
+//! therefore not modeling a real SSTable file — `merger_over_runs` (below)
+//! puts each independently-orderable entry in its OWN run so the fixture
+//! exercises the heap's REAL job (cross-run interleaving) instead of an
+//! unrealistic single-run reordering. The pre-stage-5d `step()` masked one
+//! such unrealistic fixture (raw carriers tagged with a `usize::MAX`
+//! run_index sentinel, which real carriers never carry — see
+//! `build_merge_entry`) via an unrelated bug: `current_partition` is never
+//! actually assigned, so `step()`'s "lazy init" guard re-triggers
+//! `initialize_heap()` — which happens to force-refill a stalled run — on
+//! EVERY subsequent `step()` call whenever the heap empties, silently
+//! splitting one logical partition into extra `MergeStep::Partition` steps
+//! that `drain_whole_partition` then concatenates back together. This
+//! module's tests construct carriers with their REAL run_index instead
+//! (see `range_carrier`/`partition_carrier`'s docs), matching
+//! `build_merge_entry`.
 //!
 //! ## Grouping-contiguity VERIFICATION (issue #1668 flags this as "the crux")
 //!
-//! The increment design assumes that once a caller has moved past a
-//! clustering key while draining the heap, it never sees that key again —
-//! i.e. the heap pop order groups every entry for the same `(pk, ck)`
-//! contiguously, so "accumulate only the entries for the current clustering
-//! key, then move on" never re-opens a finished group. This DOES hold:
-//! [`MergeEntry`]'s `Ord` (`model.rs`) orders primarily by
-//! `(token, key bytes, clustering_key, run_index)`, and `clustering_key`
-//! compares via `ClusteringKey`'s FALLBACK `Ord` (lexicographic by value) —
-//! the SAME fallback `Ord`/`Eq` that `merge_partition_rows`'s
-//! `clustered_rows: BTreeMap<Option<ClusteringKey>, _>` already groups by
-//! today. Since `BinaryHeap::pop` yields a non-increasing (here: `Reverse`,
-//! so non-decreasing) sequence under one fixed comparator, and grouping
-//! identity here is that SAME comparator's notion of equality, entries for
-//! one clustering key are contiguous in heap-pop order — proven directly
-//! against the heap (not assumed) by the `heap_groups_contiguously_by_ord`
-//! test below.
+//! The design assumes that once processing has moved past a clustering key
+//! while draining the heap, it never sees that key again — i.e. the heap pop
+//! order groups every NON-CARRIER entry for the same `(pk, ck)` contiguously
+//! (carriers interleave freely, per the finding above, but never split a
+//! real group since they are filtered out before the grouping decision).
+//! [`MergeEntry`]'s `Ord` (`model.rs`) orders primarily by `(token, key
+//! bytes, clustering_key, run_index)`; [`schema_order::SchemaOrderedEntry`]'s
+//! `Ord` (stage 5c-i, now what the heap actually uses) substitutes a
+//! schema-aware clustering-key comparison at that same step. Since
+//! `BinaryHeap::pop` yields a non-increasing (here: `Reverse`, so
+//! non-decreasing) sequence under one fixed total order, and grouping
+//! identity is that SAME comparator's notion of equality, entries for one
+//! clustering key are contiguous in heap-pop order — proven directly against
+//! the heap (not assumed) by the `heap_groups_contiguously_by_ord`/
+//! `heap_groups_contiguously_by_schema_aware_ord` tests.
 //!
-//! ## Cross-group emission order — resolved for THIS design (issue #1668, stage 3a)
+//! ## Cross-group emission order — schema-aware, no final sort (issue #1668, stages 3a/5c-i/5d)
 //!
-//! Stage 2 flagged a residual: `ClusteringKey`'s fallback `Ord`
-//! (`mutation.rs`) is NOT schema-aware — no `DESC` reversal, and an absent
-//! trailing component is handled by zip-stopping + a length tiebreak rather
-//! than Cassandra's explicit NULL-first rule (contrast the schema-aware
-//! `ClusteringKey::compare`). Stage 3a's blast-radius audit + new tests below
-//! resolve whether this is safe to wire a real consumer onto:
+//! Stage 2 flagged a residual: the (then-fallback, non-schema-aware) heap
+//! `Ord` doesn't reverse `DESC` columns or NULL-first an absent trailing
+//! component. Stage 5c-i made the heap's OWN comparator schema-aware
+//! (`schema_order::SchemaOrderedEntry`), so stage 5d's native per-group
+//! emission needs no compensating final sort (`schema_order.rs`'s
+//! `schema_ordered_pop_all_matches_todays_step_output_for_desc_fixture` test
+//! already proved heap-direct order matches `merge_partition_rows`'s
+//! sorted output for a DESC fixture; the tests below prove the SAME for the
+//! native per-group reconciliation path specifically). Stage 3a's residual
+//! (below) documents the ORIGINAL fallback-Ord concern, since superseded:
 //!
-//! **Blast radius**: `MergeEntry::Ord`/`PartialOrd` (the fallback comparator)
-//! has exactly ONE production consumer in the whole crate — `KWayMerger`'s
-//! `heap: BinaryHeap<Reverse<MergeEntry>>` (routing only, in `mod.rs`). No
-//! other file constructs a `BinaryHeap<Reverse<MergeEntry>>` or otherwise
-//! depends on `MergeEntry::Ord`'s specific clustering semantics; the one
-//! direct-heap unit test (`mod.rs::test_merge_entry_min_heap`) only exercises
-//! token ordering (`clustering_key: None` throughout), so it is untouched by
-//! clustering-comparator semantics either way. Changing `MergeEntry::Ord`
-//! globally would therefore be LOW risk in isolation — but it is UNNECESSARY:
-//!
-//! **Why no Ord change is needed for THIS design**: `step_streaming` (below)
-//! never consumes heap-pop order for cross-group sequencing. It drains the
-//! `Vec<MergeEntry>` `KWayMerger::step()` already returns, and `step()`
-//! (via `merge_partition_rows`) already applies an explicit
-//! `merged.sort_by(|a, b| ck_a.compare(ck_b, &self.schema) ...)` — the
-//! SCHEMA-AWARE comparator — as its LAST step, unconditionally, regardless of
-//! what order the heap or the `clustered_rows: BTreeMap` (also fallback-Ord-
-//! keyed) produced internally. So `step()`'s returned order is ALREADY
-//! schema-correct today, and `step_streaming` inherits that correctness
-//! unchanged. `step_streaming_matches_step_for_desc_clustering_fixture` and
-//! `step_streaming_matches_step_for_absent_trailing_component_fixture` below
-//! prove this directly: both assert the emitted clustering-key SEQUENCE
-//! (independently, not just old-path-equals-new-path) against the
-//! Cassandra-correct expected order for a `DESC` column and for an
-//! absent-trailing-component (NULL-first) case — neither the fallback Ord's
-//! ordering, proving the divergence does NOT leak through this design.
-//!
-//! **Residual still applies to a DIFFERENT, NOT-YET-BUILT design**: a FUTURE
-//! stage-5 rewrite that removes `merge_partition_rows`'s whole-partition
-//! buffer-then-sort and instead emits groups directly off the heap (true
-//! streaming, no per-partition buffer) would lose that final sort and must
-//! independently solve cross-group ordering then — either by making the heap
-//! comparator schema-aware (cheap: one production call site, per the blast-
-//! radius finding above) or by a small local re-sort at group boundaries.
-//! Flagged for that stage's design, not resolved here, because it does not
-//! yet exist.
-//!
-//! `step_streaming` does NOT yet avoid whole-partition buffering: it calls
-//! the unchanged [`KWayMerger::step`] (which still buffers a whole partition
-//! and fully reconciles it via `merge_partition_rows`, itself now built on the
-//! stage-1 `carriers::scan_partition_carriers` pre-scan) and then drains the
-//! resulting `Vec<MergeEntry>` one row at a time. Removing that buffering is
-//! stage 5's job; this stage proves the increment TYPE and consumer-loop
-//! shape are safe to build on.
+//! **Historical note (stage 3a, since superseded by 5c-i/5d)**:
+//! `MergeEntry::Ord`/`PartialOrd` (the fallback comparator) still has exactly
+//! ONE production consumer in the whole crate — nothing else constructs a
+//! `BinaryHeap<Reverse<MergeEntry>>` or depends on its clustering semantics
+//! (the one direct-heap unit test, `mod.rs::test_merge_entry_min_heap`, only
+//! exercises token ordering). Stage 3a reasoned that changing it was
+//! unnecessary because `step()`'s final `merged.sort_by` already fixed up
+//! any heap-order imperfection; stage 5c-i made the heap's OWN comparator
+//! schema-aware anyway (`schema_order::SchemaOrderedEntry`), and stage 5d
+//! now relies on THAT comparator directly (no final sort at all) — so this
+//! residual is fully closed, not merely deferred.
 
 #[cfg(feature = "write-support")]
-use super::model::MergeEntry;
+use super::model::{MergeEntry, RowData};
 #[cfg(feature = "write-support")]
-use super::{KWayMerger, MergeStep};
+use super::{carriers, KWayMerger, PurgeCounts};
 #[cfg(feature = "write-support")]
-use crate::error::Result;
+use crate::error::{Error, Result};
 #[cfg(feature = "write-support")]
-use crate::storage::write_engine::mutation::DecoratedKey;
+use crate::storage::write_engine::mutation::{ClusteringKey, DecoratedKey, RangeTombstone};
+#[cfg(feature = "write-support")]
+use std::cmp::Reverse;
 #[cfg(feature = "write-support")]
 use std::collections::VecDeque;
 
@@ -140,11 +228,97 @@ pub(crate) enum StreamingStep {
 /// Holds ONLY its own drain state (`partition_key` / `pending_rows`); it does
 /// not add fields to `KWayMerger` itself, so the existing `KWayMerger { .. }`
 /// struct-literal unit tests in `mod.rs` are unaffected by this addition.
+/// Opaque, resumable snapshot of a [`StreamingMerger`]'s per-partition
+/// reconciliation state (issue #1668, stage 5d). Bundles EVERYTHING
+/// [`StreamingMerger::into_paused_state`]/[`StreamingMerger::resume`] need
+/// to survive a `maintenance_step_inner` budget pause with zero
+/// re-computation and zero lost/duplicated rows, now that reconciliation
+/// happens incrementally (cluster by cluster, directly off the heap)
+/// instead of via one whole-partition `step()` call whose OUTPUT `Vec` was
+/// simply drained. `write_engine::maintenance` holds this OPAQUELY (it never
+/// inspects a field) — see `ActiveMerge::pending_partition`.
+#[cfg(feature = "write-support")]
+#[derive(Debug)]
+pub(crate) struct PartitionReconcileCheckpoint {
+    pending_rows: VecDeque<MergeEntry>,
+    /// EVERY range tombstone seen so far for this partition (never removed
+    /// once added — issue #1668 stage 5d's bounded-open-range design keeps
+    /// this deliberately simple: a row is re-checked against the FULL set
+    /// seen so far each time it might be affected, rather than tracking
+    /// exactly which ranges are still "in flight").
+    range_tombstones: Vec<(DecoratedKey, RangeTombstone)>,
+    max_partition_deletion: Option<(i64, i32)>,
+    partition_delete_key: Option<DecoratedKey>,
+    /// Resolves EXACTLY ONCE per partition, when the bounded `clustering_key:
+    /// None` PREFIX ends (the first non-carrier entry arrives) — covers the
+    /// PARTITION-level tombstone (always part of the on-disk header, so
+    /// always fully known by then) and re-emits whatever range tombstones
+    /// happened to also be seen during that prefix. Renamed from
+    /// `carriers_resolved` (issue #1668 stage 5d): a range tombstone
+    /// specifically can ALSO arrive well after this point (see
+    /// `awaiting_flush`'s doc) — this flag no longer covers that case.
+    partition_deletion_resolved: bool,
+    current_cluster: Option<(Option<ClusteringKey>, Vec<MergeEntry>)>,
+    purges: PurgeCounts,
+    /// Reconciled rows held back from `pending_rows` because at least one
+    /// range tombstone has been seen for this partition (issue #1668 stage
+    /// 5d's bounded-open-range design — see the module doc). A row lands
+    /// here instead of `pending_rows` whenever `range_tombstones` is
+    /// non-empty at the moment its cluster reconciles; every entry here is
+    /// re-shadowed and flushed to `pending_rows` as soon as either ANOTHER
+    /// range tombstone's complete entry arrives (it might affect an entry
+    /// held from before we knew about it) or the partition ends. Bounds
+    /// peak memory to "rows accumulated since the last flush point" for the
+    /// common case of narrow/occasional range tombstones, degrading toward
+    /// whole-partition width only for a tombstone spanning nearly the whole
+    /// partition — the documented residual (see the module doc and the
+    /// linked follow-up issue).
+    awaiting_flush: VecDeque<MergeEntry>,
+    /// Set once [`StreamingMerger::flush_range_tombstones`] has re-emitted
+    /// every range tombstone known so far as its own marker entry. Issue
+    /// #1668 stage 5d: a range tombstone's complete entry can arrive at any
+    /// point relative to the rows it covers (see `awaiting_flush`'s doc), so
+    /// this marker re-emission is deferred to a SINGLE point — partition end
+    /// — where the FULL, final set is known and can be coalesced exactly
+    /// once (coalescing a partial set early, then coalescing again later,
+    /// risks re-emitting overlapping marker pairs — roborev #959 High #1's
+    /// concern — if a later-discovered range overlaps an already-emitted
+    /// one). This flag makes that single call idempotent across the
+    /// `step_streaming` loop's repeated visits to the exhausted-partition
+    /// branch.
+    range_tombstones_emitted: bool,
+}
+
+#[cfg(feature = "write-support")]
+impl PartitionReconcileCheckpoint {
+    fn fresh() -> Self {
+        Self {
+            pending_rows: VecDeque::new(),
+            range_tombstones: Vec::new(),
+            max_partition_deletion: None,
+            partition_delete_key: None,
+            partition_deletion_resolved: false,
+            current_cluster: None,
+            purges: PurgeCounts::default(),
+            awaiting_flush: VecDeque::new(),
+            range_tombstones_emitted: false,
+        }
+    }
+}
+
+/// Feature-internal streaming wrapper around [`KWayMerger`] (issue #1668,
+/// stages 2-5d) — reconciles ONE clustering-key group at a time DIRECTLY off
+/// `merger`'s heap (see the module doc's "two independent accumulation
+/// dimensions" section for the full design and its correctness proof).
+///
+/// Holds ONLY its own drain/reconciliation state; it does not add fields to
+/// `KWayMerger` itself, so the existing `KWayMerger { .. }` struct-literal
+/// unit tests in `mod.rs` are unaffected by this module's changes.
 #[cfg(feature = "write-support")]
 pub(crate) struct StreamingMerger<'a> {
     merger: &'a mut KWayMerger,
     partition_key: Option<DecoratedKey>,
-    pending_rows: VecDeque<MergeEntry>,
+    state: PartitionReconcileCheckpoint,
 }
 
 #[cfg(feature = "write-support")]
@@ -154,93 +328,388 @@ impl<'a> StreamingMerger<'a> {
         Self {
             merger,
             partition_key: None,
-            pending_rows: VecDeque::new(),
+            state: PartitionReconcileCheckpoint::fresh(),
         }
     }
 
     /// Resume (or start fresh) draining, seeded with a PREVIOUSLY paused
-    /// partition's remaining, not-yet-yielded rows (issue #1668, stage 4).
+    /// partition's full reconciliation checkpoint (issue #1668, stage 4;
+    /// checkpoint shape widened in stage 5d — see
+    /// [`PartitionReconcileCheckpoint`]).
     ///
     /// `StreamingMerger` cannot itself be stored across calls — it borrows
     /// `&'a mut KWayMerger`, so it is not self-referential-storable on a
     /// struct that also owns that `KWayMerger` (e.g. `ActiveMerge`). A
     /// caller that must pause mid-partition (the "Q4" mid-partition budget
-    /// check) instead persists the OWNED `(key, remaining_rows)` extracted
-    /// via [`Self::into_paused_state`], then reconstructs a fresh
+    /// check) instead persists the OWNED `(key, checkpoint)` extracted via
+    /// [`Self::into_paused_state`], then reconstructs a fresh
     /// `StreamingMerger` next call via THIS constructor, seeded with that
     /// saved state. `saved: None` starts fresh, identical to [`Self::new`].
     ///
-    /// Nothing is re-computed and nothing is lost: `remaining_rows` are rows
-    /// `step()` ALREADY fully reconciled for `key`'s partition in a PRIOR
-    /// call — the underlying `merger`'s heap has already moved past them, so
-    /// re-calling `merger.step()` for this partition would silently skip
-    /// them. Resuming via this seeded queue (instead of starting a fresh,
-    /// empty `StreamingMerger` and calling `step()` again) is therefore
-    /// required for correctness, not just an optimization.
+    /// Nothing is re-computed and nothing is lost: the checkpoint carries
+    /// every raw entry already popped off the heap for `key`'s partition but
+    /// not yet fully reconciled (the in-progress cluster's raw rows, the
+    /// carrier accumulator) PLUS every already-reconciled, not-yet-yielded
+    /// row — the heap itself has moved past them, so resuming via this
+    /// checkpoint (instead of starting fresh and re-scanning) is required
+    /// for correctness, not just an optimization.
     pub(crate) fn resume(
         merger: &'a mut KWayMerger,
-        saved: Option<(DecoratedKey, VecDeque<MergeEntry>)>,
+        saved: Option<(DecoratedKey, PartitionReconcileCheckpoint)>,
     ) -> Self {
-        let (partition_key, pending_rows) = match saved {
-            Some((key, rows)) => (Some(key), rows),
-            None => (None, VecDeque::new()),
+        let (partition_key, state) = match saved {
+            Some((key, checkpoint)) => (Some(key), checkpoint),
+            None => (None, PartitionReconcileCheckpoint::fresh()),
         };
         Self {
             merger,
             partition_key,
-            pending_rows,
+            state,
         }
     }
 
-    /// Extract the in-progress partition's remaining, not-yet-yielded rows
-    /// (issue #1668, stage 4), for a caller that must pause mid-partition and
-    /// resume later via [`Self::resume`]. Returns `None` if no partition was
-    /// in progress (nothing to resume — the next call should start fresh via
-    /// [`Self::new`]/`resume(merger, None)`).
-    pub(crate) fn into_paused_state(self) -> Option<(DecoratedKey, VecDeque<MergeEntry>)> {
-        self.partition_key.map(|key| (key, self.pending_rows))
+    /// Extract the in-progress partition's full reconciliation checkpoint
+    /// (issue #1668, stage 4/5d), for a caller that must pause mid-partition
+    /// and resume later via [`Self::resume`]. Returns `None` if no partition
+    /// was in progress (nothing to resume — the next call should start fresh
+    /// via [`Self::new`]/`resume(merger, None)`).
+    pub(crate) fn into_paused_state(self) -> Option<(DecoratedKey, PartitionReconcileCheckpoint)> {
+        self.partition_key.map(|key| (key, self.state))
+    }
+
+    /// Pop one raw entry belonging to the CURRENT partition
+    /// (`self.partition_key`, which must already be `Some`) off the heap,
+    /// refilling from its run — the SAME peek/pop/refill mechanism
+    /// `KWayMerger::step` uses, just triggered one entry at a time instead
+    /// of in a bulk `while let` loop. Returns `None` if the heap is empty or
+    /// its next entry belongs to a DIFFERENT partition — i.e. the current
+    /// partition has no more entries.
+    fn pull_one(&mut self) -> Result<Option<MergeEntry>> {
+        let Some(current_key) = &self.partition_key else {
+            return Ok(None);
+        };
+        match self.merger.heap.peek() {
+            Some(Reverse(top)) if &top.entry.key == current_key => {}
+            _ => return Ok(None),
+        }
+        let Reverse(top) = self
+            .merger
+            .heap
+            .pop()
+            .ok_or_else(|| Error::InvalidInput("Merge heap unexpectedly empty".to_string()))?;
+        let entry = top.entry;
+        self.merger.refill_heap(entry.run_index)?;
+        Ok(Some(entry))
+    }
+
+    /// Resolve the partition-tombstone half of the carrier accumulator
+    /// EXACTLY ONCE per partition, when the bounded `clustering_key: None`
+    /// PREFIX ends (see the module doc's "load-bearing precondition"
+    /// section: the partition-level tombstone is always part of the on-disk
+    /// header, so it is FULLY known by the time any non-carrier entry
+    /// arrives). Re-emits the partition tombstone (gc/overlap-purge-gated)
+    /// into `pending_rows` — mirrors `merge_partition_rows`'s equivalent
+    /// re-emission, just triggered at the moment it is first NEEDED instead
+    /// of unconditionally after the whole partition is buffered.
+    ///
+    /// Deliberately does NOT also flush range tombstones here (issue #1668
+    /// stage 5d): a range tombstone's complete entry can arrive well after
+    /// this point (see `awaiting_flush`'s doc), so ALL range-tombstone
+    /// marker re-emission is deferred to the single partition-end call —
+    /// see `range_tombstones_emitted`'s doc for why.
+    fn resolve_partition_prefix(&mut self) {
+        if self.state.partition_deletion_resolved {
+            return;
+        }
+        self.state.partition_deletion_resolved = true;
+
+        let (effective_gc_before, max_purgeable_timestamp) = self.merger.effective_gc_settings();
+
+        if let (Some((pmfda, pldt)), Some(key)) = (
+            self.state.max_partition_deletion,
+            self.state.partition_delete_key.take(),
+        ) {
+            let purge = match effective_gc_before {
+                Some(gc_before) => {
+                    i64::from(pldt as u32) < gc_before && pmfda < max_purgeable_timestamp
+                }
+                None => false,
+            };
+            if purge {
+                self.state.purges.partition_tombstones += 1;
+            } else {
+                self.state.purges.emitted += 1;
+                self.state.pending_rows.push_back(
+                    MergeEntry::new(
+                        usize::MAX,
+                        key,
+                        None,
+                        pmfda,
+                        RowData::Tombstone {
+                            deletion_time: pmfda,
+                            local_deletion_time: pldt,
+                        },
+                    )
+                    .with_partition_deletion((pmfda, pldt)),
+                );
+            }
+        }
+    }
+
+    /// Coalesce `range_tombstones`, drop any subsumed by the partition
+    /// floor, gc/overlap-purge-gate every survivor, and re-emit the
+    /// retained markers into `pending_rows` — the marker-persistence half
+    /// of what `merge_partition_rows` does. Called EXACTLY ONCE per
+    /// partition, at partition end (guarded by `range_tombstones_emitted`
+    /// in the `step_streaming` caller), once the FULL, final set of range
+    /// tombstones is known — coalescing (and therefore re-emitting) a
+    /// partial set here and a later-discovered remainder in a SECOND call
+    /// would risk two marker pairs overlapping in the output (roborev #959
+    /// High #1's concern).
+    fn flush_range_tombstones(&mut self, effective_gc_before: Option<i64>, max_purgeable_timestamp: i64) {
+        self.state.range_tombstones_emitted = true;
+        KWayMerger::coalesce_range_tombstones(&mut self.state.range_tombstones, &self.merger.schema);
+
+        if let Some((pmfda, _)) = self.state.max_partition_deletion {
+            self.state
+                .range_tombstones
+                .retain(|(_, rt)| rt.deletion_time > pmfda);
+        }
+
+        for (key, rt) in self.state.range_tombstones.clone() {
+            if let Some(gc_before) = effective_gc_before {
+                if i64::from(rt.local_deletion_time as u32) < gc_before
+                    && rt.deletion_time < max_purgeable_timestamp
+                {
+                    self.state.purges.range_tombstones += 1;
+                    continue;
+                }
+            }
+            self.state.purges.emitted += 1;
+            self.state.pending_rows.push_back(
+                MergeEntry::new(
+                    usize::MAX,
+                    key,
+                    None,
+                    rt.deletion_time,
+                    RowData::Live { cells: Vec::new() },
+                )
+                .with_range_deletion(rt),
+            );
+        }
+    }
+
+    /// Re-apply range- then partition-shadowing (using EVERY range
+    /// tombstone known so far) to everything currently held in
+    /// `awaiting_flush`, then move every survivor into `pending_rows`
+    /// (issue #1668 stage 5d's bounded-open-range design — see
+    /// `awaiting_flush`'s field doc and the module doc's finding on why a
+    /// range tombstone's complete entry can arrive strictly after every row
+    /// it covers has already been popped off the heap).
+    fn reshadow_and_flush_awaiting(&mut self) {
+        if self.state.awaiting_flush.is_empty() {
+            return;
+        }
+        KWayMerger::coalesce_range_tombstones(&mut self.state.range_tombstones, &self.merger.schema);
+        for entry in std::mem::take(&mut self.state.awaiting_flush) {
+            if let Some(shadowed) = KWayMerger::apply_range_shadowing(
+                entry,
+                &self.state.range_tombstones,
+                &self.merger.schema,
+            ) {
+                if let Some(survivor) = KWayMerger::apply_partition_shadowing(
+                    shadowed,
+                    self.state.max_partition_deletion,
+                ) {
+                    self.state.pending_rows.push_back(survivor);
+                }
+            }
+        }
+    }
+
+    /// Finalize whatever cluster is currently accumulating (if any):
+    /// reconcile its raw rows, apply range- then partition-shadowing, and
+    /// route the survivor to `pending_rows` (zero extra buffering — the
+    /// common case, when no range tombstone has been seen for this
+    /// partition YET) or `awaiting_flush` (issue #1668 stage 5d's
+    /// bounded-open-range design: held because a range tombstone HAS been
+    /// seen, so a DIFFERENT/later one might still need to shadow this
+    /// survivor too). A no-op beyond resolving the partition-tombstone
+    /// prefix if no cluster is in progress (the tombstone-only or
+    /// truly-empty partition cases).
+    fn finalize_current_cluster(&mut self) -> Result<()> {
+        let Some((ck, rows)) = self.state.current_cluster.take() else {
+            self.resolve_partition_prefix();
+            return Ok(());
+        };
+        self.resolve_partition_prefix();
+
+        let (effective_gc_before, max_purgeable_timestamp) = self.merger.effective_gc_settings();
+        if let Some(entry) = KWayMerger::reconcile_cluster_with_overlap_counted(
+            ck,
+            rows,
+            &self.merger.schema.dropped_columns,
+            effective_gc_before,
+            max_purgeable_timestamp,
+            self.merger.now_secs,
+            &mut self.state.purges,
+        ) {
+            if self.state.range_tombstones.is_empty() {
+                // Common case: nothing has EVER shadowed anything in this
+                // partition so far — partition-shadowing alone still
+                // applies (it resolves fully during the prefix, unlike
+                // range tombstones), then flush straight through with zero
+                // extra buffering.
+                if let Some(survivor) =
+                    KWayMerger::apply_partition_shadowing(entry, self.state.max_partition_deletion)
+                {
+                    self.state.pending_rows.push_back(survivor);
+                }
+            } else {
+                self.state.awaiting_flush.push_back(entry);
+            }
+        }
+        Ok(())
     }
 
     /// Yield the next streaming increment.
     ///
-    /// Drains any in-progress partition's buffered rows one at a time as
-    /// `ClusterGroup`, emits `PartitionEnd` once exhausted, then pulls the
-    /// next whole partition from the wrapped [`KWayMerger::step`] and starts
-    /// draining it. See the module doc for why this reproduces `step()`'s
-    /// output exactly, row-for-row, just split into increments.
+    /// Drains any already-reconciled, ready-to-emit rows first; otherwise
+    /// pulls raw entries directly off the heap, siphoning carriers into the
+    /// running accumulator and growing the current clustering-key group,
+    /// until either a reconciled row becomes available, the partition ends
+    /// (`PartitionEnd`), or the whole merge ends (`Complete`). See the
+    /// module doc for the full design and its correctness proof.
     pub(crate) fn step_streaming(&mut self) -> Result<StreamingStep> {
-        if let Some(key) = self.partition_key.clone() {
-            if let Some(row) = self.pending_rows.pop_front() {
+        loop {
+            if let Some(row) = self.state.pending_rows.pop_front() {
+                let Some(key) = self.partition_key.clone() else {
+                    return Err(Error::InvalidInput(
+                        "pending row without an active partition key".to_string(),
+                    ));
+                };
                 return Ok(StreamingStep::ClusterGroup {
                     key,
                     row: Box::new(row),
                 });
             }
-            self.partition_key = None;
-            return Ok(StreamingStep::PartitionEnd { key });
-        }
 
-        match self.merger.step()? {
-            MergeStep::Partition { key, rows } => {
-                let mut pending: VecDeque<MergeEntry> = rows.into();
-                match pending.pop_front() {
-                    Some(row) => {
-                        self.partition_key = Some(key.clone());
-                        self.pending_rows = pending;
-                        Ok(StreamingStep::ClusterGroup {
-                            key,
-                            row: Box::new(row),
-                        })
+            if self.partition_key.is_none() {
+                // Lazy heap init on first use — mirrors `KWayMerger::step`'s
+                // OWN check exactly (issue #1668 stage 5d: `step_streaming`
+                // no longer delegates to `step`, so it must replicate this
+                // one-time setup itself).
+                if self.merger.heap.is_empty() && self.merger.current_partition.is_none() {
+                    self.merger.initialize_heap()?;
+                }
+                let Some(Reverse(top)) = self.merger.heap.peek() else {
+                    return Ok(StreamingStep::Complete);
+                };
+                self.partition_key = Some(top.entry.key.clone());
+                self.state = PartitionReconcileCheckpoint::fresh();
+            }
+
+            match self.pull_one()? {
+                Some(entry) => {
+                    // Carriers are siphoned off REGARDLESS of any in-progress
+                    // cluster (issue #1668 stage 5d finding: a carrier can
+                    // share a run_index tie-break with — and interleave
+                    // arbitrarily with — the current cluster for an
+                    // unclustered table's sole `ck: None` group).
+                    if entry.is_partition_delete_carrier() {
+                        if let Some((mfda, ldt)) = entry.partition_deletion {
+                            self.state
+                                .partition_delete_key
+                                .get_or_insert_with(|| entry.key.clone());
+                            match self.state.max_partition_deletion {
+                                Some((cur_mfda, _)) if cur_mfda >= mfda => {}
+                                _ => self.state.max_partition_deletion = Some((mfda, ldt)),
+                            }
+                            continue;
+                        }
                     }
-                    // A partition with no writer-emittable content still runs
-                    // through the SAME boundary the whole-partition path
-                    // would traverse — mirror it with an immediate
-                    // PartitionEnd rather than silently skipping the
-                    // boundary.
-                    None => Ok(StreamingStep::PartitionEnd { key }),
+                    if carriers::is_range_marker_carrier(&entry) {
+                        if let Some(rt) = entry.range_deletion.clone() {
+                            self.state.range_tombstones.push((entry.key.clone(), rt));
+                            // Issue #1668 stage 5d: a range tombstone's
+                            // COMPLETE entry can arrive strictly AFTER the
+                            // bounded prefix (the reader only surfaces it
+                            // once its close bound is parsed — see the
+                            // module doc's finding). Once the prefix has
+                            // already resolved, this is a NEW mid-partition
+                            // discovery: immediately re-check every row
+                            // held in `awaiting_flush` against it (and
+                            // every range tombstone seen so far) rather
+                            // than waiting — bounding the buffer to "since
+                            // the last flush point," not the whole
+                            // partition.
+                            if self.state.partition_deletion_resolved {
+                                self.reshadow_and_flush_awaiting();
+                            }
+                        }
+                        continue;
+                    }
+
+                    // Not a carrier: belongs to a clustering-key group.
+                    let starts_new_cluster = match &self.state.current_cluster {
+                        Some((ck, _)) => *ck != entry.clustering_key,
+                        None => false,
+                    };
+                    if starts_new_cluster {
+                        self.finalize_current_cluster()?;
+                    }
+                    match &mut self.state.current_cluster {
+                        Some((_, rows)) => rows.push(entry),
+                        None => {
+                            self.state.current_cluster =
+                                Some((entry.clustering_key.clone(), vec![entry]));
+                        }
+                    }
+                }
+                None => {
+                    // The current partition is exhausted (pulling again is
+                    // safe and cheap — the heap's `peek()` stays exhausted
+                    // for this partition, and `finalize_current_cluster` is
+                    // idempotent once `current_cluster` has already been
+                    // taken — issue #1668 stage 5d note): finalize the last
+                    // cluster (if any) and resolve any never-needed
+                    // carriers, then flush whatever `awaiting_flush` still
+                    // holds — the partition is DEFINITELY ending, so this
+                    // is the final, authoritative flush regardless of
+                    // whether ANOTHER range tombstone ever showed up to
+                    // trigger an earlier one. If any of this produced NEW
+                    // ready rows, loop back to drain them (via step 1,
+                    // `partition_key` untouched) before ending the
+                    // partition. Only once finalization truly yields
+                    // nothing further do we emit the purge-counter
+                    // observability EXACTLY ONCE and signal PartitionEnd.
+                    self.finalize_current_cluster()?;
+                    self.reshadow_and_flush_awaiting();
+                    if !self.state.range_tombstones.is_empty() && !self.state.range_tombstones_emitted
+                    {
+                        let (effective_gc_before, max_purgeable_timestamp) =
+                            self.merger.effective_gc_settings();
+                        self.flush_range_tombstones(effective_gc_before, max_purgeable_timestamp);
+                    }
+                    if !self.state.pending_rows.is_empty() {
+                        continue;
+                    }
+                    let purged = self.state.purges.total();
+                    if purged > 0 {
+                        crate::observability::add_counter(
+                            crate::observability::catalog::COMPACTION_TOMBSTONES_PURGED,
+                            purged,
+                            &[],
+                        );
+                    }
+                    let Some(key) = self.partition_key.take() else {
+                        return Err(Error::InvalidInput(
+                            "partition ended without an active key".to_string(),
+                        ));
+                    };
+                    return Ok(StreamingStep::PartitionEnd { key });
                 }
             }
-            MergeStep::Complete => Ok(StreamingStep::Complete),
         }
     }
 }
@@ -248,6 +717,11 @@ impl<'a> StreamingMerger<'a> {
 #[cfg(all(test, feature = "write-support"))]
 mod tests {
     use super::*;
+    // `MergeStep` is only exercised by these tests' `drain_whole_partition`
+    // oracle (the unchanged `KWayMerger::step` reference path) — not by any
+    // non-test code in this module (issue #1668 stage 5d removed the
+    // production `step()` delegation from `step_streaming`).
+    use super::super::MergeStep;
     use crate::schema::{ClusteringColumn, ClusteringOrder, KeyColumn, TableSchema};
     use crate::storage::write_engine::merge::model::{CellData, RowData};
     use crate::storage::write_engine::merge::{RunReader, SSTableRowIterator};
@@ -276,7 +750,29 @@ mod tests {
         )
     }
 
-    fn range_carrier(token: i64, deletion_time: i64, ldt: i32) -> MergeEntry {
+    /// A RAW range-tombstone carrier, as a real reader would construct it
+    /// (`KWayMerger::build_merge_entry`'s `CompactionRowData::RangeMarker`
+    /// branch) — tagged with the run it ACTUALLY came from, `run_index`,
+    /// NOT the `usize::MAX` sentinel `merge_partition_rows`'s OWN
+    /// re-emission logic uses for its SYNTHETIC output entries (issue #1668
+    /// stage 5d finding: a raw carrier's `run_index` field must match its
+    /// real `self.runs` slot, or `KWayMerger::refill_heap` — which indexes
+    /// `self.runs` by the popped entry's OWN `run_index` field — silently
+    /// stops refilling that run after this carrier is popped, exactly as a
+    /// genuine multi-entry run would starve if mis-tagged this way. The
+    /// PRE-stage-5d `step()` masked this with an unrelated bug of its own:
+    /// `current_partition` is never actually assigned, so `step()`'s "lazy
+    /// init" guard (`heap.is_empty() && current_partition.is_none()`) is
+    /// unconditionally true whenever the heap empties, re-triggering
+    /// `initialize_heap()` — which happens to "rescue" a stalled run by
+    /// force-refilling it — on EVERY subsequent `step()` call, silently
+    /// splitting one logical partition into extra `MergeStep::Partition`
+    /// steps that `drain_whole_partition` then concatenates back together.
+    /// `step_streaming` has no such accidental rescue (by design — one
+    /// partition is one cohesive state machine, not repeated fresh
+    /// `step()` calls), so a mis-tagged carrier's absence is no longer
+    /// masked.
+    fn range_carrier(run_index: usize, token: i64, deletion_time: i64, ldt: i32) -> MergeEntry {
         let rt = RangeTombstone {
             start: crate::storage::write_engine::mutation::ClusteringBound::Bottom,
             end: crate::storage::write_engine::mutation::ClusteringBound::Inclusive(ck(1)),
@@ -284,7 +780,7 @@ mod tests {
             local_deletion_time: ldt,
         };
         MergeEntry::new(
-            usize::MAX,
+            run_index,
             key(token),
             None,
             deletion_time,
@@ -293,9 +789,11 @@ mod tests {
         .with_range_deletion(rt)
     }
 
-    fn partition_carrier(token: i64, mfda: i64, ldt: i32) -> MergeEntry {
+    /// A RAW partition-tombstone carrier — see [`range_carrier`]'s doc for
+    /// why `run_index` must be the entry's REAL run, not `usize::MAX`.
+    fn partition_carrier(run_index: usize, token: i64, mfda: i64, ldt: i32) -> MergeEntry {
         MergeEntry::new(
-            usize::MAX,
+            run_index,
             key(token),
             None,
             mfda,
@@ -396,8 +894,25 @@ mod tests {
     /// `merger_over` test helper (not reusable directly here — private to a
     /// sibling module — so reconstructed with the same shape).
     fn merger_over(entries: Vec<MergeEntry>, schema: TableSchema) -> KWayMerger {
+        merger_over_runs(vec![entries], schema)
+    }
+
+    /// Build a `KWayMerger` with ONE run PER `Vec<MergeEntry>` in `runs` —
+    /// for tests that must exercise the heap's REAL cross-run interleaving
+    /// (issue #1668 stage 5d), not just a single run's own (already
+    /// necessarily monotonic) content. Each inner `Vec` must already be in
+    /// its OWN correct on-disk order — real SSTable files are always
+    /// written via the schema-aware sort `write_partition` applies before
+    /// writing (`ClusteringKey::compare`, which DOES reverse `DESC`
+    /// columns), so a genuine `RunReader` for one file never needs
+    /// re-sorting; only the heap's job of picking the next-smallest
+    /// candidate ACROSS runs remains.
+    fn merger_over_runs(runs: Vec<Vec<MergeEntry>>, schema: TableSchema) -> KWayMerger {
         KWayMerger {
-            runs: vec![RunReader::new(Box::new(VecIterator(entries.into_iter())))],
+            runs: runs
+                .into_iter()
+                .map(|entries| RunReader::new(Box::new(VecIterator(entries.into_iter()))))
+                .collect(),
             heap: BinaryHeap::new(),
             current_partition: None,
             gc_before_secs: None,
@@ -521,20 +1036,56 @@ mod tests {
         }
     }
 
-    /// THE proof stage 3 needs: for a fixture mixing plain rows, a row
+    /// Split a drained partition's rows into (carrier entries, clustering
+    /// rows) — `clustering_key.is_none()` marks a carrier (a range- or
+    /// partition-tombstone re-emission), matching `merge_partition_rows`'s
+    /// own `clustered_rows[None]` grouping.
+    fn split_carriers_and_rows(rows: Vec<MergeEntry>) -> (Vec<MergeEntry>, Vec<MergeEntry>) {
+        rows.into_iter()
+            .partition(|entry| entry.clustering_key.is_none())
+    }
+
+    /// A stable sort key for a carrier entry, independent of WHEN it was
+    /// re-emitted — distinguishes a range-tombstone marker from a
+    /// partition-tombstone marker (this fixture has at most one of each),
+    /// so two carrier sets can be compared as sets regardless of order.
+    fn carrier_sort_key(entry: &MergeEntry) -> (bool, i64) {
+        (entry.partition_deletion.is_some(), entry.timestamp)
+    }
+
+    /// THE proof stage 3/5d needs: for a fixture mixing plain rows, a row
     /// tombstone, a range-tombstone carrier (#933), and a partition-deletion
     /// carrier (#1072) — i.e. exercising stage-1's `scan_partition_carriers`
-    /// end to end — the streaming path yields EXACTLY the same reconciled
-    /// rows, in the same order, as the old whole-partition path.
+    /// end to end — the streaming path reconciles the SAME rows, with the
+    /// SAME shadowing outcome, as the old whole-partition path.
+    ///
+    /// Unlike the plain-fixture / DESC / absent-component tests, this test
+    /// does NOT assert byte-identical SEQUENCE order: issue #1668 stage 5d's
+    /// bounded-open-range design (see the module doc) defers a range
+    /// tombstone's own marker re-emission to partition end so the FULL,
+    /// final set can be coalesced exactly once, so a range marker can land
+    /// AFTER the clustering rows it shadows in the streaming path, whereas
+    /// `merge_partition_rows`'s whole-partition buffering always sorts
+    /// EVERY carrier before EVERY clustering row. The two invariants that
+    /// DO still hold — and that this test asserts — are: (a) the clustering
+    /// ROWS appear in the identical order in both paths (grouping/
+    /// reconciliation correctness is unaffected), and (b) the SET of
+    /// carrier entries (their content, not their position) is identical.
     #[test]
     fn step_streaming_matches_step_for_mixed_tombstone_fixture() {
         let schema = test_schema(ClusteringOrder::Asc);
+        // Realistic ordering (issue #1668 stage 5d finding): the partition
+        // tombstone is always part of the on-disk header, so it precedes
+        // every row; the range tombstone [Bottom, ck=1] closes right after
+        // the last row it covers (ck=1), before the row it does NOT cover
+        // (ck=2) — matching how the real reader pairs open/close bounds
+        // (`row_decoder/compaction.rs`'s `on_range_marker`/`on_data_row`).
         let entries = vec![
+            partition_carrier(0, 1, 10, 1),
             live_entry(0, 1, 0, 100),
             live_entry(0, 1, 1, 100),
+            range_carrier(0, 1, 50, 5),
             live_entry(0, 1, 2, 100),
-            range_carrier(1, 50, 5),
-            partition_carrier(1, 10, 1),
         ];
 
         let mut old_merger = merger_over(entries.clone(), schema.clone());
@@ -547,10 +1098,20 @@ mod tests {
             !old_rows.is_empty(),
             "fixture must produce at least one row"
         );
+
+        let (mut old_carriers, old_clustering_rows) = split_carriers_and_rows(old_rows);
+        let (mut new_carriers, new_clustering_rows) = split_carriers_and_rows(new_rows);
         assert_eq!(
-            old_rows, new_rows,
-            "streaming path must yield the SAME rows, in the SAME order, as \
-             the whole-partition path"
+            old_clustering_rows, new_clustering_rows,
+            "streaming path must reconcile the SAME clustering rows, in the \
+             SAME order, as the whole-partition path"
+        );
+        old_carriers.sort_by_key(carrier_sort_key);
+        new_carriers.sort_by_key(carrier_sort_key);
+        assert_eq!(
+            old_carriers, new_carriers,
+            "streaming path must re-emit the SAME carrier markers (content, \
+             not necessarily position) as the whole-partition path"
         );
     }
 
@@ -589,25 +1150,31 @@ mod tests {
         }
     }
 
-    /// Stage 3a correctness test: a `DESC` clustering column. The heap's
-    /// fallback `Ord` would (if consulted directly, uncorrected) pop these in
-    /// ASCENDING order (0, 1, 2) since it never applies `DESC` reversal — the
-    /// Cassandra-correct order is DESCENDING (2, 1, 0). Assert BOTH `step()`
+    /// Stage 3a/5d correctness test: a `DESC` clustering column, across
+    /// GENUINELY SEPARATE runs (issue #1668 stage 5d finding — see
+    /// `merger_over_runs`'s doc: a REAL SSTable file is always written in
+    /// schema-consistent order via `write_partition`'s own sort, so a
+    /// single run's entries never need reordering; the property THIS test
+    /// exercises is the HEAP correctly choosing, across MULTIPLE runs
+    /// (`ck=2`'s run, `ck=1`'s run, `ck=0`'s run — each independently
+    /// correctly "sorted" since it holds a single entry), the Cassandra-
+    /// correct DESCENDING order (2, 1, 0), which the FALLBACK
+    /// (non-schema-aware) `Ord` would get backwards. Assert BOTH `step()`
     /// and `step_streaming()` emit the CORRECT descending order — an
     /// independent check against the expected sequence, not just
-    /// old-path-equals-new-path (which would pass even if both were equally
-    /// wrong).
+    /// old-path-equals-new-path (which would pass even if both were
+    /// equally wrong).
     #[test]
     fn step_streaming_matches_step_for_desc_clustering_fixture() {
         let schema = test_schema(ClusteringOrder::Desc);
-        let entries = vec![
-            live_entry(0, 1, 0, 100),
-            live_entry(0, 1, 1, 100),
-            live_entry(0, 1, 2, 100),
+        let runs = vec![
+            vec![live_entry(0, 1, 2, 100)],
+            vec![live_entry(1, 1, 1, 100)],
+            vec![live_entry(2, 1, 0, 100)],
         ];
         let expected_order = [2, 1, 0];
 
-        let mut old_merger = merger_over(entries.clone(), schema.clone());
+        let mut old_merger = merger_over_runs(runs.clone(), schema.clone());
         let old_rows = drain_whole_partition(&mut old_merger);
         let old_order: Vec<i32> = old_rows.iter().map(ck_value).collect();
         assert_eq!(
@@ -615,7 +1182,7 @@ mod tests {
             "step() must emit DESC clustering order"
         );
 
-        let mut new_merger = merger_over(entries, schema);
+        let mut new_merger = merger_over_runs(runs, schema);
         let new_rows = drain_streaming(&mut new_merger);
         let new_order: Vec<i32> = new_rows.iter().map(ck_value).collect();
         assert_eq!(
@@ -624,19 +1191,20 @@ mod tests {
         );
     }
 
-    /// Stage 3a correctness test: absent trailing clustering component
-    /// (Cassandra NULL-first rule) combined with a `DESC` second column.
-    /// Schema-aware order: the absent-`ck2` row sorts FIRST (NULL always
-    /// sorts first, regardless of `ck2`'s `DESC`-ness), then among the two
-    /// present-`ck2` rows the LARGER value sorts first (`DESC` reversal).
-    /// Expected sequence: `[absent, ck2=2, ck2=1]`.
+    /// Stage 3a/5d correctness test: absent trailing clustering component
+    /// (Cassandra NULL-first rule) combined with a `DESC` second column,
+    /// across GENUINELY SEPARATE runs (see the DESC test's doc for why —
+    /// same finding). Schema-aware order: the absent-`ck2` row sorts FIRST
+    /// (NULL always sorts first, regardless of `ck2`'s `DESC`-ness), then
+    /// among the two present-`ck2` rows the LARGER value sorts first
+    /// (`DESC` reversal). Expected sequence: `[absent, ck2=2, ck2=1]`.
     #[test]
     fn step_streaming_matches_step_for_absent_trailing_component_fixture() {
         let schema = two_col_schema();
-        let entries = vec![
-            live_entry_ck(0, 1, ck_multi(&[("ck1", 5), ("ck2", 1)]), 100),
-            live_entry_ck(0, 1, ck_multi(&[("ck1", 5)]), 100), // absent ck2
-            live_entry_ck(0, 1, ck_multi(&[("ck1", 5), ("ck2", 2)]), 100),
+        let runs = vec![
+            vec![live_entry_ck(0, 1, ck_multi(&[("ck1", 5), ("ck2", 1)]), 100)],
+            vec![live_entry_ck(1, 1, ck_multi(&[("ck1", 5)]), 100)], // absent ck2
+            vec![live_entry_ck(2, 1, ck_multi(&[("ck1", 5), ("ck2", 2)]), 100)],
         ];
 
         // Independent expectation: identify each row by its ck2 presence/value.
@@ -653,7 +1221,7 @@ mod tests {
         }
         let expected_order = [None, Some(2), Some(1)];
 
-        let mut old_merger = merger_over(entries.clone(), schema.clone());
+        let mut old_merger = merger_over_runs(runs.clone(), schema.clone());
         let old_rows = drain_whole_partition(&mut old_merger);
         let old_order: Vec<Option<i32>> = old_rows.iter().map(ck2_marker).collect();
         assert_eq!(
@@ -661,7 +1229,7 @@ mod tests {
             "step() must put the absent-ck2 row first (NULL-first), then DESC by ck2"
         );
 
-        let mut new_merger = merger_over(entries, schema);
+        let mut new_merger = merger_over_runs(runs, schema);
         let new_rows = drain_streaming(&mut new_merger);
         let new_order: Vec<Option<i32>> = new_rows.iter().map(ck2_marker).collect();
         assert_eq!(
@@ -673,16 +1241,28 @@ mod tests {
     /// A range-tombstone carrier round-trips through the streaming path as a
     /// `ClusterGroup` with `clustering_key: None`, exactly as it would sit in
     /// `MergeStep::Partition.rows` (proving stage-1's carriers thread through
-    /// the increment API unchanged).
+    /// the increment API unchanged). The re-emitted entry matches the raw
+    /// input carrier in every field EXCEPT `run_index`: both the old
+    /// (`merge_partition_rows`) and new (`flush_range_tombstones`) paths
+    /// always reconstruct the re-emitted marker with `run_index: usize::MAX`
+    /// (it's a synthetic entry, not read from any particular run) —
+    /// `range_carrier`'s OWN `run_index` (its REAL run, since #1668 stage 5d
+    /// fixed this fixture to match `build_merge_entry`'s convention) is
+    /// deliberately different, so a literal round-trip was never the real
+    /// contract.
     #[test]
     fn range_tombstone_carrier_round_trips_as_cluster_group() {
-        let carrier = range_carrier(9, 500, 50);
+        let carrier = range_carrier(0, 9, 500, 50);
         assert!(super::super::carriers::is_range_marker_carrier(&carrier));
+        let expected = MergeEntry {
+            run_index: usize::MAX,
+            ..carrier.clone()
+        };
 
-        let mut merger = merger_over(vec![carrier.clone()], test_schema(ClusteringOrder::Asc));
+        let mut merger = merger_over(vec![carrier], test_schema(ClusteringOrder::Asc));
         let mut stream = StreamingMerger::new(&mut merger);
         match stream.step_streaming().unwrap() {
-            StreamingStep::ClusterGroup { row, .. } => assert_eq!(*row, carrier),
+            StreamingStep::ClusterGroup { row, .. } => assert_eq!(*row, expected),
             other => panic!("expected ClusterGroup, got {other:?}"),
         }
     }

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -31,25 +31,51 @@
 //! against the heap (not assumed) by the `heap_groups_contiguously_by_ord`
 //! test below.
 //!
-//! **Residual finding (documented, NOT fixed in this stage):** `ClusteringKey`'s
-//! fallback `Ord` (`mutation.rs`) is NOT schema-aware — it does not apply
-//! `DESC` clustering-column reversal, and treats an absent trailing component
-//! by zip-stopping rather than Cassandra's NULL-first rule (contrast
-//! `ClusteringKey::compare`, which IS schema-aware and DOES apply both). So
-//! while GROUPING (same-key contiguity, proven above) is safe to stream on,
-//! the ORDER in which DISTINCT clustering-key groups are emitted from the
-//! heap can diverge from the schema's true collation for `DESC` clustering
-//! columns or absent trailing components. Today's whole-partition path masks
-//! this with an explicit `merged.sort_by(schema-aware compare)` AFTER
-//! collecting every cluster in a partition (`merge_partition_rows`). A future
-//! stage that wires a true (non-buffering) streaming second pass to a real
-//! writer must either (a) make the heap comparator schema-aware, or (b)
-//! re-sort the emitted group sequence before/while writing. `step_streaming`
-//! below does not need to solve this: it drains an ALREADY schema-sorted
-//! `Vec<MergeEntry>` (the same one `step()` returns), so its own output order
-//! is byte-identical to `step()`'s regardless of this residual — but the
-//! residual applies to any FUTURE streaming pass that walks the heap directly
-//! without that final sort (stage 3+ design point, not resolved here).
+//! ## Cross-group emission order — resolved for THIS design (issue #1668, stage 3a)
+//!
+//! Stage 2 flagged a residual: `ClusteringKey`'s fallback `Ord`
+//! (`mutation.rs`) is NOT schema-aware — no `DESC` reversal, and an absent
+//! trailing component is handled by zip-stopping + a length tiebreak rather
+//! than Cassandra's explicit NULL-first rule (contrast the schema-aware
+//! `ClusteringKey::compare`). Stage 3a's blast-radius audit + new tests below
+//! resolve whether this is safe to wire a real consumer onto:
+//!
+//! **Blast radius**: `MergeEntry::Ord`/`PartialOrd` (the fallback comparator)
+//! has exactly ONE production consumer in the whole crate — `KWayMerger`'s
+//! `heap: BinaryHeap<Reverse<MergeEntry>>` (routing only, in `mod.rs`). No
+//! other file constructs a `BinaryHeap<Reverse<MergeEntry>>` or otherwise
+//! depends on `MergeEntry::Ord`'s specific clustering semantics; the one
+//! direct-heap unit test (`mod.rs::test_merge_entry_min_heap`) only exercises
+//! token ordering (`clustering_key: None` throughout), so it is untouched by
+//! clustering-comparator semantics either way. Changing `MergeEntry::Ord`
+//! globally would therefore be LOW risk in isolation — but it is UNNECESSARY:
+//!
+//! **Why no Ord change is needed for THIS design**: `step_streaming` (below)
+//! never consumes heap-pop order for cross-group sequencing. It drains the
+//! `Vec<MergeEntry>` `KWayMerger::step()` already returns, and `step()`
+//! (via `merge_partition_rows`) already applies an explicit
+//! `merged.sort_by(|a, b| ck_a.compare(ck_b, &self.schema) ...)` — the
+//! SCHEMA-AWARE comparator — as its LAST step, unconditionally, regardless of
+//! what order the heap or the `clustered_rows: BTreeMap` (also fallback-Ord-
+//! keyed) produced internally. So `step()`'s returned order is ALREADY
+//! schema-correct today, and `step_streaming` inherits that correctness
+//! unchanged. `step_streaming_matches_step_for_desc_clustering_fixture` and
+//! `step_streaming_matches_step_for_absent_trailing_component_fixture` below
+//! prove this directly: both assert the emitted clustering-key SEQUENCE
+//! (independently, not just old-path-equals-new-path) against the
+//! Cassandra-correct expected order for a `DESC` column and for an
+//! absent-trailing-component (NULL-first) case — neither the fallback Ord's
+//! ordering, proving the divergence does NOT leak through this design.
+//!
+//! **Residual still applies to a DIFFERENT, NOT-YET-BUILT design**: a FUTURE
+//! stage-5 rewrite that removes `merge_partition_rows`'s whole-partition
+//! buffer-then-sort and instead emits groups directly off the heap (true
+//! streaming, no per-partition buffer) would lose that final sort and must
+//! independently solve cross-group ordering then — either by making the heap
+//! comparator schema-aware (cheap: one production call site, per the blast-
+//! radius finding above) or by a small local re-sort at group boundaries.
+//! Flagged for that stage's design, not resolved here, because it does not
+//! yet exist.
 //!
 //! `step_streaming` does NOT yet avoid whole-partition buffering: it calls
 //! the unchanged [`KWayMerger::step`] (which still buffers a whole partition
@@ -256,6 +282,61 @@ mod tests {
         }
     }
 
+    /// A two-clustering-column schema (`ck1` ASC, `ck2` DESC) for the
+    /// absent-trailing-component (NULL-first) test (issue #1668, stage 3a).
+    fn two_col_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "ks_1668".to_string(),
+            table: "t_1668_multi".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![
+                ClusteringColumn {
+                    name: "ck1".to_string(),
+                    data_type: "int".to_string(),
+                    position: 0,
+                    order: ClusteringOrder::Asc,
+                },
+                ClusteringColumn {
+                    name: "ck2".to_string(),
+                    data_type: "int".to_string(),
+                    position: 1,
+                    order: ClusteringOrder::Desc,
+                },
+            ],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// Build a `ClusteringKey` from `(column, value)` pairs — may carry FEWER
+    /// components than the schema declares, modeling an absent trailing
+    /// component.
+    fn ck_multi(pairs: &[(&str, i32)]) -> ClusteringKey {
+        ClusteringKey::new(
+            pairs
+                .iter()
+                .map(|(n, v)| (n.to_string(), Value::Integer(*v)))
+                .collect(),
+        )
+    }
+
+    fn live_entry_ck(run_index: usize, token: i64, ck: ClusteringKey, ts: i64) -> MergeEntry {
+        MergeEntry::new(
+            run_index,
+            key(token),
+            Some(ck),
+            ts,
+            RowData::Live {
+                cells: vec![CellData::new("c".to_string(), Value::Integer(1), ts)],
+            },
+        )
+    }
+
     /// Test-only `SSTableRowIterator` over a pre-supplied `Vec<MergeEntry>`,
     /// mirroring the `VecIterator` pattern already used by `mod.rs`'s own
     /// merge unit tests (kept local here so `streaming.rs`'s tests need no
@@ -448,6 +529,100 @@ mod tests {
         let new_rows = drain_streaming(&mut new_merger);
 
         assert_eq!(old_rows, new_rows);
+    }
+
+    /// Extract the single-column `ck` value from a `MergeEntry` produced by
+    /// `live_entry`, for order-assertion readability.
+    fn ck_value(entry: &MergeEntry) -> i32 {
+        match entry
+            .clustering_key
+            .as_ref()
+            .and_then(|k| k.columns.first())
+        {
+            Some((_, Value::Integer(v))) => *v,
+            other => panic!("expected a single Integer clustering column, got {other:?}"),
+        }
+    }
+
+    /// Stage 3a correctness test: a `DESC` clustering column. The heap's
+    /// fallback `Ord` would (if consulted directly, uncorrected) pop these in
+    /// ASCENDING order (0, 1, 2) since it never applies `DESC` reversal — the
+    /// Cassandra-correct order is DESCENDING (2, 1, 0). Assert BOTH `step()`
+    /// and `step_streaming()` emit the CORRECT descending order — an
+    /// independent check against the expected sequence, not just
+    /// old-path-equals-new-path (which would pass even if both were equally
+    /// wrong).
+    #[test]
+    fn step_streaming_matches_step_for_desc_clustering_fixture() {
+        let schema = test_schema(ClusteringOrder::Desc);
+        let entries = vec![
+            live_entry(0, 1, 0, 100),
+            live_entry(0, 1, 1, 100),
+            live_entry(0, 1, 2, 100),
+        ];
+        let expected_order = [2, 1, 0];
+
+        let mut old_merger = merger_over(entries.clone(), schema.clone());
+        let old_rows = drain_whole_partition(&mut old_merger);
+        let old_order: Vec<i32> = old_rows.iter().map(ck_value).collect();
+        assert_eq!(
+            old_order, expected_order,
+            "step() must emit DESC clustering order"
+        );
+
+        let mut new_merger = merger_over(entries, schema);
+        let new_rows = drain_streaming(&mut new_merger);
+        let new_order: Vec<i32> = new_rows.iter().map(ck_value).collect();
+        assert_eq!(
+            new_order, expected_order,
+            "step_streaming() must ALSO emit DESC clustering order, matching step()"
+        );
+    }
+
+    /// Stage 3a correctness test: absent trailing clustering component
+    /// (Cassandra NULL-first rule) combined with a `DESC` second column.
+    /// Schema-aware order: the absent-`ck2` row sorts FIRST (NULL always
+    /// sorts first, regardless of `ck2`'s `DESC`-ness), then among the two
+    /// present-`ck2` rows the LARGER value sorts first (`DESC` reversal).
+    /// Expected sequence: `[absent, ck2=2, ck2=1]`.
+    #[test]
+    fn step_streaming_matches_step_for_absent_trailing_component_fixture() {
+        let schema = two_col_schema();
+        let entries = vec![
+            live_entry_ck(0, 1, ck_multi(&[("ck1", 5), ("ck2", 1)]), 100),
+            live_entry_ck(0, 1, ck_multi(&[("ck1", 5)]), 100), // absent ck2
+            live_entry_ck(0, 1, ck_multi(&[("ck1", 5), ("ck2", 2)]), 100),
+        ];
+
+        // Independent expectation: identify each row by its ck2 presence/value.
+        fn ck2_marker(entry: &MergeEntry) -> Option<i32> {
+            entry.clustering_key.as_ref().and_then(|k| {
+                k.columns
+                    .iter()
+                    .find(|(name, _)| name == "ck2")
+                    .map(|(_, v)| match v {
+                        Value::Integer(v) => *v,
+                        other => panic!("expected Integer ck2, got {other:?}"),
+                    })
+            })
+        }
+        let expected_order = [None, Some(2), Some(1)];
+
+        let mut old_merger = merger_over(entries.clone(), schema.clone());
+        let old_rows = drain_whole_partition(&mut old_merger);
+        let old_order: Vec<Option<i32>> = old_rows.iter().map(ck2_marker).collect();
+        assert_eq!(
+            old_order, expected_order,
+            "step() must put the absent-ck2 row first (NULL-first), then DESC by ck2"
+        );
+
+        let mut new_merger = merger_over(entries, schema);
+        let new_rows = drain_streaming(&mut new_merger);
+        let new_order: Vec<Option<i32>> = new_rows.iter().map(ck2_marker).collect();
+        assert_eq!(
+            new_order, expected_order,
+            "step_streaming() must ALSO put the absent-ck2 row first, then DESC by ck2"
+        );
     }
 
     /// A range-tombstone carrier round-trips through the streaming path as a

--- a/cqlite-core/src/storage/write_engine/merge/streaming/streaming_dhat_test.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming/streaming_dhat_test.rs
@@ -1,0 +1,236 @@
+//! Memory-bound regression test for issue #1668 (within-partition streaming
+//! merge) — proves the MERGE LAYER'S OWN peak-heap bound, isolated from the
+//! SSTable reader.
+//!
+//! **Why isolated from the reader**: an earlier version of this proof drove
+//! the real production path end to end (`WriteEngine::maintenance_step`
+//! reading real, uncompressed `Data.db` files) and measured 424 MiB against
+//! the 128 MiB budget. Root-causing that showed the overshoot was NOT this
+//! merge layer: `stream_all_partitions_for_compaction`
+//! (`storage/sstable/reader/data_access/compaction.rs`) only takes its
+//! sliding-window streaming path when `requires_chunk_stitching()` is true —
+//! true ONLY for the legacy `V5CompressedLegacy` chunked-compression format.
+//! `V5_0Uncompressed` — the ONLY format CQLite's own production write surface
+//! ever emits (issue #1406's claim boundary: uncompressed SSTables only) —
+//! falls back to `iterate_all_partitions_for_compaction`, which fully
+//! materializes the decompressed data section before parsing anything. That
+//! reader-side gap is tracked as its own follow-up issue; it is orthogonal to
+//! (and pre-dates) this merge-layer's own reconciliation logic.
+//!
+//! This test therefore bypasses the reader entirely: a hand-written
+//! [`LazyWideRun`] implements [`SSTableRowIterator`] by generating each row's
+//! payload ON DEMAND inside `next()` — nothing is pre-built into a `Vec`, so
+//! there is no way for this fixture ITSELF to hide a whole-partition buffer.
+//! Because [`StreamingMerger`]/`KWayMerger` are `pub(crate)` (not part of the
+//! public API — the whole point of issue #1668's merge-layer scope), this
+//! must be an in-tree `#[cfg(test)]` module (a `tests/` integration test
+//! cannot reach them at all); see `lib.rs`'s `DHAT_TEST_ALLOC` for why the
+//! dhat global allocator is installed there instead of in this file.
+//!
+//! Run via (excludes `state_machine`, which claims the SAME global-allocator
+//! slot for its own allocation-counting probe):
+//!
+//! ```text
+//! cargo test --package cqlite-core --no-default-features \
+//!   --features write-support,dhat-heap --lib --profile bench \
+//!   -- storage::write_engine::merge::streaming::streaming_dhat_test --nocapture
+//! ```
+
+use super::super::model::CellData;
+use super::super::{KWayMerger, RunReader, SSTableRowIterator};
+use super::*;
+use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use crate::types::Value;
+use std::collections::{BinaryHeap, HashMap};
+
+const HEAP_BUDGET_BYTES: usize = 128 * 1024 * 1024;
+
+// Workload sizing: ONE partition, split across RUN_COUNT runs by disjoint
+// clustering-key ranges (so the k-way merge heap genuinely interleaves
+// several runs into a single wide output partition — not a trivial
+// single-run pass-through), ROWS_PER_RUN rows each, PAYLOAD_BYTES payload
+// per row. 4 runs x 5,000 rows x 64 KiB = ~1.22 GiB of combined row content
+// in ONE partition if it were ever fully resident at once — an order of
+// magnitude past the 128 MiB budget, so staying under budget is a genuine
+// proof, not a vacuous pass on a fixture too small to matter.
+const PAYLOAD_BYTES: usize = 64 * 1024;
+const ROWS_PER_RUN: i32 = 5_000;
+const RUN_COUNT: i32 = 4;
+
+fn payload_for(ck: i32) -> String {
+    let mut s = format!("row-{ck:08}-");
+    s.push_str(&"abcdefghij".repeat((PAYLOAD_BYTES.saturating_sub(s.len())) / 10 + 1));
+    s.truncate(PAYLOAD_BYTES);
+    s
+}
+
+fn wide_partition_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "issue1668_mem_ks".to_string(),
+        table: "wide_partition".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Lazily generates ONE run's slice of a wide partition's rows, ON DEMAND —
+/// `next()` builds exactly one row's payload per call and returns
+/// immediately; nothing is ever materialized ahead of time into a `Vec` (the
+/// property this test needs to rule itself out as the source of any
+/// buffering it might observe).
+struct LazyWideRun {
+    run_index: usize,
+    key: DecoratedKey,
+    next_ck: i32,
+    end_ck_exclusive: i32,
+}
+
+impl SSTableRowIterator for LazyWideRun {
+    fn next(&mut self) -> Option<Result<MergeEntry>> {
+        if self.next_ck >= self.end_ck_exclusive {
+            return None;
+        }
+        let ck = self.next_ck;
+        self.next_ck += 1;
+        let ts = 1_000_000_000 + i64::from(ck);
+        Some(Ok(MergeEntry::new(
+            self.run_index,
+            self.key.clone(),
+            Some(ClusteringKey::single("ck", Value::Integer(ck))),
+            ts,
+            RowData::Live {
+                cells: vec![CellData::new(
+                    "payload".to_string(),
+                    Value::Text(payload_for(ck)),
+                    ts,
+                )],
+            },
+        )))
+    }
+}
+
+/// Build a `KWayMerger` over `RUN_COUNT` [`LazyWideRun`]s, each covering a
+/// disjoint `[base, base + ROWS_PER_RUN)` clustering-key range of the SAME
+/// partition (`id = 1`) — mirroring `streaming.rs`'s own `merger_over_runs`
+/// test helper (not reused directly: that one takes pre-built
+/// `Vec<MergeEntry>` runs, defeating the whole point of a LAZY source here).
+fn lazy_merger_over_wide_partition(schema: TableSchema) -> KWayMerger {
+    let key = DecoratedKey::new(1, vec![1]);
+    let runs: Vec<RunReader> = (0..RUN_COUNT)
+        .map(|run_index| {
+            let base = run_index * ROWS_PER_RUN;
+            RunReader::new(Box::new(LazyWideRun {
+                run_index: run_index as usize,
+                key: key.clone(),
+                next_ck: base,
+                end_ck_exclusive: base + ROWS_PER_RUN,
+            }))
+        })
+        .collect();
+    KWayMerger {
+        runs,
+        heap: BinaryHeap::new(),
+        current_partition: None,
+        gc_before_secs: None,
+        now_secs: None,
+        purge_safe: false,
+        max_purgeable_timestamp: None,
+        schema_arc: std::sync::Arc::new(schema.clone()),
+        schema,
+    }
+}
+
+#[test]
+fn streaming_merge_of_lazy_wide_partition_stays_within_heap_budget() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let schema = wide_partition_schema();
+    let mut merger = lazy_merger_over_wide_partition(schema);
+    let mut stream = StreamingMerger::new(&mut merger);
+
+    // Drain every increment, dropping each reconciled row IMMEDIATELY after
+    // observing it — an in-tree streaming consumer never accumulates output
+    // either, so peak heap here measures ONLY what `StreamingMerger` itself
+    // holds mid-reconciliation, not an accumulating drain buffer.
+    let mut rows_seen: u64 = 0;
+    let mut partitions_seen: u64 = 0;
+    loop {
+        match stream.step_streaming().expect("step_streaming must not error") {
+            StreamingStep::ClusterGroup { row, .. } => {
+                assert!(
+                    row.clustering_key.is_some(),
+                    "no carriers in this fixture — every row is a real clustering row"
+                );
+                rows_seen += 1;
+                drop(row);
+            }
+            StreamingStep::PartitionEnd { .. } => partitions_seen += 1,
+            StreamingStep::Complete => break,
+        }
+    }
+
+    let stats = dhat::HeapStats::get();
+    eprintln!(
+        "Issue #1668 merge-layer-only streaming: {RUN_COUNT} runs x {ROWS_PER_RUN} rows x \
+         {} KiB payload, ONE partition, peak heap {} bytes ({:.2} MiB) vs budget {} MiB",
+        PAYLOAD_BYTES / 1024,
+        stats.max_bytes,
+        stats.max_bytes as f64 / (1024.0 * 1024.0),
+        HEAP_BUDGET_BYTES / (1024 * 1024),
+    );
+
+    // Not a vacuous pass: every row from every run was reconciled into the
+    // SAME single partition (correctness), and the total logical payload
+    // volume (~1.22 GiB) is an order of magnitude over budget — so staying
+    // under budget is a real property of the streaming path, not an
+    // accident of a too-small fixture.
+    assert_eq!(partitions_seen, 1, "all runs share ONE partition key");
+    assert_eq!(
+        rows_seen,
+        (ROWS_PER_RUN as u64) * (RUN_COUNT as u64),
+        "every row across every run must be reconciled exactly once"
+    );
+
+    assert!(
+        stats.max_bytes <= HEAP_BUDGET_BYTES,
+        "Issue #1668: merge-layer-only streaming peak heap {} bytes ({:.2} MiB) exceeds the \
+         {} MiB budget — the merge regressed to whole-partition buffering",
+        stats.max_bytes,
+        stats.max_bytes as f64 / (1024.0 * 1024.0),
+        HEAP_BUDGET_BYTES / (1024 * 1024),
+    );
+}

--- a/cqlite-core/src/storage/write_engine/merge/streaming/streaming_dhat_test.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming/streaming_dhat_test.rs
@@ -189,7 +189,10 @@ fn streaming_merge_of_lazy_wide_partition_stays_within_heap_budget() {
     let mut rows_seen: u64 = 0;
     let mut partitions_seen: u64 = 0;
     loop {
-        match stream.step_streaming().expect("step_streaming must not error") {
+        match stream
+            .step_streaming()
+            .expect("step_streaming must not error")
+        {
             StreamingStep::ClusterGroup { row, .. } => {
                 assert!(
                     row.clustering_key.is_some(),

--- a/cqlite-core/tests/issue_1668_maintenance_rt_boundary.rs
+++ b/cqlite-core/tests/issue_1668_maintenance_rt_boundary.rs
@@ -1,10 +1,11 @@
 //! Issue #1383 / #1668 regression: BACKGROUND auto-compaction (via the public
 //! [`WriteEngine::maintenance_step`] surface) must SYNTHESIZE — never drop —
 //! the range-tombstone boundary when two flush generations carry ranges that
-//! OVERLAP across a clustering point.
+//! OVERLAP across a clustering point, INCLUDING when a budget pause lands
+//! mid-buffering.
 //!
 //! `issue_1383_rt_boundary_synthesis` pins this for the direct
-//! `compact_sstables`/`KWayMerger::merge` path. This test drives the SAME
+//! `compact_sstables`/`KWayMerger::merge` path. This file drives the SAME
 //! property through the streaming background-compaction state machine
 //! (`maintenance.rs`'s `PartitionStreamState`), which had the IDENTICAL
 //! late-marker-drop hazard before issue #1668's buffering fix: it opened the
@@ -18,10 +19,18 @@
 //! @ts=20 and gen-2 (older) holds `[Bottom, excl(5)]` @ts=10, so the OLDER
 //! range's coalesced marker is only surfaced by the merge stream AFTER the
 //! rows it covers have already streamed.
+//!
+//! Two tests:
+//!   1. unpaused single-drain correctness (the boundary + shadowing survive);
+//!   2. a near-zero first-call budget that forces a pause to land WHILE the
+//!      range-tombstone-bearing partition is still being BUFFERED (before the
+//!      PartitionEnd write session opens) — the highest-risk path for the
+//!      buffering struct's stash/resume — must produce byte-identical output
+//!      to the unpaused drain (and the same correct boundary + survivals).
 
 #![cfg(feature = "write-support")]
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::time::Duration;
 
 use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
@@ -145,6 +154,8 @@ fn bound_ck(b: &ClusteringBound) -> Option<i32> {
 }
 
 /// A decoded range marker as it surfaces through the compaction read path.
+/// `Eq` so two runs' marker sequences can be compared directly.
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct Marker {
     start: ClusteringBound,
     end: ClusteringBound,
@@ -152,10 +163,50 @@ struct Marker {
     local_deletion_time: i32,
 }
 
-/// Read the compacted output back through the merge read path, collecting the
-/// surviving range markers (in clustering order) and live-row clustering keys.
-fn read_back(output: PathBuf, schema: &TableSchema) -> (Vec<Marker>, Vec<i32>) {
-    let mut merger = KWayMerger::new(vec![output], schema).expect("KWayMerger::new");
+/// One compacted output, as needed to compare/assert: its raw Data.db bytes
+/// (for the paused-vs-unpaused byte-identity check) plus the surviving range
+/// markers and live-row clustering keys decoded through the merge read path.
+struct Compacted {
+    bytes: Vec<u8>,
+    markers: Vec<Marker>,
+    live_rows: Vec<i32>,
+}
+
+/// Write the WORST-CASE RT-overlap-across-generations fixture into `engine`:
+/// gen-1 (newer) holds `[incl(3), Top]` @ts=20; gen-2 (older) holds
+/// `[Bottom, excl(5)]` @ts=10 — coalescing to the boundary `[Bottom, excl(3))`
+/// @ts=10 then `[incl(3), Top]` @ts=20. Seven surviving rows (ck 0,1,2 from the
+/// ts=10 side; ck 5,6,7,8 from the ts=20 side) give enough cluster groups that
+/// a near-zero budget reliably pauses mid-buffering; ck 3,4 (@ts=15) are
+/// shadowed by the ts=20 side.
+fn write_fixture(engine: &mut WriteEngine, rt: &tokio::runtime::Runtime) {
+    // gen-1 (newer): the ts=20 range + rows that postdate it (survive) and two
+    // that predate it (shadowed).
+    engine
+        .write(range_delete(incl(3), ClusteringBound::Top, 20))
+        .unwrap();
+    for ck in [5, 6, 7, 8] {
+        engine.write(write_row(ck, 25)).unwrap();
+    }
+    for ck in [3, 4] {
+        engine.write(write_row(ck, 15)).unwrap();
+    }
+    rt.block_on(engine.flush()).unwrap().unwrap();
+
+    // gen-2 (older): the ts=10 range + rows below the boundary that postdate it.
+    engine
+        .write(range_delete(ClusteringBound::Bottom, excl(5), 10))
+        .unwrap();
+    for ck in [0, 1, 2] {
+        engine.write(write_row(ck, 15)).unwrap();
+    }
+    rt.block_on(engine.flush()).unwrap().unwrap();
+}
+
+/// Read a compacted output Data.db back through the merge read path.
+fn read_output(path: &Path, schema: &TableSchema) -> Compacted {
+    let bytes = std::fs::read(path).expect("read compacted Data.db");
+    let mut merger = KWayMerger::new(vec![path.to_path_buf()], schema).expect("KWayMerger::new");
     let mut markers = Vec::new();
     let mut live_rows = Vec::new();
     loop {
@@ -185,15 +236,54 @@ fn read_back(output: PathBuf, schema: &TableSchema) -> (Vec<Marker>, Vec<i32>) {
         }
     }
     live_rows.sort_unstable();
-    (markers, live_rows)
+    Compacted {
+        bytes,
+        markers,
+        live_rows,
+    }
 }
 
-/// Compact two overlapping-range-tombstone generations via the public
-/// background-compaction surface (`maintenance_step`) and assert the
-/// synthesized boundary at ck=3 survives — both boundary halves AND the
-/// correct row survivals.
-#[test]
-fn maintenance_step_synthesizes_range_tombstone_boundary_across_generations() {
+/// Assert the synthesized boundary at ck=3 is present and correct:
+/// `[Bottom, Exclusive(3)) @ts=10` CLOSE then `[Inclusive(3), Top] @ts=20` OPEN,
+/// each carrying its OWN distinct localDeletionTime.
+fn assert_boundary(markers: &[Marker]) {
+    assert_eq!(
+        markers.len(),
+        2,
+        "background compaction must synthesize BOTH boundary halves (not drop them), got {markers:#?}"
+    );
+    assert!(matches!(markers[0].start, ClusteringBound::Bottom));
+    assert!(
+        matches!(&markers[0].end, ClusteringBound::Exclusive(_))
+            && bound_ck(&markers[0].end) == Some(3)
+    );
+    assert_eq!(markers[0].deletion_time, 10);
+    assert_eq!(markers[0].local_deletion_time, ldt_for(10));
+    assert!(
+        matches!(&markers[1].start, ClusteringBound::Inclusive(_))
+            && bound_ck(&markers[1].start) == Some(3)
+    );
+    assert!(matches!(markers[1].end, ClusteringBound::Top));
+    assert_eq!(markers[1].deletion_time, 20);
+    assert_eq!(markers[1].local_deletion_time, ldt_for(20));
+}
+
+// The 7 surviving clustering keys: ck 0,1,2 postdate the ts=10 side; ck 5,6,7,8
+// postdate the ts=20 side. ck 3,4 are shadowed by the ts=20 side.
+const EXPECTED_LIVE_ROWS: [i32; 7] = [0, 1, 2, 5, 6, 7, 8];
+
+/// Build a fresh engine over the fixture and compact it via `maintenance_step`,
+/// using `first_budget` for the FIRST call and a generous budget for every
+/// subsequent call. Returns the compacted output decoded for assertions plus
+/// the number of `maintenance_step` calls the drain took.
+///
+/// The fixture is a SINGLE partition, and the streaming writer session opens
+/// only at `PartitionEnd`, so the output Data.db is finalized only on the
+/// final call — meaning any call count `> 1` proves the partition's drain
+/// PAUSED and RESUMED while still buffering that partition (nothing had been
+/// written yet), exercising `PartitionStreamState`'s stash/resume of the
+/// buffered rows + partial carrier/range-tombstone accumulation.
+fn compact_fixture(first_budget: Duration) -> (Compacted, u32) {
     let schema = schema();
     let temp = TempDir::new().unwrap();
     let config = WriteEngineConfig::new(
@@ -207,29 +297,17 @@ fn maintenance_step_synthesizes_range_tombstone_boundary_across_generations() {
         .build()
         .unwrap();
 
-    // gen-1 (newer): [incl(3), Top] @ts=20 + rows ck=2 (ts=15, survives — only
-    // the ts=10 side covers ck<3, and 15>10) and ck=6 (ts=25, survives — in the
-    // ts=20 side but 25>20).
-    engine
-        .write(range_delete(incl(3), ClusteringBound::Top, 20))
-        .unwrap();
-    engine.write(write_row(2, 15)).unwrap();
-    engine.write(write_row(6, 25)).unwrap();
-    rt.block_on(engine.flush()).unwrap().unwrap();
-    // gen-2 (older): [Bottom, excl(5)] @ts=10 + row ck=4 (ts=15, shadowed by
-    // the ts=20 side, 15<=20 → absent).
-    engine
-        .write(range_delete(ClusteringBound::Bottom, excl(5), 10))
-        .unwrap();
-    engine.write(write_row(4, 15)).unwrap();
-    rt.block_on(engine.flush()).unwrap().unwrap();
+    write_fixture(&mut engine, &rt);
 
     // min_sstable_size large enough that both tiny files bucket together into
     // one full (purge-safe) compaction.
     let policy = STCSPolicy::new(2, 32, 0.5, 1.5, 1024 * 1024).unwrap();
     engine.set_merge_policy(Box::new(policy)).unwrap();
 
-    let mut report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+    let mut report = engine.maintenance_step(first_budget).unwrap();
+    // Until the drain completes, nothing is finalized (single partition, write
+    // deferred to PartitionEnd) — so an incomplete first call is a genuine
+    // mid-buffering pause.
     let mut outputs = report.completed_merges.clone();
     let mut calls = 1u32;
     while report.pending_compaction {
@@ -243,62 +321,70 @@ fn maintenance_step_synthesizes_range_tombstone_boundary_across_generations() {
         1,
         "expected exactly one compacted output Data.db, got {outputs:?}"
     );
+    (read_output(&outputs[0], &schema), calls)
+}
 
-    let (markers, live_rows) = read_back(outputs.into_iter().next().unwrap(), &schema);
+/// Unpaused single-drain: the synthesized boundary and the correct row
+/// survivals must appear in the compacted output.
+#[test]
+fn maintenance_step_synthesizes_range_tombstone_boundary_across_generations() {
+    let (out, calls) = compact_fixture(Duration::from_secs(60));
+    assert_eq!(calls, 1, "generous budget should drain in a single call");
+    assert_eq!(
+        out.live_rows,
+        EXPECTED_LIVE_ROWS.to_vec(),
+        "ck 0,1,2 (postdate the ts=10 side) and 5,6,7,8 (postdate the ts=20 side) survive; \
+         ck 3,4 (shadowed by the ts=20 side) are gone"
+    );
+    assert_boundary(&out.markers);
+}
+
+/// A near-zero first-call budget forces a pause to land WHILE the
+/// range-tombstone-bearing partition is still being BUFFERED (before the
+/// PartitionEnd write session opens) — the highest-risk path for
+/// `PartitionStreamState`'s stash/resume. The resumed, multi-call drain must
+/// produce output BYTE-IDENTICAL to an unpaused single-call drain of the
+/// identical input, AND still carry the correct synthesized boundary +
+/// survivals (proving neither the buffered rows nor the partial
+/// carrier/range-tombstone accumulation is lost or corrupted across the pause).
+#[test]
+fn maintenance_step_pause_mid_buffering_matches_unpaused_for_rt_partition() {
+    // Near-zero budget on the first call: `budget * 1.1` is ~1ns, so the
+    // between-cluster-group budget check trips right after the first cluster
+    // group is buffered — long before PartitionEnd — forcing the RT partition's
+    // accumulation to pause and resume across many calls.
+    let (paused, calls) = compact_fixture(Duration::from_nanos(1));
+    assert!(
+        calls > 1,
+        "a ~1ns first-call budget must force the single RT partition's drain to PAUSE and RESUME \
+         across MULTIPLE maintenance_step calls (nothing is written until PartitionEnd, so >1 \
+         call proves a mid-buffering pause) — otherwise this test would not exercise the \
+         stash/resume path it exists to cover; got {calls} call(s)"
+    );
+
+    // Unpaused single-drain baseline over the IDENTICAL input.
+    let (unpaused, unpaused_calls) = compact_fixture(Duration::from_secs(60));
+    assert_eq!(
+        unpaused_calls, 1,
+        "generous budget should drain in one call"
+    );
 
     assert_eq!(
-        live_rows,
-        vec![2, 6],
-        "ck=2 (postdates the ts=10 side) and ck=6 (postdates the ts=20 side) survive background \
-         compaction; ck=4 (shadowed by the ts=20 side) is gone"
-    );
-
-    // The synthesized boundary at ck=3 must survive background compaction:
-    // [Bottom, Exclusive(3)) @ts=10 CLOSE, then [Inclusive(3), Top] @ts=20 OPEN.
-    assert_eq!(
-        markers.len(),
-        2,
-        "background compaction must synthesize BOTH boundary halves (not drop them)"
-    );
-    assert!(
-        matches!(markers[0].start, ClusteringBound::Bottom),
-        "closing range opens from Bottom, got {:?}",
-        markers[0].start
-    );
-    assert!(
-        matches!(&markers[0].end, ClusteringBound::Exclusive(_))
-            && bound_ck(&markers[0].end) == Some(3),
-        "closing range ends Exclusive at the ck=3 boundary, got {:?}",
-        markers[0].end
+        paused.bytes, unpaused.bytes,
+        "paused/resumed compaction of an RT-overlap partition must produce BYTE-IDENTICAL \
+         Data.db to the unpaused single-call drain (no buffered row or partial range-tombstone \
+         accumulation lost/corrupted across the mid-buffering pause)"
     );
     assert_eq!(
-        markers[0].deletion_time, 10,
-        "closing range carries the ts=10 deletion time"
+        paused.markers, unpaused.markers,
+        "the synthesized boundary markers must be identical across the pause"
     );
     assert_eq!(
-        markers[0].local_deletion_time,
-        ldt_for(10),
-        "closing range carries the ts=10 side's OWN localDeletionTime"
+        paused.live_rows, unpaused.live_rows,
+        "the surviving rows must be identical across the pause"
     );
-    assert!(
-        matches!(&markers[1].start, ClusteringBound::Inclusive(_))
-            && bound_ck(&markers[1].start) == Some(3),
-        "opening range starts Inclusive at the SAME ck=3 boundary, got {:?}",
-        markers[1].start
-    );
-    assert!(
-        matches!(markers[1].end, ClusteringBound::Top),
-        "opening range runs to Top, got {:?}",
-        markers[1].end
-    );
-    assert_eq!(
-        markers[1].deletion_time, 20,
-        "opening range carries the ts=20 deletion time"
-    );
-    assert_eq!(
-        markers[1].local_deletion_time,
-        ldt_for(20),
-        "opening range carries the ts=20 side's OWN localDeletionTime (distinct from the close \
-         side's — a swapped LDT would be caught)"
-    );
+    // Not a vacuous equality: both must actually carry the correct boundary +
+    // survivals, not merely agree with each other while both wrong.
+    assert_eq!(paused.live_rows, EXPECTED_LIVE_ROWS.to_vec());
+    assert_boundary(&paused.markers);
 }

--- a/cqlite-core/tests/issue_1668_maintenance_rt_boundary.rs
+++ b/cqlite-core/tests/issue_1668_maintenance_rt_boundary.rs
@@ -1,0 +1,304 @@
+//! Issue #1383 / #1668 regression: BACKGROUND auto-compaction (via the public
+//! [`WriteEngine::maintenance_step`] surface) must SYNTHESIZE — never drop —
+//! the range-tombstone boundary when two flush generations carry ranges that
+//! OVERLAP across a clustering point.
+//!
+//! `issue_1383_rt_boundary_synthesis` pins this for the direct
+//! `compact_sstables`/`KWayMerger::merge` path. This test drives the SAME
+//! property through the streaming background-compaction state machine
+//! (`maintenance.rs`'s `PartitionStreamState`), which had the IDENTICAL
+//! late-marker-drop hazard before issue #1668's buffering fix: it opened the
+//! writer session on the first `Some(ck)` row with an incomplete
+//! range-tombstone set, then fed each late range-only marker mutation through
+//! `feed_streaming_row`, which dropped it as a no-op — silently losing the
+//! synthesized boundary (and its shadowing) from the compacted output.
+//!
+//! Generation placement is the WORST case for the streaming path (mirrors
+//! `crit3_inverse_generation_ordering`): gen-1 (newer) holds `[incl(3), Top]`
+//! @ts=20 and gen-2 (older) holds `[Bottom, excl(5)]` @ts=10, so the OLDER
+//! range's coalesced marker is only surfaced by the merge stream AFTER the
+//! rows it covers have already streamed.
+
+#![cfg(feature = "write-support")]
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::merge::{KWayMerger, MergeStep, RowData};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, ClusteringBound, ClusteringKey, Mutation, PartitionKey, RangeTombstone, TableId,
+};
+use cqlite_core::storage::write_engine::{STCSPolicy, WriteEngine, WriteEngineConfig};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+const KS: &str = "rt_bound_ks";
+const TBL: &str = "rt_bound_tbl";
+const PID: i32 = 1;
+
+// Far-future local-deletion-times (distinct per range) so gc-grace never
+// purges a marker regardless of wall clock (no wall-clock race), AND the two
+// boundary sides carry different LDTs so a swapped LDT would be caught —
+// mirroring the issue_1383 suite.
+const NEVER_PURGE_LDT_BASE: i32 = 2_000_000_000;
+
+fn ldt_for(ts: i64) -> i32 {
+    NEVER_PURGE_LDT_BASE + (ts as i32)
+}
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: Default::default(),
+        dropped_columns: Default::default(),
+    }
+}
+
+fn write_row(ck: i32, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(PID)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(format!("r{ck}")),
+        }],
+        ts,
+        None,
+    )
+}
+
+fn range_delete(start: ClusteringBound, end: ClusteringBound, ts: i64) -> Mutation {
+    let mut m = Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(PID)),
+        None,
+        vec![],
+        ts,
+        None,
+    );
+    m.range_tombstones.push(RangeTombstone {
+        start,
+        end,
+        deletion_time: ts,
+        local_deletion_time: ldt_for(ts),
+    });
+    m
+}
+
+fn incl(ck: i32) -> ClusteringBound {
+    ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(ck)))
+}
+
+fn excl(ck: i32) -> ClusteringBound {
+    ClusteringBound::Exclusive(ClusteringKey::single("ck", Value::Integer(ck)))
+}
+
+fn ck_of(k: &ClusteringKey) -> Option<i32> {
+    match k.columns.first().map(|(_, v)| v) {
+        Some(Value::Integer(n)) => Some(*n),
+        _ => None,
+    }
+}
+
+fn bound_ck(b: &ClusteringBound) -> Option<i32> {
+    match b {
+        ClusteringBound::Inclusive(k) | ClusteringBound::Exclusive(k) => ck_of(k),
+        _ => None,
+    }
+}
+
+/// A decoded range marker as it surfaces through the compaction read path.
+struct Marker {
+    start: ClusteringBound,
+    end: ClusteringBound,
+    deletion_time: i64,
+    local_deletion_time: i32,
+}
+
+/// Read the compacted output back through the merge read path, collecting the
+/// surviving range markers (in clustering order) and live-row clustering keys.
+fn read_back(output: PathBuf, schema: &TableSchema) -> (Vec<Marker>, Vec<i32>) {
+    let mut merger = KWayMerger::new(vec![output], schema).expect("KWayMerger::new");
+    let mut markers = Vec::new();
+    let mut live_rows = Vec::new();
+    loop {
+        match merger.step().expect("merger step") {
+            MergeStep::Complete => break,
+            MergeStep::Partition { rows, .. } => {
+                for entry in rows {
+                    if let Some(rt) = &entry.range_deletion {
+                        markers.push(Marker {
+                            start: rt.start.clone(),
+                            end: rt.end.clone(),
+                            deletion_time: rt.deletion_time,
+                            local_deletion_time: rt.local_deletion_time,
+                        });
+                        continue;
+                    }
+                    if let RowData::Live { cells } = &entry.row_data {
+                        let has_data = cells.iter().any(|c| c.column != "ck" && c.column != "id");
+                        if has_data {
+                            if let Some(ck) = entry.clustering_key.as_ref().and_then(ck_of) {
+                                live_rows.push(ck);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    live_rows.sort_unstable();
+    (markers, live_rows)
+}
+
+/// Compact two overlapping-range-tombstone generations via the public
+/// background-compaction surface (`maintenance_step`) and assert the
+/// synthesized boundary at ck=3 survives — both boundary halves AND the
+/// correct row survivals.
+#[test]
+fn maintenance_step_synthesizes_range_tombstone_boundary_across_generations() {
+    let schema = schema();
+    let temp = TempDir::new().unwrap();
+    let config = WriteEngineConfig::new(
+        temp.path().join("data"),
+        temp.path().join("wal"),
+        schema.clone(),
+    );
+    let mut engine = WriteEngine::new(config).unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // gen-1 (newer): [incl(3), Top] @ts=20 + rows ck=2 (ts=15, survives — only
+    // the ts=10 side covers ck<3, and 15>10) and ck=6 (ts=25, survives — in the
+    // ts=20 side but 25>20).
+    engine
+        .write(range_delete(incl(3), ClusteringBound::Top, 20))
+        .unwrap();
+    engine.write(write_row(2, 15)).unwrap();
+    engine.write(write_row(6, 25)).unwrap();
+    rt.block_on(engine.flush()).unwrap().unwrap();
+    // gen-2 (older): [Bottom, excl(5)] @ts=10 + row ck=4 (ts=15, shadowed by
+    // the ts=20 side, 15<=20 → absent).
+    engine
+        .write(range_delete(ClusteringBound::Bottom, excl(5), 10))
+        .unwrap();
+    engine.write(write_row(4, 15)).unwrap();
+    rt.block_on(engine.flush()).unwrap().unwrap();
+
+    // min_sstable_size large enough that both tiny files bucket together into
+    // one full (purge-safe) compaction.
+    let policy = STCSPolicy::new(2, 32, 0.5, 1.5, 1024 * 1024).unwrap();
+    engine.set_merge_policy(Box::new(policy)).unwrap();
+
+    let mut report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+    let mut outputs = report.completed_merges.clone();
+    let mut calls = 1u32;
+    while report.pending_compaction {
+        report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+        outputs.extend(report.completed_merges.clone());
+        calls += 1;
+        assert!(calls < 10_000, "compaction never completed");
+    }
+    assert_eq!(
+        outputs.len(),
+        1,
+        "expected exactly one compacted output Data.db, got {outputs:?}"
+    );
+
+    let (markers, live_rows) = read_back(outputs.into_iter().next().unwrap(), &schema);
+
+    assert_eq!(
+        live_rows,
+        vec![2, 6],
+        "ck=2 (postdates the ts=10 side) and ck=6 (postdates the ts=20 side) survive background \
+         compaction; ck=4 (shadowed by the ts=20 side) is gone"
+    );
+
+    // The synthesized boundary at ck=3 must survive background compaction:
+    // [Bottom, Exclusive(3)) @ts=10 CLOSE, then [Inclusive(3), Top] @ts=20 OPEN.
+    assert_eq!(
+        markers.len(),
+        2,
+        "background compaction must synthesize BOTH boundary halves (not drop them)"
+    );
+    assert!(
+        matches!(markers[0].start, ClusteringBound::Bottom),
+        "closing range opens from Bottom, got {:?}",
+        markers[0].start
+    );
+    assert!(
+        matches!(&markers[0].end, ClusteringBound::Exclusive(_))
+            && bound_ck(&markers[0].end) == Some(3),
+        "closing range ends Exclusive at the ck=3 boundary, got {:?}",
+        markers[0].end
+    );
+    assert_eq!(
+        markers[0].deletion_time, 10,
+        "closing range carries the ts=10 deletion time"
+    );
+    assert_eq!(
+        markers[0].local_deletion_time,
+        ldt_for(10),
+        "closing range carries the ts=10 side's OWN localDeletionTime"
+    );
+    assert!(
+        matches!(&markers[1].start, ClusteringBound::Inclusive(_))
+            && bound_ck(&markers[1].start) == Some(3),
+        "opening range starts Inclusive at the SAME ck=3 boundary, got {:?}",
+        markers[1].start
+    );
+    assert!(
+        matches!(markers[1].end, ClusteringBound::Top),
+        "opening range runs to Top, got {:?}",
+        markers[1].end
+    );
+    assert_eq!(
+        markers[1].deletion_time, 20,
+        "opening range carries the ts=20 deletion time"
+    );
+    assert_eq!(
+        markers[1].local_deletion_time,
+        ldt_for(20),
+        "opening range carries the ts=20 side's OWN localDeletionTime (distinct from the close \
+         side's — a swapped LDT would be caught)"
+    );
+}


### PR DESCRIPTION
## Summary
Q5 -- replaces the whole-partition buffer-then-write merge path with a streaming, within-partition
merge for compaction, bounding merge-layer peak memory independent of partition width.

- Stages 1-4: extract carrier pre-scan, introduce a streaming cluster-group step, wire
  maintenance.rs/compact_sstables to the streaming path, add the mid-partition budget check.
- Stage 5: schema-aware heap-direct ordering (5a/5b), incremental sort_partition_items +
  collect_static_operations (5c-i-iii), a new IncrementalPartitionWriter and StreamingPartitionSession
  (owns state, zero lifetimes -- the writer is a per-call parameter, enabling pause/resume across
  maintenance_step_inner calls) (5c-iv), and bounded-open-range buffering for range tombstones that
  arrive mid-partition (5d).
- dhat proof: a synthetic LazyWideRun source (materializes each row's 64KiB payload on-demand,
  bypassing the reader entirely) feeding 4 runs x 5,000 rows x 64KiB (~1.22GiB logical) directly into
  StreamingMerger/KWayMerger measures 0.51 MiB peak vs the 128MiB budget -- proves the merge layer's
  own bound, independent of the reader-side gap (filed as #2299).
- Two roborev-flagged blockers fixed and re-verified clean: boundary coalescing in the
  incremental/streaming writers, and carrier row-count parity in maintenance.rs.

## Design decisions escalated to the owner (all resolved, see issue comments)
- Pause/resume state ownership: reworked to StreamingPartitionSession owning its own state (Option A).
- Range tombstone arriving after its covered rows: ship the common case + document the caveat.
- Original dhat test measured the READER's full materialization, not the merge layer -- rescoped to a
  synthetic source; the reader-side gap is tracked separately as #2299 (blocks #2230).

## Known follow-on (not in scope here)
- #2299 -- SSTable reader fully materializes uncompressed sources instead of streaming.

Closes #1668

## Test plan
- [x] --lite PASS on the final diff
- [x] rust-reviewer + roborev review-first pass -- 2 blockers found, fixed, re-verified clean
- [ ] Full agent-gate.sh (gate of record) + C (spec-auditor) + final roborev -- run by flow-closer
