### PR TITLE
core(#2346): shared-reader merge seam + per-call scan_cancel (WS0 for #2310 warm handles)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -9,6 +9,7 @@
 use super::super::source::ScanCursor;
 use super::super::window_cursor::WindowCursor;
 use super::super::SSTableReader;
+use crate::storage::scan_cancel::ScanCancel;
 use crate::{Error, Result};
 use std::io::SeekFrom;
 use tokio::io::AsyncSeekExt;
@@ -544,9 +545,21 @@ impl SSTableReader {
     /// Returning `ControlFlow::Break` from `emit` stops the scan early
     /// (consumer dropped). Tombstone / timestamp semantics are byte-identical to
     /// the Vec variant (Issue #505/#533).
+    ///
+    /// `scan_cancel` is an explicit PER-CALL cancellation token (issue #2346),
+    /// not the reader's own [`SSTableReader::scan_cancel`] field: a cached/shared
+    /// `Arc<SSTableReader>` (a future warm-handle registry) may drive two
+    /// concurrent calls to this method with two INDEPENDENT tokens, so
+    /// cancellation cannot live as mutable per-reader state (`set_scan_cancel`
+    /// requires `&mut self`, uncallable through a shared `Arc`). Callers that
+    /// want the reader's own field's semantics (the pre-#2346 default) pass
+    /// `&self.scan_cancel` explicitly — see
+    /// [`SSTableReader::iterate_all_partitions_cancellable`] for the analogous
+    /// non-compaction seam.
     pub async fn stream_all_partitions_for_compaction<F>(
         &self,
         schema: Option<&crate::schema::TableSchema>,
+        scan_cancel: &ScanCancel,
         mut emit: F,
     ) -> Result<()>
     where
@@ -565,14 +578,18 @@ impl SSTableReader {
         // materialising iterator with ts=0 (matches the Vec-variant fallback).
         if !self.requires_chunk_stitching() {
             // The heavy, previously-uninterruptible work is inside
-            // `iterate_all_partitions` (→ `sequential_scan` → the block parser),
-            // which now polls `scan_cancel` per partition (issue #2264). Poll again
-            // per emitted row so a cancel that lands during the drain of the
-            // already-materialised Vec is also honoured promptly.
-            let entries = self.iterate_all_partitions().await?;
+            // `iterate_all_partitions_cancellable` (→ `sequential_scan` → the
+            // block parser), which now polls `scan_cancel` per partition (issue
+            // #2264). Poll again per emitted row so a cancel that lands during the
+            // drain of the already-materialised Vec is also honoured promptly.
+            // Issue #2346: route through the PER-CALL-token sibling (not the
+            // public `iterate_all_partitions`, which always uses the reader's own
+            // field) so this method's caller-supplied `scan_cancel` governs the
+            // whole non-stitching fallback too.
+            let entries = self.iterate_all_partitions_cancellable(scan_cancel).await?;
             for (i, (key, value)) in entries.into_iter().enumerate() {
                 if i & 0xFF == 0 {
-                    self.scan_cancel.check()?;
+                    scan_cancel.check()?;
                 }
                 let row =
                     super::super::compaction_row::CompactionRow::from_legacy_value(key, value, 0);
@@ -617,7 +634,7 @@ impl SSTableReader {
             // hundreds of chunks without ever completing (so the drain loop's
             // counter never advances).
             if chunk_count & 0xFF == 0 {
-                self.scan_cancel.check()?;
+                scan_cancel.check()?;
             }
             let decompressed_chunk = if compressed_chunk.len() >= max_compressed_length {
                 // Stored uncompressed by Cassandra — pass the raw bytes through.
@@ -653,6 +670,7 @@ impl SSTableReader {
                 false,
                 &mut emit,
                 &mut broke,
+                scan_cancel,
             )?;
             if broke {
                 return Ok(());
@@ -669,6 +687,7 @@ impl SSTableReader {
                 true,
                 &mut emit,
                 &mut broke,
+                scan_cancel,
             )?;
         }
 
@@ -694,6 +713,7 @@ impl SSTableReader {
         at_final_chunk: bool,
         emit: &mut F,
         broke: &mut bool,
+        scan_cancel: &ScanCancel,
     ) -> Result<()>
     where
         F: FnMut(super::super::compaction_row::CompactionRow) -> Result<std::ops::ControlFlow<()>>,
@@ -706,11 +726,12 @@ impl SSTableReader {
             }
             // Cooperative cancellation (issue #2264): for a chunk-stitched ('nb')
             // SSTable this is the per-partition hot loop the compaction stream (and
-            // thus a Flight `do_get`) spends its time in. Poll the reader's cancel
-            // token at a bounded interval so a disconnected client abandons the
-            // walk within milliseconds instead of the coarse ~1–2 min backstop.
+            // thus a Flight `do_get`) spends its time in. Poll the PER-CALL cancel
+            // token (issue #2346) at a bounded interval so a disconnected client
+            // abandons the walk within milliseconds instead of the coarse ~1–2 min
+            // backstop.
             if drained & 0xFF == 0 {
-                self.scan_cancel.check()?;
+                scan_cancel.check()?;
             }
             drained += 1;
             let mut local_break = false;

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -358,6 +358,80 @@ async fn mid_scan_cancel_aborts_before_finishing() {
     );
 }
 
+/// Red-then-green (issue #2346, BLOCKER 1): the STITCHED `sequential_scan` path
+/// (`requires_chunk_stitching()` branch) must honour the PER-CALL cancel token.
+///
+/// Pre-#2346-fix, that branch called `stitch_and_parse_all_chunks` with NO token
+/// (only the non-stitching branch polled), so a pre-cancelled caller blocked
+/// until the ENTIRE data section was stitched + parsed and returned `Ok(all
+/// partitions)` — the `Err(Cancelled)` assertion below FAILS against that code.
+/// After the fix the chunk-stitch loop polls at chunk 0 (`stitch_all_chunks_
+/// cancellable`) and aborts with `Error::Cancelled`.
+///
+/// This drives `sequential_scan` DIRECTLY (rather than through
+/// `iterate_all_partitions_cancellable`, whose index-backed branch a
+/// writer-produced fixture may enter) so the stitched branch is unambiguously
+/// exercised — `table_id` is intentionally ignored there (see the branch's own
+/// comment), so any value serves.
+///
+/// Pre-cancel is the DETERMINISTIC discriminator (same convention as
+/// `pre_cancelled_scan_aborts_at_first_poll` above): `sequential_scan` returns a
+/// materialised `Vec` with no emit callback, so a concurrent mid-scan cancel
+/// would be a wall-clock race — a pre-cancelled token instead proves the poll
+/// fires on the FIRST chunk with no timing dependency. The uncancelled control
+/// first proves this exact path yields every partition, so the abort is cutting
+/// real work short, not passing on an empty scan.
+#[tokio::test(flavor = "multi_thread")]
+async fn stitched_sequential_scan_honors_per_call_cancel() {
+    use crate::types::TableId;
+    const TOTAL: i32 = 1000;
+    let (_temp, data_path) = index_less_fixture(TOTAL).await;
+    let reader = open_reader(&data_path).await;
+
+    // Non-vacuity guard: the fixture MUST take the STITCHED branch (the
+    // BLOCKER-1 gap), not the non-stitching branch that already polled.
+    assert!(
+        reader.requires_chunk_stitching(),
+        "fixture must take the stitched sequential-scan branch to cover the \
+         #2346 BLOCKER-1 gap"
+    );
+
+    let schema = schema();
+    // `table_id` is ignored in the stitching branch, so any value works.
+    let table_id = TableId::from("test_ks.test_table");
+
+    // Positive control: an uncancelled pass over THIS path returns every
+    // partition — so the pre-cancel abort below is cutting real work short.
+    let uncancelled = reader
+        .sequential_scan(
+            &table_id,
+            None,
+            None,
+            None,
+            Some(&schema),
+            &ScanCancel::default(),
+        )
+        .await
+        .expect("uncancelled stitched scan must succeed");
+    assert_eq!(
+        uncancelled.len(),
+        TOTAL as usize,
+        "the stitched sequential-scan path must return every partition when not cancelled"
+    );
+
+    let cancel = ScanCancel::new();
+    cancel.cancel();
+    let result = reader
+        .sequential_scan(&table_id, None, None, None, Some(&schema), &cancel)
+        .await;
+    assert!(
+        matches!(result, Err(crate::Error::Cancelled)),
+        "a pre-cancelled stitched sequential-scan must abort with Error::Cancelled \
+         (issue #2346 BLOCKER-1), got {:?}",
+        result.map(|v| v.len())
+    );
+}
+
 /// RED PROOF (issue #2346): two concurrent scans over ONE SHARED
 /// `Arc<SSTableReader>` cancel INDEPENDENTLY.
 ///
@@ -384,23 +458,50 @@ async fn mid_scan_cancel_aborts_before_finishing() {
 /// mutable state.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn two_concurrent_scans_on_shared_reader_cancel_independently() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
     const TOTAL: i32 = 2000;
     const TRIP_AT: usize = 300;
+    const PARK_AT: usize = 300;
     let (_temp, data_path) = index_less_fixture(TOTAL).await;
     let reader = std::sync::Arc::new(open_reader(&data_path).await);
 
     let cancel_a = ScanCancel::new();
     let cancel_b = ScanCancel::new();
 
+    // Two-way handshake (roborev, issue #2346) — WITHOUT it scan B can finish
+    // before scan A ever cancels, so the test would pass even if cancellation
+    // WERE shared (A's cancel would arrive after B was already done). These
+    // latches force BOTH scans demonstrably in flight at the instant A cancels:
+    //   * `b_parked`  — B has reached PARK_AT (mid-scan, NOT finished) and is
+    //                   waiting; A must not cancel until this is set.
+    //   * `a_cancelled` — A has cancelled its own token; B resumes only after.
+    // Neither side can deadlock: each waits on a flag the OTHER (running on its
+    // own worker thread) sets independently. The busy-wait is a sync section
+    // inside the emit callback (which cannot `.await`); `worker_threads = 4`
+    // guarantees both tasks run on distinct workers concurrently. The `timeout`
+    // around the joins is a safety net, not the discriminator — the counts are.
+    let b_parked = std::sync::Arc::new(AtomicBool::new(false));
+    let a_cancelled = std::sync::Arc::new(AtomicBool::new(false));
+
     let reader_a = std::sync::Arc::clone(&reader);
     let cancel_a_task = cancel_a.clone();
+    let b_parked_a = std::sync::Arc::clone(&b_parked);
+    let a_cancelled_a = std::sync::Arc::clone(&a_cancelled);
     let handle_a = tokio::spawn(async move {
         let mut count = 0usize;
         let result = reader_a
             .stream_all_partitions_for_compaction(Some(&schema()), &cancel_a_task, |_row| {
                 count += 1;
                 if count == TRIP_AT {
+                    // Wait until B is demonstrably parked mid-scan, THEN cancel —
+                    // so B is provably still in flight when A's cancel fires.
+                    while !b_parked_a.load(Ordering::Acquire) {
+                        std::hint::spin_loop();
+                    }
                     cancel_a_task.cancel();
+                    a_cancelled_a.store(true, Ordering::Release);
                 }
                 Ok(std::ops::ControlFlow::Continue(()))
             })
@@ -410,19 +511,35 @@ async fn two_concurrent_scans_on_shared_reader_cancel_independently() {
 
     let reader_b = std::sync::Arc::clone(&reader);
     let cancel_b_task = cancel_b.clone();
+    let b_parked_b = std::sync::Arc::clone(&b_parked);
+    let a_cancelled_b = std::sync::Arc::clone(&a_cancelled);
     let handle_b = tokio::spawn(async move {
         let mut count = 0usize;
         let result = reader_b
             .stream_all_partitions_for_compaction(Some(&schema()), &cancel_b_task, |_row| {
                 count += 1;
+                if count == PARK_AT {
+                    // Announce we are mid-scan, then hold here until A has
+                    // cancelled — guaranteeing B has NOT finished at that moment.
+                    b_parked_b.store(true, Ordering::Release);
+                    while !a_cancelled_b.load(Ordering::Acquire) {
+                        std::hint::spin_loop();
+                    }
+                }
                 Ok(std::ops::ControlFlow::Continue(()))
             })
             .await;
         (result, count)
     });
 
-    let (result_a, count_a) = handle_a.await.expect("scan A task did not panic");
-    let (result_b, count_b) = handle_b.await.expect("scan B task did not panic");
+    let (result_a, count_a) = tokio::time::timeout(Duration::from_secs(60), handle_a)
+        .await
+        .expect("scan A must finish within the safety timeout (no deadlock)")
+        .expect("scan A task did not panic");
+    let (result_b, count_b) = tokio::time::timeout(Duration::from_secs(60), handle_b)
+        .await
+        .expect("scan B must finish within the safety timeout (no deadlock)")
+        .expect("scan B task did not panic");
 
     assert!(
         matches!(result_a, Err(crate::Error::Cancelled)),
@@ -437,13 +554,14 @@ async fn two_concurrent_scans_on_shared_reader_cancel_independently() {
 
     assert!(
         result_b.is_ok(),
-        "scan B (never cancelled, independent token) must succeed: {result_b:?}"
+        "scan B (never cancelled, independent token) must succeed even though A \
+         cancelled while B was provably mid-scan: {result_b:?}"
     );
     assert_eq!(
         count_b, TOTAL as usize,
         "scan B must stream every partition, UNAFFECTED by scan A's cancellation \
-         on the SAME shared reader — proving the two tokens are truly \
-         independent, not per-reader mutable state (issue #2346)"
+         on the SAME shared reader while B was demonstrably in flight — proving \
+         the two tokens are truly independent, not per-reader mutable state (issue #2346)"
     );
 }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -230,14 +230,17 @@ async fn mid_scan_cancel_aborts_on_compressed_stitching_path() {
     const TOTAL: i32 = 2000;
     const TRIP_AT: usize = 300;
     let (_temp, data_path) = compressed_fixture(TOTAL).await;
-    let mut reader = open_reader(&data_path).await;
+    let reader = open_reader(&data_path).await;
 
+    // Issue #2346: `scan_cancel` is now a PER-CALL parameter, not a field
+    // mutated onto the reader — passed directly to
+    // `stream_all_partitions_for_compaction` below instead of via
+    // `set_scan_cancel`.
     let cancel = ScanCancel::new();
-    reader.set_scan_cancel(cancel.clone());
 
     let mut count = 0usize;
     let result = reader
-        .stream_all_partitions_for_compaction(Some(&schema()), |_row| {
+        .stream_all_partitions_for_compaction(Some(&schema()), &cancel, |_row| {
             count += 1;
             if count == TRIP_AT {
                 cancel.cancel();
@@ -268,7 +271,7 @@ async fn uncancelled_scan_streams_all_partitions() {
 
     let mut count = 0usize;
     let result = reader
-        .stream_all_partitions_for_compaction(Some(&schema()), |_row| {
+        .stream_all_partitions_for_compaction(Some(&schema()), &ScanCancel::default(), |_row| {
             count += 1;
             Ok(std::ops::ControlFlow::Continue(()))
         })
@@ -290,15 +293,14 @@ async fn uncancelled_scan_streams_all_partitions() {
 async fn pre_cancelled_scan_aborts_at_first_poll() {
     const TOTAL: i32 = 1000;
     let (_temp, data_path) = index_less_fixture(TOTAL).await;
-    let mut reader = open_reader(&data_path).await;
+    let reader = open_reader(&data_path).await;
 
     let cancel = ScanCancel::new();
     cancel.cancel();
-    reader.set_scan_cancel(cancel);
 
     let mut count = 0usize;
     let result = reader
-        .stream_all_partitions_for_compaction(Some(&schema()), |_row| {
+        .stream_all_partitions_for_compaction(Some(&schema()), &cancel, |_row| {
             count += 1;
             Ok(std::ops::ControlFlow::Continue(()))
         })
@@ -331,14 +333,13 @@ async fn mid_scan_cancel_aborts_before_finishing() {
     const TOTAL: i32 = 2000;
     const TRIP_AT: usize = 300;
     let (_temp, data_path) = index_less_fixture(TOTAL).await;
-    let mut reader = open_reader(&data_path).await;
+    let reader = open_reader(&data_path).await;
 
     let cancel = ScanCancel::new();
-    reader.set_scan_cancel(cancel.clone());
 
     let mut count = 0usize;
     let result = reader
-        .stream_all_partitions_for_compaction(Some(&schema()), |_row| {
+        .stream_all_partitions_for_compaction(Some(&schema()), &cancel, |_row| {
             count += 1;
             if count == TRIP_AT {
                 cancel.cancel();
@@ -354,6 +355,95 @@ async fn mid_scan_cancel_aborts_before_finishing() {
     assert!(
         count >= TRIP_AT && count < TOTAL as usize,
         "must abort after the trip point but well before the full {TOTAL} partitions, got {count}"
+    );
+}
+
+/// RED PROOF (issue #2346): two concurrent scans over ONE SHARED
+/// `Arc<SSTableReader>` cancel INDEPENDENTLY.
+///
+/// This is the core claim #2346 exists to unlock (a future Flight warm-handle
+/// registry serving two concurrent requests off ONE cached reader). It is
+/// impossible to even express against pre-#2346 `main`: cancellation there was
+/// mutable per-reader state set via `SSTableReader::set_scan_cancel(&mut self,
+/// ..)`. A SHARED `Arc<SSTableReader>` offers no `&mut self` (short of
+/// `Arc::get_mut`, which requires the refcount to be exactly 1 — impossible
+/// while a second concurrent scan holds its own clone), so two concurrent
+/// callers could not even give the ONE shared reader two DIFFERENT tokens; the
+/// only token that existed was whatever was mutated in last, racing/clobbering
+/// the other caller's. This test therefore FAILS TO COMPILE on pre-#2346 `main`
+/// — `stream_all_partitions_for_compaction` took no per-call `scan_cancel`
+/// argument at all, so there was no way to pass two independent tokens for two
+/// concurrent calls on one `&self` reader. The compile failure IS the red
+/// proof; there is no runtime "before" state to assert against.
+///
+/// After the fix, `scan_cancel` is a per-call `&ScanCancel` argument (issue
+/// #2346) — never reader-mutated state — so this spawns two scans on the SAME
+/// `Arc<SSTableReader>`: scan A self-cancels mid-stream via its OWN token; scan
+/// B (a different token, never cancelled) must still stream every partition,
+/// UNAFFECTED by A's cancellation — proving true independence, not shared
+/// mutable state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_concurrent_scans_on_shared_reader_cancel_independently() {
+    const TOTAL: i32 = 2000;
+    const TRIP_AT: usize = 300;
+    let (_temp, data_path) = index_less_fixture(TOTAL).await;
+    let reader = std::sync::Arc::new(open_reader(&data_path).await);
+
+    let cancel_a = ScanCancel::new();
+    let cancel_b = ScanCancel::new();
+
+    let reader_a = std::sync::Arc::clone(&reader);
+    let cancel_a_task = cancel_a.clone();
+    let handle_a = tokio::spawn(async move {
+        let mut count = 0usize;
+        let result = reader_a
+            .stream_all_partitions_for_compaction(Some(&schema()), &cancel_a_task, |_row| {
+                count += 1;
+                if count == TRIP_AT {
+                    cancel_a_task.cancel();
+                }
+                Ok(std::ops::ControlFlow::Continue(()))
+            })
+            .await;
+        (result, count)
+    });
+
+    let reader_b = std::sync::Arc::clone(&reader);
+    let cancel_b_task = cancel_b.clone();
+    let handle_b = tokio::spawn(async move {
+        let mut count = 0usize;
+        let result = reader_b
+            .stream_all_partitions_for_compaction(Some(&schema()), &cancel_b_task, |_row| {
+                count += 1;
+                Ok(std::ops::ControlFlow::Continue(()))
+            })
+            .await;
+        (result, count)
+    });
+
+    let (result_a, count_a) = handle_a.await.expect("scan A task did not panic");
+    let (result_b, count_b) = handle_b.await.expect("scan B task did not panic");
+
+    assert!(
+        matches!(result_a, Err(crate::Error::Cancelled)),
+        "scan A (self-cancelling mid-scan via its OWN token) must abort with \
+         Error::Cancelled, got {result_a:?}"
+    );
+    assert!(
+        count_a >= TRIP_AT && count_a < TOTAL as usize,
+        "scan A must stop after its own trip point but before the full {TOTAL} \
+         partitions, got {count_a}"
+    );
+
+    assert!(
+        result_b.is_ok(),
+        "scan B (never cancelled, independent token) must succeed: {result_b:?}"
+    );
+    assert_eq!(
+        count_b, TOTAL as usize,
+        "scan B must stream every partition, UNAFFECTED by scan A's cancellation \
+         on the SAME shared reader — proving the two tokens are truly \
+         independent, not per-reader mutable state (issue #2346)"
     );
 }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -67,8 +67,15 @@ impl SSTableReader {
     /// - `Ok(None)` — the index/data section could not be proven complete or
     ///   internally consistent. The caller then emits a loud WARN and falls back to
     ///   `sequential_scan` (never a silent fallback).
+    ///
+    /// `scan_cancel` is an explicit PER-CALL cancellation token (issue #2346);
+    /// the sole caller ([`SSTableReader::iterate_all_partitions_cancellable`])
+    /// threads either the reader's own field (the pre-#2346 default) or a
+    /// caller-supplied token (the compaction path), so a shared/cached reader's
+    /// concurrent scans cancel independently.
     pub(in crate::storage::sstable::reader) async fn iterate_all_partitions_via_full_index(
         &self,
+        scan_cancel: &crate::storage::scan_cancel::ScanCancel,
     ) -> Result<Option<Vec<(RowKey, ScanRow)>>> {
         let Some(index_reader) = &self.index_reader else {
             return Ok(None);
@@ -135,8 +142,8 @@ impl SSTableReader {
         for i in 0..entries.len() {
             // Cooperative cancellation (issue #2264): one real index-random-read +
             // Data.db parse per partition — poll every entry so a cancelled Flight
-            // `do_get` abandons the walk promptly.
-            self.scan_cancel.check()?;
+            // `do_get` abandons the walk promptly. Issue #2346: PER-CALL token.
+            scan_cancel.check()?;
 
             // Roborev job 1610 (finding 1): `raw_key: None` never actually occurs
             // in practice — `parse_big_index_entry` always sets `Some(raw_key)` —

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -309,8 +309,11 @@ impl SSTableReader {
         cursor: &ScanCursor,
         schema: Option<&crate::schema::TableSchema>,
         read_shadowing: bool,
+        scan_cancel: &crate::storage::scan_cancel::ScanCancel,
     ) -> Result<Vec<(TableId, RowKey, ScanRow)>> {
-        let stitched_buffer = self.stitch_all_chunks(cursor).await?;
+        let stitched_buffer = self
+            .stitch_all_chunks_cancellable(cursor, scan_cancel)
+            .await?;
         let parser = self.build_v5_parser(read_shadowing);
 
         // Get schema (use provided schema or reader's schema)
@@ -380,7 +383,26 @@ impl SSTableReader {
     ///
     /// Precondition: the caller has seeked `cursor`'s file to the start of the
     /// data section (the cursor's chunk index starts at 0 when freshly minted).
+    ///
+    /// Existing callers use the reader's own [`SSTableReader::scan_cancel`]
+    /// field (unchanged pre-#2346 behaviour); this is a thin wrapper over
+    /// [`Self::stitch_all_chunks_cancellable`], which the per-call seam
+    /// (`sequential_scan`) drives with its caller-supplied token instead.
     pub(super) async fn stitch_all_chunks(&self, cursor: &ScanCursor) -> Result<Vec<u8>> {
+        self.stitch_all_chunks_cancellable(cursor, &self.scan_cancel)
+            .await
+    }
+
+    /// [`Self::stitch_all_chunks`] with an explicit PER-CALL cancel token
+    /// (issue #2346). `scan_cancel` is polled every 256 chunks so a cancelled
+    /// caller abandons the stitch — the chunk-read/decompress loop is the
+    /// I/O-bound phase of the stitched scan path, matching the compaction
+    /// stream's per-256-chunk cadence (`stream_all_partitions_for_compaction`).
+    pub(super) async fn stitch_all_chunks_cancellable(
+        &self,
+        cursor: &ScanCursor,
+        scan_cancel: &crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<Vec<u8>> {
         use crate::storage::sstable::compression::Compression;
 
         // Pre-allocate buffer for ~2.5MB (estimated max size for test data)
@@ -402,6 +424,12 @@ impl SSTableReader {
 
         let mut chunk_count = 0;
         while let Some(compressed_chunk) = self.read_next_block(cursor).await? {
+            // Cooperative cancellation (issue #2346): poll the per-call token every
+            // 256 chunks so a cancelled stitched scan abandons the I/O/decompress
+            // walk promptly instead of stitching the entire data section first.
+            if chunk_count & 0xFF == 0 {
+                scan_cancel.check()?;
+            }
             let decompressed_chunk = if compressed_chunk.len() >= max_compressed_length {
                 // Stored uncompressed by Cassandra — pass the raw bytes through.
                 tracing::debug!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -21,6 +21,7 @@
 
 use super::super::compaction_row::CompactionRow;
 use super::super::SSTableReader;
+use crate::storage::scan_cancel::ScanCancel;
 use crate::Result;
 use std::ops::ControlFlow;
 
@@ -89,10 +90,16 @@ impl SSTableReader {
     /// `partition_key` is the raw partition-key bytes (as
     /// `PartitionKey::to_bytes` produces). `schema` is the authoritative table
     /// schema (the parser needs column names).
+    ///
+    /// `scan_cancel` is an explicit PER-CALL cancellation token (issue #2346),
+    /// mirroring [`SSTableReader::stream_all_partitions_for_compaction`] — not
+    /// the reader's own `scan_cancel` field, so a shared/cached `Arc<SSTableReader>`
+    /// can serve two concurrent point-read probes with independent cancellation.
     pub async fn read_single_partition_for_compaction(
         &self,
         partition_key: &[u8],
         schema: Option<&crate::schema::TableSchema>,
+        scan_cancel: &ScanCancel,
     ) -> Result<SinglePartitionCompaction> {
         // 1. Presence oracle — the only source of a definite prune. Emits
         //    `cqlite.read.sstables_pruned` internally on a definite negative.
@@ -179,7 +186,14 @@ impl SSTableReader {
         //    is stale/corrupt and pointed at another valid partition → scan
         //    fallback, never a silent drop).
         match self
-            .seek_partition_compaction_rows(offset, end_bound, partition_key, schema, is_bti)
+            .seek_partition_compaction_rows(
+                offset,
+                end_bound,
+                partition_key,
+                schema,
+                is_bti,
+                scan_cancel,
+            )
             .await?
         {
             Some(rows) => Ok(SinglePartitionCompaction::Rows(rows)),
@@ -204,6 +218,7 @@ impl SSTableReader {
         partition_key: &[u8],
         schema: Option<&crate::schema::TableSchema>,
         is_bti: bool,
+        scan_cancel: &ScanCancel,
     ) -> Result<Option<Vec<CompactionRow>>> {
         // Cooperative cancellation (issue #2207, roborev job 1620 MEDIUM): the seek
         // materializes a covering chunk window and parses one partition — the same
@@ -213,7 +228,9 @@ impl SSTableReader {
         // of decompressing/parsing to completion. Poll ONCE before materializing
         // (an already-cancelled read exits before any I/O), inside the chunk-window
         // pull loop (`pull_chunk_window`), and once more just before parsing.
-        self.scan_cancel.check()?;
+        // Issue #2346: `scan_cancel` is now the caller's PER-CALL token, not
+        // `self.scan_cancel`.
+        scan_cancel.check()?;
 
         let offset = offset as usize;
         let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
@@ -256,7 +273,7 @@ impl SSTableReader {
                     },
                 };
                 let (window, reached_end) = self
-                    .pull_chunk_window(target_chunk, window_base, end)
+                    .pull_chunk_window(target_chunk, window_base, end, scan_cancel)
                     .await?;
                 (window, within, reached_end)
             }
@@ -285,7 +302,7 @@ impl SSTableReader {
         // Cancellation poll just before the parse — the covering window is now
         // materialized, so a cancel observed here skips the (potentially large)
         // partition decode entirely (issue #2207 fail-safe cancellation).
-        self.scan_cancel.check()?;
+        scan_cancel.check()?;
 
         // Parse the FIRST partition at `window[within..]`. Collect every row whose
         // decoded key equals the queried key; a decoded DIFFERENT key means the
@@ -344,6 +361,7 @@ impl SSTableReader {
         target_chunk: usize,
         window_base: usize,
         end: usize,
+        scan_cancel: &ScanCancel,
     ) -> Result<(Vec<u8>, bool)> {
         use super::super::chunk_source::ChunkSource;
         use crate::storage::sstable::compression::Compression;
@@ -378,7 +396,7 @@ impl SSTableReader {
             // interval so a cancel is honoured mid-window, mirroring the full-scan
             // stream's `chunk_count & 0xFF == 0` poll (compaction.rs, issue #2264).
             if pulled & 0xFF == 0 {
-                self.scan_cancel.check()?;
+                scan_cancel.check()?;
             }
             pulled += 1;
             match chunk_source.chunk(chunk_index)? {

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
@@ -217,7 +217,7 @@ async fn corrupt_bti_trie_degrades_to_index_unavailable_not_err() {
         .unwrap();
 
     let outcome = reader
-        .read_single_partition_for_compaction(&key_bytes, Some(&schema))
+        .read_single_partition_for_compaction(&key_bytes, Some(&schema), &ScanCancel::default())
         .await
         .expect("a corrupt trie must degrade gracefully, never a hard Err");
     assert!(
@@ -340,7 +340,11 @@ async fn stale_index_offset_degrades_to_scan_fallback_and_finds_the_row() {
     // Layer 1: the primitive itself.
     let reader = open_reader(&data_path).await;
     let outcome = reader
-        .read_single_partition_for_compaction(&target_key_bytes, Some(&schema))
+        .read_single_partition_for_compaction(
+            &target_key_bytes,
+            Some(&schema),
+            &ScanCancel::default(),
+        )
         .await
         .expect("a stale offset must degrade gracefully, never a hard Err");
     assert!(
@@ -485,7 +489,7 @@ async fn big_foreign_partition_offset_degrades_to_scan_fallback_not_empty_rows()
     // Layer 1: the primitive itself.
     let reader = open_reader(&data_path).await;
     let outcome = reader
-        .read_single_partition_for_compaction(&key2, Some(&schema))
+        .read_single_partition_for_compaction(&key2, Some(&schema), &ScanCancel::default())
         .await
         .expect("a foreign-partition offset must degrade gracefully, never a hard Err");
     assert!(
@@ -683,7 +687,9 @@ async fn truncated_chunk_window_degrades_to_scan_fallback_not_partial_rows() {
 
     // Truncate Data.db to the new last-kept-chunk boundary (kept chunks stay
     // CRC-valid) ...
-    let cut = offsets[new_count] as u64;
+    // `chunk_offsets: Vec<u64>` — pre-existing unrelated `unnecessary_cast`
+    // clippy fix (file already touched by issue #2346), no behavior change.
+    let cut = offsets[new_count];
     let data_file = std::fs::OpenOptions::new()
         .write(true)
         .open(&data_path)
@@ -718,7 +724,7 @@ async fn truncated_chunk_window_degrades_to_scan_fallback_not_partial_rows() {
     // EOF (chunk `new_count` is gone) before reaching `end`.
     let reader = open_reader(&data_path).await;
     let outcome = reader
-        .read_single_partition_for_compaction(&key1, Some(&schema))
+        .read_single_partition_for_compaction(&key1, Some(&schema), &ScanCancel::default())
         .await
         .expect("a truncated chunk window must degrade gracefully, never a hard Err");
     assert!(
@@ -772,11 +778,12 @@ async fn valid_bti_fixture() -> (TempDir, std::path::PathBuf) {
 #[tokio::test]
 async fn pre_cancelled_seek_aborts_with_cancelled_not_rows() {
     let (_temp, data_path) = valid_bti_fixture().await;
-    let mut reader = open_reader(&data_path).await;
+    let reader = open_reader(&data_path).await;
 
+    // Issue #2346: `scan_cancel` is now a PER-CALL parameter, not a field
+    // mutated onto the reader.
     let cancel = ScanCancel::new();
     cancel.cancel();
-    reader.set_scan_cancel(cancel);
 
     let schema = schema();
     let key_bytes = WEPartitionKey::single("pk", Value::Integer(1))
@@ -784,7 +791,7 @@ async fn pre_cancelled_seek_aborts_with_cancelled_not_rows() {
         .unwrap();
 
     let result = reader
-        .read_single_partition_for_compaction(&key_bytes, Some(&schema))
+        .read_single_partition_for_compaction(&key_bytes, Some(&schema), &cancel)
         .await;
     assert!(
         matches!(result, Err(crate::Error::Cancelled)),
@@ -816,7 +823,7 @@ async fn bti_absent_key_is_definitely_absent_not_empty_rows() {
         .unwrap();
 
     let outcome = reader
-        .read_single_partition_for_compaction(&key_bytes, Some(&schema))
+        .read_single_partition_for_compaction(&key_bytes, Some(&schema), &ScanCancel::default())
         .await
         .expect("an absent-key probe must not error");
     assert!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -260,9 +260,11 @@ impl SSTableReader {
                 "V5CompressedLegacy format detected, decompressing and stitching all chunks before parsing"
             );
 
-            // Use shared stitching helper method
+            // Use shared stitching helper method. Physical enumeration
+            // (`get_all_entries`) honours the reader's own cancel field —
+            // unchanged pre-#2346 behaviour.
             let entries = self
-                .stitch_and_parse_all_chunks(&cursor, None, false)
+                .stitch_and_parse_all_chunks(&cursor, None, false, &self.scan_cancel)
                 .await?;
             results.extend(entries);
         } else {
@@ -840,9 +842,14 @@ impl SSTableReader {
                 "SSTableReader::sequential_scan - V5CompressedLegacy NB detected, using stitched buffer"
             );
 
-            // Stitch all chunks together (reuse logic from get_all_entries)
+            // Stitch all chunks together (reuse logic from get_all_entries).
+            // Thread the PER-CALL cancel token (issue #2346) so a cancelled
+            // caller abandons the stitched walk promptly instead of blocking
+            // until the entire data section is stitched+parsed — the
+            // chunk-stitch loop polls at the same 256-chunk cadence as the
+            // non-stitching branch below.
             let all_entries = self
-                .stitch_and_parse_all_chunks(&cursor, schema, true)
+                .stitch_and_parse_all_chunks(&cursor, schema, true, scan_cancel)
                 .await?;
             tracing::debug!(
                 "SSTableReader::sequential_scan - Stitched parsing returned {} total entries",
@@ -853,7 +860,17 @@ impl SSTableReader {
             // before sorting.  Limit is applied AFTER sort so that LIMIT N returns the N
             // token-smallest partitions, not the first N encountered in parse order.
             // (BLOCKING-1: limit-after-order)
-            for (_entry_table_id, entry_key, entry_value) in all_entries {
+            for (idx, (_entry_table_id, entry_key, entry_value)) in
+                all_entries.into_iter().enumerate()
+            {
+                // Cooperative cancellation (issue #2346): the chunk-stitch loop
+                // poll covers the I/O phase, but `parse_block` materialises every
+                // entry in one shot — poll here at the same 256-entry cadence as
+                // the non-stitching branch so a cancelled caller does not walk a
+                // huge already-parsed result set to completion.
+                if idx & 0xFF == 0 {
+                    scan_cancel.check()?;
+                }
                 if let Some(start) = start_key {
                     if &entry_key < start {
                         continue;

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -5,6 +5,11 @@
 //! These cover the BIG (`nb`) `V5CompressedLegacy` formats (chunk-stitched) and
 //! the non-stitching block-by-block formats. BTI (`da`) range/full scans are
 //! routed here only to delegate to [`SSTableReader::bti_scan_with_metadata`].
+//!
+//! File-size note (campsite rule, epic #1116): this file was already over the
+//! ~800-line source threshold before issue #2346's `scan_cancel` per-call
+//! parameter change (`sequential_scan`), which nudges it slightly further.
+//! Splitting it by responsibility is out of #2346's scope; tracked under #1116.
 
 use super::super::scan_stream_windowed::scan_admission::{self, ScanAdmission};
 use super::super::scan_stream_windowed::{WindowedOut, BATCH_EMIT_ROWS};
@@ -12,6 +17,7 @@ use super::super::SSTableReader;
 use super::model::{
     sort_by_token_order, sort_by_token_order_with_meta, table_ids_match, SCAN_FOR_KEY_CALLS,
 };
+use crate::storage::scan_cancel::ScanCancel;
 use crate::types::{CellWriteMetadata, ScanRow, TableId};
 use crate::{Error, Result, RowKey};
 use std::io::SeekFrom;
@@ -114,7 +120,14 @@ impl SSTableReader {
                     "SSTableReader::scan - Index returned 0 entries (BTI format or incomplete parsing), falling back to sequential scan"
                 );
                 return self
-                    .sequential_scan(table_id, start_key, end_key, limit, schema)
+                    .sequential_scan(
+                        table_id,
+                        start_key,
+                        end_key,
+                        limit,
+                        schema,
+                        &self.scan_cancel,
+                    )
                     .await;
             }
 
@@ -123,7 +136,14 @@ impl SSTableReader {
             if has_zero_size {
                 tracing::debug!("SSTableReader::scan - Index reports size=0 for some entries, using sequential scan fallback");
                 return self
-                    .sequential_scan(table_id, start_key, end_key, limit, schema)
+                    .sequential_scan(
+                        table_id,
+                        start_key,
+                        end_key,
+                        limit,
+                        schema,
+                        &self.scan_cancel,
+                    )
                     .await;
             }
 
@@ -151,7 +171,14 @@ impl SSTableReader {
             // token order (NON-BLOCKING-1: avoid double-sort — return directly).
             tracing::debug!("SSTableReader::scan - No index, falling back to sequential scan");
             let seq_results = self
-                .sequential_scan(table_id, start_key, end_key, limit, schema)
+                .sequential_scan(
+                    table_id,
+                    start_key,
+                    end_key,
+                    limit,
+                    schema,
+                    &self.scan_cancel,
+                )
                 .await?;
             tracing::debug!(
                 "SSTableReader::scan - Sequential scan returned {} results",
@@ -756,6 +783,12 @@ impl SSTableReader {
         Ok(None)
     }
 
+    /// `scan_cancel` is an explicit PER-CALL cancellation token (issue #2346).
+    /// Every existing caller passes `&self.scan_cancel` (the reader's own field,
+    /// unchanged pre-#2346 semantics); the compaction path
+    /// ([`SSTableReader::iterate_all_partitions_cancellable`]) passes its
+    /// caller-supplied token instead, so a shared/cached reader's two concurrent
+    /// scans cancel independently.
     pub(in crate::storage::sstable::reader) async fn sequential_scan(
         &self,
         table_id: &TableId,
@@ -763,6 +796,7 @@ impl SSTableReader {
         end_key: Option<&RowKey>,
         limit: Option<usize>,
         schema: Option<&crate::schema::TableSchema>,
+        scan_cancel: &ScanCancel,
     ) -> Result<Vec<(RowKey, ScanRow)>> {
         tracing::debug!("SSTableReader::sequential_scan - Starting sequential scan");
         tracing::debug!("SSTableReader::sequential_scan - Table ID: {}", table_id);
@@ -865,7 +899,7 @@ impl SSTableReader {
             // absent) SSTable materialises EVERY partition here in one pass; poll
             // the token per block so a cancelled Flight `do_get` abandons the walk
             // promptly instead of running to completion under the ~1–2 min backstop.
-            self.scan_cancel.check()?;
+            scan_cancel.check()?;
             block_count += 1;
             tracing::debug!(
                 "SSTableReader::sequential_scan - Read block {}, size {} bytes",
@@ -891,7 +925,7 @@ impl SSTableReader {
                 // how large a single block turned out to be, independent of
                 // whichever inner parser branch produced `entries`.
                 if i & 0xFF == 0 {
-                    self.scan_cancel.check()?;
+                    scan_cancel.check()?;
                 }
                 tracing::debug!(
                     "SSTableReader::sequential_scan - Block {} entry {}: table_id='{}', key={:?}",
@@ -1045,7 +1079,14 @@ impl SSTableReader {
         // Non-stitching path: fall back to regular scan + empty metadata.
         // Per-cell metadata is not yet surfaced for block-entry formats.
         let plain = self
-            .sequential_scan(table_id, start_key, end_key, limit, schema)
+            .sequential_scan(
+                table_id,
+                start_key,
+                end_key,
+                limit,
+                schema,
+                &self.scan_cancel,
+            )
             .await?;
         Ok(plain
             .into_iter()

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -570,6 +570,28 @@ impl SSTableReader {
     /// directly. For V5CompressedLegacy NB SSTables (the format the writer emits),
     /// `sequential_scan` uses the chunk-stitching path and returns every partition.
     pub async fn iterate_all_partitions(&self) -> Result<Vec<(RowKey, ScanRow)>> {
+        // Delegates to the per-call-token sibling with the reader's own field —
+        // byte-identical to the pre-#2346 behaviour of this method (every
+        // pre-existing caller keeps its exact cancellation semantics).
+        self.iterate_all_partitions_cancellable(&self.scan_cancel)
+            .await
+    }
+
+    /// Like [`Self::iterate_all_partitions`], but takes an explicit PER-CALL
+    /// cancellation token instead of always reading the reader's own
+    /// [`SSTableReader::scan_cancel`] field (issue #2346).
+    ///
+    /// A cached/shared `Arc<SSTableReader>` (a future warm-handle registry) has
+    /// no `&mut self` available to set a per-request cancel flag, so this seam
+    /// lets the compaction streaming path
+    /// ([`SSTableReader::stream_all_partitions_for_compaction`]'s non-stitching
+    /// fallback) drive two concurrent enumerations with two INDEPENDENT tokens.
+    /// `iterate_all_partitions` itself is UNCHANGED — it delegates here with
+    /// `&self.scan_cancel`, so every existing caller keeps identical behaviour.
+    pub(crate) async fn iterate_all_partitions_cancellable(
+        &self,
+        scan_cancel: &crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<Vec<(RowKey, ScanRow)>> {
         // Index-random-read path (issue #2302): when a `Index.db` is present on a
         // BIG SSTable, enumerate EVERY partition via the full Index.db
         // partition-offset table instead of the sparse `Summary.db` samples.
@@ -586,7 +608,10 @@ impl SSTableReader {
         // compressed reader the per-partition slice is mapped to its covering
         // compression chunk(s) and decompressed (`read_compressed_offset_window`).
         if self.index_reader.is_some() && self.bti_partitions_db.is_none() {
-            match self.iterate_all_partitions_via_full_index().await? {
+            match self
+                .iterate_all_partitions_via_full_index(scan_cancel)
+                .await?
+            {
                 Some(results) => return Ok(results),
                 None => {
                     // Present components that did NOT fully resolve: never silent.
@@ -651,7 +676,7 @@ impl SSTableReader {
         // format the reader's digest-based parser does not resolve).
         let table_id = self.scan_table_id();
         let schema = self.schema.as_deref();
-        self.sequential_scan(&table_id, None, None, None, schema)
+        self.sequential_scan(&table_id, None, None, None, schema, scan_cancel)
             .await
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/from_readers.rs
+++ b/cqlite-core/src/storage/write_engine/merge/from_readers.rs
@@ -202,6 +202,16 @@ impl KWayMerger {
     /// tie-break rank), exactly as the path-based constructors' `input_paths`
     /// are. Reconciliation is byte-identical to the path-based merge — only WHO
     /// opens/owns the `SSTableReader` differs.
+    ///
+    /// UDT-registry guard (issue #2346, WS1 #2345): this seam takes NO
+    /// `udt_registry` parameter (see the module doc — a shared `Arc` reader has
+    /// no `&mut self` for `set_udt_registry`). Each caller-supplied reader MUST
+    /// therefore be opened WITH its UDT registry already resolved BEFORE it is
+    /// wrapped in `Arc`. Wiring that resolution into the warm-handle registry
+    /// caller is WS1 #2345's responsibility — if a warm caller opens a
+    /// UDT-bearing table's reader WITHOUT the registry, frozen/nested UDT cells
+    /// silently decode as `Blob` (the #1234 data-loss class), NOT an error. The
+    /// merge layer cannot detect this here; #2345 owns that end-to-end guarantee.
     pub fn new_from_readers(
         readers: Vec<Arc<SSTableReader>>,
         schema: &TableSchema,
@@ -246,12 +256,14 @@ impl KWayMerger {
 mod tests {
     use super::*;
     use crate::platform::Platform;
+    use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
     use crate::storage::write_engine::merge::MergeStep;
-    use crate::storage::write_engine::mutation::PartitionKey;
+    use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
     use crate::storage::write_engine::test_support::{create_test_schema, flush_n_sstables_sync};
     use crate::storage::write_engine::{WriteEngine, WriteEngineConfig};
     use crate::types::Value;
     use crate::Config;
+    use std::collections::HashMap;
     use tempfile::TempDir;
 
     fn config_for(temp_dir: &TempDir) -> WriteEngineConfig {
@@ -268,16 +280,183 @@ mod tests {
         SSTableReader::open(path, &config, platform).await.unwrap()
     }
 
-    /// Drain a merger into `(partition_key_bytes, row_count)` pairs, sorted —
-    /// enough to prove byte-identical reconciliation across two constructors
-    /// without depending on a specific row-shape decoder.
-    fn collect_merge_rows(mut merger: KWayMerger) -> Vec<(Vec<u8>, usize)> {
+    /// Drain a merger into `(partition_key_bytes, fully-reconciled rows)` pairs,
+    /// sorted by partition key. Unlike a row-COUNT summary, this carries every
+    /// [`MergeEntry`] field — clustering key, timestamp, `RowData` cells, and all
+    /// tombstone/deletion markers — so a divergence in HOW the reader-based path
+    /// decodes or emits a cell (not just how many rows it produces) fails the
+    /// equality assertion. `MergeEntry: Eq`, so two `Vec<MergeEntry>` compare
+    /// cell-for-cell (issue #2346, parity-auditor F1).
+    fn collect_merge_entries(mut merger: KWayMerger) -> Vec<(Vec<u8>, Vec<MergeEntry>)> {
         let mut out = Vec::new();
         while let MergeStep::Partition { key, rows } = merger.step().expect("merge step") {
-            out.push((key.key.clone(), rows.len()));
+            out.push((key.key.clone(), rows));
         }
-        out.sort();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
         out
+    }
+
+    /// Schema WITH a clustering key (`id int, ck int, name text` — PK `id`,
+    /// clustering `ck`), so the overlapping-generation fixture below exercises
+    /// per-clustering-row reconciliation (row/cell tombstones, value overwrite),
+    /// not just partition-granular merges (issue #2346, parity-auditor F1).
+    fn clustering_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: ClusteringOrder::Asc,
+            }],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "ck".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn clustering_config_for(temp_dir: &TempDir) -> WriteEngineConfig {
+        WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            clustering_schema(),
+        )
+    }
+
+    fn ck_mutation(id: i32, ck: i32, ts: i64, op: CellOperation) -> Mutation {
+        Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(id)),
+            Some(
+                crate::storage::write_engine::mutation::ClusteringKey::single(
+                    "ck",
+                    Value::Integer(ck),
+                ),
+            ),
+            vec![op],
+            ts,
+            None,
+        )
+    }
+
+    /// Two OVERLAPPING generations (issue #2346, parity-auditor F1): the same
+    /// partition keys appear in BOTH SSTables with clustering rows that force
+    /// real cell-level reconciliation — a newer-generation value overwrite, a
+    /// cell tombstone, and a row tombstone — so the path-based vs reader-based
+    /// constructor comparison can catch a cell-level (not merely row-count)
+    /// divergence. Returns `[gen2_newer, gen1_older]` (newest-first, the order
+    /// both constructors expect).
+    fn flush_two_overlapping_generations(temp_dir: &TempDir) -> Vec<std::path::PathBuf> {
+        let mut engine = WriteEngine::new(clustering_config_for(temp_dir)).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        // Generation 1 (older, ts=1000): baseline rows across partitions 1,2,3.
+        for (id, ck, name) in [
+            (1, 10, "g1-1-10"),
+            (1, 20, "g1-1-20"),
+            (2, 10, "g1-2-10"),
+            (3, 10, "g1-3-10"),
+        ] {
+            engine
+                .write(ck_mutation(
+                    id,
+                    ck,
+                    1000,
+                    CellOperation::Write {
+                        column: "name".to_string(),
+                        value: Value::Text(name.to_string()),
+                    },
+                ))
+                .unwrap();
+        }
+        let gen1 = rt.block_on(engine.flush()).unwrap().unwrap().data_path;
+
+        // Generation 2 (newer, ts=2000): same partitions, overlapping rows —
+        //  (1,10) value OVERWRITE, (1,20) CELL tombstone, (2,10) ROW tombstone,
+        //  plus a fresh (3,20) row.
+        engine
+            .write(ck_mutation(
+                1,
+                10,
+                2000,
+                CellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text("g2-1-10".to_string()),
+                },
+            ))
+            .unwrap();
+        engine
+            .write(ck_mutation(
+                1,
+                20,
+                2000,
+                CellOperation::Delete {
+                    column: "name".to_string(),
+                    local_deletion_time: Some(2),
+                },
+            ))
+            .unwrap();
+        // Row tombstone for (2,10): a delete mutation carrying a coexisting row
+        // deletion, no surviving cells written afterward.
+        engine
+            .write(
+                ck_mutation(
+                    2,
+                    10,
+                    2000,
+                    CellOperation::Delete {
+                        column: "name".to_string(),
+                        local_deletion_time: Some(2),
+                    },
+                )
+                .with_row_tombstone(2000, 2),
+            )
+            .unwrap();
+        engine
+            .write(ck_mutation(
+                3,
+                20,
+                2000,
+                CellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text("g2-3-20".to_string()),
+                },
+            ))
+            .unwrap();
+        let gen2 = rt.block_on(engine.flush()).unwrap().unwrap().data_path;
+
+        vec![gen2, gen1]
     }
 
     /// Red-then-green (b): `KWayMerger::new_from_readers` (reader-based) must
@@ -316,10 +495,64 @@ mod tests {
         });
 
         assert_eq!(
-            collect_merge_rows(path_based),
-            collect_merge_rows(reader_based),
+            collect_merge_entries(path_based),
+            collect_merge_entries(reader_based),
             "reader-based full-scan merger must reconcile byte-identically to the \
              path-based one (issue #2346) — only WHO opens the reader differs"
+        );
+    }
+
+    /// The STRONG delegation proof (issue #2346, parity-auditor F1): over TWO
+    /// OVERLAPPING generations (shared partition keys, clustering rows, a
+    /// value overwrite + a cell tombstone + a row tombstone), the reader-based
+    /// `new_from_readers` must produce a FULLY CELL-IDENTICAL reconciliation to
+    /// the path-based `new_cancellable` — every [`MergeEntry`] field, not just
+    /// the row count. The earlier disjoint-key fixture never reconciles two rows
+    /// of the SAME key, so it cannot catch a cell-level decode/emit divergence;
+    /// this one does.
+    #[test]
+    fn new_from_readers_matches_path_based_full_cell_equality_overlapping() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = flush_two_overlapping_generations(&temp_dir);
+        assert_eq!(
+            paths.len(),
+            2,
+            "test precondition: two overlapping generations"
+        );
+        let schema = clustering_schema();
+
+        let path_based = KWayMerger::new_cancellable(paths.clone(), &schema, ScanCancel::default())
+            .expect("path-based merger constructs");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let reader_based = rt.block_on(async {
+            let mut readers = Vec::with_capacity(paths.len());
+            for path in &paths {
+                readers.push(Arc::new(open_reader(path).await));
+            }
+            KWayMerger::new_from_readers(readers, &schema, ScanCancel::default())
+                .expect("reader-based merger constructs")
+        });
+
+        let path_rows = collect_merge_entries(path_based);
+        let reader_rows = collect_merge_entries(reader_based);
+
+        // Non-vacuity: the overlapping fixture MUST yield real reconciled rows
+        // across multiple partitions, or a cell-equality assertion over an empty
+        // set would pass trivially.
+        let total_rows: usize = path_rows.iter().map(|(_, r)| r.len()).sum();
+        assert!(
+            path_rows.len() >= 3 && total_rows >= 3,
+            "fixture must reconcile several overlapping partitions/rows, got \
+             {} partitions / {total_rows} rows",
+            path_rows.len()
+        );
+
+        assert_eq!(
+            path_rows, reader_rows,
+            "reader-based merger must reconcile CELL-IDENTICALLY to the path-based \
+             one over overlapping generations (overwrite + cell/row tombstones) — \
+             full MergeEntry equality, not row counts (issue #2346, F1)"
         );
     }
 
@@ -369,8 +602,8 @@ mod tests {
         });
 
         assert_eq!(
-            collect_merge_rows(path_based),
-            collect_merge_rows(reader_based),
+            collect_merge_entries(path_based),
+            collect_merge_entries(reader_based),
             "reader-based point-read merger must reconcile byte-identically to the \
              path-based one (issue #2346)"
         );

--- a/cqlite-core/src/storage/write_engine/merge/from_readers.rs
+++ b/cqlite-core/src/storage/write_engine/merge/from_readers.rs
@@ -1,0 +1,378 @@
+//! Warm/shared-reader k-way merge construction (issue #2346).
+//!
+//! The path-based [`KWayMerger::new`]/[`KWayMerger::new_cancellable`] family
+//! (`mod.rs`) opens a fresh [`SSTableReader`] per input INSIDE its own detached
+//! producer thread — necessary for the compaction/write-engine callers, whose
+//! inputs may be deleted once the merge (and thus every producer thread) has
+//! finished (issue #591). A cached-reader caller — the intended consumer is a
+//! future Flight warm-handle registry (epic #2310) — instead wants to hand the
+//! merger ALREADY-OPEN, possibly-SHARED `Arc<SSTableReader>`s it keeps parsed
+//! across requests, paying the reader-open + Index/Summary/Statistics/bloom
+//! parse cost once per SSTable generation instead of once per request.
+//!
+//! [`KWayMerger::new_from_readers`] is that seam. It reuses every other piece
+//! of the k-way merge (heap, reconciliation, LWW tie-break by run index)
+//! byte-identically — only WHO opens/owns the `SSTableReader` differs from the
+//! path-based constructors.
+//!
+//! ## Delegation (no behavioural drift between the two producer shapes)
+//!
+//! [`drive_compaction_stream`] is the single streaming-emit helper BOTH producer
+//! thread shapes call: the path-based [`SSTableRowIteratorAdapter::producer_thread`]
+//! (`mod.rs`, unchanged opening/threading behaviour — still one fresh reader
+//! opened per thread, in parallel, exactly as before this issue) and the new
+//! [`SSTableRowIteratorAdapter::open_from_reader`]'s producer thread (this file,
+//! never opens a reader). Factoring the conversion/backpressure/
+//! cancellation-by-variant logic into one function means the two shapes cannot
+//! silently diverge.
+//!
+//! `KWayMerger::new_with_gc_and_registry_cancellable` (the path-based
+//! constructor) is intentionally NOT rewritten to open readers eagerly and then
+//! call [`KWayMerger::new_from_readers`] — that would move every input's open
+//! from N-parallel-producer-threads to one serial pass on the calling thread,
+//! a real latency regression for a multi-SSTable merge with no benefit (the
+//! path-based caller never has a reader to share in the first place). The
+//! shared code is the STREAMING logic, not the opening timing.
+//!
+//! ## File-lifetime / open-config contract for caller-supplied readers
+//!
+//! The path-based adapter forces `use_mmap = false` + `DiskAccessMode::Buffered`
+//! specifically because compaction inputs may be deleted by
+//! `finalize_merge_async` once every producer thread has finished (issue #591) —
+//! a reader opened any other way could hold a dangling mapping. A reader passed
+//! into [`SSTableRowIteratorAdapter::open_from_reader`] is opened by the CALLER
+//! (not by this seam), so that safety property is the CALLER's responsibility:
+//! the backing `Data.db` MUST NOT be deleted while any `Arc<SSTableReader>`
+//! clone (including ones held by other concurrent runs, or by a cache) is still
+//! alive. This is a materially different contract from the path-based adapter's
+//! self-contained guarantee, so it is called out explicitly rather than
+//! silently inherited. A read-only warm-handle cache that never deletes/replaces
+//! a generation's `Data.db` out from under a live `Arc` (evicting only its OWN
+//! reference, per #1749's fail-closed model) satisfies this trivially.
+//!
+//! UDT registry: [`SSTableRowIteratorAdapter::open`] (path-based) can call
+//! `reader.set_udt_registry(..)` because it just opened its OWN exclusive
+//! reader. `open_from_reader` CANNOT — the reader is shared (`Arc`), so no
+//! `&mut self` is available. A caller needing UDT-aware decode over a shared
+//! reader must open it WITH the registry already resolved (before wrapping it
+//! in `Arc`); `open_from_reader` takes no `udt_registry` parameter for this
+//! reason (an accepted-but-silently-ignored parameter would be a correctness
+//! trap).
+
+use std::sync::mpsc::SyncSender;
+use std::sync::Arc;
+
+use crate::error::{Error, Result};
+use crate::schema::TableSchema;
+use crate::storage::scan_cancel::ScanCancel;
+use crate::storage::sstable::reader::SSTableReader;
+
+use super::{
+    producer_gauge, KWayMerger, MergeEntry, MergeProducerError, RunReader, SSTableRowIterator,
+    SSTableRowIteratorAdapter, STREAMING_CHANNEL_CAPACITY,
+};
+
+/// Drive `reader`'s compaction stream into `sender`, converting each row via
+/// [`SSTableRowIteratorAdapter::build_merge_entry`].
+///
+/// Shared by BOTH producer-thread shapes (see the module doc): the path-based
+/// adapter (which opens its own reader per thread) and the shared-reader
+/// adapter this module adds. `scan_cancel` is the PER-CALL token
+/// [`SSTableReader::stream_all_partitions_for_compaction`] now takes (issue
+/// #2346) — never a field mutated onto `reader`, so two concurrent calls over
+/// the SAME shared reader (two different producer threads, each with its own
+/// token) cancel independently.
+pub(super) async fn drive_compaction_stream(
+    reader: &SSTableReader,
+    run_index: usize,
+    schema: &TableSchema,
+    scan_cancel: &ScanCancel,
+    sender: &SyncSender<std::result::Result<MergeEntry, MergeProducerError>>,
+) -> Result<()> {
+    reader
+        .stream_all_partitions_for_compaction(Some(schema), scan_cancel, |compaction_row| {
+            let msg =
+                SSTableRowIteratorAdapter::build_merge_entry(run_index, compaction_row, schema)
+                    .map_err(MergeProducerError::from);
+            match sender.send(msg) {
+                Ok(()) => Ok(std::ops::ControlFlow::Continue(())),
+                Err(_) => Ok(std::ops::ControlFlow::Break(())),
+            }
+        })
+        .await
+}
+
+impl SSTableRowIteratorAdapter {
+    /// Open a streaming run over an ALREADY-OPEN, possibly-SHARED
+    /// [`SSTableReader`] (issue #2346), instead of opening a fresh reader from a
+    /// path ([`SSTableRowIteratorAdapter::open`]).
+    ///
+    /// Still spawns a dedicated producer thread (preserving the O(M)
+    /// thread-per-input / bounded-channel backpressure architecture — issues
+    /// #827/#2316) but never opens/owns a reader itself; it drives the
+    /// caller-supplied `Arc<SSTableReader>` directly via
+    /// [`drive_compaction_stream`]. See the module doc for the file-lifetime
+    /// and UDT-registry contract differences from the path-based `open`.
+    pub(crate) fn open_from_reader(
+        reader: Arc<SSTableReader>,
+        run_index: usize,
+        schema: &TableSchema,
+        scan_cancel: ScanCancel,
+    ) -> Result<Self> {
+        let schema = schema.clone();
+        let (sender, receiver) = std::sync::mpsc::sync_channel(STREAMING_CHANNEL_CAPACITY);
+
+        // Issue #2316: account this producer on the live-thread gauge BEFORE
+        // spawning (see `SSTableRowIteratorAdapter::open`'s identical rationale).
+        producer_gauge::spawned();
+
+        let producer = match std::thread::Builder::new().spawn(move || {
+            Self::producer_thread_from_reader(reader, run_index, schema, scan_cancel, sender);
+        }) {
+            Ok(handle) => handle,
+            Err(e) => {
+                producer_gauge::rollback();
+                return Err(Error::Storage(format!(
+                    "streaming producer (shared reader): failed to spawn thread: {}",
+                    e
+                )));
+            }
+        };
+
+        Ok(Self {
+            receiver,
+            _producer: producer,
+        })
+    }
+
+    /// Body of the shared-reader producer thread (issue #2346).
+    ///
+    /// Unlike [`Self::producer_thread`] (path-based), this NEVER opens a
+    /// reader — it drives the caller-supplied `Arc<SSTableReader>` directly via
+    /// [`drive_compaction_stream`], reusing the exact
+    /// conversion/backpressure/cancellation-by-variant semantics. Still owns a
+    /// dedicated `current_thread` runtime (issue #2316: zero extra worker
+    /// threads) so the async `stream_all_partitions_for_compaction` call can
+    /// run without a nested-runtime panic.
+    fn producer_thread_from_reader(
+        reader: Arc<SSTableReader>,
+        run_index: usize,
+        schema: TableSchema,
+        scan_cancel: ScanCancel,
+        sender: SyncSender<std::result::Result<MergeEntry, MergeProducerError>>,
+    ) {
+        let _thread_guard = producer_gauge::ProducerThreadGuard;
+        let error_sender = sender.clone();
+
+        let stream_result = (|| -> Result<()> {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    Error::Storage(format!(
+                        "streaming producer (shared reader): failed to create runtime: {}",
+                        e
+                    ))
+                })?;
+            rt.block_on(drive_compaction_stream(
+                &reader,
+                run_index,
+                &schema,
+                &scan_cancel,
+                &sender,
+            ))
+        })();
+
+        if let Err(e) = stream_result {
+            // Forward the error (preserving `Cancelled` distinctly, issue #2264);
+            // ignore send failure (consumer may have dropped).
+            let _ = error_sender.send(Err(MergeProducerError::from(e)));
+        }
+        // Channel closed naturally when `sender` is dropped here.
+    }
+}
+
+impl KWayMerger {
+    /// Build a k-way merger over already-open, possibly-SHARED `SSTableReader`s
+    /// (issue #2346): a warm-handle cache can hand this constructor `Arc`
+    /// clones of readers it keeps parsed across requests, instead of the
+    /// per-request path-based open ([`KWayMerger::new_cancellable`]).
+    ///
+    /// `readers` must be ordered newest-to-oldest generation (run index = LWW
+    /// tie-break rank), exactly as the path-based constructors' `input_paths`
+    /// are. Reconciliation is byte-identical to the path-based merge — only WHO
+    /// opens/owns the `SSTableReader` differs.
+    pub fn new_from_readers(
+        readers: Vec<Arc<SSTableReader>>,
+        schema: &TableSchema,
+        scan_cancel: ScanCancel,
+    ) -> Result<Self> {
+        if readers.is_empty() {
+            return Err(Error::InvalidInput(
+                "K-way merge requires at least one input reader".to_string(),
+            ));
+        }
+        schema.validate_dropped_columns()?;
+
+        let mut runs = Vec::with_capacity(readers.len());
+        for (run_index, reader) in readers.into_iter().enumerate() {
+            let adapter = SSTableRowIteratorAdapter::open_from_reader(
+                reader,
+                run_index,
+                schema,
+                scan_cancel.clone(),
+            )?;
+            runs.push(RunReader::new(
+                Box::new(adapter) as Box<dyn SSTableRowIterator>
+            ));
+        }
+
+        Ok(Self {
+            runs,
+            heap: std::collections::BinaryHeap::new(),
+            current_partition: None,
+            schema: schema.clone(),
+            // Issue #1668, stage 5c-i: see the field doc in `mod.rs`.
+            schema_arc: Arc::new(schema.clone()),
+            gc_before_secs: None,
+            now_secs: None,
+            purge_safe: false,
+            max_purgeable_timestamp: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::Platform;
+    use crate::storage::write_engine::merge::MergeStep;
+    use crate::storage::write_engine::mutation::PartitionKey;
+    use crate::storage::write_engine::test_support::{create_test_schema, flush_n_sstables_sync};
+    use crate::storage::write_engine::{WriteEngine, WriteEngineConfig};
+    use crate::types::Value;
+    use crate::Config;
+    use tempfile::TempDir;
+
+    fn config_for(temp_dir: &TempDir) -> WriteEngineConfig {
+        WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            create_test_schema(),
+        )
+    }
+
+    async fn open_reader(path: &std::path::Path) -> SSTableReader {
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.unwrap());
+        SSTableReader::open(path, &config, platform).await.unwrap()
+    }
+
+    /// Drain a merger into `(partition_key_bytes, row_count)` pairs, sorted —
+    /// enough to prove byte-identical reconciliation across two constructors
+    /// without depending on a specific row-shape decoder.
+    fn collect_merge_rows(mut merger: KWayMerger) -> Vec<(Vec<u8>, usize)> {
+        let mut out = Vec::new();
+        while let MergeStep::Partition { key, rows } = merger.step().expect("merge step") {
+            out.push((key.key.clone(), rows.len()));
+        }
+        out.sort();
+        out
+    }
+
+    /// Red-then-green (b): `KWayMerger::new_from_readers` (reader-based) must
+    /// reconcile BYTE-IDENTICALLY to `KWayMerger::new_cancellable` (path-based)
+    /// over the SAME SSTables — proving the path-based constructor's behaviour
+    /// is preserved and the two producer-thread shapes never diverge (issue
+    /// #2346). Fails to compile on pre-#2346 `main` (`new_from_readers` and
+    /// `Arc<SSTableReader>`-based construction do not exist there).
+    ///
+    /// Plain `#[test]` (not `#[tokio::test]`): `flush_n_sstables_sync` drives
+    /// its OWN runtime to flush (mirrors the `cqlite-flight` test convention —
+    /// nesting a `#[tokio::test]` runtime here would panic on
+    /// "Cannot start a runtime from within a runtime"), so the SSTables are
+    /// built first, then a fresh runtime drives the async reader-open/merge.
+    #[test]
+    fn new_from_readers_matches_path_based_reconciliation() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut engine = WriteEngine::new(config_for(&temp_dir)).unwrap();
+        // Two distinct-generation SSTables — a real multi-run merge, not a
+        // single-input vacuity.
+        let paths = flush_n_sstables_sync(&mut engine, 2);
+        assert_eq!(paths.len(), 2, "test precondition: two SSTables written");
+        let schema = create_test_schema();
+
+        let path_based = KWayMerger::new_cancellable(paths.clone(), &schema, ScanCancel::default())
+            .expect("path-based merger constructs");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let reader_based = rt.block_on(async {
+            let mut readers = Vec::with_capacity(paths.len());
+            for path in &paths {
+                readers.push(Arc::new(open_reader(path).await));
+            }
+            KWayMerger::new_from_readers(readers, &schema, ScanCancel::default())
+                .expect("reader-based merger constructs")
+        });
+
+        assert_eq!(
+            collect_merge_rows(path_based),
+            collect_merge_rows(reader_based),
+            "reader-based full-scan merger must reconcile byte-identically to the \
+             path-based one (issue #2346) — only WHO opens the reader differs"
+        );
+    }
+
+    /// Red-then-green (b), point-read variant: the reader-based
+    /// `build_single_partition_merger_from_readers` must match the path-based
+    /// `build_single_partition_merger` for the SAME target key across the SAME
+    /// SSTables. Fails to compile on pre-#2346 `main` (the reader-based builder
+    /// does not exist there).
+    ///
+    /// Plain `#[test]` — same rationale as the sibling test above.
+    #[test]
+    fn build_single_partition_merger_from_readers_matches_path_based() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut engine = WriteEngine::new(config_for(&temp_dir)).unwrap();
+        let paths = flush_n_sstables_sync(&mut engine, 2);
+        let schema = create_test_schema();
+
+        // `flush_n_sstables_sync` writes ids `batch*100 + row` for row in 0..5;
+        // id=0 (batch 0, row 0) is always present.
+        let key_bytes = PartitionKey::single("id", Value::Integer(0))
+            .to_bytes(&schema)
+            .expect("encode target key");
+
+        let path_based = super::super::build_single_partition_merger(
+            paths.clone(),
+            &[key_bytes.clone()],
+            &schema,
+            ScanCancel::default(),
+        )
+        .expect("path-based probe succeeds")
+        .expect("path-based merger must find the key");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let reader_based = rt.block_on(async {
+            let mut readers = Vec::with_capacity(paths.len());
+            for path in &paths {
+                readers.push(Arc::new(open_reader(path).await));
+            }
+            super::super::build_single_partition_merger_from_readers(
+                readers,
+                &[key_bytes],
+                &schema,
+                ScanCancel::default(),
+            )
+            .expect("reader-based probe succeeds")
+            .expect("reader-based merger must find the key")
+        });
+
+        assert_eq!(
+            collect_merge_rows(path_based),
+            collect_merge_rows(reader_based),
+            "reader-based point-read merger must reconcile byte-identically to the \
+             path-based one (issue #2346)"
+        );
+    }
+}

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -3,6 +3,13 @@
 //! Implements efficient k-way merge using a binary heap for producing
 //! compacted SSTables from multiple runs.
 //!
+//! File-size note (campsite rule, epic #1116): this file was already ~12.9k
+//! lines (far over the ~800-line source threshold) before issue #2346, which
+//! nudges it slightly further (a `producer_thread` refactor + new submodule
+//! declaration) — new code for #2346 lives in the sibling `from_readers`
+//! module instead of growing this file further. Splitting this file is out of
+//! #2346's scope; tracked under #1116.
+//!
 //! ## Architecture
 //!
 //! The K-way merger uses a min-heap to efficiently merge k sorted SSTable
@@ -92,7 +99,21 @@ pub use read_assembly::assemble_read_cells;
 #[cfg(feature = "write-support")]
 mod point_read;
 #[cfg(feature = "write-support")]
-pub use point_read::build_single_partition_merger;
+pub use point_read::{build_single_partition_merger, build_single_partition_merger_from_readers};
+
+/// Warm/shared-reader k-way merge construction (issue #2346): builds a merger
+/// directly from already-open `Arc<SSTableReader>`s instead of paths, so a
+/// future cached-reader caller (e.g. a Flight warm-handle registry) can drive a
+/// merge without re-opening/re-parsing Index/Summary/Statistics/bloom state per
+/// request. Reached as `KWayMerger::new_from_readers` (an inherent method added
+/// via `impl KWayMerger` in this submodule, mirroring `point_read`'s
+/// `from_row_iterators` — no re-export needed). Also hosts
+/// `drive_compaction_stream`, the streaming-emit helper shared by BOTH the
+/// path-based producer thread (this file's `SSTableRowIteratorAdapter::
+/// producer_thread`) and the new shared-reader producer thread, so the two
+/// never drift.
+#[cfg(feature = "write-support")]
+mod from_readers;
 
 /// Fully-expired SSTable drop classification (issue #1388): the metadata-only
 /// `fully_expired_sstables` drop-set used by both compaction surfaces to skip
@@ -598,9 +619,6 @@ impl SSTableRowIteratorAdapter {
             let mut config = Config::default();
             config.storage.use_mmap = false;
             config.storage.disk_access_mode = DiskAccessMode::Buffered;
-            // Cloned so the async block can take it by move while the outer
-            // `schema` stays available for build_merge_entry below.
-            let schema_for_reader = schema.clone();
 
             // Issue #2316: a `current_thread` runtime drives the scan ON this
             // producer thread with ZERO extra workers. A multi-threaded
@@ -629,37 +647,38 @@ impl SSTableRowIteratorAdapter {
                 // value structurally. Without it the value decode errors
                 // (`UDT not found in registry`), the row reconciles to empty, and
                 // the partition is dropped — silent data loss during compaction.
+                // This mutation requires `&mut self`, so it can only happen HERE
+                // — before the reader is ever shared — not on the shared-reader
+                // producer path (issue #2346, see `from_readers::open_from_reader`'s
+                // doc comment for that seam's UDT-registry contract).
                 if let Some(registry) = udt_registry {
                     reader.set_udt_registry(registry);
                 }
 
-                // Issue #2264: wire the cooperative-cancellation token so the
-                // (uninterruptible, fully-materialising for index-less inputs)
-                // compaction scan below abandons promptly when the Flight
-                // `do_get` driving this merge is cancelled. Default (never-cancel)
-                // for callers that pass `ScanCancel::default()`.
-                reader.set_scan_cancel(scan_cancel);
-
+                // Issue #2264/#2346: the cooperative-cancellation token is now a
+                // PER-CALL parameter to `stream_all_partitions_for_compaction`
+                // rather than mutated onto the reader (`set_scan_cancel` needed
+                // `&mut self`, which a SHARED reader cannot offer — see
+                // `from_readers::drive_compaction_stream`). This path-based
+                // producer still owns its freshly-opened `reader` exclusively, so
+                // passing `scan_cancel` by reference here is behaviourally
+                // identical to the old `set_scan_cancel` + field-read.
+                //
                 // Pass the schema so the parser uses the real clustering column
                 // names; the header-inferred fallback uses generic names like
                 // "clustering_key", which would defeat extract_clustering_key.
-                //
-                // The emit callback converts and forwards one entry at a time.
-                // A blocking `send` applies backpressure; an `Err` from `send`
-                // means the consumer was dropped → stop the scan (Break).
-                reader
-                    .stream_all_partitions_for_compaction(
-                        Some(&schema_for_reader),
-                        |compaction_row| {
-                            let msg = Self::build_merge_entry(run_index, compaction_row, &schema)
-                                .map_err(MergeProducerError::from);
-                            match sender.send(msg) {
-                                Ok(()) => Ok(std::ops::ControlFlow::Continue(())),
-                                Err(_) => Ok(std::ops::ControlFlow::Break(())),
-                            }
-                        },
-                    )
-                    .await
+                // `drive_compaction_stream` is the SAME streaming helper the
+                // shared-reader producer thread uses (issue #2346) — the
+                // conversion/backpressure/cancellation-by-variant semantics are
+                // defined in exactly one place.
+                from_readers::drive_compaction_stream(
+                    &reader,
+                    run_index,
+                    &schema,
+                    &scan_cancel,
+                    &sender,
+                )
+                .await
             })
         })();
 

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -21,10 +21,14 @@
 use super::{KWayMerger, MergeEntry, RunReader, SSTableRowIterator, SSTableRowIteratorAdapter};
 use crate::schema::TableSchema;
 use crate::storage::scan_cancel::ScanCancel;
-use crate::storage::sstable::reader::CompactionRow;
+use crate::storage::sstable::reader::{CompactionRow, SSTableReader};
 use crate::{Error, Result};
 use std::collections::{BinaryHeap, VecDeque};
 use std::path::{Path, PathBuf};
+// Unconditional (issue #2346): `build_single_partition_merger_from_readers`
+// takes `Vec<Arc<SSTableReader>>` regardless of the `tombstones` feature (its
+// `NeedsScan` fail-safe still needs `SSTableReader`/`Arc` either way).
+use std::sync::Arc;
 
 // Seek-only imports (the point-read primitive is `not(tombstones)` gated, like the
 // underlying single-partition seek machinery it composes).
@@ -35,11 +39,9 @@ use crate::config::DiskAccessMode;
 #[cfg(not(feature = "tombstones"))]
 use crate::platform::Platform;
 #[cfg(not(feature = "tombstones"))]
-use crate::storage::sstable::reader::{SSTableReader, SinglePartitionCompaction};
+use crate::storage::sstable::reader::SinglePartitionCompaction;
 #[cfg(not(feature = "tombstones"))]
 use crate::Config;
-#[cfg(not(feature = "tombstones"))]
-use std::sync::Arc;
 
 impl KWayMerger {
     /// Build a k-way merger from pre-constructed run iterators (issue #2207).
@@ -155,8 +157,9 @@ enum PathProbe {
 /// `paths` must be the same (token-pruned) candidate list, in the same order, the
 /// full-scan path would merge — run index is the position here, so LWW tie-breaks
 /// match. `keys` are raw partition-key bytes (as `PartitionKey::to_bytes`
-/// produces). `scan_cancel` is wired onto every opened reader so a client
-/// disconnect abandons an in-flight fail-safe scan promptly (#2264).
+/// produces). `scan_cancel` is threaded as a PER-CALL token into every probe/scan
+/// (issue #2346) so a client disconnect abandons an in-flight fail-safe scan
+/// promptly (#2264).
 pub fn build_single_partition_merger(
     paths: Vec<PathBuf>,
     keys: &[Vec<u8>],
@@ -241,17 +244,134 @@ pub fn build_single_partition_merger(
     Ok(Some(KWayMerger::from_row_iterators(runs, schema)?))
 }
 
-/// Open `path` ONCE and probe it for every requested key via the core seek
-/// primitive, combining the outcome (default `not(tombstones)` build).
+/// Reader-based analogue of [`build_single_partition_merger`] (issue #2346):
+/// assembles a [`KWayMerger`] that reads ONLY the target `keys`, but across
+/// already-open, possibly-SHARED `readers` instead of `paths` — the seam a
+/// future cached-reader caller (e.g. a Flight warm-handle registry) uses to
+/// avoid a fresh per-request reader-open/Index/Summary/Statistics/bloom parse.
+///
+/// Semantics mirror `build_single_partition_merger` exactly (same
+/// canonicalization, same three-way per-candidate probe via [`probe_reader`],
+/// same [`SinglePartitionFilterRun`] fail-safe, same run-index ordering) — only
+/// WHO opens/owns the `SSTableReader` differs. `readers` must be the same
+/// (token-pruned) candidate list, in the same order, the full-scan reader-based
+/// merger ([`KWayMerger::new_from_readers`]) would merge.
+pub fn build_single_partition_merger_from_readers(
+    readers: Vec<Arc<SSTableReader>>,
+    keys: &[Vec<u8>],
+    schema: &TableSchema,
+    scan_cancel: ScanCancel,
+) -> Result<Option<KWayMerger>> {
+    schema.validate_dropped_columns()?;
+    if keys.is_empty() {
+        return Ok(None);
+    }
+
+    let mut canonical: Vec<Vec<u8>> = keys.to_vec();
+    canonical.sort_by_key(|k| crate::util::cassandra_murmur3::cassandra_murmur3_token(k));
+    canonical.dedup();
+    let keys: &[Vec<u8>] = &canonical;
+
+    let key_set: std::collections::HashSet<Vec<u8>> = keys.iter().cloned().collect();
+
+    let mut runs: Vec<Box<dyn SSTableRowIterator>> = Vec::new();
+    for (run_index, reader) in readers.into_iter().enumerate() {
+        // Cooperative cancellation (#2264): honour a cancel BEFORE each candidate's
+        // probe, so a disconnected point read does no further per-SSTable work.
+        scan_cancel.check()?;
+
+        match probe_reader(Arc::clone(&reader), keys, schema, scan_cancel.clone())? {
+            PathProbe::Empty => {
+                // Pruned / absent for every key. No run.
+            }
+            PathProbe::Seeked(rows) => {
+                if rows.is_empty() {
+                    continue;
+                }
+                let mut entries: Vec<MergeEntry> = Vec::with_capacity(rows.len());
+                for row in rows {
+                    entries.push(SSTableRowIteratorAdapter::build_merge_entry(
+                        run_index, row, schema,
+                    )?);
+                }
+                // See `build_single_partition_merger`'s identical sort — every
+                // `SSTableRowIterator` MUST yield ascending `MergeEntry` order.
+                entries.sort();
+                runs.push(Box::new(VecRun {
+                    entries: entries.into(),
+                }));
+            }
+            PathProbe::NeedsScan => {
+                // Fail-safe: scan this ONE shared reader's compaction stream,
+                // forwarding only the target partitions — never a fresh
+                // path-based open (issue #2346's whole point). `reader` (the
+                // ORIGINAL, not the clone `probe_reader` consumed above) is
+                // still available here.
+                let adapter = SSTableRowIteratorAdapter::open_from_reader(
+                    reader,
+                    run_index,
+                    schema,
+                    scan_cancel.clone(),
+                )?;
+                runs.push(Box::new(SinglePartitionFilterRun {
+                    inner: adapter,
+                    keys: key_set.clone(),
+                }));
+            }
+        }
+    }
+
+    if runs.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(KWayMerger::from_row_iterators(runs, schema)?))
+}
+
+/// Probe an ALREADY-OPEN `reader` for every requested key via the core seek
+/// primitive (default `not(tombstones)` build) — the shared core BOTH
+/// [`probe_path`] (path-based, opens its own reader then delegates here) and
+/// [`build_single_partition_merger_from_readers`] (reader-based) use, so the
+/// two never diverge (issue #2346).
 ///
 /// A single SSTable's index availability is a property of the SSTable (not the
 /// key), so the FIRST `IndexUnavailable` short-circuits to [`PathProbe::NeedsScan`]
 /// (scan the whole file, filtered). Otherwise every present key's seeked rows are
 /// concatenated (they share this SSTable's generation / run index).
+#[cfg(not(feature = "tombstones"))]
+async fn probe_reader_async(
+    reader: &SSTableReader,
+    keys: &[Vec<u8>],
+    schema: &TableSchema,
+    scan_cancel: &ScanCancel,
+) -> Result<PathProbe> {
+    let mut rows: Vec<CompactionRow> = Vec::new();
+    for key in keys {
+        match reader
+            .read_single_partition_for_compaction(key, Some(schema), scan_cancel)
+            .await?
+        {
+            SinglePartitionCompaction::DefinitelyAbsent => {}
+            SinglePartitionCompaction::Rows(mut r) => rows.append(&mut r),
+            // Index availability is per-SSTable, not per-key: fall back to
+            // scanning the whole file once, filtered to the key set.
+            SinglePartitionCompaction::IndexUnavailable => {
+                return Ok(PathProbe::NeedsScan);
+            }
+        }
+    }
+    if rows.is_empty() {
+        Ok(PathProbe::Empty)
+    } else {
+        Ok(PathProbe::Seeked(rows))
+    }
+}
+
+/// Open `path` ONCE and probe it for every requested key, delegating to
+/// [`probe_reader_async`] (issue #2346) once the reader is open.
 ///
 /// Runs the async open + seek on the shared bridge runtime. The reader is opened
-/// with buffered I/O (never mmap/direct — the file may be deleted after the read)
-/// and the cooperative cancel token wired in, matching the full-scan producer.
+/// with buffered I/O (never mmap/direct — the file may be deleted after the
+/// read), matching the full-scan producer's file-lifetime contract (issue #591).
 #[cfg(not(feature = "tombstones"))]
 fn probe_path(
     path: &Path,
@@ -267,30 +387,26 @@ fn probe_path(
         config.storage.use_mmap = false;
         config.storage.disk_access_mode = DiskAccessMode::Buffered;
         let platform = Arc::new(Platform::new(&config).await?);
-        let mut reader = SSTableReader::open(&path, &config, platform).await?;
-        reader.set_scan_cancel(scan_cancel);
-
-        let mut rows: Vec<CompactionRow> = Vec::new();
-        for key in &keys {
-            match reader
-                .read_single_partition_for_compaction(key, Some(&schema))
-                .await?
-            {
-                SinglePartitionCompaction::DefinitelyAbsent => {}
-                SinglePartitionCompaction::Rows(mut r) => rows.append(&mut r),
-                // Index availability is per-SSTable, not per-key: fall back to
-                // scanning the whole file once, filtered to the key set.
-                SinglePartitionCompaction::IndexUnavailable => {
-                    return Ok(PathProbe::NeedsScan);
-                }
-            }
-        }
-        if rows.is_empty() {
-            Ok(PathProbe::Empty)
-        } else {
-            Ok(PathProbe::Seeked(rows))
-        }
+        let reader = SSTableReader::open(&path, &config, platform).await?;
+        probe_reader_async(&reader, &keys, &schema, &scan_cancel).await
     })
+}
+
+/// Probe an ALREADY-OPEN, possibly-SHARED `reader` (issue #2346) — the
+/// reader-based analogue of [`probe_path`], used by
+/// [`build_single_partition_merger_from_readers`]. `reader` is an `Arc` clone
+/// (the caller keeps the original for the `NeedsScan` fail-safe path), moved
+/// into the bridged future so no borrow needs to outlive this call.
+#[cfg(not(feature = "tombstones"))]
+fn probe_reader(
+    reader: Arc<SSTableReader>,
+    keys: &[Vec<u8>],
+    schema: &TableSchema,
+    scan_cancel: ScanCancel,
+) -> Result<PathProbe> {
+    let schema = schema.clone();
+    let keys: Vec<Vec<u8>> = keys.to_vec();
+    block_on_async(async move { probe_reader_async(&reader, &keys, &schema, &scan_cancel).await })
 }
 
 /// Tombstones-build fallback: the single-partition SEEK machinery
@@ -301,6 +417,18 @@ fn probe_path(
 #[cfg(feature = "tombstones")]
 fn probe_path(
     _path: &Path,
+    _keys: &[Vec<u8>],
+    _schema: &TableSchema,
+    _scan_cancel: ScanCancel,
+) -> Result<PathProbe> {
+    Ok(PathProbe::NeedsScan)
+}
+
+/// Tombstones-build fallback for the reader-based probe (issue #2346) — mirrors
+/// [`probe_path`]'s `tombstones` fallback above.
+#[cfg(feature = "tombstones")]
+fn probe_reader(
+    _reader: Arc<SSTableReader>,
     _keys: &[Vec<u8>],
     _schema: &TableSchema,
     _scan_cancel: ScanCancel,

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -46,6 +46,10 @@ pub use memtable::Memtable;
 #[cfg(feature = "write-support")]
 pub use merge::build_single_partition_merger;
 #[cfg(feature = "write-support")]
+// Issue #2346: the reader-based analogue of `build_single_partition_merger`,
+// re-exported alongside it so both surfaces are reachable the same way.
+pub use merge::build_single_partition_merger_from_readers;
+#[cfg(feature = "write-support")]
 pub use merge::KWayMerger;
 #[cfg(feature = "write-support")]
 pub use merge_policy::STCSPolicy;

--- a/cqlite-core/tests/issue_1104_compaction_incompressible_chunks.rs
+++ b/cqlite-core/tests/issue_1104_compaction_incompressible_chunks.rs
@@ -31,6 +31,7 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use cqlite_core::storage::scan_cancel::ScanCancel;
 use cqlite_core::storage::sstable::reader::{CompactionRow, CompactionRowData, SSTableReader};
 use cqlite_core::types::Value;
 use cqlite_core::{Config, Platform};
@@ -205,7 +206,7 @@ async fn issue_1104_stream_compaction_over_incompressible_chunks() {
     let collected: Arc<Mutex<Vec<CompactionRow>>> = Arc::new(Mutex::new(Vec::new()));
     let sink = Arc::clone(&collected);
     reader
-        .stream_all_partitions_for_compaction(None, move |row| {
+        .stream_all_partitions_for_compaction(None, &ScanCancel::default(), move |row| {
             sink.lock().unwrap().push(row);
             Ok(std::ops::ControlFlow::Continue(()))
         })

--- a/cqlite-core/tests/issue_1589_window_drain_bytes.rs
+++ b/cqlite-core/tests/issue_1589_window_drain_bytes.rs
@@ -54,6 +54,7 @@ use std::sync::{Arc, Mutex};
 use cqlite_core::ingestion::{ingest, IngestionConfig};
 use cqlite_core::platform::Platform;
 use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::scan_cancel::ScanCancel;
 use cqlite_core::storage::sstable::reader::window_cursor::probe;
 use cqlite_core::storage::sstable::SSTableReader;
 use cqlite_core::{Config, Database};
@@ -238,7 +239,7 @@ async fn scan_and_compaction_windows_move_bytes_bounded_by_appended() {
 
     probe::arm();
     reader
-        .stream_all_partitions_for_compaction(None, move |_row| {
+        .stream_all_partitions_for_compaction(None, &ScanCancel::default(), move |_row| {
             *sink.lock().expect("count lock") += 1;
             Ok(std::ops::ControlFlow::Continue(()))
         })

--- a/cqlite-core/tests/test_issue_827_streaming_parity.rs
+++ b/cqlite-core/tests/test_issue_827_streaming_parity.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 
 use cqlite_core::platform::Platform;
 use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::scan_cancel::ScanCancel;
 use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::storage::write_engine::{
     CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
@@ -153,7 +154,7 @@ async fn collect_vec(reader: &SSTableReader, schema: &TableSchema) -> Vec<EntryS
 async fn collect_stream(reader: &SSTableReader, schema: &TableSchema) -> Vec<EntrySnapshot> {
     let mut out: Vec<EntrySnapshot> = Vec::new();
     reader
-        .stream_all_partitions_for_compaction(Some(schema), |row| {
+        .stream_all_partitions_for_compaction(Some(schema), &ScanCancel::default(), |row| {
             out.push(row);
             Ok(std::ops::ControlFlow::Continue(()))
         })
@@ -509,7 +510,7 @@ async fn test_streaming_break_stops_early() {
 
     let mut collected: Vec<Vec<u8>> = Vec::new();
     reader
-        .stream_all_partitions_for_compaction(Some(&schema), |row| {
+        .stream_all_partitions_for_compaction(Some(&schema), &ScanCancel::default(), |row| {
             collected.push(row.key.as_bytes().to_vec());
             if collected.len() >= 5 {
                 Ok(std::ops::ControlFlow::Break(()))


### PR DESCRIPTION
Closes #2346. WS0 prerequisite for epic #2310 (flight warm handles) — a **behavior-preserving** core seam; behavior preservation is the oracle.

## What
- `KWayMerger::new_from_readers(Vec<Arc<SSTableReader>>, schema, scan_cancel)` (new module `merge/from_readers.rs`) + `build_single_partition_merger_from_readers` — mergers over caller-supplied shared readers.
- `scan_cancel` threaded as a **per-call parameter** through the compaction read path (stream/point/sequential/full-index + the stitched-chunk path), replacing reader-stored `&mut self` cancellation there — prerequisite for sharing one `Arc<SSTableReader>` across concurrent requests with independent cancel tokens.
- Path-based constructors DELEGATE to the same shared helpers (`drive_compaction_stream`, `probe_reader_async`) — one code path, no drift.

## Red proofs
- `two_concurrent_scans_on_shared_reader_cancel_independently` — uncompilable pre-seam (cancellation was `&mut self` state, no per-caller token possible); latch-synchronized so both scans are provably in flight (roborev 1635 Low fixed).
- `stitched_sequential_scan_honors_per_call_cancel` — with polls neutralized returns Ok(1000) instead of Err(Cancelled) (roborev 1635 High fixed: stitched path now polls per-256-chunk + per-256-entry).
- `new_from_readers_matches_path_based_full_cell_equality_overlapping` — full `MergeEntry` cell equality over overlapping generations (value overwrite + cell tombstone + row tombstone + clustering keys), upgrading the parity guard from row-counts (parity-audit F1 fixed).

## Review trail
rust-reviewer CLEAN (cancellation surface traced; delegation byte-identical; shared-Arc concurrency sound) · compaction-parity-auditor code-CLEAN (F1 fixed above; F2 UDT-registry wiring guard recorded on WS1 #2345 + in-code comment) · roborev 1635 both findings fixed, re-review running.

## Notes
- Evidence: cqlite-core lib 3060 green; cancel/point-fail-safe suites 13/13; flight lib 181/181; workspace check clean.
- `CQLITE_ALLOW_FILE_GROWTH=1`: pre-existing over-threshold `merge/mod.rs` (+12) / `sequential.rs` (+36) nudged — new logic lives in `from_readers.rs`; #1116.
- Nit batch at merge: tombstones-feature wasted Arc clone (point_read.rs:283).
- Full gate of record runs pre-merge in flow-closer.