### PR TITLE
fix(#1819): bound the Docker-availability probe with a wall-clock timeout

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -158,6 +158,11 @@ zstd = { version = "0.13", features = ["zdict_builder"] }
 # Inline-CRC32 framing for the hand-built Cassandra chunk image in that same
 # test (integration tests don't inherit the library's normal dependencies).
 crc32fast = { workspace = true }
+# Wall-clock-bounded subprocess wait for the Docker-availability probe used by
+# the write-support Cassandra e2e tests: an unresponsive `docker` daemon must
+# degrade to a clean SKIP instead of wedging the test binary (issue #1819,
+# same hazard family as #1691/#1692). Mirrors cqlite-cli's dev-dep.
+wait-timeout = "0.2"
 
 # In-process sampling CPU profiler for the criterion benches (signal-based, so
 # it works in containers and on CI runners where `perf` is unavailable).

--- a/cqlite-core/tests/common/docker_probe.rs
+++ b/cqlite-core/tests/common/docker_probe.rs
@@ -30,6 +30,8 @@
 
 use std::io::Read;
 use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 use wait_timeout::ChildExt;
@@ -55,17 +57,75 @@ pub enum ProbeOutcome {
     SpawnFailed,
 }
 
+/// A concurrently-draining reader for one of the child's pipes.
+///
+/// The reader thread drains its pipe to end-of-file into a buffer and delivers
+/// it over a channel. Draining happens *concurrently* with the main thread's
+/// `wait_timeout` poll loop, mirroring what `Command::output()` does internally:
+/// a child that emits more than one OS pipe buffer (~64 KB) of output would
+/// otherwise block on its own `write()` — never exiting — and be misreported as
+/// `TimedOut`. `read_to_end` errors are treated as "no more output" (the partial
+/// buffer is kept), so the thread never panics.
+struct PipeReader {
+    handle: JoinHandle<()>,
+    rx: Receiver<Vec<u8>>,
+}
+
+impl PipeReader {
+    /// Spawn a reader draining `pipe` to EOF; `None` yields an already-satisfied
+    /// reader that produces empty output.
+    fn spawn<R: Read + Send + 'static>(pipe: Option<R>) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            if let Some(mut pipe) = pipe {
+                let _ = pipe.read_to_end(&mut buf);
+            }
+            // The receiver may already be gone (abandoned reader); ignore.
+            let _ = tx.send(buf);
+        });
+        PipeReader { handle, rx }
+    }
+
+    /// Collect the drained output, waiting at most `grace` for the reader.
+    ///
+    /// When the child has exited normally its pipes close, so the reader
+    /// delivers immediately and we join the (finished) thread for cleanliness.
+    /// If `grace` elapses first — which happens when an orphaned *grandchild*
+    /// (e.g. a `sleep` the killed shell forked) still holds the pipe's write end
+    /// open — the reader is abandoned rather than joined, so the probe stays
+    /// bounded and never re-introduces the #1819 hang. A never-joined thread is
+    /// reclaimed when the test process exits. Output is returned lossily; a
+    /// panicked reader degrades to empty output rather than propagating.
+    fn collect(self, grace: Duration) -> Vec<u8> {
+        match self.rx.recv_timeout(grace) {
+            Ok(buf) => {
+                let _ = self.handle.join();
+                buf
+            }
+            Err(_) => Vec::new(),
+        }
+    }
+}
+
 /// Run `bin args...` with a hard wall-clock `timeout`.
 ///
-/// Never blocks longer than `timeout` even if the child never exits: on timeout
-/// the child is killed and reaped and [`ProbeOutcome::TimedOut`] is returned.
+/// Never blocks longer than `timeout` (plus a small drain grace) even if the
+/// child never exits: on timeout the child is killed and reaped and
+/// [`ProbeOutcome::TimedOut`] is returned.
 ///
-/// `stdout` is drained only after the child has exited. The Docker probes this
-/// serves emit at most a few KB (well under the OS pipe buffer), so a
-/// write-side deadlock is not a concern here; callers with large output should
-/// stream instead.
+/// Both `stdout` and `stderr` are drained *concurrently* with the wait loop by
+/// dedicated reader threads, so a child that writes more than one OS pipe
+/// buffer (~64 KB) cannot deadlock on its own `write()` and be misreported as
+/// `TimedOut` (mirrors `Command::output()`'s internal concurrent draining).
 #[allow(dead_code)]
 pub fn bounded_probe(bin: &str, args: &[&str], timeout: Duration) -> ProbeOutcome {
+    // On timeout the killed child's pipes normally close and the readers finish
+    // at once; this bounded grace only bites when an orphaned grandchild keeps a
+    // write end open, in which case the reader is abandoned to keep the probe
+    // prompt.
+    const DRAIN_GRACE: Duration = Duration::from_secs(2);
+
     let mut child = match Command::new(bin)
         .args(args)
         .stdin(Stdio::null())
@@ -77,12 +137,17 @@ pub fn bounded_probe(bin: &str, args: &[&str], timeout: Duration) -> ProbeOutcom
         Err(_) => return ProbeOutcome::SpawnFailed,
     };
 
+    // Start draining both pipes immediately, before the wait loop, so the child
+    // never blocks on a full pipe buffer.
+    let stdout_reader = PipeReader::spawn(child.stdout.take());
+    let stderr_reader = PipeReader::spawn(child.stderr.take());
+
     match child.wait_timeout(timeout) {
         Ok(Some(status)) => {
-            let mut stdout = Vec::new();
-            if let Some(mut handle) = child.stdout.take() {
-                let _ = handle.read_to_end(&mut stdout);
-            }
+            // Child exited: pipes are (or will be) closed, so the readers
+            // deliver promptly. Collect the fully captured output.
+            let stdout = stdout_reader.collect(DRAIN_GRACE);
+            let _stderr = stderr_reader.collect(DRAIN_GRACE);
             ProbeOutcome::Completed {
                 success: status.success(),
                 stdout: String::from_utf8_lossy(&stdout).to_string(),
@@ -93,6 +158,8 @@ pub fn bounded_probe(bin: &str, args: &[&str], timeout: Duration) -> ProbeOutcom
         Ok(None) | Err(_) => {
             let _ = child.kill();
             let _ = child.wait();
+            let _stdout = stdout_reader.collect(DRAIN_GRACE);
+            let _stderr = stderr_reader.collect(DRAIN_GRACE);
             ProbeOutcome::TimedOut
         }
     }

--- a/cqlite-core/tests/common/docker_probe.rs
+++ b/cqlite-core/tests/common/docker_probe.rs
@@ -1,0 +1,114 @@
+//! Wall-clock-bounded subprocess probe for the Docker-availability gate shared
+//! by the write-support Cassandra e2e tests (issue #1819).
+//!
+//! # Why this exists
+//!
+//! The Docker-availability gate (`cassandra_5_image`) shells out to
+//! `docker info` and `docker images` to decide whether the live `sstabledump`
+//! comparison can run. Those calls used `std::process::Command::output()` with
+//! **no timeout**. When the local Docker daemon is *present but unresponsive*
+//! (the socket accepts the connection but never answers — observed on a CI
+//! runner where `docker info` blocked > 30 s), `output()` blocks forever
+//! draining the child's pipes, so the `#[tokio::test]` current-thread runtime —
+//! and therefore `scripts/agent-gate.sh` — wedged permanently (16+ min at 0%
+//! CPU). This is the same *blocking-wait-with-no-deadline* hazard family as
+//! #1691 / #1692, except the blocking primitive here is a subprocess wait
+//! rather than a channel `recv`.
+//!
+//! # The fix
+//!
+//! [`bounded_probe`] spawns the command, waits at most `timeout` via
+//! `wait_timeout::ChildExt::wait_timeout`, and **kills the child on timeout**,
+//! reporting [`ProbeOutcome::TimedOut`]. A healthy `docker info` / `docker
+//! images` returns near-instantly, so a few-second budget only ever bites an
+//! unresponsive daemon — which then degrades to a clean SKIP (or, in strict
+//! mode, a loud FAIL) instead of an unbounded hang.
+//!
+//! The command *name/path* is a parameter (a mockable-command seam), so a test
+//! can point it at a fake `docker` that sleeps forever and prove the probe
+//! still returns within the budget.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use wait_timeout::ChildExt;
+
+/// Default wall-clock budget for a Docker-availability probe. A healthy daemon
+/// answers `docker info` / `docker images` in well under a second; this budget
+/// only ever bites an unresponsive daemon.
+#[allow(dead_code)]
+pub const DOCKER_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Outcome of a single bounded subprocess probe.
+#[derive(Debug)]
+pub enum ProbeOutcome {
+    /// The command completed within the budget. `success` is the exit status'
+    /// success flag; `stdout` is the captured standard output.
+    Completed { success: bool, stdout: String },
+    /// The command did not finish within the budget and was killed. The
+    /// underlying resource (e.g. an unresponsive Docker daemon) is treated as
+    /// unavailable.
+    TimedOut,
+    /// The command could not be spawned at all (e.g. the `docker` binary is not
+    /// on `PATH`) — equivalent to "not installed".
+    SpawnFailed,
+}
+
+/// Run `bin args...` with a hard wall-clock `timeout`.
+///
+/// Never blocks longer than `timeout` even if the child never exits: on timeout
+/// the child is killed and reaped and [`ProbeOutcome::TimedOut`] is returned.
+///
+/// `stdout` is drained only after the child has exited. The Docker probes this
+/// serves emit at most a few KB (well under the OS pipe buffer), so a
+/// write-side deadlock is not a concern here; callers with large output should
+/// stream instead.
+#[allow(dead_code)]
+pub fn bounded_probe(bin: &str, args: &[&str], timeout: Duration) -> ProbeOutcome {
+    let mut child = match Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => return ProbeOutcome::SpawnFailed,
+    };
+
+    match child.wait_timeout(timeout) {
+        Ok(Some(status)) => {
+            let mut stdout = Vec::new();
+            if let Some(mut handle) = child.stdout.take() {
+                let _ = handle.read_to_end(&mut stdout);
+            }
+            ProbeOutcome::Completed {
+                success: status.success(),
+                stdout: String::from_utf8_lossy(&stdout).to_string(),
+            }
+        }
+        // Timed out, or waiting itself errored: kill + reap and report a timeout
+        // so an unresponsive daemon degrades to "unavailable", never a hang.
+        Ok(None) | Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            ProbeOutcome::TimedOut
+        }
+    }
+}
+
+/// Convenience wrapper: run a bounded `docker <args...>` probe with the default
+/// [`DOCKER_PROBE_TIMEOUT`]. Returns `Some(stdout)` only when `docker` ran and
+/// exited successfully within budget; `None` on non-zero exit, a spawn failure,
+/// or a timeout (all "Docker unavailable" from the caller's perspective).
+#[allow(dead_code)]
+pub fn docker_probe(args: &[&str]) -> Option<String> {
+    match bounded_probe("docker", args, DOCKER_PROBE_TIMEOUT) {
+        ProbeOutcome::Completed {
+            success: true,
+            stdout,
+        } => Some(stdout),
+        _ => None,
+    }
+}

--- a/cqlite-core/tests/docker_probe_timeout.rs
+++ b/cqlite-core/tests/docker_probe_timeout.rs
@@ -69,6 +69,49 @@ fn bounded_probe_reports_failure_exit() {
     );
 }
 
+/// Regression guard for the concurrent-drain fix: a command that writes far
+/// more than one OS pipe buffer (~64 KB) to stdout AND stderr but exits
+/// promptly must be reported as `Completed` with its output fully captured —
+/// NOT `TimedOut`. Under the old drain-after-wait approach the child would
+/// block on its own `write()` once the pipe buffer filled, never exit, and get
+/// killed at the deadline (a false `TimedOut` against a healthy command).
+#[cfg(unix)]
+#[test]
+fn bounded_probe_captures_output_larger_than_pipe_buffer() {
+    // ~200 KB per stream — comfortably past the ~64 KB Linux pipe buffer, so a
+    // non-concurrent drain would deadlock. `yes X | head -c N` is portable
+    // across POSIX shells and needs no external data files.
+    const N: usize = 200_000;
+    let script = format!("yes X | head -c {N} ; yes E | head -c {N} 1>&2");
+
+    let budget = Duration::from_secs(10);
+    let start = Instant::now();
+    let outcome = bounded_probe("sh", &["-c", &script], budget);
+    let elapsed = start.elapsed();
+
+    match outcome {
+        ProbeOutcome::Completed { success, stdout } => {
+            assert!(success, "the command should exit 0");
+            assert_eq!(
+                stdout.len(),
+                N,
+                "all {N} stdout bytes must be captured, got {}",
+                stdout.len()
+            );
+        }
+        other => panic!(
+            "large-output command must be Completed (not TimedOut) — got {other:?} \
+             after {elapsed:?}"
+        ),
+    }
+    // The command exits as fast as it can write; it must finish well within the
+    // generous budget rather than being killed at the deadline.
+    assert!(
+        elapsed < Duration::from_secs(9),
+        "large-output command should complete promptly, took {elapsed:?}"
+    );
+}
+
 /// A missing binary yields `SpawnFailed`, never a hang or panic.
 #[test]
 fn bounded_probe_reports_spawn_failure() {

--- a/cqlite-core/tests/docker_probe_timeout.rs
+++ b/cqlite-core/tests/docker_probe_timeout.rs
@@ -1,0 +1,84 @@
+//! Issue #1819: the Docker-availability probe used by the write-support
+//! Cassandra e2e tests MUST return within a bounded time even when the
+//! underlying `docker` command hangs forever (unresponsive daemon), instead of
+//! wedging the test binary — and therefore `scripts/agent-gate.sh` — the way an
+//! unbounded `Command::output()` did.
+//!
+//! These tests exercise the real shared seam (`common/docker_probe.rs`) through
+//! a mockable command path: the command name is a parameter, so a `sh -c
+//! 'sleep 3600'` stands in for an unresponsive `docker info`. The assertion is
+//! about the probe's deadline, not about any actual Docker install.
+
+#[path = "common/docker_probe.rs"]
+mod docker_probe;
+
+use std::time::{Duration, Instant};
+
+use docker_probe::{bounded_probe, ProbeOutcome};
+
+/// The core #1819 guarantee: a command that never returns is abandoned at the
+/// deadline, so the probe reports `TimedOut` promptly rather than hanging.
+#[cfg(unix)]
+#[test]
+fn bounded_probe_returns_promptly_when_command_hangs() {
+    // Mimics an unresponsive `docker info`: accepts, then blocks indefinitely.
+    let budget = Duration::from_millis(400);
+    let start = Instant::now();
+    let outcome = bounded_probe("sh", &["-c", "sleep 3600"], budget);
+    let elapsed = start.elapsed();
+
+    assert!(
+        matches!(outcome, ProbeOutcome::TimedOut),
+        "a hung command must report TimedOut, got {outcome:?}"
+    );
+    // Generous ceiling (kill + reap slack) that is still far below the old
+    // unbounded 16+ min wedge.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "probe must return near the {budget:?} budget, took {elapsed:?}"
+    );
+}
+
+/// A fast, successful command completes within budget and its stdout is
+/// captured — the "Docker healthy" path is unaffected by the deadline.
+#[cfg(unix)]
+#[test]
+fn bounded_probe_completes_for_fast_command() {
+    let outcome = bounded_probe("sh", &["-c", "echo ok"], Duration::from_secs(5));
+    match outcome {
+        ProbeOutcome::Completed { success, stdout } => {
+            assert!(success, "fast command should exit 0");
+            assert!(
+                stdout.contains("ok"),
+                "stdout should be captured: {stdout:?}"
+            );
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+/// A non-zero exit is surfaced as `Completed { success: false }`, distinct from
+/// a timeout — callers treat both as "unavailable" but for different reasons.
+#[cfg(unix)]
+#[test]
+fn bounded_probe_reports_failure_exit() {
+    let outcome = bounded_probe("sh", &["-c", "exit 1"], Duration::from_secs(5));
+    assert!(
+        matches!(outcome, ProbeOutcome::Completed { success: false, .. }),
+        "a non-zero exit must be Completed{{success:false}}, got {outcome:?}"
+    );
+}
+
+/// A missing binary yields `SpawnFailed`, never a hang or panic.
+#[test]
+fn bounded_probe_reports_spawn_failure() {
+    let outcome = bounded_probe(
+        "cqlite-nonexistent-docker-binary-1819",
+        &["info"],
+        Duration::from_secs(5),
+    );
+    assert!(
+        matches!(outcome, ProbeOutcome::SpawnFailed),
+        "a missing binary must be SpawnFailed, got {outcome:?}"
+    );
+}

--- a/cqlite-core/tests/issue_911_bti_partition_deletion_stats.rs
+++ b/cqlite-core/tests/issue_911_bti_partition_deletion_stats.rs
@@ -40,6 +40,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[path = "common/docker_probe.rs"]
+mod docker_probe;
+
 use cqlite_core::schema::{Column, KeyColumn, TableSchema};
 use cqlite_core::storage::sstable::writer::{SSTableFormat, SSTableInfo, SSTableWriter};
 use cqlite_core::storage::write_engine::mutation::{
@@ -56,18 +59,11 @@ use tempfile::TempDir;
 const SSTABLEDUMP: &str = "/opt/cassandra/tools/bin/sstabledump";
 
 fn cassandra_5_image() -> Option<String> {
-    let info = Command::new("docker").arg("info").output().ok()?;
-    if !info.status.success() {
-        return None;
-    }
-    let images = Command::new("docker")
-        .args(["images", "--format", "{{.Repository}}:{{.Tag}}"])
-        .output()
-        .ok()?;
-    if !images.status.success() {
-        return None;
-    }
-    let listing = String::from_utf8_lossy(&images.stdout);
+    // Bounded probes (issue #1819): an unresponsive Docker daemon must degrade
+    // to a clean SKIP (`None`) here, never wedge the test binary — and thus the
+    // gate — the way the old unbounded `docker info` / `docker images` did.
+    docker_probe::docker_probe(&["info"])?;
+    let listing = docker_probe::docker_probe(&["images", "--format", "{{.Repository}}:{{.Tag}}"])?;
     let mut candidate: Option<String> = None;
     for line in listing.lines() {
         let line = line.trim();

--- a/cqlite-core/tests/issue_911_bti_sstabledump_parity.rs
+++ b/cqlite-core/tests/issue_911_bti_sstabledump_parity.rs
@@ -36,6 +36,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[path = "common/docker_probe.rs"]
+mod docker_probe;
+
 use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
 use cqlite_core::storage::sstable::writer::{SSTableFormat, SSTableInfo, SSTableWriter};
 use cqlite_core::storage::write_engine::mutation::{
@@ -96,23 +99,44 @@ fn image_present_locally(listing: &str, image: &str) -> bool {
 /// local-tag discovery (exact pin, then `cassandra:5.0`, then any `cassandra:5.0.*`)
 /// for dev convenience.
 fn try_cassandra_5_image() -> Result<String, String> {
+    use docker_probe::{bounded_probe, ProbeOutcome, DOCKER_PROBE_TIMEOUT};
+
     let pinned = pinned_cassandra_image();
-    // 1. Docker daemon reachable?
-    let info = Command::new("docker").arg("info").output();
-    match info {
-        Ok(out) if out.status.success() => {}
-        Ok(_) => return Err("docker daemon not reachable (`docker info` failed)".to_string()),
-        Err(_) => return Err("docker binary not available".to_string()),
+    // 1. Docker daemon reachable? Bounded probe (issue #1819): an unresponsive
+    //    daemon (`docker info` blocks forever) must surface as an `Err` reason
+    //    within a few seconds, never wedge the gate. In strict mode the caller
+    //    turns that `Err` into a loud FAIL; outside strict mode, a clean SKIP.
+    match bounded_probe("docker", &["info"], DOCKER_PROBE_TIMEOUT) {
+        ProbeOutcome::Completed { success: true, .. } => {}
+        ProbeOutcome::Completed { success: false, .. } => {
+            return Err("docker daemon not reachable (`docker info` failed)".to_string())
+        }
+        ProbeOutcome::TimedOut => {
+            return Err(format!(
+                "`docker info` did not respond within {DOCKER_PROBE_TIMEOUT:?} \
+                 (daemon present but unresponsive); treating Docker as unavailable (issue #1819)"
+            ))
+        }
+        ProbeOutcome::SpawnFailed => return Err("docker binary not available".to_string()),
     }
     // 2. List images present locally. (We do not pull — CI provisions the pin.)
-    let images = Command::new("docker")
-        .args(["images", "--format", "{{.Repository}}:{{.Tag}}"])
-        .output();
-    let images = match images {
-        Ok(out) if out.status.success() => out,
+    let listing = match bounded_probe(
+        "docker",
+        &["images", "--format", "{{.Repository}}:{{.Tag}}"],
+        DOCKER_PROBE_TIMEOUT,
+    ) {
+        ProbeOutcome::Completed {
+            success: true,
+            stdout,
+        } => stdout,
+        ProbeOutcome::TimedOut => {
+            return Err(format!(
+                "`docker images` did not respond within {DOCKER_PROBE_TIMEOUT:?} \
+                 (daemon present but unresponsive); treating Docker as unavailable (issue #1819)"
+            ))
+        }
         _ => return Err("`docker images` failed".to_string()),
     };
-    let listing = String::from_utf8_lossy(&images.stdout);
 
     // STRICT: the exact pinned image MUST be present. No looser fallback — the
     // hard leg must validate against the stated pin, not a different local tag.


### PR DESCRIPTION
Closes #1819

## Problem
The `write-support` e2e tests' Docker-availability gate (`cassandra_5_image()`)
called `docker info`/`docker images` via unbounded `Command::output()`. When the
local Docker daemon is present but unresponsive, this blocks forever, wedging
the test binary — and `scripts/agent-gate.sh` itself — permanently (16+ min
observed). Same blocking-wait-with-no-deadline hazard family as #1691/#1692,
here a subprocess wait rather than an mpmc channel recv.

## Fix
New shared seam `cqlite-core/tests/common/docker_probe.rs`:
`bounded_probe(bin, args, timeout)` spawns the child, polls via
`wait_timeout::ChildExt`, kills+reaps on timeout. Both `cassandra_5_image()`
call sites (`issue_911_bti_partition_deletion_stats.rs`,
`issue_911_bti_sstabledump_parity.rs`) now route through it — an unresponsive
daemon degrades to a clean SKIP (non-strict) or a loud FAIL under
`CQLITE_REQUIRE_FIXTURES=1` (strict), never a hang.

Oracle-driven, no OpenSpec.

## Review-first (two rounds on the lite-green diff, before any full gate)
Round 1 (`rust-reviewer` + `roborev --branch`): 0 blockers on the seam design,
kill/reap/race-safety, and fail-closed conventions — but roborev found a real
**Low-severity correctness regression**: `bounded_probe` only drained stdout
AFTER the child exited and never drained stderr, unlike the `Command::output()`
it replaced (which drains both concurrently). A healthy `docker images`
producing output over the OS pipe buffer (~64KB) would block on its own
write(), get killed at the deadline, and be misreported `TimedOut` — a FALSE
gate failure against a healthy daemon in strict mode. Fixed in `961d7d2bd`:
per-pipe reader threads drain stdout+stderr concurrently with the wait loop,
with a bounded (`recv_timeout`) collection grace so an orphaned grandchild
holding an inherited pipe (as the test harness's `sleep`-based hang simulation
does) can't reintroduce an unbounded wait. New test
`bounded_probe_captures_output_larger_than_pipe_buffer` (200KB on both pipes,
~3x the typical buffer) proves this discriminates old vs new behavior, not
just "eventually returns."

Round 2 (re-review of the fix): clean, no blockers. One more Low/optional
note from roborev: `child.wait()` after `kill()` is technically unbounded in
theory, though `SIGKILL` makes the practical risk negligible (reviewer's own
assessment) — batching as a nit, not fixing (no concrete failure scenario).

## Nits (batched, not fixed here, no re-verify per the nit rule)
- Orphaned-grandchild kill signals only the direct child, not the process
  group — a non-issue for the real `docker` target, only a theoretical test-
  harness edge case.
- Timeout-test ceiling (10s vs 400ms budget) has slack; adequate, not tight.
- `child.wait()` post-kill is technically unbounded (see above).
- Doc comment says "a small drain grace" (singular); actual worst case is up
  to 2x `DRAIN_GRACE` (stdout then stderr sequentially). Wording nit.

## Drive-by unblock (separate commit, not part of #1819's scope)
`cargo test -p cqlite-core --lib` was compile-red on `origin/main` itself
(unrelated merge race between #2437/#2438 — tracked/fixed properly at #2462).
Added the same one-line `use serial_test::serial;` import here too so this
branch's own gate could run; will naturally dedupe on rebase once #2462 merges.

## Also filed (non-blocking, found while implementing, not fixed here to keep
this PR scoped)
#2470 — a pre-existing flaky test in the same file
(`windowed_stream_read_pattern_is_sequential`) contaminated by a shared global
counter under parallel test execution. Unrelated to this change.

## Gate status
Lite:
```
==== AGENT-GATE LITE SUMMARY ====
commit: 961d7d2bd branch: issue-1819-docker-probe-timeout dirty: no
file-size: PASS  fmt: PASS  clippy: PASS  scoped-tests: PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Full `agent-gate.sh` (the gate of record) + final roborev pass to be run by
`flow-closer`. **Dataset root + PATH note for the closer**: this sandbox needs
`export CQLITE_DATASETS_ROOT=/data/datasets` (subagents do not inherit the
parent shell's env) and the rustup 1.88.0 toolchain bin on PATH for fmt/clippy.