### PR TITLE
chore(#2519): move env_logger to [dev-dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,14 @@ cqlite-core = { path = "cqlite-core" }
 clap = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 log = { workspace = true }
-env_logger = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Dev/test-only logging init. The workspace-root `cqlite` package has no src/
+# (it only hosts the top-level tests/*.rs integration tests), so env_logger can
+# only ever serve dev/test context — a dev-dependency, never a shipped one
+# (issue #2519, item b from #2151).
+env_logger = { workspace = true }
 futures = { workspace = true }
 uuid = { version = "1.6", features = ["v4"] }
 insta = "1.34"

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -94,7 +94,6 @@ uuid = { version = "1.10", features = ["v4"] }
 regex = "1.10"
 futures = "0.3"
 clap = { version = "4.4", features = ["derive"] }
-env_logger = { workspace = true }
 async-trait = "0.1.88"
 
 # Terminal output and logging
@@ -125,6 +124,10 @@ libc = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+# Dev/test-only logging init (integration tests under tests/). Post the #1706
+# log->tracing migration the library ships no env_logger usage, so it is a
+# dev-dependency only (issue #2519, item b from #2151).
+env_logger = { workspace = true }
 # Heap profiling harness (examples/heap_profile.rs). The dhat allocator is only
 # installed when the `dhat-heap` feature is enabled; the dependency itself is
 # dev-only and never ships in the library.


### PR DESCRIPTION
Closes #2519

## Summary
`env_logger` is used only from test code post the #1706 `log`→`tracing`
migration. Moved from `[dependencies]` to `[dev-dependencies]` in
`cqlite-core/Cargo.toml` and the workspace-root `cqlite/Cargo.toml`.

Verified no non-test code needs it: `grep -rn env_logger cqlite-core/src/`
returns nothing; `cargo tree -p cqlite-core --edges normal` no longer lists it;
`cargo build --release -p cqlite-core` succeeds without dev deps.

Left as regular dependencies (correctly, genuine `src`/`src/bin` usage): the
`tests/` and `examples/` harness crates (`publish = false`, not shipped) — they
call `env_logger` directly from their own `src`.

Oracle-driven, no OpenSpec. Genuinely mechanical (`Cargo.toml` only, no
`pub`-item change, no new surface) — skipping review-first per that documented
exception.

## Gate status
Lite:
```
==== AGENT-GATE LITE SUMMARY ====
commit: c406c7422 branch: issue-2519-env-logger-dev-dep dirty: no
file-size: PASS  fmt: PASS  clippy: PASS  scoped-tests: PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Full `agent-gate.sh` (the gate of record) + final roborev pass to be run by
`flow-closer`.