### PR TITLE
docs(#2452): record reader_opens/rebind_hits_total as intentionally OTel-unmirrored

### DIFF
--- a/cqlite-flight/src/warm/metrics.rs
+++ b/cqlite-flight/src/warm/metrics.rs
@@ -173,11 +173,23 @@ pub struct WarmMetricsSnapshot {
     /// Refresh outcomes = fail-closed-retained.
     pub refresh_fail_closed_retained: u64,
     /// Total `SSTableReader::open` calls — the work-done probe (0 on a warm hit).
+    ///
+    /// **Programmatic-stats-only, NOT mirrored to OTel by design** (issue #2452
+    /// item 3; spec `flight-warm-snapshot-closure`, §D). Unlike the warm cache
+    /// hit/miss/evict/refresh counters (`WARM_CACHE_*`), `reader_opens` is
+    /// exposed ONLY through this snapshot — the authoritative surface for
+    /// round-over-round field verification. Its absence from the OTel counter
+    /// export is intentional, not a gap, so a field probe / audit does not
+    /// mistake it for a bug.
     pub reader_opens: u64,
     /// Total cached readers rebound to a fresh same-inode snapshot path
     /// (issue #2383/#2356). `0` on a pure warm hit (path unchanged) and on a
     /// full rebuild; `> 0` only when a fresh snapshot dir rolled over and the
     /// cached parsed state was repointed to it without re-parse.
+    ///
+    /// **Programmatic-stats-only, NOT mirrored to OTel by design** (issue #2452
+    /// item 3; spec `flight-warm-snapshot-closure`, §D) — same intentional
+    /// snapshot-only exposure as [`Self::reader_opens`].
     pub rebind_hits: u64,
 }
 


### PR DESCRIPTION
Addresses **item 3 (doc note)** of #2452.

Records — in the actual project source, not just a closed issue — that the warm-snapshot work-probe counters `reader_opens` and `rebind_hits` are exposed ONLY via the programmatic `WarmMetricsSnapshot` stats surface and are **intentionally NOT mirrored to the OTel counter export**, unlike the sibling warm-cache hit/miss/evict/refresh counters (`WARM_CACHE_*`). This is an already-made design decision (PR #2425 / #2356 / #2306); the `flight-warm-snapshot-closure` spec §D already states it. The note lives on the two public `WarmMetricsSnapshot` fields in `cqlite-flight/src/warm/metrics.rs` — the highest-value, most-durable location, since that struct IS the surface a field probe / audit reads. This prevents mistaking the missing OTel mirror for a bug.

Doc-only change; no logic touched. Lite gate PASS (fmt/clippy/scoped-tests/file-size all green).

Items 1-2 of #2452 (ref-counted window retirement, grace-sweep offload) remain — blocked on JDK availability in this environment, tracked in #2452, so this PR does **not** close the issue.