### PR TITLE
fix(#2288): eagerly register cqlite.errors.total at 0 on startup

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -496,6 +496,21 @@ pub const MERGE_PRODUCER_THREADS: &str = "cqlite.merge.producer_threads";
 /// Total errors observed, the canonical error-rate signal (issue #1038).
 /// Bounded attributes: [`attr::ERROR_CATEGORY`] and [`attr::SUBSYSTEM`] ONLY.
 /// The raw error message is never attached.
+///
+/// **Eagerly registered at 0 on startup (issue #2288).** When the
+/// `observability` feature is active, [`crate::observability::init`] emits a
+/// single `add(0)` with an empty attribute set so this counter is present at `0`
+/// in a scrape of a freshly-started server, before any error. This makes "metric
+/// name absent from the backend" unambiguously mean *error counting isn't wired*
+/// (never *no errors occurred yet*), which cost real diagnostic time during the
+/// #2193 round-4 field investigation. Real errors add their own labeled series
+/// alongside the unlabeled baseline.
+///
+/// Limitation (per the #2193 code audit): a peer connection RESET that arrives
+/// *after* the gRPC `END_STREAM` frame is handled entirely inside the h2/tonic
+/// transport and is invisible at this application layer, so it is not counted
+/// here. Such post-END_STREAM resets are an expected, benign transport event, not
+/// an application error.
 pub const ERRORS_TOTAL: &str = "cqlite.errors.total";
 
 // ---------------------------------------------------------------------------

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -202,6 +202,10 @@ pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
     global::set_meter_provider(meter_provider.clone());
     METRICS_ACTIVE.store(true, Ordering::Relaxed);
 
+    // Eagerly seed the always-on baseline instruments so a fresh scrape of a
+    // just-started server shows them at 0 rather than absent (issue #2288).
+    register_baseline_instruments();
+
     Ok(ObservabilityGuard {
         tracer_provider: Some(tracer_provider),
         meter_provider: Some(meter_provider),
@@ -211,6 +215,21 @@ pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
 #[inline]
 pub(crate) fn metrics_active() -> bool {
     METRICS_ACTIVE.load(Ordering::Relaxed)
+}
+
+/// Eagerly emit a zero data point for the always-on baseline instruments so they
+/// are visible in a scrape of a freshly-started server, before any real activity
+/// (issue #2288).
+///
+/// `cqlite.errors.total` otherwise registers *lazily* — it appears in a metrics
+/// backend only on its first increment — so "metric name absent from the
+/// backend" was ambiguous between *no errors occurred* and *error counting isn't
+/// wired*. A single `add(0)` builds the instrument and publishes a `0` series so
+/// absence unambiguously means "not wired". The baseline uses an empty attribute
+/// set (no invented `{category, subsystem}` values that would pollute the bounded
+/// taxonomy); real errors add their own labeled series alongside it.
+pub(crate) fn register_baseline_instruments() {
+    instruments().errors_total.add(0, &[]);
 }
 
 #[cfg(feature = "observability-testing")]

--- a/cqlite-core/src/observability/testing.rs
+++ b/cqlite-core/src/observability/testing.rs
@@ -295,6 +295,20 @@ impl CapturedMetrics {
             .unwrap_or(0.0)
     }
 
+    /// Whether the named metric has a data point with a completely EMPTY
+    /// attribute set (i.e. the unlabeled baseline series) whose value equals
+    /// `value` (within `f64::EPSILON`). Distinct from `sum_where(name, &[])`,
+    /// which matches EVERY point vacuously: this requires that an actual
+    /// unlabeled point *exists* and carries the expected value — the pin that a
+    /// zero-valued labeled point (or an absent baseline) must NOT satisfy.
+    pub fn has_point_with_empty_attrs_at(&self, name: &str, value: f64) -> bool {
+        self.find(name).is_some_and(|m| {
+            m.points
+                .iter()
+                .any(|p| p.attributes.is_empty() && (p.value - value).abs() < f64::EPSILON)
+        })
+    }
+
     /// Sum of values for the data points whose attribute set contains ALL of the
     /// given `(key, value)` pairs. Lets a test assert, e.g., that
     /// `cqlite.errors.total{category=…,subsystem=…}` incremented.

--- a/cqlite-core/src/observability/testing.rs
+++ b/cqlite-core/src/observability/testing.rs
@@ -331,6 +331,17 @@ impl MetricsCapture {
         self.exporter.reset();
     }
 
+    /// Re-emit the always-on baseline instruments (e.g. `cqlite.errors.total` at
+    /// 0), exactly as production [`crate::observability::init`] does on startup
+    /// (issue #2288). Production uses cumulative temporality so a single seed at
+    /// init is visible in every scrape; this harness uses DELTA temporality, so a
+    /// test that wants to observe the seeded `0` series in its own collect window
+    /// calls this after [`reset`](Self::reset) and before
+    /// [`flush_and_collect`](Self::flush_and_collect).
+    pub fn seed_baseline(&self) {
+        super::otel::register_baseline_instruments();
+    }
+
     /// Force the meter provider to collect + export, then return a snapshot.
     pub fn flush_and_collect(&self) -> CapturedMetrics {
         let _ = self.provider.force_flush();
@@ -372,6 +383,10 @@ pub fn metrics_capture() -> MetricsCapture {
             let provider = SdkMeterProvider::builder().with_reader(reader).build();
             opentelemetry::global::set_meter_provider(provider.clone());
             super::otel::set_metrics_active_for_testing();
+            // Mirror production `otel::init` (issue #2288): seed the always-on
+            // baseline instruments (e.g. `cqlite.errors.total` at 0) so a scrape
+            // of a freshly-started server sees them present, not absent.
+            super::otel::register_baseline_instruments();
             MetricsCapture { exporter, provider }
         })
         .clone()

--- a/cqlite-core/tests/observability_correctness.rs
+++ b/cqlite-core/tests/observability_correctness.rs
@@ -454,10 +454,15 @@ fn metric_names(m: &testing::CapturedMetrics) -> Vec<String> {
 }
 
 /// The eagerly-seeded `cqlite.errors.total` baseline (issue #2288) is present and
-/// totals exactly 0: the unlabeled baseline series is 0 AND no series contributes
-/// a nonzero increment in the collect window.
+/// totals exactly 0: an actual UNLABELED (empty-attribute) baseline point exists
+/// at value 0 AND no series contributes a nonzero increment in the collect window.
+///
+/// The unlabeled-point check is deliberately NOT `sum_where(.., &[])`, whose empty
+/// predicate matches every point vacuously (a zero-valued *labeled* point would
+/// pass): `has_point_with_empty_attrs_at` requires a genuinely attribute-free
+/// baseline point, so this fails if the seeded point were labeled or absent.
 fn mc_baseline_is_zero(m: &testing::CapturedMetrics) -> bool {
-    m.sum_where(catalog::ERRORS_TOTAL, &[]).abs() < f64::EPSILON
+    m.has_point_with_empty_attrs_at(catalog::ERRORS_TOTAL, 0.0)
         && m.counter_sum(catalog::ERRORS_TOTAL).abs() < f64::EPSILON
 }
 

--- a/cqlite-core/tests/observability_correctness.rs
+++ b/cqlite-core/tests/observability_correctness.rs
@@ -221,6 +221,39 @@ fn compaction_flow_emits_compaction_spans() {
 #[test]
 fn catalog_metrics_have_expected_names_units_and_error_labels() {
     let mc = testing::metrics_capture();
+
+    // --- Phase 0: eager registration at 0 before any error (issue #2288) ---
+    // On a freshly-started server `cqlite.errors.total` must be PRESENT at 0, not
+    // absent, so "metric name absent" unambiguously means *error counting isn't
+    // wired*. Production `otel::init` seeds this baseline once at startup under
+    // cumulative temporality (visible in every scrape); this DELTA-temporality
+    // harness mirrors that seed with `seed_baseline()` in an isolated collect
+    // window with NO error induced, then asserts the series is present at exactly
+    // 0. This runs inside the single serial metric test to avoid racing another
+    // flow's `errors.total` emission on the process-global provider.
+    mc.reset();
+    mc.seed_baseline();
+    let baseline = mc.flush_and_collect();
+    assert!(
+        baseline.contains(catalog::ERRORS_TOTAL),
+        "cqlite.errors.total must be REGISTERED at startup before any error; saw: {:?}",
+        metric_names(&baseline)
+    );
+    assert_eq!(
+        baseline.unit(catalog::ERRORS_TOTAL),
+        Some(catalog::unit::ERRORS),
+        "eagerly-registered cqlite.errors.total must carry the errors unit"
+    );
+    // Unlabeled baseline series (no invented {category, subsystem}) at exactly 0,
+    // and no other series contributes a nonzero increment in this window.
+    assert!(
+        mc_baseline_is_zero(&baseline),
+        "eagerly-registered cqlite.errors.total baseline must be exactly 0 before any error; \
+         saw entries: {:?}",
+        baseline.find(catalog::ERRORS_TOTAL)
+    );
+
+    // --- Phase 1: names, units, and induced-error labels ---
     mc.reset();
 
     // Defense-in-depth against cross-test metric bleed: the in-memory exporter is
@@ -418,6 +451,14 @@ fn span_tree(spans: &testing::CapturedSpans) -> Vec<(String, String)> {
 
 fn metric_names(m: &testing::CapturedMetrics) -> Vec<String> {
     m.entries().iter().map(|e| e.name.clone()).collect()
+}
+
+/// The eagerly-seeded `cqlite.errors.total` baseline (issue #2288) is present and
+/// totals exactly 0: the unlabeled baseline series is 0 AND no series contributes
+/// a nonzero increment in the collect window.
+fn mc_baseline_is_zero(m: &testing::CapturedMetrics) -> bool {
+    m.sum_where(catalog::ERRORS_TOTAL, &[]).abs() < f64::EPSILON
+        && m.counter_sum(catalog::ERRORS_TOTAL).abs() < f64::EPSILON
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2288

## Problem (oracle-driven)
`cqlite.errors.total` registered **lazily** — it appeared in a metrics backend only on first increment. During field investigation, "metric name absent from the backend" was ambiguous between *no errors occurred* and *error counting isn't wired* (#2193 round-4), costing real diagnostic time.

## Fix
- Add `register_baseline_instruments()` — a single unlabeled `errors_total.add(0, &[])` — called from `otel::init` **after** the meter-provider is installed and `METRICS_ACTIVE` is set. This publishes a real 0 data point so the series materializes in a fresh scrape, with no double-count (adding 0 is a no-op) and no race vs real increments (init precedes any request).
- Empty attribute set is deliberate: inventing baseline `{category,subsystem}` values would pollute the bounded error taxonomy; real errors add their own labeled series alongside the unlabeled baseline.
- Document in the counter's doc comment (catalog.rs) that post-END_STREAM peer resets are invisible at this layer (h2/tonic), per the #2193 code audit.
- `MetricsCapture::seed_baseline()` delegates to the SAME production `register_baseline_instruments()` (anti-divergence — not a reimplemented replica).

## Test (fail-closed guard)
`mc_baseline_is_zero` (Phase-0 of the serial `catalog_metrics_...` test) resets the capture, seeds the baseline (mirroring startup), collects with NO error induced, and asserts — via a new `has_point_with_empty_attrs_at(name, 0)` accessor — that a genuinely **attribute-free** `errors.total` point at value 0 EXISTS. Verified by mutation: changing the expected value to 1.0 makes it fail (real point shown as `attributes: [], value: 0.0`), so it fails if the baseline were labeled or absent and passes only for the unlabeled-zero registration. (Replaces an earlier vacuous `sum_where(_, &[])` empty-predicate check — roborev LOW.)

## Review
- rust-reviewer: APPROVE, no blockers (3 deferrable nits → follow-up).
- roborev (codex): 1 LOW (vacuous baseline assertion) — fixed in this PR.

Acceptance: fresh `cqlite-flight --features observability` scrape shows `cqlite_errors_total`==0 before any error; full `--features observability` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)