### PR TITLE
perf(writer): reusable row_scratch + in-place row-size VInt (R2, #1673)

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -173,6 +173,16 @@ pub struct DataWriter {
     /// and flushed to `sink` at the end, so only one partition is resident.
     /// In memory mode it accumulates the entire Data.db output.
     buffer: Vec<u8>,
+    /// Reusable scratch buffer for one row's serialized body (issue #1673, R2).
+    ///
+    /// Each row's body (timestamp/TTL/deletion/column-bitmap/cells, everything
+    /// after the row_size VInt) is built into this buffer, then appended to
+    /// `buffer`. `build_merged_row_body` / `build_static_row_body` `clear()` it
+    /// at the start of every row — `clear()` retains capacity, so after warmup no
+    /// per-row body allocation occurs (it previously allocated a fresh throwaway
+    /// `Vec` per row). Distinct field from `buffer` so the two can be borrowed
+    /// disjointly (`buffer.extend_from_slice(&row_scratch)`).
+    row_scratch: Vec<u8>,
     /// Streaming sink over the Data.db path (streaming mode only).
     ///
     /// Lazily opened on the first `write_partition` so that the keyspace/table
@@ -305,6 +315,7 @@ impl DataWriter {
     pub fn new(stats: StatisticsMetadata) -> Self {
         Self {
             buffer: Vec::new(),
+            row_scratch: Vec::new(),
             sink: None,
             data_path: None,
             position: 0,
@@ -335,6 +346,7 @@ impl DataWriter {
     pub fn with_sink(stats: StatisticsMetadata, data_path: PathBuf) -> Self {
         Self {
             buffer: Vec::new(),
+            row_scratch: Vec::new(),
             sink: None,
             data_path: Some(data_path),
             position: 0,

--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -828,35 +828,29 @@ impl DataWriter {
             self.write_clustering_prefix(clustering_key, schema)?;
         }
 
-        // Calculate row body size (everything after row_size VInt)
-        let (row_body, cells_written) = self.build_merged_row_body(row, schema, flags)?;
-
+        // Build the row body into the reusable `row_scratch` (issue #1673, R2).
+        let cells_written = self.build_merged_row_body(row, schema, flags)?;
         let prev_size_vint_len = unsigned_len(prev_size);
 
-        // Write row_size (VInt) — Cassandra's serializedRowBodySize() includes
-        // the prev_unfiltered_size VInt as part of the row body
-        let row_body_size = prev_size_vint_len as u64 + row_body.len() as u64;
-        let mut row_size_buf = Vec::new();
-        encode_unsigned(row_body_size, &mut row_size_buf);
-        self.buffer.extend_from_slice(&row_size_buf);
+        // Write row_size (VInt) — Cassandra's serializedRowBodySize() includes the
+        // prev_unfiltered_size VInt. Encoded straight into `self.buffer` (#1673, R2
+        // — no `row_size_buf`); body length known from `row_scratch`, order intact.
+        let row_body_size = prev_size_vint_len as u64 + self.row_scratch.len() as u64;
+        encode_unsigned(row_body_size, &mut self.buffer);
 
         // Write prev_unfiltered_size (VInt, inside the row body)
         encode_unsigned(prev_size, &mut self.buffer);
-
-        // Write rest of row body
-        self.buffer.extend_from_slice(&row_body);
+        // Append the row body (disjoint field borrow: buffer vs row_scratch).
+        self.buffer.extend_from_slice(&self.row_scratch);
 
         Ok((self.buffer.len() - start_len, cells_written))
     }
 
-    /// Build row body (everything after row_size VInt)
-    ///
-    /// Returns the bytes for: timestamp, TTL, deletion, column bitmap, and cells.
-    /// Build a row body from a single mutation (legacy/test entry point).
-    /// Routes through the merged-row body builder.
+    /// Build a row body from a single mutation (legacy/test entry point); routes
+    /// through the merged-row body builder and returns a copy of the scratch.
     #[cfg(test)]
     pub(super) fn build_row_body(
-        &self,
+        &mut self,
         mutation: &Mutation,
         schema: &TableSchema,
         flags: u8,
@@ -869,8 +863,8 @@ impl DataWriter {
             ops: Vec::new(),
             complex_element_ops: Vec::new(),
         });
-        let (body, _cells) = self.build_merged_row_body(&row, schema, flags)?;
-        Ok(body)
+        let _cells = self.build_merged_row_body(&row, schema, flags)?;
+        Ok(self.row_scratch.clone())
     }
 
     /// Build a merged row body (everything after the row_size VInt, excluding
@@ -879,19 +873,24 @@ impl DataWriter {
     /// Field order per Cassandra's `UnfilteredSerializer.serializeRowBody`:
     /// liveness timestamp, TTL + expiration LDT, row deletion, columns
     /// subset, then cells. Issue #717: the columns subset is written for
-    /// EVERY row lacking HAS_ALL_COLUMNS — including row tombstones.
+    /// EVERY row lacking HAS_ALL_COLUMNS — including row tombstones. Builds into
+    /// the reusable `self.row_scratch` (issue #1673, R2 — no per-row throwaway
+    /// `Vec`; `clear()`ed here, retaining capacity); the caller reads it back.
     ///
-    /// Returns the serialized body bytes and the number of cells (columns)
-    /// physically written (Issue #851, review): the count is sourced from
-    /// `write_merged_cells`, the only place that decides whether a cell is
-    /// emitted, so Statistics' column count cannot drift from Data.db.
+    /// Returns the number of cells (columns) physically written (Issue #851,
+    /// review): the count is sourced from `write_merged_cells`, the only place
+    /// that decides whether a cell is emitted, so Statistics' column count cannot
+    /// drift from Data.db.
     pub(super) fn build_merged_row_body(
-        &self,
+        &mut self,
         row: &RowWrite<'_>,
         schema: &TableSchema,
         flags: u8,
-    ) -> Result<(Vec<u8>, u64)> {
-        let mut body = Vec::new();
+    ) -> Result<u64> {
+        // Take the scratch out of `self` so the `&self` cell/bitmap helpers below
+        // can run while `&mut body` is held; stored back at the end (keeps capacity).
+        let mut body = std::mem::take(&mut self.row_scratch);
+        body.clear();
 
         // Issue #2038 Scope B: capture "now" ONCE for this entire row write and
         // share it with every expiring cell derived below (row liveness AND,
@@ -981,7 +980,8 @@ impl DataWriter {
         // Write cell data (none survive for pure row tombstones)
         let cells_written = self.write_merged_cells(&mut body, row, schema, now_seconds)?;
 
-        Ok((body, cells_written))
+        self.row_scratch = body; // store back, retaining capacity
+        Ok(cells_written)
     }
 
     /// Write clustering prefix

--- a/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
@@ -162,23 +162,25 @@ impl DataWriter {
 
         // NO clustering prefix for static rows (key difference from write_row)
 
-        // Build row body
-        let (row_body, cells_written) =
+        // Build the row body into the reusable `row_scratch` buffer (issue #1673,
+        // R2 — no per-row throwaway Vec).
+        let cells_written =
             self.build_static_row_body(static_ops, liveness_ts, ttl_seconds, schema, flags)?;
 
         let prev_size_vint_len = unsigned_len(prev_size);
 
-        // Write row_size (VInt) — includes prev_unfiltered_size VInt + rest of body
-        let row_body_size = prev_size_vint_len as u64 + row_body.len() as u64;
-        let mut row_size_buf = Vec::new();
-        encode_unsigned(row_body_size, &mut row_size_buf);
-        self.buffer.extend_from_slice(&row_size_buf);
+        // Write row_size (VInt) — includes prev_unfiltered_size VInt + rest of
+        // body. Encoded straight into `self.buffer` (issue #1673, R2 — no
+        // throwaway `row_size_buf`); the body length is already known from
+        // `row_scratch`, so wire order is unchanged.
+        let row_body_size = prev_size_vint_len as u64 + self.row_scratch.len() as u64;
+        encode_unsigned(row_body_size, &mut self.buffer);
 
         // Write prev_unfiltered_size (VInt, inside the row body)
         encode_unsigned(prev_size, &mut self.buffer);
 
-        // Write rest of row body
-        self.buffer.extend_from_slice(&row_body);
+        // Write rest of row body (disjoint field borrow: buffer vs row_scratch)
+        self.buffer.extend_from_slice(&self.row_scratch);
 
         Ok((self.buffer.len() - start_len, cells_written))
     }
@@ -187,18 +189,28 @@ impl DataWriter {
     ///
     /// Similar to build_row_body but only processes static columns.
     ///
-    /// Returns the body bytes and the number of static cells (columns)
-    /// physically written (Issue #851, review). A static row tombstone writes no
-    /// cells (count 0); otherwise the count is sourced from `write_static_cells`.
+    /// Builds into the reusable `self.row_scratch` buffer (issue #1673, R2 — no
+    /// per-row throwaway `Vec`; the scratch is `clear()`ed here, retaining
+    /// capacity across rows, covering BOTH the normal static path AND the
+    /// early-return static-tombstone/empty-static path). The caller reads the body
+    /// from `self.row_scratch`.
+    ///
+    /// Returns the number of static cells (columns) physically written (Issue
+    /// #851, review). A static row tombstone writes no cells (count 0); otherwise
+    /// the count is sourced from `write_static_cells`.
     pub(super) fn build_static_row_body(
-        &self,
+        &mut self,
         static_ops: &[StaticMergedOp],
         liveness_ts: i64,
         ttl_seconds: Option<u32>,
         schema: &TableSchema,
         flags: u8,
-    ) -> Result<(Vec<u8>, u64)> {
-        let mut body = Vec::new();
+    ) -> Result<u64> {
+        // Take the scratch out of `self` so the `&self` cell/bitmap/schema helpers
+        // below can run while `&mut body` is held (see `build_merged_row_body`).
+        // Stored back at every return point, preserving capacity across rows.
+        let mut body = std::mem::take(&mut self.row_scratch);
+        body.clear();
 
         // Issue #2038 Scope B: capture "now" ONCE for this static row write and
         // share it with every expiring cell derived below (mirrors
@@ -295,8 +307,10 @@ impl DataWriter {
                 self.write_column_subset(&mut body, &static_columns, &empty_present)?;
             }
 
-            // No cells written for row tombstones
-            return Ok((body, 0));
+            // No cells written for row tombstones. Store the body back into the
+            // reusable scratch (empty-static/tombstone early-return path).
+            self.row_scratch = body;
+            return Ok(0);
         }
 
         // Write column bitmap (if NOT HAS_ALL_COLUMNS)
@@ -309,7 +323,9 @@ impl DataWriter {
         let cells_written =
             self.write_static_cells(&mut body, static_ops, liveness_ts, schema, now_seconds)?;
 
-        Ok((body, cells_written))
+        // Store the built body back into the reusable scratch (retains capacity).
+        self.row_scratch = body;
+        Ok(cells_written)
     }
 
     /// Write column bitmap for static columns only.

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_1.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_1.rs
@@ -339,7 +339,7 @@ fn test_delta_encoding_unsigned_vint_fix_644() {
     stats.min_ttl = 3_600;
     stats.min_local_deletion_time = 0;
 
-    let writer = DataWriter::new(stats.clone());
+    let mut writer = DataWriter::new(stats.clone());
     let schema = create_test_schema();
 
     let table_id = TableId::new("test_ks", "test_table");
@@ -393,7 +393,7 @@ fn test_delta_encoding() {
     stats.min_timestamp = 1000000;
     stats.min_ttl = 3600;
 
-    let writer = DataWriter::new(stats.clone());
+    let mut writer = DataWriter::new(stats.clone());
     let schema = create_test_schema();
 
     let table_id = TableId::new("test_ks", "test_table");

--- a/cqlite-core/tests/test_issue_1673_row_scratch_allocs.rs
+++ b/cqlite-core/tests/test_issue_1673_row_scratch_allocs.rs
@@ -1,0 +1,319 @@
+//! Allocation regression guard for Issue #1673 (Epic R, finding R2).
+//!
+//! Before R2, EVERY row written by `DataWriter` allocated **two throwaway
+//! `Vec`s**:
+//!   1. a per-row body `Vec` (`build_merged_row_body` / `build_static_row_body`
+//!      returned a fresh `Vec<u8>`), then copied into `self.buffer`; and
+//!   2. a gratuitous size-VInt `Vec` (`row_size_buf`) holding 1–9 bytes, also
+//!      copied into `self.buffer`.
+//!
+//! R2 replaces (1) with a reusable `row_scratch` buffer on the writer (cleared,
+//! not reallocated, per row) and (2) with a direct `encode_unsigned(_, &mut
+//! self.buffer)`. After warmup neither the row body nor the size VInt allocates.
+//!
+//! ## How the guard isolates exactly those two allocations
+//!
+//! Both throwaway buffers are **freshly-empty `Vec<u8>`s**. A `Vec<u8>`'s FIRST
+//! growth always allocates `RawVec::MIN_NON_ZERO_CAP == 8` bytes (the minimum
+//! non-zero capacity for a 1-byte element type), regardless of the final body
+//! size — a body larger than 8 bytes reallocates 8→16→… afterward, but its FIRST
+//! allocation is always exactly 8. So on `main` each written row produces two
+//! extra 8-byte allocations (body Vec + `row_size_buf`) that R2 removes.
+//!
+//! After R2 the reused `row_scratch` is already grown past 8 after the first row,
+//! and `self.buffer` grows at power-of-two sizes far above 8, so neither the body
+//! nor the size VInt allocates 8 bytes per row anymore. The merge path's
+//! `HashMap`/`Vec<MergedOp>` allocations are larger than 8 bytes (and, for a
+//! pure-PK row, are never created), so they do not pollute the 8-byte count.
+//!
+//! To cancel one-time warmup + fixed per-writer overhead the guard measures the
+//! **slope** of 8-byte allocations across two sizes (the #1046 rigorous form):
+//!   * regular path — one partition, M pure-PK-insert clustering rows, M ∈ {64, 256};
+//!   * static path  — P static-only partitions (one static row each), P ∈ {32, 128}.
+//!
+//! Measured (Rust 1.88, this repo):
+//!   * regular: `main` slope 576 (≈3 eight-byte allocs/row), post-R2 192 (≈1/row);
+//!   * static:  `main` slope 288 (≈3/static-row),            post-R2 96 (≈1/row).
+//!
+//! Each path retains ONE pre-existing per-row 8-byte allocation that R2 does not
+//! touch (an incidental writer-path `Vec<u8>` unrelated to the row body/size — the
+//! regular residual is the clustering-prefix comparator path). The R2 signal is
+//! the DROP of exactly the two removed buffers: 576→192 (−2/row) on the regular
+//! path and 288→96 (−2/row) on the static path. `K` is set at the midpoint of the
+//! `main` and post-R2 slopes on each path, so `main` FAILs and post-R2 PASSes with
+//! a wide margin, and re-introducing either throwaway buffer trips the guard.
+//!
+//! Single `#[test]` in its own binary so the process-global counter observes only
+//! this thread's allocations (regular then static, measured sequentially).
+
+#![cfg(feature = "write-support")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::writer::SSTableWriter;
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+struct CountingAlloc;
+
+/// Total allocations in the counting window.
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+/// Allocations/reallocations of EXACTLY 8 bytes — a freshly-empty `Vec<u8>`'s
+/// first growth. On `main` this includes the per-row body Vec + `row_size_buf`
+/// pair (see module docs); R2 removes both, dropping the per-row count by 2.
+static ALLOCS_8B: AtomicUsize = AtomicUsize::new(0);
+static COUNTING: AtomicBool = AtomicBool::new(false);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            if layout.size() == 8 {
+                ALLOCS_8B.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            if new_size == 8 {
+                ALLOCS_8B.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+const KEYSPACE: &str = "issue1673_ks";
+const TABLE: &str = "t";
+
+/// `pk int` partition key + `ck int` clustering key + one regular `v int`.
+fn regular_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "v".to_string(),
+                data_type: "int".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// `pk int` partition key + one static `s int` (no clustering).
+fn static_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "s".to_string(),
+                data_type: "int".to_string(),
+                nullable: true,
+                default: None,
+                is_static: true,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Count total + 8-byte allocations while writing ONE partition of `m`
+/// pure-primary-key-insert clustering rows (empty ops → a row marker, no cells,
+/// tiny body). Everything is built before the counting window.
+fn regular_allocs(m: i32) -> (usize, usize) {
+    let dir = TempDir::new().expect("temp dir");
+    let schema = regular_schema();
+    let mut writer = SSTableWriter::new(dir.path().to_path_buf(), 1, &schema).expect("writer");
+
+    let mutations: Vec<Mutation> = (0..m)
+        .map(|i| {
+            Mutation::new(
+                TableId::new(KEYSPACE, TABLE),
+                PartitionKey::single("pk", Value::Integer(1)),
+                Some(ClusteringKey::single("ck", Value::Integer(i))),
+                Vec::new(), // pure-PK insert: row marker only, no cells
+                1_000_000,
+                None,
+            )
+        })
+        .collect();
+    let key = mutations[0].decorated_key(&schema).expect("decorated key");
+
+    let total_base = ALLOCS.load(Ordering::Relaxed);
+    let eight_base = ALLOCS_8B.load(Ordering::Relaxed);
+    COUNTING.store(true, Ordering::Relaxed);
+    writer.write_partition(key, mutations).expect("write");
+    COUNTING.store(false, Ordering::Relaxed);
+
+    (
+        ALLOCS.load(Ordering::Relaxed) - total_base,
+        ALLOCS_8B.load(Ordering::Relaxed) - eight_base,
+    )
+}
+
+/// Count total + 8-byte allocations while writing `p` static-only partitions
+/// (one static row per partition, no clustering rows). Everything is built
+/// before the counting window.
+fn static_allocs(p: i32) -> (usize, usize) {
+    let dir = TempDir::new().expect("temp dir");
+    let schema = static_schema();
+    let mut writer = SSTableWriter::new(dir.path().to_path_buf(), 1, &schema).expect("writer");
+
+    let mut partitions: Vec<(_, Vec<Mutation>)> = (0..p)
+        .map(|i| {
+            let mutation = Mutation::new(
+                TableId::new(KEYSPACE, TABLE),
+                PartitionKey::single("pk", Value::Integer(i)),
+                None,
+                vec![CellOperation::Write {
+                    column: "s".to_string(),
+                    value: Value::Integer(i),
+                }],
+                1_000_000,
+                None,
+            );
+            let key = mutation.decorated_key(&schema).expect("decorated key");
+            (key, vec![mutation])
+        })
+        .collect();
+    // `write_partition` requires partitions in token order.
+    partitions.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let total_base = ALLOCS.load(Ordering::Relaxed);
+    let eight_base = ALLOCS_8B.load(Ordering::Relaxed);
+    COUNTING.store(true, Ordering::Relaxed);
+    for (key, mutations) in partitions {
+        writer.write_partition(key, mutations).expect("write");
+    }
+    COUNTING.store(false, Ordering::Relaxed);
+
+    (
+        ALLOCS.load(Ordering::Relaxed) - total_base,
+        ALLOCS_8B.load(Ordering::Relaxed) - eight_base,
+    )
+}
+
+#[test]
+fn row_scratch_kills_per_row_body_and_size_allocs() {
+    // ---- Regular clustering-row path ----
+    const M1: i32 = 64;
+    const M2: i32 = 256;
+    let (reg_total_1, reg_8b_1) = regular_allocs(M1);
+    let (_reg_total_2, reg_8b_2) = regular_allocs(M2);
+    let reg_slope_8b = reg_8b_2.saturating_sub(reg_8b_1);
+
+    eprintln!(
+        "#1673 regular: M1={M1} 8b={reg_8b_1} total={reg_total_1} | M2={M2} 8b={reg_8b_2} | \
+         8b-slope={reg_slope_8b}"
+    );
+
+    // Non-vacuous: writing rows must actually allocate SOMETHING.
+    assert!(
+        reg_total_1 > 0,
+        "#1673: writing {M1} clustering rows allocated nothing — measurement is vacuous"
+    );
+
+    // Each row allocates a body Vec + a `row_size_buf` (two 8-byte first-growths)
+    // on `main` PLUS one pre-existing per-row 8-byte alloc R2 does not touch, so
+    // the measured slope is ~576 (3/row). R2 removes the two throwaway buffers,
+    // dropping it to ~192 (1/row). K is the midpoint (384): `main` (576) FAILs,
+    // post-R2 (192) PASSes, each with a ~192 margin.
+    const K_REGULAR: usize = 384;
+    assert!(
+        reg_slope_8b <= K_REGULAR,
+        "#1673: regular-row 8-byte alloc slope regressed — {M1}->{M2} rows added \
+         {reg_slope_8b} eight-byte allocations (> K={K_REGULAR}). `main` measures ~576 \
+         (per-row body Vec + row_size_buf + 1 pre-existing); after R2 the reusable \
+         row_scratch + in-place size VInt remove the two throwaway buffers (~192)."
+    );
+
+    // ---- Static-row path (companion) ----
+    const P1: i32 = 32;
+    const P2: i32 = 128;
+    let (stat_total_1, stat_8b_1) = static_allocs(P1);
+    let (_stat_total_2, stat_8b_2) = static_allocs(P2);
+    let stat_slope_8b = stat_8b_2.saturating_sub(stat_8b_1);
+
+    eprintln!(
+        "#1673 static: P1={P1} 8b={stat_8b_1} total={stat_total_1} | P2={P2} 8b={stat_8b_2} | \
+         8b-slope={stat_slope_8b}"
+    );
+
+    assert!(
+        stat_total_1 > 0,
+        "#1673: writing {P1} static partitions allocated nothing — measurement is vacuous"
+    );
+
+    // Same shape as the regular path: `main` measures ~288 (3/static-row: body
+    // Vec + row_size_buf + 1 pre-existing); R2 drops it to ~96 (1/row). K is the
+    // midpoint (192): `main` (288) FAILs, post-R2 (96) PASSes, ~96 margin each.
+    const K_STATIC: usize = 192;
+    assert!(
+        stat_slope_8b <= K_STATIC,
+        "#1673: static-row 8-byte alloc slope regressed — {P1}->{P2} partitions added \
+         {stat_slope_8b} eight-byte allocations (> K={K_STATIC}). `main` measures ~288 \
+         (per-static-row body Vec + row_size_buf + 1 pre-existing); after R2 the reusable \
+         row_scratch + in-place size VInt remove the two throwaway buffers (~96)."
+    );
+}


### PR DESCRIPTION
## Summary

Epic R (serializer allocation discipline), finding **R2** — deletes the two per-row throwaway `Vec`s in the Data.db write path:

1. **`row_size_buf`** — the row-size VInt is now encoded straight into `self.buffer` via `encode_unsigned(row_body_size, &mut self.buffer)` in both `rows.rs` and `static_rows.rs`. The body length is known from `row_scratch` before the body is appended, so the wire order (row_size VInt → prev_unfiltered_size VInt → body) is byte-identical.
2. **Per-row body `Vec`** — `build_merged_row_body` / `build_static_row_body` now build into a reusable `DataWriter::row_scratch` field (`clear()`ed per row → retains capacity, no realloc after warmup) instead of allocating and returning a fresh `Vec`. Signatures change from `&self -> Result<(Vec<u8>, usize)>` to `&mut self -> Result<usize>`; the scratch is taken out with `std::mem::take` so the `&self` cell/bitmap helpers can still borrow, then appended to `self.buffer` via a disjoint field borrow. Covers the **regular**, **static**, and **empty-static (tombstone)** paths.

Zero emitted-byte change — row-size VInt, `prev_unfiltered_size`, and body framing are byte-identical.

## Allocation impact (TDD guard `test_issue_1673_row_scratch_allocs`)

Counts 8-byte allocations (a fresh `Vec<u8>`'s first growth) via the #1046 slope method across two sizes:

| path | main slope | post-R2 slope | K (midpoint) |
|------|-----------|---------------|--------------|
| regular (M 64→256 rows) | 576 (~3/row) | 192 (~1/row) | 384 |
| static (P 32→128 parts) | 288 (~3/row) | 96 (~1/row) | 192 |

The **−2/row drop on both paths** is exactly the removed body Vec + `row_size_buf`. The retained ~1/row is a pre-existing writer-path `Vec<u8>` (clustering-prefix comparator) that R2 does not touch. Proven **red on main → green after fix** (main 576 > K=384 and 288 > K=192 both FAIL; post-fix 192/96 PASS).

## Validation

- Lite gate **PASS** (commit `5f74146`): file-size PASS, fmt PASS, clippy PASS (`-D warnings`), scoped-tests PASS.
- Byte-parity goldens green: `issue_1074_static_write_parity` (7), `issue_1190_write_load_byte_parity` (3); 240 `data_writer` unit tests pass.
- No `unwrap()`/`expect()` in library code.

## roborev (review-first, claude-code/opus) — 2 Low findings, both non-blocking (nits for the closer)

1. Alloc guard leans on `Vec<u8>` first-growth == 8 bytes (pinned to Rust 1.88 in the docstring; wide midpoint margins). Intentional/documented — a future toolchain bump means "re-measure the 4 constants," not "regression."
2. On an error `?` early-return inside the builders, `row_scratch` capacity is lost (dropped, not stored back). **Not a correctness bug** (next call `clear()`s fresh); only a lost-optimization if a writer is reused after a recoverable `Err`.

Closes #1673
