### PR TITLE
fix(#2463): restore serial_test import — unbreak main clippy (semantic collision #2438 × #2437)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -22,6 +22,7 @@ use crate::storage::write_engine::mutation::{
 };
 use crate::types::Value;
 use crate::{Config, Platform};
+use serial_test::serial;
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 use std::sync::Arc;


### PR DESCRIPTION
Closes #2463. One-line: re-add `use serial_test::serial;` to full_index_stream_tests.rs — PR #2438 removed it while dropping its tags; PR #2437 (merged later on a stale-green check, strict=false) added 4 tests still carrying `#[serial(work_counters)]`. Those tests serialize on process-global read_work_counters (INDEX_PROBES/SEEK_CALLS), which StreamWalkScope does NOT cover — so the import is correct and migration to scoped counters folds into #2451. Main's workspace clippy -D warnings is broken until this lands; found by #2460's docs-only lite. Review-first skipped: mechanical one-line import restore.