### PR TITLE
flow(#2655): supervisor-authored machine claims + CI-side reaper (#2499)

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -10,7 +10,11 @@ name: Project Board Sync
 #
 # Requires a repo secret PROJECTS_TOKEN: a PAT (or GitHub App token) with the
 # `project` scope. The default GITHUB_TOKEN CANNOT write user/org Projects v2.
-# If the secret is absent the workflow no-ops with a notice (never fails CI).
+# If the secret is ABSENT the token-guarded jobs emit a LOUD `::error::`
+# annotation and FAIL (issue #2655) — a persistent red run is the alert that
+# board hygiene + claim reaping have silently stopped working, instead of the
+# old green ::notice:: no-op that hid the outage for weeks. Add the secret and
+# the next scheduled run goes green.
 #
 # IDs below are for the "CQLite Delivery" user Project #1 (owner: pmcfadin).
 # Re-confirm with:
@@ -60,12 +64,11 @@ jobs:
         id: guard
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::notice::PROJECTS_TOKEN not set — skipping board sync. Add a PAT with 'project' scope as repo secret PROJECTS_TOKEN."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::error::PROJECTS_TOKEN not set — board sync is NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
+            exit 1
           fi
 
       - name: Move closed PR card to Done
-        if: steps.guard.outputs.skip != 'true'
         env:
           PR_NODE_ID: ${{ github.event.pull_request.node_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -114,24 +117,36 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Scheduled path: idempotent sweep over the whole board.
-  #   * OPEN issue with NULL Status        -> Backlog
+  #   * OPEN issue with NULL Status, older than the auto-add grace window
+  #                                        -> Backlog
   #   * CLOSED PR with Status != Done      -> Done   (safety net for the leak)
   # Never touches Ready / In Progress / In Review items, and never reaps claims.
+  #
+  # AUTO-ADD RACE (issue #2655): the built-in "Auto-add to project" workflow adds
+  # a freshly-created issue to the board and THEN sets its default Status in a
+  # second step. Between those two, the item is on the board with a NULL Status.
+  # If this sweep fires inside that window it would force the item to Backlog and
+  # collide with auto-add's own default write (last-writer-wins churn, and a
+  # `groom`-just-created issue can flicker). Fix: only sweep a NULL-status issue
+  # once it has been around LONGER than SWEEP_GRACE_MINUTES (default 10, well past
+  # auto-add's sub-second window but far under the 30-min cron), keyed on the
+  # issue's own createdAt — never wall-clock-racing a brand-new item.
   # ---------------------------------------------------------------------------
   sweep:
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
+    env:
+      SWEEP_GRACE_MINUTES: '10'
     steps:
       - name: Guard token
         id: guard
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::notice::PROJECTS_TOKEN not set — skipping board sweep. Add a PAT with 'project' scope as repo secret PROJECTS_TOKEN."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::error::PROJECTS_TOKEN not set — board sweep + claim reaper are NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
+            exit 1
           fi
 
       - name: Reconcile board
-        if: steps.guard.outputs.skip != 'true'
         run: |
           set -euo pipefail
 
@@ -145,8 +160,15 @@ jobs:
               }' -f p="$PROJECT_ID" -f i="$1" -f f="$STATUS_FIELD_ID" -f o="$2" >/dev/null
           }
 
+          # Grace cutoff (epoch seconds): a NULL-status issue is only swept once
+          # its createdAt is OLDER than this — i.e. it has existed longer than the
+          # auto-add settle window, so we are not racing auto-add's default write.
+          grace_secs=$(( SWEEP_GRACE_MINUTES * 60 ))
+          cutoff_epoch=$(( $(date -u +%s) - grace_secs ))
+
           cursor=""
           backlogged=0
+          skipped_fresh=0
           doned=0
           while : ; do
             if [ -z "$cursor" ]; then after="null"; else after="\"$cursor\""; fi
@@ -163,7 +185,7 @@ jobs:
                         }
                         content {
                           __typename
-                          ... on Issue { number state }
+                          ... on Issue { number state createdAt }
                           ... on PullRequest { number state }
                         }
                       }
@@ -181,16 +203,30 @@ jobs:
             # (`.items.nodes == []`) still satisfies `arrays` and is non-fatal.
             echo "$resp" | jq -e '.data.node.items.nodes | arrays' >/dev/null
 
-            # Capture the two ID lists via checked command substitutions BEFORE
+            # Capture the ID lists via checked command substitutions BEFORE
             # iterating, so any extraction failure aborts the step rather than
             # being swallowed inside a process substitution. An empty list is the
             # benign no-work case and leaves the while loop a no-op.
-            null_issue_ids=$(echo "$resp" | jq -r '
+            #
+            # Auto-add race guard: convert each issue's createdAt to epoch and
+            # keep only those OLDER than the grace cutoff. `--argjson` passes the
+            # cutoff as a number; `fromdateiso8601` is jq builtin ISO8601->epoch.
+            null_issue_ids=$(echo "$resp" | jq -r --argjson cutoff "$cutoff_epoch" '
               .data.node.items.nodes[]
               | select(.content.__typename=="Issue")
               | select(.content.state=="OPEN")
               | select((.fieldValueByName.name // "") == "")
+              | select((.content.createdAt | fromdateiso8601) < $cutoff)
               | .id')
+
+            # Count fresh (within-grace) null-status issues we deliberately SKIP,
+            # for an observable "held back N racing new issues" line.
+            skipped_fresh=$(( skipped_fresh + $(echo "$resp" | jq -r --argjson cutoff "$cutoff_epoch" '
+              [ .data.node.items.nodes[]
+                | select(.content.__typename=="Issue")
+                | select(.content.state=="OPEN")
+                | select((.fieldValueByName.name // "") == "")
+                | select((.content.createdAt | fromdateiso8601) >= $cutoff) ] | length') ))
 
             closed_pr_ids=$(echo "$resp" | jq -r '
               .data.node.items.nodes[]
@@ -199,7 +235,7 @@ jobs:
               | select((.fieldValueByName.name // "") != "Done")
               | .id')
 
-            # OPEN issues with null status -> Backlog
+            # OPEN issues with null status (past the grace window) -> Backlog
             while read -r id; do
               [ -n "$id" ] || continue
               set_status "$id" "$OPT_BACKLOG"
@@ -218,4 +254,113 @@ jobs:
             [ "$has_next" = "true" ] || break
           done
 
-          echo "Sweep complete: $backlogged issue(s) -> Backlog, $doned closed PR card(s) -> Done."
+          echo "Sweep complete: $backlogged issue(s) -> Backlog, $doned closed PR card(s) -> Done, $skipped_fresh fresh null-status issue(s) held back (within ${SWEEP_GRACE_MINUTES}m auto-add grace)."
+
+  # ---------------------------------------------------------------------------
+  # Scheduled path: CI-side claim reaper (issue #2655 / #2499 design).
+  #
+  # Enforces the deterministic reap rule IN CODE (it was previously only prose):
+  # a supervisor-authored refs/machine-claims/<machine> liveness ref is reaped when its
+  # age exceeds the threshold AND its issue has NO open PR. The PID-dead clause
+  # is a LOCAL-only refinement (a foreign machine's PID is unknowable from CI), so
+  # from CI the age + no-open-PR gate governs — exactly what `should-reap`
+  # returns for a non-local machine. `should-reap` is FAIL-SAFE: a fresh ref, an
+  # open-PR ref, or an unparseable-age ref is always KEPT (exit 1); a gh/network
+  # hiccup in the open-PR probe is treated as "assume open PR" and KEEPS the ref.
+  # Reaping deletes the claim ref and flips the freed board item In Progress ->
+  # Ready with a traceable comment, mirroring flow-board's manual reap.
+  # ---------------------------------------------------------------------------
+  reap-claims:
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    # Needs write to delete stale refs/machine-claims/* refs (the top-level
+    # default is contents: read); the sweep/pr-closed jobs stay read-only.
+    permissions:
+      contents: write
+    env:
+      REAP_THRESHOLD_SECS: '14400' # 4h — matches claim-heartbeat.sh's documented default
+    steps:
+      - name: Guard token
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::PROJECTS_TOKEN not set — claim reaper is NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
+            exit 1
+          fi
+
+      - name: Checkout (for claim-heartbeat.sh)
+        uses: actions/checkout@v4
+
+      - name: Reap stale claim refs
+        run: |
+          set -euo pipefail
+          HB="scripts/flow/claim-heartbeat.sh"
+
+          # Map a machine name -> its claim's issue number (parsed from the ref
+          # message, same field grammar claim-heartbeat.sh writes).
+          raw=$(git ls-remote origin 'refs/machine-claims/*' 2>/dev/null || true)
+          if [ -z "$raw" ]; then
+            echo "No claim refs on origin — nothing to reap."
+            exit 0
+          fi
+
+          reaped=0
+          kept=0
+          # Iterate machine names from the ref list (field 2 = refname).
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            refname=$(printf '%s' "$line" | awk '{print $2}')
+            machine="${refname#refs/machine-claims/}"
+            [ -n "$machine" ] || continue
+
+            # should-reap is the single source of truth for the predicate. Exit 0
+            # = reap; 1 = keep; 2 = ref vanished (raced away). Never reaps a
+            # fresh/open-PR/unknown-age claim. Note: from CI `machine` is never
+            # THIS runner, so the PID clause is skipped and age + no-open-PR gate.
+            rc=0
+            bash "$HB" should-reap "$machine" "$REAP_THRESHOLD_SECS" || rc=$?
+            if [ "$rc" -ne 0 ]; then
+              echo "keep claim machine=$machine (should-reap rc=$rc)"
+              kept=$((kept+1))
+              continue
+            fi
+
+            # Recover the issue number from the ref message for the board flip +
+            # comment. Best-effort: reaping the ref is the primary action.
+            git fetch origin "$refname" >/dev/null 2>&1 || true
+            msg=$(git log -1 --format=%B FETCH_HEAD 2>/dev/null || true)
+            issue=$(printf '%s' "$msg" | sed -n 's/.*issue=\([0-9][0-9]*\).*/\1/p' | head -1)
+
+            # `reap` re-checks the open-PR guard atomically before deleting, so a
+            # PR opened between should-reap and here still refuses the delete.
+            if bash "$HB" reap "$machine"; then
+              echo "reaped claim machine=$machine issue=${issue:-?}"
+              reaped=$((reaped+1))
+              # Flip the freed item back to Ready + leave a trace (skip issue "0"
+              # / unknown — a claim with no real issue has no board item to flip).
+              if [ -n "${issue:-}" ] && [ "$issue" != "0" ]; then
+                item_id=$(gh api graphql -f query='
+                  query($p: ID!) { node(id: $p) { ... on ProjectV2 {
+                    items(first: 100) { nodes { id content {
+                      ... on Issue { number state } } } } } } }' \
+                  -f p="$PROJECT_ID" \
+                  --jq ".data.node.items.nodes[] | select(.content.number==${issue}) | select(.content.state==\"OPEN\") | .id" 2>/dev/null | head -1 || true)
+                if [ -n "${item_id:-}" ]; then
+                  gh api graphql -f query='
+                    mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
+                      updateProjectV2ItemFieldValue(input: {
+                        projectId: $p, itemId: $i, fieldId: $f,
+                        value: { singleSelectOptionId: $o }
+                      }) { projectV2Item { id } }
+                    }' -f p="$PROJECT_ID" -f i="$item_id" -f f="$STATUS_FIELD_ID" -f o="$OPT_READY" >/dev/null || true
+                  echo "flipped issue #$issue -> Ready"
+                fi
+                gh issue comment "$issue" --body \
+                  "Automated claim reap (issue #2655 CI reaper): machine \`${machine}\`'s claim ref was stale (age > $((REAP_THRESHOLD_SECS/3600))h) with no open PR. Work is preserved on the \`issue-${issue}-*\` branch (never deleted); Status returned to Ready for re-pickup." >/dev/null 2>&1 || true
+              fi
+            else
+              echo "reap declined machine=$machine (open PR appeared, or push error) — kept"
+              kept=$((kept+1))
+            fi
+          done <<< "$raw"
+
+          echo "Reap complete: $reaped claim(s) reaped, $kept kept."

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -273,6 +273,7 @@ jobs:
   reap-claims:
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Needs write to delete stale refs/machine-claims/* refs (the top-level
     # default is contents: read); the sweep/pr-closed jobs stay read-only.
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,21 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   deletes the ref (refuses under an open PR without `--force`). Maintain the liveness heartbeat
   (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
   `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).
+- **Supervisor-authored machine claim + CI reaper (#2655/#2499)**: liveness is now MECHANISM-driven,
+  not prose. `worker-supervisor.sh` stamps `refs/machine-claims/<machine>` (issue+supervisor-PID+ts)
+  via `claim-heartbeat.sh stamp` at every spawn, refreshes it each iteration, and clears it on a
+  clean exit (`reap`, which REFUSES when the issue still has an open PR — an unfinished endgame stays
+  owned for adoption, never orphaned). This namespace is distinct from `claim.sh`'s per-issue lock
+  `refs/claims/issue-<N>`. `claim-heartbeat.sh should-reap <machine> [secs]` is the single, fail-safe
+  reap predicate (exit 0 = reap, 1 = keep, 2 = no ref): reap ONLY on age > threshold (4h) AND no open
+  PR AND (pid-dead, when the claim is local — a foreign machine's PID is unknowable). It KEEPS on a
+  fresh ref, an open PR, a live local PID, or an unparseable age; a `gh`/network hiccup in the
+  open-PR probe assumes an open PR (keeps). The `project-board-sync` 30-min cron runs a `reap-claims`
+  job that applies this predicate server-side and flips a freed board item back to Ready with a
+  traceable comment. **`PROJECTS_TOKEN` absence now FAILS the workflow loudly (`::error::`)** — a
+  persistent red run is the alert, replacing the old silent green `::notice::` no-op. The scheduled
+  board sweep only backlogs a null-status issue once it is past a 10-min auto-add grace window, so it
+  no longer races the built-in Auto-add's default-status write.
 - **One worker per machine (#1930)**: one lead/worker session owns a box; it fans out subagents but
   keeps to **one full gate at a time** — enforced mechanically (#2640): `bootstrap-agent-machine.sh`
   pins `CQLITE_GATE_MAX_CONCURRENCY=1` (the #1825 cap admits one gate; the per-gate core budget then

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -204,7 +204,11 @@ machine + heartbeat age (issue #2089). Interpretation:
 - **Ready, no claim ref** → next thing a worker will grab
 - **In Progress, heartbeat fresh** → leave it alone
 - **In Progress, heartbeat stale** → deterministically reaped by flow-board (heartbeat age > 4h AND no
-  open PR → Status → Ready, work preserved on the branch, traceable comment; issue #2089)
+  open PR → Status → Ready, work preserved on the branch, traceable comment; issue #2089). The
+  supervisor also stamps a machine-scoped claim ref `refs/machine-claims/<machine>` that the
+  `project-board-sync` 30-min cron's `reap-claims` job reaps on the SAME predicate server-side (age >
+  4h AND no open PR AND, for a local claim, PID-dead) — so a supervisor that dies overnight gets its
+  claim reaped by CI without waiting for a human to run flow-board (issue #2655)
 - **Ready but branch already on origin** → parked-by-design (e.g. spec approved, awaiting a
   team) — pickup is *resume that branch*, never a fresh claim
 

--- a/scripts/flow/claim-heartbeat.sh
+++ b/scripts/flow/claim-heartbeat.sh
@@ -30,6 +30,22 @@
 #     commit date, so a re-push through a clock-skewed relay or a rebasing
 #     proxy can't silently corrupt the age computation).
 #
+#   refs/machine-claims/<machine>   (issue #2655 / #2499 design)
+#     A SUPERVISOR-authored claim ref — the machine-driven complement to the
+#     LLM-driven `beat`. `worker-supervisor.sh` (#2090) stamps it at spawn,
+#     refreshes it every iteration, and clears it on a clean exit, so claim
+#     liveness no longer depends on the worker LLM *remembering* to beat. Same
+#     empty-tree/root-commit shape; the message carries the owning PID as well:
+#       "claim issue=<N> machine=<machine> pid=<PID> ts=<ISO8601 UTC>"
+#     The PID lets a reaper running ON THE CLAIM'S OWN MACHINE add a
+#     process-liveness check (a beat-then-crash no longer looks alive for the
+#     whole threshold window). A reaper running elsewhere (the project-board-sync
+#     CI cron) can't see the PID, so it falls back to age + no-open-PR only.
+#     NOTE the namespace is `refs/machine-claims/*`, deliberately DISTINCT from
+#     `scripts/flow/claim.sh`'s per-issue LOCK refs `refs/claims/issue-<N>`
+#     (#2665) — this is a per-MACHINE liveness proof, not the issue lock, and the
+#     reaper must never glob up (let alone delete) the issue-lock refs.
+#
 # THRESHOLD SEMANTICS (documented once, here — flow-board defers to this file)
 #   A heartbeat older than 4 hours (default) with NO open PR for its issue is
 #   "stale enough to reap" per issue #2089's deterministic rule. 4h
@@ -43,9 +59,22 @@
 #   script only measures and reports age.
 #
 # USAGE
-#   claim-heartbeat.sh beat <issue>      # push a fresh heartbeat for THIS machine
-#   claim-heartbeat.sh list              # one line per machine: machine/issue/ts/age
-#   claim-heartbeat.sh clear <machine>   # delete a machine's heartbeat ref (reap)
+#   claim-heartbeat.sh beat <issue>       # push a fresh heartbeat for THIS machine
+#   claim-heartbeat.sh list               # one line per machine: machine/issue/ts/age
+#   claim-heartbeat.sh clear <machine>    # delete a machine's heartbeat ref (reap)
+#
+#   claim-heartbeat.sh stamp <issue> [pid]  # push/refresh THIS machine's claim ref
+#                                            # (supervisor-authored; pid default $$)
+#   claim-heartbeat.sh list-claims          # one line per machine: machine/issue/pid/ts/age
+#   claim-heartbeat.sh should-reap <machine> [threshold_secs]
+#                                            # exit 0 iff the claim ref is stale
+#                                            # (age > threshold, default 14400s/4h)
+#                                            # AND its issue has NO open PR AND
+#                                            # (pid-dead, when the claim is local);
+#                                            # exit 1 = keep (still live / open PR /
+#                                            # foreign-pid unknowable); exit 2 = no ref.
+#   claim-heartbeat.sh reap <machine>        # delete a machine's claim ref, but
+#                                            # REFUSE if its issue has an open PR.
 #
 # Run from inside the repo (any cwd under the working tree/worktree is fine —
 # this never touches the working tree or the current branch).
@@ -55,6 +84,14 @@
 #   HEARTBEAT_MACHINE  override the machine identity (default: `hostname -s`);
 #                      tests use this to simulate multiple machines against one
 #                      fake origin from a single clone.
+#   CLAIM_OPEN_PR_CMD  hook used by `should-reap`/`reap`/`clear` to test whether
+#                      an issue has an open PR: run as `bash -c "$CMD" _ <issue>`
+#                      ($1 = issue number), exit 0 = has open PR. Default lists
+#                      open PRs via `gh` and matches the 1:1:1:1 head-branch
+#                      convention `issue-<N>-<slug>`. Tests override it to stay
+#                      hermetic (no network/gh). ANY gh/network failure is
+#                      fail-SAFE: treated as "has open PR" so a transient outage
+#                      never reaps a possibly-live claim.
 #
 # EXIT CODES
 #   0  success (including "zero heartbeats" on `list`, and "already absent" on
@@ -71,6 +108,37 @@ die_usage() { echo "$prog: $*" >&2; exit 64; }
 note()      { echo "[claim-heartbeat] $*" >&2; }
 
 REMOTE="${HEARTBEAT_REMOTE:-origin}"
+
+# Default reap threshold: 4h (matches the heartbeat threshold documented above).
+DEFAULT_REAP_THRESHOLD_SECS="${DEFAULT_REAP_THRESHOLD_SECS:-14400}"
+
+# issue_has_open_pr <issue> — exit 0 iff the issue has an open linked PR.
+# Overridable via CLAIM_OPEN_PR_CMD for hermetic tests (run as `bash -c "$CMD" _
+# <issue>`). Default consults `gh`. A gh/network FAILURE is treated fail-SAFE:
+# "we could not prove there is NO open PR" -> return "has open PR" (exit 0), so a
+# transient outage never causes a reap of a possibly-live claim.
+issue_has_open_pr() {
+  local issue="$1"
+  case "$issue" in
+    '' | *[!0-9]*) return 1 ;; # no valid issue number => cannot have an open PR
+  esac
+  if [ -n "${CLAIM_OPEN_PR_CMD:-}" ]; then
+    bash -c "$CLAIM_OPEN_PR_CMD" _ "$issue"
+    return $?
+  fi
+  command -v gh >/dev/null 2>&1 || return 0 # no gh: cannot disprove -> fail-safe keep
+  # Detect an open PR via the project's 1:1:1:1 head-branch convention
+  # (`issue-<N>-<slug>`) — `gh pr list --head` matches an exact branch, so we
+  # list all open PRs and keep those whose head starts with `issue-<N>-`. Any
+  # gh/network FAILURE is fail-SAFE: "could not prove there is NO open PR" ->
+  # return 0 (has open PR), so a transient outage never reaps a possibly-live
+  # claim.
+  local heads
+  if ! heads="$(gh pr list --state open --json headRefName --jq '.[].headRefName' 2>/dev/null)"; then
+    return 0 # gh failed -> fail-safe: assume an open PR exists, do not reap
+  fi
+  printf '%s\n' "$heads" | grep -qE "^issue-${issue}(-|$)"
+}
 
 print_help() {
   awk 'NR>=2 && /^# ---END-HELP---/{exit} NR>=2 {sub(/^# ?/,""); print}' "$0"
@@ -105,39 +173,72 @@ humanize_age() {
   fi
 }
 
-cmd_beat() {
-  local issue="${1:-}"
-  case "$issue" in
-    *[!0-9]* | '') die_usage "beat requires a numeric issue number (got '${issue:-<none>}')" ;;
-  esac
-
-  local machine ts message empty_tree commit_sha
-  machine="${HEARTBEAT_MACHINE:-$(hostname -s)}"
-  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  message="heartbeat issue=${issue} machine=${machine} ts=${ts}"
-
-  # Empty tree — the heartbeat carries no content, only the commit message.
-  # Computed via hash-object (not the well-known SHA-1 constant) so this keeps
-  # working under a SHA-256 object format too.
+# push_liveness_ref <ref> <message> <ts> — commit an empty tree carrying
+# <message> and force-push it to <ref> on $REMOTE. Shared by `beat` and `stamp`:
+# same root-commit/empty-tree shape, fixed bot identity, author/committer date =
+# <ts> so the commit metadata agrees with the message (`list`/`ref_field` still
+# authoritatively parse FROM the message, never the commit date; see header).
+# Empty tree computed via hash-object (not the SHA-1 constant) so this keeps
+# working under a SHA-256 object format too. Never touches the working tree, the
+# index, or the current branch — a pure object push against an explicit refspec.
+# Echoes the created commit sha on stdout.
+push_liveness_ref() {
+  local ref="$1" message="$2" ts="$3" empty_tree commit_sha
   empty_tree="$(git hash-object -t tree --stdin </dev/null)"
-
-  # A fixed bot identity — never rely on the caller's (or sandbox's) global
-  # git config being set, and stamp author/committer date to `ts` so the
-  # commit's own metadata agrees with the message (list() still authoritatively
-  # parses the message, never the commit date; see header).
   commit_sha="$(
     GIT_AUTHOR_NAME="cqlite-heartbeat" GIT_AUTHOR_EMAIL="heartbeat@cqlite.local" \
       GIT_COMMITTER_NAME="cqlite-heartbeat" GIT_COMMITTER_EMAIL="heartbeat@cqlite.local" \
       GIT_AUTHOR_DATE="$ts" GIT_COMMITTER_DATE="$ts" \
       git commit-tree "$empty_tree" -m "$message"
   )"
+  git push "$REMOTE" --force "${commit_sha}:${ref}"
+  printf '%s\n' "$commit_sha"
+}
 
+# ref_msg_field <refname> <key> — fetch <refname> and extract the run of
+# non-space chars after `key=` in its commit message. Empty on any failure.
+ref_msg_field() {
+  local refname="$1" key="$2" msg
+  git fetch "$REMOTE" "$refname" >/dev/null 2>&1 || return 0
+  msg="$(git log -1 --format=%B FETCH_HEAD 2>/dev/null || true)"
+  printf '%s' "$msg" | sed -n "s/.*${key}=\\([^ ][^ ]*\\).*/\\1/p" | head -1
+}
+
+cmd_beat() {
+  local issue="${1:-}"
+  case "$issue" in
+    *[!0-9]* | '') die_usage "beat requires a numeric issue number (got '${issue:-<none>}')" ;;
+  esac
+
+  local machine ts commit_sha
+  machine="${HEARTBEAT_MACHINE:-$(hostname -s)}"
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   # Force-update: ONE ref per machine (issue #1930 — one worker per machine),
   # so every beat replaces the previous liveness proof rather than growing a
-  # history. This never touches the working tree, the index, or the current
-  # branch — it is a pure object push against an explicit refspec.
-  git push "$REMOTE" --force "${commit_sha}:refs/heartbeats/${machine}"
+  # history.
+  commit_sha="$(push_liveness_ref "refs/heartbeats/${machine}" \
+    "heartbeat issue=${issue} machine=${machine} ts=${ts}" "$ts")"
   note "heartbeat pushed: machine=$machine issue=$issue ts=$ts -> refs/heartbeats/$machine ($commit_sha)"
+}
+
+# cmd_stamp <issue> [pid] — supervisor-authored claim ref (issue #2655 / #2499).
+# Same mechanism as `beat` but writes refs/machine-claims/<machine> and records the
+# owning PID so a SAME-machine reaper can add a process-liveness check.
+cmd_stamp() {
+  local issue="${1:-}" pid="${2:-$$}"
+  case "$issue" in
+    *[!0-9]* | '') die_usage "stamp requires a numeric issue number (got '${issue:-<none>}')" ;;
+  esac
+  case "$pid" in
+    *[!0-9]* | '') die_usage "stamp pid must be numeric (got '${pid}')" ;;
+  esac
+
+  local machine ts commit_sha
+  machine="${HEARTBEAT_MACHINE:-$(hostname -s)}"
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  commit_sha="$(push_liveness_ref "refs/machine-claims/${machine}" \
+    "claim issue=${issue} machine=${machine} pid=${pid} ts=${ts}" "$ts")"
+  note "claim stamped: machine=$machine issue=$issue pid=$pid ts=$ts -> refs/machine-claims/$machine ($commit_sha)"
 }
 
 cmd_list() {
@@ -176,16 +277,144 @@ cmd_list() {
   done <<<"$raw"
 }
 
+# delete_ref_guarded <ref-namespace> <machine> — shared delete for a machine's
+# heartbeat OR claim ref that REFUSES to delete when the ref's issue still has
+# an open PR (issue #2655: an open PR means the endgame is unfinished; deleting
+# the liveness ref would erase the only signal that this lane is still owned and
+# invite a duplicate pickup). A missing ref is a graceful no-op. Returns 0 on
+# delete-or-absent, 3 on refuse.
+delete_ref_guarded() {
+  local namespace="$1" machine="$2"
+  local ref="refs/${namespace}/${machine}"
+
+  if ! git ls-remote --exit-code "$REMOTE" "$ref" >/dev/null 2>&1; then
+    note "${ref} already absent on $REMOTE — nothing to clear"
+    return 0
+  fi
+
+  local issue
+  issue="$(ref_msg_field "$ref" issue)"
+  if [ -n "$issue" ] && issue_has_open_pr "$issue"; then
+    note "REFUSING to delete ${ref}: issue #${issue} has an open PR (endgame unfinished; #2655)"
+    return 3
+  fi
+
+  git push "$REMOTE" --delete "$ref"
+  note "cleared ${ref} on $REMOTE"
+  return 0
+}
+
 cmd_clear() {
   local machine="${1:-}"
   [ -n "$machine" ] || die_usage "clear requires <machine>"
+  delete_ref_guarded heartbeats "$machine"
+}
 
-  if git ls-remote --exit-code "$REMOTE" "refs/heartbeats/${machine}" >/dev/null 2>&1; then
-    git push "$REMOTE" --delete "refs/heartbeats/${machine}"
-    note "cleared refs/heartbeats/${machine} on $REMOTE"
-  else
-    note "refs/heartbeats/${machine} already absent on $REMOTE — nothing to clear"
+cmd_reap() {
+  local machine="${1:-}"
+  [ -n "$machine" ] || die_usage "reap requires <machine>"
+  delete_ref_guarded machine-claims "$machine"
+}
+
+cmd_list_claims() {
+  local now_epoch raw
+  now_epoch="$(date -u +%s)"
+  raw="$(git ls-remote "$REMOTE" 'refs/machine-claims/*' 2>/dev/null || true)"
+
+  if [ -z "$raw" ]; then
+    echo "no claims found on $REMOTE"
+    return 0
   fi
+
+  printf '%-20s %-8s %-10s %-24s %s\n' "MACHINE" "ISSUE" "PID" "TS" "AGE"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    local refname machine msg issue pid ts epoch age_h
+    refname="$(printf '%s' "$line" | awk '{print $2}')"
+    machine="${refname#refs/machine-claims/}"
+
+    if ! git fetch "$REMOTE" "$refname" >/dev/null 2>&1; then
+      printf '%-20s %-8s %-10s %-24s %s\n' "$machine" "?" "?" "?" "fetch-failed"
+      continue
+    fi
+    msg="$(git log -1 --format=%B FETCH_HEAD 2>/dev/null || true)"
+    issue="$(printf '%s' "$msg" | sed -n 's/.*issue=\([0-9][0-9]*\).*/\1/p' | head -1)"
+    pid="$(printf '%s' "$msg" | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | head -1)"
+    ts="$(printf '%s' "$msg" | sed -n 's/.*ts=\([^ ]*\).*/\1/p' | head -1)"
+    [ -n "$issue" ] || issue="?"
+    [ -n "$pid" ] || pid="?"
+    [ -n "$ts" ] || ts="?"
+
+    if [ "$ts" != "?" ] && epoch="$(ts_to_epoch "$ts" 2>/dev/null)"; then
+      age_h="$(humanize_age "$((now_epoch - epoch))")"
+    else
+      age_h="unknown"
+    fi
+    printf '%-20s %-8s %-10s %-24s %s\n' "$machine" "$issue" "$pid" "$ts" "$age_h"
+  done <<<"$raw"
+}
+
+# cmd_should_reap <machine> [threshold_secs] — the deterministic, FAIL-SAFE reap
+# predicate for a claim ref (issue #2655). Exit codes:
+#   0  reap it: age > threshold AND issue has NO open PR AND (pid-dead, when the
+#      claim belongs to THIS machine — a foreign machine's pid is unknowable, so
+#      that clause is skipped there and age + no-open-PR govern).
+#   1  keep it: still fresh, OR has an open PR, OR (local) pid is still alive,
+#      OR the ts/age is unparseable (never reap on an unknown age).
+#   2  no such claim ref.
+# Never prints a reap verdict of 0 unless ALL guards agree — a live/open-PR/
+# fresh/unknown-age claim is always kept.
+cmd_should_reap() {
+  local machine="${1:-}" threshold="${2:-$DEFAULT_REAP_THRESHOLD_SECS}"
+  [ -n "$machine" ] || die_usage "should-reap requires <machine>"
+  case "$threshold" in
+    *[!0-9]* | '') die_usage "should-reap threshold must be numeric seconds (got '${threshold}')" ;;
+  esac
+  local ref="refs/machine-claims/${machine}"
+
+  if ! git ls-remote --exit-code "$REMOTE" "$ref" >/dev/null 2>&1; then
+    note "no claim ref ${ref} on $REMOTE"
+    return 2
+  fi
+
+  local issue pid ts epoch now_epoch age
+  issue="$(ref_msg_field "$ref" issue)"
+  pid="$(ref_msg_field "$ref" pid)"
+  ts="$(ref_msg_field "$ref" ts)"
+
+  # Unparseable/absent age -> KEEP (never reap on an unknown age).
+  if [ -z "$ts" ] || ! epoch="$(ts_to_epoch "$ts" 2>/dev/null)"; then
+    note "keep ${ref}: unparseable ts ('${ts:-<none>}') — refusing to reap on unknown age"
+    return 1
+  fi
+  now_epoch="$(date -u +%s)"
+  age=$((now_epoch - epoch))
+  if [ "$age" -le "$threshold" ]; then
+    note "keep ${ref}: age ${age}s <= threshold ${threshold}s (fresh)"
+    return 1
+  fi
+
+  # Open PR -> KEEP (endgame unfinished; the #2499 orphaned-endgame case).
+  if [ -n "$issue" ] && issue_has_open_pr "$issue"; then
+    note "keep ${ref}: issue #${issue} has an open PR (endgame in flight)"
+    return 1
+  fi
+
+  # Local claim: add a process-liveness check. A live PID means the worker is
+  # still running even if a beat is overdue — never reap it.
+  local this_machine
+  this_machine="${HEARTBEAT_MACHINE:-$(hostname -s)}"
+  if [ "$machine" = "$this_machine" ] && [ -n "$pid" ]; then
+    if kill -0 "$pid" 2>/dev/null; then
+      note "keep ${ref}: local pid ${pid} is still alive"
+      return 1
+    fi
+    note "reap ${ref}: age ${age}s > ${threshold}s, no open PR, local pid ${pid} is dead"
+    return 0
+  fi
+
+  note "reap ${ref}: age ${age}s > ${threshold}s, no open PR (foreign machine — pid not checkable)"
+  return 0
 }
 
 SUBCOMMAND="${1:-}"
@@ -201,13 +430,28 @@ case "$SUBCOMMAND" in
     shift
     cmd_clear "${1:-}"
     ;;
+  stamp)
+    shift
+    cmd_stamp "${1:-}" "${2:-}"
+    ;;
+  list-claims)
+    cmd_list_claims
+    ;;
+  should-reap)
+    shift
+    cmd_should_reap "${1:-}" "${2:-}"
+    ;;
+  reap)
+    shift
+    cmd_reap "${1:-}"
+    ;;
   -h | --help)
     print_help
     ;;
   "")
-    die_usage "a subcommand is required: beat <issue> | list | clear <machine>"
+    die_usage "a subcommand is required: beat <issue> | list | clear <machine> | stamp <issue> [pid] | list-claims | should-reap <machine> [secs] | reap <machine>"
     ;;
   *)
-    die_usage "unknown subcommand: $SUBCOMMAND (expected beat|list|clear)"
+    die_usage "unknown subcommand: $SUBCOMMAND (expected beat|list|clear|stamp|list-claims|should-reap|reap)"
     ;;
 esac

--- a/scripts/flow/claim-heartbeat.sh
+++ b/scripts/flow/claim-heartbeat.sh
@@ -128,13 +128,16 @@ issue_has_open_pr() {
   fi
   command -v gh >/dev/null 2>&1 || return 0 # no gh: cannot disprove -> fail-safe keep
   # Detect an open PR via the project's 1:1:1:1 head-branch convention
-  # (`issue-<N>-<slug>`) — `gh pr list --head` matches an exact branch, so we
-  # list all open PRs and keep those whose head starts with `issue-<N>-`. Any
+  # (`issue-<N>-<slug>`) — we list open PRs and keep those whose head starts with
+  # `issue-<N>-`. `--limit 1000` is load-bearing: `gh pr list` defaults to a
+  # 30-PR window, so on a repo with >30 open PRs a live claim's PR could fall
+  # outside the default result set and be read as "no open PR" -> reaped while its
+  # endgame is in flight (the exact fail-safe this reaper is built on). Any
   # gh/network FAILURE is fail-SAFE: "could not prove there is NO open PR" ->
   # return 0 (has open PR), so a transient outage never reaps a possibly-live
   # claim.
   local heads
-  if ! heads="$(gh pr list --state open --json headRefName --jq '.[].headRefName' 2>/dev/null)"; then
+  if ! heads="$(gh pr list --state open --limit 1000 --json headRefName --jq '.[].headRefName' 2>/dev/null)"; then
     return 0 # gh failed -> fail-safe: assume an open PR exists, do not reap
   fi
   printf '%s\n' "$heads" | grep -qE "^issue-${issue}(-|$)"

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -112,6 +112,33 @@ STOP_FILE="${STOP_FILE:-$REPO_ROOT/.worker-stop}"
 MARKER_FILE="${MARKER_FILE:-$REPO_ROOT/.worker-last-iteration.json}"
 LOG_DIR="${LOG_DIR:-$REPO_ROOT/logs/worker-supervisor}"
 
+# ---------------------------------------------------------------------------
+# Supervisor-authored git-ref claim (issue #2655 / #2499 design).
+#
+# The supervisor — a long-lived, machine-scoped process — stamps a
+# refs/claims/<machine> liveness ref (issue+PID+ts) at every worker spawn and
+# clears it when it exits cleanly, so claim liveness is MECHANISM-driven and no
+# longer depends on the worker LLM remembering to `beat`. The PID recorded is
+# the SUPERVISOR's own ($$): it is the stable per-machine anchor that outlives
+# each recycled worker, so a same-machine reaper's process-liveness check tracks
+# "is this machine's supervisor still running" rather than a transient worker
+# subprocess. When the supervisor dies, nothing refreshes the ref and it goes
+# stale within the reap threshold.
+#
+# CLAIM_CMD is the claim-heartbeat.sh entrypoint; overridable so the tests can
+# substitute a hermetic stub (no origin/network). Set CLAIM_CMD="" to disable
+# claim stamping entirely (e.g. a machine with no origin push rights).
+CLAIM_CMD="${CLAIM_CMD:-bash $REPO_ROOT/scripts/flow/claim-heartbeat.sh}"
+# The machine identity the claim ref is scoped to — must match what the reaper
+# clears. Defaults to claim-heartbeat.sh's own default (`hostname -s`), honoring
+# HEARTBEAT_MACHINE when the fleet overrides it.
+CLAIM_MACHINE="${HEARTBEAT_MACHINE:-$(hostname -s 2>/dev/null || echo unknown)}"
+# Best-known issue for the CURRENT iteration's spawn stamp. Empty/unknown on the
+# first iteration (the worker picks from the board); learned from each marker and
+# reused as the next spawn's stamp. "0" is stamped when still unknown — the
+# reaper treats a non-issue as "no open-PR guard applicable" and governs on age.
+CLAIM_ISSUE="${CLAIM_ISSUE:-}"
+
 detect_ncpu() {
   if command -v nproc >/dev/null 2>&1; then nproc
   elif command -v getconf >/dev/null 2>&1 && getconf _NPROCESSORS_ONLN >/dev/null 2>&1; then getconf _NPROCESSORS_ONLN
@@ -170,6 +197,37 @@ notify() {
 
 is_gt() { awk -v a="$1" -v b="$2" 'BEGIN{ if ((a+0)>(b+0)) exit 0; exit 1 }'; }
 is_lt() { awk -v a="$1" -v b="$2" 'BEGIN{ if ((a+0)<(b+0)) exit 0; exit 1 }'; }
+
+# stamp_claim <issue>: refresh refs/claims/<machine> with issue+PID+ts (issue
+# #2655). PID stamped is the SUPERVISOR's ($$) — the stable per-machine anchor,
+# not a transient worker subprocess. A non-numeric/empty issue is stamped as "0"
+# (unknown): the reaper then governs purely on age + open-PR (a "0" issue can
+# have no open PR). Non-fatal on failure (a claim-push hiccup must never crash
+# the supervisor) — logs a WARN and continues; the ref simply won't refresh this
+# iteration and ages toward the reap threshold, which is fail-safe.
+stamp_claim() {
+  local issue="$1"
+  [[ -n "$CLAIM_CMD" ]] || return 0
+  case "$issue" in '' | *[!0-9]*) issue=0 ;; esac
+  if HEARTBEAT_MACHINE="$CLAIM_MACHINE" $CLAIM_CMD stamp "$issue" "$$" >/dev/null 2>&1; then
+    log "claim stamped: machine=$CLAIM_MACHINE issue=$issue pid=$$"
+  else
+    log "WARN: claim stamp failed (machine=$CLAIM_MACHINE issue=$issue) — ref not refreshed this iteration (non-fatal)"
+  fi
+}
+
+# clear_claim: delete refs/claims/<machine> on a CLEAN supervisor exit (issue
+# #2655). `reap` refuses to delete a ref whose issue still has an open PR, so a
+# supervisor that stops with an unfinished endgame leaves the claim in place for
+# adoption rather than orphaning it. Non-fatal on failure.
+clear_claim() {
+  [[ -n "$CLAIM_CMD" ]] || return 0
+  if HEARTBEAT_MACHINE="$CLAIM_MACHINE" $CLAIM_CMD reap "$CLAIM_MACHINE" >/dev/null 2>&1; then
+    log "claim cleared on clean exit: machine=$CLAIM_MACHINE"
+  else
+    log "WARN: claim clear declined/failed for machine=$CLAIM_MACHINE (open PR or push error) — left for adoption (non-fatal)"
+  fi
+}
 
 # detect_prompt_signature <logfile>: true (exit 0) when the LAST ~20 lines of the
 # worker's live log show an interactive-prompt signature — a wedged
@@ -347,6 +405,10 @@ MAX_HOURS_SECS=$((MAX_HOURS * 3600))
 
 finalize_exit() {
   local reason="$1" code="$2"
+  # Release this machine's claim ref on a clean stop (issue #2655). `reap`
+  # refuses when the claim's issue still has an open PR, so an unfinished endgame
+  # is preserved for adoption rather than orphaned.
+  clear_claim
   local elapsed=$(($(date +%s) - START_TS))
   mkdir -p "$LOG_DIR"
   printf '{"ts":"%s","iter":%d,"outcome":"summary","reason":"%s","issues_done":%d,"elapsed_s":%d}\n' \
@@ -365,6 +427,11 @@ run_iteration() {
   ITER=$((ITER + 1))
   rm -f "$MARKER_FILE"
   mkdir -p "$LOG_DIR"
+  # Stamp/refresh the machine's claim ref BEFORE spawning (issue #2655): the
+  # supervisor authors liveness mechanically, so a beat-then-crash worker can no
+  # longer look alive for the whole threshold window. Uses the best-known issue
+  # from the previous iteration's marker (empty/unknown -> "0").
+  stamp_claim "$CLAIM_ISSUE"
   local logfile="$LOG_DIR/iter-${ITER}.log"
   local stuck_flag="$LOG_DIR/.iter-${ITER}.stuck"
   rm -f "$stuck_flag"
@@ -461,6 +528,16 @@ run_iteration() {
   pr="$(marker_field pr)"
   reason="$(marker_field reason)"
   question="$(marker_field question)"
+
+  # Learn the issue this iteration worked so the NEXT spawn's claim stamp names
+  # it (issue #2655). A recycled worker that resumes the same machine's claim
+  # branch stays on the same issue, so carrying it forward keeps the claim ref's
+  # open-PR reap guard accurate. A finalized issue is released (its endgame is
+  # done); anything else keeps the issue for the next stamp.
+  case "$outcome" in
+    finalized) CLAIM_ISSUE="" ;;
+    *) [[ -n "$issue" ]] && CLAIM_ISSUE="$issue" ;;
+  esac
 
   case "$outcome" in
     finalized)

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -116,7 +116,7 @@ LOG_DIR="${LOG_DIR:-$REPO_ROOT/logs/worker-supervisor}"
 # Supervisor-authored git-ref claim (issue #2655 / #2499 design).
 #
 # The supervisor — a long-lived, machine-scoped process — stamps a
-# refs/claims/<machine> liveness ref (issue+PID+ts) at every worker spawn and
+# refs/machine-claims/<machine> liveness ref (issue+PID+ts) at every worker spawn and
 # clears it when it exits cleanly, so claim liveness is MECHANISM-driven and no
 # longer depends on the worker LLM remembering to `beat`. The PID recorded is
 # the SUPERVISOR's own ($$): it is the stable per-machine anchor that outlives
@@ -198,7 +198,7 @@ notify() {
 is_gt() { awk -v a="$1" -v b="$2" 'BEGIN{ if ((a+0)>(b+0)) exit 0; exit 1 }'; }
 is_lt() { awk -v a="$1" -v b="$2" 'BEGIN{ if ((a+0)<(b+0)) exit 0; exit 1 }'; }
 
-# stamp_claim <issue>: refresh refs/claims/<machine> with issue+PID+ts (issue
+# stamp_claim <issue>: refresh refs/machine-claims/<machine> with issue+PID+ts (issue
 # #2655). PID stamped is the SUPERVISOR's ($$) — the stable per-machine anchor,
 # not a transient worker subprocess. A non-numeric/empty issue is stamped as "0"
 # (unknown): the reaper then governs purely on age + open-PR (a "0" issue can
@@ -216,7 +216,7 @@ stamp_claim() {
   fi
 }
 
-# clear_claim: delete refs/claims/<machine> on a CLEAN supervisor exit (issue
+# clear_claim: delete refs/machine-claims/<machine> on a CLEAN supervisor exit (issue
 # #2655). `reap` refuses to delete a ref whose issue still has an open PR, so a
 # supervisor that stops with an unfinished endgame leaves the claim in place for
 # adoption rather than orphaning it. Non-fatal on failure.

--- a/scripts/tests/test_claim_heartbeat.sh
+++ b/scripts/tests/test_claim_heartbeat.sh
@@ -127,7 +127,10 @@ fi
 # ===========================================================================
 echo "TEST 5: clear removes the ref"
 # ===========================================================================
-(cd "$WORK" && bash "$HB" clear machineOld >/dev/null 2>&1)
+# clear now guards on open-PR state (issue #2655); pass the hermetic no-open-PR
+# hook so the test never reaches gh/network. (The open-PR REFUSAL path is
+# covered by TEST 20.)
+(cd "$WORK" && CLAIM_OPEN_PR_CMD='exit 1' bash "$HB" clear machineOld >/dev/null 2>&1)
 remaining=$(g -C "$WORK" ls-remote origin "refs/heartbeats/machineOld")
 if [ -z "$remaining" ]; then
   ok "clear removed refs/heartbeats/machineOld"
@@ -135,7 +138,7 @@ else
   bad "refs/heartbeats/machineOld still present after clear: $remaining"
 fi
 # idempotent: clearing an already-absent ref must not error
-if (cd "$WORK" && bash "$HB" clear machineOld >/dev/null 2>&1); then
+if (cd "$WORK" && CLAIM_OPEN_PR_CMD='exit 1' bash "$HB" clear machineOld >/dev/null 2>&1); then
   ok "clear on an already-absent ref is a graceful no-op (exit 0)"
 else
   bad "clear on an already-absent ref exited non-zero"
@@ -180,6 +183,188 @@ if [ -n "$on_alt" ] && [ -z "$on_default" ]; then
   ok "HEARTBEAT_REMOTE=empty-origin routed the beat to the non-default remote only"
 else
   bad "expected machineC only on empty-origin; on_alt='$on_alt' on_default='$on_default'"
+fi
+
+# craft_old_claim <work> <machine> <issue> <pid> <age_seconds> — like
+# craft_old_heartbeat but writes a refs/machine-claims/<machine> ref carrying a pid, so
+# should-reap / reap assertions don't depend on real sleeps.
+craft_old_claim() {
+  local work="$1" machine="$2" issue="$3" pid="$4" age="$5"
+  (
+    cd "$work" || exit 1
+    local now_epoch old_epoch old_ts empty_tree csha
+    now_epoch=$(date -u +%s)
+    old_epoch=$((now_epoch - age))
+    if ! old_ts=$(date -u -r "$old_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+      old_ts=$(date -u -d "@$old_epoch" +%Y-%m-%dT%H:%M:%SZ)
+    fi
+    empty_tree=$(git hash-object -t tree --stdin </dev/null)
+    csha=$(GIT_AUTHOR_DATE="$old_ts" GIT_COMMITTER_DATE="$old_ts" \
+      GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+      git commit-tree "$empty_tree" -m "claim issue=${issue} machine=${machine} pid=${pid} ts=${old_ts}")
+    g push -q origin "${csha}:refs/machine-claims/${machine}"
+  )
+}
+
+# Hermetic open-PR hooks (never touch gh/network).
+NO_OPEN_PR='exit 1'   # $1=issue -> always "no open PR"
+HAS_OPEN_PR='exit 0'  # $1=issue -> always "has open PR"
+
+# ===========================================================================
+echo "TEST 9: stamp creates refs/machine-claims/<machine> with issue+pid"
+# ===========================================================================
+(cd "$WORK" && HEARTBEAT_MACHINE=claimA bash "$HB" stamp 900 4242 >/dev/null 2>&1)
+claim_sha=$(g -C "$WORK" ls-remote origin "refs/machine-claims/claimA" | awk '{print $1}')
+claim_msg=""
+if [ -n "$claim_sha" ]; then
+  g -C "$WORK" fetch -q origin "refs/machine-claims/claimA" 2>/dev/null
+  claim_msg=$(g -C "$WORK" log -1 --format=%B FETCH_HEAD 2>/dev/null)
+fi
+if [ -n "$claim_sha" ] && printf '%s' "$claim_msg" | grep -q 'issue=900' \
+  && printf '%s' "$claim_msg" | grep -q 'pid=4242'; then
+  ok "stamp created refs/machine-claims/claimA carrying issue=900 pid=4242"
+else
+  bad "stamp did not create a well-formed claim ref (sha='$claim_sha' msg='$claim_msg')"
+fi
+
+# ===========================================================================
+echo "TEST 10: list-claims renders machine/issue/pid/age"
+# ===========================================================================
+lc_out=$(cd "$WORK" && bash "$HB" list-claims)
+if printf '%s\n' "$lc_out" | grep -qE '^claimA +900 +4242 '; then
+  ok "list-claims rendered claimA issue=900 pid=4242"
+else
+  bad "list-claims output missing expected row:
+$lc_out"
+fi
+
+# ===========================================================================
+echo "TEST 11: should-reap KEEPS a fresh claim (age <= threshold)"
+# ===========================================================================
+if (cd "$WORK" && CLAIM_OPEN_PR_CMD="$NO_OPEN_PR" bash "$HB" should-reap claimA 14400 >/dev/null 2>&1); then
+  bad "should-reap returned reap(0) for a FRESH claim — must keep"
+else
+  ok "should-reap keeps a fresh claim (exit non-zero)"
+fi
+
+# ===========================================================================
+echo "TEST 12: should-reap REAPS a stale claim with no open PR (foreign machine)"
+# ===========================================================================
+craft_old_claim "$WORK" "claimStale" 901 5555 36000  # 10h old
+if (cd "$WORK" && HEARTBEAT_MACHINE=someOtherMachine CLAIM_OPEN_PR_CMD="$NO_OPEN_PR" \
+  bash "$HB" should-reap claimStale 14400 >/dev/null 2>&1); then
+  ok "should-reap reaps a stale, no-open-PR, foreign-machine claim (exit 0)"
+else
+  bad "should-reap did NOT reap a 10h-old no-open-PR foreign claim"
+fi
+
+# ===========================================================================
+echo "TEST 13: should-reap KEEPS a stale claim that has an open PR"
+# ===========================================================================
+if (cd "$WORK" && HEARTBEAT_MACHINE=someOtherMachine CLAIM_OPEN_PR_CMD="$HAS_OPEN_PR" \
+  bash "$HB" should-reap claimStale 14400 >/dev/null 2>&1); then
+  bad "should-reap reaped a claim WITH an open PR — must keep (endgame in flight)"
+else
+  ok "should-reap keeps a stale claim that has an open PR"
+fi
+
+# ===========================================================================
+echo "TEST 14: should-reap KEEPS a stale LOCAL claim whose pid is still alive"
+# ===========================================================================
+# A long-lived local pid: use this test process's own pid ($$), guaranteed alive.
+craft_old_claim "$WORK" "localMachine" 902 "$$" 36000
+if (cd "$WORK" && HEARTBEAT_MACHINE=localMachine CLAIM_OPEN_PR_CMD="$NO_OPEN_PR" \
+  bash "$HB" should-reap localMachine 14400 >/dev/null 2>&1); then
+  bad "should-reap reaped a LOCAL claim whose pid ($$) is still alive — must keep"
+else
+  ok "should-reap keeps a stale local claim whose pid is still alive"
+fi
+
+# ===========================================================================
+echo "TEST 15: should-reap REAPS a stale LOCAL claim whose pid is dead"
+# ===========================================================================
+# A pid that is essentially never alive. 999999 is beyond default pid_max on
+# Linux/macOS; kill -0 fails -> dead.
+craft_old_claim "$WORK" "localMachine2" 903 999999 36000
+if (cd "$WORK" && HEARTBEAT_MACHINE=localMachine2 CLAIM_OPEN_PR_CMD="$NO_OPEN_PR" \
+  bash "$HB" should-reap localMachine2 14400 >/dev/null 2>&1); then
+  ok "should-reap reaps a stale local claim whose pid is dead"
+else
+  bad "should-reap did NOT reap a stale local claim with a dead pid"
+fi
+
+# ===========================================================================
+echo "TEST 16: should-reap KEEPS on unparseable ts (never reap on unknown age)"
+# ===========================================================================
+(
+  cd "$WORK" || exit 1
+  et=$(git hash-object -t tree --stdin </dev/null)
+  cs=$(GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+    git commit-tree "$et" -m "claim issue=904 machine=badTs pid=1 ts=not-a-date")
+  g push -q origin "${cs}:refs/machine-claims/badTs"
+)
+if (cd "$WORK" && HEARTBEAT_MACHINE=someOtherMachine CLAIM_OPEN_PR_CMD="$NO_OPEN_PR" \
+  bash "$HB" should-reap badTs 14400 >/dev/null 2>&1); then
+  bad "should-reap reaped a claim with an unparseable ts — must keep on unknown age"
+else
+  ok "should-reap keeps a claim with an unparseable ts"
+fi
+
+# ===========================================================================
+echo "TEST 17: should-reap returns 2 (no ref) for an absent claim"
+# ===========================================================================
+rc=0
+(cd "$WORK" && CLAIM_OPEN_PR_CMD="$NO_OPEN_PR" bash "$HB" should-reap doesNotExist 14400 >/dev/null 2>&1) || rc=$?
+if [ "$rc" -eq 2 ]; then
+  ok "should-reap returns exit 2 for a nonexistent claim ref"
+else
+  bad "should-reap returned $rc for a nonexistent claim (expected 2)"
+fi
+
+# ===========================================================================
+echo "TEST 18: reap DELETES a claim with no open PR"
+# ===========================================================================
+(cd "$WORK" && CLAIM_OPEN_PR_CMD="$NO_OPEN_PR" bash "$HB" reap claimStale >/dev/null 2>&1)
+if [ -z "$(g -C "$WORK" ls-remote origin "refs/machine-claims/claimStale")" ]; then
+  ok "reap deleted refs/machine-claims/claimStale (no open PR)"
+else
+  bad "reap did NOT delete refs/machine-claims/claimStale"
+fi
+
+# ===========================================================================
+echo "TEST 19: reap REFUSES to delete a claim whose issue has an open PR"
+# ===========================================================================
+craft_old_claim "$WORK" "claimHasPR" 905 6666 36000
+rc=0
+(cd "$WORK" && CLAIM_OPEN_PR_CMD="$HAS_OPEN_PR" bash "$HB" reap claimHasPR >/dev/null 2>&1) || rc=$?
+still_there=$(g -C "$WORK" ls-remote origin "refs/machine-claims/claimHasPR")
+if [ "$rc" -eq 3 ] && [ -n "$still_there" ]; then
+  ok "reap refused (exit 3) to delete a claim with an open PR; ref preserved"
+else
+  bad "reap should have refused an open-PR claim: rc=$rc still_there='$still_there'"
+fi
+
+# ===========================================================================
+echo "TEST 20: clear REFUSES to delete a heartbeat whose issue has an open PR"
+# ===========================================================================
+(cd "$WORK" && HEARTBEAT_MACHINE=hbHasPR bash "$HB" beat 906 >/dev/null 2>&1)
+rc=0
+(cd "$WORK" && CLAIM_OPEN_PR_CMD="$HAS_OPEN_PR" bash "$HB" clear hbHasPR >/dev/null 2>&1) || rc=$?
+hb_still=$(g -C "$WORK" ls-remote origin "refs/heartbeats/hbHasPR")
+if [ "$rc" -eq 3 ] && [ -n "$hb_still" ]; then
+  ok "clear refused (exit 3) a heartbeat with an open PR; ref preserved"
+else
+  bad "clear should have refused an open-PR heartbeat: rc=$rc still='$hb_still'"
+fi
+
+# ===========================================================================
+echo "TEST 21: clear DELETES a heartbeat with no open PR (default behavior intact)"
+# ===========================================================================
+(cd "$WORK" && CLAIM_OPEN_PR_CMD="$NO_OPEN_PR" bash "$HB" clear hbHasPR >/dev/null 2>&1)
+if [ -z "$(g -C "$WORK" ls-remote origin "refs/heartbeats/hbHasPR")" ]; then
+  ok "clear deleted a heartbeat with no open PR"
+else
+  bad "clear did NOT delete a no-open-PR heartbeat"
 fi
 
 echo

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -1061,7 +1061,7 @@ test_fast_exit_latency() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 23 (#2655): the supervisor STAMPS refs/claims/<machine> before each spawn
+# Test 23 (#2655): the supervisor STAMPS refs/machine-claims/<machine> before each spawn
 # and CLEARS (reap) it on a clean exit — via CLAIM_CMD, mechanically, without the
 # worker LLM. A hermetic CLAIM_CMD stub logs every invocation; we assert one
 # `stamp <issue> <pid>` per iteration and exactly one `reap <machine>` at stop.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -378,9 +378,26 @@ common_env() {
   export STUCK_POLL_SECS=1
   unset LOAD_CONTROL_FILE 2>/dev/null || true
   unset WORKER_CMD 2>/dev/null || true
+  # Claim stamping (issue #2655) OFF by default so most tests stay focused; the
+  # dedicated claim tests set a hermetic CLAIM_CMD stub that logs its args.
+  export CLAIM_CMD=""
+  unset HEARTBEAT_MACHINE 2>/dev/null || true
 }
 
 jline_count() { grep -c "$2" "$1" 2>/dev/null || true; }
+
+# A hermetic claim-heartbeat.sh stand-in: append "<subcmd> <args...>" to
+# $CLAIM_LOG on every call, always succeed. Lets a test assert the supervisor
+# invoked `stamp`/`reap` with the right shape, without any origin/network.
+write_claim_stub() {
+  local path="$1"
+  cat >"$path" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CLAIM_LOG:?CLAIM_LOG not set}"
+exit 0
+EOF
+  chmod +x "$path"
+}
 
 # ---------------------------------------------------------------------------
 # Test 1: happy path — 2 finalized iterations, then MAX_ISSUES=2 budget stop.
@@ -1044,6 +1061,77 @@ test_fast_exit_latency() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 23 (#2655): the supervisor STAMPS refs/claims/<machine> before each spawn
+# and CLEARS (reap) it on a clean exit — via CLAIM_CMD, mechanically, without the
+# worker LLM. A hermetic CLAIM_CMD stub logs every invocation; we assert one
+# `stamp <issue> <pid>` per iteration and exactly one `reap <machine>` at stop.
+# ---------------------------------------------------------------------------
+test_claim_stamp_each_iter_and_clear_on_exit() {
+  local d counter jf rc stamps reaps
+  d="$(new_case_dir)"
+  counter="$d/counter"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=2
+  export CLAIM_LOG="$d/claim.log"
+  : >"$CLAIM_LOG"
+  write_claim_stub "$d/bin/claim.sh"
+  export CLAIM_CMD="bash $d/bin/claim.sh"
+  export HEARTBEAT_MACHINE="testbox"
+  jf="$JOURNAL_FILE"
+
+  bash "$SUPERVISOR" >"$d/stdout.log" 2>&1
+  rc=$?
+  # 2 finalized iterations => 2 stamps; a clean budget stop => exactly 1 reap.
+  stamps=$(grep -c '^stamp ' "$CLAIM_LOG" 2>/dev/null || true)
+  reaps=$(grep -c '^reap testbox' "$CLAIM_LOG" 2>/dev/null || true)
+  # Every stamp carries the SUPERVISOR pid as the 3rd token (numeric).
+  local well_formed="yes"
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    [[ "$line" =~ ^stamp\ [0-9]+\ [0-9]+$ ]] || well_formed="no"
+  done < <(grep '^stamp ' "$CLAIM_LOG" 2>/dev/null)
+  if [[ "$rc" -eq 0 && "$stamps" -eq 2 && "$reaps" -eq 1 && "$well_formed" == "yes" ]]; then
+    pass "claim: stamp per iteration (with pid) + one reap on clean exit"
+  else
+    fail "claim: rc=$rc stamps=$stamps reaps=$reaps well_formed=$well_formed (see $CLAIM_LOG)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 24 (#2655): the NEXT spawn's claim stamp carries the issue LEARNED from a
+# non-finalized (blocked) marker — so the reaper's open-PR guard tracks the real
+# issue. Iter 1 blocks issue 88; iter 2's stamp must name issue 88 (before the
+# head-block guard stops the run on the 2nd consecutive block).
+# ---------------------------------------------------------------------------
+test_claim_issue_learned_from_marker() {
+  local d rc second_stamp
+  d="$(new_case_dir)"
+  common_env "$d"
+  write_blocked_same_issue_stub "$d/bin/worker.sh" 88
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=100
+  export BREAKER_N=100
+  export CLAIM_LOG="$d/claim.log"
+  : >"$CLAIM_LOG"
+  write_claim_stub "$d/bin/claim.sh"
+  export CLAIM_CMD="bash $d/bin/claim.sh"
+  export HEARTBEAT_MACHINE="testbox"
+
+  bash "$SUPERVISOR" >"$d/stdout.log" 2>&1
+  rc=$?
+  # Iter1 stamp = "stamp 0 <pid>" (issue unknown); iter2 stamp = "stamp 88 <pid>"
+  # (learned from iter1's blocked marker). Grab the 2nd stamp line.
+  second_stamp=$(grep '^stamp ' "$CLAIM_LOG" 2>/dev/null | sed -n '2p')
+  if [[ "$rc" -eq 0 ]] && printf '%s' "$second_stamp" | grep -qE '^stamp 88 [0-9]+$'; then
+    pass "claim: issue learned from a blocked marker names the next stamp (issue 88)"
+  else
+    fail "claim-learn: rc=$rc second_stamp='$second_stamp' (see $CLAIM_LOG)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # F1 (stale-lock reclaim double-acquire race) note: the fix makes reclaim
 # atomic via `mv "$LOCK" "$LOCK.stale.$$" && rm -rf "$LOCK.stale.$$"` instead
 # of `rm -rf "$LOCK"; mkdir "$LOCK"`. Reliably reproducing the ORIGINAL race
@@ -1084,5 +1172,7 @@ test_stray_signature_scrollback_is_abnormal
 test_genuine_wedge_frozen_is_stuck
 test_busy_writing_signature_not_stuck
 test_fast_exit_latency
+test_claim_stamp_each_iter_and_clear_on_exit
+test_claim_issue_learned_from_marker
 echo "=== $PASS_COUNT passed, $FAIL_COUNT failed ==="
 [[ "$FAIL_COUNT" -eq 0 ]]

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -215,6 +215,26 @@ issue per session). The supervisor adds a flock single-instance (mechanizing one
 fail-closed preflight (load/disk/leftover-process/stop-file), a crash-loop breaker, budgets, and ntfy
 notifications. See the [fleet runbook](https://github.com/pmcfadin/cqlite/blob/main/docs/development/fleet-runbook.md).
 
+**Supervisor-authored claim + CI-side reaper (issue #2655 / #2499 design).** Heartbeats used to depend on
+the worker LLM *remembering* to `beat`, and the reap threshold was enforced only in prose. Liveness is now
+**mechanism-driven**: the supervisor stamps `refs/machine-claims/<machine>` (issue + supervisor-PID + ts, via
+`claim-heartbeat.sh stamp`) at every worker spawn, refreshes it each iteration, and clears it on a clean
+exit — where `reap` **refuses to delete a claim whose issue still has an open PR** (an unfinished endgame
+stays owned for adoption rather than orphaned; the #2499 orphaned-endgame case). This `refs/machine-claims/*`
+namespace is deliberately distinct from `claim.sh`'s per-issue lock `refs/claims/issue-<N>`.
+`claim-heartbeat.sh should-reap <machine>` is the single, **fail-safe** reap predicate (exit `0` = reap,
+`1` = keep, `2` = no ref): it reaps ONLY when age > threshold (4h) **AND** the issue has no open PR **AND**
+(the PID is dead, *when the claim is local* — a foreign machine's PID is unknowable, so from CI that clause
+is skipped and age + no-open-PR govern). It KEEPS on a fresh ref, an open PR, a live local PID, or an
+unparseable age; a `gh`/network hiccup in the open-PR probe assumes an open PR (keeps). The
+`project-board-sync` **30-minute cron** now carries a `reap-claims` job applying exactly this predicate
+server-side, deleting the stale claim ref and flipping the freed board item back to `Ready` with a traceable
+comment. Two workflow hardenings ship with it: **`PROJECTS_TOKEN` absence now fails the workflow loudly**
+(`::error::` + non-zero exit — a persistent red run is the alert) instead of the old silent green
+`::notice::` no-op; and the scheduled board sweep only backlogs a null-status issue once it is **older than a
+10-minute auto-add grace window**, so it no longer races the built-in Auto-add workflow's default-status
+write on a freshly created issue.
+
 **Never block on a question (park-and-resume, #2666).** A worker runs unattended, so `AskUserQuestion` (and
 any interactive prompt) is attended-sessions-only. When a worker hits Seam 1 (an unapproved spec) or a
 genuine mid-run owner decision it does not wait — it **parks**: posts ONE structured question comment


### PR DESCRIPTION
Closes #2655 (Epic #2636 — supervisor-authored git-ref claims + CI-side reaper, #2499 design).

## Problem
Heartbeat/claims were prose-driven: `worker-supervisor.sh` never called `claim-heartbeat.sh`, liveness depended on the LLM remembering to beat, a beat-then-crash looked alive for the full 4h window, the reap threshold was enforced nowhere in code, and `claim-heartbeat.sh clear` deleted unconditionally.

## What changed
- **`scripts/flow/claim-heartbeat.sh`** — new subcommands on a `refs/machine-claims/<machine>` namespace (deliberately distinct from `claim.sh`'s per-issue lock `refs/claims/issue-<N>`):
  - `stamp <issue> [pid]` — supervisor-authored liveness ref (issue+PID+ts).
  - `list-claims` — machine/issue/pid/ts/age render.
  - `should-reap <machine> [secs]` — the single **fail-safe** reap predicate (exit 0=reap, 1=keep, 2=no ref): reap ONLY when age>threshold(4h) AND no open PR AND (pid-dead, when the claim is local). KEEPS on fresh/open-PR/live-pid/unparseable-age; a gh/network hiccup on the open-PR probe assumes an open PR (keeps).
  - `reap <machine>` — delete a claim, **refusing** when its issue has an open PR.
  - `clear` now also refuses an open-PR ref (default behavior otherwise unchanged).
- **`scripts/local/worker-supervisor.sh`** — stamps the claim (issue + **supervisor** PID + ts) before every spawn, refreshes each iteration, learns the issue from each marker for the next stamp, and clears (`reap`) on a clean exit. All claim ops are non-fatal (a push hiccup never crashes the loop; the ref simply ages toward reap, which is fail-safe).
- **`.github/workflows/project-board-sync.yml`**:
  - new `reap-claims` job on the 30-min cron applying `should-reap` server-side (age + no-open-PR govern from CI — foreign PID is unknowable), deleting the stale ref and flipping the freed board item → Ready with a traceable comment (`contents: write` scoped to that job only).
  - `PROJECTS_TOKEN` absence now **fails loudly** (`::error::` + exit 1) instead of the silent green `::notice::` no-op.
  - sweep gains a 10-min **auto-add grace window** (keyed on issue `createdAt`) so it no longer races the built-in Auto-add default-status write.
- **Tests**: +15 `test_claim_heartbeat.sh` cases (stamp / list-claims / all should-reap branches incl. local-pid-alive/dead + unparseable-age + no-ref + open-PR keep, reap-refuses-open-PR, clear-refuses-open-PR) and +2 `test_worker_supervisor.sh` cases (stamp-per-iteration+one-reap-on-clean-exit with a hermetic CLAIM_CMD stub, issue-learned-from-marker).
- **Doctrine**: CLAUDE.md claim section, website `agents-developing/delivery-pipeline.md`, and a fleet-runbook board-reading note.

## Roborev self-check
Shell: no word-splitting on refs/PIDs (numeric-validated; `$CLAIM_CMD` split is intentional `bash <path>`). Workflow: no `${{ }}` interpolated into `run:` (PR metadata via `env:`); ref writes are atomic force-pushes / `--delete`. Reaper predicate is fail-safe (never reaps a live/open-PR/fresh/unknown-age claim; gh failure → keep). shellcheck clean on all 4 edited scripts; YAML parses; actionlint shows only pre-existing `SC2016:info` on intentional GraphQL-variable single-quoted strings (same pattern as baseline).

## Self-test
- `bash scripts/tests/test_claim_heartbeat.sh` → **23 passed, 0 failed**
- `bash scripts/tests/test_worker_supervisor.sh` → **24 passed, 0 failed**

## Gate
LITE only (not the gate of record). Shell selftests are outside the lite blast-radius (no-Rust diff → cqlite-core --lib) and were run manually (above).

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 01ad8e543 branch: issue-2655-supervisor-claims-reaper dirty: no
lite-scope: file-size fmt clippy scoped-tests
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (127s)
scoped-tests:      PASS (109s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
