### PR TITLE
fix(#2324): reassemble multi-cell collections in flight producer read path

### DIFF
--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -78,6 +78,13 @@ mod model;
 #[cfg(feature = "write-support")]
 pub use model::{CellData, ComplexDeletion, MergeEntry, MergeStats, MergeStep, RowData};
 
+/// Read-shape reassembly of a merged row's per-column cells (issue #2324):
+/// collapse per-element collection cells back into a single `Value::List` /
+/// `Value::Set` / `Value::Map` for read consumers that key cells by column name.
+mod read_assembly;
+#[cfg(feature = "write-support")]
+pub use read_assembly::assemble_read_cells;
+
 /// Single-partition point-read merge builder (issue #2207): assembles a
 /// [`KWayMerger`] from per-candidate single-partition runs (seeked or key-filtered)
 /// for the Flight `do_get` point-read path. Byte-identical reconciliation to the

--- a/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
+++ b/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
@@ -25,15 +25,21 @@
 //!
 //! Non-scalar set elements / map keys (`frozen<tuple>`, `frozen<udt>`, nested
 //! `frozen<collection>`) are NOT decodable by the scalar `deserialize_value_bytes`
-//! codec. Rather than fail the whole query — a regression from the canonical
-//! single-generation reader, which serves such keys as opaque bytes — this mirrors
-//! that reader's `parse_cell_path_key` (complex_column.rs): the key/element is
-//! served as a raw `Value::Blob(cell_path)` and ordered by raw `cell_path` byte
-//! comparison. Within one SSTable the elements are already comparator-sorted on
-//! disk, and a byte-comparable serialized form makes byte order == comparator
-//! order; cross-SSTable ordering of a non-byte-comparable composite is a documented
-//! limitation shared with (and no worse than) the single-generation read path. The
-//! opaque/scalar choice branches on the DECLARED schema type only (no guessing).
+//! codec. Serving them as an opaque `Value::Blob(cell_path)` does not actually
+//! reassemble them — the typed Arrow builder downstream expects a tuple/struct
+//! value for the declared type and BREAKS on raw bytes, the same failure the
+//! whole-row error produced, one layer deeper. So this path FAILS CLOSED with a
+//! clear error naming the column + declared key/element type
+//! ([`composite_collection_unsupported`]); full composite key/element decode via
+//! the value deserializer is follow-up #2339. The opaque/scalar choice branches
+//! on the DECLARED schema type only (no guessing).
+//!
+//! Two decodable scalars — `inet` (`InetAddressType`) and `time` (`TimeType`) —
+//! route through the comparator's `compare_custom`, which orders by the FORMATTED
+//! string and can diverge from Cassandra's raw-byte order; their serialized
+//! `cell_path` form IS unsigned-byte-comparable, so they are ordered by raw
+//! `cell_path` bytes instead ([`comparator_orders_by_raw_cell_path_bytes`],
+//! roborev 1631/1632).
 //!
 //! Tombstone handling follows Cassandra SELECT semantics (issue #1742: SELECT
 //! output is the read-path authority), NOT the single-generation reader's
@@ -236,6 +242,12 @@ fn assemble_complex(
         // a single-generation `SELECT` returns (issue #2324, roborev 1628).
         CqlType::Set(inner) => {
             let elem_cmp = ComparatorType::from_cql_type(inner)?;
+            // A frozen tuple/UDT/nested-collection element cannot be materialized
+            // as a typed Arrow value here — fail closed (see #2339) rather than
+            // emit opaque bytes that break the typed builder downstream.
+            if key_is_opaque_composite(&elem_cmp) {
+                return Err(composite_collection_unsupported(name, "set element", inner));
+            }
             sort_elements_by_cell_path(&mut elements, &elem_cmp)?;
             Ok(Value::Set(elements.into_iter().map(|e| e.value).collect()))
         }
@@ -248,25 +260,23 @@ fn assemble_complex(
         }
         CqlType::Map(key_type, _) => {
             let key_cmp = ComparatorType::from_cql_type(key_type)?;
-            // Order entries by the declared key comparator (scalar) or raw
-            // cell_path bytes (opaque composite) so a map spanning multiple
-            // SSTables reconstructs in authoritative key order — done on the cells
-            // up front so the key is decoded once, at build time, below.
+            // A frozen tuple/UDT/nested-collection KEY cannot be materialized as a
+            // typed Arrow value here — fail closed (see #2339) rather than serve an
+            // opaque Value::Blob(cell_path) that breaks the typed builder one layer
+            // deeper. Only scalar-keyed maps reassemble on this path.
+            if key_is_opaque_composite(&key_cmp) {
+                return Err(composite_collection_unsupported(name, "map key", key_type));
+            }
+            // Order entries by the declared (scalar) key comparator so a map
+            // spanning multiple SSTables reconstructs in authoritative key order —
+            // done on the cells up front so the key is decoded once, at build time.
             sort_elements_by_cell_path(&mut elements, &key_cmp)?;
-            let opaque = key_is_opaque_composite(&key_cmp);
             let mut entries = Vec::with_capacity(elements.len());
             for e in elements {
-                // The map key is the element's cell_path (raw key bytes, no
-                // length prefix). Decode a scalar key with the declared type; an
-                // opaque composite key (frozen tuple/udt/collection) is served as
-                // raw Blob bytes, mirroring the single-generation reader (module
-                // doc + `key_is_opaque_composite`).
+                // The map key is the element's cell_path (raw key bytes, no length
+                // prefix), decoded with the declared scalar type.
                 let key_bytes = e.cell_path.as_deref().unwrap_or(&[]);
-                let key = if opaque {
-                    Value::Blob(key_bytes.to_vec())
-                } else {
-                    deserialize_value_bytes(key_bytes, &key_cmp)?
-                };
+                let key = deserialize_value_bytes(key_bytes, &key_cmp)?;
                 entries.push((key, e.value));
             }
             Ok(Value::Map(entries))
@@ -287,13 +297,18 @@ fn cell_path_bytes(cell: &CellData) -> &[u8] {
 /// Order collection cells by their `cell_path` (the element/key identity), in
 /// place, using the declared element/key comparator.
 ///
-/// A SCALAR comparator decodes each `cell_path` to a `Value` and orders by the
-/// type comparator (e.g. signed-int order != raw byte order), surfacing any
-/// genuine decode error (wrong-width scalar) rather than masking it. An OPAQUE
-/// COMPOSITE comparator (frozen tuple/udt/collection — undecodable by the scalar
-/// codec) orders by raw `cell_path` byte comparison, mirroring the
-/// single-generation reader's opaque-bytes handling (see module doc +
-/// [`key_is_opaque_composite`]).
+/// The Set/Map callers now FAIL CLOSED on an opaque composite element/key before
+/// reaching here (see [`composite_collection_unsupported`], #2339), so in practice
+/// `cmp` is always a scalar. Two scalar shapes:
+///   * A `inet`/`time` comparator ([`comparator_orders_by_raw_cell_path_bytes`])
+///     orders by raw `cell_path` byte comparison — its serialized form's unsigned
+///     byte order IS its Cassandra order, and routing it through the scalar
+///     `compare_custom` would mis-order it (roborev 1631/1632).
+///   * Any other scalar decodes each `cell_path` to a `Value` and orders by the
+///     type comparator (e.g. signed-int order != raw byte order), surfacing any
+///     genuine decode error (wrong-width scalar) rather than masking it.
+/// The [`key_is_opaque_composite`] arm is retained as defensive belt-and-suspenders
+/// (raw-byte order) should the helper ever be reused without the upstream guard.
 #[cfg(feature = "write-support")]
 fn sort_elements_by_cell_path(elements: &mut Vec<CellData>, cmp: &ComparatorType) -> Result<()> {
     if key_is_opaque_composite(cmp) || comparator_orders_by_raw_cell_path_bytes(cmp) {
@@ -353,21 +368,51 @@ fn key_is_opaque_composite(cmp: &ComparatorType) -> bool {
 /// comparison of the `cell_path`, so decoding to a `Value` and routing through
 /// the scalar type comparator would MIS-order it.
 ///
-/// `inet` (Cassandra `InetAddressType`) orders by unsigned comparison of the raw
-/// address bytes — but the scalar `Custom("inet")` comparator falls through to
-/// [`ComparatorType::compare`]'s `compare_custom`, which orders by the FORMATTED
-/// string (e.g. `"10.0.0.1" < "9.0.0.1"`), diverging from a single-generation
-/// `SELECT`. The element/key `cell_path` for an inet IS the raw address bytes, so
-/// ordering by `cell_path` bytes matches Cassandra exactly (roborev 1631, issue
-/// #2324). Branches on the DECLARED type only (no-heuristics, issue #28); recurses
-/// through `Frozen` defensively though inet is never frozen here.
+/// Every other scalar [`ComparatorType`] in this sort path has a proper
+/// [`ComparatorType::compare`] arm; the ONLY declared scalar types that fall
+/// through to `compare_custom` (which orders by the FORMATTED string, diverging
+/// from a single-generation `SELECT`) are the two decodable `Custom` names —
+/// `inet` and `time`. Both have a canonical serialized form whose UNSIGNED byte
+/// order equals their Cassandra order, and the element/key `cell_path` IS that
+/// serialized form, so ordering by raw `cell_path` bytes matches Cassandra
+/// exactly and closes the whole `compare_custom` class here (roborev 1631/1632):
+///   * `inet` (`InetAddressType`): raw address bytes, e.g. `9.0.0.1` = `[9,0,0,1]`
+///     precedes `10.0.0.1` = `[10,0,0,1]` (formatted-string order is the reverse).
+///   * `time` (`TimeType`): 8-byte big-endian nanoseconds-of-day, always
+///     non-negative, so byte order == numeric order (formatted `HH:MM:...` string
+///     order misorders, e.g. any value whose text form sorts against its magnitude).
+/// Branches on the DECLARED type only (no-heuristics, issue #28); recurses through
+/// `Frozen` defensively though neither inet nor time is ever frozen here.
 #[cfg(feature = "write-support")]
 fn comparator_orders_by_raw_cell_path_bytes(cmp: &ComparatorType) -> bool {
     match cmp {
         ComparatorType::Frozen(inner) => comparator_orders_by_raw_cell_path_bytes(inner),
-        ComparatorType::Custom(name) => name == "inet",
+        ComparatorType::Custom(name) => name == "inet" || name == "time",
         _ => false,
     }
+}
+
+/// Fail closed when a collection's key/element is an OPAQUE COMPOSITE — a frozen
+/// tuple / UDT / nested collection the scalar codec cannot decode — on the
+/// merged-read (Flight) assembly path.
+///
+/// Serving such a key/element as an opaque `Value::Blob(cell_path)` (the round-2
+/// route) does not actually reassemble it: the typed Arrow builder downstream
+/// expects a tuple/struct value for the declared type and BREAKS on raw bytes —
+/// the same failure the pre-#2324 whole-row error produced, only one layer
+/// deeper. A clear error naming the column + declared key/element type is
+/// strictly better than either, and composite decode was NEVER functional on
+/// this path (it collapsed to a scalar and errored in Arrow conversion). Full
+/// composite key/element decode via the value deserializer is follow-up #2339
+/// (roborev 1632).
+#[cfg(feature = "write-support")]
+fn composite_collection_unsupported(column: &str, kind: &str, declared: &CqlType) -> Error {
+    Error::unsupported_format(format!(
+        "column '{column}': composite-keyed collection decode unsupported on this \
+         path — {kind} type {declared:?} is a frozen tuple/UDT/nested collection the \
+         merged-read assembler cannot materialize as a typed Arrow value; failing \
+         closed rather than emitting opaque bytes (roborev 1632, follow-up #2339)"
+    ))
 }
 
 /// Sort `items` by the first tuple element with the fallible [`ComparatorType`],
@@ -450,9 +495,11 @@ mod tests {
                 // Blob + raw-byte-order path.
                 col("fset", "set<frozen<addr_type>>"),
                 col("ftk", "map<frozen<tuple<int, text>>, bigint>"),
-                // inet element ordering (roborev 1631): InetAddressType orders by
-                // unsigned address bytes, NOT the formatted-string order.
+                // inet/time element ordering (roborev 1631/1632): InetAddressType /
+                // TimeType order by raw serialized bytes, NOT the formatted-string
+                // order the scalar `compare_custom` would use.
                 col("iset", "set<inet>"),
+                col("tset", "set<time>"),
             ],
             comments: HashMap::new(),
             dropped_columns: HashMap::new(),
@@ -577,6 +624,34 @@ mod tests {
     }
 
     #[test]
+    fn set_of_time_orders_by_raw_bytes_not_formatted_string() {
+        // set<time>: cell_path is the 8-byte big-endian nanoseconds-of-day; Cassandra's
+        // TimeType orders by that raw long (non-negative → byte order == numeric order).
+        // The scalar Custom("time") comparator instead falls to compare_custom's
+        // FORMATTED-string order ("TIME(HH:MM:SS.nnn)"), which — because the hours
+        // field is only zero-padded to two digits — diverges from numeric order once
+        // the hours magnitude changes digit-width. 10h vs 100h: the string
+        // "TIME(100:..." sorts BEFORE "TIME(10:..." ('0' < ':'), the REVERSE of numeric
+        // order, so a multi-SSTable set would mis-order pre-fix. (Valid times-of-day
+        // happen to coincide under the current Display; ordering by the raw cell_path
+        // bytes is the robust, parity-correct rule and closes the compare_custom class,
+        // roborev 1632.) Arrive out of order to prove the sort runs.
+        let t_small = 36_000_000_000_000i64; // 10h in ns
+        let t_big = 360_000_000_000_000i64; // 100h in ns
+        let cells = vec![
+            elem("tset", Value::Time(t_big), t_big.to_be_bytes().to_vec()),
+            elem("tset", Value::Time(t_small), t_small.to_be_bytes().to_vec()),
+        ];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "tset"),
+            Some(&Value::Set(vec![Value::Time(t_small), Value::Time(t_big)])),
+            "set<time> must order by the raw big-endian long (10h before 100h), \
+             not the reversed formatted-string order"
+        );
+    }
+
+    #[test]
     fn deleted_elements_are_dropped() {
         let mut deleted = elem("nums", Value::Integer(99), vec![0, 0, 0, 99]);
         deleted.is_deleted = true;
@@ -694,53 +769,43 @@ mod tests {
     }
 
     #[test]
-    fn map_with_frozen_tuple_key_served_as_blob_in_byte_order() {
-        // frozen<tuple> map key: undecodable by the scalar codec. Pre-fix
-        // `deserialize_value_bytes(Frozen(Tuple))` hit the `_ => Err` arm and
-        // failed the WHOLE row — a regression from the single-generation reader,
-        // which serves an undecodable composite key as opaque bytes. Now the key
-        // is a raw Value::Blob(cell_path), ordered by raw cell_path bytes, and the
-        // row succeeds (roborev 1629 F2).
+    fn map_with_frozen_tuple_key_fails_closed() {
+        // frozen<tuple> map key: an opaque composite the scalar codec cannot decode.
+        // The round-2 route served it as a raw Value::Blob(cell_path), but that Blob
+        // breaks the typed Arrow builder downstream (which expects a tuple/struct for
+        // the declared key type) — the same failure the pre-#2324 whole-row error
+        // produced, one layer deeper. So this path now FAILS CLOSED with a clear
+        // error naming the column + declared key type (roborev 1632; full composite
+        // key decode is follow-up #2339).
         let cells = vec![
             elem("ftk", Value::BigInt(2), vec![0x00, 0x00, 0x00, 0x09, 0x62]),
             elem("ftk", Value::BigInt(1), vec![0x00, 0x00, 0x00, 0x01, 0x61]),
         ];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
-        assert_eq!(
-            get(&out, "ftk"),
-            Some(&Value::Map(vec![
-                (
-                    Value::Blob(vec![0x00, 0x00, 0x00, 0x01, 0x61]),
-                    Value::BigInt(1)
-                ),
-                (
-                    Value::Blob(vec![0x00, 0x00, 0x00, 0x09, 0x62]),
-                    Value::BigInt(2)
-                ),
-            ])),
-            "frozen<tuple> map key served as opaque Blob(cell_path) in byte order"
+        let err = assemble_read_cells(cells, &schema()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ftk") && msg.contains("map key") && msg.contains("#2339"),
+            "composite map-key error must name the column, the kind, and the follow-up, got: {msg}"
         );
     }
 
     #[test]
-    fn set_of_frozen_udt_orders_by_cell_path_bytes() {
-        // frozen<udt> set element: undecodable by the scalar codec. The reader
-        // already decoded the member into e.value (kept as-is); cross-SSTable
-        // ordering falls back to raw cell_path byte order. Pre-fix the sort's
-        // `deserialize_value_bytes(Frozen(..))` errored the whole row; now it
-        // succeeds (roborev 1629 F2). Elements arrive OUT of cell_path order.
+    fn set_of_frozen_udt_fails_closed() {
+        // frozen<udt> set element: an opaque composite the scalar codec cannot decode.
+        // The round-2 route kept the reader's e.value (an opaque Blob) and ordered by
+        // raw cell_path bytes, but that Blob likewise breaks the typed Arrow builder
+        // for the declared element type. This path now FAILS CLOSED with a clear error
+        // naming the column + declared element type (roborev 1632; full composite
+        // element decode is follow-up #2339).
         let cells = vec![
             elem("fset", Value::Blob(vec![0xBB]), vec![0x02]),
             elem("fset", Value::Blob(vec![0xAA]), vec![0x01]),
         ];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
-        assert_eq!(
-            get(&out, "fset"),
-            Some(&Value::Set(vec![
-                Value::Blob(vec![0xAA]),
-                Value::Blob(vec![0xBB]),
-            ])),
-            "frozen<udt> set members order by raw cell_path bytes, not arrival order"
+        let err = assemble_read_cells(cells, &schema()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fset") && msg.contains("set element") && msg.contains("#2339"),
+            "composite set-element error must name the column, the kind, and the follow-up, got: {msg}"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
+++ b/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
@@ -23,6 +23,18 @@
 //! with the schema's declared key type via the canonical
 //! [`deserialize_value_bytes`] codec (never guessed).
 //!
+//! Non-scalar set elements / map keys (`frozen<tuple>`, `frozen<udt>`, nested
+//! `frozen<collection>`) are NOT decodable by the scalar `deserialize_value_bytes`
+//! codec. Rather than fail the whole query — a regression from the canonical
+//! single-generation reader, which serves such keys as opaque bytes — this mirrors
+//! that reader's `parse_cell_path_key` (complex_column.rs): the key/element is
+//! served as a raw `Value::Blob(cell_path)` and ordered by raw `cell_path` byte
+//! comparison. Within one SSTable the elements are already comparator-sorted on
+//! disk, and a byte-comparable serialized form makes byte order == comparator
+//! order; cross-SSTable ordering of a non-byte-comparable composite is a documented
+//! limitation shared with (and no worse than) the single-generation read path. The
+//! opaque/scalar choice branches on the DECLARED schema type only (no guessing).
+//!
 //! Tombstone handling follows Cassandra SELECT semantics (issue #1742: SELECT
 //! output is the read-path authority), NOT the single-generation reader's
 //! physical `collapsed_value`: a deleted set/list member or deleted MAP entry is
@@ -52,6 +64,14 @@ use crate::{Error, Result};
 use super::model::CellData;
 
 /// One column's accumulated cells while grouping a row's flat cell list.
+///
+/// The two shapes are mutually exclusive for any one column: in Cassandra 5.0
+/// (na+) a column's frozen-ness is a FIXED schema property (you cannot `ALTER`
+/// a column between frozen and non-frozen), so a single consistent row can never
+/// carry BOTH a whole-value (simple) cell AND per-element (complex) cells for the
+/// same column. If both nonetheless arrive during grouping the row is
+/// inconsistent/corrupt, so [`assemble_read_cells`] fails closed (issue #28)
+/// rather than silently keep whichever shape arrived first and drop the other.
 #[cfg(feature = "write-support")]
 enum ColumnAccum {
     /// A simple (single-cell) column: its one decoded value.
@@ -60,6 +80,19 @@ enum ColumnAccum {
     /// order (re-sorted by `cell_path` at collapse time). Element tombstones are
     /// already dropped.
     Complex(Vec<CellData>),
+}
+
+/// Fail-closed error for a column that arrives with BOTH simple and complex
+/// cells in one merged row (see [`ColumnAccum`] — impossible for a consistent
+/// na+ schema). Names the offending column; never silently drops a shape.
+#[cfg(feature = "write-support")]
+fn mixed_shape_error(column: &str) -> Error {
+    Error::corruption(format!(
+        "column '{column}': merged row mixes a whole-value (simple) cell and \
+         per-element (complex) cells for one column — impossible for a consistent \
+         Cassandra 5.0 (na+) schema (frozen-ness is fixed, un-ALTERable); failing \
+         closed rather than silently dropping either shape (issues #28/#2324)"
+    ))
 }
 
 /// Reassemble a merged live row's per-column cells into user-facing
@@ -105,10 +138,10 @@ pub fn assemble_read_cells(cells: Vec<CellData>, schema: &TableSchema) -> Result
             if cell.is_deleted || matches!(cell.value, Value::Tombstone(_)) {
                 continue;
             }
-            let slot = register_complex(&mut order, &mut index, &mut accums, name);
-            if let ColumnAccum::Complex(elems) = slot {
-                elems.push(cell);
-            }
+            // Fail closed if this column already accumulated a simple cell (mixed
+            // shape — impossible for a consistent na+ schema; see `ColumnAccum`).
+            let elems = register_complex(&mut order, &mut index, &mut accums, name)?;
+            elems.push(cell);
         } else {
             // Simple cell: a tombstoned simple cell leaves the column absent
             // (reads null downstream) — mirror the prior producer filter.
@@ -116,7 +149,11 @@ pub fn assemble_read_cells(cells: Vec<CellData>, schema: &TableSchema) -> Result
                 continue;
             }
             match index.get(name.as_ref()) {
-                Some(&i) => accums[i] = ColumnAccum::Simple(cell.value),
+                Some(&i) => match &mut accums[i] {
+                    ColumnAccum::Simple(v) => *v = cell.value,
+                    // Mixed shape: complex elements already present for this column.
+                    ColumnAccum::Complex(_) => return Err(mixed_shape_error(&name)),
+                },
                 None => {
                     index.insert(Arc::clone(&name), accums.len());
                     order.push(name);
@@ -140,14 +177,16 @@ pub fn assemble_read_cells(cells: Vec<CellData>, schema: &TableSchema) -> Result
 }
 
 /// Fetch (creating if absent) the [`ColumnAccum::Complex`] slot for `name`,
-/// returning a mutable reference to it.
+/// returning a mutable reference to its element vec. Fails closed with
+/// [`mixed_shape_error`] if the column already holds a simple cell (see
+/// [`ColumnAccum`]).
 #[cfg(feature = "write-support")]
 fn register_complex<'a>(
     order: &mut Vec<Arc<str>>,
     index: &mut HashMap<Arc<str>, usize>,
     accums: &'a mut Vec<ColumnAccum>,
     name: Arc<str>,
-) -> &'a mut ColumnAccum {
+) -> Result<&'a mut Vec<CellData>> {
     let i = match index.get(name.as_ref()) {
         Some(&i) => i,
         None => {
@@ -158,7 +197,12 @@ fn register_complex<'a>(
             i
         }
     };
-    &mut accums[i]
+    // `order[i]` is the column name for `accums[i]` (both pushed together), and
+    // borrows a different vec than `accums`, so it stays available for the error.
+    match &mut accums[i] {
+        ColumnAccum::Complex(elems) => Ok(elems),
+        ColumnAccum::Simple(_) => Err(mixed_shape_error(&order[i])),
+    }
 }
 
 /// Collapse the surviving live elements of one complex column into a single
@@ -192,7 +236,7 @@ fn assemble_complex(
         // a single-generation `SELECT` returns (issue #2324, roborev 1628).
         CqlType::Set(inner) => {
             let elem_cmp = ComparatorType::from_cql_type(inner)?;
-            sort_elements_by_cell_path_value(&mut elements, &elem_cmp)?;
+            sort_elements_by_cell_path(&mut elements, &elem_cmp)?;
             Ok(Value::Set(elements.into_iter().map(|e| e.value).collect()))
         }
         // A list element's `cell_path` is its position timeuuid, which orders by
@@ -204,17 +248,27 @@ fn assemble_complex(
         }
         CqlType::Map(key_type, _) => {
             let key_cmp = ComparatorType::from_cql_type(key_type)?;
+            // Order entries by the declared key comparator (scalar) or raw
+            // cell_path bytes (opaque composite) so a map spanning multiple
+            // SSTables reconstructs in authoritative key order — done on the cells
+            // up front so the key is decoded once, at build time, below.
+            sort_elements_by_cell_path(&mut elements, &key_cmp)?;
+            let opaque = key_is_opaque_composite(&key_cmp);
             let mut entries = Vec::with_capacity(elements.len());
             for e in elements {
                 // The map key is the element's cell_path (raw key bytes, no
-                // length prefix) — decode it with the declared key type.
+                // length prefix). Decode a scalar key with the declared type; an
+                // opaque composite key (frozen tuple/udt/collection) is served as
+                // raw Blob bytes, mirroring the single-generation reader (module
+                // doc + `key_is_opaque_composite`).
                 let key_bytes = e.cell_path.as_deref().unwrap_or(&[]);
-                let key = deserialize_value_bytes(key_bytes, &key_cmp)?;
+                let key = if opaque {
+                    Value::Blob(key_bytes.to_vec())
+                } else {
+                    deserialize_value_bytes(key_bytes, &key_cmp)?
+                };
                 entries.push((key, e.value));
             }
-            // Order entries by the declared key comparator so a map spanning
-            // multiple SSTables reconstructs in authoritative key order.
-            sort_entries_by_key(&mut entries, &key_cmp)?;
             Ok(Value::Map(entries))
         }
         // A non-collection complex column (e.g. non-frozen top-level UDT):
@@ -230,14 +284,24 @@ fn cell_path_bytes(cell: &CellData) -> &[u8] {
     cell.cell_path.as_deref().unwrap_or(&[])
 }
 
-/// Order set elements by their `cell_path` (the element identity) using the
-/// declared element comparator, in place. Decodes each `cell_path` once up front
-/// (fallible → propagated) so the sort itself is total and infallible.
+/// Order collection cells by their `cell_path` (the element/key identity), in
+/// place, using the declared element/key comparator.
+///
+/// A SCALAR comparator decodes each `cell_path` to a `Value` and orders by the
+/// type comparator (e.g. signed-int order != raw byte order), surfacing any
+/// genuine decode error (wrong-width scalar) rather than masking it. An OPAQUE
+/// COMPOSITE comparator (frozen tuple/udt/collection — undecodable by the scalar
+/// codec) orders by raw `cell_path` byte comparison, mirroring the
+/// single-generation reader's opaque-bytes handling (see module doc +
+/// [`key_is_opaque_composite`]).
 #[cfg(feature = "write-support")]
-fn sort_elements_by_cell_path_value(
-    elements: &mut Vec<CellData>,
-    cmp: &ComparatorType,
-) -> Result<()> {
+fn sort_elements_by_cell_path(elements: &mut Vec<CellData>, cmp: &ComparatorType) -> Result<()> {
+    if key_is_opaque_composite(cmp) {
+        elements.sort_by(|a, b| cell_path_bytes(a).cmp(cell_path_bytes(b)));
+        return Ok(());
+    }
+    // Decode each `cell_path` once up front (fallible → propagated) so the sort
+    // itself is total and infallible.
     let mut keyed: Vec<(Value, CellData)> = Vec::with_capacity(elements.len());
     for cell in std::mem::take(elements) {
         let key = deserialize_value_bytes(cell_path_bytes(&cell), cmp)?;
@@ -248,11 +312,41 @@ fn sort_elements_by_cell_path_value(
     Ok(())
 }
 
-/// Order `(key, value)` map entries by their key using the declared key
-/// comparator, in place.
+/// True when `cmp` names an element/key type the scalar [`deserialize_value_bytes`]
+/// codec CANNOT decode — a frozen tuple / UDT / nested collection (or any other
+/// non-scalar `Custom`). Such a key/element is served as an opaque
+/// `Value::Blob(cell_path)` in raw-byte order, mirroring the canonical
+/// single-generation reader's `parse_cell_path_key` (complex_column.rs) rather
+/// than failing the whole query. The set of decodable scalars is kept in lockstep
+/// with `deserialize_value_bytes`; branching on the DECLARED type only, never a
+/// byte pattern (no-heuristics, issue #28).
 #[cfg(feature = "write-support")]
-fn sort_entries_by_key(entries: &mut [(Value, Value)], cmp: &ComparatorType) -> Result<()> {
-    sort_by_comparator(entries, cmp)
+fn key_is_opaque_composite(cmp: &ComparatorType) -> bool {
+    match cmp {
+        // `frozen` only ever wraps a composite in a map key / collection element,
+        // but recurse defensively so a hypothetical frozen scalar still decodes.
+        ComparatorType::Frozen(inner) => key_is_opaque_composite(inner),
+        ComparatorType::Boolean
+        | ComparatorType::TinyInt
+        | ComparatorType::SmallInt
+        | ComparatorType::Int
+        | ComparatorType::BigInt
+        | ComparatorType::Counter
+        | ComparatorType::Float32
+        | ComparatorType::Float
+        | ComparatorType::Text
+        | ComparatorType::Blob
+        | ComparatorType::Timestamp
+        | ComparatorType::Date
+        | ComparatorType::Uuid
+        | ComparatorType::Varint
+        | ComparatorType::Decimal
+        | ComparatorType::Duration => false,
+        // `deserialize_value_bytes` decodes only these two Custom names.
+        ComparatorType::Custom(name) => !(name == "time" || name == "inet"),
+        // Tuple / Udt / Set / List / Map: undecodable by the scalar codec.
+        _ => true,
+    }
 }
 
 /// Sort `items` by the first tuple element with the fallible [`ComparatorType`],
@@ -330,6 +424,11 @@ mod tests {
                 col("nums", "set<int>"),
                 col("items", "list<int>"),
                 col("m", "map<text, bigint>"),
+                // Non-scalar element/key columns (roborev 1629 F2): the scalar
+                // codec cannot decode these, so they exercise the opaque-composite
+                // Blob + raw-byte-order path.
+                col("fset", "set<frozen<addr_type>>"),
+                col("ftk", "map<frozen<tuple<int, text>>, bigint>"),
             ],
             comments: HashMap::new(),
             dropped_columns: HashMap::new(),
@@ -515,6 +614,86 @@ mod tests {
                 (Value::Text("beta".into()), Value::BigInt(2)),
             ])),
             "a deleted map entry must be omitted (no (key, Null)) per Cassandra SELECT semantics"
+        );
+    }
+
+    #[test]
+    fn simple_then_complex_same_column_fails_closed() {
+        // A simple (whole-value) cell then a per-element (complex) cell for the
+        // SAME column: impossible for a consistent na+ schema (roborev 1629 F1).
+        // Pre-fix the element was SILENTLY DROPPED (register_complex's `if let`
+        // fell through); now it fails closed naming the column.
+        let simple = CellData::new("nums".into(), Value::Integer(5), 1);
+        let complex = elem("nums", Value::Integer(10), vec![0, 0, 0, 10]);
+        let err = assemble_read_cells(vec![simple, complex], &schema()).unwrap_err();
+        assert!(
+            err.to_string().contains("nums"),
+            "mixed-shape error must name the column, got: {err}"
+        );
+    }
+
+    #[test]
+    fn complex_then_simple_same_column_fails_closed() {
+        // The reverse arrival order: a complex element then a simple cell for the
+        // SAME column. Pre-fix the simple cell OVERWROTE (dropped) the whole
+        // collection; now it fails closed naming the column (roborev 1629 F1).
+        let complex = elem("nums", Value::Integer(10), vec![0, 0, 0, 10]);
+        let simple = CellData::new("nums".into(), Value::Integer(5), 1);
+        let err = assemble_read_cells(vec![complex, simple], &schema()).unwrap_err();
+        assert!(
+            err.to_string().contains("nums"),
+            "mixed-shape error must name the column, got: {err}"
+        );
+    }
+
+    #[test]
+    fn map_with_frozen_tuple_key_served_as_blob_in_byte_order() {
+        // frozen<tuple> map key: undecodable by the scalar codec. Pre-fix
+        // `deserialize_value_bytes(Frozen(Tuple))` hit the `_ => Err` arm and
+        // failed the WHOLE row — a regression from the single-generation reader,
+        // which serves an undecodable composite key as opaque bytes. Now the key
+        // is a raw Value::Blob(cell_path), ordered by raw cell_path bytes, and the
+        // row succeeds (roborev 1629 F2).
+        let cells = vec![
+            elem("ftk", Value::BigInt(2), vec![0x00, 0x00, 0x00, 0x09, 0x62]),
+            elem("ftk", Value::BigInt(1), vec![0x00, 0x00, 0x00, 0x01, 0x61]),
+        ];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "ftk"),
+            Some(&Value::Map(vec![
+                (
+                    Value::Blob(vec![0x00, 0x00, 0x00, 0x01, 0x61]),
+                    Value::BigInt(1)
+                ),
+                (
+                    Value::Blob(vec![0x00, 0x00, 0x00, 0x09, 0x62]),
+                    Value::BigInt(2)
+                ),
+            ])),
+            "frozen<tuple> map key served as opaque Blob(cell_path) in byte order"
+        );
+    }
+
+    #[test]
+    fn set_of_frozen_udt_orders_by_cell_path_bytes() {
+        // frozen<udt> set element: undecodable by the scalar codec. The reader
+        // already decoded the member into e.value (kept as-is); cross-SSTable
+        // ordering falls back to raw cell_path byte order. Pre-fix the sort's
+        // `deserialize_value_bytes(Frozen(..))` errored the whole row; now it
+        // succeeds (roborev 1629 F2). Elements arrive OUT of cell_path order.
+        let cells = vec![
+            elem("fset", Value::Blob(vec![0xBB]), vec![0x02]),
+            elem("fset", Value::Blob(vec![0xAA]), vec![0x01]),
+        ];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "fset"),
+            Some(&Value::Set(vec![
+                Value::Blob(vec![0xAA]),
+                Value::Blob(vec![0xBB]),
+            ])),
+            "frozen<udt> set members order by raw cell_path bytes, not arrival order"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
+++ b/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
@@ -53,7 +53,7 @@
 #[cfg(feature = "write-support")]
 use std::cmp::Ordering;
 #[cfg(feature = "write-support")]
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 #[cfg(feature = "write-support")]
 use std::sync::Arc;
 
@@ -113,8 +113,26 @@ fn mixed_shape_error(column: &str) -> Error {
 /// A non-collection complex column (e.g. a non-frozen top-level UDT) is left as
 /// its individual cells — this reassembles collections only, the columns the
 /// issue names; other multi-cell shapes are unchanged (no worse than before).
+///
+/// `needed` is the projection-aware set of column names this scan will actually
+/// read (the output projection ∪ predicate-referenced ∪ aggregation-referenced
+/// columns); `None` means "every column" (a plain `SELECT *`). Cells of a column
+/// NOT in `needed` are dropped BEFORE reassembly — they are never emitted
+/// downstream (projection removes them from Arrow output, the filter and
+/// aggregation don't reference them). This scopes the composite-keyed-collection
+/// fail-closed error (a frozen tuple/UDT/nested-collection key/element the scalar
+/// codec cannot materialize, #2339) to the columns a query actually reads: an
+/// unrelated `SELECT` of scalar columns from a row that merely COEXISTS with an
+/// unsupported composite-keyed collection column SUCCEEDS — matching the
+/// observable pre-#2324 behaviour — while the clean error still fires when that
+/// composite column IS projected or referenced (issue #2324, roborev 1633). It
+/// is also a small perf win (unprojected collections are never reassembled).
 #[cfg(feature = "write-support")]
-pub fn assemble_read_cells(cells: Vec<CellData>, schema: &TableSchema) -> Result<RowCells> {
+pub fn assemble_read_cells(
+    cells: Vec<CellData>,
+    schema: &TableSchema,
+    needed: Option<&HashSet<String>>,
+) -> Result<RowCells> {
     // Group cells by column, preserving first-seen order so a stable, schema-
     // independent ordering results (downstream keys by name, so order is not
     // load-bearing — but a deterministic order keeps output reproducible).
@@ -123,6 +141,16 @@ pub fn assemble_read_cells(cells: Vec<CellData>, schema: &TableSchema) -> Result
     let mut accums: Vec<ColumnAccum> = Vec::new();
 
     for cell in cells {
+        // Projection-aware assembly (issue #2324, roborev 1633): drop cells of a
+        // column this scan never reads before touching the (fallible) reassembly.
+        // `None` = all columns → nothing dropped. This keeps the composite-keyed
+        // collection fail-closed error (#2339) from firing on a column an unrelated
+        // query does not project or reference (see the fn-level doc).
+        if let Some(needed) = needed {
+            if !needed.contains(cell.column.as_str()) {
+                continue;
+            }
+        }
         let name: Arc<str> = Arc::from(cell.column.as_str());
         if cell.is_complex_element {
             // Drop element tombstones (a deleted set/list member OR map entry):
@@ -534,7 +562,7 @@ mod tests {
     #[test]
     fn simple_column_passes_through() {
         let cells = vec![CellData::new("s".into(), Value::Integer(7), 1)];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(get(&out, "s"), Some(&Value::Integer(7)));
     }
 
@@ -549,7 +577,7 @@ mod tests {
             range_end: None,
         }));
         let cells = vec![CellData::new("s".into(), tomb, 1)];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(
             get(&out, "s"),
             None,
@@ -567,7 +595,7 @@ mod tests {
             elem("items", Value::Integer(2), vec![1]),
             elem("items", Value::Integer(3), vec![2]),
         ];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(
             get(&out, "nums"),
             Some(&Value::Set(vec![Value::Integer(10), Value::Integer(20)])),
@@ -591,7 +619,7 @@ mod tests {
             elem("m", Value::BigInt(100), b"alpha".to_vec()),
             elem("m", Value::BigInt(200), b"beta".to_vec()),
         ];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(
             get(&out, "m"),
             Some(&Value::Map(vec![
@@ -616,7 +644,7 @@ mod tests {
             elem("iset", Value::Inet(ip_10.clone()), ip_10.clone()),
             elem("iset", Value::Inet(ip_9.clone()), ip_9.clone()),
         ];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(
             get(&out, "iset"),
             Some(&Value::Set(vec![Value::Inet(ip_9), Value::Inet(ip_10),])),
@@ -644,7 +672,7 @@ mod tests {
             elem("tset", Value::Time(t_big), t_big.to_be_bytes().to_vec()),
             elem("tset", Value::Time(t_small), t_small.to_be_bytes().to_vec()),
         ];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(
             get(&out, "tset"),
             Some(&Value::Set(vec![Value::Time(t_small), Value::Time(t_big)])),
@@ -658,7 +686,7 @@ mod tests {
         let mut deleted = elem("nums", Value::Integer(99), vec![0, 0, 0, 99]);
         deleted.is_deleted = true;
         let cells = vec![elem("nums", Value::Integer(10), vec![0, 0, 0, 10]), deleted];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(
             get(&out, "nums"),
             Some(&Value::Set(vec![Value::Integer(10)])),
@@ -686,7 +714,7 @@ mod tests {
             elem("m", Value::BigInt(1), b"alpha".to_vec()),
             elem("m", Value::BigInt(2), b"beta".to_vec()),
         ];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(
             get(&out, "nums"),
             Some(&Value::Set(vec![
@@ -730,7 +758,7 @@ mod tests {
             deleted,
             elem("m", Value::BigInt(2), b"beta".to_vec()),
         ];
-        let out = assemble_read_cells(cells, &schema()).unwrap();
+        let out = assemble_read_cells(cells, &schema(), None).unwrap();
         assert_eq!(
             get(&out, "m"),
             Some(&Value::Map(vec![
@@ -749,7 +777,7 @@ mod tests {
         // fell through); now it fails closed naming the column.
         let simple = CellData::new("nums".into(), Value::Integer(5), 1);
         let complex = elem("nums", Value::Integer(10), vec![0, 0, 0, 10]);
-        let err = assemble_read_cells(vec![simple, complex], &schema()).unwrap_err();
+        let err = assemble_read_cells(vec![simple, complex], &schema(), None).unwrap_err();
         assert!(
             err.to_string().contains("nums"),
             "mixed-shape error must name the column, got: {err}"
@@ -763,7 +791,7 @@ mod tests {
         // collection; now it fails closed naming the column (roborev 1629 F1).
         let complex = elem("nums", Value::Integer(10), vec![0, 0, 0, 10]);
         let simple = CellData::new("nums".into(), Value::Integer(5), 1);
-        let err = assemble_read_cells(vec![complex, simple], &schema()).unwrap_err();
+        let err = assemble_read_cells(vec![complex, simple], &schema(), None).unwrap_err();
         assert!(
             err.to_string().contains("nums"),
             "mixed-shape error must name the column, got: {err}"
@@ -783,7 +811,7 @@ mod tests {
             elem("ftk", Value::BigInt(2), vec![0x00, 0x00, 0x00, 0x09, 0x62]),
             elem("ftk", Value::BigInt(1), vec![0x00, 0x00, 0x00, 0x01, 0x61]),
         ];
-        let err = assemble_read_cells(cells, &schema()).unwrap_err();
+        let err = assemble_read_cells(cells, &schema(), None).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("ftk") && msg.contains("map key") && msg.contains("#2339"),
@@ -803,7 +831,7 @@ mod tests {
             elem("fset", Value::Blob(vec![0xBB]), vec![0x02]),
             elem("fset", Value::Blob(vec![0xAA]), vec![0x01]),
         ];
-        let err = assemble_read_cells(cells, &schema()).unwrap_err();
+        let err = assemble_read_cells(cells, &schema(), None).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("fset") && msg.contains("set element") && msg.contains("#2339"),
@@ -815,11 +843,72 @@ mod tests {
     fn all_deleted_collection_is_absent() {
         let mut deleted = elem("nums", Value::Integer(99), vec![0, 0, 0, 99]);
         deleted.is_deleted = true;
-        let out = assemble_read_cells(vec![deleted], &schema()).unwrap();
+        let out = assemble_read_cells(vec![deleted], &schema(), None).unwrap();
         assert_eq!(
             get(&out, "nums"),
             None,
             "an all-deleted collection reads absent (empty non-frozen collection == null)"
+        );
+    }
+
+    #[test]
+    fn unprojected_composite_collection_column_is_dropped_not_errored() {
+        // Projection-aware assembly (issue #2324, roborev 1633): a row carrying a
+        // scalar column `s` AND an unsupported composite-keyed collection column
+        // `ftk` (frozen<tuple> map key). A query that projects ONLY `s` (so `ftk`
+        // is NOT in `needed`) must SUCCEED, dropping `ftk` entirely — matching the
+        // observable pre-#2324 behaviour where an unrelated SELECT never touched
+        // this column. Pre-fix (round-3, no `needed` filter — i.e. `None` here)
+        // this same row HARD-ERRORS the whole do_get; the guard closes that
+        // regression. (`fails_closed_without_projection_filter` below pins the red.)
+        let cells = vec![
+            CellData::new("s".into(), Value::Integer(7), 1),
+            elem("ftk", Value::BigInt(1), vec![0x00, 0x00, 0x00, 0x01, 0x61]),
+        ];
+        let needed: HashSet<String> = ["s".to_string()].into_iter().collect();
+        let out = assemble_read_cells(cells, &schema(), Some(&needed)).unwrap();
+        assert_eq!(get(&out, "s"), Some(&Value::Integer(7)));
+        assert_eq!(
+            get(&out, "ftk"),
+            None,
+            "an unprojected composite-keyed collection column is dropped, not assembled/errored"
+        );
+    }
+
+    #[test]
+    fn fails_closed_without_projection_filter() {
+        // The RED anchor for the fix above: the SAME row, but with `needed = None`
+        // (the round-3 behaviour, and a plain `SELECT *`). Because every column is
+        // read, the composite-keyed `ftk` IS assembled and fails closed — proving
+        // the projection filter, not some incidental change, is what rescues the
+        // unrelated-projection case (roborev 1633).
+        let cells = vec![
+            CellData::new("s".into(), Value::Integer(7), 1),
+            elem("ftk", Value::BigInt(1), vec![0x00, 0x00, 0x00, 0x01, 0x61]),
+        ];
+        let err = assemble_read_cells(cells, &schema(), None).unwrap_err();
+        assert!(
+            err.to_string().contains("ftk"),
+            "with no projection filter the composite column still fails closed, got: {err}"
+        );
+    }
+
+    #[test]
+    fn projected_composite_collection_column_still_fails_closed() {
+        // The complement: when the composite column IS projected/referenced (it is
+        // in `needed`), the round-3 clean fail-closed error still fires — the fix
+        // scopes the error, it does not suppress it (roborev 1632/1633; #2339).
+        let cells = vec![elem(
+            "ftk",
+            Value::BigInt(1),
+            vec![0x00, 0x00, 0x00, 0x01, 0x61],
+        )];
+        let needed: HashSet<String> = ["ftk".to_string()].into_iter().collect();
+        let err = assemble_read_cells(cells, &schema(), Some(&needed)).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ftk") && msg.contains("map key") && msg.contains("#2339"),
+            "a projected composite map-key column still fails closed, got: {msg}"
         );
     }
 }

--- a/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
+++ b/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
@@ -1,0 +1,359 @@
+//! Read-shape reassembly of a merged row's per-column cells (issue #2324).
+//!
+//! The k-way merger emits a live row as a flat `Vec<CellData>` where every
+//! element of a non-frozen collection (`list` / `set` / `map`) is its OWN
+//! [`CellData`] — one cell per element, all sharing the column name, each keyed
+//! by its authoritative `cell_path` (epic #899, byte-parity write substrate).
+//! That per-element shape is correct for the compaction WRITE path but WRONG for
+//! any read consumer that keys cells by column name: keying the elements by name
+//! (e.g. the Arrow Flight producer's `build_row_from_scan`, whose `values` is a
+//! `HashMap<column, Value>`) keeps only the LAST element and silently drops the
+//! rest of the collection.
+//!
+//! [`assemble_read_cells`] collapses those per-element cells back into a single
+//! `Value::List` / `Value::Set` / `Value::Map` per column — mirroring the shape
+//! the single-generation reader's `collapsed_value` produces, so a read that
+//! goes through the merger (the Flight `do_get` path) sees the SAME whole
+//! collection a plain single-generation `SELECT` sees.
+//!
+//! Semantics are taken from authoritative metadata only (issue #28): the element
+//! order is on-disk order (preserved by the merger), the set/list member is the
+//! reader-decoded `CellData.value`, and the map key is decoded from the element's
+//! `cell_path` with the schema's declared key type via the canonical
+//! [`deserialize_value_bytes`] codec (never guessed).
+
+#[cfg(feature = "write-support")]
+use std::collections::HashMap;
+#[cfg(feature = "write-support")]
+use std::sync::Arc;
+
+#[cfg(feature = "write-support")]
+use crate::schema::{CqlType, TableSchema};
+#[cfg(feature = "write-support")]
+use crate::storage::partition_key_codec::deserialize_value_bytes;
+#[cfg(feature = "write-support")]
+use crate::types::{ComparatorType, RowCells, Value};
+#[cfg(feature = "write-support")]
+use crate::Result;
+
+#[cfg(feature = "write-support")]
+use super::model::CellData;
+
+/// One column's accumulated cells while grouping a row's flat cell list.
+#[cfg(feature = "write-support")]
+enum ColumnAccum {
+    /// A simple (single-cell) column: its one decoded value.
+    Simple(Value),
+    /// A complex (multi-cell) column: its surviving live elements in on-disk
+    /// order. Element tombstones are already dropped.
+    Complex(Vec<CellData>),
+}
+
+/// Reassemble a merged live row's per-column cells into user-facing
+/// [`RowCells`], collapsing multi-cell collection columns into a single
+/// `Value::List` / `Value::Set` / `Value::Map` (issue #2324).
+///
+/// Cell tombstones (`Value::Tombstone` on a simple cell) and deleted complex
+/// elements (`is_deleted`) are dropped, so a column reads as its surviving live
+/// content — an absent simple column becomes null downstream, an all-deleted
+/// collection becomes the empty collection.
+///
+/// A non-collection complex column (e.g. a non-frozen top-level UDT) is left as
+/// its individual cells — this reassembles collections only, the columns the
+/// issue names; other multi-cell shapes are unchanged (no worse than before).
+pub fn assemble_read_cells(cells: Vec<CellData>, schema: &TableSchema) -> Result<RowCells> {
+    // Group cells by column, preserving first-seen order so a stable, schema-
+    // independent ordering results (downstream keys by name, so order is not
+    // load-bearing — but a deterministic order keeps output reproducible).
+    let mut order: Vec<Arc<str>> = Vec::new();
+    let mut index: HashMap<Arc<str>, usize> = HashMap::new();
+    let mut accums: Vec<ColumnAccum> = Vec::new();
+
+    for cell in cells {
+        let name: Arc<str> = Arc::from(cell.column.as_str());
+        if cell.is_complex_element {
+            // Drop element tombstones (a deleted set/list member or map entry):
+            // the whole element is removed. A collection with NO surviving live
+            // element is left absent (reads null downstream) — an empty non-frozen
+            // collection IS null in Cassandra, and this preserves the pre-fix
+            // behaviour for that edge (the fix only recovers dropped LIVE elements).
+            if cell.is_deleted || matches!(cell.value, Value::Tombstone(_)) {
+                continue;
+            }
+            let slot = register_complex(&mut order, &mut index, &mut accums, name);
+            if let ColumnAccum::Complex(elems) = slot {
+                elems.push(cell);
+            }
+        } else {
+            // Simple cell: a tombstoned simple cell leaves the column absent
+            // (reads null downstream) — mirror the prior producer filter.
+            if matches!(cell.value, Value::Tombstone(_)) {
+                continue;
+            }
+            match index.get(name.as_ref()) {
+                Some(&i) => accums[i] = ColumnAccum::Simple(cell.value),
+                None => {
+                    index.insert(Arc::clone(&name), accums.len());
+                    order.push(name);
+                    accums.push(ColumnAccum::Simple(cell.value));
+                }
+            }
+        }
+    }
+
+    let mut out: RowCells = Vec::with_capacity(order.len());
+    for (name, accum) in order.into_iter().zip(accums.into_iter()) {
+        match accum {
+            ColumnAccum::Simple(value) => out.push((name, value)),
+            ColumnAccum::Complex(elements) => {
+                let value = assemble_complex(&name, elements, schema)?;
+                out.push((name, value));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Fetch (creating if absent) the [`ColumnAccum::Complex`] slot for `name`,
+/// returning a mutable reference to it.
+#[cfg(feature = "write-support")]
+fn register_complex<'a>(
+    order: &mut Vec<Arc<str>>,
+    index: &mut HashMap<Arc<str>, usize>,
+    accums: &'a mut Vec<ColumnAccum>,
+    name: Arc<str>,
+) -> &'a mut ColumnAccum {
+    let i = match index.get(name.as_ref()) {
+        Some(&i) => i,
+        None => {
+            let i = accums.len();
+            index.insert(Arc::clone(&name), i);
+            order.push(name);
+            accums.push(ColumnAccum::Complex(Vec::new()));
+            i
+        }
+    };
+    &mut accums[i]
+}
+
+/// Collapse the surviving live elements of one complex column into a single
+/// `Value`, using the column's declared collection type from `schema`.
+#[cfg(feature = "write-support")]
+fn assemble_complex(name: &str, elements: Vec<CellData>, schema: &TableSchema) -> Result<Value> {
+    // Resolve the declared collection type. An undeclared column (the Flight
+    // producer builds cells for every on-disk column, even ones the caller did
+    // not declare) has no type here; such columns are never emitted to Arrow, so
+    // fall back to the last live element's value rather than fail the whole row.
+    let declared = schema
+        .columns
+        .iter()
+        .find(|c| c.name == name)
+        .map(|c| c.data_type.as_str());
+
+    let cql_type = match declared {
+        Some(dt) => CqlType::parse(dt)?,
+        None => return Ok(last_value(elements)),
+    };
+    let cql_type = unwrap_frozen(&cql_type);
+
+    match cql_type {
+        CqlType::Set(_) => Ok(Value::Set(elements.into_iter().map(|e| e.value).collect())),
+        CqlType::List(_) => Ok(Value::List(elements.into_iter().map(|e| e.value).collect())),
+        CqlType::Map(key_type, _) => {
+            let key_cmp = ComparatorType::from_cql_type(key_type)?;
+            let mut entries = Vec::with_capacity(elements.len());
+            for e in elements {
+                // The map key is the element's cell_path (raw key bytes, no
+                // length prefix) — decode it with the declared key type.
+                let key_bytes = e.cell_path.as_deref().unwrap_or(&[]);
+                let key = deserialize_value_bytes(key_bytes, &key_cmp)?;
+                entries.push((key, e.value));
+            }
+            Ok(Value::Map(entries))
+        }
+        // A non-collection complex column (e.g. non-frozen top-level UDT):
+        // reassembly of those shapes is out of this issue's scope. Keep the last
+        // element's value (prior behaviour) so nothing regresses.
+        _ => Ok(last_value(elements)),
+    }
+}
+
+/// Transparently unwrap `Frozen(inner)` so a `frozen<set<...>>` (single-cell,
+/// never reached as complex) and a bare `set<...>` resolve identically.
+#[cfg(feature = "write-support")]
+fn unwrap_frozen(cql: &CqlType) -> &CqlType {
+    match cql {
+        CqlType::Frozen(inner) => unwrap_frozen(inner),
+        other => other,
+    }
+}
+
+/// The last element's value, or `Value::Null` when there are none — the safe
+/// fallback for a column whose collection type cannot be resolved.
+#[cfg(feature = "write-support")]
+fn last_value(elements: Vec<CellData>) -> Value {
+    elements
+        .into_iter()
+        .last()
+        .map(|e| e.value)
+        .unwrap_or(Value::Null)
+}
+
+#[cfg(all(test, feature = "write-support"))]
+mod tests {
+    use super::*;
+    use crate::schema::{Column, KeyColumn, TableSchema};
+    use crate::types::{TombstoneInfo, TombstoneType};
+    use std::collections::HashMap;
+
+    fn col(name: &str, ty: &str) -> Column {
+        Column {
+            name: name.into(),
+            data_type: ty.into(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        }
+    }
+
+    fn schema() -> TableSchema {
+        TableSchema {
+            keyspace: "ks".into(),
+            table: "t".into(),
+            partition_keys: vec![KeyColumn {
+                name: "id".into(),
+                data_type: "int".into(),
+                position: 0,
+            }],
+            clustering_keys: Vec::new(),
+            columns: vec![
+                col("id", "int"),
+                col("s", "int"),
+                col("nums", "set<int>"),
+                col("items", "list<int>"),
+                col("m", "map<text, bigint>"),
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// One complex ELEMENT cell (a set/list member, or a map entry keyed by
+    /// `cell_path`).
+    fn elem(column: &str, value: Value, cell_path: Vec<u8>) -> CellData {
+        CellData {
+            column: column.into(),
+            value,
+            timestamp: 1,
+            ttl: None,
+            cell_path: Some(cell_path),
+            local_deletion_time: None,
+            is_complex_element: true,
+            is_deleted: false,
+            has_empty_value: false,
+        }
+    }
+
+    fn get<'a>(cells: &'a RowCells, name: &str) -> Option<&'a Value> {
+        cells
+            .iter()
+            .find(|(n, _)| n.as_ref() == name)
+            .map(|(_, v)| v)
+    }
+
+    #[test]
+    fn simple_column_passes_through() {
+        let cells = vec![CellData::new("s".into(), Value::Integer(7), 1)];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(get(&out, "s"), Some(&Value::Integer(7)));
+    }
+
+    #[test]
+    fn simple_tombstone_reads_absent() {
+        let tomb = Value::Tombstone(Box::new(TombstoneInfo {
+            deletion_time: 1,
+            tombstone_type: TombstoneType::CellTombstone,
+            local_deletion_time: 0,
+            ttl: None,
+            range_start: None,
+            range_end: None,
+        }));
+        let cells = vec![CellData::new("s".into(), tomb, 1)];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "s"),
+            None,
+            "a tombstoned simple cell is absent (null)"
+        );
+    }
+
+    #[test]
+    fn set_and_list_reassemble_all_members_not_last_cell() {
+        // Two set members + three list members, each its own cell.
+        let cells = vec![
+            elem("nums", Value::Integer(10), vec![0, 0, 0, 10]),
+            elem("nums", Value::Integer(20), vec![0, 0, 0, 20]),
+            elem("items", Value::Integer(1), vec![0]),
+            elem("items", Value::Integer(2), vec![1]),
+            elem("items", Value::Integer(3), vec![2]),
+        ];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "nums"),
+            Some(&Value::Set(vec![Value::Integer(10), Value::Integer(20)])),
+            "SET must keep ALL members, not last-cell-wins"
+        );
+        assert_eq!(
+            get(&out, "items"),
+            Some(&Value::List(vec![
+                Value::Integer(1),
+                Value::Integer(2),
+                Value::Integer(3)
+            ])),
+            "LIST must keep all members in on-disk order"
+        );
+    }
+
+    #[test]
+    fn map_reassembles_entries_decoding_key_from_cell_path() {
+        // MAP<TEXT,BIGINT>: cell_path is the raw utf8 key; value is the bigint.
+        let cells = vec![
+            elem("m", Value::BigInt(100), b"alpha".to_vec()),
+            elem("m", Value::BigInt(200), b"beta".to_vec()),
+        ];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "m"),
+            Some(&Value::Map(vec![
+                (Value::Text("alpha".into()), Value::BigInt(100)),
+                (Value::Text("beta".into()), Value::BigInt(200)),
+            ])),
+            "MAP must reassemble every entry with the key decoded from cell_path"
+        );
+    }
+
+    #[test]
+    fn deleted_elements_are_dropped() {
+        let mut deleted = elem("nums", Value::Integer(99), vec![0, 0, 0, 99]);
+        deleted.is_deleted = true;
+        let cells = vec![elem("nums", Value::Integer(10), vec![0, 0, 0, 10]), deleted];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "nums"),
+            Some(&Value::Set(vec![Value::Integer(10)])),
+            "a deleted set member must be dropped from the reassembled collection"
+        );
+    }
+
+    #[test]
+    fn all_deleted_collection_is_absent() {
+        let mut deleted = elem("nums", Value::Integer(99), vec![0, 0, 0, 99]);
+        deleted.is_deleted = true;
+        let out = assemble_read_cells(vec![deleted], &schema()).unwrap();
+        assert_eq!(
+            get(&out, "nums"),
+            None,
+            "an all-deleted collection reads absent (empty non-frozen collection == null)"
+        );
+    }
+}

--- a/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
+++ b/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
@@ -307,6 +307,7 @@ fn cell_path_bytes(cell: &CellData) -> &[u8] {
 ///   * Any other scalar decodes each `cell_path` to a `Value` and orders by the
 ///     type comparator (e.g. signed-int order != raw byte order), surfacing any
 ///     genuine decode error (wrong-width scalar) rather than masking it.
+///
 /// The [`key_is_opaque_composite`] arm is retained as defensive belt-and-suspenders
 /// (raw-byte order) should the helper ever be reused without the upstream guard.
 #[cfg(feature = "write-support")]
@@ -381,6 +382,7 @@ fn key_is_opaque_composite(cmp: &ComparatorType) -> bool {
 ///   * `time` (`TimeType`): 8-byte big-endian nanoseconds-of-day, always
 ///     non-negative, so byte order == numeric order (formatted `HH:MM:...` string
 ///     order misorders, e.g. any value whose text form sorts against its magnitude).
+///
 /// Branches on the DECLARED type only (no-heuristics, issue #28); recurses through
 /// `Frozen` defensively though neither inet nor time is ever frozen here.
 #[cfg(feature = "write-support")]

--- a/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
+++ b/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
@@ -296,7 +296,7 @@ fn cell_path_bytes(cell: &CellData) -> &[u8] {
 /// [`key_is_opaque_composite`]).
 #[cfg(feature = "write-support")]
 fn sort_elements_by_cell_path(elements: &mut Vec<CellData>, cmp: &ComparatorType) -> Result<()> {
-    if key_is_opaque_composite(cmp) {
+    if key_is_opaque_composite(cmp) || comparator_orders_by_raw_cell_path_bytes(cmp) {
         elements.sort_by(|a, b| cell_path_bytes(a).cmp(cell_path_bytes(b)));
         return Ok(());
     }
@@ -346,6 +346,27 @@ fn key_is_opaque_composite(cmp: &ComparatorType) -> bool {
         ComparatorType::Custom(name) => !(name == "time" || name == "inet"),
         // Tuple / Udt / Set / List / Map: undecodable by the scalar codec.
         _ => true,
+    }
+}
+
+/// True when the element/key type's Cassandra ordering IS unsigned raw-byte
+/// comparison of the `cell_path`, so decoding to a `Value` and routing through
+/// the scalar type comparator would MIS-order it.
+///
+/// `inet` (Cassandra `InetAddressType`) orders by unsigned comparison of the raw
+/// address bytes — but the scalar `Custom("inet")` comparator falls through to
+/// [`ComparatorType::compare`]'s `compare_custom`, which orders by the FORMATTED
+/// string (e.g. `"10.0.0.1" < "9.0.0.1"`), diverging from a single-generation
+/// `SELECT`. The element/key `cell_path` for an inet IS the raw address bytes, so
+/// ordering by `cell_path` bytes matches Cassandra exactly (roborev 1631, issue
+/// #2324). Branches on the DECLARED type only (no-heuristics, issue #28); recurses
+/// through `Frozen` defensively though inet is never frozen here.
+#[cfg(feature = "write-support")]
+fn comparator_orders_by_raw_cell_path_bytes(cmp: &ComparatorType) -> bool {
+    match cmp {
+        ComparatorType::Frozen(inner) => comparator_orders_by_raw_cell_path_bytes(inner),
+        ComparatorType::Custom(name) => name == "inet",
+        _ => false,
     }
 }
 
@@ -429,6 +450,9 @@ mod tests {
                 // Blob + raw-byte-order path.
                 col("fset", "set<frozen<addr_type>>"),
                 col("ftk", "map<frozen<tuple<int, text>>, bigint>"),
+                // inet element ordering (roborev 1631): InetAddressType orders by
+                // unsigned address bytes, NOT the formatted-string order.
+                col("iset", "set<inet>"),
             ],
             comments: HashMap::new(),
             dropped_columns: HashMap::new(),
@@ -526,6 +550,29 @@ mod tests {
                 (Value::Text("beta".into()), Value::BigInt(200)),
             ])),
             "MAP must reassemble every entry with the key decoded from cell_path"
+        );
+    }
+
+    #[test]
+    fn set_of_inet_orders_by_raw_bytes_not_string() {
+        // set<inet>: cell_path (and value) is the raw 4-byte address. Cassandra's
+        // InetAddressType orders by UNSIGNED address bytes, so 9.0.0.1 (bytes
+        // [9,0,0,1]) precedes 10.0.0.1 (bytes [10,0,0,1]). The formatted-string
+        // order the scalar `Custom("inet")` comparator would use is the REVERSE
+        // ("10.0.0.1" < "9.0.0.1"), which would mis-order a multi-SSTable set.
+        // Arrive out of order to prove the sort actually runs (roborev 1631).
+        let ip_9 = vec![9u8, 0, 0, 1];
+        let ip_10 = vec![10u8, 0, 0, 1];
+        let cells = vec![
+            elem("iset", Value::Inet(ip_10.clone()), ip_10.clone()),
+            elem("iset", Value::Inet(ip_9.clone()), ip_9.clone()),
+        ];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "iset"),
+            Some(&Value::Set(vec![Value::Inet(ip_9), Value::Inet(ip_10),])),
+            "set<inet> must order by unsigned address bytes (9.0.0.1 before 10.0.0.1), \
+             not the reversed formatted-string order"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
+++ b/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
@@ -11,17 +11,29 @@
 //! rest of the collection.
 //!
 //! [`assemble_read_cells`] collapses those per-element cells back into a single
-//! `Value::List` / `Value::Set` / `Value::Map` per column — mirroring the shape
-//! the single-generation reader's `collapsed_value` produces, so a read that
-//! goes through the merger (the Flight `do_get` path) sees the SAME whole
-//! collection a plain single-generation `SELECT` sees.
+//! `Value::List` / `Value::Set` / `Value::Map` per column, so a read that goes
+//! through the merger (the Flight `do_get` path) sees the SAME whole collection a
+//! plain single-generation `SELECT` sees.
 //!
-//! Semantics are taken from authoritative metadata only (issue #28): the element
-//! order is on-disk order (preserved by the merger), the set/list member is the
-//! reader-decoded `CellData.value`, and the map key is decoded from the element's
-//! `cell_path` with the schema's declared key type via the canonical
+//! Semantics are taken from authoritative metadata only (issue #28): elements are
+//! ordered by their authoritative `cell_path` with the collection-appropriate
+//! comparator (list = position-timeuuid byte order; set/map = the declared
+//! element/key comparator), the set/list member is the reader-decoded
+//! `CellData.value`, and the map key is decoded from the element's `cell_path`
+//! with the schema's declared key type via the canonical
 //! [`deserialize_value_bytes`] codec (never guessed).
+//!
+//! Tombstone handling follows Cassandra SELECT semantics (issue #1742: SELECT
+//! output is the read-path authority), NOT the single-generation reader's
+//! physical `collapsed_value`: a deleted set/list member or deleted MAP entry is
+//! OMITTED from the reassembled collection. This intentionally DIVERGES from
+//! `complex_column.rs`'s collapsed_value, which surfaces a deleted map entry as a
+//! physical `(key, Null)` pair; that quirk is the physical-dump side and is
+//! tracked separately (issue #2336 family). A `SELECT` never returns a deleted
+//! map key, so the merger read-shape must not either.
 
+#[cfg(feature = "write-support")]
+use std::cmp::Ordering;
 #[cfg(feature = "write-support")]
 use std::collections::HashMap;
 #[cfg(feature = "write-support")]
@@ -34,7 +46,7 @@ use crate::storage::partition_key_codec::deserialize_value_bytes;
 #[cfg(feature = "write-support")]
 use crate::types::{ComparatorType, RowCells, Value};
 #[cfg(feature = "write-support")]
-use crate::Result;
+use crate::{Error, Result};
 
 #[cfg(feature = "write-support")]
 use super::model::CellData;
@@ -44,8 +56,9 @@ use super::model::CellData;
 enum ColumnAccum {
     /// A simple (single-cell) column: its one decoded value.
     Simple(Value),
-    /// A complex (multi-cell) column: its surviving live elements in on-disk
-    /// order. Element tombstones are already dropped.
+    /// A complex (multi-cell) column: its surviving live elements in arrival
+    /// order (re-sorted by `cell_path` at collapse time). Element tombstones are
+    /// already dropped.
     Complex(Vec<CellData>),
 }
 
@@ -61,6 +74,7 @@ enum ColumnAccum {
 /// A non-collection complex column (e.g. a non-frozen top-level UDT) is left as
 /// its individual cells — this reassembles collections only, the columns the
 /// issue names; other multi-cell shapes are unchanged (no worse than before).
+#[cfg(feature = "write-support")]
 pub fn assemble_read_cells(cells: Vec<CellData>, schema: &TableSchema) -> Result<RowCells> {
     // Group cells by column, preserving first-seen order so a stable, schema-
     // independent ordering results (downstream keys by name, so order is not
@@ -72,11 +86,22 @@ pub fn assemble_read_cells(cells: Vec<CellData>, schema: &TableSchema) -> Result
     for cell in cells {
         let name: Arc<str> = Arc::from(cell.column.as_str());
         if cell.is_complex_element {
-            // Drop element tombstones (a deleted set/list member or map entry):
+            // Drop element tombstones (a deleted set/list member OR map entry):
             // the whole element is removed. A collection with NO surviving live
             // element is left absent (reads null downstream) — an empty non-frozen
             // collection IS null in Cassandra, and this preserves the pre-fix
             // behaviour for that edge (the fix only recovers dropped LIVE elements).
+            //
+            // ADJUDICATION (issue #2324, roborev 1628): dropping a deleted MAP
+            // entry — rather than surfacing it as `(key, Null)` — is DELIBERATE and
+            // matches real Cassandra SELECT output, the read-path authority per the
+            // #1742 query-semantics-oracle doctrine: a `SELECT` never returns a
+            // deleted map key. This DIVERGES from the single-generation reader's
+            // physical `collapsed_value` (complex_column.rs ~L663-733), which keeps
+            // the `(key, Null)` pair for the physical-dump oracle; that quirk is the
+            // divergent physical side, tracked separately (issue #2336 family). Do
+            // NOT "fix" this to preserve `(key, Null)` here — that would corrupt the
+            // merger read-shape a `do_get` returns.
             if cell.is_deleted || matches!(cell.value, Value::Tombstone(_)) {
                 continue;
             }
@@ -139,7 +164,11 @@ fn register_complex<'a>(
 /// Collapse the surviving live elements of one complex column into a single
 /// `Value`, using the column's declared collection type from `schema`.
 #[cfg(feature = "write-support")]
-fn assemble_complex(name: &str, elements: Vec<CellData>, schema: &TableSchema) -> Result<Value> {
+fn assemble_complex(
+    name: &str,
+    mut elements: Vec<CellData>,
+    schema: &TableSchema,
+) -> Result<Value> {
     // Resolve the declared collection type. An undeclared column (the Flight
     // producer builds cells for every on-disk column, even ones the caller did
     // not declare) has no type here; such columns are never emitted to Arrow, so
@@ -157,8 +186,22 @@ fn assemble_complex(name: &str, elements: Vec<CellData>, schema: &TableSchema) -
     let cql_type = unwrap_frozen(&cql_type);
 
     match cql_type {
-        CqlType::Set(_) => Ok(Value::Set(elements.into_iter().map(|e| e.value).collect())),
-        CqlType::List(_) => Ok(Value::List(elements.into_iter().map(|e| e.value).collect())),
+        // A set's element identity IS its `cell_path`; order by the declared
+        // element comparator so a set spanning multiple SSTables (whose elements
+        // arrive in run-encounter, not disk, order) reconstructs in the SAME order
+        // a single-generation `SELECT` returns (issue #2324, roborev 1628).
+        CqlType::Set(inner) => {
+            let elem_cmp = ComparatorType::from_cql_type(inner)?;
+            sort_elements_by_cell_path_value(&mut elements, &elem_cmp)?;
+            Ok(Value::Set(elements.into_iter().map(|e| e.value).collect()))
+        }
+        // A list element's `cell_path` is its position timeuuid, which orders by
+        // raw byte comparison — sort by `cell_path` bytes so multi-SSTable list
+        // elements land in authoritative position order, not arrival order.
+        CqlType::List(_) => {
+            elements.sort_by(|a, b| cell_path_bytes(a).cmp(cell_path_bytes(b)));
+            Ok(Value::List(elements.into_iter().map(|e| e.value).collect()))
+        }
         CqlType::Map(key_type, _) => {
             let key_cmp = ComparatorType::from_cql_type(key_type)?;
             let mut entries = Vec::with_capacity(elements.len());
@@ -169,12 +212,67 @@ fn assemble_complex(name: &str, elements: Vec<CellData>, schema: &TableSchema) -
                 let key = deserialize_value_bytes(key_bytes, &key_cmp)?;
                 entries.push((key, e.value));
             }
+            // Order entries by the declared key comparator so a map spanning
+            // multiple SSTables reconstructs in authoritative key order.
+            sort_entries_by_key(&mut entries, &key_cmp)?;
             Ok(Value::Map(entries))
         }
         // A non-collection complex column (e.g. non-frozen top-level UDT):
         // reassembly of those shapes is out of this issue's scope. Keep the last
         // element's value (prior behaviour) so nothing regresses.
         _ => Ok(last_value(elements)),
+    }
+}
+
+/// The element's authoritative `cell_path` bytes (empty when absent).
+#[cfg(feature = "write-support")]
+fn cell_path_bytes(cell: &CellData) -> &[u8] {
+    cell.cell_path.as_deref().unwrap_or(&[])
+}
+
+/// Order set elements by their `cell_path` (the element identity) using the
+/// declared element comparator, in place. Decodes each `cell_path` once up front
+/// (fallible → propagated) so the sort itself is total and infallible.
+#[cfg(feature = "write-support")]
+fn sort_elements_by_cell_path_value(
+    elements: &mut Vec<CellData>,
+    cmp: &ComparatorType,
+) -> Result<()> {
+    let mut keyed: Vec<(Value, CellData)> = Vec::with_capacity(elements.len());
+    for cell in std::mem::take(elements) {
+        let key = deserialize_value_bytes(cell_path_bytes(&cell), cmp)?;
+        keyed.push((key, cell));
+    }
+    sort_by_comparator(&mut keyed, cmp)?;
+    elements.extend(keyed.into_iter().map(|(_, cell)| cell));
+    Ok(())
+}
+
+/// Order `(key, value)` map entries by their key using the declared key
+/// comparator, in place.
+#[cfg(feature = "write-support")]
+fn sort_entries_by_key(entries: &mut [(Value, Value)], cmp: &ComparatorType) -> Result<()> {
+    sort_by_comparator(entries, cmp)
+}
+
+/// Sort `items` by the first tuple element with the fallible [`ComparatorType`],
+/// capturing the first comparison error (a type mismatch the declared metadata
+/// should never produce) and surfacing it rather than silently mis-ordering.
+#[cfg(feature = "write-support")]
+fn sort_by_comparator<T>(items: &mut [(Value, T)], cmp: &ComparatorType) -> Result<()> {
+    let mut first_err: Option<Error> = None;
+    items.sort_by(|a, b| match cmp.compare(&a.0, &b.0) {
+        Ok(ord) => ord,
+        Err(e) => {
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
+            Ordering::Equal
+        }
+    });
+    match first_err {
+        Some(e) => Err(e),
+        None => Ok(()),
     }
 }
 
@@ -342,6 +440,81 @@ mod tests {
             get(&out, "nums"),
             Some(&Value::Set(vec![Value::Integer(10)])),
             "a deleted set member must be dropped from the reassembled collection"
+        );
+    }
+
+    #[test]
+    fn elements_reassemble_in_cell_path_order_not_arrival_order() {
+        // Simulate multi-SSTable merge arrival: elements registered OUT of
+        // cell_path order (a newer run's members encountered first). The
+        // reassembled collection must land in authoritative cell_path order, not
+        // arrival order (issue #2324, roborev 1628).
+        let cells = vec![
+            // set<int>: cell_path is the 4-byte big-endian member; arrive 30,10,20.
+            elem("nums", Value::Integer(30), vec![0, 0, 0, 30]),
+            elem("nums", Value::Integer(10), vec![0, 0, 0, 10]),
+            elem("nums", Value::Integer(20), vec![0, 0, 0, 20]),
+            // list<int>: cell_path is the position (single byte here); arrive 2,0,1.
+            elem("items", Value::Integer(200), vec![2]),
+            elem("items", Value::Integer(0), vec![0]),
+            elem("items", Value::Integer(100), vec![1]),
+            // map<text,bigint>: cell_path is the key; arrive gamma,alpha,beta.
+            elem("m", Value::BigInt(3), b"gamma".to_vec()),
+            elem("m", Value::BigInt(1), b"alpha".to_vec()),
+            elem("m", Value::BigInt(2), b"beta".to_vec()),
+        ];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "nums"),
+            Some(&Value::Set(vec![
+                Value::Integer(10),
+                Value::Integer(20),
+                Value::Integer(30),
+            ])),
+            "SET must reassemble in element (cell_path) order, not arrival order"
+        );
+        assert_eq!(
+            get(&out, "items"),
+            Some(&Value::List(vec![
+                Value::Integer(0),
+                Value::Integer(100),
+                Value::Integer(200),
+            ])),
+            "LIST must reassemble in position (cell_path) order, not arrival order"
+        );
+        assert_eq!(
+            get(&out, "m"),
+            Some(&Value::Map(vec![
+                (Value::Text("alpha".into()), Value::BigInt(1)),
+                (Value::Text("beta".into()), Value::BigInt(2)),
+                (Value::Text("gamma".into()), Value::BigInt(3)),
+            ])),
+            "MAP must reassemble in key (cell_path) order, not arrival order"
+        );
+    }
+
+    #[test]
+    fn map_deleted_entry_omitted_per_cassandra_select_semantics() {
+        // A deleted MAP entry is OMITTED from the reassembled map — matching real
+        // Cassandra SELECT output (the read-path authority, issue #1742). This
+        // intentionally diverges from the single-generation reader's physical
+        // collapsed_value, which keeps a (key, Null) pair (issue #2324, roborev
+        // 1628 adjudication; see the module doc + drop-site comment).
+        let mut deleted = elem("m", Value::BigInt(999), b"gone".to_vec());
+        deleted.is_deleted = true;
+        let cells = vec![
+            elem("m", Value::BigInt(1), b"alpha".to_vec()),
+            deleted,
+            elem("m", Value::BigInt(2), b"beta".to_vec()),
+        ];
+        let out = assemble_read_cells(cells, &schema()).unwrap();
+        assert_eq!(
+            get(&out, "m"),
+            Some(&Value::Map(vec![
+                (Value::Text("alpha".into()), Value::BigInt(1)),
+                (Value::Text("beta".into()), Value::BigInt(2)),
+            ])),
+            "a deleted map entry must be omitted (no (key, Null)) per Cassandra SELECT semantics"
         );
     }
 

--- a/cqlite-flight/src/agg.rs
+++ b/cqlite-flight/src/agg.rs
@@ -178,6 +178,24 @@ impl AggPlan {
         })
     }
 
+    /// Insert every column this aggregation references — the group-by keys and
+    /// each aggregate's source column (`count(*)` has none) — into `out`.
+    ///
+    /// Used by the producer's projection-aware row assembly (issue #2324, roborev
+    /// 1633): these are exactly the columns the reassembled row must materialize
+    /// for the aggregation, so they belong in the assembler's "needed" set even
+    /// though an aggregate query emits the PARTIAL schema, not the base columns.
+    pub(crate) fn collect_referenced_columns(&self, out: &mut std::collections::HashSet<String>) {
+        for (name, _) in &self.group_by {
+            out.insert(name.clone());
+        }
+        for agg in &self.aggregates {
+            if let Some(column) = &agg.column {
+                out.insert(column.clone());
+            }
+        }
+    }
+
     fn plan_one(spec: &AggregateSpec, schema: &TableSchema) -> Result<PlannedAggregate, AggError> {
         // count(*) is the only function that may omit a column.
         let (source_type, sum_kind) = match (&spec.func, &spec.column) {

--- a/cqlite-flight/src/filter.rs
+++ b/cqlite-flight/src/filter.rs
@@ -193,6 +193,28 @@ impl FilterExpr {
     pub fn keeps(&self, row: &QueryRow) -> bool {
         matches!(self.evaluate(row), Kleene::True)
     }
+
+    /// Insert every column name this predicate tree references into `out`.
+    ///
+    /// Used by the producer's projection-aware row assembly (issue #2324, roborev
+    /// 1633): a column a predicate reads must be materialized even when it is
+    /// projected OUT of the output, so it belongs in the assembler's "needed" set.
+    pub fn collect_referenced_columns(&self, out: &mut std::collections::HashSet<String>) {
+        match self {
+            FilterExpr::Leaf(p) => {
+                out.insert(p.column.clone());
+            }
+            FilterExpr::IsNull(column) => {
+                out.insert(column.clone());
+            }
+            FilterExpr::Not(inner) => inner.collect_referenced_columns(out),
+            FilterExpr::And(exprs) | FilterExpr::Or(exprs) => {
+                for e in exprs {
+                    e.collect_referenced_columns(out);
+                }
+            }
+        }
+    }
 }
 
 /// A fully-resolved scan: what to keep and which columns to emit.

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -766,6 +766,8 @@ impl MergeProducer {
         // Issue #1817: one partition-key decode cache for the whole merge; each
         // partition's rows arrive consecutively, so its key decodes once.
         let mut pk_cache = PartitionKeyCache::default();
+        // Issue #2324 (roborev 1633): projection-aware assembly set, computed once.
+        let assemble_cols = self.assemble_columns();
 
         'partitions: loop {
             if cancel.is_cancelled() {
@@ -795,10 +797,17 @@ impl MergeProducer {
             // Count a partition actually scanned (post token-range filter).
             meter.record_partition();
             for entry in rows {
-                // Build the FULL row so predicates can reference any column, even
-                // one projected out of the output. Output projection is applied
-                // separately via `self.columns` during Arrow conversion.
-                let Some(row) = self.entry_to_row(&key.key, entry.row_data, &mut pk_cache)? else {
+                // Build the row so predicates can reference any projected-out
+                // column too (`assemble_cols` includes filter-referenced columns);
+                // output projection is applied via `self.columns` during Arrow
+                // conversion. Columns the scan never reads are skipped in assembly.
+                let Some(row) = self.entry_to_row(
+                    &key.key,
+                    entry.row_data,
+                    &mut pk_cache,
+                    assemble_cols.as_ref(),
+                )?
+                else {
                     continue;
                 };
                 // Count a row materialised/examined by the scan (BEFORE the
@@ -880,6 +889,8 @@ impl MergeProducer {
         // Issue #1817: one partition-key decode cache for the whole aggregate
         // merge; each partition's rows arrive consecutively, so its key decodes once.
         let mut pk_cache = PartitionKeyCache::default();
+        // Issue #2324 (roborev 1633): projection-aware assembly set, computed once.
+        let assemble_cols = self.assemble_columns();
         loop {
             if cancel.is_cancelled() {
                 return Err(ProducerError::Cancelled);
@@ -902,7 +913,13 @@ impl MergeProducer {
                 }
             }
             for entry in rows {
-                let Some(row) = self.entry_to_row(&key.key, entry.row_data, &mut pk_cache)? else {
+                let Some(row) = self.entry_to_row(
+                    &key.key,
+                    entry.row_data,
+                    &mut pk_cache,
+                    assemble_cols.as_ref(),
+                )?
+                else {
                     continue;
                 };
                 if let Some(filter) = &self.spec.filter {
@@ -916,11 +933,19 @@ impl MergeProducer {
         Ok(())
     }
 
-    /// Reconstruct one full logical row from a merged entry, or `None` for a row
+    /// Reconstruct one logical row from a merged entry, or `None` for a row
     /// tombstone. Cell tombstones are dropped so the column reads as null.
     ///
-    /// The row carries ALL columns (no projection) so predicate evaluation can
-    /// reference any column; output projection is applied later via `self.columns`.
+    /// The row carries the columns this scan actually reads — the output
+    /// projection PLUS any column the predicate or aggregation references, so
+    /// predicate evaluation can still reference a projected-out column. `needed`
+    /// (`None` = every column, a plain `SELECT *`) is threaded into
+    /// [`assemble_read_cells`]; a column outside that set is dropped BEFORE
+    /// reassembly. That is the projection-scoped fail-closed contract (issue
+    /// #2324, roborev 1633): the composite-keyed-collection error (#2339) fires
+    /// ONLY for a column the query projects/references — an unrelated `SELECT`
+    /// over a row that merely coexists with an unsupported composite-keyed
+    /// collection column succeeds, matching the observable pre-#2324 behaviour.
     ///
     /// Fallible: reassembling a collection column can surface authoritative
     /// corruption (e.g. a map key whose `cell_path` bytes do not decode under the
@@ -931,6 +956,7 @@ impl MergeProducer {
         partition_key: &[u8],
         row_data: RowData,
         pk_cache: &mut PartitionKeyCache,
+        needed: Option<&std::collections::HashSet<String>>,
     ) -> Result<Option<QueryRow>, ProducerError> {
         let cells = match row_data {
             RowData::Live { cells } => cells,
@@ -951,9 +977,12 @@ impl MergeProducer {
         // carrier every scan producer builds, so `build_row_from_scan`
         // disassembles it into real column values (never the non-row fallback that
         // once emitted `Value::Map` and dropped every column — roborev H2).
-        let row_cells: RowCells =
-            cqlite_core::storage::write_engine::merge::assemble_read_cells(cells, &self.schema)
-                .map_err(ProducerError::Merge)?;
+        let row_cells: RowCells = cqlite_core::storage::write_engine::merge::assemble_read_cells(
+            cells,
+            &self.schema,
+            needed,
+        )
+        .map_err(ProducerError::Merge)?;
 
         let key = RowKey::new(partition_key.to_vec());
         // Issue #1817: reuse the caller's per-merge partition-key decode cache so a
@@ -966,6 +995,46 @@ impl MergeProducer {
             Some(&self.schema),
             pk_cache,
         ))
+    }
+
+    /// The projection-aware set of column names this scan actually reads — the
+    /// columns [`entry_to_row`](Self::entry_to_row) must materialize. `None` means
+    /// "every column": a plain `SELECT *` with no aggregation, where nothing is
+    /// dropped. Computed once per merge (negligible), threaded into
+    /// [`assemble_read_cells`] to scope the composite-keyed-collection fail-closed
+    /// error (#2339) to columns a query projects/references (issue #2324, roborev
+    /// 1633) and to skip reassembling collections the query never emits.
+    fn assemble_columns(&self) -> Option<std::collections::HashSet<String>> {
+        use std::collections::HashSet;
+        match &self.agg {
+            // Aggregation: the reassembled row feeds ONLY the aggregation (group-by
+            // keys + aggregate source columns) and the predicate filter — the
+            // projected row columns are NOT emitted (the partial aggregate schema
+            // is). So the needed set is exactly those, independent of projection;
+            // an aggregate that references no regular column (e.g. `count(*)`)
+            // needs none of the row's collection columns.
+            Some(agg) => {
+                let mut needed = HashSet::new();
+                agg.collect_referenced_columns(&mut needed);
+                if let Some(filter) = &self.spec.filter {
+                    filter.collect_referenced_columns(&mut needed);
+                }
+                Some(needed)
+            }
+            // Row path: a `SELECT *` (no projection) emits every column → assemble
+            // all (None). With an explicit projection the needed set is the output
+            // columns (`self.columns`, already projection-restricted) plus any the
+            // predicate filter references (a filter may test a projected-out column).
+            None => {
+                self.spec.projection.as_ref()?;
+                let mut needed: HashSet<String> =
+                    self.columns.iter().map(|c| c.name.clone()).collect();
+                if let Some(filter) = &self.spec.filter {
+                    filter.collect_referenced_columns(&mut needed);
+                }
+                Some(needed)
+            }
+        }
     }
 
     /// Merge `paths` WITHOUT the input prune, relying only on the per-partition

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -32,7 +32,7 @@ use cqlite_core::query::{
 use cqlite_core::schema::{CqlType, TableSchema};
 use cqlite_core::storage::write_engine::merge::{MergeStep, RowData};
 use cqlite_core::storage::write_engine::KWayMerger;
-use cqlite_core::types::{DataType, RowCells, ScanRow, Value};
+use cqlite_core::types::{DataType, RowCells, ScanRow};
 use cqlite_core::RowKey;
 
 use crate::agg::{AggError, AggPlan};
@@ -798,7 +798,7 @@ impl MergeProducer {
                 // Build the FULL row so predicates can reference any column, even
                 // one projected out of the output. Output projection is applied
                 // separately via `self.columns` during Arrow conversion.
-                let Some(row) = self.entry_to_row(&key.key, entry.row_data, &mut pk_cache) else {
+                let Some(row) = self.entry_to_row(&key.key, entry.row_data, &mut pk_cache)? else {
                     continue;
                 };
                 // Count a row materialised/examined by the scan (BEFORE the
@@ -902,7 +902,7 @@ impl MergeProducer {
                 }
             }
             for entry in rows {
-                let Some(row) = self.entry_to_row(&key.key, entry.row_data, &mut pk_cache) else {
+                let Some(row) = self.entry_to_row(&key.key, entry.row_data, &mut pk_cache)? else {
                     continue;
                 };
                 if let Some(filter) = &self.spec.filter {
@@ -921,41 +921,51 @@ impl MergeProducer {
     ///
     /// The row carries ALL columns (no projection) so predicate evaluation can
     /// reference any column; output projection is applied later via `self.columns`.
+    ///
+    /// Fallible: reassembling a collection column can surface authoritative
+    /// corruption (e.g. a map key whose `cell_path` bytes do not decode under the
+    /// declared key type). Such a failure is propagated as a `Merge` error rather
+    /// than silently dropping the row (issue #2324, no-heuristics / no-silent-loss).
     fn entry_to_row(
         &self,
         partition_key: &[u8],
         row_data: RowData,
         pk_cache: &mut PartitionKeyCache,
-    ) -> Option<QueryRow> {
+    ) -> Result<Option<QueryRow>, ProducerError> {
         let cells = match row_data {
             RowData::Live { cells } => cells,
             // Whole-row deletion: suppress from output.
-            RowData::Tombstone { .. } => return None,
+            RowData::Tombstone { .. } => return Ok(None),
         };
 
-        // Issue #1334: build the SAME `ScanRow::Row` carrier every scan producer
-        // builds, so `build_row_from_scan` disassembles it into real column values
-        // (previously this emitted `Value::Map`, which fell through to the non-row
-        // fallback and silently dropped every Flight column value — roborev H2).
-        let row_cells: RowCells = cells
-            .into_iter()
-            // A cell tombstone leaves the column absent → null in Arrow output,
-            // matching the CLI's "emit null for tombstoned cells" behaviour.
-            .filter(|c| !matches!(c.value, Value::Tombstone(_)))
-            .map(|c| (std::sync::Arc::from(c.column.as_str()), c.value))
-            .collect();
+        // Issue #2324: the k-way merger emits every element of a non-frozen
+        // collection (list/set/map) as its OWN cell, all sharing the column name.
+        // Keying those by name (as `build_row_from_scan` does) would keep only the
+        // LAST element and silently drop the rest of the collection. Reassemble
+        // the per-element cells into a single `Value::List` / `Value::Set` /
+        // `Value::Map` per column — mirroring the single-generation reader's
+        // collapsed shape — BEFORE building the row carrier. Simple cell tombstones
+        // are dropped (column reads null), matching the prior behaviour.
+        //
+        // Issue #1334: the assembled cells still feed the SAME `ScanRow::Row`
+        // carrier every scan producer builds, so `build_row_from_scan`
+        // disassembles it into real column values (never the non-row fallback that
+        // once emitted `Value::Map` and dropped every column — roborev H2).
+        let row_cells: RowCells =
+            cqlite_core::storage::write_engine::merge::assemble_read_cells(cells, &self.schema)
+                .map_err(ProducerError::Merge)?;
 
         let key = RowKey::new(partition_key.to_vec());
         // Issue #1817: reuse the caller's per-merge partition-key decode cache so a
         // partition's rows (emitted consecutively by the k-way merger) decode the
         // key once, not once per row. Output is byte-identical.
-        build_row_from_scan_cached(
+        Ok(build_row_from_scan_cached(
             key,
             ScanRow::Row(row_cells),
             &[],
             Some(&self.schema),
             pk_cache,
-        )
+        ))
     }
 
     /// Merge `paths` WITHOUT the input prune, relying only on the per-partition

--- a/cqlite-flight/tests/collection_collapse_parity_test.rs
+++ b/cqlite-flight/tests/collection_collapse_parity_test.rs
@@ -1,0 +1,327 @@
+//! Issue #2324: the Flight producer's `entry_to_row` must reassemble a non-frozen
+//! collection's per-element cells (list/set/map) into the WHOLE collection value,
+//! not collapse it to the last cell.
+//!
+//! The k-way merger emits every element of a non-frozen collection as its own
+//! cell, all sharing the column name. `build_row_from_scan` keys the row's cells
+//! by name into a `HashMap`, so before the fix every collection column returned
+//! only its LAST element over `do_get` — silent partial data. This is identical
+//! on the scan and point paths (both drive `drive_merge` → `entry_to_row`), which
+//! is exactly why the dual-path parity oracle stayed green while the OUTPUT was
+//! wrong on both.
+//!
+//! Oracle: the sstabledump JSONL golden for `test_collections.collection_table`.
+//! Partition `8d08e3a4-…` carries a `SET<INT>` (9 members), a `SET<TEXT>` (4), a
+//! `LIST<INT>` (3, order-significant), a `MAP<TEXT,TEXT>` (8 entries) and a
+//! `MAP<TEXT,BIGINT>` (5 entries) — every one multi-element, so a last-cell-wins
+//! collapse is unmissable. Both the full scan and a PK-targeted point read are
+//! asserted to return the FULL collection contents.
+//!
+//! Skips (never fails) when `CQLITE_DATASETS_ROOT` is unset or the `Data.db`
+//! binary is absent (a worktree without `fetch-datasets.sh`), but asserts the
+//! target row IS found whenever it runs — never a silent 0-row false pass.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use arrow::array::{
+    Array, FixedSizeBinaryArray, Int32Array, Int64Array, ListArray, MapArray, StringArray,
+};
+use arrow::compute::concat_batches;
+use arrow::record_batch::RecordBatch;
+
+use cqlite_core::query::{SSTableFilterOp, SSTablePredicate};
+use cqlite_core::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
+use cqlite_core::types::Value;
+use cqlite_flight::cancel::CancelFlag;
+use cqlite_flight::filter::{FilterExpr, ScanSpec};
+use cqlite_flight::producer::{DirSource, MergeProducer, SstableSource};
+
+/// Raw 16 bytes of a hyphenated UUID string.
+fn uuid_bytes(s: &str) -> [u8; 16] {
+    let hex: String = s.chars().filter(|c| *c != '-').collect();
+    assert_eq!(hex.len(), 32, "not a 16-byte UUID: {s:?}");
+    let mut out = [0u8; 16];
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).expect("hex");
+    }
+    out
+}
+
+fn col(name: &str, ty: &str) -> Column {
+    Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
+}
+
+fn collection_table_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_collections".into(),
+        table: "collection_table".into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "uuid".into(),
+            position: 0,
+        }],
+        clustering_keys: Vec::<ClusteringColumn>::new(),
+        columns: vec![
+            col("id", "uuid"),
+            col("tags", "set<text>"),
+            col("scores", "list<int>"),
+            col("properties", "map<text, text>"),
+            col("numbers_set", "set<int>"),
+            col("ordered_values", "list<timestamp>"),
+            col("metadata_map", "map<text, bigint>"),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Index of the row whose `id` FixedSizeBinary(16) equals `target`.
+fn find_row(batch: &RecordBatch, target: &[u8; 16]) -> usize {
+    let idx = batch.schema().index_of("id").expect("id column present");
+    let ids = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<FixedSizeBinaryArray>()
+        .expect("id is FixedSizeBinary(16)");
+    (0..batch.num_rows())
+        .find(|&r| ids.value(r) == target.as_slice())
+        .unwrap_or_else(|| {
+            panic!(
+                "target partition row not found in {} rows",
+                batch.num_rows()
+            )
+        })
+}
+
+/// The `List<Int32>` value at `row` of column `name`, in on-disk order.
+fn list_i32(batch: &RecordBatch, name: &str, row: usize) -> Vec<i32> {
+    let idx = batch.schema().index_of(name).expect("column present");
+    let list = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap_or_else(|| panic!("{name} is not a List array"));
+    let vals = list.value(row);
+    let ints = vals
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .expect("list items are Int32");
+    (0..ints.len()).map(|i| ints.value(i)).collect()
+}
+
+/// The `List<Utf8>` value at `row` of column `name`.
+fn list_text(batch: &RecordBatch, name: &str, row: usize) -> Vec<String> {
+    let idx = batch.schema().index_of(name).expect("column present");
+    let list = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap_or_else(|| panic!("{name} is not a List array"));
+    let vals = list.value(row);
+    let strs = vals
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("list items are Utf8");
+    (0..strs.len()).map(|i| strs.value(i).to_string()).collect()
+}
+
+/// The `Map<Utf8,Utf8>` entries at `row` of column `name`.
+fn map_text(batch: &RecordBatch, name: &str, row: usize) -> Vec<(String, String)> {
+    let idx = batch.schema().index_of(name).expect("column present");
+    let map = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .unwrap_or_else(|| panic!("{name} is not a Map array"));
+    let entries = map.value(row);
+    let keys = entries
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("map keys Utf8");
+    let vals = entries
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("map values Utf8");
+    (0..keys.len())
+        .map(|i| (keys.value(i).to_string(), vals.value(i).to_string()))
+        .collect()
+}
+
+/// The `Map<Utf8,Int64>` entries at `row` of column `name`.
+fn map_bigint(batch: &RecordBatch, name: &str, row: usize) -> Vec<(String, i64)> {
+    let idx = batch.schema().index_of(name).expect("column present");
+    let map = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .unwrap_or_else(|| panic!("{name} is not a Map array"));
+    let entries = map.value(row);
+    let keys = entries
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("map keys Utf8");
+    let vals = entries
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("map values Int64");
+    (0..keys.len())
+        .map(|i| (keys.value(i).to_string(), vals.value(i)))
+        .collect()
+}
+
+/// Assert the full collection contents of the target partition in `combined`.
+fn assert_full_collections(combined: &RecordBatch, target: &[u8; 16], path: &str) {
+    let row = find_row(combined, target);
+
+    // SET<INT> — 9 members (order not significant for a set).
+    let mut numbers = list_i32(combined, "numbers_set", row);
+    numbers.sort_unstable();
+    assert_eq!(
+        numbers,
+        vec![148, 461, 473, 794, 831, 857, 881, 976, 998],
+        "{path}: numbers_set SET<INT> must reassemble ALL 9 members, not last-cell-wins"
+    );
+
+    // LIST<INT> — 3 members, on-disk ORDER is significant.
+    assert_eq!(
+        list_i32(combined, "scores", row),
+        vec![53, 45, 17],
+        "{path}: scores LIST<INT> must preserve all 3 members in order"
+    );
+
+    // SET<TEXT> — 4 members.
+    let mut tags = list_text(combined, "tags", row);
+    tags.sort();
+    assert_eq!(
+        tags,
+        vec![
+            "out".to_string(),
+            "reflect".to_string(),
+            "street".to_string(),
+            "win".to_string()
+        ],
+        "{path}: tags SET<TEXT> must reassemble all 4 members"
+    );
+
+    // MAP<TEXT,TEXT> — 8 entries (map key decoded from the element cell_path).
+    let mut props = map_text(combined, "properties", row);
+    props.sort();
+    assert_eq!(
+        props,
+        vec![
+            ("clearly".into(), "population".into()),
+            ("close".into(), "time".into()),
+            ("condition".into(), "plan".into()),
+            ("former".into(), "stand".into()),
+            ("leg".into(), "meeting".into()),
+            ("probably".into(), "must".into()),
+            ("suggest".into(), "nation".into()),
+            ("word".into(), "help".into()),
+        ],
+        "{path}: properties MAP<TEXT,TEXT> must reassemble all 8 entries"
+    );
+
+    // MAP<TEXT,BIGINT> — 5 entries.
+    let mut md = map_bigint(combined, "metadata_map", row);
+    md.sort();
+    assert_eq!(
+        md,
+        vec![
+            ("along".into(), 264406),
+            ("court".into(), 646569),
+            ("his".into(), 43965),
+            ("professor".into(), 992825),
+            ("stop".into(), 818561),
+        ],
+        "{path}: metadata_map MAP<TEXT,BIGINT> must reassemble all 5 entries"
+    );
+}
+
+fn table_dir() -> Option<PathBuf> {
+    let root = std::env::var_os("CQLITE_DATASETS_ROOT")?;
+    let dir = PathBuf::from(&root)
+        .join("sstables")
+        .join("test_collections")
+        .join("collection_table-6b8c8fb0a25111f0a3fef1a551383fb9");
+    if dir.join("nb-1-big-Data.db").is_file() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+// The multi-element target partition (from the JSONL golden).
+const TARGET_UUID: &str = "8d08e3a4-a8b1-4697-8957-82bbded1e343";
+
+#[test]
+fn scan_path_reassembles_full_collections() {
+    let Some(dir) = table_dir() else {
+        eprintln!("collection_table Data.db absent — skipping (run fetch-datasets.sh)");
+        return;
+    };
+    let schema = collection_table_schema();
+    let spec = ScanSpec {
+        token: None,
+        filter: None,
+        projection: None,
+        limit: None,
+    };
+    let producer = MergeProducer::with_spec(schema, 64, spec).unwrap();
+    let batches = producer
+        .produce_from_paths(DirSource::new(&dir).data_paths().unwrap())
+        .unwrap();
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert!(rows > 0, "scan must return rows (never a 0-row false pass)");
+
+    let arrow_schema = producer.arrow_schema().unwrap();
+    let combined = concat_batches(&arrow_schema.into(), &batches).unwrap();
+    assert_full_collections(&combined, &uuid_bytes(TARGET_UUID), "scan");
+}
+
+#[test]
+fn point_path_reassembles_full_collections() {
+    let Some(dir) = table_dir() else {
+        eprintln!("collection_table Data.db absent — skipping (run fetch-datasets.sh)");
+        return;
+    };
+    let target = uuid_bytes(TARGET_UUID);
+    let schema = collection_table_schema();
+    // PK-targeted point read (issue #2207 path): id = <target>.
+    let filter = FilterExpr::Leaf(SSTablePredicate {
+        column: "id".into(),
+        operation: SSTableFilterOp::Equal,
+        values: vec![Value::Uuid(target)],
+        token_columns: None,
+    });
+    let spec = ScanSpec {
+        token: None,
+        filter: Some(filter),
+        projection: None,
+        limit: None,
+    };
+    let producer = MergeProducer::with_spec(schema, 64, spec).unwrap();
+    let paths = producer.resolve_paths(&DirSource::new(&dir)).unwrap();
+    let batches = producer
+        .produce_streaming_to_vec(paths, &CancelFlag::new())
+        .unwrap();
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert!(
+        rows > 0,
+        "point read must return the target row (never a 0-row false pass)"
+    );
+
+    let arrow_schema = producer.arrow_schema().unwrap();
+    let combined = concat_batches(&arrow_schema.into(), &batches).unwrap();
+    assert_full_collections(&combined, &target, "point");
+}


### PR DESCRIPTION
Fixes #2324 (flight multi-cell collection collapse — 0.14 field-readiness, round-6 blocker per owner decision).

## Problem
The Arrow Flight producer collapsed multi-cell collections (list/set/map) to their **last element**: the KWayMerger row output drops the reader's `collapsed_value`, so `entry_to_row` saw one bare scalar per collection column. Arrow's List/Map conversion then rejected the row: `Convert(InvalidValue("expected List/Set value, got Text(\"win\")"))`.

**Red evidence**: with the fix stashed, both parity tests fail at the produce step with exactly that error (scan AND #2207 point paths).

## Fix
- New `cqlite_core::storage::write_engine::merge::assemble_read_cells` (`read_assembly.rs`): regroups a merged row's per-element cells and assembles `Value::List/Set/Map`.
  - Map keys decoded from `cell_path` via the canonical `deserialize_value_bytes` codec (authoritative, no-heuristics #28) — never a hand-rolled match.
  - Elements sorted by authoritative `cell_path` order (list = position-timeuuid byte order; set/map = declared comparator) — fixes wrong-order reconstruction when elements span SSTables (roborev 1628 finding, red-proven).
  - **Map-tombstone adjudication (in-code, `read_assembly.rs`)**: deleted map entries are **omitted**, matching real Cassandra SELECT semantics (#1742 query-semantics authority). This deliberately does NOT mirror the single-gen `collapsed_value` quirk that keeps `(key, Null)` — that divergence is tracked in the #2336 family. Pinned test: `map_deleted_entry_omitted_per_cassandra_select_semantics`.
- `cqlite-flight`'s `entry_to_row` is now fallible — propagates a `Merge` error instead of silently dropping a corrupt row (scan/point/aggregate all share `drive_merge`).
- `#[cfg(feature = "write-support")]` gating verified against the minimal-features build (rust-reviewer blocker; `--no-default-features --features all-compression` clean).

## Tests
- `cqlite-flight/tests/collection_collapse_parity_test.rs`: real corpus, scan + point paths, exact golden contents (`List<Int32>`, `List<Utf8>`, `Map<Utf8,Utf8>`, `Map<Utf8,Int64>`).
- 8 core unit tests incl. ordering red-proof (`elements_reassemble_in_cell_path_order_not_arrival_order`) and tombstone semantics.
- Full `cqlite-flight` suite green (181+).

## Notes
- `CQLITE_ALLOW_FILE_GROWTH=1` on gates: pre-existing over-threshold `producer.rs`/`merge/mod.rs` nudged ~10 lines; splits are #1116's scope.
- Review trail: rust-reviewer (1 blocker + 1 important, fixed/pinned) + roborev 1628 (ordering fixed; map-tombstone declined with evidence, see in-code adjudication) at 7aaf54b8; fix round → bb746c04.
- Follow-ups: #2336 (core-side `partition_live_rows` same collapse); nit batch filed at merge (Arc-per-cell alloc, declared non-frozen UDT `last_value` fallback, mixed simple/complex silent drop).
- Full gate of record runs pre-merge in flow-closer (serialized after #1940's).