### PR TITLE
fix(#2383): resolve-phase Index.db re-parse spin — single-flight opens, rebind-by-inode, cancel-aware parse (round-8 field blocker)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -156,6 +156,23 @@ pub const READ_PARTITIONS: &str = "cqlite.read.partitions";
 /// attributes: [`attr::SSTABLE_FORMAT`].
 pub const READ_DURATION: &str = "cqlite.read.duration";
 
+/// `cqlite.sstable.index_parses_total` — counter `1` (issue #2383).
+///
+/// Incremented ONCE each time the full BIG/NB `Index.db` partition index is
+/// parsed end-to-end into partition entries (`parse_all_partition_keys_with_summary`,
+/// the O(entries) `memcmp`/vint loop that dominates opening a reader for a
+/// many-partition SSTable). It is the scale-free, path-independent probe for the
+/// #2383 resolve-phase CPU spin: the field failure re-parsed the SAME 1.58M-entry
+/// Index.db 8× for one logical query (redundant per-generation opens across
+/// per-query snapshot teardown + un-coalesced concurrent splits), so this counter
+/// climbs far past the number of distinct generations. A correct read path parses
+/// each generation's Index.db at most ONCE per query (warm reuse / rebind
+/// thereafter), so `index_parses_total ≈ Σ generations`, not `Σ generations ×
+/// opens`. Emitted from every full-parse site (warm rebuild, aggregate merge,
+/// point-read routing) so no single call path can hide a redundant parse. No
+/// high-cardinality attributes.
+pub const INDEX_PARSES_TOTAL: &str = "cqlite.sstable.index_parses_total";
+
 /// `cqlite.storage.open.sstables` — counter `{sstable}`.
 ///
 /// SSTables discovered and opened by a single [`StorageEngine`] open, summed
@@ -574,6 +591,7 @@ pub const ALL_METRICS: &[&str] = &[
     MERGE_ROWS_IN,
     MERGE_ROWS_OUT,
     QUERY_DEGRADED_PATH,
+    INDEX_PARSES_TOTAL,
     STORAGE_OPEN_SSTABLES,
     STORAGE_OPEN_BYTES,
     STORAGE_OPEN_TABLES,
@@ -697,6 +715,15 @@ mod tests {
         assert!(ALL_METRICS.contains(&RPC_PHASE_ACTIVE));
         assert_eq!(RPC_PHASE_ACTIVE, "cqlite.rpc.phase.active");
         assert!(RPC_PHASE_ACTIVE.starts_with("cqlite."));
+    }
+
+    #[test]
+    fn index_parses_total_counter_is_registered_and_namespaced() {
+        // Issue #2383: the redundant-Index.db-parse probe must be catalogued (so
+        // the registration/uniqueness checks cover it) and namespaced.
+        assert!(ALL_METRICS.contains(&INDEX_PARSES_TOTAL));
+        assert_eq!(INDEX_PARSES_TOTAL, "cqlite.sstable.index_parses_total");
+        assert!(INDEX_PARSES_TOTAL.starts_with("cqlite."));
     }
 
     #[test]

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -274,6 +274,7 @@ struct Instruments {
     merge_rows_in: Counter<u64>,
     merge_rows_out: Counter<u64>,
     query_degraded_path: Counter<u64>,
+    index_parses_total: Counter<u64>,
     storage_open_sstables: Counter<u64>,
     storage_open_bytes: Counter<u64>,
     storage_open_tables: Counter<u64>,
@@ -381,6 +382,11 @@ fn instruments() -> &'static Instruments {
                 .with_description(
                     "SELECTs taking a soundness fallback, keyed by {fallback_reason}.",
                 )
+                .build(),
+            index_parses_total: m
+                .u64_counter(catalog::INDEX_PARSES_TOTAL)
+                .with_unit(catalog::unit::DIMENSIONLESS)
+                .with_description("Full Index.db partition-index parses (#2383 spin probe).")
                 .build(),
             storage_open_sstables: m
                 .u64_counter(catalog::STORAGE_OPEN_SSTABLES)
@@ -605,6 +611,7 @@ pub(crate) fn add_counter(name: &'static str, value: u64, attributes: &[KeyValue
         catalog::MERGE_ROWS_IN => &i.merge_rows_in,
         catalog::MERGE_ROWS_OUT => &i.merge_rows_out,
         catalog::QUERY_DEGRADED_PATH => &i.query_degraded_path,
+        catalog::INDEX_PARSES_TOTAL => &i.index_parses_total,
         catalog::STORAGE_OPEN_SSTABLES => &i.storage_open_sstables,
         catalog::STORAGE_OPEN_BYTES => &i.storage_open_bytes,
         catalog::STORAGE_OPEN_TABLES => &i.storage_open_tables,

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -585,7 +585,7 @@ pub(super) async fn stream_generations_for_read(
 fn ordered_generation_paths(reader_list: &[Arc<reader::SSTableReader>]) -> Vec<PathBuf> {
     let mut ordered: Vec<&Arc<reader::SSTableReader>> = reader_list.iter().collect();
     ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
-    ordered.iter().map(|r| r.file_path.clone()).collect()
+    ordered.iter().map(|r| r.file_path()).collect()
 }
 
 #[cfg(test)]

--- a/cqlite-core/src/storage/sstable/index_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/mod.rs
@@ -225,7 +225,10 @@ impl IndexReader {
                 // `WarmError::Cancelled` rather than a fail-closed retain.
                 Err(e @ Error::Cancelled) => return Err(e),
                 Err(e) => {
-                    return Err(Error::corruption(format!("Failed to parse Index.db: {:?}", e)));
+                    return Err(Error::corruption(format!(
+                        "Failed to parse Index.db: {:?}",
+                        e
+                    )));
                 }
             };
 

--- a/cqlite-core/src/storage/sstable/index_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/mod.rs
@@ -23,7 +23,7 @@ use super::summary_reader::SummaryReader;
 // working for `verify.rs`, `s3_verification_test.rs`, and the in-module tests.
 mod parse;
 pub(crate) use parse::parse_big_index_entry;
-use parse::parse_index_data_with_summary;
+use parse::parse_index_data_cancellable;
 // `parse_all_partition_keys` (legacy API) is consumed only by in-crate test modules
 // (`s3_verification_test.rs`, the `tests` module below).
 #[cfg(test)]
@@ -165,6 +165,26 @@ impl IndexReader {
         platform: Arc<Platform>,
         summary_reader: Option<&SummaryReader>,
     ) -> Result<Self> {
+        Self::open_with_summary_cancellable(
+            path,
+            platform,
+            summary_reader,
+            &crate::storage::scan_cancel::ScanCancel::default(),
+        )
+        .await
+    }
+
+    /// Cancel-aware variant of [`Self::open_with_summary`] (issue #2383 fix C):
+    /// the O(entries) partition-index parse polls `cancel` at a bounded interval
+    /// and returns [`Error::Cancelled`] promptly on a client-disconnect trip,
+    /// instead of pinning a worker to completion. Non-cancellable callers use
+    /// [`Self::open`]/[`Self::open_with_summary`] with a default never-cancel flag.
+    pub async fn open_with_summary_cancellable(
+        path: &Path,
+        platform: Arc<Platform>,
+        summary_reader: Option<&SummaryReader>,
+        cancel: &crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<Self> {
         if !platform.fs().exists(path).await? {
             return Err(Error::not_found(format!(
                 "Index.db file not found: {}",
@@ -197,15 +217,17 @@ impl IndexReader {
         // sensitive FULL enumeration can reject a mid-entry-truncated index; the
         // residual boundary-aligned-drop gap is closed at the enumeration site by
         // the last-partition coverage check. No heuristics (issue #28).
-        let (remaining, index_data) = match parse_index_data_with_summary(&buffer, summary_reader) {
-            Ok((remaining, data)) => (remaining, data),
-            Err(e) => {
-                return Err(Error::corruption(format!(
-                    "Failed to parse Index.db: {:?}",
-                    e
-                )));
-            }
-        };
+        let (remaining, index_data) =
+            match parse_index_data_cancellable(&buffer, summary_reader, cancel) {
+                Ok((remaining, data)) => (remaining, data),
+                // A mid-parse cancellation (issue #2383) is surfaced by VARIANT, never
+                // masked as a corruption error, so the warm path maps it to
+                // `WarmError::Cancelled` rather than a fail-closed retain.
+                Err(e @ Error::Cancelled) => return Err(e),
+                Err(e) => {
+                    return Err(Error::corruption(format!("Failed to parse Index.db: {:?}", e)));
+                }
+            };
 
         // A well-formed Index.db is a sequence of WHOLE entries running exactly to
         // EOF (the `rest.is_empty()` parity asserts in this module's tests). Leftover

--- a/cqlite-core/src/storage/sstable/index_reader/parse.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/parse.rs
@@ -217,10 +217,19 @@ pub(super) fn parse_all_partition_keys_cancellable<'a>(
     }
 
     tracing::debug!("Parsed {} partition entries from Index.db", entries.len());
-    // Issue #2383: count every full Index.db parse so a redundant re-parse of the
-    // SAME generation (the resolve-phase CPU spin) is observable in metrics — a
-    // correct read path parses each generation's index at most once per query.
-    crate::observability::add_counter(crate::observability::catalog::INDEX_PARSES_TOTAL, 1, &[]);
+    // Issue #2383 (roborev-1653 Low): count only a FULL pass — `remaining`
+    // non-empty means the loop `break`-ed early on a malformed/truncated tail
+    // (the documented partial-prefix tolerance `IndexReader::open` relies on for
+    // BIG point-lookup callers), which is NOT the "re-parsed the same generation"
+    // spin this counter exists to observe. Counting it would over-count partial
+    // parses against the counter's documented "one full Index.db parse" meaning.
+    if remaining.is_empty() {
+        crate::observability::add_counter(
+            crate::observability::catalog::INDEX_PARSES_TOTAL,
+            1,
+            &[],
+        );
+    }
     Ok((remaining, entries))
 }
 

--- a/cqlite-core/src/storage/sstable/index_reader/parse.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/parse.rs
@@ -9,73 +9,58 @@
 
 use super::{IndexData, IndexHeader, PartitionIndexEntry, PromotedIndexData};
 use crate::parser::vint::parse_vuint;
+use crate::storage::scan_cancel::ScanCancel;
 use crate::storage::sstable::header_spec::get_global_registry;
 use crate::storage::sstable::summary_reader::SummaryReader;
+use crate::Result;
 use nom::{bytes::complete::take, number::complete::be_u16, IResult};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Parse Index.db file data with optional Summary.db correlation using spec-driven approach
+/// How often the O(entries) `Index.db` parse loop polls the cancel flag
+/// (issue #2383 fix C): once per this many entries, NOT per entry — a single
+/// relaxed atomic load amortised over ~64k `memcmp`/vint decodes is free, yet a
+/// client-disconnect cancel still aborts a 1.58M-entry parse within one interval
+/// instead of pinning a worker to completion.
+const CANCEL_POLL_INTERVAL: usize = 1 << 16;
+
+/// Parse Index.db file data with optional Summary.db correlation using spec-driven approach.
+///
+/// Non-cancellable façade over [`parse_index_data_cancellable`] (issue #2383): the
+/// default [`ScanCancel`] never trips, so the cancel arm is unreachable here.
 pub(super) fn parse_index_data_with_summary<'a>(
     input: &'a [u8],
     summary_reader: Option<&SummaryReader>,
 ) -> IResult<&'a [u8], IndexData> {
     use nom::error::{Error as NomError, ErrorKind};
+    match parse_index_data_cancellable(input, summary_reader, &ScanCancel::default()) {
+        Ok(pair) => Ok(pair),
+        // A default (never-cancel) flag cannot yield `Cancelled`; any error here is
+        // a header/structural failure mapped to a nom error for the IResult callers.
+        Err(_) => Err(nom::Err::Error(NomError::new(input, ErrorKind::Fail))),
+    }
+}
 
-    // First try spec-driven header parsing
-    let registry = get_global_registry();
-    let (remaining, header) = match registry.parse_index_header(input) {
-        Ok(parsed_header) => {
-            tracing::debug!("Successfully parsed Index.db header using spec-driven approach");
+/// Cancel-aware Index.db parse (issue #2383 fix C).
+///
+/// Polls `cancel` before the header and roughly every [`CANCEL_POLL_INTERVAL`]
+/// entries inside the O(entries) loop, returning [`crate::Error::Cancelled`]
+/// promptly instead of running a 1.58M-entry parse to completion after a client
+/// disconnect. This is the SINGLE site that emits `index_parses_total`, so both
+/// the cancellable and non-cancellable façades count a full parse exactly once.
+pub(super) fn parse_index_data_cancellable<'a>(
+    input: &'a [u8],
+    summary_reader: Option<&SummaryReader>,
+    cancel: &ScanCancel,
+) -> Result<(&'a [u8], IndexData)> {
+    // Coarse pre-parse cancel check (covers a pre-cancelled open).
+    cancel.check()?;
 
-            // Convert ParsedHeader to IndexHeader
-            let header = IndexHeader {
-                version: parsed_header
-                    .fields
-                    .get("version")
-                    .and_then(|v| v.as_u32().ok())
-                    .unwrap_or(1),
-                entry_count: parsed_header
-                    .fields
-                    .get("entry_count")
-                    .and_then(|v| v.as_u32().ok())
-                    .unwrap_or(0),
-                data_size: parsed_header
-                    .fields
-                    .get("data_size")
-                    .and_then(|v| v.as_u64().ok())
-                    .unwrap_or(input.len() as u64),
-                checksum: parsed_header
-                    .fields
-                    .get("checksum")
-                    .and_then(|v| v.as_u32().ok())
-                    .unwrap_or(0),
-            };
+    let (remaining, header) = parse_index_header_prefix(input);
 
-            // Skip header bytes for data parsing
-            let header_size = parsed_header.header_size;
-            if input.len() < header_size {
-                return Err(nom::Err::Error(NomError::new(input, ErrorKind::Eof)));
-            }
-            (&input[header_size..], header)
-        }
-        Err(_) => {
-            tracing::debug!("Spec-driven header parsing failed, assuming headerless format");
-
-            // Parse all partition key digests - no header in some formats
-            let header = IndexHeader {
-                version: 1,
-                entry_count: 0, // Will be updated after parsing entries
-                data_size: input.len() as u64,
-                checksum: 0,
-            };
-            (input, header)
-        }
-    };
-
-    // Parse partition entries from remaining data
+    // Parse partition entries (cancel-polled) from the post-header data.
     let (remaining, partition_entries) =
-        parse_all_partition_keys_with_summary(remaining, summary_reader)?;
+        parse_all_partition_keys_cancellable(remaining, summary_reader, cancel)?;
 
     // Build lookup table with zero-copy approach using Arc::clone (reference counting only)
     // This eliminates the memory explosion from cloning Vec<u8> key digests
@@ -98,6 +83,59 @@ pub(super) fn parse_index_data_with_summary<'a>(
             key_lookup,
         },
     ))
+}
+
+/// Parse (or synthesize, for the headerless format) the `Index.db` header prefix,
+/// returning the post-header remainder. Infallible: an unparseable header falls
+/// back to the headerless layout exactly as before (issue #28, no heuristics —
+/// the spec-driven registry is the authority, the headerless case is the
+/// documented Cassandra 5.0 shape).
+fn parse_index_header_prefix(input: &[u8]) -> (&[u8], IndexHeader) {
+    let registry = get_global_registry();
+    match registry.parse_index_header(input) {
+        Ok(parsed_header) => {
+            tracing::debug!("Successfully parsed Index.db header using spec-driven approach");
+            let header = IndexHeader {
+                version: parsed_header
+                    .fields
+                    .get("version")
+                    .and_then(|v| v.as_u32().ok())
+                    .unwrap_or(1),
+                entry_count: parsed_header
+                    .fields
+                    .get("entry_count")
+                    .and_then(|v| v.as_u32().ok())
+                    .unwrap_or(0),
+                data_size: parsed_header
+                    .fields
+                    .get("data_size")
+                    .and_then(|v| v.as_u64().ok())
+                    .unwrap_or(input.len() as u64),
+                checksum: parsed_header
+                    .fields
+                    .get("checksum")
+                    .and_then(|v| v.as_u32().ok())
+                    .unwrap_or(0),
+            };
+            let header_size = parsed_header.header_size;
+            if input.len() < header_size {
+                // Truncated below the declared header: no post-header data.
+                (&[], header)
+            } else {
+                (&input[header_size..], header)
+            }
+        }
+        Err(_) => {
+            tracing::debug!("Spec-driven header parsing failed, assuming headerless format");
+            let header = IndexHeader {
+                version: 1,
+                entry_count: 0, // Will be updated after parsing entries
+                data_size: input.len() as u64,
+                checksum: 0,
+            };
+            (input, header)
+        }
+    }
 }
 
 /// Parse all partition entries from the Index.db file.
@@ -127,13 +165,35 @@ pub(super) fn parse_index_data_with_summary<'a>(
 /// inline so Summary.db correlation is no longer needed for parsing.
 pub(super) fn parse_all_partition_keys_with_summary<'a>(
     input: &'a [u8],
-    _summary_reader: Option<&SummaryReader>,
+    summary_reader: Option<&SummaryReader>,
 ) -> IResult<&'a [u8], Vec<PartitionIndexEntry>> {
+    use nom::error::{Error as NomError, ErrorKind};
+    // Non-cancellable façade: a default flag never trips, so the cancel arm is
+    // unreachable; map it defensively to a nom error for the IResult callers.
+    match parse_all_partition_keys_cancellable(input, summary_reader, &ScanCancel::default()) {
+        Ok(pair) => Ok(pair),
+        Err(_) => Err(nom::Err::Error(NomError::new(input, ErrorKind::Fail))),
+    }
+}
+
+/// Cancel-aware entry loop (issue #2383 fix C). Polls `cancel` once per
+/// [`CANCEL_POLL_INTERVAL`] entries; on a trip returns [`crate::Error::Cancelled`]
+/// promptly. Emits the `index_parses_total` counter exactly once on a full pass —
+/// the SINGLE full-parse site (both façades route here).
+pub(super) fn parse_all_partition_keys_cancellable<'a>(
+    input: &'a [u8],
+    _summary_reader: Option<&SummaryReader>,
+    cancel: &ScanCancel,
+) -> Result<(&'a [u8], Vec<PartitionIndexEntry>)> {
     let mut entries = Vec::new();
     let mut remaining = input;
 
-    let mut entry_index = 0;
+    let mut entry_index = 0usize;
     while !remaining.is_empty() {
+        // #2383 fix C: bounded-interval cooperative cancel (not per entry).
+        if entry_index % CANCEL_POLL_INTERVAL == 0 {
+            cancel.check()?;
+        }
         match parse_big_index_entry(remaining) {
             Ok((rest, entry)) => {
                 debug_assert!(

--- a/cqlite-core/src/storage/sstable/index_reader/parse.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/parse.rs
@@ -56,7 +56,7 @@ pub(super) fn parse_index_data_cancellable<'a>(
     // Coarse pre-parse cancel check (covers a pre-cancelled open).
     cancel.check()?;
 
-    let (remaining, header) = parse_index_header_prefix(input);
+    let (remaining, header) = parse_index_header_prefix(input)?;
 
     // Parse partition entries (cancel-polled) from the post-header data.
     let (remaining, partition_entries) =
@@ -86,11 +86,12 @@ pub(super) fn parse_index_data_cancellable<'a>(
 }
 
 /// Parse (or synthesize, for the headerless format) the `Index.db` header prefix,
-/// returning the post-header remainder. Infallible: an unparseable header falls
-/// back to the headerless layout exactly as before (issue #28, no heuristics —
-/// the spec-driven registry is the authority, the headerless case is the
-/// documented Cassandra 5.0 shape).
-fn parse_index_header_prefix(input: &[u8]) -> (&[u8], IndexHeader) {
+/// returning the post-header remainder. An unparseable header falls back to the
+/// headerless layout exactly as before (issue #28, no heuristics — the spec-driven
+/// registry is the authority, the headerless case is the documented Cassandra 5.0
+/// shape). A header that DECLARES more bytes than the file holds is a truncation
+/// error (preserves the pre-refactor `Eof`→corruption behavior).
+fn parse_index_header_prefix(input: &[u8]) -> Result<(&[u8], IndexHeader)> {
     let registry = get_global_registry();
     match registry.parse_index_header(input) {
         Ok(parsed_header) => {
@@ -119,11 +120,11 @@ fn parse_index_header_prefix(input: &[u8]) -> (&[u8], IndexHeader) {
             };
             let header_size = parsed_header.header_size;
             if input.len() < header_size {
-                // Truncated below the declared header: no post-header data.
-                (&[], header)
-            } else {
-                (&input[header_size..], header)
+                return Err(crate::Error::corruption(
+                    "Index.db header declares more bytes than the file holds",
+                ));
             }
+            Ok((&input[header_size..], header))
         }
         Err(_) => {
             tracing::debug!("Spec-driven header parsing failed, assuming headerless format");
@@ -133,7 +134,7 @@ fn parse_index_header_prefix(input: &[u8]) -> (&[u8], IndexHeader) {
                 data_size: input.len() as u64,
                 checksum: 0,
             };
-            (input, header)
+            Ok((input, header))
         }
     }
 }

--- a/cqlite-core/src/storage/sstable/index_reader/parse.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/parse.rs
@@ -35,8 +35,15 @@ pub(super) fn parse_index_data_with_summary<'a>(
     use nom::error::{Error as NomError, ErrorKind};
     match parse_index_data_cancellable(input, summary_reader, &ScanCancel::default()) {
         Ok(pair) => Ok(pair),
-        // A default (never-cancel) flag cannot yield `Cancelled`; any error here is
-        // a header/structural failure mapped to a nom error for the IResult callers.
+        // Restore the pre-refactor error shape for the IResult callers (roborev-1654):
+        // a header that declares more bytes than the file holds is a TRUNCATION and
+        // must map back to `Eof` (the only `Corruption` this path can emit is that
+        // header-truncation signal from `parse_index_header_prefix`; the entry loop
+        // `break`s rather than erroring). Any other structural failure stays `Fail`.
+        // A default (never-cancel) flag cannot yield `Cancelled`.
+        Err(crate::Error::Corruption(_)) => {
+            Err(nom::Err::Error(NomError::new(input, ErrorKind::Eof)))
+        }
         Err(_) => Err(nom::Err::Error(NomError::new(input, ErrorKind::Fail))),
     }
 }
@@ -169,10 +176,17 @@ pub(super) fn parse_all_partition_keys_with_summary<'a>(
     summary_reader: Option<&SummaryReader>,
 ) -> IResult<&'a [u8], Vec<PartitionIndexEntry>> {
     use nom::error::{Error as NomError, ErrorKind};
-    // Non-cancellable façade: a default flag never trips, so the cancel arm is
-    // unreachable; map it defensively to a nom error for the IResult callers.
+    // Non-cancellable façade over the break-on-error entry loop: it returns the
+    // parsed prefix as `Ok` on a malformed/truncated tail (never a structural
+    // `Err`), and a default flag never trips `Cancelled`, so no `Err` is reachable
+    // here in practice. Map defensively but preserve the shape distinction for
+    // symmetry with `parse_index_data_with_summary` (roborev-1654): a `Corruption`
+    // (truncation) → `Eof`, anything else → `Fail`.
     match parse_all_partition_keys_cancellable(input, summary_reader, &ScanCancel::default()) {
         Ok(pair) => Ok(pair),
+        Err(crate::Error::Corruption(_)) => {
+            Err(nom::Err::Error(NomError::new(input, ErrorKind::Eof)))
+        }
         Err(_) => Err(nom::Err::Error(NomError::new(input, ErrorKind::Fail))),
     }
 }

--- a/cqlite-core/src/storage/sstable/index_reader/parse.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/parse.rs
@@ -156,6 +156,10 @@ pub(super) fn parse_all_partition_keys_with_summary<'a>(
     }
 
     tracing::debug!("Parsed {} partition entries from Index.db", entries.len());
+    // Issue #2383: count every full Index.db parse so a redundant re-parse of the
+    // SAME generation (the resolve-phase CPU spin) is observable in metrics — a
+    // correct read path parses each generation's index at most once per query.
+    crate::observability::add_counter(crate::observability::catalog::INDEX_PARSES_TOTAL, 1, &[]);
     Ok((remaining, entries))
 }
 

--- a/cqlite-core/src/storage/sstable/reader/component_loading.rs
+++ b/cqlite-core/src/storage/sstable/reader/component_loading.rs
@@ -215,8 +215,13 @@ impl SSTableReader {
         };
         let index_path = parent.join(format!("{}-Index.db", base_name));
 
-        match IndexReader::open_with_summary_cancellable(&index_path, platform.clone(), None, cancel)
-            .await
+        match IndexReader::open_with_summary_cancellable(
+            &index_path,
+            platform.clone(),
+            None,
+            cancel,
+        )
+        .await
         {
             Ok(reader) => {
                 tracing::debug!("Loaded Index.db reader for {}", index_path.display());

--- a/cqlite-core/src/storage/sstable/reader/component_loading.rs
+++ b/cqlite-core/src/storage/sstable/reader/component_loading.rs
@@ -37,6 +37,7 @@ impl SSTableReader {
         header: &crate::parser::SSTableHeader,
         platform: &Arc<Platform>,
         data_file_path: &Path,
+        cancel: &crate::storage::scan_cancel::ScanCancel,
     ) -> Result<Option<SSTableIndex>> {
         // Strategy 1: Check if index information is available in header (for integrated formats)
         if let Some(index_offset) = header.properties.get("index_offset") {
@@ -64,7 +65,14 @@ impl SSTableReader {
                 .join(format!("{}-Index.db", base_name));
 
             if tokio::fs::metadata(&index_path).await.is_ok() {
-                match IndexReader::open(&index_path, platform.clone()).await {
+                match IndexReader::open_with_summary_cancellable(
+                    &index_path,
+                    platform.clone(),
+                    None,
+                    cancel,
+                )
+                .await
+                {
                     Ok(index_reader) => {
                         tracing::debug!(
                             "Found separate Index.db component at {}",
@@ -93,6 +101,10 @@ impl SSTableReader {
                             }
                         }
                     }
+                    // A mid-parse cancellation (issue #2383) must ABORT, never fall
+                    // through to a fallback strategy (that would ignore the cancel
+                    // and keep the worker spinning). Surfaced by variant.
+                    Err(e @ Error::Cancelled) => return Err(e),
                     Err(e) => {
                         tracing::debug!(
                             "Failed to load Index.db component: {}. This may indicate file corruption, permission issues, or format incompatibility.",
@@ -193,19 +205,22 @@ impl SSTableReader {
     pub(super) async fn load_index_reader(
         path: &Path,
         platform: &Arc<Platform>,
-    ) -> IndexLoadOutcome {
+        cancel: &crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<IndexLoadOutcome> {
         let Some(base_name) = extract_sstable_base_name(path) else {
-            return IndexLoadOutcome::Absent;
+            return Ok(IndexLoadOutcome::Absent);
         };
         let Some(parent) = path.parent() else {
-            return IndexLoadOutcome::Absent;
+            return Ok(IndexLoadOutcome::Absent);
         };
         let index_path = parent.join(format!("{}-Index.db", base_name));
 
-        match IndexReader::open(&index_path, platform.clone()).await {
+        match IndexReader::open_with_summary_cancellable(&index_path, platform.clone(), None, cancel)
+            .await
+        {
             Ok(reader) => {
                 tracing::debug!("Loaded Index.db reader for {}", index_path.display());
-                IndexLoadOutcome::Loaded(Box::new(reader))
+                Ok(IndexLoadOutcome::Loaded(Box::new(reader)))
             }
             // A genuinely absent Index.db (some shapes legitimately ship without one)
             // is quiet & expected. A PRESENT-but-unloadable Index.db (open/parse
@@ -215,15 +230,18 @@ impl SSTableReader {
             // is absent, so the error kind is the authoritative discriminator.
             Err(Error::NotFound(_)) => {
                 tracing::debug!("No Index.db present at {}", index_path.display());
-                IndexLoadOutcome::Absent
+                Ok(IndexLoadOutcome::Absent)
             }
+            // A mid-parse cancellation (issue #2383) aborts the open, never masked
+            // as a present-but-unloadable degradation.
+            Err(e @ Error::Cancelled) => Err(e),
             Err(e) => {
                 tracing::debug!(
                     "Index.db present at {} but failed to load: {}",
                     index_path.display(),
                     e
                 );
-                IndexLoadOutcome::PresentButUnloadable
+                Ok(IndexLoadOutcome::PresentButUnloadable)
             }
         }
     }

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -863,9 +863,10 @@ impl SSTableReader {
     /// so concurrent scans on this reader never share a mutable file position —
     /// they run in parallel without the per-scan serialization #805 required.
     pub(in crate::storage::sstable::reader) async fn new_scan_cursor(&self) -> Result<ScanCursor> {
-        Ok(ScanCursor::new(
-            self.scan_source.open(&self.file_path).await?,
-        ))
+        // Load the (interior-mutable, #2383-rebindable) path once per scan; a
+        // rebind swaps this to a live same-inode hardlink without re-parsing.
+        let file_path = self.file_path();
+        Ok(ScanCursor::new(self.scan_source.open(&file_path).await?))
     }
 
     /// Read the next block from a scan-local `cursor` (its own file position and

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -70,7 +70,7 @@ impl SSTableReader {
         schema: Option<&crate::schema::TableSchema>,
     ) -> Result<Vec<(RowKey, ScanRow)>> {
         tracing::debug!("SSTableReader::scan - Starting scan");
-        tracing::debug!("SSTableReader::scan - File path: {:?}", self.file_path);
+        tracing::debug!("SSTableReader::scan - File path: {:?}", self.file_path());
         tracing::debug!("SSTableReader::scan - Table ID: {}", table_id);
         tracing::debug!("SSTableReader::scan - Start key: {:?}", start_key);
         tracing::debug!("SSTableReader::scan - End key: {:?}", end_key);

--- a/cqlite-core/src/storage/sstable/reader/integrity.rs
+++ b/cqlite-core/src/storage/sstable/reader/integrity.rs
@@ -37,9 +37,10 @@ impl SSTableReader {
         };
         let memory_usage = std::mem::size_of::<Self>() + cache.resident_bytes();
 
+        let file_path = self.file_path();
         Ok(SSTableReaderHealthMetrics {
-            file_path: self.file_path.clone(),
-            file_accessible: self.file_path.exists(),
+            file_accessible: file_path.exists(),
+            file_path,
             header_version: self.header.cassandra_version,
             total_file_size: stats.file_size,
             estimated_memory_usage: memory_usage,
@@ -66,7 +67,8 @@ impl SSTableReader {
     /// its parent directory — roborev #1283) and map its `VerifyReport` onto the
     /// legacy `IntegrityCheckResult` shape the (test-only) consumers expect.
     pub async fn perform_integrity_check(&self) -> Result<IntegrityCheckResult> {
-        debug!("Starting integrity check for {:?}", self.file_path);
+        let file_path = self.file_path();
+        debug!("Starting integrity check for {:?}", file_path);
 
         // Delegate to the authoritative engine, verifying the EXACT generation this
         // reader is opened on (issue #1283, roborev). The directory may hold several
@@ -77,7 +79,7 @@ impl SSTableReader {
         // Data corruption is reported as findings inside an Ok(report); only
         // environmental problems return Err.
         let report = verify::verify_sstable_generation(
-            &self.file_path,
+            &file_path,
             VerifyMode::Full,
             &self.open_config,
             self.platform.clone(),
@@ -103,7 +105,7 @@ impl SSTableReader {
         // clippy `-D warnings` clean while the dead computation stays removed.
         #[allow(deprecated)]
         let result = IntegrityCheckResult {
-            file_path: self.file_path.clone(),
+            file_path: file_path.clone(),
             total_blocks_checked: 0,
             corrupted_blocks: Vec::new(),
             checksum_mismatches: 0,
@@ -115,7 +117,7 @@ impl SSTableReader {
 
         info!(
             "Integrity check completed for {:?}: {:?}, {} findings, {} rows scanned",
-            self.file_path,
+            file_path,
             result.overall_status,
             result.parsing_errors.len(),
             result.total_entries

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -95,7 +95,7 @@ use header::{
     calculate_actual_header_size, extract_generation_from_path, parse_header_with_version_detection,
 };
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use tokio::fs::File;
@@ -351,6 +351,24 @@ impl SSTableReader {
         Self::open_with_cache(path, config, platform, cache).await
     }
 
+    /// Cancel-aware [`open`](Self::open) (issue #2383 fix C).
+    ///
+    /// Threads a synchronous [`ScanCancel`](crate::storage::scan_cancel::ScanCancel)
+    /// into the Index.db partition-index parse so a client-disconnect cancel
+    /// aborts a 1.58M-entry parse within one poll interval instead of pinning a
+    /// tokio worker to completion. Non-cancellable callers use [`open`](Self::open)
+    /// (a default never-cancel flag). Returns [`Error::Cancelled`] on a mid-parse
+    /// trip.
+    pub async fn open_cancellable(
+        path: &Path,
+        config: &Config,
+        platform: Arc<Platform>,
+        cancel: crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<Self> {
+        let cache = super::build_chunk_cache(config);
+        Self::open_with_cache_cancellable(path, config, platform, cache, cancel).await
+    }
+
     /// Open an SSTable file for reading, sharing the provided
     /// [`DecompressedChunkCache`](crate::storage::cache::DecompressedChunkCache).
     ///
@@ -362,6 +380,26 @@ impl SSTableReader {
         config: &Config,
         platform: Arc<Platform>,
         cache: Arc<crate::storage::cache::DecompressedChunkCache>,
+    ) -> Result<Self> {
+        Self::open_with_cache_cancellable(
+            path,
+            config,
+            platform,
+            cache,
+            crate::storage::scan_cancel::ScanCancel::default(),
+        )
+        .await
+    }
+
+    /// Cancel-aware [`open_with_cache`](Self::open_with_cache) (issue #2383 fix C):
+    /// same as it but threads `cancel` into the Index.db parse. See
+    /// [`open_cancellable`](Self::open_cancellable).
+    pub async fn open_with_cache_cancellable(
+        path: &Path,
+        config: &Config,
+        platform: Arc<Platform>,
+        cache: Arc<crate::storage::cache::DecompressedChunkCache>,
+        cancel: crate::storage::scan_cancel::ScanCancel,
     ) -> Result<Self> {
         use crate::observability::{self as obs, catalog};
         use tracing::Instrument as _;
@@ -376,7 +414,7 @@ impl SSTableReader {
         // `.await`: entering a span guard and then awaiting can attach unrelated
         // async work scheduled on this task to the span. `Instrument` enters the
         // span only while this specific future is polled.
-        let result = Self::open_inner(path, config, platform, cache)
+        let result = Self::open_inner(path, config, platform, cache, cancel)
             .instrument(span.clone())
             .await;
         match &result {
@@ -413,6 +451,7 @@ impl SSTableReader {
         config: &Config,
         platform: Arc<Platform>,
         chunk_cache: Arc<crate::storage::cache::DecompressedChunkCache>,
+        cancel: crate::storage::scan_cancel::ScanCancel,
     ) -> Result<Self> {
         // Retain the open-time Config before any local `config` shadowing so
         // `perform_integrity_check` can delegate to `verify::verify_sstable`
@@ -654,7 +693,7 @@ impl SSTableReader {
         }
 
         // Load index if available (supports both integrated and component-based)
-        let index = Self::load_index(&file, &header, &platform, path)
+        let index = Self::load_index(&file, &header, &platform, path, &cancel)
             .instrument(tracing::debug_span!("sstable.reader.open.load_index"))
             .await?;
 
@@ -667,11 +706,11 @@ impl SSTableReader {
         // Index.db from a present-but-unloadable one (issue #2302) so the full
         // enumeration can WARN loud on the latter instead of silently full-scanning.
         let (index_reader, index_present_but_unloadable) =
-            match Self::load_index_reader(path, &platform)
+            match Self::load_index_reader(path, &platform, &cancel)
                 .instrument(tracing::debug_span!(
                     "sstable.reader.open.load_index_reader"
                 ))
-                .await
+                .await?
             {
                 component_loading::IndexLoadOutcome::Loaded(reader) => (Some(*reader), false),
                 component_loading::IndexLoadOutcome::Absent => (None, false),
@@ -809,7 +848,7 @@ impl SSTableReader {
         });
 
         Ok(Self {
-            file_path: path.to_path_buf(),
+            file_path: arc_swap::ArcSwap::from_pointee(path.to_path_buf()),
             file,
             scan_source,
             point_source,
@@ -1253,8 +1292,34 @@ impl SSTableReader {
     /// registry keys parsed state on the file's inode-stable generation identity,
     /// so it needs the backing path to `stat` device+inode without re-listing the
     /// directory.
-    pub fn file_path(&self) -> &Path {
-        &self.file_path
+    pub fn file_path(&self) -> PathBuf {
+        // Owned clone (cheap relative to a scan/point-read): the path is now
+        // interior-mutable to support [`Self::rebind_path`] (#2383), so we cannot
+        // hand out a borrow into the `ArcSwap`.
+        self.file_path.load().as_ref().clone()
+    }
+
+    /// The `Data.db` size in bytes captured at open. Used by the warm registry's
+    /// authoritative rebind identity check (issue #2383): a rebind is accepted
+    /// only when the live candidate's `(device, inode)` AND size match this
+    /// reader's, else it fails closed to a full re-open.
+    pub fn file_size(&self) -> u64 {
+        self.stats.file_size
+    }
+
+    /// Rebind this reader's lazy-scan path to `new_path` WITHOUT re-opening or
+    /// re-parsing (issue #2383, the #2356 "rebind-by-inode" direction).
+    ///
+    /// The caller MUST have already established that `new_path` is the SAME
+    /// on-disk generation as this reader by AUTHORITATIVE identity — matching
+    /// `(device, inode)` and size (issue #28 no-heuristics; Cassandra snapshot
+    /// files are hardlinks to the immutable SSTable, so a same-inode candidate is
+    /// byte-identical). The already-open point/scan handles reference the shared
+    /// inode and stay valid across the swap; only [`Self::new_scan_cursor`]'s
+    /// per-scan `File::open` reads this path, so pointing it at a LIVE hardlink
+    /// restores the #2352 ENOENT protection with zero parse cost.
+    pub fn rebind_path(&self, new_path: &Path) {
+        self.file_path.store(Arc::new(new_path.to_path_buf()));
     }
 
     /// The immutable `[first_key_token, last_key_token]` endpoints cached at open
@@ -1287,7 +1352,7 @@ impl SSTableReader {
 
     /// Close the reader and release resources
     pub async fn close(self) -> Result<()> {
-        debug!("Closing SSTable reader for {:?}", self.file_path);
+        debug!("Closing SSTable reader for {:?}", self.file_path());
         // File will be closed automatically when dropped. The shared B1
         // decompressed-chunk cache is reference-counted and outlives one reader
         // (issue #1568: the per-reader block cache that was cleared here is gone).
@@ -1336,12 +1401,12 @@ impl SSTableReader {
 
     /// Get the SSTable format version string
     pub fn format_version(&self) -> Result<String> {
-        let filename = self
-            .file_path
+        let file_path = self.file_path();
+        let filename = file_path
             .file_name()
             .and_then(|f| f.to_str())
             .ok_or_else(|| {
-                Error::InvalidPath(format!("Invalid SSTable filename: {:?}", self.file_path))
+                Error::InvalidPath(format!("Invalid SSTable filename: {:?}", file_path))
             })?;
 
         let parts: Vec<&str> = filename.split('-').collect();
@@ -1416,7 +1481,7 @@ impl Drop for SSTableReader {
 impl std::fmt::Debug for SSTableReader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SSTableReader")
-            .field("file_path", &self.file_path)
+            .field("file_path", &self.file_path())
             .field("header", &self.header)
             .field("has_index", &self.index.is_some())
             .field("has_bloom_filter", &self.bloom_filter.is_some())

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -1318,6 +1318,30 @@ impl SSTableReader {
     /// inode and stay valid across the swap; only [`Self::new_scan_cursor`]'s
     /// per-scan `File::open` reads this path, so pointing it at a LIVE hardlink
     /// restores the #2352 ENOENT protection with zero parse cost.
+    ///
+    /// ## In-flight isolation invariant (roborev-1654 HIGH, adjudicated)
+    ///
+    /// Mutating this shared `Arc<SSTableReader>`'s path while a concurrent request
+    /// scans it does NOT break the in-flight request's isolation, because the
+    /// rebind is byte-transparent and monotone-toward-live:
+    /// 1. **Same immutable inode.** The sole caller (`warm::registry::rebind`)
+    ///    fires only after `rebuild::rebind_matches` proves
+    ///    `(device, inode, generation)` + size equality; every rebind target is a
+    ///    hardlink to the SAME immutable SSTable inode, so any path this reader
+    ///    carries yields byte-identical data (issue #28 no-heuristics).
+    /// 2. **Atomic swap.** `file_path` is an `arc_swap::ArcSwap<PathBuf>`; a
+    ///    concurrent `file_path()` sees either the old or the new whole `PathBuf`,
+    ///    never a torn value.
+    /// 3. **Dead → live only.** A rebind happens only when the current path is
+    ///    dead and an identity-matching LIVE hardlink exists, so an in-flight
+    ///    request's NEXT `new_scan_cursor` `File::open` is strictly MORE likely to
+    ///    succeed after the rebind than before (pre-rebind it would ENOENT).
+    /// 4. **No semantics off the path.** No `file_path()` consumer re-derives
+    ///    keyspace/table/schema from the path after `open`; the scan path uses it
+    ///    ONLY for `File::open` (bytes) and all parsed read state (header,
+    ///    compression info, CRC, index, generation) lives on `&self`, fixed at
+    ///    open — the swapped path changes which hardlink is read, never what the
+    ///    bytes mean.
     pub fn rebind_path(&self, new_path: &Path) {
         self.file_path.store(Arc::new(new_path.to_path_buf()));
     }

--- a/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
@@ -193,7 +193,8 @@ impl SSTableReader {
         ) {
             // Extract keyspace/table from path (most reliable for V5CompressedLegacy)
             // SSTable path format: {keyspace}/{table_name}-{uuid}/nb-1-big-Data.db
-            let (keyspace, table_name) = super::extract_keyspace_table_from_path(&self.file_path)
+            let file_path = self.file_path();
+            let (keyspace, table_name) = super::extract_keyspace_table_from_path(&file_path)
                 .unwrap_or_else(|_| {
                     // Fallback to header values if path extraction fails
                     (self.header.keyspace.clone(), self.header.table_name.clone())
@@ -213,7 +214,7 @@ impl SSTableReader {
                      but got keyspace='{}', table_name='{}' from path {:?}. \
                      Cannot fall back to VInt parser (format uses u8 length prefixes, not VInt). \
                      This indicates a path parsing bug or malformed SSTable directory structure.",
-                    keyspace, table_name, self.file_path
+                    keyspace, table_name, file_path
                 )));
             }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -184,8 +184,7 @@ impl SSTableReader {
                 // Extract keyspace/table from SSTable path (authoritative source)
                 // Directory structure: {keyspace}/{table_name}-{uuid}/Data.db
                 let file_path = self.file_path();
-                let (keyspace, table_name) = match extract_keyspace_table_from_path(&file_path)
-                {
+                let (keyspace, table_name) = match extract_keyspace_table_from_path(&file_path) {
                     Ok(names) => names,
                     Err(e) => {
                         debug!(

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -183,13 +183,14 @@ impl SSTableReader {
             if let Some(registry) = self.schema_registry.as_ref() {
                 // Extract keyspace/table from SSTable path (authoritative source)
                 // Directory structure: {keyspace}/{table_name}-{uuid}/Data.db
-                let (keyspace, table_name) = match extract_keyspace_table_from_path(&self.file_path)
+                let file_path = self.file_path();
+                let (keyspace, table_name) = match extract_keyspace_table_from_path(&file_path)
                 {
                     Ok(names) => names,
                     Err(e) => {
                         debug!(
                             "get_table_schema: Failed to extract names from path {}: {}. Falling back to header names.",
-                            self.file_path.display(), e
+                            file_path.display(), e
                         );
                         // Fallback to header names if path parsing fails
                         (self.header.keyspace.clone(), self.header.table_name.clone())

--- a/cqlite-core/src/storage/sstable/reader/registry_schema.rs
+++ b/cqlite-core/src/storage/sstable/reader/registry_schema.rs
@@ -39,12 +39,13 @@ impl SSTableReader {
         // Keyspace/table from the SSTable path (authoritative), with the header
         // names as the documented fallback — same resolution the old block_on
         // path used.
-        let (keyspace, table_name) = match extract_keyspace_table_from_path(&self.file_path) {
+        let file_path = self.file_path();
+        let (keyspace, table_name) = match extract_keyspace_table_from_path(&file_path) {
             Ok(names) => names,
             Err(e) => {
                 tracing::debug!(
                     "resolve_registry_schema: path parse failed for {}: {}. Using header names.",
-                    self.file_path.display(),
+                    file_path.display(),
                     e
                 );
                 (self.header.keyspace.clone(), self.header.table_name.clone())

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -220,8 +220,16 @@ type BtiLookupMemo = std::sync::Mutex<Option<(Box<[u8]>, Option<u64>)>>;
 /// SSTable reader for efficient data access
 #[allow(dead_code)]
 pub struct SSTableReader {
-    /// Path to the SSTable file
-    pub(crate) file_path: PathBuf,
+    /// Path to the SSTable file.
+    ///
+    /// Interior-mutable (issue #2383 / #2356, "rebind-by-inode"): a warm reader
+    /// whose backing snapshot dir the Trino connector cleared can be REBOUND to a
+    /// fresh same-inode hardlink path WITHOUT re-opening/re-parsing the whole
+    /// Index.db — see [`Self::rebind_path`]. The already-open point/scan handles
+    /// stay valid (the inode outlives the cleared dir via the surviving
+    /// hardlinks); only [`Self::new_scan_cursor`]'s lazy `File::open`-by-path
+    /// needs the live path, so a lock-free `ArcSwap` swap is all a rebind costs.
+    pub(crate) file_path: arc_swap::ArcSwap<PathBuf>,
     /// Backing byte source for point reads (buffered file I/O or memory map).
     ///
     /// Used only by positioned point-read helpers (`get_cached_data`,

--- a/cqlite-core/src/storage/sstable/refresh.rs
+++ b/cqlite-core/src/storage/sstable/refresh.rs
@@ -261,9 +261,10 @@ impl SSTableManager {
             let readers = self.readers.read().await;
             let table_readers = self.table_readers.read().await;
             for r in readers.values().chain(table_readers.values().flatten()) {
+                let fp = r.file_path();
                 let c = canon_cache
-                    .entry(r.file_path.clone())
-                    .or_insert_with(|| canon(&r.file_path))
+                    .entry(fp.clone())
+                    .or_insert_with(|| canon(&fp))
                     .clone();
                 held_canon.insert(c);
             }
@@ -316,29 +317,29 @@ impl SSTableManager {
         //     guarded section performs zero filesystem syscalls.
         let before_canon: HashSet<PathBuf> = readers
             .values()
-            .map(|r| canon_of(&r.file_path))
+            .map(|r| canon_of(&r.file_path()))
             .chain(
                 table_readers
                     .values()
                     .flatten()
-                    .map(|r| canon_of(&r.file_path)),
+                    .map(|r| canon_of(&r.file_path())),
             )
             .collect();
 
-        readers.retain(|_id, r| discovered_canon.contains(&canon_of(&r.file_path)));
+        readers.retain(|_id, r| discovered_canon.contains(&canon_of(&r.file_path())));
         for list in table_readers.values_mut() {
-            list.retain(|r| discovered_canon.contains(&canon_of(&r.file_path)));
+            list.retain(|r| discovered_canon.contains(&canon_of(&r.file_path())));
         }
         table_readers.retain(|_key, list| !list.is_empty());
 
         let after_removal_canon: HashSet<PathBuf> = readers
             .values()
-            .map(|r| canon_of(&r.file_path))
+            .map(|r| canon_of(&r.file_path()))
             .chain(
                 table_readers
                     .values()
                     .flatten()
-                    .map(|r| canon_of(&r.file_path)),
+                    .map(|r| canon_of(&r.file_path())),
             )
             .collect();
         let readers_removed = before_canon.difference(&after_removal_canon).count();
@@ -352,7 +353,7 @@ impl SSTableManager {
             }
             // Guard against inserting the same freshly-opened path twice if the
             // discovery listed a duplicate (defensive; discovery does not).
-            if readers.values().any(|r| canon_of(&r.file_path) == cpath) {
+            if readers.values().any(|r| canon_of(&r.file_path()) == cpath) {
                 continue;
             }
             readers.insert(sstable_id, Arc::clone(&reader_arc));

--- a/cqlite-core/src/storage/sstable_data_manager.rs
+++ b/cqlite-core/src/storage/sstable_data_manager.rs
@@ -668,7 +668,7 @@ impl SSTableDataManager {
             };
 
             let metadata = RowMetadata {
-                source_file: reader.file_path.clone(),
+                source_file: reader.file_path(),
                 write_time: None,
                 ttl: None,
                 generation: reader.generation,
@@ -839,7 +839,7 @@ impl SSTableDataManager {
         // TODO(Issue #190): SSTableReader integrity checking API differs
         // For now, perform basic file accessibility check
         // Future: use reader.check_integrity() when available
-        if reader.file_path.exists() {
+        if reader.file_path().exists() {
             FileHealthStatus::Healthy
         } else {
             FileHealthStatus::AccessDenied

--- a/cqlite-flight/src/warm/identity.rs
+++ b/cqlite-flight/src/warm/identity.rs
@@ -79,7 +79,12 @@ fn device_inode(path: &Path) -> Option<(u64, u64)> {
     // Non-unix has no stable inode identity; fall back to "file exists" and let
     // the generation number carry the key. CQLite's supported deployment targets
     // are unix (macOS/Linux); this keeps the crate compiling elsewhere without
-    // claiming inode stability it cannot provide.
+    // claiming inode stability it cannot provide. Consequence (accepted,
+    // unsupported-target degradation): with a constant `(device, inode) = (0, 0)`
+    // here, `GenerationId` identity degrades to `(generation, size)` wherever a
+    // size check accompanies it (e.g. the #2383 rebind-by-inode gate,
+    // `rebuild::rebind_matches`) — never a silent correctness claim on a target
+    // CQLite does not support.
     std::fs::metadata(path).ok().map(|_| (0, 0))
 }
 

--- a/cqlite-flight/src/warm/mod.rs
+++ b/cqlite-flight/src/warm/mod.rs
@@ -37,6 +37,7 @@ pub mod budget;
 pub mod identity;
 pub mod metrics;
 pub mod probe;
+pub mod rebuild;
 pub mod registry;
 
 pub use identity::{GenerationId, GenerationSet};

--- a/cqlite-flight/src/warm/rebuild.rs
+++ b/cqlite-flight/src/warm/rebuild.rs
@@ -320,7 +320,9 @@ fn open_one_reader(
     cancel: ScanCancel,
 ) -> Result<SSTableReader, WarmError> {
     let reader = runtime
-        .block_on(SSTableReader::open_cancellable(path, config, platform, cancel))
+        .block_on(SSTableReader::open_cancellable(
+            path, config, platform, cancel,
+        ))
         .map_err(|source| match source {
             Error::Cancelled => WarmError::Cancelled,
             source => WarmError::Open {

--- a/cqlite-flight/src/warm/rebuild.rs
+++ b/cqlite-flight/src/warm/rebuild.rs
@@ -12,15 +12,32 @@
 //! AFTER every racer had already paid the parse. [`OpenCoalescer`] moves the
 //! coalescing point EARLIER: concurrent opens of the SAME generation identity
 //! share ONE real open+parse; the leader opens, the followers block on a condvar
-//! and clone the resulting `Arc<SSTableReader>` with zero re-parse. It does NOT
-//! serialise whole rebuilds (each rebuild still runs its own probe/swap), so the
-//! existing swap-time race tests (`concurrent_same_key_rebuild_dedups...`,
+//! (cancel-aware — see [`OpenCoalescer::open`]) and clone the resulting
+//! `Arc<SSTableReader>` with zero re-parse. It does NOT serialise whole rebuilds
+//! (each rebuild still runs its own probe/swap), so the existing swap-time race
+//! tests (`concurrent_same_key_rebuild_dedups...`,
 //! `slow_rebuild_does_not_overwrite_a_faster_newer_swap`) keep exercising their
 //! forced concurrency without deadlocking.
+//!
+//! ## Fix A × Fix B interaction — the Weak-hit path-liveness gate (issue #2383
+//! ## blocker 1, post-review)
+//!
+//! `registry::rebuild`'s rebind pass only walks the CURRENTLY CACHED reader set
+//! for a table (`inner.tables.get(key)`) — an LRU-EVICTED-but-still-alive reader
+//! (kept alive only by an in-flight `WarmSet` `Arc` a prior request is still
+//! streaming) is invisible to it, so rebind can never repoint its path. A
+//! coalesced [`SlotState::Done`] `Weak` hit here therefore CANNOT assume its
+//! reader's path is live just because it upgraded: every `Done` serve is ALSO
+//! gated on [`reader_backing_present`] before being handed out. A dead path
+//! (its per-query snapshot dir was cleared while the reader outlived the
+//! registry's own cache entry) is treated as a miss and falls through to
+//! `do_open` from the live `entry.path` — never re-serving a stale, ENOENT-prone
+//! reader (the #2352 class). See `spin_tests_2383::evicted_but_inflight_reader_is_not_served_with_dead_path`.
 
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Condvar, Mutex, PoisonError, Weak};
+use std::time::Duration;
 
 use cqlite_core::schema::TableSchema;
 use cqlite_core::storage::scan_cancel::ScanCancel;
@@ -40,6 +57,15 @@ use super::WarmError;
 /// coalescer's memory bounded on a long-running server without a background task.
 const COALESCER_PRUNE_THRESHOLD: usize = 1024;
 
+/// How often a waiting FOLLOWER re-checks its request's [`CancelFlag`] (issue
+/// #2383 roborev-1653 Medium): a plain `Condvar::wait` never re-observes
+/// cancellation, so a cancelled follower would otherwise sit behind the leader's
+/// FULL Index.db open and only notice afterwards — exactly the field's
+/// "cancellation doesn't land" symptom. A bounded `wait_timeout` loop keeps this
+/// cheap (one wake per interval, not per entry) while making a follower's cancel
+/// latency roughly this interval, never "whatever the leader's whole parse costs".
+const FOLLOWER_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(75);
+
 /// Per-generation single-flight for reader opens (issue #2383 fix A).
 ///
 /// Keyed on the inode-stable [`GenerationId`], so two per-query snapshot hardlink
@@ -50,8 +76,9 @@ const COALESCER_PRUNE_THRESHOLD: usize = 1024;
 /// FAST in-process opens a test drives, not just a real 1.58M-entry parse. The
 /// `Weak` keeps NO reader alive, so the warm budget's LRU eviction is unaffected;
 /// once a generation's reader is truly gone the slot re-opens on the next miss.
-/// Rebind (fix B) mutates the shared reader in place, so a coalesced reader always
-/// reflects the current live path (no stale-path serve).
+/// A live `Weak` upgrade is NOT sufficient to serve, though — see the module doc
+/// ("Fix A × Fix B interaction") for why every `Done` hit is ALSO gated on
+/// [`reader_backing_present`].
 #[derive(Default)]
 pub(super) struct OpenCoalescer {
     inflight: Mutex<HashMap<GenerationId, Arc<OpenSlot>>>,
@@ -68,47 +95,116 @@ enum SlotState {
     /// The leader is opening; followers wait.
     #[default]
     Pending,
-    /// The reader was opened; followers clone it while the `Weak` is live.
+    /// The reader was opened; followers clone it while the `Weak` is live AND
+    /// its backing path resolves (issue #2383 blocker 1).
     Done(Weak<SSTableReader>),
     /// The last open attempt failed; the next caller re-leads.
     Failed,
 }
 
+/// RAII guard: if the leader's `do_open` PANICS (unwinds) before the guard is
+/// disarmed, transitions the slot to [`SlotState::Failed`] and wakes every
+/// follower on drop — without this, a panicking leader would leave the slot
+/// `Pending` forever, hanging every follower on the condvar (issue #2383,
+/// post-review hardening).
+struct FailSlotOnUnwind<'a> {
+    slot: &'a OpenSlot,
+    armed: bool,
+}
+
+impl Drop for FailSlotOnUnwind<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        {
+            let mut st = self
+                .slot
+                .state
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            if matches!(*st, SlotState::Pending) {
+                *st = SlotState::Failed;
+            }
+        }
+        self.slot.ready.notify_all();
+    }
+}
+
+/// The caller's elected role for one generation-id open (see
+/// [`OpenCoalescer::open`]).
+enum Role {
+    /// A coalesced hit: the reader is alive AND its backing path resolves.
+    Hit(Arc<SSTableReader>),
+    /// Elected leader: run `do_open` and publish the outcome.
+    Lead(Arc<OpenSlot>),
+    /// Elected follower: wait for the leader, cancel-aware.
+    Follow(Arc<OpenSlot>),
+    /// The cached reader is alive but its backing path is DEAD (issue #2383
+    /// blocker 1 — an LRU-evicted-but-in-flight generation whose snapshot dir
+    /// was cleared). Never served; falls through to our own `do_open` exactly
+    /// like a `Failed` slot — NOT a re-election through the slot (NIT 4: this
+    /// intentionally lets M concurrent callers each re-open here rather than
+    /// coalescing; fail-closed correctness beats dedup on this rare path).
+    DeadPathFallThrough,
+}
+
 impl OpenCoalescer {
     /// Coalesce the open of generation `id`: the first caller (leader) runs
-    /// `do_open`; concurrent callers whose reader is still alive clone it. Returns
+    /// `do_open`; concurrent callers whose reader is alive AND whose backing
+    /// path resolves (issue #2383 blocker 1) clone it. Returns
     /// `(reader, real_open)` where `real_open` is `true` iff THIS call performed
     /// the actual open (drives the reader-opens work-done metric — a coalesced
-    /// caller reports `false`). On leader FAILURE (or a since-evicted reader) the
-    /// caller falls through to its own `do_open` (fail-closed).
-    fn open<F>(&self, id: GenerationId, do_open: F) -> Result<(Arc<SSTableReader>, bool), WarmError>
+    /// caller reports `false`).
+    ///
+    /// A FOLLOWER's wait is cancel-aware (issue #2383 roborev-1653 Medium): it
+    /// re-checks `cancel` on a bounded [`FOLLOWER_CANCEL_POLL_INTERVAL`] wake and
+    /// returns [`WarmError::Cancelled`] promptly instead of sitting behind the
+    /// leader's full open — the leader itself is unaffected and still publishes
+    /// its outcome for any other waiter.
+    ///
+    /// On leader FAILURE (including a leader PANIC, via [`FailSlotOnUnwind`]), a
+    /// dead-path `Done` reader, or a since-evicted reader, the caller falls
+    /// through to its own `do_open` (fail-closed: correctness/liveness over
+    /// dedup on these rare paths).
+    fn open<F>(
+        &self,
+        id: GenerationId,
+        cancel: &CancelFlag,
+        do_open: F,
+    ) -> Result<(Arc<SSTableReader>, bool), WarmError>
     where
         F: FnOnce() -> Result<Arc<SSTableReader>, WarmError>,
     {
-        // Elect a role under the map lock. A slot in `Done` with a LIVE reader is a
-        // fast coalesced hit (no wait); a dead/failed/absent slot makes us the
-        // leader (we reset it to `Pending` so concurrent callers wait on us).
-        let (slot, is_leader) = {
+        // Elect a role under the map lock. A slot in `Done` with a LIVE reader
+        // AND a live backing path is a fast coalesced hit (no wait); a
+        // dead-path/failed/absent slot makes us the leader (we reset it to
+        // `Pending` so concurrent callers wait on us) or falls straight through.
+        let role = {
             let mut map = self.inflight.lock().unwrap_or_else(PoisonError::into_inner);
             if let Some(slot) = map.get(&id) {
                 let mut st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
                 match &*st {
-                    SlotState::Done(weak) => {
-                        if let Some(reader) = weak.upgrade() {
-                            return Ok((reader, false));
+                    SlotState::Done(weak) => match weak.upgrade() {
+                        Some(reader) if reader_backing_present(&reader) => Role::Hit(reader),
+                        Some(_dead_path_reader) => {
+                            drop(st);
+                            Role::DeadPathFallThrough
                         }
-                        *st = SlotState::Pending; // reader evicted → re-lead
-                        drop(st);
-                        (Arc::clone(slot), true)
-                    }
+                        None => {
+                            *st = SlotState::Pending; // reader dropped → re-lead
+                            drop(st);
+                            Role::Lead(Arc::clone(slot))
+                        }
+                    },
                     SlotState::Failed => {
                         *st = SlotState::Pending;
                         drop(st);
-                        (Arc::clone(slot), true)
+                        Role::Lead(Arc::clone(slot))
                     }
                     SlotState::Pending => {
                         drop(st);
-                        (Arc::clone(slot), false)
+                        Role::Follow(Arc::clone(slot))
                     }
                 }
             } else {
@@ -120,42 +216,66 @@ impl OpenCoalescer {
                     ready: Condvar::new(),
                 });
                 map.insert(id, Arc::clone(&slot));
-                (slot, true)
+                Role::Lead(slot)
             }
         };
 
-        if is_leader {
-            let result = do_open();
-            {
-                let mut st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
-                *st = match &result {
-                    Ok(reader) => SlotState::Done(Arc::downgrade(reader)),
-                    Err(_) => SlotState::Failed,
+        match role {
+            Role::Hit(reader) => Ok((reader, false)),
+            Role::DeadPathFallThrough => do_open().map(|r| (r, true)),
+            Role::Lead(slot) => {
+                let mut guard = FailSlotOnUnwind {
+                    slot: &slot,
+                    armed: true,
                 };
+                let result = do_open();
+                guard.armed = false;
+                {
+                    let mut st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
+                    *st = match &result {
+                        Ok(reader) => SlotState::Done(Arc::downgrade(reader)),
+                        Err(_) => SlotState::Failed,
+                    };
+                }
+                slot.ready.notify_all();
+                result.map(|r| (r, true))
             }
-            slot.ready.notify_all();
-            return result.map(|r| (r, true));
-        }
-
-        // Follower: wait for the leader's outcome.
-        let mut st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
-        loop {
-            match &*st {
-                SlotState::Pending => {
-                    st = slot.ready.wait(st).unwrap_or_else(PoisonError::into_inner);
-                }
-                SlotState::Done(weak) => {
-                    if let Some(reader) = weak.upgrade() {
-                        return Ok((reader, false));
+            Role::Follow(slot) => {
+                let mut st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
+                loop {
+                    match &*st {
+                        SlotState::Pending => {
+                            if cancel.is_cancelled() {
+                                return Err(WarmError::Cancelled);
+                            }
+                            let (guard, _timed_out) = slot
+                                .ready
+                                .wait_timeout(st, FOLLOWER_CANCEL_POLL_INTERVAL)
+                                .unwrap_or_else(PoisonError::into_inner);
+                            st = guard;
+                        }
+                        SlotState::Done(weak) => match weak.upgrade() {
+                            Some(reader) if reader_backing_present(&reader) => {
+                                return Ok((reader, false));
+                            }
+                            _ => {
+                                // Evicted, or its backing path is dead (issue
+                                // #2383 blocker 1 / the #2352 ENOENT class):
+                                // never serve a stale/dead reader. Fall through
+                                // to our own `do_open` from the live
+                                // `entry.path` (fail-closed over dedup — NIT 4:
+                                // this intentionally lets M followers re-open
+                                // here, never re-electing a leader through the
+                                // slot).
+                                drop(st);
+                                return do_open().map(|r| (r, true));
+                            }
+                        },
+                        SlotState::Failed => {
+                            drop(st);
+                            return do_open().map(|r| (r, true));
+                        }
                     }
-                    // The reader was evicted between notify and our wake: open it
-                    // ourselves (fail-closed correctness over dedup).
-                    drop(st);
-                    return do_open().map(|r| (r, true));
-                }
-                SlotState::Failed => {
-                    drop(st);
-                    return do_open().map(|r| (r, true));
                 }
             }
         }
@@ -227,7 +347,7 @@ impl WarmTableRegistry {
             if cancel.is_cancelled() {
                 return Err(WarmError::Cancelled);
             }
-            let (reader, real) = self.coalescer.open(entry.id, || {
+            let (reader, real) = self.coalescer.open(entry.id, cancel, || {
                 open_one_reader(
                     &runtime,
                     &entry.path,

--- a/cqlite-flight/src/warm/rebuild.rs
+++ b/cqlite-flight/src/warm/rebuild.rs
@@ -1,0 +1,336 @@
+//! The warm rebuild's expensive half (issue #2383, campsite split of
+//! `registry.rs`): single-flight per-generation reader opens (fix A),
+//! cancel-aware opens (fix C), and the authoritative rebind-by-inode match
+//! (fix B). Split out so `registry.rs` stays within the campsite threshold.
+//!
+//! ## Fix A — single-flight opens
+//!
+//! The round-8 field spin: M concurrent `do_get`s that all MISS for one cold
+//! table each open (and thus full-parse the `Index.db` of) EVERY generation —
+//! the log showed 8× "Parsed 1586932 partition entries" for one logical query,
+//! pinning tokio workers. The registry's epoch guard deduped the CACHE but only
+//! AFTER every racer had already paid the parse. [`OpenCoalescer`] moves the
+//! coalescing point EARLIER: concurrent opens of the SAME generation identity
+//! share ONE real open+parse; the leader opens, the followers block on a condvar
+//! and clone the resulting `Arc<SSTableReader>` with zero re-parse. It does NOT
+//! serialise whole rebuilds (each rebuild still runs its own probe/swap), so the
+//! existing swap-time race tests (`concurrent_same_key_rebuild_dedups...`,
+//! `slow_rebuild_does_not_overwrite_a_faster_newer_swap`) keep exercising their
+//! forced concurrency without deadlocking.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Condvar, Mutex, PoisonError, Weak};
+
+use cqlite_core::schema::TableSchema;
+use cqlite_core::storage::scan_cancel::ScanCancel;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::{Config, Error, Platform};
+
+use crate::cancel::CancelFlag;
+
+use super::budget::account_footprint;
+use super::identity::GenerationId;
+use super::probe::GenerationEntry;
+use super::registry::{WarmReader, WarmTableRegistry};
+use super::WarmError;
+
+/// The map size past which a fresh leader election opportunistically prunes slots
+/// whose reader has since been evicted/dropped (a dead `Weak`). Keeps the
+/// coalescer's memory bounded on a long-running server without a background task.
+const COALESCER_PRUNE_THRESHOLD: usize = 1024;
+
+/// Per-generation single-flight for reader opens (issue #2383 fix A).
+///
+/// Keyed on the inode-stable [`GenerationId`], so two per-query snapshot hardlink
+/// dirs (same inodes, new paths) coalesce. Each [`OpenSlot`] caches a `Weak` to
+/// the opened reader: while that reader is still alive ANYWHERE (in the warm
+/// cache or held by an in-flight request), a concurrent miss for the same
+/// generation clones it instead of re-parsing — so coalescing survives even the
+/// FAST in-process opens a test drives, not just a real 1.58M-entry parse. The
+/// `Weak` keeps NO reader alive, so the warm budget's LRU eviction is unaffected;
+/// once a generation's reader is truly gone the slot re-opens on the next miss.
+/// Rebind (fix B) mutates the shared reader in place, so a coalesced reader always
+/// reflects the current live path (no stale-path serve).
+#[derive(Default)]
+pub(super) struct OpenCoalescer {
+    inflight: Mutex<HashMap<GenerationId, Arc<OpenSlot>>>,
+}
+
+/// The shared rendezvous for one generation's open.
+struct OpenSlot {
+    state: Mutex<SlotState>,
+    ready: Condvar,
+}
+
+#[derive(Default)]
+enum SlotState {
+    /// The leader is opening; followers wait.
+    #[default]
+    Pending,
+    /// The reader was opened; followers clone it while the `Weak` is live.
+    Done(Weak<SSTableReader>),
+    /// The last open attempt failed; the next caller re-leads.
+    Failed,
+}
+
+impl OpenCoalescer {
+    /// Coalesce the open of generation `id`: the first caller (leader) runs
+    /// `do_open`; concurrent callers whose reader is still alive clone it. Returns
+    /// `(reader, real_open)` where `real_open` is `true` iff THIS call performed
+    /// the actual open (drives the reader-opens work-done metric — a coalesced
+    /// caller reports `false`). On leader FAILURE (or a since-evicted reader) the
+    /// caller falls through to its own `do_open` (fail-closed).
+    fn open<F>(&self, id: GenerationId, do_open: F) -> Result<(Arc<SSTableReader>, bool), WarmError>
+    where
+        F: FnOnce() -> Result<Arc<SSTableReader>, WarmError>,
+    {
+        // Elect a role under the map lock. A slot in `Done` with a LIVE reader is a
+        // fast coalesced hit (no wait); a dead/failed/absent slot makes us the
+        // leader (we reset it to `Pending` so concurrent callers wait on us).
+        let (slot, is_leader) = {
+            let mut map = self.inflight.lock().unwrap_or_else(PoisonError::into_inner);
+            if let Some(slot) = map.get(&id) {
+                let mut st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
+                match &*st {
+                    SlotState::Done(weak) => {
+                        if let Some(reader) = weak.upgrade() {
+                            return Ok((reader, false));
+                        }
+                        *st = SlotState::Pending; // reader evicted → re-lead
+                        drop(st);
+                        (Arc::clone(slot), true)
+                    }
+                    SlotState::Failed => {
+                        *st = SlotState::Pending;
+                        drop(st);
+                        (Arc::clone(slot), true)
+                    }
+                    SlotState::Pending => {
+                        drop(st);
+                        (Arc::clone(slot), false)
+                    }
+                }
+            } else {
+                if map.len() >= COALESCER_PRUNE_THRESHOLD {
+                    prune_dead(&mut map);
+                }
+                let slot = Arc::new(OpenSlot {
+                    state: Mutex::new(SlotState::Pending),
+                    ready: Condvar::new(),
+                });
+                map.insert(id, Arc::clone(&slot));
+                (slot, true)
+            }
+        };
+
+        if is_leader {
+            let result = do_open();
+            {
+                let mut st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
+                *st = match &result {
+                    Ok(reader) => SlotState::Done(Arc::downgrade(reader)),
+                    Err(_) => SlotState::Failed,
+                };
+            }
+            slot.ready.notify_all();
+            return result.map(|r| (r, true));
+        }
+
+        // Follower: wait for the leader's outcome.
+        let mut st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
+        loop {
+            match &*st {
+                SlotState::Pending => {
+                    st = slot.ready.wait(st).unwrap_or_else(PoisonError::into_inner);
+                }
+                SlotState::Done(weak) => {
+                    if let Some(reader) = weak.upgrade() {
+                        return Ok((reader, false));
+                    }
+                    // The reader was evicted between notify and our wake: open it
+                    // ourselves (fail-closed correctness over dedup).
+                    drop(st);
+                    return do_open().map(|r| (r, true));
+                }
+                SlotState::Failed => {
+                    drop(st);
+                    return do_open().map(|r| (r, true));
+                }
+            }
+        }
+    }
+}
+
+/// Drop slots whose reader has been evicted/dropped (a dead `Weak`) and are not
+/// mid-open. Runs under the map lock; slot locks are always taken map-first, so
+/// this is deadlock-free with the open path.
+fn prune_dead(map: &mut HashMap<GenerationId, Arc<OpenSlot>>) {
+    map.retain(|_, slot| {
+        let st = slot.state.lock().unwrap_or_else(PoisonError::into_inner);
+        match &*st {
+            SlotState::Done(weak) => weak.strong_count() > 0,
+            // Keep Pending (in-flight) and Failed (a concurrent caller may re-lead).
+            SlotState::Pending | SlotState::Failed => true,
+        }
+    });
+}
+
+impl WarmTableRegistry {
+    /// Open the ADDED generations, single-flight-coalesced (issue #2383 fix A) and
+    /// cancel-aware (fix C). Fail-closed: any open error (or a cancellation)
+    /// returns immediately WITHOUT partial state. Readers are opened with the SAME
+    /// UDT-registry posture as the cold path (none — see the `registry` module
+    /// doc; #2349 wires a real registry into both paths together).
+    ///
+    /// Returns `(opened, real_opens)`: `real_opens` counts only the opens THIS
+    /// call actually performed (coalesced follower opens do not count), so the
+    /// reader-opens work-done metric equals #distinct generations parsed, not
+    /// #callers × #generations.
+    pub(super) fn open_added(
+        &self,
+        added: &[&GenerationEntry],
+        _schema: &TableSchema,
+        cancel: &CancelFlag,
+    ) -> Result<(Vec<WarmReader>, u64), WarmError> {
+        if added.is_empty() {
+            return Ok((Vec::new(), 0));
+        }
+        // One current-thread runtime per rebuild (reader open is async); reused
+        // across every added generation in this rebuild, like `PruneRuntime`.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| WarmError::Runtime(format!("build runtime: {e}")))?;
+        let platform = self.platform(&runtime)?;
+        let config = Config::default();
+        // Bridge the request's async-token `CancelFlag` onto the synchronous
+        // `ScanCancel` the Index.db parse loop polls (issue #2383 fix C / #2264).
+        let scan_cancel = cancel.scan_cancel();
+
+        // Open in a DETERMINISTIC (generation-id sorted) order across ALL callers
+        // (issue #2383 fix A): each caller probes the dir independently, so their
+        // `read_dir`-ordered `added` slices can differ. Without a common order,
+        // concurrent misses would race on DIFFERENT generations first and split
+        // the coalescing per phase (one real open per generation PER order),
+        // defeating the single-flight. A shared order makes all racers converge on
+        // the same generation at the same step → exactly one real open per
+        // generation. Identity is inode-stable, so the order is stable.
+        let mut added: Vec<&GenerationEntry> = added.to_vec();
+        added.sort_by_key(|e| e.id);
+
+        let mut opened = Vec::with_capacity(added.len());
+        let mut real_opens = 0u64;
+        for entry in &added {
+            #[cfg(test)]
+            self.run_open_barrier();
+            if cancel.is_cancelled() {
+                return Err(WarmError::Cancelled);
+            }
+            let (reader, real) = self.coalescer.open(entry.id, || {
+                open_one_reader(
+                    &runtime,
+                    &entry.path,
+                    &config,
+                    Arc::clone(&platform),
+                    scan_cancel.clone(),
+                )
+                .map(Arc::new)
+            })?;
+            if real {
+                real_opens += 1;
+            }
+            let footprint = account_footprint(&entry.path);
+            opened.push(WarmReader {
+                id: entry.id,
+                reader,
+                footprint,
+                last_access: 0,
+            });
+        }
+        Ok((opened, real_opens))
+    }
+
+    /// Lazily build + cache the shared [`Platform`] used to open readers.
+    pub(super) fn platform(
+        &self,
+        runtime: &tokio::runtime::Runtime,
+    ) -> Result<Arc<Platform>, WarmError> {
+        let mut guard = self.platform.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(p) = guard.as_ref() {
+            return Ok(Arc::clone(p));
+        }
+        let platform = runtime
+            .block_on(Platform::new(&Config::default()))
+            .map_err(|e| WarmError::Runtime(format!("build platform: {e}")))?;
+        let platform = Arc::new(platform);
+        *guard = Some(Arc::clone(&platform));
+        Ok(platform)
+    }
+}
+
+/// Whether a cached reader's backing `Data.db` still resolves on disk (issue
+/// #2352). A cheap `metadata` stat on the reader's `file_path` — the path is
+/// almost always dentry-cached, and this runs only on the per-request warm probe
+/// path, never a hot inner loop. Returning `false` (an ENOENT/`stat` failure)
+/// means the reader was opened from a path that has since been cleared (a
+/// per-query snapshot dir), so it must be re-opened or REBOUND from the current
+/// live dir rather than served (which would ENOENT on its next lazy scan re-open).
+pub(super) fn reader_backing_present(reader: &SSTableReader) -> bool {
+    std::fs::metadata(reader.file_path()).is_ok()
+}
+
+/// Whether `live_path` is AUTHORITATIVELY the same on-disk generation as a cached
+/// reader of identity `id` and size `expected_size` — the rebind gate (issue
+/// #2383 fix B, the #2356 "rebind-by-inode" direction).
+///
+/// Re-resolves the live candidate's identity and requires an EXACT
+/// `(device, inode, generation)` + size match. Cassandra snapshot files are
+/// hardlinks to the immutable SSTable, so a same-inode candidate is byte-identical
+/// — matching is proof the cached parsed state is still valid for the live path.
+/// Anything short of a full match (a `stat` failure, a recycled inode, a size
+/// mismatch) fails CLOSED: the caller falls back to a full re-open + re-parse
+/// rather than guessing (issue #28 no-heuristics).
+pub(super) fn rebind_matches(id: GenerationId, expected_size: u64, live_path: &Path) -> bool {
+    match (
+        GenerationId::resolve(live_path),
+        std::fs::metadata(live_path),
+    ) {
+        (Some(live_id), Ok(md)) => live_id == id && md.len() == expected_size,
+        _ => false,
+    }
+}
+
+/// Open ONE reader, cancel-aware (issue #2383 fix C), with the SAME UDT-registry
+/// posture as the cold path.
+///
+/// The cold Flight path (`KWayMerger::new_cancellable`) opens readers with
+/// `udt_registry = None`, so — to keep warm a parse-cost-only change with no
+/// read-semantics divergence — this does NOT set a registry either. Wiring a real
+/// registry into BOTH paths together is issue #2349; see the `registry` module
+/// doc. The `cancel` flag is polled inside the O(entries) `Index.db` parse
+/// (`open_cancellable`), so a mid-parse client disconnect surfaces as
+/// [`Error::Cancelled`] and is mapped to [`WarmError::Cancelled`] — never masked
+/// as an `Open` failure, never run to completion.
+fn open_one_reader(
+    runtime: &tokio::runtime::Runtime,
+    path: &Path,
+    config: &Config,
+    platform: Arc<Platform>,
+    cancel: ScanCancel,
+) -> Result<SSTableReader, WarmError> {
+    let reader = runtime
+        .block_on(SSTableReader::open_cancellable(path, config, platform, cancel))
+        .map_err(|source| match source {
+            Error::Cancelled => WarmError::Cancelled,
+            source => WarmError::Open {
+                path: path.to_path_buf(),
+                source,
+            },
+        })?;
+    debug_assert!(
+        !reader.has_udt_registry(),
+        "warm reader must match the cold path's no-UDT-registry posture (#2349)"
+    );
+    Ok(reader)
+}

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -51,11 +51,11 @@ use std::sync::{Arc, Mutex, PoisonError};
 
 use cqlite_core::schema::TableSchema;
 use cqlite_core::storage::sstable::reader::SSTableReader;
-use cqlite_core::{Config, Platform};
+use cqlite_core::Platform;
 
 use crate::cancel::CancelFlag;
 
-use super::budget::{account_footprint, DEFAULT_WARM_BUDGET_BYTES};
+use super::budget::DEFAULT_WARM_BUDGET_BYTES;
 use super::identity::{GenerationId, GenerationSet};
 use super::metrics::{RefreshOutcome, WarmMetrics};
 use super::probe::{self, GenerationEntry, ProbeOutcome};
@@ -81,11 +81,14 @@ impl TableKey {
 }
 
 /// One warm generation: its identity, the open reader, and byte accounting.
-struct WarmReader {
-    id: GenerationId,
-    reader: Arc<SSTableReader>,
-    footprint: u64,
-    last_access: u64,
+///
+/// `pub(super)` so the rebuild's expensive half (single-flight opens + rebind,
+/// [`super::rebuild`]) can construct these (issue #2383, campsite split).
+pub(super) struct WarmReader {
+    pub(super) id: GenerationId,
+    pub(super) reader: Arc<SSTableReader>,
+    pub(super) footprint: u64,
+    pub(super) last_access: u64,
 }
 
 /// Warm state for one logical table.
@@ -122,22 +125,27 @@ impl Inner {
 /// identity.
 pub struct WarmTableRegistry {
     inner: Mutex<Inner>,
-    /// Lazily-built shared platform for reader opens.
-    platform: Mutex<Option<Arc<Platform>>>,
+    /// Lazily-built shared platform for reader opens. `pub(super)` for
+    /// [`super::rebuild`] (campsite split, issue #2383).
+    pub(super) platform: Mutex<Option<Arc<Platform>>>,
     budget_bytes: u64,
     metrics: Arc<WarmMetrics>,
+    /// Per-generation single-flight for reader opens (issue #2383 fix A): M
+    /// concurrent misses for one table coalesce onto ONE real open+parse per
+    /// generation instead of opening ×M. See [`super::rebuild::OpenCoalescer`].
+    pub(super) coalescer: super::rebuild::OpenCoalescer,
     /// Test-only rendezvous invoked inside [`Self::rebuild`] AFTER the added
     /// generations are opened but BEFORE the swap lock is taken — lets the
     /// concurrent-same-key-rebuild race test hold two threads "past the probe,
     /// before either swaps" deterministically. `None` (a no-op) in production.
     #[cfg(test)]
     swap_barrier: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
-    /// Test-only hook invoked at the TOP of each [`Self::open_added`] loop
+    /// Test-only hook invoked at the TOP of each `open_added` loop
     /// iteration (before its cancel check) — lets the mid-rebuild cancellation
     /// test trip the cancel flag BETWEEN two added-generation opens. `None` in
-    /// production.
+    /// production. `pub(super)` for [`super::rebuild`] (campsite split).
     #[cfg(test)]
-    open_barrier: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+    pub(super) open_barrier: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
 }
 
 impl Default for WarmTableRegistry {
@@ -160,6 +168,7 @@ impl WarmTableRegistry {
             platform: Mutex::new(None),
             budget_bytes: budget_bytes.max(1),
             metrics: Arc::new(WarmMetrics::default()),
+            coalescer: super::rebuild::OpenCoalescer::default(),
             #[cfg(test)]
             swap_barrier: Mutex::new(None),
             #[cfg(test)]
@@ -345,10 +354,13 @@ impl WarmTableRegistry {
         // OUTSIDE the lock (slow I/O). `probe_start_set` is what THIS rebuild's
         // delta was computed against — the epoch guard below re-checks it hasn't
         // moved by the time we reach the swap (roborev 1639).
-        // Snapshot each cached generation's identity AND its reader's backing
-        // path under the brief lock; the path-liveness `stat`s run OUTSIDE the
-        // lock (no filesystem I/O under the registry mutex).
-        let cached: Vec<(GenerationId, std::path::PathBuf)> = {
+        // Snapshot each cached generation's identity AND a CLONE of its reader
+        // `Arc` under the brief lock; the path-liveness `stat`s and any rebind run
+        // OUTSIDE the lock (no filesystem I/O under the registry mutex). Cloning
+        // the `Arc` lets us rebind the cached reader in place (#2383) — the same
+        // reader is shared with the live cache entry, so a rebind is observed at
+        // the swap without a re-open.
+        let cached: Vec<(GenerationId, Arc<SSTableReader>)> = {
             let inner = self.lock_inner();
             inner
                 .tables
@@ -357,7 +369,7 @@ impl WarmTableRegistry {
                 .map(|t| {
                     t.readers
                         .iter()
-                        .map(|r| (r.id, r.reader.file_path().to_path_buf()))
+                        .map(|r| (r.id, Arc::clone(&r.reader)))
                         .collect()
                 })
                 .unwrap_or_default()
@@ -365,28 +377,45 @@ impl WarmTableRegistry {
         // `probe_start_set` is the FULL cached generation SET (by identity) this
         // delta was computed against — the epoch guard below compares the LIVE
         // entry's set to it to detect a concurrent fresher install. Path-liveness
-        // never changes the identity set, so the guard uses ALL cached ids.
+        // / rebind never change the identity set, so the guard uses ALL cached ids.
         let probe_start_set = GenerationSet::from_ids(cached.iter().map(|(id, _)| *id).collect());
 
-        // Path-liveness (issue #2352): a cached generation counts as "already
-        // warm" ONLY when its backing `Data.db` still resolves. A dead-path
-        // generation (its per-query snapshot dir was cleared by the connector) is
-        // NOT kept — it lands in `added` and is RE-OPENED from the current live
-        // `entries` path, so a subsequent lazy scan re-open cannot ENOENT.
-        let alive_ids: HashSet<GenerationId> = cached
-            .iter()
-            .filter(|(_, p)| std::fs::metadata(p).is_ok())
-            .map(|(id, _)| *id)
-            .collect();
+        // Live entries by identity, for the rebind match (issue #2383 fix B).
+        let live_by_id: HashMap<GenerationId, &GenerationEntry> =
+            entries.iter().map(|e| (e.id, e)).collect();
 
-        // ADDED = present now, not already warm on a LIVE path. Open them
-        // (fail-closed) — this includes both genuinely-new generations and
-        // dead-path ones being refreshed from the current live dir (#2352).
+        // Path-liveness (#2352) + rebind-by-inode (#2383/#2356). A cached
+        // generation counts as "already warm" (kept, ZERO re-parse) when EITHER:
+        //  (a) its current backing `Data.db` path still resolves, OR
+        //  (b) its path is dead (its per-query snapshot dir was cleared) but the
+        //      SAME generation is present in the current live dir — an
+        //      AUTHORITATIVE `(device, inode, generation)` + size match (Cassandra
+        //      snapshot files are hardlinks to the immutable SSTable; #28
+        //      no-heuristics). We REBIND the reader's lazy-scan path to that live
+        //      hardlink instead of re-opening + re-parsing the whole Index.db.
+        // A dead-path generation with NO identity-matching live entry fails CLOSED:
+        // it lands in `added` and is fully re-opened from the live dir.
+        let mut alive_ids: HashSet<GenerationId> = HashSet::new();
+        for (id, reader) in &cached {
+            let current_path = reader.file_path();
+            if std::fs::metadata(&current_path).is_ok() {
+                alive_ids.insert(*id);
+            } else if let Some(live) = live_by_id.get(id) {
+                if super::rebuild::rebind_matches(*id, reader.file_size(), &live.path) {
+                    reader.rebind_path(&live.path);
+                    alive_ids.insert(*id);
+                }
+            }
+        }
+
+        // ADDED = present now, not already warm/rebound on a LIVE path. Open them
+        // (fail-closed) — genuinely-new generations and dead-path ones with no
+        // identity-matching live hardlink to rebind onto.
         let added: Vec<&GenerationEntry> = entries
             .iter()
             .filter(|e| !alive_ids.contains(&e.id))
             .collect();
-        let opened = match self.open_added(&added, schema, cancel) {
+        let (opened, reader_opens) = match self.open_added(&added, schema, cancel) {
             Ok(opened) => opened,
             Err(e) => {
                 // The previously warm set is untouched. Record the fail-closed
@@ -398,7 +427,6 @@ impl WarmTableRegistry {
                 return Err(e);
             }
         };
-        let reader_opens = opened.len() as u64;
 
         // Test-only rendezvous: hold here (past the probe + open, before the swap)
         // so a concurrent same-key rebuild can be driven deterministically.
@@ -581,60 +609,8 @@ impl WarmTableRegistry {
         evicted
     }
 
-    /// Open the ADDED generations. Fail-closed: any open error (or a
-    /// cancellation) returns immediately WITHOUT partial state. Readers are opened
-    /// with the SAME UDT-registry posture as the cold path (none — see the module
-    /// doc; #2349 wires a real registry into both paths together).
-    fn open_added(
-        &self,
-        added: &[&GenerationEntry],
-        _schema: &TableSchema,
-        cancel: &CancelFlag,
-    ) -> Result<Vec<WarmReader>, WarmError> {
-        if added.is_empty() {
-            return Ok(Vec::new());
-        }
-        // One current-thread runtime per rebuild (reader open is async); reused
-        // across every added generation in this rebuild, like `PruneRuntime`.
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| WarmError::Runtime(format!("build runtime: {e}")))?;
-        let platform = self.platform(&runtime)?;
-        let config = Config::default();
-
-        let mut opened = Vec::with_capacity(added.len());
-        for entry in added {
-            #[cfg(test)]
-            self.run_open_barrier();
-            if cancel.is_cancelled() {
-                return Err(WarmError::Cancelled);
-            }
-            let reader = open_one_reader(&runtime, &entry.path, &config, Arc::clone(&platform))?;
-            let footprint = account_footprint(&entry.path);
-            opened.push(WarmReader {
-                id: entry.id,
-                reader: Arc::new(reader),
-                footprint,
-                last_access: 0,
-            });
-        }
-        Ok(opened)
-    }
-
-    /// Lazily build + cache the shared [`Platform`] used to open readers.
-    fn platform(&self, runtime: &tokio::runtime::Runtime) -> Result<Arc<Platform>, WarmError> {
-        let mut guard = self.platform.lock().unwrap_or_else(PoisonError::into_inner);
-        if let Some(p) = guard.as_ref() {
-            return Ok(Arc::clone(p));
-        }
-        let platform = runtime
-            .block_on(Platform::new(&Config::default()))
-            .map_err(|e| WarmError::Runtime(format!("build platform: {e}")))?;
-        let platform = Arc::new(platform);
-        *guard = Some(Arc::clone(&platform));
-        Ok(platform)
-    }
+    // `open_added` (single-flight coalesced, cancel-aware) + `platform` live in
+    // [`super::rebuild`] (issue #2383, campsite split).
 
     fn lock_inner(&self) -> std::sync::MutexGuard<'_, Inner> {
         self.inner.lock().unwrap_or_else(PoisonError::into_inner)
@@ -667,7 +643,9 @@ impl WarmTableRegistry {
                 None => return true,
             }
         };
-        readers.iter().all(|r| reader_backing_present(r))
+        readers
+            .iter()
+            .all(|r| super::rebuild::reader_backing_present(r))
     }
 
     /// Install the test-only swap rendezvous (see the field doc).
@@ -702,9 +680,10 @@ impl WarmTableRegistry {
             .unwrap_or_else(PoisonError::into_inner) = Some(f);
     }
 
-    /// Invoke the per-open rendezvous if one is installed.
+    /// Invoke the per-open rendezvous if one is installed. `pub(super)` for
+    /// [`super::rebuild::WarmTableRegistry::open_added`] (campsite split).
     #[cfg(test)]
-    fn run_open_barrier(&self) {
+    pub(super) fn run_open_barrier(&self) {
         let hook = self
             .open_barrier
             .lock()
@@ -743,41 +722,8 @@ impl WarmTableRegistry {
     }
 }
 
-/// Open ONE reader with the SAME UDT-registry posture as the cold path.
-///
-/// The cold Flight path (`KWayMerger::new_cancellable`) opens readers with
-/// `udt_registry = None`, so — to keep warm a parse-cost-only change with no
-/// read-semantics divergence — this does NOT set a registry either. Wiring a real
-/// registry into BOTH paths together is issue #2349; see the module doc.
-/// Whether a cached reader's backing `Data.db` still resolves on disk (issue
-/// #2352). A cheap `metadata` stat on the reader's `file_path` — the path is
-/// almost always dentry-cached, and this runs only on the per-request warm probe
-/// path, never a hot inner loop. Returning `false` (an ENOENT/`stat` failure)
-/// means the reader was opened from a path that has since been cleared (a
-/// per-query snapshot dir), so it must be re-opened from the current live dir
-/// rather than served (which would ENOENT on its next lazy scan re-open).
-fn reader_backing_present(reader: &SSTableReader) -> bool {
-    std::fs::metadata(reader.file_path()).is_ok()
-}
-
-fn open_one_reader(
-    runtime: &tokio::runtime::Runtime,
-    path: &Path,
-    config: &Config,
-    platform: Arc<Platform>,
-) -> Result<SSTableReader, WarmError> {
-    let reader = runtime
-        .block_on(SSTableReader::open(path, config, platform))
-        .map_err(|source| WarmError::Open {
-            path: path.to_path_buf(),
-            source,
-        })?;
-    debug_assert!(
-        !reader.has_udt_registry(),
-        "warm reader must match the cold path's no-UDT-registry posture (#2349)"
-    );
-    Ok(reader)
-}
+// `reader_backing_present` + `open_one_reader` moved to [`super::rebuild`]
+// (issue #2383, campsite split).
 
 // Registry integration tests over real in-process SSTables (issue #2310), in a
 // separate file (campsite rule) loaded here.

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -785,6 +785,12 @@ fn open_one_reader(
 #[path = "registry_tests.rs"]
 mod registry_tests;
 
+// Issue #2383 resolve-phase CPU-spin RED repros (rebind / single-flight / cancel
+// granularity), in a separate file (campsite rule) loaded here.
+#[cfg(test)]
+#[path = "spin_tests_2383.rs"]
+mod spin_tests_2383;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -1,0 +1,306 @@
+//! Issue #2383 RED repros — resolve-phase CPU spin (round-8 field failure).
+//!
+//! The field failure: Arrow Flight `do_get` against a snapshot with 2 BIG-nb
+//! SSTables (~1.58M partitions each) re-parses the FULL `Index.db` for the SAME
+//! generation repeatedly (8× "Parsed 1586932 partition entries" for one logical
+//! query), pinning tokio workers in the O(entries) `memcmp`/vint parse loop. LIMIT
+//! 5, `count(*)`, and PK point-reads all hang; cancellation doesn't stop the spin.
+//!
+//! These registry-level repros pin the three confirmed mechanisms sharply and
+//! scale-free using the warm registry's `reader_opens` work-done probe (each
+//! reader open is exactly one full `Index.db` parse):
+//!
+//! 1. **Rebind across snapshot teardown** — a per-query snapshot dir is cleared
+//!    and a NEW dir with the SAME inodes is staged; the warm set must REBIND to
+//!    the live path with ZERO further parses, not fully re-open every generation
+//!    (fix B; direction named in #2356 "rebind-by-inode").
+//! 2. **Single-flight rebuild** — M concurrent misses for ONE fresh key must
+//!    coalesce onto ONE rebuild (total opens == #generations), not open ×M
+//!    (fix A).
+//! 3. **Cancel granularity inside the parse** — cancelling DURING a large
+//!    `Index.db` parse must abort promptly, not run the whole parse to completion
+//!    (fix C).
+//!
+//! Loaded via `#[path]` from `registry.rs` (campsite rule) so it can drive the
+//! crate-internal test hooks (`set_open_barrier`, `debug_*`, `metrics`).
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+
+use arrow::array::{Array, StringArray};
+use cqlite_core::schema::TableSchema;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::storage::write_engine::{Durability, WriteEngine, WriteEngineConfig};
+
+use crate::cancel::CancelFlag;
+use crate::producer::MergeProducer;
+use crate::testutil::{
+    build_sstables, make_snapshot, simple_schema, write_row, KS, SIMPLE_DDL, TBL,
+};
+use crate::warm::{TableKey, WarmError, WarmTableRegistry};
+
+fn key() -> TableKey {
+    TableKey::new(KS, TBL)
+}
+
+fn ddl() -> u64 {
+    crate::warm::ddl_hash(SIMPLE_DDL)
+}
+
+/// Decode a warm reader set into its sorted `name` column values through the SAME
+/// streaming-merge path `do_get` drives — proves the rebound/rebuilt set reads the
+/// LIVE inodes correctly (no ENOENT), not merely that an open succeeded.
+fn decode_names(schema: &TableSchema, readers: Vec<Arc<SSTableReader>>) -> Vec<String> {
+    let producer = MergeProducer::new(schema.clone(), 1024).expect("producer");
+    let batches = producer
+        .produce_streaming_from_readers_to_vec(readers, &CancelFlag::new())
+        .expect("decode readers");
+    let mut out = Vec::new();
+    for b in &batches {
+        let names = b
+            .column_by_name("name")
+            .expect("name column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name is text");
+        for i in 0..names.len() {
+            out.push(names.value(i).to_string());
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Build ONE SSTable generation with `n` distinct int-PK partitions so its
+/// `Index.db` is large enough that a full parse dominates wall time (the spin
+/// loop). A large flush threshold keeps all `n` rows in ONE generation — the sync
+/// `write()` path auto-flushes over the default threshold when no runtime is
+/// active, which would otherwise split them across many SSTables.
+fn build_big_single_gen(schema: &TableSchema, n: i32) -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone())
+        .with_flush_threshold(1usize << 30) // 1 GiB: no mid-write auto-flush.
+        .with_durability(Durability::Disabled); // bulk-load: skip per-write WAL fsync.
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for id in 0..n {
+        engine.write(write_row(id, "n", id, 100)).expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    let table_dir = data_dir.join(&schema.keyspace).join(&schema.table);
+    // Prove it really is a SINGLE generation (one -Data.db) so the cancel repro
+    // trips DURING one parse, not at a coarse between-generation boundary.
+    let data_files = std::fs::read_dir(&table_dir)
+        .expect("table dir")
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|f| f.ends_with("-Data.db"))
+        })
+        .count();
+    assert_eq!(
+        data_files, 1,
+        "the cancel repro needs exactly ONE big generation (found {data_files})"
+    );
+    (temp, table_dir)
+}
+
+/// **Fix B — rebind across snapshot teardown WITHOUT re-parse.** Warm from a
+/// per-query snapshot dir; the connector clears it (`clearSnapshot`) and stages a
+/// FRESH dir over the SAME underlying inodes (hardlinks). Because the cached
+/// readers' paths are now dead, the warm lookup must REBIND them to the live path
+/// — zero further `Index.db` parses — instead of fully re-opening every
+/// generation. The rebound readers must back LIVE paths (#2352 ENOENT protection)
+/// and decode correctly.
+///
+/// RED on current main: `cached_paths_all_present` returns false for the dead
+/// snap1 paths, so `rebuild` lands both generations in `added` and RE-OPENS them
+/// from the live dir → `reader_opens` climbs by #generations (measured: +2). The
+/// fix rebinds by inode identity → +0. This IS the field spin: every per-query
+/// snapshot swap re-parses the whole index.
+#[test]
+fn rebind_across_snapshot_teardown_does_not_reparse() {
+    let schema = simple_schema();
+    let (_temp, _data, table_dir) = build_sstables(
+        &schema,
+        vec![
+            vec![write_row(1, "a", 1, 100)],
+            vec![write_row(2, "b", 2, 100)],
+        ],
+    );
+
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+
+    // Query N: warm from snap1 (readers open with file_path inside snap1).
+    let snap1 = make_snapshot(&table_dir, "snap1");
+    reg.warm_readers(&key(), ddl(), &schema, &snap1, Some("snap1"), &cancel)
+        .expect("first snapshot warms");
+    let opens_after_first = reg.metrics().snapshot().reader_opens;
+    assert!(opens_after_first >= 2, "both generations parsed cold");
+
+    // Connector clears query N's snapshot; the live inodes in table_dir persist.
+    std::fs::remove_dir_all(&snap1).expect("clear query-N snapshot dir");
+
+    // Query N+1: a NEW snapshot dir over the SAME inodes (hardlinks).
+    let snap2 = make_snapshot(&table_dir, "snap2");
+    let w2 = reg
+        .warm_readers(&key(), ddl(), &schema, &snap2, Some("snap2"), &cancel)
+        .expect("second snapshot request after teardown");
+
+    // Every returned reader must back a LIVE path (#2352 ENOENT protection kept).
+    for r in &w2.readers {
+        assert!(
+            std::fs::metadata(r.file_path()).is_ok(),
+            "rebound reader must back a live path, got dead {}",
+            r.file_path().display()
+        );
+    }
+    // Row correctness through the same merge path do_get drives.
+    assert_eq!(
+        decode_names(&schema, w2.readers),
+        vec!["a".to_string(), "b".to_string()],
+        "rebound warm set reads the live inodes correctly (no ENOENT)"
+    );
+
+    // THE anti-spin assertion: the teardown+restage cost ZERO further full parses.
+    // RED today (a full rebuild re-opens both generations → +2).
+    assert_eq!(
+        reg.metrics().snapshot().reader_opens,
+        opens_after_first,
+        "a snapshot teardown + same-inode restage must REBIND (zero further \
+         Index.db parses), not re-open every generation (issue #2383 / #2356)"
+    );
+}
+
+/// **Fix A — single-flight rebuild.** M concurrent misses for ONE fresh table key
+/// must coalesce onto a single rebuild: total `reader_opens` == #generations, not
+/// ×M. A start barrier launches all M threads together and a per-open sleep hook
+/// widens the open window so, on the unfixed code, every thread misses and opens
+/// its OWN copy of both generations before any swap lands.
+///
+/// RED on current main: `open_added` has no coalescing and the epoch guard
+/// discards losers only AFTER they have already parsed, so M threads × 2
+/// generations = up to 16 full `Index.db` parses (measured ≫ 2). The swap-time
+/// dedup keeps the CACHE correct (2 readers) but does nothing about the redundant
+/// PARSE work — exactly the concurrent-splits arm of the field spin.
+#[test]
+fn concurrent_misses_single_flight_one_parse_per_generation() {
+    const M: usize = 8;
+    let schema = simple_schema();
+    let (temp, _data, table_dir) = build_sstables(
+        &schema,
+        vec![
+            vec![write_row(1, "a", 1, 100)],
+            vec![write_row(2, "b", 2, 100)],
+        ],
+    );
+
+    let reg = Arc::new(WarmTableRegistry::new());
+    // Widen the per-open window so all M threads are concurrently mid-open on the
+    // unfixed path (fires only on threads that actually open — no deadlock when a
+    // single-flight fix lets just one thread open).
+    reg.set_open_barrier(Arc::new(|| thread::sleep(Duration::from_millis(40))));
+
+    let start = Arc::new(Barrier::new(M));
+    let handles: Vec<_> = (0..M)
+        .map(|_| {
+            let reg = Arc::clone(&reg);
+            let schema = schema.clone();
+            let dir = table_dir.clone();
+            let start = Arc::clone(&start);
+            thread::spawn(move || {
+                start.wait();
+                reg.warm_readers(&key(), ddl(), &schema, &dir, None, &CancelFlag::new())
+                    .expect("concurrent warm")
+                    .readers
+                    .len()
+            })
+        })
+        .collect();
+    for h in handles {
+        assert_eq!(h.join().expect("thread"), 2, "each caller gets both gens");
+    }
+
+    // The cache is correct either way (2 distinct generations); the BUG is the
+    // redundant parse work.
+    assert_eq!(
+        reg.debug_distinct_gen_count(&key()),
+        2,
+        "two generations cached"
+    );
+    assert_eq!(
+        reg.metrics().snapshot().reader_opens,
+        2,
+        "M={M} concurrent misses for one key must coalesce onto ONE rebuild — \
+         exactly #generations (2) full Index.db parses, not ×M (issue #2383)"
+    );
+    drop(temp);
+}
+
+/// **Fix C — cancel granularity inside the parse.** Cancelling DURING a large
+/// `Index.db` parse must abort promptly with `WarmError::Cancelled`, not run the
+/// whole O(entries) parse to completion. A single big generation (150k partitions)
+/// makes the parse dominate wall time; the canceller waits until the open has
+/// begun (the open barrier fired), then — after a margin that guarantees the
+/// registry's coarse pre-open cancel check has already passed — trips the flag
+/// mid-parse.
+///
+/// RED on current main: neither `parse_all_partition_keys_with_summary` nor
+/// `SSTableReader::open` polls the cancel flag, so once past the coarse
+/// between-open check the parse runs to completion and `warm_readers` returns
+/// `Ok`. The field showed workers spinning in this exact loop AFTER a client kill.
+#[test]
+fn cancel_during_large_index_parse_aborts_promptly() {
+    let schema = simple_schema();
+    let (_temp, table_dir) = build_big_single_gen(&schema, 150_000);
+
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+
+    // Signal when the (single) open has started; the open barrier fires at the top
+    // of the open loop, immediately BEFORE the registry's coarse pre-open cancel
+    // check — so the canceller waits for it, then adds a margin so that coarse
+    // check has certainly passed and we are now inside the parse.
+    let open_started = Arc::new(AtomicBool::new(false));
+    {
+        let flag = Arc::clone(&open_started);
+        reg.set_open_barrier(Arc::new(move || flag.store(true, Ordering::SeqCst)));
+    }
+
+    let canceller = {
+        let cancel = cancel.clone();
+        let open_started = Arc::clone(&open_started);
+        thread::spawn(move || {
+            while !open_started.load(Ordering::SeqCst) {
+                thread::yield_now();
+            }
+            // Margin: let the coarse pre-open cancel check run first, so this trip
+            // lands strictly DURING the parse (never at the coarse boundary, which
+            // the unfixed code already honors).
+            thread::sleep(Duration::from_millis(30));
+            cancel.cancel();
+        })
+    };
+
+    let res = reg.warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel);
+    canceller.join().expect("canceller");
+
+    // RED today: the parse ignores the mid-parse cancel and returns Ok. GREEN once
+    // the parse loop polls the cancel flag (fix C) and returns Cancelled promptly.
+    assert!(
+        matches!(res, Err(WarmError::Cancelled)),
+        "a cancel tripped DURING a large Index.db parse must abort promptly with \
+         Cancelled, got {:?} (issue #2383 fix C)",
+        res.map(|w| (w.outcome, w.readers.len()))
+    );
+}

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -255,6 +255,19 @@ fn concurrent_misses_single_flight_one_parse_per_generation() {
 /// registry's coarse pre-open cancel check has already passed — trips the flag
 /// mid-parse.
 ///
+/// The margin is CALIBRATED against this host's own just-measured cost of fully
+/// opening+parsing this exact fixture (issue #2383 roborev-1653 NIT 5 — "no
+/// wall-clock races in tests"), not a fixed constant: a hardcoded sleep flakes on
+/// a fast host once the full parse completes faster than the constant, and
+/// raising the entry count to force a structural floor was measured to scale
+/// FAR worse than linearly in `SSTableReader::open` (150k → 1.8s, 2M → 5+min;
+/// not this issue's fix surface), so it is not a viable alternative here. A
+/// small, conservative FRACTION of a just-measured baseline instead scales DOWN
+/// automatically with host speed — comfortably past the microsecond-scale
+/// coarse pre-open check (a same-thread, no-I/O comparison) and comfortably
+/// short of the real run's parse, including under page-cache speedup from the
+/// calibration pass warming the OS cache for the timed run.
+///
 /// RED on current main: neither `parse_all_partition_keys_with_summary` nor
 /// `SSTableReader::open` polls the cancel flag, so once past the coarse
 /// between-open check the parse runs to completion and `warm_readers` returns
@@ -264,13 +277,26 @@ fn cancel_during_large_index_parse_aborts_promptly() {
     let schema = simple_schema();
     let (_temp, table_dir) = build_big_single_gen(&schema, 150_000);
 
+    // Calibrate: fully open+parse the SAME fixture, uncancelled, once — this also
+    // warms the OS page cache ahead of the timed run below (biasing that run
+    // FASTER, never slower, than this baseline).
+    let calib_start = std::time::Instant::now();
+    WarmTableRegistry::new()
+        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
+        .expect("calibration warm (uncancelled) completes");
+    let baseline = calib_start.elapsed();
+    // 1/20th of the measured baseline: tens of ms on every host we've observed,
+    // dwarfing the coarse check's same-thread gap, and a small enough fraction to
+    // stay comfortably inside the timed run even under real page-cache speedup.
+    let margin = baseline / 20;
+
     let reg = WarmTableRegistry::new();
     let cancel = CancelFlag::new();
 
     // Signal when the (single) open has started; the open barrier fires at the top
     // of the open loop, immediately BEFORE the registry's coarse pre-open cancel
-    // check — so the canceller waits for it, then adds a margin so that coarse
-    // check has certainly passed and we are now inside the parse.
+    // check — so the canceller waits for it, then adds the calibrated margin so
+    // that coarse check has certainly passed and we are now inside the parse.
     let open_started = Arc::new(AtomicBool::new(false));
     {
         let flag = Arc::clone(&open_started);
@@ -287,7 +313,7 @@ fn cancel_during_large_index_parse_aborts_promptly() {
             // Margin: let the coarse pre-open cancel check run first, so this trip
             // lands strictly DURING the parse (never at the coarse boundary, which
             // the unfixed code already honors).
-            thread::sleep(Duration::from_millis(30));
+            thread::sleep(margin);
             cancel.cancel();
         })
     };
@@ -300,7 +326,106 @@ fn cancel_during_large_index_parse_aborts_promptly() {
     assert!(
         matches!(res, Err(WarmError::Cancelled)),
         "a cancel tripped DURING a large Index.db parse must abort promptly with \
-         Cancelled, got {:?} (issue #2383 fix C)",
+         Cancelled (calibrated margin {margin:?} from baseline {baseline:?}), got \
+         {:?} (issue #2383 fix C)",
         res.map(|w| (w.outcome, w.readers.len()))
     );
+}
+
+/// **Blocker 1 (post-review, roborev job 1653)** — the coalescer's `Weak` hit
+/// must NOT serve a reader whose backing path is DEAD, even when that reader is
+/// kept alive purely by an IN-FLIGHT holder OUTSIDE the registry's own cache.
+///
+/// Scenario (the exact #2352 ENOENT class, one step removed): reader `R` for
+/// table A opens from a per-query snapshot dir; A's generation is then
+/// LRU-EVICTED from the registry's cache under budget pressure while a prior
+/// request still holds `R` alive via its `WarmSet` `Arc` clone (`held` below);
+/// A's snapshot dir is then cleared by the connector. `registry::rebuild`'s
+/// rebind pass (fix B) only walks the CURRENTLY CACHED reader set — since A's
+/// generation is no longer cached, rebind can never see `R`, let alone repoint
+/// its path. The coalescer's OWN `Done(Weak)` slot for `R`'s generation
+/// identity, however, is untouched by cache eviction (it lives in a SEPARATE
+/// map), so the ONLY thing standing between the next query and re-serving `R`'s
+/// dead path is the coalescer's own path-liveness gate.
+///
+/// RED without the blocker-1 fix: the coalescer upgrades its `Weak` to `Some(R)`
+/// and returns it immediately WITHOUT checking `R`'s (now dead) backing path.
+/// GREEN with the fix: the gate rejects the dead-path hit and falls through to
+/// `do_open` from the live `entry.path`, so the served reader always backs a
+/// live inode and decodes correctly.
+#[test]
+fn evicted_but_inflight_reader_is_not_served_with_dead_path() {
+    let schema = simple_schema();
+    let (_t_a, _d_a, dir_a) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+    let (_t_b, _d_b, dir_b) = build_sstables(&schema, vec![vec![write_row(2, "b", 2, 100)]]);
+
+    let key_a = TableKey::new(KS, "blocker1_victim");
+    let key_b = TableKey::new(KS, "blocker1_pressure");
+
+    // Budget = exactly ONE generation's footprint, so warming B evicts A.
+    let probe = WarmTableRegistry::new();
+    probe
+        .warm_readers(&key_a, ddl(), &schema, &dir_a, None, &CancelFlag::new())
+        .expect("probe warm");
+    let one_gen = probe.debug_used_bytes();
+    assert!(one_gen > 0, "a generation's footprint is non-zero");
+
+    let reg = WarmTableRegistry::with_budget(one_gen);
+    let cancel = CancelFlag::new();
+
+    // Warm A from a per-query snapshot dir: reader R's `file_path` lives inside
+    // snap1. Keep the returned `Arc` alive for the WHOLE test — the "in-flight
+    // holder outside the registry's cache" this bug depends on.
+    let snap1 = make_snapshot(&dir_a, "snap1");
+    let w1 = reg
+        .warm_readers(&key_a, ddl(), &schema, &snap1, Some("snap1"), &cancel)
+        .expect("warm A from snap1");
+    assert_eq!(w1.readers.len(), 1, "table A is a single generation");
+    let held: Vec<Arc<SSTableReader>> = w1.readers.clone();
+    let held_ptr = Arc::as_ptr(&held[0]);
+
+    // Warm B: pushes `used_bytes` over budget, evicting A's generation from the
+    // registry's OWN cache — but R stays alive via `held` above.
+    reg.warm_readers(&key_b, ddl(), &schema, &dir_b, None, &cancel)
+        .expect("warm B evicts A");
+    assert_eq!(
+        reg.debug_reader_count(&key_a),
+        0,
+        "A's generation was evicted from the registry's own cache (bug precondition)"
+    );
+
+    // The connector clears query N's snapshot; R's (no-longer-cached-by-the-
+    // registry) `file_path` is now dead. R itself stays alive only via `held`.
+    std::fs::remove_dir_all(&snap1).expect("clear query-N snapshot dir");
+
+    // Query N+1: a NEW snapshot dir over the SAME inodes. Since A was evicted,
+    // this is a genuine registry miss — `rebuild`'s rebind pass never sees R (it
+    // isn't in the cached set), so the ONLY protection against re-serving R's
+    // dead path is the coalescer's own path-liveness gate (blocker 1).
+    let snap2 = make_snapshot(&dir_a, "snap2");
+    let w2 = reg
+        .warm_readers(&key_a, ddl(), &schema, &snap2, Some("snap2"), &cancel)
+        .expect("re-warm A after eviction + snapshot teardown");
+    assert_eq!(w2.readers.len(), 1, "table A is still a single generation");
+
+    // The served reader must back a LIVE path — never R's stale snap1 path.
+    assert!(
+        std::fs::metadata(w2.readers[0].file_path()).is_ok(),
+        "must never serve a dead-path reader from the coalescer, got {}",
+        w2.readers[0].file_path().display()
+    );
+    // Must NOT be R itself (the stale-path reader) — the coalescer must have
+    // fallen through to a fresh open from the live path.
+    assert_ne!(
+        Arc::as_ptr(&w2.readers[0]) as *const (),
+        held_ptr as *const (),
+        "the coalescer must not hand back R's dead-path reader (issue #2383 blocker 1)"
+    );
+    // Row correctness through the same merge path do_get drives.
+    assert_eq!(
+        decode_names(&schema, w2.readers),
+        vec!["a".to_string()],
+        "the re-warmed set decodes correctly from the live inodes (no ENOENT)"
+    );
+    drop(held);
 }

--- a/cqlite-flight/tests/issue_2383_resolve_spin_test.rs
+++ b/cqlite-flight/tests/issue_2383_resolve_spin_test.rs
@@ -1,0 +1,237 @@
+//! Issue #2383 — E2E resolve-phase CPU-spin pin over a real `do_get`.
+//!
+//! The round-8 field failure: a `do_get` against a snapshot with 2 BIG-nb
+//! SSTables re-parsed the FULL `Index.db` for the SAME generation repeatedly
+//! (debug log showed 8× "Parsed 1586932 partition entries" for one logical
+//! query), pinning tokio workers in the O(entries) parse loop so LIMIT/`count(*)`/
+//! point-reads all hung. The Trino connector takes a FRESH per-query Sidecar
+//! snapshot and CLEARS the prior one; the warm cache keys on inode-stable
+//! generation identity, so query N+1's new snapshot dir (same inodes, new path)
+//! is a set-match — but current main finds the CACHED reader paths dead (query
+//! N's cleared snapshot) and fully RE-OPENS every generation, re-parsing the
+//! whole index each time.
+//!
+//! This drives that through the REAL `FlightService::do_get` and reads back the
+//! authoritative `cqlite.sstable.index_parses_total` counter (one increment per
+//! full `Index.db` parse, emitted from the core parse loop regardless of call
+//! path). A correct read path rebinds a same-inode generation to its LIVE path
+//! with ZERO re-parse; current main re-parses #generations — the spin.
+//!
+//! Separate integration-test process (roborev #2163 precedent): the OTel capture
+//! harness installs a PROCESS-GLOBAL meter provider, so it must not share
+//! cqlite-flight's parallel `--lib` unit-test binary. Fixtures are built directly
+//! via `cqlite_core::storage::write_engine` (the crate `testutil` is
+//! `#[cfg(test)]`-gated and invisible to an external integration binary).
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --features observability-testing \
+//!   --test issue_2383_resolve_spin_test
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_flight::service::CqliteFlightService;
+
+const KS: &str = "spin_ks";
+const TBL: &str = "items";
+const DDL: &str = "CREATE TABLE spin_ks.items (id int PRIMARY KEY, name text, score int)";
+
+fn simple_schema() -> TableSchema {
+    let col = |name: &str, ty: &str, nullable: bool| Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    };
+    TableSchema {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            col("id", "int", false),
+            col("name", "text", true),
+            col("score", "int", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, score: i32) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![
+            CellOperation::Write {
+                column: "name".into(),
+                value: Value::Text(name.into()),
+            },
+            CellOperation::Write {
+                column: "score".into(),
+                value: Value::Integer(score),
+            },
+        ],
+        100,
+        None,
+    )
+}
+
+/// Flush a TWO-generation fixture (two separate flushes → two `nb-*-big`
+/// SSTables) so the merge spans ≥2 Index.db files. Returns the temp dir (keep
+/// alive), the data root, and the table dir.
+fn build_two_gen_fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let schema = simple_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    for i in 0..8 {
+        engine.write(write_row(i, "a", i)).expect("write");
+    }
+    rt.block_on(engine.flush()).expect("flush 1").expect("info");
+    for i in 8..16 {
+        engine.write(write_row(i, "b", i)).expect("write");
+    }
+    rt.block_on(engine.flush()).expect("flush 2").expect("info");
+    let table_dir = data_dir.join(KS).join(TBL);
+    let gens = std::fs::read_dir(&table_dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .count();
+    assert_eq!(gens, 2, "fixture must hold exactly two generations");
+    (temp, data_dir, table_dir)
+}
+
+/// Sidecar-style snapshot: HARDLINK every component file into
+/// `table_dir/snapshots/<name>/` (same inodes as the live SSTables, a new path).
+fn make_snapshot(table_dir: &Path, name: &str) -> PathBuf {
+    let snap = table_dir.join("snapshots").join(name);
+    std::fs::create_dir_all(&snap).unwrap();
+    for entry in std::fs::read_dir(table_dir).unwrap().flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            let dest = snap.join(entry.file_name());
+            std::fs::hard_link(&path, &dest)
+                .or_else(|_| std::fs::copy(&path, &dest).map(|_| ()))
+                .unwrap();
+        }
+    }
+    snap
+}
+
+fn ticket_bytes(snapshot: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+        "snapshot": snapshot,
+    }))
+    .unwrap()
+}
+
+/// Run one `do_get` in-process and fully drain its stream (so the whole merge
+/// completes and every parse has fired).
+async fn do_get_drain(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
+    let resp = svc
+        .do_get(Request::new(Ticket::new(ticket)))
+        .await
+        .expect("do_get");
+    let mut stream = resp.into_inner();
+    let mut msgs = 0usize;
+    while let Some(item) = stream.next().await {
+        item.expect("stream item ok");
+        msgs += 1;
+    }
+    msgs
+}
+
+/// **Resolve-phase spin pin (issue #2383).** Two `do_get`s against the SAME
+/// underlying generations reached through TWO per-query snapshot dirs (query N's
+/// is cleared before query N+1 stages a fresh same-inode dir, exactly as the
+/// Trino connector's `clearSnapshot` does). The FIRST query legitimately parses
+/// both generations cold. The SECOND must serve the same inodes with ZERO further
+/// full `Index.db` parses (rebind-by-inode) — its cost is the spin the field saw.
+///
+/// RED on current main: the cached readers' snap1 paths are dead after teardown,
+/// so the warm rebuild RE-OPENS both generations from snap2 and the do_get path
+/// re-parses their Index.db → `index_parses_total` for query 2 == 4 (MEASURED:
+/// 2 generations, each parsed twice on this second-query path — the O(entries ×
+/// opens) amplification the field saw as 8× for one logical query). GREEN after
+/// the rebind fix: query 2 re-parses 0.
+#[test]
+fn do_get_reparses_index_on_every_snapshot_swap() {
+    // Install the process-global in-memory meter BEFORE any parse in this process.
+    let mc = testing::metrics_capture();
+
+    let (_temp, data_dir, table_dir) = build_two_gen_fixture();
+    let svc = CqliteFlightService::new(data_dir, 8192);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // Query N: warm from snap1 (readers open with file_path inside snap1).
+    let snap1 = make_snapshot(&table_dir, "snap1");
+    mc.reset();
+    let msgs1 = rt.block_on(do_get_drain(&svc, ticket_bytes("snap1")));
+    let q1_parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    assert!(msgs1 > 0, "query 1 must stream at least a schema message");
+    assert!(
+        q1_parses >= 2.0,
+        "cold query 1 parses both generations' Index.db (got {q1_parses})"
+    );
+
+    // Connector clears query N's snapshot; the live inodes in table_dir persist.
+    std::fs::remove_dir_all(&snap1).expect("clear query-N snapshot dir");
+
+    // Query N+1: a NEW snapshot dir over the SAME inodes (hardlinks). The on-disk
+    // dir is what the "snap2" ticket resolves; the returned path is not read here.
+    let _snap2 = make_snapshot(&table_dir, "snap2");
+    mc.reset();
+    let msgs2 = rt.block_on(do_get_drain(&svc, ticket_bytes("snap2")));
+    let q2_parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    assert!(msgs2 > 0, "query 2 must stream at least a schema message");
+
+    // THE anti-spin assertion: the second query over the same inodes must NOT
+    // re-parse any Index.db (rebind). RED today (a full rebuild re-parses both
+    // generations → 2). GREEN after fix B.
+    assert_eq!(
+        q2_parses, 0.0,
+        "a second do_get over the SAME generations (new same-inode snapshot dir) \
+         must REBIND with zero further Index.db parses, not re-parse #generations \
+         (issue #2383 resolve-phase spin); got {q2_parses}"
+    );
+}


### PR DESCRIPTION
## Field context (round-8 blocker on #2367)

Round-8 field report (#2367): `do_get` resolve phase pins a CPU core and stalls — traced to **8× full 1.58M-entry Index.db re-parses** during a single query's partition-resolve loop. The regressor is #2357 (warm-handle path-liveness gate) layered over **per-query snapshots with no single-flight**: each resolve step re-opened the reader and re-parsed the whole Index.db, and a stale-path rebind re-parsed again. Mechanism analysis and repro on #2383.

## Fixes (three) + review hardening

- **A — single-flight opens**: concurrent/repeated resolves for the same generation share one in-flight open+parse instead of each doing its own (16→2 opens on the pin).
- **B — rebind-by-inode**: liveness rebind keys on inode identity, so a path-liveness miss reuses the already-parsed reader instead of a full re-parse (4→0 re-parses on the pin).
- **C — cancel-aware parse**: the resolve/parse loop polls the cancel token and unwinds promptly (`Cancelled`) instead of running the full parse to completion.
- Plus `warm/rebuild.rs` campsite split and truncation-error preservation.

**Review round (roborev job 1653 + rust-reviewer):** dead-path Weak-serve liveness gate + regression test, panic drop-guard, cancel-aware follower wait, counter full-parse guard, calibrated large-index cancel-test margin, doc nits. Both the Medium and Low findings fixed and adjudicated on the job.

## Red → green proof

- `single-flight`: opens **16 → 2**
- `rebind-by-inode`: re-parses **4 → 0**
- `cancel`: resolve returns **Cancelled** (calibrated large-index margin)
- e2e q2: `index_parses_total` **0** on the resolve step
- warm suite: **43/43** green

New RED-first tests: `cqlite-flight/src/warm/spin_tests_2383.rs`, `cqlite-flight/tests/issue_2383_resolve_spin_test.rs`; new `index_parses_total` observability counter.

## Gate note

Full gate run with `CQLITE_ALLOW_FILE_GROWTH=1` — the cancel-threading + rebind API grew 5 pre-existing over-threshold core files by ~5 lines each; those splits are epic #1116 scope (per the #1135 note).

## Roborev / follow-ups

- roborev job 1653 — Medium + Low fixed and adjudicated on the job.
- Follow-up **#2385** — super-linear cold Index.db parse (out of scope here).

Closes #2383
