### PR TITLE
perf(#1664): kill the MergeEntry double clone in the k-way merge core

### DIFF
--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -527,8 +527,13 @@ pub(crate) mod stream_walk_scope {
 /// compaction captures exactly the `MergeEntry` clones performed during it.
 ///
 /// `#[cfg(test)]`: the `record()` call in `MergeEntry::clone` is likewise
-/// `#[cfg(test)]`-gated, so production clone pays ZERO added cost.
-#[cfg(test)]
+/// `#[cfg(test)]`-gated, so production clone pays ZERO added cost. Gated on
+/// `feature = "write-support"` as well because every consumer (the
+/// `MergeEntry::clone` recorder and the `clone_regression_tests` guard) lives
+/// in the write-support-only merge module — under the minimal feature set those
+/// callers vanish, so an unconditional `#[cfg(test)]` here would be dead code
+/// and trip the `-D warnings` dead-code lint in the all-compression build.
+#[cfg(all(test, feature = "write-support"))]
 pub(crate) mod merge_entry_clone_scope {
     use std::cell::Cell;
 

--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -520,6 +520,76 @@ pub(crate) mod stream_walk_scope {
     }
 }
 
+/// A thread-local recording scope for `MergeEntry::clone` calls, mirroring
+/// [`stream_walk_scope`] exactly (issue #2428's parallel-test-pollution-immune
+/// design). Used by the #1664 double-clone regression guard: the k-way merge
+/// runs single-threaded, so a [`MergeEntryCloneScope`] opened around a full
+/// compaction captures exactly the `MergeEntry` clones performed during it.
+///
+/// `#[cfg(test)]`: the `record()` call in `MergeEntry::clone` is likewise
+/// `#[cfg(test)]`-gated, so production clone pays ZERO added cost.
+#[cfg(test)]
+pub(crate) mod merge_entry_clone_scope {
+    use std::cell::Cell;
+
+    thread_local! {
+        /// `Some(count)` while a [`MergeEntryCloneScope`] is active on this
+        /// thread, `None` otherwise. Only `MergeEntry::clone` calls executing
+        /// on this thread bump it.
+        static SCOPED: Cell<Option<u64>> = const { Cell::new(None) };
+    }
+
+    /// Bump the active scope on the current thread, if any. A no-op on threads
+    /// (production compaction, other tests) with no active scope.
+    pub(crate) fn record() {
+        SCOPED.with(|c| {
+            if let Some(v) = c.get() {
+                c.set(Some(v.saturating_add(1)));
+            }
+        });
+    }
+
+    /// A per-thread recording scope for `MergeEntry::clone`. Open one before
+    /// driving a `KWayMerger` compaction to completion and read
+    /// [`count`](MergeEntryCloneScope::count) after. Immune to concurrent
+    /// tests on other threads (issue #2428). Dropping it clears the scope.
+    ///
+    /// Deliberately `!Send` (holds a `PhantomData<*const ()>`): the scope is
+    /// meaningful only on the thread that opened it.
+    pub(crate) struct MergeEntryCloneScope {
+        _not_send: std::marker::PhantomData<*const ()>,
+    }
+
+    impl MergeEntryCloneScope {
+        /// Begin recording on the current thread. Panics if a scope is already
+        /// active on this thread (one scope per assertion; nesting unsupported).
+        pub(crate) fn new() -> Self {
+            SCOPED.with(|c| {
+                assert!(
+                    c.get().is_none(),
+                    "a MergeEntryCloneScope is already active on this thread (nesting unsupported)"
+                );
+                c.set(Some(0));
+            });
+            Self {
+                _not_send: std::marker::PhantomData,
+            }
+        }
+
+        /// `MergeEntry::clone` increments recorded on this thread since the
+        /// scope opened.
+        pub(crate) fn count(&self) -> u64 {
+            SCOPED.with(|c| c.get().unwrap_or(0))
+        }
+    }
+
+    impl Drop for MergeEntryCloneScope {
+        fn drop(&mut self) {
+            SCOPED.with(|c| c.set(None));
+        }
+    }
+}
+
 /// Record that one merge ENTRY was decoded from `Data.db` by ANY
 /// [`KWayMerger`](crate::storage::write_engine::KWayMerger)-adapter-driven run
 /// (Issue #2096) — a full scan, a compaction, OR a multi-candidate point read,

--- a/cqlite-core/src/storage/write_engine/merge/clone_regression_tests.rs
+++ b/cqlite-core/src/storage/write_engine/merge/clone_regression_tests.rs
@@ -1,0 +1,154 @@
+//! Issue #1664 — kill the `MergeEntry` double clone in the k-way merge core.
+//!
+//! `KWayMerger::step` used to push `entry.clone()` into `partition_rows` while
+//! already holding the owned popped entry, and `KWayMerger::refill_heap` used
+//! to `peek()` + `clone()` the front of a run's buffer and then `advance()`
+//! past it (discarding the just-cloned original) instead of moving the owned
+//! entry `advance()` already returns. This module is a sibling file (not
+//! inline in `merge/mod.rs`, per the #1116 campsite rule) housing the
+//! regression guard that proves the fix: drive a full `KWayMerger` compaction
+//! inside a [`MergeEntryCloneScope`](crate::storage::sstable::work_counters::merge_entry_clone_scope::MergeEntryCloneScope)
+//! and assert the observed clone count stays low.
+
+use super::{KWayMerger, MergeEntry, MergeStep, RowData, RunReader, SSTableRowIterator};
+use crate::error::Result;
+use crate::schema::{KeyColumn, TableSchema};
+use crate::storage::sstable::work_counters::merge_entry_clone_scope::MergeEntryCloneScope;
+use crate::storage::write_engine::merge::CellData;
+use crate::storage::write_engine::mutation::{DecoratedKey, PartitionKey};
+use crate::types::Value;
+use std::collections::{BinaryHeap, HashMap};
+
+/// Single-column `int` partition-key schema with one regular `name` column —
+/// deliberately minimal, mirroring `issue_886_empty_partition_skip::schema`.
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: "i1664".to_string(),
+        table: "clone_regression".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![crate::schema::Column {
+            name: "name".to_string(),
+            data_type: "text".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        }],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Valid on-disk partition-key bytes for `id = n` under [`schema`], built
+/// through the shared codec so the merge stream can decode them.
+fn pk_bytes(schema: &TableSchema, n: i32) -> Vec<u8> {
+    PartitionKey::single("id", Value::Integer(n))
+        .to_bytes(schema)
+        .expect("encode int partition key")
+}
+
+/// An in-memory run yielding a fixed list of `MergeEntry`s in order.
+struct VecIterator(std::vec::IntoIter<MergeEntry>);
+impl SSTableRowIterator for VecIterator {
+    fn next(&mut self) -> Option<Result<MergeEntry>> {
+        self.0.next().map(Ok)
+    }
+}
+
+/// Build a `KWayMerger` over K in-memory runs (one `RunReader` each).
+fn merger_over_runs(runs: Vec<Vec<MergeEntry>>, schema: TableSchema) -> KWayMerger {
+    let runs = runs
+        .into_iter()
+        .map(|entries| RunReader::new(Box::new(VecIterator(entries.into_iter())) as _))
+        .collect();
+    KWayMerger {
+        runs,
+        heap: BinaryHeap::new(),
+        current_partition: None,
+        gc_before_secs: None,
+        now_secs: None,
+        purge_safe: false,
+        max_purgeable_timestamp: None,
+        schema_arc: std::sync::Arc::new(schema.clone()),
+        schema,
+    }
+}
+
+/// Regression guard for issue #1664 (kill the `MergeEntry` double clone in
+/// the k-way merge core). Drives a full `KWayMerger` compaction over K=3
+/// runs of distinct single-row partitions (N total rows) inside a
+/// `MergeEntryCloneScope` and asserts the `MergeEntry::clone` count stays
+/// under a threshold that only the post-fix code (owned-move at both the
+/// `step` push and the `refill_heap` reload) can meet.
+///
+/// Empirically observed on this K/N (N=15, see the constants below):
+// main today: 30 (== 2N, the two gratuitous clones); post-fix: 0
+// (reconcile clones nothing for these single-row partitions).
+#[test]
+fn kway_merge_does_not_double_clone_entries() {
+    const PER_RUN: usize = 5;
+    const K: usize = 3;
+    const N: u64 = (PER_RUN * K) as u64;
+
+    let schema = schema();
+
+    // K runs, each with PER_RUN distinct single-row partitions. Tokens are
+    // globally distinct and ascending WITHIN each run (RunReaders must yield
+    // ascending `MergeEntry` order), so every partition is exactly one row.
+    let runs: Vec<Vec<MergeEntry>> = (0..K)
+        .map(|r| {
+            (0..PER_RUN)
+                .map(|i| {
+                    let token = (r * PER_RUN + i) as i64;
+                    MergeEntry::new(
+                        r,
+                        DecoratedKey::new(token, pk_bytes(&schema, token as i32)),
+                        None,
+                        100,
+                        RowData::Live {
+                            cells: vec![CellData::new(
+                                "name".to_string(),
+                                Value::Text("v".to_string()),
+                                100,
+                            )],
+                        },
+                    )
+                })
+                .collect()
+        })
+        .collect();
+
+    let mut merger = merger_over_runs(runs, schema);
+
+    let scope = MergeEntryCloneScope::new();
+    let mut partitions = 0u64;
+    loop {
+        match merger.step().expect("merge step must not fail") {
+            MergeStep::Complete => break,
+            MergeStep::Partition { .. } => partitions += 1,
+        }
+    }
+    let clones = scope.count();
+    drop(scope);
+
+    assert_eq!(
+        partitions, N,
+        "every distinct key is its own single-row partition"
+    );
+
+    // The two removed gratuitous clones cost exactly 2N combined (the
+    // `step` push + the `refill_heap` reload); reconcile clones nothing for
+    // these single-row partitions. Threshold (N + N/2 = 22 for N=15) sits
+    // strictly between the observed post-fix count (0) and the pre-fix
+    // count (2N = 30): red on main, green post-fix.
+    let threshold = N + N / 2; // 22 for N=15
+    assert!(
+        clones <= threshold,
+        "MergeEntry cloned {clones} times for {N} rows (threshold {threshold}); \
+         the #1664 double clone in step/refill_heap regressed"
+    );
+}

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -260,6 +260,11 @@ impl RunReader {
     /// Peek at the next entry without consuming it
     ///
     /// Returns None if this run is exhausted.
+    ///
+    /// Test-only since issue #1664: `refill_heap` was the sole production
+    /// caller and now moves the owned entry via [`Self::advance`] instead of
+    /// peek+clone. Kept for the `RunReader` API test that exercises lazy refill.
+    #[cfg(test)]
     fn peek(&mut self) -> Result<Option<&MergeEntry>> {
         // Refill buffer if empty and not exhausted
         if self.buffer.is_empty() && !self.exhausted {
@@ -2884,12 +2889,16 @@ impl KWayMerger {
                 .pop()
                 .ok_or_else(|| Error::InvalidInput("Merge heap unexpectedly empty".to_string()))?;
             let entry = wrapped.entry;
+            // Read the Copy `run_index` before moving `entry` (issue #1664: the
+            // entry is already owned, so move it into partition_rows instead of
+            // cloning).
+            let run_index = entry.run_index;
 
             // Add to partition rows
-            partition_rows.push(entry.clone());
+            partition_rows.push(entry);
 
             // Refill heap from the run we just consumed from
-            self.refill_heap(entry.run_index)?;
+            self.refill_heap(run_index)?;
         }
 
         if let Some(key) = partition_key {
@@ -2920,19 +2929,17 @@ impl KWayMerger {
 
         let run = &mut self.runs[run_index];
         if !run.is_exhausted() {
-            if let Some(entry) = run.peek()? {
-                // Clone and push to heap, paired with the schema-aware
-                // comparator's schema (issue #1668, stage 5c-i).
-                let entry = entry.clone();
+            if let Some(entry) = run.advance()? {
+                // Move the owned entry into the heap, paired with the
+                // schema-aware comparator's schema (issue #1668, stage 5c-i).
+                // Issue #1664: `advance()` returns the OWNED front entry, so we
+                // move it in instead of the former peek+clone+discard-advance.
                 self.heap
                     .push(Reverse(schema_order::SchemaOrderedEntry::new(
                         entry,
                         self.schema_arc.clone(),
                     )));
             }
-
-            // Advance the run reader
-            run.advance()?;
         }
 
         Ok(())
@@ -10266,6 +10273,103 @@ mod issue_886_empty_partition_skip {
             schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         }
+    }
+
+    /// Build a `KWayMerger` over K in-memory runs (one `RunReader` each) — the
+    /// multi-run analogue of [`merger_over`], for the #1664 double-clone guard.
+    fn merger_over_runs(runs: Vec<Vec<MergeEntry>>, schema: TableSchema) -> KWayMerger {
+        let runs = runs
+            .into_iter()
+            .map(|entries| RunReader::new(Box::new(VecIterator(entries.into_iter())) as _))
+            .collect();
+        KWayMerger {
+            runs,
+            heap: BinaryHeap::new(),
+            current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
+            purge_safe: false,
+            max_purgeable_timestamp: None,
+            schema_arc: std::sync::Arc::new(schema.clone()),
+            schema,
+        }
+    }
+
+    /// Regression guard for issue #1664 (kill the `MergeEntry` double clone in
+    /// the k-way merge core). Drives a full `KWayMerger` compaction over K=3
+    /// runs of distinct single-row partitions (N total rows) inside a
+    /// `MergeEntryCloneScope` and asserts the `MergeEntry::clone` count stays
+    /// under a threshold that only the post-fix code (owned-move at both the
+    /// `step` push and the `refill_heap` reload) can meet.
+    ///
+    /// Empirically observed on this K/N (N=15, see the constants below):
+    // main today: 30 (== 2N, the two gratuitous clones); post-fix: 0
+    // (reconcile clones nothing for these single-row partitions).
+    #[test]
+    fn kway_merge_does_not_double_clone_entries() {
+        use crate::storage::sstable::work_counters::merge_entry_clone_scope::MergeEntryCloneScope;
+
+        const PER_RUN: usize = 5;
+        const K: usize = 3;
+        const N: u64 = (PER_RUN * K) as u64;
+
+        let schema = schema();
+
+        // K runs, each with PER_RUN distinct single-row partitions. Tokens are
+        // globally distinct and ascending WITHIN each run (RunReaders must yield
+        // ascending `MergeEntry` order), so every partition is exactly one row.
+        let runs: Vec<Vec<MergeEntry>> = (0..K)
+            .map(|r| {
+                (0..PER_RUN)
+                    .map(|i| {
+                        let token = (r * PER_RUN + i) as i64;
+                        MergeEntry::new(
+                            r,
+                            DecoratedKey::new(token, pk_bytes(&schema, token as i32)),
+                            None,
+                            100,
+                            RowData::Live {
+                                cells: vec![CellData::new(
+                                    "name".to_string(),
+                                    Value::Text("v".to_string()),
+                                    100,
+                                )],
+                            },
+                        )
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let mut merger = merger_over_runs(runs, schema);
+
+        let scope = MergeEntryCloneScope::new();
+        let mut partitions = 0u64;
+        loop {
+            match merger.step().expect("merge step must not fail") {
+                MergeStep::Complete => break,
+                MergeStep::Partition { .. } => partitions += 1,
+            }
+        }
+        let clones = scope.count();
+        drop(scope);
+
+        assert_eq!(
+            partitions, N,
+            "every distinct key is its own single-row partition"
+        );
+
+        // The two removed gratuitous clones cost exactly 2N combined (the
+        // `step` push + the `refill_heap` reload); reconcile clones nothing for
+        // these single-row partitions. Threshold (N + N/2 = 22 for N=15) sits
+        // strictly between the observed post-fix count (0) and the pre-fix
+        // count (2N = 30): red on main, green post-fix.
+        let threshold = N + N / 2; // 22 for N=15
+        assert!(
+            clones <= threshold,
+            "MergeEntry cloned {clones} times for {N} rows (threshold {threshold}); \
+             the #1664 double clone in step/refill_heap regressed"
+        );
     }
 
     /// END-TO-END writer-path test (#886): a partition whose ONLY merged row is a

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -552,6 +552,11 @@ mod channel_depth;
 #[cfg(all(test, feature = "write-support"))]
 mod teardown_tests;
 
+// Issue #1664: `MergeEntry` double-clone regression guard (kept in a sibling
+// file, not inline here, per the #1116 campsite file-size rule).
+#[cfg(all(test, feature = "write-support"))]
+mod clone_regression_tests;
+
 #[cfg(feature = "write-support")]
 impl SSTableRowIteratorAdapter {
     /// Open an SSTable and start a streaming producer thread.
@@ -10273,103 +10278,6 @@ mod issue_886_empty_partition_skip {
             schema_arc: std::sync::Arc::new(schema.clone()),
             schema,
         }
-    }
-
-    /// Build a `KWayMerger` over K in-memory runs (one `RunReader` each) — the
-    /// multi-run analogue of [`merger_over`], for the #1664 double-clone guard.
-    fn merger_over_runs(runs: Vec<Vec<MergeEntry>>, schema: TableSchema) -> KWayMerger {
-        let runs = runs
-            .into_iter()
-            .map(|entries| RunReader::new(Box::new(VecIterator(entries.into_iter())) as _))
-            .collect();
-        KWayMerger {
-            runs,
-            heap: BinaryHeap::new(),
-            current_partition: None,
-            gc_before_secs: None,
-            now_secs: None,
-            purge_safe: false,
-            max_purgeable_timestamp: None,
-            schema_arc: std::sync::Arc::new(schema.clone()),
-            schema,
-        }
-    }
-
-    /// Regression guard for issue #1664 (kill the `MergeEntry` double clone in
-    /// the k-way merge core). Drives a full `KWayMerger` compaction over K=3
-    /// runs of distinct single-row partitions (N total rows) inside a
-    /// `MergeEntryCloneScope` and asserts the `MergeEntry::clone` count stays
-    /// under a threshold that only the post-fix code (owned-move at both the
-    /// `step` push and the `refill_heap` reload) can meet.
-    ///
-    /// Empirically observed on this K/N (N=15, see the constants below):
-    // main today: 30 (== 2N, the two gratuitous clones); post-fix: 0
-    // (reconcile clones nothing for these single-row partitions).
-    #[test]
-    fn kway_merge_does_not_double_clone_entries() {
-        use crate::storage::sstable::work_counters::merge_entry_clone_scope::MergeEntryCloneScope;
-
-        const PER_RUN: usize = 5;
-        const K: usize = 3;
-        const N: u64 = (PER_RUN * K) as u64;
-
-        let schema = schema();
-
-        // K runs, each with PER_RUN distinct single-row partitions. Tokens are
-        // globally distinct and ascending WITHIN each run (RunReaders must yield
-        // ascending `MergeEntry` order), so every partition is exactly one row.
-        let runs: Vec<Vec<MergeEntry>> = (0..K)
-            .map(|r| {
-                (0..PER_RUN)
-                    .map(|i| {
-                        let token = (r * PER_RUN + i) as i64;
-                        MergeEntry::new(
-                            r,
-                            DecoratedKey::new(token, pk_bytes(&schema, token as i32)),
-                            None,
-                            100,
-                            RowData::Live {
-                                cells: vec![CellData::new(
-                                    "name".to_string(),
-                                    Value::Text("v".to_string()),
-                                    100,
-                                )],
-                            },
-                        )
-                    })
-                    .collect()
-            })
-            .collect();
-
-        let mut merger = merger_over_runs(runs, schema);
-
-        let scope = MergeEntryCloneScope::new();
-        let mut partitions = 0u64;
-        loop {
-            match merger.step().expect("merge step must not fail") {
-                MergeStep::Complete => break,
-                MergeStep::Partition { .. } => partitions += 1,
-            }
-        }
-        let clones = scope.count();
-        drop(scope);
-
-        assert_eq!(
-            partitions, N,
-            "every distinct key is its own single-row partition"
-        );
-
-        // The two removed gratuitous clones cost exactly 2N combined (the
-        // `step` push + the `refill_heap` reload); reconcile clones nothing for
-        // these single-row partitions. Threshold (N + N/2 = 22 for N=15) sits
-        // strictly between the observed post-fix count (0) and the pre-fix
-        // count (2N = 30): red on main, green post-fix.
-        let threshold = N + N / 2; // 22 for N=15
-        assert!(
-            clones <= threshold,
-            "MergeEntry cloned {clones} times for {N} rows (threshold {threshold}); \
-             the #1664 double clone in step/refill_heap regressed"
-        );
     }
 
     /// END-TO-END writer-path test (#886): a partition whose ONLY merged row is a

--- a/cqlite-core/src/storage/write_engine/merge/model.rs
+++ b/cqlite-core/src/storage/write_engine/merge/model.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 /// Represents a single row from one of the input SSTables. This is the
 /// fundamental unit that flows through the merge heap.
 #[cfg(feature = "write-support")]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MergeEntry {
     /// Which SSTable this came from (0 = newest)
     pub run_index: usize,
@@ -84,6 +84,30 @@ pub struct MergeEntry {
     /// live rows in another, resurrecting the deleted partition. `None` for every
     /// non-carrier entry.
     pub partition_deletion: Option<(i64, i32)>,
+}
+
+/// Manual `Clone` (was `#[derive(Clone)]`) so the #1664 double-clone regression
+/// guard can count `MergeEntry` clones via a `#[cfg(test)]`-gated recorder.
+/// The clone is field-wise identical to the former derived clone (all 8 fields);
+/// in a production (non-test) build the `record()` call vanishes entirely, so
+/// this is a plain field-wise clone with ZERO added cost.
+#[cfg(feature = "write-support")]
+impl Clone for MergeEntry {
+    fn clone(&self) -> Self {
+        #[cfg(test)]
+        crate::storage::sstable::work_counters::merge_entry_clone_scope::record();
+        Self {
+            run_index: self.run_index,
+            key: self.key.clone(),
+            clustering_key: self.clustering_key.clone(),
+            timestamp: self.timestamp,
+            row_data: self.row_data.clone(),
+            complex_deletions: self.complex_deletions.clone(),
+            range_deletion: self.range_deletion.clone(),
+            row_deletion: self.row_deletion,
+            partition_deletion: self.partition_deletion,
+        }
+    }
 }
 
 impl MergeEntry {

--- a/cqlite-core/src/storage/write_engine/merge/model.rs
+++ b/cqlite-core/src/storage/write_engine/merge/model.rs
@@ -88,7 +88,7 @@ pub struct MergeEntry {
 
 /// Manual `Clone` (was `#[derive(Clone)]`) so the #1664 double-clone regression
 /// guard can count `MergeEntry` clones via a `#[cfg(test)]`-gated recorder.
-/// The clone is field-wise identical to the former derived clone (all 8 fields);
+/// The clone is field-wise identical to the former derived clone (all 9 fields);
 /// in a production (non-test) build the `record()` call vanishes entirely, so
 /// this is a plain field-wise clone with ZERO added cost.
 #[cfg(feature = "write-support")]


### PR DESCRIPTION
## Summary
- `KWayMerger::step` and `KWayMerger::refill_heap` each cloned an already-owned `MergeEntry` for no reason (once per row, twice total) — moves the owned entry in both places instead.
- Adds a `#[cfg(test)]`-gated `MergeEntry::clone` call counter (`merge_entry_clone_scope`, mirroring #2428's `stream_walk_scope` thread-local design; zero production overhead) and a regression test (`clone_regression_tests.rs`, a sibling file per the #1116 campsite rule) that proves the fix: 30 clones for N=15 rows on main, 0 post-fix.
- No behavior change: heap contents, pop order, and `partition_rows` contents are byte-identical — verified against the compaction byte-parity harness (issue_1017/1190/1387 byte-parity, issue_819 differential, issue_947 reconcile, compaction_integration) and the full 238-test `storage::write_engine::merge` suite, all green.

Closes #1664

## Test plan
- [x] `cargo test -p cqlite-core --lib storage::write_engine::merge` — 238 passed
- [x] New regression test `clone_regression_tests::kway_merge_does_not_double_clone_entries` — red on main (30 clones > threshold 22), green post-fix (0 clones)
- [x] Compaction byte-parity: `issue_1017_live_cell_compaction_byte_parity`, `issue_1190_write_load_byte_parity`, `issue_1387_tombstone_ttl_compaction_byte_parity`, `issue_819_differential_compaction`, `issue_947_reconcile_parity`, `compaction_integration` — all pass unchanged
- [x] LITE gate: file-size (opt-out via `CQLITE_ALLOW_FILE_GROWTH=1` — two pre-existing #1116 over-threshold files, `merge/mod.rs`'s net growth reduced to +12 lines), fmt, clippy, scoped-tests — PASS
- [x] roborev branch review (local, thorough): "No issues found."