### PR TITLE
fix(build): repair issue_1667_budget_honesty.rs vs Bytes-backed Value

### DIFF
--- a/cqlite-core/tests/issue_1667_budget_honesty.rs
+++ b/cqlite-core/tests/issue_1667_budget_honesty.rs
@@ -90,7 +90,7 @@ fn flush_ids(engine: &mut WriteEngine, ids: &[i32], ts: i64) {
             None,
             vec![CellOperation::Write {
                 column: "name".to_string(),
-                value: Value::Text(format!("row-{id}")),
+                value: Value::Text(format!("row-{id}").into()),
             }],
             ts,
             None,


### PR DESCRIPTION
## Summary
- `origin/main` HEAD (8dc4bc7) fails workspace clippy/`--all-targets`: `#1667`'s test constructs `Value::Text(String)`, but `#1644`'s K5 change (commit 5977343) already changed `Value::Text` to take `Bytes`.
- Merge race — #1667's test file was not rebased onto the new API before landing. One-line mechanical build-repair (`.into()`) to unblock every lane's gate.
- Fix independently discovered and verified by two concurrent lanes (#1679, #1681) hitting the same compile break.

## Test plan
- Verified `cargo build --package cqlite-core --tests --test issue_1667_budget_honesty` compiles clean on this branch (failed on unpatched `origin/main`).