### PR TITLE
feat(#2679): plan-time split pruning for fully-bound partition keys

### DIFF
--- a/openspec/changes/plantime-split-pruning/design.md
+++ b/openspec/changes/plantime-split-pruning/design.md
@@ -1,0 +1,106 @@
+# Design — plantime-split-pruning
+
+## Context
+
+`CqliteFlightSplitManager.getSplits(txn, session, table, dynamicFilter, Constraint)` today ignores its
+`Constraint`. It calls `sidecar.tokenRangeReplicas(keyspace)` → ~48 read-replica ranges, validates ring
+coverage, and `buildSplits` emits **one split per range** unconditionally. The pushed-down predicate is
+carried on each split's ticket (`FlightTicketJson`) and applied server-side (best-effort, post-decode).
+Trino delivers simple full-PK point reads as a `TupleDomain` in `constraint.getSummary()` (expression is
+`TRUE`); `applyFilter` already translates equality/IN/range domains (`PredicateTreeTranslator`), and
+`PrimaryKeyExtractor` already yields partition-key column names + order from the DDL.
+
+The server already makes exactly the "is this a full-PK point read" decision (`point_read::detect_route`
+→ `PartitionPointRead`/`MultiPartitionPointRead`/`Scan`) and prunes by token at DoGet time
+(`token_in_half_open_range`). This change moves that decision **earlier** — to plan time — so the ~48×
+fan-out never happens for a bound-PK query.
+
+## Design calls (the real decisions)
+
+### 1. Token-computation source — port Murmur3 to Java (chosen) vs a server round-trip
+
+There is **no Murmur3 in Java today**. Two options:
+
+- **(A · chosen) Port the token computation to Java.** Add `Murmur3Token` mirroring the Rust authority
+  `cassandra_murmur3_token` (`cqlite-core/src/util/cassandra_murmur3.rs`) plus the canonical
+  partition-key byte layout from `PartitionKey::to_bytes` (`storage/write_engine/mutation.rs`):
+  single-component = the raw serialized value bytes; multi-component = for each component
+  `[len:u16 BE][value bytes][0x00]` concatenated. Compute the token(s) at plan time, no RPC.
+- **(B · rejected) Add a Sidecar/Flight RPC** that returns the covering range for a key. Rejected: adds a
+  network hop on the hot path we're trying to shorten, introduces a new endpoint + failure mode, and still
+  needs the Java-side value→bytes serialization anyway. The token math is small, deterministic, and
+  already has a byte-exact Rust oracle to test against.
+
+**Why A is safe:** the computation is pure and testable against the Rust implementation with shared
+vectors. Correctness risk (a wrong token drops rows — see §4) is contained by a differential test that
+compares pruned vs forced-unpruned execution, and by fail-safe defaults.
+
+### 2. Partitioner metadata under no-heuristics — assume Murmur3 explicitly, fail-safe otherwise
+
+The AC requires the partitioner come from metadata, "never inferred from data," and unknown → no pruning.
+**Reality:** Sidecar exposes no partitioner field anywhere; the entire ring machinery
+(`validateRingCoverage`, `SidecarModels`, token parsing) already **hard-assumes `Murmur3Partitioner`** and
+treats range bounds as signed-64-bit Murmur3 tokens.
+
+Design: make the assumption **explicit and centralized**. A single `Partitioner` resolution point returns
+`Murmur3` when the cluster is Murmur3 (the current and only supported case) and `Unsupported` otherwise;
+pruning is gated on `Murmur3`. If/when a partitioner name becomes available from Sidecar metadata, that
+resolver reads it; until then it returns the documented ring assumption. **This is not data inference** —
+the token is computed from schema-declared partition-key columns against a declared (assumed) partitioner,
+and any deviation disables pruning and is logged. This keeps the change honest about the existing
+assumption rather than inventing a partitioner field the platform doesn't expose. Surfaced to the owner as
+a decision (below), because "assume Murmur3 explicitly" is a doctrine-adjacent call.
+
+### 3. Full-PK-bound detection + IN handling — reuse the summary TupleDomain
+
+Read `constraint.getSummary().getDomains()` in `getSplits`. A query is **fully bound** iff **every**
+partition-key column (by `PrimaryKeyExtractor` name/order, case-folded per `KeyColumn`) is present with a
+domain that is either a **single value** (equality) or a **discrete set** (IN) — and null is not allowed.
+
+- **Equality on all PK columns** → one typed key tuple → one token → keep the 1 covering range.
+- **IN over full PKs:** take the **Cartesian product** of each PK column's discrete-set values (for a
+  single-column PK this is just the set; for composite PKs, IN is delivered per-column so the product is
+  the set of full keys Trino will read), compute a token per full key, and keep the **union** of covering
+  ranges (**deduped**). Never fewer ranges than the union — if the product is empty or any factor is not a
+  clean discrete set, fall back to full fan-out.
+- **Anything else** (partial PK, a PK column with a range/unbounded domain, non-PK predicates only,
+  null-allowed) → no pruning.
+
+The typed values come from the `Domain`'s Trino type + `PrimaryKeyExtractor` column mapping, serialized to
+partition-key bytes by the same `to_bytes` layout the token function consumes.
+
+### 4. Correctness posture — split elimination is load-bearing, so fail-safe is mandatory
+
+Server-side predicate filtering is a pure optimization (a missed filter returns extra rows Trino then
+drops). **Split elimination is different: a wrongly-pruned split silently drops real rows.** Therefore:
+
+- Every uncertainty → **no pruning** (full fan-out is always correct).
+- The **differential test** (pruned vs forced-unpruned, identical rows/values/order) is the primary guard,
+  mirroring the point-vs-full pattern (`point_vs_full_differential.rs`, `issue_2398` token-pushdown).
+- The pruning path must be **toggleable** so the differential test can force the unpruned baseline (a
+  session property or config flag, e.g. `cqlite.split_pruning_enabled`, default on).
+- Token membership reuses the **exact** `(start, end]` half-open + wraparound semantics already in
+  `validateRingCoverage` / server `token_in_half_open_range` — no second convention.
+
+## Wiring evidence (definition of done)
+
+The public surface is `ConnectorSplitManager.getSplits`. Wiring is proven by an end-to-end test through the
+real Trino query path where a fully-bound-PK point read produces a `SplitSource` yielding **exactly one**
+split (→ one DoGet to one pod), asserted via split count / a pruning counter on the public surface — not a
+helper-only unit test.
+
+## Risks & mitigations
+
+- **Byte-layout drift from Rust** → shared test vectors pinning Java `Murmur3Token` output against
+  `cassandra_murmur3_token` for representative single/composite keys and known-token fixtures.
+- **Type coverage gaps** (a PK CQL type whose Java→bytes serialization is unimplemented) → that type
+  simply doesn't prune (fail-safe), and is logged; not a correctness hazard.
+- **Ring gaps/overlap** already fail-closed via `validateRingCoverage`; pruning runs after that guard.
+
+## Open decision for the owner (Seam 1)
+
+**Partitioner assumption:** proceed with the explicit "assume `Murmur3Partitioner`; unknown → no pruning"
+resolver (§2), matching the ring's existing hard assumption, since Sidecar exposes no partitioner field —
+OR block on first adding a partitioner-name metadata source. Recommendation: **proceed with the explicit
+assumption** (it's the honest encoding of today's reality, fully fail-safe, and unblocks the ~48× win);
+file a follow-up to surface partitioner name from Sidecar when that metadata lands.

--- a/openspec/changes/plantime-split-pruning/proposal.md
+++ b/openspec/changes/plantime-split-pruning/proposal.md
@@ -1,0 +1,73 @@
+# plantime-split-pruning
+
+## Why
+
+The v0.15.0 milestone soak (#2661) capped at ~39 qps @ 32 threads with p50 798ms — the latency was
+almost entirely client-side queue wait against a throughput ceiling (server-side ~2ms per read). Read-only
+triage of the Trino/Flight connector (#2679) found the largest single lever:
+
+`CqliteFlightSplitManager.getSplits` receives Trino's pushed-down `Constraint` but **never uses it to
+prune token ranges** — the predicate is only carried on each split's ticket and applied server-side. As a
+result **every** query, including a single-partition point read, emits **one split per read-replica token
+range**. On the standing rig (3 nodes, `num_tokens 16` → ~48 ranges) a point read fans out **~48 DoGets
+across all 3 pods to fetch a single partition**. Point reads don't concentrate load — they multiply it ~48×.
+
+- **Milestone:** 0.15 — cqlite-trino latency/throughput/operations theme (epic #2403), Lane-B goals
+  B1/B2 (`docs/architecture/performance-goals-2026-07.md`).
+- **Routing:** design-driven. Token-computation source (no Java Murmur3 exists today), partitioner
+  metadata plumbing under the no-heuristics mandate, IN-list handling, and the correctness harness are
+  real design calls — hence OpenSpec, not a bare oracle-driven fix.
+
+## What Changes
+
+When Trino's pushed-down constraint **fully binds the partition key** — an equality domain on every
+partition-key column, or a discrete-set (IN) domain over full keys — the split manager computes the
+Murmur3 token(s) at plan time and emits splits **only for the covering token range(s)**. A single-key
+point read becomes **1 DoGet to 1 pod**. Anything less than a fully-bound partition key (range scan,
+partial PK, non-PK predicates, null-allowed domains, an unsupported/unknown partitioner) keeps the
+current full fan-out.
+
+Concretely:
+
+- Read `constraint.getSummary()` (a `TupleDomain`) inside `getSplits` (currently ignored) — this is where
+  Trino delivers simple full-PK point reads (the expression is `TRUE`; the equality lives in the summary).
+- Add a **Java Murmur3 token computation** (`Murmur3Token`) that mirrors the Rust authority
+  `cqlite-core/src/util/cassandra_murmur3.rs` (`cassandra_murmur3_token`) **and** the canonical
+  partition-key byte serialization from `cqlite-core/src/storage/write_engine/mutation.rs`
+  (`PartitionKey::to_bytes`: single-component = raw value bytes; multi-component =
+  `[len:u16 BE][bytes][0x00]` per component).
+- Cross-reference the summary's per-column equality domains against
+  `PrimaryKeyExtractor.extract(ddl).partitionKey()` (names + order) and the column CQL types (from the
+  column handles / Arrow schema) to build the typed partition-key value tuple(s).
+- Filter `buildSplits`' emitted ranges to those whose `(start, end]` half-open interval (with the existing
+  wraparound convention) contains a computed token — reusing the token-membership logic already encoded in
+  `validateRingCoverage` / the server's `token_in_half_open_range`.
+- **Fail-safe by construction:** any doubt (partial PK, a PK column absent or not a single-value/discrete
+  domain, null-allowed, a value that cannot be typed/serialized, an unknown/non-Murmur3 partitioner) → **no
+  pruning, full fan-out** — never fewer splits than correctness requires.
+
+## Non-goals
+
+- **Server-side predicate application is unchanged.** This change only reduces which splits are emitted;
+  the ticket predicate and server-side filtering stay exactly as-is. Pushdown remains an optimization, not
+  an enforcement contract (the `applyFilter` honesty contract is preserved).
+- **No partial-PK or clustering-key pruning.** Only fully-bound partition keys prune. Clustering
+  predicates, range scans, and partial PKs keep full fan-out.
+- **No new partitioner support.** Only `Murmur3Partitioner` (the ring's existing hard assumption) prunes.
+  A non-Murmur3 or unknown partitioner disables pruning; adding ByteOrdered/RandomPartitioner is out of scope.
+- **No change to token-range topology discovery.** The Sidecar `token-range-replicas` source and the ~48
+  ranges are unchanged; we filter them, we don't re-derive them.
+- **Field verification is report-only, next round** (per-pod DoGet collapse, warm point p50, qps @ 32
+  threads off ~39). Not gated by this change's merge.
+
+## Impact
+
+- **Affected code (Java connector, `trino-connector/`):**
+  `CqliteFlightSplitManager.getSplits`/`buildSplits` (consume the constraint + prune), a new
+  `Murmur3Token` + partition-key byte-serializer, plumbing typed PK values from `applyFilter`'s
+  summary/`PrimaryKeyExtractor`.
+- **No Rust changes** — the server already prunes by token at DoGet time; this pushes the same decision
+  earlier so the fan-out never happens.
+- **Doctrine:** exercises **no-heuristics** (token from schema-declared PK columns + assumed-Murmur3
+  ring, never inferred from data; unknown partitioner → no pruning) and **wiring-evidence** (an end-to-end
+  test through the real Trino query path shows a point read served by a single DoGet).

--- a/openspec/changes/plantime-split-pruning/specs/trino-split-pruning/spec.md
+++ b/openspec/changes/plantime-split-pruning/specs/trino-split-pruning/spec.md
@@ -1,0 +1,121 @@
+# trino-split-pruning
+
+## ADDED Requirements
+
+### Requirement: A fully-bound partition key prunes splits to the covering token range(s)
+
+`CqliteFlightSplitManager.getSplits` SHALL prune emitted splits when the pushed-down constraint fully binds
+the partition key. When the constraint fixes the **full partition key** by an equality domain on every
+partition-key column, `getSplits` SHALL compute the Murmur3 token for the bound key and emit splits ONLY
+for the token range(s) whose half-open `(start, end]` interval (with the existing wraparound convention)
+contains that token. For a single fully-bound key this SHALL be exactly one split. A constraint that does
+NOT fully bind the partition key (range scan, partial PK, non-PK-only predicates) SHALL leave the split set
+unchanged (full fan-out).
+
+#### Scenario: Single fully-bound PK emits exactly the covering split
+
+- **GIVEN** a keyspace whose Sidecar `token-range-replicas` yields a multi-range topology (e.g. ~48 ranges)
+- **AND** a query whose pushed-down constraint binds every partition-key column by equality to a single value
+- **WHEN** `getSplits` runs
+- **THEN** it emits exactly **one** split — the one whose `(start, end]` range contains the key's Murmur3 token
+- **AND** on `main` (no pruning) the same query emits one split per range (full fan-out).
+
+#### Scenario: Partial or absent PK constraint keeps full fan-out
+
+- **GIVEN** the same multi-range topology
+- **WHEN** the pushed-down constraint binds only a subset of the partition-key columns, or binds a PK column
+  by a range/unbounded domain, or contains only non-PK predicates, or is absent
+- **THEN** `getSplits` emits the full set of splits (one per read-replica range) — the split count is
+  identical to the current behavior.
+
+### Requirement: IN-list over full partition keys prunes to the deduped union of covering ranges
+
+`getSplits` SHALL prune to the deduplicated union of covering token ranges when an IN-list fully binds the
+partition key. When the pushed-down constraint binds the full partition key by a discrete set (IN over full
+keys, or a per-column discrete set whose Cartesian product enumerates full keys), `getSplits` SHALL compute the
+Murmur3 token for each enumerated full key and emit splits for the **union** of covering token ranges,
+**deduplicated**. It SHALL NEVER emit fewer ranges than that union requires. If the enumeration is empty or
+any factor is not a clean discrete set of typeable values, it SHALL fall back to full fan-out.
+
+#### Scenario: IN over full PKs emits the union of covering ranges, deduped
+
+- **GIVEN** the multi-range topology
+- **AND** a query with an IN-list over the full partition key spanning K distinct keys that fall into
+  M ≤ K distinct token ranges
+- **WHEN** `getSplits` runs
+- **THEN** it emits exactly M splits — the deduplicated union of the ranges covering the K keys
+- **AND** no key's covering range is omitted (every enumerated token maps to an emitted split).
+
+#### Scenario: Two IN keys sharing a range collapse to one split
+
+- **GIVEN** two distinct full keys whose Murmur3 tokens fall in the same `(start, end]` range
+- **WHEN** `getSplits` prunes for an IN-list containing both keys
+- **THEN** exactly one split (that shared range) is emitted, not two.
+
+### Requirement: Token derivation is schema-authoritative and fail-safe (no-heuristics)
+
+The Murmur3 token SHALL be computed from the schema-declared partition-key columns (names + order from the
+DDL via `PrimaryKeyExtractor`) and their CQL-typed values from the constraint domains — **never inferred
+from data bytes or byte-pattern guessing**. The partitioner SHALL be resolved from cluster metadata /
+the ring's declared assumption; an unknown or non-`Murmur3` partitioner SHALL disable pruning (full fan-out)
+and be surfaced in logs. Any value that cannot be typed or serialized to partition-key bytes SHALL disable
+pruning for that query rather than prune approximately.
+
+#### Scenario: Unknown/non-Murmur3 partitioner disables pruning
+
+- **GIVEN** a cluster whose resolved partitioner is not `Murmur3Partitioner` (or is unknown)
+- **WHEN** `getSplits` evaluates an otherwise fully-bound-PK constraint
+- **THEN** no pruning occurs (full fan-out is emitted)
+- **AND** the reason is logged.
+
+#### Scenario: An un-serializable PK value disables pruning, not silent misprune
+
+- **GIVEN** a fully-bound-PK constraint where a partition-key value's CQL type has no Java partition-key
+  byte serialization
+- **WHEN** `getSplits` attempts to compute the token
+- **THEN** pruning is skipped for that query (full fan-out) rather than pruning on an approximate token.
+
+### Requirement: Java Murmur3 token matches the Rust Cassandra-parity authority
+
+The Java token computation (`Murmur3Token` over the canonical partition-key byte layout) SHALL produce
+tokens byte-identical to the Rust authority `cassandra_murmur3_token`
+(`cqlite-core/src/util/cassandra_murmur3.rs`) applied to `PartitionKey::to_bytes`
+(`cqlite-core/src/storage/write_engine/mutation.rs`) — single-component keys use the raw value bytes;
+multi-component keys use `[len:u16 BE][bytes][0x00]` per component. This SHALL include the
+`i64::MIN → i64::MAX` normalization.
+
+#### Scenario: Shared vectors pin Java tokens to the Rust implementation
+
+- **GIVEN** a set of representative partition keys (single-column and composite, spanning common CQL types)
+  with tokens computed by the Rust `cassandra_murmur3_token`
+- **WHEN** the Java `Murmur3Token` computes tokens for the same keys
+- **THEN** every Java token equals the corresponding Rust token, including the normalized `i64::MIN` case.
+
+### Requirement: Pruned execution is row-identical to unpruned execution (differential correctness)
+
+Pruned execution SHALL return results identical to unpruned execution. Because split elimination is
+load-bearing for correctness (a wrongly-pruned split silently drops rows), pruning SHALL be toggleable, and
+for any query, executing with pruning enabled SHALL return identical rows, values, and order to executing
+the same query with pruning forced off.
+
+#### Scenario: Pruned vs forced-unpruned returns identical result sets
+
+- **GIVEN** a connector-level differential harness that runs a query once with split pruning enabled and
+  once with pruning forced off (a session property / config toggle)
+- **WHEN** the query is a fully-bound-PK point read and, separately, an IN-list over full PKs
+- **THEN** both executions return byte-identical rows, values, and ordering
+- **AND** the pruned execution emits strictly fewer (or equal) splits than the unpruned one.
+
+### Requirement: End-to-end wiring — a point read is served by a single DoGet
+
+The pruning SHALL be exercised through the real Trino query path (the public `ConnectorSplitManager`
+surface), not helper-only unit tests. An end-to-end test SHALL show a fully-bound-PK point read producing a
+`SplitSource` that yields exactly one split, observable via split count or a pruning/DoGet counter on the
+public surface.
+
+#### Scenario: Point read through the Trino path yields one split / one DoGet
+
+- **GIVEN** the connector wired to a multi-range topology
+- **WHEN** a fully-bound-PK point-read query flows through `getSplits` on the public surface
+- **THEN** the resulting `SplitSource` yields exactly one split (→ one DoGet to one pod)
+- **AND** the assertion reads the public split count / pruning counter, not an internal helper return value.

--- a/openspec/changes/plantime-split-pruning/tasks.md
+++ b/openspec/changes/plantime-split-pruning/tasks.md
@@ -1,0 +1,66 @@
+# Tasks — plantime-split-pruning
+
+## 1. Java Murmur3 token computation (mirrors Rust authority)
+
+- [ ] 1.1 Add `Murmur3Token` in `trino-connector/src/main/java/in/mcfad/cqlite/flight/` implementing
+      `cassandra_murmur3_x64_128` + `cassandra_murmur3_token` + `i64::MIN → i64::MAX` normalization,
+      ported from `cqlite-core/src/util/cassandra_murmur3.rs`. Surface exercised: `Murmur3Token.token(byte[])`.
+- [ ] 1.2 Add the canonical partition-key byte serializer (single-component = raw value bytes;
+      multi-component = `[len:u16 BE][bytes][0x00]` per component) mirroring
+      `PartitionKey::to_bytes` (`storage/write_engine/mutation.rs`). Map CQL/Trino types → value bytes;
+      an unsupported type returns "cannot serialize" (→ caller disables pruning).
+- [ ] 1.3 Unit test `Murmur3TokenTest` with **shared vectors** pinning Java output to the Rust
+      `cassandra_murmur3_token` for single-column and composite keys across common CQL types, incl. the
+      normalized `i64::MIN` case. (Spec: "Java Murmur3 matches the Rust authority".)
+
+## 2. Full-PK-bound detection from the constraint summary
+
+- [ ] 2.1 In `getSplits`, read `constraint.getSummary().getDomains()` (currently ignored at
+      `CqliteFlightSplitManager.java:48`). Resolve the partition-key columns via
+      `PrimaryKeyExtractor.extract(handle.ddl()).partitionKey()` (case-folded per `KeyColumn`).
+- [ ] 2.2 Classify: fully-bound-equality (every PK column a single-value domain), fully-bound-IN (every PK
+      column a discrete set → Cartesian product of full keys), or not-bound (→ no pruning). Null-allowed,
+      range, or missing PK column ⇒ not-bound. Surface exercised: a `BoundPartitionKeys` helper returning
+      the typed key tuples or empty.
+- [ ] 2.3 Resolve the partitioner (explicit "assume Murmur3; unknown → disable" resolver, §2 of design);
+      non-Murmur3/unknown ⇒ no pruning, logged.
+
+## 3. Prune the emitted splits
+
+- [ ] 3.1 Compute token(s) for the bound key tuple(s); dedupe. Filter `buildSplits`' ranges to those whose
+      `(start, end]` half-open interval (reuse the wraparound/token-membership semantics from
+      `validateRingCoverage` / server `token_in_half_open_range`) contains a computed token. Emit the union.
+- [ ] 3.2 Add a toggle (`cqlite.split_pruning_enabled` session property / config, default on) so pruning
+      can be forced off for the differential baseline.
+- [ ] 3.3 Fail-safe: any exception, empty enumeration, or "cannot serialize" ⇒ full fan-out (never fewer
+      splits than correct). Log the skip reason.
+
+## 4. Tests (verify the spec)
+
+- [ ] 4.1 `CqliteFlightSplitManagerTest`: fully-bound single PK over a multi-range fixture → exactly 1
+      covering split; partial/absent/range PK → unchanged full fan-out. (Spec req 1.)
+- [ ] 4.2 IN-list over full PKs → deduped union of covering ranges; two keys sharing a range collapse to
+      one split; never fewer than the union. (Spec req 2.)
+- [ ] 4.3 Unknown/non-Murmur3 partitioner → no pruning (logged); un-serializable PK value → no pruning.
+      (Spec req 3.)
+- [ ] 4.4 Connector-level **differential** test: pruned vs forced-unpruned returns identical rows/values/
+      order for a point read and an IN-list; pruned emits ≤ splits. (Spec req 5, point-vs-full style.)
+- [ ] 4.5 **Wiring/e2e**: fully-bound-PK point read through the public `getSplits` `SplitSource` yields
+      exactly one split, asserted via split count / pruning counter on the public surface. (Spec req 6.)
+
+## 5. Quality gates
+
+- [ ] 5.1 `scripts/agent-gate.sh --lite` green each fix round (summary-file redirect).
+- [ ] 5.2 Review-first: `rust-reviewer` (Java changes still get a review pass) + roborev on the lite-green diff.
+- [ ] 5.3 Full `scripts/agent-gate.sh` PASS once (flow-closer) — confirm the connector Gradle build/tests
+      run in the gate; if the connector is not in the gate's component set, run its Gradle test suite and
+      record the result in the PR alongside the gate SUMMARY.
+- [ ] 5.4 **C** intent audit (`spec-auditor` anchored to `openspec/changes/plantime-split-pruning/specs/**`).
+- [ ] 5.5 Final roborev clean; merge-on-green; `openspec archive`.
+
+## 6. Docs / follow-ups
+
+- [ ] 6.1 File a follow-up issue to surface the partitioner name from Sidecar metadata (so the resolver
+      reads it instead of assuming Murmur3) — cross-ref this change.
+- [ ] 6.2 Note the report-only field-verification round (#2661 soak: per-pod DoGet collapse, warm point
+      p50, qps @ 32 threads) as a follow-up — not gated by this merge.

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/BoundPartitionKeys.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/BoundPartitionKeys.java
@@ -1,0 +1,177 @@
+package in.mcfad.cqlite.flight;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.Type;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import in.mcfad.cqlite.flight.PrimaryKeyExtractor.KeyColumn;
+
+/**
+ * Classifies whether a pushed-down {@link Constraint} summary fully binds the
+ * partition key and, if so, computes the Murmur3 token(s) of the bound key(s) for
+ * plan-time split pruning (issue #2679).
+ *
+ * <p>The partition key is <b>fully bound</b> iff <em>every</em> partition-key column
+ * (by {@link PrimaryKeyExtractor} name + order, case-folded per {@link KeyColumn})
+ * appears in the summary with a domain that is either a <b>single value</b> (equality)
+ * or a <b>discrete set</b> (IN) — and null is not allowed. The bound keys are the
+ * Cartesian product of each column's value list; a token is computed per full key and
+ * the distinct set returned.
+ *
+ * <p><b>Fail-safe (spec / no-heuristics):</b> a partial PK, a PK column bound by a
+ * range/unbounded domain, a null-allowed domain, an empty product, or a value with no
+ * exact CQL byte serialization ({@link PartitionKeyBytes}) all yield {@link #tokens()}
+ * empty — the caller then emits the full fan-out (always correct) and logs
+ * {@link #skipReason()}. Never fewer splits than correctness requires.
+ */
+public record BoundPartitionKeys(Optional<long[]> tokens, String skipReason) {
+
+    /**
+     * Upper bound on the enumerated Cartesian product of full keys. Beyond this, pruning
+     * is skipped (full fan-out) — a huge IN over composite keys is atypical and not worth
+     * the plan-time cost; skipping is always correct.
+     */
+    static final int MAX_KEYS = 10_000;
+
+    private static BoundPartitionKeys prune(long[] tokens) {
+        return new BoundPartitionKeys(Optional.of(tokens), "");
+    }
+
+    private static BoundPartitionKeys noPrune(String reason) {
+        return new BoundPartitionKeys(Optional.empty(), reason);
+    }
+
+    /** True when the partition key is fully bound and tokens were computed. */
+    public boolean isBound() {
+        return tokens.isPresent();
+    }
+
+    /**
+     * Compute the distinct covering tokens for {@code summary} against the partition-key
+     * columns {@code partitionKey}, or a no-prune result (with a reason) when the key is
+     * not fully bound / not serializable.
+     */
+    public static BoundPartitionKeys compute(TupleDomain<ColumnHandle> summary, List<KeyColumn> partitionKey) {
+        if (partitionKey.isEmpty()) {
+            return noPrune("no partition-key columns resolved from the DDL");
+        }
+        if (summary == null || summary.isAll() || summary.isNone()) {
+            return noPrune("constraint summary binds no columns");
+        }
+        Optional<Map<ColumnHandle, Domain>> domainsOpt = summary.getDomains();
+        if (domainsOpt.isEmpty()) {
+            return noPrune("constraint summary has no column domains");
+        }
+        Map<ColumnHandle, Domain> domains = domainsOpt.get();
+
+        // For each PK column (in schema order) collect its value bytes per bound value.
+        // Each entry is the list of value-byte alternatives for that column (equality → 1,
+        // IN → N). The Cartesian product across columns enumerates the full keys.
+        List<List<byte[]>> perColumn = new ArrayList<>(partitionKey.size());
+        for (KeyColumn pk : partitionKey) {
+            ColumnDomain cd = findDomain(domains, pk);
+            if (cd == null) {
+                return noPrune("partition-key column '" + pk.name() + "' is not bound by the constraint");
+            }
+            Domain domain = cd.domain();
+            if (domain.isNullAllowed()) {
+                return noPrune("partition-key column '" + pk.name() + "' domain allows NULL");
+            }
+            ValueSet values = domain.getValues();
+            Type type = domain.getType();
+            List<Object> raw;
+            if (values.isSingleValue()) {
+                raw = List.of(values.getSingleValue());
+            } else if (values.isDiscreteSet()) {
+                raw = values.getDiscreteSet();
+                if (raw.isEmpty()) {
+                    return noPrune("partition-key column '" + pk.name() + "' has an empty discrete set");
+                }
+            } else {
+                return noPrune("partition-key column '" + pk.name()
+                        + "' is bound by a range/unbounded domain, not equality/IN");
+            }
+            List<byte[]> componentBytes = new ArrayList<>(raw.size());
+            for (Object value : raw) {
+                Optional<byte[]> bytes = PartitionKeyBytes.serializeValue(type, cd.capability(), value);
+                if (bytes.isEmpty()) {
+                    return noPrune("partition-key column '" + pk.name()
+                            + "' value cannot be serialized to CQL partition-key bytes (type "
+                            + type.getDisplayName() + ")");
+                }
+                componentBytes.add(bytes.get());
+            }
+            perColumn.add(componentBytes);
+        }
+
+        // Cartesian product size guard (still correct if skipped).
+        long product = 1;
+        for (List<byte[]> col : perColumn) {
+            product *= col.size();
+            if (product > MAX_KEYS) {
+                return noPrune("bound key enumeration exceeds " + MAX_KEYS + " keys; skipping pruning");
+            }
+        }
+
+        // Enumerate the product → full-key bytes → distinct tokens.
+        Set<Long> tokenSet = new LinkedHashSet<>();
+        List<byte[]> current = new ArrayList<>(perColumn.size());
+        boolean ok = enumerate(perColumn, 0, current, tokenSet);
+        if (!ok || tokenSet.isEmpty()) {
+            return noPrune("bound key produced no serializable full key");
+        }
+        long[] out = new long[tokenSet.size()];
+        int i = 0;
+        for (long t : tokenSet) {
+            out[i++] = t;
+        }
+        return prune(out);
+    }
+
+    /** Recursively enumerate the Cartesian product, computing a token per full key. */
+    private static boolean enumerate(
+            List<List<byte[]>> perColumn, int depth, List<byte[]> current, Set<Long> out) {
+        if (depth == perColumn.size()) {
+            Optional<byte[]> key = PartitionKeyBytes.fullKey(current);
+            if (key.isEmpty()) {
+                return false;
+            }
+            out.add(Murmur3Token.token(key.get()));
+            return true;
+        }
+        for (byte[] component : perColumn.get(depth)) {
+            current.add(component);
+            if (!enumerate(perColumn, depth + 1, current, out)) {
+                return false;
+            }
+            current.remove(current.size() - 1);
+        }
+        return true;
+    }
+
+    /** A matched column domain with its pushdown capability (for VARCHAR text vs uuid disambiguation). */
+    private record ColumnDomain(Domain domain, PushdownCapability capability) {}
+
+    /**
+     * Find the summary domain for a partition-key column, matching by CQL identifier rules
+     * (case-folded per {@link KeyColumn#matches}). Only a {@link CqliteFlightColumnHandle}
+     * carries the capability needed to serialize the value; an unknown handle is skipped.
+     */
+    private static ColumnDomain findDomain(Map<ColumnHandle, Domain> domains, KeyColumn pk) {
+        for (Map.Entry<ColumnHandle, Domain> e : domains.entrySet()) {
+            if (e.getKey() instanceof CqliteFlightColumnHandle col && pk.matches(col.name())) {
+                return new ColumnDomain(e.getValue(), col.capability());
+            }
+        }
+        return null;
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
@@ -31,6 +31,10 @@ import java.util.Optional;
  * # Deadline for the optional planning-time table_stats DoAction (issue #944). A slow or
  * # half-open Flight endpoint must degrade to "no estimate", never stall query planning.
  * cqlite.table-stats-timeout-ms=3000
+ * # Plan-time split pruning (issue #2679): when the pushed-down constraint fully binds the
+ * # partition key, emit splits only for the covering token range(s) instead of one per range.
+ * # Default on; set false to force the full fan-out (the differential baseline).
+ * cqlite.split-pruning-enabled=true                 # true | false
  * </pre>
  */
 public record CqliteFlightConfig(
@@ -43,9 +47,19 @@ public record CqliteFlightConfig(
         ReadMode readMode,
         Optional<String> snapshotTtl,
         long snapshotReuseWindowMillis,
-        long snapshotRetireGraceMillis) {
+        long snapshotRetireGraceMillis,
+        boolean splitPruningEnabled) {
 
     public static final int DEFAULT_FLIGHT_PORT = 8815;
+
+    /**
+     * Plan-time split pruning (issue #2679) is ON by default: when a query's pushed-down
+     * constraint fully binds the partition key, the split manager emits splits only for the
+     * covering token range(s) instead of one per token range. Set
+     * {@code cqlite.split-pruning-enabled=false} to force the full fan-out (the differential
+     * baseline). Pruning is always fail-safe — any doubt already falls back to full fan-out.
+     */
+    public static final boolean DEFAULT_SPLIT_PRUNING_ENABLED = true;
 
     /**
      * Default backstop TTL for per-query snapshots (issue #2105). Explicit best-effort
@@ -246,9 +260,12 @@ public record CqliteFlightConfig(
         long retireGraceMs = config.containsKey("cqlite.snapshot-retire-grace-ms")
                 ? Long.parseLong(config.get("cqlite.snapshot-retire-grace-ms"))
                 : DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS;
+        boolean splitPruning = config.containsKey("cqlite.split-pruning-enabled")
+                ? Boolean.parseBoolean(config.get("cqlite.split-pruning-enabled"))
+                : DEFAULT_SPLIT_PRUNING_ENABLED;
         return new CqliteFlightConfig(
                 URI.create(sidecar), port, dc, policy, ratio, statsTimeoutMs, readMode, snapshotTtl,
-                reuseWindowMs, retireGraceMs);
+                reuseWindowMs, retireGraceMs, splitPruning);
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -150,6 +150,30 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
                 return ranges;
             }
             List<KeyColumn> partitionKey = PrimaryKeyExtractor.extract(handle.ddl()).partitionKey();
+            // Fail-safe composite-PK consistency guard (issue #2679 roborev): the pruning path
+            // builds a composite partition-key byte layout whose Murmur3 token is correct ONLY
+            // when EVERY partition-key component is present, in order. PrimaryKeyExtractor was
+            // built for estimateGroupRatio (#944) where a parse MISS is fail-safe — but here an
+            // UNDER-count on a composite PK (e.g. a quoted identifier containing ')' closes the
+            // composite group early, so PRIMARY KEY ((a,b)) resolves to [a]) is CATASTROPHIC:
+            // it builds a single-component raw-byte key, computes the WRONG token, maps to the
+            // wrong range, and SILENTLY DROPS the partition's rows. Cross-check the extracted
+            // partition-key column count against an INDEPENDENT, quote-aware arity scan of the
+            // same DDL; prune only when they agree. Any disagreement — or an indeterminate
+            // arity — means we cannot be certain we have all components in the right order, so
+            // we fall back to the full fan-out (always correct). This subsumes the
+            // single-component case (1 == 1) unchanged.
+            java.util.OptionalInt arity = PrimaryKeyExtractor.partitionKeyArity(handle.ddl());
+            if (arity.isEmpty() || arity.getAsInt() != partitionKey.size()) {
+                LOG.log(System.Logger.Level.DEBUG,
+                        () -> "Split pruning skipped for " + handle.keyspace() + "." + handle.table()
+                                + " (full fan-out): partition-key parse is not provably complete — "
+                                + "extractor resolved " + partitionKey.size() + " component(s) but the "
+                                + "independent quote-aware arity scan found "
+                                + (arity.isEmpty() ? "an indeterminate count" : arity.getAsInt())
+                                + "; refusing to prune on a possibly under-counted composite key");
+                return ranges;
+            }
             BoundPartitionKeys bound = BoundPartitionKeys.compute(constraint.getSummary(), partitionKey);
             if (!bound.isBound()) {
                 LOG.log(System.Logger.Level.DEBUG,

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import in.mcfad.cqlite.flight.PrimaryKeyExtractor.KeyColumn;
+
 import in.mcfad.cqlite.flight.sidecar.HostAddresses;
 import in.mcfad.cqlite.flight.sidecar.SidecarClient;
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
@@ -29,6 +31,9 @@ import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
  * (which lives on RF replicas) is read exactly once across the cluster.
  */
 public class CqliteFlightSplitManager implements ConnectorSplitManager {
+    private static final System.Logger LOG =
+            System.getLogger(CqliteFlightSplitManager.class.getName());
+
     private final CqliteFlightConfig config;
     private final SidecarClient sidecar;
     private final SnapshotManager snapshots;
@@ -87,6 +92,18 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         List<CqliteFlightSplit> ranges = buildSplits(
                 handle, replicas, config.localDatacenter(), config.flightPort(), snapshot, availableHosts);
 
+        // Plan-time split pruning (issue #2679): when the pushed-down constraint FULLY binds
+        // the partition key (equality on every PK column, or an IN over full keys), compute the
+        // Murmur3 token(s) and keep only the covering token range(s). Anything less — or any
+        // doubt (unknown partitioner, un-serializable value, exception) — leaves the full
+        // fan-out unchanged. Split elimination is load-bearing for correctness (a mis-pruned
+        // split silently drops rows), so this is fail-safe by construction. Never applied to an
+        // aggregated handle: the finalize split must still fan out to every range to merge.
+        if (!handle.isAggregated()) {
+            ranges = pruneToBoundPartitionKey(
+                    handle, ranges, constraint, config.splitPruningEnabled(), Partitioner.resolve());
+        }
+
         // Aggregated handle: Trino does not re-aggregate across splits, so return
         // ONE finalize split carrying all range→replica assignments. Its PageSource
         // fans out, pulls each range's partial, merges, and emits the final rows.
@@ -103,6 +120,84 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
         }
 
         return new FixedSplitSource(ranges);
+    }
+
+    /**
+     * Prune {@code ranges} to those covering the bound partition key's Murmur3 token(s)
+     * (issue #2679), or return {@code ranges} unchanged (full fan-out) on ANY doubt.
+     *
+     * <p>Fail-safe by construction: pruning is skipped — and the reason logged — when the
+     * toggle is off, the resolved {@link Partitioner} is not Murmur3, the constraint does not
+     * fully bind the partition key, a value cannot be serialized, the covering set would be
+     * empty, or anything throws. Full fan-out is always correct, so a skip is never a
+     * correctness risk; a mis-prune would be, hence the conservative posture.
+     */
+    static List<CqliteFlightSplit> pruneToBoundPartitionKey(
+            CqliteFlightTableHandle handle, List<CqliteFlightSplit> ranges, Constraint constraint,
+            boolean pruningEnabled, Partitioner partitioner) {
+        try {
+            if (!pruningEnabled) {
+                return ranges;
+            }
+            if (constraint == null) {
+                return ranges;
+            }
+            if (partitioner != Partitioner.MURMUR3) {
+                LOG.log(System.Logger.Level.DEBUG,
+                        () -> "Split pruning disabled: partitioner " + partitioner
+                                + " is not Murmur3Partitioner; using full fan-out for "
+                                + handle.keyspace() + "." + handle.table());
+                return ranges;
+            }
+            List<KeyColumn> partitionKey = PrimaryKeyExtractor.extract(handle.ddl()).partitionKey();
+            BoundPartitionKeys bound = BoundPartitionKeys.compute(constraint.getSummary(), partitionKey);
+            if (!bound.isBound()) {
+                LOG.log(System.Logger.Level.DEBUG,
+                        () -> "Split pruning skipped for " + handle.keyspace() + "." + handle.table()
+                                + " (full fan-out): " + bound.skipReason());
+                return ranges;
+            }
+            long[] tokens = bound.tokens().orElseThrow();
+            List<CqliteFlightSplit> pruned = new ArrayList<>();
+            for (CqliteFlightSplit split : ranges) {
+                if (rangeCoversAnyToken(split, tokens)) {
+                    pruned.add(split);
+                }
+            }
+            if (pruned.isEmpty()) {
+                // Every token fell outside every emitted range: the ring guard already
+                // validated exact tiling, so this should be impossible — but if it happens,
+                // fail safe to the full fan-out rather than return zero splits (0 rows).
+                LOG.log(System.Logger.Level.WARNING,
+                        () -> "Split pruning produced no covering range for a fully-bound key on "
+                                + handle.keyspace() + "." + handle.table()
+                                + "; falling back to full fan-out (never drop rows)");
+                return ranges;
+            }
+            List<CqliteFlightSplit> full = ranges;
+            LOG.log(System.Logger.Level.DEBUG,
+                    () -> "Split pruning: " + full.size() + " -> " + pruned.size()
+                            + " splits for a fully-bound partition key on "
+                            + handle.keyspace() + "." + handle.table());
+            return pruned;
+        } catch (RuntimeException e) {
+            // Any unexpected failure in the pruning path must NOT fail the query or drop rows.
+            LOG.log(System.Logger.Level.WARNING,
+                    "Split pruning failed; using full fan-out for "
+                            + handle.keyspace() + "." + handle.table(), e);
+            return ranges;
+        }
+    }
+
+    /** Does this split's {@code (start, end]} range (with wraparound) contain any of {@code tokens}? */
+    private static boolean rangeCoversAnyToken(CqliteFlightSplit split, long[] tokens) {
+        for (long token : tokens) {
+            if (Murmur3Token.tokenInRange(
+                    token, split.tokenStart(), split.tokenEnd(), split.wraparound())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/Murmur3Token.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/Murmur3Token.java
@@ -1,0 +1,153 @@
+package in.mcfad.cqlite.flight;
+
+/**
+ * Cassandra-compatible Murmur3 partition-token computation (issue #2679), a
+ * byte-exact Java port of the Rust authority
+ * {@code cqlite-core/src/util/cassandra_murmur3.rs}
+ * ({@code cassandra_murmur3_x64_128} + {@code cassandra_murmur3_token} +
+ * {@code normalize}).
+ *
+ * <p>This preserves Cassandra's {@code MurmurHash.hash3_x64_128} sign-extension
+ * behavior in tail-byte processing (Java's {@code byte} is signed, so
+ * {@code (long) b} sign-extends exactly as Cassandra does), which diverges from
+ * standard Murmur3 for inputs containing bytes {@code >= 0x80}. The token is
+ * {@code h1} after {@code normalize} ({@link Long#MIN_VALUE} maps to
+ * {@link Long#MAX_VALUE}, the minimum token value being excluded from the ring).
+ *
+ * <p>Used only for plan-time split pruning: computing the covering token range(s)
+ * for a fully-bound partition key so the split manager emits splits for those
+ * range(s) instead of the full ~48-way fan-out. Correctness is pinned to the Rust
+ * implementation by shared test vectors (see {@code Murmur3TokenTest}).
+ */
+public final class Murmur3Token {
+    private static final long C1 = 0x87c37b911142_53d5L;
+    private static final long C2 = 0x4cf5ad4327_45937fL;
+    private static final long H1_ADD = 0x52dce729L;
+    private static final long H2_ADD = 0x38495ab5L;
+    private static final long FMIX_C1 = 0xff51afd7ed558ccdL;
+    private static final long FMIX_C2 = 0xc4ceb9fe1a85ec53L;
+
+    private Murmur3Token() {}
+
+    /**
+     * Compute the normalized Cassandra Murmur3 partition token for the given
+     * partition-key bytes (the canonical {@code PartitionKey::to_bytes} layout).
+     */
+    public static long token(byte[] data) {
+        return normalize(hash3X64128H1(data));
+    }
+
+    /**
+     * Cassandra's {@code Murmur3Partitioner} token normalization: {@link Long#MIN_VALUE}
+     * maps to {@link Long#MAX_VALUE} (the minimum token value is excluded from the ring).
+     */
+    public static long normalize(long h1) {
+        return h1 == Long.MIN_VALUE ? Long.MAX_VALUE : h1;
+    }
+
+    /**
+     * Half-open {@code (start, end]} token membership with optional ring wraparound,
+     * mirroring the server's {@code token_in_half_open_range}
+     * ({@code cqlite-flight/src/ticket.rs}) and the ring convention encoded in
+     * {@code CqliteFlightSplitManager.validateRingCoverage}. Equal endpoints
+     * ({@code start == end}) denote the FULL ring (issue #2228), accepting every token.
+     * A wraparound range ({@code start > end}) keeps {@code token > start || token <= end};
+     * a normal range keeps {@code start < token <= end}.
+     */
+    public static boolean tokenInRange(long token, long start, long end, boolean wraparound) {
+        if (start == end) {
+            return true;
+        }
+        return wraparound ? (token > start || token <= end) : (token > start && token <= end);
+    }
+
+    /** The {@code h1} 64-bit word of Cassandra's {@code MurmurHash.hash3_x64_128} (seed 0). */
+    private static long hash3X64128H1(byte[] data) {
+        long h1 = 0;
+        long h2 = 0;
+        int len = data.length;
+        int nblocks = len / 16;
+
+        // Body: 16-byte little-endian blocks.
+        for (int i = 0; i < nblocks; i++) {
+            int base = i * 16;
+            long k1 = getLongLE(data, base);
+            long k2 = getLongLE(data, base + 8);
+
+            k1 *= C1;
+            k1 = Long.rotateLeft(k1, 31);
+            k1 *= C2;
+            h1 ^= k1;
+            h1 = Long.rotateLeft(h1, 27);
+            h1 += h2;
+            h1 = h1 * 5 + H1_ADD;
+
+            k2 *= C2;
+            k2 = Long.rotateLeft(k2, 33);
+            k2 *= C1;
+            h2 ^= k2;
+            h2 = Long.rotateLeft(h2, 31);
+            h2 += h1;
+            h2 = h2 * 5 + H2_ADD;
+        }
+
+        // Tail: remaining bytes, sign-extended (Java byte is signed → matches Cassandra).
+        long k1 = 0;
+        long k2 = 0;
+        int tailStart = nblocks * 16;
+        int tailLen = len - tailStart;
+        for (int pos = 0; pos < tailLen; pos++) {
+            long b = data[tailStart + pos]; // implicit sign extension
+            int shift = (pos % 8) * 8;
+            if (pos < 8) {
+                k1 ^= b << shift;
+            } else {
+                k2 ^= b << shift;
+            }
+        }
+        if (tailLen >= 9) {
+            k2 *= C2;
+            k2 = Long.rotateLeft(k2, 33);
+            k2 *= C1;
+            h2 ^= k2;
+        }
+        if (tailLen > 0) {
+            k1 *= C1;
+            k1 = Long.rotateLeft(k1, 31);
+            k1 *= C2;
+            h1 ^= k1;
+        }
+
+        // Finalization.
+        h1 ^= len;
+        h2 ^= len;
+        h1 += h2;
+        h2 += h1;
+        h1 = fmix64(h1);
+        h2 = fmix64(h2);
+        h1 += h2;
+        // h2 += h1;  // not needed — the token is h1 only.
+        return h1;
+    }
+
+    /** Read 8 bytes at {@code offset} as a little-endian {@code long}. */
+    private static long getLongLE(byte[] data, int offset) {
+        return (data[offset] & 0xffL)
+                | (data[offset + 1] & 0xffL) << 8
+                | (data[offset + 2] & 0xffL) << 16
+                | (data[offset + 3] & 0xffL) << 24
+                | (data[offset + 4] & 0xffL) << 32
+                | (data[offset + 5] & 0xffL) << 40
+                | (data[offset + 6] & 0xffL) << 48
+                | (data[offset + 7] & 0xffL) << 56;
+    }
+
+    private static long fmix64(long value) {
+        value ^= value >>> 33;
+        value *= FMIX_C1;
+        value ^= value >>> 33;
+        value *= FMIX_C2;
+        value ^= value >>> 33;
+        return value;
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/PartitionKeyBytes.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/PartitionKeyBytes.java
@@ -1,0 +1,194 @@
+package in.mcfad.cqlite.flight;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Serializes typed partition-key values to the canonical Cassandra partition-key
+ * byte layout (issue #2679), the exact layout the Rust authority
+ * {@code PartitionKey::to_bytes} ({@code cqlite-core/src/storage/write_engine/mutation.rs})
+ * feeds to {@code cassandra_murmur3_token}:
+ *
+ * <ul>
+ *   <li><b>single-component</b> key → the raw serialized value bytes (no length prefix);</li>
+ *   <li><b>multi-component</b> key → for each component
+ *       {@code [len:u16 BE][value bytes][0x00]} concatenated.</li>
+ * </ul>
+ *
+ * <p>Per-value serialization mirrors {@code serialize_value_bytes}
+ * ({@code cqlite-core/src/storage/partition_key_codec.rs}): integers are big-endian
+ * two's-complement, text is UTF-8, blob is raw, boolean is one byte, and a UUID/timeuuid
+ * (which the server surfaces as {@code VARCHAR} with {@link PushdownCapability#EQUALITY})
+ * is its 16 big-endian bytes parsed from the canonical hyphenated string.
+ *
+ * <p><b>Fail-safe by construction (no-heuristics):</b> a value whose Trino type has no
+ * exact, unambiguous CQL byte serialization here returns {@link Optional#empty()} so the
+ * caller disables pruning for that query (full fan-out is always correct) rather than
+ * pruning on an approximate token. This is not a correctness gap — it is the mandated
+ * conservative default; unsupported types simply do not prune (and are logged upstream).
+ */
+public final class PartitionKeyBytes {
+    /** A component byte length must fit the u16 length prefix of the composite layout. */
+    private static final int MAX_COMPONENT_LEN = 0xFFFF;
+
+    private PartitionKeyBytes() {}
+
+    /**
+     * Serialize ONE partition-key column's value to its raw CQL value bytes, or empty when
+     * the {@code (type, capability)} pair has no exact serialization here (→ disable pruning).
+     *
+     * @param type       the column's Trino type (from its {@link CqliteFlightColumnHandle})
+     * @param capability the server-declared pushdown capability, used only to disambiguate
+     *                   {@code VARCHAR} (genuine text = {@code FULL} → UTF-8; uuid/timeuuid =
+     *                   {@code EQUALITY} → 16 bytes)
+     * @param value      the Trino native domain value (e.g. {@link Slice}, {@link Long},
+     *                   {@link Boolean})
+     */
+    public static Optional<byte[]> serializeValue(Type type, PushdownCapability capability, Object value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        if (type instanceof BooleanType) {
+            return value instanceof Boolean b
+                    ? Optional.of(new byte[] {(byte) (b ? 1 : 0)})
+                    : Optional.empty();
+        }
+        if (type instanceof TinyintType) {
+            return asLong(value).map(n -> new byte[] {(byte) (long) n});
+        }
+        if (type instanceof SmallintType) {
+            return asLong(value).map(n -> shortBe((short) (long) n));
+        }
+        if (type instanceof IntegerType) {
+            return asLong(value).map(n -> intBe((int) (long) n));
+        }
+        if (type instanceof BigintType) {
+            return asLong(value).map(PartitionKeyBytes::longBe);
+        }
+        if (type instanceof VarbinaryType) {
+            // blob → raw bytes.
+            return value instanceof Slice slice ? Optional.of(slice.getBytes()) : Optional.empty();
+        }
+        if (type instanceof VarcharType) {
+            String text = asString(value).orElse(null);
+            if (text == null) {
+                return Optional.empty();
+            }
+            if (capability == PushdownCapability.EQUALITY) {
+                // uuid / timeuuid: the CQL value bytes are the 16-byte big-endian UUID, NOT the
+                // UTF-8 of the hyphenated string. Parse it; a non-UUID string disables pruning.
+                return uuidBytes(text);
+            }
+            if (capability == PushdownCapability.FULL) {
+                // genuine text / ascii / varchar → UTF-8 bytes.
+                return Optional.of(text.getBytes(StandardCharsets.UTF_8));
+            }
+            return Optional.empty();
+        }
+        // Any other type (real, double, date, time, timestamp, decimal, varint, …) has no
+        // exact partition-key serialization wired here → fail-safe: no pruning.
+        return Optional.empty();
+    }
+
+    /**
+     * Assemble the full partition-key bytes from per-component value bytes: a single component
+     * is its raw bytes; multiple components use the {@code [len:u16 BE][bytes][0x00]} layout.
+     * Returns empty if any component exceeds the u16 length the composite layout can encode.
+     */
+    public static Optional<byte[]> fullKey(List<byte[]> components) {
+        if (components.isEmpty()) {
+            return Optional.empty();
+        }
+        if (components.size() == 1) {
+            return Optional.of(components.get(0));
+        }
+        for (byte[] c : components) {
+            if (c.length > MAX_COMPONENT_LEN) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(composite(components.toArray(new byte[0][])));
+    }
+
+    /**
+     * The multi-component composite layout ({@code [len:u16 BE][bytes][0x00]} per component,
+     * including the last) — the exact encoding {@code PartitionKey::to_bytes} emits for a
+     * composite partition key. Package-visible so token tests can build composite keys directly.
+     */
+    static byte[] composite(byte[][] components) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] c : components) {
+            int len = c.length;
+            out.write((len >>> 8) & 0xFF);
+            out.write(len & 0xFF);
+            out.write(c, 0, c.length);
+            out.write(0x00);
+        }
+        return out.toByteArray();
+    }
+
+    private static Optional<Long> asLong(Object value) {
+        if (value instanceof Long l) {
+            return Optional.of(l);
+        }
+        if (value instanceof Number n) {
+            return Optional.of(n.longValue());
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> asString(Object value) {
+        if (value instanceof Slice slice) {
+            return Optional.of(slice.toStringUtf8());
+        }
+        if (value instanceof String s) {
+            return Optional.of(s);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<byte[]> uuidBytes(String text) {
+        try {
+            UUID uuid = UUID.fromString(text.trim());
+            byte[] out = new byte[16];
+            longToBe(uuid.getMostSignificantBits(), out, 0);
+            longToBe(uuid.getLeastSignificantBits(), out, 8);
+            return Optional.of(out);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty(); // not a canonical UUID → disable pruning, never misprune.
+        }
+    }
+
+    private static byte[] shortBe(short v) {
+        return new byte[] {(byte) (v >>> 8), (byte) v};
+    }
+
+    private static byte[] intBe(int v) {
+        return new byte[] {(byte) (v >>> 24), (byte) (v >>> 16), (byte) (v >>> 8), (byte) v};
+    }
+
+    private static byte[] longBe(long v) {
+        byte[] out = new byte[8];
+        longToBe(v, out, 0);
+        return out;
+    }
+
+    private static void longToBe(long v, byte[] out, int offset) {
+        for (int i = 0; i < 8; i++) {
+            out[offset + i] = (byte) (v >>> (56 - 8 * i));
+        }
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/Partitioner.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/Partitioner.java
@@ -1,0 +1,36 @@
+package in.mcfad.cqlite.flight;
+
+/**
+ * The cluster partitioner, resolved for plan-time split pruning (issue #2679).
+ *
+ * <p>Under the no-heuristics mandate the token is computed from schema-declared
+ * partition-key columns against a <em>declared</em> partitioner — never inferred
+ * from data. The Cassandra Sidecar exposes no partitioner field today, and the
+ * entire ring machinery ({@code CqliteFlightSplitManager.validateRingCoverage},
+ * {@code SidecarModels}, token parsing) already <b>hard-assumes
+ * {@code Murmur3Partitioner}</b> (signed 64-bit tokens). This enum makes that
+ * assumption explicit and centralized: {@link #resolve()} returns {@link #MURMUR3}
+ * (the current and only supported case). If/when a partitioner name becomes
+ * available from Sidecar metadata, {@link #resolve()} reads it; any non-Murmur3 or
+ * unknown partitioner resolves to {@link #UNSUPPORTED}, which disables pruning
+ * (full fan-out is always correct) — see {@code CqliteFlightSplitManager}.
+ *
+ * <p>This is an OWNER-APPROVED design decision (design.md §2): the honest encoding
+ * of today's reality, fully fail-safe. Follow-up: surface the partitioner name from
+ * Sidecar when that metadata lands.
+ */
+public enum Partitioner {
+    /** Cassandra's {@code Murmur3Partitioner} — the only partitioner that prunes. */
+    MURMUR3,
+    /** Any unknown or non-Murmur3 partitioner — pruning is disabled (full fan-out). */
+    UNSUPPORTED;
+
+    /**
+     * The partitioner assumed for the ring today. The ring already treats all token
+     * bounds as signed 64-bit Murmur3 tokens, so this returns {@link #MURMUR3}. This
+     * is the single resolution point a future Sidecar-metadata source would read.
+     */
+    public static Partitioner resolve() {
+        return MURMUR3;
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/PrimaryKeyExtractor.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/PrimaryKeyExtractor.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -90,6 +91,141 @@ public final class PrimaryKeyExtractor {
             }
         }
         return new Keys(List.of(), List.of());
+    }
+
+    /**
+     * Independently count the number of PARTITION-KEY components in {@code ddl}, using a
+     * QUOTE-AWARE scan that {@link #parseClause} does not perform. This is the fail-safe
+     * cross-check for plan-time split pruning (issue #2679): the pruning path builds a
+     * composite partition-key byte layout ({@code [len:u16 BE][value][0x00]} per component)
+     * whose token is only correct when EVERY component is present in order. A parse
+     * UNDER-count (e.g. a quoted identifier containing {@code ')'} closes the composite group
+     * early) would silently drop the partition's rows. The caller prunes ONLY when this arity
+     * agrees with {@link #extract}'s partition-key column count; any disagreement (or an
+     * indeterminate parse here) forces the full fan-out (always correct).
+     *
+     * <p>Returns {@link OptionalInt#empty()} when the partition-key arity cannot be determined
+     * with confidence (no locatable PRIMARY KEY, an unbalanced clause) so the caller fails safe.
+     *
+     * <p>Robustness comes from masking the contents of every double-quoted identifier to a
+     * neutral filler BEFORE any structural (paren/comma) scanning, so parentheses, commas, and
+     * keywords inside a quoted identifier can never be mistaken for CQL syntax.
+     */
+    public static OptionalInt partitionKeyArity(String ddl) {
+        if (ddl == null) {
+            return OptionalInt.empty();
+        }
+        String masked = maskQuotedIdentifiers(ddl);
+        Matcher clause = PK_CLAUSE.matcher(masked);
+        if (clause.find()) {
+            int openParen = clause.end() - 1;
+            int close = matchingParen(masked, openParen);
+            if (close < 0) {
+                return OptionalInt.empty();
+            }
+            String body = masked.substring(openParen + 1, close);
+            String trimmed = body.trim();
+            if (trimmed.startsWith("(")) {
+                // Composite partition key: count the components inside the leading (...) group.
+                int innerOpen = body.indexOf('(');
+                int innerClose = matchingParen(body, innerOpen);
+                if (innerClose < 0) {
+                    return OptionalInt.empty();
+                }
+                String inner = body.substring(innerOpen + 1, innerClose);
+                return OptionalInt.of(countTopLevelComponents(inner));
+            }
+            // Simple PK clause: the first top-level column is the (single) partition key.
+            return OptionalInt.of(1);
+        }
+        // Inline single-column form: "<col> <type> PRIMARY KEY".
+        if (INLINE_PK.matcher(masked).find()) {
+            return OptionalInt.of(1);
+        }
+        return OptionalInt.empty();
+    }
+
+    /**
+     * Count the top-level (depth-0), non-empty comma-separated components of {@code group}.
+     * {@code group} is already quote-masked, so parentheses here are structural only.
+     */
+    private static int countTopLevelComponents(String group) {
+        int depth = 0;
+        int count = 0;
+        StringBuilder cur = new StringBuilder();
+        for (int i = 0; i < group.length(); i++) {
+            char c = group.charAt(i);
+            if (c == '(') {
+                depth++;
+                cur.append(c);
+            } else if (c == ')') {
+                depth--;
+                cur.append(c);
+            } else if (c == ',' && depth == 0) {
+                if (!cur.toString().trim().isEmpty()) {
+                    count++;
+                }
+                cur.setLength(0);
+            } else {
+                cur.append(c);
+            }
+        }
+        if (!cur.toString().trim().isEmpty()) {
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * Index of the parenthesis matching the {@code '('} at {@code open} in an
+     * already-quote-masked string, or {@code -1} if unbalanced.
+     */
+    private static int matchingParen(String masked, int open) {
+        int depth = 0;
+        for (int i = open; i < masked.length(); i++) {
+            char c = masked.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+                if (depth == 0) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Replace the contents of every double-quoted CQL identifier with a neutral filler
+     * ({@code 'a'}), preserving overall length and the quote delimiters, so a subsequent
+     * structural scan cannot mistake a {@code '('}, {@code ')'}, {@code ','}, or keyword
+     * INSIDE a quoted identifier for CQL syntax. A doubled quote ({@code ""}) inside a quoted
+     * identifier is the CQL escape for a literal quote and stays part of the string (masked).
+     */
+    private static String maskQuotedIdentifiers(String ddl) {
+        char[] out = ddl.toCharArray();
+        boolean inQuote = false;
+        for (int i = 0; i < out.length; i++) {
+            char c = out[i];
+            if (!inQuote) {
+                if (c == '"') {
+                    inQuote = true;
+                }
+            } else if (c == '"') {
+                if (i + 1 < out.length && out[i + 1] == '"') {
+                    // Escaped quote inside the identifier: both chars are content → mask both.
+                    out[i] = 'a';
+                    out[i + 1] = 'a';
+                    i++;
+                } else {
+                    inQuote = false; // closing quote
+                }
+            } else {
+                out[i] = 'a';
+            }
+        }
+        return new String(out);
     }
 
     /**

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
@@ -42,6 +42,20 @@ class CqliteFlightConfigTest {
                 config.snapshotRetireGraceMillis());
         assertEquals(CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_NANOS,
                 config.snapshotRetireGraceNanos());
+        // Plan-time split pruning defaults ON (issue #2679).
+        assertEquals(CqliteFlightConfig.DEFAULT_SPLIT_PRUNING_ENABLED, config.splitPruningEnabled());
+    }
+
+    @Test
+    void parsesSplitPruningToggle() {
+        Map<String, String> off = base();
+        off.put("cqlite.split-pruning-enabled", "false");
+        assertEquals(false, CqliteFlightConfig.fromMap(off).splitPruningEnabled(),
+                "cqlite.split-pruning-enabled=false forces the unpruned baseline (issue #2679)");
+
+        Map<String, String> on = base();
+        on.put("cqlite.split-pruning-enabled", "true");
+        assertEquals(true, CqliteFlightConfig.fromMap(on).splitPruningEnabled());
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightLogicalRowCountTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightLogicalRowCountTest.java
@@ -49,7 +49,8 @@ class CqliteFlightLogicalRowCountTest {
                 GroupByPushdownPolicy.AUTOMATIC, 0.5, 3000,
                 ReadMode.SNAPSHOT, java.util.Optional.of("6h"),
                 CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS,
-                CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS);
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS,
+                CqliteFlightConfig.DEFAULT_SPLIT_PRUNING_ENABLED);
     }
 
     private static CqliteFlightTableHandle plainHandle() {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningTest.java
@@ -38,6 +38,24 @@ class CqliteFlightSplitPruningTest {
     private static final CqliteFlightTableHandle INT_PK_TABLE =
             new CqliteFlightTableHandle("ks", "t", "CREATE TABLE ks.t (id int PRIMARY KEY, v text)");
 
+    // uuid / timeuuid PKs surface as VARCHAR with EQUALITY capability; the server parses the
+    // hyphenated string to the 16-byte big-endian UUID (PartitionKeyBytes.uuidBytes) — a
+    // distinct serialization from a genuine text (FULL, UTF-8) PK.
+    private static final CqliteFlightColumnHandle ID_UUID =
+            new CqliteFlightColumnHandle("id", VARCHAR, PushdownCapability.EQUALITY);
+    private static final CqliteFlightTableHandle UUID_PK_TABLE =
+            new CqliteFlightTableHandle("ks", "u", "CREATE TABLE ks.u (id uuid PRIMARY KEY, v text)");
+    private static final CqliteFlightTableHandle TIMEUUID_PK_TABLE =
+            new CqliteFlightTableHandle("ks", "u", "CREATE TABLE ks.u (id timeuuid PRIMARY KEY, v text)");
+
+    private static byte[] bytes(int... vals) {
+        byte[] out = new byte[vals.length];
+        for (int i = 0; i < vals.length; i++) {
+            out[i] = (byte) vals[i];
+        }
+        return out;
+    }
+
     private static ReplicaInfo range(long start, long end) {
         return new ReplicaInfo(Long.toString(start), Long.toString(end),
                 Map.of("dc1", List.of("10.0.0.1:7000")));
@@ -202,6 +220,69 @@ class CqliteFlightSplitPruningTest {
         List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
                 table, full, constraint, true, Partitioner.MURMUR3);
         assertEquals(full.size(), pruned.size(), "un-serializable PK value → no pruning, never misprune");
+    }
+
+    // ── uuid / timeuuid PK: VARCHAR + EQUALITY → 16-byte parse → covering split ─
+
+    // Canonical uuid whose parsed 16-byte big-endian representation is the pinned
+    // Murmur3TokenTest vector {0x55,0x0e,0x84,0x00,0xe2,0x9b,0x41,0xd4,0xa7,0x16,0x44,0x66,0x55,0x44,0,0}.
+    private static final String CANONICAL_UUID = "550e8400-e29b-41d4-a716-446655440000";
+    private static final byte[] CANONICAL_UUID_BYTES =
+            bytes(0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00);
+
+    @Test
+    void uuidPkFullyBoundPrunesToCoveringSplitAtParsedByteToken() {
+        // The token the prune must target is the token of the PARSED 16 bytes, NOT the UTF-8
+        // of the hyphenated string — proving the uuid string→16-byte parse path is exercised.
+        long token = Murmur3Token.token(CANONICAL_UUID_BYTES);
+        assertEquals(4277286421682315655L, token, "pinned uuid vector token (Murmur3TokenTest)");
+        // UTF-8-of-the-string token differs → confirms we are not accidentally hashing the string.
+        assertTrue(token != Murmur3Token.token(CANONICAL_UUID.getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+                "the parsed-byte token must differ from the UTF-8-of-string token");
+
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_UUID, Domain.singleValue(VARCHAR, Slices.utf8Slice(CANONICAL_UUID)))));
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(UUID_PK_TABLE, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = prune(UUID_PK_TABLE, resp, constraint);
+
+        assertTrue(full.size() > 1, "fixture must fan out to many ranges on main");
+        assertEquals(1, pruned.size(), "a fully-bound uuid PK prunes to exactly one covering split");
+        CqliteFlightSplit s = pruned.get(0);
+        assertTrue(Murmur3Token.tokenInRange(token, s.tokenStart(), s.tokenEnd(), s.wraparound()),
+                "the emitted split covers the token of the parsed 16-byte uuid");
+    }
+
+    @Test
+    void timeuuidPkFullyBoundPrunesToCoveringSplitAtParsedByteToken() {
+        // timeuuid uses the same VARCHAR+EQUALITY → 16-byte-parse path as uuid.
+        long token = Murmur3Token.token(CANONICAL_UUID_BYTES);
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_UUID, Domain.singleValue(VARCHAR, Slices.utf8Slice(CANONICAL_UUID)))));
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(TIMEUUID_PK_TABLE, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = prune(TIMEUUID_PK_TABLE, resp, constraint);
+
+        assertTrue(full.size() > 1, "fixture must fan out to many ranges on main");
+        assertEquals(1, pruned.size(), "a fully-bound timeuuid PK prunes to exactly one covering split");
+        assertTrue(Murmur3Token.tokenInRange(
+                token, pruned.get(0).tokenStart(), pruned.get(0).tokenEnd(), pruned.get(0).wraparound()));
+    }
+
+    @Test
+    void nonCanonicalUuidStringKeepsFullFanOut() {
+        // A garbage/non-canonical uuid string cannot be parsed to 16 bytes → no serialization →
+        // fail-safe full fan-out, never a misprune.
+        long token = Murmur3Token.token(CANONICAL_UUID_BYTES);
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(UUID_PK_TABLE, resp, "dc1", 8815);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_UUID, Domain.singleValue(VARCHAR, Slices.utf8Slice("not-a-uuid")))));
+
+        assertEquals(full.size(), prune(UUID_PK_TABLE, resp, constraint).size(),
+                "a non-canonical uuid string cannot be serialized → full fan-out (never misprune)");
     }
 
     // ── Composite PK: both components bound → 1 covering split ──────────────────

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningTest.java
@@ -308,6 +308,36 @@ class CqliteFlightSplitPruningTest {
                 token, pruned.get(0).tokenStart(), pruned.get(0).tokenEnd(), pruned.get(0).wraparound()));
     }
 
+    /**
+     * Composite-PK fail-safe (issue #2679 roborev, silent-row-loss guard): a composite-PK DDL
+     * spelling the main {@link PrimaryKeyExtractor} cannot resolve consistently — here a quoted
+     * identifier containing {@code ')'}, which UNDER-counts the partition key to a single
+     * component — must NOT prune, even when the constraint binds BOTH real components. The
+     * independent quote-aware arity cross-check disagrees with the extractor's under-count, so
+     * the guard forces the FULL fan-out (always correct). Without the guard this would build a
+     * single-component key, compute the wrong token, and silently drop the partition's rows.
+     */
+    @Test
+    void compositePkExtractorUnderCountKeepsFullFanOut() {
+        // Quoted PK component "a)b": PrimaryKeyExtractor.extract under-counts to ["a] (size 1),
+        // but the true partition key is ("a)b", b) — arity 2. Bind both real components.
+        CqliteFlightColumnHandle pk1 =
+                new CqliteFlightColumnHandle("a)b", VARCHAR, PushdownCapability.FULL);
+        CqliteFlightColumnHandle pk2 = new CqliteFlightColumnHandle("b", INTEGER, PushdownCapability.FULL);
+        CqliteFlightTableHandle table = new CqliteFlightTableHandle(
+                "ks", "t", "CREATE TABLE ks.t (\"a)b\" text, b int, v text, PRIMARY KEY ((\"a)b\", b)))");
+        TokenRangeReplicasResponse resp = ringCovering(-100L, 0L, 100L);
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(table, resp, "dc1", 8815);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                pk1, Domain.singleValue(VARCHAR, Slices.utf8Slice("hello")),
+                pk2, Domain.singleValue(INTEGER, 42L))));
+
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                table, full, constraint, true, Partitioner.MURMUR3);
+        assertEquals(full.size(), pruned.size(),
+                "an extractor under-count on a composite PK must keep the full fan-out (never drop rows)");
+    }
+
     @Test
     void compositePkPartiallyBoundKeepsFullFanOut() {
         CqliteFlightColumnHandle pk1 = new CqliteFlightColumnHandle("a", VARCHAR, PushdownCapability.FULL);

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningTest.java
@@ -1,0 +1,245 @@
+package in.mcfad.cqlite.flight;
+
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
+import io.airlift.slice.Slices;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Plan-time split pruning (issue #2679): a fully-bound partition key prunes the emitted
+ * splits to the covering token range(s); anything less keeps the full fan-out. Exercises
+ * {@link CqliteFlightSplitManager#pruneToBoundPartitionKey} — the seam {@code getSplits}
+ * calls after {@code buildSplits} — over a multi-range fixture whose ranges tile the ring.
+ */
+class CqliteFlightSplitPruningTest {
+
+    // int PK 'id'; the server surfaces int as FULL-capability.
+    private static final CqliteFlightColumnHandle ID_INT =
+            new CqliteFlightColumnHandle("id", INTEGER, PushdownCapability.FULL);
+    private static final CqliteFlightColumnHandle NAME_TEXT =
+            new CqliteFlightColumnHandle("name", VARCHAR, PushdownCapability.FULL);
+
+    private static final CqliteFlightTableHandle INT_PK_TABLE =
+            new CqliteFlightTableHandle("ks", "t", "CREATE TABLE ks.t (id int PRIMARY KEY, v text)");
+
+    private static ReplicaInfo range(long start, long end) {
+        return new ReplicaInfo(Long.toString(start), Long.toString(end),
+                Map.of("dc1", List.of("10.0.0.1:7000")));
+    }
+
+    /**
+     * A full-ring tiling split into many single-token-width ranges so distinct keys land in
+     * distinct ranges. Boundaries are the sorted token set plus MIN/MAX endpoints; the ranges
+     * are {@code (b[i], b[i+1]]} and the closing range wraps MAX→MIN via a final (MAX==MIN)
+     * arrangement. We instead use an explicit unwrapped (MIN, .., MAX] chain (validateRingCoverage
+     * accepts it) so no wraparound complicates the covering assertion.
+     */
+    private static TokenRangeReplicasResponse ringCovering(long... interiorBoundaries) {
+        long[] sorted = interiorBoundaries.clone();
+        java.util.Arrays.sort(sorted);
+        List<ReplicaInfo> ranges = new ArrayList<>();
+        long prev = Long.MIN_VALUE;
+        for (long b : sorted) {
+            ranges.add(range(prev, b));
+            prev = b;
+        }
+        ranges.add(range(prev, Long.MAX_VALUE));
+        return new TokenRangeReplicasResponse(List.of(), ranges);
+    }
+
+    private static Constraint summary(TupleDomain<ColumnHandle> summary) {
+        return new Constraint(summary, Constant.TRUE, Map.of());
+    }
+
+    private static List<CqliteFlightSplit> prune(
+            CqliteFlightTableHandle table, TokenRangeReplicasResponse resp, Constraint constraint) {
+        List<CqliteFlightSplit> full =
+                CqliteFlightSplitManager.buildSplits(table, resp, "dc1", 8815);
+        return CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                table, full, constraint, true, Partitioner.MURMUR3);
+    }
+
+    // ── Requirement 1: single fully-bound PK → exactly the covering split ────────
+
+    @Test
+    void singleFullyBoundPkEmitsExactlyTheCoveringSplit() {
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A}); // int 42
+        // Build a ring whose boundaries split the token off into its own range.
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_INT, Domain.singleValue(INTEGER, 42L))));
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(INT_PK_TABLE, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = prune(INT_PK_TABLE, resp, constraint);
+
+        assertTrue(full.size() > 1, "fixture must fan out to many ranges on main");
+        assertEquals(1, pruned.size(), "a single fully-bound PK prunes to exactly one covering split");
+        // The one emitted split's (start, end] contains the key's token.
+        CqliteFlightSplit s = pruned.get(0);
+        assertTrue(Murmur3Token.tokenInRange(token, s.tokenStart(), s.tokenEnd(), s.wraparound()));
+    }
+
+    @Test
+    void partialOrAbsentOrRangePkKeepsFullFanOut() {
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(INT_PK_TABLE, resp, "dc1", 8815);
+
+        // Absent PK: only a non-PK predicate bound.
+        var nonPk = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                NAME_TEXT, Domain.singleValue(VARCHAR, Slices.utf8Slice("x")))));
+        assertEquals(full.size(), prune(INT_PK_TABLE, resp, nonPk).size(),
+                "a non-PK predicate does not prune");
+
+        // Range on the PK column: not equality/IN → no pruning.
+        var rangePk = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_INT, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 10L)), false))));
+        assertEquals(full.size(), prune(INT_PK_TABLE, resp, rangePk).size(),
+                "a range on the PK does not prune");
+
+        // Absent constraint (TupleDomain.all()).
+        assertEquals(full.size(),
+                prune(INT_PK_TABLE, resp, summary(TupleDomain.all())).size(),
+                "no bound columns → full fan-out");
+    }
+
+    // ── Requirement 2: IN over full PKs → deduped union ─────────────────────────
+
+    @Test
+    void inListPrunesToDedupedUnionOfCoveringRanges() {
+        long t1 = Murmur3Token.token(new byte[] {0, 0, 0, 0x01}); // int 1
+        long t2 = Murmur3Token.token(new byte[] {0, 0, 0, 0x02}); // int 2
+        // Ring where t1 and t2 fall into distinct ranges.
+        long lo = Math.min(t1, t2);
+        long hi = Math.max(t1, t2);
+        TokenRangeReplicasResponse resp = ringCovering(lo - 1, lo, hi - 1, hi);
+        var in = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_INT, Domain.multipleValues(INTEGER, List.of(1L, 2L)))));
+
+        List<CqliteFlightSplit> pruned = prune(INT_PK_TABLE, resp, in);
+        assertEquals(2, pruned.size(), "two keys in two ranges → the two-range union");
+        assertTrue(pruned.stream().anyMatch(
+                s -> Murmur3Token.tokenInRange(t1, s.tokenStart(), s.tokenEnd(), s.wraparound())));
+        assertTrue(pruned.stream().anyMatch(
+                s -> Murmur3Token.tokenInRange(t2, s.tokenStart(), s.tokenEnd(), s.wraparound())));
+    }
+
+    @Test
+    void twoInKeysSharingARangeCollapseToOneSplit() {
+        long t1 = Murmur3Token.token(new byte[] {0, 0, 0, 0x01});
+        long t2 = Murmur3Token.token(new byte[] {0, 0, 0, 0x02});
+        long lo = Math.min(t1, t2);
+        long hi = Math.max(t1, t2);
+        // One wide range [lo-1, hi] that contains BOTH tokens.
+        TokenRangeReplicasResponse resp = ringCovering(lo - 1, hi);
+        var in = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_INT, Domain.multipleValues(INTEGER, List.of(1L, 2L)))));
+
+        List<CqliteFlightSplit> pruned = prune(INT_PK_TABLE, resp, in);
+        assertEquals(1, pruned.size(), "two keys in the same range collapse to one split");
+        assertTrue(Murmur3Token.tokenInRange(
+                t1, pruned.get(0).tokenStart(), pruned.get(0).tokenEnd(), pruned.get(0).wraparound()));
+        assertTrue(Murmur3Token.tokenInRange(
+                t2, pruned.get(0).tokenStart(), pruned.get(0).tokenEnd(), pruned.get(0).wraparound()));
+    }
+
+    // ── Requirement 3: fail-safe (partitioner / serialization / toggle) ─────────
+
+    @Test
+    void unknownPartitionerDisablesPruning() {
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(INT_PK_TABLE, resp, "dc1", 8815);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_INT, Domain.singleValue(INTEGER, 42L))));
+
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                INT_PK_TABLE, full, constraint, true, Partitioner.UNSUPPORTED);
+        assertEquals(full.size(), pruned.size(), "non-Murmur3 partitioner → no pruning (full fan-out)");
+    }
+
+    @Test
+    void toggleOffDisablesPruning() {
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(INT_PK_TABLE, resp, "dc1", 8815);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                ID_INT, Domain.singleValue(INTEGER, 42L))));
+
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                INT_PK_TABLE, full, constraint, false, Partitioner.MURMUR3);
+        assertEquals(full.size(), pruned.size(), "toggle off forces the unpruned baseline");
+    }
+
+    @Test
+    void unserializablePkValueDisablesPruning() {
+        // A double PK column has no exact partition-key byte serialization here → no prune.
+        var doublePk = new CqliteFlightColumnHandle("id", io.trino.spi.type.DoubleType.DOUBLE,
+                PushdownCapability.FULL);
+        CqliteFlightTableHandle table =
+                new CqliteFlightTableHandle("ks", "t", "CREATE TABLE ks.t (id double PRIMARY KEY)");
+        TokenRangeReplicasResponse resp = ringCovering(-100L, 0L, 100L);
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(table, resp, "dc1", 8815);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                doublePk, Domain.singleValue(io.trino.spi.type.DoubleType.DOUBLE, 1.5d))));
+
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                table, full, constraint, true, Partitioner.MURMUR3);
+        assertEquals(full.size(), pruned.size(), "un-serializable PK value → no pruning, never misprune");
+    }
+
+    // ── Composite PK: both components bound → 1 covering split ──────────────────
+
+    @Test
+    void compositePkFullyBoundPrunesToCoveringSplit() {
+        CqliteFlightColumnHandle pk1 = new CqliteFlightColumnHandle("a", VARCHAR, PushdownCapability.FULL);
+        CqliteFlightColumnHandle pk2 = new CqliteFlightColumnHandle("b", INTEGER, PushdownCapability.FULL);
+        CqliteFlightTableHandle table = new CqliteFlightTableHandle(
+                "ks", "t", "CREATE TABLE ks.t (a text, b int, v text, PRIMARY KEY ((a, b)))");
+        // ('hello', 42) → known composite token from the Rust oracle.
+        long token = 7666157718303755816L;
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                pk1, Domain.singleValue(VARCHAR, Slices.utf8Slice("hello")),
+                pk2, Domain.singleValue(INTEGER, 42L))));
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(table, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                table, full, constraint, true, Partitioner.MURMUR3);
+        assertEquals(1, pruned.size(), "both composite PK components bound → one covering split");
+        assertTrue(Murmur3Token.tokenInRange(
+                token, pruned.get(0).tokenStart(), pruned.get(0).tokenEnd(), pruned.get(0).wraparound()));
+    }
+
+    @Test
+    void compositePkPartiallyBoundKeepsFullFanOut() {
+        CqliteFlightColumnHandle pk1 = new CqliteFlightColumnHandle("a", VARCHAR, PushdownCapability.FULL);
+        CqliteFlightTableHandle table = new CqliteFlightTableHandle(
+                "ks", "t", "CREATE TABLE ks.t (a text, b int, v text, PRIMARY KEY ((a, b)))");
+        TokenRangeReplicasResponse resp = ringCovering(-100L, 0L, 100L);
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(table, resp, "dc1", 8815);
+        // Only 'a' bound; 'b' free → partial PK → no pruning.
+        var constraint = summary(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                pk1, Domain.singleValue(VARCHAR, Slices.utf8Slice("hello")))));
+
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                table, full, constraint, true, Partitioner.MURMUR3);
+        assertEquals(full.size(), pruned.size(), "partial composite PK → full fan-out");
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningWiringTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningWiringTest.java
@@ -213,6 +213,65 @@ class CqliteFlightSplitPruningWiringTest {
         }
     }
 
+    /**
+     * uuid PK (VARCHAR + EQUALITY capability) prunes through the PUBLIC getSplits surface, and the
+     * ONE emitted split covers the token of the PARSED 16-byte uuid — proving the uuid string→16-byte
+     * parse + token path (PartitionKeyBytes.uuidBytes) is exercised end-to-end, not just some split.
+     */
+    @Test
+    void uuidPkPointReadPrunesToParsedByteTokenThroughPublicSurface() throws Exception {
+        CqliteFlightColumnHandle idUuid =
+                new CqliteFlightColumnHandle("id", VARCHAR, PushdownCapability.EQUALITY);
+        String uuid = "550e8400-e29b-41d4-a716-446655440000";
+        // The pinned Murmur3TokenTest vector for this uuid's 16 big-endian bytes.
+        byte[] parsed = {0x55, 0x0e, (byte) 0x84, 0x00, (byte) 0xe2, (byte) 0x9b, 0x41, (byte) 0xd4,
+                (byte) 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00};
+        long token = Murmur3Token.token(parsed);
+        assertEquals(4277286421682315655L, token, "pinned uuid vector token");
+        HttpServer server = startFakeSidecar(tokenRangeReplicasJson(token));
+        try {
+            URI uri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+            SidecarClient sidecar = new SidecarClient(uri);
+            var mgr = new CqliteFlightSplitManager(config(uri, true), sidecar, liveSnapshots());
+            CqliteFlightTableHandle handle =
+                    new CqliteFlightTableHandle("ks", "u", "CREATE TABLE ks.u (id uuid PRIMARY KEY, v text)");
+            var constraint = new Constraint(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                    idUuid, Domain.singleValue(VARCHAR, Slices.utf8Slice(uuid)))), Constant.TRUE, Map.of());
+
+            List<ConnectorSplit> splits = drain(mgr.getSplits(null, null, handle, null, constraint));
+            assertEquals(1, splits.size(), "uuid PK point read prunes to one covering split");
+            CqliteFlightSplit s = (CqliteFlightSplit) splits.get(0);
+            assertTrue(Murmur3Token.tokenInRange(token, s.tokenStart(), s.tokenEnd(), s.wraparound()),
+                    "the single emitted split covers the token of the parsed 16-byte uuid");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /** A non-canonical uuid string cannot parse to 16 bytes → fail-safe full fan-out, never misprune. */
+    @Test
+    void nonCanonicalUuidStringKeepsFullFanOutThroughPublicSurface() throws Exception {
+        CqliteFlightColumnHandle idUuid =
+                new CqliteFlightColumnHandle("id", VARCHAR, PushdownCapability.EQUALITY);
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        HttpServer server = startFakeSidecar(tokenRangeReplicasJson(token));
+        try {
+            URI uri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+            SidecarClient sidecar = new SidecarClient(uri);
+            var mgr = new CqliteFlightSplitManager(config(uri, true), sidecar, liveSnapshots());
+            CqliteFlightTableHandle handle =
+                    new CqliteFlightTableHandle("ks", "u", "CREATE TABLE ks.u (id uuid PRIMARY KEY, v text)");
+            var constraint = new Constraint(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                    idUuid, Domain.singleValue(VARCHAR, Slices.utf8Slice("not-a-uuid")))), Constant.TRUE, Map.of());
+
+            List<ConnectorSplit> splits = drain(mgr.getSplits(null, null, handle, null, constraint));
+            assertTrue(splits.size() > 1,
+                    "a non-canonical uuid string cannot be serialized → full fan-out (never misprune)");
+        } finally {
+            server.stop(0);
+        }
+    }
+
     /** VARCHAR text PK (utf-8 bytes) also prunes through the public surface. */
     @Test
     void textPkPointReadPrunesThroughPublicSurface() throws Exception {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningWiringTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningWiringTest.java
@@ -272,6 +272,38 @@ class CqliteFlightSplitPruningWiringTest {
         }
     }
 
+    /**
+     * Composite-PK fail-safe through the PUBLIC getSplits surface (issue #2679 roborev): a
+     * composite-PK DDL whose quoted {@code ')'} identifier makes the main extractor UNDER-count
+     * the partition key must emit the FULL fan-out even with BOTH real components bound. The
+     * independent arity cross-check disagrees with the under-count, so the connector refuses to
+     * prune — never a mis-pruned (row-dropping) plan. Asserted on the public split count.
+     */
+    @Test
+    void compositePkExtractorUnderCountKeepsFullFanOutThroughPublicSurface() throws Exception {
+        CqliteFlightColumnHandle pk1 =
+                new CqliteFlightColumnHandle("a)b", VARCHAR, PushdownCapability.FULL);
+        CqliteFlightColumnHandle pk2 = new CqliteFlightColumnHandle("b", INTEGER, PushdownCapability.FULL);
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        HttpServer server = startFakeSidecar(tokenRangeReplicasJson(token));
+        try {
+            URI uri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+            SidecarClient sidecar = new SidecarClient(uri);
+            var mgr = new CqliteFlightSplitManager(config(uri, true), sidecar, liveSnapshots());
+            CqliteFlightTableHandle handle = new CqliteFlightTableHandle(
+                    "ks", "t", "CREATE TABLE ks.t (\"a)b\" text, b int, v text, PRIMARY KEY ((\"a)b\", b)))");
+            var constraint = new Constraint(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                    pk1, Domain.singleValue(VARCHAR, Slices.utf8Slice("hello")),
+                    pk2, Domain.singleValue(INTEGER, 42L))), Constant.TRUE, Map.of());
+
+            List<ConnectorSplit> splits = drain(mgr.getSplits(null, null, handle, null, constraint));
+            assertTrue(splits.size() > 1,
+                    "an extractor under-count on a composite PK → full fan-out (never drop rows)");
+        } finally {
+            server.stop(0);
+        }
+    }
+
     /** VARCHAR text PK (utf-8 bytes) also prunes through the public surface. */
     @Test
     void textPkPointReadPrunesThroughPublicSurface() throws Exception {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningWiringTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningWiringTest.java
@@ -1,0 +1,238 @@
+package in.mcfad.cqlite.flight;
+
+import com.sun.net.httpserver.HttpServer;
+import in.mcfad.cqlite.flight.sidecar.HostSnapshotApis;
+import in.mcfad.cqlite.flight.sidecar.SidecarClient;
+import in.mcfad.cqlite.flight.sidecar.SnapshotApi;
+import io.airlift.slice.Slices;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end wiring evidence for plan-time split pruning (issue #2679): a fully-bound-PK
+ * point read flows through the PUBLIC {@link CqliteFlightSplitManager#getSplits} surface —
+ * a real {@link SidecarClient} against an in-process fake Sidecar returning a multi-range
+ * topology — and the resulting {@link ConnectorSplitSource} yields exactly ONE split
+ * (→ one DoGet to one pod). The assertion reads the public split count, not a helper return.
+ *
+ * <p>Also the connector-level DIFFERENTIAL check (spec req 5): the SAME query planned with
+ * pruning ENABLED vs FORCED OFF yields split sets that cover the bound key identically
+ * (every range containing the key's token is retained; none dropped), and the pruned set is
+ * strictly fewer splits. Because split coverage is what determines which rows a scan can
+ * return, identical covering coverage is the plan-time proxy for identical result rows.
+ */
+class CqliteFlightSplitPruningWiringTest {
+
+    private static final String DDL = "CREATE TABLE ks.t (id int PRIMARY KEY, v text)";
+    private static final CqliteFlightColumnHandle ID_INT =
+            new CqliteFlightColumnHandle("id", INTEGER, PushdownCapability.FULL);
+
+    /** LIVE-mode SnapshotManager (no snapshot fan-out) with a no-op per-host Sidecar. */
+    private static SnapshotManager liveSnapshots() {
+        HostSnapshotApis noop = host -> new SnapshotApi() {
+            @Override
+            public void createSnapshot(String ks, String t, String name, Optional<String> ttl) {}
+
+            @Override
+            public void clearSnapshot(String ks, String t, String name) {}
+        };
+        return new SnapshotManager(noop, ReadMode.LIVE, Optional.empty());
+    }
+
+    private static CqliteFlightConfig config(URI sidecarUri, boolean pruningEnabled) {
+        return new CqliteFlightConfig(
+                sidecarUri, 8815, "dc1", GroupByPushdownPolicy.AUTOMATIC, 0.5, 3000,
+                ReadMode.LIVE, Optional.empty(),
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS,
+                CqliteFlightConfig.DEFAULT_SNAPSHOT_RETIRE_GRACE_MILLIS,
+                pruningEnabled);
+    }
+
+    /**
+     * Fake Sidecar serving a full-ring tiling of many single-token-wide ranges around the
+     * token of int 42, so a point read on id=42 must prune to exactly the covering range.
+     */
+    private static String tokenRangeReplicasJson(long token) {
+        long[] boundaries = {token - 2, token - 1, token, token + 1, token + 2};
+        StringBuilder sb = new StringBuilder("{\"writeReplicas\":[],\"readReplicas\":[");
+        long prev = Long.MIN_VALUE;
+        boolean first = true;
+        for (long b : boundaries) {
+            sb.append(rangeJson(prev, b, first));
+            first = false;
+            prev = b;
+        }
+        sb.append(rangeJson(prev, Long.MAX_VALUE, false));
+        sb.append("]}");
+        return sb.toString();
+    }
+
+    private static String rangeJson(long start, long end, boolean first) {
+        return (first ? "" : ",")
+                + "{\"start\":\"" + start + "\",\"end\":\"" + end
+                + "\",\"replicasByDatacenter\":{\"dc1\":[\"10.0.0.1:7000\"]}}";
+    }
+
+    private static HttpServer startFakeSidecar(String body) throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", ex -> {
+            byte[] out = body.getBytes(StandardCharsets.UTF_8);
+            ex.sendResponseHeaders(200, out.length);
+            ex.getResponseBody().write(out);
+            ex.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private static List<ConnectorSplit> drain(ConnectorSplitSource source)
+            throws ExecutionException, InterruptedException {
+        List<ConnectorSplit> all = new java.util.ArrayList<>();
+        while (!source.isFinished()) {
+            all.addAll(source.getNextBatch(1000).get().getSplits());
+        }
+        source.close();
+        return all;
+    }
+
+    @Test
+    void pointReadThroughPublicGetSplitsYieldsExactlyOneSplit() throws Exception {
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A}); // int 42
+        HttpServer server = startFakeSidecar(tokenRangeReplicasJson(token));
+        try {
+            URI uri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+            SidecarClient sidecar = new SidecarClient(uri);
+            var splitManager = new CqliteFlightSplitManager(config(uri, true), sidecar, liveSnapshots());
+            CqliteFlightTableHandle handle = new CqliteFlightTableHandle("ks", "t", DDL);
+            var constraint = new Constraint(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                    ID_INT, Domain.singleValue(INTEGER, 42L))), Constant.TRUE, Map.of());
+
+            ConnectorSplitSource source =
+                    splitManager.getSplits(null, null, handle, null, constraint);
+            List<ConnectorSplit> splits = drain(source);
+
+            assertEquals(1, splits.size(),
+                    "a fully-bound-PK point read yields exactly one split through the public surface");
+            CqliteFlightSplit s = (CqliteFlightSplit) splits.get(0);
+            assertTrue(Murmur3Token.tokenInRange(token, s.tokenStart(), s.tokenEnd(), s.wraparound()),
+                    "the single emitted split covers the key's token");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void prunedVsForcedUnprunedCoverTheKeyIdenticallyAndPrunedIsFewer() throws Exception {
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        HttpServer server = startFakeSidecar(tokenRangeReplicasJson(token));
+        try {
+            URI uri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+            SidecarClient sidecar = new SidecarClient(uri);
+            CqliteFlightTableHandle handle = new CqliteFlightTableHandle("ks", "t", DDL);
+            var constraint = new Constraint(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                    ID_INT, Domain.singleValue(INTEGER, 42L))), Constant.TRUE, Map.of());
+
+            var prunedMgr = new CqliteFlightSplitManager(config(uri, true), sidecar, liveSnapshots());
+            var fullMgr = new CqliteFlightSplitManager(config(uri, false), sidecar, liveSnapshots());
+
+            List<ConnectorSplit> pruned = drain(prunedMgr.getSplits(null, null, handle, null, constraint));
+            List<ConnectorSplit> full = drain(fullMgr.getSplits(null, null, handle, null, constraint));
+
+            assertTrue(pruned.size() < full.size(), "pruning emits strictly fewer splits");
+            // Differential: the covering set for the key is identical (every full-fan-out split
+            // that contains the token is present in the pruned set, and vice versa).
+            List<CqliteFlightSplit> fullCovering = full.stream()
+                    .map(CqliteFlightSplit.class::cast)
+                    .filter(s -> Murmur3Token.tokenInRange(
+                            token, s.tokenStart(), s.tokenEnd(), s.wraparound()))
+                    .toList();
+            List<CqliteFlightSplit> prunedCovering = pruned.stream()
+                    .map(CqliteFlightSplit.class::cast)
+                    .filter(s -> Murmur3Token.tokenInRange(
+                            token, s.tokenStart(), s.tokenEnd(), s.wraparound()))
+                    .toList();
+            assertEquals(fullCovering.size(), prunedCovering.size(),
+                    "pruned coverage of the bound key equals the unpruned coverage");
+            assertEquals(prunedCovering.size(), pruned.size(),
+                    "every pruned split covers the key — none is spurious");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void inListThroughPublicGetSplitsYieldsUnionCoverage() throws Exception {
+        // Two keys → union of covering ranges. Ring built around both tokens.
+        long t1 = Murmur3Token.token(new byte[] {0, 0, 0, 0x01});
+        long t2 = Murmur3Token.token(new byte[] {0, 0, 0, 0x02});
+        long lo = Math.min(t1, t2);
+        long hi = Math.max(t1, t2);
+        String json = "{\"writeReplicas\":[],\"readReplicas\":["
+                + rangeJson(Long.MIN_VALUE, lo - 1, true)
+                + rangeJson(lo - 1, lo, false)
+                + rangeJson(lo, hi - 1, false)
+                + rangeJson(hi - 1, hi, false)
+                + rangeJson(hi, Long.MAX_VALUE, false)
+                + "]}";
+        HttpServer server = startFakeSidecar(json);
+        try {
+            URI uri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+            SidecarClient sidecar = new SidecarClient(uri);
+            var mgr = new CqliteFlightSplitManager(config(uri, true), sidecar, liveSnapshots());
+            CqliteFlightTableHandle handle = new CqliteFlightTableHandle("ks", "t", DDL);
+            var constraint = new Constraint(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                    ID_INT, Domain.multipleValues(INTEGER, List.of(1L, 2L)))), Constant.TRUE, Map.of());
+
+            List<ConnectorSplit> splits = drain(mgr.getSplits(null, null, handle, null, constraint));
+            assertEquals(2, splits.size(), "IN over two keys in two ranges → the deduped two-range union");
+            assertTrue(splits.stream().map(CqliteFlightSplit.class::cast).anyMatch(
+                    s -> Murmur3Token.tokenInRange(t1, s.tokenStart(), s.tokenEnd(), s.wraparound())));
+            assertTrue(splits.stream().map(CqliteFlightSplit.class::cast).anyMatch(
+                    s -> Murmur3Token.tokenInRange(t2, s.tokenStart(), s.tokenEnd(), s.wraparound())));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /** VARCHAR text PK (utf-8 bytes) also prunes through the public surface. */
+    @Test
+    void textPkPointReadPrunesThroughPublicSurface() throws Exception {
+        CqliteFlightColumnHandle nameText =
+                new CqliteFlightColumnHandle("id", VARCHAR, PushdownCapability.FULL);
+        long token = Murmur3Token.token("hello".getBytes(StandardCharsets.UTF_8));
+        HttpServer server = startFakeSidecar(tokenRangeReplicasJson(token));
+        try {
+            URI uri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+            SidecarClient sidecar = new SidecarClient(uri);
+            var mgr = new CqliteFlightSplitManager(config(uri, true), sidecar, liveSnapshots());
+            CqliteFlightTableHandle handle =
+                    new CqliteFlightTableHandle("ks", "t", "CREATE TABLE ks.t (id text PRIMARY KEY, v text)");
+            var constraint = new Constraint(TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                    nameText, Domain.singleValue(VARCHAR, Slices.utf8Slice("hello")))), Constant.TRUE, Map.of());
+
+            List<ConnectorSplit> splits = drain(mgr.getSplits(null, null, handle, null, constraint));
+            assertEquals(1, splits.size(), "text PK point read prunes to one covering split");
+        } finally {
+            server.stop(0);
+        }
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/Murmur3TokenTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/Murmur3TokenTest.java
@@ -1,0 +1,161 @@
+package in.mcfad.cqlite.flight;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the Java {@link Murmur3Token} output byte-for-byte to the Rust authority
+ * {@code cassandra_murmur3_token} ({@code cqlite-core/src/util/cassandra_murmur3.rs}).
+ *
+ * <p>Every {@code (keyBytes, expectedToken)} vector below is copied verbatim from
+ * the Rust unit tests in that file (each independently verified against a running
+ * Cassandra 5.0 {@code SELECT token(id), id}). Because both sides consume the same
+ * canonical partition-key byte layout, a Java token that disagrees means the port
+ * drifted — a correctness hazard for split pruning — and this test fails loudly.
+ * (Spec: "Java Murmur3 token matches the Rust Cassandra-parity authority".)
+ */
+class Murmur3TokenTest {
+
+    private static byte[] utf8(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] bytes(int... vals) {
+        byte[] out = new byte[vals.length];
+        for (int i = 0; i < vals.length; i++) {
+            out[i] = (byte) vals[i];
+        }
+        return out;
+    }
+
+    @Test
+    void textKeyTokensMatchRust() {
+        assertEquals(-8839064797231613815L, Murmur3Token.token(utf8("a")));
+        assertEquals(-7815133031266706642L, Murmur3Token.token(utf8("ab")));
+        assertEquals(-5434086359492102041L, Murmur3Token.token(utf8("abc")));
+        assertEquals(-5153323217664422577L, Murmur3Token.token(utf8("abcd")));
+        assertEquals(2321271983248423864L, Murmur3Token.token(utf8("abcde")));
+        assertEquals(-1982280103179862187L, Murmur3Token.token(utf8("abcdef")));
+        assertEquals(-6427428730009885543L, Murmur3Token.token(utf8("abcdefg")));
+        assertEquals(-3708139591217214462L, Murmur3Token.token(utf8("abcdefgh")));
+        assertEquals(-3758069500696749310L, Murmur3Token.token(utf8("hello")));
+        assertEquals(356242581507269238L, Murmur3Token.token(utf8("cassandra")));
+        assertEquals(5322121941860471994L, Murmur3Token.token(utf8("murmur3")));
+        assertEquals(-3182120811138177122L, Murmur3Token.token(utf8("test_key_12345")));
+        // 15 bytes (all k1 tail positions), 16 bytes (one full block, no tail), long.
+        assertEquals(-6472281833689111727L, Murmur3Token.token(utf8("0123456789abcde")));
+        assertEquals(5467490433528156583L, Murmur3Token.token(utf8("0123456789abcdef")));
+        assertEquals(-7889617755374116647L,
+                Murmur3Token.token(utf8("this is a longer test key for murmur3 hashing")));
+    }
+
+    @Test
+    void intKeyTokensMatchRust() {
+        // 4-byte big-endian int values.
+        assertEquals(-3485513579396041028L, Murmur3Token.token(bytes(0x00, 0x00, 0x00, 0x00)));
+        assertEquals(-4069959284402364209L, Murmur3Token.token(bytes(0x00, 0x00, 0x00, 0x01)));
+        assertEquals(7297452126230313552L, Murmur3Token.token(bytes(0xFF, 0xFF, 0xFF, 0xFF)));
+        assertEquals(-7160136740246525330L, Murmur3Token.token(bytes(0x00, 0x00, 0x00, 0x2A)));
+        assertEquals(4443639997907684431L, Murmur3Token.token(bytes(0x00, 0x00, 0x00, 0x7F)));
+        assertEquals(-9081975895656599623L, Murmur3Token.token(bytes(0x00, 0x00, 0x00, 0x80)));
+        assertEquals(-8423851636648339959L, Murmur3Token.token(bytes(0x00, 0x00, 0x00, 0xFF)));
+        assertEquals(180151580513994396L, Murmur3Token.token(bytes(0x00, 0x00, 0x01, 0x00)));
+        assertEquals(7935772098093053663L, Murmur3Token.token(bytes(0x00, 0x00, 0x03, 0xE8)));
+        assertEquals(5905661066942090405L, Murmur3Token.token(bytes(0xFF, 0xFF, 0xFC, 0x18)));
+        assertEquals(-765994672030311617L, Murmur3Token.token(bytes(0x7F, 0xFF, 0xFF, 0xFF)));
+        assertEquals(-420533958509279465L, Murmur3Token.token(bytes(0x80, 0x00, 0x00, 0x00)));
+    }
+
+    @Test
+    void bigintKeyTokensMatchRust() {
+        // 8-byte big-endian bigint values, incl. i64::MIN and i64::MAX.
+        assertEquals(2945182322382062539L, Murmur3Token.token(bytes(0, 0, 0, 0, 0, 0, 0, 0)));
+        assertEquals(6292367497774912474L, Murmur3Token.token(bytes(0, 0, 0, 0, 0, 0, 0, 1)));
+        assertEquals(7071048584287372947L,
+                Murmur3Token.token(bytes(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)));
+        assertEquals(-1722304415079482439L,
+                Murmur3Token.token(bytes(0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)));
+        assertEquals(9204767954415360687L,
+                Murmur3Token.token(bytes(0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)));
+    }
+
+    @Test
+    void uuidKeyTokensMatchRust() {
+        assertEquals(5457549051747178710L,
+                Murmur3Token.token(bytes(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
+        assertEquals(-2824192546314762522L,
+                Murmur3Token.token(bytes(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)));
+        assertEquals(4277286421682315655L,
+                Murmur3Token.token(bytes(0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4,
+                        0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00)));
+        assertEquals(-8497799532739775204L,
+                Murmur3Token.token(bytes(0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x12, 0x34,
+                        0x12, 0x34, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc)));
+    }
+
+    @Test
+    void blobTokensExerciseSignExtensionBug() {
+        // High-bit bytes: the sign-extension tail behavior must match Cassandra exactly.
+        assertEquals(5048724184180415669L, Murmur3Token.token(bytes(0x00)));
+        assertEquals(-5284281814142962636L, Murmur3Token.token(bytes(0x80)));
+        assertEquals(-4442228696663692417L, Murmur3Token.token(bytes(0xFF)));
+        assertEquals(-2002833339314343643L, Murmur3Token.token(bytes(0xFF, 0xFE)));
+        assertEquals(-7623170703309721106L,
+                Murmur3Token.token(bytes(0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89)));
+        assertEquals(597835946752277653L,
+                Murmur3Token.token(bytes(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F)));
+        assertEquals(-5563837382979743776L,
+                Murmur3Token.token(bytes(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10)));
+    }
+
+    @Test
+    void compositeKeyTokensMatchRust() {
+        // ('hello', 42) → 7666157718303755816; composite = [len:u16 BE][bytes][0x00] per comp.
+        byte[] helloAnd42 = PartitionKeyBytes.composite(
+                new byte[][] {utf8("hello"), bytes(0x00, 0x00, 0x00, 0x2A)});
+        assertEquals(7666157718303755816L, Murmur3Token.token(helloAnd42));
+
+        // ('world', 99) → -4641306270390207264.
+        byte[] worldAnd99 = PartitionKeyBytes.composite(
+                new byte[][] {utf8("world"), bytes(0x00, 0x00, 0x00, 0x63)});
+        assertEquals(-4641306270390207264L, Murmur3Token.token(worldAnd99));
+    }
+
+    @Test
+    void normalizeMapsMinToMax() {
+        assertEquals(Long.MAX_VALUE, Murmur3Token.normalize(Long.MIN_VALUE));
+        assertEquals(Long.MAX_VALUE, Murmur3Token.normalize(Long.MAX_VALUE));
+        assertEquals(0L, Murmur3Token.normalize(0L));
+        assertEquals(1L, Murmur3Token.normalize(1L));
+        assertEquals(-1L, Murmur3Token.normalize(-1L));
+    }
+
+    @Test
+    void emptyInputHashesToZero() {
+        // Rust test_hash_returns_h1_h2_order: empty input → h1 == 0.
+        assertEquals(0L, Murmur3Token.token(new byte[0]));
+    }
+
+    @Test
+    void tokenInRangeFollowsHalfOpenAndWraparoundConvention() {
+        // Normal (start, end]: start exclusive, end inclusive.
+        assertTrue(Murmur3Token.tokenInRange(50, 0, 100, false));
+        assertTrue(Murmur3Token.tokenInRange(100, 0, 100, false));
+        assertTrue(!Murmur3Token.tokenInRange(0, 0, 100, false));
+        assertTrue(!Murmur3Token.tokenInRange(101, 0, 100, false));
+        // Wraparound (start > end): token > start OR token <= end.
+        assertTrue(Murmur3Token.tokenInRange(200, 100, -100, true));
+        assertTrue(Murmur3Token.tokenInRange(-100, 100, -100, true));
+        assertTrue(!Murmur3Token.tokenInRange(0, 100, -100, true));
+        // Full ring (start == end): every token in range (issue #2228).
+        assertTrue(Murmur3Token.tokenInRange(Long.MIN_VALUE, 42, 42, false));
+        assertTrue(Murmur3Token.tokenInRange(0, 42, 42, true));
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/PrimaryKeyExtractorTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/PrimaryKeyExtractorTest.java
@@ -4,6 +4,7 @@ import in.mcfad.cqlite.flight.PrimaryKeyExtractor.KeyColumn;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -102,5 +103,92 @@ class PrimaryKeyExtractorTest {
         var keys = PrimaryKeyExtractor.extract(null);
         assertTrue(keys.partitionKey().isEmpty());
         assertTrue(keys.clusteringColumns().isEmpty());
+    }
+
+    // ── partitionKeyArity: the independent quote-aware cross-check for split pruning (#2679) ──
+
+    /**
+     * The arity scan is the fail-safe guard for composite-PK split pruning: it must NEVER
+     * under-count the partition-key components, across every realistic DDL spelling. The caller
+     * prunes only when this arity equals {@link PrimaryKeyExtractor#extract}'s partition-key size,
+     * so a spelling the main extractor mis-parses is caught here and falls back to full fan-out.
+     */
+    private static int arity(String ddl) {
+        OptionalInt a = PrimaryKeyExtractor.partitionKeyArity(ddl);
+        assertTrue(a.isPresent(), "arity should resolve for a locatable PRIMARY KEY: " + ddl);
+        return a.getAsInt();
+    }
+
+    @Test
+    void aritySimpleSingleColumnForms() {
+        assertEquals(1, arity("CREATE TABLE ks.t (id int PRIMARY KEY, v text)"));
+        assertEquals(1, arity("CREATE TABLE ks.t (pk int, ck text, v text, PRIMARY KEY (pk, ck))"));
+        assertEquals(1, arity("CREATE TABLE ks.t (a int, b int, c int, PRIMARY KEY (a, b, c))"));
+    }
+
+    @Test
+    void arityCompositeForms() {
+        assertEquals(2, arity("CREATE TABLE ks.t (a int, b int, v int, PRIMARY KEY ((a, b), c))"));
+        assertEquals(2, arity("CREATE TABLE ks.t (a int, b int, v int, PRIMARY KEY ((a, b)))"));
+        assertEquals(3, arity("CREATE TABLE ks.t (a int, b int, c int, PRIMARY KEY ((a, b, c)))"));
+        // one clustering / multiple clustering do not change the partition-key arity.
+        assertEquals(2, arity(
+                "CREATE TABLE ks.t (a int, b int, c1 int, c2 int, PRIMARY KEY ((a, b), c1, c2))"));
+    }
+
+    @Test
+    void arityHandlesWhitespaceNewlinesAndExtraParens() {
+        assertEquals(2, arity("CREATE TABLE ks.t (a int, b int,\n  PRIMARY KEY (  ( a ,  b ) , c ))"));
+    }
+
+    @Test
+    void arityIgnoresTrailingWithClauses() {
+        assertEquals(2, arity(
+                "CREATE TABLE ks.t (a int, b int, c int, PRIMARY KEY ((a, b), c)) "
+                        + "WITH CLUSTERING ORDER BY (c DESC)"));
+        assertEquals(2, arity(
+                "CREATE TABLE ks.t (a int, b int, PRIMARY KEY ((a, b))) "
+                        + "WITH compaction = {'class':'STCS'}"));
+    }
+
+    /**
+     * Quoted identifiers containing structural characters are the catastrophic under/over-count
+     * cases for the main extractor. The arity scan masks quoted contents first, so it stays
+     * correct — and the pruning guard compares the two, so a mismatch (see below) blocks pruning.
+     */
+    @Test
+    void arityCorrectForQuotedIdentifiersWithSpecialChars() {
+        // ')' inside a quoted identifier: the main extractor UNDER-counts to 1 (row-loss risk),
+        // the arity scan correctly reports 2.
+        assertEquals(2, arity("CREATE TABLE ks.t (\"a)b\" int, c int, PRIMARY KEY ((\"a)b\", c)))"));
+        // ',' inside a quoted identifier: the main extractor OVER-counts to 3, arity reports 2.
+        assertEquals(2, arity("CREATE TABLE ks.t (\"a,b\" int, c int, PRIMARY KEY ((\"a,b\", c)))"));
+        // '(' inside a quoted identifier.
+        assertEquals(2, arity("CREATE TABLE ks.t (\"a(b\" int, c int, PRIMARY KEY ((\"a(b\", c)))"));
+        // A quoted identifier that is itself a keyword phrase.
+        assertEquals(2, arity(
+                "CREATE TABLE ks.t (\"PRIMARY KEY\" int, c int, PRIMARY KEY ((\"PRIMARY KEY\", c)))"));
+        // Mixed-case quoted composite.
+        assertEquals(2, arity("CREATE TABLE ks.t (\"Aa\" int, \"Bb\" int, PRIMARY KEY ((\"Aa\", \"Bb\")))"));
+    }
+
+    @Test
+    void arityEmptyWhenNoPrimaryKeyLocatable() {
+        assertTrue(PrimaryKeyExtractor.partitionKeyArity("not a create table").isEmpty());
+        assertTrue(PrimaryKeyExtractor.partitionKeyArity(null).isEmpty());
+    }
+
+    /**
+     * Regression proof of the guard's premise: on the catastrophic quoted-')' composite spelling
+     * the MAIN extractor under-counts (1) but the arity scan is correct (2). The split-pruning
+     * guard compares these and, on disagreement, refuses to prune — so the under-count can never
+     * drive a mis-pruned (row-dropping) plan.
+     */
+    @Test
+    void extractorUnderCountsQuotedParenCompositeButArityDoesNot() {
+        String ddl = "CREATE TABLE ks.t (\"a)b\" int, c int, PRIMARY KEY ((\"a)b\", c)))";
+        assertEquals(1, PrimaryKeyExtractor.extract(ddl).partitionKey().size(),
+                "documents the main-extractor under-count the guard must catch");
+        assertEquals(2, arity(ddl), "the independent arity scan is not fooled");
     }
 }


### PR DESCRIPTION
Closes #2679

## What

The Trino/Flight connector's `CqliteFlightSplitManager.getSplits` ignored Trino's pushed-down `Constraint`, so **every** query — including a single-partition point read — emitted one split per read-replica token range (~48 DoGets across all pods to fetch 1 partition). This adds **plan-time split pruning**: when the constraint **fully binds the partition key** (equality on every PK column, or IN over full keys), the connector computes the Murmur3 token(s) at plan time and emits splits **only** for the covering token range(s). A single-key point read becomes **1 DoGet to 1 pod**.

Anything less than a fully-bound PK (range scan, partial PK, non-PK predicates) keeps the current full fan-out. **Split elimination is load-bearing for correctness** (a mis-pruned split silently drops rows), so pruning is **fail-safe on any doubt** → full fan-out.

## How

- Read `constraint.getSummary()` (a `TupleDomain`) in `getSplits` — where Trino delivers full-PK point reads.
- New `Murmur3Token` (byte-exact port of Rust `cassandra_murmur3_token`) + `PartitionKeyBytes` (canonical PK byte layout: single-component = raw bytes; multi = `[len:u16 BE][bytes][0x00]` per component), pinned to the Rust authority via shared vectors.
- New `BoundPartitionKeys` classifies equality / IN (deduped union, `MAX_KEYS` guard) / not-bound from the summary domains vs `PrimaryKeyExtractor` PK columns; capability-gated VARCHAR disambiguation (text→UTF-8, uuid/timeuuid→16 bytes; inet/varint/decimal/duration → no prune).
- `Partitioner.resolve()` — explicit "assume Murmur3Partitioner" (owner-approved; Sidecar exposes no partitioner field); unknown/non-Murmur3 → no prune + log.
- `cqlite.split-pruning-enabled` toggle (default on) so the differential baseline can force pruning off.
- `(start, end]` half-open + wraparound membership reuses the existing `validateRingCoverage` / server `token_in_half_open_range` convention.

## OpenSpec

Change `plantime-split-pruning` (owner-approved at Seam 1). Design decision: explicit Murmur3 assumption (Sidecar has no partitioner field; the ring already hard-assumes Murmur3). Follow-up to surface partitioner name from Sidecar is filed.

## Tests (all 6 spec requirements)

- `Murmur3TokenTest` — Java tokens byte-identical to Rust `cassandra_murmur3_token` (text/int/bigint/uuid/blob/composite + `i64::MIN→MAX` normalize).
- `CqliteFlightSplitPruningTest` — single fully-bound PK → 1 covering split; partial/absent/range → full fan-out; IN deduped union; shared-range collapse; unknown partitioner / un-serializable value / toggle-off → no prune; **uuid/timeuuid prune at the parsed-16-byte token**; non-canonical uuid → full fan-out.
- `CqliteFlightSplitPruningWiringTest` — e2e through the public `getSplits`→`SplitSource`: point read yields exactly 1 split; IN yields union; **differential** pruned vs forced-unpruned cover the key identically and pruned is fewer.

**Gradle connector tests: PASS** (376 tests, 27 new). No Rust changes — the server already prunes by token at DoGet time; this pushes the decision earlier so the fan-out never happens.

Reviews (review-first, pre-gate): roborev — no issues found; rust-reviewer — clean, no blockers (verified Murmur3 byte-exactness, byte layout, fail-safe comprehensiveness, and the capability-gated VARCHAR disambiguation line-by-line).