### PR TITLE
ci(#2359): unbreak broad lanes — drop deleted test target, metadata-driven feature-aware nextest archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,14 +269,39 @@ jobs:
           bash scripts/ci/ci-timing-summary.sh measure "core integration archive" -- bash <<'BASH'
           set -euo pipefail
           ARCHIVE_FILE="target/nextest/core-integration-tests.tar.zst"
+          # Enumerate cqlite-core integration `--test` targets from authoritative
+          # Cargo metadata (issue #2359). A feature-blind `find` archived every
+          # tests/*.rs with only `--features cli-helpers`, so a target carrying
+          # `required-features` NOT enabled here (the arrow-only
+          # issue_1495_arrow_accessor_parity, the work-counters+write-support
+          # issue_2302_written_index_resolve) broke the archive build. Each such
+          # target has its OWN dedicated gate executor (see cqlite-core/Cargo.toml),
+          # so we skip them here — LOUDLY, never silently — and this stays correct
+          # as new feature-gated targets land.
+          core_metadata="$(cargo metadata --no-deps --format-version 1)"
           mapfile -t integration_tests < <(
-            find cqlite-core/tests -maxdepth 1 -type f -name '*.rs' -print \
-              | sed 's#^cqlite-core/tests/##; s#\.rs$##' \
-              | sort
+            printf '%s' "$core_metadata" | jq -r '
+              .packages[] | select(.name == "cqlite-core") | .targets[]
+              | select(.kind[] == "test")
+              | select(((."required-features" // []) | length) == 0)
+              | .name' | sort
+          )
+          mapfile -t skipped_tests < <(
+            printf '%s' "$core_metadata" | jq -r '
+              .packages[] | select(.name == "cqlite-core") | .targets[]
+              | select(.kind[] == "test")
+              | select(((."required-features" // []) | length) > 0)
+              | "\(.name) [requires: \((."required-features") | join(","))]"' | sort
           )
           if [ "${#integration_tests[@]}" -eq 0 ]; then
             echo "No cqlite-core integration test targets found" >&2
             exit 1
+          fi
+          if [ "${#skipped_tests[@]}" -gt 0 ]; then
+            echo "⚠️  Skipping ${#skipped_tests[@]} cqlite-core --test target(s) whose required-features are not enabled by this archive (--features cli-helpers); each has a dedicated gate executor:" >&2
+            for skipped in "${skipped_tests[@]}"; do
+              echo "     - $skipped" >&2
+            done
           fi
 
           cmd=(
@@ -296,7 +321,8 @@ jobs:
             echo "### Core integration nextest archive"
             echo
             echo "- Archive: \`$ARCHIVE_FILE\`"
-            echo "- Target set: ${#integration_tests[@]} explicit \`cqlite-core/tests/*.rs\` integration targets"
+            echo "- Target set: ${#integration_tests[@]} metadata-enumerated \`cqlite-core\` integration \`--test\` targets"
+            echo "- Skipped (required-features not enabled here; dedicated gate executors): ${#skipped_tests[@]}"
           } >> "$GITHUB_STEP_SUMMARY"
           BASH
 
@@ -561,7 +587,6 @@ jobs:
           # are intentionally excluded here because they use synthetic metadata with
           # inconsistent chunk sizes unrelated to the UUID-discovery fix.
           cargo test --package cqlite-integration-tests \
-            --test chunked_data_reader_direct_test \
             --test comprehensive_component_integration_tests \
             --test fixture_specific_integration_tests \
             --test golden_path_get_operations_tests \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,25 +272,39 @@ jobs:
           # Enumerate cqlite-core integration `--test` targets from authoritative
           # Cargo metadata (issue #2359). A feature-blind `find` archived every
           # tests/*.rs with only `--features cli-helpers`, so a target carrying
-          # `required-features` NOT enabled here (the arrow-only
+          # `required-features` NOT satisfiable here (the arrow-only
           # issue_1495_arrow_accessor_parity, the work-counters+write-support
           # issue_2302_written_index_resolve) broke the archive build. Each such
           # target has its OWN dedicated gate executor (see cqlite-core/Cargo.toml),
           # so we skip them here — LOUDLY, never silently — and this stays correct
           # as new feature-gated targets land.
           core_metadata="$(cargo metadata --no-deps --format-version 1)"
+          # Subset rule: skip a target ONLY when its required-features are not a
+          # subset of this build's transitively-enabled feature set — the closure
+          # of cqlite-core's `default` feature + `cli-helpers` (`--features` ADDS
+          # to defaults, it does not replace them) over the metadata `.features`
+          # graph, never a hand-maintained list. A target gated on an
+          # already-enabled feature (e.g. the default `write-support`) is
+          # satisfiable and stays archived.
+          enabled_features="$(printf '%s' "$core_metadata" | jq -c '
+            .packages[] | select(.name == "cqlite-core") | .features as $f
+            | def close: . as $s
+                | ([$s[], ($s[] | ($f[.] // [])[] | select(in($f)))] | unique)
+                | if length == ($s | length) then . else close end;
+            (["default", "cli-helpers"] | map(select(in($f)))) | close')"
+          echo "Archive-enabled cqlite-core feature closure: $enabled_features"
           mapfile -t integration_tests < <(
-            printf '%s' "$core_metadata" | jq -r '
+            printf '%s' "$core_metadata" | jq -r --argjson enabled "$enabled_features" '
               .packages[] | select(.name == "cqlite-core") | .targets[]
               | select(.kind[] == "test")
-              | select(((."required-features" // []) | length) == 0)
+              | select((((."required-features" // []) - $enabled) | length) == 0)
               | .name' | sort
           )
           mapfile -t skipped_tests < <(
-            printf '%s' "$core_metadata" | jq -r '
+            printf '%s' "$core_metadata" | jq -r --argjson enabled "$enabled_features" '
               .packages[] | select(.name == "cqlite-core") | .targets[]
               | select(.kind[] == "test")
-              | select(((."required-features" // []) | length) > 0)
+              | select((((."required-features" // []) - $enabled) | length) > 0)
               | "\(.name) [requires: \((."required-features") | join(","))]"' | sort
           )
           if [ "${#integration_tests[@]}" -eq 0 ]; then
@@ -298,7 +312,7 @@ jobs:
             exit 1
           fi
           if [ "${#skipped_tests[@]}" -gt 0 ]; then
-            echo "⚠️  Skipping ${#skipped_tests[@]} cqlite-core --test target(s) whose required-features are not enabled by this archive (--features cli-helpers); each has a dedicated gate executor:" >&2
+            echo "⚠️  Skipping ${#skipped_tests[@]} cqlite-core --test target(s) whose required-features are not a subset of this archive's enabled feature closure (default + cli-helpers); each has a dedicated gate executor:" >&2
             for skipped in "${skipped_tests[@]}"; do
               echo "     - $skipped" >&2
             done
@@ -322,7 +336,7 @@ jobs:
             echo
             echo "- Archive: \`$ARCHIVE_FILE\`"
             echo "- Target set: ${#integration_tests[@]} metadata-enumerated \`cqlite-core\` integration \`--test\` targets"
-            echo "- Skipped (required-features not enabled here; dedicated gate executors): ${#skipped_tests[@]}"
+            echo "- Skipped (required-features not satisfiable here; dedicated gate executors): ${#skipped_tests[@]}"
           } >> "$GITHUB_STEP_SUMMARY"
           BASH
 


### PR DESCRIPTION
Fixes #2359 — the `CI [push]` broad lanes have been red on EVERY main push since 2026-07-06 (last green 2561aede). Two stacked deterministic build-time regressions in ci.yml, both from hand-duplicated target lists diverging from the gate's metadata-driven logic:

## Fix 1 — Integration tests job
Dropped the hardcoded `--test chunked_data_reader_direct_test` (target deleted by PR #2053, which fixed the gate's list but missed ci.yml's duplicate). All 6 surviving named targets verified present.

## Fix 2 — Core integration nextest archive
Replaced the feature-blind `find cqlite-core/tests` enumeration with **cargo-metadata-driven enumeration** with a **satisfiability rule**: a target is skipped only when its `required-features` are not a subset of the archive's enabled feature closure (computed at runtime from the metadata `.features` graph — closure of default + cli-helpers; no hand-maintained feature list). Skips are LOUD (per-target echo + step-summary count), never silent. Today: 309 included / 2 skipped (`issue_1495_arrow_accessor_parity` [arrow], `issue_2302_written_index_resolve` [work-counters] — both documented as gate-component-only executors, so coverage-neutral). Future feature-gated targets auto-handle.

## Proof (dispatch oracle — run BEFORE merge)
- Green broad-lane run on the ORIGINAL fix: run 29205766302 (SUCCESS, both failing jobs green)
- Green broad-lane run on the FINAL tip `ead9d320`: **run 29207383897** (SUCCESS, zero failed jobs, closure + 2 expected skips visible in logs)

## Review record
- roborev job 1646: 1 Medium (any-nonempty skip too coarse — would silently drop future satisfiable targets) → **FIXED** in ead9d320 (the subset rule above), re-proven via the second dispatch run
- roborev job 1647 on final tip: **No issues found**
- No ${{ }} interpolation in run: blocks; workflow-only diff; lite PASS (/tmp/gate-2359-lite2.txt)

Post-merge acceptance: next main push run green end-to-end (lead observes).