### PR TITLE
ci(#2653): python-ci builds/tests the shipped release-unwind profile

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -56,7 +56,11 @@ jobs:
       - name: Build local wheel
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --out dist --manylinux off
+          # release-unwind: matches the shipped profile in python-release.yml so
+          # CI exercises the exact panic = "unwind" build that PyPI receives —
+          # the PyO3 catch_unwind firewall (issue #1440) is active here, catching
+          # a panic-strategy regression at PR/CI time instead of at release.
+          args: --profile release-unwind --out dist --manylinux off
           working-directory: bindings/python
 
       - name: Install wheel and smoke dependencies
@@ -142,7 +146,11 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          # release-unwind: matches the shipped profile in python-release.yml so
+          # CI builds the exact panic = "unwind" wheel that PyPI receives (the
+          # PyO3 catch_unwind firewall, issue #1440), catching a panic-strategy
+          # regression at CI time instead of at release.
+          args: --profile release-unwind --out dist
           working-directory: bindings/python
           manylinux: ${{ matrix.manylinux || 'auto' }}
 
@@ -236,7 +244,12 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          # release-unwind: matches the shipped profile in python-release.yml so
+          # the tested wheel is byte-identical in panic strategy to the PyPI
+          # artifact (panic = "unwind", PyO3 catch_unwind firewall — issue #1440).
+          # This exercises the firewall under pytest, catching a panic-strategy
+          # regression at CI time instead of at release.
+          args: --profile release-unwind --out dist
           working-directory: bindings/python
           manylinux: ${{ matrix.manylinux || 'auto' }}
 

--- a/docs/development/dev-cookbook.md
+++ b/docs/development/dev-cookbook.md
@@ -70,7 +70,15 @@ Status metrics refresh every 5 seconds. Status line disabled for piped output.
 # Build and test
 cd bindings/python && maturin develop --profile dev  # Development build (debug; overrides the release-unwind firewall pin for a fast dev loop)
 cd bindings/python && maturin build --profile release-unwind  # Release wheel (panic-unwind firewall, issue #1440 — NOT --release, which is panic=abort)
+```
 
+**CI/release profile parity (issue #2653):** both `python-ci.yml` (smoke, build-only-wheels, test
+jobs) and `python-release.yml` (build-wheels job) build the wheel with `--profile release-unwind`,
+so CI exercises the exact panic = "unwind" firewall build that PyPI ships and a panic-strategy
+regression reds a PR instead of surfacing only at release. When changing the build profile in one
+workflow, change it in the other to keep the matrix in parity.
+
+```bash
 # Run Python tests - fast tests only (default, Issue #331)
 env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets pytest bindings/python/tests -v
 


### PR DESCRIPTION
Closes #2653 (Epic #2636, P2)

## Problem
`python-release.yml` ships wheels built with `--profile release-unwind` (PyO3 `catch_unwind` firewall, `panic = "unwind"`, #1440), but `python-ci.yml` built plain `--release` (`panic = "abort"`). A panic-strategy regression was invisible until release. (Node is already consistent — `npm run build` uses its own profile in both CI and release.)

## Change
Switch all three `python-ci.yml` wheel builds to `--profile release-unwind`:
- `smoke` (PR-tier local wheel)
- `build-only-wheels` (cross-platform matrix)
- `test` (native test matrix — wheel now exercised under pytest with the firewall active)

CI now builds the exact `panic = "unwind"` firewall wheel that PyPI receives, so a panic-strategy regression reds a PR instead of surfacing only at release.

## Matrix parity documentation
- A comment on each `python-ci.yml` build step explains why `release-unwind` is used and points at `python-release.yml`.
- `docs/development/dev-cookbook.md` gains a "CI/release profile parity (#2653)" note: both workflows build `--profile release-unwind`; change one → change the other.

The `release-unwind` profile is defined at `Cargo.toml:180` (`inherits = "release"`, `panic = "unwind"`), consistent with `bindings/python/pyproject.toml` (`profile = "release-unwind"`).

## Roborev self-check
- No `${{ }}` interpolated into `run:` — the change only adds a static `--profile release-unwind` flag to `PyO3/maturin-action@v1` `args:`. No untrusted-input injection surface.
- YAML validated (`yaml.safe_load`).

## Lite gate

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: f454d2bc1 branch: issue-2653-python-ci-release-unwind dirty: no
lite-scope: file-size fmt clippy scoped-tests
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (108s)
scoped-tests:      PASS (348s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Not the gate of record — full gate to run once pre-merge.