### PR TITLE
ci(#2646): tracked dataset pin + drift check across all workflows

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -26,6 +26,12 @@ jobs:
           "workflow policy"
           -- ruby scripts/ci/validate-workflows.rb
 
+      - name: Dataset pin agreement (#2646)
+        run: >-
+          bash scripts/ci/ci-timing-summary.sh measure
+          "dataset pin agreement"
+          -- bash scripts/ci/check-dataset-pin.sh
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust-ci
         with:

--- a/.github/workflows/workflow-config.yml
+++ b/.github/workflows/workflow-config.yml
@@ -5,12 +5,26 @@ on:
     branches: [main, develop]
     paths:
       - '.github/workflows/**'
+      - '.github/actions/restore-canonical-datasets/action.yml'
       - 'scripts/ci/validate-workflows.rb'
+      - 'scripts/ci/check-dataset-pin.sh'
+      - 'test-data/dataset-pin.env'
+      - 'test-data/scripts/fetch-datasets.sh'
+      - 'test-data/scripts/bump-dataset-pin.sh'
+      - 'scripts/local/pre-merge.sh'
+      - 'scripts/ci/ensure_real_dataset.sh'
   push:
     branches: [main, develop]
     paths:
       - '.github/workflows/**'
+      - '.github/actions/restore-canonical-datasets/action.yml'
       - 'scripts/ci/validate-workflows.rb'
+      - 'scripts/ci/check-dataset-pin.sh'
+      - 'test-data/dataset-pin.env'
+      - 'test-data/scripts/fetch-datasets.sh'
+      - 'test-data/scripts/bump-dataset-pin.sh'
+      - 'scripts/local/pre-merge.sh'
+      - 'scripts/ci/ensure_real_dataset.sh'
   workflow_dispatch:
 
 permissions:
@@ -32,3 +46,6 @@ jobs:
 
       - name: Validate workflow policy
         run: ruby scripts/ci/validate-workflows.rb
+
+      - name: Dataset pin agreement (#2646)
+        run: bash scripts/ci/check-dataset-pin.sh

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ logs/
 test-data/sstables/
 test-data/output/
 test-data/scripts/smoke-test-all-tables-results/
+# GENERATED per-fetch dataset pin (issue #2646): written by fetch-datasets.sh
+# into the fetched dataset dir. The tracked source of truth is
+# test-data/dataset-pin.env — this generated file must stay untracked.
+test-data/datasets/.dataset-pin
 *.sstable
 *.db
 

--- a/docs/runbooks/1099-dataset-republish.md
+++ b/docs/runbooks/1099-dataset-republish.md
@@ -81,23 +81,34 @@ gh release upload datasets-v3 "../$ASSET" "../$ASSET.sha256" --clobber
 > If you prefer a brand-new release tag instead, create it and pass `--new-tag`
 > in step 4.
 
-## 4. Repoint CI at the new asset (10 workflows)
+## 4. Repoint CI at the new asset (single tracked pin + finalizer)
 
-Use the finalizer — it replaces the asset filename + SHA256 across every
-pinned workflow **and** `test-data/scripts/fetch-datasets.sh` (which carries its
-own `DATASET_ASSET`/`DATASET_SHA256`/`DATASET_TAG` defaults), then verifies no
-stale reference remains. With `--new-tag` it also rewrites the inline
-`gh release download <tag>` / `releases/download/<tag>/` literals (coverage.yml,
-m1-ci.yml). It never edits its own `OLD_*` defaults or this runbook, and prints
-any doc-only references (website docs) for you to update by hand:
+**Single source of truth (issue #2646):** the canonical asset/tag/sha live in
+the tracked file **`test-data/dataset-pin.env`**. Every workflow's
+`DATASET_SHA256` env, the fetch helper, the restore action, `pre-merge.sh`, and
+this bump script all derive from (or are asserted against) it. The distinct
+GENERATED `test-data/datasets/.dataset-pin` (written per-fetch into the fetched
+dataset dir) is `.gitignore`d and must NEVER be tracked.
+
+Use the finalizer — it rewrites the asset filename + SHA256 across every pinned
+workflow, `test-data/scripts/fetch-datasets.sh`, AND `test-data/dataset-pin.env`
+in one pass (its own `OLD_*` defaults are loaded from `dataset-pin.env`, so they
+can't drift), then verifies no stale reference remains. With `--new-tag` it also
+rewrites the inline `gh release download <tag>` / `releases/download/<tag>/`
+literals (coverage.yml, m1-ci.yml) and the `DATASET_TAG=` line in the pin file.
+It never edits its own script body or this runbook, and prints any doc-only
+references (website docs) for you to update by hand:
 
 ```bash
 git switch -c chore/1099-bump-dataset-pin-v3.2
 test-data/scripts/bump-dataset-pin.sh --new-sha <sha256-from-step-2>
 # (add --new-tag <tag> if you cut a new release tag)
 
-# Stage everything the finalizer touched (workflows AND the fetch helper):
-git add .github/workflows test-data/scripts/fetch-datasets.sh
+# Assert every workflow + pin-consuming file agrees with the tracked pin:
+bash scripts/ci/check-dataset-pin.sh   # must print ✅ (the CI gate runs this too)
+
+# Stage everything the finalizer touched (workflows, fetch helper, tracked pin):
+git add .github/workflows test-data/scripts/fetch-datasets.sh test-data/dataset-pin.env
 git commit -m "ci: pin dataset asset to cassandra5-small-full-v3.4 (#1099)"
 git push -u origin chore/1099-bump-dataset-pin-v3.2
 gh pr create --base main --fill
@@ -106,6 +117,14 @@ gh pr create --base main --fill
 The 10 pinned workflows: `ci.yml`, `coverage.yml`, `docs-site.yml`,
 `m1-ci.yml`, `node-ci.yml`, `observability-gate.yml`, `perf-regression.yml`,
 `python-ci.yml`, `smoke-tests.yml`, `sstabledump-parity-gate.yml`.
+
+> **Drift guard (issue #2646):** `scripts/ci/check-dataset-pin.sh` (run by the
+> `Required PR Gate` and `Workflow Config Validation` workflows) REDS if any
+> workflow's `DATASET_SHA256`, any inline 64-hex literal in a pin-consuming
+> file, the helper/restore/pre-merge defaults, or the bump script's `OLD_*`
+> constants disagree with `test-data/dataset-pin.env` — or if the generated
+> `.dataset-pin` ever becomes git-tracked. A partial hand-edit can no longer
+> silently drift one workflow out of sync.
 
 > **Cache note:** `coverage.yml`/`m1-ci.yml` restore the dataset cache and skip
 > the download when `test_basic/simple_table-*-Data.db` is already present.

--- a/scripts/ci/check-dataset-pin.sh
+++ b/scripts/ci/check-dataset-pin.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# check-dataset-pin.sh — assert every workflow (and pin-consuming helper) agrees
+# with the tracked dataset pin (issue #2646, epic #2636).
+#
+# The canonical dataset SHA256/asset/tag lives in ONE tracked file,
+# test-data/dataset-pin.env. It is embedded across ~11 workflows plus several
+# helper scripts, a silent-drift surface. This check REDS if:
+#   - the tracked pin file is missing or malformed;
+#   - any `.github/workflows/*.yml` declares a `DATASET_SHA256:` env that does
+#     not equal the tracked sha;
+#   - the fetch helper / bump script / restore action / pre-merge / provenance
+#     guard defaults disagree with the tracked sha, asset, or tag;
+#   - ANY 64-char hex token in a pin-consuming file differs from the tracked
+#     sha (catches a stray literal that skipped the env decl);
+#   - the GENERATED test-data/datasets/.dataset-pin has become git-tracked.
+#
+# Exit 0 = all agree; non-zero = drift (prints every disagreement).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PIN_FILE="$REPO_ROOT/test-data/dataset-pin.env"
+WF_DIR="$REPO_ROOT/.github/workflows"
+
+errors=0
+err() { echo "❌ $*" >&2; errors=$((errors + 1)); }
+
+if [[ ! -f "$PIN_FILE" ]]; then
+  echo "❌ tracked pin file not found: $PIN_FILE" >&2
+  exit 1
+fi
+
+# Parse the tracked pin (KEY=value, no expansion beyond the file itself).
+DATASET_TAG=""; DATASET_ASSET=""; DATASET_SHA256=""
+# shellcheck disable=SC1090
+source "$PIN_FILE"
+
+[[ -n "$DATASET_TAG" ]]    || err "test-data/dataset-pin.env: DATASET_TAG is empty/unset"
+[[ -n "$DATASET_ASSET" ]]  || err "test-data/dataset-pin.env: DATASET_ASSET is empty/unset"
+if [[ ! "$DATASET_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  err "test-data/dataset-pin.env: DATASET_SHA256 must be 64-char lowercase hex, got '${DATASET_SHA256}'"
+fi
+if [[ "$errors" -ne 0 ]]; then
+  echo "" >&2
+  echo "Tracked pin file is malformed; cannot validate. Fix test-data/dataset-pin.env." >&2
+  exit 1
+fi
+
+echo "Tracked dataset pin (test-data/dataset-pin.env):"
+echo "  tag=${DATASET_TAG}  asset=${DATASET_ASSET}  sha256=${DATASET_SHA256}"
+
+# 1) Every workflow that declares a `DATASET_SHA256:` env must match the pin.
+shopt -s nullglob
+wf_checked=0
+for f in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
+  # Only the literal env declaration (`  DATASET_SHA256: <hex>`), not the many
+  # `${{ env.DATASET_SHA256 }}` references that derive from it.
+  while IFS= read -r decl; do
+    wf_checked=$((wf_checked + 1))
+    val="$(printf '%s' "$decl" | sed -E 's/.*DATASET_SHA256:[[:space:]]*//; s/[[:space:]].*$//')"
+    if [[ "$val" != "$DATASET_SHA256" ]]; then
+      err "${f#"$REPO_ROOT"/}: DATASET_SHA256 env '${val}' != tracked pin '${DATASET_SHA256}'"
+    fi
+  done < <(grep -E '^[[:space:]]*DATASET_SHA256:[[:space:]]*[0-9a-f]{64}' "$f" || true)
+done
+
+# 2) Every 64-hex token in a pin-consuming file must equal the tracked sha.
+#    Catches inline literals (e.g. coverage.yml, m1-ci.yml) and helper-script
+#    defaults that skipped the env-decl form. The tracked pin file and THIS
+#    script legitimately contain the sha; the bump script carries an OLD_SHA
+#    constant by design, so it is validated separately below.
+PIN_CONSUMERS=(
+  "$WF_DIR"/*.yml
+  "$WF_DIR"/*.yaml
+  "$REPO_ROOT/.github/actions/restore-canonical-datasets/action.yml"
+  "$REPO_ROOT/scripts/local/pre-merge.sh"
+  "$REPO_ROOT/scripts/ci/ensure_real_dataset.sh"
+  "$REPO_ROOT/test-data/scripts/fetch-datasets.sh"
+)
+for f in "${PIN_CONSUMERS[@]}"; do
+  [[ -e "$f" ]] || continue
+  while IFS= read -r tok; do
+    if [[ "$tok" != "$DATASET_SHA256" ]]; then
+      err "${f#"$REPO_ROOT"/}: stray dataset-like sha '${tok}' != tracked pin '${DATASET_SHA256}'"
+    fi
+  done < <(grep -hoE '[0-9a-f]{64}' "$f" || true)
+done
+
+# 3) The fetch helper + restore action + pre-merge defaults must name the pin's
+#    asset and tag (the sha is covered by check 2).
+declare -A NAMED_DEFAULTS=(
+  ["$REPO_ROOT/test-data/scripts/fetch-datasets.sh"]="fetch-datasets.sh"
+  ["$REPO_ROOT/.github/actions/restore-canonical-datasets/action.yml"]="restore-canonical-datasets/action.yml"
+  ["$REPO_ROOT/scripts/local/pre-merge.sh"]="pre-merge.sh"
+)
+for f in "${!NAMED_DEFAULTS[@]}"; do
+  [[ -e "$f" ]] || continue
+  label="${NAMED_DEFAULTS[$f]}"
+  grep -qF "$DATASET_ASSET" "$f" || err "${label}: does not reference tracked asset '${DATASET_ASSET}'"
+  grep -qF "$DATASET_TAG"   "$f" || err "${label}: does not reference tracked tag '${DATASET_TAG}'"
+done
+
+# NOTE: bump-dataset-pin.sh is intentionally NOT sha-checked here. Its `OLD_*`
+# are loaded from this tracked pin at runtime; the hardcoded literals in its
+# body are only a fallback for a missing pin file and legitimately go stale
+# after a bump (the bump skips its own body), so asserting them would false-red.
+# It is excluded from the PIN_CONSUMERS 64-hex sweep above for the same reason.
+
+# 4) The GENERATED dataset pin must NOT be tracked (it is produced per-fetch).
+if git -C "$REPO_ROOT" ls-files --error-unmatch test-data/datasets/.dataset-pin >/dev/null 2>&1; then
+  err "test-data/datasets/.dataset-pin is git-tracked; it is GENERATED by fetch-datasets.sh and must stay untracked (use test-data/dataset-pin.env)"
+fi
+
+echo "Checked ${wf_checked} workflow DATASET_SHA256 env declaration(s) and all pin-consuming files."
+if [[ "$errors" -ne 0 ]]; then
+  echo "" >&2
+  echo "❌ dataset pin drift: ${errors} disagreement(s) with test-data/dataset-pin.env." >&2
+  echo "   Fix via: test-data/scripts/bump-dataset-pin.sh --new-sha <sha> (see dev-cookbook)." >&2
+  exit 1
+fi
+echo "✅ all workflows and pin-consuming files agree with the tracked dataset pin."

--- a/test-data/dataset-pin.env
+++ b/test-data/dataset-pin.env
@@ -1,0 +1,23 @@
+# dataset-pin.env — the SINGLE tracked source of truth for the canonical
+# Cassandra 5 test-dataset asset (issue #2646, epic #2636).
+#
+# The dataset SHA256 is embedded in ~11 workflows plus several helper scripts.
+# Keeping it in one tracked file removes the silent-drift surface: fetch +
+# bump consume THIS file, and scripts/ci/check-dataset-pin.sh REDS if any
+# workflow's DATASET_SHA256 (or the asset/tag) disagrees with it.
+#
+# NOTE: this is DISTINCT from the GENERATED test-data/datasets/.dataset-pin
+# (written by fetch-datasets.sh into the fetched dataset dir, never tracked).
+# Do NOT track that generated file; edit THIS one to repoint the dataset.
+#
+# To repoint at a newly-published asset, run:
+#   test-data/scripts/bump-dataset-pin.sh --new-sha <sha256> \
+#     [--new-asset cassandra5-small-full-vX.Y.tar.gz] [--new-tag datasets-vN]
+# which rewrites every workflow AND this file in one shot. See
+# docs/development/dev-cookbook.md "Bumping the dataset pin".
+#
+# Sourced as shell (KEY=value, no spaces). Keep in sync via bump; the CI
+# check fails closed on any drift.
+DATASET_TAG=datasets-v3
+DATASET_ASSET=cassandra5-small-full-v3.5.tar.gz
+DATASET_SHA256=414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16

--- a/test-data/scripts/bump-dataset-pin.sh
+++ b/test-data/scripts/bump-dataset-pin.sh
@@ -31,12 +31,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WF_DIR="$REPO_ROOT/.github/workflows"
 
-# Current (to-be-replaced) pin — keep in sync with the committed workflows.
-# This MUST match the asset/SHA actually committed across the workflows, or the
-# default next bump is a no-op/false-success. Currently v3.5 (issue #1935).
+# Current (to-be-replaced) pin. The single source of truth is the tracked
+# test-data/dataset-pin.env (issue #2646); load OLD_* from it so this bump can
+# never drift from the committed pin. Hardcoded fallbacks below cover an older
+# checkout without the pin file. The CI check (scripts/ci/check-dataset-pin.sh)
+# additionally asserts these OLD_* equal the tracked pin.
+PIN_ENV="$REPO_ROOT/test-data/dataset-pin.env"
 OLD_ASSET="cassandra5-small-full-v3.5.tar.gz"
 OLD_SHA="414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16"
 OLD_TAG="datasets-v3"
+if [[ -f "$PIN_ENV" ]]; then
+  # shellcheck disable=SC1090
+  source "$PIN_ENV"
+  OLD_ASSET="${DATASET_ASSET:-$OLD_ASSET}"
+  OLD_SHA="${DATASET_SHA256:-$OLD_SHA}"
+  OLD_TAG="${DATASET_TAG:-$OLD_TAG}"
+fi
 
 # Next (to-be-written) pin — bump the asset version and pass the new --new-sha.
 NEW_ASSET="cassandra5-small-full-v3.6.tar.gz"
@@ -85,6 +95,9 @@ fi
 # script or the example pin in the #1099 runbook.
 FETCH_HELPER="$REPO_ROOT/test-data/scripts/fetch-datasets.sh"
 SELF_PATH="$REPO_ROOT/test-data/scripts/bump-dataset-pin.sh"
+# The tracked single-source-of-truth pin (issue #2646) — rewritten in the same
+# pass so it stays authoritative (asset/sha via the generic sed; tag below).
+TRACKED_PIN="$REPO_ROOT/test-data/dataset-pin.env"
 
 # Other pin-consuming files outside the workflows dir (issue #1935): local
 # pre-merge harness, the composite restore action, and the CI provenance guard.
@@ -99,6 +112,7 @@ for f in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
   [[ -e "$f" ]] && FILES+=("$f")
 done
 [[ -e "$FETCH_HELPER" ]] && FILES+=("$FETCH_HELPER")
+[[ -e "$TRACKED_PIN" ]] && FILES+=("$TRACKED_PIN")
 for f in "${EXTRA_PIN_FILES[@]}"; do
   [[ -e "$f" ]] && FILES+=("$f")
 done
@@ -120,11 +134,13 @@ for f in "${FILES[@]}"; do
     #   - gh release download:     gh release download <tag>
     #   - release URL path:        releases/download/<tag>/
     #   - fetch-datasets default:  DATASET_TAG:-<tag>
+    #   - tracked pin (dataset-pin.env): DATASET_TAG=<tag>
     sed_inplace \
       "s|DATASET_TAG: $OLD_TAG|DATASET_TAG: $NEW_TAG|g; \
        s|release download $OLD_TAG|release download $NEW_TAG|g; \
        s|releases/download/$OLD_TAG/|releases/download/$NEW_TAG/|g; \
-       s|DATASET_TAG:-$OLD_TAG|DATASET_TAG:-$NEW_TAG|g" "$f"
+       s|DATASET_TAG:-$OLD_TAG|DATASET_TAG:-$NEW_TAG|g; \
+       s|DATASET_TAG=$OLD_TAG|DATASET_TAG=$NEW_TAG|g" "$f"
   fi
   if [[ "$(cat "$f")" != "$before" ]]; then
     echo "  ✓ updated ${f#"$REPO_ROOT"/}"

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -4,9 +4,29 @@ set -euo pipefail
 # Fetch canonical Cassandra 5 datasets into test-data/datasets
 # Usage: DATASET_TAG=datasets-v3 DATASET_ASSET=cassandra5-small-full-v3.5.tar.gz DATASET_SHA256=414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 ./test-data/scripts/fetch-datasets.sh
 
-TAG="${DATASET_TAG:-datasets-v3}"
-ASSET="${DATASET_ASSET:-cassandra5-small-full-v3.5.tar.gz}"
-SHA256_EXPECTED="${DATASET_SHA256:-414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16}"
+# The canonical asset/tag/sha live in ONE tracked file (issue #2646):
+# test-data/dataset-pin.env. Load it for the defaults so this helper never
+# drifts from the workflows. Precedence: explicit DATASET_* env (CI passes the
+# workflow-declared pin) > tracked pin file > historical hardcoded fallback
+# (older checkouts without the pin file). We capture the incoming env FIRST so
+# sourcing the pin file cannot clobber a real override.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PIN_ENV="${SCRIPT_DIR}/../dataset-pin.env"
+_ENV_TAG="${DATASET_TAG:-}"
+_ENV_ASSET="${DATASET_ASSET:-}"
+_ENV_SHA="${DATASET_SHA256:-}"
+_PIN_TAG=""; _PIN_ASSET=""; _PIN_SHA=""
+if [ -f "${PIN_ENV}" ]; then
+  # shellcheck disable=SC1090
+  . "${PIN_ENV}"
+  _PIN_TAG="${DATASET_TAG:-}"
+  _PIN_ASSET="${DATASET_ASSET:-}"
+  _PIN_SHA="${DATASET_SHA256:-}"
+fi
+
+TAG="${_ENV_TAG:-${_PIN_TAG:-datasets-v3}}"
+ASSET="${_ENV_ASSET:-${_PIN_ASSET:-cassandra5-small-full-v3.5.tar.gz}}"
+SHA256_EXPECTED="${_ENV_SHA:-${_PIN_SHA:-414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16}}"
 DATASET_ROOT="${CQLITE_DATASETS_ROOT:-test-data/datasets}"
 ARCHIVE_DATASET_ROOT="test-data/datasets"
 PIN_FILE="${DATASET_ROOT}/.dataset-pin"


### PR DESCRIPTION
Closes #2646 (Epic #2636)

## Summary
Introduces a **single tracked source of truth** for the canonical Cassandra 5 test-dataset pin and a fast PR check that reds on any drift.

- **`test-data/dataset-pin.env`** (NEW, tracked) — holds authoritative `DATASET_TAG` / `DATASET_ASSET` / `DATASET_SHA256`.
- **`test-data/scripts/fetch-datasets.sh`** — consumes the tracked pin for its defaults (precedence: explicit `DATASET_*` env > tracked pin > historical fallback).
- **`test-data/scripts/bump-dataset-pin.sh`** — loads `OLD_*` from the tracked pin (can't drift) and rewrites the pin file in the same pass as the workflows.
- **`scripts/ci/check-dataset-pin.sh`** (NEW, +x) — REDS if any workflow's `DATASET_SHA256` env, any stray 64-hex literal in a pin-consuming file, the fetch/restore/pre-merge asset+tag defaults disagree with the tracked pin, or if the generated `.dataset-pin` becomes tracked. Wired into `pr-gate.yml` (Required PR Gate) and `workflow-config.yml` (Workflow Config Validation).
- **`.gitignore`** — keeps the GENERATED `test-data/datasets/.dataset-pin` untracked; does NOT ignore the new tracked `dataset-pin.env`.
- **`docs/runbooks/1099-dataset-republish.md`** — documents the single-pin bump flow + drift guard.

## Verification
- Clean tree: check PASSES (10 workflow `DATASET_SHA256` decls + all pin-consuming files agree).
- Mutating one workflow's `DATASET_SHA256` → check REDS (2 disagreements: env-decl + stray-hex sweep), reverts clean.
- `dataset-pin.env` confirmed tracked; `test-data/datasets/.dataset-pin` confirmed gitignored.

## Lite gate
```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite
commit: 01611c169 branch: issue-2646-tracked-dataset-pin dirty: no
file-size: PASS  fmt: PASS  clippy: PASS  scoped-tests: PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
(Full gate of record still required once before merge.)