### PR TITLE
perf(query): fan out WRITETIME/TTL IN metadata reads to targeted lookups (#1916)

### DIFF
--- a/cqlite-core/src/query/access_path.rs
+++ b/cqlite-core/src/query/access_path.rs
@@ -32,10 +32,10 @@
 //! # Scope (per #960)
 //!
 //! #960 only *exposes and reports* the path; it does not make every path
-//! targeted (that is #962). The reported path must be **honest** — if the
-//! WRITETIME/TTL metadata path still full-scans today, it reports
-//! [`AccessPath::FullScan`], and a test pins that current reality so #962 can
-//! later flip it.
+//! targeted (that is #962 for the single-key metadata lookup and #1916 for the
+//! metadata `IN (...)` fan-out). The reported path must be **honest** — a metadata
+//! projection with no usable restriction still reports an honest
+//! [`AccessPath::FallbackFullScan`], never a faked targeted path.
 
 use arc_swap::ArcSwapOption;
 use serde::{Deserialize, Serialize};
@@ -73,8 +73,8 @@ pub enum AccessPath {
     ClusteringSlice,
 
     /// The WRITETIME/TTL metadata-projection path resolved a single fully
-    /// constrained partition via a targeted lookup. Reserved for #962 — the
-    /// metadata path full-scans today (see [`FallbackReason::MetadataScanPath`]).
+    /// constrained partition via a targeted lookup (#962). The `WHERE pk IN (...)`
+    /// metadata fan-out reports [`Self::MultiPartitionLookup`] instead (#1916).
     MetadataPartitionLookup,
 
     /// The streaming SELECT path served a single fully-constrained partition via a
@@ -154,9 +154,12 @@ pub enum FallbackReason {
     /// on-disk key form (e.g. a type mismatch). A full scan is the safe fallback.
     PartitionKeyEncodingFailed,
 
-    /// The WRITETIME/TTL metadata-projection path always full-scans today; it
-    /// does not yet route through a partition-targeted lookup. Pinned by tests
-    /// so #962 can flip it to [`AccessPath::MetadataPartitionLookup`].
+    /// A WRITETIME/TTL metadata projection with NO usable partition-key
+    /// restriction full-scans (there is no key to target). A fully-constrained
+    /// `WHERE pk = ?` now routes through [`AccessPath::MetadataPartitionLookup`]
+    /// (#962) and `WHERE pk IN (...)` fans out to [`AccessPath::MultiPartitionLookup`]
+    /// (#1916); this reason is reserved for the genuinely unclassifiable metadata
+    /// scan that remains.
     MetadataScanPath,
 
     /// The legacy `QueryExecutor` issues an unconditional `storage.scan`; it does

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -19,8 +19,9 @@ use super::{
     apply_forcing, build_row_from_scan_cached, classify_partition_lookup,
     collect_capped_materialized, column_info_from_type_str, full_forbids_schemaless_seek,
     honest_targeted_path, parse_table_id, point_forbids_fallback, point_requires_engaged,
-    project_expr_reshapes_row, scan_pushdown_cap, select_has_writetime_ttl, sort_rows_by_token,
-    validate_token_predicates, ForcedPlan, PartitionLookupOutcome, SSTablePredicate,
+    project_expr_reshapes_row, scan_pushdown_cap, select_has_writetime_ttl,
+    sort_metadata_rows_by_token, sort_rows_by_token, validate_token_predicates, ForcedPlan,
+    PartitionLookupOutcome, SSTablePredicate,
 };
 use super::{
     AccessPath, ColumnInfo, ExecutionContext, ExecutionStep, FallbackReason, OptimizedQueryPlan,
@@ -557,17 +558,60 @@ impl SelectExecutor {
                     crate::query::access_path::record(path);
                     rows
                 }
-                // Issue #962: `WHERE pk IN (...)` on the metadata path is NOT yet
-                // fanned out to N targeted metadata lookups; it still full-scans.
-                // Report that honestly (MetadataScanPath) rather than faking a
-                // targeted path — the IN-metadata fan-out is a documented follow-up.
-                // Issue #1918: under `point` this unwired targeted surface is a
-                // non-targeted execution → fail closed (a classification `Fallback`
-                // already errored up front in `apply_forcing`, so only a
-                // `MultiTargeted` reaches here under `point`).
-                ForcedPlan::Proceed(
-                    PartitionLookupOutcome::MultiTargeted(_) | PartitionLookupOutcome::Fallback(_),
-                ) => {
+                // Issue #1916: `WHERE pk IN (...)` on the metadata path is the union
+                // of N independent partition-targeted metadata lookups, each of which
+                // prunes SSTables (bloom/BTI) before decoding — mirroring the plain
+                // `MultiTargeted` fan-out (see the non-metadata arm below). #962
+                // shipped the single-key metadata fast path and left this fan-out as a
+                // documented follow-up; this arm is that follow-up. Each per-key call
+                // goes through the SAME single/multi-generation reconciliation the
+                // single-key `Targeted` arm uses (#1741), so the merged WRITETIME/TTL
+                // values are byte-identical to the old full-scan result.
+                //
+                // Epic #951 (honest paths): on the `tombstones` build each lookup
+                // full-scans + retains with NO prune (`engaged == false`); report
+                // `MultiPartitionLookup` only when the lookups actually pruned, else
+                // the honest `TombstonesBuildNoPrune` fallback. Rows are unchanged.
+                ForcedPlan::Proceed(PartitionLookupOutcome::MultiTargeted(pk_keys)) => {
+                    tracing::debug!(
+                        "SSTableScan(metadata): multi-partition lookup ({} keys) for \"{}\"",
+                        pk_keys.len(),
+                        table
+                    );
+                    let mut combined = Vec::new();
+                    let mut all_engaged = true;
+                    for pk_bytes in &pk_keys {
+                        let (rows, engaged) = self
+                            .storage
+                            .scan_partition_with_cell_metadata(table, pk_bytes, schema_opt)
+                            .await?;
+                        all_engaged &= engaged;
+                        combined.extend(rows);
+                    }
+                    // Issue #1918: `point` fails closed when the fan-out did not prune
+                    // (tombstones build) rather than silently full-scanning.
+                    point_requires_engaged(
+                        mode,
+                        all_engaged,
+                        FallbackReason::TombstonesBuildNoPrune,
+                    )?;
+                    let path = honest_targeted_path(AccessPath::MultiPartitionLookup, all_engaged);
+                    context.access_path = Some(path.clone());
+                    crate::query::access_path::record(path);
+                    // Order the union with the IDENTICAL token-then-raw-bytes rule the
+                    // plain `MultiTargeted` arm uses (`sort_rows_by_token`), so the
+                    // metadata IN result equals a full scan filtered to these keys.
+                    sort_metadata_rows_by_token(&mut combined);
+                    combined
+                }
+                // A genuinely unclassifiable metadata projection (no usable
+                // restriction) still full-scans; report that honestly
+                // (MetadataScanPath) rather than faking a targeted path.
+                // Issue #1918: under `point` a classification `Fallback` already
+                // errored up front in `apply_forcing`, so this arm is reached only
+                // under `auto`/`full`; `point_forbids_fallback` keeps the fail-closed
+                // contract explicit here.
+                ForcedPlan::Proceed(PartitionLookupOutcome::Fallback(_)) => {
                     point_forbids_fallback(mode, FallbackReason::MetadataScanPath)?;
                     let metadata_path = AccessPath::FallbackFullScan {
                         reason: FallbackReason::MetadataScanPath,

--- a/cqlite-core/src/query/select_executor/forcing.rs
+++ b/cqlite-core/src/query/select_executor/forcing.rs
@@ -145,8 +145,9 @@ pub(super) fn point_requires_engaged(
 }
 
 /// Under `Point`, fail closed when a call site is about to run a NON-targeted
-/// execution its surface cannot serve as a genuine partition lookup (e.g. the
-/// metadata `IN` fan-out, which still full-scans). A no-op in every other mode.
+/// execution its surface cannot serve as a genuine partition lookup (e.g. a
+/// WRITETIME/TTL metadata projection with no usable partition-key restriction,
+/// which full-scans). A no-op in every other mode.
 pub(super) fn point_forbids_fallback(mode: ReadPathMode, reason: FallbackReason) -> Result<()> {
     if mode == ReadPathMode::Point {
         return Err(Error::forced_read_path_unavailable("point", reason.label()));

--- a/cqlite-core/src/query/select_executor/lookup.rs
+++ b/cqlite-core/src/query/select_executor/lookup.rs
@@ -367,6 +367,25 @@ pub(super) fn sort_rows_by_token(rows: &mut [(RowKey, ScanRow)]) {
     });
 }
 
+/// The metadata-carrying analogue of [`sort_rows_by_token`] for the WRITETIME/TTL
+/// `WHERE pk IN (...)` fan-out (Issue #1916). Uses the IDENTICAL token-then-raw-bytes
+/// ordering (`cmp_partition_keys_by_token`) so the metadata IN union is byte-identical
+/// to the plain `MultiTargeted` union and to a full scan filtered to the same keys —
+/// no new ordering is invented. The extra per-cell metadata element rides along
+/// untouched; the *stable* sort keeps each partition's clustering order intact
+/// (one key's rows arrive contiguously from a single `scan_partition_with_cell_metadata`).
+pub(super) fn sort_metadata_rows_by_token(
+    rows: &mut [(
+        RowKey,
+        ScanRow,
+        std::collections::HashMap<String, crate::types::CellWriteMetadata>,
+    )],
+) {
+    rows.sort_by(|a, b| {
+        crate::util::cassandra_murmur3::cmp_partition_keys_by_token(&a.0 .0, &b.0 .0)
+    });
+}
+
 /// True when `ORDER BY` is a single item on the FIRST clustering column whose
 /// requested direction is the REVERSE of that column's stored clustering order
 /// (Issue #1184) — i.e. a true reverse partition traversal is needed. A query that

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -83,7 +83,8 @@ use forcing::{
 };
 use limit_pushdown::{collect_capped_materialized, scan_pushdown_cap};
 use lookup::{
-    classify_partition_lookup, honest_targeted_path, sort_rows_by_token, PartitionLookupOutcome,
+    classify_partition_lookup, honest_targeted_path, sort_metadata_rows_by_token,
+    sort_rows_by_token, PartitionLookupOutcome,
 };
 use row_build::{column_info_from_type_str, parse_cql_type_str, parse_table_id};
 use value_ops::{compare_values_ordering, const_arithmetic, eval_arithmetic};

--- a/cqlite-core/tests/issue_960_access_path_signal.rs
+++ b/cqlite-core/tests/issue_960_access_path_signal.rs
@@ -134,6 +134,26 @@ async fn one_present_uuid(db: &Database) -> Option<[u8; 16]> {
     uuid_value(first, "id")
 }
 
+/// Learn two DISTINCT real UUID partition keys, for the `WHERE pk IN (...)` cases.
+async fn two_present_uuids(db: &Database) -> Option<([u8; 16], [u8; 16])> {
+    let full = db
+        .execute(&format!("SELECT id FROM {QUALIFIED_TABLE} LIMIT 8"))
+        .await
+        .ok()?;
+    let mut seen: Vec<[u8; 16]> = Vec::new();
+    for row in &full.rows {
+        if let Some(id) = uuid_value(row, "id") {
+            if !seen.contains(&id) {
+                seen.push(id);
+            }
+        }
+        if seen.len() == 2 {
+            return Some((seen[0], seen[1]));
+        }
+    }
+    None
+}
+
 // ---------------------------------------------------------------------------
 // 1. WHERE pk = <literal> reports PartitionLookup (NOT a full scan).
 // ---------------------------------------------------------------------------
@@ -278,6 +298,55 @@ async fn writetime_metadata_path_reports_metadata_partition_lookup() {
     assert!(
         !result.metadata.access_path.as_ref().unwrap().is_full_scan(),
         "a metadata partition-targeted lookup must NOT be classified as a full scan",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3b. Issue #1916: the WRITETIME/TTL metadata `WHERE pk IN (...)` projection is
+//     now a partition-targeted fan-out (mirroring the plain MultiTargeted union),
+//     NOT a full scan. It must report MultiPartitionLookup — replacing the old
+//     MetadataScanPath fallback for this case.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn writetime_metadata_in_reports_multi_partition_lookup() {
+    let _probe_guard = PROBE_LOCK.lock().await;
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+    let Some((a, b)) = two_present_uuids(&db).await else {
+        eprintln!("Skipping: simple_table has < 2 distinct rows (Data.db not fetched?)");
+        return;
+    };
+    let (la, lb) = (uuid_to_literal(&a), uuid_to_literal(&b));
+
+    access_path::reset();
+    let result = db
+        .execute(&format!(
+            "SELECT id, WRITETIME(name) FROM {QUALIFIED_TABLE} WHERE id IN ({la}, {lb})"
+        ))
+        .await
+        .expect("WRITETIME metadata IN query must succeed");
+
+    assert_eq!(
+        result.metadata.access_path,
+        Some(AccessPath::MultiPartitionLookup),
+        "Issue #1916: a WHERE pk IN (..) WRITETIME/TTL projection must report \
+         MultiPartitionLookup (the metadata IN fan-out), not the MetadataScanPath full-scan \
+         fallback. Got {:?}",
+        result.metadata.access_path
+    );
+    assert_eq!(access_path::last(), Some(AccessPath::MultiPartitionLookup),);
+    assert_ne!(
+        result.metadata.access_path,
+        Some(AccessPath::FallbackFullScan {
+            reason: FallbackReason::MetadataScanPath,
+        }),
+        "Issue #1916: the metadata IN case must no longer record MetadataScanPath",
     );
 }
 

--- a/cqlite-core/tests/issue_962_metadata_partition_lookup_parity.rs
+++ b/cqlite-core/tests/issue_962_metadata_partition_lookup_parity.rs
@@ -461,3 +461,58 @@ async fn metadata_in_fanout_touches_bounded_sstables_not_n() {
         targeted.rows.len()
     );
 }
+
+// ---------------------------------------------------------------------------
+// 5. Issue #1916: the TTL() projection triggers the SAME metadata IN fan-out as
+//    WRITETIME() (the metadata path is projection-agnostic). Assert the access
+//    path and byte-identity vs the full-scan-filtered TTL result, so the TTL side
+//    of the surface has explicit wiring evidence too.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn metadata_in_fanout_ttl_matches_full_scan_filtered() {
+    let _guard = PROBE_LOCK.lock().await;
+    let (db, _target_id, _temp) = open_fixture().await;
+    let (k1, k2) = two_target_ids();
+
+    access_path::reset();
+    let targeted = db
+        .execute(&format!(
+            "SELECT id, TTL(name) AS t FROM {KS}.{TBL} WHERE id IN ({k1}, {k2})"
+        ))
+        .await
+        .expect("metadata TTL IN fan-out query must succeed");
+
+    assert_eq!(
+        targeted.metadata.access_path,
+        Some(AccessPath::MultiPartitionLookup),
+        "Issue #1916: a TTL() WHERE id IN (..) query must also report MultiPartitionLookup, got {:?}",
+        targeted.metadata.access_path
+    );
+
+    let full = db
+        .execute(&format!("SELECT id, TTL(name) AS t FROM {KS}.{TBL}"))
+        .await
+        .expect("full metadata scan");
+
+    // The TTL projected column (Value, incl. null for a cell written with no TTL)
+    // must be byte-identical, in order, to the full-scan-filtered result.
+    let oracle: Vec<(Option<i32>, Option<Value>)> = full
+        .rows
+        .iter()
+        .filter(|r| matches!(id_of(r), Some(v) if v == k1 || v == k2))
+        .map(|r| (id_of(r), r.values.get("t").cloned()))
+        .collect();
+    let got: Vec<(Option<i32>, Option<Value>)> = targeted
+        .rows
+        .iter()
+        .map(|r| (id_of(r), r.values.get("t").cloned()))
+        .collect();
+
+    assert_eq!(got.len(), 2, "expected exactly the two targeted partitions");
+    assert_eq!(
+        got, oracle,
+        "Issue #1916: the metadata TTL IN fan-out result (rows + TTL, in order) must be \
+         byte-identical to the full-scan-filtered result",
+    );
+}

--- a/cqlite-core/tests/issue_962_metadata_partition_lookup_parity.rs
+++ b/cqlite-core/tests/issue_962_metadata_partition_lookup_parity.rs
@@ -43,7 +43,7 @@
 use std::sync::Arc;
 
 use cqlite_core::ingestion::{ingest, IngestionConfig};
-use cqlite_core::query::access_path::{self, AccessPath};
+use cqlite_core::query::access_path::{self, AccessPath, FallbackReason};
 use cqlite_core::query::result::QueryRow;
 use cqlite_core::storage::sstable::work_counters;
 use cqlite_core::storage::write_engine::{
@@ -175,6 +175,21 @@ fn writetime_of(row: &QueryRow, alias: &str) -> Option<i64> {
         Some(Value::BigInt(v)) => Some(*v),
         _ => None,
     }
+}
+
+fn id_of(row: &QueryRow) -> Option<i32> {
+    match row.values.get("id") {
+        Some(Value::Integer(v)) => Some(*v),
+        _ => None,
+    }
+}
+
+/// Two ids that each live in exactly one (distinct) generation of the fixture
+/// (`id = g*100 + 1`), for the `WHERE id IN (k1, k2)` fan-out. Generation 1 and
+/// generation `N-2`, so both are single-generation keys with a real holder.
+fn two_target_ids() -> (i32, i32) {
+    let gen_id = |g: i32| g * 100 + 1;
+    (gen_id(1), gen_id(N_GENERATIONS as i32 - 2))
 }
 
 // ---------------------------------------------------------------------------
@@ -313,5 +328,136 @@ async fn metadata_unrestricted_reports_full_scan_fallback() {
     assert!(
         path.is_full_scan(),
         "Issue #962: an unrestricted WRITETIME projection must report a full scan, got {path:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Issue #1916: a WRITETIME/TTL `WHERE pk IN (k1, k2)` projection fans out to
+//    N partition-targeted metadata lookups (mirroring the plain `MultiTargeted`
+//    fan-out) instead of full-scanning. It must:
+//      (a) report AccessPath::MultiPartitionLookup — NOT FallbackFullScan
+//          { MetadataScanPath } (the pre-#1916 behaviour), and
+//      (b) return rows + WRITETIME values byte-identical, IN THE SAME ORDER, to a
+//          full metadata scan filtered to the same two keys.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn metadata_in_fanout_matches_full_scan_filtered() {
+    let _guard = PROBE_LOCK.lock().await;
+    let (db, _target_id, _temp) = open_fixture().await;
+    let (k1, k2) = two_target_ids();
+
+    access_path::reset();
+    let targeted = db
+        .execute(&format!(
+            "SELECT id, WRITETIME(name) AS wt FROM {KS}.{TBL} WHERE id IN ({k1}, {k2})"
+        ))
+        .await
+        .expect("metadata IN fan-out query must succeed");
+
+    // (a) The IN fan-out is the metadata analogue of the plain MultiTargeted
+    // union: the targeted multi-partition lookup, NOT the old MetadataScanPath
+    // full-scan fallback.
+    assert_eq!(
+        targeted.metadata.access_path,
+        Some(AccessPath::MultiPartitionLookup),
+        "Issue #1916: a WHERE id IN (..) WRITETIME query must report \
+         MultiPartitionLookup, got {:?}",
+        targeted.metadata.access_path
+    );
+    assert_eq!(access_path::last(), Some(AccessPath::MultiPartitionLookup));
+    assert_ne!(
+        targeted.metadata.access_path,
+        Some(AccessPath::FallbackFullScan {
+            reason: FallbackReason::MetadataScanPath,
+        }),
+        "Issue #1916: the metadata IN case must NOT record the MetadataScanPath fallback",
+    );
+
+    // (b) Byte-identical rows + WRITETIME values, in identical order, vs a full
+    // metadata scan filtered to the same keys (the correctness oracle).
+    let full = db
+        .execute(&format!("SELECT id, WRITETIME(name) AS wt FROM {KS}.{TBL}"))
+        .await
+        .expect("full metadata scan");
+    assert!(
+        full.metadata
+            .access_path
+            .as_ref()
+            .map(|p| p.is_full_scan())
+            .unwrap_or(false),
+        "the unrestricted WRITETIME scan must report a full scan, got {:?}",
+        full.metadata.access_path
+    );
+
+    let oracle: Vec<(Option<i32>, Option<i64>)> = full
+        .rows
+        .iter()
+        .filter(|r| matches!(id_of(r), Some(v) if v == k1 || v == k2))
+        .map(|r| (id_of(r), writetime_of(r, "wt")))
+        .collect();
+    let got: Vec<(Option<i32>, Option<i64>)> = targeted
+        .rows
+        .iter()
+        .map(|r| (id_of(r), writetime_of(r, "wt")))
+        .collect();
+
+    assert_eq!(got.len(), 2, "expected exactly the two targeted partitions");
+    assert_eq!(
+        got, oracle,
+        "Issue #1916: the metadata IN fan-out result (rows + WRITETIME, in order) \
+         must be byte-identical to the full-scan-filtered result",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn metadata_in_fanout_touches_bounded_sstables_not_n() {
+    let _guard = PROBE_LOCK.lock().await;
+    let (db, _target_id, _temp) = open_fixture().await;
+    let (k1, k2) = two_target_ids();
+
+    work_counters::reset();
+    access_path::reset();
+    let targeted = db
+        .execute(&format!(
+            "SELECT id, WRITETIME(name) FROM {KS}.{TBL} WHERE id IN ({k1}, {k2})"
+        ))
+        .await
+        .expect("metadata IN fan-out query must succeed");
+
+    // Signal 1: the executor took the partition-targeted metadata fan-out (#1916),
+    // not the old MetadataScanPath full scan.
+    assert_eq!(
+        targeted.metadata.access_path,
+        Some(AccessPath::MultiPartitionLookup),
+        "Issue #1916: a WHERE id IN (..) WRITETIME query must report MultiPartitionLookup, got {:?}",
+        targeted.metadata.access_path
+    );
+
+    // Signal 2: the work counter proves O(candidates x keys), not O(N). A
+    // regression to the full metadata scan increments the counter 0 (the full
+    // scan path never touches it) OR opens all N — either way the two bounds
+    // below (>= keys AND <= keys*MAX) fail. #958 rationale for the FP allowance.
+    const KEYS: u64 = 2;
+    let scanned = work_counters::sstables_scanned();
+    assert!(
+        scanned >= KEYS,
+        "Issue #1916: the IN fan-out must parse at least one candidate per key ({KEYS}), got \
+         {scanned}. A count of 0 means the metadata IN path did NOT fan out to targeted lookups \
+         (it full-scanned, which never touches the work counter).",
+    );
+    assert!(
+        scanned <= KEYS * MAX_CANDIDATES_SCANNED,
+        "Issue #1916: a {KEYS}-key WRITETIME IN read over {N_GENERATIONS} SSTables must parse at \
+         most {} candidate(s) (bloom false-positive allowance), but parsed {scanned}. A count near \
+         {N_GENERATIONS} means the metadata IN path regressed to a full scan.",
+        KEYS * MAX_CANDIDATES_SCANNED,
+    );
+
+    assert_eq!(
+        targeted.rows.len(),
+        2,
+        "expected exactly the two targeted partitions, got {}",
+        targeted.rows.len()
     );
 }


### PR DESCRIPTION
Closes #1916 (child of epic #1915).

## What

`SELECT WRITETIME(v)/TTL(v) ... WHERE pk IN (...)` previously abandoned the partition-lookup fast path and full-scanned, recorded honestly as `FallbackFullScan { MetadataScanPath }`. This wires the metadata `MultiTargeted` arm to fan out to N partition-targeted metadata lookups, mirroring the existing non-metadata `MultiTargeted` fan-out.

## Change (access-path only, no semantic change)

- `execute.rs`: split `MultiTargeted(keys)` out of the shared `MultiTargeted | Fallback` arm in the `include_cell_metadata` branch. It now loops the deduplicated keys, calls `Storage::scan_partition_with_cell_metadata` per key (the SAME single/multi-generation reconciliation the single-key `Targeted` arm uses, #1741), concatenates, and orders the union with the identical token-then-raw-bytes rule via a new `sort_metadata_rows_by_token` (shares `cmp_partition_keys_by_token` with `sort_rows_by_token`).
- Access path recorded as `honest_targeted_path(AccessPath::MultiPartitionLookup, all_engaged)` — the exact variant the non-metadata `MultiTargeted` arm records. The genuine `Fallback(_)` arm still records `MetadataScanPath`.
- `point` mode now fails closed via `point_requires_engaged` (matching the plain arm) instead of `point_forbids_fallback`, so a metadata IN point-read succeeds as a targeted lookup.
- Updated the "so #962 can flip it" pinning comments in `access_path.rs` and `forcing.rs`.

## Tests (TDD — verified red on `main` first)

- `issue_962_metadata_partition_lookup_parity.rs`: `WRITETIME()`/`TTL()` + `IN (k1,k2)` — rows + values byte-identical, in order, to the full-scan-filtered oracle; access path is `MultiPartitionLookup`, NOT `MetadataScanPath`; work-bound (`sstables_scanned` bounded by O(keys x candidates), not O(N)).
- `issue_960_access_path_signal.rs`: dataset-backed metadata `IN` now reports `MultiPartitionLookup`.

Both new IN tests fail on `main` with `FallbackFullScan { MetadataScanPath }` and pass on the branch.

## Notes

- `execute.rs`/`lookup.rs`/`mod.rs` were already over the 800-line campsite threshold before this change; a split is out of scope for a targeted access-path fix, so `CQLITE_ALLOW_FILE_GROWTH=1` was used (#1116).
- Lite gate PASS. roborev clean (no blockers; one Low TTL-coverage nit pre-empted by test 5, one Low point-mode-metadata-IN test nit deferred to the closer).