### PR TITLE
fix(#2751): nested tooling-tests self-test gates no longer clobber the parent's summary file

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1569,7 +1569,14 @@ esac
 # child. The wrapper re-exec (which must preserve the caller's path) already ran
 # above this line, so it is unaffected. The self-test scripts also scrub it
 # themselves (belt-and-suspenders, #2751).
-export -n AGENT_GATE_SUMMARY_FILE 2>/dev/null || true
+# Visible fallback (#2751 roborev r2): this clobber fix was filed FOR a silent
+# failure, so it must not itself fail silently. If `export -n` errors on some shell,
+# fall back to a plain `unset` (which fully removes it from the env — an even
+# stronger scrub) and log one warning line, rather than swallowing it with `|| true`.
+if ! export -n AGENT_GATE_SUMMARY_FILE 2>/dev/null; then
+  echo "agent-gate: WARN export -n AGENT_GATE_SUMMARY_FILE failed; unsetting instead (#2751)" >&2
+  unset AGENT_GATE_SUMMARY_FILE
+fi
 # Keep a copy under the logs bundle for archival.
 LOG_SUMMARY_FILE="$LOG_DIR/summary.txt"
 declare -a NAMES=() STATUSES=() TIMES=()

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2407,6 +2407,21 @@ run_tooling_tests() {
   start=$(date +%s)
   : >"$log"
 
+  # #2751: EVERY self-test below may recursively invoke agent-gate.sh — the --delta
+  # self-test's temp-repo `--delta` runs, the summary self-test's
+  # `--emit-summary-selftest` runs, the parity-report/oom-audit `--only` runs. A
+  # nested gate that INHERITED this gate's AGENT_GATE_SUMMARY_FILE would overwrite
+  # our summary file mid-run with a FOREIGN verdict — a DELTA REFUSED block, or the
+  # startup INCOMPLETE placeholder stamped with the child's run-id (field impact:
+  # #2672 read a foreign verdict; #2600's full gate died here leaving an INCOMPLETE
+  # foreign-run-id placeholder, costing a 57-min re-run). SUMMARY_FILE is already
+  # resolved into the PARENT's own var (and emit_summary + the startup sentinel both
+  # write SUMMARY_FILE, never re-reading this env var), so the env var has served
+  # its purpose: de-export it here so NO child spawned by this component can inherit
+  # the parent's path (equivalent to `env -u AGENT_GATE_SUMMARY_FILE` on each child).
+  # The self-test scripts also scrub it themselves (belt-and-suspenders, #2751).
+  export -n AGENT_GATE_SUMMARY_FILE 2>/dev/null || true
+
   # generator keyspace-scoping guard (#1232): no python3 needed, always runs. A
   # failure here FAILs the component, mirroring the summary selftest semantics.
   echo ">>> [$name] bash scripts/tests/test_generator_keyspace_scoping.sh"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1554,6 +1554,22 @@ case "$SUMMARY_FILE" in
   /*) ;; # absolute (incl. the repo-root default) -> use verbatim
   *)  SUMMARY_FILE="$INVOCATION_CWD/$SUMMARY_FILE" ;;
 esac
+# #2751: the summary path is now fully resolved into SUMMARY_FILE (the parent's own
+# var). Both the startup INCOMPLETE sentinel below and emit_summary write
+# SUMMARY_FILE and NEVER re-read AGENT_GATE_SUMMARY_FILE, so the env var has served
+# its whole purpose. De-export it here — ONE scrub after resolution, before any
+# component runs — so NO child this gate spawns (present or future) can inherit the
+# parent's path and clobber the summary file mid-run with a foreign verdict. The
+# tooling-tests self-tests recursively invoke agent-gate.sh (the --delta self-test's
+# temp-repo runs, the summary self-test's --emit-summary-selftest runs); a nested
+# gate that inherited this path would overwrite our file with a DELTA REFUSED block
+# or a foreign-run-id INCOMPLETE placeholder (field impact: #2672 read a foreign
+# verdict; #2600's full gate died in tooling-tests leaving such a placeholder,
+# costing a 57-min re-run). Equivalent to `env -u AGENT_GATE_SUMMARY_FILE` on every
+# child. The wrapper re-exec (which must preserve the caller's path) already ran
+# above this line, so it is unaffected. The self-test scripts also scrub it
+# themselves (belt-and-suspenders, #2751).
+export -n AGENT_GATE_SUMMARY_FILE 2>/dev/null || true
 # Keep a copy under the logs bundle for archival.
 LOG_SUMMARY_FILE="$LOG_DIR/summary.txt"
 declare -a NAMES=() STATUSES=() TIMES=()
@@ -2407,20 +2423,10 @@ run_tooling_tests() {
   start=$(date +%s)
   : >"$log"
 
-  # #2751: EVERY self-test below may recursively invoke agent-gate.sh — the --delta
-  # self-test's temp-repo `--delta` runs, the summary self-test's
-  # `--emit-summary-selftest` runs, the parity-report/oom-audit `--only` runs. A
-  # nested gate that INHERITED this gate's AGENT_GATE_SUMMARY_FILE would overwrite
-  # our summary file mid-run with a FOREIGN verdict — a DELTA REFUSED block, or the
-  # startup INCOMPLETE placeholder stamped with the child's run-id (field impact:
-  # #2672 read a foreign verdict; #2600's full gate died here leaving an INCOMPLETE
-  # foreign-run-id placeholder, costing a 57-min re-run). SUMMARY_FILE is already
-  # resolved into the PARENT's own var (and emit_summary + the startup sentinel both
-  # write SUMMARY_FILE, never re-reading this env var), so the env var has served
-  # its purpose: de-export it here so NO child spawned by this component can inherit
-  # the parent's path (equivalent to `env -u AGENT_GATE_SUMMARY_FILE` on each child).
-  # The self-test scripts also scrub it themselves (belt-and-suspenders, #2751).
-  export -n AGENT_GATE_SUMMARY_FILE 2>/dev/null || true
+  # NOTE (#2751): AGENT_GATE_SUMMARY_FILE is already de-exported once after summary
+  # resolution (see the scrub near the SUMMARY_FILE `case` block), so none of the
+  # self-tests below — several of which recursively invoke agent-gate.sh — can
+  # inherit the parent's summary path and clobber it. No per-component scrub needed.
 
   # generator keyspace-scoping guard (#1232): no python3 needed, always runs. A
   # failure here FAILs the component, mirroring the summary selftest semantics.

--- a/scripts/tests/test_agent_gate_delta.sh
+++ b/scripts/tests/test_agent_gate_delta.sh
@@ -36,6 +36,17 @@ set -uo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 GATE="$SCRIPT_DIR/../agent-gate.sh"
 
+# #2751 defense-in-depth: this self-test recursively invokes the REAL gate — the
+# temp-repo `--delta` runs below (rename-refuses, node-build-refuse) spawn
+# agent-gate.sh WITHOUT an explicit AGENT_GATE_SUMMARY_FILE, so an inherited value
+# would make them write the DELTA REFUSED / startup INCOMPLETE block to the
+# caller's summary file (the tooling-tests clobber, #2751). Scrub any inherited
+# path up front so those nested gates fall back to their OWN (temp-repo) default,
+# never clobbering the caller — even when this script is run standalone by an agent
+# who has AGENT_GATE_SUMMARY_FILE exported. Per-case invocations below that pin
+# AGENT_GATE_SUMMARY_FILE="$tmp/..." set it fresh and are unaffected.
+unset AGENT_GATE_SUMMARY_FILE
+
 DELTA_START="==== AGENT-GATE DELTA SUMMARY ===="
 DELTA_END="==== END AGENT-GATE DELTA SUMMARY ===="
 FULL_START="==== AGENT-GATE SUMMARY ===="

--- a/scripts/tests/test_agent_gate_oom_audit.sh
+++ b/scripts/tests/test_agent_gate_oom_audit.sh
@@ -22,6 +22,12 @@ set -uo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 GATE="$SCRIPT_DIR/../agent-gate.sh"
 
+# #2751 defense-in-depth: this self-test drives nested `agent-gate.sh --only
+# oom-audit` runs. Each case below pins its own AGENT_GATE_SUMMARY_FILE, but scrub
+# any inherited value up front so a standalone run can never clobber the caller's
+# summary file (the tooling-tests component scrubs it too).
+unset AGENT_GATE_SUMMARY_FILE
+
 PASS=0
 FAIL=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }

--- a/scripts/tests/test_agent_gate_parity_report.sh
+++ b/scripts/tests/test_agent_gate_parity_report.sh
@@ -23,6 +23,11 @@ set -uo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 GATE="$SCRIPT_DIR/../agent-gate.sh"
+# #2751 defense-in-depth: this self-test drives nested `agent-gate.sh --only
+# parity-report` runs. Each case below pins its own AGENT_GATE_SUMMARY_FILE, but
+# scrub any inherited value up front so a standalone run can never clobber the
+# caller's summary file (the tooling-tests component scrubs it too).
+unset AGENT_GATE_SUMMARY_FILE
 REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 MANIFEST="$REPO_ROOT/test-data/cassandra-parity-manifest.yml"
 REPORT_REL="docs/reports/cassandra-test-parity.md"

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -997,14 +997,23 @@ fi
 #       14b behavioral — the scrub mechanism actually prevents the clobber, with a
 #           negative control proving the clobber is real (so 14b cannot pass vacuously).
 
-# 14a. STRUCTURAL: extract the run_tooling_tests body (top-level `}` ends it, same
-#      awk idiom as 7e/13e) and assert it de-exports / env -u's AGENT_GATE_SUMMARY_FILE.
-tt_body=$(awk '/^run_tooling_tests\(\)/{f=1} f{print} f&&/^\}/{exit}' "$GATE")
-if printf '%s\n' "$tt_body" | grep -v '^[[:space:]]*#' \
-     | grep -Eq 'export -n AGENT_GATE_SUMMARY_FILE|env -u AGENT_GATE_SUMMARY_FILE'; then
-  ok "2751-structural: run_tooling_tests scrubs AGENT_GATE_SUMMARY_FILE from nested self-tests"
+# 14a. STRUCTURAL (property, not location): the gate must scrub
+#      AGENT_GATE_SUMMARY_FILE from the environment exactly ONCE, AFTER the summary
+#      path is resolved into the parent's own var and BEFORE any component runs — so
+#      no child (present or future) can inherit the path. We assert the property by
+#      line ordering rather than pinning to a single component: the (non-comment)
+#      scrub line exists, sits AFTER the `case "$SUMMARY_FILE"` resolution, and
+#      BEFORE the component runner (`run_component() {`) is even defined. FAILs if
+#      the scrub line is deleted.
+scrub_ln=$(grep -nE '^[[:space:]]*(export -n|env -u) AGENT_GATE_SUMMARY_FILE' "$GATE" \
+             | grep -v ':[[:space:]]*#' | head -1 | cut -d: -f1)
+resolve_ln=$(grep -n '^case "\$SUMMARY_FILE" in' "$GATE" | head -1 | cut -d: -f1)
+dispatch_ln=$(grep -n '^run_component() {' "$GATE" | head -1 | cut -d: -f1)
+if [ -n "$scrub_ln" ] && [ -n "$resolve_ln" ] && [ -n "$dispatch_ln" ] \
+   && [ "$scrub_ln" -gt "$resolve_ln" ] && [ "$scrub_ln" -lt "$dispatch_ln" ]; then
+  ok "2751-structural: gate scrubs AGENT_GATE_SUMMARY_FILE after summary resolution and before component dispatch (line $scrub_ln)"
 else
-  bad "2751-structural: run_tooling_tests no longer scrubs AGENT_GATE_SUMMARY_FILE — nested gates can clobber the parent summary"
+  bad "2751-structural: no AGENT_GATE_SUMMARY_FILE scrub in the resolved-but-pre-dispatch region (scrub=$scrub_ln resolve=$resolve_ln dispatch=$dispatch_ln) — nested gates can clobber the parent summary"
 fi
 
 # 14b. BEHAVIORAL: copy the gate into a bare temp dir (hermetic — --emit-summary-selftest
@@ -1016,22 +1025,29 @@ SENTINEL="PARENT-OWNED-SUMMARY-2751-DO-NOT-CLOBBER"
 
 # Negative control: a nested gate that INHERITS an exported AGENT_GATE_SUMMARY_FILE
 # overwrites it. This makes the positive assertion meaningful (proves the clobber is
-# real and reachable, so 14b cannot pass just because nothing wrote anywhere).
+# real and reachable, so 14b cannot pass just because nothing wrote anywhere). We
+# assert BOTH that the sentinel is gone AND that a real gate summary marker now
+# occupies the file — so a "file vanished/emptied" outcome cannot pass the control.
 clob="$tmp/2751-parent-clobber.txt"
 printf '%s\n' "$SENTINEL" >"$clob"
 ( export AGENT_GATE_SUMMARY_FILE="$clob"; cd "$tt_repo" \
     && bash scripts/agent-gate.sh --emit-summary-selftest ) >/dev/null 2>&1
-if grep -q "$SENTINEL" "$clob" 2>/dev/null; then
-  bad "2751-clobber-control: an INHERITED AGENT_GATE_SUMMARY_FILE was NOT overwritten — behavioral control invalid"
-  echo "------- on disk -------"; cat "$clob" 2>/dev/null; echo "-----------------------"
+if ! grep -q "$SENTINEL" "$clob" 2>/dev/null \
+   && grep -q "$END_MARKER" "$clob" 2>/dev/null; then
+  ok "2751-clobber-control: a nested gate with an inherited summary path OVERWRITES it with a gate summary (clobber is real)"
 else
-  ok "2751-clobber-control: a nested gate with an inherited summary path DOES overwrite it (clobber is real)"
+  bad "2751-clobber-control: the inherited path was not overwritten with a gate summary — behavioral control invalid"
+  echo "------- on disk -------"; cat "$clob" 2>/dev/null; echo "-----------------------"
 fi
 
-# Positive: with the scrub (env -u, exactly as run_tooling_tests applies it) the
-# parent's chosen path is untouched, and the scrubbed child writes its OWN default.
+# Positive: with the scrub (env -u, exactly as the gate applies it after summary
+# resolution) the parent's chosen path is untouched, and the scrubbed child writes
+# its OWN default. Remove any prior default first so the "child wrote its own
+# default" assertion can never pass on a stale file (from the negative control or a
+# future case) — it must be (re)created by THIS invocation.
 safe="$tmp/2751-parent-safe.txt"
 printf '%s\n' "$SENTINEL" >"$safe"
+rm -f "$tt_repo/.agent-gate-summary.txt"
 ( export AGENT_GATE_SUMMARY_FILE="$safe"; cd "$tt_repo" \
     && env -u AGENT_GATE_SUMMARY_FILE bash scripts/agent-gate.sh --emit-summary-selftest ) >/dev/null 2>&1
 if grep -q "$SENTINEL" "$safe" 2>/dev/null; then
@@ -1040,13 +1056,19 @@ else
   bad "2751-scrub-prevents-clobber: the parent's summary file was clobbered despite the scrub"
   echo "------- on disk -------"; cat "$safe" 2>/dev/null; echo "-----------------------"
 fi
-# The scrubbed child must still have emitted a summary — at its OWN repo-root
-# default — proving it ran fully and simply wrote elsewhere, not that it no-op'd.
-if [ -s "$tt_repo/.agent-gate-summary.txt" ] \
-   && ! grep -q "$SENTINEL" "$tt_repo/.agent-gate-summary.txt" 2>/dev/null; then
-  ok "2751-scrub-prevents-clobber: the scrubbed child wrote its own repo-root default summary instead"
+# The scrubbed child must still have emitted a COMPLETED summary — at its OWN
+# repo-root default, (re)created by this run — proving it ran fully and simply wrote
+# elsewhere, not that it no-op'd or left only the startup INCOMPLETE sentinel.
+child_default="$tt_repo/.agent-gate-summary.txt"
+if [ -f "$child_default" ] \
+   && grep -q "$END_MARKER" "$child_default" 2>/dev/null \
+   && grep -q "^RESULT: " "$child_default" 2>/dev/null \
+   && ! grep -q "RESULT: INCOMPLETE" "$child_default" 2>/dev/null \
+   && ! grep -q "$SENTINEL" "$child_default" 2>/dev/null; then
+  ok "2751-scrub-prevents-clobber: the scrubbed child wrote a COMPLETED summary at its own repo-root default instead"
 else
-  bad "2751-scrub-prevents-clobber: the scrubbed child produced no summary at its own default path"
+  bad "2751-scrub-prevents-clobber: the scrubbed child's own-default summary is missing/incomplete"
+  echo "------- on disk -------"; cat "$child_default" 2>/dev/null; echo "-----------------------"
 fi
 
 echo "----"

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -15,6 +15,13 @@ set -uo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 GATE="$SCRIPT_DIR/../agent-gate.sh"
+
+# #2751 defense-in-depth: scrub any AGENT_GATE_SUMMARY_FILE inherited from the
+# caller before doing anything. Every case below pins its OWN caller-known path
+# per-invocation, so a top-level unset only removes a leaked value that could
+# otherwise be clobbered when this script is run standalone by an agent who has the
+# var exported (the tooling-tests component scrubs it too — belt-and-suspenders).
+unset AGENT_GATE_SUMMARY_FILE
 START_MARKER="==== AGENT-GATE SUMMARY ===="
 END_MARKER="==== END AGENT-GATE SUMMARY ===="
 STAGE_LINE="fmt:" # representative stage line from the selftest block
@@ -975,6 +982,71 @@ if printf '%s\n' "$rl_body" | grep -v '^[[:space:]]*#' | grep -q 'aggregate_lite
   ok "2121-structural: run_lite invokes aggregate_lite_components (lite OVERALL aggregation single-sourced)"
 else
   bad "2121-structural: run_lite no longer calls aggregate_lite_components — lite OVERALL aggregation lost"
+fi
+
+# 14. NESTED-GATE SUMMARY CLOBBER (#2751): the tooling-tests component runs
+#     self-test scripts that recursively invoke agent-gate.sh (the --delta
+#     self-test's temp-repo `--delta` runs, this script's `--emit-summary-selftest`
+#     runs). If a nested gate INHERITS the parent gate's AGENT_GATE_SUMMARY_FILE it
+#     overwrites the parent's summary file mid-run with a foreign verdict (field
+#     impact: #2672 read a foreign DELTA REFUSED block; #2600's full gate died in
+#     tooling-tests leaving an INCOMPLETE placeholder with a foreign run-id, costing
+#     a 57-min re-run). run_tooling_tests must scrub AGENT_GATE_SUMMARY_FILE so no
+#     child can inherit it. Two halves prove the fix and make it un-removable:
+#       14a structural — run_tooling_tests applies the scrub (FAILs if removed);
+#       14b behavioral — the scrub mechanism actually prevents the clobber, with a
+#           negative control proving the clobber is real (so 14b cannot pass vacuously).
+
+# 14a. STRUCTURAL: extract the run_tooling_tests body (top-level `}` ends it, same
+#      awk idiom as 7e/13e) and assert it de-exports / env -u's AGENT_GATE_SUMMARY_FILE.
+tt_body=$(awk '/^run_tooling_tests\(\)/{f=1} f{print} f&&/^\}/{exit}' "$GATE")
+if printf '%s\n' "$tt_body" | grep -v '^[[:space:]]*#' \
+     | grep -Eq 'export -n AGENT_GATE_SUMMARY_FILE|env -u AGENT_GATE_SUMMARY_FILE'; then
+  ok "2751-structural: run_tooling_tests scrubs AGENT_GATE_SUMMARY_FILE from nested self-tests"
+else
+  bad "2751-structural: run_tooling_tests no longer scrubs AGENT_GATE_SUMMARY_FILE — nested gates can clobber the parent summary"
+fi
+
+# 14b. BEHAVIORAL: copy the gate into a bare temp dir (hermetic — --emit-summary-selftest
+#      needs no cargo/git and writes to its OWN repo-root default when the path is unset).
+tt_repo="$tmp/2751-scrub-repo"
+mkdir -p "$tt_repo/scripts"
+cp "$GATE" "$tt_repo/scripts/agent-gate.sh"
+SENTINEL="PARENT-OWNED-SUMMARY-2751-DO-NOT-CLOBBER"
+
+# Negative control: a nested gate that INHERITS an exported AGENT_GATE_SUMMARY_FILE
+# overwrites it. This makes the positive assertion meaningful (proves the clobber is
+# real and reachable, so 14b cannot pass just because nothing wrote anywhere).
+clob="$tmp/2751-parent-clobber.txt"
+printf '%s\n' "$SENTINEL" >"$clob"
+( export AGENT_GATE_SUMMARY_FILE="$clob"; cd "$tt_repo" \
+    && bash scripts/agent-gate.sh --emit-summary-selftest ) >/dev/null 2>&1
+if grep -q "$SENTINEL" "$clob" 2>/dev/null; then
+  bad "2751-clobber-control: an INHERITED AGENT_GATE_SUMMARY_FILE was NOT overwritten — behavioral control invalid"
+  echo "------- on disk -------"; cat "$clob" 2>/dev/null; echo "-----------------------"
+else
+  ok "2751-clobber-control: a nested gate with an inherited summary path DOES overwrite it (clobber is real)"
+fi
+
+# Positive: with the scrub (env -u, exactly as run_tooling_tests applies it) the
+# parent's chosen path is untouched, and the scrubbed child writes its OWN default.
+safe="$tmp/2751-parent-safe.txt"
+printf '%s\n' "$SENTINEL" >"$safe"
+( export AGENT_GATE_SUMMARY_FILE="$safe"; cd "$tt_repo" \
+    && env -u AGENT_GATE_SUMMARY_FILE bash scripts/agent-gate.sh --emit-summary-selftest ) >/dev/null 2>&1
+if grep -q "$SENTINEL" "$safe" 2>/dev/null; then
+  ok "2751-scrub-prevents-clobber: env -u AGENT_GATE_SUMMARY_FILE leaves the parent's summary file intact"
+else
+  bad "2751-scrub-prevents-clobber: the parent's summary file was clobbered despite the scrub"
+  echo "------- on disk -------"; cat "$safe" 2>/dev/null; echo "-----------------------"
+fi
+# The scrubbed child must still have emitted a summary — at its OWN repo-root
+# default — proving it ran fully and simply wrote elsewhere, not that it no-op'd.
+if [ -s "$tt_repo/.agent-gate-summary.txt" ] \
+   && ! grep -q "$SENTINEL" "$tt_repo/.agent-gate-summary.txt" 2>/dev/null; then
+  ok "2751-scrub-prevents-clobber: the scrubbed child wrote its own repo-root default summary instead"
+else
+  bad "2751-scrub-prevents-clobber: the scrubbed child produced no summary at its own default path"
 fi
 
 echo "----"

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1005,15 +1005,33 @@ fi
 #      scrub line exists, sits AFTER the `case "$SUMMARY_FILE"` resolution, and
 #      BEFORE the component runner (`run_component() {`) is even defined. FAILs if
 #      the scrub line is deleted.
-scrub_ln=$(grep -nE '^[[:space:]]*(export -n|env -u) AGENT_GATE_SUMMARY_FILE' "$GATE" \
-             | grep -v ':[[:space:]]*#' | head -1 | cut -d: -f1)
+# Match the primary env scrub verb (`export -n`/`env -u`) that scrubs the path for
+# ALL children, optionally wrapped in an `if ! …; then` visible-fallback guard. The
+# `^[[:space:]]*` anchor already excludes comment lines, so no extra comment filter is
+# needed (a `: #` trailing comment must NOT false-FAIL it). The `unset` fallback line
+# is deliberately NOT matched — deleting the primary scrub must still FAIL this test.
+scrub_ln=$(grep -nE '^[[:space:]]*(if[[:space:]]+![[:space:]]*)?(export -n|env -u) AGENT_GATE_SUMMARY_FILE' "$GATE" \
+             | head -1 | cut -d: -f1)
 resolve_ln=$(grep -n '^case "\$SUMMARY_FILE" in' "$GATE" | head -1 | cut -d: -f1)
 dispatch_ln=$(grep -n '^run_component() {' "$GATE" | head -1 | cut -d: -f1)
-if [ -n "$scrub_ln" ] && [ -n "$resolve_ln" ] && [ -n "$dispatch_ln" ] \
-   && [ "$scrub_ln" -gt "$resolve_ln" ] && [ "$scrub_ln" -lt "$dispatch_ln" ]; then
+if [ -z "$resolve_ln" ]; then
+  # The resolution anchor is the load-bearing "after" boundary; if it moved the
+  # property is un-checkable — hard FAIL with a DISTINCT message (not "scrub missing").
+  bad "2751-structural: summary-resolution anchor ('case \"\$SUMMARY_FILE\" in') not found — test anchor moved, cannot verify scrub ordering"
+elif [ -z "$scrub_ln" ]; then
+  bad "2751-structural: no AGENT_GATE_SUMMARY_FILE scrub line in the gate — nested gates can clobber the parent summary (#2751 regression)"
+elif [ -z "$dispatch_ln" ]; then
+  # Degrade gracefully: the "before dispatch" upper bound moved, but we can still
+  # assert the essential property (scrub AFTER resolution). Warn, don't false-FAIL.
+  if [ "$scrub_ln" -gt "$resolve_ln" ]; then
+    ok "2751-structural: gate scrubs AGENT_GATE_SUMMARY_FILE after summary resolution (line $scrub_ln); NOTE: dispatch anchor 'run_component() {' moved — upper-bound check skipped"
+  else
+    bad "2751-structural: scrub line ($scrub_ln) is NOT after summary resolution ($resolve_ln) — scrub happens too early to cover the resolved path"
+  fi
+elif [ "$scrub_ln" -gt "$resolve_ln" ] && [ "$scrub_ln" -lt "$dispatch_ln" ]; then
   ok "2751-structural: gate scrubs AGENT_GATE_SUMMARY_FILE after summary resolution and before component dispatch (line $scrub_ln)"
 else
-  bad "2751-structural: no AGENT_GATE_SUMMARY_FILE scrub in the resolved-but-pre-dispatch region (scrub=$scrub_ln resolve=$resolve_ln dispatch=$dispatch_ln) — nested gates can clobber the parent summary"
+  bad "2751-structural: scrub line out of the resolved-but-pre-dispatch region (scrub=$scrub_ln resolve=$resolve_ln dispatch=$dispatch_ln) — nested gates can clobber the parent summary"
 fi
 
 # 14b. BEHAVIORAL: copy the gate into a bare temp dir (hermetic — --emit-summary-selftest
@@ -1047,7 +1065,7 @@ fi
 # future case) — it must be (re)created by THIS invocation.
 safe="$tmp/2751-parent-safe.txt"
 printf '%s\n' "$SENTINEL" >"$safe"
-rm -f "$tt_repo/.agent-gate-summary.txt"
+rm -f "$tt_repo"/.agent-gate-*summary.txt  # widen: covers lite/delta default siblings too
 ( export AGENT_GATE_SUMMARY_FILE="$safe"; cd "$tt_repo" \
     && env -u AGENT_GATE_SUMMARY_FILE bash scripts/agent-gate.sh --emit-summary-selftest ) >/dev/null 2>&1
 if grep -q "$SENTINEL" "$safe" 2>/dev/null; then


### PR DESCRIPTION
Closes #2751 (nested tooling-tests gates inherit AGENT_GATE_SUMMARY_FILE → clobber parent summary mid-run).

## Problem
The `tooling-tests` gate component runs self-test scripts that invoke `agent-gate.sh` recursively. Those children inherited the parent's exported `AGENT_GATE_SUMMARY_FILE` and overwrote the parent gate's summary file mid-run (foreign DELTA REFUSED / INCOMPLETE-placeholder verdicts). Field cost: a foreign verdict read during #2672's gate of record, and a full 57-minute gate re-run on #2600's.

## Fix (two layers)
1. **Source (agent-gate.sh `run_tooling_tests`)**: `export -n AGENT_GATE_SUMMARY_FILE` before spawning any self-test child — single choke point covering every nested gate (full/lite/delta defaults all derive from the same var). Parent writes are unaffected: `SUMMARY_FILE` is resolved once into a plain shell var and never re-read from the env.
2. **Defense-in-depth**: `test_agent_gate_{delta,summary,parity_report,oom_audit}.sh` each `unset` the inherited var at top level; per-case invocations pin unique paths.

## Regression coverage
Case 14 in `test_agent_gate_summary.sh`: (a) structural — FAILs if the scrub line is removed; (b) behavioral — negative control proves an inherited export DOES clobber, then asserts the scrub leaves the parent's file intact while the child writes its own default.

## Evidence
- LITE gate: PASS (file-size, fmt, clippy, roborev-lints, scoped-tests)
- Self-test suites: summary 76/0, delta 66/0, parity-report 7/0, oom-audit 4/0
- End-to-end `--only tooling-tests`: parent summary retains its own run-id/verdict, no foreign clobber
- rust-reviewer: CLEAN

Full gate of record runs pre-merge via flow-closer.