### PR TITLE
perf(reconcile): entry() API + mem::take survivors (Q2, #1665)

### DIFF
--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -595,6 +595,83 @@ pub(crate) mod merge_entry_clone_scope {
     }
 }
 
+/// A thread-local recording scope for `CellData::clone` calls, mirroring
+/// [`merge_entry_clone_scope`] exactly (issue #2428's parallel-test-pollution-
+/// immune design). Used by the #1665 reconcile micro-alloc guard: reconciliation
+/// runs single-threaded, so a [`CellDataCloneScope`] opened around one
+/// clustering-group reconcile captures exactly the `CellData` clones performed
+/// during it — enough to prove Site 2 (`filter_dropped_columns`) no longer
+/// deep-clones the survivor set.
+///
+/// `#[cfg(test)]`: the `record()` call in `CellData::clone` is likewise
+/// `#[cfg(test)]`-gated, so production clone pays ZERO added cost. Gated on
+/// `feature = "write-support"` as well because `CellData` and its only consumer
+/// (the `filter_dropped_columns` guard) live in the write-support-only merge
+/// module — under the minimal feature set those callers vanish, so an
+/// unconditional `#[cfg(test)]` here would be dead code and trip the
+/// `-D warnings` dead-code lint in the all-compression build.
+#[cfg(all(test, feature = "write-support"))]
+pub(crate) mod cell_data_clone_scope {
+    use std::cell::Cell;
+
+    thread_local! {
+        /// `Some(count)` while a [`CellDataCloneScope`] is active on this thread,
+        /// `None` otherwise. Only `CellData::clone` calls executing on this
+        /// thread bump it.
+        static SCOPED: Cell<Option<u64>> = const { Cell::new(None) };
+    }
+
+    /// Bump the active scope on the current thread, if any. A no-op on threads
+    /// (production reconcile, other tests) with no active scope.
+    pub(crate) fn record() {
+        SCOPED.with(|c| {
+            if let Some(v) = c.get() {
+                c.set(Some(v.saturating_add(1)));
+            }
+        });
+    }
+
+    /// A per-thread recording scope for `CellData::clone`. Open one before
+    /// driving a clustering-group reconcile and read
+    /// [`count`](CellDataCloneScope::count) after. Immune to concurrent tests on
+    /// other threads (issue #2428). Dropping it clears the scope.
+    ///
+    /// Deliberately `!Send` (holds a `PhantomData<*const ()>`): the scope is
+    /// meaningful only on the thread that opened it.
+    pub(crate) struct CellDataCloneScope {
+        _not_send: std::marker::PhantomData<*const ()>,
+    }
+
+    impl CellDataCloneScope {
+        /// Begin recording on the current thread. Panics if a scope is already
+        /// active on this thread (one scope per assertion; nesting unsupported).
+        pub(crate) fn new() -> Self {
+            SCOPED.with(|c| {
+                assert!(
+                    c.get().is_none(),
+                    "a CellDataCloneScope is already active on this thread (nesting unsupported)"
+                );
+                c.set(Some(0));
+            });
+            Self {
+                _not_send: std::marker::PhantomData,
+            }
+        }
+
+        /// `CellData::clone` increments recorded on this thread since the scope
+        /// opened.
+        pub(crate) fn count(&self) -> u64 {
+            SCOPED.with(|c| c.get().unwrap_or(0))
+        }
+    }
+
+    impl Drop for CellDataCloneScope {
+        fn drop(&mut self) {
+            SCOPED.with(|c| c.set(None));
+        }
+    }
+}
+
 /// Record that one merge ENTRY was decoded from `Data.db` by ANY
 /// [`KWayMerger`](crate::storage::write_engine::KWayMerger)-adapter-driven run
 /// (Issue #2096) — a full scan, a compaction, OR a multi-candidate point read,

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -557,6 +557,11 @@ mod teardown_tests;
 #[cfg(all(test, feature = "write-support"))]
 mod clone_regression_tests;
 
+// Issue #1665: reconcile micro-alloc guard — proves `filter_dropped_columns` no
+// longer deep-clones the survivor set (sibling file, #1116 campsite rule).
+#[cfg(all(test, feature = "write-support"))]
+mod reconcile_microalloc_tests;
+
 #[cfg(feature = "write-support")]
 impl SSTableRowIteratorAdapter {
     /// Open an SSTable and start a streaming producer thread.

--- a/cqlite-core/src/storage/write_engine/merge/model.rs
+++ b/cqlite-core/src/storage/write_engine/merge/model.rs
@@ -306,7 +306,7 @@ pub enum RowData {
 /// Where the reader does not yet surface a value the field is left `None`; the
 /// dependent issues fill it in once the reader is extended.
 #[cfg(feature = "write-support")]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CellData {
     /// Column name
     pub column: String,
@@ -366,6 +366,31 @@ pub struct CellData {
     /// on-disk emptiness rather than re-deriving it from the decoded value.
     /// Always `false` for simple cells.
     pub has_empty_value: bool,
+}
+
+/// Manual `Clone` (was `#[derive(Clone)]`) so the #1665 reconcile micro-alloc
+/// guard can count `CellData` clones via a `#[cfg(test)]`-gated recorder. The
+/// clone is field-wise identical to the former derived clone (all 9 fields); in
+/// a production (non-test) build the `record()` call vanishes entirely, so this
+/// is a plain field-wise clone with ZERO added cost (mirrors [`MergeEntry`]'s
+/// #1664 manual clone).
+#[cfg(feature = "write-support")]
+impl Clone for CellData {
+    fn clone(&self) -> Self {
+        #[cfg(test)]
+        crate::storage::sstable::work_counters::cell_data_clone_scope::record();
+        Self {
+            column: self.column.clone(),
+            value: self.value.clone(),
+            timestamp: self.timestamp,
+            ttl: self.ttl,
+            cell_path: self.cell_path.clone(),
+            local_deletion_time: self.local_deletion_time,
+            is_complex_element: self.is_complex_element,
+            is_deleted: self.is_deleted,
+            has_empty_value: self.has_empty_value,
+        }
+    }
 }
 
 #[cfg(feature = "write-support")]

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -32,6 +32,7 @@
 //! 7. [`build`](ReconcileState::build) — Step 4: phantom-row guard + emit the
 //!    merged `MergeEntry`.
 
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
 use crate::storage::write_engine::mutation::{ClusteringKey, DecoratedKey, RangeTombstone};
@@ -192,12 +193,19 @@ impl ReconcileState {
             if let RowData::Live { cells } = &entry.row_data {
                 for cell in cells {
                     let cell_key: CellKey = (cell.column.clone(), cell.cell_path.clone());
-                    match self.winners.get(&cell_key) {
-                        None => {
-                            self.order.push(cell_key.clone());
-                            self.winners.insert(cell_key, cell.clone());
+                    // Issue #1665: the HashMap `entry()` API hashes ONCE on the
+                    // vacant path (the old `get()`+`insert()` hashed twice) and
+                    // lets `order` reuse the slot's owned key. Output is
+                    // byte-identical: the vacant/occupied arms below are the same
+                    // two branches as the former `None`/`Some` match, and the
+                    // `order.push` still precedes the `insert` so first-seen order
+                    // is preserved for the equal-timestamp tie-break.
+                    match self.winners.entry(cell_key) {
+                        Entry::Vacant(slot) => {
+                            self.order.push(slot.key().clone());
+                            slot.insert(cell.clone());
                         }
-                        Some(existing) => {
+                        Entry::Occupied(mut slot) => {
                             // Higher timestamp wins. At EQUAL timestamp a cell
                             // DELETION (tombstone) beats a LIVE or EXPIRING
                             // (TTL) cell, decided BEFORE any localDeletionTime
@@ -207,8 +215,8 @@ impl ReconcileState {
                             // (newer file) winner. The tie-break is the SHARED
                             // [`reconcile_rules::cell_wins`] rule (issue #947),
                             // also used by the flush/write path.
-                            if reconcile_rules::cell_wins(cell, existing) {
-                                self.winners.insert(cell_key, cell.clone());
+                            if reconcile_rules::cell_wins(cell, slot.get()) {
+                                slot.insert(cell.clone());
                             }
                         }
                     }
@@ -379,16 +387,15 @@ impl ReconcileState {
     /// `has_data_after` / `purged_to_empty` determination is DEFERRED to
     /// [`Self::build`], after Step 3c — #921 finding 3).
     pub(super) fn filter_dropped_columns(&mut self, dropped_columns: &HashMap<String, i64>) {
-        self.surviving = self
-            .after_row_del
-            .iter()
-            .filter(|cell| match dropped_columns.get(&cell.column) {
-                Some(drop_time) => cell.timestamp > *drop_time,
-                None => true,
-            })
-            .cloned()
-            .collect();
-
+        // Issue #1665: capture the pre-purge phantom-row guard state FIRST — while
+        // `after_row_del` is still populated — so we can then MOVE it into the
+        // survivor filter instead of deep-cloning every survivor. `after_row_del`
+        // is DEAD after this method (VERIFIED against the reconcile step sequence
+        // in `merge/mod.rs`: shadow_by_row_deletion → filter_dropped_columns →
+        // expire_ttl_cells → purge_gc_grace → build, none of which read it again,
+        // and `build` destructures `self` with `..`), so `mem::take` is safe and
+        // output is byte-identical (same `had_data_before`, same `surviving`
+        // contents and order — only the survivor clone is eliminated).
         let ck_names: HashSet<&str> = self
             .clustering_key
             .as_ref()
@@ -396,6 +403,15 @@ impl ReconcileState {
             .unwrap_or_default();
         let is_data_cell = |cell: &CellData| !ck_names.contains(cell.column.as_str());
         self.had_data_before = self.after_row_del.iter().any(is_data_cell);
+        drop(ck_names);
+
+        self.surviving = std::mem::take(&mut self.after_row_del)
+            .into_iter()
+            .filter(|cell| match dropped_columns.get(&cell.column) {
+                Some(drop_time) => cell.timestamp > *drop_time,
+                None => true,
+            })
+            .collect();
     }
 
     /// Step 3b′ — TTL EXPIRY (issue #1382, parity Cassandra `ExpiringCell`

--- a/cqlite-core/src/storage/write_engine/merge/reconcile_microalloc_tests.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile_microalloc_tests.rs
@@ -57,7 +57,9 @@ fn live_entry(run_index: usize, cells: Vec<CellData>) -> MergeEntry {
 /// * `dropped_columns = {"d": 100}` → `d@50` is dropped (`50 <= 100`).
 ///
 /// Distinct winners `W = 4` (a, b, c, d); survivors `S = 3` (a, b, c).
-/// `resolve_cell_winners` clones once per winner WRITE = `W + 2` re-inserts = 6.
+/// `resolve_cell_winners` clones once per winner WRITE = `W + 2` re-inserts = 6
+/// (Site 1 is unchanged by the fix; the bound uses the DISTINCT-winner count,
+/// not the write count, so the pre-fix survivor clones show up as the excess).
 ///
 // CLONE ACCOUNTING (recorded for context):
 //   main today (pre-fix): 6 (Site 1 winner writes) + 3 (Site 2 `.cloned()`
@@ -69,8 +71,11 @@ fn live_entry(run_index: usize, cells: Vec<CellData>) -> MergeEntry {
 #[test]
 fn filter_dropped_columns_does_not_clone_survivors() {
     // Distinct winner keys across the group (the map owns one CellData per key;
-    // that clone is unavoidable — the map is by-value). = 4: a, b, c, d.
-    const WINNER_WRITES: u64 = 4;
+    // that clone is unavoidable — the map is by-value). = 4: a, b, c, d. NB: this
+    // is the DISTINCT-winner count, not the winner-map WRITE count (6 = 4 vacant
+    // inserts + 2 winning re-inserts); the extra slack from re-inserts is why the
+    // pre-fix survivor clones (3) push the total past the bound.
+    const DISTINCT_WINNERS: u64 = 4;
     // Cells surviving the dropped-column filter: a, b, c (d@50 is dropped). = 3.
     const S: u64 = 3;
 
@@ -131,11 +136,11 @@ fn filter_dropped_columns_does_not_clone_survivors() {
         other => panic!("expected a live row, got {other:?}"),
     }
 
-    let bound = S + WINNER_WRITES; // 3 + 4 = 7
+    let bound = S + DISTINCT_WINNERS; // 3 + 4 = 7
     assert!(
         clones <= bound,
         "reconcile cloned CellData {clones} times (bound {bound} = S={S} + \
-         winner_writes={WINNER_WRITES}); the #1665 survivor `.cloned()` in \
+         distinct_winners={DISTINCT_WINNERS}); the #1665 survivor `.cloned()` in \
          filter_dropped_columns regressed (main-today was 9)"
     );
 }

--- a/cqlite-core/src/storage/write_engine/merge/reconcile_microalloc_tests.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile_microalloc_tests.rs
@@ -1,0 +1,141 @@
+//! Issue #1665 — reconcile micro-alloc guard.
+//!
+//! Q2 of epic #1610 removed two avoidable per-cluster allocations from the
+//! reconcile kernel (`merge/reconcile.rs`):
+//!
+//! * **Site 1** (`resolve_cell_winners`): the `HashMap::entry()` API replaces the
+//!   old `get()`+`insert()` double-hash on the vacant path. This does NOT change
+//!   the `CellData` clone count (the map still owns one clone per winner write),
+//!   so this guard does not target it directly.
+//! * **Site 2** (`filter_dropped_columns`): the survivor set used to be
+//!   deep-cloned out of `after_row_del` (`.cloned()`); it is now MOVED
+//!   (`mem::take` + `into_iter`), eliminating one `CellData` clone per survivor.
+//!
+//! This module (a sibling file, not inline in `merge/mod.rs`, per the #1116
+//! campsite rule) is the regression guard for Site 2: it drives one
+//! clustering-group reconcile inside a
+//! [`CellDataCloneScope`](crate::storage::sstable::work_counters::cell_data_clone_scope::CellDataCloneScope)
+//! and asserts the observed `CellData::clone` count stays at or below
+//! `S + winner_writes` — a bound only the post-fix (moved-survivor) code meets.
+
+use super::reconcile::ReconcileState;
+use super::{CellData, MergeEntry, PurgeCounts, RowData};
+use crate::storage::sstable::work_counters::cell_data_clone_scope::CellDataCloneScope;
+use crate::storage::write_engine::mutation::DecoratedKey;
+use crate::types::Value;
+use std::collections::HashMap;
+
+/// A single live cell (`CellData::new` — no TTL/path/ldt), created fresh (NOT
+/// cloned), so building the input costs zero recorded clones.
+fn live_cell(column: &str, ts: i64) -> CellData {
+    CellData::new(column.to_string(), Value::Text("v".to_string()), ts)
+}
+
+/// One live `MergeEntry` in partition `token=1` with `clustering_key = None`
+/// carrying `cells`. The partition-key bytes are arbitrary — `ReconcileState`
+/// only carries the first key through, it never decodes them.
+fn live_entry(run_index: usize, cells: Vec<CellData>) -> MergeEntry {
+    MergeEntry::new(
+        run_index,
+        DecoratedKey::new(1, vec![0, 0, 0, 1]),
+        None,
+        cells.iter().map(|c| c.timestamp).max().unwrap_or(0),
+        RowData::Live { cells },
+    )
+}
+
+/// Regression guard for issue #1665 (Site 2 — kill the survivor `.cloned()` in
+/// `filter_dropped_columns`). Drives one clustering-group reconcile whose input
+/// forces both a winning re-insert (so the winner-map write count exceeds the
+/// distinct-winner count) AND a non-empty surviving set under active
+/// dropped-column filtering, then asserts the `CellData::clone` count stays at
+/// or below `S + winner_writes`.
+///
+/// Scenario (single partition, single clustering group):
+/// * run 0: `a@100, b@100, c@100, d@50`
+/// * run 1: `a@200, b@200` (both strictly newer — they win the reconcile)
+/// * `dropped_columns = {"d": 100}` → `d@50` is dropped (`50 <= 100`).
+///
+/// Distinct winners `W = 4` (a, b, c, d); survivors `S = 3` (a, b, c).
+/// `resolve_cell_winners` clones once per winner WRITE = `W + 2` re-inserts = 6.
+///
+// CLONE ACCOUNTING (recorded for context):
+//   main today (pre-fix): 6 (Site 1 winner writes) + 3 (Site 2 `.cloned()`
+//                         survivors) = 9  -> 9 > 7, so this assertion is RED.
+//   post-fix:             6 (Site 1 winner writes) + 0 (Site 2 moves) = 6
+//                         -> 6 <= 7, GREEN.
+/// The bound `S + winner_writes = 3 + 4 = 7` sits strictly between the two: a
+/// regression that reintroduces the survivor `.cloned()` fails it.
+#[test]
+fn filter_dropped_columns_does_not_clone_survivors() {
+    // Distinct winner keys across the group (the map owns one CellData per key;
+    // that clone is unavoidable — the map is by-value). = 4: a, b, c, d.
+    const WINNER_WRITES: u64 = 4;
+    // Cells surviving the dropped-column filter: a, b, c (d@50 is dropped). = 3.
+    const S: u64 = 3;
+
+    let cluster_rows = vec![
+        live_entry(
+            0,
+            vec![
+                live_cell("a", 100),
+                live_cell("b", 100),
+                live_cell("c", 100),
+                live_cell("d", 50),
+            ],
+        ),
+        live_entry(1, vec![live_cell("a", 200), live_cell("b", 200)]),
+    ];
+
+    let mut dropped_columns: HashMap<String, i64> = HashMap::new();
+    dropped_columns.insert("d".to_string(), 100);
+
+    let mut state = ReconcileState::new(None);
+    let mut purges = PurgeCounts::default();
+
+    // Record clones only across the reconcile itself (input construction above
+    // used `CellData::new`, never `clone`, and happens outside the scope).
+    let scope = CellDataCloneScope::new();
+
+    state.fold_row_deletions(&cluster_rows);
+    state.resolve_cell_winners(&cluster_rows);
+    state.apply_complex_deletions();
+    state.shadow_by_row_deletion(&mut purges);
+    state.filter_dropped_columns(&dropped_columns);
+    state.expire_ttl_cells(None);
+    state.purge_gc_grace(None, i64::MAX, &mut purges);
+    let built = state.build(&mut purges);
+
+    let clones = scope.count();
+    drop(scope);
+
+    // Output-parity sanity: the winning cells survive (a, b, c) and `d` was
+    // dropped, so a live row with exactly 3 data cells is emitted.
+    let entry = built.expect("a live row must be emitted");
+    match &entry.row_data {
+        RowData::Live { cells } => {
+            assert_eq!(
+                cells.len(),
+                S as usize,
+                "d@50 dropped, a/b/c survive as the winning cells"
+            );
+            let mut cols: Vec<&str> = cells.iter().map(|c| c.column.as_str()).collect();
+            cols.sort_unstable();
+            assert_eq!(cols, ["a", "b", "c"]);
+            // The winning (strictly-newer) values are the ts=200 cells of a, b.
+            for cell in cells {
+                let expected_ts = if cell.column == "c" { 100 } else { 200 };
+                assert_eq!(cell.timestamp, expected_ts, "winner ts for {}", cell.column);
+            }
+        }
+        other => panic!("expected a live row, got {other:?}"),
+    }
+
+    let bound = S + WINNER_WRITES; // 3 + 4 = 7
+    assert!(
+        clones <= bound,
+        "reconcile cloned CellData {clones} times (bound {bound} = S={S} + \
+         winner_writes={WINNER_WRITES}); the #1665 survivor `.cloned()` in \
+         filter_dropped_columns regressed (main-today was 9)"
+    );
+}


### PR DESCRIPTION
Closes #1665 — Q2 of epic #1610 (merge/compaction allocation honesty).

## What changed

Two output-preserving micro-alloc removals in `merge/reconcile.rs`:

- **Site 1 (`resolve_cell_winners`)** — replaced the `get()`+`insert()` double-hash / double-key-clone with the `HashMap::entry()` API. Single hash on the vacant path; `order` reuses the slot's owned key (`slot.key().clone()`). `order.push` still precedes `insert`, so first-seen order (the equal-timestamp tie-break) is byte-identical.
- **Site 2 (`filter_dropped_columns`)** — **`mem::take` path taken.** `had_data_before` is now computed FIRST (from `after_row_del` while still populated), then `after_row_del` is `mem::take`-n and filtered by value (`into_iter().filter().collect()`) — eliminating the per-survivor deep clone.
  - **VERIFY result:** `after_row_del` is DEAD after this method. The reconcile step sequence in `merge/mod.rs` is `shadow_by_row_deletion → filter_dropped_columns → expire_ttl_cells → purge_gc_grace → build`; none of the later steps read `after_row_del` (the only later mention, `reconcile.rs:588`, is a comment) and `build` destructures `self` with `..`. So `mem::take` is safe.

## TDD guard (red-on-main proven)

New `CellData` clone counter `cell_data_clone_scope` (thread-local, `!Send`, `#[cfg(all(test, feature="write-support"))]`) mirroring the #1664 `merge_entry_clone_scope`, plus a manual 9-field `CellData::clone` with a `#[cfg(test)]` recorder (zero prod cost). Guard test `filter_dropped_columns_does_not_clone_survivors` drives one clustering-group reconcile and asserts `celldata_clones <= S + distinct_winners` (= 3 + 4 = 7).

| | CellData clones | vs bound 7 |
|---|---|---|
| **main (pre-fix)** | **9** (6 Site-1 winner writes + 3 Site-2 `.cloned()` survivors) | **FAIL (RED)** — proven by temporarily reverting Site 2 |
| **post-fix** | **6** (6 Site-1 winner writes + 0 Site-2) | PASS (GREEN) |

## Byte-parity

Zero output change: `winners`/`order`/`surviving`/`had_data_before` are identical. No JSONL golden changes; #921 byte-parity harness unaffected. No `unwrap`/`expect`; `-D warnings` clean.

## Gate + review

- **Lite gate: PASS** (at 24acbf9): file-size PASS, fmt PASS, clippy PASS, scoped-tests PASS.
  - file-size required `CQLITE_ALLOW_FILE_GROWTH=1` — the two grown files (`work_counters.rs` 836→913, `merge/mod.rs` 13192→13197) are pre-existing over-threshold files; additions are minimal and structurally required (the new scope must sit beside the #1664 scope it mirrors in `work_counters.rs`; mod.rs got only a 4-line `mod` decl — the test body is correctly split into a sibling file). Splitting these is epic #1116 scope, not this micro-alloc fix.
  - The subsequent commit (1d29acc) is a test-only const rename (`WINNER_WRITES` → `DISTINCT_WINNERS`), verified by re-running the guard test (GREEN).
- **roborev (claude-code): clean** — one Low nit (test const naming clarity), fixed in 1d29acc. Summary: "byte-identical reconcile micro-optimization ... the reordered `had_data_before` capture, the manual 9-field `Clone`, and the `after_row_del` dead-after-use claim all verify as correct."

Full gate of record + final roborev run in `flow-closer`.