### PR TITLE
gate(#2641): sccache cache-health monitoring (characterized: no load→corruption evidence)

### DIFF
--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -30,7 +30,7 @@ without it, it prints the exact command for each gap. It verifies, in order:
 Every gate SUMMARY (full **and** `--lite`) carries one machine-checkable line:
 
 ```
-accelerators: sccache=on nextest=on lanes=on
+accelerators: sccache=on nextest=on lanes=on sccache-health=ok
 ```
 
 - **`sccache`** — cross-worktree compile cache (~25.6% faster fresh builds).

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -60,6 +60,50 @@ sccache --stop-server
 sccache --start-server
 ```
 
+## sccache cache-health monitoring (issue #2641)
+
+A single incident was reported of sccache serving corrupted objects under extreme
+load (loadavg ~150). Issue #2641 **characterized before mitigating**: across ~31k
+requests on a sustained-high-load gate machine, sccache's **own authoritative error
+counters** — `Cache read errors`, `Cache write errors`, `Cache errors`,
+`Cache timeouts` — were **all zero**, the eviction-capped cache held **zero
+torn/zero-byte objects**, and the cache disk had ample free space (not a disk-full
+artifact). There was **no evidence of a load→corruption mechanism**, so the gate
+does **NOT** auto-disable caching under load: doing so would forfeit the measured
+25.6% build speedup and *increase* build pressure on exactly the loaded machines
+that can least afford it, to defend an unreproduced failure mode.
+
+What the incident *did* expose is that sccache's error counters — the one signal
+that would catch real corruption — were invisible in the SUMMARY. The
+evidence-based mitigation is **monitoring that real signal**, not a blind
+auto-disable. Every SUMMARY's `accelerators:` line now carries a trailing
+`sccache-health=` token:
+
+```
+accelerators: sccache=on nextest=on lanes=on sccache-health=ok
+```
+
+- `sccache-health=na`   — sccache not in use (nothing to probe).
+- `sccache-health=ok`   — sccache in use, all error/timeout counters zero.
+- `sccache-health=warn` — a counter is non-zero → **LOUD `WARN:` on STDERR** naming
+  the count and pointing at `sccache --show-stats`. Caching stays **ENABLED** and
+  the gate does **not** fail — the WARN is a signal to inspect the cache, not a
+  blind kill switch.
+
+The counter sum is probed via `sccache --show-stats` only at SUMMARY emission
+(memoized; never in the latency-sensitive classify hooks). On a `warn`, inspect
+and, if you confirm corruption, reset the cache:
+
+```bash
+sccache --show-stats          # confirm which counter fired
+sccache --stop-server && rm -rf "$SCCACHE_DIR" && sccache --start-server
+```
+
+If a future *reproduced* incident correlates non-zero counters with load, the
+per-gate counters are now recorded to drive that decision on evidence — the point
+at which load-aware behavior could be reconsidered. Self-test coverage:
+`scripts/tests/test_agent_gate_summary.sh` (case 9c, na/ok/warn + no-auto-disable).
+
 ## Accelerator degradation is LOUD, not silent (issue #1848)
 
 Every optional accelerator the gate depends on — **sccache** (cross-worktree
@@ -81,7 +125,7 @@ Every SUMMARY block (full **and** `--lite`) carries a **machine-checkable
 scrollback:
 
 ```
-accelerators: sccache=on nextest=absent lanes=serial
+accelerators: sccache=on nextest=absent lanes=serial sccache-health=ok
 ```
 
 State values: `on` (detected & used) · `absent` (missing → WARN) · `off`

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -472,12 +472,80 @@ if [ "$AGENT_GATE_JOBS" -gt 1 ]; then
   fi
 fi
 
+# ---- sccache cache-health signal (issue #2641) ------------------------------
+# Characterization (issue #2641) of the single reported "sccache served corrupted
+# objects under load (loadavg ~150)" incident found NO evidence of a load→corruption
+# mechanism: across 31k requests on a sustained-high-load gate machine, sccache's
+# OWN authoritative error counters (read/write/errors/timeouts) were all ZERO, the
+# eviction-capped cache held zero torn/zero-byte objects, and the disk had ample
+# free space (not a disk-full artifact). Blindly auto-disabling caching under load
+# is therefore NOT justified — it would forfeit the measured 25.6% build speedup
+# and INCREASE build pressure on the loaded machines that can least afford it, to
+# defend an unreproduced failure mode.
+#
+# What the incident DID expose is that sccache's error counters — the one signal
+# that WOULD catch real corruption — were invisible in the gate SUMMARY. So the
+# evidence-based mitigation is monitoring, not auto-disable: probe those counters
+# and surface a cache-health token (na|ok|warn) on the accelerators: line, with a
+# LOUD WARN when any counter is non-zero, WITHOUT disabling caching or failing the
+# gate. If a future *reproduced* incident correlates errors with load, the per-gate
+# counters are now recorded to drive that call on evidence.
+#
+# States: na (sccache not in use → nothing to probe), ok (all counters 0), warn
+# (any error/timeout counter > 0). Memoized and probed ONLY at SUMMARY emission
+# (accelerators_line); the latency-sensitive classify hooks exit before reaching it.
+
+# _sccache_error_sum: sum sccache's authoritative failure counters from
+# `sccache --show-stats`. Robust text parse (no jq/python dependency). 0 if sccache
+# is unavailable or stats can't be read (absence is not a health failure).
+_sccache_error_sum() {
+  command -v sccache >/dev/null 2>&1 || { printf 0; return; }
+  sccache --show-stats 2>/dev/null | awk '
+    /^Cache read errors/  { s += $NF }
+    /^Cache write errors/ { s += $NF }
+    /^Cache errors/       { s += $NF }
+    /^Cache timeouts/     { s += $NF }
+    END { print s + 0 }' 2>/dev/null || printf 0
+}
+
+# _sccache_health: resolve the cache-health state (na|ok|warn), memoized, emitting
+# the LOUD WARN exactly once when warn. Test hooks (self-test, issue #2641):
+# AGENT_GATE_TEST_SCCACHE_STATE overrides the detected ACCEL_SCCACHE state and
+# AGENT_GATE_TEST_SCCACHE_ERRORS forces the error sum — so the na/ok/warn decision
+# is asserted deterministically without sccache installed or PATH surgery.
+_SCCACHE_HEALTH=""
+_sccache_health() {
+  [ -n "$_SCCACHE_HEALTH" ] && { printf '%s' "$_SCCACHE_HEALTH"; return; }
+  local state="${AGENT_GATE_TEST_SCCACHE_STATE:-${ACCEL_SCCACHE:-absent}}"
+  if [ "$state" != on ]; then
+    _SCCACHE_HEALTH=na
+    printf '%s' "$_SCCACHE_HEALTH"
+    return
+  fi
+  local errsum
+  if [ -n "${AGENT_GATE_TEST_SCCACHE_ERRORS:-}" ]; then
+    errsum="$AGENT_GATE_TEST_SCCACHE_ERRORS"
+  else
+    errsum=$(_sccache_error_sum)
+  fi
+  case "$errsum" in *[!0-9]*|'') errsum=0 ;; esac
+  if [ "$errsum" -gt 0 ]; then
+    _SCCACHE_HEALTH=warn
+    echo "agent-gate: WARN: sccache reports ${errsum} cache read/write/error/timeout event(s) — possible corrupted or torn cache object(s); inspect 'sccache --show-stats' (caching left ENABLED — see the #2641 characterization; auto-disable is NOT evidence-supported)" >&2
+  else
+    _SCCACHE_HEALTH=ok
+  fi
+  printf '%s' "$_SCCACHE_HEALTH"
+}
+
 # accelerators_line: the machine-checkable one-liner stamped into every SUMMARY
 # block (full, lite, and the emission selftest). Values: on|absent|off|serial.
-# See the ACCEL_* detection above (#1848).
+# See the ACCEL_* detection above (#1848). The trailing sccache-health token
+# (na|ok|warn, issue #2641) surfaces sccache's own corruption counters.
 accelerators_line() {
-  printf 'accelerators: sccache=%s nextest=%s lanes=%s' \
-    "${ACCEL_SCCACHE:-unknown}" "${ACCEL_NEXTEST:-unknown}" "${ACCEL_LANES:-unknown}"
+  printf 'accelerators: sccache=%s nextest=%s lanes=%s sccache-health=%s' \
+    "${ACCEL_SCCACHE:-unknown}" "${ACCEL_NEXTEST:-unknown}" "${ACCEL_LANES:-unknown}" \
+    "$(_sccache_health)"
 }
 
 # ---- Per-gate core budget (issue #2640) -------------------------------------

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -64,7 +64,7 @@ assert_accelerators() {
     return
   fi
   if printf '%s\n' "$line" \
-       | grep -Eq '^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial)$'; then
+       | grep -Eq '^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial) sccache-health=(na|ok|warn)$'; then
     ok "$label: accelerators line well-formed ($line)"
   else
     bad "$label: malformed accelerators line: '$line'"
@@ -676,6 +676,72 @@ if [ "$accel_link_fail" -eq 0 ]; then
     bad "accel-absent: missing loud WARN for an absent accelerator"
     echo "------- stderr -------"; cat "$absent_err"; echo "----------------------"
   fi
+fi
+
+# 9c. sccache cache-health token (issue #2641). The accelerators line carries a
+#     trailing `sccache-health=na|ok|warn` token driven by sccache's OWN error
+#     counters (the characterization found the single "corruption under load"
+#     incident had zero supporting evidence — so the mitigation is MONITORING the
+#     real signal, not blindly auto-disabling caching under load). The state is
+#     decided by _sccache_health via two test hooks (AGENT_GATE_TEST_SCCACHE_STATE
+#     to force the sccache accelerator state, AGENT_GATE_TEST_SCCACHE_ERRORS to
+#     force the error sum) so na/ok/warn assert deterministically without sccache
+#     installed and without PATH surgery.
+#
+# 9c-i. sccache in use, ZERO error counters -> sccache-health=ok, NO corruption WARN.
+health_err="$tmp/health-ok.stderr"
+AGENT_GATE_SUMMARY_FILE="$tmp/health-ok.txt" \
+  AGENT_GATE_TEST_SCCACHE_STATE=on AGENT_GATE_TEST_SCCACHE_ERRORS=0 \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>"$health_err"
+if grep -qE '^accelerators: .* sccache-health=ok$' "$tmp/health-ok.txt"; then
+  ok "sccache-health: on + 0 errors -> sccache-health=ok"
+else
+  bad "sccache-health: expected sccache-health=ok for on + 0 errors"
+  grep '^accelerators:' "$tmp/health-ok.txt" 2>/dev/null || cat "$tmp/health-ok.txt"
+fi
+if grep -q 'WARN:.*corrupted or torn cache' "$health_err"; then
+  bad "sccache-health: emitted a corruption WARN with ZERO error counters"
+else
+  ok "sccache-health: no corruption WARN when error counters are zero"
+fi
+
+# 9c-ii. sccache in use, NON-ZERO error counters -> sccache-health=warn + LOUD WARN.
+AGENT_GATE_SUMMARY_FILE="$tmp/health-warn.txt" \
+  AGENT_GATE_TEST_SCCACHE_STATE=on AGENT_GATE_TEST_SCCACHE_ERRORS=3 \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>"$tmp/health-warn.stderr"
+if grep -qE '^accelerators: .* sccache-health=warn$' "$tmp/health-warn.txt"; then
+  ok "sccache-health: on + >0 errors -> sccache-health=warn"
+else
+  bad "sccache-health: expected sccache-health=warn for on + >0 errors"
+  grep '^accelerators:' "$tmp/health-warn.txt" 2>/dev/null || cat "$tmp/health-warn.txt"
+fi
+if grep -qE 'WARN: sccache reports 3 cache .* corrupted or torn cache' "$tmp/health-warn.stderr"; then
+  ok "sccache-health: LOUD WARN emitted (naming count + inspect command) on non-zero error counters"
+else
+  bad "sccache-health: missing LOUD corruption WARN on non-zero error counters"
+  echo "------- stderr -------"; cat "$tmp/health-warn.stderr"; echo "----------------------"
+fi
+# The mitigation must NOT disable caching or fail the gate on a warn (that would
+# increase build pressure — the exact anti-goal from the #2641 characterization).
+# Host-independent: a warn must never flip the sccache accelerator to `off`
+# (blind auto-disable). The sccache= field reflects the host (on when installed,
+# absent otherwise); the invariant is only that a health warn never disables it.
+if grep -qE '^accelerators: sccache=off ' "$tmp/health-warn.txt"; then
+  bad "sccache-health: sccache was disabled on a warn — the #2641 anti-goal"
+  grep '^accelerators:' "$tmp/health-warn.txt" 2>/dev/null || cat "$tmp/health-warn.txt"
+else
+  ok "sccache-health: caching NOT auto-disabled on a warn (no blind auto-disable)"
+fi
+
+# 9c-iii. sccache NOT in use -> sccache-health=na, nothing to probe, no WARN.
+AGENT_GATE_SUMMARY_FILE="$tmp/health-na.txt" \
+  AGENT_GATE_TEST_SCCACHE_STATE=off \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>"$tmp/health-na.stderr"
+if grep -qE '^accelerators: .* sccache-health=na$' "$tmp/health-na.txt"; then
+  ok "sccache-health: sccache not in use -> sccache-health=na"
+else
+  bad "sccache-health: expected sccache-health=na when sccache not in use"
+  grep '^accelerators:' "$tmp/health-na.txt" 2>/dev/null || cat "$tmp/health-na.txt"
 fi
 
 # ============================================================================


### PR DESCRIPTION
Closes #2641 (Epic #2636).

## Characterize-first outcome

**Conclusion: the single "sccache corruption under load (loadavg ~150)" incident has NO evidence of a load→corruption mechanism.** Full characterization posted to #2641. On a sustained-high-load gate machine (sccache 0.16.0, loadavg 55/55/72 at inspection):
- sccache's own authoritative error counters — `Cache read errors`, `Cache write errors`, `Cache errors`, `Cache timeouts` — are **all zero across ~31k requests**.
- The eviction-capped cache (10G/10G) holds **zero torn/zero-byte objects**.
- The cache disk has **426Gi free** — not a disk-full artifact.

The incident is most consistent with a transient, non-recurring artifact, not a systemic load-caused mechanism.

## Chosen mitigation: monitoring, NOT load-based auto-disable

Blindly auto-disabling caching under load is **not evidence-supported** — it would forfeit the measured 25.6% build speedup and *increase* build pressure on loaded machines. What the incident exposed is that sccache's error counters (the one signal that would catch real corruption) were invisible in the SUMMARY. So:

- Probe `sccache --show-stats` error counters at SUMMARY emission (memoized; never in latency-sensitive classify hooks).
- Append `sccache-health=na|ok|warn` to the machine-checkable `accelerators:` line.
- On any non-zero counter → **LOUD `WARN:` on STDERR** naming the count + pointing at `sccache --show-stats`. Caching stays **ENABLED**; the gate does **not** fail (no blind kill switch).
- Self-test case 9c (na/ok/warn + no-auto-disable invariant); `docs/development/gate-ops.md` updated.

Files: `scripts/agent-gate.sh`, `scripts/tests/test_agent_gate_summary.sh`, `docs/development/gate-ops.md`, `docs/development/agent-machine-setup.md`.

Self-test: `bash scripts/tests/test_agent_gate_summary.sh` → **67 passed / 0 failed**. Live gate accelerators line now reads `sccache-health=ok`.

## Lite gate

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 0492984b1 branch: issue-2641-sccache-corruption-characterize dirty: no
accelerators: sccache=on nextest=on lanes=on sccache-health=ok
cpu-budget: wrapper=taskpolicy ncpu=16 max-concurrency=1 cores-per-gate=16 build-jobs=16(derived) test-threads=16
file-size:         PASS (1s)
fmt:               PASS (13s)
clippy:            PASS (168s)
scoped-tests:      PASS (189s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
