### PR TITLE
fix(#2452): connector snapshot retirement hardening — ref-counted rollback retire + background grace-sweep with quiet-table tick

### DIFF
--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -306,6 +306,15 @@ otherwise-separate problems:
   snapshot dir and forced a full re-open + re-parse. The flight server exposes scale-free work
   probes (`reader_opens`, `index_parses_total`, `rebind_hits_total`) so a field round can verify
   the closure: within a window these stay flat.
+
+  > **Metrics exposure (field-probe note, issue #2452 / #2356).** `reader_opens` and
+  > `rebind_hits_total` are exposed **only** through the flight server's programmatic
+  > `WarmMetricsSnapshot` stats surface (the authoritative surface for round-over-round field
+  > verification) — they are **not** mirrored to the OpenTelemetry counter export, unlike the warm
+  > cache `hit`/`miss`/`evict`/`refresh` counters. This is intentional per the
+  > `flight-warm-snapshot-closure` spec (§D): the snapshot-lifecycle work does not expand the OTel
+  > counter set. A field probe or audit that expects these two on the OTel scrape will not find
+  > them — read them from `WarmMetricsSnapshot`.
 - **Fewer memtable flushes (#2306).** Flush-on-snapshot is **by design** (issue #2305; the
   Sidecar HTTP API has no `skipFlush`, and this connector does not relitigate that). The only
   lever on flush volume is **fewer snapshot creations**: because each snapshot create triggers

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
@@ -45,9 +45,14 @@ public class CqliteFlightConnector implements Connector {
         // The superseded-snapshot grace-sweep runs on a background best-effort scheduler (issue
         // #2452 item 2), NOT synchronously on the split-planning path — a hot table would otherwise
         // pay a multi-host DELETE fan-out in planning latency (roborev job 1722). The periodic tick
-        // (cadence = the retire-grace period) also prunes QUIET tables that receive no further query,
-        // so a short reuse window plus a long TTL never accumulates snapshot dirs (the #2367 field
-        // accumulation). Retired at connector shutdown via SnapshotManager.close().
+        // (cadence = the retire-grace period) is the ACTUAL #2367 fix: it prunes QUIET tables that
+        // receive no further query, so a short reuse window plus a long TTL never accumulates
+        // snapshot dirs — this is what closes the 714-snapshot field accumulation, independent of any
+        // query ever running again. The rollback-retire (item 1) is a NARROWER, separate hardening —
+        // it only fires on an UNCONTENDED creator's own fan-out failure (see the accepted hot-table
+        // degradation on {@code Window#activeHolds}); the general (any-window, any-time)
+        // active-retire is tracked as follow-up issue #2580, not this fix. Scheduler retired at
+        // connector shutdown via SnapshotManager.close().
         this.snapshots = new SnapshotManager(
                 HostSnapshotApis.fromBaseUri(config.sidecarUri()), config.readMode(), config.snapshotTtl(),
                 config.snapshotReuseWindowNanos(), config.snapshotRetireGraceNanos(),

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
@@ -27,10 +27,17 @@ public class CqliteFlightConnector implements Connector {
         // per-query snapshot on each replica host, the metadata cleans it up — both must see
         // the same registry. Each host's Sidecar is derived from the configured URI's scheme
         // + port (uniform across the hostNetwork Sidecar DaemonSet) and the split host.
+        // The superseded-snapshot grace-sweep runs on a background best-effort scheduler (issue
+        // #2452 item 2), NOT synchronously on the split-planning path — a hot table would otherwise
+        // pay a multi-host DELETE fan-out in planning latency (roborev job 1722). The periodic tick
+        // (cadence = the retire-grace period) also prunes QUIET tables that receive no further query,
+        // so a short reuse window plus a long TTL never accumulates snapshot dirs (the #2367 field
+        // accumulation). Retired at connector shutdown via SnapshotManager.close().
         this.snapshots = new SnapshotManager(
                 HostSnapshotApis.fromBaseUri(config.sidecarUri()), config.readMode(), config.snapshotTtl(),
                 config.snapshotReuseWindowNanos(), config.snapshotRetireGraceNanos(),
-                new SnapshotManager.SystemClock());
+                new SnapshotManager.SystemClock(),
+                new SnapshotRetireScheduler.BackgroundRetireScheduler(config.snapshotRetireGraceMillis()));
         // Fail fast at catalog load if arrow-java's off-heap memory init is broken by a missing JVM
         // flag (issues #2193, #2290) — otherwise every do_get dies far downstream with a cryptic
         // "Failed to read message". Runs before the first RootAllocator (the earliest Arrow touch)
@@ -67,6 +74,8 @@ public class CqliteFlightConnector implements Connector {
         // that created it, so retirement is not per-query — the connector releases them at
         // shutdown (the Sidecar TTL backstop covers a crash/miss).
         snapshots.retireAll();
+        // Release the background retire scheduler (issue #2452 item 2) after draining the snapshots.
+        snapshots.close();
         allocator.close();
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
@@ -82,12 +82,15 @@ public class CqliteFlightConnector implements Connector {
 
     @Override
     public void shutdown() {
+        // Close the scheduler FIRST (roborev job 1755 finding 3): retireAll() below runs its own
+        // retirement synchronously on THIS thread (it never goes through the scheduler), so closing
+        // the scheduler before calling it means no background sweep can still be running concurrently
+        // with — or outlive — retireAll()'s drain or the allocator.close() that follows.
+        snapshots.close();
         // Retire every live reused snapshot (issue #2356): a reused snapshot outlives the query
         // that created it, so retirement is not per-query — the connector releases them at
         // shutdown (the Sidecar TTL backstop covers a crash/miss).
         snapshots.retireAll();
-        // Release the background retire scheduler (issue #2452 item 2) after draining the snapshots.
-        snapshots.close();
         allocator.close();
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConnector.java
@@ -23,6 +23,21 @@ public class CqliteFlightConnector implements Connector {
     public CqliteFlightConnector(CqliteFlightConfig config, SidecarClient sidecar) {
         this.config = config;
         this.sidecar = sidecar;
+        // Fail fast at catalog load if arrow-java's off-heap memory init is broken by a missing JVM
+        // flag (issues #2193, #2290) — otherwise every do_get dies far downstream with a cryptic
+        // "Failed to read message". Runs before the first RootAllocator (the earliest Arrow touch)
+        // and is a no-op when the flag is present.
+        //
+        // Deliberately BEFORE the SnapshotManager/scheduler construction below (issue #2452 item 1,
+        // roborev job 1753 blocker): the background scheduler starts a live daemon thread, and this
+        // preflight (like RootAllocator below) is designed to throw at catalog load on a broken JVM
+        // flag. Connector construction has no shutdown() hook to unwind on a thrown constructor —
+        // Trino simply discards the half-built object — so constructing the thread-owning
+        // SnapshotManager BEFORE either of these throw-prone steps would leak a scheduler thread (and
+        // its periodic task) for the JVM's lifetime, once per failed catalog-load retry.
+        ArrowMemoryPreflight.verify();
+        this.allocator = new RootAllocator();
+        this.flight = new CqliteFlightClient(allocator);
         // One shared snapshot manager (issues #2105, #2227): the split manager creates the
         // per-query snapshot on each replica host, the metadata cleans it up — both must see
         // the same registry. Each host's Sidecar is derived from the configured URI's scheme
@@ -38,13 +53,10 @@ public class CqliteFlightConnector implements Connector {
                 config.snapshotReuseWindowNanos(), config.snapshotRetireGraceNanos(),
                 new SnapshotManager.SystemClock(),
                 new SnapshotRetireScheduler.BackgroundRetireScheduler(config.snapshotRetireGraceMillis()));
-        // Fail fast at catalog load if arrow-java's off-heap memory init is broken by a missing JVM
-        // flag (issues #2193, #2290) — otherwise every do_get dies far downstream with a cryptic
-        // "Failed to read message". Runs before the first RootAllocator (the earliest Arrow touch)
-        // and is a no-op when the flag is present.
-        ArrowMemoryPreflight.verify();
-        this.allocator = new RootAllocator();
-        this.flight = new CqliteFlightClient(allocator);
+        // Started only after the SnapshotManager instance is fully constructed (this-escape nit,
+        // roborev job 1753): registering the periodic hook from WITHIN the constructor would hand the
+        // background thread a lambda closing over a not-yet-fully-initialized `this`.
+        this.snapshots.start();
     }
 
     @Override

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -108,6 +109,9 @@ public final class SnapshotManager {
      * quiet tables.
      */
     private final SnapshotRetireScheduler retireScheduler;
+    /** Guards {@link #start()} so a second call cannot double-register the periodic cadence
+     * (roborev job 1754 finding 6). */
+    private final AtomicBoolean started = new AtomicBoolean(false);
 
     /** The current reused snapshot window per {@code (keyspace, table)}. */
     private final Map<TableRef, Window> windows = new ConcurrentHashMap<>();
@@ -163,10 +167,23 @@ public final class SnapshotManager {
          * ref-counted rollback retirement). Incremented atomically under the {@code windows.compute}
          * bin lock when a query resolves the window; consulted ONLY on a fresh-window fail-closed
          * rollback so a concurrent reuser that committed this window to its tickets is never
-         * stranded by another query deleting the shared hardlinks. A successful query keeps its hold
-         * for its lifetime (there is no read-completion hook), so the count is conservatively high —
-         * which only ever SUPPRESSES a rollback delete (never strands), the safe direction. Grace /
-         * invalidate / shutdown retirement is unaffected (those paths never consult holders).
+         * stranded by another query deleting the shared hardlinks. Decremented ONLY by a query's OWN
+         * failing rollback (never by a successful query) — a successful resolve keeps its hold for
+         * the window's entire lifetime, since there is no query/read-completion hook to release it
+         * (a genuine such hook is tracked as a separate follow-up, out of scope here).
+         *
+         * <p><b>ACCEPTED design tradeoff (roborev job 1754 finding 2), pinned so it is discoverable
+         * in code+test rather than the field:</b> because a successful hold is never released,
+         * {@code holders} is permanently &ge;1 the moment ANY second query has ever resolved a given
+         * window — meaning on essentially any table with real concurrent traffic (a "hot" table),
+         * the active rollback-retire this field enables degrades to a permanent no-op: the failing
+         * query's own rollback always finds {@code remaining > 0} and leaves its partial per-host
+         * creates to the grace/TTL backstop rather than actively clearing them. This is the
+         * deliberately SAFE direction (a suppressed retire only ever costs a bounded, already-covered
+         * leak; an unconditional retire could strand a live reader) — see
+         * {@code SnapshotManagerRetireHardeningTest
+         * #successfulReuseHoldIsPermanentSoRollbackRetireDegradesToNoOpOnHotTables}, which pins both
+         * the suppression and its permanence.
          */
         final AtomicInteger holders = new AtomicInteger();
 
@@ -229,8 +246,17 @@ public final class SnapshotManager {
      * every field of the owning object) is fully constructed — never from within the constructor
      * itself (this-escape). A no-op for a scheduler whose {@code startPeriodic} does not tick (e.g.
      * {@link SnapshotRetireScheduler.InlineRetireScheduler}).
+     *
+     * <p>Idempotent (roborev job 1754 finding 6): a second call is a silent no-op so double-starting
+     * (e.g. a duplicate wiring mistake) cannot double the periodic sweep cadence.
      */
     public void start() {
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+        // Deliberate semantic shift (roborev job 1754 finding 5): the periodic tick evaluates grace
+        // due-ness against `clock.nanoTime()` read AT TICK TIME, not any `now` captured at start()
+        // call time — each tick must see the CURRENT clock, not a stale snapshot from registration.
         retireScheduler.startPeriodic(() -> sweepRetireDue(clock.nanoTime()));
     }
 
@@ -333,6 +359,30 @@ public final class SnapshotManager {
             // to the grace/TTL backstop (the pre-#2452 bounded leak, now only on the contended
             // path). A reused-window rollback (removedFresh false) never retires here: a live shared
             // window must survive a transient added-fallback error.
+            //
+            // HAZARD DOWNGRADE (roborev job 1754 finding 1, HIGH — verified, not guarded): this
+            // direct retire() COULD in principle race a background grace-sweep's retire() of the
+            // SAME window, or land on a window the Sidecar already cleared externally (its own TTL).
+            // Verified safe rather than guarded, for two independent reasons:
+            //   1. `windows.remove(ref, window)` above is an IDENTITY-based conditional removal on
+            //      the SAME ConcurrentHashMap key a supersede's `windows.compute` also locks — the
+            //      two are mutually exclusive per key, so whichever wins determines the ONE path that
+            //      retires this exact Window instance: if a concurrent supersede already replaced the
+            //      map entry, `removedFresh` is false here and this rollback never calls retire() at
+            //      all (the window is instead only ever reachable via the pendingRetire queue, whose
+            //      own `Queue#remove` race guard already dedupes concurrent sweeps — see
+            //      sweepRetireDue). So the SAME Window object can never be handed to retire() by BOTH
+            //      a rollback AND a sweep.
+            //   2. Even so, `retire()` itself is safe against a redundant call: each per-host
+            //      `clearSnapshot` is wrapped in `try/catch(RuntimeException)` that logs and swallows
+            //      (see `retire` below), and `SidecarClient.clearSnapshot`'s non-2xx failure —
+            //      including a 404/NotFound from a repeat DELETE, e.g. the Sidecar's own TTL having
+            //      already reclaimed it — surfaces as exactly that RuntimeException
+            //      (`SidecarClient.SidecarException`). So retire() NEVER throws and always converges
+            //      on the same logical outcome (every host's snapshot ends up cleared, best-effort)
+            //      regardless of how many times — or how redundantly — it is invoked. Pinned by
+            //      {@code SnapshotManagerRetireHardeningTest
+            //      #doubleRetireOfTheSameWindowNeverThrowsAndConvergesToTheSameOutcome}.
             int remaining = window.holders.decrementAndGet();
             if (removedFresh && remaining == 0) {
                 retire(window, ref);
@@ -463,7 +513,11 @@ public final class SnapshotManager {
         // Offload the due-retirement sweep off the split-planning path (issue #2452 item 2, roborev
         // job 1722): a hot table must not pay a synchronous multi-host DELETE fan-out in planning
         // latency. The inline scheduler still runs it now (deterministic tests); the background
-        // scheduler hands it to a bounded best-effort executor.
+        // scheduler hands it to a bounded best-effort executor. Deliberate semantic shift (roborev
+        // job 1754 finding 5): the lambda re-reads `clock.nanoTime()` when the sweep actually EXECUTES
+        // — NOT the `now` captured above for THIS resolve's supersede decision — since a background
+        // sweep can run an arbitrary (possibly long) delay later and must judge grace due-ness
+        // against the CURRENT clock, not a stale reading from enqueue time.
         retireScheduler.submitSweep(() -> sweepRetireDue(clock.nanoTime()));
         return new Resolved(window, reused[0]);
     }
@@ -592,6 +646,20 @@ public final class SnapshotManager {
                                 + " (TTL backstop will reclaim it): " + ex.getMessage());
             }
         }
+    }
+
+    /**
+     * Test-support hook (roborev job 1754 finding 1): directly invoke the best-effort retire logic
+     * for an already-resolved {@link Window}, so a test can pin that retiring the SAME window TWICE
+     * — the rollback-races-a-sweep / hits-an-already-cleared-snapshot hazard roborev raised — never
+     * throws and converges on the same logical outcome. Production code never needs this: {@link
+     * #invalidate}, {@link #retireAll}, and the grace-sweep are the only retire entry points, and
+     * (per the hazard-downgrade note on the rollback catch block above) the {@code windows} map's
+     * identity-based conditional removal already makes a genuine double-retire of the SAME
+     * {@code Window} instance from two DIFFERENT production code paths structurally impossible.
+     */
+    void retireForTest(Window window, String keyspace, String table) {
+        retire(window, new TableRef(keyspace, table));
     }
 
     /** The reused-window snapshot name {@code cqlite-<ks>-<table>-<epoch>}. */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -397,6 +397,12 @@ public final class SnapshotManager {
             // HAZARD (roborev job 1754 f.1 / job 1755 f.4): retire() below CAN run more than once for
             // the same window, BY DESIGN — see the {@code Window#retired} javadoc for why it is a
             // tracked fact, not a run-once gate, and why re-invocation is always safe.
+            //
+            // LOAD-BEARING (roborev job 1757): remaining==0 proves no-stranding ONLY because
+            // successful holds never release. #2580 (release-on-success hook) MUST move this retire
+            // decision under a single windows.compute(ref, ...) critical section (removal decision +
+            // activeHolds read inside the lambda) or this becomes a TOCTOU — constraint also recorded
+            // on #2580.
             if (!resolved.reused() && remaining == 0 && windows.get(ref) != window) {
                 retire(window, ref);
             }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -201,8 +201,13 @@ public final class SnapshotManager {
      * DI constructor (issue #2452 item 2): the caller supplies the {@link SnapshotRetireScheduler}.
      * Production passes {@link SnapshotRetireScheduler.BackgroundRetireScheduler} (offload +
      * periodic quiet-table sweep); tests pass a controllable or inline scheduler for determinism.
-     * Registers the periodic sweep so a quiet table (no further queries) still prunes its superseded
-     * backlog (the #2367 accumulation fix) — a no-op for the inline scheduler.
+     *
+     * <p>Does NOT register the periodic sweep itself — call {@link #start()} once construction
+     * (and, in production, the caller's own field assignment) has fully completed. Registering the
+     * periodic hook here would pass a lambda closing over {@code this} to the scheduler BEFORE the
+     * constructor returns (a partial-construction / this-escape hazard, Java reviewer nit on #2452):
+     * the background thread could invoke {@code sweepRetireDue} on a not-yet-fully-initialized
+     * instance. {@link #start()} is a no-op for the inline scheduler either way.
      */
     public SnapshotManager(
             HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl,
@@ -215,7 +220,17 @@ public final class SnapshotManager {
         this.retireGraceNanos = Math.max(0L, retireGraceNanos);
         this.clock = clock;
         this.retireScheduler = retireScheduler;
-        // Quiet-table pruning: sweep due retirements on a background cadence even without a query.
+    }
+
+    /**
+     * Start the periodic quiet-table sweep (issue #2452 item 2, #2367 accumulation fix): a table
+     * that receives no further query must still have its superseded-window backlog pruned rather
+     * than accumulating until the multi-hour TTL. Call ONCE, after the instance (and, in production,
+     * every field of the owning object) is fully constructed — never from within the constructor
+     * itself (this-escape). A no-op for a scheduler whose {@code startPeriodic} does not tick (e.g.
+     * {@link SnapshotRetireScheduler.InlineRetireScheduler}).
+     */
+    public void start() {
         retireScheduler.startPeriodic(() -> sweepRetireDue(clock.nanoTime()));
     }
 

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -348,6 +348,13 @@ public final class SnapshotManager {
         TableRef ref = new TableRef(keyspace, table);
         Resolved resolved = resolveWindow(ref, generationFingerprint);
         Window window = resolved.window();
+        // resolveWindow ALWAYS increments window.activeHolds exactly once for THIS call before
+        // returning (both the reuse and the fresh-create branch of its compute() do) — captured here,
+        // right where the increment contract is established, rather than left as something the catch
+        // block below must infer from control flow alone (roborev job 1756 finding 1): the pairing is
+        // now structural (gated on this local), and any future code path that returns from
+        // resolveWindow WITHOUT incrementing must flip this to false or the WARNING below will fire.
+        boolean heldByMe = true;
         try {
             for (String host : hosts) {
                 createOnHost(window, host, keyspace, table);
@@ -364,7 +371,18 @@ public final class SnapshotManager {
                 // actually decides whether to retire, not whether THIS call's removal won.
                 windows.remove(ref, window);
             }
-            int remaining = window.activeHolds.decrementAndGet();
+            // Release THIS query's hold ONLY if resolveWindow actually incremented it for us (see
+            // `heldByMe` above) — a structural pairing, not an inferred one (roborev job 1756
+            // finding 1). A negative result means a decrement ran without a matching increment
+            // somewhere: a pairing-invariant break that would otherwise silently corrupt every later
+            // rollback decision on this window, so it is logged loudly rather than swallowed.
+            int remaining = heldByMe ? window.activeHolds.decrementAndGet() : window.activeHolds.get();
+            if (remaining < 0) {
+                LOG.log(Level.WARNING, () -> "activeHolds went negative for " + ref.keyspace() + "."
+                        + ref.table() + " window=" + window.name()
+                        + " — a decrement ran without a matching increment (pairing invariant "
+                        + "broken); this is a bug, please file an issue");
+            }
             // Retire once nobody can still JOIN this window as a holder: true whenever `window` is no
             // longer the live `windows[ref]` entry — whether *I* just removed it above, or
             // invalidate()/retireAll() removed it earlier while my OWN fan-out was still adding hosts
@@ -377,12 +395,8 @@ public final class SnapshotManager {
             // window's rollback never reaches here (guarded above).
             //
             // HAZARD (roborev job 1754 f.1 / job 1755 f.4): retire() below CAN run more than once for
-            // the same window — BY DESIGN, to catch hosts created after an earlier call already ran.
-            // `Window#retired` is a tracked fact for tests, not a run-once gate (gating it would
-            // silently reintroduce the leak just described). Re-invocation is safe regardless: a
-            // repeat clearSnapshot swallows its own 404/NotFound, so every call converges on the same
-            // outcome. See {@code SnapshotManagerRetireHardeningTest} (double-retire + invalidate-race
-            // tests).
+            // the same window, BY DESIGN — see the {@code Window#retired} javadoc for why it is a
+            // tracked fact, not a run-once gate, and why re-invocation is always safe.
             if (!resolved.reused() && remaining == 0 && windows.get(ref) != window) {
                 retire(window, ref);
             }
@@ -469,7 +483,16 @@ public final class SnapshotManager {
      * own retirement synchronously on the CALLER's thread (it never goes through the scheduler), so
      * closing the scheduler first ensures no background sweep can still be running concurrently with
      * (or after) {@link #retireAll}'s drain — no argued-safe race to reason about, just none possible.
-     * Idempotent and a no-op for the inline scheduler.
+     * Idempotent (including under concurrent callers, roborev job 1756 finding 2) and a no-op for the
+     * inline scheduler.
+     *
+     * <p><b>Honest caveat:</b> this is a graceful-then-forceful shutdown of the scheduler's executor,
+     * NOT a hard guarantee. If the calling thread is interrupted while waiting for the executor to
+     * drain, the fallback is an immediate forceful {@code shutdownNow()} with no further wait for
+     * genuine termination — {@code close()} still returns promptly, but does NOT guarantee every
+     * in-flight sweep fully drained first. This is safe (retirement is best-effort and the Sidecar
+     * TTL backstop reclaims anything left mid-flight) but callers must not treat a returned
+     * {@code close()} as proof of a completed drain in that specific (interrupted) path.
      */
     public void close() {
         retireScheduler.close();

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -99,6 +100,14 @@ public final class SnapshotManager {
     private final long reuseWindowNanos;
     private final long retireGraceNanos;
     private final Clock clock;
+    /**
+     * Where superseded-window retirement sweeps run (issue #2452 item 2). Default is
+     * {@link SnapshotRetireScheduler.InlineRetireScheduler} (synchronous, thread-free); production
+     * ({@link CqliteFlightConnector}) injects {@link SnapshotRetireScheduler.BackgroundRetireScheduler}
+     * so the DELETE fan-out is offloaded off the split-planning path and a periodic tick prunes
+     * quiet tables.
+     */
+    private final SnapshotRetireScheduler retireScheduler;
 
     /** The current reused snapshot window per {@code (keyspace, table)}. */
     private final Map<TableRef, Window> windows = new ConcurrentHashMap<>();
@@ -149,6 +158,17 @@ public final class SnapshotManager {
         final long createdNanos;
         final long generationFingerprint;
         final Map<String, CompletableFuture<String>> hostCreates = new ConcurrentHashMap<>();
+        /**
+         * In-flight queries that resolved (created or reused) this window (issue #2452 item 1,
+         * ref-counted rollback retirement). Incremented atomically under the {@code windows.compute}
+         * bin lock when a query resolves the window; consulted ONLY on a fresh-window fail-closed
+         * rollback so a concurrent reuser that committed this window to its tickets is never
+         * stranded by another query deleting the shared hardlinks. A successful query keeps its hold
+         * for its lifetime (there is no read-completion hook), so the count is conservatively high —
+         * which only ever SUPPRESSES a rollback delete (never strands), the safe direction. Grace /
+         * invalidate / shutdown retirement is unaffected (those paths never consult holders).
+         */
+        final AtomicInteger holders = new AtomicInteger();
 
         Window(String name, long epoch, long createdNanos, long generationFingerprint) {
             this.name = name;
@@ -173,12 +193,30 @@ public final class SnapshotManager {
     public SnapshotManager(
             HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl,
             long reuseWindowNanos, long retireGraceNanos, Clock clock) {
+        this(sidecars, readMode, ttl, reuseWindowNanos, retireGraceNanos, clock,
+                new SnapshotRetireScheduler.InlineRetireScheduler());
+    }
+
+    /**
+     * DI constructor (issue #2452 item 2): the caller supplies the {@link SnapshotRetireScheduler}.
+     * Production passes {@link SnapshotRetireScheduler.BackgroundRetireScheduler} (offload +
+     * periodic quiet-table sweep); tests pass a controllable or inline scheduler for determinism.
+     * Registers the periodic sweep so a quiet table (no further queries) still prunes its superseded
+     * backlog (the #2367 accumulation fix) — a no-op for the inline scheduler.
+     */
+    public SnapshotManager(
+            HostSnapshotApis sidecars, ReadMode readMode, Optional<String> ttl,
+            long reuseWindowNanos, long retireGraceNanos, Clock clock,
+            SnapshotRetireScheduler retireScheduler) {
         this.sidecars = sidecars;
         this.readMode = readMode;
         this.ttl = ttl;
         this.reuseWindowNanos = Math.max(0L, reuseWindowNanos);
         this.retireGraceNanos = Math.max(0L, retireGraceNanos);
         this.clock = clock;
+        this.retireScheduler = retireScheduler;
+        // Quiet-table pruning: sweep due retirements on a background cadence even without a query.
+        retireScheduler.startPeriodic(() -> sweepRetireDue(clock.nanoTime()));
     }
 
     /**
@@ -270,8 +308,19 @@ public final class SnapshotManager {
             // never fully materialized) nor count a create/flush that did not complete. Roll back
             // the fresh window so the next query recomputes; a REUSED window is left intact (a
             // transient host error on an added fallback host must not nuke a live shared window).
-            if (!resolved.reused()) {
-                windows.remove(ref, window);
+            boolean removedFresh = !resolved.reused() && windows.remove(ref, window);
+            // Ref-counted retirement (issue #2452 item 1, roborev job 1721): release THIS query's
+            // hold and, when the fresh window was actually removed from the live map AND no
+            // concurrent query still holds it, ACTIVELY retire the partial hardlinks this fan-out
+            // created (else they leak to the ~6h TTL). A concurrent query that REUSED this same
+            // fresh window and committed it to its tickets is a holder — deleting the shared
+            // hardlinks would strand it (NotFound), so a remaining holder leaves the partial creates
+            // to the grace/TTL backstop (the pre-#2452 bounded leak, now only on the contended
+            // path). A reused-window rollback (removedFresh false) never retires here: a live shared
+            // window must survive a transient added-fallback error.
+            int remaining = window.holders.decrementAndGet();
+            if (removedFresh && remaining == 0) {
+                retire(window, ref);
             }
             throw e;
         }
@@ -351,6 +400,15 @@ public final class SnapshotManager {
     }
 
     /**
+     * Release the background retirement scheduler (issue #2452 item 2). Called from the connector's
+     * shutdown after {@link #retireAll} has drained the live + pending snapshots; idempotent and a
+     * no-op for the inline scheduler.
+     */
+    public void close() {
+        retireScheduler.close();
+    }
+
+    /**
      * Resolve the current reused window for {@code ref}, reusing an existing fresh window or
      * creating a new one (bumping the epoch) atomically. Counting is done by the caller AFTER the
      * per-host fan-out succeeds (issue #2356 roborev), not here.
@@ -370,6 +428,9 @@ public final class SnapshotManager {
         Window[] superseded = {null};
         Window window = windows.compute(ref, (k, existing) -> {
             if (existing != null && isFresh(existing, generationFingerprint, now)) {
+                // Ref-count this query's hold under the bin lock (issue #2452 item 1), atomic with
+                // the reuse decision so a concurrent creator's rollback sees this reuser as a holder.
+                existing.holders.incrementAndGet();
                 reused[0] = true;
                 return existing;
             }
@@ -377,12 +438,18 @@ public final class SnapshotManager {
                 superseded[0] = existing;
             }
             long epoch = epochs.computeIfAbsent(k, r -> new AtomicLong()).getAndIncrement();
-            return new Window(nameFor(k, epoch), epoch, now, generationFingerprint);
+            Window fresh = new Window(nameFor(k, epoch), epoch, now, generationFingerprint);
+            fresh.holders.incrementAndGet();
+            return fresh;
         });
         if (superseded[0] != null) {
             pendingRetire.add(new PendingRetire(ref, superseded[0], now));
         }
-        sweepRetireDue(now);
+        // Offload the due-retirement sweep off the split-planning path (issue #2452 item 2, roborev
+        // job 1722): a hot table must not pay a synchronous multi-host DELETE fan-out in planning
+        // latency. The inline scheduler still runs it now (deterministic tests); the background
+        // scheduler hands it to a bounded best-effort executor.
+        retireScheduler.submitSweep(() -> sweepRetireDue(clock.nanoTime()));
         return new Resolved(window, reused[0]);
     }
 

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotManager.java
@@ -163,29 +163,38 @@ public final class SnapshotManager {
         final long generationFingerprint;
         final Map<String, CompletableFuture<String>> hostCreates = new ConcurrentHashMap<>();
         /**
-         * In-flight queries that resolved (created or reused) this window (issue #2452 item 1,
-         * ref-counted rollback retirement). Incremented atomically under the {@code windows.compute}
-         * bin lock when a query resolves the window; consulted ONLY on a fresh-window fail-closed
-         * rollback so a concurrent reuser that committed this window to its tickets is never
-         * stranded by another query deleting the shared hardlinks. Decremented ONLY by a query's OWN
-         * failing rollback (never by a successful query) — a successful resolve keeps its hold for
-         * the window's entire lifetime, since there is no query/read-completion hook to release it
-         * (a genuine such hook is tracked as a separate follow-up, out of scope here).
+         * NOT a true refcount (roborev job 1755 finding 2, renamed from {@code holders}) — a
+         * one-shot safety latch: incremented atomically under the {@code windows.compute} bin lock
+         * when a query resolves (creates or reuses) this window, but decremented ONLY by a query's
+         * OWN failing rollback and NEVER by a successful one, since there is no query/read-completion
+         * hook to release a success (tracked as follow-up issue #2580). It guards only the CREATOR's
+         * own rollback against stranding a concurrent reuser that already committed this window to
+         * its tickets — it is not a general liveness/usage count.
          *
-         * <p><b>ACCEPTED design tradeoff (roborev job 1754 finding 2), pinned so it is discoverable
-         * in code+test rather than the field:</b> because a successful hold is never released,
-         * {@code holders} is permanently &ge;1 the moment ANY second query has ever resolved a given
-         * window — meaning on essentially any table with real concurrent traffic (a "hot" table),
-         * the active rollback-retire this field enables degrades to a permanent no-op: the failing
-         * query's own rollback always finds {@code remaining > 0} and leaves its partial per-host
-         * creates to the grace/TTL backstop rather than actively clearing them. This is the
-         * deliberately SAFE direction (a suppressed retire only ever costs a bounded, already-covered
-         * leak; an unconditional retire could strand a live reader) — see
+         * <p><b>ACCEPTED hot-table active-retire degradation, pinned so it is discoverable in
+         * code+test rather than the field:</b> because a successful hold is never released,
+         * {@code activeHolds} is permanently &ge;1 the moment ANY second query has ever resolved a
+         * given window — so on essentially any table with real concurrent traffic, the active
+         * rollback-retire this field enables degrades to a permanent no-op: the failing query's own
+         * rollback always finds {@code remaining > 0} and leaves its partial per-host creates to the
+         * grace/TTL backstop. This is the deliberately SAFE direction (a suppressed retire only ever
+         * costs a bounded, already-covered leak; an unconditional retire could strand a live reader).
+         * See issue #2580 for the read-completion-hook follow-up, and
          * {@code SnapshotManagerRetireHardeningTest
          * #successfulReuseHoldIsPermanentSoRollbackRetireDegradesToNoOpOnHotTables}, which pins both
          * the suppression and its permanence.
          */
-        final AtomicInteger holders = new AtomicInteger();
+        final AtomicInteger activeHolds = new AtomicInteger();
+        /**
+         * Set (not a run-once gate) the first time {@link #retire} is invoked for this window —
+         * tracked for tests/observability, per roborev job 1755 finding 4. {@code retire()} MAY
+         * legitimately run more than once for the same window (see the hazard note on the rollback
+         * catch block in {@code resolveSnapshot}); this flag intentionally does NOT skip a repeat
+         * invocation, since doing so would silently reintroduce the finding-1 leak (a later call can
+         * still need to clear hosts a racing {@link #invalidate}/{@link #retireAll} created before it
+         * ran).
+         */
+        final AtomicBoolean retired = new AtomicBoolean(false);
 
         Window(String name, long epoch, long createdNanos, long generationFingerprint) {
             this.name = name;
@@ -346,45 +355,35 @@ public final class SnapshotManager {
         } catch (RuntimeException e) {
             // Roborev (issue #2356, half-created window): a fail-closed fan-out must not leave a
             // freshly-created window cached as "fresh" (a later query would reuse a snapshot that
-            // never fully materialized) nor count a create/flush that did not complete. Roll back
-            // the fresh window so the next query recomputes; a REUSED window is left intact (a
-            // transient host error on an added fallback host must not nuke a live shared window).
-            boolean removedFresh = !resolved.reused() && windows.remove(ref, window);
-            // Ref-counted retirement (issue #2452 item 1, roborev job 1721): release THIS query's
-            // hold and, when the fresh window was actually removed from the live map AND no
-            // concurrent query still holds it, ACTIVELY retire the partial hardlinks this fan-out
-            // created (else they leak to the ~6h TTL). A concurrent query that REUSED this same
-            // fresh window and committed it to its tickets is a holder — deleting the shared
-            // hardlinks would strand it (NotFound), so a remaining holder leaves the partial creates
-            // to the grace/TTL backstop (the pre-#2452 bounded leak, now only on the contended
-            // path). A reused-window rollback (removedFresh false) never retires here: a live shared
-            // window must survive a transient added-fallback error.
+            // never fully materialized) nor count a create/flush that did not complete. A REUSED
+            // window is left entirely alone here (never removed, never retired): a transient host
+            // error on an added fallback host must not nuke a live shared window.
+            if (!resolved.reused()) {
+                // Best-effort: a no-op if invalidate()/retireAll() already removed this EXACT window
+                // out from under this in-flight resolve — see the liveness check below, which is what
+                // actually decides whether to retire, not whether THIS call's removal won.
+                windows.remove(ref, window);
+            }
+            int remaining = window.activeHolds.decrementAndGet();
+            // Retire once nobody can still JOIN this window as a holder: true whenever `window` is no
+            // longer the live `windows[ref]` entry — whether *I* just removed it above, or
+            // invalidate()/retireAll() removed it earlier while my OWN fan-out was still adding hosts
+            // (issue #2452 roborev job 1755 finding 1: the prior `removedFresh`-only gate — "did MY
+            // OWN remove call win" — missed exactly this: an ordinary invalidate() racing an in-flight
+            // creator retires whatever existed at THAT moment and returns, then the creator goes on to
+            // create MORE hosts that nobody ever cleans up). `remaining == 0` alone already proves no
+            // reader can be stranded (a live successful hold never releases — see `activeHolds`), so
+            // checking liveness too only adds "retire promptly" cases, never an unsafe one. A REUSED
+            // window's rollback never reaches here (guarded above).
             //
-            // HAZARD DOWNGRADE (roborev job 1754 finding 1, HIGH — verified, not guarded): this
-            // direct retire() COULD in principle race a background grace-sweep's retire() of the
-            // SAME window, or land on a window the Sidecar already cleared externally (its own TTL).
-            // Verified safe rather than guarded, for two independent reasons:
-            //   1. `windows.remove(ref, window)` above is an IDENTITY-based conditional removal on
-            //      the SAME ConcurrentHashMap key a supersede's `windows.compute` also locks — the
-            //      two are mutually exclusive per key, so whichever wins determines the ONE path that
-            //      retires this exact Window instance: if a concurrent supersede already replaced the
-            //      map entry, `removedFresh` is false here and this rollback never calls retire() at
-            //      all (the window is instead only ever reachable via the pendingRetire queue, whose
-            //      own `Queue#remove` race guard already dedupes concurrent sweeps — see
-            //      sweepRetireDue). So the SAME Window object can never be handed to retire() by BOTH
-            //      a rollback AND a sweep.
-            //   2. Even so, `retire()` itself is safe against a redundant call: each per-host
-            //      `clearSnapshot` is wrapped in `try/catch(RuntimeException)` that logs and swallows
-            //      (see `retire` below), and `SidecarClient.clearSnapshot`'s non-2xx failure —
-            //      including a 404/NotFound from a repeat DELETE, e.g. the Sidecar's own TTL having
-            //      already reclaimed it — surfaces as exactly that RuntimeException
-            //      (`SidecarClient.SidecarException`). So retire() NEVER throws and always converges
-            //      on the same logical outcome (every host's snapshot ends up cleared, best-effort)
-            //      regardless of how many times — or how redundantly — it is invoked. Pinned by
-            //      {@code SnapshotManagerRetireHardeningTest
-            //      #doubleRetireOfTheSameWindowNeverThrowsAndConvergesToTheSameOutcome}.
-            int remaining = window.holders.decrementAndGet();
-            if (removedFresh && remaining == 0) {
+            // HAZARD (roborev job 1754 f.1 / job 1755 f.4): retire() below CAN run more than once for
+            // the same window — BY DESIGN, to catch hosts created after an earlier call already ran.
+            // `Window#retired` is a tracked fact for tests, not a run-once gate (gating it would
+            // silently reintroduce the leak just described). Re-invocation is safe regardless: a
+            // repeat clearSnapshot swallows its own 404/NotFound, so every call converges on the same
+            // outcome. See {@code SnapshotManagerRetireHardeningTest} (double-retire + invalidate-race
+            // tests).
+            if (!resolved.reused() && remaining == 0 && windows.get(ref) != window) {
                 retire(window, ref);
             }
             throw e;
@@ -466,8 +465,11 @@ public final class SnapshotManager {
 
     /**
      * Release the background retirement scheduler (issue #2452 item 2). Called from the connector's
-     * shutdown after {@link #retireAll} has drained the live + pending snapshots; idempotent and a
-     * no-op for the inline scheduler.
+     * shutdown BEFORE {@link #retireAll} (roborev job 1755 finding 3): {@link #retireAll} runs its
+     * own retirement synchronously on the CALLER's thread (it never goes through the scheduler), so
+     * closing the scheduler first ensures no background sweep can still be running concurrently with
+     * (or after) {@link #retireAll}'s drain — no argued-safe race to reason about, just none possible.
+     * Idempotent and a no-op for the inline scheduler.
      */
     public void close() {
         retireScheduler.close();
@@ -493,9 +495,9 @@ public final class SnapshotManager {
         Window[] superseded = {null};
         Window window = windows.compute(ref, (k, existing) -> {
             if (existing != null && isFresh(existing, generationFingerprint, now)) {
-                // Ref-count this query's hold under the bin lock (issue #2452 item 1), atomic with
+                // Latch this query's hold under the bin lock (issue #2452 item 1), atomic with
                 // the reuse decision so a concurrent creator's rollback sees this reuser as a holder.
-                existing.holders.incrementAndGet();
+                existing.activeHolds.incrementAndGet();
                 reused[0] = true;
                 return existing;
             }
@@ -504,7 +506,7 @@ public final class SnapshotManager {
             }
             long epoch = epochs.computeIfAbsent(k, r -> new AtomicLong()).getAndIncrement();
             Window fresh = new Window(nameFor(k, epoch), epoch, now, generationFingerprint);
-            fresh.holders.incrementAndGet();
+            fresh.activeHolds.incrementAndGet();
             return fresh;
         });
         if (superseded[0] != null) {
@@ -627,6 +629,7 @@ public final class SnapshotManager {
      * swallowed — the Sidecar TTL backstop covers a miss.
      */
     private void retire(Window window, TableRef ref) {
+        window.retired.set(true); // tracked fact, not a gate — see the Window#retired javadoc.
         for (Map.Entry<String, CompletableFuture<String>> e : window.hostCreates.entrySet()) {
             String host = e.getKey();
             String name;

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
@@ -63,13 +63,23 @@ public interface SnapshotRetireScheduler {
     final class BackgroundRetireScheduler implements SnapshotRetireScheduler {
         private static final Logger LOG = Logger.getLogger(BackgroundRetireScheduler.class.getName());
 
+        /** Floor for the periodic cadence (issue #2452 roborev nit): guards against a near-zero or
+         * negative caller-supplied period turning the periodic tick into a busy-loop. */
+        private static final long MIN_PERIOD_MILLIS = 1_000L;
+
         private final ScheduledExecutorService exec;
         private final long periodMillis;
-        /** Coalesce submitted sweeps: at most one queued at a time. */
-        private final AtomicBoolean sweepQueued = new AtomicBoolean(false);
+        /**
+         * Coalesce submitted sweeps: at most one queued at a time. Package-private (not private) so
+         * {@code SnapshotManagerRetireHardeningTest} can observe that a rejected-on-close submission
+         * still resets the flag (issue #2452 item 3) rather than permanently wedging all future
+         * coalesced sweeps — a stuck-flag regression would silently disable grace-sweeps exactly like
+         * the #2367 bug this issue fixes.
+         */
+        final AtomicBoolean sweepQueued = new AtomicBoolean(false);
 
         BackgroundRetireScheduler(long periodMillis) {
-            this.periodMillis = Math.max(1L, periodMillis);
+            this.periodMillis = Math.max(MIN_PERIOD_MILLIS, periodMillis);
             ThreadFactory daemon = r -> {
                 Thread t = new Thread(r, "cqlite-snapshot-retire");
                 t.setDaemon(true);
@@ -115,10 +125,15 @@ public interface SnapshotRetireScheduler {
         private static void runSafely(Runnable sweep) {
             try {
                 sweep.run();
-            } catch (RuntimeException e) {
-                // A best-effort background sweep must never kill the executor thread; the TTL
-                // backstop reclaims anything a failed sweep left behind.
-                LOG.log(Level.WARNING, e, () -> "Background snapshot retire sweep failed (TTL backstop reclaims)");
+            } catch (Throwable t) {
+                // A best-effort background sweep must NEVER let an uncaught throwable escape (roborev
+                // job 1753 fix #2): scheduleWithFixedDelay PERMANENTLY cancels all future executions
+                // of a periodic task the moment its Runnable throws ANYTHING uncaught — catching only
+                // RuntimeException left a single Error free to silently kill quiet-table pruning for
+                // the rest of the JVM's life, a silent regression back to the exact #2367
+                // 714-snapshot accumulation bug this issue fixes. The TTL backstop reclaims anything
+                // a failed sweep left behind, so swallowing (after logging) is safe here.
+                LOG.log(Level.WARNING, t, () -> "Background snapshot retire sweep failed (TTL backstop reclaims)");
             }
         }
     }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
@@ -1,0 +1,125 @@
+package in.mcfad.cqlite.flight;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Where superseded-snapshot retirement sweeps run (issue #2452 item 2, roborev job 1722).
+ *
+ * <p>Historically {@link SnapshotManager} swept due retirements INLINE from
+ * {@code resolveSnapshot} on the split-planning path, so a hot table with a short reuse window paid
+ * a synchronous multi-host {@code clearSnapshot} DELETE fan-out on most planning cycles — planning
+ * latency (roborev job 1722 Low #1). Retirement is best-effort (the ~6h Sidecar TTL is the
+ * backstop), so it is offloaded off the planning path.
+ *
+ * <p>Two triggers feed the sweep:
+ * <ul>
+ *   <li>{@link #submitSweep} — a one-off best-effort sweep enqueued when a query supersedes a
+ *       window; it runs on the background executor rather than the caller's planning thread.</li>
+ *   <li>{@link #startPeriodic} — a periodic tick so a QUIET table (no further queries) still prunes
+ *       its superseded backlog rather than accumulating snapshot dirs until the TTL reclaims them
+ *       (the #2367 714-snapshot field accumulation).</li>
+ * </ul>
+ *
+ * <p>{@link InlineRetireScheduler} preserves the original synchronous behavior (used by the
+ * deterministic unit tests and any caller that does not want a background thread);
+ * {@link BackgroundRetireScheduler} is the production offload.
+ */
+public interface SnapshotRetireScheduler {
+
+    /** Run a best-effort retirement sweep. Inline impl runs it now; background impl offloads it. */
+    void submitSweep(Runnable sweep);
+
+    /**
+     * Register the periodic quiet-table sweep. The background impl schedules it on a fixed cadence;
+     * the inline impl ignores it (a purely inline scheduler has no thread to tick on, so quiet-table
+     * pruning is a background-only guarantee — the TTL still backstops the inline path).
+     */
+    default void startPeriodic(Runnable sweep) {}
+
+    /** Release any background resources (production executor). Idempotent; inline impl is a no-op. */
+    default void close() {}
+
+    /** Synchronous, thread-free scheduler: runs each submitted sweep immediately in-line. */
+    final class InlineRetireScheduler implements SnapshotRetireScheduler {
+        @Override
+        public void submitSweep(Runnable sweep) {
+            sweep.run();
+        }
+    }
+
+    /**
+     * Production scheduler: a single daemon thread runs both the one-off submitted sweeps and a
+     * periodic tick. Submitted sweeps are COALESCED — at most one is queued at a time (the sweep is
+     * idempotent and the periodic tick backstops any dropped one) — so a burst of planning cycles
+     * cannot pile unbounded retire tasks onto the executor.
+     */
+    final class BackgroundRetireScheduler implements SnapshotRetireScheduler {
+        private static final Logger LOG = Logger.getLogger(BackgroundRetireScheduler.class.getName());
+
+        private final ScheduledExecutorService exec;
+        private final long periodMillis;
+        /** Coalesce submitted sweeps: at most one queued at a time. */
+        private final AtomicBoolean sweepQueued = new AtomicBoolean(false);
+
+        BackgroundRetireScheduler(long periodMillis) {
+            this.periodMillis = Math.max(1L, periodMillis);
+            ThreadFactory daemon = r -> {
+                Thread t = new Thread(r, "cqlite-snapshot-retire");
+                t.setDaemon(true);
+                return t;
+            };
+            this.exec = Executors.newSingleThreadScheduledExecutor(daemon);
+        }
+
+        @Override
+        public void submitSweep(Runnable sweep) {
+            // Only enqueue if none is already pending (coalesce). The task clears the flag when it
+            // starts, so the next supersede after it begins can enqueue a fresh sweep.
+            if (!sweepQueued.compareAndSet(false, true)) {
+                return;
+            }
+            try {
+                exec.execute(() -> {
+                    sweepQueued.set(false);
+                    runSafely(sweep);
+                });
+            } catch (RejectedExecutionException e) {
+                // Executor already shut down (connector shutdown raced a late supersede): the sweep
+                // is best-effort and the TTL backstops it, so drop it. Reset the flag for tidiness.
+                sweepQueued.set(false);
+            }
+        }
+
+        @Override
+        public void startPeriodic(Runnable sweep) {
+            try {
+                exec.scheduleWithFixedDelay(
+                        () -> runSafely(sweep), periodMillis, periodMillis, TimeUnit.MILLISECONDS);
+            } catch (RejectedExecutionException e) {
+                // Already closed — nothing to schedule.
+            }
+        }
+
+        @Override
+        public void close() {
+            exec.shutdownNow();
+        }
+
+        private static void runSafely(Runnable sweep) {
+            try {
+                sweep.run();
+            } catch (RuntimeException e) {
+                // A best-effort background sweep must never kill the executor thread; the TTL
+                // backstop reclaims anything a failed sweep left behind.
+                LOG.log(Level.WARNING, e, () -> "Background snapshot retire sweep failed (TTL backstop reclaims)");
+            }
+        }
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
@@ -119,6 +119,8 @@ public interface SnapshotRetireScheduler {
                 // Executor already shut down (connector shutdown raced a late supersede): the sweep
                 // is best-effort and the TTL backstops it, so drop it. Reset the flag for tidiness.
                 sweepQueued.set(false);
+                LOG.log(Level.FINE,
+                        () -> "Snapshot retire sweep dropped: scheduler already closed (TTL backstop covers it)");
             }
         }
 

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
@@ -56,9 +56,14 @@ public interface SnapshotRetireScheduler {
 
     /**
      * Production scheduler: a single daemon thread runs both the one-off submitted sweeps and a
-     * periodic tick. Submitted sweeps are COALESCED — at most one is queued at a time (the sweep is
-     * idempotent and the periodic tick backstops any dropped one) — so a burst of planning cycles
-     * cannot pile unbounded retire tasks onto the executor.
+     * periodic tick. Submitted sweeps are COALESCED (roborev job 1754 finding 3, corrected from an
+     * earlier overstated claim): at most one sweep is queued BEHIND the one currently running — the
+     * queued task clears the coalescing flag the MOMENT it starts (before it actually runs the
+     * sweep), so a submission arriving while that sweep is still executing coalesces into the NEXT
+     * queued task rather than piling up further; it does NOT guarantee at most one sweep in flight
+     * across the executor's whole lifetime, only that a burst of planning cycles cannot queue more
+     * than one sweep waiting behind the running one. The independent periodic tick backstops any
+     * sweep this coalescing drops.
      */
     final class BackgroundRetireScheduler implements SnapshotRetireScheduler {
         private static final Logger LOG = Logger.getLogger(BackgroundRetireScheduler.class.getName());
@@ -77,6 +82,10 @@ public interface SnapshotRetireScheduler {
          * the #2367 bug this issue fixes.
          */
         final AtomicBoolean sweepQueued = new AtomicBoolean(false);
+        /** Guards {@link #startPeriodic} so a second call cannot double the tick cadence (roborev
+         * job 1754 finding 6) — defense-in-depth alongside {@link SnapshotManager#start()}'s own
+         * guard, in case some OTHER caller invokes this scheduler directly. */
+        private final AtomicBoolean periodicStarted = new AtomicBoolean(false);
 
         BackgroundRetireScheduler(long periodMillis) {
             this.periodMillis = Math.max(MIN_PERIOD_MILLIS, periodMillis);
@@ -90,8 +99,14 @@ public interface SnapshotRetireScheduler {
 
         @Override
         public void submitSweep(Runnable sweep) {
-            // Only enqueue if none is already pending (coalesce). The task clears the flag when it
-            // starts, so the next supersede after it begins can enqueue a fresh sweep.
+            // Only enqueue if none is already pending (coalesce): at most one sweep queued behind
+            // the one currently running. The queued task clears the flag as soon as it STARTS
+            // (before running the sweep body), so a submission arriving during that sweep's own
+            // execution coalesces into the next queued task instead of piling up further (roborev
+            // job 1754 finding 3 — this does not cap total in-flight sweeps at one, only the queue
+            // depth; the periodic tick backstops anything this coalescing drops). Deliberately NOT
+            // moved to clear at task END: that would delay re-arming behind every sweep's full
+            // (possibly slow) network fan-out instead of just its scheduling latency.
             if (!sweepQueued.compareAndSet(false, true)) {
                 return;
             }
@@ -109,6 +124,11 @@ public interface SnapshotRetireScheduler {
 
         @Override
         public void startPeriodic(Runnable sweep) {
+            // Idempotent (roborev job 1754 finding 6): a second call is a silent no-op so a
+            // duplicate wiring mistake can't double the periodic sweep cadence.
+            if (!periodicStarted.compareAndSet(false, true)) {
+                return;
+            }
             try {
                 exec.scheduleWithFixedDelay(
                         () -> runSafely(sweep), periodMillis, periodMillis, TimeUnit.MILLISECONDS);
@@ -119,7 +139,21 @@ public interface SnapshotRetireScheduler {
 
         @Override
         public void close() {
-            exec.shutdownNow();
+            // Graceful-then-forceful shutdown (roborev job 1754 finding 4): let an in-flight sweep
+            // finish its host fan-out (no dangling network calls or partial state once close()
+            // returns) before falling back to shutdownNow() — the connector calls this right before
+            // allocator.close(), and a forcefully-interrupted sweep must never race that. Idempotent:
+            // shutdown()/awaitTermination()/shutdownNow() are all no-ops on an already-terminated
+            // executor, so a repeat close() call is safe.
+            exec.shutdown();
+            try {
+                if (!exec.awaitTermination(2, TimeUnit.SECONDS)) {
+                    exec.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                exec.shutdownNow();
+            }
         }
 
         private static void runSafely(Runnable sweep) {

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/SnapshotRetireScheduler.java
@@ -1,5 +1,6 @@
 package in.mcfad.cqlite.flight;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -86,6 +87,13 @@ public interface SnapshotRetireScheduler {
          * job 1754 finding 6) — defense-in-depth alongside {@link SnapshotManager#start()}'s own
          * guard, in case some OTHER caller invokes this scheduler directly. */
         private final AtomicBoolean periodicStarted = new AtomicBoolean(false);
+        /** Elects exactly one caller of {@link #close} to actually perform shutdown (roborev job
+         * 1756 finding 2); every other concurrent caller waits on {@link #closed} instead of
+         * independently racing its own {@code awaitTermination} call. */
+        private final AtomicBoolean closing = new AtomicBoolean(false);
+        /** Counts down once the electing {@link #close} caller's shutdown sequence has run to
+         * completion (gracefully or via the interrupted/timeout fallback) — see {@link #close}. */
+        private final CountDownLatch closed = new CountDownLatch(1);
 
         BackgroundRetireScheduler(long periodMillis) {
             this.periodMillis = Math.max(MIN_PERIOD_MILLIS, periodMillis);
@@ -144,17 +152,38 @@ public interface SnapshotRetireScheduler {
             // Graceful-then-forceful shutdown (roborev job 1754 finding 4): let an in-flight sweep
             // finish its host fan-out (no dangling network calls or partial state once close()
             // returns) before falling back to shutdownNow() — the connector calls this right before
-            // allocator.close(), and a forcefully-interrupted sweep must never race that. Idempotent:
-            // shutdown()/awaitTermination()/shutdownNow() are all no-ops on an already-terminated
-            // executor, so a repeat close() call is safe.
-            exec.shutdown();
-            try {
-                if (!exec.awaitTermination(2, TimeUnit.SECONDS)) {
-                    exec.shutdownNow();
+            // allocator.close(), and a forcefully-interrupted sweep must never race that.
+            //
+            // Exactly ONE caller performs the actual shutdown sequence (roborev job 1756 finding 2):
+            // a concurrent second close() call must not return early while the first is still
+            // mid-awaitTermination (that would break the connector shutdown()'s "the scheduler is
+            // fully quiesced once close() returns" assumption) — it BLOCKS on `closed` instead of
+            // independently racing its own fresh awaitTermination budget.
+            if (closing.compareAndSet(false, true)) {
+                try {
+                    exec.shutdown();
+                    try {
+                        if (!exec.awaitTermination(2, TimeUnit.SECONDS)) {
+                            exec.shutdownNow();
+                        }
+                    } catch (InterruptedException e) {
+                        // Honest fallback (roborev job 1756 finding 2): an interrupted close() does
+                        // NOT retry waiting for genuine termination — it forces shutdownNow() and
+                        // returns. A caller relying on this path does NOT get a drain guarantee (see
+                        // SnapshotManager#close's javadoc); this is still safe because retirement is
+                        // best-effort and the Sidecar TTL backstop covers anything left mid-flight.
+                        Thread.currentThread().interrupt();
+                        exec.shutdownNow();
+                    }
+                } finally {
+                    closed.countDown();
                 }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                exec.shutdownNow();
+            } else {
+                try {
+                    closed.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
 

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -315,6 +316,10 @@ class SnapshotManagerRetireHardeningTest {
         // First retire: succeeds normally on both hosts.
         assertDoesNotThrow(() -> mgr.retireForTest(window, "ks", "t"));
         assertEquals(Set.of("h1/" + name, "h2/" + name), Set.copyOf(snapshotOf(fake.clears)));
+        // roborev job 1756 finding 3: Window#retired is set by retire() but was never actually READ
+        // by a test — a live reader, not just the write side, so a future regression that stops
+        // setting it (or sets it wrong) is caught here rather than staying silently unobserved.
+        assertTrue(window.retired.get(), "retire() marks the window retired on its first invocation");
 
         // Second retire of the IDENTICAL window — simulating either a racing sweep or the Sidecar
         // having already reclaimed it (TTL): every host's repeat DELETE now 404s.
@@ -493,6 +498,39 @@ class SnapshotManagerRetireHardeningTest {
         } finally {
             scheduler.close();
             scheduler.close(); // idempotent
+        }
+    }
+
+    /**
+     * Important pin (roborev job 1756 finding 4): {@code scheduleWithFixedDelay} PERMANENTLY cancels
+     * every future execution of a periodic task the moment its {@code Runnable} throws ANYTHING
+     * uncaught — this is exactly the silent-regression class the catch-{@code Throwable} fix in
+     * {@code runSafely} (roborev job 1753 fix #2) exists to prevent (catching only
+     * {@code RuntimeException} would let a single {@code Error} silently reintroduce the #2367
+     * quiet-table accumulation bug). Proven directly: the sweep throws an {@code Error} on its FIRST
+     * invocation and signals a latch on its SECOND — the tick must still be alive to reach it.
+     */
+    @Test
+    void periodicTickSurvivesAnErrorOnItsFirstInvocation() throws Exception {
+        SnapshotRetireScheduler.BackgroundRetireScheduler scheduler =
+                new SnapshotRetireScheduler.BackgroundRetireScheduler(1_000L); // clamped floor
+        try {
+            AtomicInteger invocation = new AtomicInteger();
+            CountDownLatch secondInvocationRan = new CountDownLatch(1);
+            scheduler.startPeriodic(() -> {
+                if (invocation.incrementAndGet() == 1) {
+                    throw new AssertionError("simulated Error on the first periodic tick");
+                }
+                secondInvocationRan.countDown();
+            });
+
+            assertTrue(secondInvocationRan.await(5, TimeUnit.SECONDS),
+                    "the periodic tick must survive an Error on its first invocation and still fire "
+                            + "a second time — catching only RuntimeException would let this Error "
+                            + "permanently cancel the tick, silently reintroducing the #2367 "
+                            + "quiet-table accumulation bug");
+        } finally {
+            scheduler.close();
         }
     }
 

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -237,6 +238,10 @@ class SnapshotManagerRetireHardeningTest {
         DeferringScheduler scheduler = new DeferringScheduler();
         SnapshotManager mgr = new SnapshotManager(
                 fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, clock, scheduler);
+        // start() registers the periodic hook — called explicitly post-construction (issue #2452
+        // this-escape fix), mirroring how CqliteFlightConnector calls it after the SnapshotManager
+        // instance is fully built.
+        mgr.start();
 
         String w0 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
         clock.advance(WINDOW);
@@ -271,5 +276,33 @@ class SnapshotManagerRetireHardeningTest {
             scheduler.close();
             scheduler.close(); // idempotent
         }
+    }
+
+    /**
+     * Regression guard (issue #2452 item 3, roborev job 1753): a {@code submitSweep} call whose
+     * executor has already been closed hits the {@code RejectedExecutionException} branch. That
+     * branch must reset the coalescing {@code sweepQueued} flag exactly like a normal completed
+     * sweep would — otherwise ANY submission racing (or following) a close() would permanently wedge
+     * the flag at {@code true}, silently no-op-ing every future {@code submitSweep} for the rest of
+     * the scheduler's life (indistinguishable in the field from the #2367 quiet-table accumulation
+     * bug this issue fixes: sweeps are silently never queued again).
+     */
+    @Test
+    void submitSweepAfterCloseDoesNotThrowAndDoesNotWedgeTheCoalescingFlag() {
+        SnapshotRetireScheduler.BackgroundRetireScheduler scheduler =
+                new SnapshotRetireScheduler.BackgroundRetireScheduler(1_000L);
+        scheduler.close();
+
+        assertDoesNotThrow(() -> scheduler.submitSweep(() -> { }),
+                "submitSweep after close() must not throw (best-effort, TTL backstops it)");
+        assertFalse(scheduler.sweepQueued.get(),
+                "the RejectedExecutionException path must reset sweepQueued, not leave it wedged");
+
+        // A second call after close must ALSO not throw and must ALSO not find the flag stuck —
+        // proving the reset genuinely un-wedges future calls, not just a one-shot coincidence.
+        assertDoesNotThrow(() -> scheduler.submitSweep(() -> { }),
+                "a second post-close submitSweep must not throw either");
+        assertFalse(scheduler.sweepQueued.get(),
+                "sweepQueued must still not be wedged after a second post-close submission");
     }
 }

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
@@ -5,13 +5,13 @@ import in.mcfad.cqlite.flight.sidecar.SidecarClient;
 import in.mcfad.cqlite.flight.sidecar.SnapshotApi;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -152,6 +152,100 @@ class SnapshotManagerRetireHardeningTest {
     }
 
     /**
+     * A host list whose iteration blocks right BEFORE yielding the element at {@code blockBeforeIndex}
+     * — a test can thereby pause a creator's per-host fan-out AT THE BOUNDARY between two hosts
+     * (rather than inside a host's own create call), needed to construct
+     * {@link #invalidateRacingAnInFlightCreatorStillRetiresAllOfItsPartialCreates} deterministically:
+     * blocking inside a host's create leaves an entry already present (if pending) in {@code
+     * hostCreates}, so a concurrent {@code retire()}'s weakly-consistent {@code entrySet()} iteration
+     * could non-deterministically also observe a LATER host inserted mid-iteration — not a solid
+     * regression pin. Blocking BEFORE the boundary host is even looked up guarantees no such entry
+     * can exist yet.
+     */
+    private static List<String> blockingHostList(
+            List<String> hosts, int blockBeforeIndex, CountDownLatch reached, CountDownLatch release) {
+        return new java.util.AbstractList<>() {
+            @Override
+            public String get(int index) {
+                if (index == blockBeforeIndex) {
+                    reached.countDown();
+                    try {
+                        release.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                return hosts.get(index);
+            }
+
+            @Override
+            public int size() {
+                return hosts.size();
+            }
+        };
+    }
+
+    /**
+     * roborev job 1755 finding 1 (HIGH, real defect): if {@code invalidate(ks,t)} removes window W
+     * out from under an in-flight creator A BETWEEN two of A's OWN per-host creates, invalidate's
+     * own (single, immediate) {@code retire()} call only sees whatever hosts existed AT THAT MOMENT
+     * — it cannot know about a host A goes on to create AFTERWARD. The prior code gated A's own
+     * rollback retire on {@code removedFresh} ("did *I* win the map removal"), which is false here
+     * (invalidate already removed it) — so A's rollback skipped retire entirely and the LATER host
+     * leaked to the ~6h TTL, in the fully UNCONTENDED case, via an entirely ordinary code path (no
+     * exotic timing beyond an operator calling {@code invalidate} while a query is mid-flight).
+     *
+     * <p>Constructed so the leak is deterministic, not merely likely: A's host list itself blocks
+     * BEFORE yielding h2 (via {@link #blockingHostList}), so at the moment the test calls
+     * {@code invalidate()} h1 has ALREADY fully succeeded and h2 has not even been looked up yet —
+     * {@code hostCreates} contains exactly {@code {h1}}, complete, so invalidate's retire() call is
+     * fully synchronous (no pending future to block on) and is GUARANTEED to return before h2 exists.
+     * A is then released to attempt h2 (succeeds) and h3 (fails, triggering A's rollback). The fix
+     * retires once {@code activeHolds} reaches 0 and the window is no longer the live map entry —
+     * regardless of who removed it — so A's rollback catches h2 too.
+     */
+    @Test
+    void invalidateRacingAnInFlightCreatorStillRetiresAllOfItsPartialCreates() throws Exception {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failHost = "h3"; // fails immediately, no latch needed
+        SnapshotManager mgr = new SnapshotManager(
+                fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, new ManualClock());
+
+        CountDownLatch reachedH2Boundary = new CountDownLatch(1);
+        CountDownLatch releaseH2Boundary = new CountDownLatch(1);
+        List<String> hosts =
+                blockingHostList(List.of("h1", "h2", "h3"), 1, reachedH2Boundary, releaseH2Boundary);
+
+        ExecutorService pool = Executors.newFixedThreadPool(1);
+        try {
+            // Query A: h1 succeeds immediately; the host list itself pauses right before yielding h2
+            // (h1 fully complete, h2 not yet attempted); h3 then fails, aborting A's fan-out.
+            java.util.concurrent.Future<?> a = pool.submit(() ->
+                    assertThrows(SidecarClient.SidecarException.class,
+                            () -> mgr.snapshotFor("ks", "t", hosts)));
+            assertTrue(reachedH2Boundary.await(5, TimeUnit.SECONDS),
+                    "A paused between h1 (done) and h2 (not yet attempted)");
+
+            // invalidate() races HERE: hostCreates has ONLY h1 (fully complete, no pending future),
+            // so this call is fully synchronous and deterministic — it clears h1 and returns.
+            mgr.invalidate("ks", "t");
+
+            // Release A to attempt h2 (succeeds, created strictly AFTER invalidate() already
+            // returned) then h3 (fails, aborting the loop -> A's rollback).
+            releaseH2Boundary.countDown();
+            a.get(5, TimeUnit.SECONDS);
+
+            assertTrue(snapshotOf(fake.clears).stream().anyMatch(c -> c.startsWith("h1/")),
+                    "h1 is retired directly by invalidate(): " + fake.clears);
+            assertTrue(snapshotOf(fake.clears).stream().anyMatch(c -> c.startsWith("h2/")),
+                    "h2 — created strictly AFTER invalidate()'s call already returned — is STILL "
+                            + "retired by A's own rollback, not left to leak until the TTL: " + fake.clears);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
      * THE stranding race (issue #2452 item 1, warned about explicitly): query A creates a fresh
      * window W and fans out; concurrently query B REUSES the same fresh W and commits it to its
      * tickets; then A's fan-out fails on a later host. A's rollback must NOT delete W's shared
@@ -237,9 +331,9 @@ class SnapshotManagerRetireHardeningTest {
     /**
      * roborev job 1754 finding 2 (MEDIUM) — ACCEPTED design tradeoff, pinned so it is discoverable
      * in code+test rather than the field (a query/read-completion hook to release a successful
-     * hold is tracked as a separate follow-up, out of scope here): {@code holders} is decremented
+     * hold is tracked as separate follow-up issue #2580): {@code activeHolds} is decremented
      * ONLY by a query's own failing rollback, never by a successful resolve. So once a SECOND query
-     * has ever successfully resolved (created or reused) a window, {@code holders} is permanently
+     * has ever successfully resolved (created or reused) a window, {@code activeHolds} is permanently
      * &ge;1 for that window's remaining lifetime — meaning the active rollback-retire from finding
      * 1 / item 1 degrades to a permanent no-op on any table with real concurrent traffic: the
      * failing query's own rollback always finds a remaining holder and leaves its partial per-host
@@ -266,7 +360,7 @@ class SnapshotManagerRetireHardeningTest {
             // Query B successfully reuses+commits the SAME fresh window — a permanent hold.
             SnapshotManager.Window window =
                     mgr.resolveSnapshot("ks", "t", List.of("h1")).orElseThrow();
-            assertEquals(2, window.holders.get(), "A's creator hold + B's reuser hold");
+            assertEquals(2, window.activeHolds.get(), "A's creator hold + B's reuser hold");
 
             fake.failHostRelease.countDown();
             a.get(5, TimeUnit.SECONDS);
@@ -276,7 +370,7 @@ class SnapshotManagerRetireHardeningTest {
             // there is no other trigger that revisits THIS specific window's retirement once its
             // creator's rollback has already run, so the partial h1/h2 creates now survive until an
             // explicit invalidate/shutdown or the Sidecar's own TTL backstop reclaims them.
-            assertEquals(1, window.holders.get(),
+            assertEquals(1, window.activeHolds.get(),
                     "A released its own hold; B's successful hold is never released");
             assertTrue(fake.clears.isEmpty(),
                     "rollback retire suppressed by B's permanent hold (accepted hot-table "
@@ -288,10 +382,15 @@ class SnapshotManagerRetireHardeningTest {
 
     // ---- Item 2: grace-sweep offload + quiet-table periodic tick -------------------------------
 
-    /** A scheduler that DEFERS submitted sweeps so the test controls exactly when they run. */
+    /**
+     * A scheduler that DEFERS submitted sweeps so the test controls exactly when they run. Backed by
+     * {@link ConcurrentLinkedQueue} (roborev job 1755 finding 6) rather than {@link ArrayDeque}: cheap
+     * and removes the "only ever touched from one thread" precondition an {@code ArrayDeque} would
+     * impose, in case a future test submits sweeps from a background thread.
+     */
     private static final class DeferringScheduler implements SnapshotRetireScheduler {
-        final Queue<Runnable> deferred = new ArrayDeque<>();
-        Runnable periodic;
+        final Queue<Runnable> deferred = new ConcurrentLinkedQueue<>();
+        volatile Runnable periodic;
 
         @Override
         public void submitSweep(Runnable sweep) {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,27 +48,40 @@ class SnapshotManagerRetireHardeningTest {
     private static final long WINDOW = 1_000L; // logical nanos
     private static final long GRACE = 5_000L;  // logical nanos
 
-    /** A settable logical clock so window/grace timing is pinned deterministically. */
+    /**
+     * A settable logical clock so window/grace timing is pinned deterministically. Backed by an
+     * {@link AtomicLong} (roborev job 1754 finding 7) rather than a bare {@code volatile long}: every
+     * test in this file only ever calls {@link #advance} from the main test thread (worker threads
+     * only ever READ via {@link #nanoTime}), so a plain volatile read is already correct today, but
+     * the atomic read-modify-write removes the "single-threaded only" precondition entirely — a
+     * future test that advances the clock from a worker thread can't silently reintroduce a lost
+     * update.
+     */
     private static final class ManualClock implements SnapshotManager.Clock {
-        volatile long nanos;
+        private final AtomicLong nanos = new AtomicLong();
 
         @Override
         public long nanoTime() {
-            return nanos;
+            return nanos.get();
         }
 
         void advance(long delta) {
-            nanos += delta;
+            nanos.addAndGet(delta);
         }
     }
 
-    /** Records every create/clear (prefixed with host) and can block/throw a chosen host's create. */
+    /**
+     * Records every create/clear (prefixed with host) and can block/throw a chosen host's create, or
+     * throw a repeat-DELETE-shaped {@code SidecarException} (simulating the Sidecar having already
+     * cleared the snapshot, e.g. via its own TTL) on chosen hosts' clear.
+     */
     private static final class FakeSidecars implements HostSnapshotApis {
         final List<String> creates = Collections.synchronizedList(new ArrayList<>());
         final List<String> clears = Collections.synchronizedList(new ArrayList<>());
         volatile String failHost;
         volatile CountDownLatch failHostReached;
         volatile CountDownLatch failHostRelease;
+        volatile Set<String> failClearHosts = Set.of();
 
         @Override
         public SnapshotApi forHost(String host) {
@@ -92,9 +106,23 @@ class SnapshotManagerRetireHardeningTest {
 
                 @Override
                 public void clearSnapshot(String keyspace, String table, String name) {
+                    if (failClearHosts.contains(host)) {
+                        // Simulates a repeat DELETE 404/NotFound (the snapshot is already gone —
+                        // another retire, or the Sidecar's own TTL, already reclaimed it).
+                        throw new SidecarClient.SidecarException("not found: " + host + "/" + name, 404);
+                    }
                     clears.add(host + "/" + name);
                 }
             };
+        }
+    }
+
+    /** Snapshot {@code list} under its own monitor before streaming (roborev job 1754 finding 7):
+     * {@link Collections#synchronizedList} makes individual add/contains calls thread-safe, but
+     * iteration/{@code stream()} still needs external synchronization per its own javadoc. */
+    private static List<String> snapshotOf(List<String> list) {
+        synchronized (list) {
+            return List.copyOf(list);
         }
     }
 
@@ -119,7 +147,7 @@ class SnapshotManagerRetireHardeningTest {
         // h1 and h2 were created then the window rolled back -> both are retired immediately; the
         // failing h3 created nothing (its future was removed on throw), so it is not cleared.
         assertEquals(Set.of("h1/cqlite-ks-t-0", "h2/cqlite-ks-t-0"),
-                Set.copyOf(fake.clears),
+                Set.copyOf(snapshotOf(fake.clears)),
                 "the fresh window's partial creates are actively retired, no TTL leak: " + fake.clears);
     }
 
@@ -162,6 +190,97 @@ class SnapshotManagerRetireHardeningTest {
                     "a concurrent reuser must not be stranded — W's hardlinks stay intact: " + fake.clears);
             // And W is B's live, valid snapshot: B's create on h1 succeeded and was never cleared.
             assertTrue(fake.creates.contains("h1"), "B's snapshot on h1 exists: " + fake.creates);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * roborev job 1754 finding 1 (HIGH) — VERIFIED idempotent, not guarded: a rollback's direct
+     * {@code retire()} racing a background sweep's {@code retire()} of the same window (or landing
+     * on a window the Sidecar already cleared externally, e.g. its own TTL) can never throw and
+     * always converges on the same logical outcome. Verified two ways: (1) structurally, the
+     * {@code windows} map's identity-based conditional removal makes it impossible for the SAME
+     * {@code Window} instance to be handed to {@code retire()} by both a rollback and a supersede
+     * -triggered sweep (see the hazard-downgrade comment on the rollback catch block in
+     * {@code SnapshotManager#resolveSnapshot}); (2) even so, this test pins that a raw double-retire
+     * — including one whose SECOND attempt hits a repeat-DELETE 404/NotFound on every host — never
+     * throws and the outcome (every host's snapshot ends up cleared, best-effort) is unaffected by
+     * how many times retirement is attempted.
+     */
+    @Test
+    void doubleRetireOfTheSameWindowNeverThrowsAndConvergesToTheSameOutcome() {
+        FakeSidecars fake = new FakeSidecars();
+        SnapshotManager mgr = new SnapshotManager(
+                fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, new ManualClock());
+
+        SnapshotManager.Window window =
+                mgr.resolveSnapshot("ks", "t", List.of("h1", "h2")).orElseThrow();
+        String name = window.name();
+
+        // First retire: succeeds normally on both hosts.
+        assertDoesNotThrow(() -> mgr.retireForTest(window, "ks", "t"));
+        assertEquals(Set.of("h1/" + name, "h2/" + name), Set.copyOf(snapshotOf(fake.clears)));
+
+        // Second retire of the IDENTICAL window — simulating either a racing sweep or the Sidecar
+        // having already reclaimed it (TTL): every host's repeat DELETE now 404s.
+        fake.failClearHosts = Set.of("h1", "h2");
+        assertDoesNotThrow(() -> mgr.retireForTest(window, "ks", "t"),
+                "a second retire of the same (already-cleared) window must never throw");
+
+        // Single logical outcome either way: the window's snapshots are gone on both hosts — the
+        // first retire's clears are unaffected by the second attempt's swallowed 404s.
+        assertEquals(Set.of("h1/" + name, "h2/" + name), Set.copyOf(snapshotOf(fake.clears)),
+                "the observable outcome (cleared) is unchanged by a redundant retire attempt");
+    }
+
+    /**
+     * roborev job 1754 finding 2 (MEDIUM) — ACCEPTED design tradeoff, pinned so it is discoverable
+     * in code+test rather than the field (a query/read-completion hook to release a successful
+     * hold is tracked as a separate follow-up, out of scope here): {@code holders} is decremented
+     * ONLY by a query's own failing rollback, never by a successful resolve. So once a SECOND query
+     * has ever successfully resolved (created or reused) a window, {@code holders} is permanently
+     * &ge;1 for that window's remaining lifetime — meaning the active rollback-retire from finding
+     * 1 / item 1 degrades to a permanent no-op on any table with real concurrent traffic: the
+     * failing query's own rollback always finds a remaining holder and leaves its partial per-host
+     * creates to the grace/TTL backstop. This is the deliberately SAFE direction (never strands a
+     * live reader) — just not free lunch on hot tables.
+     */
+    @Test
+    void successfulReuseHoldIsPermanentSoRollbackRetireDegradesToNoOpOnHotTables() throws Exception {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failHost = "h3";
+        fake.failHostReached = new CountDownLatch(1);
+        fake.failHostRelease = new CountDownLatch(1);
+        SnapshotManager mgr = new SnapshotManager(
+                fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, new ManualClock());
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            // Query A: the eventual-failing creator of window W.
+            java.util.concurrent.Future<?> a = pool.submit(() ->
+                    assertThrows(SidecarClient.SidecarException.class,
+                            () -> mgr.snapshotFor("ks", "t", List.of("h1", "h2", "h3"))));
+            assertTrue(fake.failHostReached.await(5, TimeUnit.SECONDS), "A reached the failing host");
+
+            // Query B successfully reuses+commits the SAME fresh window — a permanent hold.
+            SnapshotManager.Window window =
+                    mgr.resolveSnapshot("ks", "t", List.of("h1")).orElseThrow();
+            assertEquals(2, window.holders.get(), "A's creator hold + B's reuser hold");
+
+            fake.failHostRelease.countDown();
+            a.get(5, TimeUnit.SECONDS);
+
+            // A's rollback released ONLY its own hold (2 -> 1); B's successful hold is never
+            // released, so the active retire is suppressed — not merely delayed, but PERMANENTLY:
+            // there is no other trigger that revisits THIS specific window's retirement once its
+            // creator's rollback has already run, so the partial h1/h2 creates now survive until an
+            // explicit invalidate/shutdown or the Sidecar's own TTL backstop reclaims them.
+            assertEquals(1, window.holders.get(),
+                    "A released its own hold; B's successful hold is never released");
+            assertTrue(fake.clears.isEmpty(),
+                    "rollback retire suppressed by B's permanent hold (accepted hot-table "
+                            + "degradation): " + fake.clears);
         } finally {
             pool.shutdownNow();
         }
@@ -221,7 +340,7 @@ class SnapshotManagerRetireHardeningTest {
 
         // Draining the background scheduler runs the offloaded sweep, which retires the due window.
         scheduler.drain();
-        assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w0)),
+        assertTrue(snapshotOf(fake.clears).stream().anyMatch(c -> c.contains(w0)),
                 "the offloaded background sweep retires the due window: " + fake.clears);
     }
 
@@ -254,7 +373,7 @@ class SnapshotManagerRetireHardeningTest {
         clock.advance(GRACE);
         scheduler.periodic.run();
 
-        assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w0)),
+        assertTrue(snapshotOf(fake.clears).stream().anyMatch(c -> c.contains(w0)),
                 "the periodic tick prunes the quiet table's superseded backlog: " + fake.clears);
     }
 

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/SnapshotManagerRetireHardeningTest.java
@@ -1,0 +1,275 @@
+package in.mcfad.cqlite.flight;
+
+import in.mcfad.cqlite.flight.sidecar.HostSnapshotApis;
+import in.mcfad.cqlite.flight.sidecar.SidecarClient;
+import in.mcfad.cqlite.flight.sidecar.SnapshotApi;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Snapshot retirement hardening (issue #2452, follow-ups from PR #2425's endgame):
+ *
+ * <ol>
+ *   <li><b>Ref-counted retirement on fail-closed rollback</b> (roborev job 1721). A fresh window
+ *       whose per-host fan-out fails partway must actively retire the hardlinks it already created
+ *       (no leak to the ~6h TTL) — EXCEPT when a concurrent query reused the same fresh window and
+ *       committed it to its tickets, in which case deleting the shared hardlinks would strand that
+ *       reader (NotFound). The window is reference-counted and its partial creates are retired only
+ *       when no in-flight query still holds it.</li>
+ *   <li><b>Grace-sweep offloaded off the split-planning path</b> (roborev job 1722) — the
+ *       superseded-window DELETE fan-out no longer runs synchronously in {@code resolveSnapshot};
+ *       it is submitted to a background best-effort {@link SnapshotRetireScheduler}. A periodic tick
+ *       also prunes quiet tables that receive no further queries (the #2367 backlog fix).</li>
+ * </ol>
+ *
+ * All timing is driven by an injected logical clock and a controllable scheduler — never wall-clock
+ * or {@code sleep}-based (the #1742 pinned-{@code now} discipline).
+ */
+class SnapshotManagerRetireHardeningTest {
+
+    private static final long WINDOW = 1_000L; // logical nanos
+    private static final long GRACE = 5_000L;  // logical nanos
+
+    /** A settable logical clock so window/grace timing is pinned deterministically. */
+    private static final class ManualClock implements SnapshotManager.Clock {
+        volatile long nanos;
+
+        @Override
+        public long nanoTime() {
+            return nanos;
+        }
+
+        void advance(long delta) {
+            nanos += delta;
+        }
+    }
+
+    /** Records every create/clear (prefixed with host) and can block/throw a chosen host's create. */
+    private static final class FakeSidecars implements HostSnapshotApis {
+        final List<String> creates = Collections.synchronizedList(new ArrayList<>());
+        final List<String> clears = Collections.synchronizedList(new ArrayList<>());
+        volatile String failHost;
+        volatile CountDownLatch failHostReached;
+        volatile CountDownLatch failHostRelease;
+
+        @Override
+        public SnapshotApi forHost(String host) {
+            return new SnapshotApi() {
+                @Override
+                public void createSnapshot(String keyspace, String table, String name, Optional<String> ttl) {
+                    if (host.equals(failHost)) {
+                        if (failHostReached != null) {
+                            failHostReached.countDown();
+                        }
+                        if (failHostRelease != null) {
+                            try {
+                                failHostRelease.await(5, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }
+                        throw new SidecarClient.SidecarException("boom on " + host, 500);
+                    }
+                    creates.add(host);
+                }
+
+                @Override
+                public void clearSnapshot(String keyspace, String table, String name) {
+                    clears.add(host + "/" + name);
+                }
+            };
+        }
+    }
+
+    // ---- Item 1: ref-counted rollback retirement -----------------------------------------------
+
+    /**
+     * Uncontended rollback: a fresh window's fan-out fails on a later host, so the hardlinks it
+     * already created on the earlier hosts are ACTIVELY retired (no leak to the TTL). This is the
+     * behavior the naive endgame patch added; the ref-count makes it safe (proven by the race test
+     * below).
+     */
+    @Test
+    void uncontendedRollbackActivelyRetiresPartialCreates() {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failHost = "h3";
+        SnapshotManager mgr = new SnapshotManager(
+                fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, new ManualClock());
+
+        assertThrows(SidecarClient.SidecarException.class,
+                () -> mgr.snapshotFor("ks", "t", List.of("h1", "h2", "h3")));
+
+        // h1 and h2 were created then the window rolled back -> both are retired immediately; the
+        // failing h3 created nothing (its future was removed on throw), so it is not cleared.
+        assertEquals(Set.of("h1/cqlite-ks-t-0", "h2/cqlite-ks-t-0"),
+                Set.copyOf(fake.clears),
+                "the fresh window's partial creates are actively retired, no TTL leak: " + fake.clears);
+    }
+
+    /**
+     * THE stranding race (issue #2452 item 1, warned about explicitly): query A creates a fresh
+     * window W and fans out; concurrently query B REUSES the same fresh W and commits it to its
+     * tickets; then A's fan-out fails on a later host. A's rollback must NOT delete W's shared
+     * hardlinks — B is still holding them — or B strands on a NotFound. Deterministic via latches:
+     * A blocks in the failing host's create until B has reused-and-committed W.
+     */
+    @Test
+    void concurrentReuserIsNotStrandedByAnotherQueryRollback() throws Exception {
+        FakeSidecars fake = new FakeSidecars();
+        fake.failHost = "h3";
+        fake.failHostReached = new CountDownLatch(1);
+        fake.failHostRelease = new CountDownLatch(1);
+        SnapshotManager mgr = new SnapshotManager(
+                fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, new ManualClock());
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            // Query A: creates W on h1, h2, then blocks in h3's failing create.
+            java.util.concurrent.Future<?> a = pool.submit(() ->
+                    assertThrows(SidecarClient.SidecarException.class,
+                            () -> mgr.snapshotFor("ks", "t", List.of("h1", "h2", "h3"))));
+
+            // Wait until A is inside h3's create — W is now live in the map and h1/h2 exist.
+            assertTrue(fake.failHostReached.await(5, TimeUnit.SECONDS), "A reached the failing host");
+
+            // Query B reuses the SAME fresh window W and commits its name (its ticket).
+            String bName = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+            assertEquals("cqlite-ks-t-0", bName, "B reused A's fresh window");
+
+            // Now let A fail and roll back.
+            fake.failHostRelease.countDown();
+            a.get(5, TimeUnit.SECONDS);
+
+            // No stranding: A's rollback must NOT have deleted W's hardlinks — B still holds W.
+            assertTrue(fake.clears.isEmpty(),
+                    "a concurrent reuser must not be stranded — W's hardlinks stay intact: " + fake.clears);
+            // And W is B's live, valid snapshot: B's create on h1 succeeded and was never cleared.
+            assertTrue(fake.creates.contains("h1"), "B's snapshot on h1 exists: " + fake.creates);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    // ---- Item 2: grace-sweep offload + quiet-table periodic tick -------------------------------
+
+    /** A scheduler that DEFERS submitted sweeps so the test controls exactly when they run. */
+    private static final class DeferringScheduler implements SnapshotRetireScheduler {
+        final Queue<Runnable> deferred = new ArrayDeque<>();
+        Runnable periodic;
+
+        @Override
+        public void submitSweep(Runnable sweep) {
+            deferred.add(sweep);
+        }
+
+        @Override
+        public void startPeriodic(Runnable sweep) {
+            this.periodic = sweep;
+        }
+
+        void drain() {
+            Runnable r;
+            while ((r = deferred.poll()) != null) {
+                r.run();
+            }
+        }
+    }
+
+    /**
+     * Item 2 offload: the superseded-window retirement DELETE does NOT run on the split-planning
+     * path ({@code resolveSnapshot}) — it is handed to the background scheduler. Proven by a
+     * deferring scheduler: right after the resolve that supersedes a past-grace window, nothing is
+     * cleared; only draining the background task performs the retire.
+     */
+    @Test
+    void graceSweepIsOffloadedOffThePlanningPath() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        DeferringScheduler scheduler = new DeferringScheduler();
+        SnapshotManager mgr = new SnapshotManager(
+                fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, clock, scheduler);
+
+        String w0 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        // Elapse the window and resolve again: W0 is superseded and enqueued (grace starts now).
+        clock.advance(WINDOW);
+        String w1 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        assertTrue(!w0.equals(w1));
+        // Let W0's grace fully elapse so it is DUE for retirement on the next sweep.
+        clock.advance(GRACE);
+
+        // The DELETE has NOT run inline on the planning path (it was offloaded/deferred) — even
+        // though W0 is now past its grace, no sweep executed synchronously in resolveSnapshot.
+        assertTrue(fake.clears.isEmpty(),
+                "grace-sweep DELETE must not run synchronously in resolveSnapshot: " + fake.clears);
+
+        // Draining the background scheduler runs the offloaded sweep, which retires the due window.
+        scheduler.drain();
+        assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w0)),
+                "the offloaded background sweep retires the due window: " + fake.clears);
+    }
+
+    /**
+     * Item 2 quiet-table fix (#2367, 714-snapshot accumulation): a table that receives NO further
+     * query after its window is superseded must still have its backlog pruned — by the periodic
+     * background tick, not a query. Proven by invoking the captured periodic sweep after the grace
+     * elapses, with no intervening query.
+     */
+    @Test
+    void periodicTickPrunesQuietTableBacklogWithoutAQuery() {
+        FakeSidecars fake = new FakeSidecars();
+        ManualClock clock = new ManualClock();
+        DeferringScheduler scheduler = new DeferringScheduler();
+        SnapshotManager mgr = new SnapshotManager(
+                fake, ReadMode.SNAPSHOT, Optional.of("6h"), WINDOW, GRACE, clock, scheduler);
+
+        String w0 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow();
+        clock.advance(WINDOW);
+        String w1 = mgr.snapshotFor("ks", "t", List.of("h1")).orElseThrow(); // supersedes W0, enqueues
+        scheduler.drain(); // any offloaded sweep runs; W0 age 0 < GRACE -> not retired
+        assertFalse(w0.equals(w1));
+        assertTrue(fake.clears.isEmpty(), "W0 still within grace: " + fake.clears);
+
+        // The table goes quiet — NO further query. Time passes and the periodic tick fires.
+        clock.advance(GRACE);
+        scheduler.periodic.run();
+
+        assertTrue(fake.clears.stream().anyMatch(c -> c.contains(w0)),
+                "the periodic tick prunes the quiet table's superseded backlog: " + fake.clears);
+    }
+
+    // ---- Item 2: the production background scheduler actually runs work ------------------------
+
+    @Test
+    void backgroundSchedulerRunsSubmittedSweepAndPeriodicTickThenClosesCleanly() throws Exception {
+        SnapshotRetireScheduler.BackgroundRetireScheduler scheduler =
+                new SnapshotRetireScheduler.BackgroundRetireScheduler(20L);
+        try {
+            CountDownLatch submitted = new CountDownLatch(1);
+            scheduler.submitSweep(submitted::countDown);
+            assertTrue(submitted.await(5, TimeUnit.SECONDS), "submitted sweep runs on the background thread");
+
+            CountDownLatch ticked = new CountDownLatch(1);
+            scheduler.startPeriodic(ticked::countDown);
+            assertTrue(ticked.await(5, TimeUnit.SECONDS), "the periodic tick fires");
+        } finally {
+            scheduler.close();
+            scheduler.close(); // idempotent
+        }
+    }
+}


### PR DESCRIPTION
Closes #2452

## What (round-13 connector payload — answers #2367's 714-snapshot field flag)
- **Ref-counted rollback retirement** (`SnapshotManager.java`): fail-closed rollback actively retires partial per-host hardlinks (kills the ~6h-TTL leak) via an `AtomicInteger holders` on the shared `Window`, serialized against the `windows.compute` bin-lock; retire fires only at removed-from-map AND holders==0 — the previously-reverted stranding race is pinned by a deterministic latch-driven test (query B reuses+commits while query A rolls back → zero clearSnapshot calls).
- **Background grace-sweep + quiet-table periodic tick** (`SnapshotRetireScheduler.java` new): `sweepRetireDue`'s multi-host DELETE fan-out moves off the `getSplits` planning path to a single-daemon-thread coalescing scheduler with a fixed-delay tick (floored 1s, default = retire-grace cadence) — **quiet tables now prune their backlog with zero intervening queries** (the #2367 714-snapshot mechanism). Explicit `start()` post-construction (no this-escape); `runSafely` catches `Throwable` so an Error cannot silently kill the tick; connector constructs the manager AFTER ArrowMemoryPreflight/RootAllocator so catalog-load failures cannot leak the thread; close is idempotent and post-close submits are safe (wedge-flag test).
- **Metrics-surface note** (`trino-connector/README.md`): reader_opens/rebind_hits_total are programmatic-only (WarmMetricsSnapshot), intentional per spec — now documented where field operators look.

## Review-first (#2086) — done pre-gate
- Java concurrency review (opus): CLEAN, no blockers — ref-count pairing, retire-once, coalescing-loss, lifecycle all verified; race test confirmed a true regression pin. 4 nits folded in.
- roborev job 1753: 1 blocker (constructor-order thread leak) + 2 low — ALL fixed; job 1754 (confirmation) pending.
- Tests: `./gradlew test --rerun-tasks` → 36 classes, 344 tests, 0 failures (6 new hardening tests, all latch/manual-clock deterministic).

## Gate
Connector-only diff (Java + README; zero Rust). Full `agent-gate.sh` (gate of record) runs pre-merge in flow-closer per doctrine. Ships in connector 0.14.4 for round 13.