### PR TITLE
fix(#2349): wire UDT registry into both Flight read paths (cold + warm)

### DIFF
--- a/cqlite-cli/src/commands/write.rs
+++ b/cqlite-cli/src/commands/write.rs
@@ -545,9 +545,7 @@ pub(crate) fn udt_registry_from_schema_file(
     // read the file, then reuse the same `CREATE TYPE`-parsing mechanism the Flight
     // read path uses, so the two can never drift.
     match std::fs::read_to_string(schema_path) {
-        Ok(content) => {
-            cqlite_core::schema::udt_registry_from_cql(&content, default_keyspace)
-        }
+        Ok(content) => cqlite_core::schema::udt_registry_from_cql(&content, default_keyspace),
         Err(_) => cqlite_core::schema::UdtRegistry::new(),
     }
 }

--- a/cqlite-cli/src/commands/write.rs
+++ b/cqlite-cli/src/commands/write.rs
@@ -541,28 +541,15 @@ pub(crate) fn udt_registry_from_schema_file(
     schema_path: &Path,
     default_keyspace: &str,
 ) -> cqlite_core::schema::UdtRegistry {
-    use cqlite_core::schema::cql_parser::{parse_create_type, split_cql_statements};
-    use cqlite_core::schema::{CqlType, UdtRegistry};
-    use cqlite_core::types::UdtTypeDef;
-
-    let mut registry = UdtRegistry::new();
-    let Ok(content) = std::fs::read_to_string(schema_path) else {
-        return registry;
-    };
-    for stmt in split_cql_statements(&content) {
-        if let Ok((_, (name, keyspace, fields))) = parse_create_type(&stmt) {
-            let keyspace = keyspace.unwrap_or_else(|| default_keyspace.to_string());
-            let mut def = UdtTypeDef::new(keyspace, name);
-            for (field_name, field_type) in fields {
-                // Unparseable field types fall back to Blob (rendered BytesType),
-                // matching the writer's unknown-type handling.
-                let cql = CqlType::parse(&field_type).unwrap_or(CqlType::Blob);
-                def = def.with_field(field_name, cql, true);
-            }
-            registry.register_udt(def);
+    // Delegate to the single authoritative DDL→registry resolver (issue #2349):
+    // read the file, then reuse the same `CREATE TYPE`-parsing mechanism the Flight
+    // read path uses, so the two can never drift.
+    match std::fs::read_to_string(schema_path) {
+        Ok(content) => {
+            cqlite_core::schema::udt_registry_from_cql(&content, default_keyspace)
         }
+        Err(_) => cqlite_core::schema::UdtRegistry::new(),
     }
-    registry
 }
 
 /// Recursively discover published input SSTables under `dir`, ordered

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -21,7 +21,7 @@ mod key_ordering;
 mod schema_comparator;
 mod udt_registry;
 
-pub use udt_registry::UdtRegistry;
+pub use udt_registry::{udt_registry_from_cql, UdtRegistry};
 
 /// Test-only work counters for the derived-comparator caching path (issue #1709).
 ///

--- a/cqlite-core/src/schema/udt_registry.rs
+++ b/cqlite-core/src/schema/udt_registry.rs
@@ -291,18 +291,18 @@ impl UdtRegistry {
                 )
             })
             .collect();
-        // Preserve an EXPLICIT `keyspace.type` qualifier so two same-named UDTs in
-        // different keyspaces stay distinguishable on any re-resolution/round-trip
-        // (roborev job 1924 blocker 2). An UNQUALIFIED reference keeps its bare name
-        // — matching `CqlType::parse`'s output and the un-keyspaced `CqlType::Udt`
-        // form the rest of the codebase produces, so the parity/golden comparison
-        // (which reads struct FIELDS, never the node name) is unchanged.
-        let node_name = if udt_name.contains('.') {
-            udt_name.to_string()
-        } else {
-            bare_name.to_string()
-        };
-        Some(CqlType::Udt(node_name, fields))
+        // The node name is deliberately the BARE type name, never a
+        // `keyspace.type` qualifier (roborev job 1925 blocker 2). A qualifier is
+        // resolved AT resolution time — the lookup above already used the explicit
+        // keyspace, and every nested field is resolved against `def.keyspace` — so
+        // the correct definition is baked into `fields`; the keyspace need not (and
+        // MUST NOT) live in the name. Many consumers key on a bare name and would
+        // break on a qualified one: `UdtValue.type_name` is emitted verbatim as
+        // `_type` in CLI/binding JSON output (json.rs, query/result.rs), and
+        // `UdtTypeDef::validate_value` / `get_udt` / `contains_udt` all match a bare
+        // name. Keeping it bare matches `CqlType::parse`'s output and preserves that
+        // consumer contract; the golden comparison reads struct FIELDS, not the name.
+        Some(CqlType::Udt(bare_name.to_string(), fields))
     }
 
     /// Resolve UDT with full dependency chain
@@ -635,17 +635,20 @@ CREATE TYPE ks.contact_info (email text, address frozen<address_type>);";
     }
 
     #[test]
-    fn resolve_type_preserves_explicit_keyspace_qualifier() {
-        // `ks.address_type` (explicitly qualified) keeps its qualifier so two
-        // same-named UDTs in different keyspaces stay distinguishable (blocker 2).
+    fn resolve_type_qualified_reference_resolves_to_bare_node_name() {
+        // An explicit `ks.address_type` reference resolves via the named keyspace
+        // but the resulting node carries the BARE type name (roborev job 1925
+        // blocker 2): the correct definition is already baked into the fields, and
+        // bare names are the contract every name-keyed consumer (UdtValue.type_name
+        // JSON output, get_udt/validate_value) expects.
         let reg = udt_registry_from_cql(DDL, "ks");
         let parsed = CqlType::parse("frozen<ks.address_type>").unwrap();
         let resolved = reg.resolve_type(&parsed, "other_ks");
         match &resolved {
             CqlType::Frozen(inner) => match inner.as_ref() {
                 CqlType::Udt(name, fields) => {
-                    assert_eq!(name, "ks.address_type", "qualifier preserved");
-                    assert_eq!(fields.len(), 2);
+                    assert_eq!(name, "address_type", "node name stays BARE, not qualified");
+                    assert_eq!(fields.len(), 2, "resolved against the ks keyspace");
                 }
                 other => panic!("expected Udt, got {other:?}"),
             },

--- a/cqlite-core/src/schema/udt_registry.rs
+++ b/cqlite-core/src/schema/udt_registry.rs
@@ -10,6 +10,39 @@ use crate::types::UdtTypeDef;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Build a [`UdtRegistry`] from every `CREATE TYPE` statement in a CQL DDL string
+/// (issue #2349).
+///
+/// This is the SINGLE authoritative DDL→registry resolver, reused by the CLI
+/// write path (`udt_registry_from_schema_file`) and the Flight read path (which
+/// resolves a ticket's DDL): it splits the DDL into statements
+/// ([`super::cql_parser::split_cql_statements`]), parses each `CREATE TYPE`
+/// ([`super::cql_parser::parse_create_type`]), and registers the resulting
+/// [`UdtTypeDef`]. A field whose declared type does not parse falls back to
+/// [`CqlType::Blob`] (rendered `BytesType`), matching the writer's unknown-type
+/// handling. A `CREATE TYPE` with no explicit keyspace inherits `default_keyspace`.
+///
+/// No-heuristics (issue #28): types come ONLY from the authoritative DDL — never
+/// inferred from data bytes. A DDL carrying no `CREATE TYPE` yields an empty
+/// registry (resolution then a no-op), so a non-UDT table is unaffected.
+pub fn udt_registry_from_cql(cql: &str, default_keyspace: &str) -> UdtRegistry {
+    use super::cql_parser::{parse_create_type, split_cql_statements};
+
+    let mut registry = UdtRegistry::new();
+    for stmt in split_cql_statements(cql) {
+        if let Ok((_, (name, keyspace, fields))) = parse_create_type(&stmt) {
+            let keyspace = keyspace.unwrap_or_else(|| default_keyspace.to_string());
+            let mut def = UdtTypeDef::new(keyspace, name);
+            for (field_name, field_type) in fields {
+                let cql = CqlType::parse(&field_type).unwrap_or(CqlType::Blob);
+                def = def.with_field(field_name, cql, true);
+            }
+            registry.register_udt(def);
+        }
+    }
+    registry
+}
+
 /// UDT Schema Registry for managing User Defined Type definitions
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UdtRegistry {
@@ -143,6 +176,98 @@ impl UdtRegistry {
             .with_field("last_updated".to_string(), CqlType::Timestamp, true);
 
         self.register_udt(contact_info_udt);
+    }
+
+    /// Rewrite every UDT reference inside `ty` into a fully-structured
+    /// [`CqlType::Udt`] whose fields come from this registry (issue #2349).
+    ///
+    /// `CqlType::parse` renders a UDT reference as `Custom("udt:<name>")` (or a
+    /// bare `Custom("<name>")` for lowercase names) with NO field information, and
+    /// an already-`Udt` node with an empty field list is likewise unresolved. This
+    /// walks the type tree and replaces each such reference with the registry's
+    /// authoritative field definitions, recursing through collection/frozen/tuple
+    /// wrappers and into each resolved UDT field's own type (so `frozen<contact>`
+    /// with an inner `frozen<address>` field fully materializes).
+    ///
+    /// A reference with no registry entry is left UNCHANGED — resolution is a
+    /// no-op fail-open, never a fabricated type (no-heuristics, issue #28). The
+    /// lookup honours an explicit `keyspace.type` qualifier and falls back to the
+    /// `system` keyspace, mirroring [`super::TableSchema::validate_udt_references`].
+    pub fn resolve_type(&self, ty: &CqlType, keyspace: &str) -> CqlType {
+        // Cap recursion so a (registry-level) cyclic UDT reference can never
+        // loop forever; Cassandra forbids cycles, so a real schema is shallow.
+        self.resolve_type_depth(ty, keyspace, 0)
+    }
+
+    fn resolve_type_depth(&self, ty: &CqlType, keyspace: &str, depth: usize) -> CqlType {
+        const MAX_DEPTH: usize = 32;
+        if depth >= MAX_DEPTH {
+            return ty.clone();
+        }
+        match ty {
+            CqlType::List(inner) => {
+                CqlType::List(Box::new(self.resolve_type_depth(inner, keyspace, depth + 1)))
+            }
+            CqlType::Set(inner) => {
+                CqlType::Set(Box::new(self.resolve_type_depth(inner, keyspace, depth + 1)))
+            }
+            CqlType::Frozen(inner) => {
+                CqlType::Frozen(Box::new(self.resolve_type_depth(inner, keyspace, depth + 1)))
+            }
+            CqlType::Map(k, v) => CqlType::Map(
+                Box::new(self.resolve_type_depth(k, keyspace, depth + 1)),
+                Box::new(self.resolve_type_depth(v, keyspace, depth + 1)),
+            ),
+            CqlType::Tuple(types) => CqlType::Tuple(
+                types
+                    .iter()
+                    .map(|t| self.resolve_type_depth(t, keyspace, depth + 1))
+                    .collect(),
+            ),
+            CqlType::Udt(name, fields) if fields.is_empty() => self
+                .resolve_udt_reference(name, keyspace, depth)
+                .unwrap_or_else(|| ty.clone()),
+            CqlType::Custom(name) => {
+                let udt_name = name.strip_prefix("udt:").unwrap_or(name);
+                if super::is_udt_identifier(udt_name) {
+                    self.resolve_udt_reference(udt_name, keyspace, depth)
+                        .unwrap_or_else(|| ty.clone())
+                } else {
+                    ty.clone()
+                }
+            }
+            // Already-resolved UDTs (non-empty fields) and primitives pass through.
+            other => other.clone(),
+        }
+    }
+
+    /// Look a UDT reference up in this registry and return its fully-resolved
+    /// [`CqlType::Udt`] (fields recursively resolved), or `None` when absent.
+    fn resolve_udt_reference(
+        &self,
+        udt_name: &str,
+        keyspace: &str,
+        depth: usize,
+    ) -> Option<CqlType> {
+        let (lookup_keyspace, bare_name) = match udt_name.split_once('.') {
+            Some((ks, n)) => (ks, n),
+            None => (keyspace, udt_name),
+        };
+        let def = self
+            .get_udt(lookup_keyspace, bare_name)
+            .or_else(|| self.get_udt("system", bare_name))?;
+        let fields = def
+            .fields
+            .iter()
+            .map(|f| {
+                (
+                    f.name.clone(),
+                    // Resolve nested UDT fields against the UDT's OWN keyspace.
+                    self.resolve_type_depth(&f.field_type, &def.keyspace, depth + 1),
+                )
+            })
+            .collect();
+        Some(CqlType::Udt(bare_name.to_string(), fields))
     }
 
     /// Resolve UDT with full dependency chain
@@ -344,5 +469,94 @@ impl UdtRegistry {
             CqlType::Frozen(inner) => format!("frozen<{}>", self.format_cql_type(inner)),
             CqlType::Custom(name) => name.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+
+    const DDL: &str = "\
+CREATE TYPE ks.address_type (street text, city text); \
+CREATE TYPE ks.contact_info (email text, address frozen<address_type>);";
+
+    #[test]
+    fn from_cql_registers_every_create_type() {
+        let reg = udt_registry_from_cql(DDL, "ks");
+        assert!(reg.contains_udt("ks", "address_type"));
+        assert!(reg.contains_udt("ks", "contact_info"));
+        assert_eq!(reg.total_udts(), 2);
+    }
+
+    #[test]
+    fn from_cql_no_create_type_is_empty() {
+        let reg = udt_registry_from_cql("CREATE TABLE ks.t (id int PRIMARY KEY, v text)", "ks");
+        assert_eq!(reg.total_udts(), 0);
+    }
+
+    #[test]
+    fn resolve_type_rewrites_custom_udt_in_list_to_struct() {
+        let reg = udt_registry_from_cql(DDL, "ks");
+        // `list<frozen<address_type>>` parses to List(Frozen(Custom("udt:address_type"))).
+        let parsed = CqlType::parse("list<frozen<address_type>>").unwrap();
+        let resolved = reg.resolve_type(&parsed, "ks");
+        match &resolved {
+            CqlType::List(inner) => match inner.as_ref() {
+                CqlType::Frozen(udt) => match udt.as_ref() {
+                    CqlType::Udt(name, fields) => {
+                        assert_eq!(name, "address_type");
+                        assert_eq!(fields.len(), 2, "street + city resolved from the registry");
+                        assert_eq!(fields[0].0, "street");
+                    }
+                    other => panic!("inner must resolve to Udt, got {other:?}"),
+                },
+                other => panic!("expected Frozen wrapper, got {other:?}"),
+            },
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_type_recurses_into_nested_udt_fields() {
+        let reg = udt_registry_from_cql(DDL, "ks");
+        // contact_info.address is itself a frozen<address_type> — the nested UDT
+        // must resolve to a full Struct, not stay a bare Custom.
+        let parsed = CqlType::parse("frozen<contact_info>").unwrap();
+        let resolved = reg.resolve_type(&parsed, "ks");
+        let inner = match &resolved {
+            CqlType::Frozen(inner) => inner.as_ref(),
+            other => panic!("expected Frozen, got {other:?}"),
+        };
+        let fields = match inner {
+            CqlType::Udt(_, fields) => fields,
+            other => panic!("expected Udt, got {other:?}"),
+        };
+        let (_, addr_type) = fields.iter().find(|(n, _)| n == "address").expect("address field");
+        match addr_type {
+            CqlType::Frozen(a) => assert!(
+                matches!(a.as_ref(), CqlType::Udt(n, f) if n == "address_type" && f.len() == 2),
+                "nested address field must resolve to the full address_type Struct"
+            ),
+            CqlType::Udt(n, f) => {
+                assert_eq!(n, "address_type");
+                assert_eq!(f.len(), 2);
+            }
+            other => panic!("nested address must resolve to a Udt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_type_unknown_reference_is_left_unchanged() {
+        let reg = UdtRegistry::new();
+        let parsed = CqlType::parse("list<frozen<missing_type>>").unwrap();
+        // No registry entry → fail-open, type tree unchanged (no fabricated fields).
+        assert_eq!(reg.resolve_type(&parsed, "ks"), parsed);
+    }
+
+    #[test]
+    fn resolve_type_leaves_primitives_untouched() {
+        let reg = udt_registry_from_cql(DDL, "ks");
+        let parsed = CqlType::parse("map<text, int>").unwrap();
+        assert_eq!(reg.resolve_type(&parsed, "ks"), parsed);
     }
 }

--- a/cqlite-core/src/schema/udt_registry.rs
+++ b/cqlite-core/src/schema/udt_registry.rs
@@ -233,6 +233,24 @@ impl UdtRegistry {
             CqlType::Udt(name, fields) if fields.is_empty() => self
                 .resolve_udt_reference(name, keyspace, depth)
                 .unwrap_or_else(|| ty.clone()),
+            // An already-populated UDT node is NOT necessarily fully resolved: an
+            // inner field may still hold an unresolved `Custom("udt:X")` (roborev
+            // job 1924 blocker 3). Recurse into every field type so a partially-
+            // resolved nested UDT fully materializes — the exact data-loss class
+            // this issue targets. A UDT whose fields are already resolved re-maps to
+            // an equal tree (idempotent), so this is safe to run unconditionally.
+            CqlType::Udt(name, fields) => CqlType::Udt(
+                name.clone(),
+                fields
+                    .iter()
+                    .map(|(fname, ftype)| {
+                        (
+                            fname.clone(),
+                            self.resolve_type_depth(ftype, keyspace, depth + 1),
+                        )
+                    })
+                    .collect(),
+            ),
             CqlType::Custom(name) => {
                 let udt_name = name.strip_prefix("udt:").unwrap_or(name);
                 if super::is_udt_identifier(udt_name) {
@@ -242,7 +260,7 @@ impl UdtRegistry {
                     ty.clone()
                 }
             }
-            // Already-resolved UDTs (non-empty fields) and primitives pass through.
+            // Primitives pass through.
             other => other.clone(),
         }
     }
@@ -273,7 +291,18 @@ impl UdtRegistry {
                 )
             })
             .collect();
-        Some(CqlType::Udt(bare_name.to_string(), fields))
+        // Preserve an EXPLICIT `keyspace.type` qualifier so two same-named UDTs in
+        // different keyspaces stay distinguishable on any re-resolution/round-trip
+        // (roborev job 1924 blocker 2). An UNQUALIFIED reference keeps its bare name
+        // — matching `CqlType::parse`'s output and the un-keyspaced `CqlType::Udt`
+        // form the rest of the codebase produces, so the parity/golden comparison
+        // (which reads struct FIELDS, never the node name) is unchanged.
+        let node_name = if udt_name.contains('.') {
+            udt_name.to_string()
+        } else {
+            bare_name.to_string()
+        };
+        Some(CqlType::Udt(node_name, fields))
     }
 
     /// Resolve UDT with full dependency chain
@@ -567,5 +596,60 @@ CREATE TYPE ks.contact_info (email text, address frozen<address_type>);";
         let reg = udt_registry_from_cql(DDL, "ks");
         let parsed = CqlType::parse("map<text, int>").unwrap();
         assert_eq!(reg.resolve_type(&parsed, "ks"), parsed);
+    }
+
+    #[test]
+    fn resolve_type_recurses_into_a_partially_resolved_udt_node() {
+        // A Udt node that is ALREADY populated (non-empty fields) but whose inner
+        // field still holds an unresolved `Custom("udt:address_type")` must have
+        // that inner ref resolved too (roborev job 1924 blocker 3) — else the inner
+        // UDT decodes opaque, the data-loss class this issue targets.
+        let reg = udt_registry_from_cql(DDL, "ks");
+        let partial = CqlType::Udt(
+            "contact_info".to_string(),
+            vec![
+                ("email".to_string(), CqlType::Text),
+                (
+                    "address".to_string(),
+                    CqlType::Frozen(Box::new(CqlType::Custom("udt:address_type".to_string()))),
+                ),
+            ],
+        );
+        let resolved = reg.resolve_type(&partial, "ks");
+        let fields = match &resolved {
+            CqlType::Udt(_, fields) => fields,
+            other => panic!("expected Udt, got {other:?}"),
+        };
+        let (_, addr) = fields
+            .iter()
+            .find(|(n, _)| n == "address")
+            .expect("address");
+        let inner = match addr {
+            CqlType::Frozen(inner) => inner.as_ref(),
+            other => panic!("expected Frozen, got {other:?}"),
+        };
+        assert!(
+            matches!(inner, CqlType::Udt(n, f) if n == "address_type" && f.len() == 2),
+            "the inner Custom(\"udt:address_type\") must resolve to the full Struct, got {inner:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_type_preserves_explicit_keyspace_qualifier() {
+        // `ks.address_type` (explicitly qualified) keeps its qualifier so two
+        // same-named UDTs in different keyspaces stay distinguishable (blocker 2).
+        let reg = udt_registry_from_cql(DDL, "ks");
+        let parsed = CqlType::parse("frozen<ks.address_type>").unwrap();
+        let resolved = reg.resolve_type(&parsed, "other_ks");
+        match &resolved {
+            CqlType::Frozen(inner) => match inner.as_ref() {
+                CqlType::Udt(name, fields) => {
+                    assert_eq!(name, "ks.address_type", "qualifier preserved");
+                    assert_eq!(fields.len(), 2);
+                }
+                other => panic!("expected Udt, got {other:?}"),
+            },
+            other => panic!("expected Frozen, got {other:?}"),
+        }
     }
 }

--- a/cqlite-core/src/schema/udt_registry.rs
+++ b/cqlite-core/src/schema/udt_registry.rs
@@ -205,15 +205,21 @@ impl UdtRegistry {
             return ty.clone();
         }
         match ty {
-            CqlType::List(inner) => {
-                CqlType::List(Box::new(self.resolve_type_depth(inner, keyspace, depth + 1)))
-            }
-            CqlType::Set(inner) => {
-                CqlType::Set(Box::new(self.resolve_type_depth(inner, keyspace, depth + 1)))
-            }
-            CqlType::Frozen(inner) => {
-                CqlType::Frozen(Box::new(self.resolve_type_depth(inner, keyspace, depth + 1)))
-            }
+            CqlType::List(inner) => CqlType::List(Box::new(self.resolve_type_depth(
+                inner,
+                keyspace,
+                depth + 1,
+            ))),
+            CqlType::Set(inner) => CqlType::Set(Box::new(self.resolve_type_depth(
+                inner,
+                keyspace,
+                depth + 1,
+            ))),
+            CqlType::Frozen(inner) => CqlType::Frozen(Box::new(self.resolve_type_depth(
+                inner,
+                keyspace,
+                depth + 1,
+            ))),
             CqlType::Map(k, v) => CqlType::Map(
                 Box::new(self.resolve_type_depth(k, keyspace, depth + 1)),
                 Box::new(self.resolve_type_depth(v, keyspace, depth + 1)),
@@ -531,7 +537,10 @@ CREATE TYPE ks.contact_info (email text, address frozen<address_type>);";
             CqlType::Udt(_, fields) => fields,
             other => panic!("expected Udt, got {other:?}"),
         };
-        let (_, addr_type) = fields.iter().find(|(n, _)| n == "address").expect("address field");
+        let (_, addr_type) = fields
+            .iter()
+            .find(|(n, _)| n == "address")
+            .expect("address field");
         match addr_type {
             CqlType::Frozen(a) => assert!(
                 matches!(a.as_ref(), CqlType::Udt(n, f) if n == "address_type" && f.len() == 2),

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -99,7 +99,10 @@ pub use read_assembly::assemble_read_cells;
 #[cfg(feature = "write-support")]
 mod point_read;
 #[cfg(feature = "write-support")]
-pub use point_read::{build_single_partition_merger, build_single_partition_merger_from_readers};
+pub use point_read::{
+    build_single_partition_merger, build_single_partition_merger_from_readers,
+    build_single_partition_merger_with_registry,
+};
 
 /// Warm/shared-reader k-way merge construction (issue #2346): builds a merger
 /// directly from already-open `Arc<SSTableReader>`s instead of paths, so a

--- a/cqlite-core/src/storage/write_engine/merge/point_read.rs
+++ b/cqlite-core/src/storage/write_engine/merge/point_read.rs
@@ -19,7 +19,7 @@
 //! the same way.
 
 use super::{KWayMerger, MergeEntry, RunReader, SSTableRowIterator, SSTableRowIteratorAdapter};
-use crate::schema::TableSchema;
+use crate::schema::{TableSchema, UdtRegistry};
 use crate::storage::scan_cancel::ScanCancel;
 use crate::storage::sstable::reader::{CompactionRow, SSTableReader};
 use crate::{Error, Result};
@@ -166,6 +166,23 @@ pub fn build_single_partition_merger(
     schema: &TableSchema,
     scan_cancel: ScanCancel,
 ) -> Result<Option<KWayMerger>> {
+    build_single_partition_merger_with_registry(paths, keys, schema, None, scan_cancel)
+}
+
+/// Like [`build_single_partition_merger`], but threads an authoritative
+/// [`UdtRegistry`] onto every candidate reader (issue #2349) so a `frozen<UDT>`
+/// cell inside a collection decodes structurally instead of as opaque bytes — the
+/// cold point-read analogue of the full-scan
+/// [`KWayMerger::new_with_gc_and_registry_cancellable`]. Passing `None` is
+/// byte-identical to the registry-free path. Used by the Flight point-read route so
+/// point and full-scan reads never diverge (issue #1918 differential lane).
+pub fn build_single_partition_merger_with_registry(
+    paths: Vec<PathBuf>,
+    keys: &[Vec<u8>],
+    schema: &TableSchema,
+    udt_registry: Option<&UdtRegistry>,
+    scan_cancel: ScanCancel,
+) -> Result<Option<KWayMerger>> {
     schema.validate_dropped_columns()?;
     if keys.is_empty() {
         return Ok(None);
@@ -191,7 +208,7 @@ pub fn build_single_partition_merger(
         // seek/open, so a disconnected point read does no further per-SSTable work.
         scan_cancel.check()?;
 
-        match probe_path(path, keys, schema, scan_cancel.clone())? {
+        match probe_path(path, keys, schema, udt_registry, scan_cancel.clone())? {
             PathProbe::Empty => {
                 // Pruned / absent for every key. No run.
             }
@@ -233,7 +250,7 @@ pub fn build_single_partition_merger(
                     path,
                     run_index,
                     schema,
-                    None,
+                    udt_registry.cloned(),
                     scan_cancel.clone(),
                 )?;
                 runs.push(Box::new(SinglePartitionFilterRun {
@@ -390,17 +407,24 @@ fn probe_path(
     path: &Path,
     keys: &[Vec<u8>],
     schema: &TableSchema,
+    udt_registry: Option<&UdtRegistry>,
     scan_cancel: ScanCancel,
 ) -> Result<PathProbe> {
     let path = path.to_path_buf();
     let schema = schema.clone();
     let keys: Vec<Vec<u8>> = keys.to_vec();
+    let udt_registry = udt_registry.cloned();
     block_on_async(async move {
         let mut config = Config::default();
         config.storage.use_mmap = false;
         config.storage.disk_access_mode = DiskAccessMode::Buffered;
         let platform = Arc::new(Platform::new(&config).await?);
-        let reader = SSTableReader::open(&path, &config, platform).await?;
+        let mut reader = SSTableReader::open(&path, &config, platform).await?;
+        // Issue #2349: decode a `frozen<UDT>`-in-collection cell structurally on the
+        // point-read seek path too, matching the full-scan cold reader.
+        if let Some(registry) = udt_registry {
+            reader.set_udt_registry(registry);
+        }
         probe_reader_async(&reader, &keys, &schema, &scan_cancel).await
     })
 }
@@ -432,6 +456,7 @@ fn probe_path(
     _path: &Path,
     _keys: &[Vec<u8>],
     _schema: &TableSchema,
+    _udt_registry: Option<&UdtRegistry>,
     _scan_cancel: ScanCancel,
 ) -> Result<PathProbe> {
     Ok(PathProbe::NeedsScan)

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -44,7 +44,7 @@ pub use export::{ExportOptions, ExportReport};
 #[cfg(feature = "write-support")]
 pub use memtable::Memtable;
 #[cfg(feature = "write-support")]
-pub use merge::build_single_partition_merger;
+pub use merge::{build_single_partition_merger, build_single_partition_merger_with_registry};
 #[cfg(feature = "write-support")]
 // Issue #2346: the reader-based analogue of `build_single_partition_merger`,
 // re-exported alongside it so both surfaces are reachable the same way.

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -44,13 +44,13 @@ pub use export::{ExportOptions, ExportReport};
 #[cfg(feature = "write-support")]
 pub use memtable::Memtable;
 #[cfg(feature = "write-support")]
-pub use merge::{build_single_partition_merger, build_single_partition_merger_with_registry};
-#[cfg(feature = "write-support")]
 // Issue #2346: the reader-based analogue of `build_single_partition_merger`,
 // re-exported alongside it so both surfaces are reachable the same way.
 pub use merge::build_single_partition_merger_from_readers;
 #[cfg(feature = "write-support")]
 pub use merge::KWayMerger;
+#[cfg(feature = "write-support")]
+pub use merge::{build_single_partition_merger, build_single_partition_merger_with_registry};
 #[cfg(feature = "write-support")]
 pub use merge_policy::STCSPolicy;
 #[cfg(feature = "write-support")]

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -427,12 +427,23 @@ impl MergeProducer {
     /// `self` for chaining.
     pub fn with_udt_registry(mut self, registry: UdtRegistry) -> Self {
         let keyspace = self.schema.keyspace.clone();
-        for column in &mut self.columns {
-            if let Some(cql_type) = &column.cql_type {
-                let resolved = registry.resolve_type(cql_type, &keyspace);
-                column.data_type = flat_data_type(&resolved);
-                column.cql_type = Some(resolved);
+        let resolve = |columns: &mut Vec<ColumnInfo>| {
+            for column in columns {
+                if let Some(cql_type) = &column.cql_type {
+                    let resolved = registry.resolve_type(cql_type, &keyspace);
+                    column.data_type = flat_data_type(&resolved);
+                    column.cql_type = Some(resolved);
+                }
             }
+        };
+        resolve(&mut self.columns);
+        // If aggregation was already attached (a caller that chained
+        // `with_aggregation` BEFORE `with_udt_registry`), the PARTIAL output columns
+        // must be resolved too — otherwise the aggregate Arrow schema would keep
+        // pre-resolution `Custom("udt:X")` types while the emitted arrays are
+        // resolved, a silent schema/array disagreement (roborev job 1924 blocker 1).
+        if let Some(partial) = self.partial_columns.as_mut() {
+            resolve(partial);
         }
         self.udt_registry = Some(registry);
         self

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -427,26 +427,35 @@ impl MergeProducer {
     /// `self` for chaining.
     pub fn with_udt_registry(mut self, registry: UdtRegistry) -> Self {
         let keyspace = self.schema.keyspace.clone();
-        let resolve = |columns: &mut Vec<ColumnInfo>| {
-            for column in columns {
-                if let Some(cql_type) = &column.cql_type {
-                    let resolved = registry.resolve_type(cql_type, &keyspace);
-                    column.data_type = flat_data_type(&resolved);
-                    column.cql_type = Some(resolved);
-                }
-            }
-        };
-        resolve(&mut self.columns);
+        Self::resolve_columns_udts(&registry, &keyspace, &mut self.columns);
         // If aggregation was already attached (a caller that chained
         // `with_aggregation` BEFORE `with_udt_registry`), the PARTIAL output columns
         // must be resolved too — otherwise the aggregate Arrow schema would keep
         // pre-resolution `Custom("udt:X")` types while the emitted arrays are
         // resolved, a silent schema/array disagreement (roborev job 1924 blocker 1).
+        // The PRODUCTION order (`with_udt_registry` THEN `with_aggregation`) is
+        // covered symmetrically in `with_aggregation` (roborev job 1925 item 1).
         if let Some(partial) = self.partial_columns.as_mut() {
-            resolve(partial);
+            Self::resolve_columns_udts(&registry, &keyspace, partial);
         }
         self.udt_registry = Some(registry);
         self
+    }
+
+    /// Resolve each column's `cql_type` against `registry` in place (issue #2349):
+    /// a `Custom("udt:X")` becomes a fully-structured `Udt(X, fields)` so the Arrow
+    /// field is a `Struct`, not opaque `Utf8`/`Binary`. Shared by
+    /// [`Self::with_udt_registry`] (full-row columns) and [`Self::with_aggregation`]
+    /// (partial/group-by columns) so a UDT group-by column never keeps an
+    /// unresolved type the emitted arrays contradict.
+    fn resolve_columns_udts(registry: &UdtRegistry, keyspace: &str, columns: &mut [ColumnInfo]) {
+        for column in columns {
+            if let Some(cql_type) = &column.cql_type {
+                let resolved = registry.resolve_type(cql_type, keyspace);
+                column.data_type = flat_data_type(&resolved);
+                column.cql_type = Some(resolved);
+            }
+        }
     }
 
     /// Open a cold full-scan k-way merger over `paths`, threading the resolved UDT
@@ -474,7 +483,16 @@ impl MergeProducer {
     /// to the PARTIAL aggregate schema. Consumes and returns `self` for chaining.
     pub fn with_aggregation(mut self, aggregation: &Aggregation) -> Result<Self, ProducerError> {
         let plan = AggPlan::build(aggregation, &self.schema)?;
-        let partial = plan.partial_columns(&self.schema)?;
+        let mut partial = plan.partial_columns(&self.schema)?;
+        // Production order is `with_udt_registry(...)` THEN `with_aggregation(...)`
+        // (service.rs). `plan.partial_columns` derives from the RAW schema, so a
+        // UDT-typed group-by column would carry `Custom("udt:X")` while its emitted
+        // array decodes structurally — a silent Arrow schema/array disagreement
+        // (roborev job 1925 item 1). Resolve the partial columns against the already-
+        // attached registry so both are `Struct`.
+        if let Some(registry) = self.udt_registry.clone() {
+            Self::resolve_columns_udts(&registry, &self.schema.keyspace, &mut partial);
+        }
         self.agg = Some(plan);
         self.partial_columns = Some(partial);
         Ok(self)

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -29,7 +29,7 @@ use cqlite_core::export::{build_arrow_schema, rows_to_record_batch, ArrowConvert
 use cqlite_core::query::{
     build_row_from_scan_cached, AccessPath, ColumnInfo, PartitionKeyCache, QueryRow,
 };
-use cqlite_core::schema::{CqlType, TableSchema};
+use cqlite_core::schema::{CqlType, TableSchema, UdtRegistry};
 use cqlite_core::storage::write_engine::merge::{MergeStep, RowData};
 use cqlite_core::storage::write_engine::KWayMerger;
 use cqlite_core::types::{DataType, RowCells, ScanRow};
@@ -333,6 +333,19 @@ pub struct MergeProducer {
     agg: Option<AggPlan>,
     /// Partial-output column metadata, present iff [`Self::agg`] is `Some`.
     partial_columns: Option<Vec<ColumnInfo>>,
+    /// Authoritative UDT registry resolved from the ticket DDL's `CREATE TYPE`
+    /// statements (issue #2349). When present it is threaded onto every merge
+    /// reader (cold [`KWayMerger::new_with_gc_and_registry_cancellable`] and the
+    /// cold point-read [`build_single_partition_merger`]) so a `frozen<UDT>` cell
+    /// inside a collection decodes STRUCTURALLY (as `Value::Udt`) instead of
+    /// opaque bytes — the #1234 silent-data-loss class. `None` keeps the prior
+    /// non-UDT-aware decode. The `columns`' `cql_type`s are also resolved against
+    /// it ([`Self::with_udt_registry`]) so the Arrow output field is a `Struct`,
+    /// not opaque `Utf8`. The warm reader-based path sets the SAME registry on its
+    /// shared readers (see `crate::warm`), so both paths flip together. `pub(crate)`
+    /// so the service can hand the SAME resolved registry to the warm registry's
+    /// reader-open path (issue #2349).
+    pub(crate) udt_registry: Option<UdtRegistry>,
 }
 
 /// Abstraction over the k-way merge stepper.
@@ -402,7 +415,47 @@ impl MergeProducer {
             spec,
             agg: None,
             partial_columns: None,
+            udt_registry: None,
         })
+    }
+
+    /// Attach the authoritative UDT registry (issue #2349), resolving every
+    /// column's `cql_type` against it so a `frozen<UDT>` in a collection surfaces
+    /// as an Arrow `Struct` (not opaque `Utf8`/`Binary`) and threading it onto the
+    /// cold merge readers. An empty registry (a DDL with no `CREATE TYPE`) is a
+    /// no-op — column types and reader posture are unchanged. Consumes and returns
+    /// `self` for chaining.
+    pub fn with_udt_registry(mut self, registry: UdtRegistry) -> Self {
+        let keyspace = self.schema.keyspace.clone();
+        for column in &mut self.columns {
+            if let Some(cql_type) = &column.cql_type {
+                let resolved = registry.resolve_type(cql_type, &keyspace);
+                column.data_type = flat_data_type(&resolved);
+                column.cql_type = Some(resolved);
+            }
+        }
+        self.udt_registry = Some(registry);
+        self
+    }
+
+    /// Open a cold full-scan k-way merger over `paths`, threading the resolved UDT
+    /// registry (issue #2349) onto every input reader so a `frozen<UDT>` cell
+    /// inside a collection decodes structurally. With no registry this is
+    /// behaviourally identical to the prior `KWayMerger::new_cancellable`.
+    fn open_cold_merger(
+        &self,
+        paths: Vec<PathBuf>,
+        cancel: &CancelFlag,
+    ) -> Result<KWayMerger, ProducerError> {
+        KWayMerger::new_with_gc_and_registry_cancellable(
+            paths,
+            &self.schema,
+            None,
+            None,
+            self.udt_registry.clone(),
+            cancel.scan_cancel(),
+        )
+        .map_err(ProducerError::Merge)
     }
 
     /// Attach an aggregation spec (issue #841), validating it against the table
@@ -619,8 +672,7 @@ impl MergeProducer {
         // producer promptly once the consumer stops pulling — see
         // `SSTableReader::stream_all_partitions_cancellable`'s doc for the full
         // reasoning.
-        let mut merger = KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
-            .map_err(ProducerError::Merge)?;
+        let mut merger = self.open_cold_merger(paths, cancel)?;
         on_merger_built();
         self.drive_merge_over(
             &mut merger,
@@ -723,8 +775,7 @@ impl MergeProducer {
             return Ok(batches);
         }
 
-        let mut merger = KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
-            .map_err(ProducerError::Merge)?;
+        let mut merger = self.open_cold_merger(paths, cancel)?;
         let mut sink = CollectSink(&mut batches);
         // Collect path (parity oracle): a private seam — no external observer, but
         // the same incremental counter emission runs (issue #2162). This is the
@@ -872,8 +923,7 @@ impl MergeProducer {
         let mut state = plan.new_state();
 
         if !paths.is_empty() {
-            let mut merger = KWayMerger::new_cancellable(paths, &self.schema, cancel.scan_cancel())
-                .map_err(ProducerError::Merge)?;
+            let mut merger = self.open_cold_merger(paths, cancel)?;
             self.drive_aggregate(plan, &mut merger, cancel, &mut state)?;
         }
 

--- a/cqlite-flight/src/producer_point.rs
+++ b/cqlite-flight/src/producer_point.rs
@@ -16,7 +16,9 @@ use std::path::PathBuf;
 
 use arrow::record_batch::RecordBatch;
 use cqlite_core::query::AccessPath;
-use cqlite_core::storage::write_engine::{build_single_partition_merger, PartitionKey};
+use cqlite_core::storage::write_engine::{
+    build_single_partition_merger_with_registry, PartitionKey,
+};
 use cqlite_core::types::Value;
 
 use crate::cancel::CancelFlag;
@@ -167,12 +169,19 @@ impl MergeProducer {
         // Map a cooperative cancellation to the distinct `Cancelled` variant, never
         // masking a real I/O/corruption error as a clean cancel (issue #2264,
         // mirroring `drive_merge`).
-        let built =
-            build_single_partition_merger(paths, &key_bytes, &self.schema, cancel.scan_cancel())
-                .map_err(|e| match e {
-                    cqlite_core::Error::Cancelled => ProducerError::Cancelled,
-                    other => ProducerError::Merge(other),
-                })?;
+        let built = build_single_partition_merger_with_registry(
+            paths,
+            &key_bytes,
+            &self.schema,
+            // Issue #2349: thread the resolved UDT registry so a point read decodes
+            // `frozen<UDT>`-in-collection cells exactly as the full-scan cold path.
+            self.udt_registry.as_ref(),
+            cancel.scan_cancel(),
+        )
+        .map_err(|e| match e {
+            cqlite_core::Error::Cancelled => ProducerError::Cancelled,
+            other => ProducerError::Merge(other),
+        })?;
 
         on_merger_built();
         // Label = router's decision (route variant), NOT surviving key count —

--- a/cqlite-flight/src/producer_warm.rs
+++ b/cqlite-flight/src/producer_warm.rs
@@ -10,10 +10,12 @@
 //! Everything downstream — the point-read route selection, LIMIT/budget pushdown,
 //! tombstone reconciliation, Arrow conversion — is byte-identical to the cold
 //! path; only WHO opened the reader differs. Crucially, decode posture matches
-//! too: the cold path (`KWayMerger::new_cancellable`) and the warm registry BOTH
-//! open readers WITHOUT a UDT registry (`has_udt_registry() == false`), so parity
-//! is guaranteed by identical posture — NOT by warm matching some non-null
-//! authority. Wiring a real UDT registry into both paths together is issue #2349.
+//! too (issue #2349): the cold path
+//! (`KWayMerger::new_with_gc_and_registry_cancellable`) and the warm registry BOTH
+//! open readers WITH the SAME resolved UDT registry (from the ticket DDL's
+//! `CREATE TYPE` statements), so a `frozen<UDT>`-in-collection cell decodes
+//! structurally on both — parity guaranteed by matching the SAME authority, and
+//! both flip together when the DDL declares no UDTs (registry-free).
 //!
 //! Lives in its own module (not `producer.rs`) because that file is over the
 //! campsite file-size threshold (epic #1116).

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -331,8 +331,8 @@ impl CqliteFlightService {
         // registry on its shared readers in `do_get_resolve`, so both flip together.
         // An empty registry (a DDL with no `CREATE TYPE`) is a no-op.
         let registry = cqlite_core::schema::udt_registry_from_cql(&ticket.ddl, &ticket.keyspace);
-        let producer =
-            MergeProducer::with_spec((*schema).clone(), self.batch_size, spec)?.with_udt_registry(registry);
+        let producer = MergeProducer::with_spec((*schema).clone(), self.batch_size, spec)?
+            .with_udt_registry(registry);
         // Aggregation pushdown (issue #841): when the ticket carries an
         // aggregation spec, the producer emits PARTIAL aggregate rows under the
         // partial schema instead of full rows.

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -323,7 +323,16 @@ impl CqliteFlightService {
     fn build_producer(&self, ticket: &FlightTicket) -> Result<MergeProducer, Status> {
         let schema = self.cached_schema(ticket)?;
         let spec = ScanSpec::from_ticket(ticket, &schema)?;
-        let producer = MergeProducer::with_spec((*schema).clone(), self.batch_size, spec)?;
+        // Issue #2349: resolve the authoritative UDT registry from the ticket DDL's
+        // `CREATE TYPE` statements (schema-authoritative, no-heuristics #28) and
+        // attach it. This resolves each column's `cql_type` (so a `frozen<UDT>` in
+        // a collection surfaces as an Arrow `Struct`, not opaque bytes) AND threads
+        // the registry onto the cold merge readers. The warm path sets the SAME
+        // registry on its shared readers in `do_get_resolve`, so both flip together.
+        // An empty registry (a DDL with no `CREATE TYPE`) is a no-op.
+        let registry = cqlite_core::schema::udt_registry_from_cql(&ticket.ddl, &ticket.keyspace);
+        let producer =
+            MergeProducer::with_spec((*schema).clone(), self.batch_size, spec)?.with_udt_registry(registry);
         // Aggregation pushdown (issue #841): when the ticket carries an
         // aggregation spec, the producer emits PARTIAL aggregate rows under the
         // partial schema instead of full rows.
@@ -775,6 +784,10 @@ impl CqliteFlightService {
                     &key,
                     ddl_hash(&ticket.ddl),
                     &producer.schema,
+                    // Issue #2349: open warm readers WITH the same resolved UDT
+                    // registry the producer carries, so a `frozen<UDT>`-in-collection
+                    // cell decodes structurally on the warm path exactly as on cold.
+                    producer.udt_registry.as_ref(),
                     &dir,
                     ticket.snapshot.as_deref(),
                     &resolve_cancel,

--- a/cqlite-flight/src/warm/rebuild.rs
+++ b/cqlite-flight/src/warm/rebuild.rs
@@ -39,7 +39,7 @@ use std::path::Path;
 use std::sync::{Arc, Condvar, Mutex, PoisonError, Weak};
 use std::time::Duration;
 
-use cqlite_core::schema::TableSchema;
+use cqlite_core::schema::{TableSchema, UdtRegistry};
 use cqlite_core::storage::scan_cancel::ScanCancel;
 use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::{Config, Error, Platform};
@@ -299,9 +299,9 @@ fn prune_dead(map: &mut HashMap<GenerationId, Arc<OpenSlot>>) {
 impl WarmTableRegistry {
     /// Open the ADDED generations, single-flight-coalesced (issue #2383 fix A) and
     /// cancel-aware (fix C). Fail-closed: any open error (or a cancellation)
-    /// returns immediately WITHOUT partial state. Readers are opened with the SAME
-    /// UDT-registry posture as the cold path (none — see the `registry` module
-    /// doc; #2349 wires a real registry into both paths together).
+    /// returns immediately WITHOUT partial state. Each reader is opened WITH the
+    /// resolved `udt_registry` (issue #2349), matching the cold path exactly so a
+    /// `frozen<UDT>`-in-collection cell decodes structurally on both paths.
     ///
     /// Returns `(opened, real_opens)`: `real_opens` counts only the opens THIS
     /// call actually performed (coalesced follower opens do not count), so the
@@ -311,6 +311,7 @@ impl WarmTableRegistry {
         &self,
         added: &[&GenerationEntry],
         _schema: &TableSchema,
+        udt_registry: Option<&UdtRegistry>,
         cancel: &CancelFlag,
     ) -> Result<(Vec<WarmReader>, u64), WarmError> {
         if added.is_empty() {
@@ -353,6 +354,7 @@ impl WarmTableRegistry {
                     &entry.path,
                     &config,
                     Arc::clone(&platform),
+                    udt_registry,
                     scan_cancel.clone(),
                 )
                 .map(Arc::new)
@@ -426,15 +428,19 @@ pub(super) fn rebind_matches(id: GenerationId, expected_size: u64, live_path: &P
     }
 }
 
-/// Open ONE reader, cancel-aware (issue #2383 fix C), with the SAME UDT-registry
-/// posture as the cold path.
+/// Open ONE reader, cancel-aware (issue #2383 fix C), threading the SAME resolved
+/// UDT registry as the cold path (issue #2349).
 ///
-/// The cold Flight path (`KWayMerger::new_cancellable`) opens readers with
-/// `udt_registry = None`, so — to keep warm a parse-cost-only change with no
-/// read-semantics divergence — this does NOT set a registry either. Wiring a real
-/// registry into BOTH paths together is issue #2349; see the `registry` module
-/// doc. The `cancel` flag is polled inside the O(entries) `Index.db` parse
-/// (`open_cancellable`), so a mid-parse client disconnect surfaces as
+/// The cold Flight path (`KWayMerger::new_with_gc_and_registry_cancellable`) opens
+/// each reader WITH its resolved registry via `set_udt_registry` so a `frozen<UDT>`
+/// cell inside a collection decodes structurally (the #1234 data-loss class). The
+/// warm path must match EXACTLY (spec non-goal: warm is a parse-cost change, never
+/// a read-semantics change), so this sets the same registry on the freshly-opened
+/// reader BEFORE it is shared as an `Arc` (the only point a `&mut self` exists —
+/// see `from_readers.rs`'s shared-reader UDT contract). `udt_registry = None` (a
+/// DDL with no `CREATE TYPE`) leaves the reader registry-free, identical to the
+/// cold path's `None`. The `cancel` flag is polled inside the O(entries) `Index.db`
+/// parse (`open_cancellable`), so a mid-parse client disconnect surfaces as
 /// [`Error::Cancelled`] and is mapped to [`WarmError::Cancelled`] — never masked
 /// as an `Open` failure, never run to completion.
 fn open_one_reader(
@@ -442,9 +448,10 @@ fn open_one_reader(
     path: &Path,
     config: &Config,
     platform: Arc<Platform>,
+    udt_registry: Option<&UdtRegistry>,
     cancel: ScanCancel,
 ) -> Result<SSTableReader, WarmError> {
-    let reader = runtime
+    let mut reader = runtime
         .block_on(SSTableReader::open_cancellable(
             path, config, platform, cancel,
         ))
@@ -455,9 +462,13 @@ fn open_one_reader(
                 source,
             },
         })?;
-    debug_assert!(
-        !reader.has_udt_registry(),
-        "warm reader must match the cold path's no-UDT-registry posture (#2349)"
+    if let Some(registry) = udt_registry {
+        reader.set_udt_registry(registry.clone());
+    }
+    debug_assert_eq!(
+        reader.has_udt_registry(),
+        udt_registry.is_some(),
+        "warm reader UDT-registry posture must match the cold path (#2349)"
     );
     Ok(reader)
 }

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -8,24 +8,21 @@
 //! mutates nothing and in-flight requests holding `Arc` clones complete against
 //! the pre-swap set.
 //!
-//! ## UDT-registry posture — identical to the cold path (WS1 #2345, follow-up #2349)
+//! ## UDT-registry posture — identical to the cold path (WS1 #2345 → wired #2349)
 //!
 //! The reader-based merge seam `KWayMerger::new_from_readers` takes NO
 //! `udt_registry` parameter (a shared `Arc` reader has no `&mut self` for
 //! `set_udt_registry`), so a reader must be opened WITH its registry already
-//! resolved BEFORE it is wrapped in `Arc`. The cold Flight path, however, opens
-//! its readers via `KWayMerger::new_cancellable`, which passes `udt_registry =
-//! None` — so the cold path currently decodes WITHOUT a UDT registry. To keep the
-//! spec non-goal (warm is a PARSE-COST change only, never a read-semantics
-//! change), the warm path opens readers with the EXACTLY SAME posture: no UDT
-//! registry. [`open_one_reader`] therefore does NOT set a registry, and both
-//! paths hand the merge readers with `has_udt_registry() == false`. Parity is
-//! guaranteed by identical posture, not by matching a non-null authority.
-//!
-//! Wiring a real UDT registry into BOTH paths (so a frozen/nested UDT cell in a
-//! collection decodes structurally instead of as `Blob`, the #1234 data-loss
-//! class) is tracked as a single follow-up, issue #2349 — it must land for the
-//! cold path and the warm path together so they never diverge.
+//! resolved BEFORE it is wrapped in `Arc`. Issue #2349 threads a resolved
+//! `Option<&UdtRegistry>` (from the ticket DDL's `CREATE TYPE` statements, via
+//! `udt_registry_from_cql`) through `warm_readers` → `rebuild` → `open_added` →
+//! `open_one_reader`, which calls `set_udt_registry` on each freshly-opened
+//! reader BEFORE sharing it — the exact same registry the cold path sets via
+//! `KWayMerger::new_with_gc_and_registry_cancellable`. Both paths therefore flip
+//! TOGETHER: `has_udt_registry()` is `true` iff the DDL declares UDTs, so a
+//! `frozen<UDT>` cell inside a collection decodes structurally on both (the #1234
+//! data-loss class), and the warm-vs-cold read semantics never diverge. A DDL with
+//! no `CREATE TYPE` resolves to `None` and both paths stay registry-free.
 //!
 //! ## File-lifetime contract (from `from_readers.rs`)
 //!
@@ -49,7 +46,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, Mutex, PoisonError};
 
-use cqlite_core::schema::TableSchema;
+use cqlite_core::schema::{TableSchema, UdtRegistry};
 use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::Platform;
 
@@ -189,11 +186,13 @@ impl WarmTableRegistry {
     /// * `snapshot` — the ticket's snapshot name (enables the manifest fast path).
     /// * `cancel` — the request cancel flag; a pre-cancelled request does ZERO
     ///   probe/rebuild work and returns [`WarmError::Cancelled`] by variant.
+    #[allow(clippy::too_many_arguments)]
     pub fn warm_readers(
         &self,
         key: &TableKey,
         ddl_hash: u64,
         schema: &TableSchema,
+        udt_registry: Option<&UdtRegistry>,
         dir: &Path,
         snapshot: Option<&str>,
         cancel: &CancelFlag,
@@ -236,21 +235,39 @@ impl WarmTableRegistry {
                 } else {
                     None
                 };
-                self.finish_enumerated(key, ddl_hash, schema, entries, manifest, cancel)
+                self.finish_enumerated(
+                    key,
+                    ddl_hash,
+                    schema,
+                    udt_registry,
+                    entries,
+                    manifest,
+                    cancel,
+                )
             }
             ProbeOutcome::Enumerated {
                 entries, manifest, ..
-            } => self.finish_enumerated(key, ddl_hash, schema, entries, manifest, cancel),
+            } => self.finish_enumerated(
+                key,
+                ddl_hash,
+                schema,
+                udt_registry,
+                entries,
+                manifest,
+                cancel,
+            ),
         }
     }
 
     /// Resolve an authoritatively-enumerated generation set into a warm hit (set
     /// unchanged) or a fail-closed delta rebuild.
+    #[allow(clippy::too_many_arguments)]
     fn finish_enumerated(
         &self,
         key: &TableKey,
         ddl_hash: u64,
         schema: &TableSchema,
+        udt_registry: Option<&UdtRegistry>,
         entries: Vec<GenerationEntry>,
         manifest: Option<Vec<u8>>,
         cancel: &CancelFlag,
@@ -271,6 +288,7 @@ impl WarmTableRegistry {
             key,
             ddl_hash,
             schema,
+            udt_registry,
             entries,
             current_set,
             manifest,
@@ -340,6 +358,7 @@ impl WarmTableRegistry {
         key: &TableKey,
         ddl_hash: u64,
         schema: &TableSchema,
+        udt_registry: Option<&UdtRegistry>,
         entries: Vec<GenerationEntry>,
         current_set: GenerationSet,
         manifest: Option<Vec<u8>>,
@@ -423,7 +442,7 @@ impl WarmTableRegistry {
             .iter()
             .filter(|e| !alive_ids.contains(&e.id))
             .collect();
-        let (opened, reader_opens) = match self.open_added(&added, schema, cancel) {
+        let (opened, reader_opens) = match self.open_added(&added, schema, udt_registry, cancel) {
             Ok(opened) => opened,
             Err(e) => {
                 // The previously warm set is untouched. Record the fail-closed

--- a/cqlite-flight/src/warm/registry_tests.rs
+++ b/cqlite-flight/src/warm/registry_tests.rs
@@ -220,7 +220,15 @@ fn warm_and_cold_reader_udt_posture_identical() {
     // cold `SSTableReader::open`.
     let reg = WarmTableRegistry::new();
     let w_none = reg
-        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &CancelFlag::new())
+        .warm_readers(
+            &key(),
+            ddl(),
+            &schema,
+            None,
+            &table_dir,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("warms (no registry)");
     assert!(!w_none.readers.is_empty(), "opened at least one reader");
     for r in &w_none.readers {
@@ -314,7 +322,15 @@ fn concurrent_same_key_rebuild_dedups_readers_and_bytes() {
     // reader count (2) and accounted footprint.
     let reference = WarmTableRegistry::new();
     reference
-        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &CancelFlag::new())
+        .warm_readers(
+            &key(),
+            ddl(),
+            &schema,
+            None,
+            &table_dir,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("reference warm");
     let ref_used = reference.debug_used_bytes();
     let ref_count = reference.debug_reader_count(&key());
@@ -410,7 +426,15 @@ fn slow_rebuild_does_not_overwrite_a_faster_newer_swap() {
     let a_handle = thread::Builder::new()
         .name("slow-A".to_string())
         .spawn(move || {
-            a_reg.warm_readers(&key(), ddl(), &a_schema, None, &a_dir, None, &CancelFlag::new())
+            a_reg.warm_readers(
+                &key(),
+                ddl(),
+                &a_schema,
+                None,
+                &a_dir,
+                None,
+                &CancelFlag::new(),
+            )
         })
         .expect("spawn slow-A");
 
@@ -422,7 +446,15 @@ fn slow_rebuild_does_not_overwrite_a_faster_newer_swap() {
     // state A's stale probe never saw.
     append_gen(&table_dir, &schema, vec![write_row(2, "b", 2, 100)]);
     let b_result = reg
-        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &CancelFlag::new())
+        .warm_readers(
+            &key(),
+            ddl(),
+            &schema,
+            None,
+            &table_dir,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("fast rebuild B installs the newer set");
     assert_eq!(b_result.readers.len(), 2, "B installs both generations");
 
@@ -592,7 +624,15 @@ fn lru_evicts_when_over_budget() {
     // registry): B fits, but A+B together force A out.
     let probe = WarmTableRegistry::new();
     probe
-        .warm_readers(&key_b, ddl(), &schema, None, &dir_b, None, &CancelFlag::new())
+        .warm_readers(
+            &key_b,
+            ddl(),
+            &schema,
+            None,
+            &dir_b,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("probe warm");
     let one_gen = probe.debug_used_bytes();
     assert!(one_gen > 0, "a generation's footprint is non-zero");
@@ -662,7 +702,15 @@ fn capacity_eviction_preserves_global_key_cache() {
     // fits, so warming A+B forces A out via the CAPACITY-eviction path.
     let probe = WarmTableRegistry::new();
     probe
-        .warm_readers(&key_b, ddl(), &schema, None, &dir_b, None, &CancelFlag::new())
+        .warm_readers(
+            &key_b,
+            ddl(),
+            &schema,
+            None,
+            &dir_b,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("probe warm");
     let one_gen = probe.debug_used_bytes();
     assert!(one_gen > 0, "a generation's footprint is non-zero");

--- a/cqlite-flight/src/warm/registry_tests.rs
+++ b/cqlite-flight/src/warm/registry_tests.rs
@@ -94,14 +94,14 @@ fn cross_snapshot_dirs_share_one_warm_entry() {
     let cancel = CancelFlag::new();
 
     let w1 = reg
-        .warm_readers(&key(), ddl(), &schema, &snap1, Some("snap1"), &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &snap1, Some("snap1"), &cancel)
         .expect("first snapshot warms");
     assert_eq!(w1.outcome, RefreshOutcome::RebuiltDelta, "first is a build");
     let opens_after_first = reg.metrics().snapshot().reader_opens;
     assert!(opens_after_first >= 2, "both generations opened cold");
 
     let w2 = reg
-        .warm_readers(&key(), ddl(), &schema, &snap2, Some("snap2"), &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &snap2, Some("snap2"), &cancel)
         .expect("second snapshot (different dir, same inodes)");
     assert_eq!(
         w2.outcome,
@@ -150,7 +150,7 @@ fn warm_hit_after_snapshot_teardown_rebuilds_instead_of_enoent() {
     let reg = WarmTableRegistry::new();
     let cancel = CancelFlag::new();
     let w1 = reg
-        .warm_readers(&key(), ddl(), &schema, &snap1, Some("snap1"), &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &snap1, Some("snap1"), &cancel)
         .expect("first snapshot warms");
     assert_eq!(w1.outcome, RefreshOutcome::RebuiltDelta, "first is a build");
     assert_eq!(
@@ -167,7 +167,7 @@ fn warm_hit_after_snapshot_teardown_rebuilds_instead_of_enoent() {
     // identity makes this a set-match — but a dead cached path must NOT be served.
     let snap2 = make_snapshot(&table_dir, "snap2");
     let w2 = reg
-        .warm_readers(&key(), ddl(), &schema, &snap2, Some("snap2"), &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &snap2, Some("snap2"), &cancel)
         .expect("second snapshot request after the first was cleared");
 
     // The fix: a dead cached path is a rebuild (a refresh outcome), never a
@@ -201,33 +201,62 @@ fn warm_hit_after_snapshot_teardown_rebuilds_instead_of_enoent() {
 }
 
 /// Warm/cold UDT-registry PARITY (spec non-goal: warm is a parse-cost change
-/// only, never a read-semantics change; #2349): the warm path must open readers
-/// with the SAME UDT-registry posture as the cold path. The cold Flight path
-/// (`KWayMerger::new_cancellable`) opens readers with `udt_registry = None`, so a
-/// warm reader must ALSO have no registry. Both are `has_udt_registry() == false`
-/// today; they flip together when #2349 wires a real registry into both paths.
+/// only, never a read-semantics change; #2349): the warm path opens readers with
+/// the SAME UDT-registry posture as the cold path — they flip TOGETHER. When the
+/// resolved registry is `None` (a DDL with no `CREATE TYPE`), a warm reader has no
+/// registry, exactly like a plain cold `SSTableReader::open`; when a registry is
+/// supplied it is set on every warm reader, exactly as the cold
+/// `KWayMerger::new_with_gc_and_registry_cancellable` sets it. Both directions are
+/// asserted so a regression in either the None or Some posture is caught.
 #[test]
 fn warm_and_cold_reader_udt_posture_identical() {
+    use cqlite_core::schema::UdtRegistry;
     use cqlite_core::{Config, Platform};
 
     let schema = simple_schema();
     let (_temp, _data, table_dir) = build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
 
-    // WARM posture: readers handed out by the registry.
+    // Posture 1 — NO registry: warm readers must be registry-free, like a plain
+    // cold `SSTableReader::open`.
     let reg = WarmTableRegistry::new();
-    let w = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
-        .expect("warms");
-    assert!(!w.readers.is_empty(), "opened at least one reader");
-    for r in &w.readers {
+    let w_none = reg
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &CancelFlag::new())
+        .expect("warms (no registry)");
+    assert!(!w_none.readers.is_empty(), "opened at least one reader");
+    for r in &w_none.readers {
         assert!(
             !r.has_udt_registry(),
-            "a warm reader must match the cold path's no-UDT-registry posture (#2349)"
+            "a warm reader with no resolved registry must have none (parity, #2349)"
         );
     }
 
-    // COLD posture: open a reader exactly as `KWayMerger::new_cancellable` does
-    // (plain `SSTableReader::open`, never `set_udt_registry`).
+    // Posture 2 — WITH a registry: every warm reader carries it (a distinct
+    // `TableKey` so the no-registry cache entry above is not reused).
+    let reg2 = WarmTableRegistry::new();
+    let registry = UdtRegistry::with_cassandra5_defaults();
+    let key2 = TableKey::new("test_ks", "with_udt");
+    let w_some = reg2
+        .warm_readers(
+            &key2,
+            ddl(),
+            &schema,
+            Some(&registry),
+            &table_dir,
+            None,
+            &CancelFlag::new(),
+        )
+        .expect("warms (with registry)");
+    assert!(!w_some.readers.is_empty(), "opened at least one reader");
+    for r in &w_some.readers {
+        assert!(
+            r.has_udt_registry(),
+            "a warm reader opened WITH a registry must carry it — flips with the cold \
+             path (#2349)"
+        );
+    }
+
+    // COLD posture: a plain `SSTableReader::open` (as the cold path does before
+    // `set_udt_registry`) has no registry, so it matches Posture 1.
     let data_db = std::fs::read_dir(&table_dir)
         .unwrap()
         .flatten()
@@ -251,12 +280,12 @@ fn warm_and_cold_reader_udt_posture_identical() {
     });
     assert_eq!(
         cold.has_udt_registry(),
-        w.readers[0].has_udt_registry(),
-        "warm and cold readers must share one UDT-registry posture (parity, #2349)"
+        w_none.readers[0].has_udt_registry(),
+        "a registry-free warm reader matches a plain cold open (parity, #2349)"
     );
     assert!(
         !cold.has_udt_registry(),
-        "the cold path opens readers without a UDT registry"
+        "a plain cold open has no UDT registry"
     );
 }
 
@@ -285,7 +314,7 @@ fn concurrent_same_key_rebuild_dedups_readers_and_bytes() {
     // reader count (2) and accounted footprint.
     let reference = WarmTableRegistry::new();
     reference
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &CancelFlag::new())
         .expect("reference warm");
     let ref_used = reference.debug_used_bytes();
     let ref_count = reference.debug_reader_count(&key());
@@ -308,7 +337,7 @@ fn concurrent_same_key_rebuild_dedups_readers_and_bytes() {
             let schema = schema.clone();
             let dir = table_dir.clone();
             thread::spawn(move || {
-                reg.warm_readers(&key(), ddl(), &schema, &dir, None, &CancelFlag::new())
+                reg.warm_readers(&key(), ddl(), &schema, None, &dir, None, &CancelFlag::new())
                     .expect("concurrent warm")
                     .readers
                     .len()
@@ -381,7 +410,7 @@ fn slow_rebuild_does_not_overwrite_a_faster_newer_swap() {
     let a_handle = thread::Builder::new()
         .name("slow-A".to_string())
         .spawn(move || {
-            a_reg.warm_readers(&key(), ddl(), &a_schema, &a_dir, None, &CancelFlag::new())
+            a_reg.warm_readers(&key(), ddl(), &a_schema, None, &a_dir, None, &CancelFlag::new())
         })
         .expect("spawn slow-A");
 
@@ -393,7 +422,7 @@ fn slow_rebuild_does_not_overwrite_a_faster_newer_swap() {
     // state A's stale probe never saw.
     append_gen(&table_dir, &schema, vec![write_row(2, "b", 2, 100)]);
     let b_result = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &CancelFlag::new())
         .expect("fast rebuild B installs the newer set");
     assert_eq!(b_result.readers.len(), 2, "B installs both generations");
 
@@ -449,7 +478,7 @@ fn fail_closed_rebuild_retains_prior_warm_set() {
 
     // Warm the valid set.
     let w1 = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("warms the valid generation");
     let opens_after_first = reg.metrics().snapshot().reader_opens;
 
@@ -470,7 +499,7 @@ fn fail_closed_rebuild_retains_prior_warm_set() {
     .unwrap();
 
     let err = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect_err("a corrupt added generation must fail the rebuild");
     assert!(
         matches!(err, WarmError::Open { .. }),
@@ -487,7 +516,7 @@ fn fail_closed_rebuild_retains_prior_warm_set() {
     // never dropped by the failed rebuild).
     std::fs::remove_file(table_dir.join("nb-999-big-Data.db")).unwrap();
     let w2 = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("prior set still serves");
     assert_eq!(
         w2.outcome,
@@ -518,7 +547,7 @@ fn removed_generation_is_evicted_immediately() {
     let reg = WarmTableRegistry::new();
     let cancel = CancelFlag::new();
     let w1 = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("warms two generations");
     assert_eq!(w1.readers.len(), 2);
 
@@ -536,7 +565,7 @@ fn removed_generation_is_evicted_immediately() {
     std::fs::remove_file(&victim).unwrap();
 
     let w2 = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("rebuild drops the removed generation");
     assert_eq!(w2.readers.len(), 1, "the removed generation is gone");
     assert!(
@@ -563,7 +592,7 @@ fn lru_evicts_when_over_budget() {
     // registry): B fits, but A+B together force A out.
     let probe = WarmTableRegistry::new();
     probe
-        .warm_readers(&key_b, ddl(), &schema, &dir_b, None, &CancelFlag::new())
+        .warm_readers(&key_b, ddl(), &schema, None, &dir_b, None, &CancelFlag::new())
         .expect("probe warm");
     let one_gen = probe.debug_used_bytes();
     assert!(one_gen > 0, "a generation's footprint is non-zero");
@@ -571,9 +600,9 @@ fn lru_evicts_when_over_budget() {
     let reg = WarmTableRegistry::with_budget(one_gen);
     let cancel = CancelFlag::new();
 
-    reg.warm_readers(&key_a, ddl(), &schema, &dir_a, None, &cancel)
+    reg.warm_readers(&key_a, ddl(), &schema, None, &dir_a, None, &cancel)
         .expect("warm A");
-    reg.warm_readers(&key_b, ddl(), &schema, &dir_b, None, &cancel)
+    reg.warm_readers(&key_b, ddl(), &schema, None, &dir_b, None, &cancel)
         .expect("warm B evicts A");
     assert!(
         reg.metrics().snapshot().evicts >= 1,
@@ -589,7 +618,7 @@ fn lru_evicts_when_over_budget() {
     // must be CORRECT — the re-opened reader decodes partition id=1 → name "a".
     let opens_before = reg.metrics().snapshot().reader_opens;
     let wa = reg
-        .warm_readers(&key_a, ddl(), &schema, &dir_a, None, &cancel)
+        .warm_readers(&key_a, ddl(), &schema, None, &dir_a, None, &cancel)
         .expect("A re-parses after eviction");
     assert_eq!(
         wa.outcome,
@@ -633,7 +662,7 @@ fn capacity_eviction_preserves_global_key_cache() {
     // fits, so warming A+B forces A out via the CAPACITY-eviction path.
     let probe = WarmTableRegistry::new();
     probe
-        .warm_readers(&key_b, ddl(), &schema, &dir_b, None, &CancelFlag::new())
+        .warm_readers(&key_b, ddl(), &schema, None, &dir_b, None, &CancelFlag::new())
         .expect("probe warm");
     let one_gen = probe.debug_used_bytes();
     assert!(one_gen > 0, "a generation's footprint is non-zero");
@@ -642,7 +671,7 @@ fn capacity_eviction_preserves_global_key_cache() {
     let cancel = CancelFlag::new();
 
     let wa = reg
-        .warm_readers(&key_a, ddl(), &schema, &dir_a, None, &cancel)
+        .warm_readers(&key_a, ddl(), &schema, None, &dir_a, None, &cancel)
         .expect("warm A");
     let reader_a = Arc::clone(&wa.readers[0]);
 
@@ -667,7 +696,7 @@ fn capacity_eviction_preserves_global_key_cache() {
     );
 
     // Warm B past the one-generation budget → CAPACITY-evicts A from the warm set.
-    reg.warm_readers(&key_b, ddl(), &schema, &dir_b, None, &cancel)
+    reg.warm_readers(&key_b, ddl(), &schema, None, &dir_b, None, &cancel)
         .expect("warm B capacity-evicts A");
     assert!(
         reg.metrics().snapshot().evicts >= 1,
@@ -722,7 +751,7 @@ fn manifest_fast_path_serves_cached_without_relisting() {
     let reg = WarmTableRegistry::new();
     let cancel = CancelFlag::new();
     let w1 = reg
-        .warm_readers(&key(), ddl(), &schema, &snap, Some("snap1"), &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &snap, Some("snap1"), &cancel)
         .expect("warm snapshot");
     assert_eq!(w1.readers.len(), 2, "both generations warmed");
     let opens = reg.metrics().snapshot().reader_opens;
@@ -733,7 +762,7 @@ fn manifest_fast_path_serves_cached_without_relisting() {
     std::fs::write(snap.join("nb-3-big-Data.db"), b"not-a-real-sstable").unwrap();
 
     let w2 = reg
-        .warm_readers(&key(), ddl(), &schema, &snap, Some("snap1"), &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &snap, Some("snap1"), &cancel)
         .expect("manifest fast path serves cached");
     assert_eq!(
         w2.outcome,
@@ -764,7 +793,7 @@ fn held_warm_set_is_isolated_from_a_rebuild_swap() {
     let reg = WarmTableRegistry::new();
     let cancel = CancelFlag::new();
     let w1 = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("warm gen-1");
     // Hold the pre-swap Arc set (as an in-flight stream would).
     let held = w1.readers.clone();
@@ -772,7 +801,7 @@ fn held_warm_set_is_isolated_from_a_rebuild_swap() {
     // Add a second generation and rebuild+swap the warm set.
     append_gen(&table_dir, &schema, vec![write_row(2, "b", 2, 200)]);
     let w2 = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("rebuild adds gen-2");
     assert_eq!(
         w2.readers.len(),
@@ -806,7 +835,7 @@ fn mid_rebuild_cancellation_leaves_prior_set_intact() {
     let reg = WarmTableRegistry::new();
     let cancel = CancelFlag::new();
     // Warm gen-1 (the prior set).
-    reg.warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+    reg.warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("warm gen-1");
 
     // Add TWO more generations so the rebuild opens multiple.
@@ -825,7 +854,7 @@ fn mid_rebuild_cancellation_leaves_prior_set_intact() {
     }));
 
     let err = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect_err("a mid-rebuild cancellation must abort");
     assert!(matches!(err, WarmError::Cancelled), "got {err:?}");
     assert!(
@@ -849,7 +878,7 @@ fn pre_cancelled_warm_lookup_does_zero_work() {
     let cancel = CancelFlag::new();
     cancel.cancel();
     let err = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect_err("a pre-cancelled lookup must not work");
     assert!(matches!(err, WarmError::Cancelled), "got {err:?}");
     let m = reg.metrics().snapshot();
@@ -866,11 +895,11 @@ fn unchanged_live_set_is_a_warm_hit() {
     let reg = WarmTableRegistry::new();
     let cancel = CancelFlag::new();
     let _ = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("first");
     let opens = reg.metrics().snapshot().reader_opens;
     let w2 = reg
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("second");
     assert_eq!(w2.outcome, RefreshOutcome::Unchanged);
     assert_eq!(

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -174,7 +174,7 @@ fn rebind_across_snapshot_teardown_does_not_reparse() {
 
     // Query N: warm from snap1 (readers open with file_path inside snap1).
     let snap1 = make_snapshot(&table_dir, "snap1");
-    reg.warm_readers(&key(), ddl(), &schema, &snap1, Some("snap1"), &cancel)
+    reg.warm_readers(&key(), ddl(), &schema, None, &snap1, Some("snap1"), &cancel)
         .expect("first snapshot warms");
     let opens_after_first = reg.metrics().snapshot().reader_opens;
     assert!(opens_after_first >= 2, "both generations parsed cold");
@@ -185,7 +185,7 @@ fn rebind_across_snapshot_teardown_does_not_reparse() {
     // Query N+1: a NEW snapshot dir over the SAME inodes (hardlinks).
     let snap2 = make_snapshot(&table_dir, "snap2");
     let w2 = reg
-        .warm_readers(&key(), ddl(), &schema, &snap2, Some("snap2"), &cancel)
+        .warm_readers(&key(), ddl(), &schema, None, &snap2, Some("snap2"), &cancel)
         .expect("second snapshot request after teardown");
 
     // Every returned reader must back a LIVE path (#2352 ENOENT protection kept).
@@ -237,7 +237,7 @@ fn warm_hit_over_large_generation_is_scale_free() {
     let cancel = CancelFlag::new();
 
     // Cold warm: opens (parses) the one big generation.
-    reg.warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+    reg.warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("cold warm of the big generation");
     let after_cold = reg.metrics().snapshot();
     assert!(
@@ -246,7 +246,7 @@ fn warm_hit_over_large_generation_is_scale_free() {
     );
 
     // Repeat over the SAME stable path: a pure warm hit — zero further work.
-    reg.warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel)
+    reg.warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel)
         .expect("warm hit");
     let after_hit = reg.metrics().snapshot();
     assert_eq!(
@@ -297,7 +297,7 @@ fn concurrent_misses_single_flight_one_parse_per_generation() {
             let start = Arc::clone(&start);
             thread::spawn(move || {
                 start.wait();
-                reg.warm_readers(&key(), ddl(), &schema, &dir, None, &CancelFlag::new())
+                reg.warm_readers(&key(), ddl(), &schema, None, &dir, None, &CancelFlag::new())
                     .expect("concurrent warm")
                     .readers
                     .len()
@@ -374,7 +374,7 @@ fn cancel_during_large_index_parse_aborts_promptly() {
     // FASTER, never slower, than this baseline).
     let calib_start = std::time::Instant::now();
     WarmTableRegistry::new()
-        .warm_readers(&key(), ddl(), &schema, &table_dir, None, &CancelFlag::new())
+        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &CancelFlag::new())
         .expect("calibration warm (uncancelled) completes");
     let baseline = calib_start.elapsed();
     // 1/20th of the measured baseline: tens of ms on every host we've observed,
@@ -410,7 +410,7 @@ fn cancel_during_large_index_parse_aborts_promptly() {
         })
     };
 
-    let res = reg.warm_readers(&key(), ddl(), &schema, &table_dir, None, &cancel);
+    let res = reg.warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel);
     canceller.join().expect("canceller");
 
     // RED today: the parse ignores the mid-parse cancel and returns Ok. GREEN once
@@ -457,7 +457,7 @@ fn evicted_but_inflight_reader_is_not_served_with_dead_path() {
     // Budget = exactly ONE generation's footprint, so warming B evicts A.
     let probe = WarmTableRegistry::new();
     probe
-        .warm_readers(&key_a, ddl(), &schema, &dir_a, None, &CancelFlag::new())
+        .warm_readers(&key_a, ddl(), &schema, None, &dir_a, None, &CancelFlag::new())
         .expect("probe warm");
     let one_gen = probe.debug_used_bytes();
     assert!(one_gen > 0, "a generation's footprint is non-zero");
@@ -470,7 +470,7 @@ fn evicted_but_inflight_reader_is_not_served_with_dead_path() {
     // holder outside the registry's cache" this bug depends on.
     let snap1 = make_snapshot(&dir_a, "snap1");
     let w1 = reg
-        .warm_readers(&key_a, ddl(), &schema, &snap1, Some("snap1"), &cancel)
+        .warm_readers(&key_a, ddl(), &schema, None, &snap1, Some("snap1"), &cancel)
         .expect("warm A from snap1");
     assert_eq!(w1.readers.len(), 1, "table A is a single generation");
     let held: Vec<Arc<SSTableReader>> = w1.readers.clone();
@@ -478,7 +478,7 @@ fn evicted_but_inflight_reader_is_not_served_with_dead_path() {
 
     // Warm B: pushes `used_bytes` over budget, evicting A's generation from the
     // registry's OWN cache — but R stays alive via `held` above.
-    reg.warm_readers(&key_b, ddl(), &schema, &dir_b, None, &cancel)
+    reg.warm_readers(&key_b, ddl(), &schema, None, &dir_b, None, &cancel)
         .expect("warm B evicts A");
     assert_eq!(
         reg.debug_reader_count(&key_a),
@@ -496,7 +496,7 @@ fn evicted_but_inflight_reader_is_not_served_with_dead_path() {
     // dead path is the coalescer's own path-liveness gate (blocker 1).
     let snap2 = make_snapshot(&dir_a, "snap2");
     let w2 = reg
-        .warm_readers(&key_a, ddl(), &schema, &snap2, Some("snap2"), &cancel)
+        .warm_readers(&key_a, ddl(), &schema, None, &snap2, Some("snap2"), &cancel)
         .expect("re-warm A after eviction + snapshot teardown");
     assert_eq!(w2.readers.len(), 1, "table A is still a single generation");
 

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -374,7 +374,15 @@ fn cancel_during_large_index_parse_aborts_promptly() {
     // FASTER, never slower, than this baseline).
     let calib_start = std::time::Instant::now();
     WarmTableRegistry::new()
-        .warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &CancelFlag::new())
+        .warm_readers(
+            &key(),
+            ddl(),
+            &schema,
+            None,
+            &table_dir,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("calibration warm (uncancelled) completes");
     let baseline = calib_start.elapsed();
     // 1/20th of the measured baseline: tens of ms on every host we've observed,
@@ -457,7 +465,15 @@ fn evicted_but_inflight_reader_is_not_served_with_dead_path() {
     // Budget = exactly ONE generation's footprint, so warming B evicts A.
     let probe = WarmTableRegistry::new();
     probe
-        .warm_readers(&key_a, ddl(), &schema, None, &dir_a, None, &CancelFlag::new())
+        .warm_readers(
+            &key_a,
+            ddl(),
+            &schema,
+            None,
+            &dir_a,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("probe warm");
     let one_gen = probe.debug_used_bytes();
     assert!(one_gen > 0, "a generation's footprint is non-zero");

--- a/cqlite-flight/src/warm/summary_only_memory_tests.rs
+++ b/cqlite-flight/src/warm/summary_only_memory_tests.rs
@@ -101,7 +101,15 @@ fn warm_footprint_does_not_scale_with_partition_count() {
     let (_small_temp, small_dir) = build_single_gen(&schema, 200);
     let small_reg = WarmTableRegistry::new();
     small_reg
-        .warm_readers(&key(), ddl(), &schema, None, &small_dir, None, &CancelFlag::new())
+        .warm_readers(
+            &key(),
+            ddl(),
+            &schema,
+            None,
+            &small_dir,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("small generation warms");
     let small_footprint = small_reg.debug_used_bytes();
 
@@ -113,7 +121,15 @@ fn warm_footprint_does_not_scale_with_partition_count() {
     let (large_index_bytes, large_summary_bytes) = sibling_component_sizes(&large_data);
     let large_reg = WarmTableRegistry::new();
     large_reg
-        .warm_readers(&key(), ddl(), &schema, None, &large_dir, None, &CancelFlag::new())
+        .warm_readers(
+            &key(),
+            ddl(),
+            &schema,
+            None,
+            &large_dir,
+            None,
+            &CancelFlag::new(),
+        )
         .expect("large generation warms");
     let large_footprint = large_reg.debug_used_bytes();
 

--- a/cqlite-flight/src/warm/summary_only_memory_tests.rs
+++ b/cqlite-flight/src/warm/summary_only_memory_tests.rs
@@ -101,7 +101,7 @@ fn warm_footprint_does_not_scale_with_partition_count() {
     let (_small_temp, small_dir) = build_single_gen(&schema, 200);
     let small_reg = WarmTableRegistry::new();
     small_reg
-        .warm_readers(&key(), ddl(), &schema, &small_dir, None, &CancelFlag::new())
+        .warm_readers(&key(), ddl(), &schema, None, &small_dir, None, &CancelFlag::new())
         .expect("small generation warms");
     let small_footprint = small_reg.debug_used_bytes();
 
@@ -113,7 +113,7 @@ fn warm_footprint_does_not_scale_with_partition_count() {
     let (large_index_bytes, large_summary_bytes) = sibling_component_sizes(&large_data);
     let large_reg = WarmTableRegistry::new();
     large_reg
-        .warm_readers(&key(), ddl(), &schema, &large_dir, None, &CancelFlag::new())
+        .warm_readers(&key(), ddl(), &schema, None, &large_dir, None, &CancelFlag::new())
         .expect("large generation warms");
     let large_footprint = large_reg.debug_used_bytes();
 

--- a/cqlite-flight/tests/issue_2349_udt_collection_parity.rs
+++ b/cqlite-flight/tests/issue_2349_udt_collection_parity.rs
@@ -1,0 +1,278 @@
+//! Issue #2349: the Flight read path (BOTH cold and warm) must decode a
+//! `frozen<UDT>` cell inside a collection STRUCTURALLY — the #1234 silent
+//! data-loss class — once the table's UDT registry is resolved from the ticket
+//! DDL's `CREATE TYPE` statements and threaded onto every merge reader.
+//!
+//! Oracle: the sstabledump JSONL golden for `test_collections.collections_with_udts`
+//! (`LIST<FROZEN<address_type>>` etc.). Before this fix the cold path rendered
+//! `addresses` as an opaque `List<Utf8>` (the `Custom("udt:address_type")` type
+//! never resolved), losing the per-field structure; now it is a
+//! `List<Struct{street,city,state,zip_code,country}>` whose values match the
+//! golden field-for-field. The warm path (`WarmTableRegistry`) opens its shared
+//! readers with the SAME resolved registry, so it decodes IDENTICALLY — the
+//! warm-vs-cold parity the issue requires.
+//!
+//! Partition `e94f10e8-…` carries a two-element `addresses` list; both elements'
+//! five text fields are asserted verbatim against the golden. The set-element
+//! (`contacts SET<FROZEN<contact_info>>`) column is intentionally NOT projected:
+//! a composite SET element is the separate merged-read limitation tracked by
+//! #2339 (a key-position composite the assembler still fails closed on), out of
+//! this issue's value-position-UDT scope.
+//!
+//! Skips (never fails) when `CQLITE_DATASETS_ROOT` is unset or the `Data.db`
+//! binary is absent (a worktree without `fetch-datasets.sh`), but asserts the
+//! target row IS found and decodes structurally whenever it runs — never a silent
+//! 0-row false pass.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array::{Array, FixedSizeBinaryArray, ListArray, StringArray, StructArray};
+use arrow::compute::concat_batches;
+use arrow::record_batch::RecordBatch;
+
+use cqlite_core::schema::{udt_registry_from_cql, ClusteringColumn, Column, KeyColumn, TableSchema};
+use cqlite_flight::cancel::CancelFlag;
+use cqlite_flight::filter::ScanSpec;
+use cqlite_flight::producer::{DirSource, MergeProducer, SstableSource};
+use cqlite_flight::warm::{ddl_hash, TableKey, WarmTableRegistry};
+
+/// The CREATE TYPE + CREATE TABLE DDL a Trino connector would send for the table
+/// (only the `CREATE TYPE`s drive registry resolution).
+const DDL: &str = "\
+CREATE TYPE address_type (street text, city text, state text, zip_code text, country text); \
+CREATE TYPE contact_info (email text, phone text, address frozen<address_type>); \
+CREATE TABLE collections_with_udts (user_id uuid PRIMARY KEY, addresses list<frozen<address_type>>, \
+contacts set<frozen<contact_info>>, locations_visited map<date, frozen<address_type>>, \
+emergency_contacts map<text, frozen<contact_info>>)";
+
+const TARGET_UUID: &str = "e94f10e8-6d74-4da3-ae2f-e3d92cf68976";
+
+/// The two `addresses` UDT structs for `TARGET_UUID`, verbatim from the golden
+/// JSONL (`nb-1-big-Data.db.jsonl`). Order-insensitive: compared as a sorted set.
+fn golden_addresses() -> Vec<[&'static str; 5]> {
+    vec![
+        [
+            "07372 Mary Shoals Suite 758",
+            "Alyssafurt",
+            "IL",
+            "79107",
+            "British Indian Ocean Territory (Chagos Archipelago)",
+        ],
+        [
+            "13898 Adam Port Suite 788",
+            "East Veronica",
+            "IL",
+            "30919",
+            "Philippines",
+        ],
+    ]
+}
+
+fn col(name: &str, ty: &str) -> Column {
+    Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
+}
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_collections".into(),
+        table: "collections_with_udts".into(),
+        partition_keys: vec![KeyColumn {
+            name: "user_id".into(),
+            data_type: "uuid".into(),
+            position: 0,
+        }],
+        clustering_keys: Vec::<ClusteringColumn>::new(),
+        columns: vec![
+            col("user_id", "uuid"),
+            col("addresses", "list<frozen<address_type>>"),
+            col("contacts", "set<frozen<contact_info>>"),
+            col("locations_visited", "map<date, frozen<address_type>>"),
+            col("emergency_contacts", "map<text, frozen<contact_info>>"),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Projection excludes the composite-SET column `contacts` (#2339), keeping the
+/// value-position UDT columns this issue fixes.
+fn spec() -> ScanSpec {
+    ScanSpec {
+        token: None,
+        filter: None,
+        projection: Some(vec!["user_id".into(), "addresses".into()]),
+        limit: None,
+    }
+}
+
+fn uuid_bytes(s: &str) -> [u8; 16] {
+    let hex: String = s.chars().filter(|c| *c != '-').collect();
+    let mut out = [0u8; 16];
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).expect("hex");
+    }
+    out
+}
+
+fn table_dir() -> Option<PathBuf> {
+    let root = std::env::var_os("CQLITE_DATASETS_ROOT")?;
+    let dir = PathBuf::from(&root)
+        .join("sstables")
+        .join("test_collections")
+        .join("collections_with_udts-6bc2bae0a25111f0a3fef1a551383fb9");
+    if dir.join("nb-1-big-Data.db").is_file() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+fn producer() -> MergeProducer {
+    MergeProducer::with_spec(schema(), 64, spec())
+        .unwrap()
+        .with_udt_registry(udt_registry_from_cql(DDL, "test_collections"))
+}
+
+/// Extract the `addresses` `List<Struct{...}>` value for the target partition as a
+/// sorted set of `[street,city,state,zip_code,country]` rows.
+fn decoded_addresses(combined: &RecordBatch, target: &[u8; 16]) -> Vec<[String; 5]> {
+    let id_idx = combined.schema().index_of("user_id").expect("user_id");
+    let ids = combined
+        .column(id_idx)
+        .as_any()
+        .downcast_ref::<FixedSizeBinaryArray>()
+        .expect("user_id FixedSizeBinary(16)");
+    let row = (0..combined.num_rows())
+        .find(|&r| ids.value(r) == target.as_slice())
+        .expect("target partition row present (never a 0-row false pass)");
+
+    let addr_idx = combined.schema().index_of("addresses").expect("addresses");
+    let list = combined
+        .column(addr_idx)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .expect("addresses must decode as a List (registry resolved), not opaque bytes");
+    let structs = list.value(row);
+    let structs = structs
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .expect("addresses elements must be Struct (frozen<UDT> resolved), not Utf8/Binary");
+
+    let field = |name: &str| -> StringArray {
+        structs
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("UDT field '{name}' present in the Struct"))
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap_or_else(|| panic!("UDT field '{name}' is Utf8"))
+            .clone()
+    };
+    let (street, city, state, zip, country) = (
+        field("street"),
+        field("city"),
+        field("state"),
+        field("zip_code"),
+        field("country"),
+    );
+    let mut out: Vec<[String; 5]> = (0..structs.len())
+        .map(|i| {
+            [
+                street.value(i).to_string(),
+                city.value(i).to_string(),
+                state.value(i).to_string(),
+                zip.value(i).to_string(),
+                country.value(i).to_string(),
+            ]
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn expected_sorted() -> Vec<[String; 5]> {
+    let mut want: Vec<[String; 5]> =
+        golden_addresses().into_iter().map(|a| a.map(String::from)).collect();
+    want.sort();
+    want
+}
+
+/// COLD path (`produce_from_paths` → `KWayMerger::new_with_gc_and_registry_cancellable`).
+#[test]
+fn cold_path_decodes_udt_in_collection_matching_golden() {
+    let Some(dir) = table_dir() else {
+        eprintln!("collections_with_udts Data.db absent — skipping (run fetch-datasets.sh)");
+        return;
+    };
+    let producer = producer();
+    let batches = producer
+        .produce_from_paths(DirSource::new(&dir).data_paths().unwrap())
+        .unwrap();
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert!(rows > 0, "cold scan must return rows (never a 0-row false pass)");
+
+    let arrow_schema = producer.arrow_schema().unwrap();
+    let combined = concat_batches(&arrow_schema.into(), &batches).unwrap();
+    assert_eq!(
+        decoded_addresses(&combined, &uuid_bytes(TARGET_UUID)),
+        expected_sorted(),
+        "cold path: addresses frozen<UDT> list must decode field-for-field to the golden"
+    );
+}
+
+/// WARM path (`WarmTableRegistry` shared readers → `produce_streaming_from_readers`).
+/// Opens the warm reader set WITH the same resolved registry, proving warm and
+/// cold decode IDENTICALLY (issue #2349 parity requirement).
+#[test]
+fn warm_path_decodes_udt_in_collection_matching_cold_and_golden() {
+    let Some(dir) = table_dir() else {
+        eprintln!("collections_with_udts Data.db absent — skipping (run fetch-datasets.sh)");
+        return;
+    };
+    let producer = producer();
+    let schema = schema();
+    let registry = udt_registry_from_cql(DDL, "test_collections");
+
+    let warm = WarmTableRegistry::new();
+    let key = TableKey::new("test_collections", "collections_with_udts");
+    let set = warm
+        .warm_readers(
+            &key,
+            ddl_hash(DDL),
+            &schema,
+            Some(&registry),
+            &dir,
+            None,
+            &CancelFlag::new(),
+        )
+        .expect("warm readers");
+    assert!(!set.readers.is_empty(), "warm set has readers");
+    for r in &set.readers {
+        assert!(
+            r.has_udt_registry(),
+            "warm readers must carry the resolved registry (parity with cold, #2349)"
+        );
+    }
+
+    let readers: Vec<Arc<_>> = set.readers.clone();
+    let batches = producer
+        .produce_streaming_from_readers_to_vec(readers, &CancelFlag::new())
+        .unwrap();
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert!(rows > 0, "warm scan must return rows (never a 0-row false pass)");
+
+    let arrow_schema = producer.arrow_schema().unwrap();
+    let combined = concat_batches(&arrow_schema.into(), &batches).unwrap();
+    assert_eq!(
+        decoded_addresses(&combined, &uuid_bytes(TARGET_UUID)),
+        expected_sorted(),
+        "warm path: addresses frozen<UDT> list must decode identically to cold + golden"
+    );
+}

--- a/cqlite-flight/tests/issue_2349_udt_collection_parity.rs
+++ b/cqlite-flight/tests/issue_2349_udt_collection_parity.rs
@@ -124,17 +124,42 @@ fn uuid_bytes(s: &str) -> [u8; 16] {
     out
 }
 
+/// Resolve the `collections_with_udts-<cfid>` table dir by GLOB (issue #2349,
+/// roborev job 1924 blocker 4) — never pinned to one CFID, so a dataset regen
+/// (which mints a new CFID) does not silently turn this into a permanent skip.
+///
+/// Returns `None` (a legitimate skip) ONLY when `CQLITE_DATASETS_ROOT` is unset or
+/// the keyspace dir is absent (a worktree without `fetch-datasets.sh`). When the
+/// keyspace dir DOES exist but no `collections_with_udts-*` dir with a `Data.db` is
+/// found, it PANICS — the fixture moved/regressed, which must fail loudly, not skip.
 fn table_dir() -> Option<PathBuf> {
     let root = std::env::var_os("CQLITE_DATASETS_ROOT")?;
-    let dir = PathBuf::from(&root)
+    let ks_dir = PathBuf::from(&root)
         .join("sstables")
-        .join("test_collections")
-        .join("collections_with_udts-6bc2bae0a25111f0a3fef1a551383fb9");
-    if dir.join("nb-1-big-Data.db").is_file() {
-        Some(dir)
-    } else {
-        None
+        .join("test_collections");
+    if !ks_dir.is_dir() {
+        return None;
     }
+    let mut found: Option<PathBuf> = None;
+    for entry in std::fs::read_dir(&ks_dir)
+        .expect("read test_collections dir")
+        .flatten()
+    {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("collections_with_udts-")
+            && entry.path().join("nb-1-big-Data.db").is_file()
+        {
+            found = Some(entry.path());
+            break;
+        }
+    }
+    assert!(
+        found.is_some(),
+        "test_collections dir exists but no collections_with_udts-*/nb-1-big-Data.db found \
+         at {ks_dir:?} — the UDT-in-collection fixture moved or regressed (do NOT silently skip)"
+    );
+    found
 }
 
 fn producer() -> MergeProducer {

--- a/cqlite-flight/tests/issue_2349_udt_collection_parity.rs
+++ b/cqlite-flight/tests/issue_2349_udt_collection_parity.rs
@@ -147,19 +147,29 @@ fn table_dir() -> Option<PathBuf> {
     {
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if name.starts_with("collections_with_udts-")
-            && entry.path().join("nb-1-big-Data.db").is_file()
-        {
+        // Glob both the CFID (a regen mints a new one) AND the Data.db component
+        // name (`nb-*`/`da-*`, any generation) so a fixture regen can never turn
+        // this into a hard false failure (roborev job 1925 item 3).
+        if name.starts_with("collections_with_udts-") && has_data_db(&entry.path()) {
             found = Some(entry.path());
             break;
         }
     }
     assert!(
         found.is_some(),
-        "test_collections dir exists but no collections_with_udts-*/nb-1-big-Data.db found \
+        "test_collections dir exists but no collections_with_udts-*/*-Data.db found \
          at {ks_dir:?} — the UDT-in-collection fixture moved or regressed (do NOT silently skip)"
     );
     found
+}
+
+/// Whether `dir` holds any `*-Data.db` SSTable component (any version/generation).
+fn has_data_db(dir: &std::path::Path) -> bool {
+    std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .any(|e| e.file_name().to_string_lossy().ends_with("-Data.db"))
 }
 
 fn producer() -> MergeProducer {
@@ -309,5 +319,68 @@ fn warm_path_decodes_udt_in_collection_matching_cold_and_golden() {
         decoded_addresses(&combined, &uuid_bytes(TARGET_UUID)),
         expected_sorted(),
         "warm path: addresses frozen<UDT> list must decode identically to cold + golden"
+    );
+}
+
+/// Aggregate/group-by UDT-column resolution (roborev job 1925 item 4). A
+/// `GROUP BY` on a top-level `frozen<address_type>` column puts a UDT-typed column
+/// in the PARTIAL output. Under the PRODUCTION order (`with_udt_registry` THEN
+/// `with_aggregation`, as `service.rs` builds it) that partial column must resolve
+/// to an Arrow `Struct`, not opaque `Utf8` — else the aggregate schema silently
+/// disagrees with the emitted arrays. The reverse order must yield an IDENTICAL
+/// schema. Pure schema assertion — no SSTable read, so it never skips.
+#[test]
+fn aggregate_udt_group_by_column_resolves_to_struct_both_orders() {
+    use arrow::datatypes::DataType;
+
+    // id uuid PRIMARY KEY, home frozen<address_type>.
+    let schema = TableSchema {
+        keyspace: "test_collections".into(),
+        table: "udt_agg".into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "uuid".into(),
+            position: 0,
+        }],
+        clustering_keys: Vec::<ClusteringColumn>::new(),
+        columns: vec![col("id", "uuid"), col("home", "frozen<address_type>")],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    };
+    // GROUP BY home, count(*) AS cnt.
+    let aggregation: cqlite_flight::ticket::Aggregation =
+        serde_json::from_value(serde_json::json!({
+            "group_by": ["home"],
+            "aggregates": [{"func": "Count", "column": null, "output": "cnt"}]
+        }))
+        .expect("aggregation");
+    let registry = || udt_registry_from_cql(DDL, "test_collections");
+
+    // PRODUCTION order: registry first, then aggregation.
+    let prod = MergeProducer::with_spec(schema.clone(), 64, ScanSpec::default())
+        .unwrap()
+        .with_udt_registry(registry())
+        .with_aggregation(&aggregation)
+        .unwrap();
+    let prod_schema = prod.arrow_schema().unwrap();
+    let home = prod_schema
+        .field_with_name("home")
+        .expect("home in partial schema");
+    assert!(
+        matches!(home.data_type(), DataType::Struct(_)),
+        "production order: UDT group-by column must resolve to Struct, got {:?}",
+        home.data_type()
+    );
+
+    // REVERSE order: aggregation first, then registry — must be identical.
+    let rev = MergeProducer::with_spec(schema, 64, ScanSpec::default())
+        .unwrap()
+        .with_aggregation(&aggregation)
+        .unwrap()
+        .with_udt_registry(registry());
+    assert_eq!(
+        prod_schema,
+        rev.arrow_schema().unwrap(),
+        "both builder orders must yield an identical aggregate Arrow schema (#2349)"
     );
 }

--- a/cqlite-flight/tests/issue_2349_udt_collection_parity.rs
+++ b/cqlite-flight/tests/issue_2349_udt_collection_parity.rs
@@ -32,7 +32,9 @@ use arrow::array::{Array, FixedSizeBinaryArray, ListArray, StringArray, StructAr
 use arrow::compute::concat_batches;
 use arrow::record_batch::RecordBatch;
 
-use cqlite_core::schema::{udt_registry_from_cql, ClusteringColumn, Column, KeyColumn, TableSchema};
+use cqlite_core::schema::{
+    udt_registry_from_cql, ClusteringColumn, Column, KeyColumn, TableSchema,
+};
 use cqlite_flight::cancel::CancelFlag;
 use cqlite_flight::filter::ScanSpec;
 use cqlite_flight::producer::{DirSource, MergeProducer, SstableSource};
@@ -198,8 +200,10 @@ fn decoded_addresses(combined: &RecordBatch, target: &[u8; 16]) -> Vec<[String; 
 }
 
 fn expected_sorted() -> Vec<[String; 5]> {
-    let mut want: Vec<[String; 5]> =
-        golden_addresses().into_iter().map(|a| a.map(String::from)).collect();
+    let mut want: Vec<[String; 5]> = golden_addresses()
+        .into_iter()
+        .map(|a| a.map(String::from))
+        .collect();
     want.sort();
     want
 }
@@ -216,7 +220,10 @@ fn cold_path_decodes_udt_in_collection_matching_golden() {
         .produce_from_paths(DirSource::new(&dir).data_paths().unwrap())
         .unwrap();
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-    assert!(rows > 0, "cold scan must return rows (never a 0-row false pass)");
+    assert!(
+        rows > 0,
+        "cold scan must return rows (never a 0-row false pass)"
+    );
 
     let arrow_schema = producer.arrow_schema().unwrap();
     let combined = concat_batches(&arrow_schema.into(), &batches).unwrap();
@@ -266,7 +273,10 @@ fn warm_path_decodes_udt_in_collection_matching_cold_and_golden() {
         .produce_streaming_from_readers_to_vec(readers, &CancelFlag::new())
         .unwrap();
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-    assert!(rows > 0, "warm scan must return rows (never a 0-row false pass)");
+    assert!(
+        rows > 0,
+        "warm scan must return rows (never a 0-row false pass)"
+    );
 
     let arrow_schema = producer.arrow_schema().unwrap();
     let combined = concat_batches(&arrow_schema.into(), &batches).unwrap();


### PR DESCRIPTION
Closes #2349 (UDT registry unwired in flight reads).

## What
The cold flight path opened SSTable readers with `udt_registry = None` (and warm matched it by design, #2310), so UDT-in-collection cells decoded via the non-UDT-aware branch on all flight reads — the #1234 silent-data-loss class. This wires a resolved registry into BOTH paths together:

- `udt_registry_from_cql` (one authoritative DDL→registry resolver, reused by CLI + Flight) parses `CREATE TYPE` from the ticket DDL; `UdtRegistry::resolve_type` rewrites `Custom("udt:X")` → `Udt(X, fields)` recursively (schema-authoritative, no-heuristics #28; bare node name preserved for consumer compatibility).
- Registry built once per producer and threaded to the cold merger (`KWayMerger::new_with_gc_and_registry_cancellable`) AND `warm_readers` — same object, so warm/cold cannot diverge; posture test asserts both flip together.
- `with_udt_registry`/`with_aggregation` both resolve partial/group-by columns (either chaining order safe).

## Parity evidence (the oracle)
- `cqlite-flight/tests/issue_2349_udt_collection_parity.rs`: cold AND warm decode `collections_with_udts` `addresses list<frozen<address_type>>` field-for-field vs the sstabledump golden; fails (never skips) when the keyspace dir exists without the fixture; fixture glob de-brittled (`collections_with_udts-*`, any `*-Data.db`).
- Warm-vs-cold posture test green (both paths flip together); 8 resolver unit tests; aggregate UDT group-by → Arrow `Struct` under both chaining orders.

## Review trail (review-first, #2086)
- rust-reviewer: CLEAN (2 nits).
- roborev jobs 1924 → 1925 → 1926 (direct per-commit; branch-mode job 1923 = known worktree merge-base false-empty-diff, ignored). All blockers fixed across two rounds; job 1926 confirms prior blockers genuinely addressed, 3 Lows remain (nits).
- All nits batched to a linked follow-up issue (filed at merge time per #2088).

Known pre-existing limitation (out of scope, projected out of the oracle): composite `SET<FROZEN<udt>>` map/set-key elements still fail closed on the merged-read path (#2339).

Lite-green @ 7a37898cd (`/tmp/gate-lite-2349d.txt`). The full gate of record runs in flow-closer pre-merge.