### PR TITLE
fix(#2459): restore missing serial_test import — main compile break

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -22,6 +22,7 @@ use crate::storage::write_engine::mutation::{
 };
 use crate::types::Value;
 use crate::{Config, Platform};
+use serial_test::serial;
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 use std::sync::Arc;


### PR DESCRIPTION
## Summary
- Restores `use serial_test::serial;` in `cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs`, which was dropped by #2438 (fix for #2428) while #2437 (#2366) — forked before #2438 merged — added a test still using `#[serial(work_counters)]`. Both merged cleanly with no conflict, leaving 4 usages (lines 326, 373, 416, 611) and no import, breaking `origin/main` compilation for every PR's required check.
- One-line fix, no other changes. Verified `cargo check -p cqlite-core --lib --all-features` is clean and all 4 affected tests pass:
  - `windowed_stream_matches_materialising_over_larger_fixture`
  - `stream_for_compaction_emits_every_partition_windowed`
  - `windowed_stream_read_pattern_is_sequential`
  - `windowed_stream_multi_refill_and_large_partition_clamp_parity`

Closes #2459

## Test plan
- [x] `cargo check -p cqlite-core --lib --all-features` compiles clean
- [x] All 4 affected tests pass (`cargo test -p cqlite-core --lib --all-features`)
- [x] `scripts/agent-gate.sh --lite` PASS (file-size, fmt, clippy, scoped-tests)
- [ ] Full `scripts/agent-gate.sh` PASS (run once by flow-closer before merge)