### PR TITLE
feat(#1918): CQLITE_READ_PATH forcing knob + point-vs-full differential lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,10 @@ by responsibility (source: epic #1116; tests: #1135). Genuinely out of scope →
   component `query-semantics-oracle`, test `query_semantics_oracle_parity.rs`) records the
   post-reconciliation result set of a canonical `SELECT` at a PINNED `now` (never wall-clock). Add
   the correct oracle for the property under test; correctness of `SELECT` output needs the semantic one.
+  The CQLite-vs-CQLite complement is the *point-vs-full differential lane* (issue #1918,
+  `cqlite-core/tests/point_vs_full_differential.rs`): it runs the same point-eligible query under
+  forced `CQLITE_READ_PATH=point` and `=full` and asserts identical rows/values/order at a PINNED
+  `now` — catching a divergence between the two read paths that a physical dump cannot see.
 
 ### Fuzzing (issue #1614)
 `fuzz/` is a cargo-fuzz/libFuzzer crate in its own workspace, excluded from the main one — the gate

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -504,6 +504,15 @@ mod tests {
                 Error::UnsupportedQuery(_) => {
                     assert_eq!(err.category(), ErrorCategory::Query);
                 }
+                // Issue #1918: read-path forcing knob errors. `InvalidReadPath`
+                // is Configuration-category; the fail-closed `point` error is
+                // Query-category. Both flow through `category()` like the rest.
+                Error::InvalidReadPath { .. } => {
+                    assert_eq!(err.category(), ErrorCategory::Configuration);
+                }
+                Error::ForcedReadPathUnavailable { .. } => {
+                    assert_eq!(err.category(), ErrorCategory::Query);
+                }
                 Error::CqlParse(_) => {
                     // CqlParse is Query category in cqlite-core
                     assert_eq!(err.category(), ErrorCategory::Query);

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -403,6 +403,10 @@ mod tests {
                 Error::QueryExecution(_) => { /* Maps to QueryError */ }
                 Error::ResultTooLarge { .. } => { /* Maps to QueryError (issue #1582) */ }
                 Error::UnsupportedQuery(_) => { /* Maps to QueryError */ }
+                // Issue #1918: read-path forcing knob errors fall through to the
+                // base CqliteError like every other query-shaped variant below.
+                Error::InvalidReadPath { .. } => { /* Maps to CqliteError */ }
+                Error::ForcedReadPathUnavailable { .. } => { /* Maps to CqliteError */ }
                 Error::CqlParse(_) => { /* Maps to ParseError */ }
                 Error::Configuration(_) => { /* Maps to PyValueError */ }
                 Error::InvalidInput(_) => { /* Maps to PyValueError */ }

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -355,11 +355,47 @@ fn default_max_result_rows() -> u64 {
     1_000_000
 }
 
+/// Forced SELECT access path (issue #1918).
+///
+/// A **test/debug** control that removes doubt about which access path serves a
+/// `SELECT`. It never changes value decoding, tombstone/timestamp reconciliation,
+/// or WRITETIME/TTL semantics — it governs *routing only* — and is chosen
+/// exclusively from explicit operator config/env, never inferred from data bytes
+/// (no-heuristics mandate). Set programmatically via
+/// [`QueryConfig::forced_read_path`] or per-process via the `CQLITE_READ_PATH`
+/// environment variable (`auto|point|full`, case-insensitive), with config taking
+/// precedence over env. **Not a performance recommendation.**
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ReadPathMode {
+    /// Today's behavior: the classifier chooses point-vs-full per query. An unset
+    /// knob is byte-for-byte this mode.
+    #[default]
+    Auto,
+    /// Force a genuinely partition-targeted lookup. **Fails closed** with
+    /// [`crate::Error::ForcedReadPathUnavailable`] whenever the executor would not
+    /// run a partition-targeted lookup — never a silent full scan.
+    Point,
+    /// Force the full-scan + reconciliation path regardless of classification,
+    /// recording [`crate::query::access_path::FallbackReason::ForcedFullScan`].
+    Full,
+}
+
 /// Query engine configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryConfig {
     /// Maximum query execution time
     pub max_execution_time: Duration,
+
+    /// Force the SELECT access-path decision (issue #1918).
+    ///
+    /// `None` (the default) leaves routing to the per-query classifier and the
+    /// `CQLITE_READ_PATH` env knob; `Some(mode)` forces that mode and takes
+    /// precedence over the env var. A **test/debug** control — see
+    /// [`ReadPathMode`]. `#[serde(default)]` keeps configs serialized before this
+    /// field existed deserializing successfully (absent = `None`).
+    #[serde(default)]
+    pub forced_read_path: Option<ReadPathMode>,
 
     /// Maximum number of rows to return in a result set.
     ///
@@ -418,6 +454,7 @@ impl Default for QueryConfig {
     fn default() -> Self {
         Self {
             max_execution_time: Duration::from_secs(300), // 5 minutes
+            forced_read_path: None,
             max_result_rows: 1_000_000,
             max_result_bytes: DEFAULT_MAX_RESULT_BYTES,
             plan_cache_size: 1000,
@@ -799,6 +836,39 @@ mod tests {
         config = Config::default();
         config.memory.block_cache.max_size = config.memory.max_memory + 1;
         assert!(config.validate().is_err());
+    }
+
+    /// Issue #1918: `forced_read_path` defaults to `None` (auto), round-trips its
+    /// lowercase encoding, and a config serialized before the field existed still
+    /// deserializes (absent → `None`).
+    #[test]
+    fn forced_read_path_defaults_absent_and_roundtrips() {
+        // Default is None (auto).
+        assert_eq!(QueryConfig::default().forced_read_path, None);
+
+        // A config predating the field (key absent) deserializes to None.
+        let mut value = serde_json::to_value(QueryConfig::default()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("forced_read_path")
+            .expect("field present when serialized");
+        let restored: QueryConfig = serde_json::from_value(value).unwrap();
+        assert_eq!(restored.forced_read_path, None);
+
+        // Explicit values round-trip via the lowercase serde encoding.
+        for (mode, tag) in [
+            (ReadPathMode::Point, "point"),
+            (ReadPathMode::Full, "full"),
+            (ReadPathMode::Auto, "auto"),
+        ] {
+            let mut cfg = QueryConfig::default();
+            cfg.forced_read_path = Some(mode);
+            let json = serde_json::to_string(&cfg).unwrap();
+            assert!(json.contains(tag), "mode {mode:?} must serialize as {tag:?}: {json}");
+            let restored: QueryConfig = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored.forced_read_path, Some(mode));
+        }
     }
 
     #[test]

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -865,7 +865,10 @@ mod tests {
             let mut cfg = QueryConfig::default();
             cfg.forced_read_path = Some(mode);
             let json = serde_json::to_string(&cfg).unwrap();
-            assert!(json.contains(tag), "mode {mode:?} must serialize as {tag:?}: {json}");
+            assert!(
+                json.contains(tag),
+                "mode {mode:?} must serialize as {tag:?}: {json}"
+            );
             let restored: QueryConfig = serde_json::from_str(&json).unwrap();
             assert_eq!(restored.forced_read_path, Some(mode));
         }

--- a/cqlite-core/src/error.rs
+++ b/cqlite-core/src/error.rs
@@ -103,18 +103,23 @@ pub enum Error {
     /// Forced `point` read path could not run a partition-targeted lookup (issue
     /// #1918).
     ///
-    /// Raised under `CQLITE_READ_PATH=point` (or the equivalent `QueryConfig`
-    /// field) whenever the executor would not run a genuinely partition-targeted
-    /// lookup — a classification fallback, an unwired targeted surface (e.g. a
-    /// metadata `IN` fan-out), or a build/path that does not actually prune. The
-    /// query fails closed instead of silently full-scanning; `reason` names the
-    /// concrete fallback reason.
+    /// Raised whenever a forced read path cannot serve a query without silently
+    /// diverging from the `auto` result. Under `CQLITE_READ_PATH=point` (or the
+    /// equivalent `QueryConfig` field) this fires when the executor would not run
+    /// a genuinely partition-targeted lookup — a classification fallback, an
+    /// unwired targeted surface (e.g. a metadata `IN` fan-out), or a build/path
+    /// that does not actually prune. Under `CQLITE_READ_PATH=full` it fires for a
+    /// schema-less sole-pk point lookup, which only the specialized targeted seek
+    /// can serve correctly (a full scan would return 0 rows instead of the row
+    /// `auto` returns). Either way the query fails closed instead of silently
+    /// returning a wrong result; `reason` names the concrete cause.
     #[error(
-        "forced read path '{forced}' unavailable: {reason}. The query cannot run a \
-         partition-targeted lookup under CQLITE_READ_PATH={forced}; use 'auto' or 'full'"
+        "forced read path '{forced}' unavailable: {reason}. This query cannot be \
+         served under CQLITE_READ_PATH={forced} without diverging from the 'auto' \
+         result; use 'auto' to let CQLite choose the read path"
     )]
     ForcedReadPathUnavailable {
-        /// The forced mode that could not be satisfied (always `"point"` today).
+        /// The forced mode that could not be satisfied (`"point"` or `"full"`).
         forced: &'static str,
         /// The concrete fallback reason label (e.g. `partition_key_not_fully_constrained`).
         reason: String,
@@ -267,7 +272,6 @@ impl Error {
         Self::QueryExecution(msg.into())
     }
 
-    /// Create a type conversion error
     /// Create an invalid-read-path error (issue #1918).
     pub fn invalid_read_path(value: impl Into<String>) -> Self {
         Self::InvalidReadPath {
@@ -276,7 +280,7 @@ impl Error {
     }
 
     /// Create a forced-read-path-unavailable error (issue #1918). `forced` is the
-    /// forced mode (`"point"`); `reason` is the concrete fallback-reason label.
+    /// forced mode (`"point"` or `"full"`); `reason` is the concrete cause label.
     pub fn forced_read_path_unavailable(forced: &'static str, reason: impl Into<String>) -> Self {
         Self::ForcedReadPathUnavailable {
             forced,
@@ -284,6 +288,7 @@ impl Error {
         }
     }
 
+    /// Create a type conversion error
     pub fn type_conversion(msg: impl Into<String>) -> Self {
         Self::TypeConversion(msg.into())
     }

--- a/cqlite-core/src/error.rs
+++ b/cqlite-core/src/error.rs
@@ -89,6 +89,37 @@ pub enum Error {
         rows: usize,
     },
 
+    /// An unrecognized `CQLITE_READ_PATH` value was supplied (issue #1918).
+    ///
+    /// Resolving the read-path forcing knob returns this distinct error rather
+    /// than silently falling through to `auto`, so a typo'd knob is loud instead
+    /// of a no-op. Names the invalid value and the allowed set.
+    #[error("invalid CQLITE_READ_PATH value '{value}': expected one of auto, point, full")]
+    InvalidReadPath {
+        /// The unrecognized value supplied to the knob.
+        value: String,
+    },
+
+    /// Forced `point` read path could not run a partition-targeted lookup (issue
+    /// #1918).
+    ///
+    /// Raised under `CQLITE_READ_PATH=point` (or the equivalent `QueryConfig`
+    /// field) whenever the executor would not run a genuinely partition-targeted
+    /// lookup — a classification fallback, an unwired targeted surface (e.g. a
+    /// metadata `IN` fan-out), or a build/path that does not actually prune. The
+    /// query fails closed instead of silently full-scanning; `reason` names the
+    /// concrete fallback reason.
+    #[error(
+        "forced read path '{forced}' unavailable: {reason}. The query cannot run a \
+         partition-targeted lookup under CQLITE_READ_PATH={forced}; use 'auto' or 'full'"
+    )]
+    ForcedReadPathUnavailable {
+        /// The forced mode that could not be satisfied (always `"point"` today).
+        forced: &'static str,
+        /// The concrete fallback reason label (e.g. `partition_key_not_fully_constrained`).
+        reason: String,
+    },
+
     /// Type conversion errors
     #[error("Type conversion error: {0}")]
     TypeConversion(String),
@@ -237,6 +268,22 @@ impl Error {
     }
 
     /// Create a type conversion error
+    /// Create an invalid-read-path error (issue #1918).
+    pub fn invalid_read_path(value: impl Into<String>) -> Self {
+        Self::InvalidReadPath {
+            value: value.into(),
+        }
+    }
+
+    /// Create a forced-read-path-unavailable error (issue #1918). `forced` is the
+    /// forced mode (`"point"`); `reason` is the concrete fallback-reason label.
+    pub fn forced_read_path_unavailable(forced: &'static str, reason: impl Into<String>) -> Self {
+        Self::ForcedReadPathUnavailable {
+            forced,
+            reason: reason.into(),
+        }
+    }
+
     pub fn type_conversion(msg: impl Into<String>) -> Self {
         Self::TypeConversion(msg.into())
     }
@@ -357,6 +404,9 @@ impl Error {
             // Not recoverable by retry: the same query would re-materialize the
             // same oversized result. The user must add LIMIT or stream.
             Error::ResultTooLarge { .. } => false,
+            // A knob misconfiguration re-fails identically until the operator fixes it.
+            Error::InvalidReadPath { .. } => false,
+            Error::ForcedReadPathUnavailable { .. } => false,
             Error::TypeConversion(_) => false,
             Error::NotFound(_) => false,
             Error::AlreadyExists(_) => false,
@@ -402,6 +452,8 @@ impl Error {
             Error::CqlParse(_) => ErrorCategory::Query,
             Error::QueryExecution(_) => ErrorCategory::Query,
             Error::ResultTooLarge { .. } => ErrorCategory::Query,
+            Error::InvalidReadPath { .. } => ErrorCategory::Configuration,
+            Error::ForcedReadPathUnavailable { .. } => ErrorCategory::Query,
             Error::TypeConversion(_) => ErrorCategory::Data,
             Error::Configuration(_) => ErrorCategory::Configuration,
             Error::Storage(_) => ErrorCategory::Storage,

--- a/cqlite-core/src/observability/error_schema.rs
+++ b/cqlite-core/src/observability/error_schema.rs
@@ -143,6 +143,10 @@ pub(crate) fn classify(err: &Error) -> ErrorCategory {
         Error::QueryExecution(_)
         | Error::ResultTooLarge { .. }
         | Error::UnsupportedQuery(_)
+        // Issue #1918: the read-path forcing knob failing closed is a query-time
+        // outcome (`point` unavailable / invalid knob value).
+        | Error::ForcedReadPathUnavailable { .. }
+        | Error::InvalidReadPath { .. }
         | Error::InvalidInput(_) => ErrorCategory::Query,
 
         // Issue #2264: a cooperative cancellation is an expected outcome, not a

--- a/cqlite-core/src/query/access_path.rs
+++ b/cqlite-core/src/query/access_path.rs
@@ -167,6 +167,14 @@ pub enum FallbackReason {
     /// executor) and #961 (param binding).
     LegacyExecutorPath,
 
+    /// The operator forced the full-scan path via the read-path forcing knob
+    /// (`CQLITE_READ_PATH=full` or [`crate::config::ReadPathMode::Full`], issue
+    /// #1918). This is a *forced* fallback, distinct from every organic reason so
+    /// a deliberately-forced full scan is never mistaken for one the classifier
+    /// chose on its own. The rows are byte-identical to the `auto` result for the
+    /// same query — forcing governs routing only, never decoding.
+    ForcedFullScan,
+
     /// The `tombstones` build compiles out the partition-targeted prune. On that
     /// build the targeted storage surfaces (`scan_partition`,
     /// `scan_partition_with_cell_metadata`) are full-scan + retain fallbacks with
@@ -188,6 +196,7 @@ impl FallbackReason {
             }
             FallbackReason::PartitionKeyEncodingFailed => "partition_key_encoding_failed",
             FallbackReason::MetadataScanPath => "metadata_scan_path",
+            FallbackReason::ForcedFullScan => "forced_full_scan",
             FallbackReason::LegacyExecutorPath => "legacy_executor_path",
             FallbackReason::TombstonesBuildNoPrune => "tombstones_build_no_prune",
         }

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -144,7 +144,11 @@ impl QueryEngine {
                 )
                 .with_max_result_rows(
                     usize::try_from(config.query.max_result_rows).unwrap_or(usize::MAX),
-                ),
+                )
+                // Issue #1918: wire the read-path forcing knob from config so the
+                // `forced_read_path` field (config over env over auto) is
+                // load-bearing on the read path.
+                .with_forced_read_path(config.query.forced_read_path),
         );
 
         Ok(Self {

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -17,10 +17,10 @@
 use super::schemaless_point::classify_schemaless_point_lookup;
 use super::{
     apply_forcing, build_row_from_scan_cached, classify_partition_lookup,
-    collect_capped_materialized, column_info_from_type_str, honest_targeted_path, parse_table_id,
-    point_forbids_fallback, point_requires_engaged, project_expr_reshapes_row, scan_pushdown_cap,
-    select_has_writetime_ttl, sort_rows_by_token, validate_token_predicates, ForcedPlan,
-    PartitionLookupOutcome, SSTablePredicate,
+    collect_capped_materialized, column_info_from_type_str, full_forbids_schemaless_seek,
+    honest_targeted_path, parse_table_id, point_forbids_fallback, point_requires_engaged,
+    project_expr_reshapes_row, scan_pushdown_cap, select_has_writetime_ttl, sort_rows_by_token,
+    validate_token_predicates, ForcedPlan, PartitionLookupOutcome, SSTablePredicate,
 };
 use super::{
     AccessPath, ColumnInfo, ExecutionContext, ExecutionStep, FallbackReason, OptimizedQueryPlan,
@@ -481,20 +481,30 @@ impl SelectExecutor {
         // non-pk column) keeps the honest full-scan path, which correctly matches
         // regular-column equalities. Resolved only when there is no CQL schema and no
         // WRITETIME/TTL metadata projection (the two branches below own those).
-        // Issue #1918: under forced `full` the schemaless targeted seek is skipped
-        // so the query takes the full-scan path (recorded as `ForcedFullScan` by
-        // the main branch below). `point`/`auto` keep the seek; `point` adds the
-        // post-call engaged check in the seek branch.
-        let schemaless_seek: Option<super::schemaless_point::SchemalessPointSeek> = if schema_opt
-            .is_none()
-            && !context.projection_flags.include_cell_metadata
-            && mode != crate::config::ReadPathMode::Full
-        {
-            let shape = self.storage.partition_key_shape(table).await;
-            classify_schemaless_point_lookup(predicates, shape.as_ref())
-        } else {
-            None
-        };
+        // Issue #1918: `point`/`auto` keep the schema-less sole-pk targeted seek
+        // (#1750). Under forced `full` the query cannot take the general full-scan
+        // path for THIS shape: with no schema the per-row predicate backstop in
+        // `collect_capped_materialized` cannot reconstruct the pk column to match
+        // the literal, so a full scan would silently return 0 rows instead of the
+        // row `auto` returns — violating the spec's "identical to `auto`" SHALL.
+        // Fail closed with a clear error (mirror of `point_forbids_fallback`: full
+        // forbidding a shape only the specialized non-full seek can serve).
+        let schemaless_seek: Option<super::schemaless_point::SchemalessPointSeek> =
+            if schema_opt.is_none() && !context.projection_flags.include_cell_metadata {
+                let shape = self.storage.partition_key_shape(table).await;
+                let seek = classify_schemaless_point_lookup(predicates, shape.as_ref());
+                full_forbids_schemaless_seek(mode, seek.is_some())?;
+                // Under `auto`/`point` keep the seek; under `full` `seek` is `None`
+                // here only when the query did not qualify (the qualifying case
+                // errored above), so it correctly falls through to the full scan.
+                if mode == crate::config::ReadPathMode::Full {
+                    None
+                } else {
+                    seek
+                }
+            } else {
+                None
+            };
 
         // Issue #693: When WRITETIME(col) or TTL(col) is in the SELECT, use the
         // metadata-carrying scan so per-cell timestamps reach the QueryRow.

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -16,10 +16,11 @@
 
 use super::schemaless_point::classify_schemaless_point_lookup;
 use super::{
-    build_row_from_scan_cached, classify_partition_lookup, collect_capped_materialized,
-    column_info_from_type_str, honest_targeted_path, parse_table_id, project_expr_reshapes_row,
+    apply_forcing, build_row_from_scan_cached, classify_partition_lookup,
+    collect_capped_materialized, column_info_from_type_str, honest_targeted_path,
+    parse_table_id, point_forbids_fallback, point_requires_engaged, project_expr_reshapes_row,
     scan_pushdown_cap, select_has_writetime_ttl, sort_rows_by_token, validate_token_predicates,
-    PartitionLookupOutcome, SSTablePredicate,
+    ForcedPlan, PartitionLookupOutcome, SSTablePredicate,
 };
 use super::{
     AccessPath, ColumnInfo, ExecutionContext, ExecutionStep, FallbackReason, OptimizedQueryPlan,
@@ -435,6 +436,11 @@ impl SelectExecutor {
         // wrong. Reject (Cassandra-style) before scanning/evaluating.
         validate_token_predicates(predicates, schema_opt)?;
 
+        // Issue #1918: resolve the read-path forcing mode ONCE for this scan step
+        // (config over env over auto). An invalid env value fails the query loudly
+        // here rather than silently running under auto.
+        let mode = self.resolved_read_path_mode()?;
+
         // Data-safety (issue #1694): log the SHAPE of the scan — predicate count
         // and the constrained column names — never the predicate literals/values.
         tracing::debug!(
@@ -475,8 +481,15 @@ impl SelectExecutor {
         // non-pk column) keeps the honest full-scan path, which correctly matches
         // regular-column equalities. Resolved only when there is no CQL schema and no
         // WRITETIME/TTL metadata projection (the two branches below own those).
+        // Issue #1918: under forced `full` the schemaless targeted seek is skipped
+        // so the query takes the full-scan path (recorded as `ForcedFullScan` by
+        // the main branch below). `point`/`auto` keep the seek; `point` adds the
+        // post-call engaged check in the seek branch.
         let schemaless_seek: Option<super::schemaless_point::SchemalessPointSeek> =
-            if schema_opt.is_none() && !context.projection_flags.include_cell_metadata {
+            if schema_opt.is_none()
+                && !context.projection_flags.include_cell_metadata
+                && mode != crate::config::ReadPathMode::Full
+            {
                 let shape = self.storage.partition_key_shape(table).await;
                 classify_schemaless_point_lookup(predicates, shape.as_ref())
             } else {
@@ -494,8 +507,22 @@ impl SelectExecutor {
             // partition-lookup representation). The per-row predicate evaluation
             // below is unchanged, so the pk equality itself is still applied as a
             // correctness backstop and any bloom/BTI over-inclusion is filtered out.
-            let scan_results = match classify_partition_lookup(predicates, schema_opt) {
-                PartitionLookupOutcome::Targeted(pk_bytes) => {
+            // Issue #1918: the single forcing gate wraps the classifier outcome.
+            let outcome = classify_partition_lookup(predicates, schema_opt);
+            let scan_results = match apply_forcing(outcome, mode)? {
+                // Forced `full`: run the same full metadata scan the organic
+                // fallback uses, recorded with the distinct forced reason.
+                ForcedPlan::ForceFullScan => {
+                    let path = AccessPath::FallbackFullScan {
+                        reason: FallbackReason::ForcedFullScan,
+                    };
+                    context.access_path = Some(path.clone());
+                    crate::query::access_path::record(path);
+                    self.storage
+                        .scan_with_cell_metadata(table, None, None, None, schema_opt)
+                        .await?
+                }
+                ForcedPlan::Proceed(PartitionLookupOutcome::Targeted(pk_bytes)) => {
                     tracing::debug!(
                         "SSTableScan(metadata): partition-key point lookup (key len={}) for \"{}\"",
                         pk_bytes.len(),
@@ -511,6 +538,10 @@ impl SelectExecutor {
                         .storage
                         .scan_partition_with_cell_metadata(table, &pk_bytes, schema_opt)
                         .await?;
+                    // Issue #1918: under `point` a post-call no-prune (`engaged ==
+                    // false`, tombstones build) is a non-targeted execution → fail
+                    // closed rather than silently full-scanning.
+                    point_requires_engaged(mode, engaged, FallbackReason::TombstonesBuildNoPrune)?;
                     let path = honest_targeted_path(AccessPath::MetadataPartitionLookup, engaged);
                     context.access_path = Some(path.clone());
                     crate::query::access_path::record(path);
@@ -520,7 +551,14 @@ impl SelectExecutor {
                 // fanned out to N targeted metadata lookups; it still full-scans.
                 // Report that honestly (MetadataScanPath) rather than faking a
                 // targeted path — the IN-metadata fan-out is a documented follow-up.
-                PartitionLookupOutcome::MultiTargeted(_) | PartitionLookupOutcome::Fallback(_) => {
+                // Issue #1918: under `point` this unwired targeted surface is a
+                // non-targeted execution → fail closed (a classification `Fallback`
+                // already errored up front in `apply_forcing`, so only a
+                // `MultiTargeted` reaches here under `point`).
+                ForcedPlan::Proceed(
+                    PartitionLookupOutcome::MultiTargeted(_) | PartitionLookupOutcome::Fallback(_),
+                ) => {
+                    point_forbids_fallback(mode, FallbackReason::MetadataScanPath)?;
                     let metadata_path = AccessPath::FallbackFullScan {
                         reason: FallbackReason::MetadataScanPath,
                     };
@@ -599,6 +637,9 @@ impl SelectExecutor {
                 .storage
                 .scan_partition(table, &seek.bytes, None)
                 .await?;
+            // Issue #1918: `point` fails closed on a post-call no-prune. (`full`
+            // never reaches here — the seek is skipped above under forced `full`.)
+            point_requires_engaged(mode, engaged, FallbackReason::TombstonesBuildNoPrune)?;
             let path = honest_targeted_path(AccessPath::PartitionLookup, engaged);
             context.access_path = Some(path.clone());
             crate::query::access_path::record(path);
@@ -621,8 +662,31 @@ impl SelectExecutor {
             // pinned or can't be encoded. The per-row predicate evaluation below is
             // unchanged, so clustering predicates and the pk equality itself are
             // still applied (and any over-inclusion is filtered out).
-            let scan_results = match classify_partition_lookup(predicates, schema_opt) {
-                PartitionLookupOutcome::Targeted(pk_bytes) => {
+            // Issue #1918: the single forcing gate wraps the classifier outcome.
+            let outcome = classify_partition_lookup(predicates, schema_opt);
+            let scan_results = match apply_forcing(outcome, mode)? {
+                // Forced `full`: run the SAME full-scan + reconciliation code the
+                // organic fallback uses (so rows/order match `auto`), recorded with
+                // the distinct `ForcedFullScan` reason so it is never mistaken for
+                // an organic fallback.
+                ForcedPlan::ForceFullScan => {
+                    let path = AccessPath::FallbackFullScan {
+                        reason: FallbackReason::ForcedFullScan,
+                    };
+                    context.access_path = Some(path.clone());
+                    crate::query::access_path::record(path);
+                    if let Some(cap) = scan_cap {
+                        return self
+                            .capped_fallback_scan(
+                                table, predicates, projection, schema_opt, cap, context,
+                            )
+                            .await;
+                    }
+                    self.storage
+                        .scan(table, None, None, None, schema_opt)
+                        .await?
+                }
+                ForcedPlan::Proceed(PartitionLookupOutcome::Targeted(pk_bytes)) => {
                     tracing::debug!(
                         "SSTableScan: partition-key point lookup (key len={}) for \"{}\"",
                         pk_bytes.len(),
@@ -660,13 +724,20 @@ impl SelectExecutor {
                             .storage
                             .scan_partition(table, &pk_bytes, schema_opt)
                             .await?;
+                        // Issue #1918: `point` fails closed on the tombstones-build
+                        // no-prune rather than silently full-scanning.
+                        point_requires_engaged(
+                            mode,
+                            engaged,
+                            FallbackReason::TombstonesBuildNoPrune,
+                        )?;
                         let path = honest_targeted_path(AccessPath::PartitionLookup, engaged);
                         context.access_path = Some(path.clone());
                         crate::query::access_path::record(path);
                         rows
                     }
                 }
-                PartitionLookupOutcome::MultiTargeted(pk_keys) => {
+                ForcedPlan::Proceed(PartitionLookupOutcome::MultiTargeted(pk_keys)) => {
                     tracing::debug!(
                         "SSTableScan: multi-partition lookup ({} keys) for \"{}\"",
                         pk_keys.len(),
@@ -689,6 +760,9 @@ impl SelectExecutor {
                         all_engaged &= engaged;
                         combined.extend(rows);
                     }
+                    // Issue #1918: `point` fails closed when the fan-out did not
+                    // prune (tombstones build) rather than silently full-scanning.
+                    point_requires_engaged(mode, all_engaged, FallbackReason::TombstonesBuildNoPrune)?;
                     let path = honest_targeted_path(AccessPath::MultiPartitionLookup, all_engaged);
                     context.access_path = Some(path.clone());
                     crate::query::access_path::record(path);
@@ -700,8 +774,10 @@ impl SelectExecutor {
                     sort_rows_by_token(&mut combined);
                     combined
                 }
-                PartitionLookupOutcome::Fallback(reason) => {
+                ForcedPlan::Proceed(PartitionLookupOutcome::Fallback(reason)) => {
                     // Issue #960: report the honest reason a full scan was chosen.
+                    // (Under `point` a `Fallback` already errored in `apply_forcing`,
+                    // so this arm is reached only under `auto`.)
                     context.access_path = Some(AccessPath::FallbackFullScan { reason });
                     crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
                     // Issue #1577 (D1): when the plan is LIMIT-pushdown safe, stop

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -17,10 +17,10 @@
 use super::schemaless_point::classify_schemaless_point_lookup;
 use super::{
     apply_forcing, build_row_from_scan_cached, classify_partition_lookup,
-    collect_capped_materialized, column_info_from_type_str, honest_targeted_path,
-    parse_table_id, point_forbids_fallback, point_requires_engaged, project_expr_reshapes_row,
-    scan_pushdown_cap, select_has_writetime_ttl, sort_rows_by_token, validate_token_predicates,
-    ForcedPlan, PartitionLookupOutcome, SSTablePredicate,
+    collect_capped_materialized, column_info_from_type_str, honest_targeted_path, parse_table_id,
+    point_forbids_fallback, point_requires_engaged, project_expr_reshapes_row, scan_pushdown_cap,
+    select_has_writetime_ttl, sort_rows_by_token, validate_token_predicates, ForcedPlan,
+    PartitionLookupOutcome, SSTablePredicate,
 };
 use super::{
     AccessPath, ColumnInfo, ExecutionContext, ExecutionStep, FallbackReason, OptimizedQueryPlan,
@@ -485,16 +485,16 @@ impl SelectExecutor {
         // so the query takes the full-scan path (recorded as `ForcedFullScan` by
         // the main branch below). `point`/`auto` keep the seek; `point` adds the
         // post-call engaged check in the seek branch.
-        let schemaless_seek: Option<super::schemaless_point::SchemalessPointSeek> =
-            if schema_opt.is_none()
-                && !context.projection_flags.include_cell_metadata
-                && mode != crate::config::ReadPathMode::Full
-            {
-                let shape = self.storage.partition_key_shape(table).await;
-                classify_schemaless_point_lookup(predicates, shape.as_ref())
-            } else {
-                None
-            };
+        let schemaless_seek: Option<super::schemaless_point::SchemalessPointSeek> = if schema_opt
+            .is_none()
+            && !context.projection_flags.include_cell_metadata
+            && mode != crate::config::ReadPathMode::Full
+        {
+            let shape = self.storage.partition_key_shape(table).await;
+            classify_schemaless_point_lookup(predicates, shape.as_ref())
+        } else {
+            None
+        };
 
         // Issue #693: When WRITETIME(col) or TTL(col) is in the SELECT, use the
         // metadata-carrying scan so per-cell timestamps reach the QueryRow.
@@ -762,7 +762,11 @@ impl SelectExecutor {
                     }
                     // Issue #1918: `point` fails closed when the fan-out did not
                     // prune (tombstones build) rather than silently full-scanning.
-                    point_requires_engaged(mode, all_engaged, FallbackReason::TombstonesBuildNoPrune)?;
+                    point_requires_engaged(
+                        mode,
+                        all_engaged,
+                        FallbackReason::TombstonesBuildNoPrune,
+                    )?;
                     let path = honest_targeted_path(AccessPath::MultiPartitionLookup, all_engaged);
                     context.access_path = Some(path.clone());
                     crate::query::access_path::record(path);

--- a/cqlite-core/src/query/select_executor/forcing.rs
+++ b/cqlite-core/src/query/select_executor/forcing.rs
@@ -85,7 +85,9 @@ fn cached_env() -> Option<&'static str> {
 /// override (if any) wins, else the once-read `CQLITE_READ_PATH` env, else
 /// `Auto`. Returns [`Error::InvalidReadPath`] when the env is the decision source
 /// and holds an unrecognized value.
-pub(super) fn resolve_read_path_mode(config_override: Option<ReadPathMode>) -> Result<ReadPathMode> {
+pub(super) fn resolve_read_path_mode(
+    config_override: Option<ReadPathMode>,
+) -> Result<ReadPathMode> {
     resolve_mode(config_override, cached_env())
 }
 
@@ -167,7 +169,10 @@ mod tests {
     fn parse_rejects_unknown_value_loudly() {
         let err = parse_read_path_mode("compact").expect_err("unknown value must error");
         let msg = err.to_string();
-        assert!(msg.contains("compact"), "error must name the invalid value: {msg}");
+        assert!(
+            msg.contains("compact"),
+            "error must name the invalid value: {msg}"
+        );
         assert!(
             msg.contains("auto") && msg.contains("point") && msg.contains("full"),
             "error must name the allowed set: {msg}"

--- a/cqlite-core/src/query/select_executor/forcing.rs
+++ b/cqlite-core/src/query/select_executor/forcing.rs
@@ -154,6 +154,24 @@ pub(super) fn point_forbids_fallback(mode: ReadPathMode, reason: FallbackReason)
     Ok(())
 }
 
+/// The mirror image of [`point_forbids_fallback`]: under `Full`, fail closed when
+/// the query qualifies ONLY for the specialized schema-less sole-pk targeted seek
+/// (issue #1750). With no CQL schema the full-scan path's per-row predicate
+/// backstop cannot reconstruct the partition-key column to match the literal, so a
+/// forced full scan would silently return 0 rows instead of the row `auto`
+/// returns — violating the spec's "identical to `auto`" SHALL. Rather than diverge
+/// silently, fail loud with the same clear error. A no-op in every other mode and
+/// whenever the query does not qualify for the schema-less seek.
+pub(super) fn full_forbids_schemaless_seek(mode: ReadPathMode, seek_eligible: bool) -> Result<()> {
+    if mode == ReadPathMode::Full && seek_eligible {
+        return Err(Error::forced_read_path_unavailable(
+            "full",
+            "schema_less_sole_pk_lookup_requires_targeted_seek",
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,5 +336,24 @@ mod tests {
         assert!(
             point_forbids_fallback(ReadPathMode::Full, FallbackReason::MetadataScanPath).is_ok()
         );
+    }
+
+    #[test]
+    fn full_forbids_schemaless_seek_errors_only_under_full_when_eligible() {
+        // Only forced `full` on a seek-eligible query fails closed.
+        let err = full_forbids_schemaless_seek(ReadPathMode::Full, true)
+            .expect_err("forced full on a schema-less sole-pk seek must fail closed");
+        match err {
+            Error::ForcedReadPathUnavailable { forced, reason } => {
+                assert_eq!(forced, "full");
+                assert_eq!(reason, "schema_less_sole_pk_lookup_requires_targeted_seek");
+            }
+            other => panic!("expected ForcedReadPathUnavailable, got {other:?}"),
+        }
+        // Not eligible under full -> no error (falls through to the full scan).
+        assert!(full_forbids_schemaless_seek(ReadPathMode::Full, false).is_ok());
+        // Auto/point never trip this guard (they keep the specialized seek).
+        assert!(full_forbids_schemaless_seek(ReadPathMode::Auto, true).is_ok());
+        assert!(full_forbids_schemaless_seek(ReadPathMode::Point, true).is_ok());
     }
 }

--- a/cqlite-core/src/query/select_executor/forcing.rs
+++ b/cqlite-core/src/query/select_executor/forcing.rs
@@ -1,0 +1,317 @@
+//! Read-path forcing knob (issue #1918).
+//!
+//! A single gate that wraps [`classify_partition_lookup`](super::classify_partition_lookup)'s
+//! outcome so an operator can force a `SELECT` down a specific access path for
+//! **test/debug** purposes — never a performance recommendation. The knob:
+//!
+//! - [`ReadPathMode::Auto`] (default): today's behavior, byte-for-byte. An unset
+//!   knob adds no per-query cost beyond one relaxed `OnceLock` load.
+//! - [`ReadPathMode::Point`]: **fail closed** with
+//!   [`Error::ForcedReadPathUnavailable`] whenever the executor would not run a
+//!   genuinely partition-targeted lookup — never a silent full scan.
+//! - [`ReadPathMode::Full`]: force the full-scan + reconciliation path regardless
+//!   of classification, recording [`FallbackReason::ForcedFullScan`].
+//!
+//! Forcing governs **routing only** — values, tombstone shadowing, timestamp
+//! resolution, and WRITETIME/TTL are byte-identical across all three modes — and
+//! the mode is taken solely from explicit config/env, never inferred from data
+//! bytes (no-heuristics mandate, #28).
+//!
+//! # Resolution
+//!
+//! The mode is resolved config-over-env-over-`Auto`:
+//! 1. an explicit [`crate::config::QueryConfig::forced_read_path`] (programmatic
+//!    `Database` config) wins, else
+//! 2. the `CQLITE_READ_PATH` env var (`auto|point|full`, case-insensitive), read
+//!    **once** into a process-global [`OnceLock`], else
+//! 3. [`ReadPathMode::Auto`].
+//!
+//! An unrecognized env value is a loud [`Error::InvalidReadPath`], never a silent
+//! fall-through to `Auto` (a typo'd knob that silently no-ops would defeat the
+//! knob's purpose). Because the env read is cached once per process, the
+//! per-query switch used by tests and by `Database`-level config is the
+//! precedence-winning config field, not the env var.
+
+use super::super::access_path::FallbackReason;
+use super::PartitionLookupOutcome;
+use crate::config::ReadPathMode;
+use crate::{Error, Result};
+use std::sync::OnceLock;
+
+/// The environment variable that forces the SELECT access path.
+const READ_PATH_ENV: &str = "CQLITE_READ_PATH";
+
+/// Parse a `CQLITE_READ_PATH` value (case-insensitive). A pure function so the
+/// parse/validation logic is unit-testable without touching the process
+/// environment (mirrors `now_clock::now_from`, roborev #1853).
+pub(super) fn parse_read_path_mode(raw: &str) -> Result<ReadPathMode> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "auto" => Ok(ReadPathMode::Auto),
+        "point" => Ok(ReadPathMode::Point),
+        "full" => Ok(ReadPathMode::Full),
+        _ => Err(Error::invalid_read_path(raw)),
+    }
+}
+
+/// Pure resolver: config over env over `Auto`. Fully unit-testable via explicit
+/// argument passing — no process-global state.
+///
+/// A `Some` config override wins outright (config precedence), so a bad env value
+/// alongside an explicit config override does not error; the env is validated
+/// only when it is the actual source of the decision.
+pub(super) fn resolve_mode(
+    config_override: Option<ReadPathMode>,
+    env_value: Option<&str>,
+) -> Result<ReadPathMode> {
+    if let Some(mode) = config_override {
+        return Ok(mode);
+    }
+    match env_value {
+        Some(raw) => parse_read_path_mode(raw),
+        None => Ok(ReadPathMode::Auto),
+    }
+}
+
+/// The raw `CQLITE_READ_PATH` value, read once per process into a `OnceLock`.
+/// `None` means the variable is unset; a set-but-empty value round-trips as
+/// `Some("")` and is rejected loudly by [`parse_read_path_mode`] when consulted.
+fn cached_env() -> Option<&'static str> {
+    static ENV: OnceLock<Option<String>> = OnceLock::new();
+    ENV.get_or_init(|| std::env::var(READ_PATH_ENV).ok())
+        .as_deref()
+}
+
+/// Resolve the effective [`ReadPathMode`] for a query: the executor's config
+/// override (if any) wins, else the once-read `CQLITE_READ_PATH` env, else
+/// `Auto`. Returns [`Error::InvalidReadPath`] when the env is the decision source
+/// and holds an unrecognized value.
+pub(super) fn resolve_read_path_mode(config_override: Option<ReadPathMode>) -> Result<ReadPathMode> {
+    resolve_mode(config_override, cached_env())
+}
+
+/// What a call site should do with a classified outcome after the forcing gate.
+#[derive(Debug)]
+pub(super) enum ForcedPlan {
+    /// Run the classifier's outcome unchanged (`Auto`, or `Point` with a targeted
+    /// outcome the site can genuinely serve).
+    Proceed(PartitionLookupOutcome),
+    /// Force the full-scan + reconciliation path. The site must record
+    /// [`FallbackReason::ForcedFullScan`] and run the same full-scan code `Auto`
+    /// falls back to, so rows/order are identical to the organic fallback.
+    ForceFullScan,
+}
+
+/// The single forcing gate over the classifier's outcome (issue #1918). Applied
+/// at every executor call site through this one wrapper so no site re-implements
+/// the forcing policy.
+///
+/// - `Auto` passes the outcome through unchanged.
+/// - `Full` forces a full scan regardless of the outcome.
+/// - `Point` fails closed on a classification `Fallback` up front; a targeted
+///   outcome proceeds and is checked again post-call (see [`point_requires_engaged`])
+///   because the actually-executed path (`engaged`) is only known after the
+///   storage call.
+pub(super) fn apply_forcing(
+    outcome: PartitionLookupOutcome,
+    mode: ReadPathMode,
+) -> Result<ForcedPlan> {
+    match mode {
+        ReadPathMode::Auto => Ok(ForcedPlan::Proceed(outcome)),
+        ReadPathMode::Full => Ok(ForcedPlan::ForceFullScan),
+        ReadPathMode::Point => match outcome {
+            PartitionLookupOutcome::Fallback(reason) => {
+                Err(Error::forced_read_path_unavailable("point", reason.label()))
+            }
+            targeted => Ok(ForcedPlan::Proceed(targeted)),
+        },
+    }
+}
+
+/// Under `Point`, convert a post-call `engaged == false` (the storage surface did
+/// not actually prune — e.g. the `tombstones` build's no-prune fallback) into the
+/// distinct fail-closed error, naming the concrete reason. A no-op in every other
+/// mode and whenever the path genuinely engaged.
+pub(super) fn point_requires_engaged(
+    mode: ReadPathMode,
+    engaged: bool,
+    reason: FallbackReason,
+) -> Result<()> {
+    if mode == ReadPathMode::Point && !engaged {
+        return Err(Error::forced_read_path_unavailable("point", reason.label()));
+    }
+    Ok(())
+}
+
+/// Under `Point`, fail closed when a call site is about to run a NON-targeted
+/// execution its surface cannot serve as a genuine partition lookup (e.g. the
+/// metadata `IN` fan-out, which still full-scans). A no-op in every other mode.
+pub(super) fn point_forbids_fallback(mode: ReadPathMode, reason: FallbackReason) -> Result<()> {
+    if mode == ReadPathMode::Point {
+        return Err(Error::forced_read_path_unavailable("point", reason.label()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_is_case_insensitive_and_trims() {
+        assert_eq!(parse_read_path_mode("auto").unwrap(), ReadPathMode::Auto);
+        assert_eq!(parse_read_path_mode("POINT").unwrap(), ReadPathMode::Point);
+        assert_eq!(parse_read_path_mode("  Full ").unwrap(), ReadPathMode::Full);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_value_loudly() {
+        let err = parse_read_path_mode("compact").expect_err("unknown value must error");
+        let msg = err.to_string();
+        assert!(msg.contains("compact"), "error must name the invalid value: {msg}");
+        assert!(
+            msg.contains("auto") && msg.contains("point") && msg.contains("full"),
+            "error must name the allowed set: {msg}"
+        );
+        assert!(matches!(err, Error::InvalidReadPath { .. }));
+    }
+
+    #[test]
+    fn resolve_unset_is_auto() {
+        assert_eq!(resolve_mode(None, None).unwrap(), ReadPathMode::Auto);
+    }
+
+    #[test]
+    fn resolve_reads_env_when_no_config() {
+        assert_eq!(
+            resolve_mode(None, Some("point")).unwrap(),
+            ReadPathMode::Point
+        );
+        assert_eq!(
+            resolve_mode(None, Some("full")).unwrap(),
+            ReadPathMode::Full
+        );
+    }
+
+    #[test]
+    fn resolve_config_overrides_env() {
+        // env says full, config says point -> config wins.
+        assert_eq!(
+            resolve_mode(Some(ReadPathMode::Point), Some("full")).unwrap(),
+            ReadPathMode::Point
+        );
+        // A config override even bypasses an otherwise-invalid env value.
+        assert_eq!(
+            resolve_mode(Some(ReadPathMode::Auto), Some("bogus")).unwrap(),
+            ReadPathMode::Auto
+        );
+    }
+
+    #[test]
+    fn resolve_invalid_env_without_config_errors() {
+        let err = resolve_mode(None, Some("bogus")).expect_err("invalid env must error");
+        assert!(matches!(err, Error::InvalidReadPath { .. }));
+    }
+
+    #[test]
+    fn apply_forcing_auto_passes_through() {
+        let plan = apply_forcing(
+            PartitionLookupOutcome::Targeted(vec![1, 2, 3]),
+            ReadPathMode::Auto,
+        )
+        .unwrap();
+        assert!(matches!(
+            plan,
+            ForcedPlan::Proceed(PartitionLookupOutcome::Targeted(_))
+        ));
+    }
+
+    #[test]
+    fn apply_forcing_full_forces_full_scan_for_any_outcome() {
+        for outcome in [
+            PartitionLookupOutcome::Targeted(vec![9]),
+            PartitionLookupOutcome::MultiTargeted(vec![vec![1], vec![2]]),
+            PartitionLookupOutcome::Fallback(FallbackReason::NoSchema),
+        ] {
+            let plan = apply_forcing(outcome, ReadPathMode::Full).unwrap();
+            assert!(matches!(plan, ForcedPlan::ForceFullScan));
+        }
+    }
+
+    #[test]
+    fn apply_forcing_point_errors_on_fallback() {
+        let err = apply_forcing(
+            PartitionLookupOutcome::Fallback(FallbackReason::PartitionKeyNotFullyConstrained),
+            ReadPathMode::Point,
+        )
+        .expect_err("point on a classification fallback must fail closed");
+        match err {
+            Error::ForcedReadPathUnavailable { forced, reason } => {
+                assert_eq!(forced, "point");
+                assert_eq!(reason, "partition_key_not_fully_constrained");
+            }
+            other => panic!("expected ForcedReadPathUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_forcing_point_proceeds_on_targeted() {
+        let plan = apply_forcing(
+            PartitionLookupOutcome::Targeted(vec![7]),
+            ReadPathMode::Point,
+        )
+        .unwrap();
+        assert!(matches!(
+            plan,
+            ForcedPlan::Proceed(PartitionLookupOutcome::Targeted(_))
+        ));
+    }
+
+    #[test]
+    fn point_requires_engaged_errors_only_when_not_engaged_under_point() {
+        // Point + not engaged -> error naming the reason.
+        let err = point_requires_engaged(
+            ReadPathMode::Point,
+            false,
+            FallbackReason::TombstonesBuildNoPrune,
+        )
+        .expect_err("point + !engaged must fail closed");
+        match err {
+            Error::ForcedReadPathUnavailable { reason, .. } => {
+                assert_eq!(reason, "tombstones_build_no_prune")
+            }
+            other => panic!("expected ForcedReadPathUnavailable, got {other:?}"),
+        }
+        // Point + engaged -> ok. Other modes -> always ok.
+        assert!(point_requires_engaged(
+            ReadPathMode::Point,
+            true,
+            FallbackReason::TombstonesBuildNoPrune
+        )
+        .is_ok());
+        assert!(point_requires_engaged(
+            ReadPathMode::Auto,
+            false,
+            FallbackReason::TombstonesBuildNoPrune
+        )
+        .is_ok());
+        assert!(point_requires_engaged(
+            ReadPathMode::Full,
+            false,
+            FallbackReason::TombstonesBuildNoPrune
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn point_forbids_fallback_errors_only_under_point() {
+        assert!(
+            point_forbids_fallback(ReadPathMode::Point, FallbackReason::MetadataScanPath).is_err()
+        );
+        assert!(
+            point_forbids_fallback(ReadPathMode::Auto, FallbackReason::MetadataScanPath).is_ok()
+        );
+        assert!(
+            point_forbids_fallback(ReadPathMode::Full, FallbackReason::MetadataScanPath).is_ok()
+        );
+    }
+}

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -77,11 +77,11 @@ use tokio::sync::mpsc;
 
 // Issue #1577 (D1): LIMIT/OFFSET pushdown cap helper (the `capped_fallback_scan`
 // method it pairs with is an `impl SelectExecutor` block in the same submodule).
-use limit_pushdown::{collect_capped_materialized, scan_pushdown_cap};
 use forcing::{
     apply_forcing, point_forbids_fallback, point_requires_engaged, resolve_read_path_mode,
     ForcedPlan,
 };
+use limit_pushdown::{collect_capped_materialized, scan_pushdown_cap};
 use lookup::{
     classify_partition_lookup, honest_targeted_path, sort_rows_by_token, PartitionLookupOutcome,
 };

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -78,8 +78,8 @@ use tokio::sync::mpsc;
 // Issue #1577 (D1): LIMIT/OFFSET pushdown cap helper (the `capped_fallback_scan`
 // method it pairs with is an `impl SelectExecutor` block in the same submodule).
 use forcing::{
-    apply_forcing, point_forbids_fallback, point_requires_engaged, resolve_read_path_mode,
-    ForcedPlan,
+    apply_forcing, full_forbids_schemaless_seek, point_forbids_fallback, point_requires_engaged,
+    resolve_read_path_mode, ForcedPlan,
 };
 use limit_pushdown::{collect_capped_materialized, scan_pushdown_cap};
 use lookup::{

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -41,6 +41,7 @@
 
 mod aggregation;
 mod execute;
+mod forcing;
 mod limit_pushdown;
 mod lookup;
 mod numeric_acc;
@@ -77,6 +78,10 @@ use tokio::sync::mpsc;
 // Issue #1577 (D1): LIMIT/OFFSET pushdown cap helper (the `capped_fallback_scan`
 // method it pairs with is an `impl SelectExecutor` block in the same submodule).
 use limit_pushdown::{collect_capped_materialized, scan_pushdown_cap};
+use forcing::{
+    apply_forcing, point_forbids_fallback, point_requires_engaged, resolve_read_path_mode,
+    ForcedPlan,
+};
 use lookup::{
     classify_partition_lookup, honest_targeted_path, sort_rows_by_token, PartitionLookupOutcome,
 };
@@ -298,6 +303,14 @@ pub struct SelectExecutor {
     /// [`crate::config::QueryConfig::max_result_rows`] by the query engine;
     /// defaults to 1,000,000 for the bare constructors.
     max_result_rows: usize,
+    /// Explicit read-path forcing override (issue #1918).
+    ///
+    /// `Some(mode)` forces every SELECT this executor runs down that access path
+    /// and takes precedence over the `CQLITE_READ_PATH` env var; `None` (the
+    /// default) leaves routing to the classifier + env knob. Wired from
+    /// [`crate::config::QueryConfig::forced_read_path`] by the query engine. A
+    /// test/debug control — see [`crate::config::ReadPathMode`].
+    forced_read_path: Option<crate::config::ReadPathMode>,
 }
 
 impl std::fmt::Debug for SelectExecutor {
@@ -357,6 +370,7 @@ impl SelectExecutor {
             max_result_bytes: usize::try_from(crate::config::DEFAULT_MAX_RESULT_BYTES)
                 .unwrap_or(usize::MAX),
             max_result_rows: DEFAULT_MAX_RESULT_ROWS,
+            forced_read_path: None,
         }
     }
 
@@ -381,6 +395,28 @@ impl SelectExecutor {
         self
     }
 
+    /// Set the read-path forcing override (issue #1918).
+    ///
+    /// Builder-style: the query engine calls this with
+    /// [`crate::config::QueryConfig::forced_read_path`] so the config knob is
+    /// load-bearing on the read path. `Some(mode)` takes precedence over the
+    /// `CQLITE_READ_PATH` env var; `None` leaves routing to the classifier + env.
+    pub fn with_forced_read_path(
+        mut self,
+        forced_read_path: Option<crate::config::ReadPathMode>,
+    ) -> Self {
+        self.forced_read_path = forced_read_path;
+        self
+    }
+
+    /// Resolve the effective [`crate::config::ReadPathMode`] for a query on this
+    /// executor: the config override wins, else the once-read `CQLITE_READ_PATH`
+    /// env, else `Auto` (issue #1918). Returns [`Error::InvalidReadPath`] when the
+    /// env is the decision source and holds an unrecognized value.
+    fn resolved_read_path_mode(&self) -> Result<crate::config::ReadPathMode> {
+        resolve_read_path_mode(self.forced_read_path)
+    }
+
     /// Create a SELECT executor with a custom clock (for deterministic tests).
     #[cfg(test)]
     pub fn with_clock(
@@ -395,6 +431,7 @@ impl SelectExecutor {
             max_result_bytes: usize::try_from(crate::config::DEFAULT_MAX_RESULT_BYTES)
                 .unwrap_or(usize::MAX),
             max_result_rows: DEFAULT_MAX_RESULT_ROWS,
+            forced_read_path: None,
         }
     }
 
@@ -547,6 +584,12 @@ impl SelectExecutor {
             }
         }
 
+        // Issue #1918: resolve the read-path forcing mode synchronously here (like
+        // the token-predicate validation above), so an invalid `CQLITE_READ_PATH`
+        // fails the query loudly from `execute_streaming` rather than inside the
+        // spawned task (whose error would only reach the consumer as a channel item).
+        let mode = self.resolved_read_path_mode()?;
+
         // Clone what we need for the background task.
         let storage = Arc::clone(&self.storage);
         let buffer_size = config.buffer_size;
@@ -573,6 +616,7 @@ impl SelectExecutor {
                 execution_steps,
                 tx,
                 buffer_size,
+                mode,
             )
             .await
             {

--- a/cqlite-core/src/query/select_executor/stream_agg.rs
+++ b/cqlite-core/src/query/select_executor/stream_agg.rs
@@ -14,9 +14,9 @@ use super::aggregation::{
 };
 use super::row_build::parse_cql_type_str;
 use super::{
-    build_row_from_scan_cached, classify_partition_lookup, evaluate_predicates,
-    validate_token_predicates, AccessPath, ExecutionContext, ExecutionStep, PartitionKeyCache,
-    PartitionLookupOutcome, SelectExecutor,
+    apply_forcing, build_row_from_scan_cached, classify_partition_lookup, evaluate_predicates,
+    validate_token_predicates, AccessPath, ExecutionContext, ExecutionStep, FallbackReason,
+    ForcedPlan, PartitionKeyCache, PartitionLookupOutcome, SelectExecutor,
 };
 use crate::query::result::QueryRow;
 use crate::query::select_ast::WhereExpression;
@@ -185,9 +185,21 @@ impl SelectExecutor {
         // Only a full scan is folded. A targeted / multi-targeted lookup reads one
         // or a few small partitions, so the buffered path's memory is already
         // O(partition) — fall back and let it run unchanged.
-        let reason = match classify_partition_lookup(predicates, schema_opt) {
-            PartitionLookupOutcome::Fallback(reason) => reason,
-            PartitionLookupOutcome::Targeted(_) | PartitionLookupOutcome::MultiTargeted(_) => {
+        //
+        // Issue #1918: apply the single forcing gate here too. Forced `full` folds
+        // over a full scan regardless of classification (recorded as
+        // `ForcedFullScan`); forced `point` fails closed on a `Fallback` (a global
+        // full-scan aggregate is not a partition-targeted lookup) via `apply_forcing`;
+        // a `Targeted`/`MultiTargeted` outcome defers to the buffered path
+        // (`execute_sstable_scan`), which applies the same forcing gate.
+        let mode = self.resolved_read_path_mode()?;
+        let outcome = classify_partition_lookup(predicates, schema_opt);
+        let reason = match apply_forcing(outcome, mode)? {
+            ForcedPlan::ForceFullScan => FallbackReason::ForcedFullScan,
+            ForcedPlan::Proceed(PartitionLookupOutcome::Fallback(reason)) => reason,
+            ForcedPlan::Proceed(
+                PartitionLookupOutcome::Targeted(_) | PartitionLookupOutcome::MultiTargeted(_),
+            ) => {
                 return Ok(None);
             }
         };

--- a/cqlite-core/src/query/select_executor/streaming.rs
+++ b/cqlite-core/src/query/select_executor/streaming.rs
@@ -6,14 +6,15 @@
 //! directly; logic, ordering, and error handling are unchanged.
 
 use super::{
-    build_row_from_scan_cached, classify_partition_lookup, evaluate_predicates,
-    honest_targeted_path, partition_key_digest, sort_rows_by_token, validate_token_predicates,
-    PartitionKeyCache, PartitionLookupOutcome,
+    apply_forcing, build_row_from_scan_cached, classify_partition_lookup, evaluate_predicates,
+    honest_targeted_path, partition_key_digest, point_requires_engaged, sort_rows_by_token,
+    validate_token_predicates, ForcedPlan, PartitionKeyCache, PartitionLookupOutcome,
 };
 use super::{
-    AccessPath, ExecutionStep, QueryRow, Result, SelectExecutor, StorageEngine, TableId,
-    TableSchema,
+    AccessPath, ExecutionStep, FallbackReason, QueryRow, Result, SelectExecutor, StorageEngine,
+    TableId, TableSchema,
 };
+use crate::config::ReadPathMode;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -28,6 +29,10 @@ impl SelectExecutor {
         execution_steps: Vec<ExecutionStep>,
         tx: mpsc::Sender<Result<QueryRow>>,
         buffer_size: usize,
+        // Issue #1918: the read-path forcing mode, resolved once by
+        // `execute_streaming` (so an invalid env value fails the query
+        // synchronously before this task is spawned).
+        mode: ReadPathMode,
     ) -> Result<()> {
         // Issue #581: LIMIT/OFFSET must be enforced by the producer in the
         // streaming path. The `ExecutionStep::Limit` arm previously only logged a
@@ -94,8 +99,22 @@ impl SelectExecutor {
                     // materializing `scan()` (last-write-wins + tombstone shadowing),
                     // which is the authoritative read semantics; it does not merely
                     // mirror `scan_stream`'s per-key merge.
-                    let lookup = classify_partition_lookup(predicates, schema_opt);
-                    if let PartitionLookupOutcome::Targeted(ref pk_bytes) = lookup {
+                    // Issue #1918: the single forcing gate wraps the classifier
+                    // outcome. Forced `full` records the distinct `ForcedFullScan`
+                    // reason and skips the targeted branches (`lookup = None`) so
+                    // the shared full-scan streaming code below runs; `point` fails
+                    // closed on a classification `Fallback` inside `apply_forcing`.
+                    let outcome = classify_partition_lookup(predicates, schema_opt);
+                    let lookup = match apply_forcing(outcome, mode)? {
+                        ForcedPlan::ForceFullScan => {
+                            crate::query::access_path::record(AccessPath::FallbackFullScan {
+                                reason: FallbackReason::ForcedFullScan,
+                            });
+                            None
+                        }
+                        ForcedPlan::Proceed(o) => Some(o),
+                    };
+                    if let Some(PartitionLookupOutcome::Targeted(ref pk_bytes)) = lookup {
                         // Issue #960: the streaming analogue of the materializing
                         // partition-targeted lookup. Epic #951 (honest paths): the
                         // `tombstones` build's `scan_partition` is a full-scan +
@@ -103,6 +122,13 @@ impl SelectExecutor {
                         // claim `StreamingPartitionLookup` when it really pruned.
                         let (rows, engaged) =
                             storage.scan_partition(table, pk_bytes, schema_opt).await?;
+                        // Issue #1918: `point` fails closed on the tombstones-build
+                        // no-prune rather than silently full-scanning.
+                        point_requires_engaged(
+                            mode,
+                            engaged,
+                            FallbackReason::TombstonesBuildNoPrune,
+                        )?;
                         crate::query::access_path::record(honest_targeted_path(
                             AccessPath::StreamingPartitionLookup,
                             engaged,
@@ -166,7 +192,7 @@ impl SelectExecutor {
                     // union of N partition-targeted lookups. Gather them, sort by
                     // token to match full-scan order, then drive the same per-row
                     // pipeline (predicates, PER PARTITION LIMIT, OFFSET, LIMIT).
-                    if let PartitionLookupOutcome::MultiTargeted(ref pk_keys) = lookup {
+                    if let Some(PartitionLookupOutcome::MultiTargeted(ref pk_keys)) = lookup {
                         // Epic #951 (honest paths): each lookup reports whether it
                         // pruned. On the `tombstones` build every call full-scans
                         // (`engaged == false`); claim `MultiPartitionLookup` only when
@@ -179,6 +205,13 @@ impl SelectExecutor {
                             all_engaged &= engaged;
                             combined.extend(rows);
                         }
+                        // Issue #1918: `point` fails closed when the fan-out did not
+                        // prune (tombstones build).
+                        point_requires_engaged(
+                            mode,
+                            all_engaged,
+                            FallbackReason::TombstonesBuildNoPrune,
+                        )?;
                         crate::query::access_path::record(honest_targeted_path(
                             AccessPath::MultiPartitionLookup,
                             all_engaged,
@@ -243,8 +276,10 @@ impl SelectExecutor {
                     // Issue #960: the streaming path did not take a targeted
                     // lookup; report the honest fallback reason. `lookup` is the
                     // `Fallback` arm here (the `Targeted`/`MultiTargeted` arms
-                    // returned above via `continue`).
-                    if let PartitionLookupOutcome::Fallback(reason) = lookup {
+                    // returned above via `continue`). Issue #1918: forced `full`
+                    // (`lookup == None`) already recorded `ForcedFullScan` above, so
+                    // it falls straight through to the full scan without re-recording.
+                    if let Some(PartitionLookupOutcome::Fallback(reason)) = lookup {
                         crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
                     }
 

--- a/cqlite-core/tests/point_vs_full_differential.rs
+++ b/cqlite-core/tests/point_vs_full_differential.rs
@@ -1,0 +1,521 @@
+//! Issue #1918: the POINT-vs-FULL differential-equality lane.
+//!
+//! The CQLite-vs-CQLite complement to the CQLite-vs-Cassandra query-semantics
+//! oracle (`query_semantics_oracle_parity.rs`, #1742). It runs the same
+//! point-read-eligible query through BOTH forced access paths —
+//! `CQLITE_READ_PATH=point` (a partition-targeted lookup) and
+//! `CQLITE_READ_PATH=full` (a full scan + reconciliation) — via the
+//! `QueryConfig::forced_read_path` knob and asserts the two paths return
+//! byte-identical result sets (rows, values, AND order).
+//!
+//! Why this catches bugs a physical dump cannot: the `*-Data.db.jsonl` goldens
+//! enumerate every on-disk cell (tombstones/expired included), so a
+//! read-time-reconciliation divergence between the point and full paths is
+//! invisible to them (both retain the shadowed rows). This lane compares the
+//! POST-reconciliation `SELECT` result of the two paths directly — precisely the
+//! divergence class #1741 hid behind green physical goldens.
+//!
+//! It is a **query-semantics-class** oracle: TTL expiry is evaluated at a PINNED
+//! `now` via the debug-only `CQLITE_TTL_NOW_OVERRIDE_SECS` reader seam (never
+//! wall-clock), so a long-expired fixture reads deterministically and the point
+//! and full runs see identical expiry. The corpus deliberately includes
+//! multi-generation, tombstone, and TTL fixtures (`test_tomb`,
+//! `test_compaction_tombstone_ttl`) — the reconciliation classes the lane exists
+//! to guard.
+//!
+//! Anti-empty-pass / SKIP contract (matches the query-semantics oracle):
+//!   * When the committed corpus (or its `*.db` binaries) is absent, each case
+//!     SKIPs cleanly — UNLESS `CQLITE_REQUIRE_FIXTURES=1` (the agent-gate
+//!     integration-tests tier sets it), in which case an absent/empty fixture is
+//!     a hard FAIL so the lane can never green-pass without running.
+//!   * A case that discovers ZERO partition keys in a present fixture is a hard
+//!     FAIL (a fixture with rows must yield at least one point query), never a
+//!     silent vacuous pass.
+//!
+//! The harness's divergence detection is itself regression-tested by
+//! `comparison_detects_a_seeded_divergence` below (feeding the compare helper two
+//! different row sets must report a mismatch), complementing the manual
+//! seed-a-real-divergence verification recorded in the PR.
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::config::ReadPathMode;
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::QueryRow;
+use cqlite_core::{Config, Database};
+
+/// Debug-only reader seam (see `now_clock.rs`): pins read-time TTL "now" so TTL
+/// expiry is deterministic and IDENTICAL across the point and full runs.
+const TTL_NOW_OVERRIDE_ENV: &str = "CQLITE_TTL_NOW_OVERRIDE_SECS";
+
+/// A fixed pin well past every fixture's TTL boundary. The exact value is
+/// immaterial to point-vs-full EQUALITY (both runs use the same pin); a fixed
+/// value simply removes wall-clock flakiness. 2027-01-15T08:00:00Z.
+const PINNED_NOW_SECS: i64 = 1_800_000_000;
+
+/// The most point-query keys probed per table (bounds worst-case fan-out on a
+/// wide corpus while still covering every distinct partition in the small
+/// tombstone/TTL fixtures, which have only a handful of partitions).
+const MAX_KEYS_PER_TABLE: usize = 32;
+
+fn require_fixtures() -> bool {
+    std::env::var("CQLITE_REQUIRE_FIXTURES")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// One corpus table: a single-column INT partition key (so a `WHERE pk = <int>`
+/// literal is trivial and unambiguous to build). `divergence_classes` documents
+/// which reconciliation class the fixture exercises (multi-generation /
+/// tombstone / TTL), asserting the corpus stays exhaustive over #1741's classes.
+struct TableCase {
+    keyspace: &'static str,
+    table: &'static str,
+    schema: &'static str,
+    /// The single INT partition-key column name.
+    pk_column: &'static str,
+    /// Partition keys ALWAYS probed in addition to the ones discovered by a live
+    /// scan. Needed for fixtures whose partitions reconcile to ZERO live rows
+    /// (e.g. a partition-tombstone-only table): discovery finds nothing, yet the
+    /// point-vs-full equality of an empty-on-both-paths partition is a genuine
+    /// #1741 shadowing check, not a vacuous pass.
+    probe_keys: &'static [i64],
+    /// Documented reconciliation classes this fixture covers (for the corpus
+    /// coverage assertion; not used at query time).
+    divergence_classes: &'static [&'static str],
+}
+
+/// The corpus. Every table has a single INT partition key. Collectively they
+/// cover multi-generation reconciliation (`test_tomb` 2-gen tables), tombstones
+/// (row/cell/range/partition deletes), and TTL expiry (`gc_before_boundary`,
+/// `ttl_expired_live`).
+const CORPUS: &[TableCase] = &[
+    // Multi-generation (2 flushes) + cross-gen deletes shadowing older live rows.
+    TableCase {
+        keyspace: "test_tomb",
+        table: "resurrection_gc0",
+        schema: "tombstone-parity.cql",
+        pk_column: "pk",
+        probe_keys: &[],
+        divergence_classes: &["multi_generation", "tombstone"],
+    },
+    TableCase {
+        keyspace: "test_tomb",
+        table: "resurrection_gc_positive",
+        schema: "tombstone-parity.cql",
+        pk_column: "pk",
+        probe_keys: &[],
+        divergence_classes: &["multi_generation", "tombstone"],
+    },
+    // Cross-generation partition tombstone + a tombstone-only partition.
+    TableCase {
+        keyspace: "test_tomb",
+        table: "skipped_partition_delete",
+        schema: "tombstone-parity.cql",
+        pk_column: "pk",
+        probe_keys: &[1, 2],
+        divergence_classes: &["multi_generation", "tombstone"],
+    },
+    // TTL localDeletionTime boundary (expired vs live cells).
+    TableCase {
+        keyspace: "test_tomb",
+        table: "gc_before_boundary",
+        schema: "tombstone-parity.cql",
+        pk_column: "pk",
+        probe_keys: &[],
+        divergence_classes: &["ttl"],
+    },
+    // Live static cell surviving adjacent row/cell/range tombstones.
+    TableCase {
+        keyspace: "test_tomb",
+        table: "static_with_tombstones",
+        schema: "tombstone-parity.cql",
+        pk_column: "pk",
+        probe_keys: &[],
+        divergence_classes: &["tombstone"],
+    },
+    // Post-major-compaction tombstone/TTL fixtures (single output SSTable).
+    TableCase {
+        keyspace: "test_compaction_tombstone_ttl",
+        table: "shadow_row_delete",
+        schema: "compaction-tombstone-ttl-parity.cql",
+        pk_column: "id",
+        probe_keys: &[],
+        divergence_classes: &["tombstone"],
+    },
+    TableCase {
+        keyspace: "test_compaction_tombstone_ttl",
+        table: "ttl_expired_live",
+        schema: "compaction-tombstone-ttl-parity.cql",
+        pk_column: "id",
+        probe_keys: &[],
+        divergence_classes: &["ttl"],
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Path resolution (mirrors query_semantics_oracle_parity.rs)
+// ---------------------------------------------------------------------------
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cqlite-core has a parent repo dir")
+        .to_path_buf()
+}
+
+fn sstables_root(keyspace: &str) -> Option<PathBuf> {
+    let candidates = [
+        std::env::var("CQLITE_DATASETS_ROOT")
+            .ok()
+            .map(|r| PathBuf::from(r).join("sstables")),
+        Some(
+            repo_root()
+                .join("test-data")
+                .join("datasets")
+                .join("sstables"),
+        ),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|root| root.join(keyspace).is_dir())
+}
+
+fn schema_path(file: &str) -> Option<PathBuf> {
+    let candidates = [
+        std::env::var("CQLITE_DATASETS_ROOT").ok().and_then(|r| {
+            PathBuf::from(r)
+                .parent()
+                .map(|p| p.join("schemas").join(file))
+        }),
+        Some(repo_root().join("test-data").join("schemas").join(file)),
+    ];
+    candidates.into_iter().flatten().find(|p| p.exists())
+}
+
+/// True when the keyspace dir holds at least one `*-Data.db` for `table` — i.e.
+/// the (gitignored) binaries have actually been fetched, not just the JSONL.
+fn table_has_data(root: &Path, keyspace: &str, table: &str) -> bool {
+    let ks_dir = root.join(keyspace);
+    let Ok(entries) = std::fs::read_dir(&ks_dir) else {
+        return false;
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(&format!("{table}-")))
+                    .unwrap_or(false)
+        })
+        .any(|dir| {
+            std::fs::read_dir(&dir)
+                .map(|rd| {
+                    rd.filter_map(|e| e.ok()).any(|e| {
+                        e.file_name()
+                            .to_str()
+                            .map(|n| n.ends_with("-Data.db"))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Result normalization (authoritative; never a byte-pattern guess)
+// ---------------------------------------------------------------------------
+
+/// Normalize a result set to an ORDERED list of per-row strings, each a
+/// sorted-by-column-name `Debug` rendering of the row's values. `Debug` on
+/// `Value` is stable and total across every CQL type (scalars, collections,
+/// UDTs), so the comparison covers all values without a hand-maintained matcher;
+/// sorting columns within a row removes `HashMap` iteration nondeterminism while
+/// preserving ROW order (asserted per spec: rows, values, AND order).
+fn normalize(rows: &[QueryRow]) -> Vec<String> {
+    rows.iter()
+        .map(|row| {
+            let sorted: BTreeMap<&str, String> = row
+                .values
+                .iter()
+                .map(|(k, v)| (k.as_ref(), format!("{v:?}")))
+                .collect();
+            format!("{sorted:?}")
+        })
+        .collect()
+}
+
+/// Build a `Database` over the fixture with a fixed read-path forcing mode.
+async fn open_db(
+    root: &Path,
+    schema: &Path,
+    keyspace: &str,
+    mode: ReadPathMode,
+) -> Result<Database, String> {
+    let mut core_config = Config::default();
+    core_config.query.forced_read_path = Some(mode);
+    let cfg = IngestionConfig {
+        schema_paths: vec![schema.to_path_buf()],
+        data_dir: root.to_path_buf(),
+        version_hint: None,
+        core_config,
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    };
+    let result = ingest(cfg).await.map_err(|e| format!("ingestion: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".into());
+    }
+    Ok(result.database)
+}
+
+/// Discover the DISTINCT integer partition-key values present in `table` by
+/// running a full-scan `SELECT` (on the `full`-mode DB, so a full-table read is
+/// legal). Returns them sorted + deduplicated so the probe set is deterministic.
+async fn discover_pk_ints(db: &Database, case: &TableCase) -> Result<Vec<i64>, String> {
+    let query = format!(
+        "SELECT {} FROM {}.{}",
+        case.pk_column, case.keyspace, case.table
+    );
+    let result = db
+        .execute(&query)
+        .await
+        .map_err(|e| format!("discovery SELECT failed: {e}"))?;
+    let mut seen: BTreeMap<i64, ()> = BTreeMap::new();
+    for row in &result.rows {
+        if let Some(v) = row.values.get(case.pk_column) {
+            let as_int = value_as_i64(v).ok_or_else(|| {
+                format!(
+                    "partition key {} decoded as a non-integer value {v:?}; this lane \
+                     only handles INT partition keys",
+                    case.pk_column
+                )
+            })?;
+            seen.insert(as_int, ());
+        }
+    }
+    Ok(seen.into_keys().take(MAX_KEYS_PER_TABLE).collect())
+}
+
+/// Extract an `i64` from any integer-family `Value`.
+fn value_as_i64(v: &cqlite_core::types::Value) -> Option<i64> {
+    use cqlite_core::types::Value;
+    match v {
+        Value::TinyInt(i) => Some(*i as i64),
+        Value::SmallInt(i) => Some(*i as i64),
+        Value::Integer(i) => Some(*i as i64),
+        Value::BigInt(i) | Value::Counter(i) | Value::Timestamp(i) => Some(*i),
+        _ => None,
+    }
+}
+
+/// Run `query` under both forced modes and assert byte-identical (rows, values,
+/// order) result sets. Returns the diff description on mismatch.
+async fn assert_point_full_equal(
+    point_db: &Database,
+    full_db: &Database,
+    query: &str,
+) -> Result<(), String> {
+    let point = point_db
+        .execute(query)
+        .await
+        .map_err(|e| format!("point path failed for `{query}`: {e}"))?;
+    let full = full_db
+        .execute(query)
+        .await
+        .map_err(|e| format!("full path failed for `{query}`: {e}"))?;
+
+    let point_rows = normalize(&point.rows);
+    let full_rows = normalize(&full.rows);
+    if point_rows != full_rows {
+        return Err(format!(
+            "point-vs-full DIVERGENCE for `{query}`:\n  point ({} rows): {:#?}\n  full  ({} rows): {:#?}",
+            point_rows.len(),
+            point_rows,
+            full_rows.len(),
+            full_rows
+        ));
+    }
+    Ok(())
+}
+
+/// Run every eligible query for one table under `point` and `full`, asserting
+/// equality. `Ok(true)` = ran a comparison, `Ok(false)` = SKIPped (absent
+/// fixture, non-fail-closed).
+async fn run_case(case: &TableCase) -> Result<bool, String> {
+    let Some(root) = sstables_root(case.keyspace) else {
+        return skip_or_fail(&format!("keyspace {} absent", case.keyspace));
+    };
+    if !table_has_data(&root, case.keyspace, case.table) {
+        return skip_or_fail(&format!(
+            "table {}.{} has no fetched *-Data.db",
+            case.keyspace, case.table
+        ));
+    }
+    let Some(schema) = schema_path(case.schema) else {
+        return skip_or_fail(&format!("schema {} absent", case.schema));
+    };
+
+    let full_db = open_db(&root, &schema, case.keyspace, ReadPathMode::Full).await?;
+    let point_db = open_db(&root, &schema, case.keyspace, ReadPathMode::Point).await?;
+
+    let discovered = discover_pk_ints(&full_db, case).await?;
+    // Merge discovered (live) keys with the always-probe keys, deduplicated and
+    // sorted so the probe set is deterministic.
+    let mut key_set: BTreeMap<i64, ()> = BTreeMap::new();
+    for k in discovered.iter().chain(case.probe_keys.iter()) {
+        key_set.insert(*k, ());
+    }
+    let keys: Vec<i64> = key_set.into_keys().take(MAX_KEYS_PER_TABLE).collect();
+    // Anti-empty-pass: a present fixture MUST yield at least one partition key to
+    // probe (discovered or explicit), else the lane would run zero comparisons
+    // and pass vacuously. A table that reconciles to zero LIVE rows must declare
+    // explicit `probe_keys` (so the empty-on-both-paths equality is still checked).
+    if keys.is_empty() {
+        return Err(format!(
+            "case {}.{}: no partition keys to probe (discovered none and no \
+             explicit probe_keys) — a present fixture must yield at least one \
+             point query; declare probe_keys for a fully-reconciled-away table",
+            case.keyspace, case.table
+        ));
+    }
+
+    // Single-key `=` equality for every discovered partition.
+    for k in &keys {
+        let query = format!(
+            "SELECT * FROM {}.{} WHERE {} = {}",
+            case.keyspace, case.table, case.pk_column, k
+        );
+        assert_point_full_equal(&point_db, &full_db, &query).await?;
+    }
+
+    // `IN (...)` over the complete partition key (when ≥2 keys exist): the union
+    // of targeted lookups (point) must equal the full-scan + in-memory IN filter.
+    if keys.len() >= 2 {
+        let list = keys
+            .iter()
+            .map(|k| k.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let query = format!(
+            "SELECT * FROM {}.{} WHERE {} IN ({})",
+            case.keyspace, case.table, case.pk_column, list
+        );
+        assert_point_full_equal(&point_db, &full_db, &query).await?;
+    }
+
+    eprintln!(
+        "PASS {}.{} — {} point queries + IN, point == full (classes: {:?})",
+        case.keyspace,
+        case.table,
+        keys.len(),
+        case.divergence_classes
+    );
+    Ok(true)
+}
+
+/// Either SKIP cleanly (returning `Ok(false)`) or, under `CQLITE_REQUIRE_FIXTURES`,
+/// fail closed.
+fn skip_or_fail(msg: &str) -> Result<bool, String> {
+    if require_fixtures() {
+        return Err(format!("REQUIRE_FIXTURES: {msg}"));
+    }
+    eprintln!("SKIP {msg}");
+    Ok(false)
+}
+
+#[tokio::test]
+async fn point_vs_full_differential_equality() {
+    // Corpus coverage assertion: the lane must exercise every #1741 divergence
+    // class (multi-generation, tombstone, TTL) — never silently narrow to a
+    // trivial live-only corpus.
+    let covered: std::collections::BTreeSet<&str> = CORPUS
+        .iter()
+        .flat_map(|c| c.divergence_classes.iter().copied())
+        .collect();
+    for required in ["multi_generation", "tombstone", "ttl"] {
+        assert!(
+            covered.contains(required),
+            "corpus must cover the {required:?} reconciliation class (issue #1741 divergence set)"
+        );
+    }
+
+    // Pin the read-time TTL clock for the whole run (single-threaded here, so no
+    // sibling test in this binary races the process-global env seam).
+    std::env::set_var(TTL_NOW_OVERRIDE_ENV, PINNED_NOW_SECS.to_string());
+
+    let mut ran = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    for case in CORPUS {
+        match run_case(case).await {
+            Ok(true) => ran += 1,
+            Ok(false) => {}
+            Err(e) => failures.push(format!("{}.{}: {e}", case.keyspace, case.table)),
+        }
+    }
+
+    std::env::remove_var(TTL_NOW_OVERRIDE_ENV);
+
+    assert!(
+        failures.is_empty(),
+        "point-vs-full differential failures:\n{}",
+        failures.join("\n\n")
+    );
+
+    if require_fixtures() {
+        assert!(
+            ran > 0,
+            "CQLITE_REQUIRE_FIXTURES=1 but no differential case ran (fixtures absent) — fail-closed"
+        );
+    } else if ran == 0 {
+        eprintln!(
+            "SKIP point_vs_full_differential: no fixtures present \
+             (set CQLITE_REQUIRE_FIXTURES=1 to fail-close)"
+        );
+    }
+}
+
+/// Regression-test the harness itself: the compare logic MUST flag a divergence
+/// (a different or reordered row set) rather than silently passing — the
+/// "demonstrably fail if either path is broken" contract, at the harness level.
+#[test]
+fn comparison_detects_a_seeded_divergence() {
+    use cqlite_core::query::result::RowMetadata;
+    use cqlite_core::types::{RowKey, Value};
+
+    fn row(id: i64) -> QueryRow {
+        let mut values = std::collections::HashMap::new();
+        values.insert("id".into(), Value::Integer(id as i32));
+        QueryRow {
+            values,
+            key: RowKey::from(id.to_be_bytes().to_vec()),
+            metadata: RowMetadata::default(),
+            cell_metadata: None,
+        }
+    }
+
+    let base = vec![row(1), row(2), row(3)];
+
+    // Identical sets compare equal.
+    assert_eq!(normalize(&base), normalize(&base));
+
+    // A DIFFERENT value set diverges.
+    let altered_value = vec![row(1), row(9), row(3)];
+    assert_ne!(
+        normalize(&base),
+        normalize(&altered_value),
+        "a differing row value must be detected as a divergence"
+    );
+
+    // A REORDERED set diverges (order is asserted, not just the multiset).
+    let reordered = vec![row(3), row(2), row(1)];
+    assert_ne!(
+        normalize(&base),
+        normalize(&reordered),
+        "a reordered row set must be detected as a divergence (order matters)"
+    );
+}

--- a/cqlite-core/tests/read_path_forcing_e2e.rs
+++ b/cqlite-core/tests/read_path_forcing_e2e.rs
@@ -1,0 +1,265 @@
+//! Issue #1918: end-to-end wiring evidence for the read-path forcing knob.
+//!
+//! These tests exercise the knob through the REAL public read surface
+//! (`Database::execute`, config-wired via `QueryConfig::forced_read_path`) — not a
+//! helper-only unit test — and assert the observable contract via the public
+//! `AccessPath` probe (`cqlite_core::query::access_path::last`) and the public
+//! `Error` surface:
+//!
+//!   * forced `full` on a targeted query records `FallbackFullScan{ForcedFullScan}`
+//!     and returns the SAME rows as `auto`;
+//!   * forced `point` on a non-targeted query (`SELECT *`, no partition key) fails
+//!     closed with `Error::ForcedReadPathUnavailable`, returning NO rows;
+//!   * forced `point` on a fully-constrained `WHERE pk = ?` runs the targeted path.
+//!
+//! Cases run sequentially in ONE test each (the `AccessPath` probe is
+//! process-global), against a committed INT-partition-key fixture. SKIP-loud when
+//! the fixture is absent, fail-closed under `CQLITE_REQUIRE_FIXTURES=1`.
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::config::ReadPathMode;
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::access_path::{AccessPath, FallbackReason};
+use cqlite_core::query::result::QueryRow;
+use cqlite_core::{Config, Database, Error};
+
+/// A committed single-INT-partition-key fixture with surviving live rows.
+const KEYSPACE: &str = "test_compaction_tombstone_ttl";
+const TABLE: &str = "shadow_row_delete";
+const SCHEMA: &str = "compaction-tombstone-ttl-parity.cql";
+const PK_COLUMN: &str = "id";
+
+fn require_fixtures() -> bool {
+    std::env::var("CQLITE_REQUIRE_FIXTURES")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cqlite-core has a parent repo dir")
+        .to_path_buf()
+}
+
+fn sstables_root() -> Option<PathBuf> {
+    let candidates = [
+        std::env::var("CQLITE_DATASETS_ROOT")
+            .ok()
+            .map(|r| PathBuf::from(r).join("sstables")),
+        Some(
+            repo_root()
+                .join("test-data")
+                .join("datasets")
+                .join("sstables"),
+        ),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|root| root.join(KEYSPACE).is_dir())
+}
+
+fn schema_path() -> Option<PathBuf> {
+    let candidates = [
+        std::env::var("CQLITE_DATASETS_ROOT").ok().and_then(|r| {
+            PathBuf::from(r)
+                .parent()
+                .map(|p| p.join("schemas").join(SCHEMA))
+        }),
+        Some(repo_root().join("test-data").join("schemas").join(SCHEMA)),
+    ];
+    candidates.into_iter().flatten().find(|p| p.exists())
+}
+
+fn table_has_data(root: &Path) -> bool {
+    let ks_dir = root.join(KEYSPACE);
+    let Ok(entries) = std::fs::read_dir(&ks_dir) else {
+        return false;
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(&format!("{TABLE}-")))
+                    .unwrap_or(false)
+        })
+        .any(|dir| {
+            std::fs::read_dir(&dir)
+                .map(|rd| {
+                    rd.filter_map(|e| e.ok()).any(|e| {
+                        e.file_name()
+                            .to_str()
+                            .map(|n| n.ends_with("-Data.db"))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        })
+}
+
+async fn open_db(root: &Path, schema: &Path, mode: Option<ReadPathMode>) -> Database {
+    let mut core_config = Config::default();
+    core_config.query.forced_read_path = mode;
+    let cfg = IngestionConfig {
+        schema_paths: vec![schema.to_path_buf()],
+        data_dir: root.to_path_buf(),
+        version_hint: None,
+        core_config,
+        table_directory_filter: Some(format!("/{KEYSPACE}/")),
+    };
+    let result = ingest(cfg).await.expect("ingestion succeeds");
+    assert!(
+        result.schema_load_result.schemas_loaded > 0,
+        "schema must load"
+    );
+    result.database
+}
+
+fn normalize(rows: &[QueryRow]) -> Vec<String> {
+    rows.iter()
+        .map(|row| {
+            let sorted: BTreeMap<&str, String> = row
+                .values
+                .iter()
+                .map(|(k, v)| (k.as_ref(), format!("{v:?}")))
+                .collect();
+            format!("{sorted:?}")
+        })
+        .collect()
+}
+
+/// Resolve the fixture paths, or `None` (SKIP / fail-closed) when absent.
+fn resolve() -> Option<(PathBuf, PathBuf)> {
+    let Some(root) = sstables_root() else {
+        handle_absent("keyspace absent");
+        return None;
+    };
+    if !table_has_data(&root) {
+        handle_absent("no fetched *-Data.db");
+        return None;
+    }
+    let Some(schema) = schema_path() else {
+        handle_absent("schema absent");
+        return None;
+    };
+    Some((root, schema))
+}
+
+fn handle_absent(msg: &str) {
+    if require_fixtures() {
+        panic!("REQUIRE_FIXTURES: {KEYSPACE}.{TABLE}: {msg}");
+    }
+    eprintln!("SKIP {KEYSPACE}.{TABLE}: {msg}");
+}
+
+/// Discover the first live INT partition key via an unforced (auto) scan.
+async fn first_live_pk(db: &Database) -> Option<i64> {
+    let result = db
+        .execute(&format!("SELECT {PK_COLUMN} FROM {KEYSPACE}.{TABLE}"))
+        .await
+        .expect("discovery SELECT succeeds");
+    result.rows.iter().find_map(|row| {
+        row.values.get(PK_COLUMN).and_then(|v| match v {
+            cqlite_core::types::Value::Integer(i) => Some(*i as i64),
+            cqlite_core::types::Value::BigInt(i) => Some(*i),
+            _ => None,
+        })
+    })
+}
+
+#[tokio::test]
+async fn forced_full_records_forced_fallback_and_matches_auto_rows() {
+    let Some((root, schema)) = resolve() else {
+        return;
+    };
+    let auto_db = open_db(&root, &schema, None).await;
+    let Some(pk) = first_live_pk(&auto_db).await else {
+        panic!("fixture {KEYSPACE}.{TABLE} has no live partition to point-query");
+    };
+    let query = format!("SELECT * FROM {KEYSPACE}.{TABLE} WHERE {PK_COLUMN} = {pk}");
+
+    // auto: baseline rows.
+    let auto_rows = normalize(&auto_db.execute(&query).await.expect("auto SELECT").rows);
+
+    // full: same query, forced full scan. Records the DISTINCT forced fallback,
+    // and returns byte-identical rows/values/order to auto. Assert on the
+    // PER-QUERY `metadata.access_path` (not the process-global probe, which races
+    // across these parallel `#[tokio::test]`s).
+    let full_db = open_db(&root, &schema, Some(ReadPathMode::Full)).await;
+    let full_result = full_db.execute(&query).await.expect("full SELECT");
+    assert_eq!(
+        full_result.metadata.access_path,
+        Some(AccessPath::FallbackFullScan {
+            reason: FallbackReason::ForcedFullScan
+        }),
+        "forced full must record FallbackFullScan{{ForcedFullScan}}"
+    );
+    assert_eq!(
+        auto_rows,
+        normalize(&full_result.rows),
+        "forced full must return the same rows/values/order as auto"
+    );
+}
+
+#[tokio::test]
+async fn forced_point_on_non_targeted_query_fails_closed() {
+    let Some((root, schema)) = resolve() else {
+        return;
+    };
+    let point_db = open_db(&root, &schema, Some(ReadPathMode::Point)).await;
+    // A full-table SELECT (no partition key constraint) is NOT partition-targeted,
+    // so forced point must fail closed rather than silently full-scan.
+    let err = point_db
+        .execute(&format!("SELECT * FROM {KEYSPACE}.{TABLE}"))
+        .await
+        .expect_err("forced point on a full-table scan must fail closed");
+    match err {
+        Error::ForcedReadPathUnavailable { forced, reason } => {
+            assert_eq!(forced, "point");
+            assert_eq!(reason, "partition_key_not_fully_constrained");
+        }
+        other => panic!("expected ForcedReadPathUnavailable, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn forced_point_on_full_pk_takes_targeted_path() {
+    let Some((root, schema)) = resolve() else {
+        return;
+    };
+    let auto_db = open_db(&root, &schema, None).await;
+    let Some(pk) = first_live_pk(&auto_db).await else {
+        panic!("fixture {KEYSPACE}.{TABLE} has no live partition to point-query");
+    };
+    let query = format!("SELECT * FROM {KEYSPACE}.{TABLE} WHERE {PK_COLUMN} = {pk}");
+    let auto_rows = normalize(&auto_db.execute(&query).await.expect("auto SELECT").rows);
+
+    let point_db = open_db(&root, &schema, Some(ReadPathMode::Point)).await;
+    let result = point_db
+        .execute(&query)
+        .await
+        .expect("forced point on a fully-constrained pk must succeed");
+    // Per-query metadata (race-free across the parallel tests).
+    let path = result
+        .metadata
+        .access_path
+        .clone()
+        .expect("a path must be recorded");
+    assert!(
+        path.is_targeted(),
+        "forced point on a full pk must take a targeted path, got {path:?}"
+    );
+    assert!(
+        !path.is_full_scan(),
+        "forced point must not fall back to a full scan, got {path:?}"
+    );
+    // And the rows still match auto (forcing governs routing only, not decoding).
+    assert_eq!(auto_rows, normalize(&result.rows));
+}

--- a/cqlite-core/tests/read_path_forcing_e2e.rs
+++ b/cqlite-core/tests/read_path_forcing_e2e.rs
@@ -2,9 +2,8 @@
 //!
 //! These tests exercise the knob through the REAL public read surface
 //! (`Database::execute`, config-wired via `QueryConfig::forced_read_path`) — not a
-//! helper-only unit test — and assert the observable contract via the public
-//! `AccessPath` probe (`cqlite_core::query::access_path::last`) and the public
-//! `Error` surface:
+//! helper-only unit test — and assert the observable contract via the per-query
+//! `QueryResult.metadata.access_path` and the public `Error` surface:
 //!
 //!   * forced `full` on a targeted query records `FallbackFullScan{ForcedFullScan}`
 //!     and returns the SAME rows as `auto`;
@@ -12,9 +11,10 @@
 //!     closed with `Error::ForcedReadPathUnavailable`, returning NO rows;
 //!   * forced `point` on a fully-constrained `WHERE pk = ?` runs the targeted path.
 //!
-//! Cases run sequentially in ONE test each (the `AccessPath` probe is
-//! process-global), against a committed INT-partition-key fixture. SKIP-loud when
-//! the fixture is absent, fail-closed under `CQLITE_REQUIRE_FIXTURES=1`.
+//! Assertions read the PER-QUERY `metadata.access_path` (not the process-global
+//! `access_path::last()` probe), so the three `#[tokio::test]`s are safe to run in
+//! parallel. Against a committed INT-partition-key fixture; SKIP-loud when the
+//! fixture is absent, fail-closed under `CQLITE_REQUIRE_FIXTURES=1`.
 #![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
 
 use std::collections::BTreeMap;

--- a/cqlite-core/tests/read_path_forcing_schemaless_1918.rs
+++ b/cqlite-core/tests/read_path_forcing_schemaless_1918.rs
@@ -1,0 +1,158 @@
+//! Issue #1918 (review fix): forced `full` MUST NOT silently diverge from `auto`
+//! for a SCHEMA-LESS sole-pk point lookup.
+//!
+//! The forcing spec (`read-path-forcing/spec.md`) has an explicit SHALL: forced
+//! `full`'s returned rows must be identical to `auto`'s. For a schema-less
+//! `WHERE pk = <literal>` point read that only the specialized #1750 targeted seek
+//! can serve, a general full scan CANNOT reconstruct the pk column from the row
+//! bytes, so its per-row predicate backstop rejects every row and returns 0 rows —
+//! a SILENT divergence from `auto` (which serves the row via the seek). Rather than
+//! diverge silently, forced `full` now fails closed with
+//! `Error::ForcedReadPathUnavailable`.
+//!
+//! This is the shape neither `point_vs_full_differential.rs` nor
+//! `read_path_forcing_e2e.rs` catches (both always load a schema, so the full-scan
+//! predicate backstop CAN reconstruct the pk and both return the row).
+//!
+//! Non-vacuous guard: `auto` and `point` return exactly the one matching row here,
+//! so the `full` assertion is meaningfully "full alone cannot serve this without
+//! diverging". Reverting the fix (letting forced `full` fall through to the full
+//! scan) makes `full` return `Ok(0 rows)` and this test's error assertion fail.
+//!
+//! Against a committed single-INT-partition-key fixture; SKIP-loud when absent.
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::PathBuf;
+
+use cqlite_core::config::ReadPathMode;
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::{Config, Database, Error, Value};
+
+/// `test_compactionparity.live_no_clustering` is `id INT PRIMARY KEY, v TEXT` —
+/// a true single-component `int` partition key with NO clustering columns, the
+/// exact sole-pk shape the schema-less #1750 seek serves. Partition keys are 1..=4.
+const INT_PK_TABLE: &str = "test_compactionparity.live_no_clustering";
+const TABLE_FILTER: &str = "/test_compactionparity/live_no_clustering";
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// Open the int-pk fixture SCHEMA-LESS with a given forced read-path mode.
+async fn setup_schemaless(mode: Option<ReadPathMode>) -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let mut core_config = Config::default();
+    core_config.query.forced_read_path = mode;
+    let config = IngestionConfig {
+        schema_paths: vec![],
+        data_dir,
+        version_hint: None,
+        core_config,
+        table_directory_filter: Some(TABLE_FILTER.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    Ok(result.database)
+}
+
+/// Skip cleanly unless the fixture is present with live rows (so a later 0/err is
+/// meaningful, never a false pass on an empty dataset).
+async fn present_or_skip(mode: Option<ReadPathMode>) -> Option<Database> {
+    let db = match setup_schemaless(mode).await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("SKIP {INT_PK_TABLE}: {e}");
+            return None;
+        }
+    };
+    let probe = db
+        .execute(&format!("SELECT * FROM {INT_PK_TABLE}"))
+        .await
+        .ok()?;
+    if probe.rows.is_empty() {
+        eprintln!("SKIP {INT_PK_TABLE}: present but 0 rows");
+        return None;
+    }
+    Some(db)
+}
+
+/// `auto` serves the schema-less sole-pk point lookup: exactly the one matching row.
+#[tokio::test]
+async fn auto_schemaless_sole_pk_lookup_returns_the_row() {
+    let Some(db) = present_or_skip(None).await else {
+        return;
+    };
+    let hit = db
+        .execute(&format!(
+            "SELECT * FROM {INT_PK_TABLE} WHERE partition_key = 1"
+        ))
+        .await
+        .expect("auto schema-less sole-pk lookup must succeed");
+    assert_eq!(
+        hit.rows.len(),
+        1,
+        "auto must serve the schema-less sole-pk lookup via the #1750 seek (1 row)",
+    );
+    assert_eq!(
+        hit.rows[0].values.get("partition_key"),
+        Some(&Value::Integer(1)),
+    );
+}
+
+/// `point` (forced) also serves it via the seek: exactly the one matching row.
+#[tokio::test]
+async fn point_schemaless_sole_pk_lookup_returns_the_row() {
+    let Some(db) = present_or_skip(Some(ReadPathMode::Point)).await else {
+        return;
+    };
+    let hit = db
+        .execute(&format!(
+            "SELECT * FROM {INT_PK_TABLE} WHERE partition_key = 1"
+        ))
+        .await
+        .expect("forced point schema-less sole-pk lookup must succeed");
+    assert_eq!(
+        hit.rows.len(),
+        1,
+        "forced point must serve the schema-less sole-pk lookup via the #1750 seek (1 row)",
+    );
+}
+
+/// THE critical regression check (issue #1918 review fix): forced `full` on the
+/// exact schema-less sole-pk shape MUST fail closed with `ForcedReadPathUnavailable`
+/// — NOT silently return `Ok(0 rows)` (the pre-fix behavior that diverges from
+/// `auto`/`point`, which both return the row above). Reverting the fix flips this
+/// from `Err(...)` to `Ok(0 rows)` and this assertion fails.
+#[tokio::test]
+async fn full_schemaless_sole_pk_lookup_fails_closed_not_silent_zero() {
+    let Some(db) = present_or_skip(Some(ReadPathMode::Full)).await else {
+        return;
+    };
+    let err = db
+        .execute(&format!(
+            "SELECT * FROM {INT_PK_TABLE} WHERE partition_key = 1"
+        ))
+        .await
+        .expect_err(
+            "forced full on a schema-less sole-pk lookup must fail closed rather than \
+             silently full-scan to 0 rows (spec: rows identical to auto)",
+        );
+    match err {
+        Error::ForcedReadPathUnavailable { forced, reason } => {
+            assert_eq!(forced, "full", "the forced mode that failed must be 'full'");
+            assert_eq!(
+                reason, "schema_less_sole_pk_lookup_requires_targeted_seek",
+                "the reason must name the schema-less sole-pk seek requirement",
+            );
+        }
+        other => panic!("expected ForcedReadPathUnavailable, got {other:?}"),
+    }
+}

--- a/openspec/changes/read-path-forcing-knob/design.md
+++ b/openspec/changes/read-path-forcing-knob/design.md
@@ -1,0 +1,100 @@
+# Design — read-path forcing knob + differential lane (#1918)
+
+## Anchors on `main`
+- `classify_partition_lookup(predicates, schema) -> PartitionLookupOutcome`
+  (`select_executor/lookup.rs:92`). Outcome is `Targeted(Vec<u8>)` / `MultiTargeted(Vec<Vec<u8>>)` /
+  `Fallback(FallbackReason)`.
+- Five call sites consume it: `execute.rs` metadata WRITETIME/TTL (`:497`), schemaless seek (`:481`),
+  materializing (`:624`); `streaming.rs` (`:97`); `stream_agg.rs` (`:188`).
+- `AccessPath` closed enum + process-global `record`/`last`/`reset` probe (`query/access_path.rs`);
+  `FallbackReason` closed set. `honest_targeted_path(target, engaged)` already demotes a claimed
+  target to `FallbackFullScan{TombstonesBuildNoPrune}` when the storage call did not actually prune.
+- `QueryConfig` in `config.rs`; the `CQLITE_TTL_NOW_OVERRIDE_SECS` reader seam + the
+  `query_semantics_oracle_parity.rs` lane are the model for a pinned-`now`, fail-closed differential.
+
+## Chosen design: one forcing gate over the outcome, honest AccessPath, distinct fail-closed error
+
+### Knob surface
+`ReadPathMode { Auto, Point, Full }`. Resolution order, read **once** into a `OnceLock`:
+1. explicit `QueryConfig.forced_read_path: Option<ReadPathMode>` (programmatic/`Database` config), else
+2. `CQLITE_READ_PATH` env (`auto|point|full`, case-insensitive), else
+3. `Auto`.
+An unrecognized env value is a **loud startup-time error**, never silently `Auto` (a typo'd knob that
+silently no-ops would defeat the knob's purpose). `Auto` short-circuits before any allocation, so the
+unset path is byte-for-byte today plus one relaxed atomic load.
+
+### The single gate (no per-site fork)
+A `fn apply_forcing(outcome: PartitionLookupOutcome, mode: ReadPathMode) -> Result<ForcedOutcome>`
+wraps the classifier's return exactly once, applied at all five sites via a shared helper so no site
+re-implements policy:
+- `Auto` → pass the outcome through unchanged.
+- `Full` → replace any `Targeted`/`MultiTargeted` with a forced full scan; record
+  `AccessPath::FallbackFullScan{ reason: FallbackReason::ForcedFullScan }` (a NEW distinct variant, so
+  "forced" is never confused with an organic fallback). Rows are produced by the same full-scan +
+  reconciliation code `auto` uses when it falls back — identical semantics.
+- `Point` → **fail closed**: if the outcome is `Fallback(r)`, OR the classified target cannot be run as
+  a genuinely partition-targeted lookup at this surface (an unwired metadata-`IN` fan-out, or a
+  `tombstones`-build no-prune where `engaged == false`), return
+  `Error::ForcedReadPathUnavailable { forced: "point", reason }` naming the concrete
+  `FallbackReason`/surface. Never a silent full scan.
+
+`Point` fail-closed is defined against the *actually executed* path (engaged), not just the
+classification, so a classification that names a target but degrades at execution still errors — that
+is the "remove all doubt" contract. Because `engaged` is only known after the storage call, the point
+gate checks classification up front (fast fail for `Fallback`) and converts a post-call
+`engaged == false` into the same distinct error.
+
+### Why this beat the alternatives
+- **Beat per-site forcing** (a check at each of the five call sites): five copies of the policy is the
+  exact bug farm the honest-path work already fought; a single wrapper keeps one contract.
+- **Beat "silent fallback in point mode"** (the retired #942 sketch's `point = error only if
+  unclassifiable`): silent execution-time degradation is what the knob exists to expose. Fail closed on
+  the *executed* path, not just classification.
+- **Beat overloading the value set with `sequential`/`summary-guided`** (reader index-resolution
+  strategy, post-#2412): that is an orthogonal reader-internal axis, not a routing decision
+  `classify_partition_lookup` owns; folding it in would make one knob mean two things. Deferred as an
+  OWNER FORK below.
+
+## Differential-equality lane
+A new integration test target `point_vs_full_differential.rs` drives a corpus query matrix (single-key
+`=`, `IN`, clustering-pushdown, WRITETIME/TTL variants; includes multi-generation, tombstone, and TTL
+fixtures — the divergence classes #1741 hid) **twice per query** — once under forced `point`, once
+under forced `full` — and asserts normalized (rows, values, order) equality. It is a
+**query-semantics-class** oracle (CQLite-vs-CQLite): TTL `now` is pinned via
+`CQLITE_TTL_NOW_OVERRIDE_SECS`, never wall-clock. A query that is not point-eligible is exercised only
+under `full` vs `auto` (both full-scan) so the corpus stays exhaustive without asserting a
+fail-closed error as a "divergence". The lane is verified by seeding a divergence (temporarily breaking
+one path locally must turn it red — regression-test-verification doctrine).
+
+### Lane placement (recommended, with justification)
+Fold the target into the **existing `integration-tests` gate tier** (fail-closed under
+`CQLITE_REQUIRE_FIXTURES=1`, SKIP-loud when the corpus is absent), NOT a new standalone heavyweight
+gate component. Justification vs the #1825 gate-cost budget:
+- It reuses the already-fetched corpus and adds no new gate stage/slot — running each small-corpus
+  query twice is cheap relative to a new component's fixed setup + a new SUMMARY line.
+- The query-semantics oracle is a *separate* component because it is CQLite-vs-Cassandra with its own
+  committed fixtures; this lane is CQLite-vs-CQLite over the same corpus the integration tier already
+  loads, so it belongs in that tier.
+- **Alternative (owner fork):** a dedicated `point-vs-full-differential` component mirroring
+  `query-semantics-oracle` if the owner wants an independent SUMMARY line / independent SKIP visibility.
+  Costs one more gate slot; recommended only if independent reporting is valued over budget.
+
+## Observability
+The forced choice is recorded through the existing `AccessPath` probe (`record`/`last`), so
+`--explain` and tests read it with no new mechanism. Surfacing the `AccessPath` label (+ a "forced"
+marker) in the CLI `--explain` output (`query.rs`) is in scope **if cheap**; if it grows the file past
+the ratchet or needs its own UX pass, it splits to a follow-up (tracked in tasks.md).
+
+## Risks
+- **`Point` over-strictness**: erroring on a genuinely-eligible query that degrades only on the
+  `tombstones` build. Mitigation: the error names the concrete reason; the differential lane runs on the
+  default build; `tombstones`-build behavior is documented.
+- **Forced-full != organic-full ordering**: `full` must reuse the exact full-scan+merge path `auto`
+  falls back to, so multi-partition ordering matches. Mitigation: the differential lane asserts order.
+
+## OWNER FORKS
+1. **Reader index-resolution axis** — should the knob (or a second knob) also force `sequential` vs
+   post-#2412 `summary-guided` BIG-index iteration? Excluded here (orthogonal layer). Fork: separate
+   change, compound value, or leave reader-internal.
+2. **Lane placement** — fold into `integration-tests` (recommended) vs a dedicated gate component.
+3. **`--explain` forced marker** — surface now (if cheap) vs split to a follow-up.

--- a/openspec/changes/read-path-forcing-knob/proposal.md
+++ b/openspec/changes/read-path-forcing-knob/proposal.md
@@ -1,0 +1,50 @@
+# Read-path forcing knob + point-vs-full differential-equality lane (#1918)
+
+## Milestone
+0.15 (cqlite-trino latency/throughput/operations theme — ops lane). Design-driven: this change adds
+a new **user-visible env/config surface** (`CQLITE_READ_PATH`) and a new **CI test lane**, so it goes
+through OpenSpec / `flow-activate` (Seam 1) before implementation. Child of epic **#1915** (point-read
+fast-path residue). Anchors `classify_partition_lookup` (`select_executor/lookup.rs:92`) and the
+`AccessPath` signal (`query/access_path.rs`) that already exist on `main`.
+
+## Why (the gap)
+`git grep CQLITE_READ_PATH` returns nothing — there is no way to force a `SELECT` down a specific
+access path, and **no automated lane proves the point path and the full-scan path return equal
+results for the same query**. `classify_partition_lookup` silently picks point-vs-full at five call
+sites (`execute.rs` metadata/materializing/schemaless, `streaming.rs`, `stream_agg.rs`); a bug on one
+path is invisible unless a human happens to run the query that route. #958's guard bounds the *work*
+of the point path but asserts nothing about point-vs-full *result equality* — precisely the class of
+divergence that let #1741 (single-generation reads skipping reconciliation) hide behind green
+physical-dump goldens. This lane is the CQLite-vs-CQLite complement to #1742's CQLite-vs-Cassandra
+query-semantics oracle: same two-oracle doctrine, pinned `now`, never wall-clock.
+
+## What changes
+1. **Forcing knob** `CQLITE_READ_PATH=auto|point|full` (+ a `QueryConfig` equivalent). A single gate
+   wraps `classify_partition_lookup`'s outcome (not per-site logic), read once via `OnceLock`, and the
+   forced choice is recorded in `AccessPath` so tests and `--explain` can see it.
+   - `auto` (default): today's behavior, byte-for-byte, zero added overhead beyond the one env read.
+   - `point`: **fail closed** with a distinct error whenever the executor would not run a genuinely
+     partition-targeted lookup — never a silent full scan. The knob's whole purpose is to remove doubt.
+   - `full`: force the full-scan + reconciliation path regardless of classification; record
+     `AccessPath::FallbackFullScan` with a distinct **forced** reason.
+2. **Differential-equality lane**: run the eligible corpus query matrix under `point` and `full` and
+   assert identical rows, values, and order (a query-semantics-class oracle; pinned `now`; fail-closed
+   on absent fixtures; demonstrably catches a seeded divergence).
+3. **Docs**: the knob is documented as a **test/debug** surface, explicitly not a perf recommendation.
+
+## Non-goals
+- **No new access path or routing intelligence** — the knob only *forces* among paths that already
+  exist; it never makes a new query targetable (that is #1916/#1917/#951 work).
+- **No decoding/reconciliation change** — forcing governs routing only; values, tombstone shadowing,
+  timestamp resolution, WRITETIME/TTL are byte-identical across all three modes (no-heuristics intact).
+- **No BTI (`da`) fast-path** — a BTI table under `point` fails closed like any unavailable target.
+- **No reader-level index-resolution knob** (sequential-scan vs post-#2412 summary-guided iteration) —
+  that is an orthogonal axis inside the reader, not a `classify_partition_lookup` routing decision.
+  Flagged as an OWNER FORK in design.md; excluded here to keep the knob one honest concept.
+- **No perf/benchmark deliverable** — this is a correctness-differential + debug-control change.
+- **No change to `auto` behavior** — unset must be indistinguishable from today.
+
+## Doctrine impact
+Updates CLAUDE.md test-data/two-oracle note and the `agents-developing/` validation-playbook page to
+name the point-vs-full differential lane alongside the query-semantics oracle. No no-heuristics change:
+forcing is explicit operator config, never inference from bytes.

--- a/openspec/changes/read-path-forcing-knob/specs/read-path-forcing/spec.md
+++ b/openspec/changes/read-path-forcing-knob/specs/read-path-forcing/spec.md
@@ -1,0 +1,137 @@
+# read-path-forcing
+
+## ADDED Requirements
+
+### Requirement: Explicit read-path forcing surface
+
+CQLite SHALL expose an explicit `CQLITE_READ_PATH` environment variable and an equivalent
+`QueryConfig` field that force the `SELECT` access-path decision to one of `auto`, `point`, or `full`,
+resolved once per process (config over env over the `auto` default) and read via a `OnceLock` so an
+unset knob adds no per-query cost beyond a single relaxed load. An unrecognized value SHALL be a loud
+error, never a silent fall-through to `auto`.
+
+#### Scenario: Unset knob is byte-for-byte auto
+- **GIVEN** neither `CQLITE_READ_PATH` nor the `QueryConfig` forcing field is set
+- **WHEN** any `SELECT` executes
+- **THEN** the access-path decision is exactly today's `classify_partition_lookup` result
+- **AND** no forced marker is recorded in `AccessPath`.
+
+#### Scenario: Env selects a forced mode
+- **WHEN** `CQLITE_READ_PATH=point` (case-insensitive) is set
+- **THEN** every `SELECT` in the process runs under the forced `point` policy.
+
+#### Scenario: Config overrides env
+- **GIVEN** `CQLITE_READ_PATH=full` is set in the environment
+- **AND** `QueryConfig` explicitly sets the forcing field to `point`
+- **WHEN** a `SELECT` executes
+- **THEN** the `point` policy is applied (config takes precedence over env).
+
+#### Scenario: Invalid value fails loudly
+- **WHEN** `CQLITE_READ_PATH=compact` (or any value outside `auto|point|full`) is set
+- **THEN** resolving the mode returns a distinct error naming the invalid value and the allowed set
+- **AND** no query silently runs under `auto`.
+
+### Requirement: point mode fails closed on any non-targeted execution
+
+Under forced `point` mode CQLite SHALL fail the query with a distinct
+`Error::ForcedReadPathUnavailable` naming the concrete fallback reason whenever the executor would not
+run a genuinely partition-targeted lookup — a classification `Fallback`, an unwired targeted surface
+(such as a metadata `IN` fan-out), or a build/path that does not actually prune (`engaged == false`).
+It SHALL NEVER silently execute a full scan under `point`.
+
+#### Scenario: Partial partition key under point fails closed
+- **GIVEN** `CQLITE_READ_PATH=point`
+- **WHEN** a `SELECT` binds only a proper subset of the partition-key columns
+- **THEN** the query returns `Error::ForcedReadPathUnavailable` naming
+  `partition_key_not_fully_constrained`
+- **AND** no rows are returned from a silent full scan.
+
+#### Scenario: Classifiable point query takes the targeted path
+- **GIVEN** `CQLITE_READ_PATH=point`
+- **WHEN** a `SELECT` binds every partition-key column with `=`
+- **THEN** the query executes via the partition-targeted lookup
+- **AND** `AccessPath::last()` reports a targeted path, not a fallback.
+
+#### Scenario: Execution-time degradation under point fails closed
+- **GIVEN** `CQLITE_READ_PATH=point` on a build where the classified targeted surface does not prune
+  (`engaged == false`)
+- **WHEN** the fully-constrained `SELECT` executes
+- **THEN** the query returns `Error::ForcedReadPathUnavailable` naming the no-prune reason rather than
+  reporting a fake targeted success or silently full-scanning.
+
+### Requirement: full mode forces the full-scan path with an honest forced marker
+
+Under forced `full` mode CQLite SHALL execute every eligible `SELECT` via the full-scan +
+reconciliation path regardless of classification, recording `AccessPath::FallbackFullScan` with a
+distinct `FallbackReason::ForcedFullScan` so the forced fallback is never mistaken for an organic one,
+and the returned rows SHALL be identical to the `auto` result for that query.
+
+#### Scenario: Targeted-eligible query forced to full
+- **GIVEN** `CQLITE_READ_PATH=full`
+- **WHEN** a `SELECT` that `auto` would serve via a partition-targeted lookup executes
+- **THEN** `AccessPath::last()` reports `fallback_full_scan` with the `forced_full_scan` reason
+- **AND** the result set (rows, values, order) equals the `auto` result for the same query.
+
+### Requirement: A single forcing gate wraps the classifier at every call site
+
+The forcing decision SHALL be applied through one shared wrapper over
+`classify_partition_lookup`'s outcome at every executor call site (materializing, metadata WRITETIME/
+TTL, schemaless, streaming, and streaming-aggregation) — no call site SHALL re-implement the forcing
+policy — and the forced choice SHALL be recorded in `AccessPath` identically across surfaces.
+
+#### Scenario: Forcing is uniform across streaming and materializing surfaces
+- **GIVEN** `CQLITE_READ_PATH=full`
+- **WHEN** the same targeted-eligible query is run through the materializing surface and the streaming
+  surface
+- **THEN** both record `AccessPath::FallbackFullScan` with `forced_full_scan`
+- **AND** neither surface reports a targeted path.
+
+### Requirement: Point-vs-full differential-equality lane
+
+CQLite SHALL provide a differential test lane that runs the point-read-eligible corpus query matrix
+under forced `point` and forced `full` and asserts identical rows, values, and order between the two
+paths. The lane SHALL be a query-semantics-class oracle: TTL expiry SHALL be evaluated at a pinned
+`now` (never wall-clock), it SHALL fail closed (`CQLITE_REQUIRE_FIXTURES=1`) when the committed corpus
+is present, and it SHALL demonstrably fail if either path is broken.
+
+#### Scenario: Differential corpus run is equal for every eligible query
+- **GIVEN** the fetched corpus fixtures (single-key `=`, `IN`, clustering-pushdown, WRITETIME/TTL,
+  multi-generation, tombstone, and TTL tables) and a pinned `now`
+- **WHEN** each eligible query runs under `CQLITE_READ_PATH=point` and under `CQLITE_READ_PATH=full`
+- **THEN** the normalized result sets (rows, values, order) are equal for every table and query.
+
+#### Scenario: Lane catches a seeded divergence
+- **GIVEN** one read path is temporarily altered to return a different or reordered row set for a
+  queried partition
+- **WHEN** the differential lane runs
+- **THEN** the lane fails and names the diverging query and the row-level difference.
+
+#### Scenario: Absent corpus skips loudly, fails closed under the gate
+- **GIVEN** the committed corpus fixtures are absent
+- **WHEN** the differential lane runs without `CQLITE_REQUIRE_FIXTURES=1`
+- **THEN** it skips loudly rather than passing vacuously
+- **AND** with `CQLITE_REQUIRE_FIXTURES=1` an absent/empty fixture is a hard failure.
+
+### Requirement: Forcing changes routing only, never decoding semantics
+
+The forcing knob SHALL change only which access path serves a query; it SHALL NOT change value
+decoding, tombstone/timestamp reconciliation, or WRITETIME/TTL semantics, and the routing decision
+SHALL be taken only from explicit operator config — never inferred from data-byte patterns
+(no-heuristics mandate).
+
+#### Scenario: Values are byte-identical across modes
+- **GIVEN** a query whose result is non-empty under `auto`
+- **WHEN** it is run under `auto`, `full`, and (when eligible) `point`
+- **THEN** every returned value is byte-identical across the modes that return rows
+- **AND** the mode is chosen from config/env alone, with no byte-pattern inference.
+
+### Requirement: The knob is documented as a test/debug surface
+
+CQLite user/CLI documentation SHALL describe `CQLITE_READ_PATH` as a test and debugging control and
+SHALL state explicitly that it is not a performance recommendation, including the fail-closed behavior
+of `point`.
+
+#### Scenario: Docs state intent and fail-closed behavior
+- **WHEN** a reader consults the CLI/user docs for `CQLITE_READ_PATH`
+- **THEN** the docs list the `auto|point|full` values, mark the knob test/debug-only, and describe that
+  `point` errors (never silently full-scans) on an unclassifiable query.

--- a/openspec/changes/read-path-forcing-knob/tasks.md
+++ b/openspec/changes/read-path-forcing-knob/tasks.md
@@ -1,0 +1,50 @@
+# Tasks — read-path-forcing-knob (#1918)
+
+Each task names the public surface it exercises. Gate/C/roborev steps are the standing implement loop
+(`--lite` each fix round; review-first; flow-closer runs the ONE full gate → C → roborev → merge).
+
+## 1. Knob surface + resolution
+- [ ] Add `ReadPathMode { Auto, Point, Full }` and `QueryConfig.forced_read_path: Option<ReadPathMode>`
+      (`config.rs`). Public surface: `QueryConfig`.
+- [ ] Resolve mode once via `OnceLock`: config → `CQLITE_READ_PATH` env (case-insensitive) → `Auto`;
+      unrecognized value → distinct `Error`. Public surface: the resolver fn + `Error` variant.
+- [ ] Unit tests: unset=Auto, env parse, config-over-env precedence, invalid-value loud error.
+      Exercises: the resolver + `QueryConfig`.
+
+## 2. Single forcing gate over the classifier
+- [ ] Add `apply_forcing(outcome, mode) -> Result<ForcedOutcome>` wrapping
+      `classify_partition_lookup`'s return; add `FallbackReason::ForcedFullScan` and
+      `Error::ForcedReadPathUnavailable { forced, reason }`. Public surface: `AccessPath`/`FallbackReason`
+      (closed-enum contract), `Error`.
+- [ ] Wire the wrapper at all five call sites (`execute.rs` metadata/schemaless/materializing,
+      `streaming.rs`, `stream_agg.rs`) — one helper, no per-site policy. Exercises: `Database::execute`
+      (materializing + streaming SELECT surfaces).
+- [ ] `full` records `FallbackFullScan{ForcedFullScan}`; `point` fails closed on `Fallback` up front and
+      on `engaged == false` post-call. Exercises: `AccessPath::last()` probe.
+- [ ] Tests: `full` on a targeted query records forced fallback + rows == `auto`; `point` on partial-pk
+      errors distinctly; `point` on full-pk stays targeted. Exercises: `Database::execute` + probe.
+
+## 3. Differential-equality lane
+- [ ] New integration target `cqlite-core/tests/point_vs_full_differential.rs`: run the eligible corpus
+      query matrix under forced `point` and forced `full`, assert normalized (rows/values/order)
+      equality; pin `now` via `CQLITE_TTL_NOW_OVERRIDE_SECS`; fail-closed under `CQLITE_REQUIRE_FIXTURES=1`,
+      SKIP-loud when the corpus is absent. Exercises: `Database::execute` under both forced modes.
+- [ ] Include multi-generation (`ct_multi_sstable_merge` and peers), tombstone, and TTL fixtures.
+- [ ] Verify the lane by seeding a divergence locally (break one path, confirm red, revert) —
+      regression-test-verification doctrine; record the demonstration in the PR.
+- [ ] Wire into the existing `integration-tests` gate tier (design.md placement); OWNER-FORK: promote to
+      a dedicated component only if independent SUMMARY visibility is chosen.
+
+## 4. Observability + docs
+- [ ] If cheap: surface the `AccessPath` label + a "forced" marker in CLI `--explain`
+      (`cqlite-cli/src/commands/query.rs`). Else split to a follow-up issue. Exercises: `--explain`.
+- [ ] Document `CQLITE_READ_PATH` in CLI/user docs as a test/debug-only control (values, `point`
+      fail-closed behavior, not a perf recommendation).
+- [ ] Update CLAUDE.md two-oracle note + `agents-developing/` validation-playbook to name the
+      point-vs-full differential lane.
+
+## 5. Gate / C / roborev (flow-closer)
+- [ ] `--lite` each fix round (summary-file redirect); rust-reviewer + roborev on the lite-green diff.
+- [ ] flow-closer: ONE full `scripts/agent-gate.sh` PASS (paste SUMMARY), `-D warnings` clean, no
+      `unwrap()`/`expect()` in library code; C (spec-auditor) PASS on every requirement with a
+      public-surface test as evidence; roborev clean → merge → `openspec archive`.

--- a/openspec/changes/read-path-forcing-knob/tasks.md
+++ b/openspec/changes/read-path-forcing-knob/tasks.md
@@ -4,43 +4,49 @@ Each task names the public surface it exercises. Gate/C/roborev steps are the st
 (`--lite` each fix round; review-first; flow-closer runs the ONE full gate → C → roborev → merge).
 
 ## 1. Knob surface + resolution
-- [ ] Add `ReadPathMode { Auto, Point, Full }` and `QueryConfig.forced_read_path: Option<ReadPathMode>`
+- [x] Add `ReadPathMode { Auto, Point, Full }` and `QueryConfig.forced_read_path: Option<ReadPathMode>`
       (`config.rs`). Public surface: `QueryConfig`.
-- [ ] Resolve mode once via `OnceLock`: config → `CQLITE_READ_PATH` env (case-insensitive) → `Auto`;
+- [x] Resolve mode once via `OnceLock`: config → `CQLITE_READ_PATH` env (case-insensitive) → `Auto`;
       unrecognized value → distinct `Error`. Public surface: the resolver fn + `Error` variant.
-- [ ] Unit tests: unset=Auto, env parse, config-over-env precedence, invalid-value loud error.
-      Exercises: the resolver + `QueryConfig`.
+      (`select_executor/forcing.rs`: `resolve_read_path_mode`; `Error::InvalidReadPath`.)
+- [x] Unit tests: unset=Auto, env parse, config-over-env precedence, invalid-value loud error.
+      Exercises: the resolver + `QueryConfig`. (`forcing::tests`, `config::tests::forced_read_path_*`.)
 
 ## 2. Single forcing gate over the classifier
-- [ ] Add `apply_forcing(outcome, mode) -> Result<ForcedOutcome>` wrapping
+- [x] Add `apply_forcing(outcome, mode) -> Result<ForcedPlan>` wrapping
       `classify_partition_lookup`'s return; add `FallbackReason::ForcedFullScan` and
       `Error::ForcedReadPathUnavailable { forced, reason }`. Public surface: `AccessPath`/`FallbackReason`
       (closed-enum contract), `Error`.
-- [ ] Wire the wrapper at all five call sites (`execute.rs` metadata/schemaless/materializing,
-      `streaming.rs`, `stream_agg.rs`) — one helper, no per-site policy. Exercises: `Database::execute`
-      (materializing + streaming SELECT surfaces).
-- [ ] `full` records `FallbackFullScan{ForcedFullScan}`; `point` fails closed on `Fallback` up front and
+- [x] Wire the wrapper at all five call sites (`execute.rs` metadata/schemaless/materializing,
+      `streaming.rs`, `stream_agg.rs`) — one helper (`apply_forcing` + `point_requires_engaged` +
+      `point_forbids_fallback`), no per-site policy. Exercises: `Database::execute` (materializing +
+      streaming SELECT surfaces).
+- [x] `full` records `FallbackFullScan{ForcedFullScan}`; `point` fails closed on `Fallback` up front and
       on `engaged == false` post-call. Exercises: `AccessPath::last()` probe.
-- [ ] Tests: `full` on a targeted query records forced fallback + rows == `auto`; `point` on partial-pk
+- [x] Tests: `full` on a targeted query records forced fallback + rows == `auto`; `point` on partial-pk
       errors distinctly; `point` on full-pk stays targeted. Exercises: `Database::execute` + probe.
+      (`cqlite-core/tests/read_path_forcing_e2e.rs`.)
 
 ## 3. Differential-equality lane
-- [ ] New integration target `cqlite-core/tests/point_vs_full_differential.rs`: run the eligible corpus
+- [x] New integration target `cqlite-core/tests/point_vs_full_differential.rs`: run the eligible corpus
       query matrix under forced `point` and forced `full`, assert normalized (rows/values/order)
       equality; pin `now` via `CQLITE_TTL_NOW_OVERRIDE_SECS`; fail-closed under `CQLITE_REQUIRE_FIXTURES=1`,
       SKIP-loud when the corpus is absent. Exercises: `Database::execute` under both forced modes.
-- [ ] Include multi-generation (`ct_multi_sstable_merge` and peers), tombstone, and TTL fixtures.
-- [ ] Verify the lane by seeding a divergence locally (break one path, confirm red, revert) —
-      regression-test-verification doctrine; record the demonstration in the PR.
-- [ ] Wire into the existing `integration-tests` gate tier (design.md placement); OWNER-FORK: promote to
-      a dedicated component only if independent SUMMARY visibility is chosen.
+- [x] Include multi-generation (`test_tomb` 2-gen tables), tombstone, and TTL fixtures.
+- [x] Verify the lane by seeding a divergence locally (break one path, confirm red, revert) —
+      done: seeded a `__seed.pop()` in the point path, lane went red naming the diverging query, reverted.
+      Harness-level regression also pinned by `comparison_detects_a_seeded_divergence`.
+- [x] Wire into the existing `integration-tests` gate tier (design.md placement): the target is an
+      ordinary `cqlite-core/tests/*.rs` integration test picked up by the tier; OWNER-FORK (dedicated
+      SUMMARY component) NOT taken.
 
 ## 4. Observability + docs
-- [ ] If cheap: surface the `AccessPath` label + a "forced" marker in CLI `--explain`
-      (`cqlite-cli/src/commands/query.rs`). Else split to a follow-up issue. Exercises: `--explain`.
-- [ ] Document `CQLITE_READ_PATH` in CLI/user docs as a test/debug-only control (values, `point`
-      fail-closed behavior, not a perf recommendation).
-- [ ] Update CLAUDE.md two-oracle note + `agents-developing/` validation-playbook to name the
+- [~] CLI `--explain` forced marker: SPLIT to a follow-up (OWNER-FORK #3). `--explain` is plan-only
+      (`database.explain` never executes the query, so no `AccessPath` is produced); surfacing the
+      forced/actual path there would require executing or new planner plumbing — not cheap.
+- [x] Document `CQLITE_READ_PATH` in CLI/user docs as a test/debug-only control (values, `point`
+      fail-closed behavior, not a perf recommendation). (`website/.../cli-reference.md`.)
+- [x] Update CLAUDE.md two-oracle note + `agents-developing/` validation-playbook to name the
       point-vs-full differential lane.
 
 ## 5. Gate / C / roborev (flow-closer)

--- a/website/src/content/docs/agents-developing/validation-playbook.md
+++ b/website/src/content/docs/agents-developing/validation-playbook.md
@@ -53,6 +53,30 @@ env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 fixture a **hard failure**; without it, a minimal checkout that lacks the committed
 `test_compaction_tombstone_ttl` fixtures SKIPs loudly.
 
+### Point-vs-full differential lane (CQLite-vs-CQLite, issue #1918)
+
+A third lane complements the two oracles above by comparing CQLite to *itself* across
+its two read access paths. `cqlite-core/tests/point_vs_full_differential.rs` runs each
+point-read-eligible corpus query under forced `CQLITE_READ_PATH=point` (a
+partition-targeted lookup) and forced `CQLITE_READ_PATH=full` (a full scan +
+reconciliation) — via the `QueryConfig::forced_read_path` knob — and asserts the two
+paths return byte-identical rows/values/**order** at a **pinned `now`**
+(`CQLITE_TTL_NOW_OVERRIDE_SECS`). The corpus deliberately includes multi-generation,
+tombstone, and TTL fixtures — the reconciliation classes #1741 hid — so a divergence
+between the point and full paths (invisible to a physical dump, which retains the
+shadowed rows on both sides) fails the lane and names the diverging query. Same
+fail-closed/SKIP contract as the query-semantics oracle:
+
+```bash
+env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+  cargo test -p cqlite-core --features "state_machine cli-helpers" \
+  --test point_vs_full_differential -- --nocapture
+```
+
+The `CQLITE_READ_PATH` knob is a **test/debug** control (not a perf recommendation);
+`point` fails closed rather than silently full-scanning. See the CLI reference for the
+user-facing knob docs.
+
 ## Golden JSONL files
 
 Every Data.db in the dataset has a companion `.jsonl` file containing

--- a/website/src/content/docs/user-docs/cli-reference.md
+++ b/website/src/content/docs/user-docs/cli-reference.md
@@ -578,6 +578,40 @@ For write statistics, compaction, and export see the `write-stats`, `maintenance
 
 ---
 
+## Debug / test controls
+
+### `CQLITE_READ_PATH` — force the SELECT access path
+
+`CQLITE_READ_PATH` forces every `SELECT` down a specific read access path. It is a
+**test and debugging control** — **not a performance recommendation** — used to remove
+doubt about which path served a query and to differentially compare the two paths.
+
+| Value | Behavior |
+|-------|----------|
+| `auto` (default, or unset) | The engine chooses point-vs-full per query, exactly as normal. Byte-for-byte identical to leaving the knob unset. |
+| `point` | Force a genuinely partition-targeted lookup. **Fails closed** — the query returns an error whenever it would not run a partition-targeted lookup (a partial/absent partition key, an unwired targeted surface, or a path that does not actually prune). It **never** silently falls back to a full scan. |
+| `full` | Force the full-scan + reconciliation path regardless of classification. Returns the same rows/values/order as `auto` for the same query. |
+
+The value is case-insensitive (`auto`/`point`/`full`). An **unrecognized** value is a loud
+error naming the value and the allowed set — never a silent fall-through to `auto`. The
+programmatic equivalent is the `QueryConfig.forced_read_path` field, which takes precedence
+over the environment variable. The mode is resolved once per process.
+
+```bash
+# Force a point lookup; errors loudly if the query is not partition-targeted.
+CQLITE_READ_PATH=point cqlite \
+  --schema schema.cql --data-dir ./sstables \
+  -e "SELECT * FROM ks.tbl WHERE pk = 1" --out json
+
+# Force a full scan of the same query (rows/values/order match the point path).
+CQLITE_READ_PATH=full cqlite \
+  --schema schema.cql --data-dir ./sstables \
+  -e "SELECT * FROM ks.tbl WHERE pk = 1" --out json
+```
+
+Forcing changes **routing only** — value decoding, tombstone/timestamp reconciliation, and
+WRITETIME/TTL semantics are identical across all three modes.
+
 ## Logging
 
 Log output goes to **stderr only**, so it never contaminates JSON/CSV stdout output. Control verbosity with:


### PR DESCRIPTION
Closes #1918

## Summary
Adds a debug/test `CQLITE_READ_PATH` forcing knob (`ReadPathMode::{Auto,Point,Full}`, config-over-env-over-auto) that forces a `SELECT` down a specific access path, wired through a single `apply_forcing` gate at all five `classify_partition_lookup` call sites (`execute.rs` ×3, `streaming.rs`, `stream_agg.rs`). Adds a new differential-equality test lane proving point and full-scan paths return byte-identical results for the same query (pinned `now`, never wall-clock) — the CQLite-vs-CQLite complement to #1742's CQLite-vs-Cassandra query-semantics oracle.

OpenSpec change: `openspec/changes/read-path-forcing-knob/` (spec + design approved at Seam 1, 2026-07-14).

## Design highlights
- Fail-closed by construction: forced `point` on a query the point path can't serve returns `Error::ForcedReadPathUnavailable` rather than silently falling back to full-scan; forced `full` disables the point path entirely at every site.
- Wiring-evidence: `read_path_forcing_e2e.rs` drives the real public `Database::execute` surface; `point_vs_full_differential.rs` proves point/full equality over a multi-generation/tombstone/TTL corpus.
- `--explain` forced-path marker deferred (spec-sanctioned — `database.explain` is plan-only and produces no `AccessPath`; the "recorded identically across surfaces" requirement is already met via `metadata.access_path`).

## Review history (this branch)
- Round 1 (rust-reviewer + roborev): rust-reviewer clean; roborev clean (2 Low nits: untested env-resolution seam, untested aggregate-forcing path, tombstones-build lane exclusion).
- **Fix round: rust-reviewer's IMPORTANT finding** — forced `full` on a schema-less sole-pk point read silently returned 0 rows instead of matching `auto` (the general full-scan predicate path can't reconstruct pk-column identity without a schema), violating the approved spec's SHALL that `full`'s row-set be identical to `auto`'s. Fixed via a new `full_forbids_schemaless_seek` fail-closed guard (mirrors the existing `point_forbids_fallback` pattern) returning `Error::ForcedReadPathUnavailable` instead of a silently-wrong empty result. Verified non-vacuous: reverting the guard reproduced the exact bug and the new regression test caught it.
- Round 2 (rust-reviewer + roborev on the fix): both clean. 7 total Low/nit findings across all rounds (stale doc summary line; WRITETIME/metadata-branch e2e coverage gap; env-var test-hygiene in the differential lane; untested env-resolution seam; untested aggregate-forcing path; tombstones-build lane exclusion; `--explain` deferral needs a tracking issue number) — batched into one follow-up issue at merge time, none blocking.

## Gate
`--lite` PASS on every round (latest: commit cc7491748). Full `agent-gate.sh` + C intent audit + final roborev to run once via `flow-closer` before merge.