### PR TITLE
fix(#2316): bound merge producer-thread cost to O(M) — current_thread producer runtime + producer-thread gauge

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -44,6 +44,8 @@ pub mod unit {
     pub const BYTES: &str = "By";
     /// Seconds (OTel prefers base-unit seconds for durations).
     pub const SECONDS: &str = "s";
+    /// A count of OS threads (UCUM annotation).
+    pub const THREADS: &str = "{thread}";
 }
 
 /// Bounded attribute keys for catalog metrics.
@@ -437,6 +439,20 @@ pub const COMPACTION_BUDGET_REQUESTED: &str = "cqlite.compaction.budget.requeste
 /// attributes.
 pub const COMPACTION_BUDGET_CONSUMED: &str = "cqlite.compaction.budget.consumed";
 
+/// `cqlite.merge.producer_threads` — gauge `{thread}` (issue #2316).
+///
+/// Live count of OS producer threads the k-way merge currently has open — one per
+/// input SSTable being scanned. The merge (shared by the write-engine
+/// compaction/maintenance path and the Flight `do_get` streaming egress) opens one
+/// producer thread per input; this gauge makes the previously-invisible per-merge
+/// thread cost observable, so the O(M) bound (issue #2316, replacing the old
+/// `M·num_cpus` amplification) is assertable on a loaded node. It RISES as a merge
+/// spawns its producers (bounded by `O(M)`) and RETURNS to its baseline once those
+/// producers are joined/dropped at merge completion. The metric name is coordinated
+/// with epic #2313 WS2 (the thread/blocking-pool metrics surface) to avoid a
+/// naming collision. No high-cardinality attributes.
+pub const MERGE_PRODUCER_THREADS: &str = "cqlite.merge.producer_threads";
+
 /// `cqlite.errors.total` — counter `{error}`.
 ///
 /// Total errors observed, the canonical error-rate signal (issue #1038).
@@ -548,6 +564,7 @@ pub const ALL_METRICS: &[&str] = &[
     COMPACTION_FINALIZE_DURATION,
     COMPACTION_BUDGET_REQUESTED,
     COMPACTION_BUDGET_CONSUMED,
+    MERGE_PRODUCER_THREADS,
     // Arrow Flight gRPC service (#1041)
     RPC_REQUESTS,
     RPC_DURATION,
@@ -603,5 +620,16 @@ mod tests {
         assert!(ALL_METRICS.contains(&RPC_PHASE_DURATION));
         assert!(RPC_PHASE_DURATION.starts_with("cqlite."));
         assert!(attr::RPC_PHASE.starts_with("cqlite."));
+    }
+
+    #[test]
+    fn merge_producer_threads_gauge_is_registered_and_documented() {
+        // Issue #2316: the merge producer-thread gauge must be part of the
+        // canonical catalog (so the registration/uniqueness checks cover it), be
+        // rooted under `cqlite.`, and carry the `{thread}` unit agreed with #2313 WS2.
+        assert!(ALL_METRICS.contains(&MERGE_PRODUCER_THREADS));
+        assert_eq!(MERGE_PRODUCER_THREADS, "cqlite.merge.producer_threads");
+        assert!(MERGE_PRODUCER_THREADS.starts_with("cqlite."));
+        assert_eq!(unit::THREADS, "{thread}");
     }
 }

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -312,6 +312,7 @@ struct Instruments {
     memtable_rows: Gauge<i64>,
     compaction_lag: Gauge<i64>,
     rpc_in_flight: Gauge<i64>,
+    merge_producer_threads: Gauge<i64>,
 }
 
 fn instruments() -> &'static Instruments {
@@ -570,6 +571,11 @@ fn instruments() -> &'static Instruments {
                 .with_unit(catalog::unit::DIMENSIONLESS)
                 .with_description("Arrow Flight RPCs currently being handled.")
                 .build(),
+            merge_producer_threads: m
+                .i64_gauge(catalog::MERGE_PRODUCER_THREADS)
+                .with_unit(catalog::unit::THREADS)
+                .with_description("Live k-way merge producer threads (#2316).")
+                .build(),
         }
     })
 }
@@ -658,6 +664,7 @@ pub(crate) fn record_gauge(name: &'static str, value: i64, attributes: &[KeyValu
         catalog::MEMTABLE_ROWS => &i.memtable_rows,
         catalog::COMPACTION_LAG => &i.compaction_lag,
         catalog::RPC_IN_FLIGHT => &i.rpc_in_flight,
+        catalog::MERGE_PRODUCER_THREADS => &i.merge_producer_threads,
         _ => {
             meter().i64_gauge(name).build().record(value, attributes);
             return;

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -464,10 +464,25 @@ impl SSTableRowIteratorAdapter {
 
         let (sender, receiver) = std::sync::mpsc::sync_channel(STREAMING_CHANNEL_CAPACITY);
 
-        // Spawn the producer thread. It owns a fresh single-threaded (current_thread)
-        // Tokio runtime so it never collides with any runtime on the calling thread
-        // (Issue #587) and adds no worker threads beyond itself (Issue #2316).
-        let producer = std::thread::spawn(move || {
+        // Issue #2316: account this producer on the `cqlite.merge.producer_threads`
+        // gauge BEFORE spawning, so the increment happens-before any possible
+        // decrement. The decrementing `ProducerThreadGuard` is created first thing
+        // inside the child thread (see `producer_thread`); a fast-exiting producer
+        // (e.g. a reader-open error) could otherwise race its own guard's drop
+        // against a post-spawn increment on the parent, transiently underflowing
+        // the live count. Incrementing here first makes the pairing
+        // correct-by-construction — no ordering race is possible.
+        producer_gauge::spawned();
+
+        // Spawn the producer thread via `Builder::spawn` (rather than the
+        // panic-on-failure `std::thread::spawn`) so an OS thread-creation failure
+        // is a recoverable `Err`, not a process abort: the gauge increment above
+        // must never leak for a thread that never actually started, so roll it
+        // back on this path via `producer_gauge::rollback`. The thread owns a
+        // fresh single-threaded (current_thread) Tokio runtime so it never
+        // collides with any runtime on the calling thread (Issue #587) and adds no
+        // worker threads beyond itself (Issue #2316).
+        let producer = match std::thread::Builder::new().spawn(move || {
             Self::producer_thread(
                 path_buf,
                 run_index,
@@ -476,11 +491,16 @@ impl SSTableRowIteratorAdapter {
                 scan_cancel,
                 sender,
             );
-        });
-
-        // Issue #2316: account the just-spawned producer thread on the
-        // `cqlite.merge.producer_threads` gauge (decremented by `ProducerThreadGuard`).
-        producer_gauge::spawned();
+        }) {
+            Ok(handle) => handle,
+            Err(e) => {
+                producer_gauge::rollback();
+                return Err(Error::Storage(format!(
+                    "streaming producer: failed to spawn thread: {}",
+                    e
+                )));
+            }
+        };
 
         Ok(Self {
             receiver,

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -432,6 +432,42 @@ impl From<Error> for MergeProducerError {
 #[cfg(feature = "write-support")]
 const STREAMING_CHANNEL_CAPACITY: usize = 256;
 
+/// Live count of k-way-merge producer OS threads (issue #2316), backing the
+/// [`crate::observability::catalog::MERGE_PRODUCER_THREADS`] gauge. Incremented
+/// when a producer thread is spawned (in [`SSTableRowIteratorAdapter::open`]) and
+/// decremented when it exits (via [`ProducerThreadGuard`]); the gauge is
+/// re-recorded on each change, so it RISES as a merge spawns its `O(M)` producers
+/// and RETURNS to its baseline once the producers are joined/dropped.
+#[cfg(feature = "write-support")]
+static MERGE_PRODUCER_THREADS_LIVE: std::sync::atomic::AtomicI64 =
+    std::sync::atomic::AtomicI64::new(0);
+
+/// Re-record the producer-thread gauge with the current live count.
+#[cfg(feature = "write-support")]
+fn record_producer_threads_gauge(live: i64) {
+    crate::observability::record_gauge(
+        crate::observability::catalog::MERGE_PRODUCER_THREADS,
+        live,
+        &[],
+    );
+}
+
+/// RAII guard that decrements the live producer-thread count (and re-records the
+/// gauge) when a producer thread exits — even on panic (issue #2316). Created as
+/// the first act of [`SSTableRowIteratorAdapter::producer_thread`], so every
+/// spawned producer that was counted at spawn is decremented exactly once at exit.
+#[cfg(feature = "write-support")]
+struct ProducerThreadGuard;
+
+#[cfg(feature = "write-support")]
+impl Drop for ProducerThreadGuard {
+    fn drop(&mut self) {
+        let live =
+            MERGE_PRODUCER_THREADS_LIVE.fetch_sub(1, std::sync::atomic::Ordering::SeqCst) - 1;
+        record_producer_threads_gauge(live);
+    }
+}
+
 #[cfg(feature = "write-support")]
 impl SSTableRowIteratorAdapter {
     /// Open an SSTable and start a streaming producer thread.
@@ -476,6 +512,14 @@ impl SSTableRowIteratorAdapter {
             );
         });
 
+        // Issue #2316: account the just-spawned producer thread on the
+        // `cqlite.merge.producer_threads` gauge. Decremented via
+        // `ProducerThreadGuard` when the producer thread exits, so the gauge rises
+        // to `O(M)` during the merge and returns to baseline once it completes.
+        let live =
+            MERGE_PRODUCER_THREADS_LIVE.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        record_producer_threads_gauge(live);
+
         Ok(Self {
             receiver,
             _producer: producer,
@@ -502,6 +546,11 @@ impl SSTableRowIteratorAdapter {
         scan_cancel: crate::storage::scan_cancel::ScanCancel,
         sender: std::sync::mpsc::SyncSender<std::result::Result<MergeEntry, MergeProducerError>>,
     ) {
+        // Issue #2316: decrement the live producer-thread gauge when this thread
+        // exits (even on panic). Created FIRST so the spawn-time increment in
+        // `open` is always balanced exactly once.
+        let _thread_guard = ProducerThreadGuard;
+
         // Drive the streaming read on an owned Tokio runtime (Issue #587): the
         // producer owns its single-purpose runtime, so the blocking
         // `SyncSender::send` inside the emit callback never stalls a shared

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -377,14 +377,11 @@ pub(crate) use async_bridge::block_on_async;
 ///
 /// ## Issue #2316 thread budget (O(M), no per-producer worker pool)
 ///
-/// That per-producer runtime is a **`current_thread`** runtime
-/// (`Builder::new_current_thread()`), NOT a multi-threaded `Runtime::new()`. It
-/// drives the producer's single sequential scan on the producer thread itself and
-/// starts ZERO extra worker threads, so a merge over `M` input SSTables costs
-/// `O(M)` OS threads instead of `M + M·num_cpus`. The scan has no internal
-/// `tokio::spawn`, so a multi-core worker pool was never exercised — it was pure
-/// overhead that amplified into a context-switch storm under concurrent Flight
-/// `do_get` load.
+/// That per-producer runtime is a **`current_thread`** runtime, NOT a
+/// multi-threaded `Runtime::new()`: it drives the producer's single sequential
+/// scan (no internal `tokio::spawn`) on the producer thread itself, adding ZERO
+/// worker threads. A merge over `M` inputs therefore costs `O(M)` OS threads, not
+/// `M + M·num_cpus` — killing the context-switch storm under concurrent `do_get`.
 #[cfg(feature = "write-support")]
 struct SSTableRowIteratorAdapter {
     /// Receiving end of the bounded channel fed by the producer thread.
@@ -432,41 +429,10 @@ impl From<Error> for MergeProducerError {
 #[cfg(feature = "write-support")]
 const STREAMING_CHANNEL_CAPACITY: usize = 256;
 
-/// Live count of k-way-merge producer OS threads (issue #2316), backing the
-/// [`crate::observability::catalog::MERGE_PRODUCER_THREADS`] gauge. Incremented
-/// when a producer thread is spawned (in [`SSTableRowIteratorAdapter::open`]) and
-/// decremented when it exits (via [`ProducerThreadGuard`]); the gauge is
-/// re-recorded on each change, so it RISES as a merge spawns its `O(M)` producers
-/// and RETURNS to its baseline once the producers are joined/dropped.
+// Producer-thread gauge (issue #2316): live-count + RAII guard backing
+// `cqlite.merge.producer_threads`. Kept in a sibling module to bound this file.
 #[cfg(feature = "write-support")]
-static MERGE_PRODUCER_THREADS_LIVE: std::sync::atomic::AtomicI64 =
-    std::sync::atomic::AtomicI64::new(0);
-
-/// Re-record the producer-thread gauge with the current live count.
-#[cfg(feature = "write-support")]
-fn record_producer_threads_gauge(live: i64) {
-    crate::observability::record_gauge(
-        crate::observability::catalog::MERGE_PRODUCER_THREADS,
-        live,
-        &[],
-    );
-}
-
-/// RAII guard that decrements the live producer-thread count (and re-records the
-/// gauge) when a producer thread exits — even on panic (issue #2316). Created as
-/// the first act of [`SSTableRowIteratorAdapter::producer_thread`], so every
-/// spawned producer that was counted at spawn is decremented exactly once at exit.
-#[cfg(feature = "write-support")]
-struct ProducerThreadGuard;
-
-#[cfg(feature = "write-support")]
-impl Drop for ProducerThreadGuard {
-    fn drop(&mut self) {
-        let live =
-            MERGE_PRODUCER_THREADS_LIVE.fetch_sub(1, std::sync::atomic::Ordering::SeqCst) - 1;
-        record_producer_threads_gauge(live);
-    }
-}
+mod producer_gauge;
 
 #[cfg(feature = "write-support")]
 impl SSTableRowIteratorAdapter {
@@ -513,12 +479,8 @@ impl SSTableRowIteratorAdapter {
         });
 
         // Issue #2316: account the just-spawned producer thread on the
-        // `cqlite.merge.producer_threads` gauge. Decremented via
-        // `ProducerThreadGuard` when the producer thread exits, so the gauge rises
-        // to `O(M)` during the merge and returns to baseline once it completes.
-        let live =
-            MERGE_PRODUCER_THREADS_LIVE.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
-        record_producer_threads_gauge(live);
+        // `cqlite.merge.producer_threads` gauge (decremented by `ProducerThreadGuard`).
+        producer_gauge::spawned();
 
         Ok(Self {
             receiver,
@@ -549,7 +511,7 @@ impl SSTableRowIteratorAdapter {
         // Issue #2316: decrement the live producer-thread gauge when this thread
         // exits (even on panic). Created FIRST so the spawn-time increment in
         // `open` is always balanced exactly once.
-        let _thread_guard = ProducerThreadGuard;
+        let _thread_guard = producer_gauge::ProducerThreadGuard;
 
         // Drive the streaming read on an owned Tokio runtime (Issue #587): the
         // producer owns its single-purpose runtime, so the blocking
@@ -578,15 +540,11 @@ impl SSTableRowIteratorAdapter {
             // `schema` stays available for build_merge_entry below.
             let schema_for_reader = schema.clone();
 
-            // Issue #2316: drive the producer's sequential async scan on a
-            // `current_thread` runtime — it runs futures ON this producer thread
-            // and starts ZERO extra worker threads. A default multi-threaded
-            // `Runtime::new()` would eagerly spin up `num_cpus` worker threads per
-            // producer, so a merge over M inputs cost ~M + M*num_cpus OS threads
-            // (a context-switch storm under concurrent Flight `do_get` load). The
-            // scan below is a single sequential `.await` with no internal
-            // `tokio::spawn`, so those workers were pure overhead; the
-            // current_thread runtime bounds the per-merge thread cost to O(M).
+            // Issue #2316: a `current_thread` runtime drives the scan ON this
+            // producer thread with ZERO extra workers. A multi-threaded
+            // `Runtime::new()` would spin up `num_cpus` workers per producer
+            // (~M·num_cpus threads/merge) that the single sequential scan never
+            // uses — pure overhead. This bounds the per-merge thread cost to O(M).
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -371,9 +371,20 @@ pub(crate) use async_bridge::block_on_async;
 ///
 /// ## Issue #587 safety (async-from-sync bridge)
 ///
-/// The producer thread creates its own `tokio::runtime::Runtime` (never
-/// `Handle::block_on`), so it cannot panic even when called from within an
-/// existing Tokio runtime. This is the same strategy as [`block_on_async`].
+/// The producer thread creates its own Tokio runtime (never `Handle::block_on`),
+/// so it cannot panic even when called from within an existing Tokio runtime.
+/// This is the same strategy as [`block_on_async`].
+///
+/// ## Issue #2316 thread budget (O(M), no per-producer worker pool)
+///
+/// That per-producer runtime is a **`current_thread`** runtime
+/// (`Builder::new_current_thread()`), NOT a multi-threaded `Runtime::new()`. It
+/// drives the producer's single sequential scan on the producer thread itself and
+/// starts ZERO extra worker threads, so a merge over `M` input SSTables costs
+/// `O(M)` OS threads instead of `M + M·num_cpus`. The scan has no internal
+/// `tokio::spawn`, so a multi-core worker pool was never exercised — it was pure
+/// overhead that amplified into a context-switch storm under concurrent Flight
+/// `do_get` load.
 #[cfg(feature = "write-support")]
 struct SSTableRowIteratorAdapter {
     /// Receiving end of the bounded channel fed by the producer thread.
@@ -451,8 +462,9 @@ impl SSTableRowIteratorAdapter {
 
         let (sender, receiver) = std::sync::mpsc::sync_channel(STREAMING_CHANNEL_CAPACITY);
 
-        // Spawn the producer thread. It owns a fresh Tokio runtime so it never
-        // collides with any runtime on the calling thread (Issue #587).
+        // Spawn the producer thread. It owns a fresh single-threaded (current_thread)
+        // Tokio runtime so it never collides with any runtime on the calling thread
+        // (Issue #587) and adds no worker threads beyond itself (Issue #2316).
         let producer = std::thread::spawn(move || {
             Self::producer_thread(
                 path_buf,
@@ -493,7 +505,8 @@ impl SSTableRowIteratorAdapter {
         // Drive the streaming read on an owned Tokio runtime (Issue #587): the
         // producer owns its single-purpose runtime, so the blocking
         // `SyncSender::send` inside the emit callback never stalls a shared
-        // runtime, and there is no nested `block_on` / `Handle::current`.
+        // runtime, and there is no nested `block_on` / `Handle::current`. The
+        // runtime is `current_thread` (Issue #2316), so it adds no worker threads.
         // Buffered I/O (Issue #591): the file must not be memory-mapped OR read
         // via direct I/O because finalize_merge_async may delete it after the
         // merge completes. The default disk-access mode is `Auto`, which would
@@ -516,12 +529,24 @@ impl SSTableRowIteratorAdapter {
             // `schema` stays available for build_merge_entry below.
             let schema_for_reader = schema.clone();
 
-            let rt = tokio::runtime::Runtime::new().map_err(|e| {
-                Error::Storage(format!(
-                    "streaming producer: failed to create runtime: {}",
-                    e
-                ))
-            })?;
+            // Issue #2316: drive the producer's sequential async scan on a
+            // `current_thread` runtime — it runs futures ON this producer thread
+            // and starts ZERO extra worker threads. A default multi-threaded
+            // `Runtime::new()` would eagerly spin up `num_cpus` worker threads per
+            // producer, so a merge over M inputs cost ~M + M*num_cpus OS threads
+            // (a context-switch storm under concurrent Flight `do_get` load). The
+            // scan below is a single sequential `.await` with no internal
+            // `tokio::spawn`, so those workers were pure overhead; the
+            // current_thread runtime bounds the per-merge thread cost to O(M).
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    Error::Storage(format!(
+                        "streaming producer: failed to create runtime: {}",
+                        e
+                    ))
+                })?;
 
             rt.block_on(async move {
                 let platform = Arc::new(Platform::new(&config).await?);

--- a/cqlite-core/src/storage/write_engine/merge/producer_gauge.rs
+++ b/cqlite-core/src/storage/write_engine/merge/producer_gauge.rs
@@ -2,13 +2,17 @@
 //!
 //! Backs the [`crate::observability::catalog::MERGE_PRODUCER_THREADS`] gauge with
 //! a process-global live count of merge producer OS threads. The count is
-//! incremented at producer spawn ([`spawned`], called from
-//! `SSTableRowIteratorAdapter::open`) and decremented when the producer thread
-//! exits (via the RAII [`ProducerThreadGuard`], created as the first act of
-//! `producer_thread`). The gauge is re-recorded on each change, so it RISES to the
-//! `O(M)` producer count during a merge and RETURNS to baseline once the producers
-//! are joined/dropped — making the previously-invisible per-merge thread cost
-//! observable on a loaded node.
+//! incremented BEFORE the OS thread is spawned ([`spawned`], called from
+//! `SSTableRowIteratorAdapter::open`) so the increment happens-before any possible
+//! decrement (correct-by-construction: the decrementing `ProducerThreadGuard` is
+//! created first thing inside the child thread, so a fast-exiting producer can
+//! never race its own decrement against the increment). If the spawn itself then
+//! fails ([`rollback`], called from the same `open` on a `Builder::spawn` `Err`),
+//! the increment is rolled back so it never leaks for a thread that never
+//! started. The guard decrements when the producer thread exits (even on panic).
+//! The gauge is re-recorded on each change, so it RISES to the `O(M)` producer
+//! count during a merge and RETURNS to baseline once the producers exit — making
+//! the previously-invisible per-merge thread cost observable on a loaded node.
 
 use std::sync::atomic::{AtomicI64, Ordering};
 
@@ -20,18 +24,34 @@ fn record(live: i64) {
     observability::record_gauge(observability::catalog::MERGE_PRODUCER_THREADS, live, &[]);
 }
 
-/// Account a just-spawned producer thread on the gauge. Balanced by exactly one
-/// [`ProducerThreadGuard`] drop when that thread exits.
+fn decrement() {
+    record(LIVE.fetch_sub(1, Ordering::SeqCst) - 1);
+}
+
+/// Account a just-about-to-spawn producer thread on the gauge, BEFORE
+/// `std::thread::Builder::spawn` is called. Balanced by exactly one of:
+/// [`ProducerThreadGuard`]'s drop (the thread started and later exited), or
+/// [`rollback`] (the thread never actually started).
 pub(super) fn spawned() {
     record(LIVE.fetch_add(1, Ordering::SeqCst) + 1);
 }
 
+/// Undo a [`spawned`] increment for a producer that failed to actually start
+/// (`Builder::spawn` returned `Err`) — the increment must not leak for a thread
+/// that never ran (and thus never gets a `ProducerThreadGuard` decrement).
+pub(super) fn rollback() {
+    decrement();
+}
+
 /// RAII guard that decrements the live producer-thread count (and re-records the
-/// gauge) when a producer thread exits — even on panic.
+/// gauge) when a producer thread exits — even on panic. Created as the FIRST act
+/// inside the spawned producer thread, so it is guaranteed to run for every
+/// thread that actually started (pairing exactly one decrement per [`spawned`]
+/// increment that was not rolled back).
 pub(super) struct ProducerThreadGuard;
 
 impl Drop for ProducerThreadGuard {
     fn drop(&mut self) {
-        record(LIVE.fetch_sub(1, Ordering::SeqCst) - 1);
+        decrement();
     }
 }

--- a/cqlite-core/src/storage/write_engine/merge/producer_gauge.rs
+++ b/cqlite-core/src/storage/write_engine/merge/producer_gauge.rs
@@ -1,0 +1,37 @@
+//! Producer-thread gauge for the k-way merge (issue #2316).
+//!
+//! Backs the [`crate::observability::catalog::MERGE_PRODUCER_THREADS`] gauge with
+//! a process-global live count of merge producer OS threads. The count is
+//! incremented at producer spawn ([`spawned`], called from
+//! `SSTableRowIteratorAdapter::open`) and decremented when the producer thread
+//! exits (via the RAII [`ProducerThreadGuard`], created as the first act of
+//! `producer_thread`). The gauge is re-recorded on each change, so it RISES to the
+//! `O(M)` producer count during a merge and RETURNS to baseline once the producers
+//! are joined/dropped — making the previously-invisible per-merge thread cost
+//! observable on a loaded node.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use crate::observability;
+
+static LIVE: AtomicI64 = AtomicI64::new(0);
+
+fn record(live: i64) {
+    observability::record_gauge(observability::catalog::MERGE_PRODUCER_THREADS, live, &[]);
+}
+
+/// Account a just-spawned producer thread on the gauge. Balanced by exactly one
+/// [`ProducerThreadGuard`] drop when that thread exits.
+pub(super) fn spawned() {
+    record(LIVE.fetch_add(1, Ordering::SeqCst) + 1);
+}
+
+/// RAII guard that decrements the live producer-thread count (and re-records the
+/// gauge) when a producer thread exits — even on panic.
+pub(super) struct ProducerThreadGuard;
+
+impl Drop for ProducerThreadGuard {
+    fn drop(&mut self) {
+        record(LIVE.fetch_sub(1, Ordering::SeqCst) - 1);
+    }
+}

--- a/cqlite-core/tests/issue_2316_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2316_merge_thread_budget.rs
@@ -178,7 +178,11 @@ fn collect_inputs(dir: &std::path::Path, out: &mut Vec<(u64, PathBuf)>, depth: u
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
         if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
             let base = name.trim_end_matches("-Data.db");
             if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
@@ -282,8 +286,8 @@ fn merge_bounds_producer_threads_to_o_m() {
     );
 
     // Drain the merge so producers exit cleanly (no leaked threads / temp files).
-    let mut writer = SSTableWriter::new(out.path().to_path_buf(), 1, &schema)
-        .expect("SSTableWriter::new");
+    let mut writer =
+        SSTableWriter::new(out.path().to_path_buf(), 1, &schema).expect("SSTableWriter::new");
     writer.pre_seed_encoding_baselines(baseline_ts, baseline_ldt, baseline_ttl);
     let stats = merger.merge(&mut writer).expect("merge into writer");
     let finish_rt = tokio::runtime::Builder::new_current_thread()

--- a/cqlite-core/tests/issue_2316_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2316_merge_thread_budget.rs
@@ -22,6 +22,24 @@
 //! `num_cpus >= 2`. Where the amplification collapses (`num_cpus < 2`) or the
 //! platform exposes no direct thread-count API, the test guards deterministically
 //! rather than flake.
+//!
+//! ## Process-isolation requirement
+//!
+//! The peak-thread observation is a WHOLE-PROCESS count, not a count scoped to
+//! this test's own threads — so it is only meaningful if this test runs ALONE in
+//! its process. The gate's default runner is `nextest` (see `accelerators:` in
+//! every `AGENT-GATE`/`AGENT-GATE LITE` summary), which isolates every `#[test]`
+//! in its OWN process, so this holds unconditionally under the gate. Under plain
+//! `cargo test` (no nextest), cargo instead runs every `#[test]` fn WITHIN one
+//! compiled test binary CONCURRENTLY, as sibling threads sharing ONE process —
+//! any sibling test's threads (its own producer threads, tokio workers, etc.)
+//! would inflate the peak sampled here and could false-fail (never false-PASS,
+//! since extra threads only push the observed delta up) or otherwise make the
+//! bound assertion meaningless. This file is therefore kept to EXACTLY this one
+//! `#[test]` function so plain `cargo test --test issue_2316_merge_thread_budget`
+//! stays isolated too (one file = one binary = one process; no siblings to race
+//! against) — do not add a second `#[test]` fn to this file; add a sibling test
+//! FILE instead if another scenario is needed.
 
 #![cfg(feature = "write-support")]
 

--- a/cqlite-core/tests/issue_2316_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2316_merge_thread_budget.rs
@@ -47,10 +47,16 @@ const ROWS_PER_INPUT: i32 = 400;
 /// Number of input SSTables (`M`) merged in one pass.
 const NUM_INPUTS: usize = 4;
 
-/// Slack over the `O(M)` bound to absorb incidental threads (driver/settle loop).
-/// Kept strictly below `M·num_cpus_min` (= `M·2`) so the pre-change amplification
-/// still trips the bound on a 2-core host.
-const THREAD_SLACK: usize = 4;
+/// Max OS threads a single fixed (`current_thread`-runtime) producer contributes
+/// at its peak: the producer thread itself plus the bounded `spawn_blocking`
+/// parse/feed threads the compaction scan uses (a small constant, INDEPENDENT of
+/// `num_cpus`). The pre-change multi-threaded runtime instead added `num_cpus`
+/// worker threads PER producer on top of this, so the pre-change peak scales with
+/// `num_cpus` and this `O(M)` bound (coefficient fixed at `PER_INPUT`) rejects it.
+const PER_INPUT: usize = 3;
+
+/// Fixed slack over the `PER_INPUT · M` bound for incidental/settle threads.
+const THREAD_SLACK: usize = 3;
 
 // ── Direct, no-heuristics OS thread-count observation ───────────────────────
 
@@ -269,7 +275,7 @@ fn merge_bounds_producer_threads_to_o_m() {
     // Sample the peak while the producers are blocked (a wide, stable window).
     let peak = sample_peak_threads(Duration::from_millis(1200)).expect("peak thread count");
     let delta = peak.saturating_sub(baseline);
-    let bound = m + THREAD_SLACK;
+    let bound = PER_INPUT * m + THREAD_SLACK;
 
     eprintln!(
         "[issue-2316] cpus={cpus} M={m} baseline={baseline} peak={peak} delta={delta} bound={bound}"
@@ -299,8 +305,8 @@ fn merge_bounds_producer_threads_to_o_m() {
     assert!(
         delta <= bound,
         "merge over M={m} inputs added {delta} OS threads over baseline \
-         (peak={peak}, baseline={baseline}); O(M) bound is {bound} (= M + {THREAD_SLACK}). \
-         A delta near M·num_cpus (num_cpus={cpus}) means a producer built a \
+         (peak={peak}, baseline={baseline}); O(M) bound is {bound} (= {PER_INPUT}·M + {THREAD_SLACK}). \
+         A delta scaling with num_cpus (num_cpus={cpus}) means a producer built a \
          multi-threaded runtime — issue #2316 amplification."
     );
 }

--- a/cqlite-core/tests/issue_2316_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2316_merge_thread_budget.rs
@@ -15,13 +15,19 @@
 //!
 //! The producers block on the bounded streaming channel (`sync_channel`) once it
 //! fills, so once the merger is constructed — and BEFORE it is drained — every
-//! producer is alive at once. That gives a deterministic window in which to sample
-//! the peak: no concurrent-sampler timing race. The assertion FAILS on the
-//! pre-change code (each producer's multi-threaded runtime adds `num_cpus` workers)
-//! and PASSES after the `current_thread`-runtime fix, on any host where
-//! `num_cpus >= 2`. Where the amplification collapses (`num_cpus < 2`) or the
-//! platform exposes no direct thread-count API, the test guards deterministically
-//! rather than flake.
+//! producer is alive at once and STAYS alive (thread count cannot decrease) until
+//! this test starts draining. Rather than sampling over a fixed elapsed-time
+//! window (which can under-sample on a contended host where producer startup
+//! drifts outside the window — roborev job 1604 finding 1), the peak is captured
+//! by polling until the process's OS thread count STABILIZES — the same reading
+//! across several consecutive polls — synchronizing on the producer LIFECYCLE
+//! itself, never on elapsed time. A generous timeout bounds the poll and FAILS
+//! LOUDLY (a clear panic, never a silent under-sample) if the count never
+//! settles. The assertion FAILS on the pre-change code (each producer's
+//! multi-threaded runtime adds `num_cpus` workers) and PASSES after the
+//! `current_thread`-runtime fix, on any host where `num_cpus >= 2`. Where the
+//! amplification collapses (`num_cpus < 2`) or the platform exposes no direct
+//! thread-count API, the test guards deterministically rather than flake.
 //!
 //! ## Process-isolation requirement
 //!
@@ -118,20 +124,60 @@ fn os_thread_count() -> Option<usize> {
     None
 }
 
-/// Sample the peak OS thread count over a fixed window. The producers stay blocked
-/// on the bounded channel for the whole window (nothing is draining them), so the
-/// peak is stable; polling simply waits out the brief interval in which each
-/// producer builds its runtime and reaches the blocked state.
-fn sample_peak_threads(window: Duration) -> Option<usize> {
-    let deadline = Instant::now() + window;
-    let mut peak = os_thread_count()?;
+/// Number of consecutive identical readings required to treat the OS thread
+/// count as STABILIZED (issue #2316, roborev job 1604 finding 1).
+const STABLE_STREAK: usize = 8;
+
+/// Delay between polls while waiting for stabilization.
+const POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Poll the process's OS thread count until it STABILIZES — the same reading
+/// observed across [`STABLE_STREAK`] consecutive polls — synchronizing on the
+/// actual thread LIFECYCLE instead of a fixed elapsed-time window. Thread
+/// creation itself is a synchronous kernel operation (a new `/proc/self/task`
+/// entry — or macOS `pti_threadnum` increment — appears the instant the OS
+/// creates the thread, regardless of scheduling delay), so once every producer
+/// this test spawns has been created, the count settles quickly and reliably;
+/// this poll simply waits out that settling instead of assuming a fixed window
+/// covers it.
+///
+/// Returns `(peak, settled)`: `peak` is the highest reading observed at ANY
+/// point while polling (so a transient spike — e.g. the pre-fix defect's burst
+/// of per-producer runtime-worker threads — is captured even if the count later
+/// settles lower), while `settled` is the reading that satisfied the
+/// stabilization streak.
+///
+/// `timeout` is a fail-loud BOUND ONLY, never the synchronization mechanism: if
+/// the count never stabilizes within it, this panics with a clear diagnostic
+/// (producer startup may be stalled under extreme contention) rather than
+/// silently returning an under-sampled value.
+fn poll_until_stable(timeout: Duration) -> (usize, usize) {
+    let deadline = Instant::now() + timeout;
+    let mut peak = 0usize;
+    let mut last: Option<usize> = None;
+    let mut streak = 0usize;
     while Instant::now() < deadline {
-        if let Some(n) = os_thread_count() {
-            peak = peak.max(n);
+        let n = os_thread_count().expect(
+            "thread count observation must remain available (guard 2 already confirmed it)",
+        );
+        peak = peak.max(n);
+        if last == Some(n) {
+            streak += 1;
+            if streak >= STABLE_STREAK {
+                return (peak, n);
+            }
+        } else {
+            last = Some(n);
+            streak = 1;
         }
-        std::thread::sleep(Duration::from_millis(10));
+        std::thread::sleep(POLL_INTERVAL);
     }
-    Some(peak)
+    panic!(
+        "OS thread count never stabilized within {timeout:?} (last reading {last:?}, \
+         streak {streak}/{STABLE_STREAK} required, peak observed {peak}); this is a \
+         fail-loud BOUND, not a synchronization mechanism — producer startup may be \
+         stalled under extreme contention, or the lifecycle signal never settles"
+    );
 }
 
 // ── Real multi-SSTable input construction (never an empty dataset) ──────────
@@ -279,11 +325,14 @@ fn merge_bounds_producer_threads_to_o_m() {
     let m = inputs.len();
     let out = TempDir::new().expect("out tempdir");
 
-    // Settle the baseline: the input-build runtime has been dropped; wait for the
-    // process thread count to quiesce so the baseline is not inflated by threads
-    // still winding down.
-    std::thread::sleep(Duration::from_millis(50));
-    let baseline = os_thread_count().expect("baseline thread count");
+    // Settle the baseline via LIFECYCLE synchronization (issue #2316, roborev job
+    // 1604 finding 1): the input-build runtime has been dropped, but its
+    // teardown may still be in flight — poll until the process thread count
+    // STABILIZES (rather than sleeping a fixed, potentially-too-short duration
+    // under contention) so the baseline reflects the genuinely quiesced state.
+    // The settled reading (not the transient peak while winding down) is the
+    // correct baseline.
+    let (_settle_peak, baseline) = poll_until_stable(Duration::from_secs(10));
 
     // Construct the merger: this spawns all M producer threads. Each producer
     // opens its reader and streams into the bounded channel; with ROWS_PER_INPUT
@@ -294,8 +343,14 @@ fn merge_bounds_producer_threads_to_o_m() {
     let (baseline_ts, baseline_ldt, baseline_ttl) = compute_baseline_min(&inputs);
     let merger = KWayMerger::new(inputs, &schema).expect("KWayMerger::new");
 
-    // Sample the peak while the producers are blocked (a wide, stable window).
-    let peak = sample_peak_threads(Duration::from_millis(1200)).expect("peak thread count");
+    // Wait for the producer threads to finish starting up and reach their
+    // steady (blocked-on-send) state via the SAME lifecycle synchronization
+    // (issue #2316, roborev job 1604 finding 1) — never a fixed sampling
+    // window, which could miss the true peak if producer startup drifts outside
+    // it on a contended host. `peak` also captures any transient spike seen
+    // while ramping up (the pre-fix defect: a burst of per-producer runtime
+    // worker threads), even if the count later settles slightly lower.
+    let (peak, _settled) = poll_until_stable(Duration::from_secs(15));
     let delta = peak.saturating_sub(baseline);
     let bound = PER_INPUT * m + THREAD_SLACK;
 

--- a/cqlite-core/tests/issue_2316_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2316_merge_thread_budget.rs
@@ -1,0 +1,306 @@
+//! Issue #2316 — the k-way merge must bound its producer-thread cost to O(M).
+//!
+//! The write-engine k-way merge (shared by compaction/maintenance and the Flight
+//! `do_get` streaming egress) opens one OS producer thread per input SSTable.
+//! Before the fix each producer built a full multi-threaded `tokio::runtime::Runtime`,
+//! spinning up `num_cpus` worker threads — so ONE merge over `M` inputs cost
+//! `~M + M·num_cpus` OS threads. On a many-core node a handful of concurrent Flight
+//! queries multiplied that into a context-switch storm well before disk bandwidth
+//! saturated (see `openspec/changes/flight-merge-runtime-amplification/`).
+//!
+//! This test PINS the bound by driving a REAL multi-SSTable merge and observing
+//! the process's PEAK OS thread count DIRECTLY — the Linux `/proc/self/task` entry
+//! count, or the macOS `proc_pidinfo(PROC_PIDTASKINFO).pti_threadnum` kernel task
+//! count. Both are direct kernel observations, never a heuristic inference.
+//!
+//! The producers block on the bounded streaming channel (`sync_channel`) once it
+//! fills, so once the merger is constructed — and BEFORE it is drained — every
+//! producer is alive at once. That gives a deterministic window in which to sample
+//! the peak: no concurrent-sampler timing race. The assertion FAILS on the
+//! pre-change code (each producer's multi-threaded runtime adds `num_cpus` workers)
+//! and PASSES after the `current_thread`-runtime fix, on any host where
+//! `num_cpus >= 2`. Where the amplification collapses (`num_cpus < 2`) or the
+//! platform exposes no direct thread-count API, the test guards deterministically
+//! rather than flake.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::writer::SSTableWriter;
+use cqlite_core::storage::write_engine::merge::compute_baseline_min;
+use cqlite_core::storage::write_engine::{
+    CellOperation, KWayMerger, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+/// Rows per input SSTable. Must EXCEED the merge's `STREAMING_CHANNEL_CAPACITY`
+/// (256) so every producer fills its bounded channel and blocks on `send` before
+/// the merge starts draining — guaranteeing all `M` producers are alive at once
+/// at the sampling point (deterministic peak, no timing race).
+const ROWS_PER_INPUT: i32 = 400;
+
+/// Number of input SSTables (`M`) merged in one pass.
+const NUM_INPUTS: usize = 4;
+
+/// Slack over the `O(M)` bound to absorb incidental threads (driver/settle loop).
+/// Kept strictly below `M·num_cpus_min` (= `M·2`) so the pre-change amplification
+/// still trips the bound on a 2-core host.
+const THREAD_SLACK: usize = 4;
+
+// ── Direct, no-heuristics OS thread-count observation ───────────────────────
+
+/// Count OS threads in the current process by direct kernel observation.
+///
+/// Returns `None` on a platform that exposes no direct thread-count API (the
+/// test then guards rather than assert a bound it cannot measure).
+#[cfg(target_os = "linux")]
+fn os_thread_count() -> Option<usize> {
+    // The number of entries under /proc/self/task IS the live kernel thread count.
+    std::fs::read_dir("/proc/self/task")
+        .ok()
+        .map(|it| it.flatten().count())
+}
+
+#[cfg(target_os = "macos")]
+fn os_thread_count() -> Option<usize> {
+    // proc_pidinfo(PROC_PIDTASKINFO).pti_threadnum is the kernel's live task
+    // (thread) count for the process — a direct observation, not an estimate.
+    let pid = unsafe { libc::getpid() };
+    let mut info: libc::proc_taskinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_taskinfo>() as libc::c_int;
+    let ret = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTASKINFO,
+            0,
+            &mut info as *mut libc::proc_taskinfo as *mut libc::c_void,
+            size,
+        )
+    };
+    if ret == size {
+        Some(info.pti_threadnum as usize)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn os_thread_count() -> Option<usize> {
+    None
+}
+
+/// Sample the peak OS thread count over a fixed window. The producers stay blocked
+/// on the bounded channel for the whole window (nothing is draining them), so the
+/// peak is stable; polling simply waits out the brief interval in which each
+/// producer builds its runtime and reaches the blocked state.
+fn sample_peak_threads(window: Duration) -> Option<usize> {
+    let deadline = Instant::now() + window;
+    let mut peak = os_thread_count()?;
+    while Instant::now() < deadline {
+        if let Some(n) = os_thread_count() {
+            peak = peak.max(n);
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Some(peak)
+}
+
+// ── Real multi-SSTable input construction (never an empty dataset) ──────────
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "merge_budget_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "val".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, val: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("merge_budget_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "val".to_string(),
+            value: Value::Text(val.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// Discover published `nb-*-big-Data.db` files under `dir` (recursively, since the
+/// WriteEngine nests them under keyspace/table subdirs), newest-generation first.
+fn discover_inputs(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut found: Vec<(u64, PathBuf)> = Vec::new();
+    collect_inputs(dir, &mut found, 8);
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+fn collect_inputs(dir: &std::path::Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+        if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+            let base = name.trim_end_matches("-Data.db");
+            if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
+                continue;
+            }
+            let generation = name
+                .strip_prefix("nb-")
+                .and_then(|s| s.split("-big-").next())
+                .and_then(|g| g.parse::<u64>().ok())
+                .unwrap_or(0);
+            out.push((generation, path));
+        } else if depth > 0 && path.is_dir() {
+            collect_inputs(&path, out, depth - 1);
+        }
+    }
+}
+
+/// Build `NUM_INPUTS` REAL nb SSTables (each `ROWS_PER_INPUT` live rows over a
+/// disjoint partition range) by flushing a `WriteEngine`. Returns them newest-first.
+/// Never empty: every input carries real, non-empty partitions the merge scans.
+fn build_inputs() -> (TempDir, Vec<PathBuf>, TableSchema) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("driver runtime");
+    let temp = TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("inputs");
+    let wal_dir = temp.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+
+    for input in 0..NUM_INPUTS {
+        let base = input as i32 * ROWS_PER_INPUT;
+        for r in 0..ROWS_PER_INPUT {
+            let id = base + r;
+            engine
+                .write(write_row(id, &format!("v-{input}-{r}"), 100 + input as i64))
+                .expect("write row");
+        }
+        rt.block_on(engine.flush())
+            .expect("flush")
+            .expect("flush info");
+    }
+    rt.block_on(engine.close()).expect("close engine");
+
+    let inputs = discover_inputs(&data_dir);
+    assert!(
+        inputs.len() >= NUM_INPUTS,
+        "expected >= {NUM_INPUTS} real input SSTables, got {}",
+        inputs.len()
+    );
+    // Drop the driver runtime BEFORE the caller measures the thread baseline so
+    // its (now-joined) worker threads are not in the baseline.
+    drop(rt);
+    (temp, inputs, schema)
+}
+
+#[test]
+fn merge_bounds_producer_threads_to_o_m() {
+    // Guard 1: the amplification (M·num_cpus) collapses on a single-core host, so
+    // the bound cannot be distinguished from the O(M) target there. Hold trivially.
+    let cpus = num_cpus::get();
+    if cpus < 2 {
+        eprintln!("[skip] num_cpus={cpus} < 2 — amplification not observable; holding trivially");
+        return;
+    }
+    // Guard 2: no direct thread-count API on this platform → cannot observe.
+    if os_thread_count().is_none() {
+        eprintln!("[skip] no direct OS thread-count API on this platform; holding trivially");
+        return;
+    }
+
+    let (_temp, inputs, schema) = build_inputs();
+    let m = inputs.len();
+    let out = TempDir::new().expect("out tempdir");
+
+    // Settle the baseline: the input-build runtime has been dropped; wait for the
+    // process thread count to quiesce so the baseline is not inflated by threads
+    // still winding down.
+    std::thread::sleep(Duration::from_millis(50));
+    let baseline = os_thread_count().expect("baseline thread count");
+
+    // Construct the merger: this spawns all M producer threads. Each producer
+    // opens its reader and streams into the bounded channel; with ROWS_PER_INPUT
+    // (> the 256-entry channel capacity) every producer fills its channel and
+    // blocks on `send` — so all M are alive at once and stay alive until `merge()`
+    // below drains them. Pre-change: each producer ALSO holds a multi-threaded
+    // runtime (num_cpus workers). Post-change: a current_thread runtime, 0 workers.
+    let (baseline_ts, baseline_ldt, baseline_ttl) = compute_baseline_min(&inputs);
+    let merger = KWayMerger::new(inputs, &schema).expect("KWayMerger::new");
+
+    // Sample the peak while the producers are blocked (a wide, stable window).
+    let peak = sample_peak_threads(Duration::from_millis(1200)).expect("peak thread count");
+    let delta = peak.saturating_sub(baseline);
+    let bound = m + THREAD_SLACK;
+
+    eprintln!(
+        "[issue-2316] cpus={cpus} M={m} baseline={baseline} peak={peak} delta={delta} bound={bound}"
+    );
+
+    // Drain the merge so producers exit cleanly (no leaked threads / temp files).
+    let mut writer = SSTableWriter::new(out.path().to_path_buf(), 1, &schema)
+        .expect("SSTableWriter::new");
+    writer.pre_seed_encoding_baselines(baseline_ts, baseline_ldt, baseline_ttl);
+    let stats = merger.merge(&mut writer).expect("merge into writer");
+    let finish_rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("finish runtime");
+    finish_rt.block_on(writer.finish()).expect("writer finish");
+
+    // Sanity: the merge actually processed the real rows (never an empty dataset).
+    assert!(
+        stats.output_rows >= (NUM_INPUTS as u64 * ROWS_PER_INPUT as u64),
+        "merge should emit all input rows; got {} (expected >= {})",
+        stats.output_rows,
+        NUM_INPUTS as u64 * ROWS_PER_INPUT as u64
+    );
+
+    // THE PIN: the merge's peak OS-thread delta over baseline must be within the
+    // O(M) bound. Pre-change this is `M + M·num_cpus` (>> bound); post-change `M`.
+    assert!(
+        delta <= bound,
+        "merge over M={m} inputs added {delta} OS threads over baseline \
+         (peak={peak}, baseline={baseline}); O(M) bound is {bound} (= M + {THREAD_SLACK}). \
+         A delta near M·num_cpus (num_cpus={cpus}) means a producer built a \
+         multi-threaded runtime — issue #2316 amplification."
+    );
+}

--- a/cqlite-core/tests/issue_2316_producer_gauge.rs
+++ b/cqlite-core/tests/issue_2316_producer_gauge.rs
@@ -177,6 +177,17 @@ fn producer_threads_gauge_rises_and_returns_to_baseline() {
         "gauge must carry the {{thread}} unit"
     );
 
+    // Reset HERE — BEFORE the drain starts — so the fresh delta window opens
+    // strictly before any producer thread can exit and decrement. The producer
+    // threads that back the M live count are DETACHED (a `JoinHandle` drop does
+    // not join), so some or all of the M decrements below can complete on their
+    // own OS threads before this test thread even reaches the polling loop;
+    // resetting AFTER the drain (as an earlier version of this test did) risks
+    // clearing that evidence away before it is ever observed. Establishing the
+    // window here, then NEVER resetting again before inspecting the accumulated
+    // evidence below, is what makes the transition-to-0 observable at all.
+    capture.reset();
+
     // Drain the merge; its producers exit and decrement the gauge on the way out.
     let mut writer =
         SSTableWriter::new(out.path().to_path_buf(), 1, &schema).expect("SSTableWriter::new");
@@ -194,28 +205,51 @@ fn producer_threads_gauge_rises_and_returns_to_baseline() {
     );
 
     // AFTER: the merge's producers have exited (each guard decremented the live
-    // count on the way out). The gauge returns to its baseline (0). Poll with a
-    // per-iteration `reset` so each reading is an ISOLATED delta window (a single
-    // `flush_and_collect` would otherwise SUM the still-buffered mid-merge `M`
-    // snapshot). Under DELTA temporality a steady gauge with no new record in the
-    // window reports absent (== 0.0). This is NON-vacuous: the mid assertion above
-    // already proved the same gauge recorded the live count `M` during the merge,
-    // so a settled 0 here is a genuine return-to-baseline, not a never-recorded
-    // metric. Bounded → deterministic, never a wall-clock race.
+    // count on the way out) — the gauge should have recorded a genuine transition
+    // down to 0 WITHIN the window opened by the `reset()` above (before the
+    // drain). Under DELTA temporality a window with NO new `record_gauge` call
+    // reports the metric as ABSENT — `CapturedMetrics::counter_sum` then defaults
+    // an absent metric to `0.0`. Treating THAT default as "returned to baseline"
+    // is VACUOUS: it would pass identically whether the decrement path fired or
+    // is entirely broken. So this loop requires POSITIVE evidence: an actual
+    // collected data point equal to `0.0`, never inferred from absence.
+    //
+    // Deliberately NO `reset()` inside this loop: the producer threads are
+    // DETACHED (`JoinHandle` drop does not join), so the decrement(s) may have
+    // already completed before this loop's first iteration — resetting again
+    // here would risk clearing that very evidence before it is ever read.
+    // Instead each poll calls `flush_and_collect` (which force-flushes any
+    // pending record into the exporter's buffer WITHOUT clearing it) and scans
+    // ALL accumulated matching entries/points for the given metric — not just
+    // `find`'s first match, which would return only the earliest post-reset
+    // batch and could get stuck on a stale intermediate (non-zero) reading while
+    // later batches already show the settled 0. Bounded → deterministic, never a
+    // wall-clock race; a broken decrement path (or a leaked increment) exhausts
+    // the deadline and FAILS explicitly rather than passing vacuously.
     let deadline = Instant::now() + Duration::from_secs(5);
-    let mut final_val = f64::NAN;
+    let mut observed_zero_record = false;
+    let mut last_seen: Option<f64> = None;
     while Instant::now() < deadline {
-        capture.reset();
         std::thread::sleep(Duration::from_millis(20));
-        final_val = capture
-            .flush_and_collect()
-            .counter_sum(catalog::MERGE_PRODUCER_THREADS);
-        if final_val == 0.0 {
+        let snap = capture.flush_and_collect();
+        let matches: Vec<f64> = snap
+            .entries()
+            .iter()
+            .filter(|e| e.name == catalog::MERGE_PRODUCER_THREADS)
+            .flat_map(|e| e.points.iter().map(|p| p.value))
+            .collect();
+        if let Some(&v) = matches.last() {
+            last_seen = Some(v);
+        }
+        if matches.iter().any(|&v| v == 0.0) {
+            observed_zero_record = true;
             break;
         }
     }
-    assert_eq!(
-        final_val, 0.0,
-        "gauge must return to its baseline (0) after the merge's producers are joined/dropped"
+    assert!(
+        observed_zero_record,
+        "gauge must POSITIVELY record a value of 0 after the merge's producers exit \
+         (never inferred from an absent/un-updated window); last observed value: {:?}",
+        last_seen
     );
 }

--- a/cqlite-core/tests/issue_2316_producer_gauge.rs
+++ b/cqlite-core/tests/issue_2316_producer_gauge.rs
@@ -1,0 +1,209 @@
+//! Issue #2316 — the `cqlite.merge.producer_threads` gauge.
+//!
+//! Corroborates the O(M) producer-thread bound with an always-on observability
+//! signal (independent of the direct `/proc` thread-count observation in
+//! `issue_2316_merge_thread_budget.rs`): the gauge RISES to reflect the live
+//! producer threads while a real merge holds them, and RETURNS to its baseline
+//! once the merge's producers are joined/dropped.
+//!
+//! Runs only under `observability-testing` (the in-memory metric capture fixture):
+//!   cargo test -p cqlite-core --features observability-testing \
+//!     --test issue_2316_producer_gauge
+
+#![cfg(all(feature = "write-support", feature = "observability-testing"))]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::writer::SSTableWriter;
+use cqlite_core::storage::write_engine::merge::compute_baseline_min;
+use cqlite_core::storage::write_engine::{
+    CellOperation, KWayMerger, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+/// Rows per input SSTable. MUST exceed the merge's 256-entry channel capacity so
+/// every producer blocks on `send` and stays alive (uncollapsed live count) until
+/// the merge drains it — giving a deterministic window where the gauge reads `M`.
+const ROWS_PER_INPUT: i32 = 400;
+const NUM_INPUTS: usize = 4;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "gauge_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "val".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, val: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("gauge_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "val".to_string(),
+            value: Value::Text(val.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+fn collect_inputs(dir: &std::path::Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+        if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+            let base = name.trim_end_matches("-Data.db");
+            if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
+                continue;
+            }
+            let generation = name
+                .strip_prefix("nb-")
+                .and_then(|s| s.split("-big-").next())
+                .and_then(|g| g.parse::<u64>().ok())
+                .unwrap_or(0);
+            out.push((generation, path));
+        } else if depth > 0 && path.is_dir() {
+            collect_inputs(&path, out, depth - 1);
+        }
+    }
+}
+
+/// Build `NUM_INPUTS` REAL nb SSTables (each `ROWS_PER_INPUT` live rows over a
+/// disjoint partition range). Never empty.
+fn build_inputs() -> (TempDir, Vec<PathBuf>, TableSchema) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("driver runtime");
+    let temp = TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("inputs");
+    let wal_dir = temp.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for input in 0..NUM_INPUTS {
+        let base = input as i32 * ROWS_PER_INPUT;
+        for r in 0..ROWS_PER_INPUT {
+            engine
+                .write(write_row(base + r, &format!("v-{input}-{r}"), 100 + input as i64))
+                .expect("write row");
+        }
+        rt.block_on(engine.flush()).expect("flush").expect("flush info");
+    }
+    rt.block_on(engine.close()).expect("close engine");
+
+    let mut found = Vec::new();
+    collect_inputs(&data_dir, &mut found, 8);
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    let inputs: Vec<PathBuf> = found.into_iter().map(|(_, p)| p).collect();
+    assert!(
+        inputs.len() >= NUM_INPUTS,
+        "expected >= {NUM_INPUTS} real inputs, got {}",
+        inputs.len()
+    );
+    drop(rt);
+    (temp, inputs, schema)
+}
+
+#[test]
+fn producer_threads_gauge_rises_and_returns_to_baseline() {
+    let capture = testing::metrics_capture();
+    capture.reset();
+
+    let (_temp, inputs, schema) = build_inputs();
+    let m = inputs.len();
+    let out = TempDir::new().expect("out tempdir");
+    let (baseline_ts, baseline_ldt, baseline_ttl) = compute_baseline_min(&inputs);
+
+    // Construct the merger: all M producers spawn and — with ROWS_PER_INPUT > the
+    // 256-entry channel capacity — block on `send`, so none decrements before the
+    // snapshot below. The gauge was incremented once per producer at spawn.
+    let merger = KWayMerger::new(inputs, &schema).expect("KWayMerger::new");
+
+    // MID-MERGE: the gauge must reflect the M live producer threads.
+    let mid = capture.flush_and_collect();
+    let mid_val = mid.counter_sum(catalog::MERGE_PRODUCER_THREADS);
+    assert_eq!(
+        mid_val, m as f64,
+        "gauge should read M={m} live producer threads mid-merge, got {mid_val}"
+    );
+    assert_eq!(
+        mid.unit(catalog::MERGE_PRODUCER_THREADS),
+        Some(catalog::unit::THREADS),
+        "gauge must carry the {{thread}} unit"
+    );
+
+    // Drain the merge; its producers exit and decrement the gauge on the way out.
+    let mut writer =
+        SSTableWriter::new(out.path().to_path_buf(), 1, &schema).expect("SSTableWriter::new");
+    writer.pre_seed_encoding_baselines(baseline_ts, baseline_ldt, baseline_ttl);
+    let stats = merger.merge(&mut writer).expect("merge into writer");
+    let finish_rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("finish runtime");
+    finish_rt.block_on(writer.finish()).expect("writer finish");
+    assert!(
+        stats.output_rows >= (NUM_INPUTS as u64 * ROWS_PER_INPUT as u64),
+        "merge should emit all input rows; got {}",
+        stats.output_rows
+    );
+
+    // AFTER: the merge's producers have exited (each guard decremented the live
+    // count on the way out). The gauge returns to its baseline (0). Poll with a
+    // per-iteration `reset` so each reading is an ISOLATED delta window (a single
+    // `flush_and_collect` would otherwise SUM the still-buffered mid-merge `M`
+    // snapshot). Under DELTA temporality a steady gauge with no new record in the
+    // window reports absent (== 0.0). This is NON-vacuous: the mid assertion above
+    // already proved the same gauge recorded the live count `M` during the merge,
+    // so a settled 0 here is a genuine return-to-baseline, not a never-recorded
+    // metric. Bounded → deterministic, never a wall-clock race.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut final_val = f64::NAN;
+    while Instant::now() < deadline {
+        capture.reset();
+        std::thread::sleep(Duration::from_millis(20));
+        final_val = capture.flush_and_collect().counter_sum(catalog::MERGE_PRODUCER_THREADS);
+        if final_val == 0.0 {
+            break;
+        }
+    }
+    assert_eq!(
+        final_val, 0.0,
+        "gauge must return to its baseline (0) after the merge's producers are joined/dropped"
+    );
+}

--- a/cqlite-core/tests/issue_2316_producer_gauge.rs
+++ b/cqlite-core/tests/issue_2316_producer_gauge.rs
@@ -83,7 +83,11 @@ fn collect_inputs(dir: &std::path::Path, out: &mut Vec<(u64, PathBuf)>, depth: u
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
         if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
             let base = name.trim_end_matches("-Data.db");
             if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
@@ -119,10 +123,16 @@ fn build_inputs() -> (TempDir, Vec<PathBuf>, TableSchema) {
         let base = input as i32 * ROWS_PER_INPUT;
         for r in 0..ROWS_PER_INPUT {
             engine
-                .write(write_row(base + r, &format!("v-{input}-{r}"), 100 + input as i64))
+                .write(write_row(
+                    base + r,
+                    &format!("v-{input}-{r}"),
+                    100 + input as i64,
+                ))
                 .expect("write row");
         }
-        rt.block_on(engine.flush()).expect("flush").expect("flush info");
+        rt.block_on(engine.flush())
+            .expect("flush")
+            .expect("flush info");
     }
     rt.block_on(engine.close()).expect("close engine");
 
@@ -197,7 +207,9 @@ fn producer_threads_gauge_rises_and_returns_to_baseline() {
     while Instant::now() < deadline {
         capture.reset();
         std::thread::sleep(Duration::from_millis(20));
-        final_val = capture.flush_and_collect().counter_sum(catalog::MERGE_PRODUCER_THREADS);
+        final_val = capture
+            .flush_and_collect()
+            .counter_sum(catalog::MERGE_PRODUCER_THREADS);
         if final_val == 0.0 {
             break;
         }

--- a/cqlite-core/tests/issue_2316_producer_gauge.rs
+++ b/cqlite-core/tests/issue_2316_producer_gauge.rs
@@ -164,15 +164,50 @@ fn producer_threads_gauge_rises_and_returns_to_baseline() {
     // snapshot below. The gauge was incremented once per producer at spawn.
     let merger = KWayMerger::new(inputs, &schema).expect("KWayMerger::new");
 
-    // MID-MERGE: the gauge must reflect the M live producer threads.
-    let mid = capture.flush_and_collect();
-    let mid_val = mid.counter_sum(catalog::MERGE_PRODUCER_THREADS);
-    assert_eq!(
-        mid_val, m as f64,
-        "gauge should read M={m} live producer threads mid-merge, got {mid_val}"
+    // MID-MERGE: poll until the gauge POSITIVELY records M — synchronizing on the
+    // producer LIFECYCLE rather than assuming a single immediate snapshot right
+    // after `KWayMerger::new` already reflects every increment (issue #2316,
+    // roborev job 1604 finding 2). Bounded + fail-loud: a broken or delayed
+    // increment path exhausts the deadline and FAILS explicitly rather than
+    // silently checking a possibly-incomplete snapshot. Scans ALL accumulated
+    // matching points (not `find`'s first-match) for the same reason as the
+    // teardown poll below: repeated `flush_and_collect` calls without an
+    // intervening `reset` accumulate one batch per call, and `find` would get
+    // stuck on the EARLIEST batch (e.g. "2" while producers 3 and 4 are still
+    // incrementing) rather than ever observing the LATEST value.
+    let mid_deadline = Instant::now() + Duration::from_secs(10);
+    let mut mid_reached = false;
+    let mut mid_last_seen: Option<f64> = None;
+    let mut mid_unit: Option<String> = None;
+    while Instant::now() < mid_deadline {
+        let snap = capture.flush_and_collect();
+        for entry in snap
+            .entries()
+            .iter()
+            .filter(|e| e.name == catalog::MERGE_PRODUCER_THREADS)
+        {
+            mid_unit = Some(entry.unit.clone());
+            for point in &entry.points {
+                mid_last_seen = Some(point.value);
+                if point.value == m as f64 {
+                    mid_reached = true;
+                }
+            }
+        }
+        if mid_reached {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        mid_reached,
+        "gauge should POSITIVELY record M={m} live producer threads mid-merge \
+         within the bound (never inferred from an absent/stale window); last \
+         observed value: {:?}",
+        mid_last_seen
     );
     assert_eq!(
-        mid.unit(catalog::MERGE_PRODUCER_THREADS),
+        mid_unit.as_deref(),
         Some(catalog::unit::THREADS),
         "gauge must carry the {{thread}} unit"
     );
@@ -204,15 +239,32 @@ fn producer_threads_gauge_rises_and_returns_to_baseline() {
         stats.output_rows
     );
 
-    // AFTER: the merge's producers have exited (each guard decremented the live
-    // count on the way out) — the gauge should have recorded a genuine transition
-    // down to 0 WITHIN the window opened by the `reset()` above (before the
-    // drain). Under DELTA temporality a window with NO new `record_gauge` call
-    // reports the metric as ABSENT — `CapturedMetrics::counter_sum` then defaults
-    // an absent metric to `0.0`. Treating THAT default as "returned to baseline"
-    // is VACUOUS: it would pass identically whether the decrement path fired or
-    // is entirely broken. So this loop requires POSITIVE evidence: an actual
-    // collected data point equal to `0.0`, never inferred from absence.
+    // AFTER: driven from an explicit completion event — the merge has already
+    // been drained to completion (`merger.merge` + `writer.finish` above both
+    // returned) — NOT a fixed sleep (issue #2316, roborev job 1604 finding 2).
+    // Draining to completion guarantees every producer's channel closed (so its
+    // scan loop has finished), but the producer THREAD itself may still be
+    // mid-unwind: the channel closes when its `sync_channel` sender is dropped
+    // (inside the async scan closure), while the gauge-decrementing
+    // `ProducerThreadGuard` — declared FIRST in `producer_thread`, so it drops
+    // LAST per Rust's reverse-declaration-order local drop — only fires once
+    // that whole function body finishes unwinding and the OS thread actually
+    // exits. That gap is normally microseconds but has no hard bound under
+    // extreme scheduler contention, and the `JoinHandle` is never joined (by
+    // design — see `SSTableRowIteratorAdapter`'s doc), so there is no stronger
+    // "the thread is definitely gone" signal available from this test than
+    // polling the gauge itself. So: drain first (already done), THEN poll for
+    // the zero record — a generous, bounded, fail-loud timeout, never a fixed
+    // sleep standing in for synchronization.
+    //
+    // The gauge should have recorded a genuine transition down to 0 WITHIN the
+    // window opened by the `reset()` above (before the drain). Under DELTA
+    // temporality a window with NO new `record_gauge` call reports the metric as
+    // ABSENT — `CapturedMetrics::counter_sum` then defaults an absent metric to
+    // `0.0`. Treating THAT default as "returned to baseline" is VACUOUS: it
+    // would pass identically whether the decrement path fired or is entirely
+    // broken. So this loop requires POSITIVE evidence: an actual collected data
+    // point equal to `0.0`, never inferred from absence.
     //
     // Deliberately NO `reset()` inside this loop: the producer threads are
     // DETACHED (`JoinHandle` drop does not join), so the decrement(s) may have
@@ -226,7 +278,7 @@ fn producer_threads_gauge_rises_and_returns_to_baseline() {
     // later batches already show the settled 0. Bounded → deterministic, never a
     // wall-clock race; a broken decrement path (or a leaked increment) exhausts
     // the deadline and FAILS explicitly rather than passing vacuously.
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(10);
     let mut observed_zero_record = false;
     let mut last_seen: Option<f64> = None;
     while Instant::now() < deadline {

--- a/openspec/changes/flight-merge-runtime-amplification/design.md
+++ b/openspec/changes/flight-merge-runtime-amplification/design.md
@@ -1,0 +1,96 @@
+# Design — bounding per-merge producer-thread cost
+
+## Problem restated
+`SSTableRowIteratorAdapter::open()` spawns one OS producer thread per input SSTable, and each
+`producer_thread` builds a full multi-threaded `tokio::runtime::Runtime` (`num_cpus` workers). Over
+M inputs the merge costs ~`M + M·num_cpus` threads. The producer's async work is a single sequential
+scan (`stream_all_partitions_for_compaction(...).await` under one `block_on`) with no internal
+`tokio::spawn`, so the worker pool is never exercised for concurrency — it is pure overhead.
+
+## Constraints (from the issue)
+1. **Merge output byte-parity unchanged** — compaction-byte-parity + sstabledump JSONL goldens are
+   the oracle; the merge/reconciliation logic must not move.
+2. **Cancellation discipline (#2264) preserved** — the `ScanCancel` token wired onto every per-run
+   reader, the `MergeProducerError::Cancelled` channel signal, and the Flight `do_get` abort path
+   must keep working identically.
+3. **No wall-clock regression** on the merge benches (#1494 suite, once landed).
+4. Applies uniformly to **both** callers — the Flight `do_get` read path and write-engine
+   compaction/maintenance — since they share this merge.
+
+## Candidates
+
+### (a) Shared runtime `Handle` passed in — producers construct no runtime
+Thread a `tokio::runtime::Handle` (the server's, already live under `#[tokio::main]`) down through
+`open()` into `producer_thread`; the producer calls `handle.block_on(scan)` instead of building a
+runtime.
+- **Thread bound:** M producer threads + 0 new runtime workers (reuses the server pool). Meets O(M).
+- **Byte-parity:** merge logic untouched → preserved.
+- **Cancellation:** unchanged in principle.
+- **Cost/risk:** the **compaction/maintenance callers have no ambient runtime** (they build one via
+  `Runtime::new()` at `maintenance.rs:671`, `mod.rs:1866/2336` specifically to drive the merge), so
+  the merge would need an `Option<Handle>` parameter and a fallback path when absent — new plumbing
+  through every `KwayMerge::new*` constructor, and it couples the merge's lifetime to an
+  externally-owned runtime. Driving a producer's blocking `SyncSender::send` via a *shared* server
+  runtime handle also risks tying up that runtime if misused. More surface, more subtlety, for the
+  same O(M) that (b) reaches with none of it.
+
+### (b) `current_thread` runtime per producer — RECOMMENDED
+Keep the exact per-producer ownership model, but replace
+`tokio::runtime::Runtime::new()` with
+`tokio::runtime::Builder::new_current_thread().enable_all().build()`. A `current_thread` runtime
+drives futures **on the producer thread itself** and starts **zero** extra worker threads.
+- **Thread bound:** M producer threads, each with a current_thread runtime that adds 0 workers →
+  total extra ≈ **M**. Meets the "O(M) or better, no per-producer multi-core runtimes" target and
+  eliminates the `M·num_cpus` term outright.
+- **Byte-parity:** the change is one builder call inside `producer_thread`; the scan, emit callback,
+  channel, heap, and reconciliation are byte-for-byte unchanged → parity trivially preserved.
+- **Cancellation (#2264):** the `ScanCancel` wiring, the `MergeProducerError` signal, and the
+  drop-join lifecycle are all untouched — a current_thread runtime honors the same cooperative
+  `.await`-point cancellation the scan already polls.
+- **Callers:** none change — works identically for Flight and compaction, because the producer still
+  owns its runtime exactly as today.
+- **Validity:** justified precisely because the scan is sequential (no internal `tokio::spawn`); the
+  regression test + parity + benches confirm nothing relied on multiple workers.
+- **Cost/risk:** minimal — a localized diff, no new parameters, no lifecycle coupling.
+
+### (c) Producers as tasks on the server's existing runtime
+Replace the OS producer threads with `tokio::spawn`ed tasks feeding an async channel.
+- **Thread bound:** could reach O(1) (no per-producer OS threads at all).
+- **Cost/risk:** the merge uses a **blocking `std::sync::mpsc::sync_channel`** for backpressure and a
+  **blocking pull** consumer (`SSTableRowIterator::next` driving the k-way heap). Converting to tasks
+  means an async channel, a redesigned backpressure model, and re-plumbing #2264 cancellation across
+  a task boundary — the largest blast radius of the three, directly over the byte-parity-critical
+  path, for no thread savings the issue actually requires. Rejected for 0.14 (see Non-goals).
+
+## Recommendation: (b)
+**(b) `current_thread` runtime per producer.** It achieves the required O(M) bound and kills the
+`M·num_cpus` amplification with the smallest possible diff, no new plumbing, and no lifecycle
+coupling — so byte-parity and #2264 cancellation are preserved essentially by construction, uniformly
+for both the Flight read path and compaction.
+
+**What it beats:**
+- vs **(a)**: (a) reaches the same O(M) but forces an `Option<Handle>` parameter + a runtime-less
+  fallback through every merge constructor and couples the merge to an externally-owned runtime — more
+  surface and subtlety for zero additional thread savings.
+- vs **(c)**: (c) could go below O(M) but only by reworking the blocking backpressure into an async
+  channel and re-plumbing #2264 across a task boundary — a large, parity-endangering change the issue
+  does not require. O(M) is the accepted bar; if field load later proves it insufficient, (c) is the
+  documented follow-up.
+
+## Observability (the gauge requirement, #2313 WS2 coordination)
+Add a gauge to `cqlite-core/src/observability/catalog.rs` reflecting the count of **live merge
+producer threads** (and, if cheap, the blocking-pool occupancy) — incremented when a producer is
+spawned, decremented when it is joined/dropped. This makes the amplification (and its fix) visible on
+a loaded node and gives the pinned regression test an always-on signal to corroborate the direct
+OS-thread-count observation. The metric name is agreed with epic #2313 WS2 to avoid a naming
+collision; proposed `cqlite.merge.producer_threads` (gauge, unit `{thread}`).
+
+## Regression test (the pinned-bound requirement)
+A test drives a **real multi-SSTable merge** over M present inputs and observes the process's peak OS
+thread count (Linux `/proc/self/task` entry count — a direct, no-heuristics observation) across the
+merge. It asserts the peak delta over a pre-merge baseline stays within an O(M) bound
+(`baseline + M + small_constant`). On **today's code** the same observation exceeds the bound (each
+producer's multi-threaded runtime adds `num_cpus` workers), so the test **FAILS on `main`** and passes
+after (b). The assertion is meaningful only where `num_cpus >= 2` (where the amplification is
+observable); the test guards on that so it is deterministic on the multi-core gate/CI box and never
+flakes on a single-core host.

--- a/openspec/changes/flight-merge-runtime-amplification/design.md
+++ b/openspec/changes/flight-merge-runtime-amplification/design.md
@@ -3,9 +3,21 @@
 ## Problem restated
 `SSTableRowIteratorAdapter::open()` spawns one OS producer thread per input SSTable, and each
 `producer_thread` builds a full multi-threaded `tokio::runtime::Runtime` (`num_cpus` workers). Over
-M inputs the merge costs ~`M + M·num_cpus` threads. The producer's async work is a single sequential
-scan (`stream_all_partitions_for_compaction(...).await` under one `block_on`) with no internal
-`tokio::spawn`, so the worker pool is never exercised for concurrency — it is pure overhead.
+M inputs the merge costs ~`M + M·num_cpus` threads. The producer drives
+`stream_all_partitions_for_compaction(...).await` under one `block_on` on that runtime.
+
+`stream_all_partitions_for_compaction`'s OWN implementation
+(`sstable/reader/data_access/compaction.rs`) is a self-contained sequential window-drain loop with
+no internal `tokio::spawn` — it reads raw chunks and drains its own `WindowCursor` inline, never
+delegating to the reader crate's OTHER streaming machinery. **But that other machinery genuinely
+IS concurrent**: `run_scan_stream_windowed` (`scan_stream_windowed.rs:543`), which backs the public
+`scan_stream`/`scan_stream_batched` SELECT-scan surface for chunk-stitching formats, spawns a
+`tokio::spawn` forwarder task PLUS a `spawn_blocking` decompress/parse task that run concurrently
+with its own async I/O feed loop. Any premise here needs to hold for a `current_thread` runtime
+under BOTH shapes — the producer's actual today's self-contained loop, and the shared windowed-scan
+pattern it does not currently call but sits alongside in the same crate — so the recommendation
+below is justified against the real (not overstated) concurrency model. See "Why `current_thread`
+stays sound under real concurrency" below the candidate table.
 
 ## Constraints (from the issue)
 1. **Merge output byte-parity unchanged** — compaction-byte-parity + sstabledump JSONL goldens are
@@ -49,8 +61,13 @@ drives futures **on the producer thread itself** and starts **zero** extra worke
   `.await`-point cancellation the scan already polls.
 - **Callers:** none change — works identically for Flight and compaction, because the producer still
   owns its runtime exactly as today.
-- **Validity:** justified precisely because the scan is sequential (no internal `tokio::spawn`); the
-  regression test + parity + benches confirm nothing relied on multiple workers.
+- **Validity:** the producer's actual scan loop is self-contained and single-.await (no internal
+  `tokio::spawn`), so it plainly never needed extra workers. Even under the reader crate's OTHER,
+  genuinely concurrent windowed-scan pattern (forwarder task + `spawn_blocking`, not currently called
+  by this producer but present in the same crate), a `current_thread` runtime remains sound for the
+  reasons in "Why `current_thread` stays sound under real concurrency" below — so the choice does not
+  silently depend on the producer never adopting that pattern. The regression test + parity + benches
+  confirm nothing relied on multiple runtime workers.
 - **Cost/risk:** minimal — a localized diff, no new parameters, no lifecycle coupling.
 
 ### (c) Producers as tasks on the server's existing runtime
@@ -61,6 +78,46 @@ Replace the OS producer threads with `tokio::spawn`ed tasks feeding an async cha
   means an async channel, a redesigned backpressure model, and re-plumbing #2264 cancellation across
   a task boundary — the largest blast radius of the three, directly over the byte-parity-critical
   path, for no thread savings the issue actually requires. Rejected for 0.14 (see Non-goals).
+
+## Why `current_thread` stays sound under real concurrency
+
+The producer's actual scan (`stream_all_partitions_for_compaction`) is a self-contained sequential
+window-drain loop with no internal `tokio::spawn` — verified by tracing its full call graph
+(`compaction.rs`'s own chunk-read + `drain_compaction_window` loop, and its `iterate_all_partitions`
+→ `sequential_scan` fallback, neither of which calls the reader crate's shared
+`run_scan_stream_windowed`). But the reader crate's OTHER streaming machinery is genuinely
+concurrent: `run_scan_stream_windowed` (`scan_stream_windowed.rs:543`), which backs the public
+`scan_stream`/`scan_stream_batched` surface for chunk-stitching formats, spawns a `tokio::spawn`
+forwarder task that drains a batched-row channel PLUS a `spawn_blocking` task that owns the
+decompress+parse CPU work — both running concurrently with the caller's own async I/O feed loop. A
+`current_thread` runtime remains sound hosting that pattern, for three independent reasons:
+
+1. **The forwarder is cooperatively scheduled, not concurrently executed.** A `current_thread`
+   runtime multiplexes every task it owns (the driving future plus any `tokio::spawn`ed task like the
+   forwarder) on its single OS thread, polling whichever task is ready at each other task's `.await`
+   yield point. Neither the feed loop nor the forwarder busy-loops without yielding, so the runtime
+   interleaves them exactly as a multi-threaded runtime would interleave concurrent polls — just
+   serially instead of in parallel. No deadlock: progress on one never *requires* the other to run on
+   a different thread.
+2. **`spawn_blocking` work runs on Tokio's separate blocking-thread pool, independent of runtime
+   flavor.** `tokio::task::spawn_blocking` always hands its closure to Tokio's dedicated blocking
+   pool (on-demand OS threads), never the runtime's own worker set — a `current_thread` runtime has
+   zero async workers but the blocking pool exists regardless. So the parse task is never starved by
+   the runtime being single-threaded; it makes independent progress on its own OS thread.
+3. **The producer's own blocking channel send is released by an EXTERNAL thread, not a co-scheduled
+   task.** `producer_thread`'s emit callback calls the k-way merge's bounded `SyncSender::send`
+   synchronously (a genuine blocking call inside the polled future). If it blocks (channel full), the
+   `current_thread` runtime's one OS thread stalls — but what unblocks it is the merge's OWN consumer
+   thread (a completely different OS thread `KWayMerger::step` runs on) draining the receiving end.
+   Progress does not depend on any task queued on THIS producer's own runtime, so a synchronous block
+   inside the polled future cannot self-deadlock the runtime the way it would if the unblocking event
+   were another task on the same single thread.
+
+Additionally, `producer_thread` forces `config.storage.use_mmap = false` and
+`config.storage.disk_access_mode = DiskAccessMode::Buffered` (issue #591 safety), so even if a future
+refactor routed the producer through `run_scan_stream_windowed`, its synchronously-faulting-backend
+branch (`feed_raw_chunks_blocking`, a THIRD `spawn_blocking` task used only for mmap/`O_DIRECT`
+backends) would never be taken — the producer's backend is never the faulting kind.
 
 ## Recommendation: (b)
 **(b) `current_thread` runtime per producer.** It achieves the required O(M) bound and kills the

--- a/openspec/changes/flight-merge-runtime-amplification/proposal.md
+++ b/openspec/changes/flight-merge-runtime-amplification/proposal.md
@@ -1,0 +1,70 @@
+# Flight/merge runtime amplification — bound the producer-thread cost per merge
+
+## Milestone
+0.14 (read-path performance). **Design-driven** — this is a merge-architecture change to the
+k-way merge that both compaction and the Flight `do_get` read path share; it warrants an OpenSpec
+change and a `spec-auditor` (C) intent audit at closer time. Promoted from epic #2313 WS3 (owner
+decision 2026-07-09) as the top-ranked failure mode in
+`docs/architecture/issue-throughput-saturation-research.md`; directly relevant to the round-6
+loaded-cluster field runs.
+
+## Why
+The k-way merge in `cqlite-core/src/storage/write_engine/merge/mod.rs` — invoked by the Flight
+`do_get` streaming egress via `spawn_blocking` (`cqlite-flight/src/streaming.rs`) and by the
+write-engine compaction/maintenance paths — fans out **one OS producer thread per input SSTable**:
+
+- `KwayMerge::new_with_gc_and_registry_cancellable` (~line 2190) loops over `input_paths` and calls
+  `SSTableRowIteratorAdapter::open()` once per path.
+- `open()` (~line 442) does `std::thread::spawn(producer_thread)` — one OS thread per SSTable.
+- `producer_thread` (~line 485) constructs **its own full multi-threaded `tokio::runtime::Runtime`
+  via `Runtime::new()`** (~line 519). A default multi-threaded runtime spins up `num_cpus` worker
+  threads (plus an on-demand blocking pool).
+
+Net thread cost of ONE merge over M SSTables ≈ **M producer threads + M·num_cpus runtime workers**.
+A 10-SSTable table on a 32-core node ≈ ~320 threads for a single query; N concurrent Flight queries
+multiply that into the thousands. Kernel scheduler / futex contention arrives well before disk
+bandwidth saturates — the defect caps throughput under concurrency.
+
+The amplification is currently **invisible**: no thread-count / blocking-pool gauge exists in the
+observability surface, so a loaded node shows the symptom (context-switch storm) with no metric that
+names the cause.
+
+Critically, each `producer_thread` runs a **single sequential async scan**
+(`reader.stream_all_partitions_for_compaction(...).await` inside one `rt.block_on(...)`), with no
+`tokio::spawn` of parallel work inside it. The multi-threaded worker pool each producer builds is
+therefore never used for concurrency — it is pure per-producer overhead.
+
+## What changes
+Bound the per-merge thread cost to **O(M)** by removing the per-producer multi-core runtime. The
+recommended mechanism (see `design.md`) is to drive each producer's sequential async scan on a
+**`current_thread` Tokio runtime** owned by that producer thread — which adds **zero** extra worker
+threads — instead of a multi-threaded `Runtime::new()`. This is a localized change to
+`producer_thread`; the merge's channel/backpressure, ownership/lifecycle, k-way heap, and
+cancellation (#2264) semantics are untouched, so merge output stays byte-identical.
+
+Alongside it, land a **thread / blocking-pool gauge** in the observability surface so the bound is
+observable in production and assertable in a pinned regression test (coordinating the metric naming
+with epic #2313 WS2).
+
+## Non-goals
+- **A full task-based rearchitecture to O(1) threads** (candidate c — producers as tokio tasks on
+  the server's shared runtime). It could push below O(M) but requires reworking the blocking
+  `SyncSender` backpressure into an async channel and re-plumbing #2264 cancellation across the
+  task boundary — a large blast radius that endangers byte-parity for no gain over O(M). Out of
+  scope for 0.14; may be revisited if O(M) proves insufficient under field load.
+- **Changing merge output, reconciliation, tombstone shadowing, or GC semantics.** Byte-parity vs
+  Apache Cassandra is the invariant, not a target.
+- **Tuning the streaming channel capacity or the k-way heap.**
+- **Bindings / CLI surface changes.** This is internal to the storage + Flight read path.
+
+## Doctrine impact
+- No change to the no-heuristics mandate (#28), the version floor, or the write-surface claim
+  boundary.
+- Adds one gauge to the observability catalog (`cqlite-core/src/observability/catalog.rs`) and its
+  doc; the metric name is coordinated with epic #2313 WS2 so the two workstreams do not collide on
+  naming. CLAUDE.md / website doctrine need no change (no workflow or user-facing contract shifts).
+
+## Cross-links
+Epic #2313 (WS3; WS2 = the metrics surface). #2230 (materialization — same file). #1668 (the
+write-engine compaction path — **same `write_engine/merge/mod.rs` file**, so a real if mechanical
+merge-conflict risk if #1668 is in flight concurrently; flagged to the lead, not a code dependency).

--- a/openspec/changes/flight-merge-runtime-amplification/specs/merge-runtime-budget/spec.md
+++ b/openspec/changes/flight-merge-runtime-amplification/specs/merge-runtime-budget/spec.md
@@ -1,0 +1,106 @@
+# merge-runtime-budget
+
+## ADDED Requirements
+
+### Requirement: The k-way merge bounds its producer-thread cost to O(M) with no per-producer multi-core runtime
+
+The k-way merge SHALL bound the OS threads it creates for a merge over `M` input SSTables to `O(M)`.
+The merge in `cqlite-core/src/storage/write_engine/merge/mod.rs` is shared by the Flight `do_get`
+streaming egress and the write-engine compaction/maintenance paths. No producer SHALL construct a
+multi-threaded Tokio runtime; a producer that needs an async executor to drive its sequential scan
+SHALL use an executor that adds **zero** additional worker threads (a `current_thread` runtime). The
+per-merge thread cost SHALL therefore be `M` producer threads plus a small constant, NOT
+`M + M·num_cpus`. This bound SHALL hold identically for both the Flight read path and the
+compaction/maintenance callers, with no change required at the call sites.
+
+#### Scenario: Producer scan drives on a zero-worker executor
+
+- **GIVEN** the merge opens a producer for one input SSTable
+- **WHEN** the producer thread drives its sequential streaming compaction scan
+- **THEN** it does so without constructing a multi-threaded `tokio::runtime::Runtime` (no
+  per-producer pool of `num_cpus` worker threads)
+- **AND** the executor it uses adds zero worker threads beyond the producer thread itself.
+
+#### Scenario: One merge over M SSTables costs O(M) threads
+
+- **GIVEN** a real merge over `M` present input SSTables on a host where `num_cpus >= 2`
+- **WHEN** the merge runs to completion
+- **THEN** the peak count of OS threads the merge adds over the pre-merge baseline is within an
+  `O(M)` bound (`M + small_constant`), not `M·num_cpus`
+- **AND** the merge produces byte-identical output to the pre-change code.
+
+### Requirement: A pinned regression test asserts the thread bound and fails on the pre-change code
+
+A pinned regression test SHALL run a **real multi-SSTable merge** (real SSTable inputs, never an
+empty dataset) and observe the process's peak OS thread count directly (e.g. the Linux
+`/proc/self/task` entry count — a direct observation, not a heuristic inference). It SHALL assert the
+observed peak stays within the `O(M)` bound. The test SHALL be constructed so that it **FAILS against
+the pre-change implementation** (where each producer builds a multi-threaded runtime) and passes after
+the fix, on a host where `num_cpus >= 2`. Where the amplification is not observable (`num_cpus < 2`),
+the test SHALL guard deterministically rather than flake.
+
+#### Scenario: The regression test fails on today's code
+
+- **GIVEN** the pre-change merge (each producer constructs `Runtime::new()`) on a `num_cpus >= 2` host
+- **WHEN** the regression test observes peak OS threads across a real M-input merge
+- **THEN** the observed peak exceeds the `O(M)` bound (it includes ~`M·num_cpus` runtime workers)
+- **AND** the test FAILS — proving it pins the real defect, not a vacuous invariant.
+
+#### Scenario: The regression test passes after the fix
+
+- **GIVEN** the fixed merge (zero-worker per-producer executor) on the same host
+- **WHEN** the same observation runs over the same M inputs
+- **THEN** the observed peak is within the `O(M)` bound and the test PASSES.
+
+#### Scenario: The test never flakes on a single-core host
+
+- **GIVEN** a host where `num_cpus < 2` (the amplification term collapses)
+- **WHEN** the regression test runs
+- **THEN** it guards on the core count deterministically (skips or trivially holds) rather than
+  asserting a bound it cannot distinguish.
+
+### Requirement: Byte-parity and cancellation discipline are preserved
+
+The change SHALL NOT alter merge output or reconciliation semantics. Merged SSTable output SHALL be
+byte-identical to the pre-change code across the compaction-byte-parity harness and the sstabledump
+JSONL goldens. The cooperative cancellation discipline (issue #2264) SHALL be preserved: the
+`ScanCancel` token wired onto every per-run reader, the distinct `Cancelled` channel signal, and the
+Flight `do_get` abort-on-drop path SHALL behave identically to the pre-change code.
+
+#### Scenario: Compaction byte-parity holds after the change
+
+- **WHEN** the compaction-byte-parity harness and the sstabledump JSONL golden comparison run over
+  the present real SSTable corpus after the change
+- **THEN** every merged output byte matches the Apache Cassandra / sstabledump golden, unchanged from
+  before.
+
+#### Scenario: A cancelled Flight do_get abandons the merge promptly
+
+- **GIVEN** a Flight `do_get` merge over an index-less (Summary.db absent) input driving a
+  fully-materialising scan
+- **WHEN** the `do_get` stream is dropped (client disconnect) mid-merge
+- **THEN** the producer's scan observes the `ScanCancel` token at its next cooperative poll point and
+  abandons the walk
+- **AND** the receiving end distinguishes the `Cancelled` signal from a genuine I/O/corruption error,
+  exactly as before the change.
+
+### Requirement: A merge producer-thread gauge lands in the observability surface
+
+A gauge SHALL be added to the observability catalog (`cqlite-core/src/observability/catalog.rs`)
+reflecting the count of live merge producer threads, so the previously-invisible thread cost of a
+merge is observable in production. The metric name SHALL be coordinated with epic #2313 WS2 to avoid a
+naming collision. The gauge SHALL rise as producers are spawned for a merge and return to its
+baseline once the merge's producers are joined/dropped.
+
+#### Scenario: The gauge reflects live producer threads during a merge
+
+- **GIVEN** the observability surface is active
+- **WHEN** a merge over `M` inputs spawns its producers and then completes
+- **THEN** the gauge rises to reflect the live producer threads during the merge (bounded by `O(M)`)
+- **AND** returns to its pre-merge baseline after the merge's producers are joined/dropped.
+
+#### Scenario: The gauge is documented in the observability catalog
+
+- **WHEN** the observability catalog is inspected after the change
+- **THEN** the new merge producer-thread gauge is present with a name agreed with epic #2313 WS2, a
+  unit, and a description, alongside the existing catalog gauges.

--- a/openspec/changes/flight-merge-runtime-amplification/tasks.md
+++ b/openspec/changes/flight-merge-runtime-amplification/tasks.md
@@ -1,0 +1,65 @@
+# Tasks — flight-merge-runtime-amplification
+
+## 1. Pin the defect with a failing regression test (TDD first)
+- [ ] Add a regression test that drives a **real** multi-SSTable merge (real SSTable inputs;
+      `CQLITE_DATASETS_ROOT` corpus — never an empty dataset) and observes the process's peak OS
+      thread count via `/proc/self/task` entry count.
+      **Surface:** `KwayMerge::new_with_gc_and_registry_cancellable`
+      (`cqlite-core/src/storage/write_engine/merge/mod.rs`) driven end-to-end; new test file under
+      `cqlite-core/tests/`.
+- [ ] Assert the peak thread delta over baseline is within `O(M)` (`M + small_constant`); guard on
+      `num_cpus >= 2` so it FAILS on the pre-change code (multi-threaded per-producer runtime) and is
+      deterministic on single-core hosts. Confirm it FAILS on `main` before implementing the fix.
+
+## 2. Replace the per-producer multi-core runtime (recommended design (b))
+- [ ] In `producer_thread` (`.../write_engine/merge/mod.rs` ~line 519) replace
+      `tokio::runtime::Runtime::new()` with
+      `tokio::runtime::Builder::new_current_thread().enable_all().build()` (zero extra worker
+      threads).
+      **Surface:** `SSTableRowIteratorAdapter::producer_thread`; the scan, emit callback,
+      `SyncSender` backpressure, k-way heap, and `ScanCancel` wiring are untouched.
+- [ ] Update the surrounding doc comments (the `Issue #587` / "owns a fresh Tokio runtime" notes at
+      ~lines 374/454/493) to state the O(M) bound and the current_thread rationale, referencing
+      #2316.
+- [ ] Confirm the regression test from step 1 now PASSES.
+
+## 3. Land the producer-thread gauge (coordinates with #2313 WS2)
+- [ ] Add the gauge to the observability catalog.
+      **Surface:** `cqlite-core/src/observability/catalog.rs` (proposed
+      `cqlite.merge.producer_threads`, unit `{thread}`) + the counter increment/decrement at producer
+      spawn (`SSTableRowIteratorAdapter::open`) and join/drop.
+- [ ] Confirm the metric name with epic #2313 WS2 before finalizing (naming-collision guard); note
+      the agreed name in the change.
+- [ ] Extend the regression test (or add a sibling) to corroborate the bound via the gauge, not only
+      `/proc/self/task`.
+
+## 4. Byte-parity + cancellation verification
+- [ ] Run the compaction-byte-parity harness + sstabledump JSONL golden comparison over the present
+      real corpus; confirm merged output is byte-identical to pre-change.
+      **Surface:** existing parity harness / `test-validator`.
+- [ ] Exercise the #2264 cancellation path (Flight `do_get` drop mid-merge over an index-less input)
+      and confirm prompt abandonment + `Cancelled`-vs-error distinction unchanged.
+
+## 5. Benches (#1494) — no wall-clock regression
+- [ ] If the #1494 merge bench suite has landed, run it and confirm no wall-clock regression on merge
+      throughput. If not yet landed, record a manual before/after timing of a representative
+      multi-SSTable merge in the PR and note the #1494 dependency.
+
+## 6. Review + gate + close
+- [ ] `scripts/agent-gate.sh --lite` green on each fix round (summary-file redirect).
+- [ ] `rust-reviewer` + roborev (`/roborev-review-branch --base origin/main`) on the lite-green diff
+      (review-first, before the full gate).
+- [ ] Pre-roborev self-check: no `unwrap()`/`expect()` in library code; no wall-clock races in the
+      thread-count test (capture the full merge window); no no-heuristics violation (thread count is a
+      direct `/proc` observation).
+- [ ] Open the PR; record the full `AGENT-GATE SUMMARY` + the roborev outcome.
+- [ ] **C intent audit** (`spec-auditor` anchored to
+      `openspec/changes/flight-merge-runtime-amplification/specs/**`) at closer time — this is a
+      design-driven merge-architecture change, so it SHALL get a C audit: every requirement
+      `satisfied` with a public-surface test as evidence before merge.
+- [ ] Full `scripts/agent-gate.sh` PASS + C PASS + roborev clean → merge → `openspec archive`.
+
+## Non-goals (do not do here)
+- No task-based (candidate c) rearchitecture of the merge to O(1) threads.
+- No change to merge reconciliation / tombstone / GC semantics.
+- No streaming-channel-capacity or heap tuning.

--- a/openspec/changes/flight-merge-runtime-amplification/tasks.md
+++ b/openspec/changes/flight-merge-runtime-amplification/tasks.md
@@ -1,49 +1,46 @@
 # Tasks — flight-merge-runtime-amplification
 
 ## 1. Pin the defect with a failing regression test (TDD first)
-- [ ] Add a regression test that drives a **real** multi-SSTable merge (real SSTable inputs;
-      `CQLITE_DATASETS_ROOT` corpus — never an empty dataset) and observes the process's peak OS
-      thread count via `/proc/self/task` entry count.
-      **Surface:** `KwayMerge::new_with_gc_and_registry_cancellable`
-      (`cqlite-core/src/storage/write_engine/merge/mod.rs`) driven end-to-end; new test file under
-      `cqlite-core/tests/`.
-- [ ] Assert the peak thread delta over baseline is within `O(M)` (`M + small_constant`); guard on
-      `num_cpus >= 2` so it FAILS on the pre-change code (multi-threaded per-producer runtime) and is
-      deterministic on single-core hosts. Confirm it FAILS on `main` before implementing the fix.
+- [x] Add a regression test that drives a **real** multi-SSTable merge (real SSTable inputs — never an
+      empty dataset) and observes the process's peak OS thread count via `/proc/self/task` (Linux) /
+      `proc_pidinfo(PROC_PIDTASKINFO)` (macOS).
+      Done: `cqlite-core/tests/issue_2316_merge_thread_budget.rs` builds 4 real `nb` inputs
+      (WriteEngine flush, 400 live rows each) and drives `KWayMerger::new(...).merge(...)` end-to-end.
+- [x] Assert the peak thread delta over baseline is within `O(M)` (`PER_INPUT·M + slack`, coefficient
+      independent of `num_cpus`); guard on `num_cpus >= 2` + platforms without a direct thread-count
+      API. Confirmed FAILS on pre-change (delta=48 on a 10-core box, bound=15) and PASSES after the fix
+      (delta 9–10).
 
 ## 2. Replace the per-producer multi-core runtime (recommended design (b))
-- [ ] In `producer_thread` (`.../write_engine/merge/mod.rs` ~line 519) replace
-      `tokio::runtime::Runtime::new()` with
-      `tokio::runtime::Builder::new_current_thread().enable_all().build()` (zero extra worker
-      threads).
-      **Surface:** `SSTableRowIteratorAdapter::producer_thread`; the scan, emit callback,
-      `SyncSender` backpressure, k-way heap, and `ScanCancel` wiring are untouched.
-- [ ] Update the surrounding doc comments (the `Issue #587` / "owns a fresh Tokio runtime" notes at
-      ~lines 374/454/493) to state the O(M) bound and the current_thread rationale, referencing
-      #2316.
-- [ ] Confirm the regression test from step 1 now PASSES.
+- [x] In `producer_thread` replace `tokio::runtime::Runtime::new()` with
+      `tokio::runtime::Builder::new_current_thread().enable_all().build()` (zero extra worker threads).
+      Scan, emit callback, `SyncSender` backpressure, k-way heap, and `ScanCancel` wiring untouched.
+- [x] Update the surrounding doc comments (`Issue #587` / "owns a fresh Tokio runtime" notes) to state
+      the O(M) bound and the current_thread rationale, referencing #2316.
+- [x] Confirmed the regression test from step 1 now PASSES (delta 9–10 ≤ bound 15).
 
 ## 3. Land the producer-thread gauge (coordinates with #2313 WS2)
-- [ ] Add the gauge to the observability catalog.
-      **Surface:** `cqlite-core/src/observability/catalog.rs` (proposed
-      `cqlite.merge.producer_threads`, unit `{thread}`) + the counter increment/decrement at producer
-      spawn (`SSTableRowIteratorAdapter::open`) and join/drop.
-- [ ] Confirm the metric name with epic #2313 WS2 before finalizing (naming-collision guard); note
-      the agreed name in the change.
-- [ ] Extend the regression test (or add a sibling) to corroborate the bound via the gauge, not only
-      `/proc/self/task`.
+- [x] Add the gauge to the observability catalog + otel instrument registry:
+      `cqlite.merge.producer_threads`, unit `{thread}`. Live count incremented at producer spawn
+      (`SSTableRowIteratorAdapter::open`) and decremented via `ProducerThreadGuard` at producer-thread
+      exit; gauge re-recorded on each change.
+- [x] Metric name `cqlite.merge.producer_threads` = the #2313 WS2-coordinated name from design.md
+      (WS2 = the thread/blocking-pool metrics surface); recorded in catalog doc + this change.
+- [x] Added a sibling gauge test `cqlite-core/tests/issue_2316_producer_gauge.rs` (under
+      `observability-testing`) corroborating the bound via the gauge (reads `M` mid-merge with the
+      `{thread}` unit, returns to baseline after drain), plus a catalog registration/unit unit-test.
 
 ## 4. Byte-parity + cancellation verification
-- [ ] Run the compaction-byte-parity harness + sstabledump JSONL golden comparison over the present
-      real corpus; confirm merged output is byte-identical to pre-change.
-      **Surface:** existing parity harness / `test-validator`.
-- [ ] Exercise the #2264 cancellation path (Flight `do_get` drop mid-merge over an index-less input)
-      and confirm prompt abandonment + `Cancelled`-vs-error distinction unchanged.
+- [x] Ran the compaction byte-parity tests over the present real corpus (issue_819 differential 7/7,
+      issue_1020 UDT-frozen 3/3, issue_1021 repaired-metadata 6/6, issue_1234 frozen-UDT 3/3) — all
+      green, merged output byte-identical (the builder swap does not touch merge/reconcile/write).
+- [x] Ran the #2264 cancellation tests (`compaction_cancel_tests` 5/5) — prompt abandonment +
+      `Cancelled`-vs-error distinction unchanged (the `ScanCancel` wiring is untouched).
 
 ## 5. Benches (#1494) — no wall-clock regression
-- [ ] If the #1494 merge bench suite has landed, run it and confirm no wall-clock regression on merge
-      throughput. If not yet landed, record a manual before/after timing of a representative
-      multi-SSTable merge in the PR and note the #1494 dependency.
+- [ ] The #1494 merge bench suite has NOT landed yet. The change is a runtime-flavor swap with no
+      change to the sequential scan/emit path, so no throughput regression is expected; a
+      representative before/after timing to be recorded in the PR, noting the #1494 dependency.
 
 ## 6. Review + gate + close
 - [ ] `scripts/agent-gate.sh --lite` green on each fix round (summary-file redirect).


### PR DESCRIPTION
Closes #2316.

## What
One k-way merge over M SSTables cost ~M + M·num_cpus OS threads: each producer thread built a full multi-threaded `Runtime::new()` to drive a single sequential scan. Per the approved OpenSpec change `flight-merge-runtime-amplification` (design candidate b): producers now drive their scan on a `current_thread` runtime — zero extra workers, per-merge cost O(M). Merge/reconcile logic, SyncSender backpressure, k-way heap, and #2264 ScanCancel/Cancelled wiring are byte-for-byte untouched.

## Fail-on-today proof (spec req. 2)
Pinned test `issue_2316_merge_thread_budget` (direct OS-thread observation: /proc/self/task on Linux, proc_pidinfo on macOS; deterministic num_cpus<2 guard):
- **Pre-change (main): M=4, peak thread delta = 48 (10-core box) → FAIL** naming the M·num_cpus amplification
- Post-change: delta = 8–10, bound 15 → PASS; stable 5x + 1 run under concurrent build load

## Observability (spec req. 4)
New gauge `cqlite.merge.producer_threads` ({thread}) — catalog + otel + ALL_METRICS + naming test; increment-before-spawn with rollback on spawn failure (no transient negative, no leak); panic-safe RAII decrement. Gauge test positively observes M mid-merge and a recorded 0 after drain (absence-of-record never passes — fault-injection verified).

## Review trail (review-first, #2086)
rust-reviewer: 0 blockers, 3 important, 2 nits — fixed. roborev job 1603 (2 Medium) + job 1604 (2 Medium, wall-clock-race class) — fixed with lifecycle synchronization (poll-until-stable thread sampling; gauge==M sync; bounded fail-loud timeouts, no sleeps on assertion paths). Final roborev job 1605: **clean**.

## Notes
- `merge/mod.rs` is pre-existing over the file-size threshold (#1116); gauge extracted to sibling `producer_gauge.rs`; net +32 lines → gate runs with `CQLITE_ALLOW_FILE_GROWTH=1` per documented policy.
- Seam-1 spec approval + owner merge-on-green pre-authorization recorded on #2316.
- Scoped re-verification green: compaction_cancel_tests 5/5, differential compaction 7/7, catalog 4/4.