### PR TITLE
ci(#2660): route uncovered nightly parity lanes to parity-failure-issue

### DIFF
--- a/.github/workflows/parity-failure-issue.yml
+++ b/.github/workflows/parity-failure-issue.yml
@@ -29,11 +29,21 @@ name: Parity Failure Issue Automation
 on:
   workflow_run:
     workflows:
-      - "CI: Compression / Corruption Parity (Nightly Docker, Epic #970)"
-      - "CI: CQL Type & Schema-Evolution Parity (Nightly Docker, Epic #971)"
-      - "CI: Tombstone / TTL Parity (Nightly Docker, Epic #972)"
+      # Consolidated nightly regen matrix (#2651) — replaces the three retired
+      # compression-corruption / cql-type / tombstone-ttl parity lanes.
+      - "CI: Parity Regen Matrix (Nightly Docker, Epic #2636)"
       - "CI: Live-Cell Compaction Byte Parity (issue #1017, #1020)"
       - "Exhaustive Regeneration (parity corpus)"
+      # Previously-uncovered nightly lanes (#2660): their red nights filed no
+      # tracking issue until now. `nightly-docker-parity.yml` is the umbrella
+      # orchestrator (#2650); e2e-readback runs standalone on PR/dispatch/release
+      # and via the umbrella nightly; cassandra-validation, delta-roundtrip and
+      # perf-regression are the remaining scheduled/main lanes.
+      - "CI: Nightly Docker Parity (nightly_docker tier)"
+      - "CI: E2E Cassandra Readback Gate"
+      - "CI: Cassandra sstableloader Validation"
+      - "CI: Delta Round-Trip Test (DS11 / Issue #707)"
+      - "CI: Performance Regression Gate"
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -135,15 +145,18 @@ jobs:
             R_EVENT="$(printf '%s' "${META}" | jq -r '.event // ""')"
             R_CONCLUSION="$(printf '%s' "${META}" | jq -r '.conclusion // ""')"
             R_URL="$(printf '%s' "${META}" | jq -r '.url // ""')"
-            # (a) tracked-workflow allowlist — the target run must belong to one of the 5
+            # (a) tracked-workflow allowlist — the target run must belong to one of the
             # tracked parity lanes (matched by workflow NAME, the same names the auto
             # workflow_run trigger allowlists above).
             case "${R_NAME}" in
-              "CI: Compression / Corruption Parity (Nightly Docker, Epic #970)"|\
-              "CI: CQL Type & Schema-Evolution Parity (Nightly Docker, Epic #971)"|\
-              "CI: Tombstone / TTL Parity (Nightly Docker, Epic #972)"|\
+              "CI: Parity Regen Matrix (Nightly Docker, Epic #2636)"|\
               "CI: Live-Cell Compaction Byte Parity (issue #1017, #1020)"|\
-              "Exhaustive Regeneration (parity corpus)")
+              "Exhaustive Regeneration (parity corpus)"|\
+              "CI: Nightly Docker Parity (nightly_docker tier)"|\
+              "CI: E2E Cassandra Readback Gate"|\
+              "CI: Cassandra sstableloader Validation"|\
+              "CI: Delta Round-Trip Test (DS11 / Issue #707)"|\
+              "CI: Performance Regression Gate")
                 : ;;
               *)
                 echo "::warning::replay target run ${DISPATCH_RUN_ID} workflow '${R_NAME:-<none>}' is not a tracked parity lane — no issue filed."
@@ -238,7 +251,7 @@ jobs:
           # Fix A: map the completed run's identity to its workflow FILENAME so the
           # green-lane resolve is scoped to THAT lane only (never all open issues). Prefer
           # the payload `path` (`.github/workflows/<file>`); fall back to a name→filename
-          # lookup for the 5 tracked lanes. On a replay, WR_NAME/WR_PATH are empty — use
+          # lookup for the tracked lanes. On a replay, WR_NAME/WR_PATH are empty — use
           # the validated target-run workflow name. WR_PATH/WR_NAME/VALIDATED_NAME are
           # untrusted -> quoted env.
           LANE_FILE=""
@@ -247,16 +260,22 @@ jobs:
           fi
           if [ -z "${LANE_FILE}" ]; then
             case "${WR_NAME:-${VALIDATED_NAME:-}}" in
-              "CI: Compression / Corruption Parity (Nightly Docker, Epic #970)")
-                LANE_FILE="compression-corruption-parity.yml" ;;
-              "CI: CQL Type & Schema-Evolution Parity (Nightly Docker, Epic #971)")
-                LANE_FILE="cql-type-parity.yml" ;;
-              "CI: Tombstone / TTL Parity (Nightly Docker, Epic #972)")
-                LANE_FILE="tombstone-ttl-parity.yml" ;;
+              "CI: Parity Regen Matrix (Nightly Docker, Epic #2636)")
+                LANE_FILE="parity-regen-matrix.yml" ;;
               "CI: Live-Cell Compaction Byte Parity (issue #1017, #1020)")
                 LANE_FILE="live-cell-compaction-parity.yml" ;;
               "Exhaustive Regeneration (parity corpus)")
                 LANE_FILE="exhaustive-regeneration.yml" ;;
+              "CI: Nightly Docker Parity (nightly_docker tier)")
+                LANE_FILE="nightly-docker-parity.yml" ;;
+              "CI: E2E Cassandra Readback Gate")
+                LANE_FILE="e2e-readback.yml" ;;
+              "CI: Cassandra sstableloader Validation")
+                LANE_FILE="cassandra-validation.yml" ;;
+              "CI: Delta Round-Trip Test (DS11 / Issue #707)")
+                LANE_FILE="delta-roundtrip.yml" ;;
+              "CI: Performance Regression Gate")
+                LANE_FILE="perf-regression.yml" ;;
               *)
                 echo "::notice::could not map workflow_run name '${WR_NAME:-<none>}' to a tracked lane filename — resolve will be a no-op." ;;
             esac
@@ -265,14 +284,15 @@ jobs:
 
           # Fix A (round 7): derive the lane's CI TIER from its workflow FILENAME so the
           # filed issue records the correct tier (spec R1). The exhaustive-regeneration
-          # lane is tier `exhaustive_regeneration`; the three nightly parity lanes are
+          # lane is tier `exhaustive_regeneration`; the remaining nightly parity lanes are
           # tier `nightly_docker` (the script's default). An unmapped lane leaves the tier
           # empty so the `file` step falls back to the script default rather than guessing.
           LANE_TIER=""
           case "${LANE_FILE}" in
             exhaustive-regeneration.yml)
               LANE_TIER="exhaustive_regeneration" ;;
-            compression-corruption-parity.yml|cql-type-parity.yml|tombstone-ttl-parity.yml|live-cell-compaction-parity.yml)
+            parity-regen-matrix.yml|live-cell-compaction-parity.yml|nightly-docker-parity.yml|\
+            e2e-readback.yml|cassandra-validation.yml|delta-roundtrip.yml|perf-regression.yml)
               LANE_TIER="nightly_docker" ;;
             *)
               : ;;

--- a/scripts/tests/test_parity_failure_issue.py
+++ b/scripts/tests/test_parity_failure_issue.py
@@ -21,6 +21,8 @@ import unittest
 from pathlib import Path
 
 SCRIPTS = Path(__file__).resolve().parents[1]
+REPO_ROOT = SCRIPTS.parent
+WORKFLOW_YML = REPO_ROOT / ".github" / "workflows" / "parity-failure-issue.yml"
 
 # The module file name has a hyphen, so load it by path.
 _spec = importlib.util.spec_from_file_location(
@@ -721,6 +723,98 @@ class ResolveTests(unittest.TestCase):
         self.assertEqual(len(comment2), 1, "retry posts exactly one comment on success")
         self.assertTrue(pfi.is_resolved(self._body_after_resolve(calls2, "55")),
                         "successful retry stamps the resolved marker")
+
+
+class WorkflowTriggerCoverageTests(unittest.TestCase):
+    """Issue #2660: the automation workflow's four name-keyed blocks must agree on the
+    tracked-lane set, cover every nightly parity lane, and reference NO retired lane.
+
+    These read parity-failure-issue.yml as text (stdlib only — CI runs this test file with
+    no pyyaml dependency). The four blocks that key on workflow display names / filenames:
+      1. on.workflow_run.workflows       (auto trigger allowlist)
+      2. validate step `case "${R_NAME}"` (workflow_dispatch replay allowlist)
+      3. identity step name→filename `case "${WR_NAME...}"`
+      4. identity step filename→tier `case "${LANE_FILE}"`
+    Blocks 1–3 must list the SAME display names; block 4 must map every derived filename.
+    """
+
+    # Authoritative tracked-lane set after #2650/#2651: display name -> (filename, tier).
+    EXPECTED_LANES = {
+        "CI: Parity Regen Matrix (Nightly Docker, Epic #2636)":
+            ("parity-regen-matrix.yml", "nightly_docker"),
+        "CI: Live-Cell Compaction Byte Parity (issue #1017, #1020)":
+            ("live-cell-compaction-parity.yml", "nightly_docker"),
+        "Exhaustive Regeneration (parity corpus)":
+            ("exhaustive-regeneration.yml", "exhaustive_regeneration"),
+        "CI: Nightly Docker Parity (nightly_docker tier)":
+            ("nightly-docker-parity.yml", "nightly_docker"),
+        "CI: E2E Cassandra Readback Gate":
+            ("e2e-readback.yml", "nightly_docker"),
+        "CI: Cassandra sstableloader Validation":
+            ("cassandra-validation.yml", "nightly_docker"),
+        "CI: Delta Round-Trip Test (DS11 / Issue #707)":
+            ("delta-roundtrip.yml", "nightly_docker"),
+        "CI: Performance Regression Gate":
+            ("perf-regression.yml", "nightly_docker"),
+    }
+
+    # Retired by #2651 — must appear NOWHERE in the automation workflow.
+    RETIRED_NAMES = [
+        "CI: Compression / Corruption Parity (Nightly Docker, Epic #970)",
+        "CI: CQL Type & Schema-Evolution Parity (Nightly Docker, Epic #971)",
+        "CI: Tombstone / TTL Parity (Nightly Docker, Epic #972)",
+    ]
+    RETIRED_FILES = [
+        "compression-corruption-parity.yml",
+        "cql-type-parity.yml",
+        "tombstone-ttl-parity.yml",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = WORKFLOW_YML.read_text()
+
+    def test_all_tracked_lanes_and_files_and_tiers_present(self):
+        for name, (fname, tier) in self.EXPECTED_LANES.items():
+            self.assertIn(name, self.text, f"display name not routed: {name}")
+            self.assertIn(fname, self.text, f"filename not mapped: {fname}")
+            # The tier value must appear in the filename→tier case arm.
+            self.assertIn(tier, self.text, f"tier token absent: {tier}")
+
+    def test_uncovered_nightly_lanes_now_covered(self):
+        # The specific lanes #2660 set out to cover must each be routed by name.
+        for added in (
+            "CI: Cassandra sstableloader Validation",
+            "CI: E2E Cassandra Readback Gate",
+            "CI: Delta Round-Trip Test (DS11 / Issue #707)",
+            "CI: Nightly Docker Parity (nightly_docker tier)",
+            "CI: Performance Regression Gate",
+        ):
+            self.assertIn(added, self.text, f"uncovered lane still missing: {added}")
+
+    def test_no_retired_lane_referenced(self):
+        for name in self.RETIRED_NAMES:
+            self.assertNotIn(name, self.text, f"retired lane name still present: {name}")
+        for fname in self.RETIRED_FILES:
+            self.assertNotIn(fname, self.text, f"retired lane filename still present: {fname}")
+
+    def test_trigger_list_and_both_case_blocks_agree(self):
+        # Each tracked display name must appear at least 3 times: once in the
+        # workflow_run trigger list, once in the replay allowlist case, once in the
+        # name→filename case. (Comments may add more; fewer means a block dropped it.)
+        for name in self.EXPECTED_LANES:
+            self.assertGreaterEqual(
+                self.text.count(name), 3,
+                f"display name '{name}' must appear in all three name-keyed blocks")
+
+    def test_each_filename_maps_to_a_tier(self):
+        # Every filename the identity step can derive must have a tier case arm, so no
+        # tracked lane files an issue with a guessed/empty tier.
+        for _name, (fname, _tier) in self.EXPECTED_LANES.items():
+            # filename appears in name→filename case AND filename→tier case (>= 2).
+            self.assertGreaterEqual(
+                self.text.count(fname), 2,
+                f"filename '{fname}' must be in both the name→filename and filename→tier cases")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2660 (Epic #2636).

## Problem
`parity-failure-issue.yml`'s `workflow_run` trigger list did not reference several nightly lanes, so their red nights filed **no** tracking issue: `cassandra-validation`, `e2e-readback`, `delta-roundtrip`, `nightly-docker-parity`, and `perf-regression`.

## Change
Extended the automation across all four name-keyed blocks (kept consistent):
1. `on.workflow_run.workflows` (auto trigger allowlist)
2. `validate` step replay allowlist `case "${R_NAME}"`
3. `identity` step name→filename `case`
4. `identity` step filename→tier `case`

Lanes now routed (display name → filename → tier):
- `CI: Cassandra sstableloader Validation` → `cassandra-validation.yml` → nightly_docker
- `CI: E2E Cassandra Readback Gate` → `e2e-readback.yml` → nightly_docker
- `CI: Delta Round-Trip Test (DS11 / Issue #707)` → `delta-roundtrip.yml` → nightly_docker
- `CI: Nightly Docker Parity (nightly_docker tier)` → `nightly-docker-parity.yml` → nightly_docker
- `CI: Performance Regression Gate` → `perf-regression.yml` → nightly_docker

Also aligned with the just-landed consolidations:
- Added `CI: Parity Regen Matrix (Nightly Docker, Epic #2636)` (`parity-regen-matrix.yml`, #2651).
- **Removed** the three retired display names + filenames (compression-corruption / cql-type / tombstone-ttl parity, #2651). No removed workflow name is referenced anywhere.

The existing fingerprint/dedupe machinery (`scripts/parity-failure-issue.py`) is unchanged — the consolidated matrix still emits the same `parity-failures.json` schema per leg, so red runs of these lanes now file/dedupe issues via the existing path.

## Self-test
New `WorkflowTriggerCoverageTests` in `scripts/tests/test_parity_failure_issue.py` (run by `parity-failure-issue-tests.yml`, stdlib-only) asserts: all tracked lanes+filenames+tiers present; the four uncovered lanes are now routed; the trigger list and both `case` blocks agree; every filename maps to a tier; and no retired lane name/filename survives anywhere. 43 tests pass.

Workflow policy: `ruby scripts/ci/validate-workflows.rb` → "Workflow policy validated for 40 workflows" (no failures). YAML parses. No untrusted `${{ }}` interpolated into any `run:` — all edits are in YAML lists / `case` arms / comments; untrusted payload still flows via the existing quoted env vars.

## Gate
```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record)
commit: ed374f4ab branch: issue-2660-parity-failure-trigger-coverage dirty: no
file-size:         PASS
fmt:               PASS
clippy:            PASS
scoped-tests:      PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Diff is **workflow + self-test only** (no Rust) — fast-path eligible for the full gate. Not merging; leaving for the endgame owner.