### PR TITLE
fix(#2305): e2e asserts on-disk-only under live mode; document snapshot vs live read semantics

### DIFF
--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -235,8 +235,19 @@ file set a scan sees:
 | `snapshot` (default) | A **Cassandra Sidecar snapshot** — a hard-linked, immutable copy of the SSTable set taken at planning time. | **Stable file set, bounded staleness.** Every split of the query reads the same immutable files; data is "as of" snapshot time. No mid-scan file churn. | You want a consistent, repeatable read (the safe default). |
 | `live` | The node's current data directory. | **Most current, but races compaction.** A long scan can have files compacted/removed under it. | You are stress-hunting the read path, or want the absolute latest flushed data and accept the race. |
 
-Both modes only ever see **flushed** SSTables — memtable rows are invisible until a
-`nodetool flush` (a property of the SSTable-based server, not of read mode).
+**Memtable visibility differs by mode (issue #2305).** `snapshot` mode is a per-query,
+point-in-time read that **includes durable memtable state**: Cassandra's snapshot creation
+flushes the memtable as a side effect by design, and the Sidecar's `PUT .../snapshots/{name}`
+HTTP API has no `skipFlush` parameter to opt out of it (`CreateSnapshotHandler` only accepts
+`?ttl=`; `SnapshotRequestParam` carries no skip-flush field, in any released
+`apache/cassandra-sidecar` version — verified against the pinned image's compiled classes). So
+a very recent write can become visible through a `snapshot`-mode query even without an explicit
+`nodetool flush`. The operational cost of that implicit per-query flush is tracked separately
+(issue #2306).
+
+`live` mode is the strict **on-disk-SSTables-only** contract: it reads the current data
+directory directly, with no snapshot and no flush side effect, so memtable rows stay invisible
+until an explicit `nodetool flush`.
 
 ### Snapshot lifecycle (per-query, `cqlite-<queryId>`)
 

--- a/trino-connector/docker/e2e-test.sh
+++ b/trino-connector/docker/e2e-test.sh
@@ -317,10 +317,21 @@ assert_eq "partial-predicate LIMIT 5 applies residual (3 rows)" '"3"' \
   "$(trino 'SELECT count(*) FROM (SELECT id FROM cqlite.analytics.events WHERE score > 15 AND length(name) > 3 LIMIT 5)')"
 
 # Proof it reads SSTables (not live CQL): an unflushed row must be invisible.
-log "assert SSTable semantics (memtable invisible until flush)"
+#
+# On-disk-only is a `live`-mode contract, not `snapshot` mode (issue #2305):
+# `snapshot` mode's per-query Sidecar snapshot flushes the memtable as a side
+# effect by design (apache/cassandra-sidecar's create-snapshot HTTP API has no
+# skipFlush parameter — see trino-connector/README.md#read-mode-snapshot-vs-live),
+# so a snapshot-mode query can legitimately see this row before any explicit
+# `nodetool flush`. That operational cost is tracked separately (issue #2306).
+# The strict on-disk-only assertion therefore runs against the `cqlite_live`
+# catalog (read-mode is catalog-scoped config — no per-query/session override
+# exists); the post-flush assertion stays on the default `cqlite`
+# (snapshot-mode) catalog, unchanged from before.
+log "assert SSTable semantics (memtable invisible until flush, live mode)"
 "${COMPOSE[@]}" exec -T cassandra cqlsh 172.42.0.2 \
   -e "INSERT INTO analytics.events (id,name,score,active) VALUES (99,'ghost',1,true);"
-assert_eq "unflushed row invisible" '"5"'                                   "$(trino 'SELECT count(*) FROM cqlite.analytics.events')"
+assert_eq "unflushed row invisible (live mode)" '"5"'                       "$(trino 'SELECT count(*) FROM cqlite_live.analytics.events')"
 "${COMPOSE[@]}" exec -T cassandra nodetool flush analytics
 assert_eq "row visible after flush" '"6"'                                   "$(trino 'SELECT count(*) FROM cqlite.analytics.events')"
 

--- a/trino-connector/docker/trino/catalog/cqlite_live.properties
+++ b/trino-connector/docker/trino/catalog/cqlite_live.properties
@@ -1,0 +1,13 @@
+connector.name=cqlite_flight
+cqlite.sidecar-uri=http://172.42.0.2:9043
+cqlite.flight-port=8815
+cqlite.local-datacenter=dc1
+# LIVE-mode twin of the default `cqlite` catalog (issue #2305): read-mode is a
+# catalog-scoped config property (no per-query/session override exists), so
+# exercising the strict on-disk-only contract in e2e-test.sh needs its own
+# catalog rather than a session property. `live` reads the node's current data
+# directory directly — no Sidecar snapshot, so no snapshot-triggered flush —
+# unlike `snapshot` mode (the `cqlite` catalog's default), whose Sidecar
+# `PUT .../snapshots/{name}` call flushes the memtable as a side effect
+# (apache/cassandra-sidecar has no skipFlush HTTP parameter).
+cqlite.read-mode=live

--- a/website/src/content/docs/user-docs/flight-trino.md
+++ b/website/src/content/docs/user-docs/flight-trino.md
@@ -292,8 +292,16 @@ query finishes; a TTL backstop (`cqlite.snapshot-ttl`, default `6h`) ensures a
 coordinator crash can't leak it. Snapshot creation is **fail-closed** — if it
 fails, the query fails rather than silently falling back to a live read.
 
-Both modes only ever see **flushed** SSTables — memtable rows are invisible until
-a `nodetool flush`.
+**Memtable visibility differs by mode (issue #2305).** `snapshot` mode is a per-query,
+point-in-time read that **includes durable memtable state**: Cassandra's snapshot creation
+flushes the memtable as a side effect by design, and the Sidecar's create-snapshot HTTP API has
+no `skipFlush` parameter to opt out of it. So a very recent write can become visible through a
+`snapshot`-mode query even without an explicit `nodetool flush`. `live` mode is the strict
+**on-disk-SSTables-only** contract: it reads the current data directory directly, with no
+snapshot and no flush side effect, so memtable rows stay invisible until an explicit
+`nodetool flush`. See the
+[connector README](https://github.com/pmcfadin/cqlite/blob/main/trino-connector/README.md#read-mode-snapshot-vs-live)
+for the full mechanism.
 
 See the [connector README](https://github.com/pmcfadin/cqlite/blob/main/trino-connector/README.md#catalog-configuration)
 for the complete property reference, the docker-compose end-to-end topology,


### PR DESCRIPTION
Closes #2305

## Owner decision
Re-scoped per owner decision on the issue (option 4):
https://github.com/pmcfadin/cqlite/issues/2305#issuecomment (see the "OWNER DECISION (2026-07-09): re-scope to option 4" comment on the issue). Snapshot-mode's flush-on-snapshot semantics are accepted as designed; the stale part was the e2e assertion, which encoded on-disk-only as a property of *both* read modes when it is actually **live mode's** contract post-#2105.

## Sidecar API finding (from the original escalation)
The pinned Sidecar (`ghcr.io/apache/cassandra-sidecar:latest` = 0.5-SNAPSHOT) create-snapshot HTTP endpoint (`PUT /api/v1/keyspaces/{ks}/tables/{t}/snapshots/{name}`) exposes **only `?ttl=`** — verified against the pinned image's actual compiled classes (`CreateSnapshotHandler`, `SnapshotRequestParam`), not the docs. No `skipFlush`/`skip`/`flush` string exists anywhere in those classes; `SnapshotRequestParam`'s fields are `snapshotName`/`qualifiedTableName`/`ttl`/`includeSecondaryIndexFiles`. Cross-checked upstream trunk: `skipFlush` appears only in JMX-layer doc comments, never in any HTTP handler, in any released version. Cassandra's snapshot creation flushes the memtable as a side effect by design, so a `snapshot`-mode query can make a very recent write visible without an explicit `nodetool flush`.

## Fix
- New `trino-connector/docker/trino/catalog/cqlite_live.properties`: read-mode is a catalog-scoped config property with **no per-query/session override**, so exercising the strict on-disk-only contract needs its own Trino catalog (`cqlite_live`, `cqlite.read-mode=live`) alongside the default `cqlite` (snapshot mode) catalog.
- `trino-connector/docker/e2e-test.sh`: the "unflushed row invisible" assertion now queries `cqlite_live.analytics.events` (live mode); the "row visible after flush" assertion is unchanged on the default `cqlite` (snapshot mode) catalog.
- `trino-connector/README.md` + `website/src/content/docs/user-docs/flight-trino.md`: replaced the stale "both modes only ever see flushed SSTables" claim with the real per-mode contract (snapshot mode = per-query point-in-time read *including* durable memtable state; live mode = strict on-disk-SSTables-only) and cited the Sidecar API finding.

The operational cost of snapshot mode's implicit per-query flush (tiny-SSTable churn) is tracked separately in #2306 — out of this issue's scope.

## Validation
Full docker-compose e2e stack (Cassandra 5.0 + Sidecar + cqlite-flight + Trino), run on Docker Desktop (arm64). An unrelated, pre-existing `docker compose up -d --build` dependency-startup race (`Error dependency cassandra failed to start: No such container: <id>`) hit twice when all 4 services were created+started simultaneously under `--build`; reproduced it in isolation (cassandra alone starts and passes its healthcheck cleanly every time) and confirmed it disappears when cassandra is brought up first and the dependents are started once it's already healthy — an infra/Docker Desktop scheduling flake unrelated to this diff (no docker-compose.yml/Dockerfile changes here). Worked around it by bringing the already-built, unchanged image up with cassandra-first sequencing and running the exact same assertions/queries the script issues.

**Result: 34/34 assertions pass**, including:
- `PASS: unflushed row invisible (live mode)` — `cqlite_live` correctly shows `5` for an unflushed insert.
- `PASS: row visible after flush` — `cqlite` (snapshot mode) shows `6` after an explicit `nodetool flush`.

Confirmatory root-cause check (extra, not part of the 34): a second unflushed insert queried through the default `cqlite` (snapshot-mode) catalog jumped the count `6 -> 7` with **no** explicit flush — proving the exact mechanism this fix documents (Sidecar snapshot creation flushes the memtable as a side effect) — while `cqlite_live` never triggers that side effect.

## Adjacency
#2295 (another issue) also touches the Sidecar snapshot area (missing snapshot components in the field) — this diff is surgical to the read-mode/e2e-assertion scope and does not touch `SidecarClient`/`SnapshotManager` snapshot-creation logic.