### PR TITLE
docs(#2427): refresh cqlite-flight Grafana dashboard for 0.15 instruments + catalog-drift guard

### DIFF
--- a/cqlite-core/tests/kit_dashboard_metric_drift.rs
+++ b/cqlite-core/tests/kit_dashboard_metric_drift.rs
@@ -90,9 +90,33 @@ fn dotted_cqlite_names(text: &str) -> HashSet<String> {
     names
 }
 
+/// Loud skip-on-absence: the kit dashboard lives under `easy-db-lab-kits/` which
+/// is NOT present in a sparse/minimal checkout that has cqlite-core alone. This
+/// test runs under the `core-tests` gate component (all integration tests), so it
+/// must SKIP — not FAIL — when the artifact is absent; the dedicated SKIP-aware
+/// `kit-dashboard-drift` gate component ENFORCES presence (and drift) in full
+/// checkouts where the kit exists. Mirrors the repo's local-only-fixture
+/// skip-on-presence convention (dataset tests skip when Data.db is absent).
+/// Returns `None` (caller returns early, prints why) when absent; `Some(raw)`
+/// with the file contents otherwise.
+fn read_dashboard_or_skip() -> Option<String> {
+    let path = dashboard_path();
+    if !path.exists() {
+        eprintln!(
+            "SKIP: kit dashboard absent ({}) — sparse checkout without easy-db-lab-kits/; \
+             the kit-dashboard-drift gate component enforces presence in full checkouts",
+            path.display()
+        );
+        return None;
+    }
+    Some(std::fs::read_to_string(&path).expect("kit dashboard JSON must be readable when present"))
+}
+
 #[test]
 fn dashboard_is_valid_json_with_panels() {
-    let raw = std::fs::read_to_string(dashboard_path()).expect("kit dashboard JSON must exist");
+    let Some(raw) = read_dashboard_or_skip() else {
+        return;
+    };
     let v: serde_json::Value =
         serde_json::from_str(&raw).expect("kit dashboard must be well-formed JSON");
     let panels = v
@@ -110,7 +134,9 @@ fn dashboard_is_valid_json_with_panels() {
 
 #[test]
 fn every_dashboard_metric_name_exists_in_catalog() {
-    let raw = std::fs::read_to_string(dashboard_path()).expect("kit dashboard JSON must exist");
+    let Some(raw) = read_dashboard_or_skip() else {
+        return;
+    };
     let catalog: HashSet<&str> = ALL_METRICS.iter().copied().collect();
 
     let referenced = dotted_cqlite_names(&raw);

--- a/cqlite-core/tests/kit_dashboard_metric_drift.rs
+++ b/cqlite-core/tests/kit_dashboard_metric_drift.rs
@@ -2,26 +2,40 @@
 //!
 //! `easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json` visualizes the
 //! `cqlite.*` instruments the observability catalog
-//! (`cqlite-core/src/observability/catalog.rs`) defines. Panel titles and
-//! descriptions embed the DOTTED canonical metric name (e.g.
-//! `cqlite.rpc.phase.duration`) as the single machine-checkable reference to what
-//! each panel shows — the PromQL `expr`s themselves use the collector-sanitized
-//! form (dots→underscores, `_total`/`_seconds`/`_bytes` suffixes), which cannot be
-//! reversed to a catalog name unambiguously, so the dotted reference is the
-//! anchor.
+//! (`cqlite-core/src/observability/catalog.rs`) defines. This test guards the
+//! dashboard against catalog drift on TWO fronts:
 //!
-//! This test extracts every dotted `cqlite.*` token referenced anywhere in the
-//! dashboard JSON and asserts each is a real name in
-//! [`catalog::ALL_METRICS`]. A renamed/removed/typo'd metric therefore fails
-//! CLOSED — the dashboard can never silently reference a phantom instrument.
+//! 1. **Dotted references** in panel titles/descriptions embed the canonical
+//!    metric name (e.g. `cqlite.rpc.phase.duration`); each must be a real name in
+//!    [`catalog::ALL_METRICS`] (or a bounded attribute key / namespace prefix).
+//! 2. **PromQL `expr` metric names** — the tokens that ACTUALLY render each panel
+//!    — use the Prometheus/OTel-sanitized form (dots→underscores plus type/unit
+//!    suffixes: counters `_total`, histograms `_bucket`/`_count`/`_sum`, unit
+//!    `_seconds`/`_bytes`). A typo in an `expr` (`…phase_duraton_seconds_bucket`)
+//!    leaves the panel silently EMPTY even when the correct dotted name appears in
+//!    the title, so we FORWARD-derive the valid sanitized name set from
+//!    `operator_metric_docs()` (name + kind + unit — all authoritative, no
+//!    hardcoded parallel list) and assert every `cqlite_*` token referenced in
+//!    every `expr` is in that set.
+//!
+//! A renamed/removed/typo'd metric therefore fails CLOSED on either front — the
+//! dashboard can never silently reference (or render from) a phantom instrument.
 //! Mirrors the #2426 operator-metrics-doc anti-drift pattern (a committed artifact
 //! cross-checked against the catalog at gate time).
 
-use cqlite_core::observability::catalog::{attr, ALL_METRICS};
+use cqlite_core::observability::catalog::{attr, unit, ALL_METRICS};
+use cqlite_core::observability::operator_docs::{operator_metric_docs, MetricKind};
 use std::collections::HashSet;
 
 /// Repo-root-relative path of the kit dashboard.
 const DASHBOARD_REL: &str = "easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json";
+
+/// Repo-root-relative path of the kit SUBTREE root. Its presence (a full checkout
+/// with the lab kits) is what distinguishes a genuine sparse/minimal checkout
+/// (kit absent → SKIP) from real drift/breakage (kit present but the dashboard
+/// JSON deleted/renamed → FAIL). Gating the skip on the specific dashboard file
+/// would let a delete/rename pass green in a COMPLETE checkout (roborev #2427 r2).
+const KIT_ROOT_REL: &str = "easy-db-lab-kits/cqlite-flight";
 
 /// Bounded attribute keys (`cqlite.*`) a dashboard legitimately references in
 /// panel `legendFormat`/description text (e.g. `cqlite.rpc.method`). These are
@@ -90,25 +104,181 @@ fn dotted_cqlite_names(text: &str) -> HashSet<String> {
     names
 }
 
-/// Loud skip-on-absence: the kit dashboard lives under `easy-db-lab-kits/` which
-/// is NOT present in a sparse/minimal checkout that has cqlite-core alone. This
-/// test runs under the `core-tests` gate component (all integration tests), so it
-/// must SKIP — not FAIL — when the artifact is absent; the dedicated SKIP-aware
-/// `kit-dashboard-drift` gate component ENFORCES presence (and drift) in full
-/// checkouts where the kit exists. Mirrors the repo's local-only-fixture
-/// skip-on-presence convention (dataset tests skip when Data.db is absent).
-/// Returns `None` (caller returns early, prints why) when absent; `Some(raw)`
-/// with the file contents otherwise.
+/// The set of Prometheus/OTel-sanitized metric names a catalogued instrument can
+/// legitimately expose, forward-derived from its catalog `(name, kind, unit)` —
+/// NO hardcoded parallel list, so it stays anti-drift.
+///
+/// The OTel Prometheus exporter sanitizes a dotted name (dots→underscores) and
+/// appends, in order, a UNIT suffix (`s`→`_seconds`, `By`→`_bytes`; other UCUM
+/// annotation units like `{row}`/`1` add none) and a TYPE suffix (counters
+/// `_total`; histograms expose `_bucket`/`_count`/`_sum`; gauges none). The
+/// exporter also de-duplicates — it does NOT re-append a unit/`_total` suffix a
+/// name already ends with (e.g. `cqlite.errors.total` stays `…_total`,
+/// `…wait_seconds` stays `…_seconds`). We therefore emit a GENEROUS set (the bare
+/// stem plus every plausible unit/type variant): permissive on the suffix (so a
+/// legit exporter-config difference never false-fails) but STRICT on the stem, so
+/// a mistyped metric name (`…phase_duraton_…`) is never in the set.
+fn sanitized_variants(name: &str, kind: MetricKind, metric_unit: &str) -> HashSet<String> {
+    let base = name.replace('.', "_");
+    // Stems: the bare sanitized name, plus a unit-suffixed stem when the unit maps
+    // to a Prometheus suffix and the name does not already carry it.
+    let mut stems: HashSet<String> = HashSet::new();
+    stems.insert(base.clone());
+    let unit_suffix = if metric_unit == unit::SECONDS {
+        Some("seconds")
+    } else if metric_unit == unit::BYTES {
+        Some("bytes")
+    } else {
+        None
+    };
+    if let Some(u) = unit_suffix {
+        if !base.ends_with(u) {
+            stems.insert(format!("{base}_{u}"));
+        }
+    }
+    // Type suffixes applied to each stem. Always keep the bare stem too (some
+    // exporter configs omit `_total`); the stem is what actually guards typos.
+    let mut out: HashSet<String> = HashSet::new();
+    for stem in &stems {
+        out.insert(stem.clone());
+        match kind {
+            MetricKind::Gauge => {}
+            MetricKind::Counter => {
+                if !stem.ends_with("_total") {
+                    out.insert(format!("{stem}_total"));
+                }
+            }
+            MetricKind::Histogram => {
+                out.insert(format!("{stem}_bucket"));
+                out.insert(format!("{stem}_count"));
+                out.insert(format!("{stem}_sum"));
+            }
+        }
+    }
+    out
+}
+
+/// Build the complete set of valid `cqlite_*` Prometheus identifiers a dashboard
+/// `expr` may reference: every metric's sanitized variants (from
+/// `operator_metric_docs()` — authoritative name+kind+unit) UNION the sanitized
+/// bounded attribute keys (used as label selectors / `by(...)` grouping, e.g.
+/// `cqlite_rpc_method`). Anti-drift: derived entirely from the catalog.
+fn valid_sanitized_names() -> HashSet<String> {
+    let mut set = HashSet::new();
+    let docs = operator_metric_docs()
+        .expect("operator_metric_docs must succeed (every ALL_METRICS entry is annotated)");
+    for d in &docs {
+        for v in sanitized_variants(d.name, d.kind, d.unit) {
+            set.insert(v);
+        }
+    }
+    // Sanitized bounded attribute keys appear as PromQL label names.
+    for a in ATTRIBUTE_KEYS {
+        set.insert(a.replace('.', "_"));
+    }
+    set
+}
+
+/// Extract every `cqlite_*` Prometheus identifier token referenced in a PromQL
+/// `expr`. Metric names appear before `{label…}` selectors and as the leading
+/// token of functions (`rate(NAME{…}[5m])`,
+/// `histogram_quantile(0.95, sum by(le)(rate(NAME_bucket{…}[5m])))`), and label
+/// keys appear inside `{…}` / `by(…)`; all are `[a-zA-Z_][a-zA-Z0-9_]*` tokens.
+/// We collect every such token that starts with `cqlite_` and validate each —
+/// the point is to catch a mistyped `cqlite_` metric name in an expression.
+fn cqlite_expr_tokens(expr: &str) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    let bytes = expr.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        let is_ident_start = c.is_ascii_alphabetic() || c == b'_';
+        if is_ident_start {
+            let start = i;
+            while i < bytes.len() {
+                let d = bytes[i];
+                if d.is_ascii_alphanumeric() || d == b'_' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            let tok = &expr[start..i];
+            if tok.starts_with("cqlite_") {
+                tokens.insert(tok.to_string());
+            }
+        } else {
+            i += 1;
+        }
+    }
+    tokens
+}
+
+/// Collect every PromQL `expr` string from a dashboard's panels (recursing into
+/// nested `panels`, e.g. inside a row), reading each panel target's `expr`.
+fn collect_exprs(panels: &serde_json::Value, out: &mut Vec<String>) {
+    let Some(arr) = panels.as_array() else {
+        return;
+    };
+    for panel in arr {
+        if let Some(targets) = panel.get("targets").and_then(|t| t.as_array()) {
+            for t in targets {
+                if let Some(expr) = t.get("expr").and_then(|e| e.as_str()) {
+                    out.push(expr.to_string());
+                }
+            }
+        }
+        if let Some(nested) = panel.get("panels") {
+            collect_exprs(nested, out);
+        }
+    }
+}
+
+/// Resolve the kit-subtree root against the repo root (cqlite-core's parent).
+fn kit_root_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cqlite-core has a repo-root parent")
+        .join(KIT_ROOT_REL)
+}
+
+/// Loud skip-on-absence — but ONLY for a genuine sparse checkout.
+///
+/// The kit dashboard lives under `easy-db-lab-kits/` which is NOT present in a
+/// sparse/minimal checkout that has cqlite-core alone. This test runs under the
+/// `core-tests` gate component (all integration tests), so it must SKIP — not
+/// FAIL — when the WHOLE kit subtree is absent.
+///
+/// Crucially, the skip is gated on the KIT ROOT directory, not on the specific
+/// dashboard file (roborev #2427 r2): if the kit subtree IS present but the
+/// expected dashboard JSON has been deleted/renamed, that is real drift/breakage
+/// in a complete checkout and must FAIL — panicking loudly — never a silent skip
+/// that defeats the artifact-presence + panel-count protection. Mirrors the
+/// repo's local-only-fixture skip-on-presence convention (skip only when the
+/// whole fixture family is unavailable, fail on 0-when-present).
+///
+/// Returns `None` (caller returns early, prints why) on a genuine sparse checkout;
+/// `Some(raw)` with the file contents otherwise; panics on the present-kit,
+/// missing-dashboard drift case.
 fn read_dashboard_or_skip() -> Option<String> {
-    let path = dashboard_path();
-    if !path.exists() {
+    let kit_root = kit_root_path();
+    if !kit_root.exists() {
         eprintln!(
-            "SKIP: kit dashboard absent ({}) — sparse checkout without easy-db-lab-kits/; \
+            "SKIP: kit subtree absent ({}) — sparse checkout without easy-db-lab-kits/; \
              the kit-dashboard-drift gate component enforces presence in full checkouts",
-            path.display()
+            kit_root.display()
         );
         return None;
     }
+    let path = dashboard_path();
+    assert!(
+        path.exists(),
+        "FAIL: kit subtree {} IS present but the expected dashboard JSON is MISSING ({}) — \
+         a deleted/renamed dashboard in a complete checkout is drift/breakage, not a sparse \
+         checkout. Restore the dashboard at {DASHBOARD_REL} or update this test's path.",
+        kit_root.display(),
+        path.display()
+    );
     Some(std::fs::read_to_string(&path).expect("kit dashboard JSON must be readable when present"))
 }
 
@@ -171,6 +341,121 @@ fn every_dashboard_metric_name_exists_in_catalog() {
     assert!(
         referenced.iter().any(|n| catalog.contains(n.as_str())),
         "expected the dashboard to reference at least one exact catalog metric name"
+    );
+}
+
+#[test]
+fn every_expr_metric_name_is_a_valid_sanitized_catalog_name() {
+    // FINDING 1 (roborev #2427 r2): the exprs are what actually RENDER each panel.
+    // A typo in an expr metric name (`cqlite_rpc_phase_duraton_seconds_bucket`)
+    // leaves the panel silently EMPTY even though the correct dotted name still
+    // appears in the title — so we validate the PromQL expr tokens against the
+    // forward-derived sanitized-name set, not just the titles/descriptions.
+    let Some(raw) = read_dashboard_or_skip() else {
+        return;
+    };
+    let v: serde_json::Value =
+        serde_json::from_str(&raw).expect("kit dashboard must be well-formed JSON");
+    let mut exprs = Vec::new();
+    collect_exprs(
+        v.get("panels").expect("dashboard must have a panels array"),
+        &mut exprs,
+    );
+    assert!(
+        !exprs.is_empty(),
+        "expected the dashboard to have at least one panel target with a PromQL expr"
+    );
+
+    let valid = valid_sanitized_names();
+
+    // Every `cqlite_*` token referenced in any expr must be a valid sanitized
+    // metric name (or attribute label) — anything else is a mistyped/renamed
+    // reference that renders an EMPTY panel. Fail CLOSED, naming the offenders.
+    let mut invalid: Vec<String> = Vec::new();
+    let mut referenced_any_metric = false;
+    for expr in &exprs {
+        for tok in cqlite_expr_tokens(expr) {
+            if valid.contains(&tok) {
+                referenced_any_metric = true;
+            } else {
+                invalid.push(tok);
+            }
+        }
+    }
+    invalid.sort();
+    invalid.dedup();
+    assert!(
+        invalid.is_empty(),
+        "kit dashboard {DASHBOARD_REL} references cqlite_* PromQL metric/label name(s) that are \
+         NOT valid sanitized forms of any catalog metric or bounded attribute (a typo/rename \
+         renders the panel EMPTY — fix the expr or the catalog): {invalid:?}"
+    );
+    assert!(
+        referenced_any_metric,
+        "expected the dashboard exprs to reference at least one valid cqlite_* sanitized name"
+    );
+}
+
+#[test]
+fn expr_validator_rejects_a_typo_in_an_expr_metric_name_negative_test() {
+    // FINDING 1 negative test (roborev #2427 r2): corrupt ONLY an expr's metric
+    // name — leaving the correct dotted name in the title/description — and assert
+    // the guard flags it. This is precisely the empty-panel bug the title-only
+    // check missed: the correct dotted name elsewhere no longer rescues a typo'd
+    // expr. Uses a synthetic expr so the test never depends on the live dashboard.
+    let valid = valid_sanitized_names();
+
+    // The correct sanitized name IS in the valid set…
+    assert!(
+        valid.contains("cqlite_rpc_phase_duration_seconds_bucket"),
+        "the correct histogram bucket name must be a valid sanitized variant"
+    );
+    // …but a one-character typo ("duraton") is NOT — so the panel would be empty.
+    let typo_expr = "histogram_quantile(0.95, sum(rate(cqlite_rpc_phase_duraton_seconds_bucket\
+                     {cluster=~\"$cluster\"}[5m])) by (le, cqlite_rpc_phase))";
+    let mut invalid: Vec<String> = cqlite_expr_tokens(typo_expr)
+        .into_iter()
+        .filter(|t| !valid.contains(t))
+        .collect();
+    invalid.sort();
+    assert_eq!(
+        invalid,
+        vec!["cqlite_rpc_phase_duraton_seconds_bucket".to_string()],
+        "the expr validator must flag exactly the typo'd metric name (and nothing else)"
+    );
+
+    // Sanity: a counter's `_total` and a histogram's `_bucket`/`_count`/`_sum` are
+    // all accepted (forward-derived from kind), a bare gauge name is accepted, and
+    // a sanitized attribute label is accepted.
+    assert!(
+        valid.contains("cqlite_rpc_requests_total"),
+        "counter _total"
+    );
+    assert!(
+        valid.contains("cqlite_rpc_duration_seconds_count"),
+        "histogram _count"
+    );
+    assert!(
+        valid.contains("cqlite_rpc_duration_seconds_sum"),
+        "histogram _sum"
+    );
+    assert!(valid.contains("cqlite_rpc_in_flight"), "bare gauge name");
+    assert!(
+        valid.contains("cqlite_rpc_bytes_total"),
+        "counter with By unit + _total"
+    );
+    assert!(
+        valid.contains("cqlite_rpc_method"),
+        "sanitized attribute label"
+    );
+    // A name that already ends in `_total` is not double-suffixed.
+    assert!(
+        valid.contains("cqlite_errors_total"),
+        "errors.total counter"
+    );
+    assert!(
+        !valid.contains("cqlite_errors_total_total"),
+        "must not double-append _total to a name already ending in _total"
     );
 }
 

--- a/cqlite-core/tests/kit_dashboard_metric_drift.rs
+++ b/cqlite-core/tests/kit_dashboard_metric_drift.rs
@@ -66,21 +66,26 @@ const ATTRIBUTE_KEYS: &[&str] = &[
 ];
 
 /// True when `token` is an EXPLICIT `.*` wildcard group reference whose namespace
-/// covers at least one real catalog metric — e.g. `cqlite.flight.admission.*`
-/// (covers `cqlite.flight.admission.in_use`, …). ONLY the explicit-wildcard form
-/// is admitted as a group ref (roborev #2427 r3, F2): a BARE dotted prefix such as
-/// `cqlite.flight.admission` (no trailing `.*`) is NOT a valid reference, so a
-/// phantom that merely happens to be a prefix of a real namespace can no longer
-/// pass. The stem must still cover a real metric, so `cqlite.does.not.exist.*` is
-/// rejected.
+/// contains at least one real catalog metric BELOW it — e.g.
+/// `cqlite.flight.admission.*` (covers `cqlite.flight.admission.in_use`, …). ONLY
+/// the explicit-wildcard form is admitted as a group ref (roborev #2427 r3, F2): a
+/// BARE dotted prefix such as `cqlite.flight.admission` (no trailing `.*`) is NOT a
+/// valid reference, so a phantom that merely happens to be a prefix of a real
+/// namespace can no longer pass.
+///
+/// A `<stem>.*` is valid ONLY if ≥1 catalog metric name starts with the literal
+/// `"<stem>."` — i.e. a real CHILD lives under the namespace (roborev #2427 r4, F1).
+/// A wildcard on an exact LEAF metric with no children — `cqlite.errors.total.*`
+/// where `cqlite.errors.total` IS a metric but nothing lives below it — covers
+/// nothing and is REJECTED; the earlier `*m == stem` clause fail-open here let such
+/// a leaf-wildcard pass. `cqlite.does.not.exist.*` (no such namespace at all) also
+/// remains rejected.
 fn is_wildcard_group_ref(token: &str) -> bool {
     let Some(stem) = token.strip_suffix(".*") else {
         return false;
     };
     let dotted = format!("{stem}.");
-    ALL_METRICS
-        .iter()
-        .any(|m| *m == stem || m.starts_with(&dotted))
+    ALL_METRICS.iter().any(|m| m.starts_with(&dotted))
 }
 
 /// Resolve the dashboard path against the repo root (cqlite-core's parent).
@@ -264,6 +269,145 @@ fn cqlite_expr_tokens(expr: &str) -> HashSet<String> {
     tokens
 }
 
+/// PromQL grouping / vector-matching keywords whose FOLLOWING `( … )` holds LABEL
+/// keys, not metric selectors (`sum(...) by (le, cqlite_rpc_method)`). Identifiers
+/// inside such a paren group — and these keywords themselves — are never metric
+/// (vector-selector) position tokens.
+const PROMQL_GROUPING_KEYWORDS: &[&str] = &[
+    "by",
+    "without",
+    "on",
+    "ignoring",
+    "group_left",
+    "group_right",
+];
+
+/// Bare PromQL words that can appear at brace-depth 0 in identifier position but
+/// are NOT series selectors — logical/set binary operators and misc keywords that
+/// stand without an immediately-following `(`.
+const PROMQL_RESERVED_WORDS: &[&str] = &[
+    "and", "or", "unless", "bool", "offset", "atan2", "inf", "nan", "start", "end",
+];
+
+/// Extract every identifier in METRIC (instant-vector-selector) POSITION from a
+/// PromQL `expr`, REGARDLESS of prefix (roborev #2427 r4, F2). Unlike
+/// [`cqlite_expr_tokens`] — which only sees `cqlite_`-prefixed tokens and so cannot
+/// catch a *prefix* typo like `cqltie_rpc_requests_total` — this classifies by
+/// syntactic position. The dashboard is cqlite-only, so EVERY metric-position token
+/// must be a recognized catalog series; anything else renders an EMPTY panel and
+/// must FAIL. Excludes, by construction:
+///   - function/aggregation names (identifier immediately followed by `(`),
+///   - label keys inside `{ … }` selectors and quoted strings,
+///   - identifiers inside `[ … ]` range/duration brackets,
+///   - grouping-clause label lists (`by`/`without`/`on`/`ignoring`/`group_*`),
+///   - bare reserved binary keywords.
+fn metric_position_tokens(expr: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = expr.as_bytes();
+    let mut i = 0;
+    let mut brace_depth = 0usize; // inside `{ … }` label selectors
+    let mut bracket_depth = 0usize; // inside `[ … ]` range / duration
+                                    // Paren stack: true == this `( … )` is a grouping label list.
+    let mut paren_is_label_list: Vec<bool> = Vec::new();
+    let mut next_paren_is_label_list = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b'"' | b'\'' => {
+                // Skip a quoted string literal wholesale (handle `\` escapes).
+                let quote = c;
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    if bytes[i] == b'\\' {
+                        i += 1;
+                    }
+                    i += 1;
+                }
+                i += 1; // consume closing quote (or run off end)
+            }
+            b'{' => {
+                brace_depth += 1;
+                i += 1;
+            }
+            b'}' => {
+                brace_depth = brace_depth.saturating_sub(1);
+                i += 1;
+            }
+            b'[' => {
+                bracket_depth += 1;
+                i += 1;
+            }
+            b']' => {
+                bracket_depth = bracket_depth.saturating_sub(1);
+                i += 1;
+            }
+            b'(' => {
+                paren_is_label_list.push(next_paren_is_label_list);
+                next_paren_is_label_list = false;
+                i += 1;
+            }
+            b')' => {
+                paren_is_label_list.pop();
+                i += 1;
+            }
+            _ if c.is_ascii_alphabetic() || c == b'_' => {
+                let start = i;
+                while i < bytes.len()
+                    && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_' || bytes[i] == b':')
+                {
+                    i += 1;
+                }
+                let tok = &expr[start..i];
+                // Peek the next non-space char to detect a function/keyword call.
+                let mut j = i;
+                while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                let followed_by_paren = j < bytes.len() && bytes[j] == b'(';
+                if followed_by_paren {
+                    // Function or grouping keyword — never a metric itself. A
+                    // grouping keyword marks its following paren as a label list.
+                    if PROMQL_GROUPING_KEYWORDS.contains(&tok) {
+                        next_paren_is_label_list = true;
+                    }
+                    continue;
+                }
+                let in_label_context = brace_depth > 0
+                    || bracket_depth > 0
+                    || paren_is_label_list.last().copied().unwrap_or(false);
+                let is_reserved =
+                    PROMQL_GROUPING_KEYWORDS.contains(&tok) || PROMQL_RESERVED_WORDS.contains(&tok);
+                if !in_label_context && !is_reserved {
+                    out.push(tok.to_string());
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Classify one expr's metric-position tokens against the catalog, returning
+/// `(referenced_a_catalog_metric, offending_tokens)` (roborev #2427 r4, F2). A
+/// metric-position identifier that isn't a known catalog series is an offender EVEN
+/// IF it isn't `cqlite_`-prefixed — which is exactly how a *prefix* typo
+/// (`cqltie_rpc_requests_total`) is caught. Sanitized attribute labels are accepted
+/// but do NOT count as referencing a metric (roborev #2427 r3, F3).
+fn classify_expr(expr: &str, valid: &ValidNames) -> (bool, Vec<String>) {
+    let mut referenced = false;
+    let mut offenders = Vec::new();
+    for tok in metric_position_tokens(expr) {
+        if valid.metrics.contains(&tok) {
+            referenced = true;
+        } else if !valid.attributes.contains(&tok) {
+            offenders.push(tok);
+        }
+    }
+    (referenced, offenders)
+}
+
 /// Collect every PromQL `expr` string from a dashboard's panels (recursing into
 /// nested `panels`, e.g. inside a row), reading each panel target's `expr`.
 fn collect_exprs(panels: &serde_json::Value, out: &mut Vec<String>) {
@@ -420,34 +564,35 @@ fn every_expr_metric_name_is_a_valid_sanitized_catalog_name() {
 
     let valid = valid_sanitized_names();
 
-    // Every `cqlite_*` token referenced in any expr must be a valid sanitized
-    // metric name (or attribute label) — anything else is a mistyped/renamed
-    // reference that renders an EMPTY panel. Fail CLOSED, naming the offenders.
-    // `referenced_any_metric` is set ONLY by membership in the METRIC set — an
-    // attribute label alone does not count as referencing a metric (roborev #2427
-    // r3, F3).
+    // Validate PER EXPR (roborev #2427 r4, F2), by metric POSITION rather than by
+    // `cqlite_` prefix, so that (a) a *prefix* typo like `cqltie_rpc_requests_total`
+    // is caught (the old `cqlite_`-only scanner ignored it), and (b) EVERY panel
+    // target must ITSELF reference ≥1 recognized catalog metric — a valid sibling
+    // panel no longer masks a typo'd one that renders EMPTY. Both conditions fail
+    // CLOSED, naming the offending token and its expr.
     let mut invalid: Vec<String> = Vec::new();
-    let mut referenced_any_metric = false;
+    let mut exprs_without_metric: Vec<String> = Vec::new();
     for expr in &exprs {
-        for tok in cqlite_expr_tokens(expr) {
-            if valid.metrics.contains(&tok) {
-                referenced_any_metric = true;
-            } else if !valid.attributes.contains(&tok) {
-                invalid.push(tok);
-            }
+        let (referenced_metric, offenders) = classify_expr(expr, &valid);
+        for tok in offenders {
+            invalid.push(format!("{tok}  (in expr: {expr})"));
+        }
+        if !referenced_metric {
+            exprs_without_metric.push(expr.clone());
         }
     }
     invalid.sort();
     invalid.dedup();
     assert!(
         invalid.is_empty(),
-        "kit dashboard {DASHBOARD_REL} references cqlite_* PromQL metric/label name(s) that are \
-         NOT valid sanitized forms of any catalog metric or bounded attribute (a typo/rename \
-         renders the panel EMPTY — fix the expr or the catalog): {invalid:?}"
+        "kit dashboard {DASHBOARD_REL} has expr metric-position name(s) that are NOT a valid \
+         sanitized catalog metric (a typo/rename — incl. a mistyped PREFIX — renders the panel \
+         EMPTY; fix the expr or the catalog): {invalid:#?}"
     );
     assert!(
-        referenced_any_metric,
-        "expected the dashboard exprs to reference at least one valid cqlite_* sanitized name"
+        exprs_without_metric.is_empty(),
+        "kit dashboard {DASHBOARD_REL} has panel target expr(s) that reference NO recognized \
+         catalog metric (would render EMPTY): {exprs_without_metric:#?}"
     );
 }
 
@@ -570,6 +715,83 @@ fn expr_validator_rejects_a_typo_in_an_expr_metric_name_negative_test() {
     assert!(
         !is_wildcard_group_ref("cqlite.does.not.exist.*"),
         "a .* group ref covering NO real metric must be REJECTED"
+    );
+
+    // F1 (roborev #2427 r4) — a wildcard on an exact LEAF metric with no children
+    // must be REJECTED: `cqlite.errors.total` IS a metric, but no catalog series
+    // starts with `cqlite.errors.total.`, so `cqlite.errors.total.*` covers nothing
+    // and would be a dead group ref. The removed `*m == stem` clause used to let it
+    // pass (fail-open).
+    assert!(
+        ALL_METRICS.contains(&"cqlite.errors.total"),
+        "precondition: cqlite.errors.total is an exact catalog leaf metric"
+    );
+    assert!(
+        !ALL_METRICS
+            .iter()
+            .any(|m| m.starts_with("cqlite.errors.total.")),
+        "precondition: no catalog metric lives BELOW cqlite.errors.total"
+    );
+    assert!(
+        !is_wildcard_group_ref("cqlite.errors.total.*"),
+        "a wildcard on an exact leaf metric with no children must be REJECTED \
+         (roborev #2427 r4, F1) — the removed `*m == stem` clause let it pass"
+    );
+    // The dashboard's real wildcard row titles DO have children, so they still pass.
+    assert!(
+        is_wildcard_group_ref("cqlite.warm.cache.*"),
+        "a real namespace with children must still be accepted"
+    );
+}
+
+#[test]
+fn per_expr_prefix_typo_fails_even_with_a_valid_sibling_panel_negative_test() {
+    // FINDING 2 negative test (roborev #2427 r4): metric coverage is checked PER
+    // EXPR, not globally, and by metric POSITION (not `cqlite_` prefix) — so a panel
+    // whose ONLY selector is a *prefix*-typo'd metric (`cqltie_rpc_requests_total`)
+    // FAILS even when OTHER panels are valid. The old global+prefix-scoped check
+    // passed this: the typo has the wrong prefix (invisible to a `cqlite_`-only
+    // scanner) and a sibling panel satisfied the single global coverage flag.
+    let valid = valid_sanitized_names();
+
+    // A valid panel and a prefix-typo'd panel, exactly as they would coexist.
+    let valid_expr = "sum(rate(cqlite_rpc_requests_total{cluster=~\"$cluster\"}[1m])) \
+                      by (cqlite_rpc_method)";
+    let typo_expr = "sum(rate(cqltie_rpc_requests_total{cluster=~\"$cluster\"}[1m]))";
+
+    // The valid panel references a real metric; the typo panel references NONE.
+    let (valid_ref, valid_off) = classify_expr(valid_expr, &valid);
+    assert!(valid_ref, "the valid sibling expr references a real metric");
+    assert!(
+        valid_off.is_empty(),
+        "the valid sibling expr has no offending tokens, got: {valid_off:?}"
+    );
+
+    let (typo_ref, typo_off) = classify_expr(typo_expr, &valid);
+    assert!(
+        !typo_ref,
+        "the prefix-typo'd expr references NO recognized catalog metric — the \
+         per-expr coverage check must FAIL it even beside a valid sibling"
+    );
+    assert_eq!(
+        typo_off,
+        vec!["cqltie_rpc_requests_total".to_string()],
+        "the prefix typo must be flagged as an offending metric-position token \
+         (a `cqlite_`-only scanner would have missed the mistyped prefix)"
+    );
+
+    // `metric_position_tokens` isolates the SELECTOR position: function names,
+    // grouping-clause label keys, and `{…}` matcher keys are NOT metric-position.
+    let hist_expr = "histogram_quantile(0.95, sum(rate(\
+                     cqlite_rpc_duration_seconds_bucket{cluster=~\"$cluster\"}[5m])) \
+                     by (le, cqlite_rpc_method))";
+    let positions = metric_position_tokens(hist_expr);
+    assert_eq!(
+        positions,
+        vec!["cqlite_rpc_duration_seconds_bucket".to_string()],
+        "only the vector-selector metric is in metric position; \
+         histogram_quantile/sum/rate (functions), le, cqlite_rpc_method (grouping \
+         labels) and cluster ({{}} matcher key) are excluded, got: {positions:?}"
     );
 }
 

--- a/cqlite-core/tests/kit_dashboard_metric_drift.rs
+++ b/cqlite-core/tests/kit_dashboard_metric_drift.rs
@@ -1,0 +1,168 @@
+//! Catalog-drift guard for the kit Grafana dashboard (issue #2427).
+//!
+//! `easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json` visualizes the
+//! `cqlite.*` instruments the observability catalog
+//! (`cqlite-core/src/observability/catalog.rs`) defines. Panel titles and
+//! descriptions embed the DOTTED canonical metric name (e.g.
+//! `cqlite.rpc.phase.duration`) as the single machine-checkable reference to what
+//! each panel shows — the PromQL `expr`s themselves use the collector-sanitized
+//! form (dots→underscores, `_total`/`_seconds`/`_bytes` suffixes), which cannot be
+//! reversed to a catalog name unambiguously, so the dotted reference is the
+//! anchor.
+//!
+//! This test extracts every dotted `cqlite.*` token referenced anywhere in the
+//! dashboard JSON and asserts each is a real name in
+//! [`catalog::ALL_METRICS`]. A renamed/removed/typo'd metric therefore fails
+//! CLOSED — the dashboard can never silently reference a phantom instrument.
+//! Mirrors the #2426 operator-metrics-doc anti-drift pattern (a committed artifact
+//! cross-checked against the catalog at gate time).
+
+use cqlite_core::observability::catalog::{attr, ALL_METRICS};
+use std::collections::HashSet;
+
+/// Repo-root-relative path of the kit dashboard.
+const DASHBOARD_REL: &str = "easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json";
+
+/// Bounded attribute keys (`cqlite.*`) a dashboard legitimately references in
+/// panel `legendFormat`/description text (e.g. `cqlite.rpc.method`). These are
+/// dotted `cqlite.*` tokens that are NOT metric names, so the drift check accepts
+/// them — but only against this closed list mirrored from `catalog::attr`, so a
+/// renamed attribute key is still caught.
+const ATTRIBUTE_KEYS: &[&str] = &[
+    attr::ERROR_CATEGORY,
+    attr::SUBSYSTEM,
+    attr::SSTABLE_FORMAT,
+    attr::COMPRESSION,
+    attr::RESULT,
+    attr::LOOKUP_ROUTE,
+    attr::ACCESS_PATH,
+    attr::PLAN_TYPE,
+    attr::RPC_METHOD,
+    attr::RPC_STATUS,
+    attr::RPC_PHASE,
+    attr::FALLBACK_REASON,
+    attr::WARM_REFRESH_OUTCOME,
+];
+
+/// True when `token` is a namespace-group prefix of a real catalog metric — i.e.
+/// some metric name equals `token` or starts with `token + "."`. This admits a
+/// row-title group label such as `cqlite.flight.admission` (prefix of
+/// `cqlite.flight.admission.in_use`) while still rejecting a typo like
+/// `cqlite.flight.admissionx` (no metric starts with `…admissionx.`).
+fn is_metric_namespace_prefix(token: &str) -> bool {
+    let dotted = format!("{token}.");
+    ALL_METRICS
+        .iter()
+        .any(|m| *m == token || m.starts_with(&dotted))
+}
+
+/// Resolve the dashboard path against the repo root (cqlite-core's parent).
+fn dashboard_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cqlite-core has a repo-root parent")
+        .join(DASHBOARD_REL)
+}
+
+/// Extract every DOTTED `cqlite.<segment>(.<segment>)+` token from `text`.
+///
+/// A catalog metric name is `cqlite.` followed by dot-separated lower-snake
+/// segments (e.g. `cqlite.flight.admission.wait_seconds`). We greedily consume
+/// `[a-z0-9_.]` after the `cqlite.` root and then trim any trailing `.` left by a
+/// prose sentence boundary. The collector-sanitized PromQL form uses `_` instead
+/// of the leading `cqlite_` dot and so never matches `cqlite.` — those are
+/// excluded by construction, exactly as intended (we anchor on the dotted name).
+fn dotted_cqlite_names(text: &str) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for (i, _) in text.match_indices("cqlite.") {
+        let tail = &text[i..];
+        let token: String = tail
+            .chars()
+            .take_while(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '_' || *c == '.')
+            .collect();
+        // Trim trailing dots (sentence boundary) but keep interior dots.
+        let token = token.trim_end_matches('.').to_string();
+        // A bare `cqlite.` with no segment is not a metric reference.
+        if token.len() > "cqlite.".len() {
+            names.insert(token);
+        }
+    }
+    names
+}
+
+#[test]
+fn dashboard_is_valid_json_with_panels() {
+    let raw = std::fs::read_to_string(dashboard_path()).expect("kit dashboard JSON must exist");
+    let v: serde_json::Value =
+        serde_json::from_str(&raw).expect("kit dashboard must be well-formed JSON");
+    let panels = v
+        .get("panels")
+        .and_then(|p| p.as_array())
+        .expect("dashboard must have a panels array");
+    // The 0.15 refresh (issue #2427) adds phase/index/admission/warm groups on top
+    // of the original 15-panel base RPC set — guard against an accidental revert.
+    assert!(
+        panels.len() > 15,
+        "expected the 0.15-refreshed dashboard to have more than the original 15 panels, got {}",
+        panels.len()
+    );
+}
+
+#[test]
+fn every_dashboard_metric_name_exists_in_catalog() {
+    let raw = std::fs::read_to_string(dashboard_path()).expect("kit dashboard JSON must exist");
+    let catalog: HashSet<&str> = ALL_METRICS.iter().copied().collect();
+
+    let referenced = dotted_cqlite_names(&raw);
+    assert!(
+        !referenced.is_empty(),
+        "expected the dashboard to reference at least one dotted cqlite.* metric name"
+    );
+
+    let attrs: HashSet<&str> = ATTRIBUTE_KEYS.iter().copied().collect();
+
+    // A dotted `cqlite.*` token is accepted iff it is an exact metric name, a
+    // bounded attribute key, or a namespace-group prefix of a real metric (a row
+    // title). Anything else is a renamed/removed/phantom reference — fail CLOSED.
+    let mut phantom: Vec<String> = referenced
+        .iter()
+        .filter(|name| {
+            !catalog.contains(name.as_str())
+                && !attrs.contains(name.as_str())
+                && !is_metric_namespace_prefix(name)
+        })
+        .cloned()
+        .collect();
+    phantom.sort();
+    assert!(
+        phantom.is_empty(),
+        "kit dashboard {DASHBOARD_REL} references cqlite.* metric name(s) ABSENT from \
+         catalog::ALL_METRICS (renamed/removed/typo'd — fix the dashboard or the catalog): {phantom:?}"
+    );
+
+    // At least one referenced token must be an EXACT metric name (not just an
+    // attribute key or a group prefix), so the check has real metric coverage.
+    assert!(
+        referenced.iter().any(|n| catalog.contains(n.as_str())),
+        "expected the dashboard to reference at least one exact catalog metric name"
+    );
+}
+
+#[test]
+fn drift_extractor_rejects_a_phantom_name_self_test() {
+    // Self-test the guard: a bogus dotted name must be extracted and flagged as
+    // absent from the catalog, so a real drift cannot pass silently.
+    let catalog: HashSet<&str> = ALL_METRICS.iter().copied().collect();
+    let sample = "panel shows cqlite.rpc.phase.duration and a bogus cqlite.does.not.exist metric.";
+    let names = dotted_cqlite_names(sample);
+    assert!(names.contains("cqlite.rpc.phase.duration"));
+    assert!(names.contains("cqlite.does.not.exist"));
+    assert!(catalog.contains("cqlite.rpc.phase.duration"));
+    assert!(
+        !catalog.contains("cqlite.does.not.exist"),
+        "self-test bogus name must NOT be in the catalog"
+    );
+    // Trailing-dot trim: a sentence-final reference resolves to the bare name.
+    let trimmed = dotted_cqlite_names("see cqlite.errors.total.");
+    assert!(trimmed.contains("cqlite.errors.total"));
+}

--- a/cqlite-core/tests/kit_dashboard_metric_drift.rs
+++ b/cqlite-core/tests/kit_dashboard_metric_drift.rs
@@ -6,17 +6,24 @@
 //! dashboard against catalog drift on TWO fronts:
 //!
 //! 1. **Dotted references** in panel titles/descriptions embed the canonical
-//!    metric name (e.g. `cqlite.rpc.phase.duration`); each must be a real name in
-//!    [`catalog::ALL_METRICS`] (or a bounded attribute key / namespace prefix).
+//!    metric name (e.g. `cqlite.rpc.phase.duration`); each must be an EXACT name
+//!    in [`catalog::ALL_METRICS`], an EXACT bounded attribute key, or an explicit
+//!    `.*` wildcard group ref (`cqlite.flight.admission.*`) — a bare namespace
+//!    prefix that is none of those FAILS (roborev #2427 r3, F2).
 //! 2. **PromQL `expr` metric names** — the tokens that ACTUALLY render each panel
-//!    — use the Prometheus/OTel-sanitized form (dots→underscores plus type/unit
-//!    suffixes: counters `_total`, histograms `_bucket`/`_count`/`_sum`, unit
-//!    `_seconds`/`_bytes`). A typo in an `expr` (`…phase_duraton_seconds_bucket`)
-//!    leaves the panel silently EMPTY even when the correct dotted name appears in
-//!    the title, so we FORWARD-derive the valid sanitized name set from
+//!    — use the Prometheus/OTel-sanitized form (dots→underscores plus the EXACT
+//!    unit+type suffixes the collector emits: a counter is `<stem>_total`, a
+//!    seconds histogram is `<stem>_seconds_{bucket,count,sum}`, a gauge is the
+//!    bare unit-suffixed stem). A typo (`…phase_duraton_seconds_bucket`) OR a
+//!    bare/mis-suffixed form (`cqlite_rpc_requests` missing `_total`,
+//!    `cqlite_rpc_phase_duration_bucket` missing `_seconds`) leaves the panel
+//!    silently EMPTY even when the correct dotted name appears in the title, so we
+//!    FORWARD-derive the EXACT emitted-name set (NOT a permissive superset) from
 //!    `operator_metric_docs()` (name + kind + unit — all authoritative, no
 //!    hardcoded parallel list) and assert every `cqlite_*` token referenced in
-//!    every `expr` is in that set.
+//!    every `expr` is in that set (roborev #2427 r3, F1). Attribute-label tokens
+//!    are tracked in a SEPARATE set so referencing only an attribute never counts
+//!    as referencing a metric (roborev #2427 r3, F3).
 //!
 //! A renamed/removed/typo'd metric therefore fails CLOSED on either front — the
 //! dashboard can never silently reference (or render from) a phantom instrument.
@@ -58,16 +65,22 @@ const ATTRIBUTE_KEYS: &[&str] = &[
     attr::WARM_REFRESH_OUTCOME,
 ];
 
-/// True when `token` is a namespace-group prefix of a real catalog metric — i.e.
-/// some metric name equals `token` or starts with `token + "."`. This admits a
-/// row-title group label such as `cqlite.flight.admission` (prefix of
-/// `cqlite.flight.admission.in_use`) while still rejecting a typo like
-/// `cqlite.flight.admissionx` (no metric starts with `…admissionx.`).
-fn is_metric_namespace_prefix(token: &str) -> bool {
-    let dotted = format!("{token}.");
+/// True when `token` is an EXPLICIT `.*` wildcard group reference whose namespace
+/// covers at least one real catalog metric — e.g. `cqlite.flight.admission.*`
+/// (covers `cqlite.flight.admission.in_use`, …). ONLY the explicit-wildcard form
+/// is admitted as a group ref (roborev #2427 r3, F2): a BARE dotted prefix such as
+/// `cqlite.flight.admission` (no trailing `.*`) is NOT a valid reference, so a
+/// phantom that merely happens to be a prefix of a real namespace can no longer
+/// pass. The stem must still cover a real metric, so `cqlite.does.not.exist.*` is
+/// rejected.
+fn is_wildcard_group_ref(token: &str) -> bool {
+    let Some(stem) = token.strip_suffix(".*") else {
+        return false;
+    };
+    let dotted = format!("{stem}.");
     ALL_METRICS
         .iter()
-        .any(|m| *m == token || m.starts_with(&dotted))
+        .any(|m| *m == stem || m.starts_with(&dotted))
 }
 
 /// Resolve the dashboard path against the repo root (cqlite-core's parent).
@@ -78,24 +91,33 @@ fn dashboard_path() -> std::path::PathBuf {
         .join(DASHBOARD_REL)
 }
 
-/// Extract every DOTTED `cqlite.<segment>(.<segment>)+` token from `text`.
+/// Extract every DOTTED `cqlite.<segment>(.<segment>)+` token from `text`,
+/// preserving an explicit trailing `.*` wildcard group marker.
 ///
 /// A catalog metric name is `cqlite.` followed by dot-separated lower-snake
 /// segments (e.g. `cqlite.flight.admission.wait_seconds`). We greedily consume
-/// `[a-z0-9_.]` after the `cqlite.` root and then trim any trailing `.` left by a
-/// prose sentence boundary. The collector-sanitized PromQL form uses `_` instead
-/// of the leading `cqlite_` dot and so never matches `cqlite.` — those are
-/// excluded by construction, exactly as intended (we anchor on the dotted name).
+/// `[a-z0-9_.*]` after the `cqlite.` root, then trim a trailing prose dot while
+/// keeping a genuine `.*` wildcard group ref (`cqlite.flight.admission.*`). The
+/// collector-sanitized PromQL form uses `_` instead of the leading `cqlite_` dot
+/// and so never matches `cqlite.` — those are excluded by construction, exactly
+/// as intended (we anchor on the dotted name).
 fn dotted_cqlite_names(text: &str) -> HashSet<String> {
     let mut names = HashSet::new();
     for (i, _) in text.match_indices("cqlite.") {
         let tail = &text[i..];
         let token: String = tail
             .chars()
-            .take_while(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '_' || *c == '.')
+            .take_while(|c| {
+                c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '_' || *c == '.' || *c == '*'
+            })
             .collect();
-        // Trim trailing dots (sentence boundary) but keep interior dots.
-        let token = token.trim_end_matches('.').to_string();
+        // Preserve an explicit `.*` wildcard group ref; otherwise trim any
+        // trailing `.`/`*` left by a prose sentence boundary (keep interior dots).
+        let token = if token.ends_with(".*") {
+            token
+        } else {
+            token.trim_end_matches(['.', '*']).to_string()
+        };
         // A bare `cqlite.` with no segment is not a metric reference.
         if token.len() > "cqlite.".len() {
             names.insert(token);
@@ -104,26 +126,34 @@ fn dotted_cqlite_names(text: &str) -> HashSet<String> {
     names
 }
 
-/// The set of Prometheus/OTel-sanitized metric names a catalogued instrument can
-/// legitimately expose, forward-derived from its catalog `(name, kind, unit)` —
-/// NO hardcoded parallel list, so it stays anti-drift.
+/// The EXACT Prometheus/OTel-sanitized metric names a catalogued instrument
+/// exposes, forward-derived from its catalog `(name, kind, unit)` — NO hardcoded
+/// parallel list (anti-drift) and NO permissive superset (roborev #2427 r3, F1):
+/// the set holds ONLY the names the collector actually emits, so a dashboard that
+/// uses a bare/mis-suffixed form (which would render an EMPTY panel) is rejected.
 ///
-/// The OTel Prometheus exporter sanitizes a dotted name (dots→underscores) and
+/// The OTel Prometheus exporter sanitizes a dotted name (dots→underscores), then
 /// appends, in order, a UNIT suffix (`s`→`_seconds`, `By`→`_bytes`; other UCUM
-/// annotation units like `{row}`/`1` add none) and a TYPE suffix (counters
-/// `_total`; histograms expose `_bucket`/`_count`/`_sum`; gauges none). The
-/// exporter also de-duplicates — it does NOT re-append a unit/`_total` suffix a
-/// name already ends with (e.g. `cqlite.errors.total` stays `…_total`,
-/// `…wait_seconds` stays `…_seconds`). We therefore emit a GENEROUS set (the bare
-/// stem plus every plausible unit/type variant): permissive on the suffix (so a
-/// legit exporter-config difference never false-fails) but STRICT on the stem, so
-/// a mistyped metric name (`…phase_duraton_…`) is never in the set.
+/// annotation units like `{row}`/`1` add none) and a TYPE suffix. It also
+/// de-duplicates — it does NOT re-append a unit/type suffix a name already ends
+/// with. The exact emitted name(s) per kind:
+/// - **Counter** → the single `<stem>_total` (bare name is NEVER scraped; e.g.
+///   `cqlite.rpc.requests` → `cqlite_rpc_requests_total`,
+///   `cqlite.rpc.bytes` [`By`] → `cqlite_rpc_bytes_total` — the `By`→`_bytes` is
+///   de-duped against the name's existing `bytes` stem, matching the
+///   field-verified base-RPC exprs). A name already ending `_total` stays as-is.
+/// - **Histogram** → three series `<stem>_bucket`, `<stem>_count`, `<stem>_sum`,
+///   with the unit stem folded in first (`s` → `<stem>_seconds_{bucket,count,sum}`,
+///   seconds BEFORE the `_bucket`/`_count`/`_sum`).
+/// - **Gauge** → the bare unit-suffixed `<stem>` (no type suffix).
+///
+/// The STEM is dedup-guarded so a name already carrying its unit/type suffix is
+/// never double-suffixed (`cqlite.errors.total` stays `…_total`;
+/// `cqlite.flight.admission.wait_seconds` stays `…_seconds_bucket`).
 fn sanitized_variants(name: &str, kind: MetricKind, metric_unit: &str) -> HashSet<String> {
     let base = name.replace('.', "_");
-    // Stems: the bare sanitized name, plus a unit-suffixed stem when the unit maps
-    // to a Prometheus suffix and the name does not already carry it.
-    let mut stems: HashSet<String> = HashSet::new();
-    stems.insert(base.clone());
+    // Fold the UNIT suffix into the stem first (de-duped: never re-append a suffix
+    // the name already ends with).
     let unit_suffix = if metric_unit == unit::SECONDS {
         Some("seconds")
     } else if metric_unit == unit::BYTES {
@@ -131,52 +161,72 @@ fn sanitized_variants(name: &str, kind: MetricKind, metric_unit: &str) -> HashSe
     } else {
         None
     };
-    if let Some(u) = unit_suffix {
-        if !base.ends_with(u) {
-            stems.insert(format!("{base}_{u}"));
-        }
-    }
-    // Type suffixes applied to each stem. Always keep the bare stem too (some
-    // exporter configs omit `_total`); the stem is what actually guards typos.
+    let stem = match unit_suffix {
+        Some(u) if !base.ends_with(u) => format!("{base}_{u}"),
+        _ => base,
+    };
+    // Then the TYPE suffix — the EXACT emitted series, no bare-stem fallback.
     let mut out: HashSet<String> = HashSet::new();
-    for stem in &stems {
-        out.insert(stem.clone());
-        match kind {
-            MetricKind::Gauge => {}
-            MetricKind::Counter => {
-                if !stem.ends_with("_total") {
-                    out.insert(format!("{stem}_total"));
-                }
+    match kind {
+        MetricKind::Gauge => {
+            out.insert(stem);
+        }
+        MetricKind::Counter => {
+            if stem.ends_with("_total") {
+                out.insert(stem);
+            } else {
+                out.insert(format!("{stem}_total"));
             }
-            MetricKind::Histogram => {
-                out.insert(format!("{stem}_bucket"));
-                out.insert(format!("{stem}_count"));
-                out.insert(format!("{stem}_sum"));
-            }
+        }
+        MetricKind::Histogram => {
+            out.insert(format!("{stem}_bucket"));
+            out.insert(format!("{stem}_count"));
+            out.insert(format!("{stem}_sum"));
         }
     }
     out
 }
 
-/// Build the complete set of valid `cqlite_*` Prometheus identifiers a dashboard
-/// `expr` may reference: every metric's sanitized variants (from
-/// `operator_metric_docs()` — authoritative name+kind+unit) UNION the sanitized
-/// bounded attribute keys (used as label selectors / `by(...)` grouping, e.g.
-/// `cqlite_rpc_method`). Anti-drift: derived entirely from the catalog.
-fn valid_sanitized_names() -> HashSet<String> {
-    let mut set = HashSet::new();
+/// The two DISTINCT sets of valid `cqlite_*` Prometheus identifiers a dashboard
+/// `expr` may reference (roborev #2427 r3, F3 — kept separate so an attribute
+/// label never counts as a metric reference).
+struct ValidNames {
+    /// Exact sanitized METRIC-name series (from `operator_metric_docs()` —
+    /// authoritative name+kind+unit). Membership here (and ONLY here) satisfies
+    /// "the dashboard references a real metric".
+    metrics: HashSet<String>,
+    /// Sanitized bounded ATTRIBUTE keys used as PromQL label names / `by(...)`
+    /// grouping (e.g. `cqlite_rpc_method`). Valid tokens, but referencing one
+    /// does NOT count as referencing a metric.
+    attributes: HashSet<String>,
+}
+
+impl ValidNames {
+    /// A token is a valid `cqlite_*` identifier if it is either an exact metric
+    /// series name or a sanitized attribute label.
+    fn is_valid(&self, tok: &str) -> bool {
+        self.metrics.contains(tok) || self.attributes.contains(tok)
+    }
+}
+
+/// Build the metric and attribute identifier sets, both derived entirely from the
+/// catalog (anti-drift). Metric names are the EXACT emitted series per
+/// `sanitized_variants`; attributes are the sanitized bounded `catalog::attr::*`
+/// keys.
+fn valid_sanitized_names() -> ValidNames {
+    let mut metrics = HashSet::new();
     let docs = operator_metric_docs()
         .expect("operator_metric_docs must succeed (every ALL_METRICS entry is annotated)");
     for d in &docs {
         for v in sanitized_variants(d.name, d.kind, d.unit) {
-            set.insert(v);
+            metrics.insert(v);
         }
     }
-    // Sanitized bounded attribute keys appear as PromQL label names.
-    for a in ATTRIBUTE_KEYS {
-        set.insert(a.replace('.', "_"));
+    let attributes = ATTRIBUTE_KEYS.iter().map(|a| a.replace('.', "_")).collect();
+    ValidNames {
+        metrics,
+        attributes,
     }
-    set
 }
 
 /// Extract every `cqlite_*` Prometheus identifier token referenced in a PromQL
@@ -317,15 +367,17 @@ fn every_dashboard_metric_name_exists_in_catalog() {
 
     let attrs: HashSet<&str> = ATTRIBUTE_KEYS.iter().copied().collect();
 
-    // A dotted `cqlite.*` token is accepted iff it is an exact metric name, a
-    // bounded attribute key, or a namespace-group prefix of a real metric (a row
-    // title). Anything else is a renamed/removed/phantom reference — fail CLOSED.
+    // A dotted `cqlite.*` token is accepted iff it is an EXACT metric name, an
+    // EXACT bounded attribute key, or an explicit `.*` wildcard group ref (a row
+    // title such as `cqlite.flight.admission.*`). A bare namespace prefix is NOT
+    // accepted (roborev #2427 r3, F2). Anything else is a renamed/removed/phantom
+    // reference — fail CLOSED.
     let mut phantom: Vec<String> = referenced
         .iter()
         .filter(|name| {
             !catalog.contains(name.as_str())
                 && !attrs.contains(name.as_str())
-                && !is_metric_namespace_prefix(name)
+                && !is_wildcard_group_ref(name)
         })
         .cloned()
         .collect();
@@ -371,13 +423,16 @@ fn every_expr_metric_name_is_a_valid_sanitized_catalog_name() {
     // Every `cqlite_*` token referenced in any expr must be a valid sanitized
     // metric name (or attribute label) — anything else is a mistyped/renamed
     // reference that renders an EMPTY panel. Fail CLOSED, naming the offenders.
+    // `referenced_any_metric` is set ONLY by membership in the METRIC set — an
+    // attribute label alone does not count as referencing a metric (roborev #2427
+    // r3, F3).
     let mut invalid: Vec<String> = Vec::new();
     let mut referenced_any_metric = false;
     for expr in &exprs {
         for tok in cqlite_expr_tokens(expr) {
-            if valid.contains(&tok) {
+            if valid.metrics.contains(&tok) {
                 referenced_any_metric = true;
-            } else {
+            } else if !valid.attributes.contains(&tok) {
                 invalid.push(tok);
             }
         }
@@ -405,9 +460,11 @@ fn expr_validator_rejects_a_typo_in_an_expr_metric_name_negative_test() {
     // expr. Uses a synthetic expr so the test never depends on the live dashboard.
     let valid = valid_sanitized_names();
 
-    // The correct sanitized name IS in the valid set…
+    // The correct sanitized name IS in the metric set…
     assert!(
-        valid.contains("cqlite_rpc_phase_duration_seconds_bucket"),
+        valid
+            .metrics
+            .contains("cqlite_rpc_phase_duration_seconds_bucket"),
         "the correct histogram bucket name must be a valid sanitized variant"
     );
     // …but a one-character typo ("duraton") is NOT — so the panel would be empty.
@@ -415,7 +472,7 @@ fn expr_validator_rejects_a_typo_in_an_expr_metric_name_negative_test() {
                      {cluster=~\"$cluster\"}[5m])) by (le, cqlite_rpc_phase))";
     let mut invalid: Vec<String> = cqlite_expr_tokens(typo_expr)
         .into_iter()
-        .filter(|t| !valid.contains(t))
+        .filter(|t| !valid.is_valid(t))
         .collect();
     invalid.sort();
     assert_eq!(
@@ -426,36 +483,93 @@ fn expr_validator_rejects_a_typo_in_an_expr_metric_name_negative_test() {
 
     // Sanity: a counter's `_total` and a histogram's `_bucket`/`_count`/`_sum` are
     // all accepted (forward-derived from kind), a bare gauge name is accepted, and
-    // a sanitized attribute label is accepted.
+    // a sanitized attribute label is accepted (in the ATTRIBUTE set, not metrics).
     assert!(
-        valid.contains("cqlite_rpc_requests_total"),
+        valid.metrics.contains("cqlite_rpc_requests_total"),
         "counter _total"
     );
     assert!(
-        valid.contains("cqlite_rpc_duration_seconds_count"),
+        valid.metrics.contains("cqlite_rpc_duration_seconds_count"),
         "histogram _count"
     );
     assert!(
-        valid.contains("cqlite_rpc_duration_seconds_sum"),
+        valid.metrics.contains("cqlite_rpc_duration_seconds_sum"),
         "histogram _sum"
     );
-    assert!(valid.contains("cqlite_rpc_in_flight"), "bare gauge name");
     assert!(
-        valid.contains("cqlite_rpc_bytes_total"),
+        valid.metrics.contains("cqlite_rpc_in_flight"),
+        "bare gauge name"
+    );
+    assert!(
+        valid.metrics.contains("cqlite_rpc_bytes_total"),
         "counter with By unit + _total"
     );
     assert!(
-        valid.contains("cqlite_rpc_method"),
-        "sanitized attribute label"
+        valid.attributes.contains("cqlite_rpc_method"),
+        "sanitized attribute label lives in the attribute set"
+    );
+    assert!(
+        !valid.metrics.contains("cqlite_rpc_method"),
+        "an attribute label is NOT a metric name (roborev #2427 r3, F3)"
     );
     // A name that already ends in `_total` is not double-suffixed.
     assert!(
-        valid.contains("cqlite_errors_total"),
+        valid.metrics.contains("cqlite_errors_total"),
         "errors.total counter"
     );
     assert!(
-        !valid.contains("cqlite_errors_total_total"),
+        !valid.metrics.contains("cqlite_errors_total_total"),
         "must not double-append _total to a name already ending in _total"
+    );
+
+    // F1 (roborev #2427 r3) — the EXACT-name tightening: bare and mis-suffixed
+    // forms that would render an EMPTY panel are REJECTED, not accepted.
+    assert!(
+        !valid.metrics.contains("cqlite_rpc_requests"),
+        "bare counter name (missing _total) must be REJECTED — the collector emits \
+         only cqlite_rpc_requests_total"
+    );
+    assert!(
+        !valid.metrics.contains("cqlite_rpc_phase_duration_bucket"),
+        "histogram bucket missing the _seconds unit stem must be REJECTED — the \
+         collector emits cqlite_rpc_phase_duration_seconds_bucket"
+    );
+    assert!(
+        !valid.metrics.contains("cqlite_rpc_duration"),
+        "bare seconds-histogram name (no _seconds_{{bucket,count,sum}}) must be REJECTED"
+    );
+    // And they are flagged as invalid by the expr validator.
+    let bare_counter_expr = "sum(rate(cqlite_rpc_requests{cluster=~\"$cluster\"}[5m]))";
+    let mis_suffixed_hist_expr =
+        "histogram_quantile(0.95, sum(rate(cqlite_rpc_phase_duration_bucket[5m])) by (le))";
+    for (expr, want) in [
+        (bare_counter_expr, "cqlite_rpc_requests"),
+        (mis_suffixed_hist_expr, "cqlite_rpc_phase_duration_bucket"),
+    ] {
+        let flagged: Vec<String> = cqlite_expr_tokens(expr)
+            .into_iter()
+            .filter(|t| !valid.is_valid(t))
+            .collect();
+        assert!(
+            flagged.contains(&want.to_string()),
+            "expr validator must flag the bare/mis-suffixed form `{want}` (would render empty), \
+             flagged: {flagged:?}"
+        );
+    }
+
+    // F2 (roborev #2427 r3) — an explicit `.*` wildcard group ref is recognized,
+    // but a bare namespace prefix is NOT.
+    assert!(
+        is_wildcard_group_ref("cqlite.flight.admission.*"),
+        "explicit .* group ref covering real metrics must be accepted"
+    );
+    assert!(
+        !is_wildcard_group_ref("cqlite.flight.admission"),
+        "a bare namespace prefix (no trailing .*) must be REJECTED (roborev #2427 r3, F2)"
+    );
+    assert!(
+        !is_wildcard_group_ref("cqlite.does.not.exist.*"),
+        "a .* group ref covering NO real metric must be REJECTED"
     );
 }
 

--- a/easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json
+++ b/easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json
@@ -1067,14 +1067,14 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "max(cqlite_flight_admission_limit{cluster=~\"$cluster\"})",
+          "expr": "sum(cqlite_flight_admission_limit{cluster=~\"$cluster\"})",
           "legendFormat": "limit K (cqlite.flight.admission.limit)",
           "refId": "B"
         }
       ],
       "title": "Admission Permits: In Use vs Limit",
       "type": "timeseries",
-      "description": "Admitted in-flight scans (cqlite.flight.admission.in_use) against the configured ceiling K (cqlite.flight.admission.limit, #2420). in_use riding the limit = saturation; new do_get requests queue on the permit-wait."
+      "description": "Fleet-total admitted in-flight scans (sum of cqlite.flight.admission.in_use across pods) against the fleet-total ceiling (sum of cqlite.flight.admission.limit, #2420) — both series share the same sum() scope so the saturation threshold is apples-to-apples. Total in_use riding the total limit = saturation; new do_get requests queue on the permit-wait."
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },

--- a/easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json
+++ b/easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json
@@ -855,6 +855,422 @@
       "title": "Flight Error Rate (% of Requests)",
       "type": "timeseries",
       "description": "cqlite.errors.total (subsystem=flight) as a percentage of cqlite.rpc.requests."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
+      "id": 16,
+      "title": "do_get Phase Breakdown (cqlite.rpc.phase.duration / cqlite.rpc.phase.active)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
+      "id": 17,
+      "options": { "legend": { "calcs": [ "mean", "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum(rate(cqlite_rpc_phase_duration_seconds_bucket{cluster=~\"$cluster\"}[5m])) by (le, cqlite_rpc_phase))",
+          "legendFormat": "{{cqlite_rpc_phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "do_get Phase Duration p50 by Phase (cqlite.rpc.phase.duration)",
+      "type": "timeseries",
+      "description": "p50 wall time per do_get phase from cqlite.rpc.phase.duration (validate / admission / resolve / merge_setup / stream). Time piling up in merge_setup = SSTable-open stall (#2157); in admission = queued behind the #2420 admission ceiling. See docs/reports/flight-metrics-reference.md (#2426) for the phase contract."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
+      "id": 18,
+      "options": { "legend": { "calcs": [ "mean", "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum(rate(cqlite_rpc_phase_duration_seconds_bucket{cluster=~\"$cluster\"}[5m])) by (le, cqlite_rpc_phase))",
+          "legendFormat": "{{cqlite_rpc_phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "do_get Phase Duration p95 by Phase (cqlite.rpc.phase.duration)",
+      "type": "timeseries",
+      "description": "p95 wall time per do_get phase from cqlite.rpc.phase.duration. Pairs with the p50 panel to localize a slow do_get to a single phase."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "lineInterpolation": "stepAfter", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 54 },
+      "id": 19,
+      "options": { "legend": { "calcs": [ "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cqlite_rpc_phase_active{cluster=~\"$cluster\"}) by (cqlite_rpc_phase)",
+          "legendFormat": "{{cqlite_rpc_phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "do_get Active Phase (cqlite.rpc.phase.active)",
+      "type": "timeseries",
+      "description": "In-flight gauge of the phase each do_get is CURRENTLY in. cqlite.rpc.phase.duration only records on phase completion, so a do_get wedged forever in stream (the #2361 hang) or parked in admission shows up here BEFORE completion."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 62 },
+      "id": 20,
+      "title": "Index Work (cqlite.sstable.index_parses_total / index_interval_parses_total)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 63 },
+      "id": 21,
+      "options": { "legend": { "calcs": [ "mean", "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cqlite_sstable_index_parses_total{cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "full Index.db parses (cqlite.sstable.index_parses_total)",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cqlite_sstable_index_interval_parses_total{cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "bounded interval parses (cqlite.sstable.index_interval_parses_total)",
+          "refId": "B"
+        }
+      ],
+      "title": "Index Parse Rate: Full vs Interval",
+      "type": "timeseries",
+      "description": "Rate of WHOLE-file Index.db parses (cqlite.sstable.index_parses_total, #2383) vs bounded Summary-guided interval parses (cqlite.sstable.index_interval_parses_total, #2412). A climbing full-parse rate under lazy open is the #2367 R9/R10 redundant-parse regression signal."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 63 },
+      "id": 22,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cqlite_sstable_index_parses_total{cluster=~\"$cluster\"})",
+          "legendFormat": "full parses",
+          "refId": "A"
+        }
+      ],
+      "title": "Full Index.db Parses (cumulative)",
+      "type": "stat",
+      "description": "Cumulative cqlite.sstable.index_parses_total. The field check: this should be flat (warm) or ~= number of generations (cold) — NOT climbing per query (the #2383 8x-reparse smell). This was THE R9/R10 verification signal the field team hand-scraped."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 63 },
+      "id": 23,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cqlite_sstable_index_interval_parses_total{cluster=~\"$cluster\"})",
+          "legendFormat": "interval parses",
+          "refId": "A"
+        }
+      ],
+      "title": "Bounded Interval Parses (cumulative)",
+      "type": "stat",
+      "description": "Cumulative cqlite.sstable.index_interval_parses_total (#2412). A cold lazy open of K generations increments this per point lookup while full parses stay 0 — the scale-free lazy-open work probe."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 71 },
+      "id": 24,
+      "title": "do_get Admission Control (cqlite.flight.admission.*)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 72 },
+      "id": 25,
+      "options": { "legend": { "calcs": [ "mean", "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cqlite_flight_admission_in_use{cluster=~\"$cluster\"})",
+          "legendFormat": "in use (cqlite.flight.admission.in_use)",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max(cqlite_flight_admission_limit{cluster=~\"$cluster\"})",
+          "legendFormat": "limit K (cqlite.flight.admission.limit)",
+          "refId": "B"
+        }
+      ],
+      "title": "Admission Permits: In Use vs Limit",
+      "type": "timeseries",
+      "description": "Admitted in-flight scans (cqlite.flight.admission.in_use) against the configured ceiling K (cqlite.flight.admission.limit, #2420). in_use riding the limit = saturation; new do_get requests queue on the permit-wait."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 72 },
+      "id": 26,
+      "options": { "legend": { "calcs": [ "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cqlite_flight_admission_waiting{cluster=~\"$cluster\"})",
+          "legendFormat": "waiting",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Waiting for a Permit",
+      "type": "timeseries",
+      "description": "cqlite.flight.admission.waiting — do_get requests parked on acquire. Non-zero = backpressure: offered concurrency exceeds the ceiling and requests are queuing rather than degrading together (#2420)."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 72 },
+      "id": 27,
+      "options": { "legend": { "calcs": [ "mean", "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cqlite_flight_admission_rejected_total{cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "rejected/sec",
+          "refId": "A"
+        }
+      ],
+      "title": "Admission Rejections/sec (cqlite.flight.admission.rejected_total)",
+      "type": "timeseries",
+      "description": "Rate of do_get requests rejected as gRPC UNAVAILABLE because no permit freed within the permit-wait timeout (#2420). The connector treats these as retry-safe (#2241). Any sustained non-zero rate means the ceiling is too low for offered load."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "scaleDistribution": { "type": "linear" } },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 80 },
+      "id": 28,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64 },
+        "exemplars": { "color": "rgba(255,0,255,0.7)" },
+        "filterValues": { "le": 1e-9 },
+        "legend": { "show": true },
+        "rowsFrame": { "layout": "auto" },
+        "tooltip": { "mode": "single", "showColorScale": false, "yHistogram": false },
+        "yAxis": { "axisPlacement": "left", "reverse": false, "unit": "s" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cqlite_flight_admission_wait_seconds_bucket{cluster=~\"$cluster\"}[1m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Permit-Wait Distribution (cqlite.flight.admission.wait_seconds)",
+      "type": "heatmap",
+      "description": "Heatmap of how long a do_get waited on acquire before it was admitted or rejected (cqlite.flight.admission.wait_seconds, #2420). A rising tail localizes admission pressure."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 88 },
+      "id": 29,
+      "title": "Warm-Handle Cache (cqlite.warm.cache.*)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 89 },
+      "id": 30,
+      "options": { "legend": { "calcs": [ "mean", "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cqlite_warm_cache_hits_total{cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "hits (cqlite.warm.cache.hits)",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cqlite_warm_cache_misses_total{cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "misses (cqlite.warm.cache.misses)",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cqlite_warm_cache_evicts_total{cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "evicts (cqlite.warm.cache.evicts)",
+          "refId": "C"
+        }
+      ],
+      "title": "Warm Cache Hits / Misses / Evicts",
+      "type": "timeseries",
+      "description": "Flight warm-handle cache activity (#2310): a hit serves from warm parsed state with ZERO reader-open. A high miss/evict rate under a stable generation set is a warm-reuse regression."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 89 },
+      "id": 31,
+      "options": { "legend": { "calcs": [ "mean", "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cqlite_warm_cache_refresh_total{cluster=~\"$cluster\"}[1m])) by (cqlite_warm_refresh_outcome)",
+          "legendFormat": "{{cqlite_warm_refresh_outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Warm Cache Refresh Outcomes (cqlite.warm.cache.refresh)",
+      "type": "timeseries",
+      "description": "Warm-handle refresh outcomes tagged by cqlite.warm.refresh_outcome (unchanged / rebuilt_delta / fail_closed_retained, #2310). A rising fail_closed_retained means refreshes are repeatedly failing closed and retaining stale warm state."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 97 },
+      "id": 32,
+      "title": "Merge Producer Threads (cqlite.merge.producer_threads)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 98 },
+      "id": 33,
+      "options": { "legend": { "calcs": [ "mean", "max", "lastNotNull" ], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cqlite_merge_producer_threads{cluster=~\"$cluster\"})",
+          "legendFormat": "live producer threads",
+          "refId": "A"
+        }
+      ],
+      "title": "Live k-way Merge Producer Threads",
+      "type": "timeseries",
+      "description": "cqlite.merge.producer_threads (#2316): live OS producer threads the k-way merge holds open, one per input SSTable. Bounded by O(M) inputs; a runaway value on a loaded node is the M*num_cpus amplification #2316 replaced."
     }
   ],
   "refresh": "10s",

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -149,6 +149,17 @@
 #                      (issue #2426). SKIP-aware (loud, never silent PASS): SKIPs
 #                      when cqlite-core is absent (a minimal checkout). No
 #                      Docker/datasets — reads the catalog + committed doc only.
+#   kit-dashboard-drift
+#                      cqlite-core kit_dashboard_metric_drift test: FAILs (naming
+#                      the phantom name) when the kit Grafana dashboard
+#                      (easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json)
+#                      references a cqlite.* metric name absent from
+#                      catalog::ALL_METRICS, or when the dashboard JSON is
+#                      malformed. Catches the "renamed/removed a cqlite.* instrument,
+#                      the kit dashboard now points at a phantom metric" case at the
+#                      local gate (issue #2427). SKIP-aware (loud, never silent
+#                      PASS): SKIPs when cqlite-core or the dashboard is absent. No
+#                      Docker/datasets — reads the catalog + dashboard JSON only.
 #   binding-unwind-profile
 #                      fail-closed guard (#1440): the shipped Python wheel and
 #                      Node prebuild build definitions must select
@@ -1055,7 +1066,7 @@ _python_build_verify_venv() {
   return 3
 }
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry parity-report operator-metrics-doc binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile tooling-tests minimal-build smoke)
 # --lite (issue #1821) runs ONLY this fast subset: file-size ratchet, fmt,
 # FULL-workspace clippy (cross-crate API breaks are the cheap-insurance class),
 # and blast-radius-scoped tests (the touched package's --lib + the diff's new
@@ -1897,6 +1908,49 @@ run_operator_metrics_doc() {
       echo "--- [$name] FAILED: could not render $doc — a catalogued metric is missing its operator annotation."
       echo "    Add the annotation in cqlite-core/src/observability/operator_docs_annotations.rs, then regenerate."
     fi
+    echo "--- last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+  fi
+  end=$(date +%s)
+  record_result "$name" "$status" "$((end - start))"
+  echo ">>> [$name] $status ($((end - start))s)"
+}
+
+# kit-dashboard-drift: verify the kit Grafana dashboard
+# (easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json) references only
+# `cqlite.*` metric names that exist in the observability catalog (issue #2427).
+# Runs the cqlite-core `kit_dashboard_metric_drift` test: it parses the dashboard
+# JSON, extracts every dotted `cqlite.*` token from panel targets/exprs/titles,
+# and asserts each is an exact catalog metric name, a bounded attribute key, or a
+# real metric's namespace prefix — FAILing (naming the phantom name) on a
+# renamed/removed/typo'd metric. Mirrors the #2426 operator-metrics-doc anti-drift
+# component (a committed artifact cross-checked against catalog::ALL_METRICS).
+# SKIP-aware (loud, never silent PASS): SKIPs when cqlite-core or the dashboard is
+# absent (a minimal checkout). No Docker, no datasets — reads the catalog + JSON.
+run_kit_dashboard_drift() {
+  local name=kit-dashboard-drift
+  if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
+    return 0
+  fi
+  local dashboard="easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json"
+  local log="$LOG_DIR/$name.log"
+  local start end status
+  start=$(date +%s)
+  if [ ! -d "$REPO_ROOT/cqlite-core" ] || [ ! -f "$REPO_ROOT/$dashboard" ]; then
+    status=SKIP
+    echo ">>> [$name] SKIP (cqlite-core or kit dashboard unavailable)"
+    record_result "$name" "$status" 0
+    return 0
+  fi
+  echo ">>> [$name] cargo test -p cqlite-core --test kit_dashboard_metric_drift ($dashboard)"
+  if cargo test -q -p cqlite-core --test kit_dashboard_metric_drift >"$log" 2>&1; then
+    status=PASS
+  else
+    status=FAIL
+    echo "--- [$name] FAILED: the kit dashboard references a cqlite.* metric name ABSENT from"
+    echo "    catalog::ALL_METRICS (renamed/removed/typo'd), or the dashboard JSON is malformed."
+    echo "    Fix the dashboard $dashboard or reconcile the name with the catalog."
     echo "--- last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
@@ -3477,6 +3531,7 @@ dispatch_component() {
     delivery-telemetry) run_delivery_telemetry ;;
     parity-report) run_parity_report ;;
     operator-metrics-doc) run_operator_metrics_doc ;;
+    kit-dashboard-drift) run_kit_dashboard_drift ;;
     binding-unwind-profile) run_component binding-unwind-profile bash "$REPO_ROOT/scripts/tests/test_binding_unwind_profile.sh" ;;
     tooling-tests) run_tooling_tests ;;
     minimal-build) run_component minimal-build bash -c '

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1926,20 +1926,35 @@ run_operator_metrics_doc() {
 # real metric's namespace prefix — FAILing (naming the phantom name) on a
 # renamed/removed/typo'd metric. Mirrors the #2426 operator-metrics-doc anti-drift
 # component (a committed artifact cross-checked against catalog::ALL_METRICS).
-# SKIP-aware (loud, never silent PASS): SKIPs when cqlite-core or the dashboard is
-# absent (a minimal checkout). No Docker, no datasets — reads the catalog + JSON.
+# SKIP-aware (loud, never silent PASS): SKIPs ONLY when cqlite-core or the whole
+# kit subtree (easy-db-lab-kits/cqlite-flight/) is absent (a genuine sparse/minimal
+# checkout). If the kit subtree IS present but the expected dashboard JSON is
+# missing/renamed, that is real drift/breakage in a complete checkout → the test
+# FAILs (roborev #2427 r2). No Docker, no datasets — reads the catalog + JSON.
 run_kit_dashboard_drift() {
   local name=kit-dashboard-drift
   if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
     return 0
   fi
-  local dashboard="easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json"
+  local kit_root="easy-db-lab-kits/cqlite-flight"
+  local dashboard="$kit_root/dashboards/cqlite-flight.json"
   local log="$LOG_DIR/$name.log"
   local start end status
   start=$(date +%s)
-  if [ ! -d "$REPO_ROOT/cqlite-core" ] || [ ! -f "$REPO_ROOT/$dashboard" ]; then
+  # Skip ONLY on a genuine sparse checkout: cqlite-core or the whole kit subtree
+  # absent. A present kit subtree with a missing dashboard is NOT a skip — it falls
+  # through to the test, which FAILs loudly (present-kit + missing-dashboard drift).
+  if [ ! -d "$REPO_ROOT/cqlite-core" ] || [ ! -d "$REPO_ROOT/$kit_root" ]; then
     status=SKIP
-    echo ">>> [$name] SKIP (cqlite-core or kit dashboard unavailable)"
+    echo ">>> [$name] SKIP (cqlite-core or the kit subtree $kit_root is absent — sparse checkout)"
+    record_result "$name" "$status" 0
+    return 0
+  fi
+  if [ ! -f "$REPO_ROOT/$dashboard" ]; then
+    status=FAIL
+    echo ">>> [$name] FAIL: kit subtree $kit_root IS present but the expected dashboard"
+    echo "    $dashboard is MISSING (deleted/renamed) — drift/breakage in a complete checkout,"
+    echo "    not a sparse checkout. Restore the dashboard or update the drift test's path."
     record_result "$name" "$status" 0
     return 0
   fi


### PR DESCRIPTION
Closes #2427

Refreshes easy-db-lab-kits/cqlite-flight/dashboards/cqlite-flight.json with 18 new panels across 5 groups (phase breakdown, index work, admission control, warm-handle cache, merge producer threads) for the 0.15 instrument set — every cqlite.* reference verified against catalog::ALL_METRICS. Adds a SKIP-aware kit-dashboard-drift gate component + drift test that validates panel-expr metric selectors against exact collector series names (counter _total, seconds-histogram _seconds_{bucket,count,sum}), rejects wildcard-on-leaf, requires per-expr metric coverage (catches prefix typos), and splits metric vs attribute name sets. SKIPs only when the whole kit subtree is absent; fails if the kit is present but the dashboard is missing. Metrics not yet in the catalog (#2419 saturation, #2356 closures) intentionally omitted.

Review: 4 roborev rounds hardened the guard. Deferred to #2531 (shared anti-drift typed-spec + real PromQL parser across #2426/#2427): validating Grafana template-variable label_values() queries + a proper PromQL parser vs the hand-rolled classifier. The dashboard + guard as shipped are correct for all real dashboard constructs.

Follow-up: #2531.

🤖 Generated with Claude Code