### PR TITLE
perf(scan): sequential windowed Data.db pass for non-stitching full scans (#2366)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -228,7 +228,14 @@ impl SSTableReader {
             // a HashMap lookup that also incremented `INDEX_PROBES` — dropping it
             // removes O(partitions) index probes without weakening any check (the
             // up-front gate already proved every offset present, ascending, and
-            // span-representable).
+            // span-representable). This intentionally also skips the
+            // `READ_PARTITION_LOOKUP` observability counter and the B4
+            // `key_offset_cache` population that `lookup_partition_with_index`
+            // performs on the point-read path: a full scan is not a point lookup,
+            // so it must not inflate point-read lookup metrics, nor thrash/evict
+            // the bounded B4 cache by pushing ~1M entries through it. This is a
+            // deliberate divergence from the materialising sibling's
+            // `lookup_partition_with_index` call, not an oversight.
             let data_offset = entries[i].data_offset;
             let next_offset = if i + 1 < entries.len() {
                 entries[i + 1].data_offset

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -277,11 +277,7 @@ impl SSTableReader {
                     // O(N/window) read-pattern evidence for issue #2366.
                     crate::storage::sstable::read_work_counters::record_seek();
                     window = self
-                        .read_uncompressed_verified(
-                            &self.file,
-                            absolute_offset,
-                            want as usize,
-                        )
+                        .read_uncompressed_verified(&self.file, absolute_offset, want as usize)
                         .await?;
                     window_filled = true;
                 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -29,10 +29,20 @@
 //! index fully parsed, all keys non-empty, offsets strictly ascending, spans fit
 //! `u32`) is checked UP-FRONT: a failure returns [`FullIndexStreamOutcome::FellBack`]
 //! with nothing emitted, so the caller's `sequential_scan` fallback is still
-//! safe. The remaining per-partition checks (index-probe miss, a partition slice
-//! that does not fully consume) require reading the partition body, so they can
-//! only surface mid-walk — and there they are a hard `Error` (fail-closed), never
-//! a silent fallback. For a well-formed BIG SSTable none of them fire.
+//! safe. The remaining per-partition check (a partition slice that does not fully
+//! consume) requires reading the partition body, so it can only surface mid-walk
+//! — and there it is a hard `Error` (fail-closed), never a silent fallback. For a
+//! well-formed BIG SSTable it never fires.
+//!
+//! ## Sequential read window (issue #2366)
+//!
+//! The uncompressed walk resolves each partition's `data_offset` DIRECTLY from
+//! the `Index.db` offset table (no per-partition random `Index.db` probe) and
+//! serves its bytes from a bounded, forward-only sequential read window over
+//! Data.db rather than one positioned `seek`+`read_exact`+CRC per partition —
+//! turning ~O(partitions) random reads into O(data_section_len / window)
+//! sequential reads with bounded peak memory. See
+//! [`SEQUENTIAL_WINDOW_TARGET_BYTES`].
 
 use super::super::SSTableReader;
 use crate::schema::TableSchema;
@@ -41,6 +51,21 @@ use crate::types::ScanRow;
 use crate::util::cassandra_murmur3::cassandra_murmur3_token;
 use crate::{Error, Result, RowKey};
 use std::ops::ControlFlow;
+
+/// Target size (bytes) of the sequential Data.db read window used by the
+/// uncompressed non-stitching streaming walk (issue #2366).
+///
+/// The walk visits partitions in ascending `data_offset` order (== token order
+/// == Data.db physical order), so instead of one positioned `seek`+`read_exact`
+/// +CRC per partition (~1.13M small random reads at field scale) it fills a
+/// bounded in-memory window covering many consecutive partitions with ONE
+/// sequential `read_uncompressed_verified` call, then serves each partition's
+/// slice from that window. A partition larger than the target still reads in a
+/// single window sized to exactly its span (never smaller than one partition),
+/// so peak memory is bounded by `max(TARGET, largest_partition_span)`. 4 MiB is
+/// large enough to amortise the per-read + CRC overhead across ~hundreds of
+/// typical partitions yet small enough to keep the memory target (<128 MiB).
+const SEQUENTIAL_WINDOW_TARGET_BYTES: u64 = 4 * 1024 * 1024;
 
 /// Hardening B (issue #2361, roborev rounds 2/3): the streaming walk EMITS each
 /// partition to the k-way merger as it resolves it, unlike the materialising
@@ -175,10 +200,21 @@ impl SSTableReader {
         // materialising sibling's defensive `sort_by_token_order`.
         let mut prev_key: Option<(i64, &[u8])> = None;
 
+        // Sequential read window over the UNCOMPRESSED data section (issue #2366):
+        // instead of one positioned read + CRC per partition, `window` holds the
+        // bytes of `[window_start, window_start + window.len())` (data-section
+        // domain, i.e. the `data_offset` domain) and each partition's slice is
+        // served from it. Because entries are ascending, `window_start` only ever
+        // advances forward — the read pattern is O(data_section_len / TARGET)
+        // sequential reads, not O(partitions) random reads. Unused (never filled)
+        // on the compressed-offset branch.
+        let mut window: Vec<u8> = Vec::new();
+        let mut window_start: u64 = 0;
+        let mut window_filled = false;
+
         for i in 0..entries.len() {
-            // Cooperative cancellation: one real index-random-read + Data.db parse
-            // per partition — poll every entry so a cancelled scan abandons the
-            // walk promptly (issue #2264, PER-CALL token issue #2346).
+            // Cooperative cancellation: poll every entry so a cancelled scan
+            // abandons the walk promptly (issue #2264, PER-CALL token issue #2346).
             scan_cancel.check()?;
 
             let partition_key = entries[i].raw_key.as_deref().unwrap_or(&[]);
@@ -186,17 +222,14 @@ impl SSTableReader {
             check_token_order(prev_key, token, partition_key, i)?;
             prev_key = Some((token, partition_key));
 
-            let Some((data_offset, _size)) =
-                self.lookup_partition_with_index(partition_key).await?
-            else {
-                // Proven present in the offset table up-front, so a probe miss now
-                // is an index/data inconsistency — fail closed (may have emitted).
-                return Err(Error::corruption(format!(
-                    "stream_all_partitions_via_full_index: index probe missed entry {i} \
-                     listed in the offset table (index/data inconsistency, issue #2361)"
-                )));
-            };
-
+            // The partition's data offset comes DIRECTLY from the offset table
+            // entry already validated up-front (issue #2366): the former
+            // `lookup_partition_with_index` probe returned this identical value via
+            // a HashMap lookup that also incremented `INDEX_PROBES` — dropping it
+            // removes O(partitions) index probes without weakening any check (the
+            // up-front gate already proved every offset present, ascending, and
+            // span-representable).
+            let data_offset = entries[i].data_offset;
             let next_offset = if i + 1 < entries.len() {
                 entries[i + 1].data_offset
             } else {
@@ -205,7 +238,7 @@ impl SSTableReader {
             if next_offset <= data_offset {
                 return Err(Error::corruption(format!(
                     "stream_all_partitions_via_full_index: non-ascending offset at entry {i} \
-                     (probe offset {data_offset} >= successor {next_offset}, issue #2361)"
+                     (offset {data_offset} >= successor {next_offset}, issue #2361)"
                 )));
             }
             let span = next_offset - data_offset;
@@ -216,40 +249,99 @@ impl SSTableReader {
                 )));
             };
 
-            let raw = if let Some(ci) = self.compression_info.as_deref() {
-                self.read_compressed_offset_window(ci, data_offset, size)
-                    .await?
+            let control = if let Some(ci) = self.compression_info.as_deref() {
+                // Rare non-nb compressed non-stitching branch: unchanged per-partition
+                // windowed read (issue #2366 targets the uncompressed field case only).
+                let raw = self
+                    .read_compressed_offset_window(ci, data_offset, size)
+                    .await?;
+                self.emit_partition_slice(i, &raw, &parser, schema, emit)?
             } else {
-                let absolute_offset = data_offset + self.actual_header_size as u64;
-                self.read_uncompressed_verified(&self.file, absolute_offset, size as usize)
-                    .await?
+                // Uncompressed sequential window (issue #2366). Refill when the
+                // partition's slice is not fully covered by the current window.
+                if !window_filled
+                    || data_offset < window_start
+                    || next_offset > window_start + window.len() as u64
+                {
+                    window_start = data_offset;
+                    // One read per window: at least this partition's whole span,
+                    // at most the target, clamped to the data section end so we
+                    // never read past the last partition.
+                    let remaining = data_section_end - window_start;
+                    let want = span.max(SEQUENTIAL_WINDOW_TARGET_BYTES).min(remaining);
+                    let absolute_offset = window_start + self.actual_header_size as u64;
+                    // Count the window refill as one production read-path seek
+                    // (`SEEK_CALLS`) — the single positioned read stands in for the
+                    // per-partition seeks it replaces, matching the windowed-read
+                    // convention in `scan_stream_windowed_read.rs`. This is the
+                    // O(N/window) read-pattern evidence for issue #2366.
+                    crate::storage::sstable::read_work_counters::record_seek();
+                    window = self
+                        .read_uncompressed_verified(
+                            &self.file,
+                            absolute_offset,
+                            want as usize,
+                        )
+                        .await?;
+                    window_filled = true;
+                }
+                let lo = (data_offset - window_start) as usize;
+                let hi = (next_offset - window_start) as usize;
+                let raw = &window[lo..hi];
+                self.emit_partition_slice(i, raw, &parser, schema, emit)?
             };
 
-            // Structural coverage: the slice must decode as exactly one complete
-            // partition (issue #2302 Signal B). Mid-walk failure = fail-closed.
-            if !self.partition_slice_fully_consumed(&parser, &raw, schema)? {
-                return Err(Error::corruption(format!(
-                    "stream_all_partitions_via_full_index: partition {i} slice not fully \
-                     consumed (truncated/corrupt body, issue #2361)"
-                )));
-            }
-
-            // Work-probe (issue #2398): one partition body read + parsed. A
-            // token-range split must keep this bounded to its in-range slice, not
-            // the SSTable's whole partition count.
-            crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
-            let parsed = parser.parse_block(&raw, schema, self)?;
-            for (_table_id, row_key, value) in parsed {
-                if self.filter_tombstone(&value) {
-                    match emit((row_key, value))? {
-                        ControlFlow::Continue(()) => {}
-                        ControlFlow::Break(()) => return Ok(FullIndexStreamOutcome::Streamed),
-                    }
-                }
+            if control.is_break() {
+                return Ok(FullIndexStreamOutcome::Streamed);
             }
         }
 
         Ok(FullIndexStreamOutcome::Streamed)
+    }
+
+    /// Per-partition body of the streaming full-index walk (issue #2361/#2366):
+    /// verify the slice decodes as exactly one complete partition, record the
+    /// work-probe, parse it, and `emit` each surviving (tombstone-filtered) row.
+    /// Returns `ControlFlow::Break` if the consumer asked to stop.
+    ///
+    /// Factored out of [`Self::stream_all_partitions_via_full_index`] so the
+    /// compressed-offset branch and the uncompressed sequential-window branch
+    /// share identical decode/emit semantics — only how the `raw` bytes are
+    /// obtained differs (issue #2366).
+    fn emit_partition_slice<F>(
+        &self,
+        index: usize,
+        raw: &[u8],
+        parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
+        schema: Option<&TableSchema>,
+        emit: &mut F,
+    ) -> Result<ControlFlow<()>>
+    where
+        F: FnMut((RowKey, ScanRow)) -> Result<ControlFlow<()>>,
+    {
+        // Structural coverage: the slice must decode as exactly one complete
+        // partition (issue #2302 Signal B). Mid-walk failure = fail-closed.
+        if !self.partition_slice_fully_consumed(parser, raw, schema)? {
+            return Err(Error::corruption(format!(
+                "stream_all_partitions_via_full_index: partition {index} slice not fully \
+                 consumed (truncated/corrupt body, issue #2361)"
+            )));
+        }
+
+        // Work-probe (issue #2398): one partition body read + parsed. A
+        // token-range split must keep this bounded to its in-range slice, not
+        // the SSTable's whole partition count.
+        crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
+        let parsed = parser.parse_block(raw, schema, self)?;
+        for (_table_id, row_key, value) in parsed {
+            if self.filter_tombstone(&value) {
+                match emit((row_key, value))? {
+                    ControlFlow::Continue(()) => {}
+                    ControlFlow::Break(()) => return Ok(ControlFlow::Break(())),
+                }
+            }
+        }
+        Ok(ControlFlow::Continue(()))
     }
 
     /// Streaming sibling of

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -13,11 +13,13 @@
 //! not exist on pre-#2361 `main`, so the module is COMPILE-RED there (the
 //! accepted red-then-green convention for a new streaming seam).
 
-use crate::schema::{Column, KeyColumn, TableSchema};
+use crate::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
 use crate::storage::scan_cancel::ScanCancel;
 use crate::storage::sstable::reader::data_access::full_index_stream::FullIndexStreamOutcome;
 use crate::storage::sstable::reader::SSTableReader;
-use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+use crate::storage::write_engine::mutation::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+};
 use crate::types::Value;
 use crate::{Config, Platform};
 use serial_test::serial;
@@ -450,5 +452,220 @@ async fn windowed_stream_read_pattern_is_sequential() {
     assert!(
         seeks >= 1,
         "a non-empty scan must perform at least one window read ({seeks})"
+    );
+}
+
+/// Roborev follow-up (issue #2366, review-first): every fixture above is tiny
+/// (<4 MiB total Data.db), so `seek_calls == 1` in every one of them and the
+/// multi-window-refill path (a partition's slice NOT starting at
+/// `window_start == 0`, i.e. `lo != 0`) never actually runs — the defining new
+/// behavior of this change was unexercised. Note: an EARLIER version of this
+/// fixture tried to force the "large single partition" case with one ≈4.6 MiB
+/// SINGLE-CELL value; that hit an UNRELATED pre-existing correctness bug (a
+/// single-cell `Value::Text`/`Value::Blob` write/read round-trip silently drops
+/// the whole row somewhere between ~950 KB and 1 MB — confirmed present on the
+/// UNMODIFIED materialising sibling too, so it predates and is independent of
+/// this change). Flagged separately; NOT fixed here (out of scope for #2366).
+/// This fixture avoids that zone entirely: every per-cell value stays well
+/// under 1 MB.
+fn wide_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "test_wide_table".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "seq".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: Default::default(),
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "seq".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn wide_row_mutation(id: i32, seq: i32, text_len: usize) -> Mutation {
+    Mutation::new(
+        TableId::new("test_ks", "test_wide_table"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("seq", Value::Integer(seq))),
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text("x".repeat(text_len)),
+        }],
+        1_000_000 + (id as i64) * 1_000_000 + seq as i64,
+        None,
+    )
+}
+
+/// Fixture for the multi-window-refill + large-single-partition-clamp test
+/// (issue #2366 roborev follow-up): builds `small_count` ordinary single-row
+/// partitions (`id = 2..=1+small_count`, each `small_text_len` bytes) PLUS ONE
+/// "wide" multi-row partition (`id = 1`, `wide_row_count` clustered rows, each
+/// `wide_row_text_len` bytes) — all under [`wide_schema`] so they share one
+/// Data.db. The wide partition's TOTAL span (not any single cell) is what
+/// exceeds `SEQUENTIAL_WINDOW_TARGET_BYTES`, avoiding the unrelated single-cell
+/// defect noted on [`wide_schema`]. Every per-cell value here stays under 1 MB.
+async fn write_multi_window_fixture(
+    small_count: usize,
+    small_text_len: usize,
+    wide_row_count: usize,
+    wide_row_text_len: usize,
+) -> (TempDir, std::path::PathBuf) {
+    let schema = wide_schema();
+    let temp = TempDir::new().unwrap();
+    let mut writer =
+        crate::storage::sstable::writer::SSTableWriter::new(temp.path().to_path_buf(), 1, &schema)
+            .unwrap();
+
+    let mut partitions: Vec<(_, Vec<Mutation>)> = (0..small_count)
+        .map(|idx| {
+            let id = 2 + idx as i32;
+            let m = wide_row_mutation(id, 0, small_text_len);
+            let key = m.decorated_key(&schema).unwrap();
+            (key, vec![m])
+        })
+        .collect();
+
+    let wide_mutations: Vec<Mutation> = (0..wide_row_count)
+        .map(|seq| wide_row_mutation(1, seq as i32, wide_row_text_len))
+        .collect();
+    let wide_key = wide_mutations[0].decorated_key(&schema).unwrap();
+    partitions.push((wide_key, wide_mutations));
+
+    partitions.sort_by_key(|(k, _)| k.token);
+    for (key, muts) in partitions {
+        writer.write_partition(key, muts).unwrap();
+    }
+    let info = writer.finish().await.unwrap();
+    let data_path = info.data_path.clone();
+    (temp, data_path)
+}
+
+/// Issue #2366 (roborev follow-up): every fixture above tops out well under
+/// `SEQUENTIAL_WINDOW_TARGET_BYTES` (4 MiB), so `seek_calls == 1` in each of
+/// them and the multi-window-refill path — a partition's slice NOT starting at
+/// `window_start == 0` (`lo != 0`) — never actually ran. This fixture forces it:
+///
+/// - 50 ordinary single-row partitions × 100 KB ≈ 4.9 MiB total, so the walk
+///   must refill AT LEAST once among just these (they alone exceed the 4 MiB
+///   target).
+/// - ONE wide (10-row, clustered) partition whose combined span ≈ 5 MB ALONE
+///   exceeds the 4 MiB window target, forcing `want == span` — i.e. the window
+///   is sized to exactly that partition (`lo == 0`, `hi == span == window.len()`,
+///   the single-large-partition clamp roborev asked to pin). Built from
+///   MULTIPLE rows rather than one giant cell specifically to avoid the
+///   unrelated single-cell defect documented on [`wide_schema`].
+///
+/// Partitions are token-sorted before writing (this file's convention), so the
+/// wide partition's position relative to the small ones — and hence the exact
+/// refill count — is NOT controlled; the assertions are robust to that:
+/// `seek_calls() >= 2` proves multiple windows fired regardless of order.
+/// MEASURED (this fixture, 51 partitions / 60 rows, ≈9.9 MiB Data.db):
+/// `INDEX_PROBES == 0`, `seek_calls() == 3` (3 sequential window reads,
+/// not one per partition).
+///
+/// Asserts ROW-FOR-ROW parity (not just key order) against the materialising
+/// sibling `iterate_all_partitions` — `(RowKey, ScanRow)` both derive
+/// `PartialEq`, so this also proves the wide partition's rows round-tripped
+/// intact through the windowed read, not just that some row with that key
+/// arrived.
+///
+/// `#[serial(work_counters)]`: `INDEX_PROBES`/`SEEK_CALLS` are process-global.
+#[tokio::test]
+#[serial(work_counters)]
+async fn windowed_stream_multi_refill_and_large_partition_clamp_parity() {
+    use crate::storage::sstable::read_work_counters as rwc;
+
+    const SMALL_COUNT: usize = 50;
+    const SMALL_TEXT_LEN: usize = 100_000; // 50 × 100 KB ≈ 4.9 MiB > 4 MiB target.
+    const WIDE_ROW_COUNT: usize = 10;
+    const WIDE_ROW_TEXT_LEN: usize = 500_000; // 10 × 500 KB ≈ 5 MB > 4 MiB target.
+    let expected_rows = SMALL_COUNT + WIDE_ROW_COUNT;
+
+    let (_temp, data_path) = write_multi_window_fixture(
+        SMALL_COUNT,
+        SMALL_TEXT_LEN,
+        WIDE_ROW_COUNT,
+        WIDE_ROW_TEXT_LEN,
+    )
+    .await;
+    let reader = open_reader(&data_path).await;
+    let cancel = ScanCancel::default();
+
+    rwc::reset();
+    let mut streamed: Vec<(crate::RowKey, crate::types::ScanRow)> = Vec::new();
+    let outcome = reader
+        .stream_all_partitions_via_full_index(&cancel, &mut |row| {
+            streamed.push(row);
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, FullIndexStreamOutcome::Streamed),
+        "a full-Index.db fixture must stream via the index walk, not fall back"
+    );
+    assert_eq!(
+        streamed.len(),
+        expected_rows,
+        "the windowed walk must emit every one of the {expected_rows} rows \
+         ({SMALL_COUNT} single-row partitions + {WIDE_ROW_COUNT} rows in the wide partition)"
+    );
+
+    // The defining new-behavior evidence (this roborev round): the read pattern
+    // actually crosses a window boundary — unreachable by any prior (tiny)
+    // fixture. Zero index probes still holds regardless of fixture size.
+    assert_eq!(
+        rwc::index_probes(),
+        0,
+        "the windowed walk must perform ZERO Index.db probes regardless of fixture size"
+    );
+    let seeks = rwc::seek_calls();
+    assert!(
+        seeks >= 2,
+        "a >4 MiB Data.db (small partitions ≈4.9 MiB + a wide partition ≈5 MB) \
+         must force at least 2 window refills (got {seeks}) — proves the \
+         multi-window-refill path actually ran, not just the single-window case \
+         every prior (tiny) fixture exercised"
+    );
+
+    // Row-for-row parity across the refill boundary/boundaries: identical to
+    // the materialising sibling, including the wide partition's rows read via
+    // the `want == span` window-sizing clamp.
+    let materialised = reader.iterate_all_partitions().await.unwrap();
+    assert_eq!(
+        streamed, materialised,
+        "windowed streaming rows (key AND decoded value) must be IDENTICAL to \
+         the materialising sibling across the window-refill boundary — proves \
+         `window_start` advances correctly and every partition's slice \
+         (including the large single-partition clamp) is read intact"
     );
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -302,3 +302,150 @@ async fn sequential_scan_fallback_counts_each_partition_exactly_once() {
          in stream_all_partitions_cancellable must not increment again"
     );
 }
+
+/// Issue #2366 (AC #1 parity, larger fixture): over an N ≥ 50 uncompressed
+/// fixture the sequential-window streaming walk emits EVERY partition, in the
+/// SAME token order, with IDENTICAL keys to the materialising sibling
+/// `iterate_all_partitions` — the parity pin proving the window-served slices
+/// decode to exactly the same partitions as the old per-partition positioned
+/// reads. Larger than the smoke fixtures so several partitions share one window.
+///
+/// `#[serial(work_counters)]`: see
+/// `stream_all_partitions_cancellable_emits_every_partition`.
+#[tokio::test]
+#[serial(work_counters)]
+async fn windowed_stream_matches_materialising_over_larger_fixture() {
+    const N: i32 = 60;
+    let (_temp, data_path) = write_fixture(N).await;
+    let reader = open_reader(&data_path).await;
+    let cancel = ScanCancel::default();
+
+    let mut streamed_keys: Vec<crate::RowKey> = Vec::new();
+    let outcome = reader
+        .stream_all_partitions_via_full_index(&cancel, &mut |(key, _value)| {
+            streamed_keys.push(key);
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, FullIndexStreamOutcome::Streamed),
+        "a full-Index.db fixture must stream via the index walk, not fall back"
+    );
+
+    let materialised: Vec<crate::RowKey> = reader
+        .iterate_all_partitions()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(k, _)| k)
+        .collect();
+    assert_eq!(
+        streamed_keys.len(),
+        N as usize,
+        "the windowed streaming walk must emit every one of the {N} partitions"
+    );
+    assert_eq!(
+        streamed_keys, materialised,
+        "windowed streaming emission must be key-for-key IDENTICAL (order + \
+         content) to the materialising sibling — the merge-input parity pin (#2366)"
+    );
+}
+
+/// Issue #2366 (AC #1 wiring): the SAME parity holds end-to-end through the real
+/// flight full-scan producer surface `stream_all_partitions_for_compaction` (the
+/// non-stitching branch routes to the windowed streaming walk). Proves the fix
+/// is exercised by the public producer seam, not just the private helper.
+///
+/// `#[serial(work_counters)]`: see
+/// `stream_all_partitions_cancellable_emits_every_partition`.
+#[tokio::test]
+#[serial(work_counters)]
+async fn stream_for_compaction_emits_every_partition_windowed() {
+    const N: i32 = 50;
+    let (_temp, data_path) = write_fixture(N).await;
+    let reader = open_reader(&data_path).await;
+    let cancel = ScanCancel::default();
+
+    let mut emitted = 0usize;
+    reader
+        .stream_all_partitions_for_compaction(None, &cancel, |_row| {
+            emitted += 1;
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        emitted, N as usize,
+        "the flight full-scan producer surface must emit every one of the {N} \
+         partitions through the windowed non-stitching branch"
+    );
+}
+
+/// Issue #2366 (AC #3 read-pattern benchmark, work-counters): after the windowed
+/// streaming walk over a LARGE uncompressed fixture (N = 500) the read pattern is
+/// O(N/window), not O(N):
+///
+/// - `INDEX_PROBES == 0` (was `== N` before this change — one HashMap probe per
+///   partition via the dropped `lookup_partition_with_index`); the offset now
+///   comes straight from the in-memory offset table.
+/// - `seek_calls()` (one per sequential window refill) is DRAMATICALLY fewer than
+///   the partition count — the O(N)→O(N/window) reduction. The tiny single-row
+///   partitions here pack many per 4 MiB window, so in practice this is a handful
+///   of refills for 500 partitions.
+///
+/// MEASURED (this fixture, 500 single-row int/text partitions):
+///   before: INDEX_PROBES == 500, positioned reads == 500 (one per partition)
+///   after:  INDEX_PROBES == 0,   seek_calls (window refills) == 1
+/// The field ideal (a 1.13M-partition table's wall-time on the #2362/#2157/#2264
+/// live testbed) is NOT reproducible locally; this probe/seek count reduction is
+/// the acceptable substitute the issue permits.
+///
+/// `#[serial(work_counters)]`: `INDEX_PROBES`/`SEEK_CALLS` are process-global.
+#[tokio::test]
+#[serial(work_counters)]
+async fn windowed_stream_read_pattern_is_sequential() {
+    use crate::storage::sstable::read_work_counters as rwc;
+    const N: i32 = 500;
+    let (_temp, data_path) = write_fixture(N).await;
+    let reader = open_reader(&data_path).await;
+    let cancel = ScanCancel::default();
+
+    rwc::reset();
+    let mut emitted = 0usize;
+    let outcome = reader
+        .stream_all_partitions_via_full_index(&cancel, &mut |_row| {
+            emitted += 1;
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(outcome, FullIndexStreamOutcome::Streamed),
+        "the large fixture must stream via the index walk"
+    );
+    assert_eq!(emitted, N as usize, "must emit every one of the {N} partitions");
+
+    // AC #3: zero per-partition index probes (was N before #2366).
+    assert_eq!(
+        rwc::index_probes(),
+        0,
+        "the windowed walk must perform ZERO Index.db probes (offset read \
+         directly from the in-memory offset table) — was {N} before #2366"
+    );
+    // AC #3: sequential window refills, not one read per partition. Assert well
+    // below the partition count (the O(N)→O(N/window) reduction). It is exactly 1
+    // for this tiny-partition fixture, but pin the invariant loosely so the
+    // benchmark stays robust to fixture-size / window-target tweaks.
+    let seeks = rwc::seek_calls();
+    assert!(
+        seeks < N as u64 / 4,
+        "window refills ({seeks}) must be dramatically fewer than the {N} \
+         partitions (O(N/window) sequential reads, not O(N) random reads — #2366)"
+    );
+    assert!(
+        seeks >= 1,
+        "a non-empty scan must perform at least one window read ({seeks})"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -425,7 +425,10 @@ async fn windowed_stream_read_pattern_is_sequential() {
         matches!(outcome, FullIndexStreamOutcome::Streamed),
         "the large fixture must stream via the index walk"
     );
-    assert_eq!(emitted, N as usize, "must emit every one of the {N} partitions");
+    assert_eq!(
+        emitted, N as usize,
+        "must emit every one of the {N} partitions"
+    );
 
     // AC #3: zero per-partition index probes (was N before #2366).
     assert_eq!(


### PR DESCRIPTION
Closes #2366

## Problem
PR #2364 (issue #2361) fixed the full-scan hang/unbounded-memory failure by making the non-stitching (uncompressed BIG) full-scan walk emit per-partition instead of materialising a whole-file `Vec`. But that streaming walk still performed **one random `Index.db` probe + one positioned `Data.db` seek+read+CRC per partition** — ~1.13M random ops per SSTable at field scale. That's the throughput cliff this issue closes: minutes-scale full scans, now visible as sustained `stream`-phase activity rather than a hang.

## Fix
In `stream_all_partitions_via_full_index` (`cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs`):

1. **Drop the redundant index probe.** `entries[i].data_offset` is already in memory (used by the up-front structural gates and by `next_offset`) — it is the exact value `lookup_partition_with_index` would return via a HashMap probe. Read it directly instead of re-probing. Removes O(partitions) `INDEX_PROBES`.
2. **Replace the per-partition positioned read with a bounded, forward-only sequential read window.** Entries are walked in ascending `data_offset` order (== token order == Data.db physical order), so a `window: Vec<u8>` covering `[window_start, window_start+len)` serves each partition's slice; it refills — advancing `window_start` forward — only when the next partition isn't fully covered, reading `max(span, 4 MiB)` clamped to the data-section end via one CRC-verified `read_uncompressed_verified` call. This turns O(partitions) random reads into O(data_section_len / window) sequential reads, with peak memory bounded by `max(4 MiB, largest_partition_span)`.

Preserved unchanged: token-order emission, the `check_token_order` fail-closed monotonicity guard (#2361), the `partition_slice_fully_consumed` structural completeness check (#2302), `filter_tombstone`, the `add_stream_walk_partition_parsed` work-probe, CRC verification of every byte returned, and all up-front `FellBack` gates (nothing emitted before them, so the materialising `sequential_scan` fallback stays safe). The rare non-nb *compressed* non-stitching branch is untouched (out of scope — this issue targets the uncompressed field case; the compressed-nb stitching branch already streams through a proper sliding window).

## Test evidence
- **Parity (AC #2):** new test asserts the windowed streaming walk is row-for-row IDENTICAL to the materialising sibling `iterate_all_partitions_via_full_index`, including across a window-refill boundary and through the `want == span` large-partition clamp. Existing sstabledump physical-dump goldens (13/13) and `query_semantics_oracle_parity` (3/3) both stay green — untouched by this change's scope (compaction/point-read paths not modified).
- **Read-pattern / benchmark evidence (AC #3):** work-counter pins — `index_probes() == 0` (was `== N` before) on every fixture; a ~9.9 MiB / 51-partition fixture crossing multiple window boundaries measures `seek_calls() == 3` (was `== 51` before), demonstrating the O(N) -> O(N/window) read-pattern change. Every prior (tiny, <4 MiB) fixture only ever produced `seek_calls == 1`, so a dedicated multi-window fixture was added specifically to exercise the refill path (this was the one review finding from rust-reviewer + roborev, addressed below).
- **Honest gap:** field-scale wall-time on the actual 1.13M-partition table needs the live testbed (#2362/#2157/#2264), unavailable in this environment. The counter-based read-pattern measurement above is the substitute the issue's AC #3 explicitly permits; it directly demonstrates the mechanism (random-probe elimination + O(N)->O(N/window) I/O) that produces the wall-time improvement at field scale, but does not itself measure field wall-time.

## Review history
- rust-reviewer + roborev (branch review, job 24) both reviewed the lite-green diff before any full gate (review-first). Both converged on the SAME single finding: the multi-window-refill / large-partition-clamp path was untested (every fixture was <4 MiB, so `seek_calls` was always 1). Fixed with a dedicated fixture (51 partitions / ~9.9 MiB, one partition's own span exceeding the 4 MiB window target) proving parity + `seek_calls >= 2`. One doc-only nit (observability divergence: dropping the probe also intentionally skips `READ_PARTITION_LOOKUP`/B4-cache population on this path) folded into the same commit.
- Both reviewers independently proved the window arithmetic panic-free (no underflow/overflow/out-of-bounds across all up-front-gated invariants) and confirmed no behavior was weakened.

## Out-of-scope finding (filed separately, NOT fixed here)
While building a large-partition test fixture, discovered a genuinely serious, UNRELATED, pre-existing defect: a single-cell `Value::Text`/`Value::Blob` write/read round-trip silently drops the entire row (no error) once the cell's serialized size crosses a boundary between ~950KB and ~1MB. Confirmed present on unmodified `main`. Filed as #2436 (P0, bug); linked from #2366 for traceability. Worked around in this PR's test fixture by using a multi-row clustered partition instead of one oversized single-cell value.
