### PR TITLE
fix(#2352): warm hits fail closed to rebuild when cached reader paths are dead (P1 E2E ENOENT regression)

### DIFF
--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -200,10 +200,18 @@ impl WarmTableRegistry {
         match probe::probe_generation_set(dir, snapshot_mode, cached_manifest.as_deref(), cancel)? {
             ProbeOutcome::UnchangedByManifest => {
                 // Manifest fast path matched: serve the cached set with no
-                // reader-open/parse. A rare race (a concurrent rebuild replaced
-                // the entry) falls back to an authoritative re-enumeration.
-                if let Some(hit) = self.try_hit(key, ddl_hash, None) {
-                    return Ok(hit);
+                // reader-open/parse — but ONLY when every cached reader's backing
+                // path still resolves (issue #2352). A cached reader re-opens its
+                // `Data.db` lazily by the path it was opened from; if that was a
+                // per-query snapshot dir the connector has since cleared, serving
+                // it would ENOENT mid-scan. A dead cached path falls through to an
+                // authoritative re-enumeration + rebuild from the current live dir.
+                // A rare race (a concurrent rebuild replaced the entry) also falls
+                // back here.
+                if self.cached_paths_all_present(key, ddl_hash) {
+                    if let Some(hit) = self.try_hit(key, ddl_hash, None) {
+                        return Ok(hit);
+                    }
                 }
                 let entries = probe::enumerate_generations(dir)?;
                 let manifest = if snapshot_mode {
@@ -231,8 +239,16 @@ impl WarmTableRegistry {
         cancel: &CancelFlag,
     ) -> Result<WarmSet, WarmError> {
         let current_set = ProbeOutcome::set(&entries);
-        if let Some(hit) = self.try_hit(key, ddl_hash, Some((&current_set, manifest.clone()))) {
-            return Ok(hit);
+        // Serve a warm hit only when the generation SET matches AND every cached
+        // reader's backing path still resolves (issue #2352): a set-match over a
+        // fresh per-query snapshot dir whose PRIOR dir was cleared would otherwise
+        // hand back readers that ENOENT on their next lazy `Data.db` re-open. A
+        // dead cached path forces the fail-closed rebuild below, which re-opens the
+        // affected generation(s) from the current live `entries` path.
+        if self.cached_paths_all_present(key, ddl_hash) {
+            if let Some(hit) = self.try_hit(key, ddl_hash, Some((&current_set, manifest.clone()))) {
+                return Ok(hit);
+            }
         }
         self.rebuild(
             key,
@@ -321,21 +337,46 @@ impl WarmTableRegistry {
         // OUTSIDE the lock (slow I/O). `probe_start_set` is what THIS rebuild's
         // delta was computed against — the epoch guard below re-checks it hasn't
         // moved by the time we reach the swap (roborev 1639).
-        let cached_ids: Vec<GenerationId> = {
+        // Snapshot each cached generation's identity AND its reader's backing
+        // path under the brief lock; the path-liveness `stat`s run OUTSIDE the
+        // lock (no filesystem I/O under the registry mutex).
+        let cached: Vec<(GenerationId, std::path::PathBuf)> = {
             let inner = self.lock_inner();
             inner
                 .tables
                 .get(key)
                 .filter(|t| t.ddl_hash == ddl_hash)
-                .map(|t| t.readers.iter().map(|r| r.id).collect())
+                .map(|t| {
+                    t.readers
+                        .iter()
+                        .map(|r| (r.id, r.reader.file_path().to_path_buf()))
+                        .collect()
+                })
                 .unwrap_or_default()
         };
-        let probe_start_set = GenerationSet::from_ids(cached_ids.clone());
+        // `probe_start_set` is the FULL cached generation SET (by identity) this
+        // delta was computed against — the epoch guard below compares the LIVE
+        // entry's set to it to detect a concurrent fresher install. Path-liveness
+        // never changes the identity set, so the guard uses ALL cached ids.
+        let probe_start_set = GenerationSet::from_ids(cached.iter().map(|(id, _)| *id).collect());
 
-        // ADDED = present now, not already warm. Open them (fail-closed).
+        // Path-liveness (issue #2352): a cached generation counts as "already
+        // warm" ONLY when its backing `Data.db` still resolves. A dead-path
+        // generation (its per-query snapshot dir was cleared by the connector) is
+        // NOT kept — it lands in `added` and is RE-OPENED from the current live
+        // `entries` path, so a subsequent lazy scan re-open cannot ENOENT.
+        let alive_ids: HashSet<GenerationId> = cached
+            .iter()
+            .filter(|(_, p)| std::fs::metadata(p).is_ok())
+            .map(|(id, _)| *id)
+            .collect();
+
+        // ADDED = present now, not already warm on a LIVE path. Open them
+        // (fail-closed) — this includes both genuinely-new generations and
+        // dead-path ones being refreshed from the current live dir (#2352).
         let added: Vec<&GenerationEntry> = entries
             .iter()
-            .filter(|e| !cached_ids.contains(&e.id))
+            .filter(|e| !alive_ids.contains(&e.id))
             .collect();
         let opened = match self.open_added(&added, schema, cancel) {
             Ok(opened) => opened,
@@ -413,11 +454,18 @@ impl WarmTableRegistry {
         if let Some(prev) = inner.tables.remove(key) {
             if prev.ddl_hash == ddl_hash {
                 for r in prev.readers {
-                    if current_set.contains(&r.id) {
+                    // Keep a prior reader's parsed state ONLY when its generation
+                    // is still present AND its backing path is still live (issue
+                    // #2352). A present-but-dead-path generation is dropped here
+                    // and RE-OPENED from the live dir via `added`, so it is a
+                    // refresh (not an eviction) and is not counted as removed.
+                    if current_set.contains(&r.id) && alive_ids.contains(&r.id) {
                         kept.push(r);
                     } else {
                         freed = freed.saturating_add(r.footprint);
-                        removed_count += 1;
+                        if !current_set.contains(&r.id) {
+                            removed_count += 1;
+                        }
                     }
                 }
             } else {
@@ -584,6 +632,34 @@ impl WarmTableRegistry {
         self.inner.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
+    /// Whether every cached reader for `key` (when its DDL still matches) has a
+    /// backing `Data.db` that still resolves on disk (issue #2352).
+    ///
+    /// The warm cache keys parsed state on inode-stable generation identity, so a
+    /// fresh per-query snapshot hardlink dir (same inodes, new path) is a set
+    /// match — but a full-scan re-opens `Data.db` LAZILY by the PATH the reader
+    /// was opened from (`SSTableReader::new_scan_cursor` → `File::open`), unlike
+    /// the point-read path which holds a dedicated fd. When that path was an
+    /// ephemeral snapshot dir the connector has since cleared
+    /// (`SnapshotManager.clearSnapshot`), serving the cached reader would fail with
+    /// ENOENT mid-merge. Gating a warm hit on this predicate forces a dead-path
+    /// set to an authoritative rebuild from the current live dir instead.
+    ///
+    /// The reader `Arc`s are cloned under a brief lock; the `stat`s run OUTSIDE
+    /// the registry mutex (no filesystem I/O under the lock). A key with no cached
+    /// entry returns `true` vacuously — there is nothing stale to guard; the
+    /// caller's normal miss/rebuild handles it.
+    fn cached_paths_all_present(&self, key: &TableKey, ddl_hash: u64) -> bool {
+        let readers: Vec<Arc<SSTableReader>> = {
+            let inner = self.lock_inner();
+            match inner.tables.get(key).filter(|t| t.ddl_hash == ddl_hash) {
+                Some(t) => t.readers.iter().map(|r| Arc::clone(&r.reader)).collect(),
+                None => return true,
+            }
+        };
+        readers.iter().all(|r| reader_backing_present(r))
+    }
+
     /// Install the test-only swap rendezvous (see the field doc).
     #[cfg(test)]
     pub(crate) fn set_swap_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
@@ -663,6 +739,17 @@ impl WarmTableRegistry {
 /// `udt_registry = None`, so — to keep warm a parse-cost-only change with no
 /// read-semantics divergence — this does NOT set a registry either. Wiring a real
 /// registry into BOTH paths together is issue #2349; see the module doc.
+/// Whether a cached reader's backing `Data.db` still resolves on disk (issue
+/// #2352). A cheap `metadata` stat on the reader's `file_path` — the path is
+/// almost always dentry-cached, and this runs only on the per-request warm probe
+/// path, never a hot inner loop. Returning `false` (an ENOENT/`stat` failure)
+/// means the reader was opened from a path that has since been cleared (a
+/// per-query snapshot dir), so it must be re-opened from the current live dir
+/// rather than served (which would ENOENT on its next lazy scan re-open).
+fn reader_backing_present(reader: &SSTableReader) -> bool {
+    std::fs::metadata(reader.file_path()).is_ok()
+}
+
 fn open_one_reader(
     runtime: &tokio::runtime::Runtime,
     path: &Path,

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -33,8 +33,25 @@
 //! `Arc<SSTableReader>` clone is alive. This registry only ever evicts its OWN
 //! reference (per #1749's fail-closed model) and never deletes/replaces a
 //! generation's file out from under a live `Arc`; a snapshot's hardlinked inode
-//! outlives the per-query dir (the link keeps the inode alive), so the contract
-//! is satisfied trivially.
+//! outlives the per-query dir (the link keeps the inode alive), so THIS
+//! registry's own actions satisfy the contract trivially.
+//!
+//! That is not the whole story, though (issue #2352): an EXTERNAL actor — the
+//! Trino connector's per-query `SnapshotManager.clearSnapshot` — deletes the
+//! snapshot DIRECTORY (and, once its inode's last hardlink, the underlying
+//! `Data.db` bytes) once its query completes, entirely outside this registry's
+//! control. Inode identity keeps the cached READER alive as an `Arc` fine, but
+//! `SSTableReader`'s full-scan path re-opens `Data.db` LAZILY, by the path the
+//! reader was opened from (`new_scan_cursor` → `File::open`) — unlike the
+//! point-read path, which holds a dedicated fd for the reader's lifetime. A
+//! later warm hit over the SAME inode identity (a fresh per-query snapshot dir
+//! hardlinking it) would therefore serve a reader whose stored path is now dead,
+//! and a subsequent scan re-open would fail with ENOENT mid-merge. The
+//! path-liveness gate (`cached_paths_all_present` / `reader_backing_present`,
+//! checked at each warm-hit site below) is what covers this externally-driven
+//! case: a dead cached path forces a rebuild from the CURRENT live dir instead
+//! of being served. See the adjudication comment at the gate for the residual
+//! TOCTOU window this leaves open and why it is accepted.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -207,7 +224,10 @@ impl WarmTableRegistry {
                 // it would ENOENT mid-scan. A dead cached path falls through to an
                 // authoritative re-enumeration + rebuild from the current live dir.
                 // A rare race (a concurrent rebuild replaced the entry) also falls
-                // back here.
+                // back here. Accepted residual: a check-then-hit TOCTOU window
+                // between this `stat` and the served reader's later lazy scan
+                // re-open — see the adjudication comment on
+                // `cached_paths_all_present` (issue #2352, roborev job 1644).
                 if self.cached_paths_all_present(key, ddl_hash) {
                     if let Some(hit) = self.try_hit(key, ddl_hash, None) {
                         return Ok(hit);
@@ -244,7 +264,10 @@ impl WarmTableRegistry {
         // fresh per-query snapshot dir whose PRIOR dir was cleared would otherwise
         // hand back readers that ENOENT on their next lazy `Data.db` re-open. A
         // dead cached path forces the fail-closed rebuild below, which re-opens the
-        // affected generation(s) from the current live `entries` path.
+        // affected generation(s) from the current live `entries` path. Accepted
+        // residual: a check-then-hit TOCTOU window between this `stat` and the
+        // served reader's later lazy scan re-open — see the adjudication comment
+        // on `cached_paths_all_present` (issue #2352, roborev job 1644).
         if self.cached_paths_all_present(key, ddl_hash) {
             if let Some(hit) = self.try_hit(key, ddl_hash, Some((&current_set, manifest.clone()))) {
                 return Ok(hit);
@@ -649,6 +672,26 @@ impl WarmTableRegistry {
     /// the registry mutex (no filesystem I/O under the lock). A key with no cached
     /// entry returns `true` vacuously — there is nothing stale to guard; the
     /// caller's normal miss/rebuild handles it.
+    ///
+    /// ## Adjudicated residual: check-then-hit TOCTOU (issue #2352 adjudication,
+    /// roborev job 1644, rust-reviewer 2026-07-12)
+    ///
+    /// This gate is a `stat` at time T; the reader's next lazy scan re-open
+    /// (`new_scan_cursor` → `File::open`) happens LATER, at T+δ, and is
+    /// deliberately POST-LOCK (streaming holds no registry lock). A path can
+    /// therefore die inside the [T, T+δ) window — after this check passes but
+    /// before the scan actually opens the file. Accepted, not fixed here, because:
+    /// (1) holding the registry lock across the window cannot close it — the lazy
+    /// open lives inside the streaming producer, entirely outside any lock this
+    /// registry could hold; (2) a death inside the window surfaces as a transient
+    /// I/O error to that ONE in-flight request, never stale/incorrect DATA — the
+    /// reader's parsed state is untouched, only the byte source is gone; (3) the
+    /// NEXT request's gate re-`stat`s and self-heals via a fail-closed rebuild —
+    /// the same bound a freshly-swapped-in entry already has (it too could be
+    /// invalidated by an external actor moments after installation); (4) the true
+    /// closure — a durable fd/mmap held open at build time, or rebind-by-inode
+    /// instead of re-open-by-path — is a real design change, not a comment-sized
+    /// fix, and is tracked as issue #2356.
     fn cached_paths_all_present(&self, key: &TableKey, ddl_hash: u64) -> bool {
         let readers: Vec<Arc<SSTableReader>> = {
             let inner = self.lock_inner();

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -36,22 +36,14 @@
 //! outlives the per-query dir (the link keeps the inode alive), so THIS
 //! registry's own actions satisfy the contract trivially.
 //!
-//! That is not the whole story, though (issue #2352): an EXTERNAL actor — the
-//! Trino connector's per-query `SnapshotManager.clearSnapshot` — deletes the
-//! snapshot DIRECTORY (and, once its inode's last hardlink, the underlying
-//! `Data.db` bytes) once its query completes, entirely outside this registry's
-//! control. Inode identity keeps the cached READER alive as an `Arc` fine, but
-//! `SSTableReader`'s full-scan path re-opens `Data.db` LAZILY, by the path the
-//! reader was opened from (`new_scan_cursor` → `File::open`) — unlike the
-//! point-read path, which holds a dedicated fd for the reader's lifetime. A
-//! later warm hit over the SAME inode identity (a fresh per-query snapshot dir
-//! hardlinking it) would therefore serve a reader whose stored path is now dead,
-//! and a subsequent scan re-open would fail with ENOENT mid-merge. The
-//! path-liveness gate (`cached_paths_all_present` / `reader_backing_present`,
-//! checked at each warm-hit site below) is what covers this externally-driven
-//! case: a dead cached path forces a rebuild from the CURRENT live dir instead
-//! of being served. See the adjudication comment at the gate for the residual
-//! TOCTOU window this leaves open and why it is accepted.
+//! That is not the whole story (issue #2352): an EXTERNAL actor — the Trino
+//! connector's per-query `SnapshotManager.clearSnapshot` — deletes the snapshot
+//! dir after its query, outside this registry's control. Inode identity keeps
+//! a cached reader's `Arc` alive, but its full-scan path re-opens `Data.db`
+//! LAZILY by its stored path (unlike the point-read path's dedicated fd), so a
+//! later warm hit could serve a dead path → ENOENT mid-merge. The
+//! path-liveness gate (`cached_paths_all_present`, at each warm-hit site) covers
+//! this via rebuild — see its adjudication comment for the residual left open.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -218,16 +210,12 @@ impl WarmTableRegistry {
             ProbeOutcome::UnchangedByManifest => {
                 // Manifest fast path matched: serve the cached set with no
                 // reader-open/parse — but ONLY when every cached reader's backing
-                // path still resolves (issue #2352). A cached reader re-opens its
-                // `Data.db` lazily by the path it was opened from; if that was a
-                // per-query snapshot dir the connector has since cleared, serving
-                // it would ENOENT mid-scan. A dead cached path falls through to an
-                // authoritative re-enumeration + rebuild from the current live dir.
-                // A rare race (a concurrent rebuild replaced the entry) also falls
-                // back here. Accepted residual: a check-then-hit TOCTOU window
-                // between this `stat` and the served reader's later lazy scan
-                // re-open — see the adjudication comment on
-                // `cached_paths_all_present` (issue #2352, roborev job 1644).
+                // path still resolves (issue #2352, cached_paths_all_present); a
+                // dead path (e.g. a cleared per-query snapshot dir) falls through
+                // to a re-enumeration + rebuild instead of ENOENTing mid-scan. A
+                // rare race (a concurrent rebuild replaced the entry) also falls
+                // back here. Accepted TOCTOU residual — see the adjudication
+                // comment on `cached_paths_all_present` (roborev 1644).
                 if self.cached_paths_all_present(key, ddl_hash) {
                     if let Some(hit) = self.try_hit(key, ddl_hash, None) {
                         return Ok(hit);
@@ -260,14 +248,11 @@ impl WarmTableRegistry {
     ) -> Result<WarmSet, WarmError> {
         let current_set = ProbeOutcome::set(&entries);
         // Serve a warm hit only when the generation SET matches AND every cached
-        // reader's backing path still resolves (issue #2352): a set-match over a
-        // fresh per-query snapshot dir whose PRIOR dir was cleared would otherwise
-        // hand back readers that ENOENT on their next lazy `Data.db` re-open. A
-        // dead cached path forces the fail-closed rebuild below, which re-opens the
-        // affected generation(s) from the current live `entries` path. Accepted
-        // residual: a check-then-hit TOCTOU window between this `stat` and the
-        // served reader's later lazy scan re-open — see the adjudication comment
-        // on `cached_paths_all_present` (issue #2352, roborev job 1644).
+        // reader's backing path still resolves (issue #2352, cached_paths_all_present):
+        // a dead cached path (e.g. its snapshot dir was cleared) forces the
+        // fail-closed rebuild below instead of ENOENTing on a later re-open.
+        // Accepted check-then-hit TOCTOU residual — see the adjudication comment
+        // on `cached_paths_all_present` (roborev 1644).
         if self.cached_paths_all_present(key, ddl_hash) {
             if let Some(hit) = self.try_hit(key, ddl_hash, Some((&current_set, manifest.clone()))) {
                 return Ok(hit);
@@ -656,42 +641,24 @@ impl WarmTableRegistry {
     }
 
     /// Whether every cached reader for `key` (when its DDL still matches) has a
-    /// backing `Data.db` that still resolves on disk (issue #2352).
-    ///
-    /// The warm cache keys parsed state on inode-stable generation identity, so a
+    /// backing `Data.db` that still resolves on disk (issue #2352). The warm
+    /// cache keys parsed state on inode-stable generation identity, so a
     /// fresh per-query snapshot hardlink dir (same inodes, new path) is a set
     /// match — but a full-scan re-opens `Data.db` LAZILY by the PATH the reader
     /// was opened from (`SSTableReader::new_scan_cursor` → `File::open`), unlike
-    /// the point-read path which holds a dedicated fd. When that path was an
-    /// ephemeral snapshot dir the connector has since cleared
-    /// (`SnapshotManager.clearSnapshot`), serving the cached reader would fail with
-    /// ENOENT mid-merge. Gating a warm hit on this predicate forces a dead-path
-    /// set to an authoritative rebuild from the current live dir instead.
+    /// the point-read path's dedicated fd. When that path was an ephemeral
+    /// snapshot dir the connector has since cleared, serving the cached reader
+    /// would ENOENT mid-merge; this gate forces a dead-path set to a rebuild
+    /// instead. Reader `Arc`s are cloned under a brief lock; the `stat`s run
+    /// outside it. No cached entry returns `true` vacuously.
     ///
-    /// The reader `Arc`s are cloned under a brief lock; the `stat`s run OUTSIDE
-    /// the registry mutex (no filesystem I/O under the lock). A key with no cached
-    /// entry returns `true` vacuously — there is nothing stale to guard; the
-    /// caller's normal miss/rebuild handles it.
-    ///
-    /// ## Adjudicated residual: check-then-hit TOCTOU (issue #2352 adjudication,
-    /// roborev job 1644, rust-reviewer 2026-07-12)
-    ///
-    /// This gate is a `stat` at time T; the reader's next lazy scan re-open
-    /// (`new_scan_cursor` → `File::open`) happens LATER, at T+δ, and is
-    /// deliberately POST-LOCK (streaming holds no registry lock). A path can
-    /// therefore die inside the [T, T+δ) window — after this check passes but
-    /// before the scan actually opens the file. Accepted, not fixed here, because:
-    /// (1) holding the registry lock across the window cannot close it — the lazy
-    /// open lives inside the streaming producer, entirely outside any lock this
-    /// registry could hold; (2) a death inside the window surfaces as a transient
-    /// I/O error to that ONE in-flight request, never stale/incorrect DATA — the
-    /// reader's parsed state is untouched, only the byte source is gone; (3) the
-    /// NEXT request's gate re-`stat`s and self-heals via a fail-closed rebuild —
-    /// the same bound a freshly-swapped-in entry already has (it too could be
-    /// invalidated by an external actor moments after installation); (4) the true
-    /// closure — a durable fd/mmap held open at build time, or rebind-by-inode
-    /// instead of re-open-by-path — is a real design change, not a comment-sized
-    /// fix, and is tracked as issue #2356.
+    /// Adjudicated residual — check-then-hit TOCTOU (#2352 adjudication, roborev
+    /// job 1644, rust-reviewer 2026-07-12): this gate `stat`s at T; the lazy scan
+    /// re-open happens LATER at T+δ, POST-LOCK — a path can die in [T, T+δ).
+    /// Accepted: the lock can't close the window (the open is inside the
+    /// streaming producer); a death there is a transient I/O error on one
+    /// request, never stale data; the NEXT request's gate self-heals via
+    /// rebuild; true closure (durable fd/mmap, or rebind-by-inode) is #2356.
     fn cached_paths_all_present(&self, key: &TableKey, ddl_hash: u64) -> bool {
         let readers: Vec<Arc<SSTableReader>> = {
             let inner = self.lock_inner();

--- a/cqlite-flight/src/warm/registry_tests.rs
+++ b/cqlite-flight/src/warm/registry_tests.rs
@@ -117,6 +117,89 @@ fn cross_snapshot_dirs_share_one_warm_entry() {
     assert_eq!(w2.readers.len(), w1.readers.len(), "same reader set");
 }
 
+/// Regression (issue #2352): the connector creates a FRESH per-query snapshot
+/// dir and CLEARS the prior one after each query (`SnapshotManager.clearSnapshot`).
+/// The warm cache keys on inode identity, so query N+1's new snapshot dir (same
+/// inodes) is a set-match hit — but the cached reader re-opens its `Data.db`
+/// LAZILY by the PATH it was opened from (query N's snapshot dir), which the
+/// connector has since deleted. A full-scan through the warm readers then fails
+/// with `No such file or directory (os error 2)` mid-merge — the 9 nightly
+/// Flight↔Trino E2E failures.
+///
+/// RED on unfixed code: the second `warm_readers` returns a silent `Unchanged`
+/// hit carrying readers whose backing path (the deleted `snap1`) no longer
+/// resolves, so `decode_names` (the same streaming-merge path `do_get` drives)
+/// panics with the ENOENT. GREEN after the fix: a dead cached path forces an
+/// authoritative rebuild from the current LIVE dir (`snap2`), the scan reads the
+/// live inodes, and the rows decode correctly — counted as a refresh
+/// (`RebuiltDelta`), never a stale hit.
+#[test]
+fn warm_hit_after_snapshot_teardown_rebuilds_instead_of_enoent() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(
+        &schema,
+        vec![
+            vec![write_row(1, "a", 1, 100)],
+            vec![write_row(2, "b", 2, 100)],
+        ],
+    );
+
+    // Query N: a per-query snapshot dir; warm the cache from it (readers open
+    // with their `file_path` inside `snap1`).
+    let snap1 = make_snapshot(&table_dir, "snap1");
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+    let w1 = reg
+        .warm_readers(&key(), ddl(), &schema, &snap1, Some("snap1"), &cancel)
+        .expect("first snapshot warms");
+    assert_eq!(w1.outcome, RefreshOutcome::RebuiltDelta, "first is a build");
+    assert_eq!(
+        decode_names(&schema, w1.readers),
+        vec!["a".to_string(), "b".to_string()],
+        "first query decodes correctly from the live snapshot dir"
+    );
+
+    // Connector clears the query-N snapshot; the LIVE inodes in `table_dir`
+    // persist. The cached readers' `file_path`s are now dead paths.
+    std::fs::remove_dir_all(&snap1).expect("clear the query-N snapshot dir");
+
+    // Query N+1: a NEW per-query snapshot dir over the SAME inodes. Inode-keyed
+    // identity makes this a set-match — but a dead cached path must NOT be served.
+    let snap2 = make_snapshot(&table_dir, "snap2");
+    let w2 = reg
+        .warm_readers(&key(), ddl(), &schema, &snap2, Some("snap2"), &cancel)
+        .expect("second snapshot request after the first was cleared");
+
+    // The fix: a dead cached path is a rebuild (a refresh outcome), never a
+    // silent stale hit.
+    assert_eq!(
+        w2.outcome,
+        RefreshOutcome::RebuiltDelta,
+        "a cleared cached snapshot path forces a rebuild from the current live \
+         dir, not a stale warm hit (issue #2352)"
+    );
+    // Every returned reader must have a LIVE backing path (rebuilt from snap2),
+    // so a full-scan re-open cannot ENOENT.
+    for r in &w2.readers {
+        assert!(
+            std::fs::metadata(r.file_path()).is_ok(),
+            "warm reader must back a live path after teardown, got dead {}",
+            r.file_path().display()
+        );
+    }
+    // THE regression assertion: streaming the warm readers (the exact path
+    // `do_get` drives) no longer ENOENTs and returns the correct rows. On unfixed
+    // code the stale `Unchanged` hit above carries readers pointing at the
+    // deleted `snap1`, so this `decode_names` panics with
+    // `No such file or directory (os error 2)` mid-merge — the nightly signature.
+    assert_eq!(
+        decode_names(&schema, w2.readers),
+        vec!["a".to_string(), "b".to_string()],
+        "streaming the rebuilt warm readers reads the live inodes correctly \
+         (no ENOENT mid-merge)"
+    );
+}
+
 /// Warm/cold UDT-registry PARITY (spec non-goal: warm is a parse-cost change
 /// only, never a read-semantics change; #2349): the warm path must open readers
 /// with the SAME UDT-registry posture as the cold path. The cold Flight path
@@ -524,12 +607,20 @@ fn lru_evicts_when_over_budget() {
     );
 }
 
-/// Requirement 3 (snapshot manifest fast path): a byte-identical snapshot
-/// `manifest.json` serves the cached set WITHOUT relisting the directory. Proven
-/// by making an authoritative listing impossible to satisfy — every `Data.db` is
-/// deleted after warming, so a `read_dir` would enumerate ZERO generations (→ a
-/// rebuild to an empty set), while the manifest fast path still serves the two
-/// cached readers.
+/// Requirement 3 (snapshot manifest fast path), corrected for issue #2352: a
+/// byte-identical snapshot `manifest.json` serves the cached set WITHOUT relisting
+/// the directory — proven by planting a THIRD `Data.db` on disk that the manifest
+/// does NOT list. The fast path (trusting the manifest) serves exactly the two
+/// cached readers and never `read_dir`s the third file; an authoritative relist
+/// would enumerate three generations and rebuild to a different set.
+///
+/// The pre-#2352 version proved "no relist" by DELETING every `Data.db` after
+/// warming and asserting the cached readers were still served. That encoded the
+/// exact ENOENT regression #2352 fixes: a warm hit must NEVER serve a reader whose
+/// backing `Data.db` has been cleared (a full-scan would re-open the dead path and
+/// fail mid-merge). So the two real files are kept LIVE here — a dead-path cached
+/// set now rebuilds from the current live dir instead of being served (see
+/// `warm_hit_after_snapshot_teardown_rebuilds_instead_of_enoent`).
 #[test]
 fn manifest_fast_path_serves_cached_without_relisting() {
     let schema = simple_schema();
@@ -555,17 +646,10 @@ fn manifest_fast_path_serves_cached_without_relisting() {
     assert_eq!(w1.readers.len(), 2, "both generations warmed");
     let opens = reg.metrics().snapshot().reader_opens;
 
-    // Delete every Data.db (the cached Arc readers keep the inodes alive), leaving
-    // the manifest byte-identical: an authoritative relisting would now find ZERO.
-    for e in std::fs::read_dir(&snap).unwrap().flatten() {
-        let p = e.path();
-        if p.file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| n.ends_with("-Data.db"))
-        {
-            std::fs::remove_file(&p).unwrap();
-        }
-    }
+    // Plant a THIRD Data.db the manifest does NOT list, keeping the two real files
+    // LIVE. The manifest fast path (byte-identical manifest) must ignore it (no
+    // read_dir); an authoritative relist would enumerate 3 generations and rebuild.
+    std::fs::write(snap.join("nb-3-big-Data.db"), b"not-a-real-sstable").unwrap();
 
     let w2 = reg
         .warm_readers(&key(), ddl(), &schema, &snap, Some("snap1"), &cancel)
@@ -573,12 +657,13 @@ fn manifest_fast_path_serves_cached_without_relisting() {
     assert_eq!(
         w2.outcome,
         RefreshOutcome::Unchanged,
-        "identical manifest → warm hit (a relisting would have rebuilt to empty)"
+        "identical manifest → warm hit via the fast path (a relist would have \
+         seen 3 generations and NOT reported Unchanged)"
     );
     assert_eq!(
         w2.readers.len(),
         2,
-        "the cached set is served — the directory was NOT relisted"
+        "the two cached readers are served — the planted third file was never relisted"
     );
     assert_eq!(
         reg.metrics().snapshot().reader_opens,


### PR DESCRIPTION
Fixes #2352 — nightly Flight↔Trino E2E red since the #2310 warm-handles merge: 9 assertions failing with `streaming merge producer error: I/O error: No such file or directory`.

## Root cause (evidence-backed)
Warm cache keys readers by device+inode so a fresh per-query snapshot dir is a hit — but scans lazily re-open Data.db by the reader's stored **path** (`new_scan_cursor → scan_source.open(&self.file_path)`), while point reads use a held fd (`point_source`). The connector's per-query snapshot mode **deletes each snapshot dir after its query** (`SnapshotManager.clearSnapshot`) → a later warm hit served readers pointing at a dead path → ENOENT mid-merge on every row-scan shape (exactly the failing/passing split in the nightly).

## Fix
A warm hit is served only when every cached reader's backing path still resolves (`cached_paths_all_present`, stat outside the lock — never an open, zero-reader-open warm-hit property preserved). A dead path **fail-closes to an authoritative rebuild** (dead generation treated as `added`/re-open from the current dir), counted as `RebuiltDelta` + miss — never a silent stale hit, never stale data (changed inodes = different GenerationId = old reader dropped). Gated on BOTH hit paths (manifest fast path + enumerated probe).

## Evidence
- **Red-proven repro** `warm_hit_after_snapshot_teardown_rebuilds_instead_of_enoent`: unfixed code serves an `Unchanged` stale hit whose readers ENOENT in the streaming path; fixed asserts `RebuiltDelta` + live paths + correct rows.
- Corrected `manifest_fast_path_serves_cached_without_relisting`, which previously *encoded* the unsound behavior (deleted live files to 'prove' no-relist); now uses an unlisted planted file — a sharp discriminator.
- **Local docker E2E: 34/34 PASS** including all six previously-failing shapes; zero ENOENT in the log (/tmp/e2e-2352.log).
- 43/43 warm tests green incl. both #2310 warm-hit perf-property tests; lite PASS (/tmp/gate-2352-lite3.txt).

## Review record (review-first)
- rust-reviewer: **CLEAN, 0 blockers**; 3 nits → 2 batched on #2351, 1 (stale module doc) fixed here.
- roborev job 1644: 1 Medium (check-then-hit TOCTOU) — **DECLINED with evidence**: lock-holding cannot close the window (the lazy open is post-lock inside the streaming producer), a swapped-in entry is install-time-live with the same self-heal bound, stale data impossible in all variants; full closure = durable-fd/rebind, tracked as **#2356**. In-code adjudication comments added at the gate + both hit sites.

## Residual (tracked, out of scope)
- **#2356**: in per-query-snapshot mode the fail-closed rebuild fires per request — #2310's warm benefit is currently live-mode/stable-path only; rebind-by-inode design sketched there.
- CI blind spot (docker-compose E2E never runs on PRs) — wiring it for flight/trino-touching PRs remains open on #2352's checklist; if not done here, it must be spun into its own issue before #2352 closes.

Full gate of record runs in the closer pre-merge.