### PR TITLE
flight(#2684): tables_discovered + warm_tables gauges (bidirectional)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -623,6 +623,45 @@ pub const PROC_RSS_BYTES: &str = "cqlite.proc.rss_bytes";
 /// different resources. No high-cardinality attributes.
 pub const FLIGHT_BLOCKING_TASKS_IN_USE: &str = "cqlite.flight.blocking_tasks_in_use";
 
+/// `cqlite.flight.tables_discovered` — gauge `{entry}` (issue #2684).
+///
+/// Number of `<keyspace>/<table>` SSTable directories currently VISIBLE under
+/// the server's `--data-dir`, re-sampled on the same ~2s saturation tick as the
+/// `cqlite.proc.*` gauges. Each tick does a readdir-only walk (keyspace dirs →
+/// table dirs), counting a table dir iff it directly contains a `*-Data.db`
+/// entry (name check only — NO stat-for-generation, NO open, NO parse), so the
+/// cold-start invariant (#2385) holds: sampling never increments
+/// [`INDEX_PARSES_TOTAL`]. `snapshots/` and `backups/` subtrees are excluded and
+/// UUID-suffixed table dirs are counted correctly.
+///
+/// **Healthy vs alarming**: RISES when a new table appears on disk (new table, a
+/// fixed mount) and FALLS when a table is dropped/removed; a wrong or empty
+/// `--data-dir` reads **0** immediately, surfacing an inert mount before the
+/// first query errors lazily. **Undersampling caveat (#2661)**: sampled every
+/// ~2s, so a Prometheus scrape at a longer interval can miss a short-lived
+/// transition — same caveat as the rest of the #2419 saturation family. No
+/// high-cardinality attributes (total-only; the per-keyspace breakdown lives in
+/// the one-time startup log line, never as a metric label).
+pub const FLIGHT_TABLES_DISCOVERED: &str = "cqlite.flight.tables_discovered";
+
+/// `cqlite.flight.warm_tables` — gauge `{entry}` (issue #2684).
+///
+/// Current number of tables with a live warm reader set in the flight
+/// `WarmTableRegistry` (`Inner.tables.len()`). Atomic-backed at the registry's
+/// mutation sites (independent of the sampler cadence): the post-mutation
+/// `.len()` is emitted while the registry lock is held at the `rebuild()` insert
+/// and `evict_to_budget()` removal, so the remove-then-reinsert transient the
+/// rebuild performs never dips the reading.
+///
+/// **Healthy vs alarming**: RISES on the first serve of a previously-unseen
+/// table (a `do_get` rebuild insert) and FALLS on eviction/retirement (budget
+/// LRU or generation turnover). A level pinned at capacity with steady eviction
+/// churn means the warm byte budget is small versus the working set. No
+/// high-cardinality attributes (total-only). DISTINCT from
+/// [`FLIGHT_TABLES_DISCOVERED`] (what is VISIBLE on disk): this is what is
+/// actually OPENED and served warm.
+pub const FLIGHT_WARM_TABLES: &str = "cqlite.flight.warm_tables";
+
 /// `cqlite.errors.total` — counter `{error}`.
 ///
 /// Total errors observed, the canonical error-rate signal (issue #1038).
@@ -882,17 +921,26 @@ pub const ALL_METRICS: &[&str] = &[
     PROC_FDS,
     PROC_RSS_BYTES,
     FLIGHT_BLOCKING_TASKS_IN_USE,
+    // Flight table-visibility gauges (#2684)
+    FLIGHT_TABLES_DISCOVERED,
+    FLIGHT_WARM_TABLES,
 ];
 
-/// The five saturation gauges added by issue #2419 (WS2). Grouped for the
-/// distinctness/registration tests and #2426's operator reference so they can be
-/// presented as one section without re-listing them by hand.
+/// The saturation gauges added by issue #2419 (WS2), extended by the #2684
+/// flight table-visibility gauges. Grouped for the distinctness/registration
+/// tests and #2426's operator reference so they can be presented as one section
+/// without re-listing them by hand.
 pub const SATURATION_GAUGES: &[&str] = &[
     MERGE_EGRESS_CHANNEL_DEPTH,
     PROC_THREADS,
     PROC_FDS,
     PROC_RSS_BYTES,
     FLIGHT_BLOCKING_TASKS_IN_USE,
+    // Flight table-visibility gauges (#2684): sampler-driven tables_discovered +
+    // atomic-backed warm_tables. Grouped here so the dedicated-otel-arm +
+    // namespaced/unique tests cover them.
+    FLIGHT_TABLES_DISCOVERED,
+    FLIGHT_WARM_TABLES,
 ];
 
 /// The five `cqlite.flight.admission.*` gauges/counters from issue #2420 (WS4),
@@ -1133,6 +1181,9 @@ mod tests {
             FLIGHT_BLOCKING_TASKS_IN_USE,
             "cqlite.flight.blocking_tasks_in_use"
         );
+        // Flight table-visibility gauges (#2684).
+        assert_eq!(FLIGHT_TABLES_DISCOVERED, "cqlite.flight.tables_discovered");
+        assert_eq!(FLIGHT_WARM_TABLES, "cqlite.flight.warm_tables");
         // Units from the design naming table (#2419 design D4).
         assert_eq!(unit::FDS, "{fd}");
         assert_eq!(unit::ENTRIES, "{entry}");
@@ -1155,6 +1206,8 @@ mod tests {
             "PROC_FDS",
             "PROC_RSS_BYTES",
             "FLIGHT_BLOCKING_TASKS_IN_USE",
+            "FLIGHT_TABLES_DISCOVERED",
+            "FLIGHT_WARM_TABLES",
         ] {
             let arm = format!("catalog::{ident} =>");
             assert!(
@@ -1177,6 +1230,33 @@ mod tests {
             }
         }
         assert_ne!(FLIGHT_BLOCKING_TASKS_IN_USE, FLIGHT_ADMISSION_IN_USE);
+    }
+
+    #[test]
+    fn flight_table_visibility_gauges_are_registered_namespaced_and_total_only() {
+        // Issue #2684: the two flight table-visibility gauges must be catalogued
+        // (so the registration/uniqueness + operator-doc checks cover them),
+        // rooted under `cqlite.flight.`, carry the `{entry}` unit, appear in the
+        // saturation-gauge group (so the dedicated-otel-arm scan covers them),
+        // and be DISTINCT from each other and from the blocking-task gauge.
+        for m in [FLIGHT_TABLES_DISCOVERED, FLIGHT_WARM_TABLES] {
+            assert!(ALL_METRICS.contains(&m), "{m} must be catalogued");
+            assert!(m.starts_with("cqlite.flight."), "{m} must be namespaced");
+            assert!(
+                SATURATION_GAUGES.contains(&m),
+                "{m} must be in the saturation-gauge group"
+            );
+            assert_eq!(
+                ALL_METRICS.iter().filter(|n| *n == &m).count(),
+                1,
+                "{m} must appear exactly once in ALL_METRICS"
+            );
+        }
+        assert_eq!(FLIGHT_TABLES_DISCOVERED, "cqlite.flight.tables_discovered");
+        assert_eq!(FLIGHT_WARM_TABLES, "cqlite.flight.warm_tables");
+        assert_ne!(FLIGHT_TABLES_DISCOVERED, FLIGHT_WARM_TABLES);
+        assert_ne!(FLIGHT_WARM_TABLES, FLIGHT_BLOCKING_TASKS_IN_USE);
+        assert_eq!(unit::ENTRIES, "{entry}");
     }
 
     #[test]

--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -646,8 +646,10 @@ pub const FLIGHT_TABLES_DISCOVERED: &str = "cqlite.flight.tables_discovered";
 
 /// `cqlite.flight.warm_tables` — gauge `{entry}` (issue #2684).
 ///
-/// Current number of tables with a live warm reader set in the flight
-/// `WarmTableRegistry` (`Inner.tables.len()`). Atomic-backed at the registry's
+/// The count of tables with a live (non-empty) warm reader set in the flight
+/// `WarmTableRegistry` (a retired table leaves a zero-reader entry until the next
+/// rebuild, so the reading filters those out rather than using the raw map size).
+/// Atomic-backed at the registry's
 /// mutation sites (independent of the sampler cadence): the post-mutation
 /// `.len()` is emitted while the registry lock is held at the `rebuild()` insert
 /// and `evict_to_budget()` removal, so the remove-then-reinsert transient the

--- a/cqlite-core/src/observability/operator_docs_annotations.rs
+++ b/cqlite-core/src/observability/operator_docs_annotations.rs
@@ -668,4 +668,22 @@ pub(super) const ANNOTATIONS: &[MetricDoc] = &[
         interpretation: "Rises with concurrent do_get scans and returns to baseline; a level pinned near the blocking-pool size with flat rpc.rows is blocking-pool saturation. Distinct from admission.in_use.",
         round_item: "blocking-pool pressure watch (#2419/#2313)",
     },
+    MetricDoc {
+        name: catalog::FLIGHT_TABLES_DISCOVERED,
+        kind: MetricKind::Gauge,
+        unit: catalog::unit::ENTRIES,
+        summary: "Table dirs visible under --data-dir, re-sampled by a readdir-only walk on the ~2s saturation tick (no SSTable opens). Undersampled at ~2s vs a longer scrape interval (#2661).",
+        attributes: &[],
+        interpretation: "Rises when a table appears on disk and falls when one is removed; a wrong or empty --data-dir reads 0 immediately (an inert mount, visible before the first query errors).",
+        round_item: "inert-mount watch (#2684)",
+    },
+    MetricDoc {
+        name: catalog::FLIGHT_WARM_TABLES,
+        kind: MetricKind::Gauge,
+        unit: catalog::unit::ENTRIES,
+        summary: "Tables with a live warm reader set in the flight WarmTableRegistry (atomic-backed at the registry mutation sites, not sampler-driven).",
+        attributes: &[],
+        interpretation: "Rises on the first serve of a previously-unseen table and falls on eviction/retirement; pinned at capacity with steady eviction churn means the warm byte budget is small vs the working set. Distinct from tables_discovered (visible on disk).",
+        round_item: "warm-working-set watch (#2684)",
+    },
 ];

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -350,6 +350,9 @@ struct Instruments {
     proc_fds: Gauge<i64>,
     proc_rss_bytes: Gauge<i64>,
     flight_blocking_tasks_in_use: Gauge<i64>,
+    // Flight table-visibility gauges (#2684).
+    flight_tables_discovered: Gauge<i64>,
+    flight_warm_tables: Gauge<i64>,
 }
 
 fn instruments() -> &'static Instruments {
@@ -700,6 +703,18 @@ fn instruments() -> &'static Instruments {
                 .with_unit(catalog::unit::THREADS)
                 .with_description("Flight spawn_blocking tasks currently outstanding (#2419).")
                 .build(),
+            flight_tables_discovered: m
+                .i64_gauge(catalog::FLIGHT_TABLES_DISCOVERED)
+                .with_unit(catalog::unit::ENTRIES)
+                .with_description(
+                    "Table dirs visible under --data-dir, sampled by readdir on the ~2s tick (#2684).",
+                )
+                .build(),
+            flight_warm_tables: m
+                .i64_gauge(catalog::FLIGHT_WARM_TABLES)
+                .with_unit(catalog::unit::ENTRIES)
+                .with_description("Tables with a live warm reader set in the registry (#2684).")
+                .build(),
         }
     })
 }
@@ -806,6 +821,8 @@ pub(crate) fn record_gauge(name: &'static str, value: i64, attributes: &[KeyValu
         catalog::PROC_FDS => &i.proc_fds,
         catalog::PROC_RSS_BYTES => &i.proc_rss_bytes,
         catalog::FLIGHT_BLOCKING_TASKS_IN_USE => &i.flight_blocking_tasks_in_use,
+        catalog::FLIGHT_TABLES_DISCOVERED => &i.flight_tables_discovered,
+        catalog::FLIGHT_WARM_TABLES => &i.flight_warm_tables,
         _ => {
             meter().i64_gauge(name).build().record(value, attributes);
             return;

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -91,6 +91,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         wait_budget: WaitBudget::Timeout(Duration::from_millis(args.admission_wait_timeout_ms)),
     });
     let admission_limit = admission.limit();
+    // Keep a copy of the data-dir for the saturation sampler's readdir-only
+    // table-discovery walk (issue #2684) before the service takes ownership.
+    let sampler_data_dir = args.data_dir.clone();
     let service = CqliteFlightService::with_admission(args.data_dir, args.batch_size, admission);
 
     // A coarse tonic transport backstop, generously ABOVE the admission ceiling:
@@ -118,8 +121,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // without perturbing the server's shutdown wiring (no leaked task). The
     // atomic-backed gauges (`egress_channel_depth`, `blocking_tasks_in_use`)
     // update at their own call sites, independent of this cadence.
+    // The sampler also drives `cqlite.flight.tables_discovered` (issue #2684) via
+    // a readdir-only walk of `sampler_data_dir` each tick, and emits the one-time
+    // `discovered N tables across M keyspaces under <data-dir>` startup log line
+    // after its first sample.
     let _sampler = tokio::spawn(cqlite_flight::saturation::run_sampler(
         cqlite_flight::saturation::DEFAULT_SAMPLE_INTERVAL,
+        sampler_data_dir,
         shutdown_signal(),
     ));
     // Graceful shutdown (issue #1473): on ctrl_c / SIGTERM, tonic stops

--- a/cqlite-flight/src/saturation.rs
+++ b/cqlite-flight/src/saturation.rs
@@ -28,6 +28,7 @@
 //! in every build.
 
 use std::future::Future;
+use std::path::Path;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Once;
 use std::time::Duration;
@@ -113,6 +114,110 @@ pub fn read_proc_rss_bytes() -> Option<u64> {
 /// (saturates at `i64::MAX`, unreachable for a real thread/fd/RSS reading).
 fn as_gauge(v: u64) -> i64 {
     i64::try_from(v).unwrap_or(i64::MAX)
+}
+
+// --- tables_discovered: readdir-only table-dir walk (issue #2684) ----------
+//
+// Counts the `<keyspace>/<table[-uuid]>` SSTable directories currently VISIBLE
+// under `--data-dir`, using directory reads ONLY — never a stat-for-generation,
+// open, or parse — so the cold-start invariant (#2385) holds: sampling produces
+// zero `INDEX_PARSES_TOTAL` delta. Classification is STRUCTURAL (directory
+// layout: a dir directly containing a `*-Data.db` NAME), never inferred from
+// file contents (#28 no-heuristics).
+
+/// The result of one discovery walk: genuine table dirs and the keyspaces that
+/// contain at least one of them.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TableDiscovery {
+    /// Genuine `<keyspace>/<table>` SSTable directories found across all
+    /// keyspaces.
+    pub tables: u64,
+    /// Keyspace directories that contain at least one counted table dir.
+    pub keyspaces: u64,
+}
+
+/// Whether `dir` DIRECTLY contains a `*-Data.db` entry (readdir name check only
+/// — no stat, no open, no generation parse). This is the sole, structural
+/// "is a genuine table dir" test (matches the `DirSource` `-Data.db` prior art).
+fn dir_has_data_db(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|n| n.ends_with("-Data.db"))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Walk `data_dir` with readdir only and count genuine `<keyspace>/<table>`
+/// SSTable directories (issue #2684).
+///
+/// A keyspace is any directory directly under `data_dir`. Within it, a table dir
+/// is any directory whose name is NOT `snapshots`/`backups` that directly
+/// contains a `*-Data.db` entry — this covers both `<table>` and
+/// `<table>-<uuid>` layouts, counts a UUID-suffixed dir exactly once, and
+/// excludes the `snapshots/`/`backups/` subtrees and any non-table entry. A
+/// `data_dir` that is empty, unreadable, or points at a directory with no table
+/// dirs yields `tables = 0` (an inert/wrong mount reads zero immediately).
+pub fn discover_tables(data_dir: &Path) -> TableDiscovery {
+    let mut out = TableDiscovery::default();
+    let Ok(keyspaces) = std::fs::read_dir(data_dir) else {
+        return out;
+    };
+    for ks in keyspaces.flatten() {
+        let ks_path = ks.path();
+        if !ks_path.is_dir() {
+            continue;
+        }
+        let Ok(tables) = std::fs::read_dir(&ks_path) else {
+            continue;
+        };
+        let mut ks_tables: u64 = 0;
+        for tbl in tables.flatten() {
+            let name = tbl.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if name == "snapshots" || name == "backups" {
+                continue;
+            }
+            let tbl_path = tbl.path();
+            if !tbl_path.is_dir() {
+                continue;
+            }
+            if dir_has_data_db(&tbl_path) {
+                ks_tables = ks_tables.saturating_add(1);
+            }
+        }
+        if ks_tables > 0 {
+            out.tables = out.tables.saturating_add(ks_tables);
+            out.keyspaces = out.keyspaces.saturating_add(1);
+        }
+    }
+    out
+}
+
+/// Log the discovered table/keyspace count EXACTLY ONCE, after the first sample
+/// (issue #2684) — so an inert/empty mount (`discovered 0 tables ...`) is visible
+/// in logs even without a metrics stack (same spirit as the #2128 OTel-inert
+/// warn). `Once`-guarded, co-located with the sampler like
+/// [`log_platform_support_once`].
+fn log_tables_discovered_once(discovery: &TableDiscovery, data_dir: &Path) {
+    static LOGGED: Once = Once::new();
+    LOGGED.call_once(|| {
+        tracing::info!(
+            "discovered {} tables across {} keyspaces under {}",
+            discovery.tables,
+            discovery.keyspaces,
+            data_dir.display()
+        );
+    });
 }
 
 // --- Flight blocking-task gauge --------------------------------------------
@@ -225,8 +330,16 @@ pub(crate) fn sample_ticks() -> u64 {
 }
 
 /// Perform one collection tick: read each `/proc` gauge and record ONLY the ones
-/// that returned `Some` (a `None` reader emits no sample — absence, never `0`).
-fn sample_once() {
+/// that returned `Some` (a `None` reader emits no sample — absence, never `0`),
+/// then walk `data_dir` (readdir only, issue #2684) and record
+/// `cqlite.flight.tables_discovered`. Returns the discovery result so the caller
+/// can emit the one-time startup log line after the first sample.
+///
+/// Unlike the `/proc` gauges, `tables_discovered` is emitted UNCONDITIONALLY
+/// (including `0`): a `0` here is an authoritative reading of an empty/wrong
+/// mount, NOT the "absence" a `None` /proc reader represents — surfacing an inert
+/// mount is the whole point.
+fn sample_once(data_dir: &Path) -> TableDiscovery {
     if let Some(threads) = read_proc_threads() {
         obs::record_gauge(catalog::PROC_THREADS, as_gauge(threads), &[]);
     }
@@ -236,7 +349,14 @@ fn sample_once() {
     if let Some(rss) = read_proc_rss_bytes() {
         obs::record_gauge(catalog::PROC_RSS_BYTES, as_gauge(rss), &[]);
     }
+    let discovery = discover_tables(data_dir);
+    obs::record_gauge(
+        catalog::FLIGHT_TABLES_DISCOVERED,
+        as_gauge(discovery.tables),
+        &[],
+    );
     SAMPLE_TICKS.fetch_add(1, Ordering::SeqCst);
+    discovery
 }
 
 /// Log the platform's `/proc` support state EXACTLY ONCE (design D2), so an
@@ -268,7 +388,7 @@ fn log_platform_support_once() {
 /// server. Because the initial sample runs before the select loop, the sampler
 /// always performs at least one collection tick even if shutdown is already
 /// pending (deterministic, no reliance on interval first-tick timing).
-pub async fn run_sampler<S>(interval: Duration, shutdown: S)
+pub async fn run_sampler<S>(interval: Duration, data_dir: std::path::PathBuf, shutdown: S)
 where
     S: Future<Output = ()>,
 {
@@ -277,12 +397,17 @@ where
     // Immediate startup sample; the periodic ticker then fires after each full
     // `interval` (never an extra immediate tick — `interval_at` from `now +
     // interval` — so the cadence stays regular).
-    sample_once();
+    let first = sample_once(&data_dir);
+    // One-time startup log line (issue #2684) after the first walk, so an
+    // empty/wrong mount is visible in logs even without a metrics stack.
+    log_tables_discovered_once(&first, &data_dir);
     let start = tokio::time::Instant::now() + interval;
     let mut ticker = tokio::time::interval_at(start, interval);
     loop {
         tokio::select! {
-            _ = ticker.tick() => sample_once(),
+            _ = ticker.tick() => {
+                sample_once(&data_dir);
+            }
             _ = &mut shutdown => break,
         }
     }
@@ -392,7 +517,8 @@ mod tests {
     #[test]
     fn sample_once_advances_tick_and_skips_none_readers() {
         let before = sample_ticks();
-        sample_once();
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        sample_once(tmp.path());
         assert!(
             sample_ticks() > before,
             "a collection tick is counted even when every /proc reader is None"
@@ -451,16 +577,114 @@ mod tests {
         );
     }
 
+    /// Build a `<data_dir>/<keyspace>/<table>/` dir and (optionally) drop a
+    /// `*-Data.db` name into it. `data_only=false` makes a table dir WITHOUT any
+    /// Data.db (a non-table entry that must NOT be counted).
+    fn make_table_dir(data_dir: &Path, keyspace: &str, table: &str, with_data: bool) {
+        let dir = data_dir.join(keyspace).join(table);
+        std::fs::create_dir_all(&dir).expect("create table dir");
+        if with_data {
+            std::fs::write(dir.join("nb-1-big-Data.db"), b"x").expect("write data.db");
+        }
+    }
+
+    /// Issue #2684 spec Requirement 2: a UUID-suffixed table dir counts exactly
+    /// once; `snapshots/`/`backups/` subdirs and a non-table entry are excluded;
+    /// and the walk is structural (readdir name check), never a content parse.
+    #[test]
+    fn discover_counts_genuine_table_dirs_only() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        // A UUID-suffixed table dir with a Data.db — the genuine table.
+        make_table_dir(root, "ks", "users-8f3a9c2e11114b0d9c7e2a1b3d4f5e6a", true);
+        // snapshots/ and backups/ sibling dirs directly under the keyspace must
+        // NOT be counted (even though they may contain Data.db hardlinks).
+        let snap = root.join("ks").join("snapshots").join("snap1");
+        std::fs::create_dir_all(&snap).expect("snapshots dir");
+        std::fs::write(snap.join("nb-1-big-Data.db"), b"x").expect("snap data");
+        let backup = root.join("ks").join("backups");
+        std::fs::create_dir_all(&backup).expect("backups dir");
+        std::fs::write(backup.join("nb-1-big-Data.db"), b"x").expect("backup data");
+        // A directory with NO Data.db — a non-table entry, excluded.
+        make_table_dir(root, "ks", "not_a_table", false);
+        // A stray plain file directly under the keyspace — excluded (not a dir).
+        std::fs::write(root.join("ks").join("README.txt"), b"x").expect("stray file");
+
+        let d = discover_tables(root);
+        assert_eq!(
+            d.tables, 1,
+            "only the UUID-suffixed users table dir counts (snapshots/backups/non-table excluded)"
+        );
+        assert_eq!(d.keyspaces, 1, "one keyspace contains a genuine table");
+    }
+
+    /// Issue #2684 spec Requirement 1: bidirectional — remove a table dir and the
+    /// count falls; add one and it rises; an empty dir reads 0.
+    #[test]
+    fn discover_is_bidirectional_and_zero_on_empty() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        assert_eq!(
+            discover_tables(root).tables,
+            0,
+            "an empty/wrong mount reads zero immediately"
+        );
+
+        make_table_dir(root, "ks1", "a", true);
+        make_table_dir(root, "ks1", "b", true);
+        make_table_dir(root, "ks2", "c", true);
+        let d = discover_tables(root);
+        assert_eq!(d.tables, 3, "three genuine table dirs across two keyspaces");
+        assert_eq!(d.keyspaces, 2);
+
+        // Remove one table dir → the count falls.
+        std::fs::remove_dir_all(root.join("ks1").join("b")).expect("remove table dir");
+        assert_eq!(
+            discover_tables(root).tables,
+            2,
+            "removing a table dir lowers the discovered count"
+        );
+
+        // Add a new table dir → the count rises.
+        make_table_dir(root, "ks2", "d", true);
+        assert_eq!(
+            discover_tables(root).tables,
+            3,
+            "a newly-appeared table dir raises the discovered count"
+        );
+    }
+
+    /// Issue #2684 spec Requirement 3 (cold-start invariant #2385): a full
+    /// `sample_once` walk over a populated dir performs no SSTable open/parse —
+    /// exercised here as a smoke test (the OTel `INDEX_PARSES_TOTAL` zero-delta
+    /// assertion lives in the observability-testing capture harness). Confirms
+    /// the walk sees the fixture and the tick still advances.
+    #[test]
+    fn sample_once_walks_data_dir_without_panicking() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        make_table_dir(tmp.path(), "ks", "t", true);
+        let before = sample_ticks();
+        let d = sample_once(tmp.path());
+        assert_eq!(d.tables, 1, "sample_once walks the data dir and counts");
+        assert!(sample_ticks() > before, "the tick advances");
+    }
+
     /// Stage 3.2: the sampler performs ≥1 collection tick and its handle RESOLVES
     /// after the shutdown signal (it does not run forever, does not busy-spin) —
     /// asserted on task completion, never a wall-clock sleep.
     #[tokio::test]
     async fn sampler_ticks_at_least_once_then_stops_on_shutdown() {
         let base = sample_ticks();
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let data_dir = tmp.path().to_path_buf();
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let handle = tokio::spawn(run_sampler(Duration::from_millis(5), async move {
-            let _ = rx.await;
-        }));
+        let handle = tokio::spawn(run_sampler(
+            Duration::from_millis(5),
+            data_dir,
+            async move {
+                let _ = rx.await;
+            },
+        ));
 
         // Signal shutdown; `run_sampler`'s unconditional pre-loop `sample_once()`
         // (not an interval-tick race) guarantees ≥1 collection has already

--- a/cqlite-flight/src/saturation.rs
+++ b/cqlite-flight/src/saturation.rs
@@ -136,6 +136,21 @@ pub struct TableDiscovery {
     pub keyspaces: u64,
 }
 
+/// Whether a readdir entry is a directory, using the readdir-provided `d_type`
+/// (`DirEntry::file_type`) so the walk stays genuinely readdir-only — NO stat
+/// syscall on the filesystems that populate `d_type` (the common case). Only when
+/// the filesystem reports an `Unknown` file type (or the `file_type` call itself
+/// errors) do we fall back to a `Path::is_dir` stat, so correctness holds
+/// everywhere while the fast path avoids the per-entry stat.
+fn entry_is_dir(entry: &std::fs::DirEntry) -> bool {
+    match entry.file_type() {
+        Ok(ft) if ft.is_dir() => true,
+        Ok(ft) if ft.is_file() || ft.is_symlink() => false,
+        // Unknown d_type or a file_type error: fall back to a stat.
+        _ => entry.path().is_dir(),
+    }
+}
+
 /// Whether `dir` DIRECTLY contains a `*-Data.db` entry (readdir name check only
 /// — no stat, no open, no generation parse). This is the sole, structural
 /// "is a genuine table dir" test (matches the `DirSource` `-Data.db` prior art).
@@ -171,10 +186,10 @@ pub fn discover_tables(data_dir: &Path) -> TableDiscovery {
         return out;
     };
     for ks in keyspaces.flatten() {
-        let ks_path = ks.path();
-        if !ks_path.is_dir() {
+        if !entry_is_dir(&ks) {
             continue;
         }
+        let ks_path = ks.path();
         let Ok(tables) = std::fs::read_dir(&ks_path) else {
             continue;
         };
@@ -187,10 +202,10 @@ pub fn discover_tables(data_dir: &Path) -> TableDiscovery {
             if name == "snapshots" || name == "backups" {
                 continue;
             }
-            let tbl_path = tbl.path();
-            if !tbl_path.is_dir() {
+            if !entry_is_dir(&tbl) {
                 continue;
             }
+            let tbl_path = tbl.path();
             if dir_has_data_db(&tbl_path) {
                 ks_tables = ks_tables.saturating_add(1);
             }
@@ -335,11 +350,18 @@ pub(crate) fn sample_ticks() -> u64 {
 /// `cqlite.flight.tables_discovered`. Returns the discovery result so the caller
 /// can emit the one-time startup log line after the first sample.
 ///
+/// The `data_dir` walk (a `readdir` tree-scan whose cost scales with keyspaces ×
+/// tables, and which can block on a slow/network-backed mount) is offloaded to a
+/// `tokio::task::spawn_blocking` pool thread so it NEVER stalls a runtime worker
+/// polling in-flight `do_get` scan futures (roborev, issue #2684). If that
+/// blocking task fails to join (e.g. runtime shutdown), this tick simply skips the
+/// `tables_discovered` emission and returns an empty discovery — never a panic.
+///
 /// Unlike the `/proc` gauges, `tables_discovered` is emitted UNCONDITIONALLY
 /// (including `0`): a `0` here is an authoritative reading of an empty/wrong
 /// mount, NOT the "absence" a `None` /proc reader represents — surfacing an inert
 /// mount is the whole point.
-fn sample_once(data_dir: &Path) -> TableDiscovery {
+async fn sample_once(data_dir: &Path) -> TableDiscovery {
     if let Some(threads) = read_proc_threads() {
         obs::record_gauge(catalog::PROC_THREADS, as_gauge(threads), &[]);
     }
@@ -349,13 +371,24 @@ fn sample_once(data_dir: &Path) -> TableDiscovery {
     if let Some(rss) = read_proc_rss_bytes() {
         obs::record_gauge(catalog::PROC_RSS_BYTES, as_gauge(rss), &[]);
     }
-    let discovery = discover_tables(data_dir);
+    // Every tick counts as a completed collection (the work-probe), independent of
+    // the offloaded walk's outcome.
+    SAMPLE_TICKS.fetch_add(1, Ordering::SeqCst);
+    // Run the blocking readdir tree-scan OFF the async executor.
+    let dir = data_dir.to_path_buf();
+    let discovery = match tokio::task::spawn_blocking(move || discover_tables(&dir)).await {
+        Ok(discovery) => discovery,
+        Err(_join_err) => {
+            // The blocking task failed to join (runtime teardown); skip this
+            // tick's emission rather than panicking.
+            return TableDiscovery::default();
+        }
+    };
     obs::record_gauge(
         catalog::FLIGHT_TABLES_DISCOVERED,
         as_gauge(discovery.tables),
         &[],
     );
-    SAMPLE_TICKS.fetch_add(1, Ordering::SeqCst);
     discovery
 }
 
@@ -397,7 +430,7 @@ where
     // Immediate startup sample; the periodic ticker then fires after each full
     // `interval` (never an extra immediate tick — `interval_at` from `now +
     // interval` — so the cadence stays regular).
-    let first = sample_once(&data_dir);
+    let first = sample_once(&data_dir).await;
     // One-time startup log line (issue #2684) after the first walk, so an
     // empty/wrong mount is visible in logs even without a metrics stack.
     log_tables_discovered_once(&first, &data_dir);
@@ -406,7 +439,7 @@ where
     loop {
         tokio::select! {
             _ = ticker.tick() => {
-                sample_once(&data_dir);
+                sample_once(&data_dir).await;
             }
             _ = &mut shutdown => break,
         }
@@ -514,11 +547,11 @@ mod tests {
     /// and confirming it never panics and always advances the tick probe,
     /// regardless of platform (on non-`/proc` platforms all three readers are
     /// `None` and no gauge is recorded, yet the tick still counts).
-    #[test]
-    fn sample_once_advances_tick_and_skips_none_readers() {
+    #[tokio::test]
+    async fn sample_once_advances_tick_and_skips_none_readers() {
         let before = sample_ticks();
         let tmp = tempfile::TempDir::new().expect("tempdir");
-        sample_once(tmp.path());
+        sample_once(tmp.path()).await;
         assert!(
             sample_ticks() > before,
             "a collection tick is counted even when every /proc reader is None"
@@ -659,12 +692,12 @@ mod tests {
     /// exercised here as a smoke test (the OTel `INDEX_PARSES_TOTAL` zero-delta
     /// assertion lives in the observability-testing capture harness). Confirms
     /// the walk sees the fixture and the tick still advances.
-    #[test]
-    fn sample_once_walks_data_dir_without_panicking() {
+    #[tokio::test]
+    async fn sample_once_walks_data_dir_without_panicking() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         make_table_dir(tmp.path(), "ks", "t", true);
         let before = sample_ticks();
-        let d = sample_once(tmp.path());
+        let d = sample_once(tmp.path()).await;
         assert_eq!(d.tables, 1, "sample_once walks the data dir and counts");
         assert!(sample_ticks() > before, "the tick advances");
     }

--- a/cqlite-flight/src/saturation.rs
+++ b/cqlite-flight/src/saturation.rs
@@ -145,6 +145,11 @@ pub struct TableDiscovery {
 fn entry_is_dir(entry: &std::fs::DirEntry) -> bool {
     match entry.file_type() {
         Ok(ft) if ft.is_dir() => true,
+        // A symlinked dir is INTENTIONALLY not followed/counted (this arm
+        // short-circuits before the `Path::is_dir` stat fallback below, which
+        // WOULD follow the link): a deliberate safety choice so the walk never
+        // descends a symlink into a snapshot/hardlink tree (or an out-of-tree
+        // target) and double-counts or loops. Plain files are likewise not dirs.
         Ok(ft) if ft.is_file() || ft.is_symlink() => false,
         // Unknown d_type or a file_type error: fall back to a stat.
         _ => entry.path().is_dir(),
@@ -199,6 +204,17 @@ pub fn discover_tables(data_dir: &Path) -> TableDiscovery {
             let Some(name) = name.to_str() else {
                 continue;
             };
+            // Defensive skip of any `snapshots`/`backups` dir sitting directly
+            // under the keyspace. In the REAL Cassandra layout these live UNDER
+            // the table dir (`<keyspace>/<table>/snapshots/<snap>/*-Data.db`,
+            // `<keyspace>/<table>/backups/…`), NOT as keyspace-level siblings, so
+            // this name-skip is largely belt-and-braces. The ACTUAL property that
+            // keeps a nested snapshot/backup `Data.db` from being counted is
+            // NON-RECURSION: the walk descends exactly two levels (keyspace →
+            // table) and `dir_has_data_db` inspects only a dir's DIRECT children,
+            // so a `<table>/snapshots/<snap>/*-Data.db` is never reached — the
+            // table dir is counted once for its own live `*-Data.db` and the
+            // nested snapshot tree is invisible to the walk.
             if name == "snapshots" || name == "backups" {
                 continue;
             }
@@ -621,23 +637,34 @@ mod tests {
         }
     }
 
-    /// Issue #2684 spec Requirement 2: a UUID-suffixed table dir counts exactly
-    /// once; `snapshots/`/`backups/` subdirs and a non-table entry are excluded;
-    /// and the walk is structural (readdir name check), never a content parse.
+    /// Issue #2684 spec Requirement 2, modeling the REAL on-disk layout: a
+    /// UUID-suffixed table dir counts EXACTLY ONCE even though it also contains
+    /// the genuine Cassandra `snapshots/`/`backups/` subtrees (which, in real
+    /// Cassandra, live UNDER the table dir — `<keyspace>/<table>/snapshots/<snap>/`
+    /// — as hardlinks to the live SSTables, NOT as keyspace-level siblings). The
+    /// nested snapshot/backup `Data.db` hardlinks must NOT be double-counted; the
+    /// non-recursive two-level walk (keyspace → table, direct-children `Data.db`
+    /// check) is what guarantees this. A dir with no direct `Data.db` is excluded.
     #[test]
     fn discover_counts_genuine_table_dirs_only() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let root = tmp.path();
-        // A UUID-suffixed table dir with a Data.db — the genuine table.
-        make_table_dir(root, "ks", "users-8f3a9c2e11114b0d9c7e2a1b3d4f5e6a", true);
-        // snapshots/ and backups/ sibling dirs directly under the keyspace must
-        // NOT be counted (even though they may contain Data.db hardlinks).
-        let snap = root.join("ks").join("snapshots").join("snap1");
-        std::fs::create_dir_all(&snap).expect("snapshots dir");
+        // A UUID-suffixed table dir with a live Data.db — the genuine table.
+        let table = "users-8f3a9c2e11114b0d9c7e2a1b3d4f5e6a";
+        make_table_dir(root, "ks", table, true);
+        let table_dir = root.join("ks").join(table);
+
+        // REAL LAYOUT: snapshots/ and backups/ live UNDER the table dir and hold
+        // hardlinked *-Data.db copies of the live SSTable. These nested Data.db
+        // files must NOT be counted (they are not the table's own live children,
+        // and the non-recursive walk never descends into them).
+        let snap = table_dir.join("snapshots").join("snap1");
+        std::fs::create_dir_all(&snap).expect("nested snapshots dir");
         std::fs::write(snap.join("nb-1-big-Data.db"), b"x").expect("snap data");
-        let backup = root.join("ks").join("backups");
-        std::fs::create_dir_all(&backup).expect("backups dir");
+        let backup = table_dir.join("backups").join("bkp1");
+        std::fs::create_dir_all(&backup).expect("nested backups dir");
         std::fs::write(backup.join("nb-1-big-Data.db"), b"x").expect("backup data");
+
         // A directory with NO Data.db — a non-table entry, excluded.
         make_table_dir(root, "ks", "not_a_table", false);
         // A stray plain file directly under the keyspace — excluded (not a dir).
@@ -646,7 +673,9 @@ mod tests {
         let d = discover_tables(root);
         assert_eq!(
             d.tables, 1,
-            "only the UUID-suffixed users table dir counts (snapshots/backups/non-table excluded)"
+            "the users table counts EXACTLY once — its nested snapshots/ and \
+             backups/ Data.db hardlinks are not double-counted (non-recursion), \
+             and the no-Data.db dir is excluded"
         );
         assert_eq!(d.keyspaces, 1, "one keyspace contains a genuine table");
     }

--- a/cqlite-flight/src/warm/mod.rs
+++ b/cqlite-flight/src/warm/mod.rs
@@ -42,7 +42,7 @@ pub mod registry;
 
 pub use identity::{GenerationId, GenerationSet};
 pub use metrics::{RefreshOutcome, WarmMetrics, WarmMetricsSnapshot};
-pub use registry::{TableKey, WarmTableRegistry};
+pub use registry::{warm_table_count, TableKey, WarmTableRegistry};
 
 /// Errors from the warm-handle path.
 ///

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -44,8 +44,10 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
 
+use cqlite_core::observability::{self as obs, catalog};
 use cqlite_core::schema::{TableSchema, UdtRegistry};
 use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::Platform;
@@ -57,6 +59,48 @@ use super::identity::{GenerationId, GenerationSet};
 use super::metrics::{RefreshOutcome, WarmMetrics};
 use super::probe::{self, GenerationEntry, ProbeOutcome};
 use super::{WarmError, WarmSet};
+
+/// Process-wide level backing `cqlite.flight.warm_tables` (issue #2684) — the
+/// current number of tables with a live warm reader set. Set to the
+/// post-mutation `Inner.tables.len()` at each registry mutation site (rebuild
+/// insert / `evict_to_budget` removal) while the `Inner` lock is held, so the
+/// remove-then-reinsert transient a rebuild performs never dips the reading.
+///
+/// A process-wide `static` (not per-registry state) mirrors
+/// [`crate::saturation::blocking_tasks_in_use_level`]: production runs exactly
+/// one [`WarmTableRegistry`], and a level reader consumable without an OTel stack
+/// lets up/down tests assert the gauge moves. Tests that read it exactly use one
+/// `#[test]` per binary (one process), as `issue_2370_gauge_readback_test.rs`
+/// documents for the other process-global gauges.
+static WARM_TABLES: AtomicI64 = AtomicI64::new(0);
+
+/// Read the current process-wide warm-table level (issue #2684) — the same value
+/// that drives `cqlite.flight.warm_tables`. Feature-independent (maintained
+/// regardless of the `observability` OTel feature; only the emission is gated),
+/// mirroring [`crate::saturation::blocking_tasks_in_use_level`].
+pub fn warm_table_count() -> i64 {
+    WARM_TABLES.load(Ordering::SeqCst)
+}
+
+/// Record the post-mutation warm-table count: store the process-wide level AND
+/// emit the gauge (total-only, no attributes — matching the saturation gauges).
+/// Called under the `Inner` lock so the emitted value is the exact current size.
+///
+/// Counts tables with a LIVE (non-empty) warm reader set — the spec's definition
+/// ("tables with a live warm reader set"). A rebuild against an empty
+/// on-disk generation set can leave a table entry with zero readers (the
+/// generation was retired from disk); such an entry is not a live warm table, so
+/// it is excluded — which makes retirement observably DECREMENT the gauge.
+fn record_warm_tables(inner: &Inner) {
+    let live = inner
+        .tables
+        .values()
+        .filter(|t| !t.readers.is_empty())
+        .count();
+    let level = i64::try_from(live).unwrap_or(i64::MAX);
+    WARM_TABLES.store(level, Ordering::SeqCst);
+    obs::record_gauge(catalog::FLIGHT_WARM_TABLES, level, &[]);
+}
 
 /// The logical-table half of the warm cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -603,6 +647,11 @@ impl WarmTableRegistry {
                 manifest,
             },
         );
+        // Emit `cqlite.flight.warm_tables` (issue #2684) post-insert while the
+        // `Inner` lock is held: the count is exact, and emitting AFTER the swap
+        // avoids the remove-then-reinsert transient dip (this rebuild removed the
+        // same key earlier). `evict_to_budget` below emits again if it removes.
+        record_warm_tables(&inner);
 
         // Enforce the byte budget (LRU eviction), never evicting a generation in
         // THIS request's returned set.
@@ -636,6 +685,7 @@ impl WarmTableRegistry {
                 // Nothing evictable without dropping the current request's set.
                 break;
             };
+            let mut table_removed = false;
             if let Some(t) = inner.tables.get_mut(&vkey) {
                 // Issue #2059 fix round (review Medium): a CAPACITY eviction here is
                 // NOT a generation removal — the victim generation is still fully
@@ -657,7 +707,16 @@ impl WarmTableRegistry {
                 t.readers.retain(|r| r.id != vid);
                 if t.readers.is_empty() {
                     inner.tables.remove(&vkey);
+                    table_removed = true;
                 }
+            }
+            if table_removed {
+                // A table left the warm set: emit the post-removal count (issue
+                // #2684). Only a WHOLE-table removal changes the live-table
+                // count; evicting one generation of a still-warm
+                // multi-generation table does not, so the gauge is emitted
+                // exactly when the level moves.
+                record_warm_tables(inner);
             }
             inner.used_bytes = inner.used_bytes.saturating_sub(vbytes);
             evicted += 1;

--- a/cqlite-flight/tests/issue_2684_tables_discovered_coldstart_test.rs
+++ b/cqlite-flight/tests/issue_2684_tables_discovered_coldstart_test.rs
@@ -1,0 +1,149 @@
+//! Issue #2684 — cold-start invariant (#2385) for `cqlite.flight.tables_discovered`.
+//!
+//! The saturation sampler's table-discovery walk is readdir-only: it must NEVER
+//! open, stat-for-generation, or parse an SSTable. `cqlite.sstable.index_parses_total`
+//! is incremented at exactly one site (a full Index.db parse), so N sampler ticks
+//! over a POPULATED data-dir must show a zero delta on that counter — and the
+//! `tables_discovered` gauge must reflect the genuine on-disk table count.
+//!
+//! Uses the shared `observability-testing` capture harness (a process-global
+//! in-memory meter provider), so this lives in its OWN integration-test binary
+//! (matching the `metrics_capture_test.rs` precedent).
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --features observability-testing --test issue_2684_tables_discovered_coldstart_test
+//! ```
+
+#![cfg(feature = "observability-testing")]
+
+use std::time::Duration;
+
+use cqlite_core::observability::{catalog, testing};
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+
+const KS: &str = "coldstart_ks";
+const TBL: &str = "items";
+
+fn schema() -> TableSchema {
+    let col = |name: &str, ty: &str, nullable: bool| Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    };
+    TableSchema {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![col("id", "int", false), col("name", "text", true)],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "name".into(),
+            value: Value::text(name),
+        }],
+        100,
+        None,
+    )
+}
+
+/// Flush a populated single-SSTable fixture (a real Index.db present) and return
+/// its data-dir.
+fn build_populated_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for i in 1..=32 {
+        engine.write(write_row(i, &format!("n{i}"))).expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    (temp, data_dir)
+}
+
+#[test]
+fn sampler_ticks_produce_zero_index_parse_delta_and_count_tables() {
+    // Install the in-memory meter provider BEFORE any metric is recorded.
+    let mc = testing::metrics_capture();
+
+    let (_temp, data_dir) = build_populated_fixture();
+
+    mc.reset();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        // Run several sampler ticks over the populated dir with NO query activity.
+        // A tiny interval keeps the test fast; shutdown resolves after a bounded
+        // number of ticks have certainly occurred.
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(cqlite_flight::saturation::run_sampler(
+            Duration::from_millis(5),
+            data_dir.clone(),
+            async move {
+                let _ = rx.await;
+            },
+        ));
+        // Let the sampler tick many times, then stop it.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let _ = tx.send(());
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("sampler resolves after shutdown")
+            .expect("sampler task ok");
+    });
+
+    let metrics = mc.flush_and_collect();
+
+    // COLD-START INVARIANT (#2385): the discovery walk opened/parsed nothing, so
+    // the full-Index.db-parse counter shows zero delta from the sampling.
+    let index_parses = metrics.counter_sum(catalog::INDEX_PARSES_TOTAL);
+    assert_eq!(
+        index_parses, 0.0,
+        "the readdir-only discovery walk must produce zero index_parses delta \
+         (cold-start invariant #2385); got {index_parses}"
+    );
+
+    // And the gauge is emitted with the genuine table count (one table dir).
+    assert!(
+        metrics.contains(catalog::FLIGHT_TABLES_DISCOVERED),
+        "the sampler must emit cqlite.flight.tables_discovered"
+    );
+    assert_eq!(
+        metrics.unit(catalog::FLIGHT_TABLES_DISCOVERED),
+        Some("{entry}"),
+        "tables_discovered carries the {{entry}} unit"
+    );
+    // DELTA temporality: the last-collected gauge value is the current count (1).
+    let last = metrics
+        .find(catalog::FLIGHT_TABLES_DISCOVERED)
+        .and_then(|m| m.points.last())
+        .map(|p| p.value)
+        .expect("a tables_discovered data point");
+    assert_eq!(
+        last, 1.0,
+        "the populated fixture has exactly one genuine table dir"
+    );
+}

--- a/cqlite-flight/tests/issue_2684_tables_discovered_log_test.rs
+++ b/cqlite-flight/tests/issue_2684_tables_discovered_log_test.rs
@@ -1,0 +1,183 @@
+//! Issue #2684 spec Requirement 5 — the startup log line reports the discovered
+//! table/keyspace count.
+//!
+//! The saturation sampler emits EXACTLY ONE `info`-level line
+//! (`discovered N tables across M keyspaces under <data-dir>`) after its first
+//! sample, `Once`-guarded (`saturation::log_tables_discovered_once`, called from
+//! `run_sampler` after the first `sample_once`). This test captures the emitted
+//! `tracing` output and asserts that exactly one such INFO line is emitted,
+//! naming the genuine table count N, keyspace count M, and the data-dir path —
+//! even if the sampler ticks more than once (the `Once` guard).
+//!
+//! # Isolation
+//!
+//! `log_tables_discovered_once`'s `Once` guard is PROCESS-GLOBAL, so a second
+//! `run_sampler` in the same binary would NOT re-emit the line — this test lives
+//! in its OWN integration-test binary with a single `#[test]` (matching the other
+//! #2684 gauge tests' one-test-per-binary isolation convention) so the guard is
+//! pristine when the test runs.
+//!
+//! The capturing subscriber is installed as the PROCESS-GLOBAL default
+//! (`set_global_default`, not a thread-local `set_default`): `run_sampler` and its
+//! log site run on a tokio worker thread distinct from the test task, which a
+//! thread-local default would not observe (the #1703 cross-thread hazard). One
+//! `#[test]` per binary makes the single global call safe.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --test issue_2684_tables_discovered_log_test
+//! ```
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+
+/// Rendered `message` field of a captured event.
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{value:?}");
+        }
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_string();
+        }
+    }
+}
+
+/// Captures the rendered message of every event it sees (installed behind an
+/// `INFO` level filter, so only INFO-and-above events reach it).
+#[derive(Clone)]
+struct CaptureLayer {
+    messages: Arc<Mutex<Vec<String>>>,
+    events: Arc<AtomicUsize>,
+}
+
+impl<S: Subscriber> Layer<S> for CaptureLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        self.events.fetch_add(1, Ordering::Relaxed);
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        if let Ok(mut v) = self.messages.lock() {
+            v.push(visitor.message);
+        }
+    }
+}
+
+/// Build a `<data_dir>/<keyspace>/<table>/nb-1-big-Data.db` fixture (readdir-only
+/// discovery counts a dir directly containing a `*-Data.db` name — no real
+/// SSTable content is parsed).
+fn make_table_dir(data_dir: &Path, keyspace: &str, table: &str) {
+    let dir = data_dir.join(keyspace).join(table);
+    std::fs::create_dir_all(&dir).expect("create table dir");
+    std::fs::write(dir.join("nb-1-big-Data.db"), b"x").expect("write data.db");
+}
+
+/// Spec Requirement 5: after the first sample the sampler emits EXACTLY ONE
+/// INFO-level line naming the genuine table count, keyspace count, and the
+/// data-dir path — and only once, even across multiple ticks (the `Once` guard).
+#[test]
+fn startup_log_line_reports_discovered_table_and_keyspace_count() {
+    // A known layout: 3 genuine table dirs across 2 keyspaces (ks1: a, b; ks2: c).
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = tmp.path().to_path_buf();
+    make_table_dir(&data_dir, "ks1", "a");
+    make_table_dir(&data_dir, "ks1", "b");
+    make_table_dir(&data_dir, "ks2", "c");
+    const EXPECTED_TABLES: u64 = 3;
+    const EXPECTED_KEYSPACES: u64 = 2;
+
+    // The exact line the production `Once`-guarded site formats.
+    let expected_line = format!(
+        "discovered {} tables across {} keyspaces under {}",
+        EXPECTED_TABLES,
+        EXPECTED_KEYSPACES,
+        data_dir.display()
+    );
+
+    let messages = Arc::new(Mutex::new(Vec::<String>::new()));
+    let events = Arc::new(AtomicUsize::new(0));
+    let layer = CaptureLayer {
+        messages: messages.clone(),
+        events: events.clone(),
+    }
+    .with_filter(LevelFilter::INFO);
+    // PROCESS-GLOBAL default: the log site runs on a tokio worker thread, not the
+    // test task (a thread-local default would miss it — the #1703 hazard). Safe
+    // to call once: this binary has exactly one `#[test]`.
+    tracing::subscriber::set_global_default(tracing_subscriber::registry().with(layer))
+        .expect("set_global_default must succeed (only test in this binary)");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("multi-thread runtime");
+    rt.block_on(async {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(cqlite_flight::saturation::run_sampler(
+            // A tiny interval lets the sampler tick several times before shutdown,
+            // proving the `Once` guard emits the line only ONCE across many ticks.
+            Duration::from_millis(5),
+            data_dir.clone(),
+            async move {
+                let _ = rx.await;
+            },
+        ));
+        // Let the sampler tick repeatedly, then stop it.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let _ = tx.send(());
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("the sampler handle must resolve after shutdown (no forever-run)")
+            .expect("the sampler task completed without panicking");
+    });
+
+    let captured = messages.lock().expect("messages lock").clone();
+    // The sampler ran; SOME INFO event was seen (non-vacuous capture).
+    assert!(
+        events.load(Ordering::Relaxed) > 0,
+        "the capturing subscriber saw no INFO events at all — capture is vacuous"
+    );
+
+    let discovered: Vec<&String> = captured
+        .iter()
+        .filter(|m| m.starts_with("discovered ") && m.contains(" tables across "))
+        .collect();
+    assert_eq!(
+        discovered.len(),
+        1,
+        "EXACTLY ONE `discovered … tables …` INFO line must be emitted (the Once \
+         guard), even though the sampler ticked many times; captured discovery \
+         lines: {discovered:#?} (all INFO messages: {captured:#?})"
+    );
+
+    let line = discovered[0];
+    // The line names the genuine table count, keyspace count, AND the data-dir
+    // path — asserted as the full formatted string so a substring collision
+    // (e.g. a digit inside the path) cannot pass it vacuously.
+    assert_eq!(
+        line, &expected_line,
+        "the startup line must report N tables, M keyspaces, and the data-dir path \
+         (spec Requirement 5)"
+    );
+    // Belt-and-braces: each named component is present.
+    assert!(
+        line.contains(&format!("{EXPECTED_TABLES} tables"))
+            && line.contains(&format!("{EXPECTED_KEYSPACES} keyspaces"))
+            && line.contains(&data_dir.display().to_string()),
+        "the line must name the table count, keyspace count, and data-dir path"
+    );
+}

--- a/cqlite-flight/tests/issue_2684_warm_tables_eviction_test.rs
+++ b/cqlite-flight/tests/issue_2684_warm_tables_eviction_test.rs
@@ -1,0 +1,171 @@
+//! Issue #2684 — `cqlite.flight.warm_tables` DECREMENTS on a whole-table
+//! byte-budget (LRU) eviction.
+//!
+//! The existing `issue_2684_warm_tables_gauge_test.rs` covers rise-on-first-serve
+//! and fall-on-retirement (a rebuild against an empty on-disk generation set).
+//! Neither exercises the OTHER whole-table-removal site: `evict_to_budget`, which
+//! calls `record_warm_tables` only when an LRU eviction empties a table entry.
+//! This file drives enough DISTINCT warm tables past a tight warm byte budget to
+//! force that whole-table eviction and proves the gauge is decremented on it.
+//!
+//! ## Isolation requirement
+//!
+//! `warm_table_count()` reads a PROCESS-GLOBAL atomic. An exact reading is only
+//! meaningful with no sibling warm activity in flight, so this file holds EXACTLY
+//! ONE `#[test]` — one file = one binary = one process (matching the
+//! `issue_2370_gauge_readback_test.rs` / `issue_2684_warm_tables_gauge_test.rs`
+//! precedent). Do not add a second `#[test]` here; add a sibling FILE instead.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --test issue_2684_warm_tables_eviction_test
+//! ```
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+
+use cqlite_flight::cancel::CancelFlag;
+use cqlite_flight::warm::{ddl_hash, warm_table_count, TableKey, WarmTableRegistry};
+
+const KS: &str = "warm_evict_ks";
+
+fn schema(table: &str) -> TableSchema {
+    let col = |name: &str, ty: &str, nullable: bool| Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    };
+    TableSchema {
+        keyspace: KS.into(),
+        table: table.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![col("id", "int", false), col("name", "text", true)],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+fn write_row(table: &str, id: i32, name: &str) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, table),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "name".into(),
+            value: Value::text(name),
+        }],
+        100,
+        None,
+    )
+}
+
+/// Flush a small single-SSTable fixture for `table` under a shared data root and
+/// return its resolved SSTable directory (`<data_dir>/<ks>/<table>`).
+fn build_table(
+    data_dir: &std::path::Path,
+    wal_root: &std::path::Path,
+    table: &str,
+) -> std::path::PathBuf {
+    let config =
+        WriteEngineConfig::new(data_dir.to_path_buf(), wal_root.join(table), schema(table));
+    let mut engine = WriteEngine::new(config).expect("engine");
+    engine.write(write_row(table, 1, "a")).expect("write");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    data_dir.join(KS).join(table)
+}
+
+#[test]
+fn warm_tables_gauge_decrements_on_whole_table_budget_eviction() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_root = temp.path().join("wal");
+
+    // Three distinct single-SSTable tables under one data root.
+    let dir_a = build_table(&data_dir, &wal_root, "table_a");
+    let dir_b = build_table(&data_dir, &wal_root, "table_b");
+    let dir_c = build_table(&data_dir, &wal_root, "table_c");
+
+    // A budget of 1 byte: every table's footprint exceeds it, but a rebuild never
+    // evicts the CURRENT request's own (protected) generation — so exactly one
+    // table stays warm at a time, and warming the NEXT distinct table always
+    // whole-table-evicts the previous one (the `evict_to_budget` decrement site).
+    let reg = WarmTableRegistry::with_budget(1);
+    let cancel = CancelFlag::new();
+    let ddl = ddl_hash("CREATE TABLE warm_evict_ks.x (id int PRIMARY KEY, name text)");
+
+    let warm = |dir: &std::path::Path, table: &str| {
+        reg.warm_readers(
+            &TableKey::new(KS, table),
+            ddl,
+            &schema(table),
+            None,
+            dir,
+            None,
+            &cancel,
+        )
+        .expect("warm");
+    };
+
+    let baseline = warm_table_count();
+
+    // Warm A: A's generation is protected within its own request, so it is NOT
+    // evicted despite exceeding the budget — the gauge rises by one.
+    warm(&dir_a, "table_a");
+    assert_eq!(
+        warm_table_count(),
+        baseline + 1,
+        "the first warm table raises the gauge to one"
+    );
+    assert_eq!(
+        reg.metrics().snapshot().evicts,
+        0,
+        "warming the first (protected) table evicts nothing"
+    );
+
+    // Warm B: inserts B (transiently two live tables) then the byte budget forces
+    // a WHOLE-TABLE LRU eviction of A. If the eviction decrement did NOT fire the
+    // gauge would climb to baseline + 2; because it fires, the level holds at
+    // baseline + 1 and an eviction is recorded — the decrement is observable.
+    warm(&dir_b, "table_b");
+    assert_eq!(
+        warm_table_count(),
+        baseline + 1,
+        "the whole-table byte-budget eviction of A decrements the gauge back down \
+         (it did NOT climb to baseline + 2)"
+    );
+    let evicts_after_b = reg.metrics().snapshot().evicts;
+    assert!(
+        evicts_after_b >= 1,
+        "warming B past the budget whole-table-evicted A (got {evicts_after_b} evicts)"
+    );
+
+    // Warm C: again evicts the current LRU whole table (B). The gauge stays at
+    // capacity and evicts keep accumulating — each whole-table eviction decrements.
+    warm(&dir_c, "table_c");
+    assert_eq!(
+        warm_table_count(),
+        baseline + 1,
+        "each subsequent distinct warm table whole-table-evicts the prior one; the \
+         gauge holds at capacity rather than climbing"
+    );
+    assert!(
+        reg.metrics().snapshot().evicts > evicts_after_b,
+        "warming C whole-table-evicted B (a second eviction decrement)"
+    );
+
+    drop(temp);
+}

--- a/cqlite-flight/tests/issue_2684_warm_tables_gauge_test.rs
+++ b/cqlite-flight/tests/issue_2684_warm_tables_gauge_test.rs
@@ -1,0 +1,172 @@
+//! Issue #2684 — `cqlite.flight.warm_tables` proven bidirectional through the
+//! REAL `do_get` handler path (the public Flight surface).
+//!
+//! The gauge is atomic-backed at the `WarmTableRegistry` mutation sites and read
+//! back here via the feature-independent `cqlite_flight::warm::warm_table_count`
+//! level reader (no OTel stack needed — mirrors the #2419 blocking-task level
+//! reader). A first `do_get` on a previously-unseen table triggers a rebuild
+//! INSERT → the level rises; retiring the table's on-disk SSTables and issuing a
+//! second `do_get` triggers a rebuild that drops the retired generation → the
+//! level falls back.
+//!
+//! ## Isolation requirement
+//!
+//! `warm_table_count()` reads a PROCESS-GLOBAL atomic. An exact up/down read is
+//! only meaningful with no sibling `do_get` in flight, so this file holds
+//! EXACTLY ONE `#[test]` — one file = one binary = one process (matching the
+//! `issue_2370_gauge_readback_test.rs` precedent). Do not add a second `#[test]`
+//! here; add a sibling FILE instead.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-flight --test issue_2684_warm_tables_gauge_test
+//! ```
+
+use std::path::Path;
+
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tonic::Request;
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_flight::service::CqliteFlightService;
+use cqlite_flight::warm::warm_table_count;
+
+const KS: &str = "warm_gauge_ks";
+const TBL: &str = "items";
+const DDL: &str = "CREATE TABLE warm_gauge_ks.items (id int PRIMARY KEY, name text)";
+
+fn schema() -> TableSchema {
+    let col = |name: &str, ty: &str, nullable: bool| Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    };
+    TableSchema {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![col("id", "int", false), col("name", "text", true)],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "name".into(),
+            value: Value::text(name),
+        }],
+        100,
+        None,
+    )
+}
+
+/// Flush a small single-SSTable fixture and return (temp, data_dir, table_dir).
+fn build_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp = tempfile::TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for i in 1..=6 {
+        engine.write(write_row(i, &format!("n{i}"))).expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    (temp, data_dir)
+}
+
+fn ticket_bytes() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS,
+        "table": TBL,
+        "ddl": DDL,
+    }))
+    .unwrap()
+}
+
+/// Delete every `*-Data.db` under `table_dir` so the next `warm_readers` rebuild
+/// finds the generation set empty and retires the warm entry.
+fn retire_sstables(table_dir: &Path) {
+    for entry in std::fs::read_dir(table_dir)
+        .expect("read table dir")
+        .flatten()
+    {
+        let name = entry.file_name();
+        if name.to_str().is_some_and(|n| n.ends_with("-Data.db")) {
+            std::fs::remove_file(entry.path()).expect("remove data.db");
+        }
+    }
+}
+
+/// Drain a `do_get` for `ticket` to completion (or map the terminal error).
+async fn drive_do_get(svc: &CqliteFlightService, ticket: Vec<u8>) -> Result<(), tonic::Status> {
+    let resp = svc.do_get(Request::new(Ticket::new(ticket))).await?;
+    let mut stream = resp.into_inner();
+    while let Some(item) = stream.next().await {
+        item?;
+    }
+    Ok(())
+}
+
+#[test]
+fn warm_tables_gauge_rises_on_first_serve_and_falls_on_retirement() {
+    let (_temp, data_dir) = build_fixture();
+    let table_dir = data_dir.join(KS).join(TBL);
+    let svc = CqliteFlightService::new(data_dir, 4);
+
+    // The gauge is a process-global level; read the baseline explicitly so the
+    // assertions are baseline-relative and never assume a clean slate.
+    let baseline = warm_table_count();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        // UP: a real do_get on a previously-unseen table warms it (rebuild insert).
+        drive_do_get(&svc, ticket_bytes())
+            .await
+            .expect("first do_get warms the table");
+        let after_warm = warm_table_count();
+        assert_eq!(
+            after_warm,
+            baseline + 1,
+            "warm_tables must rise by one after the first serve of a previously-unseen table"
+        );
+
+        // DOWN: retire the table's SSTables on disk, then a second do_get rebuilds
+        // to an empty generation set → the table leaves the live warm set.
+        retire_sstables(&table_dir);
+        // The retired-table do_get returns zero rows (or a benign terminal status);
+        // either way the rebuild retires the warm entry and drops the gauge.
+        let _ = drive_do_get(&svc, ticket_bytes()).await;
+        let after_retire = warm_table_count();
+        assert!(
+            after_retire < after_warm,
+            "warm_tables must fall after the table's generations are retired \
+             (was {after_warm}, now {after_retire})"
+        );
+        assert_eq!(
+            after_retire, baseline,
+            "warm_tables returns to its baseline once the retired table leaves the warm set"
+        );
+    });
+}

--- a/docs/reports/flight-metrics-reference.md
+++ b/docs/reports/flight-metrics-reference.md
@@ -6,7 +6,7 @@ Operator-facing reference for every `cqlite.*` instrument CQLite emits over Arro
 
 Related: the Flight/Trino operator docs (`docs/flight-trino/`) and the round scoreboard template (issue #2399) link back to the entries here.
 
-Total instruments: **73**.
+Total instruments: **75**.
 
 ## All instruments
 
@@ -38,6 +38,8 @@ Total instruments: **73**.
 | `cqlite.flight.admission.wait_seconds` | histogram | `s` | _(none)_ | How long a do_get waited on acquire before it was admitted or rejected. | A near-zero distribution is healthy; a rising tail means requests are increasingly queuing for permits. |
 | `cqlite.flight.admission.waiting` | gauge | `1` | _(none)_ | do_get requests parked waiting for an admission permit — the backpressure signal. | Zero is healthy; a sustained non-zero value means offered concurrency exceeds the ceiling and requests are queuing. |
 | `cqlite.flight.blocking_tasks_in_use` | gauge | `{thread}` | _(none)_ | Flight spawn_blocking tasks currently outstanding (flight-managed proxy, NOT the global tokio pool queue depth). | Rises with concurrent do_get scans and returns to baseline; a level pinned near the blocking-pool size with flat rpc.rows is blocking-pool saturation. Distinct from admission.in_use. |
+| `cqlite.flight.tables_discovered` | gauge | `{entry}` | _(none)_ | Table dirs visible under --data-dir, re-sampled by a readdir-only walk on the ~2s saturation tick (no SSTable opens). Undersampled at ~2s vs a longer scrape interval (#2661). | Rises when a table appears on disk and falls when one is removed; a wrong or empty --data-dir reads 0 immediately (an inert mount, visible before the first query errors). |
+| `cqlite.flight.warm_tables` | gauge | `{entry}` | _(none)_ | Tables with a live warm reader set in the flight WarmTableRegistry (atomic-backed at the registry mutation sites, not sampler-driven). | Rises on the first serve of a previously-unseen table and falls on eviction/retirement; pinned at capacity with steady eviction churn means the warm byte budget is small vs the working set. Distinct from tables_discovered (visible on disk). |
 | `cqlite.flush.bytes` | counter | `By` | _(none)_ | Data.db bytes produced by memtable flushes. | Write volume landing on disk from flush; use with flush.duration for flush throughput. |
 | `cqlite.flush.duration` | histogram | `s` | _(none)_ | Memtable-to-SSTable flush durations. | A rising tail alongside a climbing memtable size means flush cannot drain the memtable fast enough. |
 | `cqlite.flush.rows` | counter | `{row}` | _(none)_ | Rows flushed from the memtable to L0 SSTables. | Should track write.mutations over time; a lag is the flush-behind signal. |
@@ -106,6 +108,8 @@ Metrics a #2399 round-template scoreboard item consumes. Round handoffs (#2367-s
 | `cqlite.flight.admission.wait_seconds` | admission saturation (#2420/#2399) |
 | `cqlite.flight.admission.waiting` | admission saturation (#2420/#2399) |
 | `cqlite.flight.blocking_tasks_in_use` | blocking-pool pressure watch (#2419/#2313) |
+| `cqlite.flight.tables_discovered` | inert-mount watch (#2684) |
+| `cqlite.flight.warm_tables` | warm-working-set watch (#2684) |
 | `cqlite.merge.egress_channel_depth` | egress backpressure watch (#2419/#2399) |
 | `cqlite.merge.producer_threads` | thread-budget watch (#2313/#2399) |
 | `cqlite.proc.fds` | fd-exhaustion watch (#2419/#2313) |

--- a/openspec/changes/flight-table-gauges/design.md
+++ b/openspec/changes/flight-table-gauges/design.md
@@ -1,0 +1,83 @@
+# Design — Flight table-visibility gauges
+
+## Two gauges, two emission mechanisms (both already precedented in the crate)
+
+### `cqlite.flight.tables_discovered` — sampler-driven observable gauge
+Hook: extend the ~2s saturation sampler (`cqlite-flight/src/saturation.rs`, `DEFAULT_SAMPLE_INTERVAL =
+2s`, `sample_once()` / `run_sampler()`). Today the sampler reads only `/proc/self/*`; it must gain a
+readdir walk of `--data-dir`. `data_dir` is NOT currently threaded to the sampler (it is spawned in
+`main.rs` separately from the service), so `run_sampler` gains a `data_dir: PathBuf` parameter, passed at
+the `main.rs` spawn site.
+
+The walk each tick:
+- `read_dir(data_dir)` → each entry that is a directory is a candidate keyspace.
+- Within each keyspace dir, `read_dir` → each entry that is a directory whose name is NOT `snapshots` or
+  `backups` is a candidate table dir (covers `<table>` and `<table>-<uuid>` — matches the `DirSource`
+  prefix logic).
+- A candidate table dir counts iff it **directly contains** a `*-Data.db` entry (readdir name check only —
+  NO stat, NO open, NO generation parse). This keeps the cold-start invariant (#2385): zero SSTable I/O.
+- Emit `obs::record_gauge(catalog::FLIGHT_TABLES_DISCOVERED, count as i64, &[])` and, for the startup line,
+  also compute the keyspace count.
+
+Bidirectionality is intrinsic: the count is recomputed from disk each tick, so a removed table dir lowers
+it on the next sample; a new one raises it.
+
+Testability: the in-crate saturation tests already drive `sample_once`/`run_sampler` directly against a
+temp dir; a fixture-dir test pins the exact count (including a UUID-suffixed dir + a `snapshots/`/`backups/`
+subdir that must be excluded), then removes a table dir and asserts the next sample falls.
+
+Cold-start assertion: with the OTel capture harness, snapshot `counter_sum(INDEX_PARSES_TOTAL)` before/after
+N sampler ticks over a populated data-dir and assert **zero delta** (`INDEX_PARSES_TOTAL` is incremented at
+exactly one site — a full Index.db parse — so any open would show up).
+
+### `cqlite.flight.warm_tables` — atomic-backed gauge at the registry
+Hook: `WarmTableRegistry` (`cqlite-flight/src/warm/registry.rs`), whose `Inner.tables:
+HashMap<TableKey, TableWarm>` size IS the metric. Mutation sites:
+- `rebuild()` insert (`registry.rs:597`) — the only insert; note it does a remove-then-reinsert of the same
+  key earlier (`registry.rs:519`), so a naive inc-on-insert/dec-on-remove would transiently dip.
+- `evict_to_budget()` removal (`registry.rs:659`) — the true LRU/generation-turnover removal.
+
+Chosen approach: emit the **post-mutation `inner.tables.len()`** (while the `Inner` lock is held) at the end
+of `rebuild` and `evict_to_budget` via `obs::record_gauge(catalog::FLIGHT_WARM_TABLES, len as i64, &[])`.
+This avoids the remove-then-reinsert dip and is always exact. Also expose a feature-independent level reader
+`warm_table_count() -> i64` (mirroring `saturation::blocking_tasks_in_use_level()`) so up/down tests can
+read the current value without an OTel stack.
+
+Bidirectionality: a first `do_get` on a new table triggers `rebuild` insert → count rises; eviction/retire
+triggers `evict_to_budget` removal → count falls. The only production caller of `warm_readers` is
+`do_get_resolve`'s row/point route (`service.rs`), so the public-surface test drives a real `do_get`.
+
+## Three-layer metric registration (each gauge)
+Enforced by existing `catalog.rs` tests, so all three are mandatory:
+1. `cqlite-core/src/observability/catalog.rs`: add the `&'static str` constant + a `unit` (use
+   `unit::ENTRIES` = `"{entry}"`, or a new `{table}` unit — pick `ENTRIES` to avoid a new unit), add to
+   `ALL_METRICS`, and add to `SATURATION_GAUGES` (so the namespaced/unique + dedicated-otel-arm tests cover
+   them).
+2. `cqlite-core/src/observability/otel.rs`: add a `Gauge<i64>` field to `Instruments`, build it with
+   `.i64_gauge(catalog::NAME).with_unit(...).with_description(...)`, and add a dedicated `record_gauge`
+   match arm mapping the name → field (the `saturation_gauges_have_dedicated_otel_arms_not_the_adhoc_fallback`
+   test source-scans for `catalog::IDENT =>`, so the ad-hoc `_ =>` fallback is disallowed).
+3. Emit via `cqlite_core::observability::record_gauge` (no-op when the `observability` feature is off).
+
+## Startup log line
+Emit one `info`: `discovered N tables across M keyspaces under <data-dir>` after the first sampler sample.
+Precedent: `main.rs` "cqlite-flight starting" info line, and `log_platform_support_once()` (a `Once`-guarded
+single info line inside the sampler) — co-locate the "discovered N tables" line with the sampler using the
+same `Once` pattern so it fires exactly once after the first walk. Mirrors the #2128 OTel-inert visibility
+spirit: an empty/wrong mount logs `discovered 0 tables ...` at startup, surfacing the failure mode without a
+metrics stack.
+
+## Alternatives considered
+- **Per-keyspace gauge label** — rejected: keyspace cardinality is unbounded-ish and every existing #2419
+  gauge is total-only; the startup log carries the breakdown instead.
+- **Deriving `tables_discovered` from the warm registry** — rejected: the registry only knows *opened*
+  tables, not what's *visible on disk*; the whole point is to catch an inert/empty mount before any query.
+- **On-demand (per-request) discovery walk** — rejected: the 2s sampler already exists and amortizes the
+  readdir cost; a per-request walk adds latency to the hot path.
+- **Counting by statting generations (`enumerate_generations`)** — rejected: it stats/opens; violates the
+  readdir-only + cold-start requirement. A `*-Data.db` name check is sufficient and I/O-free.
+
+## Undersampling caveat (documented, #2661)
+`tables_discovered` is sampled every 2s; a Prometheus scrape at a longer interval can miss short-lived
+transitions. Documented in the metric description / ops notes, not fixed here (same caveat as the rest of
+the #2419 family).

--- a/openspec/changes/flight-table-gauges/design.md
+++ b/openspec/changes/flight-table-gauges/design.md
@@ -37,8 +37,10 @@ HashMap<TableKey, TableWarm>` size IS the metric. Mutation sites:
   key earlier (`registry.rs:519`), so a naive inc-on-insert/dec-on-remove would transiently dip.
 - `evict_to_budget()` removal (`registry.rs:659`) — the true LRU/generation-turnover removal.
 
-Chosen approach: emit the **post-mutation `inner.tables.len()`** (while the `Inner` lock is held) at the end
-of `rebuild` and `evict_to_budget` via `obs::record_gauge(catalog::FLIGHT_WARM_TABLES, len as i64, &[])`.
+Chosen approach: emit **the count of tables with a live (non-empty) warm reader set** (while the `Inner` lock
+is held) at the end of `rebuild` and `evict_to_budget` via `obs::record_gauge(catalog::FLIGHT_WARM_TABLES,
+len as i64, &[])`. Filtering to non-empty reader sets (rather than the raw `inner.tables.len()`) is what makes
+retirement observably decrement the gauge — a retired table leaves a zero-reader entry until the next rebuild.
 This avoids the remove-then-reinsert dip and is always exact. Also expose a feature-independent level reader
 `warm_table_count() -> i64` (mirroring `saturation::blocking_tasks_in_use_level()`) so up/down tests can
 read the current value without an OTel stack.

--- a/openspec/changes/flight-table-gauges/proposal.md
+++ b/openspec/changes/flight-table-gauges/proposal.md
@@ -1,0 +1,59 @@
+# Flight table-visibility gauges — tables_discovered + warm_tables
+
+## Milestone
+0.16 observability thread (from #2419 saturation gauge family, #2661 soak follow-through). Owner-scoped
+2026-07-17. Design-driven (lightweight). Scope is **cqlite-flight** only. No parity oracle.
+
+## Why (operator problem)
+Operators have no first-class signal for "what does this cqlite-flight pod actually see?" A pod with a
+wrong `--data-dir` mount, bad permissions, or an empty volume fails **lazily** — the first query errors —
+instead of visibly at startup. And there is no live view of the warm working set (tables actually opened
+and served), even though `WarmTableRegistry` already tracks it internally.
+
+## What changes — two TRUE gauges (bidirectional; values rise AND fall)
+
+1. **`cqlite.flight.tables_discovered`** — the number of `<keyspace>/<table>` SSTable directories currently
+   visible under `--data-dir`. Re-sampled on the existing ~2s saturation sampler tick (#2419): a directory
+   walk (readdir) only, **zero SSTable I/O, zero opens** (cold-start invariant #2385 preserved). RISES when
+   new tables appear on disk (new table, mount fixed), FALLS when tables are dropped/removed. A
+   wrong/empty mount reads **0** immediately.
+
+2. **`cqlite.flight.warm_tables`** — the current size of the `WarmTableRegistry` (tables with a live warm
+   reader set). Atomic-backed like `blocking_tasks_in_use`, emitting the post-mutation `tables.len()` at the
+   registry's insert/evict sites (independent of sampler cadence). RISES on first open of a previously-unseen
+   table, FALLS on evict/retire/generation-turnover removal.
+
+Plus one **startup / first-sample `info` log line**: `discovered N tables across M keyspaces under
+<data-dir>` — makes the inert-mount failure mode visible in logs even without a metrics stack (same spirit
+as the #2128 OTel-inert warn).
+
+### Design calls resolved (see design.md)
+- **Labels:** both gauges are **total-only** (`&[]`), matching every existing #2419 saturation gauge (all
+  emit with no attributes; catalog docs say "no high-cardinality attributes"). The per-keyspace breakdown
+  lives in the one-time startup log line, not as a metric label — a per-keyspace gauge dimension would be
+  unbounded-ish (keyspace cardinality) and is explicitly out of scope.
+- **Discovery = sampler-driven** for `tables_discovered` (the walk is cheap readdir on the 2s tick);
+  **atomic-backed at call sites** for `warm_tables` (the registry already mutates under a lock, so emitting
+  `.len()` post-mutation is exact and cadence-independent).
+- **What counts as a "table dir":** a `<keyspace>/<table[-uuid]>` directory that directly contains at least
+  one `*-Data.db` file (matches the existing `DirSource`/`enumerate_generations` prior art), correct on
+  UUID-suffixed dirs, **excluding `snapshots/` and `backups/` subtrees**. Structural (directory layout)
+  only — never inferred from file contents (no-heuristics).
+- **Readdir-only:** the walk lists directory entries and checks for a `*-Data.db` *name*; it does NOT stat
+  generations, open, or parse any SSTable (so `index_parses` sees zero delta from sampling).
+
+## Non-goals
+- No per-keyspace metric label dimension (startup log carries the breakdown).
+- No new alerting/dashboard rules — the gauges are exported through the same OTLP pipeline as the #2419
+  family and become visible in the standing dashboard next field round; the 2s-vs-scrape-interval
+  undersampling caveat (#2661) is documented, not fixed here.
+- No change to query behavior, the warm eviction policy, or the connector.
+
+## Doctrine impact
+- **No-heuristics (#28):** discovery is structural (directory layout: a dir containing `*-Data.db`,
+  excluding snapshots/backups) — never inferred from file contents.
+- **Cold-start invariant (#2385):** the discovery walk does zero SSTable opens/parses; a test asserts a
+  zero `index_parses` delta across sampler ticks.
+- **Bounded-cardinality metrics:** both gauges are total-only; no new bounded-attr allowlist entry needed.
+- **Wiring-evidence:** `warm_tables` is proven through the public Flight surface — a real `do_get` on a
+  previously-unseen table increments it, and eviction/retirement decrements it.

--- a/openspec/changes/flight-table-gauges/specs/flight-table-observability/spec.md
+++ b/openspec/changes/flight-table-gauges/specs/flight-table-observability/spec.md
@@ -1,0 +1,82 @@
+# flight-table-observability
+
+## ADDED Requirements
+
+### Requirement: tables_discovered reflects the visible on-disk table set and is bidirectional
+The service SHALL export a gauge `cqlite.flight.tables_discovered` equal to the number of
+`<keyspace>/<table>` SSTable directories currently visible under `--data-dir`, re-sampled on the existing
+~2s saturation tick. The value SHALL rise when a table directory appears and fall when one is removed. A
+wrong or empty `--data-dir` SHALL read 0.
+
+#### Scenario: falls when a table directory is removed
+- **GIVEN** a `--data-dir` containing K genuine `<keyspace>/<table>` SSTable directories
+- **WHEN** the sampler tick runs and then one table directory is removed and the next tick runs
+- **THEN** `cqlite.flight.tables_discovered` reads K, then reads K-1 after the removal.
+
+#### Scenario: rises when a table directory appears
+- **GIVEN** a `--data-dir` sampled at count K
+- **WHEN** a new genuine `<keyspace>/<table>` SSTable directory appears and the next tick runs
+- **THEN** `cqlite.flight.tables_discovered` reads K+1.
+
+#### Scenario: empty or wrong mount reads zero
+- **GIVEN** a `--data-dir` that is empty (or points at a directory with no table dirs)
+- **WHEN** the sampler tick runs
+- **THEN** `cqlite.flight.tables_discovered` reads 0.
+
+### Requirement: tables_discovered counts only genuine table dirs, structurally
+`cqlite.flight.tables_discovered` SHALL count only `<keyspace>/<table>` directories that directly contain
+SSTable data, SHALL be correct on UUID-suffixed table directories, and SHALL exclude `snapshots/`,
+`backups/`, and non-table entries. Classification SHALL be structural (directory layout) only, never
+inferred from file contents.
+
+#### Scenario: UUID-suffixed table dir counts; snapshots/backups excluded
+- **GIVEN** a `--data-dir` with a `<keyspace>/<table>-<uuid>/` dir containing a `*-Data.db`, plus
+  `snapshots/` and `backups/` subdirectories and an unrelated non-table entry
+- **WHEN** the sampler tick runs
+- **THEN** the UUID-suffixed table dir is counted exactly once
+- **AND** the `snapshots/` and `backups/` subdirs and the non-table entry are NOT counted.
+
+### Requirement: the discovery walk performs no SSTable opens or parses
+The `tables_discovered` discovery walk SHALL use directory reads only and SHALL NOT open, stat-for-generation,
+or parse any SSTable, preserving the cold-start invariant.
+
+#### Scenario: sampling produces zero index_parses delta
+- **GIVEN** a populated `--data-dir` and a baseline `cqlite.sstable.index_parses_total` reading
+- **WHEN** N saturation sampler ticks run with no query activity
+- **THEN** `cqlite.sstable.index_parses_total` shows zero delta from the sampling.
+
+### Requirement: warm_tables reflects the live warm registry size and is bidirectional
+The service SHALL export a gauge `cqlite.flight.warm_tables` equal to the current number of tables with a
+live warm reader set in `WarmTableRegistry`, updated at the registry mutation sites (independent of sampler
+cadence). It SHALL rise on the first serve of a previously-unseen table and fall on eviction/retirement.
+
+#### Scenario: increments after a do_get on a previously-unseen table (public surface)
+- **GIVEN** a running Flight service with an empty warm registry
+- **WHEN** a real `do_get` is served through the public Flight surface for a previously-unseen table
+- **THEN** `cqlite.flight.warm_tables` increments to reflect the newly warm table.
+
+#### Scenario: decrements after eviction/retirement
+- **GIVEN** `cqlite.flight.warm_tables` reads W with at least one warm table
+- **WHEN** a warm table's last reader is evicted/retired (generation turnover or budget eviction)
+- **THEN** `cqlite.flight.warm_tables` falls below W.
+
+### Requirement: startup log line reports the discovered table/keyspace count
+After the first sample, the service SHALL emit exactly one `info` log line reporting the number of tables,
+the number of keyspaces, and the `--data-dir` path, so an inert/empty mount is visible in logs without a
+metrics stack.
+
+#### Scenario: first-sample info line present
+- **GIVEN** the service starts and the sampler takes its first sample
+- **WHEN** the first sample completes
+- **THEN** exactly one `info` line is emitted naming N tables, M keyspaces, and the data-dir path.
+
+### Requirement: both gauges are exported total-only through the standard OTLP pipeline
+`cqlite.flight.tables_discovered` and `cqlite.flight.warm_tables` SHALL be registered as OTel gauges with
+dedicated instrument arms (no ad-hoc fallback) and emitted with no attributes (total-only), so they carry no
+high-cardinality labels.
+
+#### Scenario: gauges are registered total-only with dedicated instruments
+- **GIVEN** the metric catalog and OTel instrument registration
+- **WHEN** the catalog/instrument invariants are checked
+- **THEN** both metrics are namespaced, unique, registered in the metric set, have dedicated gauge
+  instrument arms, and are emitted with an empty attribute set.

--- a/openspec/changes/flight-table-gauges/tasks.md
+++ b/openspec/changes/flight-table-gauges/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — Flight table-visibility gauges
+
+## Registration (3-layer, both gauges)
+- [ ] `catalog.rs`: add `FLIGHT_TABLES_DISCOVERED` + `FLIGHT_WARM_TABLES` constants (unit `ENTRIES`), add
+  to `ALL_METRICS` + `SATURATION_GAUGES`.
+- [ ] `otel.rs`: add a `Gauge<i64>` `Instruments` field + builder + dedicated `record_gauge` match arm for
+  each (no ad-hoc `_ =>` fallback — the source-scan test enforces this).
+
+## tables_discovered (sampler-driven)
+- [ ] Thread `data_dir: PathBuf` into `run_sampler`; pass it at the `main.rs` spawn site.
+- [ ] Add the readdir walk: keyspace dirs → table dirs (excl. `snapshots/`/`backups/`, incl. UUID-suffixed)
+  → count those directly containing a `*-Data.db` name. NO stat/open/parse (surface:
+  `saturation::sample_once` / the new walk fn).
+- [ ] Emit `record_gauge(FLIGHT_TABLES_DISCOVERED, count, &[])` each tick.
+
+## warm_tables (atomic-backed at the registry)
+- [ ] Emit `record_gauge(FLIGHT_WARM_TABLES, inner.tables.len() as i64, &[])` post-mutation under the lock
+  at `rebuild()` insert and `evict_to_budget()` removal (`registry.rs`).
+- [ ] Add feature-independent `warm_table_count() -> i64` level reader (mirror
+  `blocking_tasks_in_use_level`) for up/down tests.
+
+## Startup log
+- [ ] Emit one `info` line `discovered N tables across M keyspaces under <data-dir>` after the first sample
+  (Once-guarded, co-located with the sampler).
+
+## Wiring evidence + tests
+- [ ] Fixture-dir test: pins `tables_discovered` count (UUID dir counted; snapshots/backups/non-table
+  excluded); removes a table dir → next sample falls; adds one → rises; empty dir → 0.
+- [ ] Cold-start test: N sampler ticks over a populated dir → zero `INDEX_PARSES_TOTAL` delta.
+- [ ] Public-surface `warm_tables` test: real `do_get` on a previously-unseen table → gauge increments;
+  eviction/retirement → decrements (drive up AND down).
+- [ ] Startup-log-line test (or assertion) that the info line is present with N/M/data-dir.
+
+## Docs
+- [ ] Note the 2s-vs-scrape-interval undersampling caveat (#2661) in the metric description / ops notes;
+  add both gauges to any Flight metrics reference doc.
+
+## Quality gates
+- [ ] `scripts/agent-gate.sh --lite` green each round; rust-reviewer + roborev on the lite-green diff.
+- [ ] Full `scripts/agent-gate.sh` PASS (gate of record, in flow-closer).
+- [ ] C intent audit (spec-auditor) PASS. Final roborev clean. `openspec archive` on merge.

--- a/website/src/content/docs/agents-using/flight-metrics-reference.md
+++ b/website/src/content/docs/agents-using/flight-metrics-reference.md
@@ -14,7 +14,7 @@ Operator-facing reference for every `cqlite.*` instrument CQLite emits over Arro
 
 Related: the Flight/Trino operator docs (`docs/flight-trino/`) and the round scoreboard template (issue #2399) link back to the entries here.
 
-Total instruments: **73**.
+Total instruments: **75**.
 
 ## All instruments
 
@@ -46,6 +46,8 @@ Total instruments: **73**.
 | `cqlite.flight.admission.wait_seconds` | histogram | `s` | _(none)_ | How long a do_get waited on acquire before it was admitted or rejected. | A near-zero distribution is healthy; a rising tail means requests are increasingly queuing for permits. |
 | `cqlite.flight.admission.waiting` | gauge | `1` | _(none)_ | do_get requests parked waiting for an admission permit — the backpressure signal. | Zero is healthy; a sustained non-zero value means offered concurrency exceeds the ceiling and requests are queuing. |
 | `cqlite.flight.blocking_tasks_in_use` | gauge | `{thread}` | _(none)_ | Flight spawn_blocking tasks currently outstanding (flight-managed proxy, NOT the global tokio pool queue depth). | Rises with concurrent do_get scans and returns to baseline; a level pinned near the blocking-pool size with flat rpc.rows is blocking-pool saturation. Distinct from admission.in_use. |
+| `cqlite.flight.tables_discovered` | gauge | `{entry}` | _(none)_ | Table dirs visible under --data-dir, re-sampled by a readdir-only walk on the ~2s saturation tick (no SSTable opens). Undersampled at ~2s vs a longer scrape interval (#2661). | Rises when a table appears on disk and falls when one is removed; a wrong or empty --data-dir reads 0 immediately (an inert mount, visible before the first query errors). |
+| `cqlite.flight.warm_tables` | gauge | `{entry}` | _(none)_ | Tables with a live warm reader set in the flight WarmTableRegistry (atomic-backed at the registry mutation sites, not sampler-driven). | Rises on the first serve of a previously-unseen table and falls on eviction/retirement; pinned at capacity with steady eviction churn means the warm byte budget is small vs the working set. Distinct from tables_discovered (visible on disk). |
 | `cqlite.flush.bytes` | counter | `By` | _(none)_ | Data.db bytes produced by memtable flushes. | Write volume landing on disk from flush; use with flush.duration for flush throughput. |
 | `cqlite.flush.duration` | histogram | `s` | _(none)_ | Memtable-to-SSTable flush durations. | A rising tail alongside a climbing memtable size means flush cannot drain the memtable fast enough. |
 | `cqlite.flush.rows` | counter | `{row}` | _(none)_ | Rows flushed from the memtable to L0 SSTables. | Should track write.mutations over time; a lag is the flush-behind signal. |
@@ -114,6 +116,8 @@ Metrics a #2399 round-template scoreboard item consumes. Round handoffs (#2367-s
 | `cqlite.flight.admission.wait_seconds` | admission saturation (#2420/#2399) |
 | `cqlite.flight.admission.waiting` | admission saturation (#2420/#2399) |
 | `cqlite.flight.blocking_tasks_in_use` | blocking-pool pressure watch (#2419/#2313) |
+| `cqlite.flight.tables_discovered` | inert-mount watch (#2684) |
+| `cqlite.flight.warm_tables` | warm-working-set watch (#2684) |
 | `cqlite.merge.egress_channel_depth` | egress backpressure watch (#2419/#2399) |
 | `cqlite.merge.producer_threads` | thread-budget watch (#2313/#2399) |
 | `cqlite.proc.fds` | fd-exhaustion watch (#2419/#2313) |


### PR DESCRIPTION
Closes #2684

## Summary
Two TRUE (bidirectional) OTel gauges so operators can see what a cqlite-flight pod actually sees — surfacing an inert/empty `--data-dir` mount at startup instead of lazily at first query.

- **`cqlite.flight.tables_discovered`** — count of `<keyspace>/<table>` SSTable dirs visible under `--data-dir`, re-sampled on the existing ~2s saturation tick. **Readdir-only** (uses `DirEntry::file_type`, no stat/open/parse — cold-start invariant #2385 preserved), offloaded to `spawn_blocking` so it never stalls the RPC-serving runtime. Rises when tables appear, falls when removed; empty/wrong mount → 0.
- **`cqlite.flight.warm_tables`** — count of tables with a live warm reader set in `WarmTableRegistry`, atomic-backed, emitted post-mutation under the lock at `rebuild()` insert / `evict_to_budget()` removal. Rises on first serve of an unseen table, falls on retirement/budget eviction.
- Startup `info` line: `discovered N tables across M keyspaces under <data-dir>`.
- Total-only labels (matches the #2419 family); 3-layer registration (catalog + dedicated OTel arms + operator docs).

## Design
OpenSpec change `flight-table-gauges` (proposal/design/specs/tasks). Design-driven (lightweight), owner-approved at Seam 1. Structural discovery only (no-heuristics #28).

## Wiring evidence
- Fixture test pins the count (UUID-suffixed dir counted once; **real Cassandra `<table>/snapshots/`+`backups/` nested layout** proven excluded; empty→0; up/down on add/remove).
- Cold-start test: N sampler ticks over a populated dir → zero `index_parses` delta.
- Public-surface `warm_tables`: real `do_get` on an unseen table increments; retirement AND byte-budget whole-table eviction each decrement.

## Review
- rust-reviewer: clean/shippable.
- roborev: 1 Medium (blocking readdir on the async runtime) fixed via `spawn_blocking`; all nits folded in (file_type vs stat, live-reader-count doc, real snapshot/backup layout test, eviction-decrement test, symlink-non-follow comment).

## Note for reviewer
Touched core/flight files were already over the #1116 800-line threshold; metric registration inherently grows them → acked with `CQLITE_ALLOW_FILE_GROWTH=1` per doctrine (split is a separate #1116 concern).

Cross-refs: #2419 (saturation gauges), #2661 (soak), #2128 (inert-config visibility), #2310 (WarmTableRegistry).