### PR TITLE
perf(write): one murmur3 per partition — fold h1+h2 (#1681)

### DIFF
--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -14,7 +14,7 @@ pub use node::{
     BtiError, BtiNode, BtiNodeData, BtiNodeType, BtiResult, PayloadRef, SizedPointer, Transition,
 };
 pub use parser::{
-    decode_bti_partition_payload, encode_clustering_bound_oss50,
+    decode_bti_partition_payload, encode_bti_trie_key_from_token, encode_clustering_bound_oss50,
     encode_clustering_bound_oss50_with_order, encode_partition_key_for_bti_trie,
     iterate_partition_locations_in_bti_file, iterate_partitions_in_bti_file,
     iterate_rows_for_partition, iterate_rows_in_bti_file, iterate_rows_in_bti_trie,

--- a/cqlite-core/src/storage/sstable/bti/parser/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/mod.rs
@@ -69,7 +69,8 @@ mod traversal;
 // Public surface — re-exported unchanged so `bti::parser::X` paths keep working.
 pub use encoding::{encode_clustering_bound_oss50, encode_clustering_bound_oss50_with_order};
 pub use partitions::{
-    decode_bti_partition_payload, encode_partition_key_for_bti_trie, lookup_partition_in_bti_file,
+    decode_bti_partition_payload, encode_bti_trie_key_from_token,
+    encode_partition_key_for_bti_trie, lookup_partition_in_bti_file,
     lookup_raw_key_in_bti_partitions_db, BtiPartitionLocation, FLAG_HAS_HASH_BYTE,
 };
 // Crate-internal uncounted encoder (issue #2058): the successor walk encodes the SAME

--- a/cqlite-core/src/storage/sstable/bti/parser/partitions.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/partitions.rs
@@ -561,6 +561,18 @@ pub(crate) fn encode_partition_key_for_bti_trie_uncounted(raw_key_bytes: &[u8]) 
     use crate::util::cassandra_murmur3::cassandra_murmur3_token;
 
     let token: i64 = cassandra_murmur3_token(raw_key_bytes);
+    encode_bti_trie_key_from_token(token)
+}
+
+/// Encode the byte-comparable BTI trie key from a *precomputed* Murmur3
+/// partition token — the single authoritative definition of the trie-key byte
+/// layout (`[0x40] ++ be8(token ^ 0x8000_0000_0000_0000)`).
+///
+/// This lets a caller that already holds the 128-bit hash words derive the trie
+/// key without re-hashing the raw key (issue #1681): `token` must be
+/// `cassandra_murmur3_normalize_token(h1)`, so the output is byte-identical to
+/// [`encode_partition_key_for_bti_trie`] over the same raw bytes.
+pub fn encode_bti_trie_key_from_token(token: i64) -> [u8; 9] {
     let bc: u64 = (token as u64) ^ 0x8000_0000_0000_0000u64;
     let bc_bytes = bc.to_be_bytes();
 

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
@@ -72,9 +72,11 @@
 //!   (the common case). Partition-level deletions ARE wired through.
 
 use crate::error::{Error, Result};
-use crate::storage::sstable::bti::encode_partition_key_for_bti_trie;
+use crate::storage::sstable::bti::encode_bti_trie_key_from_token;
 use crate::storage::sstable::bti::parser::FLAG_HAS_HASH_BYTE;
-use crate::util::cassandra_murmur3::cassandra_partition_filter_hash_lower_bits;
+use crate::util::cassandra_murmur3::{
+    cassandra_murmur3_normalize_token, cassandra_murmur3_x64_128,
+};
 use std::collections::BTreeMap;
 
 /// Where a partition leaf payload points (issue #910).
@@ -176,8 +178,13 @@ impl PartitionsTrieWriter {
     /// [`PartitionPayload::DataOffset`] for a narrow partition (negative
     /// position, direct `Data.db` offset).
     pub fn add_partition_with_payload(&mut self, raw_key_bytes: &[u8], payload: PartitionPayload) {
-        let key = encode_partition_key_for_bti_trie(raw_key_bytes);
-        let hash_byte = filter_hash_byte(raw_key_bytes);
+        // One 128-bit Murmur3 pass per key (issue #1681, S4), replacing the two
+        // that `encode_partition_key_for_bti_trie` + `filter_hash_byte` each ran:
+        // h1 → normalized token → trie key; h2 as u8 = the leaf filter hash byte
+        // (`DecoratedKey.filterHashLowerBits() as u8`).
+        let (h1, h2) = cassandra_murmur3_x64_128(raw_key_bytes);
+        let key = encode_bti_trie_key_from_token(cassandra_murmur3_normalize_token(h1));
+        let hash_byte = h2 as u8;
 
         // Track only the boundary raw keys (min/max trie key). `finish` sorts by
         // trie key before writing the first/last-key region, so the boundaries
@@ -303,8 +310,13 @@ fn write_with_short_length(buf: &mut Vec<u8>, bytes: &[u8]) -> Result<()> {
 /// `canonical_filter_hash_byte_matches_real_bti_fixture` vector test below. It replaces
 /// the earlier phase-1 placeholder that derived the byte from the trie-key token (`h1`),
 /// which produced values a Cassandra-canonical reader would reject.
+///
+/// Test-only since issue #1681: the write path now derives this byte inline from
+/// `h2` of the single 128-bit hash it computes for the token; this re-hashing
+/// helper is kept only as the vector-test oracle for that inline derivation.
+#[cfg(test)]
 fn filter_hash_byte(raw_key_bytes: &[u8]) -> u8 {
-    cassandra_partition_filter_hash_lower_bits(raw_key_bytes) as u8
+    crate::util::cassandra_murmur3::cassandra_partition_filter_hash_lower_bits(raw_key_bytes) as u8
 }
 
 // ---------------------------------------------------------------------------

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer_tests.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer_tests.rs
@@ -153,6 +153,29 @@ fn written_leaf_hash_byte_is_canonical() {
     assert_eq!(bytes[1], 0x24, "canonical hash byte for UUID 2222… is 0x24");
 }
 
+/// Issue #1681 (S4): each partition key is hashed with Murmur3 exactly ONCE.
+/// Pre-fold this read 2N (128 for 64 keys: token + filter hash) and FAILED.
+/// The counter is thread-local, so `add_partition` (synchronous) records only
+/// this thread's hashes — deterministic under parallel test runs.
+#[test]
+fn one_murmur3_per_partition_key() {
+    use crate::util::cassandra_murmur3::{murmur3_call_count, reset_murmur3_call_count};
+
+    reset_murmur3_call_count();
+    let mut w = PartitionsTrieWriter::new();
+    for i in 0u64..64 {
+        let mut k = vec![0u8; 16];
+        k[0..8].copy_from_slice(&i.to_be_bytes());
+        w.add_partition(&k, i);
+    }
+    assert_eq!(
+        murmur3_call_count(),
+        64,
+        "expected 1 murmur3 per key (got {}); pre-#1681 this was 128 (2N)",
+        murmur3_call_count()
+    );
+}
+
 #[test]
 fn empty_trie_is_empty_bytes() {
     let w = PartitionsTrieWriter::new();

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer_tests.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer_tests.rs
@@ -6,7 +6,9 @@
 
 use super::*;
 use crate::storage::sstable::bti::sized_ints;
-use crate::storage::sstable::bti::{lookup_raw_key_in_bti_partitions_db, BtiPartitionLocation};
+use crate::storage::sstable::bti::{
+    encode_partition_key_for_bti_trie, lookup_raw_key_in_bti_partitions_db, BtiPartitionLocation,
+};
 use std::io::Cursor;
 
 /// `sized_ints_non_zero_size` must agree with the reader's `non_zero_size`.

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -20,7 +20,12 @@ const H2_ADD: u64 = 0x3849_5ab5;
 const FMIX_C1: u64 = 0xff51_afd7_ed55_8ccd;
 const FMIX_C2: u64 = 0xc4ce_b9fe_1a85_ec53;
 
-#[cfg(test)]
+// Gated to the exact condition of the ONLY caller (the `partitions_writer`
+// counter test, which lives behind `write-support`). Without the feature gate
+// these test-only helpers compile but go unused under a `--no-default-features`
+// (write-support off) test build, tripping the `-D warnings` dead_code error
+// the minimal-build gate component enforces (issue #1681).
+#[cfg(all(test, feature = "write-support"))]
 thread_local! {
     /// Per-thread count of [`cassandra_murmur3_x64_128`] invocations (issue #1681).
     /// Thread-local (not a global atomic) so a counter test is unaffected by other
@@ -29,13 +34,13 @@ thread_local! {
 }
 
 /// Reset the current thread's Murmur3 call counter to zero (test-only, #1681).
-#[cfg(test)]
+#[cfg(all(test, feature = "write-support"))]
 pub(crate) fn reset_murmur3_call_count() {
     MURMUR3_CALLS.with(|c| c.set(0));
 }
 
 /// Read the current thread's Murmur3 call count (test-only, #1681).
-#[cfg(test)]
+#[cfg(all(test, feature = "write-support"))]
 pub(crate) fn murmur3_call_count() -> u64 {
     MURMUR3_CALLS.with(|c| c.get())
 }
@@ -51,7 +56,9 @@ pub fn cassandra_murmur3_x64_128(data: &[u8]) -> (i64, i64) {
     // can prove the write path hashes each partition key exactly ONCE (not twice:
     // token + filter hash). Thread-local so it is immune to other test threads
     // hashing concurrently in the same process; compiled out entirely in release.
-    #[cfg(test)]
+    // Gated to match the counter's declaration (and its only caller under
+    // `write-support`) so a write-support-off test build has no dangling ref.
+    #[cfg(all(test, feature = "write-support"))]
     MURMUR3_CALLS.with(|c| c.set(c.get().wrapping_add(1)));
 
     let mut h1: u64 = 0;

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -20,6 +20,26 @@ const H2_ADD: u64 = 0x3849_5ab5;
 const FMIX_C1: u64 = 0xff51_afd7_ed55_8ccd;
 const FMIX_C2: u64 = 0xc4ce_b9fe_1a85_ec53;
 
+#[cfg(test)]
+thread_local! {
+    /// Per-thread count of [`cassandra_murmur3_x64_128`] invocations (issue #1681).
+    /// Thread-local (not a global atomic) so a counter test is unaffected by other
+    /// tests hashing on other threads in the same process.
+    static MURMUR3_CALLS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Reset the current thread's Murmur3 call counter to zero (test-only, #1681).
+#[cfg(test)]
+pub(crate) fn reset_murmur3_call_count() {
+    MURMUR3_CALLS.with(|c| c.set(0));
+}
+
+/// Read the current thread's Murmur3 call count (test-only, #1681).
+#[cfg(test)]
+pub(crate) fn murmur3_call_count() -> u64 {
+    MURMUR3_CALLS.with(|c| c.get())
+}
+
 /// Compute Cassandra's `MurmurHash.hash3_x64_128` with seed 0.
 ///
 /// Returns `(h1, h2)` matching `result[0]` and `result[1]` from the Java implementation.
@@ -27,6 +47,13 @@ const FMIX_C2: u64 = 0xc4ce_b9fe_1a85_ec53;
 /// This differs from standard Murmur3 in that tail bytes are sign-extended
 /// (Java's `byte` is signed), not zero-extended.
 pub fn cassandra_murmur3_x64_128(data: &[u8]) -> (i64, i64) {
+    // Work counter (issue #1681, S4): count every 128-bit Murmur3 pass so a test
+    // can prove the write path hashes each partition key exactly ONCE (not twice:
+    // token + filter hash). Thread-local so it is immune to other test threads
+    // hashing concurrently in the same process; compiled out entirely in release.
+    #[cfg(test)]
+    MURMUR3_CALLS.with(|c| c.set(c.get().wrapping_add(1)));
+
     let mut h1: u64 = 0;
     let mut h2: u64 = 0;
 
@@ -113,6 +140,18 @@ pub fn cassandra_murmur3_x64_128(data: &[u8]) -> (i64, i64) {
 /// maps `i64::MIN` to `i64::MAX` (Cassandra excludes the minimum token value).
 pub fn cassandra_murmur3_token(data: &[u8]) -> i64 {
     let (h1, _) = cassandra_murmur3_x64_128(data);
+    cassandra_murmur3_normalize_token(h1)
+}
+
+/// Apply Cassandra's `Murmur3Partitioner` token normalization to the first
+/// 64-bit word (`h1`) of a 128-bit hash: `i64::MIN` maps to `i64::MAX` (the
+/// minimum token value is excluded from the ring).
+///
+/// Exposed so a caller that already holds `(h1, h2)` from a single
+/// [`cassandra_murmur3_x64_128`] pass can derive the token without re-hashing
+/// the key (issue #1681). `cassandra_murmur3_token(data)` is exactly
+/// `cassandra_murmur3_normalize_token(cassandra_murmur3_x64_128(data).0)`.
+pub fn cassandra_murmur3_normalize_token(h1: i64) -> i64 {
     normalize(h1)
 }
 


### PR DESCRIPTION
Closes #1681 (S4 — one murmur3 per partition; fold h1+h2).

## What changed
`PartitionsTrieWriter::add_partition_with_payload` hashed each partition key with the 128-bit Cassandra Murmur3 **twice** — once via `encode_partition_key_for_bti_trie` (token/`h1`) and once via `filter_hash_byte` → `cassandra_partition_filter_hash_lower_bits` (`h2` low bits). It now makes **one** `cassandra_murmur3_x64_128` pass and derives both words:
- `h1` → `cassandra_murmur3_normalize_token(h1)` → `encode_bti_trie_key_from_token(token)` → the byte-comparable trie key.
- `h2 as u8` → the leaf filter hash byte (exactly `DecoratedKey.filterHashLowerBits() as u8`).

`cassandra_murmur3_token` / `cassandra_partition_filter_hash_lower_bits` already delegate to the single authoritative `cassandra_murmur3_x64_128`; this fold reuses it at the call site rather than re-hashing. New `encode_bti_trie_key_from_token` + `cassandra_murmur3_normalize_token` expose the from-words derivation so no hashing logic is duplicated (no heuristics, #28).

## Byte identity
The emitted `key` and `hash_byte` are provably identical (same `(h1,h2)` words feed the same encodings). Verified by:
- `canonical_filter_hash_byte_matches_real_bti_fixture` (real `da-2-bti-Partitions.db` vectors 0x24/0x22/0xf4) — green.
- `issue_1103_bti_identity` + `issue_911_bti_sstabledump_parity` `Partitions.db` byte-identity — green.

## TDD counter
Added a thread-local `#[cfg(test)]` Murmur3 call counter in the primitive plus `one_murmur3_per_partition_key`: 64 keys → **64** hashes after the fold (was **128** = 2N on main). Thread-local so it's deterministic under parallel test runs.

## Scope
S (fold) only. The optional M (bloom `Filter.db` insert reuse) is left as a follow-up — the production write surface emits uncompressed SSTables without a bloom on this path, and threading precomputed words into the bloom API is a wider change (#1406 boundary).

## Out-of-scope note
`partitions_writer.rs` (1667→1705) and `bti/parser/partitions.rs` (972→984) were already far over the 800-line campsite threshold; the required test + helper grow them. Splitting is out of scope for a hash-fold, so the lite gate ran with `CQLITE_ALLOW_FILE_GROWTH=1` (epic #1116/#1135).

Lite gate: PASS (file-size/fmt/clippy/scoped-tests). Roborev: clean (job 129, no issues). Full gate + merge left to the closer.