### PR TITLE
fix(#2299): fail-closed direct-stream gate — roborev-1723 guard omitted from PR #2421 merge

### DIFF
--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -285,7 +285,17 @@ impl WriteEngine {
         // markers to interleave — the write side can stream rows directly instead
         // of buffering the whole partition (see `ActiveMerge::stream_rows_directly`).
         // Read BEFORE the expiry floor below lowers `baseline_min_ldt`.
-        let no_deletions_in_any_input = baseline_min_ldt == i32::MAX;
+        //
+        // FAIL CLOSED (roborev job 1723, #2299): `compute_baseline_min` fails OPEN
+        // — an input whose `Statistics.db` is missing or top-level-unparseable is
+        // silently skipped and never lowers `baseline_min_ldt`, so a skipped
+        // tombstone-bearing input would leave the sentinel intact and wrongly
+        // select direct-streaming (dropping its tombstones → data resurrection).
+        // `all_input_stats_readable` refuses to prove "no deletions" unless EVERY
+        // input's authoritative deletion metadata was actually observed; otherwise
+        // we take the always-correct buffered path.
+        let no_deletions_in_any_input =
+            baseline_min_ldt == i32::MAX && merge::all_input_stats_readable(&input_paths);
         // Issue #1537: unlike `compact_sstables_with_registry` — whose
         // `now_secs: Option<i64>` parameter can be `None` (expiry disabled), so it
         // gates the floor application on `now_secs.is_some()` — this WriteEngine

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -162,6 +162,14 @@ pub struct MaintenanceReport {
     /// and its components were reclaimed after the merged output published. Empty
     /// when nothing was dropped. Paths are input Data.db paths.
     pub dropped_whole: Vec<PathBuf>,
+    /// Number of partitions written via the issue #2299 direct-stream path (rows
+    /// fed straight into the writer session with no whole-partition buffer). Taken
+    /// only when authoritative `Statistics.db` proves no input carries a deletion.
+    /// Exposed so tests can positively assert the memory-bounding path actually
+    /// executed (byte-identity alone holds on both the direct and buffered paths,
+    /// so it cannot distinguish them) — roborev job 1723. `0` when every partition
+    /// used the buffered path.
+    pub direct_stream_partitions: u64,
 }
 
 /// Active merge state for incremental compaction (M5.2, Issue #384)
@@ -420,6 +428,7 @@ impl WriteEngine {
             bytes_written: 0,
             pending_compaction: false,
             dropped_whole: Vec::new(),
+            direct_stream_partitions: 0,
         };
 
         // If no merge policy is set, no maintenance work to do
@@ -781,6 +790,10 @@ impl WriteEngine {
                             merge.rows_merged += state.row_count;
                         }
                         report.rows_merged += state.row_count;
+                        // Issue #2299 (roborev job 1723): record that this
+                        // partition used the memory-bounded direct-stream path, so
+                        // the default gate can assert it actually ran.
+                        report.direct_stream_partitions += 1;
                         continue;
                     }
 
@@ -1286,6 +1299,7 @@ mod tests {
             bytes_written: 1024 * 1024,
             pending_compaction: true,
             dropped_whole: Vec::new(),
+            direct_stream_partitions: 0,
         };
 
         assert_eq!(report.time_spent.as_millis(), 250);

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1478,6 +1478,52 @@ pub fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
     (baseline_min_ts, baseline_min_ldt, baseline_min_ttl)
 }
 
+/// Issue #2299 fail-CLOSED guard for the direct-stream compaction gate.
+///
+/// The direct-stream write path (`ActiveMerge::stream_rows_directly`) is selected
+/// from `compute_baseline_min`'s LDT baseline surviving at the `i32::MAX`
+/// (`NO_DELETION_TIME`) sentinel — read as "no input carries ANY deletion, so
+/// there are no range/row/partition tombstones to interleave." But
+/// `compute_baseline_min` fails OPEN: an input whose `Statistics.db` is MISSING or
+/// fails the top-level parse is silently skipped and never contributes to the
+/// baseline. If such a skipped input actually carries a tombstone, the baseline
+/// stays at the live sentinel, the direct path is wrongly selected, and that
+/// input's tombstones are dropped from the compacted output — previously-deleted
+/// data resurrects (a silent data-loss failure mode).
+///
+/// This returns `false` when ANY input's `Statistics.db` is missing or
+/// unparseable at the top level, so the caller can force the always-correct
+/// buffered path independently of the (fail-open) baseline seeder. The deletion
+/// signal is authoritative metadata only (`Statistics.db`), never a byte heuristic
+/// (#28); when it cannot be read we refuse to prove "no deletions" and fall back.
+///
+/// (An input that PARSES but whose best-effort STATS-extras histogram is
+/// unparseable is already handled conservatively inside `compute_baseline_min`:
+/// `has_tombstone = true` forces its LDT into the baseline, lowering it below the
+/// sentinel — so that case does not reach this guard.)
+#[cfg(feature = "write-support")]
+pub fn all_input_stats_readable(input_paths: &[PathBuf]) -> bool {
+    for data_path in input_paths {
+        let stats_path = stats_path_for(data_path);
+        if !stats_path.exists() {
+            return false;
+        }
+        let stats_bytes = match std::fs::read(&stats_path) {
+            Ok(b) => b,
+            Err(_) => return false,
+        };
+        if crate::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
+            &stats_bytes,
+            None,
+        )
+        .is_err()
+        {
+            return false;
+        }
+    }
+    true
+}
+
 /// Expiry-aware LOWER bound for the compaction output's `min_local_deletion_time`
 /// delta baseline (issue #1537).
 ///
@@ -6015,6 +6061,67 @@ mod tests {
             baseline_ldt, tomb_ldt,
             "an unparseable STATS-extras section must be treated conservatively \
              (INCLUDE the LDT baseline), not as an empty no-tombstone histogram (#1410)"
+        );
+    }
+
+    /// #2299 / roborev job 1723 — fail-CLOSED guard for the direct-stream gate.
+    ///
+    /// `compute_baseline_min` fails OPEN: an input with a MISSING or top-level
+    /// UNPARSEABLE `Statistics.db` never lowers `baseline_min_ldt`, so a skipped
+    /// tombstone-bearing input would leave the live sentinel intact and the
+    /// `#2299` gate (`baseline_min_ldt == i32::MAX`) would wrongly select the
+    /// direct-stream path, dropping that input's tombstones (data resurrection).
+    /// `all_input_stats_readable` closes that hole: it returns `false` unless EVERY
+    /// input's deletion metadata was actually observed, letting the caller force
+    /// the always-correct buffered path. Removing the AND in `compaction.rs`
+    /// re-opens the data-loss hole and re-greens this test's negative cases.
+    #[test]
+    fn all_input_stats_readable_fails_closed_on_missing_or_unparseable_stats() {
+        use crate::storage::sstable::writer::{StatisticsMetadata, StatisticsWriter};
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().expect("temp dir");
+
+        // A well-formed input: Data.db + a valid Statistics.db written through the
+        // real writer. Readable → the guard permits proving "no deletions".
+        let good_data = tmp.path().join("nb-1-big-Data.db");
+        std::fs::write(&good_data, b"").expect("touch good Data.db");
+        StatisticsWriter::new(tmp.path().join("nb-1-big-Statistics.db"))
+            .write(&StatisticsMetadata::new(), None)
+            .expect("write valid Statistics.db");
+        assert!(
+            all_input_stats_readable(&[good_data.clone()]),
+            "a well-formed input with a valid Statistics.db must be readable"
+        );
+
+        // Missing Statistics.db (roborev's primary scenario): the paired
+        // Statistics.db is simply absent. Must fail closed.
+        let missing_data = tmp.path().join("nb-2-big-Data.db");
+        std::fs::write(&missing_data, b"").expect("touch missing-stats Data.db");
+        // (deliberately write NO nb-2-big-Statistics.db)
+        assert!(
+            !all_input_stats_readable(&[missing_data.clone()]),
+            "an input whose Statistics.db is missing must NOT be provably deletion-free"
+        );
+
+        // Top-level-unparseable Statistics.db: too short to even carry the TOC
+        // count/CRC header, so `parse_statistics_with_fallback` errors. Must fail
+        // closed (do not infer "no deletions" from an undecodable component).
+        let corrupt_data = tmp.path().join("nb-3-big-Data.db");
+        std::fs::write(&corrupt_data, b"").expect("touch corrupt-stats Data.db");
+        std::fs::write(tmp.path().join("nb-3-big-Statistics.db"), b"\x00\x00")
+            .expect("write truncated Statistics.db");
+        assert!(
+            !all_input_stats_readable(&[corrupt_data.clone()]),
+            "an input whose Statistics.db is unparseable at the top level must fail closed"
+        );
+
+        // MIXED: one readable input + one missing-stats input. A single unreadable
+        // input taints the whole merge — the guard must fail closed so the direct
+        // path is never taken when any input's deletion metadata is unknown.
+        assert!(
+            !all_input_stats_readable(&[good_data, missing_data, corrupt_data]),
+            "any single unreadable input must force the whole merge to fail closed"
         );
     }
 

--- a/cqlite-core/tests/test_issue_2299_stream_readback.rs
+++ b/cqlite-core/tests/test_issue_2299_stream_readback.rs
@@ -261,10 +261,12 @@ fn direct_stream_wide_partition_reads_back_byte_identical() {
     // Phase 2: run the real N→1 STCS compaction via the direct-stream path.
     let budget = Duration::from_secs(120);
     let mut compaction_completed = false;
+    let mut direct_stream_partitions = 0u64;
     for _ in 0..8 {
         let report = engine
             .maintenance_step(budget)
             .expect("maintenance_step must not error");
+        direct_stream_partitions += report.direct_stream_partitions;
         if !report.completed_merges.is_empty() {
             compaction_completed = true;
             break;
@@ -274,6 +276,19 @@ fn direct_stream_wide_partition_reads_back_byte_identical() {
         }
     }
     assert!(compaction_completed, "compaction must complete");
+    // Positively assert the memory-bounding DIRECT-STREAM path actually ran for
+    // both wide partitions (roborev job 1723): byte-identity + the Data.db-size
+    // block-crossing check below both hold on the buffered path too, so without
+    // this a silent regression to buffering (e.g. a future change that stops
+    // setting `stream_rows_directly`) would leave these tests green while the new
+    // behavior stopped executing. Only the dhat-gated memory test — NOT in the
+    // default gate — would otherwise catch it.
+    assert_eq!(
+        direct_stream_partitions,
+        PARTITIONS.len() as u64,
+        "both wide tombstone-free partitions must compact via the issue #2299 \
+         direct-stream path, not the buffered fall-through"
+    );
     assert_eq!(
         count_data_files(&sstable_dir),
         1,


### PR DESCRIPTION
Closes #2299

## Why this exists (process failure remediation)
PR #2421 (issue #2299) merged as squash commit `b6acc7f5` but its head was the **pre-fix, pre-rebase tip `ca8eb016`** — the flow-closer's rebase and the roborev-1723 blocker fix (`da9a7cb2`) were validated locally (full gate PASS, roborev job 1724 blocker-clean) but **never pushed to origin**, so `gh pr merge` squashed stale code. Merged main is therefore missing the fail-closed guard below. This PR lands EXACTLY that omitted fix (diff = the 4 fix files; the rest of #2299 is already in main).

## The fix (roborev job 1723, Medium — silent data-loss / tombstone drop)
The #2299 direct-stream compaction gate inferred "no deletions in any input" from `compute_baseline_min`'s LDT baseline surviving at the `i32::MAX` (`NO_DELETION_TIME`) sentinel. But that seeder fails **OPEN**: an input whose `Statistics.db` is missing or top-level-unparseable is silently skipped and never lowers the baseline. A skipped tombstone-bearing input would leave the sentinel intact, wrongly select the direct-stream path (empty range-tombstone set), and **drop its tombstones — previously-deleted data resurrects**.

- Add `merge::all_input_stats_readable` (authoritative `Statistics.db` only, #28) and AND it into the direct-stream gate in `compaction.rs`, so the always-correct buffered path is forced unless EVERY input's deletion metadata was actually observed. Unit test covers missing / unparseable / mixed inputs.
- roborev-1723 Low (wiring evidence): expose `MaintenanceReport::direct_stream_partitions` and positively assert both wide partitions took the direct-stream path in `direct_stream_wide_partition_reads_back_byte_identical` (byte-identity + block-crossing both hold on the buffered path too, so only the dhat-gated memory test caught a silent regression before).

## Certification
The cherry-picked tip's tree is **byte-identical** to `da9a7cb2`, which the flow-closer certified: full AGENT-GATE SUMMARY **RESULT: PASS** (26/26 components incl. compaction-byte-parity, core-tests, write-tests, memory-budget), and roborev job 1724 blocker-clean (confirmed the fail-closed guard sound; sole residual a Low robustness/doc nit batched into #2454). A fresh full gate is re-run on this exact tip as the gate of record.

Follow-up nits: #2454.