### PR TITLE
perf(#1495): resolve per-column Arrow accessor once (kill per-cell HashMap lookup)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -174,6 +174,15 @@ pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 mach2 = "0.4"
 
+# Arrow-conversion accessor-hoist parity guard (issue #1495, AE1). Declared with
+# required-features so the agent gate's blast-radius scoping compiles+RUNS it WITH
+# the `arrow` feature it needs — without this, `#![cfg(feature = "arrow")]` would
+# make it a vacuously-passing empty binary under the default `cli-helpers`-only
+# scoped-test invocation.
+[[test]]
+name = "issue_1495_arrow_accessor_parity"
+required-features = ["arrow"]
+
 [[bench]]
 name = "partition_lookup"
 harness = false

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -175,10 +175,13 @@ pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 mach2 = "0.4"
 
 # Arrow-conversion accessor-hoist parity guard (issue #1495, AE1). Declared with
-# required-features so the agent gate's blast-radius scoping compiles+RUNS it WITH
-# the `arrow` feature it needs — without this, `#![cfg(feature = "arrow")]` would
-# make it a vacuously-passing empty binary under the default `cli-helpers`-only
-# scoped-test invocation.
+# required-features = ["arrow"] because it is `#![cfg(feature = "arrow")]`, so it
+# only compiles+runs when the arrow feature is on. The full agent gate runs it via
+# the dedicated `arrow-parity-guard` component (scripts/agent-gate.sh:
+# `cargo test -p cqlite-core --features arrow --test issue_1495_arrow_accessor_parity`),
+# which is its ONLY automated executor and fails closed on a vacuous 0-run — the
+# default `cli-helpers`-only core-tests run and pr-gate's `--lib --all-features`
+# both skip this integration target.
 [[test]]
 name = "issue_1495_arrow_accessor_parity"
 required-features = ["arrow"]

--- a/cqlite-core/src/export/arrow_columnar.rs
+++ b/cqlite-core/src/export/arrow_columnar.rs
@@ -1,0 +1,174 @@
+//! Per-column accessor resolution for Arrow conversion (issue #1495, AE1).
+//!
+//! # Why this exists
+//!
+//! Every Arrow builder in [`super::arrow_convert`] used to do
+//! `row.values.get(&col.name)` **per cell** — a `HashMap<Arc<str>, Value>`
+//! sip-hash string lookup into each row's value map. For `N` rows × `M` columns
+//! that meant `M` independent full passes over the row vector, each probing the
+//! large per-row map by name once per row (`N·M` probes total, INCLUDING absent
+//! cells), even though a column's name is known once per schema. This is the
+//! export-side instance of the string-typed per-cell dispatch that parser epic
+//! **J1** condemned; the shared fix shape is "resolve a per-column accessor once,
+//! then index rows positionally".
+//!
+//! # The fix
+//!
+//! [`transpose_columns`] resolves each schema column to its output position
+//! **once** (building a small `name → column-index` map — `M` name hashes), then
+//! makes a **single pass** over the rows, iterating each row's OWN entries. Each
+//! present cell is routed to its column's slot via one lookup into the tiny
+//! `M`-entry index map. The result is column-major: a `Vec<Option<&Value>>` per
+//! column, aligned to the row order, that each builder consumes directly.
+//!
+//! Consequently the large per-row `values` maps are **never** `.get()`-probed by
+//! column name at all — the per-cell string-hash lookup against them is gone. The
+//! only hashing is (a) the `M`-entry index map built once and (b) one lookup per
+//! *present* cell into that tiny map (so sparse rows cost nothing for their
+//! absent columns, unlike the old `N·M` full-scan).
+//!
+//! Output is byte-identical: `None` (absent column) and `Some(&Value::Null)`
+//! (explicit null) are preserved exactly as the builders' `None`/`Value::Null`
+//! arms already expect, and column/row alignment is unchanged.
+
+use std::collections::HashMap;
+
+use crate::query::{ColumnInfo, QueryRow};
+use crate::types::Value;
+
+/// Resolve every schema column to its aligned, column-major value slice in a
+/// single pass over `rows`.
+///
+/// Returns one `Vec<Option<&Value>>` per column (in `columns` order), each of
+/// length `rows.len()`. Element `i` of column `c`'s slice is:
+/// - `Some(&value)` when row `i` carries a value for `columns[c].name`, or
+/// - `None` when the column is absent from row `i` (the builders map both an
+///   absent cell and a `Value::Null` to an Arrow null, exactly as before).
+///
+/// Column names are hashed only `M` times to build the `name → index` map;
+/// thereafter the per-row work iterates the row's own entries and does one lookup
+/// per PRESENT cell into that small map — the large per-row `values` maps are
+/// never probed by column name (issue #1495 / parser epic J1).
+///
+/// Duplicate column names in `columns` are not expected (a result schema has
+/// distinct columns); if present, the last occurrence wins the index slot, which
+/// matches the old per-builder `get` (each builder resolved its own `col.name`).
+pub(crate) fn transpose_columns<'a>(
+    columns: &[ColumnInfo],
+    rows: &'a [QueryRow],
+) -> Vec<Vec<Option<&'a Value>>> {
+    let n_rows = rows.len();
+    let n_cols = columns.len();
+
+    // Resolve each column name to its output-slice index ONCE (M name hashes).
+    let mut name_to_idx: HashMap<&str, usize> = HashMap::with_capacity(n_cols);
+    for (idx, col) in columns.iter().enumerate() {
+        name_to_idx.insert(col.name.as_str(), idx);
+    }
+
+    // Column-major output, pre-sized so no slot re-allocates. Absent cells stay
+    // `None`; only present cells are written.
+    let mut columnar: Vec<Vec<Option<&'a Value>>> =
+        (0..n_cols).map(|_| vec![None; n_rows]).collect();
+
+    // Single pass over rows. For each row we iterate its OWN entries and route
+    // each present cell to its column slot via the tiny name→index map. No
+    // `values.get(col.name)` probe against the large per-row map occurs.
+    for (row_idx, row) in rows.iter().enumerate() {
+        for (name, value) in &row.values {
+            if let Some(&col_idx) = name_to_idx.get(name.as_ref()) {
+                columnar[col_idx][row_idx] = Some(value);
+            }
+            // A row entry whose name is not in the schema is ignored, matching
+            // the old behaviour (no builder ever requested it).
+        }
+    }
+
+    columnar
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::ColumnInfo;
+    use crate::types::DataType;
+    use crate::RowKey;
+    use std::sync::Arc;
+
+    fn col(name: &str) -> ColumnInfo {
+        ColumnInfo {
+            name: name.to_string(),
+            data_type: DataType::Integer,
+            nullable: true,
+            position: 0,
+            table_name: None,
+            cql_type: None,
+        }
+    }
+
+    fn row(pairs: &[(&str, Value)]) -> QueryRow {
+        let mut values: HashMap<Arc<str>, Value> = HashMap::new();
+        for (name, value) in pairs {
+            values.insert(Arc::from(*name), value.clone());
+        }
+        QueryRow::with_interned_values(RowKey::new(Vec::new()), values)
+    }
+
+    /// The transpose returns one aligned slice per column, of length `rows`, with
+    /// present cells routed to their column and absent cells left `None`.
+    #[test]
+    fn transpose_aligns_columns_and_rows() {
+        let columns = vec![col("a"), col("b"), col("c")];
+        let rows = vec![
+            row(&[
+                ("a", Value::Integer(1)),
+                ("b", Value::Integer(2)),
+                ("c", Value::Integer(3)),
+            ]),
+            // b absent; a null; c present.
+            row(&[("a", Value::Null), ("c", Value::Integer(30))]),
+        ];
+
+        let cols = transpose_columns(&columns, &rows);
+        assert_eq!(cols.len(), 3);
+        for slice in &cols {
+            assert_eq!(slice.len(), 2);
+        }
+
+        // Column a: row0 = 1, row1 = Null.
+        assert_eq!(cols[0][0], Some(&Value::Integer(1)));
+        assert_eq!(cols[0][1], Some(&Value::Null));
+        // Column b: row0 = 2, row1 ABSENT (None).
+        assert_eq!(cols[1][0], Some(&Value::Integer(2)));
+        assert_eq!(cols[1][1], None);
+        // Column c: row0 = 3, row1 = 30.
+        assert_eq!(cols[2][0], Some(&Value::Integer(3)));
+        assert_eq!(cols[2][1], Some(&Value::Integer(30)));
+    }
+
+    /// A row entry whose name is not in the schema is ignored (never panics, never
+    /// mis-routed) — matching the old per-builder `get` which simply never asked
+    /// for it.
+    #[test]
+    fn extra_row_entry_not_in_schema_is_ignored() {
+        let columns = vec![col("a")];
+        let rows = vec![row(&[("a", Value::Integer(1)), ("z", Value::Integer(9))])];
+        let cols = transpose_columns(&columns, &rows);
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0][0], Some(&Value::Integer(1)));
+    }
+
+    /// Empty inputs: no columns / no rows produce well-formed empty output.
+    #[test]
+    fn empty_inputs() {
+        let no_cols: Vec<ColumnInfo> = vec![];
+        let rows = vec![row(&[("a", Value::Integer(1))])];
+        assert!(transpose_columns(&no_cols, &rows).is_empty());
+
+        let columns = vec![col("a")];
+        let no_rows: Vec<QueryRow> = vec![];
+        let cols = transpose_columns(&columns, &no_rows);
+        assert_eq!(cols.len(), 1);
+        assert!(cols[0].is_empty());
+    }
+}

--- a/cqlite-core/src/export/arrow_columnar.rs
+++ b/cqlite-core/src/export/arrow_columnar.rs
@@ -45,14 +45,17 @@ use crate::types::Value;
 /// - `None` when the column is absent from row `i` (the builders map both an
 ///   absent cell and a `Value::Null` to an Arrow null, exactly as before).
 ///
-/// Column names are hashed only `M` times to build the `name → index` map;
+/// Column names are hashed only `M` times to build the `name → indices` map;
 /// thereafter the per-row work iterates the row's own entries and does one lookup
 /// per PRESENT cell into that small map — the large per-row `values` maps are
 /// never probed by column name (issue #1495 / parser epic J1).
 ///
-/// Duplicate column names in `columns` are not expected (a result schema has
-/// distinct columns); if present, the last occurrence wins the index slot, which
-/// matches the old per-builder `get` (each builder resolved its own `col.name`).
+/// Duplicate column names in `columns` (e.g. `SELECT a, a` or `SELECT a AS x, b
+/// AS x`) are supported: a name maps to the list of ALL its output indices, and a
+/// present cell for that name is replicated into EVERY matching column slot. This
+/// reproduces the pre-refactor behaviour exactly — each builder independently did
+/// `row.values.get(&col.name)`, so every same-named output column resolved the
+/// same row value.
 pub(crate) fn transpose_columns<'a>(
     columns: &[ColumnInfo],
     rows: &'a [QueryRow],
@@ -60,10 +63,15 @@ pub(crate) fn transpose_columns<'a>(
     let n_rows = rows.len();
     let n_cols = columns.len();
 
-    // Resolve each column name to its output-slice index ONCE (M name hashes).
-    let mut name_to_idx: HashMap<&str, usize> = HashMap::with_capacity(n_cols);
+    // Resolve each column name to ALL of its output-slice indices ONCE (M name
+    // hashes). Duplicate names collect multiple indices so a present cell can be
+    // fanned out to every matching column, matching the old per-builder `get`.
+    let mut name_to_indices: HashMap<&str, Vec<usize>> = HashMap::with_capacity(n_cols);
     for (idx, col) in columns.iter().enumerate() {
-        name_to_idx.insert(col.name.as_str(), idx);
+        name_to_indices
+            .entry(col.name.as_str())
+            .or_default()
+            .push(idx);
     }
 
     // Column-major output, pre-sized so no slot re-allocates. Absent cells stay
@@ -72,12 +80,14 @@ pub(crate) fn transpose_columns<'a>(
         (0..n_cols).map(|_| vec![None; n_rows]).collect();
 
     // Single pass over rows. For each row we iterate its OWN entries and route
-    // each present cell to its column slot via the tiny name→index map. No
-    // `values.get(col.name)` probe against the large per-row map occurs.
+    // each present cell to ALL of its column slots via the tiny name→indices map.
+    // No `values.get(col.name)` probe against the large per-row map occurs.
     for (row_idx, row) in rows.iter().enumerate() {
         for (name, value) in &row.values {
-            if let Some(&col_idx) = name_to_idx.get(name.as_ref()) {
-                columnar[col_idx][row_idx] = Some(value);
+            if let Some(col_indices) = name_to_indices.get(name.as_ref()) {
+                for &col_idx in col_indices {
+                    columnar[col_idx][row_idx] = Some(value);
+                }
             }
             // A row entry whose name is not in the schema is ignored, matching
             // the old behaviour (no builder ever requested it).
@@ -156,6 +166,28 @@ mod tests {
         let cols = transpose_columns(&columns, &rows);
         assert_eq!(cols.len(), 1);
         assert_eq!(cols[0][0], Some(&Value::Integer(1)));
+    }
+
+    /// Duplicate column names: a present cell for that name must be replicated
+    /// into EVERY matching column slot (matching main's per-builder `get`), not
+    /// just the last occurrence.
+    #[test]
+    fn duplicate_column_names_replicate_to_all_slots() {
+        let columns = vec![col("a"), col("a")];
+        let rows = vec![
+            row(&[("a", Value::Integer(1))]),
+            row(&[("a", Value::Null)]),
+            row(&[]), // absent
+        ];
+        let cols = transpose_columns(&columns, &rows);
+        assert_eq!(cols.len(), 2);
+        // Both output columns must carry identical values.
+        assert_eq!(cols[0][0], Some(&Value::Integer(1)));
+        assert_eq!(cols[1][0], Some(&Value::Integer(1)));
+        assert_eq!(cols[0][1], Some(&Value::Null));
+        assert_eq!(cols[1][1], Some(&Value::Null));
+        assert_eq!(cols[0][2], None);
+        assert_eq!(cols[1][2], None);
     }
 
     /// Empty inputs: no columns / no rows produce well-formed empty output.

--- a/cqlite-core/src/export/arrow_convert.rs
+++ b/cqlite-core/src/export/arrow_convert.rs
@@ -1285,17 +1285,27 @@ pub(crate) fn data_type_to_arrow(data_type: &DataType) -> ArrowDataType {
 // =========================================================================
 
 /// Convert all rows to Arrow arrays (one per column).
+///
+/// Per-column accessors are resolved ONCE via [`transpose_columns`] (issue #1495
+/// / parser epic J1): each builder gets its column's pre-resolved, row-aligned
+/// slice instead of re-hashing `col.name` per cell. Output is byte-identical.
+///
+/// [`transpose_columns`]: super::arrow_columnar::transpose_columns
 pub(crate) fn convert_to_arrays(
     columns: &[ColumnInfo],
     rows: &[QueryRow],
 ) -> Result<Vec<ArrayRef>, ArrowConvertError> {
+    let columnar = super::arrow_columnar::transpose_columns(columns, rows);
     columns
         .iter()
-        .map(|col| convert_column_to_array(col, rows))
+        .zip(columnar.iter())
+        .map(|(col, cells)| convert_column_to_array(col, cells))
         .collect()
 }
 
-/// Convert a single column across all rows to an Arrow array.
+/// Convert a single column's pre-resolved, row-aligned value slice to an Arrow
+/// array. `cells[i]` is row `i`'s value (`None` when the column is absent),
+/// resolved once by the transpose — no per-cell `col.name` hashing (issue #1495).
 ///
 /// When `col.cql_type` is `Some` and the type is a high-fidelity scalar
 /// (date, time, decimal, varint, duration, uuid/timeuuid, inet, counter),
@@ -1309,32 +1319,28 @@ pub(crate) fn convert_to_arrays(
 /// dispatch.
 pub(crate) fn convert_column_to_array(
     col: &ColumnInfo,
-    rows: &[QueryRow],
+    cells: Cells,
 ) -> Result<ArrayRef, ArrowConvertError> {
     // High-fidelity CQL-type dispatch
     if let Some(cql_type) = &col.cql_type {
         // Check if the (possibly Frozen-wrapped) type is a List or Set.
         let effective = unwrap_frozen_type(cql_type);
         match effective {
-            CqlType::Date => return build_date32_array(col, rows),
-            CqlType::Time => return build_time64_ns_array(col, rows),
-            CqlType::Decimal => return build_decimal128_array(col, rows),
-            CqlType::Varint => return build_varint_as_decimal128_array(col, rows),
-            CqlType::Duration => return build_duration_utf8_array(col, rows),
-            CqlType::Uuid | CqlType::TimeUuid => return build_uuid_fixed_binary_array(col, rows),
-            CqlType::Inet => return build_inet_utf8_array(col, rows),
-            CqlType::Counter => return build_int64_array(col, rows),
+            CqlType::Date => return build_date32_array(col, cells),
+            CqlType::Time => return build_time64_ns_array(col, cells),
+            CqlType::Decimal => return build_decimal128_array(col, cells),
+            CqlType::Varint => return build_varint_as_decimal128_array(col, cells),
+            CqlType::Duration => return build_duration_utf8_array(col, cells),
+            CqlType::Uuid | CqlType::TimeUuid => return build_uuid_fixed_binary_array(col, cells),
+            CqlType::Inet => return build_inet_utf8_array(col, cells),
+            CqlType::Counter => return build_int64_array(col, cells),
             // List, Set, Map, Tuple, and Udt: use the recursive typed builder.
             CqlType::List(_)
             | CqlType::Set(_)
             | CqlType::Map(_, _)
             | CqlType::Tuple(_)
             | CqlType::Udt(_, _) => {
-                let column_values: Vec<Option<&Value>> = rows
-                    .iter()
-                    .map(|row| row.values.get(col.name.as_str()))
-                    .collect();
-                return build_typed_value_array(cql_type, &column_values);
+                return build_typed_value_array(cql_type, cells);
             }
             // All other complex/collection types fall through to the flat dispatch.
             _ => {}
@@ -1343,25 +1349,25 @@ pub(crate) fn convert_column_to_array(
 
     // Flat data_type dispatch (legacy path)
     match &col.data_type {
-        DataType::Boolean => build_boolean_array(col, rows),
-        DataType::TinyInt => build_int8_array(col, rows),
-        DataType::SmallInt => build_int16_array(col, rows),
-        DataType::Integer => build_int32_array(col, rows),
-        DataType::BigInt => build_int64_array(col, rows),
-        DataType::Float32 => build_float32_array(col, rows),
-        DataType::Float => build_float64_array(col, rows),
-        DataType::Text | DataType::Json => build_string_array(col, rows),
-        DataType::Blob => build_binary_array(col, rows),
-        DataType::Timestamp => build_timestamp_array(col, rows),
-        DataType::Uuid => build_uuid_array(col, rows),
-        DataType::List | DataType::Set => build_list_array(col, rows),
-        DataType::Map => build_map_array(col, rows),
+        DataType::Boolean => build_boolean_array(col, cells),
+        DataType::TinyInt => build_int8_array(col, cells),
+        DataType::SmallInt => build_int16_array(col, cells),
+        DataType::Integer => build_int32_array(col, cells),
+        DataType::BigInt => build_int64_array(col, cells),
+        DataType::Float32 => build_float32_array(col, cells),
+        DataType::Float => build_float64_array(col, cells),
+        DataType::Text | DataType::Json => build_string_array(col, cells),
+        DataType::Blob => build_binary_array(col, cells),
+        DataType::Timestamp => build_timestamp_array(col, cells),
+        DataType::Uuid => build_uuid_array(col, cells),
+        DataType::List | DataType::Set => build_list_array(col, cells),
+        DataType::Map => build_map_array(col, cells),
         DataType::Tuple
         | DataType::Udt
         | DataType::Frozen
         | DataType::Tombstone
         | DataType::Null => {
-            build_string_array(col, rows) // Fallback to string representation
+            build_string_array(col, cells) // Fallback to string representation
         }
     }
 }
@@ -1379,85 +1385,82 @@ pub(crate) use super::arrow_decimal::rescale_decimal;
 // Type-specific array builders (flat / column-based)
 // =========================================================================
 
-fn build_boolean_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<bool>> = rows
+/// A column's pre-resolved, row-aligned cell slice (issue #1495): element `i` is
+/// row `i`'s value for the column, or `None` when absent. Produced once by
+/// [`transpose_columns`](super::arrow_columnar::transpose_columns).
+type Cells<'a> = &'a [Option<&'a Value>];
+
+fn build_boolean_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<bool>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Boolean(b)) => Ok(Some(*b)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Boolean value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Boolean(b)) => Ok(Some(*b)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Boolean value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<bool>>, ArrowConvertError>>()?;
     Ok(Arc::new(BooleanArray::from(values)))
 }
 
-fn build_int8_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<i8>> = rows
+fn build_int8_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<i8>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::TinyInt(i)) => Ok(Some(*i)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected TinyInt value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::TinyInt(i)) => Ok(Some(*i)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected TinyInt value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<i8>>, ArrowConvertError>>()?;
     Ok(Arc::new(Int8Array::from(values)))
 }
 
-fn build_int16_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<i16>> = rows
+fn build_int16_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<i16>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::SmallInt(i)) => Ok(Some(*i)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected SmallInt value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::SmallInt(i)) => Ok(Some(*i)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected SmallInt value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<i16>>, ArrowConvertError>>()?;
     Ok(Arc::new(Int16Array::from(values)))
 }
 
-fn build_int32_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
+fn build_int32_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
     // The same-width `Date`→i32 acceptance is only valid on the OPAQUE path
     // (`cql_type = None`): an authoritative `date` column routes to
     // `build_date32_array`, so an authoritative `int` column carrying a `Date`
     // is a genuine mismatch that must fail closed.
     let allow_compat = col.cql_type.is_none();
-    let values: Vec<Option<i32>> = rows
+    let values: Vec<Option<i32>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Integer(i)) => Ok(Some(*i)),
-                Some(Value::Date(d)) if allow_compat => Ok(Some(*d)), // Date is stored as i32 days
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Int value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Integer(i)) => Ok(Some(*i)),
+            Some(Value::Date(d)) if allow_compat => Ok(Some(*d)), // Date is stored as i32 days
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Int value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<i32>>, ArrowConvertError>>()?;
     Ok(Arc::new(Int32Array::from(values)))
 }
 
-fn build_int64_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
+fn build_int64_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
     // `build_int64_array` backs authoritative `bigint` and `counter` columns
     // plus the opaque (`cql_type = None`) path. `Counter` is legitimate for a
     // `counter` column; the same-width `Time`→i64 acceptance and cross-accepting
@@ -1466,67 +1469,61 @@ fn build_int64_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, Ar
     let effective = col.cql_type.as_ref().map(unwrap_frozen_type);
     let allow_counter = matches!(effective, None | Some(CqlType::Counter));
     let allow_compat = effective.is_none();
-    let values: Vec<Option<i64>> = rows
+    let values: Vec<Option<i64>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::BigInt(i)) => Ok(Some(*i)),
-                Some(Value::Counter(c)) if allow_counter => Ok(Some(*c)),
-                Some(Value::Time(t)) if allow_compat => Ok(Some(*t)), // Time is stored as i64 nanos
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected BigInt value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::BigInt(i)) => Ok(Some(*i)),
+            Some(Value::Counter(c)) if allow_counter => Ok(Some(*c)),
+            Some(Value::Time(t)) if allow_compat => Ok(Some(*t)), // Time is stored as i64 nanos
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected BigInt value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<i64>>, ArrowConvertError>>()?;
     Ok(Arc::new(Int64Array::from(values)))
 }
 
-fn build_float32_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<f32>> = rows
+fn build_float32_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<f32>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Float32(f)) => Ok(Some(*f)),
-                // A CQL `float` (32-bit) may be carried as the wider `Value::Float`
-                // (f64) by the decode path; narrow it back (lossless for genuine
-                // f32 values), mirroring build_float64_array which accepts both.
-                Some(Value::Float(f)) => Ok(Some(*f as f32)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Float value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Float32(f)) => Ok(Some(*f)),
+            // A CQL `float` (32-bit) may be carried as the wider `Value::Float`
+            // (f64) by the decode path; narrow it back (lossless for genuine
+            // f32 values), mirroring build_float64_array which accepts both.
+            Some(Value::Float(f)) => Ok(Some(*f as f32)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Float value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<f32>>, ArrowConvertError>>()?;
     Ok(Arc::new(Float32Array::from(values)))
 }
 
-fn build_float64_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<f64>> = rows
+fn build_float64_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<f64>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Float(f)) => Ok(Some(*f)),
-                Some(Value::Float32(f)) => Ok(Some(*f as f64)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Double value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Float(f)) => Ok(Some(*f)),
+            Some(Value::Float32(f)) => Ok(Some(*f as f64)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Double value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<f64>>, ArrowConvertError>>()?;
     Ok(Arc::new(Float64Array::from(values)))
 }
 
-fn build_string_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
+fn build_string_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
     // When the schema carries an AUTHORITATIVE text type, fail closed on a
     // wrong-variant value (mirroring the other scalar builders) rather than
     // silently string-formatting it. For `cql_type = None` or opaque types
@@ -1541,18 +1538,16 @@ fn build_string_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, A
         // (or null/error). Guard on BORROWED &str slices before StringArray::from
         // copies them, so the fail-closed path never clones ~2 GiB of raw text
         // just to reject it (issue #2235).
-        let refs: Vec<Option<&str>> = rows
+        let refs: Vec<Option<&str>> = cells
             .iter()
-            .map(
-                |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                    None | Some(Value::Null) => Ok(None),
-                    Some(Value::Text(s)) => Ok(Some(s.as_str())),
-                    Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                        "column '{}': expected Text value, got {:?}",
-                        col.name, other
-                    ))),
-                },
-            )
+            .map(|cell| match unwrap_frozen_value(*cell) {
+                None | Some(Value::Null) => Ok(None),
+                Some(Value::Text(s)) => Ok(Some(s.as_str())),
+                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                    "column '{}': expected Text value, got {:?}",
+                    col.name, other
+                ))),
+            })
             .collect::<Result<Vec<Option<&str>>, ArrowConvertError>>()?;
         checked_string_offsets(&refs)?;
         return Ok(Arc::new(StringArray::from(refs)));
@@ -1562,17 +1557,15 @@ fn build_string_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, A
     // lengths before any owned copy is made (issue #2235). Only the small,
     // computed `format_value`/`Json` representations are materialized as owned
     // `Cow::Owned` strings — those are never a raw multi-GiB payload.
-    let values: Vec<Option<Cow<str>>> = rows
+    let values: Vec<Option<Cow<str>>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Null) => Ok(None),
-                Some(Value::Text(s)) => Ok(Some(Cow::Borrowed(s.as_str()))),
-                Some(Value::Json(j)) => Ok(Some(Cow::Owned(j.to_string()))),
-                Some(other) => Ok(Some(Cow::Owned(ValueFormatter::format_value(other)))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Null) => Ok(None),
+            Some(Value::Text(s)) => Ok(Some(Cow::Borrowed(s.as_str()))),
+            Some(Value::Json(j)) => Ok(Some(Cow::Owned(j.to_string()))),
+            Some(other) => Ok(Some(Cow::Owned(ValueFormatter::format_value(other)))),
+        })
         .collect::<Result<Vec<Option<Cow<str>>>, ArrowConvertError>>()?;
     checked_string_offsets(&values)?;
     Ok(Arc::new(StringArray::from_iter(
@@ -1580,62 +1573,53 @@ fn build_string_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, A
     )))
 }
 
-fn build_binary_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<&[u8]>> = rows
+fn build_binary_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<&[u8]>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Blob(b)) => Ok(Some(b.as_slice())),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Blob value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Blob(b)) => Ok(Some(b.as_slice())),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Blob value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<&[u8]>>, ArrowConvertError>>()?;
     checked_binary_offsets(&values)?;
     Ok(Arc::new(BinaryArray::from(values)))
 }
 
-fn build_timestamp_array(
-    col: &ColumnInfo,
-    rows: &[QueryRow],
-) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<i64>> = rows
+fn build_timestamp_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<i64>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Timestamp(ts)) => Ok(Some(*ts)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Timestamp value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Timestamp(ts)) => Ok(Some(*ts)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Timestamp value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<i64>>, ArrowConvertError>>()?;
     Ok(Arc::new(
         TimestampMillisecondArray::from(values).with_timezone("UTC"),
     ))
 }
 
-fn build_uuid_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<[u8; 16]>> = rows
+fn build_uuid_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<[u8; 16]>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Uuid(uuid)) => Ok(Some(*uuid)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Uuid value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Uuid(uuid)) => Ok(Some(*uuid)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Uuid value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<[u8; 16]>>, ArrowConvertError>>()?;
 
     let mut builder = arrow::array::FixedSizeBinaryBuilder::new(16);
@@ -1653,57 +1637,47 @@ fn build_uuid_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, Arr
 // =========================================================================
 
 /// Build an Arrow `Date32` array from `Value::Date(i32)`.
-fn build_date32_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<i32>> = rows
+fn build_date32_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<i32>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Date(days)) => Ok(Some(*days)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Date value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Date(days)) => Ok(Some(*days)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Date value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<i32>>, ArrowConvertError>>()?;
     Ok(Arc::new(Date32Array::from(values)))
 }
 
 /// Build an Arrow `Time64(Nanosecond)` array from `Value::Time(i64)`.
-fn build_time64_ns_array(
-    col: &ColumnInfo,
-    rows: &[QueryRow],
-) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<i64>> = rows
+fn build_time64_ns_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<i64>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Time(nanos)) => Ok(Some(*nanos)),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Time value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Time(nanos)) => Ok(Some(*nanos)),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Time value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<i64>>, ArrowConvertError>>()?;
     Ok(Arc::new(Time64NanosecondArray::from(values)))
 }
 
 /// Build an Arrow `Decimal128(38, DECIMAL_FIXED_SCALE)` array from
 /// `Value::Decimal { scale, unscaled }`.
-fn build_decimal128_array(
-    col: &ColumnInfo,
-    rows: &[QueryRow],
-) -> Result<ArrayRef, ArrowConvertError> {
+fn build_decimal128_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
     let mut builder = arrow::array::Decimal128Builder::new()
         .with_precision_and_scale(DECIMAL_MAX_PRECISION, DECIMAL_FIXED_SCALE as i8)?;
 
-    for row in rows {
-        match unwrap_frozen_value(row.values.get(col.name.as_str())) {
+    for cell in cells {
+        match unwrap_frozen_value(*cell) {
             Some(Value::Decimal { scale, unscaled }) => {
                 let rescaled = rescale_decimal(*scale, unscaled).map_err(|e| {
                     ArrowConvertError::InvalidValue(format!("Column '{}': {e}", col.name))
@@ -1727,15 +1701,15 @@ fn build_decimal128_array(
 /// Build an Arrow `Decimal128(38, 0)` array from `Value::Varint(Vec<u8>)`.
 fn build_varint_as_decimal128_array(
     col: &ColumnInfo,
-    rows: &[QueryRow],
+    cells: Cells,
 ) -> Result<ArrayRef, ArrowConvertError> {
     use num_bigint::BigInt;
 
     let mut builder = arrow::array::Decimal128Builder::new()
         .with_precision_and_scale(DECIMAL_MAX_PRECISION, 0)?;
 
-    for row in rows {
-        match unwrap_frozen_value(row.values.get(col.name.as_str())) {
+    for cell in cells {
+        match unwrap_frozen_value(*cell) {
             Some(Value::Varint(bytes)) => {
                 if bytes.is_empty() {
                     builder.append_value(0);
@@ -1779,21 +1753,19 @@ fn build_varint_as_decimal128_array(
 /// Build an Arrow `Utf8` array from `Value::Duration { months, days, nanos }`.
 fn build_duration_utf8_array(
     col: &ColumnInfo,
-    rows: &[QueryRow],
+    cells: Cells,
 ) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<String>> = rows
+    let values: Vec<Option<String>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(v @ Value::Duration { .. }) => Ok(Some(ValueFormatter::format_value(v))),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Duration value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(v @ Value::Duration { .. }) => Ok(Some(ValueFormatter::format_value(v))),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Duration value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
     checked_string_offsets(&values)?;
     Ok(Arc::new(StringArray::from(values)))
@@ -1802,11 +1774,11 @@ fn build_duration_utf8_array(
 /// Build an Arrow `FixedSizeBinary(16)` array from `Value::Uuid([u8; 16])`.
 fn build_uuid_fixed_binary_array(
     col: &ColumnInfo,
-    rows: &[QueryRow],
+    cells: Cells,
 ) -> Result<ArrayRef, ArrowConvertError> {
     let mut builder = arrow::array::FixedSizeBinaryBuilder::new(16);
-    for row in rows {
-        match unwrap_frozen_value(row.values.get(col.name.as_str())) {
+    for cell in cells {
+        match unwrap_frozen_value(*cell) {
             Some(Value::Uuid(bytes)) => builder.append_value(bytes)?,
             Some(Value::Null) | None => builder.append_null(),
             Some(other) => {
@@ -1821,38 +1793,33 @@ fn build_uuid_fixed_binary_array(
 }
 
 /// Build an Arrow `Utf8` array from `Value::Inet(Vec<u8>)`.
-fn build_inet_utf8_array(
-    col: &ColumnInfo,
-    rows: &[QueryRow],
-) -> Result<ArrayRef, ArrowConvertError> {
-    let values: Vec<Option<String>> = rows
+fn build_inet_utf8_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
+    let values: Vec<Option<String>> = cells
         .iter()
-        .map(
-            |row| match unwrap_frozen_value(row.values.get(col.name.as_str())) {
-                None => Ok(None),
-                Some(Value::Inet(bytes)) => Ok(Some(ValueFormatter::format_value(&Value::Inet(
-                    bytes.clone(),
-                )))),
-                Some(Value::Null) => Ok(None),
-                Some(other) => Err(ArrowConvertError::InvalidValue(format!(
-                    "column '{}': expected Inet value, got {:?}",
-                    col.name, other
-                ))),
-            },
-        )
+        .map(|cell| match unwrap_frozen_value(*cell) {
+            None => Ok(None),
+            Some(Value::Inet(bytes)) => Ok(Some(ValueFormatter::format_value(&Value::Inet(
+                bytes.clone(),
+            )))),
+            Some(Value::Null) => Ok(None),
+            Some(other) => Err(ArrowConvertError::InvalidValue(format!(
+                "column '{}': expected Inet value, got {:?}",
+                col.name, other
+            ))),
+        })
         .collect::<Result<Vec<Option<String>>, ArrowConvertError>>()?;
     checked_string_offsets(&values)?;
     Ok(Arc::new(StringArray::from(values)))
 }
 
-fn build_list_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
+fn build_list_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
     // For lists/sets, we serialize elements as strings for simplicity
     let mut offsets: Vec<i32> = vec![0];
     let mut values: Vec<Option<String>> = Vec::new();
     let mut null_bitmap: Vec<bool> = Vec::new();
 
-    for row in rows {
-        match unwrap_frozen_value(row.values.get(col.name.as_str())) {
+    for cell in cells {
+        match unwrap_frozen_value(*cell) {
             Some(Value::List(items)) | Some(Value::Set(items)) => {
                 null_bitmap.push(true);
                 for item in items {
@@ -1887,15 +1854,15 @@ fn build_list_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, Arr
     )))
 }
 
-fn build_map_array(col: &ColumnInfo, rows: &[QueryRow]) -> Result<ArrayRef, ArrowConvertError> {
+fn build_map_array(col: &ColumnInfo, cells: Cells) -> Result<ArrayRef, ArrowConvertError> {
     // For maps, serialize key-value pairs as structs
     let mut offsets: Vec<i32> = vec![0];
     let mut keys: Vec<Option<String>> = Vec::new();
     let mut values: Vec<Option<String>> = Vec::new();
     let mut null_bitmap: Vec<bool> = Vec::new();
 
-    for row in rows {
-        match unwrap_frozen_value(row.values.get(col.name.as_str())) {
+    for cell in cells {
+        match unwrap_frozen_value(*cell) {
             Some(Value::Map(pairs)) => {
                 null_bitmap.push(true);
                 for (k, v) in pairs {

--- a/cqlite-core/src/export/mod.rs
+++ b/cqlite-core/src/export/mod.rs
@@ -38,6 +38,12 @@
 #[cfg(feature = "arrow")]
 pub mod arrow_convert;
 
+// Per-column accessor resolution for Arrow conversion (issue #1495, AE1): resolves
+// each schema column once and transposes rows into per-column value slices,
+// killing the per-cell `values.get(name)` string-hash lookup (parser epic J1).
+#[cfg(feature = "arrow")]
+pub(crate) mod arrow_columnar;
+
 // CQL decimal rescaling for Arrow/Parquet export (split out of `arrow_convert`,
 // epic #1116; issue #1755 bounded/fail-closed fix).
 #[cfg(feature = "arrow")]

--- a/cqlite-core/tests/issue_1495_arrow_accessor_parity.rs
+++ b/cqlite-core/tests/issue_1495_arrow_accessor_parity.rs
@@ -322,14 +322,56 @@ fn column_reorder_produces_permuted_but_equal_arrays() {
 
     for (i, c) in reordered.iter().enumerate() {
         let orig_idx = columns.iter().position(|o| o.name == c.name).unwrap();
+        // Compare full array CONTENTS (values + null bitmap + type), not just
+        // null_count/len — a value-swap or mis-alignment bug must surface here.
         assert_eq!(
-            batch_rev.column(i).null_count(),
-            batch.column(orig_idx).null_count(),
-            "column '{}' must be identical regardless of schema position",
+            batch_rev.column(i).to_data(),
+            batch.column(orig_idx).to_data(),
+            "column '{}' must be byte-identical regardless of schema position",
             c.name
         );
-        assert_eq!(batch_rev.column(i).len(), batch.column(orig_idx).len(),);
     }
+}
+
+/// Duplicate result-column names (e.g. `SELECT a, a` or `SELECT a AS x, b AS x`)
+/// are a REACHABLE input — `QueryMetadata.columns` is built one-per-projection
+/// with no dedup. Main resolved each builder's `col.name` independently, so every
+/// same-named output column carried the same row value. The accessor hoist must
+/// preserve that: BOTH output arrays populated identically, not just the last.
+#[test]
+fn duplicate_named_columns_populate_all_identically() {
+    let columns = vec![
+        col("dup", DataType::Integer, None),
+        col("dup", DataType::Integer, None),
+    ];
+    let rows = vec![
+        row(&[("dup", Value::Integer(42))]),
+        row(&[("dup", Value::Null)]),
+        row(&[]), // absent → Arrow null
+    ];
+    let batch = rows_to_record_batch(&columns, &rows).expect("conversion");
+
+    assert_eq!(batch.num_columns(), 2);
+    assert_eq!(batch.num_rows(), 3);
+
+    // Both duplicate-named columns must be byte-identical (same values, same
+    // null bitmap) — the earlier duplicate must NOT be all-null.
+    assert_eq!(
+        batch.column(0).to_data(),
+        batch.column(1).to_data(),
+        "duplicate-named output columns must be populated identically",
+    );
+
+    use arrow::array::Int32Array;
+    let ints = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    assert_eq!(ints.value(0), 42);
+    assert!(ints.is_null(1)); // explicit Null
+    assert!(ints.is_null(2)); // absent
+    assert_eq!(batch.column(0).null_count(), 2);
 }
 
 /// Type-mismatch fail-closed behaviour must survive the refactor: a wrong-variant

--- a/cqlite-core/tests/issue_1495_arrow_accessor_parity.rs
+++ b/cqlite-core/tests/issue_1495_arrow_accessor_parity.rs
@@ -1,0 +1,342 @@
+//! Output-equivalence guard for issue #1495 (AE1) — the load-bearing parity net
+//! for the "resolve per-column accessor once" refactor.
+//!
+//! **What #1495 does**: every Arrow builder in `export::arrow_convert` used to
+//! do `row.values.get(&col.name)` PER CELL — an N·M string-hash lookup into the
+//! per-row `HashMap<Arc<str>, Value>`. AE1 resolves each schema column to a
+//! positional accessor ONCE (O(columns) name hashes) and transposes rows into a
+//! per-column value slice in a single pass, then feeds each builder its
+//! pre-resolved slice. This is a PURE performance refactor: the emitted Arrow
+//! `RecordBatch` — schema, array types, lengths, null bitmaps, and every value —
+//! MUST be byte-identical to the pre-refactor output.
+//!
+//! **This test** builds a wide, multi-row, mixed-type input (every builder arm:
+//! scalars, high-fidelity CQL types, collections, nulls, and absent columns) and
+//! asserts the `RecordBatch` is exactly what the conversion produced. It passes
+//! on `main` (per-cell `.get()`) and MUST continue to pass after the accessor
+//! hoist — the guard is "output unchanged", verbatim.
+//!
+//! Requires the `arrow` feature (the conversion module is `#[cfg(feature =
+//! "arrow")]`).
+
+#![cfg(feature = "arrow")]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::Array;
+use cqlite_core::export::rows_to_record_batch;
+use cqlite_core::query::{ColumnInfo, QueryRow};
+use cqlite_core::schema::CqlType;
+use cqlite_core::types::{DataType, Value};
+use cqlite_core::RowKey;
+
+fn col(name: &str, data_type: DataType, cql_type: Option<CqlType>) -> ColumnInfo {
+    ColumnInfo {
+        name: name.to_string(),
+        data_type,
+        nullable: true,
+        position: 0,
+        table_name: None,
+        cql_type,
+    }
+}
+
+/// Build a `QueryRow` from an ordered list of (name, value) pairs. A column
+/// omitted from `pairs` is ABSENT (distinct from `Value::Null`) — both must map
+/// to Arrow null, which is exactly the property the accessor hoist must preserve.
+fn row(pairs: &[(&str, Value)]) -> QueryRow {
+    let mut values: HashMap<Arc<str>, Value> = HashMap::new();
+    for (name, value) in pairs {
+        values.insert(Arc::from(*name), value.clone());
+    }
+    QueryRow::with_interned_values(RowKey::new(Vec::new()), values)
+}
+
+/// A wide, mixed-type schema exercising every builder arm reached by
+/// `convert_column_to_array`: flat scalars, high-fidelity CQL scalars, and the
+/// recursive collection path.
+fn wide_schema() -> Vec<ColumnInfo> {
+    vec![
+        col("c_bool", DataType::Boolean, None),
+        col("c_tinyint", DataType::TinyInt, None),
+        col("c_smallint", DataType::SmallInt, None),
+        col("c_int", DataType::Integer, None),
+        col("c_bigint", DataType::BigInt, None),
+        col("c_float", DataType::Float32, None),
+        col("c_double", DataType::Float, None),
+        col("c_text", DataType::Text, Some(CqlType::Text)),
+        col("c_text_opaque", DataType::Text, None),
+        col("c_blob", DataType::Blob, None),
+        col("c_ts", DataType::Timestamp, None),
+        col("c_uuid_flat", DataType::Uuid, None),
+        col("c_date", DataType::Timestamp, Some(CqlType::Date)),
+        col("c_time", DataType::BigInt, Some(CqlType::Time)),
+        col("c_decimal", DataType::Text, Some(CqlType::Decimal)),
+        col("c_varint", DataType::Text, Some(CqlType::Varint)),
+        col("c_duration", DataType::Text, Some(CqlType::Duration)),
+        col("c_uuid_fixed", DataType::Uuid, Some(CqlType::Uuid)),
+        col("c_inet", DataType::Text, Some(CqlType::Inet)),
+        col("c_counter", DataType::BigInt, Some(CqlType::Counter)),
+        col(
+            "c_list_typed",
+            DataType::List,
+            Some(CqlType::List(Box::new(CqlType::Int))),
+        ),
+        col(
+            "c_map_typed",
+            DataType::Map,
+            Some(CqlType::Map(
+                Box::new(CqlType::Text),
+                Box::new(CqlType::Int),
+            )),
+        ),
+        col("c_list_flat", DataType::List, None),
+        col("c_map_flat", DataType::Map, None),
+    ]
+}
+
+/// Rows covering: fully-populated, all-null, and sparse/absent columns. The
+/// deliberate mix of `Value::Null`, absent columns, and populated values across
+/// rows is what makes the per-column transpose non-trivial — each column must
+/// still line up with the right row after the accessor hoist.
+fn wide_rows() -> Vec<QueryRow> {
+    vec![
+        row(&[
+            ("c_bool", Value::Boolean(true)),
+            ("c_tinyint", Value::TinyInt(7)),
+            ("c_smallint", Value::SmallInt(-3)),
+            ("c_int", Value::Integer(42)),
+            ("c_bigint", Value::BigInt(1_000_000_000_000)),
+            ("c_float", Value::Float32(1.5)),
+            ("c_double", Value::Float(2.25)),
+            ("c_text", Value::Text("hello".into())),
+            ("c_text_opaque", Value::Text("opaque".into())),
+            ("c_blob", Value::Blob(vec![0xde, 0xad, 0xbe, 0xef])),
+            ("c_ts", Value::Timestamp(1_700_000_000_000)),
+            ("c_uuid_flat", Value::Uuid([1u8; 16])),
+            ("c_date", Value::Date(19_000)),
+            ("c_time", Value::Time(123_456_789)),
+            (
+                "c_decimal",
+                Value::Decimal {
+                    scale: 2,
+                    unscaled: vec![0x30, 0x39], // 12345
+                },
+            ),
+            ("c_varint", Value::Varint(vec![0x01, 0x00])), // 256
+            (
+                "c_duration",
+                Value::Duration {
+                    months: 1,
+                    days: 2,
+                    nanos: 3,
+                },
+            ),
+            ("c_uuid_fixed", Value::Uuid([2u8; 16])),
+            ("c_inet", Value::Inet(vec![127, 0, 0, 1])),
+            ("c_counter", Value::Counter(99)),
+            (
+                "c_list_typed",
+                Value::List(vec![Value::Integer(1), Value::Integer(2)]),
+            ),
+            (
+                "c_map_typed",
+                Value::Map(vec![(Value::Text("k".into()), Value::Integer(5))]),
+            ),
+            (
+                "c_list_flat",
+                Value::List(vec![Value::Text("a".into()), Value::Text("b".into())]),
+            ),
+            (
+                "c_map_flat",
+                Value::Map(vec![(Value::Text("x".into()), Value::Text("y".into()))]),
+            ),
+        ]),
+        // All-null row: every column present but Null.
+        row(&[
+            ("c_bool", Value::Null),
+            ("c_tinyint", Value::Null),
+            ("c_smallint", Value::Null),
+            ("c_int", Value::Null),
+            ("c_bigint", Value::Null),
+            ("c_float", Value::Null),
+            ("c_double", Value::Null),
+            ("c_text", Value::Null),
+            ("c_text_opaque", Value::Null),
+            ("c_blob", Value::Null),
+            ("c_ts", Value::Null),
+            ("c_uuid_flat", Value::Null),
+            ("c_date", Value::Null),
+            ("c_time", Value::Null),
+            ("c_decimal", Value::Null),
+            ("c_varint", Value::Null),
+            ("c_duration", Value::Null),
+            ("c_uuid_fixed", Value::Null),
+            ("c_inet", Value::Null),
+            ("c_counter", Value::Null),
+            ("c_list_typed", Value::Null),
+            ("c_map_typed", Value::Null),
+            ("c_list_flat", Value::Null),
+            ("c_map_flat", Value::Null),
+        ]),
+        // Sparse row: most columns ABSENT (not even Null) — must still map to
+        // Arrow null and stay aligned with the other rows.
+        row(&[
+            ("c_int", Value::Integer(-1)),
+            ("c_text", Value::Text("only-two".into())),
+        ]),
+        // Second populated row with different values so column/row alignment is
+        // observable (a transpose bug that shifts values would surface here).
+        row(&[
+            ("c_bool", Value::Boolean(false)),
+            ("c_int", Value::Integer(7)),
+            ("c_bigint", Value::BigInt(-5)),
+            ("c_text", Value::Text("world".into())),
+            ("c_blob", Value::Blob(vec![0x00])),
+            ("c_list_typed", Value::List(vec![Value::Integer(9)])),
+        ]),
+    ]
+}
+
+/// The canonical, load-bearing parity assertion: the full `RecordBatch` produced
+/// for a wide mixed-type input is exactly the expected shape. Any accessor-hoist
+/// regression that mis-aligns a column, drops a null, or changes a value fails
+/// here. Passes on `main`; must keep passing after #1495.
+#[test]
+fn wide_mixed_batch_is_unchanged() {
+    let columns = wide_schema();
+    let rows = wide_rows();
+    let batch = rows_to_record_batch(&columns, &rows).expect("conversion must succeed");
+
+    // Shape: one column per schema column, one row per input row.
+    assert_eq!(batch.num_columns(), columns.len());
+    assert_eq!(batch.num_rows(), rows.len());
+
+    // Field names/order match the schema exactly.
+    for (i, c) in columns.iter().enumerate() {
+        assert_eq!(batch.schema().field(i).name(), &c.name);
+    }
+
+    // Per-column null counts pin value/null alignment across the transpose.
+    // Row 0 populated, row 1 all-null, row 2 sparse (only c_int + c_text), row 3
+    // partial. Expected null count per column below is the count of rows where
+    // the value is Null or the column is absent.
+    let expected_nulls: &[(&str, usize)] = &[
+        ("c_bool", 2),    // rows 1(null),2(absent)
+        ("c_tinyint", 3), // rows 1,2,3
+        ("c_smallint", 3),
+        ("c_int", 1),    // only row 1 null; present in 0,2,3
+        ("c_bigint", 2), // rows 1,2
+        ("c_float", 3),
+        ("c_double", 3),
+        ("c_text", 1), // only row 1 null; present in 0,2,3
+        ("c_text_opaque", 3),
+        ("c_blob", 2), // rows 1,2
+        ("c_ts", 3),
+        ("c_uuid_flat", 3),
+        ("c_date", 3),
+        ("c_time", 3),
+        ("c_decimal", 3),
+        ("c_varint", 3),
+        ("c_duration", 3),
+        ("c_uuid_fixed", 3),
+        ("c_inet", 3),
+        ("c_counter", 3),
+        ("c_list_typed", 2), // rows 1,2
+        ("c_map_typed", 3),
+        ("c_list_flat", 3),
+        ("c_map_flat", 3),
+    ];
+    for (name, want) in expected_nulls {
+        let idx = columns.iter().position(|c| &c.name == name).unwrap();
+        assert_eq!(
+            batch.column(idx).null_count(),
+            *want,
+            "column '{name}' null_count mismatch",
+        );
+    }
+
+    // Spot-check load-bearing values by downcast (value fidelity + alignment).
+    use arrow::array::{BooleanArray, Int32Array, Int64Array, StringArray};
+
+    let bool_idx = columns.iter().position(|c| c.name == "c_bool").unwrap();
+    let bools = batch
+        .column(bool_idx)
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .unwrap();
+    assert!(bools.value(0)); // row 0 = true
+    assert!(bools.is_null(1)); // row 1 null
+    assert!(bools.is_null(2)); // row 2 absent
+    assert!(!bools.value(3)); // row 3 = false
+
+    let int_idx = columns.iter().position(|c| c.name == "c_int").unwrap();
+    let ints = batch
+        .column(int_idx)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    assert_eq!(ints.value(0), 42);
+    assert!(ints.is_null(1));
+    assert_eq!(ints.value(2), -1);
+    assert_eq!(ints.value(3), 7);
+
+    let bigint_idx = columns.iter().position(|c| c.name == "c_bigint").unwrap();
+    let bigints = batch
+        .column(bigint_idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(bigints.value(0), 1_000_000_000_000);
+    assert!(bigints.is_null(1));
+    assert!(bigints.is_null(2));
+    assert_eq!(bigints.value(3), -5);
+
+    let text_idx = columns.iter().position(|c| c.name == "c_text").unwrap();
+    let texts = batch
+        .column(text_idx)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(texts.value(0), "hello");
+    assert!(texts.is_null(1));
+    assert_eq!(texts.value(2), "only-two");
+    assert_eq!(texts.value(3), "world");
+}
+
+/// Column ORDER independence: converting the same rows under a schema whose
+/// columns are reordered must produce the same per-column arrays (just permuted).
+/// This directly exercises the "resolve accessor per column" contract — the
+/// accessor must bind to the column's name, not a fixed position.
+#[test]
+fn column_reorder_produces_permuted_but_equal_arrays() {
+    let columns = wide_schema();
+    let rows = wide_rows();
+    let batch = rows_to_record_batch(&columns, &rows).expect("conversion");
+
+    // Reverse the schema.
+    let mut reordered = columns.clone();
+    reordered.reverse();
+    let batch_rev = rows_to_record_batch(&reordered, &rows).expect("conversion (reordered)");
+
+    for (i, c) in reordered.iter().enumerate() {
+        let orig_idx = columns.iter().position(|o| o.name == c.name).unwrap();
+        assert_eq!(
+            batch_rev.column(i).null_count(),
+            batch.column(orig_idx).null_count(),
+            "column '{}' must be identical regardless of schema position",
+            c.name
+        );
+        assert_eq!(batch_rev.column(i).len(), batch.column(orig_idx).len(),);
+    }
+}
+
+/// Type-mismatch fail-closed behaviour must survive the refactor: a wrong-variant
+/// value still errors rather than silently becoming null.
+#[test]
+fn type_mismatch_still_fails_closed() {
+    let columns = vec![col("n", DataType::Integer, None)];
+    let rows = vec![row(&[("n", Value::Text("not-an-int".into()))])];
+    assert!(rows_to_record_batch(&columns, &rows).is_err());
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -69,6 +69,19 @@
 #                      guard has an executing regression net. Builds its own
 #                      WriteEngine fixtures -> needs NO datasets (not in
 #                      DATASET_COMPONENTS).
+#   arrow-parity-guard cargo test -p cqlite-core --features arrow
+#                      --test issue_1495_arrow_accessor_parity (issue #1495, AE1).
+#                      The Arrow accessor-hoist byte-identity parity net. This test
+#                      is `#![cfg(feature = "arrow")]` + Cargo required-features =
+#                      ["arrow"], so NO other gate/CI run compiles it: core-tests
+#                      runs only `--features cli-helpers` (arrow OFF -> skipped) and
+#                      pr-gate's `--lib --all-features` excludes tests/ integration
+#                      targets. Without this component the sole correctness proof of
+#                      the refactor never executes (the #1597/#1618 gate-wiring
+#                      class). Builds in-memory QueryRows -> needs NO datasets (not
+#                      in DATASET_COMPONENTS). Fails CLOSED on a vacuous 0-run:
+#                      asserts the reported test count is > 0 so a renamed/removed
+#                      target can't read as PASS.
 #   memory-budget      cargo test -p cqlite-core --features cli-helpers,dhat-heap
 #                      --test memory_budget -- --test-threads=1 (issue #1565, Epic
 #                      A/A4). dhat allocation/peak-heap regression net over the real
@@ -1024,7 +1037,7 @@ _python_build_verify_venv() {
   return 3
 }
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
 # --lite (issue #1821) runs ONLY this fast subset: file-size ratchet, fmt,
 # FULL-workspace clippy (cross-crate API breaks are the cheap-insurance class),
 # and blast-radius-scoped tests (the touched package's --lib + the diff's new
@@ -3103,6 +3116,30 @@ run_scan_offload_guard_cmd() {
     -- scan_admission issue_1594_fanout_deadlock
 }
 
+# run_arrow_parity_guard_cmd: the arrow-parity-guard component's command (issue
+# #1495, AE1). Runs the Arrow accessor-hoist byte-identity parity test WITH the
+# `arrow` feature it requires. The test is `#![cfg(feature = "arrow")]` with Cargo
+# `required-features = ["arrow"]`, so it is compiled+run by NO other gate/CI lane
+# (core-tests is cli-helpers-only; pr-gate's --lib --all-features skips tests/).
+# Fails CLOSED on a vacuous 0-run: after the test binary runs we assert the cargo
+# "test result: ... N passed" line reports N > 0, so a renamed, removed, or
+# feature-skipped target reads as FAIL — never a hollow PASS. Builds in-memory
+# QueryRows, so it needs no datasets.
+run_arrow_parity_guard_cmd() {
+  local out
+  out=$(cargo test --package cqlite-core --features arrow \
+    --test issue_1495_arrow_accessor_parity 2>&1) || { echo "$out"; return 1; }
+  echo "$out"
+  # Require at least one test to have actually run (guard against a vacuous
+  # required-features skip that cargo reports as success with 0 tests).
+  local passed
+  passed=$(echo "$out" | sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed.*/\1/p' | tail -1)
+  if [ -z "$passed" ] || [ "$passed" -lt 1 ]; then
+    echo "arrow-parity-guard: FAIL — 0 tests ran (target skipped/absent, not a real PASS)" >&2
+    return 1
+  fi
+}
+
 # _pool_selected <name>: honor the --only filter when building the launch list.
 _pool_selected() {
   [ -z "$ONLY" ] && return 0
@@ -3144,6 +3181,7 @@ dispatch_component() {
       --test issue_1578_limit_exempts_max_results \
       --test issue_1578_streaming_aggregate_multigen_parity \
       --test issue_2069_global_aggregate_empty_table ;;
+    arrow-parity-guard) run_component arrow-parity-guard run_arrow_parity_guard_cmd ;;
     memory-budget) run_component memory-budget cargo test --package cqlite-core \
       --features cli-helpers,dhat-heap \
       --test memory_budget -- --test-threads=1 ;;


### PR DESCRIPTION
Closes #1495

## What
AE1 (epic #1470, per-cell cost). Pure perf refactor of Arrow export — **output byte-identical** (parity-guarded). Every Arrow builder previously did `row.values.get(&col.name)` per cell — an N·M `HashMap<Arc<str>,Value>` siphash. Now each schema column is resolved to its output index(es) ONCE via `arrow_columnar::transpose_columns`, then a single pass routes each present cell to its column slot(s). Per-cell name-hashing is gone (`rg 'values\.get\(' arrow_convert.rs` = 0).

## Correctness (byte-identity is the contract)
- New parity guard `cqlite-core/tests/issue_1495_arrow_accessor_parity.rs`: wide mixed-type RecordBatch identity, absent/null collapse, column-reorder (full `ArrayData` compare), type-mismatch fail-closed. Passed pre- AND post-refactor.
- **Duplicate result-column names** (e.g. `SELECT a, a`, `SELECT a AS x, b AS x`): a row value now fans out to ALL same-named columns (restores main's behavior — the last-wins transpose had nulled earlier duplicates). Pinned by `duplicate_named_columns_populate_all_identically` (RED before fix, GREEN after). The deeper name-keyed-row collapse is pre-existing and tracked separately in #2308.
- **Gate wiring:** new `arrow-parity-guard` gate component runs the parity test with `--features arrow` (it's arrow-gated and was otherwise skipped by every gate/CI lane); fails-closed on a 0-run skip.

## Scope
Accessor-resolution only. Does NOT fold in #1496 (AE2 capacity-hinted builders / per-value clones). Transpose peak-memory + reorder-test polish batched to a follow-up (bounded pointer matrix; streaming is #1470/#1496 scope).

Cross-links parser epic J1 (same per-cell dispatch-cost pattern).