### PR TITLE
fix(#2428): test-local StreamWalkScope — end work-counter cross-test contamination under thread-parallel cargo test

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -20,7 +20,6 @@ use crate::storage::sstable::reader::SSTableReader;
 use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
 use crate::types::Value;
 use crate::{Config, Platform};
-use serial_test::serial;
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -106,13 +105,13 @@ async fn open_reader(data_path: &std::path::Path) -> SSTableReader {
 /// Non-vacuity + full enumeration (issue #2361): `stream_all_partitions_cancellable`
 /// (no `limit` parameter) emits every one of the fixture's `N` partitions.
 ///
-/// `#[serial(work_counters)]` (issue #2398, roborev 1693): this walk increments
-/// the process-global `stream_walk_partitions_parsed` counter as a side effect;
-/// every test in this file that does so shares the `work_counters` key so none
-/// contaminates `sequential_scan_fallback_counts_each_partition_exactly_once`'s
-/// delta assertion (the established convention, issue #1071).
+/// No `#[serial(work_counters)]` needed (issue #2428): this walk bumps the
+/// process-global `stream_walk_partitions_parsed` counter as a side effect, but
+/// the only test that ASSERTS a delta on it
+/// (`sequential_scan_fallback_counts_each_partition_exactly_once`) measures
+/// through a thread-local scope immune to concurrent increments, so no sibling
+/// serialization is required.
 #[tokio::test]
-#[serial(work_counters)]
 async fn stream_all_partitions_cancellable_emits_every_partition() {
     const N: i32 = 24;
     let (_temp, data_path) = write_fixture(N).await;
@@ -139,10 +138,9 @@ async fn stream_all_partitions_cancellable_emits_every_partition() {
 /// `Streamed`), in index (token) order, emitting each as it is resolved rather
 /// than after a whole-file materialisation. Non-vacuity: all N rows arrive.
 ///
-/// `#[serial(work_counters)]`: see the doc on
+/// No `#[serial(work_counters)]` needed (issue #2428): see the doc on
 /// `stream_all_partitions_cancellable_emits_every_partition` above.
 #[tokio::test]
-#[serial(work_counters)]
 async fn stream_via_full_index_streams_every_partition_in_order() {
     const N: i32 = 16;
     let (_temp, data_path) = write_fixture(N).await;
@@ -192,10 +190,9 @@ async fn stream_via_full_index_streams_every_partition_in_order() {
 /// the pre-#2361 code the whole SSTable was materialised into a `Vec` BEFORE the
 /// first emit, so a break could never save that work; here it does.
 ///
-/// `#[serial(work_counters)]`: see the doc on
+/// No `#[serial(work_counters)]` needed (issue #2428): see the doc on
 /// `stream_all_partitions_cancellable_emits_every_partition` above.
 #[tokio::test]
-#[serial(work_counters)]
 async fn stream_all_partitions_cancellable_stops_on_break() {
     const N: i32 = 20;
     let (_temp, data_path) = write_fixture(N).await;
@@ -220,10 +217,9 @@ async fn stream_all_partitions_cancellable_stops_on_break() {
 /// walk promptly, emitting nothing and returning `Error::Cancelled` — the
 /// cooperative poll at the top of the streaming walk.
 ///
-/// `#[serial(work_counters)]`: see the doc on
+/// No `#[serial(work_counters)]` needed (issue #2428): see the doc on
 /// `stream_all_partitions_cancellable_emits_every_partition` above.
 #[tokio::test]
-#[serial(work_counters)]
 async fn stream_all_partitions_cancellable_pre_cancel_emits_nothing() {
     const N: i32 = 12;
     let (_temp, data_path) = write_fixture(N).await;
@@ -255,13 +251,19 @@ async fn stream_all_partitions_cancellable_pre_cancel_emits_nothing() {
 /// `sequential_scan`'s internal accounting — never `2 * N` (the double-count a
 /// redundant increment in the fallback's re-emit loop would produce).
 ///
-/// `#[serial(work_counters)]`: `stream_walk_partitions_parsed` is a process-global
-/// counter (issue #1071's established convention) — every OTHER test in this file
-/// that touches it shares this key so this delta assertion cannot be contaminated
-/// by a concurrently-running sibling.
+/// Contamination-proof by construction (issue #2428): the assertion measures the
+/// delta through a thread-local
+/// [`StreamWalkScope`](crate::storage::sstable::work_counters::stream_walk_scope::StreamWalkScope),
+/// NOT the process-global `stream_walk_partitions_parsed()` getter. The scope
+/// records only increments that execute on THIS test's own thread, so a
+/// concurrent scan-driving test on another thread (under thread-parallel
+/// `cargo test --lib`, the CI Required-PR-Gate invocation, which does not isolate
+/// tests per-process like nextest) cannot inflate the count. That is why this
+/// test needs no `#[serial(work_counters)]` tag and no global `reset()`. See the
+/// `work_counters::stream_walk_scope` module doc for the full rationale.
 #[tokio::test]
-#[serial(work_counters)]
 async fn sequential_scan_fallback_counts_each_partition_exactly_once() {
+    use crate::storage::sstable::work_counters::stream_walk_scope::StreamWalkScope;
     const N: i32 = 10;
     let (_temp, data_path) = write_fixture(N).await;
     // Force the fallback: delete the sibling Index.db so `index_reader` is `None`
@@ -280,7 +282,13 @@ async fn sequential_scan_fallback_counts_each_partition_exactly_once() {
     );
     let cancel = ScanCancel::default();
 
-    crate::storage::sstable::work_counters::reset();
+    // Open the recording scope BEFORE the inline scan; it counts only this
+    // thread's increments, so a concurrent scan-driving test on another thread
+    // cannot contaminate the delta (issue #2428). No global `reset()` / getter
+    // and no `#[serial(work_counters)]` needed: the fallback runs
+    // `sequential_scan` INLINE (no `spawn`) on the current-thread runtime, so
+    // every increment lands on this thread.
+    let scope = StreamWalkScope::new();
     let mut emitted = 0usize;
     reader
         .stream_all_partitions_cancellable(&cancel, |_row| {
@@ -295,7 +303,7 @@ async fn sequential_scan_fallback_counts_each_partition_exactly_once() {
         "the fallback must emit every partition"
     );
     assert_eq!(
-        crate::storage::sstable::work_counters::stream_walk_partitions_parsed(),
+        scope.count(),
         N as u64,
         "the fallback must count each partition body EXACTLY ONCE (not 2x — \
          roborev 1693): sequential_scan owns the increment, the re-emit loop \

--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -355,6 +355,8 @@ pub fn add_data_db_checksum_full_read() {
 /// (same rationale as the other read-work counters).
 pub(crate) fn add_stream_walk_partition_parsed() {
     COUNTERS.add_stream_walk_partition_parsed();
+    #[cfg(test)]
+    stream_walk_scope::record();
 }
 
 /// Number of partition bodies a `do_get` scan read + parsed since the last
@@ -366,8 +368,119 @@ pub(crate) fn add_stream_walk_partition_parsed() {
 /// today this reads the full count for any overlapping SSTable — the fixed
 /// warm-scan setup cost independent of the split range and of `LIMIT` that issue
 /// #2398 tracks.
+///
+/// This global getter is for CROSS-THREAD / integration observability (a
+/// detached compaction producer thread bumping the counter, read from the test
+/// thread). A same-thread *delta* assertion — "this scan drove EXACTLY N
+/// partition parses" — must NOT use it: the counter is process-global, so a
+/// concurrent test on another thread contaminates the delta under thread-parallel
+/// `cargo test` (issue #2428). Such assertions use [`stream_walk_scope`]'s
+/// thread-local [`StreamWalkScope`](stream_walk_scope::StreamWalkScope) instead,
+/// which is immune by construction.
 pub fn stream_walk_partitions_parsed() -> u64 {
     COUNTERS.stream_walk_partitions_parsed()
+}
+
+/// Thread-local scoping for [`stream_walk_partitions_parsed`] delta assertions
+/// (issue #2428).
+///
+/// # Why this exists
+///
+/// [`stream_walk_partitions_parsed`] is a process-global `AtomicU64` shared by
+/// every read-path scan and every test that drives one. A test that asserts a
+/// *delta* — "my scan drove EXACTLY N partition parses" — by
+/// `reset()`-ing the global, scanning, then reading the global back is
+/// contaminated the moment ANY other test in the same test binary drives a scan
+/// concurrently between the reset and the read: under thread-parallel
+/// `cargo test --lib --all-features` (the CI "Required PR Gate" invocation, which
+/// does NOT use nextest's per-process isolation) the observed delta jumps to an
+/// arbitrary inflated value. `#[serial(work_counters)]` only serialises tests
+/// that BOTH carry the tag, so a single untagged scan-driving test anywhere in
+/// the crate reintroduces the flake — a fragile, easy-to-miss invariant across a
+/// large and growing set of reachable tests.
+///
+/// # The structural fix
+///
+/// cargo runs each `#[test]` on its own OS thread, and a default (current-thread)
+/// `#[tokio::test]` drives all of its `.await`s on that one thread. So a
+/// thread-local counter, activated for the duration of one test's scan, records
+/// ONLY the increments that execute on that test's own thread — structurally
+/// immune to any concurrent test on another thread mutating the process-global
+/// counter. A delta assertion opens a [`StreamWalkScope`] before its scan and
+/// reads [`StreamWalkScope::count`] after; no `reset()`, no global read, no
+/// serial tag, and no way for a future scan-driving test to contaminate it.
+///
+/// # Boundaries
+///
+/// The scope only sees increments on THE THREAD that opened it, so it is for
+/// same-thread delta assertions of an inline (non-`spawn`) scan. A scan that
+/// fans work onto detached producer threads (the compaction merge path) would
+/// bump the global on those threads without touching the scope — such tests keep
+/// using the global [`stream_walk_partitions_parsed`] getter. This module is
+/// `#[cfg(test)]`: it exists only in the library's own test build (the binary
+/// where the contamination occurs); integration tests in `tests/` compile the
+/// library without its `test` cfg and never see it.
+#[cfg(test)]
+pub(crate) mod stream_walk_scope {
+    use std::cell::Cell;
+
+    thread_local! {
+        /// `Some(count)` while a [`StreamWalkScope`] is active on this thread,
+        /// `None` otherwise. Only `add_stream_walk_partition_parsed()` calls that
+        /// execute on this thread bump it.
+        static SCOPED: Cell<Option<u64>> = const { Cell::new(None) };
+    }
+
+    /// Bump the active scope on the current thread, if any. A no-op on threads
+    /// (production scans, detached producers, other tests) with no active scope.
+    pub(crate) fn record() {
+        SCOPED.with(|c| {
+            if let Some(v) = c.get() {
+                c.set(Some(v.saturating_add(1)));
+            }
+        });
+    }
+
+    /// A per-thread recording scope for `stream_walk_partitions_parsed`. Open one
+    /// before an inline scan whose partition-parse count you assert, and read
+    /// [`count`](StreamWalkScope::count) after. Immune to concurrent tests on
+    /// other threads (issue #2428). Dropping it clears the scope.
+    ///
+    /// Deliberately `!Send` (holds a `PhantomData<*const ()>`): the scope is
+    /// meaningful only on the thread that opened it, so the type system forbids
+    /// moving it to another thread where its `count()` would be wrong.
+    pub(crate) struct StreamWalkScope {
+        _not_send: std::marker::PhantomData<*const ()>,
+    }
+
+    impl StreamWalkScope {
+        /// Begin recording on the current thread. Panics if a scope is already
+        /// active on this thread (one scope per assertion; nesting unsupported).
+        pub(crate) fn new() -> Self {
+            SCOPED.with(|c| {
+                assert!(
+                    c.get().is_none(),
+                    "a StreamWalkScope is already active on this thread (nesting unsupported)"
+                );
+                c.set(Some(0));
+            });
+            Self {
+                _not_send: std::marker::PhantomData,
+            }
+        }
+
+        /// Partition-parse increments recorded on this thread since the scope
+        /// opened.
+        pub(crate) fn count(&self) -> u64 {
+            SCOPED.with(|c| c.get().unwrap_or(0))
+        }
+    }
+
+    impl Drop for StreamWalkScope {
+        fn drop(&mut self) {
+            SCOPED.with(|c| c.set(None));
+        }
+    }
 }
 
 /// Number of full `Data.db` re-reads performed for checksum computation since
@@ -496,5 +609,80 @@ mod tests {
         assert_eq!(c.partitions_decoded(), 0);
         assert_eq!(c.chunks_decompressed(), 0);
         assert_eq!(c.rows_decoded(), 0);
+    }
+}
+
+// NB: this module is gated ONLY on `test` (NOT `not(tombstones)`): the CI
+// Required-PR-Gate invocation this issue exists to fix is
+// `cargo test --lib --all-features`, which enables `tombstones`. The
+// `add_stream_walk_partition_parsed` mutator and the `stream_walk_scope` are both
+// present under every feature set, so this regression must run under all of them.
+#[cfg(test)]
+mod stream_walk_scope_tests {
+    use super::*;
+
+    /// Structural regression for issue #2428: a [`StreamWalkScope`] records ONLY
+    /// the `add_stream_walk_partition_parsed()` increments that execute on its own
+    /// thread, so a *concurrent* thread bumping the same process-global counter
+    /// cannot contaminate a same-thread delta assertion.
+    ///
+    /// This is the mechanism that made
+    /// `sequential_scan_fallback_counts_each_partition_exactly_once` flake under
+    /// thread-parallel `cargo test --lib` (the CI Required-PR-Gate invocation,
+    /// which does NOT isolate tests per-process like nextest): another
+    /// scan-driving test running between that test's `reset()` and its read
+    /// inflated the observed global delta. Here we reproduce that exact shape —
+    /// a foreign thread hammering the global while a scope is open — and prove the
+    /// scoped count stays exactly the number of increments made on THIS thread.
+    #[test]
+    fn stream_walk_scope_is_immune_to_a_concurrent_thread() {
+        use super::stream_walk_scope::StreamWalkScope;
+        use std::sync::mpsc;
+
+        const LOCAL: u64 = 10; // mirrors the flaky test's N
+        const FOREIGN: u64 = 500; // the contaminating "other test" load
+
+        let scope = StreamWalkScope::new();
+
+        // A foreign thread bumps the SAME process-global counter (its own thread
+        // has no active scope, so `record()` is a no-op there). Handshakes force
+        // its increments to interleave DURING this thread's scope, exactly like a
+        // concurrent scan-driving test.
+        let (started_tx, started_rx) = mpsc::channel::<()>();
+        let (proceed_tx, proceed_rx) = mpsc::channel::<()>();
+        let foreign = std::thread::spawn(move || {
+            started_tx.send(()).expect("send started");
+            proceed_rx.recv().expect("recv proceed");
+            for _ in 0..FOREIGN {
+                add_stream_walk_partition_parsed();
+            }
+        });
+
+        started_rx.recv().expect("foreign thread must start");
+        // Bump on THIS thread before, ...
+        for _ in 0..(LOCAL / 2) {
+            add_stream_walk_partition_parsed();
+        }
+        // ... let the foreign thread run its whole contaminating load, ...
+        proceed_tx.send(()).expect("release foreign thread");
+        foreign.join().expect("foreign thread must not panic");
+        // ... and after. The foreign 500 landed squarely between our increments.
+        for _ in 0..(LOCAL - LOCAL / 2) {
+            add_stream_walk_partition_parsed();
+        }
+
+        assert_eq!(
+            scope.count(),
+            LOCAL,
+            "the scope must count only this thread's {LOCAL} increments, never the \
+             foreign thread's {FOREIGN} on the shared global (issue #2428)"
+        );
+        drop(scope);
+        // After drop the scope is cleared: a fresh increment records nowhere.
+        assert_eq!(
+            StreamWalkScope::new().count(),
+            0,
+            "a fresh scope starts at zero (the previous scope's count did not leak)"
+        );
     }
 }


### PR DESCRIPTION
Closes #2428.

## What
`sequential_scan_fallback_counts_each_partition_exactly_once` flaked in CI's Required PR Gate (42 vs 10) because its delta assertion read the process-global `stream_walk_partitions_parsed` AtomicU64 while unrelated concurrent tests incremented it — `#[serial(work_counters)]` only serializes same-tag tests, and the inventory found ~10+ untagged tests reaching the 4 increment sites. Local nextest (per-process isolation) never reproduces it; CI's thread-parallel `cargo test --all-features` does.

Fix = the issue's preferred structural option: a `#[cfg(test)]` thread-local `StreamWalkScope` (work_counters.rs) — the assertion measures its own thread's increments only, contamination-proof by construction. `!Send` marker, Drop-clears, nesting panic guard. Redundant serial tags removed. Production builds: zero change (plain atomic, scope module is cfg(test)).

## Evidence
- New immunity test `stream_walk_scope_is_immune_to_a_concurrent_thread`: mpsc-handshake forces a foreign thread's 500 increments to interleave inside the scope; scope reads exactly 10.
- Non-vacuity: assertion expects `scope.count() == 10` (an off-thread hop regression reads 0 and FAILS, never passes silently).
- 6/6 thread-parallel `cargo test -p cqlite-core --lib --all-features` runs green (the exact CI invocation).

## Review trail (review-first, #2086)
- roborev job 1710: clean — verified inline-await (no spawn hop), no remaining global-delta victim, marker/Drop/nesting correct.
- rust-reviewer: no blockers — verified thread-locality soundness (increment sites lexically inside sequential_scan's async body; current-thread runtime), the only other consumer (issue_2398 pin) is a separate single-test binary immune by construction; 2 stale-doc nits → follow-up at merge.

Full gate of record: run by flow-closer pre-merge (lite PASS at 93c91668).