### PR TITLE
test(#2370): N-concurrent do_get coverage — the field-shape gap #2316/#2361 escaped through

### DIFF
--- a/cqlite-core/tests/issue_2370_concurrent_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2370_concurrent_merge_thread_budget.rs
@@ -304,9 +304,7 @@ fn concurrent_merges_bound_aggregate_threads_to_o_c_m() {
             .expect("SSTableWriter::new");
         writer.pre_seed_encoding_baselines(baseline_ts, baseline_ldt, baseline_ttl);
         let stats = merger.merge(&mut writer).expect("merge into writer");
-        finish_rt
-            .block_on(writer.finish())
-            .expect("writer finish");
+        finish_rt.block_on(writer.finish()).expect("writer finish");
         assert!(
             stats.output_rows >= (NUM_INPUTS as u64 * ROWS_PER_INPUT as u64),
             "merger {i} should emit all input rows; got {}",

--- a/cqlite-core/tests/issue_2370_concurrent_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2370_concurrent_merge_thread_budget.rs
@@ -1,0 +1,326 @@
+//! Issue #2370 — the AGGREGATE thread budget: with ≥2 k-way merges live at once
+//! the process OS-thread count must stay O(C·M), not collapse.
+//!
+//! `issue_2316_merge_thread_budget.rs` pins ONE merge's internal fan-out to O(M).
+//! The field failure (#2316 thread collapse, #2361 stall) was CONCURRENCY: several
+//! Flight `do_get`s — each a k-way merge — running at once. Before the #2316 fix
+//! each producer built a full multi-threaded `tokio::runtime::Runtime`
+//! (`num_cpus` workers), so `C` concurrent merges over `M` inputs each cost
+//! `~C·M·num_cpus` OS threads — a context-switch storm well before disk
+//! saturated. This test drives `C ≥ 2` REAL merges SIMULTANEOUSLY (all producers
+//! alive, parked on their bounded channels) and pins the process's PEAK OS-thread
+//! delta to the O(C·M) bound via the same direct `/proc/self/task` /
+//! `proc_pidinfo` kernel observation the #2316 test uses.
+//!
+//! ## Process-isolation requirement (same as #2316)
+//!
+//! The peak-thread observation is WHOLE-PROCESS, so it is only meaningful if this
+//! test runs ALONE in its process. Under nextest (the gate default) every
+//! `#[test]` is its own process. Under plain `cargo test` all `#[test]`s in one
+//! binary run as sibling threads in ONE process, inflating the sampled peak — so
+//! this file holds EXACTLY ONE `#[test]`. Do not add a second; add a sibling FILE.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::writer::SSTableWriter;
+use cqlite_core::storage::write_engine::merge::compute_baseline_min;
+use cqlite_core::storage::write_engine::{
+    CellOperation, KWayMerger, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+/// Rows per input SSTable. Must EXCEED the merge's `STREAMING_CHANNEL_CAPACITY`
+/// (256) so every producer fills its bounded channel and blocks on `send`, so all
+/// producers of all mergers are alive at once at the sampling point.
+const ROWS_PER_INPUT: i32 = 400;
+
+/// Number of input SSTables (`M`) merged per merger.
+const NUM_INPUTS: usize = 3;
+
+/// Number of CONCURRENT mergers (`C`) — the aggregate case (≥2, the field shape).
+const NUM_MERGERS: usize = 2;
+
+/// Max OS threads a single fixed (`current_thread`-runtime) producer contributes
+/// at its peak (producer thread + bounded `spawn_blocking` parse/feed threads),
+/// INDEPENDENT of `num_cpus`. The pre-#2316 multi-threaded runtime added
+/// `num_cpus` worker threads PER producer on top of this — so the pre-change peak
+/// scales with `num_cpus` and the O(C·M) bound below rejects it.
+const PER_INPUT: usize = 3;
+
+/// Fixed slack over the `PER_INPUT · M · C` bound for incidental/settle threads.
+const THREAD_SLACK: usize = 6;
+
+// ── Direct, no-heuristics OS thread-count observation (mirrors #2316) ────────
+
+#[cfg(target_os = "linux")]
+fn os_thread_count() -> Option<usize> {
+    std::fs::read_dir("/proc/self/task")
+        .ok()
+        .map(|it| it.flatten().count())
+}
+
+#[cfg(target_os = "macos")]
+fn os_thread_count() -> Option<usize> {
+    let pid = unsafe { libc::getpid() };
+    let mut info: libc::proc_taskinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_taskinfo>() as libc::c_int;
+    let ret = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTASKINFO,
+            0,
+            &mut info as *mut libc::proc_taskinfo as *mut libc::c_void,
+            size,
+        )
+    };
+    if ret == size {
+        Some(info.pti_threadnum as usize)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn os_thread_count() -> Option<usize> {
+    None
+}
+
+/// Consecutive identical readings required to treat the count as STABILIZED.
+const STABLE_STREAK: usize = 8;
+/// Delay between polls while waiting for stabilization.
+const POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Poll the process OS-thread count until it STABILIZES (same reading across
+/// [`STABLE_STREAK`] consecutive polls) — synchronizing on the thread LIFECYCLE,
+/// not a fixed elapsed window. Returns `(peak, settled)`. `timeout` is a fail-loud
+/// BOUND only: a never-settling count panics with a clear diagnostic rather than
+/// silently under-sampling.
+fn poll_until_stable(timeout: Duration) -> (usize, usize) {
+    let deadline = Instant::now() + timeout;
+    let mut peak = 0usize;
+    let mut last: Option<usize> = None;
+    let mut streak = 0usize;
+    while Instant::now() < deadline {
+        let n = os_thread_count()
+            .expect("thread count observation must remain available (guard 2 confirmed it)");
+        peak = peak.max(n);
+        if last == Some(n) {
+            streak += 1;
+            if streak >= STABLE_STREAK {
+                return (peak, n);
+            }
+        } else {
+            last = Some(n);
+            streak = 1;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    panic!(
+        "OS thread count never stabilized within {timeout:?} (last {last:?}, streak \
+         {streak}/{STABLE_STREAK}, peak {peak}); fail-loud BOUND, not a sync mechanism"
+    );
+}
+
+// ── Real multi-SSTable input construction (never an empty dataset) ──────────
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "conc_merge_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "val".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, val: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("conc_merge_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "val".to_string(),
+            value: Value::Text(val.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+fn discover_inputs(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut found: Vec<(u64, PathBuf)> = Vec::new();
+    collect_inputs(dir, &mut found, 8);
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+fn collect_inputs(dir: &std::path::Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+            let base = name.trim_end_matches("-Data.db");
+            if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
+                continue;
+            }
+            let generation = name
+                .strip_prefix("nb-")
+                .and_then(|s| s.split("-big-").next())
+                .and_then(|g| g.parse::<u64>().ok())
+                .unwrap_or(0);
+            out.push((generation, path));
+        } else if depth > 0 && path.is_dir() {
+            collect_inputs(&path, out, depth - 1);
+        }
+    }
+}
+
+/// Build `NUM_INPUTS` REAL nb SSTables (disjoint partition ranges) by flushing a
+/// `WriteEngine`. Returns them newest-first; never empty.
+fn build_inputs() -> (TempDir, Vec<PathBuf>, TableSchema) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("driver runtime");
+    let temp = TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("inputs");
+    let wal_dir = temp.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+
+    for input in 0..NUM_INPUTS {
+        let base = input as i32 * ROWS_PER_INPUT;
+        for r in 0..ROWS_PER_INPUT {
+            let id = base + r;
+            engine
+                .write(write_row(id, &format!("v-{input}-{r}"), 100 + input as i64))
+                .expect("write row");
+        }
+        rt.block_on(engine.flush())
+            .expect("flush")
+            .expect("flush info");
+    }
+    rt.block_on(engine.close()).expect("close engine");
+
+    let inputs = discover_inputs(&data_dir);
+    assert!(
+        inputs.len() >= NUM_INPUTS,
+        "expected >= {NUM_INPUTS} real input SSTables, got {}",
+        inputs.len()
+    );
+    // Drop the driver runtime BEFORE the caller measures baseline so its
+    // (now-joined) worker threads are not counted in the baseline.
+    drop(rt);
+    (temp, inputs, schema)
+}
+
+#[test]
+fn concurrent_merges_bound_aggregate_threads_to_o_c_m() {
+    // Guard 1: the amplification (M·num_cpus) collapses on a single-core host.
+    let cpus = num_cpus::get();
+    if cpus < 2 {
+        eprintln!("[skip] num_cpus={cpus} < 2 — amplification not observable; holding trivially");
+        return;
+    }
+    // Guard 2: no direct thread-count API on this platform.
+    if os_thread_count().is_none() {
+        eprintln!("[skip] no direct OS thread-count API on this platform; holding trivially");
+        return;
+    }
+
+    let (_temp, inputs, schema) = build_inputs();
+    let m = inputs.len();
+    let c = NUM_MERGERS;
+
+    // Baseline via LIFECYCLE synchronization (the input-build runtime is dropped
+    // but its teardown may still be in flight): poll until quiesced.
+    let (_settle_peak, baseline) = poll_until_stable(Duration::from_secs(10));
+
+    // Construct C mergers over the SAME inputs (read-only) — each spawns its own M
+    // producers, which fill their bounded channels and park. All C·M producers are
+    // alive at once and stay alive until we drain below. Pre-#2316: each producer
+    // ALSO holds a multi-threaded runtime (num_cpus workers) → C·M·num_cpus.
+    let (baseline_ts, baseline_ldt, baseline_ttl) = compute_baseline_min(&inputs);
+    let mut mergers = Vec::with_capacity(c);
+    for _ in 0..c {
+        mergers.push(KWayMerger::new(inputs.clone(), &schema).expect("KWayMerger::new"));
+    }
+
+    // Wait for all producers to reach their steady (blocked-on-send) state via the
+    // SAME lifecycle synchronization — never a fixed window. `peak` also captures a
+    // transient spike (the pre-fix per-producer runtime-worker burst).
+    let (peak, _settled) = poll_until_stable(Duration::from_secs(20));
+    let delta = peak.saturating_sub(baseline);
+    let bound = PER_INPUT * m * c + THREAD_SLACK;
+
+    eprintln!(
+        "[issue-2370] cpus={cpus} C={c} M={m} baseline={baseline} peak={peak} delta={delta} bound={bound}"
+    );
+
+    // Drain every merger so producers exit cleanly (no leaked threads/temp files).
+    let out = TempDir::new().expect("out tempdir");
+    let finish_rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("finish runtime");
+    for (i, merger) in mergers.into_iter().enumerate() {
+        let mut writer = SSTableWriter::new(out.path().join(format!("m{i}")), 1, &schema)
+            .expect("SSTableWriter::new");
+        writer.pre_seed_encoding_baselines(baseline_ts, baseline_ldt, baseline_ttl);
+        let stats = merger.merge(&mut writer).expect("merge into writer");
+        finish_rt
+            .block_on(writer.finish())
+            .expect("writer finish");
+        assert!(
+            stats.output_rows >= (NUM_INPUTS as u64 * ROWS_PER_INPUT as u64),
+            "merger {i} should emit all input rows; got {}",
+            stats.output_rows
+        );
+    }
+
+    // THE PIN: the aggregate peak OS-thread delta over baseline must be within the
+    // O(C·M) bound. Pre-#2316 this is ~C·M·num_cpus (>> bound); post-fix ~C·M.
+    assert!(
+        delta <= bound,
+        "C={c} concurrent merges over M={m} inputs each added {delta} OS threads over baseline \
+         (peak={peak}, baseline={baseline}); O(C·M) bound is {bound} (= {PER_INPUT}·M·C + {THREAD_SLACK}). \
+         A delta scaling with num_cpus (num_cpus={cpus}) means a producer built a multi-threaded \
+         runtime — issue #2316 amplification, unbounded under concurrency (#2370)."
+    );
+}

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -423,6 +423,17 @@ pub fn in_flight_level(method: &str) -> i64 {
     IN_FLIGHT[method_index(method)].load(Ordering::Relaxed)
 }
 
+/// Read the process-wide `cqlite.rpc.phase.active` level for `method`, summed
+/// across all phases (issue #2370). Any in-flight RPC occupies exactly one phase,
+/// so the sum is that method's true in-flight count (the #2361 gauge as a LEVEL).
+pub fn phase_active_level(method: &str) -> i64 {
+    let midx = method_index(method);
+    let c = phase_active_counters();
+    (0..RPC_PHASES.len())
+        .map(|p| c[phase_active_index(midx, p)].load(Ordering::Relaxed))
+        .sum()
+}
+
 /// Record an RPC failure into the error-rate signal (`cqlite.errors.total`,
 /// subsystem `flight`), emit a `tracing` log line, and mark the active span
 /// errored.

--- a/cqlite-flight/tests/concurrent_support/mod.rs
+++ b/cqlite-flight/tests/concurrent_support/mod.rs
@@ -1,0 +1,215 @@
+//! Shared harness for the issue #2370 N-concurrent `do_get` coverage suite.
+//!
+//! Every integration binary in the suite (`issue_2370_concurrent_doget_test`,
+//! `issue_2370_gauge_readback_test`, `issue_2370_single_flight_test`) compiles
+//! this module independently, so unused helpers in any one binary are expected —
+//! hence the crate-local `allow(dead_code)`. The helpers stand up ONE real
+//! loopback tonic server serving a shared `CqliteFlightService` and connect N
+//! real `FlightServiceClient`s over it, so the tests exercise the true gRPC
+//! handler path (not the in-process `do_get`), the layer both #2316 and #2361
+//! escaped through.
+//!
+//! Fixtures are built via the write engine (which emits UNCOMPRESSED `nb-big`
+//! SSTables — the non-stitching read path), interleaving keys across two flushes
+//! so any first-N result must span BOTH generations (the #2157 early-stop guard,
+//! reused here so a concurrency bug that drops a generation is observable).
+
+#![allow(dead_code)]
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use arrow::array::{Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::flight_service_server::FlightServiceServer;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::transport::server::TcpIncoming;
+use tonic::transport::{Channel, Server};
+
+use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use cqlite_flight::service::CqliteFlightService;
+use cqlite_flight::test_fixtures as fx;
+
+/// A running loopback tonic server plus the address to dial it on. The caller
+/// keeps this alive for the duration of the concurrent workload and `.abort()`s
+/// `server` when done.
+pub struct RunningServer {
+    pub addr: SocketAddr,
+    pub server: tokio::task::JoinHandle<Result<(), tonic::transport::Error>>,
+}
+
+/// Flush `total` rows across TWO separate memtable flushes so the resulting
+/// `data_dir` holds TWO `nb-*-big-Data.db` SSTables the server must k-way-merge.
+/// Keys are interleaved (even indices → flush 1, odd indices → flush 2) so the
+/// sorted first-N result for any `N >= 2` necessarily draws from BOTH
+/// generations. Asserts the fixture really produced ≥2 SSTables.
+pub fn build_multi_sstable_fixture(total: usize) -> (tempfile::TempDir, PathBuf) {
+    assert!(total >= 4, "need enough rows to span two flushes");
+    let schema = fx::keyvalue_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    for i in (0..total).step_by(2) {
+        engine
+            .write(fx::keyvalue_write(&format!("k{i:06}"), &format!("v{i}")))
+            .expect("write");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush 1")
+        .expect("info 1");
+    for i in (1..total).step_by(2) {
+        engine
+            .write(fx::keyvalue_write(&format!("k{i:06}"), &format!("v{i}")))
+            .expect("write");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush 2")
+        .expect("info 2");
+
+    let table_dir = data_dir.join(fx::KEYVALUE_KS).join(fx::KEYVALUE_TBL);
+    let data_files = std::fs::read_dir(&table_dir)
+        .expect("table dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .count();
+    assert!(
+        data_files >= 2,
+        "fixture must span ≥2 SSTables (found {data_files}) so a concurrency bug \
+         that drops a generation is observable",
+    );
+    (temp, data_dir)
+}
+
+/// Stand up ONE real loopback tonic server serving `svc`. All N clients in a
+/// concurrency test dial the SAME returned address, so they share one server
+/// process exactly as the field (a single Flight endpoint under Trino load).
+pub async fn start_server(svc: CqliteFlightService) -> RunningServer {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from_listener(listener, true, None).unwrap();
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(FlightServiceServer::new(svc))
+            .serve_with_incoming(incoming)
+            .await
+    });
+    RunningServer { addr, server }
+}
+
+/// Connect a real Flight client to `addr` over loopback TCP, retrying until the
+/// server accepts.
+pub async fn connect(addr: SocketAddr) -> FlightServiceClient<Channel> {
+    let endpoint = Channel::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect_timeout(Duration::from_secs(5));
+    let mut channel = None;
+    let mut last_err = None;
+    for _ in 0..100 {
+        match endpoint.connect().await {
+            Ok(c) => {
+                channel = Some(c);
+                break;
+            }
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+    }
+    let channel = channel.unwrap_or_else(|| panic!("connect failed: {last_err:?}"));
+    FlightServiceClient::new(channel)
+}
+
+/// A full-scan ticket (no filter, no limit).
+pub fn scan_ticket() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
+    }))
+    .unwrap()
+}
+
+/// A `LIMIT n` ticket over the multi-SSTable fixture.
+pub fn limit_ticket(n: u64) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
+        "limit": n,
+    }))
+    .unwrap()
+}
+
+/// A PK-equality point-read ticket for `key` (the single `text` partition key).
+pub fn point_ticket(key: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
+        "filter": {"type": "Compare", "column": "key", "op": "Equal", "value": key},
+    }))
+    .unwrap()
+}
+
+/// Run `do_get(ticket)` against `client`, fully draining the decoded stream, and
+/// return every `RecordBatch`.
+pub async fn do_get_batches(
+    client: &mut FlightServiceClient<Channel>,
+    ticket: Vec<u8>,
+) -> Vec<RecordBatch> {
+    let resp = client
+        .do_get(Ticket::new(ticket))
+        .await
+        .expect("do_get rpc");
+    let stream = resp.into_inner().map(|r| r.map_err(FlightError::Tonic));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+    let mut batches = Vec::new();
+    while let Some(batch) = rb.next().await {
+        batches.push(batch.expect("decode flight batch over transport"));
+    }
+    batches
+}
+
+/// Collect the string values of `column` across all `batches` (used for
+/// per-shape key-set correctness).
+pub fn column_strings(batches: &[RecordBatch], column: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let idx = batch
+            .schema()
+            .index_of(column)
+            .unwrap_or_else(|_| panic!("column {column} present in output"));
+        let arr = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("text column decodes as StringArray");
+        for i in 0..arr.len() {
+            out.push(arr.value(i).to_string());
+        }
+    }
+    out
+}
+
+/// Parse the numeric index `N` out of a `kNNNNNN` fixture key.
+pub fn key_index(key: &str) -> usize {
+    key.strip_prefix('k')
+        .and_then(|n| n.parse().ok())
+        .unwrap_or_else(|| panic!("fixture key {key:?} must be of the form kNNNNNN"))
+}

--- a/cqlite-flight/tests/concurrent_support/mod.rs
+++ b/cqlite-flight/tests/concurrent_support/mod.rs
@@ -213,3 +213,38 @@ pub fn key_index(key: &str) -> usize {
         .and_then(|n| n.parse().ok())
         .unwrap_or_else(|| panic!("fixture key {key:?} must be of the form kNNNNNN"))
 }
+
+/// Find the real compressed corpus fixture's `nb-*-big-Data.db` binary under
+/// `data_dir/<keyspace>/<table>-<uuid>/`, by GLOB rather than a hardcoded uuid +
+/// generation number: scans `data_dir/<keyspace>` for a `<table>-*` directory
+/// entry, then that directory for an `nb-*-big-Data.db` file. This is what keeps
+/// the real-corpus concurrency arm from silently skipping forever after a
+/// dataset regen changes the table's uuid or generation number (it would
+/// instead just find the regenerated file under the same table-name prefix).
+/// Returns `None` (never panics) when the keyspace dir, table dir, or Data.db
+/// binary is absent — the caller treats that as "fixture not fetched, skip".
+pub fn find_real_compressed_fixture(
+    data_dir: &std::path::Path,
+    keyspace: &str,
+    table: &str,
+) -> Option<PathBuf> {
+    let ks_dir = data_dir.join(keyspace);
+    let table_prefix = format!("{table}-");
+    let table_dir = std::fs::read_dir(&ks_dir)
+        .ok()?
+        .flatten()
+        .find(|e| {
+            e.file_type().is_ok_and(|t| t.is_dir())
+                && e.file_name().to_string_lossy().starts_with(&table_prefix)
+        })?
+        .path();
+    std::fs::read_dir(&table_dir)
+        .ok()?
+        .flatten()
+        .find(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            name.starts_with("nb-") && name.ends_with("-big-Data.db")
+        })
+        .map(|e| e.path())
+}

--- a/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
+++ b/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
@@ -264,11 +264,19 @@ fn concurrent_full_scans_over_real_compressed_corpus() {
 
         // Eight concurrent full scans of the SAME compressed table — they share
         // the server + warm registry, exercising the stitching path under load.
+        // Shared start barrier (roborev job 1656 MEDIUM): every client connects,
+        // THEN rendezvous before issuing its `do_get`, so all 8 genuinely fire
+        // together — no scan can serialize ahead of the others on a fast box and
+        // silently miss the concurrency this arm exists to prove.
+        const CONC: usize = 8;
+        let start = Arc::new(Barrier::new(CONC));
         let mut handles = Vec::new();
-        for _ in 0..8 {
+        for _ in 0..CONC {
             let ticket = ticket.clone();
+            let start = start.clone();
             handles.push(tokio::spawn(async move {
                 let mut client = support::connect(addr).await;
+                start.wait().await;
                 let batches = tokio::time::timeout(
                     STREAM_TIMEOUT,
                     support::do_get_batches(&mut client, ticket),

--- a/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
+++ b/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
@@ -1,0 +1,273 @@
+//! Issue #2370 — N-concurrent `do_get` stress/coverage against ONE server.
+//!
+//! The exact escape class behind #2316 (thread collapse) and #2361 (phase gauge
+//! / stall): every prior `do_get` integration test drives a SINGLE client stream,
+//! so a failure that only manifests under real concurrency (N simultaneous
+//! streams sharing one server + one warm registry + the k-way merge pool) has no
+//! asserting coverage. This suite spawns N≥8 simultaneous `do_get` streams of
+//! MIXED shapes (full scan, PK point-read, LIMIT-k, plus one client that drops
+//! midstream) over the REAL loopback gRPC transport and asserts every stream
+//! completes within a generous hang-detector timeout AND returns the correct
+//! result for its shape.
+//!
+//! The fixture is written by the write engine, so it is UNCOMPRESSED `nb-big` —
+//! the non-stitching read path (issue #2370 arm 4: concurrency × uncompressed).
+//! A second test additionally drives the concurrent workload over a REAL
+//! compressed corpus table (the stitching `V5CompressedLegacy` path) when the
+//! gitignored `Data.db` binaries are present.
+//!
+//! These tests assert per-stream RESULT correctness under a generous timeout;
+//! they deliberately avoid process-global gauge assertions so they stay robust
+//! when the harness runs their sibling `#[test]`s concurrently (plain
+//! `cargo test`). The precise mid-flight gauge read-back lives in its own
+//! isolated binary (`issue_2370_gauge_readback_test`).
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --test issue_2370_concurrent_doget_test
+//! ```
+
+use std::time::Duration;
+
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+
+use cqlite_flight::service::CqliteFlightService;
+
+mod concurrent_support;
+use concurrent_support as support;
+
+/// Generous per-stream hang detector. On a loaded box a real concurrent `do_get`
+/// completes in well under a second; this bound is only a fail-loud ceiling that
+/// turns a #2316/#2361-class hang (a stream that never completes) into a clear
+/// test failure, never a tight wall-clock margin that could flake under load.
+const STREAM_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The shape each concurrent client drives, plus its expected result.
+enum Shape {
+    /// Full scan — must return all `expect_rows` rows.
+    Scan { expect_rows: usize },
+    /// PK point-read for `key` — must return exactly that one partition.
+    Point { key: String },
+    /// `LIMIT n` — must return exactly `n` rows spanning BOTH generations.
+    Limit { n: u64 },
+    /// A client that reads one batch then drops the stream midstream (the Trino
+    /// "stop reading once satisfied" shape). Must not hang; result unchecked.
+    DropMidstream,
+}
+
+/// Drive one `do_get` of `shape` against a fresh client dialed at `addr`, fully
+/// checking the per-shape result. Returns a human label for diagnostics.
+async fn run_shape(addr: std::net::SocketAddr, shape: Shape, total: usize) -> String {
+    let mut client = support::connect(addr).await;
+    match shape {
+        Shape::Scan { expect_rows } => {
+            let batches = support::do_get_batches(&mut client, support::scan_ticket()).await;
+            let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                rows, expect_rows,
+                "concurrent full scan must return all {expect_rows} rows, got {rows}"
+            );
+            let keys = support::column_strings(&batches, "key");
+            let distinct: std::collections::BTreeSet<_> = keys.iter().collect();
+            assert_eq!(
+                distinct.len(),
+                expect_rows,
+                "concurrent full scan must return {expect_rows} distinct partitions"
+            );
+            "scan".into()
+        }
+        Shape::Point { key } => {
+            let batches = support::do_get_batches(&mut client, support::point_ticket(&key)).await;
+            let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                rows, 1,
+                "concurrent point read pk={key} must return exactly its one partition, got {rows}"
+            );
+            let keys = support::column_strings(&batches, "key");
+            assert_eq!(
+                keys,
+                vec![key.clone()],
+                "concurrent point read must return the target partition, not another"
+            );
+            format!("point({key})")
+        }
+        Shape::Limit { n } => {
+            let batches = support::do_get_batches(&mut client, support::limit_ticket(n)).await;
+            let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                rows, n as usize,
+                "concurrent LIMIT {n} over {total} rows must return exactly {n} rows, got {rows}"
+            );
+            // The capped result must genuinely span both interleaved generations.
+            let keys = support::column_strings(&batches, "key");
+            let from_flush1 = keys.iter().any(|k| support::key_index(k) % 2 == 0);
+            let from_flush2 = keys.iter().any(|k| support::key_index(k) % 2 == 1);
+            assert!(
+                from_flush1 && from_flush2,
+                "concurrent LIMIT {n} result must span BOTH SSTables \
+                 (flush1={from_flush1}, flush2={from_flush2}); keys={keys:?}"
+            );
+            format!("limit({n})")
+        }
+        Shape::DropMidstream => {
+            let resp = client
+                .do_get(Ticket::new(support::scan_ticket()))
+                .await
+                .expect("do_get rpc");
+            let stream = resp.into_inner().map(|r| r.map_err(FlightError::Tonic));
+            let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+            // Read exactly one decoded batch, then drop everything without draining.
+            let _ = rb.next().await;
+            drop(rb);
+            drop(client);
+            "drop_midstream".into()
+        }
+    }
+}
+
+/// **N-concurrent mixed-shape do_get over UNCOMPRESSED (non-stitching) path.**
+/// Eight simultaneous `do_get` streams — 3 full scans, 2 PK point-reads, 2
+/// LIMIT-k, and 1 that drops midstream — against ONE server over the real gRPC
+/// transport. Every stream must complete within the generous hang-detector
+/// timeout and return the correct result for its shape. This is the standing net
+/// for the #2316/#2361 concurrency escape class.
+#[test]
+fn eight_concurrent_mixed_shape_do_gets_all_complete_correctly() {
+    let total = 40usize;
+    let (_temp, data_dir) = support::build_multi_sstable_fixture(total);
+    // Small batch size so each scan streams several record batches — real
+    // interleaving/overlap across the concurrent streams, not one-shot replies.
+    let svc = CqliteFlightService::new(data_dir, 4);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        let running = support::start_server(svc).await;
+        let addr = running.addr;
+
+        let shapes = vec![
+            Shape::Scan { expect_rows: total },
+            Shape::Point {
+                key: "k000003".into(),
+            },
+            Shape::Limit { n: 7 },
+            Shape::Scan { expect_rows: total },
+            Shape::Point {
+                key: "k000010".into(),
+            },
+            Shape::Limit { n: 5 },
+            Shape::Scan { expect_rows: total },
+            Shape::DropMidstream,
+        ];
+        let n = shapes.len();
+        assert!(n >= 8, "issue #2370 requires N>=8 concurrent streams, have {n}");
+
+        // Spawn every stream simultaneously; each is bounded by its own hang
+        // detector so a single wedged stream fails loudly (naming its shape)
+        // rather than the whole test timing out anonymously.
+        let mut handles = Vec::new();
+        for shape in shapes {
+            handles.push(tokio::spawn(async move {
+                tokio::time::timeout(STREAM_TIMEOUT, run_shape(addr, shape, total))
+                    .await
+                    .expect("a concurrent do_get stream did not complete within the hang-detector timeout")
+            }));
+        }
+
+        let mut labels = Vec::new();
+        for h in handles {
+            labels.push(h.await.expect("concurrent stream task panicked"));
+        }
+        assert_eq!(labels.len(), n, "every concurrent stream produced a result");
+
+        running.server.abort();
+    });
+}
+
+/// **Concurrency × REAL compressed corpus (stitching path).** The same N
+/// simultaneous full scans, but against a real Cassandra 5.0 compressed `nb-big`
+/// corpus table (`V5CompressedLegacy`) — the concurrency arm of the stitching
+/// read path. Skips cleanly when the gitignored `Data.db` binary is absent (the
+/// repo ships only JSONL references), and asserts `> 0` rows so it can never
+/// 0-row-pass on an unfetched checkout.
+#[test]
+fn concurrent_full_scans_over_real_compressed_corpus() {
+    let Some(root) = std::env::var_os("CQLITE_DATASETS_ROOT") else {
+        eprintln!("CQLITE_DATASETS_ROOT unset — skipping real compressed concurrency repro");
+        return;
+    };
+    let data_dir = std::path::PathBuf::from(&root).join("sstables");
+    let data_db = data_dir
+        .join("test_basic")
+        .join("simple_table-6aa08200a25111f0a3fef1a551383fb9")
+        .join("nb-1-big-Data.db");
+    if !data_db.is_file() {
+        eprintln!("real fixture Data.db binary absent (run fetch-datasets.sh) — skipping");
+        return;
+    }
+    let ddl = "CREATE TABLE test_basic.simple_table (\
+        id uuid PRIMARY KEY, name text, age int, salary bigint, height float, \
+        weight double, active boolean, created timestamp, birth_date date, \
+        work_time time, description blob, account_balance decimal, \
+        session_id timeuuid, ip_address inet, small_number tinyint, \
+        medium_number smallint, duration_val duration, varchar_field varchar, \
+        ascii_field ascii)";
+    let ticket = serde_json::to_vec(&serde_json::json!({
+        "keyspace": "test_basic",
+        "table": "simple_table",
+        "ddl": ddl,
+    }))
+    .unwrap();
+
+    let svc = CqliteFlightService::new(data_dir, 16);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        let running = support::start_server(svc).await;
+        let addr = running.addr;
+
+        // Eight concurrent full scans of the SAME compressed table — they share
+        // the server + warm registry, exercising the stitching path under load.
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let ticket = ticket.clone();
+            handles.push(tokio::spawn(async move {
+                let mut client = support::connect(addr).await;
+                let batches = tokio::time::timeout(
+                    STREAM_TIMEOUT,
+                    support::do_get_batches(&mut client, ticket),
+                )
+                .await
+                .expect("a concurrent compressed-corpus scan did not complete in time");
+                batches.iter().map(|b| b.num_rows()).sum::<usize>()
+            }));
+        }
+
+        let mut first: Option<usize> = None;
+        for h in handles {
+            let rows = h.await.expect("concurrent compressed scan task panicked");
+            assert!(
+                rows > 0,
+                "each concurrent scan of the real compressed corpus must decode > 0 rows"
+            );
+            // Every concurrent scan of the same immutable table must agree.
+            match first {
+                None => first = Some(rows),
+                Some(f) => assert_eq!(
+                    rows, f,
+                    "all concurrent scans of the same table must return the same row count"
+                ),
+            }
+        }
+
+        running.server.abort();
+    });
+}

--- a/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
+++ b/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
@@ -119,6 +119,13 @@ async fn run_shape(
                 "concurrent LIMIT {n} over {total} rows must return exactly {n} rows, got {rows}"
             );
             // The capped result must genuinely span both interleaved generations.
+            // This is deterministic, NOT token-distribution-flaky (roborev job 1658
+            // LOW, declined with evidence): the fixture keys are the fixed set
+            // `k000000..k0000NN`, and Murmur3 tokens are a deterministic function of
+            // the key bytes, so the scan (token) order — and thus which parities
+            // fall in the first `n` rows — is identical on every run and machine.
+            // The assertion is stably green by construction and proves LIMIT push-
+            // down reconciles ACROSS both flushes, not merely within one.
             let keys = support::column_strings(&batches, "key");
             let from_flush1 = keys.iter().any(|k| support::key_index(k) % 2 == 0);
             let from_flush2 = keys.iter().any(|k| support::key_index(k) % 2 == 1);

--- a/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
+++ b/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
@@ -202,11 +202,14 @@ fn concurrent_full_scans_over_real_compressed_corpus() {
         return;
     };
     let data_dir = std::path::PathBuf::from(&root).join("sstables");
-    let data_db = data_dir
-        .join("test_basic")
-        .join("simple_table-6aa08200a25111f0a3fef1a551383fb9")
-        .join("nb-1-big-Data.db");
-    if !data_db.is_file() {
+    // Discover the `simple_table-<uuid>/nb-*-big-Data.db` binary by GLOB rather
+    // than a hardcoded uuid + generation, so a future dataset regen (a new table
+    // uuid or generation number) can never silently skip this arm forever — it
+    // would instead just find the regenerated file under the same table-name
+    // prefix (see `find_real_compressed_fixture`).
+    // The discovered path only proves the binary's presence; the service itself
+    // is pointed at `data_dir` (it re-resolves the table dir from the ticket).
+    if support::find_real_compressed_fixture(&data_dir, "test_basic", "simple_table").is_none() {
         eprintln!("real fixture Data.db binary absent (run fetch-datasets.sh) — skipping");
         return;
     }

--- a/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
+++ b/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
@@ -275,14 +275,21 @@ fn concurrent_full_scans_over_real_compressed_corpus() {
             let ticket = ticket.clone();
             let start = start.clone();
             handles.push(tokio::spawn(async move {
-                let mut client = support::connect(addr).await;
-                start.wait().await;
-                let batches = tokio::time::timeout(
-                    STREAM_TIMEOUT,
-                    support::do_get_batches(&mut client, ticket),
-                )
+                // The ENTIRE task body — connect, barrier rendezvous AND stream —
+                // is bounded by the hang detector (roborev job 1657 MEDIUM): if any
+                // one client wedges before reaching the barrier, the others must
+                // fail loudly here rather than deadlock the whole suite on
+                // `start.wait()`.
+                let batches = tokio::time::timeout(STREAM_TIMEOUT, async move {
+                    let mut client = support::connect(addr).await;
+                    start.wait().await;
+                    support::do_get_batches(&mut client, ticket).await
+                })
                 .await
-                .expect("a concurrent compressed-corpus scan did not complete in time");
+                .expect(
+                    "a concurrent compressed-corpus scan did not complete in time \
+                     (connect / barrier / stream)",
+                );
                 batches.iter().map(|b| b.num_rows()).sum::<usize>()
             }));
         }

--- a/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
+++ b/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
@@ -27,12 +27,14 @@
 //! cargo test -p cqlite-flight --test issue_2370_concurrent_doget_test
 //! ```
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
 use arrow_flight::Ticket;
 use futures::StreamExt;
+use tokio::sync::Barrier;
 
 use cqlite_flight::service::CqliteFlightService;
 
@@ -60,8 +62,23 @@ enum Shape {
 
 /// Drive one `do_get` of `shape` against a fresh client dialed at `addr`, fully
 /// checking the per-shape result. Returns a human label for diagnostics.
-async fn run_shape(addr: std::net::SocketAddr, shape: Shape, total: usize) -> String {
+///
+/// `start` is a shared start barrier (roborev job 1655 LOW): every caller
+/// connects FIRST, then rendezvous on `start` before issuing its `do_get`, so
+/// all N clients genuinely fire their RPC together — no client can finish (or
+/// even begin) before every other client has connected and is ready to go. This
+/// strengthens the overlap guarantee the test exists to prove; without it, a
+/// fast-connecting client could complete its whole `do_get` before a
+/// slower-connecting sibling even issues its RPC, undermining the "N truly
+/// concurrent" claim.
+async fn run_shape(
+    addr: std::net::SocketAddr,
+    shape: Shape,
+    total: usize,
+    start: Arc<Barrier>,
+) -> String {
     let mut client = support::connect(addr).await;
+    start.wait().await;
     match shape {
         Shape::Scan { expect_rows } => {
             let batches = support::do_get_batches(&mut client, support::scan_ticket()).await;
@@ -167,13 +184,21 @@ fn eight_concurrent_mixed_shape_do_gets_all_complete_correctly() {
         let n = shapes.len();
         assert!(n >= 8, "issue #2370 requires N>=8 concurrent streams, have {n}");
 
+        // Shared start barrier (roborev job 1655 LOW): every client connects, THEN
+        // rendezvous here before issuing its `do_get`, so all N genuinely fire
+        // together — no client can finish (or even start streaming) before every
+        // other client is connected and ready, strengthening the overlap this
+        // suite exists to prove.
+        let start = Arc::new(Barrier::new(n));
+
         // Spawn every stream simultaneously; each is bounded by its own hang
         // detector so a single wedged stream fails loudly (naming its shape)
         // rather than the whole test timing out anonymously.
         let mut handles = Vec::new();
         for shape in shapes {
+            let start = start.clone();
             handles.push(tokio::spawn(async move {
-                tokio::time::timeout(STREAM_TIMEOUT, run_shape(addr, shape, total))
+                tokio::time::timeout(STREAM_TIMEOUT, run_shape(addr, shape, total, start))
                     .await
                     .expect("a concurrent do_get stream did not complete within the hang-detector timeout")
             }));

--- a/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
+++ b/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
@@ -114,10 +114,34 @@ fn phase_active_and_in_flight_read_true_concurrent_count_then_settle() {
                     first.is_some(),
                     "each held stream must yield at least one batch before parking"
                 );
-                // Signal "I am in flight and holding", then wait for release while
-                // keeping the stream (and thus the RPC accounting) alive.
-                barrier.wait().await;
-                release.notified().await;
+                // Register for release BEFORE crossing the barrier (roborev job
+                // 1655 MEDIUM): `Notify::notify_waiters()` only wakes waiters that
+                // were already `enable()`d/polled AT THE TIME it is called — a
+                // holder that calls `release.notified().await` for the first time
+                // AFTER main has already called `notify_waiters()` would miss the
+                // wake and block forever. `enable()`ing here, before this holder
+                // crosses the barrier, makes registration happen-before this
+                // holder's OWN barrier-wait return, which happens-before ALL other
+                // parties' (including main's) barrier-wait return, which
+                // happens-before main's `notify_waiters()` call below — so the
+                // release can never be missed regardless of scheduling.
+                let released = release.notified();
+                tokio::pin!(released);
+                released.as_mut().enable();
+                // Signal "I am in flight and holding", then wait (BOUNDED — a
+                // panicked sibling holder can never let this hang the whole
+                // process; timeouts are a fail-loud bound, not the sync
+                // mechanism) for release while keeping the stream (and thus the
+                // RPC accounting) alive.
+                tokio::time::timeout(GAUGE_TIMEOUT, barrier.wait())
+                    .await
+                    .expect(
+                        "holder timed out at the in-flight barrier (issue #2370 roborev 1655) \
+                         — a sibling holder likely panicked before reaching it",
+                    );
+                tokio::time::timeout(GAUGE_TIMEOUT, released)
+                    .await
+                    .expect("holder timed out waiting for release (issue #2370 roborev 1655)");
                 // Release: drop the stream + client WITHOUT draining (a midstream
                 // drop under backpressure — the #2264 shape).
                 drop(rb);
@@ -126,7 +150,12 @@ fn phase_active_and_in_flight_read_true_concurrent_count_then_settle() {
         }
 
         // All N have read a batch and are holding → every stream is in flight.
-        barrier.wait().await;
+        tokio::time::timeout(GAUGE_TIMEOUT, barrier.wait())
+            .await
+            .expect(
+                "main timed out at the in-flight barrier (issue #2370 roborev 1655) — a holder \
+                 likely panicked before reaching it",
+            );
 
         // THE read-back: both gauges must reflect the true concurrent count N.
         let if_level = poll_until_at_least(baseline_if + N as i64, GAUGE_TIMEOUT, || {

--- a/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
+++ b/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
@@ -224,6 +224,18 @@ fn phase_active_and_in_flight_read_true_concurrent_count_then_settle() {
             after_complete <= baseline_if,
             "in_flight must settle to its {baseline_if} baseline after N streams COMPLETE, got {after_complete}"
         );
+        // phase.active must ALSO settle after normal completion (roborev job 1656
+        // LOW): a regression that leaks the new phase-active gauge on the normal
+        // completion path — not just the midstream-drop path checked in Phase 1 —
+        // would otherwise go uncaught.
+        let after_complete_pa = poll_until_at_most(baseline_pa, GAUGE_TIMEOUT, || {
+            cqlite_flight::obs::phase_active_level("do_get")
+        })
+        .await;
+        assert!(
+            after_complete_pa <= baseline_pa,
+            "phase.active must settle to its {baseline_pa} baseline after N streams COMPLETE, got {after_complete_pa}"
+        );
 
         running.server.abort();
     });

--- a/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
+++ b/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
@@ -1,0 +1,201 @@
+//! Issue #2370 — mid-flight read-back of the #2361 concurrency gauges through
+//! the REAL `do_get` handler path (the first such validation).
+//!
+//! The `cqlite.rpc.phase.active` gauge (#2361) and `cqlite.rpc.in_flight` gauge
+//! (#2264) were only ever validated by SYNCHRONOUS unit arithmetic (two guards on
+//! one thread) or single-stream settle checks — never read back while N real
+//! `do_get` RPCs overlap in flight. This test holds N streams provably open (a
+//! barrier + slow consumer under channel backpressure) and asserts BOTH gauges
+//! read the TRUE concurrent count == N mid-flight, then settle to baseline after
+//! the streams are released (a midstream drop) AND after N streams complete
+//! normally.
+//!
+//! ## Isolation requirement
+//!
+//! The gauges are PROCESS-GLOBAL atomics. An exact `== N` read-back is only
+//! meaningful if no sibling test has a `do_get` in flight concurrently, so this
+//! file holds EXACTLY ONE `#[test]` — one file = one binary = one process, with
+//! no sibling threads under plain `cargo test`, and per-test process isolation
+//! under nextest (the gate default). Do not add a second `#[test]` here; add a
+//! sibling FILE instead.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --test issue_2370_gauge_readback_test
+//! ```
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tokio::sync::{Barrier, Notify};
+
+use cqlite_flight::service::CqliteFlightService;
+
+mod concurrent_support;
+use concurrent_support as support;
+
+/// Number of simultaneous streams held open. Field runs use 8.
+const N: usize = 8;
+
+/// Generous fail-loud ceiling for a gauge to reach its expected level or settle.
+/// The gauge moves the instant the handler runs; this is a hang detector, never a
+/// tight wall-clock margin.
+const GAUGE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Poll `read()` until it returns `>= target` or the timeout elapses; returns the
+/// final observed value.
+async fn poll_until_at_least(target: i64, timeout: Duration, read: impl Fn() -> i64) -> i64 {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let v = read();
+        if v >= target || Instant::now() >= deadline {
+            return v;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Poll `read()` until it returns `<= target` or the timeout elapses; returns the
+/// final observed value.
+async fn poll_until_at_most(target: i64, timeout: Duration, read: impl Fn() -> i64) -> i64 {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let v = read();
+        if v <= target || Instant::now() >= deadline {
+            return v;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[test]
+fn phase_active_and_in_flight_read_true_concurrent_count_then_settle() {
+    // Big multi-SSTable fixture + batch_size 1 so each producer fills the 4-slot
+    // do_get channel and PARKS while its slow consumer holds — keeping the RPC in
+    // flight without draining.
+    let total = 200usize;
+    let (_temp, data_dir) = support::build_multi_sstable_fixture(total);
+    let svc = CqliteFlightService::new(data_dir, 1);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        let baseline_if = cqlite_flight::obs::in_flight_level("do_get");
+        let baseline_pa = cqlite_flight::obs::phase_active_level("do_get");
+        // In an isolated binary the baseline is 0, but read it explicitly so the
+        // assertions are baseline-relative and never assume a clean slate.
+        let running = support::start_server(svc).await;
+        let addr = running.addr;
+
+        // ---- Phase 1: hold N streams open, read the gauges mid-flight ----------
+        let barrier = Arc::new(Barrier::new(N + 1));
+        let release = Arc::new(Notify::new());
+        let mut holders = Vec::new();
+        for _ in 0..N {
+            let barrier = barrier.clone();
+            let release = release.clone();
+            holders.push(tokio::spawn(async move {
+                let mut client = support::connect(addr).await;
+                let resp = client
+                    .do_get(Ticket::new(support::scan_ticket()))
+                    .await
+                    .expect("do_get rpc");
+                let stream = resp.into_inner().map(|r| r.map_err(FlightError::Tonic));
+                let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+                // Read ONE batch so the RPC is provably in flight and streaming.
+                let first = rb.next().await;
+                assert!(
+                    first.is_some(),
+                    "each held stream must yield at least one batch before parking"
+                );
+                // Signal "I am in flight and holding", then wait for release while
+                // keeping the stream (and thus the RPC accounting) alive.
+                barrier.wait().await;
+                release.notified().await;
+                // Release: drop the stream + client WITHOUT draining (a midstream
+                // drop under backpressure — the #2264 shape).
+                drop(rb);
+                drop(client);
+            }));
+        }
+
+        // All N have read a batch and are holding → every stream is in flight.
+        barrier.wait().await;
+
+        // THE read-back: both gauges must reflect the true concurrent count N.
+        let if_level = poll_until_at_least(baseline_if + N as i64, GAUGE_TIMEOUT, || {
+            cqlite_flight::obs::in_flight_level("do_get")
+        })
+        .await;
+        assert_eq!(
+            if_level,
+            baseline_if + N as i64,
+            "cqlite.rpc.in_flight{{do_get}} must read the true {N} concurrent streams mid-flight"
+        );
+        let pa_level = poll_until_at_least(baseline_pa + N as i64, GAUGE_TIMEOUT, || {
+            cqlite_flight::obs::phase_active_level("do_get")
+        })
+        .await;
+        assert_eq!(
+            pa_level,
+            baseline_pa + N as i64,
+            "cqlite.rpc.phase.active{{do_get}} must read the true {N} concurrent streams mid-flight \
+             (the #2361 gauge as a LEVEL, not a 0/1 flag) — first real-handler validation"
+        );
+
+        // Release all holders → they drop their streams midstream.
+        release.notify_waiters();
+        for h in holders {
+            h.await.expect("holder task panicked");
+        }
+
+        // Settle after the midstream drop: both gauges return to baseline. On the
+        // pre-#2264 code the parked producers never release and this never settles.
+        let settled_if = poll_until_at_most(baseline_if, GAUGE_TIMEOUT, || {
+            cqlite_flight::obs::in_flight_level("do_get")
+        })
+        .await;
+        assert!(
+            settled_if <= baseline_if,
+            "in_flight must settle to its {baseline_if} baseline after the midstream drop, got {settled_if}"
+        );
+        let settled_pa = poll_until_at_most(baseline_pa, GAUGE_TIMEOUT, || {
+            cqlite_flight::obs::phase_active_level("do_get")
+        })
+        .await;
+        assert!(
+            settled_pa <= baseline_pa,
+            "phase.active must settle to its {baseline_pa} baseline after the midstream drop, got {settled_pa}"
+        );
+
+        // ---- Phase 2: N streams that COMPLETE normally also settle to baseline --
+        let mut drains = Vec::new();
+        for _ in 0..N {
+            drains.push(tokio::spawn(async move {
+                let mut client = support::connect(addr).await;
+                let batches = support::do_get_batches(&mut client, support::scan_ticket()).await;
+                batches.iter().map(|b| b.num_rows()).sum::<usize>()
+            }));
+        }
+        for h in drains {
+            let rows = h.await.expect("drain task panicked");
+            assert_eq!(rows, total, "each fully-drained concurrent scan returns all rows");
+        }
+        let after_complete = poll_until_at_most(baseline_if, GAUGE_TIMEOUT, || {
+            cqlite_flight::obs::in_flight_level("do_get")
+        })
+        .await;
+        assert!(
+            after_complete <= baseline_if,
+            "in_flight must settle to its {baseline_if} baseline after N streams COMPLETE, got {after_complete}"
+        );
+
+        running.server.abort();
+    });
+}

--- a/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
+++ b/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
@@ -158,6 +158,18 @@ fn phase_active_and_in_flight_read_true_concurrent_count_then_settle() {
             );
 
         // THE read-back: both gauges must reflect the true concurrent count N.
+        //
+        // Exact `== baseline + N` is sound, NOT flaky (roborev job 1658 MEDIUM,
+        // declined with evidence). `PhaseTimer::transition` briefly dec-old-then-
+        // inc-new, so the phase.active SUM can transiently dip during a phase
+        // change — but that window exists ONLY across resolve→merge_setup→stream.
+        // Every holder above read a batch (proving it reached the TERMINAL `stream`
+        // phase — `stream` has no successor, so `transition` is never called again)
+        // and then PARKS: with batch_size 1 + the 4-slot bounded channel, each
+        // producer fills the channel and backpressures mid-`stream`, keeping its
+        // PhaseTimer alive at +1 without completing. The barrier confirms ALL N are
+        // in this steady terminal state before we sample, so no transition is in
+        // flight at the sample instant → the sum is stably N (no dip, no spike).
         let if_level = poll_until_at_least(baseline_if + N as i64, GAUGE_TIMEOUT, || {
             cqlite_flight::obs::in_flight_level("do_get")
         })

--- a/cqlite-flight/tests/issue_2370_single_flight_test.rs
+++ b/cqlite-flight/tests/issue_2370_single_flight_test.rs
@@ -107,6 +107,16 @@ fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
     let total = 40usize;
     let (_temp, data_dir) = support::build_multi_sstable_fixture(total);
     let generations = generation_count(&data_dir);
+    // `>= 2` (not `== 2`) is DELIBERATE (roborev job 1657 LOW, declined with
+    // evidence): the parse bound below is generation-RELATIVE
+    // (`PER_OPEN_PARSES × generations`), and the single-flight property under test
+    // is N-independence — the fail signal is `generations × N`, which stays far
+    // above the bound for any N>2 REGARDLESS of the exact generation count. An
+    // extra generation widens the per-generation-constant bound proportionally but
+    // never weakens the N-scaling rejection, so pinning the count exactly would
+    // only couple this test to `build_multi_sstable_fixture`'s internals for no
+    // gain in discrimination. The `>= 2` floor is the meaningful precondition
+    // (≥2 generations is what makes cold-open coalescing observable at all).
     assert!(
         generations >= 2,
         "fixture must hold ≥2 generations to make single-flight meaningful, got {generations}"

--- a/cqlite-flight/tests/issue_2370_single_flight_test.rs
+++ b/cqlite-flight/tests/issue_2370_single_flight_test.rs
@@ -1,0 +1,165 @@
+//! Issue #2370 — N concurrent COLD `do_get`s must NOT amplify Index.db parses
+//! with N (the #2383 single-flight pin extended through the rpc layer under
+//! concurrency).
+//!
+//! The #2383 resolve-phase spin (a `do_get` re-parsing the same generation's full
+//! `Index.db` repeatedly) was pinned SEQUENTIALLY. The field trigger is N
+//! CONCURRENT queries against one server: if the warm registry's single-flight
+//! open fails to coalesce concurrent cold opens, each racing request re-parses
+//! every generation, so `index_parses_total` climbs toward `#generations × N` (the
+//! 8× amplifier the field saw). This test fires N concurrent cold `do_get`s at ONE
+//! service over the SAME table and reads back the authoritative
+//! `cqlite.sstable.index_parses_total` counter, pinning that the total is bounded
+//! by a small per-generation CONSTANT — INDEPENDENT of N — proving the concurrent
+//! opens single-flighted.
+//!
+//! ## Why the bound is `PER_OPEN_PARSES × #generations`, not `#generations`
+//!
+//! The issue's ideal is `index_parses_total == #generations` (each generation's
+//! Index.db parsed once per query — the counter's documented contract in
+//! `catalog::INDEX_PARSES_TOTAL`). On current main it is `2 × #generations`:
+//! `SSTableReader::open` parses the full `Index.db` TWICE per reader open —
+//! `reader/mod.rs` calls BOTH `load_index` (→ legacy `SSTableIndex`) and
+//! `load_index_reader` (→ spec `IndexReader`), each running the O(entries)
+//! `parse_all_partition_keys_*` loop `index_parses_total` counts. That per-OPEN
+//! double-parse is a SEPARATE redundancy (a real finding reported with this suite,
+//! independent of concurrency and of the warm registry) — the single-flight this
+//! test pins is that the total does NOT scale with N. `PER_OPEN_PARSES` documents
+//! the current per-open multiplicity; tighten it to `1` when the reader-open
+//! double-parse is fixed (this test stays green through that fix — the bound only
+//! rejects a per-REQUEST, N-scaling amplification, never a smaller constant).
+//!
+//! ## Separate integration-test process
+//!
+//! The OTel capture harness installs a PROCESS-GLOBAL meter provider, so this file
+//! holds exactly one `#[test]` in its own binary (matching the #2383/#2163
+//! precedent) and never shares cqlite-flight's parallel `--lib` unit-test binary.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --features observability-testing \
+//!   --test issue_2370_single_flight_test
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_flight::service::CqliteFlightService;
+use cqlite_flight::test_fixtures as fx;
+
+mod concurrent_support;
+use concurrent_support as support;
+
+/// Number of simultaneous cold requests. Field runs use 8.
+const N: usize = 8;
+
+/// Current number of full `Index.db` parses `SSTableReader::open` performs PER
+/// reader open (see the module doc: `load_index` + `load_index_reader`). The
+/// ideal is 1; `2` documents the reported per-open double-parse finding. The pin
+/// below is that the TOTAL is `PER_OPEN_PARSES × #generations` — a per-generation
+/// constant that does NOT grow with N. Reduce to 1 when the double-parse is fixed.
+const PER_OPEN_PARSES: f64 = 2.0;
+
+/// Count the `nb-*-big-Data.db` generations under the fixture's table dir.
+fn generation_count(data_dir: &std::path::Path) -> usize {
+    let table_dir = data_dir.join(fx::KEYVALUE_KS).join(fx::KEYVALUE_TBL);
+    std::fs::read_dir(&table_dir)
+        .expect("table dir")
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .count()
+}
+
+/// Drive one in-process `do_get` and fully drain its stream so every parse fires.
+async fn do_get_drain(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
+    let resp = svc
+        .do_get(Request::new(Ticket::new(ticket)))
+        .await
+        .expect("do_get");
+    let mut stream = resp.into_inner();
+    let mut msgs = 0usize;
+    while let Some(item) = stream.next().await {
+        item.expect("stream item ok");
+        msgs += 1;
+    }
+    msgs
+}
+
+#[test]
+fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
+    // Install the process-global in-memory meter BEFORE any parse in this process.
+    let mc = testing::metrics_capture();
+
+    let total = 40usize;
+    let (_temp, data_dir) = support::build_multi_sstable_fixture(total);
+    let generations = generation_count(&data_dir);
+    assert!(
+        generations >= 2,
+        "fixture must hold ≥2 generations to make single-flight meaningful, got {generations}"
+    );
+
+    let svc = CqliteFlightService::new(data_dir, 8192);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    mc.reset();
+    rt.block_on(async {
+        // Fire N COLD do_gets concurrently at the SAME (cold) service. Cloning the
+        // service shares the same warm registry via its `Arc`, so a working
+        // single-flight coalesces the concurrent opens per generation.
+        let mut handles = Vec::new();
+        for _ in 0..N {
+            let svc = svc.clone();
+            handles.push(tokio::spawn(async move {
+                do_get_drain(&svc, support::scan_ticket()).await
+            }));
+        }
+        for h in handles {
+            let msgs = h.await.expect("concurrent do_get task panicked");
+            assert!(
+                msgs > 0,
+                "each concurrent cold do_get must stream at least a schema message"
+            );
+        }
+    });
+
+    let parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+
+    // Lower bound: a cold read really parses every generation at least once (never
+    // a 0-parse skip that would mean a generation went unread).
+    assert!(
+        parses >= generations as f64,
+        "N={N} concurrent COLD do_gets over {generations} generations must parse each generation's \
+         Index.db at least once (cold real work), got {parses}"
+    );
+
+    // THE single-flight pin: the total is a small per-generation CONSTANT,
+    // INDEPENDENT of N. A single-flight failure (the #2383 ×N amplifier through the
+    // rpc layer) makes each of the N requests re-parse every generation, so the
+    // total climbs toward `#generations × N` (here up to 16–32) — far past this
+    // bound. `PER_OPEN_PARSES` (currently 2, the reported reader-open double-parse
+    // finding) is a per-generation constant; the bound rejects only a per-REQUEST,
+    // N-scaling amplification, and stays green if the double-parse is fixed to 1.
+    let bound = PER_OPEN_PARSES * generations as f64;
+    assert!(
+        parses <= bound,
+        "N={N} concurrent COLD do_gets over {generations} generations must NOT amplify Index.db \
+         parses with N: expected ≤ {bound} (= {PER_OPEN_PARSES} × {generations}, a per-generation \
+         constant), got {parses}. A value scaling toward {} means the concurrent opens did not \
+         single-flight (the #2383 amplifier through the rpc layer).",
+        generations * N
+    );
+}

--- a/cqlite-flight/tests/issue_2370_single_flight_test.rs
+++ b/cqlite-flight/tests/issue_2370_single_flight_test.rs
@@ -46,11 +46,7 @@
 
 use std::sync::Arc;
 
-use arrow_flight::flight_service_server::FlightService;
-use arrow_flight::Ticket;
-use futures::StreamExt;
 use tokio::sync::Barrier;
-use tonic::Request;
 
 use cqlite_core::observability::{catalog, testing};
 use cqlite_flight::service::CqliteFlightService;
@@ -84,21 +80,6 @@ fn generation_count(data_dir: &std::path::Path) -> usize {
         .count()
 }
 
-/// Drive one in-process `do_get` and fully drain its stream so every parse fires.
-async fn do_get_drain(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
-    let resp = svc
-        .do_get(Request::new(Ticket::new(ticket)))
-        .await
-        .expect("do_get");
-    let mut stream = resp.into_inner();
-    let mut msgs = 0usize;
-    while let Some(item) = stream.next().await {
-        item.expect("stream item ok");
-        msgs += 1;
-    }
-    msgs
-}
-
 #[test]
 fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
     // Install the process-global in-memory meter BEFORE any parse in this process.
@@ -128,39 +109,57 @@ fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
         .build()
         .unwrap();
 
-    mc.reset();
-    rt.block_on(async {
-        // Fire N COLD do_gets concurrently at the SAME (cold) service. Cloning the
-        // service shares the same warm registry via its `Arc`, so a working
-        // single-flight coalesces the concurrent opens per generation.
-        //
+    let parses = rt.block_on(async move {
+        // Serve the ONE cold service over real loopback gRPC (roborev job 1659
+        // MEDIUM): all N concurrent cold requests traverse the actual tonic
+        // transport + server-side handler before we sample the parse counter, so
+        // the single-flight coalescing is proven through the REAL rpc path (a
+        // per-connection registry regression would amplify here but be invisible to
+        // a direct in-process `svc.do_get()` that hand-shares one `Arc`). The one
+        // `FlightServiceServer` instance shares its reader registry across every
+        // connection, exactly as production does.
+        let running = support::start_server(svc).await;
+        let addr = running.addr;
+
+        // Reset AFTER the server binds but BEFORE any request: `start_server` opens
+        // no readers (they open lazily on first `do_get`) and `connect` performs no
+        // parse, so only the cold-open parses from the N concurrent do_gets below
+        // are counted. metrics_capture is process-global, so the server-side parses
+        // (same process, spawned task) are captured.
+        mc.reset();
+
         // Shared start barrier (roborev job 1656 MEDIUM): without a rendezvous the
         // first request can warm the registry before the rest overlap, so a broken
-        // (un-coalesced) implementation could still pass. Every task blocks here
-        // until all N are spawned, then they issue their cold `do_get` together —
-        // making the concurrent cold-open coalescing this test asserts genuine.
+        // (un-coalesced) implementation could still pass. Every client connects,
+        // then blocks here until all N are ready, then they issue their cold
+        // `do_get` together — making the concurrent cold-open coalescing genuine.
         let start = Arc::new(Barrier::new(N));
         let mut handles = Vec::new();
         for _ in 0..N {
-            let svc = svc.clone();
             let start = start.clone();
             handles.push(tokio::spawn(async move {
+                let mut client = support::connect(addr).await;
                 start.wait().await;
-                do_get_drain(&svc, support::scan_ticket()).await
+                let batches = support::do_get_batches(&mut client, support::scan_ticket()).await;
+                batches.iter().map(|b| b.num_rows()).sum::<usize>()
             }));
         }
         for h in handles {
-            let msgs = h.await.expect("concurrent do_get task panicked");
+            let rows = h.await.expect("concurrent do_get task panicked");
             assert!(
-                msgs > 0,
-                "each concurrent cold do_get must stream at least a schema message"
+                rows > 0,
+                "each concurrent cold do_get must stream its rows over transport"
             );
         }
-    });
 
-    let parses = mc
-        .flush_and_collect()
-        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+        running.server.abort();
+
+        // Sample the parse counter INSIDE the block (metrics_capture is moved in so
+        // the moved-in `svc` and the meter share one process): the total cold-open
+        // parses across all N concurrent requests over real transport.
+        mc.flush_and_collect()
+            .counter_sum(catalog::INDEX_PARSES_TOTAL)
+    });
 
     // Lower bound: a cold read really parses every generation at least once (never
     // a 0-parse skip that would mean a generation went unread).

--- a/cqlite-flight/tests/issue_2370_single_flight_test.rs
+++ b/cqlite-flight/tests/issue_2370_single_flight_test.rs
@@ -44,9 +44,12 @@
 
 #![cfg(feature = "observability-testing")]
 
+use std::sync::Arc;
+
 use arrow_flight::flight_service_server::FlightService;
 use arrow_flight::Ticket;
 use futures::StreamExt;
+use tokio::sync::Barrier;
 use tonic::Request;
 
 use cqlite_core::observability::{catalog, testing};
@@ -120,10 +123,19 @@ fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
         // Fire N COLD do_gets concurrently at the SAME (cold) service. Cloning the
         // service shares the same warm registry via its `Arc`, so a working
         // single-flight coalesces the concurrent opens per generation.
+        //
+        // Shared start barrier (roborev job 1656 MEDIUM): without a rendezvous the
+        // first request can warm the registry before the rest overlap, so a broken
+        // (un-coalesced) implementation could still pass. Every task blocks here
+        // until all N are spawned, then they issue their cold `do_get` together —
+        // making the concurrent cold-open coalescing this test asserts genuine.
+        let start = Arc::new(Barrier::new(N));
         let mut handles = Vec::new();
         for _ in 0..N {
             let svc = svc.clone();
+            let start = start.clone();
             handles.push(tokio::spawn(async move {
+                start.wait().await;
                 do_get_drain(&svc, support::scan_ticket()).await
             }));
         }

--- a/cqlite-flight/tests/issue_2370_single_flight_test.rs
+++ b/cqlite-flight/tests/issue_2370_single_flight_test.rs
@@ -22,12 +22,13 @@
 //! `reader/mod.rs` calls BOTH `load_index` (→ legacy `SSTableIndex`) and
 //! `load_index_reader` (→ spec `IndexReader`), each running the O(entries)
 //! `parse_all_partition_keys_*` loop `index_parses_total` counts. That per-OPEN
-//! double-parse is a SEPARATE redundancy (a real finding reported with this suite,
-//! independent of concurrency and of the warm registry) — the single-flight this
-//! test pins is that the total does NOT scale with N. `PER_OPEN_PARSES` documents
-//! the current per-open multiplicity; tighten it to `1` when the reader-open
-//! double-parse is fixed (this test stays green through that fix — the bound only
-//! rejects a per-REQUEST, N-scaling amplification, never a smaller constant).
+//! double-parse is a SEPARATE redundancy (reported with this suite as issue
+//! **#2395** — the reader-open double-parse — independent of concurrency and of
+//! the warm registry) — the single-flight this test pins is that the total does
+//! NOT scale with N. `PER_OPEN_PARSES` documents the current per-open
+//! multiplicity; tighten it to `1` when #2395 is fixed (this test stays green
+//! through that fix — the bound only rejects a per-REQUEST, N-scaling
+//! amplification, never a smaller constant).
 //!
 //! ## Separate integration-test process
 //!
@@ -60,9 +61,10 @@ const N: usize = 8;
 
 /// Current number of full `Index.db` parses `SSTableReader::open` performs PER
 /// reader open (see the module doc: `load_index` + `load_index_reader`). The
-/// ideal is 1; `2` documents the reported per-open double-parse finding. The pin
-/// below is that the TOTAL is `PER_OPEN_PARSES × #generations` — a per-generation
-/// constant that does NOT grow with N. Reduce to 1 when the double-parse is fixed.
+/// ideal is 1; `2` documents issue **#2395** (the reader-open double-parse). The
+/// pin below is that the TOTAL is `PER_OPEN_PARSES × #generations` — a
+/// per-generation constant that does NOT grow with N. Reduce to 1 when #2395 is
+/// fixed.
 const PER_OPEN_PARSES: f64 = 2.0;
 
 /// Count the `nb-*-big-Data.db` generations under the fixture's table dir.


### PR DESCRIPTION
## Context

Closes the confirmed concurrency hole from the **#2363 coverage-matrix audit** (Concurrency axis, holes CONC-1..4, QS-3). No test in the repo previously issued ≥2 concurrent do_gets against one server with assertions able to observe a concurrency failure — real N-concurrency existed only in the non-asserting field tool (`trino-loadtest/driver.py`). **Both** recent field-only escapes (#2316 merge-thread collapse, #2361 gauge/stall) were concurrency-only, i.e. they slipped through single-stream coverage. This suite validates that the #2383 resolve-phase fix holds under 8-way concurrency.

## What lands (all test-only + one behavior-neutral obs seam)

Four test binaries + a shared harness in `cqlite-flight/tests/`:

- **`issue_2370_concurrent_doget_test.rs`** — N≥8 simultaneous do_get streams over real transport (mix: full scan, point, LIMIT-k, one midstream drop) with a hang detector. Includes a **compressed-corpus variant** (glob-discovered, SKIP-aware / non-vacuous) and an uncompressed (non-stitching) scan-path pin.
- **`issue_2370_gauge_readback_test.rs`** — first-ever real-handler-path read-back of the #2361 gauge: `cqlite.rpc.in_flight` AND `cqlite.rpc.phase.active` both read `==N` mid-flight and settle to baseline after drop/completion.
- **`issue_2370_concurrent_merge_thread_budget.rs`** — process thread count bounded while ≥2 merges are simultaneously live (own binary; extends the #2316 single-merge budget to the aggregate case, #2316 pattern).
- **`issue_2370_single_flight_test.rs`** — rpc-level single-flight pin on `index_parses_total`; `PER_OPEN_PARSES=2` documents filed finding **#2395** (reader-open double-parse, P1 — NOT fixed here, out of scope).
- **`concurrent_support/mod.rs`** — shared concurrency harness.
- **`cqlite-flight/src/obs.rs`** — adds `phase_active_level(method)`, a read-only level accessor (the #2361 gauge summed across phases). Behavior-neutral seam; `parse.rs` diff confirmed empty by lead; `obs.rs` sits at the campsite ceiling (#1116) so no further growth introduced beyond this reader.

## Product finding

**#2395** (reader-open double-parse, P1) filed — the `PER_OPEN_PARSES=2` pin in the single-flight test documents it. Out of scope for this coverage suite.

## Review

- rust-reviewer: APPROVE, no blockers (src touches are behavior-neutral seams).
- roborev 1655: Medium (level-triggered release) + Low (start barrier) both FIXED and adjudicated.

Closes #2370