### PR TITLE
perf(#1672): serialize_value_into(&mut Vec<u8>) — kill fresh-Vec-per-cell + double copy

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/data_writer/cells.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/cells.rs
@@ -59,25 +59,8 @@ impl DataWriter {
             return Ok(());
         }
 
-        // Value
-        let value_bytes = serialize_value(value)?;
-
-        // Bounds check: value length must fit in i64
-        if value_bytes.len() > i64::MAX as usize {
-            return Err(Error::InvalidInput(format!(
-                "Value too large for column '{}': {} bytes (max {})",
-                column,
-                value_bytes.len(),
-                i64::MAX
-            )));
-        }
-
-        if cell_value_uses_length_prefix(value) {
-            encode_unsigned(value_bytes.len() as u64, buf);
-        }
-
-        // Write value bytes
-        buf.extend_from_slice(&value_bytes);
+        // Value — fixed-width scalars go straight into `buf` (issue #1672).
+        write_cell_value_into(buf, column, value)?;
 
         Ok(())
     }
@@ -122,21 +105,7 @@ impl DataWriter {
             return Ok(());
         }
 
-        let value_bytes = serialize_value(value)?;
-        if value_bytes.len() > i64::MAX as usize {
-            return Err(Error::InvalidInput(format!(
-                "Value too large for column '{}': {} bytes (max {})",
-                column,
-                value_bytes.len(),
-                i64::MAX
-            )));
-        }
-
-        if cell_value_uses_length_prefix(value) {
-            encode_unsigned(value_bytes.len() as u64, buf);
-        }
-
-        buf.extend_from_slice(&value_bytes);
+        write_cell_value_into(buf, column, value)?;
         Ok(())
     }
 
@@ -227,25 +196,8 @@ impl DataWriter {
             return Ok(());
         }
 
-        // Value
-        let value_bytes = serialize_value(value)?;
-
-        // Bounds check: value length must fit in i64
-        if value_bytes.len() > i64::MAX as usize {
-            return Err(Error::InvalidInput(format!(
-                "Value too large for column '{}': {} bytes (max {})",
-                column,
-                value_bytes.len(),
-                i64::MAX
-            )));
-        }
-
-        if cell_value_uses_length_prefix(value) {
-            encode_unsigned(value_bytes.len() as u64, buf);
-        }
-
-        // Write value bytes
-        buf.extend_from_slice(&value_bytes);
+        // Value — fixed-width scalars go straight into `buf` (issue #1672).
+        write_cell_value_into(buf, column, value)?;
 
         Ok(())
     }
@@ -275,21 +227,7 @@ impl DataWriter {
             return Ok(());
         }
 
-        let value_bytes = serialize_value(value)?;
-        if value_bytes.len() > i64::MAX as usize {
-            return Err(Error::InvalidInput(format!(
-                "Value too large for column '{}': {} bytes (max {})",
-                column,
-                value_bytes.len(),
-                i64::MAX
-            )));
-        }
-
-        if cell_value_uses_length_prefix(value) {
-            encode_unsigned(value_bytes.len() as u64, buf);
-        }
-
-        buf.extend_from_slice(&value_bytes);
+        write_cell_value_into(buf, column, value)?;
         Ok(())
     }
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
@@ -454,8 +454,9 @@ impl DataWriter {
         elements.sort_by(|a, b| compare_cell_paths(&a.cell_path, &b.cell_path, true));
 
         encode_unsigned(elements.len() as u64, buf);
+        let mut value_scratch = Vec::new();
         for elem in &elements {
-            self.write_complex_element_cell(buf, elem, timestamp_micros)?;
+            self.write_complex_element_cell(buf, elem, timestamp_micros, &mut value_scratch)?;
         }
         Ok(())
     }
@@ -665,30 +666,33 @@ impl DataWriter {
         // unsigned-byte otherwise) from the key `Value`s. Null keys rejected inline.
         let mut ordered: Vec<&(Value, Value)> = entries.iter().collect();
         ordered.sort_by(|a, b| compare_collection_elements(&a.0, &b.0));
-        let serialized: Vec<(Vec<u8>, Vec<u8>)> = ordered
-            .iter()
-            .map(|(key, val)| {
-                if matches!(key, Value::Null) {
-                    return Err(Error::InvalidInput(
-                        "MAP keys cannot be null (CQL semantics)".to_string(),
-                    ));
-                }
-                Ok((serialize_value(key)?, serialize_value(val)?))
-            })
-            .collect::<Result<Vec<_>>>()?;
 
-        encode_unsigned(serialized.len() as u64, buf); // cell count
-        for (path_bytes, value_bytes) in &serialized {
+        // Reusable per-entry scratch (issue #1672): one alloc for the whole map,
+        // not a Vec-of-Vecs holding every key/value.
+        encode_unsigned(ordered.len() as u64, buf); // cell count
+        let mut key_scratch = Vec::new();
+        let mut val_scratch = Vec::new();
+        for (key, val) in ordered {
+            if matches!(key, Value::Null) {
+                return Err(Error::InvalidInput(
+                    "MAP keys cannot be null (CQL semantics)".to_string(),
+                ));
+            }
+
             // Cell header: flags + optional TTL fields
             self.write_complex_cell_header(buf, 0, timestamp_micros, ttl_seconds, now_seconds)?;
 
             // Cell path: serialized key
-            encode_unsigned(path_bytes.len() as u64, buf);
-            buf.extend_from_slice(path_bytes);
+            key_scratch.clear();
+            serialize_value_into(key, &mut key_scratch)?;
+            encode_unsigned(key_scratch.len() as u64, buf);
+            buf.extend_from_slice(&key_scratch);
 
             // Cell value: serialized value
-            encode_unsigned(value_bytes.len() as u64, buf);
-            buf.extend_from_slice(value_bytes);
+            val_scratch.clear();
+            serialize_value_into(val, &mut val_scratch)?;
+            encode_unsigned(val_scratch.len() as u64, buf);
+            buf.extend_from_slice(&val_scratch);
         }
 
         Ok(())
@@ -719,6 +723,8 @@ impl DataWriter {
         // Cell count
         encode_unsigned(elements.len() as u64, buf);
 
+        // Reusable per-element scratch buffer (issue #1672).
+        let mut value_scratch = Vec::new();
         for (i, elem) in elements.iter().enumerate() {
             // Reject null elements inline (CQL semantics)
             if matches!(elem, Value::Null) {
@@ -736,9 +742,10 @@ impl DataWriter {
             buf.extend_from_slice(&timeuuid);
 
             // Cell value: serialized element
-            let value_bytes = serialize_value(elem)?;
-            encode_unsigned(value_bytes.len() as u64, buf);
-            buf.extend_from_slice(&value_bytes);
+            value_scratch.clear();
+            serialize_value_into(elem, &mut value_scratch)?;
+            encode_unsigned(value_scratch.len() as u64, buf);
+            buf.extend_from_slice(&value_scratch);
         }
 
         Ok(())
@@ -828,8 +835,9 @@ impl DataWriter {
         encode_unsigned(ordered.len() as u64, buf);
 
         // ---- Per-element cells.
+        let mut value_scratch = Vec::new();
         for elem in ordered {
-            self.write_complex_element_cell(buf, elem, row_ts)?;
+            self.write_complex_element_cell(buf, elem, row_ts, &mut value_scratch)?;
         }
 
         Ok(())
@@ -850,11 +858,14 @@ impl DataWriter {
     /// A tombstone (`is_deleted`) carries no value bytes, so it sets
     /// HAS_EMPTY_VALUE (0x04) alongside IS_DELETED (0x01) — final flags 0x05 —
     /// matching Cassandra's Cell.Serializer (`hasValue = !flag(HAS_EMPTY_VALUE)`).
+    /// `value_scratch` (issue #1672): caller-owned buffer reused across the
+    /// element loop; cleared before serializing each element's value.
     pub(super) fn write_complex_element_cell(
         &self,
         buf: &mut Vec<u8>,
         elem: &ComplexElementWrite,
         row_ts: i64,
+        value_scratch: &mut Vec<u8>,
     ) -> Result<()> {
         // Determine flags.
         //
@@ -950,9 +961,10 @@ impl DataWriter {
         let has_empty_value = (flags & CELL_HAS_EMPTY_VALUE) != 0;
         if !has_empty_value {
             if let Some(value) = &elem.value {
-                let value_bytes = serialize_value(value)?;
-                encode_unsigned(value_bytes.len() as u64, buf);
-                buf.extend_from_slice(&value_bytes);
+                value_scratch.clear();
+                serialize_value_into(value, value_scratch)?;
+                encode_unsigned(value_scratch.len() as u64, buf);
+                buf.extend_from_slice(value_scratch);
             }
         }
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
@@ -143,62 +143,93 @@ pub(crate) fn len_as_i32(len: usize) -> Result<i32> {
 }
 
 /// Serialize a collection element, rejecting null (CQL semantics: lists/sets cannot contain null).
+///
+/// Thin wrapper over [`serialize_collection_element_into`] preserving the
+/// owned-`Vec` signature that the comparator fallback (`collection_order`) and
+/// tests depend on.
 pub(crate) fn serialize_collection_element(
     value: &Value,
     collection_kind: &str,
 ) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    serialize_collection_element_into(value, collection_kind, &mut out)?;
+    Ok(out)
+}
+
+/// Serialize a collection element directly into `out`, rejecting null (CQL
+/// semantics: lists/sets cannot contain null). Byte-identical to
+/// [`serialize_collection_element`] with zero throwaway allocation (issue #1672).
+pub(crate) fn serialize_collection_element_into(
+    value: &Value,
+    collection_kind: &str,
+    out: &mut Vec<u8>,
+) -> Result<()> {
     if matches!(value, Value::Null) {
         return Err(Error::InvalidInput(format!(
             "{} elements cannot be null (CQL semantics)",
             collection_kind
         )));
     }
-    serialize_value(value)
+    serialize_value_into(value, out)
 }
 
-/// Serialize a Value to bytes for cell storage
+/// Serialize a Value to bytes for cell storage.
 ///
-/// This follows Cassandra's type-specific serialization rules.
+/// Thin wrapper over [`serialize_value_into`], preserving the owned-`Vec`
+/// signature that the comparator, UDT canonicalization, clustering-key
+/// serialization, and tests depend on. Callers on the hot write path should
+/// prefer [`serialize_value_into`] to write straight into their destination
+/// buffer (issue #1672).
 pub(crate) fn serialize_value(value: &Value) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    serialize_value_into(value, &mut out)?;
+    Ok(out)
+}
+
+/// Serialize a Value directly into `out`, following Cassandra's type-specific
+/// serialization rules. Byte-identical to [`serialize_value`] but writes into a
+/// caller-supplied buffer with no per-value throwaway `Vec` (issue #1672, R1).
+///
+/// The FIXED-WIDTH i32 length prefixes of List/Set/Map/Tuple are back-patched in
+/// place: reserve 4 bytes, serialize the element into `out`, then overwrite the
+/// reservation with the encoded length — so nested collections never build a
+/// per-element temporary either.
+pub(crate) fn serialize_value_into(value: &Value, out: &mut Vec<u8>) -> Result<()> {
     match value {
-        Value::Null => Ok(Vec::new()),
-        Value::Boolean(b) => Ok(vec![if *b { 1 } else { 0 }]),
-        Value::TinyInt(n) => Ok(vec![*n as u8]),
-        Value::SmallInt(n) => Ok(n.to_be_bytes().to_vec()),
-        Value::Integer(n) => Ok(n.to_be_bytes().to_vec()),
-        Value::BigInt(n) => Ok(n.to_be_bytes().to_vec()),
-        Value::Counter(n) => Ok(n.to_be_bytes().to_vec()),
-        Value::Float32(f) => Ok(f.to_bits().to_be_bytes().to_vec()),
-        Value::Float(f) => Ok(f.to_bits().to_be_bytes().to_vec()),
-        Value::Text(s) => Ok(s.as_bytes().to_vec()),
-        Value::Blob(bytes) => Ok(bytes.clone()),
-        Value::Timestamp(millis) => Ok(millis.to_be_bytes().to_vec()),
+        Value::Null => {}
+        Value::Boolean(b) => out.push(if *b { 1 } else { 0 }),
+        Value::TinyInt(n) => out.push(*n as u8),
+        Value::SmallInt(n) => out.extend_from_slice(&n.to_be_bytes()),
+        Value::Integer(n) => out.extend_from_slice(&n.to_be_bytes()),
+        Value::BigInt(n) => out.extend_from_slice(&n.to_be_bytes()),
+        Value::Counter(n) => out.extend_from_slice(&n.to_be_bytes()),
+        Value::Float32(f) => out.extend_from_slice(&f.to_bits().to_be_bytes()),
+        Value::Float(f) => out.extend_from_slice(&f.to_bits().to_be_bytes()),
+        Value::Text(s) => out.extend_from_slice(s.as_bytes()),
+        Value::Blob(bytes) => out.extend_from_slice(bytes),
+        Value::Timestamp(millis) => out.extend_from_slice(&millis.to_be_bytes()),
         Value::Date(days) => {
             // Cassandra DATE: stored as unsigned int with Integer.MIN_VALUE offset
             let stored = days.wrapping_sub(i32::MIN) as u32;
-            Ok(stored.to_be_bytes().to_vec())
+            out.extend_from_slice(&stored.to_be_bytes());
         }
-        Value::Time(nanos) => Ok(nanos.to_be_bytes().to_vec()),
-        Value::Uuid(bytes) => Ok(bytes.to_vec()),
-        Value::Inet(bytes) => Ok(bytes.clone()),
-        Value::Varint(bytes) => Ok(bytes.clone()),
+        Value::Time(nanos) => out.extend_from_slice(&nanos.to_be_bytes()),
+        Value::Uuid(bytes) => out.extend_from_slice(bytes),
+        Value::Inet(bytes) => out.extend_from_slice(bytes),
+        Value::Varint(bytes) => out.extend_from_slice(bytes),
         Value::Decimal { scale, unscaled } => {
-            let mut result = Vec::new();
-            result.extend_from_slice(&scale.to_be_bytes());
-            result.extend_from_slice(unscaled);
-            Ok(result)
+            out.extend_from_slice(&scale.to_be_bytes());
+            out.extend_from_slice(unscaled);
         }
         Value::Duration {
             months,
             days,
             nanos,
         } => {
-            let mut result = Vec::new();
             // Cassandra DurationType stores three signed VInts, not fixed-width ints.
-            encode_signed(*months as i64, &mut result);
-            encode_signed(*days as i64, &mut result);
-            encode_signed(*nanos, &mut result);
-            Ok(result)
+            encode_signed(*months as i64, out);
+            encode_signed(*days as i64, out);
+            encode_signed(*nanos, out);
         }
         Value::Udt(udt_value) => {
             // Construct UdtTypeDef from UdtValue fields by inferring types
@@ -211,19 +242,20 @@ pub(crate) fn serialize_value(value: &Value) -> Result<Vec<u8>> {
                 schema = schema.with_field(field.name.clone(), field_type, true);
             }
 
+            // `serialize_udt` returns an owned Vec (its signature is out of R1
+            // scope); one temp per UDT cell is acceptable (R1 targets per-SCALAR
+            // -cell allocations).
             let serializer = TypeSerializer::new();
-            serializer.serialize_udt(value, &schema)
+            out.extend_from_slice(&serializer.serialize_udt(value, &schema)?);
         }
         Value::List(elements) => {
             // ListType preserves insertion order — do NOT sort.
-            let mut buf = Vec::new();
-            buf.extend_from_slice(&len_as_i32(elements.len())?.to_be_bytes());
+            out.extend_from_slice(&len_as_i32(elements.len())?.to_be_bytes());
             for elem in elements {
-                let elem_bytes = serialize_collection_element(elem, "Collection")?;
-                buf.extend_from_slice(&len_as_i32(elem_bytes.len())?.to_be_bytes());
-                buf.extend_from_slice(&elem_bytes);
+                write_len_prefixed_i32(out, |o| {
+                    serialize_collection_element_into(elem, "Collection", o)
+                })?;
             }
-            Ok(buf)
         }
         Value::Set(elements) => {
             // Cassandra SetType is a sorted collection: a frozen set serializes its
@@ -235,21 +267,17 @@ pub(crate) fn serialize_value(value: &Value) -> Result<Vec<u8>> {
             // complex.rs). A raw serialized-byte sort (the pre-#1275 behavior) put
             // negatives last, e.g. `frozen<set<int>>` of {-1,0,1} serialized in the
             // wrong order. Then serialize each element in that order
-            // (`serialize_collection_element` rejects Value::Null).
+            // (`serialize_collection_element_into` rejects Value::Null). Sorting the
+            // `&Value` refs needs no serialization.
             let mut ordered: Vec<&Value> = elements.iter().collect();
             ordered.sort_by(|a, b| compare_collection_elements(a, b));
-            let serialized: Vec<Vec<u8>> = ordered
-                .iter()
-                .map(|e| serialize_collection_element(e, "Collection"))
-                .collect::<Result<Vec<_>>>()?;
 
-            let mut buf = Vec::new();
-            buf.extend_from_slice(&len_as_i32(serialized.len())?.to_be_bytes());
-            for elem_bytes in &serialized {
-                buf.extend_from_slice(&len_as_i32(elem_bytes.len())?.to_be_bytes());
-                buf.extend_from_slice(elem_bytes);
+            out.extend_from_slice(&len_as_i32(ordered.len())?.to_be_bytes());
+            for elem in ordered {
+                write_len_prefixed_i32(out, |o| {
+                    serialize_collection_element_into(elem, "Collection", o)
+                })?;
             }
-            Ok(buf)
         }
         Value::Map(entries) => {
             // Cassandra MapType is a sorted collection: a frozen map serializes its
@@ -262,48 +290,94 @@ pub(crate) fn serialize_value(value: &Value) -> Result<Vec<u8>> {
             // key/value in that order.
             let mut ordered: Vec<&(Value, Value)> = entries.iter().collect();
             ordered.sort_by(|a, b| compare_collection_elements(&a.0, &b.0));
-            let serialized: Vec<(Vec<u8>, Vec<u8>)> = ordered
-                .iter()
-                .map(|(key, val)| {
-                    if matches!(key, Value::Null) {
-                        return Err(Error::InvalidInput(
-                            "MAP keys cannot be null (CQL semantics)".to_string(),
-                        ));
-                    }
-                    Ok((serialize_value(key)?, serialize_value(val)?))
-                })
-                .collect::<Result<Vec<_>>>()?;
 
-            let mut buf = Vec::new();
-            buf.extend_from_slice(&len_as_i32(serialized.len())?.to_be_bytes());
-            for (key_bytes, val_bytes) in &serialized {
-                buf.extend_from_slice(&len_as_i32(key_bytes.len())?.to_be_bytes());
-                buf.extend_from_slice(key_bytes);
-                buf.extend_from_slice(&len_as_i32(val_bytes.len())?.to_be_bytes());
-                buf.extend_from_slice(val_bytes);
+            out.extend_from_slice(&len_as_i32(ordered.len())?.to_be_bytes());
+            for (key, val) in ordered {
+                if matches!(key, Value::Null) {
+                    return Err(Error::InvalidInput(
+                        "MAP keys cannot be null (CQL semantics)".to_string(),
+                    ));
+                }
+                write_len_prefixed_i32(out, |o| serialize_value_into(key, o))?;
+                write_len_prefixed_i32(out, |o| serialize_value_into(val, o))?;
             }
-            Ok(buf)
         }
         Value::Tuple(fields) => {
-            let mut buf = Vec::new();
             for field in fields {
                 match field {
-                    Value::Null => buf.extend_from_slice(&(-1i32).to_be_bytes()),
-                    other => {
-                        let field_bytes = serialize_value(other)?;
-                        buf.extend_from_slice(&len_as_i32(field_bytes.len())?.to_be_bytes());
-                        buf.extend_from_slice(&field_bytes);
-                    }
+                    Value::Null => out.extend_from_slice(&(-1i32).to_be_bytes()),
+                    other => write_len_prefixed_i32(out, |o| serialize_value_into(other, o))?,
                 }
             }
-            Ok(buf)
         }
-        Value::Frozen(inner) => serialize_value(inner),
-        _ => Err(Error::InvalidInput(format!(
-            "Unsupported value type for serialization: {:?}",
-            value
-        ))),
+        Value::Frozen(inner) => serialize_value_into(inner, out)?,
+        _ => {
+            return Err(Error::InvalidInput(format!(
+                "Unsupported value type for serialization: {:?}",
+                value
+            )))
+        }
     }
+    Ok(())
+}
+
+/// Run `write_body`, framing the bytes it appends to `out` with a FIXED 4-byte
+/// big-endian i32 length prefix — reserved before the body and back-patched
+/// after — so a collection element/field never needs a per-element temporary
+/// (issue #1672). Byte-identical to `extend(len_as_i32(bytes.len())); extend(bytes)`.
+fn write_len_prefixed_i32(
+    out: &mut Vec<u8>,
+    write_body: impl FnOnce(&mut Vec<u8>) -> Result<()>,
+) -> Result<()> {
+    let len_pos = out.len();
+    out.extend_from_slice(&[0u8; 4]);
+    write_body(out)?;
+    let body_len = out.len() - len_pos - 4;
+    out[len_pos..len_pos + 4].copy_from_slice(&len_as_i32(body_len)?.to_be_bytes());
+    Ok(())
+}
+
+/// Append a regular cell's value to `buf` with Cassandra's cell framing — a
+/// VInt length prefix for variable-width types, raw bytes for fixed-width — and
+/// the `i64::MAX` length bound check.
+///
+/// Fixed-width scalars (bool/int/bigint/float/timestamp/uuid — the types WITHOUT
+/// a length prefix, per [`cell_value_uses_length_prefix`]) are written STRAIGHT
+/// into `buf` via [`serialize_value_into`], eliminating the throwaway per-cell
+/// `Vec` + second copy that dominated the int write hot path (issue #1672, R1).
+/// Variable-width types still serialize once into an owned buffer because the
+/// VInt length must precede the bytes. Byte-identical to the prior
+/// `serialize_value` → optional length prefix → `extend_from_slice` sequence.
+pub(crate) fn write_cell_value_into(buf: &mut Vec<u8>, column: &str, value: &Value) -> Result<()> {
+    if cell_value_uses_length_prefix(value) {
+        // Variable-width: the VInt length must precede the bytes, so serialize
+        // once into an owned buffer, then length-prefix + copy.
+        let value_bytes = serialize_value(value)?;
+        if value_bytes.len() > i64::MAX as usize {
+            return Err(Error::InvalidInput(format!(
+                "Value too large for column '{}': {} bytes (max {})",
+                column,
+                value_bytes.len(),
+                i64::MAX
+            )));
+        }
+        encode_unsigned(value_bytes.len() as u64, buf);
+        buf.extend_from_slice(&value_bytes);
+    } else {
+        // Fixed-width: no length prefix — write straight into `buf` (zero alloc).
+        let start = buf.len();
+        serialize_value_into(value, buf)?;
+        let written = buf.len() - start;
+        if written > i64::MAX as usize {
+            return Err(Error::InvalidInput(format!(
+                "Value too large for column '{}': {} bytes (max {})",
+                column,
+                written,
+                i64::MAX
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Infer CQL type from a Value instance

--- a/cqlite-core/tests/test_issue_1672_serialize_value_into_allocs.rs
+++ b/cqlite-core/tests/test_issue_1672_serialize_value_into_allocs.rs
@@ -40,7 +40,9 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use cqlite_core::schema::{Column, KeyColumn, TableSchema};
 use cqlite_core::storage::sstable::writer::SSTableWriter;
-use cqlite_core::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, Mutation, PartitionKey, TableId,
+};
 use cqlite_core::types::Value;
 use tempfile::TempDir;
 

--- a/cqlite-core/tests/test_issue_1672_serialize_value_into_allocs.rs
+++ b/cqlite-core/tests/test_issue_1672_serialize_value_into_allocs.rs
@@ -1,0 +1,204 @@
+//! Allocation-slope regression guard for Issue #1672 (Epic R, finding R1).
+//!
+//! Before R1, `serialize_value` allocated a **fresh `Vec<u8>` for every cell
+//! value** and returned it by value; the writer then copied those bytes a second
+//! time into the row buffer. For a 4-byte `int` that is 1 heap alloc + 2 memcpys
+//! to move 4 bytes, once per cell, per row, per partition — the hottest write
+//! loop. R1 adds `serialize_value_into(&Value, &mut Vec<u8>)` and routes the
+//! fixed-width scalar cell path (int/bigint/float/uuid/timestamp/bool — the
+//! types WITHOUT a length prefix) straight into the row buffer, so an `int` cell
+//! allocates zero throwaway `Vec`s.
+//!
+//! This test measures the per-`int`-column allocation SLOPE of `write_partition`
+//! (the #1046 rigorous form of "independent of N"): it counts heap allocations
+//! while writing ONE partition / ONE row carrying N `int` columns, at two widths
+//! (N1=16 and N2=64), into fresh temp dirs, with the schema, writer, decorated
+//! key and mutation ALL constructed before the counting window. Subtracting the
+//! two counts cancels the fixed `write_partition` overhead and leaves only the
+//! N-scaling cost.
+//!
+//! * On `main`: each of the (N2-N1)=48 extra int cells allocates one
+//!   `serialize_value` `Vec`, so the delta grows by >= 48.
+//! * After R1: the fixed-width int path writes straight into the row buffer, so
+//!   the delta collapses to a small constant (a handful of buffer-doubling
+//!   reallocs as the row buffer grows with more columns).
+//!
+//! The guard asserts `delta(N2) - delta(N1) <= K` with K calibrated from the
+//! post-fix run plus headroom. `main` (delta >= 48) FAILS; the post-fix path
+//! PASSES; re-introducing the per-cell Vec trips it. A non-vacuous check asserts
+//! the narrow (N1) window actually allocated, so a writer that silently no-ops
+//! cannot pass.
+//!
+//! This file is its own test binary with a single `#[test]`, so the process-
+//! global counter observes allocations only from this test's thread.
+
+#![cfg(feature = "write-support")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::writer::SSTableWriter;
+use cqlite_core::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+struct CountingAlloc;
+
+/// Total allocations in the counting window.
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+/// Allocations of EXACTLY 4 bytes in the counting window. `serialize_value` for
+/// `Value::Integer` does `n.to_be_bytes().to_vec()` — a 4-byte heap allocation
+/// per int cell. The fixed-width R1 path writes those 4 bytes straight into the
+/// row buffer via `extend_from_slice` (which reallocs the buffer at power-of-two
+/// sizes, never 4), so this counter isolates the per-int-cell Vec precisely.
+static ALLOCS_4B: AtomicUsize = AtomicUsize::new(0);
+static COUNTING: AtomicBool = AtomicBool::new(false);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            if layout.size() == 4 {
+                ALLOCS_4B.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            if new_size == 4 {
+                ALLOCS_4B.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+const KEYSPACE: &str = "issue1672_ks";
+const TABLE: &str = "t";
+
+/// `pk int` partition key plus `n` regular `int` columns `c0..c{n-1}`.
+fn make_schema(n: usize) -> TableSchema {
+    let mut columns = vec![Column {
+        name: "pk".to_string(),
+        data_type: "int".to_string(),
+        nullable: false,
+        default: None,
+        is_static: false,
+    }];
+    for i in 0..n {
+        columns.push(Column {
+            name: format!("c{i}"),
+            data_type: "int".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        });
+    }
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns,
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// A single mutation writing `Value::Integer` into every `c{i}` column.
+fn make_mutation(n: usize) -> Mutation {
+    let ops = (0..n)
+        .map(|i| CellOperation::Write {
+            column: format!("c{i}"),
+            value: Value::Integer(i as i32),
+        })
+        .collect();
+    Mutation::new(
+        TableId::new(KEYSPACE, TABLE),
+        PartitionKey::single("pk", Value::Integer(1)),
+        None,
+        ops,
+        1_000_000,
+        None,
+    )
+}
+
+/// Count heap allocations performed *inside* one `write_partition` for a row of
+/// `n` int columns. Everything (schema, writer, decorated key, mutation) is
+/// built before the counting window opens, so only serialization work is
+/// measured.
+fn allocs_for_width(n: usize) -> (usize, usize) {
+    let dir = TempDir::new().expect("temp dir");
+    let schema = make_schema(n);
+    let mut writer = SSTableWriter::new(dir.path().to_path_buf(), 1, &schema).expect("writer");
+    let mutation = make_mutation(n);
+    let key = mutation.decorated_key(&schema).expect("decorated key");
+    let mutations = vec![mutation];
+
+    let total_base = ALLOCS.load(Ordering::Relaxed);
+    let small_base = ALLOCS_4B.load(Ordering::Relaxed);
+    COUNTING.store(true, Ordering::Relaxed);
+    writer
+        .write_partition(key, mutations)
+        .expect("write_partition");
+    COUNTING.store(false, Ordering::Relaxed);
+    let total = ALLOCS.load(Ordering::Relaxed) - total_base;
+    let small = ALLOCS_4B.load(Ordering::Relaxed) - small_base;
+
+    (total, small)
+}
+
+#[test]
+fn serialize_value_into_kills_per_int_cell_alloc() {
+    const N1: usize = 16;
+    const N2: usize = 64;
+
+    let (narrow_total, narrow_4b) = allocs_for_width(N1);
+    let (wide_total, wide_4b) = allocs_for_width(N2);
+    let slope_4b = wide_4b.saturating_sub(narrow_4b);
+
+    eprintln!(
+        "#1672 alloc window: N1={N1} total={narrow_total} 4b={narrow_4b} | \
+         N2={N2} total={wide_total} 4b={wide_4b} | 4b-slope={slope_4b}"
+    );
+
+    // Non-vacuous: the writer must actually do work (allocate) writing a row.
+    assert!(
+        narrow_total > 0,
+        "#1672: writing {N1} int columns allocated nothing — the measurement is vacuous"
+    );
+
+    // Isolate the per-int-cell serialization Vec via the 4-byte-allocation slope.
+    // `serialize_value(Value::Integer)` allocates exactly one 4-byte Vec per int
+    // cell (`n.to_be_bytes().to_vec()`), so on `main` the 4-byte-alloc count grows
+    // by one per extra column: slope >= (N2-N1) = 48. After R1 the fixed-width int
+    // path writes those 4 bytes straight into the row buffer (which reallocs at
+    // power-of-two sizes, never exactly 4), so the 4-byte-alloc slope collapses to
+    // ~0. K is calibrated from the post-fix run + headroom and sits FAR below the
+    // >=48 `main` slope, so re-introducing the per-cell Vec trips the guard.
+    const K: usize = 8;
+    assert!(
+        slope_4b <= K,
+        "#1672: per-int-cell 4-byte alloc slope regressed — {N1}->{N2} int columns added \
+         {slope_4b} four-byte allocations (> K={K}). On `main` this is >= {} (one throwaway \
+         `serialize_value` Vec per int cell); after R1 the fixed-width int path writes straight \
+         into the row buffer. (narrow_4b={narrow_4b}, wide_4b={wide_4b})",
+        N2 - N1
+    );
+}


### PR DESCRIPTION
Closes #1672 (Epic R / R1 — serializer allocation discipline).

## What changed
`data_writer::encoding::serialize_value` previously allocated a fresh `Vec<u8>` for **every** cell value and returned it by value; the caller then copied those bytes again into the row buffer (1 heap alloc + 2 memcpys to move a 4-byte `int`, on the hottest write loop).

- Added `serialize_value_into(&Value, &mut Vec<u8>)` — every arm of `serialize_value` translated 1:1, writing via `push`/`extend_from_slice` into the caller's buffer. Collection (List/Set/Map/Tuple) length prefixes are the FIXED 4-byte i32 form, so they are **back-patched in place** (`write_len_prefixed_i32`) — zero per-element temp Vec. Set/Map still sort `&Value` refs first via `compare_collection_elements` (ordering unchanged).
- `serialize_value` / `serialize_collection_element` kept as thin delegating wrappers — no signature breaks (comparator + `udt_canon` + all tests unaffected).
- Hot scalar cell path (`cells.rs`, 4 sites) via `write_cell_value_into`: fixed-width types (int/bigint/bool/float/timestamp/uuid — NOT length-prefixed) now serialize **straight into the row buffer** (zero alloc); variable-width (text/blob/collections, VInt-length-first) use an owned temp.
- `complex.rs` map/list per-element sites reuse a cleared scratch across the element loop (map drops its `Vec<Vec<u8>>` entirely).

## Byte-identity (non-negotiable) — confirmed
Serialized output is byte-identical on the success path. 253 `data_writer` lib tests (scenarios_1..6, collection_order_serialize) + synthetic write byte-parity suites (#1005/#1240/#1190/#1017/#1074) all green. Set/Map ordering and all length-prefix framing preserved.

## Alloc red→green (TDD)
`cqlite-core/tests/test_issue_1672_serialize_value_into_allocs.rs` (custom counting global allocator, dedicated binary): per-int-cell 4-byte-alloc **slope** across N=16→64 int columns via `SSTableWriter::write_partition`:
- **main**: slope = **48** (one throwaway `serialize_value` Vec per int cell) — FAILS.
- **post-fix**: slope = **0** (constant, independent of N) — PASSES (bound K=8).

Total allocs also dropped (N=64: 1188→1124).

## Review
- rust-reviewer: no blockers; byte-identity verified sound; alloc win real.
- roborev (`--branch`): 2 Low findings, no blockers.
- Batched into a follow-up nit issue at merge: (a) add a MAP null-key pre-check / partial-buffer-on-error note (benign today — every caller aborts the whole write on Err), (b) also convert the SET complex-cell path to scratch reuse, (c) drop the dead `i64::MAX` check on the fixed-width branch.

## Full-gate note for the closer
`complex.rs` is a **pre-existing over-threshold file** (~974 > 800, epic #1116 split candidate). This change grows it ~12 lines, so the full `agent-gate.sh` must run with **`CQLITE_ALLOW_FILE_GROWTH=1`** (splitting complex.rs is out of R1 scope; #1116).

No conflict with #1664 (that lane touches `write_engine/merge/`; this change is entirely in `sstable/writer/data_writer/`).