### PR TITLE
harness(#2668): flow-closer executable-as-written — NEEDS-SPAWN handshake, scripted #2456 pre-merge SHA assert, hard gate-wait deadline

### DIFF
--- a/.claude/agents/flow-closer.md
+++ b/.claude/agents/flow-closer.md
@@ -24,15 +24,44 @@ routing (`design`/`oracle`), the OpenSpec change `<slug>` (design only), and the
 `CQLITE_DATASETS_ROOT` (point it at the MAIN checkout's `test-data/datasets` — worktrees
 lack the gitignored `Data.db` binaries and otherwise yield 0-row false passes).
 
-## NEVER idle-wait on the gate (the #1855 rule — non-negotiable)
+## Your tools — no `Agent` grant; hand spawns back to the lead (issue #2668)
+Your frontmatter grants `Read, Write, Edit, Bash, Glob, Grep` — **no `Agent` tool**. You
+therefore CANNOT spawn `spec-auditor` (step 2, C) or a fresh `sstable-developer` (step 4,
+src-design fix) yourself. When a step needs a spawn, you **STOP and emit a NEEDS-SPAWN
+packet** to the lead, then **end your turn**; the lead performs the spawn and re-invokes
+you with the result. Exact format (a fenced block, one per needed spawn):
+```
+NEEDS-SPAWN {role: spec-auditor|sstable-developer, issue: N, anchor: <path or issue>, reason: <1 line>, resume-token: <stage>}
+```
+- `role` — `spec-auditor` (C intent audit) or `sstable-developer` (src-design fix).
+- `anchor` — what the spawned agent binds to: `openspec/changes/<slug>/specs/**` for C, or
+  the issue/finding for a fix.
+- `resume-token` — the stage to resume at when the lead re-invokes you: `C`, `fix`,
+  `re-gate`, `merge`.
+This is a two-sided handshake: the lead knows to spawn on a NEEDS-SPAWN packet and to
+re-invoke you carrying the spawned agent's verdict/report. You never idle-wait on a spawn.
+
+## NEVER idle-wait on the gate — poll the summary file on a hard deadline (#1855/#2668)
 A subagent that **idle-waits** on a 12–25 min gate is killed by the 600s stall watchdog
 and takes its child gate process down with it (3 implementers lost this way 2026-07-03/04).
 So you MUST run the full gate with `Bash run_in_background` and **end your turn** — the
 harness re-invokes you when the gate process exits. Do NOT sit in a silent wait, and do
-NOT poll in a tight `ScheduleWakeup` loop. If you must check progress, `grep` the
-summary file at **≥5-min** intervals — never a silent or hot wait. A **queued gate ≠ a
-hung gate**: under load the gate first prints `waiting for gate slot (N in use)…` once
-(#1825) and can take 20+ min wall-clock; that is normal.
+NOT poll in a tight `ScheduleWakeup` loop.
+
+**Polling is MANDATORY, not optional (#2668).** After launching the gate, poll the
+**SUMMARY FILE** (never the log) with a cheap `grep` at **5-minute intervals**:
+```bash
+grep -q 'RESULT:' /tmp/gate-<N>.txt && echo done   # summary present ⇒ gate finished
+```
+- **Hard deadline = 45 minutes** of active-gate wall-clock. On the deadline with no
+  `RESULT:` in the summary file, emit terminal packet `verdict: gate-timeout` (naming the
+  summary-file path + log path) — **never park silently**.
+- **Queued-slot waits extend the deadline by the queue wait.** A **queued gate ≠ a hung
+  gate**: under load the gate first prints `waiting for gate slot (N in use)…` (#1825) and
+  can sit 20+ min before it even starts. Detect the queue via the summary file's *absence*
+  plus that slot message; while queued, the 45-min active-gate deadline has not started —
+  extend it by the observed queue wait. Once the gate is actually running, the 45-min
+  clock applies.
 
 ## Heartbeat (issue #2089)
 Refresh the claim liveness heartbeat at the two stage transitions you own — **at start**
@@ -57,10 +86,15 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
    SUMMARY ====` block (start marker → `RESULT:` → end marker). **Never read `gate-<N>.log`
    into your context** — the SUMMARY file is the only gate text you retain. `--lite` never
    substitutes for this run.
-2. **C — intent audit (design-routed only).** Spawn `spec-auditor` (explicit model)
-   anchored to `openspec/changes/<slug>/specs/**`. Verdict MUST be PASS (every requirement
-   `satisfied` with a public-surface test as evidence). An `unmet`/uncovered/unjustified-
-   `partial` requirement blocks merge → route back (see step 4 escalation).
+2. **C — intent audit (design-routed only).** You have no `Agent` tool, so you **emit a
+   NEEDS-SPAWN packet and end your turn** — the lead spawns `spec-auditor` (explicit model)
+   anchored to `openspec/changes/<slug>/specs/**` and re-invokes you with its verdict:
+   ```
+   NEEDS-SPAWN {role: spec-auditor, issue: <N>, anchor: openspec/changes/<slug>/specs/**, reason: C intent audit before merge, resume-token: C}
+   ```
+   On re-invoke, the verdict MUST be PASS (every requirement `satisfied` with a
+   public-surface test as evidence). An `unmet`/uncovered/unjustified-`partial` requirement
+   blocks merge → route back (see step 4 escalation).
 3. **Final roborev confirmation pass.** Because review-first already ran, this should
    converge to **clean-on-arrival**. Run roborev with the machine's configured agent
    (`/roborev-review-branch --base origin/main`; no `--agent`/`--model` unless the local
@@ -74,23 +108,48 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
    - A **mechanical** blocker (fmt/clippy nit, a missing assertion, a one-line fix) you fix
      **inline** in the worktree, re-cert with `scripts/agent-gate.sh --lite` (+ any diff-
      relevant parity/integration target), and re-review.
-   - A **src-design** blocker (needs real implementation judgment) → **respawn a fresh
-     `sstable-developer`** (explicit model) to fix it TDD; consume only its LITE-block +
-     ≤5-line report.
+   - A **src-design** blocker (needs real implementation judgment) → you have no `Agent`
+     tool, so **emit a NEEDS-SPAWN packet and end your turn**; the lead respawns a fresh
+     `sstable-developer` (explicit model) to fix it TDD and re-invokes you with its
+     LITE-block + ≤5-line report:
+     ```
+     NEEDS-SPAWN {role: sstable-developer, issue: <N>, anchor: <issue or roborev finding>, reason: src-design blocker <1 line>, resume-token: fix}
+     ```
    - **Any src change after the full gate INVALIDATES that gate.** The gate of record must
      **postdate the final src change AND the final rebase** — if you fixed src (yours or the
      implementer's) or rebased after step 1, **re-run the full gate** (back to step 1).
      `--lite` re-certs are never the gate of record.
 5. **Merge on green (worker-merges-own-PR model).** When gate PASS + C PASS (design) +
    roborev clean all hold on the final tree: beat the heartbeat, rebase on `origin/main`
-   (resolve conflicts in the worktree — a rebase re-invalidates the gate per step 4), open
-   the nits follow-up issue if any, then merge:
+   (resolve conflicts in the worktree — a rebase re-invalidates the gate per step 4),
+   `git push` the certified tip, open the nits follow-up issue if any, then — **before**
+   `gh pr merge` — run the two mechanical pre-merge guards:
+
+   **(a) Scripted pre-merge SHA assert (#2456/#2668).** Never merge a head the gate of
+   record did not cover. Run the script with the SHA whose gate SUMMARY you hold
+   (`git rev-parse HEAD` on the certified worktree tip):
+   ```bash
+   bash scripts/flow/premerge-assert.sh <pr> <certified-sha>
+   ```
+   It exits `0` (prints `PREMERGE: OK <sha>`) only when the PR is OPEN **and** its
+   `headRefOid` equals `<certified-sha>`. On exit `2` (stale head or closed/merged PR) →
+   **do NOT merge**, return terminal packet `verdict: stale-head` with the script output.
+   On exit `3` (gh/network failure) → **do NOT merge**, return `verdict: gh-failure` with
+   the script output. Fail closed — never "assume ok".
+
+   **(b) Re-read for a fresh `HOLD:` order.** Immediately before merge, one pass over the
+   issue + PR comments for a manager hold:
+   ```bash
+   gh pr view <pr> --comments | grep -i hold
+   ```
+   Obey any open `HOLD: merge after #N` order — hold the merge until #N lands and report
+   `blocked` (do NOT merge).
+
+   Only when (a) is `PREMERGE: OK` and (b) shows no active hold:
    ```bash
    scripts/flow/claim-heartbeat.sh beat <N>
    gh pr merge <pr> --squash --delete-branch
    ```
-   Obey any open `HOLD: merge after #N` manager order — hold the merge until #N lands and
-   report `blocked` (do NOT merge).
 6. **Finalize.** Run `flow-finalize <N>` (archive the OpenSpec change if design, stamp the
    telemetry ledger — supply the honest `--roborev-blockers`/`--roborev-nits` split you
    observed — remove the worktree, delete the origin claim branch, clear the heartbeat,
@@ -99,7 +158,7 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
 ## Terminal packet — the ONLY thing you return (≤10 lines residual)
 Return a compact packet, nothing else — no gate log, no diff, no review transcript:
 ```
-verdict:      merged | blocked | failed
+verdict:      merged | blocked | failed | gate-timeout | stale-head | gh-failure
 pr:           <PR URL>
 summary-file: /tmp/gate-<N>.txt        # gate of record (RESULT: PASS)
 C:            PASS | n/a (oracle)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,9 +268,15 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   `opus` with a hard `400 'opus' model is not supported` — a silent review failure that looks like an
   outage. Run from a checkout whose `.roborev.toml` you know (worktrees inherit `main`'s pinned config);
   `--model` is the reliable override. codex's own configured model is `gpt-5.6-sol` (`~/.codex/config.toml`).
-- **flow-closer (#2084)**: the full gate, C, the final roborev pass, and the merge run inside the
+- **flow-closer (#2084/#2668)**: the full gate, the final roborev pass, and the merge run inside the
   disposable `flow-closer` subagent — the lead retains only its terminal packet (verdict, PR URL,
-  summary-file path, ≤10 lines residual), never gate stdout or review churn.
+  summary-file path, ≤10 lines residual), never gate stdout or review churn. The closer has **no
+  `Agent` tool**, so **C is spawned by the lead at the closer's `NEEDS-SPAWN` request** (the closer
+  stops, emits a `NEEDS-SPAWN {role: spec-auditor, …}` packet, and the lead spawns `spec-auditor`
+  then re-invokes with the verdict; a src-design fix respawns `sstable-developer` the same way).
+  Before `gh pr merge` the closer runs the scripted pre-merge assert
+  `scripts/flow/premerge-assert.sh <pr> <certified-sha>` (#2456) — refusing to merge unless the PR
+  head still equals the certified SHA — and re-reads comments for a fresh `HOLD:` order.
 - **Severity triage (#2088, rubric `docs/development/roborev-severity.md`)**: roborev **blockers**
   are fixed pre-merge — each re-triggers `fix → --lite (+ any diff-relevant parity/integration
   target) → re-review` (#2087). **Nits** never trigger

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -21,6 +21,9 @@
 # mismatch, on a closed/merged PR, or on a gh/network failure — FAIL CLOSED,
 # never "assume ok".
 #
+# We parse with gh's built-in `--jq` (jq expression run inside gh), so gh's JSON
+# serialization is NOT load-bearing — we never read raw JSON with sed/regex.
+#
 # USAGE
 #   scripts/flow/premerge-assert.sh <pr-number> <certified-sha>
 #
@@ -55,8 +58,29 @@ if [ -z "$pr" ] || [ -z "$certified" ]; then
   exit 3
 fi
 
-# Fetch head + state in one call. On any gh/network failure -> exit 3 (fail closed).
-if ! json=$(gh pr view "$pr" --repo "$repo" --json headRefOid,state 2>/dev/null); then
+# Normalize the certified SHA to lowercase and require a full 40-char hex SHA —
+# an abbreviated or malformed value can never be safely compared to headRefOid.
+certified=$(printf '%s' "$certified" | tr '[:upper:]' '[:lower:]')
+case "$certified" in
+  *[!0-9a-f]* | "")
+    printf 'error: certified SHA must be 40 hex chars (got: %s)\n' "$2" >&2
+    usage
+    exit 3
+    ;;
+esac
+if [ "${#certified}" -ne 40 ]; then
+  printf 'error: certified SHA must be a full 40-char hex SHA (got %d chars: %s)\n' \
+    "${#certified}" "$2" >&2
+  usage
+  exit 3
+fi
+
+# Fetch head + state in ONE call, extracted by gh's built-in jq into two
+# whitespace-separated tokens: "<headRefOid> <state>". Because gh runs the jq
+# expression, its JSON serialization (compact vs pretty) is irrelevant. On any
+# gh/network failure -> exit 3 (fail closed).
+if ! out=$(gh pr view "$pr" --repo "$repo" --json headRefOid,state \
+  --jq '.headRefOid + " " + .state' 2>/dev/null); then
   printf '========================================================\n' >&2
   printf 'PREMERGE: GH-FAILURE\n' >&2
   printf '  gh pr view %s --repo %s failed (auth/network/no-such-PR).\n' "$pr" "$repo" >&2
@@ -65,14 +89,15 @@ if ! json=$(gh pr view "$pr" --repo "$repo" --json headRefOid,state 2>/dev/null)
   exit 3
 fi
 
-# Parse fields without jq (bash 3.2 / minimal deps). gh emits compact JSON.
-actual=$(printf '%s\n' "$json" | sed -n 's/.*"headRefOid":"\([0-9a-fA-F]*\)".*/\1/p')
-state=$(printf '%s\n' "$json" | sed -n 's/.*"state":"\([A-Za-z]*\)".*/\1/p')
+# Split the two tokens. Empty or malformed --jq output -> exit 3 (fail closed).
+actual=$(printf '%s' "$out" | awk '{print $1}')
+state=$(printf '%s' "$out" | awk '{print $2}')
+actual=$(printf '%s' "$actual" | tr '[:upper:]' '[:lower:]')
 
 if [ -z "$actual" ] || [ -z "$state" ]; then
   printf '========================================================\n' >&2
   printf 'PREMERGE: GH-FAILURE\n' >&2
-  printf '  Could not parse headRefOid/state from gh output.\n' >&2
+  printf '  Could not parse headRefOid/state from gh --jq output.\n' >&2
   printf '  Refusing to merge (fail closed).\n' >&2
   printf '========================================================\n' >&2
   exit 3

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# premerge-assert.sh — the #2456 pre-merge SHA guard, as a script (issue #2668).
+#
+# WHY THIS EXISTS
+# ---------------
+# The flow-closer certifies a SPECIFIC SHA: the exact tree the full gate of
+# record and the final roborev pass actually ran on. If the PR's head has
+# moved since that certification (a foreign push, a stale un-pushed rebase,
+# someone else's commit), then `gh pr merge` would squash a DIFFERENT tree than
+# the one the gate covered. That is the 2026-07-14 stale-merge escape on
+# #2299/PR #2421: the closer certified a rebased-and-fixed tip locally but never
+# pushed it, and `gh pr merge` squashed the PR's stale pre-fix head, transiently
+# landing a known data-loss blocker on main. The GitHub required check re-runs
+# on push but CANNOT catch a "merge of an old green head" — this SHA assertion
+# is the real guard.
+#
+# This encodes the #2456 rule mechanically so the closer runs it instead of
+# remembering it: immediately before `gh pr merge`, assert that the PR is OPEN
+# and its headRefOid equals the locally-certified SHA. Refuse (non-zero) on any
+# mismatch, on a closed/merged PR, or on a gh/network failure — FAIL CLOSED,
+# never "assume ok".
+#
+# USAGE
+#   scripts/flow/premerge-assert.sh <pr-number> <certified-sha>
+#
+# ENVIRONMENT
+#   GH_REPO   the target repo (default: pmcfadin/cqlite). `gh` honors GH_REPO
+#             natively; we pass --repo explicitly too so the default applies.
+#
+# EXIT CODES
+#   0   head matches + PR OPEN     — prints "PREMERGE: OK <sha>"
+#   2   head moved (mismatch), OR PR closed/merged — LOUD multi-line refusal
+#   3   gh/network/usage failure   — fail closed, never merge on uncertainty
+#
+# macOS bash 3.2 compatible, shellcheck-clean.
+set -euo pipefail
+
+repo="${GH_REPO:-pmcfadin/cqlite}"
+
+usage() {
+  printf 'usage: %s <pr-number> <certified-sha>\n' "$(basename "$0")" >&2
+}
+
+if [ "$#" -ne 2 ]; then
+  usage
+  exit 3
+fi
+
+pr="$1"
+certified="$2"
+
+if [ -z "$pr" ] || [ -z "$certified" ]; then
+  usage
+  exit 3
+fi
+
+# Fetch head + state in one call. On any gh/network failure -> exit 3 (fail closed).
+if ! json=$(gh pr view "$pr" --repo "$repo" --json headRefOid,state 2>/dev/null); then
+  printf '========================================================\n' >&2
+  printf 'PREMERGE: GH-FAILURE\n' >&2
+  printf '  gh pr view %s --repo %s failed (auth/network/no-such-PR).\n' "$pr" "$repo" >&2
+  printf '  Cannot verify the PR head — refusing to merge (fail closed).\n' >&2
+  printf '========================================================\n' >&2
+  exit 3
+fi
+
+# Parse fields without jq (bash 3.2 / minimal deps). gh emits compact JSON.
+actual=$(printf '%s\n' "$json" | sed -n 's/.*"headRefOid":"\([0-9a-fA-F]*\)".*/\1/p')
+state=$(printf '%s\n' "$json" | sed -n 's/.*"state":"\([A-Za-z]*\)".*/\1/p')
+
+if [ -z "$actual" ] || [ -z "$state" ]; then
+  printf '========================================================\n' >&2
+  printf 'PREMERGE: GH-FAILURE\n' >&2
+  printf '  Could not parse headRefOid/state from gh output.\n' >&2
+  printf '  Refusing to merge (fail closed).\n' >&2
+  printf '========================================================\n' >&2
+  exit 3
+fi
+
+if [ "$state" != "OPEN" ]; then
+  printf '========================================================\n' >&2
+  printf 'PREMERGE: NOT-OPEN\n' >&2
+  printf '  PR #%s state is "%s" (expected OPEN).\n' "$pr" "$state" >&2
+  printf '  The PR is already closed or merged — do NOT merge again.\n' >&2
+  printf '========================================================\n' >&2
+  exit 2
+fi
+
+if [ "$actual" != "$certified" ]; then
+  printf '========================================================\n' >&2
+  printf 'PREMERGE: STALE-HEAD — REFUSING TO MERGE\n' >&2
+  printf '  certified SHA: %s\n' "$certified" >&2
+  printf '  actual   head: %s\n' "$actual" >&2
+  printf '  head moved since certification — the gate of record no longer\n' >&2
+  printf '  covers this PR; re-certify before merge.\n' >&2
+  printf '========================================================\n' >&2
+  exit 2
+fi
+
+printf 'PREMERGE: OK %s\n' "$certified"
+exit 0

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Regression tests for scripts/flow/premerge-assert.sh (issue #2668).
+#
+# Fast + hermetic: `gh` is shimmed by a PATH-prepended mock that returns
+# controlled JSON (or a failure) driven by env vars — no network, no GitHub.
+#
+# Run standalone:   bash scripts/tests/test_premerge_assert.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ASSERT="$SCRIPT_DIR/../flow/premerge-assert.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+T=$(mktemp -d "${TMPDIR:-/tmp}/premerge-assert-test.XXXXXX")
+trap 'rm -rf "$T"' EXIT
+
+# --- gh mock -----------------------------------------------------------------
+# A fake `gh` on PATH. It reads two env vars set per-case:
+#   MOCK_GH_JSON   the exact stdout to emit (compact JSON as `gh --json` gives)
+#   MOCK_GH_FAIL   if "1", exit non-zero without output (simulates auth/network)
+BIN="$T/bin"
+mkdir -p "$BIN"
+cat >"$BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+if [ "${MOCK_GH_FAIL:-0}" = "1" ]; then
+  echo "gh: could not connect" >&2
+  exit 1
+fi
+printf '%s\n' "${MOCK_GH_JSON:-}"
+exit 0
+MOCK
+chmod +x "$BIN/gh"
+
+# run <expected-exit> <description> — invokes the assert with the gh mock on
+# PATH, captures combined output + exit code. Sets $OUT and $RC for assertions.
+run() {
+  local want="$1" desc="$2"
+  shift 2
+  OUT=$(PATH="$BIN:$PATH" bash "$ASSERT" "$@" 2>&1)
+  RC=$?
+  if [ "$RC" -ne "$want" ]; then
+    bad "$desc (exit $RC, wanted $want)"
+    printf '     output: %s\n' "$OUT"
+    return 1
+  fi
+  return 0
+}
+
+CERTIFIED="da9a7cb2abc0000000000000000000000000000"
+STALE="ca8eb016def0000000000000000000000000000"
+
+# --- Case 1: match -> exit 0 --------------------------------------------------
+export MOCK_GH_FAIL=0
+export MOCK_GH_JSON="{\"headRefOid\":\"$CERTIFIED\",\"state\":\"OPEN\"}"
+if run 0 "match: OPEN + head==certified -> exit 0" 2421 "$CERTIFIED"; then
+  case "$OUT" in
+    *"PREMERGE: OK $CERTIFIED"*) ok "match: prints PREMERGE: OK <sha>" ;;
+    *) bad "match: missing 'PREMERGE: OK <sha>' (got: $OUT)" ;;
+  esac
+fi
+
+# --- Case 2: mismatch -> exit 2, message names BOTH SHAs -----------------------
+export MOCK_GH_JSON="{\"headRefOid\":\"$STALE\",\"state\":\"OPEN\"}"
+if run 2 "mismatch: head moved -> exit 2" 2421 "$CERTIFIED"; then
+  if [ "${OUT#*"$CERTIFIED"}" != "$OUT" ] && [ "${OUT#*"$STALE"}" != "$OUT" ]; then
+    ok "mismatch: message contains BOTH SHAs"
+  else
+    bad "mismatch: message must contain both certified + actual SHA (got: $OUT)"
+  fi
+  case "$OUT" in
+    *"re-certify before merge"*) ok "mismatch: message says re-certify before merge" ;;
+    *) bad "mismatch: missing re-certify guidance (got: $OUT)" ;;
+  esac
+fi
+
+# --- Case 3: merged/closed PR -> exit 2 ---------------------------------------
+export MOCK_GH_JSON="{\"headRefOid\":\"$CERTIFIED\",\"state\":\"MERGED\"}"
+if run 2 "merged PR -> exit 2" 2421 "$CERTIFIED"; then
+  case "$OUT" in
+    *"NOT-OPEN"*|*"closed or merged"*) ok "merged: distinct not-open refusal message" ;;
+    *) bad "merged: missing not-open message (got: $OUT)" ;;
+  esac
+fi
+
+# --- Case 4: gh/network failure -> exit 3 (fail closed) -----------------------
+export MOCK_GH_FAIL=1
+export MOCK_GH_JSON=""
+if run 3 "gh failure -> exit 3 (fail closed)" 2421 "$CERTIFIED"; then
+  case "$OUT" in
+    *"GH-FAILURE"*) ok "gh-failure: distinct fail-closed message" ;;
+    *) bad "gh-failure: missing GH-FAILURE message (got: $OUT)" ;;
+  esac
+fi
+export MOCK_GH_FAIL=0
+
+# --- Case 5: usage guard -> exit 3 --------------------------------------------
+if run 3 "missing args -> exit 3" 2421; then
+  ok "usage: too few args fails closed (exit 3)"
+fi
+
+# --- Case 6: unparseable JSON -> exit 3 (fail closed) -------------------------
+export MOCK_GH_JSON="not json at all"
+if run 3 "unparseable JSON -> exit 3" 2421 "$CERTIFIED"; then
+  ok "unparseable: fails closed (exit 3)"
+fi
+
+# --- summary -----------------------------------------------------------------
+printf '\n=== premerge-assert: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -2,8 +2,9 @@
 #
 # Regression tests for scripts/flow/premerge-assert.sh (issue #2668).
 #
-# Fast + hermetic: `gh` is shimmed by a PATH-prepended mock that returns
-# controlled JSON (or a failure) driven by env vars — no network, no GitHub.
+# Fast + hermetic: `gh` is shimmed by a PATH-prepended mock that emits the
+# two-token line the script's `--jq '.headRefOid + " " + .state'` expression
+# would produce (or a failure), driven by env vars — no network, no GitHub.
 #
 # Run standalone:   bash scripts/tests/test_premerge_assert.sh
 set -uo pipefail
@@ -20,8 +21,10 @@ T=$(mktemp -d "${TMPDIR:-/tmp}/premerge-assert-test.XXXXXX")
 trap 'rm -rf "$T"' EXIT
 
 # --- gh mock -----------------------------------------------------------------
-# A fake `gh` on PATH. It reads two env vars set per-case:
-#   MOCK_GH_JSON   the exact stdout to emit (compact JSON as `gh --json` gives)
+# A fake `gh` on PATH. Since the script parses via gh's built-in `--jq`, the
+# mock stands in for gh-plus-jq and emits the already-extracted two-token line
+# "<headRefOid> <state>". Two env vars drive it per-case:
+#   MOCK_GH_OUT    the exact stdout to emit (the two-token --jq result)
 #   MOCK_GH_FAIL   if "1", exit non-zero without output (simulates auth/network)
 BIN="$T/bin"
 mkdir -p "$BIN"
@@ -31,13 +34,13 @@ if [ "${MOCK_GH_FAIL:-0}" = "1" ]; then
   echo "gh: could not connect" >&2
   exit 1
 fi
-printf '%s\n' "${MOCK_GH_JSON:-}"
+printf '%s\n' "${MOCK_GH_OUT:-}"
 exit 0
 MOCK
 chmod +x "$BIN/gh"
 
-# run <expected-exit> <description> — invokes the assert with the gh mock on
-# PATH, captures combined output + exit code. Sets $OUT and $RC for assertions.
+# run <expected-exit> <description> <args...> — invokes the assert with the gh
+# mock on PATH, captures combined output + exit code. Sets $OUT and $RC.
 run() {
   local want="$1" desc="$2"
   shift 2
@@ -51,12 +54,12 @@ run() {
   return 0
 }
 
-CERTIFIED="da9a7cb2abc0000000000000000000000000000"
-STALE="ca8eb016def0000000000000000000000000000"
+CERTIFIED="da9a7cb2abc00000000000000000000000000000"   # full 40-char hex
+STALE="ca8eb016def11111111111111111111111111111"       # full 40-char hex
 
 # --- Case 1: match -> exit 0 --------------------------------------------------
 export MOCK_GH_FAIL=0
-export MOCK_GH_JSON="{\"headRefOid\":\"$CERTIFIED\",\"state\":\"OPEN\"}"
+export MOCK_GH_OUT="$CERTIFIED OPEN"
 if run 0 "match: OPEN + head==certified -> exit 0" 2421 "$CERTIFIED"; then
   case "$OUT" in
     *"PREMERGE: OK $CERTIFIED"*) ok "match: prints PREMERGE: OK <sha>" ;;
@@ -65,7 +68,7 @@ if run 0 "match: OPEN + head==certified -> exit 0" 2421 "$CERTIFIED"; then
 fi
 
 # --- Case 2: mismatch -> exit 2, message names BOTH SHAs -----------------------
-export MOCK_GH_JSON="{\"headRefOid\":\"$STALE\",\"state\":\"OPEN\"}"
+export MOCK_GH_OUT="$STALE OPEN"
 if run 2 "mismatch: head moved -> exit 2" 2421 "$CERTIFIED"; then
   if [ "${OUT#*"$CERTIFIED"}" != "$OUT" ] && [ "${OUT#*"$STALE"}" != "$OUT" ]; then
     ok "mismatch: message contains BOTH SHAs"
@@ -79,7 +82,7 @@ if run 2 "mismatch: head moved -> exit 2" 2421 "$CERTIFIED"; then
 fi
 
 # --- Case 3: merged/closed PR -> exit 2 ---------------------------------------
-export MOCK_GH_JSON="{\"headRefOid\":\"$CERTIFIED\",\"state\":\"MERGED\"}"
+export MOCK_GH_OUT="$CERTIFIED MERGED"
 if run 2 "merged PR -> exit 2" 2421 "$CERTIFIED"; then
   case "$OUT" in
     *"NOT-OPEN"*|*"closed or merged"*) ok "merged: distinct not-open refusal message" ;;
@@ -89,7 +92,7 @@ fi
 
 # --- Case 4: gh/network failure -> exit 3 (fail closed) -----------------------
 export MOCK_GH_FAIL=1
-export MOCK_GH_JSON=""
+export MOCK_GH_OUT=""
 if run 3 "gh failure -> exit 3 (fail closed)" 2421 "$CERTIFIED"; then
   case "$OUT" in
     *"GH-FAILURE"*) ok "gh-failure: distinct fail-closed message" ;;
@@ -103,10 +106,23 @@ if run 3 "missing args -> exit 3" 2421; then
   ok "usage: too few args fails closed (exit 3)"
 fi
 
-# --- Case 6: unparseable JSON -> exit 3 (fail closed) -------------------------
-export MOCK_GH_JSON="not json at all"
-if run 3 "unparseable JSON -> exit 3" 2421 "$CERTIFIED"; then
-  ok "unparseable: fails closed (exit 3)"
+# --- Case 6: malformed --jq output (missing state token) -> exit 3 ------------
+export MOCK_GH_OUT="$CERTIFIED"   # only one token, no state
+if run 3 "malformed --jq output -> exit 3" 2421 "$CERTIFIED"; then
+  ok "malformed: fails closed (exit 3)"
+fi
+
+# --- Case 7: certified SHA passed UPPERCASE -> still matches (normalization) --
+export MOCK_GH_OUT="$CERTIFIED OPEN"   # mock head is lowercase
+CERT_UPPER=$(printf '%s' "$CERTIFIED" | tr '[:lower:]' '[:upper:]')
+if run 0 "uppercase certified SHA -> normalized match -> exit 0" 2421 "$CERT_UPPER"; then
+  ok "normalization: uppercase certified SHA still matches lowercase head"
+fi
+
+# --- Case 8: certified SHA wrong length -> exit 3 -----------------------------
+export MOCK_GH_OUT="$CERTIFIED OPEN"
+if run 3 "short certified SHA -> exit 3" 2421 "da9a7cb2"; then
+  ok "validation: abbreviated (non-40-char) SHA fails closed (exit 3)"
 fi
 
 # --- summary -----------------------------------------------------------------

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -86,9 +86,13 @@ ever regress (contexts emptied, `enforce_admins` disabled), this doctrine govern
 The `flow-closer` certifies a **specific SHA** — the tree the full gate of record and the final
 roborev pass actually ran on. Three mechanical rules keep the merge honest:
 
-- **Pre-merge SHA assertion (#2456, hard precondition).** Immediately before `gh pr merge`, the closer
-  does `git push`, then asserts `gh pr view <N> --json headRefOid` **equals the locally-certified
-  tip** — and **refuses to merge on mismatch**. Motivated by the 2026-07-14 stale-merge escape on
+- **Pre-merge SHA assertion (#2456/#2668, scripted hard precondition).** Immediately before
+  `gh pr merge`, the closer does `git push`, then runs
+  `scripts/flow/premerge-assert.sh <pr> <certified-sha>` — which asserts the PR is OPEN and its
+  `headRefOid` **equals the locally-certified tip**, exiting non-zero (and printing a loud refusal)
+  on a moved head, a closed/merged PR, or a gh failure. The closer **refuses to merge on any
+  non-zero exit** (fail closed). It also re-reads issue/PR comments for a fresh `HOLD:` order in the
+  same pre-merge pass. Motivated by the 2026-07-14 stale-merge escape on
   #2299/PR #2421: the closer certified a rebased-and-fixed tip locally but never pushed it, so
   `gh pr merge` squashed the PR's *stale* pre-fix head and transiently landed a known data-loss
   blocker on `main` (remediated by PR #2455). The GitHub required check re-runs on push but cannot
@@ -243,11 +247,14 @@ implement (TDD) → lite (each fix round) → rust-reviewer + roborev on the lit
   criterion) are fixed pre-merge; **nits** (style, naming, comment/doc polish, no-repro test suggestions)
   are batched into ONE linked follow-up issue at merge time and never trigger a re-verify round. When in
   doubt, blocker.
-- **The disposable `flow-closer` owns the endgame (issue #2084).** `flow-implement` opens the PR, then
+- **The disposable `flow-closer` owns the endgame (issue #2084/#2668).** `flow-implement` opens the PR, then
   spawns a per-issue `flow-closer` that runs the ONE full `scripts/agent-gate.sh` of record (via
   `run_in_background` + the summary-file pattern — it **never idle-waits**, which would trip the #1855 stall
-  watchdog and orphan the gate), the **C** intent audit, the final roborev pass, then merges on green and
-  `flow-finalize`s. It returns only a terminal packet (verdict, PR URL, summary-file path, ≤10 lines
+  watchdog and orphan the gate; polling the summary file is mandatory on a hard 45-min deadline), the **C**
+  intent audit, the final roborev pass, then merges on green and `flow-finalize`s. The closer has **no
+  `Agent` tool**, so it never spawns directly: for **C** (and any src-design fix) it emits a structured
+  `NEEDS-SPAWN` packet and ends its turn — the lead spawns `spec-auditor`/`sstable-developer` and re-invokes
+  the closer with the result. It returns only a terminal packet (verdict, PR URL, summary-file path, ≤10 lines
   residual), so gate stdout and review churn die with its context instead of accreting in the lead session.
   Any src change after the full gate INVALIDATES it — the gate of record must postdate the final src change
   and rebase.


### PR DESCRIPTION
Closes #2668, closes #2456. Epic #2664 Phase-1 hardening.

## What
- **NEW `scripts/flow/premerge-assert.sh <pr> <certified-sha>`** — the #2456 rule as a fail-closed script: exit 0 only when the PR is OPEN and `headRefOid` equals the certified 40-char SHA (jq-based parse — gh serialization not load-bearing; SHA normalization + length validation); exit 2 stale/closed, exit 3 fail-closed on gh failure. Hermetic PATH-shim test suite (9/9).
- **`.claude/agents/flow-closer.md` executable as written**: NEEDS-SPAWN packet handshake replaces the impossible "spawn spec-auditor" instruction (closer has no Agent tool — lead spawns at its request, codifying field practice); gate-wait polling now MANDATORY (5-min summary-file polls, 45-min hard deadline → `verdict: gate-timeout`, never park); merge step runs `premerge-assert.sh` + a HOLD-order re-read immediately pre-merge.
- Doctrine aligned in the same change: CLAUDE.md closer bullets + website delivery-pipeline page.

## Review
- roborev job 1759: 1 High + 1 Medium + 1 Low → fix round `5c3b0c392` (jq parse hardening; the High's premise — gh pretty-prints — was empirically refuted, hardened anyway; SHA normalization). Re-review job 1761: **No issues found.**
- shellcheck clean; hermetic tests 9/9.
- Lite summaries at `003…`/`5c3b0c392` PASS; **full gate of record: run by flow-closer pre-merge, summary posted before merge.**
