### PR TITLE
ci(#2649): consolidate Rust caching onto one composite + shared key

### DIFF
--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -14,6 +14,14 @@ inputs:
     description: Stable cache namespace for this workflow or job family.
     required: false
     default: rust-ci
+  cache-targets:
+    description: >-
+      Whether to include the workspace `target/` directory in the cache.
+      Set to 'false' for jobs that build multiple checkouts into the same
+      workspace (e.g. perf A/B comparisons), where a shared `target/` cache
+      would be stale or incorrect. Registry + git are always cached.
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -42,7 +50,13 @@ runs:
         rustc --version
         cargo --version
 
-    - name: Restore Cargo cache
+    # ONE cache strategy for every Rust lane (issue #2649): a single
+    # actions/cache keyed on Cargo.lock + all Cargo.toml + the toolchain pin,
+    # namespaced per job family via `cache-key`. Registry + git + target by
+    # default; jobs that build multiple checkouts into one workspace opt out of
+    # the `target/` entry via `cache-targets: 'false'`.
+    - name: Restore Cargo cache (with target/)
+      if: ${{ inputs.cache-targets != 'false' }}
       uses: actions/cache@v5
       with:
         path: |
@@ -53,3 +67,15 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-key }}-${{ inputs.toolchain }}-
           ${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-key }}-
+
+    - name: Restore Cargo cache (registry only)
+      if: ${{ inputs.cache-targets == 'false' }}
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/git
+          ~/.cargo/registry
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-key }}-registry-${{ inputs.toolchain }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-key }}-registry-${{ inputs.toolchain }}-
+          ${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-key }}-registry-

--- a/.github/workflows/cassandra-validation.yml
+++ b/.github/workflows/cassandra-validation.yml
@@ -88,21 +88,11 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v5
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        uses: ./.github/actions/setup-rust-ci
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cassandra-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-cassandra-
-            ${{ runner.os }}-cargo-
+          cache-key: cassandra-validation
 
       - name: Wait for Cassandra to be ready
         run: |

--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -42,9 +42,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # cargo builds from cqlite-core/ still write the workspace-root target/,
+        # so the composite's root-level cache is correct for these lanes.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: minimal-features
 
       - name: Build with minimal compression (lz4 + snappy only)
         run: cargo build --no-default-features --features=lz4,snappy
@@ -61,9 +65,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # cargo builds from cqlite-core/ still write the workspace-root target/,
+        # so the composite's root-level cache is correct for these lanes.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: minimal-features
 
       - name: Build with all compression support
         run: cargo build --no-default-features --features=all-compression
@@ -90,9 +98,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # cargo builds from cqlite-core/ still write the workspace-root target/,
+        # so the composite's root-level cache is correct for these lanes.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: minimal-features
 
       - name: Build and test with parquet export feature (Epic #682)
         run: |
@@ -113,9 +125,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # cargo builds from cqlite-core/ still write the workspace-root target/,
+        # so the composite's root-level cache is correct for these lanes.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: minimal-features
 
       - name: Verify default build does not compile arrow/parquet (Epic #682)
         run: |
@@ -138,9 +154,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # cargo builds from cqlite-core/ still write the workspace-root target/,
+        # so the composite's root-level cache is correct for these lanes.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: minimal-features
 
       - name: Verify M2+ core features ARE in defaults
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,12 @@ jobs:
           df -h / | tail -1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -76,15 +81,6 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Restore dataset cache
         id: dataset-cache
@@ -205,7 +201,12 @@ jobs:
           df -h / | tail -1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -219,15 +220,6 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Restore dataset cache
         uses: actions/cache@v5
@@ -382,7 +374,12 @@ jobs:
           df -h / | tail -1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -539,7 +536,12 @@ jobs:
           df -h / | tail -1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -548,15 +550,6 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Restore dataset cache
         uses: actions/cache@v5
@@ -637,7 +630,12 @@ jobs:
           df -h / | tail -1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -646,15 +644,6 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run write-support tests (issue #552)
         run: |
@@ -694,7 +683,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -703,15 +697,6 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run delta-scan tests (issue #697)
         run: |
@@ -752,7 +737,12 @@ jobs:
           df -h / | tail -1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -761,15 +751,6 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Restore dataset cache
         uses: actions/cache@v5
@@ -924,7 +905,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Run validation script
         env:
@@ -951,7 +937,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): one composite keyed on
+        # Cargo.lock+toolchain across every Rust lane. sccache below is a
+        # complementary compiler cache, not a second dependency/target cache.
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-key: ci
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -960,15 +951,6 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-publish-dryrun-${{ hashFiles('**/Cargo.lock') }}
 
       - name: cargo publish --dry-run (cqlite-core)
         run: >-

--- a/.github/workflows/flight-ci.yml
+++ b/.github/workflows/flight-ci.yml
@@ -47,18 +47,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain across every Rust lane.
+        uses: ./.github/actions/setup-rust-ci
         with:
-          components: rustfmt, clippy
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-flight-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          components: rustfmt,clippy
+          cache-key: flight
 
       - name: rustfmt
         run: cargo fmt --package cqlite-flight -- --check
@@ -93,16 +87,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
-
-      - name: Cache cargo
-        uses: actions/cache@v5
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain. Distinct cache-key namespace ('flight-full')
+        # because this job builds a release binary (different target/ profile).
+        uses: ./.github/actions/setup-rust-ci
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-flight-full-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          cache-key: flight-full
 
       - name: test
         run: cargo test --package cqlite-flight

--- a/.github/workflows/observability-gate.yml
+++ b/.github/workflows/observability-gate.yml
@@ -104,20 +104,11 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Cache Cargo registry
-        uses: actions/cache@v5
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        uses: ./.github/actions/setup-rust-ci
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-obsgate-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-obsgate-cargo-
-            ${{ runner.os }}-cargo-
+          cache-key: observability-gate
 
       - name: Cache canonical datasets
         uses: actions/cache@v5

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -63,25 +63,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Consolidated caching (issue #2649): shared composite keyed on
+      # Cargo.lock+toolchain. cache-targets: false caches ONLY registry/git, NOT
+      # target/ — this job checks out two source trees (PR ref, then main) into
+      # the same workspace, so a cached target/ would carry incremental state
+      # across the switch. Rebuilding from clean deps is the robust gate choice.
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      # Cache only the registry/git, NOT target/. This job checks out two
-      # different source trees (PR ref, then main) into the same workspace; a
-      # cached target/ would carry incremental-compilation state across that
-      # switch. Rebuilding from clean deps is the robust choice for a gate.
-      - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: ./.github/actions/setup-rust-ci
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-perfgate-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-perfgate-cargo-
-            ${{ runner.os }}-cargo-
+          cache-key: perf-regression
+          cache-targets: 'false'
 
       - name: Cache canonical datasets
         uses: actions/cache@v5

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -73,16 +73,14 @@ jobs:
         run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
-
-      - name: Cache cargo dependencies
-        uses: actions/cache@v5
+        # Consolidated caching (issue #2649): shared composite keyed on
+        # Cargo.lock+toolchain. The composite installs the pin via a minimal
+        # rustup profile with no reconcile, so the clippy-preview conflict the
+        # step above guards against cannot occur here — the guard stays as a
+        # harmless idempotent no-op.
+        uses: ./.github/actions/setup-rust-ci
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          cache-key: smoke-tests
 
       - name: Restore dataset cache
         id: dataset-cache


### PR DESCRIPTION
Closes #2649 (Epic #2636).

## What
Consolidate CI Rust caching onto **one** strategy: every in-scope Rust lane now routes through the `.github/actions/setup-rust-ci` composite, whose cache key is **keyed on Cargo.lock + toolchain** (plus all `Cargo.toml` and `rust-toolchain.toml`), with a 2-level `restore-keys` fallback chain.

```
${os}-${arch}-<cache-key>-<toolchain>-${hashFiles('Cargo.lock','**/Cargo.toml','rust-toolchain.toml')}
```

## Mechanisms collapsed (5 → 1)
| Lane | Before | After |
|------|--------|-------|
| `ci.yml` (8 build jobs + publish) | `dtolnay` + weak `cargo-${os}-${hash}`, no restore-keys | composite `cache-key: ci` (sccache kept as complementary compiler cache) |
| `ci-minimal-features.yml` (5 jobs) | `actions-rust-lang/setup-rust-toolchain` builtin cache | composite `minimal-features` |
| `flight-ci.yml` (2 jobs) | `cargo-flight[-full]`, no restore-keys | composite `flight` / `flight-full` |
| `cassandra-validation.yml` | `cargo-cassandra` | composite `cassandra-validation` |
| `observability-gate.yml` | `obsgate-cargo` | composite `observability-gate` |
| `perf-regression.yml` | `perfgate-cargo` (registry-only, by design) | composite + new `cache-targets: 'false'` input |
| `smoke-tests.yml` | weak `cargo-${os}-${hash}`, no restore-keys | composite `smoke-tests` |

New composite input `cache-targets` lets the ONE strategy also serve the perf A/B lane that must exclude `target/` (two checkouts in one workspace).

## Cold-compile reduction (estimate)
Before, the three highest-fanout PR lanes (`ci.yml` 8 jobs, `flight-ci` 2, `smoke-tests` 1) had **no `restore-keys`** → any `Cargo.lock`/`Cargo.toml` change forced ~11 full cold `cqlite-core` compiles from disjoint namespaces. After: one shared key formula + toolchain-scoped restore-key chain warm-restores registry+git+`target/`. **Estimated ~11 forced cold compiles → 0 per Cargo-manifest-touching PR**; 5 mechanisms → 1. Exact warm-hit delta to confirm from post-merge cache telemetry. Full analysis on #2649.

## Scope boundaries
- `coverage-baseline.yml` deliberately **left to #2659** (owns its cache).
- Untouched: `python-ci.yml` (#2653), parity workflows (#2650/#2651), `pr-gate.yml` (already on the composite), `agent-gate.sh`.

## Validation
- `ruby scripts/ci/validate-workflows.rb` → **exit 0**, no new warnings (41 workflows).
- YAML parses for all 8 edited files. Every job retains its `timeout-minutes` posture (validator-enforced).

```
==== AGENT-GATE LITE SUMMARY ====
commit: a2ecb3d40 branch: issue-2649-ci-cache-consolidate dirty: no
lite-scope: file-size fmt clippy scoped-tests (full gate NOT run — run it once before merge)
file-size:         PASS (0s)
fmt:               PASS (7s)
clippy:            PASS (100s)
scoped-tests:      PASS (219s)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Full `scripts/agent-gate.sh` must PASS once before merge (flow-closer).
