### PR TITLE
perf(#2430): materializing full-index scan — use loaded entry offsets, drop O(N) per-partition re-probe

### DIFF
--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -213,6 +213,17 @@ struct Counters {
     /// once (the pre-L1 window path resolved it twice — once directly, once inside
     /// `iterate_rows_for_partition`).
     rows_db_entry_resolves: AtomicU64,
+    /// Partitions resolved from an already-loaded `Index.db` entry on the
+    /// MATERIALISING full-index walk (`INDEX_BACKED_PARTITIONS_RESOLVED`, Issue
+    /// #2430) — one per partition `iterate_all_partitions_via_full_index` resolves
+    /// directly from `entries[i].data_offset`, WITHOUT a `lookup_partition_with_index`
+    /// re-probe. This is the surviving discriminator for "the index-backed
+    /// materialising path was genuinely taken, not a silent `sequential_scan`
+    /// fallback" (issue #2302's `written_summary_index_pair_resolves_via_index_probes`
+    /// / `fully_shadowed_partition_keeps_index_path`): after #2430 removed the
+    /// redundant per-partition probe, `index_probes` reads 0 on this path even when
+    /// it fully resolves, so those two tests' oracle moved here.
+    index_backed_partitions_resolved: AtomicU64,
 }
 
 #[cfg(any(test, feature = "work-counters"))]
@@ -235,6 +246,7 @@ impl Counters {
             key_hash_calls: AtomicU64::new(0),
             range_short_circuits: AtomicU64::new(0),
             rows_db_entry_resolves: AtomicU64::new(0),
+            index_backed_partitions_resolved: AtomicU64::new(0),
         }
     }
 
@@ -303,6 +315,11 @@ impl Counters {
         self.rows_db_entry_resolves.fetch_add(1, Ordering::Relaxed);
     }
 
+    fn record_index_backed_partition_resolved(&self) {
+        self.index_backed_partitions_resolved
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
     fn trie_walks(&self) -> u64 {
         self.trie_walks.load(Ordering::Relaxed)
     }
@@ -367,6 +384,11 @@ impl Counters {
         self.rows_db_entry_resolves.load(Ordering::Relaxed)
     }
 
+    fn index_backed_partitions_resolved(&self) -> u64 {
+        self.index_backed_partitions_resolved
+            .load(Ordering::Relaxed)
+    }
+
     fn reset(&self) {
         self.trie_walks.store(0, Ordering::Relaxed);
         self.decompress_calls.store(0, Ordering::Relaxed);
@@ -384,6 +406,8 @@ impl Counters {
         self.key_hash_calls.store(0, Ordering::Relaxed);
         self.range_short_circuits.store(0, Ordering::Relaxed);
         self.rows_db_entry_resolves.store(0, Ordering::Relaxed);
+        self.index_backed_partitions_resolved
+            .store(0, Ordering::Relaxed);
     }
 }
 
@@ -602,6 +626,22 @@ pub fn record_rows_db_entry_resolve() {
     COUNTERS.record_rows_db_entry_resolve();
 }
 
+/// Record one partition resolved from an already-loaded `Index.db` entry on the
+/// MATERIALISING full-index walk (`INDEX_BACKED_PARTITIONS_RESOLVED`; issue #2430).
+///
+/// Called unconditionally at the single per-partition offset-resolution site in
+/// [`iterate_all_partitions_via_full_index`](super::reader::SSTableReader::iterate_all_partitions_via_full_index),
+/// once `entries[i].data_offset` is used directly (no `lookup_partition_with_index`
+/// re-probe); the body compiles to a no-op in a release build (design.md Decision 1).
+/// This is the surviving non-vacuous "index path was genuinely taken" signal for
+/// issue #2302's written-index-resolve guards, since #2430 removed the redundant
+/// per-partition `INDEX_PROBES` increment on this specific path.
+#[inline(always)]
+pub fn record_index_backed_partition_resolved() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_index_backed_partition_resolved();
+}
+
 /// Number of BTI trie descents since the last [`reset`] (`TRIE_WALKS`).
 #[cfg(any(test, feature = "work-counters"))]
 pub fn trie_walks() -> u64 {
@@ -709,6 +749,14 @@ pub fn range_short_circuits() -> u64 {
 #[cfg(any(test, feature = "work-counters"))]
 pub fn rows_db_entry_resolves() -> u64 {
     COUNTERS.rows_db_entry_resolves()
+}
+
+/// Number of partitions resolved from an already-loaded `Index.db` entry on the
+/// materialising full-index walk since the last [`reset`]
+/// (`INDEX_BACKED_PARTITIONS_RESOLVED`, Issue #2430).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn index_backed_partitions_resolved() -> u64 {
+    COUNTERS.index_backed_partitions_resolved()
 }
 
 /// Clear all four process-global counters. Integration tests call this before a
@@ -836,6 +884,11 @@ mod tests {
         for _ in 0..16 {
             c.record_rows_db_entry_resolve();
         }
+        // Issue #2430 index-backed-resolved counter: multiplicity 17, distinct
+        // from every sibling so a mis-wired getter/field cross-up is caught.
+        for _ in 0..17 {
+            c.record_index_backed_partition_resolved();
+        }
 
         assert_eq!(c.trie_walks(), 1);
         assert_eq!(c.decompress_calls(), 2);
@@ -853,6 +906,7 @@ mod tests {
         assert_eq!(c.key_hash_calls(), 14);
         assert_eq!(c.range_short_circuits(), 15);
         assert_eq!(c.rows_db_entry_resolves(), 16);
+        assert_eq!(c.index_backed_partitions_resolved(), 17);
 
         c.reset();
         assert_eq!(c.trie_walks(), 0);
@@ -871,6 +925,7 @@ mod tests {
         assert_eq!(c.key_hash_calls(), 0);
         assert_eq!(c.range_short_circuits(), 0);
         assert_eq!(c.rows_db_entry_resolves(), 0);
+        assert_eq!(c.index_backed_partitions_resolved(), 0);
     }
 
     // The fd high-water helper returns a positive count on the supported platforms

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -1,6 +1,15 @@
 //! Cfg-gated read-work counters for the read-path optimization program
 //! (Issue #1566, Epic A / A5).
 //!
+//! File-size note (issue #2430, campsite rule): this file was already over the
+//! ~800-line source target on `main` (890 lines) before #2430 added
+//! `index_backed_partitions_resolved` (+55 lines) — a single new counter in an
+//! already cohesive, single-responsibility registry (one `Counters` struct +
+//! `record_*`/getter free-function pairs). Splitting this file by counter group
+//! is a larger, out-of-scope refactor tracked under epic #1116 (source-file
+//! campsite backlog); not undertaken here. `CQLITE_ALLOW_FILE_GROWTH=1`
+//! acknowledged for this change.
+//!
 //! # Why this exists
 //!
 //! The July 2026 read-path audit (`docs/reports/read-path-performance-audit-2026-07-01.md`

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -585,16 +585,21 @@ async fn two_concurrent_scans_on_shared_reader_cancel_independently() {
 /// way, so the callback-based "trip at partition N" technique the other tests
 /// use does not apply here.
 ///
-/// This proves the loop's poll instead via the process-global
-/// `read_work_counters::index_probes()` counter (same oracle technique as
-/// `chunk_cache_wiring_tests.rs`): a pre-cancelled call over a REAL fixture with
-/// at least one Summary.db entry must record ZERO Index.db probes — proving the
-/// poll aborts BEFORE the loop attempts even the FIRST lookup. Disabling ONLY
-/// this poll lets `lookup_partition_with_index` run for entry 0 (recording a
-/// probe) before the function falls through to `sequential_scan`'s (unrelated,
-/// pre-existing) poll for the SAME final `Err(Cancelled)` — so the probe-count
-/// assertion, not the `Err` alone, discriminates this specific poll from the
-/// downstream fallback's. `#[serial]`: the counter is process-global.
+/// This proves the loop's poll via the per-partition BODY-DECODE work-probe
+/// (`stream_walk_partitions_parsed`), read through a thread-local
+/// `StreamWalkScope` (issue #2428): a pre-cancelled call over a REAL fixture with
+/// at least one Summary.db entry must decode ZERO partition bodies — proving the
+/// poll aborts BEFORE the loop reaches its first per-partition decode. Disabling
+/// ONLY this poll lets the loop decode partition bodies (a nonzero count) before
+/// the function returns the SAME final `Err(Cancelled)` — so the body-decode
+/// count, not the `Err` alone, discriminates this specific poll.
+///
+/// Issue #2430 migrated this oracle OFF `read_work_counters::index_probes()`: the
+/// materialising walk previously re-probed the index once per partition
+/// (`lookup_partition_with_index`), and that redundant probe was what the old
+/// oracle counted. The fix resolves each partition offset from the already-loaded
+/// `Index.db` entry and never re-probes, so `index_probes` is 0 on the fixed path
+/// — the body-decode work-probe is the surviving non-vacuous signal.
 fn datasets_root() -> Option<std::path::PathBuf> {
     std::env::var("CQLITE_DATASETS_ROOT")
         .ok()
@@ -633,9 +638,15 @@ fn real_index_backed_fixture() -> Option<std::path::PathBuf> {
 /// Skip (not fail) when the real fixture binary is absent — matches the
 /// established convention (`issue_1594_fanout_deadlock_test.rs` et al.) for
 /// tests needing `CQLITE_DATASETS_ROOT`'s local-only binaries.
-#[tokio::test(flavor = "multi_thread")]
-#[serial_test::serial]
+// Current-thread runtime (issue #2430): the non-vacuity/cancel oracle now bounds
+// on `stream_walk_partitions_parsed` via a THREAD-LOCAL `StreamWalkScope` (issue
+// #2428), which only observes increments on the thread that opened it. A default
+// (current-thread) `#[tokio::test]` drives every inline `.await` of the scan on the
+// test's own thread, so the scope sees exactly this scan's per-partition decodes and
+// is immune to concurrent scan-driving tests — no `#[serial]`, no global reset.
+#[tokio::test]
 async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
+    use crate::storage::sstable::work_counters::stream_walk_scope::StreamWalkScope;
     let Some(data_path) = real_index_backed_fixture() else {
         eprintln!(
             "Skipping (index-backed cancel poll): real multi_partition_table \
@@ -648,11 +659,10 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
     // ------------------------------------------------------------------
     // Guard 1 (structural): the reader must actually hold BOTH an
     // `index_reader` and a non-empty `summary_reader`, or the index-backed
-    // `if let Some(summary_reader)` loop in `iterate_all_partitions` is never
-    // entered and the whole call falls through to `sequential_scan` — a path
-    // with its OWN (pre-existing, unrelated) poll. Without this, the fixture
-    // could satisfy the test vacuously via the fallback, recording zero probes
-    // whether or not THIS poll exists.
+    // full-index walk in `iterate_all_partitions` is never entered and the whole
+    // call falls through to `sequential_scan` — a path with its OWN (pre-existing,
+    // unrelated) poll. Without this, the fixture could satisfy the test vacuously
+    // via the fallback.
     let entry_count = reader
         .summary_reader
         .as_ref()
@@ -669,49 +679,59 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
     );
 
     // ------------------------------------------------------------------
-    // Guard 2 (behavioural, the real fail-if-vacuous check): an UNCANCELLED
-    // pass over this exact fixture must record index probes > 0. Each iteration
-    // of the index-backed loop calls `lookup_partition_with_index`, which
-    // records exactly one probe per real Index.db lookup. A nonzero count here
-    // proves the per-entry loop body — the one guarded by the poll under test —
-    // is genuinely executed for this fixture (it does not silently resolve via
-    // the sequential-scan fallback with zero probes). If a future fixture/refactor
+    // Guard 2 (behavioural, the real fail-if-vacuous check — migrated off the
+    // per-partition index-PROBE count, issue #2430). Directly exercise the method
+    // under test with a FRESH (uncancelled) token: it must FULLY resolve this real
+    // fixture through the index-backed materialising branch (`Ok(Some(rows))`, not
+    // the sequential fallback's `None`) AND decode > 0 partition bodies — the exact
+    // per-partition work the cancel poll below guards. If a future fixture/refactor
     // stopped exercising the index-backed branch, THIS assertion fails, so the
-    // pre-cancelled assertion below can never pass vacuously.
-    crate::storage::sstable::read_work_counters::reset();
+    // pre-cancelled assertion below can never pass vacuously. The signal is
+    // `stream_walk_partitions_parsed` (partition BODIES decoded), NOT `index_probes`
+    // — after issue #2430 the loop resolves each offset from the already-loaded
+    // entry and never re-probes the index, so `index_probes` is 0 even here.
     let uncancelled = open_reader(&data_path).await;
-    let uncancelled_result = uncancelled.iterate_all_partitions().await;
+    let fresh = ScanCancel::new();
+    let scope = StreamWalkScope::new();
+    let uncancelled_result = uncancelled
+        .iterate_all_partitions_via_full_index(&fresh)
+        .await;
+    let uncancelled_parsed = scope.count();
+    drop(scope);
     assert!(
-        uncancelled_result.is_ok(),
-        "the uncancelled index-backed scan must succeed: {uncancelled_result:?}"
+        matches!(uncancelled_result, Ok(Some(_))),
+        "the index-backed materialising branch must FULLY resolve this real fixture \
+         (Ok(Some(_)), not a fall-through to sequential_scan): {uncancelled_result:?}"
     );
-    let uncancelled_probes = crate::storage::sstable::read_work_counters::index_probes();
     assert!(
-        uncancelled_probes > 0,
-        "the index-backed branch must be exercised — an uncancelled scan over this \
-         fixture recorded zero Index.db probes, meaning the loop this test targets is \
-         never entered (the test would pass vacuously). Got {uncancelled_probes}"
+        uncancelled_parsed > 0,
+        "the index-backed loop must decode > 0 partition bodies — a zero count means \
+         the loop this test targets never ran (the test would pass vacuously). \
+         Got {uncancelled_parsed}"
     );
 
     // ------------------------------------------------------------------
-    // The actual assertion: a pre-cancelled scan must record ZERO probes —
-    // the poll aborts BEFORE the loop attempts even the first Index.db lookup.
-    crate::storage::sstable::read_work_counters::reset();
+    // The actual assertion: a pre-cancelled scan must decode ZERO partition
+    // bodies — the poll aborts BEFORE the loop reaches even the first per-partition
+    // decode. Disabling the poll would let the loop parse partition bodies here,
+    // driving the count nonzero and failing this assertion (it discriminates).
     let cancel = ScanCancel::new();
     cancel.cancel();
     reader.set_scan_cancel(cancel);
 
+    let scope = StreamWalkScope::new();
     let result = reader.iterate_all_partitions().await;
+    let cancelled_parsed = scope.count();
+    drop(scope);
 
     assert!(
         matches!(result, Err(crate::Error::Cancelled)),
         "a pre-cancelled index-backed scan must abort with Error::Cancelled, got {result:?}"
     );
     assert_eq!(
-        crate::storage::sstable::read_work_counters::index_probes(),
-        0,
-        "the index-backed loop's poll must abort BEFORE attempting even the first \
-         Index.db lookup — a nonzero probe count means the loop ran ahead of the \
-         cancel check (issue #2264, roborev round 3)"
+        cancelled_parsed, 0,
+        "the index-backed loop's poll must abort BEFORE decoding even the first \
+         partition body — a nonzero count means the loop ran ahead of the cancel \
+         check (issue #2264, roborev round 3; oracle migrated in #2430)"
     );
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -735,3 +735,78 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
          check (issue #2264, roborev round 3; oracle migrated in #2430)"
     );
 }
+
+/// Issue #2430: a full MATERIALISING scan must NOT re-probe the `Index.db` once
+/// per partition. The loop already holds every partition's `data_offset` from the
+/// up-front `get_partition_entries()` load, so it resolves each offset directly
+/// from `entries[i]` — a fresh `lookup_partition_with_index` per partition (which,
+/// post-#2412, is a Summary binary search + interval read) is pure redundant work.
+///
+/// The direct on-disk measure of that redundancy is the per-partition index-PROBE
+/// count (`read_work_counters::index_probes`): before the fix it was EXACTLY the
+/// partition count `N` (one probe per entry); after the fix it is `0` — bounded by
+/// a constant, not by `N`. This is the red-then-green pin: it FAILS (records `N`
+/// probes) against the pre-#2430 materialising walk and PASSES (`0`) after.
+///
+/// `#[serial_test::serial]`: `index_probes` is a process-global counter read after
+/// a `reset()`, so this test must not run concurrently with another scan-driving
+/// test in the same binary.
+#[tokio::test]
+#[serial_test::serial]
+async fn full_materializing_scan_does_not_reprobe_index_per_partition() {
+    let Some(data_path) = real_index_backed_fixture() else {
+        eprintln!(
+            "Skipping (materializing reprobe bound): real multi_partition_table \
+             fixture not present (set CQLITE_DATASETS_ROOT)"
+        );
+        return;
+    };
+    let reader = open_reader(&data_path).await;
+
+    // Measure the index-probe work of ONE full materialising index-backed scan.
+    // (The scan internally `ensure_materialized`s the lazily-opened index, so the
+    // partition count below is read AFTER, once entries are resident.)
+    crate::storage::sstable::read_work_counters::reset();
+    let cancel = ScanCancel::new();
+    let result = reader.iterate_all_partitions_via_full_index(&cancel).await;
+    let probes = crate::storage::sstable::read_work_counters::index_probes();
+
+    // The scan must resolve fully through the index branch (not fall through to
+    // sequential_scan), else the probe count would be vacuously 0 for the wrong
+    // reason.
+    let rows = match result {
+        Ok(Some(rows)) => rows,
+        other => panic!(
+            "the materialising index-backed scan must fully resolve this real \
+             fixture (Ok(Some(_))): {other:?}"
+        ),
+    };
+    assert!(
+        !rows.is_empty(),
+        "the fixture's partitions must decode to at least one live row"
+    );
+
+    // Non-vacuity: the fixture must have SEVERAL partitions, or "O(N) probes vs a
+    // constant" cannot bite (N == 0/1 makes both sides trivially equal). Read after
+    // the scan materialised the lazy index (`get_partition_entries()` is empty
+    // before the first `ensure_materialized`).
+    let partition_count = reader
+        .index_reader
+        .as_ref()
+        .map(|ir| ir.get_partition_entries().len())
+        .unwrap_or(0);
+    assert!(
+        partition_count > 1,
+        "fixture must expose several Index.db partitions for the O(N)-vs-constant \
+         reprobe distinction to be meaningful (got {partition_count})"
+    );
+
+    // The fix: each partition's offset comes from the already-loaded entry, so the
+    // walk performs ZERO redundant per-partition Index.db probes — bounded by a
+    // constant, NOT by the partition count. Before #2430 this was == partition_count.
+    assert_eq!(
+        probes, 0,
+        "a full materialising scan must not re-probe the index per partition — got \
+         {probes} probes for {partition_count} partitions (pre-#2430 this equalled N)"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -261,6 +261,15 @@ impl SSTableReader {
                 return Ok(None);
             }
 
+            // Work-probe (issue #2398/#2430): one partition body read + parsed on
+            // the MATERIALISING full-index walk, the same per-partition decode the
+            // streaming sibling counts. This is the non-probe signal the cancel
+            // oracle (`compaction_cancel_tests`) bounds on after issue #2430 dropped
+            // the redundant per-partition `lookup_partition_with_index` re-probe:
+            // a pre-cancelled scan aborts BEFORE reaching this decode, so it records
+            // zero here.
+            crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
+
             // `parsed.is_empty()` here is UNAMBIGUOUS: the check above already
             // proved `raw` decodes to exactly one structurally complete partition,
             // so zero rows means legitimately zero LIVE rows (all-shadowed /

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -206,6 +206,12 @@ impl SSTableReader {
             // fresh Summary binary search + interval read (file open + seek + parse),
             // turning a full scan into O(N) redundant index re-resolutions.
             let data_offset = entries[i].data_offset;
+            // Non-vacuity signal (issue #2430): one per partition resolved from an
+            // already-loaded `Index.db` entry — the surviving discriminator for
+            // "the index-backed materialising path was genuinely taken", since this
+            // walk no longer re-probes `lookup_partition_with_index` per partition
+            // (that redundant probe was what `INDEX_PROBES` used to count here).
+            crate::storage::sstable::read_work_counters::record_index_backed_partition_resolved();
 
             // Bound the partition: successor entry's offset, else the data-section
             // end for the final partition. Offsets must ascend (Data.db physical

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -22,7 +22,6 @@
 //! | entries non-empty + data section empty | structurally inconsistent | incomplete `Ok(None)` | loud |
 //! | `!index_reader.is_fully_parsed()` | mid-entry-truncated Index.db (Signal A) | incomplete `Ok(None)` | loud |
 //! | `partition_key.is_empty()` | entry carries a present-but-zero-length key — legal Cassandra shape, but `key_len == 0` is unsafe to read back through the shared row/partition scanner on EITHER path (job 1610, see the call-site comment) | incomplete `Ok(None)` | loud |
-//! | `lookup_partition_with_index` misses | index/probe disagreement | incomplete `Ok(None)` | loud |
 //! | `next_offset <= data_offset` | non-ascending offsets | incomplete `Ok(None)` | loud |
 //! | `u32::try_from(span)` fails | partition span overflows `u32` | incomplete `Ok(None)` | loud |
 //! | `partition_slice_fully_consumed` false (Signal B) | dropped trailing entries, a corrupt/truncated partition body (any entry, empty or non-empty result), OR (job 1610) a slice truncated exactly at a parseable row boundary with no CONFIRMED end-of-partition terminator | incomplete `Ok(None)` | loud |
@@ -40,9 +39,12 @@ impl SSTableReader {
     /// Each `Index.db` entry stores a partition's start offset (relative to the data
     /// section) but NOT its byte size. The exclusive end of partition `i` is the
     /// start of partition `i+1` (entries are token-ordered, matching Data.db physical
-    /// order); the LAST partition ends at the data-section end. Every real probe
-    /// increments `INDEX_PROBES` via
-    /// [`lookup_partition_with_index`](SSTableReader::lookup_partition_with_index).
+    /// order); the LAST partition ends at the data-section end. Each partition's
+    /// start offset is read DIRECTLY from its already-loaded `Index.db` entry
+    /// (`entries[i].data_offset`) — the walk does NOT re-probe
+    /// [`lookup_partition_with_index`](SSTableReader::lookup_partition_with_index)
+    /// per partition (issue #2430: a redundant Summary binary search + interval read
+    /// on every entry, O(N) on a full scan).
     ///
     /// Both compression modes are handled: the offsets are in the uncompressed
     /// data-section domain, so an uncompressed reader reads the raw file slice
@@ -195,13 +197,15 @@ impl SSTableReader {
                 return Ok(None);
             }
 
-            // Resolve through the shared probe so INDEX_PROBES / the B4 key cache /
-            // the observability counters all fire exactly as a point read's would.
-            let Some((data_offset, _size)) =
-                self.lookup_partition_with_index(partition_key).await?
-            else {
-                return Ok(None);
-            };
+            // Resolve the partition's start offset DIRECTLY from the already-loaded
+            // entry (issue #2430). `get_partition_entries()` above returned the
+            // fully-materialised offset table, so `entries[i].data_offset` IS this
+            // partition's start — the same value a `lookup_partition_with_index`
+            // probe would recover, since both read the one resident index. Re-probing
+            // per partition was pure redundant work: after #2412 it routes through a
+            // fresh Summary binary search + interval read (file open + seek + parse),
+            // turning a full scan into O(N) redundant index re-resolutions.
+            let data_offset = entries[i].data_offset;
 
             // Bound the partition: successor entry's offset, else the data-section
             // end for the final partition. Offsets must ascend (Data.db physical

--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -346,8 +346,10 @@ pub fn add_data_db_checksum_full_read() {
 }
 
 /// Record that a `do_get` compaction-merge scan read + parsed one partition body
-/// (issue #2361 / #2398). Called once per partition whose `Data.db` slice is
-/// decoded, on BOTH the streaming full-index walk and the chunk-stitching walk.
+/// (issue #2361 / #2398 / #2430). Called once per partition whose `Data.db` slice
+/// is decoded, on the streaming full-index walk, the chunk-stitching walk, AND the
+/// MATERIALISING full-index walk
+/// ([`iterate_all_partitions_via_full_index`](crate::storage::sstable::reader::SSTableReader::iterate_all_partitions_via_full_index)).
 ///
 /// Not gated behind any feature: these walks run on the default read path (BIG
 /// SSTable, no BTI), and integration/flight tests compile against the library

--- a/cqlite-core/tests/issue_2302_written_index_resolve.rs
+++ b/cqlite-core/tests/issue_2302_written_index_resolve.rs
@@ -11,11 +11,20 @@
 //! each partition by the successor entry's offset (last by the data-section end).
 //!
 //! Wiring evidence (this file, `work-counters` feature):
-//! 1. `index_probes() > 0` (== partition count) after iterating a CQLite-WRITTEN
-//!    uncompressed Summary/Index pair — RED before the fix (probes were the 3
-//!    sparse samples, all resolving to nothing → 0 rows → silent fallback).
+//! 1. `index_backed_partitions_resolved() > 0` (== partition count) after
+//!    iterating a CQLite-WRITTEN uncompressed Summary/Index pair — RED before the
+//!    fix (the pre-#2302 code sparsely walked Summary.db's 3 samples, all
+//!    resolving to nothing → 0 rows → silent fallback).
 //! 2. The index path returns the SAME row set as an explicit `sequential_scan`
 //!    over the same fixture (no data loss, no reordering).
+//!
+//! NOTE (issue #2430): item 1 was originally pinned on `index_probes()` (a
+//! per-partition `lookup_partition_with_index` re-probe). #2430 removed that
+//! re-probe as pure redundant work once the loop already holds every entry's
+//! `data_offset`, so `index_probes()` reads 0 on this path even when it fully
+//! resolves — the oracle moved to `index_backed_partitions_resolved`, which
+//! tracks the exact same "index path genuinely taken, not a silent
+//! `sequential_scan` fallback" property.
 
 // Requires BOTH `work-counters` (the `read_work_counters` probe gauge asserted
 // below) AND `write-support` (the `SSTableWriter` + `write_engine::mutation` API
@@ -364,14 +373,24 @@ fn rewrite_crc_db_for(dir: &std::path::Path, new_data_bytes: &[u8]) {
 }
 
 /// The pinned regression: iterating a CQLite-WRITTEN Summary/Index pair must
-/// probe the Index.db (probes == partition count), not silently full-scan.
+/// resolve every partition through the index-backed materialising walk
+/// (`index_backed_partitions_resolved` == partition count), not silently full-scan.
+///
+/// Issue #2430: this oracle was originally `index_probes() > 0` (a per-partition
+/// `lookup_partition_with_index` re-probe). #2430 removed that re-probe — the
+/// walk now resolves each offset directly from the already-loaded `Index.db`
+/// entry — so `index_probes` reads 0 on this path even on a full resolve. The
+/// discriminating property ("index path genuinely taken, not a silent
+/// `sequential_scan` fallback") is unchanged; only the counter that proves it
+/// moved to `index_backed_partitions_resolved`, incremented once per partition
+/// exactly where the redundant probe used to fire.
 ///
 /// `#[serial]`: `read_work_counters` is a process-global `static`, so a
-/// concurrent counter-reading test in the same binary would perturb the probe
-/// count. Serialize the counter-observing tests.
+/// concurrent counter-reading test in the same binary would perturb the count.
+/// Serialize the counter-observing tests.
 #[tokio::test]
 #[serial_test::serial]
-async fn written_summary_index_pair_resolves_via_index_probes() {
+async fn written_summary_index_pair_resolves_via_index_backed_partitions() {
     let temp = TempDir::new().unwrap();
     let n = 300i32; // > min_index_interval (128) so Summary.db is genuinely sparse
     let data_path = write_fixture(&temp, n).await;
@@ -386,21 +405,49 @@ async fn written_summary_index_pair_resolves_via_index_probes() {
 
     read_work_counters::reset();
     let rows = reader.iterate_all_partitions().await.unwrap();
-    let probes = read_work_counters::index_probes();
+    let resolved = read_work_counters::index_backed_partitions_resolved();
 
-    // RED before the fix: probes were the 3 sparse Summary.db samples (all
-    // resolving to nothing), then a silent sequential_scan → this asserted 0.
+    // RED before the fix (pre-#2302): the walk sparsely sampled Summary.db (3
+    // samples, all resolving to nothing), then a silent sequential_scan — this
+    // counter would read 0.
     assert!(
-        probes > 0,
-        "index-random-read path must probe Index.db (got {probes} probes) — a silent \
-         sequential_scan fallback records zero probes (issue #2302)"
+        resolved > 0,
+        "index-backed materialising path must resolve partitions from the loaded \
+         Index.db (got {resolved}) — a silent sequential_scan fallback resolves \
+         none (issue #2302)"
     );
     assert_eq!(
-        probes, n as u64,
-        "every partition must be resolved through a real Index.db probe"
+        resolved, n as u64,
+        "every partition must be resolved through the index-backed walk"
     );
 
-    // No data loss: all partitions surface.
+    // Discrimination check (issue #2430): a reader with NO usable Index.db
+    // (sibling deleted) falls straight into `sequential_scan`, which does NOT
+    // touch this counter at all — proving `index_backed_partitions_resolved`
+    // genuinely discriminates the index-backed branch from the fallback, not
+    // just "some scan happened".
+    let index_path = find_index_db(data_path.parent().unwrap());
+    std::fs::remove_file(&index_path).unwrap();
+    let fallback_reader = open_reader(&data_path).await;
+    assert!(
+        !fallback_reader.has_partition_index(),
+        "sibling Index.db deleted: the reader must report no usable random-access index"
+    );
+    read_work_counters::reset();
+    let fallback_rows = fallback_reader.iterate_all_partitions().await.unwrap();
+    assert_eq!(
+        read_work_counters::index_backed_partitions_resolved(),
+        0,
+        "a sequential_scan fallback (no Index.db) must record ZERO index-backed \
+         resolutions — this is the discrimination proof for the counter above"
+    );
+    assert_eq!(
+        fallback_rows.len(),
+        n as usize,
+        "the fallback must still recover every partition from an intact Data.db"
+    );
+
+    // No data loss: all partitions surface via the index-backed walk.
     assert_eq!(
         rows.len(),
         n as usize,
@@ -410,12 +457,17 @@ async fn written_summary_index_pair_resolves_via_index_probes() {
 
 /// FIX B (issue #2302): a partition that decodes SUCCESSFULLY to zero LIVE rows
 /// (here a pure partition-delete tombstone) must NOT demote the whole walk to a
-/// sequential scan. The index path stays taken (probes == partition count,
-/// covering the shadowed partition too) and contributes zero rows for it — never
-/// a silent fallback just because one healthy partition happens to be fully
-/// shadowed.
+/// sequential scan. The index path stays taken (`index_backed_partitions_resolved`
+/// == partition count, covering the shadowed partition too) and contributes zero
+/// rows for it — never a silent fallback just because one healthy partition
+/// happens to be fully shadowed.
 ///
-/// `#[serial]`: reads the process-global `read_work_counters` probe gauge.
+/// Issue #2430: migrated off `index_probes` for the same reason as the sibling
+/// test above (the per-partition `lookup_partition_with_index` re-probe this
+/// counted was removed as redundant work; `index_backed_partitions_resolved` is
+/// the surviving discriminator).
+///
+/// `#[serial]`: reads the process-global `read_work_counters` gauge.
 #[tokio::test]
 #[serial_test::serial]
 async fn fully_shadowed_partition_keeps_index_path() {
@@ -432,18 +484,20 @@ async fn fully_shadowed_partition_keeps_index_path() {
 
     read_work_counters::reset();
     let rows = reader.iterate_all_partitions().await.unwrap();
-    let probes = read_work_counters::index_probes();
+    let resolved = read_work_counters::index_backed_partitions_resolved();
 
     // The index path was NOT demoted: every partition (INCLUDING the fully
-    // shadowed one) is resolved through a real Index.db probe.
+    // shadowed one) is resolved through the index-backed walk.
     assert_eq!(
-        probes, total as u64,
+        resolved, total as u64,
         "a fully-shadowed partition must NOT demote the walk to sequential_scan — \
-         every partition (shadowed included) is probed via Index.db (issue #2302 FIX B)"
+         every partition (shadowed included) is resolved via the index-backed walk \
+         (issue #2302 FIX B)"
     );
     assert!(
-        probes > 0,
-        "index path must probe Index.db (silent fallback records zero probes)"
+        resolved > 0,
+        "index path must resolve partitions from the loaded Index.db (silent \
+         fallback resolves none)"
     );
 
     // The shadowed partition contributes zero LIVE rows; the other n survive.


### PR DESCRIPTION
Closes #2430.

Mirror of #2412's streaming-path pattern onto the materializing sibling: `iterate_all_partitions_via_full_index` resolves each partition's start offset directly from the already-loaded `entries[i].data_offset` instead of re-calling `lookup_partition_with_index` per partition (O(N) redundant probes; post-#2412 each could route through summary/interval machinery).

Per the issue's ACs, in order:
1. `pre_cancelled_scan_does_not_probe_index_on_index_backed_path`'s oracle migrated off `index_probes() > 0` (which the redundant probe satisfied) onto the `StreamWalkScope` body-decode work-probe, with an in-test uncancelled-vs-precancelled contrast (non-vacuous by construction).
2. Redundant lookup removed.
3. New pin `full_materializing_scan_does_not_reprobe_index_per_partition` — RED pre-fix (100 probes / 100 partitions), GREEN post (0).

Review trail (review-first): roborev job 1717 clean (offset-domain equivalence verified — the old lookup returned the same `entries` value, no clamping/validation skipped); rust-reviewer clean, 2 nits → follow-up at merge (streaming FellBack sibling retains a cheap resident-map re-probe at full_index_stream.rs:196 — mirror candidate; materializing path's defensive probe-miss cross-check intentionally removed with rationale). Parity: query-semantics oracle + streaming-order parity green.

Full gate of record: flow-closer pre-merge (lite PASS at c81f0b45).