### PR TITLE
ci(#2358): auto-run Flight↔Trino docker E2E on integration-surface PRs

### DIFF
--- a/.github/workflows/flight-trino-e2e.yml
+++ b/.github/workflows/flight-trino-e2e.yml
@@ -20,11 +20,16 @@ on:
       - '.github/workflows/flight-trino-e2e.yml'
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
+    # Targeted path filter (#2358): the docker-compose E2E runs automatically on
+    # PRs touching the Flight/Trino integration surface or the core storage
+    # read path that feeds it — the exact surface whose regression (#2352,
+    # warm handles #2310) was structurally uncatchable pre-merge. Kept narrow so
+    # unrelated PRs (docs, other core modules) never spin up the Docker stack.
     paths:
       - 'cqlite-flight/**'
-      - 'cqlite-core/**'
       - 'trino-connector/**'
+      - 'cqlite-core/src/storage/**'
       - '.github/workflows/flight-trino-e2e.yml'
   workflow_dispatch:
 
@@ -39,13 +44,6 @@ jobs:
   tier-summary:
     name: E2E tier summary
     runs-on: ubuntu-latest
-    env:
-      RUN_FULL: >-
-        ${{
-          github.event_name != 'pull_request' ||
-          contains(github.event.pull_request.labels.*.name, 'ci:flight-full') ||
-          contains(github.event.pull_request.labels.*.name, 'ci:trino-full')
-        }}
     steps:
       - name: Write CI tier summary
         run: |
@@ -53,21 +51,20 @@ jobs:
             echo "## Flight ↔ Trino E2E tier"
             echo ""
             echo "- Docker compose E2E is a full-tier workflow."
-            echo "- Ordinary PRs skip the Docker stack by default."
-            echo "- PRs can opt in with \`ci:flight-full\` or \`ci:trino-full\`."
+            echo "- On PRs it runs automatically when the diff touches the integration surface:"
+            echo "  \`cqlite-flight/**\`, \`trino-connector/**\`, or \`cqlite-core/src/storage/**\` (#2358)."
+            echo "- Unrelated PRs (docs, other core modules) do not trigger the Docker stack."
             echo "- Full E2E also runs on push to main, nightly schedule, workflow_dispatch, and release publication."
-            echo "- Current full-tier decision: ${RUN_FULL}."
+            echo "- Need it on a PR outside the path filter? Trigger it manually via workflow_dispatch."
           } >> "$GITHUB_STEP_SUMMARY"
 
   e2e:
     name: docker-compose integration
     needs: tier-summary
-    if: >-
-      ${{
-        github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'ci:flight-full') ||
-        contains(github.event.pull_request.labels.*.name, 'ci:trino-full')
-      }}
+    # No opt-in gate: any event that reaches this workflow warrants the E2E.
+    # On pull_request the on.paths filter above already restricts triggering to
+    # the integration surface, so the job runs as a required-visible check for
+    # exactly those PRs (#2358).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Closes #2358

## Problem
The Flight↔Trino `docker-compose integration` job was gated behind an opt-in label (`ci:flight-full`/`ci:trino-full`). The workflow *triggered* on PRs (broad `cqlite-core/**` path), but the E2E job's `if:` skipped it unless a human remembered to label the PR. Result: the #2310 warm-handles PR (#2350) passed every branch-tip run while carrying a regression that broke 9 nightly assertions (#2352) — the integration surface under active hardening had **zero automatic PR coverage**.

## Change
- **Narrow the `pull_request` path filter** to the integration surface only: `cqlite-flight/**`, `trino-connector/**`, `cqlite-core/src/storage/**` (+ the workflow file). Drops the broad `cqlite-core/**` and the `labeled`/`unlabeled` types.
- **Remove the opt-in `if:` gate** on the `docker-compose integration` job so it runs automatically — a required-visible check — on any PR that reaches the workflow (i.e. exactly the path-matching PRs).
- `workflow_dispatch` remains the manual escape hatch for off-path PRs (replaces the label opt-in).
- `schedule` (nightly `35 4 * * *`), `release`, and `push` triggers **unchanged** — nightly backstop preserved.
- `tier-summary` messaging updated to describe auto-run; the now-unused `RUN_FULL` env removed.

## Acceptance verification (workflow-YAML-only change)
Path-filter logic traced against the parsed YAML:
- **(a)** PR touching `cqlite-flight/**` (e.g. `src/warm/registry.rs`, where #2352 lived) → matches → workflow triggers → `e2e` runs (no `if:` gate) → docker-compose integration is a visible check. ✓
- **(b)** Docs-only PR (`docs/**`) → matches no path → workflow does not trigger. ✓
- **(c)** Nightly `schedule` cron `35 4 * * *` unchanged; on non-PR events `e2e` runs as before. ✓
- **(d)** `cqlite-core/src/query/**` PR → does not match `cqlite-core/src/storage/**` → stays off (targeted, keeps it off unrelated core PRs). ✓

## Security (repo's #1 recurring finding class)
Swept every `run:` block — **no** `${{ github.event.* }}` / `${{ inputs.* }}` / PR-controlled interpolation. The only two `${{ }}` expressions are in the `concurrency:` block (`github.ref`, `github.event_name`), which are not shell-injection surfaces. The removed `RUN_FULL` logic (which read `github.event.pull_request.labels.*.name`) is gone entirely.

## Gate
`--lite` (workflow-only diff; no Rust changed). Full gate of record runs in the closer pre-merge, respecting tonight's single-full-gate concurrency cap.