### PR TITLE
ci(#2637): exhaustive-regeneration weekly cron cadence

### DIFF
--- a/.github/workflows/exhaustive-regeneration.yml
+++ b/.github/workflows/exhaustive-regeneration.yml
@@ -9,7 +9,7 @@ name: Exhaustive Regeneration (parity corpus)
 # and deliberately does NOT commit regenerated binaries or publish a dataset asset
 # (design D6).
 #
-# Cadence: nightly cron + manual dispatch only. It NEVER runs on pull_request and
+# Cadence: weekly cron + manual dispatch only. It NEVER runs on pull_request and
 # never gates the fast/required PR path. See the tier contract:
 # docs/development/parity-ci-tiers.md (`exhaustive_regeneration`) and the release
 # checklist (`parity-release-checklist.md`). This workflow packages regenerated
@@ -18,8 +18,8 @@ name: Exhaustive Regeneration (parity corpus)
 on:
   workflow_dispatch: {}
   schedule:
-    # Nightly at 08:10 UTC, after coverage and Docker parity lanes have started.
-    - cron: '10 8 * * *'
+    # Weekly on Sunday at 08:10 UTC, after coverage and Docker parity lanes have started.
+    - cron: '10 8 * * 0'
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #2637 (Epic #2636)

## Problem
`exhaustive-regeneration.yml` ran on cron `10 8 * * *` (daily), while `docs/development/parity-ci-tiers.md` (L246) and `CLAUDE.md` (L42) describe the `exhaustive_regeneration` tier as **weekly** (#1026). Cadence and docs disagreed.

## Change (owner decision: weekly)
- Cron `10 8 * * *` → `10 8 * * 0` (Sunday 08:10 UTC).
- Updated the workflow's cadence comments ("nightly cron" → "weekly cron"; schedule comment now "Weekly on Sunday").
- Docs already stated weekly — no doc edits needed; cron now matches them.

## Verification
- YAML parses (`yaml.safe_load`).
- `cargo run -p cassandra-parity -- tier-contract-check` → OK (documented enum == code enum == schema enum). The tier-contract check validates the tier enum block, not cron cadence, so it is unaffected and stays green.

## LITE gate
```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record)
commit: 3d1a90be5 branch: issue-2637-regen-cadence-weekly dirty: no
file-size:         PASS
fmt:               PASS
clippy:            PASS
scoped-tests:      PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```