### PR TITLE
fix(#1795/#1884/#1885): overflow-safe v5 cell bounds guards + Float32/varint parity + cell_value split

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_kind.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_kind.rs
@@ -55,11 +55,6 @@ pub(super) enum CellKind {
     Inet,
     /// The literal CQL `blob` type (decodes to `Blob`, empty-value → `Blob([])`).
     Blob,
-    /// CQL `varint` (arbitrary-precision integer). Decodes the VInt-length-prefixed
-    /// raw two's-complement big-endian bytes to `Value::Varint` (empty-value →
-    /// `Varint([])`), mirroring the block / `ComparatorType::Varint` path exactly
-    /// (issue #1885).
-    Varint,
     /// Frozen / tuple / non-frozen-collection / marshal-UDT / unknown-scalar types:
     /// the already-lowercased declared type string, decoded by the retained string
     /// ladder. Empty-value → `Null` (matching the pre-J1 `_ => Null` empty arm).
@@ -93,8 +88,7 @@ impl CellKind {
             "time" => CellKind::Time,
             "inet" => CellKind::Inet,
             "blob" => CellKind::Blob,
-            "varint" => CellKind::Varint,
-            // frozen<…>, tuple<…>, list/set/map<…>, marshal forms, and any
+            // frozen<…>, tuple<…>, list/set/map<…>, marshal forms, varint, and any
             // unrecognized type: decoded by the retained string ladder. Store the
             // lowercased string so the ladder needs no per-cell `to_lowercase`.
             _ => CellKind::Complex(Arc::from(lowered.as_str())),
@@ -121,7 +115,6 @@ mod tests {
         assert_eq!(CellKind::from_type("duration"), CellKind::Duration);
         assert_eq!(CellKind::from_type("inet"), CellKind::Inet);
         assert_eq!(CellKind::from_type("blob"), CellKind::Blob);
-        assert_eq!(CellKind::from_type("varint"), CellKind::Varint);
     }
 
     #[test]
@@ -161,6 +154,12 @@ mod tests {
         assert_eq!(
             CellKind::from_type("list<int>"),
             CellKind::Complex(Arc::from("list<int>"))
+        );
+        // `varint` has no dedicated scalar arm — pre-J1 it fell to the default blob
+        // decode (live) / Null (empty); it must land in `Complex`, not `Blob`.
+        assert_eq!(
+            CellKind::from_type("varint"),
+            CellKind::Complex(Arc::from("varint"))
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-use super::marshal_element::MarshalCollectionElements;
-
 impl V5CompressedLegacyParser {
     /// Parse a single cell value WITHOUT column name (schema-order format)
     ///
@@ -22,6 +20,11 @@ impl V5CompressedLegacyParser {
     ///   when the cell inherits the row-level timestamp (`USE_ROW_TIMESTAMP` flag).
     /// - `expiration`: TTL / localDeletionTime pair when the cell is expiring, or
     ///   `None` when the cell has no TTL.
+    ///
+    /// The scalar value-decode arms live in [`cell_value_scalar`], the
+    /// frozen/tuple/collection/marshal-UDT ladder in [`cell_value_complex`]
+    /// (campsite split, issue #1795); this function owns the flag/conditional-field
+    /// parsing and the tombstone/empty short-circuits.
     pub(super) fn parse_cell_value_schema_order(
         &self,
         data: &[u8],
@@ -40,7 +43,7 @@ impl V5CompressedLegacyParser {
         // rare recursive frozen-inner / in-crate test callers → resolve it locally
         // from `column.data_type` (bounded, off the per-cell scan hot path).
         kind: Option<&CellKind>,
-        _reader: &crate::storage::sstable::reader::types::SSTableReader,
+        reader: &crate::storage::sstable::reader::types::SSTableReader,
     ) -> Result<(Value, Option<i64>, Option<CellExpiration>, usize)> {
         // Cell flag constants (from Cassandra 5.0 Cell.Serializer)
         const CELL_IS_DELETED: u8 = 0x01;
@@ -175,10 +178,6 @@ impl V5CompressedLegacyParser {
                 _ => None,
             };
 
-        // Step 4: Cell path for complex columns (multi-cell collections/UDTs)
-        // For now, skip this - we'll add in a future iteration when we handle complex columns.
-        // Simple columns (int, text, boolean, uuid, etc.) don't have cell paths.
-
         // === End of Phase 2 conditional field parsing ===
 
         // CRITICAL: Inverted logic for HAS_EMPTY_VALUE_MASK
@@ -255,7 +254,13 @@ impl V5CompressedLegacyParser {
                 CellKind::Blob => Value::Blob(Vec::new()),
                 // Issue #1885: an empty `varint` cell is `Varint([])`, matching the
                 // block / `ComparatorType::Varint` path (empty slice → `Varint([])`).
-                CellKind::Varint => Value::Varint(Vec::new()),
+                // In this split layout `varint` routes through `CellKind::Complex`
+                // (the retained string ladder, decoded in `cell_value_complex`), so
+                // match on the lowered declared-type string rather than a dedicated
+                // scalar tag.
+                CellKind::Complex(lowered) if lowered.as_ref() == "varint" => {
+                    Value::Varint(Vec::new())
+                }
                 _ => {
                     tracing::warn!(
                         "V5CompressedLegacy: EMPTY value for cell '{}' (type {}), treating as NULL",
@@ -268,997 +273,83 @@ impl V5CompressedLegacyParser {
             return Ok((empty_value, cell_timestamp, cell_expiration, offset));
         }
 
-        // VInt-length-prefixed raw-bytes decode. Reads a single unsigned-VInt length
-        // prefix, bounds-checks it, and returns the exact payload bytes, advancing the
-        // shared `offset` cursor. The on-disk framing is identical for `blob` and
-        // `varint`; the caller wraps the bytes in the target `Value` variant. Extracted
-        // to one closure so the dispatch sites do not duplicate the length parse,
-        // bounds check, cursor advance, and allocation (issue #1885, roborev DRY).
-        let read_vint_prefixed_bytes = |offset: &mut usize| -> Result<Vec<u8>> {
-            if *offset >= data.len() {
-                return Err(Error::corruption(format!(
-                    "Cell '{}': unexpected end at blob length (type: {})",
-                    column.name, column.data_type
-                )));
-            }
-            // Parse the length prefix as an unsigned VInt (can be > 255 bytes).
-            let (remaining, len) = parse_vuint(&data[*offset..]).map_err(|e| {
-                Error::corruption(format!(
-                    "Cell '{}': failed to parse blob length as VInt: {:?}",
-                    column.name, e
-                ))
-            })?;
-            let len = len as usize;
-            let bytes_consumed = data[*offset..].len() - remaining.len();
-            *offset += bytes_consumed;
-
-            if *offset + len > data.len() {
-                return Err(Error::corruption(format!(
-                    "Cell '{}': need {} bytes for blob, only {} available (type: {})",
-                    column.name,
-                    len,
-                    data.len() - *offset,
-                    column.data_type
-                )));
-            }
-
-            let bytes = data[*offset..*offset + len].to_vec();
-            *offset += len;
-            Ok(bytes)
-        };
-
-        // Thin wrapper: the literal `blob` type (`CellKind::Blob`) and the
-        // `CellKind::Complex` default fall-through (unknown types) both wrap the shared
-        // VInt-prefixed bytes in `Value::Blob` — identical pre-J1 decode (the single
-        // `_ =>` blob arm). Advances the shared `offset` cursor.
-        let decode_vint_blob = |offset: &mut usize| -> Result<Value> {
-            Ok(Value::Blob(read_vint_prefixed_bytes(offset)?))
-        };
-
+        // At this point, we have a live cell with value data. Dispatch the decode on
+        // the precomputed `CellKind` (jump table): scalar arms in `cell_value_scalar`,
+        // the frozen/tuple/collection/marshal-UDT/default ladder in
+        // `cell_value_complex` (campsite split, issue #1795).
         let value = match kind {
-            CellKind::Blob => decode_vint_blob(&mut offset)?,
-            // CQL `varint`: VInt-length-prefixed raw two's-complement big-endian
-            // bytes → `Value::Varint`. Byte-for-byte the same on-disk framing as the
-            // `blob` arm (shares `read_vint_prefixed_bytes`), but preserves the declared
-            // `varint` type instead of blobbing it. Mirrors the block /
-            // `ComparatorType::Varint` path (`Value::Varint(value_data.to_vec())`) —
-            // issue #1885.
-            CellKind::Varint => Value::Varint(read_vint_prefixed_bytes(&mut offset)?),
-            CellKind::Boolean => {
-                // Boolean: [0x08][u8 value]
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': unexpected end at boolean value",
-                        column.name
-                    )));
-                }
-                let bool_byte = data[offset];
-                offset += 1;
-                Value::Boolean(bool_byte != 0)
-            }
-
-            CellKind::Int => {
-                // Integer (i32): fixed-width 4 bytes (no length prefix in Cassandra 5.0)
-                if offset + 4 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 4 bytes for int, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-                let int_val = i32::from_be_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                ]);
-                offset += 4;
-                Value::Integer(int_val)
-            }
-
-            CellKind::Text => {
-                // Text: [VInt len][text bytes]
-                // V5CompressedLegacy uses VInt length encoding for variable-length types
-                let (remaining, text_len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse text length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let text_len = text_len as usize;
-                let bytes_consumed = data[offset..].len() - remaining.len();
-                offset += bytes_consumed;
-
-                if offset + text_len > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need {} bytes for text, only {} available",
-                        column.name,
-                        text_len,
-                        data.len() - offset
-                    )));
-                }
-
-                let text_bytes = &data[offset..offset + text_len];
-                let text = String::from_utf8(text_bytes.to_vec()).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': invalid UTF-8 in text value: {}",
-                        column.name, e
-                    ))
-                })?;
-
-                offset += text_len;
-                Value::Text(text)
-            }
-
-            CellKind::Uuid => {
-                // UUID/TimeUUID: fixed-width 16 bytes (no length prefix in Cassandra 5.0 writer)
-                if offset + 16 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 16 bytes for UUID, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-
-                let uuid_bytes: [u8; 16] = data[offset..offset + 16]
-                    .try_into()
-                    .map_err(|_| Error::corruption("UUID byte conversion failed"))?;
-
-                offset += 16;
-                Value::Uuid(uuid_bytes)
-            }
-
-            CellKind::Decimal => {
-                // Decimal: [VInt total_len][i32 scale][unscaled bytes]
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': unexpected end at decimal length",
-                        column.name
-                    )));
-                }
-
-                let (remaining, total_len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse decimal length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let total_len = total_len as usize;
-                let bytes_consumed = data[offset..].len() - remaining.len();
-                offset += bytes_consumed;
-
-                if offset + total_len > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need {} bytes for decimal, only {} available",
-                        column.name,
-                        total_len,
-                        data.len() - offset
-                    )));
-                }
-
-                // First 4 bytes: scale (i32 BE)
-                if total_len < 4 {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': decimal length {} too small for scale",
-                        column.name, total_len
-                    )));
-                }
-                let scale = i32::from_be_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                ]);
-
-                // Remaining bytes: unscaled value
-                let unscaled = data[offset + 4..offset + total_len].to_vec();
-                offset += total_len;
-
-                Value::Decimal { scale, unscaled }
-            }
-
-            CellKind::BigInt => {
-                // BigInt: fixed-width 8 bytes (no length prefix in Cassandra 5.0)
-                if offset + 8 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 8 bytes for bigint, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-                let val = i64::from_be_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                    data[offset + 4],
-                    data[offset + 5],
-                    data[offset + 6],
-                    data[offset + 7],
-                ]);
-                offset += 8;
-                Value::BigInt(val)
-            }
-
-            CellKind::Counter => {
-                // Counter cells can arrive in two formats:
-                //
-                // 1. Real Cassandra CounterContext: [VInt length][header_size:i16][indices][shards]
-                //    The counter value is the sum of all shard counts.
-                //
-                // 2. CQLite writer format (raw i64): [VInt(8)][8 bytes big-endian i64]
-                //    The writer serialises Value::Counter as a plain 8-byte integer with a
-                //    length prefix of 8, identical to how BigInt is written.
-                //
-                // We try CounterContext first and fall back to the raw-i64 interpretation
-                // when the length prefix equals exactly 8 (the size of a raw i64).
-
-                // Read the VInt length prefix.
-                let (remaining, context_len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse counter context length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let context_len = context_len as usize;
-                let len_bytes_consumed = data[offset..].len() - remaining.len();
-                offset += len_bytes_consumed;
-
-                tracing::debug!(
-                    "V5CompressedLegacy: Counter '{}' context_len={} (len prefix: {} bytes)",
-                    column.name,
-                    context_len,
-                    len_bytes_consumed
-                );
-
-                if offset + context_len > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need {} bytes for counter context, only {} available",
-                        column.name,
-                        context_len,
-                        data.len() - offset
-                    )));
-                }
-
-                // Try the full CounterContext parse first.
-                match Self::parse_counter_context(data, offset, &column.name) {
-                    Ok((total, consumed)) if consumed == context_len => {
-                        // Successfully parsed a proper CounterContext.
-                        offset += consumed;
-                        tracing::debug!(
-                            "V5CompressedLegacy: Counter '{}' value={} (CounterContext), total consumed {} bytes",
-                            column.name,
-                            total,
-                            len_bytes_consumed + context_len
-                        );
-                        Value::Counter(total)
-                    }
-                    _ if context_len == 8 => {
-                        // A real Cassandra CounterContext is at minimum 36 bytes
-                        // (2 header + 2 indices + 32 body for 1 shard), so
-                        // context_len == 8 can only be produced by the CQLite writer
-                        // which serialises Counter as a raw big-endian i64.
-                        // This intentionally swallows any parse_counter_context error
-                        // for 8-byte payloads, which is safe since a valid
-                        // CounterContext can never be 8 bytes.
-                        //
-                        // Bounds already verified by the context_len check above.
-                        let val = i64::from_be_bytes([
-                            data[offset],
-                            data[offset + 1],
-                            data[offset + 2],
-                            data[offset + 3],
-                            data[offset + 4],
-                            data[offset + 5],
-                            data[offset + 6],
-                            data[offset + 7],
-                        ]);
-                        offset += 8;
-                        tracing::debug!(
-                            "V5CompressedLegacy: Counter '{}' value={} (raw i64 fallback), total consumed {} bytes",
-                            column.name,
-                            val,
-                            len_bytes_consumed + 8
-                        );
-                        Value::Counter(val)
-                    }
-                    Err(e) => return Err(e),
-                    Ok((_, consumed)) => {
-                        return Err(Error::corruption(format!(
-                            "Counter '{}': VInt length ({}) doesn't match parsed context size ({})",
-                            column.name, context_len, consumed
-                        )));
-                    }
-                }
-            }
-
-            CellKind::Double => {
-                // Double: 8 bytes, f64 big-endian (NO length prefix)
-                if offset + 8 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 8 bytes for double, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-                let val = f64::from_be_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                    data[offset + 4],
-                    data[offset + 5],
-                    data[offset + 6],
-                    data[offset + 7],
-                ]);
-                offset += 8;
-                Value::Float(val)
-            }
-
-            CellKind::Timestamp => {
-                // Timestamp: 8 bytes, i64 milliseconds big-endian (NO length prefix, per Cassandra spec)
-                if offset + 8 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 8 bytes for timestamp, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-                let millis = i64::from_be_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                    data[offset + 4],
-                    data[offset + 5],
-                    data[offset + 6],
-                    data[offset + 7],
-                ]);
-                offset += 8;
-                Value::Timestamp(millis)
-            }
-
-            CellKind::Date => {
-                // Date: [VInt len=4][i32 BE days]
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': unexpected end at date length",
-                        column.name
-                    )));
-                }
-
-                let (remaining, date_len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse date length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let date_len = date_len as usize;
-                let bytes_consumed = data[offset..].len() - remaining.len();
-                offset += bytes_consumed;
-
-                if date_len != 4 {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': expected date length 4, got {}",
-                        column.name, date_len
-                    )));
-                }
-
-                if offset + 4 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 4 bytes for date, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-
-                let stored = u32::from_be_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                ]);
-                offset += 4;
-                // Cassandra DATE: 4-byte unsigned int with Integer.MIN_VALUE offset
-                let days_since_epoch = stored.wrapping_add(i32::MIN as u32) as i32;
-                Value::Date(days_since_epoch)
-            }
-
-            CellKind::Duration => {
-                // Duration: [VInt len][months VInt][days VInt][nanos VInt]
-                // Format: Variable-length encoding with 3 VInt components
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': unexpected end at duration length",
-                        column.name
-                    )));
-                }
-
-                let (remaining, duration_len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse duration length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let duration_len = duration_len as usize;
-                let bytes_consumed = data[offset..].len() - remaining.len();
-                offset += bytes_consumed;
-
-                if offset + duration_len > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need {} bytes for duration, only {} available",
-                        column.name,
-                        duration_len,
-                        data.len() - offset
-                    )));
-                }
-
-                // Parse three VInt components from the duration_len bytes
-                let duration_bytes = &data[offset..offset + duration_len];
-
-                // Parse months (signed VInt)
-                let (remaining, months) = parse_vint(duration_bytes).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse duration months: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let pos = duration_bytes.len() - remaining.len();
-
-                // Parse days (signed VInt)
-                let (remaining, days) = parse_vint(&duration_bytes[pos..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse duration days: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let pos = duration_bytes.len() - remaining.len();
-
-                // Parse nanoseconds (signed VInt)
-                let (remaining, nanos) = parse_vint(&duration_bytes[pos..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse duration nanos: {:?}",
-                        column.name, e
-                    ))
-                })?;
-
-                // Verify we consumed all duration bytes
-                if !remaining.is_empty() {
-                    warn!(
-                        "V5CompressedLegacy: Duration '{}' has {} extra bytes after parsing",
-                        column.name,
-                        remaining.len()
-                    );
-                }
-
-                // months/days are i32 in Cassandra's DurationType. Reject
-                // (rather than silently truncate via `as i32`) any encoded value
-                // outside the i32 range so a corrupt encoding errors instead of
-                // wrapping (issue #1632, item b).
-                let months = i32::try_from(months).map_err(|_| {
-                    Error::corruption(format!(
-                        "Cell '{}': duration months out of i32 range",
-                        column.name
-                    ))
-                })?;
-                let days = i32::try_from(days).map_err(|_| {
-                    Error::corruption(format!(
-                        "Cell '{}': duration days out of i32 range",
-                        column.name
-                    ))
-                })?;
-
-                offset += duration_len;
-                Value::Duration {
-                    months,
-                    days,
-                    nanos,
-                }
-            }
-
-            CellKind::Float => {
-                // Float: 4 bytes, f32 big-endian (NO length prefix, fixed size)
-                if offset + 4 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 4 bytes for float, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-
-                let val = f32::from_be_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                ]);
-                offset += 4;
-                Value::Float(val as f64) // Convert f32 to f64 for storage
-            }
-
-            CellKind::SmallInt => {
-                // SmallInt: [VInt len=2][i16 BE]
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': unexpected end at smallint length",
-                        column.name
-                    )));
-                }
-
-                let (remaining, len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse smallint length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let len = len as usize;
-                let bytes_consumed = data[offset..].len() - remaining.len();
-                offset += bytes_consumed;
-
-                if len != 2 {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': expected smallint length 2, got {}",
-                        column.name, len
-                    )));
-                }
-
-                if offset + 2 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 2 bytes for smallint, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-
-                let val = i16::from_be_bytes([data[offset], data[offset + 1]]);
-                offset += 2;
-                Value::SmallInt(val)
-            }
-
-            CellKind::TinyInt => {
-                // TinyInt: [VInt len=1][i8]
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': unexpected end at tinyint length",
-                        column.name
-                    )));
-                }
-
-                let (remaining, len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse tinyint length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let len = len as usize;
-                let bytes_consumed = data[offset..].len() - remaining.len();
-                offset += bytes_consumed;
-
-                if len != 1 {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': expected tinyint length 1, got {}",
-                        column.name, len
-                    )));
-                }
-
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 1 byte for tinyint, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-
-                let val = data[offset] as i8;
-                offset += 1;
-                Value::TinyInt(val)
-            }
-
-            CellKind::Time => {
-                // Time: [VInt len=8][i64 BE nanoseconds since midnight]
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': unexpected end at time length",
-                        column.name
-                    )));
-                }
-                let (remaining, time_len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse time length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let time_len = time_len as usize;
-                let bytes_consumed = data[offset..].len() - remaining.len();
-                offset += bytes_consumed;
-                if time_len != 8 {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': expected time length 8, got {}",
-                        column.name, time_len
-                    )));
-                }
-                if offset + 8 > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need 8 bytes for time value, only {} available",
-                        column.name,
-                        data.len() - offset
-                    )));
-                }
-                let nanos = i64::from_be_bytes([
-                    data[offset],
-                    data[offset + 1],
-                    data[offset + 2],
-                    data[offset + 3],
-                    data[offset + 4],
-                    data[offset + 5],
-                    data[offset + 6],
-                    data[offset + 7],
-                ]);
-                offset += 8;
-                Value::Time(nanos)
-            }
-
-            CellKind::Inet => {
-                // Inet: [VInt len][address bytes] (len is 4 for IPv4, 16 for IPv6)
-                if offset >= data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': unexpected end at inet length",
-                        column.name
-                    )));
-                }
-
-                let (remaining, len) = parse_vuint(&data[offset..]).map_err(|e| {
-                    Error::corruption(format!(
-                        "Cell '{}': failed to parse inet length as VInt: {:?}",
-                        column.name, e
-                    ))
-                })?;
-                let len = len as usize;
-                let bytes_consumed = data[offset..].len() - remaining.len();
-                offset += bytes_consumed;
-
-                if len != 4 && len != 16 {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': invalid inet length {}, expected 4 or 16",
-                        column.name, len
-                    )));
-                }
-
-                if offset + len > data.len() {
-                    return Err(Error::corruption(format!(
-                        "Cell '{}': need {} bytes for inet, only {} available",
-                        column.name,
-                        len,
-                        data.len() - offset
-                    )));
-                }
-
-                let bytes = data[offset..offset + len].to_vec();
-                offset += len;
-                Value::Inet(bytes)
-            }
-
-            // Complex types: frozen, tuple, non-frozen collection, marshal-UDT, and
-            // any unnamed/default type. J1 (issue #1635): the DISPATCH
-            // is per-column via this single `CellKind::Complex` arm; the retained
-            // prefix ladder (Epic J2 collapses it) uses the tag's already-lowercased
-            // declared type as `type_str` — exactly the pre-J1 `normalized_type`, so
-            // there is NO per-cell `to_lowercase`. The ladder ordering is unchanged.
-            CellKind::Complex(lowered) => {
-                let type_str: &str = lowered;
-                if type_str.starts_with("frozen<") {
-                    // Frozen types: unwrap inner type and route to appropriate parser
-                    let inner_type = self.extract_frozen_inner_type(type_str)?;
-
-                    tracing::debug!(
-                        "V5CompressedLegacy: Parsing frozen type '{}' -> inner type '{}'",
-                        type_str,
-                        inner_type
-                    );
-
-                    // Issue #1340: extract the AUTHORITATIVE marshal element type(s)
-                    // from the on-disk SerializationHeader marshal type (`header_type`).
-                    // When an element is a `frozen<UDT>`, threading the marshal type lets
-                    // it decode to a typed `Value::Frozen(Value::Udt)` registry-free
-                    // (precedence: header marshal → registry → Blob, no byte-pattern
-                    // inference — no-heuristics #28). Extracted once per frozen cell
-                    // (before the element loop); the result borrows from `header_type`,
-                    // so the per-element loop is allocation-free.
-                    let marshal_elems =
-                        header_type.and_then(Self::extract_marshal_collection_elements);
-                    // Shared for list & set (both are `Sequence`): the borrowed element
-                    // marshal type, or `None` for a map / absent / mismatched marshal.
-                    let sequence_marshal_elem = match &marshal_elems {
-                        Some(MarshalCollectionElements::Sequence(m)) => Some(*m),
-                        _ => None,
-                    };
-
-                    // Route to appropriate frozen collection parser
-                    let (inner_value, new_offset) = if inner_type.starts_with("list<") {
-                        let schema_elem =
-                            self.extract_collection_element_type(&inner_type, "list")?;
-                        let element_type =
-                            Self::prefer_udt_marshal_element(sequence_marshal_elem, &schema_elem);
-                        self.parse_frozen_list_value(data, offset, element_type, column, _reader)?
-                    } else if inner_type.starts_with("set<") {
-                        let schema_elem =
-                            self.extract_collection_element_type(&inner_type, "set")?;
-                        let element_type =
-                            Self::prefer_udt_marshal_element(sequence_marshal_elem, &schema_elem);
-                        self.parse_frozen_set_value(data, offset, element_type, column, _reader)?
-                    } else if inner_type.starts_with("map<") {
-                        let (schema_key, schema_val) = self.extract_map_types(&inner_type)?;
-                        let (marshal_key, marshal_val) = match &marshal_elems {
-                            Some(MarshalCollectionElements::Map(k, v)) => (Some(*k), Some(*v)),
-                            _ => (None, None),
-                        };
-                        let key_type = Self::prefer_udt_marshal_element(marshal_key, &schema_key);
-                        let value_type = Self::prefer_udt_marshal_element(marshal_val, &schema_val);
-                        self.parse_frozen_map_value(
-                            data, offset, key_type, value_type, column, _reader,
-                        )?
-                    } else if Self::is_udt_type(&column.data_type) {
-                        // Frozen UDT - parse using UDT parser
-                        // The column.data_type contains the full Cassandra type string including UserType
-                        tracing::debug!(
-                            "V5CompressedLegacy: Parsing frozen UDT column '{}' type='{}'",
-                            column.name,
-                            column.data_type
-                        );
-
-                        // Parse UDT definition from the type string
-                        let udt_def = Self::parse_udt_type_definition(&column.data_type)?;
-
-                        // First read the VInt-prefixed blob length
-                        let (remaining, blob_len_raw) =
-                            parse_vuint(&data[offset..]).map_err(|e| {
-                                Error::corruption(format!(
-                                    "Frozen UDT '{}': failed to parse blob length: {:?}",
-                                    column.name, e
-                                ))
-                            })?;
-                        if blob_len_raw > MAX_CELL_VALUE_LENGTH {
-                            return Err(Error::corruption(format!(
-                                "Frozen UDT '{}': blob_len {} exceeds maximum {}",
-                                column.name, blob_len_raw, MAX_CELL_VALUE_LENGTH
-                            )));
-                        }
-                        let blob_len = blob_len_raw as usize;
-                        let bytes_consumed = data[offset..].len() - remaining.len();
-                        offset += bytes_consumed;
-
-                        if offset + blob_len > data.len() {
-                            return Err(Error::corruption(format!(
-                                "Frozen UDT '{}': need {} bytes but only {} available",
-                                column.name,
-                                blob_len,
-                                data.len() - offset
-                            )));
-                        }
-
-                        // Parse UDT value from the blob
-                        let udt_data = &data[offset..offset + blob_len];
-                        let (udt_value, _) = self.parse_udt_value(udt_data, 0, &udt_def, column)?;
-                        offset += blob_len;
-
-                        (udt_value, offset)
-                    } else if let Some(udt_def) = self
-                        .udt_registry
-                        .as_ref()
-                        .and_then(|reg| reg.get_udt(&self.keyspace, &inner_type).cloned())
-                    {
-                        // frozen<short_udt_name>: look up the concrete UDT definition in the
-                        // registry (Issue #502).  This handles type strings like
-                        // `frozen<person>` where "person" is a registered UDT rather than a
-                        // collection or a full marshal-format UserType string.
-                        tracing::debug!(
-                        "V5CompressedLegacy: Resolving frozen UDT '{}' via registry for column '{}'",
-                        inner_type,
-                        column.name,
-                    );
-
-                        // Read VUInt-prefixed blob length (same framing as tuple and
-                        // marshal-format UDT cells).
-                        let (remaining, blob_len_raw) =
-                            parse_vuint(&data[offset..]).map_err(|e| {
-                                Error::corruption(format!(
-                            "Frozen UDT '{}' (column '{}'): failed to parse blob length: {:?}",
-                            inner_type, column.name, e
-                        ))
-                            })?;
-                        if blob_len_raw > MAX_CELL_VALUE_LENGTH {
-                            return Err(Error::corruption(format!(
-                                "Frozen UDT '{}' (column '{}'): blob_len {} exceeds maximum {}",
-                                inner_type, column.name, blob_len_raw, MAX_CELL_VALUE_LENGTH
-                            )));
-                        }
-                        let blob_len = blob_len_raw as usize;
-                        let len_bytes_consumed = data[offset..].len() - remaining.len();
-                        offset += len_bytes_consumed;
-
-                        if offset + blob_len > data.len() {
-                            return Err(Error::corruption(format!(
-                            "Frozen UDT '{}' (column '{}'): need {} bytes but only {} available",
-                            inner_type,
-                            column.name,
-                            blob_len,
-                            data.len() - offset
-                        )));
-                        }
-
-                        let udt_data = &data[offset..offset + blob_len];
-                        let (udt_value, _) = self.parse_udt_value(udt_data, 0, &udt_def, column)?;
-                        offset += blob_len;
-
-                        (udt_value, offset)
-                    } else if let Some(ht) =
-                        header_type.filter(|ht| Self::marshal_is_top_level_frozen_udt(ht))
-                    {
-                        // Issue #1080: NO UdtRegistry is wired and the supplied schema
-                        // short form `frozen<person_type>` carries no field defs, but
-                        // the AUTHORITATIVE on-disk SerializationHeader marshal type for
-                        // this column is the full
-                        // `FrozenType(UserType(ks,hexname,field:Type,...))`. Decode the
-                        // UDT STRUCTURALLY from that header type (no guessing, issue #28)
-                        // rather than dropping the column (which also broke the Err→break
-                        // loop, silently losing all trailing columns).
-                        self.decode_frozen_udt_from_header_type(data, offset, ht, column)?
-                    } else {
-                        // Detect bare identifiers that look like unregistered UDT names.
-                        // A bare identifier has no '<' (not a container or tuple) and does not
-                        // match any known CQL primitive type.  If we reach this branch with
-                        // such an identifier it means the UDT was not in the registry — return
-                        // an actionable schema error rather than silently producing a Blob.
-                        //
-                        // Legitimate fall-through types handled below:
-                        //   • tuple<...>  (contains '<')
-                        //   • known primitives: int, text, uuid, boolean, blob, float, double,
-                        //     decimal, varint, bigint, counter, timestamp, date, time, duration,
-                        //     inet, smallint, tinyint, varchar, ascii, timeuuid
-                        const KNOWN_PRIMITIVES: &[&str] = &[
-                            "int",
-                            "bigint",
-                            "counter",
-                            "smallint",
-                            "tinyint",
-                            "text",
-                            "varchar",
-                            "ascii",
-                            "uuid",
-                            "timeuuid",
-                            "boolean",
-                            "blob",
-                            "float",
-                            "double",
-                            "decimal",
-                            "varint",
-                            "timestamp",
-                            "date",
-                            "time",
-                            "duration",
-                            "inet",
-                        ];
-                        let is_container = inner_type.contains('<');
-                        let is_primitive = KNOWN_PRIMITIVES.contains(&inner_type.as_str());
-                        if !is_container && !is_primitive {
-                            // Bare identifier that is neither a container nor a primitive —
-                            // this is an unregistered UDT name.
-                            return Err(Error::schema(format!(
-                            "frozen<{inner}>: UDT '{inner}' not found in registry for keyspace '{}'; \
-                             register it before reading",
-                            self.keyspace,
-                            inner = inner_type,
-                        )));
-                        }
-                        // Non-collection / primitive frozen type — recurse normally.
-                        // The recursive call now returns 4 elements; we only need value + offset.
-                        let mut inner_column = column.clone();
-                        inner_column.data_type = inner_type.clone();
-                        let (inner_val, _inner_ts, _inner_exp, inner_off) = self
-                            .parse_cell_value_schema_order(
-                                data,
-                                offset,
-                                &inner_column,
-                                None,
-                                // Frozen-inner recursion: resolve the tag locally from
-                                // `inner_column.data_type` (bounded, off the per-cell scan
-                                // hot path).
-                                None,
-                                _reader,
-                            )?;
-                        (inner_val, inner_off)
-                    };
-
-                    offset = new_offset;
-
-                    // Wrap in Frozen
-                    Value::Frozen(Box::new(inner_value))
-                } else if type_str.starts_with("tuple<") {
-                    // Tuple types: parse fixed number of elements
-                    self.parse_tuple_value(data, &mut offset, type_str, column, _reader)?
-                }
-                // Non-frozen collections: list, set, map
-                // TODO(Issue #162, Task 3): Multi-cell collection parsing
-                //
-                // Collections in V5CompressedLegacy are stored as MULTIPLE CELLS with path identifiers,
-                // NOT as single blob values. The current single-cell parser cannot handle this.
-                //
-                // Format (from sstabledump analysis):
-                //   {"name": "scores", "deletion_info": {...}},  // Collection tombstone
-                //   {"name": "scores", "path": ["uuid1"], "value": 23},  // Element 1
-                //   {"name": "scores", "path": ["uuid2"], "value": 99},  // Element 2
-                //
-                // Required implementation:
-                //   1. Parse cell path (clustering key bytes) for each collection element
-                //   2. Detect collection tombstone cell (has deletion_info, no path/value)
-                //   3. Read N element cells (each with path + value)
-                //   4. Aggregate elements into Value::List/Set/Map based on column type
-                //   5. Handle different path encodings:
-                //      - list<T>: path is UUID bytes (timeuuid for ordering)
-                //      - set<T>: path is serialized element value (key), value is empty
-                //      - map<K,V>: path is serialized key, value is serialized value
-                //
-                // This is a fundamental architectural change requiring cell-level parsing
-                // before column-level aggregation. For now, return stub to unblock downstream work.
-                else if type_str.starts_with("list<")
-                    || type_str.starts_with("set<")
-                    || type_str.starts_with("map<")
-                {
-                    warn!(
-                    "V5CompressedLegacy: Non-frozen collection '{}' type '{}' requires multi-cell parsing (not yet implemented). \
-                     Collections are stored as multiple cells with path identifiers, requiring cell-level aggregation. \
-                     Returning empty collection as placeholder. See Issue #162 Task 3 for implementation plan.",
-                    column.name, column.data_type
-                );
-
-                    // Return empty collection based on type
-                    if type_str.starts_with("list<") {
-                        Value::List(Vec::new())
-                    } else if type_str.starts_with("set<") {
-                        Value::Set(Vec::new())
-                    } else {
-                        Value::Map(Vec::new())
-                    }
-                }
-                // Issue #1080 / roborev job 1363: marshal-form frozen UDT. When the
-                // schema is DERIVED FROM the on-disk header (rather than supplied as a
-                // CQL short form), `column.data_type` is the authoritative marshal
-                // string `org.apache.cassandra.db.marshal.FrozenType(...UserType...)`,
-                // which does NOT start with CQL `frozen<` and so misses the arm above.
-                // Decode it structurally from that marshal type (same authoritative
-                // path as the supplied-schema header fallback) instead of blobbing it.
-                // `marshal_is_top_level_frozen_udt` accepts ONLY a top-level
-                // `FrozenType(UserType(...))` (NOT a frozen collection that contains a
-                // UDT, e.g. `FrozenType(ListType(UserType(...)))` — roborev 1365), and a
-                // non-frozen top-level UDT is routed to the complex branch by
-                // `is_complex_column`, so reaching here means a single-cell frozen UDT
-                // → wrap in `Value::Frozen` (consistent with the CQL `frozen<` arm).
-                else if Self::marshal_is_top_level_frozen_udt(&column.data_type) {
-                    let (udt_value, new_offset) = self.decode_frozen_udt_from_header_type(
-                        data,
-                        offset,
-                        &column.data_type,
-                        column,
-                    )?;
-                    offset = new_offset;
-                    Value::Frozen(Box::new(udt_value))
-                }
-                // TODO(Issue #162): UDT parsing requires schema registry access
-                // For now, UDTs fall through to blob. Future implementation will:
-                // - Extract UDT name from type_str
-                // - Look up UDT definition in schema registry
-                // - Parse fields according to UDT schema
-                // - Return Value::Udt(UdtValue)
-
-                // Default: treat as VInt-length-prefixed blob (unknown type).
-                // Shares the `decode_vint_blob` closure with the literal-`blob`
-                // `CellKind::Blob` arm — identical decode pre-J1 (both hit `_ =>`).
-                else {
-                    decode_vint_blob(&mut offset)?
-                }
-            }
+            CellKind::Complex(lowered) => self.decode_complex_cell_value(
+                data,
+                &mut offset,
+                lowered,
+                column,
+                header_type,
+                reader,
+            )?,
+            scalar => Self::decode_scalar_cell_value(data, &mut offset, scalar, column)?,
         };
 
         Ok((value, cell_timestamp, cell_expiration, offset))
+    }
+
+    /// Read a Cassandra-VInt-length-prefixed byte run with **overflow-safe** bounds
+    /// checks (issue #1795).
+    ///
+    /// The reported panic (`attempt to add with overflow`) came from decoding an
+    /// UNCAPPED `parse_vuint` length into `usize` and then computing
+    /// `offset + total_len > data.len()` — the ADD overflowed on an adversarial
+    /// length prefix before the guard could reject it. This helper mirrors the
+    /// blessed [`crate::parser::vint::parse_vint_length`] pattern: it rejects a
+    /// length exceeding [`MAX_CELL_VALUE_LENGTH`] BEFORE the `as usize` cast, and
+    /// compares against the remaining bytes with a saturating subtraction (never
+    /// `offset + len`) so no attacker-controlled length can trigger an add-overflow
+    /// panic. Returns the value bytes (borrowed from `data`) and advances `offset`
+    /// past them. Shared by the scalar blob/text/decimal/duration arms and the
+    /// complex blob/varint fall-throughs so the bounds logic lives in one place.
+    pub(super) fn read_vint_length_prefixed_bytes<'d>(
+        data: &'d [u8],
+        offset: &mut usize,
+        column: &crate::schema::Column,
+        what: &str,
+    ) -> Result<&'d [u8]> {
+        if *offset >= data.len() {
+            return Err(Error::corruption(format!(
+                "Cell '{}': unexpected end at {} length",
+                column.name, what
+            )));
+        }
+        let (remaining, len_raw) = parse_vuint(&data[*offset..]).map_err(|e| {
+            Error::corruption(format!(
+                "Cell '{}': failed to parse {} length as VInt: {:?}",
+                column.name, what, e
+            ))
+        })?;
+        // Cap BEFORE the `as usize` cast (matching `parse_vint_length`): an
+        // adversarial length must return `Err`, never overflow the add below.
+        if len_raw > MAX_CELL_VALUE_LENGTH {
+            return Err(Error::corruption(format!(
+                "Cell '{}': {} length {} exceeds maximum {}",
+                column.name, what, len_raw, MAX_CELL_VALUE_LENGTH
+            )));
+        }
+        let len = len_raw as usize;
+        let bytes_consumed = data[*offset..].len() - remaining.len();
+        *offset += bytes_consumed;
+
+        // Overflow-safe bounds check: `len > remaining` rather than
+        // `offset + len > data.len()` (the latter can overflow `usize`).
+        if len > data.len().saturating_sub(*offset) {
+            return Err(Error::corruption(format!(
+                "Cell '{}': need {} bytes for {}, only {} available",
+                column.name,
+                len,
+                what,
+                data.len() - *offset
+            )));
+        }
+
+        let bytes = &data[*offset..*offset + len];
+        *offset += len;
+        Ok(bytes)
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_complex.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_complex.rs
@@ -1,0 +1,333 @@
+//! Complex value-decode ladder for the V5CompressedLegacy per-cell decoder.
+//!
+//! Campsite split of `cell_value.rs` (issue #1795): this file owns the
+//! frozen / tuple / non-frozen-collection / marshal-UDT / `varint` / unknown-scalar
+//! decode ladder ([`CellKind::Complex`]); the scalar arms live in
+//! `cell_value_scalar.rs` and the flag/conditional-field parsing in `cell_value.rs`.
+//!
+//! The blob/`varint` fall-throughs route their length prefix through
+//! [`super::V5CompressedLegacyParser::read_vint_length_prefixed_bytes`] for
+//! overflow-safe bounds checks (issue #1795).
+
+use super::marshal_element::MarshalCollectionElements;
+use super::*;
+
+impl V5CompressedLegacyParser {
+    /// Decode a live cell value for a [`CellKind::Complex`] column: frozen types,
+    /// tuples, non-frozen collections, marshal-form frozen UDTs, CQL `varint`, and
+    /// the unknown-scalar blob fall-through. `lowered` is the already-lowercased
+    /// declared type string. Advances `offset` past the consumed value bytes.
+    pub(super) fn decode_complex_cell_value(
+        &self,
+        data: &[u8],
+        offset: &mut usize,
+        lowered: &str,
+        column: &crate::schema::Column,
+        header_type: Option<&str>,
+        reader: &crate::storage::sstable::reader::types::SSTableReader,
+    ) -> Result<Value> {
+        let mut off = *offset;
+        let type_str: &str = lowered;
+        let value = if type_str.starts_with("frozen<") {
+            // Frozen types: unwrap inner type and route to appropriate parser
+            let inner_type = self.extract_frozen_inner_type(type_str)?;
+
+            tracing::debug!(
+                "V5CompressedLegacy: Parsing frozen type '{}' -> inner type '{}'",
+                type_str,
+                inner_type
+            );
+
+            // Issue #1340: extract the AUTHORITATIVE marshal element type(s)
+            // from the on-disk SerializationHeader marshal type (`header_type`).
+            // When an element is a `frozen<UDT>`, threading the marshal type lets
+            // it decode to a typed `Value::Frozen(Value::Udt)` registry-free
+            // (precedence: header marshal → registry → Blob, no byte-pattern
+            // inference — no-heuristics #28). Extracted once per frozen cell
+            // (before the element loop); the result borrows from `header_type`,
+            // so the per-element loop is allocation-free.
+            let marshal_elems = header_type.and_then(Self::extract_marshal_collection_elements);
+            // Shared for list & set (both are `Sequence`): the borrowed element
+            // marshal type, or `None` for a map / absent / mismatched marshal.
+            let sequence_marshal_elem = match &marshal_elems {
+                Some(MarshalCollectionElements::Sequence(m)) => Some(*m),
+                _ => None,
+            };
+
+            // Route to appropriate frozen collection parser
+            let (inner_value, new_offset) = if inner_type.starts_with("list<") {
+                let schema_elem = self.extract_collection_element_type(&inner_type, "list")?;
+                let element_type =
+                    Self::prefer_udt_marshal_element(sequence_marshal_elem, &schema_elem);
+                self.parse_frozen_list_value(data, off, element_type, column, reader)?
+            } else if inner_type.starts_with("set<") {
+                let schema_elem = self.extract_collection_element_type(&inner_type, "set")?;
+                let element_type =
+                    Self::prefer_udt_marshal_element(sequence_marshal_elem, &schema_elem);
+                self.parse_frozen_set_value(data, off, element_type, column, reader)?
+            } else if inner_type.starts_with("map<") {
+                let (schema_key, schema_val) = self.extract_map_types(&inner_type)?;
+                let (marshal_key, marshal_val) = match &marshal_elems {
+                    Some(MarshalCollectionElements::Map(k, v)) => (Some(*k), Some(*v)),
+                    _ => (None, None),
+                };
+                let key_type = Self::prefer_udt_marshal_element(marshal_key, &schema_key);
+                let value_type = Self::prefer_udt_marshal_element(marshal_val, &schema_val);
+                self.parse_frozen_map_value(data, off, key_type, value_type, column, reader)?
+            } else if Self::is_udt_type(&column.data_type) {
+                // Frozen UDT - parse using UDT parser
+                // The column.data_type contains the full Cassandra type string including UserType
+                tracing::debug!(
+                    "V5CompressedLegacy: Parsing frozen UDT column '{}' type='{}'",
+                    column.name,
+                    column.data_type
+                );
+
+                // Parse UDT definition from the type string
+                let udt_def = Self::parse_udt_type_definition(&column.data_type)?;
+
+                // First read the VInt-prefixed blob length
+                let (remaining, blob_len_raw) = parse_vuint(&data[off..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Frozen UDT '{}': failed to parse blob length: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                if blob_len_raw > MAX_CELL_VALUE_LENGTH {
+                    return Err(Error::corruption(format!(
+                        "Frozen UDT '{}': blob_len {} exceeds maximum {}",
+                        column.name, blob_len_raw, MAX_CELL_VALUE_LENGTH
+                    )));
+                }
+                let blob_len = blob_len_raw as usize;
+                let bytes_consumed = data[off..].len() - remaining.len();
+                off += bytes_consumed;
+
+                if blob_len > data.len().saturating_sub(off) {
+                    return Err(Error::corruption(format!(
+                        "Frozen UDT '{}': need {} bytes but only {} available",
+                        column.name,
+                        blob_len,
+                        data.len() - off
+                    )));
+                }
+
+                // Parse UDT value from the blob
+                let udt_data = &data[off..off + blob_len];
+                let (udt_value, _) = self.parse_udt_value(udt_data, 0, &udt_def, column)?;
+                off += blob_len;
+
+                (udt_value, off)
+            } else if let Some(udt_def) = self
+                .udt_registry
+                .as_ref()
+                .and_then(|reg| reg.get_udt(&self.keyspace, &inner_type).cloned())
+            {
+                // frozen<short_udt_name>: look up the concrete UDT definition in the
+                // registry (Issue #502).  This handles type strings like
+                // `frozen<person>` where "person" is a registered UDT rather than a
+                // collection or a full marshal-format UserType string.
+                tracing::debug!(
+                    "V5CompressedLegacy: Resolving frozen UDT '{}' via registry for column '{}'",
+                    inner_type,
+                    column.name,
+                );
+
+                // Read VUInt-prefixed blob length (same framing as tuple and
+                // marshal-format UDT cells).
+                let (remaining, blob_len_raw) = parse_vuint(&data[off..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Frozen UDT '{}' (column '{}'): failed to parse blob length: {:?}",
+                        inner_type, column.name, e
+                    ))
+                })?;
+                if blob_len_raw > MAX_CELL_VALUE_LENGTH {
+                    return Err(Error::corruption(format!(
+                        "Frozen UDT '{}' (column '{}'): blob_len {} exceeds maximum {}",
+                        inner_type, column.name, blob_len_raw, MAX_CELL_VALUE_LENGTH
+                    )));
+                }
+                let blob_len = blob_len_raw as usize;
+                let len_bytes_consumed = data[off..].len() - remaining.len();
+                off += len_bytes_consumed;
+
+                if blob_len > data.len().saturating_sub(off) {
+                    return Err(Error::corruption(format!(
+                        "Frozen UDT '{}' (column '{}'): need {} bytes but only {} available",
+                        inner_type,
+                        column.name,
+                        blob_len,
+                        data.len() - off
+                    )));
+                }
+
+                let udt_data = &data[off..off + blob_len];
+                let (udt_value, _) = self.parse_udt_value(udt_data, 0, &udt_def, column)?;
+                off += blob_len;
+
+                (udt_value, off)
+            } else if let Some(ht) =
+                header_type.filter(|ht| Self::marshal_is_top_level_frozen_udt(ht))
+            {
+                // Issue #1080: NO UdtRegistry is wired and the supplied schema
+                // short form `frozen<person_type>` carries no field defs, but
+                // the AUTHORITATIVE on-disk SerializationHeader marshal type for
+                // this column is the full
+                // `FrozenType(UserType(ks,hexname,field:Type,...))`. Decode the
+                // UDT STRUCTURALLY from that header type (no guessing, issue #28)
+                // rather than dropping the column (which also broke the Err→break
+                // loop, silently losing all trailing columns).
+                self.decode_frozen_udt_from_header_type(data, off, ht, column)?
+            } else {
+                // Detect bare identifiers that look like unregistered UDT names.
+                // A bare identifier has no '<' (not a container or tuple) and does not
+                // match any known CQL primitive type.  If we reach this branch with
+                // such an identifier it means the UDT was not in the registry — return
+                // an actionable schema error rather than silently producing a Blob.
+                //
+                // Legitimate fall-through types handled below:
+                //   • tuple<...>  (contains '<')
+                //   • known primitives: int, text, uuid, boolean, blob, float, double,
+                //     decimal, varint, bigint, counter, timestamp, date, time, duration,
+                //     inet, smallint, tinyint, varchar, ascii, timeuuid
+                const KNOWN_PRIMITIVES: &[&str] = &[
+                    "int",
+                    "bigint",
+                    "counter",
+                    "smallint",
+                    "tinyint",
+                    "text",
+                    "varchar",
+                    "ascii",
+                    "uuid",
+                    "timeuuid",
+                    "boolean",
+                    "blob",
+                    "float",
+                    "double",
+                    "decimal",
+                    "varint",
+                    "timestamp",
+                    "date",
+                    "time",
+                    "duration",
+                    "inet",
+                ];
+                let is_container = inner_type.contains('<');
+                let is_primitive = KNOWN_PRIMITIVES.contains(&inner_type.as_str());
+                if !is_container && !is_primitive {
+                    // Bare identifier that is neither a container nor a primitive —
+                    // this is an unregistered UDT name.
+                    return Err(Error::schema(format!(
+                        "frozen<{inner}>: UDT '{inner}' not found in registry for keyspace '{}'; \
+                         register it before reading",
+                        self.keyspace,
+                        inner = inner_type,
+                    )));
+                }
+                // Non-collection / primitive frozen type — recurse normally.
+                // The recursive call now returns 4 elements; we only need value + offset.
+                let mut inner_column = column.clone();
+                inner_column.data_type = inner_type.clone();
+                let (inner_val, _inner_ts, _inner_exp, inner_off) = self
+                    .parse_cell_value_schema_order(
+                        data,
+                        off,
+                        &inner_column,
+                        None,
+                        // Frozen-inner recursion: resolve the tag locally from
+                        // `inner_column.data_type` (bounded, off the per-cell scan
+                        // hot path).
+                        None,
+                        reader,
+                    )?;
+                (inner_val, inner_off)
+            };
+
+            off = new_offset;
+
+            // Wrap in Frozen
+            Value::Frozen(Box::new(inner_value))
+        } else if type_str.starts_with("tuple<") {
+            // Tuple types: parse fixed number of elements
+            self.parse_tuple_value(data, &mut off, type_str, column, reader)?
+        }
+        // Non-frozen collections: list, set, map
+        // TODO(Issue #162, Task 3): Multi-cell collection parsing
+        //
+        // Collections in V5CompressedLegacy are stored as MULTIPLE CELLS with path identifiers,
+        // NOT as single blob values. The current single-cell parser cannot handle this.
+        //
+        // Format (from sstabledump analysis):
+        //   {"name": "scores", "deletion_info": {...}},  // Collection tombstone
+        //   {"name": "scores", "path": ["uuid1"], "value": 23},  // Element 1
+        //   {"name": "scores", "path": ["uuid2"], "value": 99},  // Element 2
+        //
+        // Required implementation:
+        //   1. Parse cell path (clustering key bytes) for each collection element
+        //   2. Detect collection tombstone cell (has deletion_info, no path/value)
+        //   3. Read N element cells (each with path + value)
+        //   4. Aggregate elements into Value::List/Set/Map based on column type
+        //   5. Handle different path encodings:
+        //      - list<T>: path is UUID bytes (timeuuid for ordering)
+        //      - set<T>: path is serialized element value (key), value is empty
+        //      - map<K,V>: path is serialized key, value is serialized value
+        //
+        // This is a fundamental architectural change requiring cell-level parsing
+        // before column-level aggregation. For now, return stub to unblock downstream work.
+        else if type_str.starts_with("list<")
+            || type_str.starts_with("set<")
+            || type_str.starts_with("map<")
+        {
+            warn!(
+                "V5CompressedLegacy: Non-frozen collection '{}' type '{}' requires multi-cell parsing (not yet implemented). \
+                 Collections are stored as multiple cells with path identifiers, requiring cell-level aggregation. \
+                 Returning empty collection as placeholder. See Issue #162 Task 3 for implementation plan.",
+                column.name, column.data_type
+            );
+
+            // Return empty collection based on type
+            if type_str.starts_with("list<") {
+                Value::List(Vec::new())
+            } else if type_str.starts_with("set<") {
+                Value::Set(Vec::new())
+            } else {
+                Value::Map(Vec::new())
+            }
+        }
+        // Issue #1080 / roborev job 1363: marshal-form frozen UDT. When the
+        // schema is DERIVED FROM the on-disk header (rather than supplied as a
+        // CQL short form), `column.data_type` is the authoritative marshal
+        // string `org.apache.cassandra.db.marshal.FrozenType(...UserType...)`,
+        // which does NOT start with CQL `frozen<` and so misses the arm above.
+        // Decode it structurally from that marshal type (same authoritative
+        // path as the supplied-schema header fallback) instead of blobbing it.
+        // `marshal_is_top_level_frozen_udt` accepts ONLY a top-level
+        // `FrozenType(UserType(...))` (NOT a frozen collection that contains a
+        // UDT, e.g. `FrozenType(ListType(UserType(...)))` — roborev 1365), and a
+        // non-frozen top-level UDT is routed to the complex branch by
+        // `is_complex_column`, so reaching here means a single-cell frozen UDT
+        // → wrap in `Value::Frozen` (consistent with the CQL `frozen<` arm).
+        else if Self::marshal_is_top_level_frozen_udt(&column.data_type) {
+            let (udt_value, new_offset) =
+                self.decode_frozen_udt_from_header_type(data, off, &column.data_type, column)?;
+            off = new_offset;
+            Value::Frozen(Box::new(udt_value))
+        }
+        // CQL `varint`: [VInt len][big-endian two's-complement bytes]. Decode to
+        // Value::Varint, matching the block path (issue #1885). Without this arm the
+        // value fell through to the blob default and was mis-typed as Value::Blob.
+        else if type_str == "varint" {
+            let bytes = Self::read_vint_length_prefixed_bytes(data, &mut off, column, "varint")?;
+            Value::Varint(bytes.to_vec())
+        }
+        // Default: treat as VInt-length-prefixed blob (unknown scalar type).
+        else {
+            let bytes = Self::read_vint_length_prefixed_bytes(data, &mut off, column, "blob")?;
+            Value::Blob(bytes.to_vec())
+        };
+
+        *offset = off;
+        Ok(value)
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_scalar.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_scalar.rs
@@ -1,0 +1,587 @@
+//! Scalar value-decode arms for the V5CompressedLegacy per-cell decoder.
+//!
+//! Campsite split of `cell_value.rs` (issue #1795): the flag/conditional-field
+//! parsing and dispatch stay in `cell_value.rs`; the fixed-width and
+//! VInt-length-prefixed scalar arms live here, the frozen/tuple/collection/
+//! marshal-UDT ladder in `cell_value_complex.rs`.
+//!
+//! All VInt-length-prefixed arms route their length prefix through
+//! [`super::V5CompressedLegacyParser::read_vint_length_prefixed_bytes`], which caps
+//! the length before the `as usize` cast and uses saturating bounds arithmetic — no
+//! attacker-controlled length can trigger an add-overflow panic (issue #1795).
+
+use super::*;
+
+impl V5CompressedLegacyParser {
+    /// Decode a live (non-tombstone, non-empty) scalar cell value.
+    ///
+    /// `kind` is one of the scalar [`CellKind`] variants; [`CellKind::Complex`] is
+    /// routed to [`Self::decode_complex_cell_value`] by the caller and returns an
+    /// internal error here (never reached in practice). Advances `offset` past the
+    /// consumed value bytes on success.
+    pub(super) fn decode_scalar_cell_value(
+        data: &[u8],
+        offset: &mut usize,
+        kind: &CellKind,
+        column: &crate::schema::Column,
+    ) -> Result<Value> {
+        let mut off = *offset;
+        let value = match kind {
+            CellKind::Blob => {
+                let bytes = Self::read_vint_length_prefixed_bytes(data, &mut off, column, "blob")?;
+                Value::Blob(bytes.to_vec())
+            }
+            CellKind::Boolean => {
+                // Boolean: [0x08][u8 value]
+                if off >= data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': unexpected end at boolean value",
+                        column.name
+                    )));
+                }
+                let bool_byte = data[off];
+                off += 1;
+                Value::Boolean(bool_byte != 0)
+            }
+
+            CellKind::Int => {
+                // Integer (i32): fixed-width 4 bytes (no length prefix in Cassandra 5.0)
+                if off + 4 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 4 bytes for int, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+                let int_val =
+                    i32::from_be_bytes([data[off], data[off + 1], data[off + 2], data[off + 3]]);
+                off += 4;
+                Value::Integer(int_val)
+            }
+
+            CellKind::Text => {
+                // Text: [VInt len][text bytes]
+                let bytes = Self::read_vint_length_prefixed_bytes(data, &mut off, column, "text")?;
+                let text = String::from_utf8(bytes.to_vec()).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': invalid UTF-8 in text value: {}",
+                        column.name, e
+                    ))
+                })?;
+                Value::Text(text)
+            }
+
+            CellKind::Uuid => {
+                // UUID/TimeUUID: fixed-width 16 bytes (no length prefix in Cassandra 5.0 writer)
+                if off + 16 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 16 bytes for UUID, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+
+                let uuid_bytes: [u8; 16] = data[off..off + 16]
+                    .try_into()
+                    .map_err(|_| Error::corruption("UUID byte conversion failed"))?;
+
+                off += 16;
+                Value::Uuid(uuid_bytes)
+            }
+
+            CellKind::Decimal => {
+                // Decimal: [VInt total_len][i32 scale][unscaled bytes]
+                let bytes =
+                    Self::read_vint_length_prefixed_bytes(data, &mut off, column, "decimal")?;
+
+                // First 4 bytes: scale (i32 BE)
+                if bytes.len() < 4 {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': decimal length {} too small for scale",
+                        column.name,
+                        bytes.len()
+                    )));
+                }
+                let scale = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                // Remaining bytes: unscaled value
+                let unscaled = bytes[4..].to_vec();
+                Value::Decimal { scale, unscaled }
+            }
+
+            CellKind::BigInt => {
+                // BigInt: fixed-width 8 bytes (no length prefix in Cassandra 5.0)
+                if off + 8 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 8 bytes for bigint, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+                let val = i64::from_be_bytes([
+                    data[off],
+                    data[off + 1],
+                    data[off + 2],
+                    data[off + 3],
+                    data[off + 4],
+                    data[off + 5],
+                    data[off + 6],
+                    data[off + 7],
+                ]);
+                off += 8;
+                Value::BigInt(val)
+            }
+
+            CellKind::Counter => {
+                // Counter cells can arrive in two formats:
+                //
+                // 1. Real Cassandra CounterContext: [VInt length][header_size:i16][indices][shards]
+                //    The counter value is the sum of all shard counts.
+                //
+                // 2. CQLite writer format (raw i64): [VInt(8)][8 bytes big-endian i64]
+                //    The writer serialises Value::Counter as a plain 8-byte integer with a
+                //    length prefix of 8, identical to how BigInt is written.
+                //
+                // We try CounterContext first and fall back to the raw-i64 interpretation
+                // when the length prefix equals exactly 8 (the size of a raw i64).
+
+                if off >= data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': unexpected end at counter context length",
+                        column.name
+                    )));
+                }
+                // Read the VInt length prefix.
+                let (remaining, context_len) = parse_vuint(&data[off..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse counter context length as VInt: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                // Cap BEFORE the `as usize` cast so an adversarial length returns
+                // `Err` rather than overflowing the bounds add below (issue #1795).
+                if context_len > MAX_CELL_VALUE_LENGTH {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': counter context length {} exceeds maximum {}",
+                        column.name, context_len, MAX_CELL_VALUE_LENGTH
+                    )));
+                }
+                let context_len = context_len as usize;
+                let len_bytes_consumed = data[off..].len() - remaining.len();
+                off += len_bytes_consumed;
+
+                tracing::debug!(
+                    "V5CompressedLegacy: Counter '{}' context_len={} (len prefix: {} bytes)",
+                    column.name,
+                    context_len,
+                    len_bytes_consumed
+                );
+
+                // Overflow-safe bounds check (never `off + context_len`).
+                if context_len > data.len().saturating_sub(off) {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need {} bytes for counter context, only {} available",
+                        column.name,
+                        context_len,
+                        data.len() - off
+                    )));
+                }
+
+                // Try the full CounterContext parse first.
+                match Self::parse_counter_context(data, off, &column.name) {
+                    Ok((total, consumed)) if consumed == context_len => {
+                        // Successfully parsed a proper CounterContext.
+                        off += consumed;
+                        tracing::debug!(
+                            "V5CompressedLegacy: Counter '{}' value={} (CounterContext), total consumed {} bytes",
+                            column.name,
+                            total,
+                            len_bytes_consumed + context_len
+                        );
+                        Value::Counter(total)
+                    }
+                    _ if context_len == 8 => {
+                        // A real Cassandra CounterContext is at minimum 36 bytes
+                        // (2 header + 2 indices + 32 body for 1 shard), so
+                        // context_len == 8 can only be produced by the CQLite writer
+                        // which serialises Counter as a raw big-endian i64.
+                        // This intentionally swallows any parse_counter_context error
+                        // for 8-byte payloads, which is safe since a valid
+                        // CounterContext can never be 8 bytes.
+                        //
+                        // Bounds already verified by the context_len check above.
+                        let val = i64::from_be_bytes([
+                            data[off],
+                            data[off + 1],
+                            data[off + 2],
+                            data[off + 3],
+                            data[off + 4],
+                            data[off + 5],
+                            data[off + 6],
+                            data[off + 7],
+                        ]);
+                        off += 8;
+                        tracing::debug!(
+                            "V5CompressedLegacy: Counter '{}' value={} (raw i64 fallback), total consumed {} bytes",
+                            column.name,
+                            val,
+                            len_bytes_consumed + 8
+                        );
+                        Value::Counter(val)
+                    }
+                    Err(e) => return Err(e),
+                    Ok((_, consumed)) => {
+                        return Err(Error::corruption(format!(
+                            "Counter '{}': VInt length ({}) doesn't match parsed context size ({})",
+                            column.name, context_len, consumed
+                        )));
+                    }
+                }
+            }
+
+            CellKind::Double => {
+                // Double: 8 bytes, f64 big-endian (NO length prefix)
+                if off + 8 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 8 bytes for double, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+                let val = f64::from_be_bytes([
+                    data[off],
+                    data[off + 1],
+                    data[off + 2],
+                    data[off + 3],
+                    data[off + 4],
+                    data[off + 5],
+                    data[off + 6],
+                    data[off + 7],
+                ]);
+                off += 8;
+                Value::Float(val)
+            }
+
+            CellKind::Timestamp => {
+                // Timestamp: 8 bytes, i64 milliseconds big-endian (NO length prefix, per Cassandra spec)
+                if off + 8 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 8 bytes for timestamp, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+                let millis = i64::from_be_bytes([
+                    data[off],
+                    data[off + 1],
+                    data[off + 2],
+                    data[off + 3],
+                    data[off + 4],
+                    data[off + 5],
+                    data[off + 6],
+                    data[off + 7],
+                ]);
+                off += 8;
+                Value::Timestamp(millis)
+            }
+
+            CellKind::Date => {
+                // Date: [VInt len=4][i32 BE days]
+                if off >= data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': unexpected end at date length",
+                        column.name
+                    )));
+                }
+
+                let (remaining, date_len) = parse_vuint(&data[off..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse date length as VInt: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                let date_len = date_len as usize;
+                let bytes_consumed = data[off..].len() - remaining.len();
+                off += bytes_consumed;
+
+                if date_len != 4 {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': expected date length 4, got {}",
+                        column.name, date_len
+                    )));
+                }
+
+                if off + 4 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 4 bytes for date, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+
+                let stored =
+                    u32::from_be_bytes([data[off], data[off + 1], data[off + 2], data[off + 3]]);
+                off += 4;
+                // Cassandra DATE: 4-byte unsigned int with Integer.MIN_VALUE offset
+                let days_since_epoch = stored.wrapping_add(i32::MIN as u32) as i32;
+                Value::Date(days_since_epoch)
+            }
+
+            CellKind::Duration => {
+                // Duration: [VInt len][months VInt][days VInt][nanos VInt]
+                let duration_bytes =
+                    Self::read_vint_length_prefixed_bytes(data, &mut off, column, "duration")?;
+
+                // Parse months (signed VInt)
+                let (remaining, months) = parse_vint(duration_bytes).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse duration months: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                let pos = duration_bytes.len() - remaining.len();
+
+                // Parse days (signed VInt)
+                let (remaining, days) = parse_vint(&duration_bytes[pos..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse duration days: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                let pos = duration_bytes.len() - remaining.len();
+
+                // Parse nanoseconds (signed VInt)
+                let (remaining, nanos) = parse_vint(&duration_bytes[pos..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse duration nanos: {:?}",
+                        column.name, e
+                    ))
+                })?;
+
+                // Verify we consumed all duration bytes
+                if !remaining.is_empty() {
+                    warn!(
+                        "V5CompressedLegacy: Duration '{}' has {} extra bytes after parsing",
+                        column.name,
+                        remaining.len()
+                    );
+                }
+
+                // months/days are i32 in Cassandra's DurationType. Reject
+                // (rather than silently truncate via `as i32`) any encoded value
+                // outside the i32 range so a corrupt encoding errors instead of
+                // wrapping (issue #1632, item b).
+                let months = i32::try_from(months).map_err(|_| {
+                    Error::corruption(format!(
+                        "Cell '{}': duration months out of i32 range",
+                        column.name
+                    ))
+                })?;
+                let days = i32::try_from(days).map_err(|_| {
+                    Error::corruption(format!(
+                        "Cell '{}': duration days out of i32 range",
+                        column.name
+                    ))
+                })?;
+
+                Value::Duration {
+                    months,
+                    days,
+                    nanos,
+                }
+            }
+
+            CellKind::Float => {
+                // Float: 4 bytes, f32 big-endian (NO length prefix, fixed size).
+                // CQL `float` is IEEE single precision — decode to Value::Float32,
+                // matching the block path (issue #1884). Widening to f64 was lossy.
+                if off + 4 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 4 bytes for float, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+
+                let val =
+                    f32::from_be_bytes([data[off], data[off + 1], data[off + 2], data[off + 3]]);
+                off += 4;
+                Value::Float32(val)
+            }
+
+            CellKind::SmallInt => {
+                // SmallInt: [VInt len=2][i16 BE]
+                if off >= data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': unexpected end at smallint length",
+                        column.name
+                    )));
+                }
+
+                let (remaining, len) = parse_vuint(&data[off..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse smallint length as VInt: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                let len = len as usize;
+                let bytes_consumed = data[off..].len() - remaining.len();
+                off += bytes_consumed;
+
+                if len != 2 {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': expected smallint length 2, got {}",
+                        column.name, len
+                    )));
+                }
+
+                if off + 2 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 2 bytes for smallint, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+
+                let val = i16::from_be_bytes([data[off], data[off + 1]]);
+                off += 2;
+                Value::SmallInt(val)
+            }
+
+            CellKind::TinyInt => {
+                // TinyInt: [VInt len=1][i8]
+                if off >= data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': unexpected end at tinyint length",
+                        column.name
+                    )));
+                }
+
+                let (remaining, len) = parse_vuint(&data[off..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse tinyint length as VInt: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                let len = len as usize;
+                let bytes_consumed = data[off..].len() - remaining.len();
+                off += bytes_consumed;
+
+                if len != 1 {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': expected tinyint length 1, got {}",
+                        column.name, len
+                    )));
+                }
+
+                if off >= data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 1 byte for tinyint, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+
+                let val = data[off] as i8;
+                off += 1;
+                Value::TinyInt(val)
+            }
+
+            CellKind::Time => {
+                // Time: [VInt len=8][i64 BE nanoseconds since midnight]
+                if off >= data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': unexpected end at time length",
+                        column.name
+                    )));
+                }
+                let (remaining, time_len) = parse_vuint(&data[off..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse time length as VInt: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                let time_len = time_len as usize;
+                let bytes_consumed = data[off..].len() - remaining.len();
+                off += bytes_consumed;
+                if time_len != 8 {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': expected time length 8, got {}",
+                        column.name, time_len
+                    )));
+                }
+                if off + 8 > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need 8 bytes for time value, only {} available",
+                        column.name,
+                        data.len() - off
+                    )));
+                }
+                let nanos = i64::from_be_bytes([
+                    data[off],
+                    data[off + 1],
+                    data[off + 2],
+                    data[off + 3],
+                    data[off + 4],
+                    data[off + 5],
+                    data[off + 6],
+                    data[off + 7],
+                ]);
+                off += 8;
+                Value::Time(nanos)
+            }
+
+            CellKind::Inet => {
+                // Inet: [VInt len][address bytes] (len is 4 for IPv4, 16 for IPv6)
+                if off >= data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': unexpected end at inet length",
+                        column.name
+                    )));
+                }
+
+                let (remaining, len) = parse_vuint(&data[off..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Cell '{}': failed to parse inet length as VInt: {:?}",
+                        column.name, e
+                    ))
+                })?;
+                let len = len as usize;
+                let bytes_consumed = data[off..].len() - remaining.len();
+                off += bytes_consumed;
+
+                if len != 4 && len != 16 {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': invalid inet length {}, expected 4 or 16",
+                        column.name, len
+                    )));
+                }
+
+                if off + len > data.len() {
+                    return Err(Error::corruption(format!(
+                        "Cell '{}': need {} bytes for inet, only {} available",
+                        column.name,
+                        len,
+                        data.len() - off
+                    )));
+                }
+
+                let bytes = data[off..off + len].to_vec();
+                off += len;
+                Value::Inet(bytes)
+            }
+
+            // The complex ladder is dispatched by the caller
+            // (`parse_cell_value_schema_order`) to `decode_complex_cell_value`;
+            // reaching here means an internal dispatch bug, not adversarial input.
+            CellKind::Complex(_) => {
+                return Err(Error::corruption(format!(
+                    "Cell '{}': complex type routed to the scalar decoder (internal error)",
+                    column.name
+                )));
+            }
+        };
+
+        *offset = off;
+        Ok(value)
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/decoder_lockstep_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/decoder_lockstep_tests.rs
@@ -40,10 +40,12 @@
 //!   (the audit's exemplary VInt/type reference).
 //!
 //! ## Known-divergence set recorded by this net (do NOT "fix" here — #1617)
-//! * **`float`**: block path → [`Value::Float32`] (correct single-precision
-//!   representation); v5 ladder → [`Value::Float`] (widened `f32 as f64`). Owning
-//!   issue: **J2** (collapse the `ComparatorType` decoders — must unify the
-//!   representation). Recorded as an explicit divergence assertion below.
+//! * **`float`**: CONVERGED (issue #1884) — both paths now decode CQL `float` to
+//!   [`Value::Float32`]. The v5 ladder previously widened to `Value::Float`
+//!   (`f32 as f64`); that lossy widening is fixed.
+//! * **`varint`**: CONVERGED (issue #1885) — the v5 ladder gained a `varint` arm,
+//!   so both paths decode CQL `varint` to [`Value::Varint`]. It previously fell
+//!   through to the blob default → `Value::Blob`.
 //! * **non-frozen `list`/`set`/`map`**: the v5 *single-cell* ladder STUBS these
 //!   to an empty collection — production routes non-frozen collections through
 //!   the multi-cell complex-column path instead. Owning issue: **#162 / J1**.
@@ -89,6 +91,13 @@ pub(crate) enum V5Framing {
 }
 
 /// A documented, deliberate divergence between the two read paths (issue #1617).
+///
+/// Retained scaffolding: the float/varint divergences it recorded are now
+/// converged (issues #1884/#1885), so no `ScalarCase` currently sets one. Kept so
+/// the next genuinely-divergent type can be recorded without re-deriving the
+/// machinery; `assert_ne`-based recording in the tests still exercises it once a
+/// case populates `divergence: Some(..)`.
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub(crate) struct Divergence {
     /// Owning issue/epic that will unify the paths.
@@ -186,20 +195,14 @@ pub(crate) fn scalar_cases() -> Vec<ScalarCase> {
             arbitrary_len: false,
             divergence: None,
         },
-        // KNOWN DIVERGENCE (J2): block -> Float32, v5 -> widened Float(f64).
+        // CONVERGED (issue #1884): both paths now decode CQL float to Value::Float32.
         ScalarCase {
             cql_type: "float",
             value: Value::Float32(3.5),
             value_bytes: 3.5f32.to_be_bytes().to_vec(),
             framing: V5Framing::Fixed,
             arbitrary_len: false,
-            divergence: Some(Divergence {
-                owner: "J2 (#1603) — collapse the ComparatorType decoders",
-                note: "CQL float: block path decodes Value::Float32(f32); v5 ladder \
-                       widens to Value::Float(f32 as f64). J2 must unify the representation.",
-                block: Value::Float32(3.5),
-                v5: Value::Float(3.5f32 as f64),
-            }),
+            divergence: None,
         },
         ScalarCase {
             cql_type: "double",
@@ -294,8 +297,8 @@ pub(crate) fn scalar_cases() -> Vec<ScalarCase> {
             arbitrary_len: false,
             divergence: None,
         },
-        // CONVERGED (issue #1885): the v5 ladder now has a `varint` arm decoding to
-        // Value::Varint with byte-identical framing to the block path.
+        // CONVERGED (issue #1885): v5 ladder gained a varint arm; both paths decode
+        // CQL varint to Value::Varint.
         ScalarCase {
             cql_type: "varint",
             value: Value::Varint(vec![0x01, 0x00]),
@@ -965,12 +968,13 @@ async fn v5_varint_arm_decodes_edge_cases() {
 /// the block path's empty-slice handling (issue #1885). This covers BOTH v5 wire
 /// framings that can carry a zero-length varint:
 ///  1. A live cell with a VInt length prefix of `0` (`[0x08][0x00]`) — the
-///     `CellKind::Varint => Value::Varint(read_vint_prefixed_bytes(..))` arm reading
-///     an empty payload.
+///     `CellKind::Complex("varint")` ladder arm (in `cell_value_complex`) reads an
+///     empty payload via `read_vint_length_prefixed_bytes` → `Value::Varint([])`.
 ///  2. A flags-only cell with the `CELL_HAS_EMPTY_VALUE` bit set and NO value bytes
-///     (`[0x0C]` = `CELL_USE_ROW_TIMESTAMP | CELL_HAS_EMPTY_VALUE`) — the dedicated
-///     `CellKind::Varint => Value::Varint(Vec::new())` empty arm (roborev coverage
-///     gap: this arm was previously never exercised).
+///     (`[0x0C]` = `CELL_USE_ROW_TIMESTAMP | CELL_HAS_EMPTY_VALUE`) — the empty-value
+///     arm in `parse_cell_value_schema_order` matches `CellKind::Complex("varint")`
+///     → `Value::Varint(Vec::new())` (roborev coverage gap: this arm was previously
+///     never exercised).
 #[tokio::test]
 async fn v5_varint_empty_matches_block() {
     let Some(reader) = open_reader().await else {

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -854,6 +854,9 @@ mod block_emit;
 mod block_emit_windowed;
 mod cell_kind;
 mod cell_value;
+// campsite split of `cell_value` (issue #1795): scalar arms + complex ladder.
+mod cell_value_complex;
+mod cell_value_scalar;
 mod compaction;
 mod compaction_stream; // issue #2299 (split of `compaction`, campsite #1116)
 pub(in crate::storage::sstable::reader) use compaction_stream::{
@@ -915,6 +918,11 @@ mod regression_1741k_tests;
 // allocating semantics (`!marker && parse_partition_header_full.is_ok()`).
 #[cfg(test)]
 mod regression_1641_boundary_peek_tests;
+
+// Issue #1795: per-cell VInt-length bounds guards reject adversarial lengths
+// (return `Err`, never overflow-panic).
+#[cfg(test)]
+mod regression_1795_overflow_tests;
 
 impl V5CompressedLegacyParser {
     /// Create a new V5CompressedLegacy parser

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/regression_1795_overflow_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/regression_1795_overflow_tests.rs
@@ -1,0 +1,67 @@
+//! Regression tests for issue #1795 — usize add-overflow in the V5CompressedLegacy
+//! per-cell bounds guards.
+//!
+//! The decimal (and sibling text/blob/counter/duration) value arms decoded an
+//! UNCAPPED `parse_vuint` length into `usize` and then evaluated
+//! `offset + total_len > data.len()` as a bounds check. On an adversarial length
+//! prefix the ADD overflowed `usize` (in an overflow-checked build: a panic
+//! `attempt to add with overflow`; in release: a wraparound that defeated the
+//! guard) BEFORE the guard could reject the input. Found by the #1614 parser fuzz
+//! crate (`fuzz_block_emit`).
+//!
+//! These tests craft the adversarial framing directly (dataset-independent) and
+//! assert every affected arm now returns `Err` cleanly and NEVER panics. Debug/test
+//! builds run with `overflow-checks = true`, so a regressed add would abort the
+//! process here rather than silently wrap.
+
+use super::decoder_lockstep_tests::{open_reader, test_column, v5_parser};
+use crate::parser::vint::encode_vuint;
+
+/// Build a live-cell body (`flags = 0x08` = USE_ROW_TIMESTAMP, has value) whose
+/// value length prefix is a maximal unsigned VInt — the exact shape that overflowed
+/// `offset + len` before the fix.
+fn adversarial_length_prefixed_cell() -> Vec<u8> {
+    let mut cell = vec![0x08u8];
+    // u64::MAX as a length: `offset + (u64::MAX as usize)` overflows usize.
+    cell.extend_from_slice(&encode_vuint(u64::MAX));
+    // A handful of trailing bytes so the value read (if the guard were absent)
+    // would have somewhere to start.
+    cell.extend_from_slice(&[0u8; 8]);
+    cell
+}
+
+/// The reported panic: a `decimal` cell with an adversarial length prefix must
+/// return `Err`, not overflow-panic.
+#[tokio::test]
+async fn decimal_adversarial_length_returns_err_not_panic() {
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    let parser = v5_parser();
+    let col = test_column("decimal");
+    let cell = adversarial_length_prefixed_cell();
+    let res = parser.parse_cell_value_schema_order(&cell, 0, &col, None, None, &reader);
+    assert!(
+        res.is_err(),
+        "adversarial decimal length must return Err (got {res:?})"
+    );
+}
+
+/// The same overflow shape recurs across the other VInt-length-prefixed arms; each
+/// must reject cleanly (hardening sweep, issue #1795).
+#[tokio::test]
+async fn sibling_vint_length_arms_reject_adversarial_length() {
+    let Some(reader) = open_reader().await else {
+        return;
+    };
+    let parser = v5_parser();
+    for cql_type in ["text", "blob", "counter", "duration", "varint"] {
+        let col = test_column(cql_type);
+        let cell = adversarial_length_prefixed_cell();
+        let res = parser.parse_cell_value_schema_order(&cell, 0, &col, None, None, &reader);
+        assert!(
+            res.is_err(),
+            "adversarial {cql_type} length must return Err (got {res:?})"
+        );
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/regression_1795_overflow_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/regression_1795_overflow_tests.rs
@@ -1,67 +1,152 @@
 //! Regression tests for issue #1795 — usize add-overflow in the V5CompressedLegacy
 //! per-cell bounds guards.
 //!
-//! The decimal (and sibling text/blob/counter/duration) value arms decoded an
-//! UNCAPPED `parse_vuint` length into `usize` and then evaluated
+//! The decimal (and sibling text/blob/counter/duration/varint) value arms decoded
+//! an UNCAPPED `parse_vuint` length into `usize` and then evaluated
 //! `offset + total_len > data.len()` as a bounds check. On an adversarial length
 //! prefix the ADD overflowed `usize` (in an overflow-checked build: a panic
 //! `attempt to add with overflow`; in release: a wraparound that defeated the
 //! guard) BEFORE the guard could reject the input. Found by the #1614 parser fuzz
 //! crate (`fuzz_block_emit`).
 //!
-//! These tests craft the adversarial framing directly (dataset-independent) and
-//! assert every affected arm now returns `Err` cleanly and NEVER panics. Debug/test
-//! builds run with `overflow-checks = true`, so a regressed add would abort the
-//! process here rather than silently wrap.
+//! ## Truly dataset-independent coverage (issue #1795 roborev)
+//!
+//! The shared VInt-length guard now lives in
+//! [`V5CompressedLegacyParser::read_vint_length_prefixed_bytes`] — a free
+//! associated function needing NO `SSTableReader`, no dataset, and no feature
+//! flag. The core regression assertions below call it DIRECTLY, so they exercise
+//! the overflow-safe guard **unconditionally in every build/lane**, regardless of
+//! whether `CQLITE_DATASETS_ROOT` is populated. (Previously these tests took an
+//! `open_reader().await` handle that the adversarial path never dereferences — the
+//! guard rejects the bad length first — so when the dataset was absent they
+//! silently returned, passing vacuously without ever running the guard.)
+//!
+//! The `counter` arm keeps a hand-inlined copy of the same guard inside
+//! `parse_cell_value_schema_order` (it must peek the context bytes before choosing
+//! the CounterContext vs raw-i64 interpretation), so it is exercised through the
+//! full per-cell dispatch. That full-dispatch test is `write-support`-gated because
+//! obtaining an `SSTableReader` requires the `SSTableWriter` to synthesize a
+//! dataset-free fixture; in the `write-support` build (the default, and what the
+//! `--lite` gate runs) that synthetic reader is ALWAYS constructible, so the test
+//! runs with no dataset and — being `.expect()`, not a silent `return` — can never
+//! no-op vacuously. In a non-`write-support` build it is compiled out entirely
+//! (never a runtime skip); the always-on direct-helper tests still cover the
+//! identical guard logic there.
+//!
+//! Debug/test builds run with `overflow-checks = true`, so a regressed add would
+//! abort the process here rather than silently wrap.
 
-use super::decoder_lockstep_tests::{open_reader, test_column, v5_parser};
+use super::V5CompressedLegacyParser;
 use crate::parser::vint::encode_vuint;
+use crate::schema::Column;
 
-/// Build a live-cell body (`flags = 0x08` = USE_ROW_TIMESTAMP, has value) whose
-/// value length prefix is a maximal unsigned VInt — the exact shape that overflowed
-/// `offset + len` before the fix.
-fn adversarial_length_prefixed_cell() -> Vec<u8> {
-    let mut cell = vec![0x08u8];
-    // u64::MAX as a length: `offset + (u64::MAX as usize)` overflows usize.
-    cell.extend_from_slice(&encode_vuint(u64::MAX));
-    // A handful of trailing bytes so the value read (if the guard were absent)
-    // would have somewhere to start.
-    cell.extend_from_slice(&[0u8; 8]);
-    cell
+/// A single-column schema `Column` for the given CQL type (mirrors the lockstep
+/// helper; kept local so these tests carry no reader/dataset dependency).
+fn column(cql_type: &str) -> Column {
+    Column {
+        name: "c".to_string(),
+        data_type: cql_type.to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
 }
 
-/// The reported panic: a `decimal` cell with an adversarial length prefix must
-/// return `Err`, not overflow-panic.
-#[tokio::test]
-async fn decimal_adversarial_length_returns_err_not_panic() {
-    let Some(reader) = open_reader().await else {
-        return;
-    };
-    let parser = v5_parser();
-    let col = test_column("decimal");
-    let cell = adversarial_length_prefixed_cell();
-    let res = parser.parse_cell_value_schema_order(&cell, 0, &col, None, None, &reader);
+/// The exact adversarial framing the fuzzer found: a maximal unsigned-VInt length
+/// prefix (`u64::MAX`) followed by a handful of trailing bytes. `offset + len`
+/// overflows `usize`; the overflow-safe guard must return `Err` instead. This is
+/// the value-framing WITHOUT the outer cell flags byte, so it can be fed straight
+/// to `read_vint_length_prefixed_bytes` (which starts at the length prefix).
+fn adversarial_length_prefix() -> Vec<u8> {
+    let mut framing = encode_vuint(u64::MAX);
+    framing.extend_from_slice(&[0u8; 8]);
+    framing
+}
+
+/// The reported panic: decoding a `decimal` value length prefix of `u64::MAX` must
+/// return `Err`, not overflow-panic. Calls the shared guard directly, so it runs
+/// in EVERY build/lane with no dataset dependency.
+#[test]
+fn decimal_adversarial_length_returns_err_not_panic() {
+    let data = adversarial_length_prefix();
+    let mut offset = 0usize;
+    let col = column("decimal");
+    let res = V5CompressedLegacyParser::read_vint_length_prefixed_bytes(
+        &data,
+        &mut offset,
+        &col,
+        "decimal",
+    );
     assert!(
         res.is_err(),
         "adversarial decimal length must return Err (got {res:?})"
     );
 }
 
-/// The same overflow shape recurs across the other VInt-length-prefixed arms; each
-/// must reject cleanly (hardening sweep, issue #1795).
+/// The same overflow shape recurs across the other VInt-length-prefixed arms that
+/// share the guard (`text`/`blob`/`duration`/`varint`); each must reject cleanly.
+/// Dataset-independent (direct guard call).
+#[test]
+fn sibling_vint_length_arms_reject_adversarial_length() {
+    for what in ["text", "blob", "duration", "varint"] {
+        let data = adversarial_length_prefix();
+        let mut offset = 0usize;
+        let col = column(what);
+        let res = V5CompressedLegacyParser::read_vint_length_prefixed_bytes(
+            &data,
+            &mut offset,
+            &col,
+            what,
+        );
+        assert!(
+            res.is_err(),
+            "adversarial {what} length must return Err (got {res:?})"
+        );
+    }
+}
+
+/// A legitimate length prefix within `MAX_CELL_VALUE_LENGTH` with enough
+/// trailing bytes still decodes cleanly — the guard rejects nothing valid. Pins
+/// that the #1795 cap did not regress the happy path.
+#[test]
+fn in_bounds_length_prefix_still_decodes() {
+    let payload = b"hello";
+    let mut data = encode_vuint(payload.len() as u64);
+    data.extend_from_slice(payload);
+    let mut offset = 0usize;
+    let col = column("text");
+    let bytes =
+        V5CompressedLegacyParser::read_vint_length_prefixed_bytes(&data, &mut offset, &col, "text")
+            .expect("an in-bounds length prefix must decode");
+    assert_eq!(bytes, payload);
+    assert_eq!(offset, data.len(), "offset must advance past the value");
+}
+
+/// Full per-cell dispatch (`parse_cell_value_schema_order`) rejects the adversarial
+/// length across ALL VInt-length arms — INCLUDING `counter`, whose guard is
+/// inlined in the dispatch method (not the shared helper) so it is only reachable
+/// end-to-end. `write-support`-gated: the synthetic reader is dataset-free and
+/// ALWAYS constructible here (default + `--lite`), so this runs unconditionally
+/// and can never skip vacuously. Compiled out (not skipped) without `write-support`.
+#[cfg(feature = "write-support")]
 #[tokio::test]
-async fn sibling_vint_length_arms_reject_adversarial_length() {
-    let Some(reader) = open_reader().await else {
-        return;
-    };
+async fn adversarial_lengths_rejected_via_full_cell_dispatch() {
+    use super::decoder_lockstep_tests::{open_reader, test_column, v5_parser};
+
+    let reader = open_reader()
+        .await
+        .expect("write-support build synthesizes a dataset-free reader");
     let parser = v5_parser();
-    for cql_type in ["text", "blob", "counter", "duration", "varint"] {
+
+    for cql_type in ["decimal", "text", "blob", "counter", "duration", "varint"] {
         let col = test_column(cql_type);
-        let cell = adversarial_length_prefixed_cell();
+        // Full on-disk cell body: flags 0x08 (live, has value) + adversarial length.
+        let mut cell = vec![0x08u8];
+        cell.extend_from_slice(&adversarial_length_prefix());
         let res = parser.parse_cell_value_schema_order(&cell, 0, &col, None, None, &reader);
         assert!(
             res.is_err(),
-            "adversarial {cql_type} length must return Err (got {res:?})"
+            "adversarial {cql_type} length must return Err via full dispatch (got {res:?})"
         );
     }
 }

--- a/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
+++ b/cqlite-core/tests/issue_1578_limit_exempts_max_results.rs
@@ -160,8 +160,7 @@ async fn no_limit_still_trips_row_count_valve() {
     let err = db
         .execute(&format!("SELECT * FROM {KS}.{TBL}"))
         .await
-        .err()
-        .expect(
+        .expect_err(
             "Issue #1578: an UNBOUNDED SELECT over 4 rows with max_result_rows=2 \
              must still trip the safety valve",
         );
@@ -186,8 +185,7 @@ async fn explicit_limit_does_not_exempt_byte_budget() {
     let err = db
         .execute(&format!("SELECT * FROM {KS}.{TBL} LIMIT 4"))
         .await
-        .err()
-        .expect(
+        .expect_err(
             "Issue #1578: an explicit LIMIT exempts the ROW-COUNT valve only — \
              the byte budget must still trip ResultTooLarge",
         );
@@ -249,8 +247,7 @@ async fn tight_byte_budget_still_trips_at_scale() {
     let err = db
         .execute(&format!("SELECT * FROM {KS}.{TBL} LIMIT 1500000"))
         .await
-        .err()
-        .expect(
+        .expect_err(
             "Issue #1578: a huge LIMIT over a few-thousand-row table with a \
              tiny max_result_bytes must still trip the byte guard — LIMIT \
              exempts only the row-count valve, never the byte ceiling, at any \

--- a/cqlite-core/tests/write_read_roundtrip/type_coverage.rs
+++ b/cqlite-core/tests/write_read_roundtrip/type_coverage.rs
@@ -434,20 +434,11 @@ async fn test_type_smallint_max() {
     assert_eq!(read_back, original, "SmallInt(MAX) roundtrip failed");
 }
 
-/// The reader widens Float32 → Float(f64) during read-back.
-/// IEEE 754 bits are preserved through the widening.
-fn widen_float32(v: Value) -> Value {
-    if let Value::Float32(f) = v {
-        Value::Float(f as f64)
-    } else {
-        v
-    }
-}
-
 /// Test Float32 type roundtrip
 ///
-/// The reader widens f32 to f64 (Value::Float) during read-back.
-/// IEEE 754 bits are preserved; we compare against the widened value.
+/// Issue #1884: `CellKind::Float` now decodes to `Value::Float32(f32)` (not a
+/// lossy `f32 as f64` widening to `Value::Float`), so the write→read roundtrip
+/// is lossless and the read-back must equal the original `Value::Float32`.
 #[tokio::test]
 async fn test_type_float32_roundtrip() {
     let temp_dir = TempDir::new().unwrap();
@@ -456,16 +447,12 @@ async fn test_type_float32_roundtrip() {
     let info = write_single_value(&temp_dir, &schema, "float_col", original.clone()).await;
     assert_single_partition_written(&info);
     let read_back = super::read_back_column(&temp_dir, &schema, "float_col").await;
-    assert_eq!(
-        read_back,
-        widen_float32(original),
-        "Float32 roundtrip failed"
-    );
+    assert_eq!(read_back, original, "Float32 roundtrip failed");
 }
 
 /// Test Float32 type with special value
 ///
-/// The reader widens f32 to f64 (Value::Float) during read-back.
+/// Issue #1884: read-back preserves the `Value::Float32` variant losslessly.
 #[tokio::test]
 async fn test_type_float32_special() {
     let temp_dir = TempDir::new().unwrap();
@@ -474,16 +461,14 @@ async fn test_type_float32_special() {
     let info = write_single_value(&temp_dir, &schema, "float_col", original.clone()).await;
     assert_single_partition_written(&info);
     let read_back = super::read_back_column(&temp_dir, &schema, "float_col").await;
-    assert_eq!(
-        read_back,
-        widen_float32(original),
-        "Float32 roundtrip failed"
-    );
+    assert_eq!(read_back, original, "Float32 roundtrip failed");
 }
 
 /// Test Float32 type with min value
 ///
-/// The reader widens f32 to f64 (Value::Float) during read-back.
+/// Issue #1884: `f32::MIN` roundtrips losslessly as `Value::Float32`; the old
+/// `f32 as f64` widening changed the printed value (e.g. -3.4028235e38 →
+/// -3.4028234663852886e38), which this test now pins against regressing.
 #[tokio::test]
 async fn test_type_float32_min() {
     let temp_dir = TempDir::new().unwrap();
@@ -492,10 +477,11 @@ async fn test_type_float32_min() {
     let info = write_single_value(&temp_dir, &schema, "float_col", original.clone()).await;
     assert_single_partition_written(&info);
     let read_back = super::read_back_column(&temp_dir, &schema, "float_col").await;
-    assert_eq!(
-        read_back,
-        widen_float32(original),
-        "Float32 roundtrip failed"
+    assert_eq!(read_back, original, "Float32 roundtrip failed");
+    // Pin the exact variant: read-back must be Float32, never a widened Float.
+    assert!(
+        matches!(read_back, Value::Float32(f) if f == f32::MIN),
+        "expected lossless Value::Float32(f32::MIN), got {read_back:?}"
     );
 }
 


### PR DESCRIPTION
Closes #1795
Closes #1884

## Summary
Consolidated lane (per lead's 2026-07-14 audit comment — same file, same fix
shape, one PR):

1. **#1795** — the v5_compressed_legacy decimal/text/blob/counter/duration cell
   decoders decoded a length via `parse_vuint` (u64, uncapped) then did an
   UNCHECKED `offset + total_len > data.len()` bounds check — the add itself
   could overflow `usize` on adversarial input, panicking instead of returning
   `Err` (found by the fuzz crate, #1614). Fix: new shared helper
   `read_vint_length_prefixed_bytes` caps the length against
   `MAX_CELL_VALUE_LENGTH` (64 MiB) BEFORE the `as usize` cast (mirroring the
   existing correct `parse_vint_length` pattern) and uses saturating-subtraction
   instead of an unchecked add. Applied across every vulnerable arm.
2. **#1884** — `CellKind::Float` now yields `Value::Float32(f32)`, not a lossy
   widening to `Value::Float(f32 as f64)`.
3. **#1885** — added the missing `varint` arm (was falling through to
   `Value::Blob`).
4. Flipped the `decoder_lockstep_tests.rs` float/varint cases from
   asserting divergence to asserting v5-ladder == block-path equality.
5. Campsite split: `cell_value.rs` 1251→347 lines; extracted
   `cell_value_scalar.rs` (587) and `cell_value_complex.rs` (333), all under the
   ~800 source target.

Two unrelated pre-existing `main` breakages (byte-identical to what's broken on
`main` today under the pinned 1.88.0 toolchain) fixed as drive-by unblocks since
they block `cqlite-core` clippy/tests: a missing `use serial_test::serial;`
import (same root cause as #2462, will naturally dedupe on rebase) and 3
`.err().expect()` → `.expect_err()` clippy fixups (`issue_1578_limit_exempts_max_results.rs`,
from #2070).

Oracle-driven (fuzz-found parser bug + parity fixes), no OpenSpec.

## Review-first (before any full gate)
`rust-reviewer` + `roborev review --branch` both ran on the lite-green diff.
**No blockers.** rust-reviewer verified the new bounds-check math is exactly
equivalent to the intended `offset + len > data.len()` check for all
non-overflowing inputs (no off-by-one), confirmed every vulnerable arm migrated
to the safe helper, and confirmed the split is a pure move with no visibility
widening. roborev added two Low/informational notes (no fix required):
- The overflow-safe cap now applies more broadly than before (decimal/duration/
  counter arms previously had no length ceiling at all) — intended hardening,
  consistent with the existing frozen-UDT/complex-column caps.
- The Float32/Varint representation change is a real output change for those
  column types via the v5 path — **flagging for the closer**: please confirm
  the full gate's sstabledump-golden parity suite exercises float/varint
  columns through the v5-compressed-legacy path, since goldens are the parity
  oracle for this, not just the in-crate lockstep assertions.

## Gate status
Lite:
```
==== AGENT-GATE LITE SUMMARY ====
commit: b9bcd31da branch: issue-1795-decimal-bounds-guard-lane dirty: no
file-size: PASS  fmt: PASS  clippy: PASS (158s)  scoped-tests: PASS (146s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Note: `CQLITE_ALLOW_FILE_GROWTH=1` needed for the full gate too — registering the
3 new sibling modules grew the already-over-threshold aggregator
`row_decoder/mod.rs` (1044→1052); splitting it is #1116 epic work, out of this
lane's scope.

Full `agent-gate.sh` (the gate of record) + final roborev pass to be run by
`flow-closer`. **Dataset root note for the closer**: this sandbox's real fetched
SSTable binaries live at `/data/datasets` (the environment default) — do not
override `CQLITE_DATASETS_ROOT` to a repo-relative path.

Deferred (secondary, not blocking): re-adding `fuzz_block_emit` to `fuzz.yml`'s
CI matrix with `overflow-checks=true` — recommend routing as its own follow-up
issue rather than folding into this PR.


---
**Update (post-rebase, 2026-07-15):** rebased onto `main` after a real conflict — #1885's varint-arm fix landed independently on `main` via PR #2466 (different machine, same bug, claim-protocol gap: my consolidation comment lived on #1795, not #1884/#1885 themselves, so a claim check on `issue-1885-*` found nothing). #1885 is already closed by #2466; dropped the redundant `Closes #1885` line above. Kept this branch's varint arm (in the split `cell_value_complex.rs`, overflow-safe per #1795's own fix — main's version was not) and reverted the auto-merged competing `CellKind::Varint` variant from `cell_kind.rs` back to this branch's Complex-ladder architecture to avoid two competing implementations. Verified equivalent behavior against main's own #2466 edge-case tests (both auto-merged in, both pass: negative/zero/boundary varints, and both empty-value wire framings). Lite gate re-confirmed green post-rebase.
