### PR TITLE
docs(#2460): sweep website + CLAUDE.md for 2026-07-14 ships

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,16 @@ it holds the **rules and pointers**; recipes and examples live in `docs/developm
 CQLite is a Rust library for local Apache Cassandra SSTable access — it reads (and writes)
 Cassandra 5.0 data files without cluster dependencies.
 
-**Status**: v0.13.0 (Jul 2026) — the performance release. M1–M5 complete (core reading, CLI,
-output writers, Python + Node.js bindings, write support + STCS compaction). v0.12 delivered
-byte-for-byte compaction parity vs Apache Cassandra, Arrow Flight + Trino connector, canonical BTI
-(`da`) write/read, CDC-style delta-export. v0.13 adds read-path speedups, byte-bounded result
-budgets, `Database::refresh()`, and no-heuristics correctness fixes. Next: M6 (WASM bindings),
-M7 (perf validation + v1.0).
+**Status**: v0.14.x (Jul 2026). M1–M5 complete (core reading, CLI, output writers, Python +
+Node.js bindings, write support + STCS compaction); v0.12 delivered byte-for-byte compaction parity
+vs Apache Cassandra, Arrow Flight + Trino connector, canonical BTI (`da`) write/read, CDC-style
+delta-export; v0.13 added read-path speedups, byte-bounded result budgets, and no-heuristics fixes.
+**0.15 is in progress** — the cqlite-trino latency/throughput/operations theme (epic #2403). Headline
+shipped since 0.14: lazy Summary-guided BIG index (O(summary) open, bounded point intervals,
+summary-guided scans — #2412), Flight admission control (`--max-concurrent-scans`, #2420),
+connector snapshot reuse per (keyspace,table) (#2356, connector 0.14.3), row-granular streaming for
+point-read/warm/full-scan merges (#2423/#2230), and a GitHub-enforced merge gate (#2433). Next: M6
+(WASM bindings), M7 (perf validation + v1.0).
 
 ## Documentation
 

--- a/cqlite-flight/README.md
+++ b/cqlite-flight/README.md
@@ -96,8 +96,31 @@ cargo run -p cqlite-flight -- \
 | `--data-dir` | (required) | Root holding `<keyspace>/<table>[-<uuid>]/` SSTable dirs. |
 | `--listen` | `0.0.0.0:8815` | Flight gRPC listen address. |
 | `--batch-size` | `8192` | Max rows per Arrow record batch. |
+| `--max-concurrent-scans` (`CQLITE_MAX_CONCURRENT_SCANS`) | `64` | Admission-control cap on concurrent `do_get` scans (issue #2420). Sized from blocking-pool / fd ceilings, not core count. Clamped to `[1, Semaphore::MAX_PERMITS]` (an out-of-range value is clamped with an operator warning rather than failing startup). |
 
 `RUST_LOG=info` enables logging (per-SSTable reads, etc.).
+
+### Admission control (`--max-concurrent-scans`)
+
+Each `do_get` acquires an admission permit **after** minimal ticket-syntax validation
+but **before** any producer/schema construction or filesystem work; the permit rides
+the response stream and releases on completion, client drop, or cancel. When all
+permits are held, a request queues briefly and, if none frees in time, is shed with
+gRPC **`UNAVAILABLE` before the first batch** — a retryable status that rides the
+connector's failover (never `RESOURCE_EXHAUSTED`). Malformed tickets fast-fail
+`INVALID_ARGUMENT` without consuming a permit. Queue time is visible in the
+`cqlite.rpc.phase` `admission` phase and the `cqlite.flight.admission.*` metrics
+(see [observability](../docs/observability/README.md)).
+
+### Lazy Summary-guided index (operational note, #2412)
+
+Opening a BIG-format SSTable is **O(summary)**: when a `Summary.db` component is
+present, `cqlite-flight` reads only the summary at open time and parses index
+intervals on demand, so a cold first query no longer pays a full `Index.db` parse.
+If `Summary.db` is **absent**, the reader fails closed to **one counted full
+Index.db parse** (a `FellBack` full parse). The metrics tell which path ran:
+`cqlite.sstable.index_parses_total` counts only full parses (flat on a lazy open),
+while `cqlite.sstable.index_interval_parses_total` counts per-lookup interval parses.
 
 ## Container image (GHCR)
 

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -42,6 +42,30 @@ CQLITE_OTEL_ENABLED=true CQLITE_OTEL_ENDPOINT=http://localhost:4317 \
 
 See the [Quickstart](quickstart.md) for the full walkthrough.
 
+## Recent instrument families
+
+> **Stopgap.** This hand-maintained list is a temporary bridge — issue #2426 will
+> generate the authoritative, operator-facing flight metrics reference directly
+> from `cqlite-core/src/observability/catalog.rs` (anti-drift). Until then, the
+> catalog is the source of truth; the names below are the recently-added families.
+
+- **`cqlite.flight.admission.*`** — 5 instruments for `do_get` admission control
+  (issue #2420): `limit` (gauge, configured `--max-concurrent-scans`), `in_use`
+  (gauge, permits held), `waiting` (gauge, requests queued for a permit),
+  `rejected_total` (counter, timeout sheds — each a gRPC `UNAVAILABLE`), and
+  `wait_seconds` (histogram, time spent queued before admission or rejection).
+- **`cqlite.rpc.phase` 5-phase closed set** — the bounded `do_get` phase dimension
+  on `cqlite.rpc.phase_duration` is now the closed set
+  `validate → admission → resolve → merge_setup → stream` (`admission` and
+  `validate` added by #2420), so a stalled request localizes to a phase (queued in
+  `admission`, building in `merge_setup`, etc.) from metrics alone.
+- **`cqlite.sstable.index_interval_parses_total`** — NEW counter (issue #2412):
+  one increment per summary-guided interval parse on a point lookup.
+  **`cqlite.sstable.index_parses_total` now counts FULL Index.db parses only** —
+  lazy open (#2412) makes a BIG open O(summary), so this counter stays flat on a
+  lazy open and increments only when a full parse is actually forced (e.g. an
+  absent `Summary.db` → one counted `FellBack` full parse).
+
 ## Source of truth
 
 The metric names, units, attribute keys, and env vars documented here are

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -81,6 +81,25 @@ rejected with `mergeStateStatus: BLOCKED`), so **there is no bypass**. A red tha
 `gh run rerun --failed` — never an admin override. This is load-bearing: if branch-protection settings
 ever regress (contexts emptied, `enforce_admins` disabled), this doctrine governs catching it.
 
+### Closer merge protocol (#2456)
+
+The `flow-closer` certifies a **specific SHA** — the tree the full gate of record and the final
+roborev pass actually ran on. Three mechanical rules keep the merge honest:
+
+- **Pre-merge SHA assertion (#2456, hard precondition).** Immediately before `gh pr merge`, the closer
+  does `git push`, then asserts `gh pr view <N> --json headRefOid` **equals the locally-certified
+  tip** — and **refuses to merge on mismatch**. Motivated by the 2026-07-14 stale-merge escape on
+  #2299/PR #2421: the closer certified a rebased-and-fixed tip locally but never pushed it, so
+  `gh pr merge` squashed the PR's *stale* pre-fix head and transiently landed a known data-loss
+  blocker on `main` (remediated by PR #2455). The GitHub required check re-runs on push but cannot
+  catch a "merge of an old green head" — the SHA assertion is the real guard.
+- **Unique gate-summary paths.** Each gate writes its `AGENT_GATE_SUMMARY_FILE` to a `mktemp`-unique
+  path (e.g. `$(mktemp /tmp/gate-<issue>-XXXXXX.txt)`) — shared `/tmp` names get contended under
+  multi-lane load, so one lane's summary can clobber or be misread as another's.
+- **Single full gate per machine.** The lead enforces one full gate at a time on a box; the closer
+  `pgrep`-checks for a running gate before launching its own so concurrent gates never corrupt a
+  shared `target/`.
+
 ## The specialist roster
 
 | Role | Agent / tool |

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -58,7 +58,20 @@ Asserting a value sampled at one instant against a window captured at a differen
 flakes on one-second boundaries.
 
 **Fix:** capture the time window so it covers *all* sampled operations (sample the bounds
-around the whole block, not per-call).
+around the whole block, not per-call). If the assertion is really a *perf* signal, convert it to a
+recorded metric (`eprintln!`) that belongs to the benchmark lane rather than the correctness gate —
+that is how #2369's `collection_benchmarks` wall-clock bounds were retired.
+
+### Process-global work counters under thread-parallel tests
+A test that asserts a **delta** on a process-global counter (an `AtomicU64` incremented deep in the
+read/scan path) flakes under CI's thread-parallel `cargo test` — unrelated concurrent tests bump the
+same counter between the before/after reads. `#[serial(tag)]` only serializes same-tag tests, so an
+untagged sibling still contaminates the delta. Local per-process runners (nextest) never reproduce it.
+
+**Fix (structural):** scope the measurement to the current thread — a `#[cfg(test)]` thread-local
+scope guard (the `StreamWalkScope` pattern, #2428; `index_probes` follow-up #2451) that reads only
+its own thread's increments, contamination-proof by construction. Production builds keep the plain
+atomic. Serial tags on the counter then become redundant.
 
 ### No-heuristics violations
 Inferring a type or behaviour from byte patterns instead of authoritative metadata.

--- a/website/src/content/docs/user-docs/flight-trino.md
+++ b/website/src/content/docs/user-docs/flight-trino.md
@@ -292,6 +292,14 @@ query finishes; a TTL backstop (`cqlite.snapshot-ttl`, default `6h`) ensures a
 coordinator crash can't leak it. Snapshot creation is **fail-closed** — if it
 fails, the query fails rather than silently falling back to a live read.
 
+To cut snapshot-create (and therefore memtable-flush) churn, the connector
+**reuses one snapshot per `(keyspace, table)`** across queries within a bounded
+staleness window (`cqlite.snapshot-reuse-window-ms`, default `3000`), retiring
+superseded windows after `cqlite.snapshot-retire-grace-ms` (default `10m`, must
+exceed your longest query). See
+[Snapshot reuse and the staleness bound](https://github.com/pmcfadin/cqlite/blob/main/trino-connector/README.md#snapshot-reuse-and-the-staleness-bound)
+in the connector README for the sizing rules (issue #2356/#2306).
+
 **Memtable visibility differs by mode (issue #2305).** `snapshot` mode is a per-query,
 point-in-time read that **includes durable memtable state**: Cassandra's snapshot creation
 flushes the memtable as a side effect by design, and the Sidecar's create-snapshot HTTP API has


### PR DESCRIPTION
Closes #2460. Docs-only sweep (6 files) for today's 12 merges: CLAUDE.md status paragraph (0.14.x + 0.15 theme + headline capabilities); delivery-pipeline page (closer SHA-assert #2456, unique gate-summary paths, lead-enforced gate serialization); roborev-findings page (counter-scoping class #2428/#2451, wall-clock→#2369 cross-link); observability README stopgap (admission.* / 5-phase / interval-parse counters + #2426 pointer); cqlite-flight README (--max-concurrent-scans, lazy-index note); flight-trino connector cross-link. Every claim grounded in the merged tree. Review-first skipped: mechanical docs diff. Note: this branch's earlier lite FAIL was the (now-fixed) #2459 broken-main, not this diff.