### PR TITLE
release(#2405): bump versions to 0.14.1 + release notes — cold-start stopgap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ resolver = "2"
 # belongs to an unrelated project; the CLI publishes as `cqlite-cli` (binary
 # `cqlite`). See issue #782.
 name = "cqlite"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 publish = false
 
@@ -47,7 +47,7 @@ crc32fast = { workspace = true }
 cqlite-integration-tests = { path = "tests" }
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "Apache-2.0"

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.14.0"
+version = "0.14.1"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # version is required (alongside path) so the dep resolves when published to
 # crates.io. Keep this literal in sync with [workspace.package].version on every
 # release (see release checklist).
-cqlite-core = { path = "../cqlite-core", version = "0.14.0" }
+cqlite-core = { path = "../cqlite-core", version = "0.14.1" }
 
 # CLI framework
 clap = { workspace = true }

--- a/docs/releases/RELEASE_NOTES_v0.14.1.md
+++ b/docs/releases/RELEASE_NOTES_v0.14.1.md
@@ -1,0 +1,57 @@
+# CQLite v0.14.1 — cold-start parse fix
+
+Released: 2026-07-13
+
+v0.14.1 is a patch release on top of the [v0.14.0](RELEASE_NOTES_v0.14.0.md) Flight
+field-readiness build. It fixes the cold first-query-per-table parse cost that v0.14.0 called out
+as a known limitation. No API or behavior changes — this is a pure performance fix.
+
+Release binaries and the auto-generated GitHub release body (commit/PR changelog + API-docs links)
+are produced by `release.yml` on the `v0.14.1` tag.
+
+## Headline — cold-start parse fix
+
+- **Retired the redundant `SSTableIndex` from BIG reader open**
+  ([#2385](https://github.com/pmcfadin/cqlite/issues/2385),
+  [#2395](https://github.com/pmcfadin/cqlite/issues/2395) via
+  [PR #2402](https://github.com/pmcfadin/cqlite/pull/2402)): `SSTableReader::open` no longer builds
+  a second, redundant in-memory index. The removal is behavior-identical and consumer-verified —
+  `Index.db` is now parsed exactly once per open (parses-per-open **2 → 1**), and the surviving
+  index build uses capacity hints so it grows linearithmically instead of quadratically.
+
+### Numbers
+
+- 200k-entry index build: **6.17s → 0.061s** (~**100×**).
+- Growth ratio (build time vs entry count): **15.5 → 4.96** — quadratic collapses to linearithmic.
+- Parses of `Index.db` per open: **2 → 1**.
+- Resident index memory: roughly **halved per generation**.
+
+### Field context
+
+At round-9 field validation, a cold `LIMIT` query took **4m17s at 1.42M partitions**. With this
+fix the cold cost is expected to drop to seconds-per-generation; the round-10 field pass will
+confirm.
+
+## Known limitations
+
+Unchanged from v0.14.0, minus the cold-start item fixed above:
+
+- **Reads are single-node-bound under RF=N**: under concurrency one pod does the work; throughput
+  caps at one node. Connector fix coming
+  ([#2397](https://github.com/pmcfadin/cqlite/issues/2397)).
+- **Warm scan setup overhead**: warm scans carry a fixed ~4–5s per-query resolve/merge-setup cost,
+  so a `LIMIT 5` scan runs comparably to `LIMIT 100`
+  ([#2398](https://github.com/pmcfadin/cqlite/issues/2398)).
+
+## Write-surface claim boundary
+
+Unchanged: CQLite's production write surface (flush + STCS compaction) emits **uncompressed**
+SSTables only and never a `CompressionInfo.db`. CQLite does **not** emit compressed SSTables; the
+compressed-write building blocks remain unwired
+([#1406](https://github.com/pmcfadin/cqlite/issues/1406)).
+
+## Upgrading
+
+Rust crates, the Python (`cqlite-py`) and Node (`@cqlite/node`) bindings all move `0.14.0 →
+0.14.1` in lockstep. The Trino connector (`in.mcfad:cqlite-trino`) is versioned separately and is
+not part of this crate bump.


### PR DESCRIPTION
Patch release PR for v0.14.1 (#2405 (release)). Carries #2385/#2395 (merged PR #2402: retire SSTableIndex from BIG open, parse-once, capacity hints — behavior-identical, consumer-verified).

- Workspace + cqlite-cli pin + Python + Node → 0.14.1 (lockstep); connector versioned separately
- Notes: docs/releases/RELEASE_NOTES_v0.14.1.md (numbers: 200k build 6.17s→0.061s ~100×, growth 15.5→4.96, parses 2→1; round-10 expectation recorded)
- Parity: lint 333/0/0 ✓, tier-contract ✓; required_parity re-run on the merge commit before tagging

Part of #2405 — issue stays open through tag + train.