### PR TITLE
fix(#2384): snapshot-aware SSTable identity path parsing (ID-ful snapshots + snapshots-keyspace guard)

### DIFF
--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -41,6 +41,10 @@ mod reverse_scan; // BIG reverse partition iteration (issue #1184); file is tomb
 pub mod row_cell_state_machine;
 /// Cross-SSTable scan ordering: k-way merge in Cassandra token order (issue #1580).
 mod scan_merge;
+/// Authoritative snapshot-aware SSTable path parsing (issue #2384): the single
+/// source of truth for deriving `{keyspace}.{table}` identity from a Data.db path,
+/// transparently resolving Cassandra `snapshots/{tag}` layouts.
+pub(crate) mod snapshot_path;
 pub mod statistics_reader;
 pub mod stream_merge_probe; // Multi-generation streaming-merge resident-rows probe (issue #1579, D3).
 #[cfg(feature = "tombstones")]
@@ -324,24 +328,13 @@ impl SSTableId {
 ///
 /// Note: Table names can contain hyphens, so we need to be careful to only remove the UUID.
 /// UUIDs in Cassandra directory names are 32 hex chars without hyphens (e.g., 6aa08200a25111f0a3fef1a551383fb9).
+///
+/// Snapshot-aware (issue #2384): routes through the authoritative
+/// [`snapshot_path`] parser so a snapshot read
+/// (`.../{table}-{uuid}/snapshots/{tag}/...-Data.db`) keys the `SSTableManager`
+/// under the REAL table name, never the snapshot tag.
 pub(crate) fn extract_table_name(sstable_path: &Path) -> Option<String> {
-    // Get the parent directory name
-    let dir_name = sstable_path.parent()?.file_name()?.to_str()?;
-
-    // Find the last occurrence of '-' followed by 32 hex characters (UUID without hyphens)
-    // Cassandra UUIDs in directory names are formatted as: tablename-<32-hex-chars>
-    if let Some(uuid_start) = dir_name.rfind('-') {
-        let potential_uuid = &dir_name[uuid_start + 1..];
-
-        // Check if this looks like a UUID (32 hex characters)
-        if potential_uuid.len() == 32 && potential_uuid.chars().all(|c| c.is_ascii_hexdigit()) {
-            // Extract everything before the UUID
-            return Some(dir_name[..uuid_start].to_string());
-        }
-    }
-
-    // If we couldn't find a UUID pattern, return the whole directory name
-    Some(dir_name.to_string())
+    snapshot_path::extract_table_name(sstable_path)
 }
 
 /// Extract the fully-qualified table key (`"keyspace.table"`) from an SSTable path.
@@ -375,18 +368,14 @@ pub(crate) fn extract_table_name(sstable_path: &Path) -> Option<String> {
 /// "nb-1-big-Data.db"   (flat, no parent dirs)
 ///   → None
 /// ```
+///
+/// Snapshot-aware (issue #2384): both the keyspace and the table name are derived
+/// through the authoritative [`snapshot_path`] parser, so a snapshot read resolves
+/// the REAL `{keyspace}.{table}` for `SSTableManager` keying rather than
+/// `snapshots`/`{tag}`.
 pub fn extract_keyspace_and_table_name(sstable_path: &Path) -> Option<(String, String)> {
-    let table_name = extract_table_name(sstable_path)?;
-
-    // The keyspace directory is the grandparent of the SSTable file:
-    //   <keyspace>/<table-uuid>/<sstable_file>
-    let keyspace = sstable_path
-        .parent() // table-uuid dir
-        .and_then(|p| p.parent()) // keyspace dir
-        .and_then(|p| p.file_name())
-        .and_then(|n| n.to_str())
-        .map(|s| s.to_string())?;
-
+    let table_name = snapshot_path::extract_table_name(sstable_path)?;
+    let keyspace = snapshot_path::extract_keyspace(sstable_path)?;
     Some((keyspace, table_name))
 }
 

--- a/cqlite-core/src/storage/sstable/reader/header.rs
+++ b/cqlite-core/src/storage/sstable/reader/header.rs
@@ -21,19 +21,45 @@ pub(crate) use super::header_helpers::{
     calculate_actual_header_size, extract_generation_from_path,
 };
 
+/// Resolve the `{table_name}-{uuid}` directory for a Data.db path.
+///
+/// Cassandra lays out SSTables as `.../{keyspace}/{table_name}-{uuid}/...-Data.db`.
+/// For a **snapshot**, the SSTable components live one extra level deep, under
+/// `.../{table_name}-{uuid}/snapshots/{snapshot_name}/...-Data.db` (see
+/// `Directories.SNAPSHOT_SUBDIR` in Cassandra's `Directories.java`). In that case
+/// the Data.db file's parent is the snapshot directory, whose parent is the literal
+/// `snapshots` directory, whose parent is the real `{table_name}-{uuid}` directory.
+///
+/// This is pure directory-segment structure (not a data/byte heuristic): we detect
+/// the fixed `snapshots/{snapshot_name}` layout and walk up past it so keyspace and
+/// table name resolve to the real values rather than `snapshots`/`{snapshot_name}`.
+fn resolve_table_dir(path: &Path) -> Option<&Path> {
+    // Parent of the Data.db file: `{table_name}-{uuid}` (normal) or
+    // `{snapshot_name}` (snapshot layout).
+    let parent = path.parent()?;
+
+    // Snapshot layout: parent's parent is the literal `snapshots` directory.
+    if let Some(maybe_snapshots) = parent.parent() {
+        if maybe_snapshots.file_name().and_then(|n| n.to_str()) == Some("snapshots") {
+            // Walk up past `snapshots` to the real `{table_name}-{uuid}` directory.
+            return maybe_snapshots.parent();
+        }
+    }
+
+    Some(parent)
+}
+
 /// Extract keyspace name from SSTable file path
 ///
 /// SSTable paths follow Cassandra convention:
 /// `/path/to/sstables/{keyspace}/{table_name}-{uuid}/nb-1-big-Data.db`
+/// (or, for snapshots, `.../{table_name}-{uuid}/snapshots/{snapshot}/nb-1-big-Data.db`).
 ///
-/// This function extracts the keyspace directory name (grandparent of the Data.db file).
+/// This function extracts the keyspace directory name (parent of the resolved
+/// `{table_name}-{uuid}` directory), and is snapshot-aware via [`resolve_table_dir`].
 fn extract_keyspace_from_path(path: &Path) -> String {
-    // Get parent directory containing table_name-uuid
-    path.parent()
-        .and_then(|table_dir| {
-            // Get keyspace directory (parent of table directory)
-            table_dir.parent()
-        })
+    resolve_table_dir(path)
+        .and_then(|table_dir| table_dir.parent())
         .and_then(|keyspace_dir| keyspace_dir.file_name())
         .and_then(|n| n.to_str())
         .unwrap_or("unknown")
@@ -44,11 +70,13 @@ fn extract_keyspace_from_path(path: &Path) -> String {
 ///
 /// SSTable paths follow Cassandra convention:
 /// `/path/to/sstables/{keyspace}/{table_name}-{uuid}/nb-1-big-Data.db`
+/// (or, for snapshots, `.../{table_name}-{uuid}/snapshots/{snapshot}/nb-1-big-Data.db`).
 ///
-/// This function extracts the table name from the parent directory, stripping the UUID suffix.
+/// This function extracts the table name from the resolved `{table_name}-{uuid}`
+/// directory (snapshot-aware via [`resolve_table_dir`]), stripping the UUID suffix.
 /// Format: "table_name-uuid" → "table_name"
 fn extract_table_name_from_path(path: &Path) -> String {
-    path.parent()
+    resolve_table_dir(path)
         .and_then(|p| p.file_name())
         .and_then(|n| n.to_str())
         .and_then(|s| {
@@ -999,6 +1027,77 @@ mod tests {
             !is_collision,
             "V5_0ComplexTypes should not be flagged as collision"
         );
+    }
+
+    /// Normal (non-snapshot) path resolves keyspace + table correctly.
+    ///
+    /// `.../myks/mytable-<uuid32hex>/nb-2-big-Data.db` → keyspace=`myks`, table=`mytable`.
+    #[test]
+    fn test_extract_path_normal_layout() {
+        let path = Path::new(
+            "/var/lib/cassandra/data/myks/mytable-9f3a1c2d4e5f6071829304a5b6c7d8e9/nb-2-big-Data.db",
+        );
+        assert_eq!(extract_keyspace_from_path(path), "myks");
+        assert_eq!(extract_table_name_from_path(path), "mytable");
+    }
+
+    /// Snapshot path (issue #2384) must resolve to the REAL keyspace/table, not
+    /// `snapshots`/`{snapshot_name}`.
+    ///
+    /// `.../myks/mytable-<uuid>/snapshots/cqlite-<qid>/nb-2-big-Data.db`
+    /// → keyspace=`myks`, table=`mytable` (NOT `snapshots`/`cqlite`).
+    #[test]
+    fn test_extract_path_snapshot_layout() {
+        let path = Path::new(
+            "/var/lib/cassandra/data/myks/mytable-9f3a1c2d4e5f6071829304a5b6c7d8e9/\
+             snapshots/cqlite-3b1e7f90/nb-2-big-Data.db",
+        );
+        assert_eq!(
+            extract_keyspace_from_path(path),
+            "myks",
+            "snapshot path must not misparse keyspace as 'snapshots'"
+        );
+        assert_eq!(
+            extract_table_name_from_path(path),
+            "mytable",
+            "snapshot path must not misparse table as 'cqlite'"
+        );
+    }
+
+    /// Snapshot dir named something other than `cqlite-*` (e.g. a Cassandra
+    /// nodetool snapshot tag) still resolves the real keyspace/table.
+    #[test]
+    fn test_extract_path_snapshot_arbitrary_name() {
+        let path = Path::new(
+            "/data/analytics/events-0011223344556677889900aabbccddeeff/\
+             snapshots/pre-upgrade-2026/nb-5-big-Data.db",
+        );
+        assert_eq!(extract_keyspace_from_path(path), "analytics");
+        // Table name contains no hyphen after uuid strip → "events".
+        assert_eq!(extract_table_name_from_path(path), "events");
+    }
+
+    /// Deeper absolute nesting: the keyspace/table pair is resolved relative to
+    /// the SSTable dir regardless of how deep the data root is.
+    #[test]
+    fn test_extract_path_deep_nesting_normal() {
+        let path = Path::new(
+            "/mnt/disk3/cassandra/data/ks_ts/sensor-readings-abcdef0123456789abcdef0123456789/\
+             da-11-bti-Data.db",
+        );
+        assert_eq!(extract_keyspace_from_path(path), "ks_ts");
+        // Table name with an internal hyphen: only the trailing uuid is stripped.
+        assert_eq!(extract_table_name_from_path(path), "sensor-readings");
+    }
+
+    /// Malformed / too-shallow paths fall back to the "unknown" sentinel without
+    /// panicking (preserves prior no-error-path behaviour).
+    #[test]
+    fn test_extract_path_malformed_fallback() {
+        let path = Path::new("nb-1-big-Data.db");
+        assert_eq!(extract_keyspace_from_path(path), "unknown");
+        // No hyphen-then-suffix in the (missing) parent → "unknown".
+        assert_eq!(extract_table_name_from_path(path), "unknown");
     }
 
     /// Test that unrecognized bytes are not flagged as collisions.

--- a/cqlite-core/src/storage/sstable/reader/header.rs
+++ b/cqlite-core/src/storage/sstable/reader/header.rs
@@ -21,71 +21,26 @@ pub(crate) use super::header_helpers::{
     calculate_actual_header_size, extract_generation_from_path,
 };
 
-/// Resolve the `{table_name}-{uuid}` directory for a Data.db path.
+/// Extract keyspace name from SSTable file path (snapshot-aware).
 ///
-/// Cassandra lays out SSTables as `.../{keyspace}/{table_name}-{uuid}/...-Data.db`.
-/// For a **snapshot**, the SSTable components live one extra level deep, under
-/// `.../{table_name}-{uuid}/snapshots/{snapshot_name}/...-Data.db` (see
-/// `Directories.SNAPSHOT_SUBDIR` in Cassandra's `Directories.java`). In that case
-/// the Data.db file's parent is the snapshot directory, whose parent is the literal
-/// `snapshots` directory, whose parent is the real `{table_name}-{uuid}` directory.
-///
-/// This is pure directory-segment structure (not a data/byte heuristic): we detect
-/// the fixed `snapshots/{snapshot_name}` layout and walk up past it so keyspace and
-/// table name resolve to the real values rather than `snapshots`/`{snapshot_name}`.
-fn resolve_table_dir(path: &Path) -> Option<&Path> {
-    // Parent of the Data.db file: `{table_name}-{uuid}` (normal) or
-    // `{snapshot_name}` (snapshot layout).
-    let parent = path.parent()?;
-
-    // Snapshot layout: parent's parent is the literal `snapshots` directory.
-    if let Some(maybe_snapshots) = parent.parent() {
-        if maybe_snapshots.file_name().and_then(|n| n.to_str()) == Some("snapshots") {
-            // Walk up past `snapshots` to the real `{table_name}-{uuid}` directory.
-            return maybe_snapshots.parent();
-        }
-    }
-
-    Some(parent)
-}
-
-/// Extract keyspace name from SSTable file path
-///
-/// SSTable paths follow Cassandra convention:
-/// `/path/to/sstables/{keyspace}/{table_name}-{uuid}/nb-1-big-Data.db`
-/// (or, for snapshots, `.../{table_name}-{uuid}/snapshots/{snapshot}/nb-1-big-Data.db`).
-///
-/// This function extracts the keyspace directory name (parent of the resolved
-/// `{table_name}-{uuid}` directory), and is snapshot-aware via [`resolve_table_dir`].
+/// Delegates to the authoritative snapshot-aware parser
+/// [`crate::storage::sstable::snapshot_path::extract_keyspace`] so header keyspace
+/// resolution matches schema-registry resolution and `SSTableManager` keying
+/// exactly (issue #2384). Falls back to the `"unknown"` sentinel when the path is
+/// too shallow to contain a keyspace directory.
 fn extract_keyspace_from_path(path: &Path) -> String {
-    resolve_table_dir(path)
-        .and_then(|table_dir| table_dir.parent())
-        .and_then(|keyspace_dir| keyspace_dir.file_name())
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown")
-        .to_string()
+    crate::storage::sstable::snapshot_path::extract_keyspace(path)
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
-/// Extract table name from SSTable file path
+/// Extract table name from SSTable file path (snapshot-aware).
 ///
-/// SSTable paths follow Cassandra convention:
-/// `/path/to/sstables/{keyspace}/{table_name}-{uuid}/nb-1-big-Data.db`
-/// (or, for snapshots, `.../{table_name}-{uuid}/snapshots/{snapshot}/nb-1-big-Data.db`).
-///
-/// This function extracts the table name from the resolved `{table_name}-{uuid}`
-/// directory (snapshot-aware via [`resolve_table_dir`]), stripping the UUID suffix.
-/// Format: "table_name-uuid" → "table_name"
+/// Delegates to the authoritative snapshot-aware parser
+/// [`crate::storage::sstable::snapshot_path::extract_table_name`] (issue #2384).
+/// Falls back to the `"unknown"` sentinel when the path has no directory component.
 fn extract_table_name_from_path(path: &Path) -> String {
-    resolve_table_dir(path)
-        .and_then(|p| p.file_name())
-        .and_then(|n| n.to_str())
-        .and_then(|s| {
-            // Split on last hyphen to handle table names containing hyphens
-            // Format: "table_name-uuid" or "user-profiles-abc123"
-            s.rsplit_once('-').map(|(table_name, _uuid)| table_name)
-        })
-        .unwrap_or("unknown")
-        .to_string()
+    crate::storage::sstable::snapshot_path::extract_table_name(path)
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// Check if a value appears to be ASCII corruption
@@ -1064,12 +1019,36 @@ mod tests {
         );
     }
 
+    /// BLOCKER 1 regression (issue #2384): an ORDINARY table living in a keyspace
+    /// literally named `snapshots` must NOT be misparsed as a snapshot layout.
+    ///
+    /// `.../data/snapshots/<table>-<32hex>/nb-1-big-Data.db`
+    /// → keyspace=`snapshots`, table=`<table>` (the dir above `snapshots` is the
+    /// data root, NOT a `{table}-{32hex}` dir, so the snapshot walk-up is skipped).
+    #[test]
+    fn test_extract_path_snapshots_named_keyspace_not_a_snapshot() {
+        let path = Path::new(
+            "/var/lib/cassandra/data/snapshots/mytable-9f3a1c2d4e5f6071829304a5b6c7d8e9/\
+             nb-1-big-Data.db",
+        );
+        assert_eq!(
+            extract_keyspace_from_path(path),
+            "snapshots",
+            "keyspace literally named 'snapshots' must be preserved (BLOCKER 1)"
+        );
+        assert_eq!(
+            extract_table_name_from_path(path),
+            "mytable",
+            "table must resolve normally, not be misread as a snapshot tag"
+        );
+    }
+
     /// Snapshot dir named something other than `cqlite-*` (e.g. a Cassandra
     /// nodetool snapshot tag) still resolves the real keyspace/table.
     #[test]
     fn test_extract_path_snapshot_arbitrary_name() {
         let path = Path::new(
-            "/data/analytics/events-0011223344556677889900aabbccddeeff/\
+            "/data/analytics/events-00112233445566778899aabbccddeeff/\
              snapshots/pre-upgrade-2026/nb-5-big-Data.db",
         );
         assert_eq!(extract_keyspace_from_path(path), "analytics");

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -61,17 +61,24 @@ use crate::{
 
 use super::types::SSTableReader;
 
-/// Extract keyspace and table name from SSTable directory path
+/// Extract keyspace and table name from SSTable directory path (snapshot-aware).
 ///
 /// SSTable paths follow Cassandra convention:
-/// `/path/to/sstables/{keyspace}/{table_name}-{uuid}/nb-1-big-Data.db`
+/// `/path/to/sstables/{keyspace}/{table_name}-{uuid}/nb-1-big-Data.db`, or for a
+/// snapshot `.../{table_name}-{uuid}/snapshots/{tag}/nb-1-big-Data.db`.
+///
+/// This routes through the authoritative snapshot-aware parser
+/// ([`crate::storage::sstable::snapshot_path`], issue #2384) so schema-registry
+/// resolution and the V5CompressedLegacy block parser resolve the REAL
+/// `{keyspace}.{table}` for a snapshot read — never `snapshots`/`{tag}` — matching
+/// header resolution and `SSTableManager` keying exactly.
 ///
 /// # Arguments
 /// * `path` - Path to the SSTable Data.db file
 ///
 /// # Returns
 /// * `Ok((keyspace, table_name))` - Extracted names
-/// * `Err(Error::Schema)` - If path doesn't match expected format
+/// * `Err(Error::Schema)` - If path doesn't contain enough directory components
 ///
 /// # Examples
 /// ```ignore
@@ -83,41 +90,12 @@ use super::types::SSTableReader;
 pub(in crate::storage::sstable::reader) fn extract_keyspace_table_from_path(
     path: &Path,
 ) -> Result<(String, String)> {
-    // Get parent directory containing table_name-uuid
-    let table_dir = path
-        .parent()
-        .ok_or_else(|| Error::schema("SSTable path has no parent directory"))?;
+    use crate::storage::sstable::snapshot_path;
 
-    // Extract table directory name
-    let table_dir_name = table_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| Error::schema("Invalid table directory name"))?;
-
-    // Split on last hyphen to handle table names containing hyphens
-    // Format: "table_name-uuid" or "user-profiles-abc123"
-    let table_name = table_dir_name
-        .rsplit_once('-')
-        .ok_or_else(|| {
-            Error::schema(format!(
-                "Table directory '{}' does not match 'tablename-uuid' format",
-                table_dir_name
-            ))
-        })?
-        .0
-        .to_string();
-
-    // Get keyspace directory (parent of table directory)
-    let keyspace_dir = table_dir
-        .parent()
-        .ok_or_else(|| Error::schema("Table directory has no parent (keyspace) directory"))?;
-
-    // Extract keyspace name
-    let keyspace = keyspace_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| Error::schema("Invalid keyspace directory name"))?
-        .to_string();
+    let keyspace = snapshot_path::extract_keyspace(path)
+        .ok_or_else(|| Error::schema("SSTable path has no keyspace directory (too shallow)"))?;
+    let table_name = snapshot_path::extract_table_name(path)
+        .ok_or_else(|| Error::schema("SSTable path has no table directory"))?;
 
     Ok((keyspace, table_name))
 }
@@ -279,11 +257,38 @@ mod tests {
 
     #[test]
     fn test_extract_keyspace_table_with_hyphens() {
-        // Table name contains hyphens
-        let path = Path::new("/data/sstables/my_keyspace/user-profiles-xyz789/nb-1-big-Data.db");
+        // Table name contains hyphens; only the trailing 32-hex table id is stripped.
+        let path = Path::new(
+            "/data/sstables/my_keyspace/user-profiles-00112233445566778899aabbccddeeff/nb-1-big-Data.db",
+        );
         let (keyspace, table) = extract_keyspace_table_from_path(path).unwrap();
         assert_eq!(keyspace, "my_keyspace");
         assert_eq!(table, "user-profiles");
+    }
+
+    /// Snapshot layout (issue #2384): schema-registry / block-parser identity
+    /// resolution must yield the REAL keyspace/table, not `snapshots`/`{tag}`.
+    #[test]
+    fn test_extract_keyspace_table_snapshot_layout() {
+        let path = Path::new(
+            "/data/sstables/myks/mytable-9f3a1c2d4e5f6071829304a5b6c7d8e9/\
+             snapshots/cqlite-3b1e7f90/nb-1-big-Data.db",
+        );
+        let (keyspace, table) = extract_keyspace_table_from_path(path).unwrap();
+        assert_eq!(keyspace, "myks");
+        assert_eq!(table, "mytable");
+    }
+
+    /// BLOCKER 1 regression: a keyspace literally named `snapshots` must not be
+    /// misparsed as a snapshot layout in the schema-resolution path either.
+    #[test]
+    fn test_extract_keyspace_table_snapshots_named_keyspace() {
+        let path = Path::new(
+            "/data/sstables/snapshots/mytable-9f3a1c2d4e5f6071829304a5b6c7d8e9/nb-1-big-Data.db",
+        );
+        let (keyspace, table) = extract_keyspace_table_from_path(path).unwrap();
+        assert_eq!(keyspace, "snapshots");
+        assert_eq!(table, "mytable");
     }
 
     #[test]
@@ -313,17 +318,20 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_keyspace_table_invalid_format() {
-        // Invalid format - no hyphen in table directory
+    fn test_extract_keyspace_table_no_id_suffix() {
+        // A table directory with no trailing 32-hex id: the whole directory name is
+        // the table name (no hyphen split), keyspace resolves normally.
         let path = Path::new("/data/keyspace/tablename/Data.db");
-        let result = extract_keyspace_table_from_path(path);
-        assert!(result.is_err());
+        let (keyspace, table) = extract_keyspace_table_from_path(path).unwrap();
+        assert_eq!(keyspace, "keyspace");
+        assert_eq!(table, "tablename");
     }
 
     #[test]
     fn test_extract_keyspace_table_relative_path() {
-        // Relative path (should work)
-        let path = Path::new("test_basic/simple_table-abc123/nb-1-big-Data.db");
+        // Relative path (should work) with a real 32-hex table id.
+        let path =
+            Path::new("test_basic/simple_table-6b0425d0a25111f0a3fef1a551383fb9/nb-1-big-Data.db");
         let (keyspace, table) = extract_keyspace_table_from_path(path).unwrap();
         assert_eq!(keyspace, "test_basic");
         assert_eq!(table, "simple_table");

--- a/cqlite-core/src/storage/sstable/snapshot_path.rs
+++ b/cqlite-core/src/storage/sstable/snapshot_path.rs
@@ -56,6 +56,19 @@ fn is_table_id_dir(name: &str) -> bool {
 /// (`.../data/snapshots/{table}-{id}/...-Data.db`): there the dir above
 /// `snapshots` is the keyspace root (e.g. `data`), which is NOT a table dir, so
 /// the path is correctly treated as a normal (non-snapshot) layout.
+///
+/// # Known limitation — ID-less snapshot dirs (follow-up #2415)
+///
+/// The [`is_table_id_dir`] guard requires the `-{32-hex}` id suffix, so it only
+/// fires for Cassandra-shaped ID-ful snapshots. CQLite's own write engine emits
+/// ID-LESS table dirs `{ks}/{table}/` (no uuid suffix — `writer/mod.rs`); a
+/// snapshot of one (`{ks}/{table}/snapshots/{tag}/...-Data.db`) does NOT match the
+/// guard, so the walk-up is skipped and header identity misparses as
+/// keyspace=`snapshots`, table=`{tag}`. This is inherently unresolvable from the
+/// path alone — an ID-less snapshot and an ordinary table in a keyspace literally
+/// named `snapshots` are structurally identical. The robust fix (threading
+/// authoritative keyspace/table into the reader) is tracked as #2415. See the
+/// `idless_snapshot_currently_unresolved_pending_followup` test below.
 pub(crate) fn resolve_table_dir(path: &Path) -> Option<&Path> {
     // Parent of the Data.db file: `{table_name}-{table_id}` (normal) or
     // `{snapshot_name}` (snapshot layout).
@@ -198,6 +211,36 @@ mod tests {
         // No hyphen / empty table.
         assert!(!is_table_id_dir("snapshots"));
         assert!(!is_table_id_dir("-9f3a1c2d4e5f6071829304a5b6c7d8e9"));
+    }
+
+    /// PINS A KNOWN LIMITATION, NOT DESIRED BEHAVIOR (follow-up #2415).
+    ///
+    /// CQLite's own write engine emits ID-LESS table dirs `{ks}/{table}/` (no
+    /// `-{uuid}` suffix — `writer/mod.rs`). A snapshot of such a table has the
+    /// shape `{ks}/{table}/snapshots/{tag}/...-Data.db`. Because `is_table_id_dir`
+    /// requires a `-{32-hex}` suffix, the walk-up past `snapshots` is NOT taken, so
+    /// header identity currently resolves as keyspace=`snapshots`, table=`{tag}`.
+    ///
+    /// This is inherently unresolvable from the path alone (an ID-less snapshot and
+    /// an ordinary table in a keyspace literally named `snapshots` are structurally
+    /// identical); the robust fix threads authoritative keyspace/table into the
+    /// reader and is tracked as #2415. When #2415 lands this assertion should FLIP
+    /// (to keyspace=`myks`, table=`mytable`) — that visible break is intentional.
+    #[test]
+    fn idless_snapshot_currently_unresolved_pending_followup() {
+        let path = Path::new("/data/myks/mytable/snapshots/cqlite-abc/nb-2-big-Data.db");
+        // CURRENT (limited) behavior: the `snapshots` layer is not walked past
+        // because `mytable` lacks a `-{32-hex}` id suffix.
+        assert_eq!(
+            extract_keyspace(path).as_deref(),
+            Some("snapshots"),
+            "known limitation (#2415): ID-less snapshot keyspace misparses as 'snapshots'"
+        );
+        assert_eq!(
+            extract_table_name(path).as_deref(),
+            Some("cqlite-abc"),
+            "known limitation (#2415): ID-less snapshot table misparses as the snapshot tag"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/snapshot_path.rs
+++ b/cqlite-core/src/storage/sstable/snapshot_path.rs
@@ -1,0 +1,210 @@
+//! Authoritative snapshot-aware SSTable path parsing (issue #2384).
+//!
+//! Cassandra lays SSTables out as
+//! `.../{keyspace}/{table_name}-{table_id}/...-Data.db`. For a **snapshot** the
+//! components live one level deeper, under
+//! `.../{table_name}-{table_id}/snapshots/{snapshot_name}/...-Data.db`
+//! (see `Directories.SNAPSHOT_SUBDIR` in Cassandra's `Directories.java`).
+//!
+//! Every in-crate parser that derives `{keyspace}.{table}` identity from a path —
+//! header keyspace/table, schema-registry resolution, and `SSTableManager` keying —
+//! MUST route through this module so a snapshot read resolves the REAL
+//! `{keyspace}.{table}` rather than `snapshots`/`{snapshot_name}`.
+//!
+//! This is pure directory-segment STRUCTURE matching (a fixed Cassandra naming
+//! shape), not a data/byte heuristic — it is compliant with the no-heuristics
+//! mandate (issue #28).
+
+use std::path::Path;
+
+/// Return `true` when `name` matches Cassandra's `{table_name}-{table_id}` dir
+/// shape: a non-empty table name, a `-`, then EXACTLY 32 lowercase hex chars.
+///
+/// Cassandra encodes the table UUID as 32 lowercase hex digits (no hyphens) in
+/// the on-disk directory name (`TableMetadata`/`Directories.java`). Table names
+/// may themselves contain hyphens, so only the final `-{32-hex}` suffix is the
+/// id — we split on the LAST hyphen.
+fn is_table_id_dir(name: &str) -> bool {
+    match name.rsplit_once('-') {
+        Some((table_name, id)) => {
+            !table_name.is_empty()
+                && id.len() == 32
+                && id
+                    .chars()
+                    .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f'))
+        }
+        None => false,
+    }
+}
+
+/// Resolve the real `{table_name}-{table_id}` directory for a Data.db `path`,
+/// transparently walking up past a `snapshots/{snapshot_name}` layer.
+///
+/// For a normal SSTable the resolved directory is simply the Data.db file's
+/// parent. For a snapshot (`.../{table}-{id}/snapshots/{tag}/...-Data.db`) it is
+/// the grandparent-of-`snapshots` directory.
+///
+/// # Snapshot detection is STRUCTURAL and guarded
+///
+/// A path is only treated as a snapshot when BOTH hold:
+/// 1. the grandparent directory is literally named `snapshots`, AND
+/// 2. the directory ABOVE `snapshots` matches the `{table}-{32-hex}` shape
+///    ([`is_table_id_dir`]).
+///
+/// Guard #2 prevents misresolving an ORDINARY table that happens to live in a
+/// keyspace named `snapshots`
+/// (`.../data/snapshots/{table}-{id}/...-Data.db`): there the dir above
+/// `snapshots` is the keyspace root (e.g. `data`), which is NOT a table dir, so
+/// the path is correctly treated as a normal (non-snapshot) layout.
+pub(crate) fn resolve_table_dir(path: &Path) -> Option<&Path> {
+    // Parent of the Data.db file: `{table_name}-{table_id}` (normal) or
+    // `{snapshot_name}` (snapshot layout).
+    let parent = path.parent()?;
+
+    if let Some(maybe_snapshots) = parent.parent() {
+        let is_snapshots_dir =
+            maybe_snapshots.file_name().and_then(|n| n.to_str()) == Some("snapshots");
+        if is_snapshots_dir {
+            // Only walk up past `snapshots` when the directory above it is a real
+            // `{table}-{32-hex}` dir. Otherwise this is an ordinary table inside a
+            // keyspace literally named `snapshots`.
+            if let Some(real_table_dir) = maybe_snapshots.parent() {
+                let looks_like_table = real_table_dir
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(is_table_id_dir)
+                    .unwrap_or(false);
+                if looks_like_table {
+                    return Some(real_table_dir);
+                }
+            }
+        }
+    }
+
+    Some(parent)
+}
+
+/// Extract the keyspace name for a Data.db `path` (snapshot-aware).
+///
+/// The keyspace is the parent of the resolved `{table_name}-{table_id}` dir.
+/// Returns `None` when the path is too shallow to contain a keyspace directory.
+pub(crate) fn extract_keyspace(path: &Path) -> Option<String> {
+    resolve_table_dir(path)
+        .and_then(|table_dir| table_dir.parent())
+        .and_then(|keyspace_dir| keyspace_dir.file_name())
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+}
+
+/// Extract the table name for a Data.db `path` (snapshot-aware), stripping the
+/// trailing `-{table_id}` from the resolved directory when present.
+///
+/// When the resolved directory name has no `-{id}` suffix (unusual, e.g. a flat
+/// test dir) the whole directory name is returned unchanged. Returns `None` when
+/// the path has no directory component at all.
+pub(crate) fn extract_table_name(path: &Path) -> Option<String> {
+    let dir_name = resolve_table_dir(path)?.file_name()?.to_str()?;
+
+    // Split on the LAST hyphen so table names containing hyphens survive; only a
+    // trailing 32-hex id is stripped. Non-id suffixes are left intact.
+    match dir_name.rsplit_once('-') {
+        Some((table_name, id)) if is_table_id_suffix(id) => Some(table_name.to_string()),
+        _ => Some(dir_name.to_string()),
+    }
+}
+
+/// Return `true` when `id` is EXACTLY 32 lowercase hex chars (a Cassandra table
+/// id suffix). Used to decide whether a trailing `-{id}` should be stripped.
+fn is_table_id_suffix(id: &str) -> bool {
+    id.len() == 32
+        && id
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normal_layout_resolves_keyspace_and_table() {
+        let path = Path::new(
+            "/var/lib/cassandra/data/myks/mytable-9f3a1c2d4e5f6071829304a5b6c7d8e9/nb-2-big-Data.db",
+        );
+        assert_eq!(extract_keyspace(path).as_deref(), Some("myks"));
+        assert_eq!(extract_table_name(path).as_deref(), Some("mytable"));
+    }
+
+    #[test]
+    fn snapshot_layout_resolves_real_keyspace_and_table() {
+        let path = Path::new(
+            "/var/lib/cassandra/data/myks/mytable-9f3a1c2d4e5f6071829304a5b6c7d8e9/\
+             snapshots/cqlite-3b1e7f90/nb-2-big-Data.db",
+        );
+        assert_eq!(extract_keyspace(path).as_deref(), Some("myks"));
+        assert_eq!(extract_table_name(path).as_deref(), Some("mytable"));
+    }
+
+    /// BLOCKER 1 regression (issue #2384): an ORDINARY table in a keyspace that is
+    /// literally named `snapshots` must NOT be misparsed as a snapshot.
+    #[test]
+    fn ordinary_table_in_snapshots_named_keyspace_is_not_a_snapshot() {
+        let path = Path::new(
+            "/var/lib/cassandra/data/snapshots/mytable-9f3a1c2d4e5f6071829304a5b6c7d8e9/\
+             nb-1-big-Data.db",
+        );
+        assert_eq!(
+            extract_keyspace(path).as_deref(),
+            Some("snapshots"),
+            "keyspace literally named 'snapshots' must be preserved"
+        );
+        assert_eq!(
+            extract_table_name(path).as_deref(),
+            Some("mytable"),
+            "table must resolve normally, not be misread as a snapshot tag"
+        );
+    }
+
+    #[test]
+    fn snapshot_tag_with_arbitrary_name_still_resolves() {
+        let path = Path::new(
+            "/data/analytics/events-00112233445566778899aabbccddeeff/\
+             snapshots/pre-upgrade-2026/nb-5-big-Data.db",
+        );
+        assert_eq!(extract_keyspace(path).as_deref(), Some("analytics"));
+        assert_eq!(extract_table_name(path).as_deref(), Some("events"));
+    }
+
+    #[test]
+    fn table_name_with_internal_hyphen_survives() {
+        let path = Path::new(
+            "/mnt/disk3/cassandra/data/ks_ts/sensor-readings-abcdef0123456789abcdef0123456789/\
+             da-11-bti-Data.db",
+        );
+        assert_eq!(extract_keyspace(path).as_deref(), Some("ks_ts"));
+        assert_eq!(extract_table_name(path).as_deref(), Some("sensor-readings"));
+    }
+
+    #[test]
+    fn is_table_id_dir_shape() {
+        assert!(is_table_id_dir("t-9f3a1c2d4e5f6071829304a5b6c7d8e9"));
+        assert!(is_table_id_dir("my-t-00112233445566778899aabbccddeeff"));
+        // Wrong length.
+        assert!(!is_table_id_dir("t-9f3a"));
+        // Uppercase is not Cassandra's on-disk shape.
+        assert!(!is_table_id_dir("t-9F3A1C2D4E5F6071829304A5B6C7D8E9"));
+        // Non-hex.
+        assert!(!is_table_id_dir("t-zzzz1c2d4e5f6071829304a5b6c7d8e9"));
+        // No hyphen / empty table.
+        assert!(!is_table_id_dir("snapshots"));
+        assert!(!is_table_id_dir("-9f3a1c2d4e5f6071829304a5b6c7d8e9"));
+    }
+
+    #[test]
+    fn too_shallow_paths_return_none() {
+        // No real parent dir: parent() is the empty path, which has no file_name.
+        let path = Path::new("nb-1-big-Data.db");
+        assert_eq!(extract_keyspace(path), None);
+        assert_eq!(extract_table_name(path), None);
+    }
+}

--- a/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
@@ -323,6 +323,45 @@ round-trip losslessly; regression coverage lives in
 
 ## Parsing Limitations
 
+### Snapshot header-identity extraction — ID-less snapshot dirs (Issue #2384)
+
+**Status**: ⚠️ **Partial** — ID-ful (Cassandra-shaped) snapshots fully resolved; ID-less snapshots pending follow-up (#2415)
+**Impact**: Logging + sync schema-fallback identity only (does NOT affect the ticket-derived warm-cache key)
+
+Snapshot-aware path parsing (`cqlite-core/src/storage/sstable/snapshot_path.rs`) resolves the
+real `{keyspace}.{table}` identity from a Data.db path by walking up past a
+`snapshots/{tag}/` layer. Detection is guarded by the structural
+`{table_name}-{32-hex}` shape (`is_table_id_dir`) so it triggers ONLY for
+Cassandra-shaped, ID-ful snapshot directories
+(`.../{ks}/{table}-{id}/snapshots/{tag}/...-Data.db`). This correctly:
+- resolves the real `{keyspace}.{table}` for ID-ful Cassandra snapshots, and
+- avoids the false-trigger for an ordinary table living in a keyspace literally
+  named `snapshots` (`.../data/snapshots/{table}-{id}/...-Data.db`).
+
+**Residual limitation**: CQLite's own write engine emits **ID-less** table
+directories `{keyspace}/{table}/` (no `-{uuid}` suffix — `writer/mod.rs`). When
+those are snapshotted (e.g. the flight producer's
+`reads_from_snapshot_directory` path), the read path is
+`{ks}/{table}/snapshots/{tag}/...-Data.db`. Because `is_table_id_dir` requires a
+`-{32-hex}` suffix, an ID-less snapshot dir does NOT match the guard, the walk-up
+is skipped, and the header-identity misparse persists: keyspace resolves to
+`snapshots` and table to `{tag}`.
+
+This is **inherently unresolvable from the path alone** — an ID-less snapshot
+`{ks}/{table}/snapshots/{tag}/` and an ordinary table in a keyspace literally
+named `snapshots` (`{data}/snapshots/{table}/`) are structurally identical. Only
+external authoritative keyspace/table context can disambiguate them, and threading
+that context is the scope of the follow-up.
+
+**Blast radius**: header keyspace/table are used for logging and the sync
+schema-fallback path; the ID-less misparse does NOT corrupt the ticket-derived
+warm-cache key. The robust fix (authoritative keyspace/table threaded into the
+reader) is tracked as **#2415**.
+
+**Tracking**: Issue #2384 (structural fix, shipped) → follow-up #2415 (robust fix)
+
+---
+
 ### ~~Static Column Support (Exit Code 3)~~ - FIXED
 
 **Status**: ✅ **FIXED** (Issue #210)


### PR DESCRIPTION
Closes #2384

## Problem
`extract_keyspace_from_path` / `extract_table_name_from_path` (`reader/header.rs`) misparsed snapshot paths `.../<ks>/<table>-<uuid>/snapshots/<tag>/nb-2-big-Data.db` as keyspace=`snapshots`, table=`<tag>`, misdirecting logging + sync schema-fallback resolution for snapshot reads.

## Fix
- New authoritative `cqlite-core/src/storage/sstable/snapshot_path.rs` parser: walks up past a `snapshots/<tag>` segment to the real `<table>-<uuid>` dir, **guarded by an `is_table_id_dir` (`<table>-<32hex>`) structural check** so an ordinary table in a keyspace literally named `snapshots` is NOT false-triggered (that case regressed under a naive walk).
- Routed all four in-crate identity call sites through the shared parser (header.rs, reader/parsing/mod.rs, storage/sstable/mod.rs ×2) so schema resolution + `SSTableManager` keying use one authoritative parser — not just header extraction (wiring-evidence).
- Pure directory-segment structure — no data/byte heuristics (no-heuristics compliant).

## Tests
- Pinned unit tests: normal layout, ID-ful snapshot layout, arbitrary snapshot name, deep nesting, hyphenated table names, malformed fallback, and the `snapshots`-named-keyspace regression (all resolve the real `<ks>.<table>`).

## Known limitation (documented App.F) — follow-up #2415
CQLite's own write engine emits **ID-less** dirs `<keyspace>/<table>/` (`writer/mod.rs:470`); an ID-less snapshot `<ks>/<table>/snapshots/<tag>/` is structurally identical to an ordinary table in a keyspace named `snapshots`, so it cannot be disambiguated from the path alone and still resolves header identity as `snapshots`/`<tag>`. Documented in appendix-F and pinned by test `idless_snapshot_currently_unresolved_pending_followup`. The robust fix (thread authoritative keyspace/table through `SSTableReader::open`) is oracle-driven follow-up **#2415**.

## Gate
LITE PASS (commit 36bef3ef0). Full gate of record runs pre-merge via flow-closer.

roborev: 2 rounds — all blockers resolved (regression guard + shared parser routing); ID-less residual is scoped to #2415 per owner decision.