### PR TITLE
fix(#2334): strict netty pins publish cleanly — platform() + strictly() replaces enforcedPlatform

### DIFF
--- a/.github/workflows/trino-connector-ci.yml
+++ b/.github/workflows/trino-connector-ci.yml
@@ -53,7 +53,14 @@ jobs:
         working-directory: trino-connector
         # verifyPublishedPomNettyPin asserts the netty pin survives into the
         # published POM's <dependencies> for downstream Maven consumers (issue #2300).
-        run: ./gradlew --no-daemon test verifyPublishedPomNettyPin
+        # generateMetadataFileForMavenPublication + generatePomFileForMavenPublication
+        # run Gradle 9.1's publication validation on EVERY PR (issue #2334): these tasks
+        # otherwise fire only on the publish path, so an enforced-platform / metadata
+        # leak (e.g. #2334's enforcedPlatform in a published variant) was invisible to
+        # CI until the release publish job failed. Running them here catches it pre-merge.
+        run: >-
+          ./gradlew --no-daemon test verifyPublishedPomNettyPin
+          generateMetadataFileForMavenPublication generatePomFileForMavenPublication
 
       - name: Assemble plugin
         if: env.RUN_FULL == 'true'

--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -84,19 +84,36 @@ val nettyCoreModules = listOf(
 dependencies {
     compileOnly("io.trino:trino-spi:$trinoVersion")
 
-    // The enforced BOM constrains THIS build's resolution and reaches downstream
-    // GRADLE consumers via the published `.module` metadata — but a Maven/Central
-    // consumer assembling the plugin reads only the POM. A BOM `import` lands in the
-    // POM's <dependencyManagement>, and Maven dependencyManagement is NOT transitive
-    // to downstream consumers, so it would NOT stop a Maven assembly from resolving
+    // The BOM constrains THIS build's resolution. A Maven/Central consumer assembling
+    // the plugin reads only the POM: a BOM `import` lands in the POM's
+    // <dependencyManagement>, and Maven dependencyManagement is NOT transitive to
+    // downstream consumers, so it would NOT stop a Maven assembly from resolving
     // flight-core's transitive netty at 4.2.x (re-exposing the arrow-19 allocator
     // break; issue #2300). The explicit per-module declarations below land in the
     // POM's <dependencies> with pinned versions, so a downstream Maven build resolves
-    // them at 4.1.130.Final by nearest-wins. Keep the BOM too: it keeps the in-build
-    // stack (and any future un-enumerated netty module) aligned and covers Gradle
-    // consumers.
-    implementation(enforcedPlatform("io.netty:netty-bom:$nettyVersion"))
-    nettyCoreModules.forEach { implementation("io.netty:$it:$nettyVersion") }
+    // them at 4.1.130.Final by nearest-wins — those 11 pins carry the version
+    // authority for both this build and the published component.
+    //
+    // Use a NON-enforced `platform(...)`, not `enforcedPlatform(...)` (issue #2334):
+    // Gradle 9.1's publication validation rejects an enforced platform in a published
+    // component's `runtimeElements` variant because forced constraints leak to Gradle
+    // consumers as hard overrides (`generateMetadataFileForMavenPublication` FAILS).
+    // Enforcement is redundant given the explicit pins; if `platform()` alone ever
+    // lets a transitive netty core module float in the RESOLVED graph, the
+    // graph-derived `verifyPublishedPomNettyPin` task below catches it — resolve any
+    // such drift with an explicit pin, never by re-enforcing.
+    implementation(platform("io.netty:netty-bom:$nettyVersion"))
+    // STRICT version pins (issue #2334): a plain `implementation("io.netty:x:4.1.130")`
+    // declaration LOSES to grpc-netty/flight-core's transitive 4.2.x under Gradle's
+    // highest-version-wins, so the graph floats to 4.2.9.Final (re-exposing the arrow-19
+    // allocator break). A `strictly` constraint forces the downgrade to 4.1.130.Final,
+    // wins against the transitive requests, and — unlike `enforcedPlatform` — publishes
+    // cleanly as the module's own strict requirement (no enforced-platform leak, so
+    // Gradle 9.1's publication validation passes). These 11 strict pins ARE the version
+    // authority for the build and the published component.
+    nettyCoreModules.forEach {
+        implementation("io.netty:$it") { version { strictly(nettyVersion) } }
+    }
     implementation("org.apache.arrow:flight-core:$arrowVersion")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 


### PR DESCRIPTION
Closes #2334.

## What
0.13.5 publish (run 29137448189) failed: Gradle 9.1's publication validation rejects components depending on an `enforcedPlatform` (forced deps leak to consumers). Fix:

- `enforcedPlatform(netty-bom)` → `platform(netty-bom)`
- The 11 netty pins from #2300 upgraded to `version { strictly("4.1.130.Final") }` — naive `platform()` alone let grpc/flight-core float netty to 4.2.9 via highest-wins, **caught by #2300's graph-derived verify exactly as designed**
- Published `module.json` now carries `{strictly, requires: 4.1.130.Final}` — Gradle-metadata consumers get the pins too (no enforced leak)
- CI gap closed: `trino-connector-ci.yml` now runs `generateMetadataFileForMavenPublication` + `generatePomFileForMavenPublication` on every PR (the validation only ran on the publish path before)

## Evidence
- BEFORE: `generateMetadataFileForMavenPublication FAILED` (enforced-platform leak on runtimeElements)
- AFTER: both generate tasks PASS; `verifyPublishedPomNettyPin` green (11 @ 4.1.130.Final + tcnative train); negative proof still fails-closed; full connector suite + ArrowJavaVersionPinTest green; runtime loads netty-common-4.1.130.Final

## Review
roborev 1627: clean first pass. Oracle-driven (publish validation is the oracle).

Blocks lifted: 0.13.5 publish → round 6 (#2286).

🤖 Generated with [Claude Code](https://claude.com/claude-code)