### PR TITLE
fix(#2167): restore compressed CHUNK_READ_CALLS increment + observability nits

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/chunk_cache_wiring_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/chunk_cache_wiring_tests.rs
@@ -74,6 +74,35 @@ fn uncompressed_data_db() -> Option<PathBuf> {
     None
 }
 
+/// Locate `test_comp.lz4_table`'s Data.db — a COMPRESSED BIG (`nb`) table, so
+/// `get_cached_data` routes through `read_compressed_offset_window` (CRC-validated,
+/// issue #1773). The wiring evidence is the same `CHUNK_READ_CALLS` counter, which
+/// the compressed branch must increment (issue #2167).
+fn compressed_data_db() -> Option<PathBuf> {
+    let base = datasets_root()?.join("sstables/test_comp");
+    let rd = std::fs::read_dir(&base).ok()?;
+    for entry in rd.flatten() {
+        let name = entry.file_name();
+        let name = name.to_str()?;
+        if name.starts_with("lz4_table-") {
+            let dir = entry.path();
+            if let Ok(files) = std::fs::read_dir(&dir) {
+                for f in files.flatten() {
+                    let p = f.path();
+                    if p.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|n| n.ends_with("-Data.db"))
+                        .unwrap_or(false)
+                    {
+                        return Some(p);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 async fn open(path: &std::path::Path) -> SSTableReader {
     let config = Config::default();
     let platform = Arc::new(Platform::new(&config).await.expect("platform init"));
@@ -165,5 +194,62 @@ async fn big_point_read_get_cached_data_is_wired() {
         format!("{cold:?}"),
         format!("{warm:?}"),
         "cache MUST NOT change the read result"
+    );
+}
+
+/// Issue #2167 (a): the COMPRESSED offset-read branch of `get_cached_data` must
+/// increment `CHUNK_READ_CALLS` too, so compressed-table read observability does not
+/// underreport. The #1773 CRC fix moved the read into `read_compressed_offset_window`
+/// and dropped the increment; this pins it back.
+///
+/// FAILS on pre-fix code: a compressed cold read leaves `CHUNK_READ_CALLS` at 0, so
+/// the `>= 1` assertion below trips. The warm read still leaves it unchanged (the
+/// increment sits after the shared-cache check, so a cached repeat does no backing read).
+#[tokio::test]
+#[serial_test::serial]
+async fn big_point_read_compressed_increments_chunk_read_calls() {
+    let Some(data_db) = compressed_data_db() else {
+        assert!(
+            !require_fixtures(),
+            "CQLITE_REQUIRE_FIXTURES=1 but test_comp.lz4_table is absent"
+        );
+        eprintln!("SKIP: test_comp.lz4_table absent — cannot prove compressed CHUNK_READ_CALLS");
+        return;
+    };
+
+    let reader = open(&data_db).await;
+    // Offset 0, 16 bytes lands wholly inside compressed chunk 0 of the single-partition
+    // lz4_table — the same clean window the #1773 offset-read test decodes successfully.
+    let (offset, size) = (0u64, 16u32);
+
+    // Cold read: cache miss → the compressed branch performs a real backing read and
+    // must bump the counter.
+    SSTableReader::reset_chunk_read_calls();
+    let cold = reader
+        .read_value_at_offset(offset, size)
+        .await
+        .expect("cold compressed offset read");
+    let cold_reads = SSTableReader::chunk_read_call_count();
+    assert!(
+        cold_reads >= 1,
+        "compressed cold read must increment CHUNK_READ_CALLS (issue #2167), got {cold_reads}"
+    );
+
+    // Warm read: identical offset → cache hit, ZERO further backing reads (the
+    // increment is gated behind the cache check), identical result.
+    SSTableReader::reset_chunk_read_calls();
+    let warm = reader
+        .read_value_at_offset(offset, size)
+        .await
+        .expect("warm compressed offset read");
+    assert_eq!(
+        SSTableReader::chunk_read_call_count(),
+        0,
+        "warm compressed read must perform ZERO further backing reads (cache hit)"
+    );
+    assert_eq!(
+        format!("{cold:?}"),
+        format!("{warm:?}"),
+        "cache MUST NOT change the compressed read result"
     );
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
@@ -147,6 +147,13 @@ pub(super) fn read_compressed_offset_window_impl(
             super::model::DECOMPRESS_CALLS.fetch_add(1, Ordering::Relaxed);
             out
         } else {
+            // No compression reader (should not happen: this path is only reached
+            // for a compressed Data.db, which always carries one). Mirror
+            // `stitch_all_chunks`' warn! (issue #2167) so an unexpected reach —
+            // returning still-compressed bytes as if plaintext — is visible in logs.
+            tracing::warn!(
+                "read_compressed_offset_window: No compression reader, using raw chunk data"
+            );
             compressed
         };
         assembled.extend_from_slice(&decompressed);

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -633,13 +633,13 @@ impl SSTableReader {
 
         // Produce the final DECOMPRESSED, integrity-verified window for this offset.
         let data = if let Some(comp_info) = self.compression_info.as_deref() {
-            // COMPRESSED offset read (issue #1773): the authoritative inline per-chunk
-            // CRC32 MUST be validated before decompression. `read_compressed_offset_window`
-            // reuses the shared CRC-enforcing chunk reader (multi-chunk assembly,
-            // fail-closed past-EOF) rather than reading `size` raw bytes and blindly
-            // LZ4-decoding them — the latter re-introduced the exact #1411 CRC bypass.
-            // Its single decompress resolves inside `ChunkSource` (issue #1598, G2), so
-            // this is NOT a second decode plane.
+            // COMPRESSED offset read (issue #1773): validate the inline per-chunk CRC32
+            // before decompression via the shared CRC-enforcing chunk reader (multi-chunk
+            // assembly, fail-closed past-EOF), NOT a raw read + blind LZ4 decode (#1411);
+            // the single decompress resolves inside `ChunkSource` (#1598). Count one
+            // backing read HERE (point-read site only), symmetric with the uncompressed
+            // branch below (#2167) — scan callers of the shared helper must NOT bump it.
+            model::CHUNK_READ_CALLS.fetch_add(1, Ordering::Relaxed);
             self.read_compressed_offset_window(comp_info, block_offset, size)
                 .await?
         } else {

--- a/cqlite-core/tests/issue_1773_compressed_offset_crc.rs
+++ b/cqlite-core/tests/issue_1773_compressed_offset_crc.rs
@@ -51,6 +51,12 @@ const CLEAN_DATA_DB: &str =
 /// partition of `lz4_table`). The exact window is immaterial: chunk 0's inline CRC
 /// covers the whole chunk, so any read touching it must validate that CRC.
 const CHUNK0_OFFSET: u64 = 0;
+// 16 bytes is a "non-tombstone" window for this path: the offset-read path wraps the
+// bytes as `ScanRow::RawRow` (issue #1334), which `filter_tombstone` keeps
+// unconditionally (it suppresses only a `ScanRow::Marker` row-tombstone) — the raw
+// bytes are never parsed into a tombstone marker. So a clean read surfaces as
+// `Ok(Some(_))` regardless of the 16 bytes' content; the size only has to be non-zero
+// and land inside chunk 0.
 const CHUNK0_SIZE: u32 = 16;
 
 /// `true` when the full-dataset/nightly lanes demand the corpus be present.


### PR DESCRIPTION
Closes #2167.

Follow-ups batched from the roborev review of PR #2154 (issue #1773, compressed offset-read CRC fix). All polish/observability; none block behavior.

## (a) Restore compressed `CHUNK_READ_CALLS` increment
The #1773 CRC fix moved the compressed point-read backing read into `read_compressed_offset_window` and dropped the `CHUNK_READ_CALLS` bump, so compressed-table read observability underreported. The increment is restored in `get_cached_data`'s compressed branch — the **point-read site only** (`data_access/mod.rs`), symmetric with the uncompressed branch and placed **after** the shared-cache check so a warm/cached repeat read still does zero backing reads.

It is deliberately **not** placed inside `read_compressed_offset_window`: that helper is also called from the scan paths (`summary_scan`, `full_index_scan`, `full_index_stream`), whose uncompressed counterparts do not bump this point-read counter. (Review-first caught this over-reach — see below.)

Pinned by a new in-crate `#[serial]` wiring test `big_point_read_compressed_increments_chunk_read_calls` on `test_comp.lz4_table` — proven TDD-meaningful (fails pre-fix with `got 0`).

## (b) Matching `warn!` on the unreachable `compression_reader = None` branch
`read_compressed_offset_window`'s else-branch returned still-compressed bytes with no log, unlike sibling `stitch_all_chunks`. Added a mirrored `tracing::warn!` (identical wording modulo the function-name prefix) so an unexpected reach is visible.

## (c) Comment: why `CHUNK0_SIZE = 16` is a non-tombstone window
Explained in the #1773 test: the offset-read path emits `ScanRow::RawRow`, which `filter_tombstone` keeps unconditionally (it suppresses only a `ScanRow::Marker` row-tombstone) — so a clean read always surfaces `Ok(Some(_))` regardless of the 16 bytes' content.

## Verification / review
- Lite gate PASS (file-size / fmt / clippy `-D warnings` / scoped-tests).
- Review-first: rust-reviewer APPROVE; roborev initially flagged a Medium (increment in the shared helper over-reaching to scan callers) — fixed by moving it to the point-read site; **roborev re-review: "No issues found."**
- Full `agent-gate.sh` of record runs pre-merge (flow-closer).

Scope: exactly the 3 items above + the verification test. No production behavior change beyond the counter increment.
