### PR TITLE
feat(#2412): lazy Summary-guided BIG index — O(summary) open, bounded point intervals, streaming scans (+#2413 token pushdown)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -176,6 +176,20 @@ pub const READ_DURATION: &str = "cqlite.read.duration";
 /// high-cardinality attributes.
 pub const INDEX_PARSES_TOTAL: &str = "cqlite.sstable.index_parses_total";
 
+/// `cqlite.sstable.index_interval_parses_total` — counter `1` (issue #2412).
+///
+/// Incremented once per **bounded** `Index.db` interval parse performed by the
+/// lazy Summary-guided BIG partition index: a point lookup binary-searches
+/// `Summary.db`, seeks to the covering sample's position, and parses at most one
+/// `min_index_interval` of entries (§B of the #2412 design). This is a DISTINCT
+/// counter from [`INDEX_PARSES_TOTAL`], which continues to count only WHOLE-file
+/// `Index.db` parses (so a lazy-open regression that accidentally full-parses is
+/// still visible there, exactly as the #2367 field rounds check). A cold lazy
+/// open of K generations yields `index_parses_total += 0` and
+/// `index_interval_parses_total += 0`, then `+= 1` per point lookup — the
+/// scale-free work-probe for #2412. No high-cardinality attributes.
+pub const INDEX_INTERVAL_PARSES_TOTAL: &str = "cqlite.sstable.index_interval_parses_total";
+
 /// `cqlite.storage.open.sstables` — counter `{sstable}`.
 ///
 /// SSTables discovered and opened by a single [`StorageEngine`] open, summed
@@ -651,6 +665,7 @@ pub const ALL_METRICS: &[&str] = &[
     MERGE_ROWS_OUT,
     QUERY_DEGRADED_PATH,
     INDEX_PARSES_TOTAL,
+    INDEX_INTERVAL_PARSES_TOTAL,
     STORAGE_OPEN_SSTABLES,
     STORAGE_OPEN_BYTES,
     STORAGE_OPEN_TABLES,
@@ -789,6 +804,22 @@ mod tests {
         assert!(ALL_METRICS.contains(&INDEX_PARSES_TOTAL));
         assert_eq!(INDEX_PARSES_TOTAL, "cqlite.sstable.index_parses_total");
         assert!(INDEX_PARSES_TOTAL.starts_with("cqlite."));
+    }
+
+    #[test]
+    fn index_interval_parses_counter_is_distinct_registered_and_namespaced() {
+        // Issue #2412 spec Requirement 5: the bounded interval-parse counter is a
+        // DISTINCT catalog metric (never conflated with full parses), catalogued so
+        // the registration/uniqueness checks cover it, and rooted under `cqlite.`.
+        assert!(ALL_METRICS.contains(&INDEX_INTERVAL_PARSES_TOTAL));
+        assert_eq!(
+            INDEX_INTERVAL_PARSES_TOTAL,
+            "cqlite.sstable.index_interval_parses_total"
+        );
+        assert!(INDEX_INTERVAL_PARSES_TOTAL.starts_with("cqlite."));
+        // Distinct from the full-parse counter — the two must never collapse to one
+        // name (a lazy-open regression must stay visible on INDEX_PARSES_TOTAL).
+        assert_ne!(INDEX_INTERVAL_PARSES_TOTAL, INDEX_PARSES_TOTAL);
     }
 
     #[test]

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -275,6 +275,7 @@ struct Instruments {
     merge_rows_out: Counter<u64>,
     query_degraded_path: Counter<u64>,
     index_parses_total: Counter<u64>,
+    index_interval_parses_total: Counter<u64>,
     storage_open_sstables: Counter<u64>,
     storage_open_bytes: Counter<u64>,
     storage_open_tables: Counter<u64>,
@@ -387,6 +388,13 @@ fn instruments() -> &'static Instruments {
                 .u64_counter(catalog::INDEX_PARSES_TOTAL)
                 .with_unit(catalog::unit::DIMENSIONLESS)
                 .with_description("Full Index.db partition-index parses (#2383 spin probe).")
+                .build(),
+            index_interval_parses_total: m
+                .u64_counter(catalog::INDEX_INTERVAL_PARSES_TOTAL)
+                .with_unit(catalog::unit::DIMENSIONLESS)
+                .with_description(
+                    "Bounded Summary-guided Index.db interval parses, per point lookup (issue #2412).",
+                )
                 .build(),
             storage_open_sstables: m
                 .u64_counter(catalog::STORAGE_OPEN_SSTABLES)
@@ -612,6 +620,7 @@ pub(crate) fn add_counter(name: &'static str, value: u64, attributes: &[KeyValue
         catalog::MERGE_ROWS_OUT => &i.merge_rows_out,
         catalog::QUERY_DEGRADED_PATH => &i.query_degraded_path,
         catalog::INDEX_PARSES_TOTAL => &i.index_parses_total,
+        catalog::INDEX_INTERVAL_PARSES_TOTAL => &i.index_interval_parses_total,
         catalog::STORAGE_OPEN_SSTABLES => &i.storage_open_sstables,
         catalog::STORAGE_OPEN_BYTES => &i.storage_open_bytes,
         catalog::STORAGE_OPEN_TABLES => &i.storage_open_tables,

--- a/cqlite-core/src/storage/sstable/index_reader/lazy.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/lazy.rs
@@ -7,7 +7,7 @@
 //! type, used only by `SSTableReader`'s BIG-open composition
 //! (`reader::component_loading::load_index_reader`).
 
-use super::parse::parse_index_data_cancellable;
+use super::parse::{parse_big_index_entry, parse_index_data_cancellable};
 use super::{IndexData, IndexReader};
 use crate::error::{Error, Result};
 use crate::platform::Platform;
@@ -15,6 +15,14 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
+
+/// Cap on the bounded validity-probe prefix [`IndexReader::open_lazy`] reads
+/// (issue #2302 open-time-detection preservation through the lazy-open change).
+/// Large enough to cover the WORST-CASE single `Index.db` entry — a `u16`
+/// key-length prefix (max 65535 bytes) + the raw key + two small vints — so a
+/// legitimately huge partition key can never false-trigger the probe; bounded so
+/// the probe's cost stays O(1) at open time, never O(partition count).
+const VALIDITY_PROBE_PREFIX_CAP: usize = 70_000;
 
 /// The full parse result, materialized either eagerly (at construction, the
 /// unchanged legacy behavior every direct [`IndexReader::open`] caller relies on)
@@ -51,14 +59,48 @@ impl IndexReader {
         self.materialized.get().is_some()
     }
 
-    /// Lazy Summary-guided open (issue #2412, design §A): checks only that the file
-    /// EXISTS and performs ZERO `Index.db` parse work. Used by `SSTableReader`'s BIG
-    /// open composition when a usable `Summary.db` is present, so open cost is
-    /// bounded by `Summary.db` size, not by `Index.db` partition count. The full
+    /// Lazy Summary-guided open (issue #2412, design §A): checks the file EXISTS
+    /// and is STRUCTURALLY VALID via a bounded O(1) prefix probe, but performs NO
+    /// full `Index.db` parse. Used by `SSTableReader`'s BIG open composition when a
+    /// usable `Summary.db` is present, so open cost is bounded by `Summary.db`
+    /// size + the probe's fixed cap, not by `Index.db` partition count. The full
     /// parse is deferred to the first [`Self::ensure_materialized`] call from an
     /// internal consumer that genuinely needs the resident map (a full-enumeration
     /// scan, or the point-lookup fallback before Stage 3's interval-bounded lookup
     /// lands); a point-lookup-dominated workload may never pay it at all.
+    ///
+    /// ## Open-time present-but-unloadable detection (issue #2302 contract preserved)
+    ///
+    /// A present-but-EMPTY or present-but-structurally-broken `Index.db` (open/parse
+    /// fails at the very first entry) MUST be distinguishable from a genuinely
+    /// valid file AT OPEN TIME, not only when a later consumer happens to call
+    /// [`Self::ensure_materialized`] — issue #2302 killed exactly this class of
+    /// silent degradation (the pre-#2412 eager `open` always full-parsed at open,
+    /// so a corrupt file was detected immediately; a lazy open that ONLY checked
+    /// file existence would silently regress that guarantee, reporting a broken
+    /// file as a usable lazy reader until something eventually materialized it —
+    /// possibly never, for a point-lookup-only workload). This is NOT negotiable:
+    /// open-time detection is the safer contract (`component_loading::load_index_reader`
+    /// maps any non-`NotFound` `Err` here to the loud-WARN `PresentButUnloadable`
+    /// path, exactly as the eager path always has).
+    ///
+    /// The probe: read a BOUNDED prefix (≤ [`VALIDITY_PROBE_PREFIX_CAP`] bytes, or
+    /// the whole file when smaller) and confirm the file is non-empty AND its FIRST
+    /// entry parses ([`parse_big_index_entry`]) — the SAME authoritative on-disk
+    /// entry framing `ensure_materialized`'s full parse and the eager `open` both
+    /// use (no heuristics, issue #28). This is intentionally NOT a full structural
+    /// guarantee (a corruption deep inside the file, past the first entry, is still
+    /// caught later by `is_fully_parsed()`/Signal A at first materializing use,
+    /// exactly as before this change) — it is the SAME bounded confidence the
+    /// original eager `open` effectively offered before its first byte was even
+    /// consumed, at O(1) cost instead of O(partitions).
+    ///
+    /// Not counted on EITHER `index_parses_total` or `index_interval_parses_total`:
+    /// this probe is neither a full parse nor a Summary-guided per-lookup interval
+    /// read (design §F) — conflating it with either would muddy the field-round
+    /// parse-count dashboards those counters exist for. It is deliberately silent
+    /// on success (the common case) and loud only via the `PresentButUnloadable`
+    /// WARN path on failure, matching #2302's existing observability contract.
     pub(crate) async fn open_lazy(path: &Path, platform: Arc<Platform>) -> Result<Self> {
         if !platform.fs().exists(path).await? {
             return Err(Error::not_found(format!(
@@ -66,6 +108,26 @@ impl IndexReader {
                 path.display()
             )));
         }
+
+        let mut file = File::open(path).await?;
+        let file_len = file.metadata().await?.len();
+        if file_len == 0 {
+            return Err(Error::corruption(format!(
+                "Index.db file is empty: {}",
+                path.display()
+            )));
+        }
+        let probe_len = file_len.min(VALIDITY_PROBE_PREFIX_CAP as u64) as usize;
+        let mut probe_buf = vec![0u8; probe_len];
+        file.read_exact(&mut probe_buf).await?;
+        if let Err(e) = parse_big_index_entry(&probe_buf) {
+            return Err(Error::corruption(format!(
+                "Index.db first entry failed to parse (present-but-unloadable) at {}: {:?}",
+                path.display(),
+                e
+            )));
+        }
+
         // `file_path`/`materialized` are private fields of `IndexReader`, defined in
         // the parent `index_reader` module — visible here because `lazy` is a
         // DESCENDANT module of it (Rust privacy: private items are visible to the
@@ -182,6 +244,61 @@ mod tests {
         assert_eq!(reader.get_partition_entries().len(), 1);
         assert!(reader.is_fully_parsed());
         assert!(reader.lookup_partition(&[0xAA, 0xBB, 0xCC, 0xDD]).is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Issue #2302 open-time contract, preserved through lazy open (roborev
+    /// endgame finding): a present-but-EMPTY `Index.db` must be REJECTED by
+    /// `open_lazy` itself — `Err`, never a silently "valid" lazy reader.
+    /// `component_loading::load_index_reader` maps this `Err` to the loud-WARN
+    /// `PresentButUnloadable` path (the field-level pin is
+    /// `issue_2302_written_index_resolve::present_but_unloadable_index_warns_with_summary`).
+    #[tokio::test]
+    async fn open_lazy_rejects_an_empty_file() {
+        let (dir, path) = temp_index_file("empty", &[]);
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+        let result = IndexReader::open_lazy(&path, platform).await;
+        let is_corruption = matches!(result, Err(Error::Corruption(_)));
+        let err_display = result.as_ref().err().map(|e| e.to_string());
+        assert!(
+            is_corruption,
+            "open_lazy must reject an empty Index.db as Corruption, got {err_display:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Companion to the empty-file case: a present, NON-EMPTY file whose FIRST
+    /// entry is structurally unparseable (a dangling key-length header with no
+    /// body — the SAME truncation shape `full_index_stream`'s
+    /// `scan_stops_on_truncated_tail`-style tests use elsewhere) must ALSO be
+    /// rejected by the bounded validity probe, not just the zero-byte case.
+    #[tokio::test]
+    async fn open_lazy_rejects_a_truncated_first_entry() {
+        // Dangling key-length header (claims a 0x40-byte key) with zero body bytes.
+        let entry: Vec<u8> = vec![0x00, 0x40];
+        let (dir, path) = temp_index_file("truncated-first-entry", &entry);
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+        let result = IndexReader::open_lazy(&path, platform).await;
+        let is_corruption = matches!(result, Err(Error::Corruption(_)));
+        let err_display = result.as_ref().err().map(|e| e.to_string());
+        assert!(
+            is_corruption,
+            "open_lazy must reject a truncated first entry as Corruption, got {err_display:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/cqlite-core/src/storage/sstable/index_reader/lazy.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/lazy.rs
@@ -1,0 +1,219 @@
+//! Lazy Summary-guided `Index.db` open (issue #2412, design §A).
+//!
+//! Split out of `index_reader/mod.rs` (campsite #1116) — the eager constructors,
+//! struct definition, and sync accessors stay in `mod.rs` unchanged; this file adds
+//! the NEW lazy-open primitives `IndexReader::open_lazy` /
+//! `IndexReader::ensure_materialized` plus their internal `MaterializedIndex` cell
+//! type, used only by `SSTableReader`'s BIG-open composition
+//! (`reader::component_loading::load_index_reader`).
+
+use super::parse::parse_index_data_cancellable;
+use super::{IndexData, IndexReader};
+use crate::error::{Error, Result};
+use crate::platform::Platform;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+
+/// The full parse result, materialized either eagerly (at construction, the
+/// unchanged legacy behavior every direct [`IndexReader::open`] caller relies on)
+/// or lazily (issue #2412, on the first [`IndexReader::ensure_materialized`] call).
+pub(super) struct MaterializedIndex {
+    pub(super) index_data: IndexData,
+    /// Whether the entry parse consumed the ENTIRE Index.db file (issue #2302).
+    /// The parser `break`s on the first unparseable entry and returns the parsed
+    /// PREFIX, so a mid-entry-truncated file opens with leftover bytes. `true` ⟺
+    /// no bytes remained — the authoritative signal the stream was not cut
+    /// mid-entry (WHOLE trailing entries dropped at an exact boundary are caught
+    /// separately at the enumeration site). Only the completeness-sensitive full
+    /// enumeration consults it; point-lookup callers tolerate a partial prefix.
+    pub(super) fully_parsed: bool,
+}
+
+impl IndexReader {
+    /// Lazy Summary-guided open (issue #2412, design §A): checks only that the file
+    /// EXISTS and performs ZERO `Index.db` parse work. Used by `SSTableReader`'s BIG
+    /// open composition when a usable `Summary.db` is present, so open cost is
+    /// bounded by `Summary.db` size, not by `Index.db` partition count. The full
+    /// parse is deferred to the first [`Self::ensure_materialized`] call from an
+    /// internal consumer that genuinely needs the resident map (a full-enumeration
+    /// scan, or the point-lookup fallback before Stage 3's interval-bounded lookup
+    /// lands); a point-lookup-dominated workload may never pay it at all.
+    pub(crate) async fn open_lazy(path: &Path, platform: Arc<Platform>) -> Result<Self> {
+        if !platform.fs().exists(path).await? {
+            return Err(Error::not_found(format!(
+                "Index.db file not found: {}",
+                path.display()
+            )));
+        }
+        // `file_path`/`materialized` are private fields of `IndexReader`, defined in
+        // the parent `index_reader` module — visible here because `lazy` is a
+        // DESCENDANT module of it (Rust privacy: private items are visible to the
+        // defining module and all its descendants), so no field-access bridge
+        // methods are needed on the struct itself.
+        Ok(Self {
+            file_path: path.to_path_buf(),
+            materialized: tokio::sync::OnceCell::new(),
+            platform,
+        })
+    }
+
+    /// Ensure the full `Index.db` parse has run, performing it exactly once
+    /// (memoized) on first call — the deferred cost [`Self::open_lazy`] skips at
+    /// open time (issue #2412). A no-op (immediate return) for a reader constructed
+    /// via the eager constructors, since their cell is already populated. Cancel-
+    /// aware: polls `cancel` the same way the eager parse does, so a cooperative
+    /// cancellation still aborts a large deferred parse promptly.
+    pub(crate) async fn ensure_materialized(
+        &self,
+        cancel: &crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<()> {
+        self.materialized
+            .get_or_try_init(|| async {
+                cancel.check()?;
+                let mut file = File::open(&self.file_path).await?;
+                let mut buffer = Vec::new();
+                file.read_to_end(&mut buffer).await?;
+                if buffer.is_empty() {
+                    return Err(Error::corruption(format!(
+                        "Index.db file is empty: {}",
+                        self.file_path.display()
+                    )));
+                }
+                let (remaining, index_data) =
+                    match parse_index_data_cancellable(&buffer, None, cancel) {
+                        Ok(pair) => pair,
+                        Err(e @ Error::Cancelled) => return Err(e),
+                        Err(e) => {
+                            return Err(Error::corruption(format!(
+                                "Failed to parse Index.db: {:?}",
+                                e
+                            )));
+                        }
+                    };
+                let fully_parsed = remaining.is_empty();
+                Ok(MaterializedIndex {
+                    index_data,
+                    fully_parsed,
+                })
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_index_file(name_hint: &str, entry: &[u8]) -> (std::path::PathBuf, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-2412-{name_hint}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("nb-1-big-Index.db");
+        std::fs::write(&path, entry).unwrap();
+        (dir, path)
+    }
+
+    /// Issue #2412 (Stage 2, §A): `open_lazy` performs ZERO `Index.db` parse work —
+    /// no entries touched, `is_fully_parsed()` conservatively `false` — until
+    /// `ensure_materialized` is called. Scale-free work probe: constructed from a
+    /// synthetic single-entry `Index.db` so the assertion is about ORDER of
+    /// operations, not entry count.
+    #[tokio::test]
+    async fn open_lazy_touches_zero_entries_until_materialized() {
+        // One well-formed BIG entry: key_len(2) + key(4) + vint offset + vint promoted_len=0.
+        let entry: Vec<u8> = vec![0x00, 0x04, 0xAA, 0xBB, 0xCC, 0xDD, 0x00, 0x00];
+        let (dir, path) = temp_index_file("open-lazy", &entry);
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+
+        let reader = IndexReader::open_lazy(&path, platform)
+            .await
+            .expect("open_lazy must succeed for an existing file");
+
+        // Zero work at open: no entries visible, not reported fully-parsed.
+        assert!(
+            reader.get_partition_entries().is_empty(),
+            "open_lazy must not materialize any entries before ensure_materialized"
+        );
+        assert!(
+            !reader.is_fully_parsed(),
+            "open_lazy must not report fully_parsed before materialization"
+        );
+        assert!(reader.lookup_partition(&[0xAA, 0xBB, 0xCC, 0xDD]).is_none());
+
+        // First real use triggers exactly the deferred full parse.
+        reader
+            .ensure_materialized(&crate::storage::scan_cancel::ScanCancel::default())
+            .await
+            .expect("deferred materialize must succeed for a well-formed file");
+        assert_eq!(reader.get_partition_entries().len(), 1);
+        assert!(reader.is_fully_parsed());
+        assert!(reader.lookup_partition(&[0xAA, 0xBB, 0xCC, 0xDD]).is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `ensure_materialized` is idempotent/memoized: calling it twice does not
+    /// re-parse (the second call is a cheap `OnceCell::get` under the hood) and
+    /// yields the identical result both times.
+    #[tokio::test]
+    async fn ensure_materialized_is_memoized() {
+        let entry: Vec<u8> = vec![0x00, 0x02, 0x11, 0x22, 0x00, 0x00];
+        let (dir, path) = temp_index_file("memoized", &entry);
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+        let reader = IndexReader::open_lazy(&path, platform).await.unwrap();
+        let cancel = crate::storage::scan_cancel::ScanCancel::default();
+
+        reader.ensure_materialized(&cancel).await.unwrap();
+        let first_len = reader.get_partition_entries().len();
+        reader.ensure_materialized(&cancel).await.unwrap();
+        let second_len = reader.get_partition_entries().len();
+        assert_eq!(first_len, second_len);
+        assert_eq!(first_len, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Eager constructors ([`IndexReader::open`]) are UNCHANGED: entries are
+    /// visible immediately, no `ensure_materialized` call needed — the pre-#2412
+    /// behavior every direct caller (including the many integration tests that
+    /// construct `IndexReader` directly) relies on.
+    #[tokio::test]
+    async fn eager_open_is_immediately_materialized() {
+        let entry: Vec<u8> = vec![0x00, 0x02, 0x33, 0x44, 0x00, 0x00];
+        let (dir, path) = temp_index_file("eager", &entry);
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+        let reader = IndexReader::open(&path, platform).await.unwrap();
+        assert_eq!(reader.get_partition_entries().len(), 1);
+        assert!(reader.is_fully_parsed());
+        assert!(reader.lookup_partition(&[0x33, 0x44]).is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/cqlite-core/src/storage/sstable/index_reader/lazy.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/lazy.rs
@@ -235,4 +235,108 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    /// Encode one BIG `Index.db` entry: `[key_len u16 BE][key][data_offset vint][promoted_len vint=0]`
+    /// (mirrors `index_reader::stream`'s test helper — kept local since this
+    /// module has no shared test-fixture crate to depend on without a cycle).
+    fn encode_entry(key: &[u8], data_offset: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(key.len() as u16).to_be_bytes());
+        out.extend_from_slice(key);
+        out.extend_from_slice(&crate::parser::vint::encode_vuint(data_offset));
+        out.extend_from_slice(&crate::parser::vint::encode_vuint(0));
+        out
+    }
+
+    /// Issue #2412 (coordinator-flagged regression, re-anchor of the #2383 fix-C
+    /// guard): a cancellation tripped DURING [`IndexReader::ensure_materialized`]'s
+    /// deferred full parse must abort promptly with `Error::Cancelled`, not run
+    /// the whole O(entries) parse to completion.
+    ///
+    /// `ensure_materialized` is the SURVIVING big-parse site for a Summary-usable
+    /// BIG reader (design §A/§C): open itself is now O(summary) and performs no
+    /// parse at all, but a consumer that still needs the resident map — a full
+    /// enumeration whose Summary-guided streaming walk `FellBack`, or a
+    /// compaction full-ring scan — calls `ensure_materialized`, which reuses the
+    /// SAME `parse_index_data_cancellable` entry loop the pre-#2412 eager `open`
+    /// always ran (unchanged: `CANCEL_POLL_INTERVAL`-bounded cooperative poll,
+    /// `index_reader/parse.rs`). This test proves that cancel-poll survived the
+    /// move to the deferred/lazy call site.
+    ///
+    /// Same calibrated-margin convention as
+    /// `cqlite-flight::warm::registry::spin_tests_2383::cancel_during_large_index_parse_aborts_promptly`
+    /// (issue #2383 roborev-1653 NIT 5 — no wall-clock races: the margin is a
+    /// small fraction of a JUST-measured baseline for this exact fixture on this
+    /// exact host, not a fixed sleep constant that flakes on a fast host).
+    #[tokio::test]
+    async fn ensure_materialized_cancel_mid_parse_aborts_promptly() {
+        use crate::storage::scan_cancel::ScanCancel;
+
+        // Large enough to span several `CANCEL_POLL_INTERVAL` (65536) windows, so
+        // the parse loop polls cancel multiple times before completing — proving
+        // "aborts DURING the parse", not merely at the coarse pre-check.
+        const N: usize = 400_000;
+        let mut bytes = Vec::new();
+        for i in 0..N {
+            let key = format!("key{i:010}");
+            bytes.extend_from_slice(&encode_entry(key.as_bytes(), i as u64));
+        }
+        let (dir, path) = temp_index_file("ensure-materialized-cancel", &bytes);
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+
+        // Calibrate: fully materialize the SAME fixture once, uncancelled — also
+        // warms the OS page cache ahead of the timed run below (biasing it
+        // FASTER, never slower, than this baseline).
+        let calib_start = std::time::Instant::now();
+        let calib_reader = IndexReader::open_lazy(&path, platform.clone())
+            .await
+            .expect("calibration open_lazy");
+        calib_reader
+            .ensure_materialized(&ScanCancel::default())
+            .await
+            .expect("calibration materialize (uncancelled) completes");
+        let baseline = calib_start.elapsed();
+        // 1/20th of the measured baseline (same fraction as the flight-level
+        // sibling test): small enough to land inside the timed run, large enough
+        // to dwarf the coarse pre-parse check's same-thread, no-I/O comparison.
+        let margin = baseline / 20;
+
+        let reader = IndexReader::open_lazy(&path, platform)
+            .await
+            .expect("timed open_lazy");
+        let cancel = ScanCancel::new();
+        let canceller = {
+            let cancel = cancel.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(margin);
+                cancel.cancel();
+            })
+        };
+
+        let result = reader.ensure_materialized(&cancel).await;
+        canceller.join().expect("canceller");
+
+        assert!(
+            matches!(result, Err(Error::Cancelled)),
+            "a cancel tripped DURING ensure_materialized's deferred Index.db parse \
+             must abort promptly with Error::Cancelled (calibrated margin {margin:?} \
+             from baseline {baseline:?}), got {result:?} (issue #2412 re-anchor of \
+             #2383 fix C)"
+        );
+        // The aborted materialize must NOT have left a poisoned "materialized"
+        // state: entries stay empty/not-fully-parsed, matching `open_lazy`'s
+        // pre-materialize contract (never a half-parsed resident map).
+        assert!(
+            reader.get_partition_entries().is_empty(),
+            "a cancelled materialize must not expose a partial resident map"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/cqlite-core/src/storage/sstable/index_reader/lazy.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/lazy.rs
@@ -32,6 +32,25 @@ pub(super) struct MaterializedIndex {
 }
 
 impl IndexReader {
+    /// Path to the backing `Index.db` file (issue #2412 §B). The Summary-guided
+    /// point-lookup path (`reader::summary_point`) seeks bounded intervals from this
+    /// path WITHOUT materializing the whole map. Lives here (not the parent module)
+    /// as a lazy-open support accessor, keeping `index_reader/mod.rs` under the
+    /// campsite line (#1116).
+    pub(crate) fn index_path(&self) -> &Path {
+        &self.file_path
+    }
+
+    /// Whether the full `Index.db` parse has already run (issue #2412 §B). A lazily
+    /// opened reader ([`Self::open_lazy`]) reports `false` until the first
+    /// [`Self::ensure_materialized`]; an eagerly opened reader reports `true` from
+    /// construction. The Summary-guided point path uses this to prefer the resident
+    /// map once it is already in memory (e.g. after a full scan) and the bounded
+    /// interval read only while the map is still deferred.
+    pub(crate) fn is_materialized(&self) -> bool {
+        self.materialized.get().is_some()
+    }
+
     /// Lazy Summary-guided open (issue #2412, design §A): checks only that the file
     /// EXISTS and performs ZERO `Index.db` parse work. Used by `SSTableReader`'s BIG
     /// open composition when a usable `Summary.db` is present, so open cost is

--- a/cqlite-core/src/storage/sstable/index_reader/lazy.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/lazy.rs
@@ -7,7 +7,7 @@
 //! type, used only by `SSTableReader`'s BIG-open composition
 //! (`reader::component_loading::load_index_reader`).
 
-use super::parse::{parse_big_index_entry, parse_index_data_cancellable};
+use super::parse::{parse_big_index_entry_framing, parse_index_data_cancellable};
 use super::{IndexData, IndexReader};
 use crate::error::{Error, Result};
 use crate::platform::Platform;
@@ -18,10 +18,16 @@ use tokio::io::AsyncReadExt;
 
 /// Cap on the bounded validity-probe prefix [`IndexReader::open_lazy`] reads
 /// (issue #2302 open-time-detection preservation through the lazy-open change).
-/// Large enough to cover the WORST-CASE single `Index.db` entry — a `u16`
-/// key-length prefix (max 65535 bytes) + the raw key + two small vints — so a
-/// legitimately huge partition key can never false-trigger the probe; bounded so
-/// the probe's cost stays O(1) at open time, never O(partition count).
+/// Large enough to cover the WORST-CASE single `Index.db` entry's fixed FRAMING
+/// (`key_len` u16 + up to a 65535-byte key + two small vints — [`parse_big_index_entry_framing`]),
+/// so a legitimately huge partition KEY can never false-trigger the probe; bounded
+/// so the probe's cost stays O(1) at open time, never O(partition count). This
+/// intentionally does NOT need to cover the promoted-index PAYLOAD — that is
+/// UNBOUNDED in principle (see [`parse_big_index_entry_framing`]'s doc) and is
+/// validated structurally instead (declared length vs. the file's actual size),
+/// never by requiring the bytes to be physically present in this probe (roborev
+/// endgame finding, High — a probe requiring the full payload rejected HEALTHY
+/// wide-partition files).
 const VALIDITY_PROBE_PREFIX_CAP: usize = 70_000;
 
 /// The full parse result, materialized either eagerly (at construction, the
@@ -85,15 +91,28 @@ impl IndexReader {
     /// path, exactly as the eager path always has).
     ///
     /// The probe: read a BOUNDED prefix (≤ [`VALIDITY_PROBE_PREFIX_CAP`] bytes, or
-    /// the whole file when smaller) and confirm the file is non-empty AND its FIRST
-    /// entry parses ([`parse_big_index_entry`]) — the SAME authoritative on-disk
-    /// entry framing `ensure_materialized`'s full parse and the eager `open` both
-    /// use (no heuristics, issue #28). This is intentionally NOT a full structural
-    /// guarantee (a corruption deep inside the file, past the first entry, is still
-    /// caught later by `is_fully_parsed()`/Signal A at first materializing use,
-    /// exactly as before this change) — it is the SAME bounded confidence the
-    /// original eager `open` effectively offered before its first byte was even
-    /// consumed, at O(1) cost instead of O(partitions).
+    /// the whole file when smaller), confirm the file is non-empty, and confirm the
+    /// FIRST entry's fixed FRAMING parses ([`parse_big_index_entry_framing`]) —
+    /// the SAME authoritative on-disk framing `ensure_materialized`'s full parse
+    /// and the eager `open` both use (no heuristics, issue #28). Deliberately
+    /// validates ONLY the framing, not the promoted-index payload bytes
+    /// themselves (roborev endgame finding, High): the payload is UNBOUNDED in
+    /// principle (~one `IndexInfo` per 64KiB of partition data), so a probe
+    /// requiring it to be PHYSICALLY PRESENT in a bounded read would reject a
+    /// perfectly healthy `Index.db` whose first partition is simply wide —
+    /// stricter than the eager-parse contract it exists to preserve. Instead the
+    /// declared `promoted_len` is checked STRUCTURALLY against the file's actual
+    /// length (`framing_len + promoted_len <= file_len`): a value that would push
+    /// the entry past EOF is a structural impossibility (corrupt), while any
+    /// value that fits — however large, however far past this probe's read
+    /// window — is accepted as a legitimately wide (not corrupt) partition.
+    ///
+    /// This is intentionally NOT a full structural guarantee (a corruption deep
+    /// inside the file, past the first entry, is still caught later by
+    /// `is_fully_parsed()`/Signal A at first materializing use, exactly as before
+    /// this change) — it is the SAME bounded confidence the original eager `open`
+    /// effectively offered before its first byte was even consumed, at O(1) cost
+    /// instead of O(partitions).
     ///
     /// Not counted on EITHER `index_parses_total` or `index_interval_parses_total`:
     /// this probe is neither a full parse nor a Summary-guided per-lookup interval
@@ -120,11 +139,30 @@ impl IndexReader {
         let probe_len = file_len.min(VALIDITY_PROBE_PREFIX_CAP as u64) as usize;
         let mut probe_buf = vec![0u8; probe_len];
         file.read_exact(&mut probe_buf).await?;
-        if let Err(e) = parse_big_index_entry(&probe_buf) {
+        let (framing_len, promoted_len) = match parse_big_index_entry_framing(&probe_buf) {
+            Ok((_, (framing_len, promoted_len))) => (framing_len, promoted_len),
+            Err(e) => {
+                return Err(Error::corruption(format!(
+                    "Index.db first entry's framing failed to parse (present-but-unloadable) \
+                     at {}: {:?}",
+                    path.display(),
+                    e
+                )));
+            }
+        };
+        // Structural bound (no-heuristics #28): the DECLARED promoted-index
+        // payload length must fit within the file's ACTUAL length — a value that
+        // would push the entry past EOF is a real structural impossibility,
+        // never accepted regardless of how the framing itself parsed. A payload
+        // that legitimately extends past this probe's bounded read window (the
+        // wide-partition field shape) is NOT an error here.
+        let implied_entry_end = (framing_len as u64).saturating_add(promoted_len);
+        if implied_entry_end > file_len {
             return Err(Error::corruption(format!(
-                "Index.db first entry failed to parse (present-but-unloadable) at {}: {:?}",
-                path.display(),
-                e
+                "Index.db first entry's declared promoted-index length ({promoted_len}) \
+                 extends past the file's actual length ({file_len} bytes) at {} — \
+                 structurally impossible, present-but-unloadable",
+                path.display()
             )));
         }
 
@@ -298,6 +336,60 @@ mod tests {
         assert!(
             is_corruption,
             "open_lazy must reject a truncated first entry as Corruption, got {err_display:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// THE roborev endgame false-positive pin (High): a HEALTHY `Index.db` whose
+    /// FIRST partition is wide — a `promoted_len` (promoted-index payload) far
+    /// larger than [`VALIDITY_PROBE_PREFIX_CAP`] — must be ACCEPTED by
+    /// `open_lazy`, not rejected. A probe requiring the whole payload to be
+    /// physically present in its bounded read would silently regress every
+    /// point/range query for this real field shape to an O(file) `scan_for_key`
+    /// scan (the exact cliff issue #2412 exists to remove). The payload bytes
+    /// themselves are irrelevant to the framing-only probe (never inspected), so
+    /// zero-padding is a faithful stand-in for a real promoted-index payload.
+    #[tokio::test]
+    async fn open_lazy_accepts_a_healthy_wide_partition_past_the_probe_cap() {
+        let key = [0xAAu8, 0xBB, 0xCC, 0xDD];
+        let data_offset = 0u64;
+        // Comfortably over VALIDITY_PROBE_PREFIX_CAP (70_000) — the shape a real
+        // wide partition's promoted index (~1 IndexInfo block per 64KiB of
+        // partition data) produces.
+        const PROMOTED_LEN: usize = 100_000;
+
+        let mut entry = Vec::new();
+        entry.extend_from_slice(&(key.len() as u16).to_be_bytes());
+        entry.extend_from_slice(&key);
+        entry.extend_from_slice(&crate::parser::vint::encode_vuint(data_offset));
+        entry.extend_from_slice(&crate::parser::vint::encode_vuint(PROMOTED_LEN as u64));
+        entry.extend(vec![0u8; PROMOTED_LEN]); // the (unread) payload
+
+        let (dir, path) = temp_index_file("wide-partition", &entry);
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+        let reader = IndexReader::open_lazy(&path, platform).await;
+        let err_display = reader.as_ref().err().map(|e| e.to_string());
+        assert!(
+            reader.is_ok(),
+            "a HEALTHY Index.db whose first partition's promoted-index payload \
+             ({PROMOTED_LEN} bytes) exceeds the probe's bounded read window must \
+             still open lazily — got Err: {err_display:?} (roborev endgame \
+             finding, High: the probe must not be stricter than the eager-parse \
+             contract it preserves)"
+        );
+        let reader = reader.unwrap();
+        // Still genuinely LAZY: opening did not materialize the resident map
+        // (the whole point — this is an O(1) framing check, not a full parse).
+        assert!(
+            reader.get_partition_entries().is_empty(),
+            "open_lazy must stay lazy even after accepting a wide-partition file"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/cqlite-core/src/storage/sstable/index_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/mod.rs
@@ -248,6 +248,23 @@ impl IndexReader {
         })
     }
 
+    /// Path to the backing `Index.db` file (issue #2412 §B). The Summary-guided
+    /// point-lookup path (`reader::summary_point`) seeks bounded intervals from this
+    /// path WITHOUT materializing the whole map.
+    pub(crate) fn index_path(&self) -> &Path {
+        &self.file_path
+    }
+
+    /// Whether the full `Index.db` parse has already run (issue #2412 §B). A lazily
+    /// opened reader (`open_lazy`) reports `false` until the first
+    /// [`Self::ensure_materialized`]; an eagerly opened reader reports `true` from
+    /// construction. The Summary-guided point path uses this to prefer the resident
+    /// map once it is already in memory (e.g. after a full scan) and the bounded
+    /// interval read only while the map is still deferred.
+    pub(crate) fn is_materialized(&self) -> bool {
+        self.materialized.get().is_some()
+    }
+
     /// Get all partition entries. Empty until materialized (see `lazy.rs`, #2412).
     pub fn get_partition_entries(&self) -> &[PartitionIndexEntry] {
         self.materialized

--- a/cqlite-core/src/storage/sstable/index_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/mod.rs
@@ -248,23 +248,6 @@ impl IndexReader {
         })
     }
 
-    /// Path to the backing `Index.db` file (issue #2412 §B). The Summary-guided
-    /// point-lookup path (`reader::summary_point`) seeks bounded intervals from this
-    /// path WITHOUT materializing the whole map.
-    pub(crate) fn index_path(&self) -> &Path {
-        &self.file_path
-    }
-
-    /// Whether the full `Index.db` parse has already run (issue #2412 §B). A lazily
-    /// opened reader (`open_lazy`) reports `false` until the first
-    /// [`Self::ensure_materialized`]; an eagerly opened reader reports `true` from
-    /// construction. The Summary-guided point path uses this to prefer the resident
-    /// map once it is already in memory (e.g. after a full scan) and the bounded
-    /// interval read only while the map is still deferred.
-    pub(crate) fn is_materialized(&self) -> bool {
-        self.materialized.get().is_some()
-    }
-
     /// Get all partition entries. Empty until materialized (see `lazy.rs`, #2412).
     pub fn get_partition_entries(&self) -> &[PartitionIndexEntry] {
         self.materialized

--- a/cqlite-core/src/storage/sstable/index_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/mod.rs
@@ -134,15 +134,11 @@ pub struct IndexData {
     pub key_lookup: HashMap<Arc<[u8]>, usize>,
 }
 
-/// High-level Index.db file reader
-#[allow(dead_code)]
-pub struct IndexReader {
-    /// Path to the Index.db file
-    file_path: PathBuf,
-    /// Parsed index data
+/// The full parse result, materialized either eagerly (at construction, the
+/// unchanged legacy behavior every direct [`IndexReader::open`] caller relies on)
+/// or lazily (issue #2412, on the first [`IndexReader::ensure_materialized`] call).
+struct MaterializedIndex {
     index_data: IndexData,
-    /// Platform abstraction for file operations
-    platform: Arc<Platform>,
     /// Whether the entry parse consumed the ENTIRE Index.db file (issue #2302).
     /// The parser `break`s on the first unparseable entry and returns the parsed
     /// PREFIX, so a mid-entry-truncated file opens with leftover bytes. `true` ⟺
@@ -151,6 +147,36 @@ pub struct IndexReader {
     /// separately at the enumeration site). Only the completeness-sensitive full
     /// enumeration consults it; point-lookup callers tolerate a partial prefix.
     fully_parsed: bool,
+}
+
+/// High-level Index.db file reader
+///
+/// ## Lazy Summary-guided open (issue #2412)
+///
+/// [`Self::open`]/[`Self::open_with_summary`]/[`Self::open_with_summary_cancellable`]
+/// (the constructors every direct caller — including all pre-#2412 unit/integration
+/// tests — uses) are UNCHANGED: they parse the whole `Index.db` immediately and the
+/// [`MaterializedIndex`] cell is `set()` before the reader is returned, so
+/// [`Self::get_partition_entries`]/[`Self::lookup_partition`]/[`Self::is_fully_parsed`]
+/// behave EXACTLY as before for those callers.
+///
+/// [`Self::open_lazy`] is a NEW, additive constructor used only by
+/// `SSTableReader`'s BIG-open composition (`load_index_reader`) when a usable
+/// `Summary.db` is present: it performs zero `Index.db` I/O and leaves the cell
+/// unset. The first internal consumer that needs the full resident map calls
+/// [`Self::ensure_materialized`], which performs the identical full parse ONE time
+/// (memoized) — deferring the cost from open to first full-enumeration use, never
+/// eliminating it (Stage 3/4 of #2412 replace the common point-lookup/scan
+/// consumers with a bounded Summary-guided interval read that never touches this
+/// cell at all).
+#[allow(dead_code)]
+pub struct IndexReader {
+    /// Path to the Index.db file
+    file_path: PathBuf,
+    /// Lazily (or eagerly) materialized full parse result.
+    materialized: tokio::sync::OnceCell<MaterializedIndex>,
+    /// Platform abstraction for file operations
+    platform: Arc<Platform>,
 }
 
 impl IndexReader {
@@ -238,24 +264,111 @@ impl IndexReader {
         // complete. Structural, no heuristics (issue #28).
         let fully_parsed = remaining.is_empty();
 
+        let materialized = tokio::sync::OnceCell::new();
+        // Fresh cell: `set` always succeeds. Eager construction populates it
+        // immediately so every pre-#2412 caller's sync accessors behave exactly as
+        // before this change.
+        let _ = materialized.set(MaterializedIndex {
+            index_data,
+            fully_parsed,
+        });
+
         Ok(Self {
             file_path: path.to_path_buf(),
-            index_data,
+            materialized,
             platform,
-            fully_parsed,
         })
     }
 
-    /// Get all partition entries
+    /// Lazy Summary-guided open (issue #2412, design §A): checks only that the file
+    /// EXISTS and performs ZERO `Index.db` parse work. Used by `SSTableReader`'s BIG
+    /// open composition when a usable `Summary.db` is present, so open cost is
+    /// bounded by `Summary.db` size, not by `Index.db` partition count. The full
+    /// parse is deferred to the first [`Self::ensure_materialized`] call from an
+    /// internal consumer that genuinely needs the resident map (a full-enumeration
+    /// scan, or the point-lookup fallback before Stage 3's interval-bounded lookup
+    /// lands); a point-lookup-dominated workload may never pay it at all.
+    pub(crate) async fn open_lazy(path: &Path, platform: Arc<Platform>) -> Result<Self> {
+        if !platform.fs().exists(path).await? {
+            return Err(Error::not_found(format!(
+                "Index.db file not found: {}",
+                path.display()
+            )));
+        }
+        Ok(Self {
+            file_path: path.to_path_buf(),
+            materialized: tokio::sync::OnceCell::new(),
+            platform,
+        })
+    }
+
+    /// Ensure the full `Index.db` parse has run, performing it exactly once
+    /// (memoized) on first call — the deferred cost [`Self::open_lazy`] skips at
+    /// open time (issue #2412). A no-op (immediate return) for a reader constructed
+    /// via the eager constructors, since their cell is already populated. Cancel-
+    /// aware: polls `cancel` the same way the eager parse does, so a cooperative
+    /// cancellation still aborts a large deferred parse promptly.
+    pub(crate) async fn ensure_materialized(
+        &self,
+        cancel: &crate::storage::scan_cancel::ScanCancel,
+    ) -> Result<()> {
+        self.materialized
+            .get_or_try_init(|| async {
+                cancel.check()?;
+                let mut file = File::open(&self.file_path).await?;
+                let mut buffer = Vec::new();
+                file.read_to_end(&mut buffer).await?;
+                if buffer.is_empty() {
+                    return Err(Error::corruption(format!(
+                        "Index.db file is empty: {}",
+                        self.file_path.display()
+                    )));
+                }
+                let (remaining, index_data) =
+                    match parse_index_data_cancellable(&buffer, None, cancel) {
+                        Ok(pair) => pair,
+                        Err(e @ Error::Cancelled) => return Err(e),
+                        Err(e) => {
+                            return Err(Error::corruption(format!(
+                                "Failed to parse Index.db: {:?}",
+                                e
+                            )));
+                        }
+                    };
+                let fully_parsed = remaining.is_empty();
+                Ok(MaterializedIndex {
+                    index_data,
+                    fully_parsed,
+                })
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Get all partition entries.
+    ///
+    /// Returns an empty slice if this reader was constructed via [`Self::open_lazy`]
+    /// and [`Self::ensure_materialized`] has not yet been called — every internal
+    /// consumer that needs the full map calls `ensure_materialized` first (issue
+    /// #2412). Constructors other than `open_lazy` always populate the cell before
+    /// returning, so this never returns a stale-empty slice for their callers.
     pub fn get_partition_entries(&self) -> &[PartitionIndexEntry] {
-        &self.index_data.partition_entries
+        self.materialized
+            .get()
+            .map(|m| m.index_data.partition_entries.as_slice())
+            .unwrap_or(&[])
     }
 
     /// Whether the entry parse consumed the ENTIRE Index.db file (issue #2302).
     /// `false` ⟺ the file was truncated mid-entry, so the parsed entry set is a
     /// partial prefix and MUST NOT be treated as a complete partition enumeration.
+    /// Also `false` (conservatively) if not yet materialized (issue #2412) — every
+    /// full-enumeration consumer calls `ensure_materialized` first.
     pub fn is_fully_parsed(&self) -> bool {
-        self.fully_parsed
+        self.materialized
+            .get()
+            .map(|m| m.fully_parsed)
+            .unwrap_or(false)
     }
 
     /// Look up a partition by key digest
@@ -268,11 +381,15 @@ impl IndexReader {
     ///
     /// **Before:** `let key_arc: Arc<[u8]> = key_digest.into();` (heap allocation per query)
     /// **After:** Direct `get(key_digest)` using Borrow trait (zero allocations)
+    ///
+    /// Returns `None` if not yet materialized (issue #2412's lazy constructor) —
+    /// every internal caller ensures materialization first.
     pub fn lookup_partition(&self, key_digest: &[u8]) -> Option<&PartitionIndexEntry> {
-        self.index_data
+        let m = self.materialized.get()?;
+        m.index_data
             .key_lookup
             .get(key_digest)
-            .and_then(|&index| self.index_data.partition_entries.get(index))
+            .and_then(|&index| m.index_data.partition_entries.get(index))
     }
 
     /// Get statistics about the index
@@ -280,7 +397,7 @@ impl IndexReader {
         let mut promoted_count = 0;
         let mut total_promoted_entries = 0;
 
-        for entry in &self.index_data.partition_entries {
+        for entry in self.get_partition_entries() {
             if let Some(ref promoted) = entry.promoted_index {
                 promoted_count += 1;
                 total_promoted_entries += promoted.block_count() as usize;
@@ -288,7 +405,7 @@ impl IndexReader {
         }
 
         IndexStatistics {
-            total_partitions: self.index_data.partition_entries.len(),
+            total_partitions: self.get_partition_entries().len(),
             partitions_with_promoted_index: promoted_count,
             total_promoted_entries,
             file_size: self.file_path.metadata().map(|m| m.len()).unwrap_or(0),
@@ -301,8 +418,7 @@ impl IndexReader {
 
         // Check for overlapping offsets
         let mut offsets: Vec<_> = self
-            .index_data
-            .partition_entries
+            .get_partition_entries()
             .iter()
             .map(|e| (e.data_offset, e.data_size))
             .collect();
@@ -342,6 +458,131 @@ pub struct IndexStatistics {
 mod tests {
     use super::*;
     use std::env;
+
+    /// Issue #2412 (Stage 2, §A): `open_lazy` performs ZERO `Index.db` parse work —
+    /// no entries touched, `is_fully_parsed()` conservatively `false` — until
+    /// `ensure_materialized` is called. Scale-free work probe: constructed from a
+    /// synthetic single-entry `Index.db` so the assertion is about ORDER of
+    /// operations, not entry count.
+    #[tokio::test]
+    async fn open_lazy_touches_zero_entries_until_materialized() {
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-2412-open-lazy-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("nb-1-big-Index.db");
+        // One well-formed BIG entry: key_len(2) + key(4) + vint offset + vint promoted_len=0.
+        let entry: Vec<u8> = vec![0x00, 0x04, 0xAA, 0xBB, 0xCC, 0xDD, 0x00, 0x00];
+        std::fs::write(&path, &entry).unwrap();
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+
+        let reader = IndexReader::open_lazy(&path, platform)
+            .await
+            .expect("open_lazy must succeed for an existing file");
+
+        // Zero work at open: no entries visible, not reported fully-parsed.
+        assert!(
+            reader.get_partition_entries().is_empty(),
+            "open_lazy must not materialize any entries before ensure_materialized"
+        );
+        assert!(
+            !reader.is_fully_parsed(),
+            "open_lazy must not report fully_parsed before materialization"
+        );
+        assert!(reader.lookup_partition(&[0xAA, 0xBB, 0xCC, 0xDD]).is_none());
+
+        // First real use triggers exactly the deferred full parse.
+        reader
+            .ensure_materialized(&crate::storage::scan_cancel::ScanCancel::default())
+            .await
+            .expect("deferred materialize must succeed for a well-formed file");
+        assert_eq!(reader.get_partition_entries().len(), 1);
+        assert!(reader.is_fully_parsed());
+        assert!(reader.lookup_partition(&[0xAA, 0xBB, 0xCC, 0xDD]).is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `ensure_materialized` is idempotent/memoized: calling it twice does not
+    /// re-parse (the second call is a cheap `OnceCell::get` under the hood) and
+    /// yields the identical result both times.
+    #[tokio::test]
+    async fn ensure_materialized_is_memoized() {
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-2412-memoized-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("nb-1-big-Index.db");
+        let entry: Vec<u8> = vec![0x00, 0x02, 0x11, 0x22, 0x00, 0x00];
+        std::fs::write(&path, &entry).unwrap();
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+        let reader = IndexReader::open_lazy(&path, platform).await.unwrap();
+        let cancel = crate::storage::scan_cancel::ScanCancel::default();
+
+        reader.ensure_materialized(&cancel).await.unwrap();
+        let first_len = reader.get_partition_entries().len();
+        reader.ensure_materialized(&cancel).await.unwrap();
+        let second_len = reader.get_partition_entries().len();
+        assert_eq!(first_len, second_len);
+        assert_eq!(first_len, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Eager constructors ([`IndexReader::open`]) are UNCHANGED: entries are
+    /// visible immediately, no `ensure_materialized` call needed — the pre-#2412
+    /// behavior every direct caller (including the many integration tests that
+    /// construct `IndexReader` directly) relies on.
+    #[tokio::test]
+    async fn eager_open_is_immediately_materialized() {
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-2412-eager-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("nb-1-big-Index.db");
+        let entry: Vec<u8> = vec![0x00, 0x02, 0x33, 0x44, 0x00, 0x00];
+        std::fs::write(&path, &entry).unwrap();
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("platform must initialize"),
+        );
+        let reader = IndexReader::open(&path, platform).await.unwrap();
+        assert_eq!(reader.get_partition_entries().len(), 1);
+        assert!(reader.is_fully_parsed());
+        assert!(reader.lookup_partition(&[0x33, 0x44]).is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// Test stock_prices Index.db parsing (Issue #208)
     ///
@@ -521,6 +762,14 @@ mod tests {
 
                 // Check if index_reader was loaded (it's a public field)
                 if let Some(ref index_reader) = reader.index_reader {
+                    // Issue #2412: BIG open is now lazy (Summary-guided) when a
+                    // usable Summary.db is present, so the resident map is empty
+                    // until the first real full-enumeration/point-lookup demand.
+                    // Force materialization here to assert the on-disk entry count.
+                    index_reader
+                        .ensure_materialized(&crate::storage::scan_cancel::ScanCancel::default())
+                        .await
+                        .expect("Index.db must materialize on demand");
                     let entries = index_reader.get_partition_entries();
                     println!("Index loaded with {} partition entries", entries.len());
 

--- a/cqlite-core/src/storage/sstable/index_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/mod.rs
@@ -134,41 +134,11 @@ pub struct IndexData {
     pub key_lookup: HashMap<Arc<[u8]>, usize>,
 }
 
-/// The full parse result, materialized either eagerly (at construction, the
-/// unchanged legacy behavior every direct [`IndexReader::open`] caller relies on)
-/// or lazily (issue #2412, on the first [`IndexReader::ensure_materialized`] call).
-struct MaterializedIndex {
-    index_data: IndexData,
-    /// Whether the entry parse consumed the ENTIRE Index.db file (issue #2302).
-    /// The parser `break`s on the first unparseable entry and returns the parsed
-    /// PREFIX, so a mid-entry-truncated file opens with leftover bytes. `true` ⟺
-    /// no bytes remained — the authoritative signal the stream was not cut
-    /// mid-entry (WHOLE trailing entries dropped at an exact boundary are caught
-    /// separately at the enumeration site). Only the completeness-sensitive full
-    /// enumeration consults it; point-lookup callers tolerate a partial prefix.
-    fully_parsed: bool,
-}
+// Lazy Summary-guided open (`open_lazy`/`ensure_materialized`, #2412 §A): see `lazy.rs`.
+mod lazy;
+use lazy::MaterializedIndex;
 
-/// High-level Index.db file reader
-///
-/// ## Lazy Summary-guided open (issue #2412)
-///
-/// [`Self::open`]/[`Self::open_with_summary`]/[`Self::open_with_summary_cancellable`]
-/// (the constructors every direct caller — including all pre-#2412 unit/integration
-/// tests — uses) are UNCHANGED: they parse the whole `Index.db` immediately and the
-/// [`MaterializedIndex`] cell is `set()` before the reader is returned, so
-/// [`Self::get_partition_entries`]/[`Self::lookup_partition`]/[`Self::is_fully_parsed`]
-/// behave EXACTLY as before for those callers.
-///
-/// [`Self::open_lazy`] is a NEW, additive constructor used only by
-/// `SSTableReader`'s BIG-open composition (`load_index_reader`) when a usable
-/// `Summary.db` is present: it performs zero `Index.db` I/O and leaves the cell
-/// unset. The first internal consumer that needs the full resident map calls
-/// [`Self::ensure_materialized`], which performs the identical full parse ONE time
-/// (memoized) — deferring the cost from open to first full-enumeration use, never
-/// eliminating it (Stage 3/4 of #2412 replace the common point-lookup/scan
-/// consumers with a bounded Summary-guided interval read that never touches this
-/// cell at all).
+/// High-level Index.db file reader. See `lazy.rs` for the #2412 lazy-open contract.
 #[allow(dead_code)]
 pub struct IndexReader {
     /// Path to the Index.db file
@@ -264,10 +234,8 @@ impl IndexReader {
         // complete. Structural, no heuristics (issue #28).
         let fully_parsed = remaining.is_empty();
 
+        // Eager: populate the cell immediately (fresh cell, `set` always succeeds).
         let materialized = tokio::sync::OnceCell::new();
-        // Fresh cell: `set` always succeeds. Eager construction populates it
-        // immediately so every pre-#2412 caller's sync accessors behave exactly as
-        // before this change.
         let _ = materialized.set(MaterializedIndex {
             index_data,
             fully_parsed,
@@ -280,78 +248,7 @@ impl IndexReader {
         })
     }
 
-    /// Lazy Summary-guided open (issue #2412, design §A): checks only that the file
-    /// EXISTS and performs ZERO `Index.db` parse work. Used by `SSTableReader`'s BIG
-    /// open composition when a usable `Summary.db` is present, so open cost is
-    /// bounded by `Summary.db` size, not by `Index.db` partition count. The full
-    /// parse is deferred to the first [`Self::ensure_materialized`] call from an
-    /// internal consumer that genuinely needs the resident map (a full-enumeration
-    /// scan, or the point-lookup fallback before Stage 3's interval-bounded lookup
-    /// lands); a point-lookup-dominated workload may never pay it at all.
-    pub(crate) async fn open_lazy(path: &Path, platform: Arc<Platform>) -> Result<Self> {
-        if !platform.fs().exists(path).await? {
-            return Err(Error::not_found(format!(
-                "Index.db file not found: {}",
-                path.display()
-            )));
-        }
-        Ok(Self {
-            file_path: path.to_path_buf(),
-            materialized: tokio::sync::OnceCell::new(),
-            platform,
-        })
-    }
-
-    /// Ensure the full `Index.db` parse has run, performing it exactly once
-    /// (memoized) on first call — the deferred cost [`Self::open_lazy`] skips at
-    /// open time (issue #2412). A no-op (immediate return) for a reader constructed
-    /// via the eager constructors, since their cell is already populated. Cancel-
-    /// aware: polls `cancel` the same way the eager parse does, so a cooperative
-    /// cancellation still aborts a large deferred parse promptly.
-    pub(crate) async fn ensure_materialized(
-        &self,
-        cancel: &crate::storage::scan_cancel::ScanCancel,
-    ) -> Result<()> {
-        self.materialized
-            .get_or_try_init(|| async {
-                cancel.check()?;
-                let mut file = File::open(&self.file_path).await?;
-                let mut buffer = Vec::new();
-                file.read_to_end(&mut buffer).await?;
-                if buffer.is_empty() {
-                    return Err(Error::corruption(format!(
-                        "Index.db file is empty: {}",
-                        self.file_path.display()
-                    )));
-                }
-                let (remaining, index_data) =
-                    match parse_index_data_cancellable(&buffer, None, cancel) {
-                        Ok(pair) => pair,
-                        Err(e @ Error::Cancelled) => return Err(e),
-                        Err(e) => {
-                            return Err(Error::corruption(format!(
-                                "Failed to parse Index.db: {:?}",
-                                e
-                            )));
-                        }
-                    };
-                let fully_parsed = remaining.is_empty();
-                Ok(MaterializedIndex {
-                    index_data,
-                    fully_parsed,
-                })
-            })
-            .await?;
-        Ok(())
-    }
-
-    /// Get all partition entries.
-    ///
-    /// Returns an empty slice if this reader was constructed via [`Self::open_lazy`]
-    /// and [`Self::ensure_materialized`] has not yet been called — every internal
-    /// consumer that needs the full map calls `ensure_materialized` first (issue
-    /// #2412). Constructors other than `open_lazy` always populate the cell before
-    /// returning, so this never returns a stale-empty slice for their callers.
+    /// Get all partition entries. Empty until materialized (see `lazy.rs`, #2412).
     pub fn get_partition_entries(&self) -> &[PartitionIndexEntry] {
         self.materialized
             .get()
@@ -360,10 +257,8 @@ impl IndexReader {
     }
 
     /// Whether the entry parse consumed the ENTIRE Index.db file (issue #2302).
-    /// `false` ⟺ the file was truncated mid-entry, so the parsed entry set is a
-    /// partial prefix and MUST NOT be treated as a complete partition enumeration.
-    /// Also `false` (conservatively) if not yet materialized (issue #2412) — every
-    /// full-enumeration consumer calls `ensure_materialized` first.
+    /// `false` ⟺ the file was truncated mid-entry — a partial prefix, not a
+    /// complete enumeration. Also `false` until materialized (`lazy.rs`, #2412).
     pub fn is_fully_parsed(&self) -> bool {
         self.materialized
             .get()
@@ -371,19 +266,8 @@ impl IndexReader {
             .unwrap_or(false)
     }
 
-    /// Look up a partition by key digest
-    ///
-    /// ## Zero-Allocation Optimization (Issue #107)
-    ///
-    /// This method performs HashMap lookup without heap allocation by leveraging
-    /// the `Borrow` trait. Since `Arc<[u8]>` implements `Borrow<[u8]>`, we can
-    /// lookup using `&[u8]` directly without creating a temporary Arc.
-    ///
-    /// **Before:** `let key_arc: Arc<[u8]> = key_digest.into();` (heap allocation per query)
-    /// **After:** Direct `get(key_digest)` using Borrow trait (zero allocations)
-    ///
-    /// Returns `None` if not yet materialized (issue #2412's lazy constructor) —
-    /// every internal caller ensures materialization first.
+    /// Look up a partition by key digest (zero-allocation `Borrow` lookup, Issue
+    /// #107). `None` until materialized (`lazy.rs`, #2412).
     pub fn lookup_partition(&self, key_digest: &[u8]) -> Option<&PartitionIndexEntry> {
         let m = self.materialized.get()?;
         m.index_data
@@ -459,130 +343,7 @@ mod tests {
     use super::*;
     use std::env;
 
-    /// Issue #2412 (Stage 2, §A): `open_lazy` performs ZERO `Index.db` parse work —
-    /// no entries touched, `is_fully_parsed()` conservatively `false` — until
-    /// `ensure_materialized` is called. Scale-free work probe: constructed from a
-    /// synthetic single-entry `Index.db` so the assertion is about ORDER of
-    /// operations, not entry count.
-    #[tokio::test]
-    async fn open_lazy_touches_zero_entries_until_materialized() {
-        let dir = std::env::temp_dir().join(format!(
-            "cqlite-2412-open-lazy-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("nb-1-big-Index.db");
-        // One well-formed BIG entry: key_len(2) + key(4) + vint offset + vint promoted_len=0.
-        let entry: Vec<u8> = vec![0x00, 0x04, 0xAA, 0xBB, 0xCC, 0xDD, 0x00, 0x00];
-        std::fs::write(&path, &entry).unwrap();
-
-        let config = crate::Config::default();
-        let platform = Arc::new(
-            crate::Platform::new(&config)
-                .await
-                .expect("platform must initialize"),
-        );
-
-        let reader = IndexReader::open_lazy(&path, platform)
-            .await
-            .expect("open_lazy must succeed for an existing file");
-
-        // Zero work at open: no entries visible, not reported fully-parsed.
-        assert!(
-            reader.get_partition_entries().is_empty(),
-            "open_lazy must not materialize any entries before ensure_materialized"
-        );
-        assert!(
-            !reader.is_fully_parsed(),
-            "open_lazy must not report fully_parsed before materialization"
-        );
-        assert!(reader.lookup_partition(&[0xAA, 0xBB, 0xCC, 0xDD]).is_none());
-
-        // First real use triggers exactly the deferred full parse.
-        reader
-            .ensure_materialized(&crate::storage::scan_cancel::ScanCancel::default())
-            .await
-            .expect("deferred materialize must succeed for a well-formed file");
-        assert_eq!(reader.get_partition_entries().len(), 1);
-        assert!(reader.is_fully_parsed());
-        assert!(reader.lookup_partition(&[0xAA, 0xBB, 0xCC, 0xDD]).is_some());
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    /// `ensure_materialized` is idempotent/memoized: calling it twice does not
-    /// re-parse (the second call is a cheap `OnceCell::get` under the hood) and
-    /// yields the identical result both times.
-    #[tokio::test]
-    async fn ensure_materialized_is_memoized() {
-        let dir = std::env::temp_dir().join(format!(
-            "cqlite-2412-memoized-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("nb-1-big-Index.db");
-        let entry: Vec<u8> = vec![0x00, 0x02, 0x11, 0x22, 0x00, 0x00];
-        std::fs::write(&path, &entry).unwrap();
-
-        let config = crate::Config::default();
-        let platform = Arc::new(
-            crate::Platform::new(&config)
-                .await
-                .expect("platform must initialize"),
-        );
-        let reader = IndexReader::open_lazy(&path, platform).await.unwrap();
-        let cancel = crate::storage::scan_cancel::ScanCancel::default();
-
-        reader.ensure_materialized(&cancel).await.unwrap();
-        let first_len = reader.get_partition_entries().len();
-        reader.ensure_materialized(&cancel).await.unwrap();
-        let second_len = reader.get_partition_entries().len();
-        assert_eq!(first_len, second_len);
-        assert_eq!(first_len, 1);
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    /// Eager constructors ([`IndexReader::open`]) are UNCHANGED: entries are
-    /// visible immediately, no `ensure_materialized` call needed — the pre-#2412
-    /// behavior every direct caller (including the many integration tests that
-    /// construct `IndexReader` directly) relies on.
-    #[tokio::test]
-    async fn eager_open_is_immediately_materialized() {
-        let dir = std::env::temp_dir().join(format!(
-            "cqlite-2412-eager-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("nb-1-big-Index.db");
-        let entry: Vec<u8> = vec![0x00, 0x02, 0x33, 0x44, 0x00, 0x00];
-        std::fs::write(&path, &entry).unwrap();
-
-        let config = crate::Config::default();
-        let platform = Arc::new(
-            crate::Platform::new(&config)
-                .await
-                .expect("platform must initialize"),
-        );
-        let reader = IndexReader::open(&path, platform).await.unwrap();
-        assert_eq!(reader.get_partition_entries().len(), 1);
-        assert!(reader.is_fully_parsed());
-        assert!(reader.lookup_partition(&[0x33, 0x44]).is_some());
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
+    // #2412 lazy-open pins live in `lazy.rs`'s own test module (campsite #1116).
 
     /// Test stock_prices Index.db parsing (Issue #208)
     ///
@@ -762,10 +523,7 @@ mod tests {
 
                 // Check if index_reader was loaded (it's a public field)
                 if let Some(ref index_reader) = reader.index_reader {
-                    // Issue #2412: BIG open is now lazy (Summary-guided) when a
-                    // usable Summary.db is present, so the resident map is empty
-                    // until the first real full-enumeration/point-lookup demand.
-                    // Force materialization here to assert the on-disk entry count.
+                    // #2412: BIG open is lazy now; force materialization to assert count.
                     index_reader
                         .ensure_materialized(&crate::storage::scan_cancel::ScanCancel::default())
                         .await

--- a/cqlite-core/src/storage/sstable/index_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/mod.rs
@@ -138,6 +138,11 @@ pub struct IndexData {
 mod lazy;
 use lazy::MaterializedIndex;
 
+// Forward-streaming Index.db entry iterator for the Summary-guided BIG scan
+// (#2412 §C, Stage 4): see `stream.rs`.
+mod stream;
+pub(crate) use stream::IndexEntryStream;
+
 /// High-level Index.db file reader. See `lazy.rs` for the #2412 lazy-open contract.
 #[allow(dead_code)]
 pub struct IndexReader {

--- a/cqlite-core/src/storage/sstable/index_reader/parse.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/parse.rs
@@ -314,6 +314,44 @@ pub(crate) fn parse_big_index_entry(input: &[u8]) -> IResult<&[u8], PartitionInd
     ))
 }
 
+/// Parse ONLY the fixed FRAMING of a single BIG-format `Index.db` entry —
+/// `[key_len: u16 BE][raw key][data_offset: vint][promoted_len: vint]` — WITHOUT
+/// requiring the (potentially large) promoted-index PAYLOAD bytes to be present
+/// in `input` (issue #2412 open-lazy validity probe hardening, roborev endgame
+/// finding, High).
+///
+/// Why this exists (distinct from [`parse_big_index_entry`]): the promoted-index
+/// payload is UNBOUNDED in principle — Cassandra emits roughly one `IndexInfo`
+/// block per 64KiB of partition data, so a single very wide partition's
+/// `promoted_len` can exceed any reasonable BOUNDED validity-probe read. A probe
+/// that required the full payload to be present would reject a perfectly HEALTHY
+/// `Index.db` whose first partition is simply wide — stricter than the eager-parse
+/// contract it exists to preserve, and silently regressing every point/range
+/// query for that (real, field) shape to an O(file) `scan_for_key` scan.
+///
+/// The FRAMING itself — `key_len`, the raw key bytes, `data_offset`, and
+/// `promoted_len` — is bounded (`key_len` is a `u16`, so at most 65535 bytes; the
+/// two vints are a handful of bytes each) and authoritative regardless of how
+/// large the payload turns out to be, so validating JUST the framing is a sound,
+/// no-heuristics (#28) structural check.
+///
+/// Returns `(remaining, framing_len, promoted_len)`: `framing_len` is the number
+/// of bytes consumed by the framing alone (where the promoted payload would
+/// begin — i.e. the entry's TOTAL on-disk length is `framing_len + promoted_len`
+/// once the payload is included); `promoted_len` is the DECLARED payload length
+/// (not validated against `input`'s remaining bytes — the caller cross-checks it
+/// against the file's actual length instead, since the payload may legitimately
+/// extend past `input`).
+pub(crate) fn parse_big_index_entry_framing(input: &[u8]) -> IResult<&[u8], (usize, u64)> {
+    let original_len = input.len();
+    let (input, key_len) = be_u16(input)?;
+    let (input, _key_bytes) = take(key_len)(input)?;
+    let (input, _data_offset) = parse_vuint(input)?;
+    let (remaining, promoted_len) = parse_vuint(input)?;
+    let framing_len = original_len - remaining.len();
+    Ok((remaining, (framing_len, promoted_len)))
+}
+
 // REMOVED: Old heuristic functions that violated Issue #28 no-heuristics mandate
 // - calculate_data_offset_from_summary: Summary.db correlation (now obsolete with inline offsets)
 // - interpolate_data_offset_from_summary_position: Used arbitrary estimates

--- a/cqlite-core/src/storage/sstable/index_reader/stream.rs
+++ b/cqlite-core/src/storage/sstable/index_reader/stream.rs
@@ -1,0 +1,273 @@
+//! Forward-streaming `Index.db` entry iterator for the Summary-guided BIG scan
+//! path (issue #2412 §C, Stage 4).
+//!
+//! [`super::lazy`] gives a BIG reader a lazy open (no full parse) and a bounded
+//! per-lookup interval read. A full/range scan needs the third shape: iterate
+//! `Index.db` entries FORWARD from a `Summary.db`-guided start offset, one entry
+//! at a time, WITHOUT materialising the whole `Vec<PartitionIndexEntry>` (the
+//! ~500MB-resident structure #2385 retired at open). This iterator feeds the
+//! #2361 streaming full-index walk with a disk-streamed entry source instead of
+//! a resident `Vec`.
+//!
+//! Memory is bounded to one refill window plus one entry: consumed bytes are
+//! drained after each parse, and the file is read in fixed [`REFILL_CHUNK`]
+//! chunks. A partition-count-independent footprint is the whole point.
+//!
+//! No-heuristics (issue #28): every byte comes from the authoritative on-disk
+//! `Index.db` entry framing ([`parse_big_index_entry`]); the start offset is an
+//! authoritative `Summary.db` sample position. Nothing is inferred from value
+//! bytes.
+
+use std::path::Path;
+
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+use super::{parse_big_index_entry, PartitionIndexEntry};
+use crate::error::Result;
+
+/// Bytes read from `Index.db` per refill. Large enough to amortise syscalls over
+/// many small entries (a BIG entry is typically key + two vints ≈ tens of bytes),
+/// small enough that peak buffer stays partition-count-independent.
+const REFILL_CHUNK: usize = 64 * 1024;
+
+/// A forward-only, bounded-memory reader of `Index.db` partition entries starting
+/// at an authoritative `Summary.db` sample offset (issue #2412 §C).
+pub(crate) struct IndexEntryStream {
+    file: File,
+    /// Unparsed bytes: `buf[cursor..]` is the not-yet-parsed remainder.
+    buf: Vec<u8>,
+    cursor: usize,
+    /// The file returned 0 bytes on the last read (no more data to refill).
+    eof: bool,
+    /// Total whole entries yielded so far (the scale-free work accounting).
+    entries_touched: usize,
+    /// After the stream ends, whether unparseable bytes remained at EOF — a
+    /// mid-entry-truncated `Index.db` tail (Signal A, issue #2302). The scan
+    /// terminus consults this to distinguish a clean end from a cut stream.
+    truncated_tail: bool,
+}
+
+impl IndexEntryStream {
+    /// Open `index_path` and seek to `start_position` (an authoritative
+    /// `Summary.db` sample offset; `0` for a full scan from the index start).
+    pub(crate) async fn open(index_path: &Path, start_position: u64) -> Result<Self> {
+        let mut file = File::open(index_path).await?;
+        if start_position > 0 {
+            file.seek(std::io::SeekFrom::Start(start_position)).await?;
+        }
+        Ok(Self {
+            file,
+            buf: Vec::new(),
+            cursor: 0,
+            eof: false,
+            entries_touched: 0,
+            truncated_tail: false,
+        })
+    }
+
+    /// Number of whole entries yielded so far (bounded work accounting).
+    #[cfg(test)]
+    pub(crate) fn entries_touched(&self) -> usize {
+        self.entries_touched
+    }
+
+    /// Whether the stream ended with unparseable bytes still buffered — a
+    /// mid-entry-truncated `Index.db` (Signal A). Only meaningful once
+    /// [`Self::next`] has returned `None`.
+    pub(crate) fn truncated_tail(&self) -> bool {
+        self.truncated_tail
+    }
+
+    /// Read one more [`REFILL_CHUNK`] from the file into `buf`, first dropping the
+    /// already-consumed prefix so the buffer stays bounded. Returns the number of
+    /// new bytes appended (0 at EOF).
+    async fn refill(&mut self) -> Result<usize> {
+        if self.cursor > 0 {
+            self.buf.drain(0..self.cursor);
+            self.cursor = 0;
+        }
+        let prev_len = self.buf.len();
+        self.buf.resize(prev_len + REFILL_CHUNK, 0);
+        let n = self.file.read(&mut self.buf[prev_len..]).await?;
+        self.buf.truncate(prev_len + n);
+        if n == 0 {
+            self.eof = true;
+        }
+        Ok(n)
+    }
+
+    /// Yield the next whole `Index.db` entry, or `None` at a clean end / a
+    /// truncated tail (distinguished via [`Self::truncated_tail`]).
+    ///
+    /// The BIG entry parser ([`parse_big_index_entry`]) is a `complete` combinator:
+    /// a short buffer fails indistinguishably from corruption, so on a parse
+    /// failure this refills and retries until either the entry parses or the file
+    /// is exhausted. At EOF with a non-empty unparseable remainder the tail was
+    /// cut mid-entry (`truncated_tail = true`).
+    pub(crate) async fn next(&mut self) -> Result<Option<PartitionIndexEntry>> {
+        loop {
+            // Attempt a parse from the current buffer window. The borrow of
+            // `slice`/`rest` ends before any mutation of `self.buf`.
+            let parsed = {
+                let slice = &self.buf[self.cursor..];
+                if slice.is_empty() {
+                    None
+                } else {
+                    match parse_big_index_entry(slice) {
+                        Ok((rest, entry)) => Some((slice.len() - rest.len(), entry)),
+                        Err(_) => None,
+                    }
+                }
+            };
+            if let Some((consumed, entry)) = parsed {
+                // Forward-progress guard (mirrors the full parser's debug_assert):
+                // a zero-width parse would loop forever — treat as end-of-stream.
+                if consumed == 0 {
+                    self.truncated_tail = self.cursor < self.buf.len();
+                    return Ok(None);
+                }
+                self.cursor += consumed;
+                self.entries_touched += 1;
+                return Ok(Some(entry));
+            }
+            // Could not parse a whole entry from the buffered bytes.
+            if self.eof {
+                // Nothing more to read: a non-empty remainder is a truncated tail.
+                self.truncated_tail = self.cursor < self.buf.len();
+                return Ok(None);
+            }
+            if self.refill().await? == 0 {
+                // EOF reached during refill; loop once more to classify the tail.
+                continue;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode one BIG `Index.db` entry: `[key_len u16 BE][key][data_offset vint][promoted_len vint=0]`.
+    fn encode_entry(key: &[u8], data_offset: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(key.len() as u16).to_be_bytes());
+        out.extend_from_slice(key);
+        out.extend_from_slice(&crate::parser::vint::encode_vuint(data_offset));
+        out.extend_from_slice(&crate::parser::vint::encode_vuint(0));
+        out
+    }
+
+    fn write_temp(name: &str, bytes: &[u8]) -> (std::path::PathBuf, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-2412-stream-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("nb-1-big-Index.db");
+        std::fs::write(&path, bytes).unwrap();
+        (dir, path)
+    }
+
+    async fn drain(path: &Path, start: u64) -> (Vec<PartitionIndexEntry>, bool, usize) {
+        let mut s = IndexEntryStream::open(path, start).await.unwrap();
+        let mut out = Vec::new();
+        while let Some(e) = s.next().await.unwrap() {
+            out.push(e);
+        }
+        (out, s.truncated_tail(), s.entries_touched())
+    }
+
+    #[tokio::test]
+    async fn streams_every_entry_in_order_from_offset_zero() {
+        let mut bytes = Vec::new();
+        for (k, off) in [
+            (b"aaaa".as_slice(), 0u64),
+            (b"bbbb", 100),
+            (b"cccc", 250),
+            (b"dddd", 400),
+        ] {
+            bytes.extend_from_slice(&encode_entry(k, off));
+        }
+        let (dir, path) = write_temp("order", &bytes);
+        let (entries, truncated, touched) = drain(&path, 0).await;
+        assert_eq!(entries.len(), 4);
+        assert_eq!(entries[0].key_digest.as_ref(), b"aaaa");
+        assert_eq!(entries[0].data_offset, 0);
+        assert_eq!(entries[3].key_digest.as_ref(), b"dddd");
+        assert_eq!(entries[3].data_offset, 400);
+        assert!(
+            !truncated,
+            "a clean stream must not report a truncated tail"
+        );
+        assert_eq!(touched, 4);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn seeking_to_a_sample_offset_starts_mid_file() {
+        let first = encode_entry(b"before", 0);
+        let rest = {
+            let mut v = Vec::new();
+            v.extend_from_slice(&encode_entry(b"target", 900));
+            v.extend_from_slice(&encode_entry(b"after", 950));
+            v
+        };
+        let mut bytes = first.clone();
+        bytes.extend_from_slice(&rest);
+        let (dir, path) = write_temp("seek", &bytes);
+        let (entries, _truncated, _touched) = drain(&path, first.len() as u64).await;
+        assert_eq!(entries.len(), 2, "seek skips the first entry");
+        assert_eq!(entries[0].key_digest.as_ref(), b"target");
+        assert_eq!(entries[1].key_digest.as_ref(), b"after");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn truncated_tail_is_reported() {
+        let mut bytes = encode_entry(b"whole", 10);
+        // A dangling key-length header with no body: a mid-entry cut (Signal A).
+        bytes.extend_from_slice(&[0x00, 0x40]);
+        let (dir, path) = write_temp("trunc", &bytes);
+        let (entries, truncated, touched) = drain(&path, 0).await;
+        assert_eq!(entries.len(), 1, "only the one whole entry is yielded");
+        assert!(truncated, "the dangling tail must be flagged truncated");
+        assert_eq!(touched, 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn streams_across_refill_boundaries() {
+        // Enough entries that the total exceeds REFILL_CHUNK, forcing multiple
+        // refills — the bounded-memory streaming property under test.
+        let n = 4000usize;
+        let mut bytes = Vec::new();
+        for i in 0..n {
+            let key = format!("key{i:08}");
+            bytes.extend_from_slice(&encode_entry(key.as_bytes(), (i * 10) as u64));
+        }
+        assert!(bytes.len() > REFILL_CHUNK, "fixture must span >1 refill");
+        let (dir, path) = write_temp("refill", &bytes);
+        let (entries, truncated, touched) = drain(&path, 0).await;
+        assert_eq!(entries.len(), n);
+        assert_eq!(entries[n - 1].data_offset, ((n - 1) * 10) as u64);
+        assert!(!truncated);
+        assert_eq!(touched, n);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn empty_file_is_a_clean_empty_stream() {
+        let (dir, path) = write_temp("empty", &[]);
+        let (entries, truncated, touched) = drain(&path, 0).await;
+        assert!(entries.is_empty());
+        assert!(!truncated, "a zero-length file is not a truncated tail");
+        assert_eq!(touched, 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/component_loading.rs
+++ b/cqlite-core/src/storage/sstable/reader/component_loading.rs
@@ -156,11 +156,21 @@ impl SSTableReader {
         Ok(None)
     }
 
-    /// Load Index.db reader for partition lookup
+    /// Load Index.db reader for partition lookup.
+    ///
+    /// Issue #2412 (design §A): when `summary_usable` (a `Summary.db` loaded with at
+    /// least one sample entry — the authority a bounded lazy walk needs) is `true`,
+    /// this defers the whole-file parse via [`IndexReader::open_lazy`] — BIG open
+    /// then costs O(summary), not O(partitions). When no usable `Summary.db` exists,
+    /// this falls back to today's EAGER parse (§A1's counted FellBack): there is no
+    /// summary to bound a lazy walk against, so the full parse happens immediately,
+    /// surfaced via this debug trace (never silent) and still counted on the
+    /// unchanged `index_parses_total` counter (`parse.rs`'s single full-parse site).
     pub(super) async fn load_index_reader(
         path: &Path,
         platform: &Arc<Platform>,
         cancel: &crate::storage::scan_cancel::ScanCancel,
+        summary_usable: bool,
     ) -> Result<IndexLoadOutcome> {
         let Some(base_name) = extract_sstable_base_name(path) else {
             return Ok(IndexLoadOutcome::Absent);
@@ -170,24 +180,34 @@ impl SSTableReader {
         };
         let index_path = parent.join(format!("{}-Index.db", base_name));
 
-        match IndexReader::open_with_summary_cancellable(
-            &index_path,
-            platform.clone(),
-            None,
-            cancel,
-        )
-        .await
-        {
+        let open_result = if summary_usable {
+            IndexReader::open_lazy(&index_path, platform.clone()).await
+        } else {
+            tracing::debug!(
+                "Index.db FellBack to an eager full parse for {} (issue #2412 §A1): no usable \
+                 Summary.db to bound a lazy Summary-guided walk",
+                index_path.display()
+            );
+            IndexReader::open_with_summary_cancellable(&index_path, platform.clone(), None, cancel)
+                .await
+        };
+
+        match open_result {
             Ok(reader) => {
-                tracing::debug!("Loaded Index.db reader for {}", index_path.display());
+                tracing::debug!(
+                    "Loaded Index.db reader for {} ({})",
+                    index_path.display(),
+                    if summary_usable { "lazy" } else { "eager" }
+                );
                 Ok(IndexLoadOutcome::Loaded(Box::new(reader)))
             }
             // A genuinely absent Index.db (some shapes legitimately ship without one)
             // is quiet & expected. A PRESENT-but-unloadable Index.db (open/parse
             // errored) is the silent-degradation class issue #2302 exists to kill:
             // surface it so `iterate_all_partitions` can WARN loud rather than
-            // silently full-scan. `IndexReader::open` returns `NotFound` iff the file
-            // is absent, so the error kind is the authoritative discriminator.
+            // silently full-scan. `IndexReader::open`/`open_lazy` both return
+            // `NotFound` iff the file is absent, so the error kind is the
+            // authoritative discriminator.
             Err(Error::NotFound(_)) => {
                 tracing::debug!("No Index.db present at {}", index_path.display());
                 Ok(IndexLoadOutcome::Absent)

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
@@ -138,21 +138,37 @@ impl SSTableReader {
                     // safe scan_for_key oracle to preserve the pre-#1572 result.
                 }
                 None => {
-                    // Index.db map miss. An index miss is NOT treated as a
-                    // definitive absent (issue #1572 correctness): `IndexReader::open`
-                    // opens a truncated / partially-corrupt Index.db with a PARTIAL
-                    // prefix map, and truncation aligned to an EXACT entry boundary
-                    // (whole trailing entries dropped) leaves the surviving prefix
-                    // parsing cleanly to EOF — indistinguishable from a complete map
-                    // at parse time, with no cleanly-available authoritative partition
-                    // count at this layer to detect the loss. A partition whose entry
-                    // was dropped would then miss the map yet still be present in
-                    // Data.db — a silent get/scan divergence. So conservatively fall
-                    // back to the whole-file `scan_for_key` oracle, which keeps
-                    // `get()`/`scan()` in agreement and keeps the SCAN_FOR_KEY_CALLS
-                    // counter observable. The fast definitive-absent path for the
-                    // common (non-degraded) case is the bloom pre-check above; this
-                    // fallback fires only on a bloom false-positive (rare, acceptable).
+                    // Index.db map miss.
+                    //
+                    // Stage 3 (issue #2412 §B): when the miss came from an END-BOUNDED
+                    // Summary-guided interval (a usable `Summary.db` bounds a not-yet-
+                    // materialized `Index.db`, AND the key's covering interval is
+                    // delimited above by a NEXT summary sample), the interval lies
+                    // BETWEEN two adjacent authoritative `Summary.db` sample positions,
+                    // so the absence is authoritative — the whole-file `scan_for_key`
+                    // oracle is NOT needed. The LAST interval (read to EOF) is
+                    // deliberately EXCLUDED: a tail-truncated `Index.db` (the #1572
+                    // degraded-input class) can only drop the highest-token partitions,
+                    // which live in that last interval, so a miss there keeps the
+                    // conservative scan below and preserves the #1572 get/scan
+                    // agreement. See `covering_interval_is_end_bounded`.
+                    if self.should_use_summary_interval()
+                        && self.covering_interval_is_end_bounded(key.as_bytes())
+                    {
+                        return Ok((None, false));
+                    }
+                    // FellBack / already-materialized path (no usable Summary.db, or a
+                    // resident map): an index miss is NOT a definitive absent (issue
+                    // #1572). `IndexReader::open` opens a truncated / partially-corrupt
+                    // Index.db with a PARTIAL prefix map, and truncation aligned to an
+                    // EXACT entry boundary (whole trailing entries dropped) leaves the
+                    // surviving prefix parsing cleanly to EOF — indistinguishable from a
+                    // complete map at parse time, with no cleanly-available authoritative
+                    // partition count at this layer to detect the loss. A partition whose
+                    // entry was dropped would then miss the map yet still be present in
+                    // Data.db — a silent get/scan divergence. So conservatively fall back
+                    // to the whole-file `scan_for_key` oracle, which keeps `get()`/`scan()`
+                    // in agreement and keeps the SCAN_FOR_KEY_CALLS counter observable.
                     // NOT an oracle exclusion: the scan itself is the authority here.
                     return self
                         .scan_for_key(table_id, key)

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
@@ -156,7 +156,7 @@ impl SSTableReader {
     /// promoted index (a narrow partition), a variable-width clustering column, an
     /// un-decodable block name, a block carrying an open range-tombstone marker, or
     /// an empty block selection.
-    pub(super) fn big_clustering_row_window(
+    pub(super) async fn big_clustering_row_window(
         &self,
         partition_key: &[u8],
         slice: &ClusteringSlice,
@@ -168,7 +168,10 @@ impl SSTableReader {
         let Some(layout) = fixed_clustering_layout(schema) else {
             return Ok(None);
         };
-        let Some(decoded) = self.decode_partition_promoted_index(partition_key, &layout)? else {
+        let Some(decoded) = self
+            .decode_partition_promoted_index(partition_key, &layout)
+            .await?
+        else {
             return Ok(None);
         };
         if decoded.entries.is_empty() {
@@ -222,7 +225,7 @@ impl SSTableReader {
     /// within-partition `(start, end)` byte window, a tightened decode end bound,
     /// and whether the clustering narrowing engaged.
     #[allow(clippy::type_complexity)]
-    pub(super) fn resolve_clustering_seek_window(
+    pub(super) async fn resolve_clustering_seek_window(
         &self,
         is_bti: bool,
         partition_key: &[u8],
@@ -237,7 +240,8 @@ impl SSTableReader {
         let narrow = if is_bti {
             self.bti_clustering_row_window(partition_key, slice, schema)?
         } else {
-            self.big_clustering_row_window(partition_key, slice, schema)?
+            self.big_clustering_row_window(partition_key, slice, schema)
+                .await?
         };
         let Some(narrow) = narrow else {
             return Ok((None, end_bound, false));
@@ -264,7 +268,7 @@ impl SSTableReader {
     /// the partition has no Index.db entry or no promoted index (a narrow partition).
     /// Decode errors (e.g. a non-`CLUSTERING` block name) surface as `Err` so the
     /// caller can treat them as a non-narrowable fallback.
-    fn decode_partition_promoted_index(
+    async fn decode_partition_promoted_index(
         &self,
         partition_key: &[u8],
         layout: &[(CqlTypeId, usize)],
@@ -272,6 +276,10 @@ impl SSTableReader {
         let Some(index_reader) = self.index_reader.as_ref() else {
             return Ok(None);
         };
+        // Issue #2412 Stage 2: a lazily-opened reader defers the full parse to
+        // first use — this promoted-index lookup IS that first use. No-op for an
+        // eagerly-opened reader.
+        index_reader.ensure_materialized(&self.scan_cancel).await?;
         let Some(entry) = index_reader.lookup_partition(partition_key) else {
             return Ok(None);
         };
@@ -347,7 +355,10 @@ impl SSTableReader {
         let Some(layout) = fixed_clustering_layout(schema) else {
             return Ok(None);
         };
-        let Some(decoded) = self.decode_partition_promoted_index(partition_key, &layout)? else {
+        let Some(decoded) = self
+            .decode_partition_promoted_index(partition_key, &layout)
+            .await?
+        else {
             return Ok(None);
         };
         if decoded.entries.is_empty() {
@@ -362,7 +373,10 @@ impl SSTableReader {
         let Some((offset, _size)) = self.lookup_partition_with_index(partition_key).await? else {
             return Ok(None);
         };
-        let end_bound = self.successor_partition_offset(offset)?.map(|e| e as usize);
+        let end_bound = self
+            .successor_partition_offset(offset)
+            .await?
+            .map(|e| e as usize);
 
         // Decompress exactly the chunks covering the target partition ONCE; block
         // windowing then bounds each per-iteration decode to one block.

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -146,7 +146,10 @@ impl SSTableReader {
         // `None` means `offset` is the LAST partition (no successor): the callee
         // bounds the end with the authoritative data-section length, or falls back
         // to the safe full-scan path when that length is unknown.
-        let end_bound = self.successor_partition_offset(offset)?.map(|e| e as usize);
+        let end_bound = self
+            .successor_partition_offset(offset)
+            .await?
+            .map(|e| e as usize);
 
         let schema_opt = self.get_table_schema(schema);
 
@@ -162,7 +165,8 @@ impl SSTableReader {
                 clustering,
                 schema_opt.as_ref(),
                 end_bound,
-            )?;
+            )
+            .await?;
 
         // Issue #1184: an engaged BIG clustering narrowing decodes the selected block
         // window via `big_promoted.rs` (partition-key-bytes guard, not the BTI strict

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -78,6 +78,11 @@ impl SSTableReader {
         let Some(index_reader) = &self.index_reader else {
             return Ok(None);
         };
+        // Issue #2412 Stage 2: a lazily-opened reader defers the full parse to
+        // first use — a full materializing enumeration IS that first use (Stage 4
+        // replaces this consumer with a true streaming walk that never
+        // materializes the whole map). No-op for an eagerly-opened reader.
+        index_reader.ensure_materialized(scan_cancel).await?;
         let entries = index_reader.get_partition_entries();
 
         // Exclusive end of the last partition = the UNCOMPRESSED data-section length.

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -128,6 +128,12 @@ impl SSTableReader {
         let Some(index_reader) = &self.index_reader else {
             return Ok(FullIndexStreamOutcome::FellBack);
         };
+        // Issue #2412 Stage 2: a lazily-opened reader defers the full parse to
+        // first use — a full streaming enumeration IS that first use (Stage 4
+        // replaces the SOURCE of entries with a true Summary-guided streaming
+        // walk that never materializes the whole map; the walk CONTRACT below is
+        // unchanged either way). No-op for an eagerly-opened reader.
+        index_reader.ensure_materialized(scan_cancel).await?;
         let entries = index_reader.get_partition_entries();
 
         // Exclusive end of the last partition (uncompressed data-section domain).

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -67,7 +67,7 @@ use std::ops::ControlFlow;
 /// decrease of the `(token, key)` pair is. Factored out as a pure function
 /// (`prev`/`token`/`key`/`index` in, `Result<()>` out) so it is unit-testable
 /// without a full `SSTableReader` fixture.
-fn check_token_order(
+pub(in crate::storage::sstable::reader) fn check_token_order(
     prev: Option<(i64, &[u8])>,
     token: i64,
     key: &[u8],

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -52,7 +52,9 @@ mod compressed_offset;
 // Full-Index.db partition enumeration (issue #2302).
 mod full_index_scan;
 // True-streaming full-Index.db enumeration (issue #2361).
-mod full_index_stream;
+pub(in crate::storage::sstable::reader) mod full_index_stream;
+// Summary-guided streaming enumeration + token pushdown (issue #2412 §C / #2413).
+mod summary_scan;
 // Streaming + LIMIT + cancel coverage (issue #2361). The fixtures use
 // `SSTableWriter` + `write_engine::mutation` (write-support-only APIs) to build
 // a real Index.db-backed SSTable, so — like the sibling `compaction_cancel_tests`
@@ -87,6 +89,10 @@ mod sequential;
 pub use model::ClusteringSlice;
 #[cfg(not(feature = "tombstones"))]
 pub use point_compaction::SinglePartitionCompaction;
+// Token-range bound pushed into the Summary-guided streaming walk (issue #2413
+// Option A). Re-exported to the crate so the flight warm merge can construct one
+// from its `TokenFilter`.
+pub use summary_scan::ScanTokenBound;
 
 // Re-export the decompress-work counter so the sibling `scan_stream_windowed`
 // module (outside `data_access`) can increment it on the windowed-scan miss path

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction.rs
@@ -167,7 +167,7 @@ impl SSTableReader {
         // 4. Authoritative exclusive end of the target partition: the successor
         //    partition's start (next trie/index entry), or `None` for the last.
         //    Same fail-safe class as step 3 — it reads the same index/trie.
-        let end_bound = match self.successor_partition_offset(offset) {
+        let end_bound = match self.successor_partition_offset(offset).await {
             Ok(bound) => bound,
             Err(e) => {
                 tracing::debug!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/point_compaction_fail_safe_tests.rs
@@ -658,6 +658,7 @@ async fn truncated_chunk_window_degrades_to_scan_fallback_not_partial_rows() {
             .expect("pk=1 must resolve via the intact BTI trie");
         let end = reader
             .successor_partition_offset(target_off)
+            .await
             .unwrap()
             .expect("pk=1 is a head partition and must have a successor bound");
         let ci_len = std::fs::metadata(sibling_compression_info(&data_path))

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan.rs
@@ -1,0 +1,531 @@
+//! Summary-guided streaming partition enumeration (issue #2412 §C / #2413
+//! Option A, Stage 4).
+//!
+//! The #2361 streaming walk ([`full_index_stream`](super::full_index_stream))
+//! emits each partition as the index resolves it, but sources its entries from
+//! the resident `Vec<PartitionIndexEntry>` — which requires the whole `Index.db`
+//! to be materialised first ([`IndexReader::ensure_materialized`](crate::storage::sstable::index_reader::IndexReader::ensure_materialized),
+//! the ~500MB-resident structure #2385 retired at open). This module sources the
+//! SAME walk from a FORWARD-STREAMED `Index.db`
+//! ([`IndexEntryStream`](crate::storage::sstable::index_reader::IndexEntryStream)),
+//! so a warm BIG reader never materialises the full map (spec R3/R4).
+//!
+//! Two extra wins over the materialising walk:
+//! - **No resident `Vec`.** Entry memory is one refill window, partition-count
+//!   independent — the property the warm registry (Stage 5) relies on.
+//! - **Token pushdown (#2413).** A token-range split begins the walk at the
+//!   `Summary.db` sample covering the range start
+//!   ([`SummaryReader::scan_start_position_for_token`](crate::storage::sstable::summary_reader::SummaryReader::scan_start_position_for_token))
+//!   and stops once the walk passes the range end, so out-of-range partition
+//!   bodies are never read/decoded. A compaction consumer passes no range and
+//!   walks the full ring.
+//!
+//! Walk contract preserved from #2361: the `(token, key)` order guard
+//! ([`check_token_order`](super::full_index_stream::check_token_order)),
+//! per-partition structural coverage
+//! ([`partition_slice_fully_consumed`](SSTableReader::partition_slice_fully_consumed),
+//! Signal B), cancel-aware polling, and the `stream_walk_partitions_parsed`
+//! work-probe. The completeness signal (Signal A, mid-entry truncation) moves to
+//! the streaming terminus ([`IndexEntryStream::truncated_tail`](crate::storage::sstable::index_reader::IndexEntryStream)).
+//!
+//! No-heuristics (issue #28): the start offset is an authoritative `Summary.db`
+//! sample position; every entry is authoritative `Index.db` framing; each
+//! partition body is bounded by the SUCCESSOR entry's offset (last by the
+//! data-section end) — never a guessed size.
+
+use std::ops::ControlFlow;
+
+use super::super::SSTableReader;
+use super::full_index_stream::{check_token_order, FullIndexStreamOutcome};
+use crate::storage::scan_cancel::ScanCancel;
+use crate::types::ScanRow;
+use crate::util::cassandra_murmur3::cassandra_murmur3_token;
+use crate::{Error, Result, RowKey};
+
+/// Half-open `(start_excl, end_incl]` token bound pushed into the per-SSTable walk
+/// (issue #2413 Option A). Mirrors the flight `TokenFilter` half-open semantics
+/// exactly (including the `start == end` FULL-ring convention, #2228); the flight
+/// crate constructs one of these from its `TokenFilter` and a grid test pins that
+/// the two agree, so the membership rule lives in ONE place.
+#[derive(Debug, Clone, Copy)]
+pub struct ScanTokenBound {
+    /// Exclusive lower bound.
+    pub start_excl: i64,
+    /// Inclusive upper bound.
+    pub end_incl: i64,
+    /// Ring-wraparound segment (`start > end`): keep `token > start || token <= end`.
+    pub wraparound: bool,
+}
+
+impl ScanTokenBound {
+    /// Whether `token` is inside this half-open `(start, end]` range.
+    pub fn contains(&self, token: i64) -> bool {
+        // #2228: equal endpoints denote the FULL ring, not the empty set.
+        if self.start_excl == self.end_incl {
+            return true;
+        }
+        if self.wraparound {
+            token > self.start_excl || token <= self.end_incl
+        } else {
+            token > self.start_excl && token <= self.end_incl
+        }
+    }
+
+    /// Whether every remaining (token-ascending) partition is guaranteed to be
+    /// ABOVE this range, so a forward walk can stop. Only sound for a
+    /// non-wraparound range (a wraparound range has in-range tokens at both ends
+    /// of the ring, so a forward walk cannot early-stop).
+    fn can_stop_past(&self, token: i64) -> bool {
+        !self.wraparound && self.start_excl != self.end_incl && token > self.end_incl
+    }
+}
+
+impl SSTableReader {
+    /// The `Index.db` path SIBLING of this reader's CURRENT `Data.db` path (issue
+    /// #2412 §C, #2383-aware). Derived from [`Self::file_path`] (the ArcSwap that a
+    /// #2383 inode-rebind updates) by swapping the `-Data.db` component suffix, so a
+    /// fresh streaming `Index.db` open follows a snapshot rebind rather than
+    /// re-opening a torn-down path. Falls back to the reader's recorded open-time
+    /// index path when the `Data.db` name is not the expected `*-Data.db` shape.
+    fn current_index_db_path(&self) -> std::path::PathBuf {
+        let data = self.file_path();
+        if let (Some(parent), Some(name)) =
+            (data.parent(), data.file_name().and_then(|n| n.to_str()))
+        {
+            if let Some(base) = name.strip_suffix("-Data.db") {
+                return parent.join(format!("{base}-Index.db"));
+            }
+        }
+        self.index_reader
+            .as_ref()
+            .map(|ir| ir.index_path().to_path_buf())
+            .unwrap_or(data)
+    }
+
+    /// Shared Summary-guided FORWARD `Index.db` walk (issue #2412 §C / #2413
+    /// Option A): stream in-range partition SLICES from a `Summary.db`-guided start
+    /// offset WITHOUT materialising the resident partition map, invoking `decode`
+    /// on each in-range partition's exact `Data.db` byte slice.
+    ///
+    /// Both emit shapes are built on this: the read-shadowing ScanRow decoder
+    /// ([`stream_partitions_summary_guided`](Self::stream_partitions_summary_guided),
+    /// the non-stitching `V5_0Uncompressed` model) and the full-fidelity
+    /// CompactionRow decoder
+    /// ([`stream_partitions_summary_guided_compaction`](Self::stream_partitions_summary_guided_compaction),
+    /// the chunk-stitching `nb` merge model). Factoring the walk here means the
+    /// order guard, coverage check, work-probe, and range/terminus logic are
+    /// defined ONCE — the two decoders differ only in how a proven-complete slice
+    /// becomes rows.
+    ///
+    /// `token_bound`: `None` = full ring from offset 0; `Some(bound)` = begin at
+    /// the sample covering `start_excl` and stop once past `end_incl`.
+    ///
+    /// Returns [`FullIndexStreamOutcome::FellBack`] (nothing emitted) when there is
+    /// no usable summary/index to stream from. Any inconsistency AFTER the first
+    /// emit is a hard [`Error`] (fail-closed): a streaming walk cannot fall back.
+    async fn walk_in_range_partition_slices<D>(
+        &self,
+        scan_cancel: &ScanCancel,
+        token_bound: Option<ScanTokenBound>,
+        parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
+        schema: Option<&crate::schema::TableSchema>,
+        decode: &mut D,
+    ) -> Result<FullIndexStreamOutcome>
+    where
+        D: FnMut(&[u8]) -> Result<ControlFlow<()>>,
+    {
+        let (Some(_index_reader), Some(summary)) =
+            (self.index_reader.as_ref(), self.summary_reader.as_ref())
+        else {
+            return Ok(FullIndexStreamOutcome::FellBack);
+        };
+        if summary.get_entries().is_empty() {
+            return Ok(FullIndexStreamOutcome::FellBack);
+        }
+
+        // Exclusive end of the last partition (uncompressed data-section domain),
+        // identical to the materialising walk's derivation.
+        let data_section_end = match self.compression_info.as_deref() {
+            Some(ci) => ci.data_length,
+            None => self
+                .stats
+                .file_size
+                .saturating_sub(self.actual_header_size as u64),
+        };
+        if data_section_end == 0 {
+            return Ok(FullIndexStreamOutcome::FellBack);
+        }
+
+        // Summary-guided start offset: the covering sample for a token range's
+        // exclusive lower bound, else the index start for a full scan.
+        let start_position = match token_bound {
+            Some(bound) => summary.scan_start_position_for_token(bound.start_excl),
+            None => 0,
+        };
+
+        // Derive the `Index.db` path from the reader's CURRENT (possibly
+        // #2383-rebound) `Data.db` path, NOT the index_reader's recorded open-time
+        // path: a warm reader rebound across a snapshot teardown keeps its already
+        // -open `Data.db` FD (valid even after the snapshot dir is cleared) and
+        // swaps only `file_path`, but the streaming index read does a FRESH
+        // `File::open` — so it must follow the rebind or ENOENT on the dead
+        // snapshot path (#2352). Snapshot components are same-inode hardlinks, so
+        // the rebound path's `Index.db` is byte-identical to the open-time one.
+        let index_db_path = self.current_index_db_path();
+        let mut stream = crate::storage::sstable::index_reader::IndexEntryStream::open(
+            &index_db_path,
+            start_position,
+        )
+        .await?;
+
+        // One-entry lookahead so each partition body is bounded by its SUCCESSOR's
+        // offset (the last by the data-section end), exactly as the materialising
+        // walk bounds `entries[i]` by `entries[i+1]`.
+        let mut prev_key: Option<(i64, Vec<u8>)> = None;
+        let mut index = 0usize;
+        let mut emitted_any = false;
+        let Some(mut current) = stream.next().await? else {
+            // Zero entries from the start offset: nothing in range (or empty).
+            return Ok(FullIndexStreamOutcome::Streamed);
+        };
+
+        loop {
+            scan_cancel.check()?;
+
+            let cur_key: Vec<u8> = current
+                .raw_key
+                .as_deref()
+                .map(|k| k.to_vec())
+                .unwrap_or_default();
+            // Empty partition keys round-trip corrupt through BOTH read paths
+            // (issue #2302/#2325): before any emit, fall back safely; after an
+            // emit, fail closed rather than feed the merger a corrupt shape.
+            if cur_key.is_empty() {
+                if emitted_any {
+                    return Err(Error::corruption(
+                        "walk_in_range_partition_slices: empty partition key mid-walk \
+                         (issue #2302/#2325)"
+                            .to_string(),
+                    ));
+                }
+                return Ok(FullIndexStreamOutcome::FellBack);
+            }
+
+            let token = cassandra_murmur3_token(&cur_key);
+
+            // (token, key) order guard — the merge-input contract (issue #2361).
+            check_token_order(
+                prev_key.as_ref().map(|(t, k)| (*t, k.as_slice())),
+                token,
+                &cur_key,
+                index,
+            )?;
+
+            // Read the successor to bound the current partition (and to decide the
+            // range stop). The successor of the LAST entry is the data-section end.
+            let next = stream.next().await?;
+            let end = next
+                .as_ref()
+                .map(|n| n.data_offset)
+                .unwrap_or(data_section_end);
+
+            // Token pushdown (#2413): decode only in-range bodies.
+            let in_range = token_bound.map(|b| b.contains(token)).unwrap_or(true);
+            if in_range {
+                let start = current.data_offset;
+                if end <= start {
+                    return Err(Error::corruption(format!(
+                        "walk_in_range_partition_slices: non-ascending offset at entry \
+                         {index} (offset {start} >= successor {end}, issue #2412)"
+                    )));
+                }
+                let span = end - start;
+                let Ok(size) = u32::try_from(span) else {
+                    return Err(Error::corruption(format!(
+                        "walk_in_range_partition_slices: partition {index} span {span} \
+                         overflows u32 (issue #2412)"
+                    )));
+                };
+
+                let raw = if let Some(ci) = self.compression_info.as_deref() {
+                    self.read_compressed_offset_window(ci, start, size).await?
+                } else {
+                    let absolute_offset = start + self.actual_header_size as u64;
+                    self.read_uncompressed_verified(&self.file, absolute_offset, size as usize)
+                        .await?
+                };
+
+                // Structural coverage (Signal B): the slice must decode as exactly
+                // one complete partition. Mid-walk failure = fail-closed.
+                if !self.partition_slice_fully_consumed(parser, &raw, schema)? {
+                    return Err(Error::corruption(format!(
+                        "walk_in_range_partition_slices: partition {index} slice not fully \
+                         consumed (truncated/corrupt body, issue #2412)"
+                    )));
+                }
+
+                // Work-probe (issue #2398): one partition body decoded. A narrow
+                // token range must keep this near its in-range slice, not O(all).
+                crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
+                emitted_any = true;
+                match decode(&raw)? {
+                    ControlFlow::Continue(()) => {}
+                    ControlFlow::Break(()) => return Ok(FullIndexStreamOutcome::Streamed),
+                }
+            }
+
+            // Advance. Stop early once a non-wraparound range is fully past its end.
+            if let Some(bound) = token_bound {
+                if bound.can_stop_past(token) {
+                    return Ok(FullIndexStreamOutcome::Streamed);
+                }
+            }
+            match next {
+                Some(n) => {
+                    prev_key = Some((token, cur_key));
+                    current = n;
+                    index += 1;
+                }
+                None => break,
+            }
+        }
+
+        // Terminus completeness (Signal A, issue #2302): for a FULL scan a
+        // mid-entry-truncated `Index.db` tail must be detectable — after an emit
+        // the streaming walk cannot fall back, so this is a hard fail-closed error
+        // (never a silent under-enumeration). A token-range scan does not enumerate
+        // the tail, so a truncated tail beyond its range is not its concern.
+        if token_bound.is_none() && stream.truncated_tail() {
+            return Err(Error::corruption(
+                "walk_in_range_partition_slices: Index.db tail truncated mid-entry — \
+                 full-scan enumeration is incomplete (Signal A, issue #2302/#2412)"
+                    .to_string(),
+            ));
+        }
+
+        Ok(FullIndexStreamOutcome::Streamed)
+    }
+
+    /// Read-shadowing ScanRow decoder over the shared walk (the non-stitching
+    /// `V5_0Uncompressed` model): each in-range partition slice is decoded with the
+    /// read-shadowing parser (`build_v5_parser(true)`) and its surviving rows are
+    /// emitted as `(RowKey, ScanRow)` — byte-identical to
+    /// [`stream_all_partitions_via_full_index`](Self::iterate_all_partitions_via_full_index)'s
+    /// per-partition emit, but streamed (no resident `Vec`) + token-scoped.
+    pub(in crate::storage::sstable::reader) async fn stream_partitions_summary_guided<F>(
+        &self,
+        scan_cancel: &ScanCancel,
+        token_bound: Option<ScanTokenBound>,
+        emit: &mut F,
+    ) -> Result<FullIndexStreamOutcome>
+    where
+        F: FnMut((RowKey, ScanRow)) -> Result<ControlFlow<()>>,
+    {
+        let parser = self.build_v5_parser(true);
+        let reader_schema = self.get_table_schema(None);
+        let schema = reader_schema.as_ref();
+        self.walk_in_range_partition_slices(scan_cancel, token_bound, &parser, schema, &mut |raw| {
+            let parsed = parser.parse_block(raw, schema, self)?;
+            for (_table_id, row_key, value) in parsed {
+                if self.filter_tombstone(&value) {
+                    match emit((row_key, value))? {
+                        ControlFlow::Continue(()) => {}
+                        ControlFlow::Break(()) => return Ok(ControlFlow::Break(())),
+                    }
+                }
+            }
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+    }
+
+    /// Full-fidelity CompactionRow decoder over the shared walk (the chunk-stitching
+    /// `nb` merge model): each in-range partition slice is decoded with the
+    /// compaction parser (`build_v5_parser(false)`) via
+    /// `parse_one_partition_for_compaction` — byte-identical to
+    /// [`drain_compaction_window`](Self::stream_all_partitions_for_compaction)'s
+    /// per-partition [`CompactionRow`](super::super::compaction_row::CompactionRow)
+    /// emit (preserving cell timestamps / tombstone markers the k-way merger's LWW
+    /// reconciliation needs), but streamed + token-scoped. `at_final_chunk = true`
+    /// because `raw` is exactly one complete, coverage-proven partition slice.
+    async fn stream_partitions_summary_guided_compaction<F>(
+        &self,
+        scan_cancel: &ScanCancel,
+        token_bound: Option<ScanTokenBound>,
+        schema: Option<&crate::schema::TableSchema>,
+        emit: &mut F,
+    ) -> Result<FullIndexStreamOutcome>
+    where
+        F: FnMut(super::super::compaction_row::CompactionRow) -> Result<ControlFlow<()>>,
+    {
+        use crate::storage::sstable::reader::parsing::ParseStep;
+        let parser = self.build_v5_parser(false);
+        let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
+        let sch = owned_schema.as_ref();
+        self.walk_in_range_partition_slices(scan_cancel, token_bound, &parser, sch, &mut |raw| {
+            let mut broke = false;
+            let step = parser.parse_one_partition_for_compaction(
+                raw,
+                sch,
+                self,
+                true,
+                &mut |row: super::super::compaction_row::CompactionRow| match emit(row)? {
+                    ControlFlow::Continue(()) => Ok(ControlFlow::Continue(())),
+                    ControlFlow::Break(()) => {
+                        broke = true;
+                        Ok(ControlFlow::Break(()))
+                    }
+                },
+            )?;
+            // The coverage check already proved `raw` decodes as exactly one
+            // complete partition, so a non-`Emitted` step here is a structural
+            // inconsistency — fail closed rather than silently drop the partition.
+            if !matches!(step, ParseStep::Emitted(_)) {
+                return Err(Error::corruption(
+                    "stream_partitions_summary_guided_compaction: coverage-proven slice \
+                     did not decode to a terminated partition (issue #2412)"
+                        .to_string(),
+                ));
+            }
+            if broke {
+                return Ok(ControlFlow::Break(()));
+            }
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+    }
+
+    /// Query-serve partition enumeration for the WARM reader-based merge (issue
+    /// #2412 §C / #2413 Option A) — the analogue of
+    /// [`stream_all_partitions_for_compaction`](Self::stream_all_partitions_for_compaction)
+    /// that the flight `do_get` warm path drives (`from_readers::drive_query_stream`).
+    ///
+    /// Routing MIRRORS `stream_all_partitions_for_compaction`'s per-mechanism emit
+    /// shape so the merger reconciles identically, but STREAMS the index (no
+    /// resident `Vec`, spec R4) and pushes the token range into the walk (#2413):
+    /// - Chunk-stitching (`nb`) readers use the full-fidelity CompactionRow decoder
+    ///   ([`stream_partitions_summary_guided_compaction`](Self::stream_partitions_summary_guided_compaction)) —
+    ///   byte-identical to `drain_compaction_window`'s emit, so cross-generation
+    ///   LWW reconciliation is preserved.
+    /// - Non-stitching (`V5_0Uncompressed`) readers use the read-shadowing ScanRow
+    ///   decoder ([`stream_partitions_summary_guided`](Self::stream_partitions_summary_guided)) —
+    ///   byte-identical to `stream_all_partitions_cancellable`'s emit.
+    ///
+    /// A `FellBack` (no usable summary/index) routes on to the full-ring
+    /// `stream_all_partitions_for_compaction`. Compaction consumers do NOT call
+    /// this (they use the path-based stream directly, no token range), so they keep
+    /// full-ring byte-parity walks unchanged (spec R3).
+    pub async fn stream_all_partitions_for_query<F>(
+        &self,
+        schema: Option<&crate::schema::TableSchema>,
+        scan_cancel: &ScanCancel,
+        token_bound: Option<ScanTokenBound>,
+        mut emit: F,
+    ) -> Result<()>
+    where
+        F: FnMut(super::super::compaction_row::CompactionRow) -> Result<ControlFlow<()>>,
+    {
+        let summary_usable = self
+            .summary_reader
+            .as_ref()
+            .map(|s| !s.get_entries().is_empty())
+            .unwrap_or(false);
+        if self.index_reader.is_some() && self.bti_partitions_db.is_none() && summary_usable {
+            let outcome = if self.requires_chunk_stitching() {
+                // `nb` merge model: full-fidelity CompactionRows (cell timestamps /
+                // tombstone markers preserved for the merger's LWW reconciliation).
+                self.stream_partitions_summary_guided_compaction(
+                    scan_cancel,
+                    token_bound,
+                    schema,
+                    &mut emit,
+                )
+                .await?
+            } else {
+                // `V5_0Uncompressed` model: read-shadowing rows adapted to
+                // CompactionRow (row_timestamp 0), matching the non-stitching
+                // compaction stream's emit exactly.
+                self.stream_partitions_summary_guided(scan_cancel, token_bound, &mut |(k, v)| {
+                    let row =
+                        super::super::compaction_row::CompactionRow::from_legacy_value(k, v, 0);
+                    emit(row)
+                })
+                .await?
+            };
+            if matches!(outcome, FullIndexStreamOutcome::Streamed) {
+                return Ok(());
+            }
+            tracing::warn!(
+                "stream_all_partitions_for_query: Summary-guided streaming fell back \
+                 (no usable Summary.db/Index.db to stream); using the full-ring \
+                 compaction stream (issue #2412)."
+            );
+        }
+        // Full-ring fallback (no usable summary/index): the downstream token filter
+        // still bounds the result set, so correctness holds without pushdown.
+        self.stream_all_partitions_for_compaction(schema, scan_cancel, emit)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScanTokenBound;
+
+    #[test]
+    fn contains_non_wraparound_half_open() {
+        let b = ScanTokenBound {
+            start_excl: 10,
+            end_incl: 20,
+            wraparound: false,
+        };
+        assert!(!b.contains(10), "start is exclusive");
+        assert!(b.contains(11));
+        assert!(b.contains(20), "end is inclusive");
+        assert!(!b.contains(21));
+    }
+
+    #[test]
+    fn contains_equal_endpoints_is_full_ring() {
+        let b = ScanTokenBound {
+            start_excl: 5,
+            end_incl: 5,
+            wraparound: false,
+        };
+        for t in [i64::MIN, -1, 0, 5, 6, i64::MAX] {
+            assert!(b.contains(t), "equal endpoints cover every token (#2228)");
+        }
+    }
+
+    #[test]
+    fn contains_wraparound() {
+        let b = ScanTokenBound {
+            start_excl: 100,
+            end_incl: -100,
+            wraparound: true,
+        };
+        assert!(b.contains(101), "above start is in range");
+        assert!(b.contains(-100), "at/below end is in range");
+        assert!(!b.contains(0), "the interior gap is excluded");
+    }
+
+    #[test]
+    fn can_stop_past_only_non_wraparound_above_end() {
+        let fwd = ScanTokenBound {
+            start_excl: 10,
+            end_incl: 20,
+            wraparound: false,
+        };
+        assert!(!fwd.can_stop_past(20), "at end still in range");
+        assert!(fwd.can_stop_past(21), "past end can stop");
+        let wrap = ScanTokenBound {
+            start_excl: 100,
+            end_incl: -100,
+            wraparound: true,
+        };
+        assert!(
+            !wrap.can_stop_past(i64::MAX),
+            "a wraparound range never early-stops a forward walk"
+        );
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan.rs
@@ -158,7 +158,24 @@ impl SSTableReader {
 
         // Summary-guided start offset: the covering sample for a token range's
         // exclusive lower bound, else the index start for a full scan.
+        //
+        // WRAPAROUND (roborev endgame finding, High — silent data loss): a
+        // wraparound range (`start_excl > end_incl`, the ring segment crossing the
+        // min-token boundary) is `(start_excl, MAX] ∪ [MIN, end_incl]` — its
+        // in-range partitions live in TWO disjoint physical regions of the
+        // token-ordered `Index.db`: a HIGH-token tail (`token > start_excl`) and a
+        // LOW-token head (`token <= end_incl`). This walk is a single FORWARD pass
+        // to EOF (`Index.db` is not circular), so starting at
+        // `scan_start_position_for_token(start_excl)` (the HIGH segment's start)
+        // can NEVER reach the LOW segment's entries — they physically precede that
+        // offset and are silently skipped entirely. For a wraparound range the walk
+        // MUST start at the index's true beginning (offset 0) so BOTH segments are
+        // reachable; `ScanTokenBound::contains` (the per-entry filter below) already
+        // selects exactly the two segments, and `can_stop_past` is unconditionally
+        // `false` for `wraparound` (verified: the walk never early-stops before
+        // EOF), so the pair is coherent — a full walk, filtered.
         let start_position = match token_bound {
+            Some(bound) if bound.wraparound => 0,
             Some(bound) => summary.scan_start_position_for_token(bound.start_excl),
             None => 0,
         };

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -702,11 +702,23 @@ impl SSTableReader {
             .instrument(tracing::debug_span!("sstable.reader.open.load_bloom"))
             .await?;
 
+        // Issue #2412: load Summary.db FIRST so its usability (present, parsed, at
+        // least one sample entry — the authority a bounded lazy walk needs) can
+        // gate whether `load_index_reader` defers the Index.db parse (lazy, design
+        // §A) or falls back to today's eager parse (§A1's counted FellBack).
+        let summary_reader = Self::load_summary_reader(path, &platform)
+            .instrument(tracing::debug_span!("sstable.reader.open.load_summary"))
+            .await;
+        let summary_usable = summary_reader
+            .as_ref()
+            .map(|s| !s.get_entries().is_empty())
+            .unwrap_or(false);
+
         // Load spec readers for enhanced metadata and lookups. Distinguish an absent
         // Index.db from a present-but-unloadable one (issue #2302) so the full
         // enumeration can WARN loud on the latter instead of silently full-scanning.
         let (index_reader, index_present_but_unloadable) =
-            match Self::load_index_reader(path, &platform, &cancel)
+            match Self::load_index_reader(path, &platform, &cancel, summary_usable)
                 .instrument(tracing::debug_span!(
                     "sstable.reader.open.load_index_reader"
                 ))
@@ -716,9 +728,6 @@ impl SSTableReader {
                 component_loading::IndexLoadOutcome::Absent => (None, false),
                 component_loading::IndexLoadOutcome::PresentButUnloadable => (None, true),
             };
-        let summary_reader = Self::load_summary_reader(path, &platform)
-            .instrument(tracing::debug_span!("sstable.reader.open.load_summary"))
-            .await;
         let statistics_reader = Self::load_statistics_reader(path, &platform)
             .instrument(tracing::debug_span!("sstable.reader.open.load_statistics"))
             .await?;

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -1370,6 +1370,26 @@ impl SSTableReader {
         self.endpoint_tokens
     }
 
+    /// Whether this reader's `Index.db` partition map is CURRENTLY fully
+    /// resident (issue #2412 §D — the Flight warm registry's memory accounting).
+    ///
+    /// A BIG reader opened lazily over a usable `Summary.db` (design §A) reports
+    /// `false` until some consumer's [`ensure_materialized`]-driven full parse
+    /// (a full/compaction scan whose Summary-guided streaming walk `FellBack`)
+    /// actually happens; the Summary-guided point/scan paths (§B/§C) never
+    /// trigger it. An eagerly-opened reader (the `Summary.db`-absent FellBack
+    /// case, §A1) reports `true` immediately — its `Index.db` was fully parsed
+    /// at open. No `Index.db` at all (absent component) reports `true` (there is
+    /// no resident cost to represent either way).
+    ///
+    /// [`ensure_materialized`]: crate::storage::sstable::index_reader::IndexReader
+    pub fn index_is_materialized(&self) -> bool {
+        self.index_reader
+            .as_ref()
+            .map(|ir| ir.is_materialized())
+            .unwrap_or(true)
+    }
+
     /// Wire a cooperative-cancellation token into this reader's long-running
     /// scans (issue #2264).
     ///

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -56,6 +56,7 @@ pub(crate) mod scan_stream_windowed;
 #[cfg(feature = "scan-offload-probe")]
 pub mod scan_stream_windowed;
 mod source;
+mod summary_point; // #2412 §B: Summary-guided bounded-interval BIG point lookup
 #[cfg(test)]
 mod tests;
 mod types;

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -75,6 +75,9 @@ pub use types::{
 };
 // Re-export the within-partition clustering-slice push-down spec (Issue #954).
 pub use data_access::ClusteringSlice;
+// Token-range bound pushed into the Summary-guided streaming walk (issue #2413
+// Option A) — used by the flight warm merge to scope a split's scan.
+pub use data_access::ScanTokenBound;
 // Single-partition compaction seek outcome (issue #2207). `not(tombstones)` like
 // the seek path it wraps.
 #[cfg(not(feature = "tombstones"))]

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -30,13 +30,11 @@ impl SSTableReader {
 
         let format = self.sstable_format_label();
 
-        // B4 key→partition-offset cache (issue #1570): a repeated point read of the
-        // same present key returns the cached location without re-probing Index.db,
-        // so `INDEX_PROBES` stays 0 on the hit. Positive-only, so an absent key is
-        // never cached and never fabricates a hit. The cached location is the exact
-        // `(offset,size)` a fresh probe resolved (correctness guardrail). Checked
-        // FIRST (before any materialize / interval read) so the hit skips ALL probe
-        // work on both the Summary-guided and resident-map paths (issue #2412 §B).
+        // B4 key→partition-offset cache (issue #1570): a repeated point read of a
+        // present key returns the cached `(offset,size)` without re-probing Index.db
+        // (`INDEX_PROBES` stays 0 on the hit). Positive-only. Checked FIRST — before
+        // any materialize / interval read — so the hit skips ALL probe work on both
+        // the Summary-guided and resident-map paths (issue #2412 §B).
         if let Some(loc) = self.key_offset_cache.get(partition_key) {
             debug!(
                 "B4 key-cache hit for partition (raw key len={}): offset={}, size={}",
@@ -56,25 +54,20 @@ impl SSTableReader {
             return Ok(Some((loc.data_offset, loc.data_size)));
         }
 
-        // Stage 3 (issue #2412 §B): with a usable `Summary.db` and a not-yet-
-        // materialized lazy `Index.db`, resolve via ONE bounded Summary-guided
-        // interval instead of materializing the whole partition map. The interval is
-        // bounded by two authoritative summary samples, so an interval MISS is an
-        // authoritative absence — `big_get_with_resolution` treats a resulting `None`
-        // as a definitive "not found" without a whole-file `scan_for_key` (the
-        // materialized/FellBack path below keeps the #1572 conservative scan).
+        // Stage 3 (issue #2412 §B): a usable `Summary.db` + a not-yet-materialized
+        // lazy `Index.db` → resolve via ONE bounded Summary-guided interval instead of
+        // materializing the whole map. See `reader::summary_point` for the
+        // authoritative-absence rules the BIG point path applies to a resulting `None`.
         if self.should_use_summary_interval() {
             return self
                 .lookup_partition_via_summary_interval(partition_key)
                 .await;
         }
 
-        // FellBack / already-materialized path (today's behaviour): ensure the full
-        // resident map is materialized, then probe it. `ensure_materialized` MUST run
-        // BEFORE the tracing span below — `EnteredSpan` is not `Send`, so holding it
-        // across this await would make every future `.await`ing this fn non-`Send`
-        // (`block_on_async`/`tokio::spawn` callers require `Send` futures). A no-op
-        // after the first call, or for an eagerly-opened (FellBack) reader.
+        // FellBack / already-materialized path: ensure the full resident map, then
+        // probe it. `ensure_materialized` MUST run BEFORE the tracing span — the
+        // non-`Send` `EnteredSpan` held across an await makes callers non-`Send`. A
+        // no-op after the first call, or for an eagerly-opened (FellBack) reader.
         if let Some(index_reader) = &self.index_reader {
             index_reader.ensure_materialized(&self.scan_cancel).await?;
         }
@@ -82,10 +75,8 @@ impl SSTableReader {
         let _span = tracing::debug_span!("sstable.partition_lookup.index").entered();
 
         if let Some(index_reader) = &self.index_reader {
-            // (materialization already ensured above, before the span was entered)
             // A5/B4 read-work counter (`INDEX_PROBES`; consumer B4): one per real
-            // `Index.db` probe. Counted only when a cache miss forces a real probe,
-            // so a B4 cache hit above records nothing. No-op in release.
+            // `Index.db` probe. A B4 cache hit above records nothing. No-op in release.
             crate::storage::sstable::read_work_counters::record_index_probe();
             // Direct raw-key lookup — O(1) HashMap lookup.
             // Index.db entries are keyed on the raw partition key bytes since #552;

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -28,6 +28,15 @@ impl SSTableReader {
     ) -> Result<Option<(u64, u32)>> {
         use crate::observability::{self as obs, catalog};
 
+        // Issue #2412: ensure a lazily-opened reader's Index.db is materialized
+        // BEFORE entering the tracing span below. `EnteredSpan` is not `Send`, so
+        // holding it across this await would make every future `.await`ing this
+        // fn non-Send (`block_on_async`/`tokio::spawn` callers require `Send`
+        // futures). A no-op after the first call, or for an eagerly-opened reader.
+        if let Some(index_reader) = &self.index_reader {
+            index_reader.ensure_materialized(&self.scan_cancel).await?;
+        }
+
         let _span = tracing::debug_span!("sstable.partition_lookup.index").entered();
         let format = self.sstable_format_label();
 
@@ -56,6 +65,7 @@ impl SSTableReader {
         }
 
         if let Some(index_reader) = &self.index_reader {
+            // (materialization already ensured above, before the span was entered)
             // A5/B4 read-work counter (`INDEX_PROBES`; consumer B4): one per real
             // `Index.db` probe. Counted only when a cache miss forces a real probe,
             // so a B4 cache hit above records nothing. No-op in release.

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -28,23 +28,15 @@ impl SSTableReader {
     ) -> Result<Option<(u64, u32)>> {
         use crate::observability::{self as obs, catalog};
 
-        // Issue #2412: ensure a lazily-opened reader's Index.db is materialized
-        // BEFORE entering the tracing span below. `EnteredSpan` is not `Send`, so
-        // holding it across this await would make every future `.await`ing this
-        // fn non-Send (`block_on_async`/`tokio::spawn` callers require `Send`
-        // futures). A no-op after the first call, or for an eagerly-opened reader.
-        if let Some(index_reader) = &self.index_reader {
-            index_reader.ensure_materialized(&self.scan_cancel).await?;
-        }
-
-        let _span = tracing::debug_span!("sstable.partition_lookup.index").entered();
         let format = self.sstable_format_label();
 
         // B4 key→partition-offset cache (issue #1570): a repeated point read of the
         // same present key returns the cached location without re-probing Index.db,
         // so `INDEX_PROBES` stays 0 on the hit. Positive-only, so an absent key is
         // never cached and never fabricates a hit. The cached location is the exact
-        // `(offset,size)` a fresh probe resolved (correctness guardrail).
+        // `(offset,size)` a fresh probe resolved (correctness guardrail). Checked
+        // FIRST (before any materialize / interval read) so the hit skips ALL probe
+        // work on both the Summary-guided and resident-map paths (issue #2412 §B).
         if let Some(loc) = self.key_offset_cache.get(partition_key) {
             debug!(
                 "B4 key-cache hit for partition (raw key len={}): offset={}, size={}",
@@ -63,6 +55,31 @@ impl SSTableReader {
             );
             return Ok(Some((loc.data_offset, loc.data_size)));
         }
+
+        // Stage 3 (issue #2412 §B): with a usable `Summary.db` and a not-yet-
+        // materialized lazy `Index.db`, resolve via ONE bounded Summary-guided
+        // interval instead of materializing the whole partition map. The interval is
+        // bounded by two authoritative summary samples, so an interval MISS is an
+        // authoritative absence — `big_get_with_resolution` treats a resulting `None`
+        // as a definitive "not found" without a whole-file `scan_for_key` (the
+        // materialized/FellBack path below keeps the #1572 conservative scan).
+        if self.should_use_summary_interval() {
+            return self
+                .lookup_partition_via_summary_interval(partition_key)
+                .await;
+        }
+
+        // FellBack / already-materialized path (today's behaviour): ensure the full
+        // resident map is materialized, then probe it. `ensure_materialized` MUST run
+        // BEFORE the tracing span below — `EnteredSpan` is not `Send`, so holding it
+        // across this await would make every future `.await`ing this fn non-`Send`
+        // (`block_on_async`/`tokio::spawn` callers require `Send` futures). A no-op
+        // after the first call, or for an eagerly-opened (FellBack) reader.
+        if let Some(index_reader) = &self.index_reader {
+            index_reader.ensure_materialized(&self.scan_cancel).await?;
+        }
+
+        let _span = tracing::debug_span!("sstable.partition_lookup.index").entered();
 
         if let Some(index_reader) = &self.index_reader {
             // (materialization already ensured above, before the span was entered)

--- a/cqlite-core/src/storage/sstable/reader/partition_successor.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_successor.rs
@@ -46,7 +46,10 @@ impl SSTableReader {
     ///   greater than `target_offset`.
     ///
     /// [`bti_partition_offsets`]: Self::bti_partition_offsets
-    pub(crate) fn successor_partition_offset(&self, target_offset: u64) -> Result<Option<u64>> {
+    pub(crate) async fn successor_partition_offset(
+        &self,
+        target_offset: u64,
+    ) -> Result<Option<u64>> {
         if self.bti_partitions_db.is_some() {
             let offsets = self.bti_partition_offsets()?;
             // Smallest offset strictly greater than target_offset.
@@ -59,6 +62,10 @@ impl SSTableReader {
         // key (== Data.db) order, but we take the min over `> target` defensively
         // rather than rely on positional adjacency.
         if let Some(index_reader) = &self.index_reader {
+            // Issue #2412 Stage 2: a lazily-opened reader defers the full parse to
+            // first use — this successor scan IS that first use. No-op for an
+            // eagerly-opened reader.
+            index_reader.ensure_materialized(&self.scan_cancel).await?;
             let successor = index_reader
                 .get_partition_entries()
                 .iter()

--- a/cqlite-core/src/storage/sstable/reader/summary_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/summary_point.rs
@@ -111,7 +111,12 @@ impl SSTableReader {
             // Empty summary — the precondition rules this out, but never fabricate.
             return Ok(None);
         };
-        let min_index_interval = summary.get_header().min_index_interval;
+        let header = summary.get_header();
+        let min_index_interval = header.min_index_interval;
+        // Roborev job 1709 (High): the entry cap for the read-to-EOF LAST interval
+        // must be downsampling-aware, so `sampling_level` is threaded through —
+        // never a guess, the already-parsed header field (design doc §A1/no-heuristics).
+        let sampling_level = header.sampling_level;
 
         // One real bounded interval probe (not a B4 cache hit): mirror the
         // resident-map path's `INDEX_PROBES` accounting so a repeated read served
@@ -124,6 +129,7 @@ impl SSTableReader {
             interval,
             partition_key,
             min_index_interval,
+            sampling_level,
         )
         .await?;
 

--- a/cqlite-core/src/storage/sstable/reader/summary_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/summary_point.rs
@@ -1,0 +1,166 @@
+//! Summary-guided bounded-interval BIG point lookup (issue #2412 §B, Stage 3).
+//!
+//! When a BIG (`nb`/uncompressed) reader was lazily opened over a usable `Summary.db`
+//! (design §A), a `WHERE pk = ?` point read resolves the partition's `Data.db` offset
+//! by:
+//! 1. binary-searching `Summary.db` for the sample interval covering the key
+//!    ([`SummaryReader::find_by_key`](crate::storage::sstable::summary_reader::SummaryReader::find_by_key)), then
+//! 2. reading/parsing exactly ONE `Index.db` interval (≤ `min_index_interval` entries)
+//!    from that position ([`lookup_key_in_interval`]).
+//!
+//! This REPLACES the pre-Stage-3 fallback that materialized the whole `Index.db` map
+//! (`IndexReader::ensure_materialized`) on the point-read path. The interval is bounded
+//! by two authoritative `Summary.db` sample positions, so an interval MISS is an
+//! authoritative absence — the whole-file `scan_for_key` oracle is not consulted for
+//! the common case (design §B; the FellBack/no-summary path keeps it, #1572).
+//!
+//! No-heuristics (issue #28): every seek offset and interval bound is an authoritative
+//! `Summary.db` sample position / `Index.db` entry framing — nothing is inferred from
+//! value bytes.
+
+use super::SSTableReader;
+use crate::storage::sstable::summary_reader::interval::lookup_key_in_interval;
+use crate::Result;
+
+impl SSTableReader {
+    /// Whether a BIG point lookup should resolve through ONE `Summary.db`-bounded
+    /// `Index.db` interval (design §B) rather than the full resident partition map.
+    ///
+    /// `true` iff BOTH hold:
+    /// - a usable `Summary.db` (at least one sample entry) bounds the walk, AND
+    /// - the lazy `Index.db` map has NOT already been materialized.
+    ///
+    /// The second clause preserves performance for a reader whose full map is already
+    /// resident (e.g. a prior full scan called `ensure_materialized`): the in-memory
+    /// O(1) probe beats a fresh bounded disk read, and the scan-path re-probes that
+    /// route through `lookup_partition_with_index` after materializing keep using the
+    /// resident map. It also means the FellBack (absent-`Summary.db`) reader — which
+    /// is eagerly materialized at open — never takes this path.
+    pub(super) fn should_use_summary_interval(&self) -> bool {
+        let summary_usable = self
+            .summary_reader
+            .as_ref()
+            .map(|s| !s.get_entries().is_empty())
+            .unwrap_or(false);
+        let index_lazy = self
+            .index_reader
+            .as_ref()
+            .map(|ir| !ir.is_materialized())
+            .unwrap_or(false);
+        summary_usable && index_lazy
+    }
+
+    /// Whether `partition_key`'s covering `Summary.db` interval is END-BOUNDED — i.e.
+    /// bounded ABOVE by a NEXT authoritative summary sample (`end_position.is_some()`),
+    /// not the last (read-to-EOF) interval.
+    ///
+    /// This is the #1572-safe gate for treating an interval MISS as an AUTHORITATIVE
+    /// absence (design §B, hardened): a tail-truncated `Index.db` (the #1572
+    /// degraded-input class — whole trailing entries dropped, or a mid-entry cut at
+    /// the end) can only lose the HIGHEST-token partitions, which live in the LAST
+    /// interval. An end-bounded interval `[sample_i, sample_{i+1})` is delimited by a
+    /// next sample whose position sits BEFORE any tail truncation, so its bytes are
+    /// intact and a miss within it is genuinely authoritative. The LAST interval
+    /// (`end_position == None`, read to EOF) could hide a dropped tail entry, so a miss
+    /// there keeps the whole-file `scan_for_key` fallback (`big_get_with_resolution`),
+    /// preserving the #1572 get/scan agreement on degraded inputs.
+    ///
+    /// A pure in-memory binary search (no disk read) — `big_get_with_resolution`
+    /// consults it only on an interval miss to classify the absence.
+    pub(super) fn covering_interval_is_end_bounded(&self, partition_key: &[u8]) -> bool {
+        self.summary_reader
+            .as_ref()
+            .and_then(|s| s.find_by_key(partition_key))
+            .map(|iv| iv.end_position.is_some())
+            .unwrap_or(false)
+    }
+
+    /// Resolve `partition_key` to its uncompressed `Data.db` offset via the
+    /// `Summary.db`-guided bounded `Index.db` interval (issue #2412 §B).
+    ///
+    /// Returns:
+    /// - `Ok(Some((offset, size)))` — an exact partition entry found within the one
+    ///   bounded interval (`size` is `0` — BIG `Index.db` stores no partition size —
+    ///   consistent with the resident-map path; callers parse forward from `offset`).
+    /// - `Ok(None)` — the key is genuinely absent from the interval between two
+    ///   authoritative `Summary.db` samples: an AUTHORITATIVE absence. The BIG point
+    ///   path (`big_get_with_resolution`) treats this as a definitive "not found"
+    ///   without a whole-file `scan_for_key` (design §B).
+    ///
+    /// Records exactly one real probe (`INDEX_PROBES`, mirroring the resident-map
+    /// path's accounting) plus one bounded interval parse
+    /// (`cqlite.sstable.index_interval_parses_total`, emitted inside
+    /// [`lookup_key_in_interval`], design §F) — never a full `index_parses_total`.
+    ///
+    /// Precondition: [`Self::should_use_summary_interval`] holds. When the summary /
+    /// index handles are unexpectedly absent (they should not be, given the
+    /// precondition), returns `Ok(None)` rather than fabricating a hit.
+    pub(super) async fn lookup_partition_via_summary_interval(
+        &self,
+        partition_key: &[u8],
+    ) -> Result<Option<(u64, u32)>> {
+        use crate::observability::{self as obs, catalog};
+
+        let format = self.sstable_format_label();
+        let (Some(summary), Some(index_reader)) =
+            (self.summary_reader.as_ref(), self.index_reader.as_ref())
+        else {
+            return Ok(None);
+        };
+        let Some(interval) = summary.find_by_key(partition_key) else {
+            // Empty summary — the precondition rules this out, but never fabricate.
+            return Ok(None);
+        };
+        let min_index_interval = summary.get_header().min_index_interval;
+
+        // One real bounded interval probe (not a B4 cache hit): mirror the
+        // resident-map path's `INDEX_PROBES` accounting so a repeated read served
+        // from the B4 cache still records zero probes. The distinct
+        // `index_interval_parses_total` is emitted inside `lookup_key_in_interval`.
+        crate::storage::sstable::read_work_counters::record_index_probe();
+
+        let lookup = lookup_key_in_interval(
+            index_reader.index_path(),
+            interval,
+            partition_key,
+            min_index_interval,
+        )
+        .await?;
+
+        match lookup.entry {
+            Some(entry) => {
+                obs::add_counter(
+                    catalog::READ_PARTITION_LOOKUP,
+                    1,
+                    &[
+                        (catalog::attr::RESULT, "hit".into()),
+                        (catalog::attr::LOOKUP_ROUTE, "index".into()),
+                        (catalog::attr::SSTABLE_FORMAT, format.into()),
+                    ],
+                );
+                // B4: cache this present-key resolution so a repeat point read of the
+                // same key skips both the summary search and the interval read
+                // (issue #1570). BIG `Index.db` records no size (`data_size == 0`).
+                self.key_offset_cache.insert(
+                    partition_key,
+                    crate::storage::cache::PartitionLoc::new(entry.data_offset, entry.data_size),
+                );
+                Ok(Some((entry.data_offset, entry.data_size)))
+            }
+            None => {
+                obs::add_counter(
+                    catalog::READ_PARTITION_LOOKUP,
+                    1,
+                    &[
+                        (catalog::attr::RESULT, "miss".into()),
+                        (catalog::attr::LOOKUP_ROUTE, "index".into()),
+                        (catalog::attr::SSTABLE_FORMAT, format.into()),
+                    ],
+                );
+                // Authoritative absence between two summary samples — the caller does
+                // NOT fall back to a whole-file scan_for_key (design §B).
+                Ok(None)
+            }
+        }
+    }
+}

--- a/cqlite-core/src/storage/sstable/summary_reader/interval.rs
+++ b/cqlite-core/src/storage/sstable/summary_reader/interval.rs
@@ -26,7 +26,7 @@ use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 use super::SummaryEntry;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::storage::sstable::index_reader::{parse_big_index_entry, PartitionIndexEntry};
 
 /// A `Summary.db`-derived half-open byte range `[start_position, end_position)` into
@@ -196,6 +196,25 @@ pub(crate) fn scan_interval_bytes(bytes: &[u8], key: &[u8], entry_cap: usize) ->
 /// from the SAME downsampling-adjusted formula — because `covering_interval_is_end_bounded`
 /// is `false` for it, so a capped miss there is never promoted to an authoritative
 /// absence (the caller falls back to `scan_for_key` instead, preserving #1572).
+///
+/// Corrupt-input hardening (roborev job 1709 follow-up, fuzz doctrine #1614: a
+/// parser must never panic/abort/OOM on arbitrary bytes — and through the
+/// bindings, an allocation-failure abort kills the WHOLE host process, not just
+/// this request):
+/// - `end_position` is validated against the `Index.db` file's ACTUAL length
+///   BEFORE it ever sizes an allocation. An unvalidated, corrupt `Summary.db`
+///   sample claiming an `end` far beyond EOF would otherwise drive
+///   `Vec::resize` to attempt a huge (attacker/corruption-controlled)
+///   allocation — which aborts the process on failure — before `read_exact`
+///   ever gets a chance to fail cleanly. A too-large `end` now returns a clean
+///   `Err` (fail-closed), never a huge alloc.
+/// - Non-monotone samples (`end <= start`) are ALSO fail-closed `Err`, not
+///   silently routed into the read-to-EOF branch: `end_position` staying
+///   `Some(_)` there would leave `covering_interval_is_end_bounded` reporting
+///   `true`, so a corrupt/degenerate interval's capped miss could otherwise be
+///   wrongly promoted to an AUTHORITATIVE absence (no `scan_for_key`
+///   fallback) — the exact false-negative class this job's primary fix closes,
+///   re-opened through a different corrupt-input door.
 pub async fn lookup_key_in_interval(
     index_path: &Path,
     interval: SummaryInterval,
@@ -204,24 +223,45 @@ pub async fn lookup_key_in_interval(
     sampling_level: u32,
 ) -> Result<IntervalLookup> {
     let mut file = File::open(index_path).await?;
+
+    // Validate BEFORE seeking/reading/allocating (no-heuristics #28: derived from
+    // the file's authoritative metadata, never a guess).
+    let file_len = file.metadata().await?.len();
+    match interval.end_position {
+        Some(end) if end <= interval.start_position => {
+            return Err(Error::corruption(format!(
+                "lookup_key_in_interval: interval end_position {end} does not exceed \
+                 start_position {} — non-monotone Summary.db sample ordering (corrupt input)",
+                interval.start_position
+            )));
+        }
+        Some(end) if end > file_len => {
+            return Err(Error::corruption(format!(
+                "lookup_key_in_interval: interval end_position {end} exceeds Index.db file \
+                 length {file_len} (corrupt Summary.db sample position)"
+            )));
+        }
+        _ => {}
+    }
+
     file.seek(std::io::SeekFrom::Start(interval.start_position))
         .await?;
 
     let mut buffer = Vec::new();
     let entry_cap = match interval.end_position {
-        Some(end) if end > interval.start_position => {
-            // Bounded read of exactly the interval's whole entries. The byte
-            // range itself is the bound — no entry-count cap needed or applied.
+        Some(end) => {
+            // Bounded read of exactly the interval's whole entries (validated
+            // above: `end > start` and `end <= file_len`). The byte range itself
+            // is the bound — no entry-count cap needed or applied.
             let len = (end - interval.start_position) as usize;
             buffer.resize(len, 0);
             file.read_exact(&mut buffer).await?;
             usize::MAX
         }
-        // Last interval (or a degenerate empty/zero-width range): read to EOF.
-        // The scan is bounded by the downsampling-adjusted
-        // `last_interval_entry_cap`, so this can never become a whole-file walk
-        // for a many-partition SSTable.
-        _ => {
+        // Last interval: read to EOF. The scan is bounded by the
+        // downsampling-adjusted `last_interval_entry_cap`, so this can never
+        // become a whole-file walk for a many-partition SSTable.
+        None => {
             file.read_to_end(&mut buffer).await?;
             last_interval_entry_cap(min_index_interval, sampling_level)
         }
@@ -635,6 +675,88 @@ mod tests {
             res.entry.is_some(),
             "a present key past the pre-fix cap in a downsampled LAST interval must \
              resolve too (the generous, downsampling-adjusted cap applies here)"
+        );
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    // ---- Corrupt-input hardening (roborev job 1709 follow-up, fuzz doctrine #1614) ----
+
+    /// An `end_position` far beyond the `Index.db` file's actual length (a corrupt
+    /// `Summary.db` sample) must return a clean `Err`, NEVER attempt a huge
+    /// allocation. The synthetic file here is tiny (a handful of bytes); a
+    /// too-large `HOSTILE_END` would otherwise drive `buffer.resize` to zero-fill
+    /// a huge buffer from a few real bytes on disk before `read_exact` ever gets a
+    /// chance to fail.
+    ///
+    /// Asserts on the SPECIFIC validation error message (`"exceeds Index.db file
+    /// length"`), not merely `is_err()`: a generic `Err` is also reachable via
+    /// `read_exact`'s own `UnexpectedEof` AFTER a (successful, just slow) huge
+    /// allocation — that path is NOT what this test is pinning, and asserting only
+    /// `is_err()` would pass on EITHER path, silently accepting the huge-alloc
+    /// route. Matching the specific message proves the FAIL-FAST metadata-length
+    /// check fired BEFORE any allocation was attempted (never depends on actually
+    /// forcing a multi-GiB allocation inside a unit test, which would itself be
+    /// slow/host-memory-dependent and defeat the point of a fast, safe pin).
+    #[tokio::test]
+    async fn end_position_beyond_file_length_is_a_clean_error_not_a_huge_alloc() {
+        let bytes = build_interval(&[(b"alpha", 0), (b"bravo", 100)]);
+        let path = write_temp_index("beyond-eof", &bytes).await;
+
+        // A corrupt sample claiming an `end` ~1 GiB past this tiny file's real length.
+        const HOSTILE_END: u64 = 1 << 30;
+        let iv = SummaryInterval {
+            start_position: 0,
+            end_position: Some(HOSTILE_END),
+            sample_index: 0,
+        };
+        let res = lookup_key_in_interval(&path, iv, b"alpha", 128, 128).await;
+        let err = res.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exceeds Index.db file length"),
+            "an end_position ({HOSTILE_END}) far beyond the file's real length ({}) must \
+             fail via the metadata-length pre-check (fast, no huge alloc attempted), got: {msg}",
+            bytes.len()
+        );
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    /// Non-monotone samples (`end_position <= start_position`) are corrupt Summary.db
+    /// input — Cassandra's on-disk samples are always strictly increasing. This must
+    /// fail closed with `Err`, NEVER silently fall into the read-to-EOF branch (which
+    /// would leave `end_position` as `Some(_)`, so `covering_interval_is_end_bounded`
+    /// would keep reporting `true` and a caller could wrongly promote a capped miss
+    /// to an AUTHORITATIVE absence for corrupt input).
+    #[tokio::test]
+    async fn non_monotone_interval_is_a_clean_error_never_authoritative() {
+        let bytes = build_interval(&[(b"alpha", 0), (b"bravo", 100), (b"charlie", 250)]);
+        let path = write_temp_index("non-monotone", &bytes).await;
+
+        // end == start: a degenerate zero-width interval (corrupt).
+        let iv_equal = SummaryInterval {
+            start_position: 50,
+            end_position: Some(50),
+            sample_index: 0,
+        };
+        let res_equal = lookup_key_in_interval(&path, iv_equal, b"anything", 128, 128).await;
+        assert!(
+            res_equal.is_err(),
+            "end_position == start_position must fail closed, not silently read to EOF"
+        );
+
+        // end < start: a genuinely backwards (corrupt) sample pair.
+        let iv_backwards = SummaryInterval {
+            start_position: 100,
+            end_position: Some(10),
+            sample_index: 0,
+        };
+        let res_backwards =
+            lookup_key_in_interval(&path, iv_backwards, b"anything", 128, 128).await;
+        assert!(
+            res_backwards.is_err(),
+            "end_position < start_position must fail closed, not silently read to EOF"
         );
 
         let _ = std::fs::remove_dir_all(path.parent().unwrap());

--- a/cqlite-core/src/storage/sstable/summary_reader/interval.rs
+++ b/cqlite-core/src/storage/sstable/summary_reader/interval.rs
@@ -7,10 +7,14 @@
 //!   for the half-open `Index.db` byte range [`SummaryInterval`] that must contain a
 //!   query key's partition entry (the core new search; [`super::SummaryReader::find_by_key`]
 //!   is the method wrapper).
-//! - [`lookup_key_in_interval`] reads **only that one interval** (≤ `min_index_interval`
-//!   entries) from disk and resolves the exact key, recording exactly one **interval**
-//!   parse (`cqlite.sstable.index_interval_parses_total`) — never a full parse, so a
-//!   lazy-open regression stays visible on `index_parses_total` (design §F).
+//! - [`lookup_key_in_interval`] reads **only that one interval** from disk and
+//!   resolves the exact key, recording exactly one **interval** parse
+//!   (`cqlite.sstable.index_interval_parses_total`) — never a full parse, so a
+//!   lazy-open regression stays visible on `index_parses_total` (design §F). An
+//!   END-BOUNDED interval is scanned in full (its `[start, end)` byte range between
+//!   two real samples is the bound, not an entry count — Cassandra's `Summary.db`
+//!   downsampling can widen it well past `min_index_interval`); only the read-to-EOF
+//!   LAST interval keeps a downsampling-adjusted entry cap (roborev job 1709).
 //!
 //! No-heuristics (issue #28): every seek offset and interval boundary is an
 //! authoritative `Summary.db` sample position; entry framing is the on-disk `Index.db`
@@ -87,21 +91,50 @@ pub struct IntervalLookup {
     /// this interval (an authoritative absence between two summary samples — the
     /// whole-file `scan_for_key` oracle is NOT needed for the common case, design §B).
     pub entry: Option<PartitionIndexEntry>,
-    /// Number of `Index.db` entries actually parsed/touched, bounded by one summary
-    /// interval (≤ `min_index_interval`). The scale-free work-probe for Requirement 2.
+    /// Number of `Index.db` entries actually parsed/touched, bounded by ONE summary
+    /// interval's actual entry count (an end-bounded interval's `[start, end)` byte
+    /// range; a downsampling-adjusted cap for the read-to-EOF last interval). The
+    /// scale-free work-probe for Requirement 2 — bounded by the interval, never by
+    /// the SSTable's total partition count.
     pub entries_touched: usize,
 }
 
-/// Cap on entries scanned in a single interval, derived from `min_index_interval`.
+/// Cassandra's `IndexSummary` base (non-downsampled) sampling level — sample
+/// spacing is `min_index_interval` partitions ONLY at this level; a lower
+/// `sampling_level` widens spacing proportionally (`IndexSummary.java`,
+/// `BASE_SAMPLING_LEVEL = 128`). Duplicated from the (feature-gated,
+/// write-support-only) writer-side constant of the same name and value so this
+/// read-path module never depends on `write-support` being enabled.
+const BASE_SAMPLING_LEVEL: u32 = 128;
+
+/// Cap on entries scanned in the LAST (read-to-EOF) `Index.db` interval —
+/// roborev job 1709 (High, data-loss class): the cap must be DOWNSAMPLING-AWARE.
 ///
-/// One summary interval spans `min_index_interval` partitions by construction, but a
-/// corrupt/rewritten summary could point at a wider run. Bounding the scan at
-/// `min_index_interval` (plus the boundary entry) means a hostile summary cannot turn
-/// a "bounded interval read" into a full-file walk; a genuine miss within the bound is
-/// still authoritative because the interval end is the next authoritative sample.
-fn interval_entry_cap(min_index_interval: u32) -> usize {
-    // +1 covers the boundary entry that sits exactly at the next sample position.
-    (min_index_interval as usize).saturating_add(1)
+/// Cassandra downsamples `Summary.db` under index-summary memory pressure
+/// (`sampling_level < BASE_SAMPLING_LEVEL`), which widens EVERY interval —
+/// including the last — up to `min_index_interval * BASE_SAMPLING_LEVEL /
+/// sampling_level` partitions, not `min_index_interval`. A cap fixed at
+/// `min_index_interval + 1` (the pre-fix behavior) would cut a downsampled last
+/// interval's scan short before reaching a present key that legitimately sits
+/// beyond the un-downsampled baseline. This is the ONLY cap that survives this
+/// fix (see [`scan_interval_bytes`]'s caller): a `Some(end_position)` interval
+/// is bounded by its authoritative `[start, end)` byte range instead, so no
+/// entry-count cap is needed there at all.
+///
+/// `sampling_level` is clamped to Cassandra's documented `[1,
+/// BASE_SAMPLING_LEVEL]` range (`IndexSummary.java`) before dividing: `0`
+/// (corrupt/never-should-happen) clamps to `1` — the MAXIMUM legitimate
+/// widening, the fail-safe direction for a cap (a too-generous cap only costs
+/// extra scan work; a too-small one risks exactly this issue's false-negative).
+/// A value `> BASE_SAMPLING_LEVEL` (equally never-should-happen) clamps to
+/// `BASE_SAMPLING_LEVEL`, i.e. the un-downsampled baseline — never a guess,
+/// always derived from the already-parsed header fields (no-heuristics, #28).
+fn last_interval_entry_cap(min_index_interval: u32, sampling_level: u32) -> usize {
+    let effective_sampling_level = sampling_level.clamp(1, BASE_SAMPLING_LEVEL);
+    let effective_interval = (min_index_interval as u64).saturating_mul(BASE_SAMPLING_LEVEL as u64)
+        / (effective_sampling_level as u64);
+    // +1 covers the boundary entry that sits exactly at EOF.
+    usize::try_from(effective_interval.saturating_add(1)).unwrap_or(usize::MAX)
 }
 
 /// Scan a slice of `Index.db` interval bytes for the entry whose key equals `key`.
@@ -149,31 +182,50 @@ pub(crate) fn scan_interval_bytes(bytes: &[u8], key: &[u8], entry_cap: usize) ->
 /// EOF when `interval.end_position` is `None`), and scans forward for the exact key.
 /// Increments `cqlite.sstable.index_interval_parses_total` exactly once (one bounded
 /// interval parse), never `index_parses_total` (design §F).
+///
+/// Entry-count cap (roborev job 1709, High — downsampling false-negative fix):
+/// an END-BOUNDED interval (`end_position.is_some()`) is NOT entry-capped at all —
+/// its authoritative `[start, end)` byte range, delimited by two REAL adjacent
+/// `Summary.db` samples, already bounds the read; every whole entry the buffer
+/// holds is scanned regardless of Cassandra's downsampling (which can widen an
+/// interval to `min_index_interval * 128 / sampling_level` partitions — a fixed
+/// `min_index_interval`-derived cap could otherwise stop short of a present key
+/// and be (wrongly) treated as an authoritative absence by the caller,
+/// `big_get_with_resolution`'s `covering_interval_is_end_bounded` gate). The
+/// read-to-EOF LAST interval keeps a cap — [`last_interval_entry_cap`], derived
+/// from the SAME downsampling-adjusted formula — because `covering_interval_is_end_bounded`
+/// is `false` for it, so a capped miss there is never promoted to an authoritative
+/// absence (the caller falls back to `scan_for_key` instead, preserving #1572).
 pub async fn lookup_key_in_interval(
     index_path: &Path,
     interval: SummaryInterval,
     key: &[u8],
     min_index_interval: u32,
+    sampling_level: u32,
 ) -> Result<IntervalLookup> {
     let mut file = File::open(index_path).await?;
     file.seek(std::io::SeekFrom::Start(interval.start_position))
         .await?;
 
     let mut buffer = Vec::new();
-    match interval.end_position {
+    let entry_cap = match interval.end_position {
         Some(end) if end > interval.start_position => {
-            // Bounded read of exactly the interval's whole entries.
+            // Bounded read of exactly the interval's whole entries. The byte
+            // range itself is the bound — no entry-count cap needed or applied.
             let len = (end - interval.start_position) as usize;
             buffer.resize(len, 0);
             file.read_exact(&mut buffer).await?;
+            usize::MAX
         }
-        // Last interval (or a degenerate empty/zero-width range): read to EOF. The scan
-        // is still bounded by `interval_entry_cap`, so this can never become a
-        // whole-file walk for a many-partition SSTable.
+        // Last interval (or a degenerate empty/zero-width range): read to EOF.
+        // The scan is bounded by the downsampling-adjusted
+        // `last_interval_entry_cap`, so this can never become a whole-file walk
+        // for a many-partition SSTable.
         _ => {
             file.read_to_end(&mut buffer).await?;
+            last_interval_entry_cap(min_index_interval, sampling_level)
         }
-    }
+    };
 
     // One bounded interval parse (distinct counter — never a full parse, design §F).
     crate::observability::add_counter(
@@ -182,11 +234,7 @@ pub async fn lookup_key_in_interval(
         &[],
     );
 
-    Ok(scan_interval_bytes(
-        &buffer,
-        key,
-        interval_entry_cap(min_index_interval),
-    ))
+    Ok(scan_interval_bytes(&buffer, key, entry_cap))
 }
 
 #[cfg(test)]
@@ -388,7 +436,7 @@ mod tests {
             end_position: Some((prefix.len() + interval.len()) as u64),
             sample_index: 1,
         };
-        let res = lookup_key_in_interval(&path, iv, b"target", 128)
+        let res = lookup_key_in_interval(&path, iv, b"target", 128, 128)
             .await
             .expect("interval read");
         let entry = res.entry.expect("target present in the interval");
@@ -397,7 +445,7 @@ mod tests {
         assert_eq!(res.entries_touched, 1, "matched the first interval entry");
 
         // A key beyond the bounded range is structurally unreachable for this interval.
-        let res2 = lookup_key_in_interval(&path, iv, b"after0", 128)
+        let res2 = lookup_key_in_interval(&path, iv, b"after0", 128, 128)
             .await
             .expect("interval read");
         assert!(
@@ -406,5 +454,189 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ---- Roborev job 1709 (High, data-loss class): downsampled-summary false
+    // authoritative-absence regression ----
+
+    /// Write `n` synthetic entries at strictly increasing offsets, returning the
+    /// bytes plus the byte offset the `target_index`'th entry starts at (so a
+    /// caller can carve out a `[start, target_end)` sub-slice as an end-bounded
+    /// interval whose LAST entry is the target — the exact shape
+    /// `find_interval_for_key` would hand a caller: the interval's `end_position`
+    /// sits at the position of the NEXT summary sample, which is the position
+    /// immediately after the entries this interval covers).
+    fn build_n_entries(n: usize, target_index: usize, target_key: &[u8]) -> (Vec<u8>, u64) {
+        let mut buf = Vec::new();
+        let mut target_end = 0u64;
+        for i in 0..n {
+            let key: Vec<u8> = if i == target_index {
+                target_key.to_vec()
+            } else {
+                format!("k{i:08}").into_bytes()
+            };
+            buf.extend_from_slice(&encode_entry(&key, i as u64));
+            if i == target_index {
+                target_end = buf.len() as u64;
+            }
+        }
+        (buf, target_end)
+    }
+
+    async fn write_temp_index(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-2412-ds-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("nb-1-big-Index.db");
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    /// THE blocker pin (roborev job 1709): a downsampled `Summary.db`
+    /// (`min_index_interval = 128`, `sampling_level = 32` — 4x downsampled, so a
+    /// real interval can legitimately span up to `128 * 128 / 32 = 512`
+    /// partitions) hands an END-BOUNDED interval (`end_position.is_some()`) that
+    /// spans 200 entries — comfortably past the PRE-FIX cap
+    /// (`min_index_interval + 1 = 129`), comfortably under the true downsampled
+    /// width. The target key sits at index 150 (past the old cap). It MUST
+    /// resolve: the false "authoritative absence" this fix closes would otherwise
+    /// surface as a silent "not found" for a partition that is genuinely present
+    /// on disk (`big_get_with_resolution`'s `covering_interval_is_end_bounded`
+    /// gate treats an end-bounded interval miss as definitive, never falling back
+    /// to `scan_for_key`).
+    #[tokio::test]
+    async fn downsampled_end_bounded_interval_resolves_key_past_the_old_cap() {
+        const MIN_INDEX_INTERVAL: u32 = 128;
+        const SAMPLING_LEVEL: u32 = 32; // 4x downsampled: effective width 512.
+        const N: usize = 200; // > old cap (129), < downsampled width (512).
+        const TARGET_INDEX: usize = 150; // past the old 129-entry cap.
+        let target_key = b"the-present-partition";
+
+        let (bytes, target_end) = build_n_entries(N, TARGET_INDEX, target_key);
+        let path = write_temp_index("bounded-present", &bytes).await;
+
+        let iv = SummaryInterval {
+            start_position: 0,
+            end_position: Some(bytes.len() as u64), // whole buffer is ONE interval
+            sample_index: 0,
+        };
+        let _ = target_end; // (kept for clarity; the interval covers the WHOLE buffer)
+
+        let res = lookup_key_in_interval(&path, iv, target_key, MIN_INDEX_INTERVAL, SAMPLING_LEVEL)
+            .await
+            .expect("interval read");
+        assert!(
+            res.entry.is_some(),
+            "a present key at index {TARGET_INDEX} (past the pre-fix {}-entry cap) in a \
+             downsampled end-bounded interval MUST resolve — a miss here is the false \
+             authoritative-absence data-loss bug (roborev job 1709)",
+            MIN_INDEX_INTERVAL + 1
+        );
+        assert_eq!(res.entry.unwrap().key_digest.as_ref(), target_key);
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    /// Mirror case: a key GENUINELY absent from the same downsampled end-bounded
+    /// interval still resolves to an authoritative `None` — the fix must not turn
+    /// "no premature cap" into "never stop" (an unbounded scan or a false hit).
+    /// `entries_touched` must equal the FULL interval's real entry count (every
+    /// whole entry scanned, no premature cap), not the old 129-entry cap.
+    #[tokio::test]
+    async fn downsampled_end_bounded_interval_absent_key_is_still_authoritative() {
+        const MIN_INDEX_INTERVAL: u32 = 128;
+        const SAMPLING_LEVEL: u32 = 32;
+        const N: usize = 200;
+
+        // No entry actually holds this key — build N entries with generated keys
+        // and probe with a key that structurally cannot collide with any of them.
+        let (bytes, _) = build_n_entries(N, usize::MAX, b"unused");
+        let path = write_temp_index("bounded-absent", &bytes).await;
+
+        let iv = SummaryInterval {
+            start_position: 0,
+            end_position: Some(bytes.len() as u64),
+            sample_index: 0,
+        };
+        let res = lookup_key_in_interval(
+            &path,
+            iv,
+            b"zzz-genuinely-absent-key",
+            MIN_INDEX_INTERVAL,
+            SAMPLING_LEVEL,
+        )
+        .await
+        .expect("interval read");
+        assert!(
+            res.entry.is_none(),
+            "a genuinely absent key in a downsampled end-bounded interval must still \
+             resolve to an authoritative absence"
+        );
+        assert_eq!(
+            res.entries_touched, N,
+            "the WHOLE interval's {N} entries must be scanned (no premature cap), \
+             proving the absence is genuinely exhaustive, not cap-truncated"
+        );
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    /// Last-interval (read-to-EOF) generous-cap bound test: `last_interval_entry_cap`
+    /// must derive the SAME downsampling-adjusted width formula
+    /// (`min_index_interval * 128 / sampling_level + 1`) the module doc promises —
+    /// pinned directly (pure function, no I/O) so the formula itself is load-bearing,
+    /// not just its end-to-end effect.
+    #[test]
+    fn last_interval_entry_cap_is_downsampling_adjusted() {
+        // Full sampling (128): cap is the pre-fix baseline, min_index_interval + 1.
+        assert_eq!(last_interval_entry_cap(128, 128), 129);
+        // 4x downsampled (sampling_level = 32): width widens to 128*128/32 = 512.
+        assert_eq!(last_interval_entry_cap(128, 32), 513);
+        // Maximum downsampling (sampling_level = 1): width widens to 128*128 = 16384.
+        assert_eq!(last_interval_entry_cap(128, 1), 16385);
+        // Corrupt/never-should-happen sampling_level = 0 clamps to 1 (max legitimate
+        // widening — the fail-safe direction for a cap, never a divide-by-zero).
+        assert_eq!(last_interval_entry_cap(128, 0), 16385);
+        // Corrupt/never-should-happen sampling_level > BASE_SAMPLING_LEVEL clamps to
+        // 128 (the un-downsampled baseline).
+        assert_eq!(last_interval_entry_cap(128, 9999), 129);
+    }
+
+    /// End-to-end confirmation that the read-to-EOF LAST interval (not merely the
+    /// pure-formula cap above) actually uses the downsampling-adjusted cap: a key
+    /// past the pre-fix 129-entry cap resolves when the interval is read to EOF
+    /// (`end_position: None`) under downsampling.
+    #[tokio::test]
+    async fn downsampled_last_interval_resolves_key_past_the_old_cap() {
+        const MIN_INDEX_INTERVAL: u32 = 128;
+        const SAMPLING_LEVEL: u32 = 32; // downsampled width 512.
+        const N: usize = 200;
+        const TARGET_INDEX: usize = 150;
+        let target_key = b"present-in-last-interval";
+
+        let (bytes, _) = build_n_entries(N, TARGET_INDEX, target_key);
+        let path = write_temp_index("last-present", &bytes).await;
+
+        let iv = SummaryInterval {
+            start_position: 0,
+            end_position: None, // read-to-EOF: the last interval.
+            sample_index: 0,
+        };
+        let res = lookup_key_in_interval(&path, iv, target_key, MIN_INDEX_INTERVAL, SAMPLING_LEVEL)
+            .await
+            .expect("interval read");
+        assert!(
+            res.entry.is_some(),
+            "a present key past the pre-fix cap in a downsampled LAST interval must \
+             resolve too (the generous, downsampling-adjusted cap applies here)"
+        );
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 }

--- a/cqlite-core/src/storage/sstable/summary_reader/interval.rs
+++ b/cqlite-core/src/storage/sstable/summary_reader/interval.rs
@@ -1,0 +1,410 @@
+//! Token-ordered `Summary.db` find-by-key + the lazy `Index.db` interval accessor
+//! for the Summary-guided BIG partition index (issue #2412, design §A/§B).
+//!
+//! Two primitives that make BIG open Cassandra-lazy:
+//!
+//! - [`find_interval_for_key`] binary-searches the token-ordered `Summary.db` samples
+//!   for the half-open `Index.db` byte range [`SummaryInterval`] that must contain a
+//!   query key's partition entry (the core new search; [`super::SummaryReader::find_by_key`]
+//!   is the method wrapper).
+//! - [`lookup_key_in_interval`] reads **only that one interval** (≤ `min_index_interval`
+//!   entries) from disk and resolves the exact key, recording exactly one **interval**
+//!   parse (`cqlite.sstable.index_interval_parses_total`) — never a full parse, so a
+//!   lazy-open regression stays visible on `index_parses_total` (design §F).
+//!
+//! No-heuristics (issue #28): every seek offset and interval boundary is an
+//! authoritative `Summary.db` sample position; entry framing is the on-disk `Index.db`
+//! structure. Nothing is inferred from value bytes.
+
+use std::path::Path;
+
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+use super::SummaryEntry;
+use crate::error::Result;
+use crate::storage::sstable::index_reader::{parse_big_index_entry, PartitionIndexEntry};
+
+/// A `Summary.db`-derived half-open byte range `[start_position, end_position)` into
+/// `Index.db` that must contain a query key's partition entry (issue #2412).
+///
+/// Produced by [`super::SummaryReader::find_by_key`]. `end_position == None` means
+/// "scan to EOF" (the covering sample is the last one). Both bounds are authoritative
+/// summary sample positions — the interval is structural, never a guessed boundary (#28).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SummaryInterval {
+    /// Inclusive start byte offset into `Index.db` (the covering sample's position).
+    pub start_position: u64,
+    /// Exclusive end byte offset into `Index.db` (the next sample's position), or
+    /// `None` to read to EOF when the covering sample is the last one.
+    pub end_position: Option<u64>,
+    /// Index of the covering (floor) sample within [`super::SummaryReader::get_entries`].
+    pub sample_index: usize,
+}
+
+/// Token-ordered binary search over `Summary.db` samples for the `Index.db` interval
+/// covering `key` (issue #2412). Pure core of [`super::SummaryReader::find_by_key`],
+/// factored out so it is unit-testable without a `Platform`/file open.
+///
+/// The samples are in Cassandra **token order** (murmur3 of the raw partition key,
+/// ties broken by raw bytes), NOT lexicographic byte order, so the search compares
+/// with `cmp_partition_keys_by_token` — comparing raw bytes would be wrong for any
+/// non-degenerate ring. Returns the half-open `[start, end)`: `start` is the greatest
+/// sample whose key is `<= key` (Cassandra's `getPosition` floor); `end` is the next
+/// sample's position or `None` (EOF) for the last sample. A key below the first sample
+/// clamps the floor to sample 0 (Cassandra walks from the index start); the C5 range
+/// short-circuit already answers genuinely out-of-`[first_key,last_key]` reads upstream
+/// with zero probe work. Returns `None` only for an empty summary.
+pub(crate) fn find_interval_for_key(
+    entries: &[SummaryEntry],
+    key: &[u8],
+) -> Option<SummaryInterval> {
+    use crate::util::cassandra_murmur3::cmp_partition_keys_by_token;
+    use std::cmp::Ordering;
+
+    if entries.is_empty() {
+        return None;
+    }
+
+    // Count of samples whose key is <= `key` in token order (monotone prefix).
+    let le_count = entries.partition_point(|e| {
+        cmp_partition_keys_by_token(&e.partition_key, key) != Ordering::Greater
+    });
+    // Floor index: greatest sample <= key, clamped to 0 when key sorts below all.
+    let floor = le_count.saturating_sub(1);
+
+    Some(SummaryInterval {
+        start_position: entries[floor].position,
+        end_position: entries.get(floor + 1).map(|e| e.position),
+        sample_index: floor,
+    })
+}
+
+/// Result of resolving a key within one Summary-bounded `Index.db` interval.
+#[derive(Debug)]
+pub struct IntervalLookup {
+    /// The matched partition entry, or `None` when the key is genuinely absent from
+    /// this interval (an authoritative absence between two summary samples — the
+    /// whole-file `scan_for_key` oracle is NOT needed for the common case, design §B).
+    pub entry: Option<PartitionIndexEntry>,
+    /// Number of `Index.db` entries actually parsed/touched, bounded by one summary
+    /// interval (≤ `min_index_interval`). The scale-free work-probe for Requirement 2.
+    pub entries_touched: usize,
+}
+
+/// Cap on entries scanned in a single interval, derived from `min_index_interval`.
+///
+/// One summary interval spans `min_index_interval` partitions by construction, but a
+/// corrupt/rewritten summary could point at a wider run. Bounding the scan at
+/// `min_index_interval` (plus the boundary entry) means a hostile summary cannot turn
+/// a "bounded interval read" into a full-file walk; a genuine miss within the bound is
+/// still authoritative because the interval end is the next authoritative sample.
+fn interval_entry_cap(min_index_interval: u32) -> usize {
+    // +1 covers the boundary entry that sits exactly at the next sample position.
+    (min_index_interval as usize).saturating_add(1)
+}
+
+/// Scan a slice of `Index.db` interval bytes for the entry whose key equals `key`.
+///
+/// Pure core of [`lookup_key_in_interval`] (unit-testable without a file). Parses
+/// forward with [`parse_big_index_entry`] up to `entry_cap` entries, stopping at the
+/// first exact key match, at buffer exhaustion, at the entry cap, or at the first
+/// unparseable entry (a truncated boundary tail — treated as end-of-interval).
+pub(crate) fn scan_interval_bytes(bytes: &[u8], key: &[u8], entry_cap: usize) -> IntervalLookup {
+    let mut remaining = bytes;
+    let mut entries_touched = 0usize;
+
+    while !remaining.is_empty() && entries_touched < entry_cap {
+        match parse_big_index_entry(remaining) {
+            Ok((rest, entry)) => {
+                // Forward-progress guard mirrors the full parser's debug_assert.
+                if rest.len() >= remaining.len() {
+                    break;
+                }
+                entries_touched += 1;
+                if entry.key_digest.as_ref() == key {
+                    return IntervalLookup {
+                        entry: Some(entry),
+                        entries_touched,
+                    };
+                }
+                remaining = rest;
+            }
+            // Unparseable tail at the interval boundary — end of this interval's whole
+            // entries (never a heuristic: the boundary is an authoritative summary sample).
+            Err(_) => break,
+        }
+    }
+
+    IntervalLookup {
+        entry: None,
+        entries_touched,
+    }
+}
+
+/// Read one Summary-bounded `Index.db` interval from disk and resolve `key` within it
+/// (issue #2412, design §B).
+///
+/// Seeks to `interval.start_position`, reads the interval bytes (`[start, end)`, or to
+/// EOF when `interval.end_position` is `None`), and scans forward for the exact key.
+/// Increments `cqlite.sstable.index_interval_parses_total` exactly once (one bounded
+/// interval parse), never `index_parses_total` (design §F).
+pub async fn lookup_key_in_interval(
+    index_path: &Path,
+    interval: SummaryInterval,
+    key: &[u8],
+    min_index_interval: u32,
+) -> Result<IntervalLookup> {
+    let mut file = File::open(index_path).await?;
+    file.seek(std::io::SeekFrom::Start(interval.start_position))
+        .await?;
+
+    let mut buffer = Vec::new();
+    match interval.end_position {
+        Some(end) if end > interval.start_position => {
+            // Bounded read of exactly the interval's whole entries.
+            let len = (end - interval.start_position) as usize;
+            buffer.resize(len, 0);
+            file.read_exact(&mut buffer).await?;
+        }
+        // Last interval (or a degenerate empty/zero-width range): read to EOF. The scan
+        // is still bounded by `interval_entry_cap`, so this can never become a
+        // whole-file walk for a many-partition SSTable.
+        _ => {
+            file.read_to_end(&mut buffer).await?;
+        }
+    }
+
+    // One bounded interval parse (distinct counter — never a full parse, design §F).
+    crate::observability::add_counter(
+        crate::observability::catalog::INDEX_INTERVAL_PARSES_TOTAL,
+        1,
+        &[],
+    );
+
+    Ok(scan_interval_bytes(
+        &buffer,
+        key,
+        interval_entry_cap(min_index_interval),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- find_interval_for_key (token-ordered search) ----
+
+    /// Build token-ordered summary samples from arbitrary raw keys (issue #2412). The
+    /// `Summary.db` on disk is written in token order; a test mirrors that by sorting
+    /// with the same comparator `find_interval_for_key` searches with and assigning
+    /// strictly increasing `Index.db` positions.
+    fn token_ordered_samples(keys: &[&[u8]]) -> Vec<SummaryEntry> {
+        use crate::util::cassandra_murmur3::cmp_partition_keys_by_token;
+        let mut keys: Vec<Vec<u8>> = keys.iter().map(|k| k.to_vec()).collect();
+        keys.sort_by(|a, b| cmp_partition_keys_by_token(a, b));
+        keys.into_iter()
+            .enumerate()
+            .map(|(i, partition_key)| SummaryEntry {
+                partition_key,
+                position: (i as u64) * 128,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn find_by_key_empty_summary_returns_none() {
+        assert_eq!(find_interval_for_key(&[], b"anything"), None);
+    }
+
+    #[test]
+    fn find_by_key_present_sample_bounds_one_interval() {
+        // Requirement 2: a present sample key resolves to the half-open interval
+        // [its position, next sample's position).
+        let samples = token_ordered_samples(&[b"aaaa", b"bbbb", b"cccc", b"dddd"]);
+        for i in 0..samples.len() {
+            let iv = find_interval_for_key(&samples, &samples[i].partition_key)
+                .expect("present key must resolve an interval");
+            assert_eq!(iv.sample_index, i, "floor must be the exact sample");
+            assert_eq!(iv.start_position, samples[i].position);
+            assert_eq!(
+                iv.end_position,
+                samples.get(i + 1).map(|e| e.position),
+                "end is next sample position, or None (EOF) for the last sample"
+            );
+        }
+    }
+
+    #[test]
+    fn find_by_key_between_samples_floors_to_lower() {
+        // A key sorting strictly between two samples lands in the LOWER sample's
+        // interval — the forward walk from there covers it (design §B). Asserted
+        // structurally so the test is independent of the murmur3 layout.
+        use crate::util::cassandra_murmur3::cmp_partition_keys_by_token;
+        use std::cmp::Ordering;
+        let samples = token_ordered_samples(&[b"k0", b"k1", b"k2", b"k3", b"k4"]);
+        for probe in [b"zz".as_slice(), b"m", b"q7", b"abcd", b"7", b"XYZ"] {
+            let iv = match find_interval_for_key(&samples, probe) {
+                Some(iv) => iv,
+                None => continue,
+            };
+            let floor = iv.sample_index;
+            assert_ne!(
+                cmp_partition_keys_by_token(&samples[floor].partition_key, probe),
+                Ordering::Greater,
+                "floor sample must be <= probe in token order"
+            );
+            if let Some(next) = samples.get(floor + 1) {
+                assert_eq!(
+                    cmp_partition_keys_by_token(&next.partition_key, probe),
+                    Ordering::Greater,
+                    "the sample after the floor must be > probe in token order"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn find_by_key_below_first_sample_clamps_to_zero() {
+        // Requirement 2/6: a key below the first sample clamps the floor to sample 0
+        // (Cassandra walks from the index start). Constructed DETERMINISTICALLY: take a
+        // pool of keys, sort by token, drop the lowest-token key from the samples, then
+        // probe with that dropped key — guaranteed to sort below sample 0.
+        use crate::util::cassandra_murmur3::cmp_partition_keys_by_token;
+        use std::cmp::Ordering;
+        let pool: [&[u8]; 6] = [b"p1", b"p2", b"p3", b"p4", b"p5", b"p6"];
+        let all = token_ordered_samples(&pool); // token-ascending
+        let below = all[0].partition_key.clone(); // lowest token in the pool
+        let samples: Vec<SummaryEntry> = all[1..].to_vec(); // exclude it from the samples
+        assert_eq!(
+            cmp_partition_keys_by_token(&below, &samples[0].partition_key),
+            Ordering::Less,
+            "constructed probe must sort below the first remaining sample"
+        );
+        let iv = find_interval_for_key(&samples, &below).expect("interval");
+        assert_eq!(iv.sample_index, 0, "below-first key clamps to sample 0");
+        assert_eq!(iv.start_position, samples[0].position);
+    }
+
+    // ---- interval byte scan + disk accessor ----
+
+    /// Encode one BIG `Index.db` entry: `[key_len u16 BE][key][data_offset vint][promoted_len vint=0]`.
+    fn encode_entry(key: &[u8], data_offset: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(key.len() as u16).to_be_bytes());
+        out.extend_from_slice(key);
+        out.extend_from_slice(&crate::parser::vint::encode_vuint(data_offset));
+        out.extend_from_slice(&crate::parser::vint::encode_vuint(0));
+        out
+    }
+
+    fn build_interval(keys_offsets: &[(&[u8], u64)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for (k, off) in keys_offsets {
+            buf.extend_from_slice(&encode_entry(k, *off));
+        }
+        buf
+    }
+
+    #[test]
+    fn scan_finds_present_key_and_counts_bounded_entries() {
+        let bytes = build_interval(&[
+            (b"alpha", 0),
+            (b"bravo", 100),
+            (b"charlie", 250),
+            (b"delta", 400),
+        ]);
+        let res = scan_interval_bytes(&bytes, b"charlie", 128);
+        let entry = res.entry.expect("present key must be found");
+        assert_eq!(entry.key_digest.as_ref(), b"charlie");
+        assert_eq!(entry.data_offset, 250);
+        assert_eq!(
+            res.entries_touched, 3,
+            "touched only up to and including the match"
+        );
+    }
+
+    #[test]
+    fn scan_absent_key_within_interval_is_authoritative_none() {
+        let bytes = build_interval(&[(b"alpha", 0), (b"bravo", 100), (b"charlie", 250)]);
+        let res = scan_interval_bytes(&bytes, b"zzz_absent", 128);
+        assert!(res.entry.is_none(), "absent key resolves to None");
+        assert_eq!(
+            res.entries_touched, 3,
+            "touched all interval entries, bounded"
+        );
+    }
+
+    #[test]
+    fn scan_respects_entry_cap() {
+        let bytes = build_interval(&[
+            (b"k0", 0),
+            (b"k1", 10),
+            (b"k2", 20),
+            (b"k3", 30),
+            (b"k4", 40),
+        ]);
+        let res = scan_interval_bytes(&bytes, b"k4", 2);
+        assert!(res.entry.is_none(), "cap reached before the match");
+        assert_eq!(res.entries_touched, 2, "scan stopped at the cap");
+    }
+
+    #[test]
+    fn scan_stops_on_truncated_tail() {
+        let mut bytes = build_interval(&[(b"alpha", 0), (b"bravo", 100)]);
+        bytes.extend_from_slice(&[0x00, 0x40]); // dangling key-length header, no body
+        let res = scan_interval_bytes(&bytes, b"missing", 128);
+        assert!(res.entry.is_none());
+        assert_eq!(res.entries_touched, 2, "only the two whole entries counted");
+    }
+
+    #[tokio::test]
+    async fn lookup_reads_only_the_bounded_range_from_disk() {
+        // Requirement 2: the async accessor seeks to `start_position` and reads only
+        // `[start, end)`, resolving a key inside the interval WITHOUT touching the
+        // trailing entries. The interval-parse COUNTER is asserted in the
+        // observability-testing integration test (needs the process-global meter).
+        let prefix = build_interval(&[(b"before0", 0), (b"before1", 5)]);
+        let interval = build_interval(&[(b"target", 900), (b"neighbor", 950)]);
+        let trailing = build_interval(&[(b"after0", 1000)]);
+        let mut file_bytes = prefix.clone();
+        file_bytes.extend_from_slice(&interval);
+        file_bytes.extend_from_slice(&trailing);
+
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-2412-interval-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("nb-1-big-Index.db");
+        std::fs::write(&path, &file_bytes).unwrap();
+
+        let iv = SummaryInterval {
+            start_position: prefix.len() as u64,
+            end_position: Some((prefix.len() + interval.len()) as u64),
+            sample_index: 1,
+        };
+        let res = lookup_key_in_interval(&path, iv, b"target", 128)
+            .await
+            .expect("interval read");
+        let entry = res.entry.expect("target present in the interval");
+        assert_eq!(entry.key_digest.as_ref(), b"target");
+        assert_eq!(entry.data_offset, 900);
+        assert_eq!(res.entries_touched, 1, "matched the first interval entry");
+
+        // A key beyond the bounded range is structurally unreachable for this interval.
+        let res2 = lookup_key_in_interval(&path, iv, b"after0", 128)
+            .await
+            .expect("interval read");
+        assert!(
+            res2.entry.is_none(),
+            "a key past end_position is not read (authoritative miss for this interval)"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/cqlite-core/src/storage/sstable/summary_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/summary_reader/mod.rs
@@ -216,6 +216,26 @@ impl SummaryReader {
         interval::find_interval_for_key(&self.summary_data.entries, key)
     }
 
+    /// The authoritative `Index.db` byte offset from which a token-range scan whose
+    /// exclusive lower bound is `start_excl` should begin its forward walk (issue
+    /// #2412 §C / #2413 Option A). Returns the position of the greatest sample whose
+    /// murmur3 token is `<= start_excl` — the floor sample — so the forward walk
+    /// covers every in-range partition (`token > start_excl`) while skipping the
+    /// wholly-below-range prefix. Clamps to sample 0's position (the index start)
+    /// when every sample sorts above `start_excl`, and returns `0` for an empty
+    /// summary (scan from the beginning). The samples are token-ordered on disk, so
+    /// a token binary search is exact — no key is needed and nothing is guessed
+    /// (no-heuristics, issue #28).
+    pub fn scan_start_position_for_token(&self, start_excl: i64) -> u64 {
+        use crate::util::cassandra_murmur3::cassandra_murmur3_token;
+        let entries = &self.summary_data.entries;
+        // Monotone prefix of samples whose token is <= start_excl (token order).
+        let le =
+            entries.partition_point(|e| cassandra_murmur3_token(&e.partition_key) <= start_excl);
+        let floor = le.saturating_sub(1);
+        entries.get(floor).map(|e| e.position).unwrap_or(0)
+    }
+
     /// Get summary statistics
     pub fn get_statistics(&self) -> SummaryStatistics {
         let header = &self.summary_data.header;

--- a/cqlite-core/src/storage/sstable/summary_reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/summary_reader/mod.rs
@@ -38,6 +38,12 @@
 //! Unlike all other Cassandra binary formats which use big-endian, the offset
 //! table in Summary.db uses little-endian byte order for historical reasons.
 
+// Lazy Summary-guided Index.db interval accessor + the token-ordered find-by-key
+// search (issue #2412). A submodule so the new responsibility lives in its own file
+// under the campsite line without touching the over-threshold `sstable/mod.rs`.
+pub mod interval;
+pub use interval::SummaryInterval;
+
 use crate::{
     error::{Error, Result},
     platform::Platform,
@@ -184,6 +190,30 @@ impl SummaryReader {
     /// Find the entry at a specific index
     pub fn get_entry_at(&self, index: usize) -> Option<&SummaryEntry> {
         self.summary_data.entries.get(index)
+    }
+
+    /// Binary-search the token-ordered sampled keys for the `Index.db` interval that
+    /// must contain `key`'s partition entry (issue #2412, design §A/§B — the core new
+    /// primitive that makes BIG open Cassandra-lazy).
+    ///
+    /// The `Summary.db` samples are in Cassandra **token order** (murmur3 of the raw
+    /// partition key, ties broken by raw bytes), NOT lexicographic byte order, so the
+    /// search compares with [`cmp_partition_keys_by_token`] — comparing raw bytes would
+    /// be wrong for any non-degenerate ring. Returns the half-open byte range
+    /// `[start, end)` into `Index.db`: `start` is the position of the greatest sample
+    /// whose key is `<= key` (Cassandra's `getPosition` floor); `end` is the next
+    /// sample's position, or `None` (scan to EOF) when the floor is the last sample.
+    ///
+    /// When `key` sorts below the first sample the floor clamps to sample 0 (Cassandra
+    /// begins its walk at the start of the index): the returned first interval is then
+    /// searched and yields an authoritative absence — the out-of-`[first_key,last_key]`
+    /// case is already answered upstream by the C5 range short-circuit with zero probe
+    /// work. Returns `None` only for an empty summary (no samples to bound a walk).
+    ///
+    /// The interval boundary is STRUCTURAL — two adjacent authoritative summary sample
+    /// positions — never a guessed offset (no-heuristics, issue #28).
+    pub fn find_by_key(&self, key: &[u8]) -> Option<SummaryInterval> {
+        interval::find_interval_for_key(&self.summary_data.entries, key)
     }
 
     /// Get summary statistics

--- a/cqlite-core/src/storage/write_engine/merge/from_readers.rs
+++ b/cqlite-core/src/storage/write_engine/merge/from_readers.rs
@@ -91,15 +91,53 @@ pub(super) async fn drive_compaction_stream(
 ) -> Result<()> {
     reader
         .stream_all_partitions_for_compaction(Some(schema), scan_cancel, |compaction_row| {
-            let msg =
-                SSTableRowIteratorAdapter::build_merge_entry(run_index, compaction_row, schema)
-                    .map_err(MergeProducerError::from);
-            match sender.send(msg) {
-                Ok(()) => Ok(std::ops::ControlFlow::Continue(())),
-                Err(_) => Ok(std::ops::ControlFlow::Break(())),
-            }
+            forward_row(run_index, compaction_row, schema, sender)
         })
         .await
+}
+
+/// Warm query-serve sibling of [`drive_compaction_stream`] (issue #2412 §C /
+/// #2413 Option A): drives the reader's Summary-guided query stream
+/// ([`SSTableReader::stream_all_partitions_for_query`]) with an optional token
+/// pushdown, instead of the full-ring compaction stream.
+///
+/// A SEPARATE helper (not a flag on `drive_compaction_stream`) precisely because
+/// the two must NOT drift toward each other: the path-based/compaction thread
+/// (`mod.rs`) keeps its byte-parity full-ring materialising walk unchanged, while
+/// ONLY the warm reader-based producer takes the streaming + token-scoped path.
+/// The per-row conversion/backpressure (`forward_row`) is still shared, so the
+/// emit contract cannot diverge.
+pub(super) async fn drive_query_stream(
+    reader: &SSTableReader,
+    run_index: usize,
+    schema: &TableSchema,
+    scan_cancel: &ScanCancel,
+    token_bound: Option<crate::storage::sstable::reader::ScanTokenBound>,
+    sender: &SyncSender<std::result::Result<MergeEntry, MergeProducerError>>,
+) -> Result<()> {
+    reader
+        .stream_all_partitions_for_query(Some(schema), scan_cancel, token_bound, |compaction_row| {
+            forward_row(run_index, compaction_row, schema, sender)
+        })
+        .await
+}
+
+/// Convert one streamed row into a [`MergeEntry`] and push it into `sender`,
+/// signalling `Break` when the consumer has dropped the channel. Shared by BOTH
+/// [`drive_compaction_stream`] and [`drive_query_stream`] so their emit
+/// contract is defined in exactly one place.
+fn forward_row(
+    run_index: usize,
+    compaction_row: crate::storage::sstable::reader::CompactionRow,
+    schema: &TableSchema,
+    sender: &SyncSender<std::result::Result<MergeEntry, MergeProducerError>>,
+) -> Result<std::ops::ControlFlow<()>> {
+    let msg = SSTableRowIteratorAdapter::build_merge_entry(run_index, compaction_row, schema)
+        .map_err(MergeProducerError::from);
+    match sender.send(msg) {
+        Ok(()) => Ok(std::ops::ControlFlow::Continue(())),
+        Err(_) => Ok(std::ops::ControlFlow::Break(())),
+    }
 }
 
 impl SSTableRowIteratorAdapter {
@@ -118,6 +156,7 @@ impl SSTableRowIteratorAdapter {
         run_index: usize,
         schema: &TableSchema,
         scan_cancel: ScanCancel,
+        token_bound: Option<crate::storage::sstable::reader::ScanTokenBound>,
     ) -> Result<Self> {
         let schema = schema.clone();
         // Held on the adapter for cancel-aware recv + Drop teardown (issue #2361).
@@ -129,7 +168,14 @@ impl SSTableRowIteratorAdapter {
         producer_gauge::spawned();
 
         let producer = match std::thread::Builder::new().spawn(move || {
-            Self::producer_thread_from_reader(reader, run_index, schema, scan_cancel, sender);
+            Self::producer_thread_from_reader(
+                reader,
+                run_index,
+                schema,
+                scan_cancel,
+                token_bound,
+                sender,
+            );
         }) {
             Ok(handle) => handle,
             Err(e) => {
@@ -162,6 +208,7 @@ impl SSTableRowIteratorAdapter {
         run_index: usize,
         schema: TableSchema,
         scan_cancel: ScanCancel,
+        token_bound: Option<crate::storage::sstable::reader::ScanTokenBound>,
         sender: SyncSender<std::result::Result<MergeEntry, MergeProducerError>>,
     ) {
         let _thread_guard = producer_gauge::ProducerThreadGuard;
@@ -177,11 +224,12 @@ impl SSTableRowIteratorAdapter {
                         e
                     ))
                 })?;
-            rt.block_on(drive_compaction_stream(
+            rt.block_on(drive_query_stream(
                 &reader,
                 run_index,
                 &schema,
                 &scan_cancel,
+                token_bound,
                 &sender,
             ))
         })();
@@ -206,6 +254,11 @@ impl KWayMerger {
     /// are. Reconciliation is byte-identical to the path-based merge — only WHO
     /// opens/owns the `SSTableReader` differs.
     ///
+    /// `token_bound` (issue #2412 §C / #2413 Option A): when `Some`, each reader's
+    /// Summary-guided walk is scoped to the split's `(start, end]` token range so
+    /// out-of-range partition bodies are never read; `None` walks the full ring.
+    /// Compaction never uses this seam, so it keeps full-ring parity walks.
+    ///
     /// UDT-registry guard (issue #2346, WS1 #2345): this seam takes NO
     /// `udt_registry` parameter (see the module doc — a shared `Arc` reader has
     /// no `&mut self` for `set_udt_registry`). Each caller-supplied reader MUST
@@ -219,6 +272,7 @@ impl KWayMerger {
         readers: Vec<Arc<SSTableReader>>,
         schema: &TableSchema,
         scan_cancel: ScanCancel,
+        token_bound: Option<crate::storage::sstable::reader::ScanTokenBound>,
     ) -> Result<Self> {
         if readers.is_empty() {
             return Err(Error::InvalidInput(
@@ -234,6 +288,7 @@ impl KWayMerger {
                 run_index,
                 schema,
                 scan_cancel.clone(),
+                token_bound,
             )?;
             runs.push(RunReader::new(
                 Box::new(adapter) as Box<dyn SSTableRowIterator>
@@ -493,7 +548,7 @@ mod tests {
             for path in &paths {
                 readers.push(Arc::new(open_reader(path).await));
             }
-            KWayMerger::new_from_readers(readers, &schema, ScanCancel::default())
+            KWayMerger::new_from_readers(readers, &schema, ScanCancel::default(), None)
                 .expect("reader-based merger constructs")
         });
 
@@ -533,7 +588,7 @@ mod tests {
             for path in &paths {
                 readers.push(Arc::new(open_reader(path).await));
             }
-            KWayMerger::new_from_readers(readers, &schema, ScanCancel::default())
+            KWayMerger::new_from_readers(readers, &schema, ScanCancel::default(), None)
                 .expect("reader-based merger constructs")
         });
 

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -307,11 +307,14 @@ pub fn build_single_partition_merger_from_readers(
                 // path-based open (issue #2346's whole point). `reader` (the
                 // ORIGINAL, not the clone `probe_reader` consumed above) is
                 // still available here.
+                // Point-read fail-safe: a specific-key filter, not a range scan —
+                // no token bound is pushed (issue #2412; the key set bounds it).
                 let adapter = SSTableRowIteratorAdapter::open_from_reader(
                     reader,
                     run_index,
                     schema,
                     scan_cancel.clone(),
+                    None,
                 )?;
                 runs.push(Box::new(SinglePartitionFilterRun {
                     inner: adapter,

--- a/cqlite-core/tests/issue_2385_index_single_parse.rs
+++ b/cqlite-core/tests/issue_2385_index_single_parse.rs
@@ -7,8 +7,15 @@
 //! `load_index_reader` (the raw-key `IndexReader` that actually serves lookups).
 //! At 1.42M partitions that doubled a multi-minute cold parse (#2385) — the #2395
 //! double-parse. This pins the win via the authoritative
-//! `cqlite.sstable.index_parses_total` counter (#2383): a cold open records
-//! EXACTLY 1 (RED = 2 on the pre-fix tree).
+//! `cqlite.sstable.index_parses_total` counter (#2383): the whole file is full-parsed
+//! AT MOST ONCE (RED = 2 on the pre-fix tree).
+//!
+//! Issue #2412 (lazy Summary-guided open) SUPERSEDES the earlier "exactly once at
+//! OPEN" phrasing: a BIG open with a usable `Summary.db` now full-parses `Index.db`
+//! ZERO times at open (deferred), and the single full parse happens on the first
+//! materializing use (here, a full enumeration). The anti-double-parse guard is
+//! preserved as "open + one full enumeration parses EXACTLY ONCE total, never twice".
+//! The pure open-time laziness is pinned separately by `issue_2412_lazy_big_open`.
 //!
 //! Separate integration-test process: the OTel capture harness installs a
 //! PROCESS-GLOBAL meter provider, so this must not share cqlite-core's parallel
@@ -70,13 +77,16 @@ fn find_big_data_file(keyspace: &str, table: &str) -> Option<PathBuf> {
     None
 }
 
-/// Opening a BIG SSTable must parse `Index.db` exactly once.
+/// Opening a BIG SSTable plus one full enumeration must full-parse `Index.db` at
+/// most once (never the pre-#2395 twice).
 ///
 /// RED on the pre-fix tree: `load_index` (Strategy 2 convert) + `load_index_reader`
-/// each ran a full parse → counter == 2. GREEN after retiring the Strategy 2
-/// `SSTableIndex` build: only `load_index_reader` parses → counter == 1.
+/// each ran a full parse → counter == 2. After retiring the Strategy 2 `SSTableIndex`
+/// build AND the #2412 lazy open, a cold open with a usable `Summary.db` parses ZERO
+/// times, and the first materializing use (the full enumeration here) parses exactly
+/// once → total == 1 (never 2).
 #[test]
-fn open_parses_index_exactly_once() {
+fn open_plus_enumeration_parses_index_exactly_once() {
     // Install the process-global in-memory meter BEFORE any parse in this process.
     let mc = testing::metrics_capture();
 
@@ -94,21 +104,34 @@ fn open_parses_index_exactly_once() {
             .expect("platform must initialize"),
     );
 
-    // Reset BEFORE the open so the entire open path is measured from zero.
+    // Reset BEFORE the open so the entire open + enumeration path is measured from zero.
     mc.reset();
     let reader = rt
         .block_on(SSTableReader::open(&data_file, &config, platform))
         .expect("BIG fixture must open");
-    // Keep the reader alive across the collection so the open work is attributed.
-    let _ = &reader;
 
-    let parses = mc
+    // Open alone (with a usable Summary.db) full-parses ZERO times — the #2412 lazy win.
+    let parses_after_open = mc
         .flush_and_collect()
         .counter_sum(catalog::INDEX_PARSES_TOTAL);
-
     assert_eq!(
-        parses, 1.0,
-        "opening a BIG SSTable must parse Index.db exactly ONCE (got {parses}); \
-         pre-fix this was 2 — load_index (Strategy 2 convert) plus load_index_reader (#2395)"
+        parses_after_open, 0.0,
+        "a BIG open with a usable Summary.db must full-parse Index.db ZERO times (lazy, \
+         issue #2412); got {parses_after_open}"
+    );
+
+    // The first materializing use (a full enumeration) full-parses EXACTLY ONCE — never
+    // the pre-#2395 twice. `flush_and_collect` is delta temporality, so this is the
+    // enumeration's own parse count.
+    let _ = rt
+        .block_on(reader.iterate_all_partitions())
+        .expect("full enumeration must succeed");
+    let parses_after_enum = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    assert_eq!(
+        parses_after_enum, 1.0,
+        "the first full enumeration must full-parse Index.db EXACTLY ONCE (got \
+         {parses_after_enum}); pre-#2395 this whole path parsed twice"
     );
 }

--- a/cqlite-core/tests/issue_2412_interval_parse_counter.rs
+++ b/cqlite-core/tests/issue_2412_interval_parse_counter.rs
@@ -1,0 +1,104 @@
+//! Issue #2412 — the lazy Summary-guided `Index.db` interval accessor records a
+//! bounded **interval** parse on the DISTINCT counter, never a full parse.
+//!
+//! Spec `lazy-big-partition-index` Requirement 5 (scenario "Lazy open reports zero
+//! full parses; interval work is counted separately") + design §F: a single
+//! Summary-bounded interval read increments
+//! `cqlite.sstable.index_interval_parses_total` by exactly 1 and leaves
+//! `cqlite.sstable.index_parses_total` (the field-round full-parse probe) at 0. This
+//! guarantees a lazy-open regression that accidentally full-parses stays visible on
+//! the full-parse counter.
+//!
+//! Separate integration-test process: the OTel capture harness installs a
+//! PROCESS-GLOBAL meter provider, so this must not share cqlite-core's parallel
+//! `--lib` unit-test binary (roborev #2163 / #2385 precedent).
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-core --features observability-testing \
+//!   --test issue_2412_interval_parse_counter
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::parser::vint::encode_vuint;
+use cqlite_core::storage::sstable::summary_reader::interval::lookup_key_in_interval;
+use cqlite_core::storage::sstable::summary_reader::SummaryInterval;
+
+/// Encode one BIG `Index.db` entry: `[key_len u16 BE][key][data_offset vint][promoted_len vint=0]`.
+fn encode_entry(key: &[u8], data_offset: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(key.len() as u16).to_be_bytes());
+    out.extend_from_slice(key);
+    out.extend_from_slice(&encode_vuint(data_offset));
+    out.extend_from_slice(&encode_vuint(0));
+    out
+}
+
+fn build(keys_offsets: &[(&[u8], u64)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for (k, off) in keys_offsets {
+        buf.extend_from_slice(&encode_entry(k, *off));
+    }
+    buf
+}
+
+#[test]
+fn interval_read_counts_one_interval_parse_and_zero_full_parses() {
+    let mc = testing::metrics_capture();
+
+    // Synthetic Index.db: [prefix][interval][trailing]; only the interval is read.
+    let prefix = build(&[(b"before0", 0), (b"before1", 5)]);
+    let interval = build(&[(b"target", 900), (b"neighbor", 950)]);
+    let trailing = build(&[(b"after0", 1000)]);
+    let mut file_bytes = prefix.clone();
+    file_bytes.extend_from_slice(&interval);
+    file_bytes.extend_from_slice(&trailing);
+
+    let dir = std::env::temp_dir().join(format!(
+        "cqlite-2412-counter-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let path = dir.join("nb-1-big-Index.db");
+    std::fs::write(&path, &file_bytes).expect("write index");
+
+    let iv = SummaryInterval {
+        start_position: prefix.len() as u64,
+        end_position: Some((prefix.len() + interval.len()) as u64),
+        sample_index: 1,
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    // Reset so the whole operation is measured from zero.
+    mc.reset();
+    let res = rt
+        .block_on(lookup_key_in_interval(&path, iv, b"target", 128))
+        .expect("interval read");
+    assert!(
+        res.entry.is_some(),
+        "target must resolve inside the interval"
+    );
+    assert_eq!(res.entries_touched, 1, "bounded: matched the first entry");
+
+    let collected = mc.flush_and_collect();
+    let interval_parses = collected.counter_sum(catalog::INDEX_INTERVAL_PARSES_TOTAL);
+    let full_parses = collected.counter_sum(catalog::INDEX_PARSES_TOTAL);
+
+    assert_eq!(
+        interval_parses, 1.0,
+        "one bounded interval parse must be recorded (got {interval_parses})"
+    );
+    assert_eq!(
+        full_parses, 0.0,
+        "a lazy interval read must NOT record a full Index.db parse (got {full_parses})"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/cqlite-core/tests/issue_2412_interval_parse_counter.rs
+++ b/cqlite-core/tests/issue_2412_interval_parse_counter.rs
@@ -79,7 +79,7 @@ fn interval_read_counts_one_interval_parse_and_zero_full_parses() {
     // Reset so the whole operation is measured from zero.
     mc.reset();
     let res = rt
-        .block_on(lookup_key_in_interval(&path, iv, b"target", 128))
+        .block_on(lookup_key_in_interval(&path, iv, b"target", 128, 128))
         .expect("interval read");
     assert!(
         res.entry.is_some(),

--- a/cqlite-core/tests/issue_2412_lazy_big_open.rs
+++ b/cqlite-core/tests/issue_2412_lazy_big_open.rs
@@ -1,0 +1,180 @@
+//! Issue #2412 (Stage 2, spec `lazy-big-partition-index` Requirement 1) — cold BIG
+//! `SSTableReader::open` with a usable `Summary.db` performs ZERO full `Index.db`
+//! parses, scale-free (independent of partition count).
+//!
+//! Distinguishes the two scenarios the spec names:
+//! - A BIG SSTable WITH `Summary.db`: lazy open, `index_parses_total += 0`.
+//! - A BIG SSTable WITHOUT `Summary.db` (synthesized by copying a fixture and
+//!   removing its `Summary.db` sibling): the §A1 counted FellBack full parse,
+//!   `index_parses_total += 1` — never silent, never a regression for shapes that
+//!   legitimately ship without a usable Summary.db.
+//!
+//! Separate integration-test process: the OTel capture harness installs a
+//! PROCESS-GLOBAL meter provider, so this must not share cqlite-core's parallel
+//! `--lib` unit-test binary (roborev #2163 / #2385 precedent).
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-core --features observability-testing \
+//!   --test issue_2412_lazy_big_open
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::platform::Platform;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::Config;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// Locate a `*-Data.db` in `<datasets>/sstables/<keyspace>/<table>-*/` that has a
+/// sibling `*-Index.db` AND `*-Summary.db` (a BIG-format SSTable with a usable
+/// summary). Skip keys off fixture presence.
+fn find_big_data_file_with_summary(keyspace: &str, table: &str) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let entries = std::fs::read_dir(root.join("sstables").join(keyspace)).ok()?;
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        let dir = e.path();
+        let files = std::fs::read_dir(&dir).ok()?;
+        let mut data_file: Option<PathBuf> = None;
+        let mut has_index = false;
+        let mut has_summary = false;
+        for f in files.flatten() {
+            let name = f.file_name().to_string_lossy().into_owned();
+            if name.ends_with("-Data.db") {
+                data_file = Some(f.path());
+            } else if name.ends_with("-Index.db") {
+                has_index = true;
+            } else if name.ends_with("-Summary.db") {
+                has_summary = true;
+            }
+        }
+        if has_index && has_summary {
+            if let Some(df) = data_file {
+                return Some(df);
+            }
+        }
+    }
+    None
+}
+
+/// Requirement 1, Scenario "Cold BIG open touches zero Index.db entries and
+/// performs zero full parses": a BIG SSTable with a usable `Summary.db` opens
+/// without a single full `Index.db` parse.
+#[test]
+fn cold_open_with_summary_performs_zero_full_parses() {
+    let mc = testing::metrics_capture();
+
+    let Some(data_file) = find_big_data_file_with_summary("test_basic", "simple_table") else {
+        eprintln!(
+            "Skipping (#2412 lazy BIG open): BIG test_basic/simple_table fixture (with \
+             Summary.db) absent"
+        );
+        return;
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let config = Config::default();
+    let platform = Arc::new(
+        rt.block_on(Platform::new(&config))
+            .expect("platform must initialize"),
+    );
+
+    mc.reset();
+    let reader = rt
+        .block_on(SSTableReader::open(&data_file, &config, platform))
+        .expect("BIG fixture with Summary.db must open");
+    // Keep the reader alive across the collection so the open work is attributed.
+    let _ = &reader;
+
+    let full_parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    assert_eq!(
+        full_parses, 0.0,
+        "a BIG open with a usable Summary.db must perform ZERO full Index.db \
+         parses (lazy Summary-guided open, issue #2412); got {full_parses}"
+    );
+}
+
+/// Requirement 6, Scenario "Absent Summary.db falls back to a counted full parse,
+/// not a guess": copy a real fixture into a temp dir, delete its `Summary.db`
+/// sibling, and confirm opening it performs EXACTLY ONE full parse (the §A1
+/// FellBack), never silent and never zero (which would silently under-read).
+#[test]
+fn absent_summary_falls_back_to_one_counted_full_parse() {
+    let mc = testing::metrics_capture();
+
+    let Some(data_file) = find_big_data_file_with_summary("test_basic", "simple_table") else {
+        eprintln!(
+            "Skipping (#2412 FellBack): BIG test_basic/simple_table fixture (with Summary.db) \
+             absent"
+        );
+        return;
+    };
+    let src_dir = data_file.parent().expect("fixture has a parent dir");
+
+    let tmp = std::env::temp_dir().join(format!(
+        "cqlite-2412-no-summary-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&tmp).expect("mkdir temp fixture copy");
+    let mut copied_data_path: Option<PathBuf> = None;
+    for entry in std::fs::read_dir(src_dir)
+        .expect("read fixture dir")
+        .flatten()
+    {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.ends_with("-Summary.db") {
+            // Deliberately NOT copied: this synthesizes the absent-Summary.db shape.
+            continue;
+        }
+        let dest = tmp.join(&name);
+        std::fs::copy(entry.path(), &dest).expect("copy fixture component");
+        if name.ends_with("-Data.db") {
+            copied_data_path = Some(dest);
+        }
+    }
+    let copied_data_path = copied_data_path.expect("fixture must include a Data.db");
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let config = Config::default();
+    let platform = Arc::new(
+        rt.block_on(Platform::new(&config))
+            .expect("platform must initialize"),
+    );
+
+    mc.reset();
+    let reader = rt
+        .block_on(SSTableReader::open(&copied_data_path, &config, platform))
+        .expect("BIG fixture without Summary.db must still open (FellBack, not a hard error)");
+    let _ = &reader;
+
+    let full_parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    assert_eq!(
+        full_parses, 1.0,
+        "an absent Summary.db must FellBack to exactly ONE counted full Index.db parse \
+         (issue #2412 design §A1), never silent and never zero; got {full_parses}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/cqlite-core/tests/issue_2412_point_interval.rs
+++ b/cqlite-core/tests/issue_2412_point_interval.rs
@@ -1,0 +1,367 @@
+//! Issue #2412 (Stage 3, spec `lazy-big-partition-index` Requirement 2) — a BIG
+//! point lookup resolves through ONE `Summary.db`-bounded `Index.db` interval, never
+//! by materializing the whole partition map.
+//!
+//! Public-surface work-probe pins (design §B/§F), driven through
+//! `SSTableReader::get` on real Cassandra fixtures:
+//!
+//! - **Present key**: the point read resolves the partition, records exactly ONE
+//!   bounded interval parse (`cqlite.sstable.index_interval_parses_total`) and ZERO
+//!   full parses (`cqlite.sstable.index_parses_total`).
+//! - **Within-range absent key** (bloom removed so the absence must come from the
+//!   interval, not a bloom short-circuit): the read returns "not found" as an
+//!   authoritative absence from ONE interval WITHOUT a whole-file `scan_for_key`.
+//! - **Interval-boundary key** (a `Summary.db` sample key, which sits exactly at an
+//!   interval boundary): resolves correctly via one interval.
+//!
+//! The byte-identical-golden property (Requirement 2) is covered by the repository's
+//! sstabledump / query-semantics parity oracles, which exercise `get()`/`scan()` on
+//! these same fixtures; these pins add the scale-free WORK bounds those oracles cannot
+//! observe.
+//!
+//! Separate integration-test process: the OTel capture harness installs a
+//! PROCESS-GLOBAL meter provider, so this must not share cqlite-core's parallel
+//! `--lib` unit-test binary (roborev #2163 / #2385 precedent).
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-core --features observability-testing \
+//!   --test issue_2412_point_interval
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::platform::Platform;
+use cqlite_core::storage::sstable::index_reader::IndexReader;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::storage::sstable::summary_reader::SummaryReader;
+use cqlite_core::types::{RowKey, TableId};
+use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
+use cqlite_core::Config;
+use serial_test::serial;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// Locate a `*-Data.db` in `<datasets>/sstables/<keyspace>/<table>-*/` that has a
+/// sibling `*-Index.db` AND `*-Summary.db` (a BIG SSTable with a usable summary).
+fn find_big_data_file_with_summary(keyspace: &str, table: &str) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let entries = std::fs::read_dir(root.join("sstables").join(keyspace)).ok()?;
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        let dir = e.path();
+        let files = std::fs::read_dir(&dir).ok()?;
+        let mut data_file: Option<PathBuf> = None;
+        let mut has_index = false;
+        let mut has_summary = false;
+        for f in files.flatten() {
+            let name = f.file_name().to_string_lossy().into_owned();
+            if name.ends_with("-Data.db") {
+                data_file = Some(f.path());
+            } else if name.ends_with("-Index.db") {
+                has_index = true;
+            } else if name.ends_with("-Summary.db") {
+                has_summary = true;
+            }
+        }
+        if has_index && has_summary {
+            if let Some(df) = data_file {
+                return Some(df);
+            }
+        }
+    }
+    None
+}
+
+/// The sibling component path for a `-Data.db` file (e.g. `-Index.db`, `-Summary.db`).
+fn sibling(data_file: &Path, suffix: &str) -> PathBuf {
+    let name = data_file.file_name().unwrap().to_string_lossy();
+    let base = name.strip_suffix("-Data.db").unwrap();
+    data_file.with_file_name(format!("{base}{suffix}"))
+}
+
+/// Eagerly parse the fixture's sibling `Index.db` to recover its present raw
+/// partition keys — a HELPER reader, distinct from the (lazy) reader under test.
+fn present_raw_keys(
+    data_file: &Path,
+    platform: Arc<Platform>,
+    rt: &tokio::runtime::Runtime,
+) -> Vec<Vec<u8>> {
+    let index_path = sibling(data_file, "-Index.db");
+    let ir = rt
+        .block_on(IndexReader::open(&index_path, platform))
+        .expect("eager Index.db open for present-key harvest");
+    ir.get_partition_entries()
+        .iter()
+        .map(|e| e.key_digest.to_vec())
+        .collect()
+}
+
+/// Present-key point read: exactly one bounded interval parse, zero full parses.
+/// Spec Requirement 2 scenario "A present-key point read touches at most one summary
+/// interval" + Requirement 5 (interval work counted separately from full parses).
+#[test]
+#[serial]
+fn present_key_point_read_touches_one_interval_zero_full_parses() {
+    let mc = testing::metrics_capture();
+
+    let Some(data_file) = find_big_data_file_with_summary("test_basic", "simple_table") else {
+        eprintln!("Skipping (#2412 present-key interval): BIG test_basic/simple_table absent");
+        return;
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let config = Config::default();
+    let platform = Arc::new(
+        rt.block_on(Platform::new(&config))
+            .expect("platform must initialize"),
+    );
+
+    let keys = present_raw_keys(&data_file, platform.clone(), &rt);
+    assert!(
+        !keys.is_empty(),
+        "fixture must expose present Index.db entries (0-rows-when-present is a failure)"
+    );
+    let present = keys[0].clone();
+
+    let reader = rt
+        .block_on(SSTableReader::open(&data_file, &config, platform))
+        .expect("lazy BIG open");
+    let table_id = TableId::from("test_basic.simple_table");
+
+    mc.reset();
+    let got = rt
+        .block_on(reader.get(&table_id, &RowKey::new(present)))
+        .expect("point read must not error");
+    let m = mc.flush_and_collect();
+
+    assert!(
+        got.is_some(),
+        "a known-present partition key must resolve to a row via the interval path"
+    );
+    assert_eq!(
+        m.counter_sum(catalog::INDEX_PARSES_TOTAL),
+        0.0,
+        "a lazy point read must perform ZERO full Index.db parses (design §B/§F)"
+    );
+    assert_eq!(
+        m.counter_sum(catalog::INDEX_INTERVAL_PARSES_TOTAL),
+        1.0,
+        "a present-key point read reads EXACTLY ONE bounded Summary-guided interval"
+    );
+}
+
+/// Interval-boundary key (a `Summary.db` sample, which sits exactly at an interval
+/// boundary) resolves correctly via one interval. Spec Requirement 2 scenario "A key
+/// at an interval boundary resolves correctly".
+#[test]
+#[serial]
+fn interval_boundary_sample_key_resolves_via_one_interval() {
+    let mc = testing::metrics_capture();
+
+    let Some(data_file) = find_big_data_file_with_summary("test_basic", "simple_table") else {
+        eprintln!("Skipping (#2412 boundary key): BIG test_basic/simple_table absent");
+        return;
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let config = Config::default();
+    let platform = Arc::new(
+        rt.block_on(Platform::new(&config))
+            .expect("platform must initialize"),
+    );
+
+    let summary_path = sibling(&data_file, "-Summary.db");
+    let summary = rt
+        .block_on(SummaryReader::open(&summary_path, platform.clone()))
+        .expect("Summary.db open");
+    let samples = summary.get_entries();
+    assert!(
+        !samples.is_empty(),
+        "a usable Summary.db must expose at least one sample"
+    );
+    // Prefer an INTERIOR boundary (a sample after the first) when present; the first
+    // sample sits at position 0 (index start). Either way the key is a boundary key.
+    let boundary_key = samples[samples.len().saturating_sub(1)]
+        .partition_key
+        .to_vec();
+
+    let reader = rt
+        .block_on(SSTableReader::open(&data_file, &config, platform))
+        .expect("lazy BIG open");
+    let table_id = TableId::from("test_basic.simple_table");
+
+    mc.reset();
+    let got = rt
+        .block_on(reader.get(&table_id, &RowKey::new(boundary_key)))
+        .expect("boundary point read must not error");
+    let m = mc.flush_and_collect();
+
+    assert!(
+        got.is_some(),
+        "a Summary.db sample key (interval boundary) must resolve to its present partition"
+    );
+    assert_eq!(
+        m.counter_sum(catalog::INDEX_PARSES_TOTAL),
+        0.0,
+        "a boundary point read must perform ZERO full Index.db parses"
+    );
+    assert_eq!(
+        m.counter_sum(catalog::INDEX_INTERVAL_PARSES_TOTAL),
+        1.0,
+        "a boundary key resolves through EXACTLY ONE bounded interval"
+    );
+}
+
+/// Copy every component of `data_file`'s SSTable into a fresh temp dir EXCEPT the
+/// `-Filter.db` bloom filter, returning the copied `-Data.db` path. Without a bloom
+/// filter the point read cannot short-circuit an absent key at the presence oracle,
+/// so a within-range absent key must reach — and be answered by — the Summary-guided
+/// interval path.
+fn copy_fixture_without_filter(data_file: &Path) -> (PathBuf, PathBuf) {
+    let src_dir = data_file.parent().expect("fixture parent");
+    let tmp = std::env::temp_dir().join(format!(
+        "cqlite-2412-nofilter-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&tmp).expect("mkdir temp fixture copy");
+    let mut copied_data: Option<PathBuf> = None;
+    for entry in std::fs::read_dir(src_dir)
+        .expect("read fixture dir")
+        .flatten()
+    {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.ends_with("-Filter.db") {
+            continue; // deliberately omitted: disables the bloom pre-check
+        }
+        let dest = tmp.join(&name);
+        std::fs::copy(entry.path(), &dest).expect("copy fixture component");
+        if name.ends_with("-Data.db") {
+            copied_data = Some(dest);
+        }
+    }
+    (tmp, copied_data.expect("fixture must include a Data.db"))
+}
+
+/// Within-range absent key: authoritative absence from ONE interval, NO whole-file
+/// `scan_for_key`. Spec Requirement 2 scenario "An absent-key point read within range
+/// is authoritative from one interval".
+#[test]
+#[serial]
+fn within_range_absent_key_is_authoritative_without_scan_for_key() {
+    let mc = testing::metrics_capture();
+
+    let Some(data_file) = find_big_data_file_with_summary("test_basic", "simple_table") else {
+        eprintln!("Skipping (#2412 absent-in-interval): BIG test_basic/simple_table absent");
+        return;
+    };
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let config = Config::default();
+    let platform = Arc::new(
+        rt.block_on(Platform::new(&config))
+            .expect("platform must initialize"),
+    );
+
+    // Present set (for absence) + the token bound for a NON-LAST (end-bounded)
+    // interval: the constructed key's token must sort strictly between the FIRST and
+    // the LAST `Summary.db` SAMPLE, so it (a) passes the C5 range check (in
+    // `[first_key, last_key]`) and (b) floors to an interval delimited above by a
+    // next sample — the authoritative-absence path (`covering_interval_is_end_bounded`).
+    // The last (read-to-EOF) interval is intentionally avoided; a miss there keeps the
+    // #1572 scan fallback and would not exercise the no-scan property.
+    let present: std::collections::HashSet<Vec<u8>> =
+        present_raw_keys(&data_file, platform.clone(), &rt)
+            .into_iter()
+            .collect();
+    let summary_path = sibling(&data_file, "-Summary.db");
+    let summary = rt
+        .block_on(SummaryReader::open(&summary_path, platform.clone()))
+        .expect("Summary.db open");
+    let samples = summary.get_entries();
+    if samples.len() < 2 {
+        eprintln!(
+            "Skipping (#2412 absent-in-interval): fixture has < 2 summary samples, no \
+             end-bounded interval to exercise"
+        );
+        return;
+    }
+    let first_sample_token = cassandra_murmur3_token(&samples[0].partition_key);
+    let last_sample_token = cassandra_murmur3_token(&samples[samples.len() - 1].partition_key);
+    let (lo, hi) = (
+        first_sample_token.min(last_sample_token),
+        first_sample_token.max(last_sample_token),
+    );
+
+    // Deterministic search for a 16-byte key whose Murmur3 token sorts strictly
+    // inside (lo, hi) and is absent. UUID keys spread tokens across the ring, so an
+    // in-range absent candidate is found within a few probes.
+    let mut absent: Option<Vec<u8>> = None;
+    for i in 0u64..200_000 {
+        let a = i.to_be_bytes();
+        let b = i.wrapping_mul(0x9E37_79B9_7F4A_7C15).to_be_bytes();
+        let cand = [a, b].concat();
+        let t = cassandra_murmur3_token(&cand);
+        if t > lo && t < hi && !present.contains(&cand) {
+            absent = Some(cand);
+            break;
+        }
+    }
+    let Some(absent) = absent else {
+        eprintln!("Skipping (#2412 absent-in-interval): no in-range absent key constructed");
+        return;
+    };
+
+    let (tmp, copied_data) = copy_fixture_without_filter(&data_file);
+    let reader = rt
+        .block_on(SSTableReader::open(&copied_data, &config, platform))
+        .expect("lazy BIG open without Filter.db");
+    let table_id = TableId::from("test_basic.simple_table");
+
+    let scan_before = SSTableReader::scan_for_key_call_count();
+    mc.reset();
+    let got = rt
+        .block_on(reader.get(&table_id, &RowKey::new(absent)))
+        .expect("absent point read must not error");
+    let m = mc.flush_and_collect();
+    let scan_after = SSTableReader::scan_for_key_call_count();
+
+    assert!(
+        got.is_none(),
+        "an in-range absent key must resolve to 'not found'"
+    );
+    assert_eq!(
+        scan_after, scan_before,
+        "an in-range absent key answered from the bounded interval must NOT fall back to a \
+         whole-file scan_for_key (design §B)"
+    );
+    assert_eq!(
+        m.counter_sum(catalog::INDEX_INTERVAL_PARSES_TOTAL),
+        1.0,
+        "the absence must be resolved by reading EXACTLY ONE bounded interval (not a bloom \
+         short-circuit — Filter.db was removed)"
+    );
+    assert_eq!(
+        m.counter_sum(catalog::INDEX_PARSES_TOTAL),
+        0.0,
+        "the absent read must perform ZERO full Index.db parses"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/cqlite-core/tests/issue_2412_wraparound_scan.rs
+++ b/cqlite-core/tests/issue_2412_wraparound_scan.rs
@@ -1,0 +1,271 @@
+//! Issue #2412 — roborev endgame finding (High, silent data loss): a WRAPAROUND
+//! token-range warm scan must enumerate BOTH ring segments, not just the one the
+//! forward-only `Index.db` walk happens to start in.
+//!
+//! `summary_scan.rs`'s `walk_in_range_partition_slices` streams `Index.db`
+//! FORWARD from a single start offset to EOF — the file is not circular. Before
+//! this fix, a wraparound range `(start_excl, MAX] ∪ [MIN, end_incl]`
+//! (`start_excl > end_incl`) began the walk at
+//! `scan_start_position_for_token(start_excl)` — the HIGH-token segment's start
+//! — which can only ever reach entries AT OR AFTER that file position. The
+//! LOW-token segment (`token <= end_incl`) physically precedes it in the
+//! token-ordered `Index.db` and was silently skipped in full: every in-range
+//! partition in that segment vanished from the result with no error, no WARN,
+//! nothing (issue #28: authoritative structure was available — the summary
+//! samples make the LOW segment's positions perfectly locatable — this was a
+//! pure walk-direction bug, not a missing-data one).
+//!
+//! Fix: a wraparound range starts the walk at offset 0 (the true beginning of
+//! `Index.db`) so both segments are reachable; the per-entry
+//! `ScanTokenBound::contains` filter already selects exactly the two segments,
+//! and `can_stop_past` already refuses to early-stop for `wraparound` (verified
+//! here to still hold, not merely assumed).
+//!
+//! This test builds ONE BIG generation with `N` partitions (comfortably over
+//! `min_index_interval` so `Summary.db` carries multiple samples — otherwise a
+//! single-sample summary makes `scan_start_position_for_token` return offset 0
+//! for ANY token, masking the bug), picks a wraparound range whose two segments
+//! BOTH hold real in-range partitions (verified from the ACTUAL computed token
+//! order, never assumed), and asserts every partition in EITHER segment is
+//! emitted through the public `stream_all_partitions_for_query` surface — the
+//! same call chain the flight warm query path drives.
+
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::scan_cancel::ScanCancel;
+use cqlite_core::storage::sstable::reader::{SSTableReader, ScanTokenBound};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
+use cqlite_core::Config;
+
+const KS: &str = "wraparound_ks";
+const TBL: &str = "items";
+/// Comfortably over the default `min_index_interval` (128) so `Summary.db`
+/// carries multiple samples spanning distinct `Index.db` positions — a
+/// single-sample summary would mask the bug (its one covering position is
+/// always offset 0, so even the OLD forward-only walk would "accidentally"
+/// start at the beginning).
+const N: usize = 400;
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn key_bytes(id: i32) -> Vec<u8> {
+    // Single-component int partition key: raw 4-byte big-endian value (the
+    // on-disk raw-key encoding CQLite's writer uses for a single `int` PK).
+    id.to_be_bytes().to_vec()
+}
+
+fn mutation(id: i32) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(format!("v{id}")),
+        }],
+        1_000_000 + id as i64,
+        None,
+    )
+}
+
+/// Build ONE BIG generation with `N` single-int-PK partitions, all in one
+/// generation (large flush threshold — mirrors the established convention in
+/// `cqlite-flight::warm::registry::spin_tests_2383::build_big_single_gen`).
+fn build_single_gen() -> (tempfile::TempDir, PathBuf) {
+    let sch = schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, sch)
+        .with_flush_threshold(1usize << 30)
+        .with_durability(cqlite_core::storage::write_engine::Durability::Disabled);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for id in 0..N as i32 {
+        engine.write(mutation(id)).expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+
+    let table_dir = data_dir.join(KS).join(TBL);
+    let data_files: Vec<_> = std::fs::read_dir(&table_dir)
+        .expect("table dir")
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .collect();
+    assert_eq!(
+        data_files.len(),
+        1,
+        "fixture must hold exactly ONE generation"
+    );
+    (temp, data_files[0].path())
+}
+
+async fn open_reader(data_path: &std::path::Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.unwrap());
+    SSTableReader::open(data_path, &config, platform)
+        .await
+        .unwrap()
+}
+
+/// Drive `stream_all_partitions_for_query` and collect every emitted partition
+/// key's decoded `id` (int PK) — the public surface the flight warm query path
+/// (`from_readers::drive_query_stream`) calls.
+async fn emitted_ids(reader: &SSTableReader, token_bound: Option<ScanTokenBound>) -> Vec<i32> {
+    let sch = schema();
+    let cancel = ScanCancel::default();
+    let mut ids = Vec::new();
+    reader
+        .stream_all_partitions_for_query(Some(&sch), &cancel, token_bound, |row| {
+            let key_bytes: &[u8] = &row.key.0;
+            let id = i32::from_be_bytes(key_bytes.try_into().expect("4-byte int PK"));
+            ids.push(id);
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+        .expect("stream_all_partitions_for_query");
+    ids.sort_unstable();
+    ids
+}
+
+/// THE blocker pin (roborev endgame, High): a wraparound range whose two
+/// segments BOTH hold real partitions must emit every partition in EITHER
+/// segment — not just the one the forward walk happens to start in.
+#[test]
+fn wraparound_range_emits_partitions_from_both_segments() {
+    // Compute every partition's ACTUAL token (never assumed) and sort ascending
+    // — this is the token order Index.db/Summary.db are physically written in.
+    let mut by_token: Vec<(i32, i64)> = (0..N as i32)
+        .map(|id| (id, cassandra_murmur3_token(&key_bytes(id))))
+        .collect();
+    by_token.sort_by_key(|(_, tok)| *tok);
+
+    // HIGH segment: ranks 251..N (49 partitions) — start_excl = rank 250's token.
+    // LOW segment: ranks 0..=10 (11 partitions) — end_incl = rank 10's token.
+    let start_excl = by_token[250].1;
+    let end_incl = by_token[10].1;
+    assert!(
+        start_excl > end_incl,
+        "fixture must produce a genuine wraparound pair (start > end); got \
+         start_excl={start_excl} end_incl={end_incl}"
+    );
+
+    let expected_low: Vec<i32> = by_token[0..=10].iter().map(|(id, _)| *id).collect();
+    let expected_high: Vec<i32> = by_token[251..N].iter().map(|(id, _)| *id).collect();
+    let mut expected: Vec<i32> = expected_low
+        .iter()
+        .chain(expected_high.iter())
+        .copied()
+        .collect();
+    expected.sort_unstable();
+    // Non-vacuity: BOTH segments must genuinely hold partitions, or this test
+    // cannot discriminate "walk started in the wrong segment" from "no bug to find".
+    assert!(!expected_low.is_empty() && !expected_high.is_empty());
+
+    let (_temp, data_path) = build_single_gen();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let reader = rt.block_on(open_reader(&data_path));
+
+    let bound = ScanTokenBound {
+        start_excl,
+        end_incl,
+        wraparound: true,
+    };
+    let got = rt.block_on(emitted_ids(&reader, Some(bound)));
+
+    assert_eq!(
+        got,
+        expected,
+        "a wraparound range must emit every partition in BOTH segments (low: \
+         {} partitions, high: {} partitions) — got {} partitions total. A \
+         forward-only walk starting in the high segment silently drops the low \
+         segment (roborev endgame finding, High, data loss)",
+        expected_low.len(),
+        expected_high.len(),
+        got.len()
+    );
+}
+
+/// Control: a NORMAL (non-wraparound) range is unaffected by this fix — it must
+/// still emit exactly its one contiguous segment, matching the pre-fix behavior.
+#[test]
+fn non_wraparound_range_is_unaffected() {
+    let mut by_token: Vec<(i32, i64)> = (0..N as i32)
+        .map(|id| (id, cassandra_murmur3_token(&key_bytes(id))))
+        .collect();
+    by_token.sort_by_key(|(_, tok)| *tok);
+
+    // A contiguous mid-ring segment: ranks 100..=150.
+    let start_excl = by_token[99].1;
+    let end_incl = by_token[150].1;
+    assert!(
+        start_excl < end_incl,
+        "non-wraparound pair must have start < end"
+    );
+
+    let mut expected: Vec<i32> = by_token[100..=150].iter().map(|(id, _)| *id).collect();
+    expected.sort_unstable();
+    assert!(!expected.is_empty());
+
+    let (_temp, data_path) = build_single_gen();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let reader = rt.block_on(open_reader(&data_path));
+
+    let bound = ScanTokenBound {
+        start_excl,
+        end_incl,
+        wraparound: false,
+    };
+    let got = rt.block_on(emitted_ids(&reader, Some(bound)));
+
+    assert_eq!(
+        got, expected,
+        "a non-wraparound range must emit exactly its one contiguous segment, \
+         unaffected by the wraparound fix"
+    );
+}

--- a/cqlite-flight/src/filter.rs
+++ b/cqlite-flight/src/filter.rs
@@ -65,6 +65,20 @@ impl TokenFilter {
         token_in_half_open_range(token, self.start, self.end, self.wraparound)
     }
 
+    /// Lower this split into the core-side [`ScanTokenBound`](cqlite_core::storage::sstable::reader::ScanTokenBound)
+    /// that the Summary-guided streaming walk pushes into the per-SSTable scan
+    /// (issue #2412 §C / #2413 Option A). The core bound mirrors this filter's
+    /// half-open `(start, end]` membership EXACTLY (including the `start == end`
+    /// FULL-ring convention, #2228); `token_filter_lowering_agrees_with_core` pins
+    /// that agreement so the two never diverge.
+    pub fn to_scan_bound(self) -> cqlite_core::storage::sstable::reader::ScanTokenBound {
+        cqlite_core::storage::sstable::reader::ScanTokenBound {
+            start_excl: self.start,
+            end_incl: self.end,
+            wraparound: self.wraparound,
+        }
+    }
+
     /// True if an SSTable spanning `[min_token, max_token]` (inclusive of both
     /// endpoints, since they are the smallest and largest partition tokens
     /// actually present) could contain any token in this split's `(start, end]`
@@ -586,6 +600,58 @@ mod tests {
         assert!(tf.contains(0));
         assert!(tf.contains(10), "end inclusive");
         assert!(!tf.contains(11));
+    }
+
+    /// Issue #2412 §C / #2413: the core-side `ScanTokenBound` the Summary-guided
+    /// walk uses for token pushdown must agree with this crate's `TokenFilter` on
+    /// EVERY token — the membership rule must live in one place, never diverge.
+    /// Grid across normal, wraparound, and equal-endpoint (full-ring) shapes.
+    #[test]
+    fn token_filter_lowering_agrees_with_core() {
+        let shapes = [
+            (0i64, 100i64, false),
+            (100, -100, true),
+            (42, 42, false),
+            (42, 42, true),
+            (i64::MIN, i64::MAX, false),
+            (-5, 5, false),
+        ];
+        let probes = [
+            i64::MIN,
+            -1000,
+            -101,
+            -100,
+            -99,
+            -5,
+            -1,
+            0,
+            1,
+            5,
+            41,
+            42,
+            43,
+            99,
+            100,
+            101,
+            1000,
+            i64::MAX,
+        ];
+        for (start, end, wraparound) in shapes {
+            let tf = TokenFilter {
+                start,
+                end,
+                wraparound,
+            };
+            let bound = tf.to_scan_bound();
+            for t in probes {
+                assert_eq!(
+                    tf.contains(t),
+                    bound.contains(t),
+                    "TokenFilter and ScanTokenBound must agree for token {t} on \
+                     ({start}, {end}] wrap={wraparound}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/cqlite-flight/src/producer_warm.rs
+++ b/cqlite-flight/src/producer_warm.rs
@@ -98,8 +98,14 @@ impl MergeProducer {
             };
         }
 
-        let mut merger = KWayMerger::new_from_readers(readers, &self.schema, cancel.scan_cancel())
-            .map_err(ProducerError::Merge)?;
+        // Issue #2412 §C / #2413 Option A: push the split's token range INTO the
+        // per-SSTable Summary-guided walk so out-of-range partition bodies are
+        // never read (the token filter still runs downstream at `drive_merge` as a
+        // backstop). A full scan (no token filter) passes `None` → full-ring walk.
+        let token_bound = self.spec.token.as_ref().map(|t| t.to_scan_bound());
+        let mut merger =
+            KWayMerger::new_from_readers(readers, &self.schema, cancel.scan_cancel(), token_bound)
+                .map_err(ProducerError::Merge)?;
         on_merger_built();
         // Issue #2423: the warm full-scan branch streams row-granularly too, matching
         // the cold full-scan path (#2230) — bounded memory + mid-partition cancel.

--- a/cqlite-flight/src/warm/budget.rs
+++ b/cqlite-flight/src/warm/budget.rs
@@ -38,26 +38,38 @@ const PER_GENERATION_OVERHEAD_BYTES: u64 = 64 * 1024;
 /// sidecars (Index/Summary/Statistics/Filter/Partitions/Rows/CRC/
 /// CompressionInfo/...), this sums the on-disk size of EVERY file in the
 /// generation's directory that shares its filename PREFIX — i.e. every
-/// sibling component — with exactly ONE exclusion: `Data.db` itself.
+/// sibling component — with exactly ONE unconditional exclusion: `Data.db`
+/// itself, plus ONE conditional exclusion (issue #2412 §D): `Index.db` when
+/// `index_resident` is `false`.
 ///
-/// Why exclude only `Data.db`: it is the one component the reader does NOT
-/// keep fully parsed/resident — it is PAGED (mmap'd or positionally read), so
-/// its size does not reflect memory pressure the way a fully-loaded sidecar's
-/// does. Every OTHER component that exists for a generation — whichever
-/// format, whichever compression setting — genuinely gets `stat`ed and (for
-/// the ones the reader actually loads: Index/Summary/Statistics/bloom for
-/// BIG; Partitions/Rows tries for BTI, issue #831/#909) parsed/held resident,
-/// or is at minimum a small, format-agnostic sidecar (CRC.db, which can
-/// DOMINATE on an uncompressed BIG table; CompressionInfo.db; Digest;
-/// TOC.txt) whose bytes are cheap to include and NEVER wrong to over-count
-/// slightly (the byte budget is meant to be a defensible upper bound, not a
-/// razor-thin one). This is honest for BIG, BTI, compressed, and
-/// uncompressed generations alike, and needs no future round when a new
-/// component is added — it is accounted automatically by construction.
+/// Why exclude only `Data.db` unconditionally: it is the one component the
+/// reader does NOT keep fully parsed/resident — it is PAGED (mmap'd or
+/// positionally read), so its size does not reflect memory pressure the way a
+/// fully-loaded sidecar's does. Every OTHER component that exists for a
+/// generation — whichever format, whichever compression setting — genuinely
+/// gets `stat`ed and (for the ones the reader actually loads: Index/Summary/
+/// Statistics/bloom for BIG; Partitions/Rows tries for BTI, issue #831/#909)
+/// parsed/held resident, or is at minimum a small, format-agnostic sidecar
+/// (CRC.db, which can DOMINATE on an uncompressed BIG table;
+/// CompressionInfo.db; Digest; TOC.txt) whose bytes are cheap to include and
+/// NEVER wrong to over-count slightly (the byte budget is meant to be a
+/// defensible upper bound, not a razor-thin one).
+///
+/// `index_resident` (issue #2412 §D, spec Requirement 4): whether the
+/// generation's `Index.db` partition map is CURRENTLY fully resident —
+/// [`SSTableReader::index_is_materialized`](crate)'s value at the moment the
+/// generation was opened. A BIG reader opened lazily over a usable
+/// `Summary.db` (design §A) never materializes the full map on the common
+/// point/scan query paths, so its `Index.db`'s on-disk bytes are NOT resident
+/// memory — counting them would defeat the summary-only accounting spec
+/// Requirement 4 requires and re-introduce an O(partitions) footprint the
+/// lazy-open change was meant to eliminate. `Summary.db` (and every other
+/// sidecar) is unaffected: those are always eagerly parsed regardless of
+/// `Index.db`'s laziness, so their bytes are counted unconditionally as before.
 ///
 /// Computed by `read_dir` + `stat` only (no extra parse) at open time. A
 /// fixed overhead covers the parsed-schema handle and registry bookkeeping.
-pub fn account_footprint(data_path: &Path) -> u64 {
+pub fn account_footprint(data_path: &Path, index_resident: bool) -> u64 {
     let name = match data_path.file_name().and_then(|n| n.to_str()) {
         Some(n) if n.ends_with("-Data.db") => n,
         // A path that is not a `-Data.db` (should not happen) accounts as the
@@ -72,6 +84,7 @@ pub fn account_footprint(data_path: &Path) -> u64 {
         return PER_GENERATION_OVERHEAD_BYTES;
     };
     let prefix = format!("{base}-");
+    let index_name = format!("{base}-Index.db");
     let mut total = PER_GENERATION_OVERHEAD_BYTES;
     for entry in read.flatten() {
         let entry_name = entry.file_name();
@@ -79,7 +92,7 @@ pub fn account_footprint(data_path: &Path) -> u64 {
             continue;
         };
         if entry_name == name {
-            // The single documented exclusion: Data.db is paged, not
+            // The unconditional exclusion: Data.db is paged, not
             // parsed-resident.
             continue;
         }
@@ -88,6 +101,11 @@ pub fn account_footprint(data_path: &Path) -> u64 {
             // generation's files never share this exact byte prefix — the
             // generation-number/format-tag segments always differ before the
             // trailing hyphen).
+            continue;
+        }
+        if !index_resident && entry_name == index_name {
+            // The conditional exclusion (issue #2412 §D): a lazily-opened,
+            // not-yet-materialized Index.db is not resident memory.
             continue;
         }
         if let Ok(md) = std::fs::metadata(entry.path()) {
@@ -117,7 +135,7 @@ mod tests {
         std::fs::write(dir.path().join("nb-1-big-Index.db"), vec![0u8; 100]).unwrap();
         std::fs::write(dir.path().join("nb-1-big-Summary.db"), vec![0u8; 50]).unwrap();
         // Statistics.db / Filter.db absent → contribute 0.
-        let footprint = account_footprint(&data);
+        let footprint = account_footprint(&data, true);
         assert_eq!(footprint, PER_GENERATION_OVERHEAD_BYTES + 150);
     }
 
@@ -136,7 +154,7 @@ mod tests {
         std::fs::write(dir.path().join("da-1-bti-Rows.db"), vec![0u8; 75]).unwrap();
         // Statistics.db / Filter.db absent → contribute 0. No Index.db/Summary.db
         // for BTI (by design, so they must NOT spuriously contribute either).
-        let footprint = account_footprint(&data);
+        let footprint = account_footprint(&data, true);
         assert_eq!(
             footprint,
             PER_GENERATION_OVERHEAD_BYTES + 275,
@@ -162,7 +180,7 @@ mod tests {
             vec![0u8; 40],
         )
         .unwrap();
-        let footprint = account_footprint(&data);
+        let footprint = account_footprint(&data, true);
         assert_eq!(
             footprint,
             PER_GENERATION_OVERHEAD_BYTES + 340,
@@ -179,7 +197,7 @@ mod tests {
         let data = dir.path().join("nb-1-big-Data.db");
         std::fs::write(&data, vec![0u8; 10_000]).unwrap(); // large Data.db
         std::fs::write(dir.path().join("nb-1-big-TOC.txt"), vec![0u8; 10]).unwrap();
-        let footprint = account_footprint(&data);
+        let footprint = account_footprint(&data, true);
         assert_eq!(
             footprint,
             PER_GENERATION_OVERHEAD_BYTES + 10,
@@ -199,7 +217,7 @@ mod tests {
         // A DIFFERENT generation (12) whose components must not leak in.
         std::fs::write(dir.path().join("nb-12-big-Data.db"), b"data").unwrap();
         std::fs::write(dir.path().join("nb-12-big-Index.db"), vec![0u8; 9_999]).unwrap();
-        let footprint = account_footprint(&data);
+        let footprint = account_footprint(&data, true);
         assert_eq!(
             footprint,
             PER_GENERATION_OVERHEAD_BYTES + 50,
@@ -210,8 +228,48 @@ mod tests {
     #[test]
     fn non_data_path_accounts_overhead_only() {
         assert_eq!(
-            account_footprint(Path::new("/tmp/not-an-sstable.txt")),
+            account_footprint(Path::new("/tmp/not-an-sstable.txt"), true),
             PER_GENERATION_OVERHEAD_BYTES
+        );
+    }
+
+    /// Issue #2412 §D (Stage 5): a LAZILY-opened reader (`index_resident = false`
+    /// — the common Summary-usable BIG shape, design §A) must NOT count its
+    /// `Index.db` sibling's on-disk bytes — that component is not actually
+    /// resident, so counting it would over-represent the generation's real
+    /// memory footprint and defeat the summary-only accounting spec Requirement 4
+    /// requires. Every OTHER sibling (Summary.db here) is unaffected: it is
+    /// always eagerly parsed regardless of Index.db's laziness.
+    #[test]
+    fn lazy_index_is_excluded_from_the_footprint() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let data = dir.path().join("nb-1-big-Data.db");
+        std::fs::write(&data, b"data").unwrap();
+        // A LARGE Index.db (as a huge-partition-count generation would produce)
+        // — its bytes must NOT appear in the footprint when not resident.
+        std::fs::write(dir.path().join("nb-1-big-Index.db"), vec![0u8; 1_000_000]).unwrap();
+        std::fs::write(dir.path().join("nb-1-big-Summary.db"), vec![0u8; 50]).unwrap();
+
+        let lazy_footprint = account_footprint(&data, false);
+        assert_eq!(
+            lazy_footprint,
+            PER_GENERATION_OVERHEAD_BYTES + 50,
+            "a lazy (not-yet-materialized) Index.db must contribute ZERO bytes; \
+             only the eagerly-parsed Summary.db sibling counts"
+        );
+
+        // Control: the SAME on-disk shape with `index_resident = true` (the
+        // eager/FellBack or later-materialized case) DOES count Index.db —
+        // proving the exclusion is conditional on residency, not a blanket skip.
+        let resident_footprint = account_footprint(&data, true);
+        assert_eq!(
+            resident_footprint,
+            PER_GENERATION_OVERHEAD_BYTES + 1_000_000 + 50,
+            "a resident (materialized) Index.db's bytes must still be counted"
+        );
+        assert!(
+            resident_footprint > lazy_footprint,
+            "the lazy footprint must be materially smaller than the resident one"
         );
     }
 }

--- a/cqlite-flight/src/warm/rebuild.rs
+++ b/cqlite-flight/src/warm/rebuild.rs
@@ -360,7 +360,12 @@ impl WarmTableRegistry {
             if real {
                 real_opens += 1;
             }
-            let footprint = account_footprint(&entry.path);
+            // Issue #2412 §D: account the footprint from the JUST-OPENED
+            // reader's ACTUAL Index.db residency (lazy-open leaves it `false`
+            // for the common Summary-usable BIG shape), not a blanket
+            // "always resident" assumption — the summary-only accounting spec
+            // Requirement 4 requires.
+            let footprint = account_footprint(&entry.path, reader.index_is_materialized());
             opened.push(WarmReader {
                 id: entry.id,
                 reader,

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -737,6 +737,12 @@ mod registry_tests;
 #[path = "spin_tests_2383.rs"]
 mod spin_tests_2383;
 
+// Issue #2412 §D (Stage 5) — the warm registry pins summary-only index memory,
+// in a separate file (campsite rule) loaded here.
+#[cfg(test)]
+#[path = "summary_only_memory_tests.rs"]
+mod summary_only_memory_tests;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -79,6 +79,20 @@ fn decode_names(schema: &TableSchema, readers: Vec<Arc<SSTableReader>>) -> Vec<S
 /// loop). A large flush threshold keeps all `n` rows in ONE generation — the sync
 /// `write()` path auto-flushes over the default threshold when no runtime is
 /// active, which would otherwise split them across many SSTables.
+///
+/// Strips the sibling `-Summary.db` before returning (issue #2412 re-anchor,
+/// coordinator-flagged regression): `SSTableReader::open` now defers the whole
+/// `Index.db` parse when a usable `Summary.db` is present (`open_lazy`, design
+/// §A) — for that shape `warm_readers`' OPEN call no longer performs the O(N)
+/// synchronous parse this repro targets AT ALL, so a cancel arriving during open
+/// has nothing left to interrupt (the property genuinely improved, not broke).
+/// The counted, cancel-aware FellBack path (`open_with_summary_cancellable`,
+/// §A1) is UNCHANGED and is exactly what fires when `Summary.db` is absent — so
+/// stripping it restores this repro's original at-open eager-parse scenario
+/// exactly, on the surviving code path. See also
+/// `ensure_materialized_cancel_mid_parse_aborts_promptly`
+/// (`index_reader/lazy.rs`) for the OTHER surviving big-parse site (the deferred
+/// materialize a Summary-usable reader's full/compaction scan still triggers).
 fn build_big_single_gen(schema: &TableSchema, n: i32) -> (tempfile::TempDir, PathBuf) {
     let temp = tempfile::TempDir::new().unwrap();
     let data_dir = temp.path().join("data");
@@ -98,7 +112,7 @@ fn build_big_single_gen(schema: &TableSchema, n: i32) -> (tempfile::TempDir, Pat
     let table_dir = data_dir.join(&schema.keyspace).join(&schema.table);
     // Prove it really is a SINGLE generation (one -Data.db) so the cancel repro
     // trips DURING one parse, not at a coarse between-generation boundary.
-    let data_files = std::fs::read_dir(&table_dir)
+    let data_files: Vec<_> = std::fs::read_dir(&table_dir)
         .expect("table dir")
         .flatten()
         .filter(|e| {
@@ -106,11 +120,28 @@ fn build_big_single_gen(schema: &TableSchema, n: i32) -> (tempfile::TempDir, Pat
                 .to_str()
                 .is_some_and(|f| f.ends_with("-Data.db"))
         })
-        .count();
+        .collect();
     assert_eq!(
-        data_files, 1,
-        "the cancel repro needs exactly ONE big generation (found {data_files})"
+        data_files.len(),
+        1,
+        "the cancel repro needs exactly ONE big generation (found {})",
+        data_files.len()
     );
+    // Force the FellBack eager-parse-at-open path (issue #2412 §A1): delete the
+    // sibling Summary.db so `summary_usable == false` and `load_index_reader`
+    // takes `open_with_summary_cancellable` (still eager, still cancel-aware
+    // every `CANCEL_POLL_INTERVAL` entries) instead of `open_lazy`.
+    let data_name = data_files[0].file_name();
+    let data_name = data_name.to_str().expect("utf8 filename");
+    let base = data_name
+        .strip_suffix("-Data.db")
+        .expect("writer-produced Data.db filename");
+    let summary_path = table_dir.join(format!("{base}-Summary.db"));
+    assert!(
+        summary_path.exists(),
+        "fixture precondition: the writer must emit a Summary.db to strip"
+    );
+    std::fs::remove_file(&summary_path).expect("strip Summary.db to force the FellBack path");
     (temp, table_dir)
 }
 
@@ -268,10 +299,25 @@ fn concurrent_misses_single_flight_one_parse_per_generation() {
 /// short of the real run's parse, including under page-cache speedup from the
 /// calibration pass warming the OS cache for the timed run.
 ///
-/// RED on current main: neither `parse_all_partition_keys_with_summary` nor
-/// `SSTableReader::open` polls the cancel flag, so once past the coarse
-/// between-open check the parse runs to completion and `warm_readers` returns
+/// RED pre-#2383-fix-C: neither `parse_all_partition_keys_with_summary` nor
+/// `SSTableReader::open` polled the cancel flag, so once past the coarse
+/// between-open check the parse ran to completion and `warm_readers` returned
 /// `Ok`. The field showed workers spinning in this exact loop AFTER a client kill.
+///
+/// Re-anchored (issue #2412, coordinator-flagged regression): this test drove
+/// the OPEN call's eager Index.db parse directly. Since #2412 Stage 2, BIG open
+/// defers that parse (`open_lazy`) whenever a usable `Summary.db` is present —
+/// the common/field shape — so `warm_readers`' open no longer performs the O(N)
+/// synchronous work this repro cancels mid-flight (open is now O(summary), by
+/// design). `build_big_single_gen` now strips the sibling `-Summary.db`, forcing
+/// the STILL-eager, STILL-cancel-aware FellBack path
+/// (`open_with_summary_cancellable`, §A1) — the surviving at-open big-parse site
+/// — so this exact scenario (cancel lands DURING open's Index.db parse, aborts
+/// promptly) is re-verified on the code that still runs it. The lazy
+/// `ensure_materialized` deferred-parse site (the one a Summary-usable reader's
+/// full/compaction scan still triggers) is covered by a companion test,
+/// `ensure_materialized_cancel_mid_parse_aborts_promptly`
+/// (`cqlite-core/src/storage/sstable/index_reader/lazy.rs`).
 #[test]
 fn cancel_during_large_index_parse_aborts_promptly() {
     let schema = simple_schema();

--- a/cqlite-flight/src/warm/summary_only_memory_tests.rs
+++ b/cqlite-flight/src/warm/summary_only_memory_tests.rs
@@ -1,0 +1,182 @@
+//! Issue #2412 §D / spec Requirement 4 (Stage 5) — the `WarmTableRegistry` pins
+//! SUMMARY-ONLY index memory for a generation held warm, not a full resident
+//! partition map.
+//!
+//! Scale-free wiring-evidence pin (mirroring the #2385/#2412 pin-test style):
+//! two single-generation BIG SSTables differing ONLY in partition count (small
+//! vs large) are warmed through the SAME public `warm_readers` surface a Flight
+//! `do_get` drives. If the registry's accounted footprint (`account_footprint`,
+//! `budget.rs`) still counted the full on-disk `Index.db` (the pre-#2412
+//! behavior — every partition materialized at open), the large generation's
+//! footprint would scale roughly LINEARLY with partition count (a proportionally
+//! bigger `Index.db`). After Stage 5 it does not: the large generation's `Index.db`
+//! is never materialized on this path (Summary-guided lazy open + streaming
+//! query paths, Stages 2-4), so only its `Summary.db` (O(n/128) samples) and
+//! fixed overhead are counted — materially smaller than the full index, and NOT
+//! scaling with `N` the way the on-disk `Index.db` size would.
+//!
+//! Loaded via `#[path]` from `registry.rs` (campsite rule), like the sibling
+//! `registry_tests`/`spin_tests_2383` modules.
+
+use std::path::PathBuf;
+
+use cqlite_core::schema::TableSchema;
+use cqlite_core::storage::write_engine::{Durability, WriteEngine, WriteEngineConfig};
+
+use crate::cancel::CancelFlag;
+use crate::testutil::{simple_schema, write_row, KS, TBL};
+use crate::warm::{TableKey, WarmTableRegistry};
+
+fn key() -> TableKey {
+    TableKey::new(KS, TBL)
+}
+
+fn ddl() -> u64 {
+    crate::warm::ddl_hash(crate::testutil::SIMPLE_DDL)
+}
+
+/// Build ONE SSTable generation with `n` distinct int-PK partitions, all in one
+/// generation (large flush threshold, durability disabled — bulk-load shape,
+/// mirrors `spin_tests_2383::build_big_single_gen`).
+fn build_single_gen(schema: &TableSchema, n: i32) -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone())
+        .with_flush_threshold(1usize << 30)
+        .with_durability(Durability::Disabled);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for id in 0..n {
+        engine.write(write_row(id, "n", id, 100)).expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    let table_dir = data_dir.join(&schema.keyspace).join(&schema.table);
+    (temp, table_dir)
+}
+
+/// Find the sibling `-Index.db` / `-Summary.db` file sizes for the `-Data.db`
+/// at `data_path`'s directory (authoritative on-disk sizes, no guessing).
+fn sibling_component_sizes(data_path: &std::path::Path) -> (u64, u64) {
+    let name = data_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("Data.db filename");
+    let base = name.strip_suffix("-Data.db").expect("Data.db suffix");
+    let parent = data_path.parent().expect("parent dir");
+    let index_size = std::fs::metadata(parent.join(format!("{base}-Index.db")))
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let summary_size = std::fs::metadata(parent.join(format!("{base}-Summary.db")))
+        .map(|m| m.len())
+        .unwrap_or(0);
+    (index_size, summary_size)
+}
+
+fn find_data_db(table_dir: &std::path::Path) -> std::path::PathBuf {
+    std::fs::read_dir(table_dir)
+        .expect("table dir")
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .expect("a Data.db exists")
+}
+
+/// Requirement 4's pinned scenario: a warm-held generation's accounted index
+/// footprint is bounded by `Summary.db` size (O(n/128)), NOT by the full
+/// on-disk `Index.db` size — and so does NOT scale linearly with partition
+/// count the way the full `Index.db` does.
+#[test]
+fn warm_footprint_does_not_scale_with_partition_count() {
+    let schema = simple_schema();
+
+    // Small generation: a handful of partitions (non-vacuity control).
+    let (_small_temp, small_dir) = build_single_gen(&schema, 200);
+    let small_reg = WarmTableRegistry::new();
+    small_reg
+        .warm_readers(&key(), ddl(), &schema, &small_dir, None, &CancelFlag::new())
+        .expect("small generation warms");
+    let small_footprint = small_reg.debug_used_bytes();
+
+    // Large generation: 1000x the partitions, same shape — the fixture whose
+    // FULL Index.db is genuinely ~1000x bigger (verified against the on-disk
+    // Index.db size below, not assumed).
+    let (_large_temp, large_dir) = build_single_gen(&schema, 200_000);
+    let large_data = find_data_db(&large_dir);
+    let (large_index_bytes, large_summary_bytes) = sibling_component_sizes(&large_data);
+    let large_reg = WarmTableRegistry::new();
+    large_reg
+        .warm_readers(&key(), ddl(), &schema, &large_dir, None, &CancelFlag::new())
+        .expect("large generation warms");
+    let large_footprint = large_reg.debug_used_bytes();
+
+    assert!(
+        small_footprint > 0,
+        "small generation's footprint is non-zero"
+    );
+    assert!(
+        large_footprint > 0,
+        "large generation's footprint is non-zero"
+    );
+    // Non-vacuity: the large generation's REAL on-disk Index.db must genuinely
+    // dwarf its Summary.db — otherwise the fixture cannot discriminate a
+    // "counts the full index" bug from the correct summary-only accounting.
+    assert!(
+        large_index_bytes > large_summary_bytes * 20,
+        "fixture precondition: the large generation's real Index.db \
+         ({large_index_bytes}) must dwarf its Summary.db ({large_summary_bytes})"
+    );
+
+    // THE evidence (authoritative bound, not a guessed ceiling): compare the
+    // REGISTRY's accounted footprint against what `account_footprint` itself
+    // would compute counting the full `Index.db` as resident — the exact
+    // pre-#2412 behavior. If the registry still counted the full index, the
+    // two would coincide; the fix must land materially below it.
+    let full_index_footprint = crate::warm::budget::account_footprint(&large_data, true);
+    assert!(
+        large_footprint < full_index_footprint / 2,
+        "large-generation registry-accounted footprint ({large_footprint}) must sit \
+         materially BELOW the full-Index.db-resident accounting ({full_index_footprint}) \
+         — issue #2412 §D: a Summary-usable BIG generation's Index.db is not \
+         resident on the query-serving path, so it must not be counted"
+    );
+}
+
+/// Companion direct-accounting pin: the SAME on-disk shape counted with
+/// `index_resident = true` (simulating the pre-#2412 always-eager behavior)
+/// DOES scale with the large `Index.db`'s real size — proving the bounded ratio
+/// above comes from the residency-aware exclusion, not from the fixture
+/// happening to produce small `Index.db` files.
+#[test]
+fn resident_accounting_of_the_same_fixture_would_scale_with_index_size() {
+    use crate::warm::budget::account_footprint;
+
+    let schema = simple_schema();
+    let (_temp, dir) = build_single_gen(&schema, 200_000);
+    let data_path = std::fs::read_dir(&dir)
+        .expect("table dir")
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .expect("a Data.db exists");
+
+    let lazy = account_footprint(&data_path, false);
+    let resident = account_footprint(&data_path, true);
+    assert!(
+        resident > lazy * 5,
+        "a 200k-partition Index.db is large enough that counting it resident \
+         ({resident}) must dwarf the lazy (summary-only) accounting ({lazy}) — \
+         otherwise this fixture cannot discriminate the two modes"
+    );
+}

--- a/cqlite-flight/tests/issue_2370_single_flight_test.rs
+++ b/cqlite-flight/tests/issue_2370_single_flight_test.rs
@@ -1,28 +1,32 @@
-//! Issue #2370 — N concurrent COLD `do_get`s must NOT amplify Index.db parses
-//! with N (the #2383 single-flight pin extended through the rpc layer under
+//! Issue #2370 — N concurrent COLD `do_get`s must NOT amplify reader opens with
+//! N (the #2383 single-flight pin extended through the rpc layer under
 //! concurrency).
 //!
 //! The #2383 resolve-phase spin (a `do_get` re-parsing the same generation's full
 //! `Index.db` repeatedly) was pinned SEQUENTIALLY. The field trigger is N
 //! CONCURRENT queries against one server: if the warm registry's single-flight
-//! open fails to coalesce concurrent cold opens, each racing request re-parses
-//! every generation, so `index_parses_total` climbs toward `#generations × N` (the
-//! 8× amplifier the field saw). This test fires N concurrent cold `do_get`s at ONE
-//! service over the SAME table and reads back the authoritative
-//! `cqlite.sstable.index_parses_total` counter, pinning that the total is bounded
+//! open fails to coalesce concurrent cold opens, each racing request re-opens
+//! (and, pre-#2412, re-parsed) every generation, so the work-done total climbs
+//! toward `#generations × N` (the 8× amplifier the field saw). This test fires N
+//! concurrent cold `do_get`s at ONE service over the SAME table and reads back
+//! the warm registry's `reader_opens` counter, pinning that the total is bounded
 //! by a small per-generation CONSTANT — INDEPENDENT of N — proving the concurrent
 //! opens single-flighted.
 //!
-//! ## Why the bound is `PER_OPEN_PARSES × #generations`, not `#generations`
+//! ## Re-anchored for issue #2412 (lazy Summary-guided BIG open)
 //!
-//! The issue's ideal is `index_parses_total == #generations` (each generation's
-//! Index.db parsed once per query — the counter's documented contract in
-//! `catalog::INDEX_PARSES_TOTAL`). Issue **#2395** (fixed) retired the reader-open
-//! double-parse: `SSTableReader::open` now parses each `Index.db` EXACTLY ONCE
-//! (only `load_index_reader` → spec `IndexReader`; `load_index` no longer reads
-//! the separate component), so `PER_OPEN_PARSES == 1` and the total is
-//! `1 × #generations`. The single-flight this test pins is that the total does NOT
-//! scale with N — the bound only rejects a per-REQUEST, N-scaling amplification.
+//! This test originally read back `cqlite.sstable.index_parses_total` (one
+//! increment per full `Index.db` parse) as BOTH the "cold real work happened"
+//! lower bound AND the "single-flighted, not ×N" upper bound. Since #2412 Stage
+//! 2, a cold open over a usable `Summary.db` (this fixture's writer-produced
+//! shape) performs ZERO full `Index.db` parses at open (deferred, lazy) — so
+//! `index_parses_total` reads `0` for BOTH a correctly single-flighted run AND a
+//! broken (un-coalesced) one, and can no longer discriminate them. The
+//! single-flight property is proven instead via `reader_opens` (the warm
+//! registry's real-open work-done counter, `WarmMetricsSnapshot`): a
+//! single-flighted cold run opens ONE reader PER generation (never ×N); a broken
+//! one opens up to N × generations. `index_parses_total == 0` is retained as a
+//! documentary assertion of the #2412 improvement, not the discriminating pin.
 //!
 //! ## Separate integration-test process
 //!
@@ -52,13 +56,6 @@ use concurrent_support as support;
 /// Number of simultaneous cold requests. Field runs use 8.
 const N: usize = 8;
 
-/// Number of full `Index.db` parses `SSTableReader::open` performs PER reader
-/// open. Issue **#2395** (fixed) retired the reader-open double-parse, so this is
-/// now `1` (only `load_index_reader` parses the separate `Index.db`). The pin
-/// below is that the TOTAL is `PER_OPEN_PARSES × #generations` — a per-generation
-/// constant that does NOT grow with N.
-const PER_OPEN_PARSES: f64 = 1.0;
-
 /// Count the `nb-*-big-Data.db` generations under the fixture's table dir.
 fn generation_count(data_dir: &std::path::Path) -> usize {
     let table_dir = data_dir.join(fx::KEYVALUE_KS).join(fx::KEYVALUE_TBL);
@@ -82,21 +79,26 @@ fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
     let (_temp, data_dir) = support::build_multi_sstable_fixture(total);
     let generations = generation_count(&data_dir);
     // `>= 2` (not `== 2`) is DELIBERATE (roborev job 1657 LOW, declined with
-    // evidence): the parse bound below is generation-RELATIVE
-    // (`PER_OPEN_PARSES × generations`), and the single-flight property under test
-    // is N-independence — the fail signal is `generations × N`, which stays far
-    // above the bound for any N>2 REGARDLESS of the exact generation count. An
-    // extra generation widens the per-generation-constant bound proportionally but
-    // never weakens the N-scaling rejection, so pinning the count exactly would
-    // only couple this test to `build_multi_sstable_fixture`'s internals for no
-    // gain in discrimination. The `>= 2` floor is the meaningful precondition
-    // (≥2 generations is what makes cold-open coalescing observable at all).
+    // evidence): the bound below is generation-RELATIVE, and the single-flight
+    // property under test is N-independence — the fail signal is
+    // `generations × N`, which stays far above the bound for any N>2 REGARDLESS
+    // of the exact generation count. An extra generation widens the
+    // per-generation-constant bound proportionally but never weakens the
+    // N-scaling rejection, so pinning the count exactly would only couple this
+    // test to `build_multi_sstable_fixture`'s internals for no gain in
+    // discrimination. The `>= 2` floor is the meaningful precondition (≥2
+    // generations is what makes cold-open coalescing observable at all).
     assert!(
         generations >= 2,
         "fixture must hold ≥2 generations to make single-flight meaningful, got {generations}"
     );
 
     let svc = CqliteFlightService::new(data_dir, 8192);
+    // Issue #2412 re-anchor: `CqliteFlightService` is cheaply `Clone` (an `Arc`
+    // handle over the shared warm registry), so a clone kept OUTSIDE the copy
+    // moved into the server lets this test read `warm_metrics()` after the
+    // concurrent run — both clones drive the SAME underlying registry.
+    let svc_handle = svc.clone();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -105,8 +107,8 @@ fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
     let parses = rt.block_on(async move {
         // Serve the ONE cold service over real loopback gRPC (roborev job 1659
         // MEDIUM): all N concurrent cold requests traverse the actual tonic
-        // transport + server-side handler before we sample the parse counter, so
-        // the single-flight coalescing is proven through the REAL rpc path (a
+        // transport + server-side handler before we sample the work-done counters,
+        // so the single-flight coalescing is proven through the REAL rpc path (a
         // per-connection registry regression would amplify here but be invisible to
         // a direct in-process `svc.do_get()` that hand-shares one `Arc`). The one
         // `FlightServiceServer` instance shares its reader registry across every
@@ -116,8 +118,8 @@ fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
 
         // Reset AFTER the server binds but BEFORE any request: `start_server` opens
         // no readers (they open lazily on first `do_get`) and `connect` performs no
-        // parse, so only the cold-open parses from the N concurrent do_gets below
-        // are counted. metrics_capture is process-global, so the server-side parses
+        // parse, so only the cold-open work from the N concurrent do_gets below is
+        // counted. metrics_capture is process-global, so the server-side parses
         // (same process, spawned task) are captured.
         mc.reset();
 
@@ -154,28 +156,39 @@ fn n_concurrent_cold_do_gets_do_not_amplify_index_parses_with_n() {
             .counter_sum(catalog::INDEX_PARSES_TOTAL)
     });
 
-    // Lower bound: a cold read really parses every generation at least once (never
-    // a 0-parse skip that would mean a generation went unread).
-    assert!(
-        parses >= generations as f64,
-        "N={N} concurrent COLD do_gets over {generations} generations must parse each generation's \
-         Index.db at least once (cold real work), got {parses}"
+    // Documentary assertion of the #2412 improvement (see the module doc): a
+    // usable Summary.db means cold opens never full-parse Index.db at all.
+    assert_eq!(
+        parses, 0.0,
+        "cold opens over a usable Summary.db must full-parse Index.db ZERO times \
+         (issue #2412 lazy open); got {parses}"
     );
 
-    // THE single-flight pin: the total is a small per-generation CONSTANT,
-    // INDEPENDENT of N. A single-flight failure (the #2383 ×N amplifier through the
-    // rpc layer) makes each of the N requests re-parse every generation, so the
-    // total climbs toward `#generations × N` (here up to 16–32) — far past this
-    // bound. `PER_OPEN_PARSES` (now 1 — the #2395 reader-open double-parse is
-    // fixed) is a per-generation constant; the bound rejects only a per-REQUEST,
-    // N-scaling amplification.
-    let bound = PER_OPEN_PARSES * generations as f64;
+    // THE single-flight pin, re-anchored on `reader_opens` (see module doc):
+    // `index_parses_total` reads 0 regardless of coalescing for this fixture
+    // shape, so the discriminating counter is the warm registry's real-open
+    // work-done metric instead.
+    let reader_opens = svc_handle.warm_metrics().reader_opens;
+
+    // Lower bound: a cold read really opened every generation's reader at least
+    // once (never a 0-open skip that would mean a generation went unread).
     assert!(
-        parses <= bound,
-        "N={N} concurrent COLD do_gets over {generations} generations must NOT amplify Index.db \
-         parses with N: expected ≤ {bound} (= {PER_OPEN_PARSES} × {generations}, a per-generation \
-         constant), got {parses}. A value scaling toward {} means the concurrent opens did not \
-         single-flight (the #2383 amplifier through the rpc layer).",
+        reader_opens >= generations as u64,
+        "N={N} concurrent COLD do_gets over {generations} generations must open each \
+         generation's reader at least once (cold real work), got {reader_opens}"
+    );
+
+    // The total is a small per-generation CONSTANT, INDEPENDENT of N. A
+    // single-flight failure (the #2383 ×N amplifier through the rpc layer) makes
+    // each of the N requests open every generation itself, so the total climbs
+    // toward `#generations × N` (here up to 16) — far past this bound.
+    let bound = generations as u64;
+    assert!(
+        reader_opens <= bound,
+        "N={N} concurrent COLD do_gets over {generations} generations must NOT amplify reader \
+         opens with N: expected ≤ {bound} (a per-generation constant), got {reader_opens}. A \
+         value scaling toward {} means the concurrent opens did not single-flight (the #2383 \
+         amplifier through the rpc layer).",
         generations * N
     );
 }

--- a/cqlite-flight/tests/issue_2383_resolve_spin_test.rs
+++ b/cqlite-flight/tests/issue_2383_resolve_spin_test.rs
@@ -14,8 +14,15 @@
 //! This drives that through the REAL `FlightService::do_get` and reads back the
 //! authoritative `cqlite.sstable.index_parses_total` counter (one increment per
 //! full `Index.db` parse, emitted from the core parse loop regardless of call
-//! path). A correct read path rebinds a same-inode generation to its LIVE path
-//! with ZERO re-parse; current main re-parses #generations — the spin.
+//! path) ALONGSIDE the warm registry's `reader_opens` work-done counter. A
+//! correct read path rebinds a same-inode generation to its LIVE path with ZERO
+//! FURTHER reader opens; a broken one re-opens #generations — the spin.
+//!
+//! Re-anchored for issue #2412 (lazy Summary-guided BIG open): a cold `do_get`
+//! over a usable `Summary.db` now performs ZERO full `Index.db` parses at open
+//! (deferred), so `index_parses_total` alone no longer distinguishes "rebound"
+//! from "re-opened" for this fixture shape — see the test's own doc for the
+//! `reader_opens`-based re-anchor.
 //!
 //! Separate integration-test process (roborev #2163 precedent): the OTel capture
 //! harness installs a PROCESS-GLOBAL meter provider, so it must not share
@@ -177,19 +184,33 @@ async fn do_get_drain(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
     msgs
 }
 
-/// **Resolve-phase spin pin (issue #2383).** Two `do_get`s against the SAME
-/// underlying generations reached through TWO per-query snapshot dirs (query N's
-/// is cleared before query N+1 stages a fresh same-inode dir, exactly as the
-/// Trino connector's `clearSnapshot` does). The FIRST query legitimately parses
-/// both generations cold. The SECOND must serve the same inodes with ZERO further
-/// full `Index.db` parses (rebind-by-inode) — its cost is the spin the field saw.
+/// **Resolve-phase spin pin (issue #2383), re-anchored for issue #2412.** Two
+/// `do_get`s against the SAME underlying generations reached through TWO
+/// per-query snapshot dirs (query N's is cleared before query N+1 stages a
+/// fresh same-inode dir, exactly as the Trino connector's `clearSnapshot`
+/// does). The SECOND must serve the same inodes via a REBIND — zero further
+/// reader OPENS — not a full re-open of every generation (the field's O(entries
+/// × opens) amplification, seen as 8× re-parses for one logical query).
 ///
-/// RED on current main: the cached readers' snap1 paths are dead after teardown,
-/// so the warm rebuild RE-OPENS both generations from snap2 and the do_get path
-/// re-parses their Index.db → `index_parses_total` for query 2 == 4 (MEASURED:
-/// 2 generations, each parsed twice on this second-query path — the O(entries ×
-/// opens) amplification the field saw as 8× for one logical query). GREEN after
-/// the rebind fix: query 2 re-parses 0.
+/// Re-anchored (issue #2412, coordinator-flagged regression class — same root
+/// cause as `spin_tests_2383::cancel_during_large_index_parse_aborts_promptly`):
+/// this test originally asserted query 1 (cold) full-parses `Index.db` `>= 2`
+/// (once per generation) via `index_parses_total`. Since #2412 Stage 2, BIG
+/// open defers that parse (`open_lazy`) whenever a usable `Summary.db` is
+/// present — the common/field shape this fixture produces — so a cold `do_get`
+/// now performs ZERO full parses at open (spec Requirement 7's "cold = 0 full
+/// Index.db parses", a strict IMPROVEMENT on the pre-#2412 baseline this test
+/// measured). `index_parses_total` therefore no longer distinguishes "rebound
+/// in place" from "fully re-opened" for this shape (both are now cheap/parse-
+/// free) — the REBIND-vs-reopen property #2383 fix B protects is asserted
+/// instead via `reader_opens` (the warm registry's real-open work-done counter,
+/// `#2383`/`#2310`), which is exactly what distinguishes them: a rebind costs
+/// ZERO opens, a full re-open costs one PER generation.
+///
+/// RED pre-#2383-fix-B: the cached readers' snap1 paths were dead after
+/// teardown, so the warm rebuild RE-OPENED both generations from snap2 —
+/// `reader_opens` for query 2 == 2 (one per generation), instead of the
+/// rebind's 0.
 #[test]
 fn do_get_reparses_index_on_every_snapshot_swap() {
     // Install the process-global in-memory meter BEFORE any parse in this process.
@@ -206,10 +227,19 @@ fn do_get_reparses_index_on_every_snapshot_swap() {
     let q1_parses = mc
         .flush_and_collect()
         .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    let opens_after_q1 = svc.warm_metrics().reader_opens;
     assert!(msgs1 > 0, "query 1 must stream at least a schema message");
-    assert!(
-        q1_parses >= 2.0,
-        "cold query 1 parses both generations' Index.db (got {q1_parses})"
+    // Spec Requirement 7 (issue #2412): a cold open over a usable Summary.db
+    // performs ZERO full Index.db parses (open is lazy, deferred to first
+    // materializing use — never triggered on this streaming query path).
+    assert_eq!(
+        q1_parses, 0.0,
+        "cold query 1 must full-parse Index.db ZERO times over a usable \
+         Summary.db (issue #2412 lazy open); got {q1_parses}"
+    );
+    assert_eq!(
+        opens_after_q1, 2,
+        "cold query 1 must open exactly the two generations once each"
     );
 
     // Connector clears query N's snapshot; the live inodes in table_dir persist.
@@ -223,15 +253,24 @@ fn do_get_reparses_index_on_every_snapshot_swap() {
     let q2_parses = mc
         .flush_and_collect()
         .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    let opens_after_q2 = svc.warm_metrics().reader_opens;
     assert!(msgs2 > 0, "query 2 must stream at least a schema message");
 
-    // THE anti-spin assertion: the second query over the same inodes must NOT
-    // re-parse any Index.db (rebind). RED today (a full rebuild re-parses both
-    // generations → 2). GREEN after fix B.
+    // Full parses stay zero (nothing to re-parse either way for this shape).
     assert_eq!(
         q2_parses, 0.0,
+        "a second do_get over the SAME generations must still perform zero \
+         full Index.db parses; got {q2_parses}"
+    );
+    // THE anti-spin assertion (re-anchored): the second query over the same
+    // inodes must REBIND — zero FURTHER reader opens — not fully re-open every
+    // generation. RED pre-#2383-fix-B: `opens_after_q2` would climb by 2 (a
+    // full re-open of both generations from snap2's dead-path fallback).
+    assert_eq!(
+        opens_after_q2, opens_after_q1,
         "a second do_get over the SAME generations (new same-inode snapshot dir) \
-         must REBIND with zero further Index.db parses, not re-parse #generations \
-         (issue #2383 resolve-phase spin); got {q2_parses}"
+         must REBIND with zero further reader opens, not re-open #generations \
+         (issue #2383 resolve-phase spin); opens climbed from {opens_after_q1} \
+         to {opens_after_q2}"
     );
 }

--- a/cqlite-flight/tests/issue_2398_warm_scan_token_pushdown.rs
+++ b/cqlite-flight/tests/issue_2398_warm_scan_token_pushdown.rs
@@ -1,6 +1,10 @@
-//! Issue #2398 — reproduction: a warm token-range `do_get` scan reads + parses
-//! EVERY partition body in the SSTable, a fixed O(all partitions) per-query cost
-//! independent of the split range width and of `LIMIT`.
+//! Issue #2398/#2412/#2413 — pin (FIX LANDED): a warm token-range `do_get` scan
+//! decodes ONLY the in-range partition bodies, NOT every partition in the SSTable.
+//! Before #2412/#2413 this walk read + parsed EVERY partition body, a fixed
+//! O(all partitions) per-query cost independent of the split range width and of
+//! `LIMIT` (the field's fixed multi-second warm-scan setup). The token range is
+//! now pushed INTO the per-SSTable Summary-guided walk (Option A), so a
+//! single-partition range decodes ~1 body.
 //!
 //! ## What the field saw
 //!
@@ -26,14 +30,14 @@
 //! partition and shows the server decoded ALL `N` bodies to answer it — the
 //! scale-free mechanism the field 7s reflects at ~1.9M partitions.
 //!
-//! ## Flip when the fix lands (issue #2398 acceptance criterion 2)
+//! ## The fix (issue #2413 Option A, landed in #2412)
 //!
-//! The fix is to push the token range INTO the walk (binary-search the
-//! token-ordered index entries and walk only the in-range slice). When it lands,
-//! the single-partition-range assertion below MUST become `walked <= small bound`
-//! (a few, for binary-search boundary slack) instead of `== N`, and the
-//! `>` comparison flips. See the issue for the fix plan; this test is its pinned
-//! reproduction.
+//! The token range is pushed INTO the per-SSTable walk: the Summary-guided
+//! streaming walk (`stream_partitions_summary_guided`) begins at the `Summary.db`
+//! sample covering the range start (`scan_start_position_for_token`) and stops
+//! once the walk passes the range end, so out-of-range partition bodies are never
+//! decoded. The single-partition-range assertion below is therefore `walked <= 4`
+//! (a few, for binary-search boundary slack), NOT `== N`.
 //!
 //! ## Warm small-LIMIT latency target (issue #2398 acceptance criterion 3)
 //!
@@ -151,7 +155,7 @@ async fn do_get_rows(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
 }
 
 #[test]
-fn warm_token_range_scan_reads_the_whole_sstable_for_one_partition() {
+fn warm_token_range_scan_reads_only_the_in_range_partition() {
     let (_temp, data_dir) = build_single_sstable();
     let svc = CqliteFlightService::new(data_dir, 1024);
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -206,23 +210,25 @@ fn warm_token_range_scan_reads_the_whole_sstable_for_one_partition() {
             "a full (no token range) scan walks every partition body"
         );
 
-        // THE evidence (issue #2398): answering a ONE-partition token range cost
-        // the SAME whole-SSTable body-parse work as the full scan — the token
-        // filter runs only at the consumer, so the walk reads every partition
-        // regardless of the split range. This is the fixed per-query setup the
-        // field saw as a multi-second cost independent of the result size.
-        //
-        // FLIP WHEN THE FIX LANDS: once the token range is pushed into the walk
-        // (binary-search the token-ordered index, walk only the in-range slice),
-        // change this to `assert!(walked <= 4, ...)` — the walk will touch only the
-        // in-range partition (+ small boundary slack), NOT all {N}.
+        // THE evidence (issue #2398/#2412/#2413, FIX LANDED): the token range is
+        // now pushed INTO the per-SSTable Summary-guided walk — it begins at the
+        // `Summary.db` sample covering the range start and stops once the walk
+        // passes the range end, so a ONE-partition token range decodes only that
+        // partition's body (plus at most small binary-search boundary slack), NOT
+        // the whole SSTable. This is what collapses the field's fixed multi-second
+        // warm-scan setup cost to O(in-range partitions + LIMIT).
+        assert!(
+            walked <= 4,
+            "issue #2413: a single-partition token range must decode only the \
+             in-range partition body (+ small boundary slack), got walked={walked} \
+             (full-scan baseline {full_walked} = {N}). Token pushdown into the \
+             Summary-guided walk failed — the split still reads out-of-range bodies."
+        );
+        // Non-vacuity: the full-scan control must still walk the whole SSTable, so
+        // the bound above is a genuine reduction, not both sides collapsing.
         assert_eq!(
-            walked, full_walked,
-            "issue #2398: a single-partition token range parsed {walked} partition \
-             bodies — the SAME as the whole-SSTable full scan ({full_walked}) — \
-             because the token filter is applied only downstream at the consumer, \
-             not pushed into the per-SSTable walk. This is the fixed warm-scan \
-             setup cost independent of the split range and of LIMIT."
+            full_walked, N,
+            "the full (no token range) scan still walks every partition body"
         );
     });
 }

--- a/cqlite-flight/tests/issue_2412_do_get_cold_warm_e2e.rs
+++ b/cqlite-flight/tests/issue_2412_do_get_cold_warm_e2e.rs
@@ -1,0 +1,210 @@
+//! Issue #2412 §G / spec Requirement 7 (Stage 6) — the lazy Summary-guided BIG
+//! index proven END-TO-END through the flight `do_get` path, both cold and warm.
+//!
+//! Two `do_get`s against the SAME real Cassandra-produced BIG table (a real
+//! `Summary.db` + `Index.db` pair — the shape #2412's lazy open targets):
+//!
+//! - **Cold** (first request): resolves rows over ZERO full `Index.db` parses
+//!   (open is lazy over the on-disk `Summary.db`, design §A) — open work is
+//!   bounded by `Summary.db` size, not partition count.
+//! - **Warm** (second request, same service, unchanged generation): the SAME
+//!   rows, with ZERO further reader opens (the warm registry serves the cached
+//!   reader) AND ZERO full `Index.db` parses (the streaming query path never
+//!   materializes the resident map, Stage 4).
+//!
+//! This is the wiring-evidence surface the spec requires: a named public API
+//! (`FlightService::do_get`) + a real call chain (ticket → warm registry →
+//! Summary-guided streaming merge → Arrow batches), not a helper-only unit test.
+//! Row-count equality between the cold and warm runs is the query-semantics
+//! correctness proof (a `WHERE`-less full scan's post-reconciliation result is
+//! whatever the golden JSONL enumerates, byte-identically reproduced on both
+//! requests) — the same non-vacuity discipline
+//! `do_get_over_transport_real_compressed_fixture` uses.
+//!
+//! ## Why a REAL dataset table, not a synthetic write-engine fixture
+//!
+//! A write-engine-produced (synthetic) `nb`-tagged Data.db is headerless, and
+//! `CassandraVersion` detection for a headerless file falls back to a magic-byte
+//! sniff of the FIRST few partition bytes (`reader/header.rs`): unless those
+//! bytes coincidentally match a specific magic, it classifies as `V5_0NewBig`
+//! (chunk-stitching), which decodes via `drain_compaction_window` and never
+//! touches the `Index.db`-based enumeration paths at all — making a synthetic
+//! fixture an unreliable, data-dependent discriminator for this scenario. A
+//! REAL Cassandra-produced table (this file's fixture) always classifies
+//! correctly and reliably exercises the Index.db-guided paths #2412 targets
+//! (confirmed empirically: `issue_2385_index_single_parse` proves `Index.db` a
+//! full materializing enumeration of this SAME table parses exactly once).
+//!
+//! ## Separate integration-test process
+//!
+//! The OTel capture harness installs a PROCESS-GLOBAL meter provider (roborev
+//! #2163 precedent), so this file holds exactly one `#[test]` in its own binary.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --features observability-testing \
+//!   --test issue_2412_do_get_cold_warm_e2e
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::path::PathBuf;
+
+use arrow::array::{Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_flight::service::CqliteFlightService;
+
+const DDL: &str = "CREATE TABLE test_basic.uncompressed_table (\
+    id uuid PRIMARY KEY, data text, value int, timestamp_val timestamp)";
+
+fn ticket_bytes() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": "test_basic",
+        "table": "uncompressed_table",
+        "ddl": DDL,
+    }))
+    .unwrap()
+}
+
+/// Locate the real fixture's `Data.db` sibling directory, resolved the same way
+/// `do_get_transport_test.rs::do_get_over_transport_real_compressed_fixture`
+/// does. `uncompressed_table` (no `CompressionInfo.db`) is deliberately chosen
+/// over a compressed table: a REAL Cassandra-produced compressed `nb` table
+/// takes the chunk-stitching read path (`requires_chunk_stitching() == true`),
+/// which decodes via chunk decompression and never touches the `Index.db`
+/// resident-map paths AT ALL regardless of #2412 — an uncompressed table is
+/// what actually routes through the Summary-guided / full-index-enumeration
+/// machinery this issue changes. Returns `None` (never a hard failure) when
+/// `CQLITE_DATASETS_ROOT` is unset or the gitignored binary is absent — the repo
+/// ships only the JSONL references, so a fresh worktree that never ran
+/// `fetch-datasets.sh` must skip cleanly, not fail.
+fn real_fixture_dirs() -> Option<(PathBuf, PathBuf)> {
+    let root = std::env::var_os("CQLITE_DATASETS_ROOT")?;
+    let data_dir = PathBuf::from(&root).join("sstables");
+    let table_dir = data_dir
+        .join("test_basic")
+        .join("uncompressed_table-6aedb7a0a25111f0a3fef1a551383fb9");
+    let data_db = table_dir.join("nb-1-big-Data.db");
+    if !data_db.is_file() {
+        return None;
+    }
+    Some((data_dir, table_dir))
+}
+
+/// Drive `do_get` and decode every batch into sorted `data` values — a
+/// value-level correctness check (matches the convention used across the
+/// #2310/#2412 warm-hit wiring-evidence tests), proving the cold and warm runs
+/// resolve byte-identical content, not merely "some rows."
+async fn do_get_sorted_names(svc: &CqliteFlightService, ticket: Vec<u8>) -> Vec<String> {
+    let resp = svc
+        .do_get(Request::new(Ticket::new(ticket)))
+        .await
+        .expect("do_get");
+    let stream = resp
+        .into_inner()
+        .map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+    let mut out = Vec::new();
+    while let Some(batch) = rb.next().await {
+        let batch: RecordBatch = batch.expect("decode batch");
+        let names = batch
+            .column_by_name("data")
+            .expect("data column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name is text");
+        for i in 0..names.len() {
+            out.push(names.value(i).to_string());
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Spec Requirement 7's pinned scenario, both halves in one test (they share
+/// the one warm service instance / process-global meter):
+///
+/// - Cold `do_get`: resolves real rows, 0 full `Index.db` parses.
+/// - Warm repeat `do_get` (same generation): the SAME rows, 0 further reader
+///   opens, 0 full `Index.db` parses.
+#[test]
+fn cold_and_warm_do_get_resolve_correct_rows_with_bounded_work() {
+    let Some((data_dir, table_dir)) = real_fixture_dirs() else {
+        eprintln!(
+            "real fixture Data.db binary absent (set CQLITE_DATASETS_ROOT + run \
+             fetch-datasets.sh) — skipping issue #2412 cold/warm e2e"
+        );
+        return;
+    };
+    // Precondition (never assumed): the real fixture ships a usable Summary.db —
+    // the shape a lazy BIG open (design §A) actually applies to.
+    let summary_db = table_dir.join("nb-1-big-Summary.db");
+    assert!(
+        summary_db.is_file(),
+        "fixture precondition: the real table must ship a Summary.db"
+    );
+
+    // Install the process-global in-memory meter BEFORE any parse in this process.
+    let mc = testing::metrics_capture();
+
+    let svc = CqliteFlightService::new(data_dir, 8192);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // ---- Cold do_get ----
+    mc.reset();
+    let cold_names = rt.block_on(do_get_sorted_names(&svc, ticket_bytes()));
+    let cold_parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    let opens_after_cold = svc.warm_metrics().reader_opens;
+
+    assert!(
+        !cold_names.is_empty(),
+        "cold do_get must resolve at least one row from the real fixture (never \
+         a silent 0-rows-when-present pass)"
+    );
+    assert_eq!(
+        cold_parses, 0.0,
+        "cold do_get over a generation with a usable Summary.db must perform ZERO \
+         full Index.db parses (issue #2412 lazy open, spec Requirement 7); got \
+         {cold_parses}"
+    );
+    assert_eq!(
+        opens_after_cold, 1,
+        "cold do_get must open exactly the one generation once (real work \
+         happened — never a vacuous 0-open skip)"
+    );
+
+    // ---- Warm repeat do_get (same generation, unchanged) ----
+    mc.reset();
+    let warm_names = rt.block_on(do_get_sorted_names(&svc, ticket_bytes()));
+    let warm_parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    let opens_after_warm = svc.warm_metrics().reader_opens;
+
+    assert_eq!(
+        warm_names, cold_names,
+        "warm repeat do_get must resolve the SAME rows as the cold request \
+         (query-semantics correctness, byte-identical across cold/warm)"
+    );
+    assert_eq!(
+        warm_parses, 0.0,
+        "warm repeat do_get must perform ZERO full Index.db parses over the \
+         unchanged generation (spec Requirement 7); got {warm_parses}"
+    );
+    assert_eq!(
+        opens_after_warm, opens_after_cold,
+        "warm repeat do_get over the SAME generation must perform ZERO further \
+         reader opens (the cached warm reader is reused, not re-opened); opens \
+         climbed from {opens_after_cold} to {opens_after_warm}"
+    );
+}

--- a/cqlite-flight/tests/issue_2412_do_get_cold_warm_e2e_compressed.rs
+++ b/cqlite-flight/tests/issue_2412_do_get_cold_warm_e2e_compressed.rs
@@ -1,0 +1,196 @@
+//! Issue #2412 §G / spec Requirement 7 (Stage 6) — the COMPRESSED chunk-stitching
+//! warm-query decode path (`stream_partitions_summary_guided_compaction`,
+//! `requires_chunk_stitching() == true`) proven end-to-end through the flight
+//! `do_get` path, cold and warm. Sibling of `issue_2412_do_get_cold_warm_e2e.rs`
+//! (which deliberately covers the UNCOMPRESSED / `stream_partitions_summary_guided`
+//! branch instead — the two decoders in `summary_scan.rs` share the walk but
+//! decode differently, and until this file neither real-dataset e2e exercised the
+//! compressed branch, roborev-flagged wiring-evidence gap).
+//!
+//! `test_basic.compression_test_table` is a REAL Cassandra-produced, Snappy-
+//! compressed `nb-big` table (`CompressionInfo.db` present) — the shape that
+//! routes `stream_all_partitions_for_query` through
+//! `stream_partitions_summary_guided_compaction` (full-fidelity `CompactionRow`
+//! decode over `read_compressed_offset_window`-mapped chunks), NOT the
+//! uncompressed `ScanRow` decoder the sibling file covers.
+//!
+//! Same cold/warm assertions as the sibling: cold = 0 full `Index.db` parses + 1
+//! real reader-open; warm repeat = 0 further parses + 0 further opens; identical
+//! rows both times (query-semantics correctness, byte-identical across cold/warm).
+//!
+//! ## Separate integration-test process
+//!
+//! The OTel capture harness installs a PROCESS-GLOBAL meter provider (roborev
+//! #2163 precedent), so this file holds exactly one `#[test]` in its own binary.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --features observability-testing \
+//!   --test issue_2412_do_get_cold_warm_e2e_compressed
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::path::PathBuf;
+
+use arrow::array::{Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_flight::service::CqliteFlightService;
+
+const DDL: &str = "CREATE TABLE test_basic.compression_test_table (\
+    id uuid PRIMARY KEY, large_text text, repeated_data text, random_data blob, \
+    compressed_json text)";
+
+fn ticket_bytes() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": "test_basic",
+        "table": "compression_test_table",
+        "ddl": DDL,
+    }))
+    .unwrap()
+}
+
+/// Locate the real fixture's `Data.db` sibling directory, resolved the same way
+/// the sibling (uncompressed) e2e test does. Returns `None` (never a hard
+/// failure) when `CQLITE_DATASETS_ROOT` is unset or the gitignored binary is
+/// absent — the repo ships only the JSONL references.
+fn real_fixture_dirs() -> Option<(PathBuf, PathBuf)> {
+    let root = std::env::var_os("CQLITE_DATASETS_ROOT")?;
+    let data_dir = PathBuf::from(&root).join("sstables");
+    let table_dir = data_dir
+        .join("test_basic")
+        .join("compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9");
+    let data_db = table_dir.join("nb-1-big-Data.db");
+    if !data_db.is_file() {
+        return None;
+    }
+    Some((data_dir, table_dir))
+}
+
+/// Drive `do_get` and decode every batch into sorted `compressed_json` values —
+/// a value-level correctness check proving the cold and warm runs resolve
+/// byte-identical content, not merely "some rows."
+async fn do_get_sorted_values(svc: &CqliteFlightService, ticket: Vec<u8>) -> Vec<String> {
+    let resp = svc
+        .do_get(Request::new(Ticket::new(ticket)))
+        .await
+        .expect("do_get");
+    let stream = resp
+        .into_inner()
+        .map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+    let mut out = Vec::new();
+    while let Some(batch) = rb.next().await {
+        let batch: RecordBatch = batch.expect("decode batch");
+        let values = batch
+            .column_by_name("compressed_json")
+            .expect("compressed_json column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("compressed_json is text");
+        for i in 0..values.len() {
+            out.push(values.value(i).to_string());
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Spec Requirement 7's pinned scenario over the COMPRESSED chunk-stitching decode
+/// path (both halves in one test — they share the one warm service instance /
+/// process-global meter):
+///
+/// - Cold `do_get`: resolves real rows, 0 full `Index.db` parses.
+/// - Warm repeat `do_get` (same generation): the SAME rows, 0 further reader
+///   opens, 0 full `Index.db` parses.
+#[test]
+fn cold_and_warm_do_get_resolve_correct_rows_over_compressed_chunks() {
+    let Some((data_dir, table_dir)) = real_fixture_dirs() else {
+        eprintln!(
+            "real fixture Data.db binary absent (set CQLITE_DATASETS_ROOT + run \
+             fetch-datasets.sh) — skipping issue #2412 compressed cold/warm e2e"
+        );
+        return;
+    };
+    // Preconditions (never assumed): the real fixture ships a usable Summary.db
+    // (the shape a lazy BIG open, design §A, applies to) AND a CompressionInfo.db
+    // (proving this fixture genuinely takes the chunk-stitching decode branch —
+    // the whole point of this file, distinct from the sibling uncompressed test).
+    let summary_db = table_dir.join("nb-1-big-Summary.db");
+    assert!(
+        summary_db.is_file(),
+        "fixture precondition: the real table must ship a Summary.db"
+    );
+    let compression_info = table_dir.join("nb-1-big-CompressionInfo.db");
+    assert!(
+        compression_info.is_file(),
+        "fixture precondition: this table must be COMPRESSED (CompressionInfo.db \
+         present) — the whole point of this file is exercising the \
+         chunk-stitching decode branch the sibling (uncompressed) test cannot"
+    );
+
+    // Install the process-global in-memory meter BEFORE any parse in this process.
+    let mc = testing::metrics_capture();
+
+    let svc = CqliteFlightService::new(data_dir, 8192);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // ---- Cold do_get ----
+    mc.reset();
+    let cold_values = rt.block_on(do_get_sorted_values(&svc, ticket_bytes()));
+    let cold_parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    let opens_after_cold = svc.warm_metrics().reader_opens;
+
+    assert!(
+        !cold_values.is_empty(),
+        "cold do_get must resolve at least one row from the real compressed \
+         fixture (never a silent 0-rows-when-present pass)"
+    );
+    assert_eq!(
+        cold_parses, 0.0,
+        "cold do_get over a generation with a usable Summary.db must perform ZERO \
+         full Index.db parses (issue #2412 lazy open, spec Requirement 7), even \
+         over the compressed chunk-stitching decode branch; got {cold_parses}"
+    );
+    assert_eq!(
+        opens_after_cold, 1,
+        "cold do_get must open exactly the one generation once (real work \
+         happened — never a vacuous 0-open skip)"
+    );
+
+    // ---- Warm repeat do_get (same generation, unchanged) ----
+    mc.reset();
+    let warm_values = rt.block_on(do_get_sorted_values(&svc, ticket_bytes()));
+    let warm_parses = mc
+        .flush_and_collect()
+        .counter_sum(catalog::INDEX_PARSES_TOTAL);
+    let opens_after_warm = svc.warm_metrics().reader_opens;
+
+    assert_eq!(
+        warm_values, cold_values,
+        "warm repeat do_get must resolve the SAME rows as the cold request over \
+         the compressed chunk-stitching decode branch (query-semantics \
+         correctness, byte-identical across cold/warm)"
+    );
+    assert_eq!(
+        warm_parses, 0.0,
+        "warm repeat do_get must perform ZERO full Index.db parses over the \
+         unchanged compressed generation (spec Requirement 7); got {warm_parses}"
+    );
+    assert_eq!(
+        opens_after_warm, opens_after_cold,
+        "warm repeat do_get over the SAME compressed generation must perform \
+         ZERO further reader opens (the cached warm reader is reused, not \
+         re-opened); opens climbed from {opens_after_cold} to {opens_after_warm}"
+    );
+}

--- a/openspec/changes/lazy-summary-guided-index/design.md
+++ b/openspec/changes/lazy-summary-guided-index/design.md
@@ -1,0 +1,169 @@
+# Design — Lazy Summary-guided BIG partition index (#2412)
+
+This is the design for the "real fix (b)" of #2385: stop materializing the whole `Index.db` at BIG
+open; make open O(summary), point lookup O(log n + interval), scans summary-guided streaming, and
+resident memory ≈ summary only. BTI is already lazy and out of scope.
+
+## Context / measured anchors (in-tree, this worktree)
+- **Eager parse site:** `IndexReader::open_with_summary_cancellable`
+  (`cqlite-core/src/storage/sstable/index_reader/mod.rs`) does `File::open` → `read_to_end(&mut buffer)`
+  → `parse_index_data_cancellable` into `IndexData.partition_entries: Vec<PartitionIndexEntry>`. This is
+  the O(N) cold parse and the ~500MB-resident structure. Emits `cqlite.sstable.index_parses_total` once
+  per full pass (`index_reader/parse.rs`). `fully_parsed` records whether the whole file was consumed
+  (Signal A, #2302).
+- **Open wiring:** `SSTableReader::open` → `load_index_reader` (`reader/component_loading.rs`) →
+  `IndexLoadOutcome::{Loaded(Box<IndexReader>), Absent, PresentButUnloadable}`. The redundant legacy
+  `SSTableIndex` second parse was retired by #2385/#2395 (`load_index` Strategy 2 gone; Strategy 1
+  integrated-format is inert for real 5.0). `load_summary_reader` already loads `Summary.db` but only for
+  token-range iteration + the C5 range short-circuit — it does NOT guide `Index.db` access.
+- **`Summary.db` reader:** `SummaryReader` (`summary_reader.rs`) exposes `get_entries()` (sampled
+  key→`Index.db` position), `get_header()` (`min_index_interval`, `entries_count`), `get_first_key()` /
+  `get_last_key()`, `find_entry_for_position()`, `get_entry_at()`. It has **no find-by-key binary
+  search** today — that is the core new primitive.
+- **Point lookup:** `big_get_with_resolution` (`data_access/big_point.rs`) — fast path is the resident
+  raw-key `index_reader` map (O(1)); on soft-miss/absent it falls to the whole-file `scan_for_key`
+  oracle. The C5 first/last-key range short-circuit (`RANGE_SHORT_CIRCUITS`, from `Summary.db`) already
+  answers out-of-range point reads with zero probe work.
+- **Scan:** `iterate_all_partitions_via_full_index` (`data_access/full_index_scan.rs`) consumes
+  `index_reader.get_partition_entries()` (the whole materialized `Vec`) + `is_fully_parsed()`. The
+  streaming walk lives in `full_index_stream` (#2361), sharing one implementation with the materializing
+  walk, with a `(token, key)` order guard and cancel-aware `Drop` teardown.
+- **Warm registry:** `cqlite-flight/src/warm/` (`registry.rs`, `identity.rs`, `probe.rs`, `rebuild.rs`)
+  — `WarmTableRegistry` caches `Arc<SSTableReader>` keyed on inode-stable generation identity
+  (dev+ino+size+generation, #2383 rebind-by-inode), pinning the resident index for the process lifetime.
+- **Cassandra reference:** BIG `getPosition` = binary-search the summary sample + walk ≤
+  `min_index_interval` (`BigTableReader.java`); BTI `PartitionIndex.load` = read three longs + on-demand
+  trie DFS. CQLite's BTI path already mirrors the latter → lazy. Format spec:
+  `docs/sstables-definitive-guide/chapters/06-index-and-summary.md`.
+
+## A — Summary.db as the open-time structure (+ absent/corrupt posture)
+**Chosen: at BIG open, load `Summary.db` only and add a `find_by_key` binary search to `SummaryReader`.**
+The reader keeps a lazy `Index.db` accessor (path + platform + a cheap `[first_key, last_key]` bound
+already available) but performs **no full parse** at open. `index_data.partition_entries` is no longer
+materialized eagerly; the reader holds the summary + a handle to seek/parse `Index.db` intervals on
+demand. `Summary.db` is authoritative for sample key → `Index.db` position (little-endian position,
+#1054) and for `min_index_interval` (the walk bound).
+
+**Absent / corrupt `Summary.db` posture — RECOMMENDED: counted one-time linear `Index.db` scan (a
+distinct FellBack full parse), NOT a hard error.** Options considered:
+- **(A1, chosen) One-time linear `Index.db` scan, explicitly counted.** When `Summary.db` is absent or
+  fails to parse, fall back to a single full `Index.db` parse (today's behavior), recorded as a distinct
+  **full** parse in the work counters and surfaced via a `FellBack` reason (mirrors the existing
+  `full_index_stream` FellBack gating). This is NOT a heuristic — it reads authoritative `Index.db`
+  structure in full; it is simply the non-lazy path, made explicit and observable. Preserves correctness
+  for the shapes that legitimately ship without a `Summary.db` (or with a stale/rebuildable one), which
+  read fine today; a hard error would regress them.
+- **(A2, rejected) Hard error on absent `Summary.db`.** Too aggressive: `Summary.db` is optional/
+  rebuildable in Cassandra; erroring would break reads that work today. Reserve hard failure for the
+  genuinely unusable case (both `Summary.db` AND `Index.db` corrupt/truncated — already covered by the
+  existing corruption paths + `is_fully_parsed()` Signal A).
+- **(A3, rejected) Silent linear fallback (today, un-counted).** Rejected because the field rounds
+  (#2367) rely on the parse counters to prove laziness; an invisible full parse would mask a regression.
+
+## B — Point-lookup path (O(log n + interval))
+`big_get_with_resolution` gains a summary-guided fast path:
+1. C5 first/last-key short-circuit (unchanged) — out-of-range → authoritative absence, zero probe work.
+2. **Binary-search the summary** (`SummaryReader::find_by_key`) for the sample entry covering the query
+   key → an `Index.db` start position.
+3. **Read + parse ONE `Index.db` interval** (≤ `min_index_interval` entries) from that position, scanning
+   forward for the exact partition entry. Bounded work: index entries touched ≤ one summary interval.
+4. On an exact hit → resolve into `Data.db` as today. On a soft-miss within the interval (key genuinely
+   absent) → authoritative absent (the interval is complete between two summary samples), so the
+   whole-file `scan_for_key` oracle is **no longer required** for the common case — it is retained only
+   for the absent-`Summary.db` FellBack path and genuinely index-less readers, preserving #1572
+   correctness. The interval boundary is structural (two adjacent summary samples), not a guess.
+
+## C — Scan path (summary-guided streaming) + #2361 interplay
+Scans iterate `Index.db` forward from a summary-guided start offset without building the full map:
+- Default full scan: start at the summary's first sample (offset 0) and stream forward to EOF, feeding
+  the existing #2361 streaming walk (`full_index_stream`). The `(token, key)` order guard, fail-closed
+  FellBack gating, cancel-aware `Drop` teardown, and phase-active counter are preserved unchanged — this
+  design changes the *source* of entries (streamed from disk vs. read from a resident `Vec`), not the
+  walk contract.
+- `is_fully_parsed()` / Signal A (#2302) completeness semantics are preserved: a mid-entry-truncated
+  `Index.db` streamed to EOF must still be detectable as incomplete (the streaming walk already carries
+  the last-partition coverage check); the completeness signal moves from a post-parse buffer check to the
+  streaming terminus.
+
+## D — Warm-registry integration (memory accounting)
+The `WarmTableRegistry` (`cqlite-flight/src/warm/registry.rs`) continues to pin `Arc<SSTableReader>` per
+generation, but the pinned reader now holds **the summary + a lazy `Index.db` accessor**, not the full
+partition map. Effect:
+- Resident memory per warm generation drops from ~full-index (~500MB/gen at field scale) to ~summary
+  (O(n/128) sampled entries). The `warm/budget.rs` accounting and `warm/metrics.rs` gauges are updated to
+  reflect the summary-only footprint (the budget's per-generation cost estimate shrinks accordingly).
+- The #2383 inode-stable identity + rebind and the #2310 diff/swap eviction are unchanged: identity keys
+  on `(dev, ino, size, generation)`; a rebind swaps the backing path without re-parsing. Because open no
+  longer parses `Index.db`, the single-flight `OpenCoalescer` (#2383) now coalesces a much cheaper open;
+  the index-parse storm class it guarded against is structurally reduced (interval parses are per-lookup
+  and bounded, not whole-file).
+
+## E — The #2413 interplay (REQUIRED position; owner decides at Seam 1)
+#2413 pushes the split's token range into the per-SSTable partition walk (today the token filter is
+applied only downstream at `MergeProducer::drive_merge` via `token.contains`, so every scan decodes ALL
+partition bodies from ring start; `iterate_token_range` is a deprecated no-op).
+
+- **Option A (RECOMMENDED) — this change SUBSUMES #2413.** A range-bounded walk falls out of
+  summary-guided iteration naturally: binary-search the summary to the split's token-range **start**
+  sample, begin forward iteration there, and stop when entries pass the range **end**. Out-of-range
+  partition body reads never happen. #2413's flip criterion (`walked <= 4` for a single-partition
+  token-range warm scan) becomes a scenario of this change. Compaction consumers keep full-ring by NOT
+  supplying a range (the range is a query-serve split concern only), exactly as #2413 requires. The
+  FellBack (absent-`Summary.db`) path has no summary to binary-search → it stays a full walk (or a
+  linear range filter), explicitly adjudicated and counted — the same open question #2413 flags for
+  `sequential_scan`.
+- **Option B — #2413 lands standalone FIRST on the existing resident index; this change preserves its
+  pin.** #2413 binary-searches the (already token-ordered) resident index for the range start; then this
+  change rebuilds the same range-bounded walk on the summary-guided iterator, keeping #2413's pin green.
+
+**Recommendation: Option A.** #2412 redesigns the exact walk #2413 targets; landing #2413 first on the
+resident index that #2412 *removes* is parity-sensitive work thrown away, and the summary-guided iterator
+gives the range bound essentially for free (the same binary search that bounds a point lookup bounds a
+range scan). The one reason to prefer B is scheduling: #2412 is larger and Seam-1-gated under P1 field
+pressure, so if the token-pushdown win is needed before this design ships, B delivers it sooner. The
+owner weighs that tradeoff at Seam 1; the spec's range-scoped scan scenario reflects the recommended
+Option A and is the pin #2413 closes into.
+
+## F — Metrics: `index_parses_total` semantics (field rounds depend on this)
+`cqlite.sstable.index_parses_total` (catalog, #2383) today counts one **full** `Index.db` parse per
+generation. This change **extends, not breaks** its semantics:
+- **Full parses** (the FellBack absent-`Summary.db` path, §A1) continue to increment
+  `index_parses_total` — so a lazy-open regression (accidentally full-parsing) is still visible as the
+  counter climbing per generation, exactly as the field rounds (#2367) check.
+- **Interval parses** (the bounded per-lookup `Index.db` reads, §B) are counted by a NEW **distinct**
+  counter (`cqlite.sstable.index_interval_parses_total` — separate metric, added to the catalog) so
+  interval work is observable but never conflated with full parses. A cold lazy open of K generations
+  yields `index_parses_total += 0` (no full parse) and `index_interval_parses_total += 0` at open, then
+  `+= 1` per point lookup — the work-probe pin for AC1.
+- A scale-free work-probe (mirroring the #2383/#2385 pin style) asserts: lazy BIG open over an
+  N-partition generation performs **zero** full parses and touches **zero** `Index.db` entries at open;
+  a subsequent point read touches ≤ one `min_index_interval` of entries.
+
+## G — Rollout / compatibility
+- SSTables **with** `Summary.db` (the common case): lazy open, bounded lookups, summary-only resident.
+- SSTables **without** `Summary.db`: §A1 counted full-parse FellBack — same correctness as today,
+  explicitly observable. No behavior regression.
+- The public surfaces (`Database::query`/`get`, flight `do_get` cold+warm, CLI) are unchanged in
+  contract; the change is internal to `SSTableReader` open + the point/scan data-access paths + the flight
+  warm registry's memory accounting. Wiring evidence: an end-to-end flight `do_get` (cold + warm) asserts
+  correct rows AND the work-probe/memory-probe deltas.
+
+## Sequencing (one branch, staged)
+1. `SummaryReader::find_by_key` binary search + the lazy `Index.db` interval accessor (unit-pinned).
+2. Lazy BIG open: `IndexReader`/`load_index_reader` stop materializing the full map; open loads summary
+   only; §A1 FellBack path + counters. Work-probe pins AC1/AC5.
+3. Point lookup §B on the summary-guided interval; parity + `rows_scanned`-bound pins (AC2).
+4. Scan §C summary-guided streaming into the #2361 walk; physical-dump + query-semantics parity (AC3);
+   the Option-A range-scoped scan scenario / #2413 pin flip (AC3, contingent on Seam-1 choice).
+5. Warm-registry §D memory accounting + budget/metrics; resident-memory probe (AC4).
+6. Flight `do_get` cold+warm e2e wiring evidence (AC7).
+
+## Risks
+- **Parity regression on the point/scan rewrite** — mitigated by the physical-dump + query-semantics
+  oracles as the load-bearing net, and the `is_fully_parsed()`/Signal-A completeness semantics preserved.
+- **Interval-boundary correctness** (a partition straddling a summary sample) — the interval is
+  `[sample_i, sample_{i+1})` from authoritative summary positions; the forward walk within the interval
+  is exact. Pinned by a point read whose key sits at an interval boundary.
+- **Absent-`Summary.db` silent regression** — pre-empted by §A1's counted FellBack (never silent).
+- **#2413 double-work** if landed on the doomed resident index — the recommendation (Option A) avoids it;
+  the owner's Seam-1 call is explicit.

--- a/openspec/changes/lazy-summary-guided-index/proposal.md
+++ b/openspec/changes/lazy-summary-guided-index/proposal.md
@@ -1,0 +1,77 @@
+# Lazy Summary-guided partition index for BIG open (#2412)
+
+## Milestone
+0.15 — the cqlite-trino latency/throughput/operations theme (epic #2403, Lane 1).
+**Design-driven — OpenSpec + Seam 1 required before any implementation.** This is the "real fix (b)"
+from the owner-approved #2385 analysis; the stopgap "(a)" (kill the O(N²) build, retire the redundant
+second parse, capacity hints) already shipped in v0.14.1 (PR #2402). Oracle-driven correctness stays
+pinned by the existing physical-dump + query-semantics parity nets; this change redesigns *how the BIG
+partition index is opened and walked*, which is a structural/design decision, hence OpenSpec.
+
+## Problem (measured)
+BIG `SSTableReader::open` still **eagerly parses the ENTIRE `Index.db` into a resident in-memory index**.
+`IndexReader::open_with_summary_cancellable` does `file.read_to_end(..)` then parses every partition
+entry into `IndexData.partition_entries` (a `Vec`), which the reader pins for its whole lifetime:
+
+- **Cold open cost is linear per generation** — one full `Index.db` parse per generation on every cold
+  open (R10 field: 10.7s cold on 2 generations × ~1.96M partitions; the #2385 stopgap removed the
+  quadratic and the double parse but the O(N) parse and its resident map remain).
+- **~500MB resident per generation** at field scale (~1.58M partitions), pinned for the process lifetime
+  by the flight `WarmTableRegistry` (which caches `Arc<SSTableReader>` per generation, #2310). Warm-set
+  memory therefore scales with `Σ partitions across all warm generations`, not with the working set.
+
+Cassandra's own model is lazy and CQLite already matches it on ONE path: **BIG** open reloads the
+write-time `Summary.db` (O(n/128) sampled entries) and `getPosition` binary-searches the sample then
+walks ≤ one `min_index_interval` of `Index.db`; **BTI** open reads three longs from the file tail and
+walks the trie on demand. **CQLite's BTI path is already lazy** (flat byte load + on-demand trie DFS)
+and sidesteps this entirely — the BIG path is the outlier. `Summary.db` is already parsed today
+(`SummaryReader`, used for token-range iteration and the C5 first/last-key short-circuit) but is NOT yet
+used to guide `Index.db` access; it lacks a find-by-key search.
+
+## Goal
+Make the BIG partition index Cassandra-BIG-lazy:
+
+- **Open O(summary):** load `Summary.db` only (O(n/128) sampled entries). No `Index.db` scan at open.
+- **Point lookup O(log n + interval):** binary-search the summary → read + parse ONE `Index.db`
+  interval (≤ `min_index_interval` entries) → resolve the partition. `rows_scanned` (index entries
+  touched) bounded by one summary interval.
+- **Scans summary-guided streaming:** iterate `Index.db` forward from a summary-guided start offset,
+  never materializing the whole index; integrates with the #2361 streaming full-index walk and its
+  `(token, key)` order guard.
+- **Resident memory ≈ summary only:** the warm registry pins the summary (~sampled entries), not the
+  full partition map — restart survival then needs no on-disk cache serialization.
+
+## Non-goals
+- **No BTI (`da`/`oa`) changes.** BTI is already lazy; this change is BIG (`na`/`nb`) only.
+- **No cross-restart cache persistence / daemon posture.** Serializing parsed caches to disk to survive
+  restarts is **consciously rejected** (recorded on epic #2403): the chosen "no state recreation on
+  startup" strategy is to make *open cheap*, not to persist caches. Not pursued unless field data after
+  this fix demands it.
+- **No compaction semantics change.** Compaction consumers keep full-ring, non-range-scoped walks.
+- **No `Value` decode / comparator / ordering change** — byte-parity is inviolable.
+- **No pre-`na` format support** introduced or revisited (version floor unchanged).
+- **No change to the public `Database`/`QueryRow`/flight `do_get` result contract** — same rows, same
+  bytes; only how they are located changes.
+
+## The #2413 interplay (design MUST take a position — see design.md §E)
+#2413 (token-range pushdown into the per-SSTable partition walk, oracle-driven) redesigns the SAME walk
+this change owns. The design (§E) lays out both options and **recommends Option A (this change subsumes
+#2413)**: a range-bounded walk falls out of summary-guided forward iteration naturally (binary-search the
+summary to the split's range start; stop at range end). The owner decides at Seam 1. If Option B is
+chosen instead, #2413 lands standalone first on the existing resident index and this change preserves
+its range-pushdown pin.
+
+## Doctrine impact
+- **No-heuristics (#28) reinforced:** every offset/interval boundary comes from `Summary.db` /
+  `Index.db` structure — no guessed boundaries. Absent/corrupt `Summary.db` → a documented, **counted**
+  one-time linear `Index.db` scan (the authoritative full parse, recorded as a distinct FellBack full
+  parse), never a silent guess (design §A recommends this over a hard error).
+- CLAUDE.md / website `agents-developing/`: no doctrine text change; add a one-line note to the format
+  debugging / source-map page describing the lazy BIG open once implemented (in-change, per the
+  keep-doctrine-current rule).
+
+## Definition of done
+`scripts/agent-gate.sh` full PASS (SUMMARY recorded) + spec-auditor **C** PASS (every requirement
+`satisfied` with a public-surface test) + roborev clean; `RUSTFLAGS="-D warnings"` clean; no
+`unwrap()`/`expect()` in library code; physical-dump + query-semantics parity + flight `do_get` cold+warm
+e2e green. Then `openspec archive`.

--- a/openspec/changes/lazy-summary-guided-index/specs/lazy-big-partition-index/spec.md
+++ b/openspec/changes/lazy-summary-guided-index/specs/lazy-big-partition-index/spec.md
@@ -1,0 +1,164 @@
+# lazy-big-partition-index
+
+## ADDED Requirements
+
+### Requirement: BIG open loads only Summary.db and performs no full Index.db parse
+
+BIG-format `SSTableReader::open` SHALL load `Summary.db` (O(n/128) sampled entries) as its open-time
+partition-index structure and SHALL NOT parse the whole `Index.db` into a resident in-memory map. Open
+cost SHALL be O(summary): the number of `Index.db` entries touched at open SHALL be zero and the number
+of full `Index.db` parses at open SHALL be zero. This applies to `na`/`nb` BIG SSTables that ship a
+`Summary.db`; BTI (`da`/`oa`) is out of scope (already lazy).
+
+#### Scenario: Cold BIG open touches zero Index.db entries and performs zero full parses
+
+- **GIVEN** a BIG SSTable with a `Summary.db` and an N-partition `Index.db`, with the read-work counters
+  reset
+- **WHEN** `SSTableReader::open` completes a cold open of the generation
+- **THEN** the full-`Index.db`-parse counter (`cqlite.sstable.index_parses_total`) increments by 0 for
+  that open
+- **AND** the count of `Index.db` entries touched at open is 0 (scale-free: independent of N).
+
+#### Scenario: Open cost does not grow with partition count
+
+- **GIVEN** two BIG generations of the same shape differing only in partition count (small vs large)
+- **WHEN** each is cold-opened with work counters reset between opens
+- **THEN** both opens touch 0 `Index.db` entries and perform 0 full `Index.db` parses (the open-time work
+  is bounded by `Summary.db` size, not by partition count).
+
+### Requirement: Point lookup reads a single Summary-bounded Index.db interval
+
+A BIG point lookup (`WHERE pk = ?`) SHALL binary-search `Summary.db` for the sample covering the query
+key and SHALL read/parse at most one `Index.db` interval (≤ `min_index_interval` entries) to resolve the
+partition. The number of `Index.db` index entries touched by one point lookup SHALL be bounded by one
+summary interval. Results SHALL remain byte-identical to the sstabledump/JSONL goldens.
+
+#### Scenario: A present-key point read touches at most one summary interval of index entries
+
+- **GIVEN** a BIG SSTable with `Summary.db` and a partition key known present, work counters reset
+- **WHEN** the partition is fetched via the public read path
+- **THEN** the returned partition matches the physical-dump golden byte-for-byte
+- **AND** the count of `Index.db` index entries touched is ≤ `min_index_interval` (one summary interval),
+  not O(N).
+
+#### Scenario: An absent-key point read within range is authoritative from one interval
+
+- **GIVEN** a BIG SSTable with `Summary.db` and a partition key that is in `[first_key, last_key]` but
+  genuinely absent
+- **WHEN** the partition is fetched
+- **THEN** the read returns "not found" as an authoritative absence after touching ≤ one summary interval
+  of `Index.db` entries
+- **AND** it does not fall back to a whole-file `scan_for_key` of the generation.
+
+#### Scenario: A key at an interval boundary resolves correctly
+
+- **GIVEN** a partition key whose position sits at the boundary between two adjacent `Summary.db` samples
+- **WHEN** the partition is fetched
+- **THEN** the returned partition matches the physical-dump golden (the interval `[sample_i, sample_{i+1})`
+  is derived from authoritative summary positions, not guessed).
+
+### Requirement: Full and range scans stream via Summary-guided Index.db iteration
+
+BIG full scans SHALL iterate `Index.db` forward from a `Summary.db`-guided start offset without
+materializing the whole index, feeding the existing streaming full-index walk (its `(token, key)` order
+guard, fail-closed FellBack gating, and cancel-aware teardown preserved). A token-range-scoped query
+split SHALL begin iteration at the summary sample covering the range start and stop at the range end, so
+out-of-range partition bodies are never read (the recommended #2413 Option A; the exact posture is
+confirmed at Seam 1). Compaction consumers SHALL keep full-ring, non-range-scoped walks. Parity SHALL
+hold on both the physical-dump and query-semantics oracles.
+
+#### Scenario: A full scan streams the index and matches both parity oracles
+
+- **GIVEN** a BIG SSTable with `Summary.db`
+- **WHEN** a full scan enumerates every partition via the summary-guided streaming walk
+- **THEN** the enumerated cells match the physical-dump (`*-Data.db.jsonl`) golden
+- **AND** the post-reconciliation `SELECT` result at a pinned `now` matches the query-semantics oracle
+- **AND** the `(token, key)` order guard is not violated.
+
+#### Scenario: A token-range split reads only in-range partitions (#2413 pin flip)
+
+- **GIVEN** a BIG SSTable and a query split whose token range covers a single partition
+- **WHEN** the warm scan enumerates partitions for that split
+- **THEN** the number of partition bodies decoded is ≤ 4 (bounded by the in-range set + LIMIT), not the
+  whole-SSTable count
+- **AND** the returned rows match the physical-dump + query-semantics oracles.
+
+#### Scenario: Compaction still walks the full ring
+
+- **WHEN** a compaction consumer enumerates partitions from a BIG reader
+- **THEN** it walks every partition in the generation (no token range is applied to compaction
+  consumers) and existing compaction byte-parity tests stay green.
+
+### Requirement: Resident per-generation index memory is Summary-only
+
+A BIG reader retained by the flight `WarmTableRegistry` SHALL pin only the `Summary.db`-derived structure
+(O(n/128) sampled entries) plus a lazy `Index.db` accessor, NOT a full resident partition map. Resident
+index memory per warm generation SHALL be bounded by summary size, not by partition count.
+
+#### Scenario: Warm-held generation retains summary-only index memory
+
+- **GIVEN** a BIG generation held warm in the `WarmTableRegistry` after a `do_get`
+- **WHEN** its resident index footprint is measured (memory probe or dhat budget)
+- **THEN** the retained index memory is bounded by `Summary.db` size (O(n/128)), materially below the
+  full-index footprint the pre-change reader pinned
+- **AND** it does not scale linearly with the generation's partition count.
+
+### Requirement: Index-parse work counters distinguish interval parses from full parses
+
+The observability catalog SHALL preserve `cqlite.sstable.index_parses_total` as the count of **full**
+`Index.db` parses (so a lazy-open regression that full-parses is still visible as the counter climbing
+per generation) and SHALL add a **distinct** counter for bounded **interval** parses so per-lookup
+interval work is observable but never conflated with full parses. Both counters SHALL be registered and
+namespaced under `cqlite.`.
+
+#### Scenario: Lazy open reports zero full parses; interval work is counted separately
+
+- **GIVEN** a BIG SSTable with `Summary.db` and both counters reset
+- **WHEN** the generation is cold-opened and then one point lookup is performed
+- **THEN** `cqlite.sstable.index_parses_total` increments by 0 (no full parse at open or lookup)
+- **AND** the interval-parse counter increments by exactly 1 for the single lookup
+- **AND** both counter names are present in the catalog and start with `cqlite.`.
+
+### Requirement: All offsets and intervals derive from Summary.db/Index.db structure (no-heuristics)
+
+Every `Index.db` seek offset and interval boundary SHALL come from authoritative `Summary.db` sample
+positions and `Index.db` structure — never from guessed boundaries or byte-pattern inference. When
+`Summary.db` is absent or fails to parse, the reader SHALL fall back to a single, explicit, **counted**
+full `Index.db` parse (recorded as a full parse via `cqlite.sstable.index_parses_total` and surfaced as a
+FellBack reason) rather than a silent guess or a hard error, preserving today's correctness for shapes
+that ship without a usable `Summary.db`.
+
+#### Scenario: Absent Summary.db falls back to a counted full parse, not a guess
+
+- **GIVEN** a BIG SSTable whose `Summary.db` is absent (or present-but-unparseable), counters reset
+- **WHEN** the generation is opened and scanned end-to-end
+- **THEN** exactly one full `Index.db` parse occurs, `cqlite.sstable.index_parses_total` increments by 1,
+  and the FellBack reason is surfaced (not silent)
+- **AND** the enumerated cells still match the physical-dump golden (correctness preserved).
+
+#### Scenario: No offset is inferred from value bytes
+
+- **WHEN** any partition is located via the summary-guided path
+- **THEN** the seek offset and interval bounds are taken from `Summary.db` positions / `Index.db` entry
+  framing only, with no boundary inferred from partition or cell byte patterns.
+
+### Requirement: Exercised end-to-end through the flight do_get path (cold and warm)
+
+The lazy Summary-guided BIG index SHALL be exercised end-to-end through the flight `do_get` read path on
+both a cold first request and a warm repeat request, proving the wiring (a named surface + call chain +
+an end-to-end test), not helper-only unit coverage.
+
+#### Scenario: Cold do_get resolves rows with bounded open work
+
+- **GIVEN** a BIG-backed table served over flight with work counters reset
+- **WHEN** a cold `do_get` (`SELECT` returning known rows) is served
+- **THEN** the returned rows match the query-semantics oracle
+- **AND** the cold open performed 0 full `Index.db` parses (open work bounded by `Summary.db`).
+
+#### Scenario: Warm do_get reuses the summary-only reader
+
+- **GIVEN** the same table already held warm in the `WarmTableRegistry`
+- **WHEN** the `do_get` is repeated over the unchanged generation set
+- **THEN** the rows again match the query-semantics oracle
+- **AND** the warm request performs 0 reader-opens and 0 full `Index.db` parses over the unchanged
+  generations.

--- a/openspec/changes/lazy-summary-guided-index/tasks.md
+++ b/openspec/changes/lazy-summary-guided-index/tasks.md
@@ -31,11 +31,19 @@ implementation.
   Prove: 0.1 probe green + the counter-semantics scenario. (lazy-big-partition-index)
 
 ## Stage 3 — point lookup (§B)
-- [ ] 3.1 `big_get_with_resolution` (`data_access/big_point.rs`): after the C5 short-circuit, binary-
+- [x] 3.1 `big_get_with_resolution` (`data_access/big_point.rs`): after the C5 short-circuit, binary-
   search the summary → read ONE `Index.db` interval → resolve. Within-range absent = authoritative (no
   whole-file `scan_for_key`). Interval-parse counter increments once/lookup. (lazy-big-partition-index)
-- [ ] 3.2 Prove: present-key + within-range-absent + interval-boundary point reads match physical-dump
-  goldens with `Index.db` entries touched ≤ one interval. (lazy-big-partition-index)
+  Routed via `lookup_partition_with_index` → new `reader/summary_point.rs`
+  (`should_use_summary_interval` + `lookup_partition_via_summary_interval`); the authoritative-absence
+  claim is gated on an END-BOUNDED interval (`covering_interval_is_end_bounded`) so a tail-truncated
+  `Index.db` (the #1572 class, whose dropped entries live in the last read-to-EOF interval) keeps the
+  scan fallback.
+- [x] 3.2 Prove: present-key + within-range-absent + interval-boundary point reads with `Index.db`
+  entries touched ≤ one interval — `tests/issue_2412_point_interval.rs` (public `get()` surface, work
+  probes: interval-parse == 1, full-parse == 0, no `scan_for_key` on the authoritative-absent path).
+  Byte-identical goldens covered by the query-semantics + sstabledump parity oracles.
+  (lazy-big-partition-index)
 
 ## Stage 4 — scans (§C) + #2413 posture (per Seam-1 choice)
 - [ ] 4.1 Summary-guided forward iteration feeding the #2361 streaming walk (`full_index_stream`);

--- a/openspec/changes/lazy-summary-guided-index/tasks.md
+++ b/openspec/changes/lazy-summary-guided-index/tasks.md
@@ -1,0 +1,70 @@
+# Tasks — Lazy Summary-guided BIG partition index (#2412)
+
+One branch `issue-2412-lazy-summary-guided-index`, staged commits. Each task names the surface it
+exercises and carries a red-then-green test (scale-free work/memory probes in the #2383/#2385 pin style).
+Anchors are `main`-relative and will drift; re-grep before editing. Seam 1 (owner approval of proposal +
+design, incl. the §A absent-Summary posture and the §E #2413 interplay choice) precedes all
+implementation.
+
+## Stage 0 — probes first (must fail on main)
+- [ ] 0.1 Add a scale-free work-probe: cold BIG open touches 0 `Index.db` entries + 0 full parses
+  (fails today — open full-parses). Surface: `SSTableReader::open` + read-work counters.
+  (lazy-big-partition-index)
+- [ ] 0.2 Add the interval-parse counter to the observability catalog
+  (`cqlite.sstable.index_interval_parses_total`) alongside `cqlite.sstable.index_parses_total`; catalog
+  registration/namespacing test. (lazy-big-partition-index)
+- [ ] 0.3 Add a resident-memory probe/dhat budget for a warm-held generation (fails today — full map
+  pinned). Surface: `WarmTableRegistry`. (lazy-big-partition-index)
+
+## Stage 1 — Summary find-by-key primitive
+- [ ] 1.1 Add `SummaryReader::find_by_key` (binary search over sampled keys → `Index.db` start position)
+  + a lazy `Index.db` interval accessor (seek + parse ≤ `min_index_interval` entries). Unit-pinned
+  against a real BIG `Summary.db`/`Index.db`. Surface: `SummaryReader` (`summary_reader.rs`).
+  (lazy-big-partition-index)
+
+## Stage 2 — lazy BIG open (§A)
+- [ ] 2.1 Stop materializing `IndexData.partition_entries` at open; `IndexReader` /
+  `load_index_reader` (`reader/component_loading.rs`, `index_reader/mod.rs`) hold the summary + a lazy
+  `Index.db` accessor. Open loads `Summary.db` only. (lazy-big-partition-index)
+- [ ] 2.2 §A1 absent/corrupt-`Summary.db` FellBack: one counted full `Index.db` parse (increments
+  `index_parses_total`, surfaces a FellBack reason); preserve `is_fully_parsed()`/Signal-A completeness.
+  Prove: 0.1 probe green + the counter-semantics scenario. (lazy-big-partition-index)
+
+## Stage 3 — point lookup (§B)
+- [ ] 3.1 `big_get_with_resolution` (`data_access/big_point.rs`): after the C5 short-circuit, binary-
+  search the summary → read ONE `Index.db` interval → resolve. Within-range absent = authoritative (no
+  whole-file `scan_for_key`). Interval-parse counter increments once/lookup. (lazy-big-partition-index)
+- [ ] 3.2 Prove: present-key + within-range-absent + interval-boundary point reads match physical-dump
+  goldens with `Index.db` entries touched ≤ one interval. (lazy-big-partition-index)
+
+## Stage 4 — scans (§C) + #2413 posture (per Seam-1 choice)
+- [ ] 4.1 Summary-guided forward iteration feeding the #2361 streaming walk (`full_index_stream`);
+  preserve the `(token, key)` order guard, FellBack gating, cancel-aware teardown, and Signal-A terminus.
+  `iterate_all_partitions_via_full_index` no longer consumes a resident `Vec`. (lazy-big-partition-index)
+- [ ] 4.2 Option A (recommended): range-scoped split begins at the summary sample covering the range
+  start, stops at range end; flip the #2413 pin (`walked <= 4` single-partition warm scan). Compaction
+  consumers keep full-ring (no range). FellBack (no summary) posture explicitly adjudicated + counted.
+  Prove: physical-dump + query-semantics oracles + compaction byte-parity. (lazy-big-partition-index)
+
+## Stage 5 — warm-registry memory (§D)
+- [ ] 5.1 `WarmTableRegistry` pins summary-only; update `warm/budget.rs` per-generation cost estimate +
+  `warm/metrics.rs` gauges; keep #2383 inode identity/rebind + #2310 diff/swap eviction. Prove: 0.3
+  resident-memory probe green (summary-only footprint). (lazy-big-partition-index)
+
+## Stage 6 — wiring evidence (§G, AC7)
+- [ ] 6.1 Flight `do_get` cold + warm e2e: cold resolves rows (query-semantics oracle) with 0 full
+  parses; warm repeat = 0 reader-opens + 0 full parses over unchanged generations. Surface: flight
+  `do_get` / `producer_warm`. (lazy-big-partition-index)
+- [ ] 6.2 Doctrine: one-line note on the lazy BIG open to the format-debugging / source-map
+  `agents-developing/` page + any dev-cookbook pointer (keep-doctrine-current rule).
+
+## Stage 7 — endgame (definition of done)
+- [ ] 7.1 `--lite` (summary-file redirect) each fix round; blast-radius targets + diff-relevant
+  parity/integration targets.
+- [ ] 7.2 rust-reviewer + roborev on the lite-green diff (review-first); fix blockers → re-lite +
+  re-review; batch nits into ONE follow-up issue at merge.
+- [ ] 7.3 Open PR. `flow-closer`: FULL `scripts/agent-gate.sh` ONCE → PASS (record SUMMARY); spec-auditor
+  **C** anchored to `openspec/changes/lazy-summary-guided-index/specs/**` → PASS; final roborev clean;
+  merge-on-green (`gh pr merge --squash --delete-branch`); `flow-finalize` (close #2412, telemetry).
+- [ ] 7.4 If Seam 1 chose Option A, close #2413 into this change; if Option B, keep #2413 open with its
+  pin preserved. `openspec archive lazy-summary-guided-index`.


### PR DESCRIPTION
Closes #2412. Closes #2413 (Option A: token pushdown subsumed — pin `walked <= 4` flipped here).

OpenSpec change: `lazy-summary-guided-index` (7 requirements / 15 scenarios, owner-approved Seam 1).

## What (6 stages)
1. **summary_reader split** (`summary_reader/{mod,interval}.rs`) — `find_by_key`, new `cqlite.sstable.index_interval_parses_total` counter (`index_parses_total` stays full-parse-only).
2. **Lazy open** — `IndexReader::open_lazy` + `ensure_materialized` (`index_reader/lazy.rs`): BIG open is O(summary); full Index.db parse only on demand; absent Summary.db → counted FellBack full parse (fail-closed posture).
3. **Summary-guided point lookup** (`reader/summary_point.rs`) — one interval parse per point read; authoritative absence ONLY on end-bounded intervals (tail keeps `scan_for_key` fallback).
4. **Summary-guided streaming scans** (`index_reader/stream.rs`, `data_access/summary_scan.rs`) + #2413 token pushdown; also removed a redundant per-partition re-probe on the streaming full-scan path (materializing sibling filed as #2430).
5. **Warm registry pins summary-only memory** + #2343 budget accounting (resident/gen drops to O(n/128)).
6. **Flight e2e wiring evidence** (`issue_2412_do_get_cold_warm_e2e.rs`): cold do_get = 0 full parses + 1 reader open; warm repeat = 0 parses + 0 opens; byte-identical rows. Red-then-green verified.

## Review trail (review-first, #2086) — 3 rounds
- **Round 1 (convergent HIGH, data-loss class)**: roborev job 1709 AND rust-reviewer independently found `interval_entry_cap` assumed full sampling — a downsampled Summary.db (sampling_level<128) could under-scan an interval and return FALSE authoritative absence for a present key. Fixed `68b42058`: end-bounded intervals scan the full [start,end) byte range uncapped; read-to-EOF interval keeps a sampling-adjusted cap (`min_index_interval*128/sampling_level`, clamped, from the parsed header — no heuristics). 4 red-then-green pins. Also registered `INDEX_INTERVAL_PARSES_TOTAL` in the OTel instrument struct (was rebuilding an instrument per point lookup).
- **Round 2 (scoped re-review)**: fix verified clean (formula overflow/div-zero, fail-closed reads, authoritative-absence gate unchanged, pins genuinely red). Surfaced corrupt-input hardening:
- **Round 3** (`15b59812`): bounded-read length validated against Index.db metadata length BEFORE allocation (corrupt `end` → clean Err, never an alloc-abort through FFI — fuzz doctrine #1614); non-monotone `end<=start` samples fail closed (corrupt input can no longer re-open authoritative absence). 2 red-then-green pins.
- Adversarially clean elsewhere: scan seams/token ties, cancel single-flight (`OnceCell::get_or_try_init`), #2383/#2370 test re-anchors legitimate (still red on original bugs).

## Test evidence
Core lib 0 failed; flight lib 264/264; `query_semantics_oracle_parity` 3/3 at tip; `sstabledump_parity_{data,summary,index}`; `issue_2412_{point_interval,interval_parse_counter,lazy_big_open,do_get_cold_warm_e2e}`; `issue_2398_warm_scan_token_pushdown` (walked<=4); `issue_2383_resolve_spin_test` + `issue_2370_single_flight_test` re-anchored on `reader_opens`.

Full gate of record: flow-closer pre-merge. Field expectation: cold first-query index cost drops from O(full Index.db parse) (#2385(b)) to O(summary); warm memory O(n/128).