### PR TITLE
docs(#2103): kit loadtest field artifacts — round-3/4/5 plans + harness RUN-LOG

### DIFF
--- a/easy-db-lab-kits/RUN-LOG.md
+++ b/easy-db-lab-kits/RUN-LOG.md
@@ -1,0 +1,100 @@
+# cqlite-flight + Trino loadtest harness — run log & handoff
+
+**Purpose:** Living record of the #2103 harness bring-up on a real AWS cluster —
+what was done, every bug found, and where the run stands — so another agent (or
+person) can pick up without re-deriving it.
+
+- Epic: [pmcfadin/cqlite#2103](https://github.com/pmcfadin/cqlite/issues/2103)
+- Test plan executed: `easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md`
+- Run started: 2026-07-06 (cluster `cqlite-flight-loadtest`, region us-west-1, account 417835013894)
+- Executed **directly via Bash** (the `easy-db-lab:run` plugin skill was not installed in the session; user authorized running the plan steps by hand).
+
+## TL;DR status — RUN COMPLETE (12 issues filed)
+
+The full stack was brought up and exercised end-to-end on a real 3-DB + 1-app
+cluster. **The documented happy-path does not work without fixes** — 8 hard
+blockers had to be worked around by hand. Once patched, the stack functions:
+writes OK, SSTables + compaction OK, `cqlite-flight` reads/merges SSTables
+correctly, `SHOW CATALOGS` lists `cqlite`, the connector plugin (0.13.1, JDK-25)
+loads, and the `trino-loadtest` driver runs and connects.
+
+**Two things fundamentally don't work on the published artifacts:**
+1. **Observability emits nothing (#2128)** — the `cqlite-flight` image is built
+   without `--features observability`, so `CQLITE_OTEL_*` is inert. No metrics,
+   no traces. This defeats the epic's "watch the internals" goal. The kit-side
+   wiring (env, collector reachability, dashboard) is all correct — verified.
+2. **Queries are unbounded full-scans (#2129)** — no LIMIT/count pushdown, so
+   `SELECT * ... LIMIT 5` full-scans ~2M rows (235s, then "Network closed"). The
+   read is *correct*, just not bounded. The loadtest driver ran but logged
+   qps=0.00 because every built-in query exceeds the reporting interval.
+
+Cluster was torn down after the run (see bottom).
+
+## Cluster facts (this run)
+
+- Workspace dir (all `easy-db-lab` state): `/Users/pmcfadin/projects/easy-db-lab/clusters/cqlite-flight-loadtest-20260706-192113/`
+- Wrapper: `$CLUSTER_DIR/easy-db-lab` (sets JAVA_HOME 21, cds into workspace)
+- Full raw findings log: `$CLUSTER_DIR/../RUN-FINDINGS-20260706-192103.md`
+- Topology: 3× `i4i.xlarge` db (db0 10.1.1.145, db1 10.1.2.84, db2 10.1.3.59), 1× `m5.xlarge` app (app0), 1 control. DC `us-west-2`.
+- Cassandra 5.0; Trino pinned 481; connector `in.mcfad:cqlite-trino:0.13.1`; flight image `ghcr.io/pmcfadin/cqlite-flight:v0.13.0`.
+- Data: `cassandra_easy_stress.keyvalue`, written by `cassandra-easy-stress KeyValue -d 15m --threads 50` (~1500 wr/s, job Completed). 3 SSTables/node after 6 flushes + compaction.
+
+## Environment gotchas (needed to run the plan by hand)
+
+- **Kit `bin/*.sh` scripts run LOCALLY** (KitRunnerCommand ProcessBuilder) against the remote K3s API. They shell out to `helm` and `kubectl` — both must be on the dev machine. `kubectl` was present; **`helm` was NOT** → `helm: command not found`. Fixed with `brew install helm` (v4.2.2). Not documented as a local prereq (easy-db-lab doc gap; see findings log F1).
+- **Cluster API is not directly reachable.** kubeconfig points at the control node's private IP (`10.1.1.163:6443`). A SOCKS5 proxy runs on `localhost:1080` (the `easy-db-lab` CLI uses it internally). For hand-run `helm`/`kubectl`, export:
+  ```
+  export ALL_PROXY="socks5h://localhost:1080" HTTPS_PROXY="socks5h://localhost:1080" NO_PROXY="localhost,127.0.0.1"
+  export KUBECONFIG="$CLUSTER_DIR/kubeconfig"
+  ```
+- **AWS**: `AWS_PROFILE=edl` (SSO; `aws sso login --sso-session ehc-embark` if expired).
+- Every SSH prints a harmless `axonops sudoers wildcards` warning — cosmetic, ignore.
+- `trino`/`cassandra` full-table `SELECT count(*)` is slow and blows past a 2-min timeout; Cassandra count hit a LOCAL_QUORUM read timeout — run counts with patience / higher client timeout.
+
+## Bugs filed (all on pmcfadin/cqlite)
+
+### Hard blockers on the happy-path (each worked around to proceed)
+- **#2116** — *trino kit (easy-db-lab)*: `web-ui.*` in top-level `additionalConfigProperties` → applied to workers → **worker CrashLoopBackOff at Trino 481** ("Configuration property 'web-ui.authentication.type' was not used"). Fix: scope web-ui to coordinator only. Workaround: removed web-ui lines from rendered `trino/values.yaml`.
+- **#2118** — *cqlite-flight kit*: `runAsNonRoot: true` with no numeric `runAsUser` → **CreateContainerConfigError** ("image has non-numeric user (flight)"). Fix: add `runAsUser: 10001`. Workaround: patched rendered `cqlite-flight/daemonset.yaml`.
+- **#2120** — *trino-cqlite overlay*: `cqlite start` → only `reapply-plugin-patch.sh` runs, which **references but never creates** the `cqlite-trino-plugin-src` ConfigMap (only `install.sh` does, and it's not wired as a hook) → init container **FailedMount**. Fix: create the ConfigMap in reapply/start. Workaround: ran `kubectl create configmap` by hand.
+- **#2122** — *trino-cqlite overlay*: plugin-fetch init image `gradle:9.1.0-jdk21` **can't resolve the JDK-25 connector artifact** (`cqlite-trino:0.13.1` requires JVM 25). Fix: bump init image to `gradle:9.6-jdk25`. Workaround: patched init image on both deployments.
+- **#2123** — *trino-cqlite overlay*: catalog file sets `connector.name=cqlite` but the factory is **`cqlite_flight`** → **coordinator crash "No factory for connector 'cqlite'"**. Fix: `connector.name=cqlite_flight` (catalog display name still comes from the filename). Workaround: rewrote catalog in both the sibling `.properties` and the helm `.catalogs-override.yaml`.
+
+- **#2128** — *cqlite-flight image (build/CI)*: image built **without `--features observability`** → `CQLITE_OTEL_*` inert, **no metrics/traces emitted at all**. Verified: VM has 1609 metrics, zero `cqlite_*`; node OTel collector reachable on `:4317`; flight env correct; no obs-init line in flight log. Fix: `cargo build --release -p cqlite-flight --features observability`. Blocks the whole observability goal.
+- **#2130** — *trino-loadtest driver*: `int(TRINO_PORT)` crashes on the K8s-injected `TRINO_PORT=tcp://<svcIP>:8080` service env var (Service `trino` in the namespace) → driver never starts. Fix: rename env vars out of the K8s-reserved namespace, or guard the int parse (start.sh already passes `--port` explicitly).
+- **#2132** — *trino-loadtest kit*: unset optional `--queries-file` arrives from the easy-db-lab runner as the **literal string `null`** → `start.sh` runs `--from-file=queries.txt=null` → "no objects passed to apply", pod never created. Fix: guard `!= "null"` (also raise with easy-db-lab: unset `default:""` arg should be empty, not `null`).
+
+### Other filed
+- **#2117** — *release/CI*: `cqlite-flight:v0.13.1` container **missing on GHCR** (connector JAR published to Maven, container not) + inconsistent v-prefix/bare tag scheme. Workaround: used `v0.13.0`.
+- **#2119** — *trino-cqlite overlay*: `reapply-plugin-patch.sh` patches deployments but never deletes the old coordinator → **hostPort:8080 rollout deadlock** on a single app node. Fix: delete coordinator pod after patch (as the trino kit does).
+- **#2129** — *connector (perf/enhancement)*: **no LIMIT/count pushdown**. `EXPLAIN SELECT * ... LIMIT 5` shows `Limit` above `TableScan`, scan estimate = full 1,990,586 rows / 208 MB. Every query does a full compaction-merge of all splits. `LIMIT 5` = 235s then "Network closed". Read is correct, just unbounded. Suggested: `applyLimit` → row cap in the flight ticket; count/aggregation pushdown (#893 plumbing exists).
+- **#2114** — *cqlite-flight kit* (filed pre-run, low priority): single-disk `--data-dir` assumption misses SSTables on multi-disk db nodes.
+
+### Fix-order recommendation for the team
+The happy-path unblocks in this order: **#2116** (trino workers boot at 481) → **#2118** (flight pods start) → **#2117** (a pullable container tag) → **#2120 + #2122 + #2123 + #2119** (overlay: create ConfigMap, jdk25 init image, `connector.name=cqlite_flight`, delete-coordinator-after-patch — all four needed for `cqlite start` to converge) → **#2130 + #2132** (loadtest driver starts) → **#2128** (observability actually emits) → **#2129** (queries become usably fast). The first seven are pure kit/build fixes; #2129 is connector engineering.
+
+## What passed / worked well
+
+- cqlite-flight DaemonSet: correct one-pod-per-db-node placement; after the #2118 fix, all 3 pods Running; **data dir readable** via `supplementalGroups: [999]` (no perm errors); flight server listening `0.0.0.0:8815`; **`:8815` reachable from app0** (hostNetwork model works).
+- Plugin assembly from Maven Central works once on JDK 25 (`BUILD SUCCESSFUL`, plugin JARs land in `/usr/lib/trino/plugin/cqlite_flight`).
+- `cqlite` catalog registers; `SHOW SCHEMAS FROM cqlite` returns `information_schema` (connector responds, sidecar reachable) — before Phase 1 there was no user keyspace, as expected.
+- Template variable substitution in all three kits was correct (image tags, gid, data path, sidecar URI, flight port, connector version).
+- Write load produced real multi-generation SSTables (compaction ran: 6 flushes → 3 SSTables/node).
+
+## Where it stands / next steps for the picker-upper
+
+1. **Validate read parity (Phase 3, Step 12):** confirm `SELECT count(*) FROM cqlite.cassandra_easy_stress.keyvalue` (Trino) == Cassandra count. Trino count query was in flight at handoff — check its result. This is the first real exercise of the flight `do_get` path end-to-end.
+2. **Phase 3a — snapshot mode read run:** `easy-db-lab trino-loadtest-trino start --ks cassandra_easy_stress --tbl keyvalue --threads 8 --duration 120 --traceparent`. Watch `nodetool listsnapshots` for transient `cqlite-<queryId>` snapshots.
+3. **Phase 3b — live mode:** add `cqlite.read-mode=live` to the catalog override, re-run update-catalogs (then re-apply the #2119/#2122/#2123 workarounds — helm upgrade drops the out-of-band init patch!), start a concurrent write churn + read load.
+4. **Phase 4 — observability:** confirm `cqlite_rpc_*` / `cqlite_errors_total` metrics in VictoriaMetrics; the auto-installed "CQLite Flight — RPC Metrics" Grafana dashboard; client→flight→core Tempo traces (queries used `--traceparent`); Trino Pyroscope profiles.
+5. **Phase 5 / teardown:** file any read-phase anomalies; then `$EDB down --auto-approve`. **Cluster is still UP** at handoff — remember to tear it down (real EC2 cost).
+
+### IMPORTANT operational note for re-runs
+Any `helm upgrade` on the trino release (triggered by `update-catalogs.sh` or any
+kit start/stop via the overlay's unfiltered hooks) **drops the out-of-band
+kubectl-patched plugin init container**, crashing the coordinator until the
+plugin patch is re-applied. Until #2119/#2120/#2122/#2123 are fixed in the kit,
+the working manual sequence after any helm upgrade is:
+1. ensure ConfigMap exists (#2120), 2. reapply plugin patch with the jdk25 image
+(#2122), 3. ensure catalog uses `connector.name=cqlite_flight` (#2123),
+4. delete the stale coordinator pod to free hostPort:8080 (#2119).

--- a/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node-round4.md
+++ b/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node-round4.md
@@ -1,0 +1,955 @@
+# Lab Plan: cqlite-flight + Trino Loadtest (3-Node) — ROUND 4
+
+## Round-4 context (read first)
+
+Epic [#2103](https://github.com/pmcfadin/cqlite/issues/2103) is **closed**; this is
+the round-4 verification rerun against the fixes shipped after round 3. The delta
+from round 3:
+
+- **Flight image target: `ghcr.io/pmcfadin/cqlite-flight:dev` @
+  `sha256:50557839b0cae157ae9a84b240ec3f48a571f670efbe9fca61459e1b6e28cfec`**
+  (built from cqlite main @ `7082e2dc`, workflow run 28978849847). Adds the
+  #2162/#2163 observability series, #2193's swallowed-egress-error fix, plus #1849
+  (multi-gen read-time TTL/partition-shadow reconciliation) and #1750 (point-read
+  schema-derived columns). **Round 4 pins this digest in the image reference**
+  (`--tag "dev@sha256:5055…"`, Step 4) so it cannot drift like round-3's moving
+  `:dev` did; still **verify the running pods' digest == `50557839…`.**
+- **Connector `0.13.3`** — unchanged from round 3 (Maven Central).
+- **`trino-cqlite` kit now exposes `--read-mode snapshot|live` + `--local-datacenter`
+  install flags** (PR #2197). Phase 3b live mode is now a reinstall flag, **not** a
+  hand-edit of `trino-catalog.properties` (round-3 §13b hand-edit is retired).
+- **New observability series to check** (#2162/#2163): `cqlite_rpc_rows_total` must
+  climb *mid-query*; `cqlite_rpc_phase_duration_seconds` splits time across
+  `resolve|merge_setup|stream`; `cqlite_merge_rows_in/out`,
+  `cqlite_compaction_tombstones_suppressed/emitted`, `cqlite_read_sstables_pruned`,
+  and the opt-in `cqlite_read_bloom_false_negatives` soak.
+
+### Round-4 verdicts this run must produce
+
+- **#2193** (tiny-table read, `Failed to read message`, error swallowed):
+  re-read a 3-row `nb-big` table. **Success → close #2193.** Failure → the egress
+  error now logs at ERROR server-side (`RUST_LOG=info` suffices) — grab the flight
+  pod's `flight rpc failed` line and paste on #2193; it names the real encode/send
+  cause. Either outcome closes the diagnosis.
+- **#2157** (eager-merge; LIMIT/predicate not honored): `SELECT * LIMIT 5` (expect
+  fast SECONDS, not round-3's 190–433s), `EXPLAIN … WHERE key='<pk>'` (expect
+  populated `filterJson`), `count(*)` (full-scan-bound by design — report
+  wall-clock; verify counters *move* mid-query, not dark until completion).
+- **#2116** (Trino worker CrashLoop on `web-ui.*`) — still upstream/open; the
+  round-3 workaround (strip the two `web-ui.*` lines, `helm upgrade`) is unchanged.
+
+## Goal
+
+Tie epic [#2103](https://github.com/pmcfadin/cqlite/issues/2103)'s four pieces
+(`cqlite-flight`, the `trino-cqlite` connector overlay, `trino-loadtest`, and the
+`cqlite.read-mode` toggle) into one repeatable run: drive real CQL writes into a
+3-node Cassandra 5.0 cluster, flush them to SSTables, read them back through Trino
+via Arrow Flight in both `snapshot` and `live` mode, confirm the observability
+wiring (`cqlite.rpc.*` metrics, client→flight→core traces, Trino CPU/alloc
+profiles), then triage anything broken into filed issues. This is the harness that
+*produces* numbers and bug reports — it is not itself a benchmark-numbers
+deliverable (epic non-goal).
+
+## Environment
+
+- 3 DB nodes: `i4i.xlarge` (local NVMe, no EBS) — Cassandra 5.0 + Sidecar +
+  co-located `cqlite-flight` pod (DaemonSet, one per db node)
+- 1 App node: `m5.xlarge` — Trino coordinator + worker, `trino-loadtest` driver
+  pod, and the `cassandra-easy-stress` K8s jobs
+- Cassandra version: 5.0
+- Trino version: **481** (pinned — see [Phase 0.3](#03-trino-must-be-pinned-to-481-not-the-lab-default-474))
+
+## Prerequisites
+
+Read all four before starting. Each is a verified finding from epic #2103's
+children, not a guess.
+
+### 0.1 The connector must be on Maven Central at the version under test
+
+`trino-cqlite`'s init container resolves the published
+`in.mcfad:cqlite-trino:<version>` artifact from Maven Central at pod-start time
+(no baked image — see `trino-cqlite/README.md` "Approach: init-container, not a
+baked image").
+
+**[UPDATED for round 3]** This plan now pins **`0.13.3`** — it adds predicate
+pushdown (#2166: `applyFilter` translates the TupleDomain summary into a
+non-empty `filterJson` on the ticket) on top of `applyLimit` (0.13.2) and
+`cqlite.read-mode` (0.13.1). `0.13.3` is auto-released on Maven Central. Confirm
+it is resolvable before you start:
+
+```bash
+curl -sf "https://repo1.maven.org/maven2/in/mcfad/cqlite-trino/0.13.3/cqlite-trino-0.13.3.pom" \
+  -o /dev/null && echo "published" || echo "NOT PUBLISHED — stop here"
+```
+
+If it's not resolvable, `easy-db-lab cqlite start`'s init container
+(`cqlite-plugin-fetch`) fails with a Gradle dependency-resolution error
+(`Could not resolve in.mcfad:cqlite-trino:0.13.3`) and this plan cannot proceed
+past Phase 1, step 5.
+
+If it's not published, this plan cannot proceed past Phase 1, step 5 (installing
+the `trino-cqlite` overlay).
+
+### 0.2 Kit install path: `kit source add`, not `--from`
+
+The issue's assumed `easy-db-lab kit install <kit> --from <dir>` syntax does not
+substitute a kit's declared `args:` — verified against `InstallTemplateResolver.kt`
+/ `commands/kit/Install.kt` in the easy-db-lab source. `--from` requires an
+explicit `--kit <name> --size <size>` and calls `renderAndWrite()` with no
+`extraVars`, so only the fixed cluster-level template variables land; every
+kit-declared token (`__TAG__`, `__CONNECTOR_VERSION__`, `__SIDECAR_URI__`, etc.)
+is left unresolved in the written files.
+
+**Use the out-of-tree source registration instead** — it wires args correctly,
+exactly like a built-in kit:
+
+```bash
+easy-db-lab kit source add cqlite /path/to/cqlite/easy-db-lab-kits
+```
+
+Then `easy-db-lab kit install <name> <args...>` for each of the three kits, where
+`<name>` is the **kit's source-directory name** (`cqlite-flight`, `trino-cqlite`,
+`trino-loadtest`) — this is the dispatch key `InstallTemplateResolver.listAvailableTemplates()`
+registers, read from the registered source directory's own subdirectory names.
+
+**Naming subtlety for the `trino-cqlite` overlay** (verified by reading
+`KitInstallCommand.resolveInstanceName()` — not yet confirmed against a live
+run): the *installed output directory* (and therefore the `easy-db-lab <name>
+start/stop` runner and the Trino catalog name) is **not** the dispatch name.
+`resolveInstanceName()` falls back to `config.name` — the kit's own `name:`
+field inside `kit.yaml` — whenever the kit declares no `kit-ref`/extension arg.
+`trino-cqlite/kit.yaml` deliberately sets `name: cqlite` (see its own header
+comment), so:
+
+```bash
+easy-db-lab kit install trino-cqlite --connector-version 0.13.3 --flight-port 8815 \
+  --sidecar-uri "http://$(easy-db-lab ip db0 --private):9043" --trino-image-tag 481
+# ^ dispatch verb "trino-cqlite" (source directory name) ...
+easy-db-lab cqlite start
+# ^ ... but the installed dir / runner / catalog name is "cqlite" (from kit.yaml's name: field)
+```
+
+This is **not** what `trino-cqlite/README.md`'s own "Install order" section shows
+— that section only documents the ad-hoc `--from ... --kit cqlite --size 1Gi`
+fallback (which shares the exact same arg-non-substitution bug §0.2 describes for
+`--from` generally: `__CONNECTOR_VERSION__`, `__SIDECAR_URI__`, etc. would be left
+unresolved literal tokens in the rendered files). Use the `kit source add` form
+above; it is both correct and still lands at `cqlite/`.
+
+### 0.3 Trino must be pinned to 481, not the lab default 474
+
+The `trino` kit's `--version` default is `474` (`kits/trino/kit.yaml`). The
+`cqlite-trino` connector targets Trino SPI `481`
+(`trino-connector/build.gradle.kts`). These are **not** binary-compatible —
+`trino-cqlite/bin/start.sh` reads the running `trino-coordinator`'s live image
+tag and **fails closed** with an explicit remediation message if it isn't `481`:
+
+```
+ERROR: SPI mismatch. trino-coordinator is running image '...:474' (tag '474'),
+but this cqlite-trino connector build targets Trino SPI 481 ...
+```
+
+Install the `trino` kit itself with `--version 481` (see Phase 1, step 3) — this
+overlay cannot rewrite the trino kit's own `values.yaml`.
+
+**[UPDATED after the first live run] Known upstream blocker at 481 — worker
+CrashLoopBackOff (#2116).** The easy-db-lab trino kit's
+`values.yaml.template` puts `web-ui.authentication.type` / `web-ui.user` in
+top-level `additionalConfigProperties`, which the Helm chart renders into
+BOTH coordinator and worker `config.properties`. `web-ui.*` is
+coordinator-only; at Trino 481 workers fail-fast on the unused properties:
+
+```
+ERROR io.trino.server.Server Configuration is invalid
+1) Configuration property 'web-ui.authentication.type' was not used
+```
+
+**Workaround (until fixed upstream — tracked with fix guidance in
+cqlite#2116):** after `trino` kit install, remove the two `web-ui.*` lines
+from the rendered `trino/values.yaml` and re-run the kit's `helm upgrade`
+(web-ui auth is irrelevant to a JDBC load test). Verify both `trino-worker`
+pods reach `Ready` before proceeding to step 4.
+
+### 0.4 Flight kit preflight
+
+**[UPDATED after the first live run]** The first run of this plan hit
+`CreateContainerConfigError` on every `cqlite-flight` pod: `runAsNonRoot: true`
+was set without a numeric `runAsUser`, and the image's `USER flight` directive
+is a name, not a uid, so the kubelet couldn't verify non-root and refused to
+create the container (issue #2118, fixed — the manifest now pins
+`runAsUser: 10001` / `runAsGroup: 10001` explicitly). No command in this plan
+changes; this is now expected to just work.
+
+Before `easy-db-lab cqlite-flight start`:
+
+- **Cassandra data-dir gid**: the published image runs as fixed `uid 10001`; the
+  manifest adds `supplementalGroups: [<data-gid>]` (default `999`, matching the
+  lab's own `cassandra:cassandra` uid/gid convention) so it can read the host
+  data directory read-only. If the host directory isn't group-readable for that
+  gid, pass `--data-gid <actual-gid>` or loosen host permissions. **Not verified
+  live** (`cqlite-flight/README.md` "Open risks" — no cluster was available while
+  authoring the kit) — treat as a FIRST-RUN CHECK.
+- **GHCR image pull**: `ghcr.io/pmcfadin/cqlite-flight:<tag>` is assumed public
+  (no `imagePullSecrets` wired). If it 403s, the image needs to be made public or
+  the DaemonSet needs a pull secret added by hand.
+- **Trino → db-node `:8815` reachability**: the kit runs `hostNetwork: true`, so
+  Flight is reachable at `<db-node-private-ip>:8815` — the same node-IP model the
+  connector's Sidecar-based topology discovery already assumes. Confirm this
+  reaches from an app node before relying on it (FIRST-RUN CHECK):
+  ```bash
+  $EDB exec run -t stress -- bash -c 'echo > /dev/tcp/<db0-private-ip>/8815 && echo OK'
+  ```
+
+---
+
+## Steps
+
+### 1. Create cluster workspace and provision
+
+```bash
+CLUSTER_DIR="clusters/cqlite-flight-r4-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$CLUSTER_DIR"
+bin/create-easy-db-lab-wrapper "$CLUSTER_DIR"
+EDB="$CLUSTER_DIR/easy-db-lab"
+$EDB init cqlite-flight-r4 --db 3 --app 1 \
+  --instance i4i.xlarge --stress-instance m5.xlarge --up
+```
+
+Wait for provisioning and K3s to come up (~5 min). Once `kubeconfig` exists in
+`$CLUSTER_DIR`, export it once so the raw `kubectl`/script invocations used
+throughout this plan (outside `$EDB`, which sets `KUBECONFIG` internally per
+call) target this cluster:
+
+```bash
+export KUBECONFIG="$CLUSTER_DIR/kubeconfig"
+```
+
+### 2. Bring up Cassandra 5.0
+
+```bash
+$EDB cassandra use 5.0
+$EDB cassandra update-config
+$EDB cassandra start
+$EDB cassandra nt status
+```
+
+All 3 nodes must show `UN` (Up/Normal) before continuing. If not, wait 30s and
+retry (`nt status` again).
+
+### 3. Install Trino, pinned to 481 (see [0.3](#03-trino-must-be-pinned-to-481-not-the-lab-default-474))
+
+```bash
+$EDB kit install trino --version 481
+$EDB trino start
+```
+
+Expect 2-3 minutes for the rollout. Verify:
+
+```bash
+$EDB trino status
+```
+
+Coordinator and worker pods must both be Running/Ready.
+
+### 4. Register the kit source and install cqlite-flight
+
+**[UPDATED for round 4]** Pin the moving **`dev`** image channel
+(`ghcr.io/pmcfadin/cqlite-flight:dev`) — round-4 target digest
+**`sha256:50557839b0cae157ae9a84b240ec3f48a571f670efbe9fca61459e1b6e28cfec`**
+(main @ `7082e2dc`). It carries the streaming `do_get` producer (#1476 / PR
+#2176), observability (#2128) plus the new #2162/#2163 series, the LIMIT
+early-stop, and the #2193 swallowed-egress-error fix. A tagged release image
+with these does not exist yet.
+
+**Pin the digest, not the moving `dev` tag.** The daemonset renders
+`ghcr.io/pmcfadin/cqlite-flight:__TAG__`, and OCI accepts the `tag@sha256:` form,
+so passing the digest through `--tag` produces a reference that cannot drift —
+this is the durable fix for round 3's stale-`:dev`-layer regression (no reliance
+on `imagePullPolicy: Always` racing a moving tag):
+
+```bash
+$EDB kit source add cqlite /path/to/cqlite/easy-db-lab-kits
+$EDB kit install cqlite-flight \
+  --tag "dev@sha256:50557839b0cae157ae9a84b240ec3f48a571f670efbe9fca61459e1b6e28cfec" \
+  --flight-port 8815
+$EDB cqlite-flight start
+```
+
+(If a later round targets a fresh build, swap only the digest here. Plain
+`--tag dev` still works but re-introduces the stale-layer risk — don't use it.)
+
+Expected output ends with:
+
+```
+cqlite-flight is ready — Arrow Flight gRPC on <db-node-ip>:8815 (one pod per db node).
+```
+
+Verify one pod per db node:
+
+```bash
+kubectl get pods -l easydblab.com/kit=cqlite-flight -o wide
+```
+
+**[UPDATED for round 4 — DIGEST-PINNED, VERIFY ANYWAY]** Because Step 4 pins the
+digest in the image reference, the kubelet resolves exactly
+`sha256:50557839b0ca…` regardless of where `:dev` currently points — the round-3
+stale-layer failure mode is structurally eliminated. Still **verify** the running
+pods carry that digest (a pre-existing DaemonSet from an earlier install on this
+cluster would need recreating to pick up the new reference):
+
+```bash
+kubectl get pods -l easydblab.com/kit=cqlite-flight \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.status.containerStatuses[0].imageID}{"\n"}{end}'
+kubectl logs -l easydblab.com/kit=cqlite-flight --all-containers --prefix | grep -i observability
+```
+
+The `imageID` must end in
+`50557839b0cae157ae9a84b240ec3f48a571f670efbe9fca61459e1b6e28cfec`. If it does
+NOT (stale pods from a prior install), force recreation and re-verify:
+
+```bash
+kubectl rollout restart daemonset -l easydblab.com/kit=cqlite-flight
+kubectl rollout status  daemonset -l easydblab.com/kit=cqlite-flight --timeout=120s
+```
+
+Do not attribute any #2193/#2157 result to a pod whose digest isn't `50557839…`.
+
+**Multi-disk detection (#2114, new initContainer):** the round-4 flight kit ships
+a non-fatal `detect-multidisk` initContainer. Confirm each pod's decision — the
+only quiet-OK outcome is "exactly one candidate data dir AND it equals the served
+`--data-dir`"; any warning names an unserved disk (never blocks rollout):
+
+```bash
+kubectl logs -l easydblab.com/kit=cqlite-flight -c detect-multidisk --prefix
+```
+
+### 5. Install the trino-cqlite overlay (see [0.2](#02-kit-install-path-kit-source-add-not---from) for the naming subtlety)
+
+**[UPDATED after the first live run]** This step surfaced four bugs, all now
+fixed in the kit — no command below changes, but the *observed* behavior
+during this step does. **[UPDATED after the second live run]** two more bugs
+(#2158, #2159) surfaced on a re-run after #2119's fix proved insufficient —
+see those two entries below, both now fixed:
+
+- **#2120** — `cqlite start` never created the `cqlite-trino-plugin-src`
+  ConfigMap, so both pods sat `Init:0/1` with `FailedMount`. Fixed:
+  `bin/reapply-plugin-patch.sh` now creates/refreshes the ConfigMap before
+  patching either deployment, every time it runs.
+- **#2122** — the plugin-fetch init container's `gradle:9.1.0-jdk21` image
+  couldn't resolve the connector artifact (it requires JDK 25). Fixed: bumped
+  to `gradle:9.1.0-jdk25`.
+- **#2123** — the rendered catalog used `connector.name=cqlite`, but the
+  factory registers `cqlite_flight`, so the coordinator CrashLoopBackOff'd
+  with "No factory for connector 'cqlite'". Fixed: `connector.name=cqlite_flight`
+  (the catalog name stays `cqlite` — `SHOW CATALOGS` / `cqlite.<ks>.<tbl>` are
+  unaffected).
+- **#2119** — patching the coordinator's pod template (to add the plugin
+  initContainer) started a rollout that could never converge on this plan's
+  single app node: the new pod can't bind the coordinator's `hostPort: 8080`
+  while the old one still holds it. First fix attempt: the reapply script
+  deleted the old coordinator pod **only when the patch actually changed
+  something**. **[UPDATED after the second live run]** That delete-pod fix
+  was insufficient — under `strategy: RollingUpdate` the surviving
+  ReplicaSet just recreates the deleted pod and re-grabs `hostPort: 8080`,
+  reproducing the deadlock (**#2158**). The kit now ensures
+  `strategy: Recreate` on `trino-coordinator` before every pod-template patch
+  (`bin/reapply-plugin-patch.sh`), so the controller tears down the old pod
+  before starting the new one. **Expect the `trino-coordinator` pod to be
+  recreated once** during this step on a fresh install — that is now
+  expected, not a hang. This manual workaround is no longer needed:
+  ```bash
+  # no longer required — the kit ensures strategy: Recreate itself
+  kubectl patch deployment trino-coordinator -p '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'
+  ```
+- **#2159** — **[UPDATED after the second live run]** when `cqlite start`
+  aborted on the #2158 deadlock above, the `cqlite` Trino catalog was never
+  registered, because registration relied entirely on the trino kit's
+  `post-workload-start` hook firing on a *clean* completion — a partial
+  failure left `SHOW CATALOGS` without `cqlite` and no automatic recovery
+  path. Fixed: `bin/start.sh` and `bin/verify.sh` both now call
+  `bin/ensure-catalog-registered.sh`, which checks `SHOW CATALOGS` and, if
+  `cqlite` is missing, registers it by invoking the trino kit's own
+  `bin/update-catalogs.sh` directly. The manual recovery recipe from the
+  first live run is no longer needed:
+  ```bash
+  # no longer required — bin/start.sh / bin/verify.sh self-heal this
+  bash trino/bin/update-catalogs.sh
+  ```
+  Re-running `easy-db-lab cqlite start` (or `bin/verify.sh`) alone now
+  recovers a partial failure with no manual steps.
+
+```bash
+DB0_IP=$($EDB ip db0 --private)
+$EDB kit install trino-cqlite --connector-version 0.13.3 --flight-port 8815 \
+  --sidecar-uri "http://${DB0_IP}:9043" --trino-image-tag 481 --read-mode snapshot
+$EDB cqlite start
+```
+
+**[NEW for round 4]** `--read-mode snapshot|live` is now a real install flag
+(PR #2197) — the round-3 hand-edit of `trino-catalog.properties` is retired.
+Phase 3a runs in `snapshot` (above); Phase 3b flips to `live` by **reinstalling
+this overlay** with `--read-mode live` (see [§13b](#13b-run-b--cqliteread-modelive-the-compaction-stress-weak-spot-hunt)).
+
+This fails closed with a clear message if step 3 didn't pin Trino to 481 (see
+[0.3](#03-trino-must-be-pinned-to-481-not-the-lab-default-474)). On success it
+prints:
+
+```
+cqlite plugin loaded into trino-coordinator/trino-worker at
+  /usr/lib/trino/plugin/cqlite_flight
+```
+
+Verify the catalog is registered:
+
+```bash
+"$CLUSTER_DIR/cqlite/bin/verify.sh"
+```
+
+Expected: `SHOW CATALOGS` lists `cqlite`; `SHOW SCHEMAS FROM cqlite` lists at
+least `system` (no user keyspace yet — that comes from Phase 1's stress write).
+
+### 6. Install trino-loadtest
+
+```bash
+$EDB kit install trino-loadtest --target trino
+```
+
+No `start` yet — that's Phase 3.
+
+---
+
+## Phase 1: WRITE
+
+Drive real CQL writes with `cassandra-easy-stress` to produce non-trivial
+SSTable volume — multiple flushes and at least one compaction round is the
+point; a single tiny SSTable makes the connector's merge path uninteresting.
+
+### 7. Start the write load
+
+```bash
+$EDB cassandra stress start --name cqlite-write-baseline --tags "phase=write-baseline" \
+  -- KeyValue -d 15m --threads 50
+```
+
+`stress start` auto-injects `--host <first-cassandra-node-private-ip>` if you
+don't pass one (verified against `StressStart.kt`'s `buildStressArgs`).
+
+### 8. Discover the generated keyspace/table
+
+`cassandra-easy-stress`'s default `KeyValue` workload creates its own
+keyspace/table on first run. **Do not assume a fixed name** — known reference
+material disagrees with itself on the default (`baselines.keyvalue` in one note,
+`cassandra_easy_stress.keyvalue` in the accompanying command in the same
+document). Discover it live instead (FIRST-RUN CHECK):
+
+```bash
+$EDB cassandra stress status
+$EDB cassandra cql "SELECT keyspace_name, table_name FROM system_schema.tables WHERE keyspace_name NOT IN ('system','system_schema','system_auth','system_distributed','system_traces','system_views','system_virtual_schema')"
+```
+
+Set `KEYSPACE`/`TABLE` shell variables from the result for the rest of this
+plan (e.g. `KEYSPACE=baselines`, `TABLE=keyvalue`).
+
+### 8b. Create the tiny 3-row table (#2193 discriminator) — ROUND 4
+
+Round 3's #2193 was found on a 3-row `nb-big` table that read cleanly at the
+SSTable layer but failed `Failed to read message` at the Arrow-encode/Flight-send
+stage, with the server swallowing the error. Round 4 must re-read exactly this
+shape to reach a verdict. Create it in the **same keyspace** the stress workload
+generated (so it shares the served data dir), write 3 rows, and flush so Flight
+sees a single `nb-big` SSTable:
+
+```bash
+$EDB cassandra cql "CREATE TABLE IF NOT EXISTS ${KEYSPACE}.tiny (key text PRIMARY KEY, value text)"
+$EDB cassandra cql "INSERT INTO ${KEYSPACE}.tiny (key, value) VALUES ('1','1')"
+$EDB cassandra cql "INSERT INTO ${KEYSPACE}.tiny (key, value) VALUES ('2','2')"
+$EDB cassandra cql "INSERT INTO ${KEYSPACE}.tiny (key, value) VALUES ('3','3')"
+$EDB cassandra nt flush "$KEYSPACE"
+```
+
+Confirm exactly one `nb-*-big` generation landed for `tiny` (format sanity — the
+#2193 repro is `nb-big` + LZ4, NOT BTI/`da-`):
+
+```bash
+$EDB cassandra cql "SELECT count(*) FROM ${KEYSPACE}.tiny"   # must be 3
+```
+
+### 9. Force multiple SSTable generations during the write
+
+A single end-of-run flush produces one SSTable — not enough to exercise
+compaction. Flush periodically while the write job is still running so STCS
+(default `min_threshold=4`) actually has multiple same-size tables to merge:
+
+```bash
+for i in 1 2 3 4 5; do
+  sleep 120
+  $EDB cassandra nt flush "$KEYSPACE"
+  $EDB cassandra nt compactionstats
+done
+```
+
+Watch `nt compactionstats` for a non-empty pending/active compaction after the
+4th or 5th flush.
+
+### 10. Wait for the write job to finish
+
+```bash
+$EDB cassandra stress status
+```
+
+Wait for `cqlite-write-baseline` to complete (or `stress stop
+cqlite-write-baseline --force` once you have enough data for the run size you
+want — see [Scale notes](#scale-notes)).
+
+---
+
+## Phase 2: FLUSH (mandatory)
+
+The connector only ever sees **flushed** SSTables — memtable rows are invisible
+to Flight until a `nodetool flush`, regardless of read mode. This is not
+optional even if Phase 1's periodic flushes already ran; run one final flush to
+guarantee no unflushed tail:
+
+### 11. Final flush on all db nodes
+
+```bash
+$EDB cassandra nt flush "$KEYSPACE"
+```
+
+Confirm no pending flush work:
+
+```bash
+$EDB cassandra nt tpstats
+```
+
+`FlushWriter`/`MemtablePostFlush` pending should be 0 on all 3 nodes.
+
+---
+
+## Phase 3: READ (two runs)
+
+### 12. Sanity check row count before either run
+
+```bash
+$EDB cassandra cql "SELECT count(*) FROM ${KEYSPACE}.${TABLE}"
+"$CLUSTER_DIR/cqlite/bin/verify.sh" "$KEYSPACE" "$TABLE"
+$EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"
+```
+
+Compare the Cassandra-side CQL count against the `cqlite.${KEYSPACE}.${TABLE}`
+count Trino returns. They must match exactly; a mismatch here is Phase 5's
+"wrong row counts" class before you've even started the concurrent runs.
+
+### 12a. #2193 verdict — tiny-table read (ROUND 4)
+
+Before the latency checks, settle #2193. Round 3: this 3-row `nb-big` read
+succeeded at the SSTable layer then died `Failed to read message` at
+Arrow-encode/Flight-send, **error swallowed server-side**. Round 4's image fixes
+the swallow (errors now log ERROR + count in metrics + propagate as gRPC status)
+and could not reproduce the malformed stream from Rust over real transport — so
+this read either now succeeds or the pod log names the true cause. Either closes
+the diagnosis.
+
+```bash
+# Confirm the tiny table is visible through the connector first
+"$CLUSTER_DIR/cqlite/bin/verify.sh" "$KEYSPACE" tiny
+# The #2193 read itself
+$EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.tiny"
+```
+
+- **3 rows returned → close #2193** (note it in the findings log with the round-4
+  digest).
+- **Still fails** → `RUST_LOG=info` suffices now; grab the flight pod's ERROR line
+  and paste on #2193 — it names the real encode/send cause:
+  ```bash
+  kubectl logs -l easydblab.com/kit=cqlite-flight --all-containers --prefix --since=5m \
+    | grep -iE "flight rpc failed|error|encode|arrow"
+  ```
+
+### 12b. Sanity check row count before either run
+
+```bash
+$EDB cassandra cql "SELECT count(*) FROM ${KEYSPACE}.${TABLE}"
+"$CLUSTER_DIR/cqlite/bin/verify.sh" "$KEYSPACE" "$TABLE"
+$EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"
+```
+
+Compare the Cassandra-side CQL count against the `cqlite.${KEYSPACE}.${TABLE}`
+count Trino returns. They must match exactly; a mismatch here is Phase 5's
+"wrong row counts" class before you've even started the concurrent runs.
+
+**[UPDATED for round 4 — #2157 verdict checks].** Round 3 (streaming `:dev` +
+0.13.3) still measured `LIMIT 5` at **190–433s** with `cqlite_rpc_rows_total`
+never leaving 0 and 100% of time in `do_get` — #2157 was **reopened**. Round 4
+ships the observability that localizes where the time goes (#2162/#2163) and the
+image at digest `50557839…`. Capture these three datapoints and reach the #2157
+verdict:
+
+```bash
+# 1) LIMIT 5 — round 3 was 190–433s; expect low SECONDS (streaming + limit early-stop).
+#    While it runs, in another shell confirm cqlite_rpc_rows_total CLIMBS (Step 14).
+time $EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.${TABLE} LIMIT 5"
+
+# 2) point read — EXPLAIN must show a NON-EMPTY filterJson on the table handle
+#    (round 2: filterJson=Optional.empty → full scan + Trino ScanFilter)
+$EDB trino sql "EXPLAIN SELECT * FROM cqlite.${KEYSPACE}.${TABLE} WHERE key = '<a-real-key>'"
+
+# 3) count(*) — full-scan-bound BY DESIGN (report wall-clock, not pass/fail). The
+#    verdict is behavioral: cqlite_rpc_rows_total climbs mid-query and
+#    cqlite_rpc_phase_duration_seconds splits time across resolve|merge_setup|stream,
+#    instead of going dark until completion.
+time $EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"
+```
+
+If `LIMIT 5` still takes minutes, **first** confirm the flight pods are on digest
+`50557839…` (Step 4) — round 3's regressions repeatedly traced to a stale `:dev`
+layer. If confirmed on the right image and still slow, that is a live #2157
+finding: capture the `cqlite_rpc_phase_duration_seconds` split (which phase holds
+the time) and file per Phase 5. If fast, #2157 is cleared — record the wall-clock.
+
+**[UPDATED after the first live run]** The first run of this plan hit two
+`trino-loadtest` driver bugs before any query was ever issued, both now fixed
+— no command below changes:
+
+- **#2130** — the driver crashed immediately with
+  `ValueError: invalid literal for int() with base 10: 'tcp://10.43.73.27:8080'`.
+  Kubernetes auto-injects Docker-link-style Service env vars into every pod
+  (the Trino Helm chart creates a Service named `trino`, so every pod sees
+  `TRINO_PORT=tcp://<ip>:8080`), and the driver's argparse defaults called
+  `int()` on that at parser-construction time — before `start.sh`'s explicit
+  `--port` flag ever got a chance to win. Fixed: the driver now reads
+  `TRINO_LOADTEST_HOST`/`TRINO_LOADTEST_PORT`/`TRINO_LOADTEST_USER`/
+  `TRINO_LOADTEST_CATALOG` (namespaced, not the Kubernetes-reserved bare
+  names) and falls back to the documented default instead of raising on any
+  unparseable numeric env value.
+- **#2132** — with no `--queries-file` passed (the normal case for this
+  plan's built-in query set), `start.sh` failed before the pod was even
+  created: `error: error reading null: no such file or directory` /
+  `error: no objects passed to apply`. The easy-db-lab kit runner injects the
+  literal string `null` for an unset optional arg rather than leaving it
+  empty, and `[ -n "$VAR" ]` alone is true for `"null"`. Fixed: `start.sh`
+  now also rejects the literal `"null"` before treating the var as set. **The
+  loadtest start below no longer needs a `--queries-file` workaround** —
+  omitting it (as both runs in this plan do) now correctly falls through to
+  the built-in scan+aggregate query set.
+
+### 13a. Run (a) — default `snapshot` mode: correctness/consistency run
+
+`cqlite.read-mode` defaults to `snapshot` — no catalog edit needed for this run.
+
+```bash
+$EDB trino-loadtest-trino start --ks "$KEYSPACE" --tbl "$TABLE" \
+  --threads 8 --duration 120 --traceparent
+```
+
+While this runs, in a second terminal, watch for the per-query Sidecar snapshot
+appearing and disappearing (FIRST-RUN CHECK — exact timing/overlap not verified
+live; queries loop continuously for the whole `--duration`, so a snapshot may or
+may not be visible in any single poll):
+
+```bash
+watch -n2 "$EDB cassandra nt listsnapshots"
+```
+
+Expect entries named `cqlite-<queryId>` to appear transiently and be gone by the
+time `trino-loadtest-trino start` exits.
+
+```bash
+$EDB trino-loadtest-trino stop
+```
+
+### 13b. Run (b) — `cqlite.read-mode=live`: the compaction-stress weak-spot hunt
+
+**[UPDATED for round 4]** `--read-mode` is now a real install flag (PR #2197).
+Flip to `live` by **reinstalling the overlay** — no catalog hand-edit:
+
+```bash
+$EDB kit install trino-cqlite --connector-version 0.13.3 --flight-port 8815 \
+  --sidecar-uri "http://${DB0_IP}:9043" --trino-image-tag 481 --read-mode live
+$EDB cqlite start
+# confirm the rendered catalog took the flag
+grep cqlite.read-mode "$CLUSTER_DIR/cqlite/trino-catalog.properties"   # → cqlite.read-mode=live
+```
+
+Now start a **second, concurrent** write load — the actual point of `live`
+mode is racing compaction against an in-flight scan — and the read load
+together, so the read window fully overlaps ongoing flush/compaction:
+
+```bash
+$EDB cassandra stress start --name cqlite-live-churn --tags "phase=live-hunt" \
+  -- KeyValue -d 10m --threads 20
+$EDB trino-loadtest-trino start --ks "$KEYSPACE" --tbl "$TABLE" \
+  --threads 16 --duration 300 --traceparent
+```
+
+Force a few more flushes mid-run to keep compaction pressure up while the read
+load is active:
+
+```bash
+for i in 1 2 3; do sleep 60; $EDB cassandra nt flush "$KEYSPACE"; done
+```
+
+```bash
+$EDB trino-loadtest-trino stop
+$EDB cassandra stress stop cqlite-live-churn --force
+```
+
+Revert to `snapshot` mode afterward if you plan to re-run Phase 3a — reinstall
+with `--read-mode snapshot` (the round-3 `sed` hand-edit is retired):
+
+```bash
+$EDB kit install trino-cqlite --connector-version 0.13.3 --flight-port 8815 \
+  --sidecar-uri "http://${DB0_IP}:9043" --trino-image-tag 481 --read-mode snapshot
+$EDB cqlite start
+```
+
+---
+
+## Phase 4: OBSERVE / VERIFY
+
+**[UPDATED after the first live run]** The first run of this plan found **zero**
+`cqlite.rpc.*`/`cqlite_rpc_*` series in VictoriaMetrics and no flight traces in
+Tempo, despite a correct pod env (`CQLITE_OTEL_ENABLED=true`,
+`CQLITE_OTEL_ENDPOINT=http://localhost:4317` reachable) and no export errors in
+the flight log — **root cause: #2128**, the published `cqlite-flight` image was
+built without `--features observability`, so all the OTLP metric/trace code was
+compiled out and the env vars were silently inert. Fixed:
+`cqlite-flight/Dockerfile` now builds with `--features observability`.
+**The observability check below now expects an extra startup log line** —
+confirm it's present before checking VictoriaMetrics/Tempo (FIRST-RUN CHECK,
+not yet verified against a live cluster):
+
+```bash
+kubectl logs -l easydblab.com/kit=cqlite-flight --all-containers --prefix | grep -i observability
+```
+
+Expect one `observability enabled, exporting to OTLP endpoint` info line per
+pod, naming `endpoint=http://localhost:4317`. (If the image were ever
+published again without the feature, the fix also makes that case visible
+instead of silent: a `WARN` line stating the binary was compiled without
+`observability` and that `CQLITE_OTEL_*` vars are inert.)
+
+### 14. Confirm `cqlite.rpc.*` metric names in VictoriaMetrics (FIRST-RUN CHECK)
+
+The OTel collector mangles cqlite-core's dotted metric names
+(`cqlite.rpc.requests`, etc.) into Prometheus-style names. Confirm the exact
+mangled form live rather than assuming it:
+
+```bash
+source "$CLUSTER_DIR/env.sh"
+with-proxy curl -s "http://control0:8428/api/v1/label/__name__/values" | grep cqlite_rpc
+```
+
+Expected names (per `cqlite-flight/dashboards/cqlite-flight.json`'s panel
+queries): `cqlite_rpc_requests_total`, `cqlite_rpc_duration_seconds_bucket` (+
+`_sum`/`_count`), `cqlite_rpc_rows_total`, `cqlite_rpc_bytes_total`,
+`cqlite_rpc_in_flight`, and `cqlite_errors_total` (label
+`cqlite_subsystem="flight"`).
+
+### 14b. Confirm the NEW #2162/#2163 series and mid-query movement (ROUND 4)
+
+Round 3's core finding was that during a 190–433s `do_get`, `cqlite_rpc_rows_total`
+never left 0 and no internal series moved — the query was dark until completion.
+Round 4 adds series that must **move mid-query** and localize where time goes.
+Confirm the names exist, then watch them during a long scan (e.g. the `count(*)`
+from Step 12b) in a second shell:
+
+```bash
+source "$CLUSTER_DIR/env.sh"
+# #2162 — per-record-batch rows/bytes + phase timer
+with-proxy curl -s "http://control0:8428/api/v1/label/__name__/values" \
+  | grep -E "cqlite_rpc_rows_total|cqlite_rpc_bytes_total|cqlite_rpc_phase_duration_seconds"
+# #2163 — reconciliation / prune / degraded-path correctness signals
+with-proxy curl -s "http://control0:8428/api/v1/label/__name__/values" \
+  | grep -E "cqlite_merge_rows_(in|out)|cqlite_compaction_tombstones_(suppressed|emitted)|cqlite_read_sstables_pruned|cqlite_query_degraded_path_total"
+```
+
+During the Step 12b `count(*)`, in a second shell watch these climb (proves
+streaming, not dark-until-done) and localize the time:
+
+```bash
+watch -n2 'source "$CLUSTER_DIR/env.sh"; \
+  with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_rpc_rows_total" | jq -r ".data.result[].value[1]"; \
+  echo "--- phase durations ---"; \
+  with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_rpc_phase_duration_seconds_sum" | jq -r ".data.result[] | \"\(.metric.phase)=\(.value[1])\""'
+```
+
+Verdict: `cqlite_rpc_rows_total` **must be non-zero and climbing** while the query
+is in flight, and `cqlite_rpc_phase_duration_seconds` must attribute the time to
+`resolve|merge_setup|stream`. A stall with all time in one phase and zero rows is
+the round-3 symptom persisting — capture and file per Phase 5.
+
+Post-compaction (after Phase 3b's forced flushes/compaction), check the
+reconciliation deltas are sane:
+
+```bash
+source "$CLUSTER_DIR/env.sh"
+with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_merge_rows_in" | jq -r ".data.result[].value[1]"
+with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_merge_rows_out" | jq -r ".data.result[].value[1]"
+with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_compaction_tombstones_suppressed" | jq -r ".data.result[].value[1]"
+```
+
+### 14c. Presence-oracle soak (OPT-IN, P0-if-nonzero) — ROUND 4
+
+`cqlite_read_bloom_false_negatives` is off by default. To run the correctness
+soak, set `CQLITE_VERIFY_PRESENCE_ORACLE=1` on **one** flight pod (authoritative
+re-scan of every presence-oracle negative incl. prune + reverse paths — expensive,
+one pod only) and drive read load against it:
+
+```bash
+POD=$(kubectl get pods -l easydblab.com/kit=cqlite-flight -o name | head -1)
+kubectl set env "$POD" CQLITE_VERIFY_PRESENCE_ORACLE=1   # restarts that one pod
+# ... drive a Phase 3 read run, then:
+with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_read_bloom_false_negatives" | jq -r ".data.result[].value[1]"
+```
+
+**Any `cqlite_read_bloom_false_negatives` > 0 is a P0 finding — report on the
+epic immediately** (a presence oracle returning a false negative means a live row
+was silently skipped). Zero across the soak is the pass condition.
+
+### 15. Confirm the Grafana dashboard populates
+
+`cqlite-flight/dashboards/cqlite-flight.json` auto-installs into Grafana on the
+DaemonSet's own `start` (kit contract: "any `.json` files in `dashboards/` are
+installed automatically" — `docs/development/kits.md`). Open Grafana:
+
+```
+http://<control-node-private-ip>:3000
+```
+
+(get the IP from `$CLUSTER_DIR/state.json`, or via SOCKS proxy per
+`docs/user-guide/victoria-metrics.md`). Open **CQLite Flight — RPC Metrics**:
+
+- Set `$cluster` to this cluster's name.
+- Set `$service_name` — the dashboard's templating variable is
+  `label_values(cqlite_rpc_requests_total, service_name)`; the flight
+  DaemonSet's default is `CQLITE_OTEL_SERVICE_NAME=cqlite-flight`
+  (`cqlite-flight/daemonset.yaml`), so pick `cqlite-flight` unless the kit was
+  installed with a custom `--otel-endpoint`/env override.
+- Confirm all 5 panel rows populate during the Phase 3 runs: Request Rate,
+  Latency (p50/p95/p99), Rows & Bytes Streamed, In-Flight Requests, Errors.
+
+### 16. Confirm client → Flight → core traces in Tempo (FIRST-RUN CHECK)
+
+Both Phase 3 runs used `--traceparent`, so every query carried a W3C
+traceparent header. From a panel with a data point during a Phase 3 window,
+use the panel's built-in "View Trace" link (wired in
+`cqlite-flight.json` to a Tempo TraceQL query
+`{ resource.service.name = "$service_name" && span.rpc.method =
+"$__field.labels.cqlite_rpc_method" }`), or query Tempo directly in Grafana
+Explore with the same TraceQL. Confirm:
+
+- A trace exists spanning client (Trino) → `cqlite-flight` → `cqlite-core`.
+- `span.rpc.method` is a filterable span attribute (the TraceQL query above
+  depends on it) — not yet confirmed against a live Tempo instance.
+
+### 17. Confirm Trino CPU/alloc in Pyroscope
+
+The `trino` kit already wires the Pyroscope Java agent
+(`kits/trino/bin/start.sh.template`): `-Dpyroscope.application.name=trino`,
+`-Dpyroscope.profiler.event=cpu`, `-Dpyroscope.profiler.alloc=512k`, labeled
+`component=coordinator`/`component=worker`. In Grafana Explore:
+
+- Datasource: **Pyroscope**.
+- `service_name = trino`, filter `component=coordinator` and
+  `component=worker` separately.
+- Profile types `process_cpu` (cpu) and `memory`/`alloc` (allocation) should
+  show load concentrated in the `cqlite_flight` plugin's JDBC/RecordCursor
+  path during Phase 3, not idle/GC-only stacks.
+
+### 18. Confirm snapshot lifecycle cleanup
+
+```bash
+$EDB cassandra nt listsnapshots
+```
+
+Expected: empty (or only unrelated snapshots) once both Phase 3 runs have fully
+stopped — every `cqlite-<queryId>` snapshot created during Run (a) should have
+been deleted by Trino's `cleanupQuery` hook. A non-empty, growing list of
+`cqlite-*` snapshots after the runs stop is itself a Phase 5 "wrong row
+counts"/leak-class finding (a crashed coordinator mid-query, or a
+`cleanupQuery` bug) — capture the list and file it.
+
+### 19. Tear down
+
+```bash
+$EDB trino-loadtest-trino stop
+$EDB cassandra stress stop --all --force
+$EDB cqlite uninstall
+$EDB cqlite-flight stop
+$EDB trino stop
+$EDB cassandra stop
+$EDB down --auto-approve
+```
+
+---
+
+## Phase 5: FAILURE TRIAGE → ACTIONABLE ISSUES
+
+This is the epic's actual outcome: every anomaly found in Phases 3-4 becomes a
+filed, reproducible GitHub issue — not a note left in a run log. **File under
+labels `bug` + `performance`** (both exist in this repo today), referencing
+epic #2103. Per this repo's doctrine (`CLAUDE.md` "Spec-driven work"): these are
+**oracle-driven parity/correctness bugs against a real Cassandra cluster** — file
+as a plain GitHub issue + a pinned reproduction (the captured artifacts below),
+**not** an OpenSpec change.
+
+| Failure class | Symptom / trigger | Data to capture | The filed issue must contain |
+|---|---|---|---|
+| **Flight `do_get` errors/panics under live-mode compaction races** | Run (b): errors or connection resets during a scan that overlaps a forced flush/compaction | `kubectl logs -l easydblab.com/kit=cqlite-flight --all-containers --prefix --since=30m` from the affected db node's pod; `cqlite_errors_total` broken down `by (cqlite_error_category)` for the failure window; the Tempo trace for the failed query; the exact Flight ticket JSON (`snapshot` field value, table, projection) from the query's `EXPLAIN`/coordinator log | Repro steps (this plan's Phase 1+3b exactly), the pod logs, the ticket JSON, the error-category breakdown, and whether it reproduces in `snapshot` mode (if not, it's a live-mode-specific race) |
+| **Latency cliffs** | p99 (or p50) duration jumps during a flush/compaction window in the Grafana Latency panel | The `cqlite_rpc_duration_seconds_bucket` histogram for before/during/after the cliff; the Pyroscope CPU flame graph for the `cqlite-flight` pod (or Trino worker) during the same window | The duration histogram screenshot/query, the flame graph, and the wall-clock window correlated against `nt compactionstats`/flush timestamps |
+| **Wrong row counts: snapshot vs live vs Cassandra `COUNT(*)`** | Step 12/18's count comparison disagrees between `snapshot` mode, `live` mode, and `nodetool`-level CQL `SELECT count(*)` | The exact SSTable file set at the time of the mismatch (`nodetool listsnapshots` + `ls` of the data dir on the affected node), the snapshot name used (if any), and the full query text | Which of the three counts disagreed and by how much, the captured SSTable set, and whether the gap is present in `snapshot` mode alone (data bug) or only in `live` mode (race, not a data bug) |
+| **gRPC/Flight stream resets** | Client (Trino) or `trino-loadtest` driver logs a connection reset / stream abort mid-scan | `kubectl logs` from both the Trino worker pod and the affected `cqlite-flight` pod for the same time window; `cqlite_rpc_in_flight` around the reset; whether `--traceparent` produced a partial trace (truncated span) | Both pods' logs side by side, the in-flight gauge graph, and the partial trace if present |
+| **OOM / memory growth of the flight DaemonSet** | `kubectl top pod -l easydblab.com/kit=cqlite-flight` shows unbounded growth over the run, or a pod restarts | `kubectl top pod -l easydblab.com/kit=cqlite-flight` sampled every few minutes across the whole run; `kubectl get pods -l easydblab.com/kit=cqlite-flight -o jsonpath='{.items[*].status.containerStatuses[*].restartCount}'`; Pyroscope `alloc` flame graph for the pod over the same window | The memory-over-time samples, restart counts, and the allocation flame graph pointing at the hot allocation site |
+| **Trino worker errors** (query failures not attributable to Flight) | A query fails with a Trino-side stack trace, no corresponding `cqlite_errors_total` increment | `kubectl logs deployment/trino-coordinator` and `deployment/trino-worker` for the failure window; the failing query text; whether the SPI-mismatch guard (0.3) is actually the cause before filing as a connector bug | Coordinator + worker logs, the query, and explicit confirmation the SPI/version pin (0.3) was not the actual cause |
+
+---
+
+## Scale notes
+
+| Parameter | 3-node baseline (this plan) | Bigger run |
+|---|---|---|
+| DB nodes | 3 × `i4i.xlarge` | 6-9 × `i4i.xlarge` (proportionally more SSTables/node) |
+| App nodes | 1 × `m5.xlarge` | 2-3 × `m5.xlarge` (more Trino workers — `install trino --workers N`) |
+| Phase 1 write threads/duration | `--threads 50 -d 15m` | `--threads 200 -d 1h`+ |
+| Phase 1 periodic flush interval | every 120s × 5 | every 60s for the full duration, or drop `min_compaction_threshold` via `cassandra.patch.yaml` to force compaction sooner |
+| Phase 3b concurrent write threads/duration | `--threads 20 -d 10m` | `--threads 100 -d 30m`+ (heavier churn under the read load) |
+| Phase 3 read threads/duration | `--threads 8-16`, `120s`/`300s` | `--threads 32-64`, `600s`+ |
+| trino-loadtest query mix | built-in default (2 `LIMIT` scans + `COUNT(*)`) | `--queries-file` with representative production-shaped queries |
+
+## Validation Checklist
+
+- [ ] Maven Central has `in.mcfad:cqlite-trino` at the version under test (0.1)
+- [ ] `easy-db-lab kit source add` + named `kit install` used for all three kits, not `--from` (0.2)
+- [ ] `trino` kit installed with `--version 481`; `trino-cqlite/bin/start.sh`'s SPI check passes (0.3)
+- [ ] `cqlite-flight` DaemonSet: one Running pod per db node, **image digest == `50557839…`** (Step 4)
+- [ ] `detect-multidisk` initContainer decision reviewed on every pod (Step 4)
+- [ ] `cqlite` catalog visible via `$CLUSTER_DIR/cqlite/bin/verify.sh` with no keyspace/table args
+- [ ] **#2193 verdict reached**: `SELECT * FROM cqlite.<ks>.tiny` either returns 3 rows (close #2193) or the flight pod ERROR line is captured and pasted on #2193 (Step 12a)
+- [ ] Phase 1 write produces ≥5 flushed SSTables and at least one compaction (`nt compactionstats` shows activity)
+- [ ] Phase 2 final flush leaves 0 pending `FlushWriter`/`MemtablePostFlush` tasks
+- [ ] **#2157 verdict reached**: `LIMIT 5` wall-clock recorded (fast = cleared, slow-on-`50557839…` = filed), `EXPLAIN` shows non-empty `filterJson`, `count(*)` wall-clock recorded (Step 12b)
+- [ ] Phase 3a (snapshot) row count matches Cassandra's own `SELECT count(*)` exactly
+- [ ] Phase 3b (live) installed via `--read-mode live` reinstall; completes without a fail-closed connector error (or, if it errors, it's filed per Phase 5)
+- [ ] `cqlite_rpc_*` / `cqlite_errors_total` metric names confirmed live in VictoriaMetrics
+- [ ] **NEW #2162/#2163 series confirmed** and `cqlite_rpc_rows_total` climbs mid-query; `cqlite_rpc_phase_duration_seconds` splits `resolve/merge_setup/stream` (Step 14b)
+- [ ] Presence-oracle soak (opt-in): `cqlite_read_bloom_false_negatives == 0` (any >0 reported P0 immediately) (Step 14c)
+- [ ] CQLite Flight — RPC Metrics dashboard panels populate for both Phase 3 runs
+- [ ] A Tempo trace exists spanning client → flight → core for at least one traced query
+- [ ] Trino CPU/alloc visible in Pyroscope under `service_name=trino`
+- [ ] `nodetool listsnapshots` is empty of `cqlite-*` entries after both Phase 3 runs stop
+- [ ] Every anomaly from Phase 3/4 has either a filed `bug`+`performance` issue or an explicit "not reproducible" note
+
+## Notes
+
+- Never overwrite `cassandra.patch.yaml`; `cassandra use 5.0` generates it with
+  the required snitch/data-dir settings.
+- `stress start` requires `--` before workload args when passing `--name`/`--tags`:
+  `stress start --name foo --tags "k=v" -- KeyValue -d 5m --threads 50`.
+- The `trino-cqlite` overlay's `post-workload-start`/`post-workload-stop` hooks
+  fire on **any** kit start/stop (unfiltered — matches the trino kit's own
+  Pyroscope re-patch behavior) and re-run `bin/reapply-plugin-patch.sh`. This is
+  cheap and idempotent; don't be surprised to see it fire during Phase 1/3 stress
+  job starts/stops.
+- If `cassandra cql` returns `No node was available` despite `nt status` showing
+  all nodes `UN`, the Sidecar needs more time — wait 30s and retry.

--- a/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node-round5.md
+++ b/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node-round5.md
@@ -1,0 +1,776 @@
+# Lab Plan: cqlite-flight + Trino Loadtest (3-Node) — ROUND 5
+
+## Round-5 context (read first)
+
+This is the **first field run of the post-#2227 build** — the multi-node snapshot
+fix. It is the epic-AM Wave-0 field validation and is coordinated on **cqlite
+epic [#2286](https://github.com/pmcfadin/cqlite/issues/2286)** (single source of
+truth for round-5 assets + per-issue verdict checklist). **Post ALL round-5
+results as comments on #2286**; per-issue detail may additionally go on the issue
+it adjudicates. easy-db-lab-side defects are **comment-only upstream** on
+`rustyrazorblade/easy-db-lab` (never fixed in the cqlite tree; standing owner rule).
+
+### Pinned assets (authoritative — do not run with anything else, per #2286)
+
+| Artifact | Value |
+|---|---|
+| cqlite-flight image | `ghcr.io/pmcfadin/cqlite-flight:dev` @ **`sha256:289f97e0ec07d9f7fb41efd6bcd8d9b9210ba3cca2584ced02302b9d86bb7ce1`** (multi-arch amd64+arm64, built from main @ `19b32461`, run 29036815987) |
+| Trino connector | **`in.mcfad:cqlite-trino:0.13.4`** (Maven Central — verified published) |
+| Kit | easy-db-lab kit with `--read-mode` flag |
+| Cluster shape | 3× `i4i.xlarge` db + 1× `m5.xlarge` app, Cassandra 5.0.x, nb-big/LZ4 |
+
+### What this build contains (vs round-4's `50557839…`, which predated ALL of it)
+
+- **Flight/Rust:** #2264 (cancellation-aware backpressure — the LIMIT-hang fix),
+  #2228 (full-ring token semantic), #2240, #2193 error surfacing.
+- **Connector/Java (0.13.4 vs 0.13.3):** #2227 (per-replica-host snapshots — the
+  multi-node snapshot blocker), #2228 (Java side), #2229 (hide+warn + TIME),
+  #2236, #2238, #2239, #2241 (split replica failover).
+
+All of #2227, #2228, #2229, #2241, #2264 are **CLOSED** upstream — this run
+adjudicates them in the field.
+
+### Round-5 delta from round 4 (why the round-4 verdicts flipped)
+
+Round 4 (`50557839…` + 0.13.3) found:
+- **#2157** LIMIT scans hung → ABANDONED (418s), `in_flight` gauge stuck at 8 —
+  this is exactly the parked-`blocking_send`-on-cancel bug **#2264** now claims to
+  fix. Round 5 must confirm LIMIT returns in **seconds**.
+- **#2193** tiny `nb-big` read → `Failed to read message`, no ERROR log, no
+  `cqlite_errors_total`. Round 5's #2193 error-surfacing must make the failure
+  *loud* if it still reproduces.
+- **#2227** was never field-tested (round 4's read path was too broken to reach
+  it). Round 5 is its first multi-node validation.
+
+### Round-5 verdict checklist (mirrors #2286 — fill and post to #2286)
+
+- [ ] **#2157 (LIMIT runtime):** `LIMIT 5` returns promptly (seconds, not
+  ABANDONED). PASS → close #2157. FAIL → capture `cqlite_rpc_in_flight` /
+  `cqlite_rpc_in_flight_ratio` + phase metrics during the hang; #2264's fix needs
+  field escalation.
+- [ ] **#2193 (tiny decode):** `SELECT * FROM cqlite.<ks>.tiny` returns 3 rows.
+  PASS → close #2193. FAIL → offline framing already ruled out (Phase-1 oracle,
+  PR #2284); capture the Trino-runtime arrow-java version (coordinator classpath)
+  + a client-side stack trace + the flight pod ERROR line.
+- [ ] **#2227 (default snapshot multi-node):** default-mode queries succeed across
+  all 3 replicas' splits (splits land on hosts other than the configured
+  Sidecar's node). Epic-AM Wave-0 field validation.
+- [ ] **#2228 (full-range SELECT \*):** full-range `SELECT *` returns complete
+  counts (no silent 0-row).
+- [ ] **#2229 (unsupported column):** a table with an unsupported column serves
+  its supported columns + warns (not table-poisoned). Includes a CQL `TIME`
+  column mapping check.
+- [ ] **#2241 (split replica failover):** one query against a killed flight pod
+  succeeds via fallback; loud failure only if all replicas down.
+- [ ] **Metrics sanity:** `cqlite_rpc_in_flight` returns to 0 after each query
+  (the #2264 gauge-leak signature is gone). `cqlite_errors_total` may legitimately
+  be absent until the first error (lazy registration — an open Phase-4 item on
+  #2193).
+
+## Goal
+
+Same harness intent as rounds 1–4: drive real CQL writes into a 3-node
+Cassandra 5.0 cluster, flush to SSTables, read back through Trino via Arrow
+Flight in both `snapshot` and `live` mode, confirm observability wiring, and
+triage anything broken into issues on #2286. This is the harness that *produces*
+bug reports — not itself a benchmark deliverable (epic non-goal).
+
+## Environment
+
+- 3 DB nodes: `i4i.xlarge` (local NVMe, no EBS) — Cassandra 5.0 + Sidecar +
+  co-located `cqlite-flight` pod (DaemonSet, one per db node)
+- 1 App node: `m5.xlarge` — Trino coordinator + worker, `trino-loadtest` driver
+  pod, and the `cassandra-easy-stress` K8s jobs
+- Cassandra version: 5.0
+- Trino version: **481** (pinned — see [0.3](#03-trino-must-be-pinned-to-481-not-the-lab-default-474))
+
+## Prerequisites
+
+Read all before starting. Each is a verified finding from prior rounds, not a guess.
+
+### 0.1 The connector must be on Maven Central at the version under test
+
+`trino-cqlite`'s init container resolves the published
+`in.mcfad:cqlite-trino:<version>` artifact from Maven Central at pod-start time.
+Round 5 pins **`0.13.4`** (adds #2227 per-replica-host snapshots, #2229 hide+warn
++ TIME, #2241 split replica failover on top of round-4's 0.13.3). Confirm it is
+resolvable before you start (already verified once during planning — re-confirm
+at run time):
+
+```bash
+curl -sf "https://repo1.maven.org/maven2/in/mcfad/cqlite-trino/0.13.4/cqlite-trino-0.13.4.pom" \
+  -o /dev/null && echo "published" || echo "NOT PUBLISHED — stop here"
+```
+
+If it's not resolvable, `easy-db-lab cqlite start`'s init container
+(`cqlite-plugin-fetch`) fails with `Could not resolve in.mcfad:cqlite-trino:0.13.4`
+and this plan cannot proceed past step 5.
+
+### 0.2 Kit install path: `kit source add`, not `--from`
+
+Unchanged from round 4. `--from` does not substitute a kit's declared `args:`
+(verified against `InstallTemplateResolver.kt` / `commands/kit/Install.kt`). Use
+out-of-tree source registration, which wires args correctly like a built-in kit:
+
+```bash
+easy-db-lab kit source add cqlite /path/to/cqlite/easy-db-lab-kits
+```
+
+Then `easy-db-lab kit install <name> <args...>` per kit, where `<name>` is the
+kit's **source-directory name** (`cqlite-flight`, `trino-cqlite`,
+`trino-loadtest`).
+
+**Naming subtlety for the `trino-cqlite` overlay:** `resolveInstanceName()` falls
+back to the kit's own `name:` field in `kit.yaml`, and `trino-cqlite/kit.yaml`
+sets `name: cqlite`. So the *dispatch verb* is `trino-cqlite` but the *installed
+dir / runner / catalog name* is `cqlite`:
+
+```bash
+easy-db-lab kit install trino-cqlite --connector-version 0.13.4 ...   # dispatch verb
+easy-db-lab cqlite start                                              # runner/catalog name
+```
+
+### 0.3 Trino must be pinned to 481, not the lab default 474
+
+Unchanged from round 4. The `cqlite-trino` connector targets Trino SPI **481**;
+`trino-cqlite/bin/start.sh` fails closed if the running coordinator isn't 481.
+Install the `trino` kit with `--version 481` (step 3).
+
+**Known upstream blocker at 481 — worker CrashLoopBackOff (#2116, still open).**
+The trino kit's `values.yaml.template` puts `web-ui.*` in top-level
+`additionalConfigProperties`, which the Helm chart renders into BOTH coordinator
+and worker `config.properties`; `web-ui.*` is coordinator-only, so 481 workers
+fail-fast. **Workaround:** after `trino` kit install, remove the two `web-ui.*`
+lines from the rendered `trino/values.yaml`, re-run the kit's `helm upgrade`, and
+verify both `trino-worker` pods reach `Ready` before step 4.
+
+### 0.4 Flight kit preflight
+
+Unchanged from round 4 (all previously-hit bugs — #2118 non-root uid,
+`CreateContainerConfigError` — are fixed). First-run checks that still matter:
+
+- **Cassandra data-dir gid:** image runs as fixed `uid 10001`; manifest adds
+  `supplementalGroups: [<data-gid>]` (default `999`). If the host data dir isn't
+  group-readable for that gid, pass `--data-gid <actual-gid>`.
+- **GHCR image pull:** `ghcr.io/pmcfadin/cqlite-flight:dev` is public. If it 403s,
+  the image needs a pull secret.
+- **Trino → db-node `:8815` reachability** (`hostNetwork: true`) — confirm from an
+  app node before relying on it:
+  ```bash
+  $EDB exec run -t stress -- bash -c 'echo > /dev/tcp/<db0-private-ip>/8815 && echo OK'
+  ```
+
+### 0.5 SOCKS proxy for kit commands (harness environment)
+
+Non-tailscale clusters reach the K8s API over a SOCKS proxy on `localhost:1080`.
+**`easy-db-lab trino start` and all kit `helm`/`kubectl` commands fail with
+"kubernetes cluster unreachable" unless these are exported** in the shell:
+
+```bash
+export ALL_PROXY=socks5h://localhost:1080
+export HTTPS_PROXY=socks5h://localhost:1080
+export HTTP_PROXY=socks5h://localhost:1080
+```
+
+SSH-based `cassandra` commands work *without* them. This was round-4 harness
+observation #735/#736. **PR #737 (branch `fix/735-jdbc-socks-proxy`) routes the
+`<kit> sql` JDBC path through SOCKS.** If #737 has NOT merged by run time,
+`trino sql` still needs:
+
+```bash
+export JAVA_TOOL_OPTIONS="-DsocksProxyHost=localhost -DsocksProxyPort=1080 -DsocksProxyVersion=5"
+```
+
+Check whether #737 merged (`gh pr view 737 --repo rustyrazorblade/easy-db-lab
+--json state`); if merged and this cluster is provisioned from the merged build,
+drop the `JAVA_TOOL_OPTIONS` workaround and confirm `trino sql` works without it
+(that confirmation is itself a #737 field-validation datapoint worth noting).
+
+---
+
+## Steps
+
+### 1. Create cluster workspace and provision
+
+```bash
+CLUSTER_DIR="clusters/cqlite-flight-r5-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$CLUSTER_DIR"
+bin/create-easy-db-lab-wrapper "$CLUSTER_DIR"
+EDB="$CLUSTER_DIR/easy-db-lab"
+$EDB init cqlite-flight-r5 --db 3 --app 1 \
+  --instance i4i.xlarge --stress-instance m5.xlarge --up
+```
+
+Wait for provisioning + K3s (~5 min). Once `kubeconfig` exists, export it so raw
+`kubectl`/script invocations target this cluster, and export the SOCKS vars (0.5):
+
+```bash
+export KUBECONFIG="$CLUSTER_DIR/kubeconfig"
+export ALL_PROXY=socks5h://localhost:1080 HTTPS_PROXY=socks5h://localhost:1080 HTTP_PROXY=socks5h://localhost:1080
+```
+
+### 2. Bring up Cassandra 5.0
+
+```bash
+$EDB cassandra use 5.0
+$EDB cassandra update-config
+$EDB cassandra start
+$EDB cassandra nt status
+```
+
+All 3 nodes must show `UN` before continuing. **Confirm RF will exceed 1** — #2227
+is only exercised when splits fan out to replica hosts other than the Sidecar's
+node, which requires RF ≥ 2 (the default stress keyspace uses RF depending on the
+workload; verify after Phase 1, step 8b).
+
+### 3. Install Trino, pinned to 481 (see [0.3](#03-trino-must-be-pinned-to-481-not-the-lab-default-474))
+
+```bash
+$EDB kit install trino --version 481
+$EDB trino start
+$EDB trino status
+```
+
+Apply the #2116 `web-ui.*` workaround (0.3) and confirm both worker pods reach
+`Ready` before proceeding.
+
+### 4. Register the kit source and install cqlite-flight (DIGEST-PINNED)
+
+Pin the digest, not the moving `dev` tag — OCI accepts the `tag@sha256:` form, so
+this reference cannot drift:
+
+```bash
+$EDB kit source add cqlite /path/to/cqlite/easy-db-lab-kits
+$EDB kit install cqlite-flight \
+  --tag "dev@sha256:289f97e0ec07d9f7fb41efd6bcd8d9b9210ba3cca2584ced02302b9d86bb7ce1" \
+  --flight-port 8815
+$EDB cqlite-flight start
+```
+
+Verify one pod per db node **and the digest**:
+
+```bash
+kubectl get pods -l easydblab.com/kit=cqlite-flight -o wide
+kubectl get pods -l easydblab.com/kit=cqlite-flight \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.status.containerStatuses[0].imageID}{"\n"}{end}'
+```
+
+Every `imageID` must end in
+`289f97e0ec07d9f7fb41efd6bcd8d9b9210ba3cca2584ced02302b9d86bb7ce1`. If any pod is
+stale (from a prior install on a reused cluster), force recreation:
+
+```bash
+kubectl rollout restart daemonset -l easydblab.com/kit=cqlite-flight
+kubectl rollout status  daemonset -l easydblab.com/kit=cqlite-flight --timeout=120s
+```
+
+**Do not attribute any verdict to a pod whose digest isn't `289f97e0…`.**
+
+Confirm observability compiled in and multi-disk decision (both non-fatal):
+
+```bash
+kubectl logs -l easydblab.com/kit=cqlite-flight --all-containers --prefix | grep -i observability
+kubectl logs -l easydblab.com/kit=cqlite-flight -c detect-multidisk --prefix
+```
+
+Expect one `observability enabled, exporting to OTLP endpoint` line per pod
+(endpoint `http://localhost:4317`).
+
+### 5. Install the trino-cqlite overlay — snapshot mode (see [0.2](#02-kit-install-path-kit-source-add-not---from))
+
+All the round-3/4 install bugs (#2119/#2120/#2122/#2123/#2158/#2159) are fixed;
+expect the `trino-coordinator` pod to be recreated **once** during this step
+(that is `strategy: Recreate`, not a hang).
+
+```bash
+DB0_IP=$($EDB ip db0 --private)
+$EDB kit install trino-cqlite --connector-version 0.13.4 --flight-port 8815 \
+  --sidecar-uri "http://${DB0_IP}:9043" --trino-image-tag 481 --read-mode snapshot
+$EDB cqlite start
+"$CLUSTER_DIR/cqlite/bin/verify.sh"
+```
+
+Expected: `SHOW CATALOGS` lists `cqlite`; `SHOW SCHEMAS FROM cqlite` lists at
+least `system`.
+
+### 6. Install trino-loadtest
+
+```bash
+$EDB kit install trino-loadtest --target trino
+```
+
+No `start` yet — that's Phase 3.
+
+---
+
+## Phase 1: WRITE
+
+Drive real CQL writes with `cassandra-easy-stress` to produce non-trivial SSTable
+volume across all 3 nodes (multiple flushes + at least one compaction).
+
+### 7. Start the write load
+
+```bash
+$EDB cassandra stress start --name cqlite-write-baseline --tags "phase=write-baseline" \
+  -- KeyValue -d 15m --threads 50
+```
+
+### 8. Discover the generated keyspace/table and confirm RF ≥ 2 (#2227 precondition)
+
+```bash
+$EDB cassandra stress status
+$EDB cassandra cql "SELECT keyspace_name, table_name FROM system_schema.tables WHERE keyspace_name NOT IN ('system','system_schema','system_auth','system_distributed','system_traces','system_views','system_virtual_schema')"
+```
+
+Set `KEYSPACE`/`TABLE` from the result. **Then confirm RF ≥ 2** — #2227's
+multi-node snapshot fix is only exercised when a query's splits touch replica
+hosts other than the configured Sidecar's node:
+
+```bash
+$EDB cassandra cql "SELECT keyspace_name, replication FROM system_schema.keyspaces WHERE keyspace_name = '${KEYSPACE}'"
+```
+
+If RF = 1, raise it so data lands on multiple nodes (else #2227 cannot be
+adjudicated — note this in the #2286 comment if you cannot):
+
+```bash
+$EDB cassandra cql "ALTER KEYSPACE ${KEYSPACE} WITH replication = {'class':'NetworkTopologyStrategy','<dc>':3}"
+# then repair/rewrite so replicas are populated, e.g. re-run the stress write above
+```
+
+### 8b. Create the tiny 3-row table (#2193 discriminator)
+
+Same shape as round 4 — 3-row `nb-big` + LZ4 in the stress keyspace:
+
+```bash
+$EDB cassandra cql "CREATE TABLE IF NOT EXISTS ${KEYSPACE}.tiny (key text PRIMARY KEY, value text)"
+$EDB cassandra cql "INSERT INTO ${KEYSPACE}.tiny (key, value) VALUES ('1','1')"
+$EDB cassandra cql "INSERT INTO ${KEYSPACE}.tiny (key, value) VALUES ('2','2')"
+$EDB cassandra cql "INSERT INTO ${KEYSPACE}.tiny (key, value) VALUES ('3','3')"
+$EDB cassandra nt flush "$KEYSPACE"
+$EDB cassandra cql "SELECT count(*) FROM ${KEYSPACE}.tiny"   # must be 3
+```
+
+### 8c. Create the unsupported-column table (#2229 discriminator) — NEW round 5
+
+#2229 claims a table with an unsupported column now serves its *supported* columns
++ warns (not table-poisoned), and that CQL `TIME` maps into Trino. Create a table
+mixing a supported text column with a CQL `TIME` column, write a few rows, flush:
+
+```bash
+$EDB cassandra cql "CREATE TABLE IF NOT EXISTS ${KEYSPACE}.mixed (key text PRIMARY KEY, label text, t time)"
+$EDB cassandra cql "INSERT INTO ${KEYSPACE}.mixed (key, label, t) VALUES ('a','alpha','08:30:00')"
+$EDB cassandra cql "INSERT INTO ${KEYSPACE}.mixed (key, label, t) VALUES ('b','bravo','14:45:15')"
+$EDB cassandra nt flush "$KEYSPACE"
+```
+
+(If `time` now maps cleanly rather than being "unsupported", note it — #2229's
+scope was TIME-mapping + hide-and-warn for genuinely unsupported types; adjust the
+discriminator to whatever type the connector still cannot map if `time` is
+supported. Capture the actual behavior either way.)
+
+### 9. Force multiple SSTable generations during the write
+
+```bash
+for i in 1 2 3 4 5; do
+  sleep 120
+  $EDB cassandra nt flush "$KEYSPACE"
+  $EDB cassandra nt compactionstats
+done
+```
+
+Watch for a non-empty pending/active compaction after the 4th–5th flush.
+
+### 10. Wait for the write job to finish
+
+```bash
+$EDB cassandra stress status
+```
+
+Wait for `cqlite-write-baseline` to complete (or `stress stop
+cqlite-write-baseline --force` once you have enough data — see Scale notes).
+
+---
+
+## Phase 2: FLUSH (mandatory)
+
+The connector only sees **flushed** SSTables. Run one final flush regardless of
+Phase 1's periodic flushes:
+
+### 11. Final flush on all db nodes
+
+```bash
+$EDB cassandra nt flush "$KEYSPACE"
+$EDB cassandra nt tpstats
+```
+
+`FlushWriter`/`MemtablePostFlush` pending should be 0 on all 3 nodes.
+
+---
+
+## Phase 3: READ
+
+Per #2286's run matrix: default snapshot sweep (the #2227 main event) → live-mode
+sweep → targeted verdict checks (#2193, #2157, #2241).
+
+### 12. Sanity check row count before either run
+
+```bash
+$EDB cassandra cql "SELECT count(*) FROM ${KEYSPACE}.${TABLE}"
+"$CLUSTER_DIR/cqlite/bin/verify.sh" "$KEYSPACE" "$TABLE"
+$EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"
+```
+
+Counts must match exactly. A mismatch here is a #2227/#2228 correctness finding
+before the concurrent runs even start.
+
+### 12a. #2227 verdict — default snapshot multi-node (THE MAIN EVENT)
+
+This is the first field validation of per-replica-host snapshots. In `snapshot`
+mode (the default from step 5), run a full-ring `SELECT *` whose splits fan across
+all 3 replica hosts — NOT just the Sidecar's node. Round 4 could never reach this
+because the read path hung; #2264 must have cleared that first.
+
+```bash
+# Full-ring scan — must return the complete count, splits on all 3 hosts
+$EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"
+$EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.${TABLE} LIMIT 20"
+```
+
+While it runs, in a second shell confirm splits reached hosts other than
+`db0`/the Sidecar node (transient `cqlite-<queryId>` snapshots should appear on
+**all** replica nodes, not just the Sidecar's):
+
+```bash
+watch -n2 "$EDB cassandra nt listsnapshots"
+```
+
+- **Complete count, no `NotFound` → #2227 PASS** (note the digest + that splits
+  demonstrably touched non-Sidecar hosts). This is the epic-AM Wave-0 field pass.
+- **`NotFound` / partial count** → #2227 FAIL: capture the failing split's ticket
+  JSON (snapshot name + host), which host was missing the snapshot dir, and the
+  flight pod log on that host. Post on #2227 + #2286.
+
+### 12b. #2228 verdict — full-range SELECT * returns complete counts
+
+#2228 fixed a `start==end` full-ring token range being treated as empty (silent
+0 rows). Confirm the unbounded `SELECT *` count equals Cassandra's own count
+(already compared in step 12) and is **non-zero**:
+
+```bash
+$EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"   # must equal Cassandra count, not 0
+```
+
+A silent 0 (or short count) with a non-empty table = #2228 regression → capture +
+file.
+
+### 12c. #2193 verdict — tiny-table read
+
+```bash
+"$CLUSTER_DIR/cqlite/bin/verify.sh" "$KEYSPACE" tiny
+$EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.tiny"
+```
+
+- **3 rows → close #2193** (note round-5 digest `289f97e0…`).
+- **Still fails** → #2193's error surfacing should now make it loud. Capture ALL of:
+  ```bash
+  # server-side ERROR line (RUST_LOG=info suffices per #2193 fix)
+  kubectl logs -l easydblab.com/kit=cqlite-flight --all-containers --prefix --since=5m \
+    | grep -iE "flight rpc failed|error|encode|arrow"
+  # cqlite_errors_total (may be lazily registered — note if absent)
+  source "$CLUSTER_DIR/env.sh"
+  with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_errors_total" | jq -r ".data.result[]"
+  # client-side: Trino runtime arrow-java version on the coordinator classpath
+  kubectl exec deployment/trino-coordinator -- bash -c 'ls /usr/lib/trino/lib | grep -i arrow'
+  ```
+  Post the arrow-java version + client stack trace + server ERROR line on #2193
+  and #2286 (the remaining axes are environmental: x86_64 build, runtime
+  arrow-java, live gRPC).
+
+### 12d. #2157 verdict — LIMIT runtime (the #2264 fix)
+
+Round 4: `LIMIT 5` ran 418s → ABANDONED, `in_flight` gauge stuck at 8. #2264
+(cancellation-aware backpressure) must fix this.
+
+```bash
+# Expect low SECONDS, not minutes/ABANDONED. Watch cqlite_rpc_in_flight in a 2nd shell.
+time $EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.${TABLE} LIMIT 5"
+time $EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.${TABLE} LIMIT 100"
+# point-read predicate pushdown — EXPLAIN must show a NON-EMPTY filterJson
+$EDB trino sql "EXPLAIN SELECT * FROM cqlite.${KEYSPACE}.${TABLE} WHERE key = '<a-real-key>'"
+```
+
+**Metrics sanity (the #2264 gauge-leak signature):** after each LIMIT query
+completes, `cqlite_rpc_in_flight` must return to **0** (round 4 it was stuck at 8):
+
+```bash
+source "$CLUSTER_DIR/env.sh"
+with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_rpc_in_flight" | jq -r ".data.result[].value[1]"
+```
+
+- **`LIMIT 5` in seconds + `in_flight` returns to 0 → close #2157.**
+- **Still slow/ABANDONED on `289f97e0…`** → live #2264 field escalation: capture
+  the `cqlite_rpc_phase_duration_seconds` split (which phase holds the time) +
+  `cqlite_rpc_in_flight_ratio` during the hang. Post on #2157 + #2286.
+
+### 12e. #2229 verdict — unsupported column hide-and-warn — NEW round 5
+
+Query the `mixed` table from 8c. The supported columns must return; an
+unsupported column must be hidden with a warning, not poison the whole table:
+
+```bash
+$EDB trino sql "DESCRIBE cqlite.${KEYSPACE}.mixed"        # which columns are exposed
+$EDB trino sql "SELECT key, label FROM cqlite.${KEYSPACE}.mixed"   # supported cols return
+$EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.mixed"   # TIME maps, or col hidden + warns
+```
+
+- **Supported columns return + TIME maps (or is hidden with a warning) → #2229 PASS.**
+- **Whole-table error / `mixed` unqueryable → #2229 FAIL** → capture the
+  coordinator error + `DESCRIBE` output. Post on #2229 + #2286.
+
+### 13a. Run (a) — default `snapshot` mode loadtest
+
+```bash
+$EDB trino-loadtest-trino start --ks "$KEYSPACE" --tbl "$TABLE" \
+  --threads 8 --duration 120 --traceparent
+```
+
+Watch transient per-query snapshots on **all** replica nodes (a second #2227
+signal — snapshots should appear cluster-wide, not only on the Sidecar's node):
+
+```bash
+watch -n2 "$EDB cassandra nt listsnapshots"
+```
+
+```bash
+$EDB trino-loadtest-trino stop
+```
+
+### 13b. Run (b) — `--read-mode live`: compaction-stress weak-spot hunt
+
+Flip to live by reinstalling the overlay:
+
+```bash
+$EDB kit install trino-cqlite --connector-version 0.13.4 --flight-port 8815 \
+  --sidecar-uri "http://${DB0_IP}:9043" --trino-image-tag 481 --read-mode live
+$EDB cqlite start
+grep cqlite.read-mode "$CLUSTER_DIR/cqlite/trino-catalog.properties"   # → cqlite.read-mode=live
+```
+
+Repeat the targeted verdict reads (12a–12e) in **live** mode — #2157/#2193's
+closure criteria in #2286 are defined on `live` mode, so both modes must be
+exercised:
+
+```bash
+$EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.tiny"              # #2193 in live
+time $EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.${TABLE} LIMIT 5"   # #2157 in live
+$EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"  # #2227/#2228 in live
+```
+
+Then race compaction against an in-flight scan — concurrent write churn + read load:
+
+```bash
+$EDB cassandra stress start --name cqlite-live-churn --tags "phase=live-hunt" \
+  -- KeyValue -d 10m --threads 20
+$EDB trino-loadtest-trino start --ks "$KEYSPACE" --tbl "$TABLE" \
+  --threads 16 --duration 300 --traceparent
+for i in 1 2 3; do sleep 60; $EDB cassandra nt flush "$KEYSPACE"; done
+$EDB trino-loadtest-trino stop
+$EDB cassandra stress stop cqlite-live-churn --force
+```
+
+### 13c. #2241 verdict — split replica failover (killed flight pod) — NEW round 5
+
+#2241 fixed a single down Flight endpoint failing the whole query at RF≥2. Kill
+ONE flight pod, then run a full-ring query: it must **succeed** via failover to
+another replica. Only an all-replicas-down case should fail loudly.
+
+```bash
+# Snapshot the pod set, kill exactly one
+kubectl get pods -l easydblab.com/kit=cqlite-flight -o wide
+VICTIM=$(kubectl get pods -l easydblab.com/kit=cqlite-flight -o name | head -1)
+kubectl delete "$VICTIM" --wait=false     # DaemonSet will recreate; query the gap
+# Immediately (before recreate) run a full-ring scan — expect SUCCESS via failover
+$EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"
+```
+
+- **Query succeeds while one pod is down → #2241 PASS** (splits that targeted the
+  dead endpoint fell back to another replica).
+- **Whole query fails → #2241 FAIL** → capture the coordinator error naming the
+  dead endpoint + confirm the other 2 pods were Ready. Post on #2241 + #2286.
+
+Let the DaemonSet recreate the victim and confirm it's back on digest `289f97e0…`
+before continuing:
+
+```bash
+kubectl rollout status daemonset -l easydblab.com/kit=cqlite-flight --timeout=120s
+```
+
+Revert to `snapshot` mode if re-running Phase 3a:
+
+```bash
+$EDB kit install trino-cqlite --connector-version 0.13.4 --flight-port 8815 \
+  --sidecar-uri "http://${DB0_IP}:9043" --trino-image-tag 481 --read-mode snapshot
+$EDB cqlite start
+```
+
+---
+
+## Phase 4: OBSERVE / VERIFY
+
+### 14. Confirm `cqlite_rpc_*` metric names + mid-query movement
+
+```bash
+source "$CLUSTER_DIR/env.sh"
+with-proxy curl -s "http://control0:8428/api/v1/label/__name__/values" | grep cqlite_rpc
+with-proxy curl -s "http://control0:8428/api/v1/label/__name__/values" \
+  | grep -E "cqlite_rpc_rows_total|cqlite_rpc_bytes_total|cqlite_rpc_phase_duration_seconds|cqlite_rpc_in_flight"
+```
+
+During a long scan (e.g. the step-12 `count(*)`), in a second shell watch rows
+climb and phase durations split — and confirm `in_flight` is non-zero *during* and
+0 *after* (the #2264 signature):
+
+```bash
+watch -n2 'source "$CLUSTER_DIR/env.sh"; \
+  echo "rows:"; with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_rpc_rows_total" | jq -r ".data.result[].value[1]"; \
+  echo "in_flight:"; with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_rpc_in_flight" | jq -r ".data.result[].value[1]"; \
+  echo "--- phase durations ---"; \
+  with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_rpc_phase_duration_seconds_sum" | jq -r ".data.result[] | \"\(.metric.phase)=\(.value[1])\""'
+```
+
+Verdict: rows non-zero + climbing; phase durations attribute time to
+`resolve|merge_setup|stream`; `in_flight` drains to 0 after each query. A stall
+with all time in one phase, zero rows, and a stuck gauge = round-4 symptom
+persisting → capture + file on #2264/#2157.
+
+Post-compaction reconciliation deltas:
+
+```bash
+source "$CLUSTER_DIR/env.sh"
+for m in cqlite_merge_rows_in cqlite_merge_rows_out cqlite_compaction_tombstones_suppressed; do
+  echo "$m:"; with-proxy curl -s "http://control0:8428/api/v1/query?query=$m" | jq -r ".data.result[].value[1]"
+done
+```
+
+### 14c. Presence-oracle soak (OPT-IN, P0-if-nonzero)
+
+`cqlite_read_bloom_false_negatives` is off by default. To run the correctness
+soak, enable it on ONE pod and drive read load:
+
+```bash
+POD=$(kubectl get pods -l easydblab.com/kit=cqlite-flight -o name | head -1)
+kubectl set env "$POD" CQLITE_VERIFY_PRESENCE_ORACLE=1   # restarts that one pod
+# ... drive a Phase 3 read run, then:
+with-proxy curl -s "http://control0:8428/api/v1/query?query=cqlite_read_bloom_false_negatives" | jq -r ".data.result[].value[1]"
+```
+
+**Any `> 0` is a P0 finding — report on #2286 immediately** (a false negative
+means a live row was silently skipped). Zero across the soak is the pass.
+
+### 15. Grafana dashboard, traces, profiles
+
+- **Grafana** (`http://<control-node-private-ip>:3000`): open **CQLite Flight —
+  RPC Metrics**, set `$cluster`/`$service_name` (`cqlite-flight`), confirm all 5
+  panel rows populate during Phase 3 runs.
+- **Tempo:** both Phase 3 runs used `--traceparent`; confirm a trace spans client
+  (Trino) → `cqlite-flight` → `cqlite-core` and `span.rpc.method` is filterable.
+- **Pyroscope:** datasource Pyroscope, `service_name=trino`, confirm CPU/alloc
+  load concentrated in the `cqlite_flight` plugin path (not idle/GC-only) during
+  Phase 3.
+
+### 18. Confirm snapshot lifecycle cleanup
+
+```bash
+$EDB cassandra nt listsnapshots
+```
+
+Expected: empty of `cqlite-*` entries once both Phase 3 runs stop — every
+`cqlite-<queryId>` snapshot should have been deleted by Trino's `cleanupQuery`
+hook. **With #2227's per-replica-host snapshots, verify cleanup on ALL 3 nodes,
+not just the Sidecar's** — a leak on a non-Sidecar node is a new #2227-adjacent
+finding. A growing `cqlite-*` list after runs stop = leak-class finding → capture
++ file.
+
+### 19. Tear down
+
+```bash
+$EDB trino-loadtest-trino stop
+$EDB cassandra stress stop --all --force
+$EDB cqlite uninstall
+$EDB cqlite-flight stop
+$EDB trino stop
+$EDB cassandra stop
+$EDB down --auto-approve
+```
+
+Confirm AWS is clean after teardown (no lingering instances/volumes billing).
+
+---
+
+## Phase 5: FAILURE TRIAGE → ISSUES ON #2286
+
+Every anomaly from Phases 3–4 becomes a comment on **epic #2286** (per-issue
+detail may additionally go on the adjudicated issue). easy-db-lab-side defects:
+**comment-only upstream** on `rustyrazorblade/easy-db-lab` (never fixed in the
+cqlite tree). These are oracle-driven parity/correctness bugs — plain GitHub
+comments + pinned reproduction, **not** OpenSpec changes.
+
+| Failure class | Symptom / trigger | Data to capture |
+|---|---|---|
+| **#2227 multi-node snapshot `NotFound`** | Snapshot-mode query fails / short count with splits on non-Sidecar hosts | Failing split ticket JSON (snapshot name + host), which host lacked the snapshot dir, `nt listsnapshots` on all 3 nodes, flight pod log on the failing host |
+| **#2264 LIMIT hang** | `LIMIT` query slow/ABANDONED, `cqlite_rpc_in_flight` stuck > 0 after completion | `cqlite_rpc_phase_duration_seconds` split, `cqlite_rpc_in_flight`/`_ratio` during + after, Trino task state, flight pod log |
+| **#2193 tiny decode** | `tiny` read fails `Failed to read message` | Server ERROR line (RUST_LOG=info), `cqlite_errors_total`, coordinator arrow-java version, client stack trace |
+| **#2228 silent 0-row** | Full-range `SELECT *` returns 0 / short on a non-empty table | The query, Cassandra `count(*)` vs Trino count, the ticket's token range |
+| **#2229 table poisoned** | A table with an unsupported column is wholly unqueryable | `DESCRIBE`, coordinator error, which column, whether TIME mapped |
+| **#2241 failover** | Query fails when one flight pod is down at RF≥2 | Coordinator error naming the dead endpoint, Ready-state of the other 2 pods, RF of the keyspace |
+| **Live-mode compaction race** | Errors/resets during a scan overlapping forced flush/compaction | Flight pod logs (`--since=30m`), `cqlite_errors_total by (cqlite_error_category)`, Tempo trace, ticket JSON; whether it repros in snapshot mode |
+| **Wrong row counts (snapshot vs live vs CQL)** | Step 12 counts disagree across modes | SSTable file set at mismatch time, snapshot name, full query; which mode disagreed and by how much |
+| **OOM / memory growth** | `kubectl top pod` unbounded growth or pod restart | `kubectl top pod` samples across the run, restart counts, Pyroscope `alloc` flame graph |
+
+---
+
+## Scale notes
+
+| Parameter | 3-node baseline (this plan) | Bigger run |
+|---|---|---|
+| DB nodes | 3 × `i4i.xlarge` | 6-9 × `i4i.xlarge` |
+| App nodes | 1 × `m5.xlarge` | 2-3 × `m5.xlarge` (`install trino --workers N`) |
+| Phase 1 write | `--threads 50 -d 15m` | `--threads 200 -d 1h`+ |
+| Phase 1 flush interval | every 120s × 5 | every 60s, or drop `min_compaction_threshold` |
+| Phase 3b write churn | `--threads 20 -d 10m` | `--threads 100 -d 30m`+ |
+| Phase 3 read | `--threads 8-16`, `120/300s` | `--threads 32-64`, `600s`+ |
+
+## Validation Checklist (post filled to #2286)
+
+- [ ] Maven Central has `in.mcfad:cqlite-trino:0.13.4` (0.1)
+- [ ] `kit source add` + named `kit install` used for all three kits, not `--from` (0.2)
+- [ ] `trino` installed `--version 481`; #2116 `web-ui.*` workaround applied; workers Ready (0.3)
+- [ ] SOCKS vars exported; `trino sql` works (note whether #737 merged, 0.5)
+- [ ] `cqlite-flight` DaemonSet: one Running pod per db node, **digest == `289f97e0…`** (Step 4)
+- [ ] `detect-multidisk` decision reviewed on every pod; observability line present (Step 4)
+- [ ] RF ≥ 2 confirmed on the stress keyspace (#2227 precondition, Step 8)
+- [ ] **#2227 verdict:** default snapshot full-ring scan returns complete count, splits touch non-Sidecar hosts (12a)
+- [ ] **#2228 verdict:** full-range `SELECT *` count == Cassandra count, non-zero (12b)
+- [ ] **#2193 verdict:** `tiny` returns 3 rows (close) OR ERROR line + arrow-java version + client trace captured (12c)
+- [ ] **#2157 verdict:** `LIMIT 5` in seconds + `cqlite_rpc_in_flight` drains to 0 (close) OR field escalation captured (12d)
+- [ ] **#2229 verdict:** `mixed` serves supported columns + TIME maps/warns, not poisoned (12e)
+- [ ] **#2241 verdict:** query succeeds with one flight pod killed at RF≥2 (13c)
+- [ ] Both `snapshot` AND `live` modes exercised for #2193/#2157 (closure criteria are on live)
+- [ ] `cqlite_rpc_*` names confirmed live; rows climb mid-query; phase durations split; `in_flight` drains (14)
+- [ ] Presence-oracle soak: `cqlite_read_bloom_false_negatives == 0` (any >0 → P0 on #2286) (14c)
+- [ ] Grafana panels populate; Tempo client→flight→core trace exists; Pyroscope shows plugin load (15)
+- [ ] `nt listsnapshots` empty of `cqlite-*` on ALL 3 nodes after runs stop (18)
+- [ ] Every anomaly has a #2286 comment or explicit "not reproducible" note
+
+## Notes
+
+- Never overwrite `cassandra.patch.yaml`; `cassandra use 5.0` generates it.
+- `stress start` requires `--` before workload args when passing `--name`/`--tags`.
+- The `trino-cqlite` overlay's `post-workload-start/stop` hooks fire on any kit
+  start/stop and re-run `bin/reapply-plugin-patch.sh` (cheap, idempotent).
+- If `cassandra cql` returns `No node was available` despite `nt status` all `UN`,
+  the Sidecar needs more time — wait 30s and retry.
+- `count(*)` on the big keyvalue table can time out at LOCAL_QUORUM (normal) — if
+  so, use a bounded `LIMIT` scan for the #2227/#2228 multi-node checks and note it.
+- Long `easy-db-lab` commands hit a 2-min shell cap — background them.

--- a/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md
+++ b/easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md
@@ -31,22 +31,23 @@ children, not a guess.
 `trino-cqlite`'s init container resolves the published
 `in.mcfad:cqlite-trino:<version>` artifact from Maven Central at pod-start time
 (no baked image — see `trino-cqlite/README.md` "Approach: init-container, not a
-baked image"). **As of authoring this plan, publishing is blocked** on repo
-secrets (`MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY`,
-`SIGNING_PASSWORD` — see `.github/workflows/trino-publish.yml`), and the
-`cqlite.read-mode` feature (#2105) this plan exercises needs a **new** release
-version (e.g. `0.13.1`) published *after* epic #2103 merges — the current
-released version predates it.
+baked image").
 
-Until that version is on Maven Central, `easy-db-lab cqlite start`'s init
-container (`cqlite-plugin-fetch`) fails with a Gradle dependency-resolution error
-(`Could not resolve in.mcfad:cqlite-trino:<version>` / `Could not GET
-'https://repo1.maven.org/...'`). Confirm before you start:
+**[UPDATED for round 3]** This plan now pins **`0.13.3`** — it adds predicate
+pushdown (#2166: `applyFilter` translates the TupleDomain summary into a
+non-empty `filterJson` on the ticket) on top of `applyLimit` (0.13.2) and
+`cqlite.read-mode` (0.13.1). `0.13.3` is auto-released on Maven Central. Confirm
+it is resolvable before you start:
 
 ```bash
-curl -sf "https://repo1.maven.org/maven2/in/mcfad/cqlite-trino/<version>/cqlite-trino-<version>.pom" \
+curl -sf "https://repo1.maven.org/maven2/in/mcfad/cqlite-trino/0.13.3/cqlite-trino-0.13.3.pom" \
   -o /dev/null && echo "published" || echo "NOT PUBLISHED — stop here"
 ```
+
+If it's not resolvable, `easy-db-lab cqlite start`'s init container
+(`cqlite-plugin-fetch`) fails with a Gradle dependency-resolution error
+(`Could not resolve in.mcfad:cqlite-trino:0.13.3`) and this plan cannot proceed
+past Phase 1, step 5.
 
 If it's not published, this plan cannot proceed past Phase 1, step 5 (installing
 the `trino-cqlite` overlay).
@@ -83,7 +84,7 @@ field inside `kit.yaml` — whenever the kit declares no `kit-ref`/extension arg
 comment), so:
 
 ```bash
-easy-db-lab kit install trino-cqlite --connector-version 0.13.1 --flight-port 8815 \
+easy-db-lab kit install trino-cqlite --connector-version 0.13.3 --flight-port 8815 \
   --sidecar-uri "http://$(easy-db-lab ip db0 --private):9043" --trino-image-tag 481
 # ^ dispatch verb "trino-cqlite" (source directory name) ...
 easy-db-lab cqlite start
@@ -214,9 +215,14 @@ Coordinator and worker pods must both be Running/Ready.
 
 ### 4. Register the kit source and install cqlite-flight
 
+**[UPDATED for round 3]** Pin the moving **`dev`** image channel
+(`ghcr.io/pmcfadin/cqlite-flight:dev`) — it carries the streaming `do_get`
+producer (#1476 / PR #2176), observability (#2128), and the LIMIT early-stop.
+A tagged release image with these does not exist yet.
+
 ```bash
 $EDB kit source add cqlite /path/to/cqlite/easy-db-lab-kits
-$EDB kit install cqlite-flight --tag v0.13.1 --flight-port 8815
+$EDB kit install cqlite-flight --tag dev --flight-port 8815
 $EDB cqlite-flight start
 ```
 
@@ -230,6 +236,26 @@ Verify one pod per db node:
 
 ```bash
 kubectl get pods -l easydblab.com/kit=cqlite-flight -o wide
+```
+
+**[UPDATED for round 3 — MANDATORY POD RESTART]** `imagePullPolicy: Always`
+only pulls at pod *creation*. If the `cqlite-flight` DaemonSet pods already
+existed (e.g. from a prior install on this cluster) they keep running the old
+`:dev` layer — the round-2 24-min `LIMIT 5` was almost certainly a stale
+pre-streaming image. Force a fresh pull of the current `:dev` before testing:
+
+```bash
+kubectl rollout restart daemonset -l easydblab.com/kit=cqlite-flight
+kubectl rollout status  daemonset -l easydblab.com/kit=cqlite-flight --timeout=120s
+```
+
+Confirm each pod is running the intended image digest and logged
+`observability enabled` at startup:
+
+```bash
+kubectl get pods -l easydblab.com/kit=cqlite-flight \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.status.containerStatuses[0].imageID}{"\n"}{end}'
+kubectl logs -l easydblab.com/kit=cqlite-flight --all-containers --prefix | grep -i observability
 ```
 
 ### 5. Install the trino-cqlite overlay (see [0.2](#02-kit-install-path-kit-source-add-not---from) for the naming subtlety)
@@ -289,7 +315,7 @@ see those two entries below, both now fixed:
 
 ```bash
 DB0_IP=$($EDB ip db0 --private)
-$EDB kit install trino-cqlite --connector-version 0.13.1 --flight-port 8815 \
+$EDB kit install trino-cqlite --connector-version 0.13.3 --flight-port 8815 \
   --sidecar-uri "http://${DB0_IP}:9043" --trino-image-tag 481
 $EDB cqlite start
 ```
@@ -419,6 +445,32 @@ $EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"
 Compare the Cassandra-side CQL count against the `cqlite.${KEYSPACE}.${TABLE}`
 count Trino returns. They must match exactly; a mismatch here is Phase 5's
 "wrong row counts" class before you've even started the concurrent runs.
+
+**[UPDATED for round 3 — interactive-latency regression checks].** The round-2
+run (flight pre-streaming image + connector 0.13.2) found every read shape did a
+full eager merge before emitting row 1: `LIMIT 5` = 24 min, `count(*)` = 358s+,
+point read = full scan with no predicate pushdown (#2157). Round 3 ships the
+streaming `do_get` producer (#1476/#2176, flight `:dev`) and predicate pushdown
+(#2166, connector 0.13.3). Before the two loadtest runs, capture these three
+datapoints against the round-2 baselines:
+
+```bash
+# 1) LIMIT 5 — was 24 min; expect low SECONDS (streaming + limit early-stop)
+time $EDB trino sql "SELECT * FROM cqlite.${KEYSPACE}.${TABLE} LIMIT 5"
+
+# 2) point read — EXPLAIN must show a NON-EMPTY filterJson on the table handle
+#    (round 2: filterJson=Optional.empty → full scan + Trino ScanFilter)
+$EDB trino sql "EXPLAIN SELECT * FROM cqlite.${KEYSPACE}.${TABLE} WHERE key = '<a-real-key>'"
+
+# 3) count(*) — still a full scan by nature, but do_get duration metrics must
+#    MOVE during the query (streaming) instead of going dark until completion
+time $EDB trino sql "SELECT count(*) FROM cqlite.${KEYSPACE}.${TABLE}"
+```
+
+If `LIMIT 5` still takes minutes, confirm the flight pods actually restarted
+onto the current `:dev` digest (Step 4 mandatory pod restart) before filing —
+the round-2 hang was traced to a stale image. If it's fast, that regression is
+cleared; proceed to the loadtest runs.
 
 **[UPDATED after the first live run]** The first run of this plan hit two
 `trino-loadtest` driver bugs before any query was ever issued, both now fixed


### PR DESCRIPTION
Docs-only. Lands the easy-db-lab kit loadtest field-test artifacts that were sitting uncommitted in the working tree.

## Commits
1. **round-3 rerun** (`fe6a8b81`, orig `09673b24`) — updates `cqlite-flight-loadtest-3node.md`: pins connector 0.13.3 (predicate pushdown #2166) + flight `dev` (streaming do_get #1476/#2176), and adds the **mandatory `kubectl rollout restart daemonset`** step after flight install (root cause of the round-2 24-min LIMIT 5 hang was a stale `:dev` image; `imagePullPolicy: Always` only pulls at pod creation). Adds step-12 interactive-latency regression checks vs round-2 baselines (#2157).
2. **round-4/5 + RUN-LOG** (`f9403e11`) — Round-4 (955L) and Round-5 (776L) lab plans + `RUN-LOG.md` (living harness bring-up record: bugs found, run state, agent handoff).

## Scope
- Docs only under `easy-db-lab-kits/` — no kit code, no source, no gate-relevant change.
- Kit CODE (incl. the #2290 arrow `--add-opens` injection) is already on main; this is purely the field-test plan/log documentation.

No issue closed (these are living harness docs; #2103 epic stays open).