### PR TITLE
docs: commit July research + audit artifacts (were untracked on the delivery machine only)

### DIFF
--- a/docs/architecture/build-test-deploy-audit-2026-07-lanes.md
+++ b/docs/architecture/build-test-deploy-audit-2026-07-lanes.md
@@ -1,0 +1,299 @@
+# Build/Test/Deploy Audit 2026-07-17 — raw per-lane packets
+
+> **PRE-REVIEW RAW EVIDENCE.** These are the six subagent audit packets as returned, before the
+> owner-team review. Several claims herein were corrected or retracted — see
+> `build-test-deploy-audit-2026-07.md` (rev 2) revision history. Where a packet conflicts with
+> the synthesis, **the synthesis wins**. Known-superseded claims are marked ⚠ inline.
+
+---
+
+## Lane 1 — Local gate system (`scripts/agent-gate.sh`)
+
+### Inventory (component → what it runs → est. relative cost)
+
+Full gate = 24 components (`agent-gate.sh:1042`). MAIN lane runs serially in one shared `target/`;
+SIDE lane runs the two bindings concurrently in isolated target dirs (`:3452-3491`).
+
+| # | Component | What it runs | Rel. cost |
+|---|-----------|--------------|-----------|
+| 1 | core-tests | `cargo nextest run -p cqlite-core --features cli-helpers` + `cargo test --doc` (`:3072`) | XL — "67% execution floor" (gate-ops.md:116) |
+| 2 | python-bindings (SIDE) | maturin develop + import-verify + pytest (`:1525`) | XL cold, M warm (persistent venv) |
+| 3 | node-bindings (SIDE) | `npm ci && npm run build && jest write-readback-content` (`:1596`) | L |
+| 4 | clippy | 4 invocations: workspace all-features (5 excludes) + cqlite-core ~40-feature list + cqlite-cli feature list + flight/py/node (`:1454`) | L |
+| 5 | cli-tests | Two full passes (default + write-support) over globbed `cqlite-cli/tests/*.rs` (`:3222`) | L |
+| 6 | integration-tests | `--no-run` then 6 golden-path `--test` targets (`:3208`) | L |
+| 7 | memory-budget | 3 dhat-heap lanes `--test-threads=1` (core×2 + flight) (`:3188`) | M |
+| 8–11 | tombstones-scan / scan-offload-guard / work-counters-guard / byte-budget-guard | each a `cargo test -p cqlite-core --test …` under a DISTINCT feature set (`:3160-3186`) | M each |
+| 12 | write-tests | `--lib` + roundtrip + compaction_integration, write-support (`:3218`) | M |
+| 13 | compaction-byte-parity | Rust re-compaction byte-diff subset (`:1690`) | M |
+| 14 | format-compat | `cargo test -p format-compatibility-tests` (`:3217`) | M |
+| 15 | arrow-parity-guard | one `--test` under `arrow` (`:3130`) | S–M |
+| 16 | minimal-build | `build --no-default-features --features all-compression` + test `--no-run`, `RUSTFLAGS=-D warnings` (`:3398`) | S–M |
+| 17 | smoke | build cqlite bin + `smoke-test-all-tables.sh` (`:3415`) | S–M |
+| 18–24 | query-semantics-oracle, parity-report, delivery-telemetry, binding-unwind-profile, tooling-tests, file-size, fmt | small cargo/python/bash checks (`:1633-1990`) | S each |
+
+### Findings
+
+1. ⚠ (magnitude unmeasured — #2647 Step 0) Feature-set fragmentation forces ~8–12 redundant
+   cqlite-core recompiles. Nearly every component uses a different `--features` set
+   (core-tests=`cli-helpers`; tombstones-scan=`write-support,cli-helpers,tombstones` `:3161`;
+   scan-offload-guard=`cli-helpers,scan-offload-probe` `:3109`; work-counters-guard=
+   `write-support,cli-helpers,state_machine,work-counters` `:3165`; byte-budget-guard=
+   `write-support,cli-helpers,state_machine` `:3181`; write-tests=`write-support`;
+   arrow-parity=`arrow`; memory-budget=`cli-helpers,dhat-heap,arrow`). Each combo = distinct
+   fingerprint = from-scratch compile; sccache cannot dedupe differing feature flags.
+2. The guard cluster (#8–12) is unifiable into 1–2 compiles: work-counters-guard and
+   byte-budget-guard differ only by `work-counters`; a superset invocation would compile core once
+   instead of ~5×. `dhat-heap`/`arrow` must stay isolated (global allocator, `--test-threads=1`).
+   ⚠ "~4–6 min saved" is an estimate, not a measurement.
+3. MAIN lane is strictly serial; only bindings parallelize (`launch_components` `:3468-3489`).
+   memory-budget dhat lanes, smoke, and script components are isolatable into extra lanes.
+4. Heavy components duplicate non-required PR CI (`ci.yml` runs core/integration/write/CLI/smoke
+   with datasets fetched `ci.yml:96-127`), while the required check is only the thin
+   `pr-gate.yml`. Local-vs-CI boundary is an owner decision.
+5. ⚠ (causality unresolved — #2641 characterize first) sccache corruption under extreme load: one
+   recorded incident (loadavg ~150); the gate trusts sccache unconditionally.
+6. ⚠ (precision: DHAT/sstableloader do set `--test-threads=1` for isolation; the missing control
+   is a general per-gate CPU quota) The #1825 cap bounds gate count, not per-gate resource use;
+   no `cargo -j`/nextest-thread/`nice` load management (`:2855`, gate-ops.md:137).
+7. Lite blast-radius: metadata-authoritative and sound (`classify_scoped_plan` `:628`), two
+   under-select edges: (a) no jq AND no python3 → silently narrows to `cqlite-core --lib` only
+   (`:2118`); (b) a core-src change breaking a separate test crate is invisible to lite — main
+   lite-green→full-red source.
+8. Delta fail-closed rules correct and appropriately paranoid (`_delta_is_allowed_path` `:640`,
+   metadata-verified `.rs` allowance `:702`, node refuses without pre-built module `:2666`).
+9. Script health: 3569 lines, 51 functions, 18 arg-hooks, 21 env knobs; cli-tests is a ~170-line
+   embedded heredoc program (`:3222-3389`); clippy hardcodes a ~40-item feature string (`:1473`)
+   drift-guarded only by nightly `CQLITE_CLIPPY_FULL`.
+
+---
+
+## Lane 2 — Required/correctness CI
+
+### Inventory
+
+| Workflow | PR trigger | push/sched | Role | Cost driver |
+|---|---|---|---|---|
+| pr-gate.yml | every PR, no path filter (`:4`) | — | THE required check (`required` job `:14`) | full cqlite-core all-features clippy+build+`--lib` tests |
+| ci.yml | every PR (`:24-25`) | push main; dispatch | broad lanes behind `ci:broad` label (`:52-54`); `test` job = transitional legacy required context running `pre-merge.sh fast` (`:898-903`) | duplicate fast compile every PR |
+| m1-ci.yml | every PR (`:11-12`) | dispatch | two no-op legacy required contexts (`:23,47`) | ~seconds |
+| ci-minimal-features.yml | PR if core+manifests (`:6-11`) | push | minimal-feature build (`:50`) | core compile |
+| observability-gate.yml | every PR (`:23-25`) | nightly | cheap classifier (`:39`) → correctness if obs paths | classifier ~free |
+| fuzz.yml | PR if parser paths (`:20-33`) | nightly | fuzz smoke build | nightly toolchain |
+| coverage-baseline.yml | PR if core src (`:9-11`) | nightly | tarpaulin baseline, no cache | instrumented compile |
+| coverage.yml | none (`:4-7`) | nightly | ≥77% read-path enforcement — never gates a PR | tarpaulin |
+| gate.yml | none | nightly | full agent-gate deep-check on main | full gate |
+| quality-gates.yml / future-rust-canary.yml / smoke-tests.yml / workflow-config.yml / project-board-sync.yml | various | schedule-heavy | advisory/hygiene | light |
+
+### Findings
+
+1. Triple redundant required-context emitters per PR: `pr-gate.yml:14` (real), `ci.yml:869`
+   transitional `test`, `m1-ci.yml:23/47` no-ops — one full duplicate cqlite-core compile + two
+   zombie jobs, purely for stale branch-protection context names.
+   ⚠ (post-review: live protection ALREADY requires only `required`; committed
+   `branch-protection.json` + `setup-branch-protection.js` are drifted and would RESTORE the
+   legacy contexts — fix drift BEFORE deleting workflows; see #2648.)
+2. ⚠ (do NOT fix with paths-ignore — required workflow that doesn't trigger blocks the PR; use an
+   always-emitted classifier, #2645) Required gate has no path awareness — docs-only PRs compile
+   cqlite-core all-features twice.
+3. Broad correctness is opt-in on PRs (push main / `ci:broad` / dispatch, `ci.yml:52-54` etc.) —
+   on a default PR zero integration/parity/CLI tests gate the merge; sound only because merge
+   doctrine requires the local full gate.
+4. Coverage ≥77% enforcement never gates a PR (`coverage.yml:4-7`); PR side is the weaker 30%
+   baseline. ⚠ (consolidate, don't add a parallel job — #2659.)
+5. Fragmented caching: five distinct cache mechanisms; coverage-baseline has none; 3–6 cold core
+   compiles per PR from disjoint namespaces.
+6. `ci.yml` `test` aggregator exits 0 when `RUN_BROAD != true` (`:913-918`) but correctly checks
+   `needs.*.result` in broad mode (`:932-937`).
+7. ⚠ (post-review: KEEP the build step — clippy is not a production link/codegen substitute)
+   pr-gate compiles core three ways in one job; the standalone `cargo build` after clippy looked
+   near-redundant.
+8. scripts/ci hygiene: `validate-workflows.rb` live; `ci-timing-summary.sh` consistent; three old
+   scripts (Aug 2025 mtimes) worth a drift check.
+
+---
+
+## Lane 3 — Parity/validation CI fleet
+
+### Inventory (workflow → cadence → unique property → cost)
+
+| Workflow | Cadence | Unique property | Cost driver |
+|---|---|---|---|
+| sstabledump-parity-gate.yml | PR (broad smoke_regex) + nightly | canonical/byte parity vs committed sstabledump JSONL goldens | dataset fetch, 45min |
+| cassandra-parity.yml | PR/push (manifest paths) + nightly | manifest lint, tier/retention cross-check, report-heal | light, no Docker |
+| cassandra-validation.yml | PR/push (paths) | sstableloader round-trip into real Cassandra | cassandra:5.0.2 service, 30min |
+| compaction-parity.yml | PR (paths) + nightly | LOGICAL (PR) + BYTE tier (`gradle byteParity`, nightly) | JVM harness; byte tier builds Cassandra, 60min |
+| live-cell-compaction-parity.yml | PR + nightly | live-cell/frozen-UDT compaction byte parity | committed fixtures, cheap |
+| compression-corruption-parity.yml | PR (paths) + nightly | CompressionInfo + inline-CRC + corruption verdicts | Docker regen, 60min |
+| cql-type-parity.yml | PR (paths) + nightly | CQL type + schema-evolution parity | Docker regen, 60min |
+| tombstone-ttl-parity.yml | PR (paths) + nightly | tombstone/TTL/deletion/resurrection parity | Docker regen, 60min |
+| delta-roundtrip.yml | PR/push (delta paths) | CDC delta-export round-trip | Docker + regen, 45min |
+| e2e-readback.yml | nightly + PR behind `ci:ingest-full` | live read-back semantic parity | compose Cassandra, 30min |
+| nightly-docker-parity.yml | nightly | umbrella: readback + BTI sstabledump + compaction logical+byte + Bloom | builds Cassandra from source (Ant) — ⚠ source build serves the COMPACTION legs, not BTI |
+| exhaustive-regeneration.yml | cron `10 8 * * *` = DAILY (doc says weekly) | full-corpus coverage/presence audit | 180min, full Docker regen |
+| perf-regression.yml | nightly + PR behind `ci:perf` | Criterion read-path 10% wall; flaky benches advisory | double bench build |
+| parity-failure-issue{,-tests}.yml | workflow_run on 6 lanes | red-lane → deduped tracking issue | light |
+
+### Redundancy map
+
+- Compaction BYTE parity: compaction-parity nightly `byteParity` AND nightly-docker-parity re-run
+  the same gradle target — twice nightly; PR proxy in agent-gate + live-cell + tombstone lanes.
+- Live Cassandra read-back: e2e-readback AND nightly-docker-parity leg 1 — twice nightly.
+- BTI sstabledump parity: umbrella leg 2 + sstabledump-parity-gate.
+- CompressionInfo: committed golden + Docker-regen — intentional strength ladder, not pure dup.
+
+### Findings
+
+1. exhaustive-regeneration runs DAILY vs documented weekly (#1026). ⚠ wording: 7 runs vs 1 —
+   "removes 6 of 7", not "6× reduction".
+2. nightly-docker-parity duplicates two standalone nightly lanes. ⚠ remedy: reusable workflows or
+   drop standalone schedules; preserve the citable aggregate (#2650).
+3. Query-semantics oracle (#1742) not on the required PR path — only local gate + nightly gate.yml.
+   ⚠ remedy must be fail-closed: `CQLITE_REQUIRE_FIXTURES=1` + required features (#2644).
+4. No parity property on the required per-PR check; red-lane latency-to-human ~1 day via nightlies.
+5. ⚠ (design: separate tracked pin; sha spans 11 workflows, not ~4 — #2646) `.dataset-pin` is
+   untracked (generated by fetch); workflows hardcode `DATASET_SHA256`.
+6. Failure routing solid: stable 5-field fingerprint, body-marker dedup, idempotent resolution,
+   never auto-closes, self-provisions label, unit-tested. Gap: cassandra-validation, e2e-readback,
+   delta-roundtrip, nightly-docker-parity, perf-regression not in the workflow_run list.
+7. PARITY_HEAL_TOKEN: absent → SKIP with notice (loud, not silent); merge-race stale report blocks
+   the PR queue until manual regen.
+8. perf-regression is now signal: flaky benches demoted to advisory; strict gate is read-path at
+   10% same-runner; opt-in label per PR.
+
+---
+
+## Lane 4 — Release/deploy train
+
+### Inventory (workflow → trigger → artifact → credentials)
+
+| Workflow | Trigger | Artifact | Credentials | Arch cost |
+|---|---|---|---|---|
+| release.yml | push tag v* | 6 CLI archives → GH Release; crates.io (core→cli); Homebrew tap | crates.io OIDC; HOMEBREW_TAP_TOKEN | 6 targets |
+| python-release.yml | push tag v* | sdist + 5 wheels → PyPI/TestPyPI | PyPI OIDC | 5 wheels |
+| node-release.yml | push tag v*, dispatch | 5 `.node` → npm (provenance) | npm OIDC | 5 targets |
+| trino-publish.yml | push tag v*, dispatch | Maven Central (`automaticRelease=true`) | MAVEN_CENTRAL_* + GPG | 1 |
+| flight-image.yml | push tag v*, dispatch | multi-arch GHCR (vX.Y.Z, vX.Y, latest) | GITHUB_TOKEN | 2 arches |
+| flight-ci.yml | push main/tag v*, PR, nightly | flight bin; image job pushes GHCR on tag, single-arch (`:120-153`) | GITHUB_TOKEN | 1 |
+| api-docs.yml | push tag v*, dispatch | rustdoc → gh-pages | GITHUB_TOKEN | 1 |
+| docs-site.yml | push main, PR, nightly | Astro site → gh-pages | GITHUB_TOKEN | 1 |
+
+### Findings
+
+1. Dueling image builds on a v* tag: flight-image (multi-arch) and flight-ci image job
+   (single-arch amd64, `type=ref,event=tag`) push the identical GHCR tag concurrently — last
+   writer wins.
+2. ⚠ (remedy revised: tag→GITHUB_SHA provenance assertion, not a confirmation prompt — #2639)
+   `gh workflow run trino-publish.yml` is an unguarded real publish (`dry_run` defaults false,
+   `:37-40,120`); flight-image/api-docs dispatches similarly armed.
+3. ⚠ (scope revised: preflight prevents version-skew only; registries can't be atomic — #2652)
+   No aggregate abort path: ≥7 independent publish lanes, per-lane tag==manifest checks only,
+   immutable targets, no rollback.
+4. Version bump fully manual across 4 files (`Cargo.toml:28`, `Cargo.toml:50`,
+   `pyproject.toml:7`, `package.json:3`); Trino derives from the tag.
+5. CI never exercises the shipped Python profile: release ships `--profile release-unwind`
+   (`python-release.yml:96-99`); python-ci builds plain `--release`. Node is consistent.
+6. Agent-plumbing lane blocks deploy on main but not the PR: `validate-agent-plumbing.mjs` inside
+   docs-site build (`:79-80`); not PR-required → unlinked page merges green, fails on main,
+   silently skips deploy (#2480 class).
+7. flight-image manual `version` dispatch not SHA-pinned (#2456 class); digest never written to
+   job summary (log-grep hunt persists).
+8. Non-idempotent re-runs: crates.io skip-if-published OK, Homebrew diff-guarded OK; PyPI has no
+   skip-existing; npm/Maven hard-fail on duplicate versions.
+9. Redundant from-scratch core compiles across release lanes; per-workflow caches only.
+10. Good, keep: command-injection guards (env-passed inputs, semver allowlist); cross glibc floor
+    pin; fail-closed secret guard in trino-publish; node dispatch requires pre-existing tag;
+    bootstrap carries no publish credentials (publishing is CI-OIDC only).
+
+---
+
+## Lane 5 — Fleet/worker orchestration
+
+### Inventory
+
+- `worker-supervisor.sh` (402 L): one worker process per iteration; mkdir+pid single-instance
+  lock (`L179-209`); fail-closed preflight (load>ncpu / leftover cargo / disk<40G → HOLD,
+  `L239-276`); crash-loop breaker (`L377`); head-blocked detector (`L356-364`); budgets
+  (`L391-394`). SPOF: correctness depends on the worker LLM honoring the marker contract.
+- `claim-heartbeat.sh` (213 L): liveness via `refs/heartbeats/<machine>` root-commit push; reap
+  threshold documented but enforced nowhere in code — flow-board SKILL prose only.
+- `finalize-cleanup.sh` (325 L): the most defensively-correct script in the set (validate-all-
+  then-execute, fails closed on >1 lock / dirty / unpushed / unmerged / remote-error).
+- `project-board-sync.yml`: closed-unmerged→Done + 30-min null-Status sweep; needs
+  `PROJECTS_TOKEN`; no-ops silently if absent.
+- gate-slot cap (#1825): real machine-wide semaphore, N flock lockfiles + detached
+  `gate_slot_daemon.py`; N = `max(2,(ncpu-2)/4)` (`agent-gate.sh:2825/2855`).
+- `bootstrap-agent-machine.sh`: check-only installer; sets no load/CPU policy.
+
+### Telemetry readout (289 records)
+
+| Metric | All 289 | Last 60 | Baseline |
+|---|---|---|---|
+| gate_runs mean | 1.78 (median 1) | 1.57 | 1.87 |
+| first-pass (gate_runs==1) | 56% | 67% | 54% |
+| rework mean / % with rework>0 | 1.82 / 66% | 1.93 | 1.92 |
+| roborev blockers | ⚠ CORRECTED: 55/97 = 56.7% of CLASSIFIED (field present on 97/289 only) | 34/60 = 56.7% — FLAT | — |
+| claim_collisions>0 | 2 total ever | 2 | — |
+
+⚠ The packet's original "19% all-time vs 57% recent" divided by all 289 records (fabricated
+zeros) and is retracted. Blocker rate is high but flat; "the bottleneck moved" is withdrawn.
+
+### Findings
+
+1. ⚠ (precision: DHAT/sstableloader set `--test-threads=1` for isolation; missing control is a
+   general per-gate CPU/process quota; SIGKILL evidence ~15 concurrent gates, 2 gates ⇒ timing
+   flakes) Gate cap limits count, not cores-per-gate; no `cargo -j`/`nice`/`taskpolicy` anywhere.
+2. Agents distrust the cap and hand-serialize via pgrep; `CQLITE_GATE_MAX_CONCURRENCY=1` exists
+   but defaults ≥2.
+3. Heartbeat + reaper entirely prose-driven; worker-supervisor never calls claim-heartbeat
+   (grep-verified). Beat-then-crash looks alive 4h.
+4. #2499 orphan endgame is structural; the git-ref-claim design candidate is sound (supervisor
+   stamps/refreshes a machine+PID-scoped claim ref; reaper checks age+PID+no-open-PR).
+5. Board auto-add unreliability real; 30-min sweep is a lag, not a fix; PROJECTS_TOKEN lapse
+   silently no-ops the safety net.
+6. Heartbeat ref shared across lanes; `cmd_clear` (`L179`) deletes unconditionally.
+7. Marker/PID-reuse edges handled well (stale-marker removal `L306`, finalized-without-issue
+   rejection `L333`).
+
+---
+
+## Lane 6 — Test suite + test data
+
+### Test-target inventory
+
+370 integration `--test` binaries workspace-wide: cqlite-core/tests 318 (162K lines, avg ~510/bin,
+dominated by `issue_NNNN_*` micro-bins), cqlite-cli 41, tools 11; plus lib tests,
+integration/format-compat crates, python 30 files, node 35. Heaviest: `parquet_writer_tests.rs`
+(4838), `sstableloader_integration.rs` (3821, Docker-gated), `issue_819_differential_compaction.rs`
+(1953), `scan_delta_parity_test.rs` (1716), `compaction_integration.rs` (1616),
+`write_integration.rs` (1536). No `.config/nextest.toml` exists — no test-groups, no retries, no
+slow-timeout config.
+
+### Flake ledger
+
+| Test / class | Class | Status |
+|---|---|---|
+| collection_benchmarks #2369 | wall-clock in correctness gate | fixed (592a2947) |
+| sstable_performance_regression_tests.rs | wall-clock asserts (50ms) in correctness path, lines 92/98/107/116/431/449/472 | LATENT — #2369 rule not applied |
+| cli integration_sstable_tests.rs 695/711 | loose 30s/60s ceilings | latent, low risk |
+| write_integration.rs:742 | `elapsed < 50ms` | latent, tight |
+| cli enhanced_unit_tests.rs:498 | `startup < 100ms` | ⚠ file is ORPHANED from the harness (tests/unit/ referenced by no target) — coverage gap, assert currently inert (#2642) |
+| sstable_header_parsing_basic_tests.rs:363 | `< 1000ms` | latent, loose |
+| python `ModuleNotFoundError` #1803 | stale editable venv | fixed (determinism harness) |
+| index_probes #2451 / StreamWalkScope #2428 | counter scoping | fixed |
+| Docker-runtime tests | env-dependent | contained (`CQLITE_SKIP_DOCKER_TESTS=1` default) |
+
+### Findings
+
+1. `sstable_performance_regression_tests.rs` is a live #2369 violation in default core-tests.
+2. Target sprawl: 318 core bins; clusters (`issue_953_*`×4, `issue_1577_*`×4, `issue_1578_*`×5,
+   `issue_2412_*`×4, `issue_1143_*`×3) consolidatable per epic.
+3. No nextest config — no scoped retries or serialization groups.
+4. Timing residuals beyond #1 (see ledger).
+5. Fail-closed (#2078) is gate-only: bindings suites have no equivalent anti-vacuous guard.
+6. Generator suite correctly CI-owned by policy: heavy Docker generators run only on
+   schedule/dispatch workflows; outputs pinned + fetched read-only; the normal local gate
+   disables Docker.
+7. Oracle balance lopsided: 163 physical-dump goldens vs one 5.4KB query-semantics oracle; new
+   reconciliation-sensitive features not structurally forced to extend the semantic oracle.
+8. Node bindings lack a determinism harness (python's #1803 fix has no node analog).

--- a/docs/architecture/build-test-deploy-audit-2026-07.md
+++ b/docs/architecture/build-test-deploy-audit-2026-07.md
@@ -1,0 +1,153 @@
+# Build / Test / Deploy System Audit — 2026-07-17 (rev 2)
+
+Six-lane subagent audit of the full delivery system: local agent-gate, required CI, parity CI
+fleet, release/deploy train, fleet orchestration, and test suite + test data. Goal frame: fast,
+reliable agentic development iterations — the right check at the right time, local vs CI split
+correctly.
+
+This revision integrates the 2026-07-17 owner-team review directly into the text; see Revision
+history at the bottom. This document is the synthesis of record. Raw per-lane evidence:
+`build-test-deploy-audit-2026-07-lanes.md` (committed companion; where a lane packet conflicts
+with this synthesis, this synthesis wins). Remediation epic: #2636 (children #2637–#2660 carry
+the authoritative acceptance criteria).
+
+## Executive summary — four cross-cutting themes
+
+1. **Redundant compilation is the prime cost suspect — magnitude unmeasured.** Static analysis
+   shows the full gate uses a distinct `--features` combination for nearly every component, so
+   Cargo feature-unification recompiles `cqlite-core` once per combo (sccache cannot dedupe
+   differing feature flags); CI adds 3–6 cold core compiles per PR across disjoint cache
+   namespaces plus one fully duplicated required-context compile; 318 core `--test` bins each
+   re-link the core rlib. However, gate-ops records a ~67% *execution* floor for core-tests, which
+   cuts against compilation dominating overall — so #2647 mandates profiling the compile/link/
+   execution split before any unification work, and the "~4–6 min saved" figure is a hypothesis
+   to be confirmed or retired by that measurement.
+
+2. **Load is managed by prose, not mechanism.** There is no *general per-gate CPU/process quota*:
+   no `CARGO_BUILD_JOBS` derivation, no `nice`/`taskpolicy`, no load-aware admission. (DHAT and
+   sstableloader lanes do set `--test-threads=1`, but for correctness isolation, not load
+   control.) Documented failure modes: ~15 concurrent gate-ish processes produced SIGKILLs; two
+   concurrent gates produce timing flakes (`test_write_throughput` class). Agents compensate by
+   hand-serializing gates with racy pgrep checks. One incident of sccache serving corrupted
+   objects occurred under extreme load; the load→corruption causality is unresolved and must be
+   characterized before any auto-disable ships (#2641). Same pattern in orchestration: heartbeats
+   and claims live in skill prose; the worker-supervisor — the one mechanical loop — never calls
+   the heartbeat, so #2499 orphan endgames are structural until the supervisor authors the claim
+   ref itself (#2655).
+
+3. **Right check, wrong time.** `exhaustive-regeneration.yml` — the heaviest lane (180 min, full
+   Docker regen) — runs daily where the tier doc says weekly: 7 runs/week vs 1, i.e. 7× the
+   documented frequency (#2637 embeds the keep-or-fix decision). The nightly umbrella re-proves
+   live readback + compaction byte-parity that standalone nightlies proved hours earlier the same
+   night. The query-semantics oracle (#1742) — cheap, no Docker — never gates a PR, and coverage
+   enforcement is nightly-only (the PR side has only a weaker 30% baseline). Docs-only PRs pay a
+   full all-features core compile twice.
+
+4. **Telemetry: gate cost is fine; roborev blockers are high but flat.** From the ledger (289
+   records): gate-runs/issue 1.57 recent (vs 1.87 baseline), first-pass 67% — the gate loop is
+   already at/below baseline. Blocker classification exists on only 97/289 records; among
+   classified, 55/97 = 56.7% overall and 34/60 = 56.7% in the last 60 — **high and stable, not
+   rising**. (Never divide blocker counts by all 289: the unclassified records are unobserved,
+   not zero.) Mechanizing blocker classes into `--lite` lints (#2656) is promising but
+   taxonomy-first: class → count → estimated lint catch rate before implementation.
+
+Also: the deploy train has two genuine safety holes (dueling image builds racing on the release
+tag; unguarded real-publish dispatches) and is non-atomic across five immutable registries with a
+manual 4-file version bump — non-atomicity cannot be fixed, but version-skew partials and
+non-resumable re-runs can (#2639, #2652).
+
+## What's already good (verified — keep, don't touch)
+
+Delta-mode fail-closed rules; finalize-cleanup discipline; the generator suite (the normal local
+gate disables Docker and dataset regeneration is CI-owned by policy — heavy generators run only
+on scheduled/dispatch workflows with pinned, fetchable outputs); python-binding determinism
+harness (#1803 fixed); parity-failure-issue dedup design; perf-regression now signal (flaky
+benches advisory, opt-in label); publish credentials CI-OIDC only; tier-contract machine
+enforcement (lint, retention, contract checks).
+
+## Prioritized recommendations
+
+Issue bodies under epic #2636 are the authoritative acceptance criteria; this table is the map.
+
+### Quick wins (P1, board `Ready`)
+
+| Issue | Change | Win | Effort |
+|---|--------|-----|--------|
+| #2637 | exhaustive-regeneration cron → weekly (or ratify daily + fix docs) | Removes 6 of 7 weekly runs of the heaviest CI lane | S |
+| #2638 | Remove GHCR tag-push from `flight-ci.yml` image job (main/sha only) | Release image can't be clobbered single-arch by the race with `flight-image.yml` | S |
+| #2639 | `trino-publish` `dry_run` default → true; flight-image version dispatch asserts `refs/tags/v$version` == `GITHUB_SHA` (provenance, not prompts) | No accidental publish; no arbitrary SHA wearing a release tag | S |
+| #2640 | Per-gate CPU/process quota: derive `CARGO_BUILD_JOBS` + nextest threads from gate slot; `nice`/`taskpolicy` wrap; `CQLITE_GATE_MAX_CONCURRENCY=1` default; delete pgrep-serialize prose | Oversubscription flake class retired mechanically | S–M |
+| #2641 | sccache corruption: characterize the incident first (load correlation vs disk/eviction artifact), then pick the mitigation from evidence | No blind auto-disable; corruption class addressed on facts | S |
+| #2642 | Apply #2369 record-not-assert to `sstable_performance_regression_tests.rs` + `write_integration.rs:742`; rewire (or consciously retire) the orphaned `cqlite-cli/tests/unit/` directory | Top latent flakes retired; hidden coverage gap closed | S |
+| #2643 | `.config/nextest.toml`: timing/docker test-groups, retries scoped to timing tests only | Timing transients absorbed without masking regressions | S |
+| #2644 | Query-semantics oracle on `pr-gate.yml`, **fail-closed**: `CQLITE_REQUIRE_FIXTURES=1` + required features; fixtures-absent run must FAIL | The reconciliation bug class can no longer merge green — and can't skip-pass vacuously | S |
+| #2645 | Always-emitted docs-only classifier in the required workflow (**no paths-ignore** — a required workflow that doesn't trigger blocks the PR forever); classifier fail-closed on unknown file classes | Near-instant required-green on docs-only PRs, no deadlock risk | S |
+| #2646 | Separate **tracked** dataset pin (the fetch-generated `.dataset-pin` stays untracked), consumed by fetch + existing `bump-dataset-pin.sh`; CI check across the 11 workflows carrying the sha | Silent pin drift impossible | S |
+
+### Structural (P2, board `Backlog`)
+
+| Issue | Change | Win | Effort |
+|---|--------|-----|--------|
+| #2647 | **Step 0: profile** the full gate's compile/link/execution split; only if measured redundant-compile time justifies it, unify the guard-cluster feature sets (dhat/arrow stay isolated) | Either ~minutes/gate or a definitive measurement closing the question | M |
+| #2648 | Branch-protection **drift fix first** (committed config still lists 4 legacy contexts live protection no longer requires; the setup script would restore them), then remove the transitional checkout/setup/compile steps from `ci.yml`'s `test` aggregator **retaining its broad-result aggregation**, and delete `m1-ci.yml`'s no-op contexts. `pr-gate`'s `cargo build` step stays (clippy is not a link/codegen substitute) | Duplicate required compile removed safely; config can't resurrect dead contexts | S–M |
+| #2649 | Consolidate CI Rust caching (one strategy, shared key; cache for coverage-baseline) | 2–4 fewer cold core compiles per PR | M |
+| #2650 | Nightly de-dup via **reusable workflows** (or drop standalone schedules) — preserve the umbrella's citable aggregate pass; note the umbrella's Cassandra source build serves the compaction legs | Each property proven once per night; tier contract intact | M |
+| #2651 | Consolidate compression-corruption / cql-type / tombstone-ttl into one matrix workflow | 3 near-identical 60-min YAMLs → 1 | M–L |
+| #2652 | Release train: shared preflight (prevents **version-skew** partials — five registries cannot be atomic) + `bump-version.sh` (4 hand-edited files today) + resumable re-runs (skip-existing / tolerate-duplicate) | Skew-halves prevented; failed trains resume instead of hard-failing | M |
+| #2653 | python-ci builds/tests the shipped `release-unwind` profile | Release-only breakage caught in CI | S |
+| #2654 | Make `validate-agent-plumbing` merge-required on docs PRs (it already runs there; it just doesn't gate) | #2480 class reds the PR, not the post-merge deploy | S |
+| #2655 | Supervisor-authored git-ref claims + CI-side reaper (#2499 design); heartbeat-clear refuses refs with open PRs; PROJECTS_TOKEN absence alerts | Orphan endgames closed mechanically; management overhead off dev boxes | M |
+| #2656 | Roborev blocker lints, **taxonomy-first** (baseline: 56.7% of classified records, flat) | Review rounds converted to cheap local rounds — if the taxonomy justifies it | M |
+| #2657 | Parallel gate sub-lanes for isolatable non-core components | ~2–4 min/gate (to be measured) | M |
+| #2658 | Widen `--lite` to compile-check dependent test crates on core diffs; no-jq/no-python3 fallback fails loudly | Fewer lite-green→full-red wasted rounds | M |
+| #2659 | Consolidate coverage onto **one** PR-side mechanism (the existing 30% baseline — raise/converge it or auto-file on nightly regression; no third job) | Coverage regressions stop being merge-invisible | M |
+| #2660 | Extend parity-failure-issue triggers to the uncovered nightly lanes | No silent red nights | S |
+
+### P2 residue (deliberately not filed — groom later if wanted)
+
+Test-bin consolidation 318→~150 (L); agent-gate heredoc extraction + generated clippy feature
+list; node determinism harness; bindings fail-closed centralization; semantic-oracle checklist
+lint; flight-image digest to `$GITHUB_STEP_SUMMARY`; rollback runbook (only PyPI yank is
+documented today); `PARITY_HEAL_TOKEN` provisioning.
+
+## Owner decisions (not mine to make)
+
+1. **The local-vs-CI merge boundary.** `ci.yml`'s broad jobs substantially duplicate the heaviest
+   local gate components but only run post-merge or behind `ci:broad`. Promoting them to required
+   and slimming the local full gate trades local wall-clock for merge-feedback latency and
+   touches #2433 doctrine. Status quo is coherent only because every merge genuinely runs the
+   local full gate.
+2. **#2637**: weekly (recommended) vs ratify daily for exhaustive-regeneration.
+3. **Merge-latency appetite** for new required checks (#2644, #2654, #2659).
+4. **#2648**: live protection has `strict=false`, committed config says `strict=true` — pick one
+   deliberately.
+
+## Suggested execution order (reviewer-concurred)
+
+#2648 (drift + duplicate required compile) → #2638 (GHCR tag race) → #2639 (release provenance)
+→ #2644 (fail-closed oracle) → #2653 (release-unwind parity), then the remaining Ready batch;
+#2647/#2641/#2656 gated behind their measure/characterize/taxonomy first steps.
+
+## Revision history
+
+- **rev 2 (2026-07-17)**: Integrated the owner-team review directly into the summary and tables
+  (previously an appended corrections log). Material changes: compilation dominance downgraded to
+  a hypothesis with a profiling gate (#2647); telemetry blocker claim corrected to 56.7% of
+  classified, flat (the original "57% vs 19% rising" divided by all 289 records and is
+  retracted); paths-ignore replaced by an always-emitted classifier (#2645); tracked-pin design
+  replaces committing the generated `.dataset-pin` (#2646, scope 11 workflows); pr-gate's
+  `cargo build` step retained (#2648, plus drift-first ordering); "source-build BTI" corrected
+  (the source build serves compaction legs, #2650); release preflight scoped to version-skew +
+  resumability, not atomicity (#2652); flight-image guard is tag→SHA provenance, not a
+  confirmation prompt (#2639); `--test-threads` claim corrected (per-gate CPU quota is the
+  missing control, #2640); SIGKILL evidence precision (~15 gates; 2 gates ⇒ timing flakes);
+  `enhanced_unit_tests.rs` reclassified as an orphaned-coverage gap (#2642); coverage
+  consolidation instead of a parallel job (#2659); Docker phrasing corrected to policy-based.
+- **rev 1 (2026-07-17)**: Initial six-lane synthesis.
+
+## Evidence
+
+Raw per-lane audit packets (committed): `docs/architecture/build-test-deploy-audit-2026-07-lanes.md`.
+Lanes: local gate, required CI, parity fleet, release train, fleet orchestration, test suite +
+data. Lane packets are pre-review raw evidence — where they conflict with this synthesis (rev 2),
+this synthesis wins.

--- a/docs/architecture/issue-1045-spark-connector-research.md
+++ b/docs/architecture/issue-1045-spark-connector-research.md
@@ -1,0 +1,151 @@
+# Issue #1045 — Spark connector research packet (2026-07-04)
+
+Status: research complete; architecture **A (Spark DSv2 on the existing Flight data plane)** owner-approved
+2026-07-04. Consistency posture + epic filing pending owner decision (see "Decisions").
+
+Four research passes feed this packet: (1) repo map of the existing Trino/Flight connector, (2) Spark
+DSv2 API surface, (3) Spark↔Flight prior art, (4) Apache Cassandra Analytics + Sidecar API state.
+
+## 1. Approved architecture (A)
+
+A thin **Spark DataSourceV2 read connector** that reuses the entire existing data plane: Cassandra
+Sidecar as control plane (ring / `token-range-replicas` / schema DDL), the co-located `cqlite-flight`
+server per Cassandra node as data plane (node-local SSTable reads, KWayMerger read-time reconciliation,
+Arrow batches over Flight `DoGet`), and the JSON `FlightTicket` wire contract unchanged.
+
+The Spark connector reimplements only the engine adapter layer, mirroring `trino-connector/`:
+
+| Trino SPI | Spark DSv2 equivalent |
+|---|---|
+| `CqliteFlightSplitManager.buildSplits()` | `Batch.planInputPartitions()` — one `InputPartition` per token range, pinned to one replica |
+| `CqliteFlightPageSource` (DoGet → Page) | `PartitionReaderFactory.createColumnarReader()` → `PartitionReader<ColumnarBatch>` (DoGet → `VectorSchemaRoot` → `ArrowColumnVector`) |
+| `PredicateTreeTranslator` | `SupportsPushDownV2Filters` → same predicate tree in the ticket |
+| `applyProjection` | `SupportsPushDownRequiredColumns` |
+| Sidecar client | shared verbatim (already Spark-agnostic by design, per flight-trino JOURNAL) |
+
+## 2. Findings by lane
+
+### 2.1 Repo map (what exists, what's reusable)
+
+- `cqlite-flight/` (~7.4k LOC Rust): `service.rs` (FlightService), `producer.rs` (MergeProducer/DirSource),
+  `ticket.rs` (JSON ticket + predicate tree + token range + snapshot name), `filter.rs`, `agg.rs`
+  (aggregation pushdown exists server-side), `stats.rs`, `pathsafe.rs` (#1430 guards).
+- `trino-connector/` (~3.7k LOC Java, package `in.mcfad.cqlite.flight`): the engine-neutral 80% to
+  extract = `sidecar/SidecarClient.java` + `SidecarModels.java`, `buildSplits()` range→replica pinning
+  (prefer local DC, deterministic lexicographic tiebreak), `FlightTicketJson.java`.
+- Correctness is two-layer: connector pins range→replica; Rust server re-filters rows by
+  `DecoratedKey.token ∈ (start, end]` as backstop.
+- **Gap 1 — snapshot lifecycle designed but unwired**: ticket carries optional `snapshot`, producer
+  resolves snapshot dirs, but the connector passes `Optional.empty()` and reads live files
+  (`CqliteFlightPageSourceProvider.java:69`). Freshness/torn-window gap tracked under #1477.
+- **Gap 2 — core-internals coupling**: `cqlite-flight` reaches `cqlite_core::storage::write_engine::KWayMerger`,
+  `SummaryReader`, `DecoratedKey`, `VersionGates` directly — the #1934 Phase 1 porting list. Does NOT
+  block a Spark connector (it talks Flight, never touches core).
+- Key docs: `docs/flight-trino/PLAN.md` (ticket contract, phase 5 = snapshot lifecycle spec),
+  `docs/plans/2026-06-17-cassandra-fast-analytics-arrow-flight-design.md` (frames vs Cassandra Analytics).
+
+### 2.2 Spark DSv2 surface (no architecture-changers)
+
+- **Target Spark 3.5.x (extended LTS → Nov 2027) + 4.0/4.1.** DSv2 read interfaces stable across both;
+  Spark 4 breakage (Scala 2.13-only, JDK 17+, Arrow 18, ANSI) is user-facing, not interface-facing.
+- **Write the connector in Java, single Maven module** (both reference connectors are ~92% Java) —
+  avoids the Scala cross-build matrix. Artifact per Spark major: `cqlite-flight-spark3.5_2.12` etc.
+- **Top engineering risk = Arrow Java version alignment**, not the API. `ArrowColumnVector` binds to
+  Spark's bundled unshaded Arrow (~15.x on 3.5, 18.x on 4.0). Rule: `arrow-vector`/`arrow-memory-core`
+  = `provided`; bring only `arrow-flight-core` pinned to match; shade gRPC/Netty/protobuf, NEVER Arrow.
+  Allocator lifecycle: off-heap refcounted buffers must be closed in `PartitionReader.close()`; budget
+  `spark.executor.memoryOverhead`.
+- **Columnar path**: `supportColumnarReads()=true`, DoGet stream → `VectorSchemaRoot` →
+  `ArrowColumnVector` → `ColumnarBatch`. All-or-nothing per scan (fine — all partitions are Flight).
+- **Pushdown phase 1**: `SupportsPushDownRequiredColumns` + `SupportsPushDownV2Filters` (return
+  unhandled predicates honestly — over-claiming silently drops rows). Phase 2 optional:
+  `SupportsPushDownAggregates` (server `agg.rs` already supports it), `SupportsPushDownLimit`.
+  Skip: legacy `SupportsPushDownFilters`, `TopN`, `Offset`.
+- **Locality**: `InputPartition.preferredLocations()` = replica host (DataStax-connector pattern);
+  best-effort within `spark.locality.wait`. Correctness never depends on it — every partition carries
+  a routable Flight endpoint and works from any executor.
+- **Effort**: ~1.5–3k LOC, single engineer. Novel code = split generation + replica pinning (extracted
+  from Trino anyway); Spark plumbing is well-trodden.
+
+### 2.3 Prior art (verdict: write our own; copy patterns, don't fork)
+
+- `rymurr/flight-spark-source` — Apache-2.0 prototype, dead since 2023-07, pre-modern DSv2. Reference
+  for VectorSchemaRoot→ColumnarBatch plumbing only.
+- `qwshen/spark-flight-connector` — dormant since 2023-04, Dremio-shaped, no custom tickets / host
+  pinning. Reference for pushdown + type mapping only.
+- Apache Arrow ships no official Spark source (none planned); Dremio retired theirs.
+- **Flight SQL / JDBC route ruled out**: Spark's JDBC source partitions only by numeric column ranges,
+  cannot express host-pinned token-range splits or opaque tickets; the JDBC wrapper collapses Flight's
+  multi-endpoint model to one connection. Plain Flight with custom JSON tickets stays necessary.
+- Doris/StarRocks ship the same architecture (tablet ≈ token range, Arrow transport, ~10× over JDBC) —
+  independent validation of the shape.
+- Open design point: raw Flight's idiomatic pattern is server-side `GetFlightInfo` returning one
+  `FlightEndpoint{ticket, locations}` per split. Today split intelligence is client-side (Sidecar-driven,
+  in the Trino connector). See Decision D2.
+
+### 2.4 Cassandra Analytics + Sidecar (the big finding)
+
+- `apache/cassandra-analytics` is **active** (0.4.0, 2026-06-11), Cassandra 3.0/4.0/5.0 bridges,
+  Spark 3.x/4.x. It is the canonical implementation of the sidecar-snapshot/ring technique (CEP-28).
+- **Snapshot lifecycle to adopt** (confirmed from Sidecar source, `ApiEndpointsV1.java`):
+  `PUT /api/v1/keyspaces/{ks}/tables/{table}/snapshots/{name}?ttl=<duration>` (TTL ≥1 min; snapshot
+  self-deletes — leak-safety for crashed jobs, CASSANDRASC-85), `GET` lists components,
+  `DELETE` clears, `GET .../components/{component}` streams (honors HTTP Range). Use the plural route
+  form (singular `/keyspace/...` is deprecated). **Always create with `?ttl=`.**
+- **Consistency semantics — Analytics does NOT read single-replica.** Default `LOCAL_QUORUM`: per range
+  it opens `blockFor(rf, dc)` replicas (RF=3 → 2), async with retry-on-backup (`MultipleReplicas`),
+  and merges all of them through Cassandra's `CompactionIterator` (LWW by cell timestamp + tombstone
+  resolution). CL is a user knob; `ONE` is available but not default.
+  **CQLite's Trino connector single-replica pinning is therefore CL.ONE semantics** — may miss the
+  newest write, may resurrect data hidden by a tombstone on an un-read replica. A genuine correctness
+  weakening vs the ASF reference, not a neutral choice. See Decision D1.
+- **Borrow**: snapshot TTL; primary/backup async open + retry failover model; structure split assignment
+  around `blockFor(rf, dc)` even if v1 ships single-replica, so quorum-merge can be added without redesign.
+- **Avoid**: static-IP ring discovery (Analytics limitation — we already discover via Sidecar);
+  undocumented single-replica reads.
+- **CQLite's opening**: Analytics is JVM-bound (embeds Cassandra for `CompactionIterator`) and still
+  lacks BTI/`da` support (CASSANALYTICS-27, in progress). CQLite reads BTI natively. The only non-JVM
+  prior art (`datastax/sstable-to-arrow`) is abandoned. Native Rust reader + Arrow transport fills a
+  real gap.
+
+## 3. Decisions
+
+- **D1 (OWNER — DECIDED 2026-07-04): ship CL.ONE, documented.** v1 reads each range from ONE replica,
+  with the CL.ONE contract prominently documented (Spark docs + a docs fix for the shipped Trino
+  connector, which has the same undocumented semantics today). Split-assignment API structured around
+  `blockFor(rf, dc)` so cross-replica quorum-merge can be added later without redesign; a follow-up
+  research issue covers quorum-merge (hard: cell-timestamp reconciliation across nodes' Arrow streams —
+  today KWayMerger reconciles only node-locally).
+- **D2 (design-time, lead default = client-side).** Split intelligence stays client-side in shared
+  connector-commons (mirror Trino; zero Rust changes) vs server-side `GetFlightInfo` (Flight-idiomatic
+  but couples the per-node server to Sidecar). Revisit at OpenSpec design for the epic.
+- **D3 (lead defaults, owner may veto):** Java over Scala; Maven; Spark 3.5 + 4.x dual target;
+  columnar-only reads; phase-1 pushdown = columns + V2 filters.
+- **D4 (scope).** Read-only v1. Bulk write (Analytics writer equivalent) explicitly out of scope.
+- **D5 (dependency).** Sidecar snapshot lifecycle (#1477 territory) is shared infrastructure both
+  connectors want; recommend it as a named sibling issue (adopting the `?ttl=` pattern), with the Spark
+  connector documenting the live-read freshness caveat until it lands.
+
+## 4. Epic shape (FILED 2026-07-04)
+
+#1045 retitled → "[EPIC] Spark connector — DSv2 read connector on the Flight data plane". Children
+(all design-driven → OpenSpec at pickup, board Status=Backlog, P3):
+
+1. **#1947 (S1)** connector-commons extraction — SidecarClient/Models, `TokenRangeSplitPlanner`
+   (ex-buildSplits pinning), FlightTicketJson out of `trino-connector/` into a shared Gradle module.
+   AC: trino-connector green against it, zero behavior change. Coordination note vs #1910 embedded.
+2. **#1948 (S2)** Spark DSv2 read connector — Java, `TableProvider`/`Scan`/`Batch`/`InputPartition`/
+   columnar `PartitionReader`; schema from Sidecar DDL; `preferredLocations` = replica host.
+   AC: value-parity vs JSONL goldens on a loopback harness. Depends on #1947.
+3. **#1949 (S3)** pushdown phase 1 — RequiredColumns + V2Filters → ticket predicate tree, honest
+   unhandled-return. AC: pushdown-on vs -off result identity + plan assertions. Depends on #1948.
+4. **#1950 (S4)** E2E on 3-node RF=3 docker-compose + website docs incl. CL.ONE + freshness contracts.
+   Closes the epic's wiring-evidence. Depends on #1948/#1949.
+
+Related (pre-existing #941 children cover two planned siblings — no dups filed):
+- **#1906** (df-provider A2) IS the Sidecar snapshot lifecycle work (adopt `?ttl=` per §2.4).
+- **#1911** (df-provider A7) carries the Trino-side CL.ONE contract documentation (research finding
+  cross-posted there 2026-07-04).
+- **#1951** quorum-merge research (decision packet on lifting CL.ONE toward blockFor-replica reads).
+
+Placement: engine-side connector tier per the #1934 split decision. Priority P3 unless owner reschedules.

--- a/docs/architecture/issue-2310-ms-point-reads-research.md
+++ b/docs/architecture/issue-2310-ms-point-reads-research.md
@@ -1,0 +1,158 @@
+# Millisecond point reads through cqlite-flight — cost-model gap analysis (issue #2310)
+
+Read-only static analysis at `main` @ `84b61a29` (2026-07-09). Feeds epic #2310 (warm-handle
+service). No stacks/gates/benches were run; all timings are cited from existing field/harness
+artifacts. Cwd for every command: `/Users/patrickmcfadin/local_projects/cqlite`.
+
+## Headline
+
+**A `WHERE pk = X` query through cqlite-flight does NOT do a point read today. It full-scans every
+partition of the table through the k-way compaction merge and applies the PK predicate as a per-row
+`filter.keeps()` egress filter.** The pushed-down predicate reaches the server in the ticket
+(#2164/#2166) but is used only to drop non-matching rows on the wire — it wins 1 row of egress while
+performing O(table) I/O + decode. This single term dominates point-read latency by **3–4 orders of
+magnitude** over every other cost in the path (snapshot PUT, per-request parse, gRPC/Arrow framing).
+
+Consequence for the epic that commissioned this research: **#2310 (warm generation-keyed readers) is
+a Phase-2 optimization, not the lever for ms point reads.** It caches the parse work of a scan that
+should not be happening. The ordered levers are: **#2207 first (turn the scan into an index probe),
+#2295 + #2302 alongside (make the index actually resolvable/present so the probe has something to
+probe), then #2310 (stop re-parsing the index every request), then #2306 (stop the per-query
+snapshot PUT + memtable flush).**
+
+## Measured baselines (existing artifacts, not re-run)
+
+| Env | Table shape | Query | Latency | Source |
+|---|---|---|---|---|
+| 3-node AWS kit (`i4i.xlarge`, nb-big/LZ4) | `keyvalue`, **2.16M partitions/node**, 3 SSTables | `WHERE key='<pk>'` point read | **271s** (full scan, killed) | #2157 round-3 disproof |
+| same | same | `SELECT * … LIMIT 5` | **190–433s** (one completed ~189s) | #2157 round-3 |
+| same | same | `SELECT count(*)` | 358s+ | #2157 round-3 |
+| local docker harness (arm64, all index components present) | ~100k-partition `keyvalue` | `LIMIT 5` | **3s** | #2289 harness run |
+
+The field's 100%-in-`do_get`, `rpc_rows_total` flat-at-0-for-210s signature (#2157 round-3) is the
+compound of two stacked amplifiers: (a) #2207 — the scan is O(table), and (b) #2295 — the field's
+Sidecar snapshot dir contained **only Data.db** (no Index/Summary/Filter), so each SSTable's
+compaction stream *fully materializes* the whole Data.db (414,957 partitions cloned+sorted) before a
+byte streams, instead of streaming with backpressure.
+
+## End-to-end point-read path, traced in code
+
+### Trino connector side (per query, on the critical path, synchronous before splits)
+1. `CqliteFlightSplitManager.getSplits` (`.../CqliteFlightSplitManager.java:43`) →
+   `sidecar.tokenRangeReplicas(keyspace)` — **1 Sidecar HTTP round-trip** (topology).
+2. `SnapshotManager.snapshotFor` (`SnapshotManager.java:80`) → `createOnHost` → `SidecarClient.createSnapshot`
+   PUT `/api/v1/keyspaces/{ks}/tables/{tbl}/snapshots/{snap}` (`SidecarClient.java:82`) on **every
+   replica host** the splits will read. Each PUT is **an HTTP round-trip PLUS a Cassandra memtable
+   flush** of the queried table (#2305/#2306 — the Sidecar create-snapshot endpoint has no
+   `skipFlush`; only `?ttl=` is exposed). Fail-closed on any primary host.
+3. `applyLimit`/predicate reach the ticket via `FlightTicketJson`; one split per token range, each
+   pinned to a replica.
+
+### Flight server side (`do_get`, per request, NO warm state)
+4. `FlightServiceImpl::do_get` → `do_get_inner` → `do_get_setup` (`service.rs:479`), all inside
+   `spawn_blocking`:
+   - `FlightTicket::from_bytes` + `build_producer` → `parse_schema` → `parse_cql_schema` — **schema
+     parsed from ticket every request** (`service.rs:138`).
+   - `DirSource::resolve` — filesystem `is_dir`/`read_dir` of the snapshot (or live) table dir
+     **every request** (`producer.rs:146`).
+   - `resolve_paths_cancellable` → `data_paths` lists the dir; `prune_paths_cancellable` reads each
+     SSTable's `Summary.db` for token-span prune (`producer.rs:618`) — token/split prune only, **no
+     PK prune**.
+5. `produce_streaming` (`producer.rs:582`) → `KWayMerger::new_cancellable(paths, …)` over **all**
+   surviving SSTables → `drive_merge` (`producer.rs:719`).
+6. `KWayMerger` opens each SSTable via `SSTableRowIteratorAdapter::open` →
+   `stream_all_partitions_for_compaction` (`compaction.rs:547`) — a **full sequential Data.db walk**
+   per SSTable. For an index-less input it "fully materialises the whole Data.db in one pass"
+   (`merge/mod.rs:2159`).
+7. `drive_merge` loop (`producer.rs:719-812`): per partition, per row build the full row, then
+   `filter.keeps(&row)` (`producer.rs:788`) — **the PK equality is applied HERE, as a per-row
+   filter over every partition in the table.** Token filter drops partitions outside the split
+   range only. LIMIT counted post-filter.
+8. Rows buffered to `batch_size` (8192), Arrow-encoded, `blocking_send` down the cap-4 do_get
+   channel → gRPC.
+
+**The machinery to do a real point read exists but is NOT wired to this path:** per-SSTable
+`lookup_partition_with_index` / `lookup_partition_via_bti_trie` / `might_contain_partition` (bloom
+presence oracle) in `partition_lookup.rs:25/136/416`, and `point_lookup_rows` /
+`execute_point_lookup` in the core query executor (`executor.rs:303/322`). The flight producer never
+calls any of them — it only knows the compaction-merge scan.
+
+## Cost model
+
+| Step | Today's cost class | Evidence (file:line) | What removes it | Expected residual after fix |
+|---|---|---|---|---|
+| Trino plan + split scheduling + gRPC/Arrow fixed | fixed per-query (~tens–~100ms) | Trino coordinator; `CqliteFlightSplitManager.java:43` | inherent to going through Trino | **floors through-Trino at ~50–150ms** |
+| Sidecar `tokenRangeReplicas` | per-query network RT | `CqliteFlightSplitManager.java:50` | cache topology (out of scope; minor) | ~ms |
+| Sidecar snapshot PUT **+ memtable flush** per replica host | per-query network RT **+ flush latency + cluster churn** | `SnapshotManager.java:80`, `SidecarClient.java:82` | **#2306** (snapshot reuse/TTL, or nodetool `--skip-flush`, or upstream skipFlush) | ~ms (reused snapshot); flush churn eliminated |
+| Schema parse from ticket | per-request parse | `service.rs:138` | **#2310** (cache per table) | ~0 |
+| `DirSource::resolve` + dir listing | per-request fs stat/readdir | `producer.rs:146`, `service.rs:491` | **#2310** (generation-keyed warm set) | ~0 (staleness probe only) |
+| Per-SSTable reader open + Statistics/Summary/Index/bloom parse | **per-request fs+parse × #SSTables** | `merge/mod.rs:528`, `#1599` | **#2310** (parse-once-per-generation) | ~0 (warm hit) |
+| **Full-table merge scan + per-row PK filter** | **per-row decode × O(table)** — DOMINANT | `producer.rs:719-812`, `compaction.rs:547` | **#2207** (PK-equality → index point-read + presence-oracle SSTable prune) | index probe (O(log n)) + ~3 partition reads + reconcile ≈ **single-digit ms** |
+| Index-less snapshot forces full Data.db materialize | per-request O(Data.db) materialize | `merge/mod.rs:2159`, `#2295`, `sequential.rs:759` | **#2295** (complete snapshots) + **#2302** (resolve present pairs) | streamed/point-addressable |
+| Wide-partition full materialize in `step()` | O(largest partition) peak mem | `merge/mod.rs:2264`, `producer.rs:666`, `#2230` | **#2230** (bounded intra-partition) | not on narrow point-read path; matters for wide-partition point reads |
+
+## Phased answer — ordered, minimal set to reach ms-class point reads
+
+The ms target applies to **flight-direct `do_get` latency** (a Flight client hitting `<node>:8815`).
+Through-Trino latency carries an irreducible Trino-coordinator floor (planning + split scheduling +
+page-source plumbing) of roughly **50–150ms** regardless of how fast the engine is — say so when
+reporting: "ms point reads" = flight-direct; through-Trino target is "low-double-digit to ~100ms".
+
+- **Phase 0 (today):** point read = **190–433s** field (full scan of 2.16M partitions). Flight-direct
+  same order.
+- **Phase 1 — #2207 (PK point-read/prune) + #2295 (complete snapshots) + #2302 (resolve present
+  pairs).** These are one package: #2207 turns the scan into an index probe, but the probe only
+  exists if the snapshot actually ships Index/Summary/Filter (#2295) and those components resolve for
+  the write source (#2302 covers CQLite-written pairs; the field's nb-big are Cassandra-written and
+  fine once #2295 stops stripping them). Presence-oracle (bloom) prune drops SSTables that
+  definitely lack the key. Expected flight-direct floor: **single-digit to low-double-digit ms** —
+  dominated by per-request reader-open + Index/Summary/Statistics parse across the surviving
+  SSTables. Reconciliation across all candidate SSTables is preserved (LWW/tombstone-correct — the
+  reason #2207 is design-driven, not a patch).
+- **Phase 2 — #2310 (warm generation-keyed readers).** Removes per-request schema parse, dir
+  resolve, and reader-open/index/summary/bloom parse (now the Phase-1 residual). Cache key =
+  generation identity (inode-stable across snapshot dirs), refreshed on the Seam-1-chosen trigger,
+  fail-closed. Expected flight-direct floor: **low single-digit ms** — just the index probe from
+  warm state + a page-cache partition read + Arrow-encode of a few rows.
+- **Phase 3 — #2306 (snapshot amortization) + #2230 (wide-partition bound).** #2306 removes the
+  per-query Sidecar PUT + memtable flush from the through-Trino critical path (and the cluster
+  churn) — this is a *latency* lever for through-Trino, not only an operational one. #2230 bounds
+  the wide-partition case so a point read into a multi-GB partition stays ms and memory-bounded.
+  Expected through-Trino floor: **Trino-coordinator-bound (~50–150ms)**; flight-direct unchanged at
+  low single-digit ms.
+
+**What dominates the remaining floor after all phases:** flight-direct → the index probe + one
+partition read + Arrow encode (low single-digit ms, page-cache-bound). Through-Trino → the Trino
+coordinator's own query lifecycle (~50–150ms), which no engine change can remove. If the product
+needs true single-digit-ms point reads, they must go **flight-direct (do_get), bypassing Trino** —
+Trino is for analytical/federated queries, not an OLTP point-read front door.
+
+## Measurement plan (#2289 harness)
+
+The #2289 local docker harness already records LIMIT-5 timings (3s on ~100k partitions with full
+index components) and snapshot-dir listings every run. Per phase:
+- **Baseline / after each phase:** run the harness `WHERE key='<pk>'` point read and `LIMIT 5` on
+  the ≥100k-partition `keyvalue` table; record `cqlite_rpc_duration_seconds{do_get}` and
+  `rpc_rows_total` (must show a series — flat-at-0 = still materializing). Distinguish flight-direct
+  (drive `do_get` with a raw Flight client) from through-Trino (Trino query wall time).
+- **#2207 proof (already an AC on the issue):** CountingStepper-style probe asserting partitions
+  examined ≈ candidate-SSTable point lookups, NOT the table's partition count.
+- **#2295 proof:** the harness's snapshot-listing artifact must show Index/Summary/Filter present;
+  the partition-lookup strategy probe must show the index path (not `sequential_scan`).
+- **#2310 proof:** hit/miss/evict + refresh counters; second identical query on unchanged
+  generation shows ~0 parse cost (WS4/WS5 bench evidence on the same harness + #1494 bench suite).
+- **#2306 proof:** measured flush/SSTable-creation rate under a query-heavy default-mode workload
+  (the harness can host it) before/after.
+- The field 3-node kit (#2103) remains the adjudicator for multi-node placement/failover; single
+  node cannot adjudicate #2227/#2241.
+
+## Biggest surprise
+
+The epic that requested this research — **#2310, warm handles — is not the lever for ms point
+reads, and by itself cannot deliver them.** It caches the parse cost of a full-table merge scan that
+should never run for `WHERE pk = X`. The flight producer has **no point-read code path at all**; it
+unconditionally builds a `KWayMerger` over every SSTable and applies the pushed-down PK equality as a
+per-row `filter.keeps()` (`producer.rs:788`) — so the pushdown that looks "done" on the connector
+side (predicate visible in EXPLAIN) buys only 1 row of egress while doing O(2.16M-partition) I/O and
+decode. #2207 must land first; #2310 only becomes the dominant residual *after* the scan has been
+converted into an index probe. This reorders the epic's own implied phasing.

--- a/docs/architecture/issue-905-compaction-manager-research.md
+++ b/docs/architecture/issue-905-compaction-manager-research.md
@@ -1,0 +1,320 @@
+# Issue #905 — Compaction Manager: Exploration Research (2026-07-04)
+
+**Issue:** [#905](https://github.com/pmcfadin/cqlite/issues/905) — Support a compaction manager
+**Companion:** `docs/compaction-manager-design.md` (draft design; predates M5 landing)
+**Status:** Research synthesis — no epic/children filed yet (owner exploring)
+
+Two research waves. Wave 1 (3 passes): UCS source read (trunk), CQLite reuse audit,
+ecosystem prior art. Wave 2 (5 passes, deep dive): UCS verified against `cassandra-5.0`
+(`origin/cassandra-5.0` @ `464b2e54f4`) + trunk diff, lifecycle txn-log protocol, purge/overlap
+semantics, CompactionManager scheduling + standalone-tool template, and a CQLite
+product-direction alignment analysis. This doc is the consolidated record; a future
+refresh/grooming pass starts here.
+
+---
+
+## 1. Verdict on the design doc's premise
+
+**Still valid, strengthened.** As of mid-2026 no tool in the Cassandra ecosystem performs
+offline SSTable *merge* compaction:
+
+- Cassandra's offline family (`sstablesplit`, `sstableofflinerelevel`, `sstablescrub`,
+  `sstableupgrade`) rewrites/relevels/splits — never merges. `nodetool compact` is online-only.
+- Instaclustr `ic-tools purge` runs *fake* compactions to estimate reclaimable bytes; no output.
+- Medusa dedups backup uploads; never compacts. Its own docs recommend online major
+  compaction to shrink snapshots — the exact workload an offline compactor relocates.
+- **Strongest signal:** ScyllaDB has an OPEN, unshipped first-party feature request for
+  exactly this — `scylla-sstable compact`, [scylladb/scylladb#20531](https://github.com/scylladb/scylladb/issues/20531)
+  (Sept 2024, still open). Both engine teams see the gap; neither has filled it.
+- **The simulator is the most defensibly novel piece.** Existing "simulators" are generic
+  analytical models (VLDB'21 LSM design-space) or toy teaching tools (skyzh mini-lsm).
+  Nothing replays a strategy against a real snapshot's on-disk metadata.
+- **Offload:** proven pattern elsewhere (RocksDB `CompactionService`, Rockset, CaaS-LSM
+  SIGMOD'24, D2Comp) but unclaimed for Cassandra — no CEP. Keep as forward-looking
+  groundwork. Sidecar (CEP-40 era) is a plausible future host.
+- **UCS adoption nuance:** UCS is NOT the OSS 5.0 default (STCS still is; CEP-26 plans the
+  flip after a testing period; vendors like Instaclustr already default to UCS). Say
+  "converging on," not "converged."
+- No filed Cassandra JIRA asks for offline compaction — demand is real but expressed as
+  snapshot/backup disk-blowup pain (widely documented), i.e. diffuse.
+
+## 2. UCS ground truth — VERIFIED against cassandra-5.0
+
+Wave-2 diffed every UCS file between `origin/cassandra-5.0` and trunk.
+**The deterministic core math is byte-identical on both refs** — the earlier trunk-only
+caveat is CLOSED. Path prefix: `src/java/org/apache/cassandra/db/compaction/`.
+
+### Deterministic core (replicate this; identical 5.0 ↔ trunk)
+
+- **Density** = `onDiskLength / rangeSpanned` (`ShardManager.density`, ShardManager.java:139).
+  `rangeSpanned` prefers **`StatsMetadata.tokenSpaceCoverage` — a stored double in
+  Statistics.db** (authoritative; no-heuristics-friendly), falling back to first/last-key
+  token span. Floor guard `MINIMUM_TOKEN_COVERAGE = 2^-48`.
+- **Levels** geometric in fanout F: level max density = prev max × F, from
+  `baseSstableSize(F) = max(1MiB, flushSize) * (1 − 0.9/F)`. MAX_LEVELS=32.
+  **UCS ignores the stored LCS `sstableLevel` int** — levels derive from density only.
+- **Scaling parameter** `w`: F = `w<0 ? 2−w : 2+w`; threshold t = `w≤0 ? 2 : 2+w`;
+  `Tn`→w=n−2, `Ln`→w=2−n, `N`→w=0. Per-level array, last value repeats.
+- **Trigger:** a level compacts iff **maxOverlap ≥ t** (overlap count via sweep over
+  first/last keys, `Overlaps.constructOverlapSets` — `utils/Overlaps.java` is byte-identical
+  across refs). NOT raw sstable count (design doc Appendix A misstates this).
+- **Level tie-break is deterministic** (strict `>`, lowest/first level wins);
+  **bucket tie-break within a level is random** (reservoir sample).
+- **Shard count** (`Controller.getNumShards`): power-of-two multiple of `base_shard_count`;
+  `pow = log2(density/(target·base))·(1−growth) + 0.5`, growth default 0.333, min-size
+  guard below base count.
+- **Shard boundaries**: even token-fraction split of the node's weighted local ranges via
+  `partitioner.split` — exact interpolation. **Deterministic given (partitioner, local
+  ranges+weights, shardCount) → byte-identical boundaries achievable offline.**
+
+### 5.0 → trunk deltas (track, don't implement for a 5.0 target)
+
+| Delta | Class |
+|---|---|
+| Major compaction: 5.0 `getMaximalTask` splits by token-overlap only; trunk `getMaximalTasks` additionally density-shards via `splitSSTablesInShards` (new primitive, absent in 5.0) | MATH-CHANGE, major/manual path only; background pick unchanged |
+| `parallelize_output_shards` (trunk, default on): one pick → N per-shard parallel tasks under a `CompositeLifecycleTransaction`. Same final file set; execution mechanism only. Caveat: inner tasks recompute *local* density — never call `getNumShards` twice at different scopes | RUNTIME-ONLY |
+| `ShardManagerDiskAware.count()/shardIndex()` JBOD fix (CASSANDRA-18802): 5.0 under-counts shards across multiple data dirs | BUG-FIX; irrelevant for single-directory offline use |
+| TCM epoch replaces ring-version staleness checks | RUNTIME-ONLY |
+
+### More UCS facts (verified on 5.0)
+
+- **No adaptive controller exists in mainline Cassandra** (exhaustive grep, both refs) —
+  auto-tuning `w` is documentation aspiration only. A static-config offline planner is
+  *faithful*, not approximate.
+- **No legacy-STCS special case exists.** Arbitrary/legacy sstables flow through the same
+  density → level assignment; a whole-ring STCS giant just lands in a high level,
+  deterministically. **The design doc's "convergence as a first-class planner mode"
+  dissolves** — convergence is just repeated planning, which the simulator can cost.
+- **STCS-equivalent default = `T4` (w=2, F=t=4)**, matching STCS `min_threshold=4`
+  (documented in `UnifiedCompactionStrategy.md`). Other defaults: base_shard_count 4,
+  target 1GiB, min_sstable_size 100MiB, growth 0.333, expired-check 600s,
+  overlap_inclusion TRANSITIVE.
+- **Flush size:** `flush_size_override` config wins; else live metric; **fresh-node
+  fallback = exact 1 MiB floor** in `getBaseSstableSize` (`max(1<<20, flushSize)`).
+  Offline: take flush size as an explicit input; default to the documented 1 MiB floor;
+  optionally allow "derive from smallest lowest-density sstables in the corpus" as an
+  explicit opt-in (closer to warm-node behavior).
+- **Expiration:** `unsafe_aggressive_sstable_expiration` is double-gated (table option AND
+  JVM property; fails closed). Expired sstables are computed once per pick call (10-min
+  wall-clock throttle), removed from the pool, then UNIONED into the chosen pick — or
+  returned as a standalone drop-only pick (`level=-1,overlap=-1` sentinel) if nothing else
+  triggers.
+- **UCS does NO ratio-based single-sstable tombstone compaction** — inherited
+  `tombstone_threshold` options are validated but inert. → design doc §15 Q4
+  (`JobKind::TombstoneOnly`): **defer, confidently.**
+- Minimal planner `SSTableMeta` = {size, firstToken, lastToken, tokenSpaceCoverage,
+  maxTimestamp, maxLocalDeletionTime, repairedAt/pendingRepair}.
+- Selection within a bucket: oldest-first by maxTimestamp; happy path (count ≤ F) takes
+  the whole bucket.
+
+### Fidelity posture (answers design doc §15 Q2)
+
+**Shard-boundary parity = feasible + worthwhile** (deterministic; determines output key
+ranges → byte layout), given topology/flush-size/config as **explicit inputs**.
+**Pick-selection parity = ill-defined** (random bucket tie-break + live-set state). Frame
+the planner as a **proposer/validator of candidate picks**. For `authoritative`/full-dataset
+runs, topology degenerates to whole-ring coverage.
+
+## 3. Purge / overlap semantics (verified on 5.0) — the precision ladder
+
+From `CompactionController.getPurgeEvaluator` (CompactionController.java:244-284) and
+collaborators:
+
+| Rung | What it computes | Offline data needed | Verdict |
+|---|---|---|---|
+| **(a) CQLite today** | one global `min(minTimestamp)` over ALL outside sstables (all treated as overlapping) | Statistics.db (have) | Correct, maximally conservative |
+| **(b) Interval overlap** | restrict (a) to sstables whose `[first,last]` key range intersects the compaction's merged range — port of `getOverlappingLiveSSTables` normalization (sort by first key, merge touching bounds) | first/last key per sstable (have) | **Recommended v1 target** — closes the "unrelated key range holds the bound hostage" gap with zero new I/O |
+| **(c) Cassandra's per-partition evaluator** | per partition, lazily: interval test → bloom-filter probe (`mayContainAssumingKeyIsInRange`; index probe if filter uninformative) → fold only plausibly-containing sstables' minTimestamps | `Filter.db` reader (NEW read path) | v2, after (b)'s purge-yield is measured on real corpora |
+
+Key findings:
+
+1. **Range tombstones / partition deletions need nothing finer than partition-key
+   granularity** — Cassandra applies the SAME per-partition bound to cell tombstones, range
+   tombstones, and partition deletions; it never checks clustering-range overlap. Rung (c)
+   is full Cassandra parity; anything finer exceeds the reference.
+2. **CQLite's coarse global bound IS Cassandra's fully-expired-drop algorithm** —
+   `getFullyExpiredSSTables` uses exactly that min-timestamp shape at file granularity (no
+   bloom filters). Keep the coarse bound for whole-file drops (a separate, cheap, high-value
+   tier Cassandra runs FIRST); add rung (b) for in-rewrite tombstone purging.
+3. **TTL purge math (pin as a parity test; touches #1537/#1538):** an expired TTL cell
+   converts to a synthetic tombstone with `localDeletionTime = original write time`
+   (`ldt − ttl`), NOT expiration time (`AbstractCell.purge`, AbstractCell.java:76-99).
+   Effective purge eligibility = `writeTime + max(ttl, gc_grace)` — **not**
+   `writeTime + ttl + gc_grace`. Intentional repair-correctness choice (comment at :88-90).
+   The cross-sstable shadowing check uses the original write *timestamp*, unchanged by the
+   conversion.
+4. `gcBefore = nowInSec − gc_grace`, wall clock of the compacting node, sampled ONCE per
+   compaction run. 2i tables skip gc_grace entirely.
+5. `onlyPurgeRepairedTombstones`: if on and inputs aren't all repaired → NO purging at all
+   that run. `NEVER_PURGE_TOMBSTONES` → purge evaluator returns constant-false.
+6. **`GarbageSkipper`/shadow-sources (TombstoneOption ROW/CELL) is optional** — proactive
+   shadowed-data stripping that opens overlapping sstables at key positions. Purge
+   *correctness* never requires reading overlapping data; bloom/interval checks suffice.
+
+## 4. Crash safety — txn log verdict (verified on 5.0)
+
+**The design doc's §7.3 commit-record txn log is NOT needed for CQLite's offline case.**
+
+Why Cassandra needs it: component files are written directly under final filenames (no
+tmp-then-rename for new sstables) — no filesystem rename barrier can make a multi-file
+sstable appear atomically, so an out-of-band log (`<ver>_txn_<op>_<uuid>.log`, per-line
+CRC32, ADD/REMOVE/COMMIT/ABORT records, replicated per data dir, tolerant of a torn last
+line) is the only atomic publication mechanism. Recovery: last valid record COMMIT →
+roll-forward (finish deleting REMOVEs); else roll-back (delete ADDs).
+
+Why CQLite doesn't: **live/dead is a pure function of `TOC.txt` existence**, enforced
+symmetrically — publish renames TOC last (compaction.rs:414-433); unpublish deletes TOC
+first (maintenance.rs:489-538); the startup sweep reclaims any TOC-less Data.db
+(sweep.rs:113-183). This already yields the functional equivalent of roll-forward for the
+worst window (crash mid-input-deletion after publish): a not-yet-deleted input is a
+harmless duplicate that LSM merge semantics reconcile; a half-deleted one is swept.
+Re-running the whole job is always safe.
+
+**The ONE real gap (fix regardless of #905): no directory fsyncs in the compaction
+finalize path.** `durability.rs`'s ancestor-chain fsync barrier is wired into FLUSH only;
+`compaction.rs`'s rename/delete sequence has none. Under power loss (not process kill) the
+OS may reorder renames/unlinks so `TOC.txt` lands durably while a sibling component doesn't
+— reopening exactly the ambiguity the TOC invariant closes. The existing crash-injection
+test (`FAIL_COMPACTION_BEFORE_RENAME`) simulates process crash only (syscall order
+preserved). Fix: reuse the `durability.rs` helper after the rename batch and around input
+deletion. Small, oracle-driven, hardens the SHIPPED write engine.
+
+Nice-to-haves (not correctness): a durable "output W superseded inputs X,Y,Z" audit record;
+live-node detection should scan for Cassandra's `*_txn_*.log` filename pattern (regex
+`^((?:[a-z]+-)?.{2}_)?txn_(.*)_(.*)\.log$`) in target dirs.
+
+## 5. Manager/daemon + standalone-tool reference (verified on 5.0)
+
+- **Cassandra's scheduler is event-driven, not polled**: state changes nudge
+  `submitBackground(cfs)`; each nudge asks that table's strategy for ONE task; cross-table
+  fairness is emergent from a flat shared pool (no priority queue, no manager-level
+  ranking). Starvation guard: skip re-submit if the table already has a running task and
+  the pool is saturated (CASSANDRA-4310). → The daemon needs a nudge queue + per-table
+  polls, not a clever scheduler.
+- **Throttle**: ONE global live-updatable RateLimiter shared by all tasks, acquiring
+  **compression-ratio-adjusted bytes** (models physical disk I/O). Default 64MiB/s; 0 =
+  unlimited. Copy exactly.
+- **Disk-headroom**: per-task pre-check; worst-case estimate (output = Σ inputs) + two
+  stacked margins (absolute floor per drive × fractional cap), accounts for other in-flight
+  compactions' remaining writes; `reduceScopeForLimitedSpace` drops the largest input and
+  retries; hard abort (+ `compactionsAborted` counter) when it can't shrink.
+- **No write backpressure exists in Cassandra** — `estimatedRemainingTasks` is
+  observational only. A CQLite daemon can consciously match (metrics-only) or exceed.
+- **UCS major compaction always shards** (`--split-output` silently ignored by UCS):
+  N non-overlapping token groups × M density shards. Single-monolithic-output major is an
+  STCS-ism. Confirms design doc §6.3's sharded-major shape.
+- **Standalone-tool template** (`StandaloneScrubber` et al.):
+  `DatabaseDescriptor.toolInitialization()` (config subset + partitioner + formats; no
+  gossip/sockets) → offline schema load → `openNoValidation` per sstable (one bad file
+  doesn't abort) → work inside `LifecycleTransaction.offline()` (dummy tracker — proof the
+  safety layer runs headless) → snapshot-by-hardlink before mutating.
+- **Cassandra's standalone tools have NO live-node guard** — their docs say "the script
+  does not verify that Cassandra is stopped." CQLite's refuse-if-live check (txn-log
+  pattern scan + own flock) would EXCEED the reference. Differentiator.
+- Status API reference (3 tiers): per-task `CompactionInfo` (id, table, completed/total/
+  unit, inputs, target dir; pull-model snapshots); gauges (pendingTasks[-ByTable],
+  active); counters/meters (completed rate, bytes logical+compressed,
+  `compactionsAborted`, `compactionsReduced` — cheap high-value health signals).
+
+## 6. CQLite reuse audit (what M5 already gives us)
+
+| Design-doc layer | Status | Cost | Notes |
+|---|---|---|---|
+| Executor (k-way merge + reconciliation + write) | **EXISTS** | S–M | `compact_sstables_with_registry` (merge/mod.rs:1684) is a WriteEngine-free free function over an arbitrary input dir; CLI `cqlite compact` (#842) calls it. Missing: GC modes, throttle, dry-run, **sharded output** (single-output today). |
+| Crash safety | **EXISTS — stronger than first assessed** | S | TOC-existence invariant ≈ functional roll-forward (see §4). Real gap = missing dir-fsyncs in finalize path. Commit-record log NOT needed. |
+| Planner (trait + UCS) | **MISSING** | L | `STCSPolicy` bucketing pure (#1666) but behind an I/O-doing `&[PathBuf]→Vec<PathBuf>` trait, size-only metadata. UCS, density, TableState/CompactionJob, overlap sweep, explain/dry-run net-new. |
+| Simulator inputs (Statistics.db) | **EXISTS-BUT-ENTANGLED** | M | size + min/max timestamp ready. `tokenSpaceCoverage` not yet exposed by our parser (wiring). Fallback: Summary.db first/last key (summary_reader.rs:150) + existing `cassandra_murmur3` → tokens (wiring). Droppable-tombstone scalar derivable from parsed `tombstone_drop_times` histogram (no consumer today). Per-sstable level absent — UCS doesn't need it. |
+
+Additional: **no `CompactionManager` struct exists in code** (`docs/read-path/02-storage-engine.md`
+shows an aspirational one — stale; #176 removed the old infra). Real driver =
+`WriteEngine::maintenance_step(budget)`. One-shot `cqlite compact` purge policy is only the
+boolean `--major`/`purge_safe`; the three-mode `off/grace/authoritative` policy layers over
+existing plumbing (`compute_gc_before` already reads schema gc_grace, purge-disabled when
+absent). Debt on this path: #1537/#1538 (TTL P0s in reconcile.rs — executor inherits),
+#1849 (gates the read-equivalence property-test ORACLE, not the build), #1610 Epic Q
+(merge perf; Q3 determinism), **#1633 T2 (12.3k-LOC merge/mod.rs — extraction rides that
+split)**.
+
+## 7. Product-direction alignment (#1934, #941, storage engine, milestones)
+
+**Synergies**
+- **#1934 engine split:** the pure `plan()` trait is a textbook exhibit for the Phase-1
+  curated engine API (no entangled callers to migrate, unlike the query engine). The
+  simulator is a plausible flagship demo for the new engine-tier product name (WS5).
+- **Storage-engine/memtable path:** the tail dir `CqliteTailExporter` fills is exactly what
+  #905's manager maintains — **same component, second data source**.
+- **#941 Flight:** producer.rs re-drives the k-way merge per query (no pre-merge
+  assumption) — hardening the shared merge core benefits both. **Design C
+  (materialized-epoch provider, #1914) ≈ a #905 major-compaction snapshot — reconcile the
+  two designs before #1914 activates** to avoid building "merge once, serve many" twice.
+- **T2 #1633:** write planner/executor extraction as additional seams of that split.
+
+**Conflicts / tensions**
+- **#1406 uncompressed-only writes vs snapshot hygiene (NEEDS-OWNER):** real snapshots are
+  LZ4-compressed; our compactor can only emit uncompressed output, so "compacted" can be
+  LARGER than the compressed input. Either scope the claim ("removes shadowed
+  data/tombstones; does not restore compression") or reopen compressed writes (#1406
+  posture (a), currently an M7 candidate). Blocks Phase A′ *marketing*, not Phase B.
+- **P0 gating, precise:** #1537 hard-gates Phase A′ correctness claims (small,
+  oracle-driven — fix first); #1538 gates only byte-parity claims (trail as documented
+  caveat); #1849 gates only the invariant-4 property-test oracle. **Phase B blocked by
+  nothing.**
+- **Resourcing:** #905 maps to neither M6 nor M7; 44 epics already in Backlog. Filing adds
+  a 45th unless the owner explicitly reprioritizes a slice.
+
+**Placement**
+- Do NOT mint a published `cqlite-compaction` crates.io name now (the WS5 lesson).
+  Planner/executor = in-repo module / unpublished workspace crate behind the Phase-1
+  curated API. The daemon (`cqlite-compactd`) is the natural FIRST artifact published
+  under the new engine name once WS5 lands one.
+
+**Suggested sequencing (when the owner structures it)**
+1. Owner decisions (below) + fast-track the dir-fsync gap (§4) as its own oracle-driven bug.
+2. Ride T1 #1631 / T2 #1633; write new compaction code as new seams of the split tree.
+3. **Phase B (planner + UCS + simulator) first and in parallel** — design-driven → OpenSpec
+   (new public trait + CLI verbs), UCS math TDD'd oracle-style against 5.0 source as
+   parity backstop. Unblocked by everything.
+4. Phase A′ (GC modes, rung-(b) overlap, dir-fsyncs, throttle, dry-run) gated on #1537
+   only; #1538/#1849 tracked as claim-boundary caveats (the #1406 documentation style).
+5. Phase C daemon after WS5 names the engine product.
+6. Phase D (schema pull, offload groundwork) exploratory, last.
+
+## 8. Open decisions (owner)
+
+1. **Product placement vs #1934 split** — recommendation in §7 (in-repo unpublished now;
+   daemon waits for the engine name).
+2. **v1 fidelity posture** — recommend: shard-boundary parity yes (topology + flush-size as
+   explicit inputs; golden-tested), pick-selection parity out of scope.
+3. **Priority** — #905 is P3; does the simulator's demo value justify promoting a Phase-B
+   slice ahead of adjacent Backlog work?
+4. **#1406 tension** — scope the snapshot-hygiene claim down, or reopen compressed writes.
+5. **File the dir-fsync gap now?** — independent shipped-write-engine hardening (§4),
+   oracle-driven, small.
+6. Design doc §15 Q1 (schema pull seeding UCS config) — still open, Phase D product call.
+
+## 9. Corrections to make when the design doc is refreshed
+
+- §14 Phase A: executor largely shipped; re-scope to Phase A′ (§7 sequencing).
+- §7.3: replace the commit-record txn log with the TOC-invariant + dir-fsync design (§4);
+  keep `--repair-log` OUT (re-run is always safe); add the audit-record nice-to-have.
+- §7.2/§15 Q5: adopt the precision ladder (§3) — coarse bound stays for whole-file drops,
+  rung (b) for in-rewrite purge, rung (c) documented as v2 behind `Filter.db` reading.
+- §6.2: DELETE the "legacy-layout convergence as first-class planner mode" — no such mode
+  exists in Cassandra; convergence = repeated planning (simulator costs it).
+- §6.1 `SSTableMeta`: add `tokenSpaceCoverage` (authoritative) as primary density input;
+  add topology + flush-size as explicit planner inputs (flush-size default = the 1 MiB
+  floor); drop `level_hint` (UCS ignores it); note droppable-tombstones derivable from the
+  parsed histogram.
+- §6.3: major compaction = sharded per UCS always (single-output major is an STCS-ism);
+  on 5.0 maximal splits by token-overlap only (trunk adds density-sharding — track).
+- §8: TTL purge math — synthetic tombstone LDT = original write time; eligibility =
+  `writeTime + max(ttl, gc_grace)`. Pin as parity test.
+- §11: daemon = nudge queue + per-table strategy polls (event-driven, not scanning);
+  throttle = one global live RateLimiter on compression-adjusted bytes; add
+  `compactionsAborted`/`compactionsReduced`-style counters; note Cassandra has no write
+  backpressure (decide match-or-exceed explicitly).
+- §15: record answers — Q2 split (boundaries yes / picks no), Q3 (~70% reuse; inherits
+  #1537/#1538), Q4 (defer TombstoneOnly), Q5 (coarse shipped; rung (b) is the v1 upgrade).
+- Appendix A: trigger is overlap-count ≥ threshold; UCS not yet OSS default; T4 is the
+  STCS-equivalent default.
+- `docs/read-path/02-storage-engine.md`: remove the fictional `CompactionManager` field.

--- a/docs/architecture/issue-throughput-saturation-research.md
+++ b/docs/architecture/issue-throughput-saturation-research.md
@@ -1,0 +1,242 @@
+# Maximum Read Throughput Through cqlite-flight — Pipeline, Failure Order, and a Saturation Experiment
+
+Owner-requested research (2026-07-09). Read-only static analysis at `main`. No stacks/gates/benches
+run. Purpose: a new epic will be filed from these findings. Companion to the epic-AM read-path audit
+(`docs/architecture/trino-flight-read-path-audit-2026-07-08.md`), the point-read causation record
+(`docs/architecture/issue-2310-ms-point-reads-research.md`), and the core read-path perf audit
+(`docs/reports/read-path-performance-audit-2026-07-01.md`).
+
+**Question:** under a high-volume concurrent-read scenario (many readers, many simultaneous queries),
+what does it take to get the most bits off disk through cqlite-flight, where does it fail first, and
+what does a saturation experiment that finds the stress point look like?
+
+**One-line answer:** disk is not the first thing to saturate. The server fans a *single* `do_get`
+out to `M + M·num_cpus` threads (one full multi-threaded Tokio runtime per input SSTable), has **no
+global concurrency limit or admission control**, opens a fresh file handle per SSTable per query, and
+on the field's index-less snapshots materializes the whole Data.db per query. Thread/scheduler
+collapse, fd exhaustion, and memory blow-ups all arrive well before disk bandwidth does.
+
+---
+
+## A. The throughput pipeline and its ceilings
+
+Concurrent-read data path for one `do_get`, with each stage's ceiling and configured limit
+(file:line evidence). The server is `cqlite-flight`; the merge/decode engine is `cqlite-core`.
+
+### A0. gRPC / server config — the front door is wide open
+- `main.rs:74-77` — `Server::builder().add_service(...).serve_with_shutdown(...)`. **No**
+  `.concurrency_limit_per_connection`, **no** `.max_concurrent_streams`, **no** `.tcp_nodelay`, **no**
+  gRPC message compression, **no** timeout layer. Tonic 0.12 defaults apply.
+- `#[tokio::main]` (`main.rs:34`) = multi-thread runtime, `worker_threads = num_cpus`, blocking pool
+  default max **512** threads.
+- Confirmed **no `Semaphore` / concurrency limit / rate limiter anywhere in the flight crate** (grep:
+  none). **Concurrent `do_get` count is unbounded** — bounded only by what the OS will spawn before
+  it falls over.
+
+### A1. Disk read — buffered, per-scan handle, serial within a reader
+- Three backends behind one source: `cqlite-core/.../reader/source.rs:42-55` (Buffered `BufReader`,
+  Mapped memmap2, Direct `O_DIRECT`). **Default buffered** (`config.rs:203` `use_mmap=false`;
+  `disk_access_mode=Auto`, `config.rs:124`).
+- **Compaction always reads buffered regardless of `use_mmap`** (`merge/mod.rs:497-514`,
+  `config.rs:79-82`) — the flight merge never mmaps; it always does buffered `read_exact`.
+- Per-scan file handle (`source.rs:175-208`): each scan does its own `File::open` (issue #815 — a win
+  for parallelism, a cost for fd count under concurrency; see B3). Direct-IO read-ahead window default
+  **1 MiB** (`config.rs:151,219`); `Auto` prefetch issues **no `madvise`**.
+- **Ceiling:** reads are serial within one reader; the only parallelism is independent per-scan
+  handles across queries — i.e. throughput scales by spawning *more concurrent work*, which is exactly
+  what breaks first (Section B).
+
+### A2. Decompression — serial, single-threaded, 16 KiB chunks
+- Algorithms `None/Lz4/Snappy/Deflate/Zstd` (`compression.rs:11-17`), single choke point
+  `Compression::decompress` (`compression.rs:249`).
+- **No `rayon`/`par_iter` anywhere in cqlite-core** — chunks decompress **one at a time** on the scan
+  task (or its single `spawn_blocking` half).
+- **Chunk size default = 16 KiB** (`compression_info.rs:70,203`; fixtures assert 16384) — *not* 64 KB.
+  Smaller chunks = more decompress calls per MiB.
+- **Ceiling:** single-core decompress per reader. CPU-bound; does not use the box's cores for one scan.
+
+### A3. SSTable decode + k-way merge — whole-partition (or whole-Data.db) materialization
+- Flight uses the **compaction merge**, not the query engine: `MergeProducer::produce_streaming`
+  (`producer.rs:582`) → `KWayMerger::new_cancellable` (`producer.rs:597`) → `drive_merge`.
+- **Per input SSTable, one OS producer thread + one full multi-threaded Tokio runtime:**
+  `SSTableRowIteratorAdapter::open` (`merge/mod.rs:456`) does `std::thread::spawn`, and the producer
+  thread body builds **`tokio::runtime::Runtime::new()`** (`merge/mod.rs:519`) — which is
+  `new_multi_thread` with `num_cpus` eagerly-spawned worker threads. (Contrast the token-prune
+  runtime, which is correctly `new_current_thread`, `producer.rs:267`.) **This is the dominant
+  concurrency ceiling — see B1.**
+- Each run streams partitions through a bounded `sync_channel(STREAMING_CHANNEL_CAPACITY = 256)`
+  (`merge/mod.rs:422,452`) — up to 256 `MergeEntry` (partitions) buffered per run.
+- **`KWayMerger::step()` materializes an entire partition** before the LIMIT/filter egress loop
+  (`merge/mod.rs:2264-2302`, filter at `producer.rs:788`) — `LIMIT 1` on a multi-GB wide partition =
+  O(partition) peak (audit N5 / #2230).
+- **Index-less snapshots materialize the whole Data.db:** when Summary.db is absent the compaction
+  scan fully materializes the entire Data.db in one pass (`merge/mod.rs:2159`, `sequential.rs:759`).
+  The field snapshot dirs contained only Data.db (#2295) → 414,957 partitions cloned+sorted before a
+  byte streams, defeating backpressure (`issue-2310-...md:33-37`).
+- **`Value` is 32 bytes now, hard-pinned ≤40** (`types.rs:98`) — the read-path audit's "88 bytes/value"
+  is **stale** (fat variants boxed). Rows are still `HashMap<String,Value>` with per-row column-name
+  `String` clones (read-path audit E-epic).
+
+### A4. Arrow conversion + batch assembly
+- CQL→Arrow per-cell conversion (`cqlite-core::export::arrow_convert`); known per-cell costs are the
+  0.14 arrow_convert perf items (#1495/#1496).
+- Batch size default **8192 rows** (`main.rs:30-31`), floored to ≥1 (`service.rs:133`). Not a runtime
+  knob beyond the process arg.
+
+### A5. The `do_get` egress channel — bounded, cap 4
+- `DO_GET_CHANNEL_CAPACITY = 4` batches (`streaming.rs:46`); merge runs on `spawn_blocking`, sends each
+  batch via cancellation-aware `reserve()` backpressure (`streaming.rs:130-167`).
+- **Peak resident egress payload ≈ (4 + ~3)·8192 rows** per query — genuinely bounded, independent of
+  result size. The **unbounded-channel landmine is NOT present here** (audit confirmed).
+- Caveat: this bounds the *Arrow egress buffer only*. It does **not** bound A3's per-run
+  256-partition buffer or the whole-partition / whole-Data.db materialization upstream of it.
+
+### A6. tonic/gRPC egress + Tokio runtime
+- Response stream is `FlightDataEncoderBuilder` over the receiver (`streaming.rs:359-368`). No gRPC
+  compression configured — Arrow IPC bytes go out uncompressed.
+- **Where blocking fs I/O runs:** `do_get_setup` (schema parse + dir resolve + token-prune, each reads
+  a Summary.db) is **one `spawn_blocking`** (`service.rs:488`); the merge is a **second `spawn_blocking`**
+  (`streaming.rs:263`); `gather_table_stats` (do_action) is a **third** (`service.rs:559`). Plus the
+  A3 per-SSTable producer threads and their runtimes sit *outside* the blocking pool entirely.
+
+### A7. Byte-budget guard — does NOT protect the flight path
+- The v0.13 64 MiB result-byte budget (`query/result_budget.rs`, `config.rs:335`) is a **query-engine
+  `SelectExecutor` concept**, checked once post-materialization. **The flight producer bypasses the
+  query engine** (it drives `KWayMerger` directly), so `do_get` gets **no result-byte budget at all** —
+  its only memory bound is the cap-4 egress channel, which does not cover A3's materialization.
+
+### A8. Cross-query effects
+- **Per-query snapshot → memtable flush storm (#2305/#2306):** snapshot creation is on the **connector/
+  Sidecar** side, not cqlite-flight (the server only *resolves* a snapshot dir name, `service.rs:491`).
+  `SnapshotManager` PUTs a snapshot on **every replica host per query** and **each PUT triggers a
+  Cassandra memtable flush** (`SnapshotManager.java:80`, `SidecarClient.java:82`); the Sidecar endpoint
+  exposes only `?ttl=`, **no `skipFlush`** (`issue-2310-...md:44-47`). Under many concurrent queries
+  this is a flush storm on the co-located Cassandra node, stealing IO/CPU from flight.
+- **No warm readers (#2310):** every `do_get` re-parses the DDL (`service.rs:138`), re-resolves the
+  dir (`producer.rs:491`), and re-opens every reader — fixed per-query cost × N.
+- **Memory target vs N scans:** the <128MB target is *per-scan* and already breached by A3 wide/
+  index-less cases; there is **no global memory budget across concurrent queries**, so peak RSS ≈
+  N × per-scan-materialization.
+
+---
+
+## B. Where it fails first (ranked by order-of-failure as concurrency rises)
+
+| Rank | Failure mode | Mechanism + evidence | Approx. trigger |
+|------|--------------|----------------------|-----------------|
+| **1** | **Thread / scheduler collapse (runtime amplification)** | One `do_get` spawns **M producer OS threads, each building a full `num_cpus`-worker Tokio runtime** (`merge/mod.rs:456,519`). On a 16-core node a 3-SSTable snapshot query ≈ 3 + 3·16 ≈ **51 threads** before the 2 blocking-pool threads. N concurrent queries ⇒ ~N·51 threads, mostly idle-but-scheduled. Context-switch storm and runqueue latency spike; CPU burns on scheduling, not decompression. | Low tens of concurrent queries on a multi-core box |
+| **2** | **No admission control / unbounded `do_get`** | No concurrency limit, no `Semaphore` (`main.rs:74-77`; grep: none). Each query takes 2 blocking-pool threads (setup + merge, `service.rs:488`, `streaming.rs:263`); blocking pool caps at 512 → setups queue silently past ~256 concurrent, on top of Rank 1. No backpressure to shed or reject load. | ~hundreds concurrent, or far fewer combined with Rank 1 |
+| **3** | **fd exhaustion** | Per-scan `File::open` per SSTable (`source.rs:186,203`, no reader/fd pool by #815 design) + a Summary.db read per SSTable during prune. N queries × M SSTables open fds simultaneously; container ulimit often 1024. `EMFILE` → query failures. | N·M approaching the fd ulimit |
+| **4** | **Unbounded memory growth → OOM** | A3: whole-partition materialization (`merge/mod.rs:2264-2302`, #2230) and **whole-Data.db** materialization on index-less snapshots (`merge/mod.rs:2159`, #2295); the 256-partition per-run buffer; **no result-byte budget on the flight path** (A7). No global cross-query memory cap ⇒ RSS ≈ N × per-scan peak. | Wide partitions or index-less snapshots × modest N |
+| **5** | **Steady-state per-query cost caps aggregate bytes/s** | Even absent 1-4: `WHERE pk=X` **full-scans the whole table** through the merge (egress filter, `producer.rs:788`, #2207); full-scan decode path is **not wired to the DecompressedChunkCache** so every query re-reads+re-decompresses (#2165, `chunk_source.rs:1-9`); decompression serial/single-core (A2). Field: point read = **271s** on 2.16M partitions. | Always present; sets the disk-bound ceiling you *want* to reach |
+
+Cross-query amplifiers (not a single resource, but they multiply the above): the **snapshot flush
+storm** (#2305, A8) drives Cassandra-side IO/CPU up as concurrency rises; the **per-request
+schema-parse/dir-resolve/reader-open** (#2310) adds fixed CPU per query.
+
+**Instrumentation already present** (good): `cqlite_rpc_requests_total`, `_duration_seconds` (with the
+per-phase `rpc.phase.duration` split `resolve → merge_setup → stream`, `obs.rs:191-282`),
+`_rows_total`, `_bytes_total`, `_in_flight` gauge (`obs.rs:307-352`), `cqlite_errors_total`, and
+`query.rows_scanned` deltas (`scan_progress.rs`). **Missing for saturation work:** fd-count gauge,
+thread-count gauge, blocking-pool queue depth, RSS/alloc hook, and the egress channel depth.
+
+**Biggest surprise:** the concurrency ceiling is not I/O and not the cap-4 egress channel everyone
+reasoned about — it is **thread amplification inside a single query**. `Runtime::new()` per producer
+thread (`merge/mod.rs:519`) means "many simultaneous queries" is already "thousands of threads" before
+the second client connects. A single well-formed query on a 10-SSTable table on a 32-core node asks the
+OS for ~320 worker threads. This is invisible in every existing metric (no thread gauge) and is the
+first thing that will fall over.
+
+---
+
+## C. The saturation experiment — a runnable plan to find the stress point
+
+### C0. What must be built first (epic workstream candidates)
+- **A flight-direct load client does not exist.** Exhaustive search of `tools/`, `bin/`,
+  `cqlite-flight/{examples,benches}`, and all `.py/.rs/.sh`: the only load tool is
+  `easy-db-lab-kits/trino-loadtest/driver.py` — a **through-Trino JDBC** driver (thread pool, p50/p95/p99,
+  VictoriaMetrics scrape). All its load is confounded by Trino coordinator/worker overhead
+  (irreducible ~50-150ms/query), so it cannot isolate the flight server. The #2310 measurement plan
+  explicitly calls for "a raw Flight client" that still needs building.
+- **Server-side saturation gauges are missing** (fd, thread, blocking-pool queue, RSS, channel depth).
+
+### C1. Instrument
+- **Reuse:** the `cqlite_rpc_*` series + `rpc.phase.duration` split (a `stream`-phase histogram that stays
+  flat while `merge_setup` climbs = still materializing, per #2295), `rpc.in_flight`, `errors_total`,
+  `query.rows_scanned` (flat-at-0 with `in_flight>0` = the field's "stuck in do_get" signature).
+- **Add (WS2):** process gauges sampled every ~2s — `/proc/<pid>/task` count (threads),
+  `/proc/<pid>/fd` count (fds), RSS (`/proc/<pid>/statm`), and a Tokio blocking-pool queue-depth /
+  egress-channel-depth gauge. Optionally a dhat-heap lane for the merge path.
+- **External:** `iostat -x` (disk MB/s + `%util`), per-core CPU (`mpstat -P ALL`), and a CPU flame graph
+  (Pyroscope on the pod, already wired for Trino) to attribute CPU to decompress vs merge vs
+  arrow_convert **vs kernel scheduling** (the Rank-1 tell).
+
+### C2. Load shape
+- **Stage 1 — isolate the server (local, single node):** the **#2289 docker harness** (~100k-122k-partition
+  `keyvalue` table *with full index components* — so the index-less pathology is excluded and you measure
+  the healthy path). Drive `do_get` with the WS1 flight-direct client, N parallel workers, each looping a
+  fixed query mix (full scan, `LIMIT 100`, `LIMIT 1000`, `COUNT(*)`, and a `WHERE pk=X` to expose #2207).
+- **Stage 2 — real disks (#2103 3-node kit):** `i4i.xlarge` NVMe, one `cqlite-flight` pod per node,
+  flight-direct client on the app node bypassing Trino. Re-run the ramp; add an index-*less* snapshot
+  variant to force the #2295 materialization path and watch memory.
+
+### C3. Ramp protocol
+- Readers 1 → 2 → 4 → 8 → 16 → 32 → … until a saturation or abort criterion trips. Hold each step long
+  enough for steady state (≥30s).
+- Record per step: delivered rows/s and **bytes/s** (client side); **bytes/s off disk** (`iostat`);
+  latency p50/p95/p99/p999; RSS; fd count; **thread count**; blocking-pool + channel depth; `rpc.in_flight`;
+  the `rpc.phase.duration` split.
+
+### C4. Saturation criteria — which metric proves which resource
+- **Success = disk-bandwidth-bound:** `iostat %util → ~100`, delivered bytes/s tracks disk MB/s, latency
+  rises gracefully. That is the target ceiling.
+- **Thread/scheduler-bound (expected Rank 1):** thread count explodes (`/proc/<pid>/task`), per-thread CPU
+  low, aggregate CPU high but flame graph shows **scheduler/futex**, throughput plateaus with disk `%util`
+  well under 100. → runtime amplification.
+- **CPU-stage-bound:** a core pegs and the flame graph concentrates in `decompress`/`arrow_convert`/`merge`
+  with disk `%util` low → serial decompression (A2) / per-cell conversion (A4).
+- **fd-bound:** fd count hits ulimit, `EMFILE` in logs, `errors_total` climbs.
+- **Memory-bound:** RSS climbs ~linearly with N and/or partition width; pod restart / OOM.
+- **Queue pileup:** `rpc.in_flight` climbs while delivered rows/s is flat and `query.rows_scanned` is
+  flat-at-0 → stuck in `merge_setup` materialization (#2295/#2207), not disk.
+
+### C5. Abort criteria
+- OOM / pod restart; `rpc.rows_total` flat with `in_flight>0` for > ~60s (hang); sustained `EMFILE`/
+  connection-reset error rate.
+
+### C6. Proposed epic workstreams
+- **WS1 — flight-direct load client** (`tools/flight-loadgen`): raw `FlightServiceClient` do_get against
+  `<node>:8815`, N workers, ramp harness, percentile + throughput stats, optional traceparent. *Blocks the
+  whole experiment.*
+- **WS2 — saturation instrumentation:** fd/thread/blocking-pool/channel/RSS gauges into `obs.rs`; optional
+  dhat lane. Makes Rank 1-4 observable.
+- **WS3 — runtime de-amplification (highest server-side leverage):** stop building a multi-thread
+  `Runtime::new()` per producer thread (`merge/mod.rs:519`); share one runtime, or use `new_current_thread`,
+  or restructure the merge so N inputs do not spawn N runtimes. Directly targets Rank 1.
+- **WS4 — admission control / backpressure:** tonic `concurrency_limit` + a `Semaphore` bounding concurrent
+  `do_get` merges; bound/observe blocking-pool usage. Targets Rank 2/3/4.
+- **WS5 — wire the full-scan path to `DecompressedChunkCache` (#2165) + pipeline/parallelize
+  decompression.** Targets Rank 5 / A2.
+- **WS6 — the point-read package (#2207/#2295/#2302):** index-probe instead of O(table) scan; complete
+  snapshots so the reader streams instead of materializing. Already scoped in `issue-2310-...md`.
+- **WS7 — snapshot amortization / skip-flush (#2305/#2306):** kill the cross-query flush storm.
+- **WS8 — run the ramp** on #2289 (Stage 1) then #2103 (Stage 2); file each discovered bottleneck as a
+  `bug`+`performance` issue per the #2103 Phase-5 triage table.
+
+---
+
+## Evidence index (primary files)
+- Flight server: `cqlite-flight/src/{main.rs,service.rs,streaming.rs,producer.rs,obs.rs,scan_progress.rs}`
+- Merge engine: `cqlite-core/src/storage/write_engine/merge/mod.rs` (runtime-per-input at `:519`,
+  producer thread at `:456`, whole-partition step at `:2264-2302`, index-less materialization note at
+  `:2159`, `STREAMING_CHANNEL_CAPACITY` at `:422`)
+- Core read path: `cqlite-core/src/storage/sstable/reader/{source.rs,chunk_source.rs}`,
+  `.../compression.rs`, `.../compression_info.rs`, `.../types.rs` (`Value` ≤40 pin at `:98`),
+  `query/result_budget.rs`, `storage/cache/mod.rs` (DecompressedChunkCache)
+- Prior audits: `docs/architecture/trino-flight-read-path-audit-2026-07-08.md`,
+  `docs/architecture/issue-2310-ms-point-reads-research.md`,
+  `docs/reports/read-path-performance-audit-2026-07-01.md`
+- Harnesses: `easy-db-lab-kits/trino-loadtest/` (through-Trino only),
+  `easy-db-lab-kits/test-plans/cqlite-flight-loadtest-3node.md`, #2289 docker harness (referenced only)
+</content>
+</invoke>

--- a/docs/reports/agent-delivery-journey-2026-07.md
+++ b/docs/reports/agent-delivery-journey-2026-07.md
@@ -1,0 +1,593 @@
+# The CQLite Agent-Delivery Journey
+
+*A case study and reusable playbook for engineering teams adopting LLM-agent delivery workflows.*
+
+**As of:** 2026-07-11 · **Repo:** `pmcfadin/cqlite` · **Scope of the data:** the delivery-telemetry
+ledger (`docs/reports/delivery-telemetry.jsonl`, 273 records, 2026-06-28 → 2026-07-11), the operating
+manual (`CLAUDE.md`), the doctrine site (`agents-developing/`), the OpenSpec change archive, and the
+git history.
+
+> Every number in this report is computed from a repo artifact and the source is named inline. Where
+> a claim comes from lived operation and is not reconstructable from a committed file, it is marked
+> *(observed in practice)* rather than given a false citation.
+
+---
+
+## Executive summary
+
+CQLite is a Rust library that reads and writes Apache Cassandra 5.0 SSTable files without a cluster.
+Almost all of its code is written by LLM agents. Over roughly two weeks of instrumented delivery the
+project shipped **273 delivery cycles across 272 distinct issues** (ledger row count), each one an
+issue that went from a scoped GitHub issue to a merged, gated, reviewed PR — under a small standing
+crew of agents supervised by one human owner.
+
+The interesting result is not that agents can write code. It is that a **process** made agent output
+trustworthy enough to merge without a human reading every diff. The load-bearing ideas, each covered
+below, are:
+
+1. **One gate of record.** A single script, `scripts/agent-gate.sh`, produces the only verdict that
+   counts. Ad-hoc test runs never count. Its 24-component summary block is the merge criterion.
+2. **Fail-closed everywhere.** Missing fixtures fail the gate; a staleness-probe error forces a
+   rebuild; an unsupported config returns a typed error. Nothing degrades silently.
+3. **Two human seams only.** A person approves the design spec, and the merge is pre-authorized on
+   green. Everything between is automated with evidence.
+4. **Tiered gates + review-first.** A cheap `--lite` gate runs every fix round; the expensive full
+   gate runs after review, so the one costly certification is spent on already-reviewed code.
+5. **Disposable contexts.** The high-volume text streams (full-gate stdout, adversarial-review
+   churn) run inside short-lived sub-agents that return a compact packet, so the orchestrator's
+   context stays the size of one issue no matter how many issues flow through it.
+6. **A board is the only dispatch authority, a pushed branch is the only lock.** Coordination across
+   machines is deterministic, not conventional.
+
+Measured against the project's own earlier baseline (1.87 gate-runs/issue, 1.92 rework rounds/issue,
+54% first-pass — recorded in the project's memory as the pre-restructure numbers), the mature process
+holds steady-to-better: **1.79 gate-runs/issue** overall and **1.71 on the most recent 80 cycles**,
+with **first-pass rate rising from 54% to 61%** on that recent window (all computed from the ledger,
+method below). The point is less the exact deltas than that the process is *measured at all* — every
+change to how work is done is run as an experiment against a telemetry baseline.
+
+The report closes with a single issue traced end-to-end — **#2310, the Arrow Flight "warm handles"
+performance epic** — because it exercises every part of the machine at once: a design spec with 8
+requirements, a mid-flight feasibility STOP, six rounds of adversarial review with a security class
+that recurred three times, and a disposable-context endgame that merged on green.
+
+---
+
+## The journey, in phases
+
+### Phase 0 — Origins: from a single agent to a gate of record
+
+The project began the way most do: one agent, one prompt, "make the tests pass." That does not
+scale, because *the agent grades its own homework*. An agent that runs `cargo test` in some scoped
+way and reports green has told you almost nothing — you don't know which tests, with which features,
+against which fixtures.
+
+The first structural move (issue #719, the "orchestration harness v2") was to make **one script the
+sole source of truth**: `scripts/agent-gate.sh`. Its rule, stated in `CLAUDE.md`, is blunt — "its
+`==== AGENT-GATE SUMMARY ====` block is the verdict; ad-hoc cargo runs never count." The full gate
+today runs **24 components** (verified via `scripts/agent-gate.sh --list`): `file-size`, `fmt`,
+`clippy`, `core-tests`, `tombstones-scan`, `integration-tests`, `write-tests`, `cli-tests`,
+`compaction-byte-parity`, `query-semantics-oracle`, `python-bindings`, `node-bindings`,
+`minimal-build`, `smoke`, and ten more guards.
+
+Two refinements made the gate agent-proof rather than just strict:
+
+- **Summary-block-only retention (#1175 / #2079).** The gate writes its verdict to a summary file;
+  the agent is instructed to read *only* that file, never the multi-thousand-line `gate.log`. An
+  agent that pastes raw stdout as "the summary" is caught because the real summary has a distinct
+  header the log does not.
+- **Fail-closed on missing inputs (#2078).** If the validation corpus is absent, the full gate does
+  not pass-with-a-shrug — it stamps `missing-fixtures: FAIL-CLOSED` and fails. A test that would
+  return "0 rows, all green" on an empty dataset is treated as a failure, not a pass.
+
+**Generalizable rule:** *the definition of "done" must be a single artifact the agent cannot forge
+and cannot satisfy vacuously.*
+
+### Phase 1 — Correctness doctrine: parity is truth
+
+CQLite's job is byte-level compatibility with Cassandra, so "looks right" is never enough. Three
+doctrines encode that:
+
+- **No-heuristics (#28).** Decode from authoritative metadata only — the schema, else `Statistics.db`.
+  No guessing a type from a byte pattern. Legacy guesswork lives behind an opt-in feature flag and
+  nowhere else. This is enforced in code (`BigVersionGates::from_version` rejects pre-`na` formats),
+  not just in review.
+- **Two parity oracles (#1742).** This is the subtle one. *Physical-dump parity* compares CQLite's
+  output against `sstabledump` cell-for-cell — but it enumerates tombstones and shadowed rows too, so
+  it **cannot catch a read-time reconciliation bug** (both sides keep the shadowed row → green while a
+  real `SELECT` diverges). So a second oracle, *query-semantics parity*, records the
+  post-reconciliation result of a canonical `SELECT` at a **pinned** `now` (never wall-clock). Bug
+  work must add the *correct* oracle for the property under test.
+- **Wiring evidence.** A feature is done only when its public surface exercises it: a named entry
+  point + a call chain + an end-to-end test. Green helper-unit tests are explicitly declared
+  insufficient.
+- **Red-proven regression tests.** A regression test must be shown to fail on the unfixed code
+  (revert the source, re-run, watch it go red) before the fix counts. A test that passes both before
+  and after proves nothing.
+
+**Generalizable rule:** *pick your oracle for the actual property under test; an oracle that is green
+on a real bug is worse than no oracle because it manufactures false confidence.*
+
+### Phase 2 — The delivery pipeline
+
+The work was factored into a five-verb pipeline, each verb a skill an agent runs:
+
+```
+flow-groom  →  flow-activate  →  flow-implement  →  flow-address  →  flow-finalize
+   (scope)      (SEAM 1: spec)     (build+review)     (PR comments)    (archive+close)
+```
+
+- **Exactly two human seams.** Seam 1 is the owner approving a design spec. The second is the merge —
+  and even that is *pre-authorized*: a worker merges its own PR the moment the bar is met (gate PASS +
+  intent-audit PASS for design work + review clean). The human is not in the inner loop.
+- **Routing at groom time.** Design-driven work (new surface area, UX, perf strategy) goes through
+  **OpenSpec** — a proposal/design/tasks/spec artifact set that *is* the plan. Oracle-driven bug
+  fixes (a parsing bug with a parity test) skip OpenSpec entirely and stay a GitHub issue plus a
+  pinned test. Choosing the wrong track is a real cost, so it is decided explicitly at intake. In the
+  ledger, **63 of 273 cycles are design-routed, 210 oracle-routed** — bug fixes dominate, as expected
+  for a maturing library.
+- **1:1:1:1.** One issue ↔ one worktree/branch ↔ one OpenSpec change ↔ one PR. This makes every unit
+  of work independently claimable, gate-able, and reversible.
+
+The archive holds **68 shipped OpenSpec changes** (`openspec/changes/archive/`), the durable record
+of every design-driven delivery.
+
+### Phase 3 — Scaling out: dispatch and locking as mechanism, not convention
+
+Multiple agents on multiple machines need coordination that doesn't rely on anyone being polite.
+
+- **The board is the sole dispatch authority (Path A, #1886).** Work is selected from one GitHub
+  Project `Status` field (`Backlog / Ready / In Progress / In Review / Done`). Status *labels* are
+  decorative and are never a selection source. Empty `Ready` column = stop. Board unreachable = stop
+  and fix auth — never fall back to guessing from labels.
+- **A pushed branch is the only lock.** Claiming an issue means pushing its `issue-<N>-<slug>` branch
+  to origin. The branch — not an assignee field — is the lock; you proceed only after re-reading and
+  confirming you still hold it. This makes claim collisions a git push rejection, which is
+  deterministic.
+- **Heartbeats + deterministic reaping (#2089).** A claim emits a liveness heartbeat; the board
+  reaps a claim only when it is provably dead (age > 4h **and** no open PR). No human judgment call
+  about whether an agent is stuck.
+- **One worker per machine (#1930).** A machine runs one lead/worker that fans out sub-agents but
+  **serializes its own full gates** (a hardware backstop, since a full gate is heavy). An unattended
+  supervisor (`scripts/local/worker-supervisor.sh`, #2090) recycles one worker process per issue —
+  the hard context bound is the process exiting after each issue.
+
+**Generalizable rule:** *encode coordination as mechanism (a lock that is a git push, a reap that is
+an arithmetic on timestamps), not as etiquette an agent might not follow.*
+
+### Phase 4 — Context economy: keeping the orchestrator O(1 issue)
+
+This is the phase that made high throughput sustainable, shipped as epic #2083 (12 children merged
+2026-07-06). The problem: an LLM orchestrator has a finite context window, and naively it fills with
+gate logs, review transcripts, and prior-issue state until it degrades. The fixes:
+
+- **Tiered gates.** A cheap `--lite` gate (~1–5 min: file-size + fmt + scoped clippy + blast-radius
+  tests) runs **every fix round** (#1821). A `--delta` gate re-certifies a *post-PASS, test/docs-only*
+  polish round without a full rebuild (#1892). The **full gate runs once per issue**, at the endgame.
+- **Review-first (#2086).** Adversarial review (`rust-reviewer` + the `roborev` reviewer) runs on the
+  lite-green diff *before* the one full gate, so the expensive certification is spent on
+  already-reviewed code — not on a diff that review is about to change.
+- **The disposable `flow-closer` (#2084).** The endgame — the one full gate, the intent audit, the
+  final review pass, the merge — runs inside a short-lived sub-agent that returns only a compact
+  terminal packet (verdict, PR URL, ≤10 residual lines). The two largest text streams in the whole
+  system (full-gate stdout, review churn) never touch the persistent lead session.
+- **Severity triage (#2088).** Review findings are **blockers** or **nits**. Blockers are fixed
+  pre-merge and each re-triggers a fix → lite → re-review loop. Nits never trigger a re-verify round —
+  they are batched into one follow-up issue at merge time. "When in doubt, blocker."
+- **Inter-issue reset (#2085).** After each finalize, the lead drops all prior-issue context and
+  re-hydrates the next item from *board + disk alone*. Durable lessons go to a `MEMORY.md` file, never
+  the live window.
+
+**Generalizable rule:** *treat the orchestrator's context window as the scarcest resource. Run
+high-volume streams in disposable contexts and keep only decisions.*
+
+### Phase 5 — The audit program: scoping as a first-class artifact
+
+Rather than wait for bugs to surface, the project ran systematic static audits of each subsystem —
+read-path, write-path, parser, export, bindings, platform. Each audit produced a **lettered epic with
+pre-scoped child issues whose bodies are written to be "lesser-model-ready"** — detailed enough that a
+cheaper model can implement them. For example the read-path audit alone produced epics A–G with ~39
+children (#1562–#1600). Across all audit blocks this is on the order of **~200 pre-scoped children**
+*(the individual epic ranges are recorded in the project memory; the total is an aggregate across
+blocks A through AL)*.
+
+The insight: **scoping is itself a deliverable.** A well-scoped issue is the interface between an
+expensive planning model and a cheap implementation model. Investing a strong model in decomposition
+lets weaker, cheaper agents do the bulk implementation reliably.
+
+### Phase 6 — 0.14 field-readiness and the performance journey
+
+The 0.14 release was re-scoped by a **291-issue viability audit** *(observed in practice; the audit
+artifact is a published report)* into a "Flight field-readiness" release, validated by a five-tier
+test plan: per-PR gates → a combined-main sweep → a local field-repro end-to-end run → close blockers
+→ an AWS field run on real infrastructure as the handoff gate. A field-shaped Docker testbed (#2289 —
+Trino → Arrow Flight → CQLite over real SSTables) was hardened over ~11 find-fix rounds and used as
+the standing local reproduction loop.
+
+The performance story is the sharp edge of that work, and it is worth stating in numbers because it
+motivates the case study. Cost-model research (`docs/architecture/issue-2310-ms-point-reads-research.md`,
+static analysis at `main`) established the baseline against a **2.16M-partition-per-node** AWS table:
+
+| Query | Baseline latency | Source |
+|---|---|---|
+| `WHERE key = '<pk>'` point read | **271 s** (full scan, killed) | #2157 round-3 |
+| `SELECT * … LIMIT 5` | **190–433 s** | #2157 round-3 |
+| `SELECT count(*)` | **358 s+** | #2157 round-3 |
+
+The root cause: a `WHERE pk = X` query was **not a point read at all** — it full-scanned every
+partition through the k-way merge and applied the predicate as a per-row egress filter, paying
+`O(table)` I/O to return one row. That single term dominated latency "by 3–4 orders of magnitude."
+
+The fix was sequenced, not heroic:
+
+- **Phase 1 (#2207 PK pushdown + #2295 snapshot completeness + #2302 pair resolution, all shipped):**
+  turn the scan into an index probe — `O(log n)` index lookup + ~3 partition reads + reconcile. The
+  research projects this at **single-digit ms flight-direct**, with the through-Trino path
+  "low-double-digit to ~100ms" (the coordinator becomes the bound). *(Field-observed through-Trino
+  figures land in the tens-to-~150ms range depending on shape — observed in practice.)*
+- **Phase 2 (#2310 warm handles):** once the probe is cheap, the dominant *remaining* fixed cost is
+  re-parsing the same schema + Index + Summary + Statistics + bloom on every request. Phase 2 caches
+  that parsed state across requests. This is the case study below — and it was benched the day it
+  merged (flight-direct over real tonic transport, 100,000-partition table, 1 cold + 5 repeated
+  requests per shape; results posted on #2310): a repeated point read dropped from **832 ms to
+  0.62 ms (~1,350×)**, `LIMIT 100` from 825 ms to **0.79 ms (~1,040×)**, and a full 100k-row scan
+  from 985 ms to **159 ms (6.2×**, the remainder being decode/stream, not parse). The work-done
+  counters prove the mechanism: `reader_opens=1, hits=5, refresh_unchanged=5` — only the cold
+  request opened readers; every repeat elided the parse entirely.
+
+**Generalizable rule:** *measure before you optimize, and sequence the levers — #2310 caches the
+parse cost of a scan that Phase 1 first had to stop doing. Caching the wrong thing first would have
+optimized a bug.*
+
+---
+
+## The operating system we ended with
+
+Putting the phases together, the steady-state machine looks like this.
+
+**Roles (agents):**
+
+| Role | Responsibility |
+|---|---|
+| `flow-lead` | Orchestrator/PM. Drives the pipeline, sequences specialists, writes no production code. |
+| `sstable-developer` | Implementation (TDD) inside the issue's worktree. |
+| `rust-reviewer` | Read-only Rust review against project standards. |
+| `roborev` | Adversarial automated review (the security/correctness net). |
+| `spec-auditor` | Intent audit ("C") — implementation vs the OpenSpec requirements. |
+| `coverage-reviewer` | Test-quality review — meaningful, not merely present. |
+| `flow-closer` | Disposable endgame owner — the one full gate, C, final review, merge, finalize. |
+
+**The implement loop (the inner cycle):**
+
+```
+implement (TDD)
+  → --lite gate every fix round        (cheap, summary-file redirect)
+  → rust-reviewer + roborev on the lite-green diff   (review-first)
+  → fix rounds: --lite re-cert + diff-scoped tests   (never a full gate per round)
+  → open PR
+  → flow-closer { full gate ONCE → C intent audit → final roborev → merge-on-green → finalize }
+```
+
+**The gate tiers:**
+
+| Tier | When | What it certifies |
+|---|---|---|
+| **Full** (24 components) | Once per issue, in `flow-closer` | The merge verdict of record. |
+| **Lite** (~1–5 min) | Every fix round | fmt + scoped clippy + blast-radius tests. Distinct summary — can never be pasted as the full one. |
+| **Delta** | Post-PASS test/docs-only polish | Re-certifies a narrow diff without a rebuild; fails closed on anything else. |
+
+**The two human seams:** design-spec approval (Seam 1) and merge (pre-authorized on green). That is
+the entire standing human surface.
+
+---
+
+## Metrics
+
+All figures below are computed directly from `docs/reports/delivery-telemetry.jsonl` (273 records,
+schema `docs/reports/delivery-telemetry.schema.json`). Each record is one delivery cycle and holds
+*authoritative data only* — GitHub timestamps and run-observed counters, never an estimate. A
+reopened issue that ships twice is legitimately two records (hence 273 records over 272 issues).
+
+**Method:** `gate_runs` counts full-gate runs through and including the first PASS, so
+`gate_runs == 1` is a clean first-pass. `rework` is the re-open/re-review count. `roborev_findings`
+is the raised-finding count; where classified, `roborev_blockers + roborev_nits` reconcile to it.
+
+### Overall (all 273 cycles)
+
+| Metric | Value | Baseline *(project memory, pre-restructure)* |
+|---|---|---|
+| Delivery cycles / distinct issues | 273 / 272 | — |
+| Gate-runs per issue (mean) | **1.79** | 1.87 |
+| Gate-runs p90 / max | **3 / 9** | p90 3 |
+| Rework rounds per issue (mean) | **1.83** | 1.92 |
+| First-pass rate (`gate_runs == 1`) | **55.3%** (151/273) | 54% |
+| Roborev findings (mean / total) | **3.26 / 889** | — |
+| Final gate outcome | 272 pass / 1 fail | — |
+| Median cycle time (issue open → close) | **27.4 h** | — |
+
+### Recent window (80 most recent cycles, PR > 2098 — i.e. under the mature context-economy process)
+
+| Metric | Value |
+|---|---|
+| Gate-runs per issue (mean) | **1.71** |
+| First-pass rate | **61.2%** (49/80) |
+| Rework rounds (mean) | 1.95 |
+
+First-pass rate improved from 54% (baseline) to **61%** on the recent window; gate-runs/issue held at
+the better end of the baseline. (Rework ticked up slightly on the recent window — consistent with a
+period weighted toward harder Flight/perf epics.)
+
+### Routing tells you where the cost is
+
+| Routing | n | gate-runs | rework | first-pass | findings/issue |
+|---|---|---|---|---|---|
+| **design** (OpenSpec) | 63 | 1.71 | **2.51** | 59% | **5.17** |
+| **oracle** (bug + parity test) | 210 | 1.81 | 1.63 | 54% | 2.68 |
+
+Design-driven work draws roughly **2× the review findings** and **1.5× the rework** of oracle-driven
+bug fixes — new surface area is where reviewers earn their keep. This is the empirical justification
+for routing new-surface work through a spec and a heavier review.
+
+### Review severity (81 cycles with classified findings)
+
+Of 273 findings across those cycles, **161 blockers vs 112 nits — a 59% blocker share.** The
+adversarial reviewer is not producing mostly noise: a majority of what it raises is fixed pre-merge.
+
+---
+
+## Case study: issue #2310, warm handles, end-to-end
+
+This one issue exercised every part of the machine in one week. It shipped as **PR #2350**, merged
+**2026-07-11** (squash commit `2ebd883f`). The endgame delivery cycle is recorded in the ledger under
+its spec child **#2345** (slug `flight-warm-handles`, routing `design`).
+
+### 1. Design-driven, Seam-1 approval of an 8-requirement spec
+
+Because warm handles add new server behavior, it went through OpenSpec. The owner approved a spec
+(`openspec/changes/archive/2026-07-11-flight-warm-handles/specs/flight-warm-handles/spec.md`) with
+**8 requirements**, each with red-provable scenarios:
+
+1. Cache keyed on **generation identity** (device+inode of each `Data.db`, cross-checked with the
+   parsed generation number), *not* the directory path — so the same files reached through a
+   different per-query snapshot hardlink dir are one warm entry.
+2. A **per-request staleness probe** with a **zero staleness window** — an authoritative directory/
+   generation listing, never mtime or filesystem-timing inference (#28-clean).
+3. A snapshot **`manifest.json` fast path** — a byte-identical manifest skips the `read_dir`, as an
+   optimization only, never a weaker freshness guarantee.
+4. **Fail-closed refresh** mirroring `Database::refresh()` (#1749): open every added generation
+   before swapping; any open failure returns the typed error and leaves the prior warm set fully
+   intact; a probe error counts as "changed."
+5. **LRU byte budget** (fixed 64 MiB) inside the <128 MB discipline; a generation removed on disk is
+   evicted immediately regardless of LRU age.
+6. **hit/miss/evict/refresh-outcome metrics** on the existing observability contract, no new knob.
+7. **Cancellation discipline** (#2264/#1473) held through probe and rebuild — a pre-cancelled request
+   does zero warm-path work.
+8. **Bench evidence** of ~zero parse cost on a repeated unchanged query.
+
+This is the "design-driven" cost profile from the metrics section made concrete: high requirement
+count, security-adjacent surface, heavy review ahead.
+
+### 2. A feasibility STOP mid-flight — and a split
+
+Partway in, the implementing agent discovered the planned approach needed a **core seam that did not
+exist**: the k-way merger could not be constructed from already-open shared readers. Rather than force
+a workaround into the Flight layer, the work **stopped and re-planned**. The seam was split out as
+**WS0 / #2346** (`KWayMerger::new_from_readers` + per-call `scan_cancel`) and landed first as **PR
+#2347** — a clean, oracle-routed delivery (ledger: `gate_runs 1`, `rework 1`, first-pass). The warm-
+handle epic then consumed that seam.
+
+**Lesson (and it is a doctrine, not an accident):** *agents must be allowed to STOP and re-plan.* The
+failure mode to design against is an agent bulldozing a bad approach to completion because "finish the
+task" is the instruction. A feasibility STOP that spawns a prerequisite is a success, not a stall.
+
+### 3. The adversarial-review walk, and how it converged
+
+Review ran review-first on the lite-green diff. Across the epic there were **six roborev rounds**
+(jobs 1637–1642) plus `rust-reviewer` and `coverage-reviewer` *(round numbering observed in
+practice; the ledger records the aggregate — 15 findings, 11 blockers, 4 nits for the cycle)*.
+
+- **Rounds 1–5 each surfaced a genuine blocker, all fixed red-proven.** The PR body confirms one of
+  these independently: a concurrent same-key rebuild that **duplicated readers and inflated
+  `used_bytes`**, found by both `rust-reviewer` and roborev job 1637, fixed with a deterministic
+  swap-barrier test that fails `left:4, right:2` with the dedup disabled.
+- **A security class recurred three times.** A **path-containment** check (#1430) had to be applied
+  again on each *new* file-access surface the feature introduced — the warm-probe `Data.db` read, the
+  `manifest.json` read, and budget accounting. The same class of finding reappearing on successive new
+  surfaces is the signature of a genuinely new attack surface, not reviewer repetition.
+- **Round 6 converged by an explicit rule.** The final round produced 2 non-security findings. Under a
+  **pre-declared convergence-by-scope rule**, they were declined-with-evidence and batched into
+  follow-up **#2351**, and a separate UDT-registry posture question was split to **#2349**. Without an
+  explicit convergence rule, an adversarial reviewer will always find *something*, and the walk never
+  ends.
+
+**Lesson:** *adversarial review on new cache/security-adjacent code converges in roughly six rounds —
+but only if you declare convergence-by-scope explicitly, decline with evidence, and batch nits.* And a
+second one, learned the hard way this week: **verify a reviewer's claim against ground truth before
+dispatching a fix** — one roborev job false-positived a "duplicate import" that was actually a doc
+comment *(observed in practice)*. Reviewer output is an input to judgment, not an order.
+
+### 4. The endgame, in a disposable context
+
+The close ran inside a `flow-closer` sub-agent: **one full gate of record (PASS, 24/24 components)**,
+the **spec-auditor C intent audit (PASS — all 8 requirements satisfied with public-surface tests)**, a
+final roborev confirmation, the squash-merge, the `openspec archive`, board → Done, and the telemetry
+stamp. The lead session retained only a ~20-line terminal packet — none of the gate stdout or review
+churn.
+
+The ledger's honest record of the cycle: **`gate_runs: 5`, `rework: 5`, `roborev_findings: 15`
+(11 blockers, 4 nits), `gate: pass`**, cycle time **7.7 h** (4.3 h to PR, 3.4 h in review). Note the
+tension worth being honest about: doctrine's ideal is *one* full gate per issue, and this flagship
+design epic took **five** full-gate runs through first PASS. Big, security-adjacent design work is
+exactly where the one-gate ideal bends — and the telemetry records it rather than hiding it, which is
+the point of instrumenting the process at all.
+
+The wiring evidence, from the PR: `do_get → do_get_setup → WarmTableRegistry::warm_readers →
+produce_streaming_from_readers → new_from_readers`, with an end-to-end test over real tonic transport
+(`do_get_over_transport_second_request_is_a_warm_hit`) asserting per-column `ArrayData` equality
+across the cold and warm requests. Every `#### Scenario:` in the spec has a test that fails by
+construction on pre-#2310 `main`.
+
+### 5. The measured payoff (spec requirement 8: bench evidence)
+
+Benched the day of the merge — BEFORE = `2ebd883f~1` (main immediately pre-merge), AFTER = main with
+the feature; flight-direct over a real loopback tonic server, 100,000-partition table, release
+builds, 1 cold + 5 repeated identical requests per shape, fully serialized runs (results posted on
+issue #2310):
+
+| Query shape | BEFORE cold | BEFORE repeat (med) | AFTER cold | AFTER warm (med) | Warm speedup |
+|---|---|---|---|---|---|
+| Point read (`key = X`) | 821.6 ms | 832.1 ms | 832.0 ms | **0.62 ms** | **~1,353×** |
+| `LIMIT 100` | 821.9 ms | 825.2 ms | 821.5 ms | **0.79 ms** | **~1,042×** |
+| Full scan (100k rows) | 980.6 ms | 985.1 ms | 994.8 ms | **158.8 ms** | **~6.2×** |
+
+The BEFORE build pays the full parse on *every* request (repeats ≈ cold); the AFTER build's repeats
+are sub-millisecond on point/LIMIT — the ~830 ms of per-request parse work is fully elided — while
+full-scan repeats are bounded by row decode/stream, exactly as the design predicts. The counters are
+the proof of mechanism, not just outcome: `hits=5, misses=1, reader_opens=1, evicts=0,
+refresh_unchanged=5, refresh_rebuilt_delta=1, refresh_fail_closed_retained=0` — one reader-open for
+the cold build, zero for all repeats. Row counts were identical cold vs warm on every shape, and an
+independent second run reproduced the numbers within noise. The unmodified #1494 `flight_do_get`
+criterion bench (2,000 rows, steady-state) independently showed **1.59×** (5.97 → 3.77 ms/request).
+Numbers are flight-direct by design — the through-Trino path adds a coordinator bound on top, so the
+warm-handle effect is measured where it lives.
+
+**Scope qualification (added after the fact — see the postscript):** these speedups apply to live
+mode and stable snapshot paths. In the connector's default *per-query snapshot* mode, each query's
+snapshot directory is cleared after the query, and the correctness fix below rightly forces a rebuild
+whenever cached backing paths are dead — so snapshot-mode requests currently re-pay the parse.
+Restoring the warm benefit there (rebind-by-inode, keeping all parsed state) is tracked as #2356.
+
+### 6. Postscript: the nightly caught what the PR pipeline structurally couldn't
+
+The day after the merge, the nightly Flight↔Trino docker-compose E2E on `main` went red — 9
+assertions, all `streaming merge producer error: No such file or directory`. Root cause (#2352):
+scans lazily re-open `Data.db` by the reader's stored *path* while point reads use a held file
+descriptor, and the connector deletes each per-query snapshot dir after its query — so a warm hit
+could serve a reader whose backing path was gone. Every PR-branch CI run had passed, because the
+docker-compose job ran **only on the main schedule, never on PRs** (now tracked as #2358).
+
+The machine handled it the way it is designed to: overnight red → bisect from CI history (branch
+tips green, squash-merge red) → P1 issue with hypotheses → red-proven repro → fail-closed fix (a
+warm hit is served only when every cached backing path still resolves; dead paths rebuild, counted
+as a refresh outcome, never a stale hit) → local E2E 34/34 green → review-first (one reviewer
+finding declined with an in-code adjudication, which kept the final review pass clean) → one gate of
+record → merge. Same-day turnaround. Three lessons worth exporting: **(a)** integration jobs that
+run only on a schedule are a structural blind spot for the exact surfaces under active change —
+path-filter them onto PRs; **(b)** a test can *encode* a bug — the original fast-path test "proved"
+its property by deleting live files, i.e. it asserted the unsound behavior; reviewers should ask
+what a test's setup implies, not just what it asserts; **(c)** honest qualification beats a
+retracted claim — the bench numbers above were correct as measured, and the fix narrowed their
+scope; the report says so rather than quietly standing on the headline.
+
+---
+
+## Lessons / playbook — the generalizable rules
+
+These are the transferable rules, stated so another team can adopt them without CQLite's specifics.
+
+1. **One gate of record; everything else is iteration.** Have exactly one artifact that means
+   "mergeable." Make it un-forgeable (a distinct summary block) and un-satisfiable-vacuously
+   (fail-closed on missing inputs). No ad-hoc test run ever counts.
+
+2. **Tier your gates.** A cheap gate every fix round, the expensive full gate once. Otherwise agents
+   either under-verify (cheap only) or burn hours (full every round). Give the cheap gate a *distinct*
+   output so it can never be passed off as the real one.
+
+3. **Fail-closed everywhere.** Missing fixtures fail the gate. A probe error forces a rebuild. An
+   unsupported config returns a typed error. Silent degradation is how agent systems ship confident
+   wrongness — design it out.
+
+4. **Two human seams only.** Approve the design, then pre-authorize the merge on green. If a human is
+   in the inner loop, throughput is bounded by the human. Keep them at the two decisions that actually
+   need judgment.
+
+5. **Review before the expensive gate.** So your one costly certification lands on already-reviewed
+   code, not on a diff review is about to change. The metrics show design work draws ~2× the findings
+   — spend review there.
+
+6. **Disposable contexts for high-volume streams.** Run gate stdout and review churn in short-lived
+   sub-agents that return a compact packet. The orchestrator keeps decisions, not logs — its context
+   stays the size of one issue no matter how many flow through.
+
+7. **The board is the only dispatch authority; a pushed branch is the only lock.** Encode
+   coordination as mechanism (a git-push lock, a timestamp-arithmetic reap), not etiquette. Make
+   "stuck" deterministically detectable via heartbeats.
+
+8. **Let agents STOP and re-plan.** A feasibility STOP that spawns a prerequisite is a success. The
+   worst outcome is an agent forcing a bad approach to completion because the instruction was "finish."
+
+9. **Adversarial review converges — if you make it.** New cache/security-adjacent code takes ~6
+   rounds. Declare convergence-by-scope explicitly, decline with evidence, batch the nits into one
+   follow-up. Otherwise the walk is infinite, because a good reviewer always finds one more thing.
+
+10. **Verify reviewer claims against ground truth before acting.** Reviewer output is an input to
+    judgment, not a work order. False positives (a doc comment mistaken for a duplicate import) will
+    happen; a cheap check before dispatching a fix pays for itself.
+
+11. **Route work at intake: oracle vs design.** Bug-with-a-test skips the spec; new-surface work gets
+    one. Wrong routing is real cost — either bureaucracy on a one-line fix or unreviewed surface area.
+
+12. **Pick the oracle for the actual property.** A parity check that enumerates tombstones can't catch
+    a reconciliation bug. An oracle that is green on a real bug is worse than none.
+
+13. **Red-proven regression tests; wiring evidence.** A regression test must fail on the unfixed code.
+    A feature is done only when its public surface exercises it end-to-end, not when helper units pass.
+
+14. **Measure every delivery; retro against a baseline.** One telemetry record per cycle (gate-runs,
+    rework, findings) turns each process change into an experiment with a number attached. "It feels
+    faster" is not a result.
+
+15. **Scoping is a deliverable.** A well-scoped issue is the interface between an expensive planning
+    model and a cheap implementation model. Invest strong models in decomposition; let cheaper agents
+    implement the pre-scoped children.
+
+16. **Keep doctrine current in the same change.** Any change to how work is done updates the operating
+    manual (`CLAUDE.md`) and the doctrine site in the *same* PR. Stale process docs are how a good
+    process quietly rots.
+
+---
+
+## What we would do differently
+
+- **Instrument earlier.** The richest lessons here are the ones the telemetry ledger made legible.
+  The pre-instrument period is a blur of "it felt fine"; the instrumented period is a set of
+  experiments. Start the ledger on day one, even crude.
+
+- **Declare the convergence rule up front.** The review walks that stayed cheap were the ones with a
+  pre-declared convergence-by-scope rule. The ones that sprawled were the ones where "are we done
+  reviewing?" was litigated live, per round. Make it a standing rule, not a per-issue negotiation.
+
+- **Build the feasibility-STOP culture before the first hard epic, not during it.** The #2310 WS0
+  split worked because stopping was already legitimate. A team that treats a STOP as a failure will
+  get bulldozed approaches on exactly the issues where they hurt most.
+
+- **The one-gate ideal needs a documented exception for large design work.** #2310 took 5 full-gate
+  runs, not 1. Rather than treat that as a doctrine violation, name it: design epics with new
+  security-adjacent surface get a higher gate budget, and that is fine. Pretending otherwise just
+  produces telemetry that looks like non-compliance instead of a legible cost of hard work.
+
+- **Route more aggressively to oracle where possible.** Oracle-routed work has half the findings and
+  1.5× fewer rework rounds. Some work genuinely needs a spec — but any work that *can* be reduced to
+  a bug-plus-pinned-test is cheaper delivered that way. The temptation to over-spec is real.
+
+---
+
+## Appendix: sources and how to reproduce the numbers
+
+- **Ledger aggregates:** `docs/reports/delivery-telemetry.jsonl` (273 records) +
+  `delivery-telemetry.schema.json`. Reproduce with a JSON pass: mean/p90 of `gate_runs`, `rework`;
+  first-pass = share with `gate_runs == 1`; recent window = records with `pr > 2098`.
+- **#2310 case study:** OpenSpec change `openspec/changes/archive/2026-07-11-flight-warm-handles/`
+  (proposal, design, spec with 8 requirements, tasks); PR #2350 (squash `2ebd883f`, merged
+  2026-07-11); ledger record under issue #2345; WS0 seam PR #2347 (issue #2346); follow-ups #2351,
+  #2349.
+- **Gate:** `scripts/agent-gate.sh --list` → 24 components; contract in `CLAUDE.md`; deep mechanics in
+  `docs/development/gate-ops.md`.
+- **Performance baselines:** `docs/architecture/issue-2310-ms-point-reads-research.md`.
+- **Process doctrine:** `CLAUDE.md`, `docs/development/pm-operating-loop.md`,
+  `docs/development/fleet-runbook.md`, `docs/development/roborev-severity.md`, and the doctrine site
+  under `agents-developing/`.
+- **Not repo-reconstructable, marked *(observed in practice)* in text:** the 291-issue viability
+  audit count, the roborev job numbers 1637–1642, the duplicate-import false positive, and specific
+  field-observed through-Trino latencies. These come from lived operation this week, not a committed
+  artifact.


### PR DESCRIPTION
Cleanup sweep after v0.15.0: seven research/audit markdown docs referenced by issues (#905 compaction-manager research, #1045 spark research, #2310 point-reads, throughput saturation, build/test/deploy audits, delivery journey) existed only as untracked files on the delivery machine. Committing them so the references are durable. Docs-only.