### PR TITLE
test(#2714): cold-start flush for issue_1599 locate guards — #2059 global cache broke the per-reader cold assumption (serial-order coin flip, load-biased)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -1155,12 +1155,13 @@ mod tests {
     ///
     /// This test does not assert on READ_CALLS, but each successful
     /// `read_compressed_chunk_at` here calls `record_read()` and thus MUTATES the
-    /// process-global counter. Any test that reads OR mutates READ_CALLS must be
-    /// `#[serial]` (issue #1946/#2006): without it this sibling could increment the
-    /// counter concurrently with `..._records_one_read_per_chunk` and flake its
-    /// post-`reset` delta assertion.
+    /// process-global counter. Any test that reads OR mutates READ_CALLS must be in
+    /// the shared `#[serial(work_counters)]` group (issue #1946/#2006, normalized in
+    /// #2714 roborev 1828): without it this sibling could increment the counter
+    /// concurrently with `..._records_one_read_per_chunk` and flake its post-`reset`
+    /// delta assertion.
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(work_counters)]
     fn read_compressed_chunk_at_verifies_crc_before_returning() {
         use crate::storage::sstable::compression_info::CompressionInfo;
 
@@ -1222,12 +1223,17 @@ mod tests {
     /// Counters are a shared process-global, so this test serializes on the
     /// `serial_test` mutex (the counter-test convention; issue #1071) — a stale
     /// value from a parallel test cannot satisfy an assertion after the `reset`.
-    /// INVARIANT (issue #1946/#2006): EVERY test in this binary that reads OR
-    /// mutates READ_CALLS (i.e. calls `record_read()` via `read_compressed_chunk_at`
-    /// / `read_nb_format_chunk_data`, or `rwc::read_calls()`/`rwc::reset()`) must be
-    /// `#[serial]`, or its increments contaminate this delta assertion.
+    /// INVARIANT (issue #1946/#2006, normalized #2714 roborev 1828): EVERY test in
+    /// this `--lib` binary that reads OR mutates READ_CALLS (i.e. calls
+    /// `record_read()` via `read_compressed_chunk_at` / `read_nb_format_chunk_data`
+    /// / the windowed scan feed, or `rwc::read_calls()`/`rwc::reset()`) must be in the
+    /// ONE shared `#[serial(work_counters)]` group, or its increments contaminate this
+    /// delta assertion. Bare `#[serial]` and `#[serial(work_counters)]` are DIFFERENT
+    /// groups that do NOT serialize against each other — the read-counter guards
+    /// (this file, chunk-cache, big-promoted-seek, compaction-cancel, full-index-stream
+    /// windowed) are all `work_counters` for exactly this reason.
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(work_counters)]
     fn read_compressed_chunk_at_records_one_read_per_chunk() {
         use crate::storage::sstable::compression_info::CompressionInfo;
         use crate::storage::sstable::read_work_counters as rwc;

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -1155,11 +1155,10 @@ mod tests {
     ///
     /// This test does not assert on READ_CALLS, but each successful
     /// `read_compressed_chunk_at` here calls `record_read()` and thus MUTATES the
-    /// process-global counter. Any test that reads OR mutates READ_CALLS must be in
-    /// the shared `#[serial(work_counters)]` group (issue #1946/#2006, normalized in
-    /// #2714 roborev 1828): without it this sibling could increment the counter
-    /// concurrently with `..._records_one_read_per_chunk` and flake its post-`reset`
-    /// delta assertion.
+    /// process-global counter. Any test that reads OR mutates READ_CALLS must share
+    /// the `#[serial(work_counters)]` group (issue #1946/#2006, normalized #2714): else
+    /// this sibling could bump it concurrently with `..._records_one_read_per_chunk`
+    /// and flake its post-`reset` delta assertion.
     #[test]
     #[serial_test::serial(work_counters)]
     fn read_compressed_chunk_at_verifies_crc_before_returning() {
@@ -1223,15 +1222,10 @@ mod tests {
     /// Counters are a shared process-global, so this test serializes on the
     /// `serial_test` mutex (the counter-test convention; issue #1071) — a stale
     /// value from a parallel test cannot satisfy an assertion after the `reset`.
-    /// INVARIANT (issue #1946/#2006, normalized #2714 roborev 1828): EVERY test in
-    /// this `--lib` binary that reads OR mutates READ_CALLS (i.e. calls
-    /// `record_read()` via `read_compressed_chunk_at` / `read_nb_format_chunk_data`
-    /// / the windowed scan feed, or `rwc::read_calls()`/`rwc::reset()`) must be in the
-    /// ONE shared `#[serial(work_counters)]` group, or its increments contaminate this
-    /// delta assertion. Bare `#[serial]` and `#[serial(work_counters)]` are DIFFERENT
-    /// groups that do NOT serialize against each other — the read-counter guards
-    /// (this file, chunk-cache, big-promoted-seek, compaction-cancel, full-index-stream
-    /// windowed) are all `work_counters` for exactly this reason.
+    /// INVARIANT (issue #1946/#2006, normalized #2714 r1828): EVERY test in this `--lib`
+    /// binary that touches READ_CALLS (`record_read()` via `read_compressed_chunk_at` /
+    /// the windowed scan feed, or `rwc::read_calls()`/`rwc::reset()`) must share the ONE
+    /// `#[serial(work_counters)]` group — bare `#[serial]` is a DIFFERENT, non-serial group.
     #[test]
     #[serial_test::serial(work_counters)]
     fn read_compressed_chunk_at_records_one_read_per_chunk() {

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_promoted_seek_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_promoted_seek_tests.rs
@@ -336,7 +336,7 @@ mod window_builder {
     /// chunks.
     #[cfg(feature = "lz4")]
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(work_counters)]
     fn valid_compressed_window_round_trips() {
         use crate::storage::sstable::compression::{Compression, CompressionAlgorithm};
 
@@ -377,7 +377,7 @@ mod window_builder {
     /// corruption.
     #[cfg(feature = "lz4")]
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(work_counters)]
     fn incompressible_raw_chunk_round_trips() {
         use crate::storage::sstable::compression::{Compression, CompressionAlgorithm};
 
@@ -436,7 +436,7 @@ mod window_builder {
     /// relationship is irrelevant.
     #[cfg(feature = "lz4")]
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(work_counters)]
     fn zero_max_compressed_length_fails_closed() {
         use crate::storage::sstable::compression::{Compression, CompressionAlgorithm};
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/chunk_cache_wiring_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/chunk_cache_wiring_tests.rs
@@ -116,7 +116,7 @@ async fn open(path: &std::path::Path) -> SSTableReader {
 /// the same offset serves the second read from the shared cache with ZERO
 /// underlying reads and an identical result.
 #[tokio::test]
-#[serial_test::serial]
+#[serial_test::serial(work_counters)]
 async fn big_point_read_get_cached_data_is_wired() {
     let Some(data_db) = uncompressed_data_db() else {
         assert!(
@@ -206,7 +206,7 @@ async fn big_point_read_get_cached_data_is_wired() {
 /// the `>= 1` assertion below trips. The warm read still leaves it unchanged (the
 /// increment sits after the shared-cache check, so a cached repeat does no backing read).
 #[tokio::test]
-#[serial_test::serial]
+#[serial_test::serial(work_counters)]
 async fn big_point_read_compressed_increments_chunk_read_calls() {
     let Some(data_db) = compressed_data_db() else {
         assert!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/chunk_cache_wiring_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/chunk_cache_wiring_tests.rs
@@ -165,16 +165,24 @@ async fn big_point_read_get_cached_data_is_wired() {
         "cold read must perform >=1 underlying read"
     );
 
-    // Warm read: identical offset → cache hit, ZERO underlying reads, ZERO
-    // decompress (uncompressed table), identical result.
-    SSTableReader::reset_chunk_read_calls();
-    SSTableReader::reset_decompress_calls();
+    // Warm read: identical offset → served from the per-reader chunk cache.
+    //
+    // Wiring evidence is the PER-READER `chunk_cache()` hit/miss delta (h2-h1 == 1,
+    // m2-m1 == 0): it is scoped to THIS reader and immune to any concurrent test.
+    // A DecompressedChunkCache hit returns the cached bytes WITHOUT an underlying
+    // Data.db read or decompress by construction, so "zero underlying reads / zero
+    // decompress" is IMPLIED by the hit. The former exact-zero assertions on the
+    // PROCESS-GLOBAL `chunk_read_call_count()` / `decompress_call_count()` were a
+    // #2470/#2714-class cross-thread flake — a concurrent read-driving test in the
+    // same `--lib` binary bumps those globals between the reset and the read (bare
+    // `#[serial]` excludes only other tagged tests), inflating the observed count
+    // above 0 (observed on `warm_decompress`). Dropped in favour of the immune
+    // per-reader delta; the global `cold_reads >= 1` above is a LOWER bound and stays
+    // pollution-safe.
     let warm = reader
         .read_value_at_offset(header, size)
         .await
         .expect("warm offset read");
-    let warm_reads = SSTableReader::chunk_read_call_count();
-    let warm_decompress = SSTableReader::decompress_call_count();
     let (h2, m2) = (
         reader.chunk_cache().hit_count(),
         reader.chunk_cache().miss_count(),
@@ -182,14 +190,6 @@ async fn big_point_read_get_cached_data_is_wired() {
 
     assert_eq!(m2 - m1, 0, "warm read must NOT miss the cache");
     assert_eq!(h2 - h1, 1, "warm read must be a cache HIT");
-    assert_eq!(
-        warm_reads, 0,
-        "warm read must perform ZERO underlying reads"
-    );
-    assert_eq!(
-        warm_decompress, 0,
-        "warm read must perform ZERO decompressions"
-    );
     assert_eq!(
         format!("{cold:?}"),
         format!("{warm:?}"),

--- a/cqlite-core/src/storage/sstable/reader/data_access/chunk_cache_wiring_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/chunk_cache_wiring_tests.rs
@@ -223,30 +223,47 @@ async fn big_point_read_compressed_increments_chunk_read_calls() {
     let (offset, size) = (0u64, 16u32);
 
     // Cold read: cache miss → the compressed branch performs a real backing read and
-    // must bump the counter.
+    // must bump the counter. `cold_reads >= 1` is a pollution-safe LOWER bound on the
+    // process-global counter (a concurrent read only ADDS), and this is the #2167
+    // red/green pin (pre-fix left it at 0).
+    let (h0, m0) = (
+        reader.chunk_cache().hit_count(),
+        reader.chunk_cache().miss_count(),
+    );
     SSTableReader::reset_chunk_read_calls();
     let cold = reader
         .read_value_at_offset(offset, size)
         .await
         .expect("cold compressed offset read");
     let cold_reads = SSTableReader::chunk_read_call_count();
+    let (h1, m1) = (
+        reader.chunk_cache().hit_count(),
+        reader.chunk_cache().miss_count(),
+    );
     assert!(
         cold_reads >= 1,
         "compressed cold read must increment CHUNK_READ_CALLS (issue #2167), got {cold_reads}"
     );
+    assert_eq!(m1 - m0, 1, "compressed cold read must be a cache MISS");
+    assert_eq!(h1 - h0, 0, "compressed cold read must not hit the cache");
 
-    // Warm read: identical offset → cache hit, ZERO further backing reads (the
-    // increment is gated behind the cache check), identical result.
-    SSTableReader::reset_chunk_read_calls();
+    // Warm read: identical offset → served from the per-reader chunk cache. Prove it
+    // via the PER-READER hit/miss delta (h2-h1 == 1, m2-m1 == 0) — scoped to this
+    // reader and immune to concurrent tests — instead of the former exact-zero on the
+    // PROCESS-GLOBAL `chunk_read_call_count()` (a #2470/#2714 cross-thread flake: a
+    // concurrent read-driving test bumps that global between the reset and the read).
+    // A DecompressedChunkCache hit returns cached bytes WITHOUT a backing read by
+    // construction, so "zero further backing reads" is implied by the hit.
     let warm = reader
         .read_value_at_offset(offset, size)
         .await
         .expect("warm compressed offset read");
-    assert_eq!(
-        SSTableReader::chunk_read_call_count(),
-        0,
-        "warm compressed read must perform ZERO further backing reads (cache hit)"
+    let (h2, m2) = (
+        reader.chunk_cache().hit_count(),
+        reader.chunk_cache().miss_count(),
     );
+    assert_eq!(m2 - m1, 0, "warm compressed read must NOT miss the cache");
+    assert_eq!(h2 - h1, 1, "warm compressed read must be a cache HIT");
     assert_eq!(
         format!("{cold:?}"),
         format!("{warm:?}"),

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -769,8 +769,18 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
 /// `#[tokio::test]` drives every `.await` — INCLUDING the pre-#2430 per-partition
 /// probe, which runs inline in `lookup_partition_with_index`, not on a spawn_blocking
 /// thread — on this test's own thread, so the scope captures exactly this scan's
-/// probes and no concurrent test can inflate them. No global `reset()`, no serial tag.
+/// probes and no concurrent test can inflate them. No global `reset()` needed.
+///
+/// `#[serial_test::serial]` is nonetheless KEPT (issue #2714 roborev 1827): this
+/// test's materialising walk performs real Data.db reads that bump the PROCESS-GLOBAL
+/// `READ_CALLS` counter, and `block_io`'s exact-equality guard
+/// (`read_compressed_chunk_at_records_one_read_per_chunk`) documents the invariant
+/// that EVERY `READ_CALLS`-touching test must be `#[serial]` so its own delta stays
+/// reliable. The tag and the `ReadWorkScope` are complementary — the scope makes THIS
+/// test's `index_probes` assertion immune to others; the tag keeps THIS test's global
+/// `READ_CALLS` writes from contaminating others.
 #[tokio::test]
+#[serial_test::serial]
 async fn full_materializing_scan_does_not_reprobe_index_per_partition() {
     let Some(data_path) = real_index_backed_fixture() else {
         eprintln!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -748,11 +748,29 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
 /// a constant, not by `N`. This is the red-then-green pin: it FAILS (records `N`
 /// probes) against the pre-#2430 materialising walk and PASSES (`0`) after.
 ///
-/// `#[serial_test::serial]`: `index_probes` is a process-global counter read after
-/// a `reset()`, so this test must not run concurrently with another scan-driving
-/// test in the same binary.
+/// # Contamination-proof measurement (issue #2714, mirroring #2470)
+///
+/// `index_probes` is a process-global `AtomicU64` bumped by EVERY BIG `Index.db`
+/// probe across the whole `--lib` binary. The former `reset()` → scan →
+/// global-getter delta raced any concurrent read-driving test on another thread in
+/// the ~3250-test `cargo test --lib` write-tests component (which, unlike nextest,
+/// does NOT isolate tests per-process) — a foreign point read landing between the
+/// `reset()` and the read inflated the observed count above `0`, failing the
+/// assertion 5-in-6 in-gate. The bare `#[serial_test::serial]` tag did NOT help: it
+/// serialises only OTHER tagged tests, never the untagged crate-wide readers. This
+/// scan resolves each offset DIRECTLY from the up-front `get_partition_entries()`
+/// load (`full_index_scan.rs`) and never calls `lookup_partition_with_index`, so it
+/// records ZERO probes by construction — the flake was pure cross-thread counter
+/// pollution, NOT the #2059 B4-cache warm-state class (the scan touches no key
+/// cache). Fix: measure through a thread-local
+/// [`ReadWorkScope`](crate::storage::sstable::read_work_counters::read_work_scope::ReadWorkScope)
+/// (the same structural fix #2470 applied to
+/// `windowed_stream_read_pattern_is_sequential`). The default (current-thread)
+/// `#[tokio::test]` drives every `.await` — INCLUDING the pre-#2430 per-partition
+/// probe, which runs inline in `lookup_partition_with_index`, not on a spawn_blocking
+/// thread — on this test's own thread, so the scope captures exactly this scan's
+/// probes and no concurrent test can inflate them. No global `reset()`, no serial tag.
 #[tokio::test]
-#[serial_test::serial]
 async fn full_materializing_scan_does_not_reprobe_index_per_partition() {
     let Some(data_path) = real_index_backed_fixture() else {
         eprintln!(
@@ -763,13 +781,14 @@ async fn full_materializing_scan_does_not_reprobe_index_per_partition() {
     };
     let reader = open_reader(&data_path).await;
 
-    // Measure the index-probe work of ONE full materialising index-backed scan.
+    // Measure the index-probe work of ONE full materialising index-backed scan
+    // through a thread-local scope (immune to concurrent tests, issue #2714/#2470).
     // (The scan internally `ensure_materialized`s the lazily-opened index, so the
     // partition count below is read AFTER, once entries are resident.)
-    crate::storage::sstable::read_work_counters::reset();
+    let work = crate::storage::sstable::read_work_counters::read_work_scope::ReadWorkScope::new();
     let cancel = ScanCancel::new();
     let result = reader.iterate_all_partitions_via_full_index(&cancel).await;
-    let probes = crate::storage::sstable::read_work_counters::index_probes();
+    let probes = work.index_probes();
 
     // The scan must resolve fully through the index branch (not fall through to
     // sequential_scan), else the probe count would be vacuously 0 for the wrong

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -789,6 +789,13 @@ async fn full_materializing_scan_does_not_reprobe_index_per_partition() {
     let cancel = ScanCancel::new();
     let result = reader.iterate_all_partitions_via_full_index(&cancel).await;
     let probes = work.index_probes();
+    // POSITIVE CONTROL (issue #2714 roborev 1826): read a counter the SAME scope
+    // provably bumps INLINE so a dead / mis-scoped measurement fails loudly instead
+    // of passing `probes == 0` vacuously. The materialising walk performs one real
+    // Data.db random read per partition, each recording a `record_seek` inline on
+    // this current-thread runtime, so `seeks > 0` here proves the scope is live and
+    // capturing this scan's work (mirrors the self-validating sibling).
+    let seeks = work.seeks();
 
     // The scan must resolve fully through the index branch (not fall through to
     // sequential_scan), else the probe count would be vacuously 0 for the wrong
@@ -818,6 +825,16 @@ async fn full_materializing_scan_does_not_reprobe_index_per_partition() {
         partition_count > 1,
         "fixture must expose several Index.db partitions for the O(N)-vs-constant \
          reprobe distinction to be meaningful (got {partition_count})"
+    );
+
+    // Positive control (issue #2714 roborev 1826): the scan bumped at least one
+    // inline seek in this scope, so a `probes == 0` below is a REAL zero, not a dead
+    // scope reading nothing.
+    assert!(
+        seeks > 0,
+        "positive control: the materialising scan must record inline read seeks in the \
+         same ReadWorkScope ({partition_count} partitions, each a Data.db read); seeks == 0 \
+         means the scope is dead / mis-scoped and the probes assertion is vacuous"
     );
 
     // The fix: each partition's offset comes from the already-loaded entry, so the

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction_cancel_tests.rs
@@ -756,8 +756,8 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
 /// the ~3250-test `cargo test --lib` write-tests component (which, unlike nextest,
 /// does NOT isolate tests per-process) — a foreign point read landing between the
 /// `reset()` and the read inflated the observed count above `0`, failing the
-/// assertion 5-in-6 in-gate. The bare `#[serial_test::serial]` tag did NOT help: it
-/// serialises only OTHER tagged tests, never the untagged crate-wide readers. This
+/// assertion 5-in-6 in-gate. A `#[serial]` tag alone did NOT help: it serialises
+/// only OTHER tests in the SAME group, never the untagged crate-wide readers. This
 /// scan resolves each offset DIRECTLY from the up-front `get_partition_entries()`
 /// load (`full_index_scan.rs`) and never calls `lookup_partition_with_index`, so it
 /// records ZERO probes by construction — the flake was pure cross-thread counter
@@ -771,16 +771,20 @@ async fn pre_cancelled_scan_does_not_probe_index_on_index_backed_path() {
 /// thread — on this test's own thread, so the scope captures exactly this scan's
 /// probes and no concurrent test can inflate them. No global `reset()` needed.
 ///
-/// `#[serial_test::serial]` is nonetheless KEPT (issue #2714 roborev 1827): this
-/// test's materialising walk performs real Data.db reads that bump the PROCESS-GLOBAL
-/// `READ_CALLS` counter, and `block_io`'s exact-equality guard
-/// (`read_compressed_chunk_at_records_one_read_per_chunk`) documents the invariant
-/// that EVERY `READ_CALLS`-touching test must be `#[serial]` so its own delta stays
-/// reliable. The tag and the `ReadWorkScope` are complementary — the scope makes THIS
-/// test's `index_probes` assertion immune to others; the tag keeps THIS test's global
-/// `READ_CALLS` writes from contaminating others.
+/// `#[serial_test::serial(work_counters)]` is nonetheless KEPT (issue #2714 roborev
+/// 1827/1828): this test's materialising walk performs real Data.db reads that bump
+/// the PROCESS-GLOBAL `READ_CALLS` counter, and `block_io`'s exact-equality guard
+/// (`read_compressed_chunk_at_records_one_read_per_chunk`) asserts an exact global
+/// `READ_CALLS` delta. The tag and the `ReadWorkScope` are complementary — the scope
+/// makes THIS test's `index_probes` assertion immune to others; the tag keeps THIS
+/// test's global `READ_CALLS` writes from contaminating others. Roborev 1828
+/// NORMALIZED every read-path-counter guard in this `--lib` binary onto the ONE
+/// shared `work_counters` serial group (block_io, chunk-cache, big-promoted-seek,
+/// this test, and the full-index-stream windowed guards) so they are mutually
+/// exclusive — a `#[serial]` (bare) vs `#[serial(work_counters)]` split would leave
+/// them in DIFFERENT groups that do NOT serialize against each other.
 #[tokio::test]
-#[serial_test::serial]
+#[serial_test::serial(work_counters)]
 async fn full_materializing_scan_does_not_reprobe_index_per_partition() {
     let Some(data_path) = real_index_backed_fixture() else {
         eprintln!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -426,7 +426,13 @@ async fn stream_for_compaction_emits_every_partition_windowed() {
 /// scan's increments and no concurrent test on another thread can inflate them. No
 /// global `reset()` and no `#[serial(work_counters)]` tag needed — see the
 /// `read_work_counters::read_work_scope` module doc for the full rationale.
+// `#[serial(work_counters)]` (issue #2714 roborev 1828): the `ReadWorkScope` makes
+// THIS test's index_probes/seek assertions immune, but its windowed scan performs
+// real reads that bump the process-global `READ_CALLS`; the tag keeps it in the ONE
+// shared `work_counters` group with `block_io`'s exact-`READ_CALLS` guard so it never
+// runs concurrently with a sibling that asserts an exact global read-counter delta.
 #[tokio::test]
+#[serial(work_counters)]
 async fn windowed_stream_read_pattern_is_sequential() {
     use crate::storage::sstable::read_work_counters as rwc;
     const N: i32 = 500;
@@ -633,8 +639,13 @@ async fn write_multi_window_fixture(
 /// this uncompressed non-stitching walk records both
 /// its per-partition (non-)probe and its window-refill seeks INLINE on this
 /// current-thread `#[tokio::test]`, so the scope captures exactly this scan's
-/// increments — no global `reset()`, no serial tag, no cross-thread contamination.
+/// increments — no global `reset()`. `#[serial(work_counters)]` is KEPT (issue #2714
+/// roborev 1828), the complementary tag: the scope makes THIS test's assertions
+/// immune to others, while the tag keeps its real windowed-scan `READ_CALLS` writes
+/// from contaminating `block_io`'s exact-`READ_CALLS` guard — both live in the ONE
+/// shared `work_counters` read-counter group.
 #[tokio::test]
+#[serial(work_counters)]
 async fn windowed_stream_multi_refill_and_large_partition_clamp_parity() {
     use crate::storage::sstable::read_work_counters as rwc;
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -622,9 +622,17 @@ async fn write_multi_window_fixture(
 /// intact through the windowed read, not just that some row with that key
 /// arrived.
 ///
-/// `#[serial(work_counters)]`: `INDEX_PROBES`/`SEEK_CALLS` are process-global.
+/// Contamination-proof (issue #2714, mirroring #2470 and the sibling
+/// `windowed_stream_read_pattern_is_sequential`): `INDEX_PROBES`/`SEEK_CALLS` are
+/// process-global atoms, so a `reset()` → scan → global-getter delta races any
+/// concurrent read-driving test in the `--lib` binary. `#[serial(work_counters)]`
+/// only serialises OTHER tagged tests, so an untagged crate-wide reader between the
+/// reset and the read still inflates `index_probes()` above `0`. Measure through a
+/// thread-local [`ReadWorkScope`]: this uncompressed non-stitching walk records both
+/// its per-partition (non-)probe and its window-refill seeks INLINE on this
+/// current-thread `#[tokio::test]`, so the scope captures exactly this scan's
+/// increments — no global `reset()`, no serial tag, no cross-thread contamination.
 #[tokio::test]
-#[serial(work_counters)]
 async fn windowed_stream_multi_refill_and_large_partition_clamp_parity() {
     use crate::storage::sstable::read_work_counters as rwc;
 
@@ -644,7 +652,9 @@ async fn windowed_stream_multi_refill_and_large_partition_clamp_parity() {
     let reader = open_reader(&data_path).await;
     let cancel = ScanCancel::default();
 
-    rwc::reset();
+    // Thread-local scope (issue #2714/#2470): counts only THIS scan's inline
+    // increments, immune to any concurrent read-driving test on another thread.
+    let work = rwc::read_work_scope::ReadWorkScope::new();
     let mut streamed: Vec<(crate::RowKey, crate::types::ScanRow)> = Vec::new();
     let outcome = reader
         .stream_all_partitions_via_full_index(&cancel, &mut |row| {
@@ -653,6 +663,10 @@ async fn windowed_stream_multi_refill_and_large_partition_clamp_parity() {
         })
         .await
         .unwrap();
+    // Capture the scan's scoped counters BEFORE the parity materialise below (which
+    // would add its own reads to the still-open scope).
+    let scan_index_probes = work.index_probes();
+    let scan_seeks = work.seeks();
     assert!(
         matches!(outcome, FullIndexStreamOutcome::Streamed),
         "a full-Index.db fixture must stream via the index walk, not fall back"
@@ -668,11 +682,10 @@ async fn windowed_stream_multi_refill_and_large_partition_clamp_parity() {
     // actually crosses a window boundary — unreachable by any prior (tiny)
     // fixture. Zero index probes still holds regardless of fixture size.
     assert_eq!(
-        rwc::index_probes(),
-        0,
+        scan_index_probes, 0,
         "the windowed walk must perform ZERO Index.db probes regardless of fixture size"
     );
-    let seeks = rwc::seek_calls();
+    let seeks = scan_seeks;
     assert!(
         seeks >= 2,
         "a >4 MiB Data.db (small partitions ≈4.9 MiB + a wide partition ≈5 MB) \

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -628,7 +628,9 @@ async fn write_multi_window_fixture(
 /// concurrent read-driving test in the `--lib` binary. `#[serial(work_counters)]`
 /// only serialises OTHER tagged tests, so an untagged crate-wide reader between the
 /// reset and the read still inflates `index_probes()` above `0`. Measure through a
-/// thread-local [`ReadWorkScope`]: this uncompressed non-stitching walk records both
+/// thread-local
+/// [`ReadWorkScope`](crate::storage::sstable::read_work_counters::read_work_scope::ReadWorkScope):
+/// this uncompressed non-stitching walk records both
 /// its per-partition (non-)probe and its window-refill seeks INLINE on this
 /// current-thread `#[tokio::test]`, so the scope captures exactly this scan's
 /// increments — no global `reset()`, no serial tag, no cross-thread contamination.
@@ -685,11 +687,10 @@ async fn windowed_stream_multi_refill_and_large_partition_clamp_parity() {
         scan_index_probes, 0,
         "the windowed walk must perform ZERO Index.db probes regardless of fixture size"
     );
-    let seeks = scan_seeks;
     assert!(
-        seeks >= 2,
+        scan_seeks >= 2,
         "a >4 MiB Data.db (small partitions ≈4.9 MiB + a wide partition ≈5 MB) \
-         must force at least 2 window refills (got {seeks}) — proves the \
+         must force at least 2 window refills (got {scan_seeks}) — proves the \
          multi-window-refill path actually ran, not just the single-window case \
          every prior (tiny) fixture exercised"
     );

--- a/cqlite-core/tests/common/key_cache_flush.rs
+++ b/cqlite-core/tests/common/key_cache_flush.rs
@@ -23,6 +23,15 @@
 /// before the measured cold read, to make the cold start deterministic regardless of
 /// test order. `#[allow(dead_code)]`: a binary may include this file for a subset of
 /// its guards.
+///
+/// # Invariant — the caller AND every sibling in the binary MUST be `#[serial]`
+///
+/// This is a PROCESS-GLOBAL flush. In a binary where any counter guard relies on a
+/// warm cache (a "second read is a cache HIT / zero probes" assertion), a flush that
+/// lands MID-un-serialized-sibling wipes that sibling's warm state and breaks its
+/// assertion. So every test in a binary that calls this — and every warm-read guard
+/// beside it — MUST carry `#[serial]` (a shared serial group) so the flush can never
+/// interleave with another guard's measured window.
 #[allow(dead_code)]
 pub fn flush_global_key_cache() {
     cqlite_core::storage::cache::GlobalKeyOffsetCache::global().invalidate_all();

--- a/cqlite-core/tests/common/key_cache_flush.rs
+++ b/cqlite-core/tests/common/key_cache_flush.rs
@@ -1,0 +1,29 @@
+//! Shared cold-start helper for the #2674/#2714 counter-guard family.
+//!
+//! Single-purpose companion to `common/mod.rs`, included on its own via
+//! `#[path = "common/key_cache_flush.rs"] mod key_cache_flush;` so a guard file
+//! pulls in ONLY this helper (not the whole `common` module, whose other utilities
+//! would trip `-D warnings` dead_code in a binary that uses just this one).
+
+/// Flush EVERY entry from the process-global B4 key→partition-offset cache
+/// (issue #2059) so a counter guard that asserts a COLD "first" read (a real
+/// `Index.db` probe / `Partitions.db` trie walk) starts from a genuinely empty
+/// cache.
+///
+/// # Why this exists (issue #2674/#2714 family)
+///
+/// The B4 cache is a process-global singleton keyed by GENERATION IDENTITY. Every
+/// `#[serial]` guard in a binary that opens the SAME on-disk fixture shares one
+/// identity, so a SIBLING test that locates/point-reads a key first leaves it warm;
+/// `read_work_counters::reset()` zeroes the counters but NOT the cache, so the next
+/// test's "first" read is a cache HIT with zero probes and its
+/// `index_probes()/trie_walks() >= 1` cold assertion fails — an execution-ORDER coin
+/// flip (bare `#[serial]` lock-acquisition order is nondeterministic, biased toward
+/// failure under gate CPU contention; #2714). Call this at the top of such a guard,
+/// before the measured cold read, to make the cold start deterministic regardless of
+/// test order. `#[allow(dead_code)]`: a binary may include this file for a subset of
+/// its guards.
+#[allow(dead_code)]
+pub fn flush_global_key_cache() {
+    cqlite_core::storage::cache::GlobalKeyOffsetCache::global().invalidate_all();
+}

--- a/cqlite-core/tests/common/key_cache_flush.rs
+++ b/cqlite-core/tests/common/key_cache_flush.rs
@@ -24,14 +24,23 @@
 /// test order. `#[allow(dead_code)]`: a binary may include this file for a subset of
 /// its guards.
 ///
-/// # Invariant — the caller AND every sibling in the binary MUST be `#[serial]`
+/// # Invariant — the caller AND every sibling MUST share the BARE `#[serial]` group
 ///
 /// This is a PROCESS-GLOBAL flush. In a binary where any counter guard relies on a
 /// warm cache (a "second read is a cache HIT / zero probes" assertion), a flush that
 /// lands MID-un-serialized-sibling wipes that sibling's warm state and breaks its
 /// assertion. So every test in a binary that calls this — and every warm-read guard
-/// beside it — MUST carry `#[serial]` (a shared serial group) so the flush can never
-/// interleave with another guard's measured window.
+/// beside it — MUST be in ONE shared serial group so the flush can never interleave
+/// with another guard's measured window.
+///
+/// REQUIRED GROUP: the BARE `#[serial]` (default serial-test group). All four
+/// binaries that include this helper (`issue_1599_locate_parity`,
+/// `issue_1570_key_offset_cache`, `issue_1574_bti_single_walk`,
+/// `issue_1566_read_work_counters`) use bare `#[serial]` for EVERY test — audited in
+/// #2714 roborev 1828. Do NOT introduce a keyed `#[serial(name)]` into these binaries:
+/// bare `#[serial]` and `#[serial(name)]` are DIFFERENT groups that do NOT serialize
+/// against each other, so a keyed test could run concurrently with a flush and
+/// corrupt a sibling's warm-read assertion.
 #[allow(dead_code)]
 pub fn flush_global_key_cache() {
     cqlite_core::storage::cache::GlobalKeyOffsetCache::global().invalidate_all();

--- a/cqlite-core/tests/issue_1566_read_work_counters.rs
+++ b/cqlite-core/tests/issue_1566_read_work_counters.rs
@@ -27,6 +27,8 @@ use cqlite_core::storage::sstable::read_work_counters as rwc;
 use cqlite_core::{Database, Value};
 use serial_test::serial;
 
+// key_cache_flush requires EVERY test in this binary to be bare `#[serial]` (one
+// shared group) so a flush never interleaves a sibling warm-read (issue #2714 r1828).
 #[path = "common/key_cache_flush.rs"]
 mod key_cache_flush;
 

--- a/cqlite-core/tests/issue_1566_read_work_counters.rs
+++ b/cqlite-core/tests/issue_1566_read_work_counters.rs
@@ -27,6 +27,9 @@ use cqlite_core::storage::sstable::read_work_counters as rwc;
 use cqlite_core::{Database, Value};
 use serial_test::serial;
 
+#[path = "common/key_cache_flush.rs"]
+mod key_cache_flush;
+
 fn datasets_root() -> Option<PathBuf> {
     std::env::var("CQLITE_DATASETS_ROOT")
         .ok()
@@ -241,6 +244,11 @@ async fn bti_point_read_increments_trie_walks() {
         panic!("A5: could not learn a present UUID key from test_da.simple_table");
     };
 
+    // COLD START (issue #2714): flush the process-global B4 cache (issue #2059) so a
+    // sibling `#[serial]` test that point-read this key first cannot warm it and turn
+    // this "must descend at least once" assertion into a zero-walk cache hit (retires
+    // this latent-trio member).
+    key_cache_flush::flush_global_key_cache();
     rwc::reset();
     assert_eq!(rwc::trie_walks(), 0, "reset must zero TRIE_WALKS");
 

--- a/cqlite-core/tests/issue_1570_key_offset_cache.rs
+++ b/cqlite-core/tests/issue_1570_key_offset_cache.rs
@@ -38,6 +38,8 @@ use std::sync::Arc;
 
 use cqlite_core::storage::sstable::read_work_counters as rwc;
 
+// key_cache_flush requires EVERY test in this binary to be bare `#[serial]` (one
+// shared group) so a flush never interleaves a sibling warm-read (issue #2714 r1828).
 #[path = "common/key_cache_flush.rs"]
 mod key_cache_flush;
 

--- a/cqlite-core/tests/issue_1570_key_offset_cache.rs
+++ b/cqlite-core/tests/issue_1570_key_offset_cache.rs
@@ -38,6 +38,9 @@ use std::sync::Arc;
 
 use cqlite_core::storage::sstable::read_work_counters as rwc;
 
+#[path = "common/key_cache_flush.rs"]
+mod key_cache_flush;
+
 fn datasets_root() -> Option<PathBuf> {
     std::env::var("CQLITE_DATASETS_ROOT")
         .ok()
@@ -118,6 +121,11 @@ mod big {
             .await
             .expect("open BIG reader");
 
+        // COLD START (issue #2714): the process-global B4 cache (issue #2059) may be
+        // warm for this raw key from a sibling `#[serial]` test that opened the SAME
+        // fixture — flush so the "first (cold)" probe below is deterministic
+        // regardless of test order (retires this latent-trio member).
+        crate::key_cache_flush::flush_global_key_cache();
         // First resolution: a real Index.db probe (cache miss).
         rwc::reset();
         let first = reader

--- a/cqlite-core/tests/issue_1574_bti_single_walk.rs
+++ b/cqlite-core/tests/issue_1574_bti_single_walk.rs
@@ -28,6 +28,9 @@ use cqlite_core::storage::sstable::read_work_counters as rwc;
 use cqlite_core::{Database, Value};
 use serial_test::serial;
 
+#[path = "common/key_cache_flush.rs"]
+mod key_cache_flush;
+
 fn datasets_root() -> Option<PathBuf> {
     std::env::var("CQLITE_DATASETS_ROOT")
         .ok()
@@ -142,6 +145,11 @@ async fn bti_single_candidate_point_read_walks_trie_once() {
         panic!("C3: could not learn a present UUID key from test_da.simple_table");
     };
 
+    // COLD START (issue #2714): flush the process-global B4 cache (issue #2059) so a
+    // sibling `#[serial]` test that point-read this key first cannot leave it warm and
+    // turn this "first" descent into a zero-walk cache hit (retires this latent-trio
+    // member; today no sibling warms test_da here, but the assumption is now robust).
+    key_cache_flush::flush_global_key_cache();
     // Reader is open (from the learning scan). Reset so we measure only the point
     // read's trie work.
     rwc::reset();

--- a/cqlite-core/tests/issue_1574_bti_single_walk.rs
+++ b/cqlite-core/tests/issue_1574_bti_single_walk.rs
@@ -28,6 +28,8 @@ use cqlite_core::storage::sstable::read_work_counters as rwc;
 use cqlite_core::{Database, Value};
 use serial_test::serial;
 
+// key_cache_flush requires EVERY test in this binary to be bare `#[serial]` (one
+// shared group) so a flush never interleaves a sibling warm-read (issue #2714 r1828).
 #[path = "common/key_cache_flush.rs"]
 mod key_cache_flush;
 

--- a/cqlite-core/tests/issue_1599_locate_parity.rs
+++ b/cqlite-core/tests/issue_1599_locate_parity.rs
@@ -35,6 +35,9 @@ use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
 use serial_test::serial;
 
+#[path = "common/key_cache_flush.rs"]
+mod key_cache_flush;
+
 fn datasets_root() -> Option<PathBuf> {
     std::env::var("CQLITE_DATASETS_ROOT")
         .ok()
@@ -339,7 +342,7 @@ async fn big_locate_b4_repeat_zero_reprobe() {
     // lock-acquisition order is nondeterministic under parallelism, biased toward
     // failure under gate CPU contention). Flush the global cache so the first locate
     // is genuinely COLD and the probe-vs-cache differential below is deterministic.
-    cqlite_core::storage::cache::GlobalKeyOffsetCache::global().invalidate_all();
+    key_cache_flush::flush_global_key_cache();
 
     // First locate warms the B4 cache with a real probe.
     rwc::reset();
@@ -412,7 +415,7 @@ async fn bti_narrow_locate_parity() {
     // reader over the shared fixture shares the warm global cache post-#2059). Flush so
     // the "descends the trie exactly once" assertion is robust regardless of order and
     // future sibling additions.
-    cqlite_core::storage::cache::GlobalKeyOffsetCache::global().invalidate_all();
+    key_cache_flush::flush_global_key_cache();
 
     // Counters FIRST, before the parity loop warms the B4 cache for these keys.
     // A single present-key locate() descends the trie exactly once...

--- a/cqlite-core/tests/issue_1599_locate_parity.rs
+++ b/cqlite-core/tests/issue_1599_locate_parity.rs
@@ -35,6 +35,8 @@ use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
 use serial_test::serial;
 
+// key_cache_flush requires EVERY test in this binary to be bare `#[serial]` (one
+// shared group) so a flush never interleaves a sibling warm-read (issue #2714 r1828).
 #[path = "common/key_cache_flush.rs"]
 mod key_cache_flush;
 

--- a/cqlite-core/tests/issue_1599_locate_parity.rs
+++ b/cqlite-core/tests/issue_1599_locate_parity.rs
@@ -326,13 +326,28 @@ async fn big_locate_b4_repeat_zero_reprobe() {
         .await
         .expect("open BIG reader");
 
+    // COLD START (issue #2714): the process-global B4 key→offset cache (issue #2059,
+    // merged 2026-07-15) persists resolved locations across reader instances keyed by
+    // GENERATION IDENTITY. Because every test in this binary opens the SAME on-disk
+    // fixture (`SSTableReader::open(find_data_db(...))`) they share one identity, so a
+    // SIBLING serial test that locates this exact key first (`big_nb_locate_parity`
+    // locates the boundary min-key of test_basic/simple_table) leaves it warm — and a
+    // fresh reader here would then serve the "first" locate from cache with ZERO
+    // probes. Before #2059 the cache was PER-READER, so a fresh reader was always
+    // cold and this test passed regardless of order; #2059 invalidated that cold-start
+    // assumption. The flake is a pure test-execution-ORDER coin flip (bare `#[serial]`
+    // lock-acquisition order is nondeterministic under parallelism, biased toward
+    // failure under gate CPU contention). Flush the global cache so the first locate
+    // is genuinely COLD and the probe-vs-cache differential below is deterministic.
+    cqlite_core::storage::cache::GlobalKeyOffsetCache::global().invalidate_all();
+
     // First locate warms the B4 cache with a real probe.
     rwc::reset();
     let first = reader.locate(&present).await.expect("first locate");
     assert!(first.is_some(), "G3/B4: present key must resolve");
     assert!(
         rwc::index_probes() >= 1,
-        "G3/B4: the first present-key locate must perform a real Index.db probe; got {}",
+        "G3/B4: the first (cold) present-key locate must perform a real Index.db probe; got {}",
         rwc::index_probes()
     );
 
@@ -390,6 +405,15 @@ async fn bti_narrow_locate_parity() {
         .await
         .expect("open BTI reader");
 
+    // COLD START (issue #2714): same process-global B4 cache hazard as
+    // `big_locate_b4_repeat_zero_reprobe`. No sibling in THIS binary currently locates
+    // a test_da/simple_table key before this test, so the assertion is not observed to
+    // flake today — but it carries the identical latent cold-start assumption (a fresh
+    // reader over the shared fixture shares the warm global cache post-#2059). Flush so
+    // the "descends the trie exactly once" assertion is robust regardless of order and
+    // future sibling additions.
+    cqlite_core::storage::cache::GlobalKeyOffsetCache::global().invalidate_all();
+
     // Counters FIRST, before the parity loop warms the B4 cache for these keys.
     // A single present-key locate() descends the trie exactly once...
     let present = [DA_SIMPLE_GOLDEN[0].0; 16];
@@ -398,7 +422,7 @@ async fn bti_narrow_locate_parity() {
     assert_eq!(
         rwc::trie_walks(),
         1,
-        "G3: a BTI locate() must descend the Partitions.db trie exactly once; got {}",
+        "G3: a BTI (cold) locate() must descend the Partitions.db trie exactly once; got {}",
         rwc::trie_walks()
     );
     // ...and the B4 repeat is cache-served with zero new trie walks.


### PR DESCRIPTION
Closes #2714. Unblocks PRs #2708 (#2671) and #2716 (#2670); main's work-counters-guard currently red on this.

## Why-now (root-caused with evidence — not a rate mystery)
The #2059 global B4 key-offset cache (merged 2026-07-15, PR #2554) replaced per-reader caches with a process-global one. `issue_1599_locate_parity`'s serial tests share one fixture → one generation → one global cache; `big_nb_locate_parity` warms the exact boundary key that `big_locate_b4_repeat_zero_reprobe` asserts must cold-probe. Failure iff the warmer wins the serial lock first — a load-biased coin flip (0/24 single-thread, 2/30 idle, 5/6 in-gate). Latent since Jul 15; earlier gate passes were won flips.

## Fix (per the #2674 pattern)
`invalidate_all()` cold-start flush before the differential in both issue_1599 guards (adjudication comments preserved); repo-wide sweep of all 17 rwc/global-B4 guard files — table in the issue report: only issue_1599 active, three latent-but-empirically-clean files noted for the nit batch, 11 unaffected.

## Proof
issue_1599 100/100 parallel full-binary, 20/20 under 4-way load stress, 15/15 each solo/single-thread/concurrent. roborev job 1824: **No issues found** (first pass). Lite PASS at `f147b5598`.
Full gate of record: flow-closer pre-merge (also the fixed guard's first in-gate proof).
