### PR TITLE
feat(#2012): xtask static audit for the no-unbounded-materialization invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ ad-hoc cargo runs never count. `scripts/agent-gate.sh --list` shows the componen
 
 | Mode | Command | Use |
 |------|---------|-----|
-| **Full** — the gate of record | `scripts/agent-gate.sh` | ONCE per issue, immediately pre-merge, inside `flow-closer`. fmt, clippy `-D warnings`, core/integration/write/CLI tests, minimal-features build, smoke. Emits `AGENT-GATE SUMMARY`. |
+| **Full** — the gate of record | `scripts/agent-gate.sh` | ONCE per issue, immediately pre-merge, inside `flow-closer`. fmt, clippy `-D warnings`, core/integration/write/CLI tests, `oom-audit` (SKIP-aware structural no-unbounded-materialization audit, #2012), minimal-features build, smoke. Emits `AGENT-GATE SUMMARY`. |
 | **Lite** (#1821, ~1–5 min) | `scripts/agent-gate.sh --lite` | EVERY fix round. file-size + fmt + scoped clippy + blast-radius tests (touched package `--lib` + diff's new `--test` targets, mapped from `git diff origin/main...HEAD`; defaults to `cqlite-core --lib` when no rust package is in the diff). Emits a DISTINCT `AGENT-GATE LITE SUMMARY` (MODE: lite) — can NEVER be pasted as the full SUMMARY. |
 | **Delta** (#1892) | `scripts/agent-gate.sh --delta <anchor-sha> --anchor-run-id <id>` (or `--anchor-summary-file <path>`) | Re-certify a post-full-PASS polish round whose diff is ONLY executable tests/docs (rust test code, python/node binding tests against an already-built module, `scripts/tests/*.sh`, `*.md`; #2081). FAILs CLOSED on anything else (src, scripts, workflows, `Cargo.*`, config, test-data, unbuilt node module) — never builds, never passes vacuously. Emits a DISTINCT `AGENT-GATE DELTA SUMMARY` naming the anchor + a `delta-executors:` line; record BOTH it AND the anchor's full SUMMARY in the PR. NOT the gate of record. |
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "tests/format-compatibility",
     "examples",
     "tools/*",
+    "xtask",
 ]
 # The cargo-fuzz crate (issue #1614) is its own workspace (`fuzz/Cargo.toml` has
 # an empty `[workspace]` table). Exclude it here too so no default `cargo

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -198,4 +198,39 @@ Recovery default: `.agent-gate-delta-summary.txt`.
 
 ---
 
+## The `oom-audit` component (issue #2012)
+
+`oom-audit` is a SKIP-aware full-gate component that structurally audits the
+codebase for the "never materialize an unbounded read" memory-safety invariant.
+It runs the `xtask` crate's static AST audit — `cargo run -p xtask -- oom-audit
+--enforce` — over a committed v1 scope (`cqlite-core/.../data_access/**`,
+`cqlite-core/src/query/**`, and the `cqlite-flight` producers + `streaming.rs`).
+
+- **Rule (v1): `STREAM_RETURNS_VEC`.** A `syn`-based (never regex) per-function,
+  path-scoped rule that flags a `.collect::<Vec<..>>()` or a `Vec::push`/`extend`
+  loop over a row/partition/cell iterator in a scan/producer function when no
+  bound (`ResultBudget`, a `buffer_size`/`batch_size`/`limit`/`max_*` param, or a
+  `.take(n)`) is in scope. It fires only when both the shape and the iterator
+  element type are syntactically visible (favor false-negatives), so its residue
+  is small and reviewable. Rules 2 & 3 (`UNBOUNDED_RANGE_READ`,
+  `CLONE_IN_SCAN_CLOSURE`) and the wider surface are deferred follow-ups.
+- **SKIP-aware (delivery-telemetry model):** no `cargo`, an absent `xtask` crate,
+  or a failed `xtask` build → **SKIP** (loud, never a silent PASS); a clean build
+  whose enforce run exits non-zero → **FAIL**; otherwise **PASS**. Not in
+  `DATASET_COMPONENTS` (it reads source, needs no SSTable fixtures).
+- **Suppression — the allowlist** (`xtask/oom-audit-allowlist.toml`): the ONLY
+  way to suppress a finding. Each entry carries a content fingerprint (`f1:<hex>`,
+  reformat-stable, changes when the code changes) plus a **mandatory non-empty
+  `issue`** and **mandatory non-empty `justification`**. An entry whose
+  fingerprint matches no current finding is **orphaned** and FAILs (the list
+  cannot rot); `expiry` is **optional** and FAILs only when present-and-past (per
+  design fork F-expiry — no mandatory wall-clock time bomb; review cadence is
+  manual). The v1 seeded allowlist is empty (the report is clean over scope).
+- **Self-test:** `scripts/tests/test_agent_gate_oom_audit.sh` (run inside the
+  `tooling-tests` component) drives `agent-gate.sh --only oom-audit` to assert the
+  SKIP/FAIL/PASS outcomes via the `OOM_AUDIT_XTASK_DIR` / `CQLITE_OOM_AUDIT_ROOT`
+  test seams.
+
+---
+
 Back to [`CLAUDE.md`](../../CLAUDE.md).

--- a/openspec/changes/oom-audit-xtask/design.md
+++ b/openspec/changes/oom-audit-xtask/design.md
@@ -1,0 +1,113 @@
+# Design — xtask static audit for no-unbounded-materialization (#2012)
+
+A **lint, not a prover.** The goal is to catch the recognizable *shape* of the recurring OOM class
+(#2361 whole-SSTable Vec, #2230/#2423 whole-partition Vec, #1517 hot-path copies) at PR time, cheaply
+and with a near-zero false-positive rate, backed by a reviewable allowlist. Soundness gaps are accepted
+and remain covered by the existing runtime guards (`ResultBudget`, `byte-budget-guard`,
+`scan-offload-guard`, `work-counters-guard`, `memory-budget`).
+
+## Context / in-tree anchors (this worktree; `main`-relative, will drift — re-grep)
+- **Runtime budget:** `cqlite-core/src/query/result_budget.rs` (`ResultBudget`).
+- **Scan entry points named by the issue:** `StorageEngine::scan_stream`
+  (`cqlite-core/src/storage/mod.rs:495`), the SSTable scan surface
+  (`cqlite-core/src/storage/sstable/reader/data_access/sequential.rs` — `scan` :64, `scan_stream`
+  :309, `run_scan_stream` :360, `scan_for_key` :659), and the select executor
+  (`cqlite-core/src/query/select_executor.rs`).
+- **Flight producer path:** `cqlite-flight/src/producer.rs`, `producer_stream.rs`, `producer_point.rs`,
+  `producer_warm.rs`, `streaming.rs`.
+- **Gate wiring model:** `run_delivery_telemetry` (`scripts/agent-gate.sh` :1633) — the SKIP-aware
+  component template; `COMPONENTS=` (:1042); the dispatch `case` (:3394). Sibling guards
+  `run_scan_offload_guard_cmd` (:3107), `byte-budget-guard` (:3180).
+- **Workspace:** root `Cargo.toml` `[workspace] members` lists crates explicitly; `fuzz/` is
+  `exclude`d as its own workspace. No `xtask` crate exists yet. `[workspace.lints.rust]` denies
+  `unused_imports`.
+
+## A — Workspace membership of `xtask` (chosen: member)
+**Chosen: `xtask` is a normal workspace member**, added to `[workspace] members`, depending only on
+`syn` (with `full`/`visit` features), `quote` (for fingerprint normalization), `walkdir`, and `toml`.
+Rationale: `cargo run -p xtask -- oom-audit` must resolve against the workspace; membership gives it
+`fmt`/`clippy` coverage and the shared lockfile. It pulls **no** cqlite crate, so it never enters the
+`cqlite-core`/`cqlite-flight` build graph — a plain `cargo build`/`test` of the core packages does not
+compile it, and the SKIP-aware gate component isolates its build from the rest of the gate.
+**Rejected:** the `fuzz/`-style *excluded* separate workspace — that split exists because cargo-fuzz
+needs nightly + libFuzzer; `xtask` is stable and wants to be a first-class `-p` target and be linted.
+
+## B — What the v1 rule recognizes (STREAM_RETURNS_VEC), and what it does not
+**Chosen: one precise syntactic rule, function-local, path-scoped.** Within a function whose file is in
+scope and whose name/signature marks it a scan/producer path (`scan*`, `run_scan*`, `produce*`,
+`iterate_*partitions*`, or a fn returning/holding a row/partition/cell iterator), flag:
+- `EXPR.collect::<Vec<_>>()` / `collect::<Vec<T>>()` where `EXPR` is (transitively, within the
+  expression) an iterator over a row/partition/cell type, **and**
+- a `let mut v = Vec::new(); ... loop/while/for { v.push(..) | v.extend(..) }` accumulation fed by such
+  an iterator,
+
+**unless** a bound is in scope for the function: a `ResultBudget` binding/param, a param named
+`buffer_size`/`batch_size`/`limit`/`max_*`, or a `.take(n)` on the accumulated iterator.
+
+**Deliberately NOT in v1** (accepted soundness gaps, documented, covered by runtime guards):
+- interprocedural cases (a helper returns the `Vec`, caller streams it) — no call-graph proof;
+- `Rule 2 UNBOUNDED_RANGE_READ` and `Rule 3 CLONE_IN_SCAN_CLOSURE` (issue's other rules) — higher
+  false-positive; separate follow-up change.
+
+The row/partition/cell "iterator-ness" is decided from the syntactic type where present
+(`impl Iterator<Item = ...Row/Cell/Partition...>`, `RecordBatch`, known scan return aliases) — a
+conservative allowlist of type-name fragments, not inference. When the type is not syntactically
+visible, the rule does **not** fire (favor false-negatives over false-positives — this is the whole
+point of the allowlist-backed lint posture).
+
+## C — Allowlist format and the anchor-drift problem (chosen: content fingerprint)
+**Chosen: allowlist keyed on a content fingerprint, not `file:line`.** Line numbers drift on every edit,
+producing spurious "moved" churn. Each entry:
+```toml
+[[allow]]
+file = "cqlite-core/src/storage/sstable/statistics/reader.rs"
+fn = "parse_statistics"
+# fingerprint = blake3 of the syn-normalized (whitespace/renamed-local-insensitive) offending expr
+fingerprint = "b3:9f2c…"
+issue = "#2012"
+justification = "Statistics.db is bounded-small (< a few KB); whole-file parse is sound."
+# expiry = "2026-12-31"   # optional; when present, a past date fails the audit
+```
+- **Orphaned** (fingerprint matches nothing in scope) → FAIL. Keeps the list from rotting.
+- Missing `issue`/`justification` → FAIL. Every suppression is reviewable and attributable.
+- `expiry` optional (see fork F).
+The fingerprint is the `quote`-normalized token stream of the offending expression hashed — stable
+across reformatting and local renames, changes when the code changes (so a real new materialization at
+a previously-allowed site re-fires).
+
+## D — Modes, exit codes, and gate wiring (chosen: SKIP-aware like delivery-telemetry)
+- `cargo run -p xtask -- oom-audit` → report-only, exit `0` always.
+- `cargo run -p xtask -- oom-audit --enforce` → exit non-zero on any unallowlisted finding / orphan /
+  malformed / expired entry.
+- New `run_oom_audit` gate function on the `run_delivery_telemetry` template: `command -v cargo` absent
+  or `cargo build -p xtask` fails → `SKIP` (loud); build ok + audit non-zero → `FAIL`; else `PASS`.
+  Added to full `COMPONENTS`, to the dispatch `case`, and **not** to `DATASET_COMPONENTS` (self-guarding,
+  no datasets). Runtime target < ~30s over the v1 scope; the `xtask` build is cached across gate runs.
+
+## E — Seeding so it lands green (chosen: report-only → triage → seed → enforce)
+Two-stage delivery within the one PR/branch:
+1. Build the tool + `STREAM_RETURNS_VEC` + allowlist machinery; run report-only; **triage every hit**;
+   seed the allowlist for reviewed-sound sites (each with issue + justification). Self-test fixtures
+   (a crate-local `tests/fixtures/` pair: one violating, one bounded) prove both directions.
+2. Only once report is clean, add the `oom-audit` component in `--enforce` and update gate docs.
+The component therefore never lands red. False-positive posture: the rule favors false-negatives
+(fires only when the shape *and* iterator type are syntactically visible), so the seeded allowlist is
+expected to be short and to consist of genuinely-bounded whole-buffer reads (e.g. small Statistics.db).
+
+## Open forks for Seam 1 (owner decides)
+1. **Scope width (F-scope).** Recommended v1 = `cqlite-core/.../data_access/**` + `cqlite-core/query/**`
+   + `cqlite-flight` producers only, per the task's constraint (5). The issue text lists a wider set
+   (`export`, `bindings/python`, `bindings/node`, `tools/`). Confirm v1 = narrow, wider surface as
+   follow-ups — or widen now.
+2. **Expiry semantics (F-expiry).** The issue mandates an **expiry date per entry**; but a mandatory
+   expiry is a wall-clock time bomb — the gate can fail red on a date when nobody touched the code
+   (the same hazard as the "wall-clock races in tests" self-check class). **Recommended:** make
+   `issue` + `justification` **mandatory** and `expiry` **optional** (still fails when present-and-past),
+   with a periodic manual allowlist-review cadence instead of forced per-entry expiry. Owner may instead
+   insist on mandatory expiry with a long default horizon.
+3. **Rule 2/3 timing (F-rules).** Confirm `UNBOUNDED_RANGE_READ` + `CLONE_IN_SCAN_CLOSURE` are separate
+   follow-up changes (recommended) vs bundled here (raises false-positive risk and landing difficulty).
+4. **Lite-tier membership (F-tier).** The AC asks for < ~30s "so it fits the lite gate tier," but
+   `--lite` today is `file-size fmt clippy scoped-tests` only. Recommended: add `oom-audit` to the
+   **full** `COMPONENTS` (parity with the sibling guards) and leave lite unchanged; optionally add it to
+   `--lite` later if runtime proves trivial. Owner confirms tier.

--- a/openspec/changes/oom-audit-xtask/design.md
+++ b/openspec/changes/oom-audit-xtask/design.md
@@ -62,8 +62,8 @@ producing spurious "moved" churn. Each entry:
 [[allow]]
 file = "cqlite-core/src/storage/sstable/statistics/reader.rs"
 fn = "parse_statistics"
-# fingerprint = blake3 of the syn-normalized (whitespace/renamed-local-insensitive) offending expr
-fingerprint = "b3:9f2c…"
+# fingerprint = FNV-1a-64 of the syn-normalized token stream of the offending expr (see below)
+fingerprint = "f1:9f2c…"
 issue = "#2012"
 justification = "Statistics.db is bounded-small (< a few KB); whole-file parse is sound."
 # expiry = "2026-12-31"   # optional; when present, a past date fails the audit
@@ -71,9 +71,15 @@ justification = "Statistics.db is bounded-small (< a few KB); whole-file parse i
 - **Orphaned** (fingerprint matches nothing in scope) → FAIL. Keeps the list from rotting.
 - Missing `issue`/`justification` → FAIL. Every suppression is reviewable and attributable.
 - `expiry` optional (see fork F).
-The fingerprint is the `quote`-normalized token stream of the offending expression hashed — stable
-across reformatting and local renames, changes when the code changes (so a real new materialization at
-a previously-allowed site re-fires).
+The fingerprint is the `quote`-normalized token stream of the offending expression hashed with a
+small in-tree **FNV-1a-64** (`f1:` prefix), not blake3 — the crate's dependencies are capped at
+syn/quote/walkdir/toml, and FNV-1a is deterministic and stable across Rust versions/platforms
+(unlike `std`'s SipHash `DefaultHasher`), which a committed fingerprint requires. It is stable across
+reformatting (whitespace is normalized away) but **rename-sensitive**: the token stream includes
+identifiers, so renaming a local changes the fingerprint. This is the safe direction — a rename
+orphans the allowlist entry (→ FAIL, demanding a re-review) rather than silently keeping a stale
+suppression alive. It still changes when the code changes, so a real new materialization at a
+previously-allowed site re-fires. (Impl: `xtask/src/oom_audit/fingerprint.rs`.)
 
 ## D — Modes, exit codes, and gate wiring (chosen: SKIP-aware like delivery-telemetry)
 - `cargo run -p xtask -- oom-audit` → report-only, exit `0` always.

--- a/openspec/changes/oom-audit-xtask/proposal.md
+++ b/openspec/changes/oom-audit-xtask/proposal.md
@@ -1,0 +1,84 @@
+# xtask static audit for the no-unbounded-materialization invariant (#2012)
+
+## Milestone
+0.15 — the cqlite-trino latency/throughput/operations theme (epic #2403, Lane: memory).
+**Design-driven — OpenSpec + Seam 1 required before any implementation.** This change adds *tooling
+and a gate component*; it is a process/infrastructure decision (a new structural gate), hence OpenSpec
+rather than an oracle-driven bug fix. No `Value` decode, comparator, ordering, or on-disk-format
+behavior changes.
+
+## Problem
+"Never materialize an unbounded read" is CQLite's central memory-safety invariant, but it is enforced
+only *at points*, never *structurally*:
+
+- `cqlite-core/src/query/result_budget.rs` enforces a byte budget **at runtime**.
+- The `byte-budget-guard` / `scan-offload-guard` / `work-counters-guard` / `memory-budget` gate
+  components (`scripts/agent-gate.sh` `COMPONENTS=`, line 1042) exercise **specific known paths**
+  with pinned regression tests.
+- Past incidents live as tribal knowledge in code comments (#1591 read-guard-across-I/O, #1573
+  seek-cursor mutex).
+
+Nothing catches a **new** unbounded materialization spliced into a streaming path. The recurring
+failure class is concrete and expensive:
+
+- **#2361** — the UNCOMPRESSED scan path materialized the *whole SSTable* into a `Vec` before the
+  first emit (LIMIT was consumer-only, so it never fired).
+- **#2230 / #2423** — `KWayMerger::step` and the point-read/cache-warm merge materialized the *whole
+  partition* before emit; `LIMIT`/`batch_size` did not bound intra-partition memory.
+- **#1517 (Epic E)** findings — per-row clones/copies in hot scan closures.
+
+Each was found *after the fact*, in production or field runs. A regex/grep guard cannot catch these:
+string matching is exactly what misses a renamed helper, a refactored closure, or an owned-`Vec`
+return spliced in from another module. The invariant deserves a structural, AST-level gate.
+
+## Proposed change
+Add a small **`xtask` crate** to the workspace implementing a `syn`-based AST audit invoked as
+`cargo run -p xtask -- oom-audit [--enforce]`, wired as a **SKIP-aware `oom-audit` agent-gate
+component** (the `delivery-telemetry` model: SKIP loud if the tool can't build; FAIL hard on a real
+violation). This is deliberately a **lint, not a prover** — it recognizes committed *shapes*, not a
+proof of boundedness.
+
+**v1 rule (this change):** `STREAM_RETURNS_VEC` — a `.collect::<Vec<_>>()` or a `Vec::push`/`Vec::extend`
+loop over a **row/partition/cell iterator** in a **reader/producer scan function**, with **no
+intervening budget/batch bound** (`ResultBudget`, a `buffer_size`/`batch_size`/`limit` parameter, or a
+`take(n)`) in scope. Detected syntactically per function, path-scoped — no interprocedural call-graph
+proof.
+
+**Scope (v1, per owner constraint):** `cqlite-core/src/storage/sstable/reader/data_access/**` +
+`cqlite-core/src/query/**` + `cqlite-flight/src/producer*.rs` / `streaming.rs`. The wider surface
+(`export`, `bindings/python`, `bindings/node`, `tools/`, write path) and the higher-false-positive
+rules (`UNBOUNDED_RANGE_READ`, `CLONE_IN_SCAN_CLOSURE`) are **explicitly deferred** to follow-ups so
+v1 lands green and precise.
+
+**Suppression:** a single committed allowlist TOML. Every entry carries a **content fingerprint** (not
+a line number — lines drift), a **mandatory `issue =` link**, and a **mandatory `justification =`**
+string. An entry whose fingerprint no longer matches any source (**orphaned**) fails the audit, so the
+allowlist cannot rot. Optional `expiry =` date; when present, an expired entry fails.
+
+**Landing safely (seeding):** land **report-only first**. Stage 1 runs the audit, triages every hit,
+and seeds the allowlist for the reviewed-and-sound sites (each with issue + justification). Only once
+the report is clean does Stage 2 flip the gate component to `--enforce`. The component never lands red.
+
+## Non-goals
+- **Not a prover.** No interprocedural reachability / dataflow proof of boundedness; committed
+  syntactic shapes only. Soundness gaps are accepted and covered by the runtime guards that already exist.
+- **No whole-workspace scope in v1** — `export`/bindings/`tools`/write path are follow-ups.
+- **Rules 2 & 3 deferred** (`UNBOUNDED_RANGE_READ`, `CLONE_IN_SCAN_CLOSURE`) — higher false-positive,
+  separate change.
+- **No runtime behavior change** — this is build-time tooling; zero effect on read/write output bytes.
+- **No new library dependency in cqlite-core / cqlite-flight** — `syn`/`quote`/`walkdir`/`toml` live
+  only in the `xtask` crate.
+- **No format, comparator, or no-heuristics-doctrine change.**
+
+## Doctrine impact
+- Reinforces the no-heuristics + memory-budget doctrine with a structural gate; no doctrine *text*
+  change to the invariant itself.
+- CLAUDE.md gate table + `docs/development/gate-ops.md` (or the gate-contract website page) gain a
+  one-line `oom-audit` component entry, in-change per the keep-doctrine-current rule.
+
+## Definition of done
+`scripts/agent-gate.sh` full PASS (SUMMARY recorded, `oom-audit` component PASS/SKIP as designed) +
+spec-auditor **C** PASS (every requirement `satisfied` with a public-surface test as evidence: the
+self-test fixtures below) + roborev clean; `RUSTFLAGS="-D warnings"` clean; no `unwrap()`/`expect()` in
+the tool's own non-test paths where a real error is reachable; audit runtime under ~30s on the scoped
+set. Then `openspec archive`.

--- a/openspec/changes/oom-audit-xtask/specs/oom-audit-xtask/spec.md
+++ b/openspec/changes/oom-audit-xtask/specs/oom-audit-xtask/spec.md
@@ -1,0 +1,147 @@
+# oom-audit-xtask
+
+## ADDED Requirements
+
+### Requirement: A syn-based AST audit, not string matching
+
+The `xtask` crate SHALL implement the `oom-audit` subcommand as an AST audit that parses each in-scope
+`.rs` file with `syn` and evaluates rules over the parsed syntax tree, and SHALL NOT decide violations
+by regex or substring matching. It SHALL restrict analysis to a committed set of scope roots, so files
+outside scope are neither parsed nor reported.
+
+#### Scenario: A renamed helper with the same shape is still caught
+
+- **GIVEN** a scoped scan function containing an unbounded `.collect::<Vec<_>>()` over a row iterator
+- **WHEN** the same body is refactored so the collecting helper and its variables are renamed but the
+  syntactic shape is unchanged
+- **THEN** the audit reports the violation in both the original and renamed forms (it matches on the
+  parsed shape, not on identifier text).
+
+#### Scenario: A file outside the configured scope roots is not analyzed
+
+- **GIVEN** a `.rs` file outside the committed scope roots that contains the violating shape
+- **WHEN** the audit runs
+- **THEN** that file produces no finding (scope is enforced by path, not by content).
+
+### Requirement: STREAM_RETURNS_VEC detects unbounded materialization in scan/producer functions
+
+The audit SHALL implement a `STREAM_RETURNS_VEC` rule that flags, within a reader/producer scan
+function in scope, a `.collect::<Vec<_>>()` or a `Vec::push`/`Vec::extend` accumulation loop over a
+row/partition/cell iterator when no budget or bound is in scope for that function. A budget/bound SHALL
+be recognized as any of: a `ResultBudget` in scope, a `buffer_size` / `batch_size` / `limit` /
+`max_*` parameter, or an iterator adaptor that bounds the accumulation (`.take(n)`). The rule SHALL be
+evaluated per function using in-scope syntax only; it SHALL NOT attempt interprocedural reachability.
+
+#### Scenario: An unbounded collect on a scan path is flagged
+
+- **GIVEN** a scoped scan function that collects a partition/row iterator into an owned `Vec` with no
+  `ResultBudget`, bound parameter, or `.take(n)` in scope
+- **WHEN** the audit runs in report mode
+- **THEN** it emits a `STREAM_RETURNS_VEC` finding naming the file, the enclosing function, and the
+  offending expression.
+
+#### Scenario: The same collect with a budget in scope is not flagged
+
+- **GIVEN** an otherwise identical scan function that threads a `ResultBudget` (or a `batch_size` /
+  `.take(limit)` bound) through the accumulation
+- **WHEN** the audit runs
+- **THEN** it emits no `STREAM_RETURNS_VEC` finding for that function (the bound suppresses it
+  structurally, with no allowlist entry required).
+
+### Requirement: Suppression only via a committed allowlist with justification, issue link, and no orphans
+
+Findings SHALL be suppressible only through a single committed allowlist TOML in which every entry
+carries a content fingerprint of the allowed site, a non-empty `issue =` reference, and a non-empty
+`justification =` string. An entry whose fingerprint matches no current in-scope source ("orphaned")
+SHALL fail the audit. When an optional `expiry =` date is present and has passed, that entry SHALL fail
+the audit. An allowlist entry missing `issue` or `justification` SHALL fail the audit.
+
+#### Scenario: A fingerprint-matched allowlist entry suppresses its finding
+
+- **GIVEN** a reviewed, sound whole-file read whose site is in the allowlist with a matching
+  fingerprint, an issue link, and a justification
+- **WHEN** the audit runs in enforce mode
+- **THEN** that site produces no failing finding.
+
+#### Scenario: An orphaned allowlist entry fails the audit
+
+- **GIVEN** an allowlist entry whose fingerprint no longer matches any in-scope source (the code was
+  removed or changed)
+- **WHEN** the audit runs
+- **THEN** the audit fails and names the orphaned entry (the allowlist cannot silently rot).
+
+#### Scenario: An allowlist entry missing an issue link or justification fails
+
+- **GIVEN** an allowlist entry with an empty or absent `issue` or `justification` field
+- **WHEN** the audit runs
+- **THEN** the audit fails and names the malformed entry.
+
+#### Scenario: An expired allowlist entry fails
+
+- **GIVEN** an allowlist entry carrying an `expiry` date in the past
+- **WHEN** the audit runs
+- **THEN** the audit fails and names the expired entry.
+
+### Requirement: Report-only and enforce modes with a fail-closed enforce exit code
+
+The `oom-audit` subcommand SHALL support a report-only default that prints findings and exits `0`
+regardless of findings, and an `--enforce` mode that exits non-zero when any non-allowlisted finding,
+orphaned entry, malformed entry, or expired entry is present. A self-test fixture deliberately
+introducing the violating shape SHALL cause `--enforce` to exit non-zero.
+
+#### Scenario: A newly introduced violation fails enforce mode
+
+- **GIVEN** the self-test fixture that plants a `.collect::<Vec<_>>()` on a scoped scan path with no
+  bound and no allowlist entry
+- **WHEN** the audit runs with `--enforce`
+- **THEN** the process exits non-zero and the finding is named in the output.
+
+#### Scenario: Report-only mode never fails the build
+
+- **GIVEN** the same fixture present and unallowlisted
+- **WHEN** the audit runs in report-only mode (no `--enforce`)
+- **THEN** findings are printed but the process exits `0`.
+
+### Requirement: A SKIP-aware oom-audit agent-gate component
+
+`scripts/agent-gate.sh` SHALL run `oom-audit` as a component that invokes the audit in `--enforce`
+mode, is a hard FAIL on a real violation, and is loudly SKIP (never a silent PASS) when the `xtask`
+crate cannot build or `cargo` is unavailable — following the `delivery-telemetry` SKIP-aware model.
+The component SHALL be listed in the full `COMPONENTS` set and documented in the gate contract.
+
+#### Scenario: A violation on a scoped path fails the gate component
+
+- **GIVEN** a scoped scan path carrying an unallowlisted violating shape
+- **WHEN** the `oom-audit` gate component runs
+- **THEN** it records FAIL for that component.
+
+#### Scenario: The component skips loudly when the tool cannot build
+
+- **GIVEN** an environment where the `xtask` crate cannot be built (e.g. `cargo` absent)
+- **WHEN** the `oom-audit` component runs
+- **THEN** it records SKIP with a stated reason and never records a silent PASS.
+
+### Requirement: The audit lands green via a seeded allowlist and a stated false-positive budget
+
+Delivery SHALL land the component green: an initial report-only run SHALL be triaged, every reviewed
+sound site SHALL be seeded into the allowlist with an issue link and justification, and the enforce
+flip SHALL occur only after the report is clean. The change SHALL document the seeding process and the
+false-positive posture so the component does not land red.
+
+#### Scenario: The enforce flip happens only on a clean report
+
+- **GIVEN** the seeded allowlist covering every triaged sound site in scope
+- **WHEN** the audit runs with `--enforce` at the point the component is added to the gate
+- **THEN** it exits `0` (no unallowlisted findings), so the gate component lands green.
+
+### Requirement: The tool stays small and fast
+
+The `xtask` crate SHALL remain small (campsite rule: source files ~800 lines) and depend only on
+lightweight parsing/support crates (`syn`/`quote`/`walkdir`/`toml`), adding no dependency to
+`cqlite-core` or `cqlite-flight`. The audit over the v1 scope SHALL complete in under ~30 seconds.
+
+#### Scenario: The audit completes within the runtime budget
+
+- **GIVEN** the v1 scope roots
+- **WHEN** the audit runs end to end
+- **THEN** it completes in under ~30 seconds on a developer machine.

--- a/openspec/changes/oom-audit-xtask/tasks.md
+++ b/openspec/changes/oom-audit-xtask/tasks.md
@@ -1,0 +1,48 @@
+# Tasks — xtask static audit for no-unbounded-materialization (#2012)
+
+One branch `issue-2012-oom-audit-xtask`, staged commits. Each task names the surface it exercises and
+carries a test. Anchors are `main`-relative and will drift; re-grep before editing. Seam 1 (owner
+approval of proposal + design, incl. the four open forks in design.md §"Open forks") precedes all
+implementation.
+
+## Stage 0 — crate skeleton + self-test fixtures (red first)
+- [ ] 0.1 Add the `xtask` crate: `[workspace] members` entry, `Cargo.toml` (deps `syn` full+visit,
+  `quote`, `walkdir`, `toml`; no cqlite deps), `main.rs` with a `clap`-free arg parse for
+  `oom-audit [--enforce]`. Surface: `cargo run -p xtask -- oom-audit`. (oom-audit-xtask)
+- [ ] 0.2 Add self-test fixtures under `xtask/tests/fixtures/`: `violating.rs.txt` (unbounded
+  `collect::<Vec<_>>()` on a scan-shaped fn) and `bounded.rs.txt` (same body with a `ResultBudget`/
+  `.take(limit)`). Fixture-driven unit test asserts violating→finding, bounded→none. (oom-audit-xtask)
+
+## Stage 1 — the STREAM_RETURNS_VEC rule (design §B)
+- [ ] 1.1 Implement the `syn`-visitor rule: per in-scope fn, detect the collect/push shape over a
+  row/partition/cell iterator with no in-scope bound; conservative type-fragment allowlist; fire only
+  when shape + iterator-type are syntactically visible. Unit-pinned by the Stage-0 fixtures + the
+  renamed-helper scenario. Surface: `xtask oom-audit` finding set. (oom-audit-xtask)
+- [ ] 1.2 Path-scope enforcement: only `.rs` under the committed scope roots are parsed/reported;
+  out-of-scope file with the shape → no finding (scenario). (oom-audit-xtask)
+
+## Stage 2 — allowlist machinery (design §C)
+- [ ] 2.1 Content-fingerprint (quote-normalized token hash) + TOML allowlist load/validate: suppress on
+  fingerprint match; FAIL on orphan / missing `issue` / missing `justification` / past `expiry`.
+  Unit-pinned per scenario. Surface: the allowlist TOML + `oom-audit`. (oom-audit-xtask)
+
+## Stage 3 — modes + seeding (design §D, §E)
+- [ ] 3.1 report-only (exit 0 always) vs `--enforce` (non-zero on any failing condition); self-test
+  fixture drives the enforce exit-code scenarios. (oom-audit-xtask)
+- [ ] 3.2 Run report-only over the v1 scope; triage every hit; seed the committed allowlist for
+  reviewed-sound sites (issue + justification each). Report clean before Stage 4. (oom-audit-xtask)
+
+## Stage 4 — gate wiring + docs (design §D)
+- [ ] 4.1 Add `run_oom_audit` (SKIP-aware, `delivery-telemetry` template) to `scripts/agent-gate.sh`:
+  `COMPONENTS` entry, dispatch `case`, NOT in `DATASET_COMPONENTS`; SKIP if `xtask` can't build, FAIL on
+  violation. Self-test the SKIP + FAIL paths (`scripts/tests/`). (oom-audit-xtask)
+- [ ] 4.2 Flip the component to `--enforce`; confirm green over the seeded allowlist. (oom-audit-xtask)
+- [ ] 4.3 Docs: one-line `oom-audit` row in the CLAUDE.md gate table + `docs/development/gate-ops.md`
+  (or the gate-contract website page); note the allowlist policy (issue + justification mandatory,
+  expiry per fork F-expiry). (oom-audit-xtask)
+
+## Stage 5 — gate + close
+- [ ] 5.1 `scripts/agent-gate.sh` full PASS (SUMMARY recorded; `oom-audit` PASS). rust-reviewer +
+  roborev on the lite-green diff; C PASS (every requirement satisfied by a self-test/public-surface
+  test). (oom-audit-xtask)
+- [ ] 5.2 `openspec archive`. (oom-audit-xtask)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1066,7 +1066,7 @@ _python_build_verify_venv() {
   return 3
 }
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry oom-audit parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile tooling-tests minimal-build smoke)
 # --lite (issue #1821) runs ONLY this fast subset: file-size ratchet, fmt,
 # FULL-workspace clippy (cross-crate API breaks are the cheap-insurance class),
 # and blast-radius-scoped tests (the touched package's --lib + the diff's new
@@ -1685,6 +1685,60 @@ run_delivery_telemetry() {
   echo ">>> [$name] $status ($((end - start))s)"
 }
 
+# oom-audit: the STREAM_RETURNS_VEC static AST audit (issue #2012) run in
+# --enforce mode over the v1 scope (data_access/**, query/**, flight producers +
+# streaming). SKIP-aware on the delivery-telemetry model: no cargo, an absent
+# xtask crate, or a failed xtask build -> SKIP (loud, never a silent PASS); a
+# successful build whose enforce run exits non-zero (an unallowlisted finding,
+# orphaned/malformed/expired allowlist entry) -> hard FAIL; otherwise PASS. Not
+# in DATASET_COMPONENTS: it needs no SSTable fixtures (it reads source only).
+#
+# Test seams (mirrors parity-report's env overrides, exercised by
+# scripts/tests/test_agent_gate_oom_audit.sh via `--only oom-audit`):
+#   OOM_AUDIT_XTASK_DIR      - point at an absent dir to force the SKIP path
+#   CQLITE_OOM_AUDIT_ROOT    - point the audit at a synthetic tree (a planted
+#                              violation for FAIL, a clean tree for PASS)
+run_oom_audit() {
+  local name=oom-audit
+  if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
+    return 0
+  fi
+  local log="$LOG_DIR/$name.log"
+  local start end status
+  start=$(date +%s)
+  local xtask_dir="${OOM_AUDIT_XTASK_DIR:-$REPO_ROOT/xtask}"
+  if ! command -v cargo >/dev/null 2>&1; then
+    status=SKIP
+    echo ">>> [$name] SKIP (no cargo on PATH)"
+    record_result "$name" "$status" 0
+    return 0
+  fi
+  if [ ! -f "$xtask_dir/Cargo.toml" ]; then
+    status=SKIP
+    echo ">>> [$name] SKIP (xtask crate absent at $xtask_dir)"
+    record_result "$name" "$status" 0
+    return 0
+  fi
+  echo ">>> [$name] cargo run -p xtask -- oom-audit --enforce"
+  if ! cargo build -p xtask >"$log" 2>&1; then
+    status=SKIP
+    echo ">>> [$name] SKIP (xtask build failed; see $log)"
+    record_result "$name" "$status" "$(( $(date +%s) - start ))"
+    return 0
+  fi
+  if cargo run -q -p xtask -- oom-audit --enforce >>"$log" 2>&1; then
+    status=PASS
+  else
+    status=FAIL
+    echo "--- [$name] FAILED; last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+  fi
+  end=$(date +%s)
+  record_result "$name" "$status" "$((end - start))"
+  echo ">>> [$name] $status ($((end - start))s)"
+}
+
 # compaction-byte-parity: the PR-VISIBLE proxy for the nightly-only Java
 # differential byte tier (issue #1405). The two manifest scenarios
 # cass.compaction.SSTableRewriterTest.output_component_integrity and
@@ -2041,6 +2095,23 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_agent_gate_parity_report.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (parity-report self-test); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # oom-audit component self-test (#2012): drives nested `agent-gate.sh --only
+  # oom-audit` to assert the SKIP (xtask absent) / FAIL (planted violation) /
+  # PASS (bounded tree) outcomes. The SKIP case needs no cargo; the FAIL/PASS
+  # cases self-report INFO when cargo is unavailable. A failure FAILs the
+  # component, mirroring the parity-report/keyspace-scoping guards.
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_oom_audit.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_agent_gate_oom_audit.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (oom-audit self-test); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)
@@ -3544,6 +3615,7 @@ dispatch_component() {
     python-bindings) run_python_bindings ;;
     node-bindings) run_node_bindings ;;
     delivery-telemetry) run_delivery_telemetry ;;
+    oom-audit) run_oom_audit ;;
     parity-report) run_parity_report ;;
     operator-metrics-doc) run_operator_metrics_doc ;;
     kit-dashboard-drift) run_kit_dashboard_drift ;;

--- a/scripts/tests/test_agent_gate_oom_audit.sh
+++ b/scripts/tests/test_agent_gate_oom_audit.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Regression test for issue #2012: the agent-gate `oom-audit` component must
+#   FAIL on an unallowlisted STREAM_RETURNS_VEC violation on a scoped path,
+#   PASS on a clean scoped tree, and
+#   SKIP (loudly, never silently PASS) when the xtask tool cannot build.
+#
+# It drives the real gate via `agent-gate.sh --only oom-audit` and asserts the
+# three outcomes from the SUMMARY block, mirroring test_agent_gate_parity_report.sh.
+# The FAIL/PASS cases point the audit at a synthetic source tree via
+# CQLITE_OOM_AUDIT_ROOT (a planted violation / a bounded body under a scoped
+# path) so the real source is never touched. The SKIP case points
+# OOM_AUDIT_XTASK_DIR at an absent dir.
+#
+# Docker/dataset-free. The FAIL/PASS cases need cargo (they build + run xtask);
+# if cargo is unavailable they are reported as INFO, mirroring the component's
+# own SKIP-awareness. The SKIP case needs no cargo.
+#
+# Run standalone:   bash scripts/tests/test_agent_gate_oom_audit.sh
+# Or via the gate:  scripts/agent-gate.sh runs it inside the `tooling-tests` component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+inf() { printf 'info - %s\n' "$1"; }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-oom.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# oom_status <summary-file>: the component's status token from the SUMMARY block.
+oom_status() {
+  sed -n 's/^oom-audit:[[:space:]]*\([A-Z]*\).*/\1/p' "$1" | head -1
+}
+
+# --- Build the synthetic trees -------------------------------------------------
+# A scoped path per the committed scope roots: cqlite-core/src/query/**.
+viol_root="$tmp/violation"
+clean_root="$tmp/clean"
+mkdir -p "$viol_root/cqlite-core/src/query" "$clean_root/cqlite-core/src/query"
+
+cat >"$viol_root/cqlite-core/src/query/planted.rs" <<'RS'
+// Planted STREAM_RETURNS_VEC violation on a scoped path (self-test only).
+fn scan_all_rows(reader: &Reader) -> Vec<DataRow> {
+    let rows = reader.rows().collect::<Vec<DataRow>>();
+    rows
+}
+RS
+
+cat >"$clean_root/cqlite-core/src/query/planted.rs" <<'RS'
+// Bounded equivalent: a ResultBudget / .take(limit) suppresses the rule.
+fn scan_all_rows(reader: &Reader, limit: usize) -> Vec<DataRow> {
+    let rows = reader.rows().take(limit).collect::<Vec<DataRow>>();
+    rows
+}
+RS
+
+# --- Outcome 1: SKIP when the xtask crate is absent (no cargo needed). ----------
+sum="$tmp/skip.txt"; log="$tmp/skip.log"
+AGENT_GATE_SUMMARY_FILE="$sum" OOM_AUDIT_XTASK_DIR="$tmp/no-xtask" \
+  bash "$GATE" --only oom-audit >"$log" 2>&1
+if [ "$(oom_status "$sum")" = "SKIP" ]; then
+  ok "xtask-crate-absent -> oom-audit SKIP"
+else
+  bad "xtask-crate-absent: expected SKIP, got '$(oom_status "$sum")'"
+  echo "------- summary -------"; cat "$sum"; echo "-----------------------"
+fi
+
+# The FAIL/PASS cases build + run xtask.
+if ! command -v cargo >/dev/null 2>&1; then
+  inf "cargo unavailable; skipping FAIL/PASS cases (component is SKIP-aware here)"
+  echo "----"; echo "passed: $PASS  failed: $FAIL"; [ "$FAIL" -eq 0 ]; exit $?
+fi
+
+# --- Outcome 2: FAIL on an unallowlisted violation on a scoped path. ------------
+sum="$tmp/fail.txt"; log="$tmp/fail.log"
+AGENT_GATE_SUMMARY_FILE="$sum" CQLITE_OOM_AUDIT_ROOT="$viol_root" \
+  bash "$GATE" --only oom-audit >"$log" 2>&1
+if [ "$(oom_status "$sum")" = "FAIL" ]; then
+  ok "planted-violation -> oom-audit FAIL"
+else
+  bad "planted-violation: expected FAIL, got '$(oom_status "$sum")'"
+  echo "------- gate output -------"; tail -30 "$log"; echo "---------------------------"
+fi
+# Strengthen: the FAIL must be the genuine rule firing, not an unrelated error.
+if grep -q 'STREAM_RETURNS_VEC' "$log"; then
+  ok "FAIL output names the STREAM_RETURNS_VEC rule"
+else
+  bad "FAIL case did not emit STREAM_RETURNS_VEC (rule not exercised)"
+  echo "------- gate output -------"; tail -30 "$log"; echo "---------------------------"
+fi
+
+# --- Outcome 3: PASS on a clean (bounded) scoped tree. -------------------------
+sum="$tmp/pass.txt"; log="$tmp/pass.log"
+AGENT_GATE_SUMMARY_FILE="$sum" CQLITE_OOM_AUDIT_ROOT="$clean_root" \
+  bash "$GATE" --only oom-audit >"$log" 2>&1
+if [ "$(oom_status "$sum")" = "PASS" ]; then
+  ok "bounded-tree -> oom-audit PASS"
+else
+  bad "bounded-tree: expected PASS, got '$(oom_status "$sum")'"
+  echo "------- gate output -------"; tail -30 "$log"; echo "---------------------------"
+fi
+
+echo "----"
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,29 @@
+# xtask — workspace developer-tooling crate (issue #2012).
+#
+# Hosts `cargo run -p xtask -- oom-audit [--enforce]`, the static AST audit for
+# the "never materialize an unbounded read" invariant. This crate is a normal
+# workspace member so it gets fmt/clippy coverage and the shared lockfile, but it
+# depends on NO cqlite crate — it never enters the cqlite-core/cqlite-flight
+# build graph. A plain `cargo build`/`test` of the core packages does not compile
+# it; the SKIP-aware `oom-audit` gate component builds it in isolation.
+#
+# Dependency floor (spec #2012): syn/quote/walkdir/toml only, plus proc-macro2
+# (a transitive dep of syn/quote used directly for token-stream fingerprinting).
+[package]
+name = "xtask"
+version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "visit", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
+walkdir = "2"
+toml = { workspace = true }

--- a/xtask/oom-audit-allowlist.toml
+++ b/xtask/oom-audit-allowlist.toml
@@ -1,0 +1,33 @@
+# oom-audit suppression allowlist (issue #2012).
+#
+# The ONLY way to suppress a STREAM_RETURNS_VEC finding. Every entry MUST carry:
+#   file          — repo-root-relative path of the allowed site
+#   fn            — enclosing function name
+#   fingerprint   — content fingerprint (`f1:<hex>`) printed by
+#                   `cargo run -p xtask -- oom-audit` for the finding; it is
+#                   reformat-stable and changes when the offending code changes,
+#                   so a real new materialization at an allowed site re-fires.
+#   issue         — MANDATORY, non-empty tracking issue reference (e.g. "#2012")
+#   justification — MANDATORY, non-empty reason the whole-buffer read is sound
+#                   (e.g. the source is bounded-small, like Statistics.db)
+#   expiry        — OPTIONAL "YYYY-MM-DD"; when present and past, the entry FAILS
+#                   the audit (per fork F-expiry: optional, not a mandatory
+#                   wall-clock time bomb; review cadence is manual).
+#
+# An entry whose fingerprint matches no current in-scope finding is ORPHANED and
+# FAILS the audit — the list cannot silently rot. Remove such entries.
+#
+# The v1 report over the scoped set (data_access/**, query/**, flight producers +
+# streaming) is CLEAN — zero findings — so this allowlist is intentionally empty.
+# The rule favors false-negatives (fires only when both the collect/push shape
+# AND the iterator element type are syntactically visible), so a seeded entry is
+# expected only for a genuinely-bounded whole-buffer read.
+#
+# Example (do not uncomment unless a real, reviewed, sound site exists):
+# [[allow]]
+# file = "cqlite-core/src/query/example.rs"
+# fn = "parse_small_bounded_thing"
+# fingerprint = "f1:0123456789abcdef"
+# issue = "#2012"
+# justification = "input is bounded-small (< a few KB); whole-buffer read is sound"
+# expiry = "2026-12-31"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,0 +1,7 @@
+//! `xtask` library surface (issue #2012).
+//!
+//! The audit logic lives here (not in `main.rs`) so it is reachable from the
+//! crate-external self-test fixtures under `xtask/tests/` and from any future
+//! subcommand. The binary (`main.rs`) is a thin arg-parse shell over `oom_audit`.
+
+pub mod oom_audit;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,63 @@
+//! `xtask` — CQLite developer-tooling entry point (issue #2012).
+//!
+//! Currently hosts a single subcommand, `oom-audit`, a `syn`-based AST audit
+//! for the "never materialize an unbounded read" memory-safety invariant. See
+//! `oom_audit` for the rule and allowlist machinery.
+//!
+//! Usage:
+//!   cargo run -p xtask -- oom-audit            # report-only, always exits 0
+//!   cargo run -p xtask -- oom-audit --enforce  # non-zero on any failing finding
+
+use std::process::ExitCode;
+
+use xtask::oom_audit;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("oom-audit") => run_oom_audit(&args[1..]),
+        Some(other) => {
+            eprintln!("xtask: unknown subcommand `{other}`");
+            print_usage();
+            ExitCode::from(2)
+        }
+        None => {
+            print_usage();
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run_oom_audit(rest: &[String]) -> ExitCode {
+    let mut enforce = false;
+    for arg in rest {
+        match arg.as_str() {
+            "--enforce" => enforce = true,
+            other => {
+                eprintln!("oom-audit: unknown argument `{other}`");
+                print_usage();
+                return ExitCode::from(2);
+            }
+        }
+    }
+
+    let repo_root = match oom_audit::repo_root() {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("oom-audit: could not locate workspace root: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    match oom_audit::run(&repo_root, enforce) {
+        Ok(outcome) => outcome.exit_code(enforce),
+        Err(e) => {
+            eprintln!("oom-audit: {e}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!("usage: cargo run -p xtask -- oom-audit [--enforce]");
+}

--- a/xtask/src/oom_audit/allowlist.rs
+++ b/xtask/src/oom_audit/allowlist.rs
@@ -1,0 +1,313 @@
+//! Suppression allowlist (design.md §C).
+//!
+//! Findings are suppressible ONLY through a single committed TOML allowlist.
+//! Every entry carries:
+//!   * `file` + `fn` + `fingerprint` — the content fingerprint of the allowed
+//!     site (a line number would drift; the fingerprint is reformat-stable and
+//!     changes when the code changes, so a real new materialization re-fires),
+//!   * a non-empty `issue =` reference,
+//!   * a non-empty `justification =` string,
+//!   * an optional `expiry =` "YYYY-MM-DD" (fails when present and past).
+//!
+//! An entry whose fingerprint matches no current in-scope finding is *orphaned*
+//! and FAILS — the allowlist cannot silently rot.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use super::rule::Finding;
+
+#[derive(Debug, Clone)]
+pub struct AllowEntry {
+    pub file: String,
+    pub function: String,
+    pub fingerprint: String,
+    pub issue: String,
+    pub justification: String,
+    pub expiry: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct Allowlist {
+    pub entries: Vec<AllowEntry>,
+}
+
+/// A reason an allowlist entry (not a source finding) fails the audit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllowlistProblem {
+    /// Missing/empty `issue` or `justification`, or malformed `expiry`.
+    Malformed { entry: String, reason: String },
+    /// `expiry` present and in the past.
+    Expired { entry: String, expiry: String },
+    /// Fingerprint matches no current in-scope finding.
+    Orphaned { entry: String },
+}
+
+impl AllowlistProblem {
+    pub fn describe(&self) -> String {
+        match self {
+            AllowlistProblem::Malformed { entry, reason } => {
+                format!("malformed allowlist entry [{entry}]: {reason}")
+            }
+            AllowlistProblem::Expired { entry, expiry } => {
+                format!("expired allowlist entry [{entry}]: expiry {expiry} has passed")
+            }
+            AllowlistProblem::Orphaned { entry } => {
+                format!(
+                    "orphaned allowlist entry [{entry}]: fingerprint matches no in-scope source"
+                )
+            }
+        }
+    }
+}
+
+impl Allowlist {
+    /// Load from a TOML file. A missing file is an empty allowlist (valid — the
+    /// audit simply has no suppressions). A present-but-unparseable file is an
+    /// error the caller surfaces.
+    pub fn load(path: &Path) -> Result<Allowlist, String> {
+        if !path.exists() {
+            return Ok(Allowlist::default());
+        }
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| format!("reading {}: {e}", path.display()))?;
+        Self::parse(&text)
+    }
+
+    pub fn parse(text: &str) -> Result<Allowlist, String> {
+        let value: toml::Value =
+            toml::from_str(text).map_err(|e| format!("parsing allowlist TOML: {e}"))?;
+        let mut entries = Vec::new();
+        if let Some(arr) = value.get("allow").and_then(|v| v.as_array()) {
+            for item in arr {
+                entries.push(AllowEntry {
+                    file: str_field(item, "file"),
+                    function: str_field(item, "fn"),
+                    fingerprint: str_field(item, "fingerprint"),
+                    issue: str_field(item, "issue"),
+                    justification: str_field(item, "justification"),
+                    expiry: item
+                        .get("expiry")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                });
+            }
+        }
+        Ok(Allowlist { entries })
+    }
+
+    /// Validate every entry structurally: non-empty issue/justification and a
+    /// well-formed, non-past expiry (if present). `today` is "YYYY-MM-DD"
+    /// (injected so tests are not wall-clock-racy).
+    pub fn structural_problems(&self, today: &str) -> Vec<AllowlistProblem> {
+        let mut problems = Vec::new();
+        for entry in &self.entries {
+            let label = entry_label(entry);
+            if entry.issue.trim().is_empty() {
+                problems.push(AllowlistProblem::Malformed {
+                    entry: label.clone(),
+                    reason: "empty or missing `issue`".to_string(),
+                });
+            }
+            if entry.justification.trim().is_empty() {
+                problems.push(AllowlistProblem::Malformed {
+                    entry: label.clone(),
+                    reason: "empty or missing `justification`".to_string(),
+                });
+            }
+            if entry.fingerprint.trim().is_empty() {
+                problems.push(AllowlistProblem::Malformed {
+                    entry: label.clone(),
+                    reason: "empty or missing `fingerprint`".to_string(),
+                });
+            }
+            if let Some(expiry) = &entry.expiry {
+                match validate_date(expiry) {
+                    Err(reason) => problems.push(AllowlistProblem::Malformed {
+                        entry: label.clone(),
+                        reason,
+                    }),
+                    Ok(()) => {
+                        // Lexicographic compare is correct for zero-padded ISO
+                        // dates: past strictly before today.
+                        if expiry.as_str() < today {
+                            problems.push(AllowlistProblem::Expired {
+                                entry: label.clone(),
+                                expiry: expiry.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        problems
+    }
+
+    /// Partition `findings` into (unsuppressed, orphaned-entry-problems).
+    ///
+    /// A finding is suppressed when some entry matches its `(file, fn,
+    /// fingerprint)`. Any entry matching no finding is orphaned.
+    pub fn apply<'f>(&self, findings: &'f [Finding]) -> (Vec<&'f Finding>, Vec<AllowlistProblem>) {
+        let mut matched_entries: HashSet<usize> = HashSet::new();
+        let mut remaining = Vec::new();
+        for finding in findings {
+            let mut suppressed = false;
+            for (idx, entry) in self.entries.iter().enumerate() {
+                if entry.matches(finding) {
+                    matched_entries.insert(idx);
+                    suppressed = true;
+                }
+            }
+            if !suppressed {
+                remaining.push(finding);
+            }
+        }
+        let mut orphans = Vec::new();
+        for (idx, entry) in self.entries.iter().enumerate() {
+            if !matched_entries.contains(&idx) {
+                orphans.push(AllowlistProblem::Orphaned {
+                    entry: entry_label(entry),
+                });
+            }
+        }
+        (remaining, orphans)
+    }
+}
+
+impl AllowEntry {
+    fn matches(&self, finding: &Finding) -> bool {
+        self.file == finding.file
+            && self.function == finding.function
+            && self.fingerprint == finding.fingerprint
+    }
+}
+
+fn entry_label(entry: &AllowEntry) -> String {
+    format!("{}::{} {}", entry.file, entry.function, entry.fingerprint)
+}
+
+fn str_field(item: &toml::Value, key: &str) -> String {
+    item.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Validate a "YYYY-MM-DD" date shape (not calendar-exact, but rejects garbage).
+fn validate_date(s: &str) -> Result<(), String> {
+    let parts: Vec<&str> = s.split('-').collect();
+    let ok = parts.len() == 3
+        && parts[0].len() == 4
+        && parts[1].len() == 2
+        && parts[2].len() == 2
+        && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()));
+    if ok {
+        Ok(())
+    } else {
+        Err(format!("invalid `expiry` date `{s}` (want YYYY-MM-DD)"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finding(fp: &str) -> Finding {
+        Finding {
+            rule: "STREAM_RETURNS_VEC",
+            file: "cqlite-core/src/query/x.rs".to_string(),
+            function: "scan_all".to_string(),
+            expr: "it.collect::<Vec<Row>>()".to_string(),
+            fingerprint: fp.to_string(),
+        }
+    }
+
+    fn entry(fp: &str, issue: &str, just: &str, expiry: Option<&str>) -> AllowEntry {
+        AllowEntry {
+            file: "cqlite-core/src/query/x.rs".to_string(),
+            function: "scan_all".to_string(),
+            fingerprint: fp.to_string(),
+            issue: issue.to_string(),
+            justification: just.to_string(),
+            expiry: expiry.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn matched_entry_suppresses_finding() {
+        let al = Allowlist {
+            entries: vec![entry("f1:abc", "#2012", "bounded small", None)],
+        };
+        let findings = vec![finding("f1:abc")];
+        let (remaining, orphans) = al.apply(&findings);
+        assert!(remaining.is_empty());
+        assert!(orphans.is_empty());
+    }
+
+    #[test]
+    fn unmatched_finding_survives_and_entry_orphans() {
+        let al = Allowlist {
+            entries: vec![entry("f1:stale", "#2012", "bounded", None)],
+        };
+        let findings = vec![finding("f1:live")];
+        let (remaining, orphans) = al.apply(&findings);
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(orphans.len(), 1);
+        assert!(matches!(orphans[0], AllowlistProblem::Orphaned { .. }));
+    }
+
+    #[test]
+    fn missing_issue_or_justification_is_malformed() {
+        let al = Allowlist {
+            entries: vec![
+                entry("f1:a", "", "has just", None),
+                entry("f1:b", "#2012", "", None),
+            ],
+        };
+        let problems = al.structural_problems("2026-07-16");
+        assert_eq!(problems.len(), 2);
+        assert!(problems
+            .iter()
+            .all(|p| matches!(p, AllowlistProblem::Malformed { .. })));
+    }
+
+    #[test]
+    fn past_expiry_fails_future_expiry_passes() {
+        let al = Allowlist {
+            entries: vec![
+                entry("f1:a", "#2012", "j", Some("2020-01-01")),
+                entry("f1:b", "#2012", "j", Some("2099-01-01")),
+            ],
+        };
+        let problems = al.structural_problems("2026-07-16");
+        assert_eq!(problems.len(), 1);
+        assert!(matches!(problems[0], AllowlistProblem::Expired { .. }));
+    }
+
+    #[test]
+    fn malformed_expiry_is_reported() {
+        let al = Allowlist {
+            entries: vec![entry("f1:a", "#2012", "j", Some("not-a-date"))],
+        };
+        let problems = al.structural_problems("2026-07-16");
+        assert_eq!(problems.len(), 1);
+        assert!(matches!(problems[0], AllowlistProblem::Malformed { .. }));
+    }
+
+    #[test]
+    fn parse_reads_all_fields() {
+        let toml_src = r##"
+[[allow]]
+file = "cqlite-core/src/query/x.rs"
+fn = "scan_all"
+fingerprint = "f1:abc"
+issue = "#2012"
+justification = "bounded small buffer"
+expiry = "2099-12-31"
+"##;
+        let al = Allowlist::parse(toml_src).unwrap();
+        assert_eq!(al.entries.len(), 1);
+        assert_eq!(al.entries[0].fingerprint, "f1:abc");
+        assert_eq!(al.entries[0].expiry.as_deref(), Some("2099-12-31"));
+    }
+}

--- a/xtask/src/oom_audit/fingerprint.rs
+++ b/xtask/src/oom_audit/fingerprint.rs
@@ -1,0 +1,63 @@
+//! Content fingerprint for allowlist entries (design.md §C).
+//!
+//! The fingerprint is a stable hash of the `quote`-normalized token stream of
+//! the offending expression. Normalizing through a `proc_macro2::TokenStream`
+//! collapses all whitespace/formatting differences (so a reformat does not churn
+//! the allowlist) while still changing whenever the tokens themselves change (so
+//! a real new materialization at a previously-allowed site re-fires).
+//!
+//! We deliberately use a small in-tree FNV-1a-64 hash rather than pulling in a
+//! hashing crate: the spec (#2012) caps this crate's dependencies at
+//! syn/quote/walkdir/toml. FNV-1a is deterministic and stable across Rust
+//! versions and platforms (unlike `std`'s `DefaultHasher`, whose SipHash keys
+//! are not contractually stable), which is exactly what a committed fingerprint
+//! requires.
+
+use proc_macro2::TokenStream;
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// Fingerprint a token stream: normalize (via `to_string`, which canonicalizes
+/// spacing) then FNV-1a-64 the bytes. Prefixed `f1:` to name the algorithm so a
+/// future scheme change is distinguishable in committed allowlists.
+pub fn fingerprint_tokens(tokens: &TokenStream) -> String {
+    let normalized = tokens.to_string();
+    let mut hash = FNV_OFFSET;
+    for byte in normalized.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    format!("f1:{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn whitespace_and_formatting_do_not_change_fingerprint() {
+        // Same tokens, different source spacing -> identical fingerprint.
+        let a: TokenStream = "reader . rows ( ) . collect ::< Vec < DataRow >> ( )"
+            .parse()
+            .unwrap();
+        let b: TokenStream = "reader.rows().collect::<Vec<DataRow>>()".parse().unwrap();
+        assert_eq!(fingerprint_tokens(&a), fingerprint_tokens(&b));
+    }
+
+    #[test]
+    fn different_tokens_change_fingerprint() {
+        let a = quote! { reader.rows().collect::<Vec<DataRow>>() };
+        let b = quote! { reader.cells().collect::<Vec<DataCell>>() };
+        assert_ne!(fingerprint_tokens(&a), fingerprint_tokens(&b));
+    }
+
+    #[test]
+    fn fingerprint_is_prefixed_and_stable() {
+        let a = quote! { reader.rows().collect::<Vec<DataRow>>() };
+        assert!(fingerprint_tokens(&a).starts_with("f1:"));
+        // Deterministic across calls.
+        assert_eq!(fingerprint_tokens(&a), fingerprint_tokens(&a));
+    }
+}

--- a/xtask/src/oom_audit/mod.rs
+++ b/xtask/src/oom_audit/mod.rs
@@ -24,14 +24,18 @@ pub struct Outcome {
     pub findings: Vec<Finding>,
     /// Allowlist entries that fail (orphaned / malformed / expired).
     pub allowlist_problems: Vec<AllowlistProblem>,
-    /// Files that failed to parse (reported, never fatal).
+    /// In-scope files that failed to parse (an enforce-mode failure — a
+    /// standalone `--only oom-audit` run has no compile step to catch them first).
     pub parse_errors: Vec<String>,
 }
 
 impl Outcome {
-    /// True if enforce mode should fail: any live finding or allowlist problem.
+    /// True if enforce mode should fail: any live finding, allowlist problem, or
+    /// unparseable in-scope file.
     pub fn has_failures(&self) -> bool {
-        !self.findings.is_empty() || !self.allowlist_problems.is_empty()
+        !self.findings.is_empty()
+            || !self.allowlist_problems.is_empty()
+            || !self.parse_errors.is_empty()
     }
 
     /// Whether the process should exit non-zero: only in enforce mode, and only
@@ -149,8 +153,13 @@ fn print_report(outcome: &Outcome, enforce: bool) {
 
     if !outcome.parse_errors.is_empty() {
         println!(
-            "  note: {} file(s) skipped (unparseable):",
-            outcome.parse_errors.len()
+            "  parse errors: {} in-scope file(s) unparseable ({}):",
+            outcome.parse_errors.len(),
+            if enforce {
+                "enforce failure"
+            } else {
+                "report-only"
+            }
         );
         for e in &outcome.parse_errors {
             println!("    - {e}");
@@ -252,6 +261,20 @@ mod tests {
         };
         assert!(!clean.has_failures());
         assert!(!clean.should_fail(true));
+    }
+
+    #[test]
+    fn parse_errors_fail_enforce_but_not_report_only() {
+        // Low (#2012 review): an unparseable in-scope file must not be a silent
+        // PASS under a standalone `--only oom-audit` run.
+        let outcome = Outcome {
+            findings: vec![],
+            allowlist_problems: vec![],
+            parse_errors: vec!["cqlite-core/src/query/x.rs: parse error: ...".to_string()],
+        };
+        assert!(outcome.has_failures());
+        assert!(outcome.should_fail(true));
+        assert!(!outcome.should_fail(false));
     }
 
     #[test]

--- a/xtask/src/oom_audit/mod.rs
+++ b/xtask/src/oom_audit/mod.rs
@@ -1,0 +1,256 @@
+//! `oom-audit` — static AST audit for the no-unbounded-materialization
+//! invariant (issue #2012). Orchestrates: resolve scope → parse each in-scope
+//! `.rs` → run the `STREAM_RETURNS_VEC` rule → apply the allowlist → report or
+//! enforce. See `rule`, `allowlist`, `scope`, `fingerprint`.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub mod allowlist;
+pub mod fingerprint;
+pub mod rule;
+pub mod scope;
+
+use allowlist::{Allowlist, AllowlistProblem};
+use rule::Finding;
+
+/// The committed allowlist, repo-root-relative.
+pub const ALLOWLIST_PATH: &str = "xtask/oom-audit-allowlist.toml";
+
+/// Result of an audit run.
+pub struct Outcome {
+    /// Findings not suppressed by any allowlist entry.
+    pub findings: Vec<Finding>,
+    /// Allowlist entries that fail (orphaned / malformed / expired).
+    pub allowlist_problems: Vec<AllowlistProblem>,
+    /// Files that failed to parse (reported, never fatal).
+    pub parse_errors: Vec<String>,
+}
+
+impl Outcome {
+    /// True if enforce mode should fail: any live finding or allowlist problem.
+    pub fn has_failures(&self) -> bool {
+        !self.findings.is_empty() || !self.allowlist_problems.is_empty()
+    }
+
+    /// Whether the process should exit non-zero: only in enforce mode, and only
+    /// when there is at least one live finding or allowlist problem.
+    pub fn should_fail(&self, enforce: bool) -> bool {
+        enforce && self.has_failures()
+    }
+
+    /// Exit code: report-only always `0`; enforce non-zero on any failure.
+    pub fn exit_code(&self, enforce: bool) -> ExitCode {
+        if self.should_fail(enforce) {
+            ExitCode::from(1)
+        } else {
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+/// Locate the workspace root. When run via `cargo run -p xtask`, the crate
+/// manifest dir is `<root>/xtask`, so the parent is the workspace root.
+pub fn repo_root() -> Result<PathBuf, String> {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let dir = Path::new(manifest);
+    dir.parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| format!("no parent of manifest dir {manifest}"))
+}
+
+/// Run the audit over the v1 scope roots under `repo_root`, print a human report
+/// to stdout, and return the outcome. `enforce` only affects the exit code (via
+/// `Outcome::exit_code`) and the framing of the printed report.
+pub fn run(repo_root: &Path, enforce: bool) -> Result<Outcome, String> {
+    let today = today_utc();
+    let (findings_all, parse_errors) = collect_findings(repo_root);
+
+    let allowlist_path = repo_root.join(ALLOWLIST_PATH);
+    let allowlist = Allowlist::load(&allowlist_path)?;
+
+    let mut allowlist_problems = allowlist.structural_problems(&today);
+    let (remaining, orphans) = allowlist.apply(&findings_all);
+    allowlist_problems.extend(orphans);
+
+    let findings: Vec<Finding> = remaining.into_iter().cloned().collect();
+    let outcome = Outcome {
+        findings,
+        allowlist_problems,
+        parse_errors,
+    };
+    print_report(&outcome, enforce);
+    Ok(outcome)
+}
+
+/// Walk the scope roots and analyze every in-scope `.rs`. Returns all raw
+/// findings (pre-allowlist) plus any parse-error messages.
+fn collect_findings(repo_root: &Path) -> (Vec<Finding>, Vec<String>) {
+    let mut findings = Vec::new();
+    let mut parse_errors = Vec::new();
+    for dir in scope::walk_dirs(repo_root) {
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&dir)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let Some(rel) = scope::rel_path(repo_root, entry.path()) else {
+                continue;
+            };
+            if !scope::in_scope(&rel) {
+                continue;
+            }
+            let src = match std::fs::read_to_string(entry.path()) {
+                Ok(s) => s,
+                Err(e) => {
+                    parse_errors.push(format!("{rel}: read error: {e}"));
+                    continue;
+                }
+            };
+            match rule::analyze_file(&rel, &src) {
+                Ok(mut fs) => findings.append(&mut fs),
+                Err(e) => parse_errors.push(format!("{rel}: parse error: {e}")),
+            }
+        }
+    }
+    findings.sort_by(|a, b| {
+        (a.file.as_str(), a.function.as_str(), a.fingerprint.as_str()).cmp(&(
+            b.file.as_str(),
+            b.function.as_str(),
+            b.fingerprint.as_str(),
+        ))
+    });
+    (findings, parse_errors)
+}
+
+fn print_report(outcome: &Outcome, enforce: bool) {
+    println!("oom-audit: STREAM_RETURNS_VEC over v1 scope (mode: {})", {
+        if enforce {
+            "enforce"
+        } else {
+            "report-only"
+        }
+    });
+
+    if !outcome.parse_errors.is_empty() {
+        println!(
+            "  note: {} file(s) skipped (unparseable):",
+            outcome.parse_errors.len()
+        );
+        for e in &outcome.parse_errors {
+            println!("    - {e}");
+        }
+    }
+
+    if outcome.findings.is_empty() {
+        println!("  findings: none (0 unallowlisted)");
+    } else {
+        println!("  findings: {} unallowlisted", outcome.findings.len());
+        for f in &outcome.findings {
+            println!(
+                "    [{}] {}::{}\n        expr: {}\n        fingerprint: {}",
+                f.rule, f.file, f.function, f.expr, f.fingerprint
+            );
+        }
+    }
+
+    if !outcome.allowlist_problems.is_empty() {
+        println!("  allowlist problems: {}", outcome.allowlist_problems.len());
+        for p in &outcome.allowlist_problems {
+            println!("    - {}", p.describe());
+        }
+    }
+
+    if enforce && outcome.has_failures() {
+        println!("oom-audit: FAIL (enforce)");
+    } else if outcome.has_failures() {
+        println!("oom-audit: findings present (report-only: not failing the build)");
+    } else {
+        println!("oom-audit: clean");
+    }
+}
+
+/// Today's UTC date as "YYYY-MM-DD", dependency-free (civil date from Unix days
+/// via Howard Hinnant's algorithm). Only used for expiry comparison.
+fn today_utc() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let days = (secs / 86_400) as i64;
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// Howard Hinnant's `civil_from_days`: days since 1970-01-01 -> (year, month, day).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome_with_finding() -> Outcome {
+        Outcome {
+            findings: vec![Finding {
+                rule: "STREAM_RETURNS_VEC",
+                file: "cqlite-core/src/query/x.rs".to_string(),
+                function: "scan_all".to_string(),
+                expr: "it.collect::<Vec<Row>>()".to_string(),
+                fingerprint: "f1:abc".to_string(),
+            }],
+            allowlist_problems: vec![],
+            parse_errors: vec![],
+        }
+    }
+
+    #[test]
+    fn report_only_never_fails_even_with_findings() {
+        // Spec: report-only prints findings but does not fail the build.
+        let outcome = outcome_with_finding();
+        assert!(outcome.has_failures());
+        assert!(!outcome.should_fail(false));
+    }
+
+    #[test]
+    fn enforce_fails_on_any_finding_or_problem() {
+        let outcome = outcome_with_finding();
+        assert!(outcome.should_fail(true));
+    }
+
+    #[test]
+    fn clean_outcome_never_fails() {
+        let clean = Outcome {
+            findings: vec![],
+            allowlist_problems: vec![],
+            parse_errors: vec![],
+        };
+        assert!(!clean.has_failures());
+        assert!(!clean.should_fail(true));
+    }
+
+    #[test]
+    fn civil_date_conversion_matches_known_epochs() {
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        // 2000-01-01 is 10957 days after 1970-01-01.
+        assert_eq!(civil_from_days(10_957), (2000, 1, 1));
+        // 2026-07-16 is 20650 days after epoch.
+        assert_eq!(civil_from_days(20_650), (2026, 7, 16));
+    }
+}

--- a/xtask/src/oom_audit/mod.rs
+++ b/xtask/src/oom_audit/mod.rs
@@ -52,7 +52,16 @@ impl Outcome {
 
 /// Locate the workspace root. When run via `cargo run -p xtask`, the crate
 /// manifest dir is `<root>/xtask`, so the parent is the workspace root.
+///
+/// `CQLITE_OOM_AUDIT_ROOT` overrides the root (used by the gate self-test to
+/// point the audit at a synthetic tree — a planted violation for the FAIL path,
+/// a clean tree for the PASS path — without touching the real source).
 pub fn repo_root() -> Result<PathBuf, String> {
+    if let Ok(override_root) = std::env::var("CQLITE_OOM_AUDIT_ROOT") {
+        if !override_root.is_empty() {
+            return Ok(PathBuf::from(override_root));
+        }
+    }
     let manifest = env!("CARGO_MANIFEST_DIR");
     let dir = Path::new(manifest);
     dir.parent()

--- a/xtask/src/oom_audit/rule.rs
+++ b/xtask/src/oom_audit/rule.rs
@@ -4,6 +4,9 @@
 //! Within a reader/producer *scan* function in scope, and with **no budget or
 //! bound in scope for that function**, the rule flags either shape:
 //!   * `EXPR.collect::<Vec<..>>()` over a row/partition/cell iterator, or
+//!   * a turbofish-less `EXPR.collect()` whose target `Vec<..>` element type is
+//!     learned from the enclosing `let x: Vec<T> = ..` annotation or the
+//!     enclosing function's `-> Vec<T>` return type, or
 //!   * a `for .. in <stream iterator> { .. v.push(..)/v.extend(..) .. }`
 //!     accumulation loop.
 //!
@@ -31,9 +34,9 @@ pub struct Finding {
 }
 
 /// Parse `src` and return every `STREAM_RETURNS_VEC` finding, attributing each
-/// to `file`. A parse error yields no findings (the file is skipped, reported by
-/// the caller) — the audit never fails the build on an unparseable source; that
-/// is a compiler's job, not the lint's.
+/// to `file`. A parse error yields an `Err`, surfaced by the caller — in enforce
+/// mode an unparseable in-scope file is a failure (a standalone `--only
+/// oom-audit` run has no compile step to catch it first).
 pub fn analyze_file(file: &str, src: &str) -> Result<Vec<Finding>, syn::Error> {
     let parsed = syn::parse_file(src)?;
     let mut collector = FnCollector::default();
@@ -41,6 +44,12 @@ pub fn analyze_file(file: &str, src: &str) -> Result<Vec<Finding>, syn::Error> {
 
     let mut findings = Vec::new();
     for unit in &collector.fns {
+        // The Vec element type the function returns, if any — a second way (besides
+        // a `collect::<Vec<..>>()` turbofish) to learn a materialized element type.
+        let return_elem = match &unit.output {
+            syn::ReturnType::Type(_, ty) => vec_type_element(ty),
+            _ => None,
+        };
         if !is_scan_fn(&unit.name, &unit.output) {
             continue;
         }
@@ -52,6 +61,11 @@ pub fn analyze_file(file: &str, src: &str) -> Result<Vec<Finding>, syn::Error> {
             function: &unit.name,
             findings: &mut findings,
         };
+        // Turbofish-less collect in a return position (`-> Vec<T> { .. it.collect() }`
+        // or an explicit `return it.collect();`), typed by the return type.
+        if let Some(elem) = &return_elem {
+            shape.scan_return_positions(&unit.block, elem);
+        }
         shape.visit_block(&unit.block);
     }
     Ok(findings)
@@ -117,6 +131,64 @@ impl<'a> ShapeVisitor<'a> {
             fingerprint: fingerprint_tokens(&tokens),
         });
     }
+
+    /// Flag a turbofish-less `EXPR.collect()` whose target element type `target`
+    /// (learned from a `let` annotation or the fn return type) is a stream
+    /// element, **and** whose receiver is still a recognized stream iterator.
+    /// Turbofish collects are handled by `visit_expr_method_call`, so we skip
+    /// them here to avoid double-counting.
+    fn record_turbofishless(&mut self, target: &VecElement, expr: &syn::Expr) {
+        if matches!(target, VecElement::NonStream) {
+            return;
+        }
+        if let Some(call) = as_bare_collect(expr) {
+            if call.turbofish.is_none() && receiver_is_stream_iter(&call.receiver) {
+                self.record(call);
+            }
+        }
+    }
+
+    /// Scan the function's return positions — the block's implicit tail
+    /// expression and every explicit `return EXPR;` not inside a nested
+    /// closure/item fn — for a turbofish-less collect typed by `target`.
+    fn scan_return_positions(&mut self, block: &syn::Block, target: &VecElement) {
+        if let Some(syn::Stmt::Expr(expr, None)) = block.stmts.last() {
+            self.record_turbofishless(target, expr);
+        }
+        let mut rc = ReturnCollector { exprs: Vec::new() };
+        rc.visit_block(block);
+        for expr in rc.exprs {
+            self.record_turbofishless(target, expr);
+        }
+    }
+}
+
+/// Unwrap parens/groups and return the `.collect()` method call if `expr` is one.
+fn as_bare_collect(expr: &syn::Expr) -> Option<&syn::ExprMethodCall> {
+    match expr {
+        syn::Expr::MethodCall(mc) if mc.method == "collect" => Some(mc),
+        syn::Expr::Paren(p) => as_bare_collect(&p.expr),
+        syn::Expr::Group(g) => as_bare_collect(&g.expr),
+        _ => None,
+    }
+}
+
+/// Collects the operands of `return EXPR;` statements within one function body,
+/// without crossing into nested closures or item fns (whose `return` binds to
+/// them, not the enclosing scan fn).
+struct ReturnCollector<'ast> {
+    exprs: Vec<&'ast syn::Expr>,
+}
+
+impl<'ast> Visit<'ast> for ReturnCollector<'ast> {
+    fn visit_item_fn(&mut self, _f: &'ast syn::ItemFn) {}
+    fn visit_expr_closure(&mut self, _c: &'ast syn::ExprClosure) {}
+    fn visit_expr_return(&mut self, r: &'ast syn::ExprReturn) {
+        if let Some(e) = &r.expr {
+            self.exprs.push(e);
+        }
+        syn::visit::visit_expr_return(self, r);
+    }
 }
 
 impl<'ast, 'a> Visit<'ast> for ShapeVisitor<'a> {
@@ -147,6 +219,17 @@ impl<'ast, 'a> Visit<'ast> for ShapeVisitor<'a> {
         }
         syn::visit::visit_expr_for_loop(self, for_loop);
     }
+
+    fn visit_local(&mut self, local: &'ast syn::Local) {
+        // `let x: Vec<T> = <stream iter>.collect();` — turbofish-less; the target
+        // element type comes from the binding's type annotation.
+        if let syn::Pat::Type(pt) = &local.pat {
+            if let (Some(elem), Some(init)) = (vec_type_element(&pt.ty), &local.init) {
+                self.record_turbofishless(&elem, &init.expr);
+            }
+        }
+        syn::visit::visit_local(self, local);
+    }
 }
 
 /// What `collect::<Vec<..>>()` collects into, as far as syntactically visible.
@@ -167,6 +250,14 @@ fn collect_vec_element(call: &syn::ExprMethodCall) -> Option<VecElement> {
     let syn::GenericArgument::Type(ty) = first else {
         return None;
     };
+    vec_type_element(ty)
+}
+
+/// Classify a syntactic type as a `Vec<..>` and its element: `Some(Stream)` for
+/// `Vec<row/partition/cell type>`, `Some(Unknown)` for `Vec<_>`/`Vec` without a
+/// resolvable element, `Some(NonStream)` for `Vec<other>`, `None` when not a
+/// `Vec` at all. Shared by the turbofish, `let`-annotation, and return-type paths.
+fn vec_type_element(ty: &syn::Type) -> Option<VecElement> {
     let seg = last_path_segment(ty)?;
     if seg.ident != "Vec" {
         return None;
@@ -228,7 +319,8 @@ fn block_pushes_or_extends(block: &syn::Block) -> bool {
 
 /// A reader/producer scan function: name-shaped (`scan*`, `run_scan*`,
 /// `produce*`, `iterate_*partition*`) or a signature returning/holding a
-/// row/partition/cell iterator or stream.
+/// row/partition/cell iterator or stream, or one that returns `Vec<T>` over a
+/// stream element type (the canonical `-> Vec<DataRow> { it.collect() }` shape).
 fn is_scan_fn(name: &str, output: &syn::ReturnType) -> bool {
     if name.starts_with("scan")
         || name.starts_with("run_scan")
@@ -237,9 +329,13 @@ fn is_scan_fn(name: &str, output: &syn::ReturnType) -> bool {
     {
         return true;
     }
-    // Signature-shaped: returns an iterator/stream over a stream element type.
+    // Signature-shaped: returns an iterator/stream over a stream element type, or
+    // a `Vec<T>` whose element is a recognized stream element type.
     if let syn::ReturnType::Type(_, ty) = output {
         if type_is_stream_iterator(ty) {
+            return true;
+        }
+        if matches!(vec_type_element(ty), Some(VecElement::Stream)) {
             return true;
         }
     }

--- a/xtask/src/oom_audit/rule.rs
+++ b/xtask/src/oom_audit/rule.rs
@@ -1,0 +1,520 @@
+//! The `STREAM_RETURNS_VEC` rule (design.md §B) — a `syn`/AST audit, never a
+//! substring/regex match.
+//!
+//! Within a reader/producer *scan* function in scope, and with **no budget or
+//! bound in scope for that function**, the rule flags either shape:
+//!   * `EXPR.collect::<Vec<..>>()` over a row/partition/cell iterator, or
+//!   * a `for .. in <stream iterator> { .. v.push(..)/v.extend(..) .. }`
+//!     accumulation loop.
+//!
+//! A bound suppressing the rule is any of: a `ResultBudget` binding/param, a
+//! `buffer_size`/`batch_size`/`limit`/`max_*` parameter, or a `.take(n)` on the
+//! accumulated iterator. Evaluated per function using in-scope syntax only — no
+//! interprocedural reachability. The rule fires only when BOTH the shape and the
+//! iterator element type are syntactically visible (favor false-negatives over
+//! false-positives; the allowlist backs the residue).
+
+use quote::ToTokens;
+use syn::visit::Visit;
+
+use super::fingerprint::fingerprint_tokens;
+
+/// One rule hit: the file, enclosing function, rendered offending expression,
+/// and its content fingerprint (for allowlist matching).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    pub rule: &'static str,
+    pub file: String,
+    pub function: String,
+    pub expr: String,
+    pub fingerprint: String,
+}
+
+/// Parse `src` and return every `STREAM_RETURNS_VEC` finding, attributing each
+/// to `file`. A parse error yields no findings (the file is skipped, reported by
+/// the caller) — the audit never fails the build on an unparseable source; that
+/// is a compiler's job, not the lint's.
+pub fn analyze_file(file: &str, src: &str) -> Result<Vec<Finding>, syn::Error> {
+    let parsed = syn::parse_file(src)?;
+    let mut collector = FnCollector::default();
+    collector.visit_file(&parsed);
+
+    let mut findings = Vec::new();
+    for unit in &collector.fns {
+        if !is_scan_fn(&unit.name, &unit.output) {
+            continue;
+        }
+        if fn_is_bounded(unit) {
+            continue;
+        }
+        let mut shape = ShapeVisitor {
+            file,
+            function: &unit.name,
+            findings: &mut findings,
+        };
+        shape.visit_block(&unit.block);
+    }
+    Ok(findings)
+}
+
+// ---------------------------------------------------------------------------
+// Function collection
+// ---------------------------------------------------------------------------
+
+struct FnUnit {
+    name: String,
+    inputs: Vec<syn::FnArg>,
+    output: syn::ReturnType,
+    block: syn::Block,
+}
+
+#[derive(Default)]
+struct FnCollector {
+    fns: Vec<FnUnit>,
+}
+
+impl<'ast> Visit<'ast> for FnCollector {
+    fn visit_item_fn(&mut self, f: &'ast syn::ItemFn) {
+        self.fns.push(FnUnit {
+            name: f.sig.ident.to_string(),
+            inputs: f.sig.inputs.iter().cloned().collect(),
+            output: f.sig.output.clone(),
+            block: (*f.block).clone(),
+        });
+        // Recurse so nested item fns are collected as their own units.
+        syn::visit::visit_item_fn(self, f);
+    }
+
+    fn visit_impl_item_fn(&mut self, f: &'ast syn::ImplItemFn) {
+        self.fns.push(FnUnit {
+            name: f.sig.ident.to_string(),
+            inputs: f.sig.inputs.iter().cloned().collect(),
+            output: f.sig.output.clone(),
+            block: f.block.clone(),
+        });
+        syn::visit::visit_impl_item_fn(self, f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shape detection within one function body
+// ---------------------------------------------------------------------------
+
+struct ShapeVisitor<'a> {
+    file: &'a str,
+    function: &'a str,
+    findings: &'a mut Vec<Finding>,
+}
+
+impl<'a> ShapeVisitor<'a> {
+    fn record(&mut self, expr: &dyn ToTokens) {
+        let tokens = expr.to_token_stream();
+        self.findings.push(Finding {
+            rule: "STREAM_RETURNS_VEC",
+            file: self.file.to_string(),
+            function: self.function.to_string(),
+            expr: tokens.to_string(),
+            fingerprint: fingerprint_tokens(&tokens),
+        });
+    }
+}
+
+impl<'ast, 'a> Visit<'ast> for ShapeVisitor<'a> {
+    // Do NOT descend into nested item fns: they are analyzed as their own units.
+    fn visit_item_fn(&mut self, _f: &'ast syn::ItemFn) {}
+
+    fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+        if call.method == "collect" {
+            if let Some(elem) = collect_vec_element(call) {
+                let flagged = match elem {
+                    VecElement::Stream => true,
+                    // Vec<_> / Vec<unknown>: fall back to the receiver chain —
+                    // only fire if a stream-iterator method feeds the collect.
+                    VecElement::Unknown => receiver_is_stream_iter(&call.receiver),
+                    VecElement::NonStream => false,
+                };
+                if flagged {
+                    self.record(call);
+                }
+            }
+        }
+        syn::visit::visit_expr_method_call(self, call);
+    }
+
+    fn visit_expr_for_loop(&mut self, for_loop: &'ast syn::ExprForLoop) {
+        if expr_is_stream_iter(&for_loop.expr) && block_pushes_or_extends(&for_loop.body) {
+            self.record(for_loop);
+        }
+        syn::visit::visit_expr_for_loop(self, for_loop);
+    }
+}
+
+/// What `collect::<Vec<..>>()` collects into, as far as syntactically visible.
+enum VecElement {
+    /// `Vec<T>` where `T` is a recognized row/partition/cell element type.
+    Stream,
+    /// `Vec<_>` or `Vec<T>` where `T` is not syntactically resolvable to a type.
+    Unknown,
+    /// `Vec<T>` where `T` is a recognized non-stream type, or not a `Vec` at all.
+    NonStream,
+}
+
+/// Inspect a `collect` call's turbofish: is it `collect::<Vec<..>>()`, and if so
+/// what is the element? Returns `None` when there is no `Vec<..>` turbofish.
+fn collect_vec_element(call: &syn::ExprMethodCall) -> Option<VecElement> {
+    let turbofish = call.turbofish.as_ref()?;
+    let first = turbofish.args.first()?;
+    let syn::GenericArgument::Type(ty) = first else {
+        return None;
+    };
+    let seg = last_path_segment(ty)?;
+    if seg.ident != "Vec" {
+        return None;
+    }
+    // Element of the Vec, if any.
+    let syn::PathArguments::AngleBracketed(inner) = &seg.arguments else {
+        return Some(VecElement::Unknown);
+    };
+    let Some(syn::GenericArgument::Type(elem_ty)) = inner.args.first() else {
+        return Some(VecElement::Unknown);
+    };
+    if matches!(elem_ty, syn::Type::Infer(_)) {
+        return Some(VecElement::Unknown);
+    }
+    if type_mentions_stream_element(elem_ty) {
+        Some(VecElement::Stream)
+    } else {
+        Some(VecElement::NonStream)
+    }
+}
+
+/// True if `expr` (or its method-call receiver chain) invokes a recognized
+/// stream-iterator method (`.rows()`, `.partitions()`, `.cells()`, …).
+fn expr_is_stream_iter(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::MethodCall(mc) => {
+            is_stream_iter_method(&mc.method.to_string()) || expr_is_stream_iter(&mc.receiver)
+        }
+        syn::Expr::Reference(r) => expr_is_stream_iter(&r.expr),
+        syn::Expr::Paren(p) => expr_is_stream_iter(&p.expr),
+        syn::Expr::Try(t) => expr_is_stream_iter(&t.expr),
+        _ => false,
+    }
+}
+
+fn receiver_is_stream_iter(receiver: &syn::Expr) -> bool {
+    expr_is_stream_iter(receiver)
+}
+
+/// Does the block contain a `.push(..)` or `.extend(..)` method call?
+fn block_pushes_or_extends(block: &syn::Block) -> bool {
+    struct PushFinder(bool);
+    impl<'ast> Visit<'ast> for PushFinder {
+        fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+            if call.method == "push" || call.method == "extend" {
+                self.0 = true;
+            }
+            syn::visit::visit_expr_method_call(self, call);
+        }
+    }
+    let mut f = PushFinder(false);
+    f.visit_block(block);
+    f.0
+}
+
+// ---------------------------------------------------------------------------
+// Function-shape and bound classification
+// ---------------------------------------------------------------------------
+
+/// A reader/producer scan function: name-shaped (`scan*`, `run_scan*`,
+/// `produce*`, `iterate_*partition*`) or a signature returning/holding a
+/// row/partition/cell iterator or stream.
+fn is_scan_fn(name: &str, output: &syn::ReturnType) -> bool {
+    if name.starts_with("scan")
+        || name.starts_with("run_scan")
+        || name.starts_with("produce")
+        || (name.contains("iterate") && name.contains("partition"))
+    {
+        return true;
+    }
+    // Signature-shaped: returns an iterator/stream over a stream element type.
+    if let syn::ReturnType::Type(_, ty) = output {
+        if type_is_stream_iterator(ty) {
+            return true;
+        }
+    }
+    false
+}
+
+/// A bound is in scope for this function (design.md §B): a `ResultBudget`
+/// param/local, a `buffer_size`/`batch_size`/`limit`/`max_*` param, or a
+/// `.take(n)` anywhere in the body.
+fn fn_is_bounded(unit: &FnUnit) -> bool {
+    for input in &unit.inputs {
+        if let syn::FnArg::Typed(pat_ty) = input {
+            if let syn::Pat::Ident(pi) = &*pat_ty.pat {
+                if is_bound_param_name(&pi.ident.to_string()) {
+                    return true;
+                }
+            }
+            if type_mentions_budget(&pat_ty.ty) {
+                return true;
+            }
+        }
+    }
+    block_has_budget_or_take(&unit.block)
+}
+
+fn is_bound_param_name(name: &str) -> bool {
+    matches!(name, "buffer_size" | "batch_size" | "limit") || name.starts_with("max_")
+}
+
+fn block_has_budget_or_take(block: &syn::Block) -> bool {
+    struct BoundFinder(bool);
+    impl<'ast> Visit<'ast> for BoundFinder {
+        fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+            if call.method == "take" {
+                self.0 = true;
+            }
+            syn::visit::visit_expr_method_call(self, call);
+        }
+        fn visit_local(&mut self, local: &'ast syn::Local) {
+            // `let budget: ResultBudget = ...` or a bound-named binding.
+            if let syn::Pat::Type(pt) = &local.pat {
+                if type_mentions_budget(&pt.ty) {
+                    self.0 = true;
+                }
+            }
+            if let Some(name) = local_binding_ident(local) {
+                if is_bound_param_name(&name) {
+                    self.0 = true;
+                }
+            }
+            syn::visit::visit_local(self, local);
+        }
+    }
+    let mut f = BoundFinder(false);
+    f.visit_block(block);
+    f.0
+}
+
+fn local_binding_ident(local: &syn::Local) -> Option<String> {
+    match &local.pat {
+        syn::Pat::Ident(pi) => Some(pi.ident.to_string()),
+        syn::Pat::Type(pt) => {
+            if let syn::Pat::Ident(pi) = &*pt.pat {
+                Some(pi.ident.to_string())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Type-name recognition (conservative fragment allowlist, design.md §B)
+// ---------------------------------------------------------------------------
+
+fn last_path_segment(ty: &syn::Type) -> Option<&syn::PathSegment> {
+    match ty {
+        syn::Type::Path(tp) => tp.path.segments.last(),
+        syn::Type::Reference(r) => last_path_segment(&r.elem),
+        syn::Type::Paren(p) => last_path_segment(&p.elem),
+        syn::Type::Group(g) => last_path_segment(&g.elem),
+        _ => None,
+    }
+}
+
+/// True if any path-segment ident anywhere in `ty` names a row/partition/cell
+/// element type (`DataRow`, `PartitionIterator`, `Cell`, `RecordBatch`,
+/// `Unfiltered`, …). Component-aware to avoid matching `Arrow`/`Borrow`/`narrow`.
+fn type_mentions_stream_element(ty: &syn::Type) -> bool {
+    let mut hit = false;
+    for_each_type_ident(ty, &mut |ident| {
+        if ident_is_stream_element(ident) {
+            hit = true;
+        }
+    });
+    hit
+}
+
+fn type_mentions_budget(ty: &syn::Type) -> bool {
+    let mut hit = false;
+    for_each_type_ident(ty, &mut |ident| {
+        if ident == "ResultBudget" || ident.ends_with("Budget") {
+            hit = true;
+        }
+    });
+    hit
+}
+
+/// A signature type that reads as an iterator/stream over a stream element:
+/// contains an `Iterator`/`Stream` ident AND a stream-element ident.
+fn type_is_stream_iterator(ty: &syn::Type) -> bool {
+    let mut has_iter = false;
+    let mut has_elem = false;
+    for_each_type_ident(ty, &mut |ident| {
+        if ident == "Iterator" || ident == "Stream" || ident.ends_with("Stream") {
+            has_iter = true;
+        }
+        if ident_is_stream_element(ident) {
+            has_elem = true;
+        }
+    });
+    has_iter && has_elem
+}
+
+/// Walk every path-segment ident within a type (including generic args, tuple
+/// elems, references, slices, `dyn`/`impl` bounds).
+fn for_each_type_ident(ty: &syn::Type, f: &mut dyn FnMut(&str)) {
+    match ty {
+        syn::Type::Path(tp) => {
+            for seg in &tp.path.segments {
+                f(&seg.ident.to_string());
+                if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
+                    for arg in &ab.args {
+                        match arg {
+                            syn::GenericArgument::Type(t) => for_each_type_ident(t, f),
+                            syn::GenericArgument::AssocType(at) => for_each_type_ident(&at.ty, f),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        syn::Type::Reference(r) => for_each_type_ident(&r.elem, f),
+        syn::Type::Paren(p) => for_each_type_ident(&p.elem, f),
+        syn::Type::Group(g) => for_each_type_ident(&g.elem, f),
+        syn::Type::Slice(s) => for_each_type_ident(&s.elem, f),
+        syn::Type::Array(a) => for_each_type_ident(&a.elem, f),
+        syn::Type::Ptr(p) => for_each_type_ident(&p.elem, f),
+        syn::Type::Tuple(t) => {
+            for elem in &t.elems {
+                for_each_type_ident(elem, f);
+            }
+        }
+        syn::Type::ImplTrait(it) => {
+            for bound in &it.bounds {
+                if let syn::TypeParamBound::Trait(tb) = bound {
+                    trait_path_idents(&tb.path, f);
+                }
+            }
+        }
+        syn::Type::TraitObject(to) => {
+            for bound in &to.bounds {
+                if let syn::TypeParamBound::Trait(tb) = bound {
+                    trait_path_idents(&tb.path, f);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn trait_path_idents(path: &syn::Path, f: &mut dyn FnMut(&str)) {
+    for seg in &path.segments {
+        f(&seg.ident.to_string());
+        if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
+            for arg in &ab.args {
+                match arg {
+                    syn::GenericArgument::Type(t) => for_each_type_ident(t, f),
+                    syn::GenericArgument::AssocType(at) => for_each_type_ident(&at.ty, f),
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// Recognized row/partition/cell element type by PascalCase component, plus the
+/// known scan alias `RecordBatch`. Component-splitting avoids `Arrow`/`Borrow`.
+fn ident_is_stream_element(ident: &str) -> bool {
+    if ident == "RecordBatch" {
+        return true;
+    }
+    for component in split_pascal(ident) {
+        if matches!(
+            component.as_str(),
+            "Row" | "Partition" | "Cell" | "Unfiltered"
+        ) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Recognized stream-iterator producer methods.
+fn is_stream_iter_method(name: &str) -> bool {
+    matches!(
+        name,
+        "rows"
+            | "partitions"
+            | "cells"
+            | "row_iter"
+            | "partition_iter"
+            | "cell_iter"
+            | "iter_rows"
+            | "iter_partitions"
+            | "iter_cells"
+            | "unfiltered_iterator"
+            | "unfiltereds"
+    )
+}
+
+/// Split a PascalCase/`snake` ident into PascalCase components. `DataRow` ->
+/// [`Data`, `Row`]; `Arrow` -> [`Arrow`]; `record_batch` -> [`Record`, `Batch`].
+fn split_pascal(ident: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    for ch in ident.chars() {
+        if ch == '_' {
+            if !cur.is_empty() {
+                out.push(std::mem::take(&mut cur));
+            }
+            continue;
+        }
+        if ch.is_uppercase() && !cur.is_empty() {
+            out.push(std::mem::take(&mut cur));
+        }
+        cur.push(ch);
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    // Normalize to PascalCase for equality comparison.
+    out.into_iter()
+        .map(|c| {
+            let mut chars = c.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => c,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ident_component_recognition() {
+        assert!(ident_is_stream_element("DataRow"));
+        assert!(ident_is_stream_element("PartitionIterator"));
+        assert!(ident_is_stream_element("Cell"));
+        assert!(ident_is_stream_element("RecordBatch"));
+        // Must NOT match these lookalikes.
+        assert!(!ident_is_stream_element("Arrow"));
+        assert!(!ident_is_stream_element("Borrow"));
+        assert!(!ident_is_stream_element("Narrow"));
+        assert!(!ident_is_stream_element("String"));
+    }
+
+    #[test]
+    fn split_pascal_components() {
+        assert_eq!(split_pascal("DataRow"), vec!["Data", "Row"]);
+        assert_eq!(split_pascal("Arrow"), vec!["Arrow"]);
+        assert_eq!(split_pascal("record_batch"), vec!["Record", "Batch"]);
+    }
+}

--- a/xtask/src/oom_audit/scope.rs
+++ b/xtask/src/oom_audit/scope.rs
@@ -1,0 +1,138 @@
+//! Committed scope roots for the v1 audit (proposal.md "Scope (v1)").
+//!
+//! Analysis is restricted BY PATH to these roots. A `.rs` file outside them is
+//! never parsed or reported, regardless of its content — scope is enforced by
+//! path, not by content (spec requirement "A file outside the configured scope
+//! roots is not analyzed").
+//!
+//! v1 scope:
+//!   * `cqlite-core/src/storage/sstable/reader/data_access/**`
+//!   * `cqlite-core/src/query/**`
+//!   * `cqlite-flight/src/producer*.rs`, `cqlite-flight/src/streaming.rs`
+//!
+//! The wider surface (`export`, bindings, `tools/`, the write path) and rules 2
+//! & 3 are deferred to follow-ups.
+
+use std::path::{Path, PathBuf};
+
+/// Directory roots whose `.rs` files are all in scope (recursively).
+const SCOPE_DIRS: &[&str] = &[
+    "cqlite-core/src/storage/sstable/reader/data_access",
+    "cqlite-core/src/query",
+];
+
+/// A single in-scope file matcher rooted at a directory: files directly in
+/// `dir` whose name starts with `prefix` and ends with `suffix`.
+struct FileGlob {
+    dir: &'static str,
+    prefix: &'static str,
+    suffix: &'static str,
+}
+
+const SCOPE_FILE_GLOBS: &[FileGlob] = &[
+    FileGlob {
+        dir: "cqlite-flight/src",
+        prefix: "producer",
+        suffix: ".rs",
+    },
+    FileGlob {
+        dir: "cqlite-flight/src",
+        prefix: "streaming",
+        suffix: ".rs",
+    },
+];
+
+/// The set of directories to walk for `.rs` files (each existing scope dir plus
+/// the parent dir of each file-glob). Deduplicated, absolute under `repo_root`.
+pub fn walk_dirs(repo_root: &Path) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for d in SCOPE_DIRS {
+        dirs.push(repo_root.join(d));
+    }
+    for g in SCOPE_FILE_GLOBS {
+        let p = repo_root.join(g.dir);
+        if !dirs.contains(&p) {
+            dirs.push(p);
+        }
+    }
+    dirs
+}
+
+/// True when `rel` (a repo-root-relative path with `/` separators) is an
+/// in-scope `.rs` source file. Excludes test files (`*_tests.rs` and `tests/`
+/// dirs) so the audit targets production scan/producer paths, not test scaffolds.
+pub fn in_scope(rel: &str) -> bool {
+    if !rel.ends_with(".rs") {
+        return false;
+    }
+    let file_name = rel.rsplit('/').next().unwrap_or(rel);
+    if file_name.ends_with("_tests.rs") || file_name == "tests.rs" {
+        return false;
+    }
+    if rel.contains("/tests/") {
+        return false;
+    }
+
+    for d in SCOPE_DIRS {
+        let with_slash = format!("{d}/");
+        if rel.starts_with(&with_slash) {
+            return true;
+        }
+    }
+    for g in SCOPE_FILE_GLOBS {
+        let parent = format!("{}/", g.dir);
+        if let Some(name) = rel.strip_prefix(&parent) {
+            if !name.contains('/') && name.starts_with(g.prefix) && name.ends_with(g.suffix) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Repo-root-relative, `/`-separated path for `abs` under `repo_root`.
+pub fn rel_path(repo_root: &Path, abs: &Path) -> Option<String> {
+    let rel = abs.strip_prefix(repo_root).ok()?;
+    Some(rel.to_string_lossy().replace('\\', "/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_access_and_query_dirs_are_in_scope() {
+        assert!(in_scope(
+            "cqlite-core/src/storage/sstable/reader/data_access/sequential.rs"
+        ));
+        assert!(in_scope("cqlite-core/src/query/select_executor/mod.rs"));
+    }
+
+    #[test]
+    fn flight_producer_and_streaming_files_are_in_scope() {
+        assert!(in_scope("cqlite-flight/src/producer.rs"));
+        assert!(in_scope("cqlite-flight/src/producer_stream.rs"));
+        assert!(in_scope("cqlite-flight/src/streaming.rs"));
+    }
+
+    #[test]
+    fn out_of_scope_paths_are_rejected() {
+        // Wider surface deferred to follow-ups.
+        assert!(!in_scope("cqlite-core/src/storage/mod.rs"));
+        assert!(!in_scope("cqlite-flight/src/service.rs"));
+        assert!(!in_scope("tools/format-validator/src/main.rs"));
+        assert!(!in_scope("bindings/python/src/lib.rs"));
+        // Non-rust file.
+        assert!(!in_scope("cqlite-core/src/query/README.md"));
+    }
+
+    #[test]
+    fn test_files_are_excluded() {
+        assert!(!in_scope(
+            "cqlite-core/src/query/engine_lock_hygiene_tests.rs"
+        ));
+        assert!(!in_scope(
+            "cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs"
+        ));
+    }
+}

--- a/xtask/tests/fixtures/bounded.rs.txt
+++ b/xtask/tests/fixtures/bounded.rs.txt
@@ -1,0 +1,26 @@
+// Self-test fixture (#2012): the SAME scan bodies as violating.rs.txt, but each
+// threads a bound that structurally caps the materialization — a `ResultBudget`
+// param, a `.take(limit)` adaptor, or a `batch_size` param. `oom-audit` MUST NOT
+// flag any of these (the bound suppresses the rule with no allowlist entry).
+
+fn scan_all_partitions(reader: &Reader, budget: &ResultBudget) -> Vec<DataRow> {
+    // ResultBudget in scope -> bounded.
+    let rows = reader.rows().collect::<Vec<DataRow>>();
+    let _ = budget;
+    rows
+}
+
+fn scan_with_take(reader: &Reader, limit: usize) -> Vec<DataRow> {
+    // `.take(limit)` bounds the accumulation; `limit` is also a bound param.
+    let rows = reader.rows().take(limit).collect::<Vec<DataRow>>();
+    rows
+}
+
+fn scan_via_push_loop(reader: &Reader, batch_size: usize) -> Vec<DataRow> {
+    // `batch_size` bound param -> bounded.
+    let mut out = Vec::new();
+    for row in reader.rows().take(batch_size) {
+        out.push(row);
+    }
+    out
+}

--- a/xtask/tests/fixtures/violating.rs.txt
+++ b/xtask/tests/fixtures/violating.rs.txt
@@ -1,0 +1,22 @@
+// Self-test fixture (#2012): a scan-shaped function that materializes the WHOLE
+// row iterator into an owned Vec before returning, with NO ResultBudget, bound
+// parameter, or `.take(n)` in scope. This is exactly the #2361 shape (LIMIT was
+// consumer-only, so intra-scan memory was unbounded). `oom-audit --enforce` MUST
+// flag it.
+//
+// Stored as .rs.txt (not .rs) so it is never compiled into the crate; it is read
+// as text by the fixture-driven tests.
+
+fn scan_all_partitions(reader: &Reader) -> Vec<DataRow> {
+    // Whole-SSTable materialization: unbounded collect over a row iterator.
+    let rows = reader.rows().collect::<Vec<DataRow>>();
+    rows
+}
+
+fn scan_via_push_loop(reader: &Reader) -> Vec<DataRow> {
+    let mut out = Vec::new();
+    for row in reader.rows() {
+        out.push(row);
+    }
+    out
+}

--- a/xtask/tests/fixtures/violating_renamed.rs.txt
+++ b/xtask/tests/fixtures/violating_renamed.rs.txt
@@ -1,0 +1,10 @@
+// Self-test fixture (#2012): the violating shape with the collecting helper and
+// all local variables RENAMED, but the syntactic shape (collect over a row
+// iterator, no bound) unchanged. The AST audit MUST still flag it — it matches
+// on the parsed shape, not identifier text (spec: "A renamed helper with the
+// same shape is still caught").
+
+fn scan_the_whole_thing(src: &Reader) -> Vec<DataRow> {
+    let materialized_everything = src.rows().collect::<Vec<DataRow>>();
+    materialized_everything
+}

--- a/xtask/tests/fixtures/violating_turbofishless.rs.txt
+++ b/xtask/tests/fixtures/violating_turbofishless.rs.txt
@@ -1,0 +1,22 @@
+// Self-test fixture (#2012): the CANONICAL turbofish-less shapes of the
+// unbounded-materialization anti-pattern. Neither `.collect()` carries a
+// `Vec<..>` turbofish — the target element type is learned from the enclosing
+// function's return type (a) or the `let` binding's type annotation (b). Both
+// MUST be flagged. The collecting fn in (a) is deliberately NOT `scan*`-named,
+// so admission comes solely from its `-> Vec<DataRow>` return type.
+//
+// Stored as .rs.txt (not .rs) so it is never compiled into the crate; it is read
+// as text by the fixture-driven tests.
+
+// (a) turbofish-less collect in tail/return position; plain-named fn admitted by
+//     its `-> Vec<DataRow>` return type.
+fn read_all_rows(reader: &Reader) -> Vec<DataRow> {
+    reader.rows().collect()
+}
+
+// (b) turbofish-less collect typed by a `let x: Vec<DataRow>` annotation; the fn
+//     is admitted by its `scan` name and returns something else.
+fn scan_and_count(reader: &Reader) -> usize {
+    let rows: Vec<DataRow> = reader.rows().collect();
+    rows.len()
+}

--- a/xtask/tests/oom_audit_fixtures.rs
+++ b/xtask/tests/oom_audit_fixtures.rs
@@ -1,0 +1,116 @@
+//! Fixture-driven self-tests for the `oom-audit` STREAM_RETURNS_VEC rule and
+//! allowlist (issue #2012). These are the public-surface acceptance evidence for
+//! the spec scenarios: violating -> finding, bounded -> none, renamed -> still
+//! caught, out-of-scope -> not analyzed, and the allowlist/enforce behaviors.
+
+use std::path::Path;
+
+use xtask::oom_audit::allowlist::{Allowlist, AllowlistProblem};
+use xtask::oom_audit::rule::{analyze_file, Finding};
+use xtask::oom_audit::scope;
+
+fn fixture(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+// A representative in-scope path used to attribute fixture findings.
+const SCOPED: &str = "cqlite-core/src/query/select_executor/scan.rs";
+
+fn analyze(name: &str) -> Vec<Finding> {
+    analyze_file(SCOPED, &fixture(name)).expect("fixture must parse")
+}
+
+#[test]
+fn violating_fixture_produces_findings() {
+    let findings = analyze("violating.rs.txt");
+    // Both the collect shape and the push-loop shape must fire.
+    assert!(
+        findings.len() >= 2,
+        "expected >=2 findings (collect + push-loop), got {}: {findings:?}",
+        findings.len()
+    );
+    assert!(findings.iter().all(|f| f.rule == "STREAM_RETURNS_VEC"));
+    assert!(findings.iter().any(|f| f.function == "scan_all_partitions"));
+    assert!(findings.iter().any(|f| f.function == "scan_via_push_loop"));
+}
+
+#[test]
+fn bounded_fixture_produces_no_findings() {
+    let findings = analyze("bounded.rs.txt");
+    assert!(
+        findings.is_empty(),
+        "bounded fixture must be clean, got {findings:?}"
+    );
+}
+
+#[test]
+fn renamed_helper_with_same_shape_is_still_caught() {
+    // Spec: matches on parsed shape, not identifier text.
+    let original = analyze("violating.rs.txt");
+    let renamed = analyze("violating_renamed.rs.txt");
+    assert!(
+        renamed.iter().any(|f| f.function == "scan_the_whole_thing"),
+        "renamed helper must still be flagged, got {renamed:?}"
+    );
+    // The renamed collect shape matches the original collect shape's fingerprint
+    // only when the tokens are identical; here the element type `DataRow` and the
+    // collect turbofish are preserved, so the RULE fires regardless of the local
+    // variable names — that is the property under test.
+    assert!(original.iter().any(|f| f.function == "scan_all_partitions"));
+}
+
+#[test]
+fn out_of_scope_path_is_not_analyzed() {
+    // Scope is enforced by path, not content. The same violating body under an
+    // out-of-scope path must yield no finding in a full walk. We assert the
+    // path predicate directly (the walk consults `in_scope`).
+    assert!(!scope::in_scope("cqlite-core/src/storage/mod.rs"));
+    assert!(!scope::in_scope("cqlite-flight/src/service.rs"));
+    assert!(scope::in_scope(SCOPED));
+}
+
+#[test]
+fn allowlist_fingerprint_suppresses_a_finding() {
+    let findings = analyze("violating.rs.txt");
+    let target = &findings[0];
+    let toml_src = format!(
+        r##"
+[[allow]]
+file = "{}"
+fn = "{}"
+fingerprint = "{}"
+issue = "#2012"
+justification = "self-test: reviewed sound"
+"##,
+        target.file, target.function, target.fingerprint
+    );
+    let al = Allowlist::parse(&toml_src).unwrap();
+    let (remaining, orphans) = al.apply(&findings);
+    assert!(orphans.is_empty(), "matched entry must not orphan");
+    assert!(
+        remaining
+            .iter()
+            .all(|f| f.fingerprint != target.fingerprint),
+        "the allowlisted fingerprint must be suppressed"
+    );
+}
+
+#[test]
+fn orphaned_allowlist_entry_is_reported() {
+    let findings = analyze("violating.rs.txt");
+    let toml_src = r##"
+[[allow]]
+file = "cqlite-core/src/query/gone.rs"
+fn = "removed_fn"
+fingerprint = "f1:deadbeefdeadbeef"
+issue = "#2012"
+justification = "code was deleted; entry should now orphan"
+"##;
+    let al = Allowlist::parse(toml_src).unwrap();
+    let (_remaining, orphans) = al.apply(&findings);
+    assert_eq!(orphans.len(), 1);
+    assert!(matches!(orphans[0], AllowlistProblem::Orphaned { .. }));
+}

--- a/xtask/tests/oom_audit_fixtures.rs
+++ b/xtask/tests/oom_audit_fixtures.rs
@@ -38,6 +38,34 @@ fn violating_fixture_produces_findings() {
 }
 
 #[test]
+fn turbofishless_collect_forms_are_flagged() {
+    // Blocker (#2012 review): the CANONICAL no-turbofish shapes must be caught —
+    // the target `Vec<T>` element type comes from the fn return type (a) or a
+    // `let` type annotation (b), not a `collect::<Vec<..>>()` turbofish.
+    let findings = analyze("violating_turbofishless.rs.txt");
+    assert!(
+        findings.iter().all(|f| f.rule == "STREAM_RETURNS_VEC"),
+        "unexpected rule: {findings:?}"
+    );
+    // (a) return-type-typed, plain-named fn admitted only via `-> Vec<DataRow>`.
+    assert!(
+        findings.iter().any(|f| f.function == "read_all_rows"),
+        "turbofish-less return-position collect must be flagged, got {findings:?}"
+    );
+    // (b) let-annotation-typed collect inside a scan fn returning `usize`.
+    assert!(
+        findings.iter().any(|f| f.function == "scan_and_count"),
+        "turbofish-less let-typed collect must be flagged, got {findings:?}"
+    );
+    // Exactly one finding per function — no double-counting across paths.
+    assert_eq!(
+        findings.len(),
+        2,
+        "expected exactly 2 findings (one per fn), got {findings:?}"
+    );
+}
+
+#[test]
 fn bounded_fixture_produces_no_findings() {
     let findings = analyze("bounded.rs.txt");
     assert!(


### PR DESCRIPTION
Closes #2012

## Summary
Adds a new `xtask` workspace crate implementing a `syn`-based static AST audit (`STREAM_RETURNS_VEC` rule) for CQLite's "never materialize an unbounded read" invariant — flags unbounded `collect::<Vec<_>>()`/push-loop accumulation over row/partition/cell stream iterators in scan/producer functions with no in-scope budget/limit bound. Path-scoped to `data_access/**`, `query/**`, flight producers, `streaming.rs`.

OpenSpec change: `openspec/changes/oom-audit-xtask/` (spec + design approved at Seam 1, 2026-07-14).

## Design highlights
- Fingerprinted suppression allowlist (mandatory issue+justification per entry; orphan/malformed/expired entries = FAIL, never a silent pass) using a rename-sensitive FNV-1a-64 fingerprint over the offending expression's token stream (deliberately rename-sensitive — a rename orphans the entry → FAIL rather than silently keeping a stale suppression alive).
- Report-only vs `--enforce` modes.
- Wired into `scripts/agent-gate.sh` as a new SKIP-aware `oom-audit` component (no cargo → SKIP; xtask absent/fails to build → SKIP; enforce finds violations → hard FAIL; never silent PASS).
- Real v1 scope report is clean (0 findings) — the seeded allowlist is intentionally empty.

## Review history (this branch)
- Round 1 (rust-reviewer + roborev): both independently caught the same real gap — the rule's turbofish-required `collect()` detection missed the canonical turbofish-less form (`-> Vec<T> { it.collect() }` / `let v: Vec<T> = it.collect();`), which is the most common shape of the exact anti-pattern this audit exists to catch. Fixed: added `let`-annotation and fn-return-type inference paths (mutually exclusive with the turbofish path, verified non-double-counting), widened `is_scan_fn` to admit `Vec<StreamElement>`-returning functions, added non-vacuous fixtures proving both new paths fire and existing bounded fixtures stay clean. Also fixed a Low finding (parse errors now fail enforce mode, previously silently skipped) and a doc-drift nit (design.md's fingerprint description corrected to match the actual FNV-1a-64/rename-sensitive implementation).
- Round 2 (rust-reviewer + roborev on the fix commit): clean. 4 total Low/nit findings across both rounds (a cosmetic report-only wording nit; a rare nested-`impl`-block double-count edge case; a scope-enforcement test asserted by proxy rather than a full walk; the build-failure-vs-tool-absent SKIP conflation) — batched into one follow-up issue at merge time, none blocking.

## Gate
`--lite` PASS on every round (latest: commit e2463b51f). Full `agent-gate.sh` + C intent audit + final roborev to run once via `flow-closer` before merge.