### PR TITLE
release(#2652): shared preflight + bump-version.sh + idempotent republish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -995,6 +995,15 @@ jobs:
           "flow-finalize guardrail tests"
           -- /bin/bash scripts/flow/tests/finalize-cleanup.test.sh
 
+      # Release-train version tooling (issue #2652). Runs on macOS too so the
+      # system bash 3.2 (the release preflight's real target) is validated, not
+      # just asserted.
+      - name: Run bump-version self-test (${{ matrix.os }} /bin/bash)
+        run: >-
+          bash scripts/ci/ci-timing-summary.sh measure
+          "bump-version self-test"
+          -- /bin/bash scripts/tests/test_bump_version.sh
+
       - name: CI runtime timing summary
         if: always()
         run: bash scripts/ci/ci-timing-summary.sh summary "CI flow tooling timing"

--- a/.github/workflows/flight-image.yml
+++ b/.github/workflows/flight-image.yml
@@ -47,6 +47,19 @@ env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/cqlite-flight
 
 jobs:
+  # Shared release-train preflight (issue #2652): on a v* tag push, assert the
+  # tag agrees with EVERY release manifest before the image is built and pushed.
+  # A workflow_dispatch run (version backfill or one-off image_tag) has no
+  # ref-derived release version to preflight and supplies its own inputs, so it
+  # SKIPS this gate — the merge job's own release-tag provenance assertion
+  # (#2639) still guards a manual version dispatch.
+  preflight:
+    name: Release preflight
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/release-preflight.yml
+    with:
+      version: ${{ github.ref_name }}
+
   # Build per architecture on a NATIVE runner (amd64 on ubuntu-latest, arm64 on
   # ubuntu-24.04-arm) and push each by digest. Native runners avoid
   # QEMU-emulated Rust compiles, which are slow and prone to OOM. The multi-arch
@@ -54,6 +67,11 @@ jobs:
   build:
     name: Build (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
+    needs: [preflight]
+    # preflight is `if: push`-gated, so a workflow_dispatch run SKIPS it. Build
+    # when preflight passed (tag push) or was skipped (dispatch), never when it
+    # failed — a manifest disagreement stops the image build up front.
+    if: ${{ !cancelled() && (needs.preflight.result == 'success' || needs.preflight.result == 'skipped') }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -25,6 +25,19 @@ env:
   APP_NAME: cqlite-node
 
 jobs:
+  # Shared release-train preflight (issue #2652): assert the tag agrees with
+  # EVERY release manifest before publishing to the immutable npm registry.
+  # Only runs on a v* tag push — a workflow_dispatch republish (issue #2026)
+  # resolves its version from the input against an existing tag and has no
+  # ref-derived tag to preflight, so it skips this gate (publish-npm's own
+  # version-consistency + already-tagged checks still apply).
+  preflight:
+    name: Release preflight
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/release-preflight.yml
+    with:
+      version: ${{ github.ref_name }}
+
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -129,7 +142,11 @@ jobs:
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
-    needs: build
+    needs: [preflight, build]
+    # preflight is `if: push`-gated, so on a workflow_dispatch republish it is
+    # SKIPPED. Proceed when it succeeded (tag push) or was skipped (dispatch),
+    # but never when it failed — a real manifest disagreement blocks the publish.
+    if: ${{ !cancelled() && needs.build.result == 'success' && (needs.preflight.result == 'success' || needs.preflight.result == 'skipped') }}
     timeout-minutes: 15
 
     permissions:
@@ -265,10 +282,32 @@ jobs:
           echo "::endgroup::"
           echo "Dry-run publish verification passed"
 
+      # Resumability (issue #2652): npm versions are immutable, so a re-run of a
+      # partially-failed train would hard-fail with EPUBLISHCONFLICT when this
+      # exact @cqlite/node@<version> was already published on a prior run. Query
+      # the registry first and skip the publish if the version already exists —
+      # so the train re-runs to completion instead of dead-ending here. VERSION
+      # is validated semver from the ver step; it is passed via env, never
+      # inlined into the shell.
+      - name: Check if version already on npm
+        id: published
+        working-directory: bindings/node
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          if npm view "@cqlite/node@${VERSION}" version >/dev/null 2>&1; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "@cqlite/node@${VERSION} is already on npm — will skip publish (resumable re-run)."
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+            echo "@cqlite/node@${VERSION} is not yet on npm — will publish."
+          fi
+
       # Trusted Publishing: OIDC authentication, no token needed
       # Provenance attestations are automatic with trusted publishing
       - name: Publish to npm (stable)
-        if: steps.ver.outputs.prerelease == 'false'
+        if: steps.ver.outputs.prerelease == 'false' && steps.published.outputs.already == 'false'
         working-directory: bindings/node
         env:
           NODE_AUTH_TOKEN: ""
@@ -276,7 +315,7 @@ jobs:
         run: npm publish --access public --provenance
 
       - name: Publish to npm (pre-release)
-        if: steps.ver.outputs.prerelease == 'true'
+        if: steps.ver.outputs.prerelease == 'true' && steps.published.outputs.already == 'false'
         working-directory: bindings/node
         env:
           NODE_AUTH_TOKEN: ""

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -82,6 +82,13 @@ jobs:
           "dataset pin agreement"
           -- bash scripts/ci/check-dataset-pin.sh
 
+      - name: Release manifest version agreement (#2652)
+        if: steps.classify.outputs.docs_only != 'true'
+        run: >-
+          bash scripts/ci/ci-timing-summary.sh measure
+          "release version agreement"
+          -- bash scripts/bump-version.sh check
+
       - name: Setup Rust
         if: steps.classify.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-rust-ci

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -13,6 +13,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Shared release-train preflight (issue #2652): assert the tag agrees with
+  # EVERY release manifest before publishing. Both publish lanes need this so a
+  # manifest disagreement fails up front, never after an irreversible PyPI
+  # upload to the immutable index.
+  preflight:
+    name: Release preflight
+    uses: ./.github/workflows/release-preflight.yml
+    with:
+      version: ${{ github.ref_name }}
+
   # Build source distribution
   build-sdist:
     name: Build source distribution
@@ -110,7 +120,7 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
-    needs: [build-sdist, build-wheels]
+    needs: [preflight, build-sdist, build-wheels]
     # Pre-release: any tag with hyphen suffix (v1.0.0-rc1, v1.0.0-alpha, v1.0.0-beta1, etc.)
     if: contains(github.ref_name, '-')
     timeout-minutes: 10
@@ -168,6 +178,10 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist/
+          # Resumability (issue #2652): TestPyPI is immutable, so re-running a
+          # partially-failed train tolerates files already uploaded instead of
+          # hard-failing on a duplicate.
+          skip-existing: true
 
       - name: Summary
         run: |
@@ -185,7 +199,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [build-sdist, build-wheels]
+    needs: [preflight, build-sdist, build-wheels]
     # Stable release: tag without hyphen suffix (v1.0.0, v0.3.0)
     if: ${{ !contains(github.ref_name, '-') }}
     timeout-minutes: 10
@@ -261,6 +275,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          # Resumability (issue #2652): PyPI is immutable, so re-running a
+          # partially-failed train skips files already uploaded (e.g. the sdist
+          # + some wheels) instead of hard-failing on a duplicate, letting the
+          # train re-run to completion.
+          skip-existing: true
 
       - name: Summary
         run: |

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,54 @@
+name: Release preflight
+
+# Shared release-train preflight (issue #2652, epic #2636).
+#
+# A v* release tag fans out to 7+ INDEPENDENT publish workflows (crates.io, PyPI,
+# npm, Maven Central, the cqlite-flight GHCR image, ...). Every one of those
+# registries is IMMUTABLE — once a version is published it can never be
+# overwritten — and each lane runs its own private tag==manifest check. There is
+# no shared gate that asserts, ONCE and BEFORE any lane uploads, that the tag
+# agrees with EVERY manifest. When they disagree, one lane publishes, a later
+# lane hard-fails on its own private mismatch, and the immutable registries are
+# left half-populated.
+#
+# This reusable workflow is that shared gate. Each publish workflow invokes it
+# (`uses: ./.github/workflows/release-preflight.yml`) as a `needs:` of its
+# publish job, so no lane uploads until the tag has been proven equal to all
+# four release manifests:
+#   Cargo.toml [package] + [workspace.package], bindings/python/pyproject.toml,
+#   bindings/node/package.json — via scripts/bump-version.sh check <version>.
+#
+# NOTE: this cannot make the fan-out ATOMIC (immutable registries preclude
+# that). It closes the far more common failure — shipping a tag whose manifests
+# already disagree — before any irreversible upload happens. Resumability of a
+# mid-train failure is handled per-lane (PyPI skip-existing, npm/Maven
+# tolerate-already-published); see RELEASING.md.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version or tag to assert against every manifest (leading v tolerated, e.g. v0.15.0 or 0.15.0).'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  version-agreement:
+    name: Assert tag == every manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # bump-version.sh check fails closed on: any manifest missing/empty, the
+      # four fields disagreeing, or the resolved version != the tag. VERSION is
+      # passed via env (never interpolated into the shell) and the script
+      # allowlist-validates it against ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$.
+      - name: Assert tag agrees with every manifest
+        env:
+          VERSION: ${{ inputs.version }}
+        run: bash scripts/bump-version.sh check "$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,17 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # Shared release-train preflight (issue #2652): assert the tag agrees with
+  # EVERY release manifest before any lane publishes. publish-crate needs this,
+  # so a manifest disagreement fails the whole train up front rather than after
+  # a partial, irreversible publish to an immutable registry.
+  preflight:
+    name: Release preflight
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/release-preflight.yml
+    with:
+      version: ${{ github.ref_name }}
+
   build-cli:
     name: Build CLI (${{ matrix.target }})
     strategy:
@@ -228,7 +239,7 @@ jobs:
   # auth action mints a short-lived token from the id-token JWT (#786).
   publish-crate:
     name: Publish to crates.io
-    needs: [build-cli]
+    needs: [preflight, build-cli]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/.github/workflows/trino-publish.yml
+++ b/.github/workflows/trino-publish.yml
@@ -46,9 +46,26 @@ permissions:
   contents: read
 
 jobs:
+  # Shared release-train preflight (issue #2652): assert the release tag agrees
+  # with EVERY Rust/Python/Node manifest before the connector is published to
+  # the immutable Maven Central. Only a v* tag push has a ref-derived version to
+  # preflight; a manual workflow_dispatch supplies its own `version` input and
+  # skips this gate (the publish job's `if:` below tolerates the skip).
+  preflight:
+    name: Release preflight
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/release-preflight.yml
+    with:
+      version: ${{ github.ref_name }}
+
   publish:
     name: publishToMavenCentral
     runs-on: ubuntu-latest
+    needs: [preflight]
+    # preflight is `if: push`-gated, so a workflow_dispatch run SKIPS it. Proceed
+    # when it passed (tag push) or was skipped (dispatch), never when it failed.
+    if: ${{ !cancelled() && (needs.preflight.result == 'success' || needs.preflight.result == 'skipped') }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
@@ -99,6 +116,30 @@ jobs:
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Resumability (issue #2652): Maven Central is immutable — a released
+      # version can never be overwritten, so re-running a partially-failed train
+      # would hard-fail when in.mcfad:cqlite-trino:<version> was already
+      # published on a prior run. Probe the public Central repo (no secrets) and
+      # expose an `already` boolean the Central publish step gates on, so the
+      # train re-runs to completion instead of dead-ending here. This is a
+      # public read of repo1.maven.org; PUBLISH_VERSION is validated semver and
+      # passed via env, never inlined into the shell.
+      - name: Check if version already on Maven Central
+        id: central
+        env:
+          PUBLISH_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          url="https://repo1.maven.org/maven2/in/mcfad/cqlite-trino/${PUBLISH_VERSION}/cqlite-trino-${PUBLISH_VERSION}.pom"
+          code="$(curl -s -o /dev/null -w '%{http_code}' -L "$url" || echo 000)"
+          if [ "$code" = "200" ]; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "in.mcfad:cqlite-trino:${PUBLISH_VERSION} is already on Maven Central — will skip publish (resumable re-run)."
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+            echo "in.mcfad:cqlite-trino:${PUBLISH_VERSION} is not on Maven Central (HTTP ${code}) — will publish."
+          fi
+
       # Pre-publish oracle (issue #2300): assert the netty pin survives into the
       # published POM's <dependencies> BEFORE any publish path runs, so a drifted
       # or BOM-only pin (which a downstream Maven consumer would resolve at netty
@@ -119,8 +160,15 @@ jobs:
           PUBLISH_VERSION: ${{ steps.version.outputs.version }}
         run: ./gradlew --no-daemon publishToMavenLocal -Pversion="$PUBLISH_VERSION"
 
+      - name: Skip — already on Maven Central (resumable re-run)
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.central.outputs.already == 'true' }}
+        env:
+          PUBLISH_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "in.mcfad:cqlite-trino:${PUBLISH_VERSION} is already published to Maven Central; skipping the publish so a partially-failed release train re-runs to completion (issue #2652)."
+
       - name: Publish to Maven Central
-        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.guard.outputs.should_publish == 'true' }}
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.central.outputs.already != 'true' && steps.guard.outputs.should_publish == 'true' }}
         working-directory: trino-connector
         env:
           # vanniktech reads Central credentials + the in-memory GPG key from
@@ -137,7 +185,7 @@ jobs:
       # while the Central publish silently never happened. A skip that isn't an
       # explicit dry run is now unmissable: the job FAILS instead of going green.
       - name: Fail — Central publish skipped (secrets absent, not a dry run)
-        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.guard.outputs.should_publish != 'true' }}
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.central.outputs.already != 'true' && steps.guard.outputs.should_publish != 'true' }}
         run: |
           echo "::error::Maven Central secrets absent and this is not an explicit dry run (dry_run=true) — failing instead of silently skipping the connector publish. Set MAVEN_CENTRAL_USERNAME/MAVEN_CENTRAL_PASSWORD/SIGNING_KEY/SIGNING_PASSWORD, or dispatch with dry_run=true to validate the build without publishing."
           exit 1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,130 @@
+# Releasing CQLite
+
+How a CQLite release is cut, why it is **not atomic**, and how to resume a
+release train that failed partway. Read this before pushing a `v*` tag.
+
+Issue [#2652](https://github.com/pmcfadin/cqlite/issues/2652) (epic
+[#2636](https://github.com/pmcfadin/cqlite/issues/2636)).
+
+## What a release tag does
+
+Pushing an annotated `v<version>` tag (e.g. `v0.15.0`) fans out to **7+
+independent publish workflows**, each triggered by the same tag:
+
+| Lane | Workflow | Target | Immutable? |
+|------|----------|--------|:---------:|
+| crates.io | `release.yml` (`publish-crate`) | `cqlite-core`, `cqlite-cli` | yes |
+| PyPI | `python-release.yml` (`publish-pypi`) | `cqlite-py` | yes |
+| npm | `node-release.yml` (`publish-npm`) | `@cqlite/node` | yes |
+| Maven Central | `trino-publish.yml` (`publish`) | `in.mcfad:cqlite-trino` | yes |
+| GHCR image | `flight-image.yml` | `ghcr.io/pmcfadin/cqlite-flight` | tags mutable, digests not |
+| Homebrew tap | `release.yml` (`update-homebrew-tap`) | `pmcfadin/homebrew-cqlite` | git, re-runnable |
+| GitHub releases | `release.yml` / `*-release.yml` | release assets | re-runnable |
+
+Every package registry above is **immutable**: once a version is published it can
+**never** be overwritten or deleted-and-replaced.
+
+## The version lives in four manifest fields
+
+A release version is hand-maintained in **four** places, and every publish lane
+reads its own:
+
+1. `Cargo.toml` → `[package].version` (workspace-root package)
+2. `Cargo.toml` → `[workspace.package].version` (inherited by every crate)
+3. `bindings/python/pyproject.toml` → `[project].version`
+4. `bindings/node/package.json` → `.version`
+
+Edit them by hand and it is easy to ship a tag whose manifests disagree — one
+lane publishes, a later lane hard-fails on its own private tag==manifest check,
+and the immutable registries are left **half-populated**.
+
+### Bump the version with `scripts/bump-version.sh`
+
+Never hand-edit the four fields. Use the script — it rewrites all four together
+(atomically: every file is validated in a staging copy before *any* file is
+moved into place) and re-checks agreement:
+
+```bash
+scripts/bump-version.sh current          # print the agreed version
+scripts/bump-version.sh check            # assert the four fields agree
+scripts/bump-version.sh check v0.16.0    # also assert they equal a tag/version
+scripts/bump-version.sh set 0.16.0       # rewrite all four to 0.16.0
+```
+
+`set`/`check` reject any non-semver version
+(`^[0-9]+.[0-9]+.[0-9]+(-[0-9A-Za-z.-]+)?$`), so a typo or crafted value can
+never be written into a manifest.
+
+The **CI agreement check** runs `scripts/bump-version.sh check` on every PR
+(via the Required PR Gate), so a commit that leaves the four manifests
+disagreeing is caught before it ever becomes a release tag. The same command is
+the shared **release preflight** (below).
+
+## The shared preflight — gate before any lane publishes
+
+`.github/workflows/release-preflight.yml` is a reusable
+(`workflow_call`) workflow that runs `scripts/bump-version.sh check <version>`:
+it asserts the tag equals **every** manifest field and fails closed on any
+missing/empty field, any disagreement, or a tag/manifest mismatch.
+
+Every registry publish lane invokes it as a `needs:` of its publish job, so **no
+lane uploads anything until the tag has been proven to agree with all four
+manifests**. A manifest disagreement therefore fails the train *up front*,
+before any irreversible upload — instead of after a partial publish.
+
+> The preflight makes the fan-out **fail-fast and consistent**. It does **not**
+> make it **atomic** — see below.
+
+## Why a release is NOT atomic (and cannot be)
+
+The publish targets are separate, immutable, third-party registries
+(crates.io, PyPI, npm, Maven Central, GHCR). There is no cross-registry
+transaction: you cannot "commit" all seven at once, and you cannot roll back a
+crate that already published because PyPI later failed. Atomicity across
+registries is **out of scope and impossible** — the honest guarantees are:
+
+- **fail-fast consistency** — the preflight blocks a train whose manifests
+  disagree before anything publishes;
+- **resumability** — a train that fails *after* some lanes published can be
+  re-run and will **skip the already-published lanes** rather than hard-fail on
+  a duplicate.
+
+## Resuming a partially-failed train
+
+If a lane fails after others have already published (a flaky runner, an expired
+credential, a registry outage), **do not push a new tag and do not bump the
+version**. The published artifacts are immutable and correct; you only need the
+failed lanes to complete. Every registry lane is now **idempotent**:
+
+| Lane | Resume behavior |
+|------|-----------------|
+| crates.io | `publish-crate` checks the crates.io API and **skips** any version already published (`cqlite-core`/`cqlite-cli`). |
+| PyPI / TestPyPI | `gh-action-pypi-publish` runs with `skip-existing: true` — already-uploaded files (sdist + some wheels) are skipped. |
+| npm | `publish-npm` runs `npm view @cqlite/node@<version>` first and **skips** the publish if that exact version already exists. |
+| Maven Central | `trino-publish` probes `repo1.maven.org` for the POM and **skips** the publish if `in.mcfad:cqlite-trino:<version>` is already released. |
+| GHCR image | `flight-image` republishes the same digests/tags; re-running is safe. |
+
+So a re-run **resumes** rather than restarts: it re-runs to completion, publishing
+only the lanes that had not yet succeeded.
+
+### How to re-run
+
+1. **Re-run the failed workflow(s)** from the GitHub Actions UI (the
+   tag-triggered run), or `gh run rerun --failed <run-id>`. Because every lane
+   is idempotent, the already-published lanes no-op and the failed lane
+   completes.
+2. **npm / Maven backfill without re-tagging.** `node-release.yml` and
+   `flight-image.yml` also expose a `workflow_dispatch` republish path (issue
+   #2026 / #2117): supply the `version`/`publish_version` input; it publishes
+   from the selected branch **without rewriting the git tag**, and refuses
+   unless the `v<version>` tag already exists. `trino-publish.yml` accepts a
+   manual `version` dispatch (`dry_run` defaults to **true** — a real Central
+   publish requires `dry_run=false`, issue #2639).
+3. **Verify** each registry shows `<version>` before announcing the release.
+
+### Never do
+
+- **Never** overwrite or delete a published version and re-publish. The
+  registries are immutable; instead ship a new patch version.
+- **Never** push a second tag to "fix" a partial train — re-run the lanes.
+- **Never** hand-edit the four manifest fields — use `scripts/bump-version.sh`.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+#
+# bump-version.sh — single source of truth for the CQLite release version across
+# every publish manifest (issue #2652, epic #2636).
+#
+# A CQLite release tag (v*) fans out to 7+ independent publish workflows
+# (crates.io, PyPI, npm, Maven Central, the cqlite-flight GHCR image, Homebrew,
+# GitHub releases). Each of those registries is IMMUTABLE and the version lives
+# in FOUR hand-edited manifest fields:
+#
+#   1. Cargo.toml            [package].version          (workspace-root package)
+#   2. Cargo.toml            [workspace.package].version (inherited by every crate)
+#   3. bindings/python/pyproject.toml  [project].version
+#   4. bindings/node/package.json      .version
+#
+# Editing them by hand is how a release train ships a tag whose manifests
+# disagree — one lane publishes, a later lane hard-fails on a version mismatch,
+# and the immutable registries are now half-populated. This script makes the
+# four fields move together and gives CI + the release preflight a single
+# agreement check.
+#
+# Commands:
+#   bump-version.sh current            Print the agreed version. Non-zero if the
+#                                      four manifest fields disagree.
+#   bump-version.sh check [VERSION]    Assert the four fields agree. If VERSION
+#                                      is given (leading `v` allowed, e.g. a
+#                                      release tag), also assert they equal it.
+#                                      This is the CI / preflight agreement gate.
+#   bump-version.sh set VERSION        Rewrite all four fields to VERSION
+#                                      (atomically: every file is validated in a
+#                                      staging copy before ANY file is moved into
+#                                      place), then re-check agreement.
+#
+# Options:
+#   --root DIR   Operate on the manifests under DIR instead of the repo root
+#                inferred from this script's location (used by the self-test to
+#                run against a throwaway copy). Also honored via
+#                CQLITE_VERSION_ROOT.
+#
+# VERSION is validated against a strict semver allowlist so a crafted value can
+# never be written into a manifest or flow into downstream tooling:
+#   ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$
+#
+# Pure awk/grep/sed — no node/ruby/python/cargo — so it runs identically in the
+# release preflight, in CI, and locally.
+
+set -euo pipefail
+
+SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+
+die() {
+  echo "bump-version: $*" >&2
+  exit 1
+}
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+# --- root resolution ---------------------------------------------------------
+ROOT="${CQLITE_VERSION_ROOT:-}"
+
+# --- manifest readers --------------------------------------------------------
+# Read the `version = "X"` value inside a specific TOML section (e.g. "[package]"
+# or "[workspace.package]"). Section-aware so the [package] and
+# [workspace.package] versions in one Cargo.toml are read independently and a
+# `version = ...` in some other section is never picked up.
+read_toml_section_version() {
+  local file="$1" section="$2"
+  awk -v want="$section" '
+    /^\[/ { in_s = ($0 == want) }
+    in_s && /^[[:space:]]*version[[:space:]]*=/ {
+      if (match($0, /"[^"]*"/)) { print substr($0, RSTART + 1, RLENGTH - 2); exit }
+    }
+  ' "$file"
+}
+
+# Read the top-level "version" string from a package.json (first occurrence).
+read_json_version() {
+  local file="$1"
+  awk '
+    !done && /^[[:space:]]*"version"[[:space:]]*:/ {
+      if (match($0, /"version"[[:space:]]*:[[:space:]]*"[^"]*"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/^"version"[[:space:]]*:[[:space:]]*"/, "", s)
+        sub(/"$/, "", s)
+        print s
+        done = 1
+      }
+    }
+  ' "$file"
+}
+
+CARGO_TOML=""
+PYPROJECT=""
+PACKAGE_JSON=""
+
+resolve_root() {
+  if [ -z "$ROOT" ]; then
+    ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  fi
+  [ -d "$ROOT" ] || die "root '$ROOT' is not a directory"
+  CARGO_TOML="$ROOT/Cargo.toml"
+  PYPROJECT="$ROOT/bindings/python/pyproject.toml"
+  PACKAGE_JSON="$ROOT/bindings/node/package.json"
+  local f
+  for f in "$CARGO_TOML" "$PYPROJECT" "$PACKAGE_JSON"; do
+    [ -f "$f" ] || die "manifest not found: $f (wrong --root?)"
+  done
+}
+
+# Emit each tracked field as "<label>\t<version>" so callers can report which
+# field diverged, not just that something did.
+read_all_versions() {
+  printf 'Cargo.toml [package]\t%s\n' "$(read_toml_section_version "$CARGO_TOML" '[package]')"
+  printf 'Cargo.toml [workspace.package]\t%s\n' "$(read_toml_section_version "$CARGO_TOML" '[workspace.package]')"
+  printf 'pyproject.toml [project]\t%s\n' "$(read_toml_section_version "$PYPROJECT" '[project]')"
+  printf 'package.json\t%s\n' "$(read_json_version "$PACKAGE_JSON")"
+}
+
+# --- agreement check ---------------------------------------------------------
+# check [expected-version]
+# Prints every field's value; exits non-zero (with a report) on any divergence,
+# an empty field, or a mismatch against the expected version when one is given.
+cmd_check() {
+  resolve_root
+  local expected="${1:-}"
+  expected="${expected#v}"
+  if [ -n "$expected" ] && ! printf '%s' "$expected" | grep -Eq "$SEMVER_RE"; then
+    die "expected version '$expected' is not valid semver ($SEMVER_RE)"
+  fi
+
+  local versions first="" ok=1 label ver
+  versions="$(read_all_versions)"
+
+  while IFS=$'\t' read -r label ver; do
+    if [ -z "$ver" ]; then
+      echo "  MISSING  $label" >&2
+      ok=0
+      continue
+    fi
+    if [ -z "$first" ]; then
+      first="$ver"
+    elif [ "$ver" != "$first" ]; then
+      ok=0
+    fi
+    printf '  %-32s %s\n' "$label" "$ver"
+  done <<< "$versions"
+
+  if [ "$ok" -ne 1 ]; then
+    echo "::error::manifest versions disagree — the release train would half-publish" >&2
+    return 1
+  fi
+  if [ -n "$expected" ] && [ "$first" != "$expected" ]; then
+    echo "::error::manifest version '$first' does not match expected '$expected'" >&2
+    return 1
+  fi
+  if [ -n "$expected" ]; then
+    echo "OK: all manifests agree at $first (matches expected $expected)"
+  else
+    echo "OK: all manifests agree at $first"
+  fi
+}
+
+cmd_current() {
+  resolve_root
+  local versions first="" label ver ok=1
+  versions="$(read_all_versions)"
+  while IFS=$'\t' read -r label ver; do
+    [ -n "$ver" ] || { ok=0; break; }
+    if [ -z "$first" ]; then first="$ver"; elif [ "$ver" != "$first" ]; then ok=0; break; fi
+  done <<< "$versions"
+  [ "$ok" -eq 1 ] && [ -n "$first" ] || die "manifests disagree; run 'bump-version.sh check' to see the divergence"
+  printf '%s\n' "$first"
+}
+
+# --- rewriters (emit to stdout; caller stages to a temp file) ----------------
+rewrite_cargo() {
+  awk -v v="$1" '
+    /^\[/ { sec = $0 }
+    (sec == "[package]" || sec == "[workspace.package]") && /^[[:space:]]*version[[:space:]]*=/ {
+      print "version = \"" v "\""
+      next
+    }
+    { print }
+  ' "$CARGO_TOML"
+}
+
+rewrite_pyproject() {
+  awk -v v="$1" '
+    /^\[/ { sec = $0 }
+    sec == "[project]" && /^[[:space:]]*version[[:space:]]*=/ {
+      print "version = \"" v "\""
+      next
+    }
+    { print }
+  ' "$PYPROJECT"
+}
+
+rewrite_package_json() {
+  awk -v v="$1" '
+    !done && /^[[:space:]]*"version"[[:space:]]*:/ {
+      sub(/"version"[[:space:]]*:[[:space:]]*"[^"]*"/, "\"version\": \"" v "\"")
+      done = 1
+    }
+    { print }
+  ' "$PACKAGE_JSON"
+}
+
+# set VERSION — atomic-as-possible: every rewrite is staged and verified in a
+# temp copy; only once ALL four fields read back as VERSION do we mv the temps
+# over the originals. A failure before the mv phase leaves every manifest
+# untouched. (True cross-file atomicity is impossible; this is the honest bound.)
+cmd_set() {
+  local version="${1:-}"
+  [ -n "$version" ] || die "set requires a VERSION argument"
+  version="${version#v}"
+  printf '%s' "$version" | grep -Eq "$SEMVER_RE" \
+    || die "refusing to set invalid version '$version' (expected $SEMVER_RE)"
+
+  resolve_root
+
+  local stage
+  stage="$(mktemp -d "${TMPDIR:-/tmp}/bump-version.XXXXXX")"
+  # shellcheck disable=SC2064  # expand $stage now so the trap cleans the right dir
+  trap "rm -rf '$stage'" EXIT
+
+  local cargo_tmp="$stage/Cargo.toml"
+  local py_tmp="$stage/pyproject.toml"
+  local pkg_tmp="$stage/package.json"
+
+  rewrite_cargo "$version" > "$cargo_tmp"
+  rewrite_pyproject "$version" > "$py_tmp"
+  rewrite_package_json "$version" > "$pkg_tmp"
+
+  # Verify each staged file reads back exactly VERSION in every tracked field
+  # BEFORE moving anything into place. Fail closed if any field did not take.
+  local got
+  got="$(read_toml_section_version "$cargo_tmp" '[package]')"
+  [ "$got" = "$version" ] || die "staged Cargo.toml [package] version is '$got', expected '$version'"
+  got="$(read_toml_section_version "$cargo_tmp" '[workspace.package]')"
+  [ "$got" = "$version" ] || die "staged Cargo.toml [workspace.package] version is '$got', expected '$version'"
+  got="$(read_toml_section_version "$py_tmp" '[project]')"
+  [ "$got" = "$version" ] || die "staged pyproject.toml version is '$got', expected '$version'"
+  got="$(read_json_version "$pkg_tmp")"
+  [ "$got" = "$version" ] || die "staged package.json version is '$got', expected '$version'"
+
+  # Commit phase: move the validated temps into place.
+  mv "$cargo_tmp" "$CARGO_TOML"
+  mv "$py_tmp" "$PYPROJECT"
+  mv "$pkg_tmp" "$PACKAGE_JSON"
+
+  echo "Set all manifests to $version"
+  cmd_check "$version"
+}
+
+# --- argument parsing --------------------------------------------------------
+CMD=""
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root)
+      [ $# -ge 2 ] || die "--root requires a directory"
+      ROOT="$2"
+      shift 2
+      ;;
+    --root=*)
+      ROOT="${1#--root=}"
+      shift
+      ;;
+    -h|--help)
+      usage 0
+      ;;
+    current|check|set)
+      CMD="$1"
+      shift
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+[ -n "$CMD" ] || usage 1
+
+case "$CMD" in
+  current) cmd_current "${ARGS[@]:-}" ;;
+  check)   cmd_check "${ARGS[@]:-}" ;;
+  set)     cmd_set "${ARGS[@]:-}" ;;
+  *)       usage 1 ;;
+esac

--- a/scripts/tests/test_bump_version.sh
+++ b/scripts/tests/test_bump_version.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Regression tests for scripts/bump-version.sh (issue #2652).
+#
+# Fast + hermetic: every case runs against a throwaway copy of the four release
+# manifests under a temp --root, so the repo's real Cargo.toml / pyproject.toml /
+# package.json are NEVER touched. No network, no cargo/node/python.
+#
+# Run standalone:   bash scripts/tests/test_bump_version.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUMP="$SCRIPT_DIR/../bump-version.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+[ -f "$BUMP" ] || { echo "cannot find bump-version.sh at $BUMP" >&2; exit 1; }
+
+# --- fixture builder ---------------------------------------------------------
+# Materialize a throwaway root whose four manifests hold the given start version.
+# Mirrors the real files' section shape so the section-aware readers are exercised.
+make_root() {
+  local start="$1"
+  local root
+  root="$(mktemp -d "${TMPDIR:-/tmp}/bump-version-test.XXXXXX")"
+  mkdir -p "$root/bindings/python" "$root/bindings/node"
+
+  cat >"$root/Cargo.toml" <<EOF
+[workspace]
+members = ["a"]
+resolver = "2"
+
+[package]
+name = "cqlite"
+version = "$start"
+edition = "2021"
+
+[dependencies]
+some-dep = { version = "1.0" }
+
+[workspace.package]
+version = "$start"
+edition = "2021"
+EOF
+
+  cat >"$root/bindings/python/pyproject.toml" <<EOF
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+
+[project]
+name = "cqlite-py"
+version = "$start"
+description = "x"
+EOF
+
+  cat >"$root/bindings/node/package.json" <<EOF
+{
+  "name": "@cqlite/node",
+  "version": "$start",
+  "main": "lib/index.js"
+}
+EOF
+
+  printf '%s\n' "$root"
+}
+
+field() { # field <root> <label-substring>  (fixed-string match, prints last field)
+  bash "$BUMP" --root "$1" check 2>/dev/null | awk -v l="$2" 'index($0, l) {print $NF}'
+}
+
+# --- Case 1: check passes on an agreeing fixture -----------------------------
+R="$(make_root 0.15.0)"
+if bash "$BUMP" --root "$R" check >/dev/null 2>&1; then
+  ok "check passes when all four manifests agree"
+else
+  bad "check should pass when all four manifests agree"
+fi
+if [ "$(bash "$BUMP" --root "$R" current 2>/dev/null)" = "0.15.0" ]; then
+  ok "current prints the agreed version"
+else
+  bad "current should print 0.15.0"
+fi
+rm -rf "$R"
+
+# --- Case 2: check with matching expected passes, mismatch fails -------------
+R="$(make_root 0.15.0)"
+if bash "$BUMP" --root "$R" check v0.15.0 >/dev/null 2>&1; then
+  ok "check <expected> passes when expected matches (leading v tolerated)"
+else
+  bad "check v0.15.0 should pass against 0.15.0 manifests"
+fi
+if bash "$BUMP" --root "$R" check 0.16.0 >/dev/null 2>&1; then
+  bad "check should fail when expected does not match manifests"
+else
+  ok "check <expected> fails on a tag/manifest mismatch"
+fi
+rm -rf "$R"
+
+# --- Case 3: set rewrites all four fields (round-trip) -----------------------
+R="$(make_root 0.15.0)"
+if bash "$BUMP" --root "$R" set 0.16.0 >/dev/null 2>&1; then
+  ok "set exits 0 on a valid version"
+else
+  bad "set 0.16.0 should succeed"
+fi
+all_new=1
+for label in "Cargo.toml [package]" "Cargo.toml [workspace.package]" \
+             "pyproject.toml" "package.json"; do
+  v="$(field "$R" "$label")"
+  [ "$v" = "0.16.0" ] || { bad "field '$label' is '$v', expected 0.16.0"; all_new=0; }
+done
+[ "$all_new" -eq 1 ] && ok "set rewrote all four manifest fields to 0.16.0"
+# And a fresh agreement check must now pass at the new version.
+if bash "$BUMP" --root "$R" check 0.16.0 >/dev/null 2>&1; then
+  ok "check agrees at the new version after set"
+else
+  bad "check should agree at 0.16.0 after set"
+fi
+rm -rf "$R"
+
+# --- Case 4: set accepts a prerelease suffix ---------------------------------
+R="$(make_root 0.15.0)"
+if bash "$BUMP" --root "$R" set 1.0.0-rc.1 >/dev/null 2>&1 \
+   && [ "$(bash "$BUMP" --root "$R" current 2>/dev/null)" = "1.0.0-rc.1" ]; then
+  ok "set accepts a semver prerelease suffix"
+else
+  bad "set 1.0.0-rc.1 should round-trip"
+fi
+rm -rf "$R"
+
+# --- Case 5: set rejects a non-semver / injection version, leaves files intact
+R="$(make_root 0.15.0)"
+before="$(cat "$R/Cargo.toml")"
+if bash "$BUMP" --root "$R" set '1.2; rm -rf /' >/dev/null 2>&1; then
+  bad "set must reject a non-semver version"
+else
+  ok "set rejects a non-semver / injection version"
+fi
+if [ "$(cat "$R/Cargo.toml")" = "$before" ]; then
+  ok "a rejected set leaves the manifests untouched"
+else
+  bad "a rejected set must not modify any manifest"
+fi
+rm -rf "$R"
+
+# --- Case 6: check detects a divergence between manifests --------------------
+R="$(make_root 0.15.0)"
+# Skew ONLY package.json so the four fields disagree.
+sed -i.bak 's/"version": "0.15.0"/"version": "0.14.9"/' "$R/bindings/node/package.json"
+rm -f "$R/bindings/node/package.json.bak"
+if bash "$BUMP" --root "$R" check >/dev/null 2>&1; then
+  bad "check must fail when one manifest diverges"
+else
+  ok "check detects a diverged manifest (half-published-train guard)"
+fi
+rm -rf "$R"
+
+# --- summary -----------------------------------------------------------------
+echo "----"
+echo "bump-version self-test: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #2652 (Epic #2636).

## What

A `v*` tag fans out to 7+ independent publish workflows targeting **immutable**
registries (crates.io / PyPI / npm / Maven Central / GHCR), each with its own
private tag==manifest check but no shared gate. This adds a shared preflight,
single-source version tooling, and per-lane resumability so a release can never
half-publish and a mid-train failure re-runs to completion.

## Changes

- **`scripts/bump-version.sh`** — single source of truth for the release version
  across all four manifest fields (`Cargo.toml` `[package]` + `[workspace.package]`,
  `bindings/python/pyproject.toml`, `bindings/node/package.json`). Subcommands
  `current` / `check [version]` / `set <version>`; strict semver allowlist;
  `set` is staged-and-verified before any file is moved (atomic-as-possible).
  Pure awk/grep (no node/ruby/python/cargo).
- **`scripts/tests/test_bump_version.sh`** — 11-case self-test against throwaway
  manifest copies (never touches the real ones), shellcheck-clean, bash 3.2
  compatible. Wired into `ci.yml` `flow-tooling-tests` (ubuntu + macOS).
- **`.github/workflows/release-preflight.yml`** — reusable `workflow_call` gate
  running `bump-version.sh check <tag>`. Every registry publish lane
  (`release.yml`, `python-release.yml`, `node-release.yml`, `trino-publish.yml`,
  `flight-image.yml`) `needs:` it, so **no lane uploads until the tag agrees with
  every manifest**. Fail-fast + consistent — explicitly **not** atomic.
- **CI agreement check** — `pr-gate.yml` runs `bump-version.sh check` on every PR.
- **Resumability** — PyPI/TestPyPI `skip-existing: true`; npm skips if the version
  is already on the registry; Maven skips if already on Central; crates.io was
  already idempotent. A partially-failed train re-runs to completion.
- **`RELEASING.md`** — documents the non-atomicity and the resume procedure.

Coexists with #2639 (trino `dry_run` default-true + flight-image provenance
guards) — those guards are untouched; the preflight is skipped on
`workflow_dispatch` so republish paths keep working.

## Acceptance

- [x] preflight gates every registry publish lane (`needs: preflight`)
- [x] bump script rewrites all four files atomically + CI agreement check
- [x] partially-failed train re-runs resume (skip-existing / already-published)
- [x] RELEASING.md documents non-atomicity + resume

## Scope
Script / workflow / docs only — **no Rust or Cargo files touched** (fast-path;
full gate still required once before merge per doctrine). Committed tree leaves
all four manifest versions **unchanged at 0.15.0**.

## Gate

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record)
commit: 1eb53435a branch: issue-2652-release-train-preflight dirty: no
file-size:         PASS
fmt:               PASS
clippy:            PASS
scoped-tests:      PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
