### PR TITLE
ci(#2639): guard armed publish dispatches — trino dry_run default + flight-image tag→SHA provenance

### DIFF
--- a/.github/workflows/flight-image.yml
+++ b/.github/workflows/flight-image.yml
@@ -210,6 +210,42 @@ jobs:
           echo "move_latest=$move_latest"
         } >> "$GITHUB_OUTPUT"
 
+    # Provenance guard (issue #2639, #2456 class): a manual `version` dispatch
+    # can build from an ARBITRARY ref and stamp it as the release (vX.Y.Z / vX.Y)
+    # and even move `latest`. Before any human release tag is applied, assert
+    # that the release tag refs/tags/v$version already exists AND resolves to the
+    # exact commit this run is building ($GITHUB_SHA). If it does not, refuse —
+    # a dispatch may only republish an existing release tag's commit, never mint
+    # a release tag for an arbitrary ref. This is the PRIMARY guard (provenance,
+    # not a prompt). Tag-push runs are inherently provenanced (the ref IS the
+    # tag), and the legacy image_tag-only path resolves no version, so both skip.
+    - name: Assert release tag provenance (manual version dispatch)
+      if: github.event_name == 'workflow_dispatch' && steps.version.outputs.resolved != ''
+      env:
+        # VERSION is already allowlist-validated by the Resolve version step
+        # (^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$), so embedding it in the ref
+        # path below cannot inject. Never interpolate ${{ }} into run: directly.
+        VERSION: ${{ steps.version.outputs.resolved }}
+        EXPECTED_SHA: ${{ github.sha }}
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        tag="v$VERSION"
+        # Resolve the tag to its COMMIT sha. The commits API dereferences an
+        # annotated tag ref to the underlying commit; a missing tag returns a
+        # non-2xx status, so the guard fails closed (empty -> refuse).
+        tag_sha="$(gh api "repos/$REPO/commits/$tag" --jq '.sha' 2>/dev/null || true)"
+        if [ -z "$tag_sha" ]; then
+          echo "::error::Refusing to publish release tags: git tag '$tag' does not exist. A version dispatch may only republish an EXISTING release tag — push the tag first (git push origin \"$tag\"), or use the image_tag input for a one-off non-release image."
+          exit 1
+        fi
+        if [ "$tag_sha" != "$EXPECTED_SHA" ]; then
+          echo "::error::Refusing to publish release tags: tag '$tag' resolves to commit $tag_sha but this run is building $EXPECTED_SHA. Re-dispatch this workflow with the '$tag' ref selected (Run workflow -> Use workflow from) so the image provenance matches the release tag."
+          exit 1
+        fi
+        echo "Provenance OK: tag '$tag' resolves to $EXPECTED_SHA (the commit this run builds)."
+
     - name: Docker metadata (tags)
       id: meta
       uses: docker/metadata-action@v5

--- a/.github/workflows/trino-publish.yml
+++ b/.github/workflows/trino-publish.yml
@@ -19,10 +19,13 @@ name: Publish Trino Connector
 #
 # A `workflow_dispatch` trigger allows exercising the publish on demand. Manual
 # runs have no tag to derive the version from, so the `version` input supplies
-# it. `dry_run` now DEFAULTS TO FALSE (issue #2156) — dry-run behavior (publish
-# only to the local Maven repo via publishToMavenLocal, no Central upload, no
-# secrets needed) must be explicitly requested with `dry_run=true`. Omitting
-# the flag means "really publish," gated on the secrets check above.
+# it. `dry_run` DEFAULTS TO TRUE (issue #2639) — a bare `gh workflow run
+# trino-publish.yml -f version=X` MUST NOT reach Maven Central. Dry-run behavior
+# (publish only to the local Maven repo via publishToMavenLocal, no Central
+# upload, no secrets needed) is the default; a real Central publish must be
+# requested explicitly with `dry_run=false`, gated on the secrets check above.
+# Tag-push runs (`push` on `v*`) are unaffected: `dry_run` only applies to
+# workflow_dispatch, so a `v*` tag still publishes for real.
 
 on:
   push:
@@ -35,9 +38,9 @@ on:
         type: string
         required: true
       dry_run:
-        description: 'Dry run: publishToMavenLocal only (no Central upload, no secrets needed). Must be set explicitly — omitting this means a real publish.'
+        description: 'Dry run (DEFAULT): publishToMavenLocal only, no Central upload, no secrets needed. A real Maven Central publish requires setting this to false explicitly.'
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read

--- a/docs/ci/ci-tier-policy.md
+++ b/docs/ci/ci-tier-policy.md
@@ -191,13 +191,34 @@ running any publish workflow with a non-dry-run mode:
 | Coverage | `coverage.yml` and `coverage-baseline.yml` | Green run with downloadable reports |
 | Performance | `perf-regression.yml` nightly/manual run | No regression beyond policy threshold, or release-owner waiver |
 | Supported binding and integration matrices | `node-ci.yml`, `python-ci.yml`, `flight-ci.yml`, `flight-trino-e2e.yml`, `trino-connector-ci.yml`, and `docs-site.yml` where applicable | Green full/nightly/manual matrix for changed release surfaces |
-| Publish dry-runs | `trino-publish.yml` manual `dry_run=true`; `node-release.yml` `npm pack --dry-run` step; `python-release.yml` `twine check dist/*` step; local CLI archive build matching `release.yml` | Dry-run or metadata validation output captured before real publish |
+| Publish dry-runs | `trino-publish.yml` manual dispatch (`dry_run` **defaults to `true`**, #2639); `node-release.yml` `npm pack --dry-run` step; `python-release.yml` `twine check dist/*` step; local CLI archive build matching `release.yml` | Dry-run or metadata validation output captured before real publish |
 | Actual publish workflows | `release.yml`, `node-release.yml`, `python-release.yml`, `trino-publish.yml` | Run only from intentional release tags or explicit maintainer dispatch; never from schedules |
 
 Release checks are release gates, not global PR branch-protection checks. No
 release or publish workflow may be added to `schedule`, and nightly validation
 must not upload packages, images, Maven artifacts, npm packages, Python
 distributions, or GitHub release assets.
+
+#### Armed-publish dispatch guards (issue #2639)
+
+A bare `workflow_dispatch` on a publishing workflow must never publish or move a
+release tag by accident. Two fail-closed guards enforce this; both are covered by
+`scripts/ci/validate-workflows.rb` so they cannot silently regress out of the
+workflow files:
+
+- **`trino-publish.yml` — `dry_run` defaults to `true`.** `gh workflow run
+  trino-publish.yml -f version=X` (no `dry_run`) does a *local-only*
+  `publishToMavenLocal` — it never reaches Maven Central. A real Central release
+  requires an explicit `-f dry_run=false` (still gated on the secrets check). A
+  `v*` tag push is unaffected: `dry_run` applies only to `workflow_dispatch`.
+- **`flight-image.yml` — release-tag provenance.** A manual `version` dispatch can
+  build from an arbitrary ref. Before any `vX.Y.Z` / `vX.Y` / `latest` tag is
+  applied, the `merge` job asserts that `refs/tags/v$version` already resolves to
+  the exact commit this run is building (`github.sha`) and refuses (`exit 1`)
+  otherwise. A dispatch may therefore only *republish an existing release tag's
+  commit* — it can never mint or move a release tag for an arbitrary ref. Push the
+  tag first (`git push origin vX.Y.Z`), or use the one-off `image_tag` input for a
+  non-release image. This is the PRIMARY guard (provenance, not a prompt).
 
 If a release gate is waived, the waiver must name the failed workflow, run URL,
 artifact reviewed, reason for proceeding, and follow-up issue.

--- a/docs/development/dev-cookbook.md
+++ b/docs/development/dev-cookbook.md
@@ -332,3 +332,31 @@ Policy (nightly-only, out of the stable gate, workspace-excluded) is in `CLAUDE.
   nightly long-run (both nightly + cargo-fuzz, isolated from the stable gate). A
   crash fails the job and uploads the reproducer artifact; crashes are filed as
   their own bug issues (not silently patched here).
+
+## Publish dispatches (armed by default? NO — issue #2639)
+
+The publishing workflows are guarded so a bare `workflow_dispatch` cannot publish
+to Maven Central or mint/move a release tag from an arbitrary ref. Both guards are
+enforced by `scripts/ci/validate-workflows.rb` (they fail the workflow-lint if
+removed) and documented in `docs/ci/ci-tier-policy.md` (Release tier).
+
+```bash
+# Trino connector: bare dispatch is a DRY RUN (publishToMavenLocal only, no
+# Central upload, no secrets) — dry_run DEFAULTS TO TRUE.
+gh workflow run trino-publish.yml -f version=0.15.0
+
+# A real Maven Central release requires dry_run=false explicitly:
+gh workflow run trino-publish.yml -f version=0.15.0 -f dry_run=false
+
+# flight-image: a manual `version` dispatch REFUSES unless refs/tags/v$version
+# already resolves to the commit the run builds (github.sha). Push the release
+# tag first, then dispatch with that tag's ref selected:
+git push origin v0.15.0
+gh workflow run flight-image.yml --ref v0.15.0 -f version=0.15.0
+
+# For a one-off, NON-release image (no vX.Y.Z / latest tags), use image_tag:
+gh workflow run flight-image.yml -f image_tag=dev-preview
+```
+
+A `v*` tag push (`git push origin v0.15.0`) publishes for real automatically on
+both lanes — the guards only constrain manual dispatches.

--- a/scripts/ci/validate-workflows.rb
+++ b/scripts/ci/validate-workflows.rb
@@ -263,6 +263,75 @@ def label_exempt_job_allowed?(workflow_name, job_name, job)
   false
 end
 
+# Armed-publish dispatch guards (issue #2639). A bare `workflow_dispatch` on a
+# publishing workflow must not be able to push to Maven Central or mint/move a
+# release tag from an arbitrary ref. These checks fail-close so the guards can
+# never silently regress out of the workflow files.
+def workflow_dispatch_inputs(workflow)
+  triggers = normalize_triggers(workflow["on"] || workflow[true])
+  dispatch = triggers["workflow_dispatch"]
+  return {} unless dispatch.is_a?(Hash)
+
+  inputs = dispatch["inputs"]
+  inputs.is_a?(Hash) ? inputs : {}
+end
+
+def job_step_list(job)
+  return [] unless job.is_a?(Hash)
+
+  Array(job["steps"]).select { |step| step.is_a?(Hash) }
+end
+
+# trino-publish.yml: the `dry_run` input must DEFAULT TO TRUE, so `gh workflow
+# run trino-publish.yml -f version=X` (no dry_run) never reaches Central.
+def trino_publish_guard_errors(file, workflow)
+  errors = []
+  dry_run = workflow_dispatch_inputs(workflow)["dry_run"]
+  if !dry_run.is_a?(Hash)
+    errors << "#{file}: workflow_dispatch must define a `dry_run` input (issue #2639)"
+  elsif dry_run["default"] != true
+    errors << "#{file}: `dry_run` input must default to true so a bare version dispatch cannot publish to Maven Central (issue #2639)"
+  end
+  errors
+end
+
+# flight-image.yml: the merge job (which applies the release tags) must carry a
+# fail-closed provenance assertion that runs on a manual `version` dispatch,
+# BEFORE the Docker metadata (tags) step, comparing the release tag to
+# github.sha and refusing (exit 1) otherwise.
+def flight_image_guard_errors(file, workflow)
+  errors = []
+  merge = (workflow["jobs"] || {})["merge"]
+  unless merge.is_a?(Hash)
+    errors << "#{file}: expected a `merge` job that applies release tags (issue #2639)"
+    return errors
+  end
+
+  steps = job_step_list(merge)
+  tags_index = steps.index { |s| s["id"] == "meta" }
+  provenance_index = steps.index do |s|
+    cond = s["if"].to_s
+    run = s["run"].to_s
+    env = s["env"].is_a?(Hash) ? s["env"] : {}
+    cond.include?("workflow_dispatch") &&
+      cond.include?("steps.version.outputs.resolved") &&
+      env.values.map(&:to_s).any? { |v| v.include?("github.sha") } &&
+      run.match?(/exit\s+1/)
+  end
+
+  if provenance_index.nil?
+    errors << "#{file}: `merge` job must assert release-tag provenance (tag v$version resolves to github.sha) on a manual version dispatch and refuse otherwise (issue #2639)"
+  elsif tags_index && provenance_index >= tags_index
+    errors << "#{file}: release-tag provenance assertion must run BEFORE the Docker metadata (tags) step (issue #2639)"
+  end
+  errors
+end
+
+PUBLISH_DISPATCH_GUARDS = {
+  "trino-publish.yml" => method(:trino_publish_guard_errors),
+  "flight-image.yml" => method(:flight_image_guard_errors)
+}.freeze
+
 workflow_files = Dir[File.join(options[:workflows_dir], "*.{yml,yaml}")].sort
 abort "No workflow files found under #{options[:workflows_dir]}" if workflow_files.empty?
 
@@ -440,6 +509,9 @@ workflow_files.each do |file|
                 "(single-writer with flight-image.yml, issue #2638): #{reason}"
     end
   end
+
+  guard = PUBLISH_DISPATCH_GUARDS[workflow_name]
+  errors.concat(guard.call(file, workflow)) if guard
 
   label = BINDING_PR_MATRIX_LABELS[workflow_name]
   if label && triggers.key?("pull_request")


### PR DESCRIPTION
Closes #2639 (Epic #2636 — build/test/deploy audit remediation, F2).

## Problem
- `gh workflow run trino-publish.yml -f version=X` was a REAL Maven Central publish (`dry_run` defaulted FALSE + `automaticRelease=true`).
- `flight-image.yml` `version` dispatch could build an ARBITRARY ref and stamp it `vX.Y.Z`/`vX.Y` and move `latest` (#2456 class).

## Remedies
1. **trino-publish.yml** — `dry_run` input now DEFAULTS TO TRUE. A bare version dispatch does local-only `publishToMavenLocal` (no Central, no secrets); a real release needs explicit `-f dry_run=false`. `v*` tag-push publishing is unaffected.
2. **flight-image.yml** — PRIMARY provenance guard on the `merge` job: a manual `version` dispatch refuses (`exit 1`) unless `refs/tags/v$version` already resolves to the exact commit being built (`github.sha`). A dispatch can therefore only republish an existing release tag's commit, never mint/move a tag for an arbitrary ref. Runs BEFORE the Docker metadata (tags) step. `VERSION` is read via an allowlist-validated env var, never interpolated into `run:`.
3. **scripts/ci/validate-workflows.rb** — fail-closed workflow-lint for BOTH guards so they cannot silently regress out of the workflow files.
4. **docs** — `dev-cookbook.md` publish-dispatch recipe + `docs/ci/ci-tier-policy.md` Release-tier "Armed-publish dispatch guards" section.

## Acceptance
- Bare dispatches cannot publish (trino local-only) or move release tags (flight-image refuses non-provenanced version).
- Provenance assertion + dry_run default covered by the workflow-lint negative checks.
- Docs updated (dev-cookbook + conventions/ci-tier-policy).

## Roborev self-check
- No `${{ }}` interpolation into `run:` — all inputs read via quoted env vars (`"$VERSION"`, `"$REPO"`, `"$EXPECTED_SHA"`).
- `version` allowlist-validated fail-closed (`^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$`) BEFORE any tag/publish step.
- Both workflow YAMLs parse (`python3 yaml.safe_load`).

## Lint reds on regression (verified)
- Flip trino `dry_run` default->false: lint reds (`dry_run must default to true (#2639)`), overall exit 1.
- Remove flight-image provenance step: lint reds (`merge job must assert release-tag provenance (#2639)`), overall exit 1.
- Move provenance step AFTER `meta`: lint reds (ordering), overall exit 1.
- All reverted; clean run: `Workflow policy validated for 42 workflows`, exit 0.

## LITE gate

```
==== AGENT-GATE LITE SUMMARY ====
commit: 21f899f4b branch: issue-2639-publish-dispatch-guards dirty: no
file-size:         PASS
fmt:               PASS
clippy:            PASS
scoped-tests:      PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
(run with CARGO_NET_OFFLINE=true to work around a transient local DNS outage to crates.io; diff is YAML/Ruby/Markdown only, no Rust changed.)

Do NOT merge — full gate + C + roborev pending.
