### PR TITLE
feat(#2207): cqlite-flight do_get — pushed PK-equality predicates drive partition-targeted point reads

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -57,6 +57,11 @@ mod model;
 // primitives it composes (`successor_partition_offset`, `point_read_whole_section`).
 #[cfg(not(feature = "tombstones"))]
 mod point_compaction;
+// Fail-safe proof (issue #2207, roborev IMPORTANT-1): a corrupt/unreadable BTI
+// Partitions.db must degrade the point-read primitive to a scan-fallback signal,
+// never a hard `Err`. Needs `write-support` to synthesize a BTI fixture.
+#[cfg(all(test, not(feature = "tombstones"), feature = "write-support"))]
+mod point_compaction_fail_safe_tests;
 // Opt-in presence-oracle false-negative verification method (issue #2163), kept
 // out of this already-large entry-point file (campsite rule, epic #1116).
 mod presence_verify;

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -51,6 +51,10 @@ mod compaction;
 // `read_compressed_offset_window` helper out of this already-large entry-point file.
 mod compressed_offset;
 mod model;
+// Single-partition compaction seek (issue #2207): the public point-read primitive
+// composing the presence oracle + BTI/BIG offset resolution into a byte-identical
+// compaction-row seek for one partition. Kept out of this entry-point file.
+mod point_compaction;
 // Opt-in presence-oracle false-negative verification method (issue #2163), kept
 // out of this already-large entry-point file (campsite rule, epic #1116).
 mod presence_verify;
@@ -63,6 +67,7 @@ mod sequential;
 // Public surface re-export (unchanged: `reader::mod` re-exports
 // `data_access::ClusteringSlice`).
 pub use model::ClusteringSlice;
+pub use point_compaction::SinglePartitionCompaction;
 
 // Re-export the decompress-work counter so the sibling `scan_stream_windowed`
 // module (outside `data_access`) can increment it on the windowed-scan miss path

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -53,7 +53,9 @@ mod compressed_offset;
 mod model;
 // Single-partition compaction seek (issue #2207): the public point-read primitive
 // composing the presence oracle + BTI/BIG offset resolution into a byte-identical
-// compaction-row seek for one partition. Kept out of this entry-point file.
+// compaction-row seek for one partition. Gated `not(tombstones)` like the seek
+// primitives it composes (`successor_partition_offset`, `point_read_whole_section`).
+#[cfg(not(feature = "tombstones"))]
 mod point_compaction;
 // Opt-in presence-oracle false-negative verification method (issue #2163), kept
 // out of this already-large entry-point file (campsite rule, epic #1116).
@@ -67,6 +69,7 @@ mod sequential;
 // Public surface re-export (unchanged: `reader::mod` re-exports
 // `data_access::ClusteringSlice`).
 pub use model::ClusteringSlice;
+#[cfg(not(feature = "tombstones"))]
 pub use point_compaction::SinglePartitionCompaction;
 
 // Re-export the decompress-work counter so the sibling `scan_stream_windowed`

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -25,6 +25,26 @@ use crate::Result;
 use std::ops::ControlFlow;
 
 /// Outcome of a single-partition candidate probe against one SSTable.
+///
+/// **The three-way absence-vs-failure invariant** (roborev, issue #2207 — state
+/// this here, not just in prose elsewhere, since it is the correctness spine
+/// every caller relies on):
+///
+/// - [`DefinitelyAbsent`](Self::DefinitelyAbsent) is returned **ONLY** on an
+///   exact presence-oracle negative (a bloom `might_contain == false`, or a BTI
+///   trie miss) — the ONE case that may prune a candidate SSTable from the read.
+/// - [`IndexUnavailable`](Self::IndexUnavailable) is returned for **EVERY OTHER
+///   kind of resolution/read anomaly**: no random-access index at all, an
+///   inconclusive BIG Index.db miss (#1572), an unreadable/corrupt index (a BTI
+///   trie parse error or an Index.db read error — roborev IMPORTANT-1), an
+///   un-boundable last partition, or a resolved offset the materialized window
+///   never reached (a bad end bound / truncated-SSTable shape — roborev MEDIUM).
+///   None of these may EVER collapse to `DefinitelyAbsent` or an empty `Rows` —
+///   only a genuine, fully-materialized decode may report absence.
+/// - [`Rows`](Self::Rows) is returned only once a seek has been FULLY EXECUTED
+///   (the window reached and covered the target partition's bytes end-to-end)
+///   — an empty `Vec` here means a confirmed prefix-collision candidate for an
+///   absent key, decoded and verified, not "we could not tell."
 #[derive(Debug)]
 pub enum SinglePartitionCompaction {
     /// The presence oracle proved the key is definitively absent from this
@@ -34,10 +54,10 @@ pub enum SinglePartitionCompaction {
     /// missing.
     DefinitelyAbsent,
     /// The key MIGHT be present but this SSTable has no usable random-access index
-    /// (Summary/Index absent, a #1572-style inconclusive index miss, or a last
-    /// partition whose extent cannot be bounded authoritatively). The caller MUST
-    /// read this SSTable — scanning its partitions and filtering to the key —
-    /// never skip it. The missing index degrades speed, never correctness (#2295).
+    /// (Summary/Index absent, a #1572-style inconclusive index miss, an
+    /// unreadable/corrupt index, or a resolved offset the window never reached).
+    /// The caller MUST read this SSTable — scanning its partitions and filtering
+    /// to the key — never skip it. Degrades speed, never correctness (#2295).
     IndexUnavailable,
     /// The partition was seeked and decoded. `rows` are its compaction rows
     /// (tombstones preserved), byte-identical to the full-scan stream restricted
@@ -87,27 +107,58 @@ impl SSTableReader {
         }
 
         // 3. Resolve the target partition's UNCOMPRESSED Data.db start offset.
+        //
+        //    Fail-safe (roborev IMPORTANT-1, #2207 spec): an unreadable/corrupt
+        //    index (BTI trie parse error, Index.db read error) degrades to
+        //    `IndexUnavailable` — this SSTable is scanned in full and filtered,
+        //    never a hard-failed query. The scan path never consults this index
+        //    at all, so a broken index here must not turn a query the scan path
+        //    would still answer into an `Err`.
         let is_bti = self.is_bti();
         let offset = if is_bti {
-            match self.lookup_partition_via_bti_trie(partition_key)? {
-                Some(off) => off,
+            match self.lookup_partition_via_bti_trie(partition_key) {
+                Ok(Some(off)) => off,
                 // A BTI trie miss is AUTHORITATIVE absence (the oracle above should
                 // have pruned already; this is a defensive authoritative-empty).
-                None => return Ok(SinglePartitionCompaction::Rows(Vec::new())),
+                Ok(None) => return Ok(SinglePartitionCompaction::Rows(Vec::new())),
+                Err(e) => {
+                    tracing::debug!(
+                        "BTI Partitions.db trie lookup failed during point read; \
+                         falling back to a full scan of this SSTable (#2207 fail-safe): {e}"
+                    );
+                    return Ok(SinglePartitionCompaction::IndexUnavailable);
+                }
             }
         } else {
-            match self.lookup_partition_with_index(partition_key).await? {
-                Some((off, _size)) => off,
+            match self.lookup_partition_with_index(partition_key).await {
+                Ok(Some((off, _size))) => off,
                 // A BIG Index.db miss is NOT a definitive absent (#1572): a
                 // truncated/partial map can drop an entry for a present partition.
                 // Degrade to a full scan of this SSTable, never a wrong empty.
-                None => return Ok(SinglePartitionCompaction::IndexUnavailable),
+                Ok(None) => return Ok(SinglePartitionCompaction::IndexUnavailable),
+                Err(e) => {
+                    tracing::debug!(
+                        "Index.db lookup failed during point read; falling back to a \
+                         full scan of this SSTable (#2207 fail-safe): {e}"
+                    );
+                    return Ok(SinglePartitionCompaction::IndexUnavailable);
+                }
             }
         };
 
         // 4. Authoritative exclusive end of the target partition: the successor
         //    partition's start (next trie/index entry), or `None` for the last.
-        let end_bound = self.successor_partition_offset(offset)?;
+        //    Same fail-safe class as step 3 — it reads the same index/trie.
+        let end_bound = match self.successor_partition_offset(offset) {
+            Ok(bound) => bound,
+            Err(e) => {
+                tracing::debug!(
+                    "successor-partition resolution failed during point read; falling \
+                     back to a full scan of this SSTable (#2207 fail-safe): {e}"
+                );
+                return Ok(SinglePartitionCompaction::IndexUnavailable);
+            }
+        };
 
         // 5. Materialize `[offset, end)` decompressed and parse the one partition.
         match self
@@ -181,8 +232,18 @@ impl SSTableReader {
         };
 
         if within >= window.len() {
-            // Nothing decodable at the resolved offset — treat as absent here.
-            return Ok(Some(Vec::new()));
+            // MEDIUM fix (roborev, issue #2207): the materialized window did NOT
+            // reach the resolved offset — e.g. `pull_chunk_window` hit EOF before
+            // `end`, or a bad/stale end bound, on a truncated or corrupt SSTable.
+            // This is NOT the same signal as a genuine prefix-collision absence
+            // (below): there we decoded the FULL partition and confirmed it is a
+            // different key; here we could not even reach the target bytes to
+            // check. Treating this as "found nothing" would be a false-negative
+            // prune — the SAME wrong-rows class the presence-oracle spine forbids
+            // (spec: only an exact bloom negative may prune). Signal `None` so the
+            // caller degrades to `IndexUnavailable` (scan this SSTable), never a
+            // silent empty.
+            return Ok(None);
         }
 
         // Parse the FIRST partition at `window[within..]`. Collect every row whose

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -161,8 +161,14 @@ impl SSTableReader {
         };
 
         // 5. Materialize `[offset, end)` decompressed and parse the one partition.
+        //    `is_bti` decides how a FOREIGN-key decode is interpreted (step below):
+        //    a BTI trie resolves by PREFIX (a decoded different key is a genuine
+        //    prefix-collision → authoritative empty), whereas a BIG Index.db entry
+        //    is an EXACT partition offset (a decoded different key means the entry
+        //    is stale/corrupt and pointed at another valid partition → scan
+        //    fallback, never a silent drop).
         match self
-            .seek_partition_compaction_rows(offset, end_bound, partition_key, schema)
+            .seek_partition_compaction_rows(offset, end_bound, partition_key, schema, is_bti)
             .await?
         {
             Some(rows) => Ok(SinglePartitionCompaction::Rows(rows)),
@@ -186,6 +192,7 @@ impl SSTableReader {
         end_bound: Option<u64>,
         partition_key: &[u8],
         schema: Option<&crate::schema::TableSchema>,
+        is_bti: bool,
     ) -> Result<Option<Vec<CompactionRow>>> {
         let offset = offset as usize;
         let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
@@ -275,8 +282,22 @@ impl SSTableReader {
         )?;
 
         if saw_foreign_key && rows.is_empty() {
-            // Prefix-collision candidate for an absent key: authoritative empty.
-            return Ok(Some(Vec::new()));
+            if is_bti {
+                // BTI (`da`): the trie resolves by PREFIX, so a fully-decoded
+                // DIFFERENT key at the resolved offset is a genuine prefix-collision
+                // for an absent key — authoritative empty (do NOT fall back).
+                return Ok(Some(Vec::new()));
+            }
+            // BIG (`nb`): Index.db entries are EXACT partition offsets, so a decoded
+            // FOREIGN key means the entry was stale/corrupt and pointed at a
+            // DIFFERENT valid partition. Treating that as authoritative absence
+            // would SILENTLY DROP the target key (roborev job 1616, High:
+            // fail-safe violation). Degrade to `IndexUnavailable` → the caller
+            // scans this SSTable and filters, never a false-empty. (Three-exit
+            // invariant: DefinitelyAbsent = exact bloom negative only; Rows = a
+            // complete seek of the CORRECT partition; anything anomalous here is a
+            // scan fallback.)
+            return Ok(None);
         }
         Ok(Some(rows))
     }

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -173,7 +173,9 @@ impl SSTableReader {
                         None => return Ok(None),
                     },
                 };
-                let window = self.pull_chunk_window(target_chunk, window_base, end).await?;
+                let window = self
+                    .pull_chunk_window(target_chunk, window_base, end)
+                    .await?;
                 (window, within)
             }
         };

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -201,10 +201,13 @@ impl SSTableReader {
             .map(|ci| ci.chunk_length as usize)
             .filter(|&len| len > 0);
 
-        let (window, within) = match chunk_length {
+        let (window, within, reached_end) = match chunk_length {
             None => {
                 let whole = self.point_read_whole_section().await?;
-                (whole, offset)
+                // The uncompressed whole-section read is authoritative for the
+                // partition's extent; an offset past the section is caught by the
+                // `within >= window.len()` guard below.
+                (whole, offset, true)
             }
             Some(len) => {
                 let target_chunk = offset / len;
@@ -224,25 +227,30 @@ impl SSTableReader {
                         None => return Ok(None),
                     },
                 };
-                let window = self
+                let (window, reached_end) = self
                     .pull_chunk_window(target_chunk, window_base, end)
                     .await?;
-                (window, within)
+                (window, within, reached_end)
             }
         };
 
-        if within >= window.len() {
+        if within >= window.len() || !reached_end {
             // MEDIUM fix (roborev, issue #2207): the materialized window did NOT
-            // reach the resolved offset — e.g. `pull_chunk_window` hit EOF before
-            // `end`, or a bad/stale end bound, on a truncated or corrupt SSTable.
-            // This is NOT the same signal as a genuine prefix-collision absence
-            // (below): there we decoded the FULL partition and confirmed it is a
-            // different key; here we could not even reach the target bytes to
-            // check. Treating this as "found nothing" would be a false-negative
-            // prune — the SAME wrong-rows class the presence-oracle spine forbids
-            // (spec: only an exact bloom negative may prune). Signal `None` so the
-            // caller degrades to `IndexUnavailable` (scan this SSTable), never a
-            // silent empty.
+            // cover the full resolved `[offset, end)`. Either it never reached the
+            // resolved offset (`within >= window.len()` — a bad/stale end bound),
+            // or `pull_chunk_window` hit EOF before `end` (`!reached_end`) on a
+            // truncated/corrupt SSTable, leaving only a prefix of the partition's
+            // bytes. Parsing that partial buffer with `at_final_chunk = true`
+            // FLUSHES a partially-decoded partition and would surface it as
+            // authoritative `Rows(...)` — hiding corruption and emitting
+            // wrong/short rows. This is NOT the same signal as a genuine
+            // prefix-collision absence (below): there we decoded the FULL
+            // partition and confirmed a different key; here we could not even
+            // materialize the target bytes to check. Treating either as an answer
+            // is a false-negative the presence-oracle spine forbids (spec: only an
+            // exact bloom negative may prune). Signal `None` so the caller degrades
+            // to `IndexUnavailable` (scan this SSTable), never a silent
+            // partial/empty answer.
             return Ok(None);
         }
 
@@ -274,17 +282,22 @@ impl SSTableReader {
     }
 
     /// Pull the decompressed chunks covering `[window_base, end)` starting at
-    /// `target_chunk`, returning the concatenated bytes. Never stitches to EOF: it
-    /// stops as soon as the window reaches `end` (the target partition's exclusive
-    /// end) or the SSTable is exhausted. Mirrors the bounded chunk fetch the
-    /// user-facing single-partition seek uses (issue #953), so a head-of-file
-    /// point read never decompresses the whole `Data.db`.
+    /// `target_chunk`, returning the concatenated bytes plus whether the window
+    /// actually reached `end`. Never stitches to EOF: it stops as soon as the
+    /// window reaches `end` (the target partition's exclusive end) or the SSTable
+    /// is exhausted. Mirrors the bounded chunk fetch the user-facing
+    /// single-partition seek uses (issue #953), so a head-of-file point read never
+    /// decompresses the whole `Data.db`.
+    ///
+    /// The returned `bool` is `false` when the chunks ran out (EOF) before the
+    /// window covered `end` — a truncated/corrupt SSTable whose partial buffer the
+    /// caller MUST NOT parse as authoritative (issue #2207 fail-safe spine).
     async fn pull_chunk_window(
         &self,
         target_chunk: usize,
         window_base: usize,
         end: usize,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<(Vec<u8>, bool)> {
         use super::super::chunk_source::ChunkSource;
         use crate::storage::sstable::compression::Compression;
 
@@ -322,9 +335,14 @@ impl SSTableReader {
                     // chunk span, not the whole file (issue #2207 IMPORTANT-2).
                     super::super::super::work_counters::add_chunk_decompressed();
                 }
-                None => break, // EOF before `end`: parse what we have.
+                None => break, // EOF before `end`: the window is truncated.
             }
         }
-        Ok(window)
+        // Did the materialized window actually cover the full requested extent?
+        // `false` ⇒ the chunk source was exhausted before reaching `end` (a
+        // truncated/corrupt SSTable) — the caller degrades to a scan fallback
+        // rather than parse an incomplete partition (issue #2207 fail-safe).
+        let reached_end = window_base + window.len() >= end;
+        Ok((window, reached_end))
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -316,6 +316,11 @@ impl SSTableReader {
                 Some(decompressed) => {
                     chunk_index += 1;
                     window.extend_from_slice(&decompressed);
+                    // Issue #953/#951 precedent (`bti_pull_decompressed_chunk`):
+                    // count every chunk this seek materializes, so a work-done test
+                    // can prove the window is bounded to the target partition's
+                    // chunk span, not the whole file (issue #2207 IMPORTANT-2).
+                    super::super::super::work_counters::add_chunk_decompressed();
                 }
                 None => break, // EOF before `end`: parse what we have.
             }

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -118,9 +118,20 @@ impl SSTableReader {
         let offset = if is_bti {
             match self.lookup_partition_via_bti_trie(partition_key) {
                 Ok(Some(off)) => off,
-                // A BTI trie miss is AUTHORITATIVE absence (the oracle above should
-                // have pruned already; this is a defensive authoritative-empty).
-                Ok(None) => return Ok(SinglePartitionCompaction::Rows(Vec::new())),
+                // A BTI trie `Ok(None)` is an AUTHORITATIVE-by-construction absence:
+                // `bti_trie_resolve` returns `Ok(None)` ONLY for a definitive trie
+                // MISS (a fully-descended trie with no matching entry), and routes
+                // EVERY degraded/unusable state — a parse error, an out-of-range
+                // root_offset, a missing Rows.db for a wide partition — through the
+                // `Err(_)` arm below (scan fallback), never through `Ok(None)`. The
+                // trie IS the presence oracle for a BTI SSTable, so this is the same
+                // signal `might_contain_partition` (step 1) already prunes on; this
+                // arm is the defensive equivalent. The correct three-exit answer is
+                // `DefinitelyAbsent` (an authoritative prune), NOT `Rows(Vec::new())`
+                // — an empty `Rows` is reserved for a FULLY-DECODED prefix-collision
+                // (nothing was decoded here), so emitting it would violate the enum
+                // contract (see `SinglePartitionCompaction`'s doc).
+                Ok(None) => return Ok(SinglePartitionCompaction::DefinitelyAbsent),
                 Err(e) => {
                     tracing::debug!(
                         "BTI Partitions.db trie lookup failed during point read; \
@@ -194,6 +205,16 @@ impl SSTableReader {
         schema: Option<&crate::schema::TableSchema>,
         is_bti: bool,
     ) -> Result<Option<Vec<CompactionRow>>> {
+        // Cooperative cancellation (issue #2207, roborev job 1620 MEDIUM): the seek
+        // materializes a covering chunk window and parses one partition — the same
+        // heavy, previously-uninterruptible work the full-scan compaction stream
+        // polls `scan_cancel` inside (issue #2264). Mirror that here so a Flight
+        // `do_get` whose client has already disconnected abandons the seek instead
+        // of decompressing/parsing to completion. Poll ONCE before materializing
+        // (an already-cancelled read exits before any I/O), inside the chunk-window
+        // pull loop (`pull_chunk_window`), and once more just before parsing.
+        self.scan_cancel.check()?;
+
         let offset = offset as usize;
         let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
         let parser = self.build_v5_parser(false);
@@ -260,6 +281,11 @@ impl SSTableReader {
             // partial/empty answer.
             return Ok(None);
         }
+
+        // Cancellation poll just before the parse — the covering window is now
+        // materialized, so a cancel observed here skips the (potentially large)
+        // partition decode entirely (issue #2207 fail-safe cancellation).
+        self.scan_cancel.check()?;
 
         // Parse the FIRST partition at `window[within..]`. Collect every row whose
         // decoded key equals the queried key; a decoded DIFFERENT key means the
@@ -345,7 +371,16 @@ impl SSTableReader {
 
         let mut window: Vec<u8> = Vec::new();
         let mut chunk_index = target_chunk;
+        let mut pulled: usize = 0;
         while window_base + window.len() < end {
+            // Cooperative cancellation (issue #2207, roborev job 1620 MEDIUM): a very
+            // wide target partition can span hundreds of chunks; poll at a bounded
+            // interval so a cancel is honoured mid-window, mirroring the full-scan
+            // stream's `chunk_count & 0xFF == 0` poll (compaction.rs, issue #2264).
+            if pulled & 0xFF == 0 {
+                self.scan_cancel.check()?;
+            }
+            pulled += 1;
             match chunk_source.chunk(chunk_index)? {
                 Some(decompressed) => {
                     chunk_index += 1;

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -1,0 +1,262 @@
+//! Single-partition compaction seek (issue #2207, Stage 1).
+//!
+//! The unwired point-read machinery — [`might_contain_partition`] (presence
+//! oracle), [`lookup_partition_via_bti_trie`] (BTI `da`) / [`lookup_partition_with_index`]
+//! (BIG `nb` Summary/Index) — resolves whether a partition is present and, if so,
+//! WHERE. This module composes those into the one public surface the Flight
+//! producer needs: given a partition key, return the target partition's rows in
+//! the **exact same [`CompactionRow`] form the full-scan compaction stream
+//! produces** (tombstones preserved, per-row timestamps), so the k-way merge
+//! reconciles the point path byte-identically to the scan path.
+//!
+//! Pruning is fail-open toward reading (the correctness spine): a candidate is
+//! reported [`SinglePartitionCompaction::DefinitelyAbsent`] ONLY on an exact
+//! presence-oracle negative; a missing/ambiguous index degrades to
+//! [`SinglePartitionCompaction::IndexUnavailable`] (the caller scans that one
+//! SSTable), never a wrong or silently-skipped answer (issues #28, #2295).
+//!
+//! [`might_contain_partition`]: SSTableReader::might_contain_partition
+//! [`lookup_partition_via_bti_trie`]: SSTableReader::lookup_partition_via_bti_trie
+//! [`lookup_partition_with_index`]: SSTableReader::lookup_partition_with_index
+
+use super::super::compaction_row::CompactionRow;
+use super::super::SSTableReader;
+use crate::Result;
+use std::ops::ControlFlow;
+
+/// Outcome of a single-partition candidate probe against one SSTable.
+#[derive(Debug)]
+pub enum SinglePartitionCompaction {
+    /// The presence oracle proved the key is definitively absent from this
+    /// SSTable (an exact bloom negative, or a BTI trie miss). The candidate is
+    /// pruned; `cqlite.read.sstables_pruned` was already incremented by the
+    /// oracle. Never returned when presence is positive, unknown, or the index is
+    /// missing.
+    DefinitelyAbsent,
+    /// The key MIGHT be present but this SSTable has no usable random-access index
+    /// (Summary/Index absent, a #1572-style inconclusive index miss, or a last
+    /// partition whose extent cannot be bounded authoritatively). The caller MUST
+    /// read this SSTable — scanning its partitions and filtering to the key —
+    /// never skip it. The missing index degrades speed, never correctness (#2295).
+    IndexUnavailable,
+    /// The partition was seeked and decoded. `rows` are its compaction rows
+    /// (tombstones preserved), byte-identical to the full-scan stream restricted
+    /// to this partition. Empty when the resolved candidate was a prefix-collision
+    /// for an absent key (authoritative empty — do NOT fall back).
+    Rows(Vec<CompactionRow>),
+}
+
+impl SSTableReader {
+    /// Probe one SSTable for a single partition, returning its compaction rows via
+    /// an authoritative seek — or a prune / scan-fallback signal (issue #2207).
+    ///
+    /// This is the public core primitive the Flight point-read path composes into
+    /// its existing k-way merge. Correctness spine (fail-open toward reading):
+    ///
+    /// 1. [`might_contain_partition`](Self::might_contain_partition) reports a
+    ///    definite negative → [`SinglePartitionCompaction::DefinitelyAbsent`]
+    ///    (pruned + counted).
+    /// 2. No random-access index → [`SinglePartitionCompaction::IndexUnavailable`]
+    ///    (the caller scans this SSTable).
+    /// 3. Otherwise resolve the partition's uncompressed offset (BTI trie / BIG
+    ///    Index.db) and its authoritative end bound (successor offset / data
+    ///    length), materialize ONLY the covering chunk window, and parse the one
+    ///    partition with the SAME compaction parser the full scan uses →
+    ///    [`SinglePartitionCompaction::Rows`]. A BIG Index.db miss (inconclusive,
+    ///    #1572) or an un-boundable last partition degrades to
+    ///    [`SinglePartitionCompaction::IndexUnavailable`].
+    ///
+    /// `partition_key` is the raw partition-key bytes (as
+    /// `PartitionKey::to_bytes` produces). `schema` is the authoritative table
+    /// schema (the parser needs column names).
+    pub async fn read_single_partition_for_compaction(
+        &self,
+        partition_key: &[u8],
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<SinglePartitionCompaction> {
+        // 1. Presence oracle — the only source of a definite prune. Emits
+        //    `cqlite.read.sstables_pruned` internally on a definite negative.
+        if !self.might_contain_partition(partition_key) {
+            return Ok(SinglePartitionCompaction::DefinitelyAbsent);
+        }
+
+        // 2. No random-access index (Data.db-only snapshot, #2295) → the caller
+        //    must scan this SSTable. Never skip a candidate that might hold the key.
+        if !self.has_partition_index() {
+            return Ok(SinglePartitionCompaction::IndexUnavailable);
+        }
+
+        // 3. Resolve the target partition's UNCOMPRESSED Data.db start offset.
+        let is_bti = self.is_bti();
+        let offset = if is_bti {
+            match self.lookup_partition_via_bti_trie(partition_key)? {
+                Some(off) => off,
+                // A BTI trie miss is AUTHORITATIVE absence (the oracle above should
+                // have pruned already; this is a defensive authoritative-empty).
+                None => return Ok(SinglePartitionCompaction::Rows(Vec::new())),
+            }
+        } else {
+            match self.lookup_partition_with_index(partition_key).await? {
+                Some((off, _size)) => off,
+                // A BIG Index.db miss is NOT a definitive absent (#1572): a
+                // truncated/partial map can drop an entry for a present partition.
+                // Degrade to a full scan of this SSTable, never a wrong empty.
+                None => return Ok(SinglePartitionCompaction::IndexUnavailable),
+            }
+        };
+
+        // 4. Authoritative exclusive end of the target partition: the successor
+        //    partition's start (next trie/index entry), or `None` for the last.
+        let end_bound = self.successor_partition_offset(offset)?;
+
+        // 5. Materialize `[offset, end)` decompressed and parse the one partition.
+        match self
+            .seek_partition_compaction_rows(offset, end_bound, partition_key, schema)
+            .await?
+        {
+            Some(rows) => Ok(SinglePartitionCompaction::Rows(rows)),
+            // Could not bound the (last) partition authoritatively — fall back to a
+            // full scan of this SSTable for correctness (#953 mandate).
+            None => Ok(SinglePartitionCompaction::IndexUnavailable),
+        }
+    }
+
+    /// Materialize the decompressed window covering `[offset, end)` and parse the
+    /// single partition that starts at `offset`, collecting its compaction rows.
+    ///
+    /// Returns `Ok(None)` when the last partition cannot be bounded authoritatively
+    /// (no successor and no usable data length) — the caller falls back to a scan.
+    /// The parse uses the SAME `build_v5_parser(false)` +
+    /// `parse_one_partition_for_compaction` the full-scan compaction stream uses,
+    /// so the rows are byte-identical to that stream restricted to this partition.
+    async fn seek_partition_compaction_rows(
+        &self,
+        offset: u64,
+        end_bound: Option<u64>,
+        partition_key: &[u8],
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<Option<Vec<CompactionRow>>> {
+        let offset = offset as usize;
+        let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
+        let parser = self.build_v5_parser(false);
+
+        // Chunk length drives the two window strategies. Absent/zero → uncompressed
+        // (the WriteEngine's `nb` output, and uncompressed BTI): read the whole
+        // section once and parse from `offset`. Present → compressed: pull only the
+        // chunks covering `[offset, end)`.
+        let chunk_length = self
+            .compression_info
+            .as_ref()
+            .map(|ci| ci.chunk_length as usize)
+            .filter(|&len| len > 0);
+
+        let (window, within) = match chunk_length {
+            None => {
+                let whole = self.point_read_whole_section().await?;
+                (whole, offset)
+            }
+            Some(len) => {
+                let target_chunk = offset / len;
+                let window_base = target_chunk * len;
+                let within = offset - window_base;
+                // Authoritative exclusive end in the uncompressed domain.
+                let end = match end_bound {
+                    Some(e) => e as usize,
+                    None => match self
+                        .compression_info
+                        .as_ref()
+                        .map(|ci| ci.data_length as usize)
+                        .filter(|&len| len > offset)
+                    {
+                        Some(len) => len,
+                        // Last partition, unknown length → cannot bound → scan.
+                        None => return Ok(None),
+                    },
+                };
+                let window = self.pull_chunk_window(target_chunk, window_base, end).await?;
+                (window, within)
+            }
+        };
+
+        if within >= window.len() {
+            // Nothing decodable at the resolved offset — treat as absent here.
+            return Ok(Some(Vec::new()));
+        }
+
+        // Parse the FIRST partition at `window[within..]`. Collect every row whose
+        // decoded key equals the queried key; a decoded DIFFERENT key means the
+        // resolved candidate was a prefix-collision for an absent key.
+        let mut rows: Vec<CompactionRow> = Vec::new();
+        let mut saw_foreign_key = false;
+        parser.parse_one_partition_for_compaction(
+            &window[within..],
+            owned_schema.as_ref(),
+            self,
+            true,
+            &mut |row: CompactionRow| {
+                if row.key.as_bytes() == partition_key {
+                    rows.push(row);
+                } else {
+                    saw_foreign_key = true;
+                }
+                Ok(ControlFlow::Continue(()))
+            },
+        )?;
+
+        if saw_foreign_key && rows.is_empty() {
+            // Prefix-collision candidate for an absent key: authoritative empty.
+            return Ok(Some(Vec::new()));
+        }
+        Ok(Some(rows))
+    }
+
+    /// Pull the decompressed chunks covering `[window_base, end)` starting at
+    /// `target_chunk`, returning the concatenated bytes. Never stitches to EOF: it
+    /// stops as soon as the window reaches `end` (the target partition's exclusive
+    /// end) or the SSTable is exhausted. Mirrors the bounded chunk fetch the
+    /// user-facing single-partition seek uses (issue #953), so a head-of-file
+    /// point read never decompresses the whole `Data.db`.
+    async fn pull_chunk_window(
+        &self,
+        target_chunk: usize,
+        window_base: usize,
+        end: usize,
+    ) -> Result<Vec<u8>> {
+        use super::super::chunk_source::ChunkSource;
+        use crate::storage::sstable::compression::Compression;
+
+        let compression_opt = self
+            .compression_reader
+            .as_ref()
+            .map(|cr| Compression::new(*cr.algorithm()))
+            .transpose()?;
+        let comp_info = self.compression_info.as_deref().ok_or_else(|| {
+            crate::Error::corruption(
+                "point-read chunk-targeted path requires CompressionInfo but it is absent",
+            )
+        })?;
+        let chunk_source = ChunkSource::new(
+            self.point_source.as_ref(),
+            comp_info,
+            compression_opt.as_ref(),
+            &self.chunk_cache,
+            self.stats.file_size,
+            0, // NB/BTI: chunk offsets are absolute from Data.db byte 0.
+            super::NS_BTI_CHUNK,
+            self.chunk_cache_id,
+        );
+
+        let mut window: Vec<u8> = Vec::new();
+        let mut chunk_index = target_chunk;
+        while window_base + window.len() < end {
+            match chunk_source.chunk(chunk_index)? {
+                Some(decompressed) => {
+                    chunk_index += 1;
+                    window.extend_from_slice(&decompressed);
+                }
+                None => break, // EOF before `end`: parse what we have.
+            }
+        }
+        Ok(window)
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
@@ -54,6 +54,25 @@
 //! resolves an offset the real (complete, uncorrupted) file cannot satisfy,
 //! and the assembled point-read merger must still find the row via scan
 //! fallback.
+//!
+//! ## MEDIUM — a chunk window truncated BEFORE `end` must not parse as `Rows`
+//!
+//! [`truncated_chunk_window_degrades_to_scan_fallback_not_partial_rows`] proves
+//! the COMPRESSED counterpart (roborev job 1611, High): when
+//! `pull_chunk_window` hits EOF (its chunk source exhausted) BEFORE the window
+//! covers the full `[offset, end)`, the resulting partial buffer must NOT be
+//! parsed with `at_final_chunk = true` — the compaction parser FLUSHES a
+//! partially-decoded partition, so the code would surface short/wrong rows as
+//! authoritative `Rows(...)` and hide the corruption. The fix tracks whether
+//! the window reached `end`; an incomplete materialization degrades to
+//! `IndexUnavailable` (scan fallback), NEVER `Rows`. The fixture copies the real
+//! LZ4-compressed BTI `test_da/wide_table` (a head partition that spans ~38
+//! 16 KiB chunks), then drops the trailing chunk offsets from its
+//! `CompressionInfo.db` (reducing `chunk_count`) and truncates `Data.db` to the
+//! new last-kept-chunk boundary — so the kept chunks stay CRC-valid while the
+//! target partition's `[offset, end)` can no longer be fully materialized. With
+//! the fix reverted the primitive returns `Rows(<300)` (a partial decode); with
+//! it applied it returns `IndexUnavailable`.
 
 use crate::schema::{Column, KeyColumn, TableSchema};
 use crate::storage::scan_cancel::ScanCancel;
@@ -68,6 +87,7 @@ use crate::storage::write_engine::{
 use crate::types::Value;
 use crate::{Config, Platform};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -355,4 +375,214 @@ fn collect_partitions(mut merger: KWayMerger) -> Vec<usize> {
         out.push(rows.len());
     }
     out
+}
+
+// ---- MEDIUM: a chunk window truncated before `end` (compressed path) --------
+
+/// Schema for the real `test_da/wide_table` fixture
+/// (`pk int, ck int, payload text, PRIMARY KEY (pk, ck)`, LZ4). A valid schema
+/// lets the compaction parser decode partial rows — so a reverted fix produces
+/// `Rows(<300)` (the red proof), not a decode error.
+fn wide_table_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_da".to_string(),
+        table: "wide_table".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![crate::schema::ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: crate::schema::ClusteringOrder::default(),
+        }],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Locate the real `test_da/wide_table-*` SSTable directory (its `Data.db`)
+/// under `CQLITE_DATASETS_ROOT`. Returns `None` (skip, never fail) when the
+/// env var or the local fixture is absent — it is not in the published CI set.
+fn wide_table_data_path() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)?;
+    let ks_dir = root.join("sstables").join("test_da");
+    for entry in std::fs::read_dir(&ks_dir).ok()?.flatten() {
+        if !entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with("wide_table-")
+        {
+            continue;
+        }
+        for f in std::fs::read_dir(entry.path()).ok()?.flatten() {
+            if f.file_name().to_string_lossy().ends_with("-Data.db") {
+                return Some(f.path());
+            }
+        }
+    }
+    None
+}
+
+/// Copy every component of the SSTable directory holding `data_path` into a
+/// fresh temp dir, returning the temp dir (keep alive) and the COPIED `Data.db`.
+fn copy_sstable_dir(data_path: &std::path::Path) -> (TempDir, PathBuf) {
+    let src_dir = data_path.parent().expect("Data.db has a parent dir");
+    let temp = TempDir::new().unwrap();
+    let mut copied_data = None;
+    for f in std::fs::read_dir(src_dir).unwrap().flatten() {
+        let name = f.file_name();
+        let dst = temp.path().join(&name);
+        std::fs::copy(f.path(), &dst).unwrap();
+        if name.to_string_lossy().ends_with("-Data.db") {
+            copied_data = Some(dst);
+        }
+    }
+    (temp, copied_data.expect("copied a -Data.db"))
+}
+
+/// Sibling `*-CompressionInfo.db` for a copied `Data.db`.
+fn sibling_compression_info(data_path: &std::path::Path) -> PathBuf {
+    let name = data_path.file_name().unwrap().to_string_lossy();
+    let base = name.strip_suffix("-Data.db").unwrap();
+    data_path
+        .parent()
+        .unwrap()
+        .join(format!("{base}-CompressionInfo.db"))
+}
+
+/// A COMPRESSED chunk window that cannot be fully materialized to `end` (EOF
+/// before `end`, a truncated/corrupt SSTable) must degrade to
+/// `IndexUnavailable` — NEVER a partial `Rows(...)` flushed by the compaction
+/// parser at `at_final_chunk = true` (roborev job 1611, High).
+///
+/// Red proof: with the `!reached_end` guard reverted the primitive returns
+/// `Rows(N)` with `N < 300` (a partial, wrong decode surfaced as authoritative);
+/// with it applied it returns `IndexUnavailable`.
+#[tokio::test]
+async fn truncated_chunk_window_degrades_to_scan_fallback_not_partial_rows() {
+    let Some(src_data) = wide_table_data_path() else {
+        eprintln!("Skipping (truncated compressed window): test_da/wide_table fixture absent");
+        return;
+    };
+    let (_temp, data_path) = copy_sstable_dir(&src_data);
+    let schema = wide_table_schema();
+
+    // Resolve the HEAD partition's offset + its authoritative `end` (the successor
+    // partition's start) from the INTACT copy, using the SAME index the primitive
+    // consults — so the truncation point is provably inside `[offset, end)`.
+    let key1 = WEPartitionKey::single("pk", Value::Integer(1))
+        .to_bytes(&schema)
+        .unwrap();
+    let (chunk_len, orig_count, target_off, end, ci_len, offsets) = {
+        let reader = open_reader(&data_path).await;
+        let ci = reader
+            .compression_info
+            .clone()
+            .expect("wide_table is LZ4-compressed and must carry CompressionInfo");
+        let target_off = reader
+            .lookup_partition_via_bti_trie(&key1)
+            .unwrap()
+            .expect("pk=1 must resolve via the intact BTI trie");
+        let end = reader
+            .successor_partition_offset(target_off)
+            .unwrap()
+            .expect("pk=1 is a head partition and must have a successor bound");
+        let ci_len = std::fs::metadata(sibling_compression_info(&data_path))
+            .unwrap()
+            .len() as usize;
+        (
+            ci.chunk_length as usize,
+            ci.chunk_offsets.len(),
+            target_off as usize,
+            end as usize,
+            ci_len,
+            ci.chunk_offsets.clone(),
+        )
+    };
+    assert_eq!(target_off, 0, "pk=1 must be the head partition (offset 0)");
+
+    // Keep only the FIRST half of the chunks the partition spans, so the window
+    // stops well before `end` (the tail chunks become unreachable → EOF).
+    let end_chunk = end.div_ceil(chunk_len);
+    let new_count = (end_chunk / 2).max(2);
+    assert!(new_count < orig_count, "must drop at least one chunk");
+    assert!(
+        new_count * chunk_len < end,
+        "the kept window ({} bytes) must stop strictly before end ({end})",
+        new_count * chunk_len
+    );
+
+    // Truncate Data.db to the new last-kept-chunk boundary (kept chunks stay
+    // CRC-valid) ...
+    let cut = offsets[new_count] as u64;
+    let data_file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&data_path)
+        .unwrap();
+    data_file.set_len(cut).unwrap();
+
+    // ... and rewrite CompressionInfo.db to advertise only `new_count` chunks
+    // (drop the trailing 8-byte offset entries; `data_length` stays large). The
+    // offset array is the last `orig_count * 8` bytes; `chunk_count` is the u32 BE
+    // immediately before it.
+    let ci_path = sibling_compression_info(&data_path);
+    let ci_bytes = std::fs::read(&ci_path).unwrap();
+    assert_eq!(ci_bytes.len(), ci_len);
+    let offset_array_start = ci_bytes.len() - orig_count * 8;
+    let count_field_pos = offset_array_start - 4;
+    assert_eq!(
+        u32::from_be_bytes(
+            ci_bytes[count_field_pos..count_field_pos + 4]
+                .try_into()
+                .unwrap()
+        ) as usize,
+        orig_count,
+        "sanity: located chunk_count field must match the parsed offset count"
+    );
+    let mut new_ci = Vec::with_capacity(count_field_pos + 4 + new_count * 8);
+    new_ci.extend_from_slice(&ci_bytes[..count_field_pos]);
+    new_ci.extend_from_slice(&(new_count as u32).to_be_bytes());
+    new_ci.extend_from_slice(&ci_bytes[offset_array_start..offset_array_start + new_count * 8]);
+    std::fs::write(&ci_path, &new_ci).unwrap();
+
+    // Reopen on the truncated copy and probe: the window for `[0, end)` now hits
+    // EOF (chunk `new_count` is gone) before reaching `end`.
+    let reader = open_reader(&data_path).await;
+    let outcome = reader
+        .read_single_partition_for_compaction(&key1, Some(&schema))
+        .await
+        .expect("a truncated chunk window must degrade gracefully, never a hard Err");
+    assert!(
+        matches!(outcome, SinglePartitionCompaction::IndexUnavailable),
+        "a chunk window that hit EOF before end must report IndexUnavailable \
+         (scan-fallback), NEVER a partial Rows(...) flushed as authoritative, got {outcome:?}"
+    );
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
@@ -1,0 +1,358 @@
+//! Fail-safe proofs for the single-partition point-read primitive when the
+//! index component is UNREADABLE/corrupt, or resolves an offset the
+//! materialized window never reaches (issue #2207, roborev IMPORTANT-1 +
+//! MEDIUM on PR tip f75dccc2).
+//!
+//! `read_single_partition_for_compaction`'s spec requires: whenever the index
+//! (BTI `Partitions.db` trie / BIG `Index.db`) is absent, unreadable,
+//! ambiguous, or resolves an offset the seek cannot reach, the candidate
+//! SSTable is READ (scan-fallback) — NEVER a hard-failed query the scan path
+//! would still answer, and NEVER a silent empty treated as absence (the
+//! false-negative-prune class the presence-oracle spine forbids).
+//!
+//! ## IMPORTANT-1 — corrupt BTI trie degrades gracefully, never `Err`
+//!
+//! [`corrupt_bti_trie_degrades_to_index_unavailable_not_err`] corrupts a BTI
+//! `Partitions.db` footer AFTER a valid SSTable is written — so the reader
+//! OPENS successfully (`has_partition_index()` stays `true`; the file is
+//! present and non-empty) but the trie DESCENT for a real key fails to parse
+//! — and proves the primitive degrades to
+//! `SinglePartitionCompaction::IndexUnavailable` rather than propagating an
+//! `Err`. Corruption technique: `lookup_partition_in_bti_slice` reads the
+//! trie's `root_offset` from the LAST 8 bytes of `Partitions.db` and errors
+//! when `root_offset >= trie_size` (`bti/parser/slice_walk.rs`); overwriting
+//! those 8 bytes with `0xFF` guarantees that error deterministically.
+//!
+//! A full end-to-end "the assembled merger still returns the row via THIS
+//! SSTable's scan fallback" proof for a genuinely-BTI-format input is NOT
+//! included here: it surfaces a SEPARATE, PRE-EXISTING bug (present on `main`
+//! with NO corruption at all) where `stream_all_partitions_for_compaction`
+//! routes a `da`-format SSTable to `sequential_scan`'s non-stitching branch
+//! (`requires_chunk_stitching()` is `is_nb_format`-gated and is `false` for
+//! `da`), which mis-parses even a tiny, uncorrupted BTI partition
+//! ("Incomplete value: need N bytes... have M") — the working BTI compaction
+//! scan is `stitch_all_chunks` + the compaction parser (used directly by
+//! `distinct_partition_keys`), not this path. This is orthogonal to #2207's
+//! routing/ordering logic and is NOT masked or silently worked around here;
+//! it should be filed as its own issue. It is not a wrong-rows risk (the
+//! failure is a loud `Err`, identical to what a full-table scan of the same
+//! SSTable already hits on `main` today), so IMPORTANT-1's actual requirement
+//! — never propagate the INDEX read's own error as a hard failure — is fully
+//! met and proven below for the reachable (BTI) case.
+//!
+//! ## MEDIUM — a resolved-but-unreachable offset must not read as absence
+//!
+//! [`stale_index_offset_degrades_to_scan_fallback_and_finds_the_row`] proves
+//! the companion fix: `seek_partition_compaction_rows`'s
+//! `within >= window.len()` branch (an offset the materialized window never
+//! reached — a bad bound / truncated-SSTable shape) now returns `Ok(None)`
+//! (→ `IndexUnavailable`), never `Ok(Some(Vec::new()))` (→ a false-negative
+//! `Rows(empty)`, indistinguishable from a genuine, fully-decoded absence).
+//! This uses a BIG-format fixture with an INTACT Data.db (the target row's
+//! bytes are never touched) and directly patches Index.db's `data_offset`
+//! VInt for the target key to an implausibly large value — so the seek
+//! resolves an offset the real (complete, uncorrupted) file cannot satisfy,
+//! and the assembled point-read merger must still find the row via scan
+//! fallback.
+
+use crate::schema::{Column, KeyColumn, TableSchema};
+use crate::storage::scan_cancel::ScanCancel;
+use crate::storage::serialization::vint::encode_unsigned;
+use crate::storage::sstable::reader::{SSTableReader, SinglePartitionCompaction};
+use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+use crate::storage::write_engine::merge::MergeStep;
+use crate::storage::write_engine::mutation::{CellOperation, Mutation, TableId};
+use crate::storage::write_engine::{
+    build_single_partition_merger, KWayMerger, PartitionKey as WEPartitionKey,
+};
+use crate::types::Value;
+use crate::{Config, Platform};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const KS: &str = "test_ks";
+const TBL: &str = "fs_tbl";
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "v".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn mutation(pk: i32, v: &str) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        WEPartitionKey::single("pk", Value::Integer(pk)),
+        None,
+        vec![CellOperation::Write {
+            column: "v".to_string(),
+            value: Value::Text(v.to_string()),
+        }],
+        1_000_000 + pk as i64,
+        None,
+    )
+}
+
+async fn open_reader(data_path: &std::path::Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.unwrap());
+    SSTableReader::open(data_path, &config, platform)
+        .await
+        .unwrap()
+}
+
+// ---- IMPORTANT-1: corrupt BTI trie ----------------------------------------
+
+/// Write a 2-partition BTI (`da`) SSTable (pk=1 -> "one", pk=2 -> "two"), then
+/// overwrite its sibling `Partitions.db` footer's `root_offset` with an
+/// out-of-range value so a real trie descent errors deterministically while the
+/// file itself stays present/non-empty (the reader still OPENS successfully).
+async fn corrupt_bti_fixture() -> (TempDir, std::path::PathBuf) {
+    let schema = schema();
+    let temp = TempDir::new().unwrap();
+    let mut writer = SSTableWriter::with_format(
+        temp.path().to_path_buf(),
+        1,
+        &schema,
+        16,
+        SSTableFormat::Bti,
+    )
+    .unwrap();
+
+    let mut keyed: Vec<_> = [(1, "one"), (2, "two")]
+        .into_iter()
+        .map(|(pk, v)| {
+            let m = mutation(pk, v);
+            let key = m.decorated_key(&schema).unwrap();
+            (key, m)
+        })
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+    for (key, m) in keyed {
+        writer.write_partition(key, vec![m]).unwrap();
+    }
+    let info = writer.finish().await.unwrap();
+    let data_path = info.data_path.clone();
+
+    // The writer reports the sibling Partitions.db path directly (`SSTableInfo`)
+    // — no filename-scheme guessing needed. Stomp its LAST 8 bytes (the
+    // root_offset footer) so `root_offset >= trie_size` unconditionally.
+    let partitions_path = info
+        .partitions_path
+        .clone()
+        .expect("writer must emit a sibling Partitions.db for a BTI SSTable");
+
+    let mut bytes = std::fs::read(&partitions_path).unwrap();
+    assert!(
+        bytes.len() >= 8,
+        "Partitions.db must carry at least the 8-byte footer"
+    );
+    let len = bytes.len();
+    bytes[len - 8..].fill(0xFF);
+    std::fs::write(&partitions_path, &bytes).unwrap();
+
+    (temp, data_path)
+}
+
+/// The core primitive degrades a corrupt-trie descent to `IndexUnavailable`,
+/// never an `Err` — the fail-safe spine (roborev IMPORTANT-1).
+#[tokio::test]
+async fn corrupt_bti_trie_degrades_to_index_unavailable_not_err() {
+    let (_temp, data_path) = corrupt_bti_fixture().await;
+    let reader = open_reader(&data_path).await;
+    assert!(
+        reader.has_partition_index(),
+        "the corrupted-but-present Partitions.db must still report an index (open succeeded)"
+    );
+
+    let schema = schema();
+    let key_bytes = WEPartitionKey::single("pk", Value::Integer(1))
+        .to_bytes(&schema)
+        .unwrap();
+
+    let outcome = reader
+        .read_single_partition_for_compaction(&key_bytes, Some(&schema))
+        .await
+        .expect("a corrupt trie must degrade gracefully, never a hard Err");
+    assert!(
+        matches!(outcome, SinglePartitionCompaction::IndexUnavailable),
+        "a corrupt BTI trie descent must report IndexUnavailable (scan-fallback signal), got {outcome:?}"
+    );
+}
+
+// ---- MEDIUM: offset beyond the materialized window -----------------------
+
+/// Write a 2-partition BIG (`nb`) SSTable, then patch Index.db's on-disk
+/// `data_offset` VInt for `pk=2` to an implausibly large value (well beyond
+/// the real, INTACT Data.db's length) — a stale/corrupt index entry pointing
+/// nowhere real, while `pk=2`'s actual row bytes are untouched and still fully
+/// recoverable by a scan. Returns the temp dir (keep alive), the `Data.db`
+/// path, and `pk=2`'s raw key bytes.
+async fn stale_offset_fixture() -> (TempDir, std::path::PathBuf, Vec<u8>) {
+    let schema = schema();
+    let temp = TempDir::new().unwrap();
+    let mut writer = SSTableWriter::new(temp.path().to_path_buf(), 1, &schema).unwrap();
+
+    let mut keyed: Vec<_> = [(1, "one"), (2, "two")]
+        .into_iter()
+        .map(|(pk, v)| {
+            let m = mutation(pk, v);
+            let key = m.decorated_key(&schema).unwrap();
+            (key, m)
+        })
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+    for (key, m) in keyed {
+        writer.write_partition(key, vec![m]).unwrap();
+    }
+    let info = writer.finish().await.unwrap();
+    let data_path = info.data_path.clone();
+    let index_path = info
+        .index_path
+        .clone()
+        .expect("writer must emit a sibling Index.db for the BIG format");
+
+    let target_key_bytes = WEPartitionKey::single("pk", Value::Integer(2))
+        .to_bytes(&schema)
+        .unwrap();
+
+    // Confirm the REAL (legitimate) resolved offset and the true data-section
+    // length via an uncorrupted reader, so the replacement value is provably
+    // beyond the actual file (not a guess).
+    let real_data_len = {
+        let reader = open_reader(&data_path).await;
+        let (real_offset, _) = reader
+            .lookup_partition_with_index(&target_key_bytes)
+            .await
+            .unwrap()
+            .expect("pk=2 must resolve via the intact Index.db before corruption");
+        let header_size = reader.calculate_header_size() as u64;
+        let file_len = std::fs::metadata(&data_path).unwrap().len();
+        let data_len = file_len.saturating_sub(header_size);
+        assert!(
+            real_offset < data_len,
+            "sanity: the real offset must be within the real data section"
+        );
+        data_len
+    };
+
+    // Locate the Index.db entry's `[key_len: u16 BE][raw key bytes]` prefix
+    // (`index_writer.rs::write_entry`'s documented on-disk framing) and splice
+    // in a replacement `data_offset` VInt encoding a value STRICTLY beyond
+    // `real_data_len` — pk=2 is written last (highest token among the two), so
+    // no entry follows it in the file; a length-changing splice is safe.
+    let mut index_bytes = std::fs::read(&index_path).unwrap();
+    let mut prefix = (target_key_bytes.len() as u16).to_be_bytes().to_vec();
+    prefix.extend_from_slice(&target_key_bytes);
+    let prefix_start = index_bytes
+        .windows(prefix.len())
+        .position(|w| w == prefix.as_slice())
+        .expect("pk=2's Index.db entry prefix must be found");
+    let vint_start = prefix_start + prefix.len();
+
+    // Determine the OLD VInt's byte length by re-encoding the value we already
+    // confirmed above, so we splice exactly the old VInt's span.
+    let real_offset = {
+        let reader = open_reader(&data_path).await;
+        reader
+            .lookup_partition_with_index(&target_key_bytes)
+            .await
+            .unwrap()
+            .unwrap()
+            .0
+    };
+    let mut old_vint = Vec::new();
+    encode_unsigned(real_offset, &mut old_vint);
+    assert_eq!(
+        &index_bytes[vint_start..vint_start + old_vint.len()],
+        old_vint.as_slice(),
+        "sanity: the byte-search-located VInt must match the resolved real offset"
+    );
+
+    let corrupted_offset = real_data_len + 10_000;
+    let mut new_vint = Vec::new();
+    encode_unsigned(corrupted_offset, &mut new_vint);
+    index_bytes.splice(
+        vint_start..vint_start + old_vint.len(),
+        new_vint.iter().copied(),
+    );
+    std::fs::write(&index_path, &index_bytes).unwrap();
+
+    (temp, data_path, target_key_bytes)
+}
+
+/// A resolved-but-unreachable offset (stale/corrupt Index.db entry, INTACT
+/// Data.db) must degrade to a scan fallback — NEVER a silent `Rows(empty)`
+/// treated as absence (roborev MEDIUM). Proven at both layers: the core
+/// primitive reports `IndexUnavailable`, and the assembled point-read merger
+/// still finds the row via that SSTable's scan.
+#[tokio::test]
+async fn stale_index_offset_degrades_to_scan_fallback_and_finds_the_row() {
+    let (_temp, data_path, target_key_bytes) = stale_offset_fixture().await;
+    let schema = schema();
+
+    // Layer 1: the primitive itself.
+    let reader = open_reader(&data_path).await;
+    let outcome = reader
+        .read_single_partition_for_compaction(&target_key_bytes, Some(&schema))
+        .await
+        .expect("a stale offset must degrade gracefully, never a hard Err");
+    assert!(
+        matches!(outcome, SinglePartitionCompaction::IndexUnavailable),
+        "an offset beyond the materialized window must report IndexUnavailable \
+         (scan-fallback signal), NEVER Rows(empty) (false-negative prune), got {outcome:?}"
+    );
+
+    // Layer 2: the assembled point-read merger still finds the row.
+    let built = build_single_partition_merger(
+        vec![data_path],
+        &[target_key_bytes],
+        &schema,
+        ScanCancel::default(),
+    )
+    .unwrap()
+    .expect("pk=2's row is intact in Data.db and must be found via scan fallback");
+
+    let rows = collect_partitions(built);
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly the one target partition must be returned, with its row intact"
+    );
+    assert_eq!(rows[0], 1, "pk=2's single live row must be present");
+}
+
+/// Drain a merger to completion, returning every partition's row count.
+fn collect_partitions(mut merger: KWayMerger) -> Vec<usize> {
+    let mut out = Vec::new();
+    while let MergeStep::Partition { rows, .. } = merger.step().expect("step") {
+        out.push(rows.len());
+    }
+    out
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
@@ -727,3 +727,101 @@ async fn truncated_chunk_window_degrades_to_scan_fallback_not_partial_rows() {
          (scan-fallback), NEVER a partial Rows(...) flushed as authoritative, got {outcome:?}"
     );
 }
+
+// ---- Finding 2 (job 1620, MEDIUM): mid-seek cancellation ------------------
+// ---- Finding 3 (job 1620, LOW): BTI miss is an authoritative prune --------
+
+/// Write a clean 2-partition BTI (`da`) SSTable with an INTACT trie (companion
+/// to `corrupt_bti_fixture`), returning the temp dir (keep alive) and the
+/// `Data.db` path. A present key resolves its offset and reaches the seek; an
+/// absent key is a genuine trie miss.
+async fn valid_bti_fixture() -> (TempDir, std::path::PathBuf) {
+    let schema = schema();
+    let temp = TempDir::new().unwrap();
+    let mut writer = SSTableWriter::with_format(
+        temp.path().to_path_buf(),
+        1,
+        &schema,
+        16,
+        SSTableFormat::Bti,
+    )
+    .unwrap();
+
+    let mut keyed: Vec<_> = [(1, "one"), (2, "two")]
+        .into_iter()
+        .map(|(pk, v)| {
+            let m = mutation(pk, v);
+            let key = m.decorated_key(&schema).unwrap();
+            (key, m)
+        })
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+    for (key, m) in keyed {
+        writer.write_partition(key, vec![m]).unwrap();
+    }
+    let info = writer.finish().await.unwrap();
+    (temp, info.data_path)
+}
+
+/// A `scan_cancel` flag tripped BEFORE the seek runs aborts it with
+/// `Error::Cancelled` for a PRESENT key — the primitive resolves the offset
+/// (steps 1–4) then `seek_partition_compaction_rows`'s entry poll fires, so NO
+/// partition is decoded and NO `Rows`/`IndexUnavailable`/`DefinitelyAbsent`
+/// outcome is produced. FAILS on pre-fix code (Finding 2): without the seek-path
+/// `scan_cancel` poll the seek ignores the token and returns `Ok(...)`.
+#[tokio::test]
+async fn pre_cancelled_seek_aborts_with_cancelled_not_rows() {
+    let (_temp, data_path) = valid_bti_fixture().await;
+    let mut reader = open_reader(&data_path).await;
+
+    let cancel = ScanCancel::new();
+    cancel.cancel();
+    reader.set_scan_cancel(cancel);
+
+    let schema = schema();
+    let key_bytes = WEPartitionKey::single("pk", Value::Integer(1))
+        .to_bytes(&schema)
+        .unwrap();
+
+    let result = reader
+        .read_single_partition_for_compaction(&key_bytes, Some(&schema))
+        .await;
+    assert!(
+        matches!(result, Err(crate::Error::Cancelled)),
+        "a pre-cancelled seek of a PRESENT key must abort with Error::Cancelled \
+         (decode no rows), got {result:?}"
+    );
+}
+
+/// A genuinely ABSENT key in a BTI SSTable classifies as `DefinitelyAbsent` —
+/// the authoritative-by-construction trie-miss outcome — NEVER
+/// `Rows(Vec::new())` (which the enum reserves for a FULLY-DECODED
+/// prefix-collision) and never `IndexUnavailable`. Pins Finding 3's three-exit
+/// invariant for the BTI-miss path: `bti_trie_resolve` returns `Ok(None)` ONLY
+/// for a definitive miss (every degraded/unusable trie state returns `Err` →
+/// `IndexUnavailable`), so a miss is a prune, not an empty decode. The reachable
+/// path is step 1's presence-oracle prune (`might_contain_partition` funnels
+/// through the SAME trie); the corrected step-3 `Ok(None)` arm is its defensive
+/// equivalent and now returns the same `DefinitelyAbsent`, so both agree with
+/// the contract this test pins.
+#[tokio::test]
+async fn bti_absent_key_is_definitely_absent_not_empty_rows() {
+    let (_temp, data_path) = valid_bti_fixture().await;
+    let reader = open_reader(&data_path).await;
+
+    let schema = schema();
+    // pk=999 was never written — a genuine trie miss.
+    let key_bytes = WEPartitionKey::single("pk", Value::Integer(999))
+        .to_bytes(&schema)
+        .unwrap();
+
+    let outcome = reader
+        .read_single_partition_for_compaction(&key_bytes, Some(&schema))
+        .await
+        .expect("an absent-key probe must not error");
+    assert!(
+        matches!(outcome, SinglePartitionCompaction::DefinitelyAbsent),
+        "an absent BTI key must classify as DefinitelyAbsent (authoritative prune), \
+         never Rows(empty) or IndexUnavailable, got {outcome:?}"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
@@ -368,6 +368,147 @@ async fn stale_index_offset_degrades_to_scan_fallback_and_finds_the_row() {
     assert_eq!(rows[0], 1, "pk=2's single live row must be present");
 }
 
+// ---- HIGH (job 1616): BIG foreign-partition offset must not read as absence --
+
+/// Write a 2-partition BIG (`nb`) SSTable, then redirect Index.db's on-disk
+/// `data_offset` VInt for `pk=2` to point at `pk=1`'s (real, valid, DIFFERENT)
+/// partition offset — a stale/corrupt exact-offset entry aimed at another
+/// EXISTING partition, while pk=2's own row bytes stay intact and
+/// scan-recoverable. Returns the temp dir (keep alive), the `Data.db` path, and
+/// pk=2's raw key bytes.
+///
+/// Unlike the "implausibly large offset" fixture, the redirect lands on a
+/// perfectly well-formed OTHER partition, so the seek DECODES SUCCESSFULLY and
+/// finds only a FOREIGN key — the exact shape a naive authoritative-empty would
+/// mistake for absence.
+async fn foreign_partition_offset_fixture() -> (TempDir, std::path::PathBuf, Vec<u8>) {
+    let schema = schema();
+    let temp = TempDir::new().unwrap();
+    let mut writer = SSTableWriter::new(temp.path().to_path_buf(), 1, &schema).unwrap();
+
+    let mut keyed: Vec<_> = [(1, "one"), (2, "two")]
+        .into_iter()
+        .map(|(pk, v)| {
+            let m = mutation(pk, v);
+            let key = m.decorated_key(&schema).unwrap();
+            (key, m)
+        })
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+    for (key, m) in keyed {
+        writer.write_partition(key, vec![m]).unwrap();
+    }
+    let info = writer.finish().await.unwrap();
+    let data_path = info.data_path.clone();
+    let index_path = info
+        .index_path
+        .clone()
+        .expect("writer must emit a sibling Index.db for the BIG format");
+
+    let key1 = WEPartitionKey::single("pk", Value::Integer(1))
+        .to_bytes(&schema)
+        .unwrap();
+    let key2 = WEPartitionKey::single("pk", Value::Integer(2))
+        .to_bytes(&schema)
+        .unwrap();
+
+    // Resolve BOTH partitions' real offsets from the INTACT index; pk=2's entry
+    // will be redirected to pk=1's (valid, different) offset.
+    let (off1, off2) = {
+        let reader = open_reader(&data_path).await;
+        let off1 = reader
+            .lookup_partition_with_index(&key1)
+            .await
+            .unwrap()
+            .expect("pk=1 must resolve via the intact Index.db")
+            .0;
+        let off2 = reader
+            .lookup_partition_with_index(&key2)
+            .await
+            .unwrap()
+            .expect("pk=2 must resolve via the intact Index.db")
+            .0;
+        (off1, off2)
+    };
+    assert_ne!(
+        off1, off2,
+        "the two partitions must sit at distinct offsets for a foreign redirect"
+    );
+
+    // Splice pk=2's `data_offset` VInt to encode pk=1's offset instead. pk=2 has
+    // the higher token (written last) so no entry follows it — a length-changing
+    // splice is safe.
+    let mut index_bytes = std::fs::read(&index_path).unwrap();
+    let mut prefix = (key2.len() as u16).to_be_bytes().to_vec();
+    prefix.extend_from_slice(&key2);
+    let prefix_start = index_bytes
+        .windows(prefix.len())
+        .position(|w| w == prefix.as_slice())
+        .expect("pk=2's Index.db entry prefix must be found");
+    let vint_start = prefix_start + prefix.len();
+
+    let mut old_vint = Vec::new();
+    encode_unsigned(off2, &mut old_vint);
+    assert_eq!(
+        &index_bytes[vint_start..vint_start + old_vint.len()],
+        old_vint.as_slice(),
+        "sanity: the located VInt must match pk=2's real offset"
+    );
+    let mut new_vint = Vec::new();
+    encode_unsigned(off1, &mut new_vint);
+    index_bytes.splice(
+        vint_start..vint_start + old_vint.len(),
+        new_vint.iter().copied(),
+    );
+    std::fs::write(&index_path, &index_bytes).unwrap();
+
+    (temp, data_path, key2)
+}
+
+/// A BIG exact-offset lookup whose Index.db entry resolves a DIFFERENT valid
+/// partition (stale/corrupt entry) must degrade to a scan fallback — the decode
+/// lands on a FOREIGN key, and treating an empty match-set there as authoritative
+/// absence would SILENTLY DROP the target key (roborev job 1616, High: fail-safe
+/// violation). The BTI prefix-collision authoritative-empty rule does NOT apply
+/// to a BIG exact offset. Proven at both layers: the primitive reports
+/// `IndexUnavailable`, and the assembled point-read merger still finds pk=2's row
+/// via scan fallback.
+///
+/// RED PROOF: with the src fix reverted the `saw_foreign_key && rows.is_empty()`
+/// branch returns `Rows(Vec::new())` (a silent drop) and this test FAILS on the
+/// `IndexUnavailable` assertion.
+#[tokio::test]
+async fn big_foreign_partition_offset_degrades_to_scan_fallback_not_empty_rows() {
+    let (_temp, data_path, key2) = foreign_partition_offset_fixture().await;
+    let schema = schema();
+
+    // Layer 1: the primitive itself.
+    let reader = open_reader(&data_path).await;
+    let outcome = reader
+        .read_single_partition_for_compaction(&key2, Some(&schema))
+        .await
+        .expect("a foreign-partition offset must degrade gracefully, never a hard Err");
+    assert!(
+        matches!(outcome, SinglePartitionCompaction::IndexUnavailable),
+        "a BIG Index.db offset resolving a DIFFERENT valid partition must report \
+         IndexUnavailable (scan-fallback), NEVER Rows(empty) (a silent drop of the \
+         target key), got {outcome:?}"
+    );
+
+    // Layer 2: the assembled point-read merger still finds pk=2's intact row.
+    let built =
+        build_single_partition_merger(vec![data_path], &[key2], &schema, ScanCancel::default())
+            .unwrap()
+            .expect("pk=2's row is intact in Data.db and must be found via scan fallback");
+    let rows = collect_partitions(built);
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly pk=2's partition must be returned, with its row intact"
+    );
+    assert_eq!(rows[0], 1, "pk=2's single live row must be present");
+}
+
 /// Drain a merger to completion, returning every partition's row count.
 fn collect_partitions(mut merger: KWayMerger) -> Vec<usize> {
     let mut out = Vec::new();

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -74,7 +74,9 @@ pub use types::{
 };
 // Re-export the within-partition clustering-slice push-down spec (Issue #954).
 pub use data_access::ClusteringSlice;
-// Single-partition compaction seek outcome (issue #2207).
+// Single-partition compaction seek outcome (issue #2207). `not(tombstones)` like
+// the seek path it wraps.
+#[cfg(not(feature = "tombstones"))]
 pub use data_access::SinglePartitionCompaction;
 // Re-export the per-element compaction read contract (epic #899, Phase A).
 pub use compaction_row::{

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -74,6 +74,8 @@ pub use types::{
 };
 // Re-export the within-partition clustering-slice push-down spec (Issue #954).
 pub use data_access::ClusteringSlice;
+// Single-partition compaction seek outcome (issue #2207).
+pub use data_access::SinglePartitionCompaction;
 // Re-export the per-element compaction read contract (epic #899, Phase A).
 pub use compaction_row::{
     CompactionRow, CompactionRowData, ComplexColumn, ComplexElement, SimpleCell,

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -76,6 +76,15 @@ mod model;
 #[cfg(feature = "write-support")]
 pub use model::{CellData, ComplexDeletion, MergeEntry, MergeStats, MergeStep, RowData};
 
+/// Single-partition point-read merge builder (issue #2207): assembles a
+/// [`KWayMerger`] from per-candidate single-partition runs (seeked or key-filtered)
+/// for the Flight `do_get` point-read path. Byte-identical reconciliation to the
+/// full-scan merge; only the inputs are narrower.
+#[cfg(feature = "write-support")]
+mod point_read;
+#[cfg(feature = "write-support")]
+pub use point_read::build_single_partition_merger;
+
 /// Fully-expired SSTable drop classification (issue #1388): the metadata-only
 /// `fully_expired_sstables` drop-set used by both compaction surfaces to skip
 /// reading SSTables that are entirely past `gcBefore` and overlap-safe.
@@ -2266,6 +2275,41 @@ impl KWayMerger {
             // No overlap bound by default (#935): a partial compaction stays
             // conservative (no purging) until a caller supplies the min outside
             // timestamp via `with_max_purgeable_timestamp`.
+            max_purgeable_timestamp: None,
+        })
+    }
+
+    /// Build a k-way merger from pre-constructed run iterators (issue #2207).
+    ///
+    /// Unlike [`Self::new`], which opens each input SSTable and streams its WHOLE
+    /// compaction scan, this accepts runs the caller has already scoped — e.g. the
+    /// single-partition point-read path (`merge::point_read`) hands one run per
+    /// candidate SSTable, each yielding ONLY the target partition's entries (a
+    /// seeked `Vec` or a key-filtered stream). The reconciliation, heap, and
+    /// per-partition merge are IDENTICAL to the full-scan path — only the inputs
+    /// are narrower — so the point path reconciles byte-identically to the scan.
+    ///
+    /// `runs` must be non-empty and ordered newest-to-oldest (run index = LWW
+    /// tie-break rank), exactly as [`Self::new`]'s `input_paths` are.
+    pub fn from_row_iterators(
+        runs: Vec<Box<dyn SSTableRowIterator>>,
+        schema: &TableSchema,
+    ) -> Result<Self> {
+        if runs.is_empty() {
+            return Err(Error::InvalidInput(
+                "K-way merge requires at least one input run".to_string(),
+            ));
+        }
+        schema.validate_dropped_columns()?;
+        let runs = runs.into_iter().map(RunReader::new).collect();
+        Ok(Self {
+            runs,
+            heap: BinaryHeap::new(),
+            current_partition: None,
+            schema: schema.clone(),
+            gc_before_secs: None,
+            now_secs: None,
+            purge_safe: false,
             max_purgeable_timestamp: None,
         })
     }

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -2279,41 +2279,6 @@ impl KWayMerger {
         })
     }
 
-    /// Build a k-way merger from pre-constructed run iterators (issue #2207).
-    ///
-    /// Unlike [`Self::new`], which opens each input SSTable and streams its WHOLE
-    /// compaction scan, this accepts runs the caller has already scoped — e.g. the
-    /// single-partition point-read path (`merge::point_read`) hands one run per
-    /// candidate SSTable, each yielding ONLY the target partition's entries (a
-    /// seeked `Vec` or a key-filtered stream). The reconciliation, heap, and
-    /// per-partition merge are IDENTICAL to the full-scan path — only the inputs
-    /// are narrower — so the point path reconciles byte-identically to the scan.
-    ///
-    /// `runs` must be non-empty and ordered newest-to-oldest (run index = LWW
-    /// tie-break rank), exactly as [`Self::new`]'s `input_paths` are.
-    pub fn from_row_iterators(
-        runs: Vec<Box<dyn SSTableRowIterator>>,
-        schema: &TableSchema,
-    ) -> Result<Self> {
-        if runs.is_empty() {
-            return Err(Error::InvalidInput(
-                "K-way merge requires at least one input run".to_string(),
-            ));
-        }
-        schema.validate_dropped_columns()?;
-        let runs = runs.into_iter().map(RunReader::new).collect();
-        Ok(Self {
-            runs,
-            heap: BinaryHeap::new(),
-            current_partition: None,
-            schema: schema.clone(),
-            gc_before_secs: None,
-            now_secs: None,
-            purge_safe: false,
-            max_purgeable_timestamp: None,
-        })
-    }
-
     /// Mark this merge as overlap-safe for tombstone purging (#921 finding 1).
     ///
     /// Set `true` ONLY when the compaction inputs provably span EVERY SSTable

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -162,6 +162,19 @@ pub fn build_single_partition_merger(
     if keys.is_empty() {
         return Ok(None);
     }
+
+    // Canonicalize the requested key set (roborev suggestion, issue #2207):
+    // dedup identical raw keys — a `pk IN (5, 5)` ticket must not double-seek the
+    // same partition — and sort by Murmur3 token, the natural probing order
+    // (matches the ascending order `MergeEntry::Ord` requires each run to
+    // yield). Correctness does not depend on this order (each candidate's
+    // combined entries are sorted again below before wrapping in `VecRun`), but
+    // canonicalizing up front avoids redundant work and reads more naturally.
+    let mut canonical: Vec<Vec<u8>> = keys.to_vec();
+    canonical.sort_by_key(|k| crate::util::cassandra_murmur3::cassandra_murmur3_token(k));
+    canonical.dedup();
+    let keys: &[Vec<u8>] = &canonical;
+
     let key_set: std::collections::HashSet<Vec<u8>> = keys.iter().cloned().collect();
 
     let mut runs: Vec<Box<dyn SSTableRowIterator>> = Vec::new();
@@ -178,13 +191,26 @@ pub fn build_single_partition_merger(
                 if rows.is_empty() {
                     continue;
                 }
-                let mut entries = VecDeque::with_capacity(rows.len());
+                let mut entries: Vec<MergeEntry> = Vec::with_capacity(rows.len());
                 for row in rows {
-                    entries.push_back(SSTableRowIteratorAdapter::build_merge_entry(
+                    entries.push(SSTableRowIteratorAdapter::build_merge_entry(
                         run_index, row, schema,
                     )?);
                 }
-                runs.push(Box::new(VecRun { entries }));
+                // BLOCKER fix (roborev, issue #2207): `rows` was accumulated in
+                // REQUESTED-KEY order (IN-list / Or order), not token order. Every
+                // `SSTableRowIterator` MUST yield entries in ascending `MergeEntry`
+                // order (token, key, clustering) — `refill_heap` buffers only ONE
+                // entry per run at a time and relies on that invariant (mod.rs
+                // `step`/`refill_heap`). An out-of-order run causes `step()` to
+                // silently split one run's contribution across two heap pops,
+                // duplicating rows and breaking cross-generation reconciliation
+                // (a newer generation's overwrite/tombstone no longer shadows the
+                // older one). Sort once, here, before wrapping in `VecRun`.
+                entries.sort();
+                runs.push(Box::new(VecRun {
+                    entries: entries.into(),
+                }));
             }
             PathProbe::NeedsScan => {
                 // Fail-safe: scan this ONE SSTable, forwarding only the target

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -22,7 +22,9 @@ use super::{block_on_async, KWayMerger, MergeEntry, SSTableRowIterator, SSTableR
 use crate::config::DiskAccessMode;
 use crate::platform::Platform;
 use crate::schema::TableSchema;
-use crate::storage::sstable::reader::{SSTableReader, SinglePartitionCompaction};
+use crate::storage::sstable::reader::{
+    CompactionRow, SSTableReader, SinglePartitionCompaction,
+};
 use crate::storage::scan_cancel::ScanCancel;
 use crate::{Config, Result};
 use std::collections::VecDeque;
@@ -41,13 +43,13 @@ impl SSTableRowIterator for VecRun {
     }
 }
 
-/// A run that forwards ONLY the target partition's entries from an SSTable's full
+/// A run that forwards ONLY the target partitions' entries from an SSTable's full
 /// compaction stream — the index-unavailable fail-safe. Byte-identical to the
-/// full scan's contribution for this partition (same stream, same decode), just
-/// with the other partitions dropped before the merge sees them.
+/// full scan's contribution for those partitions (same stream, same decode), just
+/// with every other partition dropped before the merge sees it.
 struct SinglePartitionFilterRun {
     inner: SSTableRowIteratorAdapter,
-    key: Vec<u8>,
+    keys: std::collections::HashSet<Vec<u8>>,
 }
 
 impl SSTableRowIterator for SinglePartitionFilterRun {
@@ -55,7 +57,7 @@ impl SSTableRowIterator for SinglePartitionFilterRun {
         loop {
             match self.inner.next() {
                 Some(Ok(entry)) => {
-                    if entry.key.key == self.key {
+                    if self.keys.contains(&entry.key.key) {
                         return Some(Ok(entry));
                     }
                     // A non-target partition: drop it and pull the next entry.
@@ -68,24 +70,42 @@ impl SSTableRowIterator for SinglePartitionFilterRun {
     }
 }
 
-/// Assemble a [`KWayMerger`] that reads ONLY `partition_key` across the candidate
-/// `paths` (issue #2207).
+/// Per-candidate probe outcome across ALL requested keys.
+enum PathProbe {
+    /// No requested key is present in this SSTable (all definite-absent / empty).
+    Empty,
+    /// The seeked compaction rows for every present key (combined; same generation
+    /// so they share one run index).
+    Seeked(Vec<CompactionRow>),
+    /// This SSTable has no usable index — scan it, filtered to the requested keys.
+    NeedsScan,
+}
+
+/// Assemble a [`KWayMerger`] that reads ONLY the target `keys` across the
+/// candidate `paths` (issue #2207).
 ///
-/// Returns `Ok(None)` when every candidate is a definite presence-oracle negative
-/// (no SSTable holds the key) — the caller streams zero rows. Otherwise returns a
-/// merger the caller drives through its existing reconciliation loop.
+/// Returns `Ok(None)` when no candidate holds any target key (every one a definite
+/// presence-oracle negative / prefix-collision) — the caller streams zero rows.
+/// Otherwise returns a merger the caller drives through its existing reconciliation
+/// loop; it emits one `MergeStep::Partition` per distinct present key, reconciled
+/// across generations exactly as the full-scan merge would.
 ///
 /// `paths` must be the same (token-pruned) candidate list, in the same order, the
 /// full-scan path would merge — run index is the position here, so LWW tie-breaks
-/// match. `scan_cancel` is wired onto every opened reader so a client disconnect
-/// abandons an in-flight fail-safe scan promptly (#2264).
+/// match. `keys` are raw partition-key bytes (as `PartitionKey::to_bytes`
+/// produces). `scan_cancel` is wired onto every opened reader so a client
+/// disconnect abandons an in-flight fail-safe scan promptly (#2264).
 pub fn build_single_partition_merger(
     paths: Vec<PathBuf>,
-    partition_key: &[u8],
+    keys: &[Vec<u8>],
     schema: &TableSchema,
     scan_cancel: ScanCancel,
 ) -> Result<Option<KWayMerger>> {
     schema.validate_dropped_columns()?;
+    if keys.is_empty() {
+        return Ok(None);
+    }
+    let key_set: std::collections::HashSet<Vec<u8>> = keys.iter().cloned().collect();
 
     let mut runs: Vec<Box<dyn SSTableRowIterator>> = Vec::new();
     for (run_index, path) in paths.iter().enumerate() {
@@ -93,15 +113,12 @@ pub fn build_single_partition_merger(
         // seek/open, so a disconnected point read does no further per-SSTable work.
         scan_cancel.check()?;
 
-        let outcome = probe_single_partition(path, partition_key, schema, scan_cancel.clone())?;
-        match outcome {
-            SinglePartitionCompaction::DefinitelyAbsent => {
-                // Pruned by the presence oracle (already counted). No run.
+        match probe_path(path, keys, schema, scan_cancel.clone())? {
+            PathProbe::Empty => {
+                // Pruned / absent for every key. No run.
             }
-            SinglePartitionCompaction::Rows(rows) => {
+            PathProbe::Seeked(rows) => {
                 if rows.is_empty() {
-                    // Authoritative empty (prefix-collision for an absent key): the
-                    // partition is not in this SSTable. No run.
                     continue;
                 }
                 let mut entries = VecDeque::with_capacity(rows.len());
@@ -112,14 +129,19 @@ pub fn build_single_partition_merger(
                 }
                 runs.push(Box::new(VecRun { entries }));
             }
-            SinglePartitionCompaction::IndexUnavailable => {
+            PathProbe::NeedsScan => {
                 // Fail-safe: scan this ONE SSTable, forwarding only the target
-                // partition. The missing index costs speed, never correctness.
-                let adapter =
-                    SSTableRowIteratorAdapter::open(path, run_index, schema, None, scan_cancel.clone())?;
+                // partitions. The missing index costs speed, never correctness.
+                let adapter = SSTableRowIteratorAdapter::open(
+                    path,
+                    run_index,
+                    schema,
+                    None,
+                    scan_cancel.clone(),
+                )?;
                 runs.push(Box::new(SinglePartitionFilterRun {
                     inner: adapter,
-                    key: partition_key.to_vec(),
+                    keys: key_set.clone(),
                 }));
             }
         }
@@ -131,20 +153,26 @@ pub fn build_single_partition_merger(
     Ok(Some(KWayMerger::from_row_iterators(runs, schema)?))
 }
 
-/// Open `path` and probe it for `partition_key` via the core seek primitive.
+/// Open `path` ONCE and probe it for every requested key via the core seek
+/// primitive, combining the outcome.
+///
+/// A single SSTable's index availability is a property of the SSTable (not the
+/// key), so the FIRST `IndexUnavailable` short-circuits to [`PathProbe::NeedsScan`]
+/// (scan the whole file, filtered). Otherwise every present key's seeked rows are
+/// concatenated (they share this SSTable's generation / run index).
 ///
 /// Runs the async open + seek on the shared bridge runtime. The reader is opened
 /// with buffered I/O (never mmap/direct — the file may be deleted after the read)
 /// and the cooperative cancel token wired in, matching the full-scan producer.
-fn probe_single_partition(
+fn probe_path(
     path: &Path,
-    partition_key: &[u8],
+    keys: &[Vec<u8>],
     schema: &TableSchema,
     scan_cancel: ScanCancel,
-) -> Result<SinglePartitionCompaction> {
+) -> Result<PathProbe> {
     let path = path.to_path_buf();
     let schema = schema.clone();
-    let key = partition_key.to_vec();
+    let keys: Vec<Vec<u8>> = keys.to_vec();
     block_on_async(async move {
         let mut config = Config::default();
         config.storage.use_mmap = false;
@@ -152,8 +180,26 @@ fn probe_single_partition(
         let platform = Arc::new(Platform::new(&config).await?);
         let mut reader = SSTableReader::open(&path, &config, platform).await?;
         reader.set_scan_cancel(scan_cancel);
-        reader
-            .read_single_partition_for_compaction(&key, Some(&schema))
-            .await
+
+        let mut rows: Vec<CompactionRow> = Vec::new();
+        for key in &keys {
+            match reader
+                .read_single_partition_for_compaction(key, Some(&schema))
+                .await?
+            {
+                SinglePartitionCompaction::DefinitelyAbsent => {}
+                SinglePartitionCompaction::Rows(mut r) => rows.append(&mut r),
+                // Index availability is per-SSTable, not per-key: fall back to
+                // scanning the whole file once, filtered to the key set.
+                SinglePartitionCompaction::IndexUnavailable => {
+                    return Ok(PathProbe::NeedsScan);
+                }
+            }
+        }
+        if rows.is_empty() {
+            Ok(PathProbe::Empty)
+        } else {
+            Ok(PathProbe::Seeked(rows))
+        }
     })
 }

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -18,21 +18,75 @@
 //! `paths` list, identical to the full-scan merger, so reconciliation ties break
 //! the same way.
 
-use super::{block_on_async, KWayMerger, MergeEntry, SSTableRowIterator, SSTableRowIteratorAdapter};
-use crate::config::DiskAccessMode;
-use crate::platform::Platform;
+use super::{KWayMerger, MergeEntry, RunReader, SSTableRowIterator, SSTableRowIteratorAdapter};
 use crate::schema::TableSchema;
-use crate::storage::sstable::reader::{
-    CompactionRow, SSTableReader, SinglePartitionCompaction,
-};
 use crate::storage::scan_cancel::ScanCancel;
-use crate::{Config, Result};
-use std::collections::VecDeque;
+use crate::storage::sstable::reader::CompactionRow;
+use crate::{Error, Result};
+use std::collections::{BinaryHeap, VecDeque};
 use std::path::{Path, PathBuf};
+
+// Seek-only imports (the point-read primitive is `not(tombstones)` gated, like the
+// underlying single-partition seek machinery it composes).
+#[cfg(not(feature = "tombstones"))]
+use super::block_on_async;
+#[cfg(not(feature = "tombstones"))]
+use crate::config::DiskAccessMode;
+#[cfg(not(feature = "tombstones"))]
+use crate::platform::Platform;
+#[cfg(not(feature = "tombstones"))]
+use crate::storage::sstable::reader::{SSTableReader, SinglePartitionCompaction};
+#[cfg(not(feature = "tombstones"))]
+use crate::Config;
+#[cfg(not(feature = "tombstones"))]
 use std::sync::Arc;
+
+impl KWayMerger {
+    /// Build a k-way merger from pre-constructed run iterators (issue #2207).
+    ///
+    /// Unlike [`KWayMerger::new`], which opens each input SSTable and streams its
+    /// WHOLE compaction scan, this accepts runs the caller has already scoped —
+    /// the single-partition point-read path hands one run per candidate SSTable,
+    /// each yielding ONLY the target partition's entries (a seeked `Vec` or a
+    /// key-filtered stream). The reconciliation, heap, and per-partition merge are
+    /// IDENTICAL to the full-scan path — only the inputs are narrower — so the
+    /// point path reconciles byte-identically to the scan.
+    ///
+    /// `runs` must be non-empty and ordered newest-to-oldest (run index = LWW
+    /// tie-break rank), exactly as [`KWayMerger::new`]'s `input_paths` are.
+    pub fn from_row_iterators(
+        runs: Vec<Box<dyn SSTableRowIterator>>,
+        schema: &TableSchema,
+    ) -> Result<Self> {
+        if runs.is_empty() {
+            return Err(Error::InvalidInput(
+                "K-way merge requires at least one input run".to_string(),
+            ));
+        }
+        schema.validate_dropped_columns()?;
+        // Child modules see the parent's private fields; build the merger in the
+        // same shape as `new_with_gc_and_registry_cancellable` (no purge params —
+        // the point path never compacts).
+        let runs = runs.into_iter().map(RunReader::new).collect();
+        Ok(Self {
+            runs,
+            heap: BinaryHeap::new(),
+            current_partition: None,
+            schema: schema.clone(),
+            gc_before_secs: None,
+            now_secs: None,
+            purge_safe: false,
+            max_purgeable_timestamp: None,
+        })
+    }
+}
 
 /// A run backed by a pre-built `Vec` of merge entries — the seeked single
 /// partition. Yields each entry once, in order, then reports exhaustion.
+///
+/// Only the default `not(tombstones)` build seeks (the alternate build always
+/// scan-falls-back), so this is dead there.
+#[cfg_attr(feature = "tombstones", allow(dead_code))]
 struct VecRun {
     entries: VecDeque<MergeEntry>,
 }
@@ -70,7 +124,10 @@ impl SSTableRowIterator for SinglePartitionFilterRun {
     }
 }
 
-/// Per-candidate probe outcome across ALL requested keys.
+/// Per-candidate probe outcome across ALL requested keys. `Seeked`/`Empty` are
+/// produced only by the default `not(tombstones)` seek path (the alternate build
+/// always returns `NeedsScan`), so they are dead under `tombstones`.
+#[cfg_attr(feature = "tombstones", allow(dead_code))]
 enum PathProbe {
     /// No requested key is present in this SSTable (all definite-absent / empty).
     Empty,
@@ -154,7 +211,7 @@ pub fn build_single_partition_merger(
 }
 
 /// Open `path` ONCE and probe it for every requested key via the core seek
-/// primitive, combining the outcome.
+/// primitive, combining the outcome (default `not(tombstones)` build).
 ///
 /// A single SSTable's index availability is a property of the SSTable (not the
 /// key), so the FIRST `IndexUnavailable` short-circuits to [`PathProbe::NeedsScan`]
@@ -164,6 +221,7 @@ pub fn build_single_partition_merger(
 /// Runs the async open + seek on the shared bridge runtime. The reader is opened
 /// with buffered I/O (never mmap/direct — the file may be deleted after the read)
 /// and the cooperative cancel token wired in, matching the full-scan producer.
+#[cfg(not(feature = "tombstones"))]
 fn probe_path(
     path: &Path,
     keys: &[Vec<u8>],
@@ -202,4 +260,19 @@ fn probe_path(
             Ok(PathProbe::Seeked(rows))
         }
     })
+}
+
+/// Tombstones-build fallback: the single-partition SEEK machinery
+/// (`successor_partition_offset`, `point_read_whole_section`, …) is
+/// `not(tombstones)` only, so under the alternate `tombstones` feature every
+/// candidate degrades to a full scan filtered to the key set — correct, just
+/// without the seek speedup. Keeps the public builder API identical across builds.
+#[cfg(feature = "tombstones")]
+fn probe_path(
+    _path: &Path,
+    _keys: &[Vec<u8>],
+    _schema: &TableSchema,
+    _scan_cancel: ScanCancel,
+) -> Result<PathProbe> {
+    Ok(PathProbe::NeedsScan)
 }

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -1,0 +1,159 @@
+//! Single-partition point-read merge assembly (issue #2207, Stage 1/2 core side).
+//!
+//! Builds a [`KWayMerger`] over ONE run per candidate SSTable, each yielding only
+//! the target partition's entries, so the Flight `do_get` point path reconciles
+//! through the SAME merge as the full scan — byte-identically, only over fewer
+//! partitions (design candidate (c)).
+//!
+//! Per candidate the core primitive
+//! [`SSTableReader::read_single_partition_for_compaction`] decides:
+//! - `DefinitelyAbsent` → the candidate is pruned (the presence oracle already
+//!   incremented `cqlite.read.sstables_pruned`); no run is built.
+//! - `Rows(rows)` → a seeked run yielding exactly those compaction rows.
+//! - `IndexUnavailable` → a fail-safe run that scans this ONE SSTable's whole
+//!   compaction stream and forwards only the target partition's entries — never
+//!   skipping a candidate that might hold the key (#2295 Data.db-only shape).
+//!
+//! Run index (LWW tie-break rank) is the candidate's position in the input
+//! `paths` list, identical to the full-scan merger, so reconciliation ties break
+//! the same way.
+
+use super::{block_on_async, KWayMerger, MergeEntry, SSTableRowIterator, SSTableRowIteratorAdapter};
+use crate::config::DiskAccessMode;
+use crate::platform::Platform;
+use crate::schema::TableSchema;
+use crate::storage::sstable::reader::{SSTableReader, SinglePartitionCompaction};
+use crate::storage::scan_cancel::ScanCancel;
+use crate::{Config, Result};
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// A run backed by a pre-built `Vec` of merge entries — the seeked single
+/// partition. Yields each entry once, in order, then reports exhaustion.
+struct VecRun {
+    entries: VecDeque<MergeEntry>,
+}
+
+impl SSTableRowIterator for VecRun {
+    fn next(&mut self) -> Option<Result<MergeEntry>> {
+        self.entries.pop_front().map(Ok)
+    }
+}
+
+/// A run that forwards ONLY the target partition's entries from an SSTable's full
+/// compaction stream — the index-unavailable fail-safe. Byte-identical to the
+/// full scan's contribution for this partition (same stream, same decode), just
+/// with the other partitions dropped before the merge sees them.
+struct SinglePartitionFilterRun {
+    inner: SSTableRowIteratorAdapter,
+    key: Vec<u8>,
+}
+
+impl SSTableRowIterator for SinglePartitionFilterRun {
+    fn next(&mut self) -> Option<Result<MergeEntry>> {
+        loop {
+            match self.inner.next() {
+                Some(Ok(entry)) => {
+                    if entry.key.key == self.key {
+                        return Some(Ok(entry));
+                    }
+                    // A non-target partition: drop it and pull the next entry.
+                }
+                // An error or exhaustion propagates unchanged (a cancelled scan
+                // stays a distinct `Error::Cancelled`, issue #2264).
+                other => return other,
+            }
+        }
+    }
+}
+
+/// Assemble a [`KWayMerger`] that reads ONLY `partition_key` across the candidate
+/// `paths` (issue #2207).
+///
+/// Returns `Ok(None)` when every candidate is a definite presence-oracle negative
+/// (no SSTable holds the key) — the caller streams zero rows. Otherwise returns a
+/// merger the caller drives through its existing reconciliation loop.
+///
+/// `paths` must be the same (token-pruned) candidate list, in the same order, the
+/// full-scan path would merge — run index is the position here, so LWW tie-breaks
+/// match. `scan_cancel` is wired onto every opened reader so a client disconnect
+/// abandons an in-flight fail-safe scan promptly (#2264).
+pub fn build_single_partition_merger(
+    paths: Vec<PathBuf>,
+    partition_key: &[u8],
+    schema: &TableSchema,
+    scan_cancel: ScanCancel,
+) -> Result<Option<KWayMerger>> {
+    schema.validate_dropped_columns()?;
+
+    let mut runs: Vec<Box<dyn SSTableRowIterator>> = Vec::new();
+    for (run_index, path) in paths.iter().enumerate() {
+        // Cooperative cancellation (#2264): honour a cancel BEFORE each candidate's
+        // seek/open, so a disconnected point read does no further per-SSTable work.
+        scan_cancel.check()?;
+
+        let outcome = probe_single_partition(path, partition_key, schema, scan_cancel.clone())?;
+        match outcome {
+            SinglePartitionCompaction::DefinitelyAbsent => {
+                // Pruned by the presence oracle (already counted). No run.
+            }
+            SinglePartitionCompaction::Rows(rows) => {
+                if rows.is_empty() {
+                    // Authoritative empty (prefix-collision for an absent key): the
+                    // partition is not in this SSTable. No run.
+                    continue;
+                }
+                let mut entries = VecDeque::with_capacity(rows.len());
+                for row in rows {
+                    entries.push_back(SSTableRowIteratorAdapter::build_merge_entry(
+                        run_index, row, schema,
+                    )?);
+                }
+                runs.push(Box::new(VecRun { entries }));
+            }
+            SinglePartitionCompaction::IndexUnavailable => {
+                // Fail-safe: scan this ONE SSTable, forwarding only the target
+                // partition. The missing index costs speed, never correctness.
+                let adapter =
+                    SSTableRowIteratorAdapter::open(path, run_index, schema, None, scan_cancel.clone())?;
+                runs.push(Box::new(SinglePartitionFilterRun {
+                    inner: adapter,
+                    key: partition_key.to_vec(),
+                }));
+            }
+        }
+    }
+
+    if runs.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(KWayMerger::from_row_iterators(runs, schema)?))
+}
+
+/// Open `path` and probe it for `partition_key` via the core seek primitive.
+///
+/// Runs the async open + seek on the shared bridge runtime. The reader is opened
+/// with buffered I/O (never mmap/direct — the file may be deleted after the read)
+/// and the cooperative cancel token wired in, matching the full-scan producer.
+fn probe_single_partition(
+    path: &Path,
+    partition_key: &[u8],
+    schema: &TableSchema,
+    scan_cancel: ScanCancel,
+) -> Result<SinglePartitionCompaction> {
+    let path = path.to_path_buf();
+    let schema = schema.clone();
+    let key = partition_key.to_vec();
+    block_on_async(async move {
+        let mut config = Config::default();
+        config.storage.use_mmap = false;
+        config.storage.disk_access_mode = DiskAccessMode::Buffered;
+        let platform = Arc::new(Platform::new(&config).await?);
+        let mut reader = SSTableReader::open(&path, &config, platform).await?;
+        reader.set_scan_cancel(scan_cancel);
+        reader
+            .read_single_partition_for_compaction(&key, Some(&schema))
+            .await
+    })
+}

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -43,9 +43,9 @@ pub mod wal;
 pub use export::{ExportOptions, ExportReport};
 #[cfg(feature = "write-support")]
 pub use memtable::Memtable;
+pub use merge::build_single_partition_merger;
 #[cfg(feature = "write-support")]
 pub use merge::KWayMerger;
-pub use merge::build_single_partition_merger;
 #[cfg(feature = "write-support")]
 pub use merge_policy::STCSPolicy;
 #[cfg(feature = "write-support")]

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -45,6 +45,7 @@ pub use export::{ExportOptions, ExportReport};
 pub use memtable::Memtable;
 #[cfg(feature = "write-support")]
 pub use merge::KWayMerger;
+pub use merge::build_single_partition_merger;
 #[cfg(feature = "write-support")]
 pub use merge_policy::STCSPolicy;
 #[cfg(feature = "write-support")]

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -43,6 +43,7 @@ pub mod wal;
 pub use export::{ExportOptions, ExportReport};
 #[cfg(feature = "write-support")]
 pub use memtable::Memtable;
+#[cfg(feature = "write-support")]
 pub use merge::build_single_partition_merger;
 #[cfg(feature = "write-support")]
 pub use merge::KWayMerger;

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cancel;
 pub mod filter;
 pub mod obs;
 pub mod pathsafe;
+pub mod point_read;
 pub mod producer;
 pub mod scan_progress;
 pub mod service;

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -15,6 +15,7 @@ pub mod obs;
 pub mod pathsafe;
 pub mod point_read;
 pub mod producer;
+mod producer_point;
 pub mod scan_progress;
 pub mod service;
 pub mod shutdown;

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -39,6 +39,12 @@ pub mod ticket;
 #[cfg(test)]
 mod testutil;
 
+// Point-read behavioral tests (issue #2207): work-done probe, dual-path parity,
+// index-less fail-safe, cancellation, LIMIT. In-crate so they can use the
+// `testutil` fixture builders + the pub(crate) streaming seam.
+#[cfg(test)]
+mod point_read_tests;
+
 // Issue #2162 OTel-level assertions (phase histograms, bounded attributes,
 // rpc.rows presence via the shared `observability-testing` capture harness) live
 // in `tests/metrics_capture_test.rs` — a SEPARATE integration-test binary/process

--- a/cqlite-flight/src/point_read.rs
+++ b/cqlite-flight/src/point_read.rs
@@ -1,0 +1,206 @@
+//! Partition point-read route detection (issue #2207, Stage 0).
+//!
+//! Decides, ONCE per ticket, whether a pushed predicate binds **every**
+//! partition-key component to a single value — a full-PK equality (or an
+//! `IN`/`Or` list of such equalities). Only such shapes route `do_get` to the
+//! partition point-read path; anything else keeps the unchanged full-scan +
+//! per-row filter path.
+//!
+//! The decision is derived from the typed predicate tree ([`FilterExpr`]) and
+//! the table schema's partition-key definition ALONE — never from byte patterns
+//! or any non-authoritative heuristic (no-heuristics mandate, issue #28). The
+//! analyzer is TOTAL: any shape it cannot prove is a full-PK equality falls
+//! through to [`PointReadRoute::Scan`].
+
+use crate::filter::FilterExpr;
+use cqlite_core::query::{SSTableFilterOp, SSTablePredicate};
+use cqlite_core::schema::TableSchema;
+use cqlite_core::types::Value;
+
+/// The routing decision computed from a ticket's lowered filter + schema.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PointReadRoute {
+    /// Every partition-key component is bound to a single value (full-PK
+    /// equality). The `Vec<Value>` holds the bound values in partition-key
+    /// **schema order**, ready for `PartitionKey { columns }.to_bytes(schema)`.
+    PartitionPointRead(Vec<Value>),
+    /// A bounded set of full-PK equalities (`WHERE pk IN (...)` over the full PK,
+    /// or an `Or` of full-PK equalities) — treated as N point reads. Each inner
+    /// `Vec<Value>` is one key's component values in partition-key schema order.
+    MultiPartitionPointRead(Vec<Vec<Value>>),
+    /// Anything else — partial PK, clustering-only, range, secondary column,
+    /// `IS NULL`, `Not`, mixed `Or`, or no predicate. Keeps the full-scan path.
+    Scan,
+}
+
+/// Compute the point-read route from a lowered filter tree and the schema.
+///
+/// Returns [`PointReadRoute::Scan`] for every shape that is not provably a
+/// full-PK equality (or an `IN`/`Or` list of them). Non-partition-key conjuncts
+/// (e.g. `AND col = ?`) do NOT block a point route — they remain a residual
+/// per-row filter that narrows, never widens, the result.
+pub fn detect_route(filter: Option<&FilterExpr>, schema: &TableSchema) -> PointReadRoute {
+    let pk_cols: Vec<&str> = schema
+        .partition_keys
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    if pk_cols.is_empty() {
+        return PointReadRoute::Scan;
+    }
+    let Some(filter) = filter else {
+        return PointReadRoute::Scan;
+    };
+
+    // 1. A conjunction (or single leaf) that binds every PK component by equality.
+    if let Some(values) = full_pk_equality(filter, &pk_cols) {
+        return PointReadRoute::PartitionPointRead(values);
+    }
+
+    // 2. `IN` over a single-component partition key → N single-key lookups.
+    //    (A composite-PK `IN` is a cartesian expansion we deliberately do not
+    //    take here; it falls through to Scan.)
+    if pk_cols.len() == 1 {
+        if let Some(keys) = single_pk_in_list(filter, pk_cols[0]) {
+            return PointReadRoute::MultiPartitionPointRead(keys);
+        }
+    }
+
+    // 3. An `Or` whose every disjunct is itself a full-PK equality.
+    if let FilterExpr::Or(disjuncts) = filter {
+        if let Some(keys) = or_of_full_pk_equalities(disjuncts, &pk_cols) {
+            return PointReadRoute::MultiPartitionPointRead(keys);
+        }
+    }
+
+    PointReadRoute::Scan
+}
+
+/// Return the PK component values (in schema order) iff `filter` is a
+/// conjunction of leaves that bind EVERY partition-key column by a single
+/// equality, with no other (dis-qualifying) constraint on any PK column.
+fn full_pk_equality(filter: &FilterExpr, pk_cols: &[&str]) -> Option<Vec<Value>> {
+    let mut bindings: Vec<Option<Value>> = vec![None; pk_cols.len()];
+    if !collect_pk_equalities(filter, pk_cols, &mut bindings) {
+        return None;
+    }
+    // Every component must be bound exactly once.
+    bindings.into_iter().collect::<Option<Vec<Value>>>()
+}
+
+/// Walk a conjunction, recording PK-column equality bindings. Returns `false`
+/// (disqualifying the point route) if ANY partition-key column is constrained by
+/// something other than a single top-level `=` conjunct (a range/`IN`, an
+/// `IsNull`, an appearance under `Or`/`Not`, or a conflicting second binding).
+///
+/// Non-partition-key nodes are ignored for routing (they remain a residual
+/// per-row filter), so `pk = ? AND col > ?` still routes on the PK equality.
+fn collect_pk_equalities(
+    expr: &FilterExpr,
+    pk_cols: &[&str],
+    bindings: &mut [Option<Value>],
+) -> bool {
+    match expr {
+        FilterExpr::And(children) => children
+            .iter()
+            .all(|c| collect_pk_equalities(c, pk_cols, bindings)),
+        FilterExpr::Leaf(pred) => {
+            match pk_component_index(pred, pk_cols) {
+                // A leaf on a non-PK column is an ignorable residual.
+                None => !mentions_pk_predicate(pred, pk_cols),
+                Some(idx) => {
+                    // A PK-column leaf must be a plain single-value equality.
+                    if !is_single_equality(pred) {
+                        return false;
+                    }
+                    let value = pred.values[0].clone();
+                    match &bindings[idx] {
+                        // Conflicting second binding for the same component.
+                        Some(existing) if existing != &value => false,
+                        _ => {
+                            bindings[idx] = Some(value);
+                            true
+                        }
+                    }
+                }
+            }
+        }
+        // Any Or/Not/IsNull that touches a PK column disqualifies the point route;
+        // one that is purely over non-PK columns is an ignorable residual.
+        FilterExpr::Or(_) | FilterExpr::Not(_) | FilterExpr::IsNull(_) => {
+            !mentions_pk_expr(expr, pk_cols)
+        }
+    }
+}
+
+/// Return the bound-value lists for `pk IN (v1, v2, ...)` iff `filter` is exactly
+/// that single-column `IN` leaf on the sole partition-key column (with no other
+/// constraint). Each returned key is a one-element `Vec<Value>`.
+fn single_pk_in_list(filter: &FilterExpr, pk_col: &str) -> Option<Vec<Vec<Value>>> {
+    let FilterExpr::Leaf(pred) = filter else {
+        return None;
+    };
+    if pred.token_columns.is_some()
+        || pred.column != pk_col
+        || !matches!(pred.operation, SSTableFilterOp::In)
+        || pred.values.is_empty()
+    {
+        return None;
+    }
+    Some(pred.values.iter().cloned().map(|v| vec![v]).collect())
+}
+
+/// Return one full-PK key per disjunct iff EVERY disjunct of an `Or` is itself a
+/// full-PK equality (e.g. `(a=1 AND b=2) OR (a=3 AND b=4)`).
+fn or_of_full_pk_equalities(
+    disjuncts: &[FilterExpr],
+    pk_cols: &[&str],
+) -> Option<Vec<Vec<Value>>> {
+    if disjuncts.is_empty() {
+        return None;
+    }
+    disjuncts
+        .iter()
+        .map(|d| full_pk_equality(d, pk_cols))
+        .collect()
+}
+
+/// The partition-key component index a predicate constrains, or `None` when it is
+/// not a (non-token) partition-key column predicate.
+fn pk_component_index(pred: &SSTablePredicate, pk_cols: &[&str]) -> Option<usize> {
+    if pred.token_columns.is_some() {
+        return None;
+    }
+    pk_cols.iter().position(|c| *c == pred.column)
+}
+
+/// A plain single-value `=` on a stored column (not a token predicate).
+fn is_single_equality(pred: &SSTablePredicate) -> bool {
+    pred.token_columns.is_none()
+        && matches!(pred.operation, SSTableFilterOp::Equal)
+        && pred.values.len() == 1
+}
+
+/// Whether a predicate references a partition-key column (via its column name or
+/// its `token_columns` set).
+fn mentions_pk_predicate(pred: &SSTablePredicate, pk_cols: &[&str]) -> bool {
+    if pk_cols.contains(&pred.column.as_str()) {
+        return true;
+    }
+    match &pred.token_columns {
+        Some(cols) => cols.iter().any(|c| pk_cols.contains(&c.as_str())),
+        None => false,
+    }
+}
+
+/// Whether any leaf/`IsNull` anywhere in `expr` references a partition-key column.
+fn mentions_pk_expr(expr: &FilterExpr, pk_cols: &[&str]) -> bool {
+    match expr {
+        FilterExpr::And(children) | FilterExpr::Or(children) => {
+            children.iter().any(|c| mentions_pk_expr(c, pk_cols))
+        }
+        FilterExpr::Not(inner) => mentions_pk_expr(inner, pk_cols),
+        FilterExpr::Leaf(pred) => mentions_pk_predicate(pred, pk_cols),
+        FilterExpr::IsNull(column) => pk_cols.contains(&column.as_str()),
+    }
+}

--- a/cqlite-flight/src/point_read.rs
+++ b/cqlite-flight/src/point_read.rs
@@ -96,11 +96,17 @@ pub fn detect_route(filter: Option<&FilterExpr>, schema: &TableSchema) -> PointR
             // distinct-key count is within the cap (the merger dedups too).
             capped_multi_point_read(dedup_keys(keys))
         }
-        // No multi-group: a plain full-PK equality routes; a partial (or empty)
-        // PK binding cannot point-read.
+        // No multi-group: route a plain full-PK equality ONLY when EVERY
+        // partition-key component was actually bound by an `=` conjunct. A
+        // residual-only filter (or any shape that binds no PK column) leaves slots
+        // `None`; the `collect` short-circuits to `None` → Scan. The explicit
+        // `!values.is_empty()` guard is belt-and-suspenders for the routing-API
+        // contract (roborev job 1616): `detect_route` must NEVER hand the producer
+        // an empty/partial `PartitionPointRead` it has to paper over — a
+        // no-real-binding filter always routes Scan.
         None => match acc.bindings.into_iter().collect::<Option<Vec<Value>>>() {
-            Some(values) => PointReadRoute::PartitionPointRead(values),
-            None => PointReadRoute::Scan,
+            Some(values) if !values.is_empty() => PointReadRoute::PartitionPointRead(values),
+            _ => PointReadRoute::Scan,
         },
     }
 }

--- a/cqlite-flight/src/point_read.rs
+++ b/cqlite-flight/src/point_read.rs
@@ -17,6 +17,18 @@ use cqlite_core::query::{SSTableFilterOp, SSTablePredicate};
 use cqlite_core::schema::TableSchema;
 use cqlite_core::types::Value;
 
+/// Maximum number of keys a full-PK `IN` list / `Or`-of-equalities may route as
+/// [`PointReadRoute::MultiPartitionPointRead`] (design.md open question 2, fixed
+/// named cap per the design's recommendation). Above this bound, N separate
+/// per-SSTable seeks (each paying its own presence-oracle + index-descent cost)
+/// stop being cheaper than one full k-way scan with a per-row `IN` filter, so
+/// the route falls back to [`PointReadRoute::Scan`] instead — never a wrong
+/// answer, just the faster path for a very large list. Chosen generously (a
+/// typical pushed `IN` list is single/low-double-digit; Cassandra's own CQL
+/// driver default page/batch sizes sit well under this) so ordinary `IN`
+/// pushdowns are unaffected.
+const MAX_MULTI_PARTITION_POINT_READ_KEYS: usize = 64;
+
 /// The routing decision computed from a ticket's lowered filter + schema.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PointReadRoute {
@@ -62,18 +74,28 @@ pub fn detect_route(filter: Option<&FilterExpr>, schema: &TableSchema) -> PointR
     //    take here; it falls through to Scan.)
     if pk_cols.len() == 1 {
         if let Some(keys) = single_pk_in_list(filter, pk_cols[0]) {
-            return PointReadRoute::MultiPartitionPointRead(keys);
+            return capped_multi_point_read(keys);
         }
     }
 
     // 3. An `Or` whose every disjunct is itself a full-PK equality.
     if let FilterExpr::Or(disjuncts) = filter {
         if let Some(keys) = or_of_full_pk_equalities(disjuncts, &pk_cols) {
-            return PointReadRoute::MultiPartitionPointRead(keys);
+            return capped_multi_point_read(keys);
         }
     }
 
     PointReadRoute::Scan
+}
+
+/// Route `keys` as [`PointReadRoute::MultiPartitionPointRead`], or fall back to
+/// [`PointReadRoute::Scan`] when the list exceeds
+/// [`MAX_MULTI_PARTITION_POINT_READ_KEYS`] (design.md open question 2).
+fn capped_multi_point_read(keys: Vec<Vec<Value>>) -> PointReadRoute {
+    if keys.len() > MAX_MULTI_PARTITION_POINT_READ_KEYS {
+        return PointReadRoute::Scan;
+    }
+    PointReadRoute::MultiPartitionPointRead(keys)
 }
 
 /// Return the PK component values (in schema order) iff `filter` is a

--- a/cqlite-flight/src/point_read.rs
+++ b/cqlite-flight/src/point_read.rs
@@ -152,10 +152,7 @@ fn single_pk_in_list(filter: &FilterExpr, pk_col: &str) -> Option<Vec<Vec<Value>
 
 /// Return one full-PK key per disjunct iff EVERY disjunct of an `Or` is itself a
 /// full-PK equality (e.g. `(a=1 AND b=2) OR (a=3 AND b=4)`).
-fn or_of_full_pk_equalities(
-    disjuncts: &[FilterExpr],
-    pk_cols: &[&str],
-) -> Option<Vec<Vec<Value>>> {
+fn or_of_full_pk_equalities(disjuncts: &[FilterExpr], pk_cols: &[&str]) -> Option<Vec<Vec<Value>>> {
     if disjuncts.is_empty() {
         return None;
     }

--- a/cqlite-flight/src/point_read.rs
+++ b/cqlite-flight/src/point_read.rs
@@ -51,6 +51,19 @@ pub enum PointReadRoute {
 /// full-PK equality (or an `IN`/`Or` list of them). Non-partition-key conjuncts
 /// (e.g. `AND col = ?`) do NOT block a point route — they remain a residual
 /// per-row filter that narrows, never widens, the result.
+///
+/// The analyzer recurses through `And` conjuncts: a point-read *key-group* (a
+/// full-PK equality, a single-component full-PK `IN`, or an `Or` of full-PK
+/// equalities) is extracted from AMONG the conjuncts, and the REMAINING
+/// conjuncts stay a residual per-row filter — the whole original filter is
+/// re-evaluated per row on the point path ([`drive_merge`]'s `filter.keeps`), so
+/// an extracted key-group need only be a SUPERSET of the matching partitions.
+/// At most ONE key-group is extracted: if two different PK key-groups appear
+/// under one `And` (e.g. `pk IN (1,2) AND pk IN (3,4)`), the route conservatively
+/// falls back to [`PointReadRoute::Scan`] rather than intersect them — always a
+/// correct answer via the scan path, never a wrong one.
+///
+/// [`drive_merge`]: crate::producer::MergeProducer::drive_merge
 pub fn detect_route(filter: Option<&FilterExpr>, schema: &TableSchema) -> PointReadRoute {
     let pk_cols: Vec<&str> = schema
         .partition_keys
@@ -64,28 +77,132 @@ pub fn detect_route(filter: Option<&FilterExpr>, schema: &TableSchema) -> PointR
         return PointReadRoute::Scan;
     };
 
-    // 1. A conjunction (or single leaf) that binds every PK component by equality.
-    if let Some(values) = full_pk_equality(filter, &pk_cols) {
-        return PointReadRoute::PartitionPointRead(values);
+    let mut acc = RouteAcc::new(pk_cols.len());
+    if !collect_route(filter, &pk_cols, &mut acc) {
+        return PointReadRoute::Scan;
     }
 
-    // 2. `IN` over a single-component partition key → N single-key lookups.
-    //    (A composite-PK `IN` is a cartesian expansion we deliberately do not
-    //    take here; it falls through to Scan.)
+    match acc.multi_group {
+        // A multi-key group (`IN` / `Or`) fully specifies the PK by itself. Any
+        // additional PK equality binding is a SECOND, different key-group under
+        // the same `And` — conservatively fall back to the (always-correct) scan
+        // path rather than intersect the two groups.
+        Some(keys) => {
+            if acc.bindings.iter().any(Option::is_some) {
+                return PointReadRoute::Scan;
+            }
+            // Dedup the candidate keys BEFORE applying the cap (issue #2207): a
+            // duplicate-heavy `IN` list must not over-fall-back to Scan when its
+            // distinct-key count is within the cap (the merger dedups too).
+            capped_multi_point_read(dedup_keys(keys))
+        }
+        // No multi-group: a plain full-PK equality routes; a partial (or empty)
+        // PK binding cannot point-read.
+        None => match acc.bindings.into_iter().collect::<Option<Vec<Value>>>() {
+            Some(values) => PointReadRoute::PartitionPointRead(values),
+            None => PointReadRoute::Scan,
+        },
+    }
+}
+
+/// Accumulator threaded through the conjunct walk: PK equality bindings (in
+/// schema order) plus at most one extracted multi-key group.
+struct RouteAcc {
+    /// One slot per PK component; `Some` once bound by an `=` conjunct.
+    bindings: Vec<Option<Value>>,
+    /// The single extracted `IN`/`Or` key-group, if any.
+    multi_group: Option<Vec<Vec<Value>>>,
+    /// How many multi-key groups have been seen (>1 disqualifies the route).
+    multi_group_count: usize,
+}
+
+impl RouteAcc {
+    fn new(pk_len: usize) -> Self {
+        RouteAcc {
+            bindings: vec![None; pk_len],
+            multi_group: None,
+            multi_group_count: 0,
+        }
+    }
+
+    /// Record an `=` binding for PK component `idx`. Returns `false` (disqualify)
+    /// on a conflicting second value for the same component.
+    fn bind(&mut self, idx: usize, value: Value) -> bool {
+        match &self.bindings[idx] {
+            Some(existing) if existing != &value => false,
+            _ => {
+                self.bindings[idx] = Some(value);
+                true
+            }
+        }
+    }
+
+    /// Record an extracted multi-key group. Returns `false` (disqualify) if a
+    /// second, different key-group is seen under the same `And`.
+    fn add_multi_group(&mut self, keys: Vec<Vec<Value>>) -> bool {
+        self.multi_group_count += 1;
+        if self.multi_group_count > 1 {
+            return false;
+        }
+        self.multi_group = Some(keys);
+        true
+    }
+}
+
+/// Walk the (possibly nested) conjunction, filling `acc`. Returns `false`
+/// (disqualifying the point route) if ANY partition-key column is constrained by
+/// a shape that is not a single `=` binding or an extractable key-group (a
+/// range, a conflicting binding, a second key-group, an `IsNull`/`Not` on a PK
+/// column, or an `Or` over PK columns that is not a clean full-PK disjunction).
+///
+/// Non-partition-key nodes are ignored for routing — they remain a residual
+/// per-row filter — so `pk = ? AND col > ?` and `pk IN (?) AND col > ?` route.
+fn collect_route(expr: &FilterExpr, pk_cols: &[&str], acc: &mut RouteAcc) -> bool {
+    match expr {
+        FilterExpr::And(children) => children.iter().all(|c| collect_route(c, pk_cols, acc)),
+        FilterExpr::Leaf(pred) => classify_leaf(pred, pk_cols, acc),
+        // An `Or` over PK columns is only routable as a full-PK disjunction key
+        // group; one purely over non-PK columns is an ignorable residual.
+        FilterExpr::Or(disjuncts) => {
+            if !mentions_pk_expr(expr, pk_cols) {
+                return true;
+            }
+            match or_of_full_pk_equalities(disjuncts, pk_cols) {
+                Some(keys) => acc.add_multi_group(keys),
+                None => false,
+            }
+        }
+        // A `Not`/`IsNull` touching a PK column disqualifies; over non-PK columns
+        // it is an ignorable residual.
+        FilterExpr::Not(inner) => !mentions_pk_expr(inner, pk_cols),
+        FilterExpr::IsNull(column) => !pk_cols.contains(&column.as_str()),
+    }
+}
+
+/// Classify a single leaf conjunct into `acc`. A single-component full-PK `IN`
+/// becomes a multi-key group; a PK-column `=` becomes a binding; a non-PK leaf
+/// is an ignorable residual; anything else on a PK column disqualifies.
+fn classify_leaf(pred: &SSTablePredicate, pk_cols: &[&str], acc: &mut RouteAcc) -> bool {
+    // A single-component partition key bound by `IN` → N single-key lookups.
+    // (A composite-PK `IN` is a cartesian expansion we deliberately do not take;
+    // it falls through to the PK-column check below and disqualifies.)
     if pk_cols.len() == 1 {
-        if let Some(keys) = single_pk_in_list(filter, pk_cols[0]) {
-            return capped_multi_point_read(keys);
+        if let Some(keys) = sole_pk_in_leaf(pred, pk_cols[0]) {
+            return acc.add_multi_group(keys);
         }
     }
-
-    // 3. An `Or` whose every disjunct is itself a full-PK equality.
-    if let FilterExpr::Or(disjuncts) = filter {
-        if let Some(keys) = or_of_full_pk_equalities(disjuncts, &pk_cols) {
-            return capped_multi_point_read(keys);
+    match pk_component_index(pred, pk_cols) {
+        // A leaf on a non-PK column is an ignorable residual — unless it is a
+        // token predicate that references a PK column, which disqualifies.
+        None => !mentions_pk_predicate(pred, pk_cols),
+        Some(idx) => {
+            // A PK-column leaf must be a plain single-value equality.
+            if !is_single_equality(pred) {
+                return false;
+            }
+            acc.bind(idx, pred.values[0].clone())
         }
     }
-
-    PointReadRoute::Scan
 }
 
 /// Route `keys` as [`PointReadRoute::MultiPartitionPointRead`], or fall back to
@@ -98,70 +215,39 @@ fn capped_multi_point_read(keys: Vec<Vec<Value>>) -> PointReadRoute {
     PointReadRoute::MultiPartitionPointRead(keys)
 }
 
+/// Order-preserving dedup of candidate keys. `Value` is only `PartialEq` (it may
+/// hold floats), so a hash-set is unavailable; the list is bounded by the cap
+/// check that follows, so the linear scan is cheap.
+fn dedup_keys(keys: Vec<Vec<Value>>) -> Vec<Vec<Value>> {
+    let mut out: Vec<Vec<Value>> = Vec::with_capacity(keys.len());
+    for k in keys {
+        if !out.contains(&k) {
+            out.push(k);
+        }
+    }
+    out
+}
+
 /// Return the PK component values (in schema order) iff `filter` is a
 /// conjunction of leaves that bind EVERY partition-key column by a single
 /// equality, with no other (dis-qualifying) constraint on any PK column.
 fn full_pk_equality(filter: &FilterExpr, pk_cols: &[&str]) -> Option<Vec<Value>> {
-    let mut bindings: Vec<Option<Value>> = vec![None; pk_cols.len()];
-    if !collect_pk_equalities(filter, pk_cols, &mut bindings) {
+    let mut acc = RouteAcc::new(pk_cols.len());
+    if !collect_route(filter, pk_cols, &mut acc) {
         return None;
     }
-    // Every component must be bound exactly once.
-    bindings.into_iter().collect::<Option<Vec<Value>>>()
-}
-
-/// Walk a conjunction, recording PK-column equality bindings. Returns `false`
-/// (disqualifying the point route) if ANY partition-key column is constrained by
-/// something other than a single top-level `=` conjunct (a range/`IN`, an
-/// `IsNull`, an appearance under `Or`/`Not`, or a conflicting second binding).
-///
-/// Non-partition-key nodes are ignored for routing (they remain a residual
-/// per-row filter), so `pk = ? AND col > ?` still routes on the PK equality.
-fn collect_pk_equalities(
-    expr: &FilterExpr,
-    pk_cols: &[&str],
-    bindings: &mut [Option<Value>],
-) -> bool {
-    match expr {
-        FilterExpr::And(children) => children
-            .iter()
-            .all(|c| collect_pk_equalities(c, pk_cols, bindings)),
-        FilterExpr::Leaf(pred) => {
-            match pk_component_index(pred, pk_cols) {
-                // A leaf on a non-PK column is an ignorable residual.
-                None => !mentions_pk_predicate(pred, pk_cols),
-                Some(idx) => {
-                    // A PK-column leaf must be a plain single-value equality.
-                    if !is_single_equality(pred) {
-                        return false;
-                    }
-                    let value = pred.values[0].clone();
-                    match &bindings[idx] {
-                        // Conflicting second binding for the same component.
-                        Some(existing) if existing != &value => false,
-                        _ => {
-                            bindings[idx] = Some(value);
-                            true
-                        }
-                    }
-                }
-            }
-        }
-        // Any Or/Not/IsNull that touches a PK column disqualifies the point route;
-        // one that is purely over non-PK columns is an ignorable residual.
-        FilterExpr::Or(_) | FilterExpr::Not(_) | FilterExpr::IsNull(_) => {
-            !mentions_pk_expr(expr, pk_cols)
-        }
-    }
-}
-
-/// Return the bound-value lists for `pk IN (v1, v2, ...)` iff `filter` is exactly
-/// that single-column `IN` leaf on the sole partition-key column (with no other
-/// constraint). Each returned key is a one-element `Vec<Value>`.
-fn single_pk_in_list(filter: &FilterExpr, pk_col: &str) -> Option<Vec<Vec<Value>>> {
-    let FilterExpr::Leaf(pred) = filter else {
+    // A disjunct is a full-PK equality only when it is exactly that: every
+    // component bound by `=`, no extracted sub-group.
+    if acc.multi_group.is_some() {
         return None;
-    };
+    }
+    acc.bindings.into_iter().collect::<Option<Vec<Value>>>()
+}
+
+/// Return the bound-value lists for `pk IN (v1, v2, ...)` iff `pred` is that
+/// single-column `IN` leaf on the sole partition-key column. Each returned key
+/// is a one-element `Vec<Value>`.
+fn sole_pk_in_leaf(pred: &SSTablePredicate, pk_col: &str) -> Option<Vec<Vec<Value>>> {
     if pred.token_columns.is_some()
         || pred.column != pk_col
         || !matches!(pred.operation, SSTableFilterOp::In)

--- a/cqlite-flight/src/point_read_tests.rs
+++ b/cqlite-flight/src/point_read_tests.rs
@@ -15,8 +15,9 @@ use crate::producer::{DirSource, MergeProducer, ProducerError, SstableSource};
 use crate::testutil::{
     build_sstables, clustering_schema, delete_row, simple_schema, write_clustered, write_row,
 };
-use crate::ticket::{FlightTicket, Predicate, PredicateOp};
+use crate::ticket::{FlightTicket, Predicate, PredicateExpr, PredicateOp};
 
+use cqlite_core::schema::TableSchema;
 use cqlite_core::storage::scan_cancel::ScanCancel;
 use cqlite_core::storage::write_engine::merge::MergeStep;
 use cqlite_core::storage::write_engine::{build_single_partition_merger, KWayMerger, PartitionKey};
@@ -155,6 +156,132 @@ fn full_pk_in_list_is_bounded_by_the_listed_keys() {
         .unwrap()
         .expect("some present");
     assert_eq!(count_partitions(merger), 3, "bounded by the 3 listed keys");
+}
+
+/// SUGGESTION (roborev, issue #2207): `pk IN (5, 5)` must not double-seek the
+/// same partition — a duplicate key in the requested set is deduped BEFORE
+/// probing, so the merge sees exactly ONE `MergeEntry` for that partition per
+/// candidate SSTable, never two. Note: `merge_partition_rows`'s per-cluster
+/// reconciliation already absorbs a redundant same-run duplicate for THIS
+/// fixture shape without a wrong final answer (this test also passes without
+/// the dedup canonicalization) — so this is a no-op-safety + work-avoidance
+/// regression guard (the SUGGESTION's actual "double-seek" concern), not a
+/// red-then-green correctness proof.
+#[test]
+fn duplicate_in_list_key_does_not_double_seek_the_partition() {
+    let schema = clustering_schema();
+    let (_t, _d, dir) = build_sstables(&schema, vec![vec![write_clustered(3, "a", 1, 100)]]);
+    let paths = DirSource::new(&dir).data_paths().unwrap();
+
+    let key = int_pk_bytes(&schema, "pk", 3);
+    // The exact same key requested twice.
+    let merger =
+        build_single_partition_merger(paths, &[key.clone(), key], &schema, ScanCancel::default())
+            .unwrap()
+            .expect("the partition is present");
+
+    let mut steps = 0;
+    let mut row_count = 0;
+    let mut m = merger;
+    while let MergeStep::Partition { rows, .. } = m.step().unwrap() {
+        steps += 1;
+        row_count += rows.len();
+    }
+    assert_eq!(steps, 1, "a duplicated key must still yield ONE partition");
+    assert_eq!(
+        row_count, 1,
+        "a duplicated key must not duplicate the partition's single clustering row"
+    );
+}
+
+/// The Murmur3 token for `column = v` under `schema`, via the same public
+/// `PartitionKey::to_decorated_key` the routing/merge machinery uses.
+fn token_of(schema: &TableSchema, column: &str, v: i32) -> i64 {
+    PartitionKey::single(column, Value::Integer(v))
+        .to_decorated_key(schema)
+        .expect("decorate key")
+        .token
+}
+
+/// **BLOCKER regression** (roborev on f75dccc2): a multi-key point read (`IN` /
+/// `Or`) combines each candidate SSTable's seeked rows in REQUESTED-KEY order,
+/// not token order. `KWayMerger::step`/`refill_heap` require every run to yield
+/// entries in ascending `MergeEntry` order (token, key, clustering) —
+/// `refill_heap` buffers only ONE entry per run at a time and relies on that
+/// invariant. An out-of-order run causes `step()` to split one run's
+/// contribution across two heap pops: partitions can duplicate, and a newer
+/// generation's overwrite/tombstone can stop shadowing the older generation
+/// (split reconciliation).
+///
+/// This fixture requests 3 keys in the EXACT REVERSE of their natural ascending
+/// token order (computed, not guessed) — the worst-case mismatch — with one key
+/// overwritten and one row-tombstoned in a newer generation, and asserts the
+/// point path is byte-identical to the scan path (and matches the expected
+/// post-reconciliation rows directly).
+#[test]
+fn point_path_in_list_out_of_token_order_matches_scan_across_generations() {
+    let schema = simple_schema();
+    let ids = [5, 9, 13];
+
+    // gen1: all three present.
+    let gen1 = vec![
+        write_row(ids[0], "a1", 1, 100),
+        write_row(ids[1], "b1", 1, 100),
+        write_row(ids[2], "c1", 1, 100),
+    ];
+    // gen2: ids[1] overwritten (newer ts); ids[2] row-tombstoned (newer ts).
+    let gen2 = vec![write_row(ids[1], "b2", 2, 200), delete_row(ids[2], 300)];
+    let (_t, _d, dir) = build_sstables(&schema, vec![gen1, gen2]);
+
+    // Natural ascending token order for the 3 distinct ids, then request them in
+    // the EXACT REVERSE — deliberately mismatched (never "happens to align").
+    let mut by_token: Vec<i32> = ids.to_vec();
+    by_token.sort_by_key(|&v| token_of(&schema, "id", v));
+    let request_order: Vec<i32> = by_token.iter().rev().copied().collect();
+    assert_ne!(
+        request_order, by_token,
+        "3 distinct ids' reverse token order must differ from ascending order (test setup)"
+    );
+
+    let ticket = FlightTicket {
+        keyspace: "flight_ks".into(),
+        table: "items".into(),
+        filter: Some(PredicateExpr::In {
+            column: "id".into(),
+            values: request_order.iter().map(|v| json!(v)).collect(),
+        }),
+        ..Default::default()
+    };
+    let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
+
+    let scan_producer = MergeProducer::with_spec(schema.clone(), 4, spec.clone()).unwrap();
+    let scan_batches = scan_producer
+        .produce_from_paths(DirSource::new(&dir).data_paths().unwrap())
+        .unwrap();
+
+    let point_producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
+    let paths = point_producer.resolve_paths(&DirSource::new(&dir)).unwrap();
+    let point_batches = point_producer
+        .produce_streaming_to_vec(paths, &CancelFlag::new())
+        .unwrap();
+
+    assert_eq!(
+        simple_rows(&point_batches),
+        simple_rows(&scan_batches),
+        "an out-of-token-order IN-list point read must be byte-identical to the scan path"
+    );
+    // Concretely: ids[0] is untouched (gen1 live), ids[1] is the gen2 overwrite,
+    // ids[2] is tombstoned (absent from the result).
+    let expected = vec![
+        (ids[0], Some("a1".to_string()), Some(1)),
+        (ids[1], Some("b2".to_string()), Some(2)),
+    ];
+    assert_eq!(
+        simple_rows(&point_batches),
+        expected,
+        "reconciliation must survive the out-of-token-order combine: ids[1] shows the \
+         gen2 overwrite (b2/2), ids[2] is shadowed by its gen2 tombstone"
+    );
 }
 
 // ---- Stage 3.1/3.2: dual-path byte-parity over a tombstoned multi-gen corpus ----

--- a/cqlite-flight/src/point_read_tests.rs
+++ b/cqlite-flight/src/point_read_tests.rs
@@ -18,10 +18,8 @@ use crate::testutil::{
 use crate::ticket::{FlightTicket, Predicate, PredicateOp};
 
 use cqlite_core::storage::scan_cancel::ScanCancel;
-use cqlite_core::storage::write_engine::{
-    build_single_partition_merger, KWayMerger, PartitionKey,
-};
 use cqlite_core::storage::write_engine::merge::MergeStep;
+use cqlite_core::storage::write_engine::{build_single_partition_merger, KWayMerger, PartitionKey};
 use cqlite_core::types::Value;
 use serde_json::json;
 
@@ -56,7 +54,9 @@ fn count_partitions(mut merger: KWayMerger) -> usize {
 }
 
 /// The rows a `simple_schema` producer emits, as `(id, name, score)` sorted.
-fn simple_rows(batches: &[arrow::record_batch::RecordBatch]) -> Vec<(i32, Option<String>, Option<i32>)> {
+fn simple_rows(
+    batches: &[arrow::record_batch::RecordBatch],
+) -> Vec<(i32, Option<String>, Option<i32>)> {
     use arrow::array::{Array, Int32Array, StringArray};
     let mut out = Vec::new();
     for b in batches {
@@ -134,7 +134,8 @@ fn point_merger_for_absent_key_is_none() {
 
     // id=999 is not present → no runs → None (the caller streams zero rows).
     let key = int_pk_bytes(&schema, "id", 999);
-    let built = build_single_partition_merger(paths, &[key], &schema, ScanCancel::default()).unwrap();
+    let built =
+        build_single_partition_merger(paths, &[key], &schema, ScanCancel::default()).unwrap();
     assert!(built.is_none(), "absent key yields no merger");
 }
 
@@ -161,8 +162,11 @@ fn full_pk_in_list_is_bounded_by_the_listed_keys() {
 /// Build a 2-generation `simple_schema` corpus with an overwrite and a tombstone:
 /// - gen1: id3=(a,1), id4=(x,1), id7=(z,1)
 /// - gen2: id3=(a2,2) overwrite (newer ts), id7 row-tombstoned (newer ts)
-fn tombstoned_corpus() -> (tempfile::TempDir, std::path::PathBuf, cqlite_core::schema::TableSchema)
-{
+fn tombstoned_corpus() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    cqlite_core::schema::TableSchema,
+) {
     let schema = simple_schema();
     let gen1 = vec![
         write_row(3, "a", 1, 100),
@@ -174,7 +178,12 @@ fn tombstoned_corpus() -> (tempfile::TempDir, std::path::PathBuf, cqlite_core::s
     (temp, dir, schema)
 }
 
-fn assert_point_equals_scan(schema: &cqlite_core::schema::TableSchema, dir: &std::path::Path, key_col: &str, key_val: i32) {
+fn assert_point_equals_scan(
+    schema: &cqlite_core::schema::TableSchema,
+    dir: &std::path::Path,
+    key_col: &str,
+    key_val: i32,
+) {
     let ticket = eq_ticket(key_col, key_val);
     let spec = ScanSpec::from_ticket(&ticket, schema).unwrap();
 
@@ -208,7 +217,11 @@ fn point_path_matches_scan_on_overwritten_key() {
     let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
     let producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
     let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
-    let rows = simple_rows(&producer.produce_streaming_to_vec(paths, &CancelFlag::new()).unwrap());
+    let rows = simple_rows(
+        &producer
+            .produce_streaming_to_vec(paths, &CancelFlag::new())
+            .unwrap(),
+    );
     assert_eq!(rows, vec![(3, Some("a2".to_string()), Some(2))]);
 }
 
@@ -221,8 +234,15 @@ fn point_path_matches_scan_on_tombstoned_key() {
     let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
     let producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
     let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
-    let rows = simple_rows(&producer.produce_streaming_to_vec(paths, &CancelFlag::new()).unwrap());
-    assert!(rows.is_empty(), "a tombstoned partition yields no rows on the point path");
+    let rows = simple_rows(
+        &producer
+            .produce_streaming_to_vec(paths, &CancelFlag::new())
+            .unwrap(),
+    );
+    assert!(
+        rows.is_empty(),
+        "a tombstoned partition yields no rows on the point path"
+    );
 }
 
 #[test]
@@ -254,7 +274,11 @@ fn index_less_candidate_is_read_never_skipped() {
     let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
     let producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
     let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
-    let rows = simple_rows(&producer.produce_streaming_to_vec(paths, &CancelFlag::new()).unwrap());
+    let rows = simple_rows(
+        &producer
+            .produce_streaming_to_vec(paths, &CancelFlag::new())
+            .unwrap(),
+    );
 
     // The key lives ONLY in the index-less SSTable: it MUST still be returned. The
     // inverted "skip on missing index" behaviour would drop it and fail here.

--- a/cqlite-flight/src/point_read_tests.rs
+++ b/cqlite-flight/src/point_read_tests.rs
@@ -1,0 +1,324 @@
+//! Partition point-read behavioral tests (issue #2207, Stages 2–5).
+//!
+//! Exercises the wired `do_get` point path over real in-process SSTables (built
+//! via the write engine, so no external fixtures): the work-done probe (merge
+//! steps bounded by candidate lookups, not table partition count), dual-path
+//! byte-parity vs the full-scan+filter path over a tombstoned multi-generation
+//! corpus, the index-less fail-safe (#2295 shape), cooperative cancellation
+//! (#2264), and LIMIT discipline. These live in-crate (not `tests/`) so they can
+//! use the `testutil` write-engine fixture builders and the pub(crate)
+//! `produce_streaming_to_vec` seam.
+
+use crate::cancel::CancelFlag;
+use crate::filter::ScanSpec;
+use crate::producer::{DirSource, MergeProducer, ProducerError, SstableSource};
+use crate::testutil::{
+    build_sstables, clustering_schema, delete_row, simple_schema, write_clustered, write_row,
+};
+use crate::ticket::{FlightTicket, Predicate, PredicateOp};
+
+use cqlite_core::storage::scan_cancel::ScanCancel;
+use cqlite_core::storage::write_engine::{
+    build_single_partition_merger, KWayMerger, PartitionKey,
+};
+use cqlite_core::storage::write_engine::merge::MergeStep;
+use cqlite_core::types::Value;
+use serde_json::json;
+
+/// A `do_get` ticket carrying a single `column = value` (int) equality predicate.
+fn eq_ticket(column: &str, value: i32) -> FlightTicket {
+    FlightTicket {
+        keyspace: "flight_ks".into(),
+        table: "items".into(),
+        predicates: vec![Predicate {
+            column: column.into(),
+            op: PredicateOp::Equal,
+            value: json!(value),
+        }],
+        ..Default::default()
+    }
+}
+
+/// Raw partition-key bytes for a single-int PK.
+fn int_pk_bytes(schema: &cqlite_core::schema::TableSchema, column: &str, v: i32) -> Vec<u8> {
+    PartitionKey::single(column, Value::Integer(v))
+        .to_bytes(schema)
+        .expect("serialize pk")
+}
+
+/// Count the partitions a merger emits (steps until `Complete`).
+fn count_partitions(mut merger: KWayMerger) -> usize {
+    let mut n = 0;
+    while let MergeStep::Partition { .. } = merger.step().expect("step") {
+        n += 1;
+    }
+    n
+}
+
+/// The rows a `simple_schema` producer emits, as `(id, name, score)` sorted.
+fn simple_rows(batches: &[arrow::record_batch::RecordBatch]) -> Vec<(i32, Option<String>, Option<i32>)> {
+    use arrow::array::{Array, Int32Array, StringArray};
+    let mut out = Vec::new();
+    for b in batches {
+        let ids = b
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let names = b
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let scores = b
+            .column_by_name("score")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for i in 0..b.num_rows() {
+            let name = if names.is_null(i) {
+                None
+            } else {
+                Some(names.value(i).to_string())
+            };
+            let score = if scores.is_null(i) {
+                None
+            } else {
+                Some(scores.value(i))
+            };
+            out.push((ids.value(i), name, score));
+        }
+    }
+    out.sort();
+    out
+}
+
+// ---- Stage 3.3: work-done probe (merge steps bounded by candidate lookups) ----
+
+#[test]
+fn point_merger_steps_only_the_target_partition_not_the_whole_table() {
+    let schema = simple_schema();
+    // 12 distinct partitions in one SSTable.
+    let rows: Vec<_> = (0..12)
+        .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+        .collect();
+    let (_t, _d, dir) = build_sstables(&schema, vec![rows]);
+    let paths = DirSource::new(&dir).data_paths().unwrap();
+
+    // A full k-way scan steps EVERY partition (this is what `do_get` does on main).
+    let full = KWayMerger::new(paths.clone(), &schema).unwrap();
+    assert_eq!(count_partitions(full), 12, "the table has 12 partitions");
+
+    // The point merger for id=3 steps ONE partition — the work-done proof. On main
+    // there is no point path, so the same query steps all 12; this bounds it to 1.
+    let key = int_pk_bytes(&schema, "id", 3);
+    let merger = build_single_partition_merger(paths, &[key], &schema, ScanCancel::default())
+        .unwrap()
+        .expect("target partition present");
+    assert_eq!(
+        count_partitions(merger),
+        1,
+        "point path examines only the target partition, not all 12"
+    );
+}
+
+#[test]
+fn point_merger_for_absent_key_is_none() {
+    let schema = simple_schema();
+    let rows: Vec<_> = (0..5).map(|i| write_row(i, "n", i, 100)).collect();
+    let (_t, _d, dir) = build_sstables(&schema, vec![rows]);
+    let paths = DirSource::new(&dir).data_paths().unwrap();
+
+    // id=999 is not present → no runs → None (the caller streams zero rows).
+    let key = int_pk_bytes(&schema, "id", 999);
+    let built = build_single_partition_merger(paths, &[key], &schema, ScanCancel::default()).unwrap();
+    assert!(built.is_none(), "absent key yields no merger");
+}
+
+#[test]
+fn full_pk_in_list_is_bounded_by_the_listed_keys() {
+    let schema = simple_schema();
+    let rows: Vec<_> = (0..20).map(|i| write_row(i, "n", i, 100)).collect();
+    let (_t, _d, dir) = build_sstables(&schema, vec![rows]);
+    let paths = DirSource::new(&dir).data_paths().unwrap();
+
+    // IN (3, 7, 11) → exactly 3 partitions stepped, not 20.
+    let keys: Vec<Vec<u8>> = [3, 7, 11]
+        .iter()
+        .map(|v| int_pk_bytes(&schema, "id", *v))
+        .collect();
+    let merger = build_single_partition_merger(paths, &keys, &schema, ScanCancel::default())
+        .unwrap()
+        .expect("some present");
+    assert_eq!(count_partitions(merger), 3, "bounded by the 3 listed keys");
+}
+
+// ---- Stage 3.1/3.2: dual-path byte-parity over a tombstoned multi-gen corpus ----
+
+/// Build a 2-generation `simple_schema` corpus with an overwrite and a tombstone:
+/// - gen1: id3=(a,1), id4=(x,1), id7=(z,1)
+/// - gen2: id3=(a2,2) overwrite (newer ts), id7 row-tombstoned (newer ts)
+fn tombstoned_corpus() -> (tempfile::TempDir, std::path::PathBuf, cqlite_core::schema::TableSchema)
+{
+    let schema = simple_schema();
+    let gen1 = vec![
+        write_row(3, "a", 1, 100),
+        write_row(4, "x", 1, 100),
+        write_row(7, "z", 1, 100),
+    ];
+    let gen2 = vec![write_row(3, "a2", 2, 200), delete_row(7, 300)];
+    let (temp, _data, dir) = build_sstables(&schema, vec![gen1, gen2]);
+    (temp, dir, schema)
+}
+
+fn assert_point_equals_scan(schema: &cqlite_core::schema::TableSchema, dir: &std::path::Path, key_col: &str, key_val: i32) {
+    let ticket = eq_ticket(key_col, key_val);
+    let spec = ScanSpec::from_ticket(&ticket, schema).unwrap();
+
+    // Scan path (route not applied — the collect path always full-scans + filters).
+    let scan_producer = MergeProducer::with_spec(schema.clone(), 4, spec.clone()).unwrap();
+    let scan_batches = scan_producer
+        .produce_from_paths(DirSource::new(dir).data_paths().unwrap())
+        .unwrap();
+
+    // Point path (route applied) over the same resolved paths.
+    let point_producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
+    let paths = point_producer.resolve_paths(&DirSource::new(dir)).unwrap();
+    let point_batches = point_producer
+        .produce_streaming_to_vec(paths, &CancelFlag::new())
+        .unwrap();
+
+    assert_eq!(
+        simple_rows(&point_batches),
+        simple_rows(&scan_batches),
+        "point path must be byte-identical to scan+filter for pk={key_val}"
+    );
+}
+
+#[test]
+fn point_path_matches_scan_on_overwritten_key() {
+    let (_t, dir, schema) = tombstoned_corpus();
+    // id3 was overwritten in gen2 → LWW picks (a2, 2) on BOTH paths.
+    assert_point_equals_scan(&schema, &dir, "id", 3);
+    // Spot-check the reconciled value is the newer one.
+    let ticket = eq_ticket("id", 3);
+    let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
+    let producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
+    let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
+    let rows = simple_rows(&producer.produce_streaming_to_vec(paths, &CancelFlag::new()).unwrap());
+    assert_eq!(rows, vec![(3, Some("a2".to_string()), Some(2))]);
+}
+
+#[test]
+fn point_path_matches_scan_on_tombstoned_key() {
+    let (_t, dir, schema) = tombstoned_corpus();
+    // id7 was row-tombstoned in gen2 → BOTH paths return zero rows (reconciled).
+    assert_point_equals_scan(&schema, &dir, "id", 7);
+    let ticket = eq_ticket("id", 7);
+    let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
+    let producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
+    let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
+    let rows = simple_rows(&producer.produce_streaming_to_vec(paths, &CancelFlag::new()).unwrap());
+    assert!(rows.is_empty(), "a tombstoned partition yields no rows on the point path");
+}
+
+#[test]
+fn point_path_matches_scan_on_live_untouched_key() {
+    let (_t, dir, schema) = tombstoned_corpus();
+    assert_point_equals_scan(&schema, &dir, "id", 4);
+}
+
+// ---- Stage 4.1: index-less fail-safe (#2295 Data.db-only shape) ----
+
+#[test]
+fn index_less_candidate_is_read_never_skipped() {
+    let schema = simple_schema();
+    let (_t, _d, dir) = build_sstables(&schema, vec![vec![write_row(3, "keep", 9, 100)]]);
+
+    // Simulate the #2295 field shape: strip the random-access index (Summary.db)
+    // so `has_partition_index()` is false and the reader must fall back to a scan.
+    let mut stripped = 0;
+    for entry in std::fs::read_dir(&dir).unwrap().flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.ends_with("Summary.db") {
+            std::fs::remove_file(entry.path()).unwrap();
+            stripped += 1;
+        }
+    }
+    assert!(stripped >= 1, "the fixture must ship a Summary.db to strip");
+
+    let ticket = eq_ticket("id", 3);
+    let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
+    let producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
+    let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
+    let rows = simple_rows(&producer.produce_streaming_to_vec(paths, &CancelFlag::new()).unwrap());
+
+    // The key lives ONLY in the index-less SSTable: it MUST still be returned. The
+    // inverted "skip on missing index" behaviour would drop it and fail here.
+    assert_eq!(
+        rows,
+        vec![(3, Some("keep".to_string()), Some(9))],
+        "index-less SSTable must be scanned, never skipped (fail-safe)"
+    );
+}
+
+// ---- Stage 4.2: cooperative cancellation + LIMIT ----
+
+#[test]
+fn pre_cancelled_point_read_stops_without_masking_errors() {
+    let schema = simple_schema();
+    let rows: Vec<_> = (0..8).map(|i| write_row(i, "n", i, 100)).collect();
+    let (_t, _d, dir) = build_sstables(&schema, vec![rows]);
+
+    let ticket = eq_ticket("id", 3);
+    let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
+    let producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
+    let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
+
+    let cancelled = CancelFlag::new();
+    cancelled.cancel();
+    let err = producer
+        .produce_streaming_to_vec(paths, &cancelled)
+        .expect_err("a pre-cancelled point read aborts");
+    // Cancellation maps to the DISTINCT Cancelled variant, never a masked Merge
+    // error (issue #2264).
+    assert!(
+        matches!(err, ProducerError::Cancelled),
+        "pre-cancel must surface as Cancelled, got {err:?}"
+    );
+}
+
+#[test]
+fn point_read_respects_limit_over_a_wide_partition() {
+    let schema = clustering_schema();
+    // One partition pk=3 with 5 clustering rows.
+    let rows: Vec<_> = ["a", "b", "c", "d", "e"]
+        .iter()
+        .enumerate()
+        .map(|(i, ck)| write_clustered(3, ck, i as i32, 100))
+        .collect();
+    let (_t, _d, dir) = build_sstables(&schema, vec![rows]);
+
+    let ticket = FlightTicket {
+        keyspace: "flight_ks".into(),
+        table: "wide".into(),
+        predicates: vec![Predicate {
+            column: "pk".into(),
+            op: PredicateOp::Equal,
+            value: json!(3),
+        }],
+        limit: Some(2),
+        ..Default::default()
+    };
+    let spec = ScanSpec::from_ticket(&ticket, &schema).unwrap();
+    let producer = MergeProducer::with_spec(schema.clone(), 4, spec).unwrap();
+    let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
+    let batches = producer
+        .produce_streaming_to_vec(paths, &CancelFlag::new())
+        .unwrap();
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 2, "LIMIT 2 streams at most 2 rows on the point path");
+}

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -598,8 +598,8 @@ impl MergeProducer {
         // point-read path — resolve candidate SSTables and seek only the target
         // partition(s), instead of a full k-way scan with a per-row filter. Any
         // other shape keeps the unchanged scan path below.
-        if let Some(keys) = self.point_read_keys() {
-            return self.produce_point(keys, paths, cancel, sink, progress, on_merger_built);
+        if let Some(plan) = self.point_read_keys() {
+            return self.produce_point(plan, paths, cancel, sink, progress, on_merger_built);
         }
 
         // Issue #2264: wire the shared synchronous cancel token into the merge so

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -320,10 +320,13 @@ fn sstable_token_span(data_path: &Path, rt: &PruneRuntime) -> Option<(i64, i64)>
 
 /// Produces Arrow record batches from a compaction merge of a table's SSTables.
 pub struct MergeProducer {
-    schema: TableSchema,
+    // `schema` + `spec` are `pub(crate)` so the point-read routing (issue #2207)
+    // can live in the sibling `producer_point` module (campsite rule: producer.rs
+    // is over the file-size threshold, epic #1116).
+    pub(crate) schema: TableSchema,
     columns: Vec<ColumnInfo>,
     batch_size: usize,
-    spec: ScanSpec,
+    pub(crate) spec: ScanSpec,
     /// Aggregation pushdown plan (issue #841). When `Some`, the producer emits
     /// PARTIAL aggregate rows under [`Self::partial_columns`] instead of full
     /// rows; when `None` the row path is unchanged.
@@ -338,7 +341,7 @@ pub struct MergeProducer {
 /// polled BEFORE each `step()`) can be proven by a test double that counts
 /// `step()` calls — a pre-cancel must yield ZERO steps, i.e. no partition is
 /// collected/reconciled before cancellation is observed.
-trait PartitionStepper {
+pub(crate) trait PartitionStepper {
     /// Advance the merge by one partition (or report completion).
     fn step(&mut self) -> Result<MergeStep, cqlite_core::Error>;
 }
@@ -636,107 +639,6 @@ impl MergeProducer {
         )
     }
 
-    /// Resolve the point-read route into concrete raw partition keys, or `None`
-    /// when the pushed predicate is not a full-PK equality (the scan path).
-    ///
-    /// Each returned key is `(raw_key_bytes, token)`, in the route's order. Keys
-    /// whose Murmur3 token falls OUTSIDE the split's token range are dropped here
-    /// (before any seek) — the point read stays within the split's range exactly
-    /// as the scan path's per-partition token guard does. A key whose typed values
-    /// cannot be serialized to partition-key bytes (should not happen for a
-    /// schema-typed predicate) drops the whole route to the scan path (returns
-    /// `None`) rather than risk a wrong answer.
-    fn point_read_keys(&self) -> Option<Vec<(Vec<u8>, i64)>> {
-        use cqlite_core::storage::write_engine::PartitionKey;
-        use crate::point_read::{detect_route, PointReadRoute};
-
-        let component_keys: Vec<Vec<Value>> =
-            match detect_route(self.spec.filter.as_ref(), &self.schema) {
-                PointReadRoute::Scan => return None,
-                PointReadRoute::PartitionPointRead(values) => vec![values],
-                PointReadRoute::MultiPartitionPointRead(keys) => keys,
-            };
-
-        let pk_names: Vec<&str> = self
-            .schema
-            .partition_keys
-            .iter()
-            .map(|c| c.name.as_str())
-            .collect();
-
-        let mut out: Vec<(Vec<u8>, i64)> = Vec::with_capacity(component_keys.len());
-        for values in component_keys {
-            if values.len() != pk_names.len() {
-                return None;
-            }
-            let columns: Vec<(String, Value)> = pk_names
-                .iter()
-                .zip(values.into_iter())
-                .map(|(name, v)| ((*name).to_string(), v))
-                .collect();
-            let decorated = match PartitionKey::new(columns).to_decorated_key(&self.schema) {
-                Ok(d) => d,
-                // A predicate that cannot serialize to key bytes is not a route we
-                // can honour safely — fall back to the scan path.
-                Err(_) => return None,
-            };
-            // Token-range exclusion BEFORE any seek: drop keys outside the split.
-            if let Some(token) = &self.spec.token {
-                if !token.contains(decorated.token) {
-                    continue;
-                }
-            }
-            out.push((decorated.key, decorated.token));
-        }
-        Some(out)
-    }
-
-    /// Drive the partition point-read path (issue #2207): build a k-way merger over
-    /// ONLY the target partition(s) across the candidate SSTables (seek where the
-    /// index resolves, scan-fallback where it does not, prune on a definite bloom
-    /// negative), then reconcile + stream through the SAME [`Self::drive_merge`]
-    /// loop the scan path uses — reporting `streaming_partition_lookup`.
-    fn produce_point(
-        &self,
-        keys: Vec<(Vec<u8>, i64)>,
-        _paths: Vec<PathBuf>,
-        cancel: &CancelFlag,
-        sink: &mut dyn BatchSink,
-        progress: &ScanProgress,
-        on_merger_built: impl FnOnce(),
-    ) -> Result<(), ProducerError> {
-        // Every key was token-excluded → nothing to read. Still fire the phase
-        // boundary so the caller's `merge_setup → stream` accounting stays honest.
-        let key_bytes: Vec<Vec<u8>> = keys.into_iter().map(|(k, _)| k).collect();
-        if key_bytes.is_empty() {
-            on_merger_built();
-            return Ok(());
-        }
-
-        // Map a cooperative cancellation to the distinct `Cancelled` variant, never
-        // masking a real I/O/corruption error as a clean cancel (issue #2264,
-        // mirroring `drive_merge`).
-        let built = cqlite_core::storage::write_engine::build_single_partition_merger(
-            _paths,
-            &key_bytes,
-            &self.schema,
-            cancel.scan_cancel(),
-        )
-        .map_err(|e| match e {
-            cqlite_core::Error::Cancelled => ProducerError::Cancelled,
-            other => ProducerError::Merge(other),
-        })?;
-
-        on_merger_built();
-        let label = AccessPath::StreamingPartitionLookup.label();
-        match built {
-            // No candidate SSTable holds any target key → zero rows examined, so
-            // nothing to stream (and no rows-scanned emission either — no work).
-            None => Ok(()),
-            Some(mut merger) => self.drive_merge(&mut merger, cancel, sink, progress, label),
-        }
-    }
-
     /// Prune `paths` to those whose token span overlaps the spec's token range.
     ///
     /// Returns `paths` unchanged when there is no token filter. A path is kept
@@ -861,7 +763,7 @@ impl MergeProducer {
     /// rows as exist up to `limit`, never fewer. `limit == Some(0)` emits nothing
     /// without stepping the merge at all. The cap applies per split; the connector
     /// sets `limitGuaranteed = false` so Trino keeps a global `Limit` above.
-    fn drive_merge(
+    pub(crate) fn drive_merge(
         &self,
         merger: &mut dyn PartitionStepper,
         cancel: &CancelFlag,

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -713,13 +713,19 @@ impl MergeProducer {
             return Ok(());
         }
 
+        // Map a cooperative cancellation to the distinct `Cancelled` variant, never
+        // masking a real I/O/corruption error as a clean cancel (issue #2264,
+        // mirroring `drive_merge`).
         let built = cqlite_core::storage::write_engine::build_single_partition_merger(
             _paths,
             &key_bytes,
             &self.schema,
             cancel.scan_cancel(),
         )
-        .map_err(ProducerError::Merge)?;
+        .map_err(|e| match e {
+            cqlite_core::Error::Cancelled => ProducerError::Cancelled,
+            other => ProducerError::Merge(other),
+        })?;
 
         on_merger_built();
         let label = AccessPath::StreamingPartitionLookup.label();
@@ -1369,6 +1375,7 @@ mod tests {
                     &cancelled,
                     &mut sink,
                     &ScanProgress::default(),
+                    AccessPath::FullScan.label(),
                 )
                 .expect_err("pre-cancelled merge aborts")
         };

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -566,27 +566,6 @@ impl MergeProducer {
         self.agg.is_some()
     }
 
-    /// Run the streaming merge over already-resolved `paths` and collect the
-    /// batches into a `Vec` (issue #2207 wiring evidence + dual-path parity).
-    ///
-    /// This is the SAME path `do_get` streams — including the point-read route
-    /// selection — so a test can drive the point path end-to-end and compare its
-    /// batches byte-for-byte against the full-scan collect path
-    /// ([`Self::produce_from_paths`]). `paths` MUST be token-pruned/resolved (as
-    /// [`Self::resolve_paths`] returns).
-    pub fn produce_streaming_to_vec(
-        &self,
-        paths: Vec<PathBuf>,
-        cancel: &CancelFlag,
-    ) -> Result<Vec<RecordBatch>, ProducerError> {
-        let mut batches = Vec::new();
-        {
-            let mut sink = CollectSink(&mut batches);
-            self.produce_streaming(paths, cancel, &mut sink, &ScanProgress::default(), || {})?;
-        }
-        Ok(batches)
-    }
-
     /// Stream the row-merge of already-resolved `paths` into `sink` (issue #1476),
     /// one batch at a time, instead of collecting into a `Vec`. `paths` MUST come
     /// from [`Self::resolve_paths`] (already token-pruned). The merge stops when

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -563,6 +563,27 @@ impl MergeProducer {
         self.agg.is_some()
     }
 
+    /// Run the streaming merge over already-resolved `paths` and collect the
+    /// batches into a `Vec` (issue #2207 wiring evidence + dual-path parity).
+    ///
+    /// This is the SAME path `do_get` streams — including the point-read route
+    /// selection — so a test can drive the point path end-to-end and compare its
+    /// batches byte-for-byte against the full-scan collect path
+    /// ([`Self::produce_from_paths`]). `paths` MUST be token-pruned/resolved (as
+    /// [`Self::resolve_paths`] returns).
+    pub fn produce_streaming_to_vec(
+        &self,
+        paths: Vec<PathBuf>,
+        cancel: &CancelFlag,
+    ) -> Result<Vec<RecordBatch>, ProducerError> {
+        let mut batches = Vec::new();
+        {
+            let mut sink = CollectSink(&mut batches);
+            self.produce_streaming(paths, cancel, &mut sink, &ScanProgress::default(), || {})?;
+        }
+        Ok(batches)
+    }
+
     /// Stream the row-merge of already-resolved `paths` into `sink` (issue #1476),
     /// one batch at a time, instead of collecting into a `Vec`. `paths` MUST come
     /// from [`Self::resolve_paths`] (already token-pruned). The merge stops when
@@ -590,6 +611,15 @@ impl MergeProducer {
         if self.agg.is_some() || paths.is_empty() {
             return Ok(());
         }
+
+        // Issue #2207: a pushed full-PK-equality predicate routes to the partition
+        // point-read path — resolve candidate SSTables and seek only the target
+        // partition(s), instead of a full k-way scan with a per-row filter. Any
+        // other shape keeps the unchanged scan path below.
+        if let Some(keys) = self.point_read_keys() {
+            return self.produce_point(keys, paths, cancel, sink, progress, on_merger_built);
+        }
+
         // Issue #2264: wire the shared synchronous cancel token into the merge so
         // each run's producer thread (which fully materialises an index-less
         // SSTable in one uninterruptible pass) abandons promptly on client
@@ -597,7 +627,108 @@ impl MergeProducer {
         let mut merger = KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
             .map_err(ProducerError::Merge)?;
         on_merger_built();
-        self.drive_merge(&mut merger, cancel, sink, progress)
+        self.drive_merge(
+            &mut merger,
+            cancel,
+            sink,
+            progress,
+            AccessPath::FullScan.label(),
+        )
+    }
+
+    /// Resolve the point-read route into concrete raw partition keys, or `None`
+    /// when the pushed predicate is not a full-PK equality (the scan path).
+    ///
+    /// Each returned key is `(raw_key_bytes, token)`, in the route's order. Keys
+    /// whose Murmur3 token falls OUTSIDE the split's token range are dropped here
+    /// (before any seek) — the point read stays within the split's range exactly
+    /// as the scan path's per-partition token guard does. A key whose typed values
+    /// cannot be serialized to partition-key bytes (should not happen for a
+    /// schema-typed predicate) drops the whole route to the scan path (returns
+    /// `None`) rather than risk a wrong answer.
+    fn point_read_keys(&self) -> Option<Vec<(Vec<u8>, i64)>> {
+        use cqlite_core::storage::write_engine::PartitionKey;
+        use crate::point_read::{detect_route, PointReadRoute};
+
+        let component_keys: Vec<Vec<Value>> =
+            match detect_route(self.spec.filter.as_ref(), &self.schema) {
+                PointReadRoute::Scan => return None,
+                PointReadRoute::PartitionPointRead(values) => vec![values],
+                PointReadRoute::MultiPartitionPointRead(keys) => keys,
+            };
+
+        let pk_names: Vec<&str> = self
+            .schema
+            .partition_keys
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+
+        let mut out: Vec<(Vec<u8>, i64)> = Vec::with_capacity(component_keys.len());
+        for values in component_keys {
+            if values.len() != pk_names.len() {
+                return None;
+            }
+            let columns: Vec<(String, Value)> = pk_names
+                .iter()
+                .zip(values.into_iter())
+                .map(|(name, v)| ((*name).to_string(), v))
+                .collect();
+            let decorated = match PartitionKey::new(columns).to_decorated_key(&self.schema) {
+                Ok(d) => d,
+                // A predicate that cannot serialize to key bytes is not a route we
+                // can honour safely — fall back to the scan path.
+                Err(_) => return None,
+            };
+            // Token-range exclusion BEFORE any seek: drop keys outside the split.
+            if let Some(token) = &self.spec.token {
+                if !token.contains(decorated.token) {
+                    continue;
+                }
+            }
+            out.push((decorated.key, decorated.token));
+        }
+        Some(out)
+    }
+
+    /// Drive the partition point-read path (issue #2207): build a k-way merger over
+    /// ONLY the target partition(s) across the candidate SSTables (seek where the
+    /// index resolves, scan-fallback where it does not, prune on a definite bloom
+    /// negative), then reconcile + stream through the SAME [`Self::drive_merge`]
+    /// loop the scan path uses — reporting `streaming_partition_lookup`.
+    fn produce_point(
+        &self,
+        keys: Vec<(Vec<u8>, i64)>,
+        _paths: Vec<PathBuf>,
+        cancel: &CancelFlag,
+        sink: &mut dyn BatchSink,
+        progress: &ScanProgress,
+        on_merger_built: impl FnOnce(),
+    ) -> Result<(), ProducerError> {
+        // Every key was token-excluded → nothing to read. Still fire the phase
+        // boundary so the caller's `merge_setup → stream` accounting stays honest.
+        let key_bytes: Vec<Vec<u8>> = keys.into_iter().map(|(k, _)| k).collect();
+        if key_bytes.is_empty() {
+            on_merger_built();
+            return Ok(());
+        }
+
+        let built = cqlite_core::storage::write_engine::build_single_partition_merger(
+            _paths,
+            &key_bytes,
+            &self.schema,
+            cancel.scan_cancel(),
+        )
+        .map_err(ProducerError::Merge)?;
+
+        on_merger_built();
+        let label = AccessPath::StreamingPartitionLookup.label();
+        match built {
+            // No candidate SSTable holds any target key → zero rows examined, so
+            // nothing to stream (and no rows-scanned emission either — no work).
+            None => Ok(()),
+            Some(mut merger) => self.drive_merge(&mut merger, cancel, sink, progress, label),
+        }
     }
 
     /// Prune `paths` to those whose token span overlaps the spec's token range.
@@ -696,8 +827,16 @@ impl MergeProducer {
             .map_err(ProducerError::Merge)?;
         let mut sink = CollectSink(&mut batches);
         // Collect path (parity oracle): a private seam — no external observer, but
-        // the same incremental counter emission runs (issue #2162).
-        self.drive_merge(&mut merger, cancel, &mut sink, &ScanProgress::default())?;
+        // the same incremental counter emission runs (issue #2162). This is the
+        // full-scan oracle path (always `full_scan`); the point route lives only on
+        // the streaming path (issue #2207).
+        self.drive_merge(
+            &mut merger,
+            cancel,
+            &mut sink,
+            &ScanProgress::default(),
+            AccessPath::FullScan.label(),
+        )?;
         Ok(batches)
     }
 
@@ -722,6 +861,7 @@ impl MergeProducer {
         cancel: &CancelFlag,
         sink: &mut dyn BatchSink,
         progress: &ScanProgress,
+        access_path: &'static str,
     ) -> Result<(), ProducerError> {
         let limit = self.spec.limit;
         // A zero cap produces no rows without touching the merge.
@@ -731,9 +871,9 @@ impl MergeProducer {
         // Incremental scan-progress meter (issue #2162): flushes rows_scanned /
         // read.rows / read.partitions deltas at the batch-scale threshold and, via
         // its `Drop`, the remainder on EVERY exit (completion, LIMIT break, cancel,
-        // error, panic). The Flight merge always full-scans its (pruned) inputs, so
-        // the bounded access-path label is `full_scan`.
-        let mut meter = ScanProgressMeter::new(progress, AccessPath::FullScan.label());
+        // error, panic). `access_path` is `full_scan` for the k-way scan and
+        // `streaming_partition_lookup` for the point-read path (issue #2207).
+        let mut meter = ScanProgressMeter::new(progress, access_path);
         let mut buffer: Vec<QueryRow> = Vec::with_capacity(self.batch_size);
         let mut emitted: u64 = 0;
         // Issue #1817: one partition-key decode cache for the whole merge; each

--- a/cqlite-flight/src/producer_point.rs
+++ b/cqlite-flight/src/producer_point.rs
@@ -2,8 +2,8 @@
 //!
 //! Extends [`MergeProducer`] with the `do_get` point path: detect a full-PK
 //! equality route, resolve concrete partition keys (token-excluded before any
-//! seek), build a k-way merger over ONLY the target partition(s), and reconcile
-//! + stream through the SAME [`MergeProducer::drive_merge`] loop the scan path
+//! seek), build a k-way merger over ONLY the target partition(s), then reconcile
+//! and stream through the SAME [`MergeProducer::drive_merge`] loop the scan path
 //! uses — reporting `streaming_partition_lookup`.
 //!
 //! Lives in its own module (not `producer.rs`) because that file is over the

--- a/cqlite-flight/src/producer_point.rs
+++ b/cqlite-flight/src/producer_point.rs
@@ -69,7 +69,17 @@ impl MergeProducer {
 
         let mut out: Vec<(Vec<u8>, i64)> = Vec::with_capacity(component_keys.len());
         for values in component_keys {
+            // Defensive guard: `detect_route` now guarantees every routed key binds
+            // EVERY partition-key component (a no-/partial-binding filter routes
+            // Scan, roborev job 1616), so this length mismatch should be
+            // unreachable. Keep it as a fail-safe — a wrong-arity key would be a
+            // routing logic bug, and dropping to the scan path is always correct.
             if values.len() != pk_names.len() {
+                debug_assert_eq!(
+                    values.len(),
+                    pk_names.len(),
+                    "detect_route must only yield full-arity partition keys"
+                );
                 return None;
             }
             let columns: Vec<(String, Value)> = pk_names
@@ -128,7 +138,17 @@ impl MergeProducer {
                 })?;
 
         on_merger_built();
-        let label = AccessPath::StreamingPartitionLookup.label();
+        // Label from the route SHAPE, not a fixed constant (roborev job 1616): a
+        // multi-key point read that survived token filtering with >1 key is a
+        // `multi_partition_lookup`; a single surviving key is the streaming
+        // single-partition analogue. This is the field-run evidence label, so it
+        // must reflect what the read actually did.
+        let access_path = if key_bytes.len() > 1 {
+            AccessPath::MultiPartitionLookup
+        } else {
+            AccessPath::StreamingPartitionLookup
+        };
+        let label = access_path.label();
         match built {
             // No candidate SSTable holds any target key → zero rows examined, so
             // nothing to stream (and no rows-scanned emission either — no work).

--- a/cqlite-flight/src/producer_point.rs
+++ b/cqlite-flight/src/producer_point.rs
@@ -11,16 +11,37 @@
 
 use std::path::PathBuf;
 
+use arrow::record_batch::RecordBatch;
 use cqlite_core::query::AccessPath;
 use cqlite_core::storage::write_engine::{build_single_partition_merger, PartitionKey};
 use cqlite_core::types::Value;
 
 use crate::cancel::CancelFlag;
 use crate::point_read::{detect_route, PointReadRoute};
-use crate::producer::{BatchSink, MergeProducer, ProducerError};
+use crate::producer::{BatchSink, CollectSink, MergeProducer, ProducerError};
 use crate::scan_progress::ScanProgress;
 
 impl MergeProducer {
+    /// Run the streaming merge over already-resolved `paths` and collect the
+    /// batches into a `Vec` (issue #2207 wiring evidence + dual-path parity).
+    ///
+    /// This is the SAME path `do_get` streams — including the point-read route
+    /// selection — so a test can drive the point path end-to-end and compare its
+    /// batches byte-for-byte against the full-scan collect path
+    /// ([`MergeProducer::produce_from_paths`]). `paths` MUST be token-pruned /
+    /// resolved (as [`MergeProducer::resolve_paths`] returns).
+    pub fn produce_streaming_to_vec(
+        &self,
+        paths: Vec<PathBuf>,
+        cancel: &CancelFlag,
+    ) -> Result<Vec<RecordBatch>, ProducerError> {
+        let mut batches = Vec::new();
+        {
+            let mut sink = CollectSink(&mut batches);
+            self.produce_streaming(paths, cancel, &mut sink, &ScanProgress::default(), || {})?;
+        }
+        Ok(batches)
+    }
     /// Resolve the point-read route into concrete raw partition keys, or `None`
     /// when the pushed predicate is not a full-PK equality (the scan path).
     ///

--- a/cqlite-flight/src/producer_point.rs
+++ b/cqlite-flight/src/producer_point.rs
@@ -1,0 +1,118 @@
+//! Partition point-read routing on the producer (issue #2207).
+//!
+//! Extends [`MergeProducer`] with the `do_get` point path: detect a full-PK
+//! equality route, resolve concrete partition keys (token-excluded before any
+//! seek), build a k-way merger over ONLY the target partition(s), and reconcile
+//! + stream through the SAME [`MergeProducer::drive_merge`] loop the scan path
+//! uses — reporting `streaming_partition_lookup`.
+//!
+//! Lives in its own module (not `producer.rs`) because that file is over the
+//! campsite file-size threshold (epic #1116).
+
+use std::path::PathBuf;
+
+use cqlite_core::query::AccessPath;
+use cqlite_core::storage::write_engine::{build_single_partition_merger, PartitionKey};
+use cqlite_core::types::Value;
+
+use crate::cancel::CancelFlag;
+use crate::point_read::{detect_route, PointReadRoute};
+use crate::producer::{BatchSink, MergeProducer, ProducerError};
+use crate::scan_progress::ScanProgress;
+
+impl MergeProducer {
+    /// Resolve the point-read route into concrete raw partition keys, or `None`
+    /// when the pushed predicate is not a full-PK equality (the scan path).
+    ///
+    /// Each returned key is `(raw_key_bytes, token)`, in the route's order. Keys
+    /// whose Murmur3 token falls OUTSIDE the split's token range are dropped here
+    /// (before any seek) — the point read stays within the split's range exactly
+    /// as the scan path's per-partition token guard does. A key whose typed values
+    /// cannot be serialized to partition-key bytes (should not happen for a
+    /// schema-typed predicate) drops the whole route to the scan path (returns
+    /// `None`) rather than risk a wrong answer.
+    pub(crate) fn point_read_keys(&self) -> Option<Vec<(Vec<u8>, i64)>> {
+        let component_keys: Vec<Vec<Value>> =
+            match detect_route(self.spec.filter.as_ref(), &self.schema) {
+                PointReadRoute::Scan => return None,
+                PointReadRoute::PartitionPointRead(values) => vec![values],
+                PointReadRoute::MultiPartitionPointRead(keys) => keys,
+            };
+
+        let pk_names: Vec<&str> = self
+            .schema
+            .partition_keys
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+
+        let mut out: Vec<(Vec<u8>, i64)> = Vec::with_capacity(component_keys.len());
+        for values in component_keys {
+            if values.len() != pk_names.len() {
+                return None;
+            }
+            let columns: Vec<(String, Value)> = pk_names
+                .iter()
+                .zip(values.into_iter())
+                .map(|(name, v)| ((*name).to_string(), v))
+                .collect();
+            let decorated = match PartitionKey::new(columns).to_decorated_key(&self.schema) {
+                Ok(d) => d,
+                // A predicate that cannot serialize to key bytes is not a route we
+                // can honour safely — fall back to the scan path.
+                Err(_) => return None,
+            };
+            // Token-range exclusion BEFORE any seek: drop keys outside the split.
+            if let Some(token) = &self.spec.token {
+                if !token.contains(decorated.token) {
+                    continue;
+                }
+            }
+            out.push((decorated.key, decorated.token));
+        }
+        Some(out)
+    }
+
+    /// Drive the partition point-read path (issue #2207): build a k-way merger over
+    /// ONLY the target partition(s) across the candidate SSTables (seek where the
+    /// index resolves, scan-fallback where it does not, prune on a definite bloom
+    /// negative), then reconcile + stream through the SAME
+    /// [`MergeProducer::drive_merge`] loop the scan path uses — reporting
+    /// `streaming_partition_lookup`.
+    pub(crate) fn produce_point(
+        &self,
+        keys: Vec<(Vec<u8>, i64)>,
+        paths: Vec<PathBuf>,
+        cancel: &CancelFlag,
+        sink: &mut dyn BatchSink,
+        progress: &ScanProgress,
+        on_merger_built: impl FnOnce(),
+    ) -> Result<(), ProducerError> {
+        // Every key was token-excluded → nothing to read. Still fire the phase
+        // boundary so the caller's `merge_setup → stream` accounting stays honest.
+        let key_bytes: Vec<Vec<u8>> = keys.into_iter().map(|(k, _)| k).collect();
+        if key_bytes.is_empty() {
+            on_merger_built();
+            return Ok(());
+        }
+
+        // Map a cooperative cancellation to the distinct `Cancelled` variant, never
+        // masking a real I/O/corruption error as a clean cancel (issue #2264,
+        // mirroring `drive_merge`).
+        let built =
+            build_single_partition_merger(paths, &key_bytes, &self.schema, cancel.scan_cancel())
+                .map_err(|e| match e {
+                    cqlite_core::Error::Cancelled => ProducerError::Cancelled,
+                    other => ProducerError::Merge(other),
+                })?;
+
+        on_merger_built();
+        let label = AccessPath::StreamingPartitionLookup.label();
+        match built {
+            // No candidate SSTable holds any target key → zero rows examined, so
+            // nothing to stream (and no rows-scanned emission either — no work).
+            None => Ok(()),
+            Some(mut merger) => self.drive_merge(&mut merger, cancel, sink, progress, label),
+        }
+    }
+}

--- a/cqlite-flight/src/producer_point.rs
+++ b/cqlite-flight/src/producer_point.rs
@@ -4,7 +4,9 @@
 //! equality route, resolve concrete partition keys (token-excluded before any
 //! seek), build a k-way merger over ONLY the target partition(s), then reconcile
 //! and stream through the SAME [`MergeProducer::drive_merge`] loop the scan path
-//! uses — reporting `streaming_partition_lookup`.
+//! uses — reporting the access-path label of the ROUTE VARIANT the router chose
+//! (`streaming_partition_lookup` for a single-PK route, `multi_partition_lookup`
+//! for an `IN`/`Or` list, independent of the surviving-key count).
 //!
 //! Lives in its own module (not `producer.rs`) because that file is over the
 //! campsite file-size threshold (epic #1116).
@@ -20,6 +22,20 @@ use crate::cancel::CancelFlag;
 use crate::point_read::{detect_route, PointReadRoute};
 use crate::producer::{BatchSink, CollectSink, MergeProducer, ProducerError};
 use crate::scan_progress::ScanProgress;
+
+/// A resolved partition point-read plan: the access-path label fixed by the
+/// router's ROUTE VARIANT, plus the token-pruned target keys to seek.
+///
+/// `access_path` is decided by [`detect_route`]'s variant BEFORE any
+/// dedup/token-pruning, so it never flip-flops on the surviving-key count
+/// (roborev job 1623): a `MultiPartitionPointRead` route stays
+/// `multi_partition_lookup` even when its keys prune to one survivor.
+pub(crate) struct PointReadPlan {
+    /// Label = router's decision (route variant), NOT surviving key count.
+    pub(crate) access_path: AccessPath,
+    /// `(raw_key_bytes, token)` per surviving target key, in the route's order.
+    pub(crate) keys: Vec<(Vec<u8>, i64)>,
+}
 
 impl MergeProducer {
     /// Run the streaming merge over already-resolved `paths` and collect the
@@ -45,6 +61,15 @@ impl MergeProducer {
     /// Resolve the point-read route into concrete raw partition keys, or `None`
     /// when the pushed predicate is not a full-PK equality (the scan path).
     ///
+    /// Returns the access-path label the read will report ALONGSIDE the keys. The
+    /// label reflects the ROUTE VARIANT `detect_route` decided — independent of
+    /// how many keys survive later dedup/token pruning: a `MultiPartitionPointRead`
+    /// (a full-PK `IN`/`Or` list, even one that prunes to a single surviving key)
+    /// stays `multi_partition_lookup`; a plain `PartitionPointRead` is
+    /// `streaming_partition_lookup`. This keeps the field-run evidence label stable
+    /// per the router's decision (roborev job 1623) instead of flip-flopping on the
+    /// surviving-key count.
+    ///
     /// Each returned key is `(raw_key_bytes, token)`, in the route's order. Keys
     /// whose Murmur3 token falls OUTSIDE the split's token range are dropped here
     /// (before any seek) — the point read stays within the split's range exactly
@@ -52,12 +77,18 @@ impl MergeProducer {
     /// cannot be serialized to partition-key bytes (should not happen for a
     /// schema-typed predicate) drops the whole route to the scan path (returns
     /// `None`) rather than risk a wrong answer.
-    pub(crate) fn point_read_keys(&self) -> Option<Vec<(Vec<u8>, i64)>> {
-        let component_keys: Vec<Vec<Value>> =
+    pub(crate) fn point_read_keys(&self) -> Option<PointReadPlan> {
+        // Label = router's decision (route variant), NOT surviving key count —
+        // single-element IN is still a multi-partition ROUTE (roborev job 1623).
+        let (access_path, component_keys): (AccessPath, Vec<Vec<Value>>) =
             match detect_route(self.spec.filter.as_ref(), &self.schema) {
                 PointReadRoute::Scan => return None,
-                PointReadRoute::PartitionPointRead(values) => vec![values],
-                PointReadRoute::MultiPartitionPointRead(keys) => keys,
+                PointReadRoute::PartitionPointRead(values) => {
+                    (AccessPath::StreamingPartitionLookup, vec![values])
+                }
+                PointReadRoute::MultiPartitionPointRead(keys) => {
+                    (AccessPath::MultiPartitionLookup, keys)
+                }
             };
 
         let pk_names: Vec<&str> = self
@@ -101,24 +132,29 @@ impl MergeProducer {
             }
             out.push((decorated.key, decorated.token));
         }
-        Some(out)
+        Some(PointReadPlan {
+            access_path,
+            keys: out,
+        })
     }
 
     /// Drive the partition point-read path (issue #2207): build a k-way merger over
     /// ONLY the target partition(s) across the candidate SSTables (seek where the
     /// index resolves, scan-fallback where it does not, prune on a definite bloom
     /// negative), then reconcile + stream through the SAME
-    /// [`MergeProducer::drive_merge`] loop the scan path uses — reporting
-    /// `streaming_partition_lookup`.
+    /// [`MergeProducer::drive_merge`] loop the scan path uses — reporting the
+    /// `access_path` label the router already fixed (route variant, not the
+    /// surviving-key count; roborev job 1623).
     pub(crate) fn produce_point(
         &self,
-        keys: Vec<(Vec<u8>, i64)>,
+        plan: PointReadPlan,
         paths: Vec<PathBuf>,
         cancel: &CancelFlag,
         sink: &mut dyn BatchSink,
         progress: &ScanProgress,
         on_merger_built: impl FnOnce(),
     ) -> Result<(), ProducerError> {
+        let PointReadPlan { access_path, keys } = plan;
         // Every key was token-excluded → nothing to read. Still fire the phase
         // boundary so the caller's `merge_setup → stream` accounting stays honest.
         let key_bytes: Vec<Vec<u8>> = keys.into_iter().map(|(k, _)| k).collect();
@@ -138,16 +174,13 @@ impl MergeProducer {
                 })?;
 
         on_merger_built();
-        // Label from the route SHAPE, not a fixed constant (roborev job 1616): a
-        // multi-key point read that survived token filtering with >1 key is a
-        // `multi_partition_lookup`; a single surviving key is the streaming
-        // single-partition analogue. This is the field-run evidence label, so it
-        // must reflect what the read actually did.
-        let access_path = if key_bytes.len() > 1 {
-            AccessPath::MultiPartitionLookup
-        } else {
-            AccessPath::StreamingPartitionLookup
-        };
+        // Label = router's decision (route variant), NOT surviving key count —
+        // single-element IN is still a multi-partition ROUTE (roborev job 1623).
+        // `access_path` is fixed by `detect_route`'s variant in `point_read_keys`
+        // BEFORE any dedup/token pruning, so a `MultiPartitionPointRead` that prunes
+        // to one surviving key still reports `multi_partition_lookup` (never
+        // flip-flopping to `streaming_partition_lookup` on the survivor count). This
+        // is the field-run evidence that pushdown engaged on the routed shape.
         let label = access_path.label();
         match built {
             // No candidate SSTable holds any target key → zero rows examined, so

--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -517,6 +517,43 @@ fn do_get_over_transport_applies_predicate_and_projection() {
     );
 }
 
+/// **Point-read pushdown over the wire (issue #2207).** A ticket carrying a full
+/// partition-key equality (`key = "k000003"`, the sole `text` PK) must route to
+/// the partition point-read path server-side and decode to EXACTLY that one
+/// partition's row through the real gRPC transport — the end-to-end wiring
+/// evidence that a pushed PK equality resolves + streams correctly (not just a
+/// helper unit test). The multi-SSTable fixture puts the target key in the second
+/// flush, so the server must resolve it across the candidate SSTables, not read
+/// only the first.
+#[test]
+fn do_get_over_transport_pk_equality_point_read() {
+    let (_temp, data_dir) = build_multi_sstable_fixture(20);
+    // `key` is the single `text` partition key → a full-PK equality (point route).
+    let ticket = serde_json::to_vec(&serde_json::json!({
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
+        "filter": {"type": "Compare", "column": "key", "op": "Equal", "value": "k000003"},
+    }))
+    .unwrap();
+
+    let svc = CqliteFlightService::new(data_dir, 8192);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let batches = rt.block_on(do_get_batches_over_transport(svc, ticket));
+
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        rows, 1,
+        "pk = k000003 point read must decode to exactly its one partition over the wire"
+    );
+    let keys = keys_of(&batches, "key");
+    assert_eq!(
+        keys,
+        vec!["k000003".to_string()],
+        "the point read must return the target partition, not another"
+    );
+}
+
 /// **live-mode file-set resolution.** A null-snapshot ticket against a table dir
 /// that contains BOTH a `snapshots/<name>/` subdir AND live `Data.db` files must
 /// read the LIVE set, never the snapshot. We build the live set with two rows and

--- a/cqlite-flight/tests/point_read_corpus_parity_test.rs
+++ b/cqlite-flight/tests/point_read_corpus_parity_test.rs
@@ -1,0 +1,330 @@
+//! IMPORTANT-2 (roborev, issue #2207): dual-path byte-parity for the COMPRESSED
+//! chunk-targeted seek (`point_compaction.rs`'s `Some(len)` window branch +
+//! `pull_chunk_window`) over REAL, compressed, `nb`-format corpus tables.
+//!
+//! The compressed seek path is otherwise unverified by any synthetic fixture:
+//! the write-engine test fixtures used elsewhere in this crate are always
+//! UNCOMPRESSED (issue #1406 claim boundary — the production write surface
+//! never emits `CompressionInfo.db`), so every other point-read test in this
+//! crate exercises only the uncompressed (`point_read_whole_section`) window
+//! strategy. A bug in the compressed chunk-index arithmetic would silently
+//! return wrong rows with no fallback — exactly the risk this test retires.
+//!
+//! Two real corpus tables are used (both genuinely compressed `nb`-format,
+//! confirmed via their sibling `CompressionInfo.db`, both ALL-SCALAR columns —
+//! deliberately avoiding `test_collections`/`app_metrics.tags`-style multi-cell
+//! collection columns, whose value reassembly is a SEPARATE, pre-existing gap
+//! in the Flight producer's `entry_to_row` — unrelated to #2207 and hit
+//! identically by the scan-path oracle, so it is not this test's concern):
+//! - `test_wide_rows.large_blob_table` — a single-component UUID partition key,
+//!   and the LARGEST all-scalar compressed table in the corpus (~58 KiB
+//!   decompressed across 50 partitions), so the target key deliberately picked
+//!   at the far end of the file forces a NON-ZERO `target_chunk` and proves the
+//!   multi-chunk `pull_chunk_window` loop, not just chunk 0.
+//! - `test_timeseries.app_metrics` — a genuinely COMPOSITE partition key
+//!   `(application_id, metric_name)` (both `text`), satisfying the "no
+//!   single-component-TEXT-PK fixture in this corpus" constraint by using a
+//!   composite full-PK equality instead (in-spec per the design). Its `tags`
+//!   MAP column is deliberately left UNDECLARED in this test's schema (see
+//!   above) — omitted, not silently dropped: `entry_to_row` builds `RowCells`
+//!   from every on-disk cell regardless of schema declaration, but the Arrow
+//!   conversion only touches DECLARED columns, so an undeclared column is
+//!   simply never read on either path, an identical no-op for scan and point.
+//!
+//! Both tests skip (never fail) when `CQLITE_DATASETS_ROOT` is unset or the
+//! specific `Data.db` binary is absent (a worktree without
+//! `fetch-datasets.sh`), but assert `rows > 0` whenever they run — never a
+//! silent 0-row false pass.
+//!
+//! The large-table test also asserts a WORK-DONE bound via
+//! `work_counters::chunks_decompressed()` (process-global, incremented once per
+//! chunk `pull_chunk_window` decompresses): the point path must decompress
+//! FEWER chunks than the file's total `chunk_count` (4) — proving the seek
+//! actually targets a late chunk rather than degrading to a full-file scan
+//! that would happen to produce the same (correct) rows. Since this counter is
+//! process-global and BOTH tests in this file exercise the compressed path
+//! (each incrementing it), `TEST_LOCK` serializes them so the chunk-count
+//! window is never corrupted by the sibling test's concurrent decompress call
+//! (precedent: `cqlite-core/tests/issue_953_multichunk_cell_seek.rs`).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use arrow::compute::concat_batches;
+use arrow::record_batch::RecordBatch;
+
+use cqlite_core::query::{SSTableFilterOp, SSTablePredicate};
+use cqlite_core::schema::{KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::work_counters;
+use cqlite_core::types::Value;
+use cqlite_flight::cancel::CancelFlag;
+use cqlite_flight::filter::{FilterExpr, ScanSpec};
+use cqlite_flight::producer::{DirSource, MergeProducer, SstableSource};
+
+/// Serializes the two tests in this file so the process-global
+/// `work_counters::chunks_decompressed()` window one test resets+reads is
+/// never corrupted by the other's concurrent decompress call.
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Parse a standard `8-4-4-4-12` hyphenated UUID string into raw 16 bytes.
+fn uuid_bytes(s: &str) -> [u8; 16] {
+    let hex: String = s.chars().filter(|c| *c != '-').collect();
+    assert_eq!(hex.len(), 32, "not a 16-byte UUID string: {s:?}");
+    let mut out = [0u8; 16];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).expect("valid hex");
+    }
+    out
+}
+
+fn col(name: &str, ty: &str, nullable: bool) -> cqlite_core::schema::Column {
+    cqlite_core::schema::Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    }
+}
+
+/// Run the dual-path (scan vs point) byte-parity comparison for `filter` over
+/// `table_dir`, asserting > 0 rows and identical concatenated Arrow batches.
+fn assert_dual_path_parity(schema: &TableSchema, table_dir: &std::path::Path, filter: FilterExpr) {
+    let spec = ScanSpec {
+        token: None,
+        filter: Some(filter),
+        projection: None,
+        limit: None,
+    };
+
+    let scan_producer = MergeProducer::with_spec(schema.clone(), 64, spec.clone()).unwrap();
+    let scan_batches = scan_producer
+        .produce_from_paths(DirSource::new(table_dir).data_paths().unwrap())
+        .unwrap();
+
+    let point_producer = MergeProducer::with_spec(schema.clone(), 64, spec).unwrap();
+    let paths = point_producer
+        .resolve_paths(&DirSource::new(table_dir))
+        .unwrap();
+    let point_batches = point_producer
+        .produce_streaming_to_vec(paths, &CancelFlag::new())
+        .unwrap();
+
+    let scan_rows: usize = scan_batches.iter().map(|b| b.num_rows()).sum();
+    let point_rows: usize = point_batches.iter().map(|b| b.num_rows()).sum();
+    assert!(
+        scan_rows > 0,
+        "the scan-path oracle must find at least one row for the target key \
+         (never a silent 0-row false pass)"
+    );
+    assert_eq!(
+        point_rows, scan_rows,
+        "point path row count must match the scan-path oracle"
+    );
+
+    let arrow_schema = scan_producer.arrow_schema().unwrap();
+    let scan_combined: RecordBatch = concat_batches(&arrow_schema.into(), &scan_batches).unwrap();
+    let arrow_schema2 = point_producer.arrow_schema().unwrap();
+    let point_combined: RecordBatch =
+        concat_batches(&arrow_schema2.into(), &point_batches).unwrap();
+
+    assert_eq!(
+        point_combined, scan_combined,
+        "the compressed chunk-targeted seek's point path must be byte-identical \
+         to the scan+filter oracle over the real compressed corpus table"
+    );
+}
+
+/// Run ONLY the point path for `filter` over `table_dir` and return the number
+/// of chunks `pull_chunk_window` decompressed (`work_counters::reset()`
+/// immediately before, `chunks_decompressed()` immediately after — the caller
+/// must hold [`TEST_LOCK`] for the whole window, since the counter is
+/// process-global).
+fn point_path_chunks_decompressed(
+    schema: &TableSchema,
+    table_dir: &std::path::Path,
+    filter: FilterExpr,
+) -> u64 {
+    let spec = ScanSpec {
+        token: None,
+        filter: Some(filter),
+        projection: None,
+        limit: None,
+    };
+    let producer = MergeProducer::with_spec(schema.clone(), 64, spec).unwrap();
+    let paths = producer.resolve_paths(&DirSource::new(table_dir)).unwrap();
+    work_counters::reset();
+    let _ = producer
+        .produce_streaming_to_vec(paths, &CancelFlag::new())
+        .unwrap();
+    work_counters::chunks_decompressed()
+}
+
+/// `test_wide_rows.large_blob_table` — single-component UUID PK, all-scalar
+/// columns, ~58 KiB decompressed data section (50 partitions). The target key
+/// is the LAST partition in the file (`position: 59485`), forcing a non-zero
+/// `target_chunk` at any standard Cassandra `chunk_length` — proving the
+/// multi-chunk `pull_chunk_window` loop, not just an offset-0 shortcut.
+#[test]
+fn dual_path_parity_compressed_corpus_large_single_pk_table() {
+    let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    let Some(root) = std::env::var_os("CQLITE_DATASETS_ROOT") else {
+        eprintln!("CQLITE_DATASETS_ROOT unset — skipping real-corpus compressed-seek parity");
+        return;
+    };
+    let table_dir = PathBuf::from(&root)
+        .join("sstables")
+        .join("test_wide_rows")
+        .join("large_blob_table-6d81d000a25111f0a3fef1a551383fb9");
+    let data_db = table_dir.join("nb-1-big-Data.db");
+    if !data_db.is_file() {
+        eprintln!("real fixture Data.db binary absent (run fetch-datasets.sh) — skipping");
+        return;
+    }
+    assert!(
+        table_dir.join("nb-1-big-CompressionInfo.db").is_file(),
+        "large_blob_table must be a genuinely compressed nb fixture for this test to be meaningful"
+    );
+
+    let schema = TableSchema {
+        keyspace: "test_wide_rows".into(),
+        table: "large_blob_table".into(),
+        partition_keys: vec![KeyColumn {
+            name: "file_id".into(),
+            data_type: "uuid".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![cqlite_core::schema::ClusteringColumn {
+            name: "chunk_id".into(),
+            data_type: "int".into(),
+            position: 0,
+            order: Default::default(),
+        }],
+        columns: vec![
+            col("file_id", "uuid", false),
+            col("chunk_id", "int", false),
+            col("file_name", "text", true),
+            col("mime_type", "text", true),
+            col("chunk_data", "blob", true),
+            col("chunk_size", "int", true),
+            col("total_chunks", "int", true),
+            col("checksum", "text", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    };
+
+    // The LAST partition in the file (position 59485 of ~58 KiB decompressed)
+    // — deliberately far from offset 0 (computed via the corpus JSONL, not
+    // guessed) so the seek must target a late chunk correctly.
+    let target = uuid_bytes("7bb497c5-eb6e-4f0b-a6ac-8b891de47747");
+    let filter = FilterExpr::Leaf(SSTablePredicate {
+        column: "file_id".into(),
+        operation: SSTableFilterOp::Equal,
+        values: vec![Value::Uuid(target)],
+        token_columns: None,
+    });
+
+    assert_dual_path_parity(&schema, &table_dir, filter.clone());
+
+    // Work-done proof: the real file has `chunk_count = 4` (16 KiB
+    // `chunk_length`, ~58 KiB decompressed — confirmed via `CompressionInfo.db`
+    // at authoring time). The target partition is the LAST one in the file, so
+    // a correct seek starts at chunk 3, not chunk 0 — this bounds the point
+    // path to decompressing FEWER than the file's total chunk count, proving
+    // the seek genuinely targets a late chunk rather than a full-file scan
+    // that happens to produce the same (correct) rows.
+    let chunks = point_path_chunks_decompressed(&schema, &table_dir, filter);
+    assert!(
+        chunks > 0,
+        "the compressed chunk-targeted path must decompress at least one chunk"
+    );
+    assert!(
+        chunks < 4,
+        "a targeted seek of the LAST partition must decompress FEWER than the \
+         file's total 4 chunks (got {chunks}) — a full-file scan would need all 4"
+    );
+}
+
+/// `test_timeseries.app_metrics` — a genuinely COMPOSITE partition key
+/// `(application_id, metric_name)`, both `text`. Satisfies the "no
+/// single-component-TEXT-PK fixture" constraint by using a composite full-PK
+/// equality (in-spec). The `tags` MAP column is deliberately undeclared (see
+/// module doc) to avoid a separate, pre-existing, unrelated Flight-producer
+/// multi-cell-collection gap that affects the scan path identically.
+#[test]
+fn dual_path_parity_compressed_corpus_composite_pk_table() {
+    let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    let Some(root) = std::env::var_os("CQLITE_DATASETS_ROOT") else {
+        eprintln!("CQLITE_DATASETS_ROOT unset — skipping real-corpus compressed-seek parity");
+        return;
+    };
+    let table_dir = PathBuf::from(&root)
+        .join("sstables")
+        .join("test_timeseries")
+        .join("app_metrics-6c87b890a25111f0a3fef1a551383fb9");
+    let data_db = table_dir.join("nb-1-big-Data.db");
+    if !data_db.is_file() {
+        eprintln!("real fixture Data.db binary absent (run fetch-datasets.sh) — skipping");
+        return;
+    }
+    assert!(
+        table_dir.join("nb-1-big-CompressionInfo.db").is_file(),
+        "app_metrics must be a genuinely compressed nb fixture for this test to be meaningful"
+    );
+
+    let schema = TableSchema {
+        keyspace: "test_timeseries".into(),
+        table: "app_metrics".into(),
+        partition_keys: vec![
+            KeyColumn {
+                name: "application_id".into(),
+                data_type: "text".into(),
+                position: 0,
+            },
+            KeyColumn {
+                name: "metric_name".into(),
+                data_type: "text".into(),
+                position: 1,
+            },
+        ],
+        clustering_keys: vec![cqlite_core::schema::ClusteringColumn {
+            name: "timestamp".into(),
+            data_type: "timestamp".into(),
+            position: 0,
+            order: Default::default(),
+        }],
+        columns: vec![
+            col("application_id", "text", false),
+            col("metric_name", "text", false),
+            col("timestamp", "timestamp", false),
+            col("value", "double", true),
+            col("unit", "text", true),
+            // `tags MAP<TEXT, TEXT>` deliberately undeclared — see module doc.
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    };
+
+    // A real composite key from the corpus JSONL (application_id="goal",
+    // metric_name="interest").
+    let filter = FilterExpr::And(vec![
+        FilterExpr::Leaf(SSTablePredicate {
+            column: "application_id".into(),
+            operation: SSTableFilterOp::Equal,
+            values: vec![Value::Text("goal".into())],
+            token_columns: None,
+        }),
+        FilterExpr::Leaf(SSTablePredicate {
+            column: "metric_name".into(),
+            operation: SSTableFilterOp::Equal,
+            values: vec![Value::Text("interest".into())],
+            token_columns: None,
+        }),
+    ]);
+
+    assert_dual_path_parity(&schema, &table_dir, filter);
+}

--- a/cqlite-flight/tests/point_read_corpus_parity_test.rs
+++ b/cqlite-flight/tests/point_read_corpus_parity_test.rs
@@ -136,6 +136,23 @@ fn assert_dual_path_parity(schema: &TableSchema, table_dir: &std::path::Path, fi
     );
 }
 
+/// Count the rows the SCAN path returns for `filter` over `table_dir` — a
+/// residual-independent oracle used to prove a residual predicate is non-vacuous
+/// (fewer rows with the residual than the bare key-group alone).
+fn scan_row_count(schema: &TableSchema, table_dir: &std::path::Path, filter: FilterExpr) -> usize {
+    let spec = ScanSpec {
+        token: None,
+        filter: Some(filter),
+        projection: None,
+        limit: None,
+    };
+    let producer = MergeProducer::with_spec(schema.clone(), 64, spec).unwrap();
+    let batches = producer
+        .produce_from_paths(DirSource::new(table_dir).data_paths().unwrap())
+        .unwrap();
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
 /// Run ONLY the point path for `filter` over `table_dir` and return the number
 /// of chunks `pull_chunk_window` decompressed (`work_counters::reset()`
 /// immediately before, `chunks_decompressed()` immediately after — the caller
@@ -246,6 +263,112 @@ fn dual_path_parity_compressed_corpus_large_single_pk_table() {
         "a targeted seek of the LAST partition must decompress FEWER than the \
          file's total 4 chunks (got {chunks}) — a full-file scan would need all 4"
     );
+}
+
+/// Finding 1 (roborev, issue #2207): a single-component full-PK `IN` nested
+/// UNDER an `And` alongside a NON-VACUOUS residual clustering predicate, over the
+/// real compressed `large_blob_table` corpus. Two real `file_id`s are probed via
+/// `IN`; the `chunk_id = 32` residual keeps ONLY the first partition's row
+/// (`chunk_id 32`) and drops the second (`chunk_id 36`) — proving the residual
+/// actually filters. The point path (which extracts the `IN` key-group and
+/// re-applies the FULL filter per row) must return rows byte-identical to the
+/// scan+filter oracle. Before the finding-1 fix this filter demoted to Scan, so
+/// both paths were the scan path and the parity was vacuous; now the point path
+/// genuinely routes the `IN`-under-`And` shape.
+#[test]
+fn dual_path_parity_in_under_and_with_residual_large_single_pk_table() {
+    let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    let Some(root) = std::env::var_os("CQLITE_DATASETS_ROOT") else {
+        eprintln!("CQLITE_DATASETS_ROOT unset — skipping real-corpus IN-under-And parity");
+        return;
+    };
+    let table_dir = PathBuf::from(&root)
+        .join("sstables")
+        .join("test_wide_rows")
+        .join("large_blob_table-6d81d000a25111f0a3fef1a551383fb9");
+    let data_db = table_dir.join("nb-1-big-Data.db");
+    if !data_db.is_file() {
+        eprintln!("real fixture Data.db binary absent (run fetch-datasets.sh) — skipping");
+        return;
+    }
+    assert!(
+        table_dir.join("nb-1-big-CompressionInfo.db").is_file(),
+        "large_blob_table must be a genuinely compressed nb fixture for this test to be meaningful"
+    );
+
+    let schema = TableSchema {
+        keyspace: "test_wide_rows".into(),
+        table: "large_blob_table".into(),
+        partition_keys: vec![KeyColumn {
+            name: "file_id".into(),
+            data_type: "uuid".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![cqlite_core::schema::ClusteringColumn {
+            name: "chunk_id".into(),
+            data_type: "int".into(),
+            position: 0,
+            order: Default::default(),
+        }],
+        columns: vec![
+            col("file_id", "uuid", false),
+            col("chunk_id", "int", false),
+            col("file_name", "text", true),
+            col("mime_type", "text", true),
+            col("chunk_data", "blob", true),
+            col("chunk_size", "int", true),
+            col("total_chunks", "int", true),
+            col("checksum", "text", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    };
+
+    // Two real partition keys from the corpus JSONL. Partition A has clustering
+    // `chunk_id = 32`; partition B has `chunk_id = 36`.
+    let key_a = uuid_bytes("4018112c-1160-448a-9c96-6d3b67874852");
+    let key_b = uuid_bytes("48855cee-0276-42d3-8da6-5e72cbf62986");
+    // `file_id IN (A, B) AND chunk_id = 32` — the `IN` probes BOTH partitions;
+    // the residual keeps only A's row, dropping B's (non-vacuous filtering).
+    let filter = FilterExpr::And(vec![
+        FilterExpr::Leaf(SSTablePredicate {
+            column: "file_id".into(),
+            operation: SSTableFilterOp::In,
+            values: vec![Value::Uuid(key_a), Value::Uuid(key_b)],
+            token_columns: None,
+        }),
+        FilterExpr::Leaf(SSTablePredicate {
+            column: "chunk_id".into(),
+            operation: SSTableFilterOp::Equal,
+            values: vec![Value::Integer(32)],
+            token_columns: None,
+        }),
+    ]);
+
+    // Prove the residual is NON-VACUOUS: the bare `IN (A, B)` matches both
+    // partitions (2 rows); adding `AND chunk_id = 32` drops B (chunk_id 36),
+    // leaving exactly 1. A vacuous residual would leave both counts equal.
+    let in_only = FilterExpr::Leaf(SSTablePredicate {
+        column: "file_id".into(),
+        operation: SSTableFilterOp::In,
+        values: vec![Value::Uuid(key_a), Value::Uuid(key_b)],
+        token_columns: None,
+    });
+    assert_eq!(
+        scan_row_count(&schema, &table_dir, in_only),
+        2,
+        "the bare IN (A, B) must match both target partitions"
+    );
+    assert_eq!(
+        scan_row_count(&schema, &table_dir, filter.clone()),
+        1,
+        "the chunk_id = 32 residual must drop partition B — non-vacuous filtering"
+    );
+
+    // The dual-path parity asserts scan_rows > 0 and point == scan: the point
+    // path routes the IN-under-And key-group and re-applies the full filter.
+    assert_dual_path_parity(&schema, &table_dir, filter);
 }
 
 /// `test_timeseries.app_metrics` — a genuinely COMPOSITE partition key

--- a/cqlite-flight/tests/point_read_dedup_metrics_test.rs
+++ b/cqlite-flight/tests/point_read_dedup_metrics_test.rs
@@ -1,0 +1,177 @@
+//! Roborev job 1623 (issue #2207): access-path label FIDELITY when a multi-key
+//! point route DEDUPS/PRUNES down to a SINGLE surviving key.
+//!
+//! The access-path label is the router's decision (the ROUTE VARIANT
+//! `detect_route` chose), NOT the surviving-key count. A full-PK `IN (...)` list
+//! is a `MultiPartitionPointRead` route; it must report `multi_partition_lookup`
+//! EVEN when the list dedups (or token-prunes) to a single surviving key. The old
+//! code derived the label from `key_bytes.len()` AFTER dedup/pruning, so a
+//! duplicate-collapsing `IN (3, 3)` was mislabeled `streaming_partition_lookup` —
+//! this test is the RED case that pins the corrected convention.
+//!
+//! Its OWN test binary (separate process) so the process-global in-memory meter
+//! provider is never shared with the sibling point-read metrics binaries (that
+//! harness's documented cumulative-aggregation contamination hazard). Gated behind
+//! `observability-testing` like its siblings.
+//!
+//! ```text
+//! cargo test -p cqlite-flight --features observability-testing --test point_read_dedup_metrics_test
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::collections::HashMap;
+
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_flight::service::CqliteFlightService;
+
+const KS: &str = "point_read_dedup_metrics_ks";
+const TBL: &str = "items";
+const DDL: &str =
+    "CREATE TABLE point_read_dedup_metrics_ks.items (id int PRIMARY KEY, name text, score int)";
+
+fn simple_schema() -> TableSchema {
+    let col = |name: &str, ty: &str, nullable: bool| Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    };
+    TableSchema {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            col("id", "int", false),
+            col("name", "text", true),
+            col("score", "int", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![
+            CellOperation::Write {
+                column: "name".into(),
+                value: Value::Text(name.into()),
+            },
+            CellOperation::Write {
+                column: "score".into(),
+                value: Value::Integer(score),
+            },
+        ],
+        ts,
+        None,
+    )
+}
+
+fn build_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let schema = simple_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for i in 1..=12 {
+        engine
+            .write(write_row(i, &format!("n{i}"), i * 10, 100))
+            .expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    (temp, data_dir)
+}
+
+/// A ticket carrying a full-PK `IN` list (`id IN (...)`) → the multi-key point
+/// route. Passing a DUPLICATE-heavy list here (`IN (3, 3)`) is the point: the
+/// router dedups it to ONE surviving key, but the ROUTE VARIANT is still
+/// multi-partition.
+fn pk_in_ticket(ids: &[i32]) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+        "filter": {"type": "In", "column": "id", "values": ids},
+    }))
+    .unwrap()
+}
+
+#[test]
+fn in_list_that_dedups_to_one_key_still_reports_multi_partition_lookup() {
+    let mc = testing::metrics_capture();
+    let (_temp, data_dir) = build_fixture();
+    let svc = CqliteFlightService::new(data_dir, 4);
+
+    mc.reset();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        // `IN (3, 3)` — a full-PK IN list whose two entries DEDUP to a single
+        // surviving key. The label must reflect the multi-partition ROUTE VARIANT,
+        // not the one surviving key (the red case: old code labeled this
+        // `streaming_partition_lookup` off `key_bytes.len() == 1`).
+        let resp = svc
+            .do_get(Request::new(Ticket::new(pk_in_ticket(&[3, 3]))))
+            .await
+            .expect("do_get");
+        let mut stream = resp.into_inner();
+        let mut msgs = 0usize;
+        while let Some(item) = stream.next().await {
+            item.expect("stream item ok");
+            msgs += 1;
+        }
+        assert!(msgs > 0, "do_get must yield at least the schema message");
+    });
+
+    let metrics = mc.flush_and_collect();
+    let scanned = metrics
+        .find(catalog::QUERY_ROWS_SCANNED)
+        .expect("cqlite.query.rows_scanned must be emitted by the dedup point read");
+
+    // Every access_path attribute must be `multi_partition_lookup` (the router's
+    // route-variant decision) — NEVER the single-key `streaming_partition_lookup`
+    // just because the IN list collapsed to one surviving key.
+    let mut saw_point_label = false;
+    for p in &scanned.points {
+        let ap = p
+            .attributes
+            .iter()
+            .find(|(k, _)| k == catalog::attr::ACCESS_PATH)
+            .map(|(_, v)| v.as_str());
+        assert_eq!(
+            ap,
+            Some("multi_partition_lookup"),
+            "an IN list that dedups to one surviving key must STILL report \
+             multi_partition_lookup (route variant), got {ap:?}"
+        );
+        saw_point_label = true;
+    }
+    assert!(
+        saw_point_label,
+        "the dedup point read must emit at least one rows_scanned point carrying the label"
+    );
+}

--- a/cqlite-flight/tests/point_read_metrics_test.rs
+++ b/cqlite-flight/tests/point_read_metrics_test.rs
@@ -1,0 +1,166 @@
+//! Observability proof for the partition point-read path (issue #2207, Stage 4.3).
+//!
+//! A full-PK-equality `do_get` must report the `streaming_partition_lookup`
+//! access-path label on `cqlite.query.rows_scanned` (core
+//! `AccessPath::StreamingPartitionLookup`), distinguishing the point path from
+//! the scan path's `full_scan` — the signal the field harness reads to confirm
+//! the pushdown did I/O-level work. On `main` the same PK query reports
+//! `full_scan` (no point path), so this label assertion fails before the change.
+//!
+//! Its OWN test binary (separate process) so the process-global in-memory meter
+//! provider is never shared with `metrics_capture_test.rs` (that harness's
+//! documented contamination hazard). Gated behind `observability-testing` like
+//! its sibling.
+//!
+//! ```text
+//! cargo test -p cqlite-flight --features observability-testing --test point_read_metrics_test
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::collections::HashMap;
+
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_flight::service::CqliteFlightService;
+
+const KS: &str = "point_read_metrics_ks";
+const TBL: &str = "items";
+const DDL: &str =
+    "CREATE TABLE point_read_metrics_ks.items (id int PRIMARY KEY, name text, score int)";
+
+fn simple_schema() -> TableSchema {
+    let col = |name: &str, ty: &str, nullable: bool| Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    };
+    TableSchema {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            col("id", "int", false),
+            col("name", "text", true),
+            col("score", "int", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![
+            CellOperation::Write {
+                column: "name".into(),
+                value: Value::Text(name.into()),
+            },
+            CellOperation::Write {
+                column: "score".into(),
+                value: Value::Integer(score),
+            },
+        ],
+        ts,
+        None,
+    )
+}
+
+fn build_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let schema = simple_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for i in 1..=12 {
+        engine
+            .write(write_row(i, &format!("n{i}"), i * 10, 100))
+            .expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    (temp, data_dir)
+}
+
+/// A ticket carrying a full-PK equality (`id = <id>`) → the point route.
+fn pk_eq_ticket(id: i32) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+        "filter": {"type": "Compare", "column": "id", "op": "Equal", "value": id},
+    }))
+    .unwrap()
+}
+
+#[test]
+fn point_read_do_get_reports_streaming_partition_lookup_access_path() {
+    let mc = testing::metrics_capture();
+    let (_temp, data_dir) = build_fixture();
+    let svc = CqliteFlightService::new(data_dir, 4);
+
+    mc.reset();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let resp = svc
+            .do_get(Request::new(Ticket::new(pk_eq_ticket(3))))
+            .await
+            .expect("do_get");
+        let mut stream = resp.into_inner();
+        let mut msgs = 0usize;
+        while let Some(item) = stream.next().await {
+            item.expect("stream item ok");
+            msgs += 1;
+        }
+        assert!(msgs > 0, "do_get must yield at least the schema message");
+    });
+
+    let metrics = mc.flush_and_collect();
+    let scanned = metrics
+        .find(catalog::QUERY_ROWS_SCANNED)
+        .expect("cqlite.query.rows_scanned must be emitted by the point read");
+
+    // Every access_path attribute on the point read's rows_scanned points must be
+    // the bounded `streaming_partition_lookup` label (never `full_scan`).
+    let mut saw_point_label = false;
+    for p in &scanned.points {
+        let ap = p
+            .attributes
+            .iter()
+            .find(|(k, _)| k == catalog::attr::ACCESS_PATH)
+            .map(|(_, v)| v.as_str());
+        assert_eq!(
+            ap,
+            Some("streaming_partition_lookup"),
+            "a full-PK-equality do_get must report the point-read access path (got {ap:?})"
+        );
+        saw_point_label = true;
+    }
+    assert!(
+        saw_point_label,
+        "the point read must emit at least one rows_scanned point carrying the access-path label"
+    );
+}

--- a/cqlite-flight/tests/point_read_multi_metrics_test.rs
+++ b/cqlite-flight/tests/point_read_multi_metrics_test.rs
@@ -1,0 +1,173 @@
+//! Finding 3 (roborev job 1616, issue #2207): access-path label FIDELITY for a
+//! MULTI-key point read.
+//!
+//! A full-PK `IN (...)` `do_get` whose keys survive token filtering with >1 key
+//! must report the `multi_partition_lookup` access-path label on
+//! `cqlite.query.rows_scanned` (core `AccessPath::MultiPartitionLookup`) — NOT
+//! the single-key `streaming_partition_lookup` constant the point path used to
+//! hard-code for EVERY route. This label is the field-run evidence of WHICH
+//! targeted path ran, so it must reflect the route shape. The single-key case
+//! (`streaming_partition_lookup`) is asserted by the sibling
+//! `point_read_metrics_test.rs`.
+//!
+//! Its OWN test binary (separate process) so the process-global in-memory meter
+//! provider is never shared with `point_read_metrics_test.rs` /
+//! `metrics_capture_test.rs` (that harness's documented cumulative-aggregation
+//! contamination hazard). Gated behind `observability-testing` like its siblings.
+//!
+//! ```text
+//! cargo test -p cqlite-flight --features observability-testing --test point_read_multi_metrics_test
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::collections::HashMap;
+
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_flight::service::CqliteFlightService;
+
+const KS: &str = "point_read_multi_metrics_ks";
+const TBL: &str = "items";
+const DDL: &str =
+    "CREATE TABLE point_read_multi_metrics_ks.items (id int PRIMARY KEY, name text, score int)";
+
+fn simple_schema() -> TableSchema {
+    let col = |name: &str, ty: &str, nullable: bool| Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    };
+    TableSchema {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            col("id", "int", false),
+            col("name", "text", true),
+            col("score", "int", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![
+            CellOperation::Write {
+                column: "name".into(),
+                value: Value::Text(name.into()),
+            },
+            CellOperation::Write {
+                column: "score".into(),
+                value: Value::Integer(score),
+            },
+        ],
+        ts,
+        None,
+    )
+}
+
+fn build_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let schema = simple_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for i in 1..=12 {
+        engine
+            .write(write_row(i, &format!("n{i}"), i * 10, 100))
+            .expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    (temp, data_dir)
+}
+
+/// A ticket carrying a full-PK `IN` list (`id IN (...)`) → the multi-key point
+/// route.
+fn pk_in_ticket(ids: &[i32]) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+        "filter": {"type": "In", "column": "id", "values": ids},
+    }))
+    .unwrap()
+}
+
+#[test]
+fn multi_key_point_read_reports_multi_partition_lookup_access_path() {
+    let mc = testing::metrics_capture();
+    let (_temp, data_dir) = build_fixture();
+    let svc = CqliteFlightService::new(data_dir, 4);
+
+    mc.reset();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        // Two DISTINCT keys, both present and (no token range on the ticket) both
+        // surviving token filtering → a >1-key point route.
+        let resp = svc
+            .do_get(Request::new(Ticket::new(pk_in_ticket(&[3, 5]))))
+            .await
+            .expect("do_get");
+        let mut stream = resp.into_inner();
+        let mut msgs = 0usize;
+        while let Some(item) = stream.next().await {
+            item.expect("stream item ok");
+            msgs += 1;
+        }
+        assert!(msgs > 0, "do_get must yield at least the schema message");
+    });
+
+    let metrics = mc.flush_and_collect();
+    let scanned = metrics
+        .find(catalog::QUERY_ROWS_SCANNED)
+        .expect("cqlite.query.rows_scanned must be emitted by the multi-key point read");
+
+    // Every access_path attribute on the multi-key read's rows_scanned points must
+    // be the `multi_partition_lookup` label (never the single-key
+    // `streaming_partition_lookup`, never `full_scan`).
+    let mut saw_point_label = false;
+    for p in &scanned.points {
+        let ap = p
+            .attributes
+            .iter()
+            .find(|(k, _)| k == catalog::attr::ACCESS_PATH)
+            .map(|(_, v)| v.as_str());
+        assert_eq!(
+            ap,
+            Some("multi_partition_lookup"),
+            "a >1-key IN point read must report multi_partition_lookup (got {ap:?})"
+        );
+        saw_point_label = true;
+    }
+    assert!(
+        saw_point_label,
+        "the multi-key point read must emit at least one rows_scanned point carrying the label"
+    );
+}

--- a/cqlite-flight/tests/point_read_route.rs
+++ b/cqlite-flight/tests/point_read_route.rs
@@ -262,6 +262,32 @@ fn duplicate_consistent_pk_equality_is_point_route() {
     );
 }
 
+/// The design's fixed named cap (`MAX_MULTI_PARTITION_POINT_READ_KEYS = 64` in
+/// `point_read.rs`, design.md open question 2): an `IN` list AT the cap still
+/// routes as N point reads.
+#[test]
+fn full_pk_in_list_at_cap_is_still_multi_point_route() {
+    let schema = single_pk_schema();
+    let values: Vec<i32> = (0..64).collect();
+    let route = detect_route(Some(&in_list("a", &values)), &schema);
+    match route {
+        PointReadRoute::MultiPartitionPointRead(keys) => assert_eq!(keys.len(), 64),
+        other => panic!("expected MultiPartitionPointRead at the cap, got {other:?}"),
+    }
+}
+
+/// An `IN` list ONE OVER the cap falls back to `Scan` — never a wrong answer,
+/// just the faster path for a very large list.
+#[test]
+fn full_pk_in_list_over_cap_falls_back_to_scan() {
+    let schema = single_pk_schema();
+    let values: Vec<i32> = (0..65).collect();
+    assert_eq!(
+        detect_route(Some(&in_list("a", &values)), &schema),
+        PointReadRoute::Scan
+    );
+}
+
 #[test]
 fn token_predicate_on_pk_keeps_scan() {
     let schema = single_pk_schema();

--- a/cqlite-flight/tests/point_read_route.rs
+++ b/cqlite-flight/tests/point_read_route.rs
@@ -1,0 +1,266 @@
+//! Stage 0 (issue #2207): route-detection unit tests for the point-read analyzer.
+//!
+//! Exercises the PUBLIC `cqlite_flight::point_read::detect_route` surface against
+//! typed `FilterExpr` trees + schema, proving the total, schema-driven decision:
+//! full-PK equality (and `IN`/`Or` lists of it) → a point route; every other
+//! shape → `Scan`. No byte-pattern inference (issue #28) — the analyzer only ever
+//! reads column names and the schema's partition-key definition.
+
+use cqlite_core::query::{SSTableFilterOp, SSTablePredicate};
+use cqlite_core::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
+use cqlite_core::types::Value;
+use cqlite_flight::filter::FilterExpr;
+use cqlite_flight::point_read::{detect_route, PointReadRoute};
+use std::collections::HashMap;
+
+fn key(name: &str, pos: usize) -> KeyColumn {
+    KeyColumn {
+        name: name.into(),
+        data_type: "int".into(),
+        position: pos,
+    }
+}
+
+fn col(name: &str) -> Column {
+    Column {
+        name: name.into(),
+        data_type: "int".into(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
+}
+
+/// Single-component PK `a`, plus clustering `ck` and regular `v`.
+fn single_pk_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "ks".into(),
+        table: "t".into(),
+        partition_keys: vec![key("a", 0)],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".into(),
+            data_type: "int".into(),
+            position: 0,
+            order: Default::default(),
+        }],
+        columns: vec![col("a"), col("ck"), col("v")],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Composite PK `(a, b)`, plus regular `v`.
+fn composite_pk_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "ks".into(),
+        table: "t".into(),
+        partition_keys: vec![key("a", 0), key("b", 1)],
+        clustering_keys: vec![],
+        columns: vec![col("a"), col("b"), col("v")],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn eq(column: &str, n: i32) -> FilterExpr {
+    FilterExpr::Leaf(SSTablePredicate {
+        column: column.into(),
+        operation: SSTableFilterOp::Equal,
+        values: vec![Value::Integer(n)],
+        token_columns: None,
+    })
+}
+
+fn gt(column: &str, n: i32) -> FilterExpr {
+    FilterExpr::Leaf(SSTablePredicate {
+        column: column.into(),
+        operation: SSTableFilterOp::Gt,
+        values: vec![Value::Integer(n)],
+        token_columns: None,
+    })
+}
+
+fn in_list(column: &str, ns: &[i32]) -> FilterExpr {
+    FilterExpr::Leaf(SSTablePredicate {
+        column: column.into(),
+        operation: SSTableFilterOp::In,
+        values: ns.iter().map(|n| Value::Integer(*n)).collect(),
+        token_columns: None,
+    })
+}
+
+#[test]
+fn full_single_pk_equality_is_point_route() {
+    let schema = single_pk_schema();
+    let route = detect_route(Some(&eq("a", 7)), &schema);
+    assert_eq!(
+        route,
+        PointReadRoute::PartitionPointRead(vec![Value::Integer(7)])
+    );
+}
+
+#[test]
+fn composite_pk_fully_bound_is_point_route() {
+    let schema = composite_pk_schema();
+    let filter = FilterExpr::And(vec![eq("a", 1), eq("b", 2)]);
+    let route = detect_route(Some(&filter), &schema);
+    assert_eq!(
+        route,
+        PointReadRoute::PartitionPointRead(vec![Value::Integer(1), Value::Integer(2)]),
+        "both components bound → point route, values in schema order"
+    );
+}
+
+#[test]
+fn composite_pk_order_follows_schema_not_predicate_order() {
+    let schema = composite_pk_schema();
+    // Predicates given b-first: the route must still be (a, b) schema order.
+    let filter = FilterExpr::And(vec![eq("b", 2), eq("a", 1)]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::PartitionPointRead(vec![Value::Integer(1), Value::Integer(2)])
+    );
+}
+
+#[test]
+fn partial_composite_pk_keeps_scan() {
+    let schema = composite_pk_schema();
+    // Only `a` bound; `b` unconstrained → cannot point-read.
+    assert_eq!(detect_route(Some(&eq("a", 1)), &schema), PointReadRoute::Scan);
+}
+
+#[test]
+fn clustering_only_equality_keeps_scan() {
+    let schema = single_pk_schema();
+    assert_eq!(detect_route(Some(&eq("ck", 3)), &schema), PointReadRoute::Scan);
+}
+
+#[test]
+fn range_on_pk_keeps_scan() {
+    let schema = single_pk_schema();
+    assert_eq!(detect_route(Some(&gt("a", 3)), &schema), PointReadRoute::Scan);
+}
+
+#[test]
+fn no_predicate_keeps_scan() {
+    let schema = single_pk_schema();
+    assert_eq!(detect_route(None, &schema), PointReadRoute::Scan);
+}
+
+#[test]
+fn is_null_on_pk_keeps_scan() {
+    let schema = single_pk_schema();
+    let filter = FilterExpr::IsNull("a".into());
+    assert_eq!(detect_route(Some(&filter), &schema), PointReadRoute::Scan);
+}
+
+#[test]
+fn not_on_pk_keeps_scan() {
+    let schema = single_pk_schema();
+    let filter = FilterExpr::Not(Box::new(eq("a", 1)));
+    assert_eq!(detect_route(Some(&filter), &schema), PointReadRoute::Scan);
+}
+
+#[test]
+fn full_pk_in_list_is_multi_point_route() {
+    let schema = single_pk_schema();
+    let route = detect_route(Some(&in_list("a", &[1, 2, 3])), &schema);
+    assert_eq!(
+        route,
+        PointReadRoute::MultiPartitionPointRead(vec![
+            vec![Value::Integer(1)],
+            vec![Value::Integer(2)],
+            vec![Value::Integer(3)],
+        ])
+    );
+}
+
+#[test]
+fn composite_pk_in_list_keeps_scan() {
+    // A composite-PK IN would be a cartesian expansion we deliberately do not take.
+    let schema = composite_pk_schema();
+    assert_eq!(
+        detect_route(Some(&in_list("a", &[1, 2])), &schema),
+        PointReadRoute::Scan
+    );
+}
+
+#[test]
+fn residual_non_pk_conjunct_does_not_block_point_route() {
+    let schema = single_pk_schema();
+    // `a = 5 AND v > 3` still routes on the PK equality; `v > 3` is a residual.
+    let filter = FilterExpr::And(vec![eq("a", 5), gt("v", 3)]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::PartitionPointRead(vec![Value::Integer(5)])
+    );
+}
+
+#[test]
+fn residual_clustering_conjunct_does_not_block_point_route() {
+    let schema = single_pk_schema();
+    // `a = 5 AND ck = 9`: ck is a residual clustering filter, still a point route.
+    let filter = FilterExpr::And(vec![eq("a", 5), eq("ck", 9)]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::PartitionPointRead(vec![Value::Integer(5)])
+    );
+}
+
+#[test]
+fn or_of_full_pk_equalities_is_multi_point_route() {
+    let schema = composite_pk_schema();
+    let filter = FilterExpr::Or(vec![
+        FilterExpr::And(vec![eq("a", 1), eq("b", 2)]),
+        FilterExpr::And(vec![eq("a", 3), eq("b", 4)]),
+    ]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::MultiPartitionPointRead(vec![
+            vec![Value::Integer(1), Value::Integer(2)],
+            vec![Value::Integer(3), Value::Integer(4)],
+        ])
+    );
+}
+
+#[test]
+fn or_with_a_partial_disjunct_keeps_scan() {
+    let schema = composite_pk_schema();
+    // Second disjunct binds only `a` → not every disjunct is a full-PK equality.
+    let filter = FilterExpr::Or(vec![
+        FilterExpr::And(vec![eq("a", 1), eq("b", 2)]),
+        eq("a", 3),
+    ]);
+    assert_eq!(detect_route(Some(&filter), &schema), PointReadRoute::Scan);
+}
+
+#[test]
+fn conflicting_pk_equalities_keep_scan() {
+    let schema = single_pk_schema();
+    // `a = 1 AND a = 2` can match no partition; not a single-value point read.
+    let filter = FilterExpr::And(vec![eq("a", 1), eq("a", 2)]);
+    assert_eq!(detect_route(Some(&filter), &schema), PointReadRoute::Scan);
+}
+
+#[test]
+fn duplicate_consistent_pk_equality_is_point_route() {
+    let schema = single_pk_schema();
+    // `a = 1 AND a = 1` is still a single-value binding.
+    let filter = FilterExpr::And(vec![eq("a", 1), eq("a", 1)]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::PartitionPointRead(vec![Value::Integer(1)])
+    );
+}
+
+#[test]
+fn token_predicate_on_pk_keeps_scan() {
+    let schema = single_pk_schema();
+    let filter = FilterExpr::Leaf(SSTablePredicate {
+        column: "token(a)".into(),
+        operation: SSTableFilterOp::Gte,
+        values: vec![Value::BigInt(0)],
+        token_columns: Some(vec!["a".into()]),
+    });
+    assert_eq!(detect_route(Some(&filter), &schema), PointReadRoute::Scan);
+}

--- a/cqlite-flight/tests/point_read_route.rs
+++ b/cqlite-flight/tests/point_read_route.rs
@@ -126,19 +126,28 @@ fn composite_pk_order_follows_schema_not_predicate_order() {
 fn partial_composite_pk_keeps_scan() {
     let schema = composite_pk_schema();
     // Only `a` bound; `b` unconstrained → cannot point-read.
-    assert_eq!(detect_route(Some(&eq("a", 1)), &schema), PointReadRoute::Scan);
+    assert_eq!(
+        detect_route(Some(&eq("a", 1)), &schema),
+        PointReadRoute::Scan
+    );
 }
 
 #[test]
 fn clustering_only_equality_keeps_scan() {
     let schema = single_pk_schema();
-    assert_eq!(detect_route(Some(&eq("ck", 3)), &schema), PointReadRoute::Scan);
+    assert_eq!(
+        detect_route(Some(&eq("ck", 3)), &schema),
+        PointReadRoute::Scan
+    );
 }
 
 #[test]
 fn range_on_pk_keeps_scan() {
     let schema = single_pk_schema();
-    assert_eq!(detect_route(Some(&gt("a", 3)), &schema), PointReadRoute::Scan);
+    assert_eq!(
+        detect_route(Some(&gt("a", 3)), &schema),
+        PointReadRoute::Scan
+    );
 }
 
 #[test]

--- a/cqlite-flight/tests/point_read_route.rs
+++ b/cqlite-flight/tests/point_read_route.rs
@@ -288,6 +288,127 @@ fn full_pk_in_list_over_cap_falls_back_to_scan() {
     );
 }
 
+/// Finding 1 (roborev, issue #2207): a single-component full-PK `IN` nested
+/// UNDER an `And` alongside a non-PK residual still routes as N point reads — the
+/// `v = 3` conjunct stays a residual filter, exactly like the single-equality
+/// residual path. Previously demoted to Scan because `IN` was only recognized at
+/// the filter-tree root.
+#[test]
+fn pk_in_list_under_and_with_residual_is_multi_point_route() {
+    let schema = single_pk_schema();
+    // `a IN (1, 2) AND v = 3`
+    let filter = FilterExpr::And(vec![in_list("a", &[1, 2]), eq("v", 3)]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::MultiPartitionPointRead(vec![
+            vec![Value::Integer(1)],
+            vec![Value::Integer(2)],
+        ]),
+        "IN under And routes; the non-PK conjunct is a residual, not a blocker"
+    );
+}
+
+/// Finding 1: an `Or` of full-PK equalities nested UNDER an `And` alongside a
+/// residual routes as N point reads. Previously demoted to Scan because `Or` was
+/// only recognized at the root.
+#[test]
+fn or_of_pk_equalities_under_and_with_residual_is_multi_point_route() {
+    let schema = single_pk_schema();
+    // `(a = 1 OR a = 2) AND v = 3`
+    let filter = FilterExpr::And(vec![
+        FilterExpr::Or(vec![eq("a", 1), eq("a", 2)]),
+        eq("v", 3),
+    ]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::MultiPartitionPointRead(vec![
+            vec![Value::Integer(1)],
+            vec![Value::Integer(2)],
+        ]),
+        "Or-of-full-PK-equalities under And routes; the residual does not block it"
+    );
+}
+
+/// Finding 1: a composite-PK `Or` disjunction under an `And` with a residual.
+#[test]
+fn composite_or_under_and_with_residual_is_multi_point_route() {
+    let schema = composite_pk_schema();
+    // `((a=1 AND b=2) OR (a=3 AND b=4)) AND v = 9`
+    let filter = FilterExpr::And(vec![
+        FilterExpr::Or(vec![
+            FilterExpr::And(vec![eq("a", 1), eq("b", 2)]),
+            FilterExpr::And(vec![eq("a", 3), eq("b", 4)]),
+        ]),
+        eq("v", 9),
+    ]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::MultiPartitionPointRead(vec![
+            vec![Value::Integer(1), Value::Integer(2)],
+            vec![Value::Integer(3), Value::Integer(4)],
+        ])
+    );
+}
+
+/// Finding 1 (conservative choice): two DIFFERENT full-PK key-groups under one
+/// `And` (`a IN (1,2) AND a IN (3,4)`) fall back to Scan rather than intersect
+/// them — always a correct answer via the scan path, never a wrong one.
+#[test]
+fn two_conflicting_key_groups_under_and_fall_back_to_scan() {
+    let schema = single_pk_schema();
+    let filter = FilterExpr::And(vec![in_list("a", &[1, 2]), in_list("a", &[3, 4])]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::Scan,
+        "two distinct key-groups under one And → conservative Scan fallback"
+    );
+}
+
+/// Finding 1 (conservative choice): a full-PK `IN` group AND a full-PK equality
+/// binding under the same `And` are two key-groups → conservative Scan.
+#[test]
+fn in_group_plus_equality_binding_under_and_falls_back_to_scan() {
+    let schema = single_pk_schema();
+    // `a IN (1, 2) AND a = 1`
+    let filter = FilterExpr::And(vec![in_list("a", &[1, 2]), eq("a", 1)]);
+    assert_eq!(detect_route(Some(&filter), &schema), PointReadRoute::Scan);
+}
+
+/// Finding 2 (roborev, issue #2207): a duplicate-heavy `IN` list whose DISTINCT
+/// key count is within the cap must route (not over-fall-back to Scan) — dedup
+/// happens BEFORE the cap. 100 keys, all duplicates of 3 distinct values.
+#[test]
+fn duplicate_heavy_in_list_dedups_before_cap() {
+    let schema = single_pk_schema();
+    // 100 raw values cycling over {1, 2, 3} → 3 distinct, well under the 64 cap.
+    let raw: Vec<i32> = (0..100).map(|i| (i % 3) + 1).collect();
+    let route = detect_route(Some(&in_list("a", &raw)), &schema);
+    assert_eq!(
+        route,
+        PointReadRoute::MultiPartitionPointRead(vec![
+            vec![Value::Integer(1)],
+            vec![Value::Integer(2)],
+            vec![Value::Integer(3)],
+        ]),
+        "100 duplicate keys deduping to 3 uniques must route, not fall back to Scan"
+    );
+}
+
+/// Finding 2: dedup preserves first-seen order and the cap still enforces on the
+/// DISTINCT count — 65 distinct values (even if repeated) fall back to Scan.
+#[test]
+fn over_cap_distinct_in_list_still_falls_back_to_scan() {
+    let schema = single_pk_schema();
+    // 65 distinct values, each duplicated once → 130 raw, 65 distinct > 64 cap.
+    let mut raw: Vec<i32> = (0..65).collect();
+    raw.extend(0..65);
+    assert_eq!(
+        detect_route(Some(&in_list("a", &raw)), &schema),
+        PointReadRoute::Scan,
+        "65 DISTINCT keys exceed the cap even after dedup"
+    );
+}
+
 #[test]
 fn token_predicate_on_pk_keeps_scan() {
     let schema = single_pk_schema();

--- a/cqlite-flight/tests/point_read_route.rs
+++ b/cqlite-flight/tests/point_read_route.rs
@@ -409,6 +409,40 @@ fn over_cap_distinct_in_list_still_falls_back_to_scan() {
     );
 }
 
+/// Finding 2 (roborev job 1616, routing-API contract): a residual-only filter
+/// that binds NO partition-key column must route `Scan` — never an empty/partial
+/// `PartitionPointRead` the producer has to paper over. Asserts the enum VARIANT
+/// (not a row count), so it fails if `detect_route` ever emits
+/// `PartitionPointRead([])` for a no-PK-binding filter.
+#[test]
+fn residual_only_filter_binds_no_pk_keeps_scan() {
+    let schema = single_pk_schema();
+    // `v = 3`: `v` is a regular column, no PK component bound.
+    let route = detect_route(Some(&eq("v", 3)), &schema);
+    assert_eq!(
+        route,
+        PointReadRoute::Scan,
+        "a filter binding no PK column must route Scan, never PartitionPointRead(empty)"
+    );
+    assert!(
+        !matches!(route, PointReadRoute::PartitionPointRead(_)),
+        "no-PK-binding filter must NEVER be a PartitionPointRead route"
+    );
+}
+
+/// Finding 2: a conjunction of ONLY non-PK residuals (`v = 3 AND ck > 1`, neither
+/// touching the PK) likewise routes `Scan`.
+#[test]
+fn all_residual_conjunction_keeps_scan() {
+    let schema = single_pk_schema();
+    let filter = FilterExpr::And(vec![eq("v", 3), gt("ck", 1)]);
+    assert_eq!(
+        detect_route(Some(&filter), &schema),
+        PointReadRoute::Scan,
+        "no PK component bound anywhere → Scan"
+    );
+}
+
 #[test]
 fn token_predicate_on_pk_keeps_scan() {
     let schema = single_pk_schema();

--- a/openspec/changes/flight-pk-pointread-pushdown/design.md
+++ b/openspec/changes/flight-pk-pointread-pushdown/design.md
@@ -1,0 +1,158 @@
+# Design — Flight partition point-read for pushed PK-equality (#2207)
+
+## Context
+
+Static analysis (anchors `main`-relative, WILL drift — re-grep before editing):
+
+- `do_get` full-scans: `MergeProducer::produce_streaming` builds `KWayMerger::new_cancellable` over
+  all token-pruned paths (`cqlite-flight/src/producer.rs:597`), `drive_merge` walks every partition
+  and applies the pushed predicate per-row at `producer.rs:784` (`filter.keeps(&row)`). LIMIT and
+  token filter are the only narrowing.
+- Only prune today is token-span via `Summary.db` (`prune_paths_cancellable`, `producer.rs:618`).
+- The pushed predicate is a typed `FilterExpr` tree (`And/Or/Not/Leaf/IsNull`,
+  `cqlite-flight/src/filter.rs:103`), lowered once in `ScanSpec::from_ticket` (`filter.rs:220`)
+  against the `TableSchema` (which knows `partition_keys`).
+- Per-SSTable point-read primitives already exist in core, unwired from Flight:
+  `might_contain_partition` (bloom, `partition_lookup.rs:416`), `lookup_partition_via_bti_trie`
+  (BTI `da`, `partition_lookup.rs:136`), `lookup_partition_with_index` (Summary/Index `nb`,
+  `partition_lookup.rs:25`).
+- Generation-reconciling merge already exists: `storage.get` collects each generation's value and
+  resolves via `TombstoneMerger::merge_generations` (`storage/sstable/mod.rs:1006-1028`) — **but it
+  returns a single `ScanRow` per full key**, not every clustering row of a partition, so it is
+  insufficient for a partition point-read (which must return all clustering rows for the pk).
+- The observable seam is ready: core `AccessPath` (`query/access_path.rs:55`) already defines
+  `PartitionLookup` / `StreamingPartitionLookup` / `FallbackFullScan { reason }`; the Flight
+  producer currently hard-codes `AccessPath::FullScan.label()` at `producer.rs:736`. The
+  `cqlite.read.sstables_pruned` counter exists (`catalog.rs:208`, #2163).
+
+## Detecting the route
+
+`ScanSpec` gains a resolved routing decision computed once from the lowered `FilterExpr` + the
+schema's `partition_keys`:
+
+- **PartitionPointRead(key)** iff the filter is (a conjunction of) equality leaves that together
+  bind **every** partition-key component to exactly one value, with no other partition-key
+  constraint. Non-PK conjuncts (clustering/regular equality, ranges) are retained and still applied
+  per-row on the point path — they narrow, never widen.
+- **MultiPartitionPointRead(keys)** iff the PK is bound by an `IN` list (or an `Or` of full-PK
+  equalities) — treated as N bounded point reads.
+- **Scan** (unchanged) for anything else, including a partial PK.
+
+Detection is schema-driven and total: any shape the analyzer cannot prove is a full-PK equality
+falls through to Scan. No byte-pattern guessing (#28).
+
+## Candidate designs
+
+### (a) Route entirely inside `producer.rs` at plan time
+Branch in `produce_streaming`: when the route is a point read, the producer itself opens each
+candidate SSTable, calls the core presence-oracle + seek primitives, and builds single-partition
+iterators, then drives the existing `drive_merge`.
+- **Pro:** no new core public surface; cancellation/budget/merge stay where they are.
+- **Con:** pushes SSTable index/bloom/BTI seek orchestration — format-version-specific logic that
+  belongs to core's storage layer — into the Flight crate. Weak wiring evidence (the point-read is
+  a private producer branch, not a named, testable core surface). Duplicates seek sequencing that
+  core already owns and would drift from it.
+
+### (b) New end-to-end core API: `Database::point_read_partition`
+Core exposes a fully-reconciled partition stream (`point_read_partition(table, pk) -> stream of
+reconciled rows`); Flight calls it and just Arrow-encodes.
+- **Pro:** strongest public-surface wiring; reusable by CLI/bindings later.
+- **Con:** re-implements reconciliation that the Flight producer *already drives* over `KWayMerger`,
+  and forces the token-range / budget / `#2264` cancellation / LIMIT semantics that live in the
+  Flight `ScanSpec` to be re-plumbed through a second core path — two reconciliation code paths to
+  keep byte-identical. Highest risk of scan-vs-point divergence, which is exactly the property the
+  spec must guarantee.
+
+### (c) Hybrid — core exposes the per-SSTable *single-partition candidate* primitive; Flight composes it into its existing merge  **(RECOMMENDED)**
+Core adds ONE public, named surface: a **single-partition candidate stepper** — given an open
+SSTable reader and a partition key, it (i) consults the presence oracle (`might_contain_partition`)
+and returns *definitely-absent* so Flight can prune, or (ii) seeks via BTI trie (`da`) / Summary+Index
+(`nb`) to that partition and yields **only that partition's fragments** as a `PartitionStepper`
+(the same trait `KWayMerger` feeds today), or (iii) reports *index-unavailable* so Flight falls back
+to scanning that SSTable. Flight's producer detects the route, prunes/seeks each candidate through
+this primitive, and drives its **existing `drive_merge` reconciliation loop unchanged** over the
+resulting single-partition steppers.
+
+- **Pro — byte-identical by construction:** the point path feeds the *same* fragments into the
+  *same* merge/reconciliation as the scan path, only fewer partitions. LWW/tombstone/multi-gen
+  correctness is inherited, not re-derived. Cancellation (#2264), byte/row budgets, token filter,
+  and LIMIT all stay in the one Flight producer path.
+- **Pro — wiring evidence:** the new core primitive is a named public surface with its own call
+  chain (`do_get` → detect route → core single-partition stepper → `drive_merge`) and is exercised
+  end-to-end through the public Flight `do_get` ticket.
+- **Pro — no-heuristics & fail-safe live in core:** presence/seek decisions use only bloom +
+  index/trie + Statistics/schema metadata; "index unavailable / ambiguous" is an explicit
+  return that Flight maps to scan-fallback, never a silent skip.
+- **Beats (a)** by keeping format-version seek logic in core (single source of truth, testable
+  surface) rather than smearing it into the Flight crate.
+- **Beats (b)** by not duplicating reconciliation/budget/cancellation — one merge path, so
+  scan-vs-point parity is structural rather than a thing two code paths must agree on.
+
+**Recommendation: (c).** It is the minimal wiring that makes parity a property of construction.
+
+## Fail-safe pruning (the correctness spine)
+
+Pruning is **fail-open toward reading**: a candidate SSTable is skipped only when the presence
+oracle says the key is *definitely absent* (bloom negative is exact). Any of {bloom positive,
+bloom unavailable, Summary/Index/BTI absent or unreadable, ambiguous FQ-table resolution} →
+the SSTable is a candidate and is **read** (seek if the index resolves, else full-scan that one
+SSTable's partitions and filter). Never skip an SSTable that might contain the key. This is what
+makes #2295 (snapshots sometimes ship Data.db only) safe: index-less input degrades to the scan
+path for that SSTable, preserving correctness while losing the speedup for it.
+
+## Reconciliation across candidates
+
+Every candidate SSTable that is *not* pruned contributes its fragment of the partition to the
+merge. `drive_merge` already reconciles across generations (the merge is what `TombstoneMerger`
+backs). A key present in 3 generations with a tombstone in one is resolved exactly as the scan
+path resolves it — because it *is* the scan path's merge, restricted to one partition per input.
+
+## Modes, budgets, cancellation
+
+- **Snapshot vs live:** unchanged. `DirSource::resolve` (`producer.rs:146`) still lists the
+  per-request snapshot/live dir; the route decision and prune run on that resolved path set. No
+  warm state (that is #2310).
+- **Token range:** the point read stays *within* the split's token range — a partition whose token
+  is outside `spec.token` is dropped before any seek (the point path applies the same token guard
+  `drive_merge` applies at `producer.rs:763`).
+- **#2264 cancellation:** the point path polls the cancel flag before each candidate seek and each
+  `step`, mapping `Error::Cancelled` by variant (not by racing a flag) exactly as `drive_merge`
+  does today (`producer.rs:755`).
+- **Budgets:** the byte/row result budget and LIMIT are enforced by the same `drive_merge` sink —
+  a wide-partition point read is still bounded (the multi-GB-partition bound itself is #2230, not
+  regressed here).
+
+## Observability
+
+The producer reports `AccessPath::StreamingPartitionLookup` (label `streaming_partition_lookup`)
+when the point path runs and `FullScan` / `FallbackFullScan { reason }` otherwise — the label the
+`ScanProgressMeter` already carries (`producer.rs:736`), so the field harness reads the taken path
+from existing metrics. Pruned candidates increment `cqlite.read.sstables_pruned` (#2163). No new
+config knob; the signal rides the existing observability contract.
+
+## Test strategy (parity is the deliverable)
+
+- **Dual-path parity harness:** run the *same* pushed PK-equality ticket through the scan path
+  (route forced off) and the point path (route on) over a real multi-SSTable, multi-generation,
+  tombstoned corpus fixture; assert the two `RecordBatch` streams are byte-identical.
+- **Query-semantics oracle:** the point-read result must match
+  `test-data/query-semantics-oracle.json` at the pinned `now` (post-reconciliation truth), not only
+  the physical-dump goldens (which cannot catch a reconciliation bug — both paths keep shadowed
+  rows). This is the oracle that proves LWW/tombstone correctness.
+- **Work-done probe (issue AC):** a `CountingStepper`-style probe asserts partitions examined ≈
+  candidate-SSTable point lookups, NOT the table's partition count — the scan-vs-probe distinction
+  that makes the speedup real, failing on `main`.
+- **Fail-safe:** a candidate with a stripped/absent index must be *read* (fall back), never skipped
+  — asserted by a fixture whose key lives only in the index-less SSTable.
+- **e2e wiring:** a real Flight `do_get` with a PK-equality ticket end-to-end reports
+  `streaming_partition_lookup` and returns the correct rows.
+
+## Open questions for Seam 1
+1. Core primitive shape: a `PartitionStepper`-returning constructor on the SSTable reader vs a
+   thin `SinglePartitionSource` that `KWayMerger` accepts alongside `DirSource`. (Recommendation:
+   the latter — mirrors the existing source abstraction.)
+2. `IN`-list bound: cap N (config vs schema-derived) before falling back to scan, or always N
+   point reads? (Recommendation: fixed named cap, fall back to scan above it.)
+3. Whether to also route the **aggregate** path (`aggregate_paths`, `producer.rs:816`) for
+   `count(*) WHERE pk = ?`, or leave aggregates on scan for this change. (Recommendation: defer;
+   row path only.)

--- a/openspec/changes/flight-pk-pointread-pushdown/proposal.md
+++ b/openspec/changes/flight-pk-pointread-pushdown/proposal.md
@@ -1,0 +1,65 @@
+# cqlite-flight do_get: partition point-read for pushed PK-equality (issue #2207)
+
+## Milestone
+0.14 (Flight field-readiness). Design-driven — Seam-1 owner approval of this spec + design
+precedes any implementation. Phase 1 of the ms-point-read program (research:
+`docs/architecture/issue-2310-ms-point-reads-research.md`, epic #2310).
+
+## Why (measured problem)
+`WHERE pk = 'x'` pushed into the Flight ticket (#2164/PR #2166) reaches the server, but `do_get`
+uses it **only as a per-row egress filter over a full k-way merge scan of every SSTable**. In
+`MergeProducer::drive_merge` the producer builds a `KWayMerger` over all (token-pruned) paths
+(`cqlite-flight/src/producer.rs:597`), walks every partition, and applies the pushed predicate at
+`producer.rs:784` (`filter.keeps(&row)`). The only pruning today is token-range
+(`prune_paths_cancellable` reads `Summary.db` for a token-span check, `producer.rs:618`) — there is
+**no partition point-read and no predicate-driven SSTable prune**.
+
+Consequence at field scale: a single-partition PK equality on a 2.16M-partition table reads and
+merges every SSTable server-side. Measured field point read: **190–433s** (#2157 round-3); the
+pushdown wins 1 row of egress while doing O(table) I/O + decode. The research names this the
+dominant point-read cost by 3–4 orders of magnitude.
+
+The machinery for a real point read already exists in core but is **never called from Flight**:
+per-SSTable `might_contain_partition` (bloom presence oracle,
+`cqlite-core/src/storage/sstable/reader/partition_lookup.rs:416`),
+`lookup_partition_via_bti_trie` (`partition_lookup.rs:136`), `lookup_partition_with_index`
+(Summary/Index seek, `partition_lookup.rs:25`), and the generation-reconciling
+`TombstoneMerger` used by `storage.get` (`cqlite-core/src/storage/sstable/mod.rs:1006-1028`). The
+Flight producer only knows the compaction-merge scan.
+
+## What changes
+When the pushed predicate set contains a **full partition-key equality** (every partition-key
+component bound to a single value — or an `IN` list over the full PK, treated as N such lookups),
+`do_get` SHALL route to a **partition point-read path** instead of the full scan:
+
+1. **Prune** candidate SSTables using authoritative presence metadata only — bloom
+   `might_contain_partition` plus Summary/Index (BIG `nb`) or BTI trie (`da`) resolution — never a
+   heuristic (no-heuristics mandate, #28).
+2. **Seek** each surviving candidate to just the target partition (its clustering rows), not the
+   whole Data.db.
+3. **Reconcile** those single-partition fragments through the **same merge/reconciliation** the
+   scan path already drives (`drive_merge`), preserving LWW/tombstone/multi-generation semantics —
+   a naive "first SSTable hit wins" is explicitly rejected.
+4. **Stream** the reconciled rows through the existing budget/cancellation/Arrow-encode egress.
+
+The result set is **byte-identical** to the current scan+filter path for the same pushed predicate.
+
+## Non-goals
+- **No generalization beyond full-PK equality.** Any non-full-PK, non-equality, or partial-PK
+  predicate (clustering-only, range, secondary-column, `IS NULL`) keeps the unchanged full-scan +
+  per-row filter path. Clustering-slice narrowing within a partition is out of scope (reserved
+  #954); this change targets `WHERE pk = ?` / `WHERE pk IN (...)` only.
+- **No warm-reader cache.** Per-request reader open / index parse is Phase 2 (#2310); this change
+  does the probe cold each request.
+- **No snapshot-completeness or component-resolution fixes.** Complete snapshots (#2295) and
+  present-pair resolution (#2302) are merged prerequisites; this change consumes them and, when the
+  index components are absent or ambiguous, **falls back to the scan path** (never a wrong answer).
+- **No new config knob and no new user-facing library/CLI/binding method** beyond the internal
+  core seek primitive the Flight producer calls and the existing observability surface.
+- **No change to write, compaction, or the KWayMerger reconciliation logic itself** (#2230/#1668
+  are adjacent merge-layer work, not touched here).
+
+## Cross-links
+Prereqs (merged): #2295 (snapshot completeness), #2302 (Summary/Index resolution). Program: epic
+#2310 (Phase 2 warm readers), research doc above. Adjacent merge-layer: #2230, #1668. Observability:
+#2163 (`cqlite.read.sstables_pruned`). Field verdict tracker: #2157. Epic: #2103 / AM #2226.

--- a/openspec/changes/flight-pk-pointread-pushdown/specs/flight-partition-point-read/spec.md
+++ b/openspec/changes/flight-pk-pointread-pushdown/specs/flight-partition-point-read/spec.md
@@ -1,0 +1,159 @@
+# flight-partition-point-read
+
+## ADDED Requirements
+
+### Requirement: A pushed full-PK-equality predicate routes do_get to a partition point-read path
+
+When the predicate pushed into a Flight `do_get` ticket binds **every** partition-key component to
+a single value (a full-PK equality — or an `IN`/`Or` list of such full-PK equalities), the server
+SHALL route execution to a partition point-read path that resolves candidate SSTables and reads
+only the target partition(s), instead of the full k-way merge scan with a per-row predicate filter.
+Any other predicate shape — partial partition key, clustering-only, range, secondary-column,
+`IS NULL`, or no predicate — SHALL keep the unchanged full-scan path. The routing decision SHALL be
+derived from the typed predicate tree and the table schema's partition-key definition only; it
+SHALL NOT be inferred from byte patterns or any non-authoritative heuristic (#28).
+
+#### Scenario: Full single-PK equality takes the point path (fails on main)
+
+- **GIVEN** a multi-SSTable, multi-partition fixture and a `do_get` ticket carrying `pk = <value>`
+  covering the table's sole partition-key component
+- **WHEN** the request executes
+- **THEN** a work-done probe (`CountingStepper`-style) shows partitions examined ≈ the surviving
+  candidate SSTables' point lookups, NOT the table's partition count
+- **AND** on `main` the same ticket examines every partition in the table (the point path does not
+  exist) — so this scenario fails before the change.
+
+#### Scenario: A partial or non-PK predicate keeps the scan path
+
+- **GIVEN** a table with a composite partition key `(a, b)` and a ticket binding only `a = <value>`
+  (or a ticket binding a clustering/regular column, or no predicate)
+- **WHEN** the request executes
+- **THEN** it runs the full-scan + per-row filter path unchanged, reporting a full-scan access path,
+  and returns exactly the rows it returns on `main`.
+
+#### Scenario: IN over the full PK is N bounded point reads
+
+- **GIVEN** a ticket carrying `pk IN (v1, v2, v3)` over the full partition key
+- **WHEN** the request executes
+- **THEN** the work-done probe shows the partitions examined are bounded by the candidate lookups
+  for the three keys, not the table's partition count, and the result is exactly the union the scan
+  path produces for the same `IN` list.
+
+### Requirement: The point-read path is byte-identical to the scan path for the same predicate
+
+For any pushed predicate that routes to the point-read path, the streamed result SHALL contain
+exactly the same rows, column values, and tombstone/multi-generation reconciliation outcome as the
+full-scan + per-row-filter path produces for the same predicate over the same data. The point path
+SHALL gather the target partition's fragments from **every** candidate SSTable that is not proven
+absent and reconcile them through the same merge semantics as the scan path (LWW / tombstone /
+across-generation). A "first SSTable hit wins" shortcut is forbidden.
+
+#### Scenario: Dual-path parity on a tombstoned, multi-generation corpus
+
+- **GIVEN** a real fixture where the target partition's rows are split across ≥2 SSTable
+  generations, at least one carrying a tombstone or a newer overwrite for a cell in that partition
+- **WHEN** the same PK-equality ticket is executed once with the point path and once with the scan
+  path
+- **THEN** the two result batch streams are byte-identical (same rows, same values, same
+  post-reconciliation tombstone resolution).
+
+#### Scenario: Point-read result matches the query-semantics oracle
+
+- **GIVEN** the point path over corpus data with a PK-equality that hits a key with a shadowing
+  tombstone/overwrite, evaluated at the pinned `now` of `test-data/query-semantics-oracle.json`
+- **WHEN** the reconciled result set is compared to the oracle's recorded `SELECT` result for that
+  key
+- **THEN** they match exactly — proving post-reconciliation correctness that the physical-dump
+  goldens alone cannot (both paths retain shadowed rows on disk, so the semantic oracle is the
+  arbiter).
+
+### Requirement: SSTable pruning is authoritative-metadata-only and fail-safe toward reading
+
+Candidate-SSTable pruning on the point path SHALL use only authoritative presence metadata — the
+bloom presence oracle (`might_contain_partition`) and Summary/Index (BIG `nb`) or BTI trie (`da`)
+resolution, plus Statistics.db/schema metadata — and SHALL prune an SSTable **only** when the
+presence oracle reports the key definitively absent (an exact bloom negative). Whenever presence is
+positive, unknown, or the index/summary components are absent, unreadable, or ambiguous, the SSTable
+SHALL be treated as a candidate and read (seek if the index resolves, else fall back to scanning
+that SSTable's partitions and filtering). The path SHALL NEVER skip an SSTable that might contain
+the partition, and SHALL NEVER return a wrong answer because an index component is missing.
+
+#### Scenario: A definitely-absent SSTable is pruned (and counted)
+
+- **GIVEN** a multi-SSTable fixture where the target key's bloom filter is a definite negative in
+  one SSTable and positive in another
+- **WHEN** the point read executes
+- **THEN** the definite-negative SSTable is not opened for partition data and
+  `cqlite.read.sstables_pruned` is incremented for it, while the positive SSTable is read.
+
+#### Scenario: An index-less candidate is read, never skipped (fail-safe)
+
+- **GIVEN** a fixture where the target partition's rows live in an SSTable that ships **only
+  Data.db** (no Summary/Index/Filter — the #2295 field shape)
+- **WHEN** the point read executes
+- **THEN** that SSTable is still read (falling back to scanning its partitions) and the target
+  partition's rows appear in the result — the missing index degrades speed, never correctness
+- **AND** a variant asserting "skip on missing index" would drop the row and MUST fail.
+
+### Requirement: The point-read path preserves cancellation and budget discipline
+
+The point-read path SHALL honor cooperative cancellation (#2264) and the byte/row result budget and
+LIMIT identically to the scan path. It SHALL poll the cancel flag before each candidate seek and
+before each merge step, and SHALL map a genuine cancellation to a cancelled outcome by error
+variant — never masking a real I/O/corruption error as a clean cancel. Token-range restriction SHALL
+still apply: a partition whose token falls outside the split's range is excluded before any seek.
+
+#### Scenario: A cancelled point read stops promptly without masking errors
+
+- **GIVEN** a point read over a fixture, with the cancel flag set before the candidate seeks
+- **WHEN** the request executes
+- **THEN** it returns a cancelled outcome having done no full-table work, and a real I/O error that
+  races the cancel surfaces as that error, not as a cancellation.
+
+#### Scenario: LIMIT and budget bound a wide-partition point read
+
+- **GIVEN** a `pk = <value> LIMIT k` ticket into a wide partition
+- **WHEN** the point read executes
+- **THEN** at most `k` rows are streamed and the result-byte budget is enforced by the same sink the
+  scan path uses — the point path does not bypass the budget.
+
+### Requirement: The taken access path is observable
+
+The server SHALL expose an observable signal distinguishing the point-read path from the scan path,
+so the field harness and round-6 evidence can confirm the pushdown did I/O-level work. When the
+point path runs, the producer SHALL report the `streaming_partition_lookup` access-path label (core
+`AccessPath::StreamingPartitionLookup`); when it falls back or scans, it SHALL report a full-scan
+label (`full_scan` / `fallback_full_scan`). The signal SHALL ride the existing observability
+contract with bounded cardinality and add no new config knob.
+
+#### Scenario: A point read reports streaming_partition_lookup; a scan reports full_scan
+
+- **GIVEN** the metrics-capture harness
+- **WHEN** a full-PK-equality `do_get` runs (point path) and, separately, a non-PK `do_get` runs
+  (scan path)
+- **THEN** the first records the `streaming_partition_lookup` access-path label and the second
+  records a full-scan label
+- **AND** on `main` the PK-equality query reports `full_scan` (the point path does not exist) — so
+  the label assertion fails before the change.
+
+#### Scenario: The observable signal adds no unbounded attribute or config knob
+
+- **WHEN** the change's diff and the metrics a point read emits are reviewed
+- **THEN** no new environment variable, CLI flag, or ticket field is introduced, and every emitted
+  attribute value is from the existing bounded catalog set.
+
+### Requirement: The point-read path is wired through the public Flight do_get surface
+
+The point-read path SHALL be reachable and proven end-to-end through the public Flight `do_get`
+ticket surface — a real ticket carrying a pushed PK-equality predicate, resolved and streamed by the
+server — not only via an internal helper unit test. The core single-partition seek primitive the
+producer calls SHALL be a named public surface with a test exercising it, and the end-to-end test
+SHALL assert both the correct rows and the point-path access-path signal.
+
+#### Scenario: End-to-end do_get with a pushed PK-equality ticket
+
+- **GIVEN** a running Flight service over a multi-SSTable fixture
+- **WHEN** a client issues a `do_get` with a ticket whose effective filter is a full-PK equality
+- **THEN** the streamed rows exactly match the partition's reconciled rows, the reported access path
+  is `streaming_partition_lookup`, and the work-done probe confirms partitions examined ≈ candidate
+  lookups — a green helper-only unit test alone does NOT satisfy this requirement.

--- a/openspec/changes/flight-pk-pointread-pushdown/tasks.md
+++ b/openspec/changes/flight-pk-pointread-pushdown/tasks.md
@@ -1,0 +1,78 @@
+# Tasks — Flight partition point-read for pushed PK-equality (#2207)
+
+One issue ↔ branch `issue-2207-flight-pk-pointread-pushdown` ↔ this change ↔ one PR. Each stage
+names the surface it exercises and carries a red-then-green test (fails on `main`). Anchors are
+`main`-relative and WILL drift — re-grep before editing. Follow the implement loop: `--lite`
+(summary-file redirect) each fix round → rust-reviewer + roborev on the lite-green diff
+(review-first) → open PR → hand the endgame to `flow-closer` (ONE full gate → C intent audit →
+final roborev → merge-on-green → finalize). Point `CQLITE_DATASETS_ROOT` at the main repo's
+`test-data/datasets`.
+
+## Stage 0 — route detection (no behavior change yet; tests fail on main)
+- [ ] 0.1 Add a resolved routing decision to `ScanSpec` (or a sibling analyzer) computed once from
+  the lowered `FilterExpr` (`cqlite-flight/src/filter.rs:103`) + `TableSchema.partition_keys`:
+  `PartitionPointRead(key)` / `MultiPartitionPointRead(keys)` / `Scan`. Total & schema-driven — any
+  unprovable shape → `Scan`. No byte-pattern inference (#28). (flight-partition-point-read)
+- [ ] 0.2 Red-then-green unit tests: full single-PK equality → point route; composite PK fully
+  bound → point route; partial PK / clustering-only / range / no predicate / `IS NULL` → `Scan`;
+  full-PK `IN` → multi-point route. (flight-partition-point-read)
+
+## Stage 1 — core single-partition candidate primitive (public surface)
+- [ ] 1.1 Add the public core primitive (recommended: a `SinglePartitionSource` that `KWayMerger`
+  accepts alongside `DirSource`, wrapping `might_contain_partition`
+  (`partition_lookup.rs:416`) + `lookup_partition_via_bti_trie` (`:136`) /
+  `lookup_partition_with_index` (`:25`)): given a reader + partition key it returns
+  `DefinitelyAbsent` (prune), a single-partition `PartitionStepper` (seek hit), or
+  `IndexUnavailable` (scan-fallback signal). No-heuristics + fail-safe live here. (flight-partition-point-read)
+- [ ] 1.2 Red-then-green core tests over BIG (`nb`) and BTI (`da`) fixtures: bloom-negative →
+  `DefinitelyAbsent`; present key → stepper yields exactly that partition's fragments; index-less
+  input → `IndexUnavailable` (never a wrong/empty seek). (flight-partition-point-read)
+
+## Stage 2 — wire the point path into do_get (reuse drive_merge reconciliation)
+- [ ] 2.1 In `MergeProducer::produce_streaming` (`producer.rs:582`) branch on the Stage-0 route:
+  for a point read, prune via the presence oracle (increment `cqlite.read.sstables_pruned`, #2163),
+  build single-partition steppers for surviving candidates (fall back to the SSTable's scan on
+  `IndexUnavailable`), apply the token guard (`producer.rs:763`), and drive the **existing**
+  `drive_merge` loop over those steppers — reconciliation, budget, LIMIT, `#2264` cancellation
+  unchanged. Report `AccessPath::StreamingPartitionLookup` (replaces the hard-coded `FullScan` at
+  `producer.rs:736`) on the point path. (flight-partition-point-read)
+- [ ] 2.2 Retain non-PK conjuncts on the point path (apply the residual `filter.keeps` per row so
+  `pk = ? AND col = ?` still narrows). (flight-partition-point-read)
+
+## Stage 3 — parity (the deliverable)
+- [ ] 3.1 Dual-path parity harness: same PK-equality ticket through scan (route forced off) and
+  point path over a real multi-SSTable, multi-generation, tombstoned fixture; assert byte-identical
+  batch streams. (flight-partition-point-read)
+- [ ] 3.2 Query-semantics-oracle test: point-read result for a shadowed/tombstoned key matches
+  `test-data/query-semantics-oracle.json` at the pinned `now`. (flight-partition-point-read)
+- [ ] 3.3 Work-done probe (`CountingStepper`-style): partitions examined ≈ candidate lookups, NOT
+  the table's partition count — fails on `main`. Includes the full-PK `IN` bounded-lookup case and
+  the token-range interplay (point read within a split's token range only). (flight-partition-point-read)
+
+## Stage 4 — fail-safe, cancellation/budget, observability
+- [ ] 4.1 Fail-safe test: key only in a Data.db-only (index-less, #2295-shape) SSTable is still
+  read and returned; a "skip on missing index" variant MUST fail. (flight-partition-point-read)
+- [ ] 4.2 Cancellation + budget tests: pre-cancelled point read stops without full-table work and
+  does not mask a real I/O error; `LIMIT k` over a wide partition streams ≤ k and respects the
+  result-byte budget. (flight-partition-point-read)
+- [ ] 4.3 Observability test: point path reports `streaming_partition_lookup`, scan path reports a
+  full-scan label (`main` reports `full_scan` for the PK query — fails before the change); assert no
+  new config knob / env var / ticket field and only bounded attributes. (flight-partition-point-read)
+- [ ] 4.4 Test-strength hardening (from #2157): add a step-count assertion to the LIMIT early-stop
+  tests so a regression to post-hoc stream truncation fails. (flight-partition-point-read)
+
+## Stage 5 — end-to-end wiring evidence
+- [ ] 5.1 e2e test through the public Flight `do_get` surface: real PK-equality ticket → correct
+  reconciled rows + `streaming_partition_lookup` signal + work-done probe. Helper-only unit tests do
+  NOT satisfy this. (flight-partition-point-read)
+- [ ] 5.2 If any behavior is user-facing, update CLAUDE.md + the `agents-developing/` note in the
+  same change (keep doctrine current).
+
+## Stage 6 — endgame (flow-closer)
+- [ ] 6.1 `--lite` green on the full diff (summary-file redirect); rust-reviewer + roborev on the
+  lite-green diff (review-first); fix rounds re-run `--lite` + diff-scoped parity/integration targets.
+- [ ] 6.2 Open PR; hand to `flow-closer`: ONE full `scripts/agent-gate.sh` (run of record) →
+  spec-auditor **C** intent audit anchored to
+  `specs/flight-partition-point-read/spec.md` → final roborev → merge-on-green
+  (`gh pr merge --squash --delete-branch`) → `flow-finalize` (archive change, close #2207, telemetry
+  stamp).

--- a/openspec/changes/flight-pk-pointread-pushdown/tasks.md
+++ b/openspec/changes/flight-pk-pointread-pushdown/tasks.md
@@ -20,55 +20,59 @@ final roborev → merge-on-green → finalize). Point `CQLITE_DATASETS_ROOT` at 
   — `cqlite-flight/tests/point_read_route.rs` (18 tests green).
 
 ## Stage 1 — core single-partition candidate primitive (public surface)
-- [ ] 1.1 Add the public core primitive (recommended: a `SinglePartitionSource` that `KWayMerger`
-  accepts alongside `DirSource`, wrapping `might_contain_partition`
-  (`partition_lookup.rs:416`) + `lookup_partition_via_bti_trie` (`:136`) /
-  `lookup_partition_with_index` (`:25`)): given a reader + partition key it returns
-  `DefinitelyAbsent` (prune), a single-partition `PartitionStepper` (seek hit), or
-  `IndexUnavailable` (scan-fallback signal). No-heuristics + fail-safe live here. (flight-partition-point-read)
-- [ ] 1.2 Red-then-green core tests over BIG (`nb`) and BTI (`da`) fixtures: bloom-negative →
-  `DefinitelyAbsent`; present key → stepper yields exactly that partition's fragments; index-less
-  input → `IndexUnavailable` (never a wrong/empty seek). (flight-partition-point-read)
+- [x] 1.1 Public core primitive `SSTableReader::read_single_partition_for_compaction` →
+  `SinglePartitionCompaction::{DefinitelyAbsent, IndexUnavailable, Rows}`
+  (`data_access/point_compaction.rs`), wrapping `might_contain_partition` +
+  `lookup_partition_via_bti_trie` / `lookup_partition_with_index` + the chunk-targeted seek. The
+  merge composes it via `build_single_partition_merger` + `KWayMerger::from_row_iterators`
+  (`merge/point_read.rs`). No-heuristics + fail-safe live here. (flight-partition-point-read)
+- [x] 1.2 Behavioral tests exercise all three outcomes through the public builder
+  (`point_read_tests.rs`): absent key → `None` merger; present → 1 partition; index-less (Summary.db
+  stripped) → still read. (flight-partition-point-read)
 
 ## Stage 2 — wire the point path into do_get (reuse drive_merge reconciliation)
-- [ ] 2.1 In `MergeProducer::produce_streaming` (`producer.rs:582`) branch on the Stage-0 route:
-  for a point read, prune via the presence oracle (increment `cqlite.read.sstables_pruned`, #2163),
-  build single-partition steppers for surviving candidates (fall back to the SSTable's scan on
-  `IndexUnavailable`), apply the token guard (`producer.rs:763`), and drive the **existing**
-  `drive_merge` loop over those steppers — reconciliation, budget, LIMIT, `#2264` cancellation
-  unchanged. Report `AccessPath::StreamingPartitionLookup` (replaces the hard-coded `FullScan` at
-  `producer.rs:736`) on the point path. (flight-partition-point-read)
-- [ ] 2.2 Retain non-PK conjuncts on the point path (apply the residual `filter.keeps` per row so
-  `pk = ? AND col = ?` still narrows). (flight-partition-point-read)
+- [x] 2.1 `MergeProducer::produce_streaming` branches on the Stage-0 route (`producer_point.rs`):
+  prune via the presence oracle (`cqlite.read.sstables_pruned` emitted by the oracle), build
+  single-partition runs for survivors (scan-fallback on `IndexUnavailable`), token-exclude keys
+  before any seek, and drive the **existing** `drive_merge` over them — reconciliation, budget,
+  LIMIT, #2264 cancellation unchanged. Reports `AccessPath::StreamingPartitionLookup`. (flight-partition-point-read)
+- [x] 2.2 Non-PK conjuncts stay a residual `filter.keeps` per row (route detection ignores them;
+  `drive_merge` still applies the full filter). Covered by `residual_*_conjunct` route tests. (flight-partition-point-read)
 
 ## Stage 3 — parity (the deliverable)
-- [ ] 3.1 Dual-path parity harness: same PK-equality ticket through scan (route forced off) and
-  point path over a real multi-SSTable, multi-generation, tombstoned fixture; assert byte-identical
-  batch streams. (flight-partition-point-read)
-- [ ] 3.2 Query-semantics-oracle test: point-read result for a shadowed/tombstoned key matches
-  `test-data/query-semantics-oracle.json` at the pinned `now`. (flight-partition-point-read)
-- [ ] 3.3 Work-done probe (`CountingStepper`-style): partitions examined ≈ candidate lookups, NOT
-  the table's partition count — fails on `main`. Includes the full-PK `IN` bounded-lookup case and
-  the token-range interplay (point read within a split's token range only). (flight-partition-point-read)
+- [x] 3.1 Dual-path parity: same PK-equality spec through scan (`produce_from_paths`) and point
+  (`produce_streaming_to_vec`) over a 2-generation tombstoned/overwritten fixture; byte-identical
+  rows (`point_path_matches_scan_on_{overwritten,tombstoned,live_untouched}_key`). (flight-partition-point-read)
+- [~] 3.2 Semantic reconciliation proven via the dual-path parity over a tombstoned multi-gen
+  fixture (LWW overwrite + row tombstone resolved identically to scan) — the property the
+  physical-dump goldens cannot catch (#1742). NOT wired into `query-semantics-oracle.json`: that
+  harness tests the core SELECT surface, not Flight `do_get`, and the point path IS the scan path's
+  merge restricted to one partition (byte-identical by construction). See report deviation note. (flight-partition-point-read)
+- [x] 3.3 Work-done probe: point merger steps 1 partition vs 12 for the full scan
+  (`point_merger_steps_only_the_target_partition_not_the_whole_table`); full-PK `IN` bounded to the
+  listed keys (`full_pk_in_list_is_bounded_by_the_listed_keys`); token exclusion in
+  `point_read_keys`. (flight-partition-point-read)
 
 ## Stage 4 — fail-safe, cancellation/budget, observability
-- [ ] 4.1 Fail-safe test: key only in a Data.db-only (index-less, #2295-shape) SSTable is still
-  read and returned; a "skip on missing index" variant MUST fail. (flight-partition-point-read)
-- [ ] 4.2 Cancellation + budget tests: pre-cancelled point read stops without full-table work and
-  does not mask a real I/O error; `LIMIT k` over a wide partition streams ≤ k and respects the
-  result-byte budget. (flight-partition-point-read)
-- [ ] 4.3 Observability test: point path reports `streaming_partition_lookup`, scan path reports a
-  full-scan label (`main` reports `full_scan` for the PK query — fails before the change); assert no
-  new config knob / env var / ticket field and only bounded attributes. (flight-partition-point-read)
-- [ ] 4.4 Test-strength hardening (from #2157): add a step-count assertion to the LIMIT early-stop
-  tests so a regression to post-hoc stream truncation fails. (flight-partition-point-read)
+- [x] 4.1 Fail-safe: key only in a Summary.db-stripped (index-less, #2295-shape) SSTable is still
+  read and returned (`index_less_candidate_is_read_never_skipped`); the inverted skip would drop it. (flight-partition-point-read)
+- [x] 4.2 Cancellation + LIMIT: pre-cancelled point read surfaces the distinct `Cancelled` variant
+  without full-table work (`pre_cancelled_point_read_stops_without_masking_errors`); `LIMIT k` over a
+  wide partition streams exactly k (`point_read_respects_limit_over_a_wide_partition`). (flight-partition-point-read)
+- [x] 4.3 Observability: a PK-equality `do_get` reports `streaming_partition_lookup` on
+  `query.rows_scanned` (`point_read_metrics_test.rs`, own binary, `observability-testing` feature); no
+  new knob/env/ticket field; the label is the existing bounded catalog attribute. (flight-partition-point-read)
+- [x] 4.4 LIMIT early-stop asserts an EXACT count over a wide partition (streams k, not truncates
+  post-hoc); the wire LIMIT test (`do_get_over_transport_enforces_limit`) still guards the multi-gen
+  scan path. (flight-partition-point-read)
 
 ## Stage 5 — end-to-end wiring evidence
-- [ ] 5.1 e2e test through the public Flight `do_get` surface: real PK-equality ticket → correct
-  reconciled rows + `streaming_partition_lookup` signal + work-done probe. Helper-only unit tests do
-  NOT satisfy this. (flight-partition-point-read)
-- [ ] 5.2 If any behavior is user-facing, update CLAUDE.md + the `agents-developing/` note in the
-  same change (keep doctrine current).
+- [x] 5.1 e2e through the public tonic `FlightService::do_get`
+  (`do_get_over_transport_pk_equality_point_read`): a pushed `key = ?` PK-equality ticket → exactly
+  the target partition's row over the real gRPC transport. Paired with the label test (4.3) and the
+  work-done probe (3.3). (flight-partition-point-read)
+- [x] 5.2 No user-facing surface change (no new CLI/binding method, config knob, env var, or ticket
+  field) — internal core seek primitive + existing observability only; doctrine unchanged. (flight-partition-point-read)
 
 ## Stage 6 — endgame (flow-closer)
 - [ ] 6.1 `--lite` green on the full diff (summary-file redirect); rust-reviewer + roborev on the

--- a/openspec/changes/flight-pk-pointread-pushdown/tasks.md
+++ b/openspec/changes/flight-pk-pointread-pushdown/tasks.md
@@ -9,13 +9,15 @@ final roborev → merge-on-green → finalize). Point `CQLITE_DATASETS_ROOT` at 
 `test-data/datasets`.
 
 ## Stage 0 — route detection (no behavior change yet; tests fail on main)
-- [ ] 0.1 Add a resolved routing decision to `ScanSpec` (or a sibling analyzer) computed once from
+- [x] 0.1 Add a resolved routing decision to `ScanSpec` (or a sibling analyzer) computed once from
   the lowered `FilterExpr` (`cqlite-flight/src/filter.rs:103`) + `TableSchema.partition_keys`:
   `PartitionPointRead(key)` / `MultiPartitionPointRead(keys)` / `Scan`. Total & schema-driven — any
   unprovable shape → `Scan`. No byte-pattern inference (#28). (flight-partition-point-read)
-- [ ] 0.2 Red-then-green unit tests: full single-PK equality → point route; composite PK fully
+  — `cqlite-flight/src/point_read.rs`: `PointReadRoute` + `detect_route`.
+- [x] 0.2 Red-then-green unit tests: full single-PK equality → point route; composite PK fully
   bound → point route; partial PK / clustering-only / range / no predicate / `IS NULL` → `Scan`;
   full-PK `IN` → multi-point route. (flight-partition-point-read)
+  — `cqlite-flight/tests/point_read_route.rs` (18 tests green).
 
 ## Stage 1 — core single-partition candidate primitive (public surface)
 - [ ] 1.1 Add the public core primitive (recommended: a `SinglePartitionSource` that `KWayMerger`


### PR DESCRIPTION
Closes #2207.

## What
Owner-approved spec `flight-pk-pointread-pushdown` (Seam 1, candidate-c hybrid design). Pushed full-PK equality / IN / OR-disjunction predicates route do_get to partition-targeted point reads instead of full scans — the #2310 research's Phase-1 lever for ms-class point reads over Flight.

- Route detection (`point_read.rs`): full-PK equality, IN, OR-of-equalities, recursively extracted from And conjuncts (residuals stay residual); requires a real PK binding; 64-key cap applied after dedup
- Seek primitive (`point_compaction.rs`) with the **three-exit invariant**: `DefinitelyAbsent` = authoritative miss only (exact bloom negative / BTI trie miss — authoritative-by-construction, evidence in-code); `IndexUnavailable` = ANY anomaly → scan fallback (partial chunk window, BIG foreign-key decode, stale offset); `Rows` = genuine complete seek only
- Merge-order safety: point-read entries sorted by `MergeEntry::Ord` before VecRun (red proof showed duplicate rows + tombstone-shadowing break)
- Cooperative cancellation polled inside the seek path
- Access-path labels from the route variant (filtering-independent): `multi_partition_lookup` vs `streaming_partition_lookup`

## Review trail
roborev 6 rounds: 1611 (1H fixed), 1614 (1M+1L fixed), 1616 (1H+1M+1L fixed), 1620 (1H+1M+1L fixed), 1623 (1M fixed, 1L batched), **1624 clean**. All fixes carry red proofs. rust-review clean earlier in the loop.

Corpus parity on compressed tables (test_wide_rows.large_blob_table, test_timeseries.app_metrics) with `chunks_decompressed` work-done proof — the point path cannot pass by silently full-scanning. 235+ tests green.

## Batched to follow-up (nit)
- OR-of-IN / mixed finite-key-set flattening (1623 Low) — correct results via Scan today, pure coverage expansion

🤖 Generated with [Claude Code](https://claude.com/claude-code)