### PR TITLE
docs(#2433): merge-on-green is now GitHub-enforced — required check + enforce_admins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,8 +345,12 @@ end-to-end test. Green helper-only unit tests are not sufficient.
 
 - The lead acts as product manager: track epics and issues, prioritize, keep work moving.
 - **Autonomy — auto-merge on green (default)**: workers (and the lead) **merge their own PR** the
-  moment the quality bar is met — gate PASS + **C** PASS (design-driven) + roborev clean — via
-  `gh pr merge --squash --delete-branch`, then `flow-finalize`. Do NOT wait for the owner. Seam 1
+  moment the quality bar is met — local gate PASS + **C** PASS (design-driven) + roborev clean **+ the
+  GitHub `required` CI check green** — via `gh pr merge --squash --delete-branch`, then `flow-finalize`.
+  Branch protection enforces the `required` check for admins too (`enforce_admins`), so bypass is
+  impossible; a known-flake red gets `gh run rerun --failed`, never a bypass. This enforcement is
+  load-bearing: if branch-protection settings change, this doc governs catching it (#2433). Do NOT
+  wait for the owner. Seam 1
   (spec approval) is the only standing human gate. Escalate and **hold the merge** ONLY for: a
   genuine design-call roborev finding, a scope/product question, an unmet/uncovered requirement, or
   work outside the issue — and obey any `HOLD: merge after #N` order.

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -70,6 +70,17 @@ required-check set. `flow-finalize` runs on the merge event (not a CI busy-wait)
 valid for genuinely external, harness-untracked state — just not for polling a PR's own CI after the work
 is complete.
 
+### GitHub-enforced merge gate (#2433)
+
+`main` now carries **full branch protection**: the `required` status check (the "Required PR Gate" CI
+workflow) is a required context, with `enforce_admins` on. Merge-on-green is therefore
+**local gate PASS + C (design) + roborev clean *and* the GitHub `required` check green** — the last term
+is machine-enforced, not honor-system. Because `enforce_admins` is enabled, even `gh pr merge --admin`
+is refused while the check is pending or red (proven on probe PR #2441: plain and `--admin` merges both
+rejected with `mergeStateStatus: BLOCKED`), so **there is no bypass**. A red that is a known flake gets
+`gh run rerun --failed` — never an admin override. This is load-bearing: if branch-protection settings
+ever regress (contexts emptied, `enforce_admins` disabled), this doctrine governs catching it.
+
 ## The specialist roster
 
 | Role | Agent / tool |


### PR DESCRIPTION
Closes #2433.

AC3 doctrine note for the branch-protection change (owner-approved full enforcement, applied 2026-07-14):
- `required_status_checks`: contexts=[`required`], strict=false
- `enforce_admins`: enabled — fleet merges as admin, so this is what makes the check real

AC1 (settings) done in repo settings; AC2 (enforcement proof) on the issue: probe PR #2441 — plain merge refused, `--admin` refused, `mergeStateStatus: BLOCKED`.

This PR: CLAUDE.md autonomy bullet (+ CI-green clause, no-bypass rule, load-bearing note) + website `agents-developing/delivery-pipeline` "GitHub-enforced merge gate (#2433)" subsection. Docs-only, 17 lines.