### PR TITLE
fix(#2524): fail closed on max_compressed_length==0 in read_compressed_offset_window

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
@@ -32,109 +32,206 @@ impl SSTableReader {
         block_offset: u64,
         size: u32,
     ) -> Result<Vec<u8>> {
-        use super::super::block_io;
         use crate::storage::sstable::compression::Compression;
 
-        let chunk_length = comp_info.chunk_length as usize;
-        if chunk_length == 0 {
-            return Err(Error::corruption(
-                "CompressionInfo chunk_length is zero; cannot map a Data.db offset to a \
-                 compressed chunk"
-                    .to_string(),
-            ));
-        }
-
-        let start = block_offset as usize;
-        let end = start.checked_add(size as usize).ok_or_else(|| {
-            Error::corruption(format!(
-                "compressed offset read range [{start}, +{size}) overflows"
-            ))
-        })?;
-        // `size >= 1` (callers reject size == 0), so `end > start` and `end - 1`
-        // never underflows; `first_chunk <= last_chunk`.
-        let first_chunk = start / chunk_length;
-        let last_chunk = (end - 1) / chunk_length;
-
-        let max_compressed_length = comp_info.max_compressed_length as usize;
         let compression = self
             .compression_reader
             .as_ref()
             .map(|r| Compression::new(*r.algorithm()))
             .transpose()?;
 
-        let mut assembled = Vec::with_capacity(
-            last_chunk.saturating_sub(first_chunk).saturating_add(1) * chunk_length,
-        );
-        for chunk_idx in first_chunk..=last_chunk {
-            // CRC-validated compressed bytes (guardrail #1411): the trailing inline
-            // per-chunk CRC32 is checked HERE, before decompression. header_offset is
-            // 0 for nb/BTI (CompressionInfo chunk offsets are absolute from Data.db
-            // byte 0), matching the cursor and BTI point-read paths (issue #1573 C2).
-            //
-            // Fail CLOSED (issue #1773 roborev): for a VALID offset+size every chunk
-            // in `first_chunk..=last_chunk` exists, so a `None` (EOF) here means the
-            // requested range does not actually fit in this compressed Data.db — a
-            // corrupt/out-of-range offset or size. Returning the partial `assembled`
-            // bytes as `Ok` would silently truncate; this must surface as a typed,
-            // non-recoverable corruption error instead.
-            let Some(compressed) = block_io::read_compressed_chunk_at(
-                self.point_source.as_ref(),
-                comp_info,
-                chunk_idx,
-                self.stats.file_size,
-                0,
-            )?
-            else {
-                return Err(Error::corruption(format!(
-                    "compressed offset read requires chunk {chunk_idx} past EOF for range \
-                     [{start}, {end}) — corrupt or out-of-range offset/size"
-                )));
-            };
+        read_compressed_offset_window_impl(
+            self.point_source.as_ref(),
+            comp_info,
+            compression.as_ref(),
+            self.stats.file_size,
+            block_offset,
+            size,
+        )
+    }
+}
 
-            // Incompressible-chunk fallback (Bug #639, epic #970): Cassandra stores a
-            // chunk RAW (not compressed) when its compressed length would meet or
-            // exceed `max_compressed_length`; those bytes are already plaintext.
-            // Authority: CompressedSequentialWriter.java:160-177.
-            let decompressed = if compressed.len() >= max_compressed_length {
-                compressed
-            } else if let Some(compression) = &compression {
-                // Single decode plane (issue #1598, G2): the actual decompress call
-                // resolves inside `ChunkSource::decompress_only`, so this module holds
-                // zero query-path decompress call sites (the architecture test proves
-                // exactly one such module). CRC is already validated above by
-                // `read_compressed_chunk_at` (guardrail #1411), so we never decode bytes
-                // that failed their inline CRC32.
-                let out = super::super::chunk_source::ChunkSource::decompress_only(
-                    Some(compression),
-                    compressed,
-                )?;
-                super::model::DECOMPRESS_CALLS.fetch_add(1, Ordering::Relaxed);
-                out
-            } else {
-                compressed
-            };
-            assembled.extend_from_slice(&decompressed);
-        }
+/// Decompression core of [`SSTableReader::read_compressed_offset_window`], factored
+/// out of the reader method so it can be exercised directly against a hand-built
+/// [`CompressionInfo`] + `ReadAt` source (no reader/SQL roundtrip) — see the
+/// `max_compressed_length == 0` regression test below.
+///
+/// [`CompressionInfo`]: crate::storage::sstable::compression_info::CompressionInfo
+pub(super) fn read_compressed_offset_window_impl(
+    point_source: &dyn super::super::read_at::ReadAt,
+    comp_info: &crate::storage::sstable::compression_info::CompressionInfo,
+    compression: Option<&crate::storage::sstable::compression::Compression>,
+    file_size: u64,
+    block_offset: u64,
+    size: u32,
+) -> Result<Vec<u8>> {
+    use super::super::block_io;
 
-        // Slice the requested window out of the assembled uncompressed chunk bytes.
+    let chunk_length = comp_info.chunk_length as usize;
+    if chunk_length == 0 {
+        return Err(Error::corruption(
+            "CompressionInfo chunk_length is zero; cannot map a Data.db offset to a \
+             compressed chunk"
+                .to_string(),
+        ));
+    }
+
+    // Fail CLOSED on a corrupt `CompressionInfo` whose `max_compressed_length == 0`
+    // (issue #2524, mirroring the #1869 fix in the sibling `compressed_partition_window`):
+    // otherwise the raw-chunk fallback below (`compressed.len() >= max_compressed_length`)
+    // is ALWAYS true, so EVERY still-LZ4-compressed chunk would be returned verbatim as
+    // "raw/incompressible" plaintext — never decompressed — and the inline CRC32 (computed
+    // over the genuine on-disk bytes) would still pass, silently handing back garbage rows.
+    // A valid Cassandra `CompressionInfo` never records a zero `max_compressed_length`
+    // (it is `i32::MAX` when minCompressRatio=0, the default; CompressionParams.java:186-189).
+    let max_compressed_length = comp_info.max_compressed_length as usize;
+    if max_compressed_length == 0 {
+        return Err(Error::corruption(
+            "compressed offset read: CompressionInfo max_compressed_length is zero; \
+             cannot distinguish compressed chunks from raw/incompressible ones"
+                .to_string(),
+        ));
+    }
+
+    let start = block_offset as usize;
+    let end = start.checked_add(size as usize).ok_or_else(|| {
+        Error::corruption(format!(
+            "compressed offset read range [{start}, +{size}) overflows"
+        ))
+    })?;
+    // `size >= 1` (callers reject size == 0), so `end > start` and `end - 1`
+    // never underflows; `first_chunk <= last_chunk`.
+    let first_chunk = start / chunk_length;
+    let last_chunk = (end - 1) / chunk_length;
+
+    let mut assembled =
+        Vec::with_capacity(last_chunk.saturating_sub(first_chunk).saturating_add(1) * chunk_length);
+    for chunk_idx in first_chunk..=last_chunk {
+        // CRC-validated compressed bytes (guardrail #1411): the trailing inline
+        // per-chunk CRC32 is checked HERE, before decompression. header_offset is
+        // 0 for nb/BTI (CompressionInfo chunk offsets are absolute from Data.db
+        // byte 0), matching the cursor and BTI point-read paths (issue #1573 C2).
         //
-        // Fail CLOSED (issue #1773 roborev): for a VALID offset+size the assembled
-        // chunks fully cover `[start, end)`. If they do not — a short final chunk, or
-        // `within_start` itself past what decoded — the offset/size is corrupt or
-        // out-of-range; return a typed corruption error rather than truncating to
-        // `Ok(partial)` / `Ok(empty)`.
-        let window_base = first_chunk * chunk_length;
-        let within_start = start - window_base;
-        let requested_end = end - window_base;
-        if requested_end > assembled.len() {
+        // Fail CLOSED (issue #1773 roborev): for a VALID offset+size every chunk
+        // in `first_chunk..=last_chunk` exists, so a `None` (EOF) here means the
+        // requested range does not actually fit in this compressed Data.db — a
+        // corrupt/out-of-range offset or size. Returning the partial `assembled`
+        // bytes as `Ok` would silently truncate; this must surface as a typed,
+        // non-recoverable corruption error instead.
+        let Some(compressed) =
+            block_io::read_compressed_chunk_at(point_source, comp_info, chunk_idx, file_size, 0)?
+        else {
             return Err(Error::corruption(format!(
-                "compressed offset read range [{start}, {end}) is short by {} bytes after \
-                 decompressing chunks {first_chunk}..={last_chunk} (assembled {} bytes) — \
-                 corrupt or out-of-range offset/size",
-                requested_end - assembled.len(),
-                assembled.len()
+                "compressed offset read requires chunk {chunk_idx} past EOF for range \
+                 [{start}, {end}) — corrupt or out-of-range offset/size"
             )));
+        };
+
+        // Incompressible-chunk fallback (Bug #639, epic #970): Cassandra stores a
+        // chunk RAW (not compressed) when its compressed length would meet or
+        // exceed `max_compressed_length`; those bytes are already plaintext.
+        // Authority: CompressedSequentialWriter.java:160-177.
+        let decompressed = if compressed.len() >= max_compressed_length {
+            compressed
+        } else if let Some(compression) = compression {
+            // Single decode plane (issue #1598, G2): the actual decompress call
+            // resolves inside `ChunkSource::decompress_only`, so this module holds
+            // zero query-path decompress call sites (the architecture test proves
+            // exactly one such module). CRC is already validated above by
+            // `read_compressed_chunk_at` (guardrail #1411), so we never decode bytes
+            // that failed their inline CRC32.
+            let out = super::super::chunk_source::ChunkSource::decompress_only(
+                Some(compression),
+                compressed,
+            )?;
+            super::model::DECOMPRESS_CALLS.fetch_add(1, Ordering::Relaxed);
+            out
+        } else {
+            compressed
+        };
+        assembled.extend_from_slice(&decompressed);
+    }
+
+    // Slice the requested window out of the assembled uncompressed chunk bytes.
+    //
+    // Fail CLOSED (issue #1773 roborev): for a VALID offset+size the assembled
+    // chunks fully cover `[start, end)`. If they do not — a short final chunk, or
+    // `within_start` itself past what decoded — the offset/size is corrupt or
+    // out-of-range; return a typed corruption error rather than truncating to
+    // `Ok(partial)` / `Ok(empty)`.
+    let window_base = first_chunk * chunk_length;
+    let within_start = start - window_base;
+    let requested_end = end - window_base;
+    if requested_end > assembled.len() {
+        return Err(Error::corruption(format!(
+            "compressed offset read range [{start}, {end}) is short by {} bytes after \
+             decompressing chunks {first_chunk}..={last_chunk} (assembled {} bytes) — \
+             corrupt or out-of-range offset/size",
+            requested_end - assembled.len(),
+            assembled.len()
+        )));
+    }
+    Ok(assembled[within_start..requested_end].to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::sstable::compression_info::CompressionInfo;
+    use crate::storage::sstable::reader::read_at::ReadAt;
+    use crate::Error;
+
+    /// Minimal `ReadAt` double. The `max_compressed_length == 0` guard fires BEFORE
+    /// any chunk read, so `read_at` is never reached — it exists only to satisfy the
+    /// signature (and panics if the guard ever regresses to touch the source).
+    struct NeverReadAt;
+    impl ReadAt for NeverReadAt {
+        fn read_at(&self, _offset: u64, _buf: &mut [u8]) -> crate::Result<usize> {
+            panic!(
+                "read_at must not be reached: the max_compressed_length==0 guard fails closed \
+                    before any chunk I/O"
+            );
         }
-        Ok(assembled[within_start..requested_end].to_vec())
+        fn len(&self) -> u64 {
+            0
+        }
+    }
+
+    /// A hand-built `CompressionInfo` with `max_compressed_length` corrupted to `0`.
+    /// One 64-byte chunk; the chunk_offsets/data_length are immaterial because the
+    /// guard rejects the metadata before mapping any offset to a chunk.
+    fn comp_info_zero_max() -> CompressionInfo {
+        CompressionInfo {
+            algorithm: "LZ4Compressor".to_string(),
+            option_pairs: Vec::new(),
+            chunk_length: 64,
+            max_compressed_length: 0, // corrupt: a valid CompressionInfo never records 0
+            data_length: 64,
+            chunk_offsets: vec![0],
+        }
+    }
+
+    /// Issue #2524 — a corrupt/malformed `CompressionInfo` whose `max_compressed_length
+    /// == 0` MUST fail closed with a typed `Error::Corruption`, never silently return
+    /// still-compressed bytes as plaintext. Pre-fix, the raw-chunk fallback test
+    /// `compressed.len() >= max_compressed_length` was `>= 0` — ALWAYS true — so every
+    /// still-LZ4-compressed chunk was returned verbatim as "raw" plaintext, and the
+    /// inline CRC32 (over the genuine on-disk bytes) still matched, failing OPEN.
+    /// Mirrors the #1869 fix + test for the sibling `compressed_partition_window`.
+    #[test]
+    fn zero_max_compressed_length_fails_closed() {
+        let ci = comp_info_zero_max();
+        let src = NeverReadAt;
+
+        let err = super::read_compressed_offset_window_impl(&src, &ci, None, 0, 0, 16).expect_err(
+            "CompressionInfo.max_compressed_length == 0 must fail closed with a typed \
+                 corruption error, not silently return still-compressed bytes as plaintext",
+        );
+        match err {
+            Error::Corruption(m) => assert!(
+                m.contains("max_compressed_length is zero"),
+                "unexpected corruption text: {m}"
+            ),
+            other => panic!("expected Corruption(max_compressed_length zero), got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Closes #2524

## Summary
`read_compressed_offset_window`'s incompressible/raw-chunk fallback
(`if compressed.len() >= max_compressed_length`) had no lower-bound check on
`max_compressed_length` (taken verbatim from `CompressionInfo`). A corrupt
`CompressionInfo.db` with `max_compressed_length == 0` made the condition
always true, so every chunk was treated as raw and returned as plaintext
instead of decompressed — fail-OPEN (silently wrong data; the CRC32 check
still passes since it's computed over the genuinely-on-disk bytes). Mirrors
the identical fix landed in the sibling `compressed_partition_window` for
issue #1869 (that PR is still in its own endgame as of this writing — this
branch forked before it merged, no file overlap).

Oracle-driven, no OpenSpec.

## Fix
Added an up-front `max_compressed_length == 0` guard returning a typed
`Error::corruption(...)` before the raw-chunk fallback is reached. Extracted
the decompression core into a free function
`read_compressed_offset_window_impl` to make it directly unit-testable without
a full reader/SQL roundtrip; new test uses a `NeverReadAt` double (panics if
any chunk I/O is attempted) proving the guard fires before any I/O.

## Review-first
rust-reviewer: clean, no blockers. Verified the extraction is byte-for-byte
equivalent to the prior inline logic (cross-checked the `compression`
resolution idiom against 4 other call sites using the identical pattern), the
guard fires before any I/O, no new `unwrap()`/`expect()`, and the test
genuinely exercises the zero-guard (not the pre-existing `chunk_length==0`
guard).

**Filed as a follow-up (#2529, not fixed here — out of scope)**: the reviewer
found the SAME unguarded pattern in two more call sites
(`ChunkSource::chunk`, `decode_scan_chunk`) that neither this PR nor #1869
touched. Since `CompressionInfo::parse` doesn't reject `max_compressed_length
== 0` at all, a single guard there would close the whole class instead of
patching call sites one at a time (this is the second whack-a-mole instance).

## Gate status
Lite:
```
==== AGENT-GATE LITE SUMMARY ====
commit: 2a2032a91 branch: issue-2524-max-compressed-length-zero-guard dirty: no
file-size: PASS  fmt: PASS  clippy: PASS  scoped-tests: PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Full `agent-gate.sh` (the gate of record) + final roborev pass to be run by
`flow-closer`.