### PR TITLE
ci(#2659): consolidate coverage — cache PR baseline + auto-file nightly 77% regression

### DIFF
--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -28,8 +28,22 @@ jobs:
 
       # Honor the repo toolchain pin (rust-toolchain.toml = 1.88.0), issue #1990.
       # Omitting `toolchain:` makes setup-rust-toolchain read the pin file.
+      # `cache: false` so caching is done by the explicit Swatinem step below with a
+      # deliberate Cargo.lock-keyed key matching the repo's other rust caches, rather
+      # than the toolchain action's implicit cache — one cache, not two overlapping ones.
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+
+      # Cache cargo registry/git + target so the PR baseline lane stops rebuilding from
+      # scratch every run (issue #2659). Keyed on Cargo.lock, matching quality-gates.yml;
+      # rust-cache folds the toolchain/rustc version into the key automatically.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage-baseline-${{ hashFiles('**/Cargo.lock') }}
+          cache-on-failure: true
 
       # Prebuilt pinned tarpaulin (issue #1990) — never source-builds, so a
       # tarpaulin/rustc incompat cannot red the coverage baseline again.

--- a/.github/workflows/coverage-regression-issue.yml
+++ b/.github/workflows/coverage-regression-issue.yml
@@ -1,0 +1,166 @@
+name: "CI: Coverage Regression Issue Automation"
+
+# Signal routing only (issue #2659, epic #2636). The read-path coverage gate
+# (coverage.yml, ≥77%) runs nightly / on manual dispatch only — by owner decision it is
+# intentionally ADVISORY and NOT a required merge check (no new required PR gate). So that a
+# nightly regression cannot sit unnoticed, this workflow files/updates ONE deduplicated
+# `coverage-regression` tracking issue whenever that gate concludes `failure` on a scheduled
+# / main-branch / manual run. It NEVER gates a merge and NEVER auto-closes the issue — a
+# human closes it once coverage is restored.
+#
+# Modeled on the parity-failure-issue pattern (issue #1028, epic #974): dedup by a hidden
+# body marker, UPDATE-not-duplicate, non-gating + fail-open. Coverage has a single logical
+# gate (one threshold), so a static marker replaces that tool's per-scenario fingerprint.
+#
+# SECURITY: this workflow consumes an UNTRUSTED `workflow_run` payload. It NEVER interpolates
+# event fields into a `run:` shell — every event value is passed via a quoted env var, and
+# the origin event is allowlist-validated fail-closed BEFORE any token-bearing step runs.
+
+on:
+  workflow_run:
+    workflows:
+      - "CI: Coverage Gate (read-path, ≥77%)"
+    types: [completed]
+  # Manual smoke trigger only: without a workflow_run payload there is no gate conclusion,
+  # so the file step below is a validated no-op (it requires WR_CONCLUSION == 'failure').
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: coverage-regression-issue-${{ github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  coverage-regression-issue:
+    runs-on: ubuntu-latest
+    # Coarse pre-filter over trusted GitHub-computed fields (event name / conclusion /
+    # branch); the Validate step below re-checks fail-closed before any token use. A manual
+    # workflow_dispatch of THIS workflow always proceeds (then no-ops without a conclusion).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      ((github.event.workflow_run.conclusion == 'failure' ||
+        github.event.workflow_run.conclusion == 'success') &&
+       github.event.workflow_run.event != 'pull_request')
+    env:
+      # Pass untrusted payload fields as env vars, never inline into a run: shell.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Give every `gh` call explicit repository context. `github.repository` is trusted.
+      GH_REPO: ${{ github.repository }}
+      WR_EVENT: ${{ github.event.workflow_run.event }}
+      WR_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      WR_URL: ${{ github.event.workflow_run.html_url }}
+      TRIGGER: ${{ github.event_name }}
+    steps:
+      - name: Guard token (fail-open, non-gating)
+        id: guard
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::GITHUB_TOKEN absent — skipping coverage-regression issue automation (non-gating no-op)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate origin event (allowlist, fail-closed)
+        id: validate
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          # A manual dispatch of THIS automation always proceeds; without a workflow_run
+          # payload it carries no conclusion, so the file step is a no-op (smoke only).
+          if [ "${TRIGGER}" = "workflow_dispatch" ]; then
+            echo "manual dispatch of the automation — proceeding (no-op without a gate conclusion)"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Allowlist the ORIGIN event. The coverage gate only runs on schedule /
+          # workflow_dispatch today; a push-origin run files ONLY when it targets main.
+          # WR_EVENT / WR_HEAD_BRANCH are untrusted payload -> compared via quoted env vars.
+          case "${WR_EVENT}" in
+            schedule|workflow_dispatch)
+              echo "origin event '${WR_EVENT}' is allowlisted — proceeding"
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            push)
+              if [ "${WR_HEAD_BRANCH:-}" = "main" ]; then
+                echo "push origin on main — proceeding"
+                echo "proceed=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "::notice::push origin on non-main branch '${WR_HEAD_BRANCH:-<none>}' — no issue filed."
+                echo "proceed=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "::notice::origin event '${WR_EVENT}' is not schedule/push/workflow_dispatch — no issue filed."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: File / update the deduplicated coverage-regression issue
+        # Only a FAILED gate conclusion files. A green gate is a no-op here (we never
+        # auto-close, and a human closes the tracker once coverage is restored).
+        if: >-
+          steps.guard.outputs.skip != 'true' && steps.validate.outputs.proceed == 'true' &&
+          env.WR_CONCLUSION == 'failure'
+        run: |
+          set -euo pipefail
+          # Hidden body marker + label dedup the tracker to ONE open issue (mirrors the
+          # parity-failure-issue pattern). The marker is a static constant — no untrusted
+          # interpolation. RUN_URL comes from the untrusted WR_URL env var but is only ever
+          # used as a shell variable, never as a workflow expression inside this run: block.
+          MARKER='<!-- COVERAGE-REGRESSION:read-path-77 -->'
+          LABEL='coverage-regression'
+          RUN_URL="${WR_URL:-<run url unavailable>}"
+          NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          # Idempotently self-provision the label BEFORE the list/create path (mirrors the
+          # parity tool's Fix A) so the first filing on a repo lacking the label is not a
+          # silent no-op. Fail-open: a provisioning failure is a warning, never a crash.
+          gh label create "$LABEL" --force \
+            --color b60205 \
+            --description "Nightly read-path coverage (>=77%) regression tracked by coverage-regression-issue.yml (issue #2659)" \
+            || echo "::warning::could not provision the '$LABEL' label — continuing (issue create may fail fail-open)."
+
+          # Dedup: is there already an open coverage-regression issue carrying the marker?
+          EXISTING="$(gh issue list --label "$LABEL" --state open \
+            --json number,body --limit 200 \
+            --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].number // empty")" || EXISTING=""
+
+          if [ -n "$EXISTING" ]; then
+            # UPDATE, never duplicate: post a dated recurrence comment on the open tracker.
+            gh issue comment "$EXISTING" \
+              --body "Read-path coverage gate regressed again on run ${RUN_URL} at ${NOW} (advisory — not merge-gating). Read-path line coverage remains below the 77% floor." \
+              || echo "::warning::coverage-regression recurrence comment failed (non-gating; coverage result unchanged)."
+            echo "updated existing coverage-regression issue #${EXISTING}"
+          else
+            # Build the body with printf (no heredoc: a heredoc body dedented to column 0
+            # would break out of this YAML block scalar). RUN_URL/NOW are shell variables,
+            # never workflow expressions.
+            BODY="$(printf '%s\n' \
+              "$MARKER" \
+              "" \
+              "The nightly read-path coverage gate (\`coverage.yml\`, >=77%) concluded \`failure\` — read-path line coverage dropped below the 77% floor." \
+              "" \
+              "This gate is **advisory** by owner decision (issue #2659, epic #2636): it is intentionally NOT a required merge check, so this auto-filed, deduplicated issue is how a regression stays visible. Add tests to restore read-path coverage, then close this issue once the nightly gate is green again." \
+              "" \
+              "## Latest failure" \
+              "- **Run:** ${RUN_URL}" \
+              "- **Observed:** ${NOW}" \
+              "- **Gate:** read-path line coverage >=77% (\`coverage.yml\`, issue #2022)" \
+              "" \
+              "_Filed by \`.github/workflows/coverage-regression-issue.yml\` (issue #2659, epic #2636). Not auto-closed — close manually once coverage is restored._")"
+            gh issue create \
+              --title "coverage-regression: read-path line coverage below the 77% floor" \
+              --body "$BODY" --label "$LABEL" \
+              || echo "::warning::coverage-regression issue create failed (non-gating; coverage result unchanged)."
+            echo "filed new coverage-regression issue"
+          fi
+
+      - name: Note (green gate)
+        if: >-
+          steps.guard.outputs.skip != 'true' && steps.validate.outputs.proceed == 'true' &&
+          env.WR_CONCLUSION == 'success'
+        run: echo "::notice::coverage gate concluded success — no coverage-regression issue filed (open trackers, if any, are closed manually)."

--- a/.github/workflows/coverage-regression-issue.yml
+++ b/.github/workflows/coverage-regression-issue.yml
@@ -134,7 +134,7 @@ jobs:
           if [ -n "$EXISTING" ]; then
             # UPDATE, never duplicate: post a dated recurrence comment on the open tracker.
             gh issue comment "$EXISTING" \
-              --body "Read-path coverage gate regressed again on run ${RUN_URL} at ${NOW} (advisory — not merge-gating). Read-path line coverage remains below the 77% floor." \
+              --body "The nightly coverage gate (\`coverage.yml\`) concluded \`failure\` again on run ${RUN_URL} at ${NOW} (advisory — not merge-gating). This is USUALLY a read-path coverage regression below the 77% floor, but \`coverage.yml\` also fails on lint / dataset-verify / tooling-install / timeout paths — inspect the run to confirm the actual cause before acting." \
               || echo "::warning::coverage-regression recurrence comment failed (non-gating; coverage result unchanged)."
             echo "updated existing coverage-regression issue #${EXISTING}"
           else
@@ -144,18 +144,22 @@ jobs:
             BODY="$(printf '%s\n' \
               "$MARKER" \
               "" \
-              "The nightly read-path coverage gate (\`coverage.yml\`, >=77%) concluded \`failure\` — read-path line coverage dropped below the 77% floor." \
+              "The nightly coverage gate (\`coverage.yml\`, read-path >=77%) concluded \`failure\`." \
               "" \
-              "This gate is **advisory** by owner decision (issue #2659, epic #2636): it is intentionally NOT a required merge check, so this auto-filed, deduplicated issue is how a regression stays visible. Add tests to restore read-path coverage, then close this issue once the nightly gate is green again." \
+              "**This is most likely a read-path coverage regression below the 77% floor**, but note \`coverage.yml\`'s enforced job also fails on non-coverage paths (Format and Lint Check / \`clippy -D warnings\`, dataset-verify \`DB_COUNT == 0\`, tarpaulin/llvm-cov install, or job timeout). **Inspect the run below to confirm the actual cause** before assuming a coverage regression." \
+              "" \
+              "If it IS a coverage regression: add tests to restore read-path coverage, then close this issue once the nightly gate is green again." \
+              "" \
+              "This gate is **advisory** by owner decision (issue #2659, epic #2636): it is intentionally NOT a required merge check, so this auto-filed, deduplicated issue is how a failure stays visible." \
               "" \
               "## Latest failure" \
               "- **Run:** ${RUN_URL}" \
               "- **Observed:** ${NOW}" \
-              "- **Gate:** read-path line coverage >=77% (\`coverage.yml\`, issue #2022)" \
+              "- **Gate:** \`coverage.yml\` (read-path line coverage >=77%, issue #2022) — verify the run for the actual failing step" \
               "" \
               "_Filed by \`.github/workflows/coverage-regression-issue.yml\` (issue #2659, epic #2636). Not auto-closed — close manually once coverage is restored._")"
             gh issue create \
-              --title "coverage-regression: read-path line coverage below the 77% floor" \
+              --title "coverage-regression: nightly coverage gate (coverage.yml) concluded failure" \
               --body "$BODY" --label "$LABEL" \
               || echo "::warning::coverage-regression issue create failed (non-gating; coverage result unchanged)."
             echo "filed new coverage-regression issue"

--- a/.github/workflows/coverage-regression-issue.yml
+++ b/.github/workflows/coverage-regression-issue.yml
@@ -36,6 +36,8 @@ concurrency:
 jobs:
   coverage-regression-issue:
     runs-on: ubuntu-latest
+    # Lightweight gh-only routing job; matches peer lightweight workflow jobs.
+    timeout-minutes: 10
     # Coarse pre-filter over trusted GitHub-computed fields (event name / conclusion /
     # branch); the Validate step below re-checks fail-closed before any token use. A manual
     # workflow_dispatch of THIS workflow always proceeds (then no-ops without a conclusion).


### PR DESCRIPTION
Closes #2659 (epic #2636).

## What

Owner-confirmed **approach (b)**: the read-path >=77% coverage gate (`coverage.yml`) stays **ADVISORY** — this PR adds **no new required merge check**. Instead it (1) caches the existing non-required PR baseline and (2) makes nightly 77% regressions auto-file a deduped tracking issue so they cannot sit unnoticed.

- **`coverage-baseline.yml`** — add `Swatinem/rust-cache@v2` (key `coverage-baseline-${{ hashFiles('**/Cargo.lock') }}`, matching `quality-gates.yml`) and set the toolchain action's `cache: false` so there is exactly one deliberate Cargo.lock-keyed cache, not two overlapping ones. Threshold unchanged (30% lib-only, **non-required**). This remains the single PR-side coverage check.
- **`coverage-regression-issue.yml`** (new) — on `workflow_run` completion of the nightly `coverage.yml` gate, a `failure` conclusion (schedule/main/dispatch origin only, never PR) files/updates ONE deduplicated `coverage-regression` tracking issue. Modeled on the parity-failure-issue pattern: hidden body-marker dedup, UPDATE-not-duplicate, self-provisioned label, non-gating + fail-open, untrusted payload passed only via quoted env vars, never auto-closes. Coverage has a single logical gate so a static marker replaces the parity tool's per-scenario fingerprint. **Not merge-gating.**

## Acceptance (#2659)
- exactly one PR-side coverage check with a deliberate threshold (baseline, non-required) ✔
- nightly regressions auto-file/dedupe, not merge-gating ✔
- coverage-baseline cached ✔
- choice + rationale recorded on the issue ✔

## Roborev self-check (workflow)
- No `${{ }}` / untrusted payload interpolated into any `run:` — all event fields pass via quoted env vars; origin event allowlist-validated fail-closed before any token step.
- `actionlint` clean on both workflows; YAML parses.

## Gate
No new required merge check added; the read-path 77% gate remains advisory by owner decision.

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: e7dbf50f6 branch: issue-2659-coverage-consolidate dirty: no
file-size:         PASS (1s)
fmt:               PASS (12s)
clippy:            PASS (293s)
scoped-tests:      PASS (322s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```