### PR TITLE
probe(#2398): identify warm-scan dominant cost — token filter is consumer-only, every scan decodes all partition bodies (work-probe counter + pin; fix = #2413)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -744,6 +744,12 @@ impl SSTableReader {
             )?;
             match step {
                 ParseStep::Emitted(consumed) => {
+                    // Work-probe (issue #2398): one partition body decoded on the
+                    // chunk-stitching ('nb') scan path — the counterpart to the
+                    // streaming full-index walk's increment. A token-range split
+                    // must keep this bounded to its in-range slice, not the
+                    // SSTable's whole partition count.
+                    crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
                     let take = if consumed == 0 { 1 } else { consumed };
                     // Advance the cursor over the confirmed partition (issue #1589):
                     // NO memmove here — the reclaimed prefix is compacted once at the

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -315,6 +315,10 @@ impl SSTableReader {
             .sequential_scan(&table_id, None, None, None, schema, scan_cancel)
             .await?;
         for (key, value) in entries {
+            // Work-probe (issue #2398, roborev 1692): the materialising sequential
+            // scan decodes every partition body too — every body-decoding path must
+            // contribute to this counter, not only the two index-driven walks.
+            crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
             match emit((key, value))? {
                 ControlFlow::Continue(()) => {}
                 ControlFlow::Break(()) => return Ok(()),

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -309,16 +309,19 @@ impl SSTableReader {
         // Fallback: materialising sequential scan (rare degenerate path). No
         // producer-side limit (see this method's doc) — the consumer's
         // post-reconciliation LIMIT break bounds it downstream instead.
+        //
+        // Work-probe (issue #2398, roborev 1693): `sequential_scan` itself owns
+        // the `stream_walk_partitions_parsed` accounting for this path (added at
+        // its per-partition decode boundary, roborev 1692) — do NOT increment
+        // again here. This loop only re-emits `sequential_scan`'s already-decoded
+        // results, one call per RETURNED ROW; a second increment here would
+        // double-count every partition body relative to what was actually decoded.
         let table_id = self.scan_table_id();
         let schema = self.schema.as_deref();
         let entries = self
             .sequential_scan(&table_id, None, None, None, schema, scan_cancel)
             .await?;
         for (key, value) in entries {
-            // Work-probe (issue #2398, roborev 1692): the materialising sequential
-            // scan decodes every partition body too — every body-decoding path must
-            // contribute to this counter, not only the two index-driven walks.
-            crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
             match emit((key, value))? {
                 ControlFlow::Continue(()) => {}
                 ControlFlow::Break(()) => return Ok(()),

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -234,6 +234,10 @@ impl SSTableReader {
                 )));
             }
 
+            // Work-probe (issue #2398): one partition body read + parsed. A
+            // token-range split must keep this bounded to its in-range slice, not
+            // the SSTable's whole partition count.
+            crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
             let parsed = parser.parse_block(&raw, schema, self)?;
             for (_table_id, row_key, value) in parsed {
                 if self.filter_tombstone(&value) {

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -20,6 +20,7 @@ use crate::storage::sstable::reader::SSTableReader;
 use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
 use crate::types::Value;
 use crate::{Config, Platform};
+use serial_test::serial;
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -104,7 +105,14 @@ async fn open_reader(data_path: &std::path::Path) -> SSTableReader {
 
 /// Non-vacuity + full enumeration (issue #2361): `stream_all_partitions_cancellable`
 /// (no `limit` parameter) emits every one of the fixture's `N` partitions.
+///
+/// `#[serial(work_counters)]` (issue #2398, roborev 1693): this walk increments
+/// the process-global `stream_walk_partitions_parsed` counter as a side effect;
+/// every test in this file that does so shares the `work_counters` key so none
+/// contaminates `sequential_scan_fallback_counts_each_partition_exactly_once`'s
+/// delta assertion (the established convention, issue #1071).
 #[tokio::test]
+#[serial(work_counters)]
 async fn stream_all_partitions_cancellable_emits_every_partition() {
     const N: i32 = 24;
     let (_temp, data_path) = write_fixture(N).await;
@@ -130,7 +138,11 @@ async fn stream_all_partitions_cancellable_emits_every_partition() {
 /// resolvable `Index.db` streams EVERY partition via the index walk (outcome
 /// `Streamed`), in index (token) order, emitting each as it is resolved rather
 /// than after a whole-file materialisation. Non-vacuity: all N rows arrive.
+///
+/// `#[serial(work_counters)]`: see the doc on
+/// `stream_all_partitions_cancellable_emits_every_partition` above.
 #[tokio::test]
+#[serial(work_counters)]
 async fn stream_via_full_index_streams_every_partition_in_order() {
     const N: i32 = 16;
     let (_temp, data_path) = write_fixture(N).await;
@@ -179,7 +191,11 @@ async fn stream_via_full_index_streams_every_partition_in_order() {
 /// FIRST emit stops the walk immediately — the anti-materialisation property. On
 /// the pre-#2361 code the whole SSTable was materialised into a `Vec` BEFORE the
 /// first emit, so a break could never save that work; here it does.
+///
+/// `#[serial(work_counters)]`: see the doc on
+/// `stream_all_partitions_cancellable_emits_every_partition` above.
 #[tokio::test]
+#[serial(work_counters)]
 async fn stream_all_partitions_cancellable_stops_on_break() {
     const N: i32 = 20;
     let (_temp, data_path) = write_fixture(N).await;
@@ -203,7 +219,11 @@ async fn stream_all_partitions_cancellable_stops_on_break() {
 /// Cancellation (issue #2361): a scan whose token is already tripped abandons the
 /// walk promptly, emitting nothing and returning `Error::Cancelled` — the
 /// cooperative poll at the top of the streaming walk.
+///
+/// `#[serial(work_counters)]`: see the doc on
+/// `stream_all_partitions_cancellable_emits_every_partition` above.
 #[tokio::test]
+#[serial(work_counters)]
 async fn stream_all_partitions_cancellable_pre_cancel_emits_nothing() {
     const N: i32 = 12;
     let (_temp, data_path) = write_fixture(N).await;
@@ -225,4 +245,60 @@ async fn stream_all_partitions_cancellable_pre_cancel_emits_nothing() {
         "a pre-cancelled streaming scan must return Error::Cancelled, got {result:?}"
     );
     assert_eq!(emitted, 0, "a pre-cancelled scan must emit no rows");
+}
+
+/// Roborev 1693 (issue #2398): a reader with NO `Index.db` (the sibling deleted
+/// before open, so `index_reader` is `None`) routes `stream_all_partitions_cancellable`
+/// straight into the SAME materialising `sequential_scan` fallback code path a
+/// `FellBack` streaming-walk outcome would use. `stream_walk_partitions_parsed`
+/// must land at EXACTLY `N` — one increment per partition, owned solely by
+/// `sequential_scan`'s internal accounting — never `2 * N` (the double-count a
+/// redundant increment in the fallback's re-emit loop would produce).
+///
+/// `#[serial(work_counters)]`: `stream_walk_partitions_parsed` is a process-global
+/// counter (issue #1071's established convention) — every OTHER test in this file
+/// that touches it shares this key so this delta assertion cannot be contaminated
+/// by a concurrently-running sibling.
+#[tokio::test]
+#[serial(work_counters)]
+async fn sequential_scan_fallback_counts_each_partition_exactly_once() {
+    const N: i32 = 10;
+    let (_temp, data_path) = write_fixture(N).await;
+    // Force the fallback: delete the sibling Index.db so `index_reader` is `None`
+    // and `stream_all_partitions_cancellable` falls straight through to the
+    // materialising `sequential_scan` — the same code the streaming walk's
+    // `FellBack` outcome reaches.
+    let index_path =
+        std::path::PathBuf::from(data_path.to_str().unwrap().replace("-Data.db", "-Index.db"));
+    assert!(index_path.exists(), "fixture must have written an Index.db");
+    std::fs::remove_file(&index_path).unwrap();
+
+    let reader = open_reader(&data_path).await;
+    assert!(
+        reader.index_reader.is_none(),
+        "the reader must open with no usable Index.db (sibling deleted)"
+    );
+    let cancel = ScanCancel::default();
+
+    crate::storage::sstable::work_counters::reset();
+    let mut emitted = 0usize;
+    reader
+        .stream_all_partitions_cancellable(&cancel, |_row| {
+            emitted += 1;
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        emitted, N as usize,
+        "the fallback must emit every partition"
+    );
+    assert_eq!(
+        crate::storage::sstable::work_counters::stream_walk_partitions_parsed(),
+        N as u64,
+        "the fallback must count each partition body EXACTLY ONCE (not 2x — \
+         roborev 1693): sequential_scan owns the increment, the re-emit loop \
+         in stream_all_partitions_cancellable must not increment again"
+    );
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -860,6 +860,13 @@ impl SSTableReader {
             // before sorting.  Limit is applied AFTER sort so that LIMIT N returns the N
             // token-smallest partitions, not the first N encountered in parse order.
             // (BLOCKING-1: limit-after-order)
+            // Work-probe (issue #2398, roborev 1692): same-partition rows arrive
+            // consecutively (Data.db is laid out partition-by-partition), so a
+            // changed `RowKey` (the partition key) marks a new partition body
+            // decoded — matching the "once per partition" semantics of the two
+            // index-driven walks. Tracked here, BEFORE the filters below, so it
+            // counts decode work regardless of a later tombstone/range skip.
+            let mut prev_partition_key: Option<RowKey> = None;
             for (idx, (_entry_table_id, entry_key, entry_value)) in
                 all_entries.into_iter().enumerate()
             {
@@ -870,6 +877,10 @@ impl SSTableReader {
                 // huge already-parsed result set to completion.
                 if idx & 0xFF == 0 {
                     scan_cancel.check()?;
+                }
+                if prev_partition_key.as_ref() != Some(&entry_key) {
+                    crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
+                    prev_partition_key = Some(entry_key.clone());
                 }
                 if let Some(start) = start_key {
                     if &entry_key < start {
@@ -911,6 +922,10 @@ impl SSTableReader {
 
         // Non-stitching path for other formats
         let mut block_count = 0;
+        // Work-probe (issue #2398, roborev 1692): scoped OUTSIDE the block loop so
+        // a partition split across a block boundary is not double-counted; see the
+        // stitching branch above for the "changed key = new partition" rationale.
+        let mut prev_partition_key: Option<RowKey> = None;
         while let Some(block) = self.read_next_block(&cursor).await? {
             // Cooperative cancellation (issue #2264): an index-less (Summary.db
             // absent) SSTable materialises EVERY partition here in one pass; poll
@@ -951,6 +966,13 @@ impl SSTableReader {
                     entry_table_id,
                     entry_key
                 );
+
+                // Work-probe (issue #2398, roborev 1692): count decode work BEFORE
+                // any table-id/range/tombstone filter, matching the other sites.
+                if prev_partition_key.as_ref() != Some(entry_key) {
+                    crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
+                    prev_partition_key = Some(entry_key.clone());
+                }
 
                 // Match table IDs - supports both qualified (keyspace.table) and unqualified (table) formats
                 // This allows queries with either format to match SSTables stored with either format

--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -114,6 +114,20 @@ struct Counters {
     /// `SSTableWriter::finish()` must leave this at 0; a regression that
     /// reintroduces the finish-time double re-read bumps it (2 on the old path).
     data_db_checksum_full_reads: AtomicU64,
+    /// Partition BODIES read + parsed by a `do_get` compaction-merge scan — one
+    /// per partition whose `Data.db` slice is decoded (Issue #2398). Incremented on
+    /// BOTH per-SSTable enumeration paths: the streaming full-index walk
+    /// (`stream_all_partitions_via_full_index`, the uncompressed `V5_0Uncompressed`
+    /// field path, issue #2361) AND the chunk-stitching walk
+    /// (`drain_compaction_window`, the `nb`/`V5CompressedLegacy` path). This is the
+    /// O(partitions actually walked) signal for a scan. A token-range split must
+    /// walk only the entries whose token falls in the split's `(start, end]` range
+    /// (the index/data are token-ordered), NOT every partition in the SSTable: the
+    /// current read paths apply the token filter only DOWNSTREAM at the consumer
+    /// (`MergeProducer::drive_merge`), so this bumps by the SSTable's WHOLE
+    /// partition count regardless of how narrow the split range (or `LIMIT`) is —
+    /// the fixed multi-second warm-scan setup this counter exists to make visible.
+    stream_walk_partitions_parsed: AtomicU64,
 }
 
 impl Counters {
@@ -127,6 +141,7 @@ impl Counters {
             reverse_blocks_decoded: AtomicU64::new(0),
             reverse_peak_block_rows: AtomicU64::new(0),
             data_db_checksum_full_reads: AtomicU64::new(0),
+            stream_walk_partitions_parsed: AtomicU64::new(0),
         }
     }
 
@@ -176,6 +191,15 @@ impl Counters {
         self.data_db_checksum_full_reads.load(Ordering::Relaxed)
     }
 
+    fn add_stream_walk_partition_parsed(&self) {
+        self.stream_walk_partitions_parsed
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn stream_walk_partitions_parsed(&self) -> u64 {
+        self.stream_walk_partitions_parsed.load(Ordering::Relaxed)
+    }
+
     fn reverse_blocks_decoded(&self) -> u64 {
         self.reverse_blocks_decoded.load(Ordering::Relaxed)
     }
@@ -213,6 +237,8 @@ impl Counters {
         self.reverse_blocks_decoded.store(0, Ordering::Relaxed);
         self.reverse_peak_block_rows.store(0, Ordering::Relaxed);
         self.data_db_checksum_full_reads.store(0, Ordering::Relaxed);
+        self.stream_walk_partitions_parsed
+            .store(0, Ordering::Relaxed);
     }
 }
 
@@ -317,6 +343,31 @@ pub(crate) fn observe_reverse_block_rows(rows: u64) {
 #[cfg(feature = "write-support")]
 pub fn add_data_db_checksum_full_read() {
     COUNTERS.add_data_db_checksum_full_read();
+}
+
+/// Record that a `do_get` compaction-merge scan read + parsed one partition body
+/// (issue #2361 / #2398). Called once per partition whose `Data.db` slice is
+/// decoded, on BOTH the streaming full-index walk and the chunk-stitching walk.
+///
+/// Not gated behind any feature: these walks run on the default read path (BIG
+/// SSTable, no BTI), and integration/flight tests compile against the library
+/// crate without its `test` cfg, so the increment must be present in every build
+/// (same rationale as the other read-work counters).
+pub(crate) fn add_stream_walk_partition_parsed() {
+    COUNTERS.add_stream_walk_partition_parsed();
+}
+
+/// Number of partition bodies a `do_get` scan read + parsed since the last
+/// [`reset`] (Issue #2398).
+///
+/// For a token-range split this SHOULD stay bounded by the number of partitions
+/// whose token falls in the split's `(start, end]` range, NOT the SSTable's whole
+/// partition count. The current read paths filter tokens only at the consumer, so
+/// today this reads the full count for any overlapping SSTable — the fixed
+/// warm-scan setup cost independent of the split range and of `LIMIT` that issue
+/// #2398 tracks.
+pub fn stream_walk_partitions_parsed() -> u64 {
+    COUNTERS.stream_walk_partitions_parsed()
 }
 
 /// Number of full `Data.db` re-reads performed for checksum computation since

--- a/cqlite-flight/tests/issue_2398_warm_scan_token_pushdown.rs
+++ b/cqlite-flight/tests/issue_2398_warm_scan_token_pushdown.rs
@@ -1,0 +1,220 @@
+//! Issue #2398 — reproduction: a warm token-range `do_get` scan reads + parses
+//! EVERY partition body in the SSTable, a fixed O(all partitions) per-query cost
+//! independent of the split range width and of `LIMIT`.
+//!
+//! ## What the field saw
+//!
+//! Round-9/10 (#2367): warm `LIMIT 5` scans took ~7-9s — a fixed multi-second
+//! per-query setup, NOT proportional to the returned row count, with
+//! `index_parses_total` FLAT (so it is neither the #2383 rebuild storm nor the
+//! #2385 cold index parse). The latency also VARIED with the split (6.3-7.4s),
+//! the signature of a cost that depends on WHERE in the ring the split falls.
+//!
+//! ## Root cause (this test's evidence)
+//!
+//! The per-SSTable partition enumeration (the streaming full-index walk for the
+//! uncompressed `V5_0Uncompressed` field path — `stream_all_partitions_via_full_index`,
+//! issue #2361 — and the chunk-stitching walk `drain_compaction_window` for the
+//! `nb` path) walks EVERY partition from the ring start and reads + parses each
+//! `Data.db` body. The split's token-range filter is applied only DOWNSTREAM at
+//! the consumer (`MergeProducer::drive_merge`'s `token.contains`). So a split
+//! whose `(start, end]` range covers a single partition still pays to read +
+//! parse the whole SSTable.
+//!
+//! `work_counters::stream_walk_partitions_parsed()` counts partition BODIES a scan
+//! decoded. This test drives a warm token-range scan whose range holds exactly ONE
+//! partition and shows the server decoded ALL `N` bodies to answer it — the
+//! scale-free mechanism the field 7s reflects at ~1.9M partitions.
+//!
+//! ## Flip when the fix lands (issue #2398 acceptance criterion 2)
+//!
+//! The fix is to push the token range INTO the walk (binary-search the
+//! token-ordered index entries and walk only the in-range slice). When it lands,
+//! the single-partition-range assertion below MUST become `walked <= small bound`
+//! (a few, for binary-search boundary slack) instead of `== N`, and the
+//! `>` comparison flips. See the issue for the fix plan; this test is its pinned
+//! reproduction.
+//!
+//! ## Warm small-LIMIT latency target (issue #2398 acceptance criterion 3)
+//!
+//! Warm point-reads already land at ~2.1s ≈ the Trino/JDBC transport floor
+//! (bounded index lookup). A warm small-`LIMIT` scan should approach that same
+//! floor: its server-side work must be O(in-range partitions + LIMIT), bounded
+//! near the transport floor (target: within ~1-2x the warm point-read, i.e. low
+//! single-digit seconds and NOT growing with the SSTable's total partition
+//! count), NOT the current O(all partitions in every overlapping SSTable) that
+//! makes it a fixed 7-9s at field scale. The `stream_walk_partitions_parsed`
+//! counter is the scale-free proxy for that target: for a narrow split it must
+//! track the in-range slice, not the whole SSTable.
+//!
+//! ## Isolation
+//!
+//! The work counter is a PROCESS-GLOBAL atomic and the scan runs on a spawned
+//! producer thread, so an exact count is only meaningful with no sibling `do_get`
+//! in flight. This file holds EXACTLY ONE `#[test]` — one file = one binary = one
+//! process (per-test process isolation under nextest, the gate default; no sibling
+//! threads under plain `cargo test`). Add a sibling FILE, not a second `#[test]`.
+
+use std::path::PathBuf;
+
+use arrow::record_batch::RecordBatch;
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::storage::sstable::work_counters;
+use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
+use cqlite_flight::service::CqliteFlightService;
+use cqlite_flight::test_fixtures as fx;
+
+/// Partitions written into the single SSTable. Enough that "walk them all" is
+/// unmistakably distinct from "walk the one in range".
+const N: usize = 40;
+
+/// Build ONE `nb-big` SSTable holding `N` single-`text`-PK partitions (keys
+/// `k000000..`). One flush → one SSTable the warm `do_get` merge scans.
+fn build_single_sstable() -> (tempfile::TempDir, PathBuf) {
+    let schema = fx::keyvalue_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    for i in 0..N {
+        engine
+            .write(fx::keyvalue_write(&key_for(i), &format!("v{i}")))
+            .expect("write");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush")
+        .expect("flush info");
+    (temp, data_dir)
+}
+
+fn key_for(i: usize) -> String {
+    format!("k{i:06}")
+}
+
+/// The Murmur3 token of partition `i`. A single-component `text` partition key is
+/// stored on disk as its raw value bytes, which is exactly what the scan hashes.
+fn token_for(i: usize) -> i64 {
+    cassandra_murmur3_token(key_for(i).as_bytes())
+}
+
+/// A token-range `do_get` ticket over `(start, end]`.
+fn token_range_ticket(start: i64, end: i64) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
+        "token_start": start,
+        "token_end": end,
+    }))
+    .unwrap()
+}
+
+/// A full-scan ticket (no token range).
+fn full_scan_ticket() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": fx::KEYVALUE_KS,
+        "table": fx::KEYVALUE_TBL,
+        "ddl": fx::KEYVALUE_DDL,
+    }))
+    .unwrap()
+}
+
+/// Drive the in-process `do_get` handler and fully drain the decoded stream,
+/// returning the total row count.
+async fn do_get_rows(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
+    let resp = svc
+        .do_get(Request::new(Ticket::new(ticket)))
+        .await
+        .expect("do_get");
+    let stream = resp
+        .into_inner()
+        .map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+    let mut rows = 0usize;
+    while let Some(batch) = rb.next().await {
+        let batch: RecordBatch = batch.expect("decode batch");
+        rows += batch.num_rows();
+    }
+    rows
+}
+
+#[test]
+fn warm_token_range_scan_reads_the_whole_sstable_for_one_partition() {
+    let (_temp, data_dir) = build_single_sstable();
+    let svc = CqliteFlightService::new(data_dir, 1024);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // The lowest-token partition is a single, well-defined target. A half-open
+    // range `(min_token - 1, min_token]` selects EXACTLY that one partition (all
+    // others have a strictly greater token).
+    let mut tokens: Vec<(usize, i64)> = (0..N).map(|i| (i, token_for(i))).collect();
+    tokens.sort_by_key(|(_, t)| *t);
+    let (min_idx, min_token) = tokens[0];
+    assert!(
+        min_token < tokens[1].1,
+        "fixture must have a unique lowest token (got {min_token} == {})",
+        tokens[1].1
+    );
+    let start = min_token.saturating_sub(1);
+    let end = min_token;
+
+    rt.block_on(async {
+        // Warm the reader (first request opens + parses the index; the #2310 warm
+        // path the field runs). Its walk parses are discarded by the reset below.
+        let _ = do_get_rows(&svc, full_scan_ticket()).await;
+
+        // ---- A warm token-range scan whose range holds exactly ONE partition. --
+        work_counters::reset();
+        let rows = do_get_rows(&svc, token_range_ticket(start, end)).await;
+        let walked = work_counters::stream_walk_partitions_parsed() as usize;
+
+        // Correctness: exactly the one in-range partition's row is returned.
+        assert_eq!(
+            rows, 1,
+            "the (min-1, min] range must return exactly the lowest-token partition \
+             (idx {min_idx})"
+        );
+
+        // Control: a full scan's whole-SSTable body count, so the comparison below
+        // is against a measured baseline, not a hard-coded N.
+        work_counters::reset();
+        let all = do_get_rows(&svc, full_scan_ticket()).await;
+        let full_walked = work_counters::stream_walk_partitions_parsed() as usize;
+        assert_eq!(all, N, "the full scan returns every partition");
+        assert_eq!(
+            full_walked, N,
+            "a full (no token range) scan walks every partition body"
+        );
+
+        // THE evidence (issue #2398): answering a ONE-partition token range cost
+        // the SAME whole-SSTable body-parse work as the full scan — the token
+        // filter runs only at the consumer, so the walk reads every partition
+        // regardless of the split range. This is the fixed per-query setup the
+        // field saw as a multi-second cost independent of the result size.
+        //
+        // FLIP WHEN THE FIX LANDS: once the token range is pushed into the walk
+        // (binary-search the token-ordered index, walk only the in-range slice),
+        // change this to `assert!(walked <= 4, ...)` — the walk will touch only the
+        // in-range partition (+ small boundary slack), NOT all {N}.
+        assert_eq!(
+            walked, full_walked,
+            "issue #2398: a single-partition token range parsed {walked} partition \
+             bodies — the SAME as the whole-SSTable full scan ({full_walked}) — \
+             because the token filter is applied only downstream at the consumer, \
+             not pushed into the per-SSTable walk. This is the fixed warm-scan \
+             setup cost independent of the split range and of LIMIT."
+        );
+    });
+}

--- a/cqlite-flight/tests/issue_2398_warm_scan_token_pushdown.rs
+++ b/cqlite-flight/tests/issue_2398_warm_scan_token_pushdown.rs
@@ -156,19 +156,27 @@ fn warm_token_range_scan_reads_the_whole_sstable_for_one_partition() {
     let svc = CqliteFlightService::new(data_dir, 1024);
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    // The lowest-token partition is a single, well-defined target. A half-open
-    // range `(min_token - 1, min_token]` selects EXACTLY that one partition (all
-    // others have a strictly greater token).
+    // Pick an INTERIOR partition (roborev 1692, low): the ring MINIMUM's
+    // predecessor bound (`min_token - 1`) collapses to `min_token` itself when
+    // `min_token == i64::MIN`, and `token_in_half_open_range` treats an equal
+    // `(start, end]` pair as the FULL ring (not empty) — so anchoring on the
+    // lowest token risks silently widening the "one partition" range to a full
+    // scan instead of narrowing it. An interior token's own predecessor in the
+    // SORTED token order is always a strictly smaller, distinct i64 (no
+    // wraparound edge), so `(predecessor, target]` is unconditionally a genuine
+    // one-partition half-open range.
     let mut tokens: Vec<(usize, i64)> = (0..N).map(|i| (i, token_for(i))).collect();
     tokens.sort_by_key(|(_, t)| *t);
-    let (min_idx, min_token) = tokens[0];
+    let mid = tokens.len() / 2;
+    let (target_idx, target_token) = tokens[mid];
+    let predecessor_token = tokens[mid - 1].1;
     assert!(
-        min_token < tokens[1].1,
-        "fixture must have a unique lowest token (got {min_token} == {})",
-        tokens[1].1
+        predecessor_token < target_token,
+        "fixture must have a unique target token (got {target_token} == predecessor \
+         {predecessor_token})"
     );
-    let start = min_token.saturating_sub(1);
-    let end = min_token;
+    let start = predecessor_token;
+    let end = target_token;
 
     rt.block_on(async {
         // Warm the reader (first request opens + parses the index; the #2310 warm
@@ -183,8 +191,8 @@ fn warm_token_range_scan_reads_the_whole_sstable_for_one_partition() {
         // Correctness: exactly the one in-range partition's row is returned.
         assert_eq!(
             rows, 1,
-            "the (min-1, min] range must return exactly the lowest-token partition \
-             (idx {min_idx})"
+            "the (predecessor, target] range must return exactly the target \
+             partition (idx {target_idx})"
         );
 
         // Control: a full scan's whole-SSTable body count, so the comparison below


### PR DESCRIPTION
Closes #2398

## What this PR ships (identification half — the fix is #2413)
- **Dominant warm-scan setup cost IDENTIFIED (AC#1)**: the token-range filter is applied only downstream at the consumer (`MergeProducer::drive_merge`); per-SSTable partition enumeration reads + parses EVERY partition body from ring start regardless of split token range or LIMIT. `iterate_token_range` is deprecated/no-op. Matches the #2367 R9/R10 field signature (fixed ~7-9s setup independent of row count, flat index_parses).
- **`stream_walk_partitions_parsed` work-probe counter** covering ALL body-decoding paths (full-index walk, chunk-stitching, sequential/FellBack — single accounting site per decode).
- **Scale-free red pin (AC#2 adjudication)**: `warm_token_range_scan_reads_the_whole_sstable_for_one_partition` documents current behavior (single-partition token-range scan decodes 40/40 bodies == full scan); flip to `walked <= 4` when #2413 lands. Plus `sequential_scan_fallback_counts_each_partition_exactly_once` (pins the accounting) and `#[serial(work_counters)]` isolation after real cross-test contamination was caught.
- **Latency target documented (AC#3)**: warm small-LIMIT = O(in-range partitions + LIMIT), near the ~2.1s point-read/transport floor.
- **Fix explicitly adjudicated to #2413** (token pushdown into the walk) — large parity-sensitive change threading compaction-shared merge constructors across both scan paths; design interplay with #2412 resolves at its Seam 1.

## Review trail (review-first, #2086)
- rust-reviewer: APPROVE, 0 blockers (observation-only confirmed; non-vacuous test confirmed).
- roborev 1692: 2 findings → fixed (FellBack counter coverage @503fb585-1; interior-partition range construction).
- roborev 1693: 1 finding → fixed (FellBack double-count; exactly-once pin added @e32fdb77).
- roborev 1694: 1 finding → DECLINED with evidence on the job (cited serial_test import does not exist in the flight test; dep declared in cqlite-core where the attributes live; lite compiled+ran the targets green).

## Nits to batch at merge (follow-up issue, per severity rubric #2088)
1. work_counters.rs:82/:451 stale "five counters" wording (now nine).
2. full_index_stream.rs counter-bump doc phrase slightly ahead of `parse_block` success.

## Notes
- `sequential.rs` is pre-existing over the campsite threshold; counter insertion re-certified with `CQLITE_ALLOW_FILE_GROWTH=1` per the documented exception (#1116) — not a split occasion.
- Lite summaries at /tmp/lite-2398.txt (MODE: lite — NOT the gate of record). The full gate of record runs once in flow-closer pre-merge.