### PR TITLE
fix(#1885): v5 ladder decoder varint arm — decode CQL varint as Value::Varint not Blob

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_kind.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_kind.rs
@@ -55,6 +55,11 @@ pub(super) enum CellKind {
     Inet,
     /// The literal CQL `blob` type (decodes to `Blob`, empty-value → `Blob([])`).
     Blob,
+    /// CQL `varint` (arbitrary-precision integer). Decodes the VInt-length-prefixed
+    /// raw two's-complement big-endian bytes to `Value::Varint` (empty-value →
+    /// `Varint([])`), mirroring the block / `ComparatorType::Varint` path exactly
+    /// (issue #1885).
+    Varint,
     /// Frozen / tuple / non-frozen-collection / marshal-UDT / unknown-scalar types:
     /// the already-lowercased declared type string, decoded by the retained string
     /// ladder. Empty-value → `Null` (matching the pre-J1 `_ => Null` empty arm).
@@ -88,7 +93,8 @@ impl CellKind {
             "time" => CellKind::Time,
             "inet" => CellKind::Inet,
             "blob" => CellKind::Blob,
-            // frozen<…>, tuple<…>, list/set/map<…>, marshal forms, varint, and any
+            "varint" => CellKind::Varint,
+            // frozen<…>, tuple<…>, list/set/map<…>, marshal forms, and any
             // unrecognized type: decoded by the retained string ladder. Store the
             // lowercased string so the ladder needs no per-cell `to_lowercase`.
             _ => CellKind::Complex(Arc::from(lowered.as_str())),
@@ -115,6 +121,7 @@ mod tests {
         assert_eq!(CellKind::from_type("duration"), CellKind::Duration);
         assert_eq!(CellKind::from_type("inet"), CellKind::Inet);
         assert_eq!(CellKind::from_type("blob"), CellKind::Blob);
+        assert_eq!(CellKind::from_type("varint"), CellKind::Varint);
     }
 
     #[test]
@@ -154,12 +161,6 @@ mod tests {
         assert_eq!(
             CellKind::from_type("list<int>"),
             CellKind::Complex(Arc::from("list<int>"))
-        );
-        // `varint` has no dedicated scalar arm — pre-J1 it fell to the default blob
-        // decode (live) / Null (empty); it must land in `Complex`, not `Blob`.
-        assert_eq!(
-            CellKind::from_type("varint"),
-            CellKind::Complex(Arc::from("varint"))
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value.rs
@@ -253,6 +253,9 @@ impl V5CompressedLegacyParser {
             let empty_value = match kind {
                 CellKind::Text => Value::Text(String::new()),
                 CellKind::Blob => Value::Blob(Vec::new()),
+                // Issue #1885: an empty `varint` cell is `Varint([])`, matching the
+                // block / `ComparatorType::Varint` path (empty slice → `Varint([])`).
+                CellKind::Varint => Value::Varint(Vec::new()),
                 _ => {
                     tracing::warn!(
                         "V5CompressedLegacy: EMPTY value for cell '{}' (type {}), treating as NULL",
@@ -267,7 +270,7 @@ impl V5CompressedLegacyParser {
 
         // VInt-length-prefixed blob decode. Shared by the literal `blob` type
         // (`CellKind::Blob`) and the `CellKind::Complex` default fall-through
-        // (unknown/`varint`), which decoded identically pre-J1 (both hit the single
+        // (unknown types), which decoded identically pre-J1 (both hit the single
         // `_ =>` blob arm). Extracted to one closure so the two dispatch sites do not
         // duplicate the decode. Advances the shared `offset` cursor.
         let decode_vint_blob = |offset: &mut usize| -> Result<Value> {
@@ -309,8 +312,48 @@ impl V5CompressedLegacyParser {
         // marshal-UDT/default ladder is retained verbatim inside `CellKind::Complex`
         // (the thin adapter Epic J2 collapses), using the tag's already-lowercased
         // declared type as `type_str` — exactly the pre-J1 `normalized_type`.
+        // Issue #1885: read VInt-length-prefixed raw bytes (shared framing with the
+        // `blob` decode). Returns the exact payload bytes; the caller wraps them in
+        // the target `Value`. Mirrors `decode_vint_blob` but hands back the raw bytes
+        // so `varint` can wrap in `Value::Varint` with byte-identical framing.
+        let read_vint_prefixed_bytes = |offset: &mut usize| -> Result<Vec<u8>> {
+            if *offset >= data.len() {
+                return Err(Error::corruption(format!(
+                    "Cell '{}': unexpected end at length prefix (type: {})",
+                    column.name, column.data_type
+                )));
+            }
+            let (remaining, len) = parse_vuint(&data[*offset..]).map_err(|e| {
+                Error::corruption(format!(
+                    "Cell '{}': failed to parse length prefix as VInt: {:?}",
+                    column.name, e
+                ))
+            })?;
+            let len = len as usize;
+            let bytes_consumed = data[*offset..].len() - remaining.len();
+            *offset += bytes_consumed;
+            if *offset + len > data.len() {
+                return Err(Error::corruption(format!(
+                    "Cell '{}': need {} bytes, only {} available (type: {})",
+                    column.name,
+                    len,
+                    data.len() - *offset,
+                    column.data_type
+                )));
+            }
+            let bytes = data[*offset..*offset + len].to_vec();
+            *offset += len;
+            Ok(bytes)
+        };
+
         let value = match kind {
             CellKind::Blob => decode_vint_blob(&mut offset)?,
+            // CQL `varint`: VInt-length-prefixed raw two's-complement big-endian
+            // bytes → `Value::Varint`. Byte-for-byte the same on-disk framing as the
+            // `blob` arm, but preserves the declared `varint` type instead of blobbing
+            // it. Mirrors the block / `ComparatorType::Varint` path
+            // (`Value::Varint(value_data.to_vec())`) — issue #1885.
+            CellKind::Varint => Value::Varint(read_vint_prefixed_bytes(&mut offset)?),
             CellKind::Boolean => {
                 // Boolean: [0x08][u8 value]
                 if offset >= data.len() {
@@ -926,7 +969,7 @@ impl V5CompressedLegacyParser {
             }
 
             // Complex types: frozen, tuple, non-frozen collection, marshal-UDT, and
-            // any unnamed/default type (e.g. `varint`). J1 (issue #1635): the DISPATCH
+            // any unnamed/default type. J1 (issue #1635): the DISPATCH
             // is per-column via this single `CellKind::Complex` arm; the retained
             // prefix ladder (Epic J2 collapses it) uses the tag's already-lowercased
             // declared type as `type_str` — exactly the pre-J1 `normalized_type`, so
@@ -1237,7 +1280,7 @@ impl V5CompressedLegacyParser {
                 // - Parse fields according to UDT schema
                 // - Return Value::Udt(UdtValue)
 
-                // Default: treat as VInt-length-prefixed blob (unknown/`varint`).
+                // Default: treat as VInt-length-prefixed blob (unknown type).
                 // Shares the `decode_vint_blob` closure with the literal-`blob`
                 // `CellKind::Blob` arm — identical decode pre-J1 (both hit `_ =>`).
                 else {

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value.rs
@@ -268,91 +268,61 @@ impl V5CompressedLegacyParser {
             return Ok((empty_value, cell_timestamp, cell_expiration, offset));
         }
 
-        // VInt-length-prefixed blob decode. Shared by the literal `blob` type
-        // (`CellKind::Blob`) and the `CellKind::Complex` default fall-through
-        // (unknown types), which decoded identically pre-J1 (both hit the single
-        // `_ =>` blob arm). Extracted to one closure so the two dispatch sites do not
-        // duplicate the decode. Advances the shared `offset` cursor.
-        let decode_vint_blob = |offset: &mut usize| -> Result<Value> {
+        // VInt-length-prefixed raw-bytes decode. Reads a single unsigned-VInt length
+        // prefix, bounds-checks it, and returns the exact payload bytes, advancing the
+        // shared `offset` cursor. The on-disk framing is identical for `blob` and
+        // `varint`; the caller wraps the bytes in the target `Value` variant. Extracted
+        // to one closure so the dispatch sites do not duplicate the length parse,
+        // bounds check, cursor advance, and allocation (issue #1885, roborev DRY).
+        let read_vint_prefixed_bytes = |offset: &mut usize| -> Result<Vec<u8>> {
             if *offset >= data.len() {
                 return Err(Error::corruption(format!(
                     "Cell '{}': unexpected end at blob length (type: {})",
                     column.name, column.data_type
                 )));
             }
-            // Parse blob length as unsigned VInt (can be > 255 bytes).
-            let (remaining, blob_len) = parse_vuint(&data[*offset..]).map_err(|e| {
-                Error::corruption(format!(
-                    "Cell '{}': failed to parse blob length as VInt: {:?}",
-                    column.name, e
-                ))
-            })?;
-            let blob_len = blob_len as usize;
-            let bytes_consumed = data[*offset..].len() - remaining.len();
-            *offset += bytes_consumed;
-
-            if *offset + blob_len > data.len() {
-                return Err(Error::corruption(format!(
-                    "Cell '{}': need {} bytes for blob, only {} available (type: {})",
-                    column.name,
-                    blob_len,
-                    data.len() - *offset,
-                    column.data_type
-                )));
-            }
-
-            let blob_bytes = data[*offset..*offset + blob_len].to_vec();
-            *offset += blob_len;
-            Ok(Value::Blob(blob_bytes))
-        };
-
-        // At this point, we have a live cell with value data.
-        // Dispatch the decode on the precomputed `CellKind` (jump table). The scalar
-        // arms map 1:1 onto the pre-J1 string-match arms; the frozen/tuple/collection/
-        // marshal-UDT/default ladder is retained verbatim inside `CellKind::Complex`
-        // (the thin adapter Epic J2 collapses), using the tag's already-lowercased
-        // declared type as `type_str` — exactly the pre-J1 `normalized_type`.
-        // Issue #1885: read VInt-length-prefixed raw bytes (shared framing with the
-        // `blob` decode). Returns the exact payload bytes; the caller wraps them in
-        // the target `Value`. Mirrors `decode_vint_blob` but hands back the raw bytes
-        // so `varint` can wrap in `Value::Varint` with byte-identical framing.
-        let read_vint_prefixed_bytes = |offset: &mut usize| -> Result<Vec<u8>> {
-            if *offset >= data.len() {
-                return Err(Error::corruption(format!(
-                    "Cell '{}': unexpected end at length prefix (type: {})",
-                    column.name, column.data_type
-                )));
-            }
+            // Parse the length prefix as an unsigned VInt (can be > 255 bytes).
             let (remaining, len) = parse_vuint(&data[*offset..]).map_err(|e| {
                 Error::corruption(format!(
-                    "Cell '{}': failed to parse length prefix as VInt: {:?}",
+                    "Cell '{}': failed to parse blob length as VInt: {:?}",
                     column.name, e
                 ))
             })?;
             let len = len as usize;
             let bytes_consumed = data[*offset..].len() - remaining.len();
             *offset += bytes_consumed;
+
             if *offset + len > data.len() {
                 return Err(Error::corruption(format!(
-                    "Cell '{}': need {} bytes, only {} available (type: {})",
+                    "Cell '{}': need {} bytes for blob, only {} available (type: {})",
                     column.name,
                     len,
                     data.len() - *offset,
                     column.data_type
                 )));
             }
+
             let bytes = data[*offset..*offset + len].to_vec();
             *offset += len;
             Ok(bytes)
+        };
+
+        // Thin wrapper: the literal `blob` type (`CellKind::Blob`) and the
+        // `CellKind::Complex` default fall-through (unknown types) both wrap the shared
+        // VInt-prefixed bytes in `Value::Blob` — identical pre-J1 decode (the single
+        // `_ =>` blob arm). Advances the shared `offset` cursor.
+        let decode_vint_blob = |offset: &mut usize| -> Result<Value> {
+            Ok(Value::Blob(read_vint_prefixed_bytes(offset)?))
         };
 
         let value = match kind {
             CellKind::Blob => decode_vint_blob(&mut offset)?,
             // CQL `varint`: VInt-length-prefixed raw two's-complement big-endian
             // bytes → `Value::Varint`. Byte-for-byte the same on-disk framing as the
-            // `blob` arm, but preserves the declared `varint` type instead of blobbing
-            // it. Mirrors the block / `ComparatorType::Varint` path
-            // (`Value::Varint(value_data.to_vec())`) — issue #1885.
+            // `blob` arm (shares `read_vint_prefixed_bytes`), but preserves the declared
+            // `varint` type instead of blobbing it. Mirrors the block /
+            // `ComparatorType::Varint` path (`Value::Varint(value_data.to_vec())`) —
+            // issue #1885.
             CellKind::Varint => Value::Varint(read_vint_prefixed_bytes(&mut offset)?),
             CellKind::Boolean => {
                 // Boolean: [0x08][u8 value]

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/decoder_lockstep_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/decoder_lockstep_tests.rs
@@ -962,7 +962,15 @@ async fn v5_varint_arm_decodes_edge_cases() {
 }
 
 /// An empty `varint` cell decodes to `Value::Varint([])` on the v5 path, matching
-/// the block path's empty-slice handling (issue #1885).
+/// the block path's empty-slice handling (issue #1885). This covers BOTH v5 wire
+/// framings that can carry a zero-length varint:
+///  1. A live cell with a VInt length prefix of `0` (`[0x08][0x00]`) — the
+///     `CellKind::Varint => Value::Varint(read_vint_prefixed_bytes(..))` arm reading
+///     an empty payload.
+///  2. A flags-only cell with the `CELL_HAS_EMPTY_VALUE` bit set and NO value bytes
+///     (`[0x0C]` = `CELL_USE_ROW_TIMESTAMP | CELL_HAS_EMPTY_VALUE`) — the dedicated
+///     `CellKind::Varint => Value::Varint(Vec::new())` empty arm (roborev coverage
+///     gap: this arm was previously never exercised).
 #[tokio::test]
 async fn v5_varint_empty_matches_block() {
     let Some(reader) = open_reader().await else {
@@ -972,15 +980,38 @@ async fn v5_varint_empty_matches_block() {
 
     let block = decode_block(&reader, "varint", &[])
         .unwrap_or_else(|e| panic!("block empty varint failed: {e:?}"));
-    let cell = frame_v5_cell(V5Framing::VintLen, &[]);
-    let v5 = decode_v5(&parser, &reader, "varint", &cell)
-        .unwrap_or_else(|e| panic!("v5 empty varint failed: {e:?}"));
+
+    // Framing 1: live cell, VInt length prefix = 0.
+    let cell_len0 = frame_v5_cell(V5Framing::VintLen, &[]);
+    let v5_len0 = decode_v5(&parser, &reader, "varint", &cell_len0)
+        .unwrap_or_else(|e| panic!("v5 zero-length varint failed: {e:?}"));
     assert_eq!(
-        v5,
+        v5_len0,
         Value::Varint(Vec::new()),
-        "empty v5 varint → Varint([])"
+        "zero-length-prefix v5 varint → Varint([])"
     );
-    assert_eq!(block, v5, "empty varint block vs v5 must agree");
+    assert_eq!(
+        block, v5_len0,
+        "zero-length-prefix varint block vs v5 must agree"
+    );
+
+    // Framing 2: flags-only cell with CELL_HAS_EMPTY_VALUE set — no value bytes at
+    // all. 0x0C = CELL_USE_ROW_TIMESTAMP (0x08) | CELL_HAS_EMPTY_VALUE (0x04); the
+    // row-timestamp bit means no timestamp delta is read, so the whole cell is the
+    // single flags byte. This is the branch that hits the empty `Value::Varint(vec)`
+    // arm rather than reading a length-prefixed payload.
+    let cell_empty_flag = vec![0x0Cu8];
+    let v5_empty_flag = decode_v5(&parser, &reader, "varint", &cell_empty_flag)
+        .unwrap_or_else(|e| panic!("v5 empty-value-flag varint failed: {e:?}"));
+    assert_eq!(
+        v5_empty_flag,
+        Value::Varint(Vec::new()),
+        "empty-value-flag (0x0C) v5 varint → Varint([]) via the empty arm"
+    );
+    assert_eq!(
+        block, v5_empty_flag,
+        "empty-value-flag varint block vs v5 must agree"
+    );
 }
 
 // ===========================================================================

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/decoder_lockstep_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/decoder_lockstep_tests.rs
@@ -44,10 +44,6 @@
 //!   representation); v5 ladder → [`Value::Float`] (widened `f32 as f64`). Owning
 //!   issue: **J2** (collapse the `ComparatorType` decoders — must unify the
 //!   representation). Recorded as an explicit divergence assertion below.
-//! * **`varint`**: block path → [`Value::Varint`]; v5 ladder has no `varint` arm
-//!   and falls through to its VInt-length-prefixed **blob** default →
-//!   [`Value::Blob`]. Mirror image of I4 (which fixed the block side); the v5
-//!   side gap is owned by **J2**.
 //! * **non-frozen `list`/`set`/`map`**: the v5 *single-cell* ladder STUBS these
 //!   to an empty collection — production routes non-frozen collections through
 //!   the multi-cell complex-column path instead. Owning issue: **#162 / J1**.
@@ -298,21 +294,15 @@ pub(crate) fn scalar_cases() -> Vec<ScalarCase> {
             arbitrary_len: false,
             divergence: None,
         },
-        // KNOWN DIVERGENCE (J2): block -> Varint, v5 ladder blobs it (no arm).
+        // CONVERGED (issue #1885): the v5 ladder now has a `varint` arm decoding to
+        // Value::Varint with byte-identical framing to the block path.
         ScalarCase {
             cql_type: "varint",
             value: Value::Varint(vec![0x01, 0x00]),
             value_bytes: vec![0x01, 0x00],
             framing: V5Framing::VintLen,
             arbitrary_len: true,
-            divergence: Some(Divergence {
-                owner: "J2 (#1603) — collapse the ComparatorType decoders",
-                note: "CQL varint: block path decodes Value::Varint; v5 ladder has no \
-                       varint arm and falls through to its blob default (Value::Blob). \
-                       Mirror of I4 (block side fixed by #1627); v5 gap owned by J2.",
-                block: Value::Varint(vec![0x01, 0x00]),
-                v5: Value::Blob(vec![0x01, 0x00]),
-            }),
+            divergence: None,
         },
         ScalarCase {
             cql_type: "decimal",
@@ -896,6 +886,101 @@ mod write_read {
             }
         }
     }
+}
+
+// ===========================================================================
+// Issue #1885 — v5 ladder `varint` arm (mirror of the block path)
+// ===========================================================================
+
+/// The v5 ladder now decodes `varint` to `Value::Varint` (not `Value::Blob`),
+/// byte-for-byte with the block / `ComparatorType::Varint` path, across the edge
+/// cases the block path handles: negative, zero, and a value larger than i64
+/// (varint is arbitrary-precision). The stored bytes are raw two's-complement
+/// big-endian — `num_bigint::BigInt::from_signed_bytes_be` recovers the integer.
+#[tokio::test]
+async fn v5_varint_arm_decodes_edge_cases() {
+    use num_bigint::BigInt;
+
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    let parser = v5_parser();
+
+    // (label, canonical BigInt) — encoded to signed BE bytes, framed for both paths.
+    let cases: Vec<(&str, BigInt)> = vec![
+        ("zero", BigInt::from(0)),
+        ("small_positive", BigInt::from(42)),
+        ("negative", BigInt::from(-12_345_678_i64)),
+        ("minus_one", BigInt::from(-1)),
+        // Larger than i64::MAX — arbitrary-precision.
+        (
+            "greater_than_i64",
+            BigInt::from(i64::MAX) * BigInt::from(1_000_000) + BigInt::from(7),
+        ),
+        // More negative than i64::MIN.
+        (
+            "less_than_i64_min",
+            BigInt::from(i64::MIN) * BigInt::from(1_000_000) - BigInt::from(7),
+        ),
+    ];
+
+    for (label, n) in cases {
+        // Cassandra `varint` on-disk bytes = Java BigInteger.toByteArray() = signed
+        // two's-complement big-endian (never empty for a real value; zero → [0x00]).
+        let value_bytes = n.to_signed_bytes_be();
+
+        // Block path: exact-slice raw bytes.
+        let block = decode_block(&reader, "varint", &value_bytes)
+            .unwrap_or_else(|e| panic!("block varint {label} failed: {e:?}"));
+        // v5 path: VInt-length-prefixed framing.
+        let cell = frame_v5_cell(V5Framing::VintLen, &value_bytes);
+        let v5 = decode_v5(&parser, &reader, "varint", &cell)
+            .unwrap_or_else(|e| panic!("v5 varint {label} failed: {e:?}"));
+
+        // Both paths must produce Value::Varint with the SAME raw bytes.
+        assert_eq!(
+            v5,
+            Value::Varint(value_bytes.clone()),
+            "v5 varint {label} must decode to Value::Varint (not Blob)"
+        );
+        assert_eq!(
+            block, v5,
+            "LOCKSTEP: block vs v5 disagree on varint {label}"
+        );
+
+        // And the bytes must round-trip back to the canonical integer.
+        if let Value::Varint(bytes) = &v5 {
+            assert_eq!(
+                BigInt::from_signed_bytes_be(bytes),
+                n,
+                "varint {label} bytes must round-trip to the canonical BigInt"
+            );
+        } else {
+            panic!("varint {label}: expected Value::Varint, got {v5:?}");
+        }
+    }
+}
+
+/// An empty `varint` cell decodes to `Value::Varint([])` on the v5 path, matching
+/// the block path's empty-slice handling (issue #1885).
+#[tokio::test]
+async fn v5_varint_empty_matches_block() {
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    let parser = v5_parser();
+
+    let block = decode_block(&reader, "varint", &[])
+        .unwrap_or_else(|e| panic!("block empty varint failed: {e:?}"));
+    let cell = frame_v5_cell(V5Framing::VintLen, &[]);
+    let v5 = decode_v5(&parser, &reader, "varint", &cell)
+        .unwrap_or_else(|e| panic!("v5 empty varint failed: {e:?}"));
+    assert_eq!(
+        v5,
+        Value::Varint(Vec::new()),
+        "empty v5 varint → Varint([])"
+    );
+    assert_eq!(block, v5, "empty varint block vs v5 must agree");
 }
 
 // ===========================================================================


### PR DESCRIPTION
Closes #1885

## Problem (oracle-driven)
The v5 per-cell "ladder" decoder `parse_cell_value_schema_order` had **no `varint` arm**, so a CQL `varint` column read through the live v5 path fell through to the blob default → `Value::Blob` instead of `Value::Varint`. The block path already decodes it correctly (`ComparatorType::Varint => Value::Varint(value_data.to_vec())`) — that block path is the oracle.

## Fix
- Add a `CellKind::Varint` arm to the v5 ladder decoder reading the VInt-length-prefixed raw two's-complement big-endian bytes into `Value::Varint` (empty cell → `Varint([])`), byte-for-byte mirroring the block path and write side. No heuristics (#28).
- Add `CellKind::Varint` + `"varint"` mapping in `cell_kind.rs` (was falling to `Complex` → blob). `frozen<varint>` inner recursion also fixed.
- Consolidated the duplicated vint-length-prefix read into one `read_vint_prefixed_bytes` helper.

## Tests
- Flipped the #1617 decoder-lockstep varint case from recorded-divergence to converged.
- `v5_varint_arm_decodes_edge_cases`: zero, positive, negative, -1, > i64::MAX, < i64::MIN (num_bigint) — block==v5 + round-trip.
- `v5_varint_empty_matches_block`: exercises both zero-length-prefix and flags-only `[0x0C]` (`CELL_USE_ROW_TIMESTAMP | CELL_HAS_EMPTY_VALUE`) → `Value::Varint([])`.

## Review
- rust-reviewer: CLEAN. roborev (codex): 2 LOW, both addressed (DRY helper + empty-varint 0x0C coverage).

## Out-of-scope base-red unblock (flagged)
`full_index_stream_tests.rs` (from #2366) used `#[serial(work_counters)]` without importing `serial_test::serial`, leaving `cqlite-core --lib` compile-red on fresh origin/main. Added the one-line import. Its `windowed_stream_read_pattern_is_sequential` is separately load-flaky (#2366) — follow-up worthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)