### PR TITLE
fix(#2148): parse Statistics.db TOC once (3 walks -> 1), thread offsets

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -198,6 +198,16 @@ required-features = ["arrow"]
 name = "issue_2302_written_index_resolve"
 required-features = ["work-counters", "write-support"]
 
+# Statistics.db single-TOC-walk oracle (issue #2148). `#![cfg(feature =
+# "cli-helpers")]` — the `toc_walk_metrics` counter getters/`reset` +
+# `record_toc_walk` live behind `cli-helpers` — so it only compiles+runs with that
+# feature. The lite gate's blast-radius scoping runs cqlite-core `--lib` +
+# `--features cli-helpers`, which compiles and runs this changed `--test` target;
+# the full gate's core-tests (`--features cli-helpers`) also picks it up.
+[[test]]
+name = "issue_2148_statistics_toc_single_walk"
+required-features = ["cli-helpers"]
+
 [[bench]]
 name = "partition_lookup"
 harness = false

--- a/cqlite-core/src/parser/enhanced_statistics_parser/header.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser/header.rs
@@ -7,16 +7,6 @@
 use super::super::statistics::StatisticsHeader;
 use nom::{number::complete::be_u32, IResult};
 
-/// Cassandra MetadataType enum ordinals (from MetadataType.java)
-/// Used to identify component types in Statistics.db TOC
-#[allow(dead_code)]
-const METADATA_TYPE_VALIDATION: u32 = 0;
-#[allow(dead_code)]
-const METADATA_TYPE_COMPACTION: u32 = 1;
-#[allow(dead_code)]
-const METADATA_TYPE_STATS: u32 = 2;
-const METADATA_TYPE_HEADER: u32 = 3; // SerializationHeader
-
 /// Enhanced Statistics.db header parser for real 'nb' format
 ///
 /// This function parses the actual 32-byte binary header structure from
@@ -71,104 +61,12 @@ pub fn parse_nb_format_header(input: &[u8]) -> IResult<&[u8], StatisticsHeader> 
     ))
 }
 
-/// Parse Statistics.db Table of Contents to get component offsets (Issue #216)
-///
-/// Statistics.db format (from Cassandra MetadataSerializer.java):
-/// - [4 bytes] number_of_components (u32 BE)
-/// - [4 bytes] checksum (u32 BE)
-/// - [TOC] component_type (u32) | offset (u32) for each component
-/// - [Component data...]
-///
-/// MetadataType enum ordinals:
-/// - 0 = VALIDATION
-/// - 1 = COMPACTION
-/// - 2 = STATS
-/// - 3 = HEADER (SerializationHeader)
-///
-/// Returns the offset to the HEADER component (SerializationHeader), or None if not found.
-pub(super) fn parse_statistics_toc_for_header_offset(input: &[u8]) -> Option<usize> {
-    // Count this TOC walk (issue #1658 A5 bench instrumentation — no decode effect).
-    super::super::toc_walk_metrics::record_toc_walk();
-    if input.len() < 8 {
-        tracing::debug!("Statistics.db too small for TOC: {} bytes", input.len());
-        return None;
-    }
-
-    // Parse number of components
-    let num_components = u32::from_be_bytes([input[0], input[1], input[2], input[3]]);
-    tracing::debug!("Statistics.db TOC: {} components", num_components);
-
-    // Sanity check: Cassandra has exactly 4 MetadataType enum values
-    // (VALIDATION=0, COMPACTION=1, STATS=2, HEADER=3)
-    // A value > 100 indicates corrupted or malicious data
-    if num_components > 100 {
-        tracing::warn!(
-            "Suspicious num_components={} in Statistics.db TOC (expected <=4)",
-            num_components
-        );
-        return None;
-    }
-
-    // Skip checksum (bytes 4-7)
-    // TOC starts at byte 8
-
-    let toc_start: usize = 8;
-    let toc_entry_size: usize = 8; // 4 bytes type + 4 bytes offset
-
-    // Use checked_mul to prevent integer overflow on multiplication
-    let toc_size = (num_components as usize)
-        .checked_mul(toc_entry_size)
-        .and_then(|size| size.checked_add(toc_start))?;
-
-    if input.len() < toc_size {
-        tracing::debug!(
-            "Statistics.db too small for {} TOC entries: {} bytes (need {})",
-            num_components,
-            input.len(),
-            toc_size
-        );
-        return None;
-    }
-
-    // Search for HEADER component (type 3)
-    for i in 0..num_components as usize {
-        // Use checked arithmetic to prevent overflow in entry offset calculation
-        let entry_offset = i
-            .checked_mul(toc_entry_size)
-            .and_then(|offset| offset.checked_add(toc_start))?;
-        let component_type = u32::from_be_bytes([
-            input[entry_offset],
-            input[entry_offset + 1],
-            input[entry_offset + 2],
-            input[entry_offset + 3],
-        ]);
-        let component_offset = u32::from_be_bytes([
-            input[entry_offset + 4],
-            input[entry_offset + 5],
-            input[entry_offset + 6],
-            input[entry_offset + 7],
-        ]) as usize;
-
-        tracing::debug!(
-            "TOC entry {}: type={} offset=0x{:x}",
-            i,
-            component_type,
-            component_offset
-        );
-
-        if component_type == METADATA_TYPE_HEADER {
-            tracing::debug!(
-                "Found HEADER component at offset 0x{:x} ({})",
-                component_offset,
-                component_offset
-            );
-            return Some(component_offset);
-        }
-    }
-
-    tracing::debug!("HEADER component not found in Statistics.db TOC");
-    None
-}
+// The Statistics.db Table-of-Contents is parsed ONCE by
+// `repair_metadata::parse_statistics_toc` (issue #2148), which resolves both the
+// HEADER (SerializationHeader) offset and the STATS component bounds in a single
+// walk. The historical per-consumer `parse_statistics_toc_for_header_offset`
+// walker (issue #216) was removed to eliminate the redundant re-walk (the metadata
+// stack previously walked the TOC three times per open).
 
 #[cfg(test)]
 mod tests {

--- a/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
@@ -53,9 +53,9 @@ pub use header::parse_nb_format_header;
 
 use super::statistics::*;
 use crate::error::{Error, Result};
+use crate::parser::repair_metadata::{parse_statistics_toc, StatisticsToc};
 use crate::storage::sstable::version_gate::VersionGates;
 use encoding_stats::parse_minimal_encoding_stats;
-use header::parse_statistics_toc_for_header_offset;
 
 /// Type alias for EncodingStats parse result to reduce complexity
 type EncodingStatsResult = (
@@ -114,8 +114,33 @@ pub fn parse_nb_format_statistics_data(
     Vec<super::header::ColumnInfo>,
     Vec<super::header::ColumnInfo>,
 )> {
-    // Get HEADER offset from TOC (Issue #216)
-    let header_offset = parse_statistics_toc_for_header_offset(full_input);
+    // Standalone/test entry: parse the TOC once here, then delegate. The main
+    // open path (`parse_enhanced_statistics_file`) parses the TOC ONCE and threads
+    // it to both this decode and the STATS post-pass (issue #2148).
+    let toc = parse_statistics_toc(full_input);
+    parse_nb_format_statistics_data_with_toc(input, header, full_input, &toc, gates)
+}
+
+/// [`parse_nb_format_statistics_data`] over a `Statistics.db` TOC that was already
+/// parsed once (issue #2148): reuses the resolved HEADER offset and STATS bounds
+/// from `toc` instead of re-walking the TOC, so a single metadata parse walks the
+/// TOC exactly once.
+#[allow(clippy::type_complexity)]
+pub(crate) fn parse_nb_format_statistics_data_with_toc(
+    input: &[u8],
+    header: &StatisticsHeader,
+    full_input: &[u8],
+    toc: &StatisticsToc,
+    gates: Option<&VersionGates>,
+) -> Result<(
+    RowStatistics,
+    TimestampStatistics,
+    Vec<super::header::ColumnInfo>,
+    Vec<super::header::ColumnInfo>,
+    Vec<super::header::ColumnInfo>,
+)> {
+    // HEADER offset from the shared single TOC parse (Issue #216, #2148).
+    let header_offset = toc.header_offset();
 
     // Parse the EncodingStats section from the data following the header
     let result = parse_minimal_encoding_stats(input, full_input, header_offset, gates);
@@ -181,7 +206,9 @@ pub fn parse_nb_format_statistics_data(
             //     safer than the old `nb` synthesis, which could fabricate a nonzero
             //     count for an oa/da file.
             let (total_rows, partition_count) =
-                match crate::parser::repair_metadata::read_table_counts(full_input, gates) {
+                match crate::parser::repair_metadata::read_table_counts_with_toc(
+                    full_input, toc, gates,
+                ) {
                     // `total_rows.unwrap_or(0)`: a `None` here means STATS does NOT
                     // authoritatively expose `totalRows` (e.g. an unmodeled
                     // improvedMinMax covered-Slice bound blocks the walk). The 0 is
@@ -301,9 +328,15 @@ pub fn parse_enhanced_statistics_file<'a>(
     // Parse the 32-byte header
     let (remaining, header) = parse_nb_format_header(input)?;
 
+    // Parse the Statistics.db TOC ONCE (issue #2148) and thread it to every
+    // downstream consumer — the EncodingStats/row-count decode below and the
+    // STATS-extras post-pass — so the TOC is walked exactly once per open,
+    // never re-walked to relocate an already-resolved component offset.
+    let toc = parse_statistics_toc(input);
+
     // Parse minimal statistics data (EncodingStats + SerializationHeader columns)
     // Pass full input for TOC-based HEADER offset lookup (Issue #216)
-    let result = parse_nb_format_statistics_data(remaining, &header, input, gates);
+    let result = parse_nb_format_statistics_data_with_toc(remaining, &header, input, &toc, gates);
 
     match result {
         Ok((row_stats, mut timestamp_stats, partition_columns, clustering_columns, columns)) => {
@@ -328,7 +361,9 @@ pub fn parse_enhanced_statistics_file<'a>(
             // substituting the min — consumers requiring a real max must not
             // proceed.
             let tombstone_drop_times =
-                match crate::parser::repair_metadata::parse_stats_extras(input, gates) {
+                match crate::parser::repair_metadata::parse_stats_extras_with_toc(
+                    input, &toc, gates,
+                ) {
                     Ok(extras) => {
                         // Only set max_deletion_time. Do NOT touch min_deletion_time
                         // (the EncodingStats min baseline consumed elsewhere).

--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -60,6 +60,8 @@ use crate::storage::sstable::version_gate::VersionGates;
 
 /// Cassandra `MetadataType.STATS` ordinal (MetadataType.java).
 const METADATA_TYPE_STATS: u32 = 2;
+/// Cassandra `MetadataType.HEADER` ordinal (SerializationHeader; MetadataType.java).
+const METADATA_TYPE_HEADER: u32 = 3;
 
 /// A STATS repair field that may either have been decoded from real bytes
 /// (`Decoded`) or is honestly reported as not-yet-decoded (`Unparsed`).
@@ -199,23 +201,99 @@ struct StatsComponentBounds {
 ///     invalid (offset past EOF, inverted, or zero-length) — fail closed so a
 ///     corrupt `Statistics.db` is never silently reported as unrepaired.
 fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> {
+    parse_statistics_toc(input).stats_bounds()
+}
+
+/// The `Statistics.db` Table-of-Contents parsed ONCE (issue #2148): the resolved
+/// HEADER (SerializationHeader) offset and the STATS component `[start, end)`
+/// bounds, both extracted in a single forward walk.
+///
+/// Before #2148 the metadata stack re-walked the same on-disk TOC **three times**
+/// per open — once for the HEADER offset in
+/// [`crate::parser::enhanced_statistics_parser`], then once each inside
+/// [`read_table_counts`] and [`parse_stats_extras`]. Parsing the TOC once and
+/// threading this struct to those consumers (`*_with_toc`) eliminates the two
+/// redundant walks (`parser::toc_walk_metrics` drops from 3 → 1 per parse).
+#[derive(Debug, Clone)]
+pub struct StatisticsToc {
+    /// Offset of the HEADER (SerializationHeader) component, or `None` when the
+    /// TOC has no HEADER entry OR is malformed. Lenient — mirrors the historical
+    /// `parse_statistics_toc_for_header_offset` semantics (a malformed TOC yields
+    /// `None`, never an error, so the EncodingStats parse degrades exactly as
+    /// before).
+    header_offset: Option<usize>,
+    /// STATS component `[start, end)` bounds. `Ok(None)` = a well-formed TOC that
+    /// carries no STATS component; `Err(msg)` = a malformed/truncated TOC or an
+    /// invalid STATS range (fail-closed). The corruption *message* is stored (not
+    /// `Error`, which is not `Clone`) so BOTH the row-count and stats-extras
+    /// consumers can each rebuild the same `Error::Corruption` from one shared
+    /// parse.
+    stats_bounds: std::result::Result<Option<StatsComponentBounds>, String>,
+}
+
+impl StatisticsToc {
+    /// The resolved HEADER (SerializationHeader) component offset (lenient `None`).
+    pub fn header_offset(&self) -> Option<usize> {
+        self.header_offset
+    }
+
+    /// The STATS component bounds as a strict [`Result`], reconstructing the
+    /// fail-closed `Error::Corruption` for a malformed TOC / invalid range so
+    /// consumers see identical error semantics to the pre-#2148 per-consumer walk.
+    fn stats_bounds(&self) -> Result<Option<StatsComponentBounds>> {
+        match &self.stats_bounds {
+            Ok(v) => Ok(*v),
+            Err(msg) => Err(Error::Corruption(msg.clone())),
+        }
+    }
+}
+
+/// Parse the `Statistics.db` TOC ONCE (issue #2148), resolving both the HEADER
+/// offset and the STATS component bounds in a single pass.
+///
+/// This is the single TOC-walk site the `parser::toc_walk_metrics` counter
+/// records — consumers that accept a [`StatisticsToc`] (`*_with_toc`) add no
+/// further walk. A malformed/truncated TOC yields `header_offset = None` (lenient)
+/// and a fail-closed STATS-bounds error (surfaced when a consumer reads it).
+pub fn parse_statistics_toc(input: &[u8]) -> StatisticsToc {
     // Count this TOC walk (issue #1658 A5 bench instrumentation — no decode effect).
     crate::parser::toc_walk_metrics::record_toc_walk();
-    // A malformed or truncated TOC must FAIL CLOSED rather than be silently
-    // reported as "no STATS component" (which would misreport corrupt repair
-    // metadata as the unrepaired default). `Ok(None)` is reserved exclusively
-    // for a well-formed TOC that genuinely carries no STATS entry (below).
+    match walk_statistics_toc(input) {
+        Ok((header_offset, stats)) => StatisticsToc {
+            header_offset,
+            stats_bounds: Ok(stats),
+        },
+        Err(msg) => StatisticsToc {
+            header_offset: None,
+            stats_bounds: Err(msg),
+        },
+    }
+}
+
+/// Single forward walk over the `Statistics.db` TOC resolving the HEADER offset
+/// and the STATS `[start, end)` bounds together. Pure (no counter side effect);
+/// the public [`parse_statistics_toc`] records the walk and wraps the outcome.
+///
+/// A malformed or truncated TOC returns `Err(msg)` so it FAILS CLOSED rather than
+/// being silently reported as "no STATS component" (which would misreport corrupt
+/// repair metadata as the unrepaired default). `Ok((_, None))` is reserved
+/// exclusively for a well-formed TOC that genuinely carries no STATS entry. The
+/// HEADER offset is resolved leniently — a present HEADER entry (first match) is
+/// returned, otherwise `None`.
+fn walk_statistics_toc(
+    input: &[u8],
+) -> std::result::Result<(Option<usize>, Option<StatsComponentBounds>), String> {
     if input.len() < 8 {
-        return Err(Error::Corruption(format!(
+        return Err(format!(
             "Statistics.db too short for a metadata TOC header: {} bytes",
             input.len()
-        )));
+        ));
     }
     let num_components = u32::from_be_bytes([input[0], input[1], input[2], input[3]]);
     if num_components == 0 || num_components > 100 {
-        return Err(Error::Corruption(format!(
+        return Err(format!(
             "Statistics.db TOC component count out of range: {num_components}"
-        )));
+        ));
     }
     let toc_start = 8usize;
     let entry_size = 8usize;
@@ -225,19 +303,20 @@ fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> 
     {
         Some(n) => n,
         None => {
-            return Err(Error::Corruption(format!(
+            return Err(format!(
                 "Statistics.db TOC size overflow for {num_components} components"
-            )))
+            ))
         }
     };
     if input.len() < toc_size {
-        return Err(Error::Corruption(format!(
+        return Err(format!(
             "Statistics.db TOC truncated: need {toc_size} bytes, have {}",
             input.len()
-        )));
+        ));
     }
 
     let mut stats_off: Option<usize> = None;
+    let mut header_off: Option<usize> = None;
     let mut offsets: Vec<usize> = Vec::with_capacity(num_components as usize);
     for i in 0..num_components as usize {
         let entry = match i
@@ -246,9 +325,9 @@ fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> 
         {
             Some(e) => e,
             None => {
-                return Err(Error::Corruption(format!(
+                return Err(format!(
                     "Statistics.db TOC entry offset overflow at index {i}"
-                )))
+                ))
             }
         };
         let ty = u32::from_be_bytes([
@@ -265,16 +344,20 @@ fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> 
         ]) as usize;
         offsets.push(off);
         if ty == METADATA_TYPE_STATS {
+            // Last-wins, matching the historical `stats_component_bounds` walk.
             stats_off = Some(off);
+        } else if ty == METADATA_TYPE_HEADER && header_off.is_none() {
+            // First-wins, matching the historical
+            // `parse_statistics_toc_for_header_offset` early-return.
+            header_off = Some(off);
         }
     }
 
     // No STATS component in the TOC → nothing to decode (not an error).
     let Some(start) = stats_off else {
-        return Ok(None);
+        return Ok((header_off, None));
     };
 
-    // The STATS body ends where the *next* component (or the file) begins. For
     // The STATS body ends 4 bytes before the *next* component begins: every
     // supported Cassandra 5.0 format (`nb`/`oa`/`da`, all `>= na`) writes a
     // per-component CRC32 between each component body and the next component's
@@ -291,18 +374,17 @@ fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> 
     let end = next_boundary.saturating_sub(METADATA_COMPONENT_CRC_LEN);
 
     // A STATS entry exists but its derived range is invalid (offset past EOF,
-    // inverted, or empty): this is genuine corruption — fail closed rather than
-    // silently reporting the unrepaired default or building a cursor over
-    // garbage.
+    // inverted, or empty): genuine corruption — fail closed rather than silently
+    // reporting the unrepaired default or building a cursor over garbage.
     if start >= end || end > input.len() {
-        return Err(Error::Corruption(format!(
+        return Err(format!(
             "STATS component range invalid: start {start}, derived end {end}, \
              Statistics.db {} bytes",
             input.len()
-        )));
+        ));
     }
 
-    Ok(Some(StatsComponentBounds { start, end }))
+    Ok((header_off, Some(StatsComponentBounds { start, end })))
 }
 
 /// A bounded cursor over the STATS component bytes that fails closed (explicit
@@ -824,9 +906,28 @@ pub struct TableCounts {
 /// `Statistics.db` with NO STATS component yields all-zero counts
 /// (`partition_count == 0`, `total_rows == None`).
 pub fn read_table_counts(input: &[u8], gates: Option<&VersionGates>) -> Result<TableCounts> {
+    read_table_counts_from_bounds(input, stats_component_bounds(input)?, gates)
+}
+
+/// [`read_table_counts`] over a `Statistics.db` TOC that was already parsed once
+/// (issue #2148): reuses the STATS bounds from `toc` instead of re-walking the
+/// TOC, so a single metadata parse walks the TOC exactly once.
+pub fn read_table_counts_with_toc(
+    input: &[u8],
+    toc: &StatisticsToc,
+    gates: Option<&VersionGates>,
+) -> Result<TableCounts> {
+    read_table_counts_from_bounds(input, toc.stats_bounds()?, gates)
+}
+
+fn read_table_counts_from_bounds(
+    input: &[u8],
+    bounds: Option<StatsComponentBounds>,
+    gates: Option<&VersionGates>,
+) -> Result<TableCounts> {
     let walk = gates.map(RepairWalkGates::from);
 
-    let Some(bounds) = stats_component_bounds(input)? else {
+    let Some(bounds) = bounds else {
         return Ok(TableCounts {
             partition_count: 0,
             total_rows: None,
@@ -1013,7 +1114,26 @@ impl Default for StatsExtras {
 /// existing placeholders" and MUST NOT propagate it (a `Statistics.db` that
 /// parses today must keep parsing).
 pub fn parse_stats_extras(input: &[u8], gates: Option<&VersionGates>) -> Result<StatsExtras> {
-    let Some(bounds) = stats_component_bounds(input)? else {
+    parse_stats_extras_from_bounds(input, stats_component_bounds(input)?, gates)
+}
+
+/// [`parse_stats_extras`] over a `Statistics.db` TOC that was already parsed once
+/// (issue #2148): reuses the STATS bounds from `toc` instead of re-walking the
+/// TOC, so a single metadata parse walks the TOC exactly once.
+pub fn parse_stats_extras_with_toc(
+    input: &[u8],
+    toc: &StatisticsToc,
+    gates: Option<&VersionGates>,
+) -> Result<StatsExtras> {
+    parse_stats_extras_from_bounds(input, toc.stats_bounds()?, gates)
+}
+
+fn parse_stats_extras_from_bounds(
+    input: &[u8],
+    bounds: Option<StatsComponentBounds>,
+    gates: Option<&VersionGates>,
+) -> Result<StatsExtras> {
+    let Some(bounds) = bounds else {
         // No STATS component → nothing to decode. Report the canonical
         // "no tombstones" default rather than failing.
         return Ok(StatsExtras::default());

--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -214,13 +214,20 @@ fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> 
 /// [`read_table_counts`] and [`parse_stats_extras`]. Parsing the TOC once and
 /// threading this struct to those consumers (`*_with_toc`) eliminates the two
 /// redundant walks (`parser::toc_walk_metrics` drops from 3 → 1 per parse).
+/// Crate-private (issue #2148 blocker): this reuse type has no external consumers
+/// (only the in-crate `enhanced_statistics_parser`), and its `*_with_toc` consumers
+/// slice `input` by bounds carried in the TOC. Keeping it `pub(crate)` guarantees a
+/// `StatisticsToc` parsed from one buffer can never be paired with a different
+/// (smaller) buffer at a public boundary, which would index out of range.
 #[derive(Debug, Clone)]
-pub struct StatisticsToc {
+pub(crate) struct StatisticsToc {
     /// Offset of the HEADER (SerializationHeader) component, or `None` when the
-    /// TOC has no HEADER entry OR is malformed. Lenient — mirrors the historical
-    /// `parse_statistics_toc_for_header_offset` semantics (a malformed TOC yields
-    /// `None`, never an error, so the EncodingStats parse degrades exactly as
-    /// before).
+    /// TOC has no HEADER entry OR is too malformed to locate one. Resolved
+    /// INDEPENDENTLY of the STATS bounds (issue #2148): a HEADER entry found before
+    /// an invalid STATS byte-range is still returned here, so EncodingStats decodes
+    /// authoritatively from it even while [`Self::stats_bounds`] fails closed. This
+    /// preserves the pre-#2148 `parse_statistics_toc_for_header_offset` semantics,
+    /// whose header walk never depended on any STATS-range check.
     header_offset: Option<usize>,
     /// STATS component `[start, end)` bounds. `Ok(None)` = a well-formed TOC that
     /// carries no STATS component; `Err(msg)` = a malformed/truncated TOC or an
@@ -233,7 +240,7 @@ pub struct StatisticsToc {
 
 impl StatisticsToc {
     /// The resolved HEADER (SerializationHeader) component offset (lenient `None`).
-    pub fn header_offset(&self) -> Option<usize> {
+    pub(crate) fn header_offset(&self) -> Option<usize> {
         self.header_offset
     }
 
@@ -255,18 +262,17 @@ impl StatisticsToc {
 /// records — consumers that accept a [`StatisticsToc`] (`*_with_toc`) add no
 /// further walk. A malformed/truncated TOC yields `header_offset = None` (lenient)
 /// and a fail-closed STATS-bounds error (surfaced when a consumer reads it).
-pub fn parse_statistics_toc(input: &[u8]) -> StatisticsToc {
+pub(crate) fn parse_statistics_toc(input: &[u8]) -> StatisticsToc {
     // Count this TOC walk (issue #1658 A5 bench instrumentation — no decode effect).
     crate::parser::toc_walk_metrics::record_toc_walk();
-    match walk_statistics_toc(input) {
-        Ok((header_offset, stats)) => StatisticsToc {
-            header_offset,
-            stats_bounds: Ok(stats),
-        },
-        Err(msg) => StatisticsToc {
-            header_offset: None,
-            stats_bounds: Err(msg),
-        },
+    // The walk resolves the HEADER offset and the STATS bounds INDEPENDENTLY: a
+    // corrupt STATS byte-range must never nuke a HEADER that was already located
+    // (issue #2148 roborev/reviewer blocker) — a valid HEADER still decodes
+    // EncodingStats authoritatively even when the STATS range fails closed.
+    let (header_offset, stats_bounds) = walk_statistics_toc(input);
+    StatisticsToc {
+        header_offset,
+        stats_bounds,
     }
 }
 
@@ -274,26 +280,39 @@ pub fn parse_statistics_toc(input: &[u8]) -> StatisticsToc {
 /// and the STATS `[start, end)` bounds together. Pure (no counter side effect);
 /// the public [`parse_statistics_toc`] records the walk and wraps the outcome.
 ///
-/// A malformed or truncated TOC returns `Err(msg)` so it FAILS CLOSED rather than
-/// being silently reported as "no STATS component" (which would misreport corrupt
-/// repair metadata as the unrepaired default). `Ok((_, None))` is reserved
-/// exclusively for a well-formed TOC that genuinely carries no STATS entry. The
-/// HEADER offset is resolved leniently — a present HEADER entry (first match) is
-/// returned, otherwise `None`.
+/// The two outputs are resolved INDEPENDENTLY, exactly as the pre-#2148 separate
+/// walks (`parse_statistics_toc_for_header_offset` for the header, and
+/// `stats_component_bounds` for STATS) were: the returned `header_offset` is the
+/// first present HEADER entry (lenient — `None` when the TOC is malformed/truncated
+/// or carries no HEADER). The STATS-bounds `Result` FAILS CLOSED (`Err(msg)`) on a
+/// malformed/truncated TOC or an invalid STATS range rather than being silently
+/// reported as "no STATS component"; `Ok(None)` is reserved exclusively for a
+/// well-formed TOC that genuinely carries no STATS entry. Crucially, a corrupt
+/// STATS byte-range does NOT discard an already-resolved HEADER offset — a valid
+/// HEADER still decodes EncodingStats authoritatively (issue #2148 blocker).
 fn walk_statistics_toc(
     input: &[u8],
-) -> std::result::Result<(Option<usize>, Option<StatsComponentBounds>), String> {
+) -> (
+    Option<usize>,
+    std::result::Result<Option<StatsComponentBounds>, String>,
+) {
     if input.len() < 8 {
-        return Err(format!(
-            "Statistics.db too short for a metadata TOC header: {} bytes",
-            input.len()
-        ));
+        return (
+            None,
+            Err(format!(
+                "Statistics.db too short for a metadata TOC header: {} bytes",
+                input.len()
+            )),
+        );
     }
     let num_components = u32::from_be_bytes([input[0], input[1], input[2], input[3]]);
     if num_components == 0 || num_components > 100 {
-        return Err(format!(
-            "Statistics.db TOC component count out of range: {num_components}"
-        ));
+        return (
+            None,
+            Err(format!(
+                "Statistics.db TOC component count out of range: {num_components}"
+            )),
+        );
     }
     let toc_start = 8usize;
     let entry_size = 8usize;
@@ -303,16 +322,22 @@ fn walk_statistics_toc(
     {
         Some(n) => n,
         None => {
-            return Err(format!(
-                "Statistics.db TOC size overflow for {num_components} components"
-            ))
+            return (
+                None,
+                Err(format!(
+                    "Statistics.db TOC size overflow for {num_components} components"
+                )),
+            )
         }
     };
     if input.len() < toc_size {
-        return Err(format!(
-            "Statistics.db TOC truncated: need {toc_size} bytes, have {}",
-            input.len()
-        ));
+        return (
+            None,
+            Err(format!(
+                "Statistics.db TOC truncated: need {toc_size} bytes, have {}",
+                input.len()
+            )),
+        );
     }
 
     let mut stats_off: Option<usize> = None;
@@ -325,9 +350,14 @@ fn walk_statistics_toc(
         {
             Some(e) => e,
             None => {
-                return Err(format!(
-                    "Statistics.db TOC entry offset overflow at index {i}"
-                ))
+                // TOC index arithmetic overflow: the header is not reliably
+                // resolvable, so surface the corruption on BOTH channels.
+                return (
+                    header_off,
+                    Err(format!(
+                        "Statistics.db TOC entry offset overflow at index {i}"
+                    )),
+                );
             }
         };
         let ty = u32::from_be_bytes([
@@ -355,7 +385,7 @@ fn walk_statistics_toc(
 
     // No STATS component in the TOC → nothing to decode (not an error).
     let Some(start) = stats_off else {
-        return Ok((header_off, None));
+        return (header_off, Ok(None));
     };
 
     // The STATS body ends 4 bytes before the *next* component begins: every
@@ -374,17 +404,22 @@ fn walk_statistics_toc(
     let end = next_boundary.saturating_sub(METADATA_COMPONENT_CRC_LEN);
 
     // A STATS entry exists but its derived range is invalid (offset past EOF,
-    // inverted, or empty): genuine corruption — fail closed rather than silently
-    // reporting the unrepaired default or building a cursor over garbage.
+    // inverted, or empty): genuine corruption — fail closed on the STATS channel
+    // rather than silently reporting the unrepaired default or building a cursor
+    // over garbage. The HEADER offset stays resolved and is returned regardless
+    // (issue #2148 blocker: a corrupt STATS range must not nuke a valid HEADER).
     if start >= end || end > input.len() {
-        return Err(format!(
-            "STATS component range invalid: start {start}, derived end {end}, \
-             Statistics.db {} bytes",
-            input.len()
-        ));
+        return (
+            header_off,
+            Err(format!(
+                "STATS component range invalid: start {start}, derived end {end}, \
+                 Statistics.db {} bytes",
+                input.len()
+            )),
+        );
     }
 
-    Ok((header_off, Some(StatsComponentBounds { start, end })))
+    (header_off, Ok(Some(StatsComponentBounds { start, end })))
 }
 
 /// A bounded cursor over the STATS component bytes that fails closed (explicit
@@ -912,7 +947,7 @@ pub fn read_table_counts(input: &[u8], gates: Option<&VersionGates>) -> Result<T
 /// [`read_table_counts`] over a `Statistics.db` TOC that was already parsed once
 /// (issue #2148): reuses the STATS bounds from `toc` instead of re-walking the
 /// TOC, so a single metadata parse walks the TOC exactly once.
-pub fn read_table_counts_with_toc(
+pub(crate) fn read_table_counts_with_toc(
     input: &[u8],
     toc: &StatisticsToc,
     gates: Option<&VersionGates>,
@@ -1120,7 +1155,7 @@ pub fn parse_stats_extras(input: &[u8], gates: Option<&VersionGates>) -> Result<
 /// [`parse_stats_extras`] over a `Statistics.db` TOC that was already parsed once
 /// (issue #2148): reuses the STATS bounds from `toc` instead of re-walking the
 /// TOC, so a single metadata parse walks the TOC exactly once.
-pub fn parse_stats_extras_with_toc(
+pub(crate) fn parse_stats_extras_with_toc(
     input: &[u8],
     toc: &StatisticsToc,
     gates: Option<&VersionGates>,
@@ -2082,6 +2117,51 @@ mod tests {
         assert_eq!(
             counts.total_rows, None,
             "no gates → totalRows honestly absent, never guessed"
+        );
+    }
+
+    /// Issue #2148 blocker (roborev + rust-reviewer): a corrupt STATS byte-range
+    /// must NOT discard an already-resolved HEADER offset. The pre-#2148 header
+    /// walk (`parse_statistics_toc_for_header_offset`) was independent of any
+    /// STATS-range check, so a Statistics.db with a VALID HEADER entry but an
+    /// INVALID STATS range still decoded EncodingStats authoritatively from the
+    /// HEADER. The single-pass walk must preserve that: the STATS channel fails
+    /// closed while `header_offset()` still returns the resolved HEADER — otherwise
+    /// EncodingStats silently falls back to the marker search (a different result).
+    #[test]
+    fn invalid_stats_range_preserves_resolved_header_offset() {
+        // 2-component TOC: HEADER (type 3) at a VALID body offset, STATS (type 2)
+        // at an offset PAST EOF (an invalid derived range → fail-closed STATS).
+        let toc_len = 4 + 4 + 2 * 8; // count + marker + 2 entries = 24
+        let header_off = toc_len; // HEADER body starts right after the TOC
+        let stats_off_bad = 10_000usize; // far past the buffer end → invalid range
+
+        let mut out = Vec::new();
+        out.extend_from_slice(&2u32.to_be_bytes()); // 2 components
+        out.extend_from_slice(&0u32.to_be_bytes()); // marker
+                                                    // HEADER first (first-wins) with a valid offset, then the bad STATS entry.
+        for (ty, off) in [
+            (METADATA_TYPE_HEADER, header_off as u32),
+            (METADATA_TYPE_STATS, stats_off_bad as u32),
+        ] {
+            out.extend_from_slice(&ty.to_be_bytes());
+            out.extend_from_slice(&off.to_be_bytes());
+        }
+        debug_assert_eq!(out.len(), header_off);
+        out.extend_from_slice(&[0xABu8; 8]); // HEADER body
+        out.extend_from_slice(&0u32.to_be_bytes()); // trailing CRC
+
+        let toc = parse_statistics_toc(&out);
+        assert_eq!(
+            toc.header_offset(),
+            Some(header_off),
+            "a corrupt STATS range must NOT nuke the already-resolved HEADER offset \
+             (issue #2148): EncodingStats must still decode from the HEADER, not the \
+             marker fallback"
+        );
+        assert!(
+            toc.stats_bounds().is_err(),
+            "the invalid STATS range must STILL fail closed on its own channel"
         );
     }
 

--- a/cqlite-core/src/parser/toc_walk_metrics.rs
+++ b/cqlite-core/src/parser/toc_walk_metrics.rs
@@ -1,15 +1,20 @@
 //! Minimal process-wide counter for Statistics.db Table-of-Contents (TOC) walks
 //! (issue #1658, epic #1606).
 //!
-//! The metadata stack re-walks the Statistics.db TOC several times during a
-//! single SSTable open — once to locate the `HEADER` (SerializationHeader)
-//! offset (`enhanced_statistics_parser::header::parse_statistics_toc_for_header_offset`)
-//! and again inside `repair_metadata::stats_component_bounds`, which
-//! `read_table_counts` and `parse_stats_extras` each invoke while building
-//! `SSTableStatistics`. This counter lets the A5 cold-open bench
-//! (`benches/open.rs`) MEASURE that redundancy so a fix can be scoped against a
-//! real number rather than a guess. It is NOT a decoding heuristic: nothing in
-//! the parse path reads the count, so it has no effect on correctness (#28).
+//! Historically the metadata stack re-walked the Statistics.db TOC three times
+//! during a single SSTable open — once to locate the `HEADER`
+//! (SerializationHeader) offset and again inside
+//! `repair_metadata::stats_component_bounds`, which `read_table_counts` and
+//! `parse_stats_extras` each invoked while building `SSTableStatistics`. This
+//! counter let the A5 cold-open bench (`benches/open.rs`) MEASURE that redundancy
+//! so the fix could be scoped against a real number rather than a guess.
+//!
+//! As of issue #2148 the TOC is parsed ONCE
+//! (`repair_metadata::parse_statistics_toc`, which resolves the HEADER offset and
+//! the STATS bounds together) and threaded to the two downstream consumers via
+//! their `*_with_toc` variants, so `toc_walk_count()` reads `1` per metadata
+//! parse. It is NOT a decoding heuristic: nothing in the parse path reads the
+//! count, so it has no effect on correctness (#28).
 //!
 //! The instrumentation is gated behind `cli-helpers` (roborev #1658): the
 //! counter is only read by the cli-helpers-gated bench, so production builds

--- a/cqlite-core/tests/issue_2148_statistics_toc_single_walk.rs
+++ b/cqlite-core/tests/issue_2148_statistics_toc_single_walk.rs
@@ -1,0 +1,152 @@
+//! Issue #2148 (oracle-driven perf): the Statistics.db metadata stack walks the
+//! on-disk Table-of-Contents EXACTLY ONCE per parse.
+//!
+//! Before #2148 the stack re-walked the same small TOC **three times** during a
+//! single parse: once to locate the `HEADER` (SerializationHeader) offset, then
+//! once each inside `read_table_counts` and `parse_stats_extras` (both via
+//! `stats_component_bounds`) — each re-parsing the same bytes to relocate an
+//! offset already resolved earlier in the same parse. #2148 parses the TOC ONCE
+//! (`repair_metadata::parse_statistics_toc`, resolving the HEADER offset AND the
+//! STATS bounds in a single forward walk) and threads the result to those
+//! consumers via their `*_with_toc` variants.
+//!
+//! ORACLE: the `parser::toc_walk_metrics` counter (from #1658) — reset, run one
+//! parse through the public `parse_statistics_with_fallback` path, read the count.
+//! It read `3` before the fix; it must read `1` after.
+//!
+//! This is a DEDICATED integration binary (process isolation for the
+//! process-global counter) driven by a SYNTHETIC in-memory Statistics.db buffer,
+//! so it NEVER dataset-skips — it runs and asserts on every invocation. The buffer
+//! is crafted to reach the FULL success path (a valid SerializationHeader that
+//! decodes EncodingStats + schema), because the two redundant walks the fix
+//! eliminates only fired on that `Ok` branch — a buffer that failed earlier could
+//! not distinguish 1 from 3.
+//!
+//! Compiled only with `--features cli-helpers` (the counter getters/`reset` and
+//! `record_toc_walk` live behind it; see Cargo `required-features`).
+
+#![cfg(feature = "cli-helpers")]
+
+use cqlite_core::parser::parse_statistics_with_fallback;
+use cqlite_core::parser::toc_walk_metrics::{reset_toc_walk_count, toc_walk_count};
+use serial_test::serial;
+
+/// A single unsigned-VInt byte for values in `0..=0x7F` (Cassandra's 1-byte VInt
+/// form: `0xxxxxxx`). All values we encode here are tiny (deltas of 0, a length of
+/// 9), so the single-byte form is exact.
+fn vint_small(v: u8) -> u8 {
+    assert!(v <= 0x7F, "helper only encodes 1-byte VInts");
+    v
+}
+
+/// Build a minimal-but-fully-valid synthetic `Statistics.db` buffer whose parse
+/// reaches the success path, exercising every site that historically re-walked
+/// the TOC.
+///
+/// Layout (`parse_statistics_toc` reads `num_components` at byte 0 of the whole
+/// buffer, skips a 4-byte marker, then reads `num_components` × `(u32 type, u32
+/// offset)` entries starting at byte 8):
+///
+/// ```text
+///   [0..4]   num_components = 1  (u32 BE)
+///   [4..8]   marker (unused by the walk)
+///   [8..16]  TOC entry 0: type = 3 (HEADER), offset = 16
+///   [16..]   SerializationHeader body:
+///              vint minTimestamp delta      = 0
+///              vint minLocalDeletionTime d. = 0
+///              vint minTTL delta            = 0
+///              vint keyType len             = 9
+///              "Int32Type"                  (9 bytes)
+///              vint clusteringCount         = 0
+///              vint staticColumnCount       = 0
+///              vint regularColumnCount      = 0
+/// ```
+///
+/// The first 32 bytes are also re-read by `parse_nb_format_header`, which performs
+/// NO validation (it just consumes 8 big-endian u32s), so the overlap is benign.
+/// There is intentionally no STATS component: `read_table_counts`/
+/// `parse_stats_extras` then resolve `stats_bounds = Ok(None)` and return their
+/// defaults — but in the pre-#2148 code each still walked the TOC first, so this
+/// buffer reproduced exactly 3 walks.
+fn synthetic_statistics_db() -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    // num_components = 1
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    // 4-byte marker (skipped by the walk)
+    buf.extend_from_slice(&0u32.to_be_bytes());
+    // TOC entry 0: HEADER (MetadataType ordinal 3) at offset 16.
+    buf.extend_from_slice(&3u32.to_be_bytes()); // type
+    buf.extend_from_slice(&16u32.to_be_bytes()); // offset
+
+    debug_assert_eq!(buf.len(), 16, "SerializationHeader must start at offset 16");
+
+    // SerializationHeader body: EncodingStats (3 zero VInt deltas) + schema.
+    buf.push(vint_small(0)); // minTimestamp delta
+    buf.push(vint_small(0)); // minLocalDeletionTime delta
+    buf.push(vint_small(0)); // minTTL delta
+    let key_type = b"Int32Type";
+    buf.push(vint_small(key_type.len() as u8)); // keyType length (9)
+    buf.extend_from_slice(key_type); // keyType marshal name
+    buf.push(vint_small(0)); // clusteringTypes count
+    buf.push(vint_small(0)); // staticColumns count
+    buf.push(vint_small(0)); // regularColumns count
+
+    // parse_nb_format_header consumes a fixed 32-byte prefix; the body above lands
+    // us at exactly 32 bytes, so no padding is needed. Guard the invariant.
+    assert!(
+        buf.len() >= 32,
+        "buffer must be >= 32 bytes for the fixed nb header prefix (got {})",
+        buf.len()
+    );
+
+    buf
+}
+
+/// The oracle: exactly one TOC walk per full Statistics.db metadata parse.
+///
+/// FAILS at the pre-#2148 count of 3 (asserts `== 1`); PASSES at the post-fix
+/// count of 1.
+#[test]
+#[serial]
+fn statistics_toc_walked_exactly_once_per_parse() {
+    let buf = synthetic_statistics_db();
+
+    // Reset the process-global counter so we measure only this parse's walks.
+    reset_toc_walk_count();
+    assert_eq!(toc_walk_count(), 0, "reset must zero the TOC-walk counter");
+
+    // Public parse path (same entry `SSTableReader::open` reaches for nb metadata).
+    let (_remaining, _stats) = parse_statistics_with_fallback(&buf, None)
+        .expect("synthetic nb Statistics.db must parse to the success path");
+
+    assert_eq!(
+        toc_walk_count(),
+        1,
+        "issue #2148: a single Statistics.db metadata parse must walk the on-disk \
+         TOC EXACTLY ONCE (parse-once + thread offsets); it walked 3× before the \
+         fix. Got {} walk(s).",
+        toc_walk_count()
+    );
+}
+
+/// Guard the oracle's premise: the synthetic buffer really does reach the FULL
+/// success path (a decoded SerializationHeader), so the two redundant walks the
+/// fix removes were genuinely on the exercised path. If this buffer regressed to
+/// failing early, the count-of-1 assertion above could pass vacuously (old code
+/// would also have walked only once), so pin the success explicitly.
+#[test]
+#[serial]
+fn synthetic_buffer_reaches_full_success_path() {
+    let buf = synthetic_statistics_db();
+    let (_remaining, stats) = parse_statistics_with_fallback(&buf, None)
+        .expect("synthetic nb Statistics.db must parse to the success path");
+    // A decoded SerializationHeader yields exactly one partition-key column
+    // (keyType = Int32Type) and no clustering/regular columns — proving we reached
+    // the schema decode, not an early EncodingStats bail-out.
+    assert_eq!(
+        stats.serialization_header_partition_keys.len(),
+        1,
+        "success path must decode the single partition-key column from the header"
+    );
+}

--- a/docs/sstables-definitive-guide/chapters/08-statistics-db.md
+++ b/docs/sstables-definitive-guide/chapters/08-statistics-db.md
@@ -163,7 +163,7 @@ Bytes 32+: EncodingStats data
 
 **Magic Number**: The constant `0x26291b05` appears at bytes 4-7 and serves dual purposes:
 - `statistics_kind` when read by `parse_nb_format_header()`
-- `checksum` when read by `parse_statistics_toc_for_header_offset()`
+- `checksum` when read by the single-pass `parse_statistics_toc()` TOC walk (issue #2148)
 
 **Version/Components**: The value `4` at bytes 0-3 indicates:
 - `version_type = 4` (Cassandra 5.0 format) for nb-format parsers


### PR DESCRIPTION
Closes #2148

Parses the Statistics.db TOC ONCE (was 3× per open) and threads resolved HEADER offset + STATS bounds to the former walk-sites via pub(crate) *_with_toc variants; removes the redundant parse_statistics_toc_for_header_offset walker. Oracle: toc_walk_metrics counter 3 -> 1 (pinned test issue_2148_statistics_toc_single_walk, process-isolated + synthetic buffer). BIG(nb)/BTI(da) behavior preserved.

Review: rust-reviewer fixes-confirmed-clean; roborev (codex) No issues found. Two blockers found in review and fixed: (1) HEADER offset was dropped when STATS byte-range invalid (divergence → marker fallback) — now HEADER is resolved independently of STATS validation and threaded through all arms, STATS still fails closed; regression test invalid_stats_range_preserves_resolved_header_offset. (2) new *_with_toc APIs + StatisticsToc made pub(crate) (no external callers) to close a cross-buffer slice panic.

🤖 Generated with Claude Code