### PR TITLE
fix(#2397): rotate split primaries across replica owners — unblock multi-node read fan-out

### DIFF
--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightAggregateSplit.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightAggregateSplit.java
@@ -3,8 +3,11 @@ package in.mcfad.cqlite.flight;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The single "finalize split" for an aggregated table handle (issue #841).
@@ -30,12 +33,20 @@ public record CqliteFlightAggregateSplit(
 
     @Override
     public List<HostAddress> getAddresses() {
-        // No single locality home: the finalize split fans out to every range's
-        // replica. Returning the first range as a soft hint at most.
+        // No single locality home: the finalize split fans out to every range's replica.
+        // Emit one soft hint per DISTINCT range PRIMARY (issue #2397), preserving order and
+        // deduplicating, so the hint reflects the rotated spread rather than always pinning
+        // to the first range's host — the fan-out itself dials each range's rotated primary.
         if (ranges.isEmpty()) {
             return List.of();
         }
-        CqliteFlightSplit first = ranges.get(0);
-        return List.of(HostAddress.fromParts(first.host(), first.port()));
+        List<HostAddress> addresses = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (CqliteFlightSplit range : ranges) {
+            if (seen.add(range.host())) {
+                addresses.add(HostAddress.fromParts(range.host(), range.port()));
+            }
+        }
+        return addresses;
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -291,8 +291,11 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         for (ReplicaInfo range : replicas.readReplicas()) {
             // Sidecar returns replicas as "ip:storage_port"; the flight server listens on
             // flightPort at the same host, so keep only the host. The ordered list's first
-            // entry is exactly the pickReplica choice (same local-DC-then-global ordering).
-            List<String> ordered = orderedReplicaHosts(range.replicasByDatacenter(), localDatacenter);
+            // entry is exactly the pickReplica choice; the primary is a deterministic per-range
+            // rotation keyed on the range start token (issue #2397) so RF==N ranges spread
+            // across owners instead of collapsing onto the lexicographic head.
+            List<String> ordered =
+                    orderedReplicaHosts(range.replicasByDatacenter(), localDatacenter, range.startToken());
             if (ordered.isEmpty()) {
                 continue; // range with no known replica — nothing to read
             }
@@ -329,25 +332,44 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
     }
 
     /**
-     * The range's replica hosts in try order (issue #2241): local-datacenter owners first
-     * (lexicographic by address), then every other datacenter's owners (lexicographic),
-     * mapped to bare hosts via {@link #hostOnly} and de-duplicated preserving order. The
-     * first element equals {@link #pickReplica}'s choice, so it is the split's primary and
-     * the rest are ordered availability fallbacks.
+     * The range's replica hosts in try order (issues #2241, #2397): the primary first, then
+     * the range's other owners as ordered availability fallbacks, mapped to bare hosts via
+     * {@link #hostOnly} and de-duplicated preserving order. The first element equals
+     * {@link #pickReplica}'s choice.
+     *
+     * <p>Primary selection is a deterministic per-range ROTATION over the sorted eligible
+     * owner set, not the lexicographic head (issue #2397): with RF == N every range shares
+     * one identical owner set, so a fixed head pinned EVERY split to the same replica and
+     * collapsed all flight reads onto a single pod (round-9 field finding). The primary is
+     * {@code sorted[floorMod(rotationKey, size)]} (a stable per-range value — the range's
+     * start token) and the remaining owners follow in sorted order as fallbacks. Rotation is
+     * applied WITHIN the local-datacenter owner set when that DC has replicas for the range
+     * (datacenter preference preserved), else across the whole owner set; owners in other
+     * datacenters are appended, sorted, as further fallbacks.
      */
-    static List<String> orderedReplicaHosts(Map<String, List<String>> replicasByDatacenter, String localDatacenter) {
-        List<String> orderedAddresses = new ArrayList<>();
-        if (localDatacenter != null) {
-            List<String> local = replicasByDatacenter.get(localDatacenter);
-            if (local != null) {
-                local.stream().sorted().forEach(orderedAddresses::add);
-            }
+    static List<String> orderedReplicaHosts(
+            Map<String, List<String>> replicasByDatacenter, String localDatacenter, long rotationKey) {
+        List<String> primaryGroup;
+        List<String> tailGroup;
+        List<String> local = localDatacenter != null ? replicasByDatacenter.get(localDatacenter) : null;
+        if (local != null && !local.isEmpty()) {
+            // Rotate within the local DC; other DCs are fallback-only, appended sorted.
+            primaryGroup = local.stream().sorted().collect(java.util.stream.Collectors.toList());
+            tailGroup = replicasByDatacenter.entrySet().stream()
+                    .filter(e -> !e.getKey().equals(localDatacenter))
+                    .flatMap(e -> e.getValue().stream())
+                    .sorted()
+                    .collect(java.util.stream.Collectors.toList());
+        } else {
+            // No local-DC preference for this range: the whole owner set is rotation-eligible.
+            primaryGroup = replicasByDatacenter.values().stream()
+                    .flatMap(List::stream)
+                    .sorted()
+                    .collect(java.util.stream.Collectors.toList());
+            tailGroup = List.of();
         }
-        replicasByDatacenter.entrySet().stream()
-                .filter(e -> !e.getKey().equals(localDatacenter))
-                .flatMap(e -> e.getValue().stream())
-                .sorted()
-                .forEach(orderedAddresses::add);
+        List<String> orderedAddresses = new ArrayList<>(rotate(primaryGroup, rotationKey));
+        orderedAddresses.addAll(tailGroup);
         List<String> hosts = new ArrayList<>();
         Set<String> seen = new LinkedHashSet<>();
         for (String address : orderedAddresses) {
@@ -360,18 +382,44 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
     }
 
     /**
-     * The distinct set of replica hosts the scan's splits will read — the same
-     * deterministic {@link #pickReplica} choice used by {@link #buildSplits}, one host per
-     * range, deduplicated. Order-preserving (insertion order) so per-host snapshot creation
-     * is stable across re-planning. This is exactly the set of hosts a per-query snapshot
-     * must be created on (issue #2227).
+     * Deterministic per-range rotation of a sorted owner list (issue #2397): the head is
+     * {@code sorted[floorMod(rotationKey, n)]}, the remaining entries follow in their natural
+     * sorted order. Stable for a given {@code rotationKey} (the range start token), so splits
+     * are reproducible across re-planning while spreading primaries across owners. A list of
+     * size &le; 1 is returned unchanged.
+     */
+    private static List<String> rotate(List<String> sorted, long rotationKey) {
+        int n = sorted.size();
+        if (n <= 1) {
+            return sorted;
+        }
+        int head = Math.floorMod(rotationKey, n);
+        List<String> rotated = new ArrayList<>(n);
+        rotated.add(sorted.get(head));
+        for (int i = 0; i < n; i++) {
+            if (i != head) {
+                rotated.add(sorted.get(i));
+            }
+        }
+        return rotated;
+    }
+
+    /**
+     * The distinct set of replica hosts the scan's splits will read — the same deterministic
+     * rotated {@link #pickReplica} choice used by {@link #buildSplits}, one host per range,
+     * deduplicated (issue #2397 routes this through the rotated chooser so every pinned
+     * primary has its snapshot). Order-preserving (insertion order) so per-host snapshot
+     * creation is stable across re-planning. This is exactly the set of hosts a per-query
+     * snapshot must be created on (issue #2227).
      */
     static Set<String> distinctReplicaHosts(TokenRangeReplicasResponse replicas, String localDatacenter) {
         Set<String> hosts = new LinkedHashSet<>();
         for (ReplicaInfo range : replicas.readReplicas()) {
-            String replica = pickReplica(range.replicasByDatacenter(), localDatacenter);
-            if (replica != null) {
-                hosts.add(hostOnly(replica));
+            // pickReplica returns the rotated primary already as a bare host (via
+            // orderedReplicaHosts), so it is added directly — no second port strip.
+            String host = pickReplica(range.replicasByDatacenter(), localDatacenter, range.startToken());
+            if (host != null) {
+                hosts.add(host);
             }
         }
         return hosts;
@@ -389,28 +437,25 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
     static Set<String> allReplicaHosts(TokenRangeReplicasResponse replicas, String localDatacenter) {
         Set<String> hosts = new LinkedHashSet<>();
         for (ReplicaInfo range : replicas.readReplicas()) {
-            hosts.addAll(orderedReplicaHosts(range.replicasByDatacenter(), localDatacenter));
+            // The full owner union is rotation-independent (order within a range does not
+            // change the set); pass the range's start token to match orderedReplicaHosts.
+            hosts.addAll(orderedReplicaHosts(range.replicasByDatacenter(), localDatacenter, range.startToken()));
         }
         return hosts;
     }
 
     /**
-     * Choose one replica for a range: prefer the local datacenter, else any DC.
-     * Selection is deterministic (lexicographically smallest address) so repeated
-     * planning yields stable splits.
+     * Choose one replica for a range: prefer the local datacenter, else any DC. Selection is
+     * a deterministic per-range ROTATION over the sorted eligible owners (issue #2397) — the
+     * head of {@link #orderedReplicaHosts} — so repeated planning yields stable splits AND
+     * primaries spread across owners instead of all pinning to the lexicographic head (which
+     * collapsed every RF==N range onto one replica). Returns {@code null} for a range with no
+     * known replica.
      */
-    static String pickReplica(Map<String, List<String>> replicasByDatacenter, String localDatacenter) {
-        if (localDatacenter != null) {
-            List<String> local = replicasByDatacenter.get(localDatacenter);
-            if (local != null && !local.isEmpty()) {
-                return local.stream().sorted().findFirst().orElseThrow();
-            }
-        }
-        return replicasByDatacenter.values().stream()
-                .flatMap(List::stream)
-                .sorted()
-                .findFirst()
-                .orElse(null);
+    static String pickReplica(
+            Map<String, List<String>> replicasByDatacenter, String localDatacenter, long rotationKey) {
+        List<String> ordered = orderedReplicaHosts(replicasByDatacenter, localDatacenter, rotationKey);
+        return ordered.isEmpty() ? null : ordered.get(0);
     }
 
     /**

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightReplicaRotationTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightReplicaRotationTest.java
@@ -1,0 +1,106 @@
+package in.mcfad.cqlite.flight;
+
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Round-9 field finding (issue #2397): with RF == N every token range shares one
+ * identical owner set, and head-of-sorted primary selection
+ * ({@code sorted().findFirst()}) pinned EVERY split to the lexicographically-smallest
+ * replica — so 1 of N flight pods did all the work (deterministic single-node collapse
+ * under concurrent load). Deterministic per-range rotation must spread the primaries
+ * across all N owners while keeping the full owner set per split for failover
+ * (issue #2241) and routing the per-host snapshot set (issue #2227) through the same
+ * chooser. The pre-existing suite hides this bug because its fixtures deliberately vary
+ * the owner set per range.
+ */
+class CqliteFlightReplicaRotationTest {
+
+    private static final CqliteFlightTableHandle TABLE =
+            new CqliteFlightTableHandle("ks", "t", "CREATE TABLE ks.t (id int PRIMARY KEY)");
+
+    // RF == N == 3: ONE identical owner set shared by every range (the field's 3-node/RF=3 shape).
+    private static final List<String> OWNERS =
+            List.of("10.0.0.1:7000", "10.0.0.2:7000", "10.0.0.3:7000");
+    private static final Set<String> BARE_OWNERS = Set.of("10.0.0.1", "10.0.0.2", "10.0.0.3");
+
+    /** M token ranges, every one owned by the identical RF=N owner set. */
+    private static TokenRangeReplicasResponse ringOf(int m) {
+        List<ReplicaInfo> ranges = new ArrayList<>();
+        for (int i = 0; i < m; i++) {
+            ranges.add(new ReplicaInfo(Integer.toString(i), Integer.toString(i + 100),
+                    Map.of("dc1", OWNERS)));
+        }
+        return new TokenRangeReplicasResponse(List.of(), ranges);
+    }
+
+    @Test
+    void primariesSpreadAcrossAllOwnersWhenRfEqualsN() {
+        int m = 9;
+        int n = OWNERS.size();
+        var splits = CqliteFlightSplitManager.buildSplits(TABLE, ringOf(m), "dc1", 8815);
+        assertEquals(m, splits.size(), "one split per token range");
+
+        // (1) The set of pinned primaries spans ALL N owners — the round-9 collapse pinned
+        // every split to the lexicographically-smallest replica, so this was 1 (RED).
+        Set<String> primaries = splits.stream().map(CqliteFlightSplit::host).collect(Collectors.toSet());
+        assertEquals(n, primaries.size(),
+                "every replica owner must be primary for some range (was 1 before the fix)");
+
+        // (2) No host is primary for more than ceil(M/N) ranges — a balanced spread.
+        Map<String, Long> perHost = splits.stream()
+                .collect(Collectors.groupingBy(CqliteFlightSplit::host, Collectors.counting()));
+        long cap = ((long) m + n - 1) / n;
+        perHost.forEach((h, c) -> assertTrue(c <= cap,
+                h + " is primary for " + c + " ranges, exceeding ceil(M/N)=" + cap));
+
+        // (3) Each split still carries the FULL owner set for failover (issue #2241 intact).
+        for (var s : splits) {
+            assertEquals(BARE_OWNERS, Set.copyOf(s.replicaHosts()),
+                    "split retains every owner for availability failover");
+            assertEquals(n, s.replicaHosts().size(), "no duplicated owner in the try list");
+            assertTrue(BARE_OWNERS.contains(s.host()), "primary is one of the owners");
+        }
+    }
+
+    @Test
+    void selectionIsDeterministicAcrossInvocations() {
+        // (4) Same range → same primary across two independent buildSplits calls (stable
+        // across Trino re-planning).
+        var a = CqliteFlightSplitManager.buildSplits(TABLE, ringOf(9), "dc1", 8815);
+        var b = CqliteFlightSplitManager.buildSplits(TABLE, ringOf(9), "dc1", 8815);
+        assertEquals(a.size(), b.size());
+        for (int i = 0; i < a.size(); i++) {
+            assertEquals(a.get(i).host(), b.get(i).host(),
+                    "same range must map to the same primary across re-planning");
+            assertEquals(a.get(i).replicaHosts(), b.get(i).replicaHosts(),
+                    "ordered try-list must be stable across re-planning");
+        }
+    }
+
+    @Test
+    void snapshotHostSetCoversEveryRotatedPrimary() {
+        // #2227 interplay: the per-host snapshot set must be computed through the SAME rotated
+        // chooser, so every pinned primary has its snapshot created (else a split reads a
+        // non-existent snapshot dir → NotFound). It must equal the set of splits' primaries.
+        var resp = ringOf(9);
+        Set<String> snapshotHosts = CqliteFlightSplitManager.distinctReplicaHosts(resp, "dc1");
+        var splits = CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815);
+        Set<String> primaries = splits.stream().map(CqliteFlightSplit::host).collect(Collectors.toSet());
+
+        assertEquals(primaries, snapshotHosts,
+                "snapshot set must equal every rotated primary so each pinned host has its snapshot");
+        assertEquals(OWNERS.size(), snapshotHosts.size(),
+                "with RF==N spread, all N owners are pinned primaries and get a snapshot");
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerTest.java
@@ -324,8 +324,11 @@ class CqliteFlightSplitManagerTest {
 
     /**
      * Availability failover (issue #2241): in LIVE mode every other replica owner of a range is
-     * an ordered fallback (primary first). {@code orderedReplicaHosts} sorts by address and
-     * de-dups by host; the primary equals {@link CqliteFlightSplitManager#pickReplica}'s choice.
+     * an ordered fallback (primary first). The primary is a deterministic per-range rotation of
+     * the sorted owner set keyed on the range start token (issue #2397) — NOT the lexicographic
+     * head, which collapsed every RF==N range onto one replica; the remaining owners follow in
+     * sorted order. Updated from the old "primary = smallest address" assertion: that behavior
+     * was the round-9 single-node collapse bug.
      */
     @Test
     void liveModeCarriesAllOtherOwnersAsOrderedFallbacks() {
@@ -336,9 +339,12 @@ class CqliteFlightSplitManagerTest {
 
         var splits = CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815);
         assertEquals(1, splits.size());
-        assertEquals("10.0.0.2", splits.get(0).host(), "primary = smallest address");
-        assertEquals(List.of("10.0.0.3", "10.0.0.4"), splits.get(0).fallbackHosts());
-        assertEquals(List.of("10.0.0.2", "10.0.0.3", "10.0.0.4"), splits.get(0).replicaHosts());
+        // sorted owners = [.2, .3, .4]; head = floorMod(-100, 3) = 2 → primary .4, rest in order.
+        assertEquals("10.0.0.4", splits.get(0).host(), "primary = rotated owner (floorMod start token)");
+        assertEquals(List.of("10.0.0.2", "10.0.0.3"), splits.get(0).fallbackHosts());
+        assertEquals(List.of("10.0.0.4", "10.0.0.2", "10.0.0.3"), splits.get(0).replicaHosts());
+        // Full owner set retained regardless of which owner is primary (failover intact).
+        assertEquals(Set.of("10.0.0.2", "10.0.0.3", "10.0.0.4"), Set.copyOf(splits.get(0).replicaHosts()));
     }
 
     /**
@@ -387,9 +393,10 @@ class CqliteFlightSplitManagerTest {
     }
 
     /**
-     * {@code orderedReplicaHosts} prefers local-DC owners (sorted), then every other DC's owners
-     * (sorted), mapping to bare hosts and de-duplicating in order. The first entry matches
-     * {@link CqliteFlightSplitManager#pickReplica}.
+     * {@code orderedReplicaHosts} prefers local-DC owners (rotated within, then sorted), then
+     * every other DC's owners (sorted) as further fallbacks, mapping to bare hosts and
+     * de-duplicating in order. Rotation applies only to the local-DC set (issue #2397); the
+     * first entry matches {@link CqliteFlightSplitManager#pickReplica}.
      */
     @Test
     void orderedReplicaHostsPrefersLocalDcThenOthers() {
@@ -397,12 +404,23 @@ class CqliteFlightSplitManagerTest {
                 "dc1", List.of("10.0.1.5:7000", "10.0.1.2:7000"),
                 "dc2", List.of("10.0.2.9:7000"));
 
+        // rotationKey 0 → head = sorted local[0] = .2; local .5 then remote dc2 .9 as fallbacks.
         assertEquals(
                 List.of("10.0.1.2", "10.0.1.5", "10.0.2.9"),
-                CqliteFlightSplitManager.orderedReplicaHosts(byDc, "dc1"));
+                CqliteFlightSplitManager.orderedReplicaHosts(byDc, "dc1", 0));
         assertEquals(
                 "10.0.1.2",
-                CqliteFlightSplitManager.pickReplica(byDc, "dc1").split(":")[0],
-                "ordered head equals pickReplica");
+                CqliteFlightSplitManager.pickReplica(byDc, "dc1", 0),
+                "ordered head equals pickReplica (bare host)");
+
+        // rotationKey 1 rotates WITHIN the local DC only: head = sorted local[1] = .5, then .2;
+        // the remote-DC owner stays a trailing fallback (never rotated into primary).
+        assertEquals(
+                List.of("10.0.1.5", "10.0.1.2", "10.0.2.9"),
+                CqliteFlightSplitManager.orderedReplicaHosts(byDc, "dc1", 1));
+        assertEquals(
+                "10.0.1.5",
+                CqliteFlightSplitManager.pickReplica(byDc, "dc1", 1),
+                "rotation stays within the local datacenter");
     }
 }


### PR DESCRIPTION
## Field context (round-9, #2367)

Round-9 throughput re-run surfaced a field-confirmed availability finding: under RF=N,
full-ring scan load landed on **1 of 3 pods** (~0.9 qps, single-node-bound). Mechanism:
the split manager chose the split primary via `sorted().findFirst()` over the replica
owner set — a stable minimum, so **every** split for a given token range pinned to the
same replica host. Read fan-out could never spread across the ring.

## Fix

Rotate the split primary deterministically across the local-DC replica owner set:
`floorMod(startToken, owners)` selects the primary within the ordered replica list, so
consecutive token ranges hand off to different owners. Both split-producing paths are
routed identically:

- `CqliteFlightSplitManager` (snapshot chooser + live path) — `orderedReplicaHosts` with
  identical inputs on both branches; snapshot fail-closed invariant preserved.
- `CqliteFlightAggregateSplit` (aggregate splits) — same ordered-rotation helper.

DC preference is preserved (local-DC set first); rotation is deterministic across negative
tokens and wraparound; no primary duplication in fallback ordering.

## Evidence

- **RED proof**: new `CqliteFlightReplicaRotationTest` pins split-primary spread across
  RF=N owners — distinct primaries went **1 -> 3** under the RF=N fixture with the fix.
- **Connector suite**: 324/324 green.
- **Review**: Java reviewer APPROVE, no blockers. roborev job 1689 clean ("No issues found").
- Split-to-endpoint distribution test present; snapshot/failover interplay covered.

## Snapshot / failover notes

Snapshot and live paths call the same `orderedReplicaHosts` with identical inputs, so the
fail-closed snapshot invariant holds; fallback ordering introduces no primary duplication.

Field-metric validation (work visible on all N pods) is verified next round — this ships
in the next connector release; **throughput re-validation is the round-11 headline**.

Closes #2397
