### PR TITLE
flight(#2310): warm-handle service — generation-keyed reader cache, probe+manifest refresh, budget/metrics (WS1–WS5)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -109,6 +109,10 @@ pub mod attr {
     /// `tombstones_build_no_prune`). Bounded by the enum itself; NEVER carries a
     /// partition key, predicate value, or query string.
     pub const FALLBACK_REASON: &str = "cqlite.query.fallback_reason";
+    /// Flight warm-handle refresh outcome (issue #2310). Bounded to the closed set
+    /// `"unchanged"`, `"rebuilt_delta"`, `"fail_closed_retained"` — a `&'static str`
+    /// from a fixed slot table, never a ticket, key, or path value.
+    pub const WARM_REFRESH_OUTCOME: &str = "cqlite.warm.refresh_outcome";
 }
 
 /// `cqlite.read.rows` — counter `{row}`.
@@ -518,6 +522,33 @@ pub const RPC_BYTES: &str = "cqlite.rpc.bytes";
 /// carries a ticket, key, token range, or query-text attribute.
 pub const RPC_PHASE_DURATION: &str = "cqlite.rpc.phase.duration";
 
+/// `cqlite.warm.cache.hits` — counter `{1}` (issue #2310).
+///
+/// Flight warm-handle cache hits: a request whose probed SSTable generation set
+/// matched the cached set, served from warm parsed state with ZERO reader-open
+/// and zero Index/Summary/Statistics/bloom parse. No attributes (bounded).
+pub const WARM_CACHE_HITS: &str = "cqlite.warm.cache.hits";
+
+/// `cqlite.warm.cache.misses` — counter `{1}` (issue #2310).
+///
+/// Flight warm-handle cache misses: no cached entry, or the generation set
+/// changed so a (delta) rebuild was required. No attributes (bounded).
+pub const WARM_CACHE_MISSES: &str = "cqlite.warm.cache.misses";
+
+/// `cqlite.warm.cache.evicts` — counter `{1}` (issue #2310).
+///
+/// Warm generations evicted, whether by LRU (byte-budget pressure) or because a
+/// rebuild found them removed on disk. No attributes (bounded).
+pub const WARM_CACHE_EVICTS: &str = "cqlite.warm.cache.evicts";
+
+/// `cqlite.warm.cache.refresh` — counter `{1}` (issue #2310).
+///
+/// Warm-handle refresh outcomes, tagged by [`attr::WARM_REFRESH_OUTCOME`]
+/// (`unchanged` / `rebuilt_delta` / `fail_closed_retained`) — the single bounded
+/// dimension. Distinguishes a warm hit from a delta rebuild from a fail-closed
+/// retention in metrics alone (spec Requirement 6).
+pub const WARM_CACHE_REFRESH: &str = "cqlite.warm.cache.refresh";
+
 /// All catalog metric names, for tests and registration sanity checks.
 pub const ALL_METRICS: &[&str] = &[
     READ_ROWS,
@@ -573,6 +604,11 @@ pub const ALL_METRICS: &[&str] = &[
     RPC_BYTES,
     // In-progress read/query metrics (#2162)
     RPC_PHASE_DURATION,
+    // Flight warm-handle cache (#2310)
+    WARM_CACHE_HITS,
+    WARM_CACHE_MISSES,
+    WARM_CACHE_EVICTS,
+    WARM_CACHE_REFRESH,
 ];
 
 #[cfg(test)]
@@ -607,9 +643,27 @@ mod tests {
             attr::RPC_STATUS,
             attr::RPC_PHASE,
             attr::FALLBACK_REASON,
+            attr::WARM_REFRESH_OUTCOME,
         ] {
             assert!(key.starts_with("cqlite."), "attr {key} must be namespaced");
         }
+    }
+
+    #[test]
+    fn warm_cache_metrics_are_registered_and_namespaced() {
+        // Issue #2310: the warm-handle counters must be part of the canonical
+        // catalog so registration/uniqueness checks cover them, and rooted under
+        // `cqlite.` like every other metric.
+        for m in [
+            WARM_CACHE_HITS,
+            WARM_CACHE_MISSES,
+            WARM_CACHE_EVICTS,
+            WARM_CACHE_REFRESH,
+        ] {
+            assert!(ALL_METRICS.contains(&m), "{m} must be catalogued");
+            assert!(m.starts_with("cqlite.warm."));
+        }
+        assert!(attr::WARM_REFRESH_OUTCOME.starts_with("cqlite."));
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -1238,6 +1238,36 @@ impl SSTableReader {
         );
     }
 
+    /// Whether a UDT registry has been wired onto this reader (issue #2310, WS1
+    /// #2345). A warm-handle cache that hands SHARED `Arc<SSTableReader>`s to the
+    /// reader-based k-way merge seam (`KWayMerger::new_from_readers`, which takes
+    /// NO `udt_registry` parameter) MUST open each reader WITH its registry
+    /// already resolved before wrapping it in `Arc`; this getter lets that caller
+    /// PROVE the registry is present rather than silently decoding a frozen/nested
+    /// UDT cell as `Blob` (the #1234 data-loss class).
+    pub fn has_udt_registry(&self) -> bool {
+        self.udt_registry.is_some()
+    }
+
+    /// The `Data.db` path this reader was opened from (issue #2310). The warm
+    /// registry keys parsed state on the file's inode-stable generation identity,
+    /// so it needs the backing path to `stat` device+inode without re-listing the
+    /// directory.
+    pub fn file_path(&self) -> &Path {
+        &self.file_path
+    }
+
+    /// The immutable `[first_key_token, last_key_token]` endpoints cached at open
+    /// (issue #1576), or `None` when `Summary.db` was absent/empty. The Flight
+    /// warm registry (issue #2310) uses this to token-prune a WARM reader set with
+    /// ZERO extra I/O — a warm hit re-reads no `Summary.db`, preserving the
+    /// "zero Index/Summary/Statistics/bloom parse" property even for a
+    /// token-filtered scan. SSTables store partitions in token order, so the
+    /// first endpoint is the min token and the last the max.
+    pub fn endpoint_tokens(&self) -> Option<(i64, i64)> {
+        self.endpoint_tokens
+    }
+
     /// Wire a cooperative-cancellation token into this reader's long-running
     /// scans (issue #2264).
     ///

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -16,11 +16,13 @@ pub mod pathsafe;
 pub mod point_read;
 pub mod producer;
 mod producer_point;
+mod producer_warm;
 pub mod scan_progress;
 pub mod service;
 pub mod shutdown;
 pub mod stats;
 pub mod streaming;
+pub mod warm;
 
 // Shared byte-pin infrastructure (issues #2283/#2285): the single source of
 // truth for the `cassandra_easy_stress.keyvalue` field shape AND the

--- a/cqlite-flight/src/producer_warm.rs
+++ b/cqlite-flight/src/producer_warm.rs
@@ -53,7 +53,17 @@ impl MergeProducer {
         // Token-prune the warm reader set with zero extra I/O.
         let readers = self.prune_readers(readers);
         if readers.is_empty() {
-            on_merger_built();
+            // Cold-path parity (issue #2310, roborev 1641): the cold
+            // `produce_streaming` prunes paths in the CALLER before ever being
+            // invoked, so an empty post-prune set never reaches a merger-built
+            // call — its top-level `paths.is_empty()` check returns `Ok(())`
+            // WITHOUT firing `on_merger_built` (no merger is built when there is
+            // nothing to merge). The warm path prunes INTERNALLY (readers arrive
+            // unpruned), so it must mirror that exact "nothing to merge → no
+            // phase-boundary fire" behavior here, not treat an empty PRUNED set
+            // like the point-read route's deliberate "still fire the boundary"
+            // case (which fires because a merger-build attempt was genuinely
+            // dispatched and came back empty, not because pruning skipped it).
             return Ok(());
         }
 
@@ -134,5 +144,100 @@ impl MergeProducer {
             )?;
         }
         Ok(batches)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use cqlite_core::{Config, Platform};
+
+    use crate::filter::ScanSpec;
+    use crate::producer::CollectSink;
+    use crate::scan_progress::ScanProgress;
+    use crate::testutil::{build_sstables, simple_schema, write_row};
+    use crate::ticket::FlightTicket;
+
+    use super::*;
+
+    /// Finding 2 (#2310, roborev 1641): when token pruning empties the warm
+    /// reader set inside `produce_streaming_from_readers`, the call must return
+    /// WITHOUT firing `on_merger_built` — mirroring the cold path's "nothing to
+    /// merge → no phase-boundary fire" posture (`produce_streaming`'s top-level
+    /// `paths.is_empty()` check never fires it either, since the cold path prunes
+    /// in the CALLER before the merge-driving call is ever invoked). Red on
+    /// pre-fix code: the pruned-to-empty branch fired the callback
+    /// unconditionally before returning.
+    #[test]
+    fn empty_pruned_warm_set_fires_no_merger_built_callback() {
+        let schema = simple_schema();
+        let (_temp, _data, table_dir) =
+            build_sstables(&schema, vec![vec![write_row(1, "a", 10, 100)]]);
+        let data_db = std::fs::read_dir(&table_dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with("-Data.db"))
+            })
+            .expect("a Data.db exists");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let reader = rt.block_on(async {
+            let config = Config::default();
+            let platform = Arc::new(Platform::new(&config).await.unwrap());
+            Arc::new(
+                SSTableReader::open(&data_db, &config, platform)
+                    .await
+                    .unwrap(),
+            )
+        });
+        let (min_tok, max_tok) = reader
+            .endpoint_tokens()
+            .expect("Summary.db parsed, endpoint tokens known");
+
+        // A token range strictly beyond the reader's own span, guaranteed NOT to
+        // overlap it — pruning must drop this single reader entirely.
+        let spec = ScanSpec::from_ticket(
+            &FlightTicket {
+                token_start: Some(max_tok.saturating_add(1)),
+                token_end: Some(max_tok.saturating_add(2)),
+                ..Default::default()
+            },
+            &schema,
+        )
+        .unwrap();
+        assert!(
+            !spec.token.as_ref().unwrap().overlaps(min_tok, max_tok),
+            "the chosen range must genuinely exclude the reader's span"
+        );
+
+        let producer = MergeProducer::with_spec(schema, 1024, spec).unwrap();
+        let fired = Arc::new(AtomicBool::new(false));
+        let fired_probe = Arc::clone(&fired);
+        let mut batches = Vec::new();
+        let mut sink = CollectSink(&mut batches);
+        producer
+            .produce_streaming_from_readers(
+                vec![reader],
+                &CancelFlag::new(),
+                &mut sink,
+                &ScanProgress::default(),
+                move || fired_probe.store(true, Ordering::SeqCst),
+            )
+            .expect("empty-pruned warm set is a clean no-op, not an error");
+
+        assert!(
+            !fired.load(Ordering::SeqCst),
+            "on_merger_built must NOT fire when token pruning empties the warm \
+             reader set (cold-path phase-accounting parity, roborev 1641)"
+        );
+        assert!(batches.is_empty(), "nothing was merged, nothing streamed");
     }
 }

--- a/cqlite-flight/src/producer_warm.rs
+++ b/cqlite-flight/src/producer_warm.rs
@@ -1,0 +1,134 @@
+//! Warm reader-set merge routing on the producer (issue #2310, WS3 #2342).
+//!
+//! The cold `do_get` path opens a fresh [`SSTableReader`] per input on every
+//! request ([`MergeProducer::produce_streaming`] → `KWayMerger::new_cancellable`,
+//! paying the Index/Summary/Statistics/bloom parse each time). This module adds
+//! the WARM analogue: the [`crate::warm::WarmTableRegistry`] hands the producer
+//! already-open, possibly-SHARED `Arc<SSTableReader>`s (kept parsed across
+//! requests) and the merge is driven via the #2346 reader-based seams
+//! (`KWayMerger::new_from_readers` / `build_single_partition_merger_from_readers`).
+//! Everything downstream — the point-read route selection, LIMIT/budget pushdown,
+//! tombstone reconciliation, Arrow conversion — is byte-identical to the cold
+//! path; only WHO opened the reader differs.
+//!
+//! Lives in its own module (not `producer.rs`) because that file is over the
+//! campsite file-size threshold (epic #1116).
+
+use std::sync::Arc;
+
+use arrow::record_batch::RecordBatch;
+use cqlite_core::query::AccessPath;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::storage::write_engine::{build_single_partition_merger_from_readers, KWayMerger};
+
+use crate::cancel::CancelFlag;
+use crate::producer::{BatchSink, CollectSink, MergeProducer, ProducerError};
+use crate::scan_progress::ScanProgress;
+
+impl MergeProducer {
+    /// Stream the row-merge of a WARM reader set (issue #2310), mirroring
+    /// [`MergeProducer::produce_streaming`] but over already-open
+    /// `Arc<SSTableReader>`s. `readers` MUST be ordered newest-generation-first
+    /// (the warm registry guarantees this) — run index = LWW tie-break rank.
+    ///
+    /// Token pruning uses each reader's ALREADY-PARSED endpoint tokens
+    /// (`SSTableReader::endpoint_tokens`, zero extra I/O), so a warm hit re-reads
+    /// no `Summary.db` even for a token-filtered scan — preserving the
+    /// "zero Index/Summary/Statistics/bloom parse" property (spec Requirement 2).
+    pub(crate) fn produce_streaming_from_readers(
+        &self,
+        readers: Vec<Arc<SSTableReader>>,
+        cancel: &CancelFlag,
+        sink: &mut dyn BatchSink,
+        progress: &ScanProgress,
+        on_merger_built: impl FnOnce(),
+    ) -> Result<(), ProducerError> {
+        if self.is_aggregating() || readers.is_empty() {
+            return Ok(());
+        }
+        // Token-prune the warm reader set with zero extra I/O.
+        let readers = self.prune_readers(readers);
+        if readers.is_empty() {
+            on_merger_built();
+            return Ok(());
+        }
+
+        // Issue #2207: a pushed full-PK-equality predicate routes to the partition
+        // point-read path over the SAME warm readers, exactly as the cold path.
+        if let Some(plan) = self.point_read_keys() {
+            let key_bytes: Vec<Vec<u8>> = plan.keys.into_iter().map(|(k, _)| k).collect();
+            let label = plan.access_path.label();
+            if key_bytes.is_empty() {
+                on_merger_built();
+                return Ok(());
+            }
+            let built = build_single_partition_merger_from_readers(
+                readers,
+                &key_bytes,
+                &self.schema,
+                cancel.scan_cancel(),
+            )
+            .map_err(|e| match e {
+                cqlite_core::Error::Cancelled => ProducerError::Cancelled,
+                other => ProducerError::Merge(other),
+            })?;
+            on_merger_built();
+            return match built {
+                None => Ok(()),
+                Some(mut merger) => self.drive_merge(&mut merger, cancel, sink, progress, label),
+            };
+        }
+
+        let mut merger = KWayMerger::new_from_readers(readers, &self.schema, cancel.scan_cancel())
+            .map_err(ProducerError::Merge)?;
+        on_merger_built();
+        self.drive_merge(
+            &mut merger,
+            cancel,
+            sink,
+            progress,
+            AccessPath::FullScan.label(),
+        )
+    }
+
+    /// Token-prune a warm reader set by each reader's already-parsed endpoint
+    /// tokens (zero I/O). Returns `readers` unchanged when there is no token
+    /// filter. A reader whose endpoint tokens are unknown (Summary.db was absent)
+    /// is KEPT (fail open) — pruning must never drop an SSTable that might contain
+    /// matching partitions, exactly like the path-based `prune_paths`.
+    fn prune_readers(&self, readers: Vec<Arc<SSTableReader>>) -> Vec<Arc<SSTableReader>> {
+        let Some(token) = &self.spec.token else {
+            return readers;
+        };
+        readers
+            .into_iter()
+            .filter(|r| match r.endpoint_tokens() {
+                Some((min_token, max_token)) => token.overlaps(min_token, max_token),
+                None => true,
+            })
+            .collect()
+    }
+
+    /// Collect the warm reader-set streaming merge into a `Vec` (issue #2310
+    /// wiring evidence + dual-path parity): the SAME path `do_get` streams over
+    /// warm readers, so a test can compare its batches byte-for-byte against the
+    /// cold path.
+    pub fn produce_streaming_from_readers_to_vec(
+        &self,
+        readers: Vec<Arc<SSTableReader>>,
+        cancel: &CancelFlag,
+    ) -> Result<Vec<RecordBatch>, ProducerError> {
+        let mut batches = Vec::new();
+        {
+            let mut sink = CollectSink(&mut batches);
+            self.produce_streaming_from_readers(
+                readers,
+                cancel,
+                &mut sink,
+                &ScanProgress::default(),
+                || {},
+            )?;
+        }
+        Ok(batches)
+    }
+}

--- a/cqlite-flight/src/producer_warm.rs
+++ b/cqlite-flight/src/producer_warm.rs
@@ -9,7 +9,11 @@
 //! (`KWayMerger::new_from_readers` / `build_single_partition_merger_from_readers`).
 //! Everything downstream — the point-read route selection, LIMIT/budget pushdown,
 //! tombstone reconciliation, Arrow conversion — is byte-identical to the cold
-//! path; only WHO opened the reader differs.
+//! path; only WHO opened the reader differs. Crucially, decode posture matches
+//! too: the cold path (`KWayMerger::new_cancellable`) and the warm registry BOTH
+//! open readers WITHOUT a UDT registry (`has_udt_registry() == false`), so parity
+//! is guaranteed by identical posture — NOT by warm matching some non-null
+//! authority. Wiring a real UDT registry into both paths together is issue #2349.
 //!
 //! Lives in its own module (not `producer.rs`) because that file is over the
 //! campsite file-size threshold (epic #1116).

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -96,9 +96,10 @@ fn warm_error_to_status(e: WarmError) -> Status {
         WarmError::Probe { source, .. } if source.kind() == std::io::ErrorKind::NotFound => {
             Status::not_found(msg)
         }
-        WarmError::Probe { .. } | WarmError::Open { .. } | WarmError::Runtime(_) => {
-            Status::internal(msg)
-        }
+        WarmError::Probe { .. }
+        | WarmError::ProbeEntry { .. }
+        | WarmError::Open { .. }
+        | WarmError::Runtime(_) => Status::internal(msg),
     }
 }
 
@@ -263,26 +264,46 @@ impl CqliteFlightService {
     /// [`SetupCaches::live_dirs`] for why caching it would leak). The
     /// keyspace/table are pathsafe-validated by `FlightTicket::from_bytes`, so a
     /// cached entry was validated when first resolved.
+    ///
+    /// The pin is CORRECTNESS-bounded (issue #2310 finding 2): a cached dir is
+    /// served only after a cheap existence re-check, so a dropped/recreated table
+    /// (whose `table-<uuid>` dir was renamed) invalidates the pin and forces a
+    /// fresh resolve — which correctly counts as resolve work; the Req-8 elision
+    /// claim only covers the steady state. And a non-existent resolution (the
+    /// `best.unwrap_or(exact)` fallback for a table with no dir on disk) is NEVER
+    /// cached, so the pin can never fossilize a wrong/absent path.
     fn resolve_dir(&self, ticket: &FlightTicket) -> Result<PathBuf, Status> {
         let snapshot_mode = ticket.snapshot.as_deref().is_some_and(|s| !s.is_empty());
         if !snapshot_mode {
             let cache_key = (ticket.keyspace.clone(), ticket.table.clone());
-            if let Some(hit) = self
-                .caches
-                .live_dirs
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .get(&cache_key)
             {
-                return Ok(hit.clone());
+                let mut live = self
+                    .caches
+                    .live_dirs
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner);
+                if let Some(hit) = live.get(&cache_key) {
+                    // Cheap re-validation: a still-present pinned dir is a warm hit
+                    // (zero resolve work). A missing/renamed one is a STALE pin —
+                    // drop it and fall through to a fresh resolve.
+                    if hit.is_dir() {
+                        return Ok(hit.clone());
+                    }
+                    live.remove(&cache_key);
+                }
             }
             let dir = self.resolve_dir_uncached(ticket)?;
-            self.caches
-                .live_dirs
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .entry(cache_key)
-                .or_insert_with(|| dir.clone());
+            // Only cache a resolution that actually EXISTS: never pin the
+            // non-existent `best.unwrap_or(exact)` fallback (would serve a wrong /
+            // stale path for the process lifetime).
+            if dir.is_dir() {
+                self.caches
+                    .live_dirs
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .entry(cache_key)
+                    .or_insert_with(|| dir.clone());
+            }
             return Ok(dir);
         }
         self.resolve_dir_uncached(ticket)
@@ -958,6 +979,71 @@ mod tests {
         assert_eq!(
             after_second.resolves, 1,
             "the warm second request re-resolves the directory ZERO times (spec Req 8)"
+        );
+    }
+
+    /// Finding 2 (#2310): a live-dir pin must NOT survive a drop + recreate under
+    /// a new `table-<uuid>` name. The first resolve caches `items-aaaa`; after it
+    /// is removed and `items-bbbb` created, the next resolve must reach the NEW
+    /// dir, never the stale pin. Red on pre-fix code (serves the pinned path).
+    #[test]
+    fn live_dir_pin_invalidated_on_table_drop_and_recreate() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let data_dir = temp.path().join("data");
+        let ks_dir = data_dir.join(KS);
+        let first = ks_dir.join(format!("{TBL}-aaaaaaaa"));
+        std::fs::create_dir_all(&first).unwrap();
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let t = FlightTicket {
+            keyspace: KS.into(),
+            table: TBL.into(),
+            ddl: SIMPLE_DDL.into(),
+            ..Default::default()
+        };
+
+        let r1 = svc.resolve_dir(&t).expect("first resolve");
+        assert_eq!(r1, first, "first resolve picks the only table-<uuid> dir");
+
+        std::fs::remove_dir_all(&first).unwrap();
+        let second = ks_dir.join(format!("{TBL}-bbbbbbbb"));
+        std::fs::create_dir_all(&second).unwrap();
+
+        let r2 = svc.resolve_dir(&t).expect("second resolve");
+        assert_eq!(
+            r2, second,
+            "a dropped/recreated table dir must NOT serve the stale pin"
+        );
+    }
+
+    /// Finding 2 (#2310): a NON-EXISTENT resolution (the `best.unwrap_or(exact)`
+    /// fallback for a table with no dir yet) must never be cached — otherwise the
+    /// wrong/absent path fossilizes for the process lifetime. After the table dir
+    /// later appears under a `table-<uuid>` name, the next resolve must reach it.
+    #[test]
+    fn resolve_never_caches_a_nonexistent_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let data_dir = temp.path().join("data");
+        let ks_dir = data_dir.join(KS);
+        std::fs::create_dir_all(&ks_dir).unwrap(); // keyspace exists, table does not
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let t = FlightTicket {
+            keyspace: KS.into(),
+            table: TBL.into(),
+            ddl: SIMPLE_DDL.into(),
+            ..Default::default()
+        };
+
+        let r1 = svc.resolve_dir(&t).expect("first resolve");
+        assert!(!r1.is_dir(), "no table dir on disk yet, got {r1:?}");
+
+        // The table now lands under a uuid-suffixed dir.
+        let real = ks_dir.join(format!("{TBL}-cccccccc"));
+        std::fs::create_dir_all(&real).unwrap();
+
+        let r2 = svc.resolve_dir(&t).expect("second resolve");
+        assert_eq!(
+            r2, real,
+            "a non-existent first resolution must not be cached over the real dir"
         );
     }
 

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -13,9 +13,11 @@
 // trait methods. Boxing would only add churn at every call site.
 #![allow(clippy::result_large_err)]
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use arrow::datatypes::Schema as ArrowSchema;
 use arrow::ipc::writer::IpcWriteOptions;
@@ -147,6 +149,41 @@ struct DoGetSetup {
     input: DoGetInput,
 }
 
+/// Cross-request setup caches (spec Requirement 8): the schema PARSE and the
+/// directory RESOLVE are the two per-request `do_get`-setup costs that survive a
+/// warm reader-cache hit unless memoized. Both are keyed on authoritative,
+/// pre-validated ticket inputs (the DDL string; the pathsafe-validated
+/// keyspace/table) and shared (`Arc`) across the `Clone`d per-RPC handles.
+#[derive(Default)]
+struct SetupCaches {
+    /// Parsed schema per exact DDL string. Keyed on the full DDL (never a hash —
+    /// a hash collision would serve the WRONG schema and corrupt decode). Bounded
+    /// in practice by the number of distinct table DDLs queried.
+    schemas: Mutex<HashMap<String, Arc<TableSchema>>>,
+    /// Resolved LIVE-mode table dir per (keyspace, table). Snapshot mode is NOT
+    /// cached on purpose: the field runs a fresh per-query `snapshots/<uuid>/`
+    /// dir per request, so a snapshot-keyed cache would grow unbounded with ZERO
+    /// hit benefit (the warm reader cache still elides the parse via inode
+    /// identity). Live mode's dir is stable, so caching it elides the resolve on
+    /// every repeat query — the dominant warm-hit case (spec Req 8).
+    live_dirs: Mutex<HashMap<(String, String), PathBuf>>,
+    /// Work-done probe: schema PARSES actually performed (a cache hit adds 0).
+    schema_parses: AtomicU64,
+    /// Work-done probe: directory RESOLVES actually performed (a live-mode cache
+    /// hit adds 0; a snapshot-mode request always resolves, by design above).
+    resolves: AtomicU64,
+}
+
+/// A point-in-time read of the `do_get`-setup work counters, for the warm-hit
+/// elision tests (spec Requirement 8) and the #2289/#1494 bench harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetupWorkSnapshot {
+    /// Schema parses performed (CQL DDL → `TableSchema`).
+    pub schema_parses: u64,
+    /// Directory resolves performed (`DirSource::resolve`).
+    pub resolves: u64,
+}
+
 /// Flight service over a node-local SSTable data directory.
 #[derive(Clone)]
 pub struct CqliteFlightService {
@@ -158,6 +195,8 @@ pub struct CqliteFlightService {
     /// readers so a repeated query on unchanged data pays ~0 reader-open/parse.
     /// Shared (`Arc`) across the `Clone`d per-RPC service handles.
     warm: Arc<WarmTableRegistry>,
+    /// Cross-request schema-parse + directory-resolve caches (spec Req 8).
+    caches: Arc<SetupCaches>,
 }
 
 impl CqliteFlightService {
@@ -167,6 +206,7 @@ impl CqliteFlightService {
             data_dir: data_dir.into(),
             batch_size: batch_size.max(1),
             warm: Arc::new(WarmTableRegistry::new()),
+            caches: Arc::new(SetupCaches::default()),
         }
     }
 
@@ -177,18 +217,96 @@ impl CqliteFlightService {
         self.warm.metrics().snapshot()
     }
 
+    /// A point-in-time read of the `do_get`-setup work counters (schema parses +
+    /// directory resolves) — the spec Req 8 elision probe (issue #2310).
+    pub fn setup_work(&self) -> SetupWorkSnapshot {
+        SetupWorkSnapshot {
+            schema_parses: self.caches.schema_parses.load(Ordering::Relaxed),
+            resolves: self.caches.resolves.load(Ordering::Relaxed),
+        }
+    }
+
     /// Parse the table schema from the ticket's CQL DDL.
     fn parse_schema(ticket: &FlightTicket) -> Result<TableSchema, Status> {
         parse_cql_schema(&ticket.ddl)
             .map_err(|e| Status::invalid_argument(format!("invalid ddl: {e}")))
     }
 
+    /// The parsed schema for a ticket, reusing a cached parse for a repeat DDL
+    /// (spec Req 8: schema parse elided on a warm hit). The CQL parse runs OUTSIDE
+    /// the cache lock; a rare concurrent first-parse of the same DDL just parses
+    /// twice (both correct), never holds the lock across the parse.
+    fn cached_schema(&self, ticket: &FlightTicket) -> Result<Arc<TableSchema>, Status> {
+        if let Some(hit) = self
+            .caches
+            .schemas
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&ticket.ddl)
+        {
+            return Ok(Arc::clone(hit));
+        }
+        let schema = Arc::new(Self::parse_schema(ticket)?);
+        self.caches.schema_parses.fetch_add(1, Ordering::Relaxed);
+        self.caches
+            .schemas
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .entry(ticket.ddl.clone())
+            .or_insert_with(|| Arc::clone(&schema));
+        Ok(schema)
+    }
+
+    /// Resolve the SSTable directory for a ticket, reusing a cached LIVE-mode
+    /// resolution on a repeat (keyspace, table) (spec Req 8: directory resolve
+    /// elided on a warm hit). Snapshot mode always resolves fresh (see
+    /// [`SetupCaches::live_dirs`] for why caching it would leak). The
+    /// keyspace/table are pathsafe-validated by `FlightTicket::from_bytes`, so a
+    /// cached entry was validated when first resolved.
+    fn resolve_dir(&self, ticket: &FlightTicket) -> Result<PathBuf, Status> {
+        let snapshot_mode = ticket.snapshot.as_deref().is_some_and(|s| !s.is_empty());
+        if !snapshot_mode {
+            let cache_key = (ticket.keyspace.clone(), ticket.table.clone());
+            if let Some(hit) = self
+                .caches
+                .live_dirs
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .get(&cache_key)
+            {
+                return Ok(hit.clone());
+            }
+            let dir = self.resolve_dir_uncached(ticket)?;
+            self.caches
+                .live_dirs
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .entry(cache_key)
+                .or_insert_with(|| dir.clone());
+            return Ok(dir);
+        }
+        self.resolve_dir_uncached(ticket)
+    }
+
+    /// The uncached `DirSource::resolve`, incrementing the resolve work probe.
+    fn resolve_dir_uncached(&self, ticket: &FlightTicket) -> Result<PathBuf, Status> {
+        let dir = DirSource::resolve(
+            &self.data_dir,
+            &ticket.keyspace,
+            &ticket.table,
+            ticket.snapshot.as_deref(),
+        )?
+        .into_dir();
+        self.caches.resolves.fetch_add(1, Ordering::Relaxed);
+        Ok(dir)
+    }
+
     /// Build a producer for a ticket, applying its token-range/predicate/projection
     /// filters. Used by every RPC so the Arrow schema reflects the projection.
     fn build_producer(&self, ticket: &FlightTicket) -> Result<MergeProducer, Status> {
-        let schema = Self::parse_schema(ticket)?;
+        let schema = self.cached_schema(ticket)?;
         let spec = ScanSpec::from_ticket(ticket, &schema)?;
-        let producer = MergeProducer::with_spec(schema, self.batch_size, spec)?;
+        let producer = MergeProducer::with_spec((*schema).clone(), self.batch_size, spec)?;
         // Aggregation pushdown (issue #841): when the ticket carries an
         // aggregation spec, the producer emits PARTIAL aggregate rows under the
         // partial schema instead of full rows.
@@ -532,17 +650,15 @@ impl CqliteFlightService {
         tokio::task::spawn_blocking(move || -> Result<DoGetSetup, Status> {
             let producer = svc.build_producer(&ticket)?;
             let schema_ref = Arc::new(producer.arrow_schema()?);
-            let source = DirSource::resolve(
-                &svc.data_dir,
-                &ticket.keyspace,
-                &ticket.table,
-                ticket.snapshot.as_deref(),
-            )?;
+            // Spec Req 8: reuse a cached LIVE-mode resolution on a warm hit instead
+            // of re-running `DirSource::resolve` every request.
+            let dir = svc.resolve_dir(&ticket)?;
 
             // Aggregate route keeps the cold path (bounded per-group output, no
             // per-request reader-open regression): resolve + token-prune paths.
             // A cancellation surfaces as `ProducerError::Cancelled` → `aborted`.
             if producer.is_aggregating() {
+                let source = DirSource::new(dir.clone());
                 let paths = producer.resolve_paths_cancellable(&source, &resolve_cancel)?;
                 return Ok(DoGetSetup {
                     producer,
@@ -556,7 +672,6 @@ impl CqliteFlightService {
             // snapshot manifest fast path) and serves cached readers on an
             // unchanged set (zero reader-open/parse), or fail-closed rebuilds
             // only the delta. Cancellation is honored inside `warm_readers`.
-            let dir = source.into_dir();
             let key = TableKey::new(&ticket.keyspace, &ticket.table);
             let warm = svc
                 .warm
@@ -642,7 +757,7 @@ impl CqliteFlightService {
 mod tests {
     use super::*;
     use crate::testutil::{
-        build_sstables, simple_schema, total_rows, write_row, KS, SIMPLE_DDL, TBL,
+        build_sstables, make_snapshot, simple_schema, total_rows, write_row, KS, SIMPLE_DDL, TBL,
     };
     use arrow::array::Array;
     use arrow::record_batch::RecordBatch;
@@ -672,6 +787,25 @@ mod tests {
         while let Some(batch) = rb.next().await {
             out.push(batch.expect("decode batch"));
         }
+        out
+    }
+
+    /// The `name` column values across all batches, sorted — a stable, order-
+    /// independent value fingerprint for asserting two responses are row-equal.
+    fn sorted_name_values(batches: &[RecordBatch]) -> Vec<String> {
+        let mut out = Vec::new();
+        for b in batches {
+            let names = b
+                .column_by_name("name")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .unwrap();
+            for i in 0..names.len() {
+                out.push(names.value(i).to_string());
+            }
+        }
+        out.sort();
         out
     }
 
@@ -734,25 +868,30 @@ mod tests {
         let svc = CqliteFlightService::new(data_dir, 1024);
         let rt = tokio::runtime::Runtime::new().unwrap();
 
-        let (rows1, rows2, opens_after_first) = rt.block_on(async {
+        let (vals1, vals2, opens_after_first) = rt.block_on(async {
             let bytes = ticket(KS, TBL).to_bytes().unwrap();
             let r1 = svc
                 .do_get(Request::new(Ticket::new(bytes.clone())))
                 .await
                 .expect("first do_get");
-            let rows1 = total_rows(&decode(r1.into_inner()).await);
+            let vals1 = sorted_name_values(&decode(r1.into_inner()).await);
             // Work-done probe checkpoint: opens charged BY the (cold) first request.
             let opens_after_first = svc.warm_metrics().reader_opens;
             let r2 = svc
                 .do_get(Request::new(Ticket::new(bytes)))
                 .await
                 .expect("second do_get");
-            let rows2 = total_rows(&decode(r2.into_inner()).await);
-            (rows1, rows2, opens_after_first)
+            let vals2 = sorted_name_values(&decode(r2.into_inner()).await);
+            (vals1, vals2, opens_after_first)
         });
 
-        assert_eq!(rows1, 2, "two partitions after LWW merge");
-        assert_eq!(rows2, rows1, "warm hit returns byte-identical row count");
+        assert_eq!(vals1.len(), 2, "two partitions after LWW merge");
+        // Value equality (not just row count): the warm hit returns the SAME rows.
+        assert_eq!(
+            vals2, vals1,
+            "warm hit returns value-identical rows, got {vals2:?} vs {vals1:?}"
+        );
+        assert!(vals1.contains(&"new".to_string()), "newer write wins");
 
         let m = svc.warm_metrics();
         assert_eq!(m.misses, 1, "exactly one cold build (first request)");
@@ -774,6 +913,97 @@ mod tests {
         assert_eq!(
             m.reader_opens, opens_after_first,
             "the warm hit performed zero reader-open/parse (spec Requirement 2)"
+        );
+    }
+
+    /// Spec Req 8 elision probe: two IDENTICAL live-mode `do_get`s re-parse the
+    /// schema ZERO times and re-resolve the directory ZERO times on the second
+    /// request. The first request pays exactly one parse + one resolve; the warm
+    /// second request reuses both caches. (The end-to-end latency win these
+    /// counters underwrite is measured downstream by the #2289/#1494 bench
+    /// harness — the counters it needs are exactly `setup_work()` +
+    /// `warm_metrics()`, in place as of this PR.)
+    #[test]
+    fn do_get_warm_hit_elides_schema_parse_and_dir_resolve() {
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) =
+            build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let bytes = ticket(KS, TBL).to_bytes().unwrap();
+        rt.block_on(async {
+            let r1 = svc
+                .do_get(Request::new(Ticket::new(bytes.clone())))
+                .await
+                .expect("first do_get");
+            let _ = decode(r1.into_inner()).await;
+        });
+        let after_first = svc.setup_work();
+        assert_eq!(after_first.schema_parses, 1, "first request parses once");
+        assert_eq!(after_first.resolves, 1, "first request resolves once");
+
+        rt.block_on(async {
+            let r2 = svc
+                .do_get(Request::new(Ticket::new(bytes)))
+                .await
+                .expect("second do_get");
+            let _ = decode(r2.into_inner()).await;
+        });
+        let after_second = svc.setup_work();
+        assert_eq!(
+            after_second.schema_parses, 1,
+            "the warm second request re-parses the schema ZERO times (spec Req 8)"
+        );
+        assert_eq!(
+            after_second.resolves, 1,
+            "the warm second request re-resolves the directory ZERO times (spec Req 8)"
+        );
+    }
+
+    /// Snapshot-mode warm path (spec Requirements 1/2/8): two identical `do_get`s
+    /// against a `snapshots/<name>/` hardlink dir return BYTE-IDENTICAL batches,
+    /// the second a warm hit with zero further reader opens.
+    #[test]
+    fn do_get_snapshot_mode_second_request_is_a_value_identical_warm_hit() {
+        let schema = simple_schema();
+        let (_temp, data_dir, table_dir) = build_sstables(
+            &schema,
+            vec![
+                vec![write_row(1, "old", 1, 100)],
+                vec![write_row(1, "new", 2, 200), write_row(2, "b", 3, 200)],
+            ],
+        );
+        make_snapshot(&table_dir, "snap1");
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let mut t = ticket(KS, TBL);
+        t.snapshot = Some("snap1".into());
+        let bytes = t.to_bytes().unwrap();
+
+        let (vals1, vals2, opens_after_first) = rt.block_on(async {
+            let r1 = svc
+                .do_get(Request::new(Ticket::new(bytes.clone())))
+                .await
+                .expect("first snapshot do_get");
+            let vals1 = sorted_name_values(&decode(r1.into_inner()).await);
+            let opens_after_first = svc.warm_metrics().reader_opens;
+            let r2 = svc
+                .do_get(Request::new(Ticket::new(bytes)))
+                .await
+                .expect("second snapshot do_get");
+            let vals2 = sorted_name_values(&decode(r2.into_inner()).await);
+            (vals1, vals2, opens_after_first)
+        });
+
+        assert_eq!(vals1.len(), 2, "two partitions after LWW merge");
+        assert_eq!(vals2, vals1, "snapshot warm hit is value-identical");
+        let m = svc.warm_metrics();
+        assert_eq!(m.hits, 1, "the second snapshot request is a warm hit");
+        assert_eq!(
+            m.reader_opens, opens_after_first,
+            "the snapshot warm hit opened zero further readers"
         );
     }
 

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -150,28 +150,38 @@ struct DoGetSetup {
     input: DoGetInput,
 }
 
-/// Cross-request setup caches (spec Requirement 8): the schema PARSE and the
-/// directory RESOLVE are the two per-request `do_get`-setup costs that survive a
-/// warm reader-cache hit unless memoized. Both are keyed on authoritative,
-/// pre-validated ticket inputs (the DDL string; the pathsafe-validated
-/// keyspace/table) and shared (`Arc`) across the `Clone`d per-RPC handles.
+/// Cross-request setup caches (spec Requirement 8): the schema PARSE is the one
+/// per-request `do_get`-setup cost that survives a warm reader-cache hit unless
+/// memoized. Keyed on the authoritative, pre-validated DDL string and shared
+/// (`Arc`) across the `Clone`d per-RPC handles.
+///
+/// The directory RESOLVE is deliberately NOT cached (roborev 1639, issue #2310
+/// finding 2 round 3): a naive path-string cache is unsound. A recreated table's
+/// OLD `<table>-<uuid>` dir commonly still exists on disk (Cassandra/the sidecar
+/// doesn't always remove it atomically with the new one landing), so a cheap
+/// `is_dir()` revalidation of a cached entry PASSES on the stale pin while a
+/// newer sibling dir is the authoritative resolution — and a cached base whose
+/// leaf later becomes a symlink swap evades the cold path's resolve-time
+/// containment check entirely. A correct revalidation (list the keyspace dir,
+/// pick the lexicographically-largest match, re-run containment) costs the same
+/// as a fresh resolve, so the cache buys nothing but the unsoundness: `resolve_dir`
+/// below re-resolves authoritatively EVERY request, exactly the pre-PR cold
+/// posture. This is not a Req-8 regression: Req 8's "approximately zero" covers
+/// PARSE work (schema parse, reader open, index/summary/bloom parse) — the
+/// directory resolve is the same cost class (one `read_dir`) as the per-request
+/// authoritative generation-set probe that spec Requirement 2 itself mandates on
+/// every request, so paying it every request was always the design, not a gap.
 #[derive(Default)]
 struct SetupCaches {
     /// Parsed schema per exact DDL string. Keyed on the full DDL (never a hash —
     /// a hash collision would serve the WRONG schema and corrupt decode). Bounded
     /// in practice by the number of distinct table DDLs queried.
     schemas: Mutex<HashMap<String, Arc<TableSchema>>>,
-    /// Resolved LIVE-mode table dir per (keyspace, table). Snapshot mode is NOT
-    /// cached on purpose: the field runs a fresh per-query `snapshots/<uuid>/`
-    /// dir per request, so a snapshot-keyed cache would grow unbounded with ZERO
-    /// hit benefit (the warm reader cache still elides the parse via inode
-    /// identity). Live mode's dir is stable, so caching it elides the resolve on
-    /// every repeat query — the dominant warm-hit case (spec Req 8).
-    live_dirs: Mutex<HashMap<(String, String), PathBuf>>,
     /// Work-done probe: schema PARSES actually performed (a cache hit adds 0).
     schema_parses: AtomicU64,
-    /// Work-done probe: directory RESOLVES actually performed (a live-mode cache
-    /// hit adds 0; a snapshot-mode request always resolves, by design above).
+    /// Work-done probe: directory RESOLVES actually performed. Always increments
+    /// once per request (live or snapshot mode) — the resolve is authoritative
+    /// per-request by design, never elided (see the struct doc above).
     resolves: AtomicU64,
 }
 
@@ -258,59 +268,12 @@ impl CqliteFlightService {
         Ok(schema)
     }
 
-    /// Resolve the SSTable directory for a ticket, reusing a cached LIVE-mode
-    /// resolution on a repeat (keyspace, table) (spec Req 8: directory resolve
-    /// elided on a warm hit). Snapshot mode always resolves fresh (see
-    /// [`SetupCaches::live_dirs`] for why caching it would leak). The
-    /// keyspace/table are pathsafe-validated by `FlightTicket::from_bytes`, so a
-    /// cached entry was validated when first resolved.
-    ///
-    /// The pin is CORRECTNESS-bounded (issue #2310 finding 2): a cached dir is
-    /// served only after a cheap existence re-check, so a dropped/recreated table
-    /// (whose `table-<uuid>` dir was renamed) invalidates the pin and forces a
-    /// fresh resolve — which correctly counts as resolve work; the Req-8 elision
-    /// claim only covers the steady state. And a non-existent resolution (the
-    /// `best.unwrap_or(exact)` fallback for a table with no dir on disk) is NEVER
-    /// cached, so the pin can never fossilize a wrong/absent path.
+    /// Resolve the SSTable directory for a ticket: the authoritative
+    /// `DirSource::resolve` (containment-checked, issue #1430), run EVERY
+    /// request — never cached (roborev 1639, issue #2310 finding 2 round 3; see
+    /// [`SetupCaches`] for why a directory-resolve cache is unsound). This
+    /// mirrors the pre-PR cold posture exactly.
     fn resolve_dir(&self, ticket: &FlightTicket) -> Result<PathBuf, Status> {
-        let snapshot_mode = ticket.snapshot.as_deref().is_some_and(|s| !s.is_empty());
-        if !snapshot_mode {
-            let cache_key = (ticket.keyspace.clone(), ticket.table.clone());
-            {
-                let mut live = self
-                    .caches
-                    .live_dirs
-                    .lock()
-                    .unwrap_or_else(PoisonError::into_inner);
-                if let Some(hit) = live.get(&cache_key) {
-                    // Cheap re-validation: a still-present pinned dir is a warm hit
-                    // (zero resolve work). A missing/renamed one is a STALE pin —
-                    // drop it and fall through to a fresh resolve.
-                    if hit.is_dir() {
-                        return Ok(hit.clone());
-                    }
-                    live.remove(&cache_key);
-                }
-            }
-            let dir = self.resolve_dir_uncached(ticket)?;
-            // Only cache a resolution that actually EXISTS: never pin the
-            // non-existent `best.unwrap_or(exact)` fallback (would serve a wrong /
-            // stale path for the process lifetime).
-            if dir.is_dir() {
-                self.caches
-                    .live_dirs
-                    .lock()
-                    .unwrap_or_else(PoisonError::into_inner)
-                    .entry(cache_key)
-                    .or_insert_with(|| dir.clone());
-            }
-            return Ok(dir);
-        }
-        self.resolve_dir_uncached(ticket)
-    }
-
-    /// The uncached `DirSource::resolve`, incrementing the resolve work probe.
-    fn resolve_dir_uncached(&self, ticket: &FlightTicket) -> Result<PathBuf, Status> {
         let dir = DirSource::resolve(
             &self.data_dir,
             &ticket.keyspace,
@@ -937,15 +900,18 @@ mod tests {
         );
     }
 
-    /// Spec Req 8 elision probe: two IDENTICAL live-mode `do_get`s re-parse the
-    /// schema ZERO times and re-resolve the directory ZERO times on the second
-    /// request. The first request pays exactly one parse + one resolve; the warm
-    /// second request reuses both caches. (The end-to-end latency win these
-    /// counters underwrite is measured downstream by the #2289/#1494 bench
-    /// harness — the counters it needs are exactly `setup_work()` +
-    /// `warm_metrics()`, in place as of this PR.)
+    /// Spec Req 8 elision probe (updated round 3, roborev 1639): two IDENTICAL
+    /// live-mode `do_get`s re-parse the schema ZERO times on the second request —
+    /// PARSE work is what Req 8 covers. The directory RESOLVE is deliberately
+    /// authoritative EVERY request (never elided): it increments on both the
+    /// first AND second request. See [`SetupCaches`] for why caching it is
+    /// unsound (a recreated table's old `<table>-<uuid>` dir commonly still
+    /// exists, so a cheap existence re-check cannot distinguish a stale pin from
+    /// a live one; and a cached base evades resolve-time containment on a
+    /// symlink swap). (The end-to-end latency win the parse-elision counters
+    /// underwrite is measured downstream by the #2289/#1494 bench harness.)
     #[test]
-    fn do_get_warm_hit_elides_schema_parse_and_dir_resolve() {
+    fn do_get_warm_hit_elides_schema_parse_not_dir_resolve() {
         let schema = simple_schema();
         let (_temp, data_dir, _dir) =
             build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
@@ -977,17 +943,22 @@ mod tests {
             "the warm second request re-parses the schema ZERO times (spec Req 8)"
         );
         assert_eq!(
-            after_second.resolves, 1,
-            "the warm second request re-resolves the directory ZERO times (spec Req 8)"
+            after_second.resolves, 2,
+            "the directory resolve is authoritative EVERY request, by design \
+             (roborev 1639) — it must NOT be elided on the warm second request"
         );
     }
 
-    /// Finding 2 (#2310): a live-dir pin must NOT survive a drop + recreate under
-    /// a new `table-<uuid>` name. The first resolve caches `items-aaaa`; after it
-    /// is removed and `items-bbbb` created, the next resolve must reach the NEW
-    /// dir, never the stale pin. Red on pre-fix code (serves the pinned path).
+    /// Finding 2 round 3 (#2310, roborev 1639): `resolve_dir` must be
+    /// authoritative EVERY request, even when a table's OLD `<table>-<uuid>` dir
+    /// is still present on disk (the common case: a recreate does not always
+    /// remove the old dir atomically with the new one landing). Red on the
+    /// round-2 cached code: the first resolve pins `items-aaaaaaaa`; a cheap
+    /// `is_dir()` revalidation of that pin PASSES (the old dir was never
+    /// removed), so the cached code serves the STALE `aaaaaaaa` dir forever
+    /// instead of the lexicographically-larger, authoritative `bbbbbbbb`.
     #[test]
-    fn live_dir_pin_invalidated_on_table_drop_and_recreate() {
+    fn resolve_dir_is_authoritative_every_request_even_when_old_dir_still_exists() {
         let temp = tempfile::TempDir::new().unwrap();
         let data_dir = temp.path().join("data");
         let ks_dir = data_dir.join(KS);
@@ -1004,23 +975,25 @@ mod tests {
         let r1 = svc.resolve_dir(&t).expect("first resolve");
         assert_eq!(r1, first, "first resolve picks the only table-<uuid> dir");
 
-        std::fs::remove_dir_all(&first).unwrap();
+        // The OLD dir is left in place (NOT removed) — the common recreate case
+        // a naive existence-only revalidation cannot distinguish from "still
+        // live". A newer, lexicographically-larger sibling appears alongside it.
         let second = ks_dir.join(format!("{TBL}-bbbbbbbb"));
         std::fs::create_dir_all(&second).unwrap();
 
         let r2 = svc.resolve_dir(&t).expect("second resolve");
         assert_eq!(
             r2, second,
-            "a dropped/recreated table dir must NOT serve the stale pin"
+            "resolve must be authoritative every request — the still-present old \
+             dir must NOT be served over the newer, correct resolution"
         );
     }
 
-    /// Finding 2 (#2310): a NON-EXISTENT resolution (the `best.unwrap_or(exact)`
-    /// fallback for a table with no dir yet) must never be cached — otherwise the
-    /// wrong/absent path fossilizes for the process lifetime. After the table dir
-    /// later appears under a `table-<uuid>` name, the next resolve must reach it.
+    /// Sanity: a table with no dir on disk yet, resolved once, then created —
+    /// the next resolve must reach the real dir (basic cold-resolve behavior,
+    /// no caching involved after roborev 1639's removal of the live-dir cache).
     #[test]
-    fn resolve_never_caches_a_nonexistent_dir() {
+    fn resolve_reaches_newly_created_table_dir_after_being_absent() {
         let temp = tempfile::TempDir::new().unwrap();
         let data_dir = temp.path().join("data");
         let ks_dir = data_dir.join(KS);
@@ -1036,15 +1009,11 @@ mod tests {
         let r1 = svc.resolve_dir(&t).expect("first resolve");
         assert!(!r1.is_dir(), "no table dir on disk yet, got {r1:?}");
 
-        // The table now lands under a uuid-suffixed dir.
         let real = ks_dir.join(format!("{TBL}-cccccccc"));
         std::fs::create_dir_all(&real).unwrap();
 
         let r2 = svc.resolve_dir(&t).expect("second resolve");
-        assert_eq!(
-            r2, real,
-            "a non-existent first resolution must not be cached over the real dir"
-        );
+        assert_eq!(r2, real, "the second resolve must reach the now-real dir");
     }
 
     /// Snapshot-mode warm path (spec Requirements 1/2/8): two identical `do_get`s

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -30,12 +30,15 @@ use tonic::{Request, Response, Status, Streaming};
 use cqlite_core::schema::{parse_cql_schema, TableSchema};
 use tracing::Instrument;
 
+use cqlite_core::storage::sstable::reader::SSTableReader;
+
 use crate::cancel::CancelFlag;
 use crate::filter::{FilterError, ScanSpec};
 use crate::obs::{rpc_span, RpcMetrics};
 use crate::producer::{DirSource, MergeProducer, ProducerError};
 use crate::stats::{gather_table_stats, StatsError, TableStatsRequest, TABLE_STATS_ACTION};
 use crate::ticket::{FlightTicket, TicketError};
+use crate::warm::{ddl_hash, TableKey, WarmError, WarmMetricsSnapshot, WarmTableRegistry};
 
 /// Boxed server response stream alias.
 type BoxStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send + 'static>>;
@@ -79,6 +82,24 @@ impl From<ProducerError> for Status {
     }
 }
 
+/// Map a warm-handle failure (issue #2310) to a gRPC status, mirroring the
+/// producer error mapping: a cancellation is a clean `aborted`; a probe that
+/// hit a missing directory is `not_found` (the same class as a missing table on
+/// the cold path); an open/parse failure during a fail-closed rebuild (e.g. a
+/// corrupt `Statistics.db`, #1626) or a runtime failure is an `internal` fault.
+fn warm_error_to_status(e: WarmError) -> Status {
+    let msg = e.to_string();
+    match e {
+        WarmError::Cancelled => Status::aborted(msg),
+        WarmError::Probe { source, .. } if source.kind() == std::io::ErrorKind::NotFound => {
+            Status::not_found(msg)
+        }
+        WarmError::Probe { .. } | WarmError::Open { .. } | WarmError::Runtime(_) => {
+            Status::internal(msg)
+        }
+    }
+}
+
 /// Bad filter input (unknown column, type mismatch, malformed operand) is a
 /// client error.
 impl From<FilterError> for Status {
@@ -105,15 +126,25 @@ impl From<StatsError> for Status {
     }
 }
 
+/// The merge input the eager setup resolved for a `do_get`: the WARM,
+/// already-open reader set for the common row path (issue #2310), or the cold
+/// token-pruned paths for the aggregate route (which still opens fresh readers —
+/// no regression, and a bounded per-group output).
+enum DoGetInput {
+    /// Aggregate route: cold token-pruned `Data.db` paths.
+    Aggregate(Vec<PathBuf>),
+    /// Row/point route: a warm reader set from the [`WarmTableRegistry`].
+    Rows(Vec<Arc<SSTableReader>>),
+}
+
 /// Resolved, ready-to-serve `do_get` inputs produced by the eager setup step
-/// (issue #1476): the built producer, its Arrow schema, the token-pruned SSTable
-/// paths, and whether the ticket aggregates. Kept together so the row and
+/// (issue #1476): the built producer, its Arrow schema, and the merge input
+/// (warm readers or cold aggregate paths). Kept together so the row and
 /// aggregate response builders share one setup path.
 struct DoGetSetup {
     producer: MergeProducer,
     schema_ref: Arc<ArrowSchema>,
-    paths: Vec<PathBuf>,
-    aggregating: bool,
+    input: DoGetInput,
 }
 
 /// Flight service over a node-local SSTable data directory.
@@ -123,6 +154,10 @@ pub struct CqliteFlightService {
     data_dir: PathBuf,
     /// Max rows per emitted Arrow record batch.
     batch_size: usize,
+    /// Cross-request warm parse cache (issue #2310): generation-keyed open
+    /// readers so a repeated query on unchanged data pays ~0 reader-open/parse.
+    /// Shared (`Arc`) across the `Clone`d per-RPC service handles.
+    warm: Arc<WarmTableRegistry>,
 }
 
 impl CqliteFlightService {
@@ -131,7 +166,15 @@ impl CqliteFlightService {
         Self {
             data_dir: data_dir.into(),
             batch_size: batch_size.max(1),
+            warm: Arc::new(WarmTableRegistry::new()),
         }
+    }
+
+    /// A point-in-time read of the warm-cache counters (hit/miss/evict/
+    /// refresh-outcome + the reader-open work probe) for the #2289/#1494 bench
+    /// harness and end-to-end warm-behavior tests (issue #2310).
+    pub fn warm_metrics(&self) -> WarmMetricsSnapshot {
+        self.warm.metrics().snapshot()
     }
 
     /// Parse the table schema from the ticket's CQL DDL.
@@ -427,37 +470,38 @@ impl CqliteFlightService {
         let DoGetSetup {
             producer,
             schema_ref,
-            paths,
-            aggregating,
+            input,
         } = setup;
 
-        if aggregating {
+        match input {
             // Aggregate output is bounded (one row per group): keep materializing
             // and serve it as a stream, unchanged in content (issue #1476).
-            return Ok(Response::new(
+            DoGetInput::Aggregate(paths) => Ok(Response::new(
                 crate::streaming::build_aggregate_response(
                     producer, paths, schema_ref, metrics, cancel, timer,
                 )
                 .await?,
-            ));
+            )),
+            // Row/point path (issue #2310): drive the merge over the WARM,
+            // already-open reader set. The merge runs on the blocking pool and
+            // sends each batch into a bounded channel; peak resident payload is
+            // O(channel capacity · batch_size), not O(result). The merge task
+            // handle is detached (a dropped response stream cancels the merge
+            // cooperatively).
+            DoGetInput::Rows(readers) => {
+                let (stream, _merge_handle) = crate::streaming::spawn_streaming_from_readers(
+                    producer,
+                    readers,
+                    schema_ref,
+                    metrics,
+                    crate::streaming::DO_GET_CHANNEL_CAPACITY,
+                    crate::streaming::StreamProbe::default(),
+                    cancel,
+                    timer,
+                );
+                Ok(Response::new(stream))
+            }
         }
-
-        // Row path: the merge runs on the blocking pool and sends each batch into a
-        // bounded channel; the response wraps the receiver. Peak resident payload
-        // is O(channel capacity · batch_size), not O(result). The merge task handle
-        // is detached (dropping it does not cancel `spawn_blocking`; a dropped
-        // response stream cancels the merge cooperatively).
-        let (stream, _merge_handle) = crate::streaming::spawn_streaming(
-            producer,
-            paths,
-            schema_ref,
-            metrics,
-            crate::streaming::DO_GET_CHANNEL_CAPACITY,
-            crate::streaming::StreamProbe::default(),
-            cancel,
-            timer,
-        );
-        Ok(Response::new(stream))
     }
 
     /// Eager, fallible `do_get` setup shared by the row and aggregate paths: parse
@@ -494,17 +538,41 @@ impl CqliteFlightService {
                 &ticket.table,
                 ticket.snapshot.as_deref(),
             )?;
-            let aggregating = producer.is_aggregating();
-            // A cancellation here surfaces as `ProducerError::Cancelled`, mapped
-            // by `From<ProducerError> for Status` to `Status::aborted` — the same
-            // clean, expected-abort class as a merge-stage cancellation.
-            let paths = producer.resolve_paths_cancellable(&source, &resolve_cancel)?;
 
+            // Aggregate route keeps the cold path (bounded per-group output, no
+            // per-request reader-open regression): resolve + token-prune paths.
+            // A cancellation surfaces as `ProducerError::Cancelled` → `aborted`.
+            if producer.is_aggregating() {
+                let paths = producer.resolve_paths_cancellable(&source, &resolve_cancel)?;
+                return Ok(DoGetSetup {
+                    producer,
+                    schema_ref,
+                    input: DoGetInput::Aggregate(paths),
+                });
+            }
+
+            // Row/point route (issue #2310): obtain the WARM reader set. The
+            // registry probes the generation set (authoritative listing /
+            // snapshot manifest fast path) and serves cached readers on an
+            // unchanged set (zero reader-open/parse), or fail-closed rebuilds
+            // only the delta. Cancellation is honored inside `warm_readers`.
+            let dir = source.into_dir();
+            let key = TableKey::new(&ticket.keyspace, &ticket.table);
+            let warm = svc
+                .warm
+                .warm_readers(
+                    &key,
+                    ddl_hash(&ticket.ddl),
+                    &producer.schema,
+                    &dir,
+                    ticket.snapshot.as_deref(),
+                    &resolve_cancel,
+                )
+                .map_err(warm_error_to_status)?;
             Ok(DoGetSetup {
                 producer,
                 schema_ref,
-                paths,
-                aggregating,
+                input: DoGetInput::Rows(warm.readers),
             })
         })
         .await
@@ -643,6 +711,168 @@ mod tests {
         let values: Vec<&str> = (0..names.len()).map(|i| names.value(i)).collect();
         assert!(values.contains(&"new"), "newer write wins, got {values:?}");
         assert!(!values.contains(&"old"));
+    }
+
+    // ---- Issue #2310: warm-handle wiring evidence through the do_get surface ----
+
+    /// THE wiring-evidence test (spec Requirements 1/2/6/8): two `do_get`s for the
+    /// same table over an unchanged generation set. The FIRST warms the cache
+    /// (miss + reader opens); the SECOND is a warm HIT that performs ZERO further
+    /// reader-open/parse (the work-done probe), and returns byte-identical rows.
+    /// Drives the real public `FlightService::do_get` surface end to end. Fails on
+    /// pre-#2310 `main` (no warm state → every request re-opens readers).
+    #[test]
+    fn do_get_second_request_is_a_warm_hit_with_zero_reader_opens() {
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) = build_sstables(
+            &schema,
+            vec![
+                vec![write_row(1, "old", 1, 100)],
+                vec![write_row(1, "new", 2, 200), write_row(2, "b", 3, 200)],
+            ],
+        );
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let (rows1, rows2, opens_after_first) = rt.block_on(async {
+            let bytes = ticket(KS, TBL).to_bytes().unwrap();
+            let r1 = svc
+                .do_get(Request::new(Ticket::new(bytes.clone())))
+                .await
+                .expect("first do_get");
+            let rows1 = total_rows(&decode(r1.into_inner()).await);
+            // Work-done probe checkpoint: opens charged BY the (cold) first request.
+            let opens_after_first = svc.warm_metrics().reader_opens;
+            let r2 = svc
+                .do_get(Request::new(Ticket::new(bytes)))
+                .await
+                .expect("second do_get");
+            let rows2 = total_rows(&decode(r2.into_inner()).await);
+            (rows1, rows2, opens_after_first)
+        });
+
+        assert_eq!(rows1, 2, "two partitions after LWW merge");
+        assert_eq!(rows2, rows1, "warm hit returns byte-identical row count");
+
+        let m = svc.warm_metrics();
+        assert_eq!(m.misses, 1, "exactly one cold build (first request)");
+        assert_eq!(m.hits, 1, "exactly one warm hit (second request)");
+        assert_eq!(
+            m.refresh_rebuilt_delta, 1,
+            "the first request recorded a delta rebuild"
+        );
+        assert_eq!(
+            m.refresh_unchanged, 1,
+            "the second request recorded an unchanged refresh"
+        );
+        assert!(
+            opens_after_first >= 2,
+            "the first request opened both generations' readers, got {opens_after_first}"
+        );
+        // THE work-done probe: the warm hit opened ZERO further readers — the
+        // cumulative open count is UNCHANGED across the second request.
+        assert_eq!(
+            m.reader_opens, opens_after_first,
+            "the warm hit performed zero reader-open/parse (spec Requirement 2)"
+        );
+    }
+
+    /// A flush that ADDS a generation between requests is visible on the next
+    /// request with zero staleness window (spec Requirement 2): the probe reports
+    /// "changed", the rebuild adds exactly the new generation, and the new data
+    /// appears. Records a second miss + rebuilt-delta.
+    #[test]
+    fn do_get_sees_a_newly_added_generation_on_next_request() {
+        let schema = simple_schema();
+        let (_temp, data_dir, table_dir) =
+            build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let bytes = ticket(KS, TBL).to_bytes().unwrap();
+        // Warm the cache.
+        let n1 = rt.block_on(async {
+            let r1 = svc
+                .do_get(Request::new(Ticket::new(bytes.clone())))
+                .await
+                .expect("first do_get");
+            total_rows(&decode(r1.into_inner()).await)
+        });
+        assert_eq!(n1, 1);
+
+        // Simulate a flush OUTSIDE the runtime (append_sstable drives its own):
+        // drop a second SSTable (a new generation) into the live table dir.
+        append_sstable(&table_dir, &schema, vec![write_row(2, "b", 4, 200)]);
+
+        let rows = rt.block_on(async {
+            let r2 = svc
+                .do_get(Request::new(Ticket::new(bytes)))
+                .await
+                .expect("second do_get");
+            total_rows(&decode(r2.into_inner()).await)
+        });
+
+        assert_eq!(
+            rows, 2,
+            "the newly-flushed generation is visible immediately"
+        );
+        let m = svc.warm_metrics();
+        assert_eq!(m.misses, 2, "the added generation forced a rebuild");
+        assert_eq!(
+            m.refresh_rebuilt_delta, 2,
+            "both requests recorded delta rebuilds (second added the new gen)"
+        );
+    }
+
+    /// A pre-cancelled `do_get` performs zero warm-path work and surfaces the
+    /// distinct `Aborted` status (spec Requirement 7), never a stale hit.
+    #[test]
+    fn do_get_setup_pre_cancelled_does_zero_warm_work() {
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) =
+            build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let err = rt.block_on(async {
+            let cancel = CancelFlag::new();
+            cancel.cancel();
+            let bytes = ticket(KS, TBL).to_bytes().unwrap();
+            match svc
+                .do_get_setup(Request::new(Ticket::new(bytes)), &cancel)
+                .await
+            {
+                Ok(_) => panic!("a pre-cancelled setup must abort, not resolve"),
+                Err(e) => e,
+            }
+        });
+        assert_eq!(err.code(), tonic::Code::Aborted, "got: {err:?}");
+        let m = svc.warm_metrics();
+        assert_eq!(m.reader_opens, 0, "a cancelled request opens zero readers");
+        assert_eq!(m.misses, 0, "and does no build");
+    }
+
+    /// Append one more SSTable generation into an existing live table dir by
+    /// running a fresh write-engine flush pointed at the SAME data root.
+    fn append_sstable(
+        table_dir: &std::path::Path,
+        schema: &cqlite_core::schema::TableSchema,
+        rows: Vec<cqlite_core::storage::write_engine::Mutation>,
+    ) {
+        use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+        // table_dir = <data>/<ks>/<table>; recover the data root.
+        let data_dir = table_dir.parent().unwrap().parent().unwrap().to_path_buf();
+        let wal = table_dir.join(".wal_append");
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let config = WriteEngineConfig::new(data_dir, wal, schema.clone());
+        let mut engine = WriteEngine::new(config).expect("engine");
+        for m in rows {
+            engine.write(m).expect("write");
+        }
+        rt.block_on(engine.flush()).expect("flush").expect("info");
     }
 
     #[tokio::test]
@@ -793,11 +1023,19 @@ mod tests {
                 .await
         });
         let setup = setup.expect("uncancelled setup resolves");
-        assert_eq!(
-            setup.paths.len(),
-            2,
-            "a full-ring token filter keeps both SSTables"
-        );
+        // The warm path (issue #2310) hands over the open reader set; a full-ring
+        // token filter keeps both generations (per-reader token prune happens in
+        // the merge stage, not here).
+        match setup.input {
+            DoGetInput::Rows(readers) => assert_eq!(
+                readers.len(),
+                2,
+                "a full-ring token filter keeps both SSTables' warm readers"
+            ),
+            DoGetInput::Aggregate(_) => {
+                panic!("non-aggregating ticket must take the warm row path")
+            }
+        }
     }
 
     // ---- Issue #1430: end-to-end path-traversal rejection (wiring evidence) ----

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -28,9 +28,28 @@ use tokio::sync::mpsc;
 use tonic::Status;
 use tracing::Span;
 
+use cqlite_core::storage::sstable::reader::SSTableReader;
+
 use crate::cancel::{CancelFlag, CancelGuard};
 use crate::obs::RpcMetrics;
 use crate::producer::{BatchSink, MergeProducer, ProducerError};
+
+/// The merge input for the streaming row path (issue #2310): either the cold
+/// per-request `Data.db` paths (opened fresh) or a WARM set of already-open,
+/// shared `Arc<SSTableReader>`s handed over by the warm-handle registry. The two
+/// drive byte-identical merges — only WHO opened the reader differs — so the
+/// single `spawn_streaming` egress serves both.
+pub(crate) enum MergeInput {
+    /// Cold path: open a fresh reader per path. Production row reads now take the
+    /// warm [`Self::Readers`] path (issue #2310), so this variant is retained as
+    /// the byte-identity regression oracle exercised by the streaming test suite
+    /// (`streaming_tests.rs`) — it proves the shared bounded-channel egress +
+    /// cancellation machinery still behaves identically for a cold input.
+    #[cfg_attr(not(test), allow(dead_code))]
+    Paths(Vec<PathBuf>),
+    /// Warm path: drive the merge over cached, shared readers.
+    Readers(Vec<Arc<SSTableReader>>),
+}
 
 /// Boxed server response stream (matches `service::BoxStream<FlightData>`).
 pub(crate) type DoGetStream =
@@ -232,9 +251,44 @@ fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
 /// caller's setup-phase guard is expected to already be disarmed by the time
 /// this runs, so the fresh guard armed here is the only one live from this
 /// point on.
+/// Warm analogue of [`spawn_streaming`] (issue #2310): drive the streaming
+/// row-merge over an already-open, shared warm reader set from the
+/// [`crate::warm::WarmTableRegistry`] instead of cold per-request paths. A thin
+/// wrapper that hands [`spawn_streaming`] a [`MergeInput::Readers`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_streaming_from_readers(
+    producer: MergeProducer,
+    readers: Vec<Arc<SSTableReader>>,
+    schema_ref: Arc<ArrowSchema>,
+    metrics: RpcMetrics,
+    capacity: usize,
+    probe: StreamProbe,
+    cancel: CancelFlag,
+    timer: crate::obs::PhaseTimer,
+) -> (DoGetStream, tokio::task::JoinHandle<()>) {
+    spawn_streaming(
+        producer,
+        MergeInput::Readers(readers),
+        schema_ref,
+        metrics,
+        capacity,
+        probe,
+        cancel,
+        timer,
+    )
+}
+
+/// Shared egress for the cold ([`MergeInput::Paths`]) and warm
+/// ([`MergeInput::Readers`]) streaming row paths (issue #2310). The two drive
+/// byte-identical merges; only the single merge-driving call inside the blocking
+/// closure branches on the input shape. `paths`-shaped inputs MUST already be
+/// token-pruned (as [`MergeProducer::resolve_paths`] returns); `readers`-shaped
+/// inputs are the warm registry's pre-parsed set. `cancel` is the SAME flag
+/// threaded through the caller's eager-setup phase (issue #1476, roborev F1).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_streaming(
     producer: MergeProducer,
-    paths: Vec<PathBuf>,
+    input: MergeInput,
     schema_ref: Arc<ArrowSchema>,
     metrics: RpcMetrics,
     capacity: usize,
@@ -276,9 +330,25 @@ pub(crate) fn spawn_streaming(
             // phase (or `merge_setup` if the merger build itself failed / there was
             // nothing to merge). Issue #2162.
             let mut timer = timer;
-            producer.produce_streaming(paths, &merge_cancel, &mut sink, &scan_progress, || {
+            let on_built = || {
                 timer.transition(crate::obs::PHASE_STREAM);
-            })
+            };
+            match input {
+                MergeInput::Paths(paths) => producer.produce_streaming(
+                    paths,
+                    &merge_cancel,
+                    &mut sink,
+                    &scan_progress,
+                    on_built,
+                ),
+                MergeInput::Readers(readers) => producer.produce_streaming_from_readers(
+                    readers,
+                    &merge_cancel,
+                    &mut sink,
+                    &scan_progress,
+                    on_built,
+                ),
+            }
         });
     });
 

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -75,7 +75,7 @@ fn first_batch_available_before_merge_completes() {
         let pr = probe();
         let (mut stream, handle) = spawn_streaming(
             producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -124,7 +124,7 @@ fn slow_consumer_bounds_produced_batches() {
         let pr = probe();
         let (mut stream, handle) = spawn_streaming(
             producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -169,7 +169,7 @@ fn dropping_stream_cancels_merge() {
         let pr = probe();
         let (mut stream, handle) = spawn_streaming(
             producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -532,7 +532,7 @@ fn metrics_parity_on_full_consumption() {
     rt.block_on(async move {
         let (stream, handle) = spawn_streaming(
             stream_producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -590,7 +590,7 @@ fn rpc_progress_moves_before_stream_completes() {
     rt.block_on(async move {
         let (mut stream, handle) = spawn_streaming(
             producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -648,7 +648,7 @@ fn per_batch_deltas_sum_to_unchanged_total() {
     rt.block_on(async move {
         let (stream, handle) = spawn_streaming(
             stream_producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -718,7 +718,7 @@ fn rows_scanned_flushes_incrementally_over_threshold() {
     rt.block_on(async move {
         let (stream, handle) = spawn_streaming(
             stream_producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -765,7 +765,7 @@ fn rows_scanned_sub_threshold_flushes_once() {
     rt.block_on(async move {
         let (stream, handle) = spawn_streaming(
             stream_producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -814,7 +814,7 @@ fn rows_scanned_flushes_remainder_on_limit_break() {
     rt.block_on(async move {
         let (stream, handle) = spawn_streaming(
             stream_producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
@@ -1005,7 +1005,7 @@ fn metrics_attribute_emitted_prefix_on_cancel() {
     rt.block_on(async move {
         let (mut stream, handle) = spawn_streaming(
             producer,
-            paths,
+            MergeInput::Paths(paths),
             schema_ref,
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,

--- a/cqlite-flight/src/warm/budget.rs
+++ b/cqlite-flight/src/warm/budget.rs
@@ -25,11 +25,21 @@ const PER_GENERATION_OVERHEAD_BYTES: u64 = 64 * 1024;
 /// Explicitly account the parsed-state footprint of the generation backing
 /// `data_path`.
 ///
-/// The warm reader keeps the generation's Index/Summary/Statistics/bloom state
-/// resident; those parsed structures derive directly from the sibling component
-/// files, so the sum of their on-disk sizes is an EXPLICIT, auditable accounting
-/// of the resident footprint (never a heuristic guess). Computed by `stat` only
-/// (no extra parse) at open time. Missing components contribute 0. A fixed
+/// The warm reader keeps resident, format-specific state per generation:
+/// * **BIG** (`na`/`nb`) — Index/Summary/Statistics/bloom-filter.
+/// * **BTI** (`oa`/`da`) — `SSTableReader::open` loads its `Partitions.db` +
+///   `Rows.db` tries FULLY into memory (issue #831/#909, the BTI point-lookup
+///   structures) INSTEAD of Index.db/Summary.db, plus the same
+///   Statistics/bloom-filter sidecars.
+///
+/// Those parsed structures derive directly from the sibling component files,
+/// so the sum of their on-disk sizes is an EXPLICIT, auditable accounting of
+/// the resident footprint (never a heuristic guess). Rather than branching on
+/// a detected format, this simply checks the UNION of both formats' sidecar
+/// suffixes and sums whichever ones actually exist on disk (`std::fs::metadata`
+/// naturally returns 0 contribution for the ones the OTHER format doesn't
+/// have) — honest for both formats without needing a separate version-gate
+/// parse. Computed by `stat` only (no extra parse) at open time. A fixed
 /// overhead covers the parsed-schema handle and registry bookkeeping.
 pub fn account_footprint(data_path: &Path) -> u64 {
     let name = match data_path.file_name().and_then(|n| n.to_str()) {
@@ -39,7 +49,19 @@ pub fn account_footprint(data_path: &Path) -> u64 {
         _ => return PER_GENERATION_OVERHEAD_BYTES,
     };
     let mut total = PER_GENERATION_OVERHEAD_BYTES;
-    for component in ["-Index.db", "-Summary.db", "-Statistics.db", "-Filter.db"] {
+    for component in [
+        // BIG (na/nb) resident sidecars.
+        "-Index.db",
+        "-Summary.db",
+        // BTI (oa/da) resident sidecars (issue #2310 roborev 1640): BTI has no
+        // Index.db/Summary.db, so these contribute 0 for a BIG generation and
+        // vice versa — the union honestly covers both formats.
+        "-Partitions.db",
+        "-Rows.db",
+        // Shared by both formats.
+        "-Statistics.db",
+        "-Filter.db",
+    ] {
         let sibling = data_path.with_file_name(name.replace("-Data.db", component));
         if let Ok(md) = std::fs::metadata(&sibling) {
             total = total.saturating_add(md.len());
@@ -70,6 +92,29 @@ mod tests {
         // Statistics.db / Filter.db absent → contribute 0.
         let footprint = account_footprint(&data);
         assert_eq!(footprint, PER_GENERATION_OVERHEAD_BYTES + 150);
+    }
+
+    #[test]
+    fn footprint_includes_bti_partitions_and_rows_sidecars() {
+        // Finding 2 (#2310, roborev 1640): a BTI (da) generation's accounted
+        // footprint must include Partitions.db + Rows.db — the tries
+        // `SSTableReader::open` loads FULLY into memory for BTI, replacing
+        // Index.db/Summary.db (issue #831/#909). Red on the pre-fix BIG-only
+        // component list: the two BTI sidecars are silently uncounted, so a
+        // BTI table's LRU budget cap is defeated by an undercount.
+        let dir = tempfile::TempDir::new().unwrap();
+        let data = dir.path().join("da-1-bti-Data.db");
+        std::fs::write(&data, b"data").unwrap();
+        std::fs::write(dir.path().join("da-1-bti-Partitions.db"), vec![0u8; 200]).unwrap();
+        std::fs::write(dir.path().join("da-1-bti-Rows.db"), vec![0u8; 75]).unwrap();
+        // Statistics.db / Filter.db absent → contribute 0. No Index.db/Summary.db
+        // for BTI (by design, so they must NOT spuriously contribute either).
+        let footprint = account_footprint(&data);
+        assert_eq!(
+            footprint,
+            PER_GENERATION_OVERHEAD_BYTES + 275,
+            "BTI Partitions.db + Rows.db must be accounted, not silently dropped"
+        );
     }
 
     #[test]

--- a/cqlite-flight/src/warm/budget.rs
+++ b/cqlite-flight/src/warm/budget.rs
@@ -1,0 +1,82 @@
+//! Memory budget + LRU eviction accounting (issue #2310, WS4 #2343).
+//!
+//! Decision 4 (design.md) + spec Requirement 5: warm state is bounded by an
+//! explicit byte budget inside the <128MB discipline, accounting the parsed-state
+//! footprint (per-generation Index/Summary/Statistics/bloom) EXPLICITLY — not by
+//! proxy — and evicting least-recently-used (table, generation) entries when the
+//! budget would be exceeded. A generation removed on disk is evicted immediately
+//! regardless of LRU age (handled in the registry rebuild).
+
+use std::path::Path;
+
+/// The FIXED named warm-state byte budget (Decision 4 / design open-question 2:
+/// a fixed named default this epic, NO new user knob/env/ticket field). Sits well
+/// inside the project-wide <128MB memory discipline while leaving ample headroom
+/// for the merge pipeline's own working set (channels, batches, producer
+/// threads). Not configurable by design — revisit only if the field needs it.
+pub const DEFAULT_WARM_BUDGET_BYTES: u64 = 64 * 1024 * 1024;
+
+/// A small fixed per-generation bookkeeping overhead added to the accounted
+/// component footprint (parsed schema handle, reader struct, per-generation
+/// registry bookkeeping). Keeps the accounting from under-counting tiny SSTables
+/// to ~0 and pinning an unbounded COUNT of them.
+const PER_GENERATION_OVERHEAD_BYTES: u64 = 64 * 1024;
+
+/// Explicitly account the parsed-state footprint of the generation backing
+/// `data_path`.
+///
+/// The warm reader keeps the generation's Index/Summary/Statistics/bloom state
+/// resident; those parsed structures derive directly from the sibling component
+/// files, so the sum of their on-disk sizes is an EXPLICIT, auditable accounting
+/// of the resident footprint (never a heuristic guess). Computed by `stat` only
+/// (no extra parse) at open time. Missing components contribute 0. A fixed
+/// overhead covers the parsed-schema handle and registry bookkeeping.
+pub fn account_footprint(data_path: &Path) -> u64 {
+    let name = match data_path.file_name().and_then(|n| n.to_str()) {
+        Some(n) if n.ends_with("-Data.db") => n,
+        // A path that is not a `-Data.db` (should not happen) accounts as the
+        // fixed overhead alone rather than fabricating a size.
+        _ => return PER_GENERATION_OVERHEAD_BYTES,
+    };
+    let mut total = PER_GENERATION_OVERHEAD_BYTES;
+    for component in ["-Index.db", "-Summary.db", "-Statistics.db", "-Filter.db"] {
+        let sibling = data_path.with_file_name(name.replace("-Data.db", component));
+        if let Ok(md) = std::fs::metadata(&sibling) {
+            total = total.saturating_add(md.len());
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_is_inside_the_128mb_discipline() {
+        assert!(
+            DEFAULT_WARM_BUDGET_BYTES < 128 * 1024 * 1024,
+            "warm budget must sit inside the <128MB discipline"
+        );
+    }
+
+    #[test]
+    fn footprint_sums_present_components_plus_overhead() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let data = dir.path().join("nb-1-big-Data.db");
+        std::fs::write(&data, b"data").unwrap();
+        std::fs::write(dir.path().join("nb-1-big-Index.db"), vec![0u8; 100]).unwrap();
+        std::fs::write(dir.path().join("nb-1-big-Summary.db"), vec![0u8; 50]).unwrap();
+        // Statistics.db / Filter.db absent → contribute 0.
+        let footprint = account_footprint(&data);
+        assert_eq!(footprint, PER_GENERATION_OVERHEAD_BYTES + 150);
+    }
+
+    #[test]
+    fn non_data_path_accounts_overhead_only() {
+        assert_eq!(
+            account_footprint(Path::new("/tmp/not-an-sstable.txt")),
+            PER_GENERATION_OVERHEAD_BYTES
+        );
+    }
+}

--- a/cqlite-flight/src/warm/budget.rs
+++ b/cqlite-flight/src/warm/budget.rs
@@ -1,11 +1,19 @@
 //! Memory budget + LRU eviction accounting (issue #2310, WS4 #2343).
 //!
 //! Decision 4 (design.md) + spec Requirement 5: warm state is bounded by an
-//! explicit byte budget inside the <128MB discipline, accounting the parsed-state
-//! footprint (per-generation Index/Summary/Statistics/bloom) EXPLICITLY — not by
-//! proxy — and evicting least-recently-used (table, generation) entries when the
-//! budget would be exceeded. A generation removed on disk is evicted immediately
+//! explicit byte budget inside the <128MB discipline, accounting the
+//! per-generation parsed-state footprint EXPLICITLY — not by proxy — and
+//! evicting least-recently-used (table, generation) entries when the budget
+//! would be exceeded. A generation removed on disk is evicted immediately
 //! regardless of LRU age (handled in the registry rebuild).
+//!
+//! [`account_footprint`] is EXHAUSTIVE BY CONSTRUCTION (issue #2310, roborev
+//! 1641): every sibling component sharing the generation's filename prefix is
+//! summed, with the single documented exception of `Data.db` (paged, not
+//! parsed-resident) — see its doc for the full rationale. This covers BIG,
+//! BTI, compressed, and uncompressed generations without a hardcoded
+//! per-component suffix list to keep extending every time a new component
+//! (Partitions/Rows, CRC, CompressionInfo, ...) turns out to matter.
 
 use std::path::Path;
 
@@ -25,22 +33,30 @@ const PER_GENERATION_OVERHEAD_BYTES: u64 = 64 * 1024;
 /// Explicitly account the parsed-state footprint of the generation backing
 /// `data_path`.
 ///
-/// The warm reader keeps resident, format-specific state per generation:
-/// * **BIG** (`na`/`nb`) — Index/Summary/Statistics/bloom-filter.
-/// * **BTI** (`oa`/`da`) — `SSTableReader::open` loads its `Partitions.db` +
-///   `Rows.db` tries FULLY into memory (issue #831/#909, the BTI point-lookup
-///   structures) INSTEAD of Index.db/Summary.db, plus the same
-///   Statistics/bloom-filter sidecars.
+/// EXHAUSTIVE BY CONSTRUCTION (issue #2310, roborev 1641 — ends the
+/// hardcoded-suffix-list churn for good): rather than enumerating named
+/// sidecars (Index/Summary/Statistics/Filter/Partitions/Rows/CRC/
+/// CompressionInfo/...), this sums the on-disk size of EVERY file in the
+/// generation's directory that shares its filename PREFIX — i.e. every
+/// sibling component — with exactly ONE exclusion: `Data.db` itself.
 ///
-/// Those parsed structures derive directly from the sibling component files,
-/// so the sum of their on-disk sizes is an EXPLICIT, auditable accounting of
-/// the resident footprint (never a heuristic guess). Rather than branching on
-/// a detected format, this simply checks the UNION of both formats' sidecar
-/// suffixes and sums whichever ones actually exist on disk (`std::fs::metadata`
-/// naturally returns 0 contribution for the ones the OTHER format doesn't
-/// have) — honest for both formats without needing a separate version-gate
-/// parse. Computed by `stat` only (no extra parse) at open time. A fixed
-/// overhead covers the parsed-schema handle and registry bookkeeping.
+/// Why exclude only `Data.db`: it is the one component the reader does NOT
+/// keep fully parsed/resident — it is PAGED (mmap'd or positionally read), so
+/// its size does not reflect memory pressure the way a fully-loaded sidecar's
+/// does. Every OTHER component that exists for a generation — whichever
+/// format, whichever compression setting — genuinely gets `stat`ed and (for
+/// the ones the reader actually loads: Index/Summary/Statistics/bloom for
+/// BIG; Partitions/Rows tries for BTI, issue #831/#909) parsed/held resident,
+/// or is at minimum a small, format-agnostic sidecar (CRC.db, which can
+/// DOMINATE on an uncompressed BIG table; CompressionInfo.db; Digest;
+/// TOC.txt) whose bytes are cheap to include and NEVER wrong to over-count
+/// slightly (the byte budget is meant to be a defensible upper bound, not a
+/// razor-thin one). This is honest for BIG, BTI, compressed, and
+/// uncompressed generations alike, and needs no future round when a new
+/// component is added — it is accounted automatically by construction.
+///
+/// Computed by `read_dir` + `stat` only (no extra parse) at open time. A
+/// fixed overhead covers the parsed-schema handle and registry bookkeeping.
 pub fn account_footprint(data_path: &Path) -> u64 {
     let name = match data_path.file_name().and_then(|n| n.to_str()) {
         Some(n) if n.ends_with("-Data.db") => n,
@@ -48,22 +64,33 @@ pub fn account_footprint(data_path: &Path) -> u64 {
         // fixed overhead alone rather than fabricating a size.
         _ => return PER_GENERATION_OVERHEAD_BYTES,
     };
+    let base = &name[..name.len() - "-Data.db".len()];
+    let Some(parent) = data_path.parent() else {
+        return PER_GENERATION_OVERHEAD_BYTES;
+    };
+    let Ok(read) = std::fs::read_dir(parent) else {
+        return PER_GENERATION_OVERHEAD_BYTES;
+    };
+    let prefix = format!("{base}-");
     let mut total = PER_GENERATION_OVERHEAD_BYTES;
-    for component in [
-        // BIG (na/nb) resident sidecars.
-        "-Index.db",
-        "-Summary.db",
-        // BTI (oa/da) resident sidecars (issue #2310 roborev 1640): BTI has no
-        // Index.db/Summary.db, so these contribute 0 for a BIG generation and
-        // vice versa — the union honestly covers both formats.
-        "-Partitions.db",
-        "-Rows.db",
-        // Shared by both formats.
-        "-Statistics.db",
-        "-Filter.db",
-    ] {
-        let sibling = data_path.with_file_name(name.replace("-Data.db", component));
-        if let Ok(md) = std::fs::metadata(&sibling) {
+    for entry in read.flatten() {
+        let entry_name = entry.file_name();
+        let Some(entry_name) = entry_name.to_str() else {
+            continue;
+        };
+        if entry_name == name {
+            // The single documented exclusion: Data.db is paged, not
+            // parsed-resident.
+            continue;
+        }
+        if !entry_name.starts_with(&prefix) {
+            // Not a sibling component of THIS generation (a different
+            // generation's files never share this exact byte prefix — the
+            // generation-number/format-tag segments always differ before the
+            // trailing hyphen).
+            continue;
+        }
+        if let Ok(md) = std::fs::metadata(entry.path()) {
             total = total.saturating_add(md.len());
         }
     }
@@ -114,6 +141,69 @@ mod tests {
             footprint,
             PER_GENERATION_OVERHEAD_BYTES + 275,
             "BTI Partitions.db + Rows.db must be accounted, not silently dropped"
+        );
+    }
+
+    #[test]
+    fn footprint_includes_crc_and_compression_info_sidecars() {
+        // Finding 1 (#2310, roborev 1641): CRC.db + CompressionInfo.db are ALSO
+        // materialized by `SSTableReader::open` — CRC.db in particular can
+        // DOMINATE on an uncompressed BIG table. Exhaustive-by-construction
+        // accounting must include them without a named-suffix-list entry. Red
+        // on the pre-fix hardcoded list (Index/Summary/Statistics/Filter only,
+        // even after round 4's BTI extension): CRC.db's bytes are silently
+        // dropped, undercounting an uncompressed-BIG generation's footprint.
+        let dir = tempfile::TempDir::new().unwrap();
+        let data = dir.path().join("nb-1-big-Data.db");
+        std::fs::write(&data, b"data").unwrap();
+        std::fs::write(dir.path().join("nb-1-big-CRC.db"), vec![0u8; 300]).unwrap();
+        std::fs::write(
+            dir.path().join("nb-1-big-CompressionInfo.db"),
+            vec![0u8; 40],
+        )
+        .unwrap();
+        let footprint = account_footprint(&data);
+        assert_eq!(
+            footprint,
+            PER_GENERATION_OVERHEAD_BYTES + 340,
+            "CRC.db + CompressionInfo.db must be accounted, not silently dropped"
+        );
+    }
+
+    #[test]
+    fn footprint_excludes_only_data_db_itself() {
+        // The single documented exclusion (issue #2310, roborev 1641): Data.db
+        // is paged, not parsed-resident, so its (potentially large) size must
+        // NEVER contribute — while a sibling of any name still does.
+        let dir = tempfile::TempDir::new().unwrap();
+        let data = dir.path().join("nb-1-big-Data.db");
+        std::fs::write(&data, vec![0u8; 10_000]).unwrap(); // large Data.db
+        std::fs::write(dir.path().join("nb-1-big-TOC.txt"), vec![0u8; 10]).unwrap();
+        let footprint = account_footprint(&data);
+        assert_eq!(
+            footprint,
+            PER_GENERATION_OVERHEAD_BYTES + 10,
+            "Data.db's 10_000 bytes must be excluded; only the TOC.txt sibling counts"
+        );
+    }
+
+    #[test]
+    fn footprint_does_not_leak_a_different_generations_components() {
+        // A generation whose number is a byte-prefix of another's (1 vs 10, 12,
+        // ...) must never absorb the OTHER generation's sidecars — the
+        // trailing hyphen in the match prefix prevents the collision.
+        let dir = tempfile::TempDir::new().unwrap();
+        let data = dir.path().join("nb-1-big-Data.db");
+        std::fs::write(&data, b"data").unwrap();
+        std::fs::write(dir.path().join("nb-1-big-Index.db"), vec![0u8; 50]).unwrap();
+        // A DIFFERENT generation (12) whose components must not leak in.
+        std::fs::write(dir.path().join("nb-12-big-Data.db"), b"data").unwrap();
+        std::fs::write(dir.path().join("nb-12-big-Index.db"), vec![0u8; 9_999]).unwrap();
+        let footprint = account_footprint(&data);
+        assert_eq!(
+            footprint,
+            PER_GENERATION_OVERHEAD_BYTES + 50,
+            "generation 12's Index.db must not leak into generation 1's footprint"
         );
     }
 

--- a/cqlite-flight/src/warm/identity.rs
+++ b/cqlite-flight/src/warm/identity.rs
@@ -1,0 +1,175 @@
+//! Inode-stable SSTable generation identity (issue #2310, WS1 #2345).
+//!
+//! Decision 1 (design.md): the warm-handle cache is keyed on the logical table
+//! plus the SET of SSTable generations present, where each generation's identity
+//! is **inode-stable** — the device+inode of its `Data.db`, cross-checked with
+//! the parsed generation number. This is the ONLY key that gives a warm hit
+//! across the per-query snapshot hardlink dirs the field actually runs (a fresh
+//! `snapshots/<uuid>/` directory per request hardlinks the SAME inodes, so a
+//! path key would miss every time) while NEVER serving parsed state for bytes
+//! that changed. Explicitly NOT a directory path and NOT a TTL/time bucket
+//! (spec Requirement 1).
+
+use std::path::Path;
+
+/// The inode-stable identity of one SSTable generation's `Data.db`.
+///
+/// `(device, inode)` is the ground truth for "are these two directory entries
+/// the same on-disk bytes" — two snapshot hardlink dirs referencing the same
+/// file share `(device, inode)`. `generation` (parsed from the Cassandra file
+/// name, e.g. `nb-12-big-Data.db` → `12`) is carried as a cross-check and for
+/// human-legible eviction/logging; the `(device, inode)` pair is what makes the
+/// key correct across hardlink dirs. All three participate in equality/ordering
+/// so a device+inode reuse after a delete (a fresh SSTable landing on a recycled
+/// inode) with a different generation number is still a distinct key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GenerationId {
+    /// Filesystem device id of the `Data.db` (`stat.st_dev`).
+    pub device: u64,
+    /// Inode number of the `Data.db` (`stat.st_ino`).
+    pub inode: u64,
+    /// Generation number parsed from the SSTable file name (best-effort; 0 when
+    /// unparseable). A cross-check on top of the authoritative inode identity.
+    pub generation: u64,
+}
+
+impl GenerationId {
+    /// Resolve the inode-stable identity of a `Data.db` at `path`.
+    ///
+    /// `stat`s the file (following the hardlink to the real inode) and parses the
+    /// generation number from the file name. Returns `None` when the file cannot
+    /// be `stat`ed (missing/racing removal) so the caller treats it as
+    /// not-present rather than fabricating an identity.
+    pub fn resolve(path: &Path) -> Option<Self> {
+        let generation = generation_of(path);
+        let (device, inode) = device_inode(path)?;
+        Some(Self {
+            device,
+            inode,
+            generation,
+        })
+    }
+}
+
+/// Best-effort parse of the generation number from a Cassandra SSTable file name
+/// such as `nb-12-big-Data.db` → `12`. Returns 0 when not parseable.
+///
+/// Mirrors `producer::generation_of` (kept independent so the warm module has no
+/// dependency on producer internals). Cross-referenced against the authoritative
+/// inode identity above, so a parse miss (0) never alone determines the key.
+fn generation_of(path: &Path) -> u64 {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|name| name.split('-').find_map(|seg| seg.parse::<u64>().ok()))
+        .unwrap_or(0)
+}
+
+#[cfg(unix)]
+fn device_inode(path: &Path) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    // `metadata` (not `symlink_metadata`) so a Cassandra snapshot hardlink
+    // resolves to the SAME (device, inode) as the live file it links — the whole
+    // point of the inode-stable key (Decision 1).
+    let md = std::fs::metadata(path).ok()?;
+    Some((md.dev(), md.ino()))
+}
+
+#[cfg(not(unix))]
+fn device_inode(path: &Path) -> Option<(u64, u64)> {
+    // Non-unix has no stable inode identity; fall back to "file exists" and let
+    // the generation number carry the key. CQLite's supported deployment targets
+    // are unix (macOS/Linux); this keeps the crate compiling elsewhere without
+    // claiming inode stability it cannot provide.
+    std::fs::metadata(path).ok().map(|_| (0, 0))
+}
+
+/// A sorted, de-duplicated set of generation identities — the generation-set half
+/// of the warm cache key. Sorted so two snapshot dirs enumerated in different
+/// `read_dir` orders over the SAME inodes compare EQUAL (order-independent).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GenerationSet {
+    ids: Vec<GenerationId>,
+}
+
+impl GenerationSet {
+    /// Build a set from resolved identities, sorting + de-duplicating so equality
+    /// is order-independent across directory-listing orders.
+    pub fn from_ids(mut ids: Vec<GenerationId>) -> Self {
+        ids.sort_unstable();
+        ids.dedup();
+        Self { ids }
+    }
+
+    /// The identities in sorted order.
+    pub fn ids(&self) -> &[GenerationId] {
+        &self.ids
+    }
+
+    /// Whether the set is empty (no SSTables present).
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    /// Whether `id` is a member of this set.
+    pub fn contains(&self, id: &GenerationId) -> bool {
+        self.ids.binary_search(id).is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(dev: u64, ino: u64, gen: u64) -> GenerationId {
+        GenerationId {
+            device: dev,
+            inode: ino,
+            generation: gen,
+        }
+    }
+
+    #[test]
+    fn set_equality_is_order_independent() {
+        // Two different read_dir orders over the SAME inodes (the cross-snapshot
+        // case) MUST compare equal — the whole basis of the warm-hit key.
+        let a = GenerationSet::from_ids(vec![id(1, 10, 1), id(1, 20, 2)]);
+        let b = GenerationSet::from_ids(vec![id(1, 20, 2), id(1, 10, 1)]);
+        assert_eq!(a, b, "generation set equality must be order-independent");
+    }
+
+    #[test]
+    fn set_dedups_repeated_identities() {
+        let s = GenerationSet::from_ids(vec![id(1, 10, 1), id(1, 10, 1)]);
+        assert_eq!(s.ids().len(), 1, "duplicate identities collapse");
+    }
+
+    #[test]
+    fn distinct_inode_or_generation_is_distinct_identity() {
+        // A recycled inode with a fresh generation number is a DIFFERENT key —
+        // never a stale warm hit for changed bytes.
+        assert_ne!(id(1, 10, 1), id(1, 10, 2), "generation differs");
+        assert_ne!(id(1, 10, 1), id(1, 11, 1), "inode differs");
+        assert_ne!(id(1, 10, 1), id(2, 10, 1), "device differs");
+    }
+
+    #[test]
+    fn resolve_reads_stable_inode_across_hardlinks() {
+        // A hardlink resolves to the same (device, inode) as its target — the
+        // property that makes a snapshot dir hit the live warm entry.
+        let dir = tempfile::TempDir::new().unwrap();
+        let original = dir.path().join("nb-7-big-Data.db");
+        std::fs::write(&original, b"data").unwrap();
+        let link = dir.path().join("snap-nb-7-big-Data.db");
+        std::fs::hard_link(&original, &link).unwrap();
+
+        let a = GenerationId::resolve(&original).expect("stat original");
+        let b = GenerationId::resolve(&link).expect("stat hardlink");
+        assert_eq!(a, b, "hardlink shares device+inode+generation identity");
+        assert_eq!(a.generation, 7, "generation parsed from the name");
+    }
+
+    #[test]
+    fn resolve_missing_file_is_none() {
+        assert!(GenerationId::resolve(Path::new("/nonexistent/nb-1-big-Data.db")).is_none());
+    }
+}

--- a/cqlite-flight/src/warm/metrics.rs
+++ b/cqlite-flight/src/warm/metrics.rs
@@ -1,0 +1,191 @@
+//! Bounded warm-cache observability counters (issue #2310, WS4 #2343).
+//!
+//! Spec Requirement 6: emit warm-cache **hit**, **miss**, **evict**, and
+//! **refresh-outcome** (unchanged / rebuilt-delta / fail-closed-retained)
+//! counters, riding the EXISTING observability contract with NO new config knob,
+//! environment variable, or ticket field.
+//!
+//! Two surfaces, one source of truth:
+//!
+//! * **Process/registry-scoped atomics** ([`WarmMetrics`]) — cheap, always-on,
+//!   feature-independent. The registry increments them; tests and the #2289/#1494
+//!   bench harness read a [`WarmMetricsSnapshot`] to PROVE warm behavior (e.g. a
+//!   warm hit opened ZERO readers). This is the always-compiled "work-done probe"
+//!   the spec's second-query-zero-parse scenarios assert against.
+//! * **OpenTelemetry counters** — mirrored via `cqlite_core::observability`, a
+//!   no-op when its feature is off, so cardinality stays bounded (the only
+//!   attribute is the fixed outcome label — never tickets, keys, or paths).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use cqlite_core::observability::{self as obs, catalog, AttrValue};
+
+/// The refresh outcome recorded per warm-handle lookup that (re)built state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshOutcome {
+    /// The probed generation set matched the cached set — a warm hit, no rebuild.
+    Unchanged,
+    /// The generation set changed; only the delta was rebuilt (added generations
+    /// opened, removed dropped, unchanged kept).
+    RebuiltDelta,
+    /// A rebuild failed (an added generation would not open); the PREVIOUSLY warm
+    /// set was retained fully intact (fail-closed, mirrors #1749).
+    FailClosedRetained,
+}
+
+impl RefreshOutcome {
+    /// Bounded attribute label for the outcome (fixed set — cardinality-safe).
+    const fn label(self) -> &'static str {
+        match self {
+            RefreshOutcome::Unchanged => "unchanged",
+            RefreshOutcome::RebuiltDelta => "rebuilt_delta",
+            RefreshOutcome::FailClosedRetained => "fail_closed_retained",
+        }
+    }
+}
+
+/// Process/registry-scoped atomic counters for the warm cache.
+///
+/// Held behind an `Arc` on the registry so clones (and the owning
+/// [`crate::service::CqliteFlightService`]) share one set. All `Relaxed` — these
+/// are monotonic diagnostic counters, never a synchronization edge.
+#[derive(Debug, Default)]
+pub struct WarmMetrics {
+    hits: AtomicU64,
+    misses: AtomicU64,
+    evicts: AtomicU64,
+    refresh_unchanged: AtomicU64,
+    refresh_rebuilt: AtomicU64,
+    refresh_fail_closed: AtomicU64,
+    /// Number of `SSTableReader::open` calls the registry performed — the
+    /// "work-done" probe. A warm hit performs ZERO opens (spec Requirement 2).
+    reader_opens: AtomicU64,
+}
+
+impl WarmMetrics {
+    /// Record a warm hit (the generation set was unchanged; state served from
+    /// cache with zero reader-open/parse).
+    pub fn record_hit(&self) {
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        obs::add_counter(catalog::WARM_CACHE_HITS, 1, &[]);
+    }
+
+    /// Record a warm miss (no cached entry, or a rebuild was required).
+    pub fn record_miss(&self) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        obs::add_counter(catalog::WARM_CACHE_MISSES, 1, &[]);
+    }
+
+    /// Record `n` evictions (LRU or removed-on-disk).
+    pub fn record_evicts(&self, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.evicts.fetch_add(n, Ordering::Relaxed);
+        obs::add_counter(catalog::WARM_CACHE_EVICTS, n, &[]);
+    }
+
+    /// Record a refresh outcome.
+    pub fn record_refresh(&self, outcome: RefreshOutcome) {
+        let counter = match outcome {
+            RefreshOutcome::Unchanged => &self.refresh_unchanged,
+            RefreshOutcome::RebuiltDelta => &self.refresh_rebuilt,
+            RefreshOutcome::FailClosedRetained => &self.refresh_fail_closed,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+        obs::add_counter(
+            catalog::WARM_CACHE_REFRESH,
+            1,
+            &[(
+                catalog::attr::WARM_REFRESH_OUTCOME,
+                AttrValue::StaticStr(outcome.label()),
+            )],
+        );
+    }
+
+    /// Record `n` reader opens performed during a (re)build.
+    pub fn record_reader_opens(&self, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.reader_opens.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// A consistent-enough snapshot of the counters for tests/benches.
+    pub fn snapshot(&self) -> WarmMetricsSnapshot {
+        WarmMetricsSnapshot {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            evicts: self.evicts.load(Ordering::Relaxed),
+            refresh_unchanged: self.refresh_unchanged.load(Ordering::Relaxed),
+            refresh_rebuilt_delta: self.refresh_rebuilt.load(Ordering::Relaxed),
+            refresh_fail_closed_retained: self.refresh_fail_closed.load(Ordering::Relaxed),
+            reader_opens: self.reader_opens.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A point-in-time read of [`WarmMetrics`], for tests and the bench harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WarmMetricsSnapshot {
+    /// Warm hits (unchanged generation set served from cache).
+    pub hits: u64,
+    /// Warm misses (fresh build or rebuild required).
+    pub misses: u64,
+    /// Total evictions (LRU + removed-on-disk).
+    pub evicts: u64,
+    /// Refresh outcomes = unchanged.
+    pub refresh_unchanged: u64,
+    /// Refresh outcomes = rebuilt-delta.
+    pub refresh_rebuilt_delta: u64,
+    /// Refresh outcomes = fail-closed-retained.
+    pub refresh_fail_closed_retained: u64,
+    /// Total `SSTableReader::open` calls — the work-done probe (0 on a warm hit).
+    pub reader_opens: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counters_start_at_zero_and_increment() {
+        let m = WarmMetrics::default();
+        assert_eq!(m.snapshot(), WarmMetricsSnapshot::default_zero());
+        m.record_hit();
+        m.record_miss();
+        m.record_evicts(2);
+        m.record_reader_opens(3);
+        m.record_refresh(RefreshOutcome::RebuiltDelta);
+        let s = m.snapshot();
+        assert_eq!(s.hits, 1);
+        assert_eq!(s.misses, 1);
+        assert_eq!(s.evicts, 2);
+        assert_eq!(s.reader_opens, 3);
+        assert_eq!(s.refresh_rebuilt_delta, 1);
+    }
+
+    #[test]
+    fn zero_evicts_and_opens_are_noops() {
+        let m = WarmMetrics::default();
+        m.record_evicts(0);
+        m.record_reader_opens(0);
+        let s = m.snapshot();
+        assert_eq!(s.evicts, 0);
+        assert_eq!(s.reader_opens, 0);
+    }
+
+    impl WarmMetricsSnapshot {
+        fn default_zero() -> Self {
+            Self {
+                hits: 0,
+                misses: 0,
+                evicts: 0,
+                refresh_unchanged: 0,
+                refresh_rebuilt_delta: 0,
+                refresh_fail_closed_retained: 0,
+                reader_opens: 0,
+            }
+        }
+    }
+}

--- a/cqlite-flight/src/warm/metrics.rs
+++ b/cqlite-flight/src/warm/metrics.rs
@@ -29,7 +29,11 @@ pub enum RefreshOutcome {
     /// opened, removed dropped, unchanged kept).
     RebuiltDelta,
     /// A rebuild failed (an added generation would not open); the PREVIOUSLY warm
-    /// set was retained fully intact (fail-closed, mirrors #1749).
+    /// set was retained fully intact (fail-closed, mirrors #1749). ALSO recorded
+    /// (issue #2310, roborev 1639) when a rebuild's epoch guard discards its own
+    /// (older-probe) result because a concurrent rebuild already installed a
+    /// fresher one under the same key — the CURRENTLY installed (here,
+    /// concurrently NEWER) set is retained/served instead of being overwritten.
     FailClosedRetained,
 }
 

--- a/cqlite-flight/src/warm/mod.rs
+++ b/cqlite-flight/src/warm/mod.rs
@@ -64,6 +64,19 @@ pub enum WarmError {
         /// Underlying I/O error.
         source: std::io::Error,
     },
+    /// A `*-Data.db` directory entry seen during the staleness probe was rejected:
+    /// its resolved path escaped the table directory (issue #1430 containment) or
+    /// it could not be `stat`ed. Fail-closed exactly like [`Probe`] — treated as
+    /// "changed" (full re-resolve), NEVER silently skipped into a smaller
+    /// generation set that could mask a generation and serve a stale warm hit
+    /// (issue #2310).
+    #[error("warm-handle probe rejected entry {path}: {reason}")]
+    ProbeEntry {
+        /// The offending directory entry.
+        path: PathBuf,
+        /// Why it was rejected (containment escape / stat failure).
+        reason: String,
+    },
     /// An added generation failed to open during a rebuild (e.g. a corrupt
     /// `Statistics.db`, #1626). The previously warm set is left fully intact
     /// (fail-closed); this typed error is surfaced.

--- a/cqlite-flight/src/warm/mod.rs
+++ b/cqlite-flight/src/warm/mod.rs
@@ -1,0 +1,121 @@
+//! Flight warm-handle service: generation-keyed parse cache across requests
+//! (epic #2310).
+//!
+//! cqlite-flight is a long-running server that behaves statelessly per request:
+//! every `do_get` re-parses the schema, re-resolves the directory, and re-opens
+//! every SSTable reader (Index/Summary/Statistics/bloom parse) from cold, then
+//! throws it away. This module gives flight a WARM, generation-keyed handle per
+//! table so that parse cost is paid once per SSTable generation instead of once
+//! per request.
+//!
+//! ## Module map (split by responsibility, campsite rule)
+//!
+//! * [`identity`] — inode-stable [`GenerationId`]/[`GenerationSet`] (Decision 1:
+//!   the cache key is generation identity, never a directory path or TTL).
+//! * [`probe`] — the per-request staleness probe (Decision 2: authoritative
+//!   listing backbone + snapshot `manifest.json` fast path, zero staleness
+//!   window, no heuristics).
+//! * [`budget`] — explicit byte accounting + the fixed named budget (Decision 4).
+//! * [`metrics`] — bounded hit/miss/evict/refresh-outcome counters riding the
+//!   existing observability contract (Decision 4 metrics surface).
+//! * [`registry`] — [`WarmTableRegistry`], the fail-closed diff/swap warm set
+//!   (Decision 3: adopts `Database::refresh()`'s #1749 contract).
+//!
+//! The registry hands [`crate::producer::MergeProducer`] a pre-resolved,
+//! pre-parsed `Vec<Arc<SSTableReader>>` (via the #2346 `new_from_readers` /
+//! `build_single_partition_merger_from_readers` seams) instead of routing through
+//! a core `Database` — flight's `DirSource`/`ScanSpec`/token-prune shape differs
+//! from `Database`'s query surface (design Open Question 1).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cqlite_core::schema::TableSchema;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+
+pub mod budget;
+pub mod identity;
+pub mod metrics;
+pub mod probe;
+pub mod registry;
+
+pub use identity::{GenerationId, GenerationSet};
+pub use metrics::{RefreshOutcome, WarmMetrics, WarmMetricsSnapshot};
+pub use registry::{TableKey, WarmTableRegistry};
+
+/// Errors from the warm-handle path.
+///
+/// Fail-closed by construction (mirrors #1749): a probe error is surfaced rather
+/// than serving a stale warm hit, and an open failure during a rebuild leaves the
+/// previously warm set intact (the registry never mutates on the error path).
+#[derive(Debug, thiserror::Error)]
+pub enum WarmError {
+    /// The request was cancelled cooperatively (issue #2264/#1473) before or
+    /// during probe/rebuild — a clean, expected abort, surfaced by VARIANT (never
+    /// masked as another error).
+    #[error("warm-handle work cancelled")]
+    Cancelled,
+    /// The staleness probe could not read the resolved directory. Treated as
+    /// "changed / re-resolve failed" — never a stale warm hit.
+    #[error("warm-handle probe failed for {path}: {source}")]
+    Probe {
+        /// Directory that could not be listed.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// An added generation failed to open during a rebuild (e.g. a corrupt
+    /// `Statistics.db`, #1626). The previously warm set is left fully intact
+    /// (fail-closed); this typed error is surfaced.
+    #[error("warm-handle rebuild failed to open {path}: {source}")]
+    Open {
+        /// The `Data.db` that failed to open.
+        path: PathBuf,
+        /// Underlying open/parse error.
+        source: cqlite_core::Error,
+    },
+    /// The registry could not build the tokio runtime / [`cqlite_core::Platform`]
+    /// needed to open readers. Internal fault; the warm set is untouched.
+    #[error("warm-handle runtime unavailable: {0}")]
+    Runtime(String),
+}
+
+/// A pre-resolved, pre-parsed reader set handed to the merge producer for one
+/// request (Decision 3). The `Arc<SSTableReader>` clones isolate this request
+/// from any concurrent rebuild swap: the in-flight request completes against
+/// exactly these readers even if the warm set is rebuilt underneath it (#1749).
+#[derive(Clone)]
+pub struct WarmSet {
+    /// The generation readers, ordered newest-generation-first (LWW tie-break
+    /// rank, exactly as the path-based `DirSource` ordering).
+    pub readers: Vec<Arc<SSTableReader>>,
+    /// The parsed table schema (cached per (table, DDL hash), Decision open-Q 3).
+    pub schema: Arc<TableSchema>,
+    /// The refresh outcome for this lookup (drives metrics + tests).
+    pub outcome: RefreshOutcome,
+    /// Reader opens performed on this call — the work-done probe. `0` on a warm
+    /// hit (spec Requirement 2/8).
+    pub reader_opens: u64,
+}
+
+impl std::fmt::Debug for WarmSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `SSTableReader` is not `Debug`; summarise the set instead of printing
+        // every reader (keeps the type usable in `Result::expect_err` etc.).
+        f.debug_struct("WarmSet")
+            .field("readers", &self.readers.len())
+            .field("outcome", &self.outcome)
+            .field("reader_opens", &self.reader_opens)
+            .finish()
+    }
+}
+
+/// A stable hash of a ticket's CQL DDL, used to key the parsed-schema cache per
+/// (table, DDL) (design Open Question 3): the DDL rides the ticket and can in
+/// principle change, so keying on it keeps the cache authoritative.
+pub fn ddl_hash(ddl: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    ddl.hash(&mut h);
+    h.finish()
+}

--- a/cqlite-flight/src/warm/probe.rs
+++ b/cqlite-flight/src/warm/probe.rs
@@ -16,8 +16,11 @@
 //!   the authoritative probe, never a weaker guarantee. Absent/unparsable
 //!   manifest → fall back to the authoritative listing (never a stale hit).
 //!
-//! Fail-closed: a probe error (dir unreadable) is surfaced so the caller treats
-//! it as "changed / re-resolve failed" rather than serving a stale warm hit.
+//! Fail-closed: any probe error — the dir unreadable, a per-entry iteration or
+//! `stat` failure, or a `Data.db` whose resolved path escapes the table dir
+//! (issue #1430 containment) — is surfaced so the caller treats it as "changed /
+//! re-resolve failed" rather than serving a stale warm hit or a silently smaller
+//! generation set that could mask a live generation.
 
 use std::path::{Path, PathBuf};
 
@@ -128,26 +131,60 @@ pub fn probe_generation_set(
 }
 
 /// Enumerate the inode-stable generations (`*-Data.db` files) directly under
-/// `dir`. A `read_dir` failure surfaces as [`WarmError::Probe`] (fail-closed —
-/// never a stale hit). A `Data.db` that cannot be `stat`ed (racing removal) is
-/// simply skipped: it is not a member of the current set.
+/// `dir`, fail-closed on the completeness posture of the cold path.
+///
+/// * A `read_dir` failure — or a per-entry iteration failure — surfaces as
+///   [`WarmError::Probe`] (never a silently smaller set, #2310).
+/// * Per-file containment (issue #1430) mirrors the cold-path
+///   `DirSource::data_paths` filter: a SYMLINK inside an otherwise-valid dir can
+///   resolve to a `Data.db` OUTSIDE it. Here it is fail-closed as
+///   [`WarmError::ProbeEntry`] (treated as changed) rather than silently
+///   excluded, so a poisoned entry can never produce a stale warm hit.
+/// * A `*-Data.db` we can list but cannot `stat` is likewise fail-closed as
+///   [`WarmError::ProbeEntry`] — a FAILED stat is treated as changed, distinct
+///   from a genuinely-not-an-SSTable filename (a benign, non-error skip).
 pub(super) fn enumerate_generations(dir: &Path) -> Result<Vec<GenerationEntry>, WarmError> {
     let read = std::fs::read_dir(dir).map_err(|source| WarmError::Probe {
         path: dir.to_path_buf(),
         source,
     })?;
     let mut entries = Vec::new();
-    for entry in read.flatten() {
+    for entry in read {
+        // A per-entry iteration failure is fail-closed (#2310): surface it as a
+        // probe error → treated as changed, never a silently smaller set.
+        let entry = entry.map_err(|source| WarmError::Probe {
+            path: dir.to_path_buf(),
+            source,
+        })?;
         let path = entry.path();
         let is_data = path
             .file_name()
             .and_then(|n| n.to_str())
             .is_some_and(|n| n.ends_with("-Data.db"));
         if !is_data {
+            // A genuinely-not-an-SSTable filename is a non-error skip (it is not a
+            // member of the generation set), distinct from a FAILED stat below.
             continue;
         }
-        if let Some(id) = GenerationId::resolve(&path) {
-            entries.push(GenerationEntry { id, path });
+        // Per-file containment (issue #1430), mirroring the cold path but
+        // fail-closed: an escaping entry aborts the probe (treated as changed).
+        if let Err(reason) = crate::pathsafe::assert_within("sstable", dir, &path) {
+            return Err(WarmError::ProbeEntry {
+                path,
+                reason: reason.to_string(),
+            });
+        }
+        match GenerationId::resolve(&path) {
+            Some(id) => entries.push(GenerationEntry { id, path }),
+            None => {
+                // A `*-Data.db` we can list but cannot `stat`: fail closed
+                // (treated as changed) rather than a silently smaller set (#2310).
+                let reason = std::fs::metadata(&path)
+                    .err()
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "Data.db entry could not be resolved".to_string());
+                return Err(WarmError::ProbeEntry { path, reason });
+            }
         }
     }
     Ok(entries)
@@ -169,6 +206,62 @@ mod tests {
         write_data(dir.path(), "nb-1-big-Index.db"); // ignored
         let entries = enumerate_generations(dir.path()).unwrap();
         assert_eq!(entries.len(), 2, "only Data.db files count as generations");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn symlink_escaping_data_db_is_probe_error_not_enumerated() {
+        // Finding 1 (#2310): a symlink inside the table dir whose name is a
+        // `*-Data.db` but whose target escapes the dir must FAIL the probe
+        // (fail-closed containment, issue #1430), never be enumerated as a
+        // generation. Red on pre-fix code: the escapee is silently enumerated.
+        use std::os::unix::fs::symlink;
+        let table = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let escapee = outside.path().join("nb-9-big-Data.db");
+        std::fs::write(&escapee, b"x").unwrap();
+        symlink(&escapee, table.path().join("nb-9-big-Data.db")).unwrap();
+
+        let err = enumerate_generations(table.path())
+            .expect_err("an escaping symlink Data.db must fail the probe, not enumerate");
+        assert!(matches!(err, WarmError::ProbeEntry { .. }), "got {err:?}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn unstatable_data_db_entry_is_probe_error_not_silent_skip() {
+        // Finding 3 (#2310): a `*-Data.db` we can list but cannot `stat` (a
+        // dangling symlink) must fail closed (treated as changed), NOT be
+        // silently dropped into a smaller set. Red on pre-fix code: the entry is
+        // silently skipped and the probe returns Ok with a smaller set.
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::TempDir::new().unwrap();
+        write_data(dir.path(), "nb-1-big-Data.db");
+        symlink(
+            dir.path().join("missing-target"),
+            dir.path().join("nb-2-big-Data.db"),
+        )
+        .unwrap();
+
+        let err = enumerate_generations(dir.path())
+            .expect_err("an unstatable Data.db must fail the probe, not be skipped");
+        assert!(matches!(err, WarmError::ProbeEntry { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn non_sstable_filename_is_a_non_error_skip() {
+        // The fail-closed posture must NOT turn a benign non-SSTable filename
+        // into an error: only Data.db entries participate in the set.
+        let dir = tempfile::TempDir::new().unwrap();
+        write_data(dir.path(), "nb-1-big-Data.db");
+        write_data(dir.path(), "nb-1-big-Index.db"); // not a Data.db
+        write_data(dir.path(), "manifest.json"); // not a Data.db
+        let entries = enumerate_generations(dir.path()).unwrap();
+        assert_eq!(
+            entries.len(),
+            1,
+            "only the one Data.db counts; others skipped"
+        );
     }
 
     #[test]

--- a/cqlite-flight/src/warm/probe.rs
+++ b/cqlite-flight/src/warm/probe.rs
@@ -1,0 +1,232 @@
+//! Per-request generation-set staleness probe (issue #2310, WS2 #2341).
+//!
+//! Decision 2 (design.md) + spec Requirements 2 & 3. On EVERY request the warm
+//! handle probes the current SSTable generation set for the resolved table and
+//! compares it to the cached set:
+//!
+//! * **Authoritative backbone (2a):** a directory listing of `*-Data.db` files,
+//!   each resolved to its inode-stable [`GenerationId`]. A listing IS ground
+//!   truth for "what generations exist right now" — ZERO staleness window, and
+//!   NO heuristic (it reads the truth, it does not infer it from mtime/timing;
+//!   no-heuristics mandate #28). A flush/compaction is visible on the very next
+//!   request.
+//! * **Snapshot manifest fast path (2b):** in snapshot mode the snapshot carries
+//!   a `manifest.json`; when it is byte-identical to the cached one, skip the
+//!   `read_dir` and take the warm hit. It is an OPTIMIZATION ONLY — equivalent to
+//!   the authoritative probe, never a weaker guarantee. Absent/unparsable
+//!   manifest → fall back to the authoritative listing (never a stale hit).
+//!
+//! Fail-closed: a probe error (dir unreadable) is surfaced so the caller treats
+//! it as "changed / re-resolve failed" rather than serving a stale warm hit.
+
+use std::path::{Path, PathBuf};
+
+use crate::cancel::CancelFlag;
+
+use super::identity::{GenerationId, GenerationSet};
+use super::WarmError;
+
+/// One enumerated generation: its inode-stable identity and the `Data.db` path a
+/// rebuild opens it from.
+#[derive(Debug, Clone)]
+pub struct GenerationEntry {
+    /// Inode-stable identity (the cache-key member).
+    pub id: GenerationId,
+    /// The `Data.db` path to open this generation from (in the resolved dir).
+    pub path: PathBuf,
+}
+
+/// The result of a staleness probe.
+#[derive(Debug)]
+pub enum ProbeOutcome {
+    /// The snapshot `manifest.json` was byte-identical to the cached one: the
+    /// cached generation set is authoritative, and NO `read_dir` was performed
+    /// (spec Requirement 3 fast path).
+    UnchangedByManifest,
+    /// An authoritative directory listing was performed. Carries the current
+    /// generation entries and (in snapshot mode) the manifest bytes to cache for
+    /// the next fast-path comparison.
+    Enumerated {
+        /// The current on-disk generations (id + path), newest resolution order
+        /// unspecified — the registry sorts.
+        entries: Vec<GenerationEntry>,
+        /// Snapshot `manifest.json` bytes, when present, to cache for the next
+        /// request's fast-path comparison. `None` in live mode or when absent.
+        manifest: Option<Vec<u8>>,
+        /// Whether a `read_dir` was actually performed (always `true` here; the
+        /// field lets tests/benches assert the fast path elided it).
+        read_dir_performed: bool,
+    },
+}
+
+impl ProbeOutcome {
+    /// The generation set of an `Enumerated` outcome (empty for a manifest hit,
+    /// which by definition kept the cached set).
+    pub fn set(entries: &[GenerationEntry]) -> GenerationSet {
+        GenerationSet::from_ids(entries.iter().map(|e| e.id).collect())
+    }
+}
+
+/// The snapshot manifest file Cassandra writes into a `snapshots/<name>/` dir.
+const MANIFEST_FILE: &str = "manifest.json";
+
+/// Read the snapshot `manifest.json` bytes from `dir`, when present. Used by the
+/// registry's manifest-hit-race fallback to re-cache the manifest after an
+/// authoritative re-enumeration.
+pub(super) fn read_manifest(dir: &Path) -> Option<Vec<u8>> {
+    std::fs::read(dir.join(MANIFEST_FILE)).ok()
+}
+
+/// Probe the current generation set for `dir`.
+///
+/// `snapshot_mode` enables the `manifest.json` fast path (2b). `cached_manifest`
+/// is the manifest bytes cached from the previous probe of the SAME warm entry
+/// (used only to decide the fast path). `cancel` is polled first so a
+/// pre-cancelled request does ZERO probe work (spec Requirement 7).
+pub fn probe_generation_set(
+    dir: &Path,
+    snapshot_mode: bool,
+    cached_manifest: Option<&[u8]>,
+    cancel: &CancelFlag,
+) -> Result<ProbeOutcome, WarmError> {
+    // Cancellation (issue #2264/#1473): a pre-cancelled request does zero work.
+    if cancel.is_cancelled() {
+        return Err(WarmError::Cancelled);
+    }
+
+    // Fast path (2b): snapshot mode + a cached manifest that matches the on-disk
+    // one → the generation set is unchanged, skip the read_dir entirely. Any read
+    // failure or mismatch falls through to the authoritative listing below; the
+    // fast path is an optimization, never the correctness backbone.
+    if snapshot_mode {
+        if let Some(cached) = cached_manifest {
+            if let Ok(current) = std::fs::read(dir.join(MANIFEST_FILE)) {
+                if current == cached {
+                    return Ok(ProbeOutcome::UnchangedByManifest);
+                }
+            }
+        }
+    }
+
+    // Cancellation boundary before the (potentially I/O-heavy) listing.
+    if cancel.is_cancelled() {
+        return Err(WarmError::Cancelled);
+    }
+
+    let entries = enumerate_generations(dir)?;
+    // In snapshot mode, cache the manifest bytes (if any) for the next fast path.
+    let manifest = if snapshot_mode {
+        std::fs::read(dir.join(MANIFEST_FILE)).ok()
+    } else {
+        None
+    };
+    Ok(ProbeOutcome::Enumerated {
+        entries,
+        manifest,
+        read_dir_performed: true,
+    })
+}
+
+/// Enumerate the inode-stable generations (`*-Data.db` files) directly under
+/// `dir`. A `read_dir` failure surfaces as [`WarmError::Probe`] (fail-closed —
+/// never a stale hit). A `Data.db` that cannot be `stat`ed (racing removal) is
+/// simply skipped: it is not a member of the current set.
+pub(super) fn enumerate_generations(dir: &Path) -> Result<Vec<GenerationEntry>, WarmError> {
+    let read = std::fs::read_dir(dir).map_err(|source| WarmError::Probe {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+    let mut entries = Vec::new();
+    for entry in read.flatten() {
+        let path = entry.path();
+        let is_data = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with("-Data.db"));
+        if !is_data {
+            continue;
+        }
+        if let Some(id) = GenerationId::resolve(&path) {
+            entries.push(GenerationEntry { id, path });
+        }
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_data(dir: &Path, name: &str) {
+        std::fs::write(dir.join(name), b"x").unwrap();
+    }
+
+    #[test]
+    fn enumerates_data_files_only() {
+        let dir = tempfile::TempDir::new().unwrap();
+        write_data(dir.path(), "nb-1-big-Data.db");
+        write_data(dir.path(), "nb-2-big-Data.db");
+        write_data(dir.path(), "nb-1-big-Index.db"); // ignored
+        let entries = enumerate_generations(dir.path()).unwrap();
+        assert_eq!(entries.len(), 2, "only Data.db files count as generations");
+    }
+
+    #[test]
+    fn missing_dir_is_probe_error_not_stale_hit() {
+        let err = enumerate_generations(Path::new("/nonexistent/warm/dir")).unwrap_err();
+        assert!(matches!(err, WarmError::Probe { .. }));
+    }
+
+    #[test]
+    fn pre_cancelled_probe_does_zero_work() {
+        let dir = tempfile::TempDir::new().unwrap();
+        write_data(dir.path(), "nb-1-big-Data.db");
+        let cancel = CancelFlag::new();
+        cancel.cancel();
+        let err = probe_generation_set(dir.path(), false, None, &cancel).unwrap_err();
+        assert!(matches!(err, WarmError::Cancelled));
+    }
+
+    #[test]
+    fn matching_manifest_takes_fast_path_without_readdir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        write_data(dir.path(), "nb-1-big-Data.db");
+        let manifest = br#"{"files":["nb-1-big-Data.db"]}"#.to_vec();
+        std::fs::write(dir.path().join(MANIFEST_FILE), &manifest).unwrap();
+        let outcome =
+            probe_generation_set(dir.path(), true, Some(&manifest), &CancelFlag::new()).unwrap();
+        assert!(
+            matches!(outcome, ProbeOutcome::UnchangedByManifest),
+            "byte-identical manifest must take the fast path"
+        );
+    }
+
+    #[test]
+    fn absent_manifest_falls_back_to_authoritative_listing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        write_data(dir.path(), "nb-1-big-Data.db");
+        // Snapshot mode, cached manifest present, but NO manifest on disk → the
+        // fast path cannot fire; fall back to the authoritative listing.
+        let outcome =
+            probe_generation_set(dir.path(), true, Some(b"cached"), &CancelFlag::new()).unwrap();
+        match outcome {
+            ProbeOutcome::Enumerated {
+                read_dir_performed, ..
+            } => assert!(read_dir_performed, "must fall back to the readdir"),
+            ProbeOutcome::UnchangedByManifest => panic!("no on-disk manifest → no fast path"),
+        }
+    }
+
+    #[test]
+    fn changed_manifest_re_enumerates() {
+        let dir = tempfile::TempDir::new().unwrap();
+        write_data(dir.path(), "nb-1-big-Data.db");
+        std::fs::write(dir.path().join(MANIFEST_FILE), b"new").unwrap();
+        let outcome =
+            probe_generation_set(dir.path(), true, Some(b"old"), &CancelFlag::new()).unwrap();
+        assert!(
+            matches!(outcome, ProbeOutcome::Enumerated { .. }),
+            "a differing manifest must re-enumerate, never a stale hit"
+        );
+    }
+}

--- a/cqlite-flight/src/warm/probe.rs
+++ b/cqlite-flight/src/warm/probe.rs
@@ -14,13 +14,19 @@
 //!   a `manifest.json`; when it is byte-identical to the cached one, skip the
 //!   `read_dir` and take the warm hit. It is an OPTIMIZATION ONLY — equivalent to
 //!   the authoritative probe, never a weaker guarantee. Absent/unparsable
-//!   manifest → fall back to the authoritative listing (never a stale hit).
+//!   manifest → fall back to the authoritative listing (never a stale hit). Every
+//!   `manifest.json` read is per-file containment-checked (issue #1430 class,
+//!   roborev 1640) — see [`read_manifest_checked`].
 //!
 //! Fail-closed: any probe error — the dir unreadable, a per-entry iteration or
-//! `stat` failure, or a `Data.db` whose resolved path escapes the table dir
-//! (issue #1430 containment) — is surfaced so the caller treats it as "changed /
-//! re-resolve failed" rather than serving a stale warm hit or a silently smaller
-//! generation set that could mask a live generation.
+//! `stat` failure, a `Data.db` whose resolved path escapes the table dir, or a
+//! `manifest.json` whose resolved path escapes the table dir (issue #1430
+//! containment, both classes) — is surfaced so the caller treats it as "changed
+//! / re-resolve failed" rather than serving a stale warm hit or a silently
+//! smaller generation set that could mask a live generation. A containment
+//! VIOLATION specifically is never treated as "absent" / a fallback trigger —
+//! only a genuinely missing or benignly-unreadable file is (see
+//! [`read_manifest_checked`]'s doc for the distinction).
 
 use std::path::{Path, PathBuf};
 
@@ -73,11 +79,34 @@ impl ProbeOutcome {
 /// The snapshot manifest file Cassandra writes into a `snapshots/<name>/` dir.
 const MANIFEST_FILE: &str = "manifest.json";
 
-/// Read the snapshot `manifest.json` bytes from `dir`, when present. Used by the
-/// registry's manifest-hit-race fallback to re-cache the manifest after an
-/// authoritative re-enumeration.
-pub(super) fn read_manifest(dir: &Path) -> Option<Vec<u8>> {
-    std::fs::read(dir.join(MANIFEST_FILE)).ok()
+/// Read the snapshot `manifest.json` bytes from `dir`, when present AND
+/// contained within `dir` (issue #1430 containment class, roborev 1640). Used
+/// by the registry's manifest-hit-race fallback to re-cache the manifest after
+/// an authoritative re-enumeration, and by every manifest read inside
+/// [`probe_generation_set`].
+///
+/// A SYMLINKED `manifest.json` pointing outside the snapshot dir could
+/// otherwise (a) leak arbitrary file bytes into the fast-path comparison, or
+/// (b) let a forged, attacker-controlled manifest byte-match the cached one and
+/// pin a stale/incorrect warm hit — exactly the class of escape the cold
+/// `DirSource::data_paths` / warm `enumerate_generations` containment filters
+/// already close for `Data.db`. A containment violation here is a SECURITY
+/// ERROR, not a fallback trigger: it is surfaced as [`WarmError::ProbeEntry`]
+/// rather than treated as "absent" — the merely-absent case (no manifest, or a
+/// benign read failure) stays `Ok(None)` and DOES fall through to the
+/// authoritative listing (the existing "optimization only" invariant), but a
+/// violating PRESENT entry must abort the request rather than silently
+/// degrading to the slower-but-still-correct path, because at that point
+/// something is actively wrong, not merely missing.
+pub(super) fn read_manifest_checked(dir: &Path) -> Result<Option<Vec<u8>>, WarmError> {
+    let path = dir.join(MANIFEST_FILE);
+    if let Err(reason) = crate::pathsafe::assert_within("manifest", dir, &path) {
+        return Err(WarmError::ProbeEntry {
+            path,
+            reason: reason.to_string(),
+        });
+    }
+    Ok(std::fs::read(&path).ok())
 }
 
 /// Probe the current generation set for `dir`.
@@ -98,12 +127,15 @@ pub fn probe_generation_set(
     }
 
     // Fast path (2b): snapshot mode + a cached manifest that matches the on-disk
-    // one → the generation set is unchanged, skip the read_dir entirely. Any read
-    // failure or mismatch falls through to the authoritative listing below; the
-    // fast path is an optimization, never the correctness backbone.
+    // one → the generation set is unchanged, skip the read_dir entirely. A
+    // benign absence/mismatch falls through to the authoritative listing below
+    // (the fast path is an optimization, never the correctness backbone) — but a
+    // containment VIOLATION (issue #1430 class, roborev 1640) is a hard error,
+    // NOT a fallback trigger: propagate it rather than silently degrading to the
+    // slower path, since at that point something is actively wrong.
     if snapshot_mode {
         if let Some(cached) = cached_manifest {
-            if let Ok(current) = std::fs::read(dir.join(MANIFEST_FILE)) {
+            if let Some(current) = read_manifest_checked(dir)? {
                 if current == cached {
                     return Ok(ProbeOutcome::UnchangedByManifest);
                 }
@@ -117,9 +149,11 @@ pub fn probe_generation_set(
     }
 
     let entries = enumerate_generations(dir)?;
-    // In snapshot mode, cache the manifest bytes (if any) for the next fast path.
+    // In snapshot mode, cache the manifest bytes (if any) for the next fast
+    // path — containment-checked (a violation aborts this whole probe, never
+    // just skips caching, since something is actively wrong at that point).
     let manifest = if snapshot_mode {
-        std::fs::read(dir.join(MANIFEST_FILE)).ok()
+        read_manifest_checked(dir)?
     } else {
         None
     };
@@ -278,6 +312,38 @@ mod tests {
         cancel.cancel();
         let err = probe_generation_set(dir.path(), false, None, &cancel).unwrap_err();
         assert!(matches!(err, WarmError::Cancelled));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn symlinked_manifest_escaping_dir_is_probe_error_not_trusted() {
+        // Finding 1 (#2310, roborev 1640): a manifest.json symlink escaping the
+        // snapshot dir must FAIL the probe (fail-closed containment, issue
+        // #1430 class), never be read+trusted for the fast-path comparison.
+        // Red on pre-fix code: the escapee's bytes are read via a plain
+        // `std::fs::read`, and if they byte-match the cached manifest, the fast
+        // path is taken (a forged/leaked manifest could pin a stale warm hit).
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let secret = outside.path().join("secret-manifest.json");
+        let payload = b"attacker-controlled bytes".to_vec();
+        std::fs::write(&secret, &payload).unwrap();
+        symlink(&secret, dir.path().join(MANIFEST_FILE)).unwrap();
+
+        // The direct helper must reject it outright.
+        let err = read_manifest_checked(dir.path())
+            .expect_err("an escaping manifest.json must fail containment, not be read");
+        assert!(matches!(err, WarmError::ProbeEntry { .. }), "got {err:?}");
+
+        // The fast path (attacker supplies a `cached_manifest` matching the
+        // secret's bytes, simulating a forged/leaked-then-replayed manifest)
+        // must propagate the SAME error — a containment violation is an ERROR,
+        // NEVER a silent fallback to the authoritative listing.
+        write_data(dir.path(), "nb-1-big-Data.db");
+        let err = probe_generation_set(dir.path(), true, Some(&payload), &CancelFlag::new())
+            .expect_err("a containment violation must abort the probe, not fall back");
+        assert!(matches!(err, WarmError::ProbeEntry { .. }), "got {err:?}");
     }
 
     #[test]

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -1,0 +1,549 @@
+//! The warm-handle registry (issue #2310, WS1 #2345 / WS3 #2342).
+//!
+//! [`WarmTableRegistry`] holds parsed, open `Arc<SSTableReader>`s keyed on
+//! inode-stable generation identity (Decision 1) and adopts `Database::refresh()`'s
+//! fail-closed diff/swap contract (#1749, Decision 3): a rebuild opens ADDED
+//! generations BEFORE swapping, keeps UNCHANGED generations' parsed state, drops
+//! REMOVED ones, and swaps atomically under a write guard — so any open failure
+//! mutates nothing and in-flight requests holding `Arc` clones complete against
+//! the pre-swap set.
+//!
+//! ## UDT-registry contract (WS1 #2345, from the #2346 review)
+//!
+//! The reader-based merge seam `KWayMerger::new_from_readers` takes NO
+//! `udt_registry` parameter (a shared `Arc` reader has no `&mut self` for
+//! `set_udt_registry`). So the registry MUST open each reader WITH its UDT
+//! registry already resolved BEFORE wrapping it in `Arc` — otherwise a
+//! frozen/nested UDT cell silently decodes as `Blob` (the #1234 data-loss class),
+//! NOT an error. [`open_one_reader`] resolves + sets the registry and asserts it
+//! is present via `SSTableReader::has_udt_registry`. (A Flight ticket carries a
+//! single-table DDL with no `CREATE TYPE` bodies, so the resolved registry is the
+//! Cassandra-5 default set — the same authority the cold path had; the plumbing
+//! is present and provable so a future ticket that DOES carry UDT bodies is
+//! decoded structurally, never dropped.)
+//!
+//! ## File-lifetime contract (from `from_readers.rs`)
+//!
+//! `new_from_readers` requires the backing `Data.db` not be deleted while any
+//! `Arc<SSTableReader>` clone is alive. This registry only ever evicts its OWN
+//! reference (per #1749's fail-closed model) and never deletes/replaces a
+//! generation's file out from under a live `Arc`; a snapshot's hardlinked inode
+//! outlives the per-query dir (the link keeps the inode alive), so the contract
+//! is satisfied trivially.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use cqlite_core::schema::{TableSchema, UdtRegistry};
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::{Config, Platform};
+
+use crate::cancel::CancelFlag;
+
+use super::budget::{account_footprint, DEFAULT_WARM_BUDGET_BYTES};
+use super::identity::{GenerationId, GenerationSet};
+use super::metrics::{RefreshOutcome, WarmMetrics};
+use super::probe::{self, GenerationEntry, ProbeOutcome};
+use super::{WarmError, WarmSet};
+
+/// The logical-table half of the warm cache key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TableKey {
+    /// Keyspace name.
+    pub keyspace: String,
+    /// Table name.
+    pub table: String,
+}
+
+impl TableKey {
+    /// Build a key from keyspace + table names.
+    pub fn new(keyspace: impl Into<String>, table: impl Into<String>) -> Self {
+        Self {
+            keyspace: keyspace.into(),
+            table: table.into(),
+        }
+    }
+}
+
+/// One warm generation: its identity, the open reader, and byte accounting.
+struct WarmReader {
+    id: GenerationId,
+    reader: Arc<SSTableReader>,
+    footprint: u64,
+    last_access: u64,
+}
+
+/// Warm state for one logical table.
+struct TableWarm {
+    ddl_hash: u64,
+    schema: Arc<TableSchema>,
+    /// Newest-generation-first (LWW tie-break rank).
+    readers: Vec<WarmReader>,
+    /// Cached snapshot `manifest.json` for the fast-path probe (Decision 2b).
+    manifest: Option<Vec<u8>>,
+}
+
+impl TableWarm {
+    fn generation_set(&self) -> GenerationSet {
+        GenerationSet::from_ids(self.readers.iter().map(|r| r.id).collect())
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    tables: HashMap<TableKey, TableWarm>,
+    used_bytes: u64,
+    tick: u64,
+}
+
+impl Inner {
+    fn next_tick(&mut self) -> u64 {
+        self.tick += 1;
+        self.tick
+    }
+}
+
+/// A flight-owned warm cache of open SSTable readers keyed on generation
+/// identity.
+pub struct WarmTableRegistry {
+    inner: Mutex<Inner>,
+    /// Lazily-built shared platform for reader opens.
+    platform: Mutex<Option<Arc<Platform>>>,
+    budget_bytes: u64,
+    metrics: Arc<WarmMetrics>,
+}
+
+impl Default for WarmTableRegistry {
+    fn default() -> Self {
+        Self::with_budget(DEFAULT_WARM_BUDGET_BYTES)
+    }
+}
+
+impl WarmTableRegistry {
+    /// A registry with the fixed named default byte budget (Decision 4).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A registry with an explicit byte budget (test/bench hook; production uses
+    /// the fixed [`DEFAULT_WARM_BUDGET_BYTES`] via [`Self::new`]).
+    pub fn with_budget(budget_bytes: u64) -> Self {
+        Self {
+            inner: Mutex::new(Inner::default()),
+            platform: Mutex::new(None),
+            budget_bytes: budget_bytes.max(1),
+            metrics: Arc::new(WarmMetrics::default()),
+        }
+    }
+
+    /// The shared metrics handle (hit/miss/evict/refresh-outcome + reader-opens
+    /// work probe) for the #2289/#1494 bench harness and tests.
+    pub fn metrics(&self) -> Arc<WarmMetrics> {
+        Arc::clone(&self.metrics)
+    }
+
+    /// Obtain the warm reader set for one request, probing staleness and
+    /// rebuilding only the delta on a change (fail-closed).
+    ///
+    /// * `dir` — the resolved SSTable directory (from `DirSource::resolve`).
+    /// * `snapshot` — the ticket's snapshot name (enables the manifest fast path).
+    /// * `cancel` — the request cancel flag; a pre-cancelled request does ZERO
+    ///   probe/rebuild work and returns [`WarmError::Cancelled`] by variant.
+    pub fn warm_readers(
+        &self,
+        key: &TableKey,
+        ddl_hash: u64,
+        schema: &TableSchema,
+        dir: &Path,
+        snapshot: Option<&str>,
+        cancel: &CancelFlag,
+    ) -> Result<WarmSet, WarmError> {
+        // Cancellation (issue #2264/#1473): zero work when pre-cancelled.
+        if cancel.is_cancelled() {
+            return Err(WarmError::Cancelled);
+        }
+        let snapshot_mode = snapshot.is_some_and(|s| !s.is_empty());
+
+        // Snapshot the cached manifest for the fast-path probe (only when the
+        // cached entry's DDL still matches — a DDL change invalidates the cache).
+        let cached_manifest = {
+            let inner = self.lock_inner();
+            inner
+                .tables
+                .get(key)
+                .filter(|t| t.ddl_hash == ddl_hash)
+                .and_then(|t| t.manifest.clone())
+        };
+
+        match probe::probe_generation_set(dir, snapshot_mode, cached_manifest.as_deref(), cancel)? {
+            ProbeOutcome::UnchangedByManifest => {
+                // Manifest fast path matched: serve the cached set with no
+                // reader-open/parse. A rare race (a concurrent rebuild replaced
+                // the entry) falls back to an authoritative re-enumeration.
+                if let Some(hit) = self.try_hit(key, ddl_hash, None) {
+                    return Ok(hit);
+                }
+                let entries = probe::enumerate_generations(dir)?;
+                let manifest = snapshot_mode.then(|| probe::read_manifest(dir)).flatten();
+                self.finish_enumerated(key, ddl_hash, schema, entries, manifest, cancel)
+            }
+            ProbeOutcome::Enumerated {
+                entries, manifest, ..
+            } => self.finish_enumerated(key, ddl_hash, schema, entries, manifest, cancel),
+        }
+    }
+
+    /// Resolve an authoritatively-enumerated generation set into a warm hit (set
+    /// unchanged) or a fail-closed delta rebuild.
+    fn finish_enumerated(
+        &self,
+        key: &TableKey,
+        ddl_hash: u64,
+        schema: &TableSchema,
+        entries: Vec<GenerationEntry>,
+        manifest: Option<Vec<u8>>,
+        cancel: &CancelFlag,
+    ) -> Result<WarmSet, WarmError> {
+        let current_set = ProbeOutcome::set(&entries);
+        if let Some(hit) = self.try_hit(key, ddl_hash, Some((&current_set, manifest.clone()))) {
+            return Ok(hit);
+        }
+        self.rebuild(
+            key,
+            ddl_hash,
+            schema,
+            entries,
+            current_set,
+            manifest,
+            cancel,
+        )
+    }
+
+    /// Try to serve a warm hit. `expected` is `None` for the manifest fast path
+    /// (which already proved the set is unchanged) or `Some((set, manifest))` for
+    /// the authoritative path (the cached set must equal `set`). Returns `None`
+    /// when there is no usable cached entry (→ the caller rebuilds).
+    fn try_hit(
+        &self,
+        key: &TableKey,
+        ddl_hash: u64,
+        expected: Option<(&GenerationSet, Option<Vec<u8>>)>,
+    ) -> Option<WarmSet> {
+        let mut inner = self.lock_inner();
+        let tick = inner.next_tick();
+        let entry = inner.tables.get_mut(key)?;
+        if entry.ddl_hash != ddl_hash {
+            return None;
+        }
+        if let Some((expected_set, new_manifest)) = expected {
+            if entry.generation_set() != *expected_set {
+                return None;
+            }
+            // Refresh the cached manifest so the next request can take the fast
+            // path (the authoritative probe just proved this manifest current).
+            if new_manifest.is_some() {
+                entry.manifest = new_manifest;
+            }
+        }
+        for r in &mut entry.readers {
+            r.last_access = tick;
+        }
+        let set = WarmSet {
+            readers: entry
+                .readers
+                .iter()
+                .map(|r| Arc::clone(&r.reader))
+                .collect(),
+            schema: Arc::clone(&entry.schema),
+            outcome: RefreshOutcome::Unchanged,
+            reader_opens: 0,
+        };
+        self.metrics.record_hit();
+        self.metrics.record_refresh(RefreshOutcome::Unchanged);
+        Some(set)
+    }
+
+    /// Fail-closed delta rebuild (Decision 3, mirrors `refresh_tables`): open only
+    /// ADDED generations (BEFORE any swap), keep UNCHANGED parsed state, drop
+    /// REMOVED, swap atomically. Any open failure returns the typed error with the
+    /// previously warm set fully intact.
+    #[allow(clippy::too_many_arguments)]
+    fn rebuild(
+        &self,
+        key: &TableKey,
+        ddl_hash: u64,
+        schema: &TableSchema,
+        entries: Vec<GenerationEntry>,
+        current_set: GenerationSet,
+        manifest: Option<Vec<u8>>,
+        cancel: &CancelFlag,
+    ) -> Result<WarmSet, WarmError> {
+        if cancel.is_cancelled() {
+            return Err(WarmError::Cancelled);
+        }
+
+        // Which generations are already warm (and DDL still matches)? Snapshot
+        // their ids so we open only the delta. Held briefly; opening happens
+        // OUTSIDE the lock (slow I/O).
+        let cached_ids: Vec<GenerationId> = {
+            let inner = self.lock_inner();
+            inner
+                .tables
+                .get(key)
+                .filter(|t| t.ddl_hash == ddl_hash)
+                .map(|t| t.readers.iter().map(|r| r.id).collect())
+                .unwrap_or_default()
+        };
+
+        // ADDED = present now, not already warm. Open them (fail-closed).
+        let added: Vec<&GenerationEntry> = entries
+            .iter()
+            .filter(|e| !cached_ids.contains(&e.id))
+            .collect();
+        let opened = match self.open_added(&added, schema, cancel) {
+            Ok(opened) => opened,
+            Err(e) => {
+                // The previously warm set is untouched. Record the fail-closed
+                // retention outcome (unless it was a plain cancellation).
+                if !matches!(e, WarmError::Cancelled) {
+                    self.metrics
+                        .record_refresh(RefreshOutcome::FailClosedRetained);
+                }
+                return Err(e);
+            }
+        };
+        let reader_opens = opened.len() as u64;
+
+        // Swap atomically under the write guard.
+        let mut inner = self.lock_inner();
+        let tick = inner.next_tick();
+        let mut freed: u64 = 0;
+        let mut removed_count: u64 = 0;
+
+        // KEEP unchanged generations' parsed state; DROP removed (evict now).
+        let mut kept: Vec<WarmReader> = Vec::new();
+        if let Some(prev) = inner.tables.remove(key) {
+            if prev.ddl_hash == ddl_hash {
+                for r in prev.readers {
+                    if current_set.contains(&r.id) {
+                        kept.push(r);
+                    } else {
+                        freed = freed.saturating_add(r.footprint);
+                        removed_count += 1;
+                    }
+                }
+            } else {
+                // DDL changed: the whole prior entry is invalid.
+                for r in prev.readers {
+                    freed = freed.saturating_add(r.footprint);
+                    removed_count += 1;
+                }
+            }
+        }
+
+        // NEW reader set = kept + newly-opened, newest-generation-first.
+        let mut readers = kept;
+        let mut added_bytes: u64 = 0;
+        for mut r in opened {
+            r.last_access = tick;
+            added_bytes = added_bytes.saturating_add(r.footprint);
+            readers.push(r);
+        }
+        for r in &mut readers {
+            r.last_access = tick;
+        }
+        readers.sort_by(|a, b| b.id.generation.cmp(&a.id.generation).then(b.id.cmp(&a.id)));
+
+        inner.used_bytes = inner
+            .used_bytes
+            .saturating_sub(freed)
+            .saturating_add(added_bytes);
+        let out = WarmSet {
+            readers: readers.iter().map(|r| Arc::clone(&r.reader)).collect(),
+            schema: Arc::new(schema.clone()),
+            outcome: RefreshOutcome::RebuiltDelta,
+            reader_opens,
+        };
+        let protected: Vec<GenerationId> = readers.iter().map(|r| r.id).collect();
+        inner.tables.insert(
+            key.clone(),
+            TableWarm {
+                ddl_hash,
+                schema: Arc::clone(&out.schema),
+                readers,
+                manifest,
+            },
+        );
+
+        // Enforce the byte budget (LRU eviction), never evicting a generation in
+        // THIS request's returned set.
+        let lru_evicted = self.evict_to_budget(&mut inner, &protected);
+
+        self.metrics.record_evicts(removed_count + lru_evicted);
+        self.metrics.record_reader_opens(reader_opens);
+        self.metrics.record_miss();
+        self.metrics.record_refresh(RefreshOutcome::RebuiltDelta);
+        Ok(out)
+    }
+
+    /// Evict least-recently-used (table, generation) entries until the accounted
+    /// footprint is within budget, never evicting a `protected` generation (the
+    /// current request's set). Returns the number evicted.
+    fn evict_to_budget(&self, inner: &mut Inner, protected: &[GenerationId]) -> u64 {
+        let mut evicted = 0u64;
+        while inner.used_bytes > self.budget_bytes {
+            // Find the global LRU victim not in `protected`.
+            let victim = inner
+                .tables
+                .iter()
+                .flat_map(|(k, t)| {
+                    t.readers
+                        .iter()
+                        .map(move |r| (k.clone(), r.id, r.last_access, r.footprint))
+                })
+                .filter(|(_, id, _, _)| !protected.contains(id))
+                .min_by_key(|(_, _, last_access, _)| *last_access);
+            let Some((vkey, vid, _, vbytes)) = victim else {
+                // Nothing evictable without dropping the current request's set.
+                break;
+            };
+            if let Some(t) = inner.tables.get_mut(&vkey) {
+                t.readers.retain(|r| r.id != vid);
+                if t.readers.is_empty() {
+                    inner.tables.remove(&vkey);
+                }
+            }
+            inner.used_bytes = inner.used_bytes.saturating_sub(vbytes);
+            evicted += 1;
+        }
+        evicted
+    }
+
+    /// Open the ADDED generations, resolving each reader's UDT registry BEFORE
+    /// wrapping in `Arc` (the #2345 contract). Fail-closed: any open error (or a
+    /// cancellation) returns immediately WITHOUT partial state.
+    fn open_added(
+        &self,
+        added: &[&GenerationEntry],
+        schema: &TableSchema,
+        cancel: &CancelFlag,
+    ) -> Result<Vec<WarmReader>, WarmError> {
+        if added.is_empty() {
+            return Ok(Vec::new());
+        }
+        // One current-thread runtime per rebuild (reader open is async); reused
+        // across every added generation in this rebuild, like `PruneRuntime`.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| WarmError::Runtime(format!("build runtime: {e}")))?;
+        let platform = self.platform(&runtime)?;
+        let config = Config::default();
+        let udt_registry = resolve_udt_registry(schema);
+
+        let mut opened = Vec::with_capacity(added.len());
+        for entry in added {
+            if cancel.is_cancelled() {
+                return Err(WarmError::Cancelled);
+            }
+            let reader = open_one_reader(
+                &runtime,
+                &entry.path,
+                &config,
+                Arc::clone(&platform),
+                udt_registry.clone(),
+            )?;
+            let footprint = account_footprint(&entry.path);
+            opened.push(WarmReader {
+                id: entry.id,
+                reader: Arc::new(reader),
+                footprint,
+                last_access: 0,
+            });
+        }
+        Ok(opened)
+    }
+
+    /// Lazily build + cache the shared [`Platform`] used to open readers.
+    fn platform(&self, runtime: &tokio::runtime::Runtime) -> Result<Arc<Platform>, WarmError> {
+        let mut guard = self.platform.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(p) = guard.as_ref() {
+            return Ok(Arc::clone(p));
+        }
+        let platform = runtime
+            .block_on(Platform::new(&Config::default()))
+            .map_err(|e| WarmError::Runtime(format!("build platform: {e}")))?;
+        let platform = Arc::new(platform);
+        *guard = Some(Arc::clone(&platform));
+        Ok(platform)
+    }
+
+    fn lock_inner(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Open ONE reader and set its UDT registry BEFORE it is shared (the #2345
+/// contract). Proves the registry is present via `has_udt_registry`; a reader
+/// that somehow lost it is a hard error rather than a silent `Blob`-decoding trap.
+fn open_one_reader(
+    runtime: &tokio::runtime::Runtime,
+    path: &Path,
+    config: &Config,
+    platform: Arc<Platform>,
+    udt_registry: UdtRegistry,
+) -> Result<SSTableReader, WarmError> {
+    let mut reader = runtime
+        .block_on(SSTableReader::open(path, config, platform))
+        .map_err(|source| WarmError::Open {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    reader.set_udt_registry(udt_registry);
+    debug_assert!(
+        reader.has_udt_registry(),
+        "warm reader must be UDT-registry-aware before sharing (#2345/#1234)"
+    );
+    Ok(reader)
+}
+
+/// Resolve the UDT registry to wire onto a warm reader (the #2345 contract).
+///
+/// A Flight ticket carries a single-table DDL with no `CREATE TYPE` bodies, so
+/// the authoritative registry is the Cassandra-5 default set — the same authority
+/// the cold path had. The plumbing is present and provable so a reader whose
+/// SSTable holds frozen/nested UDT cells is decoded structurally (never dropped
+/// as `Blob`, the #1234 class) once a registry with those bodies is available.
+fn resolve_udt_registry(_schema: &TableSchema) -> UdtRegistry {
+    UdtRegistry::with_cassandra5_defaults()
+}
+
+// Registry integration tests over real in-process SSTables (issue #2310), in a
+// separate file (campsite rule) loaded here.
+#[cfg(test)]
+#[path = "registry_tests.rs"]
+mod registry_tests;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_key_equality_and_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(TableKey::new("ks", "t"));
+        assert!(set.contains(&TableKey::new("ks", "t")));
+        assert!(!set.contains(&TableKey::new("ks", "other")));
+    }
+
+    #[test]
+    fn resolve_udt_registry_is_non_null() {
+        // The warm open must always have a registry to set (never `None` → the
+        // #1234 silent-Blob trap). A defaults registry is a valid, non-panicking
+        // authority.
+        let schema = crate::testutil::simple_schema();
+        let _reg = resolve_udt_registry(&schema);
+    }
+}

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -206,7 +206,11 @@ impl WarmTableRegistry {
                     return Ok(hit);
                 }
                 let entries = probe::enumerate_generations(dir)?;
-                let manifest = snapshot_mode.then(|| probe::read_manifest(dir)).flatten();
+                let manifest = if snapshot_mode {
+                    probe::read_manifest_checked(dir)?
+                } else {
+                    None
+                };
                 self.finish_enumerated(key, ddl_hash, schema, entries, manifest, cancel)
             }
             ProbeOutcome::Enumerated {

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -8,19 +8,24 @@
 //! mutates nothing and in-flight requests holding `Arc` clones complete against
 //! the pre-swap set.
 //!
-//! ## UDT-registry contract (WS1 #2345, from the #2346 review)
+//! ## UDT-registry posture — identical to the cold path (WS1 #2345, follow-up #2349)
 //!
 //! The reader-based merge seam `KWayMerger::new_from_readers` takes NO
 //! `udt_registry` parameter (a shared `Arc` reader has no `&mut self` for
-//! `set_udt_registry`). So the registry MUST open each reader WITH its UDT
-//! registry already resolved BEFORE wrapping it in `Arc` — otherwise a
-//! frozen/nested UDT cell silently decodes as `Blob` (the #1234 data-loss class),
-//! NOT an error. [`open_one_reader`] resolves + sets the registry and asserts it
-//! is present via `SSTableReader::has_udt_registry`. (A Flight ticket carries a
-//! single-table DDL with no `CREATE TYPE` bodies, so the resolved registry is the
-//! Cassandra-5 default set — the same authority the cold path had; the plumbing
-//! is present and provable so a future ticket that DOES carry UDT bodies is
-//! decoded structurally, never dropped.)
+//! `set_udt_registry`), so a reader must be opened WITH its registry already
+//! resolved BEFORE it is wrapped in `Arc`. The cold Flight path, however, opens
+//! its readers via `KWayMerger::new_cancellable`, which passes `udt_registry =
+//! None` — so the cold path currently decodes WITHOUT a UDT registry. To keep the
+//! spec non-goal (warm is a PARSE-COST change only, never a read-semantics
+//! change), the warm path opens readers with the EXACTLY SAME posture: no UDT
+//! registry. [`open_one_reader`] therefore does NOT set a registry, and both
+//! paths hand the merge readers with `has_udt_registry() == false`. Parity is
+//! guaranteed by identical posture, not by matching a non-null authority.
+//!
+//! Wiring a real UDT registry into BOTH paths (so a frozen/nested UDT cell in a
+//! collection decodes structurally instead of as `Blob`, the #1234 data-loss
+//! class) is tracked as a single follow-up, issue #2349 — it must land for the
+//! cold path and the warm path together so they never diverge.
 //!
 //! ## File-lifetime contract (from `from_readers.rs`)
 //!
@@ -31,11 +36,11 @@
 //! outlives the per-query dir (the link keeps the inode alive), so the contract
 //! is satisfied trivially.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, Mutex, PoisonError};
 
-use cqlite_core::schema::{TableSchema, UdtRegistry};
+use cqlite_core::schema::TableSchema;
 use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::{Config, Platform};
 
@@ -112,6 +117,18 @@ pub struct WarmTableRegistry {
     platform: Mutex<Option<Arc<Platform>>>,
     budget_bytes: u64,
     metrics: Arc<WarmMetrics>,
+    /// Test-only rendezvous invoked inside [`Self::rebuild`] AFTER the added
+    /// generations are opened but BEFORE the swap lock is taken — lets the
+    /// concurrent-same-key-rebuild race test hold two threads "past the probe,
+    /// before either swaps" deterministically. `None` (a no-op) in production.
+    #[cfg(test)]
+    swap_barrier: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+    /// Test-only hook invoked at the TOP of each [`Self::open_added`] loop
+    /// iteration (before its cancel check) — lets the mid-rebuild cancellation
+    /// test trip the cancel flag BETWEEN two added-generation opens. `None` in
+    /// production.
+    #[cfg(test)]
+    open_barrier: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
 }
 
 impl Default for WarmTableRegistry {
@@ -134,6 +151,10 @@ impl WarmTableRegistry {
             platform: Mutex::new(None),
             budget_bytes: budget_bytes.max(1),
             metrics: Arc::new(WarmMetrics::default()),
+            #[cfg(test)]
+            swap_barrier: Mutex::new(None),
+            #[cfg(test)]
+            open_barrier: Mutex::new(None),
         }
     }
 
@@ -315,6 +336,11 @@ impl WarmTableRegistry {
         };
         let reader_opens = opened.len() as u64;
 
+        // Test-only rendezvous: hold here (past the probe + open, before the swap)
+        // so a concurrent same-key rebuild can be driven deterministically.
+        #[cfg(test)]
+        self.run_swap_barrier();
+
         // Swap atomically under the write guard.
         let mut inner = self.lock_inner();
         let tick = inner.next_tick();
@@ -343,9 +369,27 @@ impl WarmTableRegistry {
         }
 
         // NEW reader set = kept + newly-opened, newest-generation-first.
+        //
+        // DEDUP by generation identity under this swap lock (fail-closed against a
+        // concurrent same-key rebuild race): two requests can each MISS for the
+        // same table, both compute the SAME added delta from a pre-swap snapshot,
+        // and both open the same added generation OUTSIDE the lock. The first
+        // swap installs it; when THIS (second) swap re-reads `prev`, `kept` now
+        // already carries that generation (it is in `current_set`), and our own
+        // `opened` carries a SECOND copy. Keeping both would double-count the
+        // footprint and hand out two `WarmReader`s per inode → permanent
+        // `used_bytes` drift → spurious LRU evictions. So we count/keep a newly
+        // opened reader ONLY when its generation is not already present.
         let mut readers = kept;
+        let mut present: HashSet<GenerationId> = readers.iter().map(|r| r.id).collect();
         let mut added_bytes: u64 = 0;
         for mut r in opened {
+            if !present.insert(r.id) {
+                // A concurrent rebuild already installed this generation; its
+                // footprint is already accounted. Drop our duplicate copy (the
+                // `Arc<SSTableReader>` is released here).
+                continue;
+            }
             r.last_access = tick;
             added_bytes = added_bytes.saturating_add(r.footprint);
             readers.push(r);
@@ -420,13 +464,14 @@ impl WarmTableRegistry {
         evicted
     }
 
-    /// Open the ADDED generations, resolving each reader's UDT registry BEFORE
-    /// wrapping in `Arc` (the #2345 contract). Fail-closed: any open error (or a
-    /// cancellation) returns immediately WITHOUT partial state.
+    /// Open the ADDED generations. Fail-closed: any open error (or a
+    /// cancellation) returns immediately WITHOUT partial state. Readers are opened
+    /// with the SAME UDT-registry posture as the cold path (none — see the module
+    /// doc; #2349 wires a real registry into both paths together).
     fn open_added(
         &self,
         added: &[&GenerationEntry],
-        schema: &TableSchema,
+        _schema: &TableSchema,
         cancel: &CancelFlag,
     ) -> Result<Vec<WarmReader>, WarmError> {
         if added.is_empty() {
@@ -440,20 +485,15 @@ impl WarmTableRegistry {
             .map_err(|e| WarmError::Runtime(format!("build runtime: {e}")))?;
         let platform = self.platform(&runtime)?;
         let config = Config::default();
-        let udt_registry = resolve_udt_registry(schema);
 
         let mut opened = Vec::with_capacity(added.len());
         for entry in added {
+            #[cfg(test)]
+            self.run_open_barrier();
             if cancel.is_cancelled() {
                 return Err(WarmError::Cancelled);
             }
-            let reader = open_one_reader(
-                &runtime,
-                &entry.path,
-                &config,
-                Arc::clone(&platform),
-                udt_registry.clone(),
-            )?;
+            let reader = open_one_reader(&runtime, &entry.path, &config, Arc::clone(&platform))?;
             let footprint = account_footprint(&entry.path);
             opened.push(WarmReader {
                 id: entry.id,
@@ -482,41 +522,103 @@ impl WarmTableRegistry {
     fn lock_inner(&self) -> std::sync::MutexGuard<'_, Inner> {
         self.inner.lock().unwrap_or_else(PoisonError::into_inner)
     }
+
+    /// Install the test-only swap rendezvous (see the field doc).
+    #[cfg(test)]
+    pub(crate) fn set_swap_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
+        *self
+            .swap_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(f);
+    }
+
+    /// Invoke the swap rendezvous if one is installed (clone the `Arc` out first
+    /// so it is called WITHOUT holding the `swap_barrier` lock).
+    #[cfg(test)]
+    fn run_swap_barrier(&self) {
+        let hook = self
+            .swap_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+        if let Some(f) = hook {
+            f();
+        }
+    }
+
+    /// Install the test-only per-open rendezvous (see the field doc).
+    #[cfg(test)]
+    pub(crate) fn set_open_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
+        *self
+            .open_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(f);
+    }
+
+    /// Invoke the per-open rendezvous if one is installed.
+    #[cfg(test)]
+    fn run_open_barrier(&self) {
+        let hook = self
+            .open_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+        if let Some(f) = hook {
+            f();
+        }
+    }
+
+    /// Test-only: the total accounted footprint (`used_bytes`).
+    #[cfg(test)]
+    pub(crate) fn debug_used_bytes(&self) -> u64 {
+        self.lock_inner().used_bytes
+    }
+
+    /// Test-only: the number of cached `WarmReader`s for `key` (counts DUPLICATES,
+    /// so the race test can catch a double-installed generation).
+    #[cfg(test)]
+    pub(crate) fn debug_reader_count(&self, key: &TableKey) -> usize {
+        self.lock_inner()
+            .tables
+            .get(key)
+            .map(|t| t.readers.len())
+            .unwrap_or(0)
+    }
+
+    /// Test-only: the number of DISTINCT generation ids cached for `key`.
+    #[cfg(test)]
+    pub(crate) fn debug_distinct_gen_count(&self, key: &TableKey) -> usize {
+        self.lock_inner()
+            .tables
+            .get(key)
+            .map(|t| t.readers.iter().map(|r| r.id).collect::<HashSet<_>>().len())
+            .unwrap_or(0)
+    }
 }
 
-/// Open ONE reader and set its UDT registry BEFORE it is shared (the #2345
-/// contract). Proves the registry is present via `has_udt_registry`; a reader
-/// that somehow lost it is a hard error rather than a silent `Blob`-decoding trap.
+/// Open ONE reader with the SAME UDT-registry posture as the cold path.
+///
+/// The cold Flight path (`KWayMerger::new_cancellable`) opens readers with
+/// `udt_registry = None`, so — to keep warm a parse-cost-only change with no
+/// read-semantics divergence — this does NOT set a registry either. Wiring a real
+/// registry into BOTH paths together is issue #2349; see the module doc.
 fn open_one_reader(
     runtime: &tokio::runtime::Runtime,
     path: &Path,
     config: &Config,
     platform: Arc<Platform>,
-    udt_registry: UdtRegistry,
 ) -> Result<SSTableReader, WarmError> {
-    let mut reader = runtime
+    let reader = runtime
         .block_on(SSTableReader::open(path, config, platform))
         .map_err(|source| WarmError::Open {
             path: path.to_path_buf(),
             source,
         })?;
-    reader.set_udt_registry(udt_registry);
     debug_assert!(
-        reader.has_udt_registry(),
-        "warm reader must be UDT-registry-aware before sharing (#2345/#1234)"
+        !reader.has_udt_registry(),
+        "warm reader must match the cold path's no-UDT-registry posture (#2349)"
     );
     Ok(reader)
-}
-
-/// Resolve the UDT registry to wire onto a warm reader (the #2345 contract).
-///
-/// A Flight ticket carries a single-table DDL with no `CREATE TYPE` bodies, so
-/// the authoritative registry is the Cassandra-5 default set — the same authority
-/// the cold path had. The plumbing is present and provable so a reader whose
-/// SSTable holds frozen/nested UDT cells is decoded structurally (never dropped
-/// as `Blob`, the #1234 class) once a registry with those bodies is available.
-fn resolve_udt_registry(_schema: &TableSchema) -> UdtRegistry {
-    UdtRegistry::with_cassandra5_defaults()
 }
 
 // Registry integration tests over real in-process SSTables (issue #2310), in a
@@ -536,14 +638,5 @@ mod tests {
         set.insert(TableKey::new("ks", "t"));
         assert!(set.contains(&TableKey::new("ks", "t")));
         assert!(!set.contains(&TableKey::new("ks", "other")));
-    }
-
-    #[test]
-    fn resolve_udt_registry_is_non_null() {
-        // The warm open must always have a registry to set (never `None` → the
-        // #1234 silent-Blob trap). A defaults registry is a valid, non-panicking
-        // authority.
-        let schema = crate::testutil::simple_schema();
-        let _reg = resolve_udt_registry(&schema);
     }
 }

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -289,6 +289,14 @@ impl WarmTableRegistry {
     /// ADDED generations (BEFORE any swap), keep UNCHANGED parsed state, drop
     /// REMOVED, swap atomically. Any open failure returns the typed error with the
     /// previously warm set fully intact.
+    ///
+    /// Epoch guard (issue #2310, roborev 1639): right before the swap, re-checks
+    /// that the live cache entry's generation set still matches
+    /// `probe_start_set` (the state THIS delta was computed against). If a
+    /// concurrent rebuild already installed a fresher result for the same key in
+    /// the meantime, this rebuild discards its own (now-stale-probe) opened
+    /// readers and hands back the current, fresher set instead of overwriting
+    /// newer state with an older probe result.
     #[allow(clippy::too_many_arguments)]
     fn rebuild(
         &self,
@@ -306,7 +314,9 @@ impl WarmTableRegistry {
 
         // Which generations are already warm (and DDL still matches)? Snapshot
         // their ids so we open only the delta. Held briefly; opening happens
-        // OUTSIDE the lock (slow I/O).
+        // OUTSIDE the lock (slow I/O). `probe_start_set` is what THIS rebuild's
+        // delta was computed against — the epoch guard below re-checks it hasn't
+        // moved by the time we reach the swap (roborev 1639).
         let cached_ids: Vec<GenerationId> = {
             let inner = self.lock_inner();
             inner
@@ -316,6 +326,7 @@ impl WarmTableRegistry {
                 .map(|t| t.readers.iter().map(|r| r.id).collect())
                 .unwrap_or_default()
         };
+        let probe_start_set = GenerationSet::from_ids(cached_ids.clone());
 
         // ADDED = present now, not already warm. Open them (fail-closed).
         let added: Vec<&GenerationEntry> = entries
@@ -343,6 +354,52 @@ impl WarmTableRegistry {
 
         // Swap atomically under the write guard.
         let mut inner = self.lock_inner();
+
+        // Epoch guard (issue #2310, roborev 1639): if the LIVE entry's DDL
+        // matches ours but its generation set has already moved past
+        // `probe_start_set` — the state THIS rebuild's delta was computed
+        // against — a concurrent rebuild already installed a fresher result
+        // under this same key while we were opening our (now stale-probe)
+        // delta. Overwriting it would regress the cache to an older view, so we
+        // DISCARD our opened readers (dropped below, never swapped in) and hand
+        // back the CURRENT, already-fresher set instead: it satisfies this
+        // request (it is at least as fresh as what we probed). A live entry
+        // with a DIFFERENT ddl_hash, or no live entry at all, is not a valid
+        // fresher substitute — those fall through to the normal rebuild below
+        // exactly as before. Folded into the `FailClosedRetained` metric
+        // (adjudicated: "the previously-installed — here, concurrently
+        // NEWER — set was retained instead of being overwritten by an older
+        // probe result") rather than adding a new bounded label.
+        if let Some(live) = inner.tables.get(key) {
+            if live.ddl_hash == ddl_hash && live.generation_set() != probe_start_set {
+                let tick = inner.next_tick();
+                let entry = inner.tables.get_mut(key).expect("checked Some above");
+                for r in &mut entry.readers {
+                    r.last_access = tick;
+                }
+                let current = WarmSet {
+                    readers: entry
+                        .readers
+                        .iter()
+                        .map(|r| Arc::clone(&r.reader))
+                        .collect(),
+                    schema: Arc::clone(&entry.schema),
+                    outcome: RefreshOutcome::FailClosedRetained,
+                    reader_opens: 0,
+                };
+                drop(inner);
+                // `opened` (our now-discarded readers) drops here, releasing
+                // their `Arc<SSTableReader>`s without ever touching `used_bytes`
+                // — the work of opening them was still real I/O, so it still
+                // counts toward the reader-opens work-done probe.
+                drop(opened);
+                self.metrics.record_reader_opens(reader_opens);
+                self.metrics
+                    .record_refresh(RefreshOutcome::FailClosedRetained);
+                return Ok(current);
+            }
+        }
+
         let tick = inner.next_tick();
         let mut freed: u64 = 0;
         let mut removed_count: u64 = 0;

--- a/cqlite-flight/src/warm/registry_tests.rs
+++ b/cqlite-flight/src/warm/registry_tests.rs
@@ -1,0 +1,280 @@
+//! Registry integration tests over REAL in-process SSTables (issue #2310).
+//!
+//! These prove the spec requirements the registry owns end to end: the
+//! generation-identity key across snapshot dirs (Req 1), fail-closed rebuild
+//! (Req 4), LRU + removed-on-disk eviction (Req 5), and the #2345 UDT-registry
+//! guard. Loaded via `#[path]` from `registry.rs` to keep that file within the
+//! campsite threshold. Plain `#[test]`s: `build_sstables` drives its own runtime,
+//! and `warm_readers` builds its own — nesting a `#[tokio::test]` runtime would
+//! panic.
+
+use std::sync::Arc;
+
+use crate::cancel::CancelFlag;
+use crate::testutil::{
+    build_sstables, make_snapshot, simple_schema, write_row, KS, SIMPLE_DDL, TBL,
+};
+use crate::warm::{RefreshOutcome, TableKey, WarmError, WarmTableRegistry};
+
+fn key() -> TableKey {
+    TableKey::new(KS, TBL)
+}
+
+fn ddl() -> u64 {
+    crate::warm::ddl_hash(SIMPLE_DDL)
+}
+
+/// Requirement 1 (generation-identity key): the SAME inodes reached through TWO
+/// different snapshot hardlink dirs resolve to ONE warm entry — the second is a
+/// warm HIT with zero further reader opens. A path key would miss here.
+#[test]
+fn cross_snapshot_dirs_share_one_warm_entry() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(
+        &schema,
+        vec![
+            vec![write_row(1, "a", 1, 100)],
+            vec![write_row(2, "b", 2, 100)],
+        ],
+    );
+    // Two per-query snapshots over the SAME underlying inodes (hardlinks).
+    let snap1 = make_snapshot(&table_dir, "snap1");
+    let snap2 = make_snapshot(&table_dir, "snap2");
+
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+
+    let w1 = reg
+        .warm_readers(&key(), ddl(), &schema, &snap1, Some("snap1"), &cancel)
+        .expect("first snapshot warms");
+    assert_eq!(w1.outcome, RefreshOutcome::RebuiltDelta, "first is a build");
+    let opens_after_first = reg.metrics().snapshot().reader_opens;
+    assert!(opens_after_first >= 2, "both generations opened cold");
+
+    let w2 = reg
+        .warm_readers(&key(), ddl(), &schema, &snap2, Some("snap2"), &cancel)
+        .expect("second snapshot (different dir, same inodes)");
+    assert_eq!(
+        w2.outcome,
+        RefreshOutcome::Unchanged,
+        "same inodes via a different snapshot dir → warm hit, not a path miss"
+    );
+    let m = reg.metrics().snapshot();
+    assert_eq!(m.hits, 1, "the second snapshot request is a warm hit");
+    assert_eq!(
+        m.reader_opens, opens_after_first,
+        "a cross-snapshot warm hit opens ZERO further readers"
+    );
+    assert_eq!(w2.readers.len(), w1.readers.len(), "same reader set");
+}
+
+/// The #2345 UDT-registry guard: every reader the registry hands out was opened
+/// WITH its UDT registry resolved (never the #1234 silent-`Blob` trap).
+#[test]
+fn warm_readers_are_udt_registry_aware() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let reg = WarmTableRegistry::new();
+    let w = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
+        .expect("warms");
+    assert!(!w.readers.is_empty(), "opened at least one reader");
+    for r in &w.readers {
+        assert!(
+            r.has_udt_registry(),
+            "a warm reader must carry a UDT registry before it is shared (#2345)"
+        );
+    }
+}
+
+/// Requirement 4 (fail-closed rebuild): a newly-added generation that cannot be
+/// opened returns the typed error and leaves the previously warm set fully
+/// intact — no partial view.
+#[test]
+fn fail_closed_rebuild_retains_prior_warm_set() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+
+    // Warm the valid set.
+    let w1 = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("warms the valid generation");
+    let opens_after_first = reg.metrics().snapshot().reader_opens;
+
+    // Add a CORRUPT generation on disk: clone the valid gen-1 components to a new
+    // generation, then corrupt its `Statistics.db` — a #1626 hard-fail on open,
+    // exactly the fail-closed rebuild scenario (design Test strategy).
+    for entry in std::fs::read_dir(&table_dir).unwrap().flatten() {
+        let name = entry.file_name();
+        let name = name.to_str().unwrap();
+        if let Some(suffix) = name.strip_prefix("nb-1-big-") {
+            std::fs::copy(entry.path(), table_dir.join(format!("nb-999-big-{suffix}"))).unwrap();
+        }
+    }
+    std::fs::write(
+        table_dir.join("nb-999-big-Statistics.db"),
+        b"corrupt statistics",
+    )
+    .unwrap();
+
+    let err = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect_err("a corrupt added generation must fail the rebuild");
+    assert!(
+        matches!(err, WarmError::Open { .. }),
+        "fail-closed rebuild surfaces the typed Open error, got {err:?}"
+    );
+    let m = reg.metrics().snapshot();
+    assert_eq!(
+        m.refresh_fail_closed_retained, 1,
+        "the fail-closed retention outcome is recorded"
+    );
+
+    // The previously warm set is still intact: remove the corrupt file and prove
+    // the original generation still serves as a warm hit (its parsed state was
+    // never dropped by the failed rebuild).
+    std::fs::remove_file(table_dir.join("nb-999-big-Data.db")).unwrap();
+    let w2 = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("prior set still serves");
+    assert_eq!(
+        w2.outcome,
+        RefreshOutcome::Unchanged,
+        "prior set intact → hit"
+    );
+    assert_eq!(
+        reg.metrics().snapshot().reader_opens,
+        opens_after_first,
+        "the failed rebuild opened no reader that survived; the retained set needs none"
+    );
+    let _ = w1;
+}
+
+/// Requirement 5 (removed-on-disk): a generation that a rebuild finds gone is
+/// evicted immediately (recorded as an evict), and the result reflects the
+/// remaining set.
+#[test]
+fn removed_generation_is_evicted_immediately() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(
+        &schema,
+        vec![
+            vec![write_row(1, "a", 1, 100)],
+            vec![write_row(2, "b", 2, 100)],
+        ],
+    );
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+    let w1 = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("warms two generations");
+    assert_eq!(w1.readers.len(), 2);
+
+    // Delete the OLDEST generation's Data.db (generation 1 — the first flush).
+    let victim = std::fs::read_dir(&table_dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("nb-1-") && n.ends_with("-Data.db"))
+        })
+        .expect("gen-1 Data.db present");
+    std::fs::remove_file(&victim).unwrap();
+
+    let w2 = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("rebuild drops the removed generation");
+    assert_eq!(w2.readers.len(), 1, "the removed generation is gone");
+    assert!(
+        reg.metrics().snapshot().evicts >= 1,
+        "the removed-on-disk generation is evicted immediately"
+    );
+}
+
+/// Requirement 5 (LRU byte budget): warming distinct tables past a tiny budget
+/// evicts the least-recently-used entry; an evicted entry re-parses on its next
+/// request (a fresh miss/open).
+#[test]
+fn lru_evicts_when_over_budget() {
+    let schema = simple_schema();
+    // Two separate tables, each one SSTable. `warm_readers` keys per TableKey.
+    let (_t_a, _d_a, dir_a) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let (_t_b, _d_b, dir_b) = build_sstables(&schema, vec![vec![write_row(1, "b", 1, 100)]]);
+
+    // Budget = 1 byte: any second generation forces the first out.
+    let reg = WarmTableRegistry::with_budget(1);
+    let cancel = CancelFlag::new();
+    let key_a = TableKey::new(KS, "table_a");
+    let key_b = TableKey::new(KS, "table_b");
+
+    reg.warm_readers(&key_a, ddl(), &schema, &dir_a, None, &cancel)
+        .expect("warm A");
+    reg.warm_readers(&key_b, ddl(), &schema, &dir_b, None, &cancel)
+        .expect("warm B evicts A");
+    assert!(
+        reg.metrics().snapshot().evicts >= 1,
+        "warming B over a 1-byte budget evicts LRU entry A"
+    );
+
+    // A must re-parse (a fresh miss + open) since it was evicted.
+    let opens_before = reg.metrics().snapshot().reader_opens;
+    let wa = reg
+        .warm_readers(&key_a, ddl(), &schema, &dir_a, None, &cancel)
+        .expect("A re-parses after eviction");
+    assert_eq!(
+        wa.outcome,
+        RefreshOutcome::RebuiltDelta,
+        "an evicted entry is a miss on its next request"
+    );
+    assert!(
+        reg.metrics().snapshot().reader_opens > opens_before,
+        "re-warming an evicted entry re-opens its reader"
+    );
+}
+
+/// Requirement 7 (cancellation): a pre-cancelled warm lookup does ZERO probe /
+/// rebuild work and returns the distinct `Cancelled` variant.
+#[test]
+fn pre_cancelled_warm_lookup_does_zero_work() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+    cancel.cancel();
+    let err = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect_err("a pre-cancelled lookup must not work");
+    assert!(matches!(err, WarmError::Cancelled), "got {err:?}");
+    let m = reg.metrics().snapshot();
+    assert_eq!(m.reader_opens, 0, "zero readers opened");
+    assert_eq!(m.misses + m.hits, 0, "no build, no hit");
+}
+
+/// A live-mode second request over an unchanged generation set is a warm hit
+/// (Requirement 2 at the registry level) — the authoritative listing matched.
+#[test]
+fn unchanged_live_set_is_a_warm_hit() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+    let _ = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("first");
+    let opens = reg.metrics().snapshot().reader_opens;
+    let w2 = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("second");
+    assert_eq!(w2.outcome, RefreshOutcome::Unchanged);
+    assert_eq!(
+        reg.metrics().snapshot().reader_opens,
+        opens,
+        "unchanged live set → warm hit → zero further opens"
+    );
+    // Keep the reader set usable (Arc clones).
+    let _keep: Vec<Arc<_>> = w2.readers;
+}

--- a/cqlite-flight/src/warm/registry_tests.rs
+++ b/cqlite-flight/src/warm/registry_tests.rs
@@ -258,6 +258,102 @@ fn concurrent_same_key_rebuild_dedups_readers_and_bytes() {
     drop(temp);
 }
 
+/// Epoch guard (issue #2310, roborev 1639): a SLOW rebuild ("A") whose own
+/// disk-probe ran BEFORE a second generation landed — so A's `current_set`
+/// only knows about gen1 — must NOT be allowed to reach the swap after a
+/// FASTER, newer rebuild ("B", probed AFTER gen2 landed) already installed
+/// `{gen1, gen2}`. Without the epoch guard, A's stale `current_set = {gen1}`
+/// would make the ORIGINAL swap logic treat B's freshly-installed gen2 as
+/// "removed" (not in A's `current_set`) and EVICT it — silently losing a live
+/// generation. `open_barrier` pauses A (by thread name) right after its OWN
+/// probe/before it opens gen1, so B can land gen2 on disk and fully complete
+/// its rebuild+swap before A is released to attempt its (now stale) swap.
+#[test]
+fn slow_rebuild_does_not_overwrite_a_faster_newer_swap() {
+    use std::sync::Barrier;
+    use std::thread;
+
+    let schema = simple_schema();
+    let (temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let reg = Arc::new(WarmTableRegistry::new());
+
+    let arrived = Arc::new(Barrier::new(2));
+    let resume = Arc::new(Barrier::new(2));
+    {
+        let arrived = Arc::clone(&arrived);
+        let resume = Arc::clone(&resume);
+        reg.set_open_barrier(Arc::new(move || {
+            // Only the slow-A thread pauses here; B's calls to the same global
+            // hook no-op and proceed immediately.
+            if thread::current().name() == Some("slow-A") {
+                arrived.wait();
+                resume.wait();
+            }
+        }));
+    }
+
+    let a_reg = Arc::clone(&reg);
+    let a_schema = schema.clone();
+    let a_dir = table_dir.clone();
+    let a_handle = thread::Builder::new()
+        .name("slow-A".to_string())
+        .spawn(move || {
+            a_reg.warm_readers(&key(), ddl(), &a_schema, &a_dir, None, &CancelFlag::new())
+        })
+        .expect("spawn slow-A");
+
+    // Block until A has probed (sees ONLY gen1) and paused before opening it.
+    arrived.wait();
+
+    // gen2 lands on disk AFTER A's probe. B (this thread) probes, opens, and
+    // swaps to completion BEFORE A is released — B's install is the "newer"
+    // state A's stale probe never saw.
+    append_gen(&table_dir, &schema, vec![write_row(2, "b", 2, 100)]);
+    let b_result = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
+        .expect("fast rebuild B installs the newer set");
+    assert_eq!(b_result.readers.len(), 2, "B installs both generations");
+
+    // Release A: it opens its own (already-stale) gen1 copy and attempts to
+    // swap against its stale current_set={gen1}.
+    resume.wait();
+    let a_result = a_handle
+        .join()
+        .expect("thread")
+        .expect("A's rebuild completes (discarded, not erroring)");
+
+    assert_eq!(
+        a_result.readers.len(),
+        2,
+        "A must be served the CURRENT (B's) fresher two-generation set, not \
+         have evicted gen2 based on its own stale one-generation probe"
+    );
+    assert_eq!(
+        a_result.outcome,
+        RefreshOutcome::FailClosedRetained,
+        "the discarded-stale-rebuild path is folded into FailClosedRetained \
+         (adjudicated, documented in warm/metrics.rs)"
+    );
+
+    // No reader churn: A must be served the IDENTICAL (B's) Arc<SSTableReader>s,
+    // never a freshly-reopened duplicate for either generation.
+    let mut a_ptrs: Vec<*const SSTableReader> = a_result.readers.iter().map(Arc::as_ptr).collect();
+    let mut b_ptrs: Vec<*const SSTableReader> = b_result.readers.iter().map(Arc::as_ptr).collect();
+    a_ptrs.sort();
+    b_ptrs.sort();
+    assert_eq!(
+        a_ptrs, b_ptrs,
+        "A's served readers must be the SAME Arcs as B's installed ones (no churn)"
+    );
+
+    assert_eq!(
+        reg.debug_reader_count(&key()),
+        2,
+        "the final cached set is B's two generations — gen2 was never evicted"
+    );
+    drop(temp);
+}
+
 /// Requirement 4 (fail-closed rebuild): a newly-added generation that cannot be
 /// opened returns the typed error and leaves the previously warm set fully
 /// intact — no partial view.

--- a/cqlite-flight/src/warm/registry_tests.rs
+++ b/cqlite-flight/src/warm/registry_tests.rs
@@ -8,9 +8,15 @@
 //! and `warm_readers` builds its own — nesting a `#[tokio::test]` runtime would
 //! panic.
 
+use std::path::Path;
 use std::sync::Arc;
 
+use cqlite_core::schema::TableSchema;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::storage::write_engine::Mutation;
+
 use crate::cancel::CancelFlag;
+use crate::producer::MergeProducer;
 use crate::testutil::{
     build_sstables, make_snapshot, simple_schema, write_row, KS, SIMPLE_DDL, TBL,
 };
@@ -22,6 +28,49 @@ fn key() -> TableKey {
 
 fn ddl() -> u64 {
     crate::warm::ddl_hash(SIMPLE_DDL)
+}
+
+/// Decode a warm reader set into its sorted `name` column values — proves ROW
+/// CORRECTNESS (not just that a reader opened) by driving the SAME merge path
+/// `do_get` uses ([`MergeProducer::produce_streaming_from_readers_to_vec`]).
+fn decode_names(schema: &TableSchema, readers: Vec<Arc<SSTableReader>>) -> Vec<String> {
+    use arrow::array::{Array, StringArray};
+    let producer = MergeProducer::new(schema.clone(), 1024).expect("producer");
+    let batches = producer
+        .produce_streaming_from_readers_to_vec(readers, &CancelFlag::new())
+        .expect("decode readers");
+    let mut out = Vec::new();
+    for b in &batches {
+        let names = b
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..names.len() {
+            out.push(names.value(i).to_string());
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Append one more SSTable generation into an existing live table dir (a fresh
+/// write-engine flush pointed at the SAME data root).
+fn append_gen(table_dir: &Path, schema: &TableSchema, rows: Vec<Mutation>) {
+    use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+    let data_dir = table_dir.parent().unwrap().parent().unwrap().to_path_buf();
+    let wal = table_dir.join(".wal_append_reg");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let config = WriteEngineConfig::new(data_dir, wal, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for m in rows {
+        engine.write(m).expect("write");
+    }
+    rt.block_on(engine.flush()).expect("flush").expect("info");
 }
 
 /// Requirement 1 (generation-identity key): the SAME inodes reached through TWO
@@ -68,12 +117,20 @@ fn cross_snapshot_dirs_share_one_warm_entry() {
     assert_eq!(w2.readers.len(), w1.readers.len(), "same reader set");
 }
 
-/// The #2345 UDT-registry guard: every reader the registry hands out was opened
-/// WITH its UDT registry resolved (never the #1234 silent-`Blob` trap).
+/// Warm/cold UDT-registry PARITY (spec non-goal: warm is a parse-cost change
+/// only, never a read-semantics change; #2349): the warm path must open readers
+/// with the SAME UDT-registry posture as the cold path. The cold Flight path
+/// (`KWayMerger::new_cancellable`) opens readers with `udt_registry = None`, so a
+/// warm reader must ALSO have no registry. Both are `has_udt_registry() == false`
+/// today; they flip together when #2349 wires a real registry into both paths.
 #[test]
-fn warm_readers_are_udt_registry_aware() {
+fn warm_and_cold_reader_udt_posture_identical() {
+    use cqlite_core::{Config, Platform};
+
     let schema = simple_schema();
     let (_temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+
+    // WARM posture: readers handed out by the registry.
     let reg = WarmTableRegistry::new();
     let w = reg
         .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
@@ -81,10 +138,124 @@ fn warm_readers_are_udt_registry_aware() {
     assert!(!w.readers.is_empty(), "opened at least one reader");
     for r in &w.readers {
         assert!(
-            r.has_udt_registry(),
-            "a warm reader must carry a UDT registry before it is shared (#2345)"
+            !r.has_udt_registry(),
+            "a warm reader must match the cold path's no-UDT-registry posture (#2349)"
         );
     }
+
+    // COLD posture: open a reader exactly as `KWayMerger::new_cancellable` does
+    // (plain `SSTableReader::open`, never `set_udt_registry`).
+    let data_db = std::fs::read_dir(&table_dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .expect("a Data.db exists");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let config = Config::default();
+    let cold = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&config).await.unwrap());
+        SSTableReader::open(&data_db, &config, platform)
+            .await
+            .unwrap()
+    });
+    assert_eq!(
+        cold.has_udt_registry(),
+        w.readers[0].has_udt_registry(),
+        "warm and cold readers must share one UDT-registry posture (parity, #2349)"
+    );
+    assert!(
+        !cold.has_udt_registry(),
+        "the cold path opens readers without a UDT registry"
+    );
+}
+
+/// Fix A (concurrent same-key rebuild race): two concurrent MISSES for ONE table
+/// each open the SAME added generations OUTSIDE the swap lock; the second swap
+/// must NOT keep both copies. A test-only rendezvous holds both threads past the
+/// probe+open, before EITHER swaps, so the race is deterministic. Asserts exactly
+/// ONE cached `WarmReader` per generation and `used_bytes` == the single-threaded
+/// accounted footprint (fails against the pre-fix no-dedup swap: 4 readers, 2x
+/// bytes).
+#[test]
+fn concurrent_same_key_rebuild_dedups_readers_and_bytes() {
+    use std::sync::Barrier;
+    use std::thread;
+
+    let schema = simple_schema();
+    let (temp, _data, table_dir) = build_sstables(
+        &schema,
+        vec![
+            vec![write_row(1, "a", 1, 100)],
+            vec![write_row(2, "b", 2, 100)],
+        ],
+    );
+
+    // Reference: a clean single-threaded warm of the SAME dir → the correct
+    // reader count (2) and accounted footprint.
+    let reference = WarmTableRegistry::new();
+    reference
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
+        .expect("reference warm");
+    let ref_used = reference.debug_used_bytes();
+    let ref_count = reference.debug_reader_count(&key());
+    assert_eq!(ref_count, 2, "reference caches two generations");
+    assert!(ref_used > 0, "reference footprint is non-zero");
+
+    // Race two concurrent same-key misses on one shared registry.
+    let reg = Arc::new(WarmTableRegistry::new());
+    let barrier = Arc::new(Barrier::new(2));
+    {
+        let b = Arc::clone(&barrier);
+        reg.set_swap_barrier(Arc::new(move || {
+            b.wait();
+        }));
+    }
+
+    let handles: Vec<_> = (0..2)
+        .map(|_| {
+            let reg = Arc::clone(&reg);
+            let schema = schema.clone();
+            let dir = table_dir.clone();
+            thread::spawn(move || {
+                reg.warm_readers(&key(), ddl(), &schema, &dir, None, &CancelFlag::new())
+                    .expect("concurrent warm")
+                    .readers
+                    .len()
+            })
+        })
+        .collect();
+    for h in handles {
+        let n = h.join().expect("thread");
+        assert_eq!(
+            n, 2,
+            "each request returns exactly two generations' readers"
+        );
+    }
+
+    assert_eq!(
+        reg.debug_reader_count(&key()),
+        2,
+        "no duplicate WarmReader survives the concurrent double-swap"
+    );
+    assert_eq!(
+        reg.debug_distinct_gen_count(&key()),
+        2,
+        "exactly one reader per distinct generation"
+    );
+    assert_eq!(
+        reg.debug_used_bytes(),
+        ref_used,
+        "used_bytes matches the single-threaded footprint (no double-count drift)"
+    );
+    drop(temp);
 }
 
 /// Requirement 4 (fail-closed rebuild): a newly-added generation that cannot be
@@ -195,9 +366,10 @@ fn removed_generation_is_evicted_immediately() {
     );
 }
 
-/// Requirement 5 (LRU byte budget): warming distinct tables past a tiny budget
-/// evicts the least-recently-used entry; an evicted entry re-parses on its next
-/// request (a fresh miss/open).
+/// Requirement 5 (LRU byte budget + hardening): warming distinct tables past a
+/// budget that holds ONE generation evicts the least-recently-used entry;
+/// `used_bytes` stays within budget after the eviction; and the evicted entry
+/// re-parses to CORRECT rows (not merely "an open succeeded") on its next request.
 #[test]
 fn lru_evicts_when_over_budget() {
     let schema = simple_schema();
@@ -205,11 +377,20 @@ fn lru_evicts_when_over_budget() {
     let (_t_a, _d_a, dir_a) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
     let (_t_b, _d_b, dir_b) = build_sstables(&schema, vec![vec![write_row(1, "b", 1, 100)]]);
 
-    // Budget = 1 byte: any second generation forces the first out.
-    let reg = WarmTableRegistry::with_budget(1);
-    let cancel = CancelFlag::new();
     let key_a = TableKey::new(KS, "table_a");
     let key_b = TableKey::new(KS, "table_b");
+
+    // Budget = table B's single-generation footprint (measured on a throwaway
+    // registry): B fits, but A+B together force A out.
+    let probe = WarmTableRegistry::new();
+    probe
+        .warm_readers(&key_b, ddl(), &schema, &dir_b, None, &CancelFlag::new())
+        .expect("probe warm");
+    let one_gen = probe.debug_used_bytes();
+    assert!(one_gen > 0, "a generation's footprint is non-zero");
+
+    let reg = WarmTableRegistry::with_budget(one_gen);
+    let cancel = CancelFlag::new();
 
     reg.warm_readers(&key_a, ddl(), &schema, &dir_a, None, &cancel)
         .expect("warm A");
@@ -217,10 +398,16 @@ fn lru_evicts_when_over_budget() {
         .expect("warm B evicts A");
     assert!(
         reg.metrics().snapshot().evicts >= 1,
-        "warming B over a 1-byte budget evicts LRU entry A"
+        "warming B past the one-generation budget evicts LRU entry A"
+    );
+    assert!(
+        reg.debug_used_bytes() <= one_gen,
+        "used_bytes stays within budget after eviction (got {})",
+        reg.debug_used_bytes()
     );
 
-    // A must re-parse (a fresh miss + open) since it was evicted.
+    // A must re-parse (a fresh miss + open) since it was evicted, and its rows
+    // must be CORRECT — the re-opened reader decodes partition id=1 → name "a".
     let opens_before = reg.metrics().snapshot().reader_opens;
     let wa = reg
         .warm_readers(&key_a, ddl(), &schema, &dir_a, None, &cancel)
@@ -233,6 +420,160 @@ fn lru_evicts_when_over_budget() {
     assert!(
         reg.metrics().snapshot().reader_opens > opens_before,
         "re-warming an evicted entry re-opens its reader"
+    );
+    assert_eq!(
+        decode_names(&schema, wa.readers),
+        vec!["a".to_string()],
+        "the re-parsed entry decodes its CORRECT rows, not just an open"
+    );
+}
+
+/// Requirement 3 (snapshot manifest fast path): a byte-identical snapshot
+/// `manifest.json` serves the cached set WITHOUT relisting the directory. Proven
+/// by making an authoritative listing impossible to satisfy — every `Data.db` is
+/// deleted after warming, so a `read_dir` would enumerate ZERO generations (→ a
+/// rebuild to an empty set), while the manifest fast path still serves the two
+/// cached readers.
+#[test]
+fn manifest_fast_path_serves_cached_without_relisting() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(
+        &schema,
+        vec![
+            vec![write_row(1, "a", 1, 100)],
+            vec![write_row(2, "b", 2, 100)],
+        ],
+    );
+    let snap = make_snapshot(&table_dir, "snap1");
+    std::fs::write(
+        snap.join("manifest.json"),
+        br#"{"files":["nb-1-big-Data.db","nb-2-big-Data.db"]}"#,
+    )
+    .unwrap();
+
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+    let w1 = reg
+        .warm_readers(&key(), ddl(), &schema, &snap, Some("snap1"), &cancel)
+        .expect("warm snapshot");
+    assert_eq!(w1.readers.len(), 2, "both generations warmed");
+    let opens = reg.metrics().snapshot().reader_opens;
+
+    // Delete every Data.db (the cached Arc readers keep the inodes alive), leaving
+    // the manifest byte-identical: an authoritative relisting would now find ZERO.
+    for e in std::fs::read_dir(&snap).unwrap().flatten() {
+        let p = e.path();
+        if p.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with("-Data.db"))
+        {
+            std::fs::remove_file(&p).unwrap();
+        }
+    }
+
+    let w2 = reg
+        .warm_readers(&key(), ddl(), &schema, &snap, Some("snap1"), &cancel)
+        .expect("manifest fast path serves cached");
+    assert_eq!(
+        w2.outcome,
+        RefreshOutcome::Unchanged,
+        "identical manifest → warm hit (a relisting would have rebuilt to empty)"
+    );
+    assert_eq!(
+        w2.readers.len(),
+        2,
+        "the cached set is served — the directory was NOT relisted"
+    );
+    assert_eq!(
+        reg.metrics().snapshot().reader_opens,
+        opens,
+        "the fast path opened zero further readers"
+    );
+}
+
+/// Requirement 4 (in-flight isolation): a warm set handed to a request is an
+/// `Arc` snapshot; a concurrent rebuild that swaps in a new generation does NOT
+/// change what the held set yields. The held (pre-swap) set decodes its original
+/// row; the NEXT lookup sees the post-swap set.
+#[test]
+fn held_warm_set_is_isolated_from_a_rebuild_swap() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+    let w1 = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("warm gen-1");
+    // Hold the pre-swap Arc set (as an in-flight stream would).
+    let held = w1.readers.clone();
+
+    // Add a second generation and rebuild+swap the warm set.
+    append_gen(&table_dir, &schema, vec![write_row(2, "b", 2, 200)]);
+    let w2 = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("rebuild adds gen-2");
+    assert_eq!(
+        w2.readers.len(),
+        2,
+        "the NEXT lookup sees the post-swap set"
+    );
+
+    // The HELD set still yields exactly its pre-swap row — isolated from the swap.
+    assert_eq!(
+        decode_names(&schema, held),
+        vec!["a".to_string()],
+        "the held set yields its pre-swap rows"
+    );
+    assert_eq!(
+        decode_names(&schema, w2.readers),
+        vec!["a".to_string(), "b".to_string()],
+        "the post-swap lookup yields both generations"
+    );
+}
+
+/// Requirement 7 (mid-rebuild cancellation): cancelling BETWEEN added-generation
+/// opens surfaces the `Cancelled` variant, leaves the prior warm set fully intact,
+/// and performs NO partial swap (the partially-opened readers are discarded, never
+/// installed).
+#[test]
+fn mid_rebuild_cancellation_leaves_prior_set_intact() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+    // Warm gen-1 (the prior set).
+    reg.warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("warm gen-1");
+
+    // Add TWO more generations so the rebuild opens multiple.
+    append_gen(&table_dir, &schema, vec![write_row(2, "b", 2, 200)]);
+    append_gen(&table_dir, &schema, vec![write_row(3, "c", 3, 300)]);
+
+    // Trip the cancel flag BETWEEN added-generation opens: the per-open barrier
+    // fires at the top of each open iteration; cancel once one gen has opened.
+    let calls = Arc::new(AtomicU64::new(0));
+    let cancel_hook = cancel.clone();
+    let calls_hook = Arc::clone(&calls);
+    reg.set_open_barrier(Arc::new(move || {
+        if calls_hook.fetch_add(1, Ordering::SeqCst) >= 1 {
+            cancel_hook.cancel();
+        }
+    }));
+
+    let err = reg
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect_err("a mid-rebuild cancellation must abort");
+    assert!(matches!(err, WarmError::Cancelled), "got {err:?}");
+    assert!(
+        calls.load(Ordering::SeqCst) >= 2,
+        "the rebuild opened at least one gen before cancelling"
+    );
+    assert_eq!(
+        reg.debug_reader_count(&key()),
+        1,
+        "no partial swap: only the prior gen-1 remains cached"
     );
 }
 

--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -781,3 +781,43 @@ fn copy_sstable_components(src: &Path, dst: &Path) {
         }
     }
 }
+
+// ---- Issue #2310: warm-handle wiring evidence over the REAL tonic transport ----
+
+/// WS5.3 e2e wiring evidence: run `FlightService::do_get` TWICE over the real
+/// loopback tonic transport for the same table/generation set. The first call
+/// warms the cache (miss); the second is a warm HIT that opens ZERO further
+/// readers (the work-done probe) and returns byte-identical rows. This exercises
+/// the named public surface (`do_get` over gRPC) end to end — the warm registry
+/// is shared across the `Clone`d per-connection service handles via its `Arc`.
+#[test]
+fn do_get_over_transport_second_request_is_a_warm_hit() {
+    let (_temp, data_dir) = build_fixture();
+    let svc = CqliteFlightService::new(data_dir, 1024);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let rows1 = rt.block_on(do_get_rows_over_transport(svc.clone(), ticket_bytes()));
+    let opens_after_first = svc.warm_metrics().reader_opens;
+    let rows2 = rt.block_on(do_get_rows_over_transport(svc.clone(), ticket_bytes()));
+
+    assert_eq!(rows1, 3, "the keyvalue fixture has 3 rows");
+    assert_eq!(
+        rows2, rows1,
+        "warm hit returns byte-identical rows over the wire"
+    );
+
+    let m = svc.warm_metrics();
+    assert_eq!(m.misses, 1, "one cold build (first transport request)");
+    assert_eq!(m.hits, 1, "one warm hit (second transport request)");
+    assert!(
+        opens_after_first >= 1,
+        "the first request opened the reader(s)"
+    );
+    assert_eq!(
+        m.reader_opens, opens_after_first,
+        "the warm hit over transport performed zero reader-open/parse (#2310)"
+    );
+}

--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -787,9 +787,10 @@ fn copy_sstable_components(src: &Path, dst: &Path) {
 /// WS5.3 e2e wiring evidence: run `FlightService::do_get` TWICE over the real
 /// loopback tonic transport for the same table/generation set. The first call
 /// warms the cache (miss); the second is a warm HIT that opens ZERO further
-/// readers (the work-done probe) and returns byte-identical rows. This exercises
-/// the named public surface (`do_get` over gRPC) end to end — the warm registry
-/// is shared across the `Clone`d per-connection service handles via its `Arc`.
+/// readers (the work-done probe) and returns VALUE-identical rows (every cell,
+/// not just the row count). This exercises the named public surface (`do_get`
+/// over gRPC) end to end — the warm registry is shared across the `Clone`d
+/// per-connection service handles via its `Arc`.
 #[test]
 fn do_get_over_transport_second_request_is_a_warm_hit() {
     let (_temp, data_dir) = build_fixture();
@@ -799,15 +800,34 @@ fn do_get_over_transport_second_request_is_a_warm_hit() {
         .build()
         .unwrap();
 
-    let rows1 = rt.block_on(do_get_rows_over_transport(svc.clone(), ticket_bytes()));
+    let batches1 = rt.block_on(do_get_batches_over_transport(svc.clone(), ticket_bytes()));
     let opens_after_first = svc.warm_metrics().reader_opens;
-    let rows2 = rt.block_on(do_get_rows_over_transport(svc.clone(), ticket_bytes()));
+    let batches2 = rt.block_on(do_get_batches_over_transport(svc.clone(), ticket_bytes()));
 
+    let rows1: usize = batches1.iter().map(|b| b.num_rows()).sum();
+    let rows2: usize = batches2.iter().map(|b| b.num_rows()).sum();
     assert_eq!(rows1, 3, "the keyvalue fixture has 3 rows");
     assert_eq!(
         rows2, rows1,
-        "warm hit returns byte-identical rows over the wire"
+        "warm hit returns the same row count over the wire"
     );
+
+    // VALUE equality: compare EVERY cell of both responses (each column's
+    // `ArrayData`) — a warm hit must be indistinguishable from the cold first
+    // response, not merely the same cardinality. Both requests use the same
+    // batch_size, so batch boundaries line up.
+    assert_eq!(batches1.len(), batches2.len(), "same batch count");
+    for (b1, b2) in batches1.iter().zip(&batches2) {
+        assert_eq!(b1.schema(), b2.schema(), "same schema");
+        assert_eq!(b1.num_columns(), b2.num_columns(), "same column count");
+        for i in 0..b1.num_columns() {
+            assert_eq!(
+                b1.column(i).to_data(),
+                b2.column(i).to_data(),
+                "column {i} is value-identical across the warm hit"
+            );
+        }
+    }
 
     let m = svc.warm_metrics();
     assert_eq!(m.misses, 1, "one cold build (first transport request)");

--- a/openspec/changes/flight-warm-handles/design.md
+++ b/openspec/changes/flight-warm-handles/design.md
@@ -1,0 +1,204 @@
+# Design — cqlite-flight warm-handle service (#2310)
+
+## Context
+
+Static analysis (anchors `main`-relative, WILL drift — re-grep before editing):
+
+- **Stateless per request.** `CqliteFlightService` holds only `data_dir` + `batch_size`
+  (`cqlite-flight/src/service.rs:119-126`). `build_producer` (`service.rs:145`) calls
+  `parse_schema` → `parse_cql_schema` (`service.rs:138`) on **every** RPC, then constructs a fresh
+  `MergeProducer`. `do_get_setup` (`service.rs:479`) resolves `DirSource` and lists paths per
+  request inside `spawn_blocking`.
+- **Directory resolve per request.** `DirSource::resolve` (`cqlite-flight/src/producer.rs:146`)
+  chooses the live `<data>/<ks>/<table>[-<uuid>]` dir or the `snapshots/<name>/` hardlink set, with
+  in-`data_dir` path safety (#1430). `data_paths` (`producer.rs:194`) `read_dir`s and
+  `generation_of` (`producer.rs:237`) parses the generation from each `Data.db` file name; paths
+  sort newest-generation-first (`producer.rs:230`). `prune_paths_cancellable` reads each
+  `Summary.db` for the token-span prune.
+- **Generation number is already parsed** (`generation_of`, `producer.rs:237`) — but nothing keys
+  cached state on it; every request re-opens readers from scratch.
+- **Core already solved warm freshness.** `Database::refresh()` (`cqlite-core/src/lib.rs:425`) →
+  `SSTableManager::refresh_tables` (`cqlite-core/src/storage/sstable/refresh.rs`): re-runs the same
+  filename/TOC discovery `open` used (no content sniffing, no heuristics), diffs canonical `Data.db`
+  paths against the held reader set, opens **added** generations, drops **removed**, and keeps
+  **unchanged** generations' warm parsed Index/Statistics/bloom state (not rebuilt). Application is
+  **atomic + fail-closed** (all adds open before the write guard; any open failure mutates nothing —
+  #1626 corrupt-`Statistics.db` hard-fail inherited). In-flight queries hold `Arc` reader clones and
+  complete against the pre-refresh set. A dedicated refresh mutex serializes concurrent refreshes;
+  it is NEVER taken on a query path.
+- **Cancellation contract (#2264/#1473).** `MergeProducer::produce_cancellable` (`producer.rs:495`)
+  polls a `CancelFlag` between partition steps; a pre-cancel yields ZERO steps.
+
+The gap: core's warm-set/refresh machinery lives on `Database`, but the flight producer never opens
+a `Database` — it constructs `DirSource` + `MergeProducer` per request and never retains parsed
+state. This epic gives flight an equivalent warm layer keyed on generation identity.
+
+---
+
+## Decision 1 — Cache key = generation identity, not directory path
+
+**Options considered.**
+
+- **(a) Key by resolved directory path.** Cache keyed on the `DirSource` dir.
+  - Con: snapshot mode creates a **new hardlinked dir per query** — a path key misses on every
+    snapshot even though the underlying inodes (and thus all parsed state) are identical. Defeats
+    the whole epic in the mode the field actually runs.
+- **(b) TTL-keyed / time-bucketed.** Key by `(table, coarse time bucket)`.
+  - Con: introduces a staleness window (a flush inside the bucket is invisible) — a correctness
+    tradeoff, and still misses across snapshot dirs within a bucket for unrelated reasons.
+- **(c, RECOMMENDED) Key by (table, SSTable generation set) with inode-stable identity.** The cache
+  key for a warm handle is the logical table plus the **set of SSTable generations** present, where
+  each generation's identity is inode-stable (device+inode of its `Data.db`, cross-checked with the
+  parsed generation number) so the SAME files reached through a fresh snapshot hardlink dir resolve
+  to the SAME key.
+
+**Recommendation: (c).** Generation identity is what actually determines the validity of parsed
+Index/Summary/Statistics/bloom state — two snapshot dirs that hardlink the same inodes describe the
+same bytes, so their parsed state is interchangeable. Keying on inode-stable generation identity
+(not the ephemeral snapshot path) is the only key that gives a warm hit across per-query snapshot
+dirs while never serving state for bytes that changed. Live-mode reuse falls out for free: a live
+dir whose generation set is unchanged between requests hits the same key.
+
+---
+
+## Decision 2 — THE refresh trigger (the epic's named Seam-1 decision)
+
+The epic lists candidates: (a) cheap per-request staleness probe (dir listing / generation-set
+diff); (b) snapshot-`manifest.json` diff fast path; (c) TTL; (d) external signal.
+
+**Options considered.**
+
+- **(a) Per-request generation-set probe.** On every request, list the resolved dir (or otherwise
+  enumerate the generation set) and compare to the warm handle's cached set. Unchanged set → warm
+  hit (no reader-open, no parse); changed set → rebuild only the delta (adopt Decision 3).
+  - Pro: **zero staleness window** — a directory listing is authoritative ground truth for "what
+    generations exist right now," so a flush/compaction is visible on the very next request. **No
+    heuristics** — it reads the truth, it does not infer it. The listing (a readdir + name parse)
+    is cheap relative to the reader-open/Index/Summary/Statistics/bloom parse it guards.
+  - Con: still one `read_dir` per request (far cheaper than the parse it saves, but non-zero).
+- **(b) Snapshot `manifest.json` diff fast path.** In snapshot mode the snapshot already carries a
+  `manifest.json` enumerating its files; when the manifest is byte-identical to the cached one for
+  that generation set, skip the `read_dir` entirely and take the warm hit.
+  - Pro: turns the probe into a single small-file stat/read in the common snapshot path.
+  - Con: only applies in snapshot mode; a manifest is a fast path, not the correctness backbone.
+- **(c) TTL.** Serve warm for N seconds, then force a rebuild.
+  - Con: **staleness window is a correctness tradeoff** — a flush inside the TTL is invisible.
+    Rejected: this epic must be zero-staleness-regression (epic acceptance).
+- **(d) External signal / fs-watching.** inotify/FSEvents or a control-plane refresh RPC.
+  - Con: fs-watching is **platform-dependent and heuristic** (coalesced/dropped events, hardlink
+    blind spots) — a no-heuristics violation. An external signal-only design has no fallback when
+    the signal is missed and reintroduces a staleness window.
+
+**Recommendation: (a) as the correctness backbone + (b) as the snapshot fast path.** The
+per-request generation-set probe is authoritative and zero-window; the `manifest.json` diff avoids
+the `read_dir` when the manifest matches in snapshot mode. **Reject TTL** (staleness window) and
+**reject fs-watching** (heuristic, platform-dependent). This keeps the no-heuristics mandate: the
+trigger is an explicit documented contract that reads ground truth every request.
+
+**Fail-closed (mirrors #1749).** A **probe error** (dir unreadable, manifest unparsable) is treated
+as **"changed" → full re-resolve** (never a stale warm hit). A **refresh/rebuild error** (an added
+generation fails to open — e.g. corrupt `Statistics.db`, #1626) leaves the **previously warm set
+fully intact** and surfaces the typed error — no partial view, exactly as `refresh_tables` does.
+
+---
+
+## Decision 3 — Reuse core's refresh contract vs new machinery
+
+**Options considered.**
+
+- **(a) New flight-local warm-set + diff/swap machinery.** Reimplement add/drop/keep diffing,
+  atomic swap, and Arc isolation inside cqlite-flight.
+  - Con: duplicates the exact semantics `refresh_tables` already proves (atomic, fail-closed, Arc
+    isolation, concurrent-refresh serialization, #1626 hard-fail); a second implementation drifts
+    from the first and re-litigates settled correctness.
+- **(b, RECOMMENDED) Adopt/adapt core's refresh contract.** Model the flight warm handle on
+  `Database::refresh()` / `SSTableManager::refresh_tables` (#1749): the warm handle holds `Arc`
+  reader (and parsed-schema) clones; a rebuild diffs the probed generation set against the held set,
+  opens only **added** generations, drops **removed**, keeps **unchanged** parsed state, and swaps
+  atomically under a write guard while in-flight requests keep their pre-swap `Arc` clones. Where
+  flight's per-request `DirSource`/`MergeProducer` shape differs from core's `Database`, adapt the
+  seam (a warm handle that hands a `MergeProducer` a pre-resolved, pre-parsed path/reader set)
+  rather than reinvent the diff/swap.
+
+**Recommendation: (b).** The freshness/atomicity/isolation properties this epic needs are exactly
+#1749's; reusing that contract inherits its tests and its no-heuristics discovery, and keeps a
+single source of truth for "how a warm CQLite reader set refreshes."
+
+---
+
+## Decision 4 — Memory budget + eviction
+
+**Options considered.**
+
+- **(a) Unbounded cache.** Keep every table/generation ever parsed.
+  - Con: violates the <128MB discipline on a many-table server; unbounded growth.
+- **(b, RECOMMENDED) LRU by (table, generation) with explicit accounting.** Bound warm state by an
+  explicit byte budget inside the <128MB discipline; evict least-recently-used (table, generation)
+  entries when the budget is exceeded. Account the parsed-state footprint explicitly (per-generation
+  Index/Summary/Statistics/bloom + parsed schema), not by proxy. A generation dropped by a rebuild
+  (removed on disk) is evicted immediately regardless of LRU age.
+
+**Recommendation: (b).** LRU by (table, generation) matches the cache key (Decision 1) and the
+refresh unit (Decision 3), giving natural, explainable eviction. Explicit accounting keeps the
+budget auditable and lets the metrics surface report it.
+
+**Metrics surface (feeds #2289).** Bounded, catalog-attribute counters: warm **hit**, **miss**,
+**evict**, and **refresh-outcome** (unchanged / rebuilt-delta / fail-closed-retained). These ride
+the existing observability contract (no new knob); the #2289 harness and #1494 bench suite consume
+them to prove the second identical query on an unchanged generation pays ~0 parse cost.
+
+---
+
+## Decision 5 — Cancellation through cached/refresh paths
+
+**Recommendation: the #2264/#1473 discipline holds unchanged through the cache and refresh paths.**
+Both the **staleness probe** and any **rebuild** (reader opens) poll the same `CancelFlag`
+cooperatively and map `Error::Cancelled` by variant (not by racing a flag): a pre-cancelled request
+does ZERO probe/rebuild work, and a client disconnect mid-rebuild stops it without corrupting the
+warm set (the fail-closed rule keeps the prior set intact). A warm hit is trivially cancellable (it
+does no I/O beyond the probe). No cancellation guarantee that holds on the cold path may weaken on
+the warm path.
+
+---
+
+## Modes, budgets, cancellation (summary)
+
+- **Snapshot vs live:** both use the warm handle keyed on generation identity (Decision 1). Snapshot
+  mode additionally gets the `manifest.json` fast path (Decision 2b). Per-query snapshots and
+  flush-on-snapshot semantics are unchanged (#2305).
+- **Budgets:** the byte/row result budget, LIMIT, and #2230 wide-partition bounds are enforced by
+  the same `drive_merge` sink — the warm handle changes only *how readers are obtained*, never how
+  rows are produced.
+- **Cancellation:** Decision 5.
+
+## Test strategy (parity is the deliverable)
+
+- **Cross-snapshot warm-hit:** two `do_get`s for the same table land in two different snapshot
+  hardlink dirs over the same inodes; assert the second is a warm hit (metrics: hit++, zero
+  reader-open/parse) and returns byte-identical batches to the first.
+- **Staleness visibility:** add a generation on disk (simulate a flush), then re-request; assert the
+  probe reports "changed," the rebuild adds exactly the new generation, and the result reflects it —
+  zero staleness window.
+- **Fail-closed rebuild:** an added generation with a corrupt `Statistics.db` (#1626) → the rebuild
+  returns the typed error and the previously warm set is still served intact.
+- **Memory budget + eviction:** drive enough distinct (table, generation) entries to exceed the
+  budget; assert LRU eviction (evict++), footprint stays within the <128MB discipline, and an
+  evicted entry re-parses correctly on next request.
+- **Cancellation:** a pre-cancelled request does zero probe/rebuild work; a disconnect mid-rebuild
+  leaves the warm set intact.
+- **Bench evidence (#2289 + #1494):** second identical query on an unchanged generation shows ~0
+  parse cost (schema parse + resolve + reader-open/index/summary/bloom parse elided), measured on
+  the #2289 harness point-read / LIMIT / full-scan runs.
+
+## Open questions for Seam 1
+
+1. **Warm-handle seam shape:** a flight-owned `WarmTableRegistry` that hands `MergeProducer` a
+   pre-resolved reader set, vs opening a core `Database` per table and calling `refresh()`.
+   (Recommendation: the former — flight's `DirSource`/`ScanSpec`/token-prune shape differs from
+   `Database`'s query surface; adapt the #1749 contract rather than route through `Database`.)
+2. **Byte budget value + source:** a fixed named default inside <128MB vs a configurable ceiling.
+   (Recommendation: a fixed named default this epic, no new user knob per Non-goals; revisit only if
+   the field needs it.)
+3. **Schema-cache scope:** cache the parsed schema per (table, ticket-DDL hash) alongside the
+   generation set, or per table only. (Recommendation: per (table, DDL) — the DDL rides the ticket
+   and can in principle change; keying on it keeps the cache authoritative.)

--- a/openspec/changes/flight-warm-handles/proposal.md
+++ b/openspec/changes/flight-warm-handles/proposal.md
@@ -1,0 +1,83 @@
+# cqlite-flight warm-handle service: generation-keyed parse cache across requests (epic #2310)
+
+## Milestone
+Unmilestoned by design — owner triages (candidate for 0.15+ after the 0.14 flight-correctness
+program closes). This is **Phase 2** of the ms-point-read program (research:
+`docs/architecture/issue-2310-ms-point-reads-research.md`). Phase 1 (#2207 PK point-read/prune,
+#2295 complete snapshots, #2302 present-pair resolution) is **all shipped**, so the probe path this
+epic caches already exists. Routing: **design-driven** — Seam-1 owner approval of this spec + design
+precedes any implementation; children (WS1–WS5) are filed after approval and each carries its own
+OpenSpec change at activation.
+
+## Why (measured problem)
+cqlite-flight is a long-running server that behaves **statelessly per request**. Every `do_get`
+re-does the same fixed rediscovery from cold and throws it away:
+
+- **Schema parse from the ticket every request** — `CqliteFlightService::parse_schema` →
+  `parse_cql_schema` at `cqlite-flight/src/service.rs:138`, called from `build_producer` on every
+  RPC.
+- **Directory resolve + listing every request** — `DirSource::resolve`
+  (`cqlite-flight/src/producer.rs:146`) `is_dir`/`read_dir`s the snapshot (or live) table dir, then
+  `data_paths` re-lists it and `prune_paths_cancellable` reads each SSTable's `Summary.db` for the
+  token-span prune.
+- **Per-SSTable reader open + Index/Summary/Statistics/bloom parse every request** across every
+  surviving SSTable.
+
+The cost model (research §"Cost model", lines 82–92) names this the **Phase-2 residual** the epic
+removes: once Phase 1 turns `WHERE pk = X` into an index probe, the dominant remaining fixed cost
+for a point/LIMIT query is exactly this per-request schema parse + `DirSource` resolve +
+reader-open/Index/Summary/Statistics/bloom parse. On unchanged data it is repeated verbatim on every
+request. There is also no warm state, so the server has **no cheap answer to "did anything change?"**
+— every request assumes everything changed.
+
+## What changes
+Give flight a **warm, generation-keyed handle** per table:
+
+1. **Cache key = SSTable generation identity, not directory path.** Snapshot mode creates a new
+   hardlinked dir per query, but the files are the same inodes; parsed Index/Summary/Statistics/
+   bloom/schema state cached per generation is valid across snapshot dirs. Per-query snapshots stay
+   (isolation + flush-on-snapshot freshness per the #2305 decision); **parse-once-per-generation
+   replaces parse-per-query.**
+2. **A per-request staleness probe** decides warm-hit vs rebuild: a generation-set diff (dir
+   listing, or the snapshot `manifest.json` fast path) with **zero staleness window** — a listing is
+   authoritative, so an unchanged set is a warm hit that skips all reader-open/parse; a changed set
+   triggers a rebuild of only the delta.
+3. **Reuse core's freshness contract.** `Database::refresh()` (#1749) is atomic, fail-closed, and
+   isolates in-flight queries on `Arc` reader clones; the flight warm set adopts the same semantics
+   rather than inventing new machinery.
+4. **Memory budget + eviction + metrics.** Warm state lives inside the <128MB discipline: LRU
+   eviction by (table, generation), explicit budget accounting, and hit/miss/evict/refresh-outcome
+   counters (the #2289 measurement plan consumes these).
+
+The observable answer set is **unchanged**: a warm hit returns exactly what a cold request returns
+for the same ticket over the same generation set.
+
+## Non-goals
+- **No change to snapshot semantics.** The #2305 owner decision stands: flush-on-snapshot,
+  point-in-time snapshot mode is unchanged. This epic is about parse-cost, not read semantics.
+- **NOT the #905 Phase-C compaction daemon.** This is flight-internal warm state, not the
+  standalone engine daemon; scopes stay distinct (also distinct from #1934 engine-name work).
+- **NOT #2306 (snapshot reuse / TTL).** #2306 reuses SNAPSHOTS and trades freshness; this epic
+  reuses PARSED STATE and trades nothing. Doing this first may reduce #2306's urgency; they are
+  adjacent but separable.
+- **No filesystem-watching heuristics.** No inotify/FSEvents/mtime-only inference (platform-
+  dependent, heuristic). The refresh trigger is an explicit, documented, authoritative contract.
+- **No new user-facing config knob, CLI/binding method, or ticket field** beyond the warm-state
+  internals and the existing observability surface.
+- **No change to the KWayMerger reconciliation, write, or compaction logic.**
+
+## Doctrine impact
+**No-heuristics (#28):** the refresh trigger MUST be an explicit, documented contract, never an
+inference from byte patterns or filesystem timing. The chosen trigger (per-request generation-set
+probe + snapshot `manifest.json` fast path) is authoritative by construction — a directory listing /
+manifest IS ground truth for the generation set, not a guess. Fail-closed mirrors #1749: a probe
+error is treated as "changed" (full re-resolve), and a refresh error leaves the previously warm set
+fully intact (no partial view).
+
+## Cross-links
+Program: epic #2310 (this proposal is Phase 2), research
+`docs/architecture/issue-2310-ms-point-reads-research.md`. Prereqs (shipped): #2207 (PK point-read),
+#2295 (snapshot completeness), #2302 (Summary/Index resolution). Reused contract: #1749
+(`Database::refresh()`). Constraints: #2305 (snapshot flush semantics, unchanged), #2306 (snapshot
+reuse, separable), #2264 (cancellation discipline, must hold). Measurement: #2289 harness, #1494
+bench suite. Distinct scope: #905 Phase-C daemon, #1934 engine-name.

--- a/openspec/changes/flight-warm-handles/specs/flight-warm-handles/spec.md
+++ b/openspec/changes/flight-warm-handles/specs/flight-warm-handles/spec.md
@@ -1,0 +1,176 @@
+# flight-warm-handles
+
+## ADDED Requirements
+
+### Requirement: Warm parsed state SHALL be keyed on generation identity, valid across snapshot dirs
+
+The warm-handle cache SHALL key parsed SSTable state (Index/Summary/Statistics/bloom) and parsed
+schema on the logical table plus the set of SSTable generations present, using an inode-stable
+generation identity (device+inode of each `Data.db`, cross-checked with the parsed generation
+number) so that the same underlying files reached through a different snapshot hardlink directory
+resolve to the same cache entry. The cache key SHALL NOT be the resolved directory path, and SHALL
+NOT be a TTL/time bucket.
+
+#### Scenario: Same generations reached through two snapshot dirs are one warm entry
+
+- **GIVEN** a table whose per-query snapshot mode hardlinks the same `Data.db` inodes into a fresh
+  `snapshots/<name>/` directory per request
+- **WHEN** two `do_get` requests for the same table resolve to two different snapshot directories
+  over the identical inode set
+- **THEN** both resolve to the same warm cache entry, the second request records a warm **hit**,
+  and it performs **zero** SSTable reader-open and zero Index/Summary/Statistics/bloom parse.
+
+#### Scenario: A path-keyed or TTL-keyed cache would miss here (regression guard)
+
+- **GIVEN** the same two-snapshot-dir sequence over identical inodes
+- **WHEN** the warm handle is queried
+- **THEN** the cache entry is selected by generation identity, not by the (differing) directory
+  paths — a path key would report a miss on the second request, and this scenario asserts a hit.
+
+### Requirement: A per-request staleness probe SHALL decide warm-hit vs rebuild with zero staleness window
+
+The service SHALL, on every request, probe the current SSTable generation set for the resolved table
+(an authoritative directory listing / generation enumeration) and compare it to the warm handle's
+cached set. When the set is unchanged the request SHALL take a warm hit and skip all reader-open and
+Index/Summary/Statistics/bloom parse; when the set has changed the request SHALL rebuild. The probe
+SHALL read ground truth (a listing/manifest), never infer freshness from filesystem timing,
+mtime-only, or any non-authoritative heuristic (#28), so that a flush/compaction is visible on the
+next request with no staleness window.
+
+#### Scenario: Unchanged generation set is a warm hit with zero parse
+
+- **GIVEN** a warm handle whose cached generation set matches the on-disk set
+- **WHEN** a second identical `do_get` executes
+- **THEN** the staleness probe reports "unchanged," the request serves from warm state, and a
+  work-done probe shows zero reader-open and zero Index/Summary/Statistics/bloom parse for that
+  request.
+
+#### Scenario: A newly added generation is visible on the next request
+
+- **GIVEN** a warm handle and a subsequent flush that adds a new SSTable generation on disk
+- **WHEN** the next `do_get` executes
+- **THEN** the staleness probe reports "changed," the rebuild adds exactly the new generation
+  (unchanged generations keep their warm parsed state), and the result reflects the new data — with
+  no staleness window and no wall-clock/TTL delay.
+
+### Requirement: The snapshot manifest.json SHALL provide a fast-path probe without a readdir
+
+In snapshot mode the service SHALL use the snapshot's `manifest.json` as a fast-path staleness
+probe: when the manifest is byte-identical to the manifest cached for that generation set, the
+service SHALL take the warm hit without performing a directory `read_dir`. The manifest fast path
+SHALL be an optimization only — its result SHALL be equivalent to the authoritative
+generation-set probe, never a weaker freshness guarantee.
+
+#### Scenario: Matching manifest skips the directory listing
+
+- **GIVEN** a snapshot-mode warm handle whose cached `manifest.json` matches the snapshot on disk
+- **WHEN** a subsequent request for the same snapshot executes
+- **THEN** the request takes a warm hit via the manifest fast path and performs no `read_dir` of the
+  snapshot directory, returning byte-identical batches to the first request.
+
+#### Scenario: Absent or unparsable manifest falls back to the authoritative probe
+
+- **GIVEN** a snapshot with no `manifest.json` or an unreadable one
+- **WHEN** a request executes
+- **THEN** the service SHALL fall back to the authoritative generation-set listing probe (never a
+  stale warm hit) and produce the correct answer.
+
+### Requirement: Refresh SHALL be fail-closed — the old warm set stays intact on any error
+
+The warm-handle rebuild SHALL be atomic and fail-closed, mirroring `Database::refresh()` (#1749):
+every added generation SHALL be opened before the warm set is swapped, so if any added generation
+fails to open (e.g. a corrupt `Statistics.db`, #1626) the rebuild SHALL return the typed error and
+leave the previously warm set fully intact — no partial view. A probe error SHALL be treated as
+"changed" (forcing a full re-resolve), never as a stale warm hit. In-flight requests SHALL hold
+their own `Arc` reader clones and complete against the pre-swap set, unaffected by a concurrent
+rebuild.
+
+#### Scenario: A corrupt added generation leaves the warm set unchanged
+
+- **GIVEN** a warm handle serving a valid generation set and a newly added generation whose
+  `Statistics.db` is corrupt
+- **WHEN** a request triggers a rebuild that tries to open the new generation
+- **THEN** the rebuild returns the typed error, the previously warm set is still served intact on
+  the next request, and no partial/half-applied generation set is ever exposed.
+
+#### Scenario: An in-flight request is isolated from a concurrent rebuild
+
+- **GIVEN** a request streaming from the warm set while a concurrent rebuild swaps in a new
+  generation set
+- **WHEN** both proceed
+- **THEN** the in-flight request completes against its pre-swap `Arc` reader clones (same rows it
+  would have returned), and the next request sees the post-rebuild set.
+
+### Requirement: Warm state SHALL stay within the memory budget via LRU eviction
+
+The warm-handle cache SHALL bound its footprint by an explicit byte budget inside the <128MB
+discipline, accounting the parsed-state footprint (per-generation Index/Summary/Statistics/bloom plus
+parsed schema) explicitly, and SHALL evict least-recently-used (table, generation) entries when the
+budget would be exceeded. A generation removed on disk (dropped by a rebuild) SHALL be evicted
+immediately regardless of LRU age.
+
+#### Scenario: Exceeding the budget evicts the least-recently-used entry
+
+- **GIVEN** a warm cache at its byte budget with N distinct (table, generation) entries
+- **WHEN** a request warms a new (table, generation) that would exceed the budget
+- **THEN** the least-recently-used entry is evicted (recorded as an **evict**), the accounted
+  footprint stays within the budget, and an evicted entry re-parses correctly on its next request.
+
+#### Scenario: A removed generation is evicted immediately
+
+- **GIVEN** a warm generation that a rebuild finds no longer on disk
+- **WHEN** the rebuild applies
+- **THEN** that generation's warm state is dropped immediately (independent of LRU age) and its
+  reader closes once the last in-flight `Arc` clone is dropped.
+
+### Requirement: The warm handle SHALL expose hit/miss/evict/refresh-outcome metrics
+
+The service SHALL emit bounded observability counters for warm-cache **hit**, **miss**, **evict**,
+and **refresh-outcome** (unchanged / rebuilt-delta / fail-closed-retained), riding the existing
+observability contract with no new configuration knob, environment variable, or ticket field. These
+counters SHALL be sufficient for the #2289 harness and #1494 bench suite to prove warm behavior.
+
+#### Scenario: A warm hit and a rebuild are distinguishable in metrics
+
+- **GIVEN** observability enabled
+- **WHEN** one request warms the cache (miss + build) and a second identical request hits it, then a
+  flush forces a third request to rebuild
+- **THEN** the counters show exactly one miss, one hit, and one refresh-outcome=rebuilt-delta, with
+  no new knob introduced to surface them.
+
+### Requirement: Cancellation discipline SHALL hold through the probe and rebuild paths
+
+The staleness probe and any rebuild (reader opens) SHALL be cooperatively cancellable under the
+#2264/#1473 discipline: a pre-cancelled request SHALL perform zero probe and zero rebuild work, and
+`Error::Cancelled` SHALL be surfaced by variant (not by racing a flag). No cancellation guarantee
+that holds on the cold path SHALL weaken on the warm path.
+
+#### Scenario: A pre-cancelled request does zero warm-path work
+
+- **GIVEN** a request whose cancel flag is already set
+- **WHEN** it reaches the warm handle
+- **THEN** it performs zero staleness-probe and zero rebuild work and surfaces the distinct
+  `Cancelled` variant without masking it as another error.
+
+#### Scenario: A disconnect mid-rebuild leaves the warm set intact
+
+- **GIVEN** a rebuild in progress when the client disconnects (cancel flag set)
+- **WHEN** cancellation is observed
+- **THEN** the rebuild stops early, the previously warm set is left intact (fail-closed), and no
+  partial generation set is exposed.
+
+### Requirement: Bench evidence SHALL show ~zero parse cost on a repeated unchanged query
+
+The change SHALL be validated with before/after bench evidence on the #2289 local harness (point
+read, LIMIT, full scan on a ≥100k-partition table) and the #1494 bench suite: a second identical
+query on an unchanged generation set SHALL show approximately zero parse cost (schema parse +
+directory resolve + reader-open/Index/Summary/Statistics/bloom parse elided) relative to the cold
+first query, with the warm-hit counter incrementing.
+
+#### Scenario: Repeated point read on unchanged data pays no parse cost
+
+- **GIVEN** the #2289 harness with a warm handle and unchanged generation set
+- **WHEN** the same `WHERE pk = X` point read runs a second time
+- **THEN** the measured per-request schema-parse + resolve + reader-open/index/summary/bloom parse
+  cost is approximately zero versus the cold run, the warm-hit counter increments, and the returned
+  rows are byte-identical to the cold run.

--- a/openspec/changes/flight-warm-handles/tasks.md
+++ b/openspec/changes/flight-warm-handles/tasks.md
@@ -1,0 +1,78 @@
+# Tasks — cqlite-flight warm-handle service (#2310)
+
+One issue ↔ branch `issue-2310-flight-warm-handles` ↔ this change ↔ one PR. Each stage names the
+public surface it exercises and carries a red-then-green test (fails on `main`). Anchors are
+`main`-relative and WILL drift — re-grep before editing. Follow the implement loop: `--lite`
+(summary-file redirect) each fix round → rust-reviewer + roborev on the lite-green diff
+(review-first) → open PR → hand the endgame to `flow-closer` (ONE full gate → C intent audit →
+final roborev → merge-on-green → finalize). Point `CQLITE_DATASETS_ROOT` at the main repo's
+`test-data/datasets`. The WS numbering maps to the epic's WS1–WS5.
+
+## WS1 — generation-identity + warm reader-set abstraction (adopt #1749 contract)
+- [ ] 1.1 Introduce a flight-owned warm-handle registry keyed on generation identity (Decision 1):
+  `(table, inode-stable generation set)` with device+inode identity cross-checked against
+  `generation_of` (`cqlite-flight/src/producer.rs:237`). Surface: a `WarmTableRegistry` (or
+  equivalent) that hands `MergeProducer` a pre-resolved, pre-parsed reader/path set instead of
+  `DirSource::resolve` + cold reader-open. (flight-warm-handles)
+- [ ] 1.2 Model the warm set's diff/swap on `SSTableManager::refresh_tables`
+  (`cqlite-core/src/storage/sstable/refresh.rs`, #1749): open **added** generations, drop
+  **removed**, keep **unchanged** parsed state; atomic swap under a write guard; in-flight requests
+  hold `Arc` clones. Adapt the seam (Open Question 1) rather than route through `Database`. (flight-warm-handles)
+- [ ] 1.3 Red-then-green test: two `do_get`s for the same table reaching two different snapshot
+  hardlink dirs over the same inodes resolve to ONE warm entry; the second is a warm hit with zero
+  reader-open/parse. Fails on `main` (no warm state). Proves *Requirement: generation-identity
+  key*. (flight-warm-handles)
+
+## WS2 — refresh-trigger (the Seam-1 decision: per-request probe + manifest fast path)
+- [ ] 2.1 Per-request generation-set staleness probe (Decision 2a): enumerate the current
+  generation set, diff against the cached set; unchanged → warm hit (skip all reader-open/parse),
+  changed → rebuild the delta. Authoritative listing, no mtime/heuristic inference (#28). Surface:
+  the warm-handle lookup path in `do_get_setup` (`cqlite-flight/src/service.rs:479`). (flight-warm-handles)
+- [ ] 2.2 Snapshot `manifest.json` fast path (Decision 2b): byte-identical manifest → warm hit
+  without a `read_dir`; absent/unparsable manifest → fall back to the authoritative probe. (flight-warm-handles)
+- [ ] 2.3 Fail-closed (Decision 2, mirrors #1749): probe error → treat as "changed" (full
+  re-resolve); rebuild error (added generation fails to open, #1626) → previously warm set stays
+  fully intact, typed error surfaced. (flight-warm-handles)
+- [ ] 2.4 Red-then-green tests: unchanged set → warm hit, zero parse (work-done probe); added
+  generation → visible next request, zero staleness window; matching manifest → no `read_dir`;
+  absent manifest → authoritative-probe fallback; corrupt added `Statistics.db` → old set served
+  intact. Proves *Requirements: per-request staleness probe*, *manifest fast path*, *fail-closed
+  refresh*. (flight-warm-handles)
+
+## WS3 — snapshot-mode integration (hardlink/inode dedup validation)
+- [ ] 3.1 Wire the warm handle into snapshot resolution (`DirSource::resolve` snapshot branch,
+  `cqlite-flight/src/producer.rs:146`): per-query snapshot dirs stay (isolation + #2305
+  flush-on-snapshot unchanged) but resolve to the shared inode-keyed warm entry. (flight-warm-handles)
+- [ ] 3.2 Validate hardlink/inode dedup on a real per-query-snapshot fixture: two snapshot dirs over
+  the same inodes share one warm entry and return byte-identical batches; assert no snapshot-semantic
+  change (point-in-time result unchanged vs `main`). Proves the cross-snapshot warm-hit scenario. (flight-warm-handles)
+
+## WS4 — memory budget + eviction + metrics
+- [ ] 4.1 LRU eviction by (table, generation) with explicit byte accounting inside the <128MB
+  discipline (Decision 4); a removed-on-disk generation evicts immediately. Surface: the registry's
+  bounded-capacity policy. (flight-warm-handles)
+- [ ] 4.2 Bounded observability counters — warm hit / miss / evict / refresh-outcome
+  (unchanged / rebuilt-delta / fail-closed-retained) — riding the existing observability contract,
+  no new knob/env/ticket field. (flight-warm-handles)
+- [ ] 4.3 Red-then-green tests: exceeding the budget evicts LRU (footprint stays bounded, evicted
+  entry re-parses on next request); metrics distinguish miss/hit/rebuild. Proves *Requirements:
+  memory budget + eviction*, *metrics counters*. (flight-warm-handles)
+
+## WS5 — cancellation + bench evidence
+- [ ] 5.1 Cancellation through the warm path (Decision 5, #2264/#1473): pre-cancelled request does
+  zero probe/rebuild work and surfaces the `Cancelled` variant; disconnect mid-rebuild leaves the
+  warm set intact. Red-then-green test. Proves *Requirement: cancellation through cached paths*. (flight-warm-handles)
+- [ ] 5.2 Bench evidence on the #2289 harness (point read, LIMIT, full scan; ≥100k-partition table)
+  + #1494 bench suite: second identical query on an unchanged generation shows ~0 parse cost vs the
+  cold run, warm-hit counter increments, rows byte-identical. Proves *Requirement: bench evidence*. (flight-warm-handles)
+- [ ] 5.3 e2e wiring evidence: a real `FlightService::do_get` over the tonic transport, run twice for
+  the same table/generation, drives the warm path end-to-end (metrics show miss then hit) and returns
+  identical rows — the named public surface exercising the warm handle. (flight-warm-handles)
+
+## WS6 — endgame (flow-closer)
+- [ ] 6.1 `--lite` green on the full diff (summary-file redirect); rust-reviewer + roborev on the
+  lite-green diff (review-first); fix rounds re-run `--lite` + diff-scoped parity/integration targets.
+- [ ] 6.2 Open PR; hand to `flow-closer`: ONE full `scripts/agent-gate.sh` (run of record) →
+  spec-auditor **C** intent audit anchored to `specs/flight-warm-handles/spec.md` → final roborev →
+  merge-on-green (`gh pr merge --squash --delete-branch`) → `flow-finalize` (archive change, close
+  the WS child / update epic #2310, telemetry stamp).


### PR DESCRIPTION
Implements the owner-approved OpenSpec change `flight-warm-handles` (epic #2310). Closes #2345, closes #2341, closes #2342, closes #2343, closes #2344.

## What
`WarmTableRegistry` (new `cqlite-flight/src/warm/`: identity/probe/budget/metrics/registry + `producer_warm`): parsed SSTable state cached per **(table, inode-stable generation set)** — valid across per-query snapshot hardlink dirs; per-request authoritative generation-set probe (zero staleness window, #28-clean) with a snapshot `manifest.json` byte-identical fast path; **fail-closed** #1749-style open-before-swap (prior set intact on any error; in-flight requests hold pre-swap `Arc` clones); fixed 64 MiB byte budget + LRU by (table, generation), removed-on-disk evicts immediately; hit/miss/evict/refresh-outcome counters on the existing observability contract (no new knob); per-(table, DDL-hash) schema cache + live-mode resolve cache. Consumes #2346's shared-reader seam (`new_from_readers` / `build_single_partition_merger_from_readers` / per-call `scan_cancel`).

## Wiring evidence (public surface)
`do_get` → `do_get_setup` → `WarmTableRegistry::warm_readers` → `produce_streaming_from_readers` → `new_from_readers`. E2E over real tonic: `do_get_over_transport_second_request_is_a_warm_hit` (per-column `ArrayData` equality across requests). Aggregate route deliberately stays cold (documented).

## Review trail (review-first, 2 rounds)
- rust-reviewer: 1 Critical **fixed** — concurrent same-key rebuild duplicated readers + inflated `used_bytes` (red-proven `left:4, right:2` with dedup disabled; deterministic swap-barrier test). roborev 1637 independently found the same race.
- **UDT-registry parity (owner-decided split)**: warm now matches the cold path exactly (no registry — both assert identical posture); registry wiring for BOTH paths is #2349. No read-semantics change in this PR (spec non-goal).
- coverage-reviewer: R8 spec gap **fixed** — warm hits now reuse cached schema + live-mode dir resolution (probes assert zero re-parse/re-resolve on the second request); snapshot-mode resolve deliberately not cached (per-query dirs — documented honestly for the C audit). R3 manifest fast-path integration (listing-skipped proof), R4 in-flight isolation (latch), R7 mid-rebuild cancel (barrier hook, no partial swap), R5 budget/row-correctness hardening — all added.

## Notes
- Red proofs throughout: every spec `#### Scenario:` has a test; warm tests fail by construction on pre-#2310 main.
- Nit batch at merge: O(n²) evict rescan, `Arc` schema clone reuse, non-unix `device_inode` note.
- `CQLITE_ALLOW_FILE_GROWTH=1`: minimal integration nudges to over-threshold `service.rs`/`producer.rs` (#1116); all new logic in `warm/`.
- Full gate of record + spec-auditor **C** (design-routed) run pre-merge in flow-closer; `openspec archive` at finalize.