### PR TITLE
docs(#2672): doctrine de-drift — merge-on-green default, #2078 present-tense, groom board-add verification

### DIFF
--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -1,6 +1,6 @@
 ---
 name: flow-lead
-description: The CQLite delivery lead / PM — the persona you start to run the agent-delivery workflow WITH you. It grooms ideas into issues, drives the flow-* pipeline (groom → activate → implement → address → finalize), spawns and sequences the specialist agents (sstable-developer, rust-reviewer, spec-auditor, test-validator, coverage-reviewer) and the quality stages (agent-gate → C intent audit → roborev), keeps a live board of what's in flight, and surfaces the one thing waiting on you. It honors the two human seams (spec approval + merge), the pre-authorized merge-on-green autonomy model, and CQLite's hard rules (no-heuristics, the gate is the only run that counts, wiring-evidence, parity-is-truth, never make a product/scope/epic decision). Launch as your main driver (`claude --agent flow-lead`); it orients from the board on start. It orchestrates — the specialists do the middle.
+description: The CQLite delivery lead / PM — the persona you start to run the agent-delivery workflow WITH you. It grooms ideas into issues, drives the flow-* pipeline (groom → activate → implement → address → finalize), spawns and sequences the specialist agents (sstable-developer, rust-reviewer, spec-auditor, test-validator, coverage-reviewer) and the quality stages (agent-gate → C intent audit → roborev), keeps a live board of what's in flight, and surfaces the one thing waiting on you. It honors the one standing human seam (spec approval; merge is autonomous — it arms `gh pr merge --auto` on green, holding only for a conditional escalate trigger), and CQLite's hard rules (no-heuristics, the gate is the only run that counts, wiring-evidence, parity-is-truth, never make a product/scope/epic decision). Launch as your main driver (`claude --agent flow-lead`); it orients from the board on start. It orchestrates — the specialists do the middle.
 ---
 
 You are the **CQLite delivery lead** — the PM/lead persona in the main session. The owner starts you
@@ -13,7 +13,7 @@ at **https://pmcfadin.github.io/cqlite/agents-developing/** (the gate contract, 
 wiring-evidence, spec-driven-audit, delivery-pipeline). Read them at the start of a session if not
 already in context — this file is your operating manual for the *role*, not a substitute.
 
-## The one job: keep the flow moving, owner in exactly two seats
+## The one job: keep the flow moving, owner in one standing seat
 
 1. **Groom** (`flow-groom`) — a rough idea → one scoped GitHub issue (exactly one `P0`–`P3`,
    `status:ready`, testable acceptance criteria). Decide **oracle vs design**: oracle-driven bugs
@@ -33,7 +33,7 @@ already in context — this file is your operating manual for the *role*, not a 
    the issue. Only after merge.
 
 `flow-board` is your visibility + "what's next": surface the **single** furthest-along item waiting on
-the owner (a green PR to merge, a spec to approve), or a short pick-list. Drive exactly one item.
+the owner (a spec to approve, or a PR held for an owner decision), or a short pick-list. Drive exactly one item.
 
 ## The standing human seam (exactly one)
 

--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -41,17 +41,21 @@ the owner (a green PR to merge, a spec to approve), or a short pick-list. Drive 
    any implementation.
 2. **Merge** (Seam 2) — see the autonomy model. Never add a third gate; never collapse these two.
 
-## Autonomy: pre-authorized merge-on-green
+## Autonomy: arm `--auto`, GitHub merges on green (default, #2667)
 
-- **Default:** you open the PR but **do NOT merge or close it** — merge is the owner's seam.
-- **Exception:** for a set the owner has **explicitly pre-authorized** ("merge #X, #Y on green"), you
-  MAY **arm `gh pr merge --auto --squash --delete-branch`** and then `flow-finalize`, **only when
-  `agent-gate.sh` PASS + C verdict PASS + roborev clean** all hold (after the pre-merge SHA assert +
-  `HOLD` re-read). GitHub owns the CI-green wait — the `required` check (#2433) lands the PR on green;
-  **never `ScheduleWakeup`-poll a PR's own CI** (#2667). Harness-tracked Workflows notify you.
+- **Default:** the moment **local certification** is met — `agent-gate.sh` PASS + **C** PASS
+  (design-driven) + roborev clean — the closer runs `scripts/flow/premerge-assert.sh <pr>
+  <certified-sha>`, re-reads for a fresh `HOLD:` order, then **arms `gh pr merge --auto --squash
+  --delete-branch`** and `flow-finalize`s. GitHub owns the CI-green wait — the `required` check
+  (#2433, enforced for admins too via `enforce_admins`) lands the PR the instant it passes; **never
+  `ScheduleWakeup`-poll a PR's own CI** (#2667). Do NOT wait for the owner. **Seam 1 (spec approval)
+  is the ONLY standing human gate.**
+- **Escalate and HOLD the merge ONLY for:** a genuine design-call roborev finding, a scope/product
+  question, an unmet/uncovered requirement, work outside the issue, or an explicit `HOLD: merge after
+  #N` order — obey it. Everything else merges autonomously.
 - **Always escalate to a NEEDS-YOU list, never decide:** product decisions, scope/title changes, and
-  **epic closes**. (This NARROWS the older "Product-manager behavior" autonomy: comment/label/assign and
-  closing a fully-done non-epic issue with a merged PR stay yours; merging follows the model above.)
+  **epic closes**. (Comment/label/assign and closing a fully-done non-epic issue with a merged PR stay
+  yours; merging follows the default above.)
 
 ## How to work with THIS owner (load-bearing)
 

--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -35,11 +35,16 @@ already in context — this file is your operating manual for the *role*, not a 
 `flow-board` is your visibility + "what's next": surface the **single** furthest-along item waiting on
 the owner (a green PR to merge, a spec to approve), or a short pick-list. Drive exactly one item.
 
-## The two human seams (sacred — exactly two)
+## The standing human seam (exactly one)
 
 1. **Spec approval** (Seam 1, in `flow-activate`) — the owner approves the OpenSpec spec + design before
-   any implementation.
-2. **Merge** (Seam 2) — see the autonomy model. Never add a third gate; never collapse these two.
+   any implementation. This is the **only standing human gate**.
+
+**Merge is autonomous by default** (see the autonomy model) — GitHub lands the PR on green, no owner
+gate. An owner merge decision exists only **conditionally**, when an escalate-and-hold trigger fires (a
+genuine design-call roborev finding, a scope/product question, an unmet/uncovered requirement, work
+outside the issue, or an explicit `HOLD:` order). Never add a third standing gate; never turn merge
+back into one.
 
 ## Autonomy: arm `--auto`, GitHub merges on green (default, #2667)
 

--- a/.claude/skills/flow-address/SKILL.md
+++ b/.claude/skills/flow-address/SKILL.md
@@ -35,4 +35,8 @@ Resolve them in the worktree and reply per thread.
    ```bash
    gh issue edit <N> --remove-label status:addressing --add-label status:in-review
    ```
-   Hand back to the owner for merge.
+7. **Re-certify and re-arm merge-on-green (#2667).** The owner's comments are input, NOT a merge
+   gate — unless a comment is an explicit `HOLD:` or raises a product/scope question. After addressing
+   them, re-certify (lite + any diff-relevant targets; a full/delta gate per the gate contract if the
+   certified SHA changed), re-run `scripts/flow/premerge-assert.sh <pr> <certified-sha>`, then re-arm
+   `gh pr merge --auto --squash --delete-branch`.

--- a/.claude/skills/flow-groom/SKILL.md
+++ b/.claude/skills/flow-groom/SKILL.md
@@ -24,8 +24,19 @@ You are the CQLite delivery lead. Turn a rough idea into exactly ONE well-scoped
    gh issue create --title "<concise>" --body "<context + oracle/design + acceptance criteria>" \
      --label "P2" --label "status:ready"
    ```
-   (Pick P0–P3 deliberately; confirm priority with the owner if unsure.)
-5. **Report** the issue number + a one-line description (`#<N> (<slug>)`) and whether it's oracle- or
+   (Pick P0–P3 deliberately; confirm priority with the owner if unsure.) The `status:*` labels are
+   **decorative mirrors only** — board `Status` is the sole dispatch authority (Path A, #1886); a
+   label never selects work.
+5. **Verify the board add — do NOT trust Project auto-add.** Auto-add has been observed missing all
+   new issues, so add the item explicitly and confirm it landed:
+   ```bash
+   gh project item-add 1 --owner pmcfadin --url <issue-url>
+   gh project item-edit --project-id <id> --id <item-id> --field-id <status-field> \
+     --single-select-option-id <Ready-or-Backlog>   # Ready if groomed-ready, else Backlog
+   gh project item-list 1 --owner pmcfadin --limit 1000 | grep "<issue-#>"   # confirm item + Status
+   ```
+   The item MUST appear with the intended `Status` before you report done.
+6. **Report** the issue number + a one-line description (`#<N> (<slug>)`) and whether it's oracle- or
    design-driven (i.e. whether `flow-activate` or a direct `flow-implement` is next).
 
 Do not create worktrees or specs here — that's `flow-activate`. One idea → one issue.

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -49,9 +49,10 @@ Sanity check: `bash scripts/agent-gate.sh --lite` should pass in ~1–5 min, and
 `accelerators:` line should read `sccache=on nextest=on lanes=parallel`. If anything says
 `absent`, the gate prints the one-line install fix — do it; a degraded machine is ~3× slower.
 
-**Datasets matter:** without them, parity components skip. Today that still yields an overall
-PASS (the dangerous silent green — being fixed as **#2078**, after which the full gate FAILS
-loudly instead). Fetch them on every machine, day one.
+**Datasets matter:** without them, parity components skip. The FULL gate FAILs CLOSED when the
+fetched validation corpus is absent (**#2078**), stamping `missing-fixtures: FAIL-CLOSED (#2078)`;
+`AGENT_GATE_ALLOW_MISSING_FIXTURES=1` opts out visibly, and `--lite`/`--only` stay lenient. Fetch
+them on every machine, day one.
 
 ---
 
@@ -254,7 +255,7 @@ machine + heartbeat age (issue #2089). Interpretation:
 | Session feels degraded / bloated | Kill it, start fresh. Board + disk are the state; the new session rehydrates in one board read. |
 | Board unreachable (auth/scope error) | The session STOPS by design (labels are decorative, never a dispatch source). Fix `gh auth refresh -s project` and restart. |
 | Gate seems hung | It's probably queued: look for `waiting for gate slot (N in use)…`. Queued ≠ hung. |
-| Green SUMMARY but parity lines say SKIP | Datasets missing on that machine — `fetch-datasets.sh`, re-run. (#2078 makes this a hard FAIL so it can't slip through.) |
+| Green SUMMARY but parity lines say SKIP | Datasets missing on that machine — `fetch-datasets.sh`, re-run. The FULL gate FAILs CLOSED here (`missing-fixtures: FAIL-CLOSED (#2078)`) so it can't slip through; `--lite`/`--only` stay lenient. |
 | Two machines want the same issue | Impossible past the claim: the second claim-ref push is rejected server-side (non-fast-forward on the fixed-name ref, #2665); the loser sees `CLAIM LOST` and picks the next Ready item. |
 
 ---

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -1,6 +1,6 @@
 ---
 title: Delivery pipeline (flow-lead)
-description: The manager-orchestrated delivery workflow — the flow-lead agent, the flow-* pipeline, the specialist roster, and the two human seams.
+description: The manager-orchestrated delivery workflow — the flow-lead agent, the flow-* pipeline, the specialist roster, and the one standing human seam (spec approval; merge is autonomous on green).
 sidebar:
   label: Delivery pipeline
 ---
@@ -8,7 +8,7 @@ sidebar:
 CQLite delivery is driven by a **manager agent, `flow-lead`**, that orchestrates a team of specialist
 agents through a defined pipeline. Start it as your session driver — `claude --agent flow-lead` (it is
 the repo's default agent) — and it orients from the board. It orchestrates; the specialists do the
-middle; you sit in two seats.
+middle; you sit in one standing seat (spec approval — merge is autonomous on green).
 
 ## The pipeline
 
@@ -38,16 +38,19 @@ middle; you sit in two seats.
 - **Design-driven** (bindings/M6, query-engine surface, CLI/REPL UX, perf/M7, process) — no oracle.
   Goes through `flow-activate` (OpenSpec proposal/design/specs/tasks).
 
-## The two human seams
+## The one standing human seam
 
 1. **Spec approval** (Seam 1, in `flow-activate`) — you approve the OpenSpec spec + design before any
-   implementation. The lead renders it inline and stops.
-2. **Merge** (Seam 2) — **arm `--auto`, GitHub merges on green** (no human merge click for worker-owned
-   issues):
-   - A worker's **terminal state** for an issue is PR-open + `agent-gate.sh` PASS + C PASS (design-driven)
-     + roborev clean. At that point it **arms `gh pr merge --auto` and ends its turn** — it does
-     **not** poll the PR's own external CI in a yield/wake loop (see [Merge-on-green](#merge-on-green-no-ci-busy-wait)).
-   - *Always escalated, never decided by the lead:* product decisions, scope/title changes, epic closes.
+   implementation. The lead renders it inline and stops. **This is the only standing human gate.**
+
+**Merge is autonomous by default** — not a standing seam. A worker's/closer's **terminal state** for an
+issue is PR-open + `agent-gate.sh` PASS + C PASS (design-driven) + roborev clean; at that point it **arms
+`gh pr merge --auto` and ends its turn**, and GitHub lands the PR on green (see
+[Merge-on-green](#merge-on-green-no-ci-busy-wait)) — it does **not** poll the PR's own external CI in a
+yield/wake loop. An owner merge decision exists only **conditionally**, when an escalate-and-hold trigger
+fires: a genuine design-call roborev finding, a scope/product question, an unmet/uncovered requirement,
+work outside the issue, or an explicit `HOLD:` order. *Always escalated, never decided by the lead:*
+product decisions, scope/title changes, epic closes.
 
 ## Merge-on-green (no CI busy-wait)
 

--- a/website/src/content/docs/agents-developing/index.md
+++ b/website/src/content/docs/agents-developing/index.md
@@ -24,7 +24,7 @@ Write for AI agents: terse, imperative, copy-pasteable commands. Skip the prose.
 | [Wiring evidence](/cqlite/agents-developing/wiring-evidence/) | Prove the public surface exercises a feature; reject helper-only implementations (issues #949/#963) |
 | [Format debugging workflow](/cqlite/agents-developing/format-debugging/) | Hex dumps, definitive-guide chapters, appendix F known limitations |
 | [Spec-driven audit](/cqlite/agents-developing/spec-driven-audit/) | OpenSpec as the front door for design-driven work; the intent audit (C) + roborev escalation (B); superpowers mapping |
-| [Delivery pipeline](/cqlite/agents-developing/delivery-pipeline/) | The `flow-lead` manager agent + `flow-*` pipeline; specialist roster; the two human seams + pre-authorized merge-on-green |
+| [Delivery pipeline](/cqlite/agents-developing/delivery-pipeline/) | The `flow-lead` manager agent + `flow-*` pipeline; specialist roster; the one standing human seam (spec approval) + autonomous merge-on-green |
 | [Pre-roborev self-check](/cqlite/agents-developing/roborev-findings/) | The recurring roborev finding classes + the one-line fix for each; scan your diff before handing off (issue #1245) |
 
 ## Non-negotiable rules


### PR DESCRIPTION
Closes #2672. Doctrine de-drift residual under epic #2664 (harness audit).

Docs/skills-only change — no production code. Delivers the four audited residual fixes plus in-scope fold-in reconciles surfaced during review; the other audited claims (2, 3a, 3c) were already fixed on main by #2665/#2667/#2668.

## Six fixes

1. **`.claude/agents/flow-lead.md`** — INVERTED the Autonomy section. The default is now merge-on-green: the moment local certification holds (gate PASS + C PASS for design-driven + roborev clean), the closer runs `scripts/flow/premerge-assert.sh`, re-reads for a fresh `HOLD:`, then arms `gh pr merge --auto --squash --delete-branch`; GitHub lands the PR when the `required` check goes green — never `ScheduleWakeup`-poll a PR's own CI. Seam 1 (spec approval) is the only standing human gate. Mirrors CLAUDE.md "Autonomy — arm `--auto`" (#2667).

2. **`.claude/skills/flow-address/SKILL.md`** — replaced "Hand back to the owner for merge." with a re-certify + re-arm step: after addressing comments, re-certify (lite + diff-relevant targets; full/delta per the gate contract if the certified SHA changed), re-run `premerge-assert.sh`, re-arm `--auto` per #2667. Owner comments are input, not a merge gate, unless an explicit `HOLD:` or a product/scope question.

3. **`docs/development/fleet-runbook.md`** — #2078 LANDED (closed 2026-07-06); rewrote both passages present-tense. The FULL gate FAILs CLOSED when the fetched validation corpus is absent (`missing-fixtures: FAIL-CLOSED (#2078)`); `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` opts out visibly; `--lite`/`--only` stay lenient.

4. **`.claude/skills/flow-groom/SKILL.md`** — (a) added the caveat that `status:*` labels are decorative mirrors; board `Status` is the sole dispatch authority (Path A, #1886). (b) added a REQUIRED verify-board-add step: do NOT trust Project auto-add — explicitly `gh project item-add`, set `Status` (Ready if groomed-ready, else Backlog), then re-read `item-list --limit 1000` and confirm the item exists with the intended Status.

5. **`.claude/agents/flow-lead.md` (fold-in reconcile)** — retitled the "two human seams" body section to "the standing human seam (exactly one)": Seam 1 is the only standing human gate; merge is autonomous by default and an owner merge decision exists only conditionally when an escalate-and-hold trigger fires. Kept the "never add a third standing gate" spirit.

6. **Two-seam residual sweep (roborev 1835)** — `.claude/agents/flow-lead.md` frontmatter `description`, the "one job / owner in one standing seat" heading, and the flow-board "what's next" line; website doctrine page `website/src/content/docs/agents-developing/delivery-pipeline.md` (frontmatter description, intro "one standing seat", "The one standing human seam" section demoting merge to the conditional escalate-and-hold triggers) and `website/src/content/docs/agents-developing/index.md` table row. Edits only — no new pages, so no cross-link requirement. Mirrors CLAUDE.md.

## Verification — lite gate PASS (r3, post-sweep)

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: f53a470c9 branch: issue-2672-doctrine-dedrift dirty: yes
lite-scope: file-size fmt clippy scoped-tests (full gate NOT run — run it once before merge)
accelerators: sccache=on nextest=on lanes=on sccache-health=ok
file-size:         PASS (1s)
fmt:               PASS (12s)
clippy:            PASS (292s)
scoped-tests:      PASS (238s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Full gate of record queued behind #2671/#2670 lanes (one-machine serialization).
