### PR TITLE
fix(#2300): propagate netty BOM pin to published trino-connector POM

### DIFF
--- a/.github/workflows/trino-connector-ci.yml
+++ b/.github/workflows/trino-connector-ci.yml
@@ -51,7 +51,9 @@ jobs:
 
       - name: Test
         working-directory: trino-connector
-        run: ./gradlew --no-daemon test
+        # verifyPublishedPomNettyPin asserts the netty pin survives into the
+        # published POM's <dependencies> for downstream Maven consumers (issue #2300).
+        run: ./gradlew --no-daemon test verifyPublishedPomNettyPin
 
       - name: Assemble plugin
         if: env.RUN_FULL == 'true'

--- a/.github/workflows/trino-publish.yml
+++ b/.github/workflows/trino-publish.yml
@@ -96,6 +96,16 @@ jobs:
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Pre-publish oracle (issue #2300): assert the netty pin survives into the
+      # published POM's <dependencies> BEFORE any publish path runs, so a drifted
+      # or BOM-only pin (which a downstream Maven consumer would resolve at netty
+      # 4.2.x, re-breaking arrow-19's allocator) can never reach Central.
+      - name: Verify published POM netty pin
+        working-directory: trino-connector
+        env:
+          PUBLISH_VERSION: ${{ steps.version.outputs.version }}
+        run: ./gradlew --no-daemon verifyPublishedPomNettyPin -Pversion="$PUBLISH_VERSION"
+
       # Dry run (manual workflow_dispatch with dry_run=true): publish only to the
       # local Maven repo. No Central upload and no signing/Central secrets needed,
       # so this path is independent of the guard step above.

--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -55,10 +55,45 @@ val jacksonVersion = "2.18.2"
 // real Trino runtime, which supplies netty 4.1.x.
 val nettyVersion = "4.1.130.Final"
 
+// The exact netty core modules flight-core:19.0.0 (+ grpc-netty:1.79.0) drag onto
+// the runtime classpath. Several are requested transitively at 4.2.9.Final and are
+// only forced down to the arrow-19-tested 4.1.130.Final by the enforced BOM below.
+// Declaring each one EXPLICITLY (issue #2300) is what makes the pin survive into the
+// published Maven POM's <dependencies> — see the note on the BOM import below.
+// Keep this list in lockstep with the resolved graph (verified by the
+// `verifyPublishedPomNettyPin` task and by ArrowJavaVersionPinTest). tcnative is
+// intentionally excluded: its native-binding train (2.0.74.Final) is versioned
+// independently of netty's 4.x line and is not part of the 4.1.x allocator pin.
+val nettyCoreModules = listOf(
+    "netty-buffer",
+    "netty-codec",
+    "netty-codec-http",
+    "netty-codec-http2",
+    "netty-codec-socks",
+    "netty-common",
+    "netty-handler",
+    "netty-handler-proxy",
+    "netty-resolver",
+    "netty-transport",
+    "netty-transport-native-unix-common",
+)
+
 dependencies {
     compileOnly("io.trino:trino-spi:$trinoVersion")
 
+    // The enforced BOM constrains THIS build's resolution and reaches downstream
+    // GRADLE consumers via the published `.module` metadata — but a Maven/Central
+    // consumer assembling the plugin reads only the POM. A BOM `import` lands in the
+    // POM's <dependencyManagement>, and Maven dependencyManagement is NOT transitive
+    // to downstream consumers, so it would NOT stop a Maven assembly from resolving
+    // flight-core's transitive netty at 4.2.x (re-exposing the arrow-19 allocator
+    // break; issue #2300). The explicit per-module declarations below land in the
+    // POM's <dependencies> with pinned versions, so a downstream Maven build resolves
+    // them at 4.1.130.Final by nearest-wins. Keep the BOM too: it keeps the in-build
+    // stack (and any future un-enumerated netty module) aligned and covers Gradle
+    // consumers.
     implementation(enforcedPlatform("io.netty:netty-bom:$nettyVersion"))
+    nettyCoreModules.forEach { implementation("io.netty:$it:$nettyVersion") }
     implementation("org.apache.arrow:flight-core:$arrowVersion")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
@@ -95,6 +130,76 @@ tasks.register<Sync>("installPlugin") {
 tasks.withType<Test>().configureEach {
     jvmArgs("--add-opens=java.base/java.nio=ALL-UNNAMED", "--enable-native-access=ALL-UNNAMED")
 }
+
+// --- Published-POM netty-pin oracle (issue #2300) ----------------------------
+// Assert the CONSUMER-FACING artifact: every netty core module appears in the
+// generated POM's <dependencies> at the pinned nettyVersion. This is the property
+// a downstream Maven assembly actually reads (the enforced BOM alone lands only in
+// <dependencyManagement>, which is not transitive to consumers). Reads the real
+// generated pom-default.xml — not build.gradle.kts — so it cannot pass vacuously.
+val verifyPublishedPomNettyPin by tasks.registering {
+    description = "Assert every netty core module is version-pinned in the published POM <dependencies> (#2300)."
+    group = "verification"
+    dependsOn("generatePomFileForMavenPublication")
+    val pomFile = layout.buildDirectory.file("publications/maven/pom-default.xml")
+    val expectedNettyVersion = nettyVersion
+    val expectedModules = nettyCoreModules
+    inputs.file(pomFile)
+    doLast {
+        val pom = pomFile.get().asFile
+        require(pom.isFile) { "generated POM not found at $pom" }
+        val doc = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+            .apply { isNamespaceAware = false }
+            .newDocumentBuilder()
+            .parse(pom)
+        // Only the top-level <project>/<dependencies> block (NOT <dependencyManagement>),
+        // since a downstream Maven consumer resolves versions from <dependencies>.
+        val depsNodes = (0 until doc.documentElement.childNodes.length)
+            .map { doc.documentElement.childNodes.item(it) }
+            .filter { it.nodeName == "dependencies" }
+        require(depsNodes.isNotEmpty()) { "published POM has no top-level <dependencies> block: $pom" }
+        val resolved = mutableMapOf<String, String>()
+        depsNodes.forEach { deps ->
+            val nodes = deps.childNodes
+            for (i in 0 until nodes.length) {
+                val dep = nodes.item(i)
+                if (dep.nodeName != "dependency") continue
+                var groupId: String? = null
+                var artifactId: String? = null
+                var version: String? = null
+                val fields = dep.childNodes
+                for (j in 0 until fields.length) {
+                    when (fields.item(j).nodeName) {
+                        "groupId" -> groupId = fields.item(j).textContent.trim()
+                        "artifactId" -> artifactId = fields.item(j).textContent.trim()
+                        "version" -> version = fields.item(j).textContent.trim()
+                    }
+                }
+                if (groupId != null && artifactId != null && version != null) {
+                    resolved["$groupId:$artifactId"] = version
+                }
+            }
+        }
+        val problems = expectedModules.mapNotNull { module ->
+            when (val v = resolved["io.netty:$module"]) {
+                null -> "missing io.netty:$module from published POM <dependencies>"
+                expectedNettyVersion -> null
+                else -> "io.netty:$module pinned to $v, expected $expectedNettyVersion"
+            }
+        }
+        require(problems.isEmpty()) {
+            "published POM netty pin drift (#2300):\n  " + problems.joinToString("\n  ")
+        }
+        logger.lifecycle(
+            "verifyPublishedPomNettyPin: ${expectedModules.size} netty modules pinned to " +
+                "$expectedNettyVersion in $pom",
+        )
+    }
+}
+
+// Run the POM oracle as part of `check` so `./gradlew check` (and any CI that runs
+// it) enforces the published pin. The connector PR lane runs it explicitly.
+tasks.named("check") { dependsOn(verifyPublishedPomNettyPin) }
 
 // --- Maven Central publication (Central Portal via vanniktech) ---------------
 // `publishToMavenLocal` / `publishToMavenCentral` produce main + sources +

--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -59,11 +59,14 @@ val nettyVersion = "4.1.130.Final"
 // the runtime classpath. Several are requested transitively at 4.2.9.Final and are
 // only forced down to the arrow-19-tested 4.1.130.Final by the enforced BOM below.
 // Declaring each one EXPLICITLY (issue #2300) is what makes the pin survive into the
-// published Maven POM's <dependencies> — see the note on the BOM import below.
-// Keep this list in lockstep with the resolved graph (verified by the
-// `verifyPublishedPomNettyPin` task and by ArrowJavaVersionPinTest). tcnative is
-// intentionally excluded: its native-binding train (2.0.74.Final) is versioned
-// independently of netty's 4.x line and is not part of the 4.1.x allocator pin.
+// published Maven POM's <dependencies> — see the note on the BOM import below. This
+// list is the DECLARATION site only: `verifyPublishedPomNettyPin` derives the
+// EXPECTED set from the RESOLVED runtime graph (not this list), so if flight-core /
+// grpc later drags an ADDITIONAL io.netty core module in via the BOM without a
+// matching entry here, that task FAILS CLOSED naming the un-declared module (it
+// would otherwise be silently omitted from the POM). tcnative is intentionally
+// excluded: its native-binding train (2.0.74.Final) is versioned independently of
+// netty's 4.x line and is not part of the 4.1.x allocator pin.
 val nettyCoreModules = listOf(
     "netty-buffer",
     "netty-codec",
@@ -132,33 +135,68 @@ tasks.withType<Test>().configureEach {
 }
 
 // --- Published-POM netty-pin oracle (issue #2300) ----------------------------
-// Assert the CONSUMER-FACING artifact: every netty core module appears in the
-// generated POM's <dependencies> at the pinned nettyVersion. This is the property
-// a downstream Maven assembly actually reads (the enforced BOM alone lands only in
-// <dependencyManagement>, which is not transitive to consumers). Reads the real
-// generated pom-default.xml — not build.gradle.kts — so it cannot pass vacuously.
+// Assert the CONSUMER-FACING artifact: every netty core module that ACTUALLY
+// RESOLVES onto the runtime classpath appears in the generated POM's <dependencies>
+// at the pinned nettyVersion. This is the property a downstream Maven assembly reads
+// (the enforced BOM alone lands only in <dependencyManagement>, which is not
+// transitive to consumers).
+//
+// The EXPECTED netty set is DERIVED FROM THE RESOLVED runtimeClasspath GRAPH, not
+// from the hand-maintained `nettyCoreModules` list — so this check cannot degrade to
+// a list-echo. If flight-core / grpc later drags an ADDITIONAL io.netty core module
+// in via the BOM without a matching explicit declaration, that module resolves onto
+// the classpath but is OMITTED from the POM, and this task FAILS CLOSED naming it.
+// The netty-tcnative-* native-binding train is versioned independently
+// (nettyTcnativeVersion) and is intentionally NOT declared in the POM, so it is
+// checked against its own expected version but not required in <dependencies>.
+// Reads the real generated pom-default.xml — not build.gradle.kts — so it cannot
+// pass vacuously.
+val nettyTcnativeVersion = "2.0.74.Final"
 val verifyPublishedPomNettyPin by tasks.registering {
-    description = "Assert every netty core module is version-pinned in the published POM <dependencies> (#2300)."
+    description =
+        "Assert every RESOLVED netty core module is version-pinned in the published POM <dependencies> (#2300)."
     group = "verification"
     dependsOn("generatePomFileForMavenPublication")
     val pomFile = layout.buildDirectory.file("publications/maven/pom-default.xml")
     val expectedNettyVersion = nettyVersion
-    val expectedModules = nettyCoreModules
+    val expectedTcnativeVersion = nettyTcnativeVersion
+    // Captured lazily at configuration time; the artifact set resolves at execution.
+    val runtimeArtifacts = configurations.runtimeClasspath.get().incoming.artifacts
     inputs.file(pomFile)
+    inputs.files(configurations.runtimeClasspath)
     doLast {
+        // 1. Derive the resolved io.netty artifact set (name -> version) from the
+        //    runtime dependency graph — the authoritative source of truth.
+        val resolvedNetty = runtimeArtifacts.artifacts.mapNotNull { art ->
+            val id = art.id.componentIdentifier
+            if (id is org.gradle.api.artifacts.component.ModuleComponentIdentifier && id.group == "io.netty") {
+                id.moduleIdentifier.name to id.version
+            } else {
+                null
+            }
+        }.toMap()
+        require(resolvedNetty.isNotEmpty()) {
+            "no io.netty artifacts resolved on runtimeClasspath — graph-derivation is broken (#2300)"
+        }
+        // The tcnative native-binding train is independently versioned and
+        // intentionally excluded from the POM pin; every other io.netty artifact is a
+        // core module that MUST land in the published POM.
+        val (tcnative, core) = resolvedNetty.entries.partition { it.key.startsWith("netty-tcnative") }
+
+        // 2. Parse the generated POM's top-level <dependencies> (NOT
+        //    <dependencyManagement> — a downstream Maven consumer resolves versions
+        //    from <dependencies>).
         val pom = pomFile.get().asFile
         require(pom.isFile) { "generated POM not found at $pom" }
         val doc = javax.xml.parsers.DocumentBuilderFactory.newInstance()
             .apply { isNamespaceAware = false }
             .newDocumentBuilder()
             .parse(pom)
-        // Only the top-level <project>/<dependencies> block (NOT <dependencyManagement>),
-        // since a downstream Maven consumer resolves versions from <dependencies>.
         val depsNodes = (0 until doc.documentElement.childNodes.length)
             .map { doc.documentElement.childNodes.item(it) }
             .filter { it.nodeName == "dependencies" }
         require(depsNodes.isNotEmpty()) { "published POM has no top-level <dependencies> block: $pom" }
-        val resolved = mutableMapOf<String, String>()
+        val pomDeps = mutableMapOf<String, String>()
         depsNodes.forEach { deps ->
             val nodes = deps.childNodes
             for (i in 0 until nodes.length) {
@@ -176,23 +214,50 @@ val verifyPublishedPomNettyPin by tasks.registering {
                     }
                 }
                 if (groupId != null && artifactId != null && version != null) {
-                    resolved["$groupId:$artifactId"] = version
+                    pomDeps["$groupId:$artifactId"] = version
                 }
             }
         }
-        val problems = expectedModules.mapNotNull { module ->
-            when (val v = resolved["io.netty:$module"]) {
-                null -> "missing io.netty:$module from published POM <dependencies>"
-                expectedNettyVersion -> null
-                else -> "io.netty:$module pinned to $v, expected $expectedNettyVersion"
+
+        val problems = mutableListOf<String>()
+        // 3a. Every RESOLVED core netty module must be declared in the POM at the pin.
+        //     An un-declared resolved module is the exact fail-closed case (#2300).
+        core.forEach { (module, resolvedVersion) ->
+            if (resolvedVersion != expectedNettyVersion) {
+                problems +=
+                    "resolved io.netty:$module at $resolvedVersion on runtimeClasspath, expected $expectedNettyVersion"
+            }
+            when (val pomVersion = pomDeps["io.netty:$module"]) {
+                null -> problems +=
+                    "resolved io.netty:$module is NOT declared in the published POM <dependencies> — it would be " +
+                        "omitted from downstream Maven resolution; add it to nettyCoreModules"
+                expectedNettyVersion -> {}
+                else -> problems += "io.netty:$module declared at $pomVersion in POM, expected $expectedNettyVersion"
+            }
+        }
+        // 3b. tcnative train: pinned to its own independent version, POM-excluded by design.
+        tcnative.forEach { (module, resolvedVersion) ->
+            if (resolvedVersion != expectedTcnativeVersion) {
+                problems +=
+                    "resolved io.netty:$module at $resolvedVersion, expected tcnative train $expectedTcnativeVersion"
+            }
+        }
+        // 3c. Reject a stale hand-list: any netty dep declared in the POM that no
+        //     longer resolves would ship a dead <dependency> to consumers.
+        pomDeps.keys.filter { it.startsWith("io.netty:") }.forEach { key ->
+            val module = key.removePrefix("io.netty:")
+            if (!resolvedNetty.containsKey(module)) {
+                problems +=
+                    "$key is declared in the POM but no longer resolves on runtimeClasspath (stale nettyCoreModules entry)"
             }
         }
         require(problems.isEmpty()) {
             "published POM netty pin drift (#2300):\n  " + problems.joinToString("\n  ")
         }
         logger.lifecycle(
-            "verifyPublishedPomNettyPin: ${expectedModules.size} netty modules pinned to " +
-                "$expectedNettyVersion in $pom",
+            "verifyPublishedPomNettyPin: ${core.size} resolved netty core modules pinned to " +
+                "$expectedNettyVersion in POM <dependencies>; ${tcnative.size} tcnative artifacts at " +
+                "$expectedTcnativeVersion (#2300)",
         )
     }
 }


### PR DESCRIPTION
Closes #2300.

## What
The netty enforcedPlatform BOM pin did not propagate to the POM Maven consumers resolve — BOM imports land in `<dependencyManagement>` (scope=import), which is NOT transitive to downstream Maven builds. flight-core 19.0.0 requests netty 4.2.9.Final, so a downstream assembly would resolve 4.2.x and re-break arrow-19's `NettyAllocationManager`.

- 11 netty core modules declared explicitly at **4.1.130.Final** → they land in the published POM's `<dependencies>` (nearest-wins for consumers); enforced BOM kept for in-build strictness + Gradle-metadata consumers
- `verifyPublishedPomNettyPin` Gradle task: **graph-derived** — walks the resolved runtimeClasspath for `io.netty` artifacts and asserts every resolved core module is declared AND pinned in the actual generated `pom-default.xml` (tcnative train checked against its own version); rejects stale POM entries; a new netty module appearing transitively FAILS the build
- Wired into `trino-connector-ci.yml` (test lane) + `trino-publish.yml` (pre-publish guard)

## Evidence
- BEFORE: generated POM had zero netty artifacts in `<dependencies>`; `./gradlew dependencies` showed flight-core requesting 4.2.9.Final
- AFTER: 11 modules pinned at 4.1.130.Final in `<dependencies>`; connector test suite (incl. ArrowJavaVersionPinTest) green
- Negative proofs: commenting out declarations → named failure; dropping one module from the list → graph-derived check fails naming `netty-resolver` (proves derivation, not list-echo)

## Review trail
roborev 1625 (1 Medium: allowlist brittleness → graph-derivation, fixed with negative proof) → **1626 clean**. Oracle-driven (published-POM shape is the oracle; no OpenSpec change).

No publish was run — verification strictly local; 0.13.5 publish remains owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)