### PR TITLE
ci(#2645): docs-only classifier for the required PR gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -19,44 +19,99 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Full history so the docs-only classifier can diff the PR base
+          # against its head (base.sha may be behind the shallow default).
+          fetch-depth: 0
+
+      # ALWAYS-EMIT docs-only classifier (issue #2645, pattern:
+      # observability-gate.yml classify job). Computes the changed-file set for
+      # this PR and decides whether the Rust build + query-semantics oracle
+      # (#2644) + heavy steps must run. Fail-closed: any non-docs file, or an
+      # empty/ambiguous set, forces the full path. This step MUST NOT be skipped
+      # so the `required` status always reports in BOTH branches; do NOT add
+      # paths/paths-ignore to the trigger (a filtered required check that never
+      # fires would block every affected PR forever).
+      - name: Classify docs-only diff
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Names only, NUL-safe path handling, base..head three-dot compare so
+          # only files the PR actually changed are considered.
+          git diff --name-only "${BASE_SHA}...${HEAD_SHA}" > changed-files.txt
+
+          echo "Changed files:"
+          sed 's/^/  - /' changed-files.txt
+
+          docs_only=false
+          if bash scripts/ci/classify-docs-only.sh < changed-files.txt; then
+            docs_only=true
+          fi
+
+          echo "docs_only=${docs_only}" >> "$GITHUB_OUTPUT"
+          echo "Classifier verdict: docs_only=${docs_only}"
+
+      - name: Docs-only short-circuit summary
+        if: steps.classify.outputs.docs_only == 'true'
+        run: |
+          {
+            echo "## Required PR Gate: docs-only short-circuit"
+            echo ""
+            echo "The changed-file set is documentation only (issue #2645), so"
+            echo "the Rust build, query-semantics oracle (#2644), and other heavy"
+            echo "steps were skipped. Docs validation runs on docs PRs via"
+            echo "docs-site.yml. This required status reports green from the"
+            echo "always-run classifier."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validate workflow policy
+        if: steps.classify.outputs.docs_only != 'true'
         run: >-
           bash scripts/ci/ci-timing-summary.sh measure
           "workflow policy"
           -- ruby scripts/ci/validate-workflows.rb
 
       - name: Dataset pin agreement (#2646)
+        if: steps.classify.outputs.docs_only != 'true'
         run: >-
           bash scripts/ci/ci-timing-summary.sh measure
           "dataset pin agreement"
           -- bash scripts/ci/check-dataset-pin.sh
 
       - name: Setup Rust
+        if: steps.classify.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-rust-ci
         with:
           components: rustfmt,clippy
           cache-key: pr-gate
 
       - name: Rust format check
+        if: steps.classify.outputs.docs_only != 'true'
         run: >-
           bash scripts/ci/ci-timing-summary.sh measure
           "cargo fmt"
           -- cargo fmt --all -- --check
 
       - name: cqlite-core clippy hard gate
+        if: steps.classify.outputs.docs_only != 'true'
         run: >-
           bash scripts/ci/ci-timing-summary.sh measure
           "cqlite-core clippy"
           -- cargo clippy --package cqlite-core --all-targets --all-features -- -D warnings
 
       - name: cqlite-core all-feature build
+        if: steps.classify.outputs.docs_only != 'true'
         run: >-
           bash scripts/ci/ci-timing-summary.sh measure
           "cqlite-core all-feature build"
           -- cargo build --package cqlite-core --all-features
 
       - name: cqlite-core fast representative tests
+        if: steps.classify.outputs.docs_only != 'true'
         run: |
           bash scripts/ci/ci-timing-summary.sh measure "cqlite-core fast tests" -- bash -e -u -o pipefail -c '
             # Mirrors scripts/local/pre-merge.sh fast. The skipped tests are legacy
@@ -70,6 +125,7 @@ jobs:
           '
 
       - name: Query-semantics oracle (fail-closed, #2644)
+        if: steps.classify.outputs.docs_only != 'true'
         run: |
           bash scripts/ci/ci-timing-summary.sh measure "query-semantics oracle" -- bash -e -u -o pipefail -c '
             # Read-time-reconciliation parity oracle (#1742): committed-fixture,
@@ -84,5 +140,5 @@ jobs:
           '
 
       - name: Required PR Gate timing summary
-        if: always()
+        if: steps.classify.outputs.docs_only != 'true'
         run: bash scripts/ci/ci-timing-summary.sh summary "Required PR Gate timing"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2424,6 +2424,22 @@ run_tooling_tests() {
     return 0
   fi
 
+  # docs-only PR-gate classifier self-test (#2645): no python3 needed, always
+  # runs (hermetic — pure-shell allowlist classification + pr-gate.yml structural
+  # contract that the required status always reports and the #2644 oracle step is
+  # gated fail-closed; no cargo). A failure FAILs the component.
+  echo ">>> [$name] bash scripts/tests/test_classify_docs_only.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_classify_docs_only.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (docs-only classifier self-test); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
   if ! command -v python3 >/dev/null 2>&1; then
     status=SKIP
     echo ">>> [$name] SKIP (no python3 on PATH; selftest truncation reader needs it)"

--- a/scripts/ci/classify-docs-only.sh
+++ b/scripts/ci/classify-docs-only.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Docs-only classifier for the required PR gate (issue #2645, epic #2636).
+#
+# pr-gate.yml is a REQUIRED status check with no path awareness: a docs- or
+# board-only PR still compiles cqlite-core all-features and runs the read-time
+# reconciliation oracle (#2644). This classifier lets the gate short-circuit
+# such PRs to green in seconds WITHOUT using paths/paths-ignore on the workflow
+# trigger — a path filter would prevent the required check from ever reporting,
+# permanently blocking a PR that touches only ignored paths.
+#
+# Contract (pure + hermetic so it is self-testable):
+#   - Reads a newline-delimited changed-file list on STDIN (one repo-relative
+#     path per line; blank lines ignored).
+#   - Exit 0  => DOCS-ONLY: every changed file is in the conservative docs
+#                allowlist. The caller MAY skip the Rust/oracle/heavy steps.
+#   - Exit 1  => FULL PATH REQUIRED (fail-closed): at least one file is NOT in
+#                the docs allowlist, OR the changed set is empty/ambiguous.
+#
+# FAIL-CLOSED by construction: this is an ALLOWLIST. Only files that are
+# unambiguously documentation short-circuit; ANY other class — Rust sources,
+# Cargo manifests, test-data manifests/fixtures, .github workflows/actions,
+# scripts, config, lockfiles, or an unrecognized extension — forces the full
+# run. An empty changed set is ambiguous and also forces the full run.
+#
+# Sensitive directories (.github/, scripts/, test-data/) force the full path
+# EVEN for a *.md file inside them, so a Markdown edit next to a workflow, a
+# gate script, or a parity manifest can never smuggle a code-relevant change
+# past the gate.
+#
+# The script prints a one-word verdict ("docs-only" / "full") to STDOUT and a
+# human-readable reason to STDERR; callers key off the EXIT CODE.
+
+set -euo pipefail
+
+# is_docs_file <path> -> 0 if the single path is unambiguously a docs file.
+# Fail-closed: unrecognized => 1 (not docs).
+is_docs_file() {
+  local path="$1"
+
+  # Sensitive dirs force the full path regardless of extension.
+  case "$path" in
+    .github/* | scripts/* | test-data/*) return 1 ;;
+  esac
+
+  case "$path" in
+    docs/*) return 0 ;;
+    *.md | *.markdown) return 0 ;;
+    *.png | *.jpg | *.jpeg | *.gif | *.svg | *.webp | *.ico) return 0 ;;
+    LICENSE | LICENSE.* | NOTICE | NOTICE.*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+main() {
+  local saw_file=0
+  local path
+  local non_docs=""
+
+  while IFS= read -r path || [ -n "$path" ]; do
+    # Skip blank lines (trailing newline, empty diff output).
+    [ -n "$path" ] || continue
+    saw_file=1
+    if ! is_docs_file "$path"; then
+      non_docs="$path"
+      break
+    fi
+  done
+
+  if [ "$saw_file" -eq 0 ]; then
+    echo "full"
+    echo "classify-docs-only: empty/ambiguous changed set -> FULL PATH (fail-closed)" >&2
+    return 1
+  fi
+
+  if [ -n "$non_docs" ]; then
+    echo "full"
+    echo "classify-docs-only: non-docs file '$non_docs' -> FULL PATH (fail-closed)" >&2
+    return 1
+  fi
+
+  echo "docs-only"
+  echo "classify-docs-only: all changed files are docs -> short-circuit to green" >&2
+  return 0
+}
+
+main "$@"

--- a/scripts/tests/test_classify_docs_only.sh
+++ b/scripts/tests/test_classify_docs_only.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Self-test for the docs-only PR-gate classifier (issue #2645, epic #2636).
+#
+# Proves the three acceptance properties of scripts/ci/classify-docs-only.sh:
+#   (a) a docs-/board-only changed set short-circuits (exit 0 => "docs-only"),
+#       so the required gate can return green in seconds;
+#   (b) any Rust / Cargo / test-data manifest / .github workflow / scripts /
+#       config / unknown-extension file forces the FULL path (exit 1 => "full");
+#   (c) FAIL-CLOSED: an empty/ambiguous changed set forces the full path, and a
+#       *.md file living under a sensitive dir (.github/, scripts/, test-data/)
+#       does NOT short-circuit.
+#
+# Also asserts the workflow contract that makes the required status ALWAYS
+# report: pr-gate.yml uses NO paths/paths-ignore trigger filter, always runs the
+# classifier step, and gates every heavy step (including the #2644
+# query-semantics oracle) on the classifier output.
+#
+# Hermetic: pure shell, no cargo/Docker/datasets/network. A failure FAILs the
+# tooling-tests gate component.
+#
+# Run standalone:   bash scripts/tests/test_classify_docs_only.sh
+# Or via the gate:  scripts/agent-gate.sh runs it inside `tooling-tests`.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+CLASSIFY="$REPO_ROOT/scripts/ci/classify-docs-only.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/pr-gate.yml"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+[ -f "$CLASSIFY" ] || { echo "FATAL: classifier missing: $CLASSIFY" >&2; exit 1; }
+
+# assert_docs_only <label> <newline-file-list>
+# Expects exit 0 and STDOUT verdict "docs-only".
+assert_docs_only() {
+  local label="$1" input="$2" out rc
+  out=$(printf '%s' "$input" | bash "$CLASSIFY" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq 0 ] && [ "$out" = "docs-only" ]; then
+    ok "$label (short-circuit: exit 0, verdict=docs-only)"
+  else
+    bad "$label (expected exit 0/docs-only, got exit $rc/'$out')"
+  fi
+}
+
+# assert_full <label> <newline-file-list>
+# Expects exit 1 and STDOUT verdict "full".
+assert_full() {
+  local label="$1" input="$2" out rc
+  out=$(printf '%s' "$input" | bash "$CLASSIFY" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq 1 ] && [ "$out" = "full" ]; then
+    ok "$label (full path: exit 1, verdict=full)"
+  else
+    bad "$label (expected exit 1/full, got exit $rc/'$out')"
+  fi
+}
+
+echo "== (a) docs-/board-only sets short-circuit to green =="
+assert_docs_only "single markdown"        $'README.md\n'
+assert_docs_only "docs tree"              $'docs/development/dev-cookbook.md\n'
+assert_docs_only "image asset"            $'docs/img/diagram.png\n'
+assert_docs_only "multiple docs files"    $'docs/a.md\nREADME.md\ndocs/img/x.svg\nCHANGELOG.markdown\n'
+assert_docs_only "license"                $'LICENSE\n'
+assert_docs_only "trailing blank lines"   $'docs/a.md\n\n\n'
+
+echo "== (b) code-relevant sets force the FULL path =="
+assert_full "rust source"                 $'cqlite-core/src/lib.rs\n'
+assert_full "rust among docs"             $'docs/a.md\ncqlite-core/src/reader.rs\n'
+assert_full "cargo manifest"              $'cqlite-core/Cargo.toml\n'
+assert_full "cargo lockfile"              $'Cargo.lock\n'
+assert_full ".github workflow"            $'.github/workflows/pr-gate.yml\n'
+assert_full ".github action"              $'.github/actions/setup-rust-ci/action.yml\n'
+assert_full "scripts dir"                 $'scripts/agent-gate.sh\n'
+assert_full "test-data manifest"          $'test-data/cassandra-parity-manifest.yml\n'
+assert_full "test-data fixture"           $'test-data/datasets/sstables/x/nb-1-big-Data.db\n'
+
+echo "== (c) fail-closed on ambiguous / smuggled changes =="
+assert_full "empty set"                   ''
+assert_full "blank lines only"            $'\n\n'
+assert_full "unknown extension"           $'tools/helper.py\n'
+assert_full "no-extension top-level"      $'Makefile\n'
+assert_full "md under .github (smuggle)"  $'.github/README.md\n'
+assert_full "md under scripts (smuggle)"  $'scripts/notes.md\n'
+assert_full "md under test-data (smuggle)" $'test-data/README.md\n'
+assert_full "docs + smuggled workflow md" $'docs/ok.md\n.github/CONTRIBUTING.md\n'
+
+echo "== workflow contract: required status ALWAYS reports =="
+if [ -f "$WORKFLOW" ]; then
+  # No path filter on the trigger (would stop the required check from firing).
+  if grep -Eq '^\s*(paths|paths-ignore)\s*:' "$WORKFLOW"; then
+    bad "pr-gate.yml must NOT use paths/paths-ignore (required check must always fire)"
+  else
+    ok "pr-gate.yml trigger has no paths/paths-ignore filter"
+  fi
+
+  # The classifier step itself must have no `if:` gate (always runs).
+  if command -v ruby >/dev/null 2>&1; then
+    ruby - "$WORKFLOW" <<'RUBY'
+      require "yaml"
+      wf = YAML.load_file(ARGV[0])
+      steps = wf.dig("jobs", "required", "steps") || []
+      classify = steps.find { |s| s.is_a?(Hash) && s["id"] == "classify" }
+      abort("no classify step") unless classify
+      # Always runs (no if:), and heavy steps are gated on its output.
+      abort("classify step must not be gated") if classify.key?("if")
+      gated = steps.select { |s| s.is_a?(Hash) && s["if"].to_s.include?("steps.classify.outputs.docs_only") }
+      # Heavy steps = everything the docs-only path must SKIP (all gated steps
+      # except the docs-only informational summary, which runs on == 'true').
+      heavy = gated.reject { |s| s["if"].to_s.include?("== 'true'") }
+      names = heavy.map { |s| s["name"].to_s }
+      abort("oracle step not gated on classifier") unless names.any? { |n| n.include?("oracle") }
+      abort("build step not gated on classifier") unless names.any? { |n| n.include?("build") }
+      abort("no heavy steps gated on classifier") if heavy.empty?
+      # Every heavy step must gate with != 'true' (fail-closed: default = full run).
+      bad_gate = heavy.find { |s| !s["if"].to_s.include?("!= 'true'") }
+      abort("heavy step gate not fail-closed (!= 'true'): #{bad_gate&.fetch("name")}") if bad_gate
+      # And a docs-only branch step must exist so the required status still
+      # reports (green summary) when the heavy path is skipped.
+      abort("no docs-only branch step (required status would not report)") unless gated.any? { |s| s["if"].to_s.include?("== 'true'") }
+RUBY
+    if [ "$?" -eq 0 ]; then
+      ok "classify step always runs; heavy steps (incl. #2644 oracle) gated fail-closed on its output"
+    else
+      bad "pr-gate.yml classify/gating contract not satisfied"
+    fi
+  else
+    printf 'info - ruby absent; skipped structural workflow assertion\n'
+  fi
+else
+  bad "pr-gate.yml not found at $WORKFLOW"
+fi
+
+echo
+echo "==== classify-docs-only self-test: PASS=$PASS FAIL=$FAIL ===="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #2645 (epic #2636).

## Problem
`pr-gate.yml` is a **required** status check with no path awareness — a docs/board-only PR compiled `cqlite-core` all-features and (since #2644 just merged) ran the query-semantics oracle. A `paths`/`paths-ignore` trigger filter is NOT an option: if the required workflow doesn't fire, the required status never reports and the PR blocks forever.

## Solution
An **always-run** docs-only classifier step in the single `required` job (pattern mirrored from `observability-gate.yml`'s classify job):

- `scripts/ci/classify-docs-only.sh` — a pure, testable **allowlist** classifier. Reads the changed-file set on stdin. Exit 0 = docs-only, exit 1 = full path. **Fail-closed**: any rust/`Cargo.*`/`test-data/**`/`.github/**`/`scripts/**`/unknown-extension file, or an empty/ambiguous set, forces the full run. Sensitive dirs (`.github/`, `scripts/`, `test-data/`) force the full path even for a `*.md` inside them, so a Markdown edit next to a workflow/manifest/gate-script can't smuggle a code-relevant change past the gate.
- `.github/workflows/pr-gate.yml` — the `required` job always checks out (full history) and runs the classifier; **every heavy step** — workflow-policy, dataset-pin, Rust setup/fmt/clippy/build, fast tests, and the **#2644 query-semantics oracle** — is gated on `steps.classify.outputs.docs_only != 'true'` (fail-closed default = full run). A docs-only branch emits a green step summary, so the **required status always reports in both branches**. No `paths`/`paths-ignore` added.
- Changed-file SHAs are passed via quoted env vars (`$BASE_SHA`/`$HEAD_SHA`), never interpolated into `run:` — no injection.
- `scripts/tests/test_classify_docs_only.sh` — 25-case self-test proving short-circuit / full-path / fail-closed, plus the workflow structural contract (no path filter; classify always runs; heavy steps incl. the oracle gated fail-closed; a docs-only branch step exists so the status reports). Wired into the gate's `tooling-tests` component.

## Proof
- **docs→short-circuit**: real `git diff --name-only base...head` of `{docs/a.md, README.md}` → exit 0, verdict `docs-only`.
- **rust→full**: same diff + `cqlite-core/src/lib.rs` → exit 1, verdict `full`. Also workflow/script/manifest/Cargo/unknown-ext → full.
- **required always emits**: no `paths`/`paths-ignore`; classify has no `if:`; docs-only branch emits a green summary step. Asserted structurally in the self-test.
- **fail-closed**: empty set, unknown extension, and `*.md` under `.github`/`scripts`/`test-data` all → full.
- **gates the #2644 oracle**: the "Query-semantics oracle (fail-closed, #2644)" step carries `if: steps.classify.outputs.docs_only != 'true'`; self-test asserts an oracle-named heavy step is gated fail-closed.

## Gate
```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 2dd720508 branch: issue-2645-docs-only-classifier dirty: no
lite-scope: file-size fmt clippy scoped-tests
file-size:         PASS (1s)
fmt:               PASS (2s)
clippy:            PASS (99s)
scoped-tests:      PASS (74s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
The full gate (gate of record) has NOT been run here — flow-closer runs it once before merge.