### PR TITLE
docs(#2433): PR-gated telemetry stamp + codex roborev model override

### DIFF
--- a/.claude/skills/flow-finalize/SKILL.md
+++ b/.claude/skills/flow-finalize/SKILL.md
@@ -45,22 +45,31 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
      --gate pass --gate-runs <runs through the first PASS; don't re-run after a pass> \
      --claim-collisions <rejected claim pushes> --rebase-events <rebases/conflict resolutions> \
      --roborev-findings <roborev findings raised> --rework <re-open / re-review rounds>
-   # Stamp on MAIN — never on a commandeered root branch. If the root is on main, commit there;
-   # otherwise land the ledger via a throwaway origin/main worktree so it can't go to the wrong branch:
-   if [ "$(git -C ~/projects/cqlite rev-parse --abbrev-ref HEAD)" = "main" ]; then
-     git -C ~/projects/cqlite add docs/reports/delivery-telemetry.jsonl
-     git -C ~/projects/cqlite commit -m "telemetry(#<N>): stamp delivery ledger" && git -C ~/projects/cqlite push
-   else
-     git -C ~/projects/cqlite worktree add /tmp/cqlite-ledger origin/main -q
-     # re-run the `record` command above with its output going to /tmp/cqlite-ledger (cd there first), then:
-     git -C /tmp/cqlite-ledger add docs/reports/delivery-telemetry.jsonl
-     git -C /tmp/cqlite-ledger commit -m "telemetry(#<N>): stamp delivery ledger" && git -C /tmp/cqlite-ledger push origin HEAD:main
-     git -C ~/projects/cqlite worktree remove /tmp/cqlite-ledger
-   fi
+   # Land the ledger via a PR — `main` blocks direct pushes (#2433 branch protection: PR required,
+   # enforce_admins=true). NEVER `git push`/`push origin HEAD:main` (rejected), and NEVER `git checkout`
+   # in the shared root (a closer that switched root to a telemetry branch stranded it off main).
+   # ALWAYS a dedicated telemetry-<N> worktree branched off origin/main:
+   git -C ~/projects/cqlite fetch origin main -q
+   git -C ~/projects/cqlite worktree add /tmp/cqlite-ledger-<N> -b telemetry-<N> origin/main -q
+   cd /tmp/cqlite-ledger-<N>
+   # IMPORTANT: `record` writes to the SCRIPT's repo ledger (the root checkout), NOT $PWD. After running
+   # it, verify the new line landed in THIS worktree's docs/reports/delivery-telemetry.jsonl (move it here
+   # if the tool wrote it to root) and leave the root checkout CLEAN.
+   git add docs/reports/delivery-telemetry.jsonl
+   git commit -m "chore(telemetry): record #<N> delivery (PR #<pr>)"
+   git push -u origin telemetry-<N>
+   gh api repos/pmcfadin/cqlite/pulls -f title="chore(telemetry): record #<N> delivery" \
+     -f head="telemetry-<N>" -f base="main" \
+     -f body="Telemetry-only ledger stamp for #<N> (PR #<pr>). Routed via PR — main blocks direct pushes." --jq '.html_url'
+   cd ~/projects/cqlite && git worktree remove /tmp/cqlite-ledger-<N> --force
+   # The telemetry PR merges once its own `required` check goes green. The ledger is a HOT append-only
+   # file: on a rebase conflict, KEEP ALL lines (main's ledger + your new record) — never drop a peer's.
+   # Do NOT block the code merge on the telemetry PR; if its CI is pending, hand its number back and
+   # merge it centrally when green.
    ```
    `--routing` is required (it is never inferred); `--priority` defaults from the issue's `P?` label
    (pass it to override). `record` refuses a second stamp for the same issue (pass `--allow-duplicate` to
-   override). The live ledger lives on `main` — stamp it on main only (never a commandeered root branch).
+   override). The live ledger lives on `main`, reachable only via a PR (never a direct push).
    Confirm with `python3 scripts/delivery-telemetry.py lint`.
 5. **Set the board to Done + release the claim.** The PR-merged / issue-closed server-side automation
    should already have moved the Project item to `Status=Done` (it fires even when you merge from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,13 @@ implement (TDD) → --lite each fix round (summary-file redirect)
 - **Review-first (#2086)**: review BEFORE the first full gate so the ONE gate certifies
   already-reviewed code. Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single
   call site AND no new surface). When in doubt, review.
+- **roborev invocation — pass BOTH agent and model (#2433).** `.roborev.toml` on `main` pins
+  `agent = 'claude-code'` + `review_model = 'opus'`. To run the codex reviewer you must override BOTH:
+  `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`. `--agent codex`
+  alone still inherits `review_model = 'opus'` from config, and codex-on-a-ChatGPT-account rejects
+  `opus` with a hard `400 'opus' model is not supported` — a silent review failure that looks like an
+  outage. Run from a checkout whose `.roborev.toml` you know (worktrees inherit `main`'s pinned config);
+  `--model` is the reliable override. codex's own configured model is `gpt-5.6-sol` (`~/.codex/config.toml`).
 - **flow-closer (#2084)**: the full gate, C, the final roborev pass, and the merge run inside the
   disposable `flow-closer` subagent — the lead retains only its terminal packet (verdict, PR URL,
   summary-file path, ≤10 lines residual), never gate stdout or review churn.
@@ -342,6 +349,17 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   data only (a counter not observed is an error, never a fabricated 0). On a cadence the manager
   runs `retro` and files a deduped `flow-meta` issue. The SKIP-aware `delivery-telemetry` gate
   component covers the tool. Doctrine: `docs/development/pm-operating-loop.md`.
+  - **Stamp via a PR-in-worktree, never a direct push (#2433 branch protection).** `main` blocks
+    direct pushes (PR required for every commit, `enforce_admins=true`), so the ledger line CANNOT be
+    pushed to `main` directly. `flow-finalize`/`flow-closer` stamp by: (1) `git worktree add` a
+    `telemetry-<N>` branch off `origin/main` — **never `git checkout` in the shared root** (a closer
+    that switched root to a `telemetry-*` branch and died stranded root off `main`, breaking every
+    session); (2) `scripts/delivery-telemetry.py record` — note it writes to the SCRIPT's repo ledger
+    (root checkout), NOT `$PWD`, so move/verify the line lands in the telemetry worktree's ledger and
+    leave root clean; (3) commit + push the branch + open a telemetry-only PR that merges once its own
+    `required` check is green. The ledger is a hot append-only file: on a rebase conflict, **keep ALL
+    lines** (main's ledger + your new record), never drop a peer's line. Do NOT block the code merge on
+    the telemetry PR — return its number as residual if its CI is still pending.
 - **Keep doctrine current in the same change** — user-facing or workflow changes update CLAUDE.md
   and the website `agents-developing/` page as part of the change.
 

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -312,7 +312,14 @@ The pipeline measures itself so improvement is data-driven, not anecdotal — **
   timestamps (issue/PR open + merge + close → cycle time and coarse phase durations) plus run-observed
   counters — claim collisions, rebase/conflict events, agent-gate pass/fail + run count, roborev findings,
   and rework. A counter that was not observed is an **error**, never a fabricated `0` (no-heuristics
-  mandate). `delivery-telemetry.py lint` schema-validates every line.
+  mandate). `delivery-telemetry.py lint` schema-validates every line. **The stamp lands via a
+  `telemetry-<N>` PR-in-worktree, not a direct push** — `main` blocks direct pushes (PR required for every
+  commit, `enforce_admins=true`). `flow-finalize` branches a throwaway worktree off `origin/main`, appends
+  the record (note `record` writes to the script's repo ledger, not `$PWD` — verify it lands in the
+  worktree and leave root clean), and opens a telemetry-only PR that merges on its own green `required`
+  check. The ledger is a hot append-only file: resolve any rebase conflict by **keeping all lines**, never
+  dropping a peer's record. Never `git checkout` in the shared root to do this — a closer that switched
+  root onto a telemetry branch and died stranded it off `main` and broke every concurrent session.
 - **Diagnose.** On a cadence (per-epic or weekly) the manager runs `delivery-telemetry.py retro`, which
   ranks the recorded failure categories by a **documented weighted tally** (`Σ count × weight` — a
   deterministic policy table, not an inferred or learned model) and reports the single highest-cost

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -92,3 +92,18 @@ fresh `git worktree add --detach HEAD`, never the dirty tree.
 2. Fix matches up front rather than waiting for roborev to flag them.
 3. Then run `scripts/agent-gate.sh` and request review as usual — see the
    [gate contract](/cqlite/agents-developing/gate-contract/).
+
+## Running the codex reviewer — override BOTH agent and model
+
+`.roborev.toml` on `main` pins `agent = 'claude-code'` and `review_model = 'opus'`. To run the codex
+backend you must override **both** on the command line:
+
+```bash
+roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait
+```
+
+`--agent codex` **alone** still inherits `review_model = 'opus'` from config, and codex on a ChatGPT
+account rejects `opus` with a hard `400 'opus' model is not supported` — a silent review failure that
+looks like a backend outage rather than a config mismatch. Worktrees inherit `main`'s pinned config, so
+`--model gpt-5.6-sol` (codex's own configured model, from `~/.codex/config.toml`) is the reliable
+override on every checkout.


### PR DESCRIPTION
Flow-doctrine updates surfaced during a 3-lane delivery session (#1885/#2288/#2148) under main's new branch protection (PR required for every commit, enforce_admins=true, 0 approvals, required status check 'required').

## Changes (docs + skill only, no code)
1. **Telemetry stamp via PR-in-worktree, never direct push.** main blocks direct pushes, so flow-finalize/closer now branch a telemetry-<N> worktree off origin/main, append the ledger record, and open a telemetry-only PR that merges on its own green 'required' check. Captures two gotchas: delivery-telemetry.py record writes to the SCRIPT's repo ledger (not $PWD), and NEVER git checkout in the shared root (a closer stranded root on a telemetry branch this session). Ledger conflicts resolve by keeping ALL lines.
   - CLAUDE.md telemetry section, .claude/skills/flow-finalize/SKILL.md step 4, delivery-pipeline website page.
2. **roborev codex invocation must override BOTH agent and model:** `--agent codex --model gpt-5.6-sol`. .roborev.toml on main pins review_model='opus'; --agent codex alone inherits it and codex/ChatGPT rejects opus with a hard 400 (silent review failure). 
   - CLAUDE.md review-first section + new section on the roborev-findings website page.
3. The required-check/enforce_admins merge rule was already documented (#2433) — no change; noted for completeness.

Keeps doctrine current in the same change (CLAUDE.md + website agents-developing pages), per the doctrine-currency rule.