### PR TITLE
feat(#2210): dedicated MADV_RANDOM point-read mmap for large SSTables

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -323,6 +323,21 @@ fn mmap_advice_for(prefetch: PrefetchMode) -> Option<memmap2::Advice> {
     }
 }
 
+/// Minimum SSTable size for the point-read path to get its OWN mmap advised
+/// `MADV_RANDOM` (issue #2210). Below this the point source shares the scan's
+/// `Arc<Mmap>` unchanged (no 2nd mapping, no advice): the whole file is small
+/// enough that the kernel's default read-ahead cheaply makes it resident, and
+/// `MADV_RANDOM` would only add per-page synchronous faults. Above it, scattered
+/// point-lookup faults otherwise waste the ~128 KiB read-ahead window per read,
+/// so a dedicated `MADV_RANDOM` mapping collapses both the block-I/O
+/// amplification (~30x) and the cold-cache per-read latency (~35-43%). Threshold
+/// is measurement-derived on Linux/EBS: the win is unambiguous by 4 MiB; 8 MiB
+/// leaves 2x margin above the sub-MB "wash" zone. See
+/// docs/reports/issue-2210-madv-random-point-mmap-ab.md. The SCAN mapping is
+/// NEVER advised (measured #1143 behaviour preserved).
+#[cfg(unix)]
+const POINT_MMAP_MADV_RANDOM_MIN_BYTES: u64 = 8 * 1024 * 1024;
+
 /// Process-wide count of currently-open [`SSTableReader`]s, the source value
 /// for the [`SSTABLES_OPEN`](crate::observability::catalog::SSTABLES_OPEN)
 /// gauge. Tracked PER FORMAT so the gauge — which carries the
@@ -550,7 +565,14 @@ impl SSTableReader {
         // backend degrades gracefully to a plain positioned fd if the faster
         // backend is refused, mirroring `build_block_sources`.
         let point_source: Arc<dyn read_at::ReadAt> = match &scan_source {
-            ScanSource::Mapped(mmap) => Arc::new(read_at::MmapReadAt::new(mmap.clone())),
+            ScanSource::Mapped(mmap) => {
+                #[cfg(unix)]
+                let point_mmap =
+                    Self::point_read_mmap(path, file_size, mmap, POINT_MMAP_MADV_RANDOM_MIN_BYTES);
+                #[cfg(not(unix))]
+                let point_mmap = mmap.clone();
+                Arc::new(read_at::MmapReadAt::new(point_mmap))
+            }
             #[cfg(unix)]
             ScanSource::Direct { .. } => match read_at::DirectReadAt::open(path, file_size) {
                 Ok(d) => Arc::new(d) as Arc<dyn read_at::ReadAt>,
@@ -1104,6 +1126,55 @@ impl SSTableReader {
         // reader's lifetime; see the function-level note above.
         let mmap = unsafe { memmap2::MmapOptions::new().map(&std_file)? };
         Ok(mmap)
+    }
+
+    /// Choose the mmap the point-read source will use. For a large file
+    /// (`file_size >= min_random_bytes`) map a SECOND, dedicated read-only mapping
+    /// of the same file and advise it `MADV_RANDOM`, returning that distinct
+    /// mapping so scattered point faults read one page instead of the ~128 KiB
+    /// read-ahead window (issue #2210). The returned mapping is a SEPARATE
+    /// allocation from `scan_mmap`, which is left unadvised — advising the point map
+    /// therefore cannot affect the scan map (#1143 preserved). Below the threshold,
+    /// or if the dedicated map / its advice fails, share `scan_mmap` unchanged
+    /// (never keep a redundant unadvised 2nd map). Mapped directly (not via
+    /// `map_file`) so the read-work FILE_OPENS counter is untouched.
+    #[cfg(unix)]
+    fn point_read_mmap(
+        path: &Path,
+        file_size: u64,
+        scan_mmap: &Arc<memmap2::Mmap>,
+        min_random_bytes: u64,
+    ) -> Arc<memmap2::Mmap> {
+        if file_size >= min_random_bytes {
+            if let Ok(std_file) = std::fs::File::open(path) {
+                // SAFETY: read-only mapping of a file assumed immutable for the
+                // reader's lifetime (same contract as `map_file`).
+                match unsafe { memmap2::MmapOptions::new().map(&std_file) } {
+                    Ok(point_mmap) => match point_mmap.advise(memmap2::Advice::Random) {
+                        Ok(()) => {
+                            tracing::debug!(
+                                "Dedicated MADV_RANDOM point-read mapping for {} ({} bytes, #2210)",
+                                path.display(),
+                                file_size
+                            );
+                            return Arc::new(point_mmap);
+                        }
+                        Err(e) => tracing::debug!(
+                            "madvise(RANDOM) on dedicated point map for {} failed ({}); \
+                             sharing scan mapping",
+                            path.display(),
+                            e
+                        ),
+                    },
+                    Err(e) => tracing::debug!(
+                        "Dedicated point map for {} failed ({}); sharing scan mapping",
+                        path.display(),
+                        e
+                    ),
+                }
+            }
+        }
+        scan_mmap.clone()
     }
 
     /// Load CompressionInfo.db metadata for chunked reading

--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -1055,4 +1055,78 @@ mod tests {
             ),
         }
     }
+
+    /// Boundary of the point-read `MADV_RANDOM` size gate (issue #2210): a file
+    /// just below the threshold shares the scan mapping (no 2nd map), while a
+    /// file at/above it gets a distinct dedicated mapping.
+    #[cfg(unix)]
+    #[test]
+    fn test_point_read_mmap_size_gate_boundary() {
+        use super::super::SSTableReader;
+        use std::io::Write;
+        use std::sync::Arc;
+
+        let mut tmp = tempfile::NamedTempFile::new().expect("temp file");
+        tmp.write_all(&[0xABu8; 4096]).expect("write");
+        tmp.flush().expect("flush");
+        let path = tmp.path();
+        let file_size = 4096u64;
+
+        let std_file = std::fs::File::open(path).expect("open");
+        let scan_mmap =
+            Arc::new(unsafe { memmap2::MmapOptions::new().map(&std_file).expect("map") });
+
+        // file_size just below the threshold -> share the scan mapping.
+        let below = SSTableReader::point_read_mmap(path, file_size, &scan_mmap, file_size + 1);
+        assert!(
+            Arc::ptr_eq(&below, &scan_mmap),
+            "below-threshold file must share the scan mapping (no dedicated map)"
+        );
+
+        // file_size == threshold -> dedicated, distinct mapping.
+        let at = SSTableReader::point_read_mmap(path, file_size, &scan_mmap, file_size);
+        assert!(
+            !Arc::ptr_eq(&at, &scan_mmap),
+            "at/above-threshold file must get its own dedicated mapping"
+        );
+    }
+
+    /// The dedicated point mapping is a SEPARATE allocation from the scan
+    /// mapping (so advising it cannot touch the scan map, #1143 preserved) yet
+    /// exposes the same bytes; below the gate the exact scan Arc is returned
+    /// unchanged (issue #2210 acceptance: "scan mapping is unaffected").
+    #[cfg(unix)]
+    #[test]
+    fn test_point_read_mmap_distinct_from_scan() {
+        use super::super::SSTableReader;
+        use std::io::Write;
+        use std::sync::Arc;
+
+        let mut tmp = tempfile::NamedTempFile::new().expect("temp file");
+        let contents: Vec<u8> = (0..2048u32).map(|i| (i % 251) as u8).collect();
+        tmp.write_all(&contents).expect("write");
+        tmp.flush().expect("flush");
+        let path = tmp.path();
+        let file_size = contents.len() as u64;
+
+        let std_file = std::fs::File::open(path).expect("open");
+        let scan_mmap =
+            Arc::new(unsafe { memmap2::MmapOptions::new().map(&std_file).expect("map") });
+
+        // Tiny threshold (1) forces the >= branch on a small file: dedicated map.
+        let dedicated = SSTableReader::point_read_mmap(path, file_size, &scan_mmap, 1);
+        assert!(
+            !Arc::ptr_eq(&dedicated, &scan_mmap),
+            "dedicated point map must be a distinct allocation from the scan map"
+        );
+        assert_eq!(dedicated.len(), scan_mmap.len(), "same length");
+        assert_eq!(&dedicated[..], &contents[..], "same byte contents");
+
+        // Threshold above the file size shares the scan Arc unchanged.
+        let shared = SSTableReader::point_read_mmap(path, file_size, &scan_mmap, file_size + 1);
+        assert!(
+            Arc::ptr_eq(&shared, &scan_mmap),
+            "below-threshold must return the exact scan Arc (scan mapping unaffected)"
+        );
+    }
 }

--- a/docs/reports/issue-2210-madv-random-point-mmap-ab.md
+++ b/docs/reports/issue-2210-madv-random-point-mmap-ab.md
@@ -1,0 +1,55 @@
+# Issue #2210 — MADV_RANDOM on a dedicated point-read mmap: Linux cold-cache A/B
+
+**Machine:** AWS EC2, Linux 6.17 aarch... x86_64, 30 GiB RAM, workspace on EBS gp3
+(`/dev/nvme0n1p1`), `read_ahead_kb = 128`. **Genuine cold cache** achieved by
+`sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'` before EVERY mapped measurement
+(passwordless sudo verified). Backing files created with real random bytes
+(`dd if=/dev/urandom`) — non-sparse, so reads hit real EBS blocks.
+
+## Method
+
+Two mappings of the SAME file are compared under identical, page-aligned, seeded random
+offsets (fair A/B): **MADV_RANDOM** vs **no-advice** (the `#1143` `Auto` scan regime — the
+current point-read behaviour, since the point source shares the scan `Arc<Mmap>`). The
+harness models the production point read: `MmapReadAt::read_at` copies a small slice out of
+the resident map, so on a cold cache each touch is a major page fault whose cost the mapping's
+madvise regime governs. Two signals recorded: (1) `read_bytes` delta from `/proc/self/io` —
+bytes pulled from the block layer, a deterministic measure of read-ahead amplification,
+independent of EBS timing noise; (2) per-read wall latency (mean/p50/p99).
+
+The A/B regime order is alternated per round to average out any residual EBS server-side
+warmth. Harness source: kept out of the shipped tree (scratchpad microbench).
+
+## Realistic point-lookup pattern — few scattered reads per reader open (8 reads × 20 rounds)
+
+This is the true point-read workload: open a reader, do a handful of scattered lookups.
+
+| File size | MADV_RANDOM mean | no-advice mean | Δ mean latency | p99 (RAND / none) | block I/O per read (RAND / none) |
+|-----------|-----------------:|---------------:|:--------------:|:-----------------:|:--------------------------------:|
+| 1 MiB     | 705 µs | 630 µs | +12% (wash) | **963** / 1665 µs | 4 KiB / 78 KiB (20x) |
+| 4 MiB     | 724 µs | 1108 µs | **-35%** | **1167** / 2222 µs | 4 KiB / 107 KiB (27x) |
+| 16 MiB    | 707 µs | 1237 µs | **-43%** | **1034** / 2110 µs | 4 KiB / 128 KiB (32x) |
+| 64 MiB    | 756 µs | 1335 µs | **-43%** | **1731** / 2656 µs | 4.5 KiB / 128 KiB (29x) |
+| 512 MiB   | 794 µs | 1280 µs | **-38%** | **1788** / 2359 µs | 4.5 KiB / 128 KiB (29x) |
+| 4 GiB     | 768 µs | 1235 µs | **-38%** | **1578** / 2358 µs | 4.5 KiB / 128 KiB (29x) |
+
+## Heavy-reuse pattern (2000 reads on ONE mapping) — for contrast, NOT the point-read case
+
+With 2000 reads reused on a single small mapping, no-advice's read-ahead pre-warms the whole
+small file, so MADV_RANDOM looks bad at ≤64 MiB (e.g. 1 MiB: 468 ms vs 45 ms). That reuse is a
+scan-like locality pattern, not a point read. It flips to a MADV_RANDOM win by 512 MiB
+(4743 ms vs 6301 ms). Documented so the size gating below is understood as reuse-aware, not a
+blanket "large = advise".
+
+## Conclusion — SHIP, size-gated
+
+- **Clear, reproducible win for point reads on SSTables ≳ 4 MiB**: ~35–43% lower cold-cache
+  per-read latency, better p99, and ~30x less block-layer I/O (fewer EBS IOPS consumed).
+- **Sub-MB files are a wash** (slight mean regression, better tail). All of CQLite's *bundled*
+  test SSTables are <1 MiB — a fixture artifact, not the production case (real Cassandra
+  SSTables are routinely tens of MiB to GiB).
+- Decision: apply `MADV_RANDOM` to a **dedicated 2nd point-read mmap** only when
+  `file_size >= 8 MiB` (2x margin above the measured 4 MiB clear-win floor, comfortably above
+  the sub-MB wash zone). Below the threshold the point source shares the scan `Arc<Mmap>`
+  unchanged — zero extra mapping, zero regression. The scan mapping is **never advised**, so
+  the measured #1143 scan behaviour is preserved.


### PR DESCRIPTION
Closes #2210.

## What
Gives the mmap **point-read** path a dedicated 2nd mmap advised `MADV_RANDOM` for SSTables **≥ 8 MiB**, leaving the scan source's `Arc<Mmap>` completely **unadvised** (the measured #1143 scan behaviour is preserved). Below the threshold the point source shares the scan mmap unchanged — no 2nd mapping, no advice, no regression. On open-fail / advise-fail it falls back to sharing the scan mmap (best-effort).

## Why — measured on Linux cold cache (the issue's hard gate)
The point source shares the scan `Arc<Mmap>` and `madvise` is per-mapping, so advising `MADV_RANDOM` needed a dedicated mapping (else it would hit scans and violate #1143). Per the acceptance criteria the change ships **only** because a genuine cold-cache A/B on Linux shows a win. Full report: `docs/reports/issue-2210-madv-random-point-mmap-ab.md`.

Method: AWS EBS-backed NVMe, `read_ahead_kb=128`, page cache dropped via `echo 3 > /proc/sys/vm/drop_caches` before **every** mapped measurement; non-sparse random backing files; identical seeded page-aligned offsets per A/B; regime order alternated to cancel EBS warmth. Signals: `/proc/self/io` `read_bytes` (deterministic read-ahead amplification) + per-read wall latency.

Realistic point-lookup pattern (few scattered reads per reader open):

| File size | MADV_RANDOM mean | no-advice mean | Δ mean | block I/O reduction |
|-----------|-----------------:|---------------:|:------:|:-------------------:|
| 1 MiB  | 705 µs | 630 µs | +12% (wash; better p99) | 20x |
| 4 MiB  | 724 µs | 1108 µs | **−35%** | 27x |
| 16 MiB | 707 µs | 1237 µs | **−43%** | 32x |
| 64 MiB | 756 µs | 1335 µs | **−43%** | 29x |
| 512 MiB| 794 µs | 1280 µs | **−38%** | 29x |
| 4 GiB  | 768 µs | 1235 µs | **−38%** | 29x |

Clear, reproducible ~35–43% cold-cache point-read latency win + ~30x fewer block-layer bytes (EBS IOPS) for SSTables ≳ 4 MiB. Sub-MB files are a wash — all CQLite *bundled* test SSTables are <1 MiB (fixture artifact; real Cassandra SSTables are tens of MiB–GiB), so the 8 MiB gate (2x margin over the measured 4 MiB clear-win floor) keeps them on current behaviour.

## Scan behaviour preserved (#1143)
The dedicated point mapping is a **separate allocation** from the scan `Arc<Mmap>`; advising it cannot reach the scan map. `build_block_sources` scan sources are untouched. Pinned by `test_point_read_mmap_distinct_from_scan` (distinct-allocation + same bytes) and `test_point_read_mmap_size_gate_boundary` (`>=` gate; shares below, dedicated at/above).

## Notes
- No `unwrap()`/`expect()` in library code; no-heuristics unaffected (pure I/O advice). Dedicated map is opened directly (not via `map_file`) so the C2/#1573 FILE_OPENS read-work counter is untouched.
- `reader/mod.rs` is already over the ~800-line campsite target (epic #1116); this focused perf change grows it, so the full gate is expected to need `CQLITE_ALLOW_FILE_GROWTH=1` (a real split is out of scope, tracked by #1116).
- Review-first: rust-reviewer (no blockers) + roborev (no issues) on the lite-green diff.
