### PR TITLE
feat(#2418): tools/flight-loadgen — raw FlightServiceClient ramp harness (WS1 of #2313)

### DIFF
--- a/openspec/changes/flight-loadgen/design.md
+++ b/openspec/changes/flight-loadgen/design.md
@@ -1,0 +1,182 @@
+# Design — tools/flight-loadgen (issue #2418, epic #2313 WS1)
+
+## Context
+
+The server exposes `FlightService::do_get(Ticket)` where the `Ticket.ticket`
+bytes are a JSON [`FlightTicket`] (`cqlite-flight/src/ticket.rs`): `keyspace`,
+`table`, `ddl`, optional `snapshot`, an optional `[token_start, token_end]` range
+(+ `wraparound`), optional `columns`, `predicates`/`filter`, `aggregation`, and
+`limit` (issue #2129 — `LIMIT`-k pushdown; `None` = full range). The client is a
+plain `arrow_flight::FlightServiceClient<Channel>` (tonic 0.12) that streams
+`FlightData`; `FlightRecordBatchStream` decodes it to Arrow `RecordBatch`es. The
+admission layer (#2420, shipped) sheds on permit-wait timeout with gRPC
+**`UNAVAILABLE`** *before the first batch* (retry-safe for the connector's #2241
+failover) — the load client MUST classify that distinctly from other failures.
+
+`cqlite-flight/benches/flight_do_get.rs` already proves the exact client path we
+need — `serve_and_connect` binds `127.0.0.1:0`, serves `CqliteFlightService`
+in-process, connects a real `FlightServiceClient`, sends a connector-shaped ticket
+JSON, and decodes batches — but at concurrency 1 with Criterion wall-time. This
+design reuses that fixture for the self-test and generalizes the client into a
+ramp.
+
+The decisions (a)–(g) each state alternatives; §Recommended package selects one
+coherent set for Seam-1 approval.
+
+---
+
+## (a) Workspace membership: join the main workspace vs. stand alone like `fuzz/`
+
+- **Join (recommended).** The root `Cargo.toml` already globs
+  `members = ["tools/*"]`, so `tools/flight-loadgen` is captured with **no
+  manifest change** (opting out would require an explicit `exclude`). Joining
+  gives free coverage: `cargo build --workspace` compiles it, the gate's
+  per-package `clippy -D warnings` lints it, the file-size ratchet watches it, and
+  it shares the single workspace lockfile + `[workspace.dependencies]` pins
+  (tonic/arrow-flight/tokio/serde already declared).
+- **Stand alone (rejected).** `fuzz/` is excluded for reasons that **do not apply
+  here**: it needs a nightly toolchain + libFuzzer sanitizer flags, and being in
+  the workspace would force every root `cargo build`/clippy to compile a target
+  that only ever runs under `cargo fuzz`. `flight-loadgen` is stable-Rust, needs
+  no special toolchain, and *wants* to be compiled/linted by the ordinary build.
+- **Cost of joining:** it adds a small binary crate to the default workspace
+  compile. Acceptable — it is a thin client over already-compiled deps.
+
+**Decision: JOIN** — no `exclude` entry; rely on the `tools/*` glob.
+
+## (b) Ticket synthesis: base template + shape transforms vs. per-shape ticket files
+
+The client must not invent partition keys or DDL. Operator supplies **one base
+ticket template** (`--ticket-template <file.json>`: the connector-shaped
+`FlightTicket` — `keyspace`/`table`/`ddl`/`snapshot`, full ring, no limit). The
+loadgen derives each shape by transforming a *clone* of the template:
+
+- **full scan** — template as-is (full ring, `limit = None`).
+- **limit-k scan** — template + `limit = Some(k)` (`--limit-k`, default e.g. 100).
+- **point read** — template + a **seeded narrow token sub-range**
+  `[t, t + width)` where `t` is drawn from a seeded RNG over the i64 ring and
+  `width` = `--point-width` (a small ring fraction). This exercises the
+  per-request **setup/resolve/prune/admission** cost (the #2207/#2295/#2398
+  point-read package) deterministically; the same seed reproduces the same tokens
+  across rounds for diffing.
+- **mixed** — a seeded weighted draw across the three (`--mix ptr=0.6,lim=0.3,full=0.1`).
+
+**Fork (recorded for the owner):** a token-narrowed "point read" is a
+*setup-cost proxy*, not a keyed single-partition lookup — it may return zero rows
+on a sparse sub-range. Making it a true keyed read needs a partition-key corpus
+(a follow-up); v1 measures the request-setup/admission cost under concurrency,
+which is what the point-read package targets. Alternative (rejected for v1):
+require the operator to supply N explicit per-shape ticket files — more faithful
+but far more operator burden and non-reproducible across corpora.
+
+## (c) Ramp model
+
+`--ramp 1,2,4,8,16,32` (ordered target concurrencies) × `--step-duration 30s`.
+Per step, a **worker pool of size `C`** keeps `C` `do_get`s in flight: each worker
+loops — build next ticket (seeded per (step,worker,iteration)), issue `do_get`,
+drain, record outcome — until the step deadline. One JSONL record per step (mixed)
+or per (step, shape) when shapes are swept separately (`--shape` selects one, or
+`--shape mixed`). Determinism: the RNG is seeded from `--seed` (fixed default) and
+salted by (step index, worker index, iteration) so a rerun is byte-reproducible
+in ticket selection; wall-clock only bounds the step, never the sampled data.
+
+## (d) Latency percentiles under a memory bound
+
+Need p50/p95/p99/max per step without retaining every sample. Options:
+- **`hdrhistogram` crate (recommended)** — fixed-footprint recording histogram,
+  O(1) record, accurate high-percentile reads; reset per step so memory is bounded
+  regardless of request volume. One new workspace dep, widely used, stable Rust.
+- Sorted-`Vec<u64>` of raw samples (rejected) — simplest, but O(requests) memory
+  per step: a 32-way pool over a 30s step can be millions of samples → violates the
+  memory-bound constraint at exactly the concurrency we most want to measure.
+
+**Decision: `hdrhistogram`**, one histogram per step, reset between steps.
+
+## (e) Outcome classification
+
+Inspect each result: success → `ok`; on `Err(tonic::Status)`, bucket
+`Code::Unavailable` → **`unavailable`** (the #2420 admission-shed signal —
+retry-safe by server contract), everything else (`Internal`, `InvalidArgument`,
+transport errors, decode errors) → **`error`**, tagged with the status code for
+the record. Rationale: the ramp's key readout is *the concurrency at which the
+server starts shedding* (`unavailable` climbing) vs. *actual failures* (`error`).
+Caveat recorded in the record schema: a transport-layer `UNAVAILABLE` is
+indistinguishable from an admission `UNAVAILABLE` on the wire; we attribute
+`UNAVAILABLE` to admission by the server's stated contract (#2420) and note it.
+
+## (f) Memory-bounded consumption
+
+Each `do_get` response is a `FlightRecordBatchStream`; the worker `poll`s it,
+and for every `RecordBatch` adds `batch.num_rows()` and
+`batch.get_array_memory_size()` to running counters, then **drops the batch**
+immediately. Never collect into a `Vec<RecordBatch>`. Peak client RSS is therefore
+O(concurrency × one in-flight batch), independent of result-set size — mirroring
+the server-side drain-don't-accumulate rule the program enforces.
+
+## (g) CI smoke: compile-only vs. in-process self-test
+
+- **In-process self-test (recommended).** A `#[test]` (and an equivalent
+  `--self-test` subcommand) that reuses the `serve_and_connect` fixture: build a
+  tiny 1-SSTable fixture, serve `CqliteFlightService` on `127.0.0.1:0`, run a
+  **1-step, concurrency-1, fixed-request-count** ramp (count-bounded, *not*
+  duration — no wall-clock), and assert ≥1 well-formed JSONL record with
+  `ok >= 1` and every required field present + parseable. Sub-second, single
+  transport, ephemeral port (no fixed-port flake). This is **wiring evidence**
+  (client → gRPC → server → JSONL), catching JSONL-schema drift and ramp-loop
+  regressions that compile-only would miss.
+- **Compile-only (rejected).** Cheapest, but lets the JSONL contract and the drain
+  loop rot silently — contrary to the "wiring evidence" rule (a green compile is
+  not exercise).
+
+The self-test is a **normal workspace test** (`cargo test -p flight-loadgen`,
+picked up by the gate's blast-radius mapping when the crate is touched) — it is
+**not** registered as a bespoke `agent-gate.sh` component and never contacts a
+real cluster.
+
+---
+
+## JSONL record schema (feeds #2399 C-throughput block)
+
+One object per emitted step, e.g.:
+
+```json
+{
+  "schema": "flight-loadgen.step/v1",
+  "round": "<--round label>", "endpoint": "http://host:8815",
+  "ts_unix_ms": 0, "seed": 42,
+  "step": 3, "target_concurrency": 8, "shape": "mixed",
+  "duration_s": 30.0,
+  "requests_ok": 0, "requests_unavailable": 0, "requests_error": 0,
+  "error_codes": {"Internal": 0},
+  "qps": 0.0, "rows_per_s": 0.0, "bytes_per_s": 0.0,
+  "rows_total": 0, "bytes_total": 0,
+  "latency_ms": {"p50": 0.0, "p95": 0.0, "p99": 0.0, "max": 0.0, "samples": 0}
+}
+```
+
+Mapping to #2399: `qps`/`p50`/`p99`/error counts = the **C (throughput)** block
+(server-direct); `requests_error`/`error_codes` also feed **D (hygiene)
+`errors_total`**. Cross-node distribution (a C sub-item) is **N/A server-direct**
+(single endpoint) and is stated as such rather than fabricated. Latency percentiles
+are over `ok` requests only (documented in the record).
+
+## Recommended package (for Seam-1 approval)
+
+Join the workspace via the `tools/*` glob (a); base-template + seeded shape
+transforms (b); ordered ramp steps × duration with a per-step worker pool and a
+salted deterministic seed (c); `hdrhistogram` per step (d); ok/unavailable/error
+classification attributing `UNAVAILABLE` to admission by server contract (e);
+drain-and-drop batches (f); an in-process count-bounded self-test, not a gate
+component (g); the `flight-loadgen.step/v1` JSONL schema above.
+
+## Open questions for the owner
+
+1. **Point-read fidelity (fork in §(b)):** ship v1 as a seeded token-narrowed
+   *setup-cost proxy*, or block on a partition-key corpus for true keyed reads?
+   (Recommend: ship the proxy now; file keyed-read fidelity as a follow-up.)
+2. **`hdrhistogram` as a new workspace dep** — acceptable, or prefer a
+   hand-rolled bounded percentile (t-digest/reservoir) to avoid the dep?
+3. **Default ramp/step/limit-k/point-width values** — set operator-friendly
+   defaults here, or leave all required (no defaults) to force explicit runs?
+4. **Should the self-test also live as an example** (`cargo run --example`) for
+   docs, in addition to the `#[test]`?

--- a/openspec/changes/flight-loadgen/proposal.md
+++ b/openspec/changes/flight-loadgen/proposal.md
@@ -1,0 +1,71 @@
+# tools/flight-loadgen — raw FlightServiceClient ramp harness (issue #2418, epic #2313 WS1)
+
+## Why
+
+Epic #2313 (the throughput-saturation program) needs to answer one question the
+existing measurements cannot: **where does the `cqlite-flight` server itself
+saturate, independent of Trino?** Every published floor to date is a
+*through-Trino* aggregate (round-10b, #2367: connector `in.mcfad:cqlite-trino:0.14.2`
++ flight `v0.14.1`, 8 threads/180s, 3-node RF=3 → ~2.34 qps, p50 2.9s, p99 10.0s).
+That path folds Trino's split planning, the JDBC connector, replica fan-out, and
+network into the number, so it cannot isolate server-side thread/fd/memory
+pressure — exactly the Rank 2/3/4 failures the admission work (#2420, shipped) and
+the WS2 saturation gauges (#2419) are built around.
+
+There is no tool that drives `FlightService::do_get` **directly**. The only
+existing client-over-transport code is `cqlite-flight/benches/flight_do_get.rs`
+(one `do_get`, single concurrency, Criterion wall-time — an advisory micro-bench,
+not a ramp). WS8 (the concurrency ramp that produces the program's saturation
+curve) is blocked until a direct load client exists, and WS1 (#2418) is the
+sequencing-first item that unblocks it.
+
+`tools/flight-loadgen` establishes the **server-direct ceiling** underneath the
+through-Trino floor: a raw `arrow_flight::FlightServiceClient` (tonic) that offers
+a parameterized concurrency ramp of `do_get` requests against a running
+`cqlite-flight` endpoint, classifies outcomes (including the #2420 admission-shed
+`UNAVAILABLE` distinctly from other errors), and emits JSONL per-step records that
+feed the #2399 round-N metrics template and diff cleanly between rounds/builds.
+
+## What Changes
+
+- Add a new binary crate `tools/flight-loadgen` (captured by the existing
+  `members = ["tools/*"]` glob — **joins the main workspace**, unlike the excluded
+  `fuzz/` crate; justified in design §(a)).
+- Provide a `flight-loadgen` binary that:
+  - connects a raw `FlightServiceClient<Channel>` to a `--endpoint` (no Trino, no
+    `cqlite-core` query engine in the client);
+  - drives a **concurrency ramp** — an ordered list of target concurrency levels,
+    each held for a fixed duration, maintaining that many in-flight `do_get`s;
+  - synthesizes four **workload shapes** — point read, `LIMIT`-k scan, full scan,
+    mixed — from a base ticket template, under a **deterministic seed**;
+  - **classifies** each request outcome: `ok`, `unavailable` (the admission-shed,
+    retry-safe gRPC `UNAVAILABLE`), `error` (any other status/transport failure);
+  - **drains and drops** every `RecordBatch` immediately (memory-bounded — never
+    accumulates the result set), counting rows and bytes incrementally;
+  - emits **JSONL per-step records** (throughput, p50/p95/p99 latency, per-class
+    counts, bytes) consumable by the #2399 template.
+- Ship a cheap in-process **self-test** (the proven `serve_and_connect`
+  ephemeral-port fixture pattern) that exercises the full client→server→JSONL
+  pipeline deterministically (request-count-bounded, no wall-clock).
+
+## Non-goals
+
+- **NOT a gate component.** An operator/bench tool; never registered in
+  `agent-gate.sh --list`, never run against a real cluster in CI.
+- **NOT a correctness oracle.** Row/tombstone/type parity stays with the
+  sstabledump goldens and the query-semantics oracle; this tool measures
+  throughput/latency/shedding, not answer correctness.
+- **NOT a Trino/JDBC path.** Isolating the server is the entire point.
+- **NOT a server change.** No edits to `cqlite-flight` server code; it consumes
+  the existing `do_get` + `FlightTicket` contract as-is.
+- **NOT the ramp analysis / WS8 deliverable itself** — this is the client that
+  WS8 drives; curve-fitting and the saturation report are downstream.
+
+## Impact
+
+- New crate `tools/flight-loadgen` (binary + a `--self-test`/`#[test]` harness).
+  Deps are already in the workspace (tonic, arrow-flight, arrow, tokio, serde,
+  serde_json, clap) plus one bounded-memory histogram dep (design §(d)).
+- Unblocks epic #2313 WS8 (the ramp) and feeds #2399 (round-N template) with a
+  server-direct C-throughput block.
+- Zero runtime-path impact: no `cqlite-flight`/`cqlite-core` source changes.

--- a/openspec/changes/flight-loadgen/specs/flight-loadgen/spec.md
+++ b/openspec/changes/flight-loadgen/specs/flight-loadgen/spec.md
@@ -1,0 +1,137 @@
+# flight-loadgen
+
+## ADDED Requirements
+
+### Requirement: drives do_get directly over a raw FlightServiceClient
+
+The `flight-loadgen` tool SHALL issue `do_get` requests to a `cqlite-flight`
+endpoint through a raw `arrow_flight::FlightServiceClient<Channel>` (tonic) over a
+real gRPC transport, and MUST NOT route through Trino, the JDBC connector, or the
+`cqlite-core` query engine, so that the measurement isolates server-side behavior.
+
+#### Scenario: a request reaches the server as a real do_get over the wire
+
+- **GIVEN** a `cqlite-flight` server serving a fixture table over a loopback
+  gRPC endpoint
+- **WHEN** `flight-loadgen` runs a one-request ramp against that endpoint with a
+  ticket for the fixture table
+- **THEN** the request is delivered via `FlightServiceClient::do_get` over the
+  transport and its Arrow `RecordBatch` stream is decoded by the client
+- **AND** no Trino/JDBC/`cqlite-core`-query-engine component participates in the
+  client path
+
+### Requirement: parameterized deterministic concurrency ramp
+
+The tool SHALL execute an ordered sequence of ramp steps, each step holding a
+configured target concurrency of in-flight `do_get`s for a configured step
+duration, and its ticket selection SHALL be reproducible from a configured seed so
+two runs with the same seed and ramp produce the same request sequence.
+
+#### Scenario: each step maintains its target concurrency for its duration
+
+- **GIVEN** a ramp `1,2,4` with a fixed per-step duration
+- **WHEN** the tool runs the ramp against a live endpoint
+- **THEN** it emits exactly one step record per configured level in order, each
+  reporting its `target_concurrency`, and during a step at most that many
+  `do_get`s are in flight at once
+
+#### Scenario: identical seed reproduces the ticket sequence
+
+- **GIVEN** two runs with the same `--seed`, `--ramp`, `--shape`, and template
+- **WHEN** the deterministic ticket sequence for a fixed step and worker is
+  generated in each run
+- **THEN** the two sequences are byte-identical (token ranges, limits, and shape
+  choices match), so wall-clock timing never perturbs which data is requested
+
+### Requirement: four workload shapes synthesized from a base ticket template
+
+The tool SHALL support the workload shapes `point`, `limit-k`, `full`, and
+`mixed`, each derived by transforming a clone of an operator-supplied base ticket
+template, and MUST NOT fabricate DDL or partition keys the operator did not
+provide.
+
+#### Scenario: each shape produces the expected ticket transform
+
+- **GIVEN** a base ticket template for `keyspace.table` describing the full ring
+  with no limit
+- **WHEN** each shape builds its ticket
+- **THEN** `full` yields the template with `limit = None` over the full ring;
+  `limit-k` yields the template with `limit = Some(k)`; `point` yields the
+  template narrowed to a seeded token sub-range `[t, t + width)`; and `mixed`
+  yields a seeded weighted draw across those three
+- **AND** every produced ticket carries the template's original `keyspace`,
+  `table`, `ddl`, and `snapshot` unchanged
+
+### Requirement: outcome classification distinguishes admission shedding from errors
+
+Each `do_get` outcome SHALL be classified as exactly one of `ok`, `unavailable`,
+or `error`; a gRPC `UNAVAILABLE` status SHALL be counted as `unavailable` (the
+retry-safe admission-shed signal per issue #2420) and every other non-success
+status or transport/decode failure SHALL be counted as `error` and recorded with
+its status code.
+
+#### Scenario: an admission shed is counted as unavailable, not error
+
+- **GIVEN** a request whose `do_get` returns gRPC status `UNAVAILABLE` before any
+  batch is delivered
+- **WHEN** the tool classifies the outcome
+- **THEN** the step's `requests_unavailable` increments by one and
+  `requests_error` does not
+
+#### Scenario: any other failure status is counted as error with its code
+
+- **GIVEN** a request whose `do_get` fails with a status other than `UNAVAILABLE`
+  (for example `Internal` or `InvalidArgument`) or with a transport/decode error
+- **WHEN** the tool classifies the outcome
+- **THEN** the step's `requests_error` increments by one and the status code is
+  recorded under `error_codes`, while `requests_unavailable` is unchanged
+
+### Requirement: memory-bounded response consumption
+
+The tool SHALL drain each `do_get` response stream by consuming and immediately
+dropping each `RecordBatch` while accumulating only running row and byte counters,
+and MUST NOT retain the decoded result set, so peak client memory is bounded by
+concurrency and one in-flight batch rather than by result-set size.
+
+#### Scenario: a large result does not accumulate in memory
+
+- **GIVEN** a `do_get` that streams many record batches
+- **WHEN** the worker consumes the stream
+- **THEN** each batch's row count and memory size are added to the running
+  counters and the batch is dropped before the next is polled
+- **AND** no `Vec<RecordBatch>` (or equivalent) retaining the full result is held
+
+### Requirement: JSONL per-step output consumable by the round-N metrics template
+
+The tool SHALL emit one JSON object per step, one per line (JSONL), each carrying
+at minimum the step's `target_concurrency`, `shape`, `duration_s`, per-class
+counts (`requests_ok`, `requests_unavailable`, `requests_error`), `qps`,
+`rows_per_s`, `bytes_per_s`, `rows_total`, `bytes_total`, and latency percentiles
+`p50`/`p95`/`p99`/`max`, so the records feed the #2399 C-throughput block and diff
+cleanly between rounds.
+
+#### Scenario: a step record carries the required fields and is valid JSONL
+
+- **GIVEN** a completed ramp step
+- **WHEN** the tool writes its record
+- **THEN** the line parses as a single JSON object containing every required
+  field with the correct types
+- **AND** `qps` equals `requests_ok / duration_s` and the latency percentiles are
+  computed over the `ok` requests of that step
+
+### Requirement: cheap in-process self-test, not a gate component
+
+The tool SHALL provide a self-test that serves `cqlite-flight` in-process on an
+ephemeral loopback port and runs a fixed, request-count-bounded (non-wall-clock)
+ramp end-to-end, asserting a well-formed JSONL record is produced; this self-test
+MUST be a normal workspace test and SHALL NOT be registered as an
+`scripts/agent-gate.sh` component nor contact any real cluster.
+
+#### Scenario: the self-test exercises the client to server to JSONL pipeline
+
+- **GIVEN** a tiny in-process fixture table served over `127.0.0.1:0`
+- **WHEN** the self-test runs a concurrency-1, fixed-request-count ramp against it
+- **THEN** it emits at least one JSONL step record with `requests_ok >= 1` and all
+  required fields present and parseable
+- **AND** the test uses no fixed port and no wall-clock-duration step, so it is
+  deterministic and free of port/timing flake

--- a/openspec/changes/flight-loadgen/tasks.md
+++ b/openspec/changes/flight-loadgen/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — flight-loadgen (issue #2418, epic #2313 WS1)
+
+## 1. Crate scaffold (`tools/flight-loadgen`)
+
+- [ ] 1.1 Add `tools/flight-loadgen/Cargo.toml` (`publish = false`, binary
+      `flight-loadgen`) — captured by the root `members = ["tools/*"]` glob, no
+      root manifest edit; deps from `[workspace.dependencies]` (tonic,
+      arrow-flight, arrow, tokio, serde, serde_json, clap) + `hdrhistogram` +
+      `rand` (seeded RNG).
+- [ ] 1.2 Confirm `cargo build --workspace` and the gate's per-package
+      `clippy -D warnings` pick up the crate (workspace membership evidence).
+
+## 2. Client + ticket synthesis
+
+- [ ] 2.1 `--endpoint` connect: build a raw `FlightServiceClient<Channel>` (reuse
+      the `benches/flight_do_get.rs` connect pattern; connect-timeout, retry loop).
+- [ ] 2.2 Load `--ticket-template <file.json>` into a `FlightTicket`; implement the
+      four shape transforms (`full`/`limit-k`/`point`/`mixed`) on clones, keeping
+      `keyspace`/`table`/`ddl`/`snapshot` unchanged (spec: shapes requirement).
+- [ ] 2.3 Seeded ticket generator salted by (step, worker, iteration); unit test
+      that identical seeds reproduce the sequence (spec: determinism scenario).
+
+## 3. Ramp engine
+
+- [ ] 3.1 Parse `--ramp` (ordered concurrencies) + `--step-duration`; per step run
+      a worker pool of size `C` that keeps `C` `do_get`s in flight until the step
+      deadline.
+- [ ] 3.2 Per-worker loop: build ticket → `do_get` → drain-and-drop each
+      `RecordBatch` (add rows + `get_array_memory_size`; never collect) → record
+      latency + outcome (spec: memory-bound + ramp requirements).
+
+## 4. Metrics + classification + output
+
+- [ ] 4.1 Per-step `hdrhistogram` (reset each step) for p50/p95/p99/max over `ok`
+      requests.
+- [ ] 4.2 Classify outcomes: `ok` / `unavailable` (gRPC `UNAVAILABLE`, #2420
+      admission shed) / `error` (+ code) (spec: classification requirement).
+- [ ] 4.3 Emit the `flight-loadgen.step/v1` JSONL record per step to stdout / a
+      `--out` file, one object per line, with `qps = requests_ok/duration_s`
+      (spec: JSONL requirement + design schema).
+
+## 5. TDD self-test (wiring evidence, not a gate component)
+
+- [ ] 5.1 Reuse the `serve_and_connect` ephemeral-port fixture to serve a tiny
+      1-SSTable table in-process; add a `--self-test` subcommand + a `#[test]`.
+- [ ] 5.2 Self-test runs a concurrency-1, fixed-request-count (no wall-clock) ramp
+      and asserts ≥1 JSONL record with `requests_ok >= 1` and all required fields
+      present/parseable (spec: self-test requirement).
+- [ ] 5.3 Unit test each shape transform's output ticket fields (spec: shapes
+      scenario) and the outcome classifier's `UNAVAILABLE`→`unavailable`,
+      other→`error` mapping (spec: classification scenarios).
+
+## 6. Docs + handoff
+
+- [ ] 6.1 A short `tools/flight-loadgen/README.md`: purpose (server-direct ceiling
+      under the through-Trino floor), CLI flags, the JSONL schema, and how the
+      output maps to the #2399 round-N C-throughput block.
+- [ ] 6.2 Note in the README that this is the client WS8 (the #2313 ramp) drives,
+      and that cross-node distribution is N/A server-direct (single endpoint).

--- a/tools/flight-loadgen/Cargo.toml
+++ b/tools/flight-loadgen/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "flight-loadgen"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Raw FlightServiceClient concurrency-ramp load generator for cqlite-flight (issue #2418, epic #2313 WS1)"
+publish = false
+
+[[bin]]
+name = "flight-loadgen"
+path = "src/main.rs"
+
+[dependencies]
+# Raw Flight client transport — pinned to the same major lines cqlite-flight
+# serves with so the tonic/arrow-flight wire types unify across the loopback
+# self-test (arrow-flight 53 → tonic 0.12).
+arrow-flight = "53"
+tonic = "0.12"
+arrow = { workspace = true, features = ["ipc"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+clap = { workspace = true }
+thiserror = { workspace = true }
+# Fixed-footprint recording histogram for per-step p50/p95/p99/max under a
+# memory bound (design §(d)); reset per step so memory is O(buckets), never
+# O(requests).
+hdrhistogram = "7"
+# Seeded RNG for deterministic, wall-clock-independent ticket selection (design §(c)).
+rand = { workspace = true }
+
+# The self-test (`--self-test` subcommand + the `#[test]`) serves a real
+# `CqliteFlightService` in-process over an ephemeral loopback port, reusing the
+# shared `keyvalue` byte-pin fixture (`test-util`) and the `write_engine` flush.
+# These are normal (not dev) deps because the binary's `--self-test` subcommand
+# must be able to spin the server up itself; this crate is `publish = false`
+# operator/bench tooling, so pulling the fixture code in is intended.
+cqlite-flight = { path = "../../cqlite-flight", features = ["test-util"] }
+cqlite-core = { path = "../../cqlite-core", features = ["arrow"] }
+tempfile = { workspace = true }
+
+# The `flight_loadgen` library holds the ramp engine, ticket synthesis, outcome
+# classifier, JSONL record schema, and the in-process self-test harness so both
+# the binary and the `#[test]` wiring-evidence test drive the same code.
+[lib]
+name = "flight_loadgen"
+path = "src/lib.rs"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
+
+[lints]
+workspace = true

--- a/tools/flight-loadgen/README.md
+++ b/tools/flight-loadgen/README.md
@@ -1,0 +1,125 @@
+# flight-loadgen
+
+A raw `arrow_flight::FlightServiceClient` (tonic) concurrency-ramp load generator
+that drives `FlightService::do_get` **directly** against a running `cqlite-flight`
+endpoint — no Trino, no JDBC connector, no `cqlite-core` query engine on the
+client path.
+
+Issue #2418, epic #2313 WS1 (the throughput-saturation program).
+
+## Why
+
+Every published `cqlite-flight` throughput floor to date is a *through-Trino*
+aggregate (round-10b, #2367), which folds split planning, the JDBC connector,
+replica fan-out, and network into the number. `flight-loadgen` establishes the
+**server-direct ceiling** underneath that floor: it isolates server-side
+thread/fd/memory pressure and the admission-shedding behavior (#2420) by talking
+to the server over a plain gRPC channel. It is the client that WS8 (the #2313
+concurrency ramp that produces the saturation curve) drives; curve-fitting and
+the saturation report are downstream of this tool.
+
+This is a measurement tool, **not** a correctness oracle: row/tombstone/type
+parity stays with the sstabledump goldens and the query-semantics oracle. It
+measures throughput / latency / shedding, not answer correctness.
+
+## Usage
+
+```bash
+# Ramp 1→32 concurrency, 30s per step, mixed workload, against a live server:
+flight-loadgen \
+  --endpoint http://127.0.0.1:8815 \
+  --ticket-template ./keyvalue-template.json \
+  --ramp 1,2,4,8,16,32 \
+  --step-duration 30s \
+  --shape mixed \
+  --round round-11-server-direct \
+  --out round-11-flight-loadgen.jsonl
+
+# Exercise the full client→server→JSONL pipeline against an in-process fixture
+# (no external server needed) — the wiring self-test:
+flight-loadgen --self-test
+```
+
+### Key flags
+
+| Flag | Meaning | Default |
+|------|---------|---------|
+| `--endpoint <URL>` | `cqlite-flight` gRPC endpoint (`http://host:port`) | required |
+| `--ticket-template <FILE>` | Base ticket JSON (connector-shaped `FlightTicket`: keyspace/table/ddl/snapshot, full ring, no limit) | required |
+| `--ramp <LIST>` | Ordered target concurrencies, one step each | `1,2,4,8,16,32` |
+| `--step-duration <DUR>` | Per-step hold time (`30s`, `500ms`, `2m`) | `30s` |
+| `--shape <SHAPE>` | `point` \| `limit-k` \| `full` \| `mixed` | `mixed` |
+| `--limit-k <N>` | `LIMIT` k for the `limit-k`/mixed shape | `100` |
+| `--point-width <N>` | Token sub-range width for the `point` shape | `2^40` |
+| `--mix <SPEC>` | Mixed weights, e.g. `ptr=0.6,lim=0.3,full=0.1` | `ptr=0.6,lim=0.3,full=0.1` |
+| `--seed <N>` | Deterministic RNG seed for ticket selection | `42` |
+| `--round <LABEL>` | Round label stamped on each record | `""` |
+| `--out <FILE>` | JSONL output file (default: stdout) | stdout |
+| `--connect-timeout <DUR>` | Per-worker TCP connect timeout | `5s` |
+| `--self-test` | Run the in-process wiring self-test instead | off |
+
+### Workload shapes
+
+Each shape is derived by transforming a **clone** of the operator-supplied base
+template — the tool never invents DDL or partition keys:
+
+- `full` — the template as-is (full ring, `limit = None`).
+- `limit-k` — the template with `limit = Some(k)`.
+- `point` — the template narrowed to a **seeded** token sub-range
+  `[t, t + width)`. This is a request-setup/admission-cost *proxy*, not a keyed
+  single-partition lookup: it may return zero rows on a sparse sub-range. A true
+  keyed read needs a partition-key corpus (a follow-up).
+- `mixed` — a seeded weighted draw across the three.
+
+Ticket selection is reproducible from `--seed` (salted by step/worker/iteration),
+so two runs with the same seed and ramp request byte-identical tickets;
+wall-clock timing only bounds a step's duration, never which data is requested.
+
+## JSONL output — `flight-loadgen.step/v1`
+
+One JSON object per line, one per ramp step:
+
+```json
+{
+  "schema": "flight-loadgen.step/v1",
+  "round": "round-11-server-direct", "endpoint": "http://127.0.0.1:8815",
+  "ts_unix_ms": 1784199735680, "seed": 42,
+  "step": 3, "target_concurrency": 8, "shape": "mixed",
+  "duration_s": 30.0,
+  "requests_ok": 0, "requests_unavailable": 0, "requests_error": 0,
+  "error_codes": {"Internal": 0},
+  "qps": 0.0, "rows_per_s": 0.0, "bytes_per_s": 0.0,
+  "rows_total": 0, "bytes_total": 0,
+  "latency_ms": {"p50": 0.0, "p95": 0.0, "p99": 0.0, "max": 0.0, "samples": 0}
+}
+```
+
+- `qps == requests_ok / duration_s`; `duration_s` is the step's measured elapsed.
+- Latency percentiles are over the step's **`ok` requests only**.
+- `requests_unavailable` counts gRPC `UNAVAILABLE` responses — the #2420
+  admission shed (retry-safe by the server contract). A transport-layer
+  `UNAVAILABLE` is indistinguishable from an admission `UNAVAILABLE` on the wire;
+  it is attributed to admission by the server's stated contract.
+- `requests_error` counts every other non-success status / transport / decode
+  failure, tagged by status code under `error_codes`.
+- Responses are **drained and dropped** batch-by-batch (row/byte counters only);
+  the full result set is never accumulated, so peak client memory is bounded by
+  concurrency × one in-flight batch.
+
+### Mapping to the #2399 round-N metrics template
+
+- `qps` / `latency_ms.p50` / `latency_ms.p99` / per-class counts → the **C
+  (throughput)** block, tagged *server-direct*.
+- `requests_error` / `error_codes` → the **D (hygiene) `errors_total`** input.
+- **Cross-node distribution (a C sub-item) is N/A server-direct** — this tool
+  drives a single endpoint, so that field is intentionally absent rather than
+  fabricated.
+
+## Self-test
+
+`--self-test` (and the `#[test]` `self_test_produces_a_wellformed_jsonl_record`)
+serves a tiny 1-SSTable `keyvalue` fixture over an ephemeral `127.0.0.1:0` port,
+runs a concurrency-1, fixed-request-count (non-wall-clock) ramp end-to-end, and
+asserts a well-formed JSONL record with `requests_ok >= 1`. It is a normal
+workspace test (`cargo test -p flight-loadgen`), **not** an `agent-gate.sh`
+component, and never contacts a real cluster.

--- a/tools/flight-loadgen/src/classify.rs
+++ b/tools/flight-loadgen/src/classify.rs
@@ -1,0 +1,107 @@
+//! Outcome classification (design §(e), spec: classification requirement).
+//!
+//! Every `do_get` outcome is exactly one of [`Outcome::Ok`],
+//! [`Outcome::Unavailable`], or [`Outcome::Error`]. A gRPC `UNAVAILABLE` status is
+//! attributed to the #2420 admission-shed signal (retry-safe by the server's
+//! stated contract) and counted as `unavailable`; every other non-success status
+//! or transport/decode failure is counted as `error`, tagged with its status code.
+//!
+//! Caveat (recorded in the record schema): a transport-layer `UNAVAILABLE` is
+//! indistinguishable from an admission `UNAVAILABLE` on the wire — we attribute
+//! `UNAVAILABLE` to admission by the server's #2420 contract and note it.
+
+use arrow_flight::error::FlightError;
+use tonic::{Code, Status};
+
+/// The classified result of one `do_get` request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// The request streamed to completion (its rows/bytes were drained).
+    Ok,
+    /// gRPC `UNAVAILABLE` — the #2420 admission shed (retry-safe).
+    Unavailable,
+    /// Any other non-success status or transport/decode failure. Carries the
+    /// status-code label recorded under `error_codes`.
+    Error(String),
+}
+
+/// Classify a `tonic::Status` (the error from the initial `do_get` call, or a
+/// mid-stream `FlightError::Tonic`).
+pub fn classify_status(status: &Status) -> Outcome {
+    if status.code() == Code::Unavailable {
+        Outcome::Unavailable
+    } else {
+        Outcome::Error(code_label(status.code()))
+    }
+}
+
+/// Classify a `FlightError` surfaced while decoding the response stream: a
+/// wrapped `tonic::Status` classifies as above; any other decode/transport
+/// variant is an `error` tagged with a stable variant label.
+pub fn classify_flight_error(err: &FlightError) -> Outcome {
+    match err {
+        FlightError::Tonic(status) => classify_status(status),
+        FlightError::Arrow(_) => Outcome::Error("ArrowDecode".to_string()),
+        FlightError::ProtocolError(_) => Outcome::Error("ProtocolError".to_string()),
+        FlightError::DecodeError(_) => Outcome::Error("DecodeError".to_string()),
+        FlightError::ExternalError(_) => Outcome::Error("ExternalError".to_string()),
+        // `FlightError` is `#[non_exhaustive]`; any future variant is still an
+        // `error` outcome (never silently `ok`).
+        _ => Outcome::Error("OtherFlightError".to_string()),
+    }
+}
+
+/// A stable, human-readable label for a gRPC status code, used as the
+/// `error_codes` map key in the JSONL record.
+fn code_label(code: Code) -> String {
+    // `Code`'s Debug is the CamelCase variant name (`Internal`, `InvalidArgument`,
+    // …) — a stable, template-friendly key.
+    format!("{code:?}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_status_is_admission_shed() {
+        let status = Status::unavailable("permit-wait timeout");
+        assert_eq!(classify_status(&status), Outcome::Unavailable);
+    }
+
+    #[test]
+    fn other_status_is_error_with_code() {
+        assert_eq!(
+            classify_status(&Status::internal("boom")),
+            Outcome::Error("Internal".to_string())
+        );
+        assert_eq!(
+            classify_status(&Status::invalid_argument("bad ticket")),
+            Outcome::Error("InvalidArgument".to_string())
+        );
+        assert_eq!(
+            classify_status(&Status::not_found("no table")),
+            Outcome::Error("NotFound".to_string())
+        );
+    }
+
+    #[test]
+    fn flight_tonic_error_delegates_to_status_classification() {
+        let shed = FlightError::Tonic(Status::unavailable("shed"));
+        assert_eq!(classify_flight_error(&shed), Outcome::Unavailable);
+        let other = FlightError::Tonic(Status::internal("mid-stream fault"));
+        assert_eq!(
+            classify_flight_error(&other),
+            Outcome::Error("Internal".to_string())
+        );
+    }
+
+    #[test]
+    fn flight_decode_error_is_error_not_unavailable() {
+        let err = FlightError::ProtocolError("truncated".to_string());
+        assert_eq!(
+            classify_flight_error(&err),
+            Outcome::Error("ProtocolError".to_string())
+        );
+    }
+}

--- a/tools/flight-loadgen/src/client.rs
+++ b/tools/flight-loadgen/src/client.rs
@@ -1,0 +1,108 @@
+//! Raw `FlightServiceClient<Channel>` connect + one drained `do_get`
+//! (design §Context/§(f); spec: raw-client + memory-bound requirements).
+//!
+//! No Trino, no JDBC, no `cqlite-core` query engine participates on this path — a
+//! plain tonic channel streams `FlightData`, decoded to `RecordBatch`es that are
+//! drained and dropped immediately (never collected).
+
+use std::time::Duration;
+
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::transport::Channel;
+
+use crate::classify::{classify_flight_error, classify_status, Outcome};
+
+/// The drained result of one `do_get`: its classified outcome plus the rows and
+/// bytes seen while draining (0 for a non-`ok` outcome).
+#[derive(Debug, Clone)]
+pub struct DrainResult {
+    pub outcome: Outcome,
+    pub rows: u64,
+    pub bytes: u64,
+}
+
+/// Connect a raw `FlightServiceClient` to `endpoint` (e.g. `http://127.0.0.1:8815`),
+/// retrying the TCP connect for up to `connect_timeout` so a just-started server
+/// is tolerated. Reuses the `benches/flight_do_get.rs` connect pattern.
+pub async fn connect(
+    endpoint: &str,
+    connect_timeout: Duration,
+) -> Result<FlightServiceClient<Channel>, String> {
+    let channel = Channel::from_shared(endpoint.to_string())
+        .map_err(|e| format!("invalid --endpoint {endpoint:?}: {e}"))?
+        .connect_timeout(connect_timeout);
+    // Retry the connect over the timeout window (a fresh server may not be
+    // listening yet). Fixed 20ms backoff, bounded by connect_timeout.
+    let deadline = std::time::Instant::now() + connect_timeout;
+    loop {
+        match channel.connect().await {
+            Ok(c) => return Ok(FlightServiceClient::new(c)),
+            Err(e) => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(format!(
+                        "could not connect to {endpoint} within {connect_timeout:?}: {e}"
+                    ));
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Issue ONE `do_get` with `ticket_bytes` and DRAIN the response.
+///
+/// Every `RecordBatch` is consumed for its `num_rows()` and
+/// `get_array_memory_size()` and then dropped before the next is polled — no
+/// `Vec<RecordBatch>` is ever held, so peak memory is O(one in-flight batch)
+/// regardless of result-set size (spec: memory-bound requirement).
+pub async fn do_get_drain(
+    client: &mut FlightServiceClient<Channel>,
+    ticket_bytes: Vec<u8>,
+) -> DrainResult {
+    let resp = match client.do_get(Ticket::new(ticket_bytes)).await {
+        Ok(resp) => resp,
+        // Admission shed (#2420) and any pre-stream failure surface here.
+        Err(status) => {
+            return DrainResult {
+                outcome: classify_status(&status),
+                rows: 0,
+                bytes: 0,
+            }
+        }
+    };
+
+    let stream = resp.into_inner().map(|r| r.map_err(FlightError::Tonic));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+    let mut rows: u64 = 0;
+    let mut bytes: u64 = 0;
+    while let Some(next) = rb.next().await {
+        match next {
+            Ok(batch) => {
+                rows = rows.saturating_add(batch.num_rows() as u64);
+                bytes = bytes.saturating_add(batch.get_array_memory_size() as u64);
+                // Explicit drop documents the drain-don't-accumulate contract;
+                // `batch` would drop at loop end regardless — it is NEVER pushed
+                // into a collection.
+                drop(batch);
+            }
+            // A mid-stream error (including a mid-stream UNAVAILABLE) reclassifies
+            // the whole request; partial rows/bytes are discarded.
+            Err(err) => {
+                return DrainResult {
+                    outcome: classify_flight_error(&err),
+                    rows: 0,
+                    bytes: 0,
+                }
+            }
+        }
+    }
+    DrainResult {
+        outcome: Outcome::Ok,
+        rows,
+        bytes,
+    }
+}

--- a/tools/flight-loadgen/src/lib.rs
+++ b/tools/flight-loadgen/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`record`] — the `flight-loadgen.step/v1` JSONL step record + accumulator,
 //! - [`client`] — raw `FlightServiceClient` connect + memory-bounded `do_get` drain,
 //! - [`ramp`] — the concurrency-ramp engine (per-step worker pool),
+//! - [`output`] — JSONL emission + write-before-error finalization,
 //! - [`selftest`] — the in-process ephemeral-port self-test harness.
 //!
 //! It measures throughput/latency/shedding of the SERVER directly (no Trino, no
@@ -17,6 +18,7 @@
 
 pub mod classify;
 pub mod client;
+pub mod output;
 pub mod ramp;
 pub mod record;
 pub mod selftest;

--- a/tools/flight-loadgen/src/lib.rs
+++ b/tools/flight-loadgen/src/lib.rs
@@ -1,0 +1,23 @@
+//! `flight-loadgen` — a raw `FlightServiceClient` concurrency-ramp load
+//! generator for `cqlite-flight` (issue #2418, epic #2313 WS1).
+//!
+//! This library holds the reusable pieces the `flight-loadgen` binary and its
+//! wiring-evidence self-test both drive:
+//!
+//! - [`shape`] — base-template + seeded shape transforms (deterministic tickets),
+//! - [`classify`] — ok / unavailable (#2420 admission shed) / error classification,
+//! - [`record`] — the `flight-loadgen.step/v1` JSONL step record + accumulator,
+//! - [`client`] — raw `FlightServiceClient` connect + memory-bounded `do_get` drain,
+//! - [`ramp`] — the concurrency-ramp engine (per-step worker pool),
+//! - [`selftest`] — the in-process ephemeral-port self-test harness.
+//!
+//! It measures throughput/latency/shedding of the SERVER directly (no Trino, no
+//! JDBC, no `cqlite-core` query engine on the client path) — the "server-direct
+//! ceiling" underneath the through-Trino floor. It is NOT a correctness oracle.
+
+pub mod classify;
+pub mod client;
+pub mod ramp;
+pub mod record;
+pub mod selftest;
+pub mod shape;

--- a/tools/flight-loadgen/src/main.rs
+++ b/tools/flight-loadgen/src/main.rs
@@ -9,12 +9,12 @@
 //! Run `flight-loadgen --help` for flags, or `flight-loadgen --self-test` to
 //! exercise the full client→server→JSONL pipeline against an in-process fixture.
 
-use std::io::Write;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::Parser;
 
+use flight_loadgen::output::{finalize, write_records};
 use flight_loadgen::ramp::{parse_duration, parse_ramp, run_ramp, RampConfig, StepBound};
 use flight_loadgen::record::StepRecord;
 use flight_loadgen::selftest::run_self_test;
@@ -110,16 +110,22 @@ fn main() -> ExitCode {
 }
 
 async fn run(cli: Cli) -> Result<(), String> {
-    let records = if cli.self_test {
-        run_self_test(cli.self_test_requests).await?
+    if cli.self_test {
+        let records = run_self_test(cli.self_test_requests).await?;
+        write_records(&records, cli.out.as_deref())
     } else {
-        run_real_ramp(&cli).await?
-    };
-    write_records(&records, cli.out.as_deref())
+        // `run_real_ramp` returns whatever steps completed PLUS any terminal error.
+        // `finalize` writes the completed steps' JSONL BEFORE surfacing that error,
+        // so a late-step connect failure never discards prior steps' data.
+        let (records, ramp_error) = run_real_ramp(&cli).await?;
+        finalize(&records, ramp_error, cli.out.as_deref())
+    }
 }
 
 /// Drive the operator ramp against `--endpoint` using `--ticket-template`.
-async fn run_real_ramp(cli: &Cli) -> Result<Vec<StepRecord>, String> {
+/// Returns the completed-step records and an optional terminal ramp error
+/// (config/setup errors are surfaced as the outer `Err`, before any ramp runs).
+async fn run_real_ramp(cli: &Cli) -> Result<(Vec<StepRecord>, Option<String>), String> {
     let endpoint = cli
         .endpoint
         .clone()
@@ -146,7 +152,7 @@ async fn run_real_ramp(cli: &Cli) -> Result<Vec<StepRecord>, String> {
         connect_timeout,
         seed: cli.seed,
     };
-    run_ramp(&config, &gen).await
+    Ok(run_ramp(&config, &gen).await)
 }
 
 /// Load and validate the base ticket template from disk.
@@ -155,27 +161,4 @@ fn load_template(path: &std::path::Path) -> Result<FlightTicket, String> {
         .map_err(|e| format!("reading --ticket-template {}: {e}", path.display()))?;
     FlightTicket::from_bytes(&bytes)
         .map_err(|e| format!("parsing --ticket-template {}: {e}", path.display()))
-}
-
-/// Write records as JSONL (one object per line) to `out` or stdout.
-fn write_records(records: &[StepRecord], out: Option<&std::path::Path>) -> Result<(), String> {
-    let mut buf = String::new();
-    for rec in records {
-        let line = rec
-            .to_jsonl()
-            .map_err(|e| format!("serializing record: {e}"))?;
-        buf.push_str(&line);
-        buf.push('\n');
-    }
-    match out {
-        Some(path) => std::fs::write(path, buf.as_bytes())
-            .map_err(|e| format!("writing --out {}: {e}", path.display())),
-        None => {
-            let stdout = std::io::stdout();
-            let mut lock = stdout.lock();
-            lock.write_all(buf.as_bytes())
-                .and_then(|()| lock.flush())
-                .map_err(|e| format!("writing stdout: {e}"))
-        }
-    }
 }

--- a/tools/flight-loadgen/src/main.rs
+++ b/tools/flight-loadgen/src/main.rs
@@ -1,0 +1,181 @@
+//! `flight-loadgen` CLI (issue #2418, epic #2313 WS1).
+//!
+//! Drives a raw `FlightServiceClient` concurrency ramp of `do_get` requests
+//! DIRECTLY against a running `cqlite-flight` endpoint — no Trino, no JDBC, no
+//! `cqlite-core` query engine on the client path — and emits one
+//! `flight-loadgen.step/v1` JSONL record per ramp step (the "server-direct
+//! ceiling" that feeds the #2399 round-N C-throughput block).
+//!
+//! Run `flight-loadgen --help` for flags, or `flight-loadgen --self-test` to
+//! exercise the full client→server→JSONL pipeline against an in-process fixture.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+
+use flight_loadgen::ramp::{parse_duration, parse_ramp, run_ramp, RampConfig, StepBound};
+use flight_loadgen::record::StepRecord;
+use flight_loadgen::selftest::run_self_test;
+use flight_loadgen::shape::{MixWeights, Shape, ShapeGen};
+
+use cqlite_flight::ticket::FlightTicket;
+
+/// Raw FlightServiceClient concurrency-ramp load generator for cqlite-flight.
+#[derive(Debug, Parser)]
+#[command(name = "flight-loadgen", version, about)]
+struct Cli {
+    /// `cqlite-flight` endpoint, e.g. `http://127.0.0.1:8815`. Required unless
+    /// `--self-test`.
+    #[arg(long)]
+    endpoint: Option<String>,
+
+    /// Path to the base ticket-template JSON (connector-shaped `FlightTicket`:
+    /// keyspace/table/ddl/snapshot, full ring, no limit). Required unless
+    /// `--self-test`.
+    #[arg(long)]
+    ticket_template: Option<PathBuf>,
+
+    /// Ordered target concurrencies, comma-separated (one ramp step each).
+    #[arg(long, default_value = "1,2,4,8,16,32")]
+    ramp: String,
+
+    /// Per-step hold duration (e.g. `30s`, `500ms`, `2m`).
+    #[arg(long, default_value = "30s")]
+    step_duration: String,
+
+    /// Workload shape: `point` | `limit-k` | `full` | `mixed`.
+    #[arg(long, default_value = "mixed")]
+    shape: String,
+
+    /// `LIMIT` k for the `limit-k` (and mixed) shape.
+    #[arg(long, default_value_t = 100)]
+    limit_k: u64,
+
+    /// Token sub-range width for the `point` shape (a small fraction of the ring).
+    #[arg(long, default_value_t = 1 << 40)]
+    point_width: i64,
+
+    /// Mixed-shape weights, e.g. `ptr=0.6,lim=0.3,full=0.1`.
+    #[arg(long, default_value = "ptr=0.6,lim=0.3,full=0.1")]
+    mix: String,
+
+    /// Deterministic RNG seed for ticket selection.
+    #[arg(long, default_value_t = 42)]
+    seed: u64,
+
+    /// Round label stamped on each JSONL record.
+    #[arg(long, default_value = "")]
+    round: String,
+
+    /// Write JSONL records here (one object per line). Defaults to stdout.
+    #[arg(long)]
+    out: Option<PathBuf>,
+
+    /// Per-worker TCP connect timeout (e.g. `5s`).
+    #[arg(long, default_value = "5s")]
+    connect_timeout: String,
+
+    /// Run the in-process wiring self-test instead of a real ramp: serve a tiny
+    /// fixture on an ephemeral loopback port and run a concurrency-1,
+    /// fixed-request-count ramp against it. Ignores `--endpoint`/`--ticket-template`.
+    #[arg(long)]
+    self_test: bool,
+
+    /// Fixed request count for `--self-test` (count-bounded, no wall-clock).
+    #[arg(long, default_value_t = 3)]
+    self_test_requests: u64,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("flight-loadgen: failed to build tokio runtime: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    match rt.block_on(run(cli)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("flight-loadgen: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run(cli: Cli) -> Result<(), String> {
+    let records = if cli.self_test {
+        run_self_test(cli.self_test_requests).await?
+    } else {
+        run_real_ramp(&cli).await?
+    };
+    write_records(&records, cli.out.as_deref())
+}
+
+/// Drive the operator ramp against `--endpoint` using `--ticket-template`.
+async fn run_real_ramp(cli: &Cli) -> Result<Vec<StepRecord>, String> {
+    let endpoint = cli
+        .endpoint
+        .clone()
+        .ok_or("--endpoint is required (unless --self-test)")?;
+    let template_path = cli
+        .ticket_template
+        .as_ref()
+        .ok_or("--ticket-template is required (unless --self-test)")?;
+
+    let template = load_template(template_path)?;
+    let shape = Shape::parse(&cli.shape)?;
+    let mix = MixWeights::parse(&cli.mix)?;
+    let concurrencies = parse_ramp(&cli.ramp)?;
+    let step_duration = parse_duration(&cli.step_duration)?;
+    let connect_timeout = parse_duration(&cli.connect_timeout)?;
+
+    let gen = ShapeGen::new(template, cli.seed, cli.limit_k, cli.point_width, mix);
+    let config = RampConfig {
+        concurrencies,
+        bound: StepBound::Duration(step_duration),
+        shape,
+        round: cli.round.clone(),
+        endpoint,
+        connect_timeout,
+        seed: cli.seed,
+    };
+    run_ramp(&config, &gen).await
+}
+
+/// Load and validate the base ticket template from disk.
+fn load_template(path: &std::path::Path) -> Result<FlightTicket, String> {
+    let bytes = std::fs::read(path)
+        .map_err(|e| format!("reading --ticket-template {}: {e}", path.display()))?;
+    FlightTicket::from_bytes(&bytes)
+        .map_err(|e| format!("parsing --ticket-template {}: {e}", path.display()))
+}
+
+/// Write records as JSONL (one object per line) to `out` or stdout.
+fn write_records(records: &[StepRecord], out: Option<&std::path::Path>) -> Result<(), String> {
+    let mut buf = String::new();
+    for rec in records {
+        let line = rec
+            .to_jsonl()
+            .map_err(|e| format!("serializing record: {e}"))?;
+        buf.push_str(&line);
+        buf.push('\n');
+    }
+    match out {
+        Some(path) => std::fs::write(path, buf.as_bytes())
+            .map_err(|e| format!("writing --out {}: {e}", path.display())),
+        None => {
+            let stdout = std::io::stdout();
+            let mut lock = stdout.lock();
+            lock.write_all(buf.as_bytes())
+                .and_then(|()| lock.flush())
+                .map_err(|e| format!("writing stdout: {e}"))
+        }
+    }
+}

--- a/tools/flight-loadgen/src/output.rs
+++ b/tools/flight-loadgen/src/output.rs
@@ -1,0 +1,108 @@
+//! JSONL output + terminal-error orchestration (spec: JSONL requirement).
+//!
+//! The ramp writes one `flight-loadgen.step/v1` line per COMPLETED step. Crucially,
+//! [`finalize`] persists whatever records completed BEFORE surfacing any terminal
+//! ramp error, so a late-step connect failure (an EXPECTED outcome under saturation,
+//! design §(c)) never discards the JSONL of the steps that already succeeded.
+
+use std::io::Write;
+use std::path::Path;
+
+use crate::record::StepRecord;
+
+/// Write `records` as JSONL (one object per line) to `out`, or stdout if `None`.
+pub fn write_records(records: &[StepRecord], out: Option<&Path>) -> Result<(), String> {
+    let mut buf = String::new();
+    for rec in records {
+        let line = rec
+            .to_jsonl()
+            .map_err(|e| format!("serializing record: {e}"))?;
+        buf.push_str(&line);
+        buf.push('\n');
+    }
+    match out {
+        Some(path) => std::fs::write(path, buf.as_bytes())
+            .map_err(|e| format!("writing --out {}: {e}", path.display())),
+        None => {
+            let stdout = std::io::stdout();
+            let mut lock = stdout.lock();
+            lock.write_all(buf.as_bytes())
+                .and_then(|()| lock.flush())
+                .map_err(|e| format!("writing stdout: {e}"))
+        }
+    }
+}
+
+/// Persist every completed-step record, THEN surface any terminal ramp error.
+///
+/// Records are ALWAYS written first: a `ramp_error` (e.g. a connect failure at a
+/// later, higher-concurrency step — an expected saturation outcome) must never
+/// discard the JSONL already earned by earlier steps. The write itself failing
+/// takes precedence (there is no output to trust), otherwise the ramp error, if
+/// any, is propagated.
+pub fn finalize(
+    records: &[StepRecord],
+    ramp_error: Option<String>,
+    out: Option<&Path>,
+) -> Result<(), String> {
+    write_records(records, out)?;
+    match ramp_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::StepAgg;
+
+    fn sample_record(step: usize) -> StepRecord {
+        StepAgg::new().into_record(
+            "r".into(),
+            "http://x".into(),
+            0,
+            42,
+            step,
+            1 << step,
+            "mixed".into(),
+            1.0,
+        )
+    }
+
+    /// The data-loss regression (roborev Medium): when a later step fails, the
+    /// records already gathered from prior successful steps MUST still be written
+    /// out — finalize persists them, then propagates the terminal error.
+    #[test]
+    fn finalize_writes_completed_steps_before_propagating_error() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("out.jsonl");
+        let records = vec![sample_record(0), sample_record(1)];
+
+        let err = finalize(
+            &records,
+            Some("ramp stopped at step 2: connect refused".to_string()),
+            Some(&path),
+        )
+        .expect_err("the terminal ramp error must still be surfaced");
+        assert!(err.contains("step 2"), "propagates the ramp error: {err}");
+
+        // ...but the two completed steps' JSONL is on disk, NOT discarded.
+        let written = std::fs::read_to_string(&path).expect("output file written");
+        let lines: Vec<&str> = written.lines().collect();
+        assert_eq!(lines.len(), 2, "both completed steps written: {written:?}");
+        for (i, line) in lines.iter().enumerate() {
+            let v: serde_json::Value = serde_json::from_str(line).expect("valid JSONL line");
+            assert_eq!(v["step"], i, "record {i} preserved in order");
+        }
+    }
+
+    #[test]
+    fn finalize_ok_when_no_error() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("out.jsonl");
+        finalize(&[sample_record(0)], None, Some(&path)).expect("clean finish");
+        let written = std::fs::read_to_string(&path).expect("output file");
+        assert_eq!(written.lines().count(), 1);
+    }
+}

--- a/tools/flight-loadgen/src/ramp.rs
+++ b/tools/flight-loadgen/src/ramp.rs
@@ -190,9 +190,19 @@ pub fn parse_ramp(s: &str) -> Result<Vec<usize>, String> {
 /// Parse a duration like `30s`, `500ms`, `2m` (default unit: seconds if bare).
 pub fn parse_duration(s: &str) -> Result<Duration, String> {
     let s = s.trim();
+    // Validate the parsed number before constructing a Duration: negative, NaN,
+    // and infinite values all make Duration::from_secs_f64 panic, so reject them
+    // here and return the Err the signature promises instead.
     let parse_num = |num: &str| -> Result<f64, String> {
-        num.parse::<f64>()
-            .map_err(|_| format!("bad duration {s:?}"))
+        let n = num
+            .parse::<f64>()
+            .map_err(|_| format!("bad duration {s:?}"))?;
+        if !n.is_finite() || n < 0.0 {
+            return Err(format!(
+                "bad duration {s:?}: must be a finite, non-negative number"
+            ));
+        }
+        Ok(n)
     };
     if let Some(ms) = s.strip_suffix("ms") {
         Ok(Duration::from_secs_f64(parse_num(ms)? / 1000.0))
@@ -232,5 +242,17 @@ mod tests {
         assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
         assert_eq!(parse_duration("5").unwrap(), Duration::from_secs(5));
         assert!(parse_duration("nope").is_err());
+    }
+
+    #[test]
+    fn parse_duration_rejects_non_finite_and_negative_without_panicking() {
+        // Regression: these previously reached Duration::from_secs_f64, which
+        // panics on negative/NaN/infinite input instead of returning Err.
+        for bad in ["-5s", "-1", "nan", "inf", "-inf", "infms", "-2m"] {
+            assert!(
+                parse_duration(bad).is_err(),
+                "expected Err for {bad:?}, got Ok"
+            );
+        }
     }
 }

--- a/tools/flight-loadgen/src/ramp.rs
+++ b/tools/flight-loadgen/src/ramp.rs
@@ -50,16 +50,32 @@ pub struct RampConfig {
     pub seed: u64,
 }
 
-/// Run the full ramp, returning one [`StepRecord`] per configured concurrency,
-/// in order. `gen` supplies deterministic tickets; each worker connects its own
-/// raw client to `config.endpoint`.
-pub async fn run_ramp(config: &RampConfig, gen: &ShapeGen) -> Result<Vec<StepRecord>, String> {
+/// Run the full ramp, returning one [`StepRecord`] per COMPLETED step (in order)
+/// plus an optional terminal error. `gen` supplies deterministic tickets; each
+/// worker connects its own raw client to `config.endpoint`.
+///
+/// A step failing (e.g. a connect failure at a later, higher-concurrency step —
+/// an EXPECTED saturation outcome, design §(c)) STOPS the ramp but is returned
+/// alongside the records already gathered from prior successful steps, never in
+/// place of them: the caller ([`crate::output::finalize`]) writes the completed
+/// steps' JSONL before surfacing the error, so one late-step hiccup can never
+/// discard many steps' worth of data.
+pub async fn run_ramp(config: &RampConfig, gen: &ShapeGen) -> (Vec<StepRecord>, Option<String>) {
     let mut records = Vec::with_capacity(config.concurrencies.len());
     for (step_idx, &concurrency) in config.concurrencies.iter().enumerate() {
-        let record = run_step(config, gen, step_idx, concurrency).await?;
-        records.push(record);
+        match run_step(config, gen, step_idx, concurrency).await {
+            Ok(record) => records.push(record),
+            Err(e) => {
+                return (
+                    records,
+                    Some(format!(
+                        "ramp stopped at step {step_idx} (target concurrency {concurrency}): {e}"
+                    )),
+                );
+            }
+        }
     }
-    Ok(records)
+    (records, None)
 }
 
 /// Run one ramp step at `concurrency`, merging per-worker partials into a record.
@@ -70,6 +86,24 @@ async fn run_step(
     concurrency: usize,
 ) -> Result<StepRecord, String> {
     let concurrency = concurrency.max(1);
+
+    // Connect ALL workers up front, BEFORE spawning any task (design 1a). If any
+    // connect fails we return `Err` here with ZERO worker tasks in flight, so no
+    // already-spawned worker is ever orphaned: dropping a `JoinHandle` DETACHES the
+    // task (it does NOT abort it), which — under the old connect-inside-the-spawn-loop
+    // code — left earlier workers issuing uncounted, unbounded load past the step's
+    // deadline on a mid-loop `?`. Nothing to abort now: on failure `clients` (and its
+    // open channels) simply drop.
+    let mut clients = Vec::with_capacity(concurrency);
+    for worker_idx in 0..concurrency {
+        let client = connect(&config.endpoint, config.connect_timeout)
+            .await
+            .map_err(|e| format!("worker {worker_idx} connect: {e}"))?;
+        clients.push(client);
+    }
+
+    // Capture the step's timing window AFTER every connect has completed, so the
+    // (variable) connect latency never biases the measured `duration_s`/deadline.
     let started = Instant::now();
     let deadline = match config.bound {
         StepBound::Duration(d) => Some(started + d),
@@ -84,13 +118,12 @@ async fn run_step(
     };
 
     let mut handles = Vec::with_capacity(concurrency);
-    for worker_idx in 0..concurrency {
+    for (worker_idx, mut client) in clients.into_iter().enumerate() {
         let gen = gen.clone();
         let shape = config.shape;
         let step_u = step_idx as u64;
         let worker_u = worker_idx as u64;
         let claimed = Arc::clone(&claimed);
-        let mut client = connect(&config.endpoint, config.connect_timeout).await?;
         handles.push(tokio::spawn(async move {
             let mut agg = StepAgg::new();
             let mut iter: u64 = 0;
@@ -240,6 +273,49 @@ mod tests {
         assert!(parse_ramp("").is_err());
         assert!(parse_ramp("0").is_err());
         assert!(parse_ramp("x").is_err());
+    }
+
+    /// Regression (roborev Medium): a connect failure must NOT `?`-propagate out of
+    /// `run_ramp` and nuke everything. It now returns the records gathered so far
+    /// (empty here — the very first step fails) PLUS a terminal error, and returns
+    /// PROMPTLY because the connect is attempted up front, before any worker task is
+    /// spawned (no orphaned/detached workers issuing load past the deadline).
+    #[tokio::test]
+    async fn run_ramp_connect_failure_returns_terminal_error_not_panic() {
+        // A definitely-closed loopback port: bind then immediately drop the listener.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral");
+        let addr = listener.local_addr().expect("local addr");
+        drop(listener);
+
+        let gen = ShapeGen::new(
+            crate::selftest::selftest_template(),
+            42,
+            100,
+            1 << 40,
+            crate::shape::MixWeights::default(),
+        );
+        let config = RampConfig {
+            concurrencies: vec![1, 2],
+            bound: StepBound::Requests(3),
+            shape: Shape::Full,
+            round: "connect-fail".into(),
+            endpoint: format!("http://{addr}"),
+            connect_timeout: Duration::from_millis(150),
+            seed: 42,
+        };
+
+        let (records, err) = run_ramp(&config, &gen).await;
+        assert!(
+            records.is_empty(),
+            "no step completed against the closed port"
+        );
+        let err = err.expect("a connect failure must surface a terminal error");
+        assert!(
+            err.contains("step 0") && err.contains("connect"),
+            "error names the failing step + connect cause: {err}"
+        );
     }
 
     #[test]

--- a/tools/flight-loadgen/src/ramp.rs
+++ b/tools/flight-loadgen/src/ramp.rs
@@ -191,8 +191,12 @@ pub fn parse_ramp(s: &str) -> Result<Vec<usize>, String> {
 pub fn parse_duration(s: &str) -> Result<Duration, String> {
     let s = s.trim();
     // Validate the parsed number before constructing a Duration: negative, NaN,
-    // and infinite values all make Duration::from_secs_f64 panic, so reject them
-    // here and return the Err the signature promises instead.
+    // and infinite values all make Duration::from_secs_f64 panic. We keep this
+    // early check for a clearer error, but the authoritative guard is
+    // Duration::try_from_secs_f64 applied to the FINAL, SCALED value in every
+    // branch below: it also rejects post-scale overflow to +inf (e.g. "1e308m")
+    // and finite values that overflow Duration's range (e.g. "1e30"), both of
+    // which would still panic under from_secs_f64.
     let parse_num = |num: &str| -> Result<f64, String> {
         let n = num
             .parse::<f64>()
@@ -204,14 +208,17 @@ pub fn parse_duration(s: &str) -> Result<Duration, String> {
         }
         Ok(n)
     };
+    let to_duration = |secs: f64| -> Result<Duration, String> {
+        Duration::try_from_secs_f64(secs).map_err(|_| format!("bad duration {s:?}: out of range"))
+    };
     if let Some(ms) = s.strip_suffix("ms") {
-        Ok(Duration::from_secs_f64(parse_num(ms)? / 1000.0))
+        to_duration(parse_num(ms)? / 1000.0)
     } else if let Some(m) = s.strip_suffix('m') {
-        Ok(Duration::from_secs_f64(parse_num(m)? * 60.0))
+        to_duration(parse_num(m)? * 60.0)
     } else if let Some(sec) = s.strip_suffix('s') {
-        Ok(Duration::from_secs_f64(parse_num(sec)?))
+        to_duration(parse_num(sec)?)
     } else {
-        Ok(Duration::from_secs_f64(parse_num(s)?))
+        to_duration(parse_num(s)?)
     }
 }
 
@@ -248,7 +255,13 @@ mod tests {
     fn parse_duration_rejects_non_finite_and_negative_without_panicking() {
         // Regression: these previously reached Duration::from_secs_f64, which
         // panics on negative/NaN/infinite input instead of returning Err.
-        for bad in ["-5s", "-1", "nan", "inf", "-inf", "infms", "-2m"] {
+        // "1e30" (bare, finite, non-negative) overflows Duration's range, and
+        // "1e308m" is finite pre-scale but overflows to +inf after *60.0 — both
+        // still panicked under from_secs_f64 despite the pre-scale check, so the
+        // try_from_secs_f64 guard on the final scaled value must catch them.
+        for bad in [
+            "-5s", "-1", "nan", "inf", "-inf", "infms", "-2m", "1e30", "1e308m",
+        ] {
             assert!(
                 parse_duration(bad).is_err(),
                 "expected Err for {bad:?}, got Ok"

--- a/tools/flight-loadgen/src/ramp.rs
+++ b/tools/flight-loadgen/src/ramp.rs
@@ -1,0 +1,236 @@
+//! The concurrency-ramp engine (design §(c); spec: ramp + memory-bound
+//! requirements).
+//!
+//! A ramp is an ordered list of target concurrencies, each held for a step
+//! bound. Per step a worker pool of size `C` keeps `C` `do_get`s in flight until
+//! the bound is reached; each worker loops build-ticket → `do_get` → drain →
+//! record. Workers accumulate into their own [`StepAgg`] (no hot-path lock) and
+//! the partials are merged at step end into one [`StepRecord`].
+//!
+//! Determinism: which data a worker requests depends only on
+//! `(seed, step, worker, iteration)` via [`ShapeGen`]; wall-clock only bounds a
+//! duration step, never the sampled data.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use crate::client::{connect, do_get_drain};
+use crate::record::{StepAgg, StepRecord};
+use crate::shape::{Shape, ShapeGen};
+
+/// How a step decides it is done.
+#[derive(Debug, Clone, Copy)]
+pub enum StepBound {
+    /// Hold the concurrency for a wall-clock duration (the operator ramp).
+    Duration(Duration),
+    /// Issue exactly this many requests total across the step's workers, then
+    /// stop (the self-test — no wall-clock, so no timing flake).
+    Requests(u64),
+}
+
+/// A single ramp configuration.
+#[derive(Debug, Clone)]
+pub struct RampConfig {
+    /// Ordered target concurrencies (one step each).
+    pub concurrencies: Vec<usize>,
+    /// Per-step bound.
+    pub bound: StepBound,
+    /// Workload shape swept for every step.
+    pub shape: Shape,
+    /// Round label stamped on each record.
+    pub round: String,
+    /// Endpoint URL every worker connects a raw `FlightServiceClient` to (also
+    /// stamped on each record). For the self-test this is the in-process
+    /// server's ephemeral `http://127.0.0.1:<port>`.
+    pub endpoint: String,
+    /// Per-worker TCP connect timeout.
+    pub connect_timeout: Duration,
+    /// Seed stamped on each record (for provenance).
+    pub seed: u64,
+}
+
+/// Run the full ramp, returning one [`StepRecord`] per configured concurrency,
+/// in order. `gen` supplies deterministic tickets; each worker connects its own
+/// raw client to `config.endpoint`.
+pub async fn run_ramp(config: &RampConfig, gen: &ShapeGen) -> Result<Vec<StepRecord>, String> {
+    let mut records = Vec::with_capacity(config.concurrencies.len());
+    for (step_idx, &concurrency) in config.concurrencies.iter().enumerate() {
+        let record = run_step(config, gen, step_idx, concurrency).await?;
+        records.push(record);
+    }
+    Ok(records)
+}
+
+/// Run one ramp step at `concurrency`, merging per-worker partials into a record.
+async fn run_step(
+    config: &RampConfig,
+    gen: &ShapeGen,
+    step_idx: usize,
+    concurrency: usize,
+) -> Result<StepRecord, String> {
+    let concurrency = concurrency.max(1);
+    let started = Instant::now();
+    let deadline = match config.bound {
+        StepBound::Duration(d) => Some(started + d),
+        StepBound::Requests(_) => None,
+    };
+    // Shared request-slot claim for the count-bounded self-test: workers claim a
+    // 0-based index; a claim >= the budget means "stop". Unused for Duration.
+    let claimed = Arc::new(AtomicU64::new(0));
+    let request_budget = match config.bound {
+        StepBound::Requests(n) => Some(n),
+        StepBound::Duration(_) => None,
+    };
+
+    let mut handles = Vec::with_capacity(concurrency);
+    for worker_idx in 0..concurrency {
+        let gen = gen.clone();
+        let shape = config.shape;
+        let step_u = step_idx as u64;
+        let worker_u = worker_idx as u64;
+        let claimed = Arc::clone(&claimed);
+        let mut client = connect(&config.endpoint, config.connect_timeout).await?;
+        handles.push(tokio::spawn(async move {
+            let mut agg = StepAgg::new();
+            let mut iter: u64 = 0;
+            loop {
+                // Bound check BEFORE issuing so we never exceed the budget/deadline.
+                match request_budget {
+                    Some(budget) => {
+                        let slot = claimed.fetch_add(1, Ordering::Relaxed);
+                        if slot >= budget {
+                            break;
+                        }
+                    }
+                    None => {
+                        if let Some(deadline) = deadline {
+                            if Instant::now() >= deadline {
+                                break;
+                            }
+                        }
+                    }
+                }
+                let ticket = gen.build(shape, step_u, worker_u, iter);
+                let ticket_bytes = match ticket.to_bytes() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        // A template that cannot serialise is a config error, not
+                        // a server outcome — surface it as an error sample.
+                        agg.record_outcome(&crate::classify::Outcome::Error(format!(
+                            "TicketEncode:{e}"
+                        )));
+                        iter += 1;
+                        continue;
+                    }
+                };
+                let req_start = Instant::now();
+                let result = do_get_drain(&mut client, ticket_bytes).await;
+                match result.outcome {
+                    crate::classify::Outcome::Ok => {
+                        let latency_us =
+                            req_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
+                        agg.record_ok(latency_us, result.rows, result.bytes);
+                    }
+                    other => agg.record_outcome(&other),
+                }
+                iter += 1;
+            }
+            agg
+        }));
+    }
+
+    let mut merged = StepAgg::new();
+    for handle in handles {
+        let partial = handle
+            .await
+            .map_err(|e| format!("worker task panicked/join failed: {e}"))?;
+        merged.merge(&partial);
+    }
+
+    let duration_s = started.elapsed().as_secs_f64();
+    let ts_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(u64::MAX as u128) as u64)
+        .unwrap_or(0);
+    Ok(merged.into_record(
+        config.round.clone(),
+        config.endpoint.clone(),
+        ts_unix_ms,
+        config.seed,
+        step_idx,
+        concurrency,
+        config.shape.label().to_string(),
+        duration_s,
+    ))
+}
+
+/// Parse `--ramp` (`1,2,4,8`) into ordered positive concurrencies.
+pub fn parse_ramp(s: &str) -> Result<Vec<usize>, String> {
+    let mut out = Vec::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let c: usize = part
+            .parse()
+            .map_err(|_| format!("bad --ramp level {part:?} (expected a positive integer)"))?;
+        if c == 0 {
+            return Err("--ramp levels must be >= 1".to_string());
+        }
+        out.push(c);
+    }
+    if out.is_empty() {
+        return Err("--ramp must list at least one concurrency".to_string());
+    }
+    Ok(out)
+}
+
+/// Parse a duration like `30s`, `500ms`, `2m` (default unit: seconds if bare).
+pub fn parse_duration(s: &str) -> Result<Duration, String> {
+    let s = s.trim();
+    let parse_num = |num: &str| -> Result<f64, String> {
+        num.parse::<f64>()
+            .map_err(|_| format!("bad duration {s:?}"))
+    };
+    if let Some(ms) = s.strip_suffix("ms") {
+        Ok(Duration::from_secs_f64(parse_num(ms)? / 1000.0))
+    } else if let Some(m) = s.strip_suffix('m') {
+        Ok(Duration::from_secs_f64(parse_num(m)? * 60.0))
+    } else if let Some(sec) = s.strip_suffix('s') {
+        Ok(Duration::from_secs_f64(parse_num(sec)?))
+    } else {
+        Ok(Duration::from_secs_f64(parse_num(s)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ramp_orders_and_rejects_bad_input() {
+        assert_eq!(
+            parse_ramp("1,2,4,8,16,32").unwrap(),
+            vec![1, 2, 4, 8, 16, 32]
+        );
+        assert_eq!(
+            parse_ramp(" 3 , 1 ").unwrap(),
+            vec![3, 1],
+            "order preserved"
+        );
+        assert!(parse_ramp("").is_err());
+        assert!(parse_ramp("0").is_err());
+        assert!(parse_ramp("x").is_err());
+    }
+
+    #[test]
+    fn parse_duration_units() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+        assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
+        assert_eq!(parse_duration("5").unwrap(), Duration::from_secs(5));
+        assert!(parse_duration("nope").is_err());
+    }
+}

--- a/tools/flight-loadgen/src/record.rs
+++ b/tools/flight-loadgen/src/record.rs
@@ -1,0 +1,308 @@
+//! Per-step aggregation and the `flight-loadgen.step/v1` JSONL record
+//! (spec: JSONL requirement; design §JSONL record schema).
+//!
+//! [`StepAgg`] accumulates one step's outcomes under a memory bound — per-class
+//! counts, running row/byte totals, and a single fixed-footprint
+//! [`hdrhistogram::Histogram`] over the latencies of `ok` requests only (reset
+//! per step, so memory is O(histogram buckets), never O(requests)). At step end
+//! it renders a [`StepRecord`], which serialises to exactly one JSONL line.
+
+use std::collections::BTreeMap;
+
+use hdrhistogram::Histogram;
+use serde::Serialize;
+
+use crate::classify::Outcome;
+
+/// JSONL schema tag emitted on every record. Bump when the shape changes.
+pub const SCHEMA_TAG: &str = "flight-loadgen.step/v1";
+
+/// A memory-bounded accumulator for one ramp step's request outcomes.
+///
+/// Latencies are recorded in **microseconds** into an auto-resizing 3-sig-fig
+/// histogram and reported in **milliseconds** in the record. The histogram is
+/// per step (a fresh `StepAgg` per step), so memory never grows with request
+/// volume — mirroring the drain-don't-accumulate rule the program enforces.
+pub struct StepAgg {
+    ok: u64,
+    unavailable: u64,
+    error: u64,
+    error_codes: BTreeMap<String, u64>,
+    rows_total: u64,
+    bytes_total: u64,
+    /// Latencies (microseconds) of `ok` requests only.
+    latency_us: Histogram<u64>,
+}
+
+impl StepAgg {
+    /// A fresh accumulator with an empty auto-resizing latency histogram.
+    pub fn new() -> Self {
+        Self {
+            ok: 0,
+            unavailable: 0,
+            error: 0,
+            error_codes: BTreeMap::new(),
+            rows_total: 0,
+            bytes_total: 0,
+            // 3 significant figures, auto-resizing so the caller never has to
+            // pick a max latency up front. Recording never fails for a resizing
+            // histogram, so any error here is a construction-time bug.
+            latency_us: Histogram::new(3).expect("valid histogram sigfig"),
+        }
+    }
+
+    /// Record a successful request: its latency, drained row count, and drained
+    /// byte count. Only `ok` latencies enter the percentile histogram.
+    pub fn record_ok(&mut self, latency_us: u64, rows: u64, bytes: u64) {
+        self.ok += 1;
+        self.rows_total = self.rows_total.saturating_add(rows);
+        self.bytes_total = self.bytes_total.saturating_add(bytes);
+        // Auto-resizing histogram: `record` only errs if the value exceeds the
+        // (auto-grown) range, which cannot happen here — saturate defensively.
+        let _ = self.latency_us.record(latency_us);
+    }
+
+    /// Record a classified non-ok outcome. `Outcome::Ok` must go through
+    /// [`Self::record_ok`] (it carries latency/rows/bytes); passing it here is a
+    /// caller bug and is ignored.
+    pub fn record_outcome(&mut self, outcome: &Outcome) {
+        match outcome {
+            Outcome::Ok => {}
+            Outcome::Unavailable => self.unavailable += 1,
+            Outcome::Error(code) => {
+                self.error += 1;
+                *self.error_codes.entry(code.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    /// Fold another accumulator (a per-worker partial) into this one.
+    pub fn merge(&mut self, other: &StepAgg) {
+        self.ok += other.ok;
+        self.unavailable += other.unavailable;
+        self.error += other.error;
+        self.rows_total = self.rows_total.saturating_add(other.rows_total);
+        self.bytes_total = self.bytes_total.saturating_add(other.bytes_total);
+        for (code, n) in &other.error_codes {
+            *self.error_codes.entry(code.clone()).or_insert(0) += n;
+        }
+        self.latency_us
+            .add(&other.latency_us)
+            .expect("compatible histograms (same sigfig, auto-resizing)");
+    }
+
+    /// Total classified requests (ok + unavailable + error).
+    pub fn total(&self) -> u64 {
+        self.ok + self.unavailable + self.error
+    }
+
+    /// Successful-request count.
+    pub fn ok(&self) -> u64 {
+        self.ok
+    }
+
+    /// Render the step record. `duration_s` is the measured elapsed wall time of
+    /// the step (bounds the sampling window; never perturbs which data was
+    /// requested). `qps`/`rows_per_s`/`bytes_per_s` are computed against it;
+    /// latency percentiles are over `ok` requests only.
+    #[allow(clippy::too_many_arguments)]
+    pub fn into_record(
+        self,
+        round: String,
+        endpoint: String,
+        ts_unix_ms: u64,
+        seed: u64,
+        step: usize,
+        target_concurrency: usize,
+        shape: String,
+        duration_s: f64,
+    ) -> StepRecord {
+        let per_s = |n: u64| {
+            if duration_s > 0.0 {
+                n as f64 / duration_s
+            } else {
+                0.0
+            }
+        };
+        let us_to_ms = |us: u64| us as f64 / 1000.0;
+        let latency = LatencyMs {
+            p50: us_to_ms(self.latency_us.value_at_quantile(0.50)),
+            p95: us_to_ms(self.latency_us.value_at_quantile(0.95)),
+            p99: us_to_ms(self.latency_us.value_at_quantile(0.99)),
+            max: us_to_ms(self.latency_us.max()),
+            samples: self.latency_us.len(),
+        };
+        StepRecord {
+            schema: SCHEMA_TAG,
+            round,
+            endpoint,
+            ts_unix_ms,
+            seed,
+            step,
+            target_concurrency,
+            shape,
+            duration_s,
+            requests_ok: self.ok,
+            requests_unavailable: self.unavailable,
+            requests_error: self.error,
+            error_codes: self.error_codes,
+            qps: per_s(self.ok),
+            rows_per_s: per_s(self.rows_total),
+            bytes_per_s: per_s(self.bytes_total),
+            rows_total: self.rows_total,
+            bytes_total: self.bytes_total,
+            latency_ms: latency,
+        }
+    }
+}
+
+impl Default for StepAgg {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Latency percentiles for a step, in milliseconds, over `ok` requests only.
+#[derive(Debug, Clone, Serialize)]
+pub struct LatencyMs {
+    pub p50: f64,
+    pub p95: f64,
+    pub p99: f64,
+    pub max: f64,
+    /// Number of `ok` latency samples the percentiles are computed from.
+    pub samples: u64,
+}
+
+/// One `flight-loadgen.step/v1` JSONL record — one object per ramp step.
+///
+/// `qps = requests_ok / duration_s`; latency percentiles are over the step's
+/// `ok` requests only. Cross-node distribution is N/A server-direct (a single
+/// endpoint) and is intentionally absent rather than fabricated.
+#[derive(Debug, Clone, Serialize)]
+pub struct StepRecord {
+    pub schema: &'static str,
+    pub round: String,
+    pub endpoint: String,
+    pub ts_unix_ms: u64,
+    pub seed: u64,
+    pub step: usize,
+    pub target_concurrency: usize,
+    pub shape: String,
+    pub duration_s: f64,
+    pub requests_ok: u64,
+    pub requests_unavailable: u64,
+    pub requests_error: u64,
+    pub error_codes: BTreeMap<String, u64>,
+    pub qps: f64,
+    pub rows_per_s: f64,
+    pub bytes_per_s: f64,
+    pub rows_total: u64,
+    pub bytes_total: u64,
+    pub latency_ms: LatencyMs,
+}
+
+impl StepRecord {
+    /// Serialise to a single JSONL line (no trailing newline).
+    pub fn to_jsonl(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qps_is_ok_over_duration_and_percentiles_over_ok_only() {
+        let mut agg = StepAgg::new();
+        // Three ok requests at 1/2/3 ms, plus one shed and one error — the error
+        // and shed must NOT enter the latency histogram or the qps numerator.
+        agg.record_ok(1_000, 10, 100);
+        agg.record_ok(2_000, 20, 200);
+        agg.record_ok(3_000, 30, 300);
+        agg.record_outcome(&Outcome::Unavailable);
+        agg.record_outcome(&Outcome::Error("Internal".to_string()));
+
+        let rec = agg.into_record(
+            "r".into(),
+            "http://x".into(),
+            0,
+            42,
+            2,
+            8,
+            "mixed".into(),
+            2.0,
+        );
+        assert_eq!(rec.requests_ok, 3);
+        assert_eq!(rec.requests_unavailable, 1);
+        assert_eq!(rec.requests_error, 1);
+        assert_eq!(rec.error_codes.get("Internal"), Some(&1));
+        assert_eq!(rec.rows_total, 60);
+        assert_eq!(rec.bytes_total, 600);
+        // qps = requests_ok / duration_s = 3 / 2.0
+        assert!((rec.qps - 1.5).abs() < 1e-9);
+        assert!((rec.rows_per_s - 30.0).abs() < 1e-9);
+        // Latency samples = ok count only (3), not 5.
+        assert_eq!(rec.latency_ms.samples, 3);
+        assert!(rec.latency_ms.p50 >= 1.0 && rec.latency_ms.p50 <= 3.0);
+        assert!(rec.latency_ms.max >= 2.9 && rec.latency_ms.max <= 3.1);
+    }
+
+    #[test]
+    fn record_is_valid_jsonl_with_required_fields() {
+        let agg = StepAgg::new();
+        let rec = agg.into_record(
+            "round1".into(),
+            "http://h:8815".into(),
+            7,
+            42,
+            0,
+            1,
+            "full".into(),
+            1.0,
+        );
+        let line = rec.to_jsonl().expect("serialize");
+        assert!(!line.contains('\n'), "a record is a single JSONL line");
+        let v: serde_json::Value = serde_json::from_str(&line).expect("parse back");
+        for field in [
+            "schema",
+            "target_concurrency",
+            "shape",
+            "duration_s",
+            "requests_ok",
+            "requests_unavailable",
+            "requests_error",
+            "qps",
+            "rows_per_s",
+            "bytes_per_s",
+            "rows_total",
+            "bytes_total",
+            "latency_ms",
+        ] {
+            assert!(v.get(field).is_some(), "required field {field} present");
+        }
+        assert_eq!(v["schema"], SCHEMA_TAG);
+        for p in ["p50", "p95", "p99", "max"] {
+            assert!(v["latency_ms"].get(p).is_some(), "latency {p} present");
+        }
+    }
+
+    #[test]
+    fn merge_folds_partials() {
+        let mut a = StepAgg::new();
+        a.record_ok(1_000, 1, 10);
+        a.record_outcome(&Outcome::Error("X".into()));
+        let mut b = StepAgg::new();
+        b.record_ok(4_000, 2, 20);
+        b.record_outcome(&Outcome::Unavailable);
+        a.merge(&b);
+        assert_eq!(a.ok(), 2);
+        assert_eq!(a.total(), 4);
+        let rec = a.into_record("".into(), "".into(), 0, 0, 0, 2, "mixed".into(), 1.0);
+        assert_eq!(rec.rows_total, 3);
+        assert_eq!(rec.bytes_total, 30);
+        assert_eq!(rec.requests_unavailable, 1);
+        assert_eq!(rec.requests_error, 1);
+        assert_eq!(rec.latency_ms.samples, 2);
+    }
+}

--- a/tools/flight-loadgen/src/selftest.rs
+++ b/tools/flight-loadgen/src/selftest.rs
@@ -120,9 +120,12 @@ pub async fn run_self_test(request_count: u64) -> Result<Vec<StepRecord>, String
         connect_timeout: Duration::from_secs(5),
         seed: 42,
     };
-    let result = run_ramp(&config, &gen).await;
+    let (records, err) = run_ramp(&config, &gen).await;
     server.shutdown();
-    result
+    match err {
+        Some(e) => Err(e),
+        None => Ok(records),
+    }
 }
 
 #[cfg(test)]

--- a/tools/flight-loadgen/src/selftest.rs
+++ b/tools/flight-loadgen/src/selftest.rs
@@ -1,0 +1,186 @@
+//! In-process self-test (design §(g); spec: self-test requirement).
+//!
+//! Serves a real `CqliteFlightService` over an ephemeral loopback port
+//! (`127.0.0.1:0`) backed by a tiny 1-SSTable `keyvalue` fixture, then runs a
+//! concurrency-1, fixed-request-count (NON-wall-clock) ramp against it through
+//! the ordinary [`run_ramp`] engine — real client → gRPC wire → server → JSONL.
+//! This is WIRING EVIDENCE: it exercises the full client→server→record pipeline,
+//! catching JSONL-schema drift and ramp-loop regressions a compile-only check
+//! would miss.
+//!
+//! This is a NORMAL workspace test surface (also reachable via the `--self-test`
+//! subcommand). It is NOT an `agent-gate.sh` component and never contacts a real
+//! cluster. It uses no fixed port and no wall-clock-duration step, so it is
+//! deterministic and free of port/timing flake.
+
+use std::time::Duration;
+
+use arrow_flight::flight_service_server::FlightServiceServer;
+use tonic::transport::server::TcpIncoming;
+use tonic::transport::Server;
+
+use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use cqlite_flight::service::CqliteFlightService;
+use cqlite_flight::test_fixtures as fx;
+
+use crate::ramp::{run_ramp, RampConfig, StepBound};
+use crate::record::StepRecord;
+use crate::shape::{Shape, ShapeGen};
+
+/// A running in-process self-test server: the temp dir (kept alive) plus the
+/// bound `http://127.0.0.1:<port>` endpoint and the server task handle.
+pub struct SelfTestServer {
+    _temp: tempfile::TempDir,
+    pub endpoint: String,
+    pub handle: tokio::task::JoinHandle<Result<(), tonic::transport::Error>>,
+}
+
+impl SelfTestServer {
+    /// Stop the background server task.
+    pub fn shutdown(self) {
+        self.handle.abort();
+    }
+}
+
+/// Build the tiny 1-SSTable `keyvalue` fixture and serve it over an ephemeral
+/// loopback port. Returns once the server socket is bound and accepting.
+pub async fn serve_fixture() -> Result<SelfTestServer, String> {
+    let schema = fx::keyvalue_schema();
+    let temp = tempfile::TempDir::new().map_err(|e| format!("temp dir: {e}"))?;
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).map_err(|e| format!("write engine: {e}"))?;
+    for (key, value) in fx::KEYVALUE_ROWS {
+        engine
+            .write(fx::keyvalue_write(key, value))
+            .map_err(|e| format!("write mutation: {e}"))?;
+    }
+    engine
+        .flush()
+        .await
+        .map_err(|e| format!("flush: {e}"))?
+        .ok_or_else(|| "flush produced no SSTable".to_string())?;
+
+    let svc = CqliteFlightService::new(data_dir, fx::KEYVALUE_BATCH_SIZE);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| format!("bind loopback: {e}"))?;
+    let addr = listener
+        .local_addr()
+        .map_err(|e| format!("local addr: {e}"))?;
+    let incoming =
+        TcpIncoming::from_listener(listener, true, None).map_err(|e| format!("incoming: {e}"))?;
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(FlightServiceServer::new(svc))
+            .serve_with_incoming(incoming)
+            .await
+    });
+
+    Ok(SelfTestServer {
+        _temp: temp,
+        endpoint: format!("http://{addr}"),
+        handle,
+    })
+}
+
+/// The self-test ticket template: the connector-shaped `keyvalue` ticket (full
+/// ring, no limit) the fixture serves.
+pub fn selftest_template() -> cqlite_flight::ticket::FlightTicket {
+    // `FlightTicket` is `#[non_exhaustive]`, so an external crate cannot use a
+    // struct literal — construct from `default()` and assign the fields.
+    let mut t = cqlite_flight::ticket::FlightTicket::default();
+    t.keyspace = fx::KEYVALUE_KS.into();
+    t.table = fx::KEYVALUE_TBL.into();
+    t.ddl = fx::KEYVALUE_DDL.into();
+    t
+}
+
+/// Run the end-to-end self-test ramp: a 1-step, concurrency-1, `request_count`
+/// bounded ramp against a freshly-served in-process fixture. Returns the emitted
+/// step records (one, for the single step). `request_count` must be >= 1.
+pub async fn run_self_test(request_count: u64) -> Result<Vec<StepRecord>, String> {
+    let server = serve_fixture().await?;
+    // Full-ring `full` shape so every request returns the fixture's rows (the
+    // point shape's seeded sub-range could legitimately be empty — design §(b)).
+    let gen = ShapeGen::new(
+        selftest_template(),
+        42,
+        100,
+        1 << 40,
+        crate::shape::MixWeights::default(),
+    );
+    let config = RampConfig {
+        concurrencies: vec![1],
+        bound: StepBound::Requests(request_count.max(1)),
+        shape: Shape::Full,
+        round: "self-test".into(),
+        endpoint: server.endpoint.clone(),
+        connect_timeout: Duration::from_secs(5),
+        seed: 42,
+    };
+    let result = run_ramp(&config, &gen).await;
+    server.shutdown();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Wiring evidence: real client → gRPC → server → JSONL. A concurrency-1,
+    /// fixed-request-count ramp against the in-process fixture emits exactly one
+    /// well-formed step record with `requests_ok >= 1` and every required field
+    /// present and parseable. No fixed port, no wall-clock step.
+    #[tokio::test]
+    async fn self_test_produces_a_wellformed_jsonl_record() {
+        let records = run_self_test(3).await.expect("self-test ramp");
+        assert_eq!(records.len(), 1, "one step ⇒ one record");
+        let rec = &records[0];
+        assert_eq!(rec.target_concurrency, 1);
+        assert_eq!(rec.shape, "full");
+        assert!(
+            rec.requests_ok >= 1,
+            "the fixture must serve at least one ok do_get, got {rec:?}"
+        );
+        assert_eq!(
+            rec.requests_error, 0,
+            "no error outcomes against the healthy fixture: {:?}",
+            rec.error_codes
+        );
+        assert!(
+            rec.rows_total >= 1,
+            "a full-ring scan of the 3-row fixture must drain rows"
+        );
+
+        // The record round-trips as a single valid JSONL line with all fields.
+        let line = rec.to_jsonl().expect("serialize");
+        assert!(!line.contains('\n'));
+        let v: serde_json::Value = serde_json::from_str(&line).expect("parse");
+        for field in [
+            "schema",
+            "target_concurrency",
+            "shape",
+            "duration_s",
+            "requests_ok",
+            "requests_unavailable",
+            "requests_error",
+            "qps",
+            "rows_per_s",
+            "bytes_per_s",
+            "rows_total",
+            "bytes_total",
+            "latency_ms",
+        ] {
+            assert!(v.get(field).is_some(), "field {field} present in JSONL");
+        }
+        // qps == requests_ok / duration_s (spec invariant).
+        let qps = v["qps"].as_f64().unwrap();
+        let ok = v["requests_ok"].as_f64().unwrap();
+        let dur = v["duration_s"].as_f64().unwrap();
+        if dur > 0.0 {
+            assert!((qps - ok / dur).abs() < 1e-6, "qps == ok/duration");
+        }
+    }
+}

--- a/tools/flight-loadgen/src/shape.rs
+++ b/tools/flight-loadgen/src/shape.rs
@@ -1,0 +1,311 @@
+//! Ticket synthesis: base template + seeded shape transforms
+//! (design §(b); spec: shapes + determinism requirements).
+//!
+//! The operator supplies ONE base [`FlightTicket`] template (connector-shaped:
+//! `keyspace`/`table`/`ddl`/`snapshot`, full ring, no limit). Each workload shape
+//! is derived by transforming a *clone* of that template — the client never
+//! invents DDL or partition keys the operator did not provide. Every derived
+//! ticket keeps the template's `keyspace`/`table`/`ddl`/`snapshot` unchanged.
+//!
+//! Determinism (design §(c)): the RNG for a request is seeded purely from
+//! `(seed, step, worker, iteration)`, so two runs with the same seed/ramp/shape/
+//! template produce a byte-identical ticket sequence — wall-clock timing never
+//! perturbs which data is requested.
+
+use cqlite_flight::ticket::FlightTicket;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+/// The four workload shapes (design §(b)).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shape {
+    /// Full-ring scan: the template as-is (`limit = None`).
+    Full,
+    /// `LIMIT`-k scan: the template with `limit = Some(k)`.
+    LimitK,
+    /// Point read: the template narrowed to a seeded token sub-range
+    /// `[t, t + width)` (a setup/admission-cost proxy — design §(b) fork).
+    Point,
+    /// A seeded weighted draw across `Point`/`LimitK`/`Full`.
+    Mixed,
+}
+
+impl Shape {
+    /// Parse the CLI `--shape` value.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.to_ascii_lowercase().as_str() {
+            "full" => Ok(Shape::Full),
+            "limit-k" | "limitk" | "limit" => Ok(Shape::LimitK),
+            "point" | "ptr" => Ok(Shape::Point),
+            "mixed" | "mix" => Ok(Shape::Mixed),
+            other => Err(format!(
+                "unknown shape {other:?} (expected point|limit-k|full|mixed)"
+            )),
+        }
+    }
+
+    /// The record's `shape` label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Shape::Full => "full",
+            Shape::LimitK => "limit-k",
+            Shape::Point => "point",
+            Shape::Mixed => "mixed",
+        }
+    }
+}
+
+/// Weights for the `mixed` shape's seeded draw across point/limit-k/full.
+#[derive(Debug, Clone, Copy)]
+pub struct MixWeights {
+    pub point: f64,
+    pub limit_k: f64,
+    pub full: f64,
+}
+
+impl Default for MixWeights {
+    fn default() -> Self {
+        Self {
+            point: 0.6,
+            limit_k: 0.3,
+            full: 0.1,
+        }
+    }
+}
+
+impl MixWeights {
+    /// Parse `ptr=0.6,lim=0.3,full=0.1` (any subset; missing keys default to 0,
+    /// but the total must be positive).
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let mut w = MixWeights {
+            point: 0.0,
+            limit_k: 0.0,
+            full: 0.0,
+        };
+        for part in s.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            let (k, v) = part
+                .split_once('=')
+                .ok_or_else(|| format!("bad --mix term {part:?} (expected key=weight)"))?;
+            let weight: f64 = v
+                .trim()
+                .parse()
+                .map_err(|_| format!("bad --mix weight {v:?}"))?;
+            if weight < 0.0 {
+                return Err(format!("--mix weight for {k:?} must be >= 0"));
+            }
+            match k.trim() {
+                "ptr" | "point" => w.point = weight,
+                "lim" | "limit" | "limit-k" => w.limit_k = weight,
+                "full" => w.full = weight,
+                other => return Err(format!("unknown --mix key {other:?}")),
+            }
+        }
+        if w.point + w.limit_k + w.full <= 0.0 {
+            return Err("--mix weights must sum to a positive value".to_string());
+        }
+        Ok(w)
+    }
+
+    /// Resolve a concrete non-mixed shape from a `[0,1)` draw.
+    fn choose(&self, draw: f64) -> Shape {
+        let total = self.point + self.limit_k + self.full;
+        let pick = draw * total;
+        if pick < self.point {
+            Shape::Point
+        } else if pick < self.point + self.limit_k {
+            Shape::LimitK
+        } else {
+            Shape::Full
+        }
+    }
+}
+
+/// Deterministic ticket generator over one base template (design §(b)/§(c)).
+#[derive(Debug, Clone)]
+pub struct ShapeGen {
+    base: FlightTicket,
+    seed: u64,
+    limit_k: u64,
+    point_width: i64,
+    mix: MixWeights,
+}
+
+impl ShapeGen {
+    /// Build a generator from a base template and CLI parameters.
+    pub fn new(
+        base: FlightTicket,
+        seed: u64,
+        limit_k: u64,
+        point_width: i64,
+        mix: MixWeights,
+    ) -> Self {
+        Self {
+            base,
+            seed,
+            limit_k,
+            point_width: point_width.max(1),
+            mix,
+        }
+    }
+
+    /// The per-request RNG, seeded purely from `(seed, step, worker, iteration)`
+    /// via a splitmix-style mix so distinct coordinates decorrelate.
+    fn rng(&self, step: u64, worker: u64, iter: u64) -> StdRng {
+        // Fold the four coordinates into one 64-bit seed. Each term is spread
+        // with a large odd constant so nearby coordinates do not collide.
+        let mut s = self.seed;
+        for coord in [step, worker, iter] {
+            s = s
+                .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                .wrapping_add(coord.wrapping_add(0xD1B5_4A32_D192_ED03));
+        }
+        StdRng::seed_from_u64(s)
+    }
+
+    /// Build the ticket for `(shape, step, worker, iteration)`. For [`Shape::Mixed`]
+    /// the concrete shape is drawn from the same seeded RNG that a `point` draw
+    /// would use, so the whole selection is reproducible.
+    pub fn build(&self, shape: Shape, step: u64, worker: u64, iter: u64) -> FlightTicket {
+        let mut rng = self.rng(step, worker, iter);
+        let concrete = match shape {
+            Shape::Mixed => self.mix.choose(rng.random::<f64>()),
+            other => other,
+        };
+        self.apply(concrete, &mut rng)
+    }
+
+    /// Apply a concrete (non-mixed) shape to a clone of the base template.
+    fn apply(&self, shape: Shape, rng: &mut StdRng) -> FlightTicket {
+        let mut t = self.base.clone();
+        match shape {
+            Shape::Full => {
+                // Template as-is: full ring, no limit.
+                t.limit = None;
+            }
+            Shape::LimitK => {
+                t.limit = Some(self.limit_k);
+            }
+            Shape::Point => {
+                // Seeded narrow token sub-range [t, t + width). Draw the start
+                // from the full i64 ring; saturate the end on overflow.
+                let start: i64 = rng.random::<i64>();
+                let end = start.saturating_add(self.point_width);
+                t.token_start = Some(start);
+                t.token_end = Some(end);
+                t.wraparound = false;
+                t.limit = None;
+            }
+            // `apply` is only ever called with a concrete shape.
+            Shape::Mixed => unreachable!("Mixed is resolved before apply"),
+        }
+        t
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> FlightTicket {
+        // `FlightTicket` is `#[non_exhaustive]`; build via `default()` + assign.
+        let mut t = FlightTicket::default();
+        t.keyspace = "ks".into();
+        t.table = "tbl".into();
+        t.ddl = "CREATE TABLE ks.tbl (id int PRIMARY KEY, v int)".into();
+        t.snapshot = Some("cqlite-snap".into());
+        t
+    }
+
+    fn gen() -> ShapeGen {
+        ShapeGen::new(base(), 42, 100, 1 << 40, MixWeights::default())
+    }
+
+    #[test]
+    fn full_is_template_with_no_limit_over_full_ring() {
+        let t = gen().build(Shape::Full, 0, 0, 0);
+        assert_eq!(t.limit, None);
+        assert_eq!(t.token_start, None);
+        assert_eq!(t.token_end, None);
+    }
+
+    #[test]
+    fn limit_k_sets_the_limit() {
+        let t = gen().build(Shape::LimitK, 0, 0, 0);
+        assert_eq!(t.limit, Some(100));
+        assert_eq!(t.token_start, None, "limit-k does not narrow the ring");
+    }
+
+    #[test]
+    fn point_narrows_to_a_seeded_subrange_of_width() {
+        let t = gen().build(Shape::Point, 0, 0, 0);
+        let start = t.token_start.expect("point sets token_start");
+        let end = t.token_end.expect("point sets token_end");
+        assert!(!t.wraparound);
+        assert_eq!(t.limit, None);
+        assert_eq!(
+            end,
+            start.saturating_add(1 << 40),
+            "sub-range width == --point-width"
+        );
+    }
+
+    #[test]
+    fn every_shape_preserves_template_identity_fields() {
+        for shape in [Shape::Full, Shape::LimitK, Shape::Point, Shape::Mixed] {
+            let t = gen().build(shape, 3, 1, 7);
+            assert_eq!(t.keyspace, "ks", "{shape:?} keeps keyspace");
+            assert_eq!(t.table, "tbl", "{shape:?} keeps table");
+            assert!(
+                t.ddl.starts_with("CREATE TABLE ks.tbl"),
+                "{shape:?} keeps ddl"
+            );
+            assert_eq!(
+                t.snapshot,
+                Some("cqlite-snap".to_string()),
+                "{shape:?} keeps snapshot"
+            );
+        }
+    }
+
+    #[test]
+    fn identical_seed_reproduces_the_ticket_sequence() {
+        // spec: determinism scenario — same seed/shape/template ⇒ byte-identical
+        // sequence for a fixed (step, worker) across iterations.
+        let a = gen();
+        let b = gen();
+        for iter in 0..64 {
+            let ta = a.build(Shape::Mixed, 5, 2, iter);
+            let tb = b.build(Shape::Mixed, 5, 2, iter);
+            assert_eq!(
+                ta.to_bytes().unwrap(),
+                tb.to_bytes().unwrap(),
+                "iteration {iter} must be byte-identical across runs"
+            );
+        }
+    }
+
+    #[test]
+    fn different_seed_changes_point_tokens() {
+        let a = ShapeGen::new(base(), 1, 100, 1 << 40, MixWeights::default());
+        let b = ShapeGen::new(base(), 2, 100, 1 << 40, MixWeights::default());
+        let ta = a.build(Shape::Point, 0, 0, 0);
+        let tb = b.build(Shape::Point, 0, 0, 0);
+        assert_ne!(
+            ta.token_start, tb.token_start,
+            "distinct seeds should pick distinct start tokens"
+        );
+    }
+
+    #[test]
+    fn mix_weights_parse_and_choose() {
+        let w = MixWeights::parse("ptr=0.5,lim=0.5,full=0.0").unwrap();
+        assert_eq!(w.choose(0.0), Shape::Point);
+        assert_eq!(w.choose(0.75), Shape::LimitK);
+        assert!(MixWeights::parse("").is_err(), "empty ⇒ non-positive total");
+        assert!(MixWeights::parse("bogus").is_err());
+    }
+}


### PR DESCRIPTION
Closes #2418

## Summary
Adds `tools/flight-loadgen`: a raw `arrow_flight::FlightServiceClient` (tonic) concurrency-ramp driver that hits `FlightService::do_get` DIRECTLY (no Trino/JDBC/query-engine in the client path) — establishing the "server-direct ceiling" underneath the existing through-Trino throughput floor (round-10b, #2367). Unblocks WS8 (epic #2313's concurrency ramp / saturation curve).

OpenSpec change: `openspec/changes/flight-loadgen/` (spec + design approved at Seam 1, 2026-07-14).

## Design highlights
- Seeded deterministic request-shape synthesis (full/limit-k/point/mixed), pinned via `identical_seed_reproduces_the_ticket_sequence`.
- Outcome classification verified against the REAL `cqlite-flight` admission-shed signal (`Status::unavailable`, `admission.rs`), not a guessed one.
- Wiring-evidence: `selftest.rs` spins up a real `cqlite-flight` server on an ephemeral loopback port and drives a real `do_get` through the actual client path — genuine client→gRPC→server→JSONL evidence, not mocked transport.
- Per-step hdrhistogram (auto-resizing, no outlier clipping) + `flight-loadgen.step/v1` JSONL output.

## Review history (this branch)
- Round 1 (rust-reviewer + roborev): rust-reviewer clean (4 nits: step-timing includes connect setup; all-or-nothing output loss on a mid-ramp error; `StdRng` cross-build-reproducibility caveat; stale doc wording). Roborev found a real **Medium**: `parse_duration` panicked (via `Duration::from_secs_f64`) on negative/NaN/infinite CLI input instead of returning `Err`.
- Fix round 1: added a pre-scale finite/non-negative guard. Re-review (rust-reviewer) found this was INCOMPLETE — large-finite values (e.g. `"1e30"`) still overflow `Duration`'s range and panic, and the `m`-unit branch can overflow to `+inf` AFTER scaling, missing the guard entirely.
- Fix round 2: switched to `Duration::try_from_secs_f64` on the final scaled value in every branch, closing the gap completely (verified: `"1e30"`, `"1e308m"` now return `Err`, not panic).
- Round 2 roborev (independently, on the original diff) escalated the connect-timing nit to **Medium**: a mid-ramp connect failure orphaned already-spawned workers (detached `JoinHandle`s kept issuing load past the step deadline) and discarded every previously-completed step's data — undermining the tool's stated purpose (measuring saturation, where connect failures are an *expected* outcome).
- Fix round 3: connect all workers up-front before spawning any (eliminates orphaning entirely; also fixes the step-timing bias as a side effect), and `run_ramp`/`finalize` now preserve and write completed-step JSONL before surfacing a terminal error instead of discarding everything.
- Round 3 review (rust-reviewer + roborev): both clean. 8 total Low/nit findings across all rounds — batched into one follow-up issue at merge time, none blocking.

## Gate
`--lite` PASS on every round (latest: commit 922150618). Full `agent-gate.sh` + C intent audit + final roborev to run once via `flow-closer` before merge.