### PR TITLE
Stage 0 (#2211): measure-first DecodePolicy bench + A/B report — go/no-go input

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -133,6 +133,13 @@ proptest = { workspace = true }
 tempfile = "3.8"
 rand = "0.8"
 tokio-test = "0.4"
+# Direct handle to the production SAFE lz4 decoder (lz4_flex with `safe-decode`
+# on, the library default) so the Stage-0 DecodePolicy bench (issue #2211,
+# benches/decode_policy_bench.rs) can time the checked decode in isolation from
+# the surrounding chunk-record machinery. Dev-only: the library itself reaches
+# lz4_flex through the optional `lz4` feature; this makes the same crate nameable
+# from the bench target regardless of feature selection.
+lz4_flex = { workspace = true }
 # Serialize tests that read/mutate the process-global work_counters within one
 # test binary so cargo's parallel intra-binary threads cannot race the shared
 # atomics between a counter test's reset() and its read (issue #1071).
@@ -216,6 +223,19 @@ harness = false
 
 [[bench]]
 name = "read"
+harness = false
+
+# Stage-0 measure-first bench for the runtime DecodePolicy work (issue #2211,
+# F6.4). Quantifies (a) SAFE lz4 decompress-only throughput via `lz4_flex`, (b)
+# the full chunk-decompress path (seek+read+CRC32+decode+validate), and (c)
+# end-to-end scan throughput over the SAME compressed fixture, so the
+# decompress-only cost can be read as a fraction of a real scan. The `full_scan`
+# arm needs `cli-helpers` (for `open_read_db`); without it that arm compiles out
+# and the binary still runs a valid criterion main. NOT a perf-gate entry — a
+# one-time decision artifact feeding the Stage-0 go/no-go (docs/reports/).
+[[bench]]
+name = "decode_policy"
+path = "benches/decode_policy_bench.rs"
 harness = false
 
 # Export / conversion throughput micro-benches (issue #1494, AD5). STRICT

--- a/cqlite-core/benches/decode_policy_bench.rs
+++ b/cqlite-core/benches/decode_policy_bench.rs
@@ -1,0 +1,258 @@
+//! Stage-0 measure-first bench for the runtime DecodePolicy work (issue #2211,
+//! F6.4). This is the blocking-gate artifact: it exists to answer, honestly and
+//! before a single line of `unsafe` is written, whether removing lz4 bounds
+//! checks (the whole point of a FastUnsafe policy) is even a *measurable*
+//! fraction of a real SSTable scan on the deployment target (Linux).
+//!
+//! Three throughput signals, all reported in decompressed/scanned bytes/sec so
+//! they can be read on one axis:
+//!
+//!  - `decode_policy/lz4_flex_decompress` — the SAFE (`safe-decode` on, the
+//!    library default) lz4 decode *in isolation*: real on-disk compressed chunk
+//!    payloads from the fixture, fed straight to `lz4_flex::decompress`. This is
+//!    the ONLY step a FastUnsafe policy would change. The delta a future
+//!    FastUnsafe backend could buy is bounded ABOVE by this number's inverse
+//!    (you cannot save more time than the decode step costs).
+//!  - `decode_policy/full_chunk_path` — the whole production chunk-decompress
+//!    path over the same fixture (seek + read compressed record + CRC32 verify +
+//!    lz4 decode + size validate), fresh `ChunkDecompressor` per iteration so the
+//!    chunk cache is cold and every chunk decodes. FastUnsafe removes NONE of the
+//!    CRC/read/validate cost, so the decode step is a fraction of even this.
+//!  - `decode_policy/full_scan` — end-to-end `SELECT *` over the SAME compressed
+//!    fixture through the public query API (requires `cli-helpers`). Throughput
+//!    is measured against the fixture's uncompressed `data_length`, so it is
+//!    directly comparable to the two decode numbers above. This is the number
+//!    field evidence (#2385, #2397) says actually dominates.
+//!
+//! Fixture: `test_timeseries.sensor_data` — the largest genuinely lz4-*decoded*
+//! fixture in the vendored corpus (the larger `test_comp` incompressible fixture
+//! stores raw chunks and never calls the lz4 decoder, so it is unusable here).
+//! The corpus is small (a fixture artifact, not the production case — real
+//! Cassandra SSTables run tens of MiB to GiB), so the decode numbers are a HOT-
+//! cache CPU-bound decode rate. That is exactly the right regime for this
+//! question: it measures the CPU cost of the bounds checks themselves, the most
+//! favorable possible case for FastUnsafe.
+//!
+//! Run (both decode arms + the end-to-end arm):
+//!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!     cargo bench -p cqlite-core --features cli-helpers --bench decode_policy
+//!
+//! Skip-registers (no group, criterion reports the arm as absent) when the
+//! fixture binaries are not fetched. NOT a perf-gate entry — a one-time Stage-0
+//! decision artifact.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use std::path::PathBuf;
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+use cqlite_core::storage::sstable::chunk_decompressor::{
+    create_decompressor_from_file, ChunkDecompressor,
+};
+use cqlite_core::storage::sstable::compression_info::CompressionInfo;
+
+/// The compressed fixture measured by every arm. `sensor_data` is the largest
+/// fixture whose LZ4 chunks are actually lz4-decoded (not stored raw).
+const FIXTURE: fixtures::ReadFixture = fixtures::ReadFixture::CLUSTERING;
+
+/// Locate the `*-Data.db` and `*-CompressionInfo.db` for the fixture table.
+fn fixture_component_paths() -> Option<(PathBuf, PathBuf)> {
+    if !fixtures::fixture_present(&FIXTURE) {
+        return None;
+    }
+    let dir = fixtures::table_dir(FIXTURE.keyspace, FIXTURE.table);
+    let mut data_db = None;
+    let mut ci_db = None;
+    for entry in std::fs::read_dir(&dir).ok()?.filter_map(|e| e.ok()) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.ends_with("-Data.db") {
+            data_db = Some(entry.path());
+        } else if name.ends_with("-CompressionInfo.db") {
+            ci_db = Some(entry.path());
+        }
+    }
+    Some((data_db?, ci_db?))
+}
+
+/// One genuinely-lz4-compressed chunk ready to hand to `lz4_flex::decompress`:
+/// the lz4 block bytes (length prefix and trailing CRC already stripped) plus the
+/// exact decompressed length Cassandra recorded for it.
+struct Lz4Chunk {
+    lz4_block: Vec<u8>,
+    decompressed_len: usize,
+}
+
+/// Extract every lz4-compressed chunk's block bytes from the real Data.db,
+/// mirroring `ChunkDecompressor::decompress_lz4_chunk`: for each chunk record,
+/// strip the trailing 4-byte inline CRC and the leading 4-byte little-endian
+/// uncompressed-length prefix. Chunks Cassandra stored raw (incompressible:
+/// `compressed_len >= max_compressed_length`) are skipped — they never reach the
+/// lz4 decoder, so they are not part of the decode cost under study.
+fn extract_lz4_chunks(data_db: &[u8], info: &CompressionInfo) -> (Vec<Lz4Chunk>, u64) {
+    let file_size = data_db.len() as u64;
+    let max_compressed = info.max_compressed_length as usize;
+    let mut chunks = Vec::new();
+    let mut decompressed_total = 0u64;
+
+    for i in 0..info.chunk_offsets.len() {
+        let (Some(offset), Some(record_size)) = (
+            info.compressed_chunk_offset(i),
+            info.compressed_chunk_size(i, file_size),
+        ) else {
+            continue;
+        };
+        if record_size < 4 {
+            continue;
+        }
+        // Record = [compressed payload][4-byte BE CRC32]; drop the CRC.
+        let compressed_len = (record_size - 4) as usize;
+        let start = offset as usize;
+        let end = start + compressed_len;
+        if end > data_db.len() || compressed_len < 4 {
+            continue;
+        }
+        // Raw (incompressible) chunk — stored uncompressed, no lz4 decode.
+        if compressed_len >= max_compressed {
+            continue;
+        }
+        let payload = &data_db[start..end];
+        // Cassandra prepends a 4-byte little-endian uncompressed length.
+        let decompressed_len =
+            u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]) as usize;
+        let lz4_block = payload[4..].to_vec();
+        decompressed_total += decompressed_len as u64;
+        chunks.push(Lz4Chunk {
+            lz4_block,
+            decompressed_len,
+        });
+    }
+    (chunks, decompressed_total)
+}
+
+/// Arm 1: SAFE lz4 decode in isolation (`lz4_flex::decompress`), the single step
+/// a FastUnsafe policy would replace.
+fn bench_decompress_only(c: &mut Criterion) {
+    let Some((data_path, ci_path)) = fixture_component_paths() else {
+        eprintln!("decode_policy/lz4_flex_decompress: fixture absent — skipping (skip-register)");
+        return;
+    };
+    let data_db = std::fs::read(&data_path).expect("read Data.db");
+    let ci_bytes = std::fs::read(&ci_path).expect("read CompressionInfo.db");
+    let info = CompressionInfo::parse(&ci_bytes).expect("parse CompressionInfo.db");
+    assert_eq!(
+        info.algorithm, "LZ4Compressor",
+        "decode_policy bench requires an LZ4 fixture"
+    );
+    let (chunks, decompressed_total) = extract_lz4_chunks(&data_db, &info);
+    assert!(
+        !chunks.is_empty() && decompressed_total > 0,
+        "no lz4-compressed chunks extracted from {} — fixture may be entirely raw",
+        data_path.display()
+    );
+
+    let mut group = c.benchmark_group("decode_policy");
+    group.throughput(Throughput::Bytes(decompressed_total));
+    group.bench_function("lz4_flex_decompress", |b| {
+        b.iter(|| {
+            for chunk in &chunks {
+                let out = lz4_flex::decompress(
+                    black_box(&chunk.lz4_block),
+                    black_box(chunk.decompressed_len),
+                )
+                .expect("lz4_flex decompress");
+                black_box(out);
+            }
+        });
+    });
+    group.finish();
+}
+
+/// Arm 2: the whole production chunk-decompress path over the same fixture, cold
+/// cache per iteration (seek + read + CRC32 + lz4 decode + validate).
+fn bench_full_chunk_path(c: &mut Criterion) {
+    let Some((data_path, ci_path)) = fixture_component_paths() else {
+        eprintln!("decode_policy/full_chunk_path: fixture absent — skipping (skip-register)");
+        return;
+    };
+    let ci_bytes = std::fs::read(&ci_path).expect("read CompressionInfo.db");
+    let info = CompressionInfo::parse(&ci_bytes).expect("parse CompressionInfo.db");
+    let data_length = info.data_length;
+
+    // Sanity: the path actually returns all the uncompressed bytes.
+    {
+        let mut probe: ChunkDecompressor =
+            create_decompressor_from_file(&ci_path).expect("build decompressor");
+        let mut f = std::fs::File::open(&data_path).expect("open Data.db");
+        let bytes = probe.read_all_data(&mut f).expect("read_all_data");
+        assert_eq!(
+            bytes.len() as u64,
+            data_length,
+            "full_chunk_path must return the full uncompressed length"
+        );
+    }
+
+    let mut group = c.benchmark_group("decode_policy");
+    group.throughput(Throughput::Bytes(data_length));
+    group.bench_function("full_chunk_path", |b| {
+        b.iter(|| {
+            // Fresh decompressor → empty chunk cache → every chunk decodes.
+            let mut dec = create_decompressor_from_file(&ci_path).expect("build decompressor");
+            let mut f = std::fs::File::open(&data_path).expect("open Data.db");
+            let bytes = dec.read_all_data(&mut f).expect("read_all_data");
+            black_box(bytes);
+        });
+    });
+    group.finish();
+}
+
+/// Arm 3: end-to-end `SELECT *` over the same compressed fixture, measured
+/// against the uncompressed `data_length` so it shares an axis with the decode
+/// arms. Requires `cli-helpers` for the queryable fixture DB.
+#[cfg(feature = "cli-helpers")]
+fn bench_full_scan(c: &mut Criterion) {
+    let Some((_data_path, ci_path)) = fixture_component_paths() else {
+        eprintln!("decode_policy/full_scan: fixture absent — skipping (skip-register)");
+        return;
+    };
+    let ci_bytes = std::fs::read(&ci_path).expect("read CompressionInfo.db");
+    let info = CompressionInfo::parse(&ci_bytes).expect("parse CompressionInfo.db");
+    let data_length = info.data_length;
+
+    let loaded = fixtures::open_read_db(&FIXTURE);
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let sql = format!("SELECT * FROM {}", FIXTURE.qualified());
+
+    // Honesty guard: never bench a 0-row scan.
+    let n = rt
+        .block_on(loaded.db.execute(&sql))
+        .expect("scan fixture")
+        .rows
+        .len();
+    assert!(n >= 1, "full_scan must return at least one row");
+
+    let mut group = c.benchmark_group("decode_policy");
+    group.throughput(Throughput::Bytes(data_length));
+    group.bench_function("full_scan", |b| {
+        b.iter(|| {
+            let res = rt.block_on(loaded.db.execute(&sql)).expect("scan fixture");
+            black_box(res.rows.len());
+        });
+    });
+    group.finish();
+}
+
+#[cfg(not(feature = "cli-helpers"))]
+fn bench_full_scan(_c: &mut Criterion) {
+    eprintln!(
+        "decode_policy/full_scan: needs --features cli-helpers to open a queryable fixture DB — skipping"
+    );
+}
+
+criterion_group!(
+    benches,
+    bench_decompress_only,
+    bench_full_chunk_path,
+    bench_full_scan
+);
+criterion_main!(benches);

--- a/docs/reports/issue-2211-decode-policy-stage0-ab.md
+++ b/docs/reports/issue-2211-decode-policy-stage0-ab.md
@@ -1,0 +1,132 @@
+# Issue #2211 — Runtime DecodePolicy (FastUnsafe lz4): Stage-0 measure-first A/B
+
+**Status:** Stage-0 blocking-gate artifact (OpenSpec change `runtime-decode-policy`, Decision 5).
+Measured, awaiting the owner's go/no-go. **No `unsafe` code was written; no fast backend was
+committed.** Stages 1–5 remain unbuilt per the design's hard gate.
+
+**Machine:** AWS EC2, Intel Xeon Platinum 8488C (16 vCPU, 2 threads/core, 105 MiB L3), 30 GiB RAM,
+Linux 6.17 (`6.17.0-1019-aws`), x86_64. Rust 1.88.0, release/LTO builds.
+
+**Fixture:** `test_timeseries.sensor_data` (`nb-1-big`, LZ4Compressor) — the largest fixture in the
+vendored corpus whose chunks are actually lz4-*decoded*. Geometry (from `CompressionInfo.db`):
+`chunk_length = 16384`, `data_length = 121,249` bytes, 8 chunks (7 full + a 6,561-byte final chunk),
+**all 8 lz4-compressed, none stored raw**. The larger `test_comp` incompressible fixture stores raw
+chunks and never calls the lz4 decoder, so it is unusable for this question.
+
+> **Corpus-size caveat (load-bearing).** 121 KiB is tiny — a fixture artifact, not the production
+> case (real Cassandra SSTables run tens of MiB to GiB). So the decode numbers below are a **hot-cache,
+> CPU-bound decode rate**: the single most favorable regime for FastUnsafe, because it isolates the CPU
+> cost of the bounds checks with zero I/O to hide behind. On a real GB-scale, I/O-bound scan the decode
+> step would be an even *smaller* fraction of end-to-end time. The Stage-0 conclusion is therefore an
+> upper bound on FastUnsafe's benefit, not a floor.
+
+## What FastUnsafe would and would not change
+
+FastUnsafe (design Decision 4) removes the lz4 output-bounds checks at exactly one site:
+`chunk_decompressor.rs::decompress_lz4_chunk`'s `lz4_flex::decompress` call. It does **not** remove the
+inline CRC32 verify, the file read, the seek, or the size validation that surround it, and it does
+**not** touch Snappy/Deflate/Zstd or the small-block path. So the ceiling on any FastUnsafe win is the
+cost of the lz4 decode step alone.
+
+## Method
+
+Two committed benches (`cqlite-core/benches/decode_policy_bench.rs`, Criterion, `harness = false`) plus
+two throwaway out-of-tree proxies for the unchecked-decode delta. All four measure the **same** 8
+on-disk lz4 chunk payloads (the committed bench extracts them mirroring `decompress_lz4_chunk`; the
+proxies were fed a byte-for-byte dump of those exact payloads). Throughputs are reported in
+decompressed/scanned bytes so all arms share one axis.
+
+Committed arms (run: `CQLITE_DATASETS_ROOT=.../test-data/datasets cargo bench -p cqlite-core
+--features cli-helpers --bench decode_policy`):
+
+- `decode_policy/lz4_flex_decompress` — SAFE lz4 decode in isolation (the only step FastUnsafe changes).
+- `decode_policy/full_chunk_path` — whole production chunk-decompress path, cold cache per iter
+  (seek + read record + CRC32 verify + lz4 decode + size validate).
+- `decode_policy/full_scan` — end-to-end `SELECT *` over the same fixture through the public query API,
+  measured against the fixture's uncompressed `data_length` for a shared axis.
+
+Throwaway proxies (out-of-tree, `opt-level=3` + LTO, 200k iterations each, **not committed**):
+
+- **liblz4 (Decision-2 backend A)** via `lz4-sys 1.11.1 +lz4-1.10.0`: `LZ4_decompress_safe` vs
+  `LZ4_decompress_fast`. All decoders verified byte-identical to `lz4_flex` before timing.
+- **`lz4_flex` safe-decode ON vs OFF**: the cleanest apples-to-apples "cost of the bounds checks in the
+  actual current decoder" — the same crate/algorithm, only the `safe-decode` feature flipped. This is
+  labeled an **upper-bound proxy** for an achievable unchecked-decode win; it is *not* a claim that any
+  shippable backend delivers it (see Decision-1 conflict below).
+
+## Results
+
+### Decompress-only (the ceiling on any FastUnsafe win)
+
+| Decoder | ns per full-fixture pass | Throughput | vs current prod |
+|---|---:|---:|---:|
+| `lz4_flex::decompress` (SAFE, current production) | 47,160 | 2.39 GiB/s | — (baseline) |
+| `lz4_flex` UNCHECKED (`safe-decode` OFF) | 23,426 | 4.82 GiB/s | **2.01x, −23.7 µs** |
+| liblz4 `LZ4_decompress_safe` (backend A, checked) | 23,965 | 4.71 GiB/s | 1.97x |
+| liblz4 `LZ4_decompress_fast` (backend A, UNCHECKED) | 109,493 | 1.03 GiB/s | **0.43x (slower!)** |
+
+Committed Criterion arm `lz4_flex_decompress` independently measured the SAFE path at **45.2 µs median
+(2.50 GiB/s)** — cross-validating the 47.2 µs proxy figure.
+
+**Two decisive facts:**
+
+1. **Removing bounds checks buys at most ~2x on the decode step** (`lz4_flex` unchecked: 23.4 µs vs
+   47.2 µs, saving ~23.7 µs/pass). That is the theoretical ceiling.
+2. **The design's recommended backend (A) cannot deliver it.** liblz4's `LZ4_decompress_fast` is
+   *deprecated upstream*, is no longer bound by modern `lz4-sys` (had to be declared by hand to link),
+   and measured **3.6x slower than `LZ4_decompress_safe`** on these payloads. Modern liblz4 optimized
+   the *safe* path and left `_fast` a slow deprecated shim, so backend (A)'s unchecked entry point is a
+   net regression, not a win. The only variant that shows a decode win is `lz4_flex` with `safe-decode`
+   off — which is exactly what Decision 1 rejects (a graph-global feature that makes the minimal build
+   and every other consumer silently unsafe under feature unification).
+
+### End-to-end context (medians, all over the same ~121 KiB fixture)
+
+| Arm | Median time | Throughput | Share of scan time |
+|---|---:|---:|---:|
+| `decode_policy/lz4_flex_decompress` (SAFE decode only) | 45.2 µs | 2.50 GiB/s | **1.78%** |
+| `decode_policy/full_chunk_path` (decode + CRC + read + validate) | 208.8 µs | 554 MiB/s | 8.22% |
+| `decode_policy/full_scan` (`SELECT *`, end-to-end) | 2.54 ms | 45.5 MiB/s | 100% |
+
+- The entire SAFE lz4 decode is **1.78% of end-to-end scan time**. Even if FastUnsafe made decode
+  *free*, the scan could improve by at most 1.78%.
+- Applying the measured best-case unchecked win (~23.7 µs saved of the 45.2 µs decode) yields a
+  projected **~0.90% end-to-end scan improvement**.
+- The `full_scan` arm's own run-to-run noise band is **±4.7%** (2.42–2.66 ms across 100 samples). The
+  projected FastUnsafe win is ~5x smaller than the measurement noise — i.e. **not detectable
+  end-to-end**.
+- This corroborates the field evidence cited in the design (#2385, #2397): decode is not the
+  bottleneck; ~91% of scan time is query execution / row materialization, not lz4.
+
+## Reproduction
+
+- Committed benches: `cqlite-core/benches/decode_policy_bench.rs` (permanent asset; skip-registers when
+  fixtures are absent; not a perf-gate entry). `lz4_flex` was added to `cqlite-core`
+  `[dev-dependencies]` so the bench can time the checked decoder in isolation.
+- Throwaway proxies (liblz4 backend-A pair; `lz4_flex` safe-on vs safe-off) were built out-of-tree over
+  a byte-for-byte dump of the same 8 payloads and are **not committed** (per Task 0.3). Method and
+  results are recorded above so the numbers are reconstructable.
+
+## Read on the Stage-0 gate (input to the owner's decision, not the decision)
+
+The evidence points hard toward **close #2211 as measured-but-not-justified** (the outcome Decision 5
+anticipated as most likely), for three compounding reasons:
+
+1. **No material end-to-end win exists even in the most favorable regime.** Best case ~0.9%, below the
+   ±4.7% noise floor, on a hot-cache CPU-bound micro-scan; a real I/O-bound scan would be smaller still.
+2. **The design-sanctioned backend (A) is a regression, not a win** — `LZ4_decompress_fast` is
+   deprecated and 3.6x slower than the checked liblz4 path on modern liblz4.
+3. **The only variant that *does* speed up decode (`lz4_flex` safe-off) is the exact approach Decision 1
+   forbids** — it makes the minimal build silently unsafe. So there is no shippable backend that both
+   respects the design's safety invariant and delivers the decode win.
+
+The counter-argument the owner may weigh: this corpus is tiny and hot-cache. If a genuinely
+decompress-bound workload is expected — very large, highly compressible SSTables scanned repeatedly from
+page cache where decode CPU (not I/O) dominates — the decode fraction would rise, and a ~2x decode
+speedup could matter. But even then, backends (A) as-specified does not provide the speedup, so a
+FastUnsafe pursuit would first need a different backend (vendored in-tree `unsafe`, Decision-2 option B)
+whose UB-liability the design explicitly steers away from.
+
+**Recommendation (owner to confirm):** close #2211, archive `runtime-decode-policy` with a
+"measured, not justified" note, and keep `cqlite-core/benches/decode_policy_bench.rs` as the standing
+decode-vs-scan measurement. Do not proceed to Stage 1+.

--- a/openspec/changes/runtime-decode-policy/design.md
+++ b/openspec/changes/runtime-decode-policy/design.md
@@ -1,0 +1,98 @@
+# Design — Runtime DecodePolicy (F6.4, issue #2211)
+
+## Context
+Two lz4 decode call sites exist today:
+1. **`storage/sstable/chunk_decompressor.rs::decompress_lz4_chunk`** — the hot production
+   compressed-SSTable read path. Reads the compressed record, verifies the 4-byte inline CRC32 over
+   the compressed bytes (`stored_crc == crc32fast::hash(&compressed_data)`) **before** decode, then
+   calls `lz4_flex::decompress(lz4_data, decompressed_length)` with the exact expected length. This is
+   the ONLY site FastUnsafe targets.
+2. **`storage/sstable/compression.rs::Compression::decompress` (Lz4 arm)** — a small-block path using
+   `decompress_size_prepended`; NOT CRC-preceded at that call. Stays Safe (out of FastUnsafe scope).
+
+The CRC-before-decompress ordering at site 1 is the load-bearing precondition and is already pinned by
+`read_compressed_chunk_at_verifies_crc_before_returning`. That pin MUST survive unchanged.
+
+## Decision 1 — a runtime `DecodePolicy`, not a cargo feature
+`enum DecodePolicy { Safe, FastUnsafe }`, `Default = Safe`. Threaded into the chunk decompressor
+(constructor arg or setter on `ChunkDecompressor`) and read at the lz4 decode branch. Rationale:
+`lz4_flex/safe-decode` is a graph-global feature; turning it off to get speed makes the minimal build
+(and every other consumer) silently unsafe under feature unification. A runtime enum keeps `safe-decode`
+compiled always and localises the unsafe choice to a single deliberate call. Cite issue #2211 body.
+
+## Decision 2 — FastUnsafe needs a SECOND, unconditionally-compiled decoder
+`lz4_flex` 0.11.6 selects safe vs unchecked at compile time (`block/decompress_safe.rs` vs
+`block/decompress.rs`, `#[cfg(feature = "safe-decode")]`); no runtime unchecked entry point exists, and
+one dependency cannot be compiled twice with different features. So the fast path requires a distinct
+decoder compiled in **unconditionally** (so the choice is purely runtime, satisfying Decision 1).
+Options — **owner picks at Seam 1**:
+
+- **(A) `lz4` / `lz4-sys` (C liblz4)** — `LZ4_decompress_fast` (unchecked) vs `LZ4_decompress_safe`.
+  A genuine runtime pair, battle-tested. Cost: a C build dependency (cross-compile/WASM friction, its
+  own CVE surface, a `build.rs`/cc toolchain requirement the pure-Rust build avoids today).
+- **(B) vendored minimal unchecked lz4 block decoder (in-tree `unsafe`)** — full control, no new
+  external dep, pure Rust. Cost: WE own audited `unsafe` and its correctness/UB burden forever; a real
+  liability under the "no `unsafe` in library code" leaning of the codebase.
+- **(C) `lz4rip`** (from the issue comment) — encapsulated `unsafe`, fewer blocks than `lz4_flex`.
+  Caveat: its author states it **validates offsets in both default and `paranoid` builds**, so it may
+  not actually expose a *truly unchecked* path — meaning it might deliver little of the 20–30% and
+  would still be a second dependency. Verify the achievable delta before adopting.
+
+**Recommendation**: do not adopt any of them until Decision 5's measurement justifies it. If justified,
+prefer **(A)** for a real, maintained checked/unchecked pair, accepting the C-dep cost, and keep it
+behind the runtime policy so pure-Rust default builds are unaffected in behaviour. Reject (B) unless the
+owner explicitly wants to own the `unsafe`.
+
+## Decision 3 — the safety boundary, stated honestly (trusted files only)
+CRC32 precedes decode, so for a **non-adversarial** file a passing CRC means the compressed bytes are
+intact and an unchecked decode of an intact stream will not read OOB. But the CRC covers the
+*compressed* bytes and is written by the same producer: an attacker who can author both the Data.db
+payload and its CRC can craft a CRC-valid compressed stream whose lz4 match offsets point out of
+bounds. Under FastUnsafe those bounds checks are gone, so **the fast path can read out of bounds / is
+undefined behaviour on adversarial input**. Therefore:
+- The `unsafe` constructor's `# Safety` doc states: sound **only** for files the operator trusts as
+  produced by Cassandra/CQLite and not tampered with; on corrupt/adversarial input, behaviour is
+  undefined (possible OOB read / crash / wrong bytes).
+- The **flight server default stays Safe**. `--decode-policy fast-unsafe` additionally requires an
+  explicit `--assume-trusted-sstables` affirmation (or equivalent), and the active policy is logged at
+  startup — mirroring the visible-state pattern of #2128 / #2420.
+- We do NOT claim UB-freedom on arbitrary input for FastUnsafe; the honest claim is "Safe is UB-free on
+  any input; FastUnsafe is UB-free only on trusted, intact input."
+
+## Decision 4 — scope: CRC-preceded lz4 chunk path only
+FastUnsafe applies solely at chunk-decompressor site 1. Snappy/Deflate/Zstd and the small-block
+`Compression::decompress` path ignore the policy and stay Safe. Keeps the audited unsafe surface as
+small as possible and rides on the one place CRC-before-decode is guaranteed.
+
+## Decision 5 — measure-first is a HARD, blocking gate
+No decoder is added and no unsafe path is written until a committed benchmark on the **real corpus**
+(a present compressed fixture, not a synthetic micro-bench) shows a **material end-to-end scan
+throughput win** attributable to removing lz4 bounds checks — measured on Linux, the deployment target.
+The bench must report BOTH the decompress-only delta AND the end-to-end scan delta, because field data
+says decode is not the bottleneck. Acceptance threshold is recorded in the bench (proposed: FastUnsafe
+must lift end-to-end scan throughput of a decompress-bound workload by a materially useful margin — the
+owner sets the number at Seam 1). **If the measurement shows no material win, FastUnsafe is not built
+and #2211 closes as not-worth-it.** This is the most likely honest outcome given the field evidence.
+
+## Decision 6 — fuzz strategy: differential-on-valid, not arbitrary-bytes-into-FastUnsafe
+Feeding arbitrary bytes to FastUnsafe would (correctly, by contract) trigger OOB reads that ASAN/the
+fuzzer reports as crashes — those are *expected*, not bugs, so pointing an arbitrary-bytes fuzz target
+at FastUnsafe would only manufacture false crashes. Instead:
+- The existing arbitrary-bytes fuzz targets (`fuzz_*`) KEEP using the **Safe** path (unchanged
+  guarantee: no panic/hang/OOM on arbitrary input).
+- Add a **differential** target/test that generates a *valid* lz4 chunk (compress arbitrary input,
+  prepend the length, append the CRC) and asserts **FastUnsafe output == Safe output** byte-for-byte.
+  This is the property that actually matters (equivalence on valid input) and is fuzzer-friendly.
+- The `# Safety` doc and the fuzz README record explicitly that arbitrary-bytes-into-FastUnsafe is
+  out of contract by design.
+
+This satisfies the issue's "include a fuzz target for the unsafe path" while being honest that the only
+sound thing to fuzz is the equivalence, not the robustness, of FastUnsafe.
+
+## Alternatives considered
+- **Cargo feature `unsafe-lz4-decode`** — rejected (Decision 1): breaks the minimal-build safety
+  invariant under feature unification. This is the whole reason #2211 is design-driven.
+- **FastUnsafe by default when CRC passed** — rejected: CRC is producer-authored, not a trust anchor;
+  default-unsafe violates the "no non-default build silently unsafe" acceptance criterion.
+- **Do nothing / close the issue** — a legitimate outcome of Decision 5; recorded as an open fork in
+  the proposal.

--- a/openspec/changes/runtime-decode-policy/proposal.md
+++ b/openspec/changes/runtime-decode-policy/proposal.md
@@ -1,0 +1,72 @@
+# Runtime DecodePolicy — Safe default / opt-in FastUnsafe lz4 (F6.4)
+
+## Milestone
+0.15 (cqlite-trino latency/throughput/operations — lane: scan latency). **Design-driven**: routed
+through OpenSpec per the owner decision on issue #2211 (decomposed out of #1596, Epic F #1518). This
+is F6.4 of the F6 read-path decode-throughput family.
+
+## Oracle vs design
+Design-driven. There is no external oracle for *how fast* to decode — lz4 decode output is byte-fixed
+(the parity goldens already pin it), but the **policy surface** (a runtime Safe/FastUnsafe knob, its
+safety contract, where it plumbs) has real latitude. The output-parity half stays oracle-pinned: a
+FastUnsafe decode of a valid chunk MUST be byte-identical to a Safe decode (the 33-table JSONL
+goldens are the truth).
+
+## Problem (claimed, must be MEASURED before any code)
+`lz4_flex`'s `safe-decode` feature (default) adds per-copy bounds checks upstream reports at
+~20–30% of *decompress* time. On the hot compressed-SSTable read path
+(`chunk_decompressor.rs::decompress_lz4_chunk`) a CRC32 over the compressed bytes is verified
+**before** decode (`read_compressed_chunk_at_verifies_crc_before_returning` pins the ordering), so the
+on-disk bytes are already integrity-checked for a *trusted* file — making an unchecked decode
+*plausibly* safe there. But: (a) the 20–30% is a decompress-only micro-number, not an end-to-end scan
+number; field evidence (round 7–10) shows scan cost is dominated by index parsing (#2385), snapshot
+resolve/lifecycle, and single-node routing (#2397) — **not** lz4 bounds checks; and (b) an unchecked
+decode is memory-unsafe on adversarial input. So this must be measured end-to-end AND fuzzed, and
+FastUnsafe must never be default-on.
+
+## Why a RUNTIME policy, not a cargo feature (owner + flow-lead decision, restated)
+Cargo features are additive/unifying. An opt-OUT of `lz4_flex/safe-decode` is inexpressible without
+making some *other* build (notably the mandated minimal-features build) **silently unsafe** under
+feature unification: any crate in the graph turning `safe-decode` off flips it off for everyone. A
+runtime `DecodePolicy` keeps `safe-decode` **always compiled** and makes the unsafe choice explicit,
+local, and per-open — the same binary, an operator's deliberate call, never a build-wide flag.
+
+## Key technical fork this change must resolve (NEW finding)
+`lz4_flex` 0.11.6 picks safe vs unchecked decode at **compile time** — two separate modules
+(`block/decompress_safe.rs` vs `block/decompress.rs`) selected by `#[cfg(feature = "safe-decode")]`.
+It exposes **no runtime-selectable unchecked function**. You cannot instantiate `lz4_flex` twice with
+different features in one dependency graph. Therefore a runtime Safe/FastUnsafe choice **requires a
+second, unconditionally-compiled decoder** for the fast path (checked `lz4_flex` stays the Safe path).
+The design records the three backend options (C `lz4-sys`, vendored in-tree unchecked decoder,
+`lz4rip`) and a recommendation; picking one is Seam-1 owner input, not the implementer's call.
+
+## What changes
+- A `DecodePolicy` enum in `cqlite-core` (`Safe` default, `FastUnsafe`), threaded to the **one**
+  CRC-preceded lz4 chunk-decode site. Default `Safe` — zero behaviour change unless opted in.
+- `FastUnsafe` reachable **only** via an explicit, `unsafe`-marked, documented constructor whose
+  safety contract states the trusted-input precondition. Never `Default`; never inferred from bytes
+  or config strings (no-heuristics, #28).
+- A second, unconditionally-compiled unchecked lz4 backend (option chosen at Seam 1) for the fast
+  path; `lz4_flex` with `safe-decode` stays the Safe path and the always-on default.
+- Flight server: a `--decode-policy` / `CQLITE_DECODE_POLICY` knob (mirrors `--max-concurrent-scans`
+  from #2420) whose default is **Safe**; selecting `fast-unsafe` requires the operator to also affirm
+  a trusted-files flag, and the choice is logged at startup.
+- A committed before/after benchmark on the **real corpus** and a differential fuzz/parity of
+  FastUnsafe-vs-Safe on valid chunks, as blocking preconditions.
+
+## Non-goals
+- Not a cargo feature and not any change to the minimal/default feature set (they stay Safe-only).
+- No FastUnsafe for Snappy/Deflate/Zstd, nor for the non-CRC small-block `Compression::decompress`
+  path — lz4 chunk path only, initially.
+- No change to any decoded value: FastUnsafe output MUST be byte-identical to Safe on valid input
+  (parity goldens unchanged).
+- Not a claim that CQLite decodes *untrusted* files fast — FastUnsafe is trusted-files-only; the
+  flight default stays Safe.
+- No pre-`na` format support introduced or revisited (version floor unchanged).
+
+## Impact
+- **No-heuristics (#28)**: policy is explicit runtime config only, never inferred.
+- **Memory budget (<128MB)**: unchanged (decode buffers are already chunk-bounded).
+- **Bindings/CLI**: no change unless a binding chooses to expose the policy later (out of scope here).
+- **If the measurement shows no material end-to-end win, the FastUnsafe path is NOT built and #2211
+  closes** — the measure-first gate can legitimately end this work.

--- a/openspec/changes/runtime-decode-policy/specs/runtime-decode-policy/spec.md
+++ b/openspec/changes/runtime-decode-policy/specs/runtime-decode-policy/spec.md
@@ -1,0 +1,143 @@
+# runtime-decode-policy
+
+## ADDED Requirements
+
+### Requirement: Safe is the default decode policy on every public entry
+`DecodePolicy::Safe` SHALL be the default decode policy at every public entry point, so that a reader,
+chunk decompressor, or flight server constructed without an explicit policy performs bounds-checked
+(`lz4_flex` `safe-decode`) LZ4 decode with zero behaviour change versus today. `DecodePolicy` SHALL
+derive `Default = Safe`, and no code path SHALL reach `FastUnsafe` without an explicit caller choice.
+
+#### Scenario: A reader constructed without a policy decodes via the checked path
+
+- **GIVEN** a compressed (LZ4) SSTable opened through the ordinary public constructor with no decode
+  policy specified
+- **WHEN** a chunk is decompressed
+- **THEN** the checked `lz4_flex` decode is used
+- **AND** the decoded bytes are byte-identical to the current (pre-change) output and the JSONL parity
+  golden.
+
+#### Scenario: The flight server defaults to Safe
+
+- **WHEN** `cqlite-flight` starts with no `--decode-policy` flag and no `CQLITE_DECODE_POLICY` env var
+- **THEN** the active policy is `Safe`
+- **AND** the startup log records `decode_policy = safe`.
+
+### Requirement: FastUnsafe is reachable only via an explicit, unsafe-marked, documented path
+`FastUnsafe` SHALL be selectable only through an explicit constructor that is `unsafe` (or an
+explicitly unsafe-named builder) carrying a `# Safety` doc comment stating the trusted-input
+precondition. It SHALL NOT be the `Default`, SHALL NOT be produced by `From`/parse of ordinary
+(non-affirmed) input, and SHALL NEVER be inferred from byte patterns, CRC state, or file contents
+(no-heuristics mandate, issue #28). Selecting it is always a deliberate operator/programmer act.
+
+#### Scenario: There is no implicit route to FastUnsafe
+
+- **WHEN** the public API surface for constructing readers/decompressors is exercised without calling
+  the unsafe constructor
+- **THEN** the resolved policy is `Safe`
+- **AND** no configuration string, CRC outcome, or byte pattern maps to `FastUnsafe`.
+
+#### Scenario: The unsafe constructor documents its safety contract
+
+- **WHEN** the `FastUnsafe` constructor is inspected
+- **THEN** it is marked `unsafe` (or unmistakably unsafe-named) and carries a `# Safety` section that
+  states FastUnsafe is sound only for trusted, intact files and is undefined behaviour on
+  adversarial/corrupt input.
+
+### Requirement: FastUnsafe is scoped to the CRC-preceded LZ4 chunk decode path
+`FastUnsafe` SHALL take effect only at the chunk-decompressor LZ4 decode site where the inline CRC32
+over the compressed bytes is verified before decode, and the CRC-before-decompress ordering SHALL be
+preserved unchanged. The Snappy, Deflate, and Zstd chunk paths, and the non-CRC small-block
+`Compression::decompress` LZ4 path, SHALL ignore the policy and always decode via their checked path.
+
+#### Scenario: CRC is still verified before decode under FastUnsafe
+
+- **GIVEN** a chunk decompressor configured with `FastUnsafe`
+- **WHEN** a chunk record is read
+- **THEN** the stored inline CRC32 is compared against the CRC of the compressed bytes BEFORE any LZ4
+  decode is attempted (the existing `read_compressed_chunk_at_verifies_crc_before_returning`
+  ordering holds)
+- **AND** a CRC mismatch returns the typed error without invoking the unchecked decoder.
+
+#### Scenario: Non-LZ4 and small-block paths ignore the policy
+
+- **GIVEN** `FastUnsafe` is configured
+- **WHEN** a Snappy/Deflate/Zstd chunk, or the small-block `Compression::decompress` LZ4 path, is
+  decoded
+- **THEN** the checked decoder is used regardless of the policy.
+
+### Requirement: The safety boundary is documented honestly and the flight default stays Safe
+The change SHALL document, at the extraction site and in user-facing flight help, that `FastUnsafe`
+assumes trusted, intact on-disk data and that on adversarial/corrupt input the removed bounds checks
+make behaviour undefined (possible out-of-bounds read). The flight server SHALL keep `Safe` as its
+default and SHALL require an explicit trusted-files affirmation flag in addition to
+`--decode-policy fast-unsafe` before enabling the unchecked path, logging the active policy at startup.
+The project SHALL NOT claim UB-freedom for `FastUnsafe` on arbitrary input; the claim is limited to
+"Safe is UB-free on any input; FastUnsafe is UB-free only on trusted, intact input."
+
+#### Scenario: Enabling FastUnsafe on the flight server requires an explicit trust affirmation
+
+- **WHEN** `cqlite-flight` is started with `--decode-policy fast-unsafe` but WITHOUT the trusted-files
+  affirmation flag
+- **THEN** startup fails (or refuses to enable FastUnsafe and stays Safe) with a message naming the
+  required affirmation flag
+- **AND** when both are supplied, the startup log records `decode_policy = fast-unsafe` and a
+  trusted-files warning.
+
+#### Scenario: The trusted-only boundary is documented
+
+- **WHEN** the rustdoc for the `FastUnsafe` constructor and the flight `--decode-policy` help are read
+- **THEN** both state the trusted-files-only precondition and the undefined-behaviour-on-corrupt-input
+  consequence.
+
+### Requirement: No non-default or minimal build becomes silently unsafe
+`lz4_flex` `safe-decode` SHALL remain compiled in every build, and `FastUnsafe` SHALL NOT be selected
+by any cargo feature — including the minimal-features build and the default build. Any second unchecked
+decoder adopted for the fast path SHALL be compiled unconditionally, so that the Safe/FastUnsafe choice
+is purely a runtime decision and no feature-flag combination silently disables bounds-checked decode.
+
+#### Scenario: Minimal and default builds decode via the checked path
+
+- **WHEN** the minimal-features build and the default build each decompress an LZ4 chunk without
+  calling the unsafe constructor
+- **THEN** both use the checked `lz4_flex` decode
+- **AND** no feature-flag combination causes decode to become unchecked without an explicit runtime
+  `FastUnsafe` call.
+
+### Requirement: FastUnsafe is built only after a measured Linux win on the real corpus
+The `FastUnsafe` decode path SHALL be implemented only after a committed before/after benchmark on the
+real SSTable corpus (a present compressed fixture, run on Linux) demonstrates a material end-to-end
+scan-throughput win attributable to removing LZ4 bounds checks. The benchmark SHALL report BOTH the
+decompress-only delta AND the end-to-end scan delta. If no material end-to-end win is demonstrated, the
+`FastUnsafe` path SHALL NOT be built and issue #2211 SHALL be closed as not-worth-it. A synthetic
+micro-benchmark alone SHALL NOT satisfy this requirement.
+
+#### Scenario: The measurement gate produces a recorded corpus benchmark
+
+- **WHEN** the FastUnsafe path is proposed for merge
+- **THEN** a committed benchmark artifact on a present real compressed fixture records both the
+  decompress-only and the end-to-end scan throughput for Safe vs FastUnsafe on Linux
+- **AND** the merge proceeds only if the end-to-end win meets the owner-set threshold; otherwise the
+  path is not built and the issue is closed.
+
+### Requirement: FastUnsafe correctness is proven by a differential fuzz/parity against Safe
+FastUnsafe SHALL be covered by a differential target/test that generates VALID LZ4 chunks (compress
+arbitrary input, prepend the length, append the CRC) and asserts that `FastUnsafe` output is
+byte-identical to `Safe` output — because feeding arbitrary bytes to an unchecked decoder produces
+out-of-bounds reads by contract, so equivalence-on-valid-input, not robustness-on-arbitrary-input, is
+the property to fuzz. The arbitrary-bytes fuzz targets SHALL continue to exercise only the Safe path
+(preserving the no panic/hang/OOM guarantee on arbitrary input), and the out-of-contract nature of
+arbitrary-bytes-into-FastUnsafe SHALL be documented in the fuzz README and the `# Safety` doc.
+
+#### Scenario: FastUnsafe equals Safe on valid chunks
+
+- **GIVEN** an arbitrary input compressed into a valid Cassandra-format LZ4 chunk (length prefix + CRC)
+- **WHEN** it is decoded once under `Safe` and once under `FastUnsafe`
+- **THEN** the two decoded outputs are byte-identical
+- **AND** the differential harness runs over the fuzz corpus without a divergence.
+
+#### Scenario: Arbitrary-bytes fuzz targets stay on the Safe path
+
+- **WHEN** the arbitrary-bytes `fuzz_*` targets run
+- **THEN** they decode via the Safe path only
+- **AND** the fuzz README documents that arbitrary-bytes-into-FastUnsafe is out of contract by design.

--- a/openspec/changes/runtime-decode-policy/tasks.md
+++ b/openspec/changes/runtime-decode-policy/tasks.md
@@ -1,0 +1,61 @@
+# Tasks — Runtime DecodePolicy (F6.4, issue #2211)
+
+Branch `issue-2211-decode-policy`. Anchors are `main`-relative and drift — re-grep before editing.
+**Stage 0 is a HARD gate: if it shows no material end-to-end win, STOP, do not build FastUnsafe, and
+close #2211.** Nothing in stages 2+ is written until the owner accepts the Stage-0 result and picks a
+backend (Decision 2).
+
+## Stage 0 — measure-first (blocking; no unsafe code yet)
+- [ ] 0.1 Add a Criterion/bench (or a gated integration bench) that decodes a present real compressed
+  LZ4 fixture and reports decompress-only throughput for checked `lz4_flex`. (runtime-decode-policy)
+- [ ] 0.2 Add an end-to-end scan bench over the same fixture reporting scan throughput, so the
+  decompress delta can be put in end-to-end context. (runtime-decode-policy)
+- [ ] 0.3 Prototype the chosen fast backend (Decision 2 option A/B/C) *locally only* to obtain a
+  FastUnsafe-vs-Safe number on Linux; commit the benchmark result artifact (both deltas). Do NOT merge
+  the prototype. (runtime-decode-policy)
+- [ ] 0.4 **Decision point**: if the end-to-end win does not meet the owner-set threshold, close #2211
+  as not-worth-it and archive this change with a "measured, not justified" note. Otherwise proceed.
+
+## Stage 1 — the policy type (Safe default, no unsafe yet)
+- [ ] 1.1 Add `enum DecodePolicy { Safe, FastUnsafe }` with `#[derive(Default)]`/`Safe` default in
+  `cqlite-core` (e.g. `storage/sstable/`); no `From<&str>` route to `FastUnsafe`. Red test: default is
+  `Safe`; no ordinary constructor yields `FastUnsafe`. (runtime-decode-policy)
+- [ ] 1.2 Thread the policy into `ChunkDecompressor` (constructor arg / setter) defaulting to `Safe`;
+  read it only at the `decompress_lz4_chunk` branch. All existing call sites pass `Safe` — zero
+  behaviour change. Preserve the CRC-before-decompress pin. (runtime-decode-policy)
+- [ ] 1.3 Test: a `Safe` decompressor is byte-identical to today on the parity fixtures (all four
+  compression algorithms unaffected). (runtime-decode-policy)
+
+## Stage 2 — the FastUnsafe backend + unsafe constructor (only if Stage 0 justified it)
+- [ ] 2.1 Add the chosen unchecked lz4 backend as an **unconditional** dependency (Decision 2). Confirm
+  minimal-features and default builds still compile the checked path and do not select the fast path.
+  (runtime-decode-policy)
+- [ ] 2.2 Add the `unsafe` (or unsafe-named) `FastUnsafe` constructor with a `# Safety` doc stating the
+  trusted-files-only precondition and UB-on-corrupt-input consequence. (runtime-decode-policy)
+- [ ] 2.3 Wire the `FastUnsafe` branch at the CRC-preceded lz4 site only; Snappy/Deflate/Zstd and the
+  small-block `Compression::decompress` path stay checked. Test: policy ignored for non-lz4 and
+  small-block paths. (runtime-decode-policy)
+
+## Stage 3 — differential fuzz/parity + robustness
+- [ ] 3.1 Add a differential test/fuzz target: compress arbitrary input → valid chunk (length + CRC) →
+  assert `FastUnsafe` output == `Safe` output byte-for-byte. (runtime-decode-policy)
+- [ ] 3.2 Confirm the arbitrary-bytes `fuzz_*` targets still exercise the Safe path only; document in
+  the fuzz README that arbitrary-bytes-into-FastUnsafe is out of contract. (runtime-decode-policy)
+- [ ] 3.3 Test: a CRC mismatch under `FastUnsafe` returns the typed error and never enters the
+  unchecked decoder. (runtime-decode-policy)
+
+## Stage 4 — flight plumbing (visible, Safe-default, trusted affirmation)
+- [ ] 4.1 Add `--decode-policy` (`safe`|`fast-unsafe`) + `CQLITE_DECODE_POLICY` to `cqlite-flight`
+  (mirror `--max-concurrent-scans`, #2420), default `safe`. (runtime-decode-policy)
+- [ ] 4.2 Require an explicit `--assume-trusted-sstables` (or equivalent) affirmation alongside
+  `fast-unsafe`; without it, fail/stay Safe with a message naming the flag. Log the active policy +
+  trusted warning at startup. Tests: default is Safe; fast-unsafe without affirmation refuses.
+  (runtime-decode-policy)
+- [ ] 4.3 Document the trusted-only boundary in flight `--help` and rustdoc. (runtime-decode-policy)
+
+## Stage 5 — close-out
+- [ ] 5.1 Update `docs/` (dev-cookbook / feature-flags note) that FastUnsafe is a runtime, trusted-only
+  choice, never a build feature. (runtime-decode-policy)
+- [ ] 5.2 Run `scripts/agent-gate.sh` (full) — PASS; paste the AGENT-GATE SUMMARY into the PR.
+- [ ] 5.3 roborev clean; spec-auditor (C) PASS (every requirement satisfied with a public-surface
+  test); then `openspec archive runtime-decode-policy`.

--- a/openspec/changes/runtime-decode-policy/tasks.md
+++ b/openspec/changes/runtime-decode-policy/tasks.md
@@ -6,15 +6,22 @@ close #2211.** Nothing in stages 2+ is written until the owner accepts the Stage
 backend (Decision 2).
 
 ## Stage 0 — measure-first (blocking; no unsafe code yet)
-- [ ] 0.1 Add a Criterion/bench (or a gated integration bench) that decodes a present real compressed
+- [x] 0.1 Add a Criterion/bench (or a gated integration bench) that decodes a present real compressed
   LZ4 fixture and reports decompress-only throughput for checked `lz4_flex`. (runtime-decode-policy)
-- [ ] 0.2 Add an end-to-end scan bench over the same fixture reporting scan throughput, so the
+  → `cqlite-core/benches/decode_policy_bench.rs` `decode_policy/lz4_flex_decompress`: 2.50 GiB/s.
+- [x] 0.2 Add an end-to-end scan bench over the same fixture reporting scan throughput, so the
   decompress delta can be put in end-to-end context. (runtime-decode-policy)
-- [ ] 0.3 Prototype the chosen fast backend (Decision 2 option A/B/C) *locally only* to obtain a
+  → same bench, `decode_policy/full_scan`: 45.5 MiB/s; SAFE decode is only 1.78% of scan time.
+- [x] 0.3 Prototype the chosen fast backend (Decision 2 option A/B/C) *locally only* to obtain a
   FastUnsafe-vs-Safe number on Linux; commit the benchmark result artifact (both deltas). Do NOT merge
   the prototype. (runtime-decode-policy)
-- [ ] 0.4 **Decision point**: if the end-to-end win does not meet the owner-set threshold, close #2211
-  as not-worth-it and archive this change with a "measured, not justified" note. Otherwise proceed.
+  → throwaway liblz4 (backend A) + `lz4_flex` safe-off proxies (NOT committed); results +
+  methodology in `docs/reports/issue-2211-decode-policy-stage0-ab.md`. Best-case unchecked decode
+  win ~2x, projecting ~0.90% end-to-end (below the scan's ±4.7% noise). Backend A's
+  `LZ4_decompress_fast` is deprecated and measured SLOWER than the checked path.
+- [ ] 0.4 **Decision point (OWNER)**: if the end-to-end win does not meet the owner-set threshold, close
+  #2211 as not-worth-it and archive this change with a "measured, not justified" note. Otherwise
+  proceed. → Evidence recommends CLOSE; awaiting owner call. Nothing in Stages 1–5 is written yet.
 
 ## Stage 1 — the policy type (Safe default, no unsafe yet)
 - [ ] 1.1 Add `enum DecodePolicy { Safe, FastUnsafe }` with `#[derive(Default)]`/`Safe` default in


### PR DESCRIPTION
## What this is

**Stage 0 only** of the approved OpenSpec change \`runtime-decode-policy\` (F6.4, issue #2211). This is the measure-first blocking gate (design Decision 5): quantify whether removing lz4 bounds checks is a material end-to-end win **before** writing any \`unsafe\`. **No unsafe code, no fast backend** is committed. Stages 1–5 remain unbuilt.

Not merge-urgent — this PR is the artifact feeding the owner's Task 0.4 go/no-go. Merging it keeps the bench as a permanent decode-vs-scan measurement asset regardless of whether FastUnsafe is ever pursued.

## Contents

- \`cqlite-core/benches/decode_policy_bench.rs\` — Criterion bench (three arms on one bytes/sec axis over \`test_timeseries.sensor_data\`): SAFE decode-only, full chunk-decompress path, end-to-end \`SELECT *\`. Skip-registers when fixtures absent; NOT a perf-gate entry. Adds \`lz4_flex\` to \`[dev-dependencies]\`.
- \`docs/reports/issue-2211-decode-policy-stage0-ab.md\` — both deltas + methodology, honest about proxy-vs-measured.

## Headline numbers (Linux, Xeon 8488C)

| Arm | Throughput | Share of scan time |
|---|---:|---:|
| SAFE lz4 decode only | 2.50 GiB/s | **1.78%** |
| full chunk path (decode+CRC+read+validate) | 554 MiB/s | 8.22% |
| end-to-end \`SELECT *\` scan | 45.5 MiB/s | 100% |

- Best-case unchecked decode win ~2x → projects **~0.90% end-to-end**, below the scan's own **±4.7%** run-to-run noise (undetectable).
- Design-recommended backend (A) \`LZ4_decompress_fast\` is **deprecated** and measured **3.6x slower** than the checked liblz4 path. The only variant that speeds up decode (\`lz4_flex\` safe-off) is exactly what Decision 1 forbids.

## Recommendation (owner decides)

Evidence points to **close #2211 as measured-but-not-justified** and archive the change with a "measured, not justified" note, keeping the bench. Full reasoning + counter-argument in the report.

Lite gate: PASS (fmt/clippy/file-size/scoped-tests). Full gate deferred pending the go/no-go.