### PR TITLE
fix(#2299): bound peak heap in uncompressed SSTable compaction (410→54 MiB) — row-granular streaming read + writer/merge direct-stream

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -599,6 +599,24 @@ impl SSTableReader {
         let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
         let parser = self.build_v5_parser(false);
 
+        // Issue #2299 (roborev blocker): build the column resolution ONCE for the
+        // whole scan and thread it into every drain step. `RowColumnResolution`
+        // is derived purely from the SSTable serialization header
+        // (`self.header`) + `schema`, both INVARIANT across every partition of a
+        // single SSTable, so one build is semantically identical to the buffered
+        // `drive_partition_sliding`'s per-PARTITION build
+        // (`partition_driver.rs:179`) — but WITHOUT the per-structure rebuild the
+        // row-granular driver would otherwise incur. `build` allocates a HashMap
+        // over `schema.columns` plus a fresh `Arc<str>` per header/clustering
+        // column; rebuilding it per drain step (once per row on a wide partition)
+        // turned an O(partitions) alloc cost into O(rows × header_cols) on exactly
+        // the wide-partition workload this issue optimizes. Both `owned_schema`
+        // (a local) and `self` (the reader) outlive the drain loop below, so the
+        // borrow is sound for the whole scan.
+        let resolution = owned_schema
+            .as_ref()
+            .map(|s| crate::storage::sstable::reader::parsing::RowColumnResolution::build(s, self));
+
         // Sliding window with a FRONT CURSOR (issue #1589): confirmed structures are
         // consumed by advancing the cursor, and the reclaimed prefix is compacted
         // once per refill — not memmoved per partition as the old front-drain did.
@@ -673,6 +691,7 @@ impl SSTableReader {
             self.drain_compaction_window(
                 &parser,
                 owned_schema.as_ref(),
+                resolution.as_ref(),
                 &mut window,
                 false,
                 &mut emit,
@@ -691,6 +710,7 @@ impl SSTableReader {
             self.drain_compaction_window(
                 &parser,
                 owned_schema.as_ref(),
+                resolution.as_ref(),
                 &mut window,
                 true,
                 &mut emit,
@@ -725,6 +745,7 @@ impl SSTableReader {
         &self,
         parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
         schema: Option<&crate::schema::TableSchema>,
+        resolution: Option<&crate::storage::sstable::reader::parsing::RowColumnResolution>,
         window: &mut WindowCursor,
         at_final_chunk: bool,
         emit: &mut F,
@@ -756,6 +777,7 @@ impl SSTableReader {
                 window.as_slice(),
                 schema,
                 self,
+                resolution,
                 at_final_chunk,
                 partition_state,
                 &mut |row: super::super::compaction_row::CompactionRow| emit(row),

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -599,11 +599,23 @@ impl SSTableReader {
         let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
         let parser = self.build_v5_parser(false);
 
-        // Sliding window with a FRONT CURSOR (issue #1589): confirmed partitions are
+        // Sliding window with a FRONT CURSOR (issue #1589): confirmed structures are
         // consumed by advancing the cursor, and the reclaimed prefix is compacted
         // once per refill — not memmoved per partition as the old front-drain did.
         let mut window = WindowCursor::new();
         let mut broke = false;
+
+        // Issue #2299: row-granular resumable partition state. Unlike the buffered
+        // `parse_one_partition_for_compaction` (which drained a WHOLE partition per
+        // step, so a WIDE partition stayed fully resident in both the window and the
+        // parser's `pending` vec), this carries the in-flight partition's decode
+        // context across refills so the drain below advances the window cursor after
+        // EVERY confirmed row — peak memory is bounded by one row + one chunk, not by
+        // `max_partition_size`. This is what keeps a real compaction of CQLite's own
+        // uncompressed output (one wide partition split across the merge inputs)
+        // within the 128 MiB budget.
+        let mut partition_state =
+            crate::storage::sstable::reader::parsing::CompactionPartitionState::new();
 
         use crate::storage::sstable::compression::Compression;
 
@@ -656,7 +668,8 @@ impl SSTableReader {
             chunk_count += 1;
 
             // Not the final chunk yet: NeedMore means "await more bytes". Drain
-            // every confirmed partition from the front of the window.
+            // every confirmed structure (row / marker / partition end) from the
+            // front of the window, advancing the cursor per structure.
             self.drain_compaction_window(
                 &parser,
                 owned_schema.as_ref(),
@@ -664,6 +677,7 @@ impl SSTableReader {
                 false,
                 &mut emit,
                 &mut broke,
+                &mut partition_state,
                 scan_cancel,
             )?;
             if broke {
@@ -681,6 +695,7 @@ impl SSTableReader {
                 true,
                 &mut emit,
                 &mut broke,
+                &mut partition_state,
                 scan_cancel,
             )?;
         }
@@ -694,11 +709,18 @@ impl SSTableReader {
         Ok(())
     }
 
-    /// Drain every confirmed partition from the front of the sliding `window`,
-    /// emitting each row via `emit` (issue #827). After each `Emitted` the
-    /// consumed prefix is removed so the window's peak size stays bounded by
-    /// `max_partition_size + one_chunk`. Stops at `NeedMore` / `Done` (await the
-    /// next chunk / genuine end) or when `emit` returns `Break` (sets `*broke`).
+    /// Drain every confirmed STRUCTURE (row / range marker / partition end) from
+    /// the front of the sliding `window`, emitting each row via `emit` (issue #827,
+    /// row-granular per issue #2299). After each confirmed structure the consumed
+    /// prefix is advanced (the window's peak stays bounded by `one row + one
+    /// chunk` — NOT `max_partition_size` — so a WIDE partition never has to be
+    /// fully resident). Stops at `NeedMore` / `AllDone` (await the next chunk /
+    /// genuine end) or when `emit` returns `Break` (sets `*broke`).
+    ///
+    /// `partition_state` carries the in-flight partition's decode context across
+    /// refills (its key + in-flight range-tombstone start bound), so a partition
+    /// straddling a chunk boundary resumes correctly.
+    #[allow(clippy::too_many_arguments)]
     fn drain_compaction_window<F>(
         &self,
         parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
@@ -707,61 +729,71 @@ impl SSTableReader {
         at_final_chunk: bool,
         emit: &mut F,
         broke: &mut bool,
+        partition_state: &mut crate::storage::sstable::reader::parsing::CompactionPartitionState,
         scan_cancel: &ScanCancel,
     ) -> Result<()>
     where
         F: FnMut(super::super::compaction_row::CompactionRow) -> Result<std::ops::ControlFlow<()>>,
     {
-        use crate::storage::sstable::reader::parsing::ParseStep;
+        use crate::storage::sstable::reader::parsing::PartitionStreamStep;
         let mut drained: usize = 0;
         loop {
             if *broke || window.is_empty() {
                 return Ok(());
             }
             // Cooperative cancellation (issue #2264): for a chunk-stitched ('nb')
-            // SSTable this is the per-partition hot loop the compaction stream (and
+            // SSTable this is the per-STRUCTURE hot loop the compaction stream (and
             // thus a Flight `do_get`) spends its time in. Poll the PER-CALL cancel
             // token (issue #2346) at a bounded interval so a disconnected client
             // abandons the walk within milliseconds instead of the coarse ~1–2 min
-            // backstop.
+            // backstop. Per-structure polling (rather than per-partition) also
+            // catches a single partition so wide it spans hundreds of chunks.
             if drained & 0xFF == 0 {
                 scan_cancel.check()?;
             }
             drained += 1;
-            let mut local_break = false;
-            let step = parser.parse_one_partition_for_compaction(
+            let step = parser.stream_partition_body_incremental(
                 window.as_slice(),
                 schema,
                 self,
                 at_final_chunk,
-                &mut |row: super::super::compaction_row::CompactionRow| match emit(row)? {
-                    std::ops::ControlFlow::Continue(()) => Ok(std::ops::ControlFlow::Continue(())),
-                    std::ops::ControlFlow::Break(()) => {
-                        local_break = true;
-                        Ok(std::ops::ControlFlow::Break(()))
-                    }
-                },
+                partition_state,
+                &mut |row: super::super::compaction_row::CompactionRow| emit(row),
             )?;
             match step {
-                ParseStep::Emitted(consumed) => {
+                // A confirmed mid-partition structure: advance the cursor over
+                // exactly the bytes it consumed (issue #1589: NO memmove here —
+                // the reclaimed prefix is compacted once at the next refill).
+                // `consume` clamps to the remaining length. The partition
+                // CONTINUES, so the #2398 per-partition work-probe is NOT bumped
+                // here (it counts partitions, not structures — see PartitionDone).
+                PartitionStreamStep::Consumed(consumed) => {
+                    window.consume(consumed);
+                }
+                // The partition ended. Advance over its final bytes (`consumed ==
+                // 0` for a terminal trailing partition makes no progress, but the
+                // window is then empty so the top-of-loop guard returns).
+                PartitionStreamStep::PartitionDone(consumed) => {
                     // Work-probe (issue #2398): one partition body decoded on the
                     // chunk-stitching ('nb') scan path — the counterpart to the
-                    // streaming full-index walk's increment. A token-range split
-                    // must keep this bounded to its in-range slice, not the
-                    // SSTable's whole partition count.
+                    // streaming full-index walk's per-partition increment. Placed
+                    // on PartitionDone (NOT the mid-partition Consumed) so a wide
+                    // partition drained row-by-row (issue #2299) still counts
+                    // exactly once. A token-range split keeps this bounded to its
+                    // in-range slice, not the SSTable's whole partition count.
                     crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
-                    let take = if consumed == 0 { 1 } else { consumed };
-                    // Advance the cursor over the confirmed partition (issue #1589):
-                    // NO memmove here — the reclaimed prefix is compacted once at the
-                    // next refill. `consume` clamps to the remaining length, matching
-                    // the prior `drain(0..take.min(window.len()))`.
-                    window.consume(take);
-                    if local_break {
-                        *broke = true;
-                        return Ok(());
-                    }
+                    window.consume(consumed);
                 }
-                ParseStep::NeedMore | ParseStep::Done => return Ok(()),
+                // Consumer dropped mid-emit: advance over the breaking structure and
+                // stop the whole scan.
+                PartitionStreamStep::Break(consumed) => {
+                    window.consume(consumed);
+                    *broke = true;
+                    return Ok(());
+                }
+                // Await the next chunk (a structure straddles this boundary) or a
+                // genuine end of data.
+                PartitionStreamStep::NeedMore | PartitionStreamStep::AllDone => return Ok(()),
             }
         }
     }

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -789,8 +789,26 @@ impl SSTableReader {
                 // `consume` clamps to the remaining length. The partition
                 // CONTINUES, so the #2398 per-partition work-probe is NOT bumped
                 // here (it counts partitions, not structures — see PartitionDone).
+                //
+                // Forward-progress guard (roborev blocker, issue #2299): the
+                // pre-#2299 buffered driver clamped a zero-length "confirmed"
+                // step to 1 (`let take = if consumed == 0 { 1 } else { consumed
+                // };`) — this row-granular rewrite dropped that clamp. A
+                // `Consumed(0)` here would leave `window` unchanged AND
+                // `state.header_parsed` still `true`, so the NEXT call re-parses
+                // the IDENTICAL front byte and can return the SAME step forever:
+                // a live `do_get` consumer would spin, since `scan_cancel` is
+                // only polled every 256 iterations and escapes on client
+                // DISCONNECT, never on lack of forward progress. Every decode
+                // path in `stream_partition_body_incremental` currently
+                // guarantees `consumed >= 1` on a genuine `Ok` (the row-flags /
+                // marker-flags / partition-key-length byte is always >= 1 on
+                // success — see that function's doc comment), so this clamp is
+                // defense-in-depth against a FUTURE decoder change silently
+                // reintroducing the pre-#2299 hang, restoring the invariant the
+                // type signature alone does not enforce.
                 PartitionStreamStep::Consumed(consumed) => {
-                    window.consume(consumed);
+                    window.consume(clamp_forward_progress(consumed));
                 }
                 // The partition ended. Advance over its final bytes (`consumed ==
                 // 0` for a terminal trailing partition makes no progress, but the
@@ -818,5 +836,83 @@ impl SSTableReader {
                 PartitionStreamStep::NeedMore | PartitionStreamStep::AllDone => return Ok(()),
             }
         }
+    }
+}
+
+/// Forward-progress clamp for [`SSTableReader::drain_compaction_window`]'s
+/// `PartitionStreamStep::Consumed` arm (roborev blocker, issue #2299): a
+/// `consumed == 0` step must still advance the window by at least one byte, or
+/// the drain loop can spin on a stalled decoder forever (see the call site's
+/// doc comment for the full hang mechanism this restores protection against).
+#[inline]
+fn clamp_forward_progress(consumed: usize) -> usize {
+    if consumed == 0 {
+        1
+    } else {
+        consumed
+    }
+}
+
+#[cfg(test)]
+mod forward_progress_guard_tests {
+    use super::clamp_forward_progress;
+    use crate::storage::sstable::reader::window_cursor::WindowCursor;
+
+    /// The clamp forces a zero-length step to advance by exactly one byte.
+    #[test]
+    fn zero_consumed_is_clamped_to_one() {
+        assert_eq!(clamp_forward_progress(0), 1);
+    }
+
+    /// A genuinely nonzero consumed count is passed through unchanged.
+    #[test]
+    fn nonzero_consumed_is_unaffected() {
+        for n in [1usize, 2, 64, 4096] {
+            assert_eq!(clamp_forward_progress(n), n);
+        }
+    }
+
+    /// RED-then-GREEN, deterministic bounded-iteration simulation (roborev
+    /// blocker, issue #2299): NOT a live-hang repro through the real parser —
+    /// every current decode path in `stream_partition_body_incremental`
+    /// provably reports `consumed >= 1` on a genuine `Ok` (the row-flags /
+    /// marker-flags / partition-key-length byte is always >= 1 on success), so
+    /// no byte sequence drives today's parser to a `Consumed(0)` on a
+    /// non-empty window. This test instead pins the CLAMP's own behavior: a
+    /// hypothetical decoder that always reports 0 consumed bytes (exactly the
+    /// pre-#2299-regression shape) must still drain a finite window in
+    /// bounded steps, never an unbounded loop. The iteration bound is derived
+    /// from the buffer length (deterministic), never a wall-clock timeout —
+    /// pre-fix (no clamp) this loop would spin forever and the `iterations <=
+    /// bound` assertion would be the only thing standing between a passing
+    /// test and a hung test process.
+    #[test]
+    fn simulated_stalled_decoder_terminates_within_window_len_iterations() {
+        let mut window = WindowCursor::new();
+        let payload = vec![0xFFu8; 32];
+        window.refill(&payload);
+
+        let bound = payload.len() + 1;
+        let mut iterations = 0usize;
+        while !window.is_empty() {
+            iterations += 1;
+            assert!(
+                iterations <= bound,
+                "forward-progress guard failed to terminate within {bound} iterations \
+                 (issue #2299 roborev blocker: a stalled decoder that always reports \
+                 0 consumed bytes must still drain the window in bounded steps, never \
+                 spin unboundedly)"
+            );
+            // Simulate a decoder that ALWAYS reports it consumed 0 bytes (the
+            // hypothetical pre-#2299-regression behavior) — the clamp must
+            // still force progress.
+            let consumed = clamp_forward_progress(0);
+            window.consume(consumed);
+        }
+        assert_eq!(
+            iterations,
+            payload.len(),
+            "each iteration must advance by exactly 1 clamped byte"
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_range_marker_resume_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_range_marker_resume_tests.rs
@@ -1,0 +1,307 @@
+//! Issue #2299 (roborev should-fix): range-marker resume parity.
+//!
+//! The trickiest genuinely-new logic the streaming compaction path adds is
+//! [`CompactionPartitionState::pending_range_start`] — the cross-chunk carry that
+//! lets a range tombstone whose CLOSE bound arrives in a LATER window refill still
+//! pair with the START bound seen in an earlier one. The two default-gate e2e
+//! tests (`test_issue_2299_stream_readback` + the dhat memory test) are
+//! deliberately tombstone-FREE (to keep the write-side `stream_rows_directly` gate
+//! true), so before this test the range-marker resume path through
+//! [`V5CompressedLegacyParser::stream_partition_body_incremental`] was asserted
+//! only by comment, never executed.
+//!
+//! ## What this proves
+//!
+//! Over a REAL, `SSTableWriter`-produced SSTable holding a partition with a bounded
+//! range tombstone, the row-granular streaming drain (driven here with a window
+//! refilled ONE BYTE AT A TIME, so EVERY multi-byte structure — including the
+//! range-tombstone bound markers — is assembled across many `NeedMore` refills and
+//! the range's START/END bounds land in SEPARATE refill chunks) emits a
+//! `CompactionRow` sequence BYTE-IDENTICAL to the buffered
+//! [`V5CompressedLegacyParser::parse_block_for_compaction`] output on the SAME
+//! stitched bytes. Byte-by-byte refill is the strongest possible chunk-straddling
+//! stress: it guarantees the marker resume path (and every row's mid-structure
+//! `NeedMore`) is exercised, not merely reachable.
+//!
+//! This is a READER-path parity test: it constructs the input SSTable directly via
+//! the writer (a range tombstone in a flushed SSTable — the SAME shape
+//! `issue_933_range_tombstone_compaction` relies on) and never touches the
+//! write-side direct-stream gate.
+
+use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use crate::storage::sstable::reader::parsing::{
+    CompactionPartitionState, PartitionStreamStep, RowColumnResolution,
+};
+use crate::storage::sstable::reader::window_cursor::WindowCursor;
+use crate::storage::sstable::reader::SSTableReader;
+use crate::storage::write_engine::mutation::{
+    CellOperation, ClusteringBound, ClusteringKey, Mutation, PartitionKey, RangeTombstone, TableId,
+};
+use crate::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use crate::types::Value;
+use crate::{Config, Platform};
+use std::io::SeekFrom;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::io::AsyncSeekExt;
+
+const KS: &str = "issue2299_rt_resume_ks";
+const TBL: &str = "rt_items";
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: Default::default(),
+        dropped_columns: Default::default(),
+    }
+}
+
+fn write_row(id: i32, ck: i32, name: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// A range-tombstone mutation covering `[start, end]` on partition `id`.
+fn range_delete(id: i32, start: ClusteringBound, end: ClusteringBound, ts: i64) -> Mutation {
+    let mut m = Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![],
+        ts,
+        None,
+    );
+    m.range_tombstones.push(RangeTombstone {
+        start,
+        end,
+        deletion_time: ts,
+        // Far-future LDT so gc-grace never purges the marker in this test.
+        local_deletion_time: 2_000_000_000,
+    });
+    m
+}
+
+fn incl(ck: i32) -> ClusteringBound {
+    ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(ck)))
+}
+
+/// Flush one uncompressed 'nb' SSTable holding TWO partitions, EACH carrying live
+/// rows plus a bounded range tombstone, and return (kept-alive tempdir, Data.db).
+/// Two partitions force a real partition boundary (PartitionDone/reset) between the
+/// range-marker carries, so the per-partition `pending_range_start` reset is also
+/// exercised.
+async fn write_fixture() -> (TempDir, std::path::PathBuf) {
+    let schema = schema();
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("inputs");
+    let mut engine = WriteEngine::new(WriteEngineConfig::new(
+        data_dir.clone(),
+        temp.path().join("wal"),
+        schema.clone(),
+    ))
+    .unwrap();
+
+    // Two partitions, each: live rows ck 0..=6 plus a range tombstone [2, 4].
+    for id in [1, 2] {
+        for ck in 0..=6 {
+            engine
+                .write(write_row(id, ck, &format!("p{id}-v{ck}"), 100))
+                .expect("write row");
+        }
+        engine
+            .write(range_delete(id, incl(2), incl(4), 200))
+            .expect("write range tombstone");
+    }
+    let info = engine
+        .flush()
+        .await
+        .expect("flush")
+        .expect("non-empty sstable");
+    let data_path = info.data_path.clone();
+    (temp, data_path)
+}
+
+async fn open_reader(data_path: &std::path::Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.unwrap());
+    SSTableReader::open(data_path, &config, platform)
+        .await
+        .unwrap()
+}
+
+/// Drive the row-granular streaming compaction decode over `whole` with the window
+/// refilled ONE BYTE AT A TIME — the strongest chunk-straddling stress, so every
+/// multi-byte structure (range-tombstone bound markers included) is assembled
+/// across many `NeedMore` refills and each range's START/END bounds land in
+/// SEPARATE refill chunks. Returns the emitted rows in order.
+fn stream_byte_by_byte(
+    reader: &SSTableReader,
+    parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
+    schema: &TableSchema,
+    resolution: &RowColumnResolution,
+    whole: &[u8],
+) -> Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> {
+    let mut window = WindowCursor::new();
+    let mut state = CompactionPartitionState::new();
+    let mut out = Vec::new();
+    let mut fed = 0usize;
+
+    // Feed one byte, then drain every structure the window can now confirm. Repeat
+    // until the whole buffer is fed, then run a final at_final_chunk drain.
+    loop {
+        let at_final = fed >= whole.len();
+        // Refill with exactly one more byte (if any remain) before draining.
+        if !at_final {
+            window.refill(&whole[fed..fed + 1]);
+            fed += 1;
+        }
+        loop {
+            if window.is_empty() {
+                break;
+            }
+            let step = parser
+                .stream_partition_body_incremental(
+                    window.as_slice(),
+                    Some(schema),
+                    reader,
+                    Some(resolution),
+                    at_final,
+                    &mut state,
+                    &mut |row| {
+                        out.push(row);
+                        Ok(std::ops::ControlFlow::Continue(()))
+                    },
+                )
+                .expect("streaming decode must not error");
+            match step {
+                PartitionStreamStep::Consumed(n) | PartitionStreamStep::PartitionDone(n) => {
+                    if n == 0 {
+                        // No progress possible on this buffer (terminal 0-byte
+                        // done): stop draining and await more bytes / finish.
+                        break;
+                    }
+                    window.consume(n);
+                }
+                PartitionStreamStep::Break(n) => {
+                    window.consume(n);
+                    return out;
+                }
+                PartitionStreamStep::NeedMore | PartitionStreamStep::AllDone => break,
+            }
+        }
+        if at_final {
+            return out;
+        }
+    }
+}
+
+/// Byte-identical parity: the row-granular streaming drain over a byte-by-byte
+/// refilled window (range-tombstone START/END bounds forced into separate refill
+/// chunks) emits exactly the buffered `parse_block_for_compaction` sequence.
+#[tokio::test(flavor = "multi_thread")]
+async fn range_marker_resumes_across_window_refill_byte_identical() {
+    let schema = schema();
+    let (_temp, data_path) = write_fixture().await;
+    let reader = open_reader(&data_path).await;
+
+    // `nb` uncompressed → the compaction stream stitches the data section.
+    assert!(
+        reader.requires_chunk_stitching(),
+        "fixture must take the chunk-stitching compaction path"
+    );
+
+    // Stitch the whole decompressed data section (header stripped) — the SAME
+    // bytes both the buffered and streaming decoders consume.
+    let cursor = reader.new_scan_cursor().await.unwrap();
+    let header_size = reader.calculate_header_size();
+    {
+        let mut file_guard = cursor.file.lock().await;
+        file_guard
+            .seek(SeekFrom::Start(header_size as u64))
+            .await
+            .unwrap();
+    }
+    let whole = reader.stitch_all_chunks(&cursor).await.unwrap();
+    assert!(!whole.is_empty(), "stitched data section must be non-empty");
+
+    let parser = reader.build_v5_parser(false);
+    let resolution = RowColumnResolution::build(&schema, &reader);
+
+    // Reference: the buffered whole-partition decode.
+    let buffered = parser
+        .parse_block_for_compaction(&whole, Some(&schema), &reader)
+        .expect("buffered compaction decode");
+
+    // Non-vacuity: the fixture really produced a RangeMarker per partition, so the
+    // resume path under test is actually exercised (not a rows-only false pass).
+    let marker_count =
+        buffered
+            .iter()
+            .filter(|r| {
+                matches!(
+                r.row_data,
+                crate::storage::sstable::reader::compaction_row::CompactionRowData::RangeMarker {
+                    ..
+                }
+            )
+            })
+            .count();
+    assert!(
+        marker_count >= 2,
+        "fixture must emit >= 2 range markers (one per partition), got {marker_count}"
+    );
+
+    // Streaming: byte-by-byte refill forces cross-chunk resume of every structure.
+    let streamed = stream_byte_by_byte(&reader, &parser, &schema, &resolution, &whole);
+
+    assert_eq!(
+        streamed, buffered,
+        "the row-granular streaming drain (range-marker START/END bounds split \
+         across window refills) must emit a CompactionRow sequence byte-identical \
+         to the buffered parse_block_for_compaction output on the same bytes"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -43,6 +43,15 @@ mod chunk_cache_wiring_tests;
 // cannot live in `tests/`.
 #[cfg(all(test, feature = "write-support"))]
 mod compaction_cancel_tests;
+// Issue #2299 (roborev should-fix): range-marker resume parity. Drives the
+// row-granular `stream_partition_body_incremental` over a partition whose range
+// tombstone START/END bounds land in SEPARATE window refill chunks, and asserts
+// the emitted `CompactionRow`s are byte-identical to the buffered
+// `parse_block_for_compaction` output on the SAME bytes — proving the
+// cross-chunk `CompactionPartitionState::pending_range_start` carry. Needs
+// `write-support` to synthesize the range-tombstone SSTable bytes.
+#[cfg(all(test, feature = "write-support"))]
+mod compaction_range_marker_resume_tests;
 // BIG ("nb"/uncompressed) point lookup: raw-key Index.db resolve + covering-chunk
 // seek (issue #1572), replacing the whole-file scan_for_key fallback.
 mod big_point;

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -52,6 +52,14 @@ pub(in crate::storage::sstable::reader) use row_decoder::{
     CompactionPartitionState, PartitionStreamStep,
 };
 
+// Issue #2299 (roborev blocker): the compaction-stream column resolution, built
+// ONCE per scan in `data_access::compaction` and threaded into
+// `stream_partition_body_incremental` so a wide partition's per-structure drain
+// does NOT rebuild it per row (the buffered driver builds it per PARTITION —
+// `partition_driver.rs:179`). Derived purely from the invariant serialization
+// header + schema, so one build per scan is semantically identical.
+pub(in crate::storage::sstable::reader) use row_decoder::RowColumnResolution;
+
 // Re-export publicly for integration tests (Issue #166 regression tests)
 // Using doc(hidden) to keep it out of public documentation but available for testing
 #[doc(hidden)]

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -44,6 +44,14 @@ pub(in crate::storage::sstable::reader) use row_decoder::V5CompressedLegacyParse
 // compaction-read streaming driver in data_access.rs can match on it.
 pub(in crate::storage::sstable::reader) use row_decoder::ParseStep;
 
+// Issue #2299: row-granular resumable compaction streaming — the state carried
+// across a wide partition's chunk-straddling refills and the per-structure step
+// outcome, so `stream_all_partitions_for_compaction` drains a wide partition
+// row-by-row instead of buffering it whole.
+pub(in crate::storage::sstable::reader) use row_decoder::{
+    CompactionPartitionState, PartitionStreamStep,
+};
+
 // Re-export publicly for integration tests (Issue #166 regression tests)
 // Using doc(hidden) to keep it out of public documentation but available for testing
 #[doc(hidden)]

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction.rs
@@ -360,315 +360,6 @@ impl V5CompressedLegacyParser {
             emit(row)
         })
     }
-
-    /// Row-granular resumable partition streaming for the compaction read path
-    /// (issue #2299).
-    ///
-    /// [`Self::parse_one_partition_for_compaction`] buffers a WHOLE partition
-    /// into the driver-owned `pending` vec and only reports its consumed byte
-    /// count (and forwards its rows) once the partition is CONFIRMED complete —
-    /// i.e. at the END_OF_PARTITION marker or the next partition header. For a
-    /// WIDE partition (a single partition holding the bulk of an SSTable, e.g. a
-    /// time-series row split by clustering-key range across the merge inputs)
-    /// that means the sliding-window driver in
-    /// [`SSTableReader::stream_all_partitions_for_compaction`] cannot advance its
-    /// window cursor until the whole partition is resident — so peak memory
-    /// scales with `max_partition_size`, not `one row + one chunk`. With four
-    /// concurrent producers each holding a ~40 MiB wide partition (window bytes
-    /// PLUS the buffered rows), the compaction blows the 128 MiB budget.
-    ///
-    /// This method streams the partition BODY one confirmed structure at a time,
-    /// invoking `emit` per row/marker and reporting via [`PartitionStreamStep`]
-    /// exactly how many bytes of `data` are now safe to drain from the FRONT of
-    /// the caller's sliding window — WITHOUT waiting for END_OF_PARTITION. The
-    /// caller drives it as a resumable cursor: it calls this repeatedly on the
-    /// (growing/shrinking) window, advancing the front cursor by the returned
-    /// `consumed` after every call.
-    ///
-    /// `state` carries the cross-call partition context (the partition key, the
-    /// header-parsed flag, and the in-flight range-tombstone start bound) so a
-    /// partition that straddles a chunk boundary resumes correctly after a
-    /// refill. Tombstone / timestamp / range-marker semantics are byte-identical
-    /// to [`Self::parse_one_partition_for_compaction`] — this is the SAME
-    /// `CompactionPolicy` decode, only the buffering granularity differs.
-    ///
-    /// `at_final_chunk` flips a mid-structure end-of-buffer between a refill
-    /// request ([`PartitionStreamStep::NeedMore`]) and terminal completion
-    /// ([`PartitionStreamStep::PartitionDone`]), exactly as the sliding driver's
-    /// `NeedMore`/`Done` distinction does.
-    pub fn stream_partition_body_incremental<F>(
-        &self,
-        data: &[u8],
-        schema: Option<&TableSchema>,
-        reader: &crate::storage::sstable::reader::types::SSTableReader,
-        at_final_chunk: bool,
-        state: &mut CompactionPartitionState,
-        emit: &mut F,
-    ) -> Result<PartitionStreamStep>
-    where
-        F: FnMut(
-            crate::storage::sstable::reader::compaction_row::CompactionRow,
-        ) -> Result<std::ops::ControlFlow<()>>,
-    {
-        use super::row_framing::PartitionHeaderReadiness;
-
-        if data.is_empty() {
-            return Ok(if at_final_chunk {
-                PartitionStreamStep::AllDone
-            } else {
-                PartitionStreamStep::NeedMore
-            });
-        }
-
-        let schema = schema.ok_or_else(|| {
-            Error::schema(format!(
-                "V5CompressedLegacy (compaction) format requires schema for {}.{}",
-                self.keyspace, self.table_name
-            ))
-        })?;
-
-        // Every row-body offset arithmetic below reuses the SAME primitives the
-        // buffered `drive_partition_sliding` uses, so decode is byte-identical.
-        let resolution = RowColumnResolution::build(schema, reader);
-
-        // (1) Parse the partition header ONCE per partition. When the header has
-        //     already been parsed for this partition (a resumed body call after a
-        //     refill) the window front is the body start (offset 0).
-        if !state.header_parsed {
-            match self.partition_header_readiness(data) {
-                PartitionHeaderReadiness::Malformed => {
-                    // Skip one byte to resynchronise (matches the buffered driver's
-                    // `Emitted(1)` malformed-header behaviour).
-                    return Ok(PartitionStreamStep::Consumed(1));
-                }
-                PartitionHeaderReadiness::Incomplete => {
-                    return Ok(if at_final_chunk {
-                        PartitionStreamStep::AllDone
-                    } else {
-                        PartitionStreamStep::NeedMore
-                    });
-                }
-                PartitionHeaderReadiness::Ready => {}
-            }
-
-            let (partition_key, after_header, partition_deletion) =
-                match self.parse_partition_header_full(data, 0) {
-                    Ok(v) => v,
-                    Err(_) => {
-                        if !at_final_chunk
-                            && self.partition_header_readiness(data)
-                                == PartitionHeaderReadiness::Incomplete
-                        {
-                            return Ok(PartitionStreamStep::NeedMore);
-                        }
-                        return Ok(PartitionStreamStep::Consumed(1));
-                    }
-                };
-
-            // Emit a partition-level tombstone carrier immediately (issue #1072),
-            // via the shared CompactionPolicy hook — same synthetic carrier the
-            // buffered path pushes into `pending`. The policy's transient state
-            // (partition key + in-flight range-start bound) is written back into
-            // `state` so a resumed body call rebuilds an equivalent policy.
-            let mut policy = CompactionPolicy::new(self);
-            let mut carriers: Vec<
-                crate::storage::sstable::reader::compaction_row::CompactionRow,
-            > = Vec::new();
-            policy.on_partition_open(partition_key, partition_deletion, schema, &mut carriers);
-            state.partition_key = policy.partition_key.clone();
-            state.pending_range_start = policy.pending_range_start.clone();
-            state.header_parsed = true;
-            // The header bytes are confirmed; drain them from the window front so a
-            // refill re-parse never re-reads the header. The next call sees the body
-            // at offset 0.
-            for row in carriers {
-                match emit(row)? {
-                    std::ops::ControlFlow::Continue(()) => {}
-                    std::ops::ControlFlow::Break(()) => {
-                        return Ok(PartitionStreamStep::Break(after_header));
-                    }
-                }
-            }
-            return Ok(PartitionStreamStep::Consumed(after_header));
-        }
-
-        // (2) Body: parse ONE confirmed structure (row / range marker /
-        //     end-of-partition) from the front (offset 0), emit it, and report its
-        //     consumed bytes so the caller advances the window cursor per structure.
-        //     Rebuild the policy from `state` (it only carries owned pieces: the
-        //     partition key and the in-flight range-tombstone start bound).
-        let offset = 0usize;
-
-        // END_OF_PARTITION (0x01): partition complete; consume the marker byte and
-        // signal the caller to reset for the next partition.
-        if offset < data.len() && Self::is_end_of_partition(data[offset]) {
-            state.reset();
-            return Ok(PartitionStreamStep::PartitionDone(1));
-        }
-
-        // Consumed everything but never saw END_OF_PARTITION: the partition may
-        // continue in the next chunk.
-        if offset >= data.len() {
-            if at_final_chunk {
-                // Trailing (unterminated) partition is terminal (no bytes to drain).
-                state.reset();
-                return Ok(PartitionStreamStep::PartitionDone(0));
-            }
-            return Ok(PartitionStreamStep::NeedMore);
-        }
-
-        let mut policy = CompactionPolicy::new(self);
-        policy.partition_key = state.partition_key.clone();
-        policy.pending_range_start = state.pending_range_start.clone();
-
-        // A range-tombstone marker: pair it via the policy (the surviving marker
-        // row, if any, is emitted here). A truncated marker on a non-final chunk
-        // requests more bytes.
-        if Self::is_range_tombstone_marker(data[offset]) {
-            let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
-                Vec::new();
-            match policy.on_range_marker(data, offset, schema, &mut emitted) {
-                super::partition_driver::MarkerOutcome::Advanced(next_offset) => {
-                    // Confirm the marker is fully framed within the window.
-                    if next_offset > data.len() {
-                        return Ok(if at_final_chunk {
-                            PartitionStreamStep::AllDone
-                        } else {
-                            PartitionStreamStep::NeedMore
-                        });
-                    }
-                    state.pending_range_start = policy.pending_range_start.clone();
-                    for row in emitted {
-                        match emit(row)? {
-                            std::ops::ControlFlow::Continue(()) => {}
-                            std::ops::ControlFlow::Break(()) => {
-                                return Ok(PartitionStreamStep::Break(next_offset));
-                            }
-                        }
-                    }
-                    return Ok(PartitionStreamStep::Consumed(next_offset));
-                }
-                super::partition_driver::MarkerOutcome::Stop => {
-                    if at_final_chunk {
-                        state.reset();
-                        return Ok(PartitionStreamStep::PartitionDone(0));
-                    }
-                    return Ok(PartitionStreamStep::NeedMore);
-                }
-            }
-        }
-
-        // A data row: decode exactly one, emit it, and report its consumed bytes.
-        let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
-            Vec::new();
-        match policy.on_data_row(data, offset, schema, reader, &resolution, &mut emitted) {
-            Some(next_offset) => {
-                // Confirm the row is fully framed WITHIN the window: a next_offset
-                // past the buffer end means we may have decoded a truncated row on a
-                // non-final chunk — request more bytes rather than emit a partial row.
-                if next_offset > data.len() {
-                    return Ok(if at_final_chunk {
-                        PartitionStreamStep::AllDone
-                    } else {
-                        PartitionStreamStep::NeedMore
-                    });
-                }
-                state.pending_range_start = policy.pending_range_start.clone();
-                for row in emitted {
-                    match emit(row)? {
-                        std::ops::ControlFlow::Continue(()) => {}
-                        std::ops::ControlFlow::Break(()) => {
-                            return Ok(PartitionStreamStep::Break(next_offset));
-                        }
-                    }
-                }
-                Ok(PartitionStreamStep::Consumed(next_offset))
-            }
-            None => {
-                // A row failed to parse. Mid-stream that may be a row straddling the
-                // chunk boundary, so request more bytes unless this is the final
-                // chunk (where it is end-of-partition).
-                if at_final_chunk {
-                    state.reset();
-                    Ok(PartitionStreamStep::PartitionDone(0))
-                } else {
-                    Ok(PartitionStreamStep::NeedMore)
-                }
-            }
-        }
-    }
-}
-
-/// Cross-call state for [`V5CompressedLegacyParser::stream_partition_body_incremental`]
-/// (issue #2299). Carries the in-flight partition's decode context so a partition
-/// that straddles a sliding-window chunk boundary resumes correctly after a refill.
-pub struct CompactionPartitionState {
-    /// Whether the partition header (key + partition-level deletion) has been
-    /// parsed for the CURRENT partition. Reset to `false` at each partition
-    /// boundary so the next partition re-parses its own header.
-    header_parsed: bool,
-    /// The current partition's key, decoded once from the header and reused for
-    /// every row this partition emits across resumed calls.
-    partition_key: RowKey,
-    /// Issue #933: the in-flight range-tombstone start bound
-    /// `(bound, markedForDeleteAt µs, localDeletionTime s)`, carried across
-    /// resumed calls so a range whose CLOSE bound arrives in a later chunk still
-    /// pairs correctly (the incremental driver never re-parses from the partition
-    /// start, so this cross-call carry replaces the buffered driver's re-derive).
-    pending_range_start: Option<(
-        crate::storage::sstable::reader::compaction_row::CompactionBound,
-        i64,
-        i32,
-    )>,
-}
-
-impl Default for CompactionPartitionState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl CompactionPartitionState {
-    /// A fresh state positioned at the start of a (not-yet-parsed) partition.
-    pub fn new() -> Self {
-        Self {
-            header_parsed: false,
-            partition_key: RowKey::new(Vec::new()),
-            pending_range_start: None,
-        }
-    }
-
-    /// Reset to await the next partition header (after an END_OF_PARTITION or a
-    /// terminal trailing partition).
-    fn reset(&mut self) {
-        self.header_parsed = false;
-        self.partition_key = RowKey::new(Vec::new());
-        self.pending_range_start = None;
-    }
-}
-
-/// Outcome of one [`V5CompressedLegacyParser::stream_partition_body_incremental`]
-/// call (issue #2299). Reports how many bytes of the window front are now safe to
-/// drain, WITHOUT waiting for a whole partition.
-#[derive(Debug, PartialEq, Eq)]
-pub enum PartitionStreamStep {
-    /// One structure (header prefix, row, or range marker) was confirmed and its
-    /// rows emitted; `usize` bytes may be drained from the window front. The
-    /// current partition CONTINUES — call again.
-    Consumed(usize),
-    /// The partition ended (END_OF_PARTITION, or a terminal trailing partition on
-    /// the final chunk); `usize` bytes may be drained. State is reset for the next
-    /// partition.
-    PartitionDone(usize),
-    /// The window is (possibly) truncated mid-structure and `!at_final_chunk`:
-    /// the caller must append the next chunk and retry (nothing to drain). Never
-    /// returned when `at_final_chunk`.
-    NeedMore,
-    /// The window is empty at the final chunk — genuine end of data. Terminal.
-    AllDone,
-    /// `emit` returned `Break` (consumer dropped); `usize` bytes were consumed up
-    /// to and including the breaking structure. The caller stops the scan.
-    Break(usize),
 }
 
 /// Issue #1640 (K1): [`SlidingPartitionPolicy`] for the per-element compaction
@@ -676,7 +367,7 @@ pub enum PartitionStreamStep {
 /// shadowing (it reconciles tombstones itself across generations), the static
 /// row is emitted as its own `CompactionRow` (issue #1074, not merged), and
 /// range-tombstone markers are paired into `RangeMarker` rows (issue #933).
-struct CompactionPolicy<'a> {
+pub(super) struct CompactionPolicy<'a> {
     parser: &'a V5CompressedLegacyParser,
     partition_key: RowKey,
     /// Issue #933: in-flight range-tombstone start bound
@@ -690,12 +381,49 @@ struct CompactionPolicy<'a> {
 }
 
 impl<'a> CompactionPolicy<'a> {
-    fn new(parser: &'a V5CompressedLegacyParser) -> Self {
+    pub(super) fn new(parser: &'a V5CompressedLegacyParser) -> Self {
         Self {
             parser,
             partition_key: RowKey::new(Vec::new()),
             pending_range_start: None,
         }
+    }
+
+    /// The partition key decoded on `on_partition_open` (issue #2299: the
+    /// resumable streaming driver in `compaction_stream` reads it back to carry
+    /// across a chunk-straddling refill).
+    pub(super) fn partition_key(&self) -> &RowKey {
+        &self.partition_key
+    }
+
+    /// The in-flight range-tombstone start bound (issue #2299: carried across
+    /// resumed streaming calls — see `CompactionPartitionState::pending_range_start`).
+    pub(super) fn pending_range_start(
+        &self,
+    ) -> &Option<(
+        crate::storage::sstable::reader::compaction_row::CompactionBound,
+        i64,
+        i32,
+    )> {
+        &self.pending_range_start
+    }
+
+    /// Restore the partition key on a resumed streaming call (issue #2299).
+    pub(super) fn set_partition_key(&mut self, key: RowKey) {
+        self.partition_key = key;
+    }
+
+    /// Restore the in-flight range-tombstone start bound on a resumed streaming
+    /// call (issue #2299).
+    pub(super) fn set_pending_range_start(
+        &mut self,
+        pending: Option<(
+            crate::storage::sstable::reader::compaction_row::CompactionBound,
+            i64,
+            i32,
+        )>,
+    ) {
+        self.pending_range_start = pending;
     }
 
     /// Build a `CompactionBound` from decoded clustering-prefix values. An empty

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction.rs
@@ -360,6 +360,315 @@ impl V5CompressedLegacyParser {
             emit(row)
         })
     }
+
+    /// Row-granular resumable partition streaming for the compaction read path
+    /// (issue #2299).
+    ///
+    /// [`Self::parse_one_partition_for_compaction`] buffers a WHOLE partition
+    /// into the driver-owned `pending` vec and only reports its consumed byte
+    /// count (and forwards its rows) once the partition is CONFIRMED complete —
+    /// i.e. at the END_OF_PARTITION marker or the next partition header. For a
+    /// WIDE partition (a single partition holding the bulk of an SSTable, e.g. a
+    /// time-series row split by clustering-key range across the merge inputs)
+    /// that means the sliding-window driver in
+    /// [`SSTableReader::stream_all_partitions_for_compaction`] cannot advance its
+    /// window cursor until the whole partition is resident — so peak memory
+    /// scales with `max_partition_size`, not `one row + one chunk`. With four
+    /// concurrent producers each holding a ~40 MiB wide partition (window bytes
+    /// PLUS the buffered rows), the compaction blows the 128 MiB budget.
+    ///
+    /// This method streams the partition BODY one confirmed structure at a time,
+    /// invoking `emit` per row/marker and reporting via [`PartitionStreamStep`]
+    /// exactly how many bytes of `data` are now safe to drain from the FRONT of
+    /// the caller's sliding window — WITHOUT waiting for END_OF_PARTITION. The
+    /// caller drives it as a resumable cursor: it calls this repeatedly on the
+    /// (growing/shrinking) window, advancing the front cursor by the returned
+    /// `consumed` after every call.
+    ///
+    /// `state` carries the cross-call partition context (the partition key, the
+    /// header-parsed flag, and the in-flight range-tombstone start bound) so a
+    /// partition that straddles a chunk boundary resumes correctly after a
+    /// refill. Tombstone / timestamp / range-marker semantics are byte-identical
+    /// to [`Self::parse_one_partition_for_compaction`] — this is the SAME
+    /// `CompactionPolicy` decode, only the buffering granularity differs.
+    ///
+    /// `at_final_chunk` flips a mid-structure end-of-buffer between a refill
+    /// request ([`PartitionStreamStep::NeedMore`]) and terminal completion
+    /// ([`PartitionStreamStep::PartitionDone`]), exactly as the sliding driver's
+    /// `NeedMore`/`Done` distinction does.
+    pub fn stream_partition_body_incremental<F>(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &crate::storage::sstable::reader::types::SSTableReader,
+        at_final_chunk: bool,
+        state: &mut CompactionPartitionState,
+        emit: &mut F,
+    ) -> Result<PartitionStreamStep>
+    where
+        F: FnMut(
+            crate::storage::sstable::reader::compaction_row::CompactionRow,
+        ) -> Result<std::ops::ControlFlow<()>>,
+    {
+        use super::row_framing::PartitionHeaderReadiness;
+
+        if data.is_empty() {
+            return Ok(if at_final_chunk {
+                PartitionStreamStep::AllDone
+            } else {
+                PartitionStreamStep::NeedMore
+            });
+        }
+
+        let schema = schema.ok_or_else(|| {
+            Error::schema(format!(
+                "V5CompressedLegacy (compaction) format requires schema for {}.{}",
+                self.keyspace, self.table_name
+            ))
+        })?;
+
+        // Every row-body offset arithmetic below reuses the SAME primitives the
+        // buffered `drive_partition_sliding` uses, so decode is byte-identical.
+        let resolution = RowColumnResolution::build(schema, reader);
+
+        // (1) Parse the partition header ONCE per partition. When the header has
+        //     already been parsed for this partition (a resumed body call after a
+        //     refill) the window front is the body start (offset 0).
+        if !state.header_parsed {
+            match self.partition_header_readiness(data) {
+                PartitionHeaderReadiness::Malformed => {
+                    // Skip one byte to resynchronise (matches the buffered driver's
+                    // `Emitted(1)` malformed-header behaviour).
+                    return Ok(PartitionStreamStep::Consumed(1));
+                }
+                PartitionHeaderReadiness::Incomplete => {
+                    return Ok(if at_final_chunk {
+                        PartitionStreamStep::AllDone
+                    } else {
+                        PartitionStreamStep::NeedMore
+                    });
+                }
+                PartitionHeaderReadiness::Ready => {}
+            }
+
+            let (partition_key, after_header, partition_deletion) =
+                match self.parse_partition_header_full(data, 0) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        if !at_final_chunk
+                            && self.partition_header_readiness(data)
+                                == PartitionHeaderReadiness::Incomplete
+                        {
+                            return Ok(PartitionStreamStep::NeedMore);
+                        }
+                        return Ok(PartitionStreamStep::Consumed(1));
+                    }
+                };
+
+            // Emit a partition-level tombstone carrier immediately (issue #1072),
+            // via the shared CompactionPolicy hook — same synthetic carrier the
+            // buffered path pushes into `pending`. The policy's transient state
+            // (partition key + in-flight range-start bound) is written back into
+            // `state` so a resumed body call rebuilds an equivalent policy.
+            let mut policy = CompactionPolicy::new(self);
+            let mut carriers: Vec<
+                crate::storage::sstable::reader::compaction_row::CompactionRow,
+            > = Vec::new();
+            policy.on_partition_open(partition_key, partition_deletion, schema, &mut carriers);
+            state.partition_key = policy.partition_key.clone();
+            state.pending_range_start = policy.pending_range_start.clone();
+            state.header_parsed = true;
+            // The header bytes are confirmed; drain them from the window front so a
+            // refill re-parse never re-reads the header. The next call sees the body
+            // at offset 0.
+            for row in carriers {
+                match emit(row)? {
+                    std::ops::ControlFlow::Continue(()) => {}
+                    std::ops::ControlFlow::Break(()) => {
+                        return Ok(PartitionStreamStep::Break(after_header));
+                    }
+                }
+            }
+            return Ok(PartitionStreamStep::Consumed(after_header));
+        }
+
+        // (2) Body: parse ONE confirmed structure (row / range marker /
+        //     end-of-partition) from the front (offset 0), emit it, and report its
+        //     consumed bytes so the caller advances the window cursor per structure.
+        //     Rebuild the policy from `state` (it only carries owned pieces: the
+        //     partition key and the in-flight range-tombstone start bound).
+        let offset = 0usize;
+
+        // END_OF_PARTITION (0x01): partition complete; consume the marker byte and
+        // signal the caller to reset for the next partition.
+        if offset < data.len() && Self::is_end_of_partition(data[offset]) {
+            state.reset();
+            return Ok(PartitionStreamStep::PartitionDone(1));
+        }
+
+        // Consumed everything but never saw END_OF_PARTITION: the partition may
+        // continue in the next chunk.
+        if offset >= data.len() {
+            if at_final_chunk {
+                // Trailing (unterminated) partition is terminal (no bytes to drain).
+                state.reset();
+                return Ok(PartitionStreamStep::PartitionDone(0));
+            }
+            return Ok(PartitionStreamStep::NeedMore);
+        }
+
+        let mut policy = CompactionPolicy::new(self);
+        policy.partition_key = state.partition_key.clone();
+        policy.pending_range_start = state.pending_range_start.clone();
+
+        // A range-tombstone marker: pair it via the policy (the surviving marker
+        // row, if any, is emitted here). A truncated marker on a non-final chunk
+        // requests more bytes.
+        if Self::is_range_tombstone_marker(data[offset]) {
+            let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
+                Vec::new();
+            match policy.on_range_marker(data, offset, schema, &mut emitted) {
+                super::partition_driver::MarkerOutcome::Advanced(next_offset) => {
+                    // Confirm the marker is fully framed within the window.
+                    if next_offset > data.len() {
+                        return Ok(if at_final_chunk {
+                            PartitionStreamStep::AllDone
+                        } else {
+                            PartitionStreamStep::NeedMore
+                        });
+                    }
+                    state.pending_range_start = policy.pending_range_start.clone();
+                    for row in emitted {
+                        match emit(row)? {
+                            std::ops::ControlFlow::Continue(()) => {}
+                            std::ops::ControlFlow::Break(()) => {
+                                return Ok(PartitionStreamStep::Break(next_offset));
+                            }
+                        }
+                    }
+                    return Ok(PartitionStreamStep::Consumed(next_offset));
+                }
+                super::partition_driver::MarkerOutcome::Stop => {
+                    if at_final_chunk {
+                        state.reset();
+                        return Ok(PartitionStreamStep::PartitionDone(0));
+                    }
+                    return Ok(PartitionStreamStep::NeedMore);
+                }
+            }
+        }
+
+        // A data row: decode exactly one, emit it, and report its consumed bytes.
+        let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
+            Vec::new();
+        match policy.on_data_row(data, offset, schema, reader, &resolution, &mut emitted) {
+            Some(next_offset) => {
+                // Confirm the row is fully framed WITHIN the window: a next_offset
+                // past the buffer end means we may have decoded a truncated row on a
+                // non-final chunk — request more bytes rather than emit a partial row.
+                if next_offset > data.len() {
+                    return Ok(if at_final_chunk {
+                        PartitionStreamStep::AllDone
+                    } else {
+                        PartitionStreamStep::NeedMore
+                    });
+                }
+                state.pending_range_start = policy.pending_range_start.clone();
+                for row in emitted {
+                    match emit(row)? {
+                        std::ops::ControlFlow::Continue(()) => {}
+                        std::ops::ControlFlow::Break(()) => {
+                            return Ok(PartitionStreamStep::Break(next_offset));
+                        }
+                    }
+                }
+                Ok(PartitionStreamStep::Consumed(next_offset))
+            }
+            None => {
+                // A row failed to parse. Mid-stream that may be a row straddling the
+                // chunk boundary, so request more bytes unless this is the final
+                // chunk (where it is end-of-partition).
+                if at_final_chunk {
+                    state.reset();
+                    Ok(PartitionStreamStep::PartitionDone(0))
+                } else {
+                    Ok(PartitionStreamStep::NeedMore)
+                }
+            }
+        }
+    }
+}
+
+/// Cross-call state for [`V5CompressedLegacyParser::stream_partition_body_incremental`]
+/// (issue #2299). Carries the in-flight partition's decode context so a partition
+/// that straddles a sliding-window chunk boundary resumes correctly after a refill.
+pub struct CompactionPartitionState {
+    /// Whether the partition header (key + partition-level deletion) has been
+    /// parsed for the CURRENT partition. Reset to `false` at each partition
+    /// boundary so the next partition re-parses its own header.
+    header_parsed: bool,
+    /// The current partition's key, decoded once from the header and reused for
+    /// every row this partition emits across resumed calls.
+    partition_key: RowKey,
+    /// Issue #933: the in-flight range-tombstone start bound
+    /// `(bound, markedForDeleteAt µs, localDeletionTime s)`, carried across
+    /// resumed calls so a range whose CLOSE bound arrives in a later chunk still
+    /// pairs correctly (the incremental driver never re-parses from the partition
+    /// start, so this cross-call carry replaces the buffered driver's re-derive).
+    pending_range_start: Option<(
+        crate::storage::sstable::reader::compaction_row::CompactionBound,
+        i64,
+        i32,
+    )>,
+}
+
+impl Default for CompactionPartitionState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CompactionPartitionState {
+    /// A fresh state positioned at the start of a (not-yet-parsed) partition.
+    pub fn new() -> Self {
+        Self {
+            header_parsed: false,
+            partition_key: RowKey::new(Vec::new()),
+            pending_range_start: None,
+        }
+    }
+
+    /// Reset to await the next partition header (after an END_OF_PARTITION or a
+    /// terminal trailing partition).
+    fn reset(&mut self) {
+        self.header_parsed = false;
+        self.partition_key = RowKey::new(Vec::new());
+        self.pending_range_start = None;
+    }
+}
+
+/// Outcome of one [`V5CompressedLegacyParser::stream_partition_body_incremental`]
+/// call (issue #2299). Reports how many bytes of the window front are now safe to
+/// drain, WITHOUT waiting for a whole partition.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PartitionStreamStep {
+    /// One structure (header prefix, row, or range marker) was confirmed and its
+    /// rows emitted; `usize` bytes may be drained from the window front. The
+    /// current partition CONTINUES — call again.
+    Consumed(usize),
+    /// The partition ended (END_OF_PARTITION, or a terminal trailing partition on
+    /// the final chunk); `usize` bytes may be drained. State is reset for the next
+    /// partition.
+    PartitionDone(usize),
+    /// The window is (possibly) truncated mid-structure and `!at_final_chunk`:
+    /// the caller must append the next chunk and retry (nothing to drain). Never
+    /// returned when `at_final_chunk`.
+    NeedMore,
+    /// The window is empty at the final chunk — genuine end of data. Terminal.
+    AllDone,
+    /// `emit` returned `Break` (consumer dropped); `usize` bytes were consumed up
+    /// to and including the breaking structure. The caller stops the scan.
+    Break(usize),
 }
 
 /// Issue #1640 (K1): [`SlidingPartitionPolicy`] for the per-element compaction

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction_stream.rs
@@ -1,0 +1,328 @@
+//! Row-granular resumable within-partition compaction streaming (issue #2299).
+//!
+//! Split out of the sibling `compaction` module (campsite rule, epic #1116):
+//! [`V5CompressedLegacyParser::stream_partition_body_incremental`] and its
+//! cross-call [`CompactionPartitionState`] / per-structure [`PartitionStreamStep`]
+//! types. Reuses the SAME `CompactionPolicy` decode as the buffered
+//! `parse_one_partition_for_compaction`, so tombstone / timestamp / range-marker
+//! semantics are byte-identical — only the buffering GRANULARITY differs (this
+//! path drains one confirmed structure at a time so the sliding-window compaction
+//! driver never has to keep a WIDE partition fully resident).
+
+use super::compaction::CompactionPolicy;
+use super::partition_driver::{MarkerOutcome, SlidingPartitionPolicy};
+use super::row_framing::PartitionHeaderReadiness;
+use super::{RowColumnResolution, V5CompressedLegacyParser};
+use crate::schema::TableSchema;
+use crate::types::RowKey;
+use crate::{Error, Result};
+
+impl V5CompressedLegacyParser {
+    /// Row-granular resumable partition streaming for the compaction read path
+    /// (issue #2299).
+    ///
+    /// [`Self::parse_one_partition_for_compaction`] buffers a WHOLE partition
+    /// into the driver-owned `pending` vec and only reports its consumed byte
+    /// count (and forwards its rows) once the partition is CONFIRMED complete —
+    /// i.e. at the END_OF_PARTITION marker or the next partition header. For a
+    /// WIDE partition (a single partition holding the bulk of an SSTable, e.g. a
+    /// time-series row split by clustering-key range across the merge inputs)
+    /// that means the sliding-window driver in
+    /// [`SSTableReader::stream_all_partitions_for_compaction`] cannot advance its
+    /// window cursor until the whole partition is resident — so peak memory
+    /// scales with `max_partition_size`, not `one row + one chunk`. With four
+    /// concurrent producers each holding a ~40 MiB wide partition (window bytes
+    /// PLUS the buffered rows), the compaction blows the 128 MiB budget.
+    ///
+    /// This method streams the partition BODY one confirmed structure at a time,
+    /// invoking `emit` per row/marker and reporting via [`PartitionStreamStep`]
+    /// exactly how many bytes of `data` are now safe to drain from the FRONT of
+    /// the caller's sliding window — WITHOUT waiting for END_OF_PARTITION. The
+    /// caller drives it as a resumable cursor: it calls this repeatedly on the
+    /// (growing/shrinking) window, advancing the front cursor by the returned
+    /// `consumed` after every call.
+    ///
+    /// `state` carries the cross-call partition context (the partition key, the
+    /// header-parsed flag, and the in-flight range-tombstone start bound) so a
+    /// partition that straddles a chunk boundary resumes correctly after a
+    /// refill. Tombstone / timestamp / range-marker semantics are byte-identical
+    /// to [`Self::parse_one_partition_for_compaction`] — this is the SAME
+    /// `CompactionPolicy` decode, only the buffering granularity differs.
+    ///
+    /// `at_final_chunk` flips a mid-structure end-of-buffer between a refill
+    /// request ([`PartitionStreamStep::NeedMore`]) and terminal completion
+    /// ([`PartitionStreamStep::PartitionDone`]), exactly as the sliding driver's
+    /// `NeedMore`/`Done` distinction does.
+    ///
+    /// [`SSTableReader::stream_all_partitions_for_compaction`]: crate::storage::sstable::SSTableReader
+    pub fn stream_partition_body_incremental<F>(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &crate::storage::sstable::reader::types::SSTableReader,
+        at_final_chunk: bool,
+        state: &mut CompactionPartitionState,
+        emit: &mut F,
+    ) -> Result<PartitionStreamStep>
+    where
+        F: FnMut(
+            crate::storage::sstable::reader::compaction_row::CompactionRow,
+        ) -> Result<std::ops::ControlFlow<()>>,
+    {
+        if data.is_empty() {
+            return Ok(if at_final_chunk {
+                PartitionStreamStep::AllDone
+            } else {
+                PartitionStreamStep::NeedMore
+            });
+        }
+
+        let schema = schema.ok_or_else(|| {
+            Error::schema(format!(
+                "V5CompressedLegacy (compaction) format requires schema for {}.{}",
+                self.keyspace, self.table_name
+            ))
+        })?;
+
+        // Every row-body offset arithmetic below reuses the SAME primitives the
+        // buffered `drive_partition_sliding` uses, so decode is byte-identical.
+        let resolution = RowColumnResolution::build(schema, reader);
+
+        // (1) Parse the partition header ONCE per partition. When the header has
+        //     already been parsed for this partition (a resumed body call after a
+        //     refill) the window front is the body start (offset 0).
+        if !state.header_parsed {
+            match self.partition_header_readiness(data) {
+                PartitionHeaderReadiness::Malformed => {
+                    // Skip one byte to resynchronise (matches the buffered driver's
+                    // `Emitted(1)` malformed-header behaviour).
+                    return Ok(PartitionStreamStep::Consumed(1));
+                }
+                PartitionHeaderReadiness::Incomplete => {
+                    return Ok(if at_final_chunk {
+                        PartitionStreamStep::AllDone
+                    } else {
+                        PartitionStreamStep::NeedMore
+                    });
+                }
+                PartitionHeaderReadiness::Ready => {}
+            }
+
+            let (partition_key, after_header, partition_deletion) =
+                match self.parse_partition_header_full(data, 0) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        if !at_final_chunk
+                            && self.partition_header_readiness(data)
+                                == PartitionHeaderReadiness::Incomplete
+                        {
+                            return Ok(PartitionStreamStep::NeedMore);
+                        }
+                        return Ok(PartitionStreamStep::Consumed(1));
+                    }
+                };
+
+            // Emit a partition-level tombstone carrier immediately (issue #1072),
+            // via the shared CompactionPolicy hook — same synthetic carrier the
+            // buffered path pushes into `pending`. The policy's transient state
+            // (partition key + in-flight range-start bound) is written back into
+            // `state` so a resumed body call rebuilds an equivalent policy.
+            let mut policy = CompactionPolicy::new(self);
+            let mut carriers: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
+                Vec::new();
+            policy.on_partition_open(partition_key, partition_deletion, schema, &mut carriers);
+            state.partition_key = policy.partition_key().clone();
+            state.pending_range_start = policy.pending_range_start().clone();
+            state.header_parsed = true;
+            // The header bytes are confirmed; drain them from the window front so a
+            // refill re-parse never re-reads the header. The next call sees the body
+            // at offset 0.
+            for row in carriers {
+                match emit(row)? {
+                    std::ops::ControlFlow::Continue(()) => {}
+                    std::ops::ControlFlow::Break(()) => {
+                        return Ok(PartitionStreamStep::Break(after_header));
+                    }
+                }
+            }
+            return Ok(PartitionStreamStep::Consumed(after_header));
+        }
+
+        // (2) Body: parse ONE confirmed structure (row / range marker /
+        //     end-of-partition) from the front (offset 0), emit it, and report its
+        //     consumed bytes so the caller advances the window cursor per structure.
+        //     Rebuild the policy from `state` (it only carries owned pieces: the
+        //     partition key and the in-flight range-tombstone start bound).
+        let offset = 0usize;
+
+        // END_OF_PARTITION (0x01): partition complete; consume the marker byte and
+        // signal the caller to reset for the next partition.
+        if offset < data.len() && Self::is_end_of_partition(data[offset]) {
+            state.reset();
+            return Ok(PartitionStreamStep::PartitionDone(1));
+        }
+
+        // Consumed everything but never saw END_OF_PARTITION: the partition may
+        // continue in the next chunk.
+        if offset >= data.len() {
+            if at_final_chunk {
+                // Trailing (unterminated) partition is terminal (no bytes to drain).
+                state.reset();
+                return Ok(PartitionStreamStep::PartitionDone(0));
+            }
+            return Ok(PartitionStreamStep::NeedMore);
+        }
+
+        let mut policy = CompactionPolicy::new(self);
+        policy.set_partition_key(state.partition_key.clone());
+        policy.set_pending_range_start(state.pending_range_start.clone());
+
+        // A range-tombstone marker: pair it via the policy (the surviving marker
+        // row, if any, is emitted here). A truncated marker on a non-final chunk
+        // requests more bytes.
+        if Self::is_range_tombstone_marker(data[offset]) {
+            let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
+                Vec::new();
+            match policy.on_range_marker(data, offset, schema, &mut emitted) {
+                MarkerOutcome::Advanced(next_offset) => {
+                    // Confirm the marker is fully framed within the window.
+                    if next_offset > data.len() {
+                        return Ok(if at_final_chunk {
+                            PartitionStreamStep::AllDone
+                        } else {
+                            PartitionStreamStep::NeedMore
+                        });
+                    }
+                    state.pending_range_start = policy.pending_range_start().clone();
+                    for row in emitted {
+                        match emit(row)? {
+                            std::ops::ControlFlow::Continue(()) => {}
+                            std::ops::ControlFlow::Break(()) => {
+                                return Ok(PartitionStreamStep::Break(next_offset));
+                            }
+                        }
+                    }
+                    return Ok(PartitionStreamStep::Consumed(next_offset));
+                }
+                MarkerOutcome::Stop => {
+                    if at_final_chunk {
+                        state.reset();
+                        return Ok(PartitionStreamStep::PartitionDone(0));
+                    }
+                    return Ok(PartitionStreamStep::NeedMore);
+                }
+            }
+        }
+
+        // A data row: decode exactly one, emit it, and report its consumed bytes.
+        let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
+            Vec::new();
+        match policy.on_data_row(data, offset, schema, reader, &resolution, &mut emitted) {
+            Some(next_offset) => {
+                // Confirm the row is fully framed WITHIN the window: a next_offset
+                // past the buffer end means we may have decoded a truncated row on a
+                // non-final chunk — request more bytes rather than emit a partial row.
+                if next_offset > data.len() {
+                    return Ok(if at_final_chunk {
+                        PartitionStreamStep::AllDone
+                    } else {
+                        PartitionStreamStep::NeedMore
+                    });
+                }
+                state.pending_range_start = policy.pending_range_start().clone();
+                for row in emitted {
+                    match emit(row)? {
+                        std::ops::ControlFlow::Continue(()) => {}
+                        std::ops::ControlFlow::Break(()) => {
+                            return Ok(PartitionStreamStep::Break(next_offset));
+                        }
+                    }
+                }
+                Ok(PartitionStreamStep::Consumed(next_offset))
+            }
+            None => {
+                // A row failed to parse. Mid-stream that may be a row straddling the
+                // chunk boundary, so request more bytes unless this is the final
+                // chunk (where it is end-of-partition).
+                if at_final_chunk {
+                    state.reset();
+                    Ok(PartitionStreamStep::PartitionDone(0))
+                } else {
+                    Ok(PartitionStreamStep::NeedMore)
+                }
+            }
+        }
+    }
+}
+
+/// Cross-call state for [`V5CompressedLegacyParser::stream_partition_body_incremental`]
+/// (issue #2299). Carries the in-flight partition's decode context so a partition
+/// that straddles a sliding-window chunk boundary resumes correctly after a refill.
+pub struct CompactionPartitionState {
+    /// Whether the partition header (key + partition-level deletion) has been
+    /// parsed for the CURRENT partition. Reset to `false` at each partition
+    /// boundary so the next partition re-parses its own header.
+    header_parsed: bool,
+    /// The current partition's key, decoded once from the header and reused for
+    /// every row this partition emits across resumed calls.
+    partition_key: RowKey,
+    /// Issue #933: the in-flight range-tombstone start bound
+    /// `(bound, markedForDeleteAt µs, localDeletionTime s)`, carried across
+    /// resumed calls so a range whose CLOSE bound arrives in a later chunk still
+    /// pairs correctly (the incremental driver never re-parses from the partition
+    /// start, so this cross-call carry replaces the buffered driver's re-derive).
+    pending_range_start: Option<(
+        crate::storage::sstable::reader::compaction_row::CompactionBound,
+        i64,
+        i32,
+    )>,
+}
+
+impl Default for CompactionPartitionState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CompactionPartitionState {
+    /// A fresh state positioned at the start of a (not-yet-parsed) partition.
+    pub fn new() -> Self {
+        Self {
+            header_parsed: false,
+            partition_key: RowKey::new(Vec::new()),
+            pending_range_start: None,
+        }
+    }
+
+    /// Reset to await the next partition header (after an END_OF_PARTITION or a
+    /// terminal trailing partition).
+    fn reset(&mut self) {
+        self.header_parsed = false;
+        self.partition_key = RowKey::new(Vec::new());
+        self.pending_range_start = None;
+    }
+}
+
+/// Outcome of one [`V5CompressedLegacyParser::stream_partition_body_incremental`]
+/// call (issue #2299). Reports how many bytes of the window front are now safe to
+/// drain, WITHOUT waiting for a whole partition.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PartitionStreamStep {
+    /// One structure (header prefix, row, or range marker) was confirmed and its
+    /// rows emitted; `usize` bytes may be drained from the window front. The
+    /// current partition CONTINUES — call again.
+    Consumed(usize),
+    /// The partition ended (END_OF_PARTITION, or a terminal trailing partition on
+    /// the final chunk); `usize` bytes may be drained. State is reset for the next
+    /// partition.
+    PartitionDone(usize),
+    /// The window is (possibly) truncated mid-structure and `!at_final_chunk`:
+    /// the caller must append the next chunk and retry (nothing to drain). Never
+    /// returned when `at_final_chunk`.
+    NeedMore,
+    /// The window is empty at the final chunk — genuine end of data. Terminal.
+    AllDone,
+    /// `emit` returned `Break` (consumer dropped); `usize` bytes were consumed up
+    /// to and including the breaking structure. The caller stops the scan.
+    Break(usize),
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction_stream.rs
@@ -54,12 +54,29 @@ impl V5CompressedLegacyParser {
     /// ([`PartitionStreamStep::PartitionDone`]), exactly as the sliding driver's
     /// `NeedMore`/`Done` distinction does.
     ///
+    /// `resolution` is the column resolution built ONCE per scan by the caller
+    /// ([`SSTableReader::stream_all_partitions_for_compaction`]) and threaded in
+    /// (the same way `schema` / `state` are). It is derived purely from the
+    /// SSTable serialization header (`reader.header`) + `schema`, both INVARIANT
+    /// across every partition of a single SSTable, so a single build is
+    /// semantically identical to the buffered `drive_partition_sliding`'s
+    /// per-partition build (`partition_driver.rs:179`) — only without that path's
+    /// per-partition (and, for this per-structure driver, once-PER-ROW) allocation
+    /// churn: `RowColumnResolution::build` allocates a `HashMap` over
+    /// `schema.columns` plus a fresh `Arc<str>` per header/clustering column, so
+    /// rebuilding it per drain step turned an O(partitions) cost into
+    /// O(rows × header_cols) on exactly the wide-partition workload issue #2299
+    /// optimizes. Threading the once-built resolution restores per-scan
+    /// (≤ per-partition) allocation. `None` only when `schema` is `None`, which
+    /// this method rejects before any row decode.
+    ///
     /// [`SSTableReader::stream_all_partitions_for_compaction`]: crate::storage::sstable::SSTableReader
     pub fn stream_partition_body_incremental<F>(
         &self,
         data: &[u8],
         schema: Option<&TableSchema>,
         reader: &crate::storage::sstable::reader::types::SSTableReader,
+        resolution: Option<&RowColumnResolution>,
         at_final_chunk: bool,
         state: &mut CompactionPartitionState,
         emit: &mut F,
@@ -84,9 +101,17 @@ impl V5CompressedLegacyParser {
             ))
         })?;
 
-        // Every row-body offset arithmetic below reuses the SAME primitives the
-        // buffered `drive_partition_sliding` uses, so decode is byte-identical.
-        let resolution = RowColumnResolution::build(schema, reader);
+        // The column resolution is built ONCE per scan by the caller and threaded
+        // in (see the doc comment). It is required whenever `schema` is present
+        // (the caller builds it from the same schema); a missing resolution here
+        // is an internal wiring bug, not a data condition.
+        let resolution = resolution.ok_or_else(|| {
+            Error::schema(format!(
+                "V5CompressedLegacy (compaction) streaming requires a prebuilt column \
+                 resolution for {}.{}",
+                self.keyspace, self.table_name
+            ))
+        })?;
 
         // (1) Parse the partition header ONCE per partition. When the header has
         //     already been parsed for this partition (a resumed body call after a
@@ -208,7 +233,7 @@ impl V5CompressedLegacyParser {
         // A data row: decode exactly one, emit it, and report its consumed bytes.
         let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
             Vec::new();
-        match policy.on_data_row(data, 0, schema, reader, &resolution, &mut emitted) {
+        match policy.on_data_row(data, 0, schema, reader, resolution, &mut emitted) {
             Some(next_offset) => {
                 // Confirm the row is fully framed WITHIN the window: a next_offset
                 // STRICTLY PAST the buffer end means we decoded a truncated row on a

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction_stream.rs
@@ -149,28 +149,19 @@ impl V5CompressedLegacyParser {
         }
 
         // (2) Body: parse ONE confirmed structure (row / range marker /
-        //     end-of-partition) from the front (offset 0), emit it, and report its
-        //     consumed bytes so the caller advances the window cursor per structure.
-        //     Rebuild the policy from `state` (it only carries owned pieces: the
-        //     partition key and the in-flight range-tombstone start bound).
-        let offset = 0usize;
+        //     end-of-partition) from the FRONT of the window (offset 0 — this
+        //     driver resumes from 0 each call, reporting its consumed byte count so
+        //     the caller advances the window cursor per structure), emit it, and
+        //     report its consumed bytes. Rebuild the policy from `state` (it only
+        //     carries owned pieces: the partition key and the in-flight
+        //     range-tombstone start bound). `data` is non-empty here (early return
+        //     at the top), so the front byte `data[0]` is always in bounds.
 
         // END_OF_PARTITION (0x01): partition complete; consume the marker byte and
         // signal the caller to reset for the next partition.
-        if offset < data.len() && Self::is_end_of_partition(data[offset]) {
+        if Self::is_end_of_partition(data[0]) {
             state.reset();
             return Ok(PartitionStreamStep::PartitionDone(1));
-        }
-
-        // Consumed everything but never saw END_OF_PARTITION: the partition may
-        // continue in the next chunk.
-        if offset >= data.len() {
-            if at_final_chunk {
-                // Trailing (unterminated) partition is terminal (no bytes to drain).
-                state.reset();
-                return Ok(PartitionStreamStep::PartitionDone(0));
-            }
-            return Ok(PartitionStreamStep::NeedMore);
         }
 
         let mut policy = CompactionPolicy::new(self);
@@ -180,10 +171,10 @@ impl V5CompressedLegacyParser {
         // A range-tombstone marker: pair it via the policy (the surviving marker
         // row, if any, is emitted here). A truncated marker on a non-final chunk
         // requests more bytes.
-        if Self::is_range_tombstone_marker(data[offset]) {
+        if Self::is_range_tombstone_marker(data[0]) {
             let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
                 Vec::new();
-            match policy.on_range_marker(data, offset, schema, &mut emitted) {
+            match policy.on_range_marker(data, 0, schema, &mut emitted) {
                 MarkerOutcome::Advanced(next_offset) => {
                     // Confirm the marker is fully framed within the window.
                     if next_offset > data.len() {
@@ -217,11 +208,24 @@ impl V5CompressedLegacyParser {
         // A data row: decode exactly one, emit it, and report its consumed bytes.
         let mut emitted: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> =
             Vec::new();
-        match policy.on_data_row(data, offset, schema, reader, &resolution, &mut emitted) {
+        match policy.on_data_row(data, 0, schema, reader, &resolution, &mut emitted) {
             Some(next_offset) => {
                 // Confirm the row is fully framed WITHIN the window: a next_offset
-                // past the buffer end means we may have decoded a truncated row on a
-                // non-final chunk — request more bytes rather than emit a partial row.
+                // STRICTLY PAST the buffer end means we decoded a truncated row on a
+                // non-final chunk — request more bytes rather than emit a partial
+                // row. NB: `>` not `>=` (the buffered `drive_partition_sliding` uses
+                // `>=` on line 240 of partition_driver.rs). The difference is
+                // intentional and load-bearing for this resume-from-0 driver: this
+                // path parses ONE structure from the FRONT (offset 0) and reports
+                // its consumed byte count so the caller advances the window cursor
+                // per-structure, so a row that ends EXACTLY at `data.len()`
+                // (`next_offset == data.len()`) is a fully-framed row whose bytes we
+                // must consume and drain — treating `==` as truncation would stall
+                // the cursor forever (re-parsing the same trailing row every refill).
+                // The buffered driver's `>=` is correct for ITS loop (it keeps
+                // advancing `offset` within one call and uses `offset >= data.len()`
+                // to decide whether to look for the next structure), not for a
+                // per-structure resume cursor. Do not "simplify" `>` to `>=`.
                 if next_offset > data.len() {
                     return Ok(if at_final_chunk {
                         PartitionStreamStep::AllDone
@@ -237,6 +241,21 @@ impl V5CompressedLegacyParser {
                             return Ok(PartitionStreamStep::Break(next_offset));
                         }
                     }
+                }
+                // Partition-boundary defense-in-depth (roborev): mirror the buffered
+                // `drive_partition_sliding` EXACTLY. If the very next bytes are a
+                // partition header (a body NOT terminated by an explicit
+                // END_OF_PARTITION 0x01 — e.g. malformed/corrupt input, or a
+                // producer that elides the marker), the current partition is
+                // complete. Feeding the next partition's header into `on_data_row`
+                // would mis-attribute/desync it. Split here (reset for the next
+                // partition) so the streaming path and the buffered path can never
+                // diverge. Only meaningful when the header is fully framed within
+                // the window; a truncated header on a non-final chunk falls through
+                // to the normal per-structure refill on the next call.
+                if next_offset < data.len() && self.peek_is_partition_header(data, next_offset) {
+                    state.reset();
+                    return Ok(PartitionStreamStep::PartitionDone(next_offset));
                 }
                 Ok(PartitionStreamStep::Consumed(next_offset))
             }

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -855,10 +855,8 @@ mod block_emit_windowed;
 mod cell_kind;
 mod cell_value;
 mod compaction;
-// Issue #2299: row-granular resumable compaction streaming state + step enum,
-// re-exported so the sliding-window compaction driver in `data_access` can drive
-// a wide partition WITHOUT buffering it whole.
-pub(in crate::storage::sstable::reader) use compaction::{
+mod compaction_stream; // issue #2299 (split of `compaction`, campsite #1116)
+pub(in crate::storage::sstable::reader) use compaction_stream::{
     CompactionPartitionState, PartitionStreamStep,
 };
 mod complex_column;

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -164,7 +164,7 @@ pub(super) struct ColumnToParse<'a> {
 /// (resolution is built at the top of each `parse_block_emit*` / per-partition
 /// driver, where `reader` and `schema` are in scope). This is a per-BLOCK hoist —
 /// allocations scale with block count, not row count.
-pub(super) struct RowColumnResolution<'a> {
+pub(in crate::storage::sstable::reader) struct RowColumnResolution<'a> {
     /// On-disk regular (non-static) columns in serialization-header order.
     regular: Vec<ColumnToParse<'a>>,
     /// On-disk static columns in serialization-header order.
@@ -186,7 +186,7 @@ impl<'a> RowColumnResolution<'a> {
     /// semantics). On the header-empty fallback path (synthetic SSTables) the
     /// supplied schema order is used directly, every column schema-present by
     /// construction.
-    pub(super) fn build(
+    pub(in crate::storage::sstable::reader) fn build(
         schema: &'a TableSchema,
         reader: &'a crate::storage::sstable::reader::types::SSTableReader,
     ) -> Self {

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -855,6 +855,12 @@ mod block_emit_windowed;
 mod cell_kind;
 mod cell_value;
 mod compaction;
+// Issue #2299: row-granular resumable compaction streaming state + step enum,
+// re-exported so the sliding-window compaction driver in `data_access` can drive
+// a wide partition WITHOUT buffering it whole.
+pub(in crate::storage::sstable::reader) use compaction::{
+    CompactionPartitionState, PartitionStreamStep,
+};
 mod complex_column;
 mod frozen;
 mod marshal_element;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -394,6 +394,24 @@ impl DataWriter {
         Ok(())
     }
 
+    /// Flush the current scratch `buffer` to the streaming sink MID-PARTITION
+    /// (issue #2299), advancing `position` and clearing the scratch.
+    ///
+    /// Mechanically identical to [`Self::flush_partition`] (feed the CRC/`CRC.db`
+    /// accumulator in write order, advance `position`, clear `buffer`), but named
+    /// distinctly to document the caller's contract: it is safe to call between
+    /// two whole promoted-index blocks of an IN-PROGRESS partition ONLY because the
+    /// streaming session tracks every partition offset as flush-invariant absolute
+    /// math (`writer.position() - partition_offset`), not as a `buffer`-relative
+    /// index. Calling it mid-BLOCK would be equally correct for the on-disk bytes
+    /// (they are append-only), but the session only calls it at block boundaries so
+    /// its bounded-scratch guarantee is exactly one promoted-index block. No-op in
+    /// in-memory mode (the scratch keeps accumulating, matching `flush_partition`).
+    pub(super) fn flush_buffered_partition_scratch(&mut self) -> Result<()> {
+        // Same body as `flush_partition`: the two differ only in intent/documentation.
+        self.flush_partition()
+    }
+
     /// Update the statistics metadata
     ///
     /// This should be called after computing stats from all mutations

--- a/cqlite-core/src/storage/sstable/writer/data_writer/streaming_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/streaming_partition.rs
@@ -66,14 +66,19 @@ impl OwnedSortableMarker {
 /// replacing it.
 pub(crate) struct StreamingPartitionSession {
     partition_offset: u64,
-    partition_buf_start: usize,
     prev_unfiltered_size: u64,
     partition_floor: Option<i64>,
     range_tombstones: Vec<RangeTombstone>,
     sorted_markers: Vec<OwnedSortableMarker>,
     marker_cursor: usize,
     emit: PartitionEmitCounts,
-    block_start_buf_offset: Option<usize>,
+    /// Promoted-index block start, as a PARTITION-RELATIVE byte offset (issue
+    /// #2299). Absolute, flush-invariant math (`writer.position() -
+    /// partition_offset`) replaced the old `buffer.len() - partition_buf_start`
+    /// buffer-index form so the session can flush its scratch to the sink
+    /// MID-PARTITION (a wide partition no longer stays fully resident in
+    /// `DataWriter::buffer`).
+    block_start_rel_offset: Option<u64>,
     blocks: Vec<PromotedIndexBlock>,
     current_block_first_ck: Option<Vec<u8>>,
     current_block_last_ck: Option<Vec<u8>>,
@@ -95,7 +100,6 @@ impl DataWriter {
         schema: &TableSchema,
     ) -> Result<StreamingPartitionSession> {
         let partition_offset = self.position + self.buffer.len() as u64;
-        let partition_buf_start = self.buffer.len();
         let header_start = self.buffer.len();
         self.write_partition_header(key, partition_tombstone)?;
         let prev_unfiltered_size = (self.buffer.len() - header_start) as u64;
@@ -123,14 +127,13 @@ impl DataWriter {
 
         Ok(StreamingPartitionSession {
             partition_offset,
-            partition_buf_start,
             prev_unfiltered_size,
             partition_floor,
             range_tombstones: range_tombstones.to_vec(),
             sorted_markers,
             marker_cursor: 0,
             emit: PartitionEmitCounts::default(),
-            block_start_buf_offset: None,
+            block_start_rel_offset: None,
             blocks: Vec::new(),
             current_block_first_ck: None,
             current_block_last_ck: None,
@@ -228,14 +231,15 @@ impl StreamingPartitionSession {
             self.current_block_first_ck.take(),
             self.current_block_last_ck.take(),
         ) {
-            let current_buf_offset = writer.buffer.len() - self.partition_buf_start;
-            let block_start = self.block_start_buf_offset.unwrap_or(current_buf_offset);
-            let block_bytes = (current_buf_offset - block_start) as u64;
+            // Partition-relative offset via absolute, flush-invariant math (#2299).
+            let current_rel_offset = writer.position() - self.partition_offset;
+            let block_start = self.block_start_rel_offset.unwrap_or(current_rel_offset);
+            let block_bytes = current_rel_offset - block_start;
             if block_bytes > 0 {
                 self.blocks.push(PromotedIndexBlock {
                     first_name: first,
                     last_name: last,
-                    offset: block_start as u64,
+                    offset: block_start,
                     width: block_bytes,
                     oss50_separator: self.current_block_oss50.take().flatten(),
                 });
@@ -316,7 +320,6 @@ impl StreamingPartitionSession {
                 .unwrap_or_else(|_| boundary_prefix_for_index_fallback(*kind)),
         };
 
-        let partition_buf_start = self.partition_buf_start;
         if self.current_block_first_ck.is_none() {
             self.current_block_first_ck = Some(ck_bytes.clone());
             let ck_values: Option<Vec<Value>> = match &item {
@@ -338,8 +341,9 @@ impl StreamingPartitionSession {
                 )
                 .ok()
             }));
-            self.block_start_buf_offset
-                .get_or_insert(writer.buffer.len() - partition_buf_start);
+            // Partition-relative block start via absolute, flush-invariant math (#2299).
+            self.block_start_rel_offset
+                .get_or_insert(writer.position() - self.partition_offset);
         }
         self.current_block_last_ck = Some(ck_bytes.clone());
 
@@ -386,9 +390,10 @@ impl StreamingPartitionSession {
             )? as u64,
         };
 
-        let current_buf_offset = writer.buffer.len() - partition_buf_start;
-        let block_start = self.block_start_buf_offset.unwrap_or(current_buf_offset);
-        let block_bytes = (current_buf_offset - block_start) as u64;
+        // Partition-relative offset via absolute, flush-invariant math (#2299).
+        let current_rel_offset = writer.position() - self.partition_offset;
+        let block_start = self.block_start_rel_offset.unwrap_or(current_rel_offset);
+        let block_bytes = current_rel_offset - block_start;
 
         if block_bytes >= COLUMN_INDEX_SIZE_BYTES {
             self.blocks.push(PromotedIndexBlock {
@@ -400,14 +405,24 @@ impl StreamingPartitionSession {
                     .current_block_last_ck
                     .take()
                     .unwrap_or_else(empty_clustering_prefix_for_index),
-                offset: block_start as u64,
+                offset: block_start,
                 width: block_bytes,
                 oss50_separator: self.current_block_oss50.take().flatten(),
             });
-            self.block_start_buf_offset = Some(current_buf_offset);
+            self.block_start_rel_offset = Some(current_rel_offset);
             self.current_block_first_ck = None;
             self.current_block_last_ck = None;
             self.current_block_oss50 = None;
+
+            // Issue #2299: a completed promoted-index block is a SAFE mid-partition
+            // flush point — every offset the session tracks is now partition-relative
+            // absolute math (`writer.position() - partition_offset`), which is
+            // invariant across a `DataWriter::buffer` → sink flush. Flushing here
+            // bounds a WIDE partition's resident scratch to ~one promoted-index block
+            // (COLUMN_INDEX_SIZE_BYTES, Cassandra default 64 KiB) instead of the whole
+            // partition, so a real compaction of CQLite's own uncompressed output
+            // stays within the 128 MiB budget. No-op in in-memory mode.
+            writer.flush_buffered_partition_scratch()?;
         }
         Ok(())
     }

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -278,6 +278,14 @@ impl WriteEngine {
         // The output baseline must be ≤ all per-partition values from all inputs.
         let (baseline_min_ts, mut baseline_min_ldt, baseline_min_ttl) =
             merge::compute_baseline_min(&input_paths);
+        // Issue #2299: capture the raw pre-floor LDT baseline. `i32::MAX` is
+        // Cassandra's `NO_DELETION_TIME` sentinel; when it survives the min over
+        // EVERY input's Statistics.db, no input carries ANY deletion (partition/
+        // row/cell/range tombstone), so the merged output has no range-tombstone
+        // markers to interleave — the write side can stream rows directly instead
+        // of buffering the whole partition (see `ActiveMerge::stream_rows_directly`).
+        // Read BEFORE the expiry floor below lowers `baseline_min_ldt`.
+        let no_deletions_in_any_input = baseline_min_ldt == i32::MAX;
         // Issue #1537: unlike `compact_sstables_with_registry` — whose
         // `now_secs: Option<i64>` parameter can be `None` (expiry disabled), so it
         // gates the floor application on `now_secs.is_some()` — this WriteEngine
@@ -312,6 +320,9 @@ impl WriteEngine {
             dropped_whole,
             // Stage 4 (#1668): no partition is mid-drain when a merge starts.
             pending_partition: None,
+            // Issue #2299: stream rows straight to the writer session (no
+            // whole-partition buffer) when no input carries any deletion.
+            stream_rows_directly: no_deletions_in_any_input,
         });
 
         Ok(())

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -5,6 +5,14 @@
 //! (`maintenance_step`), candidate scanning, startup orphan sweeps, atomic
 //! input deletion, and the public `MaintenanceReport` type. `WriteEngine`'s
 //! fields are reachable here because this is a sibling module in the same crate.
+//!
+//! File-size note (campsite rule, epic #1116): this file was already over the
+//! ~800-line source threshold before issue #2299's direct-stream compaction
+//! read-path fix (row-granular within-partition streaming + the writer-session
+//! absolute-offset / mid-partition-flush changes) grew it further. Splitting it
+//! was judged out of scope for that fix (owner-approved,
+//! `CQLITE_ALLOW_FILE_GROWTH=1`); a follow-up split by responsibility remains
+//! tracked under #1116.
 
 use super::merge;
 // `Mutation` is named in production again (issue #1383 fix): a partition's

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -77,7 +77,19 @@ pub(crate) struct PartitionStreamState {
     /// Surviving `Some(ck)` clustering-row mutations, buffered in arrival
     /// (clustering) order and written in one session at partition end (see
     /// the type doc for why buffering is required).
+    ///
+    /// UNUSED on the issue #2299 direct-stream path
+    /// ([`ActiveMerge::stream_rows_directly`]): there each row is fed straight
+    /// into `direct_session` as it arrives, so this stays empty.
     buffered_rows: Vec<Mutation>,
+    /// Issue #2299 direct-stream path only: the OPEN writer session for this
+    /// partition, held across budget pauses (the session is lifetime-free by
+    /// design — see [`StreamingPartitionSession`]). `Some` once the first row
+    /// (or static carrier) of a tombstone-free partition has opened it; each
+    /// subsequent row feeds straight through it, so no whole-partition
+    /// `buffered_rows` accumulation is needed. `None` on the buffered path.
+    direct_session:
+        Option<crate::storage::sstable::writer::data_writer::StreamingPartitionSession>,
 }
 
 impl PartitionStreamState {
@@ -93,6 +105,7 @@ impl PartitionStreamState {
             partition_stats: StatisticsMetadata::new(),
             row_count: 0,
             buffered_rows: Vec::new(),
+            direct_session: None,
         }
     }
 
@@ -224,6 +237,22 @@ pub(crate) struct ActiveMerge {
         merge::PartitionReconcileCheckpoint,
         PartitionStreamState,
     )>,
+    /// Issue #2299: when EVERY input SSTable's authoritative `Statistics.db`
+    /// `min_local_deletion_time` is the `NO_DELETION_TIME` sentinel (`i32::MAX`),
+    /// NO input carries any deletion — no partition/row/cell/range tombstone —
+    /// so the merged output has NO range-tombstone markers to interleave with
+    /// rows. In that (common) case a clustering row can stream STRAIGHT into the
+    /// writer session as it is reconciled, WITHOUT the whole-partition
+    /// `buffered_rows` accumulation that a range-tombstone-bearing partition
+    /// requires (a late marker must shadow already-buffered rows — see
+    /// [`PartitionStreamState`]'s doc). This bounds a WIDE tombstone-free
+    /// partition's write-side peak to one row + one promoted-index block instead
+    /// of the whole partition. Authoritative metadata only (issue #28): derived
+    /// from `Statistics.db`, never guessed. Conservative — a cell tombstone also
+    /// lowers `min_local_deletion_time`, so a partition with cell tombstones but
+    /// no range tombstones falls back to buffering (still correct, just not
+    /// bounded), which is acceptable.
+    pub(crate) stream_rows_directly: bool,
 }
 
 impl WriteEngine {
@@ -544,7 +573,27 @@ impl WriteEngine {
             // see that stage's fix for the full incident writeup.
             let write_schema = merge.writer.schema().clone();
             let schema_has_static = write_schema.columns.iter().any(|c| c.is_static);
-            let mut stream = merge::StreamingMerger::resume(&mut merge.merger, resume_state);
+            // Issue #2299: on the direct-stream path each clustering row is fed
+            // STRAIGHT into the writer session as it arrives (no whole-partition
+            // `buffered_rows`). That needs `&mut merge.writer` INSIDE the drain
+            // loop while `stream` holds `&mut merge.merger`, so split `merge`
+            // into disjoint field borrows here (borrowing `merge` whole would
+            // conflict). `stream_rows_directly` is safe ONLY when no input
+            // carries any deletion, so there is no range-tombstone marker to
+            // interleave: opening the session with an empty marker set and
+            // feeding rows immediately is byte-identical to buffering then
+            // feeding at PartitionEnd.
+            let stream_rows_directly = merge.stream_rows_directly;
+            let key_for_open = resume_state.as_ref().map(|(k, _)| k.clone());
+            let ActiveMerge {
+                merger: merger_ref,
+                writer: writer_ref,
+                ..
+            } = merge;
+            // On the direct path, if a session was already opened for this
+            // partition on a PRIOR (paused) call, `stream_state.direct_session`
+            // still holds it — keep feeding into it.
+            let mut stream = merge::StreamingMerger::resume(merger_ref, resume_state);
             // True once THIS call has popped at least one cluster group —
             // guarantees forward progress within a call even when resuming
             // an already-in-progress `stream_state` from a prior call
@@ -604,6 +653,10 @@ impl WriteEngine {
                             mutation.clustering_key.is_none() && schema_has_static;
 
                         if is_partition_only {
+                            // A partition tombstone only reaches here when an
+                            // input carried a deletion, so `stream_rows_directly`
+                            // was never set (the direct path is gated on NO
+                            // deletion in any input). Buffered path only.
                             stream_state.partition_tombstone = mutation.partition_tombstone;
                             stream_state.saw_carrier_or_static = true;
                             continue;
@@ -632,11 +685,55 @@ impl WriteEngine {
                             continue;
                         }
 
-                        // A real clustering row (or an unclustered table's
-                        // sole `clustering_key: None` row): buffer it for the
-                        // single PartitionEnd write.
-                        stream_state.buffered_rows.push(mutation);
-                        stream_state.row_count += 1;
+                        // A real clustering row (or an unclustered table's sole
+                        // `clustering_key: None` row).
+                        if stream_rows_directly {
+                            // Issue #2299 direct-stream path: feed this row
+                            // STRAIGHT into the writer session (opening it lazily
+                            // on the first row — a tombstone-free partition has no
+                            // partition tombstone and an empty range-tombstone
+                            // set). No whole-partition buffering, so a WIDE
+                            // partition's write-side peak stays bounded to one row
+                            // + one promoted-index block. The static prelude (if
+                            // any) was already fed on the first static carrier
+                            // (which sorts strictly before any `Some(ck)` row), so
+                            // opening here preserves the on-disk header→static→rows
+                            // order byte-for-byte.
+                            if stream_state.direct_session.is_none() {
+                                let open_key = key_for_open
+                                    .clone()
+                                    .or_else(|| stream.current_partition_key())
+                                    .ok_or_else(|| {
+                                        Error::Storage(
+                                            "issue #2299 direct-stream: no partition key to open the writer session".to_string(),
+                                        )
+                                    })?;
+                                let mut session = writer_ref.begin_streaming_partition(
+                                    &open_key,
+                                    None,
+                                    &[],
+                                )?;
+                                if schema_has_static {
+                                    let merged =
+                                        std::mem::take(&mut stream_state.static_tracker).finish();
+                                    writer_ref.feed_streaming_static_row(
+                                        &mut session,
+                                        &merged,
+                                        stream_state.static_first_ts,
+                                    )?;
+                                }
+                                stream_state.direct_session = Some(session);
+                            }
+                            if let Some(session) = stream_state.direct_session.as_mut() {
+                                writer_ref.feed_streaming_row(session, &mutation)?;
+                            }
+                            stream_state.row_count += 1;
+                        } else {
+                            // Buffered path: buffer for the single PartitionEnd
+                            // write (a range tombstone may still arrive later).
+                            stream_state.buffered_rows.push(mutation);
+                            stream_state.row_count += 1;
+                        }
                     }
                     merge::StreamingStep::PartitionEnd { key } => {
                         break DrainOutcome::Ready(
@@ -654,7 +751,34 @@ impl WriteEngine {
             match outcome {
                 DrainOutcome::Ready(key, state) => {
                     partitions_processed += 1;
-                    let state = *state;
+                    let mut state = *state;
+
+                    // Issue #2299 direct-stream path: the session was opened on
+                    // the first `Some(ck)` row and every row fed straight through
+                    // it, so here we ONLY finish it (no re-open, no re-feed). A
+                    // direct-path partition with a static carrier but no `Some(ck)`
+                    // row never opened the session — fall through to the buffered
+                    // path below, which opens + feeds the static prelude. The
+                    // direct path is gated on NO deletion in any input, so
+                    // `partition_tombstone` is always `None` and `range_tombstones`
+                    // always empty here.
+                    if let Some(session) = state.direct_session.take() {
+                        if let Some(merge) = &mut self.active_merge {
+                            let (offset, blocks, emit) =
+                                merge.writer.finish_streaming_partition(session)?;
+                            merge.writer.complete_partition_incremental(
+                                &key,
+                                None,
+                                offset,
+                                &blocks,
+                                emit,
+                                &state.partition_stats,
+                            )?;
+                            merge.rows_merged += state.row_count;
+                        }
+                        report.rows_merged += state.row_count;
+                        continue;
+                    }
 
                     // Truly empty partition (every entry was
                     // metadata-only-no-op, and no carrier/static survived) —

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -88,8 +88,7 @@ pub(crate) struct PartitionStreamState {
     /// (or static carrier) of a tombstone-free partition has opened it; each
     /// subsequent row feeds straight through it, so no whole-partition
     /// `buffered_rows` accumulation is needed. `None` on the buffered path.
-    direct_session:
-        Option<crate::storage::sstable::writer::data_writer::StreamingPartitionSession>,
+    direct_session: Option<crate::storage::sstable::writer::data_writer::StreamingPartitionSession>,
 }
 
 impl PartitionStreamState {
@@ -708,11 +707,8 @@ impl WriteEngine {
                                             "issue #2299 direct-stream: no partition key to open the writer session".to_string(),
                                         )
                                     })?;
-                                let mut session = writer_ref.begin_streaming_partition(
-                                    &open_key,
-                                    None,
-                                    &[],
-                                )?;
+                                let mut session =
+                                    writer_ref.begin_streaming_partition(&open_key, None, &[])?;
                                 if schema_has_static {
                                     let merged =
                                         std::mem::take(&mut stream_state.static_tracker).finish();

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -703,9 +703,9 @@ impl WriteEngine {
                                     .clone()
                                     .or_else(|| stream.current_partition_key())
                                     .ok_or_else(|| {
-                                        Error::Storage(
-                                            "issue #2299 direct-stream: no partition key to open the writer session".to_string(),
-                                        )
+                                        Error::Storage(format!(
+                                            "issue #2299 direct-stream: no partition key to open the writer session (partition index {partitions_processed} in this merge)"
+                                        ))
                                     })?;
                                 let mut session =
                                     writer_ref.begin_streaming_partition(&open_key, None, &[])?;

--- a/cqlite-core/src/storage/write_engine/merge/streaming.rs
+++ b/cqlite-core/src/storage/write_engine/merge/streaming.rs
@@ -385,6 +385,15 @@ impl<'a> StreamingMerger<'a> {
         self.partition_key.map(|key| (key, self.state))
     }
 
+    /// The partition key currently being reconciled, if any (issue #2299).
+    ///
+    /// The direct-stream compaction path opens its writer session lazily on the
+    /// first `Some(ck)` row and needs the partition key to do so; once
+    /// `step_streaming` has yielded a `ClusterGroup`, `partition_key` is `Some`.
+    pub(crate) fn current_partition_key(&self) -> Option<DecoratedKey> {
+        self.partition_key.clone()
+    }
+
     /// Pop one raw entry belonging to the CURRENT partition
     /// (`self.partition_key`, which must already be `Some`) off the heap,
     /// refilling from its run — the SAME peek/pop/refill mechanism

--- a/cqlite-core/tests/test_issue_2299_stream_readback.rs
+++ b/cqlite-core/tests/test_issue_2299_stream_readback.rs
@@ -39,6 +39,7 @@ use std::time::Duration;
 use cqlite_core::platform::Platform;
 use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
 use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::merge;
 use cqlite_core::storage::write_engine::{
     CellOperation, ClusteringKey, Mutation, PartitionKey, STCSPolicy, TableId, WriteEngine,
     WriteEngineConfig,
@@ -316,6 +317,456 @@ fn direct_stream_wide_partition_reads_back_byte_identical() {
         actual, expected,
         "every (partition id, clustering key) + payload must read back byte-identical \
          to what was written through the direct-stream mid-partition-flush compaction path"
+    );
+
+    drop(temp_dir);
+}
+
+// ---------------------------------------------------------------------------
+// Roborev (issue #2299 endgame): the direct-stream static-row prelude
+// (`WriteEngine::maintenance_step`, the `if schema_has_static { ... }` block
+// that opens a streaming partition session) was UNTESTED — all three existing
+// tests in this file use zero-static schemas. The two tests below lock the
+// on-disk header -> static -> rows byte order for (a) a partition whose
+// direct-stream session opens on its first clustering row (the static prelude
+// is fed on that open), and (b) a static-carrier partition with NO clustering
+// row at all, which the direct-stream loop never opens a session for and must
+// fall through to the buffered path (`maintenance.rs`, the `state.direct_
+// session.take()` comment right above the fall-through).
+// ---------------------------------------------------------------------------
+
+const TABLE_STATIC: &str = "wide_partition_with_static";
+const TABLE_STATIC_ONLY: &str = "static_only_partition";
+
+/// `id int, ck int, region text static, payload text` — same shape as
+/// [`make_schema`] plus one static column.
+fn schema_with_static(table: &str) -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: table.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "region".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: true,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+fn write_clustering_row(table: &str, id: i32, ck: i32, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, table);
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ck_key = ClusteringKey::single("ck", Value::Integer(ck));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Text(payload_for(ck)),
+    }];
+    Mutation::new(table_id, pk, Some(ck_key), ops, timestamp, None)
+}
+
+/// A pure static write: `clustering_key: None`, only the `region` column.
+fn write_static_region(table: &str, id: i32, region: &str, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, table);
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    Mutation::new(
+        table_id,
+        pk,
+        None,
+        vec![CellOperation::Write {
+            column: "region".to_string(),
+            value: Value::Text(region.to_string()),
+        }],
+        timestamp,
+        None,
+    )
+}
+
+/// One decoded scan row: the partition `id`, its clustering key (`None` for a
+/// partition static row), and every named cell (schema-column-name -> value)
+/// the reader surfaced for it.
+struct DecodedRow2299 {
+    id: i32,
+    ck: Option<i32>,
+    cells: std::collections::HashMap<String, Value>,
+}
+
+/// Drive `KWayMerger` directly over the SINGLE compacted output `Data.db` and
+/// decode every partition's rows, INCLUDING its partition static row
+/// (`ck.is_none()`). This bypasses `SSTableManager::scan`'s query-level
+/// reconciliation entirely, so it asserts the PHYSICAL on-disk header ->
+/// static -> rows byte order the direct-stream / buffered-fall-through write
+/// paths produced — the same convention
+/// `issue_1074_static_write_parity.rs`'s `collect_merge_rows` uses.
+fn decode_output_rows(data_path: &Path, schema: &TableSchema) -> Vec<DecodedRow2299> {
+    let mut merger = merge::KWayMerger::new(vec![data_path.to_path_buf()], schema).expect("merger");
+    let mut out = Vec::new();
+    loop {
+        match merger.step().expect("merge step") {
+            merge::MergeStep::Complete => break,
+            merge::MergeStep::Partition { key, rows } => {
+                let key_bytes = &key.key;
+                let id = if key_bytes.len() == 4 {
+                    i32::from_be_bytes([key_bytes[0], key_bytes[1], key_bytes[2], key_bytes[3]])
+                } else {
+                    continue;
+                };
+                for row in rows {
+                    let ck = row.clustering_key.as_ref().and_then(|c| {
+                        c.columns.first().and_then(|(_, v)| match v {
+                            Value::Integer(i) => Some(*i),
+                            _ => None,
+                        })
+                    });
+                    if let merge::RowData::Live { cells } = &row.row_data {
+                        let mut map = std::collections::HashMap::new();
+                        for c in cells {
+                            if !matches!(c.value, Value::Tombstone(_)) {
+                                map.insert(c.column.clone(), c.value.clone());
+                            }
+                        }
+                        out.push(DecodedRow2299 { id, ck, cells: map });
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn text_cell(row: &DecodedRow2299, column: &str) -> Option<String> {
+    match row.cells.get(column) {
+        Some(Value::Text(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// The single surviving `-big-Data.db` file in `dir` (post-compaction).
+fn find_single_data_file(dir: &Path) -> std::path::PathBuf {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+        .expect("exactly one compacted Data.db")
+        .path()
+}
+
+/// (a) Direct-stream path WITH a static column: the session opens on the
+/// first clustering row per partition, feeding the static prelude at that
+/// point (`maintenance.rs`'s `if schema_has_static { ... }` block). Proves
+/// the static value AND every clustering row survive the direct-stream
+/// compaction byte-for-byte.
+#[test]
+fn direct_stream_static_column_reads_back_byte_identical() {
+    const PARTITIONS: [(i32, &str); 2] = [(1, "region-east"), (2, "region-west")];
+    const SSTABLE_COUNT_STATIC: i32 = 3;
+    const ROWS_PER_SSTABLE_STATIC: i32 = 5;
+    const TOTAL_ROWS_STATIC: i32 = SSTABLE_COUNT_STATIC * ROWS_PER_SSTABLE_STATIC;
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = schema_with_static(TABLE_STATIC);
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    // The static write for each partition is folded into FILE 0's flush
+    // (alongside its first batch of clustering rows) rather than its own
+    // separate flush — a standalone static-only file would be MUCH smaller
+    // than the row-bearing files and STCS's size-bucketing (bucket_low/high =
+    // 0.5/1.5) would then never group it with the other 3, leaving the merge
+    // permanently pending. It is still the ONLY write touching `region`, so
+    // no conflict resolution is needed.
+    let mut expected_payload: BTreeMap<(i32, i32), String> = BTreeMap::new();
+    for file_idx in 0..SSTABLE_COUNT_STATIC {
+        let base = file_idx * ROWS_PER_SSTABLE_STATIC;
+        if file_idx == 0 {
+            for (id, region) in PARTITIONS {
+                engine
+                    .write(write_static_region(TABLE_STATIC, id, region, 1))
+                    .expect("write static region");
+            }
+        }
+        for (id, _region) in PARTITIONS {
+            for ck in base..base + ROWS_PER_SSTABLE_STATIC {
+                engine
+                    .write(write_clustering_row(
+                        TABLE_STATIC,
+                        id,
+                        ck,
+                        100 + i64::from(ck),
+                    ))
+                    .expect("write row");
+                expected_payload.insert((id, ck), payload_for(ck));
+            }
+        }
+        rt.block_on(engine.flush())
+            .expect("flush sstable")
+            .expect("non-empty sstable");
+    }
+
+    let sstable_dir = data_dir.join(KEYSPACE).join(TABLE_STATIC);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        SSTABLE_COUNT_STATIC as usize
+    );
+
+    engine
+        .set_merge_policy(Box::new(
+            STCSPolicy::new(SSTABLE_COUNT_STATIC as usize, 32, 0.5, 1.5, 0)
+                .expect("valid STCS parameters"),
+        ))
+        .expect("set merge policy");
+
+    let budget = Duration::from_secs(60);
+    let mut compaction_completed = false;
+    for _ in 0..8 {
+        let report = engine
+            .maintenance_step(budget)
+            .expect("maintenance_step must not error");
+        if !report.completed_merges.is_empty() {
+            compaction_completed = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(compaction_completed, "compaction must complete");
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        1,
+        "N input SSTables must compact to exactly 1 output"
+    );
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    let output_path = find_single_data_file(&sstable_dir);
+    let rows = decode_output_rows(&output_path, &schema);
+
+    // Every clustering row must read back with its expected payload.
+    let mut actual_payload: BTreeMap<(i32, i32), String> = BTreeMap::new();
+    for row in &rows {
+        if let Some(ck) = row.ck {
+            if let Some(payload) = text_cell(row, "payload") {
+                actual_payload.insert((row.id, ck), payload);
+            }
+        }
+    }
+    assert_eq!(
+        actual_payload.len(),
+        PARTITIONS.len() * TOTAL_ROWS_STATIC as usize,
+        "read-back must return exactly {} clustering rows, got {}",
+        PARTITIONS.len() * TOTAL_ROWS_STATIC as usize,
+        actual_payload.len()
+    );
+    assert_eq!(
+        actual_payload, expected_payload,
+        "every (partition id, clustering key) + payload must read back byte-identical \
+         to what was written through the direct-stream static-column compaction path"
+    );
+
+    // Each partition's static `region` value must be readable SOMEWHERE (a
+    // dedicated static row with `ck.is_none()`, or folded into every
+    // clustering row — either shape proves the writer's header -> static ->
+    // rows byte order decoded correctly; a wrong order would corrupt row
+    // framing and either error or surface no/garbage region values).
+    for (id, expected_region) in PARTITIONS {
+        let seen_regions: std::collections::HashSet<String> = rows
+            .iter()
+            .filter(|r| r.id == id)
+            .filter_map(|r| text_cell(r, "region"))
+            .collect();
+        assert_eq!(
+            seen_regions,
+            std::collections::HashSet::from([expected_region.to_string()]),
+            "partition id={id} must surface its static `region`={expected_region} value \
+             (and ONLY that value) after the direct-stream compaction, got {seen_regions:?}"
+        );
+    }
+
+    drop(temp_dir);
+}
+
+/// (b) A partition whose ONLY mutation is a static write (no clustering row
+/// at all) alongside partitions that DO have clustering rows in the SAME
+/// merge. The direct-stream loop opens its session lazily on the first
+/// `Some(ck)` row, so this partition's `direct_session` stays `None` for its
+/// whole lifetime — it must fall through to the buffered path
+/// (`maintenance.rs`'s `state.direct_session.take()` comment) instead of
+/// being silently dropped.
+#[test]
+fn direct_stream_static_only_partition_falls_through_to_buffered_path() {
+    const STATIC_ONLY_ID: i32 = 7;
+    const CLUSTERED_ID: i32 = 1;
+    const CLUSTERED_ROWS: i32 = 4;
+    const STATIC_ONLY_REGION: &str = "static-only-region";
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = schema_with_static(TABLE_STATIC_ONLY);
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    // File 1: the static-only partition (no clustering row, ever) plus a
+    // clustering partition sharing the SAME merge batch, so the overall
+    // `stream_rows_directly` gate (tombstone-free across every input) is
+    // still true and both partitions go through the SAME merge.
+    engine
+        .write(write_static_region(
+            TABLE_STATIC_ONLY,
+            STATIC_ONLY_ID,
+            STATIC_ONLY_REGION,
+            1,
+        ))
+        .expect("write static-only region");
+    for ck in 0..CLUSTERED_ROWS {
+        engine
+            .write(write_clustering_row(
+                TABLE_STATIC_ONLY,
+                CLUSTERED_ID,
+                ck,
+                100 + i64::from(ck),
+            ))
+            .expect("write clustering row (file 1)");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush file 1")
+        .expect("non-empty sstable");
+
+    // File 2: more of the clustering partition's rows (disjoint ck range),
+    // forcing a real N-input merge.
+    for ck in CLUSTERED_ROWS..2 * CLUSTERED_ROWS {
+        engine
+            .write(write_clustering_row(
+                TABLE_STATIC_ONLY,
+                CLUSTERED_ID,
+                ck,
+                100 + i64::from(ck),
+            ))
+            .expect("write clustering row (file 2)");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush file 2")
+        .expect("non-empty sstable");
+
+    let sstable_dir = data_dir.join(KEYSPACE).join(TABLE_STATIC_ONLY);
+    assert_eq!(count_data_files(&sstable_dir), 2);
+
+    engine
+        .set_merge_policy(Box::new(
+            STCSPolicy::new(2, 32, 0.5, 1.5, 0).expect("valid STCS parameters"),
+        ))
+        .expect("set merge policy");
+
+    let budget = Duration::from_secs(60);
+    let mut compaction_completed = false;
+    for _ in 0..8 {
+        let report = engine
+            .maintenance_step(budget)
+            .expect("maintenance_step must not error");
+        if !report.completed_merges.is_empty() {
+            compaction_completed = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(compaction_completed, "compaction must complete");
+    assert_eq!(count_data_files(&sstable_dir), 1);
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    let output_path = find_single_data_file(&sstable_dir);
+    let rows = decode_output_rows(&output_path, &schema);
+
+    // The static-only partition must have survived (issue #933/#1072 shape):
+    // its `region` value is readable, proving the buffered fall-through fed
+    // the static prelude even though no `direct_session` was ever opened for
+    // it.
+    let static_only_regions: std::collections::HashSet<String> = rows
+        .iter()
+        .filter(|r| r.id == STATIC_ONLY_ID)
+        .filter_map(|r| text_cell(r, "region"))
+        .collect();
+    assert_eq!(
+        static_only_regions,
+        std::collections::HashSet::from([STATIC_ONLY_REGION.to_string()]),
+        "the static-only partition (id={STATIC_ONLY_ID}) must survive the direct-stream \
+         compaction's buffered fall-through with its region value intact, got {static_only_regions:?}"
+    );
+    assert!(
+        !rows
+            .iter()
+            .any(|r| r.id == STATIC_ONLY_ID && r.ck.is_some()),
+        "the static-only partition must never surface a clustering row (it wrote none)"
+    );
+
+    // The clustering partition (which DID take the direct-stream path) must
+    // still read back completely and correctly in the SAME merge.
+    let mut actual_payload: BTreeMap<i32, String> = BTreeMap::new();
+    for row in rows.iter().filter(|r| r.id == CLUSTERED_ID) {
+        if let Some(ck) = row.ck {
+            if let Some(payload) = text_cell(row, "payload") {
+                actual_payload.insert(ck, payload);
+            }
+        }
+    }
+    let expected_payload: BTreeMap<i32, String> = (0..2 * CLUSTERED_ROWS)
+        .map(|ck| (ck, payload_for(ck)))
+        .collect();
+    assert_eq!(
+        actual_payload, expected_payload,
+        "the clustering partition sharing this merge batch must read back unaffected \
+         by the static-only partition's buffered fall-through"
     );
 
     drop(temp_dir);

--- a/cqlite-core/tests/test_issue_2299_stream_readback.rs
+++ b/cqlite-core/tests/test_issue_2299_stream_readback.rs
@@ -1,0 +1,322 @@
+//! End-to-end read-back parity for issue #2299's genuinely-NEW on-disk behavior:
+//! the mid-partition scratch flush + buffer clear on a WIDE, tombstone-free
+//! partition that crosses ≥1 promoted-index block (>64 KiB
+//! `COLUMN_INDEX_SIZE_BYTES`) via the DIRECT row-stream compaction path in
+//! `WriteEngine::maintenance_step`.
+//!
+//! This runs in the DEFAULT gate (feature `write-support`, NO `dhat-heap` gate).
+//! It complements the heap-budget-only `test_issue_2299_uncompressed_stream_memory`
+//! (which asserts peak heap + `count_data_files == 1` but never reads the rows
+//! back) by proving VALUE correctness: after the real N→1 STCS compaction of the
+//! wide partition, EVERY clustering row's `ck` + `payload` reads back byte-for-byte
+//! equal to what was written.
+//!
+//! ## Why this exercises the direct-stream mid-partition flush
+//!
+//! - **Direct-stream path (tombstone-free gate = true):** the fixture writes ONLY
+//!   `Write` cell operations — zero deletes / TTLs / range tombstones — so every
+//!   input's `Statistics.db` min-LDT stays at Cassandra's `NO_DELETION_TIME`
+//!   sentinel and `stream_rows_directly` is set (see
+//!   `write_engine::compaction::no_deletions_in_any_input`). That is the path whose
+//!   scratch flush is the new behavior.
+//! - **Crosses ≥1 promoted-index block + forces a mid-partition flush:** the wide
+//!   partition (id = 1) holds `TOTAL_ROWS` rows of `PAYLOAD_BYTES` each, so its
+//!   encoded body is `TOTAL_ROWS * PAYLOAD_BYTES` ≈ 800 KiB — an order of magnitude
+//!   past the 64 KiB `COLUMN_INDEX_SIZE_BYTES` block size, so the writer completes
+//!   ~12 promoted-index blocks mid-partition and flushes the scratch at each.
+//! - **Real N→1 STCS compaction via the direct-stream path:** the rows are split
+//!   across `SSTABLE_COUNT` input SSTables by DISJOINT clustering-key ranges of the
+//!   SAME partition, so a real k-way merge reconciles them into one wide output
+//!   partition through `WriteEngine::maintenance_step`.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, STCSPolicy, TableId, WriteEngine,
+    WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use cqlite_core::ScanRow;
+use tempfile::TempDir;
+
+const KEYSPACE: &str = "issue2299_readback_ks";
+const TABLE: &str = "wide_partition";
+
+// 4 files × 80 rows × 2 KiB payload ≈ 640 KiB of row content in ONE partition
+// (id = 1), split across the 4 files by disjoint clustering-key ranges so a real
+// k-way merge reconciles them into one wide output partition. At 2 KiB/row the
+// partition body is ~10× the 64 KiB `COLUMN_INDEX_SIZE_BYTES` block size, forcing
+// ~10 promoted-index block boundaries — hence multiple mid-partition scratch
+// flushes on the direct-stream compaction path. Zero tombstones/deletes keeps the
+// tombstone-free gate (`stream_rows_directly`) true. Small enough for the normal
+// gate budget (no dhat overhead).
+const PAYLOAD_BYTES: usize = 2 * 1024;
+const ROWS_PER_SSTABLE: i32 = 80;
+const SSTABLE_COUNT: i32 = 4;
+const TOTAL_ROWS: i32 = ROWS_PER_SSTABLE * SSTABLE_COUNT;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+/// Deterministic per-row payload so read-back can assert full value equality.
+fn payload_for(ck: i32) -> String {
+    let mut s = format!("row-{ck:08}-");
+    s.push_str(&"abcdefghij".repeat((PAYLOAD_BYTES.saturating_sub(s.len())) / 10 + 1));
+    s.truncate(PAYLOAD_BYTES);
+    s
+}
+
+fn write_row(id: i32, ck: i32, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, TABLE);
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ck_key = ClusteringKey::single("ck", Value::Integer(ck));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Text(payload_for(ck)),
+    }];
+    Mutation::new(table_id, pk, Some(ck_key), ops, timestamp, None)
+}
+
+fn make_policy() -> STCSPolicy {
+    STCSPolicy::new(SSTABLE_COUNT as usize, 32, 0.5, 1.5, 0).expect("valid STCS parameters")
+}
+
+fn count_data_files(dir: &Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Read every surviving clustering row back through `SSTableManager::scan` and
+/// return an `(id, ck) -> payload` map. Each wide-partition clustering row surfaces
+/// as one `ScanRow::Row` whose cells carry the partition `id`, clustering `ck`, and
+/// the `payload` column.
+fn read_back_id_ck_payload(data_dir: &Path, schema: &TableSchema) -> BTreeMap<(i32, i32), String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        let manager = SSTableManager::new(
+            data_dir,
+            &config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager opens the compacted output");
+
+        let table_id = CqlTableId::from(format!("{KEYSPACE}.{TABLE}").as_str());
+        let results = manager
+            .scan(&table_id, None, None, None, Some(schema))
+            .await
+            .expect("post-compaction scan must not error");
+
+        let mut map = BTreeMap::new();
+        for (key, row) in results {
+            // The partition key `id` (int) is carried by the RowKey (4-byte
+            // big-endian), NOT as a row cell — only clustering + regular columns
+            // surface as cells.
+            let key_bytes = key.as_bytes();
+            let id = if key_bytes.len() == 4 {
+                i32::from_be_bytes([key_bytes[0], key_bytes[1], key_bytes[2], key_bytes[3]])
+            } else {
+                continue;
+            };
+            if let ScanRow::Row(cells) = row {
+                let mut ck: Option<i32> = None;
+                let mut payload: Option<String> = None;
+                for (name, value) in &cells {
+                    match name.as_ref() {
+                        "ck" => {
+                            if let Value::Integer(i) = value {
+                                ck = Some(*i);
+                            }
+                        }
+                        "payload" => {
+                            if let Value::Text(t) = value {
+                                payload = Some(t.clone());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                if let (Some(ck), Some(payload)) = (ck, payload) {
+                    map.insert((id, ck), payload);
+                }
+            }
+        }
+        map
+    })
+}
+
+/// The genuinely-NEW on-disk behavior — mid-partition scratch flush on a WIDE,
+/// tombstone-free partition crossing multiple promoted-index blocks via the
+/// direct-stream compaction path — read back and asserted for full VALUE equality
+/// (row count + every clustering key + every payload), not just count/heap.
+///
+/// Uses TWO wide partitions (id = 1, id = 2) so the streaming compaction path also
+/// crosses a real partition boundary end-to-end (PartitionDone/reset between them),
+/// exercising the partition-boundary handling alongside the mid-partition flush.
+#[test]
+fn direct_stream_wide_partition_reads_back_byte_identical() {
+    const PARTITIONS: [i32; 2] = [1, 2];
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // Phase 1: write SSTABLE_COUNT files, each holding a DISJOINT clustering-key
+    // range of BOTH wide partitions (id = 1 and id = 2). Track the exact written
+    // values keyed by (id, ck).
+    let mut expected: BTreeMap<(i32, i32), String> = BTreeMap::new();
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    for file_idx in 0..SSTABLE_COUNT {
+        let base = file_idx * ROWS_PER_SSTABLE;
+        for id in PARTITIONS {
+            for ck in base..base + ROWS_PER_SSTABLE {
+                engine
+                    .write(write_row(id, ck, 100 + i64::from(ck)))
+                    .expect("write row");
+                expected.insert((id, ck), payload_for(ck));
+            }
+        }
+        rt.block_on(engine.flush())
+            .expect("flush sstable")
+            .expect("non-empty sstable");
+    }
+    assert_eq!(expected.len(), PARTITIONS.len() * TOTAL_ROWS as usize);
+
+    let sstable_dir = data_dir.join(KEYSPACE).join(TABLE);
+    assert_eq!(count_data_files(&sstable_dir), SSTABLE_COUNT as usize);
+
+    engine
+        .set_merge_policy(Box::new(make_policy()))
+        .expect("set merge policy");
+
+    // Phase 2: run the real N→1 STCS compaction via the direct-stream path.
+    let budget = Duration::from_secs(120);
+    let mut compaction_completed = false;
+    for _ in 0..8 {
+        let report = engine
+            .maintenance_step(budget)
+            .expect("maintenance_step must not error");
+        if !report.completed_merges.is_empty() {
+            compaction_completed = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(compaction_completed, "compaction must complete");
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        1,
+        "N input SSTables must compact to exactly 1 output"
+    );
+
+    // The compacted single Data.db body must be well past the 64 KiB
+    // `COLUMN_INDEX_SIZE_BYTES` block size — this is the fixture invariant that
+    // guarantees the wide partition crossed multiple promoted-index blocks and thus
+    // triggered mid-partition scratch flushes on the direct-stream write path. If a
+    // future change shrank the payload below the block size, this catches it before
+    // the read-back assertion could false-pass on a no-flush partition.
+    let data_len = std::fs::read_dir(&sstable_dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+        .and_then(|e| e.metadata().ok())
+        .map(|m| m.len())
+        .expect("compacted Data.db present");
+    assert!(
+        data_len > 4 * 64 * 1024,
+        "compacted Data.db ({data_len} bytes) must exceed several 64 KiB promoted-index \
+         blocks so the wide partition triggered a mid-partition scratch flush; if this \
+         fails the fixture no longer exercises issue #2299's new behavior"
+    );
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    // Phase 3: read the compacted output back and assert FULL value equality.
+    // `SSTableManager::new` discovers `<keyspace>/<table>` subdirs, so open on the
+    // data-dir ROOT (not the table subdir).
+    let actual = read_back_id_ck_payload(&data_dir, &schema);
+    assert_eq!(
+        actual.len(),
+        PARTITIONS.len() * TOTAL_ROWS as usize,
+        "read-back must return exactly {} rows, got {}",
+        PARTITIONS.len() * TOTAL_ROWS as usize,
+        actual.len()
+    );
+    assert_eq!(
+        actual, expected,
+        "every (partition id, clustering key) + payload must read back byte-identical \
+         to what was written through the direct-stream mid-partition-flush compaction path"
+    );
+
+    drop(temp_dir);
+}

--- a/cqlite-core/tests/test_issue_2299_uncompressed_stream_memory.rs
+++ b/cqlite-core/tests/test_issue_2299_uncompressed_stream_memory.rs
@@ -159,7 +159,7 @@ fn test_within_partition_streaming_merge_stays_within_heap_budget() {
         .expect("set merge policy");
 
     // Phase 2 (MEASURED): run the k-way-merge compaction under dhat.
-    let _profiler = dhat::Profiler::builder().testing().build();
+    let _profiler = dhat::Profiler::builder().file_name(std::path::PathBuf::from("/tmp/dhat-2299.json")).build();
 
     let budget = Duration::from_secs(120);
     let mut compaction_completed = false;

--- a/cqlite-core/tests/test_issue_2299_uncompressed_stream_memory.rs
+++ b/cqlite-core/tests/test_issue_2299_uncompressed_stream_memory.rs
@@ -1,0 +1,204 @@
+//! Memory-bound regression test for issue #2299 (uncompressed compaction
+//! within-partition streaming, dhat-gated) — originally held back from #1668's
+//! branch (the doc-comment below preserves that lineage). Measured 424 MiB peak
+//! vs. a 128 MiB budget — root-caused to THIS issue (the uncompressed compaction
+//! read path materialising a whole wide partition per source), not the merge
+//! layer.
+//!
+//! CQLite's ENTIRE production write surface emits UNCOMPRESSED SSTables (no
+//! `CompressionInfo.db`), so every real compaction of CQLite's own output takes
+//! the non-stitching read path. This test writes four uncompressed Data.db
+//! files, each covering a DISJOINT clustering-key range of the SAME wide
+//! partition (id = 1), then runs a real STCS compaction (k-way merge) under the
+//! dhat heap profiler and asserts the peak live heap stays within 128 MiB. On
+//! the pre-fix code the uncompressed compaction read materialised the whole wide
+//! partition per source, blowing the budget; with the bounded within-partition
+//! streaming read it stays bounded.
+//!
+//! Run via:
+//! ```text
+//! cargo test --package cqlite-core --features write-support,dhat-heap \
+//!   --test test_issue_2299_uncompressed_stream_memory --profile bench -- --nocapture
+//! ```
+
+#![cfg(all(feature = "write-support", feature = "dhat-heap"))]
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, STCSPolicy, TableId, WriteEngine,
+    WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+const HEAP_BUDGET_BYTES: usize = 128 * 1024 * 1024;
+const KEYSPACE: &str = "issue2299_mem_ks";
+const TABLE: &str = "wide_partition";
+
+// 4 files x 600 rows x 64 KiB payload ~= 150 MiB of combined row content in
+// ONE partition (id = 1), split across the 4 files by disjoint clustering-key
+// ranges so a real k-way merge reconciles them into one wide output
+// partition. Zero tombstones/deletes.
+const PAYLOAD_BYTES: usize = 64 * 1024;
+const ROWS_PER_SSTABLE: i32 = 600;
+const SSTABLE_COUNT: i32 = 4;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn payload_for(ck: i32) -> String {
+    let mut s = format!("row-{ck:08}-");
+    s.push_str(&"abcdefghij".repeat((PAYLOAD_BYTES.saturating_sub(s.len())) / 10 + 1));
+    s.truncate(PAYLOAD_BYTES);
+    s
+}
+
+fn write_row(ck: i32, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, TABLE);
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ck_key = ClusteringKey::single("ck", Value::Integer(ck));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Text(payload_for(ck)),
+    }];
+    Mutation::new(table_id, pk, Some(ck_key), ops, timestamp, None)
+}
+
+fn make_policy() -> STCSPolicy {
+    STCSPolicy::new(SSTABLE_COUNT as usize, 32, 0.5, 1.5, 0).expect("valid STCS parameters")
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+#[test]
+fn test_within_partition_streaming_merge_stays_within_heap_budget() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // Phase 1 (UNMEASURED): write SSTABLE_COUNT files for the SAME partition,
+    // each covering a disjoint clustering-key range.
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    for file_idx in 0..SSTABLE_COUNT {
+        let base = file_idx * ROWS_PER_SSTABLE;
+        for ck in base..base + ROWS_PER_SSTABLE {
+            engine
+                .write(write_row(ck, 100 + i64::from(ck)))
+                .expect("write row");
+        }
+        rt.block_on(engine.flush())
+            .expect("flush sstable")
+            .expect("non-empty sstable");
+    }
+
+    let sstable_dir = data_dir.join(KEYSPACE).join(TABLE);
+    assert_eq!(count_data_files(&sstable_dir), SSTABLE_COUNT as usize);
+
+    engine
+        .set_merge_policy(Box::new(make_policy()))
+        .expect("set merge policy");
+
+    // Phase 2 (MEASURED): run the k-way-merge compaction under dhat.
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let budget = Duration::from_secs(120);
+    let mut compaction_completed = false;
+    for _ in 0..8 {
+        let report = engine
+            .maintenance_step(budget)
+            .expect("maintenance_step must not error");
+        if !report.completed_merges.is_empty() {
+            compaction_completed = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(compaction_completed);
+
+    let stats = dhat::HeapStats::get();
+    eprintln!(
+        "issue #2299 uncompressed within-partition streaming merge: peak heap {} bytes \
+         ({:.2} MiB) vs budget {} MiB",
+        stats.max_bytes,
+        stats.max_bytes as f64 / (1024.0 * 1024.0),
+        HEAP_BUDGET_BYTES / (1024 * 1024)
+    );
+
+    assert_eq!(count_data_files(&sstable_dir), 1);
+
+    // MEASURED RESULT (pre-fix): 424827541 bytes (~424.22 MiB) vs. the 128 MiB budget.
+    assert!(
+        stats.max_bytes <= HEAP_BUDGET_BYTES,
+        "issue #2299: uncompressed within-partition k-way-merge peak heap {} bytes \
+         ({:.2} MiB) exceeds the {} MiB budget — the compaction read path materialised \
+         the whole wide partition per source",
+        stats.max_bytes,
+        stats.max_bytes as f64 / (1024.0 * 1024.0),
+        HEAP_BUDGET_BYTES / (1024 * 1024)
+    );
+
+    rt.block_on(engine.close()).expect("close engine");
+    drop(temp_dir);
+}

--- a/cqlite-core/tests/test_issue_2299_uncompressed_stream_memory.rs
+++ b/cqlite-core/tests/test_issue_2299_uncompressed_stream_memory.rs
@@ -159,7 +159,7 @@ fn test_within_partition_streaming_merge_stays_within_heap_budget() {
         .expect("set merge policy");
 
     // Phase 2 (MEASURED): run the k-way-merge compaction under dhat.
-    let _profiler = dhat::Profiler::builder().file_name(std::path::PathBuf::from("/tmp/dhat-2299.json")).build();
+    let _profiler = dhat::Profiler::builder().testing().build();
 
     let budget = Duration::from_secs(120);
     let mut compaction_completed = false;


### PR DESCRIPTION
Closes #2299

## Problem
Compaction of uncompressed SSTables (CQLite's entire production write surface) peaked at **410 MiB heap vs a 128 MiB budget**. The filed root cause was stale — `V5_0NewBig` uncompressed already takes `requires_chunk_stitching()==true`, so the `iterate_all_partitions()` fallback named in the issue is not the path hit. dhat profiling of the real `WriteEngine::maintenance_step` path found **three stacked buffering contributors** (see the root-cause correction comment on #2299).

## Fix (410.78 MiB → 54.31 MiB peak, byte-parity preserved)
1. **Reader (within-partition):** resumable row-by-row driver `row_decoder/compaction_stream.rs` (`stream_partition_body_incremental` + `CompactionPartitionState`/`PartitionStreamStep`) drains the sliding window per-structure instead of buffering the whole partition. Splits partitions on both `END_OF_PARTITION` and a next-partition header (mirrors the buffered `drive_partition_sliding` exactly — no divergence).
2. **Writer:** `StreamingPartitionSession` promoted-index offsets changed from buffer-relative indices to flush-invariant **absolute** offsets + mid-partition scratch flush at promoted-index block boundaries (stops pinning the whole encoded partition in `DataWriter::buffer`).
3. **Merge write side:** direct row-stream write path taken **only when authoritative Statistics prove no input carries any deletion** (`min_local_deletion_time == i32::MAX`, all tombstone kinds registered) — byte-safe: no range markers to interleave. Otherwise the old buffered path.

## No-heuristics
The tombstone-free decision is from the authoritative `Statistics.db` histogram, not byte-guessing. Conservative granularity: any deletion in any input forces the buffered path for the whole merge.

## Tests
- `test_issue_2299_uncompressed_stream_memory.rs` (dhat-gated): pins the 410→54 MiB bound + N→1.
- `test_issue_2299_stream_readback.rs` (**default gate**, NOT dhat-gated): `direct_stream_wide_partition_reads_back_byte_identical` — compacts 2 wide (~640 KiB each, >10× the 64 KiB block threshold → forces a mid-partition flush) tombstone-free partitions across disjoint clustering ranges, reads back via `SSTableManager::scan`, asserts all 640 rows + full `(id,ck)→payload` value equality.
- Existing in-memory byte-identity suite (`data_writer/tests/streaming_partition.rs`): full Data.db byte equality vs whole-slice path for plain/static/range-tombstone/partition-tombstone/wide (≥2 block) cases + exhaustive pause/resume.

## Residuals (follow-up candidates, out of scope)
- One-shot CLI `KWayMerger::merge()` still whole-partition-buffers (only `maintenance_step` bounded here).
- Range-tombstone-bearing wide partitions still buffer whole-partition (documented #1668 residual).

## Gate / review
LITE PASS (commit 2dd5b1110). Full gate of record runs pre-merge via flow-closer.
Review-first: rust-reviewer APPROVE-WITH-NITS (byte-parity sound by construction); roborev round 1 (claude-code) — 2 blockers fixed (partition-boundary divergence + on-disk read-back test), nits addressed; final roborev confirmation in progress.
Note: codex roborev backend is down (revoked token + CLI version skew — needs `npm i -g @openai/codex@latest`); using claude-code agent.