### PR TITLE
docs(#2647): profile guard-cluster compile split; record not-justified unify decision

### DIFF
--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -195,6 +195,71 @@ Verify groups resolve (no TOML parse errors, membership as intended):
 cargo nextest show-config test-groups --package cqlite-core --features cli-helpers
 # prints: group: docker (max threads = 1) … group: timing (max threads = 1) … with members
 ```
+## Guard-cluster compile/link/exec profile (issue #2647)
+
+**Question (epic #2636):** the guard-cluster components — `tombstones-scan`,
+`scan-offload-guard`, `work-counters-guard`, `byte-budget-guard`, `write-tests` —
+each invoke `cargo test -p cqlite-core` with a *different* `--features` set. Each
+distinct feature set is a distinct `cfg` fingerprint, so `cqlite-core`'s own crate
+(lib + the component's test harnesses) recompiles per set even with a warm shared
+target (sccache caches *dependency* crates across sets, not the first-party crate
+whose `cfg` changed). The #2636 hypothesis was that collapsing them onto one
+superset `--features` invocation would save ~4–6 min of redundant compile.
+
+**Measured (2026-07-18, 16-core arm64, warm sccache 66% hit rate, shared target
+dir, `CARGO_BUILD_JOBS=4` to mimic a serial main-lane compile under load).** The
+distinct feature sets, additive over the `cqlite-core` defaults
+(`all-compression,state_machine,write-support`):
+
+| component | `--features` delta vs default | first-`cargo`-in-set recompile |
+|-----------|-------------------------------|-------------------------------|
+| (warm baseline: deps + first `cqlite-core` cfg) | `write-support,cli-helpers,state_machine` | 476 s (deps-dominated, paid once) |
+| `tombstones-scan` | `+cli-helpers,+tombstones` | **24 s** |
+| `scan-offload-guard` | `cli-helpers,scan-offload-probe` (drops write-support) | **36 s** |
+| `work-counters-guard` | `+cli-helpers,+state_machine,+work-counters` | **30 s** |
+| `byte-budget-guard` | `+cli-helpers,+state_machine` (== default cfg) | **1 s** (cache hit — no recompile) |
+| `write-tests` | default only (drops `cli-helpers`) | **56 s** |
+
+Redundant per-`cfg` recompile in the cluster ≈ **24 + 36 + 30 + 56 = 146 s** (the
+byte-budget set is identical to the default cfg and pays nothing). A single
+**unified superset** (`write-support,cli-helpers,state_machine,tombstones,scan-offload-probe,work-counters`)
+built once measured **275 s from a cold target** and then compiled ALL the cluster's
+`--test`/`--lib` targets under that one cfg with **0 s** incremental thrash. So the
+realizable saving is ~one first-party recompile pass — **≈ 1.5–1.6 min**, NOT the
+4–6 min hypothesized. gate-ops' 67% execution floor for `core-tests` bounds the
+other side: the guard cluster's *execution* (short, targeted `--test` runs) is a
+small fraction of gate wall-clock; compile is the dominant cost only for these
+short-execution components, and 146 s of it is what's on the table.
+
+**Decision (issue #2647): NOT UNIFIED — measurement is the deliverable.** Two
+reasons the ~1.5 min saving does not justify collapsing the cluster:
+
+1. **Coverage would not be identical (`--features` isolation risk).**
+   `scan-offload-probe`, `work-counters`, and `tombstones` do NOT gate test
+   modules only — they gate **production code paths and `pub`/`pub(crate)`
+   visibility** (`scan_stream_windowed*`, `scan_admission`, `read_work_counters`,
+   `work_counters`, the tombstone/GC branches in `select_executor`/`generation_merge`).
+   The gate deliberately exercises BOTH postures: probes-OFF (`core-tests`,
+   `write-tests --lib` on the default cfg with `cli-helpers` and probes absent) and
+   probes-ON (the guards). A superset cfg changes the compiled-code-under-test for
+   the `--lib` runs (extra `record_*` call sites, extra pub surface, the
+   `scan-offload-probe` deadlock module), so the probes-OFF regression net —
+   "a default/release build links no counter/probe statics and pays nothing"
+   (Cargo.toml `work-counters`/`scan-offload-probe` docs) — would no longer be
+   proven by the same run. Acceptance requires *identical* `--test` coverage; a
+   superset silently trades a coverage posture for ~90 s.
+2. **The parallel-lane design already amortizes most of the compile.** #1737's
+   capped 2-lane pool runs these components concurrently against a shared target;
+   the 146 s is wall-clock-overlapped with `core-tests`/`integration-tests`/binding
+   lanes, so the *serial* redundant-compile figure over-states the on-the-clock
+   cost. The net PR-visible saving is well under a minute, against a real coverage
+   regression and a more brittle single invocation.
+
+`dhat-heap` (`memory-budget`) and `arrow` (`arrow-parity-guard`) were out of scope
+for unification regardless (global allocator needs `--test-threads=1`; `arrow`
+pulls the arrow crate) and stay isolated. Re-open only if a *measured* redundant
+compile > ~4 min appears (e.g. after the cluster grows), and only with a scheme
+that preserves the dual OFF/ON coverage posture.
 
 ## Machine-wide full-gate concurrency cap (issue #1825)
 


### PR DESCRIPTION
Closes #2647 (epic #2636, P2).

## What this does (measure-first: STEP 0 profiling → decision)

Profiles the `agent-gate.sh` guard-cluster (`tombstones-scan`, `scan-offload-guard`, `work-counters-guard`, `byte-budget-guard`, `write-tests`) compile/link/exec split, then records an evidence-based **do-not-unify** decision. Docs-only; **no `agent-gate.sh` change** — the guard-cluster feature invocations are untouched, so P2 followers (#2656/#2657/#2658) inherit the unchanged cluster.

## Profiling numbers (16-core arm64, warm sccache 66%, shared target, serial-lane mimic)

Feature sets additive over `cqlite-core` defaults (`all-compression,state_machine,write-support`):

| component | `--features` delta | first-cargo recompile |
|---|---|---|
| warm baseline (deps + first cfg) | write-support,cli-helpers,state_machine | 476 s (paid once) |
| tombstones-scan | +cli-helpers,+tombstones | 24 s |
| scan-offload-guard | cli-helpers,scan-offload-probe | 36 s |
| work-counters-guard | +cli-helpers,+state_machine,+work-counters | 30 s |
| byte-budget-guard | +cli-helpers,+state_machine (== default cfg) | 1 s (cache hit) |
| write-tests | default only | 56 s |

Redundant per-cfg recompile ≈ **146 s**; a unified superset built once (275 s cold) then compiled all cluster targets at **0 s** thrash → realizable saving ≈ **1.5–1.6 min**, NOT the 4–6 min hypothesized.

## Decision: NOT unified

1. **Coverage would change** — `scan-offload-probe`/`work-counters`/`tombstones` gate production code + `pub` visibility, and the gate deliberately runs both probes-OFF (`core-tests`/`write-tests --lib`) and probes-ON (guards) postures. A superset cfg changes the compiled-code-under-test for the `--lib` runs, breaking "identical `--test` coverage" and losing the "default build links no probe statics" regression net.
2. **#1737's 2-lane pool already amortizes** the 146 s against `core-tests`/binding lanes; net PR-visible saving is sub-minute against a real coverage regression.

`dhat-heap`/`arrow` stay isolated regardless. Full measurement + isolation-risk note in `docs/development/gate-ops.md` and issue #2647.

## Acceptance
- profile recorded ✅ (issue comment + gate-ops.md)
- measured wall-clock delta recorded ✅ (~1.5 min, not 4–6 min)
- feature-isolation risk documented ✅
- not implemented (measurement-only close-out, per acceptance's "otherwise CLOSE-OUT with the measurement as the deliverable") ✅

## LITE verdict (NOT the gate of record; docs-only diff)
```
==== AGENT-GATE LITE SUMMARY ====
commit: 032525b14 branch: issue-2647-gate-profile-unify dirty: no
lite-scope: file-size fmt clippy scoped-tests
accelerators: sccache=on nextest=on lanes=on sccache-health=ok
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (110s)
scoped-tests:      PASS (87s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
Diff is docs-only (`docs/development/gate-ops.md`) — full gate not meaningful for merge certification of this change, but flow-closer runs it as the gate of record per protocol.
