### PR TITLE
fix(#2385/#2395): retire redundant SSTableIndex from BIG open — parse-once, kill O(N²) cold-start

### DIFF
--- a/cqlite-core/src/storage/sstable/index.rs
+++ b/cqlite-core/src/storage/sstable/index.rs
@@ -52,12 +52,52 @@ impl Index {
         }
     }
 
-    /// Create index from a vector of entries
+    /// Create index from a vector of entries.
+    ///
+    /// Issue #2385: builds the per-table `sorted_keys` by collecting each table's
+    /// unique keys and sorting ONCE (O(N log N) total) rather than the per-entry
+    /// `binary_search` + `Vec::insert` of [`Self::add_entry`], which is O(N²) when
+    /// keys do not arrive in ascending byte order (real `Index.db` arrives in token
+    /// order, but `RowKey` sorts by raw bytes, so every insert lands mid-vector).
+    /// The result is byte-for-byte identical to feeding the same entries through
+    /// `add_entry` one at a time: last write wins per `(table_id, key)`, duplicate
+    /// keys collapse in `sorted_keys`, and `total_entries` counts input entries.
     pub fn from_entries(entries: Vec<IndexEntry>) -> Self {
         let mut index = Self::new();
+        // `total_entries` matches `add_entry`'s call-count semantics (incremented
+        // unconditionally, including for a duplicate key).
+        index.total_entries = entries.len();
 
         for entry in entries {
-            index.add_entry(entry);
+            let table_id = entry.table_id.clone();
+
+            // Reverse index: unqualified name -> qualified TableId (dedup).
+            let table_name = table_id.name();
+            let unqualified = if let Some(dot_pos) = table_name.rfind('.') {
+                table_name[dot_pos + 1..].to_string()
+            } else {
+                table_name.to_string()
+            };
+            let qualified_list = index.unqualified_to_qualified.entry(unqualified).or_default();
+            if !qualified_list.contains(&table_id) {
+                qualified_list.push(table_id.clone());
+            }
+
+            // Entries map: last write wins per key (matches add_entry).
+            index
+                .entries
+                .entry(table_id)
+                .or_default()
+                .insert(entry.key.clone(), entry);
+        }
+
+        // Sort each table's keys ONCE. The keys come from the entries map, so they
+        // are already unique (duplicates collapsed) — sorting yields the same
+        // ascending byte order add_entry maintained incrementally.
+        for (table_id, table_entries) in &index.entries {
+            let mut keys: Vec<RowKey> = table_entries.keys().cloned().collect();
+            keys.sort();
+            index.sorted_keys.insert(table_id.clone(), keys);
         }
 
         index

--- a/cqlite-core/src/storage/sstable/index.rs
+++ b/cqlite-core/src/storage/sstable/index.rs
@@ -78,7 +78,10 @@ impl Index {
             } else {
                 table_name.to_string()
             };
-            let qualified_list = index.unqualified_to_qualified.entry(unqualified).or_default();
+            let qualified_list = index
+                .unqualified_to_qualified
+                .entry(unqualified)
+                .or_default();
             if !qualified_list.contains(&table_id) {
                 qualified_list.push(table_id.clone());
             }

--- a/cqlite-core/src/storage/sstable/index_reader/parse.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/parse.rs
@@ -70,8 +70,10 @@ pub(super) fn parse_index_data_cancellable<'a>(
         parse_all_partition_keys_cancellable(remaining, summary_reader, cancel)?;
 
     // Build lookup table with zero-copy approach using Arc::clone (reference counting only)
-    // This eliminates the memory explosion from cloning Vec<u8> key digests
-    let mut key_lookup = HashMap::new();
+    // This eliminates the memory explosion from cloning Vec<u8> key digests.
+    // Issue #2385: pre-size EXACTLY from the parsed entry count so the map never
+    // rehashes while filling.
+    let mut key_lookup = HashMap::with_capacity(partition_entries.len());
     for (index, entry) in partition_entries.iter().enumerate() {
         key_lookup.insert(Arc::clone(&entry.key_digest), index);
     }
@@ -200,7 +202,17 @@ pub(super) fn parse_all_partition_keys_cancellable<'a>(
     _summary_reader: Option<&SummaryReader>,
     cancel: &ScanCancel,
 ) -> Result<(&'a [u8], Vec<PartitionIndexEntry>)> {
-    let mut entries = Vec::new();
+    // Issue #2385: pre-size the entry Vec from a cheap file-size estimate so the
+    // O(entries) parse loop does not repeatedly reallocate-and-copy (each doubling
+    // moves every prior entry). A typical BIG Index.db entry is ~24 bytes
+    // ([key_len:2][raw key:~16][data_offset vint][promoted_len vint]); the hint is
+    // CAPPED so a corrupt/oversized Index.db cannot trigger a hostile up-front
+    // reservation — the Vec still grows past the cap via normal doubling if a
+    // genuinely larger file needs it.
+    const AVG_ENTRY_BYTES: usize = 24;
+    const MAX_CAP_HINT: usize = 4_000_000;
+    let cap_hint = (input.len() / AVG_ENTRY_BYTES).min(MAX_CAP_HINT);
+    let mut entries = Vec::with_capacity(cap_hint);
     let mut remaining = input;
 
     let mut entry_index = 0usize;

--- a/cqlite-core/src/storage/sstable/reader/component_loading.rs
+++ b/cqlite-core/src/storage/sstable/reader/component_loading.rs
@@ -9,7 +9,7 @@ use crate::storage::sstable::{
     bloom::BloomFilter, index::SSTableIndex, index_reader::IndexReader,
     statistics_reader::StatisticsReader, summary_reader::SummaryReader,
 };
-use crate::{Error, Result, RowKey};
+use crate::{Error, Result};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -31,13 +31,30 @@ pub(super) enum IndexLoadOutcome {
 }
 
 impl SSTableReader {
-    /// Load index from integrated or component-based format
+    /// Load the integrated in-Data.db index, if the header advertises one.
+    ///
+    /// Issue #2385 / #2395: the separate `Index.db` component is NO LONGER read
+    /// here. It is parsed exactly once by [`Self::load_index_reader`] into the
+    /// raw-key `IndexReader` that actually serves point lookups (`big_get`) and
+    /// full-index scans. The legacy digest/raw-key `SSTableIndex` this used to
+    /// build (via `convert_index_reader_to_sstable_index`) was a REDUNDANT second
+    /// parse of the same file (#2395's double parse) whose per-entry
+    /// `binary_search` + `Vec::insert` build was the O(N²) cold-open cost (#2385) —
+    /// and whose only consumers already fall through to the same authoritative
+    /// fallbacks when it is `None`:
+    /// - `big_get` reaches its `self.index` branch only after the `index_reader`
+    ///   fast path (present) soft-misses or is absent; both cases already end at
+    ///   the whole-file `scan_for_key` oracle (`data_access/big_point.rs`).
+    /// - the range scan's `self.index` path builds entries with `size == 0` (the
+    ///   BIG `Index.db` parser stores no partition size), so its `has_zero_size`
+    ///   guard ALWAYS degrades it to `sequential_scan` — identical to the `None`
+    ///   fallback (`data_access/sequential.rs`).
+    ///
+    /// The integrated-format Strategy 1 below is retained unchanged (real
+    /// Cassandra 5.0 SSTables never set `index_offset`, so it is inert for them).
     pub(super) async fn load_index(
         file: &Arc<tokio::sync::Mutex<BlockSource>>,
         header: &crate::parser::SSTableHeader,
-        platform: &Arc<Platform>,
-        data_file_path: &Path,
-        cancel: &crate::storage::scan_cancel::ScanCancel,
     ) -> Result<Option<SSTableIndex>> {
         // Strategy 1: Check if index information is available in header (for integrated formats)
         if let Some(index_offset) = header.properties.get("index_offset") {
@@ -55,73 +72,11 @@ impl SSTableReader {
             }
         }
 
-        // Strategy 2: Check for separate Index.db component file (Cassandra 5+ standard)
-        if let Some(base_name) = extract_sstable_base_name(data_file_path) {
-            let index_path = data_file_path
-                .parent()
-                .ok_or_else(|| {
-                    Error::invalid_operation("Cannot determine parent directory for Index.db")
-                })?
-                .join(format!("{}-Index.db", base_name));
-
-            if tokio::fs::metadata(&index_path).await.is_ok() {
-                match IndexReader::open_with_summary_cancellable(
-                    &index_path,
-                    platform.clone(),
-                    None,
-                    cancel,
-                )
-                .await
-                {
-                    Ok(index_reader) => {
-                        tracing::debug!(
-                            "Found separate Index.db component at {}",
-                            index_path.display()
-                        );
-
-                        // Convert IndexReader to SSTableIndex by extracting partition entries
-                        match Self::convert_index_reader_to_sstable_index(
-                            index_reader,
-                            data_file_path,
-                        )
-                        .await
-                        {
-                            Ok(sstable_index) => {
-                                tracing::debug!(
-                                    "Successfully converted Index.db component to SSTableIndex"
-                                );
-                                return Ok(Some(sstable_index));
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "Failed to convert Index.db component to SSTableIndex: {}. This may indicate an incompatible Index.db format or corruption.",
-                                    e
-                                );
-                                // Continue to fallback strategies
-                            }
-                        }
-                    }
-                    // A mid-parse cancellation (issue #2383) must ABORT, never fall
-                    // through to a fallback strategy (that would ignore the cancel
-                    // and keep the worker spinning). Surfaced by variant.
-                    Err(e @ Error::Cancelled) => return Err(e),
-                    Err(e) => {
-                        tracing::debug!(
-                            "Failed to load Index.db component: {}. This may indicate file corruption, permission issues, or format incompatibility.",
-                            e
-                        );
-                        // Continue to fallback strategies
-                    }
-                }
-            } else {
-                tracing::debug!(
-                    "No Index.db component file found at {}",
-                    index_path.display()
-                );
-            }
-        }
-
-        tracing::debug!("No index source available (neither header offset nor Index.db component)");
+        // Strategy 2 (separate Index.db component) retired — parsed once by
+        // load_index_reader (issue #2385 / #2395). See the doc comment above.
+        tracing::debug!(
+            "No integrated index in header; separate Index.db is served by index_reader"
+        );
         Ok(None)
     }
 
@@ -333,8 +288,14 @@ impl SSTableReader {
     /// `/var/lib/cassandra/data/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db`
     /// → keyspace: "test_basic", table: "simple_table"
     ///
+    /// Issue #2385: the production caller (the retired `SSTableIndex` conversion)
+    /// is gone; the equivalent public helper is
+    /// `crate::storage::sstable::extract_keyspace_and_table_name`. Retained under
+    /// `cfg(test)` for the path-parsing unit tests below.
+    ///
     /// # Errors
     /// Returns error if path doesn't match expected structure.
+    #[cfg(test)]
     fn extract_keyspace_and_table(sstable_path: &Path) -> Result<(String, String)> {
         // Extract table name (already handles UUID stripping)
         let table_name =
@@ -370,51 +331,6 @@ impl SSTableReader {
         );
 
         Ok((keyspace, table_name))
-    }
-
-    /// Convert IndexReader to SSTableIndex for backward compatibility
-    pub(super) async fn convert_index_reader_to_sstable_index(
-        index_reader: IndexReader,
-        data_file_path: &Path,
-    ) -> Result<SSTableIndex> {
-        use crate::storage::sstable::index::{Index, IndexEntry};
-
-        // Extract keyspace and table name from SSTable directory path
-        // Issue #188: Must use fully-qualified table ID (keyspace.table) to match
-        // query executor expectations, not just table name alone
-        let (keyspace, table_name) = Self::extract_keyspace_and_table(data_file_path)?;
-
-        // Create fully-qualified table ID: "keyspace.table"
-        let table_id = crate::types::TableId::new(format!("{}.{}", keyspace, table_name));
-
-        let mut index = Index::new();
-
-        // Extract partition entries from IndexReader and convert to IndexEntry format
-        let partition_entries = index_reader.get_partition_entries();
-
-        for partition_entry in partition_entries {
-            // Convert partition entry to our internal IndexEntry format
-            let index_entry = IndexEntry {
-                table_id: table_id.clone(),
-                key: RowKey::new(partition_entry.key_digest.to_vec()),
-                offset: partition_entry.data_offset,
-                size: partition_entry.data_size,
-                compressed: false,
-            };
-
-            // Add to index using extracted table ID
-            index.add_entry(index_entry);
-        }
-
-        tracing::debug!(
-            "Converted {} partition entries from IndexReader to SSTableIndex for table '{}' (keyspace: {}, table: {})",
-            partition_entries.len(),
-            table_id.name(),
-            keyspace,
-            table_name
-        );
-
-        Ok(index)
     }
 
     /// Detect and construct paths for SSTable component files

--- a/cqlite-core/src/storage/sstable/reader/integrity.rs
+++ b/cqlite-core/src/storage/sstable/reader/integrity.rs
@@ -49,7 +49,11 @@ impl SSTableReader {
             compression_enabled: self.compression_reader.is_some(),
             compression_algorithm: self.header.compression.algorithm.clone(),
             bloom_filter_enabled: self.bloom_filter.is_some(),
-            index_available: self.index.is_some(),
+            // Issue #2385: the raw-key `index_reader` is THE partition index for a
+            // BIG SSTable now that the redundant `self.index` build is retired; the
+            // integrated `self.index` only ever populates for the (inert) in-Data.db
+            // format. Either being present means index-based lookups are available.
+            index_available: self.index_reader.is_some() || self.index.is_some(),
             generation: self.generation,
             last_error: None,
         })

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -692,9 +692,7 @@ impl SSTableReader {
             }
         }
 
-        // Load the integrated in-Data.db index if the header advertises one. The
-        // separate Index.db component is parsed exactly once by load_index_reader
-        // below (issue #2385 / #2395), not here.
+        // Integrated in-Data.db index only; separate Index.db is parsed once by load_index_reader (#2385/#2395).
         let index = Self::load_index(&file, &header)
             .instrument(tracing::debug_span!("sstable.reader.open.load_index"))
             .await?;

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -692,8 +692,10 @@ impl SSTableReader {
             }
         }
 
-        // Load index if available (supports both integrated and component-based)
-        let index = Self::load_index(&file, &header, &platform, path, &cancel)
+        // Load the integrated in-Data.db index if the header advertises one. The
+        // separate Index.db component is parsed exactly once by load_index_reader
+        // below (issue #2385 / #2395), not here.
+        let index = Self::load_index(&file, &header)
             .instrument(tracing::debug_span!("sstable.reader.open.load_index"))
             .await?;
 

--- a/cqlite-core/tests/issue_2385_index_build_growth.rs
+++ b/cqlite-core/tests/issue_2385_index_build_growth.rs
@@ -57,7 +57,7 @@ fn time_build(entries: Vec<IndexEntry>) -> f64 {
     let index = Index::from_entries(entries);
     let elapsed = start.elapsed().as_secs_f64();
     // Prevent the optimizer from eliding the build.
-    assert!(index.len() > 0, "build must retain entries");
+    assert!(!index.is_empty(), "build must retain entries");
     elapsed
 }
 

--- a/cqlite-core/tests/issue_2385_index_build_growth.rs
+++ b/cqlite-core/tests/issue_2385_index_build_growth.rs
@@ -50,15 +50,23 @@ fn descending_entries(table_id: &TableId, n: u64) -> Vec<IndexEntry> {
     entries
 }
 
-/// Time `Index::from_entries` for a prebuilt entry vector (build cost only; the
-/// vector is constructed outside the timed region).
-fn time_build(entries: Vec<IndexEntry>) -> f64 {
-    let start = Instant::now();
-    let index = Index::from_entries(entries);
-    let elapsed = start.elapsed().as_secs_f64();
-    // Prevent the optimizer from eliding the build.
-    assert!(!index.is_empty(), "build must retain entries");
-    elapsed
+/// Fastest `Index::from_entries` build over `runs` attempts (the entry vector is
+/// cloned OUTSIDE each timed region). Taking the MIN filters transient scheduler
+/// stalls on a loaded box: a single preemption can only inflate an individual
+/// sample, and the min discards it — so the growth ratio never false-REDs on a
+/// one-off hiccup while still capturing the true O(N²) vs O(N log N) signal.
+fn time_build_min(entries: &[IndexEntry], runs: usize) -> f64 {
+    let mut best = f64::INFINITY;
+    for _ in 0..runs {
+        let cloned = entries.to_vec();
+        let start = Instant::now();
+        let index = Index::from_entries(cloned);
+        let elapsed = start.elapsed().as_secs_f64();
+        // Prevent the optimizer from eliding the build.
+        assert!(!index.is_empty(), "build must retain entries");
+        best = best.min(elapsed);
+    }
+    best
 }
 
 #[test]
@@ -76,8 +84,9 @@ fn index_build_is_not_quadratic() {
     let v1 = descending_entries(&table_id, N1);
     let v2 = descending_entries(&table_id, N2);
 
-    let t1 = time_build(v1);
-    let t2 = time_build(v2);
+    // Min-of-3 to filter transient scheduler stalls (loaded-box safe).
+    let t1 = time_build_min(&v1, 3);
+    let t2 = time_build_min(&v2, 3);
 
     // Guard against a degenerate near-zero t1 that would inflate the ratio into a
     // false RED on an absurdly fast machine: require a floor before dividing.

--- a/cqlite-core/tests/issue_2385_index_build_growth.rs
+++ b/cqlite-core/tests/issue_2385_index_build_growth.rs
@@ -1,0 +1,96 @@
+//! Issue #2385 — cold-open super-linear catch: `Index::from_entries` must build
+//! in ~O(N log N), not O(N²).
+//!
+//! Root cause (analysis comment on #2385): `SSTableIndex::add_entry` did a
+//! `Vec::binary_search` + `Vec::insert` into `sorted_keys` per entry. `Index.db`
+//! arrives in TOKEN order but `RowKey` sorts by raw bytes, so inserts land
+//! mid-vector → an O(N) memmove each → O(N²) total. The field measured this as a
+//! ~257s cold `LIMIT 5` at 1.42M partitions (local 150k→1.8s, 2M→312s: ~13× data
+//! → ~173× time ≈ 13²).
+//!
+//! This pins the fix with a GROWTH RATIO, not an absolute wall-clock (loaded-box
+//! safe): building 4× the entries must cost ≤ ~8× the time. A quadratic build
+//! gives ~16× (=4²); a linearithmic build gives ~4.3× (4 · log(4N)/log(N)). The
+//! bound of 8 sits between them with generous headroom for scheduler noise.
+//!
+//! Insertion order is DESCENDING by key bytes — the worst case for the old
+//! binary-search-then-insert loop (every insert lands at position 0 → a full
+//! memmove), so the quadratic signal is maximal and deterministic.
+//!
+//! RED on the pre-fix tree (per-entry insert): ratio ≈ 16 (FAILS ≤ 8).
+//! GREEN after the sort-once bulk build: ratio ≈ 4–5.
+
+#![cfg(feature = "state_machine")]
+
+use std::time::Instant;
+
+use cqlite_core::{
+    storage::sstable::index::{Index, IndexEntry},
+    types::TableId,
+    RowKey,
+};
+
+/// Build `n` index entries whose keys DESCEND in byte order (worst case for a
+/// per-entry `binary_search` + `insert` into a byte-sorted vector: every insert
+/// is at position 0).
+fn descending_entries(table_id: &TableId, n: u64) -> Vec<IndexEntry> {
+    let mut entries = Vec::with_capacity(n as usize);
+    for i in 0..n {
+        // key = (n - i): first entry is the LARGEST key, each subsequent smaller,
+        // so every insertion lands before all prior keys.
+        let key_val = n - i;
+        entries.push(IndexEntry {
+            table_id: table_id.clone(),
+            key: RowKey::new(key_val.to_be_bytes().to_vec()),
+            offset: i * 64,
+            size: 0,
+            compressed: false,
+        });
+    }
+    entries
+}
+
+/// Time `Index::from_entries` for a prebuilt entry vector (build cost only; the
+/// vector is constructed outside the timed region).
+fn time_build(entries: Vec<IndexEntry>) -> f64 {
+    let start = Instant::now();
+    let index = Index::from_entries(entries);
+    let elapsed = start.elapsed().as_secs_f64();
+    // Prevent the optimizer from eliding the build.
+    assert!(index.len() > 0, "build must retain entries");
+    elapsed
+}
+
+#[test]
+fn index_build_is_not_quadratic() {
+    let table_id = TableId::new("growth_ks.growth_tbl");
+
+    // 50k and 200k (4×). Big enough that O(N²) dominates fixed overhead, small
+    // enough that even the PRE-FIX quadratic build completes in seconds in a debug
+    // test binary (at 800k the O(N²) memmove of the byte-sorted key vector runs
+    // ~4 minutes — matching the field's 2M→312s — which is impractical to gate on).
+    const N1: u64 = 50_000;
+    const N2: u64 = 200_000;
+
+    // Build both entry vectors up front (outside the timed regions).
+    let v1 = descending_entries(&table_id, N1);
+    let v2 = descending_entries(&table_id, N2);
+
+    let t1 = time_build(v1);
+    let t2 = time_build(v2);
+
+    // Guard against a degenerate near-zero t1 that would inflate the ratio into a
+    // false RED on an absurdly fast machine: require a floor before dividing.
+    let ratio = if t1 > 1e-4 { t2 / t1 } else { 0.0 };
+
+    eprintln!(
+        "index_build growth: N1={N1} took {t1:.4}s, N2={N2} (4x) took {t2:.4}s, ratio={ratio:.2} \
+         (quadratic ~16, linearithmic ~4.3, bound 8)"
+    );
+
+    assert!(
+        ratio <= 8.0,
+        "Index::from_entries must build in ~O(N log N): 4x the entries took {ratio:.2}x the time \
+         (bound 8; a quadratic per-entry insert gives ~16). N1={N1} t1={t1:.4}s, N2={N2} t2={t2:.4}s"
+    );
+}

--- a/cqlite-core/tests/issue_2385_index_single_parse.rs
+++ b/cqlite-core/tests/issue_2385_index_single_parse.rs
@@ -1,0 +1,112 @@
+//! Issue #2385 / #2395 — opening a BIG (`nb`) SSTable parses its `Index.db`
+//! EXACTLY ONCE.
+//!
+//! Before this fix the reader open path parsed the same `Index.db` twice: once via
+//! `load_index` (Strategy 2 → `convert_index_reader_to_sstable_index`, only to
+//! build the now-retired digest-keyed `SSTableIndex`) and once via
+//! `load_index_reader` (the raw-key `IndexReader` that actually serves lookups).
+//! At 1.42M partitions that doubled a multi-minute cold parse (#2385) — the #2395
+//! double-parse. This pins the win via the authoritative
+//! `cqlite.sstable.index_parses_total` counter (#2383): a cold open records
+//! EXACTLY 1 (RED = 2 on the pre-fix tree).
+//!
+//! Separate integration-test process: the OTel capture harness installs a
+//! PROCESS-GLOBAL meter provider, so this must not share cqlite-core's parallel
+//! `--lib` unit-test binary (roborev #2163 precedent). Requires
+//! `CQLITE_DATASETS_ROOT` + fetched binaries; skips (never fails) when the fixture
+//! is absent — a present fixture that fails to open stays a hard failure.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-core --features observability-testing \
+//!   --test issue_2385_index_single_parse
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::platform::Platform;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::Config;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// Locate a `*-Data.db` in `<datasets>/sstables/<keyspace>/<table>-*/` that has a
+/// sibling `*-Index.db` (a BIG-format SSTable). Skip keys off fixture presence.
+fn find_big_data_file(keyspace: &str, table: &str) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let entries = std::fs::read_dir(root.join("sstables").join(keyspace)).ok()?;
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        let dir = e.path();
+        let files = std::fs::read_dir(&dir).ok()?;
+        let mut data_file: Option<PathBuf> = None;
+        let mut has_index = false;
+        for f in files.flatten() {
+            let name = f.file_name().to_string_lossy().into_owned();
+            if name.ends_with("-Data.db") {
+                data_file = Some(f.path());
+            } else if name.ends_with("-Index.db") {
+                has_index = true;
+            }
+        }
+        if has_index {
+            if let Some(df) = data_file {
+                return Some(df);
+            }
+        }
+    }
+    None
+}
+
+/// Opening a BIG SSTable must parse `Index.db` exactly once.
+///
+/// RED on the pre-fix tree: `load_index` (Strategy 2 convert) + `load_index_reader`
+/// each ran a full parse → counter == 2. GREEN after retiring the Strategy 2
+/// `SSTableIndex` build: only `load_index_reader` parses → counter == 1.
+#[test]
+fn open_parses_index_exactly_once() {
+    // Install the process-global in-memory meter BEFORE any parse in this process.
+    let mc = testing::metrics_capture();
+
+    let Some(data_file) = find_big_data_file("test_basic", "simple_table") else {
+        eprintln!("Skipping (#2385 one-parse-per-open): BIG test_basic/simple_table fixture absent");
+        return;
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let config = Config::default();
+    let platform = Arc::new(
+        rt.block_on(Platform::new(&config))
+            .expect("platform must initialize"),
+    );
+
+    // Reset BEFORE the open so the entire open path is measured from zero.
+    mc.reset();
+    let reader = rt
+        .block_on(SSTableReader::open(&data_file, &config, platform))
+        .expect("BIG fixture must open");
+    // Keep the reader alive across the collection so the open work is attributed.
+    let _ = &reader;
+
+    let parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+
+    assert_eq!(
+        parses, 1.0,
+        "opening a BIG SSTable must parse Index.db exactly ONCE (got {parses}); \
+         pre-fix this was 2 — load_index (Strategy 2 convert) plus load_index_reader (#2395)"
+    );
+}

--- a/cqlite-core/tests/issue_2385_index_single_parse.rs
+++ b/cqlite-core/tests/issue_2385_index_single_parse.rs
@@ -81,7 +81,9 @@ fn open_parses_index_exactly_once() {
     let mc = testing::metrics_capture();
 
     let Some(data_file) = find_big_data_file("test_basic", "simple_table") else {
-        eprintln!("Skipping (#2385 one-parse-per-open): BIG test_basic/simple_table fixture absent");
+        eprintln!(
+            "Skipping (#2385 one-parse-per-open): BIG test_basic/simple_table fixture absent"
+        );
         return;
     };
 

--- a/cqlite-flight/tests/issue_2370_single_flight_test.rs
+++ b/cqlite-flight/tests/issue_2370_single_flight_test.rs
@@ -17,18 +17,12 @@
 //!
 //! The issue's ideal is `index_parses_total == #generations` (each generation's
 //! Index.db parsed once per query — the counter's documented contract in
-//! `catalog::INDEX_PARSES_TOTAL`). On current main it is `2 × #generations`:
-//! `SSTableReader::open` parses the full `Index.db` TWICE per reader open —
-//! `reader/mod.rs` calls BOTH `load_index` (→ legacy `SSTableIndex`) and
-//! `load_index_reader` (→ spec `IndexReader`), each running the O(entries)
-//! `parse_all_partition_keys_*` loop `index_parses_total` counts. That per-OPEN
-//! double-parse is a SEPARATE redundancy (reported with this suite as issue
-//! **#2395** — the reader-open double-parse — independent of concurrency and of
-//! the warm registry) — the single-flight this test pins is that the total does
-//! NOT scale with N. `PER_OPEN_PARSES` documents the current per-open
-//! multiplicity; tighten it to `1` when #2395 is fixed (this test stays green
-//! through that fix — the bound only rejects a per-REQUEST, N-scaling
-//! amplification, never a smaller constant).
+//! `catalog::INDEX_PARSES_TOTAL`). Issue **#2395** (fixed) retired the reader-open
+//! double-parse: `SSTableReader::open` now parses each `Index.db` EXACTLY ONCE
+//! (only `load_index_reader` → spec `IndexReader`; `load_index` no longer reads
+//! the separate component), so `PER_OPEN_PARSES == 1` and the total is
+//! `1 × #generations`. The single-flight this test pins is that the total does NOT
+//! scale with N — the bound only rejects a per-REQUEST, N-scaling amplification.
 //!
 //! ## Separate integration-test process
 //!
@@ -58,13 +52,12 @@ use concurrent_support as support;
 /// Number of simultaneous cold requests. Field runs use 8.
 const N: usize = 8;
 
-/// Current number of full `Index.db` parses `SSTableReader::open` performs PER
-/// reader open (see the module doc: `load_index` + `load_index_reader`). The
-/// ideal is 1; `2` documents issue **#2395** (the reader-open double-parse). The
-/// pin below is that the TOTAL is `PER_OPEN_PARSES × #generations` — a
-/// per-generation constant that does NOT grow with N. Reduce to 1 when #2395 is
-/// fixed.
-const PER_OPEN_PARSES: f64 = 2.0;
+/// Number of full `Index.db` parses `SSTableReader::open` performs PER reader
+/// open. Issue **#2395** (fixed) retired the reader-open double-parse, so this is
+/// now `1` (only `load_index_reader` parses the separate `Index.db`). The pin
+/// below is that the TOTAL is `PER_OPEN_PARSES × #generations` — a per-generation
+/// constant that does NOT grow with N.
+const PER_OPEN_PARSES: f64 = 1.0;
 
 /// Count the `nb-*-big-Data.db` generations under the fixture's table dir.
 fn generation_count(data_dir: &std::path::Path) -> usize {
@@ -173,9 +166,9 @@ fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
     // INDEPENDENT of N. A single-flight failure (the #2383 ×N amplifier through the
     // rpc layer) makes each of the N requests re-parse every generation, so the
     // total climbs toward `#generations × N` (here up to 16–32) — far past this
-    // bound. `PER_OPEN_PARSES` (currently 2, the reported reader-open double-parse
-    // finding) is a per-generation constant; the bound rejects only a per-REQUEST,
-    // N-scaling amplification, and stays green if the double-parse is fixed to 1.
+    // bound. `PER_OPEN_PARSES` (now 1 — the #2395 reader-open double-parse is
+    // fixed) is a per-generation constant; the bound rejects only a per-REQUEST,
+    // N-scaling amplification.
     let bound = PER_OPEN_PARSES * generations as f64;
     assert!(
         parses <= bound,


### PR DESCRIPTION
## Field context

Round-9 field capture (#2367) at **1.42M partitions**: a cold `LIMIT 5` took **~257s**
and a cold `count(*)` ran **>10 min**. Opening a BIG (`nb`) SSTable was super-linear in
partition count — an O(N²) cold-start that dominates the first query against a
many-partition generation.

Root cause: opening the reader **parsed the same `Index.db` twice** and then built a
**redundant** partition index with a per-entry `binary_search` + `Vec::insert`.

## The three fixes

1. **Retire the redundant `SSTableIndex` from BIG open (#2385/#2395).** `load_index`
   no longer reads the separate `Index.db` (Strategy 2 / `convert_index_reader_to_sstable_index`
   is deleted). That file is now parsed **exactly once** by `load_index_reader` into the
   raw-key `IndexReader` that actually serves point lookups and full-index scans.
   Consumer-by-consumer evidence that retiring `self.index` is behavior-identical:
   - `big_get` reaches its `self.index` branch only after the `index_reader` fast path
     soft-misses or is absent; both cases already end at the whole-file `scan_for_key`
     oracle (digest-keyed `SSTableIndex` was an always-miss on raw-key lookups → same scan).
   - the range-scan `self.index` path builds entries with `size == 0` (the BIG parser
     stores no partition size), so its `has_zero_size` guard **always** degrades it to
     `sequential_scan` — identical to the `None` fallback.
   - `index_available` in the integrity report is now `index_reader.is_some() || index.is_some()`
     (the raw-key reader is THE partition index now); test-only consumers unaffected.
   - `#2383` mid-parse cancel pins and the integrated in-Data.db Strategy 1 are untouched.

2. **`Index::from_entries` bulk build (#2385).** Replaces the per-entry
   `add_entry` (`binary_search` + `Vec::insert`) — O(N²) because `Index.db` arrives in
   **token** order but `RowKey` sorts by **raw bytes**, so every insert lands mid-vector
   (a full memmove). Now collects each table's unique keys and sorts **once**
   (O(N log N)). Byte-for-byte identical output to feeding the same entries through
   `add_entry`: last-write-wins per `(table_id, key)`, duplicate keys collapse,
   `total_entries` counts input entries.

3. **Capacity hints (#2385).** `parse_all_partition_keys_cancellable` pre-sizes its
   entry `Vec` from a **capped** file-size estimate (`AVG_ENTRY_BYTES=24`,
   `MAX_CAP_HINT=4_000_000`) so the parse loop stops reallocate-and-copy churn without
   letting a corrupt/oversized `Index.db` trigger a hostile up-front reservation; the
   digest lookup map pre-sizes exactly from the parsed entry count.

## Red -> green proof

- **Index-build growth ratio: 15.5 -> 4.96** (quadratic ~16 = 4^2, linearithmic ~4.3).
- **200k-entry index build: 6.17s -> 0.061s (~100x).**
- **Parses per reader open: 2 -> 1.**

## Pins

- `cqlite-core/tests/issue_2385_index_build_growth.rs` — worst-case DESCENDING-key
  growth ratio (4x entries must cost <= ~8x time; RED ~16 pre-fix). Min-of-3 timing,
  loaded-box flake-proof.
- `cqlite-core/tests/issue_2385_index_single_parse.rs` — a cold BIG open records
  **exactly 1** `cqlite.sstable.index_parses_total` (#2383 counter; RED = 2 pre-fix).
  Separate integration process (process-global meter provider).

## Review

- rust-reviewer: **APPROVE**, no blockers (behavior-identity of the `SSTableIndex`
  retirement verified consumer-by-consumer; `from_entries` byte-identical; cancel/#2383
  pins intact; no cfg traps).
- roborev job 1663: **"No issues found."**

Ships as **v0.14.1**.

Closes #2385
Closes #2395
