### PR TITLE
fix(#2462): restore serial_test::serial import lost in #2437/#2438 merge race

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -22,6 +22,7 @@ use crate::storage::write_engine::mutation::{
 };
 use crate::types::Value;
 use crate::{Config, Platform};
+use serial_test::serial;
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 use std::sync::Arc;


### PR DESCRIPTION
Closes #2462

## Problem
`origin/main` fails `cargo clippy --workspace --all-targets --all-features` and
`cargo test -p cqlite-core --lib` for every worker on every machine:
```
error[E0433]: failed to resolve: use of undeclared crate or module `serial_test`
  --> cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs:326
```

## Root cause
Merge race between two independently-green PRs: #2438 removed the (then-unused)
`use serial_test::serial;` import; #2437 (branched before that removal) added 4
new `#[serial(work_counters)]` attributes to the same file. Neither diff was wrong
in isolation; the merged tree on `main` is orphaned.

## Fix
One-line: restore `use serial_test::serial;`.

## Priority
Discovered while running the lite gate for an unrelated issue (#1818) — blocking
every worker's `--lite` and full gate on `cqlite-core` fleet-wide. Fast-tracking
this fix ahead of the issue that found it. Genuinely mechanical (no `pub`-item
change, single line, no new surface) — skipping the review-first rust-reviewer/
roborev pass per that documented exception; going straight to the full gate.

## Gate
```
==== AGENT-GATE LITE SUMMARY ====
commit: 710dde190 branch: issue-2462-serial-import-fix dirty: yes
file-size: PASS  fmt: PASS  clippy: PASS (266s)  scoped-tests: PASS (110s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Full `agent-gate.sh` to be run by `flow-closer`.