### PR TITLE
feat(#2420): flight do_get admission control — bounded concurrency, UNAVAILABLE shedding, phase-visible queueing (WS4, spec flight-admission-control)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -94,12 +94,13 @@ pub mod attr {
     /// Bounded to two values so a single metric series carries both arms for
     /// success/error-rate dashboards.
     pub const RPC_STATUS: &str = "cqlite.rpc.status";
-    /// `do_get` execution phase (issue #2162). Bounded to the closed set
-    /// `"resolve"`, `"merge_setup"`, `"stream"` — a `&'static str` from a fixed
-    /// slot table, never a per-query, per-ticket, key, or query-text value. Used
-    /// as the bounded dimension on [`super::RPC_PHASE_DURATION`] so a stalled
-    /// `do_get` localizes to a phase (time piling up in `merge_setup`) from
-    /// metrics alone.
+    /// `do_get` execution phase (issue #2162; `"admission"` added #2420
+    /// roborev-1700). Bounded to the closed set `"admission"`, `"resolve"`,
+    /// `"merge_setup"`, `"stream"` — a `&'static str` from a fixed slot table,
+    /// never a per-query, per-ticket, key, or query-text value. Used as the
+    /// bounded dimension on [`super::RPC_PHASE_DURATION`] so a stalled `do_get`
+    /// localizes to a phase (time piling up in `merge_setup`, or queued behind
+    /// the admission semaphore in `admission`) from metrics alone.
     pub const RPC_PHASE: &str = "cqlite.rpc.phase";
     /// Reason a `SELECT` fell back to a degraded (full-scan) read path
     /// (issue #2163). Values come from
@@ -526,29 +527,40 @@ pub const RPC_ROWS: &str = "cqlite.rpc.rows";
 /// single end-of-stream emission. Bounded attributes: [`attr::RPC_METHOD`].
 pub const RPC_BYTES: &str = "cqlite.rpc.bytes";
 
-/// `cqlite.rpc.phase.duration` — histogram `s` (issue #2162).
+/// `cqlite.rpc.phase.duration` — histogram `s` (issue #2162; `admission` phase
+/// added #2420 roborev-1700).
 ///
 /// Wall time a `do_get` spends in each of a bounded, closed set of execution
-/// phases — `resolve` (path discovery + token prune), `merge_setup` (opening
-/// input SSTables + building the k-way merger, the #2157 stall suspect), and
-/// `stream` (partitions stepping + batches flowing to the client). Recorded once
-/// per phase transition, so a `do_get` dominated by opening SSTables shows its
-/// wall time accumulating in `merge_setup` BEFORE the first batch — a stall that
-/// emits zero rows still localizes to a phase. Bounded attributes:
-/// [`attr::RPC_METHOD`], [`attr::RPC_PHASE`] (the closed three-value set). NEVER
+/// phases — `admission` (queued waiting for, or immediately granted, an
+/// admission permit — see #2420 — BEFORE any producer/schema construction or
+/// filesystem access), `resolve` (producer/schema construction + path
+/// discovery/token prune), `merge_setup` (opening input SSTables + building the
+/// k-way merger, the #2157 stall suspect), and `stream` (partitions stepping +
+/// batches flowing to the client). Recorded once per phase transition, so a
+/// `do_get` dominated by opening SSTables shows its wall time accumulating in
+/// `merge_setup` BEFORE the first batch, and a `do_get` queued behind a
+/// saturated admission ceiling shows it accumulating in `admission` BEFORE
+/// `resolve` even starts — a stall (or queueing delay) that emits zero rows
+/// still localizes to a phase. `cqlite.rpc.duration` already includes admission
+/// wait time in the RPC total; this is the per-phase breakdown field triage uses
+/// to localize WHERE that time went (e.g. #2398). Bounded attributes:
+/// [`attr::RPC_METHOD`], [`attr::RPC_PHASE`] (the closed four-value set). NEVER
 /// carries a ticket, key, token range, or query-text attribute.
 pub const RPC_PHASE_DURATION: &str = "cqlite.rpc.phase.duration";
 
-/// `cqlite.rpc.phase.active` — gauge `1` (issue #2361).
+/// `cqlite.rpc.phase.active` — gauge `1` (issue #2361; `admission` phase added
+/// #2420 roborev-1700).
 ///
 /// In-flight visibility of the phase a `do_get` is CURRENTLY executing, set to 1
 /// on phase entry and back to 0 on exit (via [`super::super`]'s `PhaseTimer`
 /// transition/`Drop`). [`RPC_PHASE_DURATION`] only records a sample once a phase
 /// COMPLETES, so a `do_get` wedged forever in `stream` (the #2361 hang: a merge
 /// that never returns a batch) recorded NOTHING — this gauge shows `stream = 1`
-/// for the entire hang, so a stall is observable BEFORE completion. Bounded
-/// attributes: [`attr::RPC_METHOD`], [`attr::RPC_PHASE`] (the closed three-value
-/// set) — low cardinality (methods × 3 phases). NEVER a ticket/key/query value.
+/// for the entire hang, so a stall is observable BEFORE completion; likewise a
+/// `do_get` queued behind a saturated admission ceiling shows `admission = 1`
+/// for the whole wait. Bounded attributes: [`attr::RPC_METHOD`],
+/// [`attr::RPC_PHASE`] (the closed four-value set) — low cardinality (methods ×
+/// 4 phases). NEVER a ticket/key/query value.
 pub const RPC_PHASE_ACTIVE: &str = "cqlite.rpc.phase.active";
 
 /// `cqlite.warm.cache.hits` — counter `{1}` (issue #2310).

--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -578,6 +578,48 @@ pub const WARM_CACHE_EVICTS: &str = "cqlite.warm.cache.evicts";
 /// retention in metrics alone (spec Requirement 6).
 pub const WARM_CACHE_REFRESH: &str = "cqlite.warm.cache.refresh";
 
+/// `cqlite.flight.admission.limit` — gauge `1` (issue #2420, WS4).
+///
+/// The configured `do_get` admission ceiling `K` (the `--max-concurrent-scans`
+/// value). A constant level while the server runs; recorded on startup so a
+/// dashboard can chart `in_use` against the limit. No attributes (bounded).
+/// DISTINCT from [`RPC_IN_FLIGHT`]: this is the CONFIGURED ceiling, not a live
+/// count.
+pub const FLIGHT_ADMISSION_LIMIT: &str = "cqlite.flight.admission.limit";
+
+/// `cqlite.flight.admission.in_use` — gauge `1` (issue #2420, WS4).
+///
+/// `do_get` admission permits currently held — the number of scans ADMITTED and
+/// in-flight (an up/down level like [`RPC_IN_FLIGHT`], but counting only admitted
+/// scans, not every accepted RPC incl. the ones parked waiting for a permit).
+/// Returns to zero when every admitted scan completes/cancels/disconnects (the
+/// RAII permit release). No attributes (bounded). DISTINCT from [`RPC_IN_FLIGHT`].
+pub const FLIGHT_ADMISSION_IN_USE: &str = "cqlite.flight.admission.in_use";
+
+/// `cqlite.flight.admission.waiting` — gauge `1` (issue #2420, WS4).
+///
+/// `do_get` requests currently parked on `acquire`, waiting for an admission
+/// permit to free within the permit-wait timeout. A non-zero value is the
+/// backpressure signal: offered concurrency has exceeded the ceiling and requests
+/// are queuing rather than degrading together. No attributes (bounded).
+pub const FLIGHT_ADMISSION_WAITING: &str = "cqlite.flight.admission.waiting";
+
+/// `cqlite.flight.admission.rejected_total` — counter `{1}` (issue #2420, WS4).
+///
+/// `do_get` requests rejected because no admission permit freed within the
+/// permit-wait timeout — each returned to the client as gRPC `UNAVAILABLE` (so the
+/// connector's #2241 replica-failover treats it as retry-safe), before any record
+/// batch was delivered. A monotonic total; scale-free. No attributes (bounded).
+pub const FLIGHT_ADMISSION_REJECTED_TOTAL: &str = "cqlite.flight.admission.rejected_total";
+
+/// `cqlite.flight.admission.wait_seconds` — histogram `s` (issue #2420, WS4).
+///
+/// Distribution of how long a `do_get` waited on `acquire` before it was admitted
+/// (a permit freed) OR rejected (the wait timeout elapsed). Localizes admission
+/// pressure: a rising tail means requests are increasingly queuing for permits.
+/// No attributes (bounded).
+pub const FLIGHT_ADMISSION_WAIT_SECONDS: &str = "cqlite.flight.admission.wait_seconds";
+
 /// All catalog metric names, for tests and registration sanity checks.
 pub const ALL_METRICS: &[&str] = &[
     READ_ROWS,
@@ -641,6 +683,12 @@ pub const ALL_METRICS: &[&str] = &[
     WARM_CACHE_MISSES,
     WARM_CACHE_EVICTS,
     WARM_CACHE_REFRESH,
+    // Flight do_get admission control (#2420, WS4)
+    FLIGHT_ADMISSION_LIMIT,
+    FLIGHT_ADMISSION_IN_USE,
+    FLIGHT_ADMISSION_WAITING,
+    FLIGHT_ADMISSION_REJECTED_TOTAL,
+    FLIGHT_ADMISSION_WAIT_SECONDS,
 ];
 
 #[cfg(test)]

--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -95,12 +95,14 @@ pub mod attr {
     /// success/error-rate dashboards.
     pub const RPC_STATUS: &str = "cqlite.rpc.status";
     /// `do_get` execution phase (issue #2162; `"admission"` added #2420
-    /// roborev-1700). Bounded to the closed set `"admission"`, `"resolve"`,
-    /// `"merge_setup"`, `"stream"` — a `&'static str` from a fixed slot table,
-    /// never a per-query, per-ticket, key, or query-text value. Used as the
-    /// bounded dimension on [`super::RPC_PHASE_DURATION`] so a stalled `do_get`
-    /// localizes to a phase (time piling up in `merge_setup`, or queued behind
-    /// the admission semaphore in `admission`) from metrics alone.
+    /// roborev-1700; `"validate"` added #2420 roborev-1702). Bounded to the
+    /// closed set `"validate"`, `"admission"`, `"resolve"`, `"merge_setup"`,
+    /// `"stream"` — a `&'static str` from a fixed slot table, never a
+    /// per-query, per-ticket, key, or query-text value. Used as the bounded
+    /// dimension on [`super::RPC_PHASE_DURATION`] so a stalled `do_get`
+    /// localizes to a phase (time piling up in `merge_setup`, queued behind the
+    /// admission semaphore in `admission`, or stuck parsing/validating a
+    /// malformed ticket in `validate`) from metrics alone.
     pub const RPC_PHASE: &str = "cqlite.rpc.phase";
     /// Reason a `SELECT` fell back to a degraded (full-scan) read path
     /// (issue #2163). Values come from
@@ -528,28 +530,31 @@ pub const RPC_ROWS: &str = "cqlite.rpc.rows";
 pub const RPC_BYTES: &str = "cqlite.rpc.bytes";
 
 /// `cqlite.rpc.phase.duration` — histogram `s` (issue #2162; `admission` phase
-/// added #2420 roborev-1700).
+/// added #2420 roborev-1700; `validate` phase added #2420 roborev-1702).
 ///
 /// Wall time a `do_get` spends in each of a bounded, closed set of execution
-/// phases — `admission` (queued waiting for, or immediately granted, an
-/// admission permit — see #2420 — BEFORE any producer/schema construction or
-/// filesystem access), `resolve` (producer/schema construction + path
+/// phases — `validate` (parsing the ticket bytes, BEFORE any admission-permit
+/// acquire — a syntactically malformed ticket records ONLY this phase),
+/// `admission` (queued waiting for, or immediately granted, an admission permit
+/// — see #2420 — AFTER validation but BEFORE any producer/schema construction
+/// or filesystem access), `resolve` (producer/schema construction + path
 /// discovery/token prune), `merge_setup` (opening input SSTables + building the
 /// k-way merger, the #2157 stall suspect), and `stream` (partitions stepping +
 /// batches flowing to the client). Recorded once per phase transition, so a
 /// `do_get` dominated by opening SSTables shows its wall time accumulating in
 /// `merge_setup` BEFORE the first batch, and a `do_get` queued behind a
 /// saturated admission ceiling shows it accumulating in `admission` BEFORE
-/// `resolve` even starts — a stall (or queueing delay) that emits zero rows
-/// still localizes to a phase. `cqlite.rpc.duration` already includes admission
-/// wait time in the RPC total; this is the per-phase breakdown field triage uses
-/// to localize WHERE that time went (e.g. #2398). Bounded attributes:
-/// [`attr::RPC_METHOD`], [`attr::RPC_PHASE`] (the closed four-value set). NEVER
-/// carries a ticket, key, token range, or query-text attribute.
+/// `resolve` even starts — a stall (or queueing delay, or a flood of malformed
+/// tickets) that emits zero rows still localizes to a phase. `cqlite.rpc.duration`
+/// already includes admission wait time in the RPC total; this is the per-phase
+/// breakdown field triage uses to localize WHERE that time went (e.g. #2398).
+/// Bounded attributes: [`attr::RPC_METHOD`], [`attr::RPC_PHASE`] (the closed
+/// five-value set). NEVER carries a ticket, key, token range, or query-text
+/// attribute.
 pub const RPC_PHASE_DURATION: &str = "cqlite.rpc.phase.duration";
 
 /// `cqlite.rpc.phase.active` — gauge `1` (issue #2361; `admission` phase added
-/// #2420 roborev-1700).
+/// #2420 roborev-1700; `validate` phase added #2420 roborev-1702).
 ///
 /// In-flight visibility of the phase a `do_get` is CURRENTLY executing, set to 1
 /// on phase entry and back to 0 on exit (via [`super::super`]'s `PhaseTimer`
@@ -559,8 +564,8 @@ pub const RPC_PHASE_DURATION: &str = "cqlite.rpc.phase.duration";
 /// for the entire hang, so a stall is observable BEFORE completion; likewise a
 /// `do_get` queued behind a saturated admission ceiling shows `admission = 1`
 /// for the whole wait. Bounded attributes: [`attr::RPC_METHOD`],
-/// [`attr::RPC_PHASE`] (the closed four-value set) — low cardinality (methods ×
-/// 4 phases). NEVER a ticket/key/query value.
+/// [`attr::RPC_PHASE`] (the closed five-value set) — low cardinality (methods ×
+/// 5 phases). NEVER a ticket/key/query value.
 pub const RPC_PHASE_ACTIVE: &str = "cqlite.rpc.phase.active";
 
 /// `cqlite.warm.cache.hits` — counter `{1}` (issue #2310).

--- a/cqlite-flight/Cargo.toml
+++ b/cqlite-flight/Cargo.toml
@@ -78,6 +78,11 @@ dhat-heap = []
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# `test-util` enables the paused/auto-advancing Tokio clock (`tokio::time::pause`)
+# so the #2420 admission-control tests drive the permit-wait timeout
+# deterministically (no wall-clock sleep). Dev-only: never compiled into the
+# production `cqlite-flight` binary.
+tokio = { workspace = true, features = ["test-util"] }
 # Criterion for the end-to-end `flight_do_get` throughput bench (issue #1494,
 # AD5). ADVISORY perf-gate entry — its wall time is Tokio-runtime + tonic-
 # transport dominated (the `write/ingest_wal_on` precedent), so it is reported

--- a/cqlite-flight/src/admission.rs
+++ b/cqlite-flight/src/admission.rs
@@ -339,9 +339,18 @@ impl Drop for WaitGuard {
 /// permit and decrements `in_use`. Moved into the `do_get` response stream so
 /// every stream-exit path (completion, client disconnect, cancellation) drops it —
 /// one lifetime, structurally leak-free.
+///
+/// The permit field is `Option` (roborev-1702), NOT a bare `OwnedSemaphorePermit`:
+/// Rust drops a struct's fields AFTER `Drop::drop` returns, so a bare field would
+/// release the semaphore permit (making capacity available to a waiter) ONLY
+/// AFTER the `in_use` gauge decrement below had already executed — a transient
+/// window where the gauge undercounts real capacity relative to what a waiter
+/// can actually observe becoming free. `Drop` below explicitly `take()`s and
+/// drops the permit FIRST, so the semaphore's availability and the `in_use`
+/// gauge move in the same order every time.
 #[derive(Debug)]
 pub struct AdmissionPermit {
-    _permit: OwnedSemaphorePermit,
+    permit: Option<OwnedSemaphorePermit>,
     inner: Arc<AdmissionInner>,
 }
 
@@ -350,7 +359,7 @@ impl AdmissionPermit {
         let level = inner.in_use.fetch_add(1, Ordering::Relaxed) + 1;
         obs::record_gauge(catalog::FLIGHT_ADMISSION_IN_USE, level, &[]);
         Self {
-            _permit: permit,
+            permit: Some(permit),
             inner,
         }
     }
@@ -358,6 +367,10 @@ impl AdmissionPermit {
 
 impl Drop for AdmissionPermit {
     fn drop(&mut self) {
+        // Release the semaphore permit FIRST (roborev-1702) — before the `in_use`
+        // gauge decrement, so a waiter that wakes on this release never observes
+        // a gauge still counting this permit as held.
+        drop(self.permit.take());
         let prev = self.inner.in_use.fetch_sub(1, Ordering::Relaxed);
         let level = (prev - 1).max(0);
         obs::record_gauge(catalog::FLIGHT_ADMISSION_IN_USE, level, &[]);

--- a/cqlite-flight/src/admission.rs
+++ b/cqlite-flight/src/admission.rs
@@ -270,10 +270,19 @@ impl Admission {
         // released on EVERY exit, including a cancellation that drops this
         // future mid-`.await` (a request cancelled while waiting never held a
         // permit and must not leak the waiting count).
-        let _waiter = WaitGuard::enter(Arc::clone(&inner));
+        let waiter = WaitGuard::enter(Arc::clone(&inner));
         let started = tokio::time::Instant::now();
         let sem = Arc::clone(&inner.sem);
-        match tokio::time::timeout(inner.wait_timeout, sem.acquire_owned()).await {
+        let result = tokio::time::timeout(inner.wait_timeout, sem.acquire_owned()).await;
+        // roborev-1700 (same gauge-accuracy class as roborev-1696): drop the
+        // waiter THE INSTANT the future resolves — before recording the wait
+        // sample or constructing the `AdmissionPermit` (which bumps `in_use`) —
+        // so an admitted (or rejected) request is never simultaneously counted
+        // both waiting AND in_use. `waiter`'s scope-end drop would otherwise
+        // outlive `AdmissionPermit::new` below, overlapping both gauges for the
+        // span of that call.
+        drop(waiter);
+        match result {
             Ok(Ok(permit)) => {
                 inner.record_wait(started.elapsed());
                 Ok(AdmissionPermit::new(permit, inner))

--- a/cqlite-flight/src/admission.rs
+++ b/cqlite-flight/src/admission.rs
@@ -1,0 +1,341 @@
+//! `do_get` admission control (issue #2420, WS4).
+//!
+//! The Flight server has no application-level ceiling on concurrent `do_get`
+//! scans: past ~256 concurrent scans the Tokio blocking pool (512 threads, ~2 per
+//! scan) queues silently, each scan opens a fresh fd per SSTable toward the
+//! container `ulimit`, and peak RSS grows with offered concurrency — every
+//! in-flight request degrades together rather than the server queueing or
+//! shedding load gracefully.
+//!
+//! [`Admission`] bounds concurrent admitted scans to a configured `K` via an
+//! owned [`tokio::sync::Semaphore`]. A `do_get` acquires a permit BEFORE opening
+//! any SSTable (see [`crate::service`]), holds it — through the RAII
+//! [`AdmissionPermit`] moved into the response stream — for the scan's lifetime,
+//! and releases it on completion, client disconnect, or cancellation. On
+//! saturation a request waits a bounded [`AdmissionConfig::wait_timeout`] for a
+//! permit; if none frees it is rejected with gRPC **`UNAVAILABLE`** (never
+//! `RESOURCE_EXHAUSTED`, which the connector's #2241 replica-failover would treat
+//! as a hard query failure) BEFORE any record batch is delivered, so failover to
+//! another replica is correctness-safe.
+//!
+//! All admission state is mirrored to the `cqlite.flight.admission.*` metric
+//! catalog AND held in feature-independent atomics (readable via [`Admission::snapshot`]),
+//! so the deterministic tests observe engagement without depending on the
+//! `observability` OTel feature — mirroring the [`crate::obs::RpcMetrics`] pattern.
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use cqlite_core::observability::{self as obs, catalog};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tonic::Status;
+
+/// Default `do_get` admission ceiling.
+///
+/// Sized from the binding constraints (NOT `num_cpus` — CPU is not the limit):
+/// the Tokio blocking pool caps at 512 threads and each scan consumes ~2 (a setup
+/// `spawn_blocking` + the merge `spawn_blocking`), a ~256 ceiling; each scan also
+/// opens one fd per input SSTable against the ~1024 container `ulimit`, a
+/// `1024 / M`-SSTable ceiling. 64 sits well below both (≥4× blocking-pool
+/// headroom, ~64 fds at M≈16) while still absorbing bursty offered concurrency.
+/// Conservative pending WS1-ramp (WS8) validation before the default is locked.
+pub const DEFAULT_MAX_CONCURRENT_SCANS: usize = 64;
+
+/// Default permit-wait timeout: how long a saturated `do_get` parks for a permit
+/// before it is shed with `UNAVAILABLE`. Long enough to absorb short bursts
+/// transparently, bounded so sustained overload sheds rather than hangs.
+pub const DEFAULT_WAIT_TIMEOUT_MS: u64 = 30_000;
+
+/// Environment variable backing `--max-concurrent-scans`.
+pub const ENV_MAX_CONCURRENT_SCANS: &str = "CQLITE_MAX_CONCURRENT_SCANS";
+
+/// Environment variable backing `--admission-wait-timeout-ms`.
+pub const ENV_WAIT_TIMEOUT_MS: &str = "CQLITE_ADMISSION_WAIT_TIMEOUT_MS";
+
+/// Configuration for [`Admission`]: the ceiling and the permit-wait timeout. Both
+/// are real, wired knobs (CLI flag + env; see [`crate`]'s `main`).
+#[derive(Debug, Clone, Copy)]
+pub struct AdmissionConfig {
+    /// The admission ceiling `K` — the maximum number of concurrently admitted
+    /// `do_get` scans. Clamped to a minimum of 1 by [`Admission::new`].
+    pub max_concurrent_scans: usize,
+    /// How long a request waits on `acquire` for a permit before it is rejected
+    /// with `UNAVAILABLE`. Injectable so tests drive it deterministically under a
+    /// paused Tokio clock (no wall-clock sleep).
+    pub wait_timeout: Duration,
+}
+
+impl Default for AdmissionConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_scans: DEFAULT_MAX_CONCURRENT_SCANS,
+            wait_timeout: Duration::from_millis(DEFAULT_WAIT_TIMEOUT_MS),
+        }
+    }
+}
+
+impl AdmissionConfig {
+    /// Build from the environment, falling back to the documented defaults. A
+    /// present-but-unparseable value (or a zero ceiling) falls back to the default
+    /// rather than failing startup. `max_concurrent_scans` is clamped to ≥1 by
+    /// [`Admission::new`].
+    pub fn from_env() -> Self {
+        let mut cfg = Self::default();
+        if let Some(k) = std::env::var(ENV_MAX_CONCURRENT_SCANS)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|k| *k >= 1)
+        {
+            cfg.max_concurrent_scans = k;
+        }
+        if let Some(ms) = std::env::var(ENV_WAIT_TIMEOUT_MS)
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+        {
+            cfg.wait_timeout = Duration::from_millis(ms);
+        }
+        cfg
+    }
+}
+
+/// A point-in-time read of the admission counters, feature-independent (does not
+/// require the `observability` OTel feature). All fields are levels or monotonic
+/// totals — scale-free, independent of fixture row/SSTable count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdmissionSnapshot {
+    /// The configured ceiling `K`.
+    pub limit: usize,
+    /// Permits currently held (admitted, in-flight scans).
+    pub in_use: i64,
+    /// Requests currently parked on `acquire`.
+    pub waiting: i64,
+    /// Monotonic count of timeout rejections (each returned `UNAVAILABLE`).
+    pub rejected_total: u64,
+    /// Monotonic count of permit-wait histogram samples recorded (one per
+    /// acquire outcome — admit or reject). The feature-independent evidence that
+    /// the wait-latency instrument engaged.
+    pub wait_samples: u64,
+}
+
+/// Shared admission state behind [`Admission`]'s `Arc`.
+#[derive(Debug)]
+struct AdmissionInner {
+    /// The permit pool. Held in its own `Arc` so [`Semaphore::acquire_owned`] can
+    /// hand out `'static` [`OwnedSemaphorePermit`]s moved into response streams.
+    sem: Arc<Semaphore>,
+    limit: usize,
+    wait_timeout: Duration,
+    in_use: AtomicI64,
+    waiting: AtomicI64,
+    rejected: AtomicU64,
+    wait_samples: AtomicU64,
+}
+
+impl AdmissionInner {
+    /// Record a permit-wait sample (both the admit and reject paths): bump the
+    /// feature-independent sample counter and mirror the duration to the catalog
+    /// histogram.
+    fn record_wait(&self, waited: Duration) {
+        self.wait_samples.fetch_add(1, Ordering::Relaxed);
+        obs::record_histogram(
+            catalog::FLIGHT_ADMISSION_WAIT_SECONDS,
+            waited.as_secs_f64(),
+            &[],
+        );
+    }
+}
+
+/// A cloneable `do_get` admission ceiling. Clones share one semaphore + counter
+/// set (the `Arc`), so every per-RPC [`crate::service::CqliteFlightService`] clone
+/// throttles against the SAME `K`.
+#[derive(Clone)]
+pub struct Admission {
+    inner: Arc<AdmissionInner>,
+}
+
+impl Admission {
+    /// Build an admission ceiling from `config`. The ceiling is clamped to a
+    /// minimum of 1 (a zero-permit semaphore would reject every request). Records
+    /// the configured limit gauge.
+    pub fn new(config: AdmissionConfig) -> Self {
+        let limit = config.max_concurrent_scans.max(1);
+        obs::record_gauge(catalog::FLIGHT_ADMISSION_LIMIT, limit as i64, &[]);
+        Self {
+            inner: Arc::new(AdmissionInner {
+                sem: Arc::new(Semaphore::new(limit)),
+                limit,
+                wait_timeout: config.wait_timeout,
+                in_use: AtomicI64::new(0),
+                waiting: AtomicI64::new(0),
+                rejected: AtomicU64::new(0),
+                wait_samples: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    /// The configured ceiling `K`.
+    pub fn limit(&self) -> usize {
+        self.inner.limit
+    }
+
+    /// The configured permit-wait timeout.
+    pub fn wait_timeout(&self) -> Duration {
+        self.inner.wait_timeout
+    }
+
+    /// A point-in-time read of the admission counters.
+    pub fn snapshot(&self) -> AdmissionSnapshot {
+        AdmissionSnapshot {
+            limit: self.inner.limit,
+            in_use: self.inner.in_use.load(Ordering::Relaxed),
+            waiting: self.inner.waiting.load(Ordering::Relaxed),
+            rejected_total: self.inner.rejected.load(Ordering::Relaxed),
+            wait_samples: self.inner.wait_samples.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Acquire an admission permit, waiting up to [`AdmissionConfig::wait_timeout`].
+    ///
+    /// On success returns an [`AdmissionPermit`] RAII guard that holds the
+    /// semaphore permit AND the `in_use` gauge until dropped (moved into the
+    /// response stream so every exit path — completion, disconnect, cancel —
+    /// releases it). On timeout returns a gRPC **`UNAVAILABLE`** [`Status`] (never
+    /// `RESOURCE_EXHAUSTED`) and increments `rejected_total`.
+    ///
+    /// A request whose future is dropped while WAITING (client disconnect before
+    /// admission) never acquires a permit and its `waiting` count is released by
+    /// the [`WaitGuard`] drop — no leak on either the wait or the hold path.
+    pub async fn acquire(&self) -> Result<AdmissionPermit, Status> {
+        let inner = Arc::clone(&self.inner);
+        // RAII: the `waiting` gauge is released on EVERY exit, including a
+        // cancellation that drops this future mid-`.await` (a request cancelled
+        // while waiting never held a permit and must not leak the waiting count).
+        let _waiter = WaitGuard::enter(Arc::clone(&inner));
+        let started = tokio::time::Instant::now();
+        let sem = Arc::clone(&inner.sem);
+        match tokio::time::timeout(inner.wait_timeout, sem.acquire_owned()).await {
+            Ok(Ok(permit)) => {
+                inner.record_wait(started.elapsed());
+                Ok(AdmissionPermit::new(permit, inner))
+            }
+            // The semaphore is only ever closed on shutdown; surface it as the same
+            // retry-safe status so an in-flight acquire during drain sheds cleanly.
+            Ok(Err(_closed)) => Err(reject_status()),
+            Err(_elapsed) => {
+                inner.record_wait(started.elapsed());
+                inner.rejected.fetch_add(1, Ordering::Relaxed);
+                obs::add_counter(catalog::FLIGHT_ADMISSION_REJECTED_TOTAL, 1, &[]);
+                Err(reject_status())
+            }
+        }
+    }
+}
+
+/// The rejection status returned when no permit frees within the wait timeout.
+///
+/// MUST be `UNAVAILABLE`: the connector's #2241 `ReplicaFailoverStream` fails over
+/// to the next replica ONLY on `UNAVAILABLE` (and only pre-first-batch), so a
+/// sustained-overload reject sheds to a less-loaded replica rather than failing
+/// the query. `RESOURCE_EXHAUSTED` (or any other code) would be rethrown and fail
+/// the split.
+fn reject_status() -> Status {
+    Status::unavailable(
+        "cqlite-flight: server at max-concurrent-scans capacity; \
+         retry (failover-safe: no batch delivered)",
+    )
+}
+
+/// RAII guard for the `waiting` gauge: bumped on `enter`, released on `Drop` —
+/// including the future-drop (client-disconnect-while-waiting) path.
+struct WaitGuard {
+    inner: Arc<AdmissionInner>,
+}
+
+impl WaitGuard {
+    fn enter(inner: Arc<AdmissionInner>) -> Self {
+        let level = inner.waiting.fetch_add(1, Ordering::Relaxed) + 1;
+        obs::record_gauge(catalog::FLIGHT_ADMISSION_WAITING, level, &[]);
+        Self { inner }
+    }
+}
+
+impl Drop for WaitGuard {
+    fn drop(&mut self) {
+        let prev = self.inner.waiting.fetch_sub(1, Ordering::Relaxed);
+        let level = (prev - 1).max(0);
+        obs::record_gauge(catalog::FLIGHT_ADMISSION_WAITING, level, &[]);
+    }
+}
+
+/// An held admission permit. Owns the [`OwnedSemaphorePermit`] AND the `in_use`
+/// gauge: constructing it increments `in_use`, dropping it releases the semaphore
+/// permit and decrements `in_use`. Moved into the `do_get` response stream so
+/// every stream-exit path (completion, client disconnect, cancellation) drops it —
+/// one lifetime, structurally leak-free.
+#[derive(Debug)]
+pub struct AdmissionPermit {
+    _permit: OwnedSemaphorePermit,
+    inner: Arc<AdmissionInner>,
+}
+
+impl AdmissionPermit {
+    fn new(permit: OwnedSemaphorePermit, inner: Arc<AdmissionInner>) -> Self {
+        let level = inner.in_use.fetch_add(1, Ordering::Relaxed) + 1;
+        obs::record_gauge(catalog::FLIGHT_ADMISSION_IN_USE, level, &[]);
+        Self {
+            _permit: permit,
+            inner,
+        }
+    }
+}
+
+impl Drop for AdmissionPermit {
+    fn drop(&mut self) {
+        let prev = self.inner.in_use.fetch_sub(1, Ordering::Relaxed);
+        let level = (prev - 1).max(0);
+        obs::record_gauge(catalog::FLIGHT_ADMISSION_IN_USE, level, &[]);
+    }
+}
+
+/// Wrap a `do_get` response stream so it holds `permit` for the stream's whole
+/// lifetime. The wrapper is a transparent pass-through — it forwards every item
+/// and the terminal `None` unchanged (byte-identical rows/order/schema/batch
+/// boundaries; admission changes *when* a scan runs, never *what* it returns) —
+/// and drops `permit` (releasing admission) when the stream completes or is
+/// dropped (client disconnect).
+pub(crate) fn admitted_stream(
+    inner: crate::streaming::DoGetStream,
+    permit: AdmissionPermit,
+) -> crate::streaming::DoGetStream {
+    Box::pin(AdmittedStream {
+        inner,
+        _permit: permit,
+    })
+}
+
+/// The pass-through stream produced by [`admitted_stream`]. `AdmittedStream` is
+/// `Unpin` (both fields are), so `poll_next` projects through `get_mut`.
+struct AdmittedStream {
+    inner: crate::streaming::DoGetStream,
+    _permit: AdmissionPermit,
+}
+
+impl futures::Stream for AdmittedStream {
+    type Item = Result<arrow_flight::FlightData, Status>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.get_mut().inner.as_mut().poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+#[cfg(test)]
+#[path = "admission_tests.rs"]
+mod tests;

--- a/cqlite-flight/src/admission.rs
+++ b/cqlite-flight/src/admission.rs
@@ -187,6 +187,23 @@ impl Admission {
         }
     }
 
+    /// An admission ceiling that is, for all practical purposes, unconstrained
+    /// (issue #2420, roborev-1699): `Semaphore::MAX_PERMITS` permits and an
+    /// effectively-infinite wait timeout, so this can never meaningfully gate a
+    /// `do_get`. This is what
+    /// [`crate::service::CqliteFlightService::new`] uses so a library caller
+    /// embedding `cqlite-flight` keeps EXACTLY today's (pre-#2420) behavior — no
+    /// environment read, no ceiling on concurrent scans. Admission becomes a
+    /// real gate only when a caller explicitly opts in via
+    /// [`crate::service::CqliteFlightService::with_admission`] (the `cqlite-flight`
+    /// SERVER BINARY, `main`, does this with a CLI/env-configured `K`).
+    pub fn unconstrained() -> Self {
+        Self::new(AdmissionConfig {
+            max_concurrent_scans: Semaphore::MAX_PERMITS,
+            wait_timeout: Duration::MAX,
+        })
+    }
+
     /// The configured ceiling `K`.
     pub fn limit(&self) -> usize {
         self.inner.limit

--- a/cqlite-flight/src/admission.rs
+++ b/cqlite-flight/src/admission.rs
@@ -53,7 +53,37 @@ pub const ENV_MAX_CONCURRENT_SCANS: &str = "CQLITE_MAX_CONCURRENT_SCANS";
 /// Environment variable backing `--admission-wait-timeout-ms`.
 pub const ENV_WAIT_TIMEOUT_MS: &str = "CQLITE_ADMISSION_WAIT_TIMEOUT_MS";
 
-/// Configuration for [`Admission`]: the ceiling and the permit-wait timeout. Both
+/// The permit-wait budget: how long a saturated `do_get` may wait for an
+/// admission permit before it is rejected with `UNAVAILABLE`.
+///
+/// Deliberately NOT represented as a bare `Duration` with a `Duration::MAX`
+/// sentinel for "unbounded" (roborev-1703): `tokio::time::timeout` computes an
+/// absolute deadline (`Instant::now() + duration`) internally, and
+/// `Instant::now() + Duration::MAX` is an overflow/panic hazard that must never
+/// depend on how far in the future "now" happens to be — library code must
+/// never carry that hazard, even latently. [`WaitBudget::Unbounded`] instead
+/// skips the `timeout()` wrapper entirely in [`Admission::acquire`], awaiting
+/// `acquire_owned()` directly — no deadline math at all, so there is nothing to
+/// overflow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitBudget {
+    /// Wait as long as it takes for a permit to free (or the semaphore to
+    /// close, on shutdown). Used by [`Admission::unconstrained`] — a caller
+    /// that never opted into a configured ceiling gets a `do_get` that never
+    /// sheds on a wait timeout (the semaphore is effectively uncontended at
+    /// [`Semaphore::MAX_PERMITS`] anyway).
+    Unbounded,
+    /// Wait up to `Duration`, then reject with `UNAVAILABLE`.
+    Timeout(Duration),
+}
+
+impl From<Duration> for WaitBudget {
+    fn from(d: Duration) -> Self {
+        WaitBudget::Timeout(d)
+    }
+}
+
+/// Configuration for [`Admission`]: the ceiling and the permit-wait budget. Both
 /// are real, wired knobs (CLI flag + env; see [`crate`]'s `main`).
 #[derive(Debug, Clone, Copy)]
 pub struct AdmissionConfig {
@@ -61,16 +91,17 @@ pub struct AdmissionConfig {
     /// `do_get` scans. Clamped to a minimum of 1 by [`Admission::new`].
     pub max_concurrent_scans: usize,
     /// How long a request waits on `acquire` for a permit before it is rejected
-    /// with `UNAVAILABLE`. Injectable so tests drive it deterministically under a
+    /// with `UNAVAILABLE` — see [`WaitBudget`] for why this is an enum, not a
+    /// bare `Duration`. Injectable so tests drive it deterministically under a
     /// paused Tokio clock (no wall-clock sleep).
-    pub wait_timeout: Duration,
+    pub wait_budget: WaitBudget,
 }
 
 impl Default for AdmissionConfig {
     fn default() -> Self {
         Self {
             max_concurrent_scans: DEFAULT_MAX_CONCURRENT_SCANS,
-            wait_timeout: Duration::from_millis(DEFAULT_WAIT_TIMEOUT_MS),
+            wait_budget: WaitBudget::Timeout(Duration::from_millis(DEFAULT_WAIT_TIMEOUT_MS)),
         }
     }
 }
@@ -93,7 +124,7 @@ impl AdmissionConfig {
             .ok()
             .and_then(|v| v.trim().parse::<u64>().ok())
         {
-            cfg.wait_timeout = Duration::from_millis(ms);
+            cfg.wait_budget = WaitBudget::Timeout(Duration::from_millis(ms));
         }
         cfg
     }
@@ -125,7 +156,7 @@ struct AdmissionInner {
     /// hand out `'static` [`OwnedSemaphorePermit`]s moved into response streams.
     sem: Arc<Semaphore>,
     limit: usize,
-    wait_timeout: Duration,
+    wait_budget: WaitBudget,
     in_use: AtomicI64,
     waiting: AtomicI64,
     rejected: AtomicU64,
@@ -178,7 +209,7 @@ impl Admission {
             inner: Arc::new(AdmissionInner {
                 sem: Arc::new(Semaphore::new(limit)),
                 limit,
-                wait_timeout: config.wait_timeout,
+                wait_budget: config.wait_budget,
                 in_use: AtomicI64::new(0),
                 waiting: AtomicI64::new(0),
                 rejected: AtomicU64::new(0),
@@ -188,9 +219,10 @@ impl Admission {
     }
 
     /// An admission ceiling that is, for all practical purposes, unconstrained
-    /// (issue #2420, roborev-1699): `Semaphore::MAX_PERMITS` permits and an
-    /// effectively-infinite wait timeout, so this can never meaningfully gate a
-    /// `do_get`. This is what
+    /// (issue #2420, roborev-1699): `Semaphore::MAX_PERMITS` permits and
+    /// [`WaitBudget::Unbounded`] (never a `Duration::MAX` sentinel — see
+    /// [`WaitBudget`]'s doc for why that would be an overflow hazard), so this
+    /// can never meaningfully gate a `do_get`. This is what
     /// [`crate::service::CqliteFlightService::new`] uses so a library caller
     /// embedding `cqlite-flight` keeps EXACTLY today's (pre-#2420) behavior — no
     /// environment read, no ceiling on concurrent scans. Admission becomes a
@@ -200,7 +232,7 @@ impl Admission {
     pub fn unconstrained() -> Self {
         Self::new(AdmissionConfig {
             max_concurrent_scans: Semaphore::MAX_PERMITS,
-            wait_timeout: Duration::MAX,
+            wait_budget: WaitBudget::Unbounded,
         })
     }
 
@@ -209,9 +241,9 @@ impl Admission {
         self.inner.limit
     }
 
-    /// The configured permit-wait timeout.
-    pub fn wait_timeout(&self) -> Duration {
-        self.inner.wait_timeout
+    /// The configured permit-wait budget.
+    pub fn wait_budget(&self) -> WaitBudget {
+        self.inner.wait_budget
     }
 
     /// A point-in-time read of the admission counters.
@@ -225,8 +257,8 @@ impl Admission {
         }
     }
 
-    /// Acquire an admission permit, waiting up to [`AdmissionConfig::wait_timeout`]
-    /// only if the ceiling is currently saturated.
+    /// Acquire an admission permit, waiting up to the configured
+    /// [`WaitBudget`] only if the ceiling is currently saturated.
     ///
     /// **Fast path (roborev-1696):** an UNCONTENDED acquire (a permit is
     /// immediately available) is served by [`Semaphore::try_acquire_owned`] and
@@ -240,18 +272,22 @@ impl Admission {
     /// non-events.
     ///
     /// **Slow path:** only entered on [`tokio::sync::TryAcquireError::NoPermits`]
-    /// — the ceiling is saturated. Bumps `waiting`, then waits up to the
-    /// configured timeout. On success returns an [`AdmissionPermit`] RAII guard
-    /// that holds the semaphore permit AND the `in_use` gauge until dropped
-    /// (moved into the response stream so every exit path — completion,
-    /// disconnect, cancel — releases it) and records the genuine wait sample. On
-    /// timeout returns a gRPC **`UNAVAILABLE`** [`Status`] (never
-    /// `RESOURCE_EXHAUSTED`) and increments `rejected_total`.
+    /// — the ceiling is saturated. Bumps `waiting`, then waits per the configured
+    /// [`WaitBudget`] — [`WaitBudget::Timeout`] wraps the acquire in
+    /// `tokio::time::timeout`; [`WaitBudget::Unbounded`] (roborev-1703) awaits
+    /// `acquire_owned` DIRECTLY, with no `timeout()` wrapper and therefore no
+    /// deadline computation to overflow. On success returns an
+    /// [`AdmissionPermit`] RAII guard that holds the semaphore permit AND the
+    /// `in_use` gauge until dropped (moved into the response stream so every
+    /// exit path — completion, disconnect, cancel — releases it) and records the
+    /// genuine wait sample. On a `Timeout` budget's deadline elapsing, returns a
+    /// gRPC **`UNAVAILABLE`** [`Status`] (never `RESOURCE_EXHAUSTED`) and
+    /// increments `rejected_total`; `Unbounded` can never take this arm.
     ///
     /// A request whose future is dropped while WAITING (client disconnect before
     /// admission) never acquires a permit and its `waiting` count is released by
     /// the [`WaitGuard`] drop — no leak on either the wait or the hold path. The
-    /// semaphore is only ever closed on shutdown; both paths map a closed
+    /// semaphore is only ever closed on shutdown; both budgets map a closed
     /// semaphore to the same retry-safe `UNAVAILABLE` shed.
     pub async fn acquire(&self) -> Result<AdmissionPermit, Status> {
         let inner = Arc::clone(&self.inner);
@@ -273,7 +309,21 @@ impl Admission {
         let waiter = WaitGuard::enter(Arc::clone(&inner));
         let started = tokio::time::Instant::now();
         let sem = Arc::clone(&inner.sem);
-        let result = tokio::time::timeout(inner.wait_timeout, sem.acquire_owned()).await;
+        // roborev-1703: NO `Duration::MAX` sentinel anywhere. `Unbounded` awaits
+        // `acquire_owned` with no `timeout()` wrapper at all — no deadline
+        // computed, so nothing can overflow. Only `Timeout(d)` computes a
+        // (bounded, caller-supplied) deadline.
+        let outcome = match inner.wait_budget {
+            WaitBudget::Unbounded => match sem.acquire_owned().await {
+                Ok(permit) => SlowAcquireOutcome::Admitted(permit),
+                Err(_closed) => SlowAcquireOutcome::Closed,
+            },
+            WaitBudget::Timeout(d) => match tokio::time::timeout(d, sem.acquire_owned()).await {
+                Ok(Ok(permit)) => SlowAcquireOutcome::Admitted(permit),
+                Ok(Err(_closed)) => SlowAcquireOutcome::Closed,
+                Err(_elapsed) => SlowAcquireOutcome::TimedOut,
+            },
+        };
         // roborev-1700 (same gauge-accuracy class as roborev-1696): drop the
         // waiter THE INSTANT the future resolves — before recording the wait
         // sample or constructing the `AdmissionPermit` (which bumps `in_use`) —
@@ -282,13 +332,13 @@ impl Admission {
         // outlive `AdmissionPermit::new` below, overlapping both gauges for the
         // span of that call.
         drop(waiter);
-        match result {
-            Ok(Ok(permit)) => {
+        match outcome {
+            SlowAcquireOutcome::Admitted(permit) => {
                 inner.record_wait(started.elapsed());
                 Ok(AdmissionPermit::new(permit, inner))
             }
-            Ok(Err(_closed)) => Err(reject_status()),
-            Err(_elapsed) => {
+            SlowAcquireOutcome::Closed => Err(reject_status()),
+            SlowAcquireOutcome::TimedOut => {
                 inner.record_wait(started.elapsed());
                 inner.rejected.fetch_add(1, Ordering::Relaxed);
                 obs::add_counter(catalog::FLIGHT_ADMISSION_REJECTED_TOTAL, 1, &[]);
@@ -296,6 +346,16 @@ impl Admission {
             }
         }
     }
+}
+
+/// The three outcomes of the slow-path acquire (roborev-1703): unifies the
+/// `WaitBudget::Unbounded` (no timeout wrapper — cannot time out) and
+/// `WaitBudget::Timeout` (may time out) arms into one `match` below, so the
+/// gauge/counter bookkeeping after the await is written exactly once.
+enum SlowAcquireOutcome {
+    Admitted(OwnedSemaphorePermit),
+    Closed,
+    TimedOut,
 }
 
 /// The rejection status returned when no permit frees within the wait timeout.

--- a/cqlite-flight/src/admission.rs
+++ b/cqlite-flight/src/admission.rs
@@ -195,22 +195,51 @@ impl Admission {
         }
     }
 
-    /// Acquire an admission permit, waiting up to [`AdmissionConfig::wait_timeout`].
+    /// Acquire an admission permit, waiting up to [`AdmissionConfig::wait_timeout`]
+    /// only if the ceiling is currently saturated.
     ///
-    /// On success returns an [`AdmissionPermit`] RAII guard that holds the
-    /// semaphore permit AND the `in_use` gauge until dropped (moved into the
-    /// response stream so every exit path — completion, disconnect, cancel —
-    /// releases it). On timeout returns a gRPC **`UNAVAILABLE`** [`Status`] (never
+    /// **Fast path (roborev-1696):** an UNCONTENDED acquire (a permit is
+    /// immediately available) is served by [`Semaphore::try_acquire_owned`] and
+    /// never touches the `waiting` gauge or records a permit-wait histogram
+    /// sample — the gauge is a genuine backpressure signal (requests parked in
+    /// the wait queue), so an instant admit must not transiently over-report
+    /// queue depth. An instant admit is deliberately zero-sample in the
+    /// histogram too (not a `0.0` sample): `cqlite.flight.admission.wait_seconds`
+    /// measures how long a request that DID contend waited, so mixing in a flood
+    /// of zero-duration instant admits would dilute that distribution with
+    /// non-events.
+    ///
+    /// **Slow path:** only entered on [`tokio::sync::TryAcquireError::NoPermits`]
+    /// — the ceiling is saturated. Bumps `waiting`, then waits up to the
+    /// configured timeout. On success returns an [`AdmissionPermit`] RAII guard
+    /// that holds the semaphore permit AND the `in_use` gauge until dropped
+    /// (moved into the response stream so every exit path — completion,
+    /// disconnect, cancel — releases it) and records the genuine wait sample. On
+    /// timeout returns a gRPC **`UNAVAILABLE`** [`Status`] (never
     /// `RESOURCE_EXHAUSTED`) and increments `rejected_total`.
     ///
     /// A request whose future is dropped while WAITING (client disconnect before
     /// admission) never acquires a permit and its `waiting` count is released by
-    /// the [`WaitGuard`] drop — no leak on either the wait or the hold path.
+    /// the [`WaitGuard`] drop — no leak on either the wait or the hold path. The
+    /// semaphore is only ever closed on shutdown; both paths map a closed
+    /// semaphore to the same retry-safe `UNAVAILABLE` shed.
     pub async fn acquire(&self) -> Result<AdmissionPermit, Status> {
         let inner = Arc::clone(&self.inner);
-        // RAII: the `waiting` gauge is released on EVERY exit, including a
-        // cancellation that drops this future mid-`.await` (a request cancelled
-        // while waiting never held a permit and must not leak the waiting count).
+
+        // Fast path: try to admit without ever registering as "waiting". Covers
+        // the common uncontended case with zero gauge/histogram noise.
+        match inner.sem.clone().try_acquire_owned() {
+            Ok(permit) => return Ok(AdmissionPermit::new(permit, inner)),
+            Err(tokio::sync::TryAcquireError::Closed) => return Err(reject_status()),
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                // Fall through to the slow, timed wait path below.
+            }
+        }
+
+        // Slow path: the ceiling is saturated. RAII: the `waiting` gauge is
+        // released on EVERY exit, including a cancellation that drops this
+        // future mid-`.await` (a request cancelled while waiting never held a
+        // permit and must not leak the waiting count).
         let _waiter = WaitGuard::enter(Arc::clone(&inner));
         let started = tokio::time::Instant::now();
         let sem = Arc::clone(&inner.sem);
@@ -219,8 +248,6 @@ impl Admission {
                 inner.record_wait(started.elapsed());
                 Ok(AdmissionPermit::new(permit, inner))
             }
-            // The semaphore is only ever closed on shutdown; surface it as the same
-            // retry-safe status so an in-flight acquire during drain sheds cleanly.
             Ok(Err(_closed)) => Err(reject_status()),
             Err(_elapsed) => {
                 inner.record_wait(started.elapsed());

--- a/cqlite-flight/src/admission.rs
+++ b/cqlite-flight/src/admission.rs
@@ -155,11 +155,24 @@ pub struct Admission {
 }
 
 impl Admission {
-    /// Build an admission ceiling from `config`. The ceiling is clamped to a
-    /// minimum of 1 (a zero-permit semaphore would reject every request). Records
-    /// the configured limit gauge.
+    /// Build an admission ceiling from `config`. The ceiling is clamped
+    /// symmetrically at both ends (roborev-1697): a minimum of 1 (a zero-permit
+    /// semaphore would reject every request) and a maximum of
+    /// [`Semaphore::MAX_PERMITS`] — `Semaphore::new` PANICS above that bound, so
+    /// an absurd `--max-concurrent-scans`/`CQLITE_MAX_CONCURRENT_SCANS` value
+    /// must be capped, never allowed to crash startup. A clamp (at either end) is
+    /// logged so an operator setting an out-of-range value learns it was capped,
+    /// not silently honoured. Records the (post-clamp) configured limit gauge.
     pub fn new(config: AdmissionConfig) -> Self {
-        let limit = config.max_concurrent_scans.max(1);
+        let requested = config.max_concurrent_scans;
+        let limit = requested.clamp(1, Semaphore::MAX_PERMITS);
+        if limit != requested {
+            tracing::warn!(
+                requested,
+                clamped_to = limit,
+                "max-concurrent-scans out of range [1, Semaphore::MAX_PERMITS]; clamped"
+            );
+        }
         obs::record_gauge(catalog::FLIGHT_ADMISSION_LIMIT, limit as i64, &[]);
         Self {
             inner: Arc::new(AdmissionInner {

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -447,6 +447,21 @@ fn req4_configured_k_bounds_admitted_concurrency() {
     }
 }
 
+/// roborev-1697: a `--max-concurrent-scans` value ABOVE `Semaphore::MAX_PERMITS`
+/// must construct cleanly with a clamped ceiling, never panic (`Semaphore::new`
+/// panics above that bound) — a bad operator-supplied config must fail
+/// gracefully, never crash startup.
+#[test]
+fn req4_absurd_configured_k_clamps_instead_of_panicking() {
+    let absurd = tokio::sync::Semaphore::MAX_PERMITS + 1_000_000;
+    let adm = Admission::new(cfg(absurd, BIG_TIMEOUT));
+    assert_eq!(
+        adm.limit(),
+        tokio::sync::Semaphore::MAX_PERMITS,
+        "an out-of-range K is clamped to Semaphore::MAX_PERMITS, not honoured verbatim"
+    );
+}
+
 /// Scenario: the permit-wait timeout is honoured as configured — a different
 /// budget yields a correspondingly different reject point (logical time under the
 /// paused clock; no real sleep).

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -725,18 +725,19 @@ fn req6_admitted_after_wait_equals_unbounded_result() {
     );
 }
 
-// ---- roborev-1700 (round 5): admission is a first-class phase ----
+// ---- roborev-1700/1702 (rounds 5/7): validate + admission are first-class phases ----
 
-/// roborev-1700 (finding 1): `PhaseTimer` — the SAME type `do_get_inner` drives
-/// — opens `PHASE_ADMISSION` at construction and closes it on the FIRST
-/// `transition`, unconditionally (this is a property of the type itself, not of
-/// whether a permit happened to be free — so it covers both the contended and
-/// uncontended `do_get` cases in one deterministic check). Pre-fix, `start`
-/// opened `resolve` directly, so admission wait was folded into (or, before
-/// admission existed at all, simply absent from) the per-phase breakdown;
-/// `cqlite.rpc.duration` already counted the wait in the RPC total, but field
-/// triage localizes latency FROM the per-phase view (e.g. #2398), so queue time
-/// must be a first-class phase there too.
+/// roborev-1700/1702: `PhaseTimer` — the SAME type `do_get_inner` drives — opens
+/// `PHASE_VALIDATE` at construction, moves to `PHASE_ADMISSION` on the first
+/// `transition`, and to `PHASE_RESOLVE` on the second, unconditionally (this is
+/// a property of the type itself, not of whether the ticket happened to be
+/// valid or a permit happened to be free — so it covers the malformed-ticket,
+/// contended, AND uncontended `do_get` cases in one deterministic check).
+/// Pre-#2420, `start` opened `resolve` directly, so a malformed ticket recorded
+/// a (mislabeled) `resolve` sample and admission wait was folded into it too;
+/// `cqlite.rpc.duration` already counts both in the RPC total, but field triage
+/// localizes latency FROM the per-phase view (e.g. #2398), so both a malformed
+/// ticket AND a queued request must be precisely, separately visible there.
 ///
 /// Verified against a synthetic, otherwise-UNUSED bounded method slot
 /// (`"handshake"` — the real `handshake` RPC handler uses only `RpcMetrics`, not
@@ -746,27 +747,63 @@ fn req6_admitted_after_wait_equals_unbounded_result() {
 /// calls a real `do_get` — asserting an exact delta against the shared `do_get`
 /// slot would be flaky under this crate's parallel test execution (many other
 /// tests drive real `do_get` RPCs concurrently). A dedicated slot sidesteps that
-/// while still proving the exact mechanics `do_get_inner` relies on.
+/// while still proving the exact mechanics `do_get_inner` relies on. The REAL
+/// `do_get` path's OTel-level "a malformed ticket records a validate-phase
+/// sample" evidence lives in `metrics_capture_test.rs` (feature
+/// `observability-testing`), which reads back the actual emitted histogram —
+/// this crate's unit-test binary has no such capture harness (installs a
+/// process-global meter provider unsafe to share with `cargo test --lib`).
 #[test]
-fn req_admission_phase_opens_before_resolve() {
-    use crate::obs::{phase_active_level_for, PhaseTimer, PHASE_ADMISSION, PHASE_RESOLVE};
+fn req_validate_then_admission_phase_chain() {
+    use crate::obs::{
+        phase_active_level_for, PhaseTimer, PHASE_ADMISSION, PHASE_RESOLVE, PHASE_VALIDATE,
+    };
     const METHOD: &str = "handshake";
 
+    let validate_base = phase_active_level_for(METHOD, PHASE_VALIDATE);
     let admission_base = phase_active_level_for(METHOD, PHASE_ADMISSION);
     let resolve_base = phase_active_level_for(METHOD, PHASE_RESOLVE);
 
     let mut timer = PhaseTimer::start(METHOD);
     assert_eq!(
-        phase_active_level_for(METHOD, PHASE_ADMISSION),
-        admission_base + 1,
-        "PhaseTimer::start opens the admission phase, not resolve"
+        phase_active_level_for(METHOD, PHASE_VALIDATE),
+        validate_base + 1,
+        "PhaseTimer::start opens the validate phase, not admission or resolve"
     );
     assert_eq!(
-        phase_active_level_for(METHOD, PHASE_RESOLVE),
-        resolve_base,
-        "resolve is untouched while the timer is in admission"
+        phase_active_level_for(METHOD, PHASE_ADMISSION),
+        admission_base,
+        "admission is untouched while the timer is in validate"
     );
 
+    // Simulates a MALFORMED ticket: the timer drops here without ever
+    // transitioning — proving a validation failure still records a phase
+    // sample, preserving pre-#2420 main's "some phase sample always exists"
+    // invariant (main recorded `resolve`; this now records the precise
+    // `validate`).
+    let malformed_ticket_timer = PhaseTimer::start(METHOD);
+    drop(malformed_ticket_timer);
+    assert_eq!(
+        phase_active_level_for(METHOD, PHASE_VALIDATE),
+        validate_base + 1,
+        "the malformed-ticket timer's drop closed validate again — back to the \
+         one still-open timer from above"
+    );
+
+    // Validated: transition to admission.
+    timer.transition(PHASE_ADMISSION);
+    assert_eq!(
+        phase_active_level_for(METHOD, PHASE_VALIDATE),
+        validate_base,
+        "transitioning out of validate closes it"
+    );
+    assert_eq!(
+        phase_active_level_for(METHOD, PHASE_ADMISSION),
+        admission_base + 1,
+        "and opens admission"
+    );
+
+    // Admitted: transition to resolve.
     timer.transition(PHASE_RESOLVE);
     assert_eq!(
         phase_active_level_for(METHOD, PHASE_ADMISSION),
@@ -777,7 +814,8 @@ fn req_admission_phase_opens_before_resolve() {
         phase_active_level_for(METHOD, PHASE_RESOLVE),
         resolve_base + 1,
         "and opens resolve — this is the exact sequence do_get_inner drives: \
-         start() in admission, then transition(PHASE_RESOLVE) once admitted"
+         start() in validate, transition(PHASE_ADMISSION) once validated, \
+         transition(PHASE_RESOLVE) once admitted"
     );
 
     drop(timer);

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -36,7 +36,7 @@ use arrow_flight::Ticket;
 use futures::StreamExt;
 use tonic::{Code, Request};
 
-use crate::admission::{Admission, AdmissionConfig};
+use crate::admission::{Admission, AdmissionConfig, WaitBudget};
 use crate::service::CqliteFlightService;
 use crate::testutil::{build_sstables, simple_schema, total_rows, write_row, KS, SIMPLE_DDL, TBL};
 use crate::ticket::FlightTicket;
@@ -47,7 +47,7 @@ use cqlite_core::observability::catalog;
 fn cfg(k: usize, timeout: Duration) -> AdmissionConfig {
     AdmissionConfig {
         max_concurrent_scans: k,
-        wait_timeout: timeout,
+        wait_budget: WaitBudget::Timeout(timeout),
     }
 }
 
@@ -623,6 +623,58 @@ fn req4_permit_wait_timeout_is_wired() {
         long > short,
         "a longer configured budget yields a later reject point"
     );
+}
+
+/// roborev-1703: `WaitBudget::Unbounded` (used by [`Admission::unconstrained`])
+/// must never compute a deadline — `acquire` awaits `acquire_owned` directly
+/// with NO `timeout()` wrapper, so there is no `Instant::now() + Duration::MAX`
+/// overflow hazard. Proven two ways in one deterministic test: (1) the paused
+/// clock is advanced ARBITRARILY far (far beyond any real timeout budget) while
+/// a request is genuinely contended on an `Unbounded` admission, and the test
+/// process never panics/aborts — the overflow hazard this fix removes would
+/// have panicked inside `tokio::time::timeout`'s internal deadline math; (2)
+/// once a permit frees, the waiting request is admitted (never spuriously
+/// rejected — `Unbounded` has no timeout arm to spuriously fire).
+#[test]
+fn req4_unbounded_wait_budget_never_times_out_even_under_extreme_advance() {
+    block_on_paused(async {
+        let adm = Admission::new(AdmissionConfig {
+            max_concurrent_scans: 1,
+            wait_budget: WaitBudget::Unbounded,
+        });
+        let held = adm.acquire().await.unwrap(); // occupy the only permit
+
+        let mut waiter = Box::pin(adm.acquire());
+        assert!(
+            matches!(futures::poll!(waiter.as_mut()), Poll::Pending),
+            "a saturated Unbounded acquire parks, same as a Timeout budget would"
+        );
+        assert_eq!(adm.snapshot().waiting, 1);
+
+        // Advance the paused clock ARBITRARILY far — far beyond any real
+        // wait-timeout budget this crate configures. An `Unbounded` acquire has
+        // NO deadline to elapse, so this must not panic (the overflow hazard a
+        // `Duration::MAX` sentinel would carry) and must NOT admit/reject the
+        // still-parked waiter on its own.
+        tokio::time::advance(Duration::from_secs(u32::MAX as u64)).await;
+        assert!(
+            matches!(futures::poll!(waiter.as_mut()), Poll::Pending),
+            "advancing the clock arbitrarily far must never time out an \
+             Unbounded acquire — it stays parked until a permit genuinely frees"
+        );
+        assert_eq!(
+            adm.snapshot().rejected_total,
+            0,
+            "Unbounded never rejects on a clock advance — there is no timeout arm"
+        );
+
+        drop(held); // the only way an Unbounded acquire is ever resolved: a free permit
+        match futures::poll!(waiter.as_mut()) {
+            Poll::Ready(Ok(permit)) => drop(permit),
+            other => panic!("Unbounded acquire must admit once a permit frees, got {other:?}"),
+        }
+        assert_eq!(adm.snapshot().waiting, 0);
+    });
 }
 
 // ---- Requirement 5: admission state is exported as observability instruments ----

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -13,10 +13,17 @@
 //! by the filesystem-touching `resolve_dir` call inside it, stays flat) while all
 //! permits are held — with the acquire-before-resolve wiring removed, every
 //! offered request runs the filesystem resolve and the counter jumps, reding the
-//! test. Ticket VALIDATION (parse + schema/predicate build, roborev-1698) is
-//! deliberately excluded from this gate: it is cheap and filesystem-free, so it
-//! runs BEFORE admission and must not wait behind the semaphore — see
-//! `req_malformed_ticket_bypasses_admission_entirely` below.
+//! test.
+//!
+//! Pre-permit validation is MINIMAL (roborev-1699): only `FlightTicket::from_bytes`
+//! (ticket syntax) runs before admission. Producer/schema construction (CQL DDL
+//! parse, predicate/projection/aggregation-spec lowering — expensive,
+//! attacker-influenced work) moves INSIDE the gate, alongside the filesystem
+//! resolve — see `req_malformed_ticket_bypasses_admission_entirely` (a
+//! syntactically malformed ticket bypasses admission) and
+//! `req_valid_ticket_for_bogus_table_does_not_reach_producer_construction_before_admission`
+//! (a syntactically VALID ticket still does not reach producer construction
+//! until admitted).
 
 use std::task::Poll;
 use std::time::Duration;
@@ -342,6 +349,51 @@ fn req_malformed_ticket_bypasses_admission_entirely() {
             "the malformed ticket never contended for (or was shed by) admission"
         );
         assert_eq!(after.in_use, before.in_use, "the held permit is untouched");
+        drop(held);
+    });
+}
+
+/// roborev-1699: a SYNTACTICALLY VALID ticket (parses fine — for a table that
+/// simply doesn't exist on disk) must NOT reach producer/schema construction
+/// (the expensive, attacker-influenced CQL DDL parse + predicate/projection
+/// lowering) before a permit is admitted. Probed via `schema_parses` — the
+/// schema-cache-miss counter `build_producer` bumps — which must stay flat while
+/// every permit is held and only climb once the request is actually admitted.
+#[test]
+fn req_valid_ticket_for_bogus_table_does_not_reach_producer_construction_before_admission() {
+    let adm = Admission::new(cfg(1, BIG_TIMEOUT));
+    let (_temp, svc) = build_service(adm.clone(), 8);
+    block_on_paused(async move {
+        let held = adm.acquire().await.unwrap(); // hold the only permit
+        let baseline = svc.setup_work().schema_parses;
+
+        // Syntactically valid ticket, never-before-seen DDL, pointing at a table
+        // that does not exist on disk — proves the schema-cache miss (inside
+        // `build_producer`) does not fire before admission, regardless of
+        // whether the request could ever resolve.
+        let bogus = FlightTicket {
+            keyspace: KS.into(),
+            table: "does_not_exist".into(),
+            ddl: "CREATE TABLE flight_ks.does_not_exist (id int PRIMARY KEY)".into(),
+            ..Default::default()
+        };
+        let bytes = bogus.to_bytes().unwrap();
+        let svc2 = svc.clone();
+        let task = tokio::spawn(async move { svc2.do_get(Request::new(Ticket::new(bytes))).await });
+        settle().await;
+
+        assert_eq!(
+            svc.setup_work().schema_parses,
+            baseline,
+            "producer/schema construction must not run before a permit is admitted"
+        );
+        assert_eq!(
+            adm.snapshot().waiting,
+            1,
+            "the request is waiting on admission, not building the producer"
+        );
+
+        task.abort();
         drop(held);
     });
 }

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -181,6 +181,21 @@ fn req1_contended_acquire_path_unchanged() {
         };
         let after = adm.snapshot();
         assert_eq!(after.waiting, 0, "admission clears the waiting gauge");
+        // roborev-1700: the instant a contended acquire is admitted, `waiting`
+        // and `in_use` must never simultaneously double-count the same request —
+        // `Admission::acquire`'s slow path drops the `WaitGuard` BEFORE
+        // constructing the `AdmissionPermit` that bumps `in_use`, so by the time
+        // this single synchronous continuation returns `Ready`, exactly one of
+        // the two gauges reflects this request, never both at once.
+        assert_eq!(
+            after.in_use, 1,
+            "the admitted request is counted exactly once, as in_use"
+        );
+        assert_eq!(
+            after.waiting + after.in_use,
+            1,
+            "no overlap window: waiting and in_use never both count this one request"
+        );
         assert!(
             after.wait_samples > before.wait_samples,
             "a genuinely-contended acquire still records a permit-wait sample"
@@ -708,4 +723,86 @@ fn req6_admitted_after_wait_equals_unbounded_result() {
         unbounded, admitted,
         "admission is transparent: identical rows, order, schema, and batch boundaries"
     );
+}
+
+// ---- roborev-1700 (round 5): admission is a first-class phase ----
+
+/// roborev-1700 (finding 1): a `do_get` queued behind a saturated admission
+/// ceiling must be visible in the `cqlite.rpc.phase.active` breakdown as the
+/// `admission` phase — not silently folded into `resolve` (which pre-fix this
+/// timer started in even before the permit was granted) and not invisible.
+/// `cqlite.rpc.duration` already includes admission wait in the RPC total, but
+/// the per-phase breakdown is what field triage localizes latency with (e.g.
+/// #2398), so queue time must be first-class there too. Feature-independent:
+/// `PhaseTimer`'s phase-active atomics are always maintained regardless of the
+/// `observability` OTel feature (only the OTel emission itself is gated), so
+/// this pins the wiring without needing that feature on.
+#[test]
+fn req_admission_wait_is_visible_as_its_own_phase() {
+    let adm = Admission::new(cfg(1, BIG_TIMEOUT));
+    let (_temp, svc) = build_service(adm.clone(), 8);
+    block_on_paused(async move {
+        let held = adm.acquire().await.unwrap(); // saturate the only permit
+        let admission_base =
+            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION);
+        let resolve_base = crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_RESOLVE);
+
+        let svc2 = svc.clone();
+        let task = tokio::spawn(async move { svc2.do_get(do_get_request()).await });
+        settle().await;
+
+        assert_eq!(
+            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION),
+            admission_base + 1,
+            "a queued do_get occupies the admission phase — queue time is visible \
+             in the phase breakdown, not folded into resolve or invisible"
+        );
+        assert_eq!(
+            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_RESOLVE),
+            resolve_base,
+            "resolve is untouched while the request is queued in admission — the \
+             other phases' meanings are unchanged"
+        );
+
+        drop(held); // admits the waiter
+        settle().await;
+
+        // Once admitted, the phase moves OUT of admission (into resolve, and
+        // likely on through to completion for this tiny in-process fixture) —
+        // either way, this request no longer occupies `admission`.
+        assert_eq!(
+            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION),
+            admission_base,
+            "admitted: the admission phase is vacated"
+        );
+
+        let _ = task.await;
+    });
+}
+
+/// roborev-1700: an UNCONTENDED admit (the fast path, no waiting) still opens
+/// and closes the `admission` phase — briefly, but it is never skipped. Proves
+/// the phase machinery is correct for both the contended AND uncontended cases,
+/// not just when the semaphore happens to be saturated.
+#[test]
+fn req_admission_phase_opens_even_on_an_uncontended_admit() {
+    let adm = Admission::new(cfg(4, BIG_TIMEOUT));
+    let (_temp, svc) = build_service(adm, 8);
+    block_on_paused(async move {
+        let admission_base =
+            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION);
+
+        // An uncontended do_get: never waits, but must still transition THROUGH
+        // the admission phase (start() opens it, the first transition() closes
+        // it) rather than skip straight to resolve.
+        let resp = svc.do_get(do_get_request()).await.unwrap();
+        drop(resp);
+
+        assert_eq!(
+            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION),
+            admission_base,
+            "a completed uncontended do_get leaves the admission phase vacated, \
+             same as the contended case"
+        );
+    });
 }

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -109,6 +109,74 @@ async fn decode(stream: <CqliteFlightService as FlightService>::DoGetStream) -> 
 
 // ---- Requirement 1: do_get concurrency is bounded by the configured limit ----
 
+/// roborev-1696: an UNCONTENDED acquire (a permit is immediately available) must
+/// NOT be counted as waiting even transiently — the `waiting` gauge is a genuine
+/// backpressure signal (requests parked in the wait queue), not an artifact of
+/// how `acquire` is implemented. Also asserts an instant admit records no
+/// permit-wait histogram sample (the fast path is a distinct, zero-noise path
+/// from the slow/contended one).
+#[test]
+fn req1_uncontended_acquire_never_touches_waiting_gauge() {
+    block_on_paused(async {
+        let adm = Admission::new(cfg(4, BIG_TIMEOUT));
+        let before = adm.snapshot();
+        assert_eq!(before.waiting, 0);
+        assert_eq!(before.in_use, 0);
+
+        // Four uncontended acquires — the ceiling is never saturated.
+        let mut held = Vec::new();
+        for _ in 0..4 {
+            held.push(adm.acquire().await.unwrap());
+        }
+
+        let after = adm.snapshot();
+        assert_eq!(after.in_use, 4, "all four admitted");
+        assert_eq!(
+            after.waiting, 0,
+            "an uncontended acquire must never register as waiting, even transiently"
+        );
+        assert_eq!(
+            after.wait_samples, before.wait_samples,
+            "an instant admit records no permit-wait histogram sample"
+        );
+        drop(held);
+    });
+}
+
+/// roborev-1696: the CONTENDED path is unchanged — a request that genuinely waits
+/// (the ceiling is saturated) still shows up in the `waiting` gauge and still
+/// records a permit-wait sample once admitted.
+#[test]
+fn req1_contended_acquire_path_unchanged() {
+    block_on_paused(async {
+        let adm = Admission::new(cfg(1, BIG_TIMEOUT));
+        let held = adm.acquire().await.unwrap(); // uncontended — fast path
+        assert_eq!(adm.snapshot().waiting, 0, "the first acquire never waits");
+
+        let before = adm.snapshot();
+        let mut waiter = Box::pin(adm.acquire());
+        assert!(matches!(futures::poll!(waiter.as_mut()), Poll::Pending));
+        assert_eq!(
+            adm.snapshot().waiting,
+            1,
+            "the contended acquire IS counted as waiting"
+        );
+
+        drop(held); // free the only permit — admits the waiter
+        let admitted = match futures::poll!(waiter.as_mut()) {
+            Poll::Ready(Ok(permit)) => permit,
+            other => panic!("the waiter should be admitted once the permit frees, got {other:?}"),
+        };
+        let after = adm.snapshot();
+        assert_eq!(after.waiting, 0, "admission clears the waiting gauge");
+        assert!(
+            after.wait_samples > before.wait_samples,
+            "a genuinely-contended acquire still records a permit-wait sample"
+        );
+        drop(admitted);
+    });
+}
+
 /// Scenario: offering more than `K` concurrent acquires holds in-flight at `K`.
 /// Primitive-level: all `K` permits held, `M` excess futures polled once each stay
 /// Pending; the in-use gauge never exceeds `K` and waiting reads `M`.

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -26,7 +26,7 @@ use tonic::{Code, Request};
 
 use crate::admission::{Admission, AdmissionConfig};
 use crate::service::CqliteFlightService;
-use crate::testutil::{build_sstables, simple_schema, total_rows, write_row, SIMPLE_DDL, KS, TBL};
+use crate::testutil::{build_sstables, simple_schema, total_rows, write_row, KS, SIMPLE_DDL, TBL};
 use crate::ticket::FlightTicket;
 use cqlite_core::observability::catalog;
 
@@ -126,11 +126,18 @@ fn req1_bounded_admission_holds_in_flight_at_k() {
             assert!(matches!(futures::poll!(f.as_mut()), Poll::Pending));
         }
         let s = adm.snapshot();
-        assert_eq!(s.in_use, 2, "in-use never exceeds K while the barrier is held");
+        assert_eq!(
+            s.in_use, 2,
+            "in-use never exceeds K while the barrier is held"
+        );
         assert_eq!(s.waiting, 3, "all M excess are parked waiting");
 
         drop(excess);
-        assert_eq!(adm.snapshot().waiting, 0, "dropping waiters clears the gauge");
+        assert_eq!(
+            adm.snapshot().waiting,
+            0,
+            "dropping waiters clears the gauge"
+        );
         drop((p1, p2));
     });
 }
@@ -187,7 +194,9 @@ fn req1_excess_do_gets_never_reach_setup() {
         let mut tasks = Vec::new();
         for _ in 0..4 {
             let svc = svc.clone();
-            tasks.push(tokio::spawn(async move { svc.do_get(do_get_request()).await }));
+            tasks.push(tokio::spawn(
+                async move { svc.do_get(do_get_request()).await },
+            ));
         }
         settle().await;
 
@@ -198,7 +207,10 @@ fn req1_excess_do_gets_never_reach_setup() {
         );
         let s = adm.snapshot();
         assert_eq!(s.in_use, 2, "only the K barrier permits are held");
-        assert_eq!(s.waiting, 4, "all K + M offered requests are parked in admission");
+        assert_eq!(
+            s.waiting, 4,
+            "all K + M offered requests are parked in admission"
+        );
 
         for t in tasks {
             t.abort();
@@ -227,7 +239,11 @@ fn req2_overload_rejects_unavailable_after_timeout() {
             .await
             .err()
             .expect("saturated do_get must be rejected, not admitted");
-        assert_eq!(err.code(), Code::Unavailable, "reject status must be UNAVAILABLE");
+        assert_eq!(
+            err.code(),
+            Code::Unavailable,
+            "reject status must be UNAVAILABLE"
+        );
         assert_ne!(
             err.code(),
             Code::ResourceExhausted,
@@ -394,7 +410,10 @@ fn req4_permit_wait_timeout_is_wired() {
         long >= Duration::from_secs(30) && long < Duration::from_secs(30) + slack,
         "reject point tracks the configured 30s budget, got {long:?}"
     );
-    assert!(long > short, "a longer configured budget yields a later reject point");
+    assert!(
+        long > short,
+        "a longer configured budget yields a later reject point"
+    );
 }
 
 // ---- Requirement 5: admission state is exported as observability instruments ----
@@ -411,8 +430,15 @@ fn req5_admission_instruments_track_engagement() {
         catalog::FLIGHT_ADMISSION_REJECTED_TOTAL,
         catalog::FLIGHT_ADMISSION_WAIT_SECONDS,
     ] {
-        assert_ne!(name, catalog::RPC_IN_FLIGHT, "distinct from the RPC in-flight gauge");
-        assert!(catalog::ALL_METRICS.contains(&name), "{name} registered in the catalog");
+        assert_ne!(
+            name,
+            catalog::RPC_IN_FLIGHT,
+            "distinct from the RPC in-flight gauge"
+        );
+        assert!(
+            catalog::ALL_METRICS.contains(&name),
+            "{name} registered in the catalog"
+        );
     }
 
     block_on_paused(async {
@@ -424,7 +450,11 @@ fn req5_admission_instruments_track_engagement() {
         // A waiting reading (M made to wait), then release it.
         let mut waiter = Box::pin(adm.acquire());
         assert!(matches!(futures::poll!(waiter.as_mut()), Poll::Pending));
-        assert_eq!(adm.snapshot().waiting, 1, "waiting reads the current wait count");
+        assert_eq!(
+            adm.snapshot().waiting,
+            1,
+            "waiting reads the current wait count"
+        );
         drop(waiter);
 
         // One wait times out: rejection counter increments by one and a
@@ -433,9 +463,16 @@ fn req5_admission_instruments_track_engagement() {
         let err = adm.acquire().await.unwrap_err();
         assert_eq!(err.code(), Code::Unavailable);
         let after = adm.snapshot();
-        assert_eq!(after.in_use, 2, "the timeout admitted nothing — in-use still K");
+        assert_eq!(
+            after.in_use, 2,
+            "the timeout admitted nothing — in-use still K"
+        );
         assert_eq!(after.waiting, 0, "the timed-out waiter released its slot");
-        assert_eq!(after.rejected_total, before.rejected_total + 1, "one rejection");
+        assert_eq!(
+            after.rejected_total,
+            before.rejected_total + 1,
+            "one rejection"
+        );
         assert!(
             after.wait_samples > before.wait_samples,
             "the permit-wait histogram recorded a sample"

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -727,82 +727,95 @@ fn req6_admitted_after_wait_equals_unbounded_result() {
 
 // ---- roborev-1700 (round 5): admission is a first-class phase ----
 
-/// roborev-1700 (finding 1): a `do_get` queued behind a saturated admission
-/// ceiling must be visible in the `cqlite.rpc.phase.active` breakdown as the
-/// `admission` phase — not silently folded into `resolve` (which pre-fix this
-/// timer started in even before the permit was granted) and not invisible.
-/// `cqlite.rpc.duration` already includes admission wait in the RPC total, but
-/// the per-phase breakdown is what field triage localizes latency with (e.g.
-/// #2398), so queue time must be first-class there too. Feature-independent:
-/// `PhaseTimer`'s phase-active atomics are always maintained regardless of the
-/// `observability` OTel feature (only the OTel emission itself is gated), so
-/// this pins the wiring without needing that feature on.
+/// roborev-1700 (finding 1): `PhaseTimer` — the SAME type `do_get_inner` drives
+/// — opens `PHASE_ADMISSION` at construction and closes it on the FIRST
+/// `transition`, unconditionally (this is a property of the type itself, not of
+/// whether a permit happened to be free — so it covers both the contended and
+/// uncontended `do_get` cases in one deterministic check). Pre-fix, `start`
+/// opened `resolve` directly, so admission wait was folded into (or, before
+/// admission existed at all, simply absent from) the per-phase breakdown;
+/// `cqlite.rpc.duration` already counted the wait in the RPC total, but field
+/// triage localizes latency FROM the per-phase view (e.g. #2398), so queue time
+/// must be a first-class phase there too.
+///
+/// Verified against a synthetic, otherwise-UNUSED bounded method slot
+/// (`"handshake"` — the real `handshake` RPC handler uses only `RpcMetrics`, not
+/// `PhaseTimer`, and no test in this crate drives it) rather than the real
+/// `do_get` path: `phase_active_level_for` reads a PROCESS-WIDE counter keyed
+/// only by `(method, phase)`, shared by every concurrently-running test that
+/// calls a real `do_get` — asserting an exact delta against the shared `do_get`
+/// slot would be flaky under this crate's parallel test execution (many other
+/// tests drive real `do_get` RPCs concurrently). A dedicated slot sidesteps that
+/// while still proving the exact mechanics `do_get_inner` relies on.
+#[test]
+fn req_admission_phase_opens_before_resolve() {
+    use crate::obs::{phase_active_level_for, PhaseTimer, PHASE_ADMISSION, PHASE_RESOLVE};
+    const METHOD: &str = "handshake";
+
+    let admission_base = phase_active_level_for(METHOD, PHASE_ADMISSION);
+    let resolve_base = phase_active_level_for(METHOD, PHASE_RESOLVE);
+
+    let mut timer = PhaseTimer::start(METHOD);
+    assert_eq!(
+        phase_active_level_for(METHOD, PHASE_ADMISSION),
+        admission_base + 1,
+        "PhaseTimer::start opens the admission phase, not resolve"
+    );
+    assert_eq!(
+        phase_active_level_for(METHOD, PHASE_RESOLVE),
+        resolve_base,
+        "resolve is untouched while the timer is in admission"
+    );
+
+    timer.transition(PHASE_RESOLVE);
+    assert_eq!(
+        phase_active_level_for(METHOD, PHASE_ADMISSION),
+        admission_base,
+        "transitioning out of admission closes it"
+    );
+    assert_eq!(
+        phase_active_level_for(METHOD, PHASE_RESOLVE),
+        resolve_base + 1,
+        "and opens resolve — this is the exact sequence do_get_inner drives: \
+         start() in admission, then transition(PHASE_RESOLVE) once admitted"
+    );
+
+    drop(timer);
+    assert_eq!(
+        phase_active_level_for(METHOD, PHASE_RESOLVE),
+        resolve_base,
+        "drop closes whichever phase was open"
+    );
+}
+
+/// roborev-1700 (finding 1), wiring evidence on the REAL `do_get` path: a
+/// request queued behind a saturated admission ceiling is observably occupying
+/// the `admission` phase (`>= 1`, not the racy exact-delta the mechanics test
+/// above proves in isolation — this process-wide counter is shared with every
+/// OTHER concurrently-running test that drives a real `do_get`, so only a
+/// robust lower-bound is safe here; the exact ordering guarantee is
+/// `req_admission_phase_opens_before_resolve`'s job). Proves the production
+/// code path — not just the `PhaseTimer` type — actually reaches `admission`
+/// while genuinely parked on the semaphore.
 #[test]
 fn req_admission_wait_is_visible_as_its_own_phase() {
     let adm = Admission::new(cfg(1, BIG_TIMEOUT));
     let (_temp, svc) = build_service(adm.clone(), 8);
     block_on_paused(async move {
         let held = adm.acquire().await.unwrap(); // saturate the only permit
-        let admission_base =
-            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION);
-        let resolve_base = crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_RESOLVE);
 
         let svc2 = svc.clone();
         let task = tokio::spawn(async move { svc2.do_get(do_get_request()).await });
         settle().await;
 
-        assert_eq!(
-            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION),
-            admission_base + 1,
-            "a queued do_get occupies the admission phase — queue time is visible \
-             in the phase breakdown, not folded into resolve or invisible"
-        );
-        assert_eq!(
-            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_RESOLVE),
-            resolve_base,
-            "resolve is untouched while the request is queued in admission — the \
-             other phases' meanings are unchanged"
+        assert!(
+            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION) >= 1,
+            "a do_get genuinely parked on the admission semaphore is observably \
+             occupying the admission phase — queue time is visible in the phase \
+             breakdown, not folded into resolve or invisible"
         );
 
         drop(held); // admits the waiter
-        settle().await;
-
-        // Once admitted, the phase moves OUT of admission (into resolve, and
-        // likely on through to completion for this tiny in-process fixture) —
-        // either way, this request no longer occupies `admission`.
-        assert_eq!(
-            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION),
-            admission_base,
-            "admitted: the admission phase is vacated"
-        );
-
         let _ = task.await;
-    });
-}
-
-/// roborev-1700: an UNCONTENDED admit (the fast path, no waiting) still opens
-/// and closes the `admission` phase — briefly, but it is never skipped. Proves
-/// the phase machinery is correct for both the contended AND uncontended cases,
-/// not just when the semaphore happens to be saturated.
-#[test]
-fn req_admission_phase_opens_even_on_an_uncontended_admit() {
-    let adm = Admission::new(cfg(4, BIG_TIMEOUT));
-    let (_temp, svc) = build_service(adm, 8);
-    block_on_paused(async move {
-        let admission_base =
-            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION);
-
-        // An uncontended do_get: never waits, but must still transition THROUGH
-        // the admission phase (start() opens it, the first transition() closes
-        // it) rather than skip straight to resolve.
-        let resp = svc.do_get(do_get_request()).await.unwrap();
-        drop(resp);
-
-        assert_eq!(
-            crate::obs::phase_active_level_for("do_get", crate::obs::PHASE_ADMISSION),
-            admission_base,
-            "a completed uncontended do_get leaves the admission phase vacated, \
-             same as the contended case"
-        );
     });
 }

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -1,0 +1,480 @@
+//! Deterministic `do_get` admission-control tests (issue #2420, WS4).
+//!
+//! Every scenario is injected, never timed: concurrency is held via pre-acquired
+//! permits / single-poll `futures::poll!` (which never idles the runtime, so the
+//! paused clock cannot auto-advance), and the permit-wait timeout fires via the
+//! paused/auto-advancing Tokio clock (`tokio::time::pause`) — never a wall-clock
+//! sleep. The end-to-end tests build real in-process SSTables (via the write
+//! engine, so no external fixtures) and drive the public `FlightService::do_get`
+//! surface, proving the ceiling engages on the real path.
+//!
+//! Red-on-main proof: `excess_do_gets_never_reach_setup` asserts the excess
+//! requests never run `do_get_setup` (the `resolves` work counter stays flat)
+//! while all permits are held — with the acquire-before-setup wiring removed,
+//! every offered request runs setup and the counter jumps, reding the test.
+
+use std::task::Poll;
+use std::time::Duration;
+
+use arrow::record_batch::RecordBatch;
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::{Code, Request};
+
+use crate::admission::{Admission, AdmissionConfig};
+use crate::service::CqliteFlightService;
+use crate::testutil::{build_sstables, simple_schema, total_rows, write_row, SIMPLE_DDL, KS, TBL};
+use crate::ticket::FlightTicket;
+use cqlite_core::observability::catalog;
+
+/// A small ceiling with a generous, effectively-non-firing wait timeout (the
+/// tests that need a timeout to fire configure their own tiny value).
+fn cfg(k: usize, timeout: Duration) -> AdmissionConfig {
+    AdmissionConfig {
+        max_concurrent_scans: k,
+        wait_timeout: timeout,
+    }
+}
+
+/// A wait timeout large enough that it never auto-advances during a test that
+/// wakes its waiters explicitly (by releasing a held permit / aborting).
+const BIG_TIMEOUT: Duration = Duration::from_secs(3600);
+
+/// The `do_get` ticket bytes for the shared in-process table.
+fn ticket_bytes() -> Vec<u8> {
+    FlightTicket {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        ddl: SIMPLE_DDL.into(),
+        ..Default::default()
+    }
+    .to_bytes()
+    .unwrap()
+}
+
+fn do_get_request() -> Request<Ticket> {
+    Request::new(Ticket::new(ticket_bytes()))
+}
+
+/// Build a service over `n` in-process rows sharing `admission`. Runs OUTSIDE any
+/// async runtime (`build_sstables` drives its own), so callers invoke this before
+/// entering [`block_on_paused`].
+fn build_service(admission: Admission, n: i32) -> (tempfile::TempDir, CqliteFlightService) {
+    let schema = simple_schema();
+    let rows: Vec<_> = (0..n)
+        .map(|i| write_row(i, &format!("n{i}"), i * 10, 100))
+        .collect();
+    let (temp, data_dir, _dir) = build_sstables(&schema, vec![rows]);
+    (
+        temp,
+        CqliteFlightService::with_admission(data_dir, 1024, admission),
+    )
+}
+
+/// Drive `fut` on a fresh current-thread runtime with the Tokio clock PAUSED, so
+/// the permit-wait timeout auto-advances deterministically (no real sleep). Must
+/// be called with `fut` constructed OUTSIDE any other runtime.
+fn block_on_paused<F: std::future::Future>(fut: F) -> F::Output {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async move {
+        tokio::time::pause();
+        fut.await
+    })
+}
+
+/// Let every currently-spawned task run up to its first `.await` park. `yield_now`
+/// keeps the yielding task ready, so the runtime never idles onto a timer — the
+/// paused clock cannot auto-advance during this loop.
+async fn settle() {
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn decode(stream: <CqliteFlightService as FlightService>::DoGetStream) -> Vec<RecordBatch> {
+    let mapped = stream.map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(mapped);
+    let mut out = Vec::new();
+    while let Some(batch) = rb.next().await {
+        out.push(batch.unwrap());
+    }
+    out
+}
+
+// ---- Requirement 1: do_get concurrency is bounded by the configured limit ----
+
+/// Scenario: offering more than `K` concurrent acquires holds in-flight at `K`.
+/// Primitive-level: all `K` permits held, `M` excess futures polled once each stay
+/// Pending; the in-use gauge never exceeds `K` and waiting reads `M`.
+#[test]
+fn req1_bounded_admission_holds_in_flight_at_k() {
+    block_on_paused(async {
+        let adm = Admission::new(cfg(2, BIG_TIMEOUT));
+        let p1 = adm.acquire().await.unwrap();
+        let p2 = adm.acquire().await.unwrap();
+        assert_eq!(adm.snapshot().in_use, 2, "K permits admitted");
+
+        // M = 3 excess acquires; poll each once — they park, never admitted.
+        let mut excess: Vec<_> = (0..3).map(|_| Box::pin(adm.acquire())).collect();
+        for f in excess.iter_mut() {
+            assert!(matches!(futures::poll!(f.as_mut()), Poll::Pending));
+        }
+        let s = adm.snapshot();
+        assert_eq!(s.in_use, 2, "in-use never exceeds K while the barrier is held");
+        assert_eq!(s.waiting, 3, "all M excess are parked waiting");
+
+        drop(excess);
+        assert_eq!(adm.snapshot().waiting, 0, "dropping waiters clears the gauge");
+        drop((p1, p2));
+    });
+}
+
+/// Scenario: releasing exactly one permit admits exactly one waiter — no
+/// over-admission, no lost wakeup.
+#[test]
+fn req1_releasing_one_permit_admits_exactly_one_waiter() {
+    block_on_paused(async {
+        let adm = Admission::new(cfg(1, BIG_TIMEOUT));
+        let held = adm.acquire().await.unwrap();
+        let mut a = Box::pin(adm.acquire());
+        let mut b = Box::pin(adm.acquire());
+        assert!(matches!(futures::poll!(a.as_mut()), Poll::Pending));
+        assert!(matches!(futures::poll!(b.as_mut()), Poll::Pending));
+        assert_eq!(adm.snapshot().waiting, 2);
+
+        drop(held); // free exactly one permit
+
+        // FIFO: the first waiter is admitted; the second stays parked.
+        let first = futures::poll!(a.as_mut());
+        let second = futures::poll!(b.as_mut());
+        let admitted = match first {
+            Poll::Ready(Ok(permit)) => permit,
+            Poll::Ready(Err(_)) => panic!("first waiter errored unexpectedly"),
+            Poll::Pending => panic!("first waiter should be admitted after a permit freed"),
+        };
+        assert!(
+            matches!(second, Poll::Pending),
+            "the second waiter must NOT be admitted (no over-admission)"
+        );
+        let s = adm.snapshot();
+        assert_eq!(s.in_use, 1, "exactly one admitted");
+        assert_eq!(s.waiting, 1, "one still waiting");
+        drop((admitted, b));
+    });
+}
+
+/// Red-on-main proof (Scenario 1's do_get clause): with all `K` permits held, the
+/// `K + M` offered `do_get`s never reach `do_get_setup` — the `resolves` work
+/// counter stays flat. Remove the acquire-before-setup wiring and every request
+/// runs setup, jumping the counter: the test reds.
+#[test]
+fn req1_excess_do_gets_never_reach_setup() {
+    let adm = Admission::new(cfg(2, BIG_TIMEOUT));
+    let (_temp, svc) = build_service(adm.clone(), 8);
+    block_on_paused(async move {
+        // Hold ALL K permits via the barrier.
+        let h1 = adm.acquire().await.unwrap();
+        let h2 = adm.acquire().await.unwrap();
+        let baseline = svc.setup_work().resolves;
+
+        // Offer K + M = 4 do_gets; each parks on acquire before opening anything.
+        let mut tasks = Vec::new();
+        for _ in 0..4 {
+            let svc = svc.clone();
+            tasks.push(tokio::spawn(async move { svc.do_get(do_get_request()).await }));
+        }
+        settle().await;
+
+        assert_eq!(
+            svc.setup_work().resolves,
+            baseline,
+            "no excess request reached do_get_setup while all K permits are held"
+        );
+        let s = adm.snapshot();
+        assert_eq!(s.in_use, 2, "only the K barrier permits are held");
+        assert_eq!(s.waiting, 4, "all K + M offered requests are parked in admission");
+
+        for t in tasks {
+            t.abort();
+        }
+        drop((h1, h2));
+    });
+}
+
+// ---- Requirement 2: sustained overload sheds with UNAVAILABLE ----
+
+/// Scenario: a request that cannot get a permit within the timeout is rejected
+/// `UNAVAILABLE` (never `RESOURCE_EXHAUSTED`, never `OK`), zero batches delivered,
+/// `rejected_total += 1`.
+#[test]
+fn req2_overload_rejects_unavailable_after_timeout() {
+    let adm = Admission::new(cfg(1, Duration::from_secs(30)));
+    let (_temp, svc) = build_service(adm.clone(), 8);
+    block_on_paused(async move {
+        let held = adm.acquire().await.unwrap(); // take the only permit
+        let before = adm.snapshot().rejected_total;
+
+        // The paused clock auto-advances the 30s wait deadline while the barrier
+        // is held → the do_get is shed before any batch.
+        let err = svc
+            .do_get(do_get_request())
+            .await
+            .err()
+            .expect("saturated do_get must be rejected, not admitted");
+        assert_eq!(err.code(), Code::Unavailable, "reject status must be UNAVAILABLE");
+        assert_ne!(
+            err.code(),
+            Code::ResourceExhausted,
+            "RESOURCE_EXHAUSTED would defeat the connector's #2241 failover"
+        );
+        assert_eq!(
+            adm.snapshot().rejected_total,
+            before + 1,
+            "rejected_total increments by exactly one"
+        );
+        drop(held);
+    });
+}
+
+/// Scenario: a short burst is absorbed by the wait — a permit frees before the
+/// timeout, so the request is admitted with `OK` and `rejected_total` is unchanged.
+#[test]
+fn req2_short_burst_absorbed_without_rejection() {
+    let adm = Admission::new(cfg(1, BIG_TIMEOUT));
+    let (_temp, svc) = build_service(adm.clone(), 8);
+    block_on_paused(async move {
+        let held = adm.acquire().await.unwrap();
+        let before_reject = adm.snapshot().rejected_total;
+
+        let svc2 = svc.clone();
+        let handle = tokio::spawn(async move { svc2.do_get(do_get_request()).await });
+        settle().await;
+        assert_eq!(adm.snapshot().waiting, 1, "the excess request is waiting");
+
+        drop(held); // free a permit BEFORE the timeout — the burst is absorbed
+        let resp = handle
+            .await
+            .unwrap()
+            .expect("the waiter must be admitted, not rejected");
+        let batches = decode(resp.into_inner()).await;
+        assert!(total_rows(&batches) > 0, "admitted scan returns its rows");
+        assert_eq!(
+            adm.snapshot().rejected_total,
+            before_reject,
+            "no rejection on an absorbed burst"
+        );
+    });
+}
+
+// ---- Requirement 3: a cancelled/disconnected do_get releases its permit ----
+
+/// Scenario: dropping every admitted stream returns the admission gauge to
+/// baseline (zero leaked permits) and a subsequently offered scan is admitted
+/// immediately.
+#[test]
+fn req3_dropping_admitted_streams_returns_gauge_to_baseline() {
+    let adm = Admission::new(cfg(2, BIG_TIMEOUT));
+    let (_temp, svc) = build_service(adm.clone(), 8);
+    block_on_paused(async move {
+        let baseline = adm.snapshot().in_use;
+        let mut streams = Vec::new();
+        for _ in 0..2 {
+            let resp = svc.do_get(do_get_request()).await.unwrap();
+            let mut stream = resp.into_inner();
+            let _first = stream.next().await; // consume the first message
+            streams.push(stream);
+        }
+        assert_eq!(adm.snapshot().in_use, 2, "K admitted, in-flight");
+
+        drop(streams); // client disconnect on all K
+        assert_eq!(
+            adm.snapshot().in_use,
+            baseline,
+            "gauge returns to baseline — zero leaked permits"
+        );
+
+        // A new scan is admitted immediately (a permit is free again).
+        let resp = svc.do_get(do_get_request()).await.unwrap();
+        assert_eq!(adm.snapshot().in_use, 1, "the freed permit re-admits");
+        drop(resp);
+    });
+}
+
+/// Scenario: a request cancelled while waiting for a permit never holds one — the
+/// waiting gauge returns to zero and the in-use gauge is unchanged.
+#[test]
+fn req3_cancel_while_waiting_never_acquires() {
+    block_on_paused(async {
+        let adm = Admission::new(cfg(1, BIG_TIMEOUT));
+        let held = adm.acquire().await.unwrap();
+        let mut waiter = Box::pin(adm.acquire());
+        assert!(matches!(futures::poll!(waiter.as_mut()), Poll::Pending));
+        assert_eq!(adm.snapshot().waiting, 1);
+
+        drop(waiter); // cancelled while waiting (client disconnect before admission)
+
+        let s = adm.snapshot();
+        assert_eq!(s.waiting, 0, "the cancelled waiter released its wait slot");
+        assert_eq!(s.in_use, 1, "it never acquired — in-use unchanged");
+        drop(held);
+    });
+}
+
+// ---- Requirement 4: the admission limit is a real, wired configuration knob ----
+
+/// Scenario: a configured limit `K` bounds admitted concurrency to `K`,
+/// demonstrated for two distinct `K` so the value provably flows to the ceiling.
+#[test]
+fn req4_configured_k_bounds_admitted_concurrency() {
+    for k in [1usize, 3usize] {
+        let adm = Admission::new(cfg(k, BIG_TIMEOUT));
+        let (_temp, svc) = build_service(adm.clone(), 8);
+        block_on_paused(async move {
+            assert_eq!(adm.limit(), k, "configured K flows to the ceiling");
+
+            // Admit K do_gets; hold their (unconsumed) response streams so the
+            // permits stay in use.
+            let mut held = Vec::new();
+            for _ in 0..k {
+                held.push(svc.do_get(do_get_request()).await.unwrap());
+            }
+            assert_eq!(adm.snapshot().in_use as usize, k, "in-use == configured K");
+
+            // One more request cannot be admitted — it waits.
+            let svc2 = svc.clone();
+            let excess = tokio::spawn(async move { svc2.do_get(do_get_request()).await });
+            settle().await;
+            let s = adm.snapshot();
+            assert_eq!(
+                s.in_use as usize, k,
+                "in-use bounded by exactly the configured K={k}, not a constant"
+            );
+            assert!(s.waiting >= 1, "the excess request waits");
+
+            excess.abort();
+            drop(held);
+        });
+    }
+}
+
+/// Scenario: the permit-wait timeout is honoured as configured — a different
+/// budget yields a correspondingly different reject point (logical time under the
+/// paused clock; no real sleep).
+#[test]
+fn req4_permit_wait_timeout_is_wired() {
+    fn reject_after(budget: Duration) -> Duration {
+        block_on_paused(async move {
+            let adm = Admission::new(cfg(1, budget));
+            let _held = adm.acquire().await.unwrap(); // occupy the only permit
+            let start = tokio::time::Instant::now();
+            let err = adm.acquire().await.unwrap_err();
+            assert_eq!(err.code(), Code::Unavailable);
+            start.elapsed()
+        })
+    }
+
+    // The paused clock advances to the deadline (tokio's timer granularity rounds
+    // up to the next millisecond), so assert a tight window at the configured
+    // budget rather than exact equality — and that a longer budget provably waits
+    // longer (the knob is wired, not decorative).
+    let slack = Duration::from_millis(50);
+    let short = reject_after(Duration::from_secs(5));
+    let long = reject_after(Duration::from_secs(30));
+    assert!(
+        short >= Duration::from_secs(5) && short < Duration::from_secs(5) + slack,
+        "reject point tracks the configured 5s budget, got {short:?}"
+    );
+    assert!(
+        long >= Duration::from_secs(30) && long < Duration::from_secs(30) + slack,
+        "reject point tracks the configured 30s budget, got {long:?}"
+    );
+    assert!(long > short, "a longer configured budget yields a later reject point");
+}
+
+// ---- Requirement 5: admission state is exported as observability instruments ----
+
+/// Scenario: admission gauges/counters track engagement deterministically, and are
+/// distinct names from `cqlite.rpc.in_flight`.
+#[test]
+fn req5_admission_instruments_track_engagement() {
+    // Distinct instrument names from the WS2 RPC gauge (no double counting).
+    for name in [
+        catalog::FLIGHT_ADMISSION_LIMIT,
+        catalog::FLIGHT_ADMISSION_IN_USE,
+        catalog::FLIGHT_ADMISSION_WAITING,
+        catalog::FLIGHT_ADMISSION_REJECTED_TOTAL,
+        catalog::FLIGHT_ADMISSION_WAIT_SECONDS,
+    ] {
+        assert_ne!(name, catalog::RPC_IN_FLIGHT, "distinct from the RPC in-flight gauge");
+        assert!(catalog::ALL_METRICS.contains(&name), "{name} registered in the catalog");
+    }
+
+    block_on_paused(async {
+        let adm = Admission::new(cfg(2, Duration::from_secs(10)));
+        let p1 = adm.acquire().await.unwrap();
+        let p2 = adm.acquire().await.unwrap();
+        assert_eq!(adm.snapshot().in_use, 2, "in-use reads K");
+
+        // A waiting reading (M made to wait), then release it.
+        let mut waiter = Box::pin(adm.acquire());
+        assert!(matches!(futures::poll!(waiter.as_mut()), Poll::Pending));
+        assert_eq!(adm.snapshot().waiting, 1, "waiting reads the current wait count");
+        drop(waiter);
+
+        // One wait times out: rejection counter increments by one and a
+        // permit-wait sample is recorded.
+        let before = adm.snapshot();
+        let err = adm.acquire().await.unwrap_err();
+        assert_eq!(err.code(), Code::Unavailable);
+        let after = adm.snapshot();
+        assert_eq!(after.in_use, 2, "the timeout admitted nothing — in-use still K");
+        assert_eq!(after.waiting, 0, "the timed-out waiter released its slot");
+        assert_eq!(after.rejected_total, before.rejected_total + 1, "one rejection");
+        assert!(
+            after.wait_samples > before.wait_samples,
+            "the permit-wait histogram recorded a sample"
+        );
+        drop((p1, p2));
+    });
+}
+
+// ---- Requirement 6: admission does not alter the result of an admitted scan ----
+
+/// Scenario: an admitted-after-wait result equals the unbounded result — identical
+/// rows, order, schema, and batch boundaries.
+#[test]
+fn req6_admitted_after_wait_equals_unbounded_result() {
+    // Unbounded path: a generous ceiling, admitted immediately.
+    let adm_unbounded = Admission::new(cfg(64, BIG_TIMEOUT));
+    let (_t1, svc_unbounded) = build_service(adm_unbounded, 8);
+    let unbounded = block_on_paused(async move {
+        let resp = svc_unbounded.do_get(do_get_request()).await.unwrap();
+        decode(resp.into_inner()).await
+    });
+
+    // Admission path: K = 1, admitted only after waiting for a permit to free.
+    let adm = Admission::new(cfg(1, BIG_TIMEOUT));
+    let (_t2, svc) = build_service(adm.clone(), 8);
+    let admitted = block_on_paused(async move {
+        let held = adm.acquire().await.unwrap();
+        let svc2 = svc.clone();
+        let handle = tokio::spawn(async move { svc2.do_get(do_get_request()).await });
+        settle().await;
+        assert_eq!(adm.snapshot().waiting, 1, "the scan waits for a permit");
+        drop(held); // admit it after the wait
+        let resp = handle.await.unwrap().expect("admitted after waiting");
+        decode(resp.into_inner()).await
+    });
+
+    assert!(!unbounded.is_empty(), "the fixture returns rows");
+    assert_eq!(
+        unbounded, admitted,
+        "admission is transparent: identical rows, order, schema, and batch boundaries"
+    );
+}

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -9,9 +9,14 @@
 //! surface, proving the ceiling engages on the real path.
 //!
 //! Red-on-main proof: `excess_do_gets_never_reach_setup` asserts the excess
-//! requests never run `do_get_setup` (the `resolves` work counter stays flat)
-//! while all permits are held — with the acquire-before-setup wiring removed,
-//! every offered request runs setup and the counter jumps, reding the test.
+//! requests never run `do_get_resolve` (the `resolves` work counter, bumped only
+//! by the filesystem-touching `resolve_dir` call inside it, stays flat) while all
+//! permits are held — with the acquire-before-resolve wiring removed, every
+//! offered request runs the filesystem resolve and the counter jumps, reding the
+//! test. Ticket VALIDATION (parse + schema/predicate build, roborev-1698) is
+//! deliberately excluded from this gate: it is cheap and filesystem-free, so it
+//! runs BEFORE admission and must not wait behind the semaphore — see
+//! `req_malformed_ticket_bypasses_admission_entirely` below.
 
 use std::task::Poll;
 use std::time::Duration;
@@ -245,9 +250,12 @@ fn req1_releasing_one_permit_admits_exactly_one_waiter() {
 }
 
 /// Red-on-main proof (Scenario 1's do_get clause): with all `K` permits held, the
-/// `K + M` offered `do_get`s never reach `do_get_setup` — the `resolves` work
-/// counter stays flat. Remove the acquire-before-setup wiring and every request
-/// runs setup, jumping the counter: the test reds.
+/// `K + M` offered `do_get`s never reach the filesystem resolve (`do_get_resolve`)
+/// — the `resolves` work counter, bumped only inside `resolve_dir`, stays flat.
+/// Remove the acquire-before-resolve wiring and every request runs the resolve,
+/// jumping the counter: the test reds. (Ticket validation itself — parse +
+/// schema/predicate build — deliberately runs BEFORE this gate; see
+/// `req_malformed_ticket_bypasses_admission_entirely`.)
 #[test]
 fn req1_excess_do_gets_never_reach_setup() {
     let adm = Admission::new(cfg(2, BIG_TIMEOUT));
@@ -271,7 +279,7 @@ fn req1_excess_do_gets_never_reach_setup() {
         assert_eq!(
             svc.setup_work().resolves,
             baseline,
-            "no excess request reached do_get_setup while all K permits are held"
+            "no excess request reached the filesystem resolve while all K permits are held"
         );
         let s = adm.snapshot();
         assert_eq!(s.in_use, 2, "only the K barrier permits are held");
@@ -284,6 +292,57 @@ fn req1_excess_do_gets_never_reach_setup() {
             t.abort();
         }
         drop((h1, h2));
+    });
+}
+
+/// roborev-1698: a MALFORMED ticket (fails validation with no filesystem access)
+/// must bypass admission entirely — it can never succeed no matter how many times
+/// it is retried, so it must fail with its OWN status (`INVALID_ARGUMENT`)
+/// immediately: never wait behind the admission semaphore (even with every permit
+/// held), never `UNAVAILABLE` (which would make the connector failover-retry an
+/// unsatisfiable request into a poison retry storm), and never consume/contend
+/// for a permit (`rejected_total` and the waiting gauge stay exactly where they
+/// started).
+#[test]
+fn req_malformed_ticket_bypasses_admission_entirely() {
+    let adm = Admission::new(cfg(1, BIG_TIMEOUT));
+    let (_temp, svc) = build_service(adm.clone(), 8);
+    block_on_paused(async move {
+        // Hold the ONLY permit — every real do_get would have to wait for it.
+        let held = adm.acquire().await.unwrap();
+        let before = adm.snapshot();
+
+        // Malformed ticket bytes: not even valid JSON, so `FlightTicket::from_bytes`
+        // fails before admission is ever consulted.
+        let malformed = Request::new(Ticket::new(b"not a valid flight ticket".to_vec()));
+        let err = svc
+            .do_get(malformed)
+            .await
+            .err()
+            .expect("a malformed ticket must error");
+
+        assert_eq!(
+            err.code(),
+            Code::InvalidArgument,
+            "a malformed ticket fails validation, never waits for admission, got: {err:?}"
+        );
+        assert_ne!(
+            err.code(),
+            Code::Unavailable,
+            "validation failures are not shed as UNAVAILABLE — they can never succeed on retry"
+        );
+
+        let after = adm.snapshot();
+        assert_eq!(
+            after.waiting, before.waiting,
+            "the malformed ticket never registered as waiting"
+        );
+        assert_eq!(
+            after.rejected_total, before.rejected_total,
+            "the malformed ticket never contended for (or was shed by) admission"
+        );
+        assert_eq!(after.in_use, before.in_use, "the held permit is untouched");
+        drop(held);
     });
 }
 

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -8,6 +8,7 @@
 //! See `docs/flight-trino/PLAN.md` for the full design and `JOURNAL.md` for the
 //! change log.
 
+pub mod admission;
 pub mod agg;
 pub mod cancel;
 pub mod filter;

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use tonic::transport::Server;
 
 use cqlite_flight::admission::{
-    Admission, AdmissionConfig, DEFAULT_MAX_CONCURRENT_SCANS, DEFAULT_WAIT_TIMEOUT_MS,
+    Admission, AdmissionConfig, WaitBudget, DEFAULT_MAX_CONCURRENT_SCANS, DEFAULT_WAIT_TIMEOUT_MS,
     ENV_MAX_CONCURRENT_SCANS, ENV_WAIT_TIMEOUT_MS,
 };
 use cqlite_flight::service::CqliteFlightService;
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // observable, cancel-releasable ceiling.
     let admission = Admission::new(AdmissionConfig {
         max_concurrent_scans: args.max_concurrent_scans,
-        wait_timeout: Duration::from_millis(args.admission_wait_timeout_ms),
+        wait_budget: WaitBudget::Timeout(Duration::from_millis(args.admission_wait_timeout_ms)),
     });
     let admission_limit = admission.limit();
     let service = CqliteFlightService::with_admission(args.data_dir, args.batch_size, admission);

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -8,8 +8,13 @@ use arrow_flight::flight_service_server::FlightServiceServer;
 use clap::Parser;
 use tonic::transport::Server;
 
+use cqlite_flight::admission::{
+    Admission, AdmissionConfig, DEFAULT_MAX_CONCURRENT_SCANS, DEFAULT_WAIT_TIMEOUT_MS,
+    ENV_MAX_CONCURRENT_SCANS, ENV_WAIT_TIMEOUT_MS,
+};
 use cqlite_flight::service::CqliteFlightService;
 use cqlite_flight::shutdown::shutdown_signal;
+use std::time::Duration;
 
 /// Command-line arguments.
 #[derive(Parser, Debug)]
@@ -29,6 +34,20 @@ struct Args {
     /// Maximum rows per Arrow record batch.
     #[arg(long, default_value_t = 8192)]
     batch_size: usize,
+
+    /// Maximum concurrently admitted `do_get` scans (issue #2420, WS4). A `do_get`
+    /// acquires a permit before opening any SSTable; past this ceiling requests
+    /// wait up to `--admission-wait-timeout-ms`, then are shed with gRPC
+    /// `UNAVAILABLE` (retry-safe for the connector's replica failover). Sized from
+    /// the blocking-pool (~256) / fd (~1024÷SSTables) ceilings, not core count.
+    #[arg(long, env = ENV_MAX_CONCURRENT_SCANS, default_value_t = DEFAULT_MAX_CONCURRENT_SCANS)]
+    max_concurrent_scans: usize,
+
+    /// How long a saturated `do_get` waits for an admission permit before it is
+    /// rejected with `UNAVAILABLE` (issue #2420, WS4). Short bursts under this
+    /// budget are absorbed transparently with no client-visible error.
+    #[arg(long, env = ENV_WAIT_TIMEOUT_MS, default_value_t = DEFAULT_WAIT_TIMEOUT_MS)]
+    admission_wait_timeout_ms: u64,
 }
 
 #[tokio::main]
@@ -65,13 +84,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
     let listen = args.listen;
-    let service = CqliteFlightService::new(args.data_dir, args.batch_size);
+    // Admission control (issue #2420, WS4): the owned Semaphore is the real,
+    // observable, cancel-releasable ceiling.
+    let admission = Admission::new(AdmissionConfig {
+        max_concurrent_scans: args.max_concurrent_scans,
+        wait_timeout: Duration::from_millis(args.admission_wait_timeout_ms),
+    });
+    let admission_limit = admission.limit();
+    let service = CqliteFlightService::with_admission(args.data_dir, args.batch_size, admission);
 
-    tracing::info!(%listen, batch_size = args.batch_size, "cqlite-flight starting");
+    // A coarse tonic transport backstop, generously ABOVE the admission ceiling:
+    // it guards the HTTP/2 accept loop / stream table from a client opening far
+    // more streams than `K`, but the Semaphore — not this cap — is the real
+    // admission throttle (issue #2420). `saturating_mul` avoids overflow on an
+    // extreme configured `K`.
+    let max_concurrent_streams: u32 = u32::try_from(admission_limit)
+        .unwrap_or(u32::MAX)
+        .saturating_mul(4)
+        .max(1024);
+
+    tracing::info!(
+        %listen,
+        batch_size = args.batch_size,
+        max_concurrent_scans = admission_limit,
+        admission_wait_timeout_ms = args.admission_wait_timeout_ms,
+        max_concurrent_streams,
+        "cqlite-flight starting"
+    );
     // Graceful shutdown (issue #1473): on ctrl_c / SIGTERM, tonic stops
     // accepting new connections and drains in-flight RPCs rather than tearing
     // every open stream down abruptly.
     Server::builder()
+        .max_concurrent_streams(max_concurrent_streams)
         .add_service(FlightServiceServer::new(service))
         .serve_with_shutdown(listen, shutdown_signal())
         .await?;

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -181,32 +181,45 @@ impl Drop for RpcMetrics {
 }
 
 /// `do_get` execution phases (issue #2162; `admission` added #2420
-/// roborev-1700), a fixed, bounded, ordered set. Used as the `cqlite.rpc.phase`
-/// attribute value on `cqlite.rpc.phase.duration`; the values are `&'static str`
-/// from this closed table so metric cardinality is capped exactly like
-/// [`RPC_METHODS`] — never a per-query/ticket/key value.
+/// roborev-1700; `validate` added #2420 roborev-1702), a fixed, bounded,
+/// ordered set. Used as the `cqlite.rpc.phase` attribute value on
+/// `cqlite.rpc.phase.duration`; the values are `&'static str` from this closed
+/// table so metric cardinality is capped exactly like [`RPC_METHODS`] — never a
+/// per-query/ticket/key value.
 ///
+/// - `validate`: parsing the ticket bytes (`FlightTicket::from_bytes`) — cheap,
+///   filesystem-free syntax validation, BEFORE the admission-permit acquire. On
+///   `main` (pre-#2420) this same failure mode recorded a `resolve`-phase
+///   sample (the timer was already open in `resolve` when ticket-parsing failed
+///   inside the old `do_get_setup`); `validate` gives it a precise label of its
+///   own instead of folding it into `resolve`'s meaning, while preserving the
+///   invariant that a malformed ticket still records SOME phase sample (never
+///   silently drops phase visibility relative to pre-#2420 behavior).
 /// - `admission`: queued waiting for (or immediately granted) an admission
-///   permit (issue #2420), BEFORE any producer/schema construction or
-///   filesystem access begins. `cqlite.rpc.duration` already includes this wait
-///   in the RPC total, but the per-phase breakdown is what field triage uses to
-///   localize latency (e.g. #2398) — without this phase, admission queueing
-///   time was invisible here even though it dominates the RPC under saturation.
+///   permit (issue #2420), AFTER validation passes but BEFORE any producer/
+///   schema construction or filesystem access begins. `cqlite.rpc.duration`
+///   already includes this wait in the RPC total, but the per-phase breakdown
+///   is what field triage uses to localize latency (e.g. #2398) — without this
+///   phase, admission queueing time was invisible here even though it
+///   dominates the RPC under saturation.
 /// - `resolve`: producer/schema construction + path discovery/token prune
 ///   (`do_get_resolve`).
 /// - `merge_setup`: opening every input SSTable + building the k-way merger
 ///   (`KWayMerger::new`, the #2157 stall suspect) before the first batch.
 /// - `stream`: partitions stepping + batches flowing to the client.
+pub const PHASE_VALIDATE: &str = "validate";
+/// See [`PHASE_VALIDATE`].
 pub const PHASE_ADMISSION: &str = "admission";
-/// See [`PHASE_ADMISSION`].
+/// See [`PHASE_VALIDATE`].
 pub const PHASE_RESOLVE: &str = "resolve";
-/// See [`PHASE_ADMISSION`].
+/// See [`PHASE_VALIDATE`].
 pub const PHASE_MERGE_SETUP: &str = "merge_setup";
-/// See [`PHASE_ADMISSION`].
+/// See [`PHASE_VALIDATE`].
 pub const PHASE_STREAM: &str = "stream";
 
 /// The closed set of `do_get` phase labels, in transition order.
-const RPC_PHASES: [&str; 4] = [
+const RPC_PHASES: [&str; 5] = [
+    PHASE_VALIDATE,
     PHASE_ADMISSION,
     PHASE_RESOLVE,
     PHASE_MERGE_SETUP,
@@ -227,7 +240,8 @@ fn phase_slot(phase: &str) -> &'static str {
 }
 
 /// Resolve a phase label to its index in [`RPC_PHASES`]. Unknown values map to
-/// index 0 (`resolve`), mirroring [`phase_slot`]'s fallback — never panics.
+/// index 0 (`validate`, [`RPC_PHASES`]'s first entry), mirroring
+/// [`phase_slot`]'s fallback — never panics.
 fn phase_index(phase: &str) -> usize {
     RPC_PHASES.iter().position(|p| *p == phase).unwrap_or(0)
 }
@@ -254,19 +268,24 @@ fn phase_active_counters() -> &'static [AtomicI64] {
 }
 
 /// Records the wall time a `do_get` spends in each bounded execution phase
-/// (issue #2162, `admission` phase added #2420 roborev-1700):
-/// `admission` → `resolve` → `merge_setup` → `stream`.
+/// (issue #2162, `admission` phase added #2420 roborev-1700, `validate` phase
+/// added #2420 roborev-1702): `validate` → `admission` → `resolve` →
+/// `merge_setup` → `stream`.
 ///
-/// Constructed at `do_get` entry, BEFORE the admission-permit acquire (phase
-/// `admission`) — so a request queued behind a saturated ceiling shows that wait
-/// in the per-phase breakdown, not silently folded into `resolve` or invisible
-/// entirely (RPC_DURATION already includes it in the RPC total, but the
-/// per-phase view is what field triage localizes latency with, e.g. #2398).
-/// [`Self::transition`] closes the current phase — emitting a
+/// Constructed at `do_get` entry, BEFORE the ticket is even parsed (phase
+/// `validate`) — so a syntactically malformed ticket still records a phase
+/// sample (matching `main`'s pre-#2420 behavior, which recorded a `resolve`
+/// sample for this same failure mode; `validate` now gives it a precise label
+/// instead), and a request queued behind a saturated admission ceiling shows
+/// that wait in the per-phase breakdown, not silently folded into `resolve` or
+/// invisible entirely (RPC_DURATION already includes both in the RPC total,
+/// but the per-phase view is what field triage localizes latency with, e.g.
+/// #2398). [`Self::transition`] closes the current phase — emitting a
 /// `cqlite.rpc.phase.duration` histogram sample tagged with the bounded
 /// `cqlite.rpc.phase` attribute plus a `tracing` span event — and opens the
 /// next. [`Drop`] closes whichever phase is still open, so EVERY entered phase
-/// records exactly one sample even on an error/cancel/panic exit (including an
+/// records exactly one sample even on an error/cancel/panic exit (including a
+/// ticket-validation failure, which never transitions past `validate`, or an
 /// admission timeout/reject, which never transitions past `admission`), and a
 /// phase never entered records none (never a fabricated zero).
 ///
@@ -282,14 +301,15 @@ pub struct PhaseTimer {
 }
 
 impl PhaseTimer {
-    /// Begin timing at the `admission` phase for `method` (a `&'static str` from
+    /// Begin timing at the `validate` phase for `method` (a `&'static str` from
     /// the bounded `FlightService` method set) — see the type doc for why
-    /// admission wait must be the FIRST phase, not folded into `resolve`.
+    /// ticket validation must be the FIRST phase, not folded into `resolve` (or
+    /// skipped entirely).
     pub fn start(method: &'static str) -> Self {
         let method = RPC_METHODS[method_index(method)];
         let timer = Self {
             method,
-            phase: PHASE_ADMISSION,
+            phase: PHASE_VALIDATE,
             started: Instant::now(),
             span: tracing::Span::current(),
         };
@@ -676,9 +696,9 @@ mod tests {
     #[test]
     fn phase_active_counter_reflects_concurrent_overlap_not_a_flag() {
         // Dedicated method slot so no other test's PhaseTimer perturbs the count.
-        // `PhaseTimer::start` opens `PHASE_ADMISSION` (issue #2420 roborev-1700).
+        // `PhaseTimer::start` opens `PHASE_VALIDATE` (issue #2420 roborev-1702).
         let midx = method_index("list_actions");
-        let pidx = phase_index(PHASE_ADMISSION);
+        let pidx = phase_index(PHASE_VALIDATE);
         let idx = phase_active_index(midx, pidx);
         let base = phase_active_counters()[idx].load(Ordering::Relaxed);
 
@@ -720,10 +740,10 @@ mod tests {
     /// leaking a stale increment on the old phase (issue #2361).
     #[test]
     fn phase_active_counter_moves_on_transition() {
-        // `PhaseTimer::start` opens `PHASE_ADMISSION` (issue #2420 roborev-1700);
+        // `PhaseTimer::start` opens `PHASE_VALIDATE` (issue #2420 roborev-1702);
         // `resolve_idx` names the STARTING phase's slot for this test's purposes.
         let midx = method_index("do_action");
-        let resolve_idx = phase_active_index(midx, phase_index(PHASE_ADMISSION));
+        let resolve_idx = phase_active_index(midx, phase_index(PHASE_VALIDATE));
         let stream_idx = phase_active_index(midx, phase_index(PHASE_STREAM));
         let resolve_base = phase_active_counters()[resolve_idx].load(Ordering::Relaxed);
         let stream_base = phase_active_counters()[stream_idx].load(Ordering::Relaxed);

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -180,32 +180,50 @@ impl Drop for RpcMetrics {
     }
 }
 
-/// `do_get` execution phases (issue #2162), a fixed, bounded, ordered set. Used
-/// as the `cqlite.rpc.phase` attribute value on `cqlite.rpc.phase.duration`; the
-/// values are `&'static str` from this closed table so metric cardinality is
-/// capped exactly like [`RPC_METHODS`] — never a per-query/ticket/key value.
+/// `do_get` execution phases (issue #2162; `admission` added #2420
+/// roborev-1700), a fixed, bounded, ordered set. Used as the `cqlite.rpc.phase`
+/// attribute value on `cqlite.rpc.phase.duration`; the values are `&'static str`
+/// from this closed table so metric cardinality is capped exactly like
+/// [`RPC_METHODS`] — never a per-query/ticket/key value.
 ///
-/// - `resolve`: path discovery + token prune (`do_get_setup`).
+/// - `admission`: queued waiting for (or immediately granted) an admission
+///   permit (issue #2420), BEFORE any producer/schema construction or
+///   filesystem access begins. `cqlite.rpc.duration` already includes this wait
+///   in the RPC total, but the per-phase breakdown is what field triage uses to
+///   localize latency (e.g. #2398) — without this phase, admission queueing
+///   time was invisible here even though it dominates the RPC under saturation.
+/// - `resolve`: producer/schema construction + path discovery/token prune
+///   (`do_get_resolve`).
 /// - `merge_setup`: opening every input SSTable + building the k-way merger
 ///   (`KWayMerger::new`, the #2157 stall suspect) before the first batch.
 /// - `stream`: partitions stepping + batches flowing to the client.
+pub const PHASE_ADMISSION: &str = "admission";
+/// See [`PHASE_ADMISSION`].
 pub const PHASE_RESOLVE: &str = "resolve";
-/// See [`PHASE_RESOLVE`].
+/// See [`PHASE_ADMISSION`].
 pub const PHASE_MERGE_SETUP: &str = "merge_setup";
-/// See [`PHASE_RESOLVE`].
+/// See [`PHASE_ADMISSION`].
 pub const PHASE_STREAM: &str = "stream";
 
 /// The closed set of `do_get` phase labels, in transition order.
-const RPC_PHASES: [&str; 3] = [PHASE_RESOLVE, PHASE_MERGE_SETUP, PHASE_STREAM];
+const RPC_PHASES: [&str; 4] = [
+    PHASE_ADMISSION,
+    PHASE_RESOLVE,
+    PHASE_MERGE_SETUP,
+    PHASE_STREAM,
+];
 
 /// Normalise a phase label to its bounded slot, so an unexpected value can never
-/// leak as a metric attribute (it maps to `resolve`, never an arbitrary string).
+/// leak as a metric attribute (it maps to [`RPC_PHASES`]'s first entry, never an
+/// arbitrary string — derived from the table, not a separately hardcoded label,
+/// so it can never silently drift from [`phase_index`]'s matching `unwrap_or(0)`
+/// fallback).
 fn phase_slot(phase: &str) -> &'static str {
     RPC_PHASES
         .iter()
         .find(|p| **p == phase)
         .copied()
-        .unwrap_or(PHASE_RESOLVE)
+        .unwrap_or(RPC_PHASES[0])
 }
 
 /// Resolve a phase label to its index in [`RPC_PHASES`]. Unknown values map to
@@ -236,14 +254,21 @@ fn phase_active_counters() -> &'static [AtomicI64] {
 }
 
 /// Records the wall time a `do_get` spends in each bounded execution phase
-/// (issue #2162): `resolve` → `merge_setup` → `stream`.
+/// (issue #2162, `admission` phase added #2420 roborev-1700):
+/// `admission` → `resolve` → `merge_setup` → `stream`.
 ///
-/// Constructed at `do_get` entry (phase `resolve`). [`Self::transition`] closes
-/// the current phase — emitting a `cqlite.rpc.phase.duration` histogram sample
-/// tagged with the bounded `cqlite.rpc.phase` attribute plus a `tracing` span
-/// event — and opens the next. [`Drop`] closes whichever phase is still open, so
-/// EVERY entered phase records exactly one sample even on an error/cancel/panic
-/// exit, and a phase never entered records none (never a fabricated zero).
+/// Constructed at `do_get` entry, BEFORE the admission-permit acquire (phase
+/// `admission`) — so a request queued behind a saturated ceiling shows that wait
+/// in the per-phase breakdown, not silently folded into `resolve` or invisible
+/// entirely (RPC_DURATION already includes it in the RPC total, but the
+/// per-phase view is what field triage localizes latency with, e.g. #2398).
+/// [`Self::transition`] closes the current phase — emitting a
+/// `cqlite.rpc.phase.duration` histogram sample tagged with the bounded
+/// `cqlite.rpc.phase` attribute plus a `tracing` span event — and opens the
+/// next. [`Drop`] closes whichever phase is still open, so EVERY entered phase
+/// records exactly one sample even on an error/cancel/panic exit (including an
+/// admission timeout/reject, which never transitions past `admission`), and a
+/// phase never entered records none (never a fabricated zero).
 ///
 /// The recorder captures the `do_get` span at construction and re-enters it
 /// around each emission, so the span events attach to the `flight.do_get` span
@@ -257,13 +282,14 @@ pub struct PhaseTimer {
 }
 
 impl PhaseTimer {
-    /// Begin timing at the `resolve` phase for `method` (a `&'static str` from the
-    /// bounded `FlightService` method set).
+    /// Begin timing at the `admission` phase for `method` (a `&'static str` from
+    /// the bounded `FlightService` method set) — see the type doc for why
+    /// admission wait must be the FIRST phase, not folded into `resolve`.
     pub fn start(method: &'static str) -> Self {
         let method = RPC_METHODS[method_index(method)];
         let timer = Self {
             method,
-            phase: PHASE_RESOLVE,
+            phase: PHASE_ADMISSION,
             started: Instant::now(),
             span: tracing::Span::current(),
         };
@@ -432,6 +458,27 @@ pub fn phase_active_level(method: &str) -> i64 {
     (0..RPC_PHASES.len())
         .map(|p| c[phase_active_index(midx, p)].load(Ordering::Relaxed))
         .sum()
+}
+
+/// Read the process-wide `cqlite.rpc.phase.active` level for a SPECIFIC
+/// `(method, phase)` pair (issue #2420 roborev-1700) — isolates one phase's
+/// count, unlike [`phase_active_level`] (which sums across all phases). Used to
+/// pin that a `do_get` queued behind a saturated admission ceiling occupies the
+/// `admission` phase specifically (queue time visible in the phase breakdown,
+/// not folded into `resolve`). The underlying atomic is maintained regardless of
+/// the `observability` OTel feature (only the OTel emission itself is gated), so
+/// this is a feature-independent pin, mirroring [`phase_active_level`]. Unknown
+/// method/phase values normalise to their bounded slot (never panics), matching
+/// [`phase_slot`]/[`method_index`].
+///
+/// `#[cfg(test)]`-only (unlike the fully-`pub` [`phase_active_level`], which an
+/// EXTERNAL integration test binary also needs): this helper is consumed only by
+/// in-crate unit tests (`admission_tests.rs`), so it would otherwise be flagged
+/// dead code in a non-test build.
+#[cfg(test)]
+pub(crate) fn phase_active_level_for(method: &str, phase: &str) -> i64 {
+    let idx = phase_active_index(method_index(method), phase_index(phase));
+    phase_active_counters()[idx].load(Ordering::Relaxed)
 }
 
 /// Record an RPC failure into the error-rate signal (`cqlite.errors.total`,
@@ -629,8 +676,9 @@ mod tests {
     #[test]
     fn phase_active_counter_reflects_concurrent_overlap_not_a_flag() {
         // Dedicated method slot so no other test's PhaseTimer perturbs the count.
+        // `PhaseTimer::start` opens `PHASE_ADMISSION` (issue #2420 roborev-1700).
         let midx = method_index("list_actions");
-        let pidx = phase_index(PHASE_RESOLVE);
+        let pidx = phase_index(PHASE_ADMISSION);
         let idx = phase_active_index(midx, pidx);
         let base = phase_active_counters()[idx].load(Ordering::Relaxed);
 
@@ -672,8 +720,10 @@ mod tests {
     /// leaking a stale increment on the old phase (issue #2361).
     #[test]
     fn phase_active_counter_moves_on_transition() {
+        // `PhaseTimer::start` opens `PHASE_ADMISSION` (issue #2420 roborev-1700);
+        // `resolve_idx` names the STARTING phase's slot for this test's purposes.
         let midx = method_index("do_action");
-        let resolve_idx = phase_active_index(midx, phase_index(PHASE_RESOLVE));
+        let resolve_idx = phase_active_index(midx, phase_index(PHASE_ADMISSION));
         let stream_idx = phase_active_index(midx, phase_index(PHASE_STREAM));
         let resolve_base = phase_active_counters()[resolve_idx].load(Ordering::Relaxed);
         let stream_base = phase_active_counters()[stream_idx].load(Ordering::Relaxed);

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -596,6 +596,20 @@ impl CqliteFlightService {
             Ok(t) => t,
             Err(status) => return Err((status, metrics)),
         };
+        // Phase timing (issue #2162, `admission` phase added #2420
+        // roborev-1700): begin BEFORE the admission-permit acquire, in the new
+        // `admission` phase. The timer captures the `flight.do_get` span (this
+        // future runs under it via `.instrument`), so its per-phase histogram
+        // samples + span events attach to that span even for the phases that run
+        // on the blocking merge pool. `cqlite.rpc.duration` already includes
+        // admission wait in the RPC total, but the per-phase breakdown is what
+        // field triage localizes latency with (e.g. #2398) — starting the timer
+        // here (rather than after `acquire`, or folding the wait into `resolve`)
+        // makes queueing time a first-class, directly observable phase instead of
+        // vanishing from this breakdown. On an admission timeout/reject the timer
+        // drops here without ever transitioning, recording the `admission` phase
+        // duration it died in.
+        let mut timer = crate::obs::PhaseTimer::start("do_get");
         // Admission control (issue #2420, WS4): acquire a permit immediately
         // after the minimal syntax check, before producer/schema construction,
         // any filesystem access (directory resolve / SSTable open), or batch
@@ -613,13 +627,11 @@ impl CqliteFlightService {
         };
         let cancel = CancelFlag::new();
         let mut setup_guard = cancel.drop_guard();
-        // Phase timing (issue #2162): begin in the `resolve` phase. The timer
-        // captures the `flight.do_get` span (this future runs under it via
-        // `.instrument`), so its per-phase histogram samples + span events attach
-        // to that span even for the phases that run on the blocking merge pool. On
-        // the setup-error path below the timer drops here, recording the `resolve`
-        // phase it died in — so a stall that never produces a row still localizes.
-        let mut timer = crate::obs::PhaseTimer::start("do_get");
+        // Admitted: close the `admission` phase and enter `resolve` (producer/
+        // schema construction + path discovery/token prune). On the resolve-error
+        // path below the timer drops here, recording the `resolve` phase it died
+        // in — so a stall that never produces a row still localizes.
+        timer.transition(crate::obs::PHASE_RESOLVE);
         // Fallible eager resolve: build the producer + Arrow schema and resolve/
         // token-prune the SSTable paths off the reactor — ALL post-permit. A
         // missing table (or invalid DDL/predicate/aggregation spec) surfaces here

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -579,10 +579,25 @@ impl CqliteFlightService {
         // and the SAME flag hands off to the merge stage under a fresh guard
         // (`spawn_streaming`/`build_aggregate_response`) covering the stream's
         // lifetime, exactly as before this fix.
-        // Admission control (issue #2420, WS4): acquire a permit BEFORE any
-        // SSTable is opened or any batch produced, so `K` bounds concurrent scans
-        // ahead of blocking-pool/fd/memory pressure. On saturation this waits a
-        // bounded timeout, then sheds with `UNAVAILABLE` (retry-safe for the #2241
+        // Cheap, filesystem-free request validation FIRST — BEFORE admission
+        // (roborev-1698): parse the ticket bytes and build the producer + Arrow
+        // schema (schema-cache lookup, predicate/projection/aggregation-spec
+        // construction). None of this touches the filesystem, so it must not wait
+        // behind the admission semaphore and must not consume a permit — an
+        // invalid ticket can never succeed no matter how many times it is
+        // retried, so it fails with its OWN status (`invalid_argument` /
+        // `not_found` from ticket/schema/predicate parsing) immediately, never a
+        // permit-consuming `UNAVAILABLE` that would make the connector
+        // failover-retry an unsatisfiable request into a poison retry storm.
+        let (ticket, producer, schema_ref) = match self.validate_do_get_ticket(request) {
+            Ok(v) => v,
+            Err(status) => return Err((status, metrics)),
+        };
+        // Admission control (issue #2420, WS4): acquire a permit immediately
+        // before any filesystem access (directory resolve / SSTable open) or
+        // batch production, so `K` bounds concurrent scans ahead of
+        // blocking-pool/fd/memory pressure. On saturation this waits a bounded
+        // timeout, then sheds with `UNAVAILABLE` (retry-safe for the #2241
         // connector failover) — never `RESOURCE_EXHAUSTED`, and always before the
         // first batch. A request cancelled WHILE waiting drops this future and
         // never acquires a permit. The returned permit is held for the scan's
@@ -601,10 +616,14 @@ impl CqliteFlightService {
         // the setup-error path below the timer drops here, recording the `resolve`
         // phase it died in — so a stall that never produces a row still localizes.
         let mut timer = crate::obs::PhaseTimer::start("do_get");
-        // Fallible eager setup: parse the ticket, build the producer + schema, and
-        // resolve/token-prune the SSTable paths off the reactor. A missing table
-        // surfaces here as a clean `not_found` BEFORE the stream opens.
-        let setup = match self.do_get_setup(request, &cancel).await {
+        // Fallible eager resolve: resolve the table's on-disk directory and
+        // token-prune the SSTable paths off the reactor (the ticket/producer/
+        // schema are already validated above). A missing table surfaces here as a
+        // clean `not_found` BEFORE the stream opens.
+        let setup = match self
+            .do_get_resolve(ticket, producer, schema_ref, &cancel)
+            .await
+        {
             Ok(setup) => setup,
             Err(status) => return Err((status, metrics)),
         };
@@ -655,34 +674,51 @@ impl CqliteFlightService {
         )))
     }
 
-    /// Eager, fallible `do_get` setup shared by the row and aggregate paths: parse
-    /// the ticket, build the producer + Arrow schema, resolve the table's on-disk
-    /// directory, and token-prune the SSTable paths. A missing table surfaces as
-    /// `not_found` here, before any stream opens.
-    ///
-    /// The ENTIRE fallible sequence — schema/producer construction,
-    /// `DirSource::resolve` (filesystem `is_dir`/`read_dir`, including the
-    /// Cassandra `<table>-<uuid>` layout scan), and the token-prune (reads a
-    /// sibling `Summary.db` per SSTable) — runs in ONE `spawn_blocking` closure
-    /// (issue #1476, roborev round 3). Pre-change, ALL filesystem access for
-    /// `do_get` ran inside the blocking task; letting any of it run on the async
-    /// request task instead would stall the gRPC reactor for unrelated RPCs under
-    /// slow/busy storage. `cancel` is polled inside this same closure (issue
-    /// #1476, roborev F1) so a client disconnect during setup stops it instead of
-    /// running to completion; `do_get_inner`'s `CancelGuard` still covers this
-    /// whole `.await` for the future-drop case.
-    async fn do_get_setup(
+    /// Cheap, filesystem-free `do_get` request validation (roborev-1698): parse
+    /// the ticket bytes and build the producer + Arrow schema (schema-cache
+    /// lookup, predicate/projection/aggregation-spec construction). Touches NO
+    /// filesystem, so [`Self::do_get_inner`] runs this BEFORE acquiring an
+    /// admission permit — an invalid ticket can never succeed regardless of how
+    /// many times it is retried, so it must fail with its own status
+    /// immediately: never wait behind the admission semaphore, never consume a
+    /// permit, never surface as a retry-inviting `UNAVAILABLE`.
+    fn validate_do_get_ticket(
         &self,
         request: Request<Ticket>,
+    ) -> Result<(FlightTicket, MergeProducer, Arc<ArrowSchema>), Status> {
+        let ticket = FlightTicket::from_bytes(&request.into_inner().ticket)?;
+        let producer = self.build_producer(&ticket)?;
+        let schema_ref = Arc::new(producer.arrow_schema()?);
+        Ok((ticket, producer, schema_ref))
+    }
+
+    /// Eager, fallible `do_get` filesystem resolve shared by the row and
+    /// aggregate paths, run AFTER admission (issue #2420): resolve the table's
+    /// on-disk directory and token-prune the SSTable paths for an already
+    /// validated `ticket`/`producer`/`schema_ref` (see
+    /// [`Self::validate_do_get_ticket`]). A missing table surfaces as `not_found`
+    /// here, before any stream opens.
+    ///
+    /// `DirSource::resolve` (filesystem `is_dir`/`read_dir`, including the
+    /// Cassandra `<table>-<uuid>` layout scan) and the token-prune (reads a
+    /// sibling `Summary.db` per SSTable) run in ONE `spawn_blocking` closure
+    /// (issue #1476, roborev round 3) — letting filesystem access run on the
+    /// async request task instead would stall the gRPC reactor for unrelated
+    /// RPCs under slow/busy storage. `cancel` is polled inside this same closure
+    /// (issue #1476, roborev F1) so a client disconnect during resolve stops it
+    /// instead of running to completion; `do_get_inner`'s `CancelGuard` still
+    /// covers this whole `.await` for the future-drop case.
+    async fn do_get_resolve(
+        &self,
+        ticket: FlightTicket,
+        producer: MergeProducer,
+        schema_ref: Arc<ArrowSchema>,
         cancel: &CancelFlag,
     ) -> Result<DoGetSetup, Status> {
-        let ticket = FlightTicket::from_bytes(&request.into_inner().ticket)?;
         let svc = self.clone();
         let resolve_cancel = cancel.clone();
 
         tokio::task::spawn_blocking(move || -> Result<DoGetSetup, Status> {
-            let producer = svc.build_producer(&ticket)?;
-            let schema_ref = Arc::new(producer.arrow_schema()?);
             // Spec Req 8: reuse a cached LIVE-mode resolution on a warm hit instead
             // of re-running `DirSource::resolve` every request.
             let dir = svc.resolve_dir(&ticket)?;
@@ -1172,10 +1208,10 @@ mod tests {
             let cancel = CancelFlag::new();
             cancel.cancel();
             let bytes = ticket(KS, TBL).to_bytes().unwrap();
-            match svc
-                .do_get_setup(Request::new(Ticket::new(bytes)), &cancel)
-                .await
-            {
+            let (t, producer, schema_ref) = svc
+                .validate_do_get_ticket(Request::new(Ticket::new(bytes)))
+                .expect("ticket validates");
+            match svc.do_get_resolve(t, producer, schema_ref, &cancel).await {
                 Ok(_) => panic!("a pre-cancelled setup must abort, not resolve"),
                 Err(e) => e,
             }
@@ -1315,8 +1351,10 @@ mod tests {
             let cancel = CancelFlag::new();
             cancel.cancel();
             let bytes = t.to_bytes().unwrap();
-            svc.do_get_setup(Request::new(Ticket::new(bytes)), &cancel)
-                .await
+            let (t, producer, schema_ref) = svc
+                .validate_do_get_ticket(Request::new(Ticket::new(bytes)))
+                .expect("ticket validates");
+            svc.do_get_resolve(t, producer, schema_ref, &cancel).await
         });
         let err = match result {
             Ok(_) => panic!("a cancelled setup must not resolve/return paths"),
@@ -1353,8 +1391,10 @@ mod tests {
         let setup = rt.block_on(async {
             let cancel = CancelFlag::new();
             let bytes = t.to_bytes().unwrap();
-            svc.do_get_setup(Request::new(Ticket::new(bytes)), &cancel)
-                .await
+            let (t, producer, schema_ref) = svc
+                .validate_do_get_ticket(Request::new(Ticket::new(bytes)))
+                .expect("ticket validates");
+            svc.do_get_resolve(t, producer, schema_ref, &cancel).await
         });
         let setup = setup.expect("uncancelled setup resolves");
         // The warm path (issue #2310) hands over the open reader set; a full-ring

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -34,7 +34,7 @@ use tracing::Instrument;
 
 use cqlite_core::storage::sstable::reader::SSTableReader;
 
-use crate::admission::{Admission, AdmissionConfig};
+use crate::admission::Admission;
 use crate::cancel::CancelFlag;
 use crate::filter::{FilterError, ScanSpec};
 use crate::obs::{rpc_span, RpcMetrics};
@@ -217,14 +217,17 @@ pub struct CqliteFlightService {
 }
 
 impl CqliteFlightService {
-    /// Create a service serving SSTables under `data_dir`, with admission control
-    /// configured from the environment (see [`AdmissionConfig::from_env`]).
+    /// Create a service serving SSTables under `data_dir` with admission
+    /// UNCONSTRAINED (issue #2420, roborev-1699): NO environment read and NO
+    /// ceiling on concurrent `do_get` scans, matching this constructor's
+    /// pre-#2420 behavior exactly. A library caller embedding `cqlite-flight`
+    /// keeps today's behavior unchanged; a caller that wants a real admission
+    /// ceiling opts in explicitly via [`Self::with_admission`] — the
+    /// `cqlite-flight` SERVER BINARY (`main`) does this with a CLI/env-configured
+    /// `K`, so the SERVER still gets admission-by-default in deployment even
+    /// though this library constructor does not impose it silently.
     pub fn new(data_dir: impl Into<PathBuf>, batch_size: usize) -> Self {
-        Self::with_admission(
-            data_dir,
-            batch_size,
-            Admission::new(AdmissionConfig::from_env()),
-        )
+        Self::with_admission(data_dir, batch_size, Admission::unconstrained())
     }
 
     /// Create a service with an explicit [`Admission`] ceiling — the wiring point
@@ -579,30 +582,31 @@ impl CqliteFlightService {
         // and the SAME flag hands off to the merge stage under a fresh guard
         // (`spawn_streaming`/`build_aggregate_response`) covering the stream's
         // lifetime, exactly as before this fix.
-        // Cheap, filesystem-free request validation FIRST — BEFORE admission
-        // (roborev-1698): parse the ticket bytes and build the producer + Arrow
-        // schema (schema-cache lookup, predicate/projection/aggregation-spec
-        // construction). None of this touches the filesystem, so it must not wait
-        // behind the admission semaphore and must not consume a permit — an
-        // invalid ticket can never succeed no matter how many times it is
-        // retried, so it fails with its OWN status (`invalid_argument` /
-        // `not_found` from ticket/schema/predicate parsing) immediately, never a
-        // permit-consuming `UNAVAILABLE` that would make the connector
-        // failover-retry an unsatisfiable request into a poison retry storm.
-        let (ticket, producer, schema_ref) = match self.validate_do_get_ticket(request) {
-            Ok(v) => v,
+        // MINIMAL, filesystem-free syntax validation FIRST — BEFORE admission
+        // (roborev-1699 refining roborev-1698): parse the ticket bytes ONLY.
+        // Schema/producer construction (CQL DDL parse, predicate/projection/
+        // aggregation-spec lowering) is EXPENSIVE, attacker-influenced work and
+        // moves to `do_get_resolve` below, INSIDE the admission gate — only this
+        // cheap syntax check runs pre-permit. A malformed ticket can never
+        // succeed no matter how many times it is retried, so it fails with its
+        // OWN status (`invalid_argument`) immediately, never waiting behind the
+        // admission semaphore and never consuming a permit or surfacing as a
+        // retry-inviting `UNAVAILABLE`.
+        let ticket = match self.validate_do_get_ticket(request) {
+            Ok(t) => t,
             Err(status) => return Err((status, metrics)),
         };
         // Admission control (issue #2420, WS4): acquire a permit immediately
-        // before any filesystem access (directory resolve / SSTable open) or
-        // batch production, so `K` bounds concurrent scans ahead of
-        // blocking-pool/fd/memory pressure. On saturation this waits a bounded
-        // timeout, then sheds with `UNAVAILABLE` (retry-safe for the #2241
-        // connector failover) — never `RESOURCE_EXHAUSTED`, and always before the
-        // first batch. A request cancelled WHILE waiting drops this future and
-        // never acquires a permit. The returned permit is held for the scan's
-        // lifetime and moved into the response stream below (`admitted_stream`), so
-        // completion/disconnect/cancel all release it via one RAII drop.
+        // after the minimal syntax check, before producer/schema construction,
+        // any filesystem access (directory resolve / SSTable open), or batch
+        // production, so `K` bounds concurrent scans ahead of CPU/blocking-pool/
+        // fd/memory pressure. On saturation this waits a bounded timeout, then
+        // sheds with `UNAVAILABLE` (retry-safe for the #2241 connector failover)
+        // — never `RESOURCE_EXHAUSTED`, and always before the first batch. A
+        // request cancelled WHILE waiting drops this future and never acquires a
+        // permit. The returned permit is held for the scan's lifetime and moved
+        // into the response stream below (`admitted_stream`), so completion/
+        // disconnect/cancel all release it via one RAII drop.
         let permit = match self.admission.acquire().await {
             Ok(permit) => permit,
             Err(status) => return Err((status, metrics)),
@@ -616,14 +620,11 @@ impl CqliteFlightService {
         // the setup-error path below the timer drops here, recording the `resolve`
         // phase it died in — so a stall that never produces a row still localizes.
         let mut timer = crate::obs::PhaseTimer::start("do_get");
-        // Fallible eager resolve: resolve the table's on-disk directory and
-        // token-prune the SSTable paths off the reactor (the ticket/producer/
-        // schema are already validated above). A missing table surfaces here as a
-        // clean `not_found` BEFORE the stream opens.
-        let setup = match self
-            .do_get_resolve(ticket, producer, schema_ref, &cancel)
-            .await
-        {
+        // Fallible eager resolve: build the producer + Arrow schema and resolve/
+        // token-prune the SSTable paths off the reactor — ALL post-permit. A
+        // missing table (or invalid DDL/predicate/aggregation spec) surfaces here
+        // as a clean error BEFORE the stream opens.
+        let setup = match self.do_get_resolve(ticket, &cancel).await {
             Ok(setup) => setup,
             Err(status) => return Err((status, metrics)),
         };
@@ -674,51 +675,51 @@ impl CqliteFlightService {
         )))
     }
 
-    /// Cheap, filesystem-free `do_get` request validation (roborev-1698): parse
-    /// the ticket bytes and build the producer + Arrow schema (schema-cache
-    /// lookup, predicate/projection/aggregation-spec construction). Touches NO
-    /// filesystem, so [`Self::do_get_inner`] runs this BEFORE acquiring an
-    /// admission permit — an invalid ticket can never succeed regardless of how
-    /// many times it is retried, so it must fail with its own status
+    /// MINIMAL, filesystem-free `do_get` ticket syntax validation
+    /// (roborev-1699): parse the ticket bytes ONLY. Deliberately does NOT build
+    /// the producer/schema (CQL DDL parse, predicate/projection/aggregation-spec
+    /// lowering) — that is expensive, attacker-influenced work and belongs
+    /// INSIDE the admission gate (see [`Self::do_get_resolve`]), never ahead of
+    /// it. [`Self::do_get_inner`] runs this BEFORE acquiring an admission
+    /// permit — a syntactically malformed ticket can never succeed regardless of
+    /// how many times it is retried, so it must fail with its own status
     /// immediately: never wait behind the admission semaphore, never consume a
     /// permit, never surface as a retry-inviting `UNAVAILABLE`.
-    fn validate_do_get_ticket(
-        &self,
-        request: Request<Ticket>,
-    ) -> Result<(FlightTicket, MergeProducer, Arc<ArrowSchema>), Status> {
-        let ticket = FlightTicket::from_bytes(&request.into_inner().ticket)?;
-        let producer = self.build_producer(&ticket)?;
-        let schema_ref = Arc::new(producer.arrow_schema()?);
-        Ok((ticket, producer, schema_ref))
+    fn validate_do_get_ticket(&self, request: Request<Ticket>) -> Result<FlightTicket, Status> {
+        Ok(FlightTicket::from_bytes(&request.into_inner().ticket)?)
     }
 
-    /// Eager, fallible `do_get` filesystem resolve shared by the row and
-    /// aggregate paths, run AFTER admission (issue #2420): resolve the table's
-    /// on-disk directory and token-prune the SSTable paths for an already
-    /// validated `ticket`/`producer`/`schema_ref` (see
-    /// [`Self::validate_do_get_ticket`]). A missing table surfaces as `not_found`
-    /// here, before any stream opens.
+    /// Eager, fallible `do_get` setup shared by the row and aggregate paths, run
+    /// ENTIRELY AFTER admission (issue #2420, roborev-1699): build the producer +
+    /// Arrow schema (schema-cache lookup, predicate/projection/aggregation-spec
+    /// construction — expensive, attacker-influenced work that must not run
+    /// ahead of the admission gate) for the syntactically pre-validated `ticket`
+    /// (see [`Self::validate_do_get_ticket`]), then resolve the table's on-disk
+    /// directory and token-prune the SSTable paths. A missing table (or an
+    /// invalid DDL/predicate/aggregation spec) surfaces here as a clean error,
+    /// before any stream opens.
     ///
-    /// `DirSource::resolve` (filesystem `is_dir`/`read_dir`, including the
-    /// Cassandra `<table>-<uuid>` layout scan) and the token-prune (reads a
-    /// sibling `Summary.db` per SSTable) run in ONE `spawn_blocking` closure
-    /// (issue #1476, roborev round 3) — letting filesystem access run on the
-    /// async request task instead would stall the gRPC reactor for unrelated
-    /// RPCs under slow/busy storage. `cancel` is polled inside this same closure
-    /// (issue #1476, roborev F1) so a client disconnect during resolve stops it
-    /// instead of running to completion; `do_get_inner`'s `CancelGuard` still
-    /// covers this whole `.await` for the future-drop case.
+    /// Producer/schema construction, `DirSource::resolve` (filesystem
+    /// `is_dir`/`read_dir`, including the Cassandra `<table>-<uuid>` layout
+    /// scan), and the token-prune (reads a sibling `Summary.db` per SSTable) run
+    /// in ONE `spawn_blocking` closure (issue #1476, roborev round 3) — letting
+    /// any of this run on the async request task instead would stall the gRPC
+    /// reactor for unrelated RPCs under slow/busy storage or an expensive DDL
+    /// parse. `cancel` is polled inside this same closure (issue #1476, roborev
+    /// F1) so a client disconnect during resolve stops it instead of running to
+    /// completion; `do_get_inner`'s `CancelGuard` still covers this whole
+    /// `.await` for the future-drop case.
     async fn do_get_resolve(
         &self,
         ticket: FlightTicket,
-        producer: MergeProducer,
-        schema_ref: Arc<ArrowSchema>,
         cancel: &CancelFlag,
     ) -> Result<DoGetSetup, Status> {
         let svc = self.clone();
         let resolve_cancel = cancel.clone();
 
         tokio::task::spawn_blocking(move || -> Result<DoGetSetup, Status> {
+            let producer = svc.build_producer(&ticket)?;
+            let schema_ref = Arc::new(producer.arrow_schema()?);
             // Spec Req 8: reuse a cached LIVE-mode resolution on a warm hit instead
             // of re-running `DirSource::resolve` every request.
             let dir = svc.resolve_dir(&ticket)?;
@@ -1208,10 +1209,10 @@ mod tests {
             let cancel = CancelFlag::new();
             cancel.cancel();
             let bytes = ticket(KS, TBL).to_bytes().unwrap();
-            let (t, producer, schema_ref) = svc
+            let t = svc
                 .validate_do_get_ticket(Request::new(Ticket::new(bytes)))
                 .expect("ticket validates");
-            match svc.do_get_resolve(t, producer, schema_ref, &cancel).await {
+            match svc.do_get_resolve(t, &cancel).await {
                 Ok(_) => panic!("a pre-cancelled setup must abort, not resolve"),
                 Err(e) => e,
             }
@@ -1351,10 +1352,10 @@ mod tests {
             let cancel = CancelFlag::new();
             cancel.cancel();
             let bytes = t.to_bytes().unwrap();
-            let (t, producer, schema_ref) = svc
+            let t = svc
                 .validate_do_get_ticket(Request::new(Ticket::new(bytes)))
                 .expect("ticket validates");
-            svc.do_get_resolve(t, producer, schema_ref, &cancel).await
+            svc.do_get_resolve(t, &cancel).await
         });
         let err = match result {
             Ok(_) => panic!("a cancelled setup must not resolve/return paths"),
@@ -1391,10 +1392,10 @@ mod tests {
         let setup = rt.block_on(async {
             let cancel = CancelFlag::new();
             let bytes = t.to_bytes().unwrap();
-            let (t, producer, schema_ref) = svc
+            let t = svc
                 .validate_do_get_ticket(Request::new(Ticket::new(bytes)))
                 .expect("ticket validates");
-            svc.do_get_resolve(t, producer, schema_ref, &cancel).await
+            svc.do_get_resolve(t, &cancel).await
         });
         let setup = setup.expect("uncancelled setup resolves");
         // The warm path (issue #2310) hands over the open reader set; a full-ring

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -34,6 +34,7 @@ use tracing::Instrument;
 
 use cqlite_core::storage::sstable::reader::SSTableReader;
 
+use crate::admission::{Admission, AdmissionConfig};
 use crate::cancel::CancelFlag;
 use crate::filter::{FilterError, ScanSpec};
 use crate::obs::{rpc_span, RpcMetrics};
@@ -208,17 +209,42 @@ pub struct CqliteFlightService {
     warm: Arc<WarmTableRegistry>,
     /// Cross-request schema-parse + directory-resolve caches (spec Req 8).
     caches: Arc<SetupCaches>,
+    /// `do_get` admission ceiling (issue #2420, WS4): bounds concurrently
+    /// admitted scans to a configured `K`, acquired before any SSTable open.
+    /// Shared (`Arc` inside [`Admission`]) across the `Clone`d per-RPC handles so
+    /// every request throttles against the same permit pool.
+    admission: Admission,
 }
 
 impl CqliteFlightService {
-    /// Create a service serving SSTables under `data_dir`.
+    /// Create a service serving SSTables under `data_dir`, with admission control
+    /// configured from the environment (see [`AdmissionConfig::from_env`]).
     pub fn new(data_dir: impl Into<PathBuf>, batch_size: usize) -> Self {
+        Self::with_admission(data_dir, batch_size, Admission::new(AdmissionConfig::from_env()))
+    }
+
+    /// Create a service with an explicit [`Admission`] ceiling — the wiring point
+    /// for the `--max-concurrent-scans` CLI knob (`main`) and the deterministic
+    /// admission tests (which supply a tiny `K` + injectable wait timeout).
+    pub fn with_admission(
+        data_dir: impl Into<PathBuf>,
+        batch_size: usize,
+        admission: Admission,
+    ) -> Self {
         Self {
             data_dir: data_dir.into(),
             batch_size: batch_size.max(1),
             warm: Arc::new(WarmTableRegistry::new()),
             caches: Arc::new(SetupCaches::default()),
+            admission,
         }
+    }
+
+    /// The service's admission ceiling (issue #2420) — for `main` (to log the
+    /// configured limit) and the admission tests (to hold permits / read the
+    /// counters).
+    pub fn admission(&self) -> &Admission {
+        &self.admission
     }
 
     /// A point-in-time read of the warm-cache counters (hit/miss/evict/
@@ -549,6 +575,19 @@ impl CqliteFlightService {
         // and the SAME flag hands off to the merge stage under a fresh guard
         // (`spawn_streaming`/`build_aggregate_response`) covering the stream's
         // lifetime, exactly as before this fix.
+        // Admission control (issue #2420, WS4): acquire a permit BEFORE any
+        // SSTable is opened or any batch produced, so `K` bounds concurrent scans
+        // ahead of blocking-pool/fd/memory pressure. On saturation this waits a
+        // bounded timeout, then sheds with `UNAVAILABLE` (retry-safe for the #2241
+        // connector failover) — never `RESOURCE_EXHAUSTED`, and always before the
+        // first batch. A request cancelled WHILE waiting drops this future and
+        // never acquires a permit. The returned permit is held for the scan's
+        // lifetime and moved into the response stream below (`admitted_stream`), so
+        // completion/disconnect/cancel all release it via one RAII drop.
+        let permit = match self.admission.acquire().await {
+            Ok(permit) => permit,
+            Err(status) => return Err((status, metrics)),
+        };
         let cancel = CancelFlag::new();
         let mut setup_guard = cancel.drop_guard();
         // Phase timing (issue #2162): begin in the `resolve` phase. The timer
@@ -575,15 +614,15 @@ impl CqliteFlightService {
             input,
         } = setup;
 
-        match input {
+        let stream: <Self as FlightService>::DoGetStream = match input {
             // Aggregate output is bounded (one row per group): keep materializing
             // and serve it as a stream, unchanged in content (issue #1476).
-            DoGetInput::Aggregate(paths) => Ok(Response::new(
+            DoGetInput::Aggregate(paths) => {
                 crate::streaming::build_aggregate_response(
                     producer, paths, schema_ref, metrics, cancel, timer,
                 )
-                .await?,
-            )),
+                .await?
+            }
             // Row/point path (issue #2310): drive the merge over the WARM,
             // already-open reader set. The merge runs on the blocking pool and
             // sends each batch into a bounded channel; peak resident payload is
@@ -601,9 +640,13 @@ impl CqliteFlightService {
                     cancel,
                     timer,
                 );
-                Ok(Response::new(stream))
+                stream
             }
-        }
+        };
+        // Hold the admission permit for the scan's lifetime: the wrapper is a
+        // transparent pass-through that drops the permit (releasing admission) when
+        // the stream completes or the client disconnects (issue #2420).
+        Ok(Response::new(crate::admission::admitted_stream(stream, permit)))
     }
 
     /// Eager, fallible `do_get` setup shared by the row and aggregate paths: parse

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -220,7 +220,11 @@ impl CqliteFlightService {
     /// Create a service serving SSTables under `data_dir`, with admission control
     /// configured from the environment (see [`AdmissionConfig::from_env`]).
     pub fn new(data_dir: impl Into<PathBuf>, batch_size: usize) -> Self {
-        Self::with_admission(data_dir, batch_size, Admission::new(AdmissionConfig::from_env()))
+        Self::with_admission(
+            data_dir,
+            batch_size,
+            Admission::new(AdmissionConfig::from_env()),
+        )
     }
 
     /// Create a service with an explicit [`Admission`] ceiling — the wiring point
@@ -646,7 +650,9 @@ impl CqliteFlightService {
         // Hold the admission permit for the scan's lifetime: the wrapper is a
         // transparent pass-through that drops the permit (releasing admission) when
         // the stream completes or the client disconnects (issue #2420).
-        Ok(Response::new(crate::admission::admitted_stream(stream, permit)))
+        Ok(Response::new(crate::admission::admitted_stream(
+            stream, permit,
+        )))
     }
 
     /// Eager, fallible `do_get` setup shared by the row and aggregate paths: parse

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -582,7 +582,19 @@ impl CqliteFlightService {
         // and the SAME flag hands off to the merge stage under a fresh guard
         // (`spawn_streaming`/`build_aggregate_response`) covering the stream's
         // lifetime, exactly as before this fix.
-        // MINIMAL, filesystem-free syntax validation FIRST — BEFORE admission
+        // Phase timing (issue #2162, `admission` phase added #2420
+        // roborev-1700, `validate` phase added #2420 roborev-1702): begin BEFORE
+        // the ticket is even parsed, in the `validate` phase. The timer captures
+        // the `flight.do_get` span (this future runs under it via `.instrument`),
+        // so its per-phase histogram samples + span events attach to that span
+        // even for the phases that run on the blocking merge pool. On `main`
+        // (pre-#2420) a malformed ticket recorded a `resolve`-phase sample (the
+        // timer was already open in `resolve` when parsing failed inside the old
+        // `do_get_setup`); starting the timer here preserves that invariant — a
+        // malformed ticket still records SOME phase sample — with a precise
+        // `validate` label instead of folding it into `resolve`'s meaning.
+        let mut timer = crate::obs::PhaseTimer::start("do_get");
+        // MINIMAL, filesystem-free syntax validation — BEFORE admission
         // (roborev-1699 refining roborev-1698): parse the ticket bytes ONLY.
         // Schema/producer construction (CQL DDL parse, predicate/projection/
         // aggregation-spec lowering) is EXPENSIVE, attacker-influenced work and
@@ -591,25 +603,21 @@ impl CqliteFlightService {
         // succeed no matter how many times it is retried, so it fails with its
         // OWN status (`invalid_argument`) immediately, never waiting behind the
         // admission semaphore and never consuming a permit or surfacing as a
-        // retry-inviting `UNAVAILABLE`.
+        // retry-inviting `UNAVAILABLE`. On failure the timer drops here without
+        // ever transitioning, recording the `validate` phase duration it died in.
         let ticket = match self.validate_do_get_ticket(request) {
             Ok(t) => t,
             Err(status) => return Err((status, metrics)),
         };
-        // Phase timing (issue #2162, `admission` phase added #2420
-        // roborev-1700): begin BEFORE the admission-permit acquire, in the new
-        // `admission` phase. The timer captures the `flight.do_get` span (this
-        // future runs under it via `.instrument`), so its per-phase histogram
-        // samples + span events attach to that span even for the phases that run
-        // on the blocking merge pool. `cqlite.rpc.duration` already includes
-        // admission wait in the RPC total, but the per-phase breakdown is what
-        // field triage localizes latency with (e.g. #2398) — starting the timer
-        // here (rather than after `acquire`, or folding the wait into `resolve`)
-        // makes queueing time a first-class, directly observable phase instead of
+        // Validated: close `validate` and enter `admission`. `cqlite.rpc.duration`
+        // already includes admission wait in the RPC total, but the per-phase
+        // breakdown is what field triage localizes latency with (e.g. #2398) —
+        // giving queueing time its own phase (rather than folding it into
+        // `resolve`) makes it a first-class, directly observable phase instead of
         // vanishing from this breakdown. On an admission timeout/reject the timer
-        // drops here without ever transitioning, recording the `admission` phase
-        // duration it died in.
-        let mut timer = crate::obs::PhaseTimer::start("do_get");
+        // drops here without transitioning further, recording the `admission`
+        // phase duration it died in.
+        timer.transition(crate::obs::PHASE_ADMISSION);
         // Admission control (issue #2420, WS4): acquire a permit immediately
         // after the minimal syntax check, before producer/schema construction,
         // any filesystem access (directory resolve / SSTable open), or batch

--- a/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
+++ b/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
@@ -162,7 +162,8 @@ fn phase_active_and_in_flight_read_true_concurrent_count_then_settle() {
         // Exact `== baseline + N` is sound, NOT flaky (roborev job 1658 MEDIUM,
         // declined with evidence). `PhaseTimer::transition` briefly dec-old-then-
         // inc-new, so the phase.active SUM can transiently dip during a phase
-        // change — but that window exists ONLY across resolve→merge_setup→stream.
+        // change — but that window exists ONLY across the (issue #2420
+        // roborev-1700) admission→resolve→merge_setup→stream sequence.
         // Every holder above read a batch (proving it reached the TERMINAL `stream`
         // phase — `stream` has no successor, so `transition` is never called again)
         // and then PARKS: with batch_size 1 + the 4-slot bounded channel, each

--- a/cqlite-flight/tests/metrics_capture_test.rs
+++ b/cqlite-flight/tests/metrics_capture_test.rs
@@ -16,9 +16,10 @@
 //! (feature-off-safe) wiring evidence; THIS file additionally reads back the
 //! actual emitted OTel series to prove:
 //!
-//! * `cqlite.rpc.phase.duration` records a bounded `merge_setup` phase sample
-//!   over a completed `do_get` (Stage 2), every phase value is in the closed
-//!   set, and no phase sample carries an unbounded attribute (Stage 2/4),
+//! * `cqlite.rpc.phase.duration` records bounded `admission` (issue #2420
+//!   roborev-1700) and `merge_setup` phase samples over a completed `do_get`
+//!   (Stage 2), every phase value is in the closed 4-value set, and no phase
+//!   sample carries an unbounded attribute (Stage 2/4),
 //! * `cqlite.rpc.rows` and `cqlite.query.rows_scanned` are emitted, carrying
 //!   only their bounded attribute keys (Stage 1/3/4).
 //!
@@ -184,7 +185,7 @@ fn do_get_emits_bounded_phase_and_incremental_metrics() {
 
     let metrics = mc.flush_and_collect();
 
-    // --- Stage 2: a bounded merge_setup phase sample is recorded ---------------
+    // --- Stage 2: bounded admission + merge_setup phase samples are recorded ---
     let phase = metrics
         .find(catalog::RPC_PHASE_DURATION)
         .expect("cqlite.rpc.phase.duration must be recorded over a completed do_get");
@@ -192,21 +193,41 @@ fn do_get_emits_bounded_phase_and_incremental_metrics() {
         metrics.unit(catalog::RPC_PHASE_DURATION),
         Some(catalog::unit::SECONDS)
     );
-    let merge_setup_samples = phase
-        .points
-        .iter()
-        .filter(|p| {
-            p.attributes
-                .iter()
-                .any(|(k, v)| k == catalog::attr::RPC_PHASE && v == "merge_setup")
-        })
-        .count();
+    let phase_sample_count = |phase_name: &str| {
+        phase
+            .points
+            .iter()
+            .filter(|p| {
+                p.attributes
+                    .iter()
+                    .any(|(k, v)| k == catalog::attr::RPC_PHASE && v == phase_name)
+            })
+            .count()
+    };
     assert!(
-        merge_setup_samples >= 1,
+        phase_sample_count("merge_setup") >= 1,
         "a merge_setup-tagged phase sample must exist (the #2157 stall localizer)"
     );
+    // Issue #2420 roborev-1700: `do_get_inner` now opens `PhaseTimer` in the
+    // `admission` phase BEFORE acquiring a permit, so even an uncontended
+    // (never-queued) `do_get` — this fixture's `Admission::unconstrained()`
+    // default (see `CqliteFlightService::new`) never saturates — still records
+    // one admission-phase sample: `start()` opens it, the first `transition()`
+    // (to `resolve`) closes it. Without this the queue-time phase would be
+    // invisible in `cqlite.rpc.phase.duration` even though
+    // `cqlite.rpc.duration` already counts it in the RPC total — field triage
+    // localizes latency FROM the per-phase breakdown (e.g. #2398).
+    assert!(
+        phase_sample_count("admission") >= 1,
+        "an admission-tagged phase sample must exist even on an uncontended \
+         do_get (issue #2420 roborev-1700) — admission wait must never be \
+         invisible in the phase breakdown"
+    );
 
-    // Every phase value is one of the closed set; no ticket/key/query attribute.
+    // Every phase value is one of the CLOSED 4-value set (issue #2420
+    // roborev-1701: this closed-set list is intentionally exhaustive — a future
+    // 5th phase must update this assertion as a deliberate decision, not drift
+    // silently past it); no ticket/key/query attribute.
     for p in &phase.points {
         let phase_val = p
             .attributes
@@ -214,7 +235,10 @@ fn do_get_emits_bounded_phase_and_incremental_metrics() {
             .find(|(k, _)| k == catalog::attr::RPC_PHASE)
             .map(|(_, v)| v.as_str());
         assert!(
-            matches!(phase_val, Some("resolve" | "merge_setup" | "stream")),
+            matches!(
+                phase_val,
+                Some("admission" | "resolve" | "merge_setup" | "stream")
+            ),
             "phase value must be in the closed set, got {phase_val:?}"
         );
         assert_bounded_attrs(&p.attributes, catalog::RPC_PHASE_DURATION);

--- a/cqlite-flight/tests/metrics_capture_test.rs
+++ b/cqlite-flight/tests/metrics_capture_test.rs
@@ -18,8 +18,10 @@
 //!
 //! * `cqlite.rpc.phase.duration` records bounded `admission` (issue #2420
 //!   roborev-1700) and `merge_setup` phase samples over a completed `do_get`
-//!   (Stage 2), every phase value is in the closed 4-value set, and no phase
+//!   (Stage 2), every phase value is in the closed 5-value set, and no phase
 //!   sample carries an unbounded attribute (Stage 2/4),
+//! * a syntactically malformed ticket records a `validate`-phase sample (issue
+//!   #2420 roborev-1702) instead of no phase sample at all,
 //! * `cqlite.rpc.rows` and `cqlite.query.rows_scanned` are emitted, carrying
 //!   only their bounded attribute keys (Stage 1/3/4).
 //!
@@ -208,15 +210,24 @@ fn do_get_emits_bounded_phase_and_incremental_metrics() {
         phase_sample_count("merge_setup") >= 1,
         "a merge_setup-tagged phase sample must exist (the #2157 stall localizer)"
     );
-    // Issue #2420 roborev-1700: `do_get_inner` now opens `PhaseTimer` in the
-    // `admission` phase BEFORE acquiring a permit, so even an uncontended
-    // (never-queued) `do_get` — this fixture's `Admission::unconstrained()`
-    // default (see `CqliteFlightService::new`) never saturates — still records
-    // one admission-phase sample: `start()` opens it, the first `transition()`
-    // (to `resolve`) closes it. Without this the queue-time phase would be
-    // invisible in `cqlite.rpc.phase.duration` even though
-    // `cqlite.rpc.duration` already counts it in the RPC total — field triage
-    // localizes latency FROM the per-phase breakdown (e.g. #2398).
+    // Issue #2420 roborev-1700/1702: `do_get_inner` now opens `PhaseTimer` in
+    // the `validate` phase (parsing the ticket), transitions to `admission`
+    // once validated, and to `resolve` once admitted — so even an uncontended
+    // (never-queued), well-formed `do_get` — this fixture's
+    // `Admission::unconstrained()` default (see `CqliteFlightService::new`)
+    // never saturates — still records one sample for EACH of `validate` and
+    // `admission`: `start()` opens `validate`, the first `transition()` (to
+    // `admission`) closes it, the second `transition()` (to `resolve`) closes
+    // `admission`. Without this the queue-time (and validation-time) phases
+    // would be invisible in `cqlite.rpc.phase.duration` even though
+    // `cqlite.rpc.duration` already counts both in the RPC total — field
+    // triage localizes latency FROM the per-phase breakdown (e.g. #2398).
+    assert!(
+        phase_sample_count("validate") >= 1,
+        "a validate-tagged phase sample must exist even for a well-formed \
+         do_get (issue #2420 roborev-1702) — ticket parsing must never be \
+         invisible in the phase breakdown"
+    );
     assert!(
         phase_sample_count("admission") >= 1,
         "an admission-tagged phase sample must exist even on an uncontended \
@@ -224,10 +235,10 @@ fn do_get_emits_bounded_phase_and_incremental_metrics() {
          invisible in the phase breakdown"
     );
 
-    // Every phase value is one of the CLOSED 4-value set (issue #2420
-    // roborev-1701: this closed-set list is intentionally exhaustive — a future
-    // 5th phase must update this assertion as a deliberate decision, not drift
-    // silently past it); no ticket/key/query attribute.
+    // Every phase value is one of the CLOSED 5-value set (issue #2420
+    // roborev-1701/1702: this closed-set list is intentionally exhaustive — a
+    // future 6th phase must update this assertion as a deliberate decision,
+    // not drift silently past it); no ticket/key/query attribute.
     for p in &phase.points {
         let phase_val = p
             .attributes
@@ -237,7 +248,7 @@ fn do_get_emits_bounded_phase_and_incremental_metrics() {
         assert!(
             matches!(
                 phase_val,
-                Some("admission" | "resolve" | "merge_setup" | "stream")
+                Some("validate" | "admission" | "resolve" | "merge_setup" | "stream")
             ),
             "phase value must be in the closed set, got {phase_val:?}"
         );
@@ -301,5 +312,57 @@ fn do_get_emits_bounded_phase_and_incremental_metrics() {
                 p.attributes
             );
         }
+    }
+
+    // --- Stage 5 (issue #2420 roborev-1702): a malformed ticket records a
+    // validate-phase sample, not zero phase samples --------------------------
+    //
+    // Sequenced AFTER the well-formed flow above (reusing the SAME `svc`/`rt`,
+    // resetting the shared capture in between) rather than a second `#[test]`
+    // fn: the capture harness's meter provider is process-global with DELTA
+    // temporality isolated only across SEQUENTIAL `reset`/`flush_and_collect`
+    // pairs within one test — see this module's `testing` doc ("all metric
+    // assertions run inside a single serial test"). A second `#[test]` fn
+    // would risk cross-test contamination under `cargo test`'s default
+    // parallelism.
+    mc.reset();
+    let malformed_err = rt.block_on(async {
+        svc.do_get(Request::new(Ticket::new(
+            b"not a valid flight ticket".to_vec(),
+        )))
+        .await
+        .err()
+        .expect("a malformed ticket must error")
+    });
+    assert_eq!(
+        malformed_err.code(),
+        tonic::Code::InvalidArgument,
+        "a malformed ticket fails validation before any admission/resolve work"
+    );
+
+    let malformed_metrics = mc.flush_and_collect();
+    let malformed_phase = malformed_metrics
+        .find(catalog::RPC_PHASE_DURATION)
+        .expect("a malformed ticket must still record a phase.duration sample");
+    let malformed_phase_values: Vec<&str> = malformed_phase
+        .points
+        .iter()
+        .filter_map(|p| {
+            p.attributes
+                .iter()
+                .find(|(k, _)| k == catalog::attr::RPC_PHASE)
+                .map(|(_, v)| v.as_str())
+        })
+        .collect();
+    assert_eq!(
+        malformed_phase_values,
+        vec!["validate"],
+        "a malformed ticket must record EXACTLY ONE phase sample, tagged \
+         validate — never zero (pre-#2420 main recorded a resolve sample for \
+         this same failure mode) and never admission/resolve/merge_setup/\
+         stream (it must never reach those phases), got {malformed_phase_values:?}"
+    );
+    for p in &malformed_phase.points {
+        assert_bounded_attrs(&p.attributes, catalog::RPC_PHASE_DURATION);
     }
 }

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -351,3 +351,39 @@ Format:
     - `flight-trino-e2e.yml` — runs `e2e-test.sh` (both sides, full docker-compose integration) on PR/main.
 - **Artifacts published:** flight binary + GHCR container image (Rust side); Trino plugin dir (Java side).
 - **Next:** commit; push.
+
+## 2026-07-13 — do_get admission control (issue #2420, WS4)
+
+- **What:** Added an application-level admission ceiling on `do_get`. An owned
+  `tokio::sync::Semaphore` with `K` permits (`--max-concurrent-scans`, env
+  `CQLITE_MAX_CONCURRENT_SCANS`, default **64**) gates entry to the merge: a
+  request acquires a permit BEFORE any SSTable is opened or any batch produced,
+  holds it (RAII, moved into the response stream) for the scan's lifetime, and
+  releases it on completion/disconnect/cancel. On saturation a request waits up to
+  `--admission-wait-timeout-ms` (env `CQLITE_ADMISSION_WAIT_TIMEOUT_MS`, default
+  30000); if no permit frees it is shed with gRPC **`UNAVAILABLE`** (never
+  `RESOURCE_EXHAUSTED`) BEFORE any batch. A coarse tonic `max_concurrent_streams`
+  (≥ `max(K·4, 1024)`) backstops the HTTP/2 accept loop — the Semaphore, not the
+  transport cap, is the real throttle. New `cqlite.flight.admission.*` instruments
+  (limit/in_use/waiting/rejected_total/wait_seconds), distinct from
+  `cqlite.rpc.in_flight`.
+- **Overload contract:** short bursts under the wait budget are absorbed
+  transparently (no client-visible error, no connector change); sustained overload
+  sheds to another replica via the connector's #2241 `ReplicaFailoverStream`
+  (retry-safe: the reject provably precedes the first batch, and failover triggers
+  ONLY on `UNAVAILABLE`); only when EVERY replica saturates does the query fail
+  loudly. Admission is transparent to results — byte-identical rows/order/schema/
+  batch boundaries.
+- **Default `K` sizing:** from the binding constraints, NOT `num_cpus`: blocking
+  pool 512 ÷ ~2 threads/scan ≈ 256 ceiling; fd ~1024 ÷ M SSTables. 64 sits well
+  below both. Conservative pending WS1-ramp (WS8) validation before the default is
+  locked.
+- **Files:** `cqlite-flight/src/admission.rs` (+ `admission_tests.rs`),
+  `service.rs` (acquire before setup; permit into the response stream),
+  `main.rs` (CLI/env knobs + `max_concurrent_streams`), `lib.rs`, `Cargo.toml`
+  (dev `tokio` `test-util`); `cqlite-core/.../observability/catalog.rs` (5
+  instruments).
+- **Verified:** 11 deterministic tests (paused Tokio clock, injected barriers —
+  no wall-clock) covering all 6 spec requirements; the excess-do_get gate reds when
+  the acquire-before-setup wiring is removed (setup `resolves` counter jumps).
+- **Next:** WS1-ramp validation of the default `K` (WS8); record on #2420.

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -517,3 +517,54 @@ Format:
   `--features observability-testing`.
 - **Files:** `cqlite-flight/tests/metrics_capture_test.rs`,
   `cqlite-flight/tests/issue_2370_gauge_readback_test.rs` (comment only).
+
+## 2026-07-13 — admission-control roborev round 7 (job 1702)
+
+- **What (finding 1, mechanical, gauge-vs-availability ordering):**
+  `AdmissionPermit`'s `_permit: OwnedSemaphorePermit` field is now
+  `permit: Option<OwnedSemaphorePermit>`. `Drop::drop` explicitly `take()`s and
+  drops the permit BEFORE decrementing the `in_use` gauge — Rust drops a
+  struct's fields AFTER `Drop::drop` returns, so the bare-field version
+  released real semaphore capacity to a waiter strictly AFTER the gauge already
+  said "one fewer in use," a transient window where the gauge undercounted
+  relative to what a waiter could observe. Gauge and availability now move in
+  the same order.
+- **What (finding 2, ADJUDICATED — real regression, fixed with option (b)):**
+  Verified against `origin/main` (`c2a86299`): pre-#2420, `PhaseTimer::start`
+  opened `resolve` BEFORE `do_get_setup` even ran, and `do_get_setup`'s
+  `FlightTicket::from_bytes(...)?` failure propagated through `do_get_inner`'s
+  `Err(status) => return Err(...)` — the still-open `resolve`-phase timer then
+  dropped at the function return, recording a `resolve`-tagged
+  `cqlite.rpc.phase.duration` sample. So `main` DID give phase visibility for a
+  malformed ticket (a `resolve` sample), and round-6's `validate_do_get_ticket`
+  (run before the `PhaseTimer` even existed) silently dropped that to ZERO
+  phase samples — a real regression, not a non-issue. Fixed per option (b):
+  added a dedicated `validate` phase (`validate` → `admission` → `resolve` →
+  `merge_setup` → `stream`, 5-phase CLOSED set), giving the pre-existing
+  behavior a MORE PRECISE label instead of restoring the imprecise `resolve`
+  one. `PhaseTimer::start` now opens `validate`; `do_get_inner` constructs the
+  timer before `validate_do_get_ticket` and transitions to `admission` only
+  once the ticket parses.
+- **Tests:** `req_validate_then_admission_phase_chain` (replaces
+  `req_admission_phase_opens_before_resolve`) — deterministic mechanics test on
+  the dedicated `"handshake"` slot proving the full `validate → admission →
+  resolve` sequence AND that a malformed-ticket-shaped drop (never
+  transitioning) still records a `validate` sample. New Stage 5 in
+  `metrics_capture_test.rs` (same test fn, sequenced after the happy path via
+  `mc.reset()` — a second `#[test]` fn would risk cross-test OTel contamination
+  per the capture harness's "single serial test" doc invariant): a real
+  malformed `do_get` records EXACTLY ONE phase sample, tagged `validate` (never
+  zero, never admission/resolve/merge_setup/stream). Updated the two obs.rs
+  mechanics tests + the 5-value closed sets in `metrics_capture_test.rs` and
+  the `catalog.rs` doc comments.
+- **Verified:** `cargo test -p cqlite-flight --features observability-testing
+  --test metrics_capture_test` and the admission target (18/18) both pass,
+  stable across 3 repeated runs each; full 254-test lib suite stable across 3
+  runs; clippy clean (incl. `--features observability-testing`); red-on-main
+  re-confirmed (still 6 tests red when the acquire moves back past
+  `do_get_resolve`).
+- **Files:** `cqlite-flight/src/admission.rs` (permit drop ordering),
+  `obs.rs` (5-phase set, 2 updated unit tests), `service.rs` (timer starts
+  before ticket parse), `admission_tests.rs`, `tests/metrics_capture_test.rs`
+  (Stage 5 + closed-set update), `cqlite-core/.../observability/catalog.rs`
+  (doc updates for the 5-phase set).

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -468,3 +468,21 @@ Format:
   before `acquire`), `admission.rs` (gauge-overlap fix), `admission_tests.rs`
   (2 new tests + 1 extended), `cqlite-core/.../observability/catalog.rs`
   (doc updates for the 4-phase set).
+- **Post-commit self-caught flakiness fix (same round):** the first cut of the
+  two finding-1 phase-visibility tests asserted EXACT deltas on
+  `phase_active_level_for("do_get", ...)` — a PROCESS-WIDE counter keyed only by
+  `(method, phase)`, shared with every OTHER concurrently-running test that
+  drives a real `do_get` (this crate's test suite runs thread-parallel, not
+  process-isolated, for `cargo test -p cqlite-flight --lib`). Standalone re-runs
+  flaked (`cargo test --lib admission` failed ~1/6 runs on the "resolve
+  untouched"/"vacated to exact baseline" assertions). Fixed by splitting into
+  (a) `req_admission_phase_opens_before_resolve` — a fully deterministic
+  `PhaseTimer` mechanics test against a synthetic, otherwise-unused method slot
+  (`"handshake"`, never driven by any test), proving the exact admission→resolve
+  ordering with zero cross-test interference, and (b)
+  `req_admission_wait_is_visible_as_its_own_phase` — wiring evidence on the REAL
+  `do_get` path, loosened to a robust `>= 1` lower bound (always true while our
+  own request is genuinely parked, immune to concurrent noise in either
+  direction). Verified stable across 5 repeated runs of both the admission
+  filter and the full 254-test lib suite; red-on-main re-confirmed after the
+  robustness rewrite (still 6 tests red).

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -387,3 +387,45 @@ Format:
   no wall-clock) covering all 6 spec requirements; the excess-do_get gate reds when
   the acquire-before-setup wiring is removed (setup `resolves` counter jumps).
 - **Next:** WS1-ramp validation of the default `K` (WS8); record on #2420.
+
+## 2026-07-13 — admission-control roborev fixes (rounds 1696–1699)
+
+- **What (roborev-1696):** Fast-pathed `Semaphore::try_acquire_owned()` first so
+  an UNCONTENDED acquire never touches the `waiting` gauge or records a
+  permit-wait histogram sample (was transiently over-reporting queue depth on
+  every admit, even instant ones). The slow, contended (`NoPermits`) path is
+  unchanged — it still bumps `waiting` and records a genuine wait sample.
+- **What (roborev-1697):** `Admission::new` now clamps `max_concurrent_scans`
+  symmetrically to `[1, Semaphore::MAX_PERMITS]` (was floored at 1 only) —
+  `Semaphore::new` PANICS above `MAX_PERMITS`, so an absurd
+  `--max-concurrent-scans`/env value must be capped, never crash startup. Logs a
+  `warn` when a clamp actually changes the requested value.
+- **What (roborev-1698 → refined by 1699):** `do_get`'s pre-permit validation is
+  now MINIMAL and filesystem-free: `validate_do_get_ticket` parses ONLY the
+  ticket bytes (`FlightTicket::from_bytes`). Producer/schema construction (CQL
+  DDL parse, predicate/projection/aggregation-spec lowering — expensive,
+  attacker-influenced work) moved INTO `do_get_resolve`, run AFTER admission
+  alongside the filesystem resolve (both inside one `spawn_blocking`, exactly as
+  pre-#2420). A syntactically malformed ticket still fails fast with its own
+  status (never `UNAVAILABLE`, never waits, never consumes a permit); a
+  syntactically VALID ticket for a bogus/nonexistent table now also does not
+  reach producer construction until a permit is admitted.
+- **What (roborev-1699, `new()` semantics):** `CqliteFlightService::new()` no
+  longer reads the environment or applies a default admission ceiling — it uses
+  `Admission::unconstrained()` (`Semaphore::MAX_PERMITS`, `Duration::MAX` wait),
+  restoring this constructor's exact pre-#2420 behavior for library callers.
+  `with_admission(data_dir, batch_size, admission)` is the explicit opt-in the
+  `cqlite-flight` SERVER BINARY (`main`) uses to wire a real, CLI/env-configured
+  `K` — the server still gets admission-by-default in deployment even though the
+  library constructor stays unconstrained.
+- **Tests:** 16 deterministic admission tests (was 11), incl. two new
+  roborev-pinned scenarios: `req1_uncontended_acquire_never_touches_waiting_gauge`
+  / `req1_contended_acquire_path_unchanged` (1696),
+  `req4_absurd_configured_k_clamps_instead_of_panicking` (1697),
+  `req_malformed_ticket_bypasses_admission_entirely` /
+  `req_valid_ticket_for_bogus_table_does_not_reach_producer_construction_before_admission`
+  (1698/1699). Re-verified the red-on-main proof after each restructure by
+  moving the acquire back past resolve — the affected tests correctly red.
+- **Files:** `cqlite-flight/src/admission.rs`, `admission_tests.rs`,
+  `service.rs` (`new`/`with_admission`, `validate_do_get_ticket`/
+  `do_get_resolve` split).

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -486,3 +486,34 @@ Format:
   direction). Verified stable across 5 repeated runs of both the admission
   filter and the full 254-test lib suite; red-on-main re-confirmed after the
   robustness rewrite (still 6 tests red).
+
+## 2026-07-13 — admission-control roborev round 6 (job 1701)
+
+- **What:** The round-5 `admission` phase addition was correct but escaped the
+  lite-gate blast radius for `cqlite-flight/tests/metrics_capture_test.rs`
+  (feature-gated behind `observability-testing`, not in the default scoped-test
+  set), which still hardcoded the closed 3-phase set `{resolve, merge_setup,
+  stream}` in its phase-value assertion. Fixed:
+  - `metrics_capture_test.rs`: the closed-set match now asserts exactly
+    `{admission, resolve, merge_setup, stream}` (still a CLOSED set — a future
+    5th phase must update this assertion deliberately, not drift past it via a
+    loosened check). Added an `admission`-tagged phase-sample assertion
+    alongside the existing `merge_setup` one, proving even an UNCONTENDED
+    `do_get` (this fixture's default `Admission::unconstrained()`) records one
+    admission-phase OTel sample — the actual emitted histogram series, not just
+    the feature-independent atomic this round's earlier tests pinned.
+  - `issue_2370_gauge_readback_test.rs`: updated a stale prose comment
+    (`resolve→merge_setup→stream`) referencing the old 3-phase transition
+    window to include `admission` — the assertion logic itself (`phase_active_level`
+    sums ALL phases) was already phase-count-agnostic and needed no functional
+    change.
+  - Swept the whole workspace (`rg merge_setup`) for other 3-phase assumptions —
+    none found; `obs.rs`'s own `phase_slot`/`phase_index` fallbacks were already
+    derived generically from `RPC_PHASES[0]`/`.len()` in round 5, not hardcoded.
+- **Verified:** `cargo test -p cqlite-flight --features observability-testing
+  --test metrics_capture_test` PASSES directly (was the test that escaped this
+  round's lite blast radius); `cargo test -p cqlite-flight --lib admission`
+  (18/18) and the full 254-test lib suite both still pass; clippy clean incl.
+  `--features observability-testing`.
+- **Files:** `cqlite-flight/tests/metrics_capture_test.rs`,
+  `cqlite-flight/tests/issue_2370_gauge_readback_test.rs` (comment only).

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -429,3 +429,42 @@ Format:
 - **Files:** `cqlite-flight/src/admission.rs`, `admission_tests.rs`,
   `service.rs` (`new`/`with_admission`, `validate_do_get_ticket`/
   `do_get_resolve` split).
+
+## 2026-07-13 — admission-control roborev round 5 (job 1700)
+
+- **What (finding 1, admission is a first-class phase):** Added a new
+  `admission` phase to the `do_get` phase set (`admission` → `resolve` →
+  `merge_setup` → `stream`, was 3 phases, now 4). `PhaseTimer::start` now opens
+  `admission` (was `resolve`) and the timer is constructed BEFORE
+  `Admission::acquire()`, transitioning to `resolve` only once a permit is
+  granted. Previously admission wait was invisible in the
+  `cqlite.rpc.phase.duration`/`cqlite.rpc.phase.active` breakdown (folded into
+  neither phase, since the timer didn't exist yet) even though
+  `cqlite.rpc.duration` already counted it — field triage localizes latency FROM
+  the phase breakdown (that's how #2398 was diagnosed), so queue time is now a
+  first-class, directly observable phase. Updated the catalog doc comments
+  (`RPC_PHASE`, `RPC_PHASE_DURATION`, `RPC_PHASE_ACTIVE`) to register the new
+  label.
+- **What (finding 2, gauge-overlap fix, same class as roborev-1696):**
+  `Admission::acquire`'s slow (contended) path now drops the `WaitGuard`
+  immediately when the timed acquire future resolves — BEFORE recording the
+  wait sample or constructing the `AdmissionPermit` (which bumps `in_use`) — so
+  an admitted/rejected request is never simultaneously counted both `waiting`
+  AND `in_use`.
+- **Tests:** 18 deterministic admission tests (was 16). New:
+  `req_admission_wait_is_visible_as_its_own_phase` /
+  `req_admission_phase_opens_even_on_an_uncontended_admit` (finding 1, via a new
+  `pub(crate) #[cfg(test)] obs::phase_active_level_for` isolating one
+  `(method, phase)` counter — feature-independent, no OTel needed); extended
+  `req1_contended_acquire_path_unchanged` with an explicit no-overlap assertion
+  (finding 2). Updated two pre-existing `obs.rs` unit tests
+  (`phase_active_counter_reflects_concurrent_overlap_not_a_flag`,
+  `phase_active_counter_moves_on_transition`) that hardcoded `PHASE_RESOLVE` as
+  the assumed starting phase — now `PHASE_ADMISSION`. Re-verified red-on-main:
+  moving the acquire back past `do_get_resolve` now reds 6 tests (up from 5 —
+  the new admission-phase pin also reds).
+- **Files:** `cqlite-flight/src/obs.rs` (phase set, `PhaseTimer::start`,
+  `phase_active_level_for`, 2 updated unit tests), `service.rs` (timer starts
+  before `acquire`), `admission.rs` (gauge-overlap fix), `admission_tests.rs`
+  (2 new tests + 1 extended), `cqlite-core/.../observability/catalog.rs`
+  (doc updates for the 4-phase set).

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -568,3 +568,43 @@ Format:
   before ticket parse), `admission_tests.rs`, `tests/metrics_capture_test.rs`
   (Stage 5 + closed-set update), `cqlite-core/.../observability/catalog.rs`
   (doc updates for the 5-phase set).
+
+## 2026-07-13 — admission-control roborev round 8 (job 1703)
+
+- **What:** `Admission::unconstrained()` (used by `CqliteFlightService::new`,
+  the library-embedding constructor) represented "no timeout" as
+  `wait_timeout: Duration::MAX` flowing through `tokio::time::timeout` — an
+  overflow/panic hazard in library code (`timeout()` computes `Instant::now() +
+  duration` internally). Fixed by introducing an explicit `WaitBudget` enum
+  (`Unbounded` | `Timeout(Duration)`) replacing the bare `Duration` field on
+  `AdmissionConfig`/the internal `AdmissionInner`. `Admission::acquire`'s slow
+  path now branches: `Timeout(d)` keeps the existing `tokio::time::timeout(d,
+  ...)` wrapper; `Unbounded` awaits `acquire_owned()` DIRECTLY with no
+  `timeout()` wrapper at all — no deadline computed, so nothing can overflow. A
+  small `SlowAcquireOutcome` enum (`Admitted`/`Closed`/`TimedOut`) unifies the
+  two arms' await results into one post-await `match` so the gauge/counter
+  bookkeeping (unchanged from round 7's ordering fix) is written exactly once.
+  `Admission::wait_timeout() -> Duration` renamed to `wait_budget() ->
+  WaitBudget` (no callers existed). Clamp/knob semantics (the `[1,
+  Semaphore::MAX_PERMITS]` ceiling clamp, the CLI/env `--admission-wait-
+  timeout-ms` knob) are unchanged — `main.rs` now constructs
+  `WaitBudget::Timeout(Duration::from_millis(...))` explicitly.
+- **Test:** `req4_unbounded_wait_budget_never_times_out_even_under_extreme_advance`
+  — a saturated `Unbounded` admission parks a waiter, then the paused Tokio
+  clock is advanced by `u32::MAX` seconds (`tokio::time::advance`, far beyond
+  any real timeout budget this crate configures); the test process does not
+  panic, the waiter stays `Pending` (never spuriously times out — there is no
+  timeout arm to fire), and `rejected_total` stays 0. Releasing the held permit
+  then admits the waiter normally, proving `Unbounded` still resolves correctly
+  via a genuine permit free (the ONLY way it resolves).
+- **Verified:** admission target 19/19 (was 18), stable across 3 repeated runs;
+  `metrics_capture_test` still passes; full 255-test lib suite passes; clippy
+  clean; red-on-main re-confirmed (still 6 tests red).
+- **Ops note:** the shared machine's disk hit 100% capacity (119Mi free)
+  mid-round, failing the first rebuild with `No space left on device`; freed
+  ~5.8Gi by removing this worktree's own stale `target/debug/incremental`
+  (5.7G) — did not touch any other worktree's `target/` (shared box, #2412
+  co-resident).
+- **Files:** `cqlite-flight/src/admission.rs` (`WaitBudget` enum,
+  `SlowAcquireOutcome`), `admission_tests.rs` (`cfg()` + new test),
+  `main.rs` (explicit `WaitBudget::Timeout` construction).

--- a/openspec/changes/flight-admission-control/design.md
+++ b/openspec/changes/flight-admission-control/design.md
@@ -1,0 +1,212 @@
+# Design — Flight do_get admission control (issue #2420, WS4)
+
+## Context
+
+`do_get` today runs unbounded. The merge runs on `spawn_blocking`
+(`streaming.rs:317`) after an eager setup `spawn_blocking` (`service.rs:634`); each
+scan opens a fresh fd per SSTable and streams batches through a bounded channel
+(`DO_GET_CHANNEL_CAPACITY = 4` + allowance). The crate already has cancel-aware
+teardown: `CancelFlag` (a `CancellationToken` + a synchronous `ScanCancel`,
+`cancel.rs`), `CancelGuard` (cancel-on-drop, disarm-on-success), and an async
+`cancelled()` future the streaming sink races against a full-channel send
+(#2264/#2383). `RpcMetrics` maintains the `cqlite.rpc.in_flight` gauge as an
+up/down level; `PhaseTimer` maintains per-phase in-flight counters. There is no
+Semaphore and no transport concurrency limit.
+
+The connector's failover machinery (`ReplicaFailoverStream`, `ReplicaFailover`,
+#2241) is **decisive** for the semantics choice and is quoted in §(b).
+
+The product decisions (a)–(f) below each state the alternatives; §Recommended
+package selects one coherent set for Seam-1 approval.
+
+---
+
+## (a) Admission mechanism: tonic `concurrency_limit` vs. owned `Semaphore` vs. both
+
+- **tonic `concurrency_limit` / `max_concurrent_streams` (transport-wide).** One
+  line on `Server::builder()`. But it is **RPC-agnostic** — it would throttle
+  `handshake`, `get_flight_info`, `do_action` identically to `do_get`, even
+  though only the merge is the heavy consumer — and it is **opaque**: no
+  cancel-aware release semantics we control, no per-scan gauge, no wait/reject
+  distinction we can observe or shape. Queued requests park inside tonic with no
+  signal we emit.
+- **Owned `Semaphore` in `do_get` (scan-scoped).** `K` permits, acquired at the
+  top of `do_get_inner` before setup opens anything, held by an RAII guard for the
+  scan lifetime, released on completion/drop/cancel. Gates **exactly** the merge,
+  is directly observable, and releases the permit the moment the `CancelGuard`
+  fires — the precise lifecycle §(d) needs. Precedent exists in-tree:
+  `cqlite-core/.../sstable_data_manager.rs:183` gates the write-engine data
+  manager with an `operation_semaphore` (a different subsystem — see §(f)).
+- **Both, layered.** The Semaphore is the real, observable, cancel-aware admission
+  ceiling; a generous tonic `max_concurrent_streams` (well above `K`) is a coarse
+  backstop protecting the accept loop / HTTP-2 stream table from a client that
+  opens far more streams than `K`.
+
+**Recommendation: both, Semaphore-primary.** The owned Semaphore does the real
+admission work (scan-scoped, observable, cancel-releasable); the tonic cap is a
+coarse transport guard, not the throttle. Using tonic *alone* fails §(d) (no
+cancel-aware release) and §(e) (no admission observability) and mis-throttles
+lightweight RPCs.
+
+## (b) Overload semantics: hard reject vs. bounded queue-and-wait — the client contract
+
+The connector contract makes this consequential. `ReplicaFailoverStream.next()`
+(trino-connector) only fails over to the next replica when **both**: (i) no batch
+of this stream has been delivered yet (`started == false`), and (ii)
+`ReplicaFailover.isConnectClass(e)` is true — which is **`FlightStatusCode.UNAVAILABLE`
+only**. Any other status (including `RESOURCE_EXHAUSTED`) is rethrown → the split
+fails → the query fails.
+
+Consequences for each option:
+
+- **Hard reject with `RESOURCE_EXHAUSTED`.** The connector does **not** retry or
+  fail over — a saturated server turns offered load directly into **query
+  failures**. Making it retryable would require a connector change (a new
+  admission-aware retry path). Worst client experience with no connector work.
+- **Hard reject with `UNAVAILABLE`.** The connector **fails over to the next
+  replica in the split's ordered list** (retry-safe: no batch delivered yet, so
+  no row duplication). This composes with the existing #2241 machinery *today*,
+  with no connector change. The mild cost is semantic overload of `UNAVAILABLE`
+  ("endpoint down") to mean "endpoint busy"; under *global* saturation every
+  replica rejects and the client eventually sees the last failure propagate —
+  loud, never silent.
+- **Bounded queue-and-wait (timeout).** The request parks for a permit up to a
+  configured timeout, absorbing short bursts **transparently** — no status, no
+  connector change, the split just takes longer. Only on timeout must a status be
+  returned; per the contract above that status should be `UNAVAILABLE` so a
+  sustained-overload reject sheds to a less-loaded replica rather than failing the
+  query.
+
+**Recommendation: bounded queue-and-wait, and on timeout return `UNAVAILABLE`
+(never `RESOURCE_EXHAUSTED`).** Rationale: (1) short bursts are absorbed with zero
+client-visible error and zero connector change; (2) sustained overload sheds to
+another replica via the existing #2241 failover (correctness-safe because the
+reject provably precedes the first batch); (3) only when *every* replica is
+saturated does the query fail loudly — the graceful-degradation ladder the epic
+asks for. Choosing `RESOURCE_EXHAUSTED` would convert saturation into query
+failures and is rejected on that basis; a connector-side admission-retry is a
+possible future refinement but is out of scope here (no Trino-side change).
+
+## (c) Limit sizing: fixed default vs. f(cores) vs. config knob
+
+- **f(num_cpus) alone.** CPU is **not** the binding constraint. The Rank 2/3/4
+  failures are blocking-pool threads (512 cap, ~2 per scan → ~256 ceiling), fds
+  (~1024 ulimit ÷ M SSTables), and RSS — none of which scale with core count.
+  A cores-derived default would be miscalibrated.
+- **Fixed default.** Simple and predictable, but a single baked-in number cannot
+  fit every deployment's ulimit / SSTable-count / memory envelope.
+- **Config knob with an evidence-based default.** `--max-concurrent-scans` (CLI
+  flag + env), default a conservative fixed value sized against the
+  blocking-pool ceiling (~256) and fd ceiling (~1024 ÷ M) — well below both — and
+  **validated by the WS1 ramp (WS8)** before the default is locked. Per the AH
+  decorative-knob doctrine, the knob is *real*: a test proves that setting `K`
+  bounds in-flight scans to `K` end-to-end.
+
+**Recommendation: a real config knob, default a conservative fixed value pending
+WS1-ramp validation, sized from the blocking-pool/fd ceilings, NOT from
+num_cpus.** The permit-wait timeout §(b) is a second (injectable) knob. Both are
+wired end-to-end and covered by tests; neither is decorative.
+
+## (d) Permit lifecycle under cancellation
+
+A cancelled or superseded `do_get` **must** release its permit promptly — a leaked
+permit permanently lowers `K` and eventually deadlocks admission.
+
+- The permit is held by an **RAII guard dropped on every exit path** of the scan:
+  normal completion, setup error, client disconnect (response-stream drop), and
+  cooperative cancellation. The guard is owned by the same structure that owns the
+  `CancelGuard` today (the metered stream / merge task), so a future-drop that
+  already fires `CancelFlag` **also** drops the permit — one lifetime, no separate
+  bookkeeping.
+- Because the permit is `Owning` (`OwnedSemaphorePermit`) and moved into the
+  stream, dropping the stream (the #2264/#2383 disconnect path) frees it without
+  any explicit `release` call — leaks are structurally impossible on the drop
+  path. The acquire happens *before* setup, so a request cancelled while waiting
+  for a permit simply abandons the `acquire` future and never held one.
+
+**Requirement:** a saturation test asserts the admission gauge returns to its
+pre-scan level after all admitted scans are cancelled/dropped (zero permit leak).
+
+## (e) Observability
+
+New catalog instruments (in `cqlite-core` `observability::catalog`, recorded from
+`cqlite-flight/src/obs.rs`), composing with WS2 (#2419) rather than duplicating
+`cqlite.rpc.in_flight`:
+
+- `cqlite.flight.admission.limit` (gauge) — configured `K`.
+- `cqlite.flight.admission.in_use` (gauge, up/down level like RPC_IN_FLIGHT) —
+  permits currently held.
+- `cqlite.flight.admission.waiting` (gauge) — requests parked on `acquire`.
+- `cqlite.flight.admission.rejected_total` (counter) — timeout rejections.
+- `cqlite.flight.admission.wait_seconds` (histogram) — permit-acquire latency.
+
+These are admission-specific and distinct from the RPC-level in-flight gauge (that
+counts *accepted* RPCs including the queued ones; `in_use` counts *admitted*
+scans). The counters are scale-free (levels + monotonic totals), so tests assert
+them without fixture-size coupling.
+
+## (f) Interaction with the machine's blocking-pool admission (#1594 class)
+
+Two distinct layers, both needed:
+
+- **`sstable_data_manager`'s `operation_semaphore`** (#1594 class,
+  `cqlite-core/.../sstable_data_manager.rs:228`) bounds concurrent operations
+  *inside the write-engine data manager* — a core-storage concern, per-manager,
+  unrelated to the Flight transport.
+- **This WS4 admission Semaphore** bounds concurrent *`do_get` transport scans* at
+  the server boundary, before any core-storage work begins.
+
+They are not redundant: WS4 caps how many scans *enter* the server; the data
+manager caps concurrency *within* a storage subsystem a scan may touch. WS4 sits
+strictly above and does not re-count the data-manager permits (a `do_get` merge is
+read-path and does not acquire the write-engine data-manager permit at all). The
+design keeps them independent knobs so neither silently constrains the other.
+
+---
+
+## Recommended package (for Seam-1 approval)
+
+1. **(a) Owned `Semaphore` primary + coarse tonic `max_concurrent_streams`
+   backstop.** Scan-scoped, observable, cancel-releasable admission; transport cap
+   guards the accept loop only.
+2. **(b) Bounded queue-and-wait; on timeout reject with `UNAVAILABLE`.** Absorbs
+   bursts transparently, sheds sustained overload to another replica via existing
+   #2241 failover (retry-safe pre-first-batch), fails loudly only when all
+   replicas saturate. Never `RESOURCE_EXHAUSTED` (the connector would fail the
+   query).
+3. **(c) Real `--max-concurrent-scans` knob (CLI + env) + injectable permit-wait
+   timeout; default a conservative fixed value validated by the WS1 ramp, sized
+   from blocking-pool/fd ceilings, not num_cpus.** Anti-decorative: tested to
+   truly bound in-flight to `K`.
+4. **(d) `OwnedSemaphorePermit` held by the stream/merge-task RAII guard alongside
+   the `CancelGuard`** — released on every exit path incl. disconnect/cancel; zero
+   leak asserted.
+5. **(e) Five admission instruments** composing with WS2, distinct from
+   `cqlite.rpc.in_flight`.
+6. **(f) Independent of the #1594 data-manager semaphore** — two layers, WS4 above
+   the transport boundary.
+
+## Alternatives considered and rejected
+
+- **Transport `concurrency_limit` only** — fails §(d)/(e), mis-throttles
+  lightweight RPCs.
+- **Hard `RESOURCE_EXHAUSTED` reject** — connector fails the query (no #2241
+  failover); would need Trino-side work to be graceful.
+- **f(num_cpus) default** — mis-sized against the real (fd/blocking-pool)
+  constraints.
+- **Unbounded wait (no timeout)** — under sustained overload the client sees a
+  hang instead of a sheddable status; violates the "backpressure signal" goal.
+
+## Testing strategy (determinism)
+
+- **Injectable concurrency, no wall-clock.** Tests hold `K` permits via a test
+  barrier / pre-acquired guards, then offer `K + M` requests; assert admitted
+  in-flight ≤ `K` and the `M` excess either wait (bounded) or reject with
+  `UNAVAILABLE` per the injected timeout. The timeout is a configured value, not a
+  real sleep; any observation window is captured to cover **all** sampled requests
+  (pre-roborev wall-clock-race checklist).
+- **Scale-free counters.** Assertions read the admission gauges/counters as
+  levels + totals, independent of fixture row/SSTable count.
+- **Wiring through the flight surface.** The saturation test drives real `do_get`
+  RPCs (or the `do_get_inner` surface) end-to-end, not a helper in isolation —
+  proving the ceiling engages on the public path.

--- a/openspec/changes/flight-admission-control/proposal.md
+++ b/openspec/changes/flight-admission-control/proposal.md
@@ -1,0 +1,98 @@
+# Flight do_get admission control — bounded concurrent scans with graceful backpressure (issue #2420, WS4)
+
+## Why
+
+The `cqlite-flight` server has **no admission control**. Nothing bounds how many
+concurrent `do_get` scans/merges run at once. Verified on `main`:
+
+- `cqlite-flight/src/main.rs:74` builds the server as
+  `Server::builder().add_service(FlightServiceServer::new(service)).serve_with_shutdown(...)`
+  — no tonic `concurrency_limit(...)` and no `max_concurrent_streams`.
+- `rg 'Semaphore' cqlite-flight/` returns nothing — no application-level ceiling
+  gates concurrent work anywhere in the crate.
+
+Under rising concurrency the throughput-saturation research
+(`docs/architecture/issue-throughput-saturation-research.md` §C6-WS4) ranks the
+consequences #2–#4 in order-of-failure:
+
+- **Blocking-pool queueing (Rank 2).** Each `do_get` consumes up to two
+  blocking-pool threads (setup `spawn_blocking` at `service.rs:634`, merge
+  `spawn_blocking` at `streaming.rs:317`). Tokio's blocking pool caps at 512, so
+  past ~256 concurrent scans, setups queue silently with **no backpressure signal
+  to the client** — offered concurrency becomes latency the client cannot see.
+- **fd exhaustion (Rank 3).** Each scan opens a fresh fd per SSTable
+  (`reader/source.rs`, no reader/fd pool by #815 design) plus a `Summary.db` read
+  per SSTable during prune. N scans × M SSTables drive fd count toward the
+  container ulimit (~1024) → `EMFILE` → query failures.
+- **Unbounded memory (Rank 4).** Peak resident payload is
+  O(channel · batch) per scan, so RSS grows ≈ N × per-scan peak with no global
+  cap → OOM risk.
+
+In short: with no admission ceiling, offered concurrency translates directly into
+unbounded thread/fd/memory pressure and **every in-flight request degrades
+together** rather than the server queueing or shedding load gracefully.
+
+Round-10b field floor (#2367, connector 0.14.2, 8 threads/180s, 3-node RF=3):
+~2.34 qps, ~48 rows/s, p50 2.9s, p99 10.0s, **0 client errors**, all 3 pods
+working; flight-layer `do_get` error-status **2.6%** (down from R10's 14%, largely
+cleared by #2397 replica rotation). At 8 threads the server has headroom. WS4's
+job is to keep behavior graceful as the WS1 ramp pushes concurrency well past
+that, where the research predicts the Rank 2/3/4 failures with no ceiling in place.
+
+- **Milestone:** 0.15. Epic #2313 (flight read-throughput saturation) WS4; epic
+  #2403 (cqlite-trino latency/throughput/operations) Lane 2.
+- **Design-driven** — the overload behavior (reject vs. queue-and-wait), the
+  status returned, and the client contract are **product decisions with no parity
+  oracle**; they are exactly the client-contract/semantics calls CLAUDE.md routes
+  through OpenSpec + Seam 1. Requires Seam-1 owner approval before implementation.
+- **Creates capability** `flight-admission-control`.
+
+## What Changes
+
+- **An application-level admission ceiling on `do_get`.** An owned, cloneable
+  `tokio::sync::Semaphore` with `K` permits gates entry to the `do_get` merge.
+  A request acquires a permit **before** any SSTable is opened or any batch is
+  produced, holds it for the scan's lifetime, and releases it on completion,
+  client disconnect, or cancellation. In-flight admitted scans are thereby bounded
+  by `K`, capping blocking-pool, fd, and memory pressure at a configured limit
+  rather than at an OS ceiling.
+- **Graceful overload behavior (queue-and-wait, then shed).** On saturation a
+  request waits a bounded time for a permit; if none frees within the timeout it
+  is rejected with a status the connector can **fail over** on. Because the reject
+  happens before any batch is delivered, failover to another replica is
+  correctness-safe (see design.md §b — the client contract is decisive here).
+- **A real, wired admission knob.** `--max-concurrent-scans` (CLI flag + env),
+  default a conservative fixed value validated by the WS1 ramp; the permit-wait
+  timeout is likewise configurable. Per the AH decorative-knob doctrine, setting
+  `K` is tested to actually bound in-flight scans to `K`.
+- **A coarse tonic transport backstop.** A generous `max_concurrent_streams` on
+  the server builder (above `K`) protects the accept loop; the Semaphore, not the
+  transport cap, is the real admission ceiling.
+- **Admission observability.** New catalog gauges/counters — admission limit,
+  permits in use, requests waiting, rejections, permit-wait latency — composing
+  with the WS2 (#2419) gauges without duplicating `cqlite.rpc.in_flight`.
+- **Permit release is cancel-aware.** The permit is held by an RAII guard tied to
+  the existing #2361/#2383 `CancelFlag`/drop-cancel machinery, so a cancelled or
+  superseded `do_get` releases its permit promptly with no leak.
+
+## Non-goals
+
+- **No Trino-side scheduling changes.** The connector's split scheduling and
+  page-source loop are unchanged; this is transport-level server admission only.
+- **No change to #2397 replica rotation.** Rotation distributes primaries;
+  admission is what the server adds *on top* of rotation to stay graceful once
+  offered concurrency exceeds a single node's capacity.
+- **No query-planner / result-byte-budget admission.** This gates transport
+  concurrency, not per-query resource accounting (that is the core query engine's
+  domain).
+- **No change to the existing bounded egress channel** (`DO_GET_CHANNEL_CAPACITY`)
+  or the #2316 producer-thread budget — admission composes with them, it does not
+  re-count them.
+- **No wall-clock in tests.** Concurrency is injected deterministically (held
+  permits / barriers); timeouts are injectable, never real-time sleeps.
+
+## Doctrine impact
+
+Adds a `--max-concurrent-scans` operator knob to the flight server; the
+`agents-developing/` flight/ops docs and the WS4 research section are updated in
+the implementing change. No CLAUDE.md rule change.

--- a/openspec/changes/flight-admission-control/specs/flight-admission-control/spec.md
+++ b/openspec/changes/flight-admission-control/specs/flight-admission-control/spec.md
@@ -1,0 +1,133 @@
+# flight-admission-control
+
+## ADDED Requirements
+
+### Requirement: do_get concurrency is bounded by a configured admission limit
+
+`FlightService::do_get` SHALL bound the number of concurrently admitted scans to a
+configured limit `K` by acquiring an admission permit before opening any SSTable
+or producing any batch, and MUST NOT admit more than `K` scans at once regardless
+of offered concurrency.
+
+#### Scenario: offering more than K concurrent do_gets holds in-flight at K
+
+- **GIVEN** an admission limit `K` and a deterministic test that holds all `K`
+  permits via pre-acquired guards (no wall-clock; concurrency injected, not timed)
+- **WHEN** `K + M` `do_get` requests are offered against a live table
+- **THEN** the admission in-use gauge never exceeds `K` while the barrier is held
+- **AND** every one of the `M` excess requests is blocked from opening an SSTable
+  (observed via an SSTable-open / permit-acquire work counter that stays at the
+  `K`-admitted level)
+- **AND** this test FAILS on pre-change `main`, where offering `K + M` admits all
+  `K + M` (no permit exists to bound them)
+
+#### Scenario: releasing a permit admits exactly one waiting request
+
+- **GIVEN** `K` permits held and `M ≥ 1` requests waiting on `acquire`
+- **WHEN** exactly one held permit is released
+- **THEN** exactly one waiting request is admitted (in-use returns to `K`) and the
+  remaining `M − 1` stay waiting — no over-admission, no lost wakeup
+
+### Requirement: sustained overload sheds with a retry-safe status, never RESOURCE_EXHAUSTED
+
+An admission rejection SHALL be returned only after a bounded permit-wait timeout
+elapses with no permit available, MUST use gRPC status `UNAVAILABLE` (so the
+connector's #2241 replica-failover treats it as retry-safe), MUST NOT use
+`RESOURCE_EXHAUSTED`, and MUST occur before any record batch has been delivered
+for that request.
+
+#### Scenario: a request that cannot get a permit within the timeout is rejected UNAVAILABLE
+
+- **GIVEN** an admission limit `K`, all `K` permits held by a test barrier, and a
+  configured (injectable, non-wall-clock) permit-wait timeout
+- **WHEN** one more `do_get` is offered and the injected timeout is advanced past
+  the wait deadline while the barrier is still held
+- **THEN** that request completes with gRPC status `UNAVAILABLE` (not
+  `RESOURCE_EXHAUSTED`, not `OK`) having delivered zero record batches
+- **AND** the admission `rejected_total` counter increments by exactly one
+
+#### Scenario: a short burst is absorbed by the wait without rejection
+
+- **GIVEN** an admission limit `K` and all `K` permits held only transiently (a
+  single held permit released before the wait deadline)
+- **WHEN** one excess `do_get` is offered and waits, then a permit frees before
+  the timeout
+- **THEN** the request is admitted and returns its complete result with status
+  `OK` — no rejection, no error status — and `rejected_total` is unchanged
+
+### Requirement: a cancelled or disconnected do_get releases its permit promptly
+
+A `do_get` that is cancelled, superseded, or whose client disconnects SHALL
+release its admission permit within a bounded number of steps via the same
+RAII/cancel-aware teardown as the #2361/#2383 machinery, leaving no permit leaked.
+
+#### Scenario: dropping every admitted stream returns the admission gauge to baseline
+
+- **GIVEN** `K` admitted, in-flight `do_get` scans over a multi-batch table
+- **WHEN** all `K` client streams are dropped (disconnect) after the first batch
+- **THEN** the admission in-use gauge returns to its pre-scan baseline (zero
+  leaked permits) and a subsequently offered scan is admitted immediately
+- **AND** this is asserted via the gauge/level, not a timed sleep
+
+#### Scenario: a request cancelled while waiting for a permit never holds one
+
+- **GIVEN** all `K` permits held and one request waiting on `acquire`
+- **WHEN** that waiting request is cancelled (client disconnect before admission)
+- **THEN** it completes with a cancellation/`Aborted`-class outcome, the waiting
+  gauge returns to zero, and the in-use gauge is unchanged (it never acquired)
+
+### Requirement: the admission limit is a real, wired configuration knob
+
+The admission limit SHALL be settable via a `--max-concurrent-scans` CLI flag and
+an environment variable with a documented conservative default, and setting it to
+`K` MUST bound admitted concurrency to `K` end-to-end (the knob is functional, not
+decorative).
+
+#### Scenario: a configured limit K bounds admitted concurrency to K
+
+- **GIVEN** a flight server configured with `--max-concurrent-scans = K` for a
+  small deterministic `K`
+- **WHEN** `K + M` concurrent `do_get` requests are offered
+- **THEN** the admission in-use gauge is bounded by exactly the configured `K`
+  (not a hard-coded constant), demonstrated for at least two distinct `K` values
+  so the value is proven to flow through to the ceiling
+
+#### Scenario: the permit-wait timeout is honoured as configured
+
+- **GIVEN** a configured (injectable) permit-wait timeout value
+- **WHEN** a request waits for a permit that never frees
+- **THEN** it is rejected after the configured wait budget is exhausted, and a
+  different configured budget yields a correspondingly different reject point —
+  proving the timeout knob is wired (asserted deterministically, no real sleep)
+
+### Requirement: admission state is exported as observability instruments
+
+The server SHALL export admission observability distinct from the RPC in-flight
+gauge: the configured limit, permits in use, requests waiting, a monotonic
+rejection counter, and a permit-wait latency histogram — all via the metric
+catalog and all scale-free (independent of fixture size).
+
+#### Scenario: admission gauges and counters track engagement deterministically
+
+- **GIVEN** the in-process metric recorder installed and an admission limit `K`
+- **WHEN** `K` scans are admitted, `M` are made to wait, and one wait times out
+- **THEN** the in-use gauge reads `K`, the waiting gauge reads the current wait
+  count, the rejection counter increments by one on the timeout, and the
+  permit-wait histogram records a sample — each read as a level/total, not derived
+  from fixture row or SSTable counts
+- **AND** these instruments are distinct names from `cqlite.rpc.in_flight`
+  (no double-counting of the WS2 gauges)
+
+### Requirement: admission does not alter the result of an admitted scan
+
+Admission control SHALL be transparent to result content: a scan that is admitted
+(immediately or after waiting) MUST return the byte-identical rows, order, schema,
+and batch boundaries it would return with admission disabled/unbounded.
+
+#### Scenario: admitted-after-wait result equals the unbounded result
+
+- **GIVEN** a table and a ticket exercising rows, a limit, and a predicate filter
+- **WHEN** the same ticket is executed once through an unbounded path and once
+  through the admission path after waiting for a permit
+- **THEN** row content, row order, schema, and batch boundaries are identical —
+  admission changes *when* a scan runs, never *what* it returns

--- a/openspec/changes/flight-admission-control/tasks.md
+++ b/openspec/changes/flight-admission-control/tasks.md
@@ -2,64 +2,64 @@
 
 ## 1. TDD guards (fail on main first)
 
-- [ ] 1.1 Bounded-admission test: offer `K + M` concurrent `do_get`s with all `K`
+- [x] 1.1 Bounded-admission test: offer `K + M` concurrent `do_get`s with all `K`
       permits held by a test barrier (injected concurrency, no wall-clock); assert
       in-use gauge ≤ `K` and the `M` excess never open an SSTable. FAILS on main
       (no permit exists).
-- [ ] 1.2 Timeout-reject test: with the barrier held and an injectable permit-wait
+- [x] 1.2 Timeout-reject test: with the barrier held and an injectable permit-wait
       timeout advanced past the deadline, assert the excess request returns
       `UNAVAILABLE` (never `RESOURCE_EXHAUSTED`), zero batches delivered,
       `rejected_total += 1`. FAILS on main.
-- [ ] 1.3 Burst-absorb test: release a held permit before the timeout; assert the
+- [x] 1.3 Burst-absorb test: release a held permit before the timeout; assert the
       waiter is admitted with `OK` and `rejected_total` unchanged. FAILS on main.
-- [ ] 1.4 Permit-leak test: admit `K`, drop all `K` streams; assert the in-use
+- [x] 1.4 Permit-leak test: admit `K`, drop all `K` streams; assert the in-use
       gauge returns to baseline and a new scan is admitted. FAILS on main.
-- [ ] 1.5 Knob test: configure two distinct `K` values via `--max-concurrent-scans`;
+- [x] 1.5 Knob test: configure two distinct `K` values via `--max-concurrent-scans`;
       assert the ceiling equals each configured `K` (proves non-decorative). FAILS
       on main.
 
 ## 2. Admission primitive (`cqlite-flight`)
 
-- [ ] 2.1 Add an `Admission` type wrapping an `Arc<Semaphore>` (capacity `K`) and
+- [x] 2.1 Add an `Admission` type wrapping an `Arc<Semaphore>` (capacity `K`) and
       the configured permit-wait timeout; `try_acquire_with_timeout` returns an
       `OwnedSemaphorePermit`-holding guard or an `UNAVAILABLE` `Status` on timeout.
-- [ ] 2.2 Increment/decrement the admission gauges (in-use, waiting) around
+- [x] 2.2 Increment/decrement the admission gauges (in-use, waiting) around
       acquire/release; increment `rejected_total` + record the permit-wait
       histogram on the reject and admit paths. Use catalog constants.
 
 ## 3. Service wiring (`cqlite-flight/src/service.rs`, `streaming.rs`)
 
-- [ ] 3.1 Acquire the admission permit at the top of `do_get_inner`, before
+- [x] 3.1 Acquire the admission permit at the top of `do_get_inner`, before
       `do_get_setup` opens anything; on timeout return the `UNAVAILABLE` status
       through the existing error path (records the RPC error + closes the span).
-- [ ] 3.2 Move the `OwnedSemaphorePermit` guard into the metered stream / merge
+- [x] 3.2 Move the `OwnedSemaphorePermit` guard into the metered stream / merge
       task alongside the existing `CancelGuard`, so every exit path (completion,
       setup error, disconnect, cancel) drops it — one lifetime, zero leak.
-- [ ] 3.3 Aggregate and row paths both gated by the same permit.
+- [x] 3.3 Aggregate and row paths both gated by the same permit.
 
 ## 4. Configuration (`cqlite-flight/src/main.rs`)
 
-- [ ] 4.1 Add `--max-concurrent-scans` (CLI + env) with a documented conservative
+- [x] 4.1 Add `--max-concurrent-scans` (CLI + env) with a documented conservative
       default and a `--admission-wait-timeout` (or equivalent) knob; thread them
       into `CqliteFlightService::new`.
-- [ ] 4.2 Add a coarse tonic `max_concurrent_streams` transport backstop (well
+- [x] 4.2 Add a coarse tonic `max_concurrent_streams` transport backstop (well
       above `K`) on `Server::builder()`.
 
 ## 5. Observability (`cqlite-flight/src/obs.rs`, `cqlite-core` catalog)
 
-- [ ] 5.1 Add the five catalog instruments (limit, in_use, waiting,
+- [x] 5.1 Add the five catalog instruments (limit, in_use, waiting,
       rejected_total, wait_seconds); confirm distinct names from
       `cqlite.rpc.in_flight`.
 
 ## 6. Docs
 
-- [ ] 6.1 Document `--max-concurrent-scans` + the overload contract (queue-then-
+- [x] 6.1 Document `--max-concurrent-scans` + the overload contract (queue-then-
       `UNAVAILABLE`, connector fails over) in the flight/ops docs and update the
       WS4 research-section pointer.
 
 ## 7. Endgame
 
-- [ ] 7.1 `--lite` green each fix round (summary-file redirect); blast-radius
+- [x] 7.1 `--lite` green each fix round (summary-file redirect); blast-radius
       tests for `cqlite-flight`.
 - [ ] 7.2 rust-reviewer + roborev on the lite-green diff; address blockers.
 - [ ] 7.3 Open PR; flow-closer runs the FULL gate ONCE → spec-auditor (C) → final

--- a/openspec/changes/flight-admission-control/tasks.md
+++ b/openspec/changes/flight-admission-control/tasks.md
@@ -1,0 +1,69 @@
+# Tasks — flight-admission-control (issue #2420, WS4)
+
+## 1. TDD guards (fail on main first)
+
+- [ ] 1.1 Bounded-admission test: offer `K + M` concurrent `do_get`s with all `K`
+      permits held by a test barrier (injected concurrency, no wall-clock); assert
+      in-use gauge ≤ `K` and the `M` excess never open an SSTable. FAILS on main
+      (no permit exists).
+- [ ] 1.2 Timeout-reject test: with the barrier held and an injectable permit-wait
+      timeout advanced past the deadline, assert the excess request returns
+      `UNAVAILABLE` (never `RESOURCE_EXHAUSTED`), zero batches delivered,
+      `rejected_total += 1`. FAILS on main.
+- [ ] 1.3 Burst-absorb test: release a held permit before the timeout; assert the
+      waiter is admitted with `OK` and `rejected_total` unchanged. FAILS on main.
+- [ ] 1.4 Permit-leak test: admit `K`, drop all `K` streams; assert the in-use
+      gauge returns to baseline and a new scan is admitted. FAILS on main.
+- [ ] 1.5 Knob test: configure two distinct `K` values via `--max-concurrent-scans`;
+      assert the ceiling equals each configured `K` (proves non-decorative). FAILS
+      on main.
+
+## 2. Admission primitive (`cqlite-flight`)
+
+- [ ] 2.1 Add an `Admission` type wrapping an `Arc<Semaphore>` (capacity `K`) and
+      the configured permit-wait timeout; `try_acquire_with_timeout` returns an
+      `OwnedSemaphorePermit`-holding guard or an `UNAVAILABLE` `Status` on timeout.
+- [ ] 2.2 Increment/decrement the admission gauges (in-use, waiting) around
+      acquire/release; increment `rejected_total` + record the permit-wait
+      histogram on the reject and admit paths. Use catalog constants.
+
+## 3. Service wiring (`cqlite-flight/src/service.rs`, `streaming.rs`)
+
+- [ ] 3.1 Acquire the admission permit at the top of `do_get_inner`, before
+      `do_get_setup` opens anything; on timeout return the `UNAVAILABLE` status
+      through the existing error path (records the RPC error + closes the span).
+- [ ] 3.2 Move the `OwnedSemaphorePermit` guard into the metered stream / merge
+      task alongside the existing `CancelGuard`, so every exit path (completion,
+      setup error, disconnect, cancel) drops it — one lifetime, zero leak.
+- [ ] 3.3 Aggregate and row paths both gated by the same permit.
+
+## 4. Configuration (`cqlite-flight/src/main.rs`)
+
+- [ ] 4.1 Add `--max-concurrent-scans` (CLI + env) with a documented conservative
+      default and a `--admission-wait-timeout` (or equivalent) knob; thread them
+      into `CqliteFlightService::new`.
+- [ ] 4.2 Add a coarse tonic `max_concurrent_streams` transport backstop (well
+      above `K`) on `Server::builder()`.
+
+## 5. Observability (`cqlite-flight/src/obs.rs`, `cqlite-core` catalog)
+
+- [ ] 5.1 Add the five catalog instruments (limit, in_use, waiting,
+      rejected_total, wait_seconds); confirm distinct names from
+      `cqlite.rpc.in_flight`.
+
+## 6. Docs
+
+- [ ] 6.1 Document `--max-concurrent-scans` + the overload contract (queue-then-
+      `UNAVAILABLE`, connector fails over) in the flight/ops docs and update the
+      WS4 research-section pointer.
+
+## 7. Endgame
+
+- [ ] 7.1 `--lite` green each fix round (summary-file redirect); blast-radius
+      tests for `cqlite-flight`.
+- [ ] 7.2 rust-reviewer + roborev on the lite-green diff; address blockers.
+- [ ] 7.3 Open PR; flow-closer runs the FULL gate ONCE → spec-auditor (C) → final
+      roborev → merge-on-green → finalize.
+- [ ] 7.4 Default `K` validated against the WS1 ramp (WS8) before the default is
+      locked; record the evidence on #2420.
+- [ ] 7.5 `openspec archive flight-admission-control` after merge.


### PR DESCRIPTION
Closes #2420

Implements the owner-approved OpenSpec change `flight-admission-control` (Seam 1 approved 2026-07-14; epic #2313 WS4 + #2403 Lane 2).

## What ships
- **Owned-Semaphore admission in do_get**: permit acquired after minimal ticket-syntax validation, before ANY producer/schema construction or filesystem work; RAII permit rides the response stream (client drop/cancel releases; explicit drop-ordering keeps gauges truthful).
- **Overload semantics**: bounded queue-and-wait (`WaitBudget::{Unbounded, Timeout}` — no Duration::MAX sentinel); timeout sheds with **UNAVAILABLE pre-first-batch** (rides #2241 connector failover; RESOURCE_EXHAUSTED forbidden). Malformed tickets fast-fail INVALID_ARGUMENT without consuming permits.
- **Real knob**: `--max-concurrent-scans` / `CQLITE_MAX_CONCURRENT_SCANS`, default **64** (sized from blocking-pool/fd ceilings, not cores; WS1 #2418 ramp validates), clamped `[1, Semaphore::MAX_PERMITS]` with operator warn. Tonic `max_concurrent_streams` backstop. Library `new()` unchanged (admission explicit; the binary wires it).
- **Observability**: 5 `cqlite.flight.admission.*` instruments + a new **5-phase closed set** `validate→admission→resolve→merge_setup→stream` (queue time is field-visible in the phase breakdown — the #2398-style diagnosis path; evidence-verified that main emitted phase samples for malformed tickets, so `validate` restores that contract).
- 19 deterministic tests (paused clock, injected barriers, zero wall-clock); red-on-main proof = 6 tests red when the gate is unwired.

## Review trail (review-first, #2086)
- rust-reviewer: APPROVE, 0 blockers (permit lifecycle traced leak-free; 3 nits batched below).
- roborev rounds 1696→1703: 8 blockers found + fixed (waiting-gauge semantics; MAX_PERMITS startup panic; error-contract placement; public-constructor default; permit boundary vs expensive work; admission phase visibility + gauge overlap; closed phase set; Duration::MAX overflow hazard). **Round 1704: clean — "No issues found."**

## Nits to batch at merge (per #2088; ONE follow-up issue)
1. Detached `_merge_handle` can outlive permit release on client-drop (bounded by cancel latency) — doc note.
2. Semaphore-closed drain shed records no metric.
3. `from_env` accepts `wait_timeout_ms=0` (instant reject) unlike the ≥1 scan-cap clamp.

## Notes for the closer
- Design-routed: C audit against `openspec/changes/flight-admission-control/specs/**` (6 reqs / 10 scenarios + the validate-phase addition adjudicated in-code).
- `service.rs` pre-existing over-threshold; growth per #1116 — full gate needs `CQLITE_ALLOW_FILE_GROWTH=1`.
- Lite summaries: /tmp/lite-2420-*.txt (MODE: lite — NOT the gate of record).