### PR TITLE
ci(#2644): run query-semantics oracle fail-closed in required PR gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -69,6 +69,20 @@ jobs:
               --skip tests::test_database
           '
 
+      - name: Query-semantics oracle (fail-closed, #2644)
+        run: |
+          bash scripts/ci/ci-timing-summary.sh measure "query-semantics oracle" -- bash -e -u -o pipefail -c '
+            # Read-time-reconciliation parity oracle (#1742): committed-fixture,
+            # pinned-now, no Docker. The fixtures live in-repo under
+            # test-data/datasets/sstables/test_compaction_tombstone_ttl (git-tracked),
+            # so actions/checkout alone provides them and the test resolves them via
+            # its repo-root fallback. CQLITE_REQUIRE_FIXTURES=1 makes an absent/empty
+            # fixture a HARD FAILURE (reds this required job) instead of a silent skip.
+            CQLITE_REQUIRE_FIXTURES=1 \
+              cargo test -p cqlite-core --features "state_machine cli-helpers" \
+                --test query_semantics_oracle_parity
+          '
+
       - name: Required PR Gate timing summary
         if: always()
         run: bash scripts/ci/ci-timing-summary.sh summary "Required PR Gate timing"


### PR DESCRIPTION
Closes #2644 (Epic #2636)

## What
Folds the `query_semantics_oracle_parity` read-time-reconciliation parity oracle (#1742) into pr-gate.yml's existing `required` job as a fail-closed step, making it **required for merge**.

Per the epic's owner decision this is the ONLY new required check being added. It is added INTO the existing `required` job (not as a new required context) — branch protection requires only the single `required` context, so no branch-protection edit is needed.

## Fail-closed
The step sets `CQLITE_REQUIRE_FIXTURES=1` so an absent/empty committed fixture is a **hard failure that reds the required check**, never a silent vacuous skip. The oracle fixtures are git-tracked in-repo (`test-data/datasets/sstables/test_compaction_tombstone_ttl`) and resolved via the test's repo-root fallback, so `actions/checkout` alone provides them — no dataset download, no Docker, pinned-now: gate-cheap.

## Fail-closed proof (manual, local)
Hid the fixture keyspace, ran the built test binary:
- fixtures ABSENT + `CQLITE_REQUIRE_FIXTURES=1` → **exit 101 (FAILED)** — reds the required check
- fixtures ABSENT, flag unset → exit 0 (SKIP green — the vacuous pass the flag prevents)
- fixtures PRESENT + `CQLITE_REQUIRE_FIXTURES=1` (no `CQLITE_DATASETS_ROOT`, CI-like) → PASS, test body runs in **0.03s**

Fixtures restored; git status clean.

## Cost
Oracle test execution: ~0.03s. Step also compiles the `--test query_semantics_oracle_parity` target on top of the job's already-built cqlite-core; well within the <~2min budget.

## Roborev self-check (workflow)
No `${{ }}` interpolation into `run:` — static command only. YAML parses; `scripts/ci/validate-workflows.rb` passes (42 workflows validated).

## Note
This ADDS a required check by folding it into the existing `required` job — **no new branch-protection context**.

## Lite gate
\`\`\`
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record)
commit: ccd0d9954 branch: issue-2644-oracle-pr-gate dirty: no
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (331s)
scoped-tests:      PASS (148s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
\`\`\`

Do NOT merge — flow-closer runs the full gate of record.