### PR TITLE
fix(#2074): GROUP BY on float/double groups by Cassandra comparator

### DIFF
--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -5,6 +5,8 @@
 //! `finalize_group`) that the executor's `execute_aggregation` drives row by
 //! row.
 
+mod group_key_cmp;
+
 use super::super::select_ast::AggregateType;
 use super::super::select_optimizer::{AggregateComputation, AggregationPlan};
 use super::numeric_acc::NumericAcc;
@@ -14,9 +16,9 @@ use crate::{
     query::result::QueryRow,
     types::{RowKey, Value},
 };
+use group_key_cmp::{group_key_eq, hash_group_key};
 use rustc_hash::FxHashMap;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 
 // Test-only counter for GROUP-key exact (`==`) comparisons performed while
 // locating a row's group (issue #1587, E5). The hash index makes this
@@ -37,12 +39,13 @@ pub(super) struct AggregationState {
     pub(super) groups: Vec<(Vec<Value>, Vec<AggregateValue>)>,
     /// Issue #1587 (E5): hash index over the group key → candidate `groups`
     /// indices sharing that hash. `Value` does not implement `Hash`/`Eq`
-    /// (floats), so we hash a normalization that is *consistent* with `Vec<Value>`
-    /// equality (equal keys hash equal; `-0.0`/`+0.0` normalized) and confirm the
-    /// match with an exact `==` against each candidate. Distinct-but-colliding
-    /// keys (and every NaN key, which is never `==` itself) simply fall through
-    /// the exact check, so grouping semantics are byte-identical to the prior
-    /// linear scan.
+    /// (floats), so we hash a normalization *consistent* with the group-key
+    /// equality used to confirm a match ([`group_key_eq`]), and confirm the match
+    /// with that predicate against each candidate. Issue #2074: `float`/`double`
+    /// group-key equality follows Cassandra's total-order comparator (`float_cmp`),
+    /// so the hash canonicalizes NaN to one bit pattern (all NaN keys hash-collide
+    /// into ONE group) and keeps signed-zero bits DISTINCT (`-0.0`/`+0.0` hash into
+    /// two groups) — exactly consistent with [`group_key_eq`].
     ///
     /// Issue #1590 (E8): `FxHashMap` rather than the default `HashMap`. The key
     /// is already a well-mixed `u64` group-key hash, so SipHashing it again is
@@ -53,70 +56,6 @@ pub(super) struct AggregationState {
     pub(super) memory_usage_bytes: usize,
     /// Maximum memory limit
     pub(super) memory_limit_bytes: usize,
-}
-
-/// Hash a group key consistently with `Vec<Value>` equality: if two keys are
-/// `==`, they hash identically. Only floats need care (`-0.0 == +0.0`), which
-/// are normalized; NaN keys are never `==` themselves, so their hash is
-/// irrelevant to correctness (the exact `==` check separates them). Exotic /
-/// nested variants that are not cheap to hash structurally fall back to a
-/// discriminant-only contribution — still consistent (equal values agree on
-/// discriminant), merely less selective, and only for key types that never
-/// appear in practice.
-fn hash_group_key(key: &[Value]) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    key.len().hash(&mut hasher);
-    for v in key {
-        hash_one_value(v, &mut hasher);
-    }
-    hasher.finish()
-}
-
-fn hash_one_value<H: Hasher>(v: &Value, h: &mut H) {
-    // Tag by discriminant so different variants never alias.
-    std::mem::discriminant(v).hash(h);
-    match v {
-        Value::Null => {}
-        Value::Boolean(b) => b.hash(h),
-        Value::Integer(x) => x.hash(h),
-        Value::BigInt(x) | Value::Counter(x) | Value::Timestamp(x) | Value::Time(x) => x.hash(h),
-        Value::Date(x) => x.hash(h),
-        Value::TinyInt(x) => x.hash(h),
-        Value::SmallInt(x) => x.hash(h),
-        // `-0.0 == +0.0` must hash equal; NaN's hash is irrelevant (never `==`).
-        Value::Float(f) => (if *f == 0.0 { 0.0f64 } else { *f }).to_bits().hash(h),
-        Value::Float32(f) => (if *f == 0.0 { 0.0f32 } else { *f }).to_bits().hash(h),
-        Value::Text(s) => s.hash(h),
-        Value::Blob(b) | Value::Varint(b) | Value::Inet(b) => b.hash(h),
-        Value::Uuid(u) => u.hash(h),
-        Value::Decimal { scale, unscaled } => {
-            scale.hash(h);
-            unscaled.hash(h);
-        }
-        Value::Duration {
-            months,
-            days,
-            nanos,
-        } => {
-            months.hash(h);
-            days.hash(h);
-            nanos.hash(h);
-        }
-        Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
-            for item in items {
-                hash_one_value(item, h);
-            }
-        }
-        Value::Map(pairs) => {
-            for (k, val) in pairs {
-                hash_one_value(k, h);
-                hash_one_value(val, h);
-            }
-        }
-        Value::Frozen(inner) => hash_one_value(inner, h),
-        // Exotic / rarely-grouped variants: discriminant-only (still consistent).
-        Value::Json(_) | Value::Udt(_) | Value::Tombstone(_) => {}
-    }
 }
 
 /// Aggregate value accumulator
@@ -181,9 +120,11 @@ pub(super) fn build_group_key(row: &QueryRow, group_by_columns: &[String]) -> Ve
 /// amortized instead of the old `O(groups)` linear scan (which made a full
 /// aggregation `O(rows × groups)`). Result-row ordering is still defined solely
 /// by insertion order into `state.groups`; the index only accelerates lookup,
-/// and the exact `==` confirmation preserves grouping semantics byte-for-byte
-/// (colliding-but-unequal keys, and NaN keys, create distinct groups exactly as
-/// the linear scan did).
+/// and the [`group_key_eq`] confirmation defines the grouping semantics
+/// (colliding-but-unequal keys create distinct groups). Issue #2074: that
+/// confirmation is [`group_key_eq`], NOT derived `Vec<Value>` `==`, so
+/// `float`/`double` grouping follows Cassandra's comparator (all NaN → ONE group;
+/// `-0.0`/`+0.0` → DISTINCT groups).
 pub(super) fn find_or_init_group(
     state: &mut AggregationState,
     key: Vec<Value>,
@@ -195,7 +136,7 @@ pub(super) fn find_or_init_group(
         for &idx in candidates {
             #[cfg(test)]
             GROUP_KEY_COMPARISONS.with(|c| c.set(c.get() + 1));
-            if state.groups[idx].0 == key {
+            if group_key_eq(&state.groups[idx].0, &key) {
                 return idx;
             }
         }
@@ -462,38 +403,84 @@ mod tests {
         }
     }
 
-    /// The hash index must never merge distinct keys: `-0.0`/`+0.0` group
-    /// together (they are `==`), NaN never groups with itself, and different
-    /// scalars stay separate — byte-identical to the linear-scan semantics.
+    /// Issue #2074: GROUP BY on a float/double key follows Cassandra's total-order
+    /// comparator (`float_cmp`), NOT IEEE `==`. `-0.0` and `+0.0` are DISTINCT
+    /// groups (Cassandra orders them apart); ALL NaN bit-patterns form ONE group
+    /// (Java `doubleToLongBits` canonical); while cross-variant keys (`Integer(1)`
+    /// vs `BigInt(1)`) stay distinct. Both the hash and the `group_key_eq`
+    /// confirmation must agree, so the assertions below simultaneously prove
+    /// hash/eq consistency.
     #[test]
-    fn find_or_init_group_preserves_equality_semantics() {
+    fn find_or_init_group_uses_cassandra_float_comparator() {
         let plan = count_star_plan();
         let mut state = new_state();
+        let mut group =
+            |f: f64| find_or_init_group(&mut state, vec![Value::Float(f)], &plan.aggregates, &[]);
 
-        // -0.0 and +0.0 are `==` → same group.
-        let i0 = find_or_init_group(&mut state, vec![Value::Float(0.0)], &plan.aggregates, &[]);
-        let i1 = find_or_init_group(&mut state, vec![Value::Float(-0.0)], &plan.aggregates, &[]);
-        assert_eq!(i0, i1, "-0.0 and +0.0 must land in the same group");
+        // -0.0 and +0.0 are ordered apart → DISTINCT groups.
+        let i0 = group(0.0);
+        let i1 = group(-0.0);
+        assert_ne!(i0, i1, "-0.0 and +0.0 must land in DISTINCT groups (#2074)");
 
-        // Two NaN keys are never `==` → two distinct groups.
-        let n0 = find_or_init_group(
-            &mut state,
-            vec![Value::Float(f64::NAN)],
-            &plan.aggregates,
-            &[],
+        // Multiple NaN keys — including DIFFERENT NaN bit patterns — all collapse
+        // into ONE group (canonicalized, matching Cassandra).
+        let other_nan = f64::from_bits(0xFFF8_0000_0000_0001);
+        assert!(other_nan.is_nan());
+        let n0 = group(f64::NAN);
+        let n1 = group(f64::NAN);
+        let n2 = group(other_nan);
+        assert_eq!(n0, n1, "all NaN keys share ONE group (#2074)");
+        assert_eq!(
+            n0, n2,
+            "a DIFFERENT NaN bit pattern also joins the single NaN group (#2074)"
         );
-        let n1 = find_or_init_group(
-            &mut state,
-            vec![Value::Float(f64::NAN)],
-            &plan.aggregates,
-            &[],
-        );
-        assert_ne!(n0, n1, "each NaN key forms its own group (NaN != NaN)");
 
-        // Same-value different-variant keys stay separate.
+        // The same holds for f32 (`float`): -0.0/+0.0 distinct, NaN patterns merged.
+        let f32key = |f: f32| vec![Value::Float32(f)];
+        let f0 = find_or_init_group(&mut state, f32key(0.0), &plan.aggregates, &[]);
+        let f1 = find_or_init_group(&mut state, f32key(-0.0), &plan.aggregates, &[]);
+        assert_ne!(f0, f1, "f32 -0.0 and +0.0 must be DISTINCT groups (#2074)");
+        let other_nan32 = f32::from_bits(0xFFC0_0001);
+        assert!(other_nan32.is_nan());
+        let g0 = find_or_init_group(&mut state, f32key(f32::NAN), &plan.aggregates, &[]);
+        let g1 = find_or_init_group(&mut state, f32key(other_nan32), &plan.aggregates, &[]);
+        assert_eq!(g0, g1, "f32 NaN bit patterns share ONE group (#2074)");
+
+        // Same-value different-variant keys stay separate (no numeric coercion).
         let a = find_or_init_group(&mut state, vec![Value::Integer(1)], &plan.aggregates, &[]);
         let b = find_or_init_group(&mut state, vec![Value::BigInt(1)], &plan.aggregates, &[]);
         assert_ne!(a, b, "Integer(1) and BigInt(1) are distinct groups");
+    }
+
+    /// Issue #2074 (nested scope): the Cassandra float comparator applies at
+    /// EVERY nesting depth, not just top-level scalar group columns — a float
+    /// buried inside a `Tuple`/`List` group key must hash AND compare consistent
+    /// with the same total order, or hash/eq would disagree (a correctness bug).
+    #[test]
+    fn find_or_init_group_nested_float_uses_cassandra_comparator() {
+        let plan = count_star_plan();
+        let mut state = new_state();
+        let other_nan = f64::from_bits(0xFFF8_0000_0000_0001);
+        assert!(other_nan.is_nan());
+        let mut group = |k: Vec<Value>| find_or_init_group(&mut state, k, &plan.aggregates, &[]);
+
+        // Nested -0.0 vs +0.0 inside a Tuple → DISTINCT groups (not merged by IEEE).
+        let t0 = group(vec![Value::Tuple(vec![Value::Float(0.0)])]);
+        let t1 = group(vec![Value::Tuple(vec![Value::Float(-0.0)])]);
+        assert_ne!(t0, t1, "nested Tuple -0.0/+0.0 must be DISTINCT (#2074)");
+
+        // Two DIFFERENT NaN bit patterns nested inside a Tuple → SAME group.
+        let n0 = group(vec![Value::Tuple(vec![Value::Float(f64::NAN)])]);
+        let n1 = group(vec![Value::Tuple(vec![Value::Float(other_nan)])]);
+        assert_eq!(
+            n0, n1,
+            "nested Tuple differing-NaN must be ONE group (#2074)"
+        );
+
+        // Same nested behavior inside a List.
+        let l0 = group(vec![Value::List(vec![Value::Float(0.0)])]);
+        let l1 = group(vec![Value::List(vec![Value::Float(-0.0)])]);
+        assert_ne!(l0, l1, "nested List -0.0/+0.0 must be DISTINCT (#2074)");
     }
 
     // ---- Issue #2202: SUM/AVG integral result-type preservation ----

--- a/cqlite-core/src/query/select_executor/aggregation/group_key_cmp.rs
+++ b/cqlite-core/src/query/select_executor/aggregation/group_key_cmp.rs
@@ -1,0 +1,184 @@
+//! GROUP BY key hashing + equality (issue #1587 hash index, #2074 Cassandra
+//! float comparator).
+//!
+//! Split out of `aggregation.rs` (campsite rule, epic #1116) — these are pure,
+//! self-contained functions with no `AggregationState`/executor dependencies.
+//! [`hash_group_key`] and [`group_key_eq`] MUST stay mutually consistent (equal
+//! keys hash equal) — see each doc comment.
+
+use crate::types::Value;
+use std::hash::{Hash, Hasher};
+
+/// Hash a group key consistently with [`group_key_eq`]: if two keys are equal
+/// under that predicate, they hash identically. Floats follow Cassandra's
+/// total-order comparator (issue #2074), so NaN is canonicalized to a single bit
+/// pattern (all NaN keys hash-collide into ONE group) and signed-zero bits are
+/// kept DISTINCT (`-0.0` and `+0.0` hash apart into two groups) — at ALL nesting
+/// depths, recursing into `List`/`Set`/`Map`/`Tuple`/`Frozen`. Exotic variants
+/// that are not cheap to hash structurally fall back to a discriminant-only
+/// contribution — still consistent (equal values agree on discriminant), merely
+/// less selective, and only for key types that never appear in practice.
+pub(super) fn hash_group_key(key: &[Value]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.len().hash(&mut hasher);
+    for v in key {
+        hash_one_value(v, &mut hasher);
+    }
+    hasher.finish()
+}
+
+fn hash_one_value<H: Hasher>(v: &Value, h: &mut H) {
+    // Tag by discriminant so different variants never alias.
+    std::mem::discriminant(v).hash(h);
+    match v {
+        Value::Null => {}
+        Value::Boolean(b) => b.hash(h),
+        Value::Integer(x) => x.hash(h),
+        Value::BigInt(x) | Value::Counter(x) | Value::Timestamp(x) | Value::Time(x) => x.hash(h),
+        Value::Date(x) => x.hash(h),
+        Value::TinyInt(x) => x.hash(h),
+        Value::SmallInt(x) => x.hash(h),
+        // Issue #2074 (Cassandra comparator, consistent with `group_key_eq`):
+        // canonicalize NaN to ONE bit pattern so all NaN keys hash-collide into one
+        // group; keep signed-zero bits DISTINCT so `-0.0`/`+0.0` hash into two.
+        Value::Float(f) => (if f.is_nan() { f64::NAN } else { *f }).to_bits().hash(h),
+        Value::Float32(f) => (if f.is_nan() { f32::NAN } else { *f }).to_bits().hash(h),
+        Value::Text(s) => s.hash(h),
+        Value::Blob(b) | Value::Varint(b) | Value::Inet(b) => b.hash(h),
+        Value::Uuid(u) => u.hash(h),
+        Value::Decimal { scale, unscaled } => {
+            scale.hash(h);
+            unscaled.hash(h);
+        }
+        Value::Duration {
+            months,
+            days,
+            nanos,
+        } => {
+            months.hash(h);
+            days.hash(h);
+            nanos.hash(h);
+        }
+        Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
+            for item in items {
+                hash_one_value(item, h);
+            }
+        }
+        Value::Map(pairs) => {
+            for (k, val) in pairs {
+                hash_one_value(k, h);
+                hash_one_value(val, h);
+            }
+        }
+        Value::Frozen(inner) => hash_one_value(inner, h),
+        // Exotic / rarely-grouped variants: discriminant-only (still consistent).
+        Value::Json(_) | Value::Udt(_) | Value::Tombstone(_) => {}
+    }
+}
+
+/// Group-key VALUE equality with Cassandra float-comparator semantics (issue
+/// #2074), at ALL nesting depths: `float`/`double` — top-level OR nested inside a
+/// `List`/`Set`/`Map`/`Tuple`/`Frozen` group key — route through `float_cmp` so
+/// all NaN bit-patterns are EQUAL and `-0.0`/`+0.0` are DISTINCT (Cassandra's
+/// comparator); every other leaf uses derived `==`. Recurses through the SAME
+/// variants [`hash_one_value`] does, so it stays consistent with
+/// [`hash_group_key`] at every depth. Cross-variant keys stay distinct (the
+/// `_ => a == b` fallback) — never `compare_values_ordering`'s cross-coercion.
+fn group_value_eq(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Float(p), Value::Float(q)) => {
+            crate::float_cmp::cassandra_double_cmp(*p, *q).is_eq()
+        }
+        (Value::Float32(p), Value::Float32(q)) => {
+            crate::float_cmp::cassandra_float_cmp(*p, *q).is_eq()
+        }
+        (Value::List(x), Value::List(y))
+        | (Value::Set(x), Value::Set(y))
+        | (Value::Tuple(x), Value::Tuple(y)) => {
+            x.len() == y.len() && x.iter().zip(y).all(|(m, n)| group_value_eq(m, n))
+        }
+        (Value::Map(x), Value::Map(y)) => {
+            x.len() == y.len()
+                && x.iter()
+                    .zip(y)
+                    .all(|((k1, v1), (k2, v2))| group_value_eq(k1, k2) && group_value_eq(v1, v2))
+        }
+        (Value::Frozen(x), Value::Frozen(y)) => group_value_eq(x, y),
+        _ => a == b,
+    }
+}
+
+/// Group-key equality: see [`group_value_eq`] for the per-element (recursive,
+/// float-comparator-aware) semantics.
+pub(super) fn group_key_eq(a: &[Value], b: &[Value]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| group_value_eq(x, y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #2074: hash/eq consistency at every nesting depth — the specific
+    /// property the review round flagged. For every pair below, `group_key_eq`
+    /// agreeing (or disagreeing) MUST match `hash_group_key` agreeing (or
+    /// disagreeing), or the hash index would silently split/merge groups the
+    /// exact-match confirmation disagrees with.
+    #[test]
+    fn hash_and_eq_agree_for_nested_floats() {
+        let other_nan = f64::from_bits(0xFFF8_0000_0000_0001);
+        assert!(other_nan.is_nan());
+        let cases: &[(Value, Value, bool)] = &[
+            (
+                Value::Tuple(vec![Value::Float(0.0)]),
+                Value::Tuple(vec![Value::Float(-0.0)]),
+                false, // -0.0/+0.0 distinct even nested
+            ),
+            (
+                Value::Tuple(vec![Value::Float(f64::NAN)]),
+                Value::Tuple(vec![Value::Float(other_nan)]),
+                true, // differing NaN bit patterns merge even nested
+            ),
+            (
+                Value::List(vec![Value::Float(0.0)]),
+                Value::List(vec![Value::Float(-0.0)]),
+                false,
+            ),
+            (
+                Value::Map(vec![(Value::Integer(1), Value::Float(0.0))]),
+                Value::Map(vec![(Value::Integer(1), Value::Float(-0.0))]),
+                false,
+            ),
+            (
+                Value::Frozen(Box::new(Value::Float(f64::NAN))),
+                Value::Frozen(Box::new(Value::Float(other_nan))),
+                true,
+            ),
+        ];
+        for (a, b, expect_eq) in cases {
+            let ka = [a.clone()];
+            let kb = [b.clone()];
+            let eq = group_key_eq(&ka, &kb);
+            assert_eq!(
+                eq, *expect_eq,
+                "group_key_eq({a:?}, {b:?}) expected {expect_eq}"
+            );
+            let hash_eq = hash_group_key(&ka) == hash_group_key(&kb);
+            assert!(
+                hash_eq == eq || !eq,
+                "hash/eq inconsistency for {a:?} vs {b:?}: eq={eq} but hashes {}",
+                if hash_eq { "match" } else { "differ" }
+            );
+            // When eq() says equal, hash MUST also agree (the formal contract);
+            // when eq() says unequal, colliding hashes are merely a (harmless)
+            // collision, not a bug, so we only assert the equal-implies-equal-hash
+            // direction strictly.
+            if eq {
+                assert!(
+                    hash_eq,
+                    "eq() reports equal but hashes differ for {a:?} vs {b:?} — \
+                     violates the hash/eq contract"
+                );
+            }
+        }
+    }
+}

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -1047,17 +1047,17 @@ impl Value {
 
 /// Ordering for `Value`.
 ///
-/// NOTE (contract split, #1870/#2010): this `PartialOrd` INTENTIONALLY diverges
-/// from the derived `PartialEq`. For `float`/`double` it uses the Cassandra/Java
-/// total order (`-0.0 < +0.0`, and every `NaN` sorts last and compares Equal to
-/// every other `NaN`), whereas `PartialEq` keeps IEEE semantics (`-0.0 == +0.0`,
-/// `NaN != NaN`). This is deliberate: ordering (ORDER BY / MIN / MAX / clustering
-/// order) must be a TOTAL order, while equality (GROUP BY) stays IEEE. As a
-/// result `partial_cmp` may report `Equal` where `eq` reports `false` (two NaNs)
-/// and vice-versa (`-0.0`/`+0.0`). If an `impl Ord for Value` is ever added it
-/// MUST reuse this comparator (never derive from `PartialEq`) and callers must
-/// not assume the `PartialOrd`/`PartialEq` consistency the std traits normally
-/// imply.
+/// NOTE (contract split, #1870/#2010/#2074): this `PartialOrd` INTENTIONALLY
+/// diverges from the DERIVED `PartialEq`. For `float`/`double` it uses the
+/// Cassandra/Java total order (`-0.0 < +0.0`; every `NaN` sorts last and compares
+/// Equal to every other `NaN`), whereas the derived `PartialEq` keeps IEEE
+/// semantics (`-0.0 == +0.0`, `NaN != NaN`). `partial_cmp` may thus report `Equal`
+/// where `eq` reports `false` (two NaNs) and vice-versa (`-0.0`/`+0.0`). GROUP BY
+/// grouping (issue #2074) does NOT use the derived `PartialEq` for floats: the
+/// aggregation group-key path (`aggregation::group_key_eq` + `hash_group_key`)
+/// routes them through this SAME total order (all NaN → ONE group; `-0.0`/`+0.0`
+/// DISTINCT). Any future `impl Ord for Value` MUST reuse this comparator, never
+/// derive from `PartialEq`.
 impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         use crate::float_cmp::{cassandra_double_cmp as dcmp, cassandra_float_cmp as fcmp};

--- a/cqlite-core/tests/issue_2074_group_by_float_comparator_parity.rs
+++ b/cqlite-core/tests/issue_2074_group_by_float_comparator_parity.rs
@@ -1,0 +1,196 @@
+//! Issue #2074: GROUP BY on a `float`/`double` column must group by Cassandra's
+//! total-order comparator (`float_cmp`), NOT IEEE `==`:
+//!   * `-0.0` and `+0.0` are DISTINCT groups (Cassandra orders them apart);
+//!   * ALL NaN bit-patterns collapse into ONE group (Java `doubleToLongBits`).
+//!
+//! Wiring evidence (acceptance criterion 3): this drives GROUP BY THROUGH the
+//! real query engine end-to-end. It writes a small UNCOMPRESSED SSTable via the
+//! public write engine (one single-row partition per float value), ingests it,
+//! and runs `SELECT fv, COUNT(*) ... GROUP BY fv` via `Database::execute`,
+//! asserting the group partitioning. `-0.0` and both NaN bit patterns are raw
+//! IEEE bytes, so they round-trip exactly through write → read → the aggregation
+//! `find_or_init_group` group-key path.
+//!
+//! Run:
+//!   cargo test --package cqlite-core \
+//!     --features write-support,cli-helpers,state_machine \
+//!     --test issue_2074_group_by_float_comparator_parity
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "state_machine"
+))]
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database};
+use tempfile::TempDir;
+
+const KS: &str = "gbf_ks";
+const TBL: &str = "floats";
+
+fn schema_cql() -> String {
+    format!("CREATE TABLE {KS}.{TBL} (\n  id int PRIMARY KEY,\n  fv double\n);\n")
+}
+
+fn write_mutation(id: i32, fv: f64, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "fv".to_string(),
+        value: Value::Float(fv),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+/// Build a single-generation fixture with one single-row partition per float
+/// value, ingest it, and return an open `Database`.
+async fn open_float_fixture(values: &[f64]) -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema_path = temp_dir.path().join("schema.cql");
+    std::fs::write(&schema_path, schema_cql()).expect("write schema file");
+
+    {
+        let data_dir = data_dir.clone();
+        let wal_dir = wal_dir.clone();
+        let values: Vec<f64> = values.to_vec();
+        tokio::task::spawn_blocking(move || {
+            use cqlite_core::schema::parse_cql_schema;
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime");
+            let schema = parse_cql_schema(&schema_cql()).expect("parse schema");
+            let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+            let mut engine = WriteEngine::new(config).expect("engine");
+            for (i, v) in values.iter().enumerate() {
+                engine
+                    .write(write_mutation(i as i32, *v, 100))
+                    .expect("write row");
+            }
+            rt.block_on(engine.flush())
+                .expect("flush")
+                .expect("must produce an SSTable");
+            rt.block_on(engine.close()).expect("close");
+        })
+        .await
+        .expect("fixture build task");
+    }
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: None,
+    })
+    .await
+    .expect("ingest fixture");
+    (result.database, temp_dir)
+}
+
+/// The COUNT(*) BigInt in a GROUP BY result row (the sole non-`fv` BigInt value).
+fn count_of_row(row: &cqlite_core::query::result::QueryRow) -> Option<i64> {
+    row.values.iter().find_map(|(k, v)| match v {
+        Value::BigInt(n) if k.as_ref() != "fv" => Some(*n),
+        _ => None,
+    })
+}
+
+/// The grouped `fv` float value in a result row.
+fn fv_of_row(row: &cqlite_core::query::result::QueryRow) -> Option<f64> {
+    match row.values.get("fv") {
+        Some(Value::Float(f)) => Some(*f),
+        _ => None,
+    }
+}
+
+/// GROUP BY on a `double` column groups by Cassandra's comparator through the
+/// public `Database::execute` path:
+///   * `+0.0` and `-0.0` → TWO distinct single-row groups;
+///   * two DIFFERENT NaN bit patterns → ONE group aggregating both rows;
+///   * a plain duplicated finite value → ONE group of its rows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn group_by_double_uses_cassandra_comparator_via_execute() {
+    // Two different NaN bit patterns prove canonicalization (both are raw IEEE
+    // bytes, so they round-trip through write → read exactly).
+    let nan_a = f64::NAN;
+    let nan_b = f64::from_bits(0xFFF8_0000_0000_0001);
+    assert!(nan_a.is_nan() && nan_b.is_nan());
+
+    // id: 0=+0.0, 1=-0.0, 2=NaN_a, 3=NaN_b, 4=1.0, 5=1.0
+    let values = [0.0_f64, -0.0, nan_a, nan_b, 1.0, 1.0];
+    let (db, _tmp) = open_float_fixture(&values).await;
+
+    let result = db
+        .execute(&format!("SELECT fv, COUNT(*) FROM {KS}.{TBL} GROUP BY fv"))
+        .await
+        .expect("GROUP BY query must execute through the public path");
+
+    // Categorize the returned groups by their grouped `fv` value.
+    let mut nan_groups = 0usize;
+    let mut nan_group_count = 0i64;
+    let mut pos_zero_groups = 0usize;
+    let mut neg_zero_groups = 0usize;
+    let mut one_groups = 0usize;
+    let mut one_group_count = 0i64;
+
+    for row in &result.rows {
+        let fv = fv_of_row(row).expect("group row carries an fv double");
+        let count = count_of_row(row).expect("group row carries a COUNT(*) BigInt");
+        if fv.is_nan() {
+            nan_groups += 1;
+            nan_group_count = count;
+        } else if fv == 0.0 && fv.is_sign_positive() {
+            pos_zero_groups += 1;
+        } else if fv == 0.0 && fv.is_sign_negative() {
+            neg_zero_groups += 1;
+        } else if fv == 1.0 {
+            one_groups += 1;
+            one_group_count = count;
+        } else {
+            panic!("unexpected group value {fv:?}");
+        }
+    }
+
+    // Signed zeros are DISTINCT groups (#2074) — exactly one of each.
+    assert_eq!(
+        pos_zero_groups, 1,
+        "+0.0 must form exactly one group (rows: {:?})",
+        result.rows
+    );
+    assert_eq!(
+        neg_zero_groups, 1,
+        "-0.0 must form its OWN group distinct from +0.0 (#2074) (rows: {:?})",
+        result.rows
+    );
+
+    // ALL NaN bit patterns collapse into ONE group aggregating BOTH NaN rows.
+    assert_eq!(
+        nan_groups, 1,
+        "all NaN rows (two different bit patterns) must form exactly ONE group (#2074) \
+         (rows: {:?})",
+        result.rows
+    );
+    assert_eq!(
+        nan_group_count, 2,
+        "the single NaN group must aggregate BOTH NaN rows (#2074)"
+    );
+
+    // The plain finite duplicate is one group of both rows (sanity control).
+    assert_eq!(one_groups, 1, "1.0 must form exactly one group");
+    assert_eq!(one_group_count, 2, "the 1.0 group aggregates both 1.0 rows");
+
+    // Total distinct groups: +0.0, -0.0, NaN, 1.0 = 4.
+    assert_eq!(
+        result.rows.len(),
+        4,
+        "exactly four distinct groups (+0.0, -0.0, NaN, 1.0); got {:?}",
+        result.rows
+    );
+}


### PR DESCRIPTION
## Summary
Closes #2074.

CQLite's GROUP BY on a `float`/`double` column grouped rows by IEEE `==`/hash, which diverges from Cassandra's comparator in BOTH directions:
- IEEE `-0.0 == +0.0` merged them into one group (Cassandra keeps them distinct).
- IEEE `NaN != NaN` split every NaN row into its own group (Cassandra collapses all NaN bit-patterns into one group).

This routes the GROUP BY group-key hashing and equality confirmation through the existing Cassandra/Java total-order comparator (`cqlite-core/src/float_cmp.rs`, added in #1870 for ORDER BY/MIN/MAX), so grouping is now internally consistent with ordering:
- `-0.0`/`+0.0` → DISTINCT groups.
- ALL NaN bit-patterns → ONE group.
- This holds at every group-key nesting depth (`List`/`Set`/`Map`/`Tuple`/`Frozen`), keeping the hash/equality contract consistent throughout (a review-round finding — the first pass only fixed top-level scalar keys, leaving a nested-float hash/eq inconsistency; fixed by making `group_key_eq`/`group_value_eq` recurse identically to the hash function). UDT-nested floats are the sole acknowledged carve-out (fall through to derived `PartialEq`, contract-sound since UDT hashes by discriminant only) — noted as out of scope in the doc comment.
- `cqlite-core/src/types.rs`'s `PartialOrd` doc comment corrected: GROUP BY grouping no longer "stays IEEE" for floats — it shares the same Cassandra total order via the aggregation group-key path.

## Root cause
`cqlite-core/src/query/select_executor/aggregation.rs` (`hash_one_value`/`find_or_init_group`, now split into `aggregation/group_key_cmp.rs` per the campsite file-size rule): the hash normalized signed zeros together and left NaN un-canonicalized, and the group match confirmation used derived `Vec<Value>` `PartialEq` (IEEE) — the exact opposite of what Cassandra's `DoubleType`/`FloatType` comparator does.

## Wiring evidence
`cqlite-core/tests/issue_2074_group_by_float_comparator_parity.rs` drives GROUP BY through the full public path: writes a real uncompressed SSTable via `WriteEngine`, ingests it, and runs `SELECT fv, COUNT(*) FROM ... GROUP BY fv` via `Database::execute`, asserting `+0.0`/`-0.0` form two distinct single-row groups and two different NaN bit patterns collapse into one 2-row group. Unit tests in `aggregation.rs` and the new `group_key_cmp.rs` pin the same semantics (including nested-key hash/eq consistency) at the helper level.

## Query-semantics oracle
Not added to `test-data/query-semantics-oracle.json` — that lane is strictly fixture-driven (requires a committed real-Cassandra SSTable + JSONL golden), which isn't available in this environment. The dedicated end-to-end test above pins the query-semantics assertion instead. Candidate follow-up: add a `test_group_by_float` Cassandra fixture + oracle case when a Cassandra container is available.

## Review
- rust-reviewer + roborev (round 1) both independently flagged the same real issue: a nested-float hash/eq inconsistency in the first-pass fix (top-level-only comparator routing). Fixed by recursing the equality predicate identically to the hash function.
- roborev (round 2, post-fix): no issues found. Two Low items noted (UDT-nested floats stay IEEE; missing Set/Map-key-nested test cases) — assessed as narrow, contract-sound, out of stated scope, no defect.

## Test plan
- [x] `scripts/agent-gate.sh --lite` PASS (fmt/clippy/scoped-tests) post-rebase on `f9945ab`.
- [x] New unit tests (`aggregation.rs`, `group_key_cmp.rs`) pin top-level AND nested hash/eq consistency.
- [x] New end-to-end integration test drives the fix through `Database::execute`.
- [ ] Full `scripts/agent-gate.sh` (the gate of record) — run once by `flow-closer` before merge.