### PR TITLE
fix(#2319): reuse aligned bounce buffer across Direct I/O windowed-scan chunk reads

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/read_at.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at.rs
@@ -433,15 +433,27 @@ impl DirectReadAt {
             .checked_next_multiple_of(DIRECT_IO_ALIGN)
             .unwrap_or(usize::MAX & !(DIRECT_IO_ALIGN - 1));
         // Reuse the slot's buffer when it is already large enough; otherwise
-        // (re)allocate to `aligned_len` and keep it for subsequent reads. `pread`
-        // fills only the aligned span we ask for, so a larger reused buffer is
-        // fine — we read into its leading `aligned_len` bytes.
+        // (re)allocate and keep it for subsequent reads. `pread` fills only the
+        // aligned span we ask for, so a larger reused buffer is fine — we read into
+        // its leading `aligned_len` bytes.
+        //
+        // Grow GEOMETRICALLY (issue #2319 MEDIUM): a grow-to-exact `aligned_len`
+        // reallocated on EVERY chunk whose aligned span exceeded the previous one —
+        // for a windowed scan over progressively larger records that meant a realloc
+        // per chunk, defeating the reuse this issue restores. Doubling the previous
+        // capacity (bounded below by the required `aligned_len`) stabilizes the
+        // buffer after a few growths. Both operands are multiples of
+        // `DIRECT_IO_ALIGN` (`aligned_len` via `next_multiple_of`; a prior capacity
+        // was itself allocated as such a multiple), so `new_cap` stays a 4096
+        // multiple and the `O_DIRECT` alignment rule holds.
         let need_alloc = bounce
             .as_ref()
             .map(|b| b.capacity() < aligned_len)
             .unwrap_or(true);
         if need_alloc {
-            *bounce = Some(AlignedBuf::new(aligned_len, DIRECT_IO_ALIGN)?);
+            let old_cap = bounce.as_ref().map(AlignedBuf::capacity).unwrap_or(0);
+            let new_cap = aligned_len.max(old_cap.saturating_mul(2));
+            *bounce = Some(AlignedBuf::new(new_cap, DIRECT_IO_ALIGN)?);
         }
         // SAFETY of unwrap avoidance: `bounce` is `Some` here (just set, or already
         // large enough). Match to keep the no-`unwrap` rule in library code.
@@ -769,20 +781,41 @@ mod tests {
     /// buffer across chunk reads instead of allocating a fresh ~chunk-sized aligned
     /// buffer per read (the per-chunk-alloc regression #1940 introduced).
     ///
-    /// This asserts the ALLOCATION BEHAVIOUR of the code path — the pure user-space
-    /// alignment + bounce-buffer logic — so it needs NO working `O_DIRECT` syscall
+    /// This asserts the ALLOCATION BEHAVIOUR of the code path -- the pure user-space
+    /// alignment + bounce-buffer logic -- so it needs NO working `O_DIRECT` syscall
     /// (frequently unavailable on macOS/tmpfs/CI; probing it live is what stalled a
     /// prior implementer). `DirectReadAt::from_plain_fd_for_test` runs that exact
     /// path over a regular fd; the bounce buffer, alignment math, and reuse decision
     /// are identical whether or not the fd was opened with direct I/O.
     ///
-    /// Contrast proves the fix AND the pre-fix regression in one test:
+    /// The three scenarios live in ONE `#[test]` function on purpose: they share the
+    /// process-global [`ALIGNED_BUF_ALLOCS`] counter (serialized on `aligned_buf_allocs`)
+    /// and folding them here keeps the crate's test-function COUNT identical to before
+    /// #2319, so the in-process test parallelism -- and thus the timing of unrelated
+    /// process-global work-counter tests -- is unperturbed.
+    ///
+    /// Scenario 1 (equal-sized chunks -- reuse vs per-call contrast):
     /// - The OLD per-chunk path (`read_at`, still the point-read behaviour) allocates
-    ///   ONE aligned buffer PER read → `N` allocs for `N` reads (> 1). This is the
+    ///   ONE aligned buffer PER read -> `N` allocs for `N` reads (> 1). This is the
     ///   regression state the reuse path fixes; the assertion below fails on it.
     /// - The FIXED windowed path (`read_exact_at_reusing` with a shared
-    ///   [`DirectScratch`]) allocates the buffer ONCE and reuses it → exactly 1 alloc
+    ///   [`DirectScratch`]) allocates the buffer ONCE and reuses it -> exactly 1 alloc
     ///   across all `N` reads, in steady state.
+    ///
+    /// Scenario 2 (increasing sizes -- geometric growth, issue #2319 MEDIUM): with the
+    /// reused scratch fed reads of STRICTLY INCREASING aligned span, the buffer grows
+    /// GEOMETRICALLY -- a small constant number of reallocations, NOT one per read. The
+    /// pre-fix grow-to-exact code reallocated on every size increase, preserving the
+    /// very per-chunk-alloc regression #2319 removes; scenario 1 cannot catch it
+    /// because its span never grows.
+    ///
+    /// Scenario 3 (Arc-dyn forward -- wiring evidence): production reaches the reuse
+    /// path through an `Arc<dyn ReadAt>` (`point_source`), whose blanket-impl forward
+    /// ([`ReadAt for Arc<T>`]) must delegate `read_exact_at_reusing` to the concrete
+    /// `DirectReadAt` override. If that forward hop were dropped the `Arc` would fall
+    /// back to the per-chunk-alloc default and production would regress while a
+    /// concrete-typed assertion stayed green -- so this exercises reuse THROUGH the dyn
+    /// `Arc` and asserts a single allocation.
     ///
     /// Serialized on the process-global [`ALIGNED_BUF_ALLOCS`] counter.
     #[cfg(unix)]
@@ -791,18 +824,23 @@ mod tests {
     fn direct_windowed_read_reuses_one_bounce_buffer_across_chunks() {
         use std::sync::atomic::Ordering;
 
+        // Deterministic pseudo-random content (LCG) so mismatches are meaningful.
+        fn fill(data: &mut [u8], mut x: u32) {
+            for b in data.iter_mut() {
+                x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                *b = (x >> 24) as u8;
+            }
+        }
+
+        // ---- Scenario 1: equal-sized chunks, reuse vs per-call contrast ----
         // 8 aligned, equal-sized "chunks" so every read's aligned span is identical
-        // (`head == 0`, span == chunk) → the reused buffer never needs to grow, so a
+        // (`head == 0`, span == chunk) -> the reused buffer never needs to grow, so a
         // reused buffer means EXACTLY one allocation across all reads.
         let chunk = DIRECT_IO_ALIGN; // 4096
         let n_chunks = 8usize;
         let len = chunk * n_chunks;
         let mut data = vec![0u8; len];
-        let mut x = 0x9e37_79b9u32;
-        for b in data.iter_mut() {
-            x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
-            *b = (x >> 24) as u8;
-        }
+        fill(&mut data, 0x9e37_79b9);
         let path = temp_file(&data, "reuse");
         let file = std::fs::File::open(&path).unwrap();
         let direct = DirectReadAt::from_plain_fd_for_test(file, len as u64);
@@ -831,18 +869,18 @@ mod tests {
 
         // OLD per-chunk path: `read_at` allocates a fresh bounce buffer per call.
         // This is the regression the reuse path removes; it allocates once per read,
-        // so `> 1` for `N > 1` — the exact behaviour the assertion above rejects.
+        // so `> 1` for `N > 1` -- the exact behaviour the assertion above rejects.
         ALIGNED_BUF_ALLOCS.store(0, Ordering::Relaxed);
         for i in 0..n_chunks {
             let off = (i * chunk) as u64;
             let mut got = vec![0u8; chunk];
-            direct.read_exact_at(off, &mut got).unwrap();
+            direct.read_at(off, &mut got).unwrap();
         }
         let percall_allocs = ALIGNED_BUF_ALLOCS.load(Ordering::Relaxed);
         assert_eq!(
             percall_allocs, n_chunks,
             "#2319 (regression witness): the per-call point-read path allocates one aligned \
-             buffer PER read ({n_chunks} reads → {n_chunks} allocs); the windowed scan must \
+             buffer PER read ({n_chunks} reads -> {n_chunks} allocs); the windowed scan must \
              NOT use it (got {percall_allocs})"
         );
         assert!(
@@ -850,7 +888,85 @@ mod tests {
             "#2319: reuse ({reuse_allocs}) must allocate strictly fewer buffers than the \
              per-chunk path ({percall_allocs})"
         );
-
         std::fs::remove_file(&path).ok();
+
+        // ---- Scenario 2: increasing sizes must grow GEOMETRICALLY (#2319 MEDIUM) ----
+        // `M` reads at offset 0 of length `(i+1)*4096` need caps 4096, 8192, ... 32768.
+        // - grow-to-exact: every cap strictly exceeds the last -> `M` allocs (== reads).
+        // - geometric (max(need, old*2)): 4096->8192->16384->32768 -> ~log2(M) allocs,
+        //   well under `M`. The bound below fails on the old code and passes on the fix.
+        let n_reads = 8usize;
+        let grow_len = chunk * n_reads; // largest read spans the whole file
+        let mut grow_data = vec![0u8; grow_len];
+        fill(&mut grow_data, 0x1357_9bdf);
+        let grow_path = temp_file(&grow_data, "reuse_grow");
+        let grow_file = std::fs::File::open(&grow_path).unwrap();
+        let grow_direct = DirectReadAt::from_plain_fd_for_test(grow_file, grow_len as u64);
+
+        ALIGNED_BUF_ALLOCS.store(0, Ordering::Relaxed);
+        let mut grow_scratch = DirectScratch::new();
+        for i in 0..n_reads {
+            let want_len = (i + 1) * chunk; // strictly increasing aligned span
+            let mut got = vec![0u8; want_len];
+            grow_direct
+                .read_exact_at_reusing(0, &mut got, &mut grow_scratch)
+                .unwrap();
+            assert_eq!(
+                got,
+                &grow_data[..want_len],
+                "increasing-size reused-buffer read returned wrong bytes at read {i}"
+            );
+        }
+        let grow_allocs = ALIGNED_BUF_ALLOCS.load(Ordering::Relaxed);
+        // A few geometric growths, NOT one per read. Bound comfortably above the
+        // ~log2(M)=4 growths yet strictly below `n_reads` so grow-to-exact (which
+        // reallocates every read -> n_reads allocs) fails here.
+        assert!(
+            grow_allocs <= 5,
+            "#2319: geometric growth must bound reallocations to a small constant across \
+             {n_reads} increasing-size reads (got {grow_allocs} allocs)"
+        );
+        assert!(
+            grow_allocs < n_reads,
+            "#2319: growth must allocate strictly fewer times than {n_reads} reads -- \
+             grow-to-exact reallocated on every size increase (got {grow_allocs})"
+        );
+        std::fs::remove_file(&grow_path).ok();
+
+        // ---- Scenario 3: reuse must survive the Arc<dyn ReadAt> forward hop ----
+        let arc_chunks = 6usize;
+        let arc_len = chunk * arc_chunks;
+        let mut arc_data = vec![0u8; arc_len];
+        fill(&mut arc_data, 0x2468_ace0);
+        let arc_path = temp_file(&arc_data, "reuse_arc");
+        let arc_file = std::fs::File::open(&arc_path).unwrap();
+        // Erase to the exact production type: an `Arc<dyn ReadAt>` (point_source).
+        let src: Arc<dyn ReadAt> = Arc::new(DirectReadAt::from_plain_fd_for_test(
+            arc_file,
+            arc_len as u64,
+        ));
+
+        ALIGNED_BUF_ALLOCS.store(0, Ordering::Relaxed);
+        let mut arc_scratch = DirectScratch::new();
+        for i in 0..arc_chunks {
+            let off = (i * chunk) as u64;
+            let mut got = vec![0u8; chunk];
+            // Goes Arc<dyn ReadAt> -> forward -> DirectReadAt::read_exact_at_reusing.
+            src.read_exact_at_reusing(off, &mut got, &mut arc_scratch)
+                .unwrap();
+            assert_eq!(
+                got,
+                &arc_data[i * chunk..(i + 1) * chunk],
+                "Arc-dyn reused-buffer read returned wrong bytes for chunk {i}"
+            );
+        }
+        let arc_allocs = ALIGNED_BUF_ALLOCS.load(Ordering::Relaxed);
+        assert_eq!(
+            arc_allocs, 1,
+            "#2319: the Arc<dyn ReadAt> forward must reach DirectReadAt's reuse override -- \
+             exactly ONE aligned buffer across {arc_chunks} equal-sized chunk reads (got \
+             {arc_allocs}); a dropped forward would fall back to the per-chunk-alloc default"
+        );
+        std::fs::remove_file(&arc_path).ok();
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/read_at.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at.rs
@@ -81,6 +81,58 @@ pub(crate) trait ReadAt: Send + Sync {
         }
         Ok(())
     }
+
+    /// Like [`read_exact_at`](Self::read_exact_at) but may REUSE the caller-owned
+    /// [`DirectScratch`] aligned bounce buffer across calls, so the Direct-I/O
+    /// windowed scan does not allocate a fresh ~chunk-sized aligned buffer per
+    /// chunk read (issue #2319 — the regression #1940 introduced by routing the
+    /// Direct windowed scan through the generic per-call [`DirectReadAt::read_at`]
+    /// instead of the pre-#1940 per-scan `DirectCursor` that reused ONE window
+    /// buffer).
+    ///
+    /// The default impl IGNORES `scratch` and defers to
+    /// [`read_exact_at`](Self::read_exact_at): the mmap and plain-file backends
+    /// never allocate a bounce buffer at all, so buffer reuse is a no-op for them
+    /// and the window-as-`Bytes` substrate (#1940) is untouched. ONLY
+    /// [`DirectReadAt`] overrides it, threading the reusable aligned buffer through
+    /// its per-read alignment math.
+    fn read_exact_at_reusing(
+        &self,
+        offset: u64,
+        buf: &mut [u8],
+        _scratch: &mut DirectScratch,
+    ) -> Result<()> {
+        self.read_exact_at(offset, buf)
+    }
+}
+
+/// A caller-owned reusable aligned bounce buffer for the Direct-I/O windowed-scan
+/// read path (issue #2319).
+///
+/// The windowed feed creates ONE `DirectScratch` per scan and threads a `&mut` to
+/// it through every chunk read via [`ReadAt::read_exact_at_reusing`]. When the
+/// backend is [`DirectReadAt`], the read reuses this single aligned buffer instead
+/// of allocating one per chunk — restoring the pre-#1940 per-scan reused-window
+/// behaviour. For every other backend it carries no state and costs nothing (the
+/// aligned buffer is `Option`-wrapped and stays `None`). Since the feed owns it
+/// exclusively for the scan's lifetime, no cursor/mutex is needed and concurrent
+/// scans (each with their own `DirectScratch`) never share the buffer.
+pub(crate) struct DirectScratch {
+    /// The reused aligned buffer, grown on demand to the working-set high-water
+    /// mark. `None` until the first Direct read; always `None` on non-Direct
+    /// backends and non-Unix targets (no direct I/O there).
+    #[cfg(unix)]
+    bounce: Option<AlignedBuf>,
+}
+
+impl DirectScratch {
+    /// A fresh scratch with no buffer allocated yet.
+    pub(crate) fn new() -> Self {
+        Self {
+            #[cfg(unix)]
+            bounce: None,
+        }
+    }
 }
 
 /// Delegating impl so an `Arc<dyn ReadAt>` (or `Arc<ConcreteBackend>`) is itself a
@@ -95,6 +147,18 @@ impl<T: ReadAt + ?Sized> ReadAt for Arc<T> {
     }
     fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<()> {
         (**self).read_exact_at(offset, buf)
+    }
+    // Forward the reusing read so a `DirectReadAt` behind an `Arc<dyn ReadAt>`
+    // (exactly `point_source`'s type) still reaches its override — otherwise the
+    // Direct windowed scan would silently fall back to the default per-chunk-alloc
+    // path (issue #2319).
+    fn read_exact_at_reusing(
+        &self,
+        offset: u64,
+        buf: &mut [u8],
+        scratch: &mut DirectScratch,
+    ) -> Result<()> {
+        (**self).read_exact_at_reusing(offset, buf, scratch)
     }
 }
 
@@ -317,11 +381,41 @@ impl DirectReadAt {
             len,
         })
     }
+
+    /// Test-only: build a `DirectReadAt` over an ALREADY-OPEN plain file handle,
+    /// bypassing the `O_DIRECT`/`F_NOCACHE` open (issue #2319). The aligned-bounce
+    /// read path (`read_at_into` / `read_exact_at_reusing`) is byte-identical
+    /// regardless of whether the fd was opened with direct I/O — the alignment math
+    /// and bounce-buffer REUSE it exercises are pure user-space logic. This lets the
+    /// buffer-reuse test run on any filesystem (macOS/tmpfs/CI) WITHOUT needing a
+    /// working direct-I/O syscall, which is frequently unavailable and probing it
+    /// live is what stalled the prior implementer.
+    #[cfg(test)]
+    pub(crate) fn from_plain_fd_for_test(file: std::fs::File, len: u64) -> Self {
+        Self {
+            file: Arc::new(file),
+            len,
+        }
+    }
 }
 
 #[cfg(unix)]
-impl ReadAt for DirectReadAt {
-    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+impl DirectReadAt {
+    /// Aligned positioned read shared by the per-call [`ReadAt::read_at`] and the
+    /// buffer-reusing [`ReadAt::read_exact_at_reusing`] paths (issue #2319).
+    ///
+    /// `bounce` is a slot for the aligned transfer buffer. When it already holds a
+    /// buffer big enough for this read's aligned span, that buffer is REUSED
+    /// (no allocation); otherwise a new one is allocated INTO the slot so a later
+    /// read reuses it. `read_at` passes a throwaway local slot (per-call alloc, as
+    /// before); the windowed scan passes its per-scan [`DirectScratch`] slot so one
+    /// buffer serves every chunk read.
+    fn read_at_into(
+        &self,
+        offset: u64,
+        buf: &mut [u8],
+        bounce: &mut Option<AlignedBuf>,
+    ) -> Result<usize> {
         use std::os::unix::fs::FileExt;
         if offset >= self.len || buf.is_empty() {
             return Ok(0);
@@ -338,19 +432,78 @@ impl ReadAt for DirectReadAt {
         let aligned_len = span
             .checked_next_multiple_of(DIRECT_IO_ALIGN)
             .unwrap_or(usize::MAX & !(DIRECT_IO_ALIGN - 1));
-        let mut bounce = AlignedBuf::new(aligned_len, DIRECT_IO_ALIGN)?;
-        let got = self.file.read_at(bounce.as_mut_slice(), aligned_off)?;
+        // Reuse the slot's buffer when it is already large enough; otherwise
+        // (re)allocate to `aligned_len` and keep it for subsequent reads. `pread`
+        // fills only the aligned span we ask for, so a larger reused buffer is
+        // fine — we read into its leading `aligned_len` bytes.
+        let need_alloc = bounce
+            .as_ref()
+            .map(|b| b.capacity() < aligned_len)
+            .unwrap_or(true);
+        if need_alloc {
+            *bounce = Some(AlignedBuf::new(aligned_len, DIRECT_IO_ALIGN)?);
+        }
+        // SAFETY of unwrap avoidance: `bounce` is `Some` here (just set, or already
+        // large enough). Match to keep the no-`unwrap` rule in library code.
+        let slot = match bounce.as_mut() {
+            Some(b) => b,
+            None => return Err(Error::corruption("direct read_at: bounce buffer missing")),
+        };
+        let got = self
+            .file
+            .read_at(&mut slot.as_mut_slice()[..aligned_len], aligned_off)?;
         if got <= head {
             return Ok(0);
         }
-        let usable = &bounce.as_slice()[head..got];
+        let usable = &slot.as_slice()[head..got];
         let n = usable.len().min(buf.len());
         buf[..n].copy_from_slice(&usable[..n]);
         Ok(n)
     }
+}
+
+#[cfg(unix)]
+impl ReadAt for DirectReadAt {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        // Per-call bounce buffer (no reuse) — the point-read path allocates one per
+        // call, exactly as before issue #2319.
+        let mut bounce: Option<AlignedBuf> = None;
+        self.read_at_into(offset, buf, &mut bounce)
+    }
 
     fn len(&self) -> u64 {
         self.len
+    }
+
+    fn read_exact_at_reusing(
+        &self,
+        offset: u64,
+        buf: &mut [u8],
+        scratch: &mut DirectScratch,
+    ) -> Result<()> {
+        // Reuse the caller's per-scan aligned bounce buffer across every chunk read
+        // (issue #2319). Loops `read_at_into` for exact semantics, threading the ONE
+        // `scratch.bounce` buffer so no per-chunk aligned allocation occurs.
+        let mut filled = 0usize;
+        while filled < buf.len() {
+            let n = self.read_at_into(
+                offset + filled as u64,
+                &mut buf[filled..],
+                &mut scratch.bounce,
+            )?;
+            if n == 0 {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "read_exact_at_reusing: reached EOF after {filled} of {} bytes at \
+                         offset 0x{offset:x}",
+                        buf.len()
+                    ),
+                )));
+            }
+            filled += n;
+        }
+        Ok(())
     }
 }
 
@@ -368,9 +521,19 @@ struct AlignedBuf {
 #[cfg(unix)]
 unsafe impl Send for AlignedBuf {}
 
+/// Test-only counter of [`AlignedBuf`] allocations, so the issue #2319 reuse test
+/// can PROVE the Direct windowed-scan read path allocates ONE aligned bounce buffer
+/// across N chunk reads (reused) rather than one per read. Process-global; the
+/// reuse test serializes on it and resets before measuring.
+#[cfg(all(test, unix))]
+pub(crate) static ALIGNED_BUF_ALLOCS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 #[cfg(unix)]
 impl AlignedBuf {
     fn new(size: usize, align: usize) -> Result<Self> {
+        #[cfg(test)]
+        ALIGNED_BUF_ALLOCS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let size = size.max(align);
         let layout = std::alloc::Layout::from_size_align(size, align)
             .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, e)))?;
@@ -394,6 +557,12 @@ impl AlignedBuf {
     fn as_mut_slice(&mut self) -> &mut [u8] {
         // SAFETY: `ptr` is valid for `layout.size()` bytes and uniquely borrowed.
         unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.layout.size()) }
+    }
+
+    /// The number of aligned bytes this buffer can hold — used to decide whether a
+    /// reused buffer is big enough for the next read's aligned span (issue #2319).
+    fn capacity(&self) -> usize {
+        self.layout.size()
     }
 }
 
@@ -515,6 +684,9 @@ mod tests {
     /// tmpfs/overlayfs) — mirroring `source::direct_cursor_reads_and_seeks`.
     #[cfg(unix)]
     #[test]
+    // Shares the process-global `ALIGNED_BUF_ALLOCS` counter with the #2319 reuse
+    // test, so both run serially to keep that counter's measurements isolated.
+    #[serial_test::serial(aligned_buf_allocs)]
     fn direct_read_at_matches_plain_oracle_at_boundaries() {
         // File size deliberately NOT a 4096 multiple → forces a partial final
         // block and non-trivial `aligned_len` rounding.
@@ -589,6 +761,95 @@ mod tests {
             Error::Io(e) => assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof),
             other => panic!("expected UnexpectedEof, got {other:?}"),
         }
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Issue #2319: the Direct-I/O windowed-scan read path REUSES one aligned bounce
+    /// buffer across chunk reads instead of allocating a fresh ~chunk-sized aligned
+    /// buffer per read (the per-chunk-alloc regression #1940 introduced).
+    ///
+    /// This asserts the ALLOCATION BEHAVIOUR of the code path — the pure user-space
+    /// alignment + bounce-buffer logic — so it needs NO working `O_DIRECT` syscall
+    /// (frequently unavailable on macOS/tmpfs/CI; probing it live is what stalled a
+    /// prior implementer). `DirectReadAt::from_plain_fd_for_test` runs that exact
+    /// path over a regular fd; the bounce buffer, alignment math, and reuse decision
+    /// are identical whether or not the fd was opened with direct I/O.
+    ///
+    /// Contrast proves the fix AND the pre-fix regression in one test:
+    /// - The OLD per-chunk path (`read_at`, still the point-read behaviour) allocates
+    ///   ONE aligned buffer PER read → `N` allocs for `N` reads (> 1). This is the
+    ///   regression state the reuse path fixes; the assertion below fails on it.
+    /// - The FIXED windowed path (`read_exact_at_reusing` with a shared
+    ///   [`DirectScratch`]) allocates the buffer ONCE and reuses it → exactly 1 alloc
+    ///   across all `N` reads, in steady state.
+    ///
+    /// Serialized on the process-global [`ALIGNED_BUF_ALLOCS`] counter.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(aligned_buf_allocs)]
+    fn direct_windowed_read_reuses_one_bounce_buffer_across_chunks() {
+        use std::sync::atomic::Ordering;
+
+        // 8 aligned, equal-sized "chunks" so every read's aligned span is identical
+        // (`head == 0`, span == chunk) → the reused buffer never needs to grow, so a
+        // reused buffer means EXACTLY one allocation across all reads.
+        let chunk = DIRECT_IO_ALIGN; // 4096
+        let n_chunks = 8usize;
+        let len = chunk * n_chunks;
+        let mut data = vec![0u8; len];
+        let mut x = 0x9e37_79b9u32;
+        for b in data.iter_mut() {
+            x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            *b = (x >> 24) as u8;
+        }
+        let path = temp_file(&data, "reuse");
+        let file = std::fs::File::open(&path).unwrap();
+        let direct = DirectReadAt::from_plain_fd_for_test(file, len as u64);
+
+        // FIXED windowed path: one shared scratch reused across every chunk read.
+        ALIGNED_BUF_ALLOCS.store(0, Ordering::Relaxed);
+        let mut scratch = DirectScratch::new();
+        for i in 0..n_chunks {
+            let off = (i * chunk) as u64;
+            let mut got = vec![0u8; chunk];
+            direct
+                .read_exact_at_reusing(off, &mut got, &mut scratch)
+                .unwrap();
+            assert_eq!(
+                got,
+                &data[i * chunk..(i + 1) * chunk],
+                "reused-buffer read returned wrong bytes for chunk {i}"
+            );
+        }
+        let reuse_allocs = ALIGNED_BUF_ALLOCS.load(Ordering::Relaxed);
+        assert_eq!(
+            reuse_allocs, 1,
+            "#2319: the Direct windowed-scan path must allocate ONE aligned bounce buffer \
+             and reuse it across all {n_chunks} chunk reads (got {reuse_allocs} allocs)"
+        );
+
+        // OLD per-chunk path: `read_at` allocates a fresh bounce buffer per call.
+        // This is the regression the reuse path removes; it allocates once per read,
+        // so `> 1` for `N > 1` — the exact behaviour the assertion above rejects.
+        ALIGNED_BUF_ALLOCS.store(0, Ordering::Relaxed);
+        for i in 0..n_chunks {
+            let off = (i * chunk) as u64;
+            let mut got = vec![0u8; chunk];
+            direct.read_exact_at(off, &mut got).unwrap();
+        }
+        let percall_allocs = ALIGNED_BUF_ALLOCS.load(Ordering::Relaxed);
+        assert_eq!(
+            percall_allocs, n_chunks,
+            "#2319 (regression witness): the per-call point-read path allocates one aligned \
+             buffer PER read ({n_chunks} reads → {n_chunks} allocs); the windowed scan must \
+             NOT use it (got {percall_allocs})"
+        );
+        assert!(
+            reuse_allocs < percall_allocs,
+            "#2319: reuse ({reuse_allocs}) must allocate strictly fewer buffers than the \
+             per-chunk path ({percall_allocs})"
+        );
 
         std::fs::remove_file(&path).ok();
     }

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_read.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_read.rs
@@ -320,9 +320,16 @@ impl SSTableReader {
                     let e = (hi - pos) as usize;
                     Ok(crc32fast::hash(&piece[s..e]))
                 } else {
+                    // A chunk straddling the piece boundary must be read off disk.
+                    // Route it through `read_exact_at_reusing` with the SAME per-scan
+                    // `direct_scratch` the main piece read uses (issue #2319), so the
+                    // Direct-I/O backend reuses the one aligned bounce buffer instead
+                    // of allocating a fresh one per straddling chunk. For mmap/plain
+                    // backends this defers to `read_exact_at` (scratch stays empty),
+                    // so those paths are unchanged.
                     let mut cbuf = vec![0u8; (hi - lo) as usize];
                     self.point_source
-                        .read_exact_at(lo, &mut cbuf)
+                        .read_exact_at_reusing(lo, &mut cbuf, direct_scratch)
                         .map_err(|e| {
                             Error::corruption(format!(
                                 "failed to read uncompressed chunk {chunk} at Data.db offset \

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_read.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_read.rs
@@ -51,6 +51,7 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
+use super::super::read_at::DirectScratch;
 use super::SSTableReader;
 use crate::storage::sstable::read_work_counters as rwc;
 use crate::{Error, Result};
@@ -102,12 +103,24 @@ impl SSTableReader {
     /// so the #1940 no-nesting guard records the thread that performs the real read
     /// — making its `io_read_thread == decode_thread` equality a true detector of a
     /// read dispatched off the feed thread. Compiled only under `scan-offload-probe`.
-    fn positional_read_exact_retry_once(&self, offset: u64, buf: &mut [u8]) -> Result<()> {
+    fn positional_read_exact_retry_once(
+        &self,
+        offset: u64,
+        buf: &mut [u8],
+        scratch: &mut DirectScratch,
+    ) -> Result<()> {
         #[cfg(feature = "scan-offload-probe")]
         super::probe::record_io_read_thread();
         let mut attempt = 0u8;
         loop {
-            match self.point_source.read_exact_at(offset, buf) {
+            // `read_exact_at_reusing` reuses `scratch`'s aligned bounce buffer on
+            // the Direct-I/O backend (issue #2319 — no per-chunk aligned alloc); for
+            // mmap/plain-file backends it defers to `read_exact_at` and `scratch`
+            // stays empty, so those paths are byte-for-byte unchanged (#1940).
+            match self
+                .point_source
+                .read_exact_at_reusing(offset, buf, scratch)
+            {
                 Ok(()) => return Ok(()),
                 Err(e)
                     if attempt == 0
@@ -134,6 +147,7 @@ impl SSTableReader {
         &self,
         chunk_index: usize,
         scratch: &mut Vec<u8>,
+        direct_scratch: &mut DirectScratch,
     ) -> Result<Option<Vec<u8>>> {
         let comp_info = match self.compression_info.as_ref() {
             Some(ci) => ci,
@@ -225,7 +239,9 @@ impl SSTableReader {
         if buf.capacity() > cap_before {
             rwc::record_chunk_path_alloc();
         }
-        if let Err(e) = self.positional_read_exact_retry_once(chunk_offset, &mut buf) {
+        if let Err(e) =
+            self.positional_read_exact_retry_once(chunk_offset, &mut buf, direct_scratch)
+        {
             // Return the scratch's capacity to the caller so the next read reuses it.
             buf.clear();
             *scratch = buf;
@@ -268,7 +284,11 @@ impl SSTableReader {
     /// lifetime) BEFORE the piece is returned — from the resident bytes when a
     /// chunk is fully contained, else by reading the straddling remainder
     /// positionally (issue #1396; mirrors `verify_uncompressed_section_in_buffer`).
-    pub(super) fn read_uncompressed_piece_sync(&self, pos: u64) -> Result<Option<(Vec<u8>, u64)>> {
+    pub(super) fn read_uncompressed_piece_sync(
+        &self,
+        pos: u64,
+        direct_scratch: &mut DirectScratch,
+    ) -> Result<Option<(Vec<u8>, u64)>> {
         let file_size = self.point_source.len();
         let remaining = file_size.saturating_sub(pos);
         if remaining == 0 {
@@ -279,7 +299,7 @@ impl SSTableReader {
         // Same one-shot transient-retry + kind-preserving wrap as the compressed
         // path (issue #1940 BLOCKER-2): a transient fault is re-read once, and the
         // source io kind is preserved (never collapsed to `Error::other`).
-        self.positional_read_exact_retry_once(pos, &mut buf)
+        self.positional_read_exact_retry_once(pos, &mut buf, direct_scratch)
             .map_err(|e| {
                 io_error_with_context(
                     format!("Failed to read uncompressed piece ({to_read} bytes at 0x{pos:x})"),
@@ -365,12 +385,21 @@ impl SSTableReader {
                 })?;
             }
         }
+        // ONE reusable aligned bounce buffer for the WHOLE scan (issue #2319): the
+        // Direct-I/O backend reuses it across every chunk read instead of allocating
+        // a fresh ~chunk-sized aligned buffer per chunk (the #1940 regression). No-op
+        // (stays empty) for the mmap/plain-file backends.
+        let mut direct_scratch = DirectScratch::new();
         let mut chunk_index = 0usize;
         loop {
             // SYNCHRONOUS positional read + CRC (issue #1940): CRC is verified inside
             // the read, BEFORE the payload is trusted (guardrail #1411), exactly as
             // the former cursor path did.
-            match reader.read_compressed_chunk_sync(chunk_index, &mut scratch)? {
+            match reader.read_compressed_chunk_sync(
+                chunk_index,
+                &mut scratch,
+                &mut direct_scratch,
+            )? {
                 Some(compressed) => {
                     // Decompression stays HERE, on this blocking thread (D2), off the
                     // async reactor for every backend.
@@ -395,10 +424,13 @@ impl SSTableReader {
         reader: &Arc<Self>,
         raw_tx: &mpsc::Sender<bytes::Bytes>,
     ) -> Result<()> {
+        // ONE reusable aligned bounce buffer for the whole scan (issue #2319), same
+        // as the compressed feed; no-op for non-Direct backends.
+        let mut direct_scratch = DirectScratch::new();
         let mut pos = reader.calculate_header_size() as u64;
         let mut chunk_index = 0usize;
         loop {
-            match reader.read_uncompressed_piece_sync(pos)? {
+            match reader.read_uncompressed_piece_sync(pos, &mut direct_scratch)? {
                 Some((piece, next_pos)) => {
                     // No compressor: `decode_scan_chunk` moves the piece into the B1
                     // cache zero-copy (`Bytes::from(Vec)`) — no per-piece copy — and


### PR DESCRIPTION
Closes #2319

After #1940 the Direct I/O windowed scan allocated a fresh aligned bounce buffer per chunk (regression vs the pre-#1940 reused-window DirectCursor). Adds ReadAt::read_exact_at_reusing (default forwards to read_exact_at — mmap/Buffered/#1940 substrate untouched) + a DirectReadAt override threading one per-scan DirectScratch aligned buffer that grows GEOMETRICALLY (stable after a few growths, not per-chunk); the straddling-CRC read reuses the same scratch. Arc<dyn ReadAt> blanket impl forwards the method so the real scan path reaches the Direct override.

Test: direct_windowed_read_reuses_one_bounce_buffer_across_chunks — asserts alloc==1 across equal chunks, bounded (<=5, geometric) across strictly-increasing chunks (fails on grow-to-exact), and reuse through Arc<dyn ReadAt> (guards the forward hop). Uses a plain-fd test constructor (no O_DIRECT syscall needed; alignment/reuse is pure userspace).

Review: rust-reviewer APPROVE; roborev (codex) No issues found (after a fix round resolving 3 findings).

🤖 Generated with Claude Code