### PR TITLE
perf(writer): cache ordered column lists + per-column is_complex (#1674)

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/data_writer/column_cache.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/column_cache.rs
@@ -23,6 +23,12 @@ impl DataWriter {
     /// header and clustering prefix. Within the regular set, simple columns
     /// sort before complex columns, then by name. The order is served from the
     /// per-writer cache (issue #1674, R3), so no per-row sort runs.
+    ///
+    /// Test-only helper (issue #1674, R3): the per-row hot paths read the cached
+    /// indices directly (`cached_cols(...).regular`) to stay allocation-free
+    /// (issue #1673 ratchet); this `Vec<&Column>` form exists for order-assertion
+    /// tests (`scenarios_3`).
+    #[cfg(test)]
     pub(super) fn regular_columns<'a>(&self, schema: &'a TableSchema) -> Vec<&'a Column> {
         self.cached_cols(schema)
             .regular
@@ -32,6 +38,12 @@ impl DataWriter {
     }
 
     /// Get static columns from schema in Cassandra serialization-header order.
+    ///
+    /// Test-only helper (issue #1674, R3): per-row hot paths read the cached
+    /// indices directly (`cached_cols(...).static_`) to stay allocation-free
+    /// (issue #1673 ratchet); this `Vec<&Column>` form exists for order-assertion
+    /// tests (`scenarios_3`).
+    #[cfg(test)]
     pub(super) fn static_columns<'a>(&self, schema: &'a TableSchema) -> Vec<&'a Column> {
         self.cached_cols(schema)
             .static_

--- a/cqlite-core/src/storage/sstable/writer/data_writer/column_cache.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/column_cache.rs
@@ -73,9 +73,24 @@ impl DataWriter {
     /// (issue #1674, R3). The schema is fixed for the writer's lifetime, so this
     /// runs the filter + sort + `is_complex_column` classification exactly ONCE;
     /// every later row read is `O(C)` index resolution with no `to_lowercase`.
+    ///
+    /// Invariant: a `DataWriter` sees exactly ONE schema for its lifetime
+    /// (`SSTableWriter` owns one `schema` and threads it into every call). The
+    /// cache is built from the FIRST schema and reused; since `is_complex` /
+    /// index resolution below assumes the passed `schema` matches, the
+    /// `debug_assert` fails loudly in debug/test if a caller ever swaps schemas
+    /// (a differently-sized column list) rather than emitting wrong bytes.
     pub(super) fn cached_cols(&self, schema: &TableSchema) -> &OrderedCols {
-        self.column_cache
-            .get_or_init(|| Self::build_ordered_cols(schema))
+        let cols = self
+            .column_cache
+            .get_or_init(|| Self::build_ordered_cols(schema));
+        debug_assert_eq!(
+            cols.is_complex.len(),
+            schema.columns.len(),
+            "DataWriter column cache built from a different schema than now passed \
+             (one-schema-per-writer invariant, issue #1674)"
+        );
+        cols
     }
 
     /// Compute the ordered regular/static column index lists + per-column

--- a/cqlite-core/src/storage/sstable/writer/data_writer/column_cache.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/column_cache.rs
@@ -1,0 +1,199 @@
+//! Schema-constant ordered column lists, memoized once per writer (issue #1674,
+//! R3).
+//!
+//! Part of the `data_writer` responsibility split (issue #1118): this module
+//! holds one `impl DataWriter` block. `use super::*` pulls the shared writer
+//! types, serialization/schema helpers, and crate imports re-exported from
+//! `data_writer/mod.rs`. No emitted bytes change.
+//!
+//! The schema is fixed for a writer's lifetime, yet `regular_columns` /
+//! `static_columns` were re-filtered and re-sorted up to 3× per row, and the
+//! sort comparator (`column_order_key` → `is_complex_column`) allocated a
+//! lowercased `String` on every comparison. These accessors resolve through a
+//! lazily-built [`OrderedCols`](super::OrderedCols) cache instead, so the sort +
+//! `to_lowercase` classification runs exactly once (O(C)), never per row.
+
+use super::*;
+
+impl DataWriter {
+    /// Get regular (non-PK, non-CK, non-static) columns from schema.
+    ///
+    /// Cassandra's column bitmap only covers regular columns — partition key
+    /// and clustering key columns are serialized separately in the partition
+    /// header and clustering prefix. Within the regular set, simple columns
+    /// sort before complex columns, then by name. The order is served from the
+    /// per-writer cache (issue #1674, R3), so no per-row sort runs.
+    pub(super) fn regular_columns<'a>(&self, schema: &'a TableSchema) -> Vec<&'a Column> {
+        self.cached_cols(schema)
+            .regular
+            .iter()
+            .map(|&idx| &schema.columns[idx])
+            .collect()
+    }
+
+    /// Get static columns from schema in Cassandra serialization-header order.
+    pub(super) fn static_columns<'a>(&self, schema: &'a TableSchema) -> Vec<&'a Column> {
+        self.cached_cols(schema)
+            .static_
+            .iter()
+            .map(|&idx| &schema.columns[idx])
+            .collect()
+    }
+
+    /// Regular columns paired with their cached `is_complex` flag, in Cassandra
+    /// serialization-header order (issue #1674, R3). Lets the cell-emission loop
+    /// read complexity from the cache instead of re-lowercasing each column's
+    /// type per row.
+    pub(super) fn regular_columns_with_complex<'a>(
+        &self,
+        schema: &'a TableSchema,
+    ) -> Vec<(&'a Column, bool)> {
+        let cache = self.cached_cols(schema);
+        cache
+            .regular
+            .iter()
+            .map(|&idx| (&schema.columns[idx], cache.is_complex[idx]))
+            .collect()
+    }
+
+    /// `is_complex_column` for the column named `col_name`, read from the
+    /// per-writer cache (issue #1674, R3) so `to_lowercase` never runs per row.
+    /// Unknown names (no matching schema column) are non-complex, matching the
+    /// prior `find(...).map(...).unwrap_or(false)` behaviour.
+    pub(super) fn column_is_complex(&self, schema: &TableSchema, col_name: &str) -> bool {
+        schema
+            .columns
+            .iter()
+            .position(|c| c.name == col_name)
+            .map(|idx| self.cached_cols(schema).is_complex[idx])
+            .unwrap_or(false)
+    }
+
+    /// Borrow the schema-constant ordered column cache, building it on first use
+    /// (issue #1674, R3). The schema is fixed for the writer's lifetime, so this
+    /// runs the filter + sort + `is_complex_column` classification exactly ONCE;
+    /// every later row read is `O(C)` index resolution with no `to_lowercase`.
+    pub(super) fn cached_cols(&self, schema: &TableSchema) -> &OrderedCols {
+        self.column_cache
+            .get_or_init(|| Self::build_ordered_cols(schema))
+    }
+
+    /// Compute the ordered regular/static column index lists + per-column
+    /// `is_complex` classification (issue #1674, R3).
+    ///
+    /// Byte-order invariant: the ordering MUST equal the previous
+    /// `sort_by_key(column_order_key)` — i.e. the same `(is_complex, name)` tuple
+    /// key — so the emitted column bitmap / cell order stays byte-identical. Names
+    /// are unique within a table, so ties on the key never occur and sort
+    /// stability is irrelevant.
+    fn build_ordered_cols(schema: &TableSchema) -> OrderedCols {
+        // One `to_lowercase` per column (O(C)), never per row.
+        let is_complex: Vec<bool> = schema
+            .columns
+            .iter()
+            .map(|column| is_complex_column(&column.data_type))
+            .collect();
+        // Same key as `column_order_key(column)` = `(is_complex, name)`, resolved
+        // through the precomputed `is_complex` slice.
+        let order_key = |idx: usize| (is_complex[idx], schema.columns[idx].name.as_str());
+
+        let mut regular: Vec<usize> = schema
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, column)| {
+                !column.is_static
+                    && !schema.is_partition_key(&column.name)
+                    && !schema.is_clustering_key(&column.name)
+            })
+            .map(|(idx, _)| idx)
+            .collect();
+        regular.sort_by(|&a, &b| order_key(a).cmp(&order_key(b)));
+
+        let mut static_: Vec<usize> = schema
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, column)| column.is_static)
+            .map(|(idx, _)| idx)
+            .collect();
+        static_.sort_by(|&a, &b| order_key(a).cmp(&order_key(b)));
+
+        OrderedCols {
+            regular,
+            static_,
+            is_complex,
+        }
+    }
+}
+
+/// A thread-local recording scope for `is_complex_column` calls on the WRITE
+/// path (issue #1674, R3), mirroring the `#2428` parallel-test-pollution-immune
+/// design of the `work_counters` scopes (`cell_data_clone_scope` et al.). The
+/// writer's `is_complex_column` allocates a lowercased `String` per call, so this
+/// scope makes it observable that the schema-constant ordered column lists and
+/// per-column complexity classification are computed ONCE per writer (an `O(C)`
+/// pass) rather than re-derived per row (`O(R·C·log C)`).
+///
+/// Kept HERE, alongside the cache it guards, rather than in the (already
+/// over-threshold, epic #1116) `work_counters.rs`. `#[cfg(test)]`: the
+/// `record()` call in `is_complex_column` is likewise `#[cfg(test)]`-gated, so
+/// production pays ZERO added cost. Also gated on `feature = "write-support"`
+/// because `is_complex_column` and this module only compile with that feature.
+#[cfg(all(test, feature = "write-support"))]
+pub(crate) mod is_complex_scope {
+    use std::cell::Cell;
+
+    thread_local! {
+        /// `Some(count)` while an [`IsComplexScope`] is active on this thread,
+        /// `None` otherwise. Only `is_complex_column` calls on this thread bump it.
+        static SCOPED: Cell<Option<u64>> = const { Cell::new(None) };
+    }
+
+    /// Bump the active scope on the current thread, if any. A no-op on threads
+    /// (production writes, other tests) with no active scope.
+    pub(crate) fn record() {
+        SCOPED.with(|c| {
+            if let Some(v) = c.get() {
+                c.set(Some(v.saturating_add(1)));
+            }
+        });
+    }
+
+    /// A per-thread recording scope for `is_complex_column`. Open one before
+    /// driving row writes and read [`count`](IsComplexScope::count) after. Immune
+    /// to concurrent tests on other threads (issue #2428); dropping it clears the
+    /// scope. Deliberately `!Send` (holds a `PhantomData<*const ()>`).
+    pub(crate) struct IsComplexScope {
+        _not_send: std::marker::PhantomData<*const ()>,
+    }
+
+    impl IsComplexScope {
+        /// Begin recording on the current thread. Panics if a scope is already
+        /// active on this thread (one scope per assertion; nesting unsupported).
+        pub(crate) fn new() -> Self {
+            SCOPED.with(|c| {
+                assert!(
+                    c.get().is_none(),
+                    "an IsComplexScope is already active on this thread (nesting unsupported)"
+                );
+                c.set(Some(0));
+            });
+            Self {
+                _not_send: std::marker::PhantomData,
+            }
+        }
+
+        /// `is_complex_column` increments recorded on this thread since the scope
+        /// opened.
+        pub(crate) fn count(&self) -> u64 {
+            SCOPED.with(|c| c.get().unwrap_or(0))
+        }
+    }
+
+    impl Drop for IsComplexScope {
+        fn drop(&mut self) {
+            SCOPED.with(|c| c.set(None));
+        }
+    }
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/complex.rs
@@ -65,17 +65,18 @@ impl DataWriter {
 
         // ONE schema-ordered emission pass (issue #930): for each regular column
         // emit its whole-column op and/or its per-element complex column, walking
-        // `regular_columns(schema)` — the exact order the header bitmap /
+        // `regular_columns` order — the exact order the header bitmap /
         // `write_column_subset` use. A previous two-pass design emitted every
         // whole-column op first and every per-element column second, which
         // inverted the wire order whenever a row mixed a whole-column write for
-        // one column with per-element ops for another column that sorts earlier,
-        // misaligning the bodies against the bitmap for strict positional readers.
+        // one column with per-element ops for another column that sorts earlier.
         let mut cells_written: u64 = 0;
-        for col in self.regular_columns(schema) {
+        // Issue #1674 (R3): `is_complex` from the per-writer cache — no per-row sort.
+        for (col, is_complex) in self.regular_columns_with_complex(schema) {
             let name = col.name.as_str();
             if let Some(mop) = whole_by_col.get(name) {
-                cells_written += self.emit_whole_column_op(buf, row, col, mop, now_seconds)?;
+                cells_written +=
+                    self.emit_whole_column_op(buf, row, col, mop, is_complex, now_seconds)?;
             }
             if let Some((complex_deletion, elements)) = per_element_by_col.remove(name) {
                 self.write_complex_column_per_element(
@@ -95,19 +96,18 @@ impl DataWriter {
     /// Emit a single reconciled WHOLE-COLUMN op (`Write` / `WriteWithTtl` /
     /// `Delete`) for `col`. Returns the number of cells serialized: 0 for a
     /// skipped NULL write (represented by absence in the bitmap), else 1.
+    /// `is_complex` is supplied from the per-writer column cache (issue #1674, R3)
+    /// so this hot path never re-lowercases `col`'s type.
     pub(super) fn emit_whole_column_op(
         &self,
         buf: &mut Vec<u8>,
         row: &RowWrite<'_>,
         col: &Column,
         mop: &MergedOp<'_>,
+        is_complex: bool,
         now_seconds: i32,
     ) -> Result<u64> {
         use crate::storage::write_engine::mutation::CellOperation;
-
-        // `col` is the schema column for this op, so the complex check needs no
-        // second lookup.
-        let is_complex = is_complex_column(&col.data_type);
 
         match mop.op {
             CellOperation::Write { column, value } => {

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -213,10 +213,43 @@ pub struct DataWriter {
     /// the read-side shadowing then treats as a partition delete). Default `false`
     /// preserves byte-identical `nb` output.
     oa_partition_deletion: bool,
+    /// Schema-constant ordered column lists + per-column complexity, computed
+    /// exactly once per writer (issue #1674, R3).
+    ///
+    /// The schema is fixed for a writer's lifetime, yet `regular_columns` /
+    /// `static_columns` were re-filtered and re-sorted up to 3× per row, and the
+    /// sort comparator (`column_order_key` → `is_complex_column`) allocated a
+    /// lowercased `String` on every comparison — `O(R·C·log C)` allocations for R
+    /// rows × C columns. This memoizes the ordered column INDICES (Cassandra
+    /// serialization-header order: `(is_complex, name)` key) plus a per-column
+    /// `is_complex` flag, so the per-row hot path reads cached data and
+    /// `to_lowercase` never runs per row. Stored as indices (not `&Column`) to
+    /// avoid entangling the long-lived cache with the per-call `schema` borrow;
+    /// callers resolve `schema.columns[idx]` at use. Filled lazily on first use
+    /// via [`OnceCell`](std::cell::OnceCell) (interior mutability keeps the
+    /// existing `&self` accessors), which also guarantees single computation.
+    column_cache: std::cell::OnceCell<OrderedCols>,
+}
+
+/// Schema-constant ordered column lists, memoized once per [`DataWriter`]
+/// (issue #1674, R3). See [`DataWriter::column_cache`].
+#[derive(Debug)]
+pub(super) struct OrderedCols {
+    /// Indices into `schema.columns` of the regular (non-PK/CK/static) columns,
+    /// in Cassandra serialization-header order (`(is_complex, name)` key).
+    pub(super) regular: Vec<usize>,
+    /// Indices into `schema.columns` of the static columns, same order key.
+    pub(super) static_: Vec<usize>,
+    /// Per-column `is_complex_column` classification, parallel to
+    /// `schema.columns` (one `to_lowercase` per column at cache-build time).
+    pub(super) is_complex: Vec<bool>,
 }
 
 mod cells;
 mod collection_order;
+/// Schema-constant ordered column lists memoized once per writer (issue #1674,
+/// R3). See [`column_cache`].
+mod column_cache;
 mod complex;
 mod encoding;
 /// Incremental partition-write entry point (issue #1668, stage 5c-iv, part
@@ -322,6 +355,7 @@ impl DataWriter {
             crc: StreamingCrc::new(),
             stats: EncodingStatsBaselines::from(&stats),
             oa_partition_deletion: false,
+            column_cache: std::cell::OnceCell::new(),
         }
     }
 
@@ -353,6 +387,7 @@ impl DataWriter {
             crc: StreamingCrc::new(),
             stats: EncodingStatsBaselines::from(&stats),
             oa_partition_deletion: false,
+            column_cache: std::cell::OnceCell::new(),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
@@ -637,9 +637,10 @@ impl DataWriter {
 
         // Column bitmap: "all columns missing" for every static column.
         // write_column_subset with an empty present_set.
-        let static_columns = self.static_columns(schema);
+        // Issue #1674 (R3): cached static-column indices — no per-row vec.
+        let static_ = &self.cached_cols(schema).static_;
         let empty_present: std::collections::HashSet<&str> = std::collections::HashSet::new();
-        self.write_column_subset(&mut body, &static_columns, &empty_present)?;
+        self.write_column_subset(&mut body, schema, static_, &empty_present)?;
 
         let prev_size_vint_len = unsigned_len(prev_size);
         let row_body_size = prev_size_vint_len as u64 + body.len() as u64;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -779,7 +779,7 @@ impl DataWriter {
                 }
                 _ => false,
             });
-            let regular_column_count = self.regular_columns(schema).len();
+            let regular_column_count = self.cached_cols(schema).regular.len();
             if all_writes && !has_nulls && row.ops.len() == regular_column_count {
                 flags |= ROW_HAS_ALL_COLUMNS;
             }
@@ -1070,8 +1070,9 @@ impl DataWriter {
             })
             .collect();
 
-        let regular_columns = self.regular_columns(schema);
-        self.write_column_subset(buf, &regular_columns, &present_columns)
+        // Issue #1674 (R3): pass cached regular-column indices — no per-row vec.
+        let regular = &self.cached_cols(schema).regular;
+        self.write_column_subset(buf, schema, regular, &present_columns)
     }
 
     /// Write the columns subset for a merged row's surviving operations.
@@ -1118,24 +1119,36 @@ impl DataWriter {
             }
         }
 
-        let regular_columns = self.regular_columns(schema);
-        self.write_column_subset(buf, &regular_columns, &present_columns)
+        // Issue #1674 (R3): pass cached regular-column indices — no per-row vec.
+        let regular = &self.cached_cols(schema).regular;
+        self.write_column_subset(buf, schema, regular, &present_columns)
     }
 
+    /// Emit the Cassandra `Columns.Serializer.serializeSubset()` bitmap for a row.
+    ///
+    /// Issue #1674 (R3): takes the cached ordered column INDICES (`&[usize]` into
+    /// `schema.columns`, the regular or static subset already in serialization-
+    /// header order) rather than a freshly-collected `Vec<&Column>`, so the per-row
+    /// hot path allocates no throwaway column vec — preserving issue #1673's
+    /// row-allocation ratchet. Bit positions are the column's position WITHIN the
+    /// ordered subset (the `enumerate` index), identical to the prior `&[&Column]`
+    /// form, so the emitted bytes are unchanged.
     pub(super) fn write_column_subset(
         &self,
         buf: &mut Vec<u8>,
-        columns: &[&Column],
+        schema: &TableSchema,
+        col_indices: &[usize],
         present_columns: &std::collections::HashSet<&str>,
     ) -> Result<()> {
+        let columns_len = col_indices.len();
         let mut present_indices = Vec::new();
         let mut missing_indices = Vec::new();
 
-        for (idx, column) in columns.iter().enumerate() {
-            if present_columns.contains(column.name.as_str()) {
-                present_indices.push(idx);
+        for (pos, &col_idx) in col_indices.iter().enumerate() {
+            if present_columns.contains(schema.columns[col_idx].name.as_str()) {
+                present_indices.push(pos);
             } else {
-                missing_indices.push(idx);
+                missing_indices.push(pos);
             }
         }
 
@@ -1144,7 +1157,7 @@ impl DataWriter {
             return Ok(());
         }
 
-        if columns.len() < 64 {
+        if columns_len < 64 {
             let mut bitmap = 0u64;
             for idx in missing_indices {
                 bitmap |= 1u64 << idx;
@@ -1153,9 +1166,9 @@ impl DataWriter {
             return Ok(());
         }
 
-        encode_unsigned((columns.len() - present_indices.len()) as u64, buf);
+        encode_unsigned((columns_len - present_indices.len()) as u64, buf);
 
-        if present_indices.len() < columns.len() / 2 {
+        if present_indices.len() < columns_len / 2 {
             for idx in present_indices {
                 encode_unsigned(idx as u64, buf);
             }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -792,14 +792,9 @@ impl DataWriter {
         // WriteComplexElement/ComplexDeletion would NOT set
         // ROW_HAS_COMPLEX_DELETION and the reader would parse the column with the
         // wrong (simple-cell) layout.
-        let op_targets_complex = |col_name: &str| {
-            schema
-                .columns
-                .iter()
-                .find(|c| c.name == col_name)
-                .map(|c| is_complex_column(&c.data_type))
-                .unwrap_or(false)
-        };
+        // Issue #1674 (R3): read complexity from the per-writer cache instead of
+        // re-lowercasing each op's column type per row.
+        let op_targets_complex = |col_name: &str| self.column_is_complex(schema, col_name);
         let has_complex = row.ops.iter().any(|mop| {
             let col_name = match mop.op {
                 CellOperation::Write { column, .. }
@@ -1125,42 +1120,6 @@ impl DataWriter {
 
         let regular_columns = self.regular_columns(schema);
         self.write_column_subset(buf, &regular_columns, &present_columns)
-    }
-
-    /// Get regular (non-PK, non-CK, non-static) columns from schema.
-    ///
-    /// Cassandra's column bitmap only covers regular columns — partition key
-    /// and clustering key columns are serialized separately in the partition
-    /// header and clustering prefix. Within the regular set, simple columns
-    /// sort before complex columns, then by name.
-    pub(super) fn regular_columns<'a>(&self, schema: &'a TableSchema) -> Vec<&'a Column> {
-        self.ordered_columns(schema, |column| {
-            !column.is_static
-                && !schema.is_partition_key(&column.name)
-                && !schema.is_clustering_key(&column.name)
-        })
-    }
-
-    /// Get static columns from schema in Cassandra serialization-header order.
-    pub(super) fn static_columns<'a>(&self, schema: &'a TableSchema) -> Vec<&'a Column> {
-        self.ordered_columns(schema, |column| column.is_static)
-    }
-
-    pub(super) fn ordered_columns<'a, F>(
-        &self,
-        schema: &'a TableSchema,
-        predicate: F,
-    ) -> Vec<&'a Column>
-    where
-        F: Fn(&Column) -> bool,
-    {
-        let mut columns: Vec<&'a Column> = schema
-            .columns
-            .iter()
-            .filter(|column| predicate(column))
-            .collect();
-        columns.sort_by_key(|column| column_order_key(column));
-        columns
     }
 
     pub(super) fn write_column_subset(

--- a/cqlite-core/src/storage/sstable/writer/data_writer/schema_helpers.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/schema_helpers.rs
@@ -12,6 +12,8 @@ use super::*;
 /// frozen collections which are stored as a single cell with blob value.
 /// Matches the reader logic in `row_decoder.rs`.
 pub(crate) fn is_complex_column(data_type: &str) -> bool {
+    #[cfg(test)] // #1674 R3: count calls to prove O(C)/writer, never per row
+    super::column_cache::is_complex_scope::record();
     let dt = data_type.to_lowercase();
 
     // Frozen collections are NOT complex (they're single-cell frozen types)
@@ -36,10 +38,8 @@ pub(crate) fn is_complex_column(data_type: &str) -> bool {
     // column (each field is a cell keyed by its 2-byte signed-short field index).
     // Frozen UDTs were excluded above; a UDT nested in a collection is matched by
     // its outer list/set/map branch. Bare CQL UDT names (e.g. `address`) are NOT
-    // detected here — the writer holds only a `&TableSchema` and cannot resolve a
-    // bare name to a UDT without a `UdtRegistry` (issue #927 item 4, follow-up).
-    // Compaction inputs always carry the full `UserType(...)` marshal string, so
-    // this covers the compaction path.
+    // detected here — the writer holds only a `&TableSchema`, no `UdtRegistry`
+    // (issue #927 item 4). Compaction inputs always carry the full `UserType(...)`.
     if is_udt_marshal(&dt) {
         return true;
     }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
@@ -301,10 +301,11 @@ impl DataWriter {
             // reader consume the next row's bytes as a subset bitmask
             // ("Invalid Columns subset bytes; too many bits set").
             if (flags & ROW_HAS_ALL_COLUMNS) == 0 {
-                let static_columns = self.static_columns(schema);
+                // Issue #1674 (R3): cached static-column indices — no per-row vec.
+                let static_ = &self.cached_cols(schema).static_;
                 let empty_present: std::collections::HashSet<&str> =
                     std::collections::HashSet::new();
-                self.write_column_subset(&mut body, &static_columns, &empty_present)?;
+                self.write_column_subset(&mut body, schema, static_, &empty_present)?;
             }
 
             // No cells written for row tombstones. Store the body back into the
@@ -355,8 +356,9 @@ impl DataWriter {
             })
             .collect();
 
-        let static_columns = self.static_columns(schema);
-        self.write_column_subset(buf, &static_columns, &present_columns)
+        // Issue #1674 (R3): cached static-column indices — no per-row vec.
+        let static_ = &self.cached_cols(schema).static_;
+        self.write_column_subset(buf, schema, static_, &present_columns)
     }
 
     /// Write cells for static columns only.
@@ -501,11 +503,14 @@ impl DataWriter {
         ops: &'b [StaticMergedOp],
         schema: &'a TableSchema,
     ) -> Vec<&'b StaticMergedOp> {
-        let columns = self.static_columns(schema);
-        let column_order: std::collections::HashMap<&str, usize> = columns
+        // Issue #1674 (R3): build the ordering map from cached static-column
+        // indices — no per-row `Vec<&Column>` materialization.
+        let cache = self.cached_cols(schema);
+        let column_order: std::collections::HashMap<&str, usize> = cache
+            .static_
             .iter()
             .enumerate()
-            .map(|(idx, column)| (column.name.as_str(), idx))
+            .map(|(idx, &col_idx)| (schema.columns[col_idx].name.as_str(), idx))
             .collect();
 
         let mut sorted: Vec<&'b StaticMergedOp> = ops.iter().collect();

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/issue_1674_column_cache.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/issue_1674_column_cache.rs
@@ -1,0 +1,105 @@
+//! Issue #1674 (R3): cache ordered column lists + per-column complexity so the
+//! schema-constant column ordering is NOT recomputed per row and
+//! `is_complex_column` (which allocates a lowercased `String` per call) never
+//! runs on the per-row hot path.
+
+#![allow(unused_imports)]
+
+use super::super::column_cache::is_complex_scope::IsComplexScope;
+use super::super::*;
+use super::support::*;
+use crate::schema::{ClusteringColumn, ClusteringOrder, Column, CqlType, KeyColumn, TableSchema};
+use crate::storage::write_engine::mutation::{CellOperation, ClusteringKey, PartitionKey, TableId};
+use std::collections::HashMap;
+
+/// Build a schema with `c` regular columns (`c_00`..) plus an `id` PK and `ck`
+/// clustering column. A mix of simple + complex types so the ordering key
+/// `(is_complex, name)` is exercised.
+fn schema_with_regular_columns(c: usize) -> TableSchema {
+    let columns: Vec<Column> = (0..c)
+        .map(|i| Column {
+            name: format!("c_{i:02}"),
+            // Alternate simple/complex to exercise both `is_complex` branches.
+            data_type: if i % 3 == 0 {
+                "set<text>".to_string()
+            } else {
+                "text".to_string()
+            },
+            nullable: true,
+            default: None,
+            is_static: false,
+        })
+        .collect();
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "test_table".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns,
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Writing R rows must invoke `is_complex_column` a number of times bounded by
+/// `f(C)` — INDEPENDENT of the row count R — because the ordered column lists and
+/// per-column `is_complex` classification are computed exactly ONCE per writer
+/// and cached (issue #1674, R3).
+///
+/// On `main` (pre-R3) each `write_row` re-filters + re-sorts the columns via
+/// `sort_by_key(column_order_key)` (calling `is_complex_column` O(C·log C) times
+/// per `regular_columns` call, and `regular_columns` runs ~3× per row) plus a
+/// per-op complex check and a per-column check in `write_merged_cells` — so R
+/// rows produce far more than R·C calls, growing linearly with R. This test with
+/// R = 200 therefore FAILS on main (>= R = 200 > the O(C) bound) and PASSES after
+/// R3 (a single O(C) cache build; here exactly C simple lowercasings, well below
+/// the generous `4·C` bound).
+#[test]
+fn is_complex_column_is_not_called_per_row_issue_1674() {
+    const C: usize = 6;
+    const R: u64 = 200;
+
+    let schema = schema_with_regular_columns(C);
+    let stats = create_test_stats();
+    let mut writer = DataWriter::new(stats);
+
+    let scope = IsComplexScope::new();
+    for r in 0..R {
+        let table_id = TableId::new("test_ks", "test_table");
+        let pk = PartitionKey::single("id", Value::Integer(1));
+        let ck = ClusteringKey::single("ck", Value::Integer(r as i32));
+        // One non-null write per simple regular column (skip the complex ones to
+        // keep the write path a pure scalar emission; the classifier still runs
+        // over ALL columns on main via the ordering sort + per-column checks).
+        let ops: Vec<CellOperation> = (0..C)
+            .filter(|i| i % 3 != 0)
+            .map(|i| CellOperation::Write {
+                column: format!("c_{i:02}"),
+                value: Value::Text("x".to_string()),
+            })
+            .collect();
+        let mutation = Mutation::new(table_id, pk, Some(ck), ops, 1_001_000, None);
+        writer.write_row(&mutation, &schema).unwrap();
+    }
+    let calls = scope.count();
+    drop(scope);
+
+    // After R3 the cache is built once: one `is_complex_column` pass over the C
+    // columns (== C calls). Bound generously at 4·C to stay implementation-robust
+    // while remaining FAR below R. On main this scaled with R (>= R = 200).
+    let bound = 4 * C as u64;
+    assert!(
+        calls <= bound,
+        "is_complex_column ran {calls} times for R={R} rows (C={C}); expected O(C) \
+         (<= {bound}), INDEPENDENT of R. On main it scales with R (>= R = {R})."
+    );
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/mod.rs
@@ -5,6 +5,10 @@ mod collection_order_serialize;
 /// Correctness proof for `IncrementalPartitionWriter` (issue #1668, stage
 /// 5c-iv part 1) against today's whole-slice `write_partition_with_index_blocks`.
 mod incremental_partition;
+/// Work-counter guard proving the schema-constant ordered column lists +
+/// per-column `is_complex` classification are computed once per writer, never
+/// per row (issue #1674, R3).
+mod issue_1674_column_cache;
 mod scenarios_1;
 mod scenarios_2;
 mod scenarios_3;


### PR DESCRIPTION
Closes #1674 (R3 — Epic R #1611, serializer allocation discipline).

## Problem
The schema-constant regular/static column ordering was recomputed up to 3× per row via `sort_by_key(column_order_key)`, whose comparator allocates a lowercased `String` (`is_complex_column`) on every comparison — `O(R·C·log C)` allocations for R rows × C columns. The schema is fixed for a writer's lifetime, so this is pure waste.

## Fix
- New `DataWriter.column_cache: OnceCell<OrderedCols>` holding the ordered regular/static column **indices** (not `&Column` refs — no lifetime entanglement with the per-call `schema` borrow) plus a per-column `is_complex` flag classified **once** at build time (`O(C)` `to_lowercase`, never per row).
- The cache is built with the **same `(is_complex, name)` key** as the prior `sort_by_key(column_order_key)`, so the emitted column bitmap / cell order stays **byte-identical**.
- `regular_columns` / `static_columns` / `column_is_complex` / `regular_columns_with_complex` route through the cache; the per-row op complex-check (`rows.rs`) and the cell-emission loop (`complex.rs`) read cached bools instead of re-lowercasing.
- The column-cache concern lives in a new `column_cache.rs` (`rows.rs` was already over the file-size threshold; this keeps every touched over-threshold file at/under its prior size).
- A `debug_assert` in `cached_cols` guards the one-schema-per-writer invariant (roborev Low nit, addressed).

## TDD (red-on-main → green)
New `is_complex_column_is_not_called_per_row_issue_1674` (via a thread-local `is_complex_scope`, mirroring the `work_counters` scope pattern used by #1664/#1665/#1676): writing **R=200** rows to a **C=6**-column table calls `is_complex_column`:
- **main: 13600** (≈68/row, scales with R)
- **after fix: 6** (== C, the single cache build; independent of R)

Proven red-on-main by reverting the src changes and re-running (13600 > bound 24 → FAIL), green after.

## Validation
- `cargo test -p cqlite-core --lib` data_writer: 255 pass.
- Byte-parity green: `issue_990_data_db_row_framing_parity`, `issue_1074_static_write_parity`, `issue_1295_signed_collection_order_parity`, `issue_1017`/`issue_1020` compaction byte-parity, `v5_compressed_legacy_parity_test`, and the #921 harness (`issue_921_background_compaction_dropped_column_header`).
- `scripts/agent-gate.sh --lite`: PASS (file-size, fmt, clippy, scoped-tests).
- roborev: 1 finding, Severity **Low** (nit), addressed by the `debug_assert`.

Full `scripts/agent-gate.sh` is the closer's job.