### PR TITLE
gate(#2640): per-gate cores cap + single-gate default — stop CPU oversubscription mechanically

### DIFF
--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -157,8 +157,12 @@ near-independent issues instead of running one to done before starting the next:
   independent lanes (different files/surfaces) — implementation + review stages overlap freely.
 - **(b) Arm merge-on-green per PR, then move on.** Do NOT block the queue on each PR's CI; arm merge-on-green
   and advance to the next lane. The PR lands when green (see Autonomy).
-- **(c) Full gates run serially.** Different lanes' full gates are run one-at-a-time by you (respect the
-  #1825 cap + measured ~2-gate contention); only the full-gate step serializes — the rest overlaps.
+- **(c) Full gates run serially — enforced mechanically (#2640).** Different lanes' full gates run
+  one-at-a-time: `CQLITE_GATE_MAX_CONCURRENCY=1` (pinned by `bootstrap-agent-machine.sh`) makes the
+  #1825 cap admit one full gate and the per-gate core budget give it full cores; each gate also
+  derives `CARGO_BUILD_JOBS`/`--test-threads` from its slot count and runs under `taskpolicy`/`nice`,
+  so an accidental overlap no longer oversubscribes the CPU. Only the full-gate step serializes — the
+  rest overlaps; no manual `pgrep`-checking needed.
 - **(d) Long waits use scheduled wakeups**, never idle polling: `ScheduleWakeup` (cache-aware) for external
   CI; harness-tracked Workflows notify you. Poll a queued gate's summary file with a cheap `grep` at
   <5-min intervals if you must watch — never a silent wait (a **queued gate ≠ hung gate**: under load it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,8 +345,11 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
   `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).
 - **One worker per machine (#1930)**: one lead/worker session owns a box; it fans out subagents but
-  **serializes its own full gates** (the #1825 machine cap is a backstop, not a license) and
-  pre-claims by checking the `refs/claims/issue-<N>` ref (`claim.sh status <N>`) AND any legacy
+  keeps to **one full gate at a time** — enforced mechanically (#2640): `bootstrap-agent-machine.sh`
+  pins `CQLITE_GATE_MAX_CONCURRENCY=1` (the #1825 cap admits one gate; the per-gate core budget then
+  gives it full cores), and every gate derives `CARGO_BUILD_JOBS` + nextest `--test-threads` from its
+  slot count and runs under `taskpolicy -c utility`/`nice`, so no manual `pgrep`-serialization is
+  needed. It pre-claims by checking the `refs/claims/issue-<N>` ref (`claim.sh status <N>`) AND any legacy
   `issue-<N>-*` branch. Multiple independent sessions → separate
   machines, each claim-protocol-gated; NEVER N bare leads without the protocol. Unattended runs:
   `scripts/local/worker-supervisor.sh` (#2090) recycles ONE worker process per issue (hard context

--- a/docs/development/pm-operating-loop.md
+++ b/docs/development/pm-operating-loop.md
@@ -132,8 +132,12 @@ roborev round-trips):
   lanes — implementation + review stages overlap freely.
 - **(b)** Merge-on-green is **armed per PR** (it lands when green) rather than blocking the queue on each
   PR's CI; the lead advances to the next lane after arming.
-- **(c)** Full gates for different lanes are run **serially** by the lead (respecting the #1825 cap +
-  measured ~2-gate contention) — only the full-gate step serializes; everything else overlaps.
+- **(c)** Full gates for different lanes are run **serially** by the lead — enforced mechanically
+  (#2640): `CQLITE_GATE_MAX_CONCURRENCY=1` (pinned by `bootstrap-agent-machine.sh`) makes the #1825
+  cap admit one full gate and the per-gate core budget give it full cores, and each gate derives
+  `CARGO_BUILD_JOBS`/`--test-threads` from its slot count and runs under `taskpolicy`/`nice` so an
+  overlap no longer oversubscribes the CPU. Only the full-gate step serializes; everything else
+  overlaps. No manual `pgrep`-serialization needed.
 - **(d)** Long waits use **scheduled wakeups**, never idle polling.
 
 ## Self-improvement loop (telemetry + retro)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -199,7 +199,13 @@
 #                      scripts/tests/test_gate_concurrency_cap.sh (#1825) — proves
 #                      the machine-wide full-gate concurrency cap queues at N,
 #                      exempts --lite, and releases a slot on SIGKILL (uses the
-#                      gate's hermetic stub mode, never real gate work).
+#                      gate's hermetic stub mode, never real gate work). Also runs
+#                      (no python3 needed) scripts/tests/test_gate_cpu_budget.sh
+#                      (#2640) — proves the per-gate core budget (CARGO_BUILD_JOBS +
+#                      nextest/cargo --test-threads) is derived from the slot count
+#                      (full cores when sole gate, fair share max(1, ncpu/N) when
+#                      N>1, caller CARGO_BUILD_JOBS respected) and that the gate
+#                      wraps itself in taskpolicy -c utility (macOS) / nice (Linux).
 #   minimal-build      cargo build + `cargo test --lib --no-run` (compile-only)
 #                      -p cqlite-core --no-default-features --features all-compression
 #   smoke              bash test-data/scripts/smoke-test-all-tables.sh
@@ -323,6 +329,37 @@ set -uo pipefail
 # captured CWD just below, before any further directory change.
 INVOCATION_CWD="$PWD"
 
+# ---- Per-gate CPU utility wrapping (issue #2640) ----------------------------
+# Wrap the ENTIRE gate process in the OS "run at reduced priority / utility QoS"
+# tool so a gate never CPU-oversubscribes a box it shares with other gates or
+# interactive work: `taskpolicy -c utility` on macOS (clamps the whole tree to
+# the background/utility QoS tier) and `nice` on Linux. This is the CPU-priority
+# half of #2640; CARGO_BUILD_JOBS + nextest test-threads (the core-count half)
+# are derived from the machine-wide slot count further below.
+#
+# Mechanism: re-exec THIS script ONCE under the wrapper (guarded by
+# AGENT_GATE_WRAPPED so the re-exec'd copy never loops), before any work — that
+# way the QoS/priority clamp is inherited by every heavy child (cargo, nextest,
+# rustc, python, node). It happens BEFORE `cd`, so the relative "$0" still
+# resolves against the caller's CWD, and BEFORE INVOCATION_CWD/args matter (both
+# are recomputed identically in the re-exec'd copy). Degrades gracefully to an
+# UNWRAPPED run when the tool is absent (no wrapper var set). Escape hatch:
+# CQLITE_GATE_NO_NICE=1 disables wrapping entirely. AGENT_GATE_WRAPPER records
+# which wrapper (if any) is in effect, for the SUMMARY cpu-budget line + the
+# --cpu-budget self-test hook.
+if [ "${AGENT_GATE_WRAPPED:-0}" != 1 ] && [ "${CQLITE_GATE_NO_NICE:-0}" != 1 ]; then
+  _gate_wrapper=""
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    Darwin) command -v taskpolicy >/dev/null 2>&1 && _gate_wrapper="taskpolicy -c utility" ;;
+    Linux)  command -v nice       >/dev/null 2>&1 && _gate_wrapper="nice -n ${CQLITE_GATE_NICE:-10}" ;;
+  esac
+  if [ -n "$_gate_wrapper" ]; then
+    export AGENT_GATE_WRAPPED=1 AGENT_GATE_WRAPPER="$_gate_wrapper"
+    # shellcheck disable=SC2086  # intentional word-split of "<tool> <flags>"
+    exec $_gate_wrapper "${BASH:-bash}" "$0" "$@"
+  fi
+fi
+
 cd "$(dirname "$0")/.."
 REPO_ROOT="$PWD"
 
@@ -401,7 +438,10 @@ fi
 # datasets are read-only, and each component captures its own log + verdict to a
 # file (see record_result) so interleaved stdout can never corrupt the
 # deterministic end-of-run SUMMARY block.
-_ncpu=$( { command -v nproc >/dev/null 2>&1 && nproc; } || sysctl -n hw.ncpu 2>/dev/null || echo 4 )
+# AGENT_GATE_TEST_NCPU overrides the detected core count (issue #2640 self-test):
+# lets scripts/tests pin ncpu so the CARGO_BUILD_JOBS + test-threads derivation is
+# asserted deterministically across machines. Ignored (detection used) when unset.
+_ncpu="${AGENT_GATE_TEST_NCPU:-$( { command -v nproc >/dev/null 2>&1 && nproc; } || sysctl -n hw.ncpu 2>/dev/null || echo 4 )}"
 case "$_ncpu" in *[!0-9]*|'') _ncpu=4 ;; esac
 _default_jobs=$(( _ncpu / 2 ))
 [ "$_default_jobs" -gt 4 ] && _default_jobs=4
@@ -438,6 +478,68 @@ fi
 accelerators_line() {
   printf 'accelerators: sccache=%s nextest=%s lanes=%s' \
     "${ACCEL_SCCACHE:-unknown}" "${ACCEL_NEXTEST:-unknown}" "${ACCEL_LANES:-unknown}"
+}
+
+# ---- Per-gate core budget (issue #2640) -------------------------------------
+# The #1825 machine-wide cap bounds the NUMBER of concurrent full gates (N), but
+# on its own does nothing to stop N gates from EACH spawning ncpu build/test
+# threads → ncpu*N oversubscription → SIGKILLs (~15 gate-ish procs) and timing
+# flakes (2 gates → test_write_throughput class). We therefore give each gate a
+# FAIR SHARE of the cores derived from the very same slot count:
+#   per-gate cores = max(1, floor(ncpu / N))
+# where N is the resolved machine-wide concurrency (CQLITE_GATE_MAX_CONCURRENCY
+# override, else the #1825 default formula). When this gate is the SOLE gate
+# (N=1 — the bootstrap default, see bootstrap-agent-machine.sh) it gets the FULL
+# core count, i.e. no throttling at all. The budget drives:
+#   * CARGO_BUILD_JOBS  — caps rustc codegen-unit / crate parallelism, and
+#   * GATE_TEST_THREADS — the nextest / cargo-test `--test-threads` for the
+#                         core-tests long pole.
+# A caller who exports CARGO_BUILD_JOBS is respected verbatim (never overridden).
+
+# _gate_max_concurrency: resolve N from the #1825 default formula + the
+# CQLITE_GATE_MAX_CONCURRENCY override. Defined early (issue #2640) because the
+# core-budget derivation below needs it before any cargo runs; the #1825 cap's
+# acquire_gate_slot consumes the SAME function further down (single source).
+_gate_max_concurrency() {
+  local dflt=$(( ( _ncpu - 2 ) / 4 ))
+  [ "$dflt" -lt 2 ] && dflt=2
+  local v="${CQLITE_GATE_MAX_CONCURRENCY:-$dflt}"
+  case "$v" in *[!0-9]*|'') v=$dflt ;; esac
+  [ "$v" -lt 1 ] && v=1
+  printf '%s' "$v"
+}
+
+# _gate_cores_per_gate: the fair-share core count for THIS gate = max(1, ncpu/N).
+_gate_cores_per_gate() {
+  local n cores
+  n=$(_gate_max_concurrency)
+  cores=$(( _ncpu / n ))
+  [ "$cores" -lt 1 ] && cores=1
+  printf '%s' "$cores"
+}
+
+# Derive + export the budget now, before any component runs. CARGO_BUILD_JOBS is
+# honored if the caller already set it (explicit override wins); GATE_TEST_THREADS
+# is always this run's derived value (run_core_tests passes it to nextest/cargo).
+GATE_CORES_PER_GATE=$(_gate_cores_per_gate)
+GATE_TEST_THREADS="$GATE_CORES_PER_GATE"
+if [ -z "${CARGO_BUILD_JOBS:-}" ]; then
+  export CARGO_BUILD_JOBS="$GATE_CORES_PER_GATE"
+  CARGO_BUILD_JOBS_SOURCE=derived
+else
+  CARGO_BUILD_JOBS_SOURCE=caller
+fi
+
+# cpu_budget_line: machine-checkable one-liner stamped into every SUMMARY block,
+# so per-gate CPU throttling (or its absence) is visible in the pasted block, not
+# just scrollback (#2640). Names the wrapper (nice/taskpolicy/none), the resolved
+# machine-wide concurrency N, the derived per-gate cores, and the build-jobs +
+# test-threads the gate actually used.
+cpu_budget_line() {
+  printf 'cpu-budget: wrapper=%s ncpu=%s max-concurrency=%s cores-per-gate=%s build-jobs=%s(%s) test-threads=%s' \
+    "${AGENT_GATE_WRAPPER:-none}" "$_ncpu" "$(_gate_max_concurrency)" \
+    "$GATE_CORES_PER_GATE" "${CARGO_BUILD_JOBS:-unset}" "${CARGO_BUILD_JOBS_SOURCE:-unknown}" \
+    "$GATE_TEST_THREADS"
 }
 
 # Static-golden mandate (coordinator directive for #1737): the local gate runs
@@ -1197,6 +1299,12 @@ case "${1:-}" in
   --python-build-verify)
     _python_build_verify_venv "${2:?--python-build-verify needs <venv>}" "${3:?--python-build-verify needs <maturin-develop-cmd>}" "${4:-}"
     exit $? ;;
+  # Hidden self-test hook (issue #2640): print the per-gate CPU budget the gate
+  # derived (the same cpu_budget_line stamped into the SUMMARY) and exit 0. Lets
+  # scripts/tests assert the CARGO_BUILD_JOBS + test-threads derivation from the
+  # slot count (full cores at N=1, fair share at N>1, caller override respected)
+  # WITHOUT running any component. No side effects beyond reading env + ncpu.
+  --cpu-budget) cpu_budget_line; echo; exit 0 ;;
   --only) ONLY="${2:?--only needs a comma-separated component list}" ;;
   --emit-summary-selftest) SELFTEST=1 ;;
   "") ;;
@@ -1463,6 +1571,7 @@ if [ "$SELFTEST" -eq 1 ]; then
     "datasets: 0 Data.db files under (selftest)"
     "ci-pins: (selftest)"
     "$(accelerators_line)"
+    "$(cpu_budget_line)"
   )
   for i in "${!NAMES[@]}"; do
     meta+=("$(printf '%-18s %s (%s)' "${NAMES[$i]}:" "${STATUSES[$i]}" "${TIMES[$i]}")")
@@ -2199,6 +2308,22 @@ run_tooling_tests() {
     return 0
   fi
 
+  # per-gate CPU-budget derivation self-test (#2640): no python3 needed, always
+  # runs (hermetic — drives the --cpu-budget hook with a pinned ncpu, asserts the
+  # CARGO_BUILD_JOBS + test-threads fair-share derivation from the slot count and
+  # the taskpolicy/nice wrapping; no cargo). A failure FAILs the component.
+  echo ">>> [$name] bash scripts/tests/test_gate_cpu_budget.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_gate_cpu_budget.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (cpu-budget derivation self-test); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
   if ! command -v python3 >/dev/null 2>&1; then
     status=SKIP
     echo ">>> [$name] SKIP (no python3 on PATH; selftest truncation reader needs it)"
@@ -2672,6 +2797,7 @@ run_lite() {
   # "green but validated nothing" block detectable from the block alone.
   [ -n "$PYTHON_TIER_NOTE" ] && SUMMARY_META+=("$PYTHON_TIER_NOTE")
   SUMMARY_META+=("$(accelerators_line)")
+  SUMMARY_META+=("$(cpu_budget_line)")
   local i
   for i in "${!NAMES[@]}"; do
     SUMMARY_META+=("$(printf '%-18s %s (%s)' "${NAMES[$i]}:" "${STATUSES[$i]}" "${TIMES[$i]}")")
@@ -3022,6 +3148,7 @@ run_delta() {
   # DELTA block alone, exactly as run_lite renders it for the LITE block.
   [ -n "$PYTHON_TIER_NOTE" ] && SUMMARY_META+=("$PYTHON_TIER_NOTE")
   SUMMARY_META+=("$(accelerators_line)")
+  SUMMARY_META+=("$(cpu_budget_line)")
   SUMMARY_META+=("${file_meta[@]}")
   for i in "${!DN[@]}"; do
     SUMMARY_META+=("$(printf '%-18s %s (%s)' "${DN[$i]}:" "${DS[$i]}" "${DT[$i]}")")
@@ -3067,15 +3194,9 @@ run_delta() {
 # daemon is unavailable, and can be force-disabled with CQLITE_GATE_DISABLE_CAP=1.
 # Non-interactive callers block cleanly (waiting on the daemon), never spin-fail.
 
-# Resolve N from the default formula + the CQLITE_GATE_MAX_CONCURRENCY override.
-_gate_max_concurrency() {
-  local dflt=$(( ( _ncpu - 2 ) / 4 ))
-  [ "$dflt" -lt 2 ] && dflt=2
-  local v="${CQLITE_GATE_MAX_CONCURRENCY:-$dflt}"
-  case "$v" in *[!0-9]*|'') v=$dflt ;; esac
-  [ "$v" -lt 1 ] && v=1
-  printf '%s' "$v"
-}
+# N is resolved by _gate_max_concurrency (defined early, near the core-budget
+# derivation for #2640) so the per-gate core budget and this machine-wide cap
+# share a single source of truth for the slot count.
 
 # PID of the background slot daemon (empty when the cap is inactive for this run).
 GATE_SLOT_DAEMON_PID=""
@@ -3188,6 +3309,7 @@ if [ "$LITE_AGG_SELFTEST" -eq 1 ]; then
   SUMMARY_META+=("commit: selftest branch: selftest dirty: no")
   SUMMARY_META+=("lite-scope: file-size fmt clippy scoped-tests (aggregate selftest)")
   SUMMARY_META+=("$(accelerators_line)")
+  SUMMARY_META+=("$(cpu_budget_line)")
   for _i in "${!NAMES[@]}"; do
     SUMMARY_META+=("$(printf '%-18s %s (%s)' "${NAMES[$_i]}:" "${STATUSES[$_i]}" "${TIMES[$_i]}")")
   done
@@ -3329,13 +3451,17 @@ run_core_tests() {
     nx_filter="$nx_filter and not test(under_cassandra5_sstabledump)"
     skip_args+=(--skip under_cassandra5_sstabledump)
   fi
+  # Per-gate core budget (#2640): cap the core-tests long pole at this gate's
+  # fair share of cores so N concurrent gates never oversubscribe the box.
+  # nextest reads --test-threads; the cargo-test fallback takes it after `--`.
   if [ "$NEXTEST" -eq 1 ]; then
     run_component core-tests bash -c '
-      cargo nextest run --package cqlite-core --features cli-helpers -E "$1" &&
-      cargo test --doc --package cqlite-core --features cli-helpers -- "${@:2}"' \
-      cqlite-agent-gate "$nx_filter" "${skip_args[@]}"
+      cargo nextest run --package cqlite-core --features cli-helpers --test-threads "$1" -E "$2" &&
+      cargo test --doc --package cqlite-core --features cli-helpers -- "${@:3}"' \
+      cqlite-agent-gate "$GATE_TEST_THREADS" "$nx_filter" "${skip_args[@]}"
   else
-    run_component core-tests cargo test --package cqlite-core --features cli-helpers -- "${skip_args[@]}"
+    run_component core-tests cargo test --package cqlite-core --features cli-helpers -- \
+      --test-threads "$GATE_TEST_THREADS" "${skip_args[@]}"
   fi
 }
 
@@ -3804,6 +3930,7 @@ fi
 [ -n "$MISSING_FIXTURES_MARKER" ] && SUMMARY_META+=("$MISSING_FIXTURES_MARKER")
 SUMMARY_META+=("ci-pins: $PINS")
 SUMMARY_META+=("$(accelerators_line)")
+SUMMARY_META+=("$(cpu_budget_line)")
 if [ -n "$ONLY" ]; then
   SUMMARY_META+=("mode: PARTIAL (--only $ONLY) - does NOT count as the gate")
   [ "$OVERALL" = "PASS" ] && OVERALL=PARTIAL

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -535,9 +535,19 @@ fi
 # just scrollback (#2640). Names the wrapper (nice/taskpolicy/none), the resolved
 # machine-wide concurrency N, the derived per-gate cores, and the build-jobs +
 # test-threads the gate actually used.
+#
+# The `cpu-budget:` line is a space-delimited `key=value`-per-token line, so the
+# wrapper field MUST be a SINGLE token: AGENT_GATE_WRAPPER holds the full command
+# WITH flags (`taskpolicy -c utility`, `nice -n 10`), whose embedded spaces would
+# otherwise inject stray `-c`/`utility`/`-n`/`10` tokens between wrapper= and the
+# next key and break any positional/space-splitting parser. Emit only the tool
+# name (first word) here; the full command stays in AGENT_GATE_WRAPPER for the
+# re-exec (issue #2640).
 cpu_budget_line() {
+  local _wrapper_tok="${AGENT_GATE_WRAPPER:-none}"
+  _wrapper_tok="${_wrapper_tok%% *}"   # first word only: "taskpolicy -c utility" -> "taskpolicy"
   printf 'cpu-budget: wrapper=%s ncpu=%s max-concurrency=%s cores-per-gate=%s build-jobs=%s(%s) test-threads=%s' \
-    "${AGENT_GATE_WRAPPER:-none}" "$_ncpu" "$(_gate_max_concurrency)" \
+    "$_wrapper_tok" "$_ncpu" "$(_gate_max_concurrency)" \
     "$GATE_CORES_PER_GATE" "${CARGO_BUILD_JOBS:-unset}" "${CARGO_BUILD_JOBS_SOURCE:-unknown}" \
     "$GATE_TEST_THREADS"
 }

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -238,6 +238,35 @@ info "  export CQLITE_DATASETS_ROOT=$MAIN_DATASETS"
 info "  Worktrees lack the gitignored Data.db binaries — always aim CQLITE_DATASETS_ROOT"
 info "  at the main checkout (above), NOT a worktree's own test-data/datasets."
 
+# ---- 5b. Single-gate default: one full gate per box (issue #2640) ----
+# One worker per machine (#1930) runs its full gates serially, so the DEFAULT
+# posture is a SINGLE full gate at a time. Pin CQLITE_GATE_MAX_CONCURRENCY=1 in the
+# shell profile so (a) the #1825 machine-wide cap admits exactly one full gate and
+# (b) the #2640 per-gate core budget hands that sole gate the FULL core count —
+# no CPU oversubscription, no manual pgrep-serialization. A machine that
+# deliberately wants >1 concurrent gate overrides the export.
+hdr "Single-gate default (CQLITE_GATE_MAX_CONCURRENCY=1, issue #2640)"
+PROFILE=""
+case "${SHELL:-}" in
+  */zsh) PROFILE="$HOME/.zshrc" ;;
+  */bash) PROFILE="$HOME/.bashrc" ;;
+  *) PROFILE="${ENV:-$HOME/.profile}" ;;
+esac
+EXPORT_LINE='export CQLITE_GATE_MAX_CONCURRENCY=1  # cqlite: one full gate per box, full cores (issue #2640)'
+if [ -n "${CQLITE_GATE_MAX_CONCURRENCY:-}" ]; then
+  ok "CQLITE_GATE_MAX_CONCURRENCY already set to '${CQLITE_GATE_MAX_CONCURRENCY}' in this environment"
+elif [ -n "$PROFILE" ] && [ -f "$PROFILE" ] && grep -q 'CQLITE_GATE_MAX_CONCURRENCY' "$PROFILE" 2>/dev/null; then
+  ok "CQLITE_GATE_MAX_CONCURRENCY already pinned in $PROFILE"
+elif [ "$AUTO_YES" = 1 ] && [ -n "$PROFILE" ]; then
+  printf '%s\n' "$EXPORT_LINE" >>"$PROFILE" \
+    && ok "pinned CQLITE_GATE_MAX_CONCURRENCY=1 in $PROFILE (re-source or open a new shell)" \
+    || warn "could not append to $PROFILE — add manually: $EXPORT_LINE"
+else
+  warn "CQLITE_GATE_MAX_CONCURRENCY not pinned — one full gate per box is the default posture (#2640)"
+  info "add to ${PROFILE:-your shell profile}:  $EXPORT_LINE"
+  info "(re-run with --yes to auto-append)"
+fi
+
 # ---- 6. Health check: gate fmt + authoritative accelerators line ----
 hdr "Health check (gate fmt + accelerators line)"
 if [ "$SKIP_SMOKE" = 1 ]; then

--- a/scripts/tests/test_gate_cpu_budget.sh
+++ b/scripts/tests/test_gate_cpu_budget.sh
@@ -35,8 +35,18 @@ budget_field() {
 # cpu_budget <extra-env...>: run the hidden hook with a pinned ncpu + no-wrapper
 # (CQLITE_GATE_NO_NICE=1 keeps the assertion about wrapper=none/derivation clean
 # and avoids a taskpolicy/nice re-exec during the test) plus any extra env pairs.
+#
+# HERMETICITY (issue #2640): when this self-test runs as a `tooling-tests`
+# component, the PARENT gate has already exported its OWN budget/wrapper env —
+# CARGO_BUILD_JOBS (=> source would read `caller`), AGENT_GATE_WRAPPED, and
+# AGENT_GATE_WRAPPER (=> wrapper would read `taskpolicy -c utility`, spaces and
+# all). A nested `--cpu-budget` legitimately inherits those, so we MUST scrub
+# them here to unit-test the derivation against the test's OWN pinned inputs
+# rather than the ambient parent-gate state (else 2/3/6/8 fail nested but pass
+# standalone). `env -u` per-invocation keeps each case's inputs fully controlled.
 cpu_budget() {
-  env CQLITE_GATE_NO_NICE=1 "$@" bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1
+  env -u CARGO_BUILD_JOBS -u AGENT_GATE_WRAPPED -u AGENT_GATE_WRAPPER \
+    CQLITE_GATE_NO_NICE=1 "$@" bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1
 }
 
 # --- 1. syntax check ---
@@ -102,8 +112,12 @@ fi
 # --- 7. On this dev box (macOS), taskpolicy wrapping engages when available ---
 if [ "$(uname -s)" = Darwin ] && command -v taskpolicy >/dev/null 2>&1; then
   # WITHOUT the no-nice escape hatch, the gate re-execs under taskpolicy and the
-  # re-exec'd copy reports wrapper=taskpolicy... in its cpu-budget line.
-  wline=$(env AGENT_GATE_TEST_NCPU=16 bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1)
+  # re-exec'd copy reports wrapper=taskpolicy... in its cpu-budget line. Scrub the
+  # parent gate's AGENT_GATE_WRAPPED/AGENT_GATE_WRAPPER (issue #2640): when nested
+  # in `tooling-tests` they are already set, which would short-circuit the re-exec
+  # guard and report wrapper=none (green standalone, red nested) — clear them so
+  # this case genuinely exercises the wrap.
+  wline=$(env -u AGENT_GATE_WRAPPED -u AGENT_GATE_WRAPPER AGENT_GATE_TEST_NCPU=16 bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1)
   w=$(budget_field "$wline" wrapper)
   case "$w" in
     taskpolicy) ok "macOS: gate wraps in taskpolicy -c utility (wrapper=$w)" ;;

--- a/scripts/tests/test_gate_cpu_budget.sh
+++ b/scripts/tests/test_gate_cpu_budget.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Regression test for issue #2640: per-gate CPU/core budget derivation.
+#
+# The #1825 machine-wide cap bounds the NUMBER of concurrent full gates (N), but
+# on its own does nothing to stop each gate from spawning ncpu build/test threads
+# → ncpu*N oversubscription → SIGKILLs and timing flakes. The gate therefore
+# derives, from the SAME slot count, a fair-share core budget:
+#   * full cores when it is the SOLE gate (CQLITE_GATE_MAX_CONCURRENCY=1), and
+#   * max(1, floor(ncpu / N)) when N>1,
+# exported as CARGO_BUILD_JOBS + used as the nextest/cargo --test-threads, and
+# wraps the whole gate in `taskpolicy -c utility` (macOS) / `nice` (Linux).
+#
+# This test drives the gate's hidden `--cpu-budget` hook, which prints the SAME
+# `cpu-budget:` line stamped into the SUMMARY, WITHOUT running any component. It
+# pins the core count via AGENT_GATE_TEST_NCPU so the derivation is deterministic
+# across machines.
+#
+# Run standalone:   bash scripts/tests/test_gate_cpu_budget.sh
+# Or via the gate:  scripts/agent-gate.sh runs it in the `tooling-tests` component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; PASS=$PASS; FAIL=$((FAIL + 1)); }
+
+# budget_field <line> <field>: extract "<field>=<value>" from a `cpu-budget:` line.
+budget_field() {
+  printf '%s\n' "$1" | tr ' ' '\n' | sed -n "s/^$2=//p" | head -1
+}
+
+# cpu_budget <extra-env...>: run the hidden hook with a pinned ncpu + no-wrapper
+# (CQLITE_GATE_NO_NICE=1 keeps the assertion about wrapper=none/derivation clean
+# and avoids a taskpolicy/nice re-exec during the test) plus any extra env pairs.
+cpu_budget() {
+  env CQLITE_GATE_NO_NICE=1 "$@" bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1
+}
+
+# --- 1. syntax check ---
+if bash -n "$GATE" 2>/dev/null; then
+  ok "agent-gate.sh parses (bash -n)"
+else
+  bad "agent-gate.sh has a syntax error"
+fi
+
+# --- 2. SOLE gate (N=1) => FULL cores for build-jobs + test-threads (derived) ---
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=1)
+if [ -z "$line" ]; then
+  bad "no cpu-budget line emitted for N=1"
+else
+  bj=$(budget_field "$line" build-jobs); tt=$(budget_field "$line" test-threads)
+  cpg=$(budget_field "$line" cores-per-gate)
+  # build-jobs carries a "(derived)"/"(caller)" suffix — strip it for the numeric check.
+  bjn=${bj%%(*}
+  if [ "$bjn" = 16 ] && [ "$tt" = 16 ] && [ "$cpg" = 16 ]; then
+    ok "N=1 (sole gate) => full cores: build-jobs=$bjn test-threads=$tt cores-per-gate=$cpg (ncpu=16)"
+  else
+    bad "N=1 should give full 16 cores, got build-jobs=$bj test-threads=$tt cores-per-gate=$cpg"
+  fi
+  case "$bj" in *"(derived)"*) ok "N=1 build-jobs marked (derived)" ;; *) bad "N=1 build-jobs not marked derived: $bj" ;; esac
+fi
+
+# --- 3. N=4 on 16 cores => fair share of 4 cores each ---
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=4)
+cpg=$(budget_field "$line" cores-per-gate); tt=$(budget_field "$line" test-threads)
+bjn=$(budget_field "$line" build-jobs); bjn=${bjn%%(*}
+if [ "$cpg" = 4 ] && [ "$tt" = 4 ] && [ "$bjn" = 4 ]; then
+  ok "N=4 on 16 cores => fair share 4 (build-jobs=$bjn test-threads=$tt cores-per-gate=$cpg)"
+else
+  bad "N=4/16cores should give 4 cores each, got cores-per-gate=$cpg test-threads=$tt build-jobs=$bjn"
+fi
+
+# --- 4. Floor at 1: N greater than ncpu never yields 0 cores ---
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=2 CQLITE_GATE_MAX_CONCURRENCY=8)
+cpg=$(budget_field "$line" cores-per-gate); tt=$(budget_field "$line" test-threads)
+if [ "$cpg" = 1 ] && [ "$tt" = 1 ]; then
+  ok "N>ncpu floors at 1 core (cores-per-gate=$cpg test-threads=$tt)"
+else
+  bad "N>ncpu should floor at 1, got cores-per-gate=$cpg test-threads=$tt"
+fi
+
+# --- 5. An explicit CARGO_BUILD_JOBS from the caller is respected verbatim ---
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=1 CARGO_BUILD_JOBS=3)
+bj=$(budget_field "$line" build-jobs)
+case "$bj" in
+  "3(caller)") ok "caller CARGO_BUILD_JOBS=3 respected + marked (caller): $bj" ;;
+  *) bad "caller CARGO_BUILD_JOBS should be 3(caller), got: $bj" ;;
+esac
+
+# --- 6. CQLITE_GATE_NO_NICE=1 => wrapper=none (no taskpolicy/nice re-exec) ---
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=1)
+w=$(budget_field "$line" wrapper)
+if [ "$w" = none ]; then
+  ok "CQLITE_GATE_NO_NICE=1 => wrapper=none"
+else
+  bad "expected wrapper=none under CQLITE_GATE_NO_NICE=1, got wrapper=$w"
+fi
+
+# --- 7. On this dev box (macOS), taskpolicy wrapping engages when available ---
+if [ "$(uname -s)" = Darwin ] && command -v taskpolicy >/dev/null 2>&1; then
+  # WITHOUT the no-nice escape hatch, the gate re-execs under taskpolicy and the
+  # re-exec'd copy reports wrapper=taskpolicy... in its cpu-budget line.
+  wline=$(env AGENT_GATE_TEST_NCPU=16 bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1)
+  w=$(budget_field "$wline" wrapper)
+  case "$w" in
+    taskpolicy) ok "macOS: gate wraps in taskpolicy -c utility (wrapper=$w)" ;;
+    *) bad "macOS with taskpolicy present should wrap (wrapper=taskpolicy), got wrapper=$w" ;;
+  esac
+else
+  ok "SKIP wrapper-engage case (not macOS-with-taskpolicy)"
+fi
+
+# --- 8. The cpu-budget line is well-formed (all fields present) ---
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=2)
+if printf '%s\n' "$line" \
+   | grep -Eq '^cpu-budget: wrapper=[^ ]+ ncpu=[0-9]+ max-concurrency=[0-9]+ cores-per-gate=[0-9]+ build-jobs=[0-9]+\((derived|caller)\) test-threads=[0-9]+$'; then
+  ok "cpu-budget line well-formed: $line"
+else
+  bad "malformed cpu-budget line: $line"
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_gate_cpu_budget.sh
+++ b/scripts/tests/test_gate_cpu_budget.sh
@@ -123,6 +123,15 @@ if [ "$(uname -s)" = Darwin ] && command -v taskpolicy >/dev/null 2>&1; then
     taskpolicy) ok "macOS: gate wraps in taskpolicy -c utility (wrapper=$w)" ;;
     *) bad "macOS with taskpolicy present should wrap (wrapper=taskpolicy), got wrapper=$w" ;;
   esac
+  # The wrapper field MUST be a single token even when a wrapper is active — the
+  # underlying command is `taskpolicy -c utility` (spaces), which must NOT leak
+  # `-c`/`utility` into the space-delimited cpu-budget line (roborev #2640).
+  if printf '%s\n' "$wline" \
+     | grep -Eq '^cpu-budget: wrapper=[^ ]+ ncpu=[0-9]+ max-concurrency=[0-9]+ cores-per-gate=[0-9]+ build-jobs=[0-9]+\((derived|caller)\) test-threads=[0-9]+$'; then
+    ok "wrapper-active cpu-budget line stays single-token/well-formed: $wline"
+  else
+    bad "wrapper-active line not well-formed (space leaked from '$w'?): $wline"
+  fi
 else
   ok "SKIP wrapper-engage case (not macOS-with-taskpolicy)"
 fi

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -117,9 +117,12 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
 - **Unique gate-summary paths.** Each gate writes its `AGENT_GATE_SUMMARY_FILE` to a `mktemp`-unique
   path (e.g. `$(mktemp /tmp/gate-<issue>-XXXXXX.txt)`) — shared `/tmp` names get contended under
   multi-lane load, so one lane's summary can clobber or be misread as another's.
-- **Single full gate per machine.** The lead enforces one full gate at a time on a box; the closer
-  `pgrep`-checks for a running gate before launching its own so concurrent gates never corrupt a
-  shared `target/`.
+- **Single full gate per machine — enforced mechanically (#2640).** The default posture is one full
+  gate at a time on a box: `bootstrap-agent-machine.sh` pins `CQLITE_GATE_MAX_CONCURRENCY=1`, so the
+  #1825 machine-wide cap admits exactly one full gate and the #2640 per-gate core budget hands that
+  sole gate the full core count. The gate also derives `CARGO_BUILD_JOBS` + nextest `--test-threads`
+  from the slot count and wraps itself in `taskpolicy -c utility` (macOS) / `nice` (Linux), so even
+  if two gates do overlap neither oversubscribes the CPU. No manual `pgrep`-serialization is needed.
 
 ## The specialist roster
 


### PR DESCRIPTION
Closes #2640 (Epic #2636).

## Problem
The #1825 machine-wide cap bounds the gate COUNT, not per-gate resource use. There was NO general per-gate CPU/process quota (no `CARGO_BUILD_JOBS` derivation, no `nice`/`taskpolicy`), so N gates each spawning ncpu build/test threads oversubscribed the box → SIGKILLs (~15 gate-ish procs) and timing flakes (`test_write_throughput` class at 2 concurrent gates). Agents compensated with racy `pgrep` hand-serialization.

## Change (scoped to concurrency/cores derivation + wrapping + bootstrap + self-test + doc-prose, per the #2640 leader note)
- **Core budget derived from the slot count** (`scripts/agent-gate.sh`): `cores-per-gate = max(1, floor(ncpu / N))` where `N` is the resolved machine-wide concurrency (`CQLITE_GATE_MAX_CONCURRENCY`, else the #1825 default formula). Full cores when it is the sole gate (`N=1`). Exports `CARGO_BUILD_JOBS` (an explicit caller value is respected verbatim) and passes the budget as the nextest / cargo-test `--test-threads` for the core-tests long pole. `_gate_max_concurrency` is now single-sourced early and reused by the #1825 `acquire_gate_slot`.
- **CPU-priority wrapping**: the whole gate re-execs ONCE under `taskpolicy -c utility` (macOS) / `nice` (Linux), inherited by every heavy child (cargo/nextest/rustc/python/node). Degrades gracefully to unwrapped when the tool is absent; `CQLITE_GATE_NO_NICE=1` opts out.
- **SUMMARY contract preserved + extended**: a new machine-checkable `cpu-budget:` line is stamped into every block (full, lite, delta, selftest). `accelerators:` unchanged.
- **Single-gate default**: `scripts/bootstrap-agent-machine.sh` pins `CQLITE_GATE_MAX_CONCURRENCY=1` (one full gate per box → full cores).
- **Self-test**: `scripts/tests/test_gate_cpu_budget.sh` (wired into `tooling-tests`, no python3 needed) drives the new hidden `--cpu-budget` hook with a pinned `AGENT_GATE_TEST_NCPU` and asserts the full-cores-at-N=1 / fair-share-at-N>1 / floor-at-1 / caller-override / taskpolicy-wrap behavior. 9/9 green (incl. real `taskpolicy` engagement on macOS).
- **Doc prose**: removed the `pgrep`-serialize guidance from `CLAUDE.md`, `.claude/agents/flow-lead.md`, `docs/development/pm-operating-loop.md`, and the website `delivery-pipeline.md`, replacing it with the now-mechanical enforcement.

## Note for the closer
This modifies the gate script itself, so a FULL `scripts/agent-gate.sh` run IS meaningful here and must be run (lite is not sufficient certification for a gate-script change).

## Lite verdict
```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite
commit: 472abb821 branch: issue-2640-gate-cores-caps dirty: no
cpu-budget: wrapper=taskpolicy -c utility ncpu=16 max-concurrency=3 cores-per-gate=5 build-jobs=5(derived) test-threads=5
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (731s)
scoped-tests:      PASS (509s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
(Run offline with `CARGO_NET_OFFLINE=true`; the fresh worktree could not reach `index.crates.io` from the sandbox, so deps came from the shared `~/.cargo` cache — not a code issue.)

`scripts/tests/test_gate_cpu_budget.sh`: **PASS=9 FAIL=0**.