### PR TITLE
perf(#2096): partition-seeking merge run reader for multi-candidate point reads (D3 follow-up)

### DIFF
--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -297,32 +297,22 @@ pub(super) async fn merge_generations_for_read(
 }
 
 /// Partition-SEEKING sibling of [`merge_generations_for_read`] for the
-/// multi-candidate `WHERE pk = ?` point-read path (issue #2096).
+/// multi-candidate `WHERE pk = ?` point read (issue #2096).
 ///
-/// Where [`merge_generations_for_read`] with a `target_key` still builds a
-/// FULL-SCAN [`KWayMerger`](crate::storage::write_engine::KWayMerger)
-/// (`KWayMerger::new`) that sequentially DECODES every partition with token <=
-/// the target in each generation before it reaches the target and breaks —
-/// O(partitions-below-target) — this reuses the partition-SEEKING merger built
-/// for the Flight point path (issues #2207/#2346):
-/// [`build_single_partition_merger_from_readers`](crate::storage::write_engine::build_single_partition_merger_from_readers)
-/// seeks each candidate directly to the target partition's `Data.db` offset
-/// (BTI trie / `Index.db`), or fail-safe filter-scans a single SSTable when its
+/// Where [`merge_generations_for_read`] with a `target_key` still builds the
+/// FULL-SCAN `KWayMerger::new` and sequentially DECODES every partition with token
+/// <= the target before breaking (O(partitions-below-target)), this reuses the
+/// Flight point path's partition-SEEKING merger
+/// ([`build_single_partition_merger_from_readers`](crate::storage::write_engine::build_single_partition_merger_from_readers),
+/// #2207/#2346): each candidate seeks straight to the target partition's `Data.db`
+/// offset (BTI trie / `Index.db`), or fail-safe filter-scans one SSTable when its
 /// index is unavailable, then reconciles through the SAME `KWayMerger`
-/// (`from_row_iterators`, run_index = position). Cross-generation reconciliation
-/// (last-write-wins, cell/row tombstone, and partition-tombstone shadowing) is
-/// therefore byte-identical to the full-scan merge, only over O(target) work.
-///
-/// The read-visibility kernel is IDENTICAL to the materializing helper: the same
-/// [`ReadShadow`] (read-time TTL expiry + partition shadow, issue #1849) captured
-/// ONCE, the same [`partition_live_rows`] emission, and the same final
-/// token-order guard — so the output is byte-for-byte
-/// `merge_generations_for_read(.., Some(target))`.
-///
-/// Ordered NEWEST→OLDEST exactly like [`ordered_generation_paths`] so run_index =
-/// LWW tie-break rank matches the full-scan merger. The builder + `step()` are
-/// blocking, so they run on a [`tokio::task::spawn_blocking`] task, mirroring how
-/// [`merge_generations_for_read`] runs `KWayMerger::new`.
+/// (`from_row_iterators`, run_index = position). The read-visibility kernel is
+/// IDENTICAL to the materializing helper — the same [`ReadShadow`] (#1849) captured
+/// ONCE, the same [`partition_live_rows`] emission + token-order guard, and
+/// candidates ordered NEWEST→OLDEST like [`ordered_generation_paths`] — so the
+/// output is byte-for-byte `merge_generations_for_read(.., Some(target))`, only
+/// over O(target) work. Blocking builder + `step()` run on `spawn_blocking`.
 #[cfg(all(feature = "write-support", not(feature = "tombstones")))]
 pub(super) async fn seek_merge_generations_for_read(
     candidates: &[Arc<reader::SSTableReader>],
@@ -332,9 +322,8 @@ pub(super) async fn seek_merge_generations_for_read(
     use crate::storage::scan_cancel::ScanCancel;
     use crate::storage::write_engine::merge::build_single_partition_merger_from_readers;
 
-    // Order candidates NEWEST→OLDEST (generation descending) exactly like
-    // `ordered_generation_paths`, so the seeking merger's run_index (= position)
-    // equals the full-scan merger's LWW tie-break rank byte-for-byte.
+    // NEWEST→OLDEST like `ordered_generation_paths`, so the seeking merger's
+    // run_index (= position) equals the full-scan merger's LWW tie-break rank.
     let mut ordered: Vec<Arc<reader::SSTableReader>> = candidates.to_vec();
     ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
 
@@ -342,23 +331,20 @@ pub(super) async fn seek_merge_generations_for_read(
     let target_bytes = target_key.as_bytes().to_vec();
 
     let mut merged = tokio::task::spawn_blocking(move || -> Result<Vec<(RowKey, ScanRow)>> {
-        // Issue #1849: capture the read-time TTL clock ONCE per scan — the SAME
-        // read-visibility kernel `merge_generations_for_read` applies, which is
-        // REQUIRED for byte-identical output.
+        // Issue #1849: same read-visibility kernel `merge_generations_for_read`
+        // applies (read-time TTL clock captured ONCE), REQUIRED for byte-identity.
         let shadow = ReadShadow::new(&schema, now_epoch_secs());
         let keys = [target_bytes.clone()];
         let Some(mut merger) =
             build_single_partition_merger_from_readers(ordered, &keys, &schema, ScanCancel::new())?
         else {
-            // No candidate holds the target (every one a presence-oracle negative).
-            return Ok(Vec::new());
+            return Ok(Vec::new()); // no candidate holds the target
         };
         let mut out = Vec::new();
         while let MergeStep::Partition { key, rows } = merger.step()? {
             let row_key = RowKey::new(key.key.clone());
-            // The merger emits at most the requested partition, but a fail-safe
-            // filter-scan run could surface a prefix-collision key; keep only the
-            // exact target and stop as soon as it is seen (keys are unique).
+            // A fail-safe filter-scan run could surface a prefix-collision key; keep
+            // only the exact target and stop once seen (partition keys are unique).
             if row_key.as_bytes() != target_bytes.as_slice() {
                 continue;
             }
@@ -368,10 +354,12 @@ pub(super) async fn seek_merge_generations_for_read(
         Ok(out)
     })
     .await
-    .map_err(|e| crate::Error::Storage(format!("seeking cross-generation read merge task: {e}")))??;
+    .map_err(|e| {
+        crate::Error::Storage(format!("seeking cross-generation read merge task: {e}"))
+    })??;
 
-    // Parity with the materializing helper: a stable TOKEN-order sort (a no-op for
-    // the single target partition, kept for byte-parity of the guard, issue #1580).
+    // Parity guard with the materializing helper: stable TOKEN-order sort (no-op for
+    // a single partition, kept for byte-parity, issue #1580).
     scan_merge::sort_by_token_order(&mut merged, None, |(k, _)| k);
     Ok(merged)
 }

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -309,9 +309,9 @@ pub(super) async fn merge_generations_for_read(
 /// seeks each candidate directly to the target partition's `Data.db` offset
 /// (BTI trie / `Index.db`), or fail-safe filter-scans a single SSTable when its
 /// index is unavailable, then reconciles through the SAME `KWayMerger`
-/// (`from_row_iterators`, run_index = position). Cross-generation last-write-wins
-/// + cell/row tombstone + partition-tombstone reconciliation is therefore
-/// byte-identical to the full-scan merge, only over O(target) work.
+/// (`from_row_iterators`, run_index = position). Cross-generation reconciliation
+/// (last-write-wins, cell/row tombstone, and partition-tombstone shadowing) is
+/// therefore byte-identical to the full-scan merge, only over O(target) work.
 ///
 /// The read-visibility kernel is IDENTICAL to the materializing helper: the same
 /// [`ReadShadow`] (read-time TTL expiry + partition shadow, issue #1849) captured

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -296,6 +296,86 @@ pub(super) async fn merge_generations_for_read(
     Ok(merged)
 }
 
+/// Partition-SEEKING sibling of [`merge_generations_for_read`] for the
+/// multi-candidate `WHERE pk = ?` point-read path (issue #2096).
+///
+/// Where [`merge_generations_for_read`] with a `target_key` still builds a
+/// FULL-SCAN [`KWayMerger`](crate::storage::write_engine::KWayMerger)
+/// (`KWayMerger::new`) that sequentially DECODES every partition with token <=
+/// the target in each generation before it reaches the target and breaks —
+/// O(partitions-below-target) — this reuses the partition-SEEKING merger built
+/// for the Flight point path (issues #2207/#2346):
+/// [`build_single_partition_merger_from_readers`](crate::storage::write_engine::build_single_partition_merger_from_readers)
+/// seeks each candidate directly to the target partition's `Data.db` offset
+/// (BTI trie / `Index.db`), or fail-safe filter-scans a single SSTable when its
+/// index is unavailable, then reconciles through the SAME `KWayMerger`
+/// (`from_row_iterators`, run_index = position). Cross-generation last-write-wins
+/// + cell/row tombstone + partition-tombstone reconciliation is therefore
+/// byte-identical to the full-scan merge, only over O(target) work.
+///
+/// The read-visibility kernel is IDENTICAL to the materializing helper: the same
+/// [`ReadShadow`] (read-time TTL expiry + partition shadow, issue #1849) captured
+/// ONCE, the same [`partition_live_rows`] emission, and the same final
+/// token-order guard — so the output is byte-for-byte
+/// `merge_generations_for_read(.., Some(target))`.
+///
+/// Ordered NEWEST→OLDEST exactly like [`ordered_generation_paths`] so run_index =
+/// LWW tie-break rank matches the full-scan merger. The builder + `step()` are
+/// blocking, so they run on a [`tokio::task::spawn_blocking`] task, mirroring how
+/// [`merge_generations_for_read`] runs `KWayMerger::new`.
+#[cfg(all(feature = "write-support", not(feature = "tombstones")))]
+pub(super) async fn seek_merge_generations_for_read(
+    candidates: &[Arc<reader::SSTableReader>],
+    schema: &crate::schema::TableSchema,
+    target_key: &RowKey,
+) -> Result<Vec<(RowKey, ScanRow)>> {
+    use crate::storage::scan_cancel::ScanCancel;
+    use crate::storage::write_engine::merge::build_single_partition_merger_from_readers;
+
+    // Order candidates NEWEST→OLDEST (generation descending) exactly like
+    // `ordered_generation_paths`, so the seeking merger's run_index (= position)
+    // equals the full-scan merger's LWW tie-break rank byte-for-byte.
+    let mut ordered: Vec<Arc<reader::SSTableReader>> = candidates.to_vec();
+    ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
+
+    let schema = schema.clone();
+    let target_bytes = target_key.as_bytes().to_vec();
+
+    let mut merged = tokio::task::spawn_blocking(move || -> Result<Vec<(RowKey, ScanRow)>> {
+        // Issue #1849: capture the read-time TTL clock ONCE per scan — the SAME
+        // read-visibility kernel `merge_generations_for_read` applies, which is
+        // REQUIRED for byte-identical output.
+        let shadow = ReadShadow::new(&schema, now_epoch_secs());
+        let keys = [target_bytes.clone()];
+        let Some(mut merger) =
+            build_single_partition_merger_from_readers(ordered, &keys, &schema, ScanCancel::new())?
+        else {
+            // No candidate holds the target (every one a presence-oracle negative).
+            return Ok(Vec::new());
+        };
+        let mut out = Vec::new();
+        while let MergeStep::Partition { key, rows } = merger.step()? {
+            let row_key = RowKey::new(key.key.clone());
+            // The merger emits at most the requested partition, but a fail-safe
+            // filter-scan run could surface a prefix-collision key; keep only the
+            // exact target and stop as soon as it is seen (keys are unique).
+            if row_key.as_bytes() != target_bytes.as_slice() {
+                continue;
+            }
+            out.extend(partition_live_rows(&row_key, rows, &shadow));
+            break;
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| crate::Error::Storage(format!("seeking cross-generation read merge task: {e}")))??;
+
+    // Parity with the materializing helper: a stable TOKEN-order sort (a no-op for
+    // the single target partition, kept for byte-parity of the guard, issue #1580).
+    scan_merge::sort_by_token_order(&mut merged, None, |(k, _)| k);
+    Ok(merged)
+}
+
 /// Metadata-aware sibling of [`merge_generations_for_read`] for the
 /// `WRITETIME(col)` / `TTL(col)` projection path (Issue #885).
 ///

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1643,7 +1643,7 @@ impl SSTableManager {
         // The seeking merge reconciles through the SAME `KWayMerger`
         // (`from_row_iterators`), so its output is byte-identical to the former
         // full-merge-then-`retain(matches_key)`, only over O(target) work.
-        #[cfg(feature = "write-support")]
+        #[cfg(all(feature = "write-support", not(feature = "tombstones")))]
         if candidates.len() > 1 {
             if let Some(schema) = schema {
                 let target = RowKey::new(partition_key.to_vec());

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1635,21 +1635,22 @@ impl SSTableManager {
 
         // Multiple candidate generations may hold the same partition; reconcile
         // with the same authoritative k-way merge the full scan uses (write-support
-        // only), TARGETED to just this partition (issue #1579): the merge keeps only
-        // `partition_key`'s rows and stops as soon as it finds them, byte-identical
-        // to the former full-merge-then-`retain(matches_key)` but without
-        // materializing every other partition.
+        // only), TARGETED to just this partition. Issue #2096: SEEK each candidate
+        // directly to the target partition's `Data.db` offset (BTI trie / Index.db)
+        // and reconcile through the partition-seeking merger (issues #2207/#2346)
+        // instead of the full-scan `KWayMerger::new`, which decoded every partition
+        // with token <= the target before reaching it (O(partitions-below-target)).
+        // The seeking merge reconciles through the SAME `KWayMerger`
+        // (`from_row_iterators`), so its output is byte-identical to the former
+        // full-merge-then-`retain(matches_key)`, only over O(target) work.
         #[cfg(feature = "write-support")]
         if candidates.len() > 1 {
             if let Some(schema) = schema {
                 let target = RowKey::new(partition_key.to_vec());
-                match generation_merge::merge_generations_for_read(
+                match generation_merge::seek_merge_generations_for_read(
                     &candidates,
                     schema,
-                    None,
-                    None,
-                    None,
-                    Some(&target),
+                    &target,
                 )
                 .await
                 {

--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -128,6 +128,21 @@ struct Counters {
     /// partition count regardless of how narrow the split range (or `LIMIT`) is —
     /// the fixed multi-second warm-scan setup this counter exists to make visible.
     stream_walk_partitions_parsed: AtomicU64,
+    /// Merge ENTRIES decoded from `Data.db` by a MULTI-candidate point-read merge
+    /// run (Issue #2096). Bumped once per merge entry the reconciliation actually
+    /// materialises out of `Data.db`: on the full-scan run inside
+    /// [`SSTableRowIteratorAdapter`](crate::storage::write_engine::KWayMerger)
+    /// (once per `Ok(entry)` streamed) AND on the seek run's `PathProbe::Seeked`
+    /// arm (once per entry built from a seeked partition).
+    ///
+    /// This makes the merge run's per-partition decode observable, which the
+    /// existing `partitions_decoded` (#953, single-candidate seek only) does not
+    /// cover. A multi-candidate `WHERE pk = ?` that reconciles through the OLD
+    /// full-scan `KWayMerger::new` decodes every partition with token <= the
+    /// target in every generation, so this balloons far past the number of
+    /// candidates holding the key; the partition-SEEKING merger (#2096) decodes
+    /// only the target partition per candidate, so it stays O(target rows).
+    merge_run_partitions_decoded: AtomicU64,
 }
 
 impl Counters {
@@ -142,6 +157,7 @@ impl Counters {
             reverse_peak_block_rows: AtomicU64::new(0),
             data_db_checksum_full_reads: AtomicU64::new(0),
             stream_walk_partitions_parsed: AtomicU64::new(0),
+            merge_run_partitions_decoded: AtomicU64::new(0),
         }
     }
 
@@ -200,6 +216,16 @@ impl Counters {
         self.stream_walk_partitions_parsed.load(Ordering::Relaxed)
     }
 
+    #[cfg(feature = "write-support")]
+    fn add_merge_run_partition_decoded(&self) {
+        self.merge_run_partitions_decoded
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn merge_run_partitions_decoded(&self) -> u64 {
+        self.merge_run_partitions_decoded.load(Ordering::Relaxed)
+    }
+
     fn reverse_blocks_decoded(&self) -> u64 {
         self.reverse_blocks_decoded.load(Ordering::Relaxed)
     }
@@ -238,6 +264,8 @@ impl Counters {
         self.reverse_peak_block_rows.store(0, Ordering::Relaxed);
         self.data_db_checksum_full_reads.store(0, Ordering::Relaxed);
         self.stream_walk_partitions_parsed
+            .store(0, Ordering::Relaxed);
+        self.merge_run_partitions_decoded
             .store(0, Ordering::Relaxed);
     }
 }
@@ -483,6 +511,32 @@ pub(crate) mod stream_walk_scope {
             SCOPED.with(|c| c.set(None));
         }
     }
+}
+
+/// Record that one merge ENTRY was decoded from `Data.db` by a multi-candidate
+/// point-read merge run (Issue #2096). Called once per entry the reconciliation
+/// materialises out of `Data.db`: the full-scan run's per-`Ok(entry)` yield and
+/// the seek run's per-built-entry `PathProbe::Seeked` arm.
+///
+/// Gated on `write-support` because both increment sites live in the k-way
+/// merge machinery, which is only compiled with that feature; the getter and
+/// [`reset`] are available in every build for the test API.
+#[cfg(feature = "write-support")]
+pub(crate) fn add_merge_run_partition_decoded() {
+    COUNTERS.add_merge_run_partition_decoded();
+}
+
+/// Number of merge entries decoded from `Data.db` by multi-candidate point-read
+/// merge runs since the last [`reset`] (Issue #2096).
+///
+/// For a multi-candidate `WHERE pk = ?` this stays O(target rows) once the
+/// partition-SEEKING merger is wired in: only the target partition per candidate
+/// is decoded. A regression that reverts to the full-scan `KWayMerger::new`
+/// merge decodes every partition with token <= the target in every generation,
+/// ballooning this far past the candidate count — which the `issue_2096` bound
+/// test catches.
+pub fn merge_run_partitions_decoded() -> u64 {
+    COUNTERS.merge_run_partitions_decoded()
 }
 
 /// Number of full `Data.db` re-reads performed for checksum computation since

--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -128,21 +128,29 @@ struct Counters {
     /// partition count regardless of how narrow the split range (or `LIMIT`) is —
     /// the fixed multi-second warm-scan setup this counter exists to make visible.
     stream_walk_partitions_parsed: AtomicU64,
-    /// Merge ENTRIES decoded from `Data.db` by a MULTI-candidate point-read merge
-    /// run (Issue #2096). Bumped once per merge entry the reconciliation actually
-    /// materialises out of `Data.db`: on the full-scan run inside
-    /// [`SSTableRowIteratorAdapter`](crate::storage::write_engine::KWayMerger)
-    /// (once per `Ok(entry)` streamed) AND on the seek run's `PathProbe::Seeked`
-    /// arm (once per entry built from a seeked partition).
+    /// Merge ENTRIES decoded from `Data.db` by ANY [`KWayMerger`]-adapter-driven
+    /// run (Issue #2096) — full scans, compaction, AND multi-candidate point
+    /// reads all share the same [`SSTableRowIteratorAdapter`]/`PathProbe::Seeked`
+    /// increment sites, so this counts entries for all of them, not point reads
+    /// alone. Bumped once per merge entry a run actually materialises out of
+    /// `Data.db`: once per `Ok(entry)` streamed on the full-scan adapter run, and
+    /// once per entry built from a seeked partition on the seek run's
+    /// `PathProbe::Seeked` arm. A single partition with N clustering rows bumps
+    /// this N times (an ENTRY-granularity counter, not partition-granularity).
     ///
-    /// This makes the merge run's per-partition decode observable, which the
-    /// existing `partitions_decoded` (#953, single-candidate seek only) does not
-    /// cover. A multi-candidate `WHERE pk = ?` that reconciles through the OLD
+    /// This makes a merge run's decode volume observable, which the existing
+    /// `partitions_decoded` (#953, single-candidate seek only) does not cover.
+    /// For a multi-candidate `WHERE pk = ?` point read specifically: the OLD
     /// full-scan `KWayMerger::new` decodes every partition with token <= the
-    /// target in every generation, so this balloons far past the number of
-    /// candidates holding the key; the partition-SEEKING merger (#2096) decodes
-    /// only the target partition per candidate, so it stays O(target rows).
-    merge_run_partitions_decoded: AtomicU64,
+    /// target in every generation, so the DELTA around that call balloons far
+    /// past the number of candidates holding the key; the partition-SEEKING
+    /// merger (#2096) decodes only the target partition's entries per candidate,
+    /// so its delta stays O(target rows). It is process-global, so a bound
+    /// test's delta assertion around one call is polluted by ANY concurrent
+    /// scan/compaction in the same test binary — callers must `reset()` first
+    /// and serialize (`#[serial_test::serial]`) against other counter-reading
+    /// tests, exactly like the other counters in this file.
+    merge_run_entries_decoded: AtomicU64,
 }
 
 impl Counters {
@@ -157,7 +165,7 @@ impl Counters {
             reverse_peak_block_rows: AtomicU64::new(0),
             data_db_checksum_full_reads: AtomicU64::new(0),
             stream_walk_partitions_parsed: AtomicU64::new(0),
-            merge_run_partitions_decoded: AtomicU64::new(0),
+            merge_run_entries_decoded: AtomicU64::new(0),
         }
     }
 
@@ -217,13 +225,13 @@ impl Counters {
     }
 
     #[cfg(feature = "write-support")]
-    fn add_merge_run_partition_decoded(&self) {
-        self.merge_run_partitions_decoded
+    fn add_merge_run_entry_decoded(&self) {
+        self.merge_run_entries_decoded
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn merge_run_partitions_decoded(&self) -> u64 {
-        self.merge_run_partitions_decoded.load(Ordering::Relaxed)
+    fn merge_run_entries_decoded(&self) -> u64 {
+        self.merge_run_entries_decoded.load(Ordering::Relaxed)
     }
 
     fn reverse_blocks_decoded(&self) -> u64 {
@@ -265,8 +273,7 @@ impl Counters {
         self.data_db_checksum_full_reads.store(0, Ordering::Relaxed);
         self.stream_walk_partitions_parsed
             .store(0, Ordering::Relaxed);
-        self.merge_run_partitions_decoded
-            .store(0, Ordering::Relaxed);
+        self.merge_run_entries_decoded.store(0, Ordering::Relaxed);
     }
 }
 
@@ -513,30 +520,40 @@ pub(crate) mod stream_walk_scope {
     }
 }
 
-/// Record that one merge ENTRY was decoded from `Data.db` by a multi-candidate
-/// point-read merge run (Issue #2096). Called once per entry the reconciliation
-/// materialises out of `Data.db`: the full-scan run's per-`Ok(entry)` yield and
-/// the seek run's per-built-entry `PathProbe::Seeked` arm.
+/// Record that one merge ENTRY was decoded from `Data.db` by ANY
+/// [`KWayMerger`](crate::storage::write_engine::KWayMerger)-adapter-driven run
+/// (Issue #2096) — a full scan, a compaction, OR a multi-candidate point read,
+/// whichever run this increment site's caller is executing. Called once per
+/// entry a run materialises out of `Data.db`: the full-scan adapter's
+/// per-`Ok(entry)` yield and the seek run's per-built-entry `PathProbe::Seeked`
+/// arm. This is an ENTRY-granularity count — a partition with N clustering rows
+/// bumps it N times, not once.
 ///
 /// Gated on `write-support` because both increment sites live in the k-way
 /// merge machinery, which is only compiled with that feature; the getter and
 /// [`reset`] are available in every build for the test API.
 #[cfg(feature = "write-support")]
-pub(crate) fn add_merge_run_partition_decoded() {
-    COUNTERS.add_merge_run_partition_decoded();
+pub(crate) fn add_merge_run_entry_decoded() {
+    COUNTERS.add_merge_run_entry_decoded();
 }
 
-/// Number of merge entries decoded from `Data.db` by multi-candidate point-read
-/// merge runs since the last [`reset`] (Issue #2096).
+/// Number of merge entries decoded from `Data.db` by ANY `KWayMerger`-adapter-
+/// driven run since the last [`reset`] (Issue #2096) — full scans, compaction,
+/// and multi-candidate point reads all share this counter, so it is NOT
+/// point-read-specific. It is process-global: a delta assertion around one call
+/// (e.g. "did this point read stay O(target rows)?") must `reset()` first and
+/// run with no concurrent scan/compaction in the same test binary — serialize
+/// with `#[serial_test::serial]` against other counter-reading tests, exactly
+/// like the other counters in this module.
 ///
-/// For a multi-candidate `WHERE pk = ?` this stays O(target rows) once the
-/// partition-SEEKING merger is wired in: only the target partition per candidate
-/// is decoded. A regression that reverts to the full-scan `KWayMerger::new`
-/// merge decodes every partition with token <= the target in every generation,
-/// ballooning this far past the candidate count — which the `issue_2096` bound
-/// test catches.
-pub fn merge_run_partitions_decoded() -> u64 {
-    COUNTERS.merge_run_partitions_decoded()
+/// For a multi-candidate `WHERE pk = ?` point read specifically, the delta
+/// around that call stays O(target rows) once the partition-SEEKING merger is
+/// wired in: only the target partition's entries per candidate are decoded. A
+/// regression that reverts to the full-scan `KWayMerger::new` merge decodes
+/// every partition with token <= the target in every generation, ballooning the
+/// delta far past the candidate count — which the `issue_2096` bound test catches.
+pub fn merge_run_entries_decoded() -> u64 {
+    COUNTERS.merge_run_entries_decoded()
 }
 
 /// Number of full `Data.db` re-reads performed for checksum computation since

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1179,7 +1179,14 @@ impl SSTableRowIterator for SSTableRowIteratorAdapter {
                 return Some(Err(Error::Cancelled));
             }
             match receiver.recv_timeout(RECV_CANCEL_POLL) {
-                Ok(Ok(entry)) => return Some(Ok(entry)),
+                Ok(Ok(entry)) => {
+                    // Issue #2096: one merge entry decoded from `Data.db` by a
+                    // full-scan run. This is the O(partitions-below-target) signal
+                    // the seeking point-read merger replaces — see
+                    // `work_counters::merge_run_partitions_decoded`.
+                    crate::storage::sstable::work_counters::add_merge_run_partition_decoded();
+                    return Some(Ok(entry));
+                }
                 // Issue #2264: reconstruct `Error::Cancelled` distinctly so a
                 // cancelled scan is never confused with a genuine I/O/corruption
                 // error at the merge/producer boundary — `drive_merge` matches on

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1180,11 +1180,14 @@ impl SSTableRowIterator for SSTableRowIteratorAdapter {
             }
             match receiver.recv_timeout(RECV_CANCEL_POLL) {
                 Ok(Ok(entry)) => {
-                    // Issue #2096: one merge entry decoded from `Data.db` by a
-                    // full-scan run. This is the O(partitions-below-target) signal
-                    // the seeking point-read merger replaces — see
-                    // `work_counters::merge_run_partitions_decoded`.
-                    crate::storage::sstable::work_counters::add_merge_run_partition_decoded();
+                    // Issue #2096: one merge entry decoded from `Data.db` by THIS
+                    // adapter-driven run — a full scan, compaction, or (via the
+                    // fail-safe `SinglePartitionFilterRun`) a point read all share
+                    // this increment site, so `merge_run_entries_decoded` counts
+                    // entries for any of them, not point reads alone. See
+                    // `work_counters::merge_run_entries_decoded`'s doc for the
+                    // process-global caveat when using it as a delta assertion.
+                    crate::storage::sstable::work_counters::add_merge_run_entry_decoded();
                     return Some(Ok(entry));
                 }
                 // Issue #2264: reconstruct `Error::Cancelled` distinctly so a

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -204,9 +204,9 @@ pub fn build_single_partition_merger(
                     // Issue #2096: one merge entry decoded from `Data.db` by the
                     // SEEK path (this candidate held the target partition). Counting
                     // per built entry — the same unit the full-scan run counts per
-                    // `Ok(entry)` — keeps the merge-run decode counter apples-to-
+                    // `Ok(entry)` — keeps `merge_run_entries_decoded` apples-to-
                     // apples between the two paths.
-                    crate::storage::sstable::work_counters::add_merge_run_partition_decoded();
+                    crate::storage::sstable::work_counters::add_merge_run_entry_decoded();
                     entries.push(SSTableRowIteratorAdapter::build_merge_entry(
                         run_index, row, schema,
                     )?);
@@ -299,7 +299,7 @@ pub fn build_single_partition_merger_from_readers(
                     // Issue #2096: one merge entry decoded from `Data.db` by the
                     // SEEK path (this candidate held the target partition), same
                     // accounting as the path-based builder above.
-                    crate::storage::sstable::work_counters::add_merge_run_partition_decoded();
+                    crate::storage::sstable::work_counters::add_merge_run_entry_decoded();
                     entries.push(SSTableRowIteratorAdapter::build_merge_entry(
                         run_index, row, schema,
                     )?);

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -201,6 +201,12 @@ pub fn build_single_partition_merger(
                 }
                 let mut entries: Vec<MergeEntry> = Vec::with_capacity(rows.len());
                 for row in rows {
+                    // Issue #2096: one merge entry decoded from `Data.db` by the
+                    // SEEK path (this candidate held the target partition). Counting
+                    // per built entry — the same unit the full-scan run counts per
+                    // `Ok(entry)` — keeps the merge-run decode counter apples-to-
+                    // apples between the two paths.
+                    crate::storage::sstable::work_counters::add_merge_run_partition_decoded();
                     entries.push(SSTableRowIteratorAdapter::build_merge_entry(
                         run_index, row, schema,
                     )?);
@@ -290,6 +296,10 @@ pub fn build_single_partition_merger_from_readers(
                 }
                 let mut entries: Vec<MergeEntry> = Vec::with_capacity(rows.len());
                 for row in rows {
+                    // Issue #2096: one merge entry decoded from `Data.db` by the
+                    // SEEK path (this candidate held the target partition), same
+                    // accounting as the path-based builder above.
+                    crate::storage::sstable::work_counters::add_merge_run_partition_decoded();
                     entries.push(SSTableRowIteratorAdapter::build_merge_entry(
                         run_index, row, schema,
                     )?);

--- a/cqlite-core/tests/issue_2096_seeking_point_merge_parity.rs
+++ b/cqlite-core/tests/issue_2096_seeking_point_merge_parity.rs
@@ -1,0 +1,433 @@
+//! Issue #2096: the multi-candidate `WHERE pk = ?` point read must SEEK each
+//! candidate directly to the target partition (BTI/Index.db) and reconcile
+//! through the partition-seeking merger, decoding ONLY the target partition per
+//! generation — NOT the former full-scan `KWayMerger::new` that sequentially
+//! decodes every partition with token <= the target before reaching it.
+//!
+//! This file pins two things that must never regress:
+//!
+//! A. **Parity oracle (correctness, non-negotiable)** — the seeking point read
+//!    (`SSTableManager::scan_partition`, the public surface) returns rows
+//!    BYTE-IDENTICAL to the full-scan reconciliation oracle (`scan(..)` retained
+//!    to the target partition) across cross-generation last-write-wins,
+//!    cell/row-tombstone shadowing, AND a partition-tombstone resurrection.
+//!
+//! B. **Work-counter red→green (the headline AC)** — the new
+//!    `work_counters::merge_run_partitions_decoded` counter proves the multi-gen
+//!    point read decodes only the target partition per generation: the OLD
+//!    full-scan merge (exercised here through `scan(..)`, which routes through the
+//!    same `merge_generations_for_read` full-scan `KWayMerger::new`) decodes every
+//!    partition and reads a LARGE count; the NEW seek path reads a SMALL count
+//!    that does not scale with the number of below-target filler partitions.
+//!
+//! Run with:
+//!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!     cargo test --package cqlite-core --features write-support \
+//!     --test issue_2096_seeking_point_merge_parity
+
+#![cfg(all(feature = "write-support", not(feature = "tombstones")))]
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::{work_counters, SSTableManager};
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, PartitionTombstone, TableId, WriteEngine,
+    WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use cqlite_core::{RowKey, ScanRow};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const KS: &str = "seek_ks";
+const TBL: &str = "items";
+
+/// The overwrite + cell-tombstone + row-tombstone target partition.
+const TARGET: i32 = 500;
+/// The partition-tombstone (resurrection) target partition.
+const PTOMB: i32 = 600;
+/// Filler partitions written into gen1 only, so the full-scan merge has many
+/// partitions to decode while the seek touches only the target.
+const FILLER_LO: i32 = 1000;
+const FILLER_HI: i32 = 1025; // exclusive → 25 filler partitions
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "score".to_string(),
+                data_type: "int".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn clustering(ck: i32) -> Option<ClusteringKey> {
+    Some(ClusteringKey::single("ck", Value::Integer(ck)))
+}
+
+fn write_row(id: i32, ck: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![
+        CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        },
+        CellOperation::Write {
+            column: "score".to_string(),
+            value: Value::Integer(score),
+        },
+    ];
+    Mutation::new(TableId::new(KS, TBL), pk, clustering(ck), ops, ts, None)
+}
+
+/// Write only the `name` column at `(id, ck)` — a disjoint overwrite that must
+/// keep the older generation's `score`.
+fn write_name_only(id: i32, ck: i32, name: &str, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value: Value::Text(name.to_string()),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, clustering(ck), ops, ts, None)
+}
+
+fn delete_row(id: i32, ck: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    Mutation::new(
+        TableId::new(KS, TBL),
+        pk,
+        clustering(ck),
+        vec![CellOperation::DeleteRow],
+        ts,
+        None,
+    )
+}
+
+fn delete_score(id: i32, ck: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Delete {
+        column: "score".to_string(),
+        local_deletion_time: None,
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, clustering(ck), ops, ts, None)
+}
+
+/// A mutation whose only effect is a partition-level tombstone on `id`.
+fn partition_delete(id: i32, deletion_micros: i64, local_secs: i32) -> Mutation {
+    let mut m = Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![],
+        deletion_micros,
+        None,
+    );
+    m.partition_tombstone = Some(PartitionTombstone {
+        deletion_time: deletion_micros,
+        local_deletion_time: local_secs,
+    });
+    m
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with("-Data.db"))
+        .count()
+}
+
+/// Build the 3-generation, clustering-keyed multi-candidate fixture and return
+/// its data dir. No compaction runs, so all three generations stay on disk.
+fn build_fixture(data_dir: &std::path::Path, wal_dir: &std::path::Path, schema: &TableSchema) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let config = WriteEngineConfig::new(data_dir.to_path_buf(), wal_dir.to_path_buf(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // ── Gen 1 (ts=100): base state ────────────────────────────────────────────
+    // TARGET: three clustering rows.
+    engine.write(write_row(TARGET, 1, "a1", 10, 100)).unwrap();
+    engine.write(write_row(TARGET, 2, "b1", 20, 100)).unwrap();
+    engine.write(write_row(TARGET, 3, "c1", 30, 100)).unwrap();
+    // PTOMB: one clustering row that a later partition tombstone shadows.
+    engine.write(write_row(PTOMB, 1, "p_old", 1, 100)).unwrap();
+    // Many filler partitions — the below/above-target partitions the OLD
+    // sequential merge walks past.
+    for id in FILLER_LO..FILLER_HI {
+        engine.write(write_row(id, 1, "filler", id, 100)).unwrap();
+    }
+    rt.block_on(engine.flush()).expect("flush 1").expect("gen1");
+
+    // ── Gen 2 (ts=200): overwrite + partition tombstone ───────────────────────
+    // TARGET ck=1: disjoint name-only overwrite (score=10 from gen1 must survive).
+    engine.write(write_name_only(TARGET, 1, "a2", 200)).unwrap();
+    // PTOMB: partition tombstone @200µs shadows gen1's ck=1 (writetime 100).
+    engine.write(partition_delete(PTOMB, 200, 200)).unwrap();
+    rt.block_on(engine.flush()).expect("flush 2").expect("gen2");
+
+    // ── Gen 3 (ts=300): tombstones + resurrection ─────────────────────────────
+    // TARGET ck=2: row tombstone shadowing gen1's whole row.
+    engine.write(delete_row(TARGET, 2, 300)).unwrap();
+    // TARGET ck=3: cell tombstone on `score` (name survives).
+    engine.write(delete_score(TARGET, 3, 300)).unwrap();
+    // PTOMB ck=1: resurrecting write (writetime 300 > partition tombstone 200).
+    engine.write(write_row(PTOMB, 1, "p_new", 9, 300)).unwrap();
+    rt.block_on(engine.flush()).expect("flush 3").expect("gen3");
+
+    rt.block_on(engine.close()).expect("close engine");
+}
+
+fn open_manager(data_dir: &std::path::Path) -> (SSTableManager, tokio::runtime::Runtime) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager open")
+    });
+    (manager, rt)
+}
+
+fn pk(id: i32) -> Vec<u8> {
+    id.to_be_bytes().to_vec()
+}
+
+fn col<'a>(row: &'a ScanRow, name: &str) -> Option<&'a Value> {
+    match row {
+        ScanRow::Row(cells) => cells
+            .iter()
+            .find_map(|(k, v)| if k.as_ref() == name { Some(v) } else { None }),
+        _ => None,
+    }
+}
+
+/// A. Parity + C. Wiring: the public seeking point read is byte-identical to the
+/// full-scan reconciliation oracle for BOTH the overwrite/tombstone target and
+/// the partition-tombstone (resurrection) partition.
+#[test]
+fn seeking_point_read_is_byte_identical_to_full_scan_oracle() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+    build_fixture(&data_dir, &wal_dir, &schema);
+
+    let sstable_dir = data_dir.join(KS).join(TBL);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        3,
+        "fixture must exercise a 3-generation directory (multi-candidate merge)"
+    );
+
+    let (manager, rt) = open_manager(&data_dir);
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+
+    // Full-scan reconciliation oracle: the authoritative merged table state.
+    let full = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("full scan must not error");
+
+    for target in [TARGET, PTOMB] {
+        let oracle: Vec<(RowKey, ScanRow)> = full
+            .iter()
+            .filter(|(k, _)| k.as_bytes() == pk(target))
+            .cloned()
+            .collect();
+
+        // The NEW seeking public surface (issue #2096) — wiring evidence (C).
+        let (seek, engaged) = rt
+            .block_on(manager.scan_partition(&table_id, &pk(target), Some(&schema)))
+            .expect("scan_partition must not error");
+        assert!(engaged, "scan_partition always reports the partition-targeted path");
+
+        assert_eq!(
+            seek, oracle,
+            "seeking point read for id={target} must be BYTE-IDENTICAL to the full-scan \
+             reconciliation oracle (cross-generation LWW / tombstone / partition-tombstone \
+             semantics must not diverge)"
+        );
+        assert!(
+            !oracle.is_empty(),
+            "id={target} must have surviving reconciled rows (a 0-row parity is a false pass)"
+        );
+    }
+
+    // Spot-check the reconciled semantics themselves so the parity oracle above is
+    // not vacuously comparing two identically-wrong results.
+    let target_rows: Vec<&(RowKey, ScanRow)> =
+        full.iter().filter(|(k, _)| k.as_bytes() == pk(TARGET)).collect();
+    assert_eq!(
+        target_rows.len(),
+        2,
+        "TARGET keeps ck=1 (overwrite) + ck=3 (cell-tombstoned score); ck=2 row-deleted"
+    );
+    // ck=1 overwrite: gen2 name wins, gen1 score survives (disjoint merge).
+    let r1 = &target_rows[0].1;
+    assert_eq!(col(r1, "name"), Some(&Value::Text("a2".to_string())));
+    assert_eq!(col(r1, "score"), Some(&Value::Integer(10)));
+    // ck=3 cell tombstone: name survives, score gone.
+    let r3 = &target_rows[1].1;
+    assert_eq!(col(r3, "name"), Some(&Value::Text("c1".to_string())));
+    assert!(col(r3, "score").is_none(), "score cell-deleted in gen3");
+
+    // PTOMB: only the resurrecting gen3 row survives the gen2 partition tombstone.
+    let ptomb_rows: Vec<&(RowKey, ScanRow)> =
+        full.iter().filter(|(k, _)| k.as_bytes() == pk(PTOMB)).collect();
+    assert_eq!(ptomb_rows.len(), 1, "PTOMB keeps only the resurrecting gen3 row");
+    let rp = &ptomb_rows[0].1;
+    assert_eq!(
+        col(rp, "name"),
+        Some(&Value::Text("p_new".to_string())),
+        "gen1 row must stay shadowed by the partition tombstone; gen3 resurrects"
+    );
+    assert_eq!(col(rp, "score"), Some(&Value::Integer(9)));
+
+    drop(temp_dir);
+}
+
+/// B. Work-counter red→green: the multi-candidate point read decodes ONLY the
+/// target partition per generation. The OLD full-scan merge (exercised via the
+/// full `scan(..)`, which routes through the same `KWayMerger::new`) decodes
+/// every partition and reads a LARGE `merge_run_partitions_decoded`; the NEW
+/// seek path reads a SMALL count that does not scale with the filler count.
+///
+/// Process-global counters: `#[serial]` + a `reset()` before each measured scan
+/// keeps the deltas uncontaminated by any concurrent scan-driving test.
+#[test]
+#[serial_test::serial(work_counters)]
+fn seeking_point_read_decodes_only_the_target_partition() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+    build_fixture(&data_dir, &wal_dir, &schema);
+
+    let (manager, rt) = open_manager(&data_dir);
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+
+    // TARGET / PTOMB each live in all three generations → 3 candidates hold them.
+    const CANDIDATES_HOLDING_TARGET: u64 = 3;
+    // Total partitions on disk (25 fillers + TARGET + PTOMB). The OLD full-scan
+    // merge decodes at least this many entries.
+    let n_partitions = (FILLER_HI - FILLER_LO) as u64 + 2;
+
+    // ── RED proof: the OLD full-scan merge decodes every partition ─────────────
+    work_counters::reset();
+    let _ = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("full scan must not error");
+    let counter_full = work_counters::merge_run_partitions_decoded();
+    assert!(
+        counter_full >= n_partitions,
+        "full-scan merge must decode at least one entry per partition (got {counter_full}, \
+         expected >= {n_partitions}) — the O(all partitions) path #2096 replaces"
+    );
+
+    // ── GREEN: the NEW seek path decodes only the target partition ─────────────
+    work_counters::reset();
+    let (seek_target, _) = rt
+        .block_on(manager.scan_partition(&table_id, &pk(TARGET), Some(&schema)))
+        .expect("scan_partition must not error");
+    let counter_seek_target = work_counters::merge_run_partitions_decoded();
+    assert!(
+        !seek_target.is_empty(),
+        "TARGET seek must return rows (guards against a 0-row false pass)"
+    );
+
+    work_counters::reset();
+    let (seek_ptomb, _) = rt
+        .block_on(manager.scan_partition(&table_id, &pk(PTOMB), Some(&schema)))
+        .expect("scan_partition must not error");
+    let counter_seek_ptomb = work_counters::merge_run_partitions_decoded();
+    assert!(!seek_ptomb.is_empty(), "PTOMB seek must return rows");
+
+    // The seek decodes at least one entry per candidate holding the key ...
+    assert!(
+        counter_seek_target >= CANDIDATES_HOLDING_TARGET,
+        "the seek decodes >= 1 entry per candidate holding TARGET (got {counter_seek_target}, \
+         expected >= {CANDIDATES_HOLDING_TARGET})"
+    );
+    // ... and stays O(target rows): a small constant independent of the filler
+    // count, decisively below the full-scan count. The TARGET partition holds at
+    // most ~6 merge entries across the three generations (3 gen1 rows + 1 gen2
+    // overwrite + 2 gen3 tombstones); PTOMB fewer. `2 * CANDIDATES...` headroom
+    // keeps the bound robust without weakening the O(target) guarantee.
+    const SEEK_UPPER_BOUND: u64 = 4 * CANDIDATES_HOLDING_TARGET; // 12
+    assert!(
+        counter_seek_target <= SEEK_UPPER_BOUND,
+        "seeking TARGET read must stay O(target rows) (got {counter_seek_target}, bound \
+         {SEEK_UPPER_BOUND}); a regression to the full-scan merge would balloon this toward \
+         {counter_full}"
+    );
+    assert!(
+        counter_seek_ptomb <= SEEK_UPPER_BOUND,
+        "seeking PTOMB read must stay O(target rows) (got {counter_seek_ptomb}, bound \
+         {SEEK_UPPER_BOUND})"
+    );
+    // The essential red→green relationship: the seek decodes strictly, decisively
+    // fewer entries than the OLD full-scan merge on the SAME fixture.
+    assert!(
+        counter_seek_target < counter_full,
+        "seek ({counter_seek_target}) must decode strictly fewer entries than the full-scan \
+         merge ({counter_full})"
+    );
+
+    drop(temp_dir);
+}

--- a/cqlite-core/tests/issue_2096_seeking_point_merge_parity.rs
+++ b/cqlite-core/tests/issue_2096_seeking_point_merge_parity.rs
@@ -188,7 +188,11 @@ fn build_fixture(data_dir: &std::path::Path, wal_dir: &std::path::Path, schema: 
         .build()
         .expect("tokio runtime");
 
-    let config = WriteEngineConfig::new(data_dir.to_path_buf(), wal_dir.to_path_buf(), schema.clone());
+    let config = WriteEngineConfig::new(
+        data_dir.to_path_buf(),
+        wal_dir.to_path_buf(),
+        schema.clone(),
+    );
     let mut engine = WriteEngine::new(config).expect("engine creation");
 
     // ── Gen 1 (ts=100): base state ────────────────────────────────────────────
@@ -251,9 +255,11 @@ fn pk(id: i32) -> Vec<u8> {
 
 fn col<'a>(row: &'a ScanRow, name: &str) -> Option<&'a Value> {
     match row {
-        ScanRow::Row(cells) => cells
-            .iter()
-            .find_map(|(k, v)| if k.as_ref() == name { Some(v) } else { None }),
+        ScanRow::Row(cells) => {
+            cells
+                .iter()
+                .find_map(|(k, v)| if k.as_ref() == name { Some(v) } else { None })
+        }
         _ => None,
     }
 }
@@ -300,7 +306,10 @@ fn seeking_point_read_is_byte_identical_to_full_scan_oracle() {
         let (seek, engaged) = rt
             .block_on(manager.scan_partition(&table_id, &pk(target), Some(&schema)))
             .expect("scan_partition must not error");
-        assert!(engaged, "scan_partition always reports the partition-targeted path");
+        assert!(
+            engaged,
+            "scan_partition always reports the partition-targeted path"
+        );
 
         assert_eq!(
             seek, oracle,
@@ -316,8 +325,10 @@ fn seeking_point_read_is_byte_identical_to_full_scan_oracle() {
 
     // Spot-check the reconciled semantics themselves so the parity oracle above is
     // not vacuously comparing two identically-wrong results.
-    let target_rows: Vec<&(RowKey, ScanRow)> =
-        full.iter().filter(|(k, _)| k.as_bytes() == pk(TARGET)).collect();
+    let target_rows: Vec<&(RowKey, ScanRow)> = full
+        .iter()
+        .filter(|(k, _)| k.as_bytes() == pk(TARGET))
+        .collect();
     assert_eq!(
         target_rows.len(),
         2,
@@ -333,9 +344,15 @@ fn seeking_point_read_is_byte_identical_to_full_scan_oracle() {
     assert!(col(r3, "score").is_none(), "score cell-deleted in gen3");
 
     // PTOMB: only the resurrecting gen3 row survives the gen2 partition tombstone.
-    let ptomb_rows: Vec<&(RowKey, ScanRow)> =
-        full.iter().filter(|(k, _)| k.as_bytes() == pk(PTOMB)).collect();
-    assert_eq!(ptomb_rows.len(), 1, "PTOMB keeps only the resurrecting gen3 row");
+    let ptomb_rows: Vec<&(RowKey, ScanRow)> = full
+        .iter()
+        .filter(|(k, _)| k.as_bytes() == pk(PTOMB))
+        .collect();
+    assert_eq!(
+        ptomb_rows.len(),
+        1,
+        "PTOMB keeps only the resurrecting gen3 row"
+    );
     let rp = &ptomb_rows[0].1;
     assert_eq!(
         col(rp, "name"),

--- a/cqlite-core/tests/issue_2096_seeking_point_merge_parity.rs
+++ b/cqlite-core/tests/issue_2096_seeking_point_merge_parity.rs
@@ -13,7 +13,7 @@
 //!    cell/row-tombstone shadowing, AND a partition-tombstone resurrection.
 //!
 //! B. **Work-counter red→green (the headline AC)** — the new
-//!    `work_counters::merge_run_partitions_decoded` counter proves the multi-gen
+//!    `work_counters::merge_run_entries_decoded` counter proves the multi-gen
 //!    point read decodes only the target partition per generation: the OLD
 //!    full-scan merge (exercised here through `scan(..)`, which routes through the
 //!    same `merge_generations_for_read` full-scan `KWayMerger::new`) decodes every
@@ -268,7 +268,7 @@ fn col<'a>(row: &'a ScanRow, name: &str) -> Option<&'a Value> {
 /// full-scan reconciliation oracle for BOTH the overwrite/tombstone target and
 /// the partition-tombstone (resurrection) partition.
 // `#[serial(work_counters)]`: this test drives scans that bump the process-global
-// `merge_run_partitions_decoded`, so it must never run concurrently (in this test
+// `merge_run_entries_decoded`, so it must never run concurrently (in this test
 // binary) with the counter-asserting test below, whose `reset()`→scan→read delta
 // would otherwise be contaminated (issue #2428 contamination shape).
 #[test]
@@ -367,7 +367,7 @@ fn seeking_point_read_is_byte_identical_to_full_scan_oracle() {
 /// B. Work-counter red→green: the multi-candidate point read decodes ONLY the
 /// target partition per generation. The OLD full-scan merge (exercised via the
 /// full `scan(..)`, which routes through the same `KWayMerger::new`) decodes
-/// every partition and reads a LARGE `merge_run_partitions_decoded`; the NEW
+/// every partition and reads a LARGE `merge_run_entries_decoded`; the NEW
 /// seek path reads a SMALL count that does not scale with the filler count.
 ///
 /// Process-global counters: `#[serial]` + a `reset()` before each measured scan
@@ -395,7 +395,7 @@ fn seeking_point_read_decodes_only_the_target_partition() {
     let _ = rt
         .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
         .expect("full scan must not error");
-    let counter_full = work_counters::merge_run_partitions_decoded();
+    let counter_full = work_counters::merge_run_entries_decoded();
     assert!(
         counter_full >= n_partitions,
         "full-scan merge must decode at least one entry per partition (got {counter_full}, \
@@ -407,7 +407,7 @@ fn seeking_point_read_decodes_only_the_target_partition() {
     let (seek_target, _) = rt
         .block_on(manager.scan_partition(&table_id, &pk(TARGET), Some(&schema)))
         .expect("scan_partition must not error");
-    let counter_seek_target = work_counters::merge_run_partitions_decoded();
+    let counter_seek_target = work_counters::merge_run_entries_decoded();
     assert!(
         !seek_target.is_empty(),
         "TARGET seek must return rows (guards against a 0-row false pass)"
@@ -417,7 +417,7 @@ fn seeking_point_read_decodes_only_the_target_partition() {
     let (seek_ptomb, _) = rt
         .block_on(manager.scan_partition(&table_id, &pk(PTOMB), Some(&schema)))
         .expect("scan_partition must not error");
-    let counter_seek_ptomb = work_counters::merge_run_partitions_decoded();
+    let counter_seek_ptomb = work_counters::merge_run_entries_decoded();
     assert!(!seek_ptomb.is_empty(), "PTOMB seek must return rows");
 
     // The seek decodes at least one entry per candidate holding the key ...

--- a/cqlite-core/tests/issue_2096_seeking_point_merge_parity.rs
+++ b/cqlite-core/tests/issue_2096_seeking_point_merge_parity.rs
@@ -261,7 +261,12 @@ fn col<'a>(row: &'a ScanRow, name: &str) -> Option<&'a Value> {
 /// A. Parity + C. Wiring: the public seeking point read is byte-identical to the
 /// full-scan reconciliation oracle for BOTH the overwrite/tombstone target and
 /// the partition-tombstone (resurrection) partition.
+// `#[serial(work_counters)]`: this test drives scans that bump the process-global
+// `merge_run_partitions_decoded`, so it must never run concurrently (in this test
+// binary) with the counter-asserting test below, whose `reset()`→scan→read delta
+// would otherwise be contaminated (issue #2428 contamination shape).
 #[test]
+#[serial_test::serial(work_counters)]
 fn seeking_point_read_is_byte_identical_to_full_scan_oracle() {
     let temp_dir = TempDir::new().unwrap();
     let data_dir = temp_dir.path().join("data");


### PR DESCRIPTION
Closes #2096 (D3 follow-up, epic D #1516 read-path audit).

## What
`SSTableManager::scan_partition_clustering`'s multi-candidate `WHERE pk = ?` branch reconciled through a **full-scan** `KWayMerger` (`generation_merge::merge_generations_for_read(.., Some(target))`), which sequentially DECODED every partition with token <= the target's token in each candidate generation before reaching it and breaking — O(partitions-below-target), not O(target).

This wires that branch to the partition-**seeking** merger already built for cqlite-flight's point path (`build_single_partition_merger_from_readers`, issues #2207/#2346): each candidate is seeked directly to the target partition's `Data.db` offset via the BTI trie / `Index.db` (or fail-safe filter-scans a single SSTable when its index is unavailable), and the seeked runs reconcile through the SAME `KWayMerger` (`from_row_iterators`) — run_index = candidate position, identical LWW tie-break rank to the full-scan path.

- `cqlite-core/src/storage/sstable/generation_merge.rs`: new `seek_merge_generations_for_read`, gated `#[cfg(all(feature = "write-support", not(feature = "tombstones")))]`. Applies the IDENTICAL read-visibility kernel as the materializing helper (`ReadShadow::new(&schema, now_epoch_secs())`, `partition_live_rows`, final `scan_merge::sort_by_token_order`), candidates ordered NEWEST→OLDEST to match `ordered_generation_paths`.
- `cqlite-core/src/storage/sstable/mod.rs`: the multi-candidate point-read branch now calls the seek helper; cfg mirrored to the callee (`not(feature = "tombstones")`) so `write-support,tombstones` still compiles. Work-counter accounting (`add_sstables_scanned`/`add_partitions_parsed`) and the `Err`→concat fallback are unchanged.
- `cqlite-core/src/storage/sstable/work_counters.rs` + `write_engine/merge/{mod.rs,point_read.rs}`: new `merge_run_entries_decoded` counter (renamed post-review from `merge_run_partitions_decoded` — it counts merge ENTRIES from ANY adapter-driven merge run, not partitions, not point-reads-only; doc corrected).
- Out of scope (documented, unchanged): the WRITETIME/TTL metadata point-read path (`merge_generations_for_read_with_metadata`, issue #962) keeps its existing within-partition full-decode; a metadata seek is a separate follow-up.

## Evidence
- **Parity oracle (non-negotiable)**: 3-generation fixture (clustering keys, overwrite, cell tombstone, row tombstone, partition-tombstone resurrection, plus filler partitions with tokens both below and above target) — the new seeking path's `scan_partition(target)` is byte-identical to the old materializing-merge oracle for every case.
- **Work-counter red→green** (`merge_run_entries_decoded`): OLD sequential point-read path (reverted for the red-proof sibling assertion) reads 18/31 entries on the two fixtures — exceeds the O(target) bound. NEW seeking path reads 6/3 entries — within bound, well under the full-scan's 34.
- **Reconciliation suites green locally**: issue_883, issue_885_cross_generation_metadata_merge, issue_957_metadata_range_bound_parity, issue_957_streaming_materializing_parity, issue_958_partition_lookup_work_bound, issue_955_multi_partition_lookup_parity(+work_bound), issue_962_metadata_partition_lookup_parity (unchanged path, still green), issue_953_seek_window_bound.
- **Wiring evidence**: assertions drive the public `SSTableManager::scan_partition(table_id, partition_key, Some(schema))` surface, not just the `generation_merge` helper directly.

## Review
- rust-reviewer: no blockers (2 nits — counter doc precision, minor hot-path perf note).
- roborev (3 commits reviewed): no blockers — 2 shared Low findings (cfg-gate asymmetry write-support+tombstones; counter name/scope), both fixed mechanically in `0e7c049` (rename + cfg mirror; no logic/threshold change). Confirmed locally: `cargo check -p cqlite-core --features write-support,tombstones` and `--no-default-features` both compile clean.
- Lite PASS @ `0e7c049` (fmt/clippy/scoped-tests). Full gate + C + final roborev pass to run once via `flow-closer` before merge.