### PR TITLE
fix(#2314): key telemetry dup-check on (issue, pr) — reopen cycles are legitimate records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,9 +330,11 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   `spec-auditor` re-reads them from `openspec/changes/<slug>/`. Durable lessons → `MEMORY.md` /
   `process_improvements.md`, never the live window.
 - Spawn subagents with an explicit accessible model (e.g. opus).
-- **Telemetry**: `flow-finalize` stamps one record per issue into
+- **Telemetry**: `flow-finalize` stamps one record per delivery cycle (issue, pr) into
   `docs/reports/delivery-telemetry.jsonl` (schema `docs/reports/delivery-telemetry.schema.json`)
-  via `scripts/delivery-telemetry.py record` — authoritative
+  via `scripts/delivery-telemetry.py record` — a reopened issue that ships more than once
+  legitimately gets one record per shipped PR, so retro aggregation by issue treats such
+  multi-cycle issues as multiple deliveries, not one (issue #2314). Records hold authoritative
   data only (a counter not observed is an error, never a fabricated 0). On a cadence the manager
   runs `retro` and files a deduped `flow-meta` issue. The SKIP-aware `delivery-telemetry` gate
   component covers the tool. Doctrine: `docs/development/pm-operating-loop.md`.

--- a/docs/development/pm-operating-loop.md
+++ b/docs/development/pm-operating-loop.md
@@ -129,12 +129,14 @@ roborev round-trips):
 ## Self-improvement loop (telemetry + retro)
 
 The pipeline measures itself so improvement is data-driven, not anecdotal:
-- **Sense** — at finalize, the worker stamps one record per completed issue into the append-only ledger
-  `docs/reports/delivery-telemetry.jsonl` (schema: `docs/reports/delivery-telemetry.schema.json`) via
-  `scripts/delivery-telemetry.py record`. Records hold authoritative data only — GitHub-derived
-  timestamps (cycle time + coarse phase durations) plus run-observed counters (claim collisions, rebase
-  events, agent-gate pass/fail + run count, roborev findings, rework). A counter that was not observed is
-  an error, never a fabricated `0`.
+- **Sense** — at finalize, the worker stamps one record per delivery cycle (issue, pr) into the
+  append-only ledger `docs/reports/delivery-telemetry.jsonl` (schema:
+  `docs/reports/delivery-telemetry.schema.json`) via `scripts/delivery-telemetry.py record`. A
+  reopened issue that ships more than once legitimately gets one record per shipped PR (issue #2314)
+  — retro aggregation by issue treats such multi-cycle issues as multiple deliveries, not one. Records
+  hold authoritative data only — GitHub-derived timestamps (cycle time + coarse phase durations) plus
+  run-observed counters (claim collisions, rebase events, agent-gate pass/fail + run count, roborev
+  findings, rework). A counter that was not observed is an error, never a fabricated `0`.
 - **Diagnose** — on a cadence (per-epic or weekly) the **manager** runs `delivery-telemetry.py retro`,
   which ranks the recorded failure categories by a documented weighted tally (deterministic, not an
   inferred model) and reports the single highest-cost recurring failure. `--file` files a `flow-meta`

--- a/docs/reports/delivery-telemetry.schema.json
+++ b/docs/reports/delivery-telemetry.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/pmcfadin/cqlite/docs/reports/delivery-telemetry.schema.json",
   "title": "Delivery telemetry ledger record (v1)",
-  "description": "One record per completed delivery-pipeline issue. Authoritative data only: every field is an observed event (GitHub timestamp/label or a supplied run counter) or arithmetic over authoritative timestamps. No value is inferred, estimated, or guessed.",
+  "description": "One record per delivery cycle (issue, pr). A reopened issue that ships more than once legitimately produces one record per shipped PR — retro aggregation by issue treats such multi-cycle issues as multiple deliveries. Authoritative data only: every field is an observed event (GitHub timestamp/label or a supplied run counter) or arithmetic over authoritative timestamps. No value is inferred, estimated, or guessed.",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/openspec/specs/delivery-pipeline/spec.md
+++ b/openspec/specs/delivery-pipeline/spec.md
@@ -80,16 +80,25 @@ SHALL NOT introduce a weaker done bar.
 
 ### Requirement: Delivery telemetry ledger
 The workflow SHALL maintain an append-only telemetry ledger at
-`docs/reports/delivery-telemetry.jsonl` (one JSON record per line, one record per completed
-issue) governed by a versioned JSON Schema at `docs/reports/delivery-telemetry.schema.json`.
-A telemetry tool (`scripts/delivery-telemetry.py`) SHALL provide a `record` subcommand that
-builds a schema-valid record and appends exactly one line, and a `lint` (alias `validate`)
-subcommand that schema-validates every line and exits non-zero naming any malformed line.
+`docs/reports/delivery-telemetry.jsonl` (one JSON record per line, one record per delivery
+cycle — the (issue, pr) pair) governed by a versioned JSON Schema at
+`docs/reports/delivery-telemetry.schema.json`. A reopened issue that ships more than once
+legitimately produces one record per shipped PR; retro aggregation by issue treats such
+multi-cycle issues as multiple deliveries, not one (issue #2314). A telemetry tool
+(`scripts/delivery-telemetry.py`) SHALL provide a `record` subcommand that builds a
+schema-valid record and appends exactly one line, and a `lint` (alias `validate`)
+subcommand that schema-validates every line — including rejecting a duplicate (issue, pr)
+pair — and exits non-zero naming any malformed line.
 
 #### Scenario: Record subcommand appends one schema-valid line
-- **WHEN** `delivery-telemetry.py record` is run for a completed issue (GitHub-derived fields supplied via `--from-json` in tests, or pulled live from `gh`) with the required run counters
+- **WHEN** `delivery-telemetry.py record` is run for a completed delivery cycle (GitHub-derived fields supplied via `--from-json` in tests, or pulled live from `gh`) with the required run counters
 - **THEN** it appends exactly one JSON line to the ledger that validates against `delivery-telemetry.schema.json`
 - **AND** the record carries the issue/PR numbers, routing, priority, the GitHub timestamps, the durations computed from those timestamps, and the supplied counters
+
+#### Scenario: Reopened issue shipping again is a new delivery cycle, not a duplicate
+- **WHEN** an issue already has a ledger record and is later reopened and ships again under a different PR
+- **THEN** `delivery-telemetry.py record` appends the new record without requiring `--allow-duplicate`
+- **AND** `lint`/`validate` accepts both records as distinct delivery cycles, keyed on (issue, pr)
 
 #### Scenario: Lint rejects a malformed record
 - **WHEN** `delivery-telemetry.py lint` runs against a ledger containing a line that violates the schema
@@ -108,13 +117,14 @@ are permitted; a counter that was not observed SHALL NOT be defaulted to a fabri
 - **AND** every numeric field in a written record traces to a supplied counter or to arithmetic over GitHub-sourced timestamps
 
 ### Requirement: Finalize stamps the ledger
-`flow-finalize` SHALL, as a step on a merged issue, write the issue's telemetry record by
-invoking the `record` subcommand, so that every issue completed through the pipeline produces
-exactly one ledger record.
+`flow-finalize` SHALL, as a step on a merged PR, write that delivery cycle's telemetry record
+by invoking the `record` subcommand, so that every (issue, pr) delivery cycle completed
+through the pipeline produces exactly one ledger record. An issue merged more than once (a
+reopen cycle) produces one record per merged PR, not one total.
 
-#### Scenario: Finalize produces one record per completed issue
-- **WHEN** `flow-finalize` completes for a merged issue
-- **THEN** the ledger gains exactly one new record for that issue
+#### Scenario: Finalize produces one record per delivery cycle
+- **WHEN** `flow-finalize` completes for a merged PR
+- **THEN** the ledger gains exactly one new record for that (issue, pr) delivery cycle
 - **AND** that record passes `lint`
 
 ### Requirement: Recurring retro ranks failures and files a deduped improvement issue

--- a/scripts/delivery-telemetry.py
+++ b/scripts/delivery-telemetry.py
@@ -2,9 +2,14 @@
 """delivery-telemetry.py — delivery-pipeline telemetry ledger + recurring retro.
 
 Closes the pipeline self-improvement loop:
-  sense    -> an append-only ledger, one record per completed issue (`record`)
+  sense    -> an append-only ledger, one record per delivery cycle (issue, pr) (`record`)
   diagnose -> rank recorded failures, file a deduped flow-meta issue (`retro`)
   improve  -> that issue runs through the normal pipeline
+
+A "delivery cycle" is one shipped PR: a reopened issue that ships more than once
+legitimately has one record per shipped PR (e.g. #2264 via PR #2282 then PR #2301), so the
+dup key is the (issue, pr) pair, not the issue alone. Retro aggregation by issue should
+treat such multi-cycle issues as multiple deliveries (they are), not fold them into one.
 
 Authoritative-data-only mandate (CLAUDE.md / issue #28): every field is an observed
 event — a GitHub timestamp/label or a run counter supplied by the stamping step — or
@@ -259,7 +264,7 @@ def build_record(args, gh_fields: dict) -> dict:
     Error convention: caller-input / precondition errors (a missing counter, a null
     timestamp, an undeterminable priority/routing) `raise SystemExit` here — they are bad
     invocations, like an argparse failure. Ledger-state outcomes (a built record that
-    fails schema validation, a duplicate issue) are reported by `cmd_record` with a stderr
+    fails schema validation, a duplicate (issue, pr) cycle) are reported by `cmd_record` with a stderr
     message + `return 1`. Both surface as a non-zero exit.
     """
     for counter in REQUIRED_COUNTERS:
@@ -353,11 +358,12 @@ def cmd_record(args) -> int:
         return 1
 
     ledger = Path(args.ledger)
-    # Idempotency: one record per completed issue. A re-run / double finalize must not
-    # append a second record (which would double-count that issue in retro). Refuse
-    # unless --allow-duplicate is given. This check is best-effort, not atomic — the real
-    # cross-session serializer is the per-issue branch lock (one worktree → one finalize);
-    # `lint` is the after-the-fact backstop that flags any duplicate that slips through.
+    # Idempotency: one record per delivery cycle (issue, pr). A re-run / double finalize of
+    # the SAME cycle must not append a second record (which would double-count it in retro).
+    # Refuse a same-(issue, pr) re-stamp unless --allow-duplicate is given. A reopened issue
+    # that ships again under a NEW pr is a legitimate new cycle and appends freely. This
+    # check is best-effort, not atomic — the real cross-session serializer is the per-issue
+    # branch lock (one worktree → one finalize); `lint` is the after-the-fact backstop.
     if ledger.exists():
         for lineno, raw in enumerate(ledger.read_text().splitlines(), start=1):
             if not raw.strip():
@@ -369,10 +375,12 @@ def cmd_record(args) -> int:
                 print(f"warning: existing ledger line {lineno} is unparseable — run `lint`",
                       file=sys.stderr)
                 continue
-            if (isinstance(existing, dict) and existing.get("issue") == record["issue"]
+            if (isinstance(existing, dict)
+                    and existing.get("issue") == record["issue"]
+                    and existing.get("pr") == record["pr"]
                     and not args.allow_duplicate):
-                print(f"error: issue #{record['issue']} already has a ledger record "
-                      f"(pass --allow-duplicate to override)", file=sys.stderr)
+                print(f"error: issue #{record['issue']} / pr #{record['pr']} already has a "
+                      f"ledger record (pass --allow-duplicate to override)", file=sys.stderr)
                 return 1
 
     ledger.parent.mkdir(parents=True, exist_ok=True)
@@ -386,12 +394,18 @@ def cmd_record(args) -> int:
 
 def load_ledger(ledger: Path, schema: dict):
     """Parse + validate every ledger line. Returns (records, errors) where errors is a
-    list of (lineno, message): malformed JSON, schema violations, AND duplicate issue
-    numbers (one-record-per-issue). Shared by `lint` and `retro` so both apply the exact
-    same rules — neither can rank/accept a ledger the other would reject.
+    list of (lineno, message): malformed JSON, schema violations, AND duplicate delivery
+    cycles (one record per (issue, pr)). Shared by `lint` and `retro` so both apply the
+    exact same rules — neither can rank/accept a ledger the other would reject.
+
+    The dup key is the (issue, pr) pair, not the issue alone: a REOPENED issue that ships
+    more than once legitimately has one record per shipped PR (e.g. #2264 via PR #2282 then
+    PR #2301). Only a genuine same-(issue, pr) re-stamp is a duplicate. Retro consumers
+    that aggregate by issue should treat such multi-cycle issues as multiple deliveries
+    (they are), not fold them into one.
     """
     records, errors = [], []
-    seen_issues: dict = {}
+    seen_cycles: dict = {}
     for lineno, raw in enumerate(ledger.read_text().splitlines(), start=1):
         if not raw.strip():
             continue
@@ -402,14 +416,18 @@ def load_ledger(ledger: Path, schema: dict):
             continue
         for e in validate_record(record, schema):
             errors.append((lineno, e))
-        # one record per completed issue — a duplicate 'issue' skews retro. A non-object
-        # line already produced a type error above; skip the bookkeeping (no .get crash).
-        issue = record.get("issue") if isinstance(record, dict) else None
-        if issue is not None and issue in seen_issues:
-            errors.append((lineno, f"duplicate record for issue #{issue} "
-                                   f"(first seen line {seen_issues[issue]})"))
-        elif issue is not None:
-            seen_issues[issue] = lineno
+        # one record per delivery cycle (issue, pr) — a duplicate cycle skews retro. A
+        # non-object line already produced a type error above; skip the bookkeeping. A
+        # record missing 'pr' already failed schema validation above; key on (issue, None)
+        # so we still don't crash and still flag an exact repeat of that malformed line.
+        if isinstance(record, dict) and record.get("issue") is not None:
+            key = (record.get("issue"), record.get("pr"))
+            if key in seen_cycles:
+                issue, pr = key
+                errors.append((lineno, f"duplicate record for issue #{issue} / pr #{pr} "
+                                       f"(first seen line {seen_cycles[key]})"))
+            else:
+                seen_cycles[key] = lineno
         records.append(record)
     return records, errors
 
@@ -514,7 +532,7 @@ def cmd_retro(args) -> int:
         print(f"error: ledger not found: {ledger}", file=sys.stderr)
         return 1
     # Refuse to rank a non-conforming ledger: a malformed/partial line, a record missing a
-    # counter, OR a duplicate issue (which would double-count in the tally) must be a clean
+    # counter, OR a duplicate (issue, pr) cycle (which would double-count in the tally) must be a clean
     # error (run `lint`), never silently parsed/defaulted/double-counted. Same loader as
     # `lint`, so retro applies the identical bar.
     records, errors = load_ledger(ledger, load_schema(Path(args.schema)))
@@ -623,7 +641,8 @@ def build_parser() -> argparse.ArgumentParser:
     rec.add_argument("--from-json", dest="from_json", default=None,
                      help="inject GitHub-derived fields from a JSON file (else pull via gh)")
     rec.add_argument("--allow-duplicate", dest="allow_duplicate", action="store_true",
-                     help="append even if the issue already has a record (default: refuse)")
+                     help="append even if this (issue, pr) cycle already has a record "
+                          "(default: refuse; a reopened issue's NEW pr never needs this)")
     rec.set_defaults(func=cmd_record)
 
     lint = sub.add_parser("lint", aliases=["validate"], help="schema-validate the ledger")

--- a/scripts/tests/test_delivery_telemetry.py
+++ b/scripts/tests/test_delivery_telemetry.py
@@ -105,7 +105,7 @@ class RecordTests(unittest.TestCase):
             self.assertFalse(ledger.exists() and ledger.read_text().strip())
 
 
-    def test_record_refuses_duplicate_issue(self):
+    def test_record_refuses_duplicate_cycle(self):
         with tempfile.TemporaryDirectory() as d:
             tmp = Path(d)
             ledger = tmp / "ledger.jsonl"
@@ -118,11 +118,32 @@ class RecordTests(unittest.TestCase):
             self.assertEqual(dt.main(base), 0)
             err = io.StringIO()
             with contextlib.redirect_stderr(err):
-                self.assertEqual(dt.main(base), 1)         # second stamp refused
-            self.assertIn("already has a ledger record", err.getvalue())
+                self.assertEqual(dt.main(base), 1)         # same (issue, pr) re-stamp refused
+            self.assertIn("issue #42 / pr #7 already has a ledger record", err.getvalue())
             self.assertEqual(dt.main(base + ["--allow-duplicate"]), 0)  # explicit override
             lines = [l for l in ledger.read_text().splitlines() if l.strip()]
             self.assertEqual(len(lines), 2)
+
+    def test_record_accepts_reopen_cycle_without_allow_duplicate(self):
+        # issue #2314: same issue, a NEW pr (a reopened issue shipping again) must append
+        # WITHOUT --allow-duplicate — it is a distinct delivery cycle, not a re-stamp.
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            ledger = tmp / "ledger.jsonl"
+            first = ["record", "--ledger", str(ledger),
+                     "--issue", "2264", "--pr", "2282", "--slug", "x",
+                     "--gate", "pass", "--gate-runs", "1",
+                     "--claim-collisions", "0", "--rebase-events", "0",
+                     "--roborev-findings", "0", "--rework", "0",
+                     "--from-json", _from_json_file(tmp)]
+            self.assertEqual(dt.main(first), 0)
+            second = list(first)
+            second[second.index("2282")] = "2301"     # same issue, second shipped PR
+            self.assertEqual(dt.main(second), 0)       # no --allow-duplicate needed
+            lines = [l for l in ledger.read_text().splitlines() if l.strip()]
+            self.assertEqual(len(lines), 2)
+            # and the resulting two-cycle ledger lints clean
+            self.assertEqual(dt.main(["lint", "--ledger", str(ledger)]), 0)
 
     def test_routing_required_when_not_determinable(self):
         with tempfile.TemporaryDirectory() as d:
@@ -355,16 +376,31 @@ class LintTests(unittest.TestCase):
             self.assertEqual(rc, 1)
             self.assertIn("unknown field 'reworkk'", err.getvalue())
 
-    def test_duplicate_issue_is_flagged(self):
+    def test_duplicate_cycle_is_flagged(self):
+        # same (issue, pr) twice is a genuine duplicate cycle -> error naming both.
         with tempfile.TemporaryDirectory() as d:
             ledger = Path(d) / "ledger.jsonl"
             line = (FIXTURES / "sample-ledger.jsonl").read_text().splitlines()[0]
-            ledger.write_text(line + "\n" + line + "\n")   # same issue twice
+            ledger.write_text(line + "\n" + line + "\n")   # same (issue, pr) twice
             err = io.StringIO()
             with contextlib.redirect_stderr(err):
                 rc = dt.main(["lint", "--ledger", str(ledger)])
             self.assertEqual(rc, 1)
-            self.assertIn("duplicate record for issue", err.getvalue())
+            msg = err.getvalue()
+            self.assertIn("duplicate record for issue #1001 / pr #2001", msg)
+            self.assertIn("first seen line 1", msg)
+
+    def test_reopen_cycle_same_issue_different_pr_is_valid(self):
+        # issue #2314: a reopened issue that ships twice (same issue, DIFFERENT pr) is a
+        # legitimate per-cycle record, NOT a duplicate — lint must PASS.
+        with tempfile.TemporaryDirectory() as d:
+            ledger = Path(d) / "ledger.jsonl"
+            first = json.loads((FIXTURES / "sample-ledger.jsonl").read_text().splitlines()[0])
+            second = dict(first)
+            second["pr"] = first["pr"] + 1     # same issue, a new shipped PR
+            ledger.write_text(json.dumps(first) + "\n" + json.dumps(second) + "\n")
+            rc = dt.main(["lint", "--ledger", str(ledger)])
+            self.assertEqual(rc, 0)
 
     def test_non_object_line_is_clean_error_not_crash(self):
         with tempfile.TemporaryDirectory() as d:

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -273,9 +273,12 @@ The lead **pipelines** near-independent issues rather than serializing on long w
 
 The pipeline measures itself so improvement is data-driven, not anecdotal — **sense → diagnose → improve**:
 
-- **Sense.** `flow-finalize` stamps one record per completed issue into the append-only ledger
-  `docs/reports/delivery-telemetry.jsonl` (governed by `docs/reports/delivery-telemetry.schema.json`)
-  using `scripts/delivery-telemetry.py record`. Records carry **authoritative data only**: GitHub-derived
+- **Sense.** `flow-finalize` stamps one record per delivery cycle (issue, pr) into the append-only
+  ledger `docs/reports/delivery-telemetry.jsonl` (governed by
+  `docs/reports/delivery-telemetry.schema.json`) using `scripts/delivery-telemetry.py record`. A
+  reopened issue that ships more than once legitimately gets one record per shipped PR — retro
+  aggregation by issue treats such multi-cycle issues as multiple deliveries, not one (issue #2314).
+  Records carry **authoritative data only**: GitHub-derived
   timestamps (issue/PR open + merge + close → cycle time and coarse phase durations) plus run-observed
   counters — claim collisions, rebase/conflict events, agent-gate pass/fail + run count, roborev findings,
   and rework. A counter that was not observed is an **error**, never a fabricated `0` (no-heuristics


### PR DESCRIPTION
Closes #2314.

## Problem (pinned repro on main @ 84b61a29)
`delivery-telemetry.py validate`/`lint` keyed the duplicate check on **issue number alone**, so a legitimately reopened issue that ships twice (same issue, DIFFERENT pr) can never have honest per-cycle records. The tool contradicted itself: `record --allow-duplicate` wrote what `validate` then rejected — turning the `delivery-telemetry` gate component red on every branch containing main @ 84b61a29 (the #2264 second-cycle record, ledger lines 250/256).

Repro before the fix:
```
$ python3 scripts/delivery-telemetry.py validate
line 256: duplicate record for issue #2264 (first seen line 250)
FAIL: 1 problem(s)
```

## Fix — code (97234bde)
- `load_ledger` (validate/lint) keys duplicates on the **(issue, pr)** pair; error names both: `duplicate record for issue #N / pr #M (first seen line L)`. Records missing `pr` key on `(issue, None)` — no crash; the missing `pr` already fails schema validation separately.
- `cmd_record` best-effort check keys on **(issue, pr)** too, so `--allow-duplicate` is needed only for a genuine same-(issue, pr) re-stamp. A reopened issue's new pr appends freely.
- `scripts/delivery-telemetry.py` docstrings/comments + `--allow-duplicate` help updated.

## Fix — contract docs (1050e2db, roborev follow-up)
roborev flagged that the repository's documented ledger contract still said "one record per completed issue" in several places while the tool now enforces one per (issue, pr). Updated every living-doc statement of the invariant to **one record per delivery cycle (issue, pr); reopened issues legitimately record one per shipped PR; retro aggregates multi-cycle issues as multiple deliveries**:
- `docs/reports/delivery-telemetry.schema.json` — top-level `description` (non-markdown — this is the schema-touched case, not md-only; see gate-strategy note below)
- `docs/development/pm-operating-loop.md`
- `openspec/specs/delivery-pipeline/spec.md` — requirement text + 2 scenarios (renamed "Finalize produces one record per completed issue" → "...per delivery cycle"; added a new scenario covering the reopen-cycle case)
- `website/src/content/docs/agents-developing/delivery-pipeline.md`
- `CLAUDE.md`

Archived OpenSpec change snapshots (`openspec/changes/archive/2026-06-28-delivery-telemetry-ledger/**`) were intentionally left untouched — they're a historical record of what was proposed at the time, not living doctrine.

### Gate-strategy note
`docs/reports/delivery-telemetry.schema.json` states the invariant in its JSON Schema `description` field — this is **NOT** an `*.md` file, so the contract-doc fix is **schema-touched, not docs-only**. Per the coordinator's instruction, correctness took priority over gate convenience: this fix does **not** qualify for a `--delta` re-cert against the 97234bde anchor and needs its own full-gate pass (owned by flow-closer, not re-run here to avoid contending with an already-in-flight full gate in this same worktree/target dir).

## Tests (scripts/tests/test_delivery_telemetry.py — the gate's `delivery-telemetry` component)
- `test_reopen_cycle_same_issue_different_pr_is_valid` — same issue different pr → lint PASSES.
- `test_duplicate_cycle_is_flagged` — same (issue, pr) twice → duplicate error naming both.
- `test_record_refuses_duplicate_cycle` / `test_record_accepts_reopen_cycle_without_allow_duplicate` — record-time check refuses a same-(issue, pr) re-stamp, accepts a reopen cycle without the flag.

## Validation
- `python3 scripts/delivery-telemetry.py validate` on the REAL ledger → `OK: ledger is well-formed` (rc=0), with the #2264 pair present, re-verified after the doc commit.
- `python3 -m json.tool docs/reports/delivery-telemetry.schema.json` / `json.load` → still valid JSON.
- 39 unit tests OK (re-run after both commits).

### `--only delivery-telemetry` (component PASS, at 97234bde)
```
delivery-telemetry: PASS (0s)
RESULT: PARTIAL
```

### LITE SUMMARY (at 97234bde)
```
==== AGENT-GATE LITE SUMMARY ====
commit: 97234bde branch: issue-2314-telemetry-reopen-dup dirty: no
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (113s)
scoped-tests:      PASS (102s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Full gate to be (re-)run by flow-closer at HEAD (1050e2db) before merge — the schema.json change means the prior lite/only evidence at 97234bde does not cover the doc-contract commit.