### PR TITLE
test(#2172): faithful subscriber-on overhead bench + wider #1703 span/info demotion coverage (a,b)

### DIFF
--- a/cqlite-core/benches/observability_overhead.rs
+++ b/cqlite-core/benches/observability_overhead.rs
@@ -34,19 +34,31 @@
 //! `#[inline]` and branch on a `const` feature predicate) to keep the CI signal
 //! non-flaky on shared runners.
 //!
-//! # Subscriber-on variant (issue #1703, epic #1686 AI3)
+//! # Subscriber-on variant (issue #1703, epic #1686 AI3; faithful install #2172a)
 //!
-//! The arms above run **subscriber-less** — Criterion installs no `tracing`
-//! subscriber, so the `#[tracing::instrument]` spans on the workload are inert.
-//! That is NOT the posture a real CLI user runs in: the CLI installs a fmt
-//! subscriber at INFO. To measure that previously-unmeasured default posture,
-//! each workload also gets a `*_subscriber_on` variant that wraps the SAME work
-//! in `tracing::subscriber::with_default(<fmt subscriber at INFO>)` (writing to a
-//! sink so span/event formatting cost is counted without polluting output).
-//! After the #1703 uniform DEBUG demotion the write/compaction spans are DEBUG,
-//! so an INFO subscriber filters them out and this number should be close to the
-//! subscriber-less one. The comparison script records it **advisory-first**
-//! (prints + warns, never fails) so the default posture is visible.
+//! A real CLI user runs with a fmt subscriber installed at INFO — the previously
+//! unmeasured default posture. To measure it faithfully this bench installs a
+//! **process-global** fmt subscriber (INFO, writing to `io::sink`) EXACTLY ONCE
+//! (see [`ensure_global_subscriber`]) with a per-call [`ToggleFilter`] gated by an
+//! atomic [`SUBSCRIBER_ON`] toggle. The `*_subscriber_on` variants flip the toggle
+//! ON for their measurement; the baseline arms (`read_scan`, `write_merge`) leave
+//! it OFF.
+//!
+//! Why global, not thread-local: the earlier `*_subscriber_on` arms installed the
+//! subscriber via `tracing::subscriber::with_default`, which is THREAD-LOCAL — it
+//! observed only spans emitted on the bench's own thread. The read scan crosses
+//! `spawn_blocking` / blocking-pool threads, whose spans were therefore NOT
+//! counted, so the recorded subscriber-on number under-counted the true default
+//! posture. A single process-global default reaches every thread, so spans on
+//! `spawn_blocking` threads are now counted too.
+//!
+//! The baseline arms therefore run with the global subscriber INSTALLED but the
+//! toggle OFF (not truly subscriber-less). This does NOT affect the cross-build
+//! feature-overhead comparison: the toggled-off global has the identical structure
+//! in both the default and `observability` builds, so it cancels out. After the
+//! #1703 uniform DEBUG demotion the write/compaction spans are DEBUG, so the INFO
+//! filter drops them and the subscriber-on number stays close to baseline. The
+//! comparison script records it **advisory-first** (prints + warns, never fails).
 //!
 //! Bench group/IDs (consumed by the comparison script):
 //! - `observability_overhead/read_scan`
@@ -55,17 +67,90 @@
 //! - `observability_overhead/write_merge_subscriber_on`  (write-support only)
 
 use criterion::{criterion_group, criterion_main, Criterion};
-
-/// A real `tracing` fmt subscriber capped at INFO — the CLI's default posture —
-/// writing to `io::sink` so span/event formatting cost is measured without
-/// polluting bench output. Installed thread-locally via `with_default` for the
-/// `*_subscriber_on` bench variants (issue #1703).
 #[cfg(any(feature = "cli-helpers", feature = "write-support"))]
-fn info_sink_subscriber() -> impl tracing::Subscriber + Send + Sync {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .with_writer(std::io::sink)
-        .finish()
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+use std::sync::Once;
+
+/// Process-global on/off toggle for the INFO subscriber installed by
+/// [`ensure_global_subscriber`]. The `*_subscriber_on` bench variants flip this
+/// ON for the duration of their measurement (via [`SubscriberOnGuard`]); every
+/// baseline arm leaves it OFF. Because the subscriber is a single PROCESS-GLOBAL
+/// default it reaches spans emitted on `spawn_blocking` / blocking-pool threads
+/// too — which the old thread-local `with_default` install silently missed,
+/// under-counting the true default posture (issue #2172a).
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+static SUBSCRIBER_ON: AtomicBool = AtomicBool::new(false);
+
+/// Guards the one-time install of the process-global subscriber.
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+static INSTALL_SUBSCRIBER: Once = Once::new();
+
+/// A per-callsite `tracing` filter whose verdict is re-evaluated on EVERY call so
+/// the runtime [`SUBSCRIBER_ON`] toggle is honored. Returning
+/// `Interest::sometimes()` from `callsite_enabled` is load-bearing: `always()` /
+/// `never()` would let `tracing` cache the first verdict per callsite and freeze
+/// the toggle.
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+struct ToggleFilter;
+
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+impl<S> tracing_subscriber::layer::Filter<S> for ToggleFilter {
+    fn enabled(
+        &self,
+        meta: &tracing::Metadata<'_>,
+        _cx: &tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        SUBSCRIBER_ON.load(Ordering::Relaxed) && *meta.level() <= tracing::Level::INFO
+    }
+
+    fn callsite_enabled(
+        &self,
+        _meta: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        // NEVER always()/never(): those cache the first verdict per callsite and
+        // would defeat the runtime toggle. `sometimes()` forces per-call
+        // `enabled()` re-evaluation.
+        tracing::subscriber::Interest::sometimes()
+    }
+}
+
+/// Install the process-global fmt subscriber (INFO, writing to `io::sink`) EXACTLY
+/// once, gated by [`ToggleFilter`]. Called at the top of each bench fn so the
+/// global is in place before any measurement regardless of which bench runs
+/// first. The baseline arms run with [`SUBSCRIBER_ON`] == false, so this global is
+/// a structurally-identical no-op in both the default and `observability` builds —
+/// the cross-build feature-overhead comparison is unaffected.
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+fn ensure_global_subscriber() {
+    use tracing_subscriber::prelude::*;
+    INSTALL_SUBSCRIBER.call_once(|| {
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_writer(std::io::sink)
+            .with_filter(ToggleFilter);
+        tracing_subscriber::registry().with(fmt_layer).init();
+    });
+}
+
+/// RAII guard that flips [`SUBSCRIBER_ON`] on for its lifetime and resets it on
+/// drop — so a panic inside the measured closure still clears the toggle and
+/// cannot leak the subscriber-on posture into a later baseline arm.
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+struct SubscriberOnGuard;
+
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+impl SubscriberOnGuard {
+    fn activate() -> Self {
+        SUBSCRIBER_ON.store(true, Ordering::Relaxed);
+        SubscriberOnGuard
+    }
+}
+
+#[cfg(any(feature = "cli-helpers", feature = "write-support"))]
+impl Drop for SubscriberOnGuard {
+    fn drop(&mut self) {
+        SUBSCRIBER_ON.store(false, Ordering::Relaxed);
+    }
 }
 
 #[path = "fixtures/mod.rs"]
@@ -94,6 +179,9 @@ pub const OVERHEAD_THRESHOLD_PCT: f64 = 2.0;
 #[cfg(feature = "cli-helpers")]
 fn bench_read_scan(c: &mut Criterion) {
     use criterion::{black_box, Throughput};
+
+    // Install the process-global subscriber before any measurement (idempotent).
+    ensure_global_subscriber();
 
     const REPEATS: usize = 8;
 
@@ -127,22 +215,21 @@ fn bench_read_scan(c: &mut Criterion) {
         });
     });
 
-    // Subscriber-on variant (issue #1703): identical work, but with a real fmt
-    // subscriber at INFO installed for the whole measurement — the CLI's default
-    // posture. Advisory number recorded by the comparison script.
+    // Subscriber-on variant (issue #1703 / #2172a): identical work, but with the
+    // process-global INFO subscriber toggled ON for the whole measurement — the
+    // CLI's default posture, now faithfully counting spans on `spawn_blocking`
+    // threads too. Advisory number recorded by the comparison script.
     group.bench_function("read_scan_subscriber_on", |b| {
-        let subscriber = info_sink_subscriber();
-        tracing::subscriber::with_default(subscriber, || {
-            b.iter(|| {
-                let mut rows = 0usize;
-                for _ in 0..REPEATS {
-                    let res = rt
-                        .block_on(loaded.db.execute(black_box(&sql)))
-                        .expect("overhead read scan (subscriber on)");
-                    rows += res.rows.len();
-                }
-                black_box(rows)
-            });
+        let _on = SubscriberOnGuard::activate();
+        b.iter(|| {
+            let mut rows = 0usize;
+            for _ in 0..REPEATS {
+                let res = rt
+                    .block_on(loaded.db.execute(black_box(&sql)))
+                    .expect("overhead read scan (subscriber on)");
+                rows += res.rows.len();
+            }
+            black_box(rows)
         });
     });
     group.finish();
@@ -161,6 +248,9 @@ fn bench_read_scan(c: &mut Criterion) {
 fn bench_write_merge(c: &mut Criterion) {
     use criterion::{black_box, BatchSize, Throughput};
     use rand::Rng;
+
+    // Install the process-global subscriber before any measurement (idempotent).
+    ensure_global_subscriber();
 
     /// Fixed number of rows ingested + flushed per iteration. Deterministic via
     /// the shared seeded RNG.
@@ -207,32 +297,30 @@ fn bench_write_merge(c: &mut Criterion) {
         );
     });
 
-    // Subscriber-on variant (issue #1703): identical ingest, but with a real fmt
-    // subscriber at INFO installed for the whole measurement — the CLI's default
-    // posture (per-mutation write.mutation / wal.* / memtable.insert spans are
-    // DEBUG post-#1703, so an INFO subscriber filters them out). Advisory number.
+    // Subscriber-on variant (issue #1703 / #2172a): identical ingest, but with the
+    // process-global INFO subscriber toggled ON for the whole measurement — the
+    // CLI's default posture (per-mutation write.mutation / wal.* / memtable.insert
+    // spans are DEBUG post-#1703, so the INFO filter drops them). Advisory number.
     group.bench_function("write_merge_subscriber_on", |b| {
-        let subscriber = info_sink_subscriber();
-        tracing::subscriber::with_default(subscriber, || {
-            b.iter_batched(
-                || {
-                    let tmp = tempfile::TempDir::new()
-                        .expect("temp dir for write overhead bench (subscriber on)");
-                    let engine = fixtures::open_write_engine_wal_off(tmp.path(), usize::MAX);
-                    (tmp, engine)
-                },
-                |(_tmp, mut engine)| {
-                    fill_engine(&mut engine);
-                    assert_eq!(
-                        engine.memtable_row_count(),
-                        ROWS as usize,
-                        "write_merge overhead (subscriber on): every row must reach the memtable"
-                    );
-                    black_box(engine.memtable_row_count())
-                },
-                BatchSize::SmallInput,
-            );
-        });
+        let _on = SubscriberOnGuard::activate();
+        b.iter_batched(
+            || {
+                let tmp = tempfile::TempDir::new()
+                    .expect("temp dir for write overhead bench (subscriber on)");
+                let engine = fixtures::open_write_engine_wal_off(tmp.path(), usize::MAX);
+                (tmp, engine)
+            },
+            |(_tmp, mut engine)| {
+                fill_engine(&mut engine);
+                assert_eq!(
+                    engine.memtable_row_count(),
+                    ROWS as usize,
+                    "write_merge overhead (subscriber on): every row must reach the memtable"
+                );
+                black_box(engine.memtable_row_count())
+            },
+            BatchSize::SmallInput,
+        );
     });
     group.finish();
 }

--- a/cqlite-core/tests/issue_1703_select_info_level.rs
+++ b/cqlite-core/tests/issue_1703_select_info_level.rs
@@ -1,7 +1,8 @@
-//! Issue #1703 (epic #1686, AI3 "observability honesty"): a single SELECT
-//! executed through the public query API MUST emit AT MOST ONE INFO-level line
-//! at the default level — the per-query `tracing::info!` chatter in the SELECT
-//! executor is demoted to DEBUG.
+//! Issue #1703 (epic #1686, AI3 "observability honesty") + #2172(b): a single
+//! SELECT executed through the public query API MUST emit AT MOST ONE INFO-level
+//! line at the default level — the per-query `tracing::info!` chatter in the
+//! SELECT executor is demoted to DEBUG — across the full-scan, targeted
+//! point-lookup, AND materialization branches.
 //!
 //! # What this pins
 //!
@@ -9,6 +10,17 @@
 //! ("Found schema for …", "Scan returned N rows", the point-lookup lines, the
 //! materialization line, …), all at the default INFO level. After the demotion
 //! those become DEBUG, so a subscriber capped at INFO sees ≤1 line per SELECT.
+//!
+//! Three phases run under ONE process-global subscriber, resetting the event
+//! tally to 0 between them:
+//!   - Phase 1 — full-table `SELECT *` (the scan branch);
+//!   - Phase 2 — targeted `WHERE id = <uuid>` point lookup (the partition-key
+//!     point-lookup branch in `execute.rs`), using a REAL partition key read
+//!     from the fixture so the branch actually runs and returns ≥1 row;
+//!   - Phase 3 — materialization via `execute_streaming` with a reshaping
+//!     projection (`SELECT name AS n`), which trips `requires_materialization`
+//!     and drives the materialization debug site in `execute_streaming`
+//!     (`mod.rs`), draining the iterator so the path really executes.
 //!
 //! # Wiring evidence
 //!
@@ -23,9 +35,9 @@
 //! blocking-pool threads. A thread-local default installed on the test's own
 //! task is NOT observed there, so it would under-count (or miss entirely) any
 //! INFO emitted on a blocking-pool thread — a vacuous-pass risk (roborev,
-//! issue #1703 fix-round 2). This file contains exactly one test, so a
-//! process-wide global default is safe (no other test in this binary competes
-//! for it).
+//! issue #1703 fix-round 2). Because `set_global_default` can be called only
+//! ONCE per binary, this file keeps exactly one `#[test]` and reuses the single
+//! global across all three phases (safe: no other test competes for it).
 //!
 //! Requires `CQLITE_DATASETS_ROOT` + fetched binaries; skips (never fails) when
 //! the fixture is absent, and treats a present-but-0-rows scan as a hard failure
@@ -138,17 +150,18 @@ async fn setup(keyspace: &str, schema_file: &str) -> Option<Database> {
     Some(result.database)
 }
 
-/// One full-scan SELECT, observed through a real INFO-capped subscriber, must
-/// emit AT MOST ONE INFO line. RED before the demotion (info sites fire on
-/// whichever thread runs them, including `spawn_blocking` worker threads);
-/// GREEN after (0).
+/// SELECTs across the scan, targeted point-lookup, and materialization branches,
+/// each observed through a real INFO-capped subscriber, must emit AT MOST ONE
+/// INFO line. RED before the demotion (info sites fire on whichever thread runs
+/// them, including `spawn_blocking` worker threads); GREEN after (0).
 ///
 /// Uses a MULTI-thread tokio runtime (not the `#[tokio::test]` default
 /// current-thread flavor) so `spawn_blocking` closures really do run on a
 /// separate OS thread from the test task — the exact cross-thread hazard this
-/// test's global subscriber must be able to observe.
+/// test's global subscriber must be able to observe. One `set_global_default`
+/// for the binary; the event tally is reset to 0 between phases.
 #[test]
-fn select_emits_at_most_one_info_line() {
+fn select_branches_emit_at_most_one_info_line() {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
         .enable_all()
@@ -178,15 +191,19 @@ fn select_emits_at_most_one_info_line() {
         // default installed only on this task would miss any INFO emitted
         // there, making the assertion vacuously pass. `set_global_default` is
         // observed by every thread in the process. This file has exactly one
-        // test, so calling it once is safe.
+        // test, so calling it once is safe; the phases below reuse it.
         tracing::subscriber::set_global_default(subscriber)
             .expect("set_global_default must succeed (only test in this binary)");
 
+        let reset = || tally.events.store(0, Ordering::Relaxed);
+        let info_lines = || tally.events.load(Ordering::Relaxed);
+
+        // ---- Phase 1: full-table SELECT * (the scan branch) --------------
+        reset();
         let result = db
             .execute("SELECT * FROM test_basic.simple_table")
             .await
             .expect("scan");
-
         // A present fixture must return rows — otherwise the scan info sites
         // never fired and the assertion below would pass vacuously.
         assert!(
@@ -195,13 +212,68 @@ fn select_emits_at_most_one_info_line() {
              regression, not a skip",
             result.rows.len()
         );
-
-        let info_lines = tally.events.load(Ordering::Relaxed);
         assert!(
-            info_lines <= 1,
-            "a single SELECT emitted {info_lines} INFO lines (observed process-wide, \
-             including spawn_blocking threads), expected ≤1 — the per-query SELECT \
-             `info!` chatter must be demoted to DEBUG (issue #1703)"
+            info_lines() <= 1,
+            "full-scan SELECT emitted {} INFO lines (observed process-wide, including \
+             spawn_blocking threads), expected ≤1 (issue #1703)",
+            info_lines()
+        );
+
+        // ---- Phase 2: targeted WHERE id = <uuid> point lookup ------------
+        // Read a REAL partition key from the fixture so the point-lookup branch
+        // in execute.rs actually runs (not a synthetic key that matches nothing).
+        let id_row = db
+            .execute("SELECT id FROM test_basic.simple_table LIMIT 1")
+            .await
+            .expect("id probe");
+        let id_uuid = match id_row.rows.first().and_then(|r| r.get("id")) {
+            Some(cqlite_core::types::Value::Uuid(bytes)) => uuid::Uuid::from_bytes(*bytes),
+            other => panic!("expected a UUID `id` from the fixture, got {other:?}"),
+        };
+        reset();
+        let point = db
+            .execute(&format!(
+                "SELECT * FROM test_basic.simple_table WHERE id = {id_uuid}"
+            ))
+            .await
+            .expect("point lookup");
+        assert!(
+            !point.rows.is_empty(),
+            "targeted WHERE id = {id_uuid} returned 0 rows — the point-lookup branch did \
+             not run, so its info sites never fired (vacuous)"
+        );
+        assert!(
+            info_lines() <= 1,
+            "targeted point-lookup SELECT emitted {} INFO lines, expected ≤1 (issue #1703)",
+            info_lines()
+        );
+
+        // ---- Phase 3: materialization via execute_streaming --------------
+        // `SELECT name AS n` is a reshaping projection → `requires_materialization`
+        // is true (mod.rs), so this drives the materialization debug site in
+        // `execute_streaming`. Drain the iterator so the path really executes.
+        reset();
+        let mut iter = db
+            .execute_streaming(
+                "SELECT name AS n FROM test_basic.simple_table",
+                cqlite_core::query::result::StreamingConfig::default(),
+            )
+            .await
+            .expect("streaming materialization");
+        let mut drained = 0usize;
+        while let Some(row) = iter.next_async().await {
+            row.expect("streamed row");
+            drained += 1;
+        }
+        assert!(
+            drained > 0,
+            "materialization SELECT drained 0 rows — the materialization path did not run \
+             (vacuous); expected the fixture's full row set"
+        );
+        assert!(
+            info_lines() <= 1,
+            "materialization SELECT emitted {} INFO lines, expected ≤1 (issue #1703)",
+            info_lines()
         );
     });
 }

--- a/cqlite-core/tests/issue_1703_write_span_levels.rs
+++ b/cqlite-core/tests/issue_1703_write_span_levels.rs
@@ -1,21 +1,40 @@
-//! Issue #1703 (epic #1686, AI3 "observability honesty"): the write-side
-//! `#[tracing::instrument]` spans MUST emit at DEBUG, not INFO, so that at the
-//! CLI's default INFO level a batch of N mutations does NOT emit O(N) spans.
+//! Issue #1703 (epic #1686, AI3 "observability honesty") + #2172(b): the
+//! write-side `#[tracing::instrument]` spans MUST emit at DEBUG, not INFO, so
+//! that at the CLI's default INFO level a batch of N mutations — through ANY of
+//! the public write entry points — does NOT emit O(N) spans.
 //!
 //! # What this pins
 //!
-//! A batch of N mutations drives, per mutation, the `write.mutation`,
-//! `wal.append`, `wal.sync`, and `memtable.insert` spans. Before this change all
-//! four defaulted to INFO (no `level` on the attribute), so a real subscriber
-//! installed at INFO — the exact posture a CLI user / embedder experiences — saw
-//! ~3–4N spans per batch. After the uniform DEBUG demotion, none of those spans
-//! reach a subscriber capped at INFO, so the INFO-level span count is O(1).
+//! Every public write entry point drives a family of write-side spans:
+//!   - sync `write()` / async `write_async()` → `write.mutation` (+ `wal.append`,
+//!     `wal.sync`, `memtable.insert` per mutation);
+//!   - sync `execute("INSERT …")` → `write.cql_execute`;
+//!   - async `execute_flushing("INSERT …")` (the Node/Python binding path) →
+//!     `write.cql_execute_flushing`, and when it crosses the flush threshold the
+//!     flush spans `flush.memtable`;
+//!   - async `flush()` → `flush.public` (+ nested `flush.memtable`);
+//!   - `maintenance_step()` → `compaction.maintenance_step`,
+//!     `compaction.scan_candidates`, `compaction.policy_select`.
+//!
+//! Before the #1703 demotion these defaulted to INFO, so a real subscriber at
+//! INFO — the exact posture a CLI user / embedder experiences — saw O(N) spans
+//! per batch. After the uniform DEBUG demotion, NONE of them reach a subscriber
+//! capped at INFO, so the INFO-level span count is O(1) on every path.
 //!
 //! # Wiring evidence
 //!
 //! The count is observed through a REAL `tracing_subscriber::registry()`
-//! subscriber with an `INFO` level filter (not a helper or a mock) — proving the
-//! *default output* is quiet, exactly what a CLI user sees.
+//! subscriber with an `INFO` level filter (not a helper or a mock), proving the
+//! *default output* is quiet.
+//!
+//! Installed as the **process-global** default (`set_global_default`), not a
+//! thread-local (`with_default`). `execute_flushing`/`flush` cross `spawn_blocking`
+//! onto separate tokio blocking-pool threads during the SSTable flush, and the
+//! async phases run on a MULTI-thread runtime so those closures really do run off
+//! the test task; a thread-local default would miss any INFO emitted there
+//! (a vacuous-pass risk). `set_global_default` is observed by every thread. This
+//! file contains exactly ONE `#[test]`, so calling it once is safe; the phases
+//! run sequentially and RESET the captured span-name list between them.
 //!
 //! Routing: design-driven (OpenSpec change `demote-write-spans`). No production
 //! behavior changes beyond the span level; names/keys are unchanged.
@@ -25,6 +44,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use cqlite_core::schema::{Column, KeyColumn, TableSchema};
 use cqlite_core::storage::write_engine::{
@@ -41,9 +61,25 @@ use tracing_subscriber::registry::LookupSpan;
 
 const KEYSPACE: &str = "ks_1703";
 const TABLE: &str = "span_levels_t";
-/// Number of mutations written in the batch. Kept small so the per-write
+/// Number of mutations written per phase. Kept small so the per-write
 /// `wal.sync` fsync stays cheap and deterministic.
 const N: usize = 16;
+
+/// Every write-side span name that #1703 demoted to DEBUG. NONE of these may be
+/// observed through an INFO-capped subscriber on any public write path.
+const DEMOTED_WRITE_SPANS: &[&str] = &[
+    "write.mutation",
+    "write.cql_execute",
+    "write.cql_execute_flushing",
+    "wal.append",
+    "wal.sync",
+    "memtable.insert",
+    "flush.public",
+    "flush.memtable",
+    "compaction.policy_select",
+    "compaction.maintenance_step",
+    "compaction.scan_candidates",
+];
 
 /// Shared, thread-safe tallies for the counting subscriber below.
 #[derive(Clone, Default)]
@@ -52,6 +88,22 @@ struct Tally {
     span_names: Arc<Mutex<Vec<String>>>,
     /// Count of events (log lines) at or above the level filter.
     events: Arc<AtomicUsize>,
+}
+
+impl Tally {
+    /// Clear the captured span names + event count between phases so each phase
+    /// asserts against only the spans IT produced.
+    fn reset(&self) {
+        if let Ok(mut names) = self.span_names.lock() {
+            names.clear();
+        }
+        self.events.store(0, Ordering::Relaxed);
+    }
+
+    /// Snapshot the captured INFO-level span names.
+    fn info_spans(&self) -> Vec<String> {
+        self.span_names.lock().expect("span names lock").clone()
+    }
 }
 
 /// A `tracing` layer that records the NAME of every span it is handed and counts
@@ -121,63 +173,150 @@ fn mutation(i: usize) -> Mutation {
     )
 }
 
-/// A batch of N mutations, observed through a real INFO-capped subscriber, must
-/// emit an O(1) number of INFO-level spans — NOT the ~3–4N the write spans
-/// produced when they defaulted to INFO. Specifically, none of the write-side
-/// span names may appear at INFO.
+fn insert_sql(i: usize) -> String {
+    format!("INSERT INTO {KEYSPACE}.{TABLE} (id, value) VALUES ({i}, 'row-{i}')")
+}
+
+/// Build a fresh engine over a throwaway temp dir. `SyncEachWrite` so
+/// `wal.append` + `wal.sync` fire per write; the caller picks the flush
+/// threshold (`usize::MAX` to suppress auto-flush, or a small value to force a
+/// mid-batch flush). The returned `TempDir` must outlive the engine.
+fn build_engine(flush_threshold: usize) -> (TempDir, WriteEngine) {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        span_schema(),
+    )
+    .with_flush_threshold(flush_threshold)
+    .with_durability(Durability::SyncEachWrite);
+    let engine = WriteEngine::new(config).expect("engine");
+    (temp_dir, engine)
+}
+
+/// Assert that a phase produced an O(1) number of INFO spans and that NONE of the
+/// demoted write-side span names were observed at INFO.
+fn assert_quiet(phase: &str, tally: &Tally) {
+    let info_spans = tally.info_spans();
+    let n_info = info_spans.len();
+
+    // O(1), not O(N): the INFO span count must not scale with the batch size.
+    assert!(
+        n_info < N,
+        "phase `{phase}`: expected O(1) INFO-level spans for a batch of N={N}, got \
+         {n_info}: {info_spans:?} — a write-side span is still at INFO (issue #1703)"
+    );
+
+    for name in DEMOTED_WRITE_SPANS {
+        assert!(
+            !info_spans.iter().any(|s| s == name),
+            "phase `{phase}`: span `{name}` was emitted at INFO but MUST be DEBUG \
+             (issue #1703); captured INFO spans: {info_spans:?}"
+        );
+    }
+}
+
+/// Every public write entry point, observed through a real INFO-capped
+/// subscriber, must emit an O(1) number of INFO-level spans — NOT the O(N) the
+/// write spans produced when they defaulted to INFO. The phases run under ONE
+/// process-global subscriber (one `set_global_default` per binary), resetting
+/// the captured span-name list between them.
 ///
-/// RED before the demotion (each `write.mutation` / `wal.append` / `wal.sync` /
-/// `memtable.insert` span is INFO, so ~4N names are captured); GREEN after (0).
+/// RED before the demotion (each write/wal/memtable/flush/compaction span is
+/// INFO, so O(N) names are captured); GREEN after (0 demoted names).
 #[test]
-fn write_batch_emits_no_info_spans() {
+fn write_paths_emit_no_info_spans() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("multi-thread runtime");
+
     let tally = Tally::default();
     let layer = CountingLayer {
         tally: tally.clone(),
     }
     .with_filter(LevelFilter::INFO);
     let subscriber = tracing_subscriber::registry().with(layer);
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("set_global_default must succeed (only test in this binary)");
 
-    tracing::subscriber::with_default(subscriber, || {
-        let temp_dir = TempDir::new().expect("tempdir");
-        let config = WriteEngineConfig::new(
-            temp_dir.path().join("data"),
-            temp_dir.path().join("wal"),
-            span_schema(),
-        )
-        // High threshold so the batch never auto-flushes: we are measuring the
-        // per-mutation write spans, not flush spans.
-        .with_flush_threshold(usize::MAX)
-        // SyncEachWrite so `wal.append` + `wal.sync` fire per write — the exact
-        // per-mutation spans the audit flagged.
-        .with_durability(Durability::SyncEachWrite);
-
-        let mut engine = WriteEngine::new(config).expect("engine");
+    // ---- Phase 1: sync write() batch (write.mutation + wal.* + memtable.insert)
+    {
+        let (_tmp, mut engine) = build_engine(usize::MAX);
         for i in 0..N {
-            engine.write(mutation(i)).expect("write");
+            engine.write(mutation(i)).expect("sync write");
+        }
+    }
+    assert_quiet("sync write()", &tally);
+    tally.reset();
+
+    // ---- Phase 2: sync execute("INSERT …") (write.cql_execute)
+    {
+        let (_tmp, mut engine) = build_engine(usize::MAX);
+        for i in 0..N {
+            engine.execute(&insert_sql(i)).expect("sync execute");
+        }
+    }
+    assert_quiet("sync execute()", &tally);
+    tally.reset();
+
+    // ---- Phase 3: async write_async().await (write.mutation)
+    rt.block_on(async {
+        let (_tmp, mut engine) = build_engine(usize::MAX);
+        for i in 0..N {
+            engine.write_async(mutation(i)).await.expect("write_async");
         }
     });
+    assert_quiet("async write_async()", &tally);
+    tally.reset();
 
-    let info_spans = tally.span_names.lock().expect("span names lock").clone();
-    let n_info = info_spans.len();
+    // ---- Phase 4: async execute_flushing().await crossing the flush threshold
+    // (write.cql_execute_flushing + flush.memtable, which crosses spawn_blocking).
+    rt.block_on(async {
+        // A tiny flush threshold so the memtable crosses it mid-batch and the
+        // flush path (spanning spawn_blocking onto worker threads) really runs.
+        let (_tmp, mut engine) = build_engine(64);
+        for i in 0..N {
+            engine
+                .execute_flushing(&insert_sql(i))
+                .await
+                .expect("execute_flushing");
+        }
+    });
+    assert_quiet("async execute_flushing() with flush", &tally);
+    tally.reset();
 
-    // O(1), not O(N): the count must not scale with the batch size.
-    assert!(
-        n_info < N,
-        "expected O(1) INFO-level spans for a batch of N={N} writes, got {n_info}: {info_spans:?} \
-         — the write-side spans are still at INFO (issue #1703 demotion missing)"
-    );
+    // ---- Phase 5: explicit async flush() (flush.public + nested flush.memtable)
+    rt.block_on(async {
+        let (_tmp, mut engine) = build_engine(usize::MAX);
+        for i in 0..N {
+            engine.write_async(mutation(i)).await.expect("write_async");
+        }
+        engine.flush().await.expect("flush");
+    });
+    assert_quiet("async flush()", &tally);
+    tally.reset();
 
-    // None of the demoted write-side spans may be observed at INFO.
-    for name in [
-        "write.mutation",
-        "wal.append",
-        "wal.sync",
-        "memtable.insert",
-    ] {
-        assert!(
-            !info_spans.iter().any(|s| s == name),
-            "span `{name}` was emitted at INFO but MUST be DEBUG (issue #1703); \
-             captured INFO spans: {info_spans:?}"
-        );
+    // ---- Phase 6: maintenance_step() (compaction.maintenance_step /
+    // scan_candidates / policy_select). A single step exercises all three
+    // compaction spans regardless of whether a merge is actually selected — the
+    // policy scan + select run on every step — so no heavy 4-SSTable setup is
+    // needed to pin the level.
+    {
+        let (_tmp, mut engine) = build_engine(64);
+        for i in 0..N {
+            engine
+                .execute(&insert_sql(i))
+                .expect("execute for compaction setup");
+        }
+        rt.block_on(async {
+            engine.flush().await.expect("flush before maintenance");
+        });
+        tally.reset();
+        engine
+            .maintenance_step(Duration::from_millis(50))
+            .expect("maintenance_step");
     }
+    assert_quiet("maintenance_step()", &tally);
 }


### PR DESCRIPTION
Closes #2172 (items **(a)** and **(b)** only — see note on (c) below).

Follow-ups triaged out of #1703 (PR #2169). Test + bench only — **no production `src/**` changes**.

## (a) P2 — faithful subscriber-on overhead bench
`cqlite-core/benches/observability_overhead.rs` previously installed the INFO subscriber via thread-local `tracing::subscriber::with_default`, so the `*_subscriber_on` arms only observed spans on the bench's own thread and **under-counted** work on `spawn_blocking`/blocking-pool threads (the read scan crosses these).

Fix: install a **process-global** subscriber exactly once (`Once`-guarded) with a `static AtomicBool` on/off toggle. A custom `Filter` returns `Interest::sometimes()` from `callsite_enabled` (defeats per-callsite verdict caching so the runtime toggle is honored) and gates `enabled()` on the atomic + `<= INFO`. Each `*_subscriber_on` arm flips the toggle on for its measured region via a panic-safe RAII guard; baseline arms run with it off. The global reaches every thread, so cross-thread spans are now counted. Bench group/IDs unchanged (comparison script contract preserved). The toggled-off baseline is identical structure across the default and `observability` builds, so the cross-build overhead delta still cancels.

Representative post-fix numbers (short criterion run): `read_scan` ≈ `read_scan_subscriber_on` and `write_merge` ≈ `write_merge_subscriber_on` (within noise) — expected, since #1703 demoted the write/read spans to DEBUG so an INFO subscriber drops them; the numbers are now trustworthy because the global subscriber observes the cross-thread spans the old thread-local variant silently missed.

## (b) Low — wider span/info demotion coverage
Extended the two #1703 regression tests (each keeps exactly one `#[test]` + one `set_global_default`, resetting its tally between phases):
- `issue_1703_write_span_levels.rs` — now pins **not-at-INFO** for `write.mutation` (sync `write` + `write_async`), `write.cql_execute` (`execute`), `write.cql_execute_flushing` (`execute_flushing`, crossing the flush threshold), `wal.append`, `wal.sync`, `memtable.insert`, `flush.public`, `flush.memtable`, and `compaction.{policy_select,scan_candidates,maintenance_step}` (via a single cheap `maintenance_step()`). Uses a process-global subscriber on a multi-thread runtime so `spawn_blocking` flush spans are observed.
- `issue_1703_select_info_level.rs` — adds a **targeted** point-lookup phase (`WHERE id = <real-uuid read from the fixture>`, asserts ≥1 row) and a **materialization** phase (`execute_streaming` with a reshaping projection that trips `requires_materialization`, iterator fully drained), each asserting ≤1 INFO line, alongside the existing full-scan phase.

## (c) — deliberately NOT included (product decision)
Item (c) proposed keeping one top-level "SELECT executed, N rows" INFO marker at the `db.execute()` boundary. The issue explicitly flags this as a **product/observability call**, so it is left out of this PR. #2172 can be closed on (a)+(b) alone, or the owner may decide whether (c) warrants its own follow-up.

## Verification
- Lite gate: PASS (file-size, fmt, clippy `-D warnings`, scoped tests).
- Both extended tests run non-skip and PASS locally (fixtures present).
- Review-first: `rust-reviewer` CLEAN (one informational nit re documenting `Relaxed` ordering — batched, non-blocking); roborev "No issues found".