### PR TITLE
harness(#2671): defuse TaskCompleted issue-gate hook — budgeted fail-open --lite, slot-aware, pgid-verified kills, no roborev

### DIFF
--- a/.claude/hooks/issue-gate.sh
+++ b/.claude/hooks/issue-gate.sh
@@ -225,6 +225,13 @@ elif [ -n "$TEST_CMD" ]; then
     fail "lite check failed — see the SUMMARY above; full output: $GATE_OUTPUT_LOG"
   fi
   rm -f "$AGENT_GATE_SUMMARY_FILE" "$GATE_OUTPUT_LOG" 2>/dev/null
+  # Scope the trap + export to the test block only (roborev 1817): clear the EXIT
+  # trap and drop the exported summary path so neither leaks into the coverage
+  # block below — that command runs its own gate and must not inherit this
+  # (now-removed) lite summary path. The fail/signal short-circuit path exits
+  # before here, so the trap has already served its safety-net purpose.
+  trap - EXIT
+  unset AGENT_GATE_SUMMARY_FILE
 else
   echo "issue-gate: ISSUE_GATE_TEST_CMD is unset — skipping the test check." 1>&2
 fi

--- a/.claude/hooks/issue-gate.sh
+++ b/.claude/hooks/issue-gate.sh
@@ -24,14 +24,19 @@
 #     interval ramps 0.2s -> 2s, so the effective ceiling is budget + ~2s poll slop
 #     + 2s TERM grace (still far under the 600s hook timeout).
 #   * No hook path runs roborev anymore — the flow-* review pipeline owns reviews.
+#   * If a FULL gate currently holds a machine-wide concurrency slot, the advisory
+#     check is SKIPPED — yielding to the gate of record is always correct (#1930/#2640).
 #   * If the repo has no Rust diff vs origin/main the advisory --lite test is
 #     intentionally SKIPPED (matching --lite's blast-radius philosophy) — a non-Rust
 #     diff is left uncovered by this test. A wired coverage command still runs.
-#   * On a genuine FAIL the lite SUMMARY block is echoed into the block reason before
-#     the summary file is removed — the SUMMARY is the only retainable text (doctrine).
+#   * The gate's own verbose output goes to a temp log; on a genuine FAIL the block
+#     reason is ONLY the lite SUMMARY block + the log path — never the raw log
+#     (mirroring the doctrine invocation: read the SUMMARY, never the gate log).
+#   * The FAILING-OPEN notice is emitted on BOTH stdout and stderr so it reaches the
+#     session (hook stdout is surfaced on a success/exit-0 completion).
 #
 # Exit 2 -> blocks completion (a genuine lite FAIL); stderr is fed back as the
-# reason. Exit 0 -> allowed (PASS, no-diff skip, or a fail-open timeout).
+# reason. Exit 0 -> allowed (PASS, slot/no-diff skip, or a fail-open timeout).
 #
 # Configure via env (set in .claude/settings.json "env" or your shell):
 #   ISSUE_GATE_TEST_CMD           the fast check, e.g. "scripts/agent-gate.sh --lite"
@@ -62,8 +67,40 @@ fail() {
 warn_line() {
   # Advisory-only warning helper. It NEVER exits — the caller decides whether to
   # continue (e.g. so a wired coverage command still runs after a fail-open timeout).
-  echo "issue-gate: WARNING — $1" 1>&2
-  echo "issue-gate: (advisory hook only; the gate of record is the flow-closer's full gate)." 1>&2
+  # Emitted on BOTH stdout (surfaced to the session on an exit-0 completion) and
+  # stderr (always visible), so a FAILING-OPEN notice can never be swallowed (#2671).
+  printf 'issue-gate: WARNING — %s\nissue-gate: (advisory hook only; the gate of record is the flow-closer'"'"'s full gate).\n' "$1"
+  printf 'issue-gate: WARNING — %s\nissue-gate: (advisory hook only; the gate of record is the flow-closer'"'"'s full gate).\n' "$1" 1>&2
+}
+
+# full_gate_active: true (0) when a FULL agent-gate run currently HOLDS one of the
+# machine-wide concurrency slots (issue #1825). Slots live under
+# $CQLITE_GATE_SLOTS_DIR (default ${TMPDIR:-/tmp}/cqlite-gate-slots) as slot.N files
+# held by a live daemon via a non-blocking fcntl.flock (LOCK_EX). Existence alone is
+# stale-prone (the file survives the gate), so we TEST the lock: python3 tries a
+# non-blocking flock on each slot; a slot it cannot lock is held -> a gate is active.
+# No python3 (or no dir) -> we cannot tell -> return false (fail toward running).
+full_gate_active() {
+  local dir="${CQLITE_GATE_SLOTS_DIR:-${TMPDIR:-/tmp}/cqlite-gate-slots}"
+  [ -d "$dir" ] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - "$dir" <<'PY'
+import sys, os, fcntl, glob
+d = sys.argv[1]
+for p in glob.glob(os.path.join(d, "slot.*")):
+    try:
+        fd = os.open(p, os.O_RDWR)
+    except OSError:
+        continue
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        sys.exit(0)   # locked -> a full gate holds this slot
+    finally:
+        os.close(fd)
+sys.exit(1)           # no held slot found
+PY
 }
 
 # --- Resolve the repo root from THIS hook file, never the session cwd (#2671) ---
@@ -72,6 +109,14 @@ REPO_ROOT="$(git -C "$HOOK_DIR" rev-parse --show-toplevel 2>/dev/null || echo ""
 if [ -z "$REPO_ROOT" ]; then
   # No repo root -> nothing this advisory hook can run; exit clean (never block).
   warn_line "could not resolve the repo root from ${HOOK_DIR:-<unknown>}; skipping the advisory check."
+  exit 0
+fi
+
+# --- Slot-aware skip: yield to the gate of record (#1930/#2640) ---
+# If a FULL gate holds a slot, an advisory --lite run would contend for CPU/slots
+# invisibly — the exact hazard this defusal closes. Skip the whole advisory check.
+if full_gate_active; then
+  echo "issue-gate: full gate active — advisory check skipped" 1>&2
   exit 0
 fi
 
@@ -90,8 +135,11 @@ if git -C "$REPO_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; t
 fi
 
 # --- Run the test command under a wall-clock budget, from the repo root ---
-# run_budgeted <budget-secs> <shell-command-string>
-#   returns 0 on success, the child's exit code on genuine failure, 124 on timeout.
+# run_budgeted <budget-secs> <shell-command-string> <output-log>
+#   Returns the child's real exit code; sets the GLOBAL BUDGET_TIMED_OUT=1 (never a
+#   124 sentinel — a child that genuinely exits 124 must still BLOCK) when it killed
+#   the child for exceeding the budget. Command output goes to <output-log> (never to
+#   this hook's stderr) so a FAIL reason can be ONLY the SUMMARY + the log path.
 # Portable (no GNU `timeout` dependency — stock macOS lacks it): `set -m` puts the
 # backgrounded command in its OWN process group (group id == $!), so on a timeout we
 # kill the NEGATIVE pid (the whole group: the subshell, the gate, and any cargo/gate
@@ -102,10 +150,12 @@ fi
 # accounting, no drift. On timeout we group-kill with a direct-pid fallback and the
 # final wait can never block. The poll interval ramps 0.2s -> 2s to stay cheap, so the
 # effective ceiling is budget + ~2s poll slop + 2s TERM grace.
+BUDGET_TIMED_OUT=0
 run_budgeted() {
-  local budget="$1" cmd="$2" pid t0 interval_tenths=2
+  local budget="$1" cmd="$2" log="$3" pid t0 interval_tenths=2
+  BUDGET_TIMED_OUT=0
   set -m
-  ( cd "$REPO_ROOT" && eval "$cmd" ) </dev/null 1>&2 &
+  ( cd "$REPO_ROOT" && eval "$cmd" ) >"$log" 2>&1 </dev/null &
   pid=$!
   set +m
   t0=$(date +%s)
@@ -116,6 +166,7 @@ run_budgeted() {
       sleep 2
       kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null || true
+      BUDGET_TIMED_OUT=1
       return 124
     fi
     sleep "$(printf '%d.%d' "$((interval_tenths / 10))" "$((interval_tenths % 10))")"
@@ -129,28 +180,30 @@ run_budgeted() {
 if [ "$SKIP_TEST" = "1" ]; then
   echo "issue-gate: no Rust diff vs origin/main — the advisory --lite test is intentionally skipped (#2671)." 1>&2
 elif [ -n "$TEST_CMD" ]; then
-  # Unique summary path so concurrent/foreign gates never contend on one file (#2671/#2079).
+  # Unique summary + log paths so concurrent/foreign gates never contend (#2671/#2079).
   AGENT_GATE_SUMMARY_FILE="$(mktemp -t issue-gate-lite-summary.XXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}/issue-gate-lite-summary.$$")"
+  GATE_OUTPUT_LOG="$(mktemp -t issue-gate-lite.XXXXXX.log 2>/dev/null || echo "${TMPDIR:-/tmp}/issue-gate-lite.$$.log")"
   export AGENT_GATE_SUMMARY_FILE
-  run_budgeted "$LITE_BUDGET_SECS" "$TEST_CMD"
+  run_budgeted "$LITE_BUDGET_SECS" "$TEST_CMD" "$GATE_OUTPUT_LOG"
   rc=$?
-  if [ "$rc" -eq 124 ]; then
-    rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
+  if [ "$BUDGET_TIMED_OUT" = "1" ]; then
+    rm -f "$AGENT_GATE_SUMMARY_FILE" "$GATE_OUTPUT_LOG" 2>/dev/null
     # FAIL OPEN on a budget overrun: warn and fall through (never block; a wired
-    # coverage command still runs, then the hook exits 0).
+    # coverage command still runs, then the hook exits 0). A genuine child exit 124
+    # is NOT a timeout (BUDGET_TIMED_OUT stays 0) and takes the block path below.
     warn_line "the lite check ('$TEST_CMD') exceeded its ${LITE_BUDGET_SECS}s budget — FAILING OPEN."
   elif [ "$rc" -ne 0 ]; then
-    # Echo the SUMMARY block (the only retainable text, per doctrine) into the block
-    # reason BEFORE removing the file.
+    # Block reason = ONLY the SUMMARY block (the only retainable text, per doctrine)
+    # plus the log path — never the raw gate log.
     if [ -s "$AGENT_GATE_SUMMARY_FILE" ]; then
       echo "issue-gate: --- lite gate SUMMARY (retainable text) ---" 1>&2
       cat "$AGENT_GATE_SUMMARY_FILE" 1>&2
       echo "issue-gate: --- end lite gate SUMMARY ---" 1>&2
     fi
     rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
-    fail "Lite check failed ('$TEST_CMD'). Fix the failures before marking this issue done (the full gate of record is the flow-closer's)."
+    fail "lite check failed — see the SUMMARY above; full output: $GATE_OUTPUT_LOG"
   fi
-  rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
+  rm -f "$AGENT_GATE_SUMMARY_FILE" "$GATE_OUTPUT_LOG" 2>/dev/null
 else
   echo "issue-gate: ISSUE_GATE_TEST_CMD is unset — skipping the test check." 1>&2
 fi

--- a/.claude/hooks/issue-gate.sh
+++ b/.claude/hooks/issue-gate.sh
@@ -31,7 +31,9 @@
 #     diff is left uncovered by this test. A wired coverage command still runs.
 #   * The gate's own verbose output goes to a temp log; on a genuine FAIL the block
 #     reason is ONLY the lite SUMMARY block + the log path — never the raw log
-#     (mirroring the doctrine invocation: read the SUMMARY, never the gate log).
+#     (mirroring the doctrine invocation: read the SUMMARY, never the gate log). The
+#     summary file is removed via an EXIT trap; the output log is RETAINED on a FAIL
+#     (so the block reason's path resolves) and removed on PASS/timeout.
 #   * The FAILING-OPEN notice is emitted on BOTH stdout and stderr so it reaches the
 #     session (hook stdout is surfaced on a success/exit-0 completion).
 #
@@ -73,12 +75,15 @@ warn_line() {
   printf 'issue-gate: WARNING — %s\nissue-gate: (advisory hook only; the gate of record is the flow-closer'"'"'s full gate).\n' "$1" 1>&2
 }
 
-# full_gate_active: true (0) when a FULL agent-gate run currently HOLDS one of the
-# machine-wide concurrency slots (issue #1825). Slots live under
-# $CQLITE_GATE_SLOTS_DIR (default ${TMPDIR:-/tmp}/cqlite-gate-slots) as slot.N files
-# held by a live daemon via a non-blocking fcntl.flock (LOCK_EX). Existence alone is
-# stale-prone (the file survives the gate), so we TEST the lock: python3 tries a
-# non-blocking flock on each slot; a slot it cannot lock is held -> a gate is active.
+# full_gate_active: true (0) when ANY gate slot holder currently holds one of the
+# machine-wide concurrency slots (issue #1825). In practice only FULL gates take a
+# slot (--lite self-exempts), so a held slot means the gate of record is running;
+# distinguishing full-vs-lite holders is not worth a new slot-file protocol here.
+# Slots live under $CQLITE_GATE_SLOTS_DIR (default ${TMPDIR:-/tmp}/cqlite-gate-slots)
+# as slot.N files held by a live daemon via a non-blocking fcntl.flock (LOCK_EX).
+# Existence alone is stale-prone (the file survives the gate), so we TEST the lock:
+# python3 tries a non-blocking flock on each slot; a slot it cannot lock (or cannot
+# even open, because another UID's live gate owns it) is held -> a gate is active.
 # No python3 (or no dir) -> we cannot tell -> return false (fail toward running).
 full_gate_active() {
   local dir="${CQLITE_GATE_SLOTS_DIR:-${TMPDIR:-/tmp}/cqlite-gate-slots}"
@@ -90,13 +95,15 @@ d = sys.argv[1]
 for p in glob.glob(os.path.join(d, "slot.*")):
     try:
         fd = os.open(p, os.O_RDWR)
+    except PermissionError:
+        sys.exit(0)   # another UID owns the slot file -> its live gate holds it
     except OSError:
         continue
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         fcntl.flock(fd, fcntl.LOCK_UN)
     except OSError:
-        sys.exit(0)   # locked -> a full gate holds this slot
+        sys.exit(0)   # locked -> a gate holds this slot
     finally:
         os.close(fd)
 sys.exit(1)           # no held slot found
@@ -152,7 +159,7 @@ fi
 # effective ceiling is budget + ~2s poll slop + 2s TERM grace.
 BUDGET_TIMED_OUT=0
 run_budgeted() {
-  local budget="$1" cmd="$2" log="$3" pid t0 interval_tenths=2
+  local budget="$1" cmd="$2" log="$3" pid t0 interval_tenths=2 child_pgid
   BUDGET_TIMED_OUT=0
   set -m
   ( cd "$REPO_ROOT" && eval "$cmd" ) >"$log" 2>&1 </dev/null &
@@ -161,10 +168,20 @@ run_budgeted() {
   t0=$(date +%s)
   while kill -0 "$pid" 2>/dev/null; do
     if [ "$(( $(date +%s) - t0 ))" -ge "$budget" ]; then
-      # Group kill (negative pid) with a direct-child fallback; never hang on wait.
-      kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
-      sleep 2
-      kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+      # SAFETY: only signal the process GROUP when the child actually leads its own
+      # group (pgid == pid) — i.e. `set -m` really gave it one. If `set -m` silently
+      # failed, the child shares OUR group, and a negative-pid kill would signal this
+      # hook's own session; fall back to a direct single-process kill in that case.
+      child_pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')
+      if [ -n "$child_pgid" ] && [ "$child_pgid" = "$pid" ]; then
+        kill -TERM "-$child_pgid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+        sleep 2
+        kill -KILL "-$child_pgid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+      else
+        kill -TERM "$pid" 2>/dev/null
+        sleep 2
+        kill -KILL "$pid" 2>/dev/null
+      fi
       wait "$pid" 2>/dev/null || true
       BUDGET_TIMED_OUT=1
       return 124
@@ -183,6 +200,10 @@ elif [ -n "$TEST_CMD" ]; then
   # Unique summary + log paths so concurrent/foreign gates never contend (#2671/#2079).
   AGENT_GATE_SUMMARY_FILE="$(mktemp -t issue-gate-lite-summary.XXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}/issue-gate-lite-summary.$$")"
   GATE_OUTPUT_LOG="$(mktemp -t issue-gate-lite.XXXXXX.log 2>/dev/null || echo "${TMPDIR:-/tmp}/issue-gate-lite.$$.log")"
+  # Always remove the summary file on exit, even if fail()/a signal short-circuits the
+  # explicit rm below. The output log is intentionally NOT cleaned here — it is retained
+  # on a FAIL so the block reason's log path stays valid (see header).
+  trap 'rm -f "${AGENT_GATE_SUMMARY_FILE:-}"' EXIT
   export AGENT_GATE_SUMMARY_FILE
   run_budgeted "$LITE_BUDGET_SECS" "$TEST_CMD" "$GATE_OUTPUT_LOG"
   rc=$?

--- a/.claude/hooks/issue-gate.sh
+++ b/.claude/hooks/issue-gate.sh
@@ -1,23 +1,41 @@
 #!/usr/bin/env bash
 # .claude/hooks/issue-gate.sh
 #
-# TaskCompleted gate. An issue's task cannot be marked complete until:
-#   1. the project's tests pass,
-#   2. (optional) a coverage command passes its own threshold,
-#   3. roborev has no failing reviews for the current branch.
+# TaskCompleted advisory gate. Runs a FAST sanity check when a task is marked
+# complete. It is deliberately NOT the gate of record — that is the flow-closer's
+# ONE full `scripts/agent-gate.sh` run, immediately pre-merge (see CLAUDE.md).
 #
-# Exit 2 -> blocks completion; stderr is fed back as the reason. Exit 0 -> allowed.
+# DEFUSED for issue #2671 (epic #2664 harness audit). The prior version pointed
+# ISSUE_GATE_TEST_CMD at the FULL gate (`scripts/agent-gate.sh`, 12-25 min) under
+# this hook's 600s timeout, ran it from whatever cwd the session happened to have
+# (field-observed firing full gates from the MAIN checkout), and blocked on a
+# synchronous `roborev --wait`. It could not succeed and contended for gate slots
+# invisibly. The defusal:
+#   * ISSUE_GATE_TEST_CMD now points at the LITE gate (`scripts/agent-gate.sh --lite`).
+#   * The test command runs from the REPO ROOT of THIS hook file (derived from
+#     BASH_SOURCE via git rev-parse), never the session cwd, with a UNIQUE mktemp
+#     AGENT_GATE_SUMMARY_FILE so concurrent gates never contend on one summary path.
+#   * A wall-clock budget (ISSUE_GATE_LITE_BUDGET_SECS, default 480s) fits inside the
+#     600s hook timeout with margin; exceeding it FAILS OPEN with a visible warning
+#     (task completion is NEVER blocked on a timeout — this hook is advisory).
+#   * No hook path runs roborev anymore — the flow-* review pipeline owns reviews.
+#   * If the repo has no Rust diff vs origin/main the hook skips entirely (cheap
+#     early-exit, matching --lite's blast-radius philosophy).
+#
+# Exit 2 -> blocks completion (a genuine lite FAIL); stderr is fed back as the
+# reason. Exit 0 -> allowed (PASS, no-diff skip, or a fail-open timeout).
 #
 # Configure via env (set in .claude/settings.json "env" or your shell):
-#   ISSUE_GATE_TEST_CMD       e.g. "make test"
-#   ISSUE_GATE_COVERAGE_CMD   exits non-zero when coverage is under threshold
-#   ISSUE_GATE_ROBOREV        "1" (default) to run the roborev branch gate, "0" to skip
+#   ISSUE_GATE_TEST_CMD           the fast check, e.g. "scripts/agent-gate.sh --lite"
+#   ISSUE_GATE_COVERAGE_CMD       exits non-zero when coverage is under threshold
+#   ISSUE_GATE_LITE_BUDGET_SECS   wall-clock budget for the test cmd (default 480)
 
 EVENT_JSON="$(cat || true)"   # TaskCompleted event JSON on stdin (context only)
+: "${EVENT_JSON:=}"           # referenced only for context; keep shellcheck quiet
 
 TEST_CMD="${ISSUE_GATE_TEST_CMD:-}"
 COVERAGE_CMD="${ISSUE_GATE_COVERAGE_CMD:-}"
-ROBOREV_ENABLED="${ISSUE_GATE_ROBOREV:-1}"
+LITE_BUDGET_SECS="${ISSUE_GATE_LITE_BUDGET_SECS:-480}"
 
 fail() {
   echo "Issue gate blocked task completion:" 1>&2
@@ -25,31 +43,82 @@ fail() {
   exit 2
 }
 
+warn_open() {
+  # Advisory-only fail-open: never block task completion. The gate of record is
+  # the flow-closer's full gate.
+  echo "issue-gate: WARNING — $1" 1>&2
+  echo "issue-gate: FAILING OPEN (advisory hook only; the gate of record is the flow-closer's full gate)." 1>&2
+  exit 0
+}
+
+# --- Resolve the repo root from THIS hook file, never the session cwd (#2671) ---
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(git -C "$HOOK_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [ -z "$REPO_ROOT" ]; then
+  warn_open "could not resolve the repo root from ${HOOK_DIR:-<unknown>}; skipping the advisory check."
+fi
+
+# --- Cheap early-exit: no Rust diff vs origin/main -> nothing for --lite to do ---
+# Only skip when we can POSITIVELY determine there is no Rust change; if the base
+# ref is unresolvable we fall through and run the check (conservative).
+if git -C "$REPO_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  RUST_DIFF="$(git -C "$REPO_ROOT" diff --name-only origin/main...HEAD -- '*.rs' 2>/dev/null || echo "")"
+  if [ -z "$RUST_DIFF" ]; then
+    echo "issue-gate: no Rust diff vs origin/main — skipping the advisory --lite check (#2671)." 1>&2
+    exit 0
+  fi
+fi
+
+# --- Run the test command under a wall-clock budget, from the repo root ---
+# run_budgeted <budget-secs> <shell-command-string>
+#   returns 0 on success, the child's exit code on genuine failure, 124 on timeout.
+# Portable (no GNU `timeout` dependency — stock macOS lacks it): backgrounds the
+# command and polls, TERM/KILL-ing it if the budget is exceeded.
+run_budgeted() {
+  local budget="$1" cmd="$2" pid waited=0
+  ( cd "$REPO_ROOT" && eval "$cmd" ) </dev/null 1>&2 &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$budget" ]; then
+      kill -TERM "$pid" 2>/dev/null
+      sleep 2
+      kill -KILL "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      return 124
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  wait "$pid"
+  return $?
+}
+
 if [ -n "$TEST_CMD" ]; then
-  if ! eval "$TEST_CMD" 1>&2; then
-    fail "Tests failed ('$TEST_CMD'). Fix the failures before marking this issue done."
+  # Unique summary path so concurrent/foreign gates never contend on one file (#2671/#2079).
+  AGENT_GATE_SUMMARY_FILE="$(mktemp -t issue-gate-lite-summary.XXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}/issue-gate-lite-summary.$$")"
+  export AGENT_GATE_SUMMARY_FILE
+  run_budgeted "$LITE_BUDGET_SECS" "$TEST_CMD"
+  rc=$?
+  rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
+  if [ "$rc" -eq 124 ]; then
+    warn_open "the lite check ('$TEST_CMD') exceeded its ${LITE_BUDGET_SECS}s budget."
+  elif [ "$rc" -ne 0 ]; then
+    fail "Lite check failed ('$TEST_CMD'). Fix the failures before marking this issue done (the full gate of record is the flow-closer's)."
   fi
 else
   echo "issue-gate: ISSUE_GATE_TEST_CMD is unset — skipping the test check." 1>&2
 fi
 
 if [ -n "$COVERAGE_CMD" ]; then
-  if ! eval "$COVERAGE_CMD" 1>&2; then
+  if ! ( cd "$REPO_ROOT" && eval "$COVERAGE_CMD" ) 1>&2; then
     fail "Coverage check failed ('$COVERAGE_CMD'). Add tests until coverage meets the threshold."
   fi
 fi
 
-# roborev: no unresolved findings on the current branch. --wait gives a synchronous
-# verdict (exit 0 = PASS, 1 = FAIL). Use --branch= with the equals sign. If you rely on
-# roborev's post-commit hook, you can swap the line below for `roborev wait` to avoid
-# enqueuing a duplicate review job.
-if [ "$ROBOREV_ENABLED" = "1" ] && command -v roborev >/dev/null 2>&1; then
-  BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
-  if [ -n "$BRANCH" ] && [ "$BRANCH" != "HEAD" ]; then
-    if ! roborev review --branch="$BRANCH" --wait --quiet 1>&2; then
-      fail "roborev found unresolved issues on branch '$BRANCH'. Open 'roborev tui' or run '/roborev-fix', resolve them, then retry."
-    fi
-  fi
-fi
+# roborev: intentionally NOT run from this hook (#2671). A TaskCompleted hook must
+# not launch a review — the flow-* delivery pipeline (rust-reviewer + roborev on the
+# lite-green diff, then the flow-closer's final roborev pass) owns all reviews. The
+# prior synchronous `roborev review --wait` here double-enqueued jobs and blocked
+# task completion for minutes. Do not reintroduce it.
 
 exit 0

--- a/.claude/hooks/issue-gate.sh
+++ b/.claude/hooks/issue-gate.sh
@@ -17,10 +17,18 @@
 #     AGENT_GATE_SUMMARY_FILE so concurrent gates never contend on one summary path.
 #   * A wall-clock budget (ISSUE_GATE_LITE_BUDGET_SECS, default 480s) fits inside the
 #     600s hook timeout with margin; exceeding it FAILS OPEN with a visible warning
-#     (task completion is NEVER blocked on a timeout — this hook is advisory).
+#     (task completion is NEVER blocked on a timeout — this hook is advisory). On a
+#     timeout the ENTIRE process group is killed (TERM, 2s grace, then KILL), so a
+#     backgrounded cargo/gate grandchild can never keep contending for gate slots
+#     invisibly — the exact failure mode this defusal exists to close. The poll
+#     interval ramps 0.2s -> 2s, so the effective ceiling is budget + ~2s poll slop
+#     + 2s TERM grace (still far under the 600s hook timeout).
 #   * No hook path runs roborev anymore — the flow-* review pipeline owns reviews.
-#   * If the repo has no Rust diff vs origin/main the hook skips entirely (cheap
-#     early-exit, matching --lite's blast-radius philosophy).
+#   * If the repo has no Rust diff vs origin/main the advisory --lite test is
+#     intentionally SKIPPED (matching --lite's blast-radius philosophy) — a non-Rust
+#     diff is left uncovered by this test. A wired coverage command still runs.
+#   * On a genuine FAIL the lite SUMMARY block is echoed into the block reason before
+#     the summary file is removed — the SUMMARY is the only retainable text (doctrine).
 #
 # Exit 2 -> blocks completion (a genuine lite FAIL); stderr is fed back as the
 # reason. Exit 0 -> allowed (PASS, no-diff skip, or a fail-open timeout).
@@ -58,53 +66,73 @@ if [ -z "$REPO_ROOT" ]; then
   warn_open "could not resolve the repo root from ${HOOK_DIR:-<unknown>}; skipping the advisory check."
 fi
 
-# --- Cheap early-exit: no Rust diff vs origin/main -> nothing for --lite to do ---
+# --- Cheap skip: no Rust diff vs origin/main -> nothing for --lite to do ---
+# This short-circuits ONLY the TEST_CMD block (a wired coverage command still runs).
 # Only skip when we can POSITIVELY determine there is no Rust change; if the base
 # ref is unresolvable we fall through and run the check (conservative).
+SKIP_TEST=0
 if git -C "$REPO_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
   RUST_DIFF="$(git -C "$REPO_ROOT" diff --name-only origin/main...HEAD -- '*.rs' 2>/dev/null || echo "")"
   if [ -z "$RUST_DIFF" ]; then
-    echo "issue-gate: no Rust diff vs origin/main — skipping the advisory --lite check (#2671)." 1>&2
-    exit 0
+    SKIP_TEST=1
   fi
 fi
 
 # --- Run the test command under a wall-clock budget, from the repo root ---
 # run_budgeted <budget-secs> <shell-command-string>
 #   returns 0 on success, the child's exit code on genuine failure, 124 on timeout.
-# Portable (no GNU `timeout` dependency — stock macOS lacks it): backgrounds the
-# command and polls, TERM/KILL-ing it if the budget is exceeded.
+# Portable (no GNU `timeout` dependency — stock macOS lacks it): `set -m` puts the
+# backgrounded command in its OWN process group (group id == $!), so on a timeout we
+# kill the NEGATIVE pid (the whole group: the subshell, the gate, and any cargo/gate
+# grandchildren) — a direct-child-only kill would orphan the grandchild to keep
+# contending for gate slots, the very failure this defusal closes. `set +m` right
+# after the fork silences async job-completion notices without moving the child back
+# out of its group. The poll interval ramps 0.2s -> 2s to keep a fast check cheap.
 run_budgeted() {
-  local budget="$1" cmd="$2" pid waited=0
+  local budget="$1" cmd="$2" pid waited=0 interval="0.2"
+  set -m
   ( cd "$REPO_ROOT" && eval "$cmd" ) </dev/null 1>&2 &
   pid=$!
+  set +m
   while kill -0 "$pid" 2>/dev/null; do
-    if [ "$waited" -ge "$budget" ]; then
-      kill -TERM "$pid" 2>/dev/null
+    if awk "BEGIN{exit !($waited >= $budget)}"; then
+      kill -TERM -"$pid" 2>/dev/null
       sleep 2
-      kill -KILL "$pid" 2>/dev/null
+      kill -KILL -"$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
       return 124
     fi
-    sleep 2
-    waited=$((waited + 2))
+    sleep "$interval"
+    waited=$(awk "BEGIN{printf \"%.1f\", $waited + $interval}")
+    interval=$(awk "BEGIN{n=$interval*2; if(n>2)n=2; printf \"%.1f\", n}")
   done
   wait "$pid"
   return $?
 }
 
-if [ -n "$TEST_CMD" ]; then
+if [ "$SKIP_TEST" = "1" ]; then
+  echo "issue-gate: no Rust diff vs origin/main — the advisory --lite test is intentionally skipped (#2671)." 1>&2
+elif [ -n "$TEST_CMD" ]; then
   # Unique summary path so concurrent/foreign gates never contend on one file (#2671/#2079).
   AGENT_GATE_SUMMARY_FILE="$(mktemp -t issue-gate-lite-summary.XXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}/issue-gate-lite-summary.$$")"
   export AGENT_GATE_SUMMARY_FILE
   run_budgeted "$LITE_BUDGET_SECS" "$TEST_CMD"
   rc=$?
-  rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
   if [ "$rc" -eq 124 ]; then
+    rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
     warn_open "the lite check ('$TEST_CMD') exceeded its ${LITE_BUDGET_SECS}s budget."
   elif [ "$rc" -ne 0 ]; then
+    # Echo the SUMMARY block (the only retainable text, per doctrine) into the block
+    # reason BEFORE removing the file.
+    if [ -s "$AGENT_GATE_SUMMARY_FILE" ]; then
+      echo "issue-gate: --- lite gate SUMMARY (retainable text) ---" 1>&2
+      cat "$AGENT_GATE_SUMMARY_FILE" 1>&2
+      echo "issue-gate: --- end lite gate SUMMARY ---" 1>&2
+    fi
+    rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
     fail "Lite check failed ('$TEST_CMD'). Fix the failures before marking this issue done (the full gate of record is the flow-closer's)."
   fi
+  rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
 else
   echo "issue-gate: ISSUE_GATE_TEST_CMD is unset — skipping the test check." 1>&2
 fi

--- a/.claude/hooks/issue-gate.sh
+++ b/.claude/hooks/issue-gate.sh
@@ -45,35 +45,46 @@ TEST_CMD="${ISSUE_GATE_TEST_CMD:-}"
 COVERAGE_CMD="${ISSUE_GATE_COVERAGE_CMD:-}"
 LITE_BUDGET_SECS="${ISSUE_GATE_LITE_BUDGET_SECS:-480}"
 
+# Validate the budget numerically before any arithmetic uses it (a non-integer would
+# break the `[ ... -ge ]` test and could hang the poll). Fall back to the default.
+case "$LITE_BUDGET_SECS" in
+  ''|*[!0-9]*)
+    echo "issue-gate: WARNING — ISSUE_GATE_LITE_BUDGET_SECS='$LITE_BUDGET_SECS' is not a non-negative integer; using 480." 1>&2
+    LITE_BUDGET_SECS=480 ;;
+esac
+
 fail() {
   echo "Issue gate blocked task completion:" 1>&2
   echo "  $1" 1>&2
   exit 2
 }
 
-warn_open() {
-  # Advisory-only fail-open: never block task completion. The gate of record is
-  # the flow-closer's full gate.
+warn_line() {
+  # Advisory-only warning helper. It NEVER exits — the caller decides whether to
+  # continue (e.g. so a wired coverage command still runs after a fail-open timeout).
   echo "issue-gate: WARNING — $1" 1>&2
-  echo "issue-gate: FAILING OPEN (advisory hook only; the gate of record is the flow-closer's full gate)." 1>&2
-  exit 0
+  echo "issue-gate: (advisory hook only; the gate of record is the flow-closer's full gate)." 1>&2
 }
 
 # --- Resolve the repo root from THIS hook file, never the session cwd (#2671) ---
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 REPO_ROOT="$(git -C "$HOOK_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")"
 if [ -z "$REPO_ROOT" ]; then
-  warn_open "could not resolve the repo root from ${HOOK_DIR:-<unknown>}; skipping the advisory check."
+  # No repo root -> nothing this advisory hook can run; exit clean (never block).
+  warn_line "could not resolve the repo root from ${HOOK_DIR:-<unknown>}; skipping the advisory check."
+  exit 0
 fi
 
-# --- Cheap skip: no Rust diff vs origin/main -> nothing for --lite to do ---
+# --- Cheap skip: no Rust change (committed OR working-tree) -> nothing for --lite ---
 # This short-circuits ONLY the TEST_CMD block (a wired coverage command still runs).
-# Only skip when we can POSITIVELY determine there is no Rust change; if the base
-# ref is unresolvable we fall through and run the check (conservative).
+# Skip only when BOTH the committed diff vs origin/main AND the working tree are free
+# of *.rs changes. `|| echo x` on either query FAILS TOWARD RUNNING (a git error makes
+# the var non-empty, so we do NOT skip). If the base ref is unresolvable we run too.
 SKIP_TEST=0
 if git -C "$REPO_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
-  RUST_DIFF="$(git -C "$REPO_ROOT" diff --name-only origin/main...HEAD -- '*.rs' 2>/dev/null || echo "")"
-  if [ -z "$RUST_DIFF" ]; then
+  RUST_DIFF="$(git -C "$REPO_ROOT" diff --name-only origin/main...HEAD -- '*.rs' 2>/dev/null || echo x)"
+  RUST_DIRTY="$(git -C "$REPO_ROOT" status --porcelain -- '*.rs' 2>/dev/null || echo x)"
+  if [ -z "$RUST_DIFF" ] && [ -z "$RUST_DIRTY" ]; then
     SKIP_TEST=1
   fi
 fi
@@ -87,24 +98,29 @@ fi
 # grandchildren) — a direct-child-only kill would orphan the grandchild to keep
 # contending for gate slots, the very failure this defusal closes. `set +m` right
 # after the fork silences async job-completion notices without moving the child back
-# out of its group. The poll interval ramps 0.2s -> 2s to keep a fast check cheap.
+# out of its group. Elapsed time is real integer wall-clock (date +%s) — no float
+# accounting, no drift. On timeout we group-kill with a direct-pid fallback and the
+# final wait can never block. The poll interval ramps 0.2s -> 2s to stay cheap, so the
+# effective ceiling is budget + ~2s poll slop + 2s TERM grace.
 run_budgeted() {
-  local budget="$1" cmd="$2" pid waited=0 interval="0.2"
+  local budget="$1" cmd="$2" pid t0 interval_tenths=2
   set -m
   ( cd "$REPO_ROOT" && eval "$cmd" ) </dev/null 1>&2 &
   pid=$!
   set +m
+  t0=$(date +%s)
   while kill -0 "$pid" 2>/dev/null; do
-    if awk "BEGIN{exit !($waited >= $budget)}"; then
-      kill -TERM -"$pid" 2>/dev/null
+    if [ "$(( $(date +%s) - t0 ))" -ge "$budget" ]; then
+      # Group kill (negative pid) with a direct-child fallback; never hang on wait.
+      kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
       sleep 2
-      kill -KILL -"$pid" 2>/dev/null
-      wait "$pid" 2>/dev/null
+      kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null || true
       return 124
     fi
-    sleep "$interval"
-    waited=$(awk "BEGIN{printf \"%.1f\", $waited + $interval}")
-    interval=$(awk "BEGIN{n=$interval*2; if(n>2)n=2; printf \"%.1f\", n}")
+    sleep "$(printf '%d.%d' "$((interval_tenths / 10))" "$((interval_tenths % 10))")"
+    interval_tenths=$((interval_tenths * 2))
+    [ "$interval_tenths" -gt 20 ] && interval_tenths=20
   done
   wait "$pid"
   return $?
@@ -120,7 +136,9 @@ elif [ -n "$TEST_CMD" ]; then
   rc=$?
   if [ "$rc" -eq 124 ]; then
     rm -f "$AGENT_GATE_SUMMARY_FILE" 2>/dev/null
-    warn_open "the lite check ('$TEST_CMD') exceeded its ${LITE_BUDGET_SECS}s budget."
+    # FAIL OPEN on a budget overrun: warn and fall through (never block; a wired
+    # coverage command still runs, then the hook exits 0).
+    warn_line "the lite check ('$TEST_CMD') exceeded its ${LITE_BUDGET_SECS}s budget — FAILING OPEN."
   elif [ "$rc" -ne 0 ]; then
     # Echo the SUMMARY block (the only retainable text, per doctrine) into the block
     # reason BEFORE removing the file.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "agent": "flow-lead",
   "env": {
-    "ISSUE_GATE_TEST_CMD": "scripts/agent-gate.sh",
+    "ISSUE_GATE_TEST_CMD": "scripts/agent-gate.sh --lite",
     "ISSUE_GATE_COVERAGE_CMD": "",
     "CQLITE_PROJECT_OWNER": "pmcfadin",
     "CQLITE_PROJECT_NUMBER": "1"

--- a/docs/development/METHODOLOGY.md
+++ b/docs/development/METHODOLOGY.md
@@ -178,11 +178,15 @@ idea ──► spec (OpenSpec change) ──► epic + child issues ──► im
    issue/module, each in its own worktree) plus a `spec-auditor` and `coverage-reviewer`.
    Implementers follow the superpowers process (plan → TDD → implement) and **commit
    often** so reviews land while context is fresh. **[live]**
-4. **Gate.** A task cannot be marked done until `scripts/agent-gate.sh` passes — `cargo
-   fmt`, `clippy -D warnings`, core/integration/write/CLI tests, minimal-features build,
-   and smoke — emitting a machine-checkable summary block. Enforced by the `TaskCompleted`
-   hook (exit 2 blocks completion). **Paste the summary block verbatim; ad-hoc `cargo`
-   runs do not count as "the gate passed."** **[live]**
+4. **Gate.** `scripts/agent-gate.sh` — `cargo fmt`, `clippy -D warnings`,
+   core/integration/write/CLI tests, minimal-features build, and smoke — emits a
+   machine-checkable summary block; the **full gate of record runs once per issue inside
+   the closer** (`#719`/`#2084`), immediately pre-merge, and is the only run that counts.
+   The `TaskCompleted` hook is **advisory only** (`#2671`): it runs `scripts/agent-gate.sh
+   --lite` under a 480s budget inside the 600s hook timeout, **fails OPEN** on overrun
+   (process-group kill), yields to a running full gate, and is explicitly **NOT** the gate
+   of record — it never blocks task completion. **Paste the summary block verbatim; ad-hoc
+   `cargo` runs do not count as "the gate passed."** **[live]**
 5. **Review.** roborev (a second model family) reviews each commit/branch; clear its
    findings (`/roborev-fix`) before handing an issue off. **[live]**
 6. **Audit.** The `spec-auditor` confirms the implementation meets the spec; the

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2440,6 +2440,24 @@ run_tooling_tests() {
     return 0
   fi
 
+  # TaskCompleted issue-gate hook defusal self-test (#2671, epic #2664): no python3
+  # needed, always runs (hermetic — builds a throwaway repo, copies the real hook,
+  # and shims the gate + roborev; never runs the real gate). Asserts the hook wires
+  # --lite (never the full gate), uses a unique mktemp summary path from the hook's
+  # own repo root, fails OPEN on a budget overrun, and runs no roborev. A failure
+  # FAILs the component, mirroring the cpu-budget/delta/parity-report guards.
+  echo ">>> [$name] bash scripts/tests/test_issue_gate_hook.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_issue_gate_hook.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (issue-gate hook defusal self-test); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
   if ! command -v python3 >/dev/null 2>&1; then
     status=SKIP
     echo ">>> [$name] SKIP (no python3 on PATH; selftest truncation reader needs it)"

--- a/scripts/tests/test_issue_gate_hook.sh
+++ b/scripts/tests/test_issue_gate_hook.sh
@@ -62,6 +62,12 @@ RECORD="$tmp/gate-record.txt"
 ROBOREV_SENTINEL="$tmp/roborev-was-called.txt"
 SLEEP_FINISHED_MARKER="$tmp/sleep-grandchild-finished.txt"
 SLEEP_PID_FILE="$tmp/sleep-grandchild-pid.txt"
+# An EMPTY slots dir every case points at by default, so a real full gate running
+# on this machine (e.g. when this self-test runs INSIDE the gate) can never make the
+# hook's slot-aware skip fire and flip an unrelated assertion. The slot-skip case
+# overrides SLOTS_DIR with a dir holding a genuinely locked slot.
+EMPTY_SLOTS="$tmp/empty-slots"
+mkdir -p "$EMPTY_SLOTS"
 
 # Build a fake repo with the hook and a recording fake gate.
 build_repo() {
@@ -123,6 +129,7 @@ run_hook() {
       ISSUE_GATE_ROBOREV="1" \
       ISSUE_GATE_LITE_BUDGET_SECS="${BUDGET:-480}" \
       FAKE_GATE_MODE="${FAKE_GATE_MODE:-pass}" \
+      CQLITE_GATE_SLOTS_DIR="${SLOTS_DIR:-$EMPTY_SLOTS}" \
       PATH="$tmp/shim:$PATH" \
       bash "$repo/.claude/hooks/issue-gate.sh" )
 }
@@ -193,11 +200,17 @@ if [ "$rcB" -eq 2 ]; then
 else
   bad "lite FAIL produced exit $rcB (expected 2)"
 fi
-# fix #3: the SUMMARY block (the only retainable text) is echoed into the reason.
+# the SUMMARY block (the only retainable text) is echoed into the reason.
 if grep -q 'AGENT-GATE-LITE-SUMMARY-SENTINEL' "$failB_out"; then
   ok "FAIL path echoes the lite SUMMARY block into the block reason"
 else
   bad "FAIL path did not echo the lite SUMMARY block"
+fi
+# fix #1: the block reason names the log path, not the raw gate output.
+if grep -q 'full output:' "$failB_out"; then
+  ok "FAIL path names the log path in the block reason (raw output kept out of the reason)"
+else
+  bad "FAIL path did not name the log path"
 fi
 
 # --- Case C: budget exceeded FAILS OPEN + kills the whole process group ----------
@@ -209,7 +222,8 @@ build_repo "$repoC"
 : >"$RECORD"
 rm -f "$SLEEP_FINISHED_MARKER" "$SLEEP_PID_FILE"
 warn_out="$tmp/warn.txt"
-FAKE_GATE_MODE=sleep BUDGET=2 run_hook "$repoC" 2>"$warn_out"
+out_c="$tmp/out_c.txt"
+FAKE_GATE_MODE=sleep BUDGET=2 run_hook "$repoC" >"$out_c" 2>"$warn_out"
 rcC=$?
 if [ "$rcC" -eq 0 ]; then
   ok "timeout path fails OPEN (exit 0), never blocking on a budget overrun"
@@ -217,9 +231,15 @@ else
   bad "timeout path exited $rcC (expected 0 — fail open)"
 fi
 if grep -q 'FAILING OPEN' "$warn_out"; then
-  ok "timeout path emits a visible FAILING OPEN warning"
+  ok "timeout path emits a visible FAILING OPEN warning (stderr)"
 else
-  bad "timeout path did not emit a 'FAILING OPEN' warning"
+  bad "timeout path did not emit a 'FAILING OPEN' warning on stderr"
+fi
+# fix #4: the FAILING OPEN notice must also reach stdout (surfaced on exit-0).
+if grep -q 'FAILING OPEN' "$out_c"; then
+  ok "timeout path emits the FAILING OPEN notice on stdout too (reaches the session)"
+else
+  bad "timeout path did not emit the FAILING OPEN notice on stdout"
 fi
 
 # Read the grandchild PID (bounded poll — the file appears as soon as the shim starts).
@@ -261,7 +281,7 @@ build_repo "$repoC2"
 rm -f "$SLEEP_PID_FILE"
 cov_marker="$tmp/coverage-ran.txt"
 rm -f "$cov_marker"
-FAKE_GATE_MODE=sleep BUDGET=2 COV="touch $cov_marker" run_hook "$repoC2" 2>/dev/null
+FAKE_GATE_MODE=sleep BUDGET=2 COV="touch $cov_marker" run_hook "$repoC2" >/dev/null 2>&1
 rcC2=$?
 if [ "$rcC2" -eq 0 ] && [ -f "$cov_marker" ]; then
   ok "fail-open timeout falls through — a wired coverage command still runs (exit 0)"
@@ -301,6 +321,75 @@ if [ "$rcE" -eq 0 ] && [ -s "$RECORD" ]; then
   ok "dirty *.rs working tree runs the gate even with no committed diff (exit 0, gate invoked)"
 else
   bad "dirty *.rs working tree did not run the gate (rc=$rcE, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ))"
+fi
+
+# --- Case F: fix #5 — a non-integer budget warns, defaults to 480, and RUNS -------
+repoF="$tmp/repoF"
+build_repo "$repoF"
+: >"$RECORD"
+warnF_out="$tmp/warnF.txt"
+FAKE_GATE_MODE=pass BUDGET=abc run_hook "$repoF" 2>"$warnF_out"
+rcF=$?
+if [ "$rcF" -eq 0 ] && [ -s "$RECORD" ] && grep -q 'is not a non-negative integer' "$warnF_out"; then
+  ok "non-integer budget warns, defaults to 480, and runs the gate normally"
+else
+  bad "non-integer budget mishandled (rc=$rcF, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ), warned=$(grep -qc 'not a non-negative integer' "$warnF_out" && echo yes || echo no))"
+fi
+
+# --- Case G: fix #5 — hook invoked from a NON-git dir -> exit 0, gate never runs ---
+# The hook resolves its repo root from its own location; outside any git repo that
+# resolution fails, so it exits 0 without running anything.
+nongit_hooks="$tmp/nongit/.claude/hooks"
+mkdir -p "$nongit_hooks"
+cp "$HOOK_SRC" "$nongit_hooks/issue-gate.sh"
+chmod +x "$nongit_hooks/issue-gate.sh"
+: >"$RECORD"
+outG="$tmp/outG.txt"
+( cd "$tmp" && echo '{}' | GATE_RECORD="$RECORD" ISSUE_GATE_TEST_CMD="scripts/agent-gate.sh --lite" \
+    CQLITE_GATE_SLOTS_DIR="$EMPTY_SLOTS" PATH="$tmp/shim:$PATH" \
+    bash "$nongit_hooks/issue-gate.sh" ) >"$outG" 2>&1
+rcG=$?
+if [ "$rcG" -eq 0 ] && [ ! -s "$RECORD" ] && grep -q 'could not resolve the repo root' "$outG"; then
+  ok "non-git invocation exits 0 and never invokes the gate"
+else
+  bad "non-git invocation mishandled (rc=$rcG, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ))"
+fi
+
+# --- Case H: fix #2 — a full gate holding a slot -> advisory check skipped ---------
+if command -v python3 >/dev/null 2>&1; then
+  repoH="$tmp/repoH"
+  build_repo "$repoH"
+  live_slots="$tmp/live-slots"
+  mkdir -p "$live_slots"
+  slot_ready="$tmp/slot-ready.txt"
+  rm -f "$slot_ready"
+  # Background holder: flock slot.0 (LOCK_EX) and hold it, mimicking the live daemon.
+  python3 - "$live_slots" "$slot_ready" >/dev/null 2>&1 <<'PY' &
+import sys, os, fcntl, time
+d, ready = sys.argv[1], sys.argv[2]
+os.makedirs(d, exist_ok=True)
+fd = os.open(os.path.join(d, "slot.0"), os.O_RDWR | os.O_CREAT, 0o644)
+fcntl.flock(fd, fcntl.LOCK_EX)
+open(ready, "w").write("ok")
+time.sleep(30)
+PY
+  holder_pid=$!
+  # Wait for the holder to actually hold the lock (bounded).
+  waited=0
+  while [ "$waited" -lt 5 ] && [ ! -s "$slot_ready" ]; do sleep 1; waited=$((waited + 1)); done
+  : >"$RECORD"
+  outH="$tmp/outH.txt"
+  FAKE_GATE_MODE=pass SLOTS_DIR="$live_slots" run_hook "$repoH" >"$outH" 2>&1
+  rcH=$?
+  kill "$holder_pid" 2>/dev/null
+  wait "$holder_pid" 2>/dev/null
+  if [ "$rcH" -eq 0 ] && [ ! -s "$RECORD" ] && grep -q 'full gate active — advisory check skipped' "$outH"; then
+    ok "full gate holding a slot -> advisory check skipped (exit 0, gate never invoked)"
+  else
+    bad "slot-aware skip failed (rc=$rcH, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ), notice=$(grep -qc 'advisory check skipped' "$outH" && echo yes || echo no))"
+  fi
+else
+  ok "slot-aware skip case SKIPPED (no python3 — the hook's slot probe also no-ops without it)"
 fi
 
 echo

--- a/scripts/tests/test_issue_gate_hook.sh
+++ b/scripts/tests/test_issue_gate_hook.sh
@@ -61,6 +61,7 @@ trap 'rm -rf "$tmp"' EXIT
 RECORD="$tmp/gate-record.txt"
 ROBOREV_SENTINEL="$tmp/roborev-was-called.txt"
 SLEEP_FINISHED_MARKER="$tmp/sleep-grandchild-finished.txt"
+SLEEP_PID_FILE="$tmp/sleep-grandchild-pid.txt"
 
 # Build a fake repo with the hook and a recording fake gate.
 build_repo() {
@@ -84,10 +85,12 @@ case "${FAKE_GATE_MODE:-pass}" in
     # Emit a recognizable SUMMARY block so the hook's fail path can echo it.
     [ -n "${AGENT_GATE_SUMMARY_FILE:-}" ] && printf 'AGENT-GATE-LITE-SUMMARY-SENTINEL\nRESULT: FAIL\n' >"$AGENT_GATE_SUMMARY_FILE"
     exit 1 ;;
-  # sleep past the budget, then drop a marker. If the hook's timeout path only
-  # killed the direct child (not the process group), this grandchild survives and
-  # writes the marker — exactly the invisible-contention leak we must prevent.
-  sleep) sleep 6; echo done >"$SLEEP_FINISHED_MARKER"; exit 0 ;;
+  # Record this gate process's PID, then sleep LONG (30s) past a small budget and
+  # only then drop a marker. The de-flake: the assertion does not race the marker —
+  # it proves the process group was actually killed by checking the recorded PID is
+  # gone (bounded poll), well before the 30s marker could ever appear. If the hook
+  # killed only the direct child, this grandchild survives — kill -0 stays true.
+  sleep) echo "$$" >"$SLEEP_PID_FILE"; sleep 30; echo done >"$SLEEP_FINISHED_MARKER"; exit 0 ;;
   *)     exit 0 ;;
 esac
 EOF
@@ -114,8 +117,9 @@ run_hook() {
   ( cd "$tmp" && echo '{}' | \
       GATE_RECORD="$RECORD" \
       SLEEP_FINISHED_MARKER="$SLEEP_FINISHED_MARKER" \
+      SLEEP_PID_FILE="$SLEEP_PID_FILE" \
       ISSUE_GATE_TEST_CMD="scripts/agent-gate.sh --lite" \
-      ISSUE_GATE_COVERAGE_CMD="" \
+      ISSUE_GATE_COVERAGE_CMD="${COV:-}" \
       ISSUE_GATE_ROBOREV="1" \
       ISSUE_GATE_LITE_BUDGET_SECS="${BUDGET:-480}" \
       FAKE_GATE_MODE="${FAKE_GATE_MODE:-pass}" \
@@ -196,11 +200,14 @@ else
   bad "FAIL path did not echo the lite SUMMARY block"
 fi
 
-# --- Case C: budget exceeded FAILS OPEN (exit 0 + warning) ----------------------
+# --- Case C: budget exceeded FAILS OPEN + kills the whole process group ----------
+# Load-proof (no timing-coupled marker race): the grandchild records its PID then
+# sleeps 30s. We assert exit 0 + warning, then prove the process group is actually
+# gone by polling the recorded PID with a bounded cap (never the 30s marker).
 repoC="$tmp/repoC"
 build_repo "$repoC"
 : >"$RECORD"
-rm -f "$SLEEP_FINISHED_MARKER"
+rm -f "$SLEEP_FINISHED_MARKER" "$SLEEP_PID_FILE"
 warn_out="$tmp/warn.txt"
 FAKE_GATE_MODE=sleep BUDGET=2 run_hook "$repoC" 2>"$warn_out"
 rcC=$?
@@ -214,33 +221,86 @@ if grep -q 'FAILING OPEN' "$warn_out"; then
 else
   bad "timeout path did not emit a 'FAILING OPEN' warning"
 fi
-# Wait past the grandchild's sleep (6s): if the process-group kill worked, the
-# grandchild is dead and the marker NEVER appears. A direct-child-only kill would
-# leave it running to write the marker (and keep contending for gate slots).
-sleep 7
-if [ ! -f "$SLEEP_FINISHED_MARKER" ]; then
-  ok "timeout path killed the whole process group — grandchild never finished (no marker)"
+
+# Read the grandchild PID (bounded poll — the file appears as soon as the shim starts).
+gc_pid=""
+waited=0
+while [ "$waited" -lt 5 ]; do
+  if [ -s "$SLEEP_PID_FILE" ]; then gc_pid=$(cat "$SLEEP_PID_FILE"); break; fi
+  sleep 1; waited=$((waited + 1))
+done
+# Poll-with-cap (bounded ~6s) for the grandchild to be gone. The hook already
+# TERM/KILLed the group during run_hook; this only confirms it, with generous margin.
+gc_gone=0
+if [ -n "$gc_pid" ]; then
+  waited=0
+  while [ "$waited" -lt 6 ]; do
+    if kill -0 "$gc_pid" 2>/dev/null; then
+      sleep 1; waited=$((waited + 1))
+    else
+      gc_gone=1; break
+    fi
+  done
+fi
+if [ "$gc_gone" -eq 1 ]; then
+  ok "timeout path killed the whole process group — grandchild PID $gc_pid is gone (kill -0 fails)"
 else
-  bad "timeout path left the gate grandchild alive (marker present) — process-group kill failed"
+  bad "timeout path left the gate grandchild (PID '${gc_pid:-unknown}') alive — process-group kill failed"
+fi
+# The 30s marker must never have appeared (secondary sanity check; the process is dead).
+if [ ! -f "$SLEEP_FINISHED_MARKER" ]; then
+  ok "gate grandchild never wrote its finished marker (killed before the 30s sleep completed)"
+else
+  bad "gate grandchild wrote its finished marker — it outlived the timeout"
 fi
 
-# --- Case D: no Rust diff vs origin/main -> cheap skip, gate never runs ----------
+# --- Case C2: fix #4 — a wired coverage command STILL runs after a fail-open timeout
+repoC2="$tmp/repoC2"
+build_repo "$repoC2"
+: >"$RECORD"
+rm -f "$SLEEP_PID_FILE"
+cov_marker="$tmp/coverage-ran.txt"
+rm -f "$cov_marker"
+FAKE_GATE_MODE=sleep BUDGET=2 COV="touch $cov_marker" run_hook "$repoC2" 2>/dev/null
+rcC2=$?
+if [ "$rcC2" -eq 0 ] && [ -f "$cov_marker" ]; then
+  ok "fail-open timeout falls through — a wired coverage command still runs (exit 0)"
+else
+  bad "fail-open timeout did not run the wired coverage command (rc=$rcC2, marker $( [ -f "$cov_marker" ] && echo present || echo absent ))"
+fi
+
+# --- Case D: no Rust change (committed AND clean tree) -> cheap skip, gate never runs
 repoD="$tmp/repoD"
 build_repo "$repoD"
-# Advance origin/main to HEAD so there is no Rust diff.
+# Advance origin/main to HEAD so there is no committed Rust diff; tree is clean.
 ( cd "$repoD" && git update-ref refs/remotes/origin/main HEAD )
 : >"$RECORD"
 FAKE_GATE_MODE=pass run_hook "$repoD"
 rcD=$?
 if [ "$rcD" -eq 0 ]; then
-  ok "no-Rust-diff path exits 0"
+  ok "no-Rust-change path exits 0"
 else
-  bad "no-Rust-diff path exited $rcD (expected 0)"
+  bad "no-Rust-change path exited $rcD (expected 0)"
 fi
 if [ ! -s "$RECORD" ]; then
-  ok "no-Rust-diff path skips the gate entirely (gate never invoked)"
+  ok "no-Rust-change path skips the gate entirely (gate never invoked)"
 else
-  bad "no-Rust-diff path invoked the gate (record: $(cat "$RECORD"))"
+  bad "no-Rust-change path invoked the gate (record: $(cat "$RECORD"))"
+fi
+
+# --- Case E: fix #3 — committed diff empty but a DIRTY *.rs working tree -> RUN ---
+# The skip must consult the working tree; an uncommitted Rust edit must NOT be skipped.
+repoE="$tmp/repoE"
+build_repo "$repoE"
+( cd "$repoE" && git update-ref refs/remotes/origin/main HEAD )  # no committed diff
+echo '// uncommitted edit' >>"$repoE/src/lib.rs"                  # dirty *.rs working tree
+: >"$RECORD"
+FAKE_GATE_MODE=pass run_hook "$repoE"
+rcE=$?
+if [ "$rcE" -eq 0 ] && [ -s "$RECORD" ]; then
+  ok "dirty *.rs working tree runs the gate even with no committed diff (exit 0, gate invoked)"
+else
+  bad "dirty *.rs working tree did not run the gate (rc=$rcE, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ))"
 fi
 
 echo

--- a/scripts/tests/test_issue_gate_hook.sh
+++ b/scripts/tests/test_issue_gate_hook.sh
@@ -60,6 +60,7 @@ trap 'rm -rf "$tmp"' EXIT
 
 RECORD="$tmp/gate-record.txt"
 ROBOREV_SENTINEL="$tmp/roborev-was-called.txt"
+SLEEP_FINISHED_MARKER="$tmp/sleep-grandchild-finished.txt"
 
 # Build a fake repo with the hook and a recording fake gate.
 build_repo() {
@@ -79,8 +80,14 @@ build_repo() {
   echo "CWD:$PWD"
 } >>"$GATE_RECORD"
 case "${FAKE_GATE_MODE:-pass}" in
-  fail)  exit 1 ;;
-  sleep) sleep 15; exit 0 ;;
+  fail)
+    # Emit a recognizable SUMMARY block so the hook's fail path can echo it.
+    [ -n "${AGENT_GATE_SUMMARY_FILE:-}" ] && printf 'AGENT-GATE-LITE-SUMMARY-SENTINEL\nRESULT: FAIL\n' >"$AGENT_GATE_SUMMARY_FILE"
+    exit 1 ;;
+  # sleep past the budget, then drop a marker. If the hook's timeout path only
+  # killed the direct child (not the process group), this grandchild survives and
+  # writes the marker — exactly the invisible-contention leak we must prevent.
+  sleep) sleep 6; echo done >"$SLEEP_FINISHED_MARKER"; exit 0 ;;
   *)     exit 0 ;;
 esac
 EOF
@@ -106,6 +113,7 @@ run_hook() {
   local repo="$1"
   ( cd "$tmp" && echo '{}' | \
       GATE_RECORD="$RECORD" \
+      SLEEP_FINISHED_MARKER="$SLEEP_FINISHED_MARKER" \
       ISSUE_GATE_TEST_CMD="scripts/agent-gate.sh --lite" \
       ISSUE_GATE_COVERAGE_CMD="" \
       ISSUE_GATE_ROBOREV="1" \
@@ -173,18 +181,26 @@ fi
 repoB="$tmp/repoB"
 build_repo "$repoB"
 : >"$RECORD"
-FAKE_GATE_MODE=fail run_hook "$repoB"
+failB_out="$tmp/failB.txt"
+FAKE_GATE_MODE=fail run_hook "$repoB" 2>"$failB_out"
 rcB=$?
 if [ "$rcB" -eq 2 ]; then
   ok "genuine lite FAIL blocks task completion (exit 2)"
 else
   bad "lite FAIL produced exit $rcB (expected 2)"
 fi
+# fix #3: the SUMMARY block (the only retainable text) is echoed into the reason.
+if grep -q 'AGENT-GATE-LITE-SUMMARY-SENTINEL' "$failB_out"; then
+  ok "FAIL path echoes the lite SUMMARY block into the block reason"
+else
+  bad "FAIL path did not echo the lite SUMMARY block"
+fi
 
 # --- Case C: budget exceeded FAILS OPEN (exit 0 + warning) ----------------------
 repoC="$tmp/repoC"
 build_repo "$repoC"
 : >"$RECORD"
+rm -f "$SLEEP_FINISHED_MARKER"
 warn_out="$tmp/warn.txt"
 FAKE_GATE_MODE=sleep BUDGET=2 run_hook "$repoC" 2>"$warn_out"
 rcC=$?
@@ -197,6 +213,15 @@ if grep -q 'FAILING OPEN' "$warn_out"; then
   ok "timeout path emits a visible FAILING OPEN warning"
 else
   bad "timeout path did not emit a 'FAILING OPEN' warning"
+fi
+# Wait past the grandchild's sleep (6s): if the process-group kill worked, the
+# grandchild is dead and the marker NEVER appears. A direct-child-only kill would
+# leave it running to write the marker (and keep contending for gate slots).
+sleep 7
+if [ ! -f "$SLEEP_FINISHED_MARKER" ]; then
+  ok "timeout path killed the whole process group — grandchild never finished (no marker)"
+else
+  bad "timeout path left the gate grandchild alive (marker present) — process-group kill failed"
 fi
 
 # --- Case D: no Rust diff vs origin/main -> cheap skip, gate never runs ----------

--- a/scripts/tests/test_issue_gate_hook.sh
+++ b/scripts/tests/test_issue_gate_hook.sh
@@ -62,6 +62,7 @@ RECORD="$tmp/gate-record.txt"
 ROBOREV_SENTINEL="$tmp/roborev-was-called.txt"
 SLEEP_FINISHED_MARKER="$tmp/sleep-grandchild-finished.txt"
 SLEEP_PID_FILE="$tmp/sleep-grandchild-pid.txt"
+SLEEP_KILLED_MARKER="$tmp/sleep-grandchild-killed.txt"
 # An EMPTY slots dir every case points at by default, so a real full gate running
 # on this machine (e.g. when this self-test runs INSIDE the gate) can never make the
 # hook's slot-aware skip fire and flip an unrelated assertion. The slot-skip case
@@ -91,12 +92,18 @@ case "${FAKE_GATE_MODE:-pass}" in
     # Emit a recognizable SUMMARY block so the hook's fail path can echo it.
     [ -n "${AGENT_GATE_SUMMARY_FILE:-}" ] && printf 'AGENT-GATE-LITE-SUMMARY-SENTINEL\nRESULT: FAIL\n' >"$AGENT_GATE_SUMMARY_FILE"
     exit 1 ;;
-  # Record this gate process's PID, then sleep LONG (30s) past a small budget and
-  # only then drop a marker. The de-flake: the assertion does not race the marker —
-  # it proves the process group was actually killed by checking the recorded PID is
-  # gone (bounded poll), well before the 30s marker could ever appear. If the hook
-  # killed only the direct child, this grandchild survives — kill -0 stays true.
-  sleep) echo "$$" >"$SLEEP_PID_FILE"; sleep 30; echo done >"$SLEEP_FINISHED_MARKER"; exit 0 ;;
+  # Trap TERM and write a 'killed' marker BY THIS ACTUAL PROCESS, then sleep LONG
+  # (30s) past a small budget and only then drop a 'finished' marker. The de-flake:
+  # the assertion polls for the killed-marker (written by the real grandchild when the
+  # group TERM reaches it) rather than probing a recyclable PID with kill -0. If the
+  # hook killed only the direct child, this grandchild survives — no killed-marker and
+  # (30s later) a finished-marker.
+  sleep)
+    trap 'echo killed >"$SLEEP_KILLED_MARKER"; exit 143' TERM
+    echo "$$" >"$SLEEP_PID_FILE"
+    sleep 30
+    echo done >"$SLEEP_FINISHED_MARKER"
+    exit 0 ;;
   *)     exit 0 ;;
 esac
 EOF
@@ -124,6 +131,7 @@ run_hook() {
       GATE_RECORD="$RECORD" \
       SLEEP_FINISHED_MARKER="$SLEEP_FINISHED_MARKER" \
       SLEEP_PID_FILE="$SLEEP_PID_FILE" \
+      SLEEP_KILLED_MARKER="$SLEEP_KILLED_MARKER" \
       ISSUE_GATE_TEST_CMD="scripts/agent-gate.sh --lite" \
       ISSUE_GATE_COVERAGE_CMD="${COV:-}" \
       ISSUE_GATE_ROBOREV="1" \
@@ -214,13 +222,14 @@ else
 fi
 
 # --- Case C: budget exceeded FAILS OPEN + kills the whole process group ----------
-# Load-proof (no timing-coupled marker race): the grandchild records its PID then
-# sleeps 30s. We assert exit 0 + warning, then prove the process group is actually
-# gone by polling the recorded PID with a bounded cap (never the 30s marker).
+# Load-proof, no recyclable-PID probe: the grandchild traps TERM and writes a 'killed'
+# marker BY ITSELF, then sleeps 30s. We assert exit 0 + warning, then poll (bounded)
+# for that killed-marker — proof the group TERM actually reached the grandchild — and
+# confirm the 30s 'finished' marker never appeared.
 repoC="$tmp/repoC"
 build_repo "$repoC"
 : >"$RECORD"
-rm -f "$SLEEP_FINISHED_MARKER" "$SLEEP_PID_FILE"
+rm -f "$SLEEP_FINISHED_MARKER" "$SLEEP_PID_FILE" "$SLEEP_KILLED_MARKER"
 warn_out="$tmp/warn.txt"
 out_c="$tmp/out_c.txt"
 FAKE_GATE_MODE=sleep BUDGET=2 run_hook "$repoC" >"$out_c" 2>"$warn_out"
@@ -242,30 +251,18 @@ else
   bad "timeout path did not emit the FAILING OPEN notice on stdout"
 fi
 
-# Read the grandchild PID (bounded poll — the file appears as soon as the shim starts).
-gc_pid=""
+# Poll-with-cap (bounded ~6s) for the grandchild's OWN 'killed' marker — written by its
+# TERM trap when the group signal reaches it. No kill -0 on a recyclable PID.
+gc_killed=0
 waited=0
-while [ "$waited" -lt 5 ]; do
-  if [ -s "$SLEEP_PID_FILE" ]; then gc_pid=$(cat "$SLEEP_PID_FILE"); break; fi
+while [ "$waited" -lt 6 ]; do
+  if [ -f "$SLEEP_KILLED_MARKER" ]; then gc_killed=1; break; fi
   sleep 1; waited=$((waited + 1))
 done
-# Poll-with-cap (bounded ~6s) for the grandchild to be gone. The hook already
-# TERM/KILLed the group during run_hook; this only confirms it, with generous margin.
-gc_gone=0
-if [ -n "$gc_pid" ]; then
-  waited=0
-  while [ "$waited" -lt 6 ]; do
-    if kill -0 "$gc_pid" 2>/dev/null; then
-      sleep 1; waited=$((waited + 1))
-    else
-      gc_gone=1; break
-    fi
-  done
-fi
-if [ "$gc_gone" -eq 1 ]; then
-  ok "timeout path killed the whole process group — grandchild PID $gc_pid is gone (kill -0 fails)"
+if [ "$gc_killed" -eq 1 ]; then
+  ok "timeout path killed the whole process group — grandchild caught the group TERM (wrote its killed-marker)"
 else
-  bad "timeout path left the gate grandchild (PID '${gc_pid:-unknown}') alive — process-group kill failed"
+  bad "timeout path did not signal the gate grandchild — no killed-marker (process-group kill failed)"
 fi
 # The 30s marker must never have appeared (secondary sanity check; the process is dead).
 if [ ! -f "$SLEEP_FINISHED_MARKER" ]; then
@@ -333,7 +330,7 @@ rcF=$?
 if [ "$rcF" -eq 0 ] && [ -s "$RECORD" ] && grep -q 'is not a non-negative integer' "$warnF_out"; then
   ok "non-integer budget warns, defaults to 480, and runs the gate normally"
 else
-  bad "non-integer budget mishandled (rc=$rcF, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ), warned=$(grep -qc 'not a non-negative integer' "$warnF_out" && echo yes || echo no))"
+  bad "non-integer budget mishandled (rc=$rcF, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ), warned=$(grep -q 'not a non-negative integer' "$warnF_out" && echo yes || echo no))"
 fi
 
 # --- Case G: fix #5 — hook invoked from a NON-git dir -> exit 0, gate never runs ---
@@ -386,7 +383,7 @@ PY
   if [ "$rcH" -eq 0 ] && [ ! -s "$RECORD" ] && grep -q 'full gate active — advisory check skipped' "$outH"; then
     ok "full gate holding a slot -> advisory check skipped (exit 0, gate never invoked)"
   else
-    bad "slot-aware skip failed (rc=$rcH, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ), notice=$(grep -qc 'advisory check skipped' "$outH" && echo yes || echo no))"
+    bad "slot-aware skip failed (rc=$rcH, record $( [ -s "$RECORD" ] && echo nonempty || echo empty ), notice=$(grep -q 'advisory check skipped' "$outH" && echo yes || echo no))"
   fi
 else
   ok "slot-aware skip case SKIPPED (no python3 — the hook's slot probe also no-ops without it)"

--- a/scripts/tests/test_issue_gate_hook.sh
+++ b/scripts/tests/test_issue_gate_hook.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Regression test for issue #2671 (epic #2664 harness audit): the TaskCompleted
+# issue-gate hook (.claude/hooks/issue-gate.sh) is DEFUSED. The prior version ran
+# the FULL gate (12-25 min) under the hook's 600s timeout, from the session cwd,
+# plus a synchronous `roborev --wait`. This test proves the defusal holds:
+#   (a) the wired test command is the LITE gate (--lite), never the full gate;
+#   (b) the gate is invoked with a UNIQUE mktemp AGENT_GATE_SUMMARY_FILE and from
+#       the REPO ROOT derived from the hook's own location (not the session cwd);
+#   (c) a check that exceeds its wall-clock budget FAILS OPEN (exit 0 + warning),
+#       never blocking task completion on a timeout;
+#   (d) no roborev invocation remains — statically and behaviorally;
+#   plus: a genuine lite FAIL still blocks (exit 2), and a no-Rust-diff repo skips.
+#
+# Fast + hermetic by design: it never runs the real gate. It builds a throwaway git
+# repo, copies the real hook into it, and PATH/relative-path-shims the gate binary
+# and roborev with recorders. FAILS against the pre-#2671 hook, PASSES with the fix.
+#
+# Run standalone:   bash scripts/tests/test_issue_gate_hook.sh
+# Or via the gate:  scripts/agent-gate.sh runs it in the tooling-tests component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+HOOK_SRC="$REPO_ROOT/.claude/hooks/issue-gate.sh"
+SETTINGS="$REPO_ROOT/.claude/settings.json"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "FAIL - hook not found at $HOOK_SRC" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Static assertions on the wiring
+# ---------------------------------------------------------------------------
+
+# settings.json wires the LITE gate, not the bare full gate.
+if grep -q '"ISSUE_GATE_TEST_CMD": "scripts/agent-gate.sh --lite"' "$SETTINGS"; then
+  ok "settings.json wires ISSUE_GATE_TEST_CMD to the --lite gate"
+else
+  bad "settings.json does not wire ISSUE_GATE_TEST_CMD to 'scripts/agent-gate.sh --lite'"
+fi
+
+# The hook source contains no ACTIVE roborev invocation (comments allowed).
+if grep -nE '^[[:space:]]*[^#].*roborev[[:space:]]+(review|wait)' "$HOOK_SRC" >/dev/null 2>&1; then
+  bad "hook still contains an active roborev invocation"
+else
+  ok "hook contains no active roborev invocation (static)"
+fi
+
+# ---------------------------------------------------------------------------
+# Behavioral harness: build a throwaway repo and drive the real hook
+# ---------------------------------------------------------------------------
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/issue-gate-hook-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+RECORD="$tmp/gate-record.txt"
+ROBOREV_SENTINEL="$tmp/roborev-was-called.txt"
+
+# Build a fake repo with the hook and a recording fake gate.
+build_repo() {
+  local repo="$1"
+  rm -rf "$repo"
+  mkdir -p "$repo/.claude/hooks" "$repo/scripts" "$repo/src"
+  cp "$HOOK_SRC" "$repo/.claude/hooks/issue-gate.sh"
+  chmod +x "$repo/.claude/hooks/issue-gate.sh"
+
+  # Recording fake gate: logs argv, the summary-file env, and its cwd; behavior
+  # is driven by FAKE_GATE_MODE (pass|fail|sleep).
+  cat >"$repo/scripts/agent-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+{
+  echo "ARGS:$*"
+  echo "SUMMARY:${AGENT_GATE_SUMMARY_FILE:-}"
+  echo "CWD:$PWD"
+} >>"$GATE_RECORD"
+case "${FAKE_GATE_MODE:-pass}" in
+  fail)  exit 1 ;;
+  sleep) sleep 15; exit 0 ;;
+  *)     exit 0 ;;
+esac
+EOF
+  chmod +x "$repo/scripts/agent-gate.sh"
+
+  ( cd "$repo" || exit 1
+    git init -q
+    git config user.email t@t
+    git config user.name t
+    git add -A
+    git commit -qm base
+    # origin/main = base commit (no Rust yet)
+    git update-ref refs/remotes/origin/main HEAD
+    # add a Rust file so there IS a diff vs origin/main
+    echo 'pub fn f() {}' >src/lib.rs
+    git add src/lib.rs
+    git commit -qm rust
+  )
+}
+
+# Run the hook from an UNRELATED cwd, so any repo-root reliance on cwd would break.
+run_hook() {
+  local repo="$1"
+  ( cd "$tmp" && echo '{}' | \
+      GATE_RECORD="$RECORD" \
+      ISSUE_GATE_TEST_CMD="scripts/agent-gate.sh --lite" \
+      ISSUE_GATE_COVERAGE_CMD="" \
+      ISSUE_GATE_ROBOREV="1" \
+      ISSUE_GATE_LITE_BUDGET_SECS="${BUDGET:-480}" \
+      FAKE_GATE_MODE="${FAKE_GATE_MODE:-pass}" \
+      PATH="$tmp/shim:$PATH" \
+      bash "$repo/.claude/hooks/issue-gate.sh" )
+}
+
+# PATH shim: a roborev that trips a sentinel if EVER called.
+mkdir -p "$tmp/shim"
+cat >"$tmp/shim/roborev" <<EOF
+#!/usr/bin/env bash
+echo "called" >"$ROBOREV_SENTINEL"
+exit 0
+EOF
+chmod +x "$tmp/shim/roborev"
+
+# --- Case A: PASS path — --lite, unique summary, repo-root cwd, no roborev -------
+repoA="$tmp/repoA"
+build_repo "$repoA"
+: >"$RECORD"
+rm -f "$ROBOREV_SENTINEL"
+FAKE_GATE_MODE=pass run_hook "$repoA"
+rcA=$?
+
+if [ "$rcA" -eq 0 ]; then
+  ok "PASS path: hook exits 0"
+else
+  bad "PASS path: hook exited $rcA (expected 0)"
+fi
+
+args_line=$(grep '^ARGS:' "$RECORD" | head -1)
+if [ "$args_line" = "ARGS:--lite" ]; then
+  ok "gate invoked with '--lite'"
+else
+  bad "gate argv was '$args_line' (expected 'ARGS:--lite')"
+fi
+
+summary_line=$(grep '^SUMMARY:' "$RECORD" | head -1)
+summary_path=${summary_line#SUMMARY:}
+if [ -n "$summary_path" ] && [[ "$summary_path" == *issue-gate-lite-summary* ]] \
+   && [ "$summary_path" != ".agent-gate-lite-summary.txt" ]; then
+  ok "gate ran with a unique mktemp AGENT_GATE_SUMMARY_FILE ($summary_path)"
+else
+  bad "gate summary path was '$summary_path' (expected a unique mktemp issue-gate-lite-summary path)"
+fi
+
+cwd_line=$(grep '^CWD:' "$RECORD" | head -1)
+gate_cwd=${cwd_line#CWD:}
+expected_root=$(cd "$repoA" && git rev-parse --show-toplevel)
+if [ "$gate_cwd" = "$expected_root" ]; then
+  ok "gate ran from the hook's repo root, not the session cwd ($gate_cwd)"
+else
+  bad "gate cwd was '$gate_cwd' (expected repo root '$expected_root')"
+fi
+
+if [ -f "$ROBOREV_SENTINEL" ]; then
+  bad "roborev was invoked (sentinel present) — the hook must not run reviews"
+else
+  ok "roborev was never invoked (behavioral)"
+fi
+
+# --- Case B: genuine FAIL still blocks (exit 2) ---------------------------------
+repoB="$tmp/repoB"
+build_repo "$repoB"
+: >"$RECORD"
+FAKE_GATE_MODE=fail run_hook "$repoB"
+rcB=$?
+if [ "$rcB" -eq 2 ]; then
+  ok "genuine lite FAIL blocks task completion (exit 2)"
+else
+  bad "lite FAIL produced exit $rcB (expected 2)"
+fi
+
+# --- Case C: budget exceeded FAILS OPEN (exit 0 + warning) ----------------------
+repoC="$tmp/repoC"
+build_repo "$repoC"
+: >"$RECORD"
+warn_out="$tmp/warn.txt"
+FAKE_GATE_MODE=sleep BUDGET=2 run_hook "$repoC" 2>"$warn_out"
+rcC=$?
+if [ "$rcC" -eq 0 ]; then
+  ok "timeout path fails OPEN (exit 0), never blocking on a budget overrun"
+else
+  bad "timeout path exited $rcC (expected 0 — fail open)"
+fi
+if grep -q 'FAILING OPEN' "$warn_out"; then
+  ok "timeout path emits a visible FAILING OPEN warning"
+else
+  bad "timeout path did not emit a 'FAILING OPEN' warning"
+fi
+
+# --- Case D: no Rust diff vs origin/main -> cheap skip, gate never runs ----------
+repoD="$tmp/repoD"
+build_repo "$repoD"
+# Advance origin/main to HEAD so there is no Rust diff.
+( cd "$repoD" && git update-ref refs/remotes/origin/main HEAD )
+: >"$RECORD"
+FAKE_GATE_MODE=pass run_hook "$repoD"
+rcD=$?
+if [ "$rcD" -eq 0 ]; then
+  ok "no-Rust-diff path exits 0"
+else
+  bad "no-Rust-diff path exited $rcD (expected 0)"
+fi
+if [ ! -s "$RECORD" ]; then
+  ok "no-Rust-diff path skips the gate entirely (gate never invoked)"
+else
+  bad "no-Rust-diff path invoked the gate (record: $(cat "$RECORD"))"
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #2671. Epic #2664 Phase-1 P2 batch.

## What
Defuses the TaskCompleted issue-gate hook (a FULL 12-25 min gate under a 600s hook timeout, from arbitrary cwd, with a synchronous roborev — it could never succeed and contended invisibly for gate slots):
- `ISSUE_GATE_TEST_CMD` → `scripts/agent-gate.sh --lite`; hook runs from the repo root (derived from its own location, never session cwd), unique mktemp summary path, no roborev (the flow pipeline owns reviews).
- **Budgeted + fail-open**: real-elapsed integer budget (default 480s, env-validated), pgid-verified process-group kill with direct-pid fallback (a failed `set -m` can never signal the session's own group), `BUDGET_TIMED_OUT` flag (no 124 sentinel), FAILING-OPEN notice on stdout, summary cleanup trap.
- **Slot-aware**: skips the advisory check when any gate slot is flock-held (never contends with a gate of record; PermissionError = held); no-Rust-diff early exit consults the working tree too; genuine FAILs block with the SUMMARY block + log path only.
- Hermetic suite `test_issue_gate_hook.sh` (22 cases incl. group-kill proof via TERM-trap marker, slot-skip, dirty-tree scope, fail-open visibility) — gate-wired in tooling-tests.

## Review
4 rounds (jobs 1808, 1811, 1812, 1815 — 18 findings fixed, zero re-raises; terminal round declared, further findings batch). shellcheck clean throughout. Lite PASS at `50b33c7f1`.
Full gate of record: run by flow-closer pre-merge.
