### PR TITLE
test(#2643): .config/nextest.toml — timing/docker test-groups + scoped retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,62 @@
+# cargo-nextest configuration (issue #2643, epic #2636 build/test/deploy audit).
+#
+# This file is auto-discovered by `cargo nextest run` when it lives at the repo
+# root under .config/ — no --config-file flag is needed. `scripts/agent-gate.sh`
+# runs `core-tests` under `cargo nextest run` (#1737), so the gate picks this up
+# transparently. It is ORTHOGONAL to the gate's per-gate CPU budget (#2640):
+# that derives `--test-threads` (the global concurrency ceiling); this file adds
+# test-GROUPS (bounded co-scheduling of load-sensitive tests), scoped retries,
+# and a hung-test slow-timeout. The two never fight.
+#
+# Doctrine (see docs/development/gate-ops.md, "nextest test-groups, retries, and
+# slow-timeout"):
+#   * TIMING tests (ratio/latency/throughput checks that legitimately vary under
+#     a loaded, oversubscribed CI box) get retries 1-2 AND are co-scheduled one
+#     at a time so they never perturb each other's timings.
+#   * DOCKER / live-Cassandra parity tests are serialized (a single Docker host)
+#     and get a hard hung-test kill — but NOT retries (a real parity divergence
+#     must fail, not flap-retry green).
+#   * PARITY / CORRECTNESS tests keep retries = 0 (the profile default below): a
+#     wrong byte or a diverged SELECT must fail deterministically, never be
+#     masked by a retry.
+
+[profile.default]
+# Correctness default: no test is retried unless an override below opts it in.
+# Only the `timing` group opts in; everything else (parity, byte-for-byte,
+# read-path, type-decode) stays deterministic.
+retries = 0
+
+# Hung-test guard: warn once a test exceeds 60s, then hard-kill after 4 periods
+# (240s). Deliberately generous so a slow-but-honest test on a loaded box is
+# never killed mid-run; it only backstops a genuinely wedged test/process.
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[test-groups]
+# max-threads = 1 co-schedules each group's tests one at a time (across ALL
+# nextest worker threads), so members never contend with each other for CPU.
+# This is the load-control lever that makes the timing ratios stable; it is
+# independent of the gate's global --test-threads ceiling (#2640).
+timing = { max-threads = 1 }
+docker = { max-threads = 1 }
+
+# --- TIMING group: load-sensitive tests get scoped retries + serialization ----
+# tail_latency_harness      — mixed_p99 / cold_mmap_mixed_p99 ratio bounds; the
+#                             documented tail-latency flake under 2 concurrent
+#                             gates (MEMORY: mixed_p99_bounded_by_k_times_baseline).
+# sstable_performance_regression_tests — wall-clock MAX_*_MS budget asserts that
+#                             legitimately vary under load (retirement is #2642;
+#                             until it lands, scoped retries de-flake the gate).
+[[profile.default.overrides]]
+filter = 'binary(tail_latency_harness) | binary(sstable_performance_regression_tests)'
+test-group = 'timing'
+retries = { backoff = "exponential", count = 2, delay = "2s" }
+
+# --- DOCKER group: serialize live-Docker parity tests + hard hung-test kill ----
+# docker_probe_timeout           — exercises the bounded-probe timeout machinery.
+# *under_cassandra5_sstabledump  — live Cassandra 5.0 sstabledump parity (#911),
+#                                  skipped by default in the gate, run in nightly
+#                                  Docker lanes; one Docker host → serialize them.
+# NO retries: a parity divergence must fail, never flap-retry to green.
+[[profile.default.overrides]]
+filter = 'binary(docker_probe_timeout) | test(/under_cassandra5_sstabledump/)'
+test-group = 'docker'

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -178,6 +178,24 @@ CQLITE_SKIP_DOCKER_TESTS=0 bash scripts/agent-gate.sh     # include live Cassand
 
 **Graceful fallback**: absent `cargo-nextest`, no `/bin/bash wait -n` (macOS stock 3.2), or `AGENT_GATE_JOBS=1` → gate degrades gracefully to the historical sequential run without loss of coverage.
 
+## nextest test-groups, retries, and slow-timeout (issue #2643)
+
+`.config/nextest.toml` at the repo root is **auto-discovered** by `cargo nextest run` — no `--config-file` flag needed — so the gate's `core-tests` nextest invocation (#1737) picks it up transparently. It is **orthogonal to the per-gate CPU budget (#2640)**: that derives the global `--test-threads` ceiling; this file adds test-*groups* (bounded co-scheduling of load-sensitive tests), scoped retries, and a hung-test `slow-timeout`. The two levers never fight — `--test-threads` caps total concurrency; a group's `max-threads = 1` caps concurrency *within that group*.
+
+The design principle is **retries scoped to load-variance, never to correctness**:
+
+- **`timing` group** (`max-threads = 1`, `retries = 2` exponential backoff): the ratio/latency/throughput tests that legitimately vary on a loaded, oversubscribed box — `tail_latency_harness` (the documented `mixed_p99_bounded_by_k_times_baseline` tail-latency flake under concurrent gates) and `sstable_performance_regression_tests` (wall-clock `MAX_*_MS` budget asserts; their retirement is #2642 — until that lands, scoped retries de-flake the gate). Serialized so they never perturb each other's timings.
+- **`docker` group** (`max-threads = 1`, **no retries**): `docker_probe_timeout` plus the `*under_cassandra5_sstabledump` live-Cassandra parity tests (#911, skipped by default in the gate, run in nightly Docker lanes). A single Docker host → serialize; but a parity divergence must **fail**, never flap-retry to green.
+- **Everything else — parity, byte-for-byte, read-path, type-decode — keeps `retries = 0`** (the `profile.default` default). A wrong byte or a diverged `SELECT` must fail deterministically, never be masked by a retry.
+- **`slow-timeout`** = warn at 60s, hard-kill after 4 periods (240s) — a generous backstop for a genuinely wedged test/process, never a killer of slow-but-honest tests on a loaded box.
+
+Verify groups resolve (no TOML parse errors, membership as intended):
+
+```bash
+cargo nextest show-config test-groups --package cqlite-core --features cli-helpers
+# prints: group: docker (max threads = 1) … group: timing (max threads = 1) … with members
+```
+
 ## Machine-wide full-gate concurrency cap (issue #1825)
 
 Running many sessions/worktrees at once used to let ~15 full gates hit the CPU at once (load 30–60) and SIGKILL gates mid-`core-tests`. The FULL `agent-gate.sh` run now takes a **cross-process bounded semaphore**: at most **N** full gates execute machine-wide at once; excess invocations **queue** (block) for a slot — printing `waiting for gate slot (N in use)…` once — and then proceed. **They never fail from the cap**; non-interactive callers block cleanly.


### PR DESCRIPTION
Closes #2643 (Epic #2636, build/test/deploy audit lane F3).

## What
No nextest config existed — all parallelism/retry behavior was defaults. Adds `.config/nextest.toml` (auto-discovered at repo root, so `scripts/agent-gate.sh`'s `core-tests` nextest run (#1737) picks it up with no flag change) plus doctrine in `docs/development/gate-ops.md`.

**Coexists with #2640** (`d40ee47d`, just merged): that derives the global `--test-threads` from a per-gate CPU budget; this file adds test-*groups*, scoped retries, and a `slow-timeout` — all orthogonal to thread derivation. The LITE summary confirms it: `test-threads=16 ... nextest=on`.

## Design — retries scoped to load-variance, never to correctness
- `[test-groups] timing` (`max-threads=1`, `retries=2` exp backoff): `tail_latency_harness` (the documented `mixed_p99_bounded_by_k_times_baseline` flake under concurrent gates) + `sstable_performance_regression_tests` (wall-clock `MAX_*_MS` budgets; retirement is #2642). Serialized so they don't perturb each other.
- `[test-groups] docker` (`max-threads=1`, **no retries**): `docker_probe_timeout` + `*under_cassandra5_sstabledump` (#911). One Docker host → serialize; a parity divergence must FAIL, not flap-retry.
- `profile.default` `retries=0`: **all parity/correctness tests stay deterministic**.
- `slow-timeout` 60s warn / 240s hard-kill: hung-test backstop, generous for slow-but-honest tests.

## Proof groups resolve
`cargo nextest show-config test-groups --package cqlite-core --features cli-helpers`:
```
group: docker (max threads = 1)
  cqlite-core::docker_probe_timeout: (5 tests)
  cqlite-core::issue_911_bti_partition_deletion_stats: partition_deletion_reads_back_under_cassandra5_sstabledump
  cqlite-core::issue_911_bti_sstabledump_parity: bti_writer_output_reads_under_cassandra5_sstabledump, ...
group: timing (max threads = 1)
  cqlite-core::sstable_performance_regression_tests: (5 tests)
  cqlite-core::tail_latency_harness: mixed_p99_bounded_by_k_times_baseline, cold_mmap_..., ...
```

## Files
- `.config/nextest.toml` (new)
- `docs/development/gate-ops.md` (new section: "nextest test-groups, retries, and slow-timeout (issue #2643)")

## LITE gate
```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite
commit: 585098cb5 branch: issue-2643-nextest-config dirty: no
accelerators: sccache=on nextest=on lanes=on
cpu-budget: ncpu=16 max-concurrency=1 cores-per-gate=16 build-jobs=16 test-threads=16
file-size: PASS  fmt: PASS  clippy: PASS  scoped-tests: PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Full gate must PASS once before merge (config/docs diff; no correctness code change).