### PR TITLE
fix(#2356/#2306): connector-side snapshot lifecycle closure — per-(ks,table) reuse + warm rebind

### DIFF
--- a/cqlite-core/src/storage/sstable/index_reader/lazy.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/lazy.rs
@@ -11,7 +11,7 @@ use super::parse::{parse_big_index_entry_framing, parse_index_data_cancellable};
 use super::{IndexData, IndexReader};
 use crate::error::{Error, Result};
 use crate::platform::Platform;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
@@ -51,8 +51,24 @@ impl IndexReader {
     /// path WITHOUT materializing the whole map. Lives here (not the parent module)
     /// as a lazy-open support accessor, keeping `index_reader/mod.rs` under the
     /// campsite line (#1116).
-    pub(crate) fn index_path(&self) -> &Path {
-        &self.file_path
+    pub(crate) fn index_path(&self) -> PathBuf {
+        // Owned snapshot of the interior-mutable path (issue #2356 roborev): a
+        // #2383 rebind can repoint it, so we cannot hand out a borrow into the
+        // `ArcSwap`. Cheap relative to the bounded-interval read that consumes it.
+        self.file_path.load().as_ref().clone()
+    }
+
+    /// Repoint this reader's DEFERRED `Index.db` open at `new_path` after a #2383
+    /// warm inode-rebind (issue #2356 roborev). The caller (`SSTableReader::rebind_path`)
+    /// has already proven the new generation is the SAME immutable on-disk generation by
+    /// authoritative `(device, inode, generation)` + size identity, and `new_path` is the
+    /// `Index.db` hardlink SIBLING of the rebound `Data.db`; snapshot components are
+    /// same-inode hardlinks, so the bytes are byte-identical (issue #28 no-heuristics).
+    /// Without this, a LAZY reader that has not yet materialized would `File::open` its
+    /// ORIGINAL (now torn-down) snapshot path on the next `ensure_materialized`/interval
+    /// read and ENOENT — the #2352 class the Data.db-only rebind reintroduced.
+    pub(crate) fn rebind_path(&self, new_path: &Path) {
+        self.file_path.store(Arc::new(new_path.to_path_buf()));
     }
 
     /// Whether the full `Index.db` parse has already run (issue #2412 §B). A lazily
@@ -172,7 +188,7 @@ impl IndexReader {
         // defining module and all its descendants), so no field-access bridge
         // methods are needed on the struct itself.
         Ok(Self {
-            file_path: path.to_path_buf(),
+            file_path: arc_swap::ArcSwap::from_pointee(path.to_path_buf()),
             materialized: tokio::sync::OnceCell::new(),
             platform,
         })
@@ -191,13 +207,17 @@ impl IndexReader {
         self.materialized
             .get_or_try_init(|| async {
                 cancel.check()?;
-                let mut file = File::open(&self.file_path).await?;
+                // Load the CURRENT (possibly #2383-rebound) path so a lazy reader
+                // whose original snapshot dir was torn down opens the live hardlink,
+                // not the dead path (issue #2356 roborev, #2352 class).
+                let path = self.file_path.load_full();
+                let mut file = File::open(path.as_ref()).await?;
                 let mut buffer = Vec::new();
                 file.read_to_end(&mut buffer).await?;
                 if buffer.is_empty() {
                     return Err(Error::corruption(format!(
                         "Index.db file is empty: {}",
-                        self.file_path.display()
+                        path.display()
                     )));
                 }
                 let (remaining, index_data) =

--- a/cqlite-core/src/storage/sstable/index_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/mod.rs
@@ -146,8 +146,15 @@ pub(crate) use stream::IndexEntryStream;
 /// High-level Index.db file reader. See `lazy.rs` for the #2412 lazy-open contract.
 #[allow(dead_code)]
 pub struct IndexReader {
-    /// Path to the Index.db file
-    file_path: PathBuf,
+    /// Path to the Index.db file. Interior-mutable (`ArcSwap`) so a #2383 warm
+    /// inode-rebind can repoint a LAZY reader's DEFERRED `Index.db` open at the
+    /// live hardlink after its original snapshot dir is torn down (issue #2356
+    /// roborev): the Data.db path alone was rebound, but every deferred
+    /// `ensure_materialized`/bounded-interval open reads THIS path, so a
+    /// not-yet-materialized reader would otherwise `File::open` the dead
+    /// snapshot path and ENOENT (the #2352 class). Same-inode hardlink target,
+    /// so the bytes are byte-identical (issue #28 no-heuristics).
+    file_path: arc_swap::ArcSwap<PathBuf>,
     /// Lazily (or eagerly) materialized full parse result.
     materialized: tokio::sync::OnceCell<MaterializedIndex>,
     /// Platform abstraction for file operations
@@ -247,7 +254,7 @@ impl IndexReader {
         });
 
         Ok(Self {
-            file_path: path.to_path_buf(),
+            file_path: arc_swap::ArcSwap::from_pointee(path.to_path_buf()),
             materialized,
             platform,
         })
@@ -297,7 +304,12 @@ impl IndexReader {
             total_partitions: self.get_partition_entries().len(),
             partitions_with_promoted_index: promoted_count,
             total_promoted_entries,
-            file_size: self.file_path.metadata().map(|m| m.len()).unwrap_or(0),
+            file_size: self
+                .file_path
+                .load()
+                .metadata()
+                .map(|m| m.len())
+                .unwrap_or(0),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan.rs
@@ -89,17 +89,14 @@ impl SSTableReader {
     /// index path when the `Data.db` name is not the expected `*-Data.db` shape.
     fn current_index_db_path(&self) -> std::path::PathBuf {
         let data = self.file_path();
-        if let (Some(parent), Some(name)) =
-            (data.parent(), data.file_name().and_then(|n| n.to_str()))
-        {
-            if let Some(base) = name.strip_suffix("-Data.db") {
-                return parent.join(format!("{base}-Index.db"));
-            }
-        }
-        self.index_reader
-            .as_ref()
-            .map(|ir| ir.index_path().to_path_buf())
-            .unwrap_or(data)
+        // Same `-Data.db` → `-Index.db` sibling rule the #2383 rebind uses to repoint
+        // the lazy IndexReader, so both stay on the rebound generation (issue #2356).
+        crate::storage::sstable::reader::index_db_sibling(&data).unwrap_or_else(|| {
+            self.index_reader
+                .as_ref()
+                .map(|ir| ir.index_path())
+                .unwrap_or(data)
+        })
     }
 
     /// Shared Summary-guided FORWARD `Index.db` walk (issue #2412 §C / #2413

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -127,6 +127,19 @@ use tracing::debug;
 #[cfg(feature = "tombstones")]
 use super::tombstone_merger::TombstoneMerger;
 
+/// The `Index.db` hardlink SIBLING of a `Data.db` path (issue #2356 roborev),
+/// i.e. the `*-Data.db` name-suffix swapped for `*-Index.db` in the same
+/// directory. `None` when the name is not the expected `*-Data.db` shape. Used
+/// by [`SSTableReader::rebind_path`] to follow a #2383 inode-rebind for the lazy
+/// `Index.db` path, and by the streaming-walk `current_index_db_path` derivation
+/// (same rule) so every `Index.db` consumer stays on the rebound generation.
+pub(crate) fn index_db_sibling(data_path: &Path) -> Option<PathBuf> {
+    let parent = data_path.parent()?;
+    let name = data_path.file_name().and_then(|n| n.to_str())?;
+    let base = name.strip_suffix("-Data.db")?;
+    Some(parent.join(format!("{base}-Index.db")))
+}
+
 /// Returns `true` when memory-mapped reads are force-enabled via the
 /// `CQLITE_USE_MMAP` environment variable.
 ///
@@ -1350,13 +1363,37 @@ impl SSTableReader {
     ///    request's NEXT `new_scan_cursor` `File::open` is strictly MORE likely to
     ///    succeed after the rebind than before (pre-rebind it would ENOENT).
     /// 4. **No semantics off the path.** No `file_path()` consumer re-derives
-    ///    keyspace/table/schema from the path after `open`; the scan path uses it
-    ///    ONLY for `File::open` (bytes) and all parsed read state (header,
-    ///    compression info, CRC, index, generation) lives on `&self`, fixed at
-    ///    open — the swapped path changes which hardlink is read, never what the
-    ///    bytes mean.
+    ///    keyspace/table/schema from the path after `open`; the path is used ONLY
+    ///    for `File::open` (bytes) and all parsed read state (header, compression
+    ///    info, CRC, index, generation) lives on `&self`, fixed at open — the
+    ///    swapped path changes which hardlink is read, never what the bytes mean.
+    ///    This covers BOTH the `Data.db` path AND the lazy `Index.db` path (below):
+    ///    both are same-inode hardlink siblings in the rebound snapshot dir.
+    ///
+    /// ## Rebinding the lazy `Index.db` path too (issue #2356 roborev)
+    ///
+    /// Repointing ONLY the `Data.db` path reintroduced the #2352 ENOENT class for
+    /// the dominant point-read shape: a BIG reader opened lazily over a usable
+    /// `Summary.db` (#2412 §A) keeps its own `Index.db` path, and every DEFERRED
+    /// `Index.db` open (`ensure_materialized`, the Summary-guided bounded-interval
+    /// point probe) reads THAT path. If the original snapshot dir is torn down
+    /// before the reader ever materialized, a not-yet-materialized reader would
+    /// `File::open` the dead path and ENOENT. So the rebind ALSO repoints the
+    /// `IndexReader`'s path to the `Index.db` hardlink sibling of `new_path`,
+    /// keeping every `Index.db` consumer (deferred-materialize, point-interval, and
+    /// the streaming walk's `current_index_db_path` Data.db-sibling derivation) on
+    /// the live generation.
     pub fn rebind_path(&self, new_path: &Path) {
         self.file_path.store(Arc::new(new_path.to_path_buf()));
+        // Follow the rebind for the lazy Index.db path too: derive the Index.db
+        // hardlink sibling of the new Data.db path and repoint the IndexReader, so a
+        // deferred materialize / point-interval read opens the live file, not the
+        // dead open-time snapshot path (issue #2356 roborev, #2352 class).
+        if let Some(index_reader) = self.index_reader.as_ref() {
+            if let Some(index_sibling) = index_db_sibling(new_path) {
+                index_reader.rebind_path(&index_sibling);
+            }
+        }
     }
 
     /// The immutable `[first_key_token, last_key_token]` endpoints cached at open

--- a/cqlite-core/src/storage/sstable/reader/summary_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/summary_point.rs
@@ -124,8 +124,12 @@ impl SSTableReader {
         // `index_interval_parses_total` is emitted inside `lookup_key_in_interval`.
         crate::storage::sstable::read_work_counters::record_index_probe();
 
+        // The reader's CURRENT (possibly #2383-rebound) Index.db path (issue #2356
+        // roborev): a lazy warm reader rebound across a snapshot teardown must open the
+        // live hardlink here, not the dead open-time path (#2352 class).
+        let index_db_path = index_reader.index_path();
         let lookup = lookup_key_in_interval(
-            index_reader.index_path(),
+            &index_db_path,
             interval,
             partition_key,
             min_index_interval,

--- a/cqlite-core/tests/issue_2356_rebind_lazy_index.rs
+++ b/cqlite-core/tests/issue_2356_rebind_lazy_index.rs
@@ -1,0 +1,157 @@
+//! Issue #2356 roborev (Rust side) — a #2383 warm inode-rebind must follow the
+//! LAZY `Index.db` path, not only `Data.db`.
+//!
+//! Under #2412's lazy Summary-guided BIG open, `SSTableReader` defers the
+//! `Index.db` parse: the point-read path resolves a partition through ONE
+//! `Summary.db`-bounded `Index.db` interval, opening the `Index.db` file fresh
+//! at read time. The warm rebind (`SSTableReader::rebind_path`) originally
+//! repointed ONLY the `Data.db` `ArcSwap`, leaving the lazy `IndexReader` pinned
+//! to its open-time snapshot path. So when that snapshot dir is torn down and the
+//! reader is rebound to a fresh same-generation dir, a NOT-YET-MATERIALIZED reader
+//! would `File::open` the DEAD `Index.db` path on the next point read → ENOENT
+//! (the #2352 class, for the dominant point-read shape).
+//!
+//! This pins the fix at the reader public surface: open lazily from snapshot dir
+//! A, tear A down, rebind to a fresh dir B, and a point read must SUCCEED (open
+//! B's `Index.db`), not error on the dead A path. Fails on the Data.db-only rebind.
+//!
+//! Run with:
+//! ```text
+//! CQLITE_DATASETS_ROOT=<datasets> cargo test -p cqlite-core \
+//!   --test issue_2356_rebind_lazy_index
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::Config;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// A `*-Data.db` in `<datasets>/sstables/<keyspace>/<table>-*/` with sibling
+/// `*-Index.db` AND `*-Summary.db` (a BIG SSTable with a usable summary → lazy open).
+fn find_big_data_file_with_summary(keyspace: &str, table: &str) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let entries = std::fs::read_dir(root.join("sstables").join(keyspace)).ok()?;
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        let dir = e.path();
+        let files = std::fs::read_dir(&dir).ok()?;
+        let mut data_file: Option<PathBuf> = None;
+        let (mut has_index, mut has_summary) = (false, false);
+        for f in files.flatten() {
+            let name = f.file_name().to_string_lossy().into_owned();
+            if name.ends_with("-Data.db") {
+                data_file = Some(f.path());
+            } else if name.ends_with("-Index.db") {
+                has_index = true;
+            } else if name.ends_with("-Summary.db") {
+                has_summary = true;
+            }
+        }
+        if has_index && has_summary {
+            if let Some(df) = data_file {
+                return Some(df);
+            }
+        }
+    }
+    None
+}
+
+/// Copy every component of `src_dir` into a fresh unique temp dir and return the
+/// copied `*-Data.db` path. Byte-identical copies stand in for the same-inode
+/// hardlinks a real snapshot dir would carry; the reader-level rebind trusts the
+/// caller's identity proof, so a copy is sufficient to exercise path-following.
+fn copy_sstable_dir(src_dir: &Path, tag: &str) -> PathBuf {
+    let tmp = std::env::temp_dir().join(format!(
+        "cqlite-2356-rebind-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&tmp).expect("mkdir temp snapshot dir");
+    let mut data_path = None;
+    for entry in std::fs::read_dir(src_dir)
+        .expect("read fixture dir")
+        .flatten()
+    {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let dest = tmp.join(&name);
+        std::fs::copy(entry.path(), &dest).expect("copy component");
+        if name.ends_with("-Data.db") {
+            data_path = Some(dest);
+        }
+    }
+    data_path.expect("copied snapshot dir must include a Data.db")
+}
+
+#[test]
+fn point_read_after_rebind_follows_lazy_index_to_the_live_snapshot_dir() {
+    let Some(src_data) = find_big_data_file_with_summary("test_basic", "simple_table") else {
+        eprintln!(
+            "Skipping (#2356 rebind lazy Index.db): BIG test_basic/simple_table fixture \
+             (with Summary.db) absent"
+        );
+        return;
+    };
+    let src_dir = src_data.parent().expect("fixture has a parent dir");
+
+    // Snapshot dir A: the reader opens from here (lazy). Dir B: the fresh
+    // same-generation snapshot the warm rebind repoints to.
+    let dir_a_data = copy_sstable_dir(src_dir, "a");
+    let dir_b_data = copy_sstable_dir(src_dir, "b");
+    let dir_a = dir_a_data.parent().expect("dir A parent").to_path_buf();
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let config = Config::default();
+    let platform = Arc::new(
+        rt.block_on(Platform::new(&config))
+            .expect("platform must initialize"),
+    );
+
+    let reader = rt
+        .block_on(SSTableReader::open(&dir_a_data, &config, platform))
+        .expect("BIG fixture with Summary.db must open");
+
+    // Precondition: the reader is genuinely LAZY (Index.db deferred, not yet
+    // parsed) — otherwise this would not exercise the deferred-open path.
+    assert!(
+        !reader.index_is_materialized(),
+        "a BIG open with a usable Summary.db must be lazy (Index.db deferred, #2412)"
+    );
+
+    // Tear the ORIGINAL snapshot dir down: A's Index.db path is now dead. The
+    // reader's already-open Data.db handle survives (Unix unlink semantics), but a
+    // deferred fresh Index.db `File::open` on the A path would now ENOENT.
+    std::fs::remove_dir_all(&dir_a).expect("tear down snapshot dir A");
+
+    // Warm inode-rebind to the fresh dir B (the fix repoints BOTH Data.db AND the
+    // lazy Index.db path to B's hardlink siblings).
+    reader.rebind_path(&dir_b_data);
+
+    // A point read now resolves through the Summary-guided bounded Index.db
+    // interval, which opens the Index.db file fresh. The key content is irrelevant
+    // (a miss is fine) — what matters is that the open targets the LIVE dir B, not
+    // the dead dir A. Pre-fix (Data.db-only rebind) this ENOENTs on A/Index.db.
+    let key: &[u8] = &[0x00, 0x00, 0x00, 0x01];
+    let result = rt.block_on(reader.lookup_partition_with_index(key));
+    assert!(
+        result.is_ok(),
+        "a point read after a rebind must open the LIVE snapshot's Index.db, not the \
+         torn-down open-time path (issue #2356 roborev, #2352 class); got {result:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir_b_data.parent().expect("dir B parent"));
+}

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -1168,6 +1168,129 @@ mod tests {
         );
     }
 
+    /// Snapshot-lifecycle-closure counters distinguish a pure warm hit, a
+    /// rebind, and a rebuild over a four-request `do_get` sequence
+    /// (flight-warm-snapshot-closure spec — "Counters distinguish pure warm hit,
+    /// rebind, and rebuild over a query sequence"; issue #2356). THE wiring
+    /// evidence that the rebind path is reached through the flight `do_get`
+    /// surface, not just the registry helper:
+    ///
+    /// 1. cold (snap1)               → `reader_opens` climbs, `rebind_hits` 0
+    /// 2. stable repeat (snap1)      → pure warm hit: BOTH deltas 0
+    /// 3. fresh same-inode (snap2)   → rebind: `rebind_hits` climbs, `reader_opens` 0
+    /// 4. fresh changed-inode (snap3)→ rebuild: `reader_opens` climbs
+    ///
+    /// The `resolves` counter increments exactly once per request throughout
+    /// (the authoritative per-request resolve stays UNCHANGED, #2341/#1430).
+    /// Fails on pre-#2356 `main` (no `rebind_hits` counter).
+    #[test]
+    fn do_get_snapshot_lifecycle_counters_distinguish_hit_rebind_rebuild() {
+        let schema = simple_schema();
+        // Two generations so a rebind/rebuild moves a non-trivial reader set.
+        let (_temp, data_dir, table_dir) = build_sstables(
+            &schema,
+            vec![
+                vec![write_row(1, "a", 1, 100)],
+                vec![write_row(2, "b", 2, 100)],
+            ],
+        );
+        // An INDEPENDENT build of the same table with DIFFERENT on-disk inodes,
+        // to stage request 4's changed-inode dir (a genuine rebuild, never a
+        // rebind — the authoritative (device, inode, generation) match fails).
+        let (_temp2, _data2, other_dir) =
+            build_sstables(&schema, vec![vec![write_row(3, "c", 3, 100)]]);
+
+        make_snapshot(&table_dir, "snap1");
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let ticket_bytes = |snap: &str| {
+            let mut t = ticket(KS, TBL);
+            t.snapshot = Some(snap.into());
+            t.to_bytes().unwrap()
+        };
+        let run = |snap: Vec<u8>| {
+            rt.block_on(async {
+                let r = svc
+                    .do_get(Request::new(Ticket::new(snap)))
+                    .await
+                    .expect("do_get");
+                sorted_name_values(&decode(r.into_inner()).await)
+            })
+        };
+
+        // (1) COLD: warms from snap1 — reader opens climb, no rebind.
+        let vals1 = run(ticket_bytes("snap1"));
+        let m1 = svc.warm_metrics();
+        let s1 = svc.setup_work();
+        assert!(m1.reader_opens >= 2, "cold build opens both generations");
+        assert_eq!(m1.rebind_hits, 0, "cold build performs no rebind");
+        assert_eq!(s1.resolves, 1, "one resolve per request");
+
+        // (2) STABLE REPEAT: same snap1 dir, same inodes → pure warm hit.
+        let vals2 = run(ticket_bytes("snap1"));
+        let m2 = svc.warm_metrics();
+        let s2 = svc.setup_work();
+        assert_eq!(vals2, vals1, "stable warm hit is value-identical");
+        assert_eq!(
+            m2.reader_opens, m1.reader_opens,
+            "pure warm hit opens ZERO further readers"
+        );
+        assert_eq!(
+            m2.rebind_hits, m1.rebind_hits,
+            "pure warm hit performs ZERO rebinds (path unchanged)"
+        );
+        assert_eq!(s2.resolves, 2, "resolve stays authoritative per request");
+
+        // (3) FRESH SAME-INODE: clear snap1, stage snap2 over the SAME inodes.
+        std::fs::remove_dir_all(table_dir.join("snapshots").join("snap1"))
+            .expect("clear snap1");
+        make_snapshot(&table_dir, "snap2");
+        let vals3 = run(ticket_bytes("snap2"));
+        let m3 = svc.warm_metrics();
+        let s3 = svc.setup_work();
+        assert_eq!(vals3, vals1, "rebound warm set reads the live inodes");
+        assert_eq!(
+            m3.reader_opens, m1.reader_opens,
+            "same-inode rebind opens ZERO further readers (no re-parse)"
+        );
+        assert!(
+            m3.rebind_hits > m2.rebind_hits,
+            "same-inode snapshot rollover REBINDS the cached readers"
+        );
+        assert_eq!(s3.resolves, 3, "resolve stays authoritative per request");
+
+        // (4) FRESH CHANGED-INODE: clear snap2, stage snap3 from the OTHER build
+        // (different inodes) → a genuine rebuild, never a rebind.
+        std::fs::remove_dir_all(table_dir.join("snapshots").join("snap2"))
+            .expect("clear snap2");
+        let snap3 = table_dir.join("snapshots").join("snap3");
+        std::fs::create_dir_all(&snap3).unwrap();
+        for entry in std::fs::read_dir(&other_dir).unwrap().flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                let dest = snap3.join(entry.file_name());
+                std::fs::hard_link(&path, &dest)
+                    .or_else(|_| std::fs::copy(&path, &dest).map(|_| ()))
+                    .unwrap();
+            }
+        }
+        let opens_before_4 = m3.reader_opens;
+        let vals4 = run(ticket_bytes("snap3"));
+        let m4 = svc.warm_metrics();
+        let s4 = svc.setup_work();
+        assert_eq!(vals4, vec!["c".to_string()], "rebuilt set reads snap3");
+        assert!(
+            m4.reader_opens > opens_before_4,
+            "a changed-inode dir REBUILDS (opens a fresh reader), never rebinds"
+        );
+        assert_eq!(
+            m4.rebind_hits, m3.rebind_hits,
+            "a changed-inode generation fails closed to a rebuild, never a rebind"
+        );
+        assert_eq!(s4.resolves, 4, "resolve stays authoritative per request");
+    }
+
     /// A flush that ADDS a generation between requests is visible on the next
     /// request with zero staleness window (spec Requirement 2): the probe reports
     /// "changed", the rebuild adds exactly the new generation, and the new data

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -1243,8 +1243,7 @@ mod tests {
         assert_eq!(s2.resolves, 2, "resolve stays authoritative per request");
 
         // (3) FRESH SAME-INODE: clear snap1, stage snap2 over the SAME inodes.
-        std::fs::remove_dir_all(table_dir.join("snapshots").join("snap1"))
-            .expect("clear snap1");
+        std::fs::remove_dir_all(table_dir.join("snapshots").join("snap1")).expect("clear snap1");
         make_snapshot(&table_dir, "snap2");
         let vals3 = run(ticket_bytes("snap2"));
         let m3 = svc.warm_metrics();
@@ -1262,8 +1261,7 @@ mod tests {
 
         // (4) FRESH CHANGED-INODE: clear snap2, stage snap3 from the OTHER build
         // (different inodes) → a genuine rebuild, never a rebind.
-        std::fs::remove_dir_all(table_dir.join("snapshots").join("snap2"))
-            .expect("clear snap2");
+        std::fs::remove_dir_all(table_dir.join("snapshots").join("snap2")).expect("clear snap2");
         let snap3 = table_dir.join("snapshots").join("snap3");
         std::fs::create_dir_all(&snap3).unwrap();
         for entry in std::fs::read_dir(&other_dir).unwrap().flatten() {

--- a/cqlite-flight/src/warm/metrics.rs
+++ b/cqlite-flight/src/warm/metrics.rs
@@ -64,6 +64,14 @@ pub struct WarmMetrics {
     /// Number of `SSTableReader::open` calls the registry performed — the
     /// "work-done" probe. A warm hit performs ZERO opens (spec Requirement 2).
     reader_opens: AtomicU64,
+    /// Number of cached readers rebound in place to a fresh same-inode snapshot
+    /// path (issue #2383/#2356 rebind-by-inode) — parsed state kept, ZERO
+    /// reader-open/index-parse. Distinguishes a warm-hit-WITH-rebind (path
+    /// rolled over to a fresh snapshot dir) from a pure warm hit (path
+    /// unchanged, `rebind_hits == 0`) and from a full rebuild (`reader_opens`
+    /// climbs). The snapshot-lifecycle-closure work probe (flight-warm-snapshot-
+    /// closure spec, §D).
+    rebind_hits: AtomicU64,
 }
 
 impl WarmMetrics {
@@ -115,6 +123,16 @@ impl WarmMetrics {
         self.reader_opens.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Record `n` cached readers rebound in place to a fresh same-inode snapshot
+    /// path (the #2383/#2356 rebind pass). A no-op for `n == 0` so a pure warm
+    /// hit (path unchanged) never touches the counter.
+    pub fn record_rebind_hits(&self, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.rebind_hits.fetch_add(n, Ordering::Relaxed);
+    }
+
     /// A consistent-enough snapshot of the counters for tests/benches.
     pub fn snapshot(&self) -> WarmMetricsSnapshot {
         WarmMetricsSnapshot {
@@ -125,6 +143,7 @@ impl WarmMetrics {
             refresh_rebuilt_delta: self.refresh_rebuilt.load(Ordering::Relaxed),
             refresh_fail_closed_retained: self.refresh_fail_closed.load(Ordering::Relaxed),
             reader_opens: self.reader_opens.load(Ordering::Relaxed),
+            rebind_hits: self.rebind_hits.load(Ordering::Relaxed),
         }
     }
 }
@@ -146,6 +165,11 @@ pub struct WarmMetricsSnapshot {
     pub refresh_fail_closed_retained: u64,
     /// Total `SSTableReader::open` calls — the work-done probe (0 on a warm hit).
     pub reader_opens: u64,
+    /// Total cached readers rebound to a fresh same-inode snapshot path
+    /// (issue #2383/#2356). `0` on a pure warm hit (path unchanged) and on a
+    /// full rebuild; `> 0` only when a fresh snapshot dir rolled over and the
+    /// cached parsed state was repointed to it without re-parse.
+    pub rebind_hits: u64,
 }
 
 #[cfg(test)]
@@ -160,23 +184,27 @@ mod tests {
         m.record_miss();
         m.record_evicts(2);
         m.record_reader_opens(3);
+        m.record_rebind_hits(2);
         m.record_refresh(RefreshOutcome::RebuiltDelta);
         let s = m.snapshot();
         assert_eq!(s.hits, 1);
         assert_eq!(s.misses, 1);
         assert_eq!(s.evicts, 2);
         assert_eq!(s.reader_opens, 3);
+        assert_eq!(s.rebind_hits, 2);
         assert_eq!(s.refresh_rebuilt_delta, 1);
     }
 
     #[test]
-    fn zero_evicts_and_opens_are_noops() {
+    fn zero_evicts_opens_and_rebinds_are_noops() {
         let m = WarmMetrics::default();
         m.record_evicts(0);
         m.record_reader_opens(0);
+        m.record_rebind_hits(0);
         let s = m.snapshot();
         assert_eq!(s.evicts, 0);
         assert_eq!(s.reader_opens, 0);
+        assert_eq!(s.rebind_hits, 0);
     }
 
     impl WarmMetricsSnapshot {
@@ -189,6 +217,7 @@ mod tests {
                 refresh_rebuilt_delta: 0,
                 refresh_fail_closed_retained: 0,
                 reader_opens: 0,
+                rebind_hits: 0,
             }
         }
     }

--- a/cqlite-flight/src/warm/metrics.rs
+++ b/cqlite-flight/src/warm/metrics.rs
@@ -116,6 +116,12 @@ impl WarmMetrics {
     }
 
     /// Record `n` reader opens performed during a (re)build.
+    ///
+    /// Snapshot-only exposure (issue #2356 roborev, spec `flight-warm-snapshot-closure`):
+    /// this work-probe is read via [`WarmMetrics::snapshot`] (the surface the warm-closure
+    /// tests + field probes consume), NOT mirrored to the OTel counter export like the
+    /// cache hit/miss/evict/refresh counters — this change deliberately does not expand
+    /// the OTel surface for it.
     pub fn record_reader_opens(&self, n: u64) {
         if n == 0 {
             return;
@@ -126,6 +132,9 @@ impl WarmMetrics {
     /// Record `n` cached readers rebound in place to a fresh same-inode snapshot
     /// path (the #2383/#2356 rebind pass). A no-op for `n == 0` so a pure warm
     /// hit (path unchanged) never touches the counter.
+    ///
+    /// Snapshot-only exposure, same as [`Self::record_reader_opens`] (spec
+    /// `flight-warm-snapshot-closure`): read via [`WarmMetrics::snapshot`], not OTel.
     pub fn record_rebind_hits(&self, n: u64) {
         if n == 0 {
             return;

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -396,6 +396,7 @@ impl WarmTableRegistry {
         // A dead-path generation with NO identity-matching live entry fails CLOSED:
         // it lands in `added` and is fully re-opened from the live dir.
         let mut alive_ids: HashSet<GenerationId> = HashSet::new();
+        let mut rebind_hits: u64 = 0;
         for (id, reader) in &cached {
             let current_path = reader.file_path();
             if std::fs::metadata(&current_path).is_ok() {
@@ -404,9 +405,16 @@ impl WarmTableRegistry {
                 if super::rebuild::rebind_matches(*id, reader.file_size(), &live.path) {
                     reader.rebind_path(&live.path);
                     alive_ids.insert(*id);
+                    rebind_hits += 1;
                 }
             }
         }
+        // Record the rebinds NOW (not gated on the swap outcome): a rebind
+        // mutates the shared `Arc<SSTableReader>` in place (ArcSwap `file_path`),
+        // so the repoint is already observed by the live cache entry — the
+        // snapshot-lifecycle-closure work probe (flight-warm-snapshot-closure §D:
+        // distinguishes a warm-hit-with-rebind from a full rebuild).
+        self.metrics.record_rebind_hits(rebind_hits);
 
         // ADDED = present now, not already warm/rebound on a LIVE path. Open them
         // (fail-closed) — genuinely-new generations and dead-path ones with no

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -459,10 +459,12 @@ impl WarmTableRegistry {
         // (adjudicated: "the previously-installed — here, concurrently
         // NEWER — set was retained instead of being overwritten by an older
         // probe result") rather than adding a new bounded label.
-        if let Some(live) = inner.tables.get(key) {
-            if live.ddl_hash == ddl_hash && live.generation_set() != probe_start_set {
-                let tick = inner.next_tick();
-                let entry = inner.tables.get_mut(key).expect("checked Some above");
+        let fresher_installed = inner.tables.get(key).is_some_and(|live| {
+            live.ddl_hash == ddl_hash && live.generation_set() != probe_start_set
+        });
+        if fresher_installed {
+            let tick = inner.next_tick();
+            if let Some(entry) = inner.tables.get_mut(key) {
                 for r in &mut entry.readers {
                     r.last_access = tick;
                 }

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -211,6 +211,14 @@ fn rebind_across_snapshot_teardown_does_not_reparse() {
         "a snapshot teardown + same-inode restage must REBIND (zero further \
          Index.db parses), not re-open every generation (issue #2383 / #2356)"
     );
+    // The rebind is COUNTED (issue #2356 §D closure probe): both generations
+    // were rebound to the fresh snap2 hardlinks, distinguishing this from a
+    // pure warm hit (which would leave `rebind_hits` at 0).
+    assert!(
+        reg.metrics().snapshot().rebind_hits >= 2,
+        "both generations must be counted as rebinds, got {}",
+        reg.metrics().snapshot().rebind_hits
+    );
 }
 
 /// **Fix A — single-flight rebuild.** M concurrent misses for ONE fresh table key

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -221,6 +221,44 @@ fn rebind_across_snapshot_teardown_does_not_reparse() {
     );
 }
 
+/// **Warm-hit work is scale-free (flight-warm-snapshot-closure spec).** A warm hit
+/// over a LARGE-partition-count generation costs ZERO reader opens and ZERO rebinds
+/// — the warm-hit work probe is bounded by the warm-set DIFF (here: nothing
+/// changed), never by partition count. Pairs with the small-generation warm-hit
+/// tests (e.g. `service::do_get_second_request_is_a_warm_hit_with_zero_reader_opens`)
+/// to show independence from partition count: both are 0.
+#[test]
+fn warm_hit_over_large_generation_is_scale_free() {
+    let schema = simple_schema();
+    // Many partitions in ONE generation so a cold parse is genuinely large.
+    let (_temp, table_dir) = build_big_single_gen(&schema, 3_000);
+
+    let reg = WarmTableRegistry::new();
+    let cancel = CancelFlag::new();
+
+    // Cold warm: opens (parses) the one big generation.
+    reg.warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("cold warm of the big generation");
+    let after_cold = reg.metrics().snapshot();
+    assert!(
+        after_cold.reader_opens >= 1,
+        "cold build parsed the generation"
+    );
+
+    // Repeat over the SAME stable path: a pure warm hit — zero further work.
+    reg.warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .expect("warm hit");
+    let after_hit = reg.metrics().snapshot();
+    assert_eq!(
+        after_hit.reader_opens, after_cold.reader_opens,
+        "the warm hit opened ZERO further readers regardless of partition count"
+    );
+    assert_eq!(
+        after_hit.rebind_hits, after_cold.rebind_hits,
+        "a stable-path warm hit performs ZERO rebinds regardless of partition count"
+    );
+}
+
 /// **Fix A — single-flight rebuild.** M concurrent misses for ONE fresh table key
 /// must coalesce onto a single rebuild: total `reader_opens` == #generations, not
 /// ×M. A start barrier launches all M threads together and a per-open sleep hook

--- a/openspec/changes/snapshot-lifecycle-closure/design.md
+++ b/openspec/changes/snapshot-lifecycle-closure/design.md
@@ -1,0 +1,204 @@
+# Design — Snapshot lifecycle closure
+
+## Context
+
+The Trino connector's default read mode is per-query snapshot (issue #2105/#2227). Per query,
+`SnapshotManager.snapshotFor(queryId, ks, table, hosts)` creates a snapshot named `cqlite-<queryId>` on
+EVERY replica host's Sidecar (instance-local PUT, #2227), the splits carry that name in their flight
+tickets, and `cleanup(queryId)` best-effort deletes it at query end (a Sidecar TTL is the leak
+backstop). On the Rust side, `FlightService::resolve_dir` re-resolves the SSTable directory
+authoritatively EVERY request (`DirSource::resolve`, containment-checked #1430; NOT cached — roborev
+1639/#2341), and `WarmTableRegistry::warm_readers` diff/swaps the warm reader set keyed on inode-stable
+`GenerationId` (`device, inode, generation`).
+
+Post-#2352 a warm hit is served only when `cached_paths_all_present` — every cached reader's backing
+path still `stat`s. In per-query snapshot mode the cached path is the PRIOR (now-cleared) snapshot dir,
+so this fails and forces a rebuild. #2383 added rebind-by-inode: on a warm hit with a dead cached path,
+if the CURRENT request's resolved dir holds a `Data.db` whose `(device, inode, generation)` + size
+match the cached `GenerationId`, `reader.rebind_path(&live.path)` repoints the reader (ArcSwap
+`file_path`) and keeps ALL parsed state; a mismatch fails closed to a full rebuild.
+
+So today: parse is elided (good), but the closure is incomplete — every query still pays a
+resolve + per-generation `stat` + rebind, the rebind is fragile against a snapshot cleared before the
+scan opens its fd (#2352 ENOENT class), and NOTHING reduces the snapshot create/flush churn (#2306).
+
+## The three sub-problems
+
+This change decomposes into: (a) warm-state closure across per-query snapshots, (b) memtable-flush
+churn, (c) the interplay lever that serves both — plus (d) observability and (e) failure modes.
+
+---
+
+## §A — Warm-state closure across per-query snapshots (#2356)
+
+### Option 1 — "rebind everywhere" (complete #2383)
+Keep inode-stable rebind as THE closure mechanism. #2383 already rebinds the scan path
+(`stream_all_partitions_for_compaction → new_scan_cursor → open(&self.file_path)`, now ArcSwap
+`file_path`) and the point path uses a held-fd `point_source`.
+
+- **What is still path-bound after #2383:** the rebind FIRES per query and requires (i) an authoritative
+  `resolve_dir` (one `read_dir`), (ii) a `GenerationId::resolve` `stat` per cached generation, (iii)
+  an identity-matching LIVE entry in the CURRENT resolved dir to rebind onto. If the connector cleared
+  the prior snapshot AND has not yet (or ever) created a fresh matching dir for this query, there is no
+  live hardlink to rebind onto → fail closed to full rebuild. Rebind therefore only wins when a fresh
+  same-inode snapshot dir is present at resolve time — i.e. it is coupled to the connector's snapshot
+  cadence.
+- **Verdict:** necessary and correct, but INSUFFICIENT alone — it cannot close the churn (create/flush
+  fan-out per query) and remains one clear-race away from a rebuild. KEEP it as the correctness
+  backstop; do not make it the whole answer.
+
+### Option 2 — durable fd / mmap scans (hold backings; path death irrelevant)
+At warm-cache time, hold the `Data.db` fd (and Index/Summary/etc.) open for the reader's lifetime and
+serve BOTH scan and point paths off held descriptors (adopt the point path's `pread` `point_source` for
+scans — read-path audit F3 territory). Under POSIX unlinked-but-open semantics, a cleared snapshot dir
+does not invalidate an open fd, so path death becomes a non-event — no resolve dependency for the DATA
+read, no rebind, no #2352 clear race on an in-flight scan.
+
+- **Cost:** an fd (really a small set of fds) held per warm generation for the process lifetime →
+  `Σ (generations × components)` descriptors. Bounded by the warm-budget LRU (`with_budget`), but at
+  field scale (many generations × many warm tables) this is a real fd-exhaustion surface needing an
+  explicit `ulimit`-aware cap and eviction. It is also a larger, parity-sensitive core change to the
+  scan path (currently re-opens by path).
+- **Verdict:** the most ROBUST closure and the true "path death is irrelevant" answer, but too large +
+  fd-risky for the 0.15 lane. **Defer** to bounded future hardening (recommend only if field data
+  after Seams A/B still shows rebuild churn). Record the posture; do not implement now.
+
+### Option 3 — connector-side longer-lived / reused snapshots
+Covered under §B (it is the shared lever). From §A's perspective: a stable snapshot path across queries
+means `resolve_dir` returns the SAME dir → `cached_paths_all_present` PASSES → a pure warm hit with NO
+rebind, NO re-parse. The rebind (Option 1) then fires only once per snapshot-window rollover.
+
+### §A recommendation — **Option 3 (keystone) + Option 1 (backstop); Option 2 deferred**
+The closure is delivered primarily by making the path STABLE (Option 3), with #2383's inode rebind
+(Option 1) as the correctness backstop for the once-per-window rollover and any residual per-query dir.
+Option 2 (durable fds) is evaluated and DEFERRED (fd-exhaustion + core-change cost) — recorded as future
+hardening. Seam A's NEW work is therefore: (1) pin the end-to-end warm hit through `do_get` in
+snapshot mode with scale-free counters, (2) keep the #2352 fail-closed and #2383 rebind invariants
+green, (3) expose the closure counters (§D). The authoritative per-request resolve (#2341/#1430) is
+UNCHANGED.
+
+---
+
+## §B — Memtable-flush churn (#2306)
+
+Constraint (owner #2305): flush-on-snapshot is BY DESIGN; the Sidecar HTTP API has no `skipFlush`. The
+lever is FEWER snapshot CALLS, never skipping the flush.
+
+### Option B1 — snapshot reuse / TTL batching (keyed on `(keyspace, table)`)
+Reuse a single snapshot across queries within a bounded freshness window instead of one per `queryId`.
+Name it `cqlite-<ks>-<table>-<epoch>` (epoch = the logical freshness window id) rather than
+`cqlite-<queryId>`. `SnapshotManager` caches, per `(host, ks, table)`, the current snapshot name +
+window; `snapshotFor`/`availableHosts` return the cached name while the window is fresh, create a new
+one when it expires or is invalidated, and `cleanup` retires superseded snapshots (a Sidecar TTL stays
+the leak backstop). N queries in one window → 1 create fan-out → 1 flush per host, not N.
+
+- **Cost:** reads reflect data up to one window old (documented staleness bound — acceptable for the
+  Trino/analytics workload). Slightly more code in `SnapshotManager`; interacts with the #2227
+  per-replica-host model (reuse is per host, same as create).
+- **Verdict:** RECOMMENDED. Directly reduces flush/create volume by the reuse factor and (via §A) makes
+  the path stable. This is the #2306 option-1 "snapshot reuse / TTL batching."
+
+### Option B2 — `skipFlush` via `nodetool`/JMX or a sidecar HTTP contribution
+#2306 options 2/3. Moves snapshot creation off the Sidecar HTTP path onto `nodetool`/JMX (adds JMX +
+`nodetool` to the flight/connector image) OR contributes `?skipFlush` upstream to
+`apache/cassandra-sidecar`.
+
+- **Verdict:** REJECTED for this change. The upstream contribution violates the comment-only rule;
+  the JMX/`nodetool` route is an architectural image change that relitigates #2305's HTTP-API posture.
+  Park both.
+
+### Option B3 — LIVE-mode routing where isolation is not required
+Route workloads that tolerate no point-in-time isolation to `ReadMode.LIVE` (no snapshot, no flush,
+inert `SnapshotManager`). Already exists; this change only DOCUMENTS it as the zero-churn option for
+callers who accept live reads.
+
+### §B recommendation — **B1 (snapshot reuse/TTL) primary; B3 documented; B2 rejected**
+B1 is the lever that reduces flush churn without touching flush semantics. B3 is documented as the
+zero-isolation escape hatch. B2 is parked (comment-only + #2305).
+
+---
+
+## §C — Interplay: one lever, both problems
+
+**Option 3 / B1 (longer-lived, reused snapshots) is the single keystone that serves BOTH §A and §B.**
+A reused snapshot within a freshness window gives:
+- **(§A) a stable resolved path** → warm hit with zero rebuild and zero rebind within the window;
+- **(§B) fewer creates** → fewer flushes.
+
+### Lifetime / invalidation semantics (no wall-clock in tests)
+A reused snapshot for `(keyspace, table)` is valid until the FIRST of:
+1. **Window expiry** — the freshness window `W` elapses. `W` is measured on an INJECTABLE logical clock
+   (a `Clock`/`Ticker` seam in `SnapshotManager`, `nanos`/epoch counter), never `System.currentTimeMillis`
+   in tests. Production default is a configurable `snapshotReuseWindow` (e.g. a few seconds — the
+   staleness the analytics workload tolerates); tests advance the injected clock deterministically.
+2. **Live-generation-set change** — the table's on-disk SSTable generation set changed (a flush or
+   compaction produced/removed generations) since the snapshot was taken. Detection is authoritative:
+   the connector observes the resolved generation set (or a cheap generation-set fingerprint the flight
+   server can expose) and invalidates on change. NOTE: a reused snapshot is ALWAYS a correct immutable
+   point-in-time even across a generation change (Cassandra snapshots are immutable hardlinks) — this
+   invalidation is a FRESHNESS lever, not a correctness requirement; it bounds how stale a reused read
+   may be when the table is actively changing.
+3. **Explicit refresh** — an operator/connector `invalidate(ks, table)` (the `Database::refresh()`
+   analog) forces a new snapshot on the next query.
+
+The staleness bound is thus: reads reflect table state no older than `min(W, time-since-last-
+generation-change)`, and NEVER an inconsistent mix (each reused snapshot is one atomic point-in-time).
+This bound is documented in the connector docs.
+
+---
+
+## §D — Metrics / observability (design, exact names at implementation)
+
+Field rounds must measure the closure round-over-round on the #2399 scoreboard. Counters:
+- **`snapshot_creations_total`** (connector, per `(ks, table)`) — snapshot create fan-outs performed.
+  Reuse is proven by `creations_total / queries` dropping toward `1 / (queries-per-window)`.
+- **`snapshot_reuse_hits_total`** (connector) — queries served by an already-live snapshot.
+- **flushes-avoided proxy** — derived from `snapshot_creations_total` (one create ⇒ one flush per host
+  under #2305); the connector docs state the derivation. No new server metric needed for #2306's AC.
+- **Rust side:** reuse the existing `resolves` (per-request resolve count, service caches),
+  `cqlite.sstable.index_parses_total` (#2383; parse-elision proof), `reader_opens` (warm work-probe),
+  and add a **`rebind_hits_total`** on the warm registry so a warm-hit-with-rebind is distinguishable
+  from a pure warm hit (path unchanged) and from a full rebuild.
+
+All counters are scale-free work-probes (independent of partition count), pinnable by unit/integration
+tests without a field fixture, per the #2383 pin style.
+
+---
+
+## §E — Failure modes
+
+1. **Snapshot deleted mid-scan (the #2352 ENOENT class).** With reuse, the window makes this rare, but
+   it can still happen at a window rollover or an operator `clearsnapshot`. Invariant preserved: a dead
+   cached path with NO identity-matching live entry FAILS CLOSED to a rebuild (never ENOENT mid-merge,
+   never a stale serve). If Option 2 (durable fds) were later adopted, an in-flight scan would complete
+   over the held backing; under the recommended package it fails closed and the query re-runs cold — no
+   correctness loss.
+2. **fd exhaustion.** Only relevant if Option 2 is later adopted; the recommended package does NOT hold
+   extra fds beyond today's point-`source`, so no new fd surface. Recorded so the deferred option
+   carries an explicit `ulimit`-aware cap requirement when picked up.
+3. **Staleness vs the per-request probe (#2341).** The Rust resolve stays authoritative per request BY
+   DESIGN; reuse changes only the snapshot NAME the connector passes, so the server-side containment +
+   liveness guarantees are unchanged. A reused snapshot that was retired server-side (TTL fired) resolves
+   to a dead dir → the §E-1 fail-closed rebuild path, never a stale serve.
+4. **Reuse across a schema/DDL change.** `WarmTableRegistry` already keys on a `ddl_hash`; a DDL change
+   invalidates the warm set independently. Snapshot reuse additionally invalidates on the
+   generation-set change a DDL-driven flush produces, so no stale-schema serve.
+
+## Composition with #2412 (lazy Summary-guided index)
+#2412 makes BIG open O(summary) and warm resident memory ≈ summary. This change is orthogonal: it never
+redefines index open/walk, only READS `index_parses_total` and the warm-registry hit path. Post-#2412,
+a cold rebuild is cheaper (so the §A closure is less costly to miss), but the snapshot create/flush
+churn (§B) and the per-query resolve+stat are unchanged — this change still delivers the churn reduction
+and the stable-path warm hit. The two land independently; whichever merges second rebases onto the
+other with no requirement overlap (verified: #2412's spec touches `cqlite-core` reader/index; this
+change touches `cqlite-flight` warm registry + `trino-connector` SnapshotManager).
+
+## Recommended package (single, for Seam 1 approval)
+- **§A:** Option 3 keystone + Option 1 (#2383 rebind) backstop; Option 2 durable-fd DEFERRED.
+- **§B:** Option B1 (snapshot reuse/TTL) primary; B3 (LIVE-mode) documented; B2 (skipFlush) rejected.
+- **§C:** the reused snapshot is the shared lever; lifetime = `min(window W, generation-set change,
+  explicit refresh)`, injectable logical clock, documented staleness bound, no wall-clock in tests.
+- **§D:** `snapshot_creations_total` + `snapshot_reuse_hits_total` (connector), `rebind_hits_total`
+  (Rust) + existing resolve/parse/opens counters.
+- **§E:** fail-closed on mid-scan deletion preserved; no new fd surface; staleness bounded and
+  documented.

--- a/openspec/changes/snapshot-lifecycle-closure/design.md
+++ b/openspec/changes/snapshot-lifecycle-closure/design.md
@@ -116,6 +116,21 @@ callers who accept live reads.
 B1 is the lever that reduces flush churn without touching flush semantics. B3 is documented as the
 zero-isolation escape hatch. B2 is parked (comment-only + #2305).
 
+### §B addendum — bounded retirement of superseded windows (roborev on the initial impl)
+The first implementation retired a superseded window ONLY on explicit `invalidate`/`retireAll`, leaving
+supersede-on-roll to the ~6h Sidecar TTL alone. Roborev flagged the resource-retention regression: a hot
+table with a 3s window accumulates on the order of `ttl / window` (~7200) live hardlink sets per table
+per host until TTL. Decision: retire a superseded window after a bounded **grace period**
+(`cqlite.snapshot-retire-grace-ms`, default 10 min) — chosen over per-window in-flight-reader
+ref-counting because the connector has no reader-drain hook (the actual reads happen out-of-process on
+the Rust flight server), whereas a grace tied to the max query duration is simple, race-free (once the
+grace elapses no query that resolved the window can still be reading it), and deterministically testable
+on the existing injected clock. Retirement is swept lazily on the next `resolveSnapshot` (no background
+thread); steady-state retained superseded dirs bound to ~`grace / window`, well under the TTL backstop
+which still covers a crash between supersede and sweep. The counters (`snapshot_creations_total`/
+`snapshot_reuse_hits_total`, the #2306 flush proxy) are incremented only after a fan-out fully succeeds,
+and a fail-closed partial fan-out rolls back its half-created window rather than caching it.
+
 ---
 
 ## §C — Interplay: one lever, both problems

--- a/openspec/changes/snapshot-lifecycle-closure/proposal.md
+++ b/openspec/changes/snapshot-lifecycle-closure/proposal.md
@@ -1,0 +1,109 @@
+# Snapshot lifecycle closure (#2356 primary, #2306 secondary)
+
+## Milestone
+0.15 — the cqlite-trino latency/throughput/operations theme (epic #2403, **Lane 3**). Serves the
+Trino latency/throughput/operations lanes; acceptance measured round-over-round on the #2399 field
+scoreboard.
+**Design-driven — OpenSpec + Seam 1 required before any implementation.** Both anchored issues route
+design-driven (their bodies say so). Oracle-driven correctness (rows returned) stays pinned by the
+existing physical-dump + query-semantics parity nets; this change redesigns the *per-query snapshot
+lifecycle* — how a snapshot is created, reused, resolved, and how warm parsed state survives it —
+which is a structural/operational decision, hence OpenSpec.
+
+## Issue anchors
+- **#2356 (primary, P2)** — flight warm handles are a rebuild-per-query no-op in per-query-snapshot
+  mode. Post-#2352 a warm hit is served only when every cached reader's backing path still resolves;
+  the connector's default per-query snapshot mode clears the prior snapshot dir, so the cached path is
+  always dead → every query re-opens + re-parses. #2383 delivered rebind-by-inode (parse elided when a
+  fresh matching snapshot dir presents), but the closure is incomplete: it still depends on a
+  per-query resolve+stat+rebind against a dir that may already be gone, and the underlying churn
+  remains.
+- **#2306 (secondary, P3)** — the per-query snapshot flushes the queried table's memtable, producing
+  tiny-SSTable spam + compaction churn on the production cluster under query-heavy workloads. Owner
+  decision (#2305, 2026-07-09): flush-on-snapshot is BY DESIGN for the Sidecar HTTP API (no
+  `skipFlush`; JMX-only). #2306 tracks the remaining OPERATIONAL cost, not the flush semantics.
+
+These two issues share ONE design space — the per-query-snapshot lifecycle — so ONE change covers
+both. The keystone lever (a longer-lived / reused snapshot) serves both: a stable snapshot path lets
+warm state stay warm (#2356) AND fewer snapshot creations means fewer flushes (#2306).
+
+## Why
+Field baselines on #2367 (rounds 9/10) and the #2356/#2306/#2398 issue bodies:
+
+1. **Warm benefit does not reach the field's default mode.** #2310's warm parse-elision (~830ms
+   parse elided, ~1,350× on repeated point reads flight-direct) applies to LIVE mode and stable
+   snapshot paths only. In per-query snapshot mode each query gets a fresh `cqlite-<queryId>` snapshot
+   dir and the prior dir is cleared, so the cached path is always dead. #2383 rebinds parsed state
+   onto the new matching dir, but only when the current request has already resolved a fresh dir whose
+   `Data.db` inodes match — a per-query resolve+stat+rebind that is fragile against the #2352 clear
+   race and does nothing to reduce the snapshot churn itself.
+2. **Per-query snapshot creation is a triple sidecar fan-out.** `SnapshotManager` (`trino-connector/`)
+   creates `cqlite-<queryId>` on EVERY replica host (issue #2227: a Sidecar snapshot PUT is
+   instance-local), so a scan pays 3× create round-trips per query, then a best-effort clear at query
+   end. #2398 attributes ~4-5s of fixed warm-scan setup to resolve/merge_setup; the snapshot
+   create/clear fan-out is a lifecycle-owned slice of that.
+3. **Every query flushes the queried table's memtable.** Flush-on-snapshot (accepted by #2305) means
+   one flush per query per replica host — tiny SSTables + compaction churn scaling with query volume,
+   not data volume (#2306).
+
+Individually tolerable; together they defeat the entire warm-handle investment in the field's default
+mode and impose a query-rate-proportional operational tax on the cluster.
+
+## What Changes
+- **Seam A — warm-state closure across the snapshot lifecycle (Rust `cqlite-flight`, #2356):** make
+  the warm hit VERIFIABLY survive the per-query snapshot lifecycle end-to-end through `do_get`, keeping
+  #2383's inode-stable rebind as the correctness backstop and pinning it with scale-free work-probe
+  counters (index parses, reader opens, rebind hits). No change to the authoritative per-request
+  directory resolve (#2341/#1430 — kept BY DESIGN).
+- **Seam B — snapshot reuse / TTL (Java `trino-connector/SnapshotManager`, #2356 + #2306):** the
+  keystone. Instead of one snapshot per `queryId`, reuse a per-`(keyspace, table)` snapshot within a
+  bounded freshness window, invalidated by window expiry or an observed live-generation-set change.
+  Fewer snapshot creations → a stable snapshot path (Seam A stays warm, zero rebind churn within the
+  window) AND fewer flushes (#2306). The lever is FEWER snapshot CALLS, never skipping the flush
+  (#2305 is not relitigated).
+- **Metrics:** snapshot creations per N queries, flushes avoided (creation-rate proxy), rebind hits,
+  parse-elision hits — so field rounds can measure the closure round-over-round on #2399.
+
+## Non-goals
+- **No change to snapshot correctness or isolation semantics.** A reused snapshot is still a valid,
+  immutable Cassandra point-in-time; the only observable change is a bounded, documented staleness
+  window for analytics reads. Row-level parity (physical-dump + query-semantics oracles) is inviolable.
+- **#2305's flush-on-snapshot verdict is NOT relitigated.** No `skipFlush`, no JMX/`nodetool` in the
+  flight image, no per-snapshot flush-skipping. The only lever on flush volume is fewer snapshot calls.
+- **No upstream `apache/cassandra-sidecar` or `easy-db-lab` changes** (comment-only rule). The
+  `?skipFlush` HTTP-endpoint contribution (#2306 option 3) is explicitly parked, not pursued here.
+  `SnapshotManager` lives in OUR `trino-connector/`, so its reuse/TTL logic is an in-tree change.
+- **No overlap with #2412 (lazy Summary-guided BIG index).** #2412 owns how the partition index is
+  opened and walked (open O(summary), resident memory ≈ summary). This change owns the snapshot
+  *lifecycle* around the reader — orthogonal. With #2412 landed, a cold rebuild is cheaper, but the
+  resolve+stat per query and the snapshot create/flush churn remain, so this change stays valuable and
+  independent. Where the two touch (warm-registry memory, `index_parses_total` semantics), this change
+  only READS the counters #2412 defines; it does not redefine index open/walk.
+- **No change to the public `Database`/`QueryRow`/flight `do_get` result contract** — same rows, same
+  bytes; only the snapshot lifecycle and warm-hit path change.
+- **No pre-`na` format support** introduced or revisited (version floor unchanged).
+
+## The #2398 / #2413 boundary (design MUST stay clear of)
+#2398 (warm-scan fixed ~4-5s setup) and its fix #2413 (token-range pushdown into the per-SSTable walk)
+own the *merge_setup / token-filter* slice of setup cost. THIS change owns the *snapshot lifecycle*
+slice (create/clear fan-out, resolve+stat, flush churn). The design (§B, §interplay) states the split
+explicitly so the two lanes do not double-count or collide.
+
+## Doctrine impact
+- **No-heuristics (#28) preserved:** inode identity (`device, inode, generation` + size) remains the
+  ONLY key for rebind; snapshot reuse is keyed on explicit `(keyspace, table)` + a logical freshness
+  epoch, never inferred from content. Staleness/invalidation is authoritative (window + generation-set
+  change), never guessed.
+- **No wall-clock in tests:** the reuse freshness window and invalidation are driven by an injectable
+  logical clock / epoch so parity and unit tests pin behavior deterministically (per the #1742
+  query-semantics-oracle pinned-`now` discipline).
+- CLAUDE.md / website `agents-developing/`: no doctrine text change; add a one-line note to the
+  flight/trino connector docs describing snapshot reuse + the staleness bound once implemented
+  (in-change, per the keep-doctrine-current rule).
+
+## Definition of done
+`scripts/agent-gate.sh` full PASS (SUMMARY recorded) + spec-auditor **C** PASS (every requirement
+`satisfied` with a public-surface test) + roborev clean; `RUSTFLAGS="-D warnings"` clean; no
+`unwrap()`/`expect()` in library code; physical-dump + query-semantics parity + flight `do_get`
+warm+snapshot-mode e2e green; the connector test suite (`trino-connector`) green. Then
+`openspec archive`.

--- a/openspec/changes/snapshot-lifecycle-closure/specs/flight-snapshot-reuse/spec.md
+++ b/openspec/changes/snapshot-lifecycle-closure/specs/flight-snapshot-reuse/spec.md
@@ -1,0 +1,96 @@
+# flight-snapshot-reuse
+
+## ADDED Requirements
+
+### Requirement: Snapshots are reused per (keyspace, table) within a bounded freshness window
+
+The connector's `SnapshotManager` SHALL, in snapshot read mode, reuse a single snapshot for a
+`(keyspace, table)` across queries within a bounded freshness window instead of creating one snapshot
+per `queryId`. While a `(keyspace, table)` snapshot is fresh, `snapshotFor`/`availableHosts` SHALL
+return the existing snapshot's name and perform NO new Sidecar create call. The number of snapshot
+create fan-outs SHALL therefore be bounded by the number of freshness windows, not by the number of
+queries. Reuse SHALL be per replica host (consistent with the #2227 instance-local create model).
+
+#### Scenario: N queries within one window create exactly one snapshot
+
+- **GIVEN** a `SnapshotManager` in snapshot mode with an injected logical clock held within one
+  freshness window, and a `snapshot_creations_total` counter reset to 0
+- **WHEN** N distinct queries for the same `(keyspace, table)` request a snapshot on the same host
+- **THEN** exactly one snapshot create call is made to that host's Sidecar
+  (`snapshot_creations_total == 1`) and the other N-1 queries increment `snapshot_reuse_hits_total`
+- **AND** all N queries receive the SAME snapshot name in their tickets.
+
+### Requirement: A reused snapshot is invalidated by window expiry, generation-set change, or explicit refresh
+
+A reused `(keyspace, table)` snapshot SHALL be invalidated — forcing a fresh create on the next query
+— when the FIRST of these occurs: (1) the freshness window elapses on the injectable logical clock;
+(2) the table's observed live SSTable generation set changes since the snapshot was taken; or (3) an
+explicit `invalidate(keyspace, table)` refresh is requested. Window timing SHALL be driven by an
+injectable clock/ticker seam, never `System.currentTimeMillis` in tests, so invalidation is pinned
+deterministically.
+
+#### Scenario: A new query after window expiry creates a fresh snapshot
+
+- **GIVEN** a fresh reused snapshot for a `(keyspace, table)` and a `snapshot_creations_total` reset to 0
+- **WHEN** the injected logical clock is advanced past the freshness window and a new query requests a
+  snapshot for that table
+- **THEN** exactly one new snapshot create call is made (`snapshot_creations_total == 1`) and the new
+  query receives the NEW snapshot name.
+
+#### Scenario: An explicit refresh forces a fresh snapshot on the next query
+
+- **GIVEN** a fresh reused snapshot for a `(keyspace, table)`
+- **WHEN** `invalidate(keyspace, table)` is called and a subsequent query requests a snapshot within the
+  window
+- **THEN** a new snapshot is created for that table and the subsequent query receives the new name.
+
+#### Scenario: An observed generation-set change invalidates reuse
+
+- **GIVEN** a fresh reused snapshot taken over generation set G for a `(keyspace, table)`
+- **WHEN** the connector observes the table's live generation set change to G' (a flush/compaction) and a
+  new query requests a snapshot within the window
+- **THEN** a new snapshot is created (the stale-generation snapshot is not reused) and the query receives
+  the new name.
+
+### Requirement: Reuse reduces memtable-flush churn without changing flush semantics
+
+Reusing snapshots SHALL reduce the flush/SSTable-creation rate on the cluster proportionally to the
+reuse factor under a query-heavy default-mode workload, because each snapshot create triggers one
+memtable flush per host by design (#2305). This change SHALL NOT skip, defer, or otherwise alter the
+flush-on-snapshot semantics (#2305 not relitigated); the only lever on flush volume is fewer snapshot
+create calls. The flush-rate reduction SHALL be measurable from `snapshot_creations_total` (one create
+⇒ one flush per host), and the derivation SHALL be documented in the connector docs.
+
+#### Scenario: Snapshot creation rate over a query-heavy workload drops by the reuse factor
+
+- **GIVEN** a snapshot-mode workload of Q queries for one `(keyspace, table)` spanning W freshness
+  windows on the injected clock, with `snapshot_creations_total` reset
+- **WHEN** the workload completes
+- **THEN** `snapshot_creations_total` equals W (one create per window), not Q (one per query), so the
+  flush-inducing create rate drops from Q to W
+- **AND** the connector docs state the `creations ⇒ flushes` derivation used to report the #2306
+  operational-cost reduction.
+
+### Requirement: Reuse preserves point-in-time correctness, isolation, and LIVE-mode inertness
+
+A reused snapshot SHALL remain a valid, immutable Cassandra point-in-time; the only observable change
+SHALL be that a read may reflect table state up to one freshness window old (a documented staleness
+bound), never an inconsistent mix of point-in-times within a single query. Row-level parity
+(physical-dump + query-semantics oracles) SHALL hold for reads served from a reused snapshot. In
+`ReadMode.LIVE` the `SnapshotManager` SHALL remain inert (no snapshot name, no reuse cache, no Sidecar
+create calls), exactly as today.
+
+#### Scenario: A read from a reused snapshot returns a correct point-in-time result set
+
+- **GIVEN** a reused snapshot for a `(keyspace, table)` taken at a pinned point-in-time
+- **WHEN** a query is served from that reused snapshot
+- **THEN** the returned result set matches the query-semantics oracle for that point-in-time at a pinned
+  `now` (no wall-clock), reflecting exactly the snapshot's atomic state
+- **AND** the connector docs state the staleness bound `min(window, time-since-last-generation-change)`.
+
+#### Scenario: LIVE mode performs no reuse and no Sidecar calls
+
+- **GIVEN** a `SnapshotManager` constructed in `ReadMode.LIVE`
+- **WHEN** any number of queries request a snapshot for any `(keyspace, table)`
+- **THEN** `snapshotFor` returns empty (ticket `snapshot=null`), `snapshot_creations_total` stays 0, and
+  no reuse-cache entry is created (the pre-#2105 behavior is unchanged).

--- a/openspec/changes/snapshot-lifecycle-closure/specs/flight-snapshot-reuse/spec.md
+++ b/openspec/changes/snapshot-lifecycle-closure/specs/flight-snapshot-reuse/spec.md
@@ -52,6 +52,41 @@ deterministically.
 - **THEN** a new snapshot is created (the stale-generation snapshot is not reused) and the query receives
   the new name.
 
+### Requirement: A superseded snapshot is actively retired after a bounded grace period
+
+The `SnapshotManager` SHALL NOT delete a superseded reuse window (window expiry or generation-set
+change) the instant it is superseded — an in-flight query may still be reading it (the retire-race) —
+but SHALL actively retire it (delete its per-host hardlink sets) once a bounded, configurable
+retire-grace period elapses on the injectable clock, so retention is NOT left to the multi-hour Sidecar
+TTL backstop alone. The grace period SHALL be
+configurable (`cqlite.snapshot-retire-grace-ms`) with a default that safely exceeds the longest Trino
+query, and the worst-case retained superseded snapshot directories per table per host SHALL be bounded
+by roughly `retire-grace / reuse-window` (well under `snapshot-ttl / reuse-window`). A superseded window
+still WITHIN its grace SHALL survive. Explicit `invalidate` and shutdown `retireAll` SHALL still retire
+immediately (draining any pending-retire queue). The `retire-grace × reuse-window × snapshot-ttl` sizing
+interaction SHALL be documented in the connector config docs. `snapshot_creations_total`/
+`snapshot_reuse_hits_total` SHALL count only a fully materialized fan-out (a fail-closed partial create
+counts neither and caches no reusable window).
+
+#### Scenario: A superseded snapshot is retired once its grace elapses while an in-grace one survives
+
+- **GIVEN** a reused snapshot W0 for a `(keyspace, table)` and an injected logical clock, with a
+  retire-grace configured to several freshness windows
+- **WHEN** a later query supersedes W0 with W1 and the clock is then advanced past W0's retire-grace (but
+  not W1's) and a subsequent query resolves
+- **THEN** W0's per-host snapshots are cleared (actively retired) exactly once, while W1 (still within its
+  grace) and the current window are NOT cleared
+- **AND** before W0's grace elapses, a superseded W0 is not cleared (the in-flight reader is safe).
+
+#### Scenario: A fail-closed partial fan-out caches no window and counts no creation
+
+- **GIVEN** a snapshot-mode `SnapshotManager` where one replica host's snapshot create will fail
+- **WHEN** a query resolves a fresh window and the per-host fan-out fails closed on that host
+- **THEN** `snapshot_creations_total` and `snapshot_reuse_hits_total` are unchanged (the create that
+  never fully materialized is not counted) and the half-created window is not cached
+- **AND** a subsequent successful query CREATES a fresh snapshot (it does not reuse the rolled-back
+  window).
+
 ### Requirement: Reuse reduces memtable-flush churn without changing flush semantics
 
 Reusing snapshots SHALL reduce the flush/SSTable-creation rate on the cluster proportionally to the

--- a/openspec/changes/snapshot-lifecycle-closure/specs/flight-warm-snapshot-closure/spec.md
+++ b/openspec/changes/snapshot-lifecycle-closure/specs/flight-warm-snapshot-closure/spec.md
@@ -81,7 +81,12 @@ unchanged, zero rebind) from a warm-hit-with-rebind from a full rebuild, so a fi
 snapshot-lifecycle closure round-over-round. At minimum: the per-request directory `resolves` counter
 (unchanged, authoritative per request), `index_parses_total`, `reader_opens`, and a new
 `rebind_hits_total` (rebound generations). These counters SHALL be observable through the existing
-flight stats/metrics surface.
+flight stats/metrics surface. Exposure surface (explicit, so a field probe and the intent audit agree):
+`reader_opens` and `rebind_hits_total` SHALL be exposed via the programmatic `WarmMetricsSnapshot` stats
+surface (the same surface the warm-closure tests and field probes read), which is authoritative for the
+round-over-round verification; unlike the warm cache hit/miss/evict/refresh counters they are NOT also
+mirrored to the OTel counter export (a snapshot-only exposure this change does not expand). `resolves`
+and `index_parses_total` retain their existing surfaces (#2341/#2412).
 
 #### Scenario: Counters distinguish pure warm hit, rebind, and rebuild over a query sequence
 

--- a/openspec/changes/snapshot-lifecycle-closure/specs/flight-warm-snapshot-closure/spec.md
+++ b/openspec/changes/snapshot-lifecycle-closure/specs/flight-warm-snapshot-closure/spec.md
@@ -1,0 +1,96 @@
+# flight-warm-snapshot-closure
+
+## ADDED Requirements
+
+### Requirement: A repeated query over a stable snapshot path takes a warm hit with zero re-parse
+
+The flight server SHALL serve, from the warm reader set and WITHOUT re-opening or re-parsing any
+component, consecutive `do_get` requests for the same `(keyspace, table)` that resolve to the SAME
+snapshot directory (a reused/longer-lived snapshot, §B/§C) whose `Data.db` inodes are unchanged. The
+full-`Index.db`-parse counter (`cqlite.sstable.index_parses_total`) and
+the warm reader-open work-probe (`reader_opens`) SHALL increment by 0 for such a warm hit. This SHALL
+hold end-to-end through the flight `do_get` path (wiring evidence), not only at the registry helper
+level.
+
+#### Scenario: Second identical snapshot-mode query re-parses nothing
+
+- **GIVEN** a flight service warmed for a `(keyspace, table)` from a snapshot directory, with the
+  work counters (`index_parses_total`, `reader_opens`) reset after the first `do_get`
+- **WHEN** a second `do_get` for the same table resolves to the SAME snapshot directory (same
+  `Data.db` inodes)
+- **THEN** the second `do_get` returns the same rows byte-for-byte as the first
+- **AND** `index_parses_total` increments by 0 and `reader_opens` increments by 0 for the second
+  request (a pure warm hit, no rebind needed because the path is unchanged).
+
+#### Scenario: Warm-hit work is independent of partition count (scale-free)
+
+- **GIVEN** two warmed generations of the same shape differing only in partition count (small vs large)
+- **WHEN** each is served a repeat `do_get` over its stable snapshot path with counters reset
+- **THEN** both repeats increment `index_parses_total` and `reader_opens` by 0 (the warm-hit work is
+  bounded by the warm-set diff, not by partition count).
+
+### Requirement: Rebind-by-inode closes a fresh matching snapshot dir without re-parse; a changed-inode set fails closed
+
+The warm registry SHALL rebind each cached reader to the current directory's `Data.db` — preserving all
+parsed state and incrementing `index_parses_total` by 0 — when a `do_get` resolves to a FRESH snapshot
+directory (window rollover or a per-query dir) whose cached readers' paths are now dead, when and only
+when the current `Data.db`'s authoritative `(device, inode, generation)` + file size match the cached
+`GenerationId`. A generation whose inodes do NOT match (a recycled inode, a genuinely new generation, or a
+`stat` failure) SHALL fail closed to a full rebuild — never a stale serve, never an ENOENT. The #2352
+regression invariant (dead path with CHANGED inodes must rebuild) SHALL stay green.
+
+#### Scenario: Fresh same-inode snapshot dir rebinds parsed state, zero parse
+
+- **GIVEN** a warm reader set whose cached snapshot dir was cleared, and a fresh snapshot dir for the
+  same table hardlinking the SAME `Data.db` inodes, counters reset
+- **WHEN** a `do_get` resolves to the fresh dir and takes a warm hit
+- **THEN** each matching reader is rebound to the fresh path (`rebind_hits_total` increments per rebound
+  generation) and `index_parses_total` increments by 0
+- **AND** the returned rows match the physical-dump golden byte-for-byte.
+
+#### Scenario: Changed-inode generation fails closed to a rebuild
+
+- **GIVEN** a warm reader set whose cached path is dead and a fresh dir whose `Data.db` has a DIFFERENT
+  `(device, inode)` than the cached `GenerationId`
+- **WHEN** a `do_get` resolves to the fresh dir
+- **THEN** the mismatching generation is fully rebuilt (`reader_opens` increments for it), never rebound
+- **AND** the request never serves the stale cached reader and never returns an ENOENT error.
+
+### Requirement: A snapshot cleared mid-lifecycle never serves stale data or an ENOENT
+
+The request SHALL fail closed to a fresh rebuild of the affected generation when a resolved snapshot
+directory is deleted (a window rollover, an operator `clearsnapshot`, or a retired reused snapshot) such
+that a warm-hit candidate's backing path is dead and no identity-matching live entry exists in the
+current resolved directory. It SHALL NOT return partial/stale rows from the dead path and SHALL NOT surface a
+raw ENOENT mid-merge. Row-level parity SHALL hold on both the physical-dump and query-semantics oracles
+after the rebuild.
+
+#### Scenario: Dead cached path with no live match rebuilds cleanly
+
+- **GIVEN** a warm reader set whose cached snapshot dir is deleted and a current resolved dir that does
+  NOT contain a matching-inode `Data.db` for that generation
+- **WHEN** a `do_get` is served
+- **THEN** the request rebuilds the generation from the authoritative current directory (or returns an
+  authoritative not-found if the generation is genuinely gone), never an ENOENT and never a stale serve
+- **AND** the returned result set matches the query-semantics oracle at a pinned `now`.
+
+### Requirement: Closure counters are exposed for field measurement
+
+The flight service SHALL expose scale-free work-probe counters that distinguish a pure warm hit (path
+unchanged, zero rebind) from a warm-hit-with-rebind from a full rebuild, so a field round can verify the
+snapshot-lifecycle closure round-over-round. At minimum: the per-request directory `resolves` counter
+(unchanged, authoritative per request), `index_parses_total`, `reader_opens`, and a new
+`rebind_hits_total` (rebound generations). These counters SHALL be observable through the existing
+flight stats/metrics surface.
+
+#### Scenario: Counters distinguish pure warm hit, rebind, and rebuild over a query sequence
+
+- **GIVEN** a sequence of `do_get` requests: (1) cold, (2) repeat on a stable path, (3) repeat on a
+  fresh same-inode dir, (4) repeat on a changed-inode dir, with the metrics surface observed
+- **WHEN** the four requests complete
+- **THEN** request 1 increments `reader_opens` (cold build), request 2 increments none of
+  `reader_opens`/`index_parses_total`/`rebind_hits_total` (pure warm hit), request 3 increments
+  `rebind_hits_total` but not `index_parses_total` (rebind), and request 4 increments `reader_opens`
+  (rebuild)
+- **AND** the `resolves` counter increments by exactly 1 per request (the resolve stays authoritative
+  per request, #2341/#1430, unchanged).

--- a/openspec/changes/snapshot-lifecycle-closure/tasks.md
+++ b/openspec/changes/snapshot-lifecycle-closure/tasks.md
@@ -1,0 +1,57 @@
+# Tasks — Snapshot lifecycle closure
+
+Sequenced on branch `issue-2356-snapshot-lifecycle-closure` (staged commits). Each stage names the
+public surface it exercises and carries a red-then-green test. Anchors are `main`-relative and will
+drift; the implementer re-greps before editing. `CQLITE_DATASETS_ROOT` points at the MAIN checkout's
+`test-data/datasets` (a worktree lacks the gitignored `Data.db` binaries — 0-row false passes).
+
+## Stage 0 — red probes first (must fail before the fix)
+- [ ] 0.1 Add a `rebind_hits_total` field + accessor to the warm metrics
+  (`cqlite-flight/src/warm/metrics.rs`), and a flight-level probe test asserting the FOUR-request
+  sequence (cold / stable-repeat / fresh-same-inode / changed-inode) counter deltas — fails on `main`
+  (no `rebind_hits_total` yet). (flight-warm-snapshot-closure)
+- [ ] 0.2 Add a `SnapshotManagerTest` (Java, `trino-connector/src/test/...`) with an injected logical
+  clock asserting "N queries in one window ⇒ 1 create" — fails on `main` (one create per `queryId`).
+  (flight-snapshot-reuse)
+
+## Stage 1 — Seam A: warm-state closure (Rust `cqlite-flight`)
+- [ ] 1.1 Wire `rebind_hits_total`: increment on each `reader.rebind_path(&live.path)` in
+  `warm/registry.rs` (the #2383 rebind pass); expose via `WarmMetrics::snapshot` and the flight stats
+  surface (`service.rs` metrics). (flight-warm-snapshot-closure)
+- [ ] 1.2 End-to-end `do_get` pin (snapshot mode): repeat query over a STABLE resolved snapshot path
+  asserts `index_parses_total` and `reader_opens` deltas of 0 (pure warm hit); a fresh same-inode dir
+  asserts `rebind_hits_total` delta > 0 with `index_parses_total` delta 0. Exercise through the flight
+  `do_get` path, not the registry helper alone. (flight-warm-snapshot-closure)
+- [ ] 1.3 Keep the #2352 fail-closed + #2383 changed-inode-rebuild invariants green (dead path, changed
+  inodes ⇒ rebuild; dead path, no live match ⇒ clean rebuild, never ENOENT/stale). Extend
+  `warm/spin_tests_2383.rs` / `warm/registry_tests.rs`. (flight-warm-snapshot-closure)
+- [ ] 1.4 Confirm the per-request `resolves` counter still increments exactly once per request
+  (authoritative resolve UNCHANGED, #2341/#1430). (flight-warm-snapshot-closure)
+
+## Stage 2 — Seam B: snapshot reuse / TTL (Java `trino-connector/SnapshotManager`)
+- [ ] 2.1 Introduce an injectable `Clock`/`Ticker` seam + a `snapshotReuseWindow` config
+  (`CqliteFlightConfig`); default a small window; tests inject a manual clock (no
+  `System.currentTimeMillis`). (flight-snapshot-reuse)
+- [ ] 2.2 Reuse cache keyed on `(host, keyspace, table)` → (snapshot name, window epoch, generation-set
+  fingerprint). `snapshotFor`/`availableHosts` return the cached name while fresh; create on expiry /
+  generation-set change / explicit `invalidate(ks, table)`; name `cqlite-<ks>-<table>-<epoch>`.
+  Retire superseded snapshots via `cleanup` (Sidecar TTL stays the leak backstop). (flight-snapshot-reuse)
+- [ ] 2.3 Add `snapshot_creations_total` + `snapshot_reuse_hits_total` connector counters; assert the
+  window/expiry/refresh/generation-change scenarios. (flight-snapshot-reuse)
+- [ ] 2.4 Preserve `ReadMode.LIVE` inertness (no reuse cache, no creates); assert. (flight-snapshot-reuse)
+- [ ] 2.5 Query-semantics parity: a read from a reused snapshot matches the oracle at a pinned `now`.
+  (flight-snapshot-reuse)
+
+## Stage 3 — docs + observability
+- [ ] 3.1 Connector docs (`docs/flight-trino/`): snapshot reuse, the `min(window, generation-change)`
+  staleness bound, the `creations ⇒ flushes` derivation for the #2306 cost report, and the LIVE-mode
+  zero-churn escape hatch. One-line note on the flight/source-map page per keep-doctrine-current.
+- [ ] 3.2 Record the DEFERRED durable-fd (§A Option 2) posture + the fd-cap requirement in the connector
+  docs / a follow-up issue stub, so field data can reopen it.
+
+## Stage 4 — endgame (standard loop)
+- [ ] 4.1 `--lite` each fix round (summary-file redirect); iterate to PASS.
+- [ ] 4.2 Review-first: `rust-reviewer` + roborev on the lite-green diff; fix blockers, re-`--lite`.
+- [ ] 4.3 Open PR; `flow-closer` runs the FULL gate ONCE → spec-auditor **C** (every requirement
+  `satisfied` with a public-surface test) → final roborev → merge-on-green → `openspec archive`.
+- [ ] 4.4 Telemetry stamp (`flow-finalize`); batch nits into ONE linked follow-up at merge.

--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -209,7 +209,8 @@ Catalog properties (`etc/catalog/cqlite.properties`):
 | `cqlite.flight-port` | `8815` | Arrow Flight port on each Cassandra node. |
 | `cqlite.local-datacenter` | *(none)* | Preferred datacenter for split placement. |
 | `cqlite.read-mode` | `snapshot` | `snapshot` (default) reads a consistent, per-query Sidecar snapshot; `live` reads the current data dir (races compaction). See [Read mode](#read-mode-snapshot-vs-live). |
-| `cqlite.snapshot-ttl` | `6h` | `snapshot` mode only: a Cassandra 4.1+ TTL on each per-query snapshot so a coordinator crash between create and cleanup can't leak it (Cassandra auto-drops it). Set blank to disable. |
+| `cqlite.snapshot-ttl` | `6h` | `snapshot` mode only: a Cassandra 4.1+ TTL on each snapshot so a crash (or a reused snapshot outliving its window) can't leak it (Cassandra auto-drops it). Set blank to disable. |
+| `cqlite.snapshot-reuse-window-ms` | `3000` | `snapshot` mode only: reuse a single snapshot per `(keyspace, table)` across queries for this many milliseconds (issue #2356/#2306). Larger ⇒ fewer snapshot creates/flushes and a warmer read path, at the cost of up to one window of staleness. `0` disables reuse (a fresh snapshot per query). See [Snapshot reuse](#snapshot-reuse-and-the-staleness-bound). |
 | `cqlite.aggregation-pushdown-group-by` | `automatic` | GROUP BY aggregation-pushdown policy: `automatic`, `always`, or `never`. Global aggregates (no GROUP BY) are an unconditional win and always push regardless of this setting. |
 | `cqlite.aggregation-pushdown-max-group-ratio` | `0.5` | `automatic` only: decline GROUP BY pushdown once the estimated distinct-groups / rows ratio exceeds this. Must be in `(0.0, 1.0]`. |
 
@@ -249,13 +250,15 @@ a very recent write can become visible through a `snapshot`-mode query even with
 directory directly, with no snapshot and no flush side effect, so memtable rows stay invisible
 until an explicit `nodetool flush`.
 
-### Snapshot lifecycle (per-query, `cqlite-<queryId>`)
+### Snapshot lifecycle (reused per `(keyspace, table)`, `cqlite-<ks>-<table>-<epoch>`)
 
-In `snapshot` mode the connector, at **split-planning time** (once per query, per table):
+In `snapshot` mode the connector, at **split-planning time**, resolves the snapshot for the
+scanned `(keyspace, table)` — **reusing** the current one when it is still fresh (see
+[Snapshot reuse](#snapshot-reuse-and-the-staleness-bound)) and otherwise creating a new one:
 
-1. Creates a Sidecar snapshot named `cqlite-<queryId>` of the scanned table **on every
-   distinct replica host the query's splits will read**
-   (`PUT /api/v1/keyspaces/{keyspace}/tables/{table}/snapshots/{name}`, with the
+1. Creates a Sidecar snapshot named `cqlite-<ks>-<table>-<epoch>` (the `epoch` identifies the
+   freshness window) of the scanned table **on every distinct replica host the query's splits
+   will read** (`PUT /api/v1/keyspaces/{keyspace}/tables/{table}/snapshots/{name}`, with the
    configured `?ttl=` backstop). A Sidecar snapshot `PUT` is *instance-local* — it creates
    the snapshot only on the node fronting that one Sidecar (issue #2227). Since a multi-node
    scan fans splits across every replica host, the connector must create the snapshot on
@@ -263,9 +266,12 @@ In `snapshot` mode the connector, at **split-planning time** (once per query, pe
    exist and fail NotFound.
 2. Names that snapshot in **every** Flight ticket, so all splits read the one immutable
    file set on their host.
-3. Best-effort **deletes** the snapshot on each of those hosts when the query finishes —
-   success or failure — via Trino's `cleanupQuery` hook
-   (`DELETE /api/v1/keyspaces/{keyspace}/tables/{table}/snapshots/{name}`).
+3. **Retires** a snapshot when a fresher window supersedes it (or an explicit refresh /
+   window expiry / observed generation-set change invalidates it), and retires every live
+   snapshot at connector shutdown
+   (`DELETE /api/v1/keyspaces/{keyspace}/tables/{table}/snapshots/{name}`). A reused snapshot
+   OUTLIVES the query that created it, so cleanup is **not** per-query; the `cqlite.snapshot-ttl`
+   backstop reclaims any snapshot a crash leaves behind.
 
 **Per-host Sidecar addressing.** The connector only ever queries the configured
 `cqlite.sidecar-uri` (db0) for discovery, but the Cassandra Sidecar runs as a `hostNetwork`
@@ -280,10 +286,42 @@ explicit port, and no userinfo/credentials, path, query, or fragment (e.g.
 per-host snapshot PUTs, so it is rejected at config load rather than surfacing later at first
 snapshot use.
 
-Why per-query rather than a long-lived reusable snapshot: it needs no background reaper,
-each query gets an isolated consistent view, and the queryId makes the name collision-free
-and traceable. The `cqlite.snapshot-ttl` backstop means even a coordinator crash between
-create and cleanup can't leak the snapshot — Cassandra auto-drops it.
+### Snapshot reuse and the staleness bound
+
+Reusing one snapshot per `(keyspace, table)` across queries within the
+`cqlite.snapshot-reuse-window-ms` window (issue #2356/#2306) is the keystone that serves two
+otherwise-separate problems:
+
+- **Warm read path (#2356).** A stable, reused snapshot path means the flight server's warm
+  reader set stays valid across queries — a repeat query is a pure warm hit with zero re-parse
+  and zero rebind, instead of the prior per-query behavior where every query cleared the last
+  snapshot dir and forced a full re-open + re-parse. The flight server exposes scale-free work
+  probes (`reader_opens`, `index_parses_total`, `rebind_hits_total`) so a field round can verify
+  the closure: within a window these stay flat.
+- **Fewer memtable flushes (#2306).** Flush-on-snapshot is **by design** (issue #2305; the
+  Sidecar HTTP API has no `skipFlush`, and this connector does not relitigate that). The only
+  lever on flush volume is **fewer snapshot creations**: because each snapshot create triggers
+  one memtable flush per host, reusing a snapshot for *Q* queries spanning *W* windows drops the
+  flush-inducing create rate from *Q* to *W*. This is the `creations ⇒ flushes` derivation used
+  to report the #2306 operational-cost reduction — measured directly from the connector's
+  `snapshot_creations_total` (one create ⇒ one flush per host); `snapshot_reuse_hits_total`
+  counts the queries served by an already-live snapshot.
+
+A reused snapshot is invalidated — forcing a fresh create on the next query — by the FIRST of:
+(1) the freshness window elapsing, (2) an observed change in the table's live SSTable
+generation set (a flush/compaction), or (3) an explicit refresh. A reused snapshot is always a
+valid, immutable Cassandra point-in-time (snapshots are hard-linked), so the only observable
+effect is a bounded, documented **staleness bound**: a read reflects table state no older than
+`min(window, time-since-last-generation-change)`, and never an inconsistent mix of
+point-in-times within one query.
+
+**Zero-churn escape hatch.** A workload that needs no point-in-time isolation can set
+`cqlite.read-mode=live`: no snapshot, no flush, no reuse cache, always the latest flushed data
+(at the cost of racing compaction). That is the zero-snapshot-churn option for callers who
+accept live reads.
+
+The `cqlite.snapshot-ttl` backstop means even a coordinator crash can't leak a snapshot —
+Cassandra auto-drops it.
 
 **Fail-closed:** if snapshot creation fails on **any** replica host in `snapshot` mode, the
 query **fails** with an actionable error naming the host + snapshot — the connector does

--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -266,12 +266,16 @@ scanned `(keyspace, table)` — **reusing** the current one when it is still fre
    exist and fail NotFound.
 2. Names that snapshot in **every** Flight ticket, so all splits read the one immutable
    file set on their host.
-3. **Retires** a snapshot when a fresher window supersedes it (or an explicit refresh /
-   window expiry / observed generation-set change invalidates it), and retires every live
-   snapshot at connector shutdown
-   (`DELETE /api/v1/keyspaces/{keyspace}/tables/{table}/snapshots/{name}`). A reused snapshot
-   OUTLIVES the query that created it, so cleanup is **not** per-query; the `cqlite.snapshot-ttl`
-   backstop reclaims any snapshot a crash leaves behind.
+3. **Retires** a snapshot ONLY on an explicit refresh (`SnapshotManager.invalidate`) or at
+   connector shutdown (`SnapshotManager.retireAll`)
+   (`DELETE /api/v1/keyspaces/{keyspace}/tables/{table}/snapshots/{name}`). A window that is merely
+   **superseded** by a fresher one (window expiry / observed generation-set change rolling to a new
+   epoch) is **not** actively deleted (issue #2356): a long-running query may still be reading the
+   superseded snapshot — its splits not yet opened, or a cold remote host — when a later query rolls
+   the window, so deleting it on supersede would break those in-flight reads. Superseded snapshots
+   are instead reclaimed by the `cqlite.snapshot-ttl` backstop. A reused snapshot OUTLIVES the query
+   that created it, so cleanup is **not** per-query; the same TTL backstop also reclaims any snapshot
+   a crash leaves behind.
 
 **Per-host Sidecar addressing.** The connector only ever queries the configured
 `cqlite.sidecar-uri` (db0) for discovery, but the Cassandra Sidecar runs as a `hostNetwork`

--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -211,6 +211,7 @@ Catalog properties (`etc/catalog/cqlite.properties`):
 | `cqlite.read-mode` | `snapshot` | `snapshot` (default) reads a consistent, per-query Sidecar snapshot; `live` reads the current data dir (races compaction). See [Read mode](#read-mode-snapshot-vs-live). |
 | `cqlite.snapshot-ttl` | `6h` | `snapshot` mode only: a Cassandra 4.1+ TTL on each snapshot so a crash (or a reused snapshot outliving its window) can't leak it (Cassandra auto-drops it). Set blank to disable. |
 | `cqlite.snapshot-reuse-window-ms` | `3000` | `snapshot` mode only: reuse a single snapshot per `(keyspace, table)` across queries for this many milliseconds (issue #2356/#2306). Larger ⇒ fewer snapshot creates/flushes and a warmer read path, at the cost of up to one window of staleness. `0` disables reuse (a fresh snapshot per query). See [Snapshot reuse](#snapshot-reuse-and-the-staleness-bound). |
+| `cqlite.snapshot-retire-grace-ms` | `600000` | `snapshot` mode only: how long a **superseded** reuse window is kept before it is actively deleted (issue #2356). Must safely exceed your longest query so an in-flight read never loses its snapshot mid-scan; raise it above your `query.max-run-time` if you run long queries. Worst-case retained superseded snapshot dirs per table per host ≈ `snapshot-retire-grace-ms / snapshot-reuse-window-ms` (bounded well under `snapshot-ttl / snapshot-reuse-window-ms`). See [Snapshot reuse](#snapshot-reuse-and-the-staleness-bound). |
 | `cqlite.aggregation-pushdown-group-by` | `automatic` | GROUP BY aggregation-pushdown policy: `automatic`, `always`, or `never`. Global aggregates (no GROUP BY) are an unconditional win and always push regardless of this setting. |
 | `cqlite.aggregation-pushdown-max-group-ratio` | `0.5` | `automatic` only: decline GROUP BY pushdown once the estimated distinct-groups / rows ratio exceeds this. Must be in `(0.0, 1.0]`. |
 
@@ -266,16 +267,19 @@ scanned `(keyspace, table)` — **reusing** the current one when it is still fre
    exist and fail NotFound.
 2. Names that snapshot in **every** Flight ticket, so all splits read the one immutable
    file set on their host.
-3. **Retires** a snapshot ONLY on an explicit refresh (`SnapshotManager.invalidate`) or at
-   connector shutdown (`SnapshotManager.retireAll`)
-   (`DELETE /api/v1/keyspaces/{keyspace}/tables/{table}/snapshots/{name}`). A window that is merely
-   **superseded** by a fresher one (window expiry / observed generation-set change rolling to a new
-   epoch) is **not** actively deleted (issue #2356): a long-running query may still be reading the
-   superseded snapshot — its splits not yet opened, or a cold remote host — when a later query rolls
-   the window, so deleting it on supersede would break those in-flight reads. Superseded snapshots
-   are instead reclaimed by the `cqlite.snapshot-ttl` backstop. A reused snapshot OUTLIVES the query
-   that created it, so cleanup is **not** per-query; the same TTL backstop also reclaims any snapshot
-   a crash leaves behind.
+3. **Retires** a snapshot (`DELETE /api/v1/keyspaces/{keyspace}/tables/{table}/snapshots/{name}`)
+   immediately on an explicit refresh (`SnapshotManager.invalidate`) or at connector shutdown
+   (`SnapshotManager.retireAll`), and — for a window that is merely **superseded** by a fresher one
+   (window expiry / observed generation-set change rolling to a new epoch) — after a bounded
+   **retire-grace** (`cqlite.snapshot-retire-grace-ms`, default 10 min). The grace exists because a
+   long-running query may still be reading the superseded snapshot — its splits not yet opened, or a
+   cold remote host — when a later query rolls the window, so deleting it on supersede would break
+   those in-flight reads; once the grace (set to safely exceed the longest query) elapses, no query
+   that resolved that window can still be reading it, so the delete is race-free. This bounds retained
+   superseded snapshot dirs to roughly `snapshot-retire-grace-ms / snapshot-reuse-window-ms` per table
+   per host instead of leaving them to the multi-hour `cqlite.snapshot-ttl` backstop (which still
+   reclaims any snapshot a crash leaves behind between supersede and sweep). A reused snapshot OUTLIVES
+   the query that created it, so cleanup is **not** per-query.
 
 **Per-host Sidecar addressing.** The connector only ever queries the configured
 `cqlite.sidecar-uri` (db0) for discovery, but the Cassandra Sidecar runs as a `hostNetwork`
@@ -324,8 +328,15 @@ point-in-times within one query.
 (at the cost of racing compaction). That is the zero-snapshot-churn option for callers who
 accept live reads.
 
-The `cqlite.snapshot-ttl` backstop means even a coordinator crash can't leak a snapshot —
-Cassandra auto-drops it.
+**Bounded retention of superseded snapshots.** When a query rolls to a fresh window, the previous
+window is not deleted on the spot (an in-flight query may still be reading it) but is retired once
+`cqlite.snapshot-retire-grace-ms` (default 10 min) elapses — set the grace to safely exceed your
+longest query (e.g. above Trino's `query.max-run-time`). Sizing: worst-case retained superseded
+snapshot dirs per table per host ≈ `snapshot-retire-grace-ms / snapshot-reuse-window-ms`, kept well
+under `snapshot-ttl / snapshot-reuse-window-ms`; so a short reuse window plus a long TTL no longer
+accumulates snapshot directories without bound. The `cqlite.snapshot-ttl` backstop remains the
+crash-safety net — even a coordinator crash between supersede and sweep can't leak a snapshot, since
+Cassandra auto-drops it after the TTL.
 
 **Fail-closed:** if snapshot creation fails on **any** replica host in `snapshot` mode, the
 query **fails** with an actionable error naming the host + snapshot — the connector does

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
@@ -34,7 +34,8 @@ public record CqliteFlightConfig(
         double maxGroupRatio,
         long tableStatsTimeoutMillis,
         ReadMode readMode,
-        Optional<String> snapshotTtl) {
+        Optional<String> snapshotTtl,
+        long snapshotReuseWindowMillis) {
 
     public static final int DEFAULT_FLIGHT_PORT = 8815;
 
@@ -64,6 +65,20 @@ public record CqliteFlightConfig(
      */
     public static final double DEFAULT_MAX_GROUP_RATIO = 0.5;
 
+    /**
+     * Default snapshot-reuse freshness window (issue #2356/#2306). Within this window a single
+     * Sidecar snapshot is REUSED per {@code (keyspace, table)} across queries — one create
+     * fan-out (→ one memtable flush per host, #2305/#2306) and a stable resolved path that keeps
+     * the flight warm readers warm (#2356). The window is the staleness a Trino/analytics read
+     * tolerates: a read may reflect table state up to {@code min(window, time-since-last-
+     * generation-change)} old. {@code 0} disables reuse (every query takes a fresh snapshot).
+     */
+    public static final long DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS = 3_000L;
+
+    /** {@link #DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS} in nanoseconds (the {@link SnapshotManager} unit). */
+    public static final long DEFAULT_SNAPSHOT_REUSE_WINDOW_NANOS =
+            DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS * 1_000_000L;
+
     public CqliteFlightConfig {
         if (maxGroupRatio <= 0.0 || maxGroupRatio > 1.0) {
             throw new IllegalArgumentException(
@@ -73,7 +88,16 @@ public record CqliteFlightConfig(
             throw new IllegalArgumentException(
                     "cqlite.table-stats-timeout-ms must be > 0, got " + tableStatsTimeoutMillis);
         }
+        if (snapshotReuseWindowMillis < 0) {
+            throw new IllegalArgumentException(
+                    "cqlite.snapshot-reuse-window-ms must be >= 0, got " + snapshotReuseWindowMillis);
+        }
         requireRootPerNodeBase(sidecarUri);
+    }
+
+    /** The snapshot-reuse freshness window in nanoseconds (the {@link SnapshotManager} unit). */
+    public long snapshotReuseWindowNanos() {
+        return snapshotReuseWindowMillis * 1_000_000L;
     }
 
     /**
@@ -165,8 +189,12 @@ public record CqliteFlightConfig(
                 : DEFAULT_TABLE_STATS_TIMEOUT_MILLIS;
         ReadMode readMode = ReadMode.fromConfig(config.get("cqlite.read-mode"));
         Optional<String> snapshotTtl = parseSnapshotTtl(config.get("cqlite.snapshot-ttl"));
+        long reuseWindowMs = config.containsKey("cqlite.snapshot-reuse-window-ms")
+                ? Long.parseLong(config.get("cqlite.snapshot-reuse-window-ms"))
+                : DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS;
         return new CqliteFlightConfig(
-                URI.create(sidecar), port, dc, policy, ratio, statsTimeoutMs, readMode, snapshotTtl);
+                URI.create(sidecar), port, dc, policy, ratio, statsTimeoutMs, readMode, snapshotTtl,
+                reuseWindowMs);
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
@@ -92,12 +92,22 @@ public record CqliteFlightConfig(
             throw new IllegalArgumentException(
                     "cqlite.snapshot-reuse-window-ms must be >= 0, got " + snapshotReuseWindowMillis);
         }
+        try {
+            // Fail fast on a configured value so large the ms→ns conversion would overflow long
+            // (a partial overflow could otherwise silently wrap to a small positive window).
+            Math.multiplyExact(snapshotReuseWindowMillis, 1_000_000L);
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException(
+                    "cqlite.snapshot-reuse-window-ms is too large (ns overflow), got " + snapshotReuseWindowMillis);
+        }
         requireRootPerNodeBase(sidecarUri);
     }
 
     /** The snapshot-reuse freshness window in nanoseconds (the {@link SnapshotManager} unit). */
     public long snapshotReuseWindowNanos() {
-        return snapshotReuseWindowMillis * 1_000_000L;
+        // Overflow is rejected at construction (see the compact constructor), so this is safe;
+        // multiplyExact keeps it fail-fast rather than silently wrapping if that ever changes.
+        return Math.multiplyExact(snapshotReuseWindowMillis, 1_000_000L);
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
@@ -18,6 +18,13 @@ import java.util.Optional;
  * # Backstop TTL for per-query snapshots so a coordinator crash can't leak them
  * # (Cassandra auto-drops after this). Blank disables the TTL. Cassandra 4.1+ syntax.
  * cqlite.snapshot-ttl=6h
+ * # Snapshot REUSE freshness window (ms): one snapshot is reused per (keyspace, table) across
+ * # queries within this window (issue #2356/#2306). 0 disables reuse (a snapshot per query).
+ * cqlite.snapshot-reuse-window-ms=3000
+ * # Grace (ms) before a SUPERSEDED reuse window is actively retired (issue #2356). MUST exceed
+ * # your longest query so an in-flight read never loses its snapshot; retained superseded dirs
+ * # per table per host ≈ retire-grace / reuse-window (bounded well under snapshot-ttl / window).
+ * cqlite.snapshot-retire-grace-ms=600000
  * # Aggregation-pushdown gate (issue #893); GROUP BY only — globals always push.
  * cqlite.aggregation-pushdown-group-by=automatic   # automatic | always | never
  * cqlite.aggregation-pushdown-max-group-ratio=0.5   # decline above this groups/rows ratio
@@ -35,7 +42,8 @@ public record CqliteFlightConfig(
         long tableStatsTimeoutMillis,
         ReadMode readMode,
         Optional<String> snapshotTtl,
-        long snapshotReuseWindowMillis) {
+        long snapshotReuseWindowMillis,
+        long snapshotRetireGraceMillis) {
 
     public static final int DEFAULT_FLIGHT_PORT = 8815;
 
@@ -79,6 +87,27 @@ public record CqliteFlightConfig(
     public static final long DEFAULT_SNAPSHOT_REUSE_WINDOW_NANOS =
             DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS * 1_000_000L;
 
+    /**
+     * Default grace period (milliseconds) before a SUPERSEDED reuse window is actively retired
+     * (issue #2356 roborev, bounded retention). When a query rolls to a fresh window the old window
+     * is not deleted immediately — a still-running query may be reading its snapshot (the
+     * retire-race) — but leaving it to the ~6h {@link #DEFAULT_SNAPSHOT_TTL} backstop would let a
+     * hot table with a short {@code snapshot-reuse-window-ms} accumulate on the order of
+     * {@code snapshot-ttl / window} live snapshot dirs (each a full hardlink set) per table per
+     * host. So a superseded window is retired once this grace elapses, which MUST safely exceed the
+     * longest-running Trino query so no in-flight read loses its snapshot mid-scan; 10 minutes covers
+     * typical analytical queries with margin. Operators running longer queries SHOULD raise this to
+     * exceed their {@code query.max-run-time}. Sizing: worst-case retained superseded dirs per table
+     * per host ≈ {@code snapshot-retire-grace-ms / snapshot-reuse-window-ms} (bounded well under
+     * {@code snapshot-ttl / snapshot-reuse-window-ms}). {@code 0} retires a superseded window on the
+     * very next resolve (only safe when queries never outlive a window).
+     */
+    public static final long DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS = 600_000L;
+
+    /** {@link #DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS} in nanoseconds (the {@link SnapshotManager} unit). */
+    public static final long DEFAULT_SNAPSHOT_RETIRE_GRACE_NANOS =
+            DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS * 1_000_000L;
+
     public CqliteFlightConfig {
         if (maxGroupRatio <= 0.0 || maxGroupRatio > 1.0) {
             throw new IllegalArgumentException(
@@ -92,13 +121,19 @@ public record CqliteFlightConfig(
             throw new IllegalArgumentException(
                     "cqlite.snapshot-reuse-window-ms must be >= 0, got " + snapshotReuseWindowMillis);
         }
+        if (snapshotRetireGraceMillis < 0) {
+            throw new IllegalArgumentException(
+                    "cqlite.snapshot-retire-grace-ms must be >= 0, got " + snapshotRetireGraceMillis);
+        }
         try {
             // Fail fast on a configured value so large the ms→ns conversion would overflow long
             // (a partial overflow could otherwise silently wrap to a small positive window).
             Math.multiplyExact(snapshotReuseWindowMillis, 1_000_000L);
+            Math.multiplyExact(snapshotRetireGraceMillis, 1_000_000L);
         } catch (ArithmeticException e) {
             throw new IllegalArgumentException(
-                    "cqlite.snapshot-reuse-window-ms is too large (ns overflow), got " + snapshotReuseWindowMillis);
+                    "cqlite.snapshot-reuse-window-ms / snapshot-retire-grace-ms is too large (ns overflow), got "
+                            + snapshotReuseWindowMillis + " / " + snapshotRetireGraceMillis);
         }
         requireRootPerNodeBase(sidecarUri);
     }
@@ -108,6 +143,12 @@ public record CqliteFlightConfig(
         // Overflow is rejected at construction (see the compact constructor), so this is safe;
         // multiplyExact keeps it fail-fast rather than silently wrapping if that ever changes.
         return Math.multiplyExact(snapshotReuseWindowMillis, 1_000_000L);
+    }
+
+    /** The superseded-window retire grace period in nanoseconds (the {@link SnapshotManager} unit). */
+    public long snapshotRetireGraceNanos() {
+        // Overflow is rejected at construction (see the compact constructor).
+        return Math.multiplyExact(snapshotRetireGraceMillis, 1_000_000L);
     }
 
     /**
@@ -202,9 +243,12 @@ public record CqliteFlightConfig(
         long reuseWindowMs = config.containsKey("cqlite.snapshot-reuse-window-ms")
                 ? Long.parseLong(config.get("cqlite.snapshot-reuse-window-ms"))
                 : DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS;
+        long retireGraceMs = config.containsKey("cqlite.snapshot-retire-grace-ms")
+                ? Long.parseLong(config.get("cqlite.snapshot-retire-grace-ms"))
+                : DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS;
         return new CqliteFlightConfig(
                 URI.create(sidecar), port, dc, policy, ratio, statsTimeoutMs, readMode, snapshotTtl,
-                reuseWindowMs);
+                reuseWindowMs, retireGraceMs);
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
@@ -29,7 +29,8 @@ public class CqliteFlightConnector implements Connector {
         // + port (uniform across the hostNetwork Sidecar DaemonSet) and the split host.
         this.snapshots = new SnapshotManager(
                 HostSnapshotApis.fromBaseUri(config.sidecarUri()), config.readMode(), config.snapshotTtl(),
-                config.snapshotReuseWindowNanos(), new SnapshotManager.SystemClock());
+                config.snapshotReuseWindowNanos(), config.snapshotRetireGraceNanos(),
+                new SnapshotManager.SystemClock());
         // Fail fast at catalog load if arrow-java's off-heap memory init is broken by a missing JVM
         // flag (issues #2193, #2290) — otherwise every do_get dies far downstream with a cryptic
         // "Failed to read message". Runs before the first RootAllocator (the earliest Arrow touch)

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
@@ -28,7 +28,8 @@ public class CqliteFlightConnector implements Connector {
         // the same registry. Each host's Sidecar is derived from the configured URI's scheme
         // + port (uniform across the hostNetwork Sidecar DaemonSet) and the split host.
         this.snapshots = new SnapshotManager(
-                HostSnapshotApis.fromBaseUri(config.sidecarUri()), config.readMode(), config.snapshotTtl());
+                HostSnapshotApis.fromBaseUri(config.sidecarUri()), config.readMode(), config.snapshotTtl(),
+                config.snapshotReuseWindowNanos(), new SnapshotManager.SystemClock());
         // Fail fast at catalog load if arrow-java's off-heap memory init is broken by a missing JVM
         // flag (issues #2193, #2290) — otherwise every do_get dies far downstream with a cryptic
         // "Failed to read message". Runs before the first RootAllocator (the earliest Arrow touch)
@@ -46,7 +47,7 @@ public class CqliteFlightConnector implements Connector {
 
     @Override
     public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle) {
-        return new CqliteFlightMetadata(config, sidecar, flight, snapshots);
+        return new CqliteFlightMetadata(config, sidecar, flight);
     }
 
     @Override
@@ -61,6 +62,10 @@ public class CqliteFlightConnector implements Connector {
 
     @Override
     public void shutdown() {
+        // Retire every live reused snapshot (issue #2356): a reused snapshot outlives the query
+        // that created it, so retirement is not per-query — the connector releases them at
+        // shutdown (the Sidecar TTL backstop covers a crash/miss).
+        snapshots.retireAll();
         allocator.close();
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -59,7 +59,6 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
     private final CqliteFlightConfig config;
     private final SidecarClient sidecar;
     private final CqliteFlightClient flight;
-    private final SnapshotManager snapshots;
 
     /**
      * Tables for which the "hiding unsupported-type columns" warning has already
@@ -90,28 +89,23 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             new ConcurrentHashMap<>();
 
     public CqliteFlightMetadata(CqliteFlightConfig config, SidecarClient sidecar, CqliteFlightClient flight) {
-        this(config, sidecar, flight, null);
-    }
-
-    public CqliteFlightMetadata(
-            CqliteFlightConfig config, SidecarClient sidecar, CqliteFlightClient flight, SnapshotManager snapshots) {
         this.config = config;
         this.sidecar = sidecar;
         this.flight = flight;
-        this.snapshots = snapshots;
     }
 
     /**
-     * Query teardown (issue #2105): best-effort delete any per-query Sidecar snapshot this
-     * query created. Trino calls this once when the query finishes (success or failure), so
-     * it is the lifecycle counterpart to the split manager's create. A miss is covered by
-     * the snapshot's Sidecar-side TTL backstop.
+     * Query teardown. Under snapshot REUSE (issue #2356/#2306) a snapshot is shared across queries
+     * within a freshness window, so it must OUTLIVE the query that created it — per-query cleanup
+     * would defeat reuse (and re-flush on the next query). Retirement is therefore NOT per-query:
+     * a superseded window is retired when a fresh one replaces it (see {@code SnapshotManager
+     * .resolveWindow}/{@code invalidate}), the connector retires all live windows at shutdown
+     * ({@code SnapshotManager.retireAll}), and a Sidecar-side TTL backstop reclaims any miss. This
+     * hook is intentionally a no-op.
      */
     @Override
     public void cleanupQuery(ConnectorSession session) {
-        if (snapshots != null) {
-            snapshots.cleanup(session.getQueryId());
-        }
+        // Intentionally empty — see javadoc (reuse: snapshots outlive the query, #2356/#2306).
     }
 
     @Override

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -63,8 +63,13 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         // Fails closed — a create error on a PRIMARY host propagates (naming host + snapshot)
         // and the query fails; that host must have the snapshot, no failover is possible without it.
         Set<String> primaryHosts = distinctReplicaHosts(replicas, config.localDatacenter());
-        Optional<String> snapshot =
-                snapshots.snapshotFor(handle.keyspace(), handle.table(), primaryHosts);
+        // Resolve the reuse window ONCE and thread it into availableHosts below, so the ticket name
+        // and the per-fallback-host availability creation operate on the EXACT same window even if
+        // the freshness window would otherwise roll between the two calls (issue #2356 roborev,
+        // double-resolve race).
+        Optional<SnapshotManager.Window> window =
+                snapshots.resolveSnapshot(handle.keyspace(), handle.table(), primaryHosts);
+        Optional<String> snapshot = window.map(SnapshotManager.Window::name);
         // Availability failover (issue #2241): a fallback host is only usable if IT ALSO has the
         // snapshot. Roborev on #2241: restricting to `primaryHosts` here would only ever admit a
         // fallback that happens to be some OTHER range's primary — a fallback-only host (never a
@@ -75,8 +80,8 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         // succeeded. Best-effort here is safe: every host in `primaryHosts` is already required
         // above (fail-closed); only the EXTRA fallback-only hosts can be silently excluded, and a
         // split simply won't list an excluded host as a fallback — never a silent partial result.
-        Set<String> availableHosts = snapshot.isPresent()
-                ? snapshots.availableHosts(handle.keyspace(), handle.table(),
+        Set<String> availableHosts = window.isPresent()
+                ? snapshots.availableHosts(window.get(), handle.keyspace(), handle.table(),
                         allReplicaHosts(replicas, config.localDatacenter()))
                 : Set.of();
         List<CqliteFlightSplit> ranges = buildSplits(

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -64,7 +64,7 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         // and the query fails; that host must have the snapshot, no failover is possible without it.
         Set<String> primaryHosts = distinctReplicaHosts(replicas, config.localDatacenter());
         Optional<String> snapshot =
-                snapshots.snapshotFor(session.getQueryId(), handle.keyspace(), handle.table(), primaryHosts);
+                snapshots.snapshotFor(handle.keyspace(), handle.table(), primaryHosts);
         // Availability failover (issue #2241): a fallback host is only usable if IT ALSO has the
         // snapshot. Roborev on #2241: restricting to `primaryHosts` here would only ever admit a
         // fallback that happens to be some OTHER range's primary — a fallback-only host (never a
@@ -76,7 +76,7 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         // above (fail-closed); only the EXTRA fallback-only hosts can be silently excluded, and a
         // split simply won't list an excluded host as a fallback — never a silent partial result.
         Set<String> availableHosts = snapshot.isPresent()
-                ? snapshots.availableHosts(session.getQueryId(), handle.keyspace(), handle.table(),
+                ? snapshots.availableHosts(handle.keyspace(), handle.table(),
                         allReplicaHosts(replicas, config.localDatacenter()))
                 : Set.of();
         List<CqliteFlightSplit> ranges = buildSplits(

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -12,116 +12,212 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /**
- * Owns the per-query Sidecar snapshot lifecycle (issues #2105, #2227). One instance is
- * shared by the split manager (which creates the snapshot at split-planning time and names
- * it in every ticket) and the metadata (whose {@code cleanupQuery} best-effort deletes it
- * at query end).
+ * Owns the Sidecar snapshot lifecycle (issues #2105, #2227, #2356, #2306). One instance is
+ * shared by the split manager (which resolves the snapshot at split-planning time and names
+ * it in every ticket) and the metadata.
  *
- * <h2>Design: per-query snapshot named {@code cqlite-<queryId>}, created on EVERY replica host</h2>
- * <ul>
- *   <li><b>Create</b> at split planning ({@link CqliteFlightSplitManager#getSplits}), once
- *       per (query, host, keyspace, table) — memoized so re-planning never double-PUTs.
- *       A Sidecar snapshot {@code PUT} is instance-local (issue #2227): it only creates the
- *       snapshot on the node fronting that one Sidecar. Because the scan's splits fan out
- *       across every replica host, the snapshot must be created on each host's own Sidecar
- *       (via {@link HostSnapshotApis}); otherwise a split on any other host reads a
- *       non-existent directory and fails NotFound. Every split names the same snapshot, so
- *       the whole scan reads one immutable file set per host while Cassandra compacts
- *       underneath.</li>
- *   <li><b>Fail closed</b> in {@link ReadMode#SNAPSHOT}: if creation errors on ANY host we
- *       propagate an actionable error naming the host + snapshot and the query fails. We
- *       never silently fall back to a live read — a silent fallback would hand back a
- *       compaction-racing result the operator asked to avoid, and a NotFound on a
- *       not-created host would be an opaque failure.</li>
- *   <li><b>Clean up</b> best-effort at query end ({@link #cleanup}) on each host the snapshot
- *       was created on; a failed delete is logged, not fatal. A Sidecar-side TTL (see
- *       {@link CqliteFlightConfig#snapshotTtl}) is the backstop so a coordinator crash
- *       between create and cleanup can't leak the snapshot permanently.</li>
- * </ul>
+ * <h2>Snapshot REUSE per {@code (keyspace, table)} within a freshness window (#2356/#2306)</h2>
+ *
+ * Instead of one snapshot per {@code queryId} — which cleared the prior dir every query and so
+ * defeated the flight warm-handle investment (#2356) and flushed the memtable per query (#2306,
+ * flush-on-snapshot is BY DESIGN per #2305) — a single snapshot is REUSED for a
+ * {@code (keyspace, table)} across queries while it is fresh. The snapshot is named
+ * {@code cqlite-<ks>-<table>-<epoch>} where {@code epoch} identifies the freshness window. N
+ * queries in one window pay ONE create fan-out (→ one flush per host), not N, and the resolved
+ * snapshot PATH stays stable so the flight server's warm readers stay warm with zero rebind
+ * churn within the window (see {@code cqlite-flight}'s warm registry / {@code rebind_hits_total}).
+ *
+ * <p>A reused window is invalidated — forcing a fresh create on the next query — when the FIRST
+ * of these occurs (design §C):
+ * <ol>
+ *   <li><b>Window expiry</b> — the freshness window elapses on the {@link Clock} seam. The clock
+ *       is injectable so tests pin invalidation deterministically (never {@code System
+ *       .currentTimeMillis}, per the #1742 pinned-{@code now} discipline).</li>
+ *   <li><b>Generation-set change</b> — the observed live SSTable generation-set fingerprint for
+ *       the table changed since the snapshot was taken (a flush/compaction). Authoritative, never
+ *       guessed (#28). The fingerprint is passed by the caller; {@link #NO_GENERATION} means
+ *       "not observed" and disables this lever (window + explicit refresh still apply).</li>
+ *   <li><b>Explicit refresh</b> — {@link #invalidate(String, String)} (the {@code
+ *       Database::refresh()} analog).</li>
+ * </ol>
+ * A reused snapshot is ALWAYS a valid immutable Cassandra point-in-time (snapshots are hardlinks);
+ * invalidation is a FRESHNESS lever, not a correctness requirement. The staleness bound is thus
+ * {@code min(window, time-since-last-generation-change)}, documented in the connector docs.
+ *
+ * <p><b>Per-host, fail-closed create model preserved (#2227).</b> A Sidecar snapshot PUT is
+ * instance-local, so the snapshot is created on EVERY replica host a split will read, memoized
+ * per {@code (window, host)}. {@link #snapshotFor} fails closed on the first host whose create
+ * errors (naming host + snapshot); {@link #availableHosts} is best-effort for optional fallback
+ * hosts. Superseded windows are retired best-effort ({@link #retire}); a Sidecar-side TTL
+ * ({@link CqliteFlightConfig#snapshotTtl}) stays the leak backstop for the live window and crash
+ * cases.
  *
  * <p>In {@link ReadMode#LIVE} this manager is inert: {@link #snapshotFor} returns empty
- * (ticket {@code snapshot=null}, the pre-#2105 behavior) and no Sidecar calls are made.
+ * (ticket {@code snapshot=null}), no reuse cache entry is created, and no Sidecar calls are made.
  */
 public final class SnapshotManager {
     private static final Logger LOG = Logger.getLogger(SnapshotManager.class.getName());
 
-    /** Trino query ids are safe already; strip anything outside the Sidecar-safe charset. */
+    /** Strip anything outside the Sidecar-safe charset from a name component. */
     private static final Pattern UNSAFE = Pattern.compile("[^A-Za-z0-9._-]");
+
+    /**
+     * Sentinel generation fingerprint meaning "the caller did not observe the generation set".
+     * When passed, the generation-set-change invalidation lever is disabled (window + explicit
+     * refresh still apply). The flight server does not yet expose a generation fingerprint, so
+     * the split-manager call path uses this; the fingerprint-taking overload exists so a future
+     * server-exposed fingerprint (design §C.2) wires in without an API change.
+     */
+    public static final long NO_GENERATION = Long.MIN_VALUE;
 
     private final HostSnapshotApis sidecars;
     private final ReadMode readMode;
     private final Optional<String> ttl;
+    private final long reuseWindowNanos;
+    private final Clock clock;
 
-    /** queryId → ((host, keyspace, table) → snapshotName) created for that query. */
-    private final Map<String, Map<SnapshotKey, CompletableFuture<String>>> created = new ConcurrentHashMap<>();
+    /** The current reused snapshot window per {@code (keyspace, table)}. */
+    private final Map<TableRef, Window> windows = new ConcurrentHashMap<>();
+    /** Monotonic freshness-window epoch counter per {@code (keyspace, table)}. */
+    private final Map<TableRef, AtomicLong> epochs = new ConcurrentHashMap<>();
 
-    /** One created (or in-flight) snapshot: which Sidecar host, and which table. */
-    private record SnapshotKey(String host, String keyspace, String table) {}
+    /** Snapshot create fan-outs performed (one per freshness window) — the #2306 flush proxy. */
+    private final AtomicLong snapshotCreationsTotal = new AtomicLong();
+    /** Queries served by an already-live (reused) snapshot — the reuse-factor numerator. */
+    private final AtomicLong snapshotReuseHitsTotal = new AtomicLong();
 
-    public SnapshotManager(HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl) {
+    /** A logical clock seam so tests pin window timing deterministically (no wall-clock). */
+    public interface Clock {
+        /** A monotonically non-decreasing nanosecond reading (never wall-clock in tests). */
+        long nanoTime();
+    }
+
+    /** Production clock: {@link System#nanoTime()}. */
+    public static final class SystemClock implements Clock {
+        @Override
+        public long nanoTime() {
+            return System.nanoTime();
+        }
+    }
+
+    /** The logical-table half of the reuse cache key. */
+    private record TableRef(String keyspace, String table) {}
+
+    /**
+     * One reused snapshot window: its name, the freshness epoch, when it was taken (on the
+     * injectable clock), the generation fingerprint it was taken over, and the per-host create
+     * memoization (create at most once per host for this window's snapshot).
+     */
+    private static final class Window {
+        final String name;
+        final long epoch;
+        final long createdNanos;
+        final long generationFingerprint;
+        final Map<String, CompletableFuture<String>> hostCreates = new ConcurrentHashMap<>();
+
+        Window(String name, long epoch, long createdNanos, long generationFingerprint) {
+            this.name = name;
+            this.epoch = epoch;
+            this.createdNanos = createdNanos;
+            this.generationFingerprint = generationFingerprint;
+        }
+    }
+
+    /**
+     * Full constructor (production + tests). {@code reuseWindowNanos <= 0} disables reuse (every
+     * query gets a fresh window — the pre-#2356 per-query cadence, without the queryId naming).
+     */
+    public SnapshotManager(
+            HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl,
+            long reuseWindowNanos, Clock clock) {
         this.sidecars = sidecars;
         this.readMode = readMode;
         this.ttl = ttl;
+        this.reuseWindowNanos = Math.max(0L, reuseWindowNanos);
+        this.clock = clock;
     }
 
     /**
-     * The snapshot name to put in this scan's tickets, creating the snapshot on the Sidecar
-     * of every replica host a split will read (issue #2227). Fails closed on the first host
-     * whose create errors, naming that host + snapshot.
+     * Convenience constructor: the default freshness window on the production {@link SystemClock}.
+     * Used where a config-driven window is not threaded through (and by tests that do not exercise
+     * window timing).
+     */
+    public SnapshotManager(HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl) {
+        this(sidecars, readMode, ttl,
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_NANOS, new SystemClock());
+    }
+
+    /** Snapshot create fan-outs performed so far (one per freshness window). */
+    public long snapshotCreationsTotal() {
+        return snapshotCreationsTotal.get();
+    }
+
+    /** Queries served by an already-live reused snapshot so far. */
+    public long snapshotReuseHitsTotal() {
+        return snapshotReuseHitsTotal.get();
+    }
+
+    /**
+     * The snapshot name to put in this scan's tickets, reusing the current fresh {@code (keyspace,
+     * table)} snapshot when possible (design §B, #2356/#2306) and otherwise creating a fresh one
+     * on the Sidecar of every replica host a split will read (#2227). Fails closed on the first
+     * host whose create errors, naming that host + snapshot.
      *
      * @param hosts every distinct replica host the scan's splits will read
-     * @return {@link Optional#empty()} in {@link ReadMode#LIVE}; otherwise the created
-     *         snapshot's name ({@code cqlite-<queryId>}).
+     * @return {@link Optional#empty()} in {@link ReadMode#LIVE}; otherwise the reused/created
+     *         snapshot's name ({@code cqlite-<ks>-<table>-<epoch>}).
      * @throws SidecarClient.SidecarException if creation fails on any host (fail closed)
      */
-    public Optional<String> snapshotFor(String queryId, String keyspace, String table, Collection<String> hosts) {
+    public Optional<String> snapshotFor(String keyspace, String table, Collection<String> hosts) {
+        return snapshotFor(keyspace, table, hosts, NO_GENERATION);
+    }
+
+    /**
+     * As {@link #snapshotFor(String, String, Collection)}, additionally invalidating a reused
+     * snapshot whose {@code generationFingerprint} differs from the current live generation set
+     * (design §C.2). {@link #NO_GENERATION} disables that lever.
+     */
+    public Optional<String> snapshotFor(
+            String keyspace, String table, Collection<String> hosts, long generationFingerprint) {
         if (readMode == ReadMode.LIVE) {
             return Optional.empty();
         }
-        String name = snapshotName(queryId);
-        Map<SnapshotKey, CompletableFuture<String>> forQuery =
-                created.computeIfAbsent(queryId, q -> new ConcurrentHashMap<>());
+        Window window = resolveWindow(new TableRef(keyspace, table), generationFingerprint, true);
         for (String host : hosts) {
-            createOnHost(forQuery, new SnapshotKey(host, keyspace, table), name);
+            createOnHost(window, host, keyspace, table);
         }
-        return Optional.of(name);
+        return Optional.of(window.name);
     }
 
     /**
-     * Best-effort per-host snapshot availability for a candidate host set (issue #2241):
-     * attempts creation (the same memoized per-(query, host, keyspace, table) fan-out as
-     * {@link #snapshotFor}, so a host already created there — e.g. a split's primary — resolves
-     * instantly with no duplicate PUT) on every host in {@code hosts}, but — unlike {@link
-     * #snapshotFor} — does NOT fail closed on an individual host's creation failure. A host
-     * whose creation fails is logged and excluded from the returned set; the caller ({@link
-     * CqliteFlightSplitManager#getSplits}) uses this to restrict availability-failover fallback
-     * lists to hosts that actually have the snapshot, without failing the whole query over an
-     * optional fallback host (a required PRIMARY host still fails closed via {@link
-     * #snapshotFor}).
+     * Best-effort per-host snapshot availability for a candidate host set (#2241): ensures the
+     * CURRENT reused window's snapshot exists on every host in {@code hosts} (the same memoized
+     * per-(window, host) create as {@link #snapshotFor}, so a host already created there resolves
+     * with no duplicate PUT), but — unlike {@link #snapshotFor} — does NOT fail closed on an
+     * individual host's creation failure (a failed host is logged and excluded). Counters are NOT
+     * touched here: this is part of the SAME query's planning as the preceding {@link #snapshotFor}
+     * (which already counted the create/reuse), so it reuses that window without double-counting.
      *
-     * <p>In {@link ReadMode#LIVE} this is a no-op returning every candidate host unchanged
-     * (fallback restriction is meaningful only in snapshot mode).
+     * <p>In {@link ReadMode#LIVE} this is a no-op returning every candidate host unchanged.
      *
      * @param hosts every candidate replica host to check/create snapshot availability for
      * @return the subset of {@code hosts} that have (or now have) the snapshot
      */
-    public Set<String> availableHosts(String queryId, String keyspace, String table, Collection<String> hosts) {
+    public Set<String> availableHosts(String keyspace, String table, Collection<String> hosts) {
         if (readMode == ReadMode.LIVE) {
             return Set.copyOf(hosts);
         }
-        String name = snapshotName(queryId);
-        Map<SnapshotKey, CompletableFuture<String>> forQuery =
-                created.computeIfAbsent(queryId, q -> new ConcurrentHashMap<>());
+        Window window = resolveWindow(new TableRef(keyspace, table), NO_GENERATION, false);
         Set<String> available = new LinkedHashSet<>();
         for (String host : hosts) {
-            SnapshotKey key = new SnapshotKey(host, keyspace, table);
             try {
-                createOnHost(forQuery, key, name);
+                createOnHost(window, host, keyspace, table);
                 available.add(host);
             } catch (RuntimeException e) {
                 LOG.log(Level.WARNING,
@@ -134,31 +230,102 @@ public final class SnapshotManager {
     }
 
     /**
-     * Create the snapshot on one host, once per (query, host, keyspace, table).
-     *
-     * <p>Per-key-future memoization: the PUT happens at most once even if Trino re-plans the
-     * same scan — WITHOUT ever holding a ConcurrentHashMap bin lock across the (up to 30s)
-     * network call. We insert an empty future under the bin lock (cheap); only the thread
-     * that won the insert performs the Sidecar PUT OUTSIDE the lock, then completes the
-     * future. Every other caller joins that future's result.
+     * Force a fresh snapshot for {@code (keyspace, table)} on the next query (design §C.3, the
+     * {@code Database::refresh()} analog): drop the current reused window and retire its snapshots.
      */
-    private void createOnHost(Map<SnapshotKey, CompletableFuture<String>> forQuery, SnapshotKey key, String name) {
+    public void invalidate(String keyspace, String table) {
+        TableRef ref = new TableRef(keyspace, table);
+        Window removed = windows.remove(ref);
+        if (removed != null) {
+            retire(removed, ref);
+        }
+    }
+
+    /**
+     * Retire every live reused window (connector shutdown): best-effort clear of each window's
+     * snapshots on every host it was created on. The Sidecar TTL backstop covers any miss.
+     */
+    public void retireAll() {
+        for (Map.Entry<TableRef, Window> e : windows.entrySet()) {
+            Window w = windows.remove(e.getKey());
+            if (w != null) {
+                retire(w, e.getKey());
+            }
+        }
+    }
+
+    /**
+     * Resolve the current reused window for {@code ref}, reusing an existing fresh window or
+     * creating a new one (bumping the epoch) atomically. When {@code countStats}, records exactly
+     * one {@link #snapshotReuseHitsTotal} (reuse) or {@link #snapshotCreationsTotal} (create). A
+     * superseded window is retired best-effort OUTSIDE the map-compute critical section.
+     */
+    private Window resolveWindow(TableRef ref, long generationFingerprint, boolean countStats) {
+        long now = clock.nanoTime();
+        Window[] superseded = {null};
+        boolean[] reused = {false};
+        Window window = windows.compute(ref, (k, existing) -> {
+            if (existing != null && isFresh(existing, generationFingerprint, now)) {
+                reused[0] = true;
+                return existing;
+            }
+            if (existing != null) {
+                superseded[0] = existing;
+            }
+            long epoch = epochs.computeIfAbsent(k, r -> new AtomicLong()).getAndIncrement();
+            return new Window(nameFor(k, epoch), epoch, now, generationFingerprint);
+        });
+        if (countStats) {
+            if (reused[0]) {
+                snapshotReuseHitsTotal.incrementAndGet();
+            } else {
+                snapshotCreationsTotal.incrementAndGet();
+            }
+        }
+        if (superseded[0] != null) {
+            retire(superseded[0], ref);
+        }
+        return window;
+    }
+
+    /**
+     * Whether {@code w} is still reusable at {@code now}: within the freshness window AND (when a
+     * generation fingerprint was observed) taken over the same generation set. {@code now -
+     * createdNanos} uses long subtraction so a {@link System#nanoTime()} origin never trips it.
+     */
+    private boolean isFresh(Window w, long generationFingerprint, long now) {
+        if (now - w.createdNanos >= reuseWindowNanos) {
+            return false;
+        }
+        return generationFingerprint == NO_GENERATION || w.generationFingerprint == generationFingerprint;
+    }
+
+    /**
+     * Create the snapshot on one host, once per {@code (window, host)}.
+     *
+     * <p>Per-host-future memoization: the PUT happens at most once per window even if Trino
+     * re-plans the same scan — WITHOUT ever holding a ConcurrentHashMap bin lock across the (up to
+     * 30s) network call. We insert an empty future under the bin lock (cheap); only the thread that
+     * won the insert performs the Sidecar PUT OUTSIDE the lock, then completes the future. Every
+     * other caller joins that future's result.
+     */
+    private void createOnHost(Window window, String host, String keyspace, String table) {
         CompletableFuture<String> mine = new CompletableFuture<>();
-        CompletableFuture<String> winner = forQuery.putIfAbsent(key, mine);
+        CompletableFuture<String> winner = window.hostCreates.putIfAbsent(host, mine);
         if (winner == null) {
             // We won: do the network I/O off-lock, then publish the result.
             try {
-                sidecars.forHost(key.host()).createSnapshot(key.keyspace(), key.table(), name, ttl);
+                sidecars.forHost(host).createSnapshot(keyspace, table, window.name, ttl);
             } catch (Throwable t) {
-                // Fail closed AND never leave an incomplete future behind (roborev, #2113):
-                // on ANY throw drop the future so a retry can recompute, and fail it so
-                // concurrent joiners unblock with the same error instead of blocking forever.
-                // cleanup therefore never sees (and never tries to delete) a snapshot that was
-                // never made. RuntimeExceptions are wrapped into an actionable error naming the
-                // host + snapshot (issue #2227); Errors and sneaky checked throwables keep their
-                // identity so liveness/error-propagation invariants hold (see SnapshotManagerTest).
-                forQuery.remove(key, mine);
-                Throwable toThrow = (t instanceof RuntimeException re) ? actionable(key, name, re) : t;
+                // Fail closed AND never leave an incomplete future behind (roborev, #2113): on ANY
+                // throw drop the future so a retry can recompute, and fail it so concurrent joiners
+                // unblock with the same error instead of blocking forever. RuntimeExceptions are
+                // wrapped into an actionable error naming the host + snapshot (#2227); Errors and
+                // sneaky checked throwables keep their identity so liveness/error-propagation
+                // invariants hold (see SnapshotManagerTest).
+                window.hostCreates.remove(host, mine);
+                Throwable toThrow = (t instanceof RuntimeException re)
+                        ? actionable(host, keyspace, table, window.name, re) : t;
                 mine.completeExceptionally(toThrow);
                 if (toThrow instanceof RuntimeException re) {
                     throw re;
@@ -168,12 +335,12 @@ public final class SnapshotManager {
                 }
                 throw new IllegalStateException("Unexpected checked throwable from createSnapshot", toThrow);
             }
-            mine.complete(name);
+            mine.complete(window.name);
             return;
         }
-        // Someone else is creating (or already created) it — adopt their result. If their
-        // create failed, join() rethrows the same failure here (still fail-closed), and the
-        // failing thread already removed the future so the next call recomputes.
+        // Someone else is creating (or already created) it — adopt their result. If their create
+        // failed, join() rethrows the same failure here (still fail-closed), and the failing thread
+        // already removed the future so the next call recomputes.
         try {
             winner.join();
         } catch (CompletionException e) {
@@ -189,55 +356,55 @@ public final class SnapshotManager {
     }
 
     /** Wrap a per-host create failure into a fail-closed error naming host + snapshot. */
-    private static SidecarClient.SidecarException actionable(SnapshotKey key, String name, RuntimeException cause) {
+    private static SidecarClient.SidecarException actionable(
+            String host, String keyspace, String table, String name, RuntimeException cause) {
         int status = (cause instanceof SidecarClient.SidecarException se) ? se.statusCode() : -1;
         return new SidecarClient.SidecarException(
-                "Failed to create snapshot '" + name + "' on replica host " + key.host()
-                        + " for " + key.keyspace() + "." + key.table()
+                "Failed to create snapshot '" + name + "' on replica host " + host
+                        + " for " + keyspace + "." + table
                         + " — snapshot read-mode fails closed: every replica host a split reads must have "
                         + "the snapshot (per-host creation, issue #2227). Cause: " + cause.getMessage(),
                 status, cause);
     }
 
     /**
-     * Best-effort delete of every snapshot created for {@code queryId}, on each host it was
-     * created on. Called from {@code ConnectorMetadata.cleanupQuery} at query teardown
-     * (success or failure). Individual delete failures are logged and swallowed — the TTL
-     * backstop covers a miss — but every (host, table) is attempted regardless of earlier
-     * failures.
+     * Best-effort delete of every snapshot a superseded/invalidated {@code window} created, on each
+     * host it was created on. Individual delete failures are logged and swallowed — the Sidecar TTL
+     * backstop covers a miss.
      */
-    public void cleanup(String queryId) {
-        Map<SnapshotKey, CompletableFuture<String>> forQuery = created.remove(queryId);
-        if (forQuery == null) {
-            return;
-        }
-        for (Map.Entry<SnapshotKey, CompletableFuture<String>> e : forQuery.entrySet()) {
-            SnapshotKey key = e.getKey();
+    private void retire(Window window, TableRef ref) {
+        for (Map.Entry<String, CompletableFuture<String>> e : window.hostCreates.entrySet()) {
+            String host = e.getKey();
             String name;
             try {
-                // Successful creates leave a completed future here; a create that failed
-                // already removed its own future, so anything still present resolves to a
-                // real snapshot name (join blocks only for a rare concurrent in-flight
-                // create, then returns it).
+                // Successful creates leave a completed future; a create that failed already removed
+                // its own future, so anything still present resolves to a real snapshot name.
                 name = e.getValue().join();
             } catch (RuntimeException ex) {
-                // A create that raced to failure: nothing was made, nothing to delete.
-                continue;
+                continue; // a create that raced to failure: nothing was made, nothing to delete.
             }
             try {
-                sidecars.forHost(key.host()).clearSnapshot(key.keyspace(), key.table(), name);
+                sidecars.forHost(host).clearSnapshot(ref.keyspace(), ref.table(), name);
             } catch (RuntimeException ex) {
                 LOG.log(Level.WARNING,
-                        () -> "Best-effort snapshot cleanup failed for " + key.keyspace() + "." + key.table()
-                                + " on host " + key.host() + " snapshot=" + name
+                        () -> "Best-effort snapshot retirement failed for " + ref.keyspace() + "." + ref.table()
+                                + " on host " + host + " snapshot=" + name
                                 + " (TTL backstop will reclaim it): " + ex.getMessage());
             }
         }
     }
 
-    /** The deterministic per-query snapshot name. */
-    static String snapshotName(String queryId) {
-        String safe = UNSAFE.matcher(queryId).replaceAll("_").toLowerCase(Locale.ROOT);
-        return "cqlite-" + safe;
+    /** The reused-window snapshot name {@code cqlite-<ks>-<table>-<epoch>}. */
+    static String nameFor(String keyspace, String table, long epoch) {
+        return "cqlite-" + sanitize(keyspace) + "-" + sanitize(table) + "-" + epoch;
+    }
+
+    private static String nameFor(TableRef ref, long epoch) {
+        return nameFor(ref.keyspace(), ref.table(), epoch);
+    }
+
+    /** Strip unsafe chars and lowercase a name component for the Sidecar-safe charset. */
+    static String sanitize(String component) {
+        return UNSAFE.matcher(component).replaceAll("_").toLowerCase(Locale.ROOT);
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -8,10 +8,12 @@ import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -54,11 +56,24 @@ import java.util.regex.Pattern;
  * instance-local, so the snapshot is created on EVERY replica host a split will read, memoized
  * per {@code (window, host)}. {@link #snapshotFor} fails closed on the first host whose create
  * errors (naming host + snapshot); {@link #availableHosts} is best-effort for optional fallback
- * hosts. A SUPERSEDED window is NOT actively retired (issue #2356 roborev, retire-race): a
+ * hosts.
+ *
+ * <p><b>Bounded retirement of superseded windows (issue #2356 roborev, resource retention).</b> A
+ * window is NOT deleted the instant it is superseded (window expiry / generation change): a
  * long-running query may still be reading its snapshot when a later query rolls to a fresh window,
- * so superseded windows are reclaimed solely by the Sidecar-side TTL backstop
- * ({@link CqliteFlightConfig#snapshotTtl}). Active retirement ({@link #retire}) happens ONLY on
- * explicit {@link #invalidate} and {@link #retireAll} (shutdown).
+ * and deleting the hardlink set out from under an in-flight read is the retire-race. But it must
+ * ALSO not leak until the ~6h Sidecar TTL backstop — a hot table with a 3s window would then
+ * accumulate on the order of {@code ttl / window} live snapshot dirs (each a full hardlink set) per
+ * table per host. So a superseded window is enqueued and actively retired ({@link #retire}) after a
+ * <b>grace period</b> ({@code retireGraceNanos}) configured to safely exceed the longest Trino query
+ * (see {@link CqliteFlightConfig#DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS}): once the grace elapses no
+ * query that resolved that window can still be planning/reading it, so the delete is race-free.
+ * Retirement is swept lazily on the next {@link #resolveSnapshot} (no background thread) and bounds
+ * steady-state retained superseded dirs to roughly {@code grace / window} per table per host, well
+ * under the TTL. Explicit {@link #invalidate} still retires the current window immediately (the
+ * {@code Database::refresh()} analog) and {@link #retireAll} (shutdown) drains both the live windows
+ * and the pending-retire queue; the Sidecar-side TTL backstop ({@link CqliteFlightConfig#snapshotTtl})
+ * still covers a coordinator crash between supersede and sweep.
  *
  * <p>In {@link ReadMode#LIVE} this manager is inert: {@link #snapshotFor} returns empty
  * (ticket {@code snapshot=null}), no reuse cache entry is created, and no Sidecar calls are made.
@@ -82,12 +97,24 @@ public final class SnapshotManager {
     private final ReadMode readMode;
     private final Optional<String> ttl;
     private final long reuseWindowNanos;
+    private final long retireGraceNanos;
     private final Clock clock;
 
     /** The current reused snapshot window per {@code (keyspace, table)}. */
     private final Map<TableRef, Window> windows = new ConcurrentHashMap<>();
     /** Monotonic freshness-window epoch counter per {@code (keyspace, table)}. */
     private final Map<TableRef, AtomicLong> epochs = new ConcurrentHashMap<>();
+    /**
+     * Superseded windows awaiting grace-period retirement, oldest first (the clock is
+     * non-decreasing and windows are enqueued in supersede order, so peek() is the oldest).
+     */
+    private final Queue<PendingRetire> pendingRetire = new ConcurrentLinkedQueue<>();
+
+    /** A superseded window and the clock reading at which it was superseded (grace starts here). */
+    private record PendingRetire(TableRef ref, Window window, long supersededNanos) {}
+
+    /** The outcome of resolving a reuse window: the window plus whether it was reused (vs created). */
+    private record Resolved(Window window, boolean reused) {}
 
     /** Snapshot create fan-outs performed (one per freshness window) — the #2306 flush proxy. */
     private final AtomicLong snapshotCreationsTotal = new AtomicLong();
@@ -139,25 +166,41 @@ public final class SnapshotManager {
     /**
      * Full constructor (production + tests). {@code reuseWindowNanos <= 0} disables reuse (every
      * query gets a fresh window — the pre-#2356 per-query cadence, without the queryId naming).
+     * {@code retireGraceNanos} is the delay after a window is superseded before it is actively
+     * retired (issue #2356 roborev, bounded retention); it must safely exceed the longest query so
+     * an in-flight read never loses its snapshot.
      */
     public SnapshotManager(
             HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl,
-            long reuseWindowNanos, Clock clock) {
+            long reuseWindowNanos, long retireGraceNanos, Clock clock) {
         this.sidecars = sidecars;
         this.readMode = readMode;
         this.ttl = ttl;
         this.reuseWindowNanos = Math.max(0L, reuseWindowNanos);
+        this.retireGraceNanos = Math.max(0L, retireGraceNanos);
         this.clock = clock;
     }
 
     /**
-     * Convenience constructor: the default freshness window on the production {@link SystemClock}.
-     * Used where a config-driven window is not threaded through (and by tests that do not exercise
-     * window timing).
+     * Constructor without an explicit retire-grace: uses the default grace
+     * ({@link CqliteFlightConfig#DEFAULT_SNAPSHOT_RETIRE_GRACE_NANOS}). Kept for existing call sites
+     * that do not pin grace-period retirement timing.
+     */
+    public SnapshotManager(
+            HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl,
+            long reuseWindowNanos, Clock clock) {
+        this(sidecars, readMode, ttl, reuseWindowNanos,
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_NANOS, clock);
+    }
+
+    /**
+     * Convenience constructor: the default freshness window + retire grace on the production
+     * {@link SystemClock}. Used where config-driven timing is not threaded through (and by tests
+     * that do not exercise window/grace timing).
      */
     public SnapshotManager(HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl) {
-        this(sidecars, readMode, ttl,
-                CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_NANOS, new SystemClock());
+        this(sidecars, readMode, ttl, CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_NANOS,
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_NANOS, new SystemClock());
     }
 
     /** Snapshot create fan-outs performed so far (one per freshness window). */
@@ -214,9 +257,30 @@ public final class SnapshotManager {
         if (readMode == ReadMode.LIVE) {
             return Optional.empty();
         }
-        Window window = resolveWindow(new TableRef(keyspace, table), generationFingerprint, true);
-        for (String host : hosts) {
-            createOnHost(window, host, keyspace, table);
+        TableRef ref = new TableRef(keyspace, table);
+        Resolved resolved = resolveWindow(ref, generationFingerprint);
+        Window window = resolved.window();
+        try {
+            for (String host : hosts) {
+                createOnHost(window, host, keyspace, table);
+            }
+        } catch (RuntimeException e) {
+            // Roborev (issue #2356, half-created window): a fail-closed fan-out must not leave a
+            // freshly-created window cached as "fresh" (a later query would reuse a snapshot that
+            // never fully materialized) nor count a create/flush that did not complete. Roll back
+            // the fresh window so the next query recomputes; a REUSED window is left intact (a
+            // transient host error on an added fallback host must not nuke a live shared window).
+            if (!resolved.reused()) {
+                windows.remove(ref, window);
+            }
+            throw e;
+        }
+        // Count (the #2306 flush proxy) only once the full fan-out succeeded: exactly one reuse hit
+        // or one create per resolved window.
+        if (resolved.reused()) {
+            snapshotReuseHitsTotal.incrementAndGet();
+        } else {
+            snapshotCreationsTotal.incrementAndGet();
         }
         return Optional.of(window);
     }
@@ -269,8 +333,9 @@ public final class SnapshotManager {
     }
 
     /**
-     * Retire every live reused window (connector shutdown): best-effort clear of each window's
-     * snapshots on every host it was created on. The Sidecar TTL backstop covers any miss.
+     * Retire every live reused window AND every superseded window still awaiting grace-period
+     * retirement (connector shutdown): best-effort clear of each window's snapshots on every host it
+     * was created on. The Sidecar TTL backstop covers any miss.
      */
     public void retireAll() {
         for (Map.Entry<TableRef, Window> e : windows.entrySet()) {
@@ -279,41 +344,64 @@ public final class SnapshotManager {
                 retire(w, e.getKey());
             }
         }
+        PendingRetire pending;
+        while ((pending = pendingRetire.poll()) != null) {
+            retire(pending.window(), pending.ref());
+        }
     }
 
     /**
      * Resolve the current reused window for {@code ref}, reusing an existing fresh window or
-     * creating a new one (bumping the epoch) atomically. When {@code countStats}, records exactly
-     * one {@link #snapshotReuseHitsTotal} (reuse) or {@link #snapshotCreationsTotal} (create).
+     * creating a new one (bumping the epoch) atomically. Counting is done by the caller AFTER the
+     * per-host fan-out succeeds (issue #2356 roborev), not here.
      *
-     * <p><b>A superseded window is NOT retired here (issue #2356 roborev, retire-race).</b> A
-     * long-running query A can still be reading a window's snapshot (splits not yet opened, or a
-     * cold remote host) when a later query B rolls to a fresh window; actively deleting A's snapshot
-     * dir on supersede would break A's in-flight reads. Superseded windows are therefore reclaimed
-     * solely by the Sidecar-side TTL backstop ({@link CqliteFlightConfig#snapshotTtl}). Active
-     * retirement ({@link #retire}) happens ONLY on explicit {@link #invalidate} (the
-     * {@code Database::refresh()} analog) and {@link #retireAll} (shutdown), never as a side effect
-     * of rolling to a new window.
+     * <p><b>A superseded window is NOT retired on supersede (issue #2356 roborev, retire-race)</b> —
+     * a long-running query A can still be reading a window's snapshot (splits not yet opened, or a
+     * cold remote host) when a later query B rolls to a fresh window; deleting A's snapshot dir on
+     * supersede would break A's in-flight reads. Instead the superseded window is ENQUEUED with the
+     * supersede time and retired later by {@link #sweepRetireDue} once the grace period elapses
+     * (bounded retention, see the class javadoc). Each resolve also sweeps any now-due pending
+     * window. Immediate active retirement ({@link #retire}) still happens on explicit
+     * {@link #invalidate} (the {@code Database::refresh()} analog) and {@link #retireAll} (shutdown).
      */
-    private Window resolveWindow(TableRef ref, long generationFingerprint, boolean countStats) {
+    private Resolved resolveWindow(TableRef ref, long generationFingerprint) {
         long now = clock.nanoTime();
         boolean[] reused = {false};
+        Window[] superseded = {null};
         Window window = windows.compute(ref, (k, existing) -> {
             if (existing != null && isFresh(existing, generationFingerprint, now)) {
                 reused[0] = true;
                 return existing;
             }
+            if (existing != null) {
+                superseded[0] = existing;
+            }
             long epoch = epochs.computeIfAbsent(k, r -> new AtomicLong()).getAndIncrement();
             return new Window(nameFor(k, epoch), epoch, now, generationFingerprint);
         });
-        if (countStats) {
-            if (reused[0]) {
-                snapshotReuseHitsTotal.incrementAndGet();
-            } else {
-                snapshotCreationsTotal.incrementAndGet();
+        if (superseded[0] != null) {
+            pendingRetire.add(new PendingRetire(ref, superseded[0], now));
+        }
+        sweepRetireDue(now);
+        return new Resolved(window, reused[0]);
+    }
+
+    /**
+     * Retire every pending superseded window whose grace period has elapsed at {@code now}. The
+     * queue is ordered oldest-first (non-decreasing clock + supersede-order enqueue), so the first
+     * not-yet-due window ends the sweep. Concurrent sweeps race on {@link Queue#remove}; only the
+     * winner of the atomic remove performs the retire, so each window is retired at most once.
+     */
+    private void sweepRetireDue(long now) {
+        while (true) {
+            PendingRetire head = pendingRetire.peek();
+            if (head == null || now - head.supersededNanos() < retireGraceNanos) {
+                return;
+            }
+            if (pendingRetire.remove(head)) {
+                retire(head.window(), head.ref());
             }
         }
-        return window;
     }
 
     /**
@@ -396,10 +484,11 @@ public final class SnapshotManager {
     }
 
     /**
-     * Best-effort delete of every snapshot an EXPLICITLY-invalidated {@code window} created (via
-     * {@link #invalidate} or {@link #retireAll} only — never on supersede, see {@link #resolveWindow}),
-     * on each host it was created on. Individual delete failures are logged and swallowed — the
-     * Sidecar TTL backstop covers a miss.
+     * Best-effort delete of every snapshot {@code window} created, on each host it was created on.
+     * Called on explicit {@link #invalidate}, on {@link #retireAll} (shutdown), and on
+     * {@link #sweepRetireDue} once a superseded window's grace period elapses (issue #2356 roborev)
+     * — never the instant a window is superseded. Individual delete failures are logged and
+     * swallowed — the Sidecar TTL backstop covers a miss.
      */
     private void retire(Window window, TableRef ref) {
         for (Map.Entry<String, CompletableFuture<String>> e : window.hostCreates.entrySet()) {

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -54,9 +54,11 @@ import java.util.regex.Pattern;
  * instance-local, so the snapshot is created on EVERY replica host a split will read, memoized
  * per {@code (window, host)}. {@link #snapshotFor} fails closed on the first host whose create
  * errors (naming host + snapshot); {@link #availableHosts} is best-effort for optional fallback
- * hosts. Superseded windows are retired best-effort ({@link #retire}); a Sidecar-side TTL
- * ({@link CqliteFlightConfig#snapshotTtl}) stays the leak backstop for the live window and crash
- * cases.
+ * hosts. A SUPERSEDED window is NOT actively retired (issue #2356 roborev, retire-race): a
+ * long-running query may still be reading its snapshot when a later query rolls to a fresh window,
+ * so superseded windows are reclaimed solely by the Sidecar-side TTL backstop
+ * ({@link CqliteFlightConfig#snapshotTtl}). Active retirement ({@link #retire}) happens ONLY on
+ * explicit {@link #invalidate} and {@link #retireAll} (shutdown).
  *
  * <p>In {@link ReadMode#LIVE} this manager is inert: {@link #snapshotFor} returns empty
  * (ticket {@code snapshot=null}), no reuse cache entry is created, and no Sidecar calls are made.
@@ -114,7 +116,7 @@ public final class SnapshotManager {
      * injectable clock), the generation fingerprint it was taken over, and the per-host create
      * memoization (create at most once per host for this window's snapshot).
      */
-    private static final class Window {
+    static final class Window {
         final String name;
         final long epoch;
         final long createdNanos;
@@ -126,6 +128,11 @@ public final class SnapshotManager {
             this.epoch = epoch;
             this.createdNanos = createdNanos;
             this.generationFingerprint = generationFingerprint;
+        }
+
+        /** The resolved snapshot name stamped into this window's tickets. */
+        String name() {
+            return name;
         }
     }
 
@@ -185,6 +192,25 @@ public final class SnapshotManager {
      */
     public Optional<String> snapshotFor(
             String keyspace, String table, Collection<String> hosts, long generationFingerprint) {
+        return resolveSnapshot(keyspace, table, hosts, generationFingerprint).map(Window::name);
+    }
+
+    /**
+     * Resolve the reuse window ONCE (reusing the current fresh one or creating a fresh one on the
+     * Sidecar of every replica host in {@code hosts}, fail-closed) and return the resolved
+     * {@link Window}, so the caller can thread the EXACT same window into {@link #availableHosts}
+     * rather than independently re-resolving it (issue #2356 roborev, double-resolve race: if the
+     * freshness window elapsed between a separate {@code snapshotFor} + {@code availableHosts} pair,
+     * the two could resolve DIFFERENT windows, decoupling the tickets from the per-host snapshot
+     * actually ensured). Returns {@link Optional#empty()} in {@link ReadMode#LIVE}.
+     */
+    public Optional<Window> resolveSnapshot(String keyspace, String table, Collection<String> hosts) {
+        return resolveSnapshot(keyspace, table, hosts, NO_GENERATION);
+    }
+
+    /** As {@link #resolveSnapshot(String, String, Collection)} with a generation fingerprint. */
+    public Optional<Window> resolveSnapshot(
+            String keyspace, String table, Collection<String> hosts, long generationFingerprint) {
         if (readMode == ReadMode.LIVE) {
             return Optional.empty();
         }
@@ -192,28 +218,29 @@ public final class SnapshotManager {
         for (String host : hosts) {
             createOnHost(window, host, keyspace, table);
         }
-        return Optional.of(window.name);
+        return Optional.of(window);
     }
 
     /**
      * Best-effort per-host snapshot availability for a candidate host set (#2241): ensures the
-     * CURRENT reused window's snapshot exists on every host in {@code hosts} (the same memoized
-     * per-(window, host) create as {@link #snapshotFor}, so a host already created there resolves
-     * with no duplicate PUT), but — unlike {@link #snapshotFor} — does NOT fail closed on an
-     * individual host's creation failure (a failed host is logged and excluded). Counters are NOT
-     * touched here: this is part of the SAME query's planning as the preceding {@link #snapshotFor}
-     * (which already counted the create/reuse), so it reuses that window without double-counting.
+     * ALREADY-RESOLVED {@code window}'s snapshot exists on every host in {@code hosts} (the same
+     * memoized per-(window, host) create as {@link #resolveSnapshot}, so a host already created
+     * there resolves with no duplicate PUT), but — unlike the fail-closed resolve — does NOT fail
+     * closed on an individual host's creation failure (a failed host is logged and excluded).
+     * Counters are NOT touched here: this is part of the SAME query's planning as the preceding
+     * {@link #resolveSnapshot} (which already counted the create/reuse), so it reuses that window
+     * without double-counting.
      *
-     * <p>In {@link ReadMode#LIVE} this is a no-op returning every candidate host unchanged.
+     * <p>The caller passes the {@link Window} returned by {@link #resolveSnapshot} so both operate
+     * on the EXACT same window even if the freshness window would otherwise have rolled between the
+     * two calls (issue #2356 roborev, double-resolve race).
      *
+     * @param window the window resolved for this query by {@link #resolveSnapshot}
      * @param hosts every candidate replica host to check/create snapshot availability for
      * @return the subset of {@code hosts} that have (or now have) the snapshot
      */
-    public Set<String> availableHosts(String keyspace, String table, Collection<String> hosts) {
-        if (readMode == ReadMode.LIVE) {
-            return Set.copyOf(hosts);
-        }
-        Window window = resolveWindow(new TableRef(keyspace, table), NO_GENERATION, false);
+    public Set<String> availableHosts(
+            Window window, String keyspace, String table, Collection<String> hosts) {
         Set<String> available = new LinkedHashSet<>();
         for (String host : hosts) {
             try {
@@ -257,20 +284,24 @@ public final class SnapshotManager {
     /**
      * Resolve the current reused window for {@code ref}, reusing an existing fresh window or
      * creating a new one (bumping the epoch) atomically. When {@code countStats}, records exactly
-     * one {@link #snapshotReuseHitsTotal} (reuse) or {@link #snapshotCreationsTotal} (create). A
-     * superseded window is retired best-effort OUTSIDE the map-compute critical section.
+     * one {@link #snapshotReuseHitsTotal} (reuse) or {@link #snapshotCreationsTotal} (create).
+     *
+     * <p><b>A superseded window is NOT retired here (issue #2356 roborev, retire-race).</b> A
+     * long-running query A can still be reading a window's snapshot (splits not yet opened, or a
+     * cold remote host) when a later query B rolls to a fresh window; actively deleting A's snapshot
+     * dir on supersede would break A's in-flight reads. Superseded windows are therefore reclaimed
+     * solely by the Sidecar-side TTL backstop ({@link CqliteFlightConfig#snapshotTtl}). Active
+     * retirement ({@link #retire}) happens ONLY on explicit {@link #invalidate} (the
+     * {@code Database::refresh()} analog) and {@link #retireAll} (shutdown), never as a side effect
+     * of rolling to a new window.
      */
     private Window resolveWindow(TableRef ref, long generationFingerprint, boolean countStats) {
         long now = clock.nanoTime();
-        Window[] superseded = {null};
         boolean[] reused = {false};
         Window window = windows.compute(ref, (k, existing) -> {
             if (existing != null && isFresh(existing, generationFingerprint, now)) {
                 reused[0] = true;
                 return existing;
-            }
-            if (existing != null) {
-                superseded[0] = existing;
             }
             long epoch = epochs.computeIfAbsent(k, r -> new AtomicLong()).getAndIncrement();
             return new Window(nameFor(k, epoch), epoch, now, generationFingerprint);
@@ -281,9 +312,6 @@ public final class SnapshotManager {
             } else {
                 snapshotCreationsTotal.incrementAndGet();
             }
-        }
-        if (superseded[0] != null) {
-            retire(superseded[0], ref);
         }
         return window;
     }
@@ -368,9 +396,10 @@ public final class SnapshotManager {
     }
 
     /**
-     * Best-effort delete of every snapshot a superseded/invalidated {@code window} created, on each
-     * host it was created on. Individual delete failures are logged and swallowed — the Sidecar TTL
-     * backstop covers a miss.
+     * Best-effort delete of every snapshot an EXPLICITLY-invalidated {@code window} created (via
+     * {@link #invalidate} or {@link #retireAll} only — never on supersede, see {@link #resolveWindow}),
+     * on each host it was created on. Individual delete failures are logged and swallowed — the
+     * Sidecar TTL backstop covers a miss.
      */
     private void retire(Window window, TableRef ref) {
         for (Map.Entry<String, CompletableFuture<String>> e : window.hostCreates.entrySet()) {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
@@ -63,6 +63,16 @@ class CqliteFlightConfigTest {
     }
 
     @Test
+    void rejectsOversizedSnapshotReuseWindowInsteadOfSilentlyWrapping() {
+        // Blocker 3 (issue #2356 roborev, unchecked arithmetic): a ms value so large that ms→ns
+        // (* 1_000_000) overflows long must fail fast at parse time, not silently wrap to a small
+        // positive window. Long.MAX_VALUE / 1_000_000 ≈ 9.22e12, so 1e13 ms overflows.
+        Map<String, String> m = base();
+        m.put("cqlite.snapshot-reuse-window-ms", "10000000000000");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(m));
+    }
+
+    @Test
     void parsesReadModeLive() {
         Map<String, String> m = base();
         m.put("cqlite.read-mode", "LIVE");

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
@@ -32,6 +32,34 @@ class CqliteFlightConfigTest {
         assertEquals(ReadMode.SNAPSHOT, config.readMode());
         assertEquals(java.util.Optional.of(CqliteFlightConfig.DEFAULT_SNAPSHOT_TTL),
                 config.snapshotTtl());
+        // Snapshot-reuse freshness window defaults (issue #2356/#2306).
+        assertEquals(CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS,
+                config.snapshotReuseWindowMillis());
+        assertEquals(CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_NANOS,
+                config.snapshotReuseWindowNanos());
+    }
+
+    @Test
+    void parsesSnapshotReuseWindow() {
+        Map<String, String> m = base();
+        m.put("cqlite.snapshot-reuse-window-ms", "7500");
+        CqliteFlightConfig config = CqliteFlightConfig.fromMap(m);
+        assertEquals(7500L, config.snapshotReuseWindowMillis());
+        assertEquals(7_500_000_000L, config.snapshotReuseWindowNanos());
+    }
+
+    @Test
+    void zeroSnapshotReuseWindowIsAllowedAndDisablesReuse() {
+        Map<String, String> m = base();
+        m.put("cqlite.snapshot-reuse-window-ms", "0");
+        assertEquals(0L, CqliteFlightConfig.fromMap(m).snapshotReuseWindowMillis());
+    }
+
+    @Test
+    void rejectsNegativeSnapshotReuseWindow() {
+        Map<String, String> m = base();
+        m.put("cqlite.snapshot-reuse-window-ms", "-1");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(m));
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
@@ -37,6 +37,36 @@ class CqliteFlightConfigTest {
                 config.snapshotReuseWindowMillis());
         assertEquals(CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_NANOS,
                 config.snapshotReuseWindowNanos());
+        // Superseded-window retire-grace defaults (issue #2356 roborev, bounded retention).
+        assertEquals(CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS,
+                config.snapshotRetireGraceMillis());
+        assertEquals(CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_NANOS,
+                config.snapshotRetireGraceNanos());
+    }
+
+    @Test
+    void parsesSnapshotRetireGrace() {
+        Map<String, String> m = base();
+        m.put("cqlite.snapshot-retire-grace-ms", "90000");
+        CqliteFlightConfig config = CqliteFlightConfig.fromMap(m);
+        assertEquals(90_000L, config.snapshotRetireGraceMillis());
+        assertEquals(90_000_000_000L, config.snapshotRetireGraceNanos());
+    }
+
+    @Test
+    void rejectsNegativeSnapshotRetireGrace() {
+        Map<String, String> m = base();
+        m.put("cqlite.snapshot-retire-grace-ms", "-1");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(m));
+    }
+
+    @Test
+    void rejectsOversizedSnapshotRetireGraceInsteadOfSilentlyWrapping() {
+        // Same overflow guard as the reuse window: a ms value whose ms→ns (* 1_000_000) overflows
+        // long must fail fast, not silently wrap.
+        Map<String, String> m = base();
+        m.put("cqlite.snapshot-retire-grace-ms", "10000000000000");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(m));
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightLogicalRowCountTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightLogicalRowCountTest.java
@@ -47,7 +47,8 @@ class CqliteFlightLogicalRowCountTest {
         return new CqliteFlightConfig(
                 URI.create("http://sidecar:9043"), 8815, localDatacenter,
                 GroupByPushdownPolicy.AUTOMATIC, 0.5, 3000,
-                ReadMode.SNAPSHOT, java.util.Optional.of("6h"));
+                ReadMode.SNAPSHOT, java.util.Optional.of("6h"),
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS);
     }
 
     private static CqliteFlightTableHandle plainHandle() {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightLogicalRowCountTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightLogicalRowCountTest.java
@@ -48,7 +48,8 @@ class CqliteFlightLogicalRowCountTest {
                 URI.create("http://sidecar:9043"), 8815, localDatacenter,
                 GroupByPushdownPolicy.AUTOMATIC, 0.5, 3000,
                 ReadMode.SNAPSHOT, java.util.Optional.of("6h"),
-                CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS);
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS,
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS);
     }
 
     private static CqliteFlightTableHandle plainHandle() {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerSnapshotFailoverTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerSnapshotFailoverTest.java
@@ -76,9 +76,9 @@ class CqliteFlightSplitManagerSnapshotFailoverTest {
     private static List<CqliteFlightSplit> planSnapshotModeSplits(
             TokenRangeReplicasResponse resp, SnapshotManager snapshots) {
         Set<String> primaryHosts = CqliteFlightSplitManager.distinctReplicaHosts(resp, "dc1");
-        Optional<String> snapshot = snapshots.snapshotFor("q1", "ks", "t", primaryHosts);
+        Optional<String> snapshot = snapshots.snapshotFor("ks", "t", primaryHosts);
         Set<String> availableHosts = snapshots.availableHosts(
-                "q1", "ks", "t", CqliteFlightSplitManager.allReplicaHosts(resp, "dc1"));
+                "ks", "t", CqliteFlightSplitManager.allReplicaHosts(resp, "dc1"));
         return CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815, snapshot, availableHosts);
     }
 

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerSnapshotFailoverTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitManagerSnapshotFailoverTest.java
@@ -76,9 +76,14 @@ class CqliteFlightSplitManagerSnapshotFailoverTest {
     private static List<CqliteFlightSplit> planSnapshotModeSplits(
             TokenRangeReplicasResponse resp, SnapshotManager snapshots) {
         Set<String> primaryHosts = CqliteFlightSplitManager.distinctReplicaHosts(resp, "dc1");
-        Optional<String> snapshot = snapshots.snapshotFor("ks", "t", primaryHosts);
-        Set<String> availableHosts = snapshots.availableHosts(
-                "ks", "t", CqliteFlightSplitManager.allReplicaHosts(resp, "dc1"));
+        // Resolve the window ONCE and thread it into availableHosts, mirroring the double-resolve
+        // race fix in getSplits (issue #2356 roborev).
+        Optional<SnapshotManager.Window> window = snapshots.resolveSnapshot("ks", "t", primaryHosts);
+        Optional<String> snapshot = window.map(SnapshotManager.Window::name);
+        Set<String> availableHosts = window.isPresent()
+                ? snapshots.availableHosts(
+                        window.get(), "ks", "t", CqliteFlightSplitManager.allReplicaHosts(resp, "dc1"))
+                : Set.of();
         return CqliteFlightSplitManager.buildSplits(TABLE, resp, "dc1", 8815, snapshot, availableHosts);
     }
 

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/ReadModeWiringTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/ReadModeWiringTest.java
@@ -55,19 +55,20 @@ class ReadModeWiringTest {
     @Test
     void snapshotModeNamesSnapshotInTicket() throws Exception {
         SnapshotManager mgr = new SnapshotManager(noopSidecar(), ReadMode.SNAPSHOT, Optional.of("6h"));
-        Optional<String> snapshot = mgr.snapshotFor("q1", "ks", "t", List.of("10.0.0.2"));
+        Optional<String> snapshot = mgr.snapshotFor("ks", "t", List.of("10.0.0.2"));
 
         List<CqliteFlightSplit> splits =
                 CqliteFlightSplitManager.buildSplits(TABLE, REPLICAS, "dc1", 8815, snapshot);
 
-        assertEquals(Optional.of("cqlite-q1"), splits.get(0).snapshot());
-        assertEquals("cqlite-q1", ticketFor(splits.get(0)).get("snapshot").asText());
+        // Reuse names snapshots per (ks, table, epoch), not per queryId (issue #2356).
+        assertEquals(Optional.of("cqlite-ks-t-0"), splits.get(0).snapshot());
+        assertEquals("cqlite-ks-t-0", ticketFor(splits.get(0)).get("snapshot").asText());
     }
 
     @Test
     void liveModeLeavesSnapshotNullInTicket() throws Exception {
         SnapshotManager mgr = new SnapshotManager(noopSidecar(), ReadMode.LIVE, Optional.of("6h"));
-        Optional<String> snapshot = mgr.snapshotFor("q1", "ks", "t", List.of("10.0.0.2"));
+        Optional<String> snapshot = mgr.snapshotFor("ks", "t", List.of("10.0.0.2"));
 
         List<CqliteFlightSplit> splits =
                 CqliteFlightSplitManager.buildSplits(TABLE, REPLICAS, "dc1", 8815, snapshot);

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SnapshotManagerTest {
 
     private static final long WINDOW = 1_000L; // logical nanos
+    private static final long GRACE = 5_000L;  // logical nanos: retire a superseded window after 5 windows
 
     /** A settable logical clock so window timing is pinned deterministically (no wall-clock). */
     private static final class ManualClock implements SnapshotManager.Clock {
@@ -195,10 +196,12 @@ class SnapshotManagerTest {
         assertEquals("cqlite-ks-t-1", w1, "post-expiry query gets a fresh (next-epoch) snapshot");
         assertEquals(2, mgr.snapshotCreationsTotal(), "one create per window");
         assertEquals(0, mgr.snapshotReuseHitsTotal(), "no reuse across the window boundary");
-        // The superseded window's snapshot is NOT actively deleted (issue #2356 roborev,
-        // retire-race): a long-running query may still be reading it; the TTL backstop reclaims it.
+        // The superseded window's snapshot is NOT actively deleted the instant it is superseded
+        // (issue #2356 roborev, retire-race): a long-running query may still be reading it. It is
+        // retired only after the retire-grace elapses (here the default 10-min grace, far beyond
+        // this tiny advance), so within the grace clears stay empty.
         assertTrue(fake.clears.isEmpty(),
-                "a superseded snapshot is NOT retired on supersede, got clears=" + fake.clears);
+                "a superseded snapshot is NOT retired on supersede (within grace), got clears=" + fake.clears);
     }
 
     /**
@@ -237,6 +240,66 @@ class SnapshotManagerTest {
         mgr.retireAll();
         assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w3)),
                 "retireAll() retires the live window, got clears=" + fake.clears);
+    }
+
+    /**
+     * Blocker (issue #2356 roborev, resource retention): a superseded window must be actively
+     * retired once the retire-grace elapses (bounded retention — not left to the ~6h TTL backstop),
+     * while a still-in-grace superseded window survives (its in-flight readers may still be reading).
+     * Deterministic on the injected clock.
+     */
+    @Test
+    void supersededWindowIsRetiredAfterGraceWhileInGraceWindowSurvives() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        SnapshotManager mgr =
+                new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, clock);
+
+        // W0 taken at t=0.
+        String w0 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        // At t=WINDOW the window elapses; the next query rolls to W1 and enqueues W0 for retirement.
+        clock.advance(WINDOW);
+        String w1 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        assertNotEquals(w0, w1);
+        // W0 is still within its grace (age 0), so it is NOT yet retired — an in-flight reader is safe.
+        assertTrue(fake.clears.isEmpty(),
+                "a superseded window within its grace is not retired, got clears=" + fake.clears);
+
+        // Advance so W0's grace has fully elapsed (age = WINDOW+GRACE - WINDOW = GRACE) but W1's has
+        // not; the next resolve sweeps and retires ONLY W0.
+        clock.advance(GRACE);
+        String w2 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        assertNotEquals(w1, w2);
+        assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w0)),
+                "W0 is retired once its grace elapses, got clears=" + fake.clears);
+        assertTrue(fake.clears.stream().noneMatch(c -> c.contains(w1)),
+                "W1 is still within its grace and must survive, got clears=" + fake.clears);
+        assertTrue(fake.clears.stream().noneMatch(c -> c.contains(w2)),
+                "the current window W2 is never retired, got clears=" + fake.clears);
+    }
+
+    /**
+     * Blocker (issue #2356 roborev, half-created window): a fail-closed per-host fan-out must not
+     * leave a freshly-created window cached as "fresh" nor count a create/flush that never fully
+     * materialized. A later query must therefore NOT reuse the phantom — it must create a real one.
+     */
+    @Test
+    void failedFanOutCachesNoWindowAndCountsNoCreation() {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failCreateHosts = Set.of("h1");
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
+
+        assertThrows(SidecarClient.SidecarException.class, () -> mgr.snapshotFor("ks", "t", List.of("h1")));
+        assertEquals(0, mgr.snapshotCreationsTotal(), "a failed fan-out counts no creation");
+        assertEquals(0, mgr.snapshotReuseHitsTotal(), "a failed fan-out is not a reuse either");
+
+        // Clear the failure: the retry must CREATE (not reuse a cached phantom fresh window).
+        fake.failCreateHosts = Set.of();
+        mgr.snapshotFor("ks", "t", List.of("h1"));
+        assertEquals(1, mgr.snapshotCreationsTotal(),
+                "the retry creates a real snapshot — the failed fan-out cached nothing to reuse");
+        assertEquals(0, mgr.snapshotReuseHitsTotal(),
+                "nothing was reusable from the rolled-back half-created window");
     }
 
     /** Scenario: An explicit refresh forces a fresh snapshot on the next query. */

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerTest.java
@@ -85,8 +85,9 @@ class SnapshotManagerTest {
 
         for (int i = 0; i < 5; i++) {
             assertEquals(Optional.empty(), mgr.snapshotFor("ks", "t", List.of("h1", "h2")));
+            assertEquals(Optional.empty(), mgr.resolveSnapshot("ks", "t", List.of("h1", "h2")),
+                    "live mode resolves no reuse window");
         }
-        assertEquals(Set.of("h1", "h2"), mgr.availableHosts("ks", "t", List.of("h1", "h2")));
 
         assertTrue(fake.creates.isEmpty(), "live mode creates no snapshot");
         assertTrue(fake.clears.isEmpty(), "live mode clears nothing");
@@ -194,9 +195,48 @@ class SnapshotManagerTest {
         assertEquals("cqlite-ks-t-1", w1, "post-expiry query gets a fresh (next-epoch) snapshot");
         assertEquals(2, mgr.snapshotCreationsTotal(), "one create per window");
         assertEquals(0, mgr.snapshotReuseHitsTotal(), "no reuse across the window boundary");
-        // The superseded window's snapshot is retired.
-        assertTrue(fake.clears.stream().anyMatch(c -> c.contains("cqlite-ks-t-0")),
-                "the superseded snapshot is retired, got clears=" + fake.clears);
+        // The superseded window's snapshot is NOT actively deleted (issue #2356 roborev,
+        // retire-race): a long-running query may still be reading it; the TTL backstop reclaims it.
+        assertTrue(fake.clears.isEmpty(),
+                "a superseded snapshot is NOT retired on supersede, got clears=" + fake.clears);
+    }
+
+    /**
+     * Blocker 1 (issue #2356 roborev, retire-race): superseding a window (window expiry / generation
+     * change) must NOT delete the superseded snapshot's hardlinks — an in-flight query may still be
+     * reading them — while an explicit {@link SnapshotManager#invalidate} and shutdown
+     * {@link SnapshotManager#retireAll} still retire correctly.
+     */
+    @Test
+    void supersedeDoesNotRetireButInvalidateAndRetireAllDo() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        SnapshotManager mgr = snapshotMgr(fake, clock);
+
+        // Query A takes W0 and (conceptually) is still reading it.
+        String w0 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        // Query B, after the window elapses, supersedes W0 with W1 — W0 must NOT be deleted.
+        clock.advance(WINDOW);
+        String w1 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        assertNotEquals(w0, w1);
+        assertTrue(fake.clears.isEmpty(), "supersede must not delete W0, got clears=" + fake.clears);
+
+        // Generation-set change also supersedes without retiring.
+        clock.advance(1);
+        String w2 = mgr.snapshotFor("ks", "t", List.of("h1"), 999L).orElseThrow();
+        assertNotEquals(w1, w2);
+        assertTrue(fake.clears.isEmpty(), "generation-change supersede must not delete W1, got " + fake.clears);
+
+        // Explicit refresh (Database::refresh() analog) DOES retire the current window.
+        mgr.invalidate("ks", "t");
+        assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w2)),
+                "invalidate() retires the current window, got clears=" + fake.clears);
+
+        // Shutdown retires every live window.
+        String w3 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        mgr.retireAll();
+        assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w3)),
+                "retireAll() retires the live window, got clears=" + fake.clears);
     }
 
     /** Scenario: An explicit refresh forces a fresh snapshot on the next query. */
@@ -264,8 +304,9 @@ class SnapshotManagerTest {
         FakeSidecars fake = new FakeSidecars();
         SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
 
-        mgr.snapshotFor("ks", "t", List.of("10.0.0.2")); // primary (required) create
-        Set<String> available = mgr.availableHosts("ks", "t", List.of("10.0.0.2", "10.0.0.9"));
+        SnapshotManager.Window window =
+                mgr.resolveSnapshot("ks", "t", List.of("10.0.0.2")).orElseThrow(); // primary create
+        Set<String> available = mgr.availableHosts(window, "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
 
         assertEquals(Set.of("10.0.0.2", "10.0.0.9"), available);
         assertEquals(1, fake.creates.stream().filter(c -> c.startsWith("10.0.0.2|")).count(),
@@ -280,9 +321,40 @@ class SnapshotManagerTest {
         fake.failCreateHosts = Set.of("10.0.0.9");
         SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
 
-        Set<String> available = mgr.availableHosts("ks", "t", List.of("10.0.0.2", "10.0.0.9"));
+        SnapshotManager.Window window =
+                mgr.resolveSnapshot("ks", "t", List.of("10.0.0.2")).orElseThrow();
+        Set<String> available = mgr.availableHosts(window, "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
 
         assertEquals(Set.of("10.0.0.2"), available, "the failed host is excluded, not propagated");
+    }
+
+    /**
+     * Blocker 2 (issue #2356 roborev, double-resolve race): the window resolved for the ticket
+     * (via {@link SnapshotManager#resolveSnapshot}) must be threaded into
+     * {@link SnapshotManager#availableHosts} so both operate on the EXACT same window even if the
+     * freshness window elapses between the two calls — availableHosts must NOT independently roll
+     * to a fresh (new-epoch) window and decouple the tickets from the per-host snapshot ensured.
+     */
+    @Test
+    void availableHostsUsesResolvedWindowEvenIfClockAdvancesPastTheWindow() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        SnapshotManager mgr = snapshotMgr(fake, clock);
+
+        SnapshotManager.Window window =
+                mgr.resolveSnapshot("ks", "t", List.of("10.0.0.2")).orElseThrow();
+        assertEquals("cqlite-ks-t-0", window.name());
+
+        // The freshness window elapses between resolveSnapshot and availableHosts.
+        clock.advance(WINDOW + 1);
+        Set<String> available = mgr.availableHosts(window, "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
+
+        assertEquals(Set.of("10.0.0.2", "10.0.0.9"), available);
+        // Every create — primary AND fallback — is against W0, never a rolled-forward W1.
+        assertTrue(fake.creates.stream().allMatch(c -> c.contains("cqlite-ks-t-0")),
+                "availableHosts ensured the SAME resolved window, got creates=" + fake.creates);
+        assertEquals(1, mgr.snapshotCreationsTotal(),
+                "no new window is created by availableHosts despite the elapsed clock");
     }
 
     // ---- Retirement / fail-closed edge cases ---------------------------------------------------

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerTest.java
@@ -17,16 +17,35 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Per-query snapshot lifecycle (issues #2105, #2227): create-at-planning on EVERY replica
- * host, fail-closed (naming host + snapshot), idempotent per (query, host, table),
- * best-effort per-host cleanup. Uses a recording fake {@link HostSnapshotApis} so no live
- * Sidecar / HTTP is needed.
+ * Snapshot lifecycle: per-{@code (keyspace, table)} REUSE within a freshness window (issues
+ * #2356/#2306) — one create fan-out per window (not per query), invalidated by window expiry, an
+ * observed generation-set change, or an explicit refresh — on top of the preserved per-host
+ * fail-closed create model (#2227). Window timing is driven by an injected logical clock (never
+ * {@code System.currentTimeMillis}, per #1742). Uses a recording fake {@link HostSnapshotApis} so
+ * no live Sidecar / HTTP is needed.
  */
 class SnapshotManagerTest {
+
+    private static final long WINDOW = 1_000L; // logical nanos
+
+    /** A settable logical clock so window timing is pinned deterministically (no wall-clock). */
+    private static final class ManualClock implements SnapshotManager.Clock {
+        volatile long nanos;
+
+        @Override
+        public long nanoTime() {
+            return nanos;
+        }
+
+        void advance(long delta) {
+            nanos += delta;
+        }
+    }
 
     /** Records every create/clear (prefixed with the host) and can be armed to throw. */
     private static final class FakeSidecars implements HostSnapshotApis {
@@ -53,105 +72,249 @@ class SnapshotManagerTest {
         }
     }
 
-    @Test
-    void liveModeNeverTouchesSidecar() {
-        FakeSidecars fake = new FakeSidecars();
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.LIVE, Optional.of("6h"));
+    private SnapshotManager snapshotMgr(HostSnapshotApis sidecars, ManualClock clock) {
+        return new SnapshotManager(sidecars, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, clock);
+    }
 
-        assertEquals(Optional.empty(), mgr.snapshotFor("q1", "ks", "t", List.of("h1", "h2")));
-        mgr.cleanup("q1");
+    // ---- LIVE-mode inertness (flight-snapshot-reuse spec) --------------------------------------
+
+    @Test
+    void liveModePerformsNoReuseAndNoSidecarCalls() {
+        FakeSidecars fake = new FakeSidecars();
+        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.LIVE, Optional.of("6h"), WINDOW, new ManualClock());
+
+        for (int i = 0; i < 5; i++) {
+            assertEquals(Optional.empty(), mgr.snapshotFor("ks", "t", List.of("h1", "h2")));
+        }
+        assertEquals(Set.of("h1", "h2"), mgr.availableHosts("ks", "t", List.of("h1", "h2")));
 
         assertTrue(fake.creates.isEmpty(), "live mode creates no snapshot");
         assertTrue(fake.clears.isEmpty(), "live mode clears nothing");
+        assertEquals(0, mgr.snapshotCreationsTotal(), "live mode never creates");
+        assertEquals(0, mgr.snapshotReuseHitsTotal(), "live mode never reuses");
     }
+
+    // ---- Naming + per-host fail-closed create (#2227) ------------------------------------------
 
     @Test
-    void snapshotModeCreatesNamedSnapshotWithTtl() {
+    void snapshotModeCreatesEpochNamedSnapshotWithTtl() {
         FakeSidecars fake = new FakeSidecars();
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.of("6h"));
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
 
-        Optional<String> name =
-                mgr.snapshotFor("20260706_120000_00001_abcde", "ks", "t", List.of("10.0.0.1"));
+        Optional<String> name = mgr.snapshotFor("ks", "t", List.of("10.0.0.1"));
 
-        assertEquals(Optional.of("cqlite-20260706_120000_00001_abcde"), name);
-        assertEquals(List.of("10.0.0.1|ks.t/cqlite-20260706_120000_00001_abcde/ttl=6h"), fake.creates);
+        assertEquals(Optional.of("cqlite-ks-t-0"), name);
+        assertEquals(List.of("10.0.0.1|ks.t/cqlite-ks-t-0/ttl=6h"), fake.creates);
+        assertEquals(1, mgr.snapshotCreationsTotal());
     }
 
-    /**
-     * AC1/AC2 (issue #2227): the snapshot must be created on EVERY replica host a split will
-     * read, not just the configured Sidecar's node — one PUT per distinct host, same name.
-     */
     @Test
     void createsSnapshotOnEveryReplicaHost() {
         FakeSidecars fake = new FakeSidecars();
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.of("6h"));
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
 
-        Optional<String> name = mgr.snapshotFor("q1", "ks", "t", List.of("10.0.0.1", "10.0.0.2", "10.0.0.3"));
+        Optional<String> name = mgr.snapshotFor("ks", "t", List.of("10.0.0.1", "10.0.0.2", "10.0.0.3"));
 
-        assertEquals(Optional.of("cqlite-q1"), name);
+        assertEquals(Optional.of("cqlite-ks-t-0"), name);
         assertEquals(List.of(
-                        "10.0.0.1|ks.t/cqlite-q1/ttl=6h",
-                        "10.0.0.2|ks.t/cqlite-q1/ttl=6h",
-                        "10.0.0.3|ks.t/cqlite-q1/ttl=6h"),
+                        "10.0.0.1|ks.t/cqlite-ks-t-0/ttl=6h",
+                        "10.0.0.2|ks.t/cqlite-ks-t-0/ttl=6h",
+                        "10.0.0.3|ks.t/cqlite-ks-t-0/ttl=6h"),
                 fake.creates.stream().sorted().toList());
+        assertEquals(1, mgr.snapshotCreationsTotal(), "one window ⇒ one create fan-out");
     }
 
-    /**
-     * AC3 (issue #2227): a create failure on one host fails closed with an actionable error
-     * naming the offending host AND the snapshot — never a bare NotFound / opaque failure.
-     */
     @Test
     void failsClosedNamingHostAndSnapshot() {
         FakeSidecars fake = new FakeSidecars();
         fake.failCreateHosts = Set.of("10.0.0.2");
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.of("6h"));
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
 
         SidecarClient.SidecarException ex = assertThrows(SidecarClient.SidecarException.class,
-                () -> mgr.snapshotFor("q1", "ks", "t", List.of("10.0.0.1", "10.0.0.2")));
+                () -> mgr.snapshotFor("ks", "t", List.of("10.0.0.1", "10.0.0.2")));
 
         assertTrue(ex.getMessage().contains("10.0.0.2"), "error names the failing host: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains("cqlite-q1"), "error names the snapshot: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("cqlite-ks-t-0"), "error names the snapshot: " + ex.getMessage());
     }
 
     @Test
-    void createIsIdempotentPerQueryHostTable() {
+    void nameSanitizesUnsafeChars() {
+        assertEquals("cqlite-k_s-t_x-3", SnapshotManager.nameFor("k/s", "t x", 3));
+    }
+
+    // ---- Reuse within one window (flight-snapshot-reuse spec) ----------------------------------
+
+    /** Scenario: N queries within one window create exactly one snapshot. */
+    @Test
+    void nQueriesInOneWindowCreateExactlyOneSnapshot() {
         FakeSidecars fake = new FakeSidecars();
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
+        ManualClock clock = new ManualClock();
+        SnapshotManager mgr = snapshotMgr(fake, clock);
 
-        mgr.snapshotFor("q1", "ks", "t", List.of("h1", "h2"));
-        mgr.snapshotFor("q1", "ks", "t", List.of("h1", "h2")); // re-plan same scan
+        int n = 5;
+        String first = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        for (int i = 1; i < n; i++) {
+            clock.advance(1); // still well within WINDOW
+            assertEquals(Optional.of(first), mgr.snapshotFor("ks", "t", List.of("h1")),
+                    "every query in the window receives the SAME snapshot name");
+        }
 
-        assertEquals(2, fake.creates.size(), "at most one PUT per (query, host, keyspace, table)");
+        assertEquals(1, mgr.snapshotCreationsTotal(), "exactly one create fan-out for N queries in one window");
+        assertEquals(n - 1L, mgr.snapshotReuseHitsTotal(), "the other N-1 queries are reuse hits");
+        assertEquals(1, fake.creates.size(), "exactly one Sidecar PUT on the host");
     }
 
     @Test
-    void failsClosedOnCreateError() {
+    void rePlanReusesWindowWithoutDuplicatePut() {
         FakeSidecars fake = new FakeSidecars();
-        fake.failCreateHosts = Set.of("h1");
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.of("6h"));
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
 
-        assertThrows(SidecarClient.SidecarException.class, () -> mgr.snapshotFor("q1", "ks", "t", List.of("h1")));
+        mgr.snapshotFor("ks", "t", List.of("h1", "h2"));
+        mgr.snapshotFor("ks", "t", List.of("h1", "h2")); // re-plan same scan, same window
 
-        // A failed create is NOT recorded, so cleanup won't try to delete a phantom snapshot.
-        mgr.cleanup("q1");
-        assertTrue(fake.clears.isEmpty());
+        assertEquals(2, fake.creates.size(), "at most one PUT per (window, host)");
+        assertEquals(1, mgr.snapshotCreationsTotal());
+        assertEquals(1, mgr.snapshotReuseHitsTotal());
+    }
+
+    // ---- Invalidation: window expiry / generation change / explicit refresh --------------------
+
+    /** Scenario: A new query after window expiry creates a fresh snapshot. */
+    @Test
+    void newQueryAfterWindowExpiryCreatesFreshSnapshot() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        SnapshotManager mgr = snapshotMgr(fake, clock);
+
+        String w0 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        clock.advance(WINDOW); // window elapses
+        String w1 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+
+        assertEquals("cqlite-ks-t-0", w0);
+        assertEquals("cqlite-ks-t-1", w1, "post-expiry query gets a fresh (next-epoch) snapshot");
+        assertEquals(2, mgr.snapshotCreationsTotal(), "one create per window");
+        assertEquals(0, mgr.snapshotReuseHitsTotal(), "no reuse across the window boundary");
+        // The superseded window's snapshot is retired.
+        assertTrue(fake.clears.stream().anyMatch(c -> c.contains("cqlite-ks-t-0")),
+                "the superseded snapshot is retired, got clears=" + fake.clears);
+    }
+
+    /** Scenario: An explicit refresh forces a fresh snapshot on the next query. */
+    @Test
+    void explicitRefreshForcesFreshSnapshot() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        SnapshotManager mgr = snapshotMgr(fake, clock);
+
+        String w0 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        mgr.invalidate("ks", "t");
+        String w1 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow(); // still within window
+
+        assertNotEquals(w0, w1, "explicit refresh forces a NEW snapshot even within the window");
+        assertEquals(2, mgr.snapshotCreationsTotal());
+        assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w0)),
+                "the invalidated snapshot is retired, got clears=" + fake.clears);
+    }
+
+    /** Scenario: An observed generation-set change invalidates reuse. */
+    @Test
+    void observedGenerationSetChangeInvalidatesReuse() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        SnapshotManager mgr = snapshotMgr(fake, clock);
+
+        String overG = mgr.snapshotFor("ks", "t", List.of("h1"), 111L).orElseThrow();
+        // Same generation within the window ⇒ reuse.
+        assertEquals(overG, mgr.snapshotFor("ks", "t", List.of("h1"), 111L).orElseThrow());
+        // A changed generation set within the window ⇒ fresh snapshot.
+        String overGprime = mgr.snapshotFor("ks", "t", List.of("h1"), 222L).orElseThrow();
+
+        assertNotEquals(overG, overGprime, "a generation-set change forces a fresh snapshot");
+        assertEquals(2, mgr.snapshotCreationsTotal(), "one create for G, one for G'");
+        assertEquals(1, mgr.snapshotReuseHitsTotal(), "the same-generation repeat was the only reuse");
+    }
+
+    /** Scenario: Snapshot creation rate over a query-heavy workload drops by the reuse factor. */
+    @Test
+    void snapshotCreationRateOverWorkloadDropsByReuseFactor() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        SnapshotManager mgr = snapshotMgr(fake, clock);
+
+        int windows = 3;
+        int queriesPerWindow = 4;
+        for (int w = 0; w < windows; w++) {
+            for (int q = 0; q < queriesPerWindow; q++) {
+                mgr.snapshotFor("ks", "t", List.of("h1"));
+                clock.advance(1); // stays within the window
+            }
+            clock.advance(WINDOW); // roll to the next window
+        }
+
+        int totalQueries = windows * queriesPerWindow;
+        assertEquals(windows, mgr.snapshotCreationsTotal(),
+                "flush-inducing create rate is W (one per window), not Q (one per query)");
+        assertEquals(totalQueries - windows, mgr.snapshotReuseHitsTotal());
+    }
+
+    // ---- availableHosts reuse (#2241) ----------------------------------------------------------
+
+    @Test
+    void availableHostsReusesCurrentWindowWithoutCountingOrDuplicatePut() {
+        FakeSidecars fake = new FakeSidecars();
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
+
+        mgr.snapshotFor("ks", "t", List.of("10.0.0.2")); // primary (required) create
+        Set<String> available = mgr.availableHosts("ks", "t", List.of("10.0.0.2", "10.0.0.9"));
+
+        assertEquals(Set.of("10.0.0.2", "10.0.0.9"), available);
+        assertEquals(1, fake.creates.stream().filter(c -> c.startsWith("10.0.0.2|")).count(),
+                "the already-created host is not PUT again within the window");
+        assertEquals(1, mgr.snapshotCreationsTotal(), "availableHosts does not re-count the same window");
+        assertEquals(0, mgr.snapshotReuseHitsTotal(), "availableHosts is part of the same query's planning");
     }
 
     @Test
-    void cleanupDeletesEveryCreatedSnapshotOnEveryHost() {
+    void availableHostsExcludesFailedHostWithoutThrowing() {
         FakeSidecars fake = new FakeSidecars();
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
+        fake.failCreateHosts = Set.of("10.0.0.9");
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
 
-        mgr.snapshotFor("q1", "ks", "a", List.of("h1", "h2"));
-        mgr.snapshotFor("q1", "ks", "b", List.of("h1"));
-        mgr.cleanup("q1");
+        Set<String> available = mgr.availableHosts("ks", "t", List.of("10.0.0.2", "10.0.0.9"));
 
-        assertEquals(List.of("h1|ks.a/cqlite-q1", "h1|ks.b/cqlite-q1", "h2|ks.a/cqlite-q1"),
+        assertEquals(Set.of("10.0.0.2"), available, "the failed host is excluded, not propagated");
+    }
+
+    // ---- Retirement / fail-closed edge cases ---------------------------------------------------
+
+    @Test
+    void retireAllClearsEveryLiveWindow() {
+        FakeSidecars fake = new FakeSidecars();
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
+
+        mgr.snapshotFor("ks", "a", List.of("h1", "h2"));
+        mgr.snapshotFor("ks", "b", List.of("h1"));
+        mgr.retireAll();
+
+        assertEquals(List.of("h1|ks.a/cqlite-ks-a-0", "h1|ks.b/cqlite-ks-b-0", "h2|ks.a/cqlite-ks-a-0"),
                 fake.clears.stream().sorted().toList());
     }
 
     @Test
-    void cleanupSwallowsDeleteFailures() {
+    void failsClosedOnCreateErrorAndRetiresNoPhantom() {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failCreateHosts = Set.of("h1");
+        SnapshotManager mgr = snapshotMgr(fake, new ManualClock());
+
+        assertThrows(SidecarClient.SidecarException.class, () -> mgr.snapshotFor("ks", "t", List.of("h1")));
+
+        // A failed create left no future, so retirement never deletes a phantom snapshot.
+        mgr.retireAll();
+        assertTrue(fake.clears.isEmpty(), "no phantom snapshot is cleared, got " + fake.clears);
+    }
+
+    @Test
+    void retireSwallowsDeleteFailures() {
         HostSnapshotApis throwing = host -> new SnapshotApi() {
             @Override
             public void createSnapshot(String k, String t, String n, Optional<String> ttl) {}
@@ -160,84 +323,18 @@ class SnapshotManagerTest {
                 throw new SidecarClient.SidecarException("delete failed", 500);
             }
         };
-        SnapshotManager mgr = new SnapshotManager(throwing, ReadMode.SNAPSHOT, Optional.empty());
-        mgr.snapshotFor("q1", "ks", "t", List.of("h1", "h2"));
+        SnapshotManager mgr = new SnapshotManager(throwing, ReadMode.SNAPSHOT, Optional.empty(), WINDOW, new ManualClock());
+        mgr.snapshotFor("ks", "t", List.of("h1", "h2"));
         // Best-effort: a delete failure must not propagate (TTL backstop reclaims it).
-        mgr.cleanup("q1");
+        mgr.retireAll();
     }
 
-    @Test
-    void snapshotNameSanitizesUnsafeChars() {
-        assertEquals("cqlite-q_1_x", SnapshotManager.snapshotName("q/1 x"));
-    }
+    // ---- Concurrency (per-host exactly-once, off-lock create) ----------------------------------
 
     /**
-     * {@code availableHosts} (issue #2241): best-effort creates on every candidate host and
-     * returns the subset that succeeded — creating snapshots for hosts that were never
-     * {@code snapshotFor}'s required set (e.g. a fallback-only host that is never any range's
-     * primary), fixing the roborev finding that fallback restriction was primaries-only.
-     */
-    @Test
-    void availableHostsCreatesSnapshotOnEveryCandidateAndReturnsAllOnSuccess() {
-        FakeSidecars fake = new FakeSidecars();
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.of("6h"));
-
-        Set<String> available = mgr.availableHosts("q1", "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
-
-        assertEquals(Set.of("10.0.0.2", "10.0.0.9"), available);
-        assertEquals(List.of("10.0.0.2|ks.t/cqlite-q1/ttl=6h", "10.0.0.9|ks.t/cqlite-q1/ttl=6h"),
-                fake.creates.stream().sorted().toList());
-    }
-
-    /**
-     * A host whose creation fails is excluded from the returned set but does NOT propagate —
-     * unlike {@link SnapshotManager#snapshotFor}, this call never fails closed. Loud (fail-closed)
-     * behavior is reserved for REQUIRED (primary) hosts via {@code snapshotFor}.
-     */
-    @Test
-    void availableHostsExcludesFailedHostWithoutThrowing() {
-        FakeSidecars fake = new FakeSidecars();
-        fake.failCreateHosts = Set.of("10.0.0.9");
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
-
-        Set<String> available = mgr.availableHosts("q1", "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
-
-        assertEquals(Set.of("10.0.0.2"), available, "the failed host is excluded, not propagated");
-    }
-
-    /**
-     * A host already created via {@code snapshotFor} (e.g. a range's primary, required and
-     * fail-closed) resolves instantly through {@code availableHosts} without a duplicate PUT —
-     * the memoized per-(query, host, keyspace, table) future is shared between both call paths.
-     */
-    @Test
-    void availableHostsReusesAlreadyCreatedSnapshotWithoutDuplicatePut() {
-        FakeSidecars fake = new FakeSidecars();
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.SNAPSHOT, Optional.empty());
-
-        mgr.snapshotFor("q1", "ks", "t", List.of("10.0.0.2")); // required (primary) create
-        Set<String> available = mgr.availableHosts("q1", "ks", "t", List.of("10.0.0.2", "10.0.0.9"));
-
-        assertEquals(Set.of("10.0.0.2", "10.0.0.9"), available);
-        assertEquals(1, fake.creates.stream().filter(c -> c.startsWith("10.0.0.2|")).count(),
-                "the already-created primary host is not PUT again");
-    }
-
-    @Test
-    void liveModeAvailableHostsReturnsAllCandidatesWithoutTouchingSidecar() {
-        FakeSidecars fake = new FakeSidecars();
-        SnapshotManager mgr = new SnapshotManager(fake, ReadMode.LIVE, Optional.empty());
-
-        assertEquals(Set.of("h1", "h2"), mgr.availableHosts("q1", "ks", "t", List.of("h1", "h2")));
-        assertTrue(fake.creates.isEmpty(), "live mode touches no Sidecar");
-    }
-
-    /**
-     * Concurrent callers for the same (query, host, keyspace, table) must PUT exactly once,
-     * even while the (slow) create is in flight. The per-key-future memoization (issue #2113
-     * / N5) moves the network call off the ConcurrentHashMap bin lock but keeps exactly-once
-     * — this test gates the create on a latch so many threads pile up mid-create, then
-     * asserts one PUT and one shared snapshot name.
+     * Concurrent callers for the same {@code (window, host)} must PUT exactly once, even while the
+     * (slow) create is in flight — the per-key-future memoization (#2113) moves the network call
+     * off the ConcurrentHashMap bin lock but keeps exactly-once.
      */
     @Test
     void concurrentCallersPutExactlyOnce() throws Exception {
@@ -248,7 +345,6 @@ class SnapshotManagerTest {
             public void createSnapshot(String k, String t, String n, Optional<String> ttl) {
                 creates.incrementAndGet();
                 try {
-                    // Hold the create open so competing threads reach putIfAbsent while it runs.
                     release.await(5, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -257,7 +353,7 @@ class SnapshotManagerTest {
             @Override
             public void clearSnapshot(String k, String t, String n) {}
         };
-        SnapshotManager mgr = new SnapshotManager(blocking, ReadMode.SNAPSHOT, Optional.empty());
+        SnapshotManager mgr = new SnapshotManager(blocking, ReadMode.SNAPSHOT, Optional.empty(), WINDOW, new ManualClock());
 
         int threads = 16;
         ExecutorService pool = Executors.newFixedThreadPool(threads);
@@ -266,27 +362,25 @@ class SnapshotManagerTest {
         for (int i = 0; i < threads; i++) {
             results.add(pool.submit(() -> {
                 start.await();
-                return mgr.snapshotFor("q1", "ks", "t", List.of("h1"));
+                return mgr.snapshotFor("ks", "t", List.of("h1"));
             }));
         }
-        start.countDown();          // fire all callers
-        Thread.sleep(50);           // let them collide on the in-flight create
-        release.countDown();        // let the winning create finish
+        start.countDown();
+        Thread.sleep(50);
+        release.countDown();
 
         for (java.util.concurrent.Future<Optional<String>> f : results) {
-            assertEquals(Optional.of("cqlite-q1"), f.get(5, TimeUnit.SECONDS));
+            assertEquals(Optional.of("cqlite-ks-t-0"), f.get(5, TimeUnit.SECONDS));
         }
         pool.shutdownNow();
 
-        assertEquals(1, creates.get(), "exactly one PUT for concurrent same-key callers");
+        assertEquals(1, creates.get(), "exactly one PUT for concurrent same-(window,host) callers");
     }
 
     /**
-     * A winner that dies with a NON-RuntimeException throwable (an {@link Error}) must never
-     * leave an incomplete future in the map (roborev on issue #2113): a concurrent waiter
-     * must unblock with a failure — not hang on {@code join()} forever — and a subsequent
-     * caller must retry with exactly one new PUT. Uses short get() timeouts so a liveness
-     * regression fails this test fast instead of hanging the suite.
+     * A winner that dies with a NON-RuntimeException throwable (an {@link Error}) must never leave
+     * an incomplete future in the map (roborev on #2113): a concurrent waiter unblocks with a
+     * failure — not hang on {@code join()} — and a subsequent caller retries with one new PUT.
      */
     @Test
     void errorFromCreateNeverLeavesIncompleteFuture() throws Exception {
@@ -299,7 +393,6 @@ class SnapshotManagerTest {
                 if (creates.incrementAndGet() == 1) {
                     winnerInCreate.countDown();
                     try {
-                        // Hold the create open so the waiter joins the in-flight future.
                         release.await(5, TimeUnit.SECONDS);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
@@ -311,37 +404,30 @@ class SnapshotManagerTest {
             @Override
             public void clearSnapshot(String k, String t, String n) {}
         };
-        SnapshotManager mgr = new SnapshotManager(api, ReadMode.SNAPSHOT, Optional.empty());
+        SnapshotManager mgr = new SnapshotManager(api, ReadMode.SNAPSHOT, Optional.empty(), WINDOW, new ManualClock());
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
         try {
             java.util.concurrent.Future<Optional<String>> winner =
-                    pool.submit(() -> mgr.snapshotFor("q1", "ks", "t", List.of("h1")));
+                    pool.submit(() -> mgr.snapshotFor("ks", "t", List.of("h1")));
             assertTrue(winnerInCreate.await(5, TimeUnit.SECONDS), "winner reached the create");
             java.util.concurrent.Future<Optional<String>> waiter =
-                    pool.submit(() -> mgr.snapshotFor("q1", "ks", "t", List.of("h1")));
-            Thread.sleep(50); // let the waiter pile up on the in-flight future
+                    pool.submit(() -> mgr.snapshotFor("ks", "t", List.of("h1")));
+            Thread.sleep(50);
             release.countDown();
 
-            // (a) Both callers FAIL (fail-closed); the waiter does NOT hang on join().
             java.util.concurrent.ExecutionException winnerEx = assertThrows(
-                    java.util.concurrent.ExecutionException.class,
-                    () -> winner.get(5, TimeUnit.SECONDS));
+                    java.util.concurrent.ExecutionException.class, () -> winner.get(5, TimeUnit.SECONDS));
             assertTrue(winnerEx.getCause() instanceof AssertionError,
                     "winner rethrows the original Error, got: " + winnerEx.getCause());
             java.util.concurrent.ExecutionException waiterEx = assertThrows(
-                    java.util.concurrent.ExecutionException.class,
-                    () -> waiter.get(5, TimeUnit.SECONDS));
+                    java.util.concurrent.ExecutionException.class, () -> waiter.get(5, TimeUnit.SECONDS));
             assertTrue(waiterEx.getCause() instanceof AssertionError,
                     "waiter surfaces the winner's Error, got: " + waiterEx.getCause());
 
-            // (b) The failed future was removed, so a retry recomputes and succeeds —
-            // with exactly one NEW PUT.
-            assertEquals(Optional.of("cqlite-q1"), mgr.snapshotFor("q1", "ks", "t", List.of("h1")));
+            // The failed future was removed, so a retry recomputes and succeeds — one NEW PUT.
+            assertEquals(Optional.of("cqlite-ks-t-0"), mgr.snapshotFor("ks", "t", List.of("h1")));
             assertEquals(2, creates.get(), "one failed PUT + one successful retry PUT");
-
-            // cleanup deletes only the successfully created snapshot and must not throw.
-            mgr.cleanup("q1");
         } finally {
             pool.shutdownNow();
         }


### PR DESCRIPTION
Closes #2356
Closes #2306

## Summary
Replaces the per-query Sidecar snapshot lifecycle with per-`(keyspace,table)` reuse
within an injectable-clock freshness window (Trino connector), plus a Rust flight
`rebind_hits` warm-closure counter + wiring test so a second query against an
unchanged snapshot rebinds instead of re-parsing from scratch (#2356). Snapshot
*creation* rate (and therefore memtable-flush churn, #2306) drops accordingly.

Approved design (Seam 1, owner 2026-07-14): connector-side REUSE per (ks,table)
within a documented, explicitly-approved staleness bound; generation-set change
invalidates early; LIVE mode untouched; #2383 rebind as correctness backstop.
Durable-fd option DEFERRED (recorded in design.md); `skipFlush` REJECTED (#2305 not
relitigated).

OpenSpec change: `openspec/changes/snapshot-lifecycle-closure/` (8 requirements /
13 scenarios, two capabilities: `flight-snapshot-reuse`, `flight-warm-snapshot-closure`).

## Review-first (before any full gate)
`rust-reviewer` + `roborev review --branch` both ran on the lite-green diff.
roborev found 4 blockers (triaged per `docs/development/roborev-severity.md` —
correctness bugs / unchecked arithmetic / library `expect()` are blocker-class,
no exceptions), all fixed in `6ad2004e4`:
1. **Retire-race** — superseded windows were actively `retire()`d, with no
   reference count against in-flight queries; a long scan's later splits could
   hit a deleted snapshot dir. Fixed: supersede no longer retires; reclamation is
   the Sidecar TTL backstop; active retirement only on explicit `invalidate()`/
   `retireAll()`.
2. **Double-resolveWindow race** — `snapshotFor` and `availableHosts` each
   independently re-resolved the window; fixed by resolving once and threading
   the `Window` through.
3. **Overflow** in `snapshotReuseWindowNanos()` — now uses `Math.multiplyExact`
   and fails config validation instead of silently wrapping.
4. **`expect()` in library code** (`registry.rs`) — restructured to a single
   `if let Some(...)`.

One nit (counter incremented before create-success confirmed in
`SnapshotManager.java`) is non-blocking — will batch into one follow-up issue at
merge time per the nit-batching rule, not re-verified here.

## Known gap — flag for CI, not a local blind spot to ignore
**This environment has no local JDK** — the Java/trino-connector changes (all
three Java-side blockers above, plus the original connector implementation)
could NOT be compiled or test-run locally. They were verified by close reading
only. The lite gate below is Rust-only (`cqlite-flight`). **Please do not treat
local-gate-green as sufficient for this PR** — the Gradle/trino-connector CI
lane is the first real compile check for the Java side and must go green before
merge.

## Gate status
Lite (Rust-only, this fix round):
```
==== AGENT-GATE LITE SUMMARY ====
commit: 6ad2004e4 branch: issue-2356-snapshot-lifecycle-closure dirty: no
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (5s)
scoped-tests:      PASS (17s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Note: `cqlite-flight/src/service.rs` is 1675 lines (grew 1554->1675 earlier in this
branch, driven by the flagship e2e wiring test required for wiring-evidence).
Over the ~800-line campsite target; splitting is out of this change's scope per
epic #1116 -- `CQLITE_ALLOW_FILE_GROWTH=1` was used for `--lite` with this note;
the full gate will need the same.

Full `agent-gate.sh` (the gate of record) + spec-auditor **C** intent audit +
final roborev pass to be run by `flow-closer`.