### PR TITLE
perf(write): cache parsed CqlType + skip ordered-key re-sort (R6, #1677)

### DIFF
--- a/cqlite-core/src/schema/key_ordering.rs
+++ b/cqlite-core/src/schema/key_ordering.rs
@@ -1,0 +1,131 @@
+//! Ordered partition/clustering key accessors for [`TableSchema`] (issue #1677).
+//!
+//! Extracted from `schema/mod.rs` (source-split doctrine, issue #1116) so the
+//! per-call re-sort that finding R6 flagged can be removed without growing the
+//! already-over-threshold `mod.rs`.
+//!
+//! [`TableSchema::ordered_partition_keys`] / [`TableSchema::ordered_clustering_keys`]
+//! previously sorted their key slice by `position` on **every** call. During
+//! CQL→mutation building these are hit once per statement, so a `BEGIN BATCH` of N
+//! statements re-sorted N times even though the schema — and hence the ordering —
+//! is fixed. Key `position`s are assigned contiguously in order at schema
+//! construction (see `TableSchema::from_sstable_header`), so the slice is virtually
+//! always already sorted; the fast path below detects that with one linear scan and
+//! skips the sort entirely. When a schema *is* built out of order the sort still
+//! runs, so the returned order is byte-for-byte identical to before.
+
+use super::{ClusteringColumn, KeyColumn, TableSchema};
+
+impl TableSchema {
+    /// Get partition key columns ordered by `position`.
+    ///
+    /// Returns the same order as a full `sort_by_key(position)` would, but skips
+    /// the sort when the keys are already in ascending `position` order (the
+    /// common case — see the module docs), so it is no longer re-sorted per call.
+    pub fn ordered_partition_keys(&self) -> Vec<&KeyColumn> {
+        let mut keys = self.partition_keys.iter().collect::<Vec<_>>();
+        if !keys.is_sorted_by_key(|k| k.position) {
+            keys.sort_by_key(|k| k.position);
+        }
+        keys
+    }
+
+    /// Get clustering key columns ordered by `position`.
+    ///
+    /// Same order as before; the sort is skipped when the keys are already ordered.
+    pub fn ordered_clustering_keys(&self) -> Vec<&ClusteringColumn> {
+        let mut keys = self.clustering_keys.iter().collect::<Vec<_>>();
+        if !keys.is_sorted_by_key(|k| k.position) {
+            keys.sort_by_key(|k| k.position);
+        }
+        keys
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{ClusteringColumn, ClusteringOrder, KeyColumn};
+    use std::collections::HashMap;
+
+    fn schema_with(
+        partition_keys: Vec<KeyColumn>,
+        clustering_keys: Vec<ClusteringColumn>,
+    ) -> TableSchema {
+        TableSchema {
+            keyspace: "ks".into(),
+            table: "t".into(),
+            partition_keys,
+            clustering_keys,
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn pk(name: &str, position: usize) -> KeyColumn {
+        KeyColumn {
+            name: name.into(),
+            data_type: "int".into(),
+            position,
+        }
+    }
+
+    fn ck(name: &str, position: usize) -> ClusteringColumn {
+        ClusteringColumn {
+            name: name.into(),
+            data_type: "int".into(),
+            position,
+            order: ClusteringOrder::Asc,
+        }
+    }
+
+    #[test]
+    fn already_sorted_keys_keep_their_order() {
+        let schema = schema_with(
+            vec![pk("a", 0), pk("b", 1), pk("c", 2)],
+            vec![ck("x", 0), ck("y", 1)],
+        );
+        let pks: Vec<_> = schema
+            .ordered_partition_keys()
+            .iter()
+            .map(|k| k.name.clone())
+            .collect();
+        assert_eq!(pks, vec!["a", "b", "c"]);
+        let cks: Vec<_> = schema
+            .ordered_clustering_keys()
+            .iter()
+            .map(|k| k.name.clone())
+            .collect();
+        assert_eq!(cks, vec!["x", "y"]);
+    }
+
+    #[test]
+    fn out_of_order_keys_are_still_sorted_by_position() {
+        // Byte-identical to the previous unconditional sort: order is by position,
+        // not by insertion order.
+        let schema = schema_with(
+            vec![pk("c", 2), pk("a", 0), pk("b", 1)],
+            vec![ck("y", 1), ck("x", 0)],
+        );
+        let pks: Vec<_> = schema
+            .ordered_partition_keys()
+            .iter()
+            .map(|k| (k.name.clone(), k.position))
+            .collect();
+        assert_eq!(pks, vec![("a".into(), 0), ("b".into(), 1), ("c".into(), 2)]);
+        let cks: Vec<_> = schema
+            .ordered_clustering_keys()
+            .iter()
+            .map(|k| (k.name.clone(), k.position))
+            .collect();
+        assert_eq!(cks, vec![("x".into(), 0), ("y".into(), 1)]);
+    }
+
+    #[test]
+    fn empty_key_lists_are_handled() {
+        let schema = schema_with(vec![], vec![]);
+        assert!(schema.ordered_partition_keys().is_empty());
+        assert!(schema.ordered_clustering_keys().is_empty());
+    }
+}

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -17,6 +17,7 @@ pub mod registry;
 // `UdtRegistry` type; the `pub use` below preserves the `schema::UdtRegistry`
 // public path.
 mod cql_type_parser;
+mod key_ordering;
 mod schema_comparator;
 mod udt_registry;
 
@@ -725,19 +726,9 @@ impl TableSchema {
         self.clustering_keys.iter().any(|k| k.name == name)
     }
 
-    /// Get partition key columns in order
-    pub fn ordered_partition_keys(&self) -> Vec<&KeyColumn> {
-        let mut keys = self.partition_keys.iter().collect::<Vec<_>>();
-        keys.sort_by_key(|k| k.position);
-        keys
-    }
-
-    /// Get clustering key columns in order
-    pub fn ordered_clustering_keys(&self) -> Vec<&ClusteringColumn> {
-        let mut keys = self.clustering_keys.iter().collect::<Vec<_>>();
-        keys.sort_by_key(|k| k.position);
-        keys
-    }
+    // `ordered_partition_keys` / `ordered_clustering_keys` live in the
+    // `key_ordering` submodule (issue #1677): they memoize-avoid the per-call
+    // re-sort via a "sort only if not already ordered" fast path.
 
     /// Create a minimal test schema (for testing only)
     #[cfg(test)]

--- a/cqlite-core/src/storage/write_engine/cql_to_mutation/builders.rs
+++ b/cqlite-core/src/storage/write_engine/cql_to_mutation/builders.rs
@@ -18,7 +18,7 @@ use crate::cql::ast::{
     CqlLiteral, CqlTable, CqlUpdate, CqlUsing,
 };
 #[cfg(feature = "write-support")]
-use crate::schema::{CqlType, TableSchema};
+use crate::schema::TableSchema;
 #[cfg(feature = "write-support")]
 use crate::storage::write_engine::mutation::{
     CellOperation, ClusteringKey, Mutation, PartitionKey, PartitionTombstone, TableId,
@@ -96,7 +96,7 @@ pub(crate) fn insert_to_mutation(
                     pk_col.name
                 ))
             })?;
-        let cql_type = CqlType::parse(&pk_col.data_type)?;
+        let cql_type = super::type_cache::cached_parse(&pk_col.data_type)?;
         let value = expression_to_value(expr, &cql_type)?;
         pk_columns.push((pk_col.name.clone(), value));
     }
@@ -111,7 +111,7 @@ pub(crate) fn insert_to_mutation(
             let col_name_lc = ck_col.name.to_lowercase();
             // Clustering key columns are optional in INSERT (may be absent)
             if let Some((_, expr)) = col_val_pairs.iter().find(|(name, _)| *name == col_name_lc) {
-                let cql_type = CqlType::parse(&ck_col.data_type)?;
+                let cql_type = super::type_cache::cached_parse(&ck_col.data_type)?;
                 let value = expression_to_value(expr, &cql_type)?;
                 ck_columns.push((ck_col.name.clone(), value));
             }
@@ -133,7 +133,7 @@ pub(crate) fn insert_to_mutation(
         let column = schema
             .get_column(col_name)
             .ok_or_else(|| Error::InvalidInput(format!("Unknown column '{}'", col_name)))?;
-        let cql_type = CqlType::parse(&column.data_type)?;
+        let cql_type = super::type_cache::cached_parse(&column.data_type)?;
         let value = expression_to_value(expr, &cql_type)?;
         operations.push(CellOperation::Write {
             column: column.name.clone(),
@@ -218,7 +218,7 @@ fn insert_json_to_mutation(
                     pk_col.name
                 ))
             })?;
-        let cql_type = CqlType::parse(&pk_col.data_type)?;
+        let cql_type = super::type_cache::cached_parse(&pk_col.data_type)?;
         let value = json_value_to_cql_value(json_val, &cql_type)?;
         pk_columns.push((pk_col.name.clone(), value));
     }
@@ -230,7 +230,7 @@ fn insert_json_to_mutation(
     for ck_col in &ordered_ck {
         let col_name_lc = ck_col.name.to_lowercase();
         if let Some((_, json_val)) = col_values.iter().find(|(n, _)| *n == col_name_lc) {
-            let cql_type = CqlType::parse(&ck_col.data_type)?;
+            let cql_type = super::type_cache::cached_parse(&ck_col.data_type)?;
             let value = json_value_to_cql_value(json_val, &cql_type)?;
             ck_columns.push((ck_col.name.clone(), value));
         }
@@ -253,7 +253,7 @@ fn insert_json_to_mutation(
         let column = schema
             .get_column(col_name_lc)
             .ok_or_else(|| Error::InvalidInput(format!("Unknown column '{}'", col_name_lc)))?;
-        let cql_type = CqlType::parse(&column.data_type)?;
+        let cql_type = super::type_cache::cached_parse(&column.data_type)?;
         let value = json_value_to_cql_value(json_val, &cql_type)?;
         operations.push(CellOperation::Write {
             column: column.name.clone(),
@@ -318,7 +318,7 @@ pub(crate) fn update_to_mutation(
                 let column = schema
                     .get_column(&col_name)
                     .ok_or_else(|| Error::InvalidInput(format!("Unknown column '{}'", col_name)))?;
-                let cql_type = CqlType::parse(&column.data_type)?;
+                let cql_type = super::type_cache::cached_parse(&column.data_type)?;
                 let value = expression_to_value(&assignment.value, &cql_type)?;
                 operations.push(CellOperation::Write {
                     column: column.name.clone(),
@@ -336,7 +336,7 @@ pub(crate) fn update_to_mutation(
                 let column = schema
                     .get_column(&col_name)
                     .ok_or_else(|| Error::InvalidInput(format!("Unknown column '{}'", col_name)))?;
-                let cql_type = CqlType::parse(&column.data_type)?;
+                let cql_type = super::type_cache::cached_parse(&column.data_type)?;
                 let value = expression_to_value(&assignment.value, &cql_type)?;
                 operations.push(CellOperation::Write {
                     column: column.name.clone(),

--- a/cqlite-core/src/storage/write_engine/cql_to_mutation/delta_helpers.rs
+++ b/cqlite-core/src/storage/write_engine/cql_to_mutation/delta_helpers.rs
@@ -8,9 +8,11 @@
 #[cfg(feature = "write-support")]
 use super::codec::expression_to_value;
 #[cfg(feature = "write-support")]
+use super::type_cache::cached_parse;
+#[cfg(feature = "write-support")]
 use crate::cql::ast::{CqlBinaryOperator, CqlExpression, CqlLiteral, CqlTable, CqlUsing};
 #[cfg(feature = "write-support")]
-use crate::schema::{CqlType, TableSchema};
+use crate::schema::TableSchema;
 #[cfg(feature = "write-support")]
 use crate::storage::write_engine::mutation::{ClusteringBound, ClusteringKey, RangeTombstone};
 #[cfg(feature = "write-support")]
@@ -229,7 +231,7 @@ pub(super) fn build_range_tombstones(
                     pred.column
                 ))
             })?;
-        let cql_type = CqlType::parse(&ck_col.data_type)?;
+        let cql_type = cached_parse(&ck_col.data_type)?;
         let value = expression_to_value(&pred.value, &cql_type)?;
         let ck = ClusteringKey::new(vec![(ck_col.name.clone(), value)]);
 
@@ -294,7 +296,7 @@ pub(super) fn resolve_key_bindings(
                     pk_col.name
                 ))
             })?;
-        let cql_type = CqlType::parse(&pk_col.data_type)?;
+        let cql_type = cached_parse(&pk_col.data_type)?;
         let value = expression_to_value(expr, &cql_type)?;
         pk_columns.push((pk_col.name.clone(), value));
     }
@@ -304,7 +306,7 @@ pub(super) fn resolve_key_bindings(
     for ck_col in &ordered_ck {
         let col_name_lc = ck_col.name.to_lowercase();
         if let Some((_, expr)) = bindings.iter().find(|(name, _)| *name == col_name_lc) {
-            let cql_type = CqlType::parse(&ck_col.data_type)?;
+            let cql_type = cached_parse(&ck_col.data_type)?;
             let value = expression_to_value(expr, &cql_type)?;
             ck_columns.push((ck_col.name.clone(), value));
         }

--- a/cqlite-core/src/storage/write_engine/cql_to_mutation/mod.rs
+++ b/cqlite-core/src/storage/write_engine/cql_to_mutation/mod.rs
@@ -24,6 +24,8 @@ mod builders;
 mod codec;
 #[cfg(feature = "write-support")]
 mod delta_helpers;
+#[cfg(feature = "write-support")]
+mod type_cache;
 
 #[cfg(feature = "write-support")]
 pub(crate) use builders::{
@@ -53,6 +55,9 @@ pub(crate) fn convert_cql_to_mutation(
     statement: &str,
     schema: &TableSchema,
 ) -> Result<Mutation, Error> {
+    // Cache parsed column types for the duration of this conversion so the builder
+    // sites reuse each schema type string's parse instead of re-parsing it (#1677).
+    let _type_cache = type_cache::TypeCacheScope::new();
     let trimmed = statement.trim();
 
     if trimmed.len() >= 6 && trimmed.as_bytes()[..6].eq_ignore_ascii_case(b"INSERT") {
@@ -82,6 +87,9 @@ pub(crate) fn convert_cql_to_mutations(
     statement: &str,
     schema: &TableSchema,
 ) -> Result<Vec<Mutation>, Error> {
+    // One parsed-type cache for the whole conversion; a BATCH of N statements then
+    // parses each distinct column type string once, not once per statement (#1677).
+    let _type_cache = type_cache::TypeCacheScope::new();
     let trimmed = statement.trim();
 
     if trimmed.len() >= 5 && trimmed.as_bytes()[..5].eq_ignore_ascii_case(b"BEGIN") {
@@ -428,6 +436,59 @@ mod tests {
         let result = convert_cql_to_mutations(sql, &schema);
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         assert_eq!(result.unwrap().len(), 1);
+    }
+
+    /// Issue #1677 (R6): building the mutations for a 100-statement BATCH must
+    /// parse each column's `CqlType` from the (fixed) schema at most once — NOT
+    /// once per column per statement.
+    ///
+    /// The thread-local parse-call counter (`schema::work_counters`, the H5
+    /// pattern) is incremented inside `CqlType::parse`. Before this fix,
+    /// `batch_to_mutations` re-parsed every touched column's type string on every
+    /// statement, so a 100-row batch over a table with C columns performed ~100·C
+    /// parses (here ~400: 100 statements × 4 touched columns). After caching, the
+    /// count is bounded by the number of DISTINCT type strings the batch touches
+    /// (≤ C), independent of the row count. RED on main (~400 ≫ C), GREEN after.
+    #[test]
+    fn issue_1677_batch_parses_each_column_type_once() {
+        use crate::schema::work_counters;
+
+        let schema = simple_json_schema();
+        let column_count = schema.columns.len(); // C
+
+        // 100 INSERTs, each touching id/name/value/flag (4 columns).
+        const ROWS: usize = 100;
+        let mut sql = String::from("BEGIN BATCH ");
+        for i in 0..ROWS {
+            sql.push_str(&format!(
+                "INSERT INTO test_ks.test_tbl (id, name, value, flag) \
+                 VALUES ({i}, 'n{i}', {i}, true); "
+            ));
+        }
+        sql.push_str("APPLY BATCH");
+
+        // Measure only the conversion (schema is built by literal, so no parses
+        // happen before this point).
+        work_counters::reset();
+        let mutations = convert_cql_to_mutations(&sql, &schema).expect("batch converts");
+        let parse_calls = work_counters::parse_calls();
+
+        assert_eq!(mutations.len(), ROWS, "one mutation per batched INSERT");
+
+        // ≤ C total (once per distinct column type), NOT ~100·C. A small margin K
+        // absorbs any incidental parse; the load-bearing check is that it does not
+        // scale with ROWS.
+        assert!(
+            parse_calls <= column_count,
+            "expected ≤ C ({column_count}) parses for a {ROWS}-row batch, got {parse_calls} \
+             (main performs ~{}·C ≈ {})",
+            ROWS,
+            ROWS * column_count
+        );
+        assert!(
+            parse_calls < ROWS,
+            "parse count ({parse_calls}) must not scale with the {ROWS} rows"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/cql_to_mutation/type_cache.rs
+++ b/cqlite-core/src/storage/write_engine/cql_to_mutation/type_cache.rs
@@ -1,0 +1,199 @@
+//! Per-conversion parsed-`CqlType` cache for the mutation builders (issue #1677,
+//! Epic R — serializer allocation discipline, audit finding R6).
+//!
+//! # Why this exists
+//!
+//! The mutation builders in [`super::builders`] / [`super::delta_helpers`] resolve
+//! each written column's type by calling [`CqlType::parse`] on the *static* schema
+//! type string (`column.data_type`). The schema is fixed for the whole conversion,
+//! yet a `BEGIN BATCH` of N statements re-parses every column's type string N
+//! times — for a 100-row batch that is 100× the parsing work that only needs to
+//! happen once, and each [`CqlType::parse`] does ≥1 `to_lowercase` `String`
+//! allocation. R6 caches the parse *output* so each distinct type string is parsed
+//! at most once per conversion. It is purely a caching layer: it never changes what
+//! [`CqlType::parse`] returns, never accepts new syntax, and preserves the parse
+//! error path (an un-parseable type still returns `Err` from the mutation build).
+//!
+//! # Why a thread-local scope (not a field on the schema)
+//!
+//! [`crate::schema::TableSchema`] / `Column` are constructed by struct literal at
+//! ~200 sites across the crate, so a cached `OnceCell<CqlType>` field on them would
+//! require touching every one and would grow files already over the campsite-rule
+//! size threshold. Instead the cache lives in a thread-local, activated by a
+//! [`TypeCacheScope`] RAII guard for the duration of one CQL→mutation conversion
+//! (opened in [`super`]'s entry points). This mirrors the established thread-local
+//! work-counter / scope pattern (issue #2428) and is immune to cross-thread
+//! pollution: the mutation builders run inline on the caller's thread, so the cache
+//! only ever sees that conversion's own parses.
+//!
+//! When no scope is active (a builder called directly, e.g. a single non-batched
+//! statement) [`cached_parse`] falls straight through to [`CqlType::parse`], so
+//! behaviour is identical — a single statement already parses each of its columns
+//! at most once.
+
+#[cfg(feature = "write-support")]
+use crate::schema::CqlType;
+#[cfg(feature = "write-support")]
+use crate::Error;
+#[cfg(feature = "write-support")]
+use std::cell::RefCell;
+#[cfg(feature = "write-support")]
+use std::collections::HashMap;
+
+#[cfg(feature = "write-support")]
+thread_local! {
+    /// `Some(map)` while a [`TypeCacheScope`] is active on this thread, `None`
+    /// otherwise. Keyed by the raw `data_type` string; the value is the parsed
+    /// [`CqlType`]. Only successful parses are cached — an `Err` is re-derived on
+    /// every call so the error path is preserved exactly.
+    static PARSED_TYPES: RefCell<Option<HashMap<String, CqlType>>> = const { RefCell::new(None) };
+}
+
+/// RAII activation of the per-conversion parsed-type cache on the current thread.
+///
+/// Open one at the start of a CQL→mutation conversion; every [`cached_parse`] call
+/// executed on this thread while it is alive shares one cache, so a batch parses
+/// each distinct column type string at most once. Dropping it clears the cache.
+///
+/// Re-entrant: if a scope is already active (e.g. `convert_cql_to_mutations`
+/// delegating to `convert_cql_to_mutation`), the inner guard is a no-op and only
+/// the outermost guard clears the cache on drop.
+#[cfg(feature = "write-support")]
+pub(super) struct TypeCacheScope {
+    /// Whether THIS guard installed the cache (and so must clear it on drop).
+    owns: bool,
+}
+
+#[cfg(feature = "write-support")]
+impl TypeCacheScope {
+    /// Activate the cache on the current thread (idempotent: nesting is safe).
+    pub(super) fn new() -> Self {
+        let owns = PARSED_TYPES.with(|c| {
+            let mut guard = c.borrow_mut();
+            if guard.is_none() {
+                *guard = Some(HashMap::new());
+                true
+            } else {
+                false
+            }
+        });
+        Self { owns }
+    }
+}
+
+#[cfg(feature = "write-support")]
+impl Drop for TypeCacheScope {
+    fn drop(&mut self) {
+        if self.owns {
+            PARSED_TYPES.with(|c| *c.borrow_mut() = None);
+        }
+    }
+}
+
+/// Parse a schema type string, reusing the active per-conversion cache if one is
+/// installed. Semantically identical to [`CqlType::parse`] — same `Ok`/`Err`, same
+/// [`CqlType`] — it only avoids re-parsing a type string already seen in this
+/// conversion.
+#[cfg(feature = "write-support")]
+pub(super) fn cached_parse(data_type: &str) -> Result<CqlType, Error> {
+    PARSED_TYPES.with(|c| {
+        let mut guard = c.borrow_mut();
+        match guard.as_mut() {
+            Some(map) => {
+                if let Some(cached) = map.get(data_type) {
+                    return Ok(cached.clone());
+                }
+                // Cache misses (and only successes) so an un-parseable type keeps
+                // surfacing its `Err` from the mutation build, exactly as before.
+                let parsed = CqlType::parse(data_type)?;
+                map.insert(data_type.to_string(), parsed.clone());
+                Ok(parsed)
+            }
+            None => CqlType::parse(data_type),
+        }
+    })
+}
+
+#[cfg(all(test, feature = "write-support"))]
+mod tests {
+    use super::*;
+    use crate::schema::work_counters;
+
+    #[test]
+    fn cached_parse_dedups_within_a_scope() {
+        work_counters::reset();
+        let _scope = TypeCacheScope::new();
+
+        // Same type string parsed repeatedly -> exactly one CqlType::parse call.
+        for _ in 0..50 {
+            assert_eq!(cached_parse("int").unwrap(), CqlType::Int);
+        }
+        // A second distinct type adds exactly one more parse.
+        for _ in 0..50 {
+            assert_eq!(cached_parse("text").unwrap(), CqlType::Text);
+        }
+        assert_eq!(
+            work_counters::parse_calls(),
+            2,
+            "two distinct type strings must parse exactly twice inside a scope"
+        );
+    }
+
+    #[test]
+    fn without_a_scope_every_call_parses() {
+        work_counters::reset();
+        // No TypeCacheScope active: fall straight through to CqlType::parse.
+        for _ in 0..3 {
+            assert_eq!(cached_parse("int").unwrap(), CqlType::Int);
+        }
+        assert_eq!(
+            work_counters::parse_calls(),
+            3,
+            "with no scope, each call must parse (identical to CqlType::parse)"
+        );
+    }
+
+    #[test]
+    fn parse_error_is_not_cached_and_propagates_each_time() {
+        work_counters::reset();
+        let _scope = TypeCacheScope::new();
+
+        // A map with the wrong arity is a hard parse error (not a Custom fallback).
+        assert!(cached_parse("map<int>").is_err());
+        assert!(cached_parse("map<int>").is_err());
+        assert_eq!(
+            work_counters::parse_calls(),
+            2,
+            "errors must NOT be cached — the parse error path is preserved per call"
+        );
+    }
+
+    #[test]
+    fn scope_clears_on_drop_and_nesting_is_safe() {
+        work_counters::reset();
+        {
+            let _outer = TypeCacheScope::new();
+            assert_eq!(cached_parse("int").unwrap(), CqlType::Int);
+            {
+                // Nested guard is a no-op: it shares the outer cache and must not
+                // clear it on drop.
+                let _inner = TypeCacheScope::new();
+                assert_eq!(cached_parse("int").unwrap(), CqlType::Int);
+            }
+            // Still cached after the inner guard dropped.
+            assert_eq!(cached_parse("int").unwrap(), CqlType::Int);
+            assert_eq!(
+                work_counters::parse_calls(),
+                1,
+                "nested scope shares one cache"
+            );
+        }
+        // Outer scope dropped: cache gone, next call parses afresh.
+        assert_eq!(cached_parse("int").unwrap(), CqlType::Int);
+        assert_eq!(
+            work_counters::parse_calls(),
+            2,
+            "the cache must be cleared when the owning scope drops"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1677 — R6 (Epic R #1611, serializer allocation discipline).

## Problem
CQL→mutation building called `CqlType::parse(&col.data_type)` **per column per statement** (~11 sites in `builders.rs`/`delta_helpers.rs`). The schema type strings are static, so a 100-row `BEGIN BATCH` did ~100·C parses (each doing ≥1 `to_lowercase` `String` alloc). `ordered_partition_keys`/`ordered_clustering_keys` also re-sorted on every call.

Per the issue's dependency note (J2 / #1603 landed), this is the **caching layer only** — no new parser, no new syntax.

## Fix
1. **Parsed-type cache** — a per-conversion thread-local (`TypeCacheScope` RAII guard, H5 pattern) opened in the `cql_to_mutation` entry points; the builder/delta_helper sites now go through `cached_parse`. Only **successful** parses are cached, so an un-parseable type still returns `Err` from the mutation build (**error path preserved**, never panics). A thread-local scope (not a struct field on `TableSchema`/`Column`) avoids editing ~200 struct-literal sites and growing over-threshold files; it mirrors the codebase's established thread-local work-counter/scope pattern (#2428) and is cross-thread-pollution-immune.
2. **Ordered keys** — moved `ordered_*_keys` to `schema::key_ordering` with a *sort-only-if-not-already-ordered* fast path. Same order as before (verified for already-sorted, out-of-order, and empty).
3. All ~11 call sites now consume the cached parse.

Behaviour is byte-identical: same `CqlType`, same errors, same produced mutations.

## Evidence
- **TDD counter test** `issue_1677_batch_parses_each_column_type_once`: RED on main (**400** parses for a 100-row batch, ~100·C), GREEN after (**3**, ≤ C, independent of row count). Red-on-main proven by temporarily neutralizing the scope.
- New unit tests: cache dedup / no-scope passthrough / error-not-cached / scope-clear+nesting; key-ordering order preservation.
- `cargo test -p cqlite-core --lib -- cql_to_mutation:: schema::` → 228 passed.
- Byte-parity: `issue_1190_write_load_byte_parity` (3) + `write_engine_integration_test` (21) green.
- Lite gate: **PASS** (file-size/fmt/clippy/scoped-tests). `builders.rs`/`schema/mod.rs` net non-growing (over-threshold-safe).
- roborev (claude-code/opus, branch): **No issues found.**

## Do-NOT compliance
No new parser/syntax; mutations & emitted bytes unchanged; parse errors still propagate from a mutation build; `ordered_*` ordering unchanged; no `unwrap()`/`expect()` in lib code; `-D warnings` clean.

Note: full `agent-gate.sh` is the closer's job (not run here).