### PR TITLE
feat(#2063): admit eager multi-generation merge path through the scan-admission semaphore

### DIFF
--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -243,6 +243,15 @@ pub(super) async fn merge_generations_for_read(
     limit: Option<usize>,
     target_key: Option<&RowKey>,
 ) -> Result<Vec<(RowKey, ScanRow)>> {
+    // Issue #2063: admit this eager multi-generation operation through the SAME
+    // operation-level scan-admission semaphore the windowed path uses (#1594).
+    // ONE permit for the whole operation, acquired at the top before the single
+    // `spawn_blocking`, held (RAII) across the join `.await`, and released on
+    // every exit (success/error/cancel) via `Drop`. Once-only, no nested acquire:
+    // the KWayMerger's producer OS threads never call `admit()`, so this cannot
+    // reintroduce the #1594 fan-out hold-and-wait deadlock.
+    let _admission = reader::scan_stream_windowed::scan_admission::admit().await;
+
     // Own the bounds/target so the merge body can use them without borrowing
     // across the await; cheap clone of the key bytes.
     let start_key = start_key.cloned();
@@ -392,6 +401,14 @@ pub(super) async fn merge_generations_for_read_with_metadata(
     limit: Option<usize>,
     target_key: Option<&RowKey>,
 ) -> Result<Vec<(RowKey, ScanRow, HashMap<String, CellWriteMetadata>)>> {
+    // Issue #2063: admit this eager multi-generation metadata operation through the
+    // SAME operation-level scan-admission semaphore the windowed path uses (#1594),
+    // identically to the plain `merge_generations_for_read`. ONE permit for the whole
+    // operation, acquired at the top before the single `KWayMerger` `spawn_blocking`,
+    // held (RAII) across the join `.await`, released on every exit via `Drop`. No
+    // nested acquire, so no #1594 hold-and-wait deadlock.
+    let _admission = reader::scan_stream_windowed::scan_admission::admit().await;
+
     // Own the bounds so the merge body can use them without borrowing across the
     // await; cheap clone of the key bytes. Mirrors the plain helper.
     let owned_start = start_key.cloned();

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -406,11 +406,13 @@ pub(super) async fn merge_generations_for_read_with_metadata(
     limit: Option<usize>,
     target_key: Option<&RowKey>,
 ) -> Result<Vec<(RowKey, ScanRow, HashMap<String, CellWriteMetadata>)>> {
-    // Issue #2063: one operation-level scan-admission permit, held as an OUTER future
-    // guard (NOT in a closure): it must span both the async per-reader
-    // `scan_with_cell_metadata` loop AND the `spawn_blocking` merge. RESIDUAL: weaker
-    // cancellation than the plain/seek helpers (`scan_admission.rs` `# Scope`).
-    let _admission = reader::scan_stream_windowed::scan_admission::admit().await;
+    // Issue #2063: one operation-level scan-admission permit. Held as an OUTER future
+    // guard across the async per-reader `scan_with_cell_metadata` loop (cancellation
+    // there is clean — no detached blocking work exists yet, so early release is
+    // harmless), THEN MOVED into the `spawn_blocking` merge closure below so the permit
+    // is held until the detached blocking work TERMINATES. This matches the plain/seek
+    // helpers: no phase both runs detached blocking work AND has released the permit.
+    let admission = reader::scan_stream_windowed::scan_admission::admit().await;
 
     // Own the bounds so the merge body can use them without borrowing across the
     // await; cheap clone of the key bytes. Mirrors the plain helper.
@@ -454,7 +456,8 @@ pub(super) async fn merge_generations_for_read_with_metadata(
     let target_for_merge = target_bytes;
 
     let merged_rows = tokio::task::spawn_blocking(move || -> Result<Vec<MergedMetaRow>> {
-        // Issue #1849: capture the read-time TTL clock ONCE per scan.
+        let _admission = admission; // #2063: hold across the detached blocking work.
+                                    // Issue #1849: capture the read-time TTL clock ONCE per scan.
         let shadow = ReadShadow::new(&merge_schema, now_epoch_secs());
         let mut merger = KWayMerger::new(paths, &merge_schema)?;
         let mut out = Vec::new();

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -36,6 +36,9 @@
 //!
 //! The whole module is gated on `write-support` at its `mod` declaration in the
 //! parent (`sstable/mod.rs`).
+//!
+//! NOTE (#1116 file-size): already over the 800-line target on `origin/main`; the
+//! #2063 admission acquires add a few lines. Splitting is tracked under epic #1116.
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -243,14 +246,9 @@ pub(super) async fn merge_generations_for_read(
     limit: Option<usize>,
     target_key: Option<&RowKey>,
 ) -> Result<Vec<(RowKey, ScanRow)>> {
-    // Issue #2063: admit this eager multi-generation operation through the SAME
-    // operation-level scan-admission semaphore the windowed path uses (#1594).
-    // ONE permit for the whole operation, acquired at the top before the single
-    // `spawn_blocking`, held (RAII) across the join `.await`, and released on
-    // every exit (success/error/cancel) via `Drop`. Once-only, no nested acquire:
-    // the KWayMerger's producer OS threads never call `admit()`, so this cannot
-    // reintroduce the #1594 fan-out hold-and-wait deadlock.
-    let _admission = reader::scan_stream_windowed::scan_admission::admit().await;
+    // Issue #2063: one operation-level scan-admission permit; rationale + cancellation
+    // shape in `scan_admission.rs` `# Scope`. Moved into the closure below.
+    let admission = reader::scan_stream_windowed::scan_admission::admit().await;
 
     // Own the bounds/target so the merge body can use them without borrowing
     // across the await; cheap clone of the key bytes.
@@ -262,7 +260,8 @@ pub(super) async fn merge_generations_for_read(
     let schema = schema.clone();
 
     let mut merged = tokio::task::spawn_blocking(move || -> Result<Vec<(RowKey, ScanRow)>> {
-        // Issue #1849: capture the read-time TTL clock ONCE per scan.
+        let _admission = admission; // #2063: hold across the detached blocking work.
+                                    // Issue #1849: capture the read-time TTL clock ONCE per scan.
         let shadow = ReadShadow::new(&schema, now_epoch_secs());
         let mut merger = KWayMerger::new(paths, &schema)?;
         let mut out = Vec::new();
@@ -331,6 +330,11 @@ pub(super) async fn seek_merge_generations_for_read(
     use crate::storage::scan_cancel::ScanCancel;
     use crate::storage::write_engine::merge::build_single_partition_merger_from_readers;
 
+    // Issue #2063: one operation-level scan-admission permit; ONLY call site is the
+    // top-level `scan_partition_clustering`, never nested. Rationale + cancellation
+    // shape in `scan_admission.rs` `# Scope`.
+    let admission = reader::scan_stream_windowed::scan_admission::admit().await;
+
     // NEWEST→OLDEST like `ordered_generation_paths`, so the seeking merger's
     // run_index (= position) equals the full-scan merger's LWW tie-break rank.
     let mut ordered: Vec<Arc<reader::SSTableReader>> = candidates.to_vec();
@@ -340,8 +344,9 @@ pub(super) async fn seek_merge_generations_for_read(
     let target_bytes = target_key.as_bytes().to_vec();
 
     let mut merged = tokio::task::spawn_blocking(move || -> Result<Vec<(RowKey, ScanRow)>> {
-        // Issue #1849: same read-visibility kernel `merge_generations_for_read`
-        // applies (read-time TTL clock captured ONCE), REQUIRED for byte-identity.
+        let _admission = admission; // #2063: hold across the detached blocking work.
+                                    // Issue #1849: same read-visibility kernel `merge_generations_for_read`
+                                    // applies (read-time TTL clock captured ONCE), REQUIRED for byte-identity.
         let shadow = ReadShadow::new(&schema, now_epoch_secs());
         let keys = [target_bytes.clone()];
         let Some(mut merger) =
@@ -401,12 +406,10 @@ pub(super) async fn merge_generations_for_read_with_metadata(
     limit: Option<usize>,
     target_key: Option<&RowKey>,
 ) -> Result<Vec<(RowKey, ScanRow, HashMap<String, CellWriteMetadata>)>> {
-    // Issue #2063: admit this eager multi-generation metadata operation through the
-    // SAME operation-level scan-admission semaphore the windowed path uses (#1594),
-    // identically to the plain `merge_generations_for_read`. ONE permit for the whole
-    // operation, acquired at the top before the single `KWayMerger` `spawn_blocking`,
-    // held (RAII) across the join `.await`, released on every exit via `Drop`. No
-    // nested acquire, so no #1594 hold-and-wait deadlock.
+    // Issue #2063: one operation-level scan-admission permit, held as an OUTER future
+    // guard (NOT in a closure): it must span both the async per-reader
+    // `scan_with_cell_metadata` loop AND the `spawn_blocking` merge. RESIDUAL: weaker
+    // cancellation than the plain/seek helpers (`scan_admission.rs` `# Scope`).
     let _admission = reader::scan_stream_windowed::scan_admission::admit().await;
 
     // Own the bounds so the merge body can use them without borrowing across the

--- a/cqlite-core/src/storage/sstable/reader/scan_admission.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_admission.rs
@@ -50,12 +50,28 @@
 //!
 //! # Scope
 //!
-//! Admission covers the LAZY/WINDOWED scan path only. The write-support
-//! multi-generation EAGER-materialize branch (`merge_generations_for_read` in
-//! `storage/sstable/mod.rs`, which drains a `KWayMerger` inside a single
-//! `spawn_blocking`) does NOT pass through admission — it predates F4 and is not
-//! the `spawn_blocking`-windowed target. Do not assume ALL reads are throttled by
-//! this semaphore; wiring that eager path in would be a separate change.
+//! Admission covers BOTH the LAZY/WINDOWED scan path AND the write-support
+//! multi-generation EAGER-materialize path (issue #2063). The eager path —
+//! `merge_generations_for_read` and its metadata sibling
+//! `merge_generations_for_read_with_metadata` in
+//! `storage/sstable/generation_merge.rs`, each of which drains a `KWayMerger`
+//! inside a single `spawn_blocking` — acquires exactly ONE operation-level permit
+//! at the top of the function (before its `spawn_blocking`, held across the join
+//! via the RAII guard), through this same process-wide semaphore. That is the
+//! precise fit for the eager shape (one `spawn_blocking`, no async fan-out, no
+//! sub-scans) and cannot reintroduce the #1594 hold-and-wait deadlock: it is a
+//! single top-level once-only `admit()` with no nested acquisition (the
+//! KWayMerger's producer OS threads never call [`admit`]).
+//!
+//! KNOWN LIMITATION (documented, not solved here): the shared semaphore bounds
+//! eager *operation* concurrency, NOT the eager path's per-operation resource
+//! footprint. Unlike the windowed path (tokio blocking-pool threads), each eager
+//! operation drives `M` `std::thread` producer threads (M = generation count;
+//! KWayMerger, #2316), so `cap` admitted eager operations can still spawn up to
+//! `cap × M` producer OS threads. The bound limits how many eager operations run
+//! at once, consistent with #1594's "operation concurrency, not total blocking
+//! threads" semantic; sizing the eager path's thread footprint separately is a
+//! future issue (see the change's Non-goals).
 //!
 //! # Deadlock-freedom
 //!

--- a/cqlite-core/src/storage/sstable/reader/scan_admission.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_admission.rs
@@ -70,15 +70,16 @@
 //! each is a single top-level once-only `admit()` with no nested acquisition (the
 //! KWayMerger's producer OS threads never call [`admit`]).
 //!
-//! CANCELLATION (issue #2063): the two PURE-blocking helpers
-//! (`merge_generations_for_read`, `seek_merge_generations_for_read`) MOVE the permit
-//! INTO the `spawn_blocking` closure, so a cancelled/dropped join holds the slot until
-//! the detached blocking work actually terminates — repeated cancels can never exceed
-//! the bound. The METADATA helper cannot (its permit must span an async per-reader
-//! `scan_with_cell_metadata` loop OUTSIDE `spawn_blocking`), so it holds the permit as
-//! an outer future guard; on cancellation it releases immediately while a detached
-//! in-flight merge keeps its producer threads running permit-free — a weaker property
-//! (repeated mid-merge cancels of the metadata path can transiently exceed the bound).
+//! CANCELLATION (issue #2063): ALL THREE helpers hold the permit until the detached
+//! `spawn_blocking` merge TERMINATES, so no phase both runs detached blocking work AND
+//! has already released the permit — repeated cancels can never exceed the bound. The
+//! two PURE-blocking helpers (`merge_generations_for_read`,
+//! `seek_merge_generations_for_read`) MOVE the permit INTO the `spawn_blocking` closure
+//! directly. The METADATA helper holds the permit as an OUTER future guard across its
+//! async per-reader `scan_with_cell_metadata` loop (cancellation there is clean — no
+//! detached blocking work exists yet, so early release is harmless), THEN MOVES it into
+//! the `spawn_blocking` merge closure for the detached phase. The three helpers are
+//! therefore UNIFORMLY cancellation-safe.
 //!
 //! KNOWN LIMITATION (documented, not solved here): the shared semaphore bounds
 //! eager *operation* concurrency, NOT the eager path's per-operation resource

--- a/cqlite-core/src/storage/sstable/reader/scan_admission.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_admission.rs
@@ -51,17 +51,34 @@
 //! # Scope
 //!
 //! Admission covers BOTH the LAZY/WINDOWED scan path AND the write-support
-//! multi-generation EAGER-materialize path (issue #2063). The eager path —
-//! `merge_generations_for_read` and its metadata sibling
-//! `merge_generations_for_read_with_metadata` in
-//! `storage/sstable/generation_merge.rs`, each of which drains a `KWayMerger`
-//! inside a single `spawn_blocking` — acquires exactly ONE operation-level permit
-//! at the top of the function (before its `spawn_blocking`, held across the join
-//! via the RAII guard), through this same process-wide semaphore. That is the
-//! precise fit for the eager shape (one `spawn_blocking`, no async fan-out, no
-//! sub-scans) and cannot reintroduce the #1594 hold-and-wait deadlock: it is a
-//! single top-level once-only `admit()` with no nested acquisition (the
+//! multi-generation EAGER-materialize path (issue #2063). The eager path is THREE
+//! helpers in `storage/sstable/generation_merge.rs`, each draining a `KWayMerger`
+//! inside a single `spawn_blocking`, each acquiring exactly ONE operation-level
+//! permit at the top of the function through this same process-wide semaphore:
+//!
+//! - `merge_generations_for_read` — the materializing plain read (`scan` / range /
+//!   partition-targeted point read).
+//! - `seek_merge_generations_for_read` — the partition-SEEKING point-read merge
+//!   (`scan_partition_clustering`, multi-candidate `WHERE pk = ?`). Its only call
+//!   site is that top-level manager operation, never nested under another admitted
+//!   operation.
+//! - `merge_generations_for_read_with_metadata` — the `WRITETIME`/`TTL` projection
+//!   sibling.
+//!
+//! That is the precise fit for the eager shape (one `spawn_blocking`, no async
+//! fan-out, no sub-scans) and cannot reintroduce the #1594 hold-and-wait deadlock:
+//! each is a single top-level once-only `admit()` with no nested acquisition (the
 //! KWayMerger's producer OS threads never call [`admit`]).
+//!
+//! CANCELLATION (issue #2063): the two PURE-blocking helpers
+//! (`merge_generations_for_read`, `seek_merge_generations_for_read`) MOVE the permit
+//! INTO the `spawn_blocking` closure, so a cancelled/dropped join holds the slot until
+//! the detached blocking work actually terminates — repeated cancels can never exceed
+//! the bound. The METADATA helper cannot (its permit must span an async per-reader
+//! `scan_with_cell_metadata` loop OUTSIDE `spawn_blocking`), so it holds the permit as
+//! an outer future guard; on cancellation it releases immediately while a detached
+//! in-flight merge keeps its producer threads running permit-free — a weaker property
+//! (repeated mid-merge cancels of the metadata path can transiently exceed the bound).
 //!
 //! KNOWN LIMITATION (documented, not solved here): the shared semaphore bounds
 //! eager *operation* concurrency, NOT the eager path's per-operation resource

--- a/cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs
+++ b/cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs
@@ -72,6 +72,12 @@ const CONCURRENT_SCANS: usize = 6;
 /// Partitions written per generation — enough rows that each materializing scan
 /// does real work and concurrent scans can overlap under the shared semaphore.
 const PARTITIONS_PER_GEN: i32 = 64;
+/// Partition key targeted by the seek/point-read test. It is written into BOTH
+/// generations (see `build_multigen_fixture`) so a `WHERE id = SEEK_TARGET_ID`
+/// point read genuinely resolves to >1 candidate generation and takes the
+/// multi-candidate `seek_merge_generations_for_read` branch (not a single-candidate
+/// permit-free seek).
+const SEEK_TARGET_ID: i32 = 0;
 
 fn make_schema() -> TableSchema {
     TableSchema {
@@ -141,12 +147,18 @@ async fn build_multigen_fixture(schema: &TableSchema) -> (TempDir, std::path::Pa
     }
     engine.flush().await.expect("flush 1").expect("gen1");
 
-    // Gen 2 (ts=200): odd ids (distinct partitions, so both generations contribute).
+    // Gen 2 (ts=200): odd ids (distinct partitions, so both generations contribute)
+    // PLUS a re-write of the seek target (an even id already in gen 1) so that key is
+    // present in BOTH generations — a `WHERE id = SEEK_TARGET_ID` point read then
+    // resolves to >1 candidate and drives the multi-candidate seek merge branch.
     for id in (1..PARTITIONS_PER_GEN).step_by(2) {
         engine
             .write(write_name(id, &format!("g2-{id}"), 200))
             .expect("write gen2");
     }
+    engine
+        .write(write_name(SEEK_TARGET_ID, &format!("g2-{SEEK_TARGET_ID}"), 200))
+        .expect("write seek target into gen2");
     engine.flush().await.expect("flush 2").expect("gen2");
 
     engine.close().await.expect("close engine");
@@ -406,15 +418,25 @@ async fn concurrent_eager_seek_point_reads_never_exceed_admission_limit() {
     let schema = Arc::new(schema);
     let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
 
+    // The fixture wrote SEEK_TARGET_ID into BOTH generations, so the point-read
+    // resolves to 2 candidate generations and the multi-candidate seek merge branch is
+    // genuinely taken (not a single-candidate permit-free seek). Confirm the fixture is
+    // a 2-generation directory, as the other cases do.
+    let sstable_dir = data_dir.join(KS).join(TBL);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        2,
+        "seek fixture MUST hold 2 generations so `WHERE id = SEEK_TARGET_ID` (present \
+         in both) resolves to >1 candidate and drives `seek_merge_generations_for_read`"
+    );
+
     admission::set_test_limit(LIMIT);
 
-    // Point-read the SAME partition key concurrently. To make the seeking merge take
-    // the multi-candidate (>1 generation) branch, target a key present in BOTH
-    // generations is not required — the prune only needs >1 candidate to admit it;
-    // we target an even id (written in gen 1) but both generations' bloom/BTI are
-    // consulted, so `candidates.len() > 1` drives `seek_merge_generations_for_read`.
-    let pk_bytes =
-        encode_partition_key_columns(&[Value::Integer(0)], &schema).expect("encode partition key");
+    // Point-read the SAME partition key concurrently. SEEK_TARGET_ID is present in BOTH
+    // generations, so both blooms report it present → `candidates.len() > 1` → the
+    // multi-candidate `seek_merge_generations_for_read` branch runs (and admits).
+    let pk_bytes = encode_partition_key_columns(&[Value::Integer(SEEK_TARGET_ID)], &schema)
+        .expect("encode partition key");
     let pk = Arc::new(pk_bytes);
 
     let mut handles = Vec::with_capacity(CONCURRENT_SCANS);
@@ -441,10 +463,15 @@ async fn concurrent_eager_seek_point_reads_never_exceed_admission_limit() {
     let residual = admission::current_in_flight();
     admission::clear_test_limit();
 
-    // The point read may or may not route through the multi-candidate seek merge
-    // depending on prune outcome; if it did NOT admit at all we cannot assert wiring
-    // here (the single-candidate seek path is permit-free by design). Only assert the
-    // SAFETY bound + release, which must hold unconditionally.
+    // The target key is present in BOTH generations, so the point read routes through
+    // the multi-candidate `seek_merge_generations_for_read` branch, which admits.
+    // Non-vacuous: a never-admitting path leaves `max_admitted == 0`.
+    assert!(
+        max_admitted >= 1,
+        "Issue #2063: seek eager path never admitted — the acquire in \
+         `seek_merge_generations_for_read` is not wired (or the fixture failed to place \
+         the target key in >1 candidate generation)"
+    );
     assert!(
         max_admitted <= LIMIT,
         "Issue #2063 REGRESSION: {max_admitted} eager seek merge operations were admitted \

--- a/cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs
+++ b/cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs
@@ -321,3 +321,137 @@ async fn more_eager_scans_than_cap_all_complete_without_hanging() {
         "Issue #2063: {residual} permits still held after all eager scans completed"
     );
 }
+
+/// FIX 4 (rust-reviewer): the metadata sibling `merge_generations_for_read_with_metadata`
+/// (the WRITETIME/TTL projection path) also acquires an operation-level permit.
+/// Drive concurrent `scan_with_cell_metadata` reads over the multi-gen + schema
+/// fixture so that acquire is exercised end-to-end: non-vacuous (`>= 1`), bounded
+/// (`<= LIMIT`), and leak-free (`current_in_flight == 0` after).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn concurrent_eager_metadata_scans_never_exceed_admission_limit() {
+    let schema = make_schema();
+    let config = Config::default();
+    let (_temp_dir, data_dir) = build_multigen_fixture(&schema).await;
+    let manager = Arc::new(open_manager(&data_dir, &config).await);
+    let schema = Arc::new(schema);
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+
+    admission::set_test_limit(LIMIT);
+
+    // N > LIMIT concurrent metadata scans; each routes through
+    // `merge_generations_for_read_with_metadata` (multi-gen + schema present).
+    let mut handles = Vec::with_capacity(CONCURRENT_SCANS);
+    for _ in 0..CONCURRENT_SCANS {
+        let manager = Arc::clone(&manager);
+        let schema = Arc::clone(&schema);
+        let table_id = table_id.clone();
+        handles.push(tokio::spawn(async move {
+            manager
+                .scan_with_cell_metadata(&table_id, None, None, None, Some(&schema))
+                .await
+                .expect("eager metadata multi-gen scan must not error")
+                .len()
+        }));
+    }
+
+    let mut total_rows = 0usize;
+    for h in handles {
+        total_rows += h.await.expect("metadata scan task joins");
+    }
+
+    let max_admitted = admission::max_in_flight();
+    let residual = admission::current_in_flight();
+    admission::clear_test_limit();
+
+    // Non-vacuous: the eager metadata merge returned the full reconciled row set.
+    assert_eq!(
+        total_rows,
+        (CONCURRENT_SCANS as i32 * PARTITIONS_PER_GEN) as usize,
+        "each metadata scan must return all {PARTITIONS_PER_GEN} reconciled rows; a \
+         short/zero count means the eager metadata merge path was not exercised"
+    );
+    // Wiring: the metadata acquire is actually reached (non-vacuous).
+    assert!(
+        max_admitted >= 1,
+        "Issue #2063: metadata eager path never admitted — the acquire in \
+         `merge_generations_for_read_with_metadata` is not wired"
+    );
+    // The bound holds for the metadata path too.
+    assert!(
+        max_admitted <= LIMIT,
+        "Issue #2063 REGRESSION: {max_admitted} eager metadata merge operations were \
+         admitted at once, exceeding the admission limit of {LIMIT}"
+    );
+    // Every permit released (RAII): no slot leaked on the metadata path.
+    assert_eq!(
+        residual, 0,
+        "Issue #2063: {residual} metadata-scan admission permits still held after completion"
+    );
+}
+
+/// FIX 1 (roborev): the partition-SEEKING point-read helper
+/// `seek_merge_generations_for_read` (reached via `scan_partition` when >1 candidate
+/// generation holds the key) also acquires an operation-level permit. Drive concurrent
+/// multi-candidate point reads and assert the acquire is wired, bounded, and leak-free.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn concurrent_eager_seek_point_reads_never_exceed_admission_limit() {
+    use cqlite_core::storage::partition_key_codec::encode_partition_key_columns;
+
+    let schema = make_schema();
+    let config = Config::default();
+    let (_temp_dir, data_dir) = build_multigen_fixture(&schema).await;
+    let manager = Arc::new(open_manager(&data_dir, &config).await);
+    let schema = Arc::new(schema);
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+
+    admission::set_test_limit(LIMIT);
+
+    // Point-read the SAME partition key concurrently. To make the seeking merge take
+    // the multi-candidate (>1 generation) branch, target a key present in BOTH
+    // generations is not required — the prune only needs >1 candidate to admit it;
+    // we target an even id (written in gen 1) but both generations' bloom/BTI are
+    // consulted, so `candidates.len() > 1` drives `seek_merge_generations_for_read`.
+    let pk_bytes =
+        encode_partition_key_columns(&[Value::Integer(0)], &schema).expect("encode partition key");
+    let pk = Arc::new(pk_bytes);
+
+    let mut handles = Vec::with_capacity(CONCURRENT_SCANS);
+    for _ in 0..CONCURRENT_SCANS {
+        let manager = Arc::clone(&manager);
+        let schema = Arc::clone(&schema);
+        let table_id = table_id.clone();
+        let pk = Arc::clone(&pk);
+        handles.push(tokio::spawn(async move {
+            manager
+                .scan_partition(&table_id, &pk, Some(&schema))
+                .await
+                .expect("eager seek point read must not error")
+                .0
+                .len()
+        }));
+    }
+
+    for h in handles {
+        h.await.expect("seek point-read task joins");
+    }
+
+    let max_admitted = admission::max_in_flight();
+    let residual = admission::current_in_flight();
+    admission::clear_test_limit();
+
+    // The point read may or may not route through the multi-candidate seek merge
+    // depending on prune outcome; if it did NOT admit at all we cannot assert wiring
+    // here (the single-candidate seek path is permit-free by design). Only assert the
+    // SAFETY bound + release, which must hold unconditionally.
+    assert!(
+        max_admitted <= LIMIT,
+        "Issue #2063 REGRESSION: {max_admitted} eager seek merge operations were admitted \
+         at once, exceeding the admission limit of {LIMIT}"
+    );
+    assert_eq!(
+        residual, 0,
+        "Issue #2063: {residual} seek point-read admission permits still held after completion"
+    );
+}

--- a/cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs
+++ b/cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs
@@ -157,7 +157,11 @@ async fn build_multigen_fixture(schema: &TableSchema) -> (TempDir, std::path::Pa
             .expect("write gen2");
     }
     engine
-        .write(write_name(SEEK_TARGET_ID, &format!("g2-{SEEK_TARGET_ID}"), 200))
+        .write(write_name(
+            SEEK_TARGET_ID,
+            &format!("g2-{SEEK_TARGET_ID}"),
+            200,
+        ))
         .expect("write seek target into gen2");
     engine.flush().await.expect("flush 2").expect("gen2");
 

--- a/cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs
+++ b/cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs
@@ -1,0 +1,323 @@
+//! Issue #2063 (Epic F, F4 — deferred second half of #1594): the write-support
+//! multi-generation EAGER-materialize read path
+//! (`generation_merge::merge_generations_for_read`, chosen when a table dir holds
+//! more than one SSTable generation AND a schema is present) now acquires ONE
+//! operation-level permit from the SAME process-wide `scan_admission` semaphore the
+//! windowed/lazy path uses. Before this change the eager path drained a `KWayMerger`
+//! inside a single `spawn_blocking` WITHOUT passing through admission, so concurrent
+//! eager multi-gen scans (the schema-present common case) were unbounded.
+//!
+//! ## What this guards (wiring evidence + non-vacuity)
+//!
+//! A self-contained fixture flushes TWO generations via the public `WriteEngine`
+//! API (exactly the `issue_1849` multi-gen harness), so the reopened table dir has
+//! `candidates > 1`; scanning it with `Some(schema)` provably routes through the
+//! eager `merge_generations_for_read` branch (`mod.rs:1133-1135`) rather than the
+//! lazy per-reader concatenation fallback (which is taken only on a merge ERROR or
+//! `schema=None`). Contrast the #1594 fan-out guard, which passes `schema=None` to
+//! force the LAZY branch — here we do the OPPOSITE.
+//!
+//! With a LOW admission limit `L` installed and `N > L` concurrent eager scans
+//! driven, the `scan-offload-probe` in-flight instrumentation records:
+//! - `max_in_flight <= L` — the eager path is now covered by the operation bound;
+//! - `max_in_flight >= 1` — the acquire is actually WIRED (non-vacuous: a
+//!   never-admitting path leaves `max_in_flight == 0`, and — because the ONLY
+//!   `admit()` on the materializing multi-gen `scan` path is the new eager-path
+//!   one — a non-zero max PROVES the eager branch was admitted, not the lazy
+//!   fallback);
+//! - `current_in_flight == 0` after — every permit was released across the
+//!   `spawn_blocking` join (RAII, no leak).
+//!
+//! Deterministic — the assertions are the SAFETY bound and level snapshots, never
+//! wall-clock timing. The deadlock-freedom flavor wraps the concurrent drive in a
+//! generous timeout purely as a hang backstop (proving the shared semaphore does
+//! not deadlock under `N > cap` contention); correctness is asserted from the
+//! probe counters, not from elapsed time.
+//!
+//! On `main` (eager path unadmitted) `max_in_flight` stays `0` and the `>= 1`
+//! assertion fails; a mis-sized-larger semaphore trips the `<= L` bound.
+
+// Requires the non-default `scan-offload-probe` feature (gates the admission probe
+// surface) plus `write-support` (the eager multi-gen merge path itself) and
+// `state_machine` (the `SSTableManager::new` signature). The agent gate runs this
+// binary with these features enabled.
+#![cfg(all(
+    feature = "write-support",
+    feature = "state_machine",
+    feature = "scan-offload-probe"
+))]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::reader::scan_stream_windowed::scan_admission::probe as admission;
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use serial_test::serial;
+use tempfile::TempDir;
+
+const KS: &str = "eager_admit_ks";
+const TBL: &str = "sessions";
+/// Deliberately small admission limit so `N > LIMIT` eager scans contend.
+const LIMIT: usize = 2;
+/// Concurrent eager multi-gen scans launched (must exceed `LIMIT`).
+const CONCURRENT_SCANS: usize = 6;
+/// Partitions written per generation — enough rows that each materializing scan
+/// does real work and concurrent scans can overlap under the shared semaphore.
+const PARTITIONS_PER_GEN: i32 = 64;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// A simple live row (`name` cell only) — always survives the merge.
+fn write_name(id: i32, name: &str, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value: Value::Text(name.to_string()),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+        .count()
+}
+
+/// Flush TWO generations into a fresh table dir and return `(TempDir, data_dir)`.
+/// The two generations guarantee `candidates > 1`, so a schema-carrying scan takes
+/// the eager `merge_generations_for_read` branch.
+async fn build_multigen_fixture(schema: &TableSchema) -> (TempDir, std::path::PathBuf) {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // Gen 1 (ts=100): even ids.
+    for id in (0..PARTITIONS_PER_GEN).step_by(2) {
+        engine
+            .write(write_name(id, &format!("g1-{id}"), 100))
+            .expect("write gen1");
+    }
+    engine.flush().await.expect("flush 1").expect("gen1");
+
+    // Gen 2 (ts=200): odd ids (distinct partitions, so both generations contribute).
+    for id in (1..PARTITIONS_PER_GEN).step_by(2) {
+        engine
+            .write(write_name(id, &format!("g2-{id}"), 200))
+            .expect("write gen2");
+    }
+    engine.flush().await.expect("flush 2").expect("gen2");
+
+    engine.close().await.expect("close engine");
+
+    let sstable_dir = data_dir.join(KS).join(TBL);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        2,
+        "fixture MUST be a genuine multi-generation directory (>1 Data.db) so the \
+         eager KWayMerger `merge_generations_for_read` branch is taken"
+    );
+
+    (temp_dir, data_dir)
+}
+
+async fn open_manager(data_dir: &std::path::Path, config: &Config) -> SSTableManager {
+    let platform = Arc::new(Platform::new(config).await.expect("platform"));
+    SSTableManager::new(
+        data_dir,
+        config,
+        platform,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("SSTableManager open")
+}
+
+/// Concurrent EAGER multi-gen scans never exceed the installed admission limit,
+/// the acquire is demonstrably wired (non-vacuous), and every permit is released.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn concurrent_eager_merge_scans_never_exceed_admission_limit() {
+    let schema = make_schema();
+    let config = Config::default();
+    let (_temp_dir, data_dir) = build_multigen_fixture(&schema).await;
+    let manager = Arc::new(open_manager(&data_dir, &config).await);
+    let schema = Arc::new(schema);
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+
+    // Install a low admission limit and zero the in-flight counters.
+    admission::set_test_limit(LIMIT);
+
+    // Launch N > LIMIT concurrent eager multi-gen scans. Each routes through
+    // `merge_generations_for_read`, which now acquires one permit for the whole
+    // operation; the semaphore caps concurrently-admitted operations at LIMIT.
+    let mut handles = Vec::with_capacity(CONCURRENT_SCANS);
+    for _ in 0..CONCURRENT_SCANS {
+        let manager = Arc::clone(&manager);
+        let schema = Arc::clone(&schema);
+        let table_id = table_id.clone();
+        handles.push(tokio::spawn(async move {
+            manager
+                .scan(&table_id, None, None, None, Some(&schema))
+                .await
+                .expect("eager multi-gen scan must not error")
+                .len()
+        }));
+    }
+
+    let mut total_rows = 0usize;
+    for h in handles {
+        total_rows += h.await.expect("scan task joins");
+    }
+
+    let max_admitted = admission::max_in_flight();
+    let residual = admission::current_in_flight();
+    admission::clear_test_limit();
+
+    eprintln!(
+        "Issue #2063 eager-merge admission guard: limit={LIMIT} \
+         concurrent_scans={CONCURRENT_SCANS} max_admitted={max_admitted} total_rows={total_rows}"
+    );
+
+    // Non-vacuous: the eager merge returned the full reconciled row set.
+    assert_eq!(
+        total_rows,
+        (CONCURRENT_SCANS as i32 * PARTITIONS_PER_GEN) as usize,
+        "each of the {CONCURRENT_SCANS} eager scans must return all {PARTITIONS_PER_GEN} \
+         reconciled rows; a short/zero count means the eager merge path was not exercised"
+    );
+    // Wiring / non-vacuity: at least one operation was admitted. The ONLY `admit()`
+    // on the materializing multi-gen `scan` path is the new eager-path acquire, so a
+    // non-zero max proves the EAGER branch (not the lazy fallback) was admitted.
+    assert!(
+        max_admitted >= 1,
+        "Issue #2063: no eager multi-gen operation was ever recorded as admitted — the \
+         `scan_admission::admit()` acquire in `merge_generations_for_read` is not wired \
+         (or the scan fell to the lazy fallback, which does not exercise the eager path)"
+    );
+    // The bound: concurrently-admitted eager operations never exceeded the limit.
+    assert!(
+        max_admitted <= LIMIT,
+        "Issue #2063 REGRESSION: {max_admitted} eager multi-gen merge operations were admitted \
+         at once, exceeding the admission limit of {LIMIT}. The eager path must be bounded by \
+         the same operation-concurrency semaphore as the windowed path (#1594)."
+    );
+    // Every permit released across the spawn_blocking join (RAII): no slot leaked.
+    assert_eq!(
+        residual, 0,
+        "Issue #2063: {residual} admission permits were still held after all eager scans \
+         finished — a scan leaked its admission slot instead of releasing it (RAII on the join)"
+    );
+}
+
+/// Deadlock-freedom: more concurrent eager scans than the cap all COMPLETE (the
+/// shared semaphore does not hang under contention), do real work, and stay bounded.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn more_eager_scans_than_cap_all_complete_without_hanging() {
+    const CAP: usize = 2;
+    const N: usize = 8;
+
+    let schema = make_schema();
+    let config = Config::default();
+    let (_temp_dir, data_dir) = build_multigen_fixture(&schema).await;
+    let manager = Arc::new(open_manager(&data_dir, &config).await);
+    let schema = Arc::new(schema);
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+
+    admission::set_test_limit(CAP);
+
+    let mut handles = Vec::with_capacity(N);
+    for _ in 0..N {
+        let manager = Arc::clone(&manager);
+        let schema = Arc::clone(&schema);
+        let table_id = table_id.clone();
+        handles.push(tokio::spawn(async move {
+            manager
+                .scan(&table_id, None, None, None, Some(&schema))
+                .await
+                .expect("eager multi-gen scan must not error")
+                .len()
+        }));
+    }
+
+    // Generous timeout is a HANG BACKSTOP only (pre-change there was no bound on the
+    // eager path; the guard proves the shared semaphore does not deadlock). All
+    // correctness assertions below come from the probe counters / row totals, never
+    // from elapsed time.
+    let total_rows: usize = tokio::time::timeout(std::time::Duration::from_secs(60), async {
+        let mut total = 0usize;
+        for h in handles {
+            total += h.await.expect("scan task joins");
+        }
+        total
+    })
+    .await
+    .expect("all N eager scans must complete — a hang means the shared semaphore deadlocked");
+
+    let max_admitted = admission::max_in_flight();
+    let residual = admission::current_in_flight();
+    admission::clear_test_limit();
+
+    // Scans did real work (not a vacuous early return).
+    assert!(
+        total_rows > 0,
+        "Issue #2063: {N} concurrent eager scans returned 0 rows total — the scans did no work"
+    );
+    // The bound held while all N eventually completed.
+    assert!(
+        max_admitted <= CAP,
+        "Issue #2063: max_admitted {max_admitted} exceeded CAP {CAP} under N>{CAP} contention"
+    );
+    // Wiring: the eager path admitted at least once.
+    assert!(
+        max_admitted >= 1,
+        "Issue #2063: eager path never admitted (max_in_flight == 0) — acquire not wired"
+    );
+    assert_eq!(
+        residual, 0,
+        "Issue #2063: {residual} permits still held after all eager scans completed"
+    );
+}

--- a/openspec/changes/eager-merge-admission/design.md
+++ b/openspec/changes/eager-merge-admission/design.md
@@ -77,14 +77,15 @@ no outer permit, so admitting it introduces no cross-path hold-and-wait (verifie
 ## Decision 4 — cancellation: hold the permit until the detached blocking work terminates
 Dropping a `spawn_blocking` `JoinHandle` DETACHES the closure — the KWayMerger producer OS threads keep
 running — while a permit guard bound to the OUTER future would already be released, so repeated cancels
-could exceed the bound. **Chosen: for the two PURE-blocking helpers (`merge_generations_for_read`,
-`seek_merge_generations_for_read`) MOVE the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure**
-(`Send + 'static`), so the permit is released only when the detached blocking work actually finishes.
-The METADATA helper cannot do this — its permit must span the async per-reader `scan_with_cell_metadata`
-loop that runs OUTSIDE `spawn_blocking` — so it keeps the outer future guard. That is an honestly weaker
-cancellation property (a cancelled metadata read releases immediately while a detached in-flight merge's
-producer threads run permit-free), documented in the scope doc + Known-limitation rather than
-over-engineered away.
+could exceed the bound. **Chosen: ALL THREE helpers hold the permit until the detached `spawn_blocking`
+merge TERMINATES.** The two PURE-blocking helpers (`merge_generations_for_read`,
+`seek_merge_generations_for_read`) MOVE the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure
+directly (`Send + 'static`). The METADATA helper holds the permit as an OUTER future guard across its
+async per-reader `scan_with_cell_metadata` loop — where cancellation is clean because no detached
+blocking work exists yet, so an early release is harmless — THEN MOVES the permit into the
+`spawn_blocking` merge closure for the detached phase. No phase both runs detached blocking work AND has
+already released the permit, so repeated cancels can never exceed the bound. The three helpers are
+uniformly cancellation-safe.
 
 ## Known limitation (documented, not solved)
 The shared semaphore bounds *operation concurrency*. The eager path's real resource footprint is
@@ -93,12 +94,6 @@ path). So `cap` admitted eager operations can still spawn up to `cap × M` produ
 bound limits how many eager *operations* run at once, not their aggregate thread count. This matches
 #1594's stated semantic ("operation concurrency, not total blocking threads") and is called out in the
 scope doc; sizing the eager path's thread footprint separately is explicitly a Non-goal / future issue.
-
-Additionally, the METADATA helper (`merge_generations_for_read_with_metadata`) has a weaker CANCELLATION
-property than the two pure-blocking helpers (Decision 4): its permit is an outer future guard, so on
-cancellation it releases immediately while a detached in-flight merge's producer threads run permit-free.
-Repeated mid-merge cancels of the metadata path can transiently exceed the bound. Documented, not solved
-— the two-phase (async TTL scan + blocking merge) shape cannot move the permit into a single closure.
 
 ## Test / verification plan
 - **Bound guard** (new `tests/issue_2063_eager_merge_admission_bound.rs`, `scan-offload-probe`-gated):

--- a/openspec/changes/eager-merge-admission/design.md
+++ b/openspec/changes/eager-merge-admission/design.md
@@ -9,11 +9,14 @@ reached through a free function `admit() -> ScanAdmissionPermit` (RAII; releases
 operation** (`ScanAdmission::Acquire`) and mark cross-generation sub-scans `Exempt` so a fan-out merge
 holds exactly one permit (`mod.rs:2226-2242`, `sequential.rs:377-380`).
 
-The eager path — `merge_generations_for_read` (`generation_merge.rs:238-297`) and its metadata sibling
-`merge_generations_for_read_with_metadata` (`generation_merge.rs:319`) — was explicitly carved out
-(scope doc `scan_admission.rs:51-58`). It is chosen when `reader_list.len() > 1` AND a schema is present
-(`mod.rs:1135`, `1646`, `1482`, `1853`), and drains a `KWayMerger` in a **single** `spawn_blocking`
-(`generation_merge.rs:255`), awaiting the join at line 287.
+The eager path is THREE helpers in `generation_merge.rs`, each explicitly carved out (scope doc
+`scan_admission.rs:51-58`), each chosen when `reader_list.len() > 1` (or `candidates.len() > 1` for the
+point read) AND a schema is present, and each draining a `KWayMerger` in a **single** `spawn_blocking`:
+
+- `merge_generations_for_read` — the materializing plain read (`mod.rs:1135`, `1646`).
+- `seek_merge_generations_for_read` — the partition-SEEKING point-read merge (`mod.rs:1650`, reached
+  via `scan_partition_clustering`); `#[cfg(all(write-support, not(tombstones)))]`.
+- `merge_generations_for_read_with_metadata` — the WRITETIME/TTL sibling (`mod.rs:1482`, `1854`).
 
 ## Goals / constraints
 - Bound concurrent eager multi-gen operations under the SAME operation-concurrency semaphore as the
@@ -61,11 +64,27 @@ sub-scans → no permit ever frees. The eager path has **none of that topology**
 
 Therefore one top-level, once-only `admit()` with no nested acquire is deadlock-safe.
 
-## Decision 3 — scope: include the metadata sibling
-**Chosen: yes.** `merge_generations_for_read_with_metadata` (`generation_merge.rs:319`, called at
-`mod.rs:1482`, `1853`) has the identical single-`spawn_blocking(KWayMerger)` shape and is equally
-unadmitted. Fixing only the non-metadata variant would leave a twin gap that silently defeats the bound
-on the metadata read path. Both get the same one-line acquire.
+## Decision 3 — scope: ALL THREE eager helpers
+**Chosen: admit all three.** Beyond `merge_generations_for_read`, both
+`merge_generations_for_read_with_metadata` (the WRITETIME/TTL sibling) and
+`seek_merge_generations_for_read` (the partition-SEEKING point read) have the identical
+single-`spawn_blocking(KWayMerger)` shape and were equally unadmitted. Fixing only one would leave a
+twin/triplet gap that silently defeats the bound on the metadata and point-read paths. All three get the
+same operation-level acquire. `seek_merge_generations_for_read`'s only call site
+(`SSTableManager::scan_partition_clustering`, `mod.rs:1650`) is a top-level manager operation that holds
+no outer permit, so admitting it introduces no cross-path hold-and-wait (verified: no nested acquire).
+
+## Decision 4 — cancellation: hold the permit until the detached blocking work terminates
+Dropping a `spawn_blocking` `JoinHandle` DETACHES the closure — the KWayMerger producer OS threads keep
+running — while a permit guard bound to the OUTER future would already be released, so repeated cancels
+could exceed the bound. **Chosen: for the two PURE-blocking helpers (`merge_generations_for_read`,
+`seek_merge_generations_for_read`) MOVE the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure**
+(`Send + 'static`), so the permit is released only when the detached blocking work actually finishes.
+The METADATA helper cannot do this — its permit must span the async per-reader `scan_with_cell_metadata`
+loop that runs OUTSIDE `spawn_blocking` — so it keeps the outer future guard. That is an honestly weaker
+cancellation property (a cancelled metadata read releases immediately while a detached in-flight merge's
+producer threads run permit-free), documented in the scope doc + Known-limitation rather than
+over-engineered away.
 
 ## Known limitation (documented, not solved)
 The shared semaphore bounds *operation concurrency*. The eager path's real resource footprint is
@@ -74,6 +93,12 @@ path). So `cap` admitted eager operations can still spawn up to `cap × M` produ
 bound limits how many eager *operations* run at once, not their aggregate thread count. This matches
 #1594's stated semantic ("operation concurrency, not total blocking threads") and is called out in the
 scope doc; sizing the eager path's thread footprint separately is explicitly a Non-goal / future issue.
+
+Additionally, the METADATA helper (`merge_generations_for_read_with_metadata`) has a weaker CANCELLATION
+property than the two pure-blocking helpers (Decision 4): its permit is an outer future guard, so on
+cancellation it releases immediately while a detached in-flight merge's producer threads run permit-free.
+Repeated mid-merge cancels of the metadata path can transiently exceed the bound. Documented, not solved
+— the two-phase (async TTL scan + blocking merge) shape cannot move the permit into a single closure.
 
 ## Test / verification plan
 - **Bound guard** (new `tests/issue_2063_eager_merge_admission_bound.rs`, `scan-offload-probe`-gated):

--- a/openspec/changes/eager-merge-admission/design.md
+++ b/openspec/changes/eager-merge-admission/design.md
@@ -1,0 +1,93 @@
+# Design — eager multi-generation merge admission
+
+## Context
+
+#1594 (F4) introduced `scan_admission` (`cqlite-core/src/storage/sstable/reader/scan_admission.rs`): a
+process-wide `static OnceLock<Arc<Semaphore>>` sized from `available_parallelism().unwrap_or(4).max(1)`,
+reached through a free function `admit() -> ScanAdmissionPermit` (RAII; releases on every exit path via
+`Drop`; fail-open if the semaphore is closed). The windowed/lazy paths acquire **one permit per scan
+operation** (`ScanAdmission::Acquire`) and mark cross-generation sub-scans `Exempt` so a fan-out merge
+holds exactly one permit (`mod.rs:2226-2242`, `sequential.rs:377-380`).
+
+The eager path — `merge_generations_for_read` (`generation_merge.rs:238-297`) and its metadata sibling
+`merge_generations_for_read_with_metadata` (`generation_merge.rs:319`) — was explicitly carved out
+(scope doc `scan_admission.rs:51-58`). It is chosen when `reader_list.len() > 1` AND a schema is present
+(`mod.rs:1135`, `1646`, `1482`, `1853`), and drains a `KWayMerger` in a **single** `spawn_blocking`
+(`generation_merge.rs:255`), awaiting the join at line 287.
+
+## Goals / constraints
+- Bound concurrent eager multi-gen operations under the SAME operation-concurrency semaphore as the
+  windowed path (one shared admission bound for all scan operations).
+- **Must not** reintroduce the #1594 fan-out hold-and-wait deadlock.
+- No `unwrap`/`expect` in library code; permit released on every exit (success/error/cancel).
+- No change to eager-vs-lazy branch selection, KWayMerger, or the merge-error concatenation fallback.
+
+## Decision 1 — where to acquire the permit
+**Chosen: acquire inside the eager functions, at the top, before `spawn_blocking`, holding the RAII
+guard across the join `.await`.**
+
+```rust
+// top of merge_generations_for_read (and _with_metadata), before line 255:
+let _admission = scan_admission::admit().await;   // one permit for the whole op; RAII release
+// ... existing spawn_blocking(KWayMerger drain) ... .await
+```
+
+Reachable via `super::reader::scan_stream_windowed::scan_admission::admit()` (the module path the
+fan-out site already uses; `generation_merge.rs` already `use super::reader;`).
+
+**Alternatives considered:**
+- *Acquire at the `mod.rs` call sites* (like the fan-out merge does at `mod.rs:2226`): rejected — the
+  eager function has 4 call sites (2 per variant) and no fan-out, so acquiring inside the function is
+  one edit per variant instead of four, and keeps the permit lifetime co-located with the work it
+  bounds. The windowed fan-out acquires at the call site only because the permit must span multiple
+  `Exempt` sub-scan opens; the eager path has no sub-scans, so that reason does not apply.
+- *Add a `ScanAdmission` parameter to the eager functions*: rejected — unnecessary indirection; the
+  eager path is never itself a sub-scan of another admitted operation (it is always a top-level
+  materialize), so it never needs an `Exempt` mode. (If a future caller ever nests it under an already
+  admitted operation, that caller would need the parameter — noted as a latent extension, not built.)
+
+## Decision 2 — deadlock-freedom argument (why one permit is safe here)
+The #1594 deadlock required: N concurrent async sub-scans, `cap` winning permits and parking in
+consumer backpressure while a priming merge waits on the remaining `N-cap` blocked-on-`admit()`
+sub-scans → no permit ever frees. The eager path has **none of that topology**:
+- It is a single `spawn_blocking` draining `KWayMerger::step()` **sequentially** — no N concurrent
+  async sub-scans, no prime-then-drain, no call to `scan_stream_admitted`.
+- KWayMerger's internal producers are plain `std::thread::spawn` OS threads each running a
+  `current_thread` runtime (`write_engine/merge/mod.rs:437-447`, #2316) — they **never call
+  `admit()`**, so there is no nested permit acquisition and no hold-and-wait.
+- No cross-path cycle: neither a windowed operation nor an eager operation, while holding its permit,
+  acquires a second permit or depends on *another* operation getting one. So sharing the semaphore
+  across both paths preserves the #1594 deadlock-freedom invariant.
+
+Therefore one top-level, once-only `admit()` with no nested acquire is deadlock-safe.
+
+## Decision 3 — scope: include the metadata sibling
+**Chosen: yes.** `merge_generations_for_read_with_metadata` (`generation_merge.rs:319`, called at
+`mod.rs:1482`, `1853`) has the identical single-`spawn_blocking(KWayMerger)` shape and is equally
+unadmitted. Fixing only the non-metadata variant would leave a twin gap that silently defeats the bound
+on the metadata read path. Both get the same one-line acquire.
+
+## Known limitation (documented, not solved)
+The shared semaphore bounds *operation concurrency*. The eager path's real resource footprint is
+`M std::thread` producer threads per operation (not tokio blocking-pool threads like the windowed
+path). So `cap` admitted eager operations can still spawn up to `cap × M` producer OS threads — the
+bound limits how many eager *operations* run at once, not their aggregate thread count. This matches
+#1594's stated semantic ("operation concurrency, not total blocking threads") and is called out in the
+scope doc; sizing the eager path's thread footprint separately is explicitly a Non-goal / future issue.
+
+## Test / verification plan
+- **Bound guard** (new `tests/issue_2063_eager_merge_admission_bound.rs`, `scan-offload-probe`-gated):
+  drive N concurrent eager multi-gen scans (multi-generation fixture WITH a schema present so the
+  `merge_generations_for_read` branch is taken — contrast the #1594 fan-out test which passes
+  `schema=None` to force the lazy branch). Assert `max_in_flight <= LIMIT` (bound covers eager),
+  `max_in_flight >= 1` (acquire is wired — non-vacuous), `current_in_flight == 0` after (RAII release
+  across the join). Deterministic — asserts the safety bound and level snapshots, never wall-clock.
+- **Deadlock-freedom flavor**: N > cap concurrent eager scans complete within a timeout (proves the
+  shared semaphore doesn't hang when both paths contend). Trivially true given the single-spawn_blocking
+  shape, but pins the no-cross-path-hold-and-wait claim.
+- **Non-redundancy check**: confirm which branch the existing `issue_1594_scan_admission_bound.rs`
+  fixture hits once the eager path is wired (it uses a schema-carrying `SELECT *`); if it now also
+  exercises the eager path, ensure the new guard adds distinct coverage (explicit multi-gen + eager
+  assertion).
+- **Gate**: the new `scan-offload-probe` test runs in the same gate lane as the #1594 guard; full
+  `agent-gate.sh` must PASS. C (spec-auditor) anchored to this change's specs. roborev clean.

--- a/openspec/changes/eager-merge-admission/proposal.md
+++ b/openspec/changes/eager-merge-admission/proposal.md
@@ -33,15 +33,25 @@ cannot reintroduce the #1594 hold-and-wait deadlock (there is exactly one thing 
 permit; the KWayMerger's producer threads are plain OS threads that never call `admit()`).
 
 Concretely:
-1. Acquire `scan_admission::admit().await` at the top of `merge_generations_for_read`
-   (`generation_merge.rs:238`) **and** its metadata sibling `merge_generations_for_read_with_metadata`
-   (`generation_merge.rs:319`) — both have the identical single-`spawn_blocking(KWayMerger)` shape and
-   are equally unadmitted today.
-2. Update the `scan_admission.rs` `# Scope` doc comment to reflect that the eager path is now admitted
-   (and fix its stale `storage/sstable/mod.rs` reference → `generation_merge.rs`).
-3. Add an eager-path admission bound + deadlock-freedom regression guard (a `scan-offload-probe`-gated
+1. Acquire `scan_admission::admit().await` at the top of ALL THREE eager helpers, each of which has the
+   identical single-`spawn_blocking(KWayMerger)` shape and was equally unadmitted:
+   - `merge_generations_for_read` — the materializing plain read (`scan` / range / point read).
+   - `seek_merge_generations_for_read` — the partition-SEEKING point-read merge (multi-candidate
+     `WHERE pk = ?`, via `scan_partition_clustering`); its sole call site is a top-level manager
+     operation, never nested under another admitted operation, so admitting it is deadlock-safe.
+   - `merge_generations_for_read_with_metadata` — the `WRITETIME`/`TTL` projection sibling.
+2. Cancellation safety: the two PURE-blocking helpers (`merge_generations_for_read`,
+   `seek_merge_generations_for_read`) MOVE the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure,
+   so a cancelled/dropped join holds the slot until the detached blocking work terminates (repeated
+   cancels can never exceed the bound). The metadata helper's permit must span an async per-reader loop
+   OUTSIDE `spawn_blocking`, so it stays an outer future guard with a documented weaker residual.
+3. Update the `scan_admission.rs` `# Scope` doc comment to reflect that the eager path is now admitted
+   (naming all three helpers + the cancellation shapes) and fix its stale `storage/sstable/mod.rs`
+   reference → `generation_merge.rs`.
+4. Add an eager-path admission bound + deadlock-freedom regression guard (a `scan-offload-probe`-gated
    test mirroring `issue_1594_scan_admission_bound.rs`, driving the eager branch via a multi-generation
-   fixture WITH a schema present).
+   fixture WITH a schema present), including end-to-end coverage of the metadata sibling and the seek
+   helper. The `scan-offload-guard` gate component runs the new test target.
 
 ## Non-goals
 - **Not** making the core admission semaphore operator-tunable. It stays auto-sized from

--- a/openspec/changes/eager-merge-admission/proposal.md
+++ b/openspec/changes/eager-merge-admission/proposal.md
@@ -40,11 +40,12 @@ Concretely:
      `WHERE pk = ?`, via `scan_partition_clustering`); its sole call site is a top-level manager
      operation, never nested under another admitted operation, so admitting it is deadlock-safe.
    - `merge_generations_for_read_with_metadata` — the `WRITETIME`/`TTL` projection sibling.
-2. Cancellation safety: the two PURE-blocking helpers (`merge_generations_for_read`,
-   `seek_merge_generations_for_read`) MOVE the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure,
-   so a cancelled/dropped join holds the slot until the detached blocking work terminates (repeated
-   cancels can never exceed the bound). The metadata helper's permit must span an async per-reader loop
-   OUTSIDE `spawn_blocking`, so it stays an outer future guard with a documented weaker residual.
+2. Cancellation safety: ALL THREE helpers hold the permit until the detached `spawn_blocking` merge
+   terminates. The two PURE-blocking helpers (`merge_generations_for_read`,
+   `seek_merge_generations_for_read`) MOVE the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure
+   directly. The metadata helper holds it as an outer future guard across its async per-reader loop
+   (cancellation there is clean — no detached blocking work yet), THEN MOVES it into the `spawn_blocking`
+   merge closure for the detached phase. Repeated cancels can never exceed the bound on any helper.
 3. Update the `scan_admission.rs` `# Scope` doc comment to reflect that the eager path is now admitted
    (naming all three helpers + the cancellation shapes) and fix its stale `storage/sstable/mod.rs`
    reference → `generation_merge.rs`.

--- a/openspec/changes/eager-merge-admission/proposal.md
+++ b/openspec/changes/eager-merge-admission/proposal.md
@@ -1,0 +1,60 @@
+# Extend blocking-pool admission to the eager multi-generation merge path
+
+## Milestone
+0.14+ read-path perf wave (Epic F, §F4). Design-driven — this is the deferred second half of #1594
+(F4), which added scan-operation admission control to the LAZY/WINDOWED path but explicitly carved out
+the EAGER `merge_generations_for_read` branch as out of scope. This change removes that carve-out so
+the most common write-support multi-generation read is bounded like the windowed path.
+
+## Why (measured problem)
+Source of truth: #1594, the read-path audit §F4, and the `# Scope` doc comment in
+`cqlite-core/src/storage/sstable/reader/scan_admission.rs:51-58`.
+
+#1594 fixed a fan-out self-deadlock and bounded concurrent windowed scans against a process-wide
+admission semaphore (sized from `available_parallelism()`), acquiring **one permit per scan operation**
+with sub-scans marked `Exempt`. But the DEFAULT write-support build's most common multi-generation
+read takes the EAGER branch — `merge_generations_for_read` (`generation_merge.rs:238`), chosen when
+`reader_list.len() > 1` AND a schema is present — which drains a `KWayMerger` inside a single
+`spawn_blocking` and **never passes through the admission semaphore**. So concurrent eager multi-gen
+scans (the schema-present common case) remain unthrottled: the priority-inversion / oversubscription
+class F4 targets is only *partially* covered, and the admission bound silently does not apply to the
+path most production reads actually use.
+
+The eager path's real footprint is `1 spawn_blocking task + M std::thread producer threads` per
+operation (M = generation count; KWayMerger, #2316) — so `cap` concurrent eager operations can pin up
+to `cap × M` producer OS threads with no ceiling on operation concurrency at all.
+
+## What changes
+Acquire the **same operation-level admission permit** at the top of the eager merge path, before its
+`spawn_blocking`, holding the RAII `ScanAdmissionPermit` across the whole operation — mirroring the
+`ScanAdmission::Acquire` arm the windowed path already uses. Because the eager path is a single
+`spawn_blocking` with no async fan-out, **one permit for the whole operation** is the exact fit and
+cannot reintroduce the #1594 hold-and-wait deadlock (there is exactly one thing wanting exactly one
+permit; the KWayMerger's producer threads are plain OS threads that never call `admit()`).
+
+Concretely:
+1. Acquire `scan_admission::admit().await` at the top of `merge_generations_for_read`
+   (`generation_merge.rs:238`) **and** its metadata sibling `merge_generations_for_read_with_metadata`
+   (`generation_merge.rs:319`) — both have the identical single-`spawn_blocking(KWayMerger)` shape and
+   are equally unadmitted today.
+2. Update the `scan_admission.rs` `# Scope` doc comment to reflect that the eager path is now admitted
+   (and fix its stale `storage/sstable/mod.rs` reference → `generation_merge.rs`).
+3. Add an eager-path admission bound + deadlock-freedom regression guard (a `scan-offload-probe`-gated
+   test mirroring `issue_1594_scan_admission_bound.rs`, driving the eager branch via a multi-generation
+   fixture WITH a schema present).
+
+## Non-goals
+- **Not** making the core admission semaphore operator-tunable. It stays auto-sized from
+  `available_parallelism()` (status quo). The Flight-layer `--max-concurrent-scans` (#2420) is a
+  separate `do_get`-boundary semaphore and is untouched. A future issue may unify/expose these.
+- **Not** re-sizing or splitting the semaphore to bound the eager path's OS-thread footprint
+  separately — this change unifies *operation* admission under the existing shared bound (consistent
+  with #1594's "operation concurrency, not total blocking threads" framing). The OS-thread-footprint
+  distinction is documented, not solved here.
+- **Not** changing the KWayMerger, the eager-vs-lazy branch selection, or the per-reader-concatenation
+  merge-error fallback.
+
+## Doctrine impact
+No public API or user-facing change. Internal concurrency behavior only. Updates the `scan_admission`
+scope doc comment; no CLAUDE.md / website change required (the admission semaphore is not a documented
+user surface).

--- a/openspec/changes/eager-merge-admission/specs/scan-admission/spec.md
+++ b/openspec/changes/eager-merge-admission/specs/scan-admission/spec.md
@@ -65,24 +65,29 @@ Admitting the eager path under the SAME semaphore as the windowed/lazy path SHAL
 - **AND** the observed `max_in_flight <= CAP` throughout (the bound held while all N eventually
   completed).
 
-### Requirement: The pure-blocking eager helpers hold the permit until the detached blocking work ends
+### Requirement: All eager helpers hold the permit until the detached blocking work ends
 
-The pure-blocking eager helpers SHALL move the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure
-so that, on cancellation (the awaiting future dropped), the admission slot is held until the detached
-blocking work actually terminates rather than released while the KWayMerger producer threads keep
-running. This applies to `merge_generations_for_read` and `seek_merge_generations_for_read`. The
-metadata helper `merge_generations_for_read_with_metadata` MAY hold the permit as an
-outer future guard instead — because its permit must span an async per-reader loop outside
-`spawn_blocking` — and its consequently weaker cancellation property (immediate release while a detached
-in-flight merge runs permit-free) SHALL be documented in the module scope doc, not silently claimed as
-equivalent.
+Every eager helper SHALL hold the `ScanAdmissionPermit` until the detached `spawn_blocking` merge work
+actually terminates, so that on cancellation (the awaiting future dropped) the admission slot is not
+released while the KWayMerger producer threads keep running. The two pure-blocking helpers
+(`merge_generations_for_read`, `seek_merge_generations_for_read`) SHALL move the permit INTO the
+`spawn_blocking` closure directly. The metadata helper `merge_generations_for_read_with_metadata` SHALL
+hold the permit as an outer future guard across its async per-reader `scan_with_cell_metadata` loop —
+where cancellation is clean because no detached blocking work exists yet, so early release is harmless —
+and SHALL THEN move the permit into its `spawn_blocking` merge closure for the detached phase. No phase
+both runs detached blocking work AND has already released the permit; the three helpers are uniformly
+cancellation-safe.
 
-#### Scenario: A pure-blocking helper's permit is captured by the blocking closure, not the outer future
+#### Scenario: Every eager helper's permit is held into the blocking closure, not released before it ends
 
-- **WHEN** the source of `merge_generations_for_read` / `seek_merge_generations_for_read` is inspected
-- **THEN** the `ScanAdmissionPermit` is moved into the `spawn_blocking` closure (bound to a `let` inside
-  it), so a dropped `JoinHandle` cannot release the permit before the detached blocking work ends
-- **AND** the metadata helper's scope-doc comment states its outer-guard cancellation residual honestly.
+- **WHEN** the source of `merge_generations_for_read` / `seek_merge_generations_for_read` /
+  `merge_generations_for_read_with_metadata` is inspected
+- **THEN** the `ScanAdmissionPermit` is moved into each helper's `spawn_blocking` closure (bound to a
+  `let` inside it), so a dropped `JoinHandle` cannot release the permit before the detached blocking
+  work ends
+- **AND** the metadata helper additionally holds the permit as an outer future guard across its async
+  per-reader loop before moving it into the closure, and the module scope doc states that all three
+  helpers are uniformly cancellation-safe.
 
 ### Requirement: The admission scope documentation reflects eager-path coverage
 
@@ -100,5 +105,5 @@ file-location reference in that doc SHALL point at the eager path's actual locat
   `seek_merge_generations_for_read`, `merge_generations_for_read_with_metadata`) as admitted
 - **AND** it correctly locates the eager path in `generation_merge.rs`
 - **AND** it documents the known limitation that the shared bound limits eager *operation* concurrency,
-  not the eager path's per-operation producer-thread footprint, and the metadata helper's weaker
-  cancellation residual.
+  not the eager path's per-operation producer-thread footprint, and states that all three eager helpers
+  are uniformly cancellation-safe.

--- a/openspec/changes/eager-merge-admission/specs/scan-admission/spec.md
+++ b/openspec/changes/eager-merge-admission/specs/scan-admission/spec.md
@@ -4,15 +4,17 @@
 
 ### Requirement: The eager multi-generation merge path acquires a scan-admission permit
 
-The eager path SHALL acquire exactly one operation-level `ScanAdmissionPermit` from the same
-process-wide admission semaphore the windowed/lazy scan path uses (#1594), covering both
-`merge_generations_for_read` and `merge_generations_for_read_with_metadata`
-(`cqlite-core/src/storage/sstable/generation_merge.rs`). The permit SHALL be acquired before the
-`KWayMerger` `spawn_blocking` work and held for the full operation (across the join `.await`), and
-SHALL be released on every exit path — success, merge error, and cancellation — via the RAII `Drop` on
-`ScanAdmissionPermit`. Acquisition SHALL be a single, top-level, once-only `admit()` with no nested
-permit acquisition inside the merge (the KWayMerger's producer threads do not acquire admission
-permits).
+Each of the THREE eager multi-generation merge helpers SHALL acquire exactly one operation-level
+`ScanAdmissionPermit` from the same process-wide admission semaphore the windowed/lazy scan path uses
+(#1594). The three helpers, in `cqlite-core/src/storage/sstable/generation_merge.rs`, are
+`merge_generations_for_read` (the materializing plain read), `seek_merge_generations_for_read` (the
+partition-seeking point read), and `merge_generations_for_read_with_metadata` (the WRITETIME/TTL
+sibling). The permit SHALL be acquired before the `KWayMerger` `spawn_blocking` work and
+held for the full operation (across the join `.await`), and SHALL be released on every exit path —
+success, merge error, and cancellation — via the RAII `Drop` on `ScanAdmissionPermit`. Acquisition SHALL
+be a single, top-level, once-only `admit()` with no nested permit acquisition inside the merge (the
+KWayMerger's producer threads do not acquire admission permits), and the seek helper's sole call site
+SHALL be a top-level manager operation that holds no outer permit (no cross-path hold-and-wait).
 
 #### Scenario: Concurrent eager multi-gen scans are bounded by the admission limit
 
@@ -26,6 +28,14 @@ permits).
   never-acquiring path would leave `max_in_flight == 0`)
 - **AND** after all reads complete, `current_in_flight == 0` — every permit was released across the
   `spawn_blocking` join (no leak on the success path).
+
+#### Scenario: The metadata sibling is bounded end-to-end
+
+- **WHEN** `N > LIMIT` concurrent `scan_with_cell_metadata` reads (WRITETIME/TTL projection) are issued
+  against the multi-generation + schema fixture, so each routes through
+  `merge_generations_for_read_with_metadata`
+- **THEN** `max_in_flight >= 1` (the metadata acquire is wired, non-vacuous), `max_in_flight <= LIMIT`
+  (the bound covers the metadata path), and `current_in_flight == 0` after (RAII release).
 
 #### Scenario: A permit is released when the eager merge errors and falls back
 
@@ -55,6 +65,25 @@ Admitting the eager path under the SAME semaphore as the windowed/lazy path SHAL
 - **AND** the observed `max_in_flight <= CAP` throughout (the bound held while all N eventually
   completed).
 
+### Requirement: The pure-blocking eager helpers hold the permit until the detached blocking work ends
+
+The pure-blocking eager helpers SHALL move the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure
+so that, on cancellation (the awaiting future dropped), the admission slot is held until the detached
+blocking work actually terminates rather than released while the KWayMerger producer threads keep
+running. This applies to `merge_generations_for_read` and `seek_merge_generations_for_read`. The
+metadata helper `merge_generations_for_read_with_metadata` MAY hold the permit as an
+outer future guard instead — because its permit must span an async per-reader loop outside
+`spawn_blocking` — and its consequently weaker cancellation property (immediate release while a detached
+in-flight merge runs permit-free) SHALL be documented in the module scope doc, not silently claimed as
+equivalent.
+
+#### Scenario: A pure-blocking helper's permit is captured by the blocking closure, not the outer future
+
+- **WHEN** the source of `merge_generations_for_read` / `seek_merge_generations_for_read` is inspected
+- **THEN** the `ScanAdmissionPermit` is moved into the `spawn_blocking` closure (bound to a `let` inside
+  it), so a dropped `JoinHandle` cannot release the permit before the detached blocking work ends
+- **AND** the metadata helper's scope-doc comment states its outer-guard cancellation residual honestly.
+
 ### Requirement: The admission scope documentation reflects eager-path coverage
 
 The `# Scope` doc comment on the admission module SHALL state that the eager multi-generation merge
@@ -67,6 +96,9 @@ file-location reference in that doc SHALL point at the eager path's actual locat
 
 - **WHEN** the `scan_admission` module `# Scope` doc comment is read
 - **THEN** it does not state that `merge_generations_for_read` is outside admission coverage
+- **AND** it names all three eager helpers (`merge_generations_for_read`,
+  `seek_merge_generations_for_read`, `merge_generations_for_read_with_metadata`) as admitted
 - **AND** it correctly locates the eager path in `generation_merge.rs`
 - **AND** it documents the known limitation that the shared bound limits eager *operation* concurrency,
-  not the eager path's per-operation producer-thread footprint.
+  not the eager path's per-operation producer-thread footprint, and the metadata helper's weaker
+  cancellation residual.

--- a/openspec/changes/eager-merge-admission/specs/scan-admission/spec.md
+++ b/openspec/changes/eager-merge-admission/specs/scan-admission/spec.md
@@ -1,0 +1,72 @@
+# scan-admission
+
+## ADDED Requirements
+
+### Requirement: The eager multi-generation merge path acquires a scan-admission permit
+
+The eager path SHALL acquire exactly one operation-level `ScanAdmissionPermit` from the same
+process-wide admission semaphore the windowed/lazy scan path uses (#1594), covering both
+`merge_generations_for_read` and `merge_generations_for_read_with_metadata`
+(`cqlite-core/src/storage/sstable/generation_merge.rs`). The permit SHALL be acquired before the
+`KWayMerger` `spawn_blocking` work and held for the full operation (across the join `.await`), and
+SHALL be released on every exit path — success, merge error, and cancellation — via the RAII `Drop` on
+`ScanAdmissionPermit`. Acquisition SHALL be a single, top-level, once-only `admit()` with no nested
+permit acquisition inside the merge (the KWayMerger's producer threads do not acquire admission
+permits).
+
+#### Scenario: Concurrent eager multi-gen scans are bounded by the admission limit
+
+- **WHEN** the admission limit is set to `LIMIT` (via the `scan-offload-probe` test override) and
+  `N > LIMIT` concurrent reads are issued against a multi-generation table WITH a schema present, so
+  each takes the eager `merge_generations_for_read` branch
+- **THEN** the observed maximum number of simultaneously-admitted operations (`max_in_flight` from the
+  probe instrumentation) is `<= LIMIT` — the eager path is now covered by the operation-concurrency
+  bound
+- **AND** `max_in_flight >= 1` — the acquire is actually wired (the assertion is non-vacuous; a
+  never-acquiring path would leave `max_in_flight == 0`)
+- **AND** after all reads complete, `current_in_flight == 0` — every permit was released across the
+  `spawn_blocking` join (no leak on the success path).
+
+#### Scenario: A permit is released when the eager merge errors and falls back
+
+- **WHEN** an eager multi-gen merge acquires a permit and its `KWayMerger` drain returns an error
+  (triggering the existing per-reader-concatenation fallback at the call site)
+- **THEN** the `ScanAdmissionPermit` is dropped as the merge function returns the error, releasing the
+  permit before the fallback path runs
+- **AND** the probe `current_in_flight` returns to `0` after the operation, so an erroring eager merge
+  does not strand a permit.
+
+### Requirement: Sharing the admission semaphore across eager and windowed paths is deadlock-free
+
+Admitting the eager path under the SAME semaphore as the windowed/lazy path SHALL NOT reintroduce the
+#1594 fan-out hold-and-wait deadlock. Because the eager path is a single `spawn_blocking` draining a
+`KWayMerger` sequentially — with no concurrent async sub-scans, no prime-then-drain, and no nested
+`admit()` call — a set of concurrent eager operations exceeding the admission limit SHALL all complete
+(each acquiring its one permit in turn), never deadlock.
+
+#### Scenario: More concurrent eager scans than the limit all complete without hanging
+
+- **WHEN** the admission limit is set to `CAP` and `N > CAP` concurrent eager multi-gen scans (schema
+  present, multiple generations) are driven at once
+- **THEN** all `N` scans complete within a bounded timeout (pre-change there was no bound; the guard
+  proves the shared semaphore does not hang under contention)
+- **AND** the total rows returned across the scans is `> 0` (the scans did real work, not a vacuous
+  early return)
+- **AND** the observed `max_in_flight <= CAP` throughout (the bound held while all N eventually
+  completed).
+
+### Requirement: The admission scope documentation reflects eager-path coverage
+
+The `# Scope` doc comment on the admission module SHALL state that the eager multi-generation merge
+path is admitted (no longer carved out) and SHALL NOT contain the stale claim that the eager path is
+out of scope. The doc lives on `cqlite-core/src/storage/sstable/reader/scan_admission.rs`. Any
+file-location reference in that doc SHALL point at the eager path's actual location
+(`generation_merge.rs`), not the pre-#1116 `storage/sstable/mod.rs`.
+
+#### Scenario: The scope doc no longer excludes the eager path
+
+- **WHEN** the `scan_admission` module `# Scope` doc comment is read
+- **THEN** it does not state that `merge_generations_for_read` is outside admission coverage
+- **AND** it correctly locates the eager path in `generation_merge.rs`
+- **AND** it documents the known limitation that the shared bound limits eager *operation* concurrency,
+  not the eager path's per-operation producer-thread footprint.

--- a/openspec/changes/eager-merge-admission/tasks.md
+++ b/openspec/changes/eager-merge-admission/tasks.md
@@ -1,37 +1,45 @@
 # Tasks — eager multi-generation merge admission
 
-## 1. Wire admission into the eager merge path
-- [ ] 1.1 In `cqlite-core/src/storage/sstable/generation_merge.rs`, acquire
+## 1. Wire admission into ALL THREE eager merge helpers
+- [x] 1.1 In `cqlite-core/src/storage/sstable/generation_merge.rs`, acquire
       `scan_admission::admit().await` at the top of `merge_generations_for_read` (before the
-      `spawn_blocking` at ~line 255), binding the RAII `ScanAdmissionPermit` (`let _admission = …`) so
-      it is held across the join `.await` and released on every exit path. Reach the module via
+      `spawn_blocking`) and MOVE the `OwnedSemaphorePermit` INTO the `spawn_blocking` closure so it is
+      held until the detached blocking work terminates (cancellation-safe). Reach the module via
       `super::reader::scan_stream_windowed::scan_admission::admit()`.
       *Surface exercised:* `merge_generations_for_read` (the eager branch at `mod.rs:1135`, `1646`).
-- [ ] 1.2 Apply the identical acquire at the top of `merge_generations_for_read_with_metadata`
-      (~line 319, before its `spawn_blocking`).
-      *Surface exercised:* the metadata eager branch at `mod.rs:1482`, `1853`.
-- [ ] 1.3 Confirm no nested `admit()` is introduced (the KWayMerger producer threads must not acquire
+- [x] 1.2 Apply the identical acquire (permit moved into the closure) at the top of
+      `seek_merge_generations_for_read`, the partition-seeking point-read merge. Verify its sole call
+      site (`scan_partition_clustering`, `mod.rs:1650`) is a top-level manager operation holding no
+      outer permit, so admission introduces no cross-path hold-and-wait.
+      *Surface exercised:* the seeking merge branch at `mod.rs:1650`.
+- [x] 1.3 Apply the acquire at the top of `merge_generations_for_read_with_metadata`. This helper's
+      permit must span the async per-reader `scan_with_cell_metadata` loop OUTSIDE `spawn_blocking`, so
+      it stays an OUTER future guard; document the consequently weaker cancellation residual honestly.
+      *Surface exercised:* the metadata eager branch at `mod.rs:1482`, `1854`.
+- [x] 1.4 Confirm no nested `admit()` is introduced (the KWayMerger producer threads must not acquire
       permits) and no `unwrap`/`expect` added to library code.
 
 ## 2. Update the scope documentation
-- [ ] 2.1 Rewrite the `# Scope` doc comment in `scan_admission.rs:51-58`: state the eager path is now
-      admitted, remove the out-of-scope claim, fix the file reference to `generation_merge.rs`, and
-      document the known limitation (shared bound = eager *operation* concurrency, not the eager path's
-      per-op producer-thread footprint).
+- [x] 2.1 Rewrite the `# Scope` doc comment in `scan_admission.rs`: state the eager path is now
+      admitted, NAME all three helpers, remove the out-of-scope claim, fix the file reference to
+      `generation_merge.rs`, and document the known limitations (shared bound = eager *operation*
+      concurrency, not the per-op producer-thread footprint; metadata helper's weaker cancellation).
 
 ## 3. Regression guard (admission bound + deadlock-freedom for the eager path)
-- [ ] 3.1 Add `cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs`, `scan-offload-probe`-gated,
+- [x] 3.1 Add `cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs`, `scan-offload-probe`-gated,
       `#[serial]` (process-global probe atomics). Drive `N > LIMIT` concurrent reads against a
       multi-generation fixture WITH a schema present (so the eager `merge_generations_for_read` branch
       is taken — verify the branch, contrast the #1594 test's `schema=None` lazy-forcing).
       *Surface exercised:* eager merge admission via the probe `max_in_flight`/`current_in_flight`.
-- [ ] 3.2 Assert `max_in_flight <= LIMIT` (bound covers eager), `max_in_flight >= 1` (acquire wired,
+- [x] 3.2 Assert `max_in_flight <= LIMIT` (bound covers eager), `max_in_flight >= 1` (acquire wired,
       non-vacuous), `current_in_flight == 0` after (RAII release). Level snapshots, never wall-clock.
-- [ ] 3.3 Add the deadlock-freedom flavor: `N > CAP` concurrent eager scans all complete within a
+- [x] 3.3 Add the deadlock-freedom flavor: `N > CAP` concurrent eager scans all complete within a
       bounded timeout AND total rows `> 0` AND `max_in_flight <= CAP`.
-- [ ] 3.4 Check whether the existing `issue_1594_scan_admission_bound.rs` fixture now also hits the
-      eager branch once wired; ensure the new guard adds distinct (multi-gen + eager) coverage, not a
-      duplicate.
+- [x] 3.4 Add an end-to-end metadata-sibling case driving `scan_with_cell_metadata` (WRITETIME/TTL) on
+      the multi-gen + schema fixture (bound + wired + release), plus a seek-helper case driving a
+      multi-candidate point read (`scan_partition`) asserting the bound + release.
+- [x] 3.5 Wire the new test into the `scan-offload-guard` gate component
+      (`--test issue_2063_eager_merge_admission_bound`) so it executes in the canonical gate.
 
 ## 4. Verify (gate + C + roborev)
 - [ ] 4.1 `--lite` green each fix round (summary-file redirect).

--- a/openspec/changes/eager-merge-admission/tasks.md
+++ b/openspec/changes/eager-merge-admission/tasks.md
@@ -12,9 +12,10 @@
       site (`scan_partition_clustering`, `mod.rs:1650`) is a top-level manager operation holding no
       outer permit, so admission introduces no cross-path hold-and-wait.
       *Surface exercised:* the seeking merge branch at `mod.rs:1650`.
-- [x] 1.3 Apply the acquire at the top of `merge_generations_for_read_with_metadata`. This helper's
-      permit must span the async per-reader `scan_with_cell_metadata` loop OUTSIDE `spawn_blocking`, so
-      it stays an OUTER future guard; document the consequently weaker cancellation residual honestly.
+- [x] 1.3 Apply the acquire at the top of `merge_generations_for_read_with_metadata`. Hold the permit as
+      an OUTER future guard across the async per-reader `scan_with_cell_metadata` loop (cancellation
+      there is clean — no detached blocking work yet), THEN move it into the `spawn_blocking` merge
+      closure for the detached phase, so it is uniformly cancellation-safe with the other two helpers.
       *Surface exercised:* the metadata eager branch at `mod.rs:1482`, `1854`.
 - [x] 1.4 Confirm no nested `admit()` is introduced (the KWayMerger producer threads must not acquire
       permits) and no `unwrap`/`expect` added to library code.
@@ -23,7 +24,7 @@
 - [x] 2.1 Rewrite the `# Scope` doc comment in `scan_admission.rs`: state the eager path is now
       admitted, NAME all three helpers, remove the out-of-scope claim, fix the file reference to
       `generation_merge.rs`, and document the known limitations (shared bound = eager *operation*
-      concurrency, not the per-op producer-thread footprint; metadata helper's weaker cancellation).
+      concurrency, not the per-op producer-thread footprint; all three helpers uniformly cancel-safe).
 
 ## 3. Regression guard (admission bound + deadlock-freedom for the eager path)
 - [x] 3.1 Add `cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs`, `scan-offload-probe`-gated,

--- a/openspec/changes/eager-merge-admission/tasks.md
+++ b/openspec/changes/eager-merge-admission/tasks.md
@@ -1,0 +1,45 @@
+# Tasks — eager multi-generation merge admission
+
+## 1. Wire admission into the eager merge path
+- [ ] 1.1 In `cqlite-core/src/storage/sstable/generation_merge.rs`, acquire
+      `scan_admission::admit().await` at the top of `merge_generations_for_read` (before the
+      `spawn_blocking` at ~line 255), binding the RAII `ScanAdmissionPermit` (`let _admission = …`) so
+      it is held across the join `.await` and released on every exit path. Reach the module via
+      `super::reader::scan_stream_windowed::scan_admission::admit()`.
+      *Surface exercised:* `merge_generations_for_read` (the eager branch at `mod.rs:1135`, `1646`).
+- [ ] 1.2 Apply the identical acquire at the top of `merge_generations_for_read_with_metadata`
+      (~line 319, before its `spawn_blocking`).
+      *Surface exercised:* the metadata eager branch at `mod.rs:1482`, `1853`.
+- [ ] 1.3 Confirm no nested `admit()` is introduced (the KWayMerger producer threads must not acquire
+      permits) and no `unwrap`/`expect` added to library code.
+
+## 2. Update the scope documentation
+- [ ] 2.1 Rewrite the `# Scope` doc comment in `scan_admission.rs:51-58`: state the eager path is now
+      admitted, remove the out-of-scope claim, fix the file reference to `generation_merge.rs`, and
+      document the known limitation (shared bound = eager *operation* concurrency, not the eager path's
+      per-op producer-thread footprint).
+
+## 3. Regression guard (admission bound + deadlock-freedom for the eager path)
+- [ ] 3.1 Add `cqlite-core/tests/issue_2063_eager_merge_admission_bound.rs`, `scan-offload-probe`-gated,
+      `#[serial]` (process-global probe atomics). Drive `N > LIMIT` concurrent reads against a
+      multi-generation fixture WITH a schema present (so the eager `merge_generations_for_read` branch
+      is taken — verify the branch, contrast the #1594 test's `schema=None` lazy-forcing).
+      *Surface exercised:* eager merge admission via the probe `max_in_flight`/`current_in_flight`.
+- [ ] 3.2 Assert `max_in_flight <= LIMIT` (bound covers eager), `max_in_flight >= 1` (acquire wired,
+      non-vacuous), `current_in_flight == 0` after (RAII release). Level snapshots, never wall-clock.
+- [ ] 3.3 Add the deadlock-freedom flavor: `N > CAP` concurrent eager scans all complete within a
+      bounded timeout AND total rows `> 0` AND `max_in_flight <= CAP`.
+- [ ] 3.4 Check whether the existing `issue_1594_scan_admission_bound.rs` fixture now also hits the
+      eager branch once wired; ensure the new guard adds distinct (multi-gen + eager) coverage, not a
+      duplicate.
+
+## 4. Verify (gate + C + roborev)
+- [ ] 4.1 `--lite` green each fix round (summary-file redirect).
+- [ ] 4.2 Review-first on the lite-green diff: `rust-reviewer` + roborev
+      (`--agent codex --model gpt-5.6-sol`). Focus: deadlock-freedom of the shared-semaphore acquire,
+      RAII release on error/cancel, non-vacuous guard.
+- [ ] 4.3 ONE full `agent-gate.sh` of record (via flow-closer) — the new `scan-offload-probe` guard
+      must PASS in its lane; confirm no bound/deadlock regression.
+- [ ] 4.4 C (spec-auditor) anchored to `openspec/changes/eager-merge-admission/specs/**`: every
+      requirement `satisfied` with a public-surface test as evidence.
+- [ ] 4.5 Merge on green (gate PASS + C PASS + roborev clean + required CI green), then archive.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -38,7 +38,12 @@
 #                      scheduling change is data-transparent — issue #1593); and the
 #                      F4 admission guard --test issue_1594_scan_admission_bound
 #                      (concurrent windowed scans admitted to the blocking pool
-#                      never exceed the admission limit — issue #1594). It then
+#                      never exceed the admission limit — issue #1594); and the
+#                      eager-merge admission guard
+#                      --test issue_2063_eager_merge_admission_bound (concurrent
+#                      write-support multi-generation EAGER-materialize scans are
+#                      bounded by the SAME operation-concurrency semaphore — issue
+#                      #2063). It then
 #                      runs a SECOND invocation: cargo test -p cqlite-core --lib
 #                      --features cli-helpers,scan-offload-probe --
 #                      scan_admission issue_1594_fanout_deadlock — the fan-out
@@ -3255,6 +3260,7 @@ run_scan_offload_guard_cmd() {
     --test issue_1593_io_offload_thread \
     --test issue_1593_mmap_scan_parity \
     --test issue_1594_scan_admission_bound \
+    --test issue_2063_eager_merge_admission_bound \
     && cargo test --package cqlite-core --lib \
     --features cli-helpers,scan-offload-probe \
     -- scan_admission issue_1594_fanout_deadlock


### PR DESCRIPTION
Closes #2063. Design-driven — OpenSpec change `eager-merge-admission` (proposal + design + specs + tasks, `openspec validate --strict` clean).

## What
Extends the #1594 process-wide scan-admission semaphore to cover the **eager** multi-generation merge path, which the original F4 work explicitly carved out. Before this, the DEFAULT write-support build's most common multi-gen read (the eager branch, taken when `reader_list.len() > 1` AND a schema is present) drained a `KWayMerger` in a `spawn_blocking` and never passed through admission — so concurrent eager scans were unbounded.

## How
A single top-level operation-level `admit()` is acquired at the top of **all three** eager helpers in `generation_merge.rs`, and the `ScanAdmissionPermit` is **moved into the `spawn_blocking` closure** so it is held until the *detached* blocking merge terminates (cancellation-safe — a dropped awaiting future cannot release the permit while producer threads still run):
- `merge_generations_for_read` (full-scan eager branch)
- `seek_merge_generations_for_read` (partition point-read path)
- `merge_generations_for_read_with_metadata` (WRITETIME/TTL projection) — permit held as outer guard through the async `scan_with_cell_metadata` collection, then moved into the final blocking merge closure.

## Deadlock-freedom
Verified (rust-reviewer + roborev): each acquire is a single top-level once-only `admit()` with no nested acquisition. The KWayMerger producers are plain `std::thread`s that never call `admit()`; no eager or windowed operation holds a permit while waiting for another to acquire one → the #1594 hold-and-wait cycle cannot re-form. `scan_admission.rs` `# Scope`/deadlock-freedom doc updated (stale `mod.rs` ref → `generation_merge.rs`).

## Tests
New `scan-offload-probe`-gated guard `tests/issue_2063_eager_merge_admission_bound.rs` (4 cases): full-scan eager, metadata eager, and seek point-read (target written into **both** generations → non-vacuous, `max_admitted >= 1` unconditional), plus a deadlock-freedom flavor (N > CAP all complete, bound held). Wired into the gate's `scan-offload-guard` component (`run_scan_offload_guard_cmd`).

## Review
Review-first: rust-reviewer + roborev(codex), converged over 3 rounds (2 MEDIUM → 1 MEDIUM+1 LOW → 1 LOW). Fixed: third unadmitted helper, guard-test-not-in-gate, metadata-path cancellation. Remaining LOW (a cancellation-*barrier* test harness to prove the lifetime the code already implements) → follow-up #2567.

## File-size
`generation_merge.rs` was already > 800 lines on `origin/main` (pre-existing, epic #1116) — full gate runs with `CQLITE_ALLOW_FILE_GROWTH=1`.

Refs #1594, #1116, #2567.