### PR TITLE
ci(#2638): flight-ci image job no longer pushes on v* tag refs

### DIFF
--- a/.github/workflows/flight-ci.yml
+++ b/.github/workflows/flight-ci.yml
@@ -77,7 +77,7 @@ jobs:
             echo ""
             echo "- Ordinary PRs run fmt, clippy, and cqlite-flight library tests."
             echo "- Full package tests and release binary artifacts run on push to main/tags, nightly schedule, workflow_dispatch, or PRs labeled \`ci:flight-full\`."
-            echo "- Container publishing remains limited to push and workflow_dispatch runs."
+            echo "- Container publishing here is limited to main-branch pushes and workflow_dispatch runs (\`latest\` + sha tags); v* tag release images are built multi-arch solely by flight-image.yml (issue #2638)."
           } >> "$GITHUB_STEP_SUMMARY"
 
   full:
@@ -120,8 +120,18 @@ jobs:
   image:
     name: build & push container image
     needs: full
-    # Don't publish images from PRs or nightly validation runs.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # Publish only main-branch and workflow_dispatch images (main/sha tags).
+    # NOT on v* tag pushes: on a release tag, flight-image.yml is the SOLE
+    # writer of the canonical vX.Y.Z / vX.Y / latest tags as a MULTI-ARCH
+    # manifest. If this single-arch (amd64) job also pushed vX.Y.Z on the same
+    # tag ref, the two runs would race the same GHCR tag and last-writer-wins
+    # could silently leave the release image amd64-only (issue #2638). Gating on
+    # `github.ref_type != 'tag'` keeps this job to branch pushes only.
+    if: >-
+      ${{
+        (github.event_name == 'push' && github.ref_type != 'tag') ||
+        github.event_name == 'workflow_dispatch'
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -138,9 +148,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/cqlite-flight
+          # No `type=ref,event=tag` here: v* tag pushes are handled solely by
+          # flight-image.yml (multi-arch). This job never runs on tag refs (see
+          # the job `if:` above), so it publishes only `latest` (main) + sha
+          # tags and can never clobber the release manifest (issue #2638).
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=tag
             type=sha
 
       - name: Build & push

--- a/scripts/ci/validate-workflows.rb
+++ b/scripts/ci/validate-workflows.rb
@@ -266,6 +266,38 @@ end
 workflow_files = Dir[File.join(options[:workflows_dir], "*.{yml,yaml}")].sort
 abort "No workflow files found under #{options[:workflows_dir]}" if workflow_files.empty?
 
+# Single-writer guard for the canonical release image tag (issue #2638).
+#
+# On a v* tag push, flight-image.yml builds and publishes the canonical
+# vX.Y.Z / vX.Y / latest tags as a MULTI-ARCH manifest and must be the SOLE
+# writer of those tags. flight-ci.yml's `image` job builds a single-arch
+# (amd64) image; if it also ran on tag refs it would race the same GHCR tags
+# and last-writer-wins could silently leave the release image amd64-only.
+# Assert flight-ci's image job is fenced off tag refs on BOTH fronts:
+#   1. its `if:` excludes tag pushes (`github.ref_type != 'tag'`), and
+#   2. its metadata emits no `type=ref,event=tag` tag.
+def flight_ci_image_job_off_tag_refs?(jobs)
+  image = jobs["image"]
+  return [false, "image job missing"] unless image.is_a?(Hash)
+
+  condition = image["if"].to_s.gsub(/\s+/, " ").strip
+  unless condition.include?("github.ref_type != 'tag'")
+    return [false, "image job `if:` must exclude tag refs via github.ref_type != 'tag'"]
+  end
+
+  meta_step = Array(image["steps"]).find do |step|
+    step.is_a?(Hash) && step["uses"].to_s.start_with?("docker/metadata-action")
+  end
+  return [false, "image job missing docker/metadata-action step"] unless meta_step
+
+  tags = meta_step.dig("with", "tags").to_s
+  if tags.match?(/type=ref\s*,\s*event=tag/)
+    return [false, "image job must not emit `type=ref,event=tag` (clobbers flight-image.yml on v* tags)"]
+  end
+
+  [true, nil]
+end
+
 errors = []
 warnings = []
 
@@ -399,6 +431,14 @@ workflow_files.each do |file|
 
   if LABEL_GATED_PATH_EXEMPTIONS.key?(workflow_name) && triggers.key?("pull_request_target")
     errors << "#{file}: label-gated path-filter exemption must not use pull_request_target"
+  end
+
+  if workflow_name == "flight-ci.yml"
+    ok, reason = flight_ci_image_job_off_tag_refs?(jobs)
+    unless ok
+      errors << "#{file}: flight-ci image job must not push on v* tag refs " \
+                "(single-writer with flight-image.yml, issue #2638): #{reason}"
+    end
   end
 
   label = BINDING_PR_MATRIX_LABELS[workflow_name]


### PR DESCRIPTION
Closes #2638 (Epic #2636)

## Problem
On a `v*` tag push, BOTH `flight-image.yml` (multi-arch manifest) and the `flight-ci.yml` `image` job (single-arch amd64, via `type=ref,event=tag`) pushed the SAME GHCR `vX.Y.Z` tag concurrently. Last-writer-wins meant the canonical release image could silently end up amd64-only.

## Change
Make `flight-image.yml` the sole writer of the release tags:
- Gate the `flight-ci` `image` job off tag pushes: `if: (github.event_name == 'push' && github.ref_type != 'tag') || github.event_name == 'workflow_dispatch'`. It now publishes only main-branch `latest` + `sha` tags.
- Drop the now-dead `type=ref,event=tag` from its `docker/metadata-action` tag list (belt-and-suspenders; it can never fire on a tag ref anymore).
- Update the CI tier summary text.
- Add a workflow-lint assertion in `scripts/ci/validate-workflows.rb` proving the single-writer invariant: flight-ci's image job must exclude tag refs (`github.ref_type != 'tag'`) AND must not emit `type=ref,event=tag`. Verified it fires on both regressions.

Main/sha image behavior is preserved. Only trusted `github.*` context is used in the `if:` (no untrusted input into `run:`), YAML validates, and the linter passes.

## Acceptance
- flight-ci image job no longer pushes on tag refs (main/sha only) ✅
- tag-push produces exactly one writer for vX.Y.Z tags (flight-image.yml, multi-arch) ✅
- workflow-lint assertion added and proven to catch both regression forms ✅

## LITE SUMMARY
```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 0d5d8a40e branch: issue-2638-flight-ci-tag-clobber dirty: no
lite-scope: file-size fmt clippy scoped-tests
accelerators: sccache=on nextest=on lanes=on
file-size:         PASS
fmt:               PASS
clippy:            PASS
scoped-tests:      PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Note: YAML/Ruby-only change (no Rust source touched). The full agent-gate is meaningful mainly as a formality here; the load-bearing verification is the `validate-workflows.rb` lint assertion (run in `pr-gate.yml` / `workflow-config.yml`) plus the negative tests above.