### PR TITLE
fix(#2529): centralize max_compressed_length==0 guard at CompressionInfo::parse

### DIFF
--- a/cqlite-core/src/storage/sstable/compression_info.rs
+++ b/cqlite-core/src/storage/sstable/compression_info.rs
@@ -215,6 +215,19 @@ impl CompressionInfo {
 
         // 5. writeInt(max_compressed_length) — present for all Cassandra 5.0 (version >= "na") files
         let max_compressed_length = read_u32(&mut cursor, "max_compressed_length")?;
+        // A zero max_compressed_length is corrupt authoritative metadata: every
+        // downstream incompressible/raw-chunk fallback (`compressed.len() >=
+        // max_compressed_length`) would treat EVERY chunk as raw, silently returning
+        // still-compressed bytes as plaintext instead of a typed error (fail-open). The
+        // CRC32 check cannot catch this — it is computed over the genuinely-on-disk
+        // bytes. Reject it ONCE here at parse time so no consumer (e.g.
+        // ChunkSource::chunk, decode_scan_chunk, the #1869/#2524 windows) can ever
+        // observe an unguarded zero (issues #28 no-heuristics, #2529).
+        if max_compressed_length == 0 {
+            return Err(Error::InvalidFormat(
+                "max_compressed_length cannot be zero".to_string(),
+            ));
+        }
 
         // 6. writeLong(data_length)
         let data_length = read_u64(&mut cursor, "data_length")?;
@@ -470,6 +483,42 @@ mod tests {
             i32::MAX as u32,
             "Bug #638: max_compressed_length field must be exposed for incompressible-chunk fallback"
         );
+    }
+
+    #[test]
+    fn test_parse_rejects_zero_max_compressed_length() {
+        // Issue #2529: a corrupt CompressionInfo.db with max_compressed_length == 0
+        // must be rejected AT PARSE TIME, not silently tolerated. Otherwise every
+        // downstream `compressed.len() >= max_compressed_length` fallback (e.g.
+        // ChunkSource::chunk, decode_scan_chunk, the #1869/#2524 windows) treats every
+        // chunk as raw/incompressible and returns still-compressed bytes as plaintext
+        // (fail-open) — the CRC32 check cannot catch it. Rejecting once here closes the
+        // whole class transitively (no-heuristics mandate, issue #28).
+        let blob = make_compression_info_blob(
+            "LZ4Compressor",
+            &[],
+            16384,
+            0, // corrupt: max_compressed_length == 0
+            32768,
+            &[0, 8200],
+        );
+
+        let result = CompressionInfo::parse(&blob);
+        assert!(
+            result.is_err(),
+            "parse must reject max_compressed_length == 0 as corrupt, got {:?}",
+            result
+        );
+        match result {
+            Err(Error::InvalidFormat(msg)) => {
+                assert!(
+                    msg.contains("max_compressed_length"),
+                    "error should name the offending field, got: {}",
+                    msg
+                );
+            }
+            other => panic!("expected Error::InvalidFormat, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #2529

## Summary
#1869 and #2524 each added a per-call-site guard against
`max_compressed_length == 0` (a corrupt `CompressionInfo.db` that made the
incompressible/raw-chunk fallback treat every chunk as raw, failing OPEN —
silently returning still-compressed bytes as plaintext instead of a typed
error). This centralizes the fix: `CompressionInfo::parse` now rejects
`max_compressed_length == 0` at parse time with `Error::InvalidFormat`,
mirroring the file's existing `chunk_length==0`/`chunk_count==0` checks. All
production consumers read `max_compressed_length` from an already-parsed
`CompressionInfo`, so this one guard transitively protects every call site —
including the two NOT touched by #1869/#2524 that review found
(`ChunkSource::chunk`, `decode_scan_chunk`). The two existing per-call-site
guards become harmless defense-in-depth.

Oracle-driven, no OpenSpec, no-heuristics-aligned (reject corrupt authoritative
metadata at the source, not downstream).

## Review-first (rust-reviewer + roborev)
**Zero blockers.** rust-reviewer traced every `CompressionInfo`-populating
call site (all through `::parse`) and every raw-chunk-fallback consumer
(all read from an already-parsed `CompressionInfo`), confirmed the error type
matches the file's own convention, confirmed the test isolates the new guard
precisely (not a bare `.is_err()`), and confirmed no legitimate SSTable can
have `max_compressed_length == 0` (default is `i32::MAX`, both Cassandra's
writer and CQLite's own writer always emit `>= 1`) — no backward-compat risk.
One wording nit (my own PR-description overstated "test/fixture-only" for the
remaining struct-literal constructions; one production struct-literal exists
in `scan_stream_windowed_decode.rs` but doesn't bypass the guard — its value
is sourced transitively from an already-guarded parameter). roborev: no issues
found.

## Gate status
Lite:
```
==== AGENT-GATE LITE SUMMARY ====
commit: e28b75100 branch: issue-2529-centralize-compressed-length-guard dirty: no
file-size: PASS  fmt: PASS  clippy: PASS  scoped-tests: PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Full `agent-gate.sh` (the gate of record) + final roborev pass to be run by
`flow-closer`.